### PR TITLE
Style: Detect unnecessary semicolons via `clang-tidy`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,22 +1,25 @@
----
-Checks: >-
-  -*,
-  cppcoreguidelines-pro-type-member-init,
-  modernize-redundant-void-arg,
-  modernize-use-bool-literals,
-  modernize-use-default-member-init,
-  modernize-use-nullptr,
-  readability-braces-around-statements,
-  readability-redundant-member-init
-WarningsAsErrors: ''
+Checks:
+  - -*
+  - clang-diagnostic-extra-semi*
+  - cppcoreguidelines-pro-type-member-init
+  - modernize-redundant-void-arg
+  - modernize-use-bool-literals
+  - modernize-use-default-member-init
+  - modernize-use-nullptr
+  - readability-braces-around-statements
+  - readability-redundant-member-init
 HeaderFileExtensions: ['', h, hh, hpp, hxx, inc, glsl]
 ImplementationFileExtensions: [c, cc, cpp, cxx, m, mm, java]
 HeaderFilterRegex: (core|doc|drivers|editor|main|modules|platform|scene|servers|tests)/
 FormatStyle: file
+ExtraArgs: # Ensure certain clang warnings are caught regardless of compiler/settings.
+  - -Wextra-semi
+  - -Wno-error=extra-semi
+  - -Wextra-semi-stmt
+  - -Wno-error=extra-semi-stmt
 CheckOptions:
   cppcoreguidelines-pro-type-member-init.IgnoreArrays: true
   cppcoreguidelines-pro-type-member-init.UseAssignment: true
   modernize-use-bool-literals.IgnoreMacros: false
   modernize-use-default-member-init.IgnoreMacros: false
   modernize-use-default-member-init.UseAssignment: true
