### PR TITLE
Update `AnimationTree` parameter list when updating `AnimationNodeTransition` input names

### DIFF
--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1139,7 +1139,11 @@ void AnimationNodeTransition::remove_input(int p_index) {
 
 bool AnimationNodeTransition::set_input_name(int p_input, const String &p_name) {
 	pending_update = true;
-	return AnimationNode::set_input_name(p_input, p_name);
+	if (!AnimationNode::set_input_name(p_input, p_name)) {
+		return false;
+	}
+	emit_signal(SNAME("tree_changed")); // For updating enum options.
+	return true;
 }
 
 void AnimationNodeTransition::set_input_as_auto_advance(int p_input, bool p_enable) {


### PR DESCRIPTION
Modifying input names currently does not update the available options of "Transition Request".

![image](https://github.com/user-attachments/assets/d29f110f-3fbe-44b2-926f-a6eb6d4ed1ce)
