### PR TITLE
ColorPicker: Ignore TextureRect expand mode during legacy picking

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1556,6 +1556,7 @@ void ColorPicker::_pick_button_pressed_legacy() {
 
 		picker_texture_rect = memnew(TextureRect);
 		picker_texture_rect->set_anchors_preset(Control::PRESET_FULL_RECT);
+		picker_texture_rect->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 		picker_window->add_child(picker_texture_rect);
 		picker_texture_rect->set_default_cursor_shape(CURSOR_POINTING_HAND);
 		picker_texture_rect->connect(SceneStringName(gui_input), callable_mp(this, &ColorPicker::_picker_texture_input));


### PR DESCRIPTION
Fixes #75514

The color picker has a "legacy" fallback mode when `FEATURE_SCREEN_CAPTURE` is not supported by the current `DisplayServer`. It works by "freezing" the current view by making a huge `Popup` with a `TextureRect` inside covering the screen.

Before this patch, said `TextureRect` could get cut off if its buffer was nominally bigger than the parent popup, such as when the `canvas_items` content scale mode is active.

This is because the default TextureRect scaling logic only allows expanding the texture up. `EXPAND_IGNORE_SIZE` fixes that by allowing the texture to logically "shrink", filling the whole screen independently of the actual buffer size.

Special thanks to @fedyfausto for helping with the diagnosis :D

---

Note that the preview will be blurrier than the native `canvas_items` rendering. I think that's because the popup is re-rendering the buffer but I'm not completely sure.

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/69e360bb-1b51-40d5-91b5-0c3d1b351a70) | ![after](https://github.com/user-attachments/assets/2f9b8b21-dbd2-4c3b-a6da-6e45423cf305) |


