### PR TITLE
Style: Update `ruff` & `mypy` to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,14 +39,14 @@ repos:
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.6.6
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v1.11.2
     hooks:
       - id: mypy
         files: \.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ warn_unreachable = true
 namespace_packages = true
 explicit_package_bases = true
 exclude = ["thirdparty/"]
+python_version = "3.8"
 
 [tool.ruff]
 extend-exclude = ["thirdparty"]


### PR DESCRIPTION
Ruff required no further updates. Mypy needs two small tweaks:
- Ensure lowest supported python version is used (3.8).
- Fix the one new typing error in `godot_update_emtree.py`.