### PR TITLE
Add built-in GDScript keywords to the class reference

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -712,6 +712,7 @@ public:
 		Vector<ConstantDoc> constants;
 		HashMap<String, EnumDoc> enums;
 		Vector<PropertyDoc> properties;
+		Vector<MethodDoc> builtins;
 		Vector<MethodDoc> annotations;
 		Vector<ThemeItemDoc> theme_properties;
 		bool is_deprecated = false;
@@ -808,6 +809,14 @@ public:
 			}
 			for (int i = 0; i < properties.size(); i++) {
 				doc.properties.push_back(PropertyDoc::from_dict(properties[i]));
+			}
+
+			Array builtins;
+			if (p_dict.has("builtins")) {
+				builtins = p_dict["builtins"];
+			}
+			for (int i = 0; i < builtins.size(); i++) {
+				doc.builtins.push_back(MethodDoc::from_dict(builtins[i]));
 			}
 
 			Array annotations;
@@ -937,6 +946,14 @@ public:
 					properties.push_back(PropertyDoc::to_dict(p_doc.properties[i]));
 				}
 				dict["properties"] = properties;
+			}
+
+			if (!p_doc.builtins.is_empty()) {
+				Array builtins;
+				for (int i = 0; i < p_doc.builtins.size(); i++) {
+					builtins.push_back(MethodDoc::to_dict(p_doc.builtins[i]));
+				}
+				dict["builtins"] = builtins;
 			}
 
 			if (!p_doc.annotations.is_empty()) {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -346,6 +346,7 @@ public:
 		LOOKUP_RESULT_CLASS_ENUM,
 		LOOKUP_RESULT_CLASS_TBD_GLOBALSCOPE,
 		LOOKUP_RESULT_CLASS_ANNOTATION,
+		LOOKUP_RESULT_CLASS_BUILTIN,
 		LOOKUP_RESULT_MAX
 	};
 
@@ -397,6 +398,7 @@ public:
 	/* LOADER FUNCTIONS */
 
 	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	virtual void get_public_keywords(List<MethodInfo> *p_keywords) const = 0;
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const = 0;
 	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const = 0;
 	virtual void get_public_annotations(List<MethodInfo> *p_annotations) const = 0;

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -146,6 +146,7 @@ void ScriptLanguageExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_reload_tool_script, "script", "soft_reload");
 
 	GDVIRTUAL_BIND(_get_recognized_extensions);
+	GDVIRTUAL_BIND(_get_public_keywords);
 	GDVIRTUAL_BIND(_get_public_functions);
 	GDVIRTUAL_BIND(_get_public_constants);
 	GDVIRTUAL_BIND(_get_public_annotations);
@@ -171,6 +172,7 @@ void ScriptLanguageExtension::_bind_methods() {
 	BIND_ENUM_CONSTANT(LOOKUP_RESULT_CLASS_ENUM);
 	BIND_ENUM_CONSTANT(LOOKUP_RESULT_CLASS_TBD_GLOBALSCOPE);
 	BIND_ENUM_CONSTANT(LOOKUP_RESULT_CLASS_ANNOTATION);
+	BIND_ENUM_CONSTANT(LOOKUP_RESULT_CLASS_BUILTIN);
 	BIND_ENUM_CONSTANT(LOOKUP_RESULT_MAX);
 
 	BIND_ENUM_CONSTANT(LOCATION_LOCAL);

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -600,6 +600,16 @@ public:
 		}
 	}
 
