### PR TITLE
Fix error on `New Viewport Texture` in Editor Inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4138,9 +4138,11 @@ void EditorInspector::_notification(int p_what) {
 			changing++;
 
 			if (update_tree_pending) {
-				update_tree();
-				update_tree_pending = false;
-				pending.clear();
+				if (!update_tree_paused) {
+					update_tree();
+					update_tree_pending = false;
+					pending.clear();
+				}
 
 			} else {
 				while (pending.size()) {
@@ -4245,6 +4247,10 @@ void EditorInspector::set_property_clipboard(const Variant &p_value) {
 
 Variant EditorInspector::get_property_clipboard() const {
 	return property_clipboard;
+}
+
+void EditorInspector::set_update_tree_paused(bool p_paused) {
+	update_tree_paused = p_paused;
 }
 
 void EditorInspector::_show_add_meta_dialog() {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -520,6 +520,7 @@ class EditorInspector : public ScrollContainer {
 
 	float refresh_countdown;
 	bool update_tree_pending = false;
+	bool update_tree_paused = false;
 	StringName _prop_edited;
 	StringName property_selected;
 	int property_focusable;
@@ -652,6 +653,8 @@ public:
 	void set_restrict_to_basic_settings(bool p_restrict);
 	void set_property_clipboard(const Variant &p_value);
 	Variant get_property_clipboard() const;
+
+	void set_update_tree_paused(bool p_paused);
 
 	EditorInspector();
 };

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3122,7 +3122,19 @@ void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) 
 
 			add_child(scene_tree);
 			scene_tree->connect("selected", callable_mp(this, &EditorPropertyResource::_viewport_selected));
+			scene_tree->connect("visibility_changed", callable_mp(this, &EditorPropertyResource::_scene_tree_visibility_changed));
 		}
+
+		// We need to pause the inspector to update it's tree to prevent the
+		// recreation of the current EditorPropertyResource instance which contains
+		// the scene tree dialog. EditorInspector recreates all the controls on update tree
+		// and the update tree is triggered by the signal property_list_changed in BaseMaterial3D
+		// when the ViewportTexture is set on the current propecty.
+		EditorInspector *parent_inspector = _get_parent_inspector();
+		if (parent_inspector) {
+			parent_inspector->set_update_tree_paused(true);
+		}
+
 		scene_tree->popup_scenetree_dialog();
 	}
 }
@@ -3192,6 +3204,27 @@ void EditorPropertyResource::_viewport_selected(const NodePath &p_path) {
 
 	emit_changed(get_edited_property(), vt);
 	update_property();
+}
+
+EditorInspector *EditorPropertyResource::_get_parent_inspector() {
+	Node *parent = get_parent();
+	while (parent) {
+		EditorInspector *inspector = Object::cast_to<EditorInspector>(parent);
+		if (inspector) {
+			return inspector;
+		}
+		parent = parent->get_parent();
+	}
+	return nullptr;
+}
+
+void EditorPropertyResource::_scene_tree_visibility_changed() {
+	if (!scene_tree->is_visible()) {
+		EditorInspector *parent_inspector = _get_parent_inspector();
+		if (parent_inspector) {
+			parent_inspector->set_update_tree_paused(false);
+		}
+	}
 }
 
 void EditorPropertyResource::setup(Object *p_object, const String &p_path, const String &p_base_type) {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -677,6 +677,9 @@ class EditorPropertyResource : public EditorProperty {
 
 	void _viewport_selected(const NodePath &p_path);
 
+	EditorInspector *_get_parent_inspector();
+	void _scene_tree_visibility_changed();
+
 	void _sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool p_advance);
 	void _sub_inspector_resource_selected(const Ref<Resource> &p_resource, const String &p_property);
 	void _sub_inspector_object_id_selected(int p_id);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -167,7 +167,10 @@ Ref<Image> ViewportTexture::get_image() const {
 }
 
 void ViewportTexture::_err_print_viewport_not_set() const {
-	if (!vp_pending && !vp_changed) {
+	// Removing this error while in the editor to prevent printing this error
+	// while creating the new ViewportTexture. When creating a new ViewportTexture in the editor,
+	// it's normal that the vp is not initialized.
+	if (!vp_pending && !vp_changed && !Engine::get_singleton()->is_editor_hint()) {
 		ERR_PRINT("Viewport Texture must be set to use it.");
 	}
 }


### PR DESCRIPTION
- Fixes #97225

This PR should resolve the unnecessary error "Viewport Texture must be set to use it" when using "New Viewport Texture" from the Editor Inspector. It also fixes the issue where the popup to select the `SubViewport` flashes and disappears immediately.

I couldn't find a better way to prevent the error "Viewport Texture must be set to use it" other than adding a check for `Engine::get_singleton()->is_editor_hint()`. No properties are set when the new inspector tries to get the texture, and the `get_texture` method is default behavior in the editor, which I didn’t want to interfere with. I'm even considering whether this error should be removed completely.

As for the popup to select the `SubViewport`, that was a bit trickier. When creating a new ViewportTexture, the editor calls `set_texture` on the currently edited property, which triggers `BaseMaterial3D::set_texture`. This method emits `property_list_changed`, which causes an update of the tree in the parent `EditorInspector`. The inspector then destroys and recreates its controls during the update, which destroys the popup. To prevent this, I added a method in the `EditorInspector` to pause the tree update while the popup is open. I tried deferring the `popup_scenetree_dialog` call, but it was still executed before the tree update. Maybe there's better way to do that, I'm not that familiar with the inspector.
