### PR TITLE
Fix typo in CompositorEffect documentation

### DIFF
--- a/doc/classes/CompositorEffect.xml
+++ b/doc/classes/CompositorEffect.xml
@@ -87,7 +87,7 @@
 			The callback is called before our transparent rendering pass, but after our sky is rendered and we've created our back buffers.
 		</constant>
 		<constant name="EFFECT_CALLBACK_TYPE_POST_TRANSPARENT" value="4" enum="EffectCallbackType">
-			The callback is called after our transparent rendering pass, but before any build in post effects and output to our render target.
+			The callback is called after our transparent rendering pass, but before any built-in post-processing effects and output to our render target.
 		</constant>
 		<constant name="EFFECT_CALLBACK_TYPE_MAX" value="5" enum="EffectCallbackType">
 			Represents the size of the [enum EffectCallbackType] enum.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -5148,7 +5148,7 @@
 			The callback is called before our transparent rendering pass, but after our sky is rendered and we've created our back buffers.
 		</constant>
 		<constant name="COMPOSITOR_EFFECT_CALLBACK_TYPE_POST_TRANSPARENT" value="4" enum="CompositorEffectCallbackType">
-			The callback is called after our transparent rendering pass, but before any build in post effects and output to our render target.
+			The callback is called after our transparent rendering pass, but before any built-in post-processing effects and output to our render target.
 		</constant>
 		<constant name="COMPOSITOR_EFFECT_CALLBACK_TYPE_ANY" value="-1" enum="CompositorEffectCallbackType">
 		</constant>


### PR DESCRIPTION
Changes `build in post effects` to `built-in post-processing effects`.