+	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_public_keywords)
+	virtual void get_public_keywords(List<MethodInfo> *p_keywords) const override {
+		TypedArray<Dictionary> ret;
+		GDVIRTUAL_REQUIRED_CALL(_get_public_keywords, ret);
+		for (const Variant &var : ret) {
+			MethodInfo mi = MethodInfo::from_dict(var);
+			p_keywords->push_back(mi);
+		}
+	}
+
 	GDVIRTUAL0RC(TypedArray<Dictionary>, _get_public_functions)
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const override {
 		TypedArray<Dictionary> ret;

--- a/doc/class.xsd
+++ b/doc/class.xsd
@@ -196,6 +196,34 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
+				<xs:element name="builtins" minOccurs="0">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="builtin" maxOccurs="unbounded" minOccurs="0">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="param" maxOccurs="unbounded" minOccurs="0">
+											<xs:complexType>
+												<xs:sequence>
+													<xs:sequence />
+												</xs:sequence>
+												<xs:attribute type="xs:byte" name="index" />
+												<xs:attribute type="xs:string" name="name" />
+												<xs:attribute type="xs:string" name="type" />
+												<xs:attribute type="xs:string" name="enum" use="optional" />
+												<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
+												<xs:attribute type="xs:string" name="default" use="optional" />
+											</xs:complexType>
+										</xs:element>
+										<xs:element type="xs:string" name="description" />
+									</xs:sequence>
+									<xs:attribute type="xs:string" name="name" use="optional" />
+									<xs:attribute type="xs:string" name="keywords" use="optional" />
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
 				<xs:element name="annotations" minOccurs="0">
 					<xs:complexType>
 						<xs:sequence>

--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -60,6 +60,8 @@
 				class_signal:BaseButton:pressed
 				# Shows help for the CanvasItem property visible.
 				class_property:CanvasItem:visible
+				# Shows help for the GDScript built-in keyword.
+				class_builtin:@GDScript:for
 				# Shows help for the GDScript annotation export.
 				# Annotations should be prefixed with the `@` symbol in the descriptor, as shown here.
 				class_annotation:@GDScript:@export

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -189,6 +189,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_public_keywords" qualifiers="virtual const">
+			<return type="Dictionary[]" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_recognized_extensions" qualifiers="virtual const">
 			<return type="PackedStringArray" />
 			<description>
@@ -391,7 +396,9 @@
 		</constant>
 		<constant name="LOOKUP_RESULT_CLASS_ANNOTATION" value="8" enum="LookupResultType">
 		</constant>
-		<constant name="LOOKUP_RESULT_MAX" value="9" enum="LookupResultType">
+		<constant name="LOOKUP_RESULT_CLASS_BUILTIN" value="9" enum="LookupResultType">
+		</constant>
+		<constant name="LOOKUP_RESULT_MAX" value="10" enum="LookupResultType">
 		</constant>
 		<constant name="LOCATION_LOCAL" value="0" enum="CodeCompletionLocation">
 			The option is local to the location of the code completion query - e.g. a local variable. Subsequent value of location represent options from the outer class, the exact value represent how far they are (in terms of inner classes).

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -107,6 +107,7 @@ class EditorHelp : public VBoxContainer {
 	HashMap<String, int> property_line;
 	HashMap<String, int> theme_property_line;
 	HashMap<String, int> constant_line;
+	HashMap<String, int> builtin_line;
 	HashMap<String, int> annotation_line;
 	HashMap<String, int> enum_line;
 	HashMap<String, HashMap<String, int>> enum_values_line;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1047,6 +1047,9 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 			case ScriptLanguage::LOOKUP_RESULT_CLASS_ANNOTATION: {
 				emit_signal(SNAME("go_to_help"), "class_annotation:" + result.class_name + ":" + result.class_member);
 			} break;
+			case ScriptLanguage::LOOKUP_RESULT_CLASS_BUILTIN: {
+				emit_signal(SNAME("go_to_help"), "class_builtin:" + result.class_name + ":" + result.class_member);
+			} break;
 			case ScriptLanguage::LOOKUP_RESULT_CLASS_TBD_GLOBALSCOPE: {
 				emit_signal(SNAME("go_to_help"), "class_global:" + result.class_name + ":" + result.class_member);
 			} break;

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -280,6 +280,205 @@
 			[b]Warning:[/b] "Not a Number" is only a concept with floating-point numbers, and has no equivalent for integers. Dividing an integer [code]0[/code] by [code]0[/code] will not result in [constant NAN] and will result in a run-time error instead.
 		</constant>
 	</constants>
+	<builtins>
+		<builtin name="and">
+			<return type="void" />
+			<description>
+				AND boolean operator. This evaluates to [code]true[/code] if [b]both[/b] operands evaluate to [code]true[/code]. Otherwise, this evaluates to [code]false[/code]. See also [builtin or].
+				[code]&amp;&amp;[/code] can be used as an alternative syntax with the same operator precedence.
+				[codeblock]
+				var bucket_full = true
+				var glass_full = false
+
+				var both_containers_full = bucket_full and glass_full  # Evaluates to `false`.
+				both_containers_full = bucket_full &amp;&amp; glass_full  # Alternative syntax, also evaluates to `false`.
+				[/codeblock]
+			</description>
+		</builtin>
+		<builtin name="as">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="await">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="break">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="breakpoint">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="class">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="class_name">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="const">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="continue">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="elif">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="else">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="enum">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="extends">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="false">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="for">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="func">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="if">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="in">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="is">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="match">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="namespace">
+			<return type="void" />
+			<description>
+				Reserved. This keyword causes a script error when used.
+			</description>
+		</builtin>
+		<builtin name="not">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="null">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="or">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="pass">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="return">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="self">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="signal">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="static">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="super">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="trait">
+			<return type="void" />
+			<description>
+				Reserved. This keyword causes a script error when used.
+			</description>
+		</builtin>
+		<builtin name="true">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="var">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="void">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="when">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="while">
+			<return type="void" />
+			<description>
+			</description>
+		</builtin>
+		<builtin name="yield">
+			<return type="void" />
+			<description>
+				Reserved. This keyword causes a script error when used.
+			</description>
+		</builtin>
+	</builtins>
 	<annotations>
 		<annotation name="@export">
 			<return type="void" />

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -611,6 +611,7 @@ public:
 
 	virtual void frame() override;
 
+	virtual void get_public_keywords(List<MethodInfo> *p_keywords) const override;
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const override;
 	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const override;
 	virtual void get_public_annotations(List<MethodInfo> *p_annotations) const override;

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -89,6 +89,20 @@ TEST_CASE("[Modules][GDScript] Validate built-in API") {
 		}
 	}
 
+	// Validate builtins.
+	List<MethodInfo> builtins;
+	lang->get_public_keywords(&builtins);
+
+	SUBCASE("[Modules][GDScript] Validate built-in keywords") {
+		for (const MethodInfo &bi : builtins) {
+			int i = 0;
+			for (List<PropertyInfo>::ConstIterator itr = bi.arguments.begin(); itr != bi.arguments.end(); ++itr, ++i) {
+				TEST_COND((itr->name.is_empty() || itr->name.begins_with("_unnamed_arg")),
+						vformat("Unnamed argument in position %d of built-in keyword '%s'.", i, bi.name));
+			}
+		}
+	}
+
 	// Validate annotations.
 	List<MethodInfo> builtin_annotations;
 	lang->get_public_annotations(&builtin_annotations);

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -553,6 +553,7 @@ public:
 
 	void frame() override;
 
+	/* TODO? */ void get_public_keywords(List<PropertyInfo> *p_keywords) const override {}
 	/* TODO? */ void get_public_functions(List<MethodInfo> *p_functions) const override {}
 	/* TODO? */ void get_public_constants(List<Pair<String, Variant>> *p_constants) const override {}
 	/* TODO? */ void get_public_annotations(List<MethodInfo> *p_annotations) const override {}


### PR DESCRIPTION
These are part of `@GDScript` and appear in search results as part of a new `builtin` documentable type. (`keyword` is not used, as `keywords` is already the name of an optional attribute for most documentable types.)

Keywords can now be <kbd>Ctrl</kbd> + clicked in the script editor to go to their class reference description.

- This closes https://github.com/godotengine/godot-proposals/issues/2361.

## Preview

https://github.com/user-attachments/assets/5caf0619-0fea-44af-819c-6f149b32f576

## TODO

- [ ] Fill in descriptions.
- [ ] Define parameters for keywords when relevant.
- [ ] Update `doc_status.py` to allow tracking progress on builtins.
- [ ] Test `make_rst.py`'s reStructuredText generation on the docs website.

Filling in the descriptions could be done in a separate PR if we want, like we did for https://github.com/godotengine/godot/pull/48548 (where https://github.com/godotengine/godot/pull/63870 added the descriptions).

In a future PR, we can look into using a similar approach to [document shader keywords in the class reference](https://github.com/godotengine/godot-proposals/issues/3767), in addition to built-ins (which would probably be considered member variables there).
