### PR TITLE
Add "Inspect Native Shader Code" to shader inspector and shader editor

### DIFF
--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -45,7 +45,7 @@
 		<method name="inspect_native_shader_code">
 			<return type="void" />
 			<description>
-				Only available when running in the editor. Opens a popup that visualizes the generated shader code, including all variants and internal shader code.
+				Only available when running in the editor. Opens a popup that visualizes the generated shader code, including all variants and internal shader code. See also [method Shader.inspect_native_shader_code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -35,6 +35,12 @@
 				If argument [param get_groups] is true, parameter grouping hints will be provided.
 			</description>
 		</method>
+		<method name="inspect_native_shader_code">
+			<return type="void" />
+			<description>
+				Only available when running in the editor. Opens a popup that visualizes the generated shader code, including all variants and internal shader code. See also [method Material.inspect_native_shader_code].
+			</description>
+		</method>
 		<method name="set_default_texture_parameter">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -396,6 +396,7 @@ void ShaderEditorPlugin::_setup_popup_menu(PopupMenuType p_type, PopupMenu *p_me
 	if (p_type == FILE) {
 		p_menu->add_separator();
 		p_menu->add_item(TTR("Open File in Inspector"), FILE_INSPECT);
+		p_menu->add_item(TTR("Inspect Native Shader Code..."), FILE_INSPECT_NATIVE_SHADER_CODE);
 		p_menu->add_separator();
 		p_menu->add_shortcut(ED_SHORTCUT("shader_editor/close_file", TTR("Close File"), KeyModifierMask::CMD_OR_CTRL | Key::W), FILE_CLOSE);
 	} else {
@@ -552,6 +553,12 @@ void ShaderEditorPlugin::_menu_item_pressed(int p_index) {
 				EditorNode::get_singleton()->push_item(edited_shaders[index].shader.ptr());
 			} else {
 				EditorNode::get_singleton()->push_item(edited_shaders[index].shader_inc.ptr());
+			}
+		} break;
+		case FILE_INSPECT_NATIVE_SHADER_CODE: {
+			int index = shader_tabs->get_current_tab();
+			if (edited_shaders[index].shader.is_valid()) {
+				edited_shaders[index].shader->inspect_native_shader_code();
 			}
 		} break;
 		case FILE_CLOSE: {
@@ -754,6 +761,7 @@ void ShaderEditorPlugin::_set_file_specific_items_disabled(bool p_disabled) {
 	file_popup_menu->set_item_disabled(file_popup_menu->get_item_index(FILE_SAVE), p_disabled);
 	file_popup_menu->set_item_disabled(file_popup_menu->get_item_index(FILE_SAVE_AS), p_disabled);
 	file_popup_menu->set_item_disabled(file_popup_menu->get_item_index(FILE_INSPECT), p_disabled);
+	file_popup_menu->set_item_disabled(file_popup_menu->get_item_index(FILE_INSPECT_NATIVE_SHADER_CODE), p_disabled);
 	file_popup_menu->set_item_disabled(file_popup_menu->get_item_index(FILE_CLOSE), p_disabled);
 }
 

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -69,6 +69,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 		FILE_SAVE,
 		FILE_SAVE_AS,
 		FILE_INSPECT,
+		FILE_INSPECT_NATIVE_SHADER_CODE,
 		FILE_CLOSE,
 		CLOSE_ALL,
 		CLOSE_OTHER_TABS,

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -32,6 +32,7 @@
 #include "shader.compat.inc"
 
 #include "core/io/file_access.h"
+#include "scene/main/scene_tree.h"
 #include "servers/rendering/shader_language.h"
 #include "servers/rendering/shader_preprocessor.h"
 #include "servers/rendering_server.h"
@@ -122,6 +123,14 @@ void Shader::set_code(const String &p_code) {
 String Shader::get_code() const {
 	_update_shader();
 	return code;
+}
+
+void Shader::inspect_native_shader_code() {
+	SceneTree *st = SceneTree::get_singleton();
+	RID _shader = get_rid();
+	if (st && _shader.is_valid()) {
+		st->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, "_native_shader_source_visualizer", "_inspect_shader", _shader);
+	}
 }
 
 void Shader::get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_groups) const {
@@ -247,6 +256,9 @@ void Shader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_default_texture_parameter", "name", "index"), &Shader::get_default_texture_parameter, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("get_shader_uniform_list", "get_groups"), &Shader::_get_shader_uniform_list, DEFVAL(false));
+
+	ClassDB::bind_method(D_METHOD("inspect_native_shader_code"), &Shader::inspect_native_shader_code);
+	ClassDB::set_method_flags(get_class_static(), _scs_create("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_code", "get_code");
 

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -84,6 +84,8 @@ public:
 	void set_code(const String &p_code);
 	String get_code() const;
 
+	void inspect_native_shader_code();
+
 	void get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_groups = false) const;
 
 	void set_default_texture_parameter(const StringName &p_name, const Ref<Texture> &p_texture, int p_index = 0);


### PR DESCRIPTION
Implements and closes https://github.com/godotengine/godot-proposals/issues/10278.

Adds the action "Inspect Native Shader Code", currently available on the [Material resource](https://docs.godotengine.org/en/stable/classes/class_material.html#class-material-method-inspect-native-shader-code) inspector ([implementation](https://github.com/godotengine/godot/blob/0a4aedb36065f66fc7e99cb2e6de3e55242f9dfb/scene/resources/material.cpp#L106C1-L112C2)), to the Shader resource inspector and to the shader editor.
![LMPrAaIzQi](https://github.com/user-attachments/assets/9b34659f-e87e-4424-935f-1910a7dbe45b)
![SC05RjXnlO](https://github.com/user-attachments/assets/d4fdcb16-8357-441a-953e-4ba0dc55cc47)

![godot windows editor dev x86_64_tU88Nvc2Ah](https://github.com/user-attachments/assets/980365be-f9d8-43db-af5b-d786a1feae0e)
![godot windows editor dev x86_64_hcpELW4Tsh](https://github.com/user-attachments/assets/7b1abdb4-ac5b-4773-a18d-8db7cb15a6de)
![godot windows editor dev x86_64_OBXfqaaZUL](https://github.com/user-attachments/assets/52237dbb-8b24-4d94-a48c-3e8358565307)



I added the action to the shader editor under the `File` menu, because it's a valid action for both text and visual shaders. I can see reasons to instead do one of the following:
- Add the action to one of the other menus, like `Edit`, which only appear for text shaders. This action is for advanced users, currently takes multiple seconds to open on my machine, and may be confused with the "Show Generated Shader Code" action in visual shaders. On the other hand, it is a *valid* action for both types of shader.
- Not include this action in the shader editor at all. Perhaps it will cause more confusion than its worth. With this PR, you can now do `File -> Open File in Inspector` and then `Manage object properties -> Inspect Native Shader Code`.