### PR TITLE
Don't list CSV as a valid extension for `Translation` resource

### DIFF
--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -37,7 +37,6 @@
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/pot_generator.h"
-#include "editor/themes/editor_scale.h"
 #include "scene/gui/control.h"
 
 void LocalizationEditor::_notification(int p_what) {
@@ -49,6 +48,7 @@ void LocalizationEditor::_notification(int p_what) {
 
 			List<String> tfn;
 			ResourceLoader::get_recognized_extensions_for_type("Translation", &tfn);
+			tfn.erase("csv"); // CSV is recognized by the resource importer to generate translation files, but it's not a translation file itself.
 			for (const String &E : tfn) {
 				translation_file_open->add_filter("*." + E);
 			}


### PR DESCRIPTION
Resolves #87187

When adding translation files in the Project Settings dialog, a `.csv` file is currently valid choice.

CSV is recognized by the resource importer to generate translation files, but it's not a `Translation` resource file itself.

Also removed an unused header include in the modified source file :P

Note: One drawback is that if someone created a custom importer that _does_ import a CSV file as one valid `Translation` resource (which is not very useful), this PR also prevents the user from selecting the file directly. However, the user can still select the file by selecting the "All Files" filter.