### PR TITLE
Fix minor typo in EditorPlugin `remove_inspector_plugin`

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -701,7 +701,7 @@
 			<return type="void" />
 			<param index="0" name="plugin" type="EditorInspectorPlugin" />
 			<description>
-				Removes an inspector plugin registered by [method add_import_plugin]
+				Removes an inspector plugin registered by [method add_inspector_plugin].
 			</description>
 		</method>
 		<method name="remove_node_3d_gizmo_plugin">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
In the EditorPlugin docs, the method description for `remove_inspector_plugin` erroneously linked to `add_import_plugin` instead of `add_inspector_plugin`.