-...

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -37,7 +37,7 @@ template <typename T>
 class TypedArray;
 
 class ProjectSettings : public Object {
-	GDCLASS(ProjectSettings, Object);
+	GDCLASS(ProjectSettings, Object)
 	_THREAD_SAFE_CLASS_
 	friend class TestProjectSettingsInternalsAccessor;
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -48,7 +48,7 @@ class TypedArray;
 namespace core_bind {
 
 class ResourceLoader : public Object {
-	GDCLASS(ResourceLoader, Object);
+	GDCLASS(ResourceLoader, Object)
 
 protected:
 	static void _bind_methods();
@@ -91,7 +91,7 @@ public:
 };
 
 class ResourceSaver : public Object {
-	GDCLASS(ResourceSaver, Object);
+	GDCLASS(ResourceSaver, Object)
 
 protected:
 	static void _bind_methods();
@@ -120,7 +120,7 @@ public:
 };
 
 class OS : public Object {
-	GDCLASS(OS, Object);
+	GDCLASS(OS, Object)
 
 	mutable HashMap<String, bool> feature_cache;
 
@@ -263,7 +263,7 @@ public:
 };
 
 class Geometry2D : public Object {
-	GDCLASS(Geometry2D, Object);
+	GDCLASS(Geometry2D, Object)
 
 	static Geometry2D *singleton;
 
@@ -327,7 +327,7 @@ public:
 };
 
 class Geometry3D : public Object {
-	GDCLASS(Geometry3D, Object);
+	GDCLASS(Geometry3D, Object)
 
 	static Geometry3D *singleton;
 
@@ -358,7 +358,7 @@ public:
 };
 
 class Marshalls : public Object {
-	GDCLASS(Marshalls, Object);
+	GDCLASS(Marshalls, Object)
 
 	static Marshalls *singleton;
 
@@ -382,7 +382,7 @@ public:
 };
 
 class Mutex : public RefCounted {
-	GDCLASS(Mutex, RefCounted);
+	GDCLASS(Mutex, RefCounted)
 	::Mutex mutex;
 
 	static void _bind_methods();
@@ -394,7 +394,7 @@ public:
 };
 
 class Semaphore : public RefCounted {
-	GDCLASS(Semaphore, RefCounted);
+	GDCLASS(Semaphore, RefCounted)
 	::Semaphore semaphore;
 
 protected:
@@ -411,7 +411,7 @@ public:
 };
 
 class Thread : public RefCounted {
-	GDCLASS(Thread, RefCounted);
+	GDCLASS(Thread, RefCounted)
 
 protected:
 	Variant ret;
@@ -441,7 +441,7 @@ public:
 namespace special {
 
 class ClassDB : public Object {
-	GDCLASS(ClassDB, Object);
+	GDCLASS(ClassDB, Object)
 
 protected:
 	static void _bind_methods();
@@ -507,7 +507,7 @@ public:
 } // namespace special
 
 class Engine : public Object {
-	GDCLASS(Engine, Object);
+	GDCLASS(Engine, Object)
 
 protected:
 	static void _bind_methods();
@@ -578,7 +578,7 @@ public:
 };
 
 class EngineDebugger : public Object {
-	GDCLASS(EngineDebugger, Object);
+	GDCLASS(EngineDebugger, Object)
 
 	HashMap<StringName, Callable> captures;
 	HashMap<StringName, Ref<EngineProfiler>> profilers;

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -38,7 +38,7 @@
 #include "core/object/ref_counted.h"
 
 class CryptoKey : public Resource {
-	GDCLASS(CryptoKey, Resource);
+	GDCLASS(CryptoKey, Resource)
 
 protected:
 	static void _bind_methods();
@@ -54,7 +54,7 @@ public:
 };
 
 class X509Certificate : public Resource {
-	GDCLASS(X509Certificate, Resource);
+	GDCLASS(X509Certificate, Resource)
 
 protected:
 	static void _bind_methods();
@@ -70,7 +70,7 @@ public:
 };
 
 class TLSOptions : public RefCounted {
-	GDCLASS(TLSOptions, RefCounted);
+	GDCLASS(TLSOptions, RefCounted)
 
 private:
 	enum Mode {
@@ -102,7 +102,7 @@ public:
 };
 
 class HMACContext : public RefCounted {
-	GDCLASS(HMACContext, RefCounted);
+	GDCLASS(HMACContext, RefCounted)
 
 protected:
 	static void _bind_methods();
@@ -120,7 +120,7 @@ public:
 };
 
 class Crypto : public RefCounted {
-	GDCLASS(Crypto, RefCounted);
+	GDCLASS(Crypto, RefCounted)
 
 protected:
 	static void _bind_methods();

--- a/core/crypto/hashing_context.h
+++ b/core/crypto/hashing_context.h
@@ -34,7 +34,7 @@
 #include "core/object/ref_counted.h"
 
 class HashingContext : public RefCounted {
-	GDCLASS(HashingContext, RefCounted);
+	GDCLASS(HashingContext, RefCounted)
 
 public:
 	enum HashType {

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -106,7 +106,7 @@ public:
 	_FORCE_INLINE_ static EngineDebugger *get_singleton() { return singleton; }
 	_FORCE_INLINE_ static bool is_active() { return singleton != nullptr && script_debugger != nullptr; }
 
-	_FORCE_INLINE_ static ScriptDebugger *get_script_debugger() { return script_debugger; };
+	_FORCE_INLINE_ static ScriptDebugger *get_script_debugger() { return script_debugger; }
 
 	static void initialize(const String &p_uri, bool p_skip_breakpoints, const Vector<String> &p_breakpoints, void (*p_allow_focus_steal_fn)());
 	static void deinitialize();

--- a/core/debugger/engine_profiler.h
+++ b/core/debugger/engine_profiler.h
@@ -35,7 +35,7 @@
 #include "core/object/ref_counted.h"
 
 class EngineProfiler : public RefCounted {
-	GDCLASS(EngineProfiler, RefCounted);
+	GDCLASS(EngineProfiler, RefCounted)
 
 private:
 	String registration;
@@ -52,9 +52,9 @@ public:
 	Error unbind();
 	bool is_bound() const { return registration.length() > 0; }
 
-	GDVIRTUAL2(_toggle, bool, Array);
-	GDVIRTUAL1(_add_frame, Array);
-	GDVIRTUAL4(_tick, double, double, double, double);
+	GDVIRTUAL2(_toggle, bool, Array)
+	GDVIRTUAL1(_add_frame, Array)
+	GDVIRTUAL4(_tick, double, double, double, double)
 
 	EngineProfiler() {}
 	virtual ~EngineProfiler();

--- a/core/extension/gdextension_manager.h
+++ b/core/extension/gdextension_manager.h
@@ -34,7 +34,7 @@
 #include "core/extension/gdextension.h"
 
 class GDExtensionManager : public Object {
-	GDCLASS(GDExtensionManager, Object);
+	GDCLASS(GDExtensionManager, Object)
 
 	int32_t level = -1;
 	HashMap<String, Ref<GDExtension>> gdextension_map;

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -39,7 +39,7 @@
 #include "core/variant/typed_array.h"
 
 class Input : public Object {
-	GDCLASS(Input, Object);
+	GDCLASS(Input, Object)
 	_THREAD_SAFE_CLASS_
 
 	static Input *singleton;

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -51,7 +51,7 @@ class Shortcut;
  */
 
 class InputEvent : public Resource {
-	GDCLASS(InputEvent, Resource);
+	GDCLASS(InputEvent, Resource)
 
 	int device = 0;
 
@@ -94,7 +94,7 @@ public:
 };
 
 class InputEventFromWindow : public InputEvent {
-	GDCLASS(InputEventFromWindow, InputEvent);
+	GDCLASS(InputEventFromWindow, InputEvent)
 
 	int64_t window_id = 0;
 
@@ -109,7 +109,7 @@ public:
 };
 
 class InputEventWithModifiers : public InputEventFromWindow {
-	GDCLASS(InputEventWithModifiers, InputEventFromWindow);
+	GDCLASS(InputEventWithModifiers, InputEventFromWindow)
 
 	bool command_or_control_autoremap = false;
 
@@ -151,7 +151,7 @@ public:
 };
 
 class InputEventKey : public InputEventWithModifiers {
-	GDCLASS(InputEventKey, InputEventWithModifiers);
+	GDCLASS(InputEventKey, InputEventWithModifiers)
 
 	Key keycode = Key::NONE; // Key enum, without modifier masks.
 	Key physical_keycode = Key::NONE;
@@ -207,7 +207,7 @@ public:
 };
 
 class InputEventMouse : public InputEventWithModifiers {
-	GDCLASS(InputEventMouse, InputEventWithModifiers);
+	GDCLASS(InputEventMouse, InputEventWithModifiers)
 
 	BitField<MouseButtonMask> button_mask;
 
@@ -231,7 +231,7 @@ public:
 };
 
 class InputEventMouseButton : public InputEventMouse {
-	GDCLASS(InputEventMouseButton, InputEventMouse);
+	GDCLASS(InputEventMouseButton, InputEventMouse)
 
 	float factor = 1;
 	MouseButton button_index = MouseButton::NONE;
@@ -266,7 +266,7 @@ public:
 };
 
 class InputEventMouseMotion : public InputEventMouse {
-	GDCLASS(InputEventMouseMotion, InputEventMouse);
+	GDCLASS(InputEventMouseMotion, InputEventMouse)
 
 	Vector2 tilt;
 	float pressure = 0;
@@ -311,7 +311,7 @@ public:
 };
 
 class InputEventJoypadMotion : public InputEvent {
-	GDCLASS(InputEventJoypadMotion, InputEvent);
+	GDCLASS(InputEventJoypadMotion, InputEvent)
 	JoyAxis axis = (JoyAxis)0; ///< Joypad axis
 	float axis_value = 0; ///< -1 to 1
 
@@ -338,7 +338,7 @@ public:
 };
 
 class InputEventJoypadButton : public InputEvent {
-	GDCLASS(InputEventJoypadButton, InputEvent);
+	GDCLASS(InputEventJoypadButton, InputEvent)
 
 	JoyButton button_index = (JoyButton)0;
 	float pressure = 0; //0 to 1
@@ -368,7 +368,7 @@ public:
 };
 
 class InputEventScreenTouch : public InputEventFromWindow {
-	GDCLASS(InputEventScreenTouch, InputEventFromWindow);
+	GDCLASS(InputEventScreenTouch, InputEventFromWindow)
 	int index = 0;
 	Vector2 pos;
 	bool double_tap = false;
@@ -397,7 +397,7 @@ public:
 };
 
 class InputEventScreenDrag : public InputEventFromWindow {
-	GDCLASS(InputEventScreenDrag, InputEventFromWindow);
+	GDCLASS(InputEventScreenDrag, InputEventFromWindow)
 	int index = 0;
 	Vector2 pos;
 	Vector2 relative;
@@ -449,7 +449,7 @@ public:
 };
 
 class InputEventAction : public InputEvent {
-	GDCLASS(InputEventAction, InputEvent);
+	GDCLASS(InputEventAction, InputEvent)
 
 	StringName action;
 	float strength = 1.0f;
@@ -484,7 +484,7 @@ public:
 };
 
 class InputEventGesture : public InputEventWithModifiers {
-	GDCLASS(InputEventGesture, InputEventWithModifiers);
+	GDCLASS(InputEventGesture, InputEventWithModifiers)
 
 	Vector2 pos;
 
@@ -497,7 +497,7 @@ public:
 };
 
 class InputEventMagnifyGesture : public InputEventGesture {
-	GDCLASS(InputEventMagnifyGesture, InputEventGesture);
+	GDCLASS(InputEventMagnifyGesture, InputEventGesture)
 	real_t factor = 1.0;
 
 protected:
@@ -515,7 +515,7 @@ public:
 };
 
 class InputEventPanGesture : public InputEventGesture {
-	GDCLASS(InputEventPanGesture, InputEventGesture);
+	GDCLASS(InputEventPanGesture, InputEventGesture)
 	Vector2 delta;
 
 protected:
@@ -533,7 +533,7 @@ public:
 };
 
 class InputEventMIDI : public InputEvent {
-	GDCLASS(InputEventMIDI, InputEvent);
+	GDCLASS(InputEventMIDI, InputEvent)
 
 	int channel = 0;
 	MIDIMessage message = MIDIMessage::NONE;
@@ -579,7 +579,7 @@ public:
 };
 
 class InputEventShortcut : public InputEvent {
-	GDCLASS(InputEventShortcut, InputEvent);
+	GDCLASS(InputEventShortcut, InputEvent)
 
 	Ref<Shortcut> shortcut;
 

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -40,7 +40,7 @@ template <typename T>
 class TypedArray;
 
 class InputMap : public Object {
-	GDCLASS(InputMap, Object);
+	GDCLASS(InputMap, Object)
 
 public:
 	/**

--- a/core/input/shortcut.h
+++ b/core/input/shortcut.h
@@ -35,7 +35,7 @@
 #include "core/io/resource.h"
 
 class Shortcut : public Resource {
-	GDCLASS(Shortcut, Resource);
+	GDCLASS(Shortcut, Resource)
 
 	Array events;
 

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -37,7 +37,7 @@
 #include "core/variant/variant_parser.h"
 
 class ConfigFile : public RefCounted {
-	GDCLASS(ConfigFile, RefCounted);
+	GDCLASS(ConfigFile, RefCounted)
 
 	HashMap<String, HashMap<String, Variant>> values;
 

--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -37,7 +37,7 @@
 
 //@ TODO, excellent candidate for THREAD_SAFE MACRO, should go through all these and add THREAD_SAFE where it applies
 class DirAccess : public RefCounted {
-	GDCLASS(DirAccess, RefCounted);
+	GDCLASS(DirAccess, RefCounted)
 
 public:
 	enum AccessType {
@@ -96,8 +96,8 @@ public:
 
 	virtual bool file_exists(String p_file) = 0;
 	virtual bool dir_exists(String p_dir) = 0;
-	virtual bool is_readable(String p_dir) { return true; };
-	virtual bool is_writable(String p_dir) { return true; };
+	virtual bool is_readable(String p_dir) { return true; }
+	virtual bool is_writable(String p_dir) { return true; }
 	static bool exists(const String &p_dir);
 	virtual uint64_t get_space_left() = 0;
 

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -43,7 +43,7 @@
  */
 
 class FileAccess : public RefCounted {
-	GDCLASS(FileAccess, RefCounted);
+	GDCLASS(FileAccess, RefCounted)
 
 public:
 	enum AccessType {
@@ -215,8 +215,8 @@ public:
 	static bool get_read_only_attribute(const String &p_file);
 	static Error set_read_only_attribute(const String &p_file, bool p_ro);
 
-	static void set_backup_save(bool p_enable) { backup_save = p_enable; };
-	static bool is_backup_save_enabled() { return backup_save; };
+	static void set_backup_save(bool p_enable) { backup_save = p_enable; }
+	static bool is_backup_save_enabled() { return backup_save; }
 
 	static String get_md5(const String &p_file);
 	static String get_sha256(const String &p_file);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -56,7 +56,7 @@ typedef Error (*SaveEXRFunc)(const String &p_path, const Ref<Image> &p_img, bool
 typedef Vector<uint8_t> (*SaveEXRBufferFunc)(const Ref<Image> &p_img, bool p_grayscale);
 
 class Image : public Resource {
-	GDCLASS(Image, Resource);
+	GDCLASS(Image, Resource)
 
 public:
 	static SavePNGFunc save_png_func;

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -43,7 +43,7 @@
 class ImageLoader;
 
 class ImageFormatLoader : public RefCounted {
-	GDCLASS(ImageFormatLoader, RefCounted);
+	GDCLASS(ImageFormatLoader, RefCounted)
 
 	friend class ImageLoader;
 	friend class ResourceFormatLoaderImage;
@@ -69,7 +69,7 @@ public:
 VARIANT_BITFIELD_CAST(ImageFormatLoader::LoaderFlags);
 
 class ImageFormatLoaderExtension : public ImageFormatLoader {
-	GDCLASS(ImageFormatLoaderExtension, ImageFormatLoader);
+	GDCLASS(ImageFormatLoaderExtension, ImageFormatLoader)
 
 protected:
 	static void _bind_methods();
@@ -81,8 +81,8 @@ public:
 	void add_format_loader();
 	void remove_format_loader();
 
-	GDVIRTUAL0RC(PackedStringArray, _get_recognized_extensions);
-	GDVIRTUAL4R(Error, _load_image, Ref<Image>, Ref<FileAccess>, BitField<ImageFormatLoader::LoaderFlags>, float);
+	GDVIRTUAL0RC(PackedStringArray, _get_recognized_extensions)
+	GDVIRTUAL4R(Error, _load_image, Ref<Image>, Ref<FileAccess>, BitField<ImageFormatLoader::LoaderFlags>, float)
 };
 
 class ImageLoader {

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -40,7 +40,7 @@ class TypedArray;
 struct _IP_ResolverPrivate;
 
 class IP : public Object {
-	GDCLASS(IP, Object);
+	GDCLASS(IP, Object)
 
 public:
 	enum ResolverStatus {

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -37,7 +37,7 @@
 #include "core/variant/variant.h"
 
 class JSON : public Resource {
-	GDCLASS(JSON, Resource);
+	GDCLASS(JSON, Resource)
 
 	enum TokenType {
 		TK_CURLY_BRACKET_OPEN,

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -48,7 +48,7 @@ public:                                                                         
 private:
 
 class Resource : public RefCounted {
-	GDCLASS(Resource, RefCounted);
+	GDCLASS(Resource, RefCounted)
 
 public:
 	static void register_custom_data_to_otdb() { ClassDB::add_resource_base_extension("res", get_class_static()); }
@@ -85,9 +85,9 @@ protected:
 	void _take_over_path(const String &p_path);
 
 	virtual void reset_local_to_scene();
-	GDVIRTUAL0(_setup_local_to_scene);
+	GDVIRTUAL0(_setup_local_to_scene)
 
-	GDVIRTUAL0RC(RID, _get_rid);
+	GDVIRTUAL0RC(RID, _get_rid)
 
 public:
 	static Node *(*_get_local_scene_func)(); //used by editor

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -103,7 +103,7 @@ public:
 };
 
 class ResourceImporter : public RefCounted {
-	GDCLASS(ResourceImporter, RefCounted);
+	GDCLASS(ResourceImporter, RefCounted)
 
 protected:
 	static void _bind_methods();

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -43,7 +43,7 @@ template <int Tag>
 class SafeBinaryMutex;
 
 class ResourceFormatLoader : public RefCounted {
-	GDCLASS(ResourceFormatLoader, RefCounted);
+	GDCLASS(ResourceFormatLoader, RefCounted)
 
 public:
 	enum CacheMode {
@@ -222,7 +222,7 @@ public:
 	static ThreadLoadStatus load_threaded_get_status(const String &p_path, float *r_progress = nullptr);
 	static Ref<Resource> load_threaded_get(const String &p_path, Error *r_error = nullptr);
 
-	static bool is_within_load() { return load_nesting > 0; };
+	static bool is_within_load() { return load_nesting > 0; }
 
 	static void resource_changed_connect(Resource *p_source, const Callable &p_callable, uint32_t p_flags);
 	static void resource_changed_disconnect(Resource *p_source, const Callable &p_callable);

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -35,7 +35,7 @@
 #include "core/object/gdvirtual.gen.inc"
 
 class ResourceFormatSaver : public RefCounted {
-	GDCLASS(ResourceFormatSaver, RefCounted);
+	GDCLASS(ResourceFormatSaver, RefCounted)
 
 protected:
 	static void _bind_methods();

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -38,7 +38,7 @@
 #include "core/variant/native_ptr.h"
 
 class StreamPeer : public RefCounted {
-	GDCLASS(StreamPeer, RefCounted);
+	GDCLASS(StreamPeer, RefCounted)
 
 protected:
 	static void _bind_methods();
@@ -97,29 +97,29 @@ public:
 };
 
 class StreamPeerExtension : public StreamPeer {
-	GDCLASS(StreamPeerExtension, StreamPeer);
+	GDCLASS(StreamPeerExtension, StreamPeer)
 
 protected:
 	static void _bind_methods();
 
 public:
 	virtual Error put_data(const uint8_t *p_data, int p_bytes) override;
-	GDVIRTUAL3R(Error, _put_data, GDExtensionConstPtr<const uint8_t>, int, GDExtensionPtr<int>);
+	GDVIRTUAL3R(Error, _put_data, GDExtensionConstPtr<const uint8_t>, int, GDExtensionPtr<int>)
 
 	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) override;
-	GDVIRTUAL3R(Error, _put_partial_data, GDExtensionConstPtr<const uint8_t>, int, GDExtensionPtr<int>);
+	GDVIRTUAL3R(Error, _put_partial_data, GDExtensionConstPtr<const uint8_t>, int, GDExtensionPtr<int>)
 
 	virtual Error get_data(uint8_t *p_buffer, int p_bytes) override;
-	GDVIRTUAL3R(Error, _get_data, GDExtensionPtr<uint8_t>, int, GDExtensionPtr<int>);
+	GDVIRTUAL3R(Error, _get_data, GDExtensionPtr<uint8_t>, int, GDExtensionPtr<int>)
 
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
-	GDVIRTUAL3R(Error, _get_partial_data, GDExtensionPtr<uint8_t>, int, GDExtensionPtr<int>);
+	GDVIRTUAL3R(Error, _get_partial_data, GDExtensionPtr<uint8_t>, int, GDExtensionPtr<int>)
 
-	EXBIND0RC(int, get_available_bytes);
+	EXBIND0RC(int, get_available_bytes)
 };
 
 class StreamPeerBuffer : public StreamPeer {
-	GDCLASS(StreamPeerBuffer, StreamPeer);
+	GDCLASS(StreamPeerBuffer, StreamPeer)
 
 	Vector<uint8_t> data;
 	int pointer = 0;

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -37,7 +37,7 @@
 #include "core/io/stream_peer.h"
 
 class StreamPeerTCP : public StreamPeer {
-	GDCLASS(StreamPeerTCP, StreamPeer);
+	GDCLASS(StreamPeerTCP, StreamPeer)
 
 public:
 	enum Status {

--- a/core/io/tcp_server.h
+++ b/core/io/tcp_server.h
@@ -37,7 +37,7 @@
 #include "core/io/stream_peer_tcp.h"
 
 class TCPServer : public RefCounted {
-	GDCLASS(TCPServer, RefCounted);
+	GDCLASS(TCPServer, RefCounted)
 
 protected:
 	enum {

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -41,7 +41,7 @@
 */
 
 class XMLParser : public RefCounted {
-	GDCLASS(XMLParser, RefCounted);
+	GDCLASS(XMLParser, RefCounted)
 
 public:
 	//! Enumeration of all supported source text file formats

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -223,7 +223,7 @@ struct [[nodiscard]] Basis {
 
 	static Basis looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
 
-	Basis(const Quaternion &p_quaternion) { set_quaternion(p_quaternion); };
+	Basis(const Quaternion &p_quaternion) { set_quaternion(p_quaternion); }
 	Basis(const Quaternion &p_quaternion, const Vector3 &p_scale) { set_quaternion_scale(p_quaternion, p_scale); }
 
 	Basis(const Vector3 &p_axis, real_t p_angle) { set_axis_angle(p_axis, p_angle); }

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -122,9 +122,9 @@ bool Face3::intersects_aabb2(const AABB &p_aabb) const {
 			return false;                                          \
 	}
 
-	TEST_AXIS(x);
-	TEST_AXIS(y);
-	TEST_AXIS(z);
+	TEST_AXIS(x)
+	TEST_AXIS(y)
+	TEST_AXIS(z)
 
 #undef TEST_AXIS
 

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -736,23 +736,23 @@ public:
 		fex = Math::abs(e0.x);
 		fey = Math::abs(e0.y);
 		fez = Math::abs(e0.z);
-		AXISTEST_X01(e0.z, e0.y, fez, fey);
-		AXISTEST_Y02(e0.z, e0.x, fez, fex);
-		AXISTEST_Z12(e0.y, e0.x, fey, fex);
+		AXISTEST_X01(e0.z, e0.y, fez, fey)
+		AXISTEST_Y02(e0.z, e0.x, fez, fex)
+		AXISTEST_Z12(e0.y, e0.x, fey, fex)
 
 		fex = Math::abs(e1.x);
 		fey = Math::abs(e1.y);
 		fez = Math::abs(e1.z);
-		AXISTEST_X01(e1.z, e1.y, fez, fey);
-		AXISTEST_Y02(e1.z, e1.x, fez, fex);
-		AXISTEST_Z0(e1.y, e1.x, fey, fex);
+		AXISTEST_X01(e1.z, e1.y, fez, fey)
+		AXISTEST_Y02(e1.z, e1.x, fez, fex)
+		AXISTEST_Z0(e1.y, e1.x, fey, fex)
 
 		fex = Math::abs(e2.x);
 		fey = Math::abs(e2.y);
 		fez = Math::abs(e2.z);
-		AXISTEST_X2(e2.z, e2.y, fez, fey);
-		AXISTEST_Y1(e2.z, e2.x, fez, fex);
-		AXISTEST_Z12(e2.y, e2.x, fey, fex);
+		AXISTEST_X2(e2.z, e2.y, fez, fey)
+		AXISTEST_Y1(e2.z, e2.x, fez, fex)
+		AXISTEST_Z12(e2.y, e2.x, fey, fex)
 
 		/* Bullet 1: */
 		/*  first test overlap in the {x,y,z}-directions */
@@ -761,19 +761,19 @@ public:
 		/*  the triangle against the AABB */
 
 		/* test in X-direction */
-		FINDMINMAX(v0.x, v1.x, v2.x, min, max);
+		FINDMINMAX(v0.x, v1.x, v2.x, min, max)
 		if (min > boxhalfsize.x || max < -boxhalfsize.x) {
 			return false;
 		}
 
 		/* test in Y-direction */
-		FINDMINMAX(v0.y, v1.y, v2.y, min, max);
+		FINDMINMAX(v0.y, v1.y, v2.y, min, max)
 		if (min > boxhalfsize.y || max < -boxhalfsize.y) {
 			return false;
 		}
 
 		/* test in Z-direction */
-		FINDMINMAX(v0.z, v1.z, v2.z, min, max);
+		FINDMINMAX(v0.z, v1.z, v2.z, min, max)
 		if (min > boxhalfsize.z || max < -boxhalfsize.z) {
 			return false;
 		}

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -40,7 +40,7 @@ struct [[nodiscard]] Plane {
 	real_t d = 0;
 
 	void set_normal(const Vector3 &p_normal);
-	_FORCE_INLINE_ Vector3 get_normal() const { return normal; };
+	_FORCE_INLINE_ Vector3 get_normal() const { return normal; }
 
 	void normalize();
 	Plane normalized() const;

--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -35,7 +35,7 @@
 #include "core/object/ref_counted.h"
 
 class TriangleMesh : public RefCounted {
-	GDCLASS(TriangleMesh, RefCounted);
+	GDCLASS(TriangleMesh, RefCounted)
 
 public:
 	struct Triangle {

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -206,7 +206,7 @@ public:
 
 	template <typename T>
 	static void register_class(bool p_virtual = false) {
-		GLOBAL_LOCK_FUNCTION;
+		GLOBAL_LOCK_FUNCTION
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -109,7 +109,7 @@ public:
 	_FORCE_INLINE_ StringName get_instance_class() const { return instance_class; }
 	_FORCE_INLINE_ void set_instance_class(const StringName &p_class) { instance_class = p_class; }
 
-	_FORCE_INLINE_ int get_argument_count() const { return argument_count; };
+	_FORCE_INLINE_ int get_argument_count() const { return argument_count; }
 
 #ifdef TOOLS_ENABLED
 	virtual bool is_valid() const { return true; }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -686,22 +686,22 @@ protected:
 	_ALWAYS_INLINE_ const ObjectGDExtension *_get_extension() const { return _extension; }
 	_ALWAYS_INLINE_ GDExtensionClassInstancePtr _get_extension_instance() const { return _extension_instance; }
 	virtual void _initialize_classv() { initialize_class(); }
-	virtual bool _setv(const StringName &p_name, const Variant &p_property) { return false; };
-	virtual bool _getv(const StringName &p_name, Variant &r_property) const { return false; };
-	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const {};
-	virtual void _validate_propertyv(PropertyInfo &p_property) const {};
-	virtual bool _property_can_revertv(const StringName &p_name) const { return false; };
-	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_property) const { return false; };
+	virtual bool _setv(const StringName &p_name, const Variant &p_property) { return false; }
+	virtual bool _getv(const StringName &p_name, Variant &r_property) const { return false; }
+	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const {}
+	virtual void _validate_propertyv(PropertyInfo &p_property) const {}
+	virtual bool _property_can_revertv(const StringName &p_name) const { return false; }
+	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_property) const { return false; }
 	virtual void _notificationv(int p_notification, bool p_reversed) {}
 
 	static void _bind_methods();
 	static void _bind_compatibility_methods() {}
-	bool _set(const StringName &p_name, const Variant &p_property) { return false; };
-	bool _get(const StringName &p_name, Variant &r_property) const { return false; };
-	void _get_property_list(List<PropertyInfo> *p_list) const {};
-	void _validate_property(PropertyInfo &p_property) const {};
-	bool _property_can_revert(const StringName &p_name) const { return false; };
-	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; };
+	bool _set(const StringName &p_name, const Variant &p_property) { return false; }
+	bool _get(const StringName &p_name, Variant &r_property) const { return false; }
+	void _get_property_list(List<PropertyInfo> *p_list) const {}
+	void _validate_property(PropertyInfo &p_property) const {}
+	bool _property_can_revert(const StringName &p_name) const { return false; }
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; }
 	void _notification(int p_notification) {}
 
 	_FORCE_INLINE_ static void (*_get_bind_methods())() {

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -35,7 +35,7 @@
 #include "core/templates/safe_refcount.h"
 
 class RefCounted : public Object {
-	GDCLASS(RefCounted, Object);
+	GDCLASS(RefCounted, Object)
 	SafeRefCount refcount;
 	SafeRefCount refcount_init;
 
@@ -230,7 +230,7 @@ public:
 };
 
 class WeakRef : public RefCounted {
-	GDCLASS(WeakRef, RefCounted);
+	GDCLASS(WeakRef, RefCounted)
 
 	ObjectID ref;
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -108,8 +108,8 @@ public:
 class PlaceHolderScriptInstance;
 
 class Script : public Resource {
-	GDCLASS(Script, Resource);
-	OBJ_SAVE_TYPE(Script);
+	GDCLASS(Script, Resource)
+	OBJ_SAVE_TYPE(Script)
 
 protected:
 	virtual bool editor_can_reload_from_file() override { return false; } // this is handled by editor better
@@ -443,8 +443,8 @@ public:
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = nullptr) const override;
 	virtual void validate_property(PropertyInfo &p_property) const override {}
 
-	virtual bool property_can_revert(const StringName &p_name) const override { return false; };
-	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const override { return false; };
+	virtual bool property_can_revert(const StringName &p_name) const override { return false; }
+	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const override { return false; }
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const override;
 	virtual bool has_method(const StringName &p_method) const override;

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -36,7 +36,7 @@
 #include "core/object/ref_counted.h"
 
 class MainLoop : public Object {
-	GDCLASS(MainLoop, Object);
+	GDCLASS(MainLoop, Object)
 
 protected:
 	static void _bind_methods();

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -177,14 +177,14 @@ public:
 	void set_delta_smoothing(bool p_enabled);
 	bool is_delta_smoothing_enabled() const;
 
-	virtual Vector<String> get_system_fonts() const { return Vector<String>(); };
-	virtual String get_system_font_path(const String &p_font_name, int p_weight = 400, int p_stretch = 100, bool p_italic = false) const { return String(); };
-	virtual Vector<String> get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale = String(), const String &p_script = String(), int p_weight = 400, int p_stretch = 100, bool p_italic = false) const { return Vector<String>(); };
+	virtual Vector<String> get_system_fonts() const { return Vector<String>(); }
+	virtual String get_system_font_path(const String &p_font_name, int p_weight = 400, int p_stretch = 100, bool p_italic = false) const { return String(); }
+	virtual Vector<String> get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale = String(), const String &p_script = String(), int p_weight = 400, int p_stretch = 100, bool p_italic = false) const { return Vector<String>(); }
 	virtual String get_executable_path() const;
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false) = 0;
 	virtual Dictionary execute_with_pipe(const String &p_path, const List<String> &p_arguments, bool p_blocking = true) { return Dictionary(); }
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) = 0;
-	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) { return create_process(get_executable_path(), p_arguments, r_child_id); };
+	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) { return create_process(get_executable_path(), p_arguments, r_child_id); }
 	virtual Error kill(const ProcessID &p_pid) = 0;
 	virtual int get_process_id() const;
 	virtual bool is_process_running(const ProcessID &p_pid) const = 0;

--- a/core/os/time.h
+++ b/core/os/time.h
@@ -45,7 +45,7 @@
 // Suffixes such as "Z" are not handled, you need to strip them away manually.
 
 class Time : public Object {
-	GDCLASS(Time, Object);
+	GDCLASS(Time, Object)
 	static void _bind_methods();
 	static Time *singleton;
 

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -35,9 +35,9 @@
 #include "core/object/gdvirtual.gen.inc"
 
 class Translation : public Resource {
-	GDCLASS(Translation, Resource);
-	OBJ_SAVE_TYPE(Translation);
-	RES_BASE_EXTENSION("translation");
+	GDCLASS(Translation, Resource)
+	OBJ_SAVE_TYPE(Translation)
+	RES_BASE_EXTENSION("translation")
 
 	String locale = "en";
 	HashMap<StringName, StringName> translation_map;
@@ -51,8 +51,8 @@ class Translation : public Resource {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL2RC(StringName, _get_message, StringName, StringName);
-	GDVIRTUAL4RC(StringName, _get_plural_message, StringName, StringName, int, StringName);
+	GDVIRTUAL2RC(StringName, _get_message, StringName, StringName)
+	GDVIRTUAL4RC(StringName, _get_plural_message, StringName, StringName, int, StringName)
 
 public:
 	void set_locale(const String &p_locale);

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -35,7 +35,7 @@
 #include "core/string/translation_domain.h"
 
 class TranslationServer : public Object {
-	GDCLASS(TranslationServer, Object);
+	GDCLASS(TranslationServer, Object)
 
 	String locale = "en";
 	String fallback;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -118,7 +118,7 @@ public:
 	Char16String &operator+=(char16_t p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char16_t *get_data() const;
-	operator const char16_t *() const { return get_data(); };
+	operator const char16_t *() const { return get_data(); }
 
 protected:
 	void copy_from(const char16_t *p_cstr);
@@ -160,7 +160,7 @@ public:
 	CharString &operator+=(char p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char *get_data() const;
-	operator const char *() const { return get_data(); };
+	operator const char *() const { return get_data(); }
 
 protected:
 	void copy_from(const char *p_cstr);

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -241,7 +241,7 @@ public:
 
 	_FORCE_INLINE_ CowData() {}
 	_FORCE_INLINE_ ~CowData();
-	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); };
+	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); }
 };
 
 template <typename T>

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -223,7 +223,7 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_buffer(const void *key, int length, 
 			k1 = hash_rotl32(k1, 15);
 			k1 *= c2;
 			h1 ^= k1;
-	};
+	}
 
 	// Finalize with additional bit mixing.
 	h1 ^= length;

--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -89,7 +89,7 @@ public:
 		CRASH_COND(!e);
 		_list.move_to_front(*e);
 		return (*e)->get().data;
-	};
+	}
 
 	const TData *getptr(const TKey &p_key) {
 		Element *e = _map.getptr(p_key);

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -76,7 +76,7 @@ public:
 		}
 		const T &get() const {
 			return value;
-		};
+		}
 		Element() {}
 	};
 

--- a/core/templates/sort_array.h
+++ b/core/templates/sort_array.h
@@ -175,14 +175,14 @@ public:
 		while (true) {
 			while (compare(p_array[p_first], p_pivot)) {
 				if constexpr (Validate) {
-					ERR_BAD_COMPARE(p_first == unmodified_last - 1);
+					ERR_BAD_COMPARE(p_first == unmodified_last - 1)
 				}
 				p_first++;
 			}
 			p_last--;
 			while (compare(p_pivot, p_array[p_last])) {
 				if constexpr (Validate) {
-					ERR_BAD_COMPARE(p_last == unmodified_first);
+					ERR_BAD_COMPARE(p_last == unmodified_first)
 				}
 				p_last--;
 			}
@@ -252,7 +252,7 @@ public:
 		int64_t next = p_last - 1;
 		while (compare(p_value, p_array[next])) {
 			if constexpr (Validate) {
-				ERR_BAD_COMPARE(next == 0);
+				ERR_BAD_COMPARE(next == 0)
 			}
 			p_array[p_last] = p_array[next];
 			p_last = next;

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -43,7 +43,7 @@
 class MenuButton;
 
 class GotoLineDialog : public ConfirmationDialog {
-	GDCLASS(GotoLineDialog, ConfirmationDialog);
+	GDCLASS(GotoLineDialog, ConfirmationDialog)
 
 	Label *line_label = nullptr;
 	LineEdit *line = nullptr;
@@ -62,7 +62,7 @@ public:
 class CodeTextEditor;
 
 class FindReplaceBar : public HBoxContainer {
-	GDCLASS(FindReplaceBar, HBoxContainer);
+	GDCLASS(FindReplaceBar, HBoxContainer)
 
 	enum SearchMode {
 		SEARCH_CURRENT,
@@ -157,7 +157,7 @@ public:
 typedef void (*CodeTextEditorCodeCompleteFunc)(void *p_ud, const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_forced);
 
 class CodeTextEditor : public VBoxContainer {
-	GDCLASS(CodeTextEditor, VBoxContainer);
+	GDCLASS(CodeTextEditor, VBoxContainer)
 
 	CodeEdit *text_editor = nullptr;
 	FindReplaceBar *find_replace_bar = nullptr;

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -40,7 +40,7 @@ struct DAPeer;
 class DebugAdapterProtocol;
 
 class DebugAdapterParser : public Object {
-	GDCLASS(DebugAdapterParser, Object);
+	GDCLASS(DebugAdapterParser, Object)
 
 private:
 	friend DebugAdapterProtocol;

--- a/editor/debugger/debug_adapter/debug_adapter_server.h
+++ b/editor/debugger/debug_adapter/debug_adapter_server.h
@@ -35,7 +35,7 @@
 #include "editor/plugins/editor_plugin.h"
 
 class DebugAdapterServer : public EditorPlugin {
-	GDCLASS(DebugAdapterServer, EditorPlugin);
+	GDCLASS(DebugAdapterServer, EditorPlugin)
 
 	DebugAdapterProtocol protocol;
 

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -46,7 +46,7 @@ class TabContainer;
 class UndoRedo;
 
 class EditorDebuggerNode : public MarginContainer {
-	GDCLASS(EditorDebuggerNode, MarginContainer);
+	GDCLASS(EditorDebuggerNode, MarginContainer)
 
 public:
 	enum CameraOverride {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -271,7 +271,7 @@ public:
  * such as the SceneTreeDock or a main screen editor plugin (e.g. CanvasItemEditor).
  */
 class EditorSelection : public Object {
-	GDCLASS(EditorSelection, Object);
+	GDCLASS(EditorSelection, Object)
 
 	// Contains the selected nodes and corresponding metadata.
 	// Metadata objects come from calling _get_editor_data on the editor_plugins, passing the selected node.

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -44,7 +44,7 @@ class FileAccess;
 
 struct EditorProgressBG;
 class EditorFileSystemDirectory : public Object {
-	GDCLASS(EditorFileSystemDirectory, Object);
+	GDCLASS(EditorFileSystemDirectory, Object)
 
 	String name;
 	uint64_t modified_time;
@@ -109,16 +109,16 @@ public:
 };
 
 class EditorFileSystemImportFormatSupportQuery : public RefCounted {
-	GDCLASS(EditorFileSystemImportFormatSupportQuery, RefCounted);
+	GDCLASS(EditorFileSystemImportFormatSupportQuery, RefCounted)
 
 protected:
 	GDVIRTUAL0RC(bool, _is_active)
 	GDVIRTUAL0RC(Vector<String>, _get_file_extensions)
 	GDVIRTUAL0RC(bool, _query)
 	static void _bind_methods() {
-		GDVIRTUAL_BIND(_is_active);
-		GDVIRTUAL_BIND(_get_file_extensions);
-		GDVIRTUAL_BIND(_query);
+		GDVIRTUAL_BIND(_is_active)
+		GDVIRTUAL_BIND(_get_file_extensions)
+		GDVIRTUAL_BIND(_query)
 	}
 
 public:
@@ -140,7 +140,7 @@ public:
 };
 
 class EditorFileSystem : public Node {
-	GDCLASS(EditorFileSystem, Node);
+	GDCLASS(EditorFileSystem, Node)
 
 	_THREAD_SAFE_CLASS_
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -47,7 +47,7 @@
 #include "modules/modules_enabled.gen.h" // For gdscript, mono.
 
 class FindBar : public HBoxContainer {
-	GDCLASS(FindBar, HBoxContainer);
+	GDCLASS(FindBar, HBoxContainer)
 
 	LineEdit *search_text = nullptr;
 	Button *find_prev = nullptr;
@@ -86,7 +86,7 @@ public:
 };
 
 class EditorHelp : public VBoxContainer {
-	GDCLASS(EditorHelp, VBoxContainer);
+	GDCLASS(EditorHelp, VBoxContainer)
 
 	enum MethodType {
 		METHOD_TYPE_METHOD,
@@ -252,7 +252,7 @@ public:
 };
 
 class EditorHelpBit : public VBoxContainer {
-	GDCLASS(EditorHelpBit, VBoxContainer);
+	GDCLASS(EditorHelpBit, VBoxContainer)
 
 	struct DocType {
 		String type;
@@ -323,7 +323,7 @@ public:
 // Standard tooltips do not allow you to hover over them.
 // This class is intended as a temporary workaround.
 class EditorHelpBitTooltip : public PopupPanel {
-	GDCLASS(EditorHelpBitTooltip, PopupPanel);
+	GDCLASS(EditorHelpBitTooltip, PopupPanel)
 
 	Timer *timer = nullptr;
 	int _pushing_input = 0;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -111,7 +111,7 @@ struct EditorProgress {
 };
 
 class EditorNode : public Node {
-	GDCLASS(EditorNode, Node);
+	GDCLASS(EditorNode, Node)
 
 public:
 	enum SceneNameCasing {
@@ -927,7 +927,7 @@ public:
 	void dim_editor(bool p_dimming);
 	bool is_editor_dimmed() const;
 
-	void edit_current() { _edit_current(); };
+	void edit_current() { _edit_current(); }
 
 	bool has_scenes_in_session();
 

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -40,7 +40,7 @@
 class EditorPlugin;
 
 class EditorSettings : public Resource {
-	GDCLASS(EditorSettings, Resource);
+	GDCLASS(EditorSettings, Resource)
 
 	_THREAD_SAFE_CLASS_
 

--- a/editor/plugins/editor_context_menu_plugin.h
+++ b/editor/plugins/editor_context_menu_plugin.h
@@ -40,7 +40,7 @@ class Shortcut;
 class Texture2D;
 
 class EditorContextMenuPlugin : public RefCounted {
-	GDCLASS(EditorContextMenuPlugin, RefCounted);
+	GDCLASS(EditorContextMenuPlugin, RefCounted)
 
 	friend class EditorContextMenuPluginManager;
 
@@ -72,7 +72,7 @@ public:
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL1(_popup_menu, Vector<String>);
+	GDVIRTUAL1(_popup_menu, Vector<String>)
 
 public:
 	virtual void get_options(const Vector<String> &p_paths);
@@ -85,7 +85,7 @@ public:
 VARIANT_ENUM_CAST(EditorContextMenuPlugin::ContextMenuSlot);
 
 class EditorContextMenuPluginManager : public Object {
-	GDCLASS(EditorContextMenuPluginManager, Object);
+	GDCLASS(EditorContextMenuPluginManager, Object)
 
 	using ContextMenuSlot = EditorContextMenuPlugin::ContextMenuSlot;
 	static inline EditorContextMenuPluginManager *singleton = nullptr;

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -56,7 +56,7 @@ class EditorUndoRedoManager;
 class ScriptCreateDialog;
 
 class EditorPlugin : public Node {
-	GDCLASS(EditorPlugin, Node);
+	GDCLASS(EditorPlugin, Node)
 	friend class EditorData;
 
 	bool input_event_forwarding_always_enabled = false;

--- a/editor/progress_dialog.h
+++ b/editor/progress_dialog.h
@@ -38,7 +38,7 @@
 #include "scene/gui/progress_bar.h"
 
 class BackgroundProgress : public HBoxContainer {
-	GDCLASS(BackgroundProgress, HBoxContainer);
+	GDCLASS(BackgroundProgress, HBoxContainer)
 
 	_THREAD_SAFE_CLASS_
 
@@ -65,7 +65,7 @@ public:
 };
 
 class ProgressDialog : public PopupPanel {
-	GDCLASS(ProgressDialog, PopupPanel);
+	GDCLASS(ProgressDialog, PopupPanel)
 	struct Task {
 		String task;
 		VBoxContainer *vb = nullptr;

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -53,7 +53,7 @@ class TabContainer;
 class VBoxContainer;
 
 class ProjectManager : public Control {
-	GDCLASS(ProjectManager, Control);
+	GDCLASS(ProjectManager, Control)
 
 	static ProjectManager *singleton;
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -933,7 +933,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	translation_server = memnew(TranslationServer);
 	performance = memnew(Performance);
-	GDREGISTER_CLASS(Performance);
+	GDREGISTER_CLASS(Performance)
 	engine->add_singleton(Engine::Singleton("Performance", performance));
 
 	// Only flush stdout in debug builds by default, as spamming `print()` will
@@ -2016,145 +2016,145 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 		// AMD GPUs.
-		BLOCK_DEVICE("ATI", "Radeon 9"); // ATI Radeon 9000 Series
-		BLOCK_DEVICE("ATI", "Radeon X"); // ATI Radeon X500-X2000 Series
-		BLOCK_DEVICE("ATI", "Radeon HD 2"); // AMD/ATI (Mobility) Radeon HD 2xxx Series
-		BLOCK_DEVICE("ATI", "Radeon HD 3"); // AMD/ATI (Mobility) Radeon HD 3xxx Series
-		BLOCK_DEVICE("ATI", "Radeon HD 4"); // AMD/ATI (Mobility) Radeon HD 4xxx Series
-		BLOCK_DEVICE("ATI", "Radeon HD 5"); // AMD/ATI (Mobility) Radeon HD 5xxx Series
-		BLOCK_DEVICE("ATI", "Radeon HD 6"); // AMD/ATI (Mobility) Radeon HD 6xxx Series
-		BLOCK_DEVICE("ATI", "Radeon HD 7"); // AMD/ATI (Mobility) Radeon HD 7xxx Series
-		BLOCK_DEVICE("ATI", "Radeon HD 8"); // AMD/ATI (Mobility) Radeon HD 8xxx Series
-		BLOCK_DEVICE("ATI", "Radeon(TM) R2 Graphics"); // APUs
-		BLOCK_DEVICE("ATI", "Radeon(TM) R3 Graphics");
-		BLOCK_DEVICE("ATI", "Radeon(TM) R4 Graphics");
-		BLOCK_DEVICE("ATI", "Radeon(TM) R5 Graphics");
-		BLOCK_DEVICE("ATI", "Radeon(TM) R6 Graphics");
-		BLOCK_DEVICE("ATI", "Radeon(TM) R7 Graphics");
-		BLOCK_DEVICE("AMD", "Radeon(TM) R7 Graphics");
-		BLOCK_DEVICE("AMD", "Radeon(TM) R8 Graphics");
-		BLOCK_DEVICE("ATI", "Radeon R5 Graphics");
-		BLOCK_DEVICE("ATI", "Radeon R6 Graphics");
-		BLOCK_DEVICE("ATI", "Radeon R7 Graphics");
-		BLOCK_DEVICE("AMD", "Radeon R7 Graphics");
-		BLOCK_DEVICE("AMD", "Radeon R8 Graphics");
-		BLOCK_DEVICE("ATI", "Radeon R5 2"); // Rx 2xx Series
-		BLOCK_DEVICE("ATI", "Radeon R7 2");
-		BLOCK_DEVICE("ATI", "Radeon R9 2");
-		BLOCK_DEVICE("ATI", "Radeon R5 M2"); // Rx M2xx Series
-		BLOCK_DEVICE("ATI", "Radeon R7 M2");
-		BLOCK_DEVICE("ATI", "Radeon R9 M2");
-		BLOCK_DEVICE("ATI", "Radeon (TM) R9 Fury");
-		BLOCK_DEVICE("ATI", "Radeon (TM) R5 3"); // Rx 3xx Series
-		BLOCK_DEVICE("AMD", "Radeon (TM) R5 3");
-		BLOCK_DEVICE("ATI", "Radeon (TM) R7 3");
-		BLOCK_DEVICE("AMD", "Radeon (TM) R7 3");
-		BLOCK_DEVICE("ATI", "Radeon (TM) R9 3");
-		BLOCK_DEVICE("AMD", "Radeon (TM) R9 3");
-		BLOCK_DEVICE("ATI", "Radeon (TM) R5 M3"); // Rx M3xx Series
-		BLOCK_DEVICE("AMD", "Radeon (TM) R5 M3");
-		BLOCK_DEVICE("ATI", "Radeon (TM) R7 M3");
-		BLOCK_DEVICE("AMD", "Radeon (TM) R7 M3");
-		BLOCK_DEVICE("ATI", "Radeon (TM) R9 M3");
-		BLOCK_DEVICE("AMD", "Radeon (TM) R9 M3");
+		BLOCK_DEVICE("ATI", "Radeon 9") // ATI Radeon 9000 Series
+		BLOCK_DEVICE("ATI", "Radeon X") // ATI Radeon X500-X2000 Series
+		BLOCK_DEVICE("ATI", "Radeon HD 2") // AMD/ATI (Mobility) Radeon HD 2xxx Series
+		BLOCK_DEVICE("ATI", "Radeon HD 3") // AMD/ATI (Mobility) Radeon HD 3xxx Series
+		BLOCK_DEVICE("ATI", "Radeon HD 4") // AMD/ATI (Mobility) Radeon HD 4xxx Series
+		BLOCK_DEVICE("ATI", "Radeon HD 5") // AMD/ATI (Mobility) Radeon HD 5xxx Series
+		BLOCK_DEVICE("ATI", "Radeon HD 6") // AMD/ATI (Mobility) Radeon HD 6xxx Series
+		BLOCK_DEVICE("ATI", "Radeon HD 7") // AMD/ATI (Mobility) Radeon HD 7xxx Series
+		BLOCK_DEVICE("ATI", "Radeon HD 8") // AMD/ATI (Mobility) Radeon HD 8xxx Series
+		BLOCK_DEVICE("ATI", "Radeon(TM) R2 Graphics") // APUs
+		BLOCK_DEVICE("ATI", "Radeon(TM) R3 Graphics")
+		BLOCK_DEVICE("ATI", "Radeon(TM) R4 Graphics")
+		BLOCK_DEVICE("ATI", "Radeon(TM) R5 Graphics")
+		BLOCK_DEVICE("ATI", "Radeon(TM) R6 Graphics")
+		BLOCK_DEVICE("ATI", "Radeon(TM) R7 Graphics")
+		BLOCK_DEVICE("AMD", "Radeon(TM) R7 Graphics")
+		BLOCK_DEVICE("AMD", "Radeon(TM) R8 Graphics")
+		BLOCK_DEVICE("ATI", "Radeon R5 Graphics")
+		BLOCK_DEVICE("ATI", "Radeon R6 Graphics")
+		BLOCK_DEVICE("ATI", "Radeon R7 Graphics")
+		BLOCK_DEVICE("AMD", "Radeon R7 Graphics")
+		BLOCK_DEVICE("AMD", "Radeon R8 Graphics")
+		BLOCK_DEVICE("ATI", "Radeon R5 2") // Rx 2xx Series
+		BLOCK_DEVICE("ATI", "Radeon R7 2")
+		BLOCK_DEVICE("ATI", "Radeon R9 2")
+		BLOCK_DEVICE("ATI", "Radeon R5 M2") // Rx M2xx Series
+		BLOCK_DEVICE("ATI", "Radeon R7 M2")
+		BLOCK_DEVICE("ATI", "Radeon R9 M2")
+		BLOCK_DEVICE("ATI", "Radeon (TM) R9 Fury")
+		BLOCK_DEVICE("ATI", "Radeon (TM) R5 3") // Rx 3xx Series
+		BLOCK_DEVICE("AMD", "Radeon (TM) R5 3")
+		BLOCK_DEVICE("ATI", "Radeon (TM) R7 3")
+		BLOCK_DEVICE("AMD", "Radeon (TM) R7 3")
+		BLOCK_DEVICE("ATI", "Radeon (TM) R9 3")
+		BLOCK_DEVICE("AMD", "Radeon (TM) R9 3")
+		BLOCK_DEVICE("ATI", "Radeon (TM) R5 M3") // Rx M3xx Series
+		BLOCK_DEVICE("AMD", "Radeon (TM) R5 M3")
+		BLOCK_DEVICE("ATI", "Radeon (TM) R7 M3")
+		BLOCK_DEVICE("AMD", "Radeon (TM) R7 M3")
+		BLOCK_DEVICE("ATI", "Radeon (TM) R9 M3")
+		BLOCK_DEVICE("AMD", "Radeon (TM) R9 M3")
 
 		// Intel GPUs.
-		BLOCK_DEVICE("0x8086", "0x0042"); // HD Graphics, Gen5, Clarkdale
-		BLOCK_DEVICE("0x8086", "0x0046"); // HD Graphics, Gen5, Arrandale
-		BLOCK_DEVICE("0x8086", "0x010A"); // HD Graphics, Gen6, Sandy Bridge
-		BLOCK_DEVICE("Intel", "Intel HD Graphics 2000");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 2000");
-		BLOCK_DEVICE("0x8086", "0x0102"); // HD Graphics 2000, Gen6, Sandy Bridge
-		BLOCK_DEVICE("0x8086", "0x0116"); // HD Graphics 3000, Gen6, Sandy Bridge
-		BLOCK_DEVICE("Intel", "Intel HD Graphics 3000");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 3000");
-		BLOCK_DEVICE("0x8086", "0x0126"); // HD Graphics 3000, Gen6, Sandy Bridge
-		BLOCK_DEVICE("Intel", "Intel HD Graphics P3000");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics P3000");
-		BLOCK_DEVICE("0x8086", "0x0112"); // HD Graphics P3000, Gen6, Sandy Bridge
-		BLOCK_DEVICE("0x8086", "0x0122");
-		BLOCK_DEVICE("0x8086", "0x015A"); // HD Graphics, Gen7, Ivy Bridge
-		BLOCK_DEVICE("Intel", "Intel HD Graphics 2500");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 2500");
-		BLOCK_DEVICE("0x8086", "0x0152"); // HD Graphics 2500, Gen7, Ivy Bridge
-		BLOCK_DEVICE("Intel", "Intel HD Graphics 4000");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 4000");
-		BLOCK_DEVICE("0x8086", "0x0162"); // HD Graphics 4000, Gen7, Ivy Bridge
-		BLOCK_DEVICE("0x8086", "0x0166");
-		BLOCK_DEVICE("Intel", "Intel HD Graphics P4000");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics P4000");
-		BLOCK_DEVICE("0x8086", "0x016A"); // HD Graphics P4000, Gen7, Ivy Bridge
-		BLOCK_DEVICE("Intel", "Intel(R) Vallyview Graphics");
-		BLOCK_DEVICE("0x8086", "0x0F30"); // Intel(R) Vallyview Graphics, Gen7, Vallyview
-		BLOCK_DEVICE("0x8086", "0x0F31");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 4200");
-		BLOCK_DEVICE("0x8086", "0x0A1E"); // Intel(R) HD Graphics 4200, Gen7.5, Haswell
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 4400");
-		BLOCK_DEVICE("0x8086", "0x0A16"); // Intel(R) HD Graphics 4400, Gen7.5, Haswell
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 4600");
-		BLOCK_DEVICE("0x8086", "0x0412"); // Intel(R) HD Graphics 4600, Gen7.5, Haswell
-		BLOCK_DEVICE("0x8086", "0x0416");
-		BLOCK_DEVICE("0x8086", "0x0426");
-		BLOCK_DEVICE("0x8086", "0x0D12");
-		BLOCK_DEVICE("0x8086", "0x0D16");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics P4600/P4700");
-		BLOCK_DEVICE("0x8086", "0x041A"); // Intel(R) HD Graphics P4600/P4700, Gen7.5, Haswell
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 5000");
-		BLOCK_DEVICE("0x8086", "0x0422"); // Intel(R) HD Graphics 5000, Gen7.5, Haswell
-		BLOCK_DEVICE("0x8086", "0x042A");
-		BLOCK_DEVICE("0x8086", "0x0A26");
-		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Graphics 5100");
-		BLOCK_DEVICE("0x8086", "0x0A22"); // Intel(R) Iris(TM) Graphics 5100, Gen7.5, Haswell
-		BLOCK_DEVICE("0x8086", "0x0A2A");
-		BLOCK_DEVICE("0x8086", "0x0A2B");
-		BLOCK_DEVICE("0x8086", "0x0A2E");
-		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Pro Graphics 5200");
-		BLOCK_DEVICE("0x8086", "0x0D22"); // Intel(R) Iris(TM) Pro Graphics 5200, Gen7.5, Haswell
-		BLOCK_DEVICE("0x8086", "0x0D26");
-		BLOCK_DEVICE("0x8086", "0x0D2A");
-		BLOCK_DEVICE("0x8086", "0x0D2B");
-		BLOCK_DEVICE("0x8086", "0x0D2E");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 400");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 405");
-		BLOCK_DEVICE("0x8086", "0x22B0"); // Intel(R) HD Graphics, Gen8, Cherryview Braswell
-		BLOCK_DEVICE("0x8086", "0x22B1");
-		BLOCK_DEVICE("0x8086", "0x22B2");
-		BLOCK_DEVICE("0x8086", "0x22B3");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 5300");
-		BLOCK_DEVICE("0x8086", "0x161E"); // Intel(R) HD Graphics 5300, Gen8, Broadwell
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 5500");
-		BLOCK_DEVICE("0x8086", "0x1616"); // Intel(R) HD Graphics 5500, Gen8, Broadwell
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 5600");
-		BLOCK_DEVICE("0x8086", "0x1612"); // Intel(R) HD Graphics 5600, Gen8, Broadwell
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 6000");
-		BLOCK_DEVICE("0x8086", "0x1626"); // Intel(R) HD Graphics 6000, Gen8, Broadwell
-		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Graphics 6100");
-		BLOCK_DEVICE("0x8086", "0x162B"); // Intel(R) Iris(TM) Graphics 6100, Gen8, Broadwell
-		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Pro Graphics 6200");
-		BLOCK_DEVICE("0x8086", "0x1622"); // Intel(R) Iris(TM) Pro Graphics 6200, Gen8, Broadwell
-		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Pro Graphics P6300");
-		BLOCK_DEVICE("0x8086", "0x162A"); // Intel(R) Iris(TM) Pro Graphics P6300, Gen8, Broadwell
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 500");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 505");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 510");
-		BLOCK_DEVICE("0x8086", "0x1902"); // Intel(R) HD Graphics 510, Gen9, Skylake
-		BLOCK_DEVICE("0x8086", "0x1906");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 520");
-		BLOCK_DEVICE("0x8086", "0x1916"); // Intel(R) HD Graphics 520, Gen9, Skylake
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 530");
-		BLOCK_DEVICE("0x8086", "0x1912"); // Intel(R) HD Graphics 530, Gen9, Skylake
-		BLOCK_DEVICE("0x8086", "0x191B");
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics P530");
-		BLOCK_DEVICE("0x8086", "0x191D"); // Intel(R) HD Graphics P530, Gen9, Skylake
-		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 515");
-		BLOCK_DEVICE("0x8086", "0x191E"); // Intel(R) HD Graphics 515, Gen9, Skylake
-		BLOCK_DEVICE("Intel", "Intel(R) Iris Graphics 540");
-		BLOCK_DEVICE("0x8086", "0x1926"); // Intel(R) Iris Graphics 540, Gen9, Skylake
-		BLOCK_DEVICE("0x8086", "0x1927");
-		BLOCK_DEVICE("Intel", "Intel(R) Iris Pro Graphics 580");
-		BLOCK_DEVICE("0x8086", "0x193B"); // Intel(R) Iris Pro Graphics 580, Gen9, Skylake
-		BLOCK_DEVICE("Intel", "Intel(R) Iris Pro Graphics P580");
-		BLOCK_DEVICE("0x8086", "0x193D"); // Intel(R) Iris Pro Graphics P580, Gen9, Skylake
+		BLOCK_DEVICE("0x8086", "0x0042") // HD Graphics, Gen5, Clarkdale
+		BLOCK_DEVICE("0x8086", "0x0046") // HD Graphics, Gen5, Arrandale
+		BLOCK_DEVICE("0x8086", "0x010A") // HD Graphics, Gen6, Sandy Bridge
+		BLOCK_DEVICE("Intel", "Intel HD Graphics 2000")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 2000")
+		BLOCK_DEVICE("0x8086", "0x0102") // HD Graphics 2000, Gen6, Sandy Bridge
+		BLOCK_DEVICE("0x8086", "0x0116") // HD Graphics 3000, Gen6, Sandy Bridge
+		BLOCK_DEVICE("Intel", "Intel HD Graphics 3000")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 3000")
+		BLOCK_DEVICE("0x8086", "0x0126") // HD Graphics 3000, Gen6, Sandy Bridge
+		BLOCK_DEVICE("Intel", "Intel HD Graphics P3000")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics P3000")
+		BLOCK_DEVICE("0x8086", "0x0112") // HD Graphics P3000, Gen6, Sandy Bridge
+		BLOCK_DEVICE("0x8086", "0x0122")
+		BLOCK_DEVICE("0x8086", "0x015A") // HD Graphics, Gen7, Ivy Bridge
+		BLOCK_DEVICE("Intel", "Intel HD Graphics 2500")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 2500")
+		BLOCK_DEVICE("0x8086", "0x0152") // HD Graphics 2500, Gen7, Ivy Bridge
+		BLOCK_DEVICE("Intel", "Intel HD Graphics 4000")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 4000")
+		BLOCK_DEVICE("0x8086", "0x0162") // HD Graphics 4000, Gen7, Ivy Bridge
+		BLOCK_DEVICE("0x8086", "0x0166")
+		BLOCK_DEVICE("Intel", "Intel HD Graphics P4000")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics P4000")
+		BLOCK_DEVICE("0x8086", "0x016A") // HD Graphics P4000, Gen7, Ivy Bridge
+		BLOCK_DEVICE("Intel", "Intel(R) Vallyview Graphics")
+		BLOCK_DEVICE("0x8086", "0x0F30") // Intel(R) Vallyview Graphics, Gen7, Vallyview
+		BLOCK_DEVICE("0x8086", "0x0F31")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 4200")
+		BLOCK_DEVICE("0x8086", "0x0A1E") // Intel(R) HD Graphics 4200, Gen7.5, Haswell
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 4400")
+		BLOCK_DEVICE("0x8086", "0x0A16") // Intel(R) HD Graphics 4400, Gen7.5, Haswell
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 4600")
+		BLOCK_DEVICE("0x8086", "0x0412") // Intel(R) HD Graphics 4600, Gen7.5, Haswell
+		BLOCK_DEVICE("0x8086", "0x0416")
+		BLOCK_DEVICE("0x8086", "0x0426")
+		BLOCK_DEVICE("0x8086", "0x0D12")
+		BLOCK_DEVICE("0x8086", "0x0D16")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics P4600/P4700")
+		BLOCK_DEVICE("0x8086", "0x041A") // Intel(R) HD Graphics P4600/P4700, Gen7.5, Haswell
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 5000")
+		BLOCK_DEVICE("0x8086", "0x0422") // Intel(R) HD Graphics 5000, Gen7.5, Haswell
+		BLOCK_DEVICE("0x8086", "0x042A")
+		BLOCK_DEVICE("0x8086", "0x0A26")
+		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Graphics 5100")
+		BLOCK_DEVICE("0x8086", "0x0A22") // Intel(R) Iris(TM) Graphics 5100, Gen7.5, Haswell
+		BLOCK_DEVICE("0x8086", "0x0A2A")
+		BLOCK_DEVICE("0x8086", "0x0A2B")
+		BLOCK_DEVICE("0x8086", "0x0A2E")
+		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Pro Graphics 5200")
+		BLOCK_DEVICE("0x8086", "0x0D22") // Intel(R) Iris(TM) Pro Graphics 5200, Gen7.5, Haswell
+		BLOCK_DEVICE("0x8086", "0x0D26")
+		BLOCK_DEVICE("0x8086", "0x0D2A")
+		BLOCK_DEVICE("0x8086", "0x0D2B")
+		BLOCK_DEVICE("0x8086", "0x0D2E")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 400")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 405")
+		BLOCK_DEVICE("0x8086", "0x22B0") // Intel(R) HD Graphics, Gen8, Cherryview Braswell
+		BLOCK_DEVICE("0x8086", "0x22B1")
+		BLOCK_DEVICE("0x8086", "0x22B2")
+		BLOCK_DEVICE("0x8086", "0x22B3")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 5300")
+		BLOCK_DEVICE("0x8086", "0x161E") // Intel(R) HD Graphics 5300, Gen8, Broadwell
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 5500")
+		BLOCK_DEVICE("0x8086", "0x1616") // Intel(R) HD Graphics 5500, Gen8, Broadwell
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 5600")
+		BLOCK_DEVICE("0x8086", "0x1612") // Intel(R) HD Graphics 5600, Gen8, Broadwell
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 6000")
+		BLOCK_DEVICE("0x8086", "0x1626") // Intel(R) HD Graphics 6000, Gen8, Broadwell
+		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Graphics 6100")
+		BLOCK_DEVICE("0x8086", "0x162B") // Intel(R) Iris(TM) Graphics 6100, Gen8, Broadwell
+		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Pro Graphics 6200")
+		BLOCK_DEVICE("0x8086", "0x1622") // Intel(R) Iris(TM) Pro Graphics 6200, Gen8, Broadwell
+		BLOCK_DEVICE("Intel", "Intel(R) Iris(TM) Pro Graphics P6300")
+		BLOCK_DEVICE("0x8086", "0x162A") // Intel(R) Iris(TM) Pro Graphics P6300, Gen8, Broadwell
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 500")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 505")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 510")
+		BLOCK_DEVICE("0x8086", "0x1902") // Intel(R) HD Graphics 510, Gen9, Skylake
+		BLOCK_DEVICE("0x8086", "0x1906")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 520")
+		BLOCK_DEVICE("0x8086", "0x1916") // Intel(R) HD Graphics 520, Gen9, Skylake
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 530")
+		BLOCK_DEVICE("0x8086", "0x1912") // Intel(R) HD Graphics 530, Gen9, Skylake
+		BLOCK_DEVICE("0x8086", "0x191B")
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics P530")
+		BLOCK_DEVICE("0x8086", "0x191D") // Intel(R) HD Graphics P530, Gen9, Skylake
+		BLOCK_DEVICE("Intel", "Intel(R) HD Graphics 515")
+		BLOCK_DEVICE("0x8086", "0x191E") // Intel(R) HD Graphics 515, Gen9, Skylake
+		BLOCK_DEVICE("Intel", "Intel(R) Iris Graphics 540")
+		BLOCK_DEVICE("0x8086", "0x1926") // Intel(R) Iris Graphics 540, Gen9, Skylake
+		BLOCK_DEVICE("0x8086", "0x1927")
+		BLOCK_DEVICE("Intel", "Intel(R) Iris Pro Graphics 580")
+		BLOCK_DEVICE("0x8086", "0x193B") // Intel(R) Iris Pro Graphics 580, Gen9, Skylake
+		BLOCK_DEVICE("Intel", "Intel(R) Iris Pro Graphics P580")
+		BLOCK_DEVICE("0x8086", "0x193D") // Intel(R) Iris Pro Graphics P580, Gen9, Skylake
 
 #undef BLOCK_DEVICE
 
@@ -3034,9 +3034,10 @@ Error Main::setup2(bool p_show_boot_logo) {
 			DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(0));
 		}
 
-		print_verbose("Using \"" + tablet_driver + "\" pen tablet driver...");
+		print_verbose("Using \"" + tablet_driver + "\" pen tablet driver...")
 
-		OS::get_singleton()->benchmark_end_measure("Servers", "Tablet Driver");
+				OS::get_singleton()
+						->benchmark_end_measure("Servers", "Tablet Driver");
 	}
 
 	/* Initialize Rendering Server */
@@ -3367,9 +3368,9 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 	ClassDB::set_current_api(ClassDB::API_NONE); //no more APIs are registered at this point
 
-	print_verbose("CORE API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_CORE)));
-	print_verbose("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
-	MAIN_PRINT("Main: Done");
+	print_verbose("CORE API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_CORE)))
+			print_verbose("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)))
+					MAIN_PRINT("Main: Done");
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Setup2");
 

--- a/main/performance.h
+++ b/main/performance.h
@@ -41,7 +41,7 @@ template <typename T>
 class TypedArray;
 
 class Performance : public Object {
-	GDCLASS(Performance, Object);
+	GDCLASS(Performance, Object)
 
 	static Performance *singleton;
 	static void _bind_methods();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -42,7 +42,7 @@
 #include "core/templates/rb_set.h"
 
 class GDScriptNativeClass : public RefCounted {
-	GDCLASS(GDScriptNativeClass, RefCounted);
+	GDCLASS(GDScriptNativeClass, RefCounted)
 
 	StringName name;
 
@@ -59,7 +59,7 @@ public:
 };
 
 class GDScript : public Script {
-	GDCLASS(GDScript, Script);
+	GDCLASS(GDScript, Script)
 	bool tool = false;
 	bool valid = false;
 	bool reloading = false;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -599,7 +599,7 @@ public:
 };
 
 class GDScriptFunctionState : public RefCounted {
-	GDCLASS(GDScriptFunctionState, RefCounted);
+	GDCLASS(GDScriptFunctionState, RefCounted)
 	friend class GDScriptFunction;
 	GDScriptFunction *function = nullptr;
 	GDScriptFunction::CallState state;

--- a/modules/gdscript/language_server/gdscript_language_server.h
+++ b/modules/gdscript/language_server/gdscript_language_server.h
@@ -37,7 +37,7 @@
 #include "editor/plugins/editor_plugin.h"
 
 class GDScriptLanguageServer : public EditorPlugin {
-	GDCLASS(GDScriptLanguageServer, EditorPlugin);
+	GDCLASS(GDScriptLanguageServer, EditorPlugin)
 
 	GDScriptLanguageProtocol protocol;
 

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -39,7 +39,7 @@
 #include "editor/editor_file_system.h"
 
 class GDScriptWorkspace : public RefCounted {
-	GDCLASS(GDScriptWorkspace, RefCounted);
+	GDCLASS(GDScriptWorkspace, RefCounted)
 
 private:
 	void _get_owners(EditorFileSystemDirectory *efsd, String p_path, List<String> &owners);

--- a/modules/regex/regex.h
+++ b/modules/regex/regex.h
@@ -40,7 +40,7 @@
 #include "core/variant/typed_array.h"
 
 class RegExMatch : public RefCounted {
-	GDCLASS(RegExMatch, RefCounted);
+	GDCLASS(RegExMatch, RefCounted)
 
 	struct Range {
 		int start = 0;
@@ -70,7 +70,7 @@ public:
 };
 
 class RegEx : public RefCounted {
-	GDCLASS(RegEx, RefCounted);
+	GDCLASS(RegEx, RefCounted)
 
 	void *general_ctx = nullptr;
 	void *code = nullptr;

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -34,7 +34,7 @@
 #include "scene/main/canvas_item.h"
 
 class Node2D : public CanvasItem {
-	GDCLASS(Node2D, CanvasItem);
+	GDCLASS(Node2D, CanvasItem)
 
 	mutable MTFlag xform_dirty;
 	mutable Point2 position;

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -38,7 +38,7 @@
 #include "scene/resources/environment.h"
 
 class Camera3D : public Node3D {
-	GDCLASS(Camera3D, Node3D);
+	GDCLASS(Camera3D, Node3D)
 
 public:
 	enum ProjectionType {

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -35,7 +35,7 @@
 #include "scene/resources/3d/world_3d.h"
 
 class Node3DGizmo : public RefCounted {
-	GDCLASS(Node3DGizmo, RefCounted);
+	GDCLASS(Node3DGizmo, RefCounted)
 
 public:
 	virtual void create() = 0;
@@ -49,7 +49,7 @@ public:
 };
 
 class Node3D : public Node {
-	GDCLASS(Node3D, Node);
+	GDCLASS(Node3D, Node)
 
 public:
 	// Edit mode for the rotation.
@@ -233,8 +233,8 @@ public:
 #ifdef TOOLS_ENABLED
 	virtual Transform3D get_global_gizmo_transform() const;
 	virtual Transform3D get_local_gizmo_transform() const;
-	virtual void set_transform_gizmo_visible(bool p_enabled) { data.transform_gizmo_visible = p_enabled; };
-	virtual bool is_transform_gizmo_visible() const { return data.transform_gizmo_visible; };
+	virtual void set_transform_gizmo_visible(bool p_enabled) { data.transform_gizmo_visible = p_enabled; }
+	virtual bool is_transform_gizmo_visible() const { return data.transform_gizmo_visible; }
 #endif
 	virtual void reparent(Node *p_parent, bool p_keep_global_transform = true) override;
 

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -37,7 +37,7 @@
 class ButtonGroup;
 
 class BaseButton : public Control {
-	GDCLASS(BaseButton, Control);
+	GDCLASS(BaseButton, Control)
 
 public:
 	enum ActionMode {
@@ -149,7 +149,7 @@ VARIANT_ENUM_CAST(BaseButton::DrawMode)
 VARIANT_ENUM_CAST(BaseButton::ActionMode)
 
 class ButtonGroup : public Resource {
-	GDCLASS(ButtonGroup, Resource);
+	GDCLASS(ButtonGroup, Resource)
 	friend class BaseButton;
 	HashSet<BaseButton *> buttons;
 	bool allow_unpress = false;

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -34,7 +34,7 @@
 #include "scene/gui/container.h"
 
 class BoxContainer : public Container {
-	GDCLASS(BoxContainer, Container);
+	GDCLASS(BoxContainer, Container)
 
 public:
 	enum AlignmentMode {
@@ -78,7 +78,7 @@ public:
 };
 
 class HBoxContainer : public BoxContainer {
-	GDCLASS(HBoxContainer, BoxContainer);
+	GDCLASS(HBoxContainer, BoxContainer)
 
 public:
 	HBoxContainer() :
@@ -87,7 +87,7 @@ public:
 
 class MarginContainer;
 class VBoxContainer : public BoxContainer {
-	GDCLASS(VBoxContainer, BoxContainer);
+	GDCLASS(VBoxContainer, BoxContainer)
 
 public:
 	MarginContainer *add_margin_child(const String &p_label, Control *p_control, bool p_expand = false);

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -35,7 +35,7 @@
 #include "scene/resources/text_paragraph.h"
 
 class Button : public BaseButton {
-	GDCLASS(Button, BaseButton);
+	GDCLASS(Button, BaseButton)
 
 private:
 	bool flat = false;

--- a/scene/gui/check_box.h
+++ b/scene/gui/check_box.h
@@ -34,7 +34,7 @@
 #include "scene/gui/button.h"
 
 class CheckBox : public Button {
-	GDCLASS(CheckBox, Button);
+	GDCLASS(CheckBox, Button)
 
 	struct ThemeCache {
 		int h_separation = 0;

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -34,7 +34,7 @@
 #include "scene/gui/control.h"
 
 class Container : public Control {
-	GDCLASS(Container, Control);
+	GDCLASS(Container, Control)
 
 	bool pending_sort = false;
 	void _sort_children();

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -45,7 +45,7 @@ class ThemeOwner;
 class ThemeContext;
 
 class Control : public CanvasItem {
-	GDCLASS(Control, CanvasItem);
+	GDCLASS(Control, CanvasItem)
 
 #ifdef TOOLS_ENABLED
 	bool saving = false;

--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -42,7 +42,7 @@
 class LineEdit;
 
 class AcceptDialog : public Window {
-	GDCLASS(AcceptDialog, Window);
+	GDCLASS(AcceptDialog, Window)
 
 	Window *parent_visible = nullptr;
 
@@ -125,7 +125,7 @@ public:
 };
 
 class ConfirmationDialog : public AcceptDialog {
-	GDCLASS(ConfirmationDialog, AcceptDialog);
+	GDCLASS(ConfirmationDialog, AcceptDialog)
 	Button *cancel = nullptr;
 
 protected:

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -35,7 +35,7 @@
 #include "scene/resources/label_settings.h"
 
 class Label : public Control {
-	GDCLASS(Label, Control);
+	GDCLASS(Label, Control)
 
 private:
 	enum LabelDrawStep {

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -35,7 +35,7 @@
 #include "scene/gui/popup_menu.h"
 
 class LineEdit : public Control {
-	GDCLASS(LineEdit, Control);
+	GDCLASS(LineEdit, Control)
 
 public:
 	enum MenuItems {

--- a/scene/gui/margin_container.h
+++ b/scene/gui/margin_container.h
@@ -34,7 +34,7 @@
 #include "scene/gui/container.h"
 
 class MarginContainer : public Container {
-	GDCLASS(MarginContainer, Container);
+	GDCLASS(MarginContainer, Container)
 
 	struct ThemeCache {
 		int margin_left = 0;

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -36,7 +36,7 @@
 #include "scene/property_list_helper.h"
 
 class MenuButton : public Button {
-	GDCLASS(MenuButton, Button);
+	GDCLASS(MenuButton, Button)
 
 	bool clicked = false;
 	bool switch_on_hover = false;

--- a/scene/gui/panel.h
+++ b/scene/gui/panel.h
@@ -34,7 +34,7 @@
 #include "scene/gui/control.h"
 
 class Panel : public Control {
-	GDCLASS(Panel, Control);
+	GDCLASS(Panel, Control)
 
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;

--- a/scene/gui/panel_container.h
+++ b/scene/gui/panel_container.h
@@ -34,7 +34,7 @@
 #include "scene/gui/container.h"
 
 class PanelContainer : public Container {
-	GDCLASS(PanelContainer, Container);
+	GDCLASS(PanelContainer, Container)
 
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -38,7 +38,7 @@
 class Panel;
 
 class Popup : public Window {
-	GDCLASS(Popup, Window);
+	GDCLASS(Popup, Window)
 
 	LocalVector<Window *> visible_parents;
 	bool popped_up = false;
@@ -77,7 +77,7 @@ public:
 };
 
 class PopupPanel : public Popup {
-	GDCLASS(PopupPanel, Popup);
+	GDCLASS(PopupPanel, Popup)
 
 	Panel *panel = nullptr;
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -38,7 +38,7 @@
 #include "scene/resources/text_line.h"
 
 class PopupMenu : public Popup {
-	GDCLASS(PopupMenu, Popup);
+	GDCLASS(PopupMenu, Popup)
 
 	static HashMap<NativeMenu::SystemMenus, PopupMenu *> system_menus;
 

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -34,7 +34,7 @@
 #include "scene/gui/range.h"
 
 class ProgressBar : public Range {
-	GDCLASS(ProgressBar, Range);
+	GDCLASS(ProgressBar, Range)
 
 	bool show_percentage = true;
 	bool indeterminate = false;

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -34,7 +34,7 @@
 #include "scene/gui/control.h"
 
 class Range : public Control {
-	GDCLASS(Range, Control);
+	GDCLASS(Range, Control)
 
 	struct Shared {
 		double val = 0.0;
@@ -64,7 +64,7 @@ class Range : public Control {
 
 protected:
 	virtual void _value_changed(double p_value);
-	void _notify_shared_value_changed() { shared->emit_value_changed(); };
+	void _notify_shared_value_changed() { shared->emit_value_changed(); }
 
 	static void _bind_methods();
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -41,7 +41,7 @@ class CharFXTransform;
 class RichTextEffect;
 
 class RichTextLabel : public Control {
-	GDCLASS(RichTextLabel, Control);
+	GDCLASS(RichTextLabel, Control)
 
 	enum RTLDrawStep {
 		DRAW_STEP_BACKGROUND,

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -34,7 +34,7 @@
 #include "scene/gui/range.h"
 
 class ScrollBar : public Range {
-	GDCLASS(ScrollBar, Range);
+	GDCLASS(ScrollBar, Range)
 
 	enum HighlightStatus {
 		HIGHLIGHT_NONE,
@@ -130,7 +130,7 @@ public:
 };
 
 class HScrollBar : public ScrollBar {
-	GDCLASS(HScrollBar, ScrollBar);
+	GDCLASS(HScrollBar, ScrollBar)
 
 public:
 	HScrollBar() :
@@ -138,7 +138,7 @@ public:
 };
 
 class VScrollBar : public ScrollBar {
-	GDCLASS(VScrollBar, ScrollBar);
+	GDCLASS(VScrollBar, ScrollBar)
 
 public:
 	VScrollBar() :

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -36,7 +36,7 @@
 #include "scroll_bar.h"
 
 class ScrollContainer : public Container {
-	GDCLASS(ScrollContainer, Container);
+	GDCLASS(ScrollContainer, Container)
 
 public:
 	enum ScrollMode {

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -34,7 +34,7 @@
 #include "scene/gui/container.h"
 
 class SplitContainerDragger : public Control {
-	GDCLASS(SplitContainerDragger, Control);
+	GDCLASS(SplitContainerDragger, Control)
 	friend class SplitContainer;
 	Rect2 split_bar_rect;
 
@@ -53,7 +53,7 @@ public:
 };
 
 class SplitContainer : public Container {
-	GDCLASS(SplitContainer, Container);
+	GDCLASS(SplitContainer, Container)
 	friend class SplitContainerDragger;
 
 public:
@@ -143,7 +143,7 @@ public:
 VARIANT_ENUM_CAST(SplitContainer::DraggerVisibility);
 
 class HSplitContainer : public SplitContainer {
-	GDCLASS(HSplitContainer, SplitContainer);
+	GDCLASS(HSplitContainer, SplitContainer)
 
 public:
 	HSplitContainer() :
@@ -151,7 +151,7 @@ public:
 };
 
 class VSplitContainer : public SplitContainer {
-	GDCLASS(VSplitContainer, SplitContainer);
+	GDCLASS(VSplitContainer, SplitContainer)
 
 public:
 	VSplitContainer() :

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -36,7 +36,7 @@
 #include "scene/resources/text_line.h"
 
 class TabBar : public Control {
-	GDCLASS(TabBar, Control);
+	GDCLASS(TabBar, Control)
 
 public:
 	enum AlignmentMode {

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -36,7 +36,7 @@
 #include "scene/gui/tab_bar.h"
 
 class TabContainer : public Container {
-	GDCLASS(TabContainer, Container);
+	GDCLASS(TabContainer, Container)
 
 public:
 	enum TabPosition {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -39,7 +39,7 @@
 #include "scene/resources/text_paragraph.h"
 
 class TextEdit : public Control {
-	GDCLASS(TextEdit, Control);
+	GDCLASS(TextEdit, Control)
 
 public:
 	/* Edit Actions. */
@@ -692,9 +692,9 @@ protected:
 	void _set_symbol_lookup_word(const String &p_symbol);
 
 	// Theme items.
-	virtual Color _get_brace_mismatch_color() const { return Color(); };
-	virtual Color _get_code_folding_color() const { return Color(); };
-	virtual Ref<Texture2D> _get_folded_eol_icon() const { return Ref<Texture2D>(); };
+	virtual Color _get_brace_mismatch_color() const { return Color(); }
+	virtual Color _get_code_folding_color() const { return Color(); }
+	virtual Ref<Texture2D> _get_folded_eol_icon() const { return Ref<Texture2D>(); }
 
 	/* Text manipulation */
 

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -34,7 +34,7 @@
 #include "scene/gui/base_button.h"
 #include "scene/resources/bit_map.h"
 class TextureButton : public BaseButton {
-	GDCLASS(TextureButton, BaseButton);
+	GDCLASS(TextureButton, BaseButton)
 
 public:
 	enum StretchMode {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -42,7 +42,7 @@ class Window;
 class World2D;
 
 class CanvasItem : public Node {
-	GDCLASS(CanvasItem, Node);
+	GDCLASS(CanvasItem, Node)
 
 	friend class CanvasLayer;
 
@@ -211,20 +211,20 @@ public:
 	virtual Size2 _edit_get_scale() const = 0;
 
 	// Used to rotate the node
-	virtual bool _edit_use_rotation() const { return false; };
+	virtual bool _edit_use_rotation() const { return false; }
 	virtual void _edit_set_rotation(real_t p_rotation) {}
-	virtual real_t _edit_get_rotation() const { return 0.0; };
+	virtual real_t _edit_get_rotation() const { return 0.0; }
 
 	// Used to resize/move the node
-	virtual bool _edit_use_rect() const { return false; }; // MAYBE REPLACE BY A _edit_get_editmode()
+	virtual bool _edit_use_rect() const { return false; } // MAYBE REPLACE BY A _edit_get_editmode()
 	virtual void _edit_set_rect(const Rect2 &p_rect) {}
-	virtual Rect2 _edit_get_rect() const { return Rect2(0, 0, 0, 0); };
-	virtual Size2 _edit_get_minimum_size() const { return Size2(-1, -1); }; // LOOKS WEIRD
+	virtual Rect2 _edit_get_rect() const { return Rect2(0, 0, 0, 0); }
+	virtual Size2 _edit_get_minimum_size() const { return Size2(-1, -1); } // LOOKS WEIRD
 
 	// Used to set a pivot
-	virtual bool _edit_use_pivot() const { return false; };
+	virtual bool _edit_use_pivot() const { return false; }
 	virtual void _edit_set_pivot(const Point2 &p_pivot) {}
-	virtual Point2 _edit_get_pivot() const { return Point2(); };
+	virtual Point2 _edit_get_pivot() const { return Point2(); }
 
 	virtual Transform2D _edit_get_transform() const;
 #endif
@@ -375,7 +375,7 @@ public:
 	TextureRepeat get_texture_repeat_in_tree() const;
 
 	// Used by control nodes to retrieve the parent's anchorable area
-	virtual Rect2 get_anchorable_rect() const { return Rect2(0, 0, 0, 0); };
+	virtual Rect2 get_anchorable_rect() const { return Rect2(0, 0, 0, 0); }
 
 	int get_canvas_layer() const;
 	CanvasLayer *get_canvas_layer_node() const;
@@ -389,8 +389,8 @@ VARIANT_ENUM_CAST(CanvasItem::TextureRepeat)
 VARIANT_ENUM_CAST(CanvasItem::ClipChildrenMode)
 
 class CanvasTexture : public Texture2D {
-	GDCLASS(CanvasTexture, Texture2D);
-	OBJ_SAVE_TYPE(Texture2D); // Saves derived classes with common type so they can be interchanged.
+	GDCLASS(CanvasTexture, Texture2D)
+	OBJ_SAVE_TYPE(Texture2D) // Saves derived classes with common type so they can be interchanged.
 
 	Ref<Texture2D> diffuse_texture;
 	Ref<Texture2D> normal_texture;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -47,7 +47,7 @@ SAFE_FLAG_TYPE_PUN_GUARANTEES
 SAFE_NUMERIC_TYPE_PUN_GUARANTEES(uint32_t)
 
 class Node : public Object {
-	GDCLASS(Node, Object);
+	GDCLASS(Node, Object)
 
 protected:
 	// During group processing, these are thread-safe.

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -53,7 +53,7 @@ class Tween;
 class Viewport;
 
 class SceneTreeTimer : public RefCounted {
-	GDCLASS(SceneTreeTimer, RefCounted);
+	GDCLASS(SceneTreeTimer, RefCounted)
 
 	double time_left = 0.0;
 	bool process_always = true;
@@ -84,7 +84,7 @@ public:
 class SceneTree : public MainLoop {
 	_THREAD_SAFE_CLASS_
 
-	GDCLASS(SceneTree, MainLoop);
+	GDCLASS(SceneTree, MainLoop)
 
 public:
 	typedef void (*IdleCallback)();

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -34,7 +34,7 @@
 #include "scene/main/node.h"
 
 class Timer : public Node {
-	GDCLASS(Timer, Node);
+	GDCLASS(Timer, Node)
 
 	double wait_time = 1.0;
 	bool one_shot = false;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -53,7 +53,7 @@ class Window;
 class World2D;
 
 class ViewportTexture : public Texture2D {
-	GDCLASS(ViewportTexture, Texture2D);
+	GDCLASS(ViewportTexture, Texture2D)
 
 	NodePath path;
 
@@ -93,7 +93,7 @@ public:
 };
 
 class Viewport : public Node {
-	GDCLASS(Viewport, Node);
+	GDCLASS(Viewport, Node)
 
 public:
 	enum Scaling3DMode {
@@ -789,7 +789,7 @@ public:
 };
 
 class SubViewport : public Viewport {
-	GDCLASS(SubViewport, Viewport);
+	GDCLASS(SubViewport, Viewport)
 
 public:
 	enum ClearMode {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -41,7 +41,7 @@ class ThemeOwner;
 class ThemeContext;
 
 class Window : public Viewport {
-	GDCLASS(Window, Viewport);
+	GDCLASS(Window, Viewport)
 
 public:
 	// Keep synced with enum hint for `mode` property.
@@ -368,7 +368,7 @@ public:
 	bool is_wrapping_controls() const;
 	void child_controls_changed();
 
-	Window *get_exclusive_child() const { return exclusive_child; };
+	Window *get_exclusive_child() const { return exclusive_child; }
 	Window *get_parent_visible_window() const;
 	Viewport *get_parent_viewport() const;
 

--- a/scene/resources/2d/navigation_mesh_source_geometry_data_2d.h
+++ b/scene/resources/2d/navigation_mesh_source_geometry_data_2d.h
@@ -36,7 +36,7 @@
 #include "scene/resources/2d/navigation_polygon.h"
 
 class NavigationMeshSourceGeometryData2D : public Resource {
-	GDCLASS(NavigationMeshSourceGeometryData2D, Resource);
+	GDCLASS(NavigationMeshSourceGeometryData2D, Resource)
 	RWLock geometry_rwlock;
 
 	Vector<Vector<Vector2>> traversable_outlines;

--- a/scene/resources/2d/navigation_polygon.h
+++ b/scene/resources/2d/navigation_polygon.h
@@ -36,7 +36,7 @@
 #include "servers/navigation/navigation_globals.h"
 
 class NavigationPolygon : public Resource {
-	GDCLASS(NavigationPolygon, Resource);
+	GDCLASS(NavigationPolygon, Resource)
 	RWLock rwlock;
 
 	Vector<Vector2> vertices;

--- a/scene/resources/3d/navigation_mesh_source_geometry_data_3d.h
+++ b/scene/resources/3d/navigation_mesh_source_geometry_data_3d.h
@@ -35,7 +35,7 @@
 #include "scene/resources/mesh.h"
 
 class NavigationMeshSourceGeometryData3D : public Resource {
-	GDCLASS(NavigationMeshSourceGeometryData3D, Resource);
+	GDCLASS(NavigationMeshSourceGeometryData3D, Resource)
 	RWLock geometry_rwlock;
 
 	Vector<float> vertices;

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -36,9 +36,9 @@
 class ArrayMesh;
 
 class Shape3D : public Resource {
-	GDCLASS(Shape3D, Resource);
-	OBJ_SAVE_TYPE(Shape3D);
-	RES_BASE_EXTENSION("shape");
+	GDCLASS(Shape3D, Resource)
+	OBJ_SAVE_TYPE(Shape3D)
+	RES_BASE_EXTENSION("shape")
 	RID shape;
 	real_t custom_bias = 0.0;
 	real_t margin = 0.04;

--- a/scene/resources/3d/world_3d.h
+++ b/scene/resources/3d/world_3d.h
@@ -43,7 +43,7 @@ class VisibleOnScreenNotifier3D;
 struct SpatialIndexer;
 
 class World3D : public Resource {
-	GDCLASS(World3D, Resource);
+	GDCLASS(World3D, Resource)
 
 private:
 	RID scenario;

--- a/scene/resources/bit_map.h
+++ b/scene/resources/bit_map.h
@@ -39,8 +39,8 @@ template <typename T>
 class TypedArray;
 
 class BitMap : public Resource {
-	GDCLASS(BitMap, Resource);
-	OBJ_SAVE_TYPE(BitMap);
+	GDCLASS(BitMap, Resource)
+	OBJ_SAVE_TYPE(BitMap)
 
 	Vector<uint8_t> bitmask;
 	int width = 0;

--- a/scene/resources/camera_attributes.h
+++ b/scene/resources/camera_attributes.h
@@ -35,7 +35,7 @@
 #include "core/templates/rid.h"
 
 class CameraAttributes : public Resource {
-	GDCLASS(CameraAttributes, Resource);
+	GDCLASS(CameraAttributes, Resource)
 
 private:
 	RID camera_attributes;
@@ -76,7 +76,7 @@ public:
 };
 
 class CameraAttributesPractical : public CameraAttributes {
-	GDCLASS(CameraAttributesPractical, CameraAttributes);
+	GDCLASS(CameraAttributesPractical, CameraAttributes)
 
 private:
 	// DOF blur
@@ -127,7 +127,7 @@ public:
 };
 
 class CameraAttributesPhysical : public CameraAttributes {
-	GDCLASS(CameraAttributesPhysical, CameraAttributes);
+	GDCLASS(CameraAttributesPhysical, CameraAttributes)
 
 private:
 	// Exposure

--- a/scene/resources/canvas_item_material.h
+++ b/scene/resources/canvas_item_material.h
@@ -34,7 +34,7 @@
 #include "scene/resources/material.h"
 
 class CanvasItemMaterial : public Material {
-	GDCLASS(CanvasItemMaterial, Material);
+	GDCLASS(CanvasItemMaterial, Material)
 
 public:
 	enum BlendMode {

--- a/scene/resources/compositor.h
+++ b/scene/resources/compositor.h
@@ -38,7 +38,7 @@
 /* Compositor Effect */
 
 class CompositorEffect : public Resource {
-	GDCLASS(CompositorEffect, Resource);
+	GDCLASS(CompositorEffect, Resource)
 
 public:
 	enum EffectCallbackType {
@@ -100,7 +100,7 @@ VARIANT_ENUM_CAST(CompositorEffect::EffectCallbackType)
 /* Compositor */
 
 class Compositor : public Resource {
-	GDCLASS(Compositor, Resource);
+	GDCLASS(Compositor, Resource)
 
 private:
 	RID compositor;

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -35,7 +35,7 @@
 
 // y(x) curve
 class Curve : public Resource {
-	GDCLASS(Curve, Resource);
+	GDCLASS(Curve, Resource)
 
 public:
 	static const int MIN_X = 0.f;
@@ -162,7 +162,7 @@ private:
 VARIANT_ENUM_CAST(Curve::TangentMode)
 
 class Curve2D : public Resource {
-	GDCLASS(Curve2D, Resource);
+	GDCLASS(Curve2D, Resource)
 
 	struct Point {
 		Vector2 in;
@@ -249,7 +249,7 @@ public:
 };
 
 class Curve3D : public Resource {
-	GDCLASS(Curve3D, Resource);
+	GDCLASS(Curve3D, Resource)
 
 	struct Point {
 		Vector3 in;

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -36,7 +36,7 @@
 #include "scene/resources/texture.h"
 
 class Environment : public Resource {
-	GDCLASS(Environment, Resource);
+	GDCLASS(Environment, Resource)
 
 public:
 	enum BGMode {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -45,7 +45,7 @@ class TextParagraph;
 /*************************************************************************/
 
 class Font : public Resource {
-	GDCLASS(Font, Resource);
+	GDCLASS(Font, Resource)
 
 	struct ShapedTextKey {
 		String text;
@@ -177,8 +177,8 @@ public:
 /*************************************************************************/
 
 class FontFile : public Font {
-	GDCLASS(FontFile, Font);
-	RES_BASE_EXTENSION("fontdata");
+	GDCLASS(FontFile, Font)
+	RES_BASE_EXTENSION("fontdata")
 
 	// Font source data.
 	const uint8_t *data_ptr = nullptr;
@@ -394,7 +394,7 @@ public:
 /*************************************************************************/
 
 class FontVariation : public Font {
-	GDCLASS(FontVariation, Font);
+	GDCLASS(FontVariation, Font)
 
 	struct Variation {
 		Dictionary opentype;
@@ -458,7 +458,7 @@ public:
 /*************************************************************************/
 
 class SystemFont : public Font {
-	GDCLASS(SystemFont, Font);
+	GDCLASS(SystemFont, Font)
 
 	PackedStringArray names;
 	bool italic = false;

--- a/scene/resources/gradient.h
+++ b/scene/resources/gradient.h
@@ -36,8 +36,8 @@
 #include "thirdparty/misc/ok_color.h"
 
 class Gradient : public Resource {
-	GDCLASS(Gradient, Resource);
-	OBJ_SAVE_TYPE(Gradient);
+	GDCLASS(Gradient, Resource)
+	OBJ_SAVE_TYPE(Gradient)
 
 public:
 	enum InterpolationMode {

--- a/scene/resources/label_settings.h
+++ b/scene/resources/label_settings.h
@@ -37,7 +37,7 @@
 /*************************************************************************/
 
 class LabelSettings : public Resource {
-	GDCLASS(LabelSettings, Resource);
+	GDCLASS(LabelSettings, Resource)
 
 	real_t line_spacing = 3;
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -38,9 +38,9 @@
 #include "servers/rendering_server.h"
 
 class Material : public Resource {
-	GDCLASS(Material, Resource);
+	GDCLASS(Material, Resource)
 	RES_BASE_EXTENSION("material")
-	OBJ_SAVE_TYPE(Material);
+	OBJ_SAVE_TYPE(Material)
 
 	RID material;
 	Ref<Material> next_pass;
@@ -92,7 +92,7 @@ public:
 };
 
 class ShaderMaterial : public Material {
-	GDCLASS(ShaderMaterial, Material);
+	GDCLASS(ShaderMaterial, Material)
 	Ref<Shader> shader;
 
 	mutable HashMap<StringName, StringName> remap_cache;
@@ -134,7 +134,7 @@ public:
 class StandardMaterial3D;
 
 class BaseMaterial3D : public Material {
-	GDCLASS(BaseMaterial3D, Material);
+	GDCLASS(BaseMaterial3D, Material)
 
 public:
 	enum TextureParam {

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -46,7 +46,7 @@ class MeshConvexDecompositionSettings;
 class Shape3D;
 
 class Mesh : public Resource {
-	GDCLASS(Mesh, Resource);
+	GDCLASS(Mesh, Resource)
 
 	mutable Ref<TriangleMesh> triangle_mesh; //cached
 	mutable Vector<Ref<TriangleMesh>> surface_triangle_meshes; //cached
@@ -211,7 +211,7 @@ public:
 };
 
 class MeshConvexDecompositionSettings : public RefCounted {
-	GDCLASS(MeshConvexDecompositionSettings, RefCounted);
+	GDCLASS(MeshConvexDecompositionSettings, RefCounted)
 
 public:
 	enum Mode : int {
@@ -294,8 +294,8 @@ public:
 VARIANT_ENUM_CAST(MeshConvexDecompositionSettings::Mode);
 
 class ArrayMesh : public Mesh {
-	GDCLASS(ArrayMesh, Mesh);
-	RES_BASE_EXTENSION("mesh");
+	GDCLASS(ArrayMesh, Mesh)
+	RES_BASE_EXTENSION("mesh")
 
 	PackedStringArray _get_blend_shape_names() const;
 	void _set_blend_shape_names(const PackedStringArray &p_names);
@@ -406,7 +406,7 @@ VARIANT_ENUM_CAST(Mesh::PrimitiveType);
 VARIANT_ENUM_CAST(Mesh::BlendShapeMode);
 
 class PlaceholderMesh : public Mesh {
-	GDCLASS(PlaceholderMesh, Mesh);
+	GDCLASS(PlaceholderMesh, Mesh)
 
 	RID rid;
 	AABB aabb;

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -36,7 +36,7 @@
 #include "servers/navigation/navigation_globals.h"
 
 class NavigationMesh : public Resource {
-	GDCLASS(NavigationMesh, Resource);
+	GDCLASS(NavigationMesh, Resource)
 	RWLock rwlock;
 
 	Vector<Vector3> vertices;

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -35,7 +35,7 @@
 #include "scene/main/node.h"
 
 class SceneState : public RefCounted {
-	GDCLASS(SceneState, RefCounted);
+	GDCLASS(SceneState, RefCounted)
 
 	Vector<StringName> names;
 	Vector<Variant> variants;
@@ -230,8 +230,8 @@ public:
 VARIANT_ENUM_CAST(SceneState::GenEditState)
 
 class PackedScene : public Resource {
-	GDCLASS(PackedScene, Resource);
-	RES_BASE_EXTENSION("scn");
+	GDCLASS(PackedScene, Resource)
+	RES_BASE_EXTENSION("scn")
 
 	Ref<SceneState> state;
 

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -38,8 +38,8 @@
 #include "shader_include.h"
 
 class Shader : public Resource {
-	GDCLASS(Shader, Resource);
-	OBJ_SAVE_TYPE(Shader);
+	GDCLASS(Shader, Resource)
+	OBJ_SAVE_TYPE(Shader)
 
 public:
 	enum Mode {

--- a/scene/resources/shader_include.h
+++ b/scene/resources/shader_include.h
@@ -37,8 +37,8 @@
 #include "core/templates/hash_set.h"
 
 class ShaderInclude : public Resource {
-	GDCLASS(ShaderInclude, Resource);
-	OBJ_SAVE_TYPE(ShaderInclude);
+	GDCLASS(ShaderInclude, Resource)
+	OBJ_SAVE_TYPE(ShaderInclude)
 
 private:
 	String code;

--- a/scene/resources/sky.h
+++ b/scene/resources/sky.h
@@ -36,7 +36,7 @@
 #include "scene/resources/texture.h"
 
 class Sky : public Resource {
-	GDCLASS(Sky, Resource);
+	GDCLASS(Sky, Resource)
 
 public:
 	enum RadianceSize {

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -38,9 +38,9 @@
 class CanvasItem;
 
 class StyleBox : public Resource {
-	GDCLASS(StyleBox, Resource);
-	RES_BASE_EXTENSION("stylebox");
-	OBJ_SAVE_TYPE(StyleBox);
+	GDCLASS(StyleBox, Resource)
+	RES_BASE_EXTENSION("stylebox")
+	OBJ_SAVE_TYPE(StyleBox)
 
 	float content_margin[4];
 
@@ -75,7 +75,7 @@ public:
 };
 
 class StyleBoxEmpty : public StyleBox {
-	GDCLASS(StyleBoxEmpty, StyleBox);
+	GDCLASS(StyleBoxEmpty, StyleBox)
 	virtual float get_style_margin(Side p_side) const override { return 0; }
 
 public:

--- a/scene/resources/text_line.h
+++ b/scene/resources/text_line.h
@@ -37,7 +37,7 @@
 /*************************************************************************/
 
 class TextLine : public RefCounted {
-	GDCLASS(TextLine, RefCounted);
+	GDCLASS(TextLine, RefCounted)
 
 private:
 	RID rid;

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -38,7 +38,7 @@
 /*************************************************************************/
 
 class TextParagraph : public RefCounted {
-	GDCLASS(TextParagraph, RefCounted);
+	GDCLASS(TextParagraph, RefCounted)
 	_THREAD_SAFE_CLASS_
 
 private:
@@ -152,7 +152,7 @@ public:
 
 	int hit_test(const Point2 &p_coords) const;
 
-	Mutex &get_mutex() const { return _thread_safe_; };
+	Mutex &get_mutex() const { return _thread_safe_; }
 
 	TextParagraph(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language = "", float p_width = -1.f, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL);
 	TextParagraph();

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -44,15 +44,15 @@
 #include "servers/rendering_server.h"
 
 class Texture : public Resource {
-	GDCLASS(Texture, Resource);
+	GDCLASS(Texture, Resource)
 
 public:
 	Texture() {}
 };
 
 class Texture2D : public Texture {
-	GDCLASS(Texture2D, Texture);
-	OBJ_SAVE_TYPE(Texture2D); // Saves derived classes with common type so they can be interchanged.
+	GDCLASS(Texture2D, Texture)
+	OBJ_SAVE_TYPE(Texture2D) // Saves derived classes with common type so they can be interchanged.
 
 protected:
 	static void _bind_methods();
@@ -88,7 +88,7 @@ public:
 };
 
 class TextureLayered : public Texture {
-	GDCLASS(TextureLayered, Texture);
+	GDCLASS(TextureLayered, Texture)
 
 protected:
 	static void _bind_methods();
@@ -121,7 +121,7 @@ public:
 VARIANT_ENUM_CAST(TextureLayered::LayeredType)
 
 class Texture3D : public Texture {
-	GDCLASS(Texture3D, Texture);
+	GDCLASS(Texture3D, Texture)
 
 protected:
 	static void _bind_methods();

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -37,8 +37,8 @@
 #include "scene/resources/texture.h"
 
 class Theme : public Resource {
-	GDCLASS(Theme, Resource);
-	RES_BASE_EXTENSION("theme");
+	GDCLASS(Theme, Resource)
+	RES_BASE_EXTENSION("theme")
 
 #ifdef TOOLS_ENABLED
 	friend class ThemeItemImportTree;

--- a/scene/theme/theme_db.h
+++ b/scene/theme/theme_db.h
@@ -71,7 +71,7 @@ class ThemeContext;
 			})
 
 class ThemeDB : public Object {
-	GDCLASS(ThemeDB, Object);
+	GDCLASS(ThemeDB, Object)
 
 	static ThemeDB *singleton;
 
@@ -184,7 +184,7 @@ public:
 };
 
 class ThemeContext : public Object {
-	GDCLASS(ThemeContext, Object);
+	GDCLASS(ThemeContext, Object)
 
 	friend class ThemeDB;
 

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -61,7 +61,7 @@ class AudioDriverDummy : public AudioDriver {
 public:
 	virtual const char *get_name() const override {
 		return "Dummy";
-	};
+	}
 
 	virtual Error init() override;
 	virtual void start() override;

--- a/servers/audio/audio_effect.h
+++ b/servers/audio/audio_effect.h
@@ -37,7 +37,7 @@
 #include "core/variant/native_ptr.h"
 
 class AudioEffectInstance : public RefCounted {
-	GDCLASS(AudioEffectInstance, RefCounted);
+	GDCLASS(AudioEffectInstance, RefCounted)
 
 protected:
 	GDVIRTUAL3(_process, GDExtensionConstPtr<AudioFrame>, GDExtensionPtr<AudioFrame>, int)
@@ -50,7 +50,7 @@ public:
 };
 
 class AudioEffect : public Resource {
-	GDCLASS(AudioEffect, Resource);
+	GDCLASS(AudioEffect, Resource)
 
 protected:
 	GDVIRTUAL0R(Ref<AudioEffectInstance>, _instantiate)

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -180,7 +180,7 @@ public:
 class AudioBusLayout;
 
 class AudioServer : public Object {
-	GDCLASS(AudioServer, Object);
+	GDCLASS(AudioServer, Object)
 
 public:
 	//re-expose this here, as AudioDriver is not exposed to script
@@ -498,7 +498,7 @@ VARIANT_ENUM_CAST(AudioServer::SpeakerMode)
 VARIANT_ENUM_CAST(AudioServer::PlaybackType)
 
 class AudioBusLayout : public Resource {
-	GDCLASS(AudioBusLayout, Resource);
+	GDCLASS(AudioBusLayout, Resource)
 
 	friend class AudioServer;
 

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -47,7 +47,7 @@ template <typename T>
 class TypedArray;
 
 class CameraServer : public Object {
-	GDCLASS(CameraServer, Object);
+	GDCLASS(CameraServer, Object)
 	_THREAD_SAFE_CLASS_
 
 public:
@@ -87,7 +87,7 @@ public:
 	static CameraServer *create() {
 		CameraServer *server = create_func ? create_func() : memnew(CameraServer);
 		return server;
-	};
+	}
 
 	// Right now we identify our feed by it's ID when it's used in the background.
 	// May see if we can change this to purely relying on CameraFeed objects or by name.

--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -36,7 +36,7 @@
 #include "servers/audio_server.h"
 
 class MovieWriter : public Object {
-	GDCLASS(MovieWriter, Object);
+	GDCLASS(MovieWriter, Object)
 
 	uint64_t fps = 0;
 	uint64_t mix_rate = 0;

--- a/servers/navigation/navigation_path_query_parameters_2d.h
+++ b/servers/navigation/navigation_path_query_parameters_2d.h
@@ -35,7 +35,7 @@
 #include "servers/navigation/navigation_utilities.h"
 
 class NavigationPathQueryParameters2D : public RefCounted {
-	GDCLASS(NavigationPathQueryParameters2D, RefCounted);
+	GDCLASS(NavigationPathQueryParameters2D, RefCounted)
 
 	NavigationUtilities::PathQueryParameters parameters;
 

--- a/servers/navigation/navigation_path_query_parameters_3d.h
+++ b/servers/navigation/navigation_path_query_parameters_3d.h
@@ -35,7 +35,7 @@
 #include "servers/navigation/navigation_utilities.h"
 
 class NavigationPathQueryParameters3D : public RefCounted {
-	GDCLASS(NavigationPathQueryParameters3D, RefCounted);
+	GDCLASS(NavigationPathQueryParameters3D, RefCounted)
 
 	NavigationUtilities::PathQueryParameters parameters;
 

--- a/servers/navigation/navigation_path_query_result_2d.h
+++ b/servers/navigation/navigation_path_query_result_2d.h
@@ -35,7 +35,7 @@
 #include "servers/navigation/navigation_utilities.h"
 
 class NavigationPathQueryResult2D : public RefCounted {
-	GDCLASS(NavigationPathQueryResult2D, RefCounted);
+	GDCLASS(NavigationPathQueryResult2D, RefCounted)
 
 	Vector<Vector2> path;
 	Vector<int32_t> path_types;

--- a/servers/navigation/navigation_path_query_result_3d.h
+++ b/servers/navigation/navigation_path_query_result_3d.h
@@ -36,7 +36,7 @@
 #include "servers/navigation/navigation_utilities.h"
 
 class NavigationPathQueryResult3D : public RefCounted {
-	GDCLASS(NavigationPathQueryResult3D, RefCounted);
+	GDCLASS(NavigationPathQueryResult3D, RefCounted)
 
 	Vector<Vector3> path;
 	Vector<int32_t> path_types;

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -45,7 +45,7 @@ class NavMeshGenerator2D;
 
 // This server exposes the `NavigationServer3D` features in the 2D world.
 class NavigationServer2D : public Object {
-	GDCLASS(NavigationServer2D, Object);
+	GDCLASS(NavigationServer2D, Object)
 
 	static NavigationServer2D *singleton;
 

--- a/servers/navigation_server_2d_dummy.h
+++ b/servers/navigation_server_2d_dummy.h
@@ -34,7 +34,7 @@
 #include "servers/navigation_server_2d.h"
 
 class NavigationServer2DDummy : public NavigationServer2D {
-	GDCLASS(NavigationServer2DDummy, NavigationServer2D);
+	GDCLASS(NavigationServer2DDummy, NavigationServer2D)
 
 public:
 	TypedArray<RID> get_maps() const override { return TypedArray<RID>(); }
@@ -58,7 +58,7 @@ public:
 	TypedArray<RID> map_get_agents(RID p_map) const override { return TypedArray<RID>(); }
 	TypedArray<RID> map_get_obstacles(RID p_map) const override { return TypedArray<RID>(); }
 	void map_force_update(RID p_map) override {}
-	Vector2 map_get_random_point(RID p_map, uint32_t p_naviation_layers, bool p_uniformly) const override { return Vector2(); };
+	Vector2 map_get_random_point(RID p_map, uint32_t p_naviation_layers, bool p_uniformly) const override { return Vector2(); }
 	uint32_t map_get_iteration_id(RID p_map) const override { return 0; }
 
 	RID region_create() override { return RID(); }
@@ -84,7 +84,7 @@ public:
 	Vector2 region_get_connection_pathway_start(RID p_region, int p_connection_id) const override { return Vector2(); }
 	Vector2 region_get_connection_pathway_end(RID p_region, int p_connection_id) const override { return Vector2(); }
 	Vector2 region_get_closest_point(RID p_region, const Vector2 &p_point) const override { return Vector2(); }
-	Vector2 region_get_random_point(RID p_region, uint32_t p_navigation_layers, bool p_uniformly) const override { return Vector2(); };
+	Vector2 region_get_random_point(RID p_region, uint32_t p_navigation_layers, bool p_uniformly) const override { return Vector2(); }
 
 	RID link_create() override { return RID(); }
 	void link_set_map(RID p_link, RID p_map) override {}

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -47,7 +47,7 @@
 /// don't expect that a change is immediately propagated.
 
 class NavigationServer3D : public Object {
-	GDCLASS(NavigationServer3D, Object);
+	GDCLASS(NavigationServer3D, Object)
 
 	static NavigationServer3D *singleton;
 

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -34,7 +34,7 @@
 #include "servers/navigation_server_3d.h"
 
 class NavigationServer3DDummy : public NavigationServer3D {
-	GDCLASS(NavigationServer3DDummy, NavigationServer3D);
+	GDCLASS(NavigationServer3DDummy, NavigationServer3D)
 
 public:
 	TypedArray<RID> get_maps() const override { return TypedArray<RID>(); }

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -40,7 +40,7 @@ template <typename T>
 class TypedArray;
 
 class PhysicsDirectBodyState2D : public Object {
-	GDCLASS(PhysicsDirectBodyState2D, Object);
+	GDCLASS(PhysicsDirectBodyState2D, Object)
 
 protected:
 	static void _bind_methods();
@@ -115,7 +115,7 @@ class PhysicsPointQueryParameters2D;
 class PhysicsShapeQueryParameters2D;
 
 class PhysicsDirectSpaceState2D : public Object {
-	GDCLASS(PhysicsDirectSpaceState2D, Object);
+	GDCLASS(PhysicsDirectSpaceState2D, Object)
 
 	Dictionary _intersect_ray(const Ref<PhysicsRayQueryParameters2D> &p_ray_query);
 	TypedArray<Dictionary> _intersect_point(const Ref<PhysicsPointQueryParameters2D> &p_point_query, int p_max_results = 32);
@@ -205,7 +205,7 @@ class PhysicsTestMotionParameters2D;
 class PhysicsTestMotionResult2D;
 
 class PhysicsServer2D : public Object {
-	GDCLASS(PhysicsServer2D, Object);
+	GDCLASS(PhysicsServer2D, Object)
 
 	static PhysicsServer2D *singleton;
 
@@ -614,7 +614,7 @@ public:
 };
 
 class PhysicsRayQueryParameters2D : public RefCounted {
-	GDCLASS(PhysicsRayQueryParameters2D, RefCounted);
+	GDCLASS(PhysicsRayQueryParameters2D, RefCounted)
 
 	PhysicsDirectSpaceState2D::RayParameters parameters;
 
@@ -648,7 +648,7 @@ public:
 };
 
 class PhysicsPointQueryParameters2D : public RefCounted {
-	GDCLASS(PhysicsPointQueryParameters2D, RefCounted);
+	GDCLASS(PhysicsPointQueryParameters2D, RefCounted)
 
 	PhysicsDirectSpaceState2D::PointParameters parameters;
 
@@ -678,7 +678,7 @@ public:
 };
 
 class PhysicsShapeQueryParameters2D : public RefCounted {
-	GDCLASS(PhysicsShapeQueryParameters2D, RefCounted);
+	GDCLASS(PhysicsShapeQueryParameters2D, RefCounted)
 
 	PhysicsDirectSpaceState2D::ShapeParameters parameters;
 
@@ -719,7 +719,7 @@ public:
 };
 
 class PhysicsTestMotionParameters2D : public RefCounted {
-	GDCLASS(PhysicsTestMotionParameters2D, RefCounted);
+	GDCLASS(PhysicsTestMotionParameters2D, RefCounted)
 
 	PhysicsServer2D::MotionParameters parameters;
 
@@ -752,7 +752,7 @@ public:
 };
 
 class PhysicsTestMotionResult2D : public RefCounted {
-	GDCLASS(PhysicsTestMotionResult2D, RefCounted);
+	GDCLASS(PhysicsTestMotionResult2D, RefCounted)
 
 	PhysicsServer2D::MotionResult result;
 
@@ -779,7 +779,7 @@ public:
 };
 
 class PhysicsServer2DManager : public Object {
-	GDCLASS(PhysicsServer2DManager, Object);
+	GDCLASS(PhysicsServer2DManager, Object)
 
 	static PhysicsServer2DManager *singleton;
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -43,7 +43,7 @@ template <typename T>
 class TypedArray;
 
 class PhysicsDirectBodyState3D : public Object {
-	GDCLASS(PhysicsDirectBodyState3D, Object);
+	GDCLASS(PhysicsDirectBodyState3D, Object)
 
 protected:
 	static void _bind_methods();
@@ -120,7 +120,7 @@ class PhysicsPointQueryParameters3D;
 class PhysicsShapeQueryParameters3D;
 
 class PhysicsDirectSpaceState3D : public Object {
-	GDCLASS(PhysicsDirectSpaceState3D, Object);
+	GDCLASS(PhysicsDirectSpaceState3D, Object)
 
 private:
 	Dictionary _intersect_ray(const Ref<PhysicsRayQueryParameters3D> &p_ray_query);
@@ -231,7 +231,7 @@ class PhysicsTestMotionParameters3D;
 class PhysicsTestMotionResult3D;
 
 class PhysicsServer3D : public Object {
-	GDCLASS(PhysicsServer3D, Object);
+	GDCLASS(PhysicsServer3D, Object)
 
 	static PhysicsServer3D *singleton;
 
@@ -817,7 +817,7 @@ public:
 };
 
 class PhysicsRayQueryParameters3D : public RefCounted {
-	GDCLASS(PhysicsRayQueryParameters3D, RefCounted);
+	GDCLASS(PhysicsRayQueryParameters3D, RefCounted)
 
 	PhysicsDirectSpaceState3D::RayParameters parameters;
 
@@ -854,7 +854,7 @@ public:
 };
 
 class PhysicsPointQueryParameters3D : public RefCounted {
-	GDCLASS(PhysicsPointQueryParameters3D, RefCounted);
+	GDCLASS(PhysicsPointQueryParameters3D, RefCounted)
 
 	PhysicsDirectSpaceState3D::PointParameters parameters;
 
@@ -881,7 +881,7 @@ public:
 };
 
 class PhysicsShapeQueryParameters3D : public RefCounted {
-	GDCLASS(PhysicsShapeQueryParameters3D, RefCounted);
+	GDCLASS(PhysicsShapeQueryParameters3D, RefCounted)
 
 	PhysicsDirectSpaceState3D::ShapeParameters parameters;
 
@@ -922,7 +922,7 @@ public:
 };
 
 class PhysicsTestMotionParameters3D : public RefCounted {
-	GDCLASS(PhysicsTestMotionParameters3D, RefCounted);
+	GDCLASS(PhysicsTestMotionParameters3D, RefCounted)
 
 	PhysicsServer3D::MotionParameters parameters;
 
@@ -958,7 +958,7 @@ public:
 };
 
 class PhysicsTestMotionResult3D : public RefCounted {
-	GDCLASS(PhysicsTestMotionResult3D, RefCounted);
+	GDCLASS(PhysicsTestMotionResult3D, RefCounted)
 
 	PhysicsServer3D::MotionResult result;
 
@@ -987,7 +987,7 @@ public:
 };
 
 class PhysicsServer3DManager : public Object {
-	GDCLASS(PhysicsServer3DManager, Object);
+	GDCLASS(PhysicsServer3DManager, Object)
 
 	static PhysicsServer3DManager *singleton;
 

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -105,7 +105,7 @@ public:
 	virtual double get_frame_delta_time() const = 0;
 	virtual double get_total_time() const = 0;
 
-	static bool is_low_end() { return low_end; };
+	static bool is_low_end() { return low_end; }
 	virtual bool is_xr_enabled() const;
 
 	static RendererCompositor *get_singleton() { return singleton; }

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -230,11 +230,11 @@ public:
 
 	RendererSceneOcclusionCull() {
 		singleton = this;
-	};
+	}
 
 	virtual ~RendererSceneOcclusionCull() {
 		singleton = nullptr;
-	};
+	}
 };
 
 #endif // RENDERER_SCENE_OCCLUSION_CULL_H

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -145,23 +145,23 @@ public:
 	static_assert(sizeof(m_name##ID) == sizeof(void *));
 
 	// Id types declared before anything else to prevent cyclic dependencies between the different concerns.
-	DEFINE_ID(Buffer);
-	DEFINE_ID(Texture);
-	DEFINE_ID(Sampler);
-	DEFINE_ID(VertexFormat);
-	DEFINE_ID(CommandQueue);
-	DEFINE_ID(CommandQueueFamily);
-	DEFINE_ID(CommandPool);
-	DEFINE_ID(CommandBuffer);
-	DEFINE_ID(SwapChain);
-	DEFINE_ID(Framebuffer);
-	DEFINE_ID(Shader);
-	DEFINE_ID(UniformSet);
-	DEFINE_ID(Pipeline);
-	DEFINE_ID(RenderPass);
-	DEFINE_ID(QueryPool);
-	DEFINE_ID(Fence);
-	DEFINE_ID(Semaphore);
+	DEFINE_ID(Buffer)
+	DEFINE_ID(Texture)
+	DEFINE_ID(Sampler)
+	DEFINE_ID(VertexFormat)
+	DEFINE_ID(CommandQueue)
+	DEFINE_ID(CommandQueueFamily)
+	DEFINE_ID(CommandPool)
+	DEFINE_ID(CommandBuffer)
+	DEFINE_ID(SwapChain)
+	DEFINE_ID(Framebuffer)
+	DEFINE_ID(Shader)
+	DEFINE_ID(UniformSet)
+	DEFINE_ID(Pipeline)
+	DEFINE_ID(RenderPass)
+	DEFINE_ID(QueryPool)
+	DEFINE_ID(Fence)
+	DEFINE_ID(Semaphore)
 
 public:
 	/*****************/

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -768,11 +768,11 @@ public:
 	FUNC1(sub_surface_scattering_set_quality, SubSurfaceScatteringQuality)
 	FUNC2(sub_surface_scattering_set_scale, float, float)
 
-	FUNC1(positional_soft_shadow_filter_set_quality, ShadowQuality);
-	FUNC1(directional_soft_shadow_filter_set_quality, ShadowQuality);
-	FUNC1(decals_set_filter, RS::DecalFilter);
-	FUNC1(light_projectors_set_filter, RS::LightProjectorFilter);
-	FUNC1(lightmaps_set_bicubic_filter, bool);
+	FUNC1(positional_soft_shadow_filter_set_quality, ShadowQuality)
+	FUNC1(directional_soft_shadow_filter_set_quality, ShadowQuality)
+	FUNC1(decals_set_filter, RS::DecalFilter)
+	FUNC1(light_projectors_set_filter, RS::LightProjectorFilter)
+	FUNC1(lightmaps_set_bicubic_filter, bool)
 
 	/* CAMERA ATTRIBUTES */
 

--- a/servers/rendering/storage/camera_attributes_storage.h
+++ b/servers/rendering/storage/camera_attributes_storage.h
@@ -72,8 +72,8 @@ public:
 	RendererCameraAttributes();
 	~RendererCameraAttributes();
 
-	CameraAttributes *get_camera_attributes(RID p_rid) { return camera_attributes_owner.get_or_null(p_rid); };
-	bool owns_camera_attributes(RID p_rid) { return camera_attributes_owner.owns(p_rid); };
+	CameraAttributes *get_camera_attributes(RID p_rid) { return camera_attributes_owner.get_or_null(p_rid); }
+	bool owns_camera_attributes(RID p_rid) { return camera_attributes_owner.owns(p_rid); }
 
 	RID camera_attributes_allocate();
 	void camera_attributes_initialize(RID p_rid);

--- a/servers/rendering/storage/render_data.h
+++ b/servers/rendering/storage/render_data.h
@@ -36,7 +36,7 @@
 #include "render_scene_data.h"
 
 class RenderData : public Object {
-	GDCLASS(RenderData, Object);
+	GDCLASS(RenderData, Object)
 
 protected:
 	static void _bind_methods();
@@ -50,7 +50,7 @@ public:
 };
 
 class RenderDataExtension : public RenderData {
-	GDCLASS(RenderDataExtension, RenderData);
+	GDCLASS(RenderDataExtension, RenderData)
 
 protected:
 	static void _bind_methods();

--- a/servers/rendering/storage/render_scene_buffers.h
+++ b/servers/rendering/storage/render_scene_buffers.h
@@ -35,7 +35,7 @@
 #include "servers/rendering_server.h"
 
 class RenderSceneBuffersConfiguration : public RefCounted {
-	GDCLASS(RenderSceneBuffersConfiguration, RefCounted);
+	GDCLASS(RenderSceneBuffersConfiguration, RefCounted)
 
 private:
 	RID render_target;
@@ -95,7 +95,7 @@ public:
 };
 
 class RenderSceneBuffers : public RefCounted {
-	GDCLASS(RenderSceneBuffers, RefCounted);
+	GDCLASS(RenderSceneBuffers, RefCounted)
 
 protected:
 	static void _bind_methods();
@@ -113,7 +113,7 @@ public:
 };
 
 class RenderSceneBuffersExtension : public RenderSceneBuffers {
-	GDCLASS(RenderSceneBuffersExtension, RenderSceneBuffers);
+	GDCLASS(RenderSceneBuffersExtension, RenderSceneBuffers)
 
 protected:
 	static void _bind_methods();

--- a/servers/rendering/storage/render_scene_data.h
+++ b/servers/rendering/storage/render_scene_data.h
@@ -37,7 +37,7 @@
 #include "core/object/script_language.h"
 
 class RenderSceneData : public Object {
-	GDCLASS(RenderSceneData, Object);
+	GDCLASS(RenderSceneData, Object)
 
 protected:
 	static void _bind_methods();
@@ -54,7 +54,7 @@ public:
 };
 
 class RenderSceneDataExtension : public RenderSceneData {
-	GDCLASS(RenderSceneDataExtension, RenderSceneData);
+	GDCLASS(RenderSceneDataExtension, RenderSceneData)
 
 protected:
 	static void _bind_methods();

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -61,7 +61,7 @@ template <typename T>
 class TypedArray;
 
 class RenderingServer : public Object {
-	GDCLASS(RenderingServer, Object);
+	GDCLASS(RenderingServer, Object)
 
 	static RenderingServer *singleton;
 

--- a/servers/text/text_server_dummy.h
+++ b/servers/text/text_server_dummy.h
@@ -36,7 +36,7 @@
 /*************************************************************************/
 
 class TextServerDummy : public TextServerExtension {
-	GDCLASS(TextServerDummy, TextServerExtension);
+	GDCLASS(TextServerDummy, TextServerExtension)
 	_THREAD_SAFE_CLASS_
 
 public:
@@ -88,7 +88,7 @@ public:
 	virtual int64_t font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const override { return 0; }
 	virtual bool font_has_char(const RID &p_font_rid, int64_t p_char) const override { return false; }
 	virtual String font_get_supported_chars(const RID &p_font_rid) const override { return String(); }
-	virtual PackedInt32Array font_get_supported_glyphs(const RID &p_font_rid) const override { return PackedInt32Array(); };
+	virtual PackedInt32Array font_get_supported_glyphs(const RID &p_font_rid) const override { return PackedInt32Array(); }
 	virtual void font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const override {}
 	virtual void font_draw_glyph_outline(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const override {}
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -38,7 +38,7 @@
 #include "servers/text_server.h"
 
 class TextServerExtension : public TextServer {
-	GDCLASS(TextServerExtension, TextServer);
+	GDCLASS(TextServerExtension, TextServer)
 
 protected:
 	_THREAD_SAFE_CLASS_
@@ -49,456 +49,456 @@ public:
 	virtual bool has_feature(Feature p_feature) const override;
 	virtual String get_name() const override;
 	virtual int64_t get_features() const override;
-	GDVIRTUAL1RC(bool, _has_feature, Feature);
-	GDVIRTUAL0RC(String, _get_name);
-	GDVIRTUAL0RC(int64_t, _get_features);
+	GDVIRTUAL1RC(bool, _has_feature, Feature)
+	GDVIRTUAL0RC(String, _get_name)
+	GDVIRTUAL0RC(int64_t, _get_features)
 
 	virtual void free_rid(const RID &p_rid) override;
 	virtual bool has(const RID &p_rid) override;
 	virtual bool load_support_data(const String &p_filename) override;
-	GDVIRTUAL1(_free_rid, RID);
-	GDVIRTUAL1R(bool, _has, RID);
-	GDVIRTUAL1R(bool, _load_support_data, const String &);
+	GDVIRTUAL1(_free_rid, RID)
+	GDVIRTUAL1R(bool, _has, RID)
+	GDVIRTUAL1R(bool, _load_support_data, const String &)
 
 	virtual String get_support_data_filename() const override;
 	virtual String get_support_data_info() const override;
 	virtual bool save_support_data(const String &p_filename) const override;
-	GDVIRTUAL0RC(String, _get_support_data_filename);
-	GDVIRTUAL0RC(String, _get_support_data_info);
-	GDVIRTUAL1RC(bool, _save_support_data, const String &);
+	GDVIRTUAL0RC(String, _get_support_data_filename)
+	GDVIRTUAL0RC(String, _get_support_data_info)
+	GDVIRTUAL1RC(bool, _save_support_data, const String &)
 
 	virtual bool is_locale_right_to_left(const String &p_locale) const override;
-	GDVIRTUAL1RC(bool, _is_locale_right_to_left, const String &);
+	GDVIRTUAL1RC(bool, _is_locale_right_to_left, const String &)
 
 	virtual int64_t name_to_tag(const String &p_name) const override;
 	virtual String tag_to_name(int64_t p_tag) const override;
-	GDVIRTUAL1RC(int64_t, _name_to_tag, const String &);
-	GDVIRTUAL1RC(String, _tag_to_name, int64_t);
+	GDVIRTUAL1RC(int64_t, _name_to_tag, const String &)
+	GDVIRTUAL1RC(String, _tag_to_name, int64_t)
 
 	/* Font interface */
 
 	virtual RID create_font() override;
-	GDVIRTUAL0R(RID, _create_font);
+	GDVIRTUAL0R(RID, _create_font)
 
 	virtual RID create_font_linked_variation(const RID &p_font_rid) override;
-	GDVIRTUAL1R(RID, _create_font_linked_variation, RID);
+	GDVIRTUAL1R(RID, _create_font_linked_variation, RID)
 
 	virtual void font_set_data(const RID &p_font_rid, const PackedByteArray &p_data) override;
 	virtual void font_set_data_ptr(const RID &p_font_rid, const uint8_t *p_data_ptr, int64_t p_data_size) override;
-	GDVIRTUAL2(_font_set_data, RID, const PackedByteArray &);
-	GDVIRTUAL3(_font_set_data_ptr, RID, GDExtensionConstPtr<const uint8_t>, int64_t);
+	GDVIRTUAL2(_font_set_data, RID, const PackedByteArray &)
+	GDVIRTUAL3(_font_set_data_ptr, RID, GDExtensionConstPtr<const uint8_t>, int64_t)
 
 	virtual void font_set_face_index(const RID &p_font_rid, int64_t p_index) override;
 	virtual int64_t font_get_face_index(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_face_index, RID, int64_t);
-	GDVIRTUAL1RC(int64_t, _font_get_face_index, RID);
+	GDVIRTUAL2(_font_set_face_index, RID, int64_t)
+	GDVIRTUAL1RC(int64_t, _font_get_face_index, RID)
 
 	virtual int64_t font_get_face_count(const RID &p_font_rid) const override;
-	GDVIRTUAL1RC(int64_t, _font_get_face_count, RID);
+	GDVIRTUAL1RC(int64_t, _font_get_face_count, RID)
 
 	virtual void font_set_style(const RID &p_font_rid, BitField<FontStyle> p_style) override;
 	virtual BitField<FontStyle> font_get_style(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_style, RID, BitField<FontStyle>);
-	GDVIRTUAL1RC(BitField<FontStyle>, _font_get_style, RID);
+	GDVIRTUAL2(_font_set_style, RID, BitField<FontStyle>)
+	GDVIRTUAL1RC(BitField<FontStyle>, _font_get_style, RID)
 
 	virtual void font_set_name(const RID &p_font_rid, const String &p_name) override;
 	virtual String font_get_name(const RID &p_font_rid) const override;
 	virtual Dictionary font_get_ot_name_strings(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_name, RID, const String &);
-	GDVIRTUAL1RC(String, _font_get_name, RID);
-	GDVIRTUAL1RC(Dictionary, _font_get_ot_name_strings, RID);
+	GDVIRTUAL2(_font_set_name, RID, const String &)
+	GDVIRTUAL1RC(String, _font_get_name, RID)
+	GDVIRTUAL1RC(Dictionary, _font_get_ot_name_strings, RID)
 
 	virtual void font_set_style_name(const RID &p_font_rid, const String &p_name) override;
 	virtual String font_get_style_name(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_style_name, RID, const String &);
-	GDVIRTUAL1RC(String, _font_get_style_name, RID);
+	GDVIRTUAL2(_font_set_style_name, RID, const String &)
+	GDVIRTUAL1RC(String, _font_get_style_name, RID)
 
 	virtual void font_set_weight(const RID &p_font_rid, int64_t p_weight) override;
 	virtual int64_t font_get_weight(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_weight, RID, int64_t);
-	GDVIRTUAL1RC(int64_t, _font_get_weight, RID);
+	GDVIRTUAL2(_font_set_weight, RID, int64_t)
+	GDVIRTUAL1RC(int64_t, _font_get_weight, RID)
 
 	virtual void font_set_stretch(const RID &p_font_rid, int64_t p_stretch) override;
 	virtual int64_t font_get_stretch(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_stretch, RID, int64_t);
-	GDVIRTUAL1RC(int64_t, _font_get_stretch, RID);
+	GDVIRTUAL2(_font_set_stretch, RID, int64_t)
+	GDVIRTUAL1RC(int64_t, _font_get_stretch, RID)
 
 	virtual void font_set_antialiasing(const RID &p_font_rid, TextServer::FontAntialiasing p_antialiasing) override;
 	virtual TextServer::FontAntialiasing font_get_antialiasing(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_antialiasing, RID, TextServer::FontAntialiasing);
-	GDVIRTUAL1RC(TextServer::FontAntialiasing, _font_get_antialiasing, RID);
+	GDVIRTUAL2(_font_set_antialiasing, RID, TextServer::FontAntialiasing)
+	GDVIRTUAL1RC(TextServer::FontAntialiasing, _font_get_antialiasing, RID)
 
 	virtual void font_set_disable_embedded_bitmaps(const RID &p_font_rid, bool p_disable_embedded_bitmaps) override;
 	virtual bool font_get_disable_embedded_bitmaps(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_disable_embedded_bitmaps, RID, bool);
-	GDVIRTUAL1RC(bool, _font_get_disable_embedded_bitmaps, RID);
+	GDVIRTUAL2(_font_set_disable_embedded_bitmaps, RID, bool)
+	GDVIRTUAL1RC(bool, _font_get_disable_embedded_bitmaps, RID)
 
 	virtual void font_set_generate_mipmaps(const RID &p_font_rid, bool p_generate_mipmaps) override;
 	virtual bool font_get_generate_mipmaps(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_generate_mipmaps, RID, bool);
-	GDVIRTUAL1RC(bool, _font_get_generate_mipmaps, RID);
+	GDVIRTUAL2(_font_set_generate_mipmaps, RID, bool)
+	GDVIRTUAL1RC(bool, _font_get_generate_mipmaps, RID)
 
 	virtual void font_set_multichannel_signed_distance_field(const RID &p_font_rid, bool p_msdf) override;
 	virtual bool font_is_multichannel_signed_distance_field(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_multichannel_signed_distance_field, RID, bool);
-	GDVIRTUAL1RC(bool, _font_is_multichannel_signed_distance_field, RID);
+	GDVIRTUAL2(_font_set_multichannel_signed_distance_field, RID, bool)
+	GDVIRTUAL1RC(bool, _font_is_multichannel_signed_distance_field, RID)
 
 	virtual void font_set_msdf_pixel_range(const RID &p_font_rid, int64_t p_msdf_pixel_range) override;
 	virtual int64_t font_get_msdf_pixel_range(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_msdf_pixel_range, RID, int64_t);
-	GDVIRTUAL1RC(int64_t, _font_get_msdf_pixel_range, RID);
+	GDVIRTUAL2(_font_set_msdf_pixel_range, RID, int64_t)
+	GDVIRTUAL1RC(int64_t, _font_get_msdf_pixel_range, RID)
 
 	virtual void font_set_msdf_size(const RID &p_font_rid, int64_t p_msdf_size) override;
 	virtual int64_t font_get_msdf_size(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_msdf_size, RID, int64_t);
-	GDVIRTUAL1RC(int64_t, _font_get_msdf_size, RID);
+	GDVIRTUAL2(_font_set_msdf_size, RID, int64_t)
+	GDVIRTUAL1RC(int64_t, _font_get_msdf_size, RID)
 
 	virtual void font_set_fixed_size(const RID &p_font_rid, int64_t p_fixed_size) override;
 	virtual int64_t font_get_fixed_size(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_fixed_size, RID, int64_t);
-	GDVIRTUAL1RC(int64_t, _font_get_fixed_size, RID);
+	GDVIRTUAL2(_font_set_fixed_size, RID, int64_t)
+	GDVIRTUAL1RC(int64_t, _font_get_fixed_size, RID)
 
 	virtual void font_set_fixed_size_scale_mode(const RID &p_font_rid, FixedSizeScaleMode p_fixed_size_scale) override;
 	virtual FixedSizeScaleMode font_get_fixed_size_scale_mode(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_fixed_size_scale_mode, RID, FixedSizeScaleMode);
-	GDVIRTUAL1RC(FixedSizeScaleMode, _font_get_fixed_size_scale_mode, RID);
+	GDVIRTUAL2(_font_set_fixed_size_scale_mode, RID, FixedSizeScaleMode)
+	GDVIRTUAL1RC(FixedSizeScaleMode, _font_get_fixed_size_scale_mode, RID)
 
 	virtual void font_set_subpixel_positioning(const RID &p_font_rid, SubpixelPositioning p_subpixel) override;
 	virtual SubpixelPositioning font_get_subpixel_positioning(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_subpixel_positioning, RID, SubpixelPositioning);
-	GDVIRTUAL1RC(SubpixelPositioning, _font_get_subpixel_positioning, RID);
+	GDVIRTUAL2(_font_set_subpixel_positioning, RID, SubpixelPositioning)
+	GDVIRTUAL1RC(SubpixelPositioning, _font_get_subpixel_positioning, RID)
 
 	virtual void font_set_embolden(const RID &p_font_rid, double p_strength) override;
 	virtual double font_get_embolden(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_embolden, RID, double);
-	GDVIRTUAL1RC(double, _font_get_embolden, RID);
+	GDVIRTUAL2(_font_set_embolden, RID, double)
+	GDVIRTUAL1RC(double, _font_get_embolden, RID)
 
 	virtual void font_set_spacing(const RID &p_font_rid, SpacingType p_spacing, int64_t p_value) override;
 	virtual int64_t font_get_spacing(const RID &p_font_rid, SpacingType p_spacing) const override;
-	GDVIRTUAL3(_font_set_spacing, const RID &, SpacingType, int64_t);
-	GDVIRTUAL2RC(int64_t, _font_get_spacing, const RID &, SpacingType);
+	GDVIRTUAL3(_font_set_spacing, const RID &, SpacingType, int64_t)
+	GDVIRTUAL2RC(int64_t, _font_get_spacing, const RID &, SpacingType)
 
 	virtual void font_set_baseline_offset(const RID &p_font_rid, double p_baseline_offset) override;
 	virtual double font_get_baseline_offset(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_baseline_offset, const RID &, double);
-	GDVIRTUAL1RC(double, _font_get_baseline_offset, const RID &);
+	GDVIRTUAL2(_font_set_baseline_offset, const RID &, double)
+	GDVIRTUAL1RC(double, _font_get_baseline_offset, const RID &)
 
 	virtual void font_set_transform(const RID &p_font_rid, const Transform2D &p_transform) override;
 	virtual Transform2D font_get_transform(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_transform, RID, Transform2D);
-	GDVIRTUAL1RC(Transform2D, _font_get_transform, RID);
+	GDVIRTUAL2(_font_set_transform, RID, Transform2D)
+	GDVIRTUAL1RC(Transform2D, _font_get_transform, RID)
 
 	virtual void font_set_allow_system_fallback(const RID &p_font_rid, bool p_allow_system_fallback) override;
 	virtual bool font_is_allow_system_fallback(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_allow_system_fallback, RID, bool);
-	GDVIRTUAL1RC(bool, _font_is_allow_system_fallback, RID);
+	GDVIRTUAL2(_font_set_allow_system_fallback, RID, bool)
+	GDVIRTUAL1RC(bool, _font_is_allow_system_fallback, RID)
 
 	virtual void font_set_force_autohinter(const RID &p_font_rid, bool p_force_autohinter) override;
 	virtual bool font_is_force_autohinter(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_force_autohinter, RID, bool);
-	GDVIRTUAL1RC(bool, _font_is_force_autohinter, RID);
+	GDVIRTUAL2(_font_set_force_autohinter, RID, bool)
+	GDVIRTUAL1RC(bool, _font_is_force_autohinter, RID)
 
 	virtual void font_set_hinting(const RID &p_font_rid, Hinting p_hinting) override;
 	virtual Hinting font_get_hinting(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_hinting, RID, Hinting);
-	GDVIRTUAL1RC(Hinting, _font_get_hinting, RID);
+	GDVIRTUAL2(_font_set_hinting, RID, Hinting)
+	GDVIRTUAL1RC(Hinting, _font_get_hinting, RID)
 
 	virtual void font_set_variation_coordinates(const RID &p_font_rid, const Dictionary &p_variation_coordinates) override;
 	virtual Dictionary font_get_variation_coordinates(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_variation_coordinates, RID, Dictionary);
-	GDVIRTUAL1RC(Dictionary, _font_get_variation_coordinates, RID);
+	GDVIRTUAL2(_font_set_variation_coordinates, RID, Dictionary)
+	GDVIRTUAL1RC(Dictionary, _font_get_variation_coordinates, RID)
 
 	virtual void font_set_oversampling(const RID &p_font_rid, double p_oversampling) override;
 	virtual double font_get_oversampling(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_oversampling, RID, double);
-	GDVIRTUAL1RC(double, _font_get_oversampling, RID);
+	GDVIRTUAL2(_font_set_oversampling, RID, double)
+	GDVIRTUAL1RC(double, _font_get_oversampling, RID)
 
 	virtual TypedArray<Vector2i> font_get_size_cache_list(const RID &p_font_rid) const override;
 	virtual void font_clear_size_cache(const RID &p_font_rid) override;
 	virtual void font_remove_size_cache(const RID &p_font_rid, const Vector2i &p_size) override;
-	GDVIRTUAL1RC(TypedArray<Vector2i>, _font_get_size_cache_list, RID);
-	GDVIRTUAL1(_font_clear_size_cache, RID);
-	GDVIRTUAL2(_font_remove_size_cache, RID, const Vector2i &);
+	GDVIRTUAL1RC(TypedArray<Vector2i>, _font_get_size_cache_list, RID)
+	GDVIRTUAL1(_font_clear_size_cache, RID)
+	GDVIRTUAL2(_font_remove_size_cache, RID, const Vector2i &)
 
 	virtual void font_set_ascent(const RID &p_font_rid, int64_t p_size, double p_ascent) override;
 	virtual double font_get_ascent(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_ascent, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_ascent, RID, int64_t);
+	GDVIRTUAL3(_font_set_ascent, RID, int64_t, double)
+	GDVIRTUAL2RC(double, _font_get_ascent, RID, int64_t)
 
 	virtual void font_set_descent(const RID &p_font_rid, int64_t p_size, double p_descent) override;
 	virtual double font_get_descent(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_descent, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_descent, RID, int64_t);
+	GDVIRTUAL3(_font_set_descent, RID, int64_t, double)
+	GDVIRTUAL2RC(double, _font_get_descent, RID, int64_t)
 
 	virtual void font_set_underline_position(const RID &p_font_rid, int64_t p_size, double p_underline_position) override;
 	virtual double font_get_underline_position(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_underline_position, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_underline_position, RID, int64_t);
+	GDVIRTUAL3(_font_set_underline_position, RID, int64_t, double)
+	GDVIRTUAL2RC(double, _font_get_underline_position, RID, int64_t)
 
 	virtual void font_set_underline_thickness(const RID &p_font_rid, int64_t p_size, double p_underline_thickness) override;
 	virtual double font_get_underline_thickness(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_underline_thickness, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_underline_thickness, RID, int64_t);
+	GDVIRTUAL3(_font_set_underline_thickness, RID, int64_t, double)
+	GDVIRTUAL2RC(double, _font_get_underline_thickness, RID, int64_t)
 
 	virtual void font_set_scale(const RID &p_font_rid, int64_t p_size, double p_scale) override;
 	virtual double font_get_scale(const RID &p_font_rid, int64_t p_size) const override;
-	GDVIRTUAL3(_font_set_scale, RID, int64_t, double);
-	GDVIRTUAL2RC(double, _font_get_scale, RID, int64_t);
+	GDVIRTUAL3(_font_set_scale, RID, int64_t, double)
+	GDVIRTUAL2RC(double, _font_get_scale, RID, int64_t)
 
 	virtual int64_t font_get_texture_count(const RID &p_font_rid, const Vector2i &p_size) const override;
 	virtual void font_clear_textures(const RID &p_font_rid, const Vector2i &p_size) override;
 	virtual void font_remove_texture(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) override;
-	GDVIRTUAL2RC(int64_t, _font_get_texture_count, RID, const Vector2i &);
-	GDVIRTUAL2(_font_clear_textures, RID, const Vector2i &);
-	GDVIRTUAL3(_font_remove_texture, RID, const Vector2i &, int64_t);
+	GDVIRTUAL2RC(int64_t, _font_get_texture_count, RID, const Vector2i &)
+	GDVIRTUAL2(_font_clear_textures, RID, const Vector2i &)
+	GDVIRTUAL3(_font_remove_texture, RID, const Vector2i &, int64_t)
 
 	virtual void font_set_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const Ref<Image> &p_image) override;
 	virtual Ref<Image> font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const override;
-	GDVIRTUAL4(_font_set_texture_image, RID, const Vector2i &, int64_t, const Ref<Image> &);
-	GDVIRTUAL3RC(Ref<Image>, _font_get_texture_image, RID, const Vector2i &, int64_t);
+	GDVIRTUAL4(_font_set_texture_image, RID, const Vector2i &, int64_t, const Ref<Image> &)
+	GDVIRTUAL3RC(Ref<Image>, _font_get_texture_image, RID, const Vector2i &, int64_t)
 
 	virtual void font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offset) override;
 	virtual PackedInt32Array font_get_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const override;
-	GDVIRTUAL4(_font_set_texture_offsets, RID, const Vector2i &, int64_t, const PackedInt32Array &);
-	GDVIRTUAL3RC(PackedInt32Array, _font_get_texture_offsets, RID, const Vector2i &, int64_t);
+	GDVIRTUAL4(_font_set_texture_offsets, RID, const Vector2i &, int64_t, const PackedInt32Array &)
+	GDVIRTUAL3RC(PackedInt32Array, _font_get_texture_offsets, RID, const Vector2i &, int64_t)
 
 	virtual PackedInt32Array font_get_glyph_list(const RID &p_font_rid, const Vector2i &p_size) const override;
 	virtual void font_clear_glyphs(const RID &p_font_rid, const Vector2i &p_size) override;
 	virtual void font_remove_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) override;
-	GDVIRTUAL2RC(PackedInt32Array, _font_get_glyph_list, RID, const Vector2i &);
-	GDVIRTUAL2(_font_clear_glyphs, RID, const Vector2i &);
-	GDVIRTUAL3(_font_remove_glyph, RID, const Vector2i &, int64_t);
+	GDVIRTUAL2RC(PackedInt32Array, _font_get_glyph_list, RID, const Vector2i &)
+	GDVIRTUAL2(_font_clear_glyphs, RID, const Vector2i &)
+	GDVIRTUAL3(_font_remove_glyph, RID, const Vector2i &, int64_t)
 
 	virtual Vector2 font_get_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_advance(const RID &p_font_rid, int64_t p_size, int64_t p_glyph, const Vector2 &p_advance) override;
-	GDVIRTUAL3RC(Vector2, _font_get_glyph_advance, RID, int64_t, int64_t);
-	GDVIRTUAL4(_font_set_glyph_advance, RID, int64_t, int64_t, const Vector2 &);
+	GDVIRTUAL3RC(Vector2, _font_get_glyph_advance, RID, int64_t, int64_t)
+	GDVIRTUAL4(_font_set_glyph_advance, RID, int64_t, int64_t, const Vector2 &)
 
 	virtual Vector2 font_get_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_offset(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_offset) override;
-	GDVIRTUAL3RC(Vector2, _font_get_glyph_offset, RID, const Vector2i &, int64_t);
-	GDVIRTUAL4(_font_set_glyph_offset, RID, const Vector2i &, int64_t, const Vector2 &);
+	GDVIRTUAL3RC(Vector2, _font_get_glyph_offset, RID, const Vector2i &, int64_t)
+	GDVIRTUAL4(_font_set_glyph_offset, RID, const Vector2i &, int64_t, const Vector2 &)
 
 	virtual Vector2 font_get_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Vector2 &p_gl_size) override;
-	GDVIRTUAL3RC(Vector2, _font_get_glyph_size, RID, const Vector2i &, int64_t);
-	GDVIRTUAL4(_font_set_glyph_size, RID, const Vector2i &, int64_t, const Vector2 &);
+	GDVIRTUAL3RC(Vector2, _font_get_glyph_size, RID, const Vector2i &, int64_t)
+	GDVIRTUAL4(_font_set_glyph_size, RID, const Vector2i &, int64_t, const Vector2 &)
 
 	virtual Rect2 font_get_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_uv_rect(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, const Rect2 &p_uv_rect) override;
-	GDVIRTUAL3RC(Rect2, _font_get_glyph_uv_rect, RID, const Vector2i &, int64_t);
-	GDVIRTUAL4(_font_set_glyph_uv_rect, RID, const Vector2i &, int64_t, const Rect2 &);
+	GDVIRTUAL3RC(Rect2, _font_get_glyph_uv_rect, RID, const Vector2i &, int64_t)
+	GDVIRTUAL4(_font_set_glyph_uv_rect, RID, const Vector2i &, int64_t, const Rect2 &)
 
 	virtual int64_t font_get_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
 	virtual void font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) override;
-	GDVIRTUAL3RC(int64_t, _font_get_glyph_texture_idx, RID, const Vector2i &, int64_t);
-	GDVIRTUAL4(_font_set_glyph_texture_idx, RID, const Vector2i &, int64_t, int64_t);
+	GDVIRTUAL3RC(int64_t, _font_get_glyph_texture_idx, RID, const Vector2i &, int64_t)
+	GDVIRTUAL4(_font_set_glyph_texture_idx, RID, const Vector2i &, int64_t, int64_t)
 
 	virtual RID font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
-	GDVIRTUAL3RC(RID, _font_get_glyph_texture_rid, RID, const Vector2i &, int64_t);
+	GDVIRTUAL3RC(RID, _font_get_glyph_texture_rid, RID, const Vector2i &, int64_t)
 
 	virtual Size2 font_get_glyph_texture_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override;
-	GDVIRTUAL3RC(Size2, _font_get_glyph_texture_size, RID, const Vector2i &, int64_t);
+	GDVIRTUAL3RC(Size2, _font_get_glyph_texture_size, RID, const Vector2i &, int64_t)
 
 	virtual Dictionary font_get_glyph_contours(const RID &p_font, int64_t p_size, int64_t p_index) const override;
-	GDVIRTUAL3RC(Dictionary, _font_get_glyph_contours, RID, int64_t, int64_t);
+	GDVIRTUAL3RC(Dictionary, _font_get_glyph_contours, RID, int64_t, int64_t)
 
 	virtual TypedArray<Vector2i> font_get_kerning_list(const RID &p_font_rid, int64_t p_size) const override;
 	virtual void font_clear_kerning_map(const RID &p_font_rid, int64_t p_size) override;
 	virtual void font_remove_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) override;
-	GDVIRTUAL2RC(TypedArray<Vector2i>, _font_get_kerning_list, RID, int64_t);
-	GDVIRTUAL2(_font_clear_kerning_map, RID, int64_t);
-	GDVIRTUAL3(_font_remove_kerning, RID, int64_t, const Vector2i &);
+	GDVIRTUAL2RC(TypedArray<Vector2i>, _font_get_kerning_list, RID, int64_t)
+	GDVIRTUAL2(_font_clear_kerning_map, RID, int64_t)
+	GDVIRTUAL3(_font_remove_kerning, RID, int64_t, const Vector2i &)
 
 	virtual void font_set_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair, const Vector2 &p_kerning) override;
 	virtual Vector2 font_get_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) const override;
-	GDVIRTUAL4(_font_set_kerning, RID, int64_t, const Vector2i &, const Vector2 &);
-	GDVIRTUAL3RC(Vector2, _font_get_kerning, RID, int64_t, const Vector2i &);
+	GDVIRTUAL4(_font_set_kerning, RID, int64_t, const Vector2i &, const Vector2 &)
+	GDVIRTUAL3RC(Vector2, _font_get_kerning, RID, int64_t, const Vector2i &)
 
 	virtual int64_t font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector = 0) const override;
-	GDVIRTUAL4RC(int64_t, _font_get_glyph_index, RID, int64_t, int64_t, int64_t);
+	GDVIRTUAL4RC(int64_t, _font_get_glyph_index, RID, int64_t, int64_t, int64_t)
 
 	virtual int64_t font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const override;
-	GDVIRTUAL3RC(int64_t, _font_get_char_from_glyph_index, RID, int64_t, int64_t);
+	GDVIRTUAL3RC(int64_t, _font_get_char_from_glyph_index, RID, int64_t, int64_t)
 
 	virtual bool font_has_char(const RID &p_font_rid, int64_t p_char) const override;
 	virtual String font_get_supported_chars(const RID &p_font_rid) const override;
 	virtual PackedInt32Array font_get_supported_glyphs(const RID &p_font_rid) const override;
-	GDVIRTUAL2RC(bool, _font_has_char, RID, int64_t);
-	GDVIRTUAL1RC(String, _font_get_supported_chars, RID);
-	GDVIRTUAL1RC(PackedInt32Array, _font_get_supported_glyphs, RID);
+	GDVIRTUAL2RC(bool, _font_has_char, RID, int64_t)
+	GDVIRTUAL1RC(String, _font_get_supported_chars, RID)
+	GDVIRTUAL1RC(PackedInt32Array, _font_get_supported_glyphs, RID)
 
 	virtual void font_render_range(const RID &p_font, const Vector2i &p_size, int64_t p_start, int64_t p_end) override;
 	virtual void font_render_glyph(const RID &p_font_rid, const Vector2i &p_size, int64_t p_index) override;
-	GDVIRTUAL4(_font_render_range, RID, const Vector2i &, int64_t, int64_t);
-	GDVIRTUAL3(_font_render_glyph, RID, const Vector2i &, int64_t);
+	GDVIRTUAL4(_font_render_range, RID, const Vector2i &, int64_t, int64_t)
+	GDVIRTUAL3(_font_render_glyph, RID, const Vector2i &, int64_t)
 
 	virtual void font_draw_glyph(const RID &p_font, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1)) const override;
 	virtual void font_draw_glyph_outline(const RID &p_font, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1)) const override;
-	GDVIRTUAL6C(_font_draw_glyph, RID, RID, int64_t, const Vector2 &, int64_t, const Color &);
-	GDVIRTUAL7C(_font_draw_glyph_outline, RID, RID, int64_t, int64_t, const Vector2 &, int64_t, const Color &);
+	GDVIRTUAL6C(_font_draw_glyph, RID, RID, int64_t, const Vector2 &, int64_t, const Color &)
+	GDVIRTUAL7C(_font_draw_glyph_outline, RID, RID, int64_t, int64_t, const Vector2 &, int64_t, const Color &)
 
 	virtual bool font_is_language_supported(const RID &p_font_rid, const String &p_language) const override;
 	virtual void font_set_language_support_override(const RID &p_font_rid, const String &p_language, bool p_supported) override;
 	virtual bool font_get_language_support_override(const RID &p_font_rid, const String &p_language) override;
 	virtual void font_remove_language_support_override(const RID &p_font_rid, const String &p_language) override;
 	virtual PackedStringArray font_get_language_support_overrides(const RID &p_font_rid) override;
-	GDVIRTUAL2RC(bool, _font_is_language_supported, RID, const String &);
-	GDVIRTUAL3(_font_set_language_support_override, RID, const String &, bool);
-	GDVIRTUAL2R(bool, _font_get_language_support_override, RID, const String &);
-	GDVIRTUAL2(_font_remove_language_support_override, RID, const String &);
-	GDVIRTUAL1R(PackedStringArray, _font_get_language_support_overrides, RID);
+	GDVIRTUAL2RC(bool, _font_is_language_supported, RID, const String &)
+	GDVIRTUAL3(_font_set_language_support_override, RID, const String &, bool)
+	GDVIRTUAL2R(bool, _font_get_language_support_override, RID, const String &)
+	GDVIRTUAL2(_font_remove_language_support_override, RID, const String &)
+	GDVIRTUAL1R(PackedStringArray, _font_get_language_support_overrides, RID)
 
 	virtual bool font_is_script_supported(const RID &p_font_rid, const String &p_script) const override;
 	virtual void font_set_script_support_override(const RID &p_font_rid, const String &p_script, bool p_supported) override;
 	virtual bool font_get_script_support_override(const RID &p_font_rid, const String &p_script) override;
 	virtual void font_remove_script_support_override(const RID &p_font_rid, const String &p_script) override;
 	virtual PackedStringArray font_get_script_support_overrides(const RID &p_font_rid) override;
-	GDVIRTUAL2RC(bool, _font_is_script_supported, RID, const String &);
-	GDVIRTUAL3(_font_set_script_support_override, RID, const String &, bool);
-	GDVIRTUAL2R(bool, _font_get_script_support_override, RID, const String &);
-	GDVIRTUAL2(_font_remove_script_support_override, RID, const String &);
-	GDVIRTUAL1R(PackedStringArray, _font_get_script_support_overrides, RID);
+	GDVIRTUAL2RC(bool, _font_is_script_supported, RID, const String &)
+	GDVIRTUAL3(_font_set_script_support_override, RID, const String &, bool)
+	GDVIRTUAL2R(bool, _font_get_script_support_override, RID, const String &)
+	GDVIRTUAL2(_font_remove_script_support_override, RID, const String &)
+	GDVIRTUAL1R(PackedStringArray, _font_get_script_support_overrides, RID)
 
 	virtual void font_set_opentype_feature_overrides(const RID &p_font_rid, const Dictionary &p_overrides) override;
 	virtual Dictionary font_get_opentype_feature_overrides(const RID &p_font_rid) const override;
-	GDVIRTUAL2(_font_set_opentype_feature_overrides, RID, const Dictionary &);
-	GDVIRTUAL1RC(Dictionary, _font_get_opentype_feature_overrides, RID);
+	GDVIRTUAL2(_font_set_opentype_feature_overrides, RID, const Dictionary &)
+	GDVIRTUAL1RC(Dictionary, _font_get_opentype_feature_overrides, RID)
 
 	virtual Dictionary font_supported_feature_list(const RID &p_font_rid) const override;
 	virtual Dictionary font_supported_variation_list(const RID &p_font_rid) const override;
-	GDVIRTUAL1RC(Dictionary, _font_supported_feature_list, RID);
-	GDVIRTUAL1RC(Dictionary, _font_supported_variation_list, RID);
+	GDVIRTUAL1RC(Dictionary, _font_supported_feature_list, RID)
+	GDVIRTUAL1RC(Dictionary, _font_supported_variation_list, RID)
 
 	virtual double font_get_global_oversampling() const override;
 	virtual void font_set_global_oversampling(double p_oversampling) override;
-	GDVIRTUAL0RC(double, _font_get_global_oversampling);
-	GDVIRTUAL1(_font_set_global_oversampling, double);
+	GDVIRTUAL0RC(double, _font_get_global_oversampling)
+	GDVIRTUAL1(_font_set_global_oversampling, double)
 
 	virtual Vector2 get_hex_code_box_size(int64_t p_size, int64_t p_index) const override;
 	virtual void draw_hex_code_box(const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const override;
-	GDVIRTUAL2RC(Vector2, _get_hex_code_box_size, int64_t, int64_t);
-	GDVIRTUAL5C(_draw_hex_code_box, RID, int64_t, const Vector2 &, int64_t, const Color &);
+	GDVIRTUAL2RC(Vector2, _get_hex_code_box_size, int64_t, int64_t)
+	GDVIRTUAL5C(_draw_hex_code_box, RID, int64_t, const Vector2 &, int64_t, const Color &)
 
 	/* Shaped text buffer interface */
 
 	virtual RID create_shaped_text(Direction p_direction = DIRECTION_AUTO, Orientation p_orientation = ORIENTATION_HORIZONTAL) override;
-	GDVIRTUAL2R(RID, _create_shaped_text, Direction, Orientation);
+	GDVIRTUAL2R(RID, _create_shaped_text, Direction, Orientation)
 
 	virtual void shaped_text_clear(const RID &p_shaped) override;
-	GDVIRTUAL1(_shaped_text_clear, RID);
+	GDVIRTUAL1(_shaped_text_clear, RID)
 
 	virtual void shaped_text_set_direction(const RID &p_shaped, Direction p_direction = DIRECTION_AUTO) override;
 	virtual Direction shaped_text_get_direction(const RID &p_shaped) const override;
 	virtual Direction shaped_text_get_inferred_direction(const RID &p_shaped) const override;
-	GDVIRTUAL2(_shaped_text_set_direction, RID, Direction);
-	GDVIRTUAL1RC(Direction, _shaped_text_get_direction, RID);
-	GDVIRTUAL1RC(Direction, _shaped_text_get_inferred_direction, RID);
+	GDVIRTUAL2(_shaped_text_set_direction, RID, Direction)
+	GDVIRTUAL1RC(Direction, _shaped_text_get_direction, RID)
+	GDVIRTUAL1RC(Direction, _shaped_text_get_inferred_direction, RID)
 
 	virtual void shaped_text_set_bidi_override(const RID &p_shaped, const Array &p_override) override;
-	GDVIRTUAL2(_shaped_text_set_bidi_override, RID, const Array &);
+	GDVIRTUAL2(_shaped_text_set_bidi_override, RID, const Array &)
 
 	virtual void shaped_text_set_custom_punctuation(const RID &p_shaped, const String &p_punct) override;
 	virtual String shaped_text_get_custom_punctuation(const RID &p_shaped) const override;
-	GDVIRTUAL2(_shaped_text_set_custom_punctuation, RID, String);
-	GDVIRTUAL1RC(String, _shaped_text_get_custom_punctuation, RID);
+	GDVIRTUAL2(_shaped_text_set_custom_punctuation, RID, String)
+	GDVIRTUAL1RC(String, _shaped_text_get_custom_punctuation, RID)
 
 	virtual void shaped_text_set_custom_ellipsis(const RID &p_shaped, int64_t p_char) override;
 	virtual int64_t shaped_text_get_custom_ellipsis(const RID &p_shaped) const override;
-	GDVIRTUAL2(_shaped_text_set_custom_ellipsis, RID, int64_t);
-	GDVIRTUAL1RC(int64_t, _shaped_text_get_custom_ellipsis, RID);
+	GDVIRTUAL2(_shaped_text_set_custom_ellipsis, RID, int64_t)
+	GDVIRTUAL1RC(int64_t, _shaped_text_get_custom_ellipsis, RID)
 
 	virtual void shaped_text_set_orientation(const RID &p_shaped, Orientation p_orientation = ORIENTATION_HORIZONTAL) override;
 	virtual Orientation shaped_text_get_orientation(const RID &p_shaped) const override;
-	GDVIRTUAL2(_shaped_text_set_orientation, RID, Orientation);
-	GDVIRTUAL1RC(Orientation, _shaped_text_get_orientation, RID);
+	GDVIRTUAL2(_shaped_text_set_orientation, RID, Orientation)
+	GDVIRTUAL1RC(Orientation, _shaped_text_get_orientation, RID)
 
 	virtual void shaped_text_set_preserve_invalid(const RID &p_shaped, bool p_enabled) override;
 	virtual bool shaped_text_get_preserve_invalid(const RID &p_shaped) const override;
-	GDVIRTUAL2(_shaped_text_set_preserve_invalid, RID, bool);
-	GDVIRTUAL1RC(bool, _shaped_text_get_preserve_invalid, RID);
+	GDVIRTUAL2(_shaped_text_set_preserve_invalid, RID, bool)
+	GDVIRTUAL1RC(bool, _shaped_text_get_preserve_invalid, RID)
 
 	virtual void shaped_text_set_preserve_control(const RID &p_shaped, bool p_enabled) override;
 	virtual bool shaped_text_get_preserve_control(const RID &p_shaped) const override;
-	GDVIRTUAL2(_shaped_text_set_preserve_control, RID, bool);
-	GDVIRTUAL1RC(bool, _shaped_text_get_preserve_control, RID);
+	GDVIRTUAL2(_shaped_text_set_preserve_control, RID, bool)
+	GDVIRTUAL1RC(bool, _shaped_text_get_preserve_control, RID)
 
 	virtual void shaped_text_set_spacing(const RID &p_shaped, SpacingType p_spacing, int64_t p_value) override;
 	virtual int64_t shaped_text_get_spacing(const RID &p_shaped, SpacingType p_spacing) const override;
-	GDVIRTUAL3(_shaped_text_set_spacing, RID, SpacingType, int64_t);
-	GDVIRTUAL2RC(int64_t, _shaped_text_get_spacing, RID, SpacingType);
+	GDVIRTUAL3(_shaped_text_set_spacing, RID, SpacingType, int64_t)
+	GDVIRTUAL2RC(int64_t, _shaped_text_get_spacing, RID, SpacingType)
 
 	virtual bool shaped_text_add_string(const RID &p_shaped, const String &p_text, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary(), const String &p_language = "", const Variant &p_meta = Variant()) override;
 	virtual bool shaped_text_add_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, int64_t p_length = 1, double p_baseline = 0.0) override;
 	virtual bool shaped_text_resize_object(const RID &p_shaped, const Variant &p_key, const Size2 &p_size, InlineAlignment p_inline_align = INLINE_ALIGNMENT_CENTER, double p_baseline = 0.0) override;
-	GDVIRTUAL7R(bool, _shaped_text_add_string, RID, const String &, const TypedArray<RID> &, int64_t, const Dictionary &, const String &, const Variant &);
-	GDVIRTUAL6R(bool, _shaped_text_add_object, RID, const Variant &, const Size2 &, InlineAlignment, int64_t, double);
-	GDVIRTUAL5R(bool, _shaped_text_resize_object, RID, const Variant &, const Size2 &, InlineAlignment, double);
+	GDVIRTUAL7R(bool, _shaped_text_add_string, RID, const String &, const TypedArray<RID> &, int64_t, const Dictionary &, const String &, const Variant &)
+	GDVIRTUAL6R(bool, _shaped_text_add_object, RID, const Variant &, const Size2 &, InlineAlignment, int64_t, double)
+	GDVIRTUAL5R(bool, _shaped_text_resize_object, RID, const Variant &, const Size2 &, InlineAlignment, double)
 
 	virtual int64_t shaped_get_span_count(const RID &p_shaped) const override;
 	virtual Variant shaped_get_span_meta(const RID &p_shaped, int64_t p_index) const override;
 	virtual void shaped_set_span_update_font(const RID &p_shaped, int64_t p_index, const TypedArray<RID> &p_fonts, int64_t p_size, const Dictionary &p_opentype_features = Dictionary()) override;
-	GDVIRTUAL1RC(int64_t, _shaped_get_span_count, RID);
-	GDVIRTUAL2RC(Variant, _shaped_get_span_meta, RID, int64_t);
-	GDVIRTUAL5(_shaped_set_span_update_font, RID, int64_t, const TypedArray<RID> &, int64_t, const Dictionary &);
+	GDVIRTUAL1RC(int64_t, _shaped_get_span_count, RID)
+	GDVIRTUAL2RC(Variant, _shaped_get_span_meta, RID, int64_t)
+	GDVIRTUAL5(_shaped_set_span_update_font, RID, int64_t, const TypedArray<RID> &, int64_t, const Dictionary &)
 
 	virtual RID shaped_text_substr(const RID &p_shaped, int64_t p_start, int64_t p_length) const override;
 	virtual RID shaped_text_get_parent(const RID &p_shaped) const override;
-	GDVIRTUAL3RC(RID, _shaped_text_substr, RID, int64_t, int64_t);
-	GDVIRTUAL1RC(RID, _shaped_text_get_parent, RID);
+	GDVIRTUAL3RC(RID, _shaped_text_substr, RID, int64_t, int64_t)
+	GDVIRTUAL1RC(RID, _shaped_text_get_parent, RID)
 
 	virtual double shaped_text_fit_to_width(const RID &p_shaped, double p_width, BitField<TextServer::JustificationFlag> p_jst_flags = JUSTIFICATION_WORD_BOUND | JUSTIFICATION_KASHIDA) override;
 	virtual double shaped_text_tab_align(const RID &p_shaped, const PackedFloat32Array &p_tab_stops) override;
-	GDVIRTUAL3R(double, _shaped_text_fit_to_width, RID, double, BitField<TextServer::JustificationFlag>);
-	GDVIRTUAL2R(double, _shaped_text_tab_align, RID, const PackedFloat32Array &);
+	GDVIRTUAL3R(double, _shaped_text_fit_to_width, RID, double, BitField<TextServer::JustificationFlag>)
+	GDVIRTUAL2R(double, _shaped_text_tab_align, RID, const PackedFloat32Array &)
 
 	virtual bool shaped_text_shape(const RID &p_shaped) override;
 	virtual bool shaped_text_update_breaks(const RID &p_shaped) override;
 	virtual bool shaped_text_update_justification_ops(const RID &p_shaped) override;
-	GDVIRTUAL1R(bool, _shaped_text_shape, RID);
-	GDVIRTUAL1R(bool, _shaped_text_update_breaks, RID);
-	GDVIRTUAL1R(bool, _shaped_text_update_justification_ops, RID);
+	GDVIRTUAL1R(bool, _shaped_text_shape, RID)
+	GDVIRTUAL1R(bool, _shaped_text_update_breaks, RID)
+	GDVIRTUAL1R(bool, _shaped_text_update_justification_ops, RID)
 
 	virtual bool shaped_text_is_ready(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(bool, _shaped_text_is_ready, RID);
+	GDVIRTUAL1RC(bool, _shaped_text_is_ready, RID)
 
 	virtual const Glyph *shaped_text_get_glyphs(const RID &p_shaped) const override;
 	virtual const Glyph *shaped_text_sort_logical(const RID &p_shaped) override;
 	virtual int64_t shaped_text_get_glyph_count(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(GDExtensionConstPtr<const Glyph>, _shaped_text_get_glyphs, RID);
-	GDVIRTUAL1R(GDExtensionConstPtr<const Glyph>, _shaped_text_sort_logical, RID);
-	GDVIRTUAL1RC(int64_t, _shaped_text_get_glyph_count, RID);
+	GDVIRTUAL1RC(GDExtensionConstPtr<const Glyph>, _shaped_text_get_glyphs, RID)
+	GDVIRTUAL1R(GDExtensionConstPtr<const Glyph>, _shaped_text_sort_logical, RID)
+	GDVIRTUAL1RC(int64_t, _shaped_text_get_glyph_count, RID)
 
 	virtual Vector2i shaped_text_get_range(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(Vector2i, _shaped_text_get_range, RID);
+	GDVIRTUAL1RC(Vector2i, _shaped_text_get_range, RID)
 
 	virtual PackedInt32Array shaped_text_get_line_breaks_adv(const RID &p_shaped, const PackedFloat32Array &p_width, int64_t p_start = 0, bool p_once = true, BitField<TextServer::LineBreakFlag> p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const override;
 	virtual PackedInt32Array shaped_text_get_line_breaks(const RID &p_shaped, double p_width, int64_t p_start = 0, BitField<TextServer::LineBreakFlag> p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const override;
 	virtual PackedInt32Array shaped_text_get_word_breaks(const RID &p_shaped, BitField<TextServer::GraphemeFlag> p_grapheme_flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION, BitField<TextServer::GraphemeFlag> p_skip_grapheme_flags = GRAPHEME_IS_VIRTUAL) const override;
-	GDVIRTUAL5RC(PackedInt32Array, _shaped_text_get_line_breaks_adv, RID, const PackedFloat32Array &, int64_t, bool, BitField<TextServer::LineBreakFlag>);
-	GDVIRTUAL4RC(PackedInt32Array, _shaped_text_get_line_breaks, RID, double, int64_t, BitField<TextServer::LineBreakFlag>);
-	GDVIRTUAL3RC(PackedInt32Array, _shaped_text_get_word_breaks, RID, BitField<TextServer::GraphemeFlag>, BitField<TextServer::GraphemeFlag>);
+	GDVIRTUAL5RC(PackedInt32Array, _shaped_text_get_line_breaks_adv, RID, const PackedFloat32Array &, int64_t, bool, BitField<TextServer::LineBreakFlag>)
+	GDVIRTUAL4RC(PackedInt32Array, _shaped_text_get_line_breaks, RID, double, int64_t, BitField<TextServer::LineBreakFlag>)
+	GDVIRTUAL3RC(PackedInt32Array, _shaped_text_get_word_breaks, RID, BitField<TextServer::GraphemeFlag>, BitField<TextServer::GraphemeFlag>)
 
 	virtual int64_t shaped_text_get_trim_pos(const RID &p_shaped) const override;
 	virtual int64_t shaped_text_get_ellipsis_pos(const RID &p_shaped) const override;
 	virtual const Glyph *shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const override;
 	virtual int64_t shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(int64_t, _shaped_text_get_trim_pos, RID);
-	GDVIRTUAL1RC(int64_t, _shaped_text_get_ellipsis_pos, RID);
-	GDVIRTUAL1RC(GDExtensionConstPtr<const Glyph>, _shaped_text_get_ellipsis_glyphs, RID);
-	GDVIRTUAL1RC(int64_t, _shaped_text_get_ellipsis_glyph_count, RID);
+	GDVIRTUAL1RC(int64_t, _shaped_text_get_trim_pos, RID)
+	GDVIRTUAL1RC(int64_t, _shaped_text_get_ellipsis_pos, RID)
+	GDVIRTUAL1RC(GDExtensionConstPtr<const Glyph>, _shaped_text_get_ellipsis_glyphs, RID)
+	GDVIRTUAL1RC(int64_t, _shaped_text_get_ellipsis_glyph_count, RID)
 
 	virtual void shaped_text_overrun_trim_to_width(const RID &p_shaped, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) override;
-	GDVIRTUAL3(_shaped_text_overrun_trim_to_width, RID, double, BitField<TextServer::TextOverrunFlag>);
+	GDVIRTUAL3(_shaped_text_overrun_trim_to_width, RID, double, BitField<TextServer::TextOverrunFlag>)
 
 	virtual Array shaped_text_get_objects(const RID &p_shaped) const override;
 	virtual Rect2 shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const override;
 	virtual Vector2i shaped_text_get_object_range(const RID &p_shaped, const Variant &p_key) const override;
 	virtual int64_t shaped_text_get_object_glyph(const RID &p_shaped, const Variant &p_key) const override;
-	GDVIRTUAL1RC(Array, _shaped_text_get_objects, RID);
-	GDVIRTUAL2RC(Rect2, _shaped_text_get_object_rect, RID, const Variant &);
-	GDVIRTUAL2RC(Vector2i, _shaped_text_get_object_range, RID, const Variant &);
-	GDVIRTUAL2RC(int64_t, _shaped_text_get_object_glyph, RID, const Variant &);
+	GDVIRTUAL1RC(Array, _shaped_text_get_objects, RID)
+	GDVIRTUAL2RC(Rect2, _shaped_text_get_object_rect, RID, const Variant &)
+	GDVIRTUAL2RC(Vector2i, _shaped_text_get_object_range, RID, const Variant &)
+	GDVIRTUAL2RC(int64_t, _shaped_text_get_object_glyph, RID, const Variant &)
 
 	virtual Size2 shaped_text_get_size(const RID &p_shaped) const override;
 	virtual double shaped_text_get_ascent(const RID &p_shaped) const override;
@@ -506,85 +506,85 @@ public:
 	virtual double shaped_text_get_width(const RID &p_shaped) const override;
 	virtual double shaped_text_get_underline_position(const RID &p_shaped) const override;
 	virtual double shaped_text_get_underline_thickness(const RID &p_shaped) const override;
-	GDVIRTUAL1RC(Size2, _shaped_text_get_size, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_ascent, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_descent, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_width, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_underline_position, RID);
-	GDVIRTUAL1RC(double, _shaped_text_get_underline_thickness, RID);
+	GDVIRTUAL1RC(Size2, _shaped_text_get_size, RID)
+	GDVIRTUAL1RC(double, _shaped_text_get_ascent, RID)
+	GDVIRTUAL1RC(double, _shaped_text_get_descent, RID)
+	GDVIRTUAL1RC(double, _shaped_text_get_width, RID)
+	GDVIRTUAL1RC(double, _shaped_text_get_underline_position, RID)
+	GDVIRTUAL1RC(double, _shaped_text_get_underline_thickness, RID)
 
 	virtual Direction shaped_text_get_dominant_direction_in_range(const RID &p_shaped, int64_t p_start, int64_t p_end) const override;
-	GDVIRTUAL3RC(int64_t, _shaped_text_get_dominant_direction_in_range, RID, int64_t, int64_t);
+	GDVIRTUAL3RC(int64_t, _shaped_text_get_dominant_direction_in_range, RID, int64_t, int64_t)
 
 	virtual CaretInfo shaped_text_get_carets(const RID &p_shaped, int64_t p_position) const override;
 	virtual Vector<Vector2> shaped_text_get_selection(const RID &p_shaped, int64_t p_start, int64_t p_end) const override;
-	GDVIRTUAL3C(_shaped_text_get_carets, RID, int64_t, GDExtensionPtr<CaretInfo>);
-	GDVIRTUAL3RC(Vector<Vector2>, _shaped_text_get_selection, RID, int64_t, int64_t);
+	GDVIRTUAL3C(_shaped_text_get_carets, RID, int64_t, GDExtensionPtr<CaretInfo>)
+	GDVIRTUAL3RC(Vector<Vector2>, _shaped_text_get_selection, RID, int64_t, int64_t)
 
 	virtual int64_t shaped_text_hit_test_grapheme(const RID &p_shaped, double p_coords) const override;
 	virtual int64_t shaped_text_hit_test_position(const RID &p_shaped, double p_coords) const override;
-	GDVIRTUAL2RC(int64_t, _shaped_text_hit_test_grapheme, RID, double);
-	GDVIRTUAL2RC(int64_t, _shaped_text_hit_test_position, RID, double);
+	GDVIRTUAL2RC(int64_t, _shaped_text_hit_test_grapheme, RID, double)
+	GDVIRTUAL2RC(int64_t, _shaped_text_hit_test_position, RID, double)
 
 	virtual void shaped_text_draw(const RID &p_shaped, const RID &p_canvas, const Vector2 &p_pos, double p_clip_l = -1.0, double p_clip_r = -1.0, const Color &p_color = Color(1, 1, 1)) const override;
 	virtual void shaped_text_draw_outline(const RID &p_shaped, const RID &p_canvas, const Vector2 &p_pos, double p_clip_l = -1.0, double p_clip_r = -1.0, int64_t p_outline_size = 1, const Color &p_color = Color(1, 1, 1)) const override;
-	GDVIRTUAL6C(_shaped_text_draw, RID, RID, const Vector2 &, double, double, const Color &);
-	GDVIRTUAL7C(_shaped_text_draw_outline, RID, RID, const Vector2 &, double, double, int64_t, const Color &);
+	GDVIRTUAL6C(_shaped_text_draw, RID, RID, const Vector2 &, double, double, const Color &)
+	GDVIRTUAL7C(_shaped_text_draw_outline, RID, RID, const Vector2 &, double, double, int64_t, const Color &)
 
 	virtual Vector2 shaped_text_get_grapheme_bounds(const RID &p_shaped, int64_t p_pos) const override;
 	virtual int64_t shaped_text_next_grapheme_pos(const RID &p_shaped, int64_t p_pos) const override;
 	virtual int64_t shaped_text_prev_grapheme_pos(const RID &p_shaped, int64_t p_pos) const override;
-	GDVIRTUAL2RC(Vector2, _shaped_text_get_grapheme_bounds, RID, int64_t);
-	GDVIRTUAL2RC(int64_t, _shaped_text_next_grapheme_pos, RID, int64_t);
-	GDVIRTUAL2RC(int64_t, _shaped_text_prev_grapheme_pos, RID, int64_t);
+	GDVIRTUAL2RC(Vector2, _shaped_text_get_grapheme_bounds, RID, int64_t)
+	GDVIRTUAL2RC(int64_t, _shaped_text_next_grapheme_pos, RID, int64_t)
+	GDVIRTUAL2RC(int64_t, _shaped_text_prev_grapheme_pos, RID, int64_t)
 
 	virtual PackedInt32Array shaped_text_get_character_breaks(const RID &p_shaped) const override;
 	virtual int64_t shaped_text_next_character_pos(const RID &p_shaped, int64_t p_pos) const override;
 	virtual int64_t shaped_text_prev_character_pos(const RID &p_shaped, int64_t p_pos) const override;
 	virtual int64_t shaped_text_closest_character_pos(const RID &p_shaped, int64_t p_pos) const override;
-	GDVIRTUAL1RC(PackedInt32Array, _shaped_text_get_character_breaks, RID);
-	GDVIRTUAL2RC(int64_t, _shaped_text_next_character_pos, RID, int64_t);
-	GDVIRTUAL2RC(int64_t, _shaped_text_prev_character_pos, RID, int64_t);
-	GDVIRTUAL2RC(int64_t, _shaped_text_closest_character_pos, RID, int64_t);
+	GDVIRTUAL1RC(PackedInt32Array, _shaped_text_get_character_breaks, RID)
+	GDVIRTUAL2RC(int64_t, _shaped_text_next_character_pos, RID, int64_t)
+	GDVIRTUAL2RC(int64_t, _shaped_text_prev_character_pos, RID, int64_t)
+	GDVIRTUAL2RC(int64_t, _shaped_text_closest_character_pos, RID, int64_t)
 
 	virtual String format_number(const String &p_string, const String &p_language = "") const override;
 	virtual String parse_number(const String &p_string, const String &p_language = "") const override;
 	virtual String percent_sign(const String &p_language = "") const override;
-	GDVIRTUAL2RC(String, _format_number, const String &, const String &);
-	GDVIRTUAL2RC(String, _parse_number, const String &, const String &);
-	GDVIRTUAL1RC(String, _percent_sign, const String &);
+	GDVIRTUAL2RC(String, _format_number, const String &, const String &)
+	GDVIRTUAL2RC(String, _parse_number, const String &, const String &)
+	GDVIRTUAL1RC(String, _percent_sign, const String &)
 
 	virtual String strip_diacritics(const String &p_string) const override;
-	GDVIRTUAL1RC(String, _strip_diacritics, const String &);
+	GDVIRTUAL1RC(String, _strip_diacritics, const String &)
 
 	virtual PackedInt32Array string_get_word_breaks(const String &p_string, const String &p_language = "", int64_t p_chars_per_line = 0) const override;
-	GDVIRTUAL3RC(PackedInt32Array, _string_get_word_breaks, const String &, const String &, int64_t);
+	GDVIRTUAL3RC(PackedInt32Array, _string_get_word_breaks, const String &, const String &, int64_t)
 
 	virtual PackedInt32Array string_get_character_breaks(const String &p_string, const String &p_language = "") const override;
-	GDVIRTUAL2RC(PackedInt32Array, _string_get_character_breaks, const String &, const String &);
+	GDVIRTUAL2RC(PackedInt32Array, _string_get_character_breaks, const String &, const String &)
 
 	virtual bool is_valid_identifier(const String &p_string) const override;
-	GDVIRTUAL1RC(bool, _is_valid_identifier, const String &);
+	GDVIRTUAL1RC(bool, _is_valid_identifier, const String &)
 	virtual bool is_valid_letter(uint64_t p_unicode) const override;
-	GDVIRTUAL1RC(bool, _is_valid_letter, uint64_t);
+	GDVIRTUAL1RC(bool, _is_valid_letter, uint64_t)
 
 	virtual String string_to_upper(const String &p_string, const String &p_language = "") const override;
 	virtual String string_to_lower(const String &p_string, const String &p_language = "") const override;
 	virtual String string_to_title(const String &p_string, const String &p_language = "") const override;
-	GDVIRTUAL2RC(String, _string_to_upper, const String &, const String &);
-	GDVIRTUAL2RC(String, _string_to_lower, const String &, const String &);
-	GDVIRTUAL2RC(String, _string_to_title, const String &, const String &);
+	GDVIRTUAL2RC(String, _string_to_upper, const String &, const String &)
+	GDVIRTUAL2RC(String, _string_to_lower, const String &, const String &)
+	GDVIRTUAL2RC(String, _string_to_title, const String &, const String &)
 
 	TypedArray<Vector3i> parse_structured_text(StructuredTextParser p_parser_type, const Array &p_args, const String &p_text) const;
-	GDVIRTUAL3RC(TypedArray<Vector3i>, _parse_structured_text, StructuredTextParser, const Array &, const String &);
+	GDVIRTUAL3RC(TypedArray<Vector3i>, _parse_structured_text, StructuredTextParser, const Array &, const String &)
 
 	virtual int64_t is_confusable(const String &p_string, const PackedStringArray &p_dict) const override;
 	virtual bool spoof_check(const String &p_string) const override;
-	GDVIRTUAL2RC(int64_t, _is_confusable, const String &, const PackedStringArray &);
-	GDVIRTUAL1RC(bool, _spoof_check, const String &);
+	GDVIRTUAL2RC(int64_t, _is_confusable, const String &, const PackedStringArray &)
+	GDVIRTUAL1RC(bool, _spoof_check, const String &)
 
 	virtual void cleanup() override;
-	GDVIRTUAL0(_cleanup);
+	GDVIRTUAL0(_cleanup)
 
 	TextServerExtension();
 	~TextServerExtension();

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -46,7 +46,7 @@ struct CaretInfo;
 #define OT_TAG(m_c1, m_c2, m_c3, m_c4) ((int32_t)((((uint32_t)(m_c1) & 0xff) << 24) | (((uint32_t)(m_c2) & 0xff) << 16) | (((uint32_t)(m_c3) & 0xff) << 8) | ((uint32_t)(m_c4) & 0xff)))
 
 class TextServer : public RefCounted {
-	GDCLASS(TextServer, RefCounted);
+	GDCLASS(TextServer, RefCounted)
 
 public:
 	enum FontAntialiasing {
@@ -543,8 +543,8 @@ public:
 	virtual PackedInt32Array string_get_word_breaks(const String &p_string, const String &p_language = "", int64_t p_chars_per_line = 0) const = 0;
 	virtual PackedInt32Array string_get_character_breaks(const String &p_string, const String &p_language = "") const;
 
-	virtual int64_t is_confusable(const String &p_string, const PackedStringArray &p_dict) const { return -1; };
-	virtual bool spoof_check(const String &p_string) const { return false; };
+	virtual int64_t is_confusable(const String &p_string, const PackedStringArray &p_dict) const { return -1; }
+	virtual bool spoof_check(const String &p_string) const { return false; }
 
 	virtual String strip_diacritics(const String &p_string) const;
 	virtual bool is_valid_identifier(const String &p_string) const;
@@ -598,7 +598,7 @@ struct CaretInfo {
 /*************************************************************************/
 
 class TextServerManager : public Object {
-	GDCLASS(TextServerManager, Object);
+	GDCLASS(TextServerManager, Object)
 
 protected:
 	static void _bind_methods();

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -50,7 +50,7 @@ struct BlitToScreen;
 */
 
 class XRInterface : public RefCounted {
-	GDCLASS(XRInterface, RefCounted);
+	GDCLASS(XRInterface, RefCounted)
 
 public:
 	enum Capabilities { /* purely metadata, provides some info about what this interface supports */
@@ -138,7 +138,7 @@ public:
 	virtual RID get_depth_texture(); /* obtain depth output texture (if applicable, used for reprojection) */
 	virtual RID get_velocity_texture(); /* obtain velocity output texture (if applicable, used for spacewarp) */
 	virtual void pre_render() {}
-	virtual bool pre_draw_viewport(RID p_render_target) { return true; }; /* inform XR interface we are about to start our viewport draw process */
+	virtual bool pre_draw_viewport(RID p_render_target) { return true; } /* inform XR interface we are about to start our viewport draw process */
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) = 0; /* inform XR interface we finished our viewport draw process */
 	virtual void end_frame() {}
 

--- a/servers/xr/xr_vrs.h
+++ b/servers/xr/xr_vrs.h
@@ -39,7 +39,7 @@
 /* This is a helper class for generating stereoscopic VRS images */
 
 class XRVRS : public Object {
-	GDCLASS(XRVRS, Object);
+	GDCLASS(XRVRS, Object)
 
 private:
 	float vrs_min_radius = 20.0;

--- a/servers/xr_server.h
+++ b/servers/xr_server.h
@@ -55,7 +55,7 @@ class XRPositionalTracker;
 **/
 
 class XRServer : public Object {
-	GDCLASS(XRServer, Object);
+	GDCLASS(XRServer, Object)
 	_THREAD_SAFE_CLASS_
 
 public:


### PR DESCRIPTION
Opening as a draft because this is largely to showcase the ramifications of implementing this fix via clang-tidy. While this easily recognizes & takes care of the obvious scenarios, it features a lot of collatoral which probably isn't desired as-is. However, I think it's ultimately an improvement & these warnings can be addressed over more of a long-term process. With enough integration, they could even be integrated into the buildsystem as *actual* warnings (clang, gcc, and msvc all support unnecessary semicolon warnings to some extent), but that's a ways off.

The biggest examples of outlier cases are macros like `GDCLASS()`, which frequently use a semicolon even if that's not strictly necessary. I'm fairly confident this is at least part of the reason as to why we need a `cpp.hint` file, because it otherwise throws off certain IDEs into misattributing them as class methods. There most likely should be a standard syntax enforced for these kinds of macros, and there's two main ways of going about it:

- Disallow semicolons (suggested). Catch primarily via clang-tidy warnings in IDE contexts. Could be elevated to actual errors over time, but wouldn't be immediately "required". Less destructive initially, but would eventually affect more files.
- Enforce semicolons. `#define FORCE_SEMICOLON static_assert(true)` would be added to `typedefs.h`, allowing it to be appended to any macro that requires a trailing semicolon. Destructive change, as this would make those macros **require** a semicolon. Most "mixed" macros already end with semicolons, so it'd affect comparatively fewer files.

This of course is assuming that the macro doesn't naturally end with a semicolon. If a macro already does, then the fix is as simple as removing that semicolon from the macro itself, making the user have to add a "natural" semicolon. This is also technically destructive, albeit in a much less arbitrary context.

I'll be using this PR as a frame of reference while I chip away at implementing these concepts in more bite-sized chunks.