### PR TITLE
Fix TabContainer tab offset moving when not needed

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -267,10 +267,14 @@ void TabContainer::_repaint() {
 	Vector<Control *> controls = _get_tab_controls();
 	int current = get_current_tab();
 
+	// Move the TabBar to the top or bottom.
+	// Don't change the left and right offsets since the TabBar will resize and may change tab offset.
 	if (tabs_position == POSITION_BOTTOM) {
-		tab_bar->set_anchors_and_offsets_preset(PRESET_BOTTOM_WIDE);
+		tab_bar->set_anchor_and_offset(SIDE_BOTTOM, 1.0, 0.0);
+		tab_bar->set_anchor_and_offset(SIDE_TOP, 1.0, -_get_tab_height());
 	} else {
-		tab_bar->set_anchors_and_offsets_preset(PRESET_TOP_WIDE);
+		tab_bar->set_anchor_and_offset(SIDE_BOTTOM, 0.0, _get_tab_height());
+		tab_bar->set_anchor_and_offset(SIDE_TOP, 0.0, 0.0);
 	}
 
 	updating_visibility = true;
@@ -299,7 +303,6 @@ void TabContainer::_repaint() {
 	}
 	updating_visibility = false;
 
-	_update_margins();
 	update_minimum_size();
 }
 


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/97133

It was caused by the call to `set_anchors_and_offsets_preset(PRESET_TOP_WIDE);` since it reset the left and right offsets and then the TabBar resizes and changes the tab offset to fit. The offsets were fixed after, but the tab offset was already changed. The call to `_update_margins` is no longer needed.

I made sure that the anchors and offsets are the same as before:
tabs_position: top
anchors: top 0, bot 0, left 0, right 1
offsets: top 0, bot 31, left 8, right 0
tabs_position: bottom
anchors: top 1, bot 1, left 0, right 1
offsets: top -31, bot 0, left 8, right 0
