### PR TITLE
Ensure excluded GDExtension files are not included in `extension_list.cfg`

### DIFF
--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -135,6 +135,8 @@ private:
 	void _edit_files_with_filter(Ref<DirAccess> &da, const Vector<String> &p_filters, HashSet<String> &r_list, bool exclude);
 	void _edit_filter_list(HashSet<String> &r_list, const String &p_filter, bool exclude);
 
+	static Vector<uint8_t> _filter_extension_list_config_file(const String &p_config_path, const HashSet<String> &p_paths);
+
 	struct FileExportCache {
 		uint64_t source_modified_time = 0;
 		String source_md5;


### PR DESCRIPTION
The implemented solution to the problem of the error message appearing when an excluded GDExtension in an export of a project, is to filter the lines in the extension_list.cfg file to only include those that are in the paths actually included for export.  If there are no entries remaining, don't write the file at all.

* *Bugsquad edit, fixes: #97207*

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
