### PR TITLE
Fix C# `operator *(Transform3D, Aabb)`

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -41,11 +41,11 @@ struct [[nodiscard]] Basis {
 		Vector3(0, 0, 1)
 	};
 
-	_FORCE_INLINE_ const Vector3 &operator[](int p_axis) const {
-		return rows[p_axis];
+	_FORCE_INLINE_ const Vector3 &operator[](int p_row) const {
+		return rows[p_row];
 	}
-	_FORCE_INLINE_ Vector3 &operator[](int p_axis) {
-		return rows[p_axis];
+	_FORCE_INLINE_ Vector3 &operator[](int p_row) {
+		return rows[p_row];
 	}
 
 	void invert();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -468,8 +468,8 @@ namespace Godot
             {
                 for (int j = 0; j < 3; j++)
                 {
-                    real_t e = transform.Basis[i][j] * min[j];
-                    real_t f = transform.Basis[i][j] * max[j];
+                    real_t e = transform.Basis[j][i] * min[j];
+                    real_t f = transform.Basis[j][i] * max[j];
                     if (e < f)
                     {
                         tmin[i] += e;


### PR DESCRIPTION
The current C# implemention of `static Aabb operator *(Transform3D transform, Aabb aabb)` (added in #64729) is pretty-much a copy-paste of the core/C++ implementation of `AABB Transform3D::xform(const AABB &p_aabb)`. The issue is that such implemenation uses `Basis[int]` operator and:
- in core/C++ this operator returns Basis row,
- in GDscript/C# this operator returns Basis column (axis).

This discrepancy was not taken into account, hence incorrect calculations. This PR fixes that.

Fixes #97197.

