### PR TITLE
Remove `stdint.h` from some files

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -35,8 +35,6 @@
 #include "core/debugger/script_debugger.h"
 #include "core/io/resource_loader.h"
 
-#include <stdint.h>
-
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
 int ScriptServer::_language_count = 0;
 bool ScriptServer::languages_ready = false;

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -35,8 +35,6 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 
-#include <stdint.h> // INT32_MAX
-
 #include <functiondiscoverykeys.h>
 
 #include <wrl/client.h>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -61,8 +61,6 @@
 #include "editor/editor_paths.h"
 #endif
 
-#include <stdint.h>
-
 ///////////////////////////
 
 GDScriptNativeClass::GDScriptNativeClass(const StringName &p_name) {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -66,8 +66,6 @@
 #include "editor/node_dock.h"
 #endif
 
-#include <stdint.h>
-
 // Types that will be skipped over (in favor of their base types) when setting up instance bindings.
 // This must be a superset of `ignored_types` in bindings_generator.cpp.
 const Vector<String> ignored_types = {};

--- a/modules/mono/interop_types.h
+++ b/modules/mono/interop_types.h
@@ -38,7 +38,6 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
-#include <stdint.h>
 
 // This is taken from the old GDNative, which was removed.
 

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -42,8 +42,6 @@
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 
-#include <stdint.h>
-
 class CSharpScript;
 
 namespace GDMonoCache {

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -37,8 +37,6 @@
 #include "core/os/os.h"
 #endif
 
-#include <stdint.h>
-
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneMultiplayer::_profile_bandwidth(const String &p_what, int p_value) {
 	if (EngineDebugger::is_profiling("multiplayer:bandwidth")) {

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -33,8 +33,6 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/io/marshalls.h"
 
-#include <stdint.h>
-
 #ifdef DEBUG_ENABLED
 #include "core/os/os.h"
 #endif

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -43,8 +43,6 @@
 #include "scene/resources/packed_scene.h"
 #include "viewport.h"
 
-#include <stdint.h>
-
 int Node::orphan_node_count = 0;
 
 thread_local Node *Node::current_process_thread_group = nullptr;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This PR removes `#include <stdint.h>` from most files except `version.h`, `gdextenstion_interface.h`, `freedesktop_screensaver.h`, `d3d12_godot_nir_bridge.h`, Web, and all `so_wrap` ones.