### PR TITLE
C#: Use dotnet CLI to launch `OpenVisualStudio.dll`

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/GodotTools.OpenVisualStudio.csproj
+++ b/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/GodotTools.OpenVisualStudio.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>False</SelfContained>
     <RollForward>LatestMajor</RollForward>
   </PropertyGroup>

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -259,11 +259,12 @@ namespace GodotTools
 
                     var args = new List<string>
                     {
+                        Path.Combine(GodotSharpDirs.DataEditorToolsDir, "GodotTools.OpenVisualStudio.dll"),
                         GodotSharpDirs.ProjectSlnPath,
                         line >= 0 ? $"{scriptPath};{line + 1};{col + 1}" : scriptPath
                     };
 
-                    string command = Path.Combine(GodotSharpDirs.DataEditorToolsDir, "GodotTools.OpenVisualStudio.exe");
+                    string command = DotNetFinder.FindDotNetExe() ?? "dotnet";
 
                     try
                     {


### PR DESCRIPTION
Use the DLL instead of the EXE, so we can rely on the dotnet CLI handling the architecture.

- Fixes https://github.com/godotengine/godot/issues/95657.

:warning: _I don't have a Windows device, so testing is appreciated._