### PR TITLE
Make `inst_to_dict` and `dict_to_inst` recursive

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -77,8 +77,10 @@
 		<method name="dict_to_inst">
 			<return type="Object" />
 			<param index="0" name="dictionary" type="Dictionary" />
+			<param index="1" name="deep" type="bool" default="false" />
 			<description>
 				Converts a [param dictionary] (created with [method inst_to_dict]) back to an Object instance. Can be useful for deserializing.
+				If [param deep] is [code]true[/code], the method converts any inner instances recursively. Use this option only if you're sure that instances have no circular references to each other as it can lead to an endless conversion loop.
 			</description>
 		</method>
 		<method name="get_stack">
@@ -106,8 +108,10 @@
 		<method name="inst_to_dict">
 			<return type="Dictionary" />
 			<param index="0" name="instance" type="Object" />
+			<param index="1" name="deep" type="bool" default="false" />
 			<description>
 				Returns the passed [param instance] converted to a Dictionary. Can be useful for serializing.
+				If [param deep] is [code]true[/code], the method converts any inner instances recursively. Use this option only if you're sure that instances have no circular references to each other as it can lead to an endless conversion loop.
 				[b]Note:[/b] Cannot be used to serialize objects with built-in scripts attached or objects allocated within built-in scripts.
 				[codeblock]
 				var foo = "bar"

--- a/modules/gdscript/tests/scripts/utility_functions/bar.notest.gd
+++ b/modules/gdscript/tests/scripts/utility_functions/bar.notest.gd
@@ -1,0 +1,9 @@
+extends Resource
+
+@export var text: String
+@export var qux: Resource
+
+
+func _init(p_text = "", p_qux = null):
+	text = p_text
+	qux = p_qux

--- a/modules/gdscript/tests/scripts/utility_functions/bar.tres
+++ b/modules/gdscript/tests/scripts/utility_functions/bar.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://cqd4xsl30rr7b"]
+
+[ext_resource type="Script" path="./bar.notest.gd" id="1_bar"]
+[ext_resource type="Script" path="./qux.tres" id="1_qux"]
+
+[resource]
+script = ExtResource("1_bar")
+text = "lorem ipsum"
+qux = ExtResource("1_qux")

--- a/modules/gdscript/tests/scripts/utility_functions/errors/inst_to_dict_not_resource.gd
+++ b/modules/gdscript/tests/scripts/utility_functions/errors/inst_to_dict_not_resource.gd
@@ -1,0 +1,10 @@
+extends Resource
+
+
+class NotResource:
+	@export var number: int
+
+func test():
+	var obj:NotResource = NotResource.new()
+	inst_to_dict(obj)
+	print('not ok')

--- a/modules/gdscript/tests/scripts/utility_functions/errors/inst_to_dict_not_resource.out
+++ b/modules/gdscript/tests/scripts/utility_functions/errors/inst_to_dict_not_resource.out
@@ -1,0 +1,6 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR
+>> on function: test()
+>> utility_functions/errors/inst_to_dict_not_resource.gd
+>> 9
+>> Error calling GDScript utility function "inst_to_dict()": Not based on a resource file.

--- a/modules/gdscript/tests/scripts/utility_functions/foo.notest.gd
+++ b/modules/gdscript/tests/scripts/utility_functions/foo.notest.gd
@@ -1,0 +1,9 @@
+extends Resource
+
+@export var number: int
+@export var bar: Resource
+
+
+func _init(p_number = 0, p_bar = null):
+	number = p_number
+	bar = p_bar

--- a/modules/gdscript/tests/scripts/utility_functions/foo.tres
+++ b/modules/gdscript/tests/scripts/utility_functions/foo.tres
@@ -1,0 +1,9 @@
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://cqd4xsl30rr7a"]
+
+[ext_resource type="Script" path="./foo.notest.gd" id="1_foo"]
+[ext_resource type="Script" path="./bar.tres" id="1_bar"]
+
+[resource]
+script = ExtResource("1_foo")
+number = 42
+bar = ExtResource("1_bar")

--- a/modules/gdscript/tests/scripts/utility_functions/inst_to_dict.gd
+++ b/modules/gdscript/tests/scripts/utility_functions/inst_to_dict.gd
@@ -1,0 +1,54 @@
+extends Resource
+
+var foo = preload("./foo.tres")
+var foo_bar_null = preload("./foo.tres")
+
+
+func test():
+	# Sunny day
+	var obj:Object = foo
+	var dict:Dictionary = inst_to_dict(obj)
+	var dict_ok = true
+	dict_ok = dict_ok && dict.get("number") == 42
+	dict_ok = dict_ok && dict.get("bar") is Resource
+	if not dict_ok:
+		printerr("Can't convert foo instance to dictionary properly")
+
+	dict = inst_to_dict(obj, true)
+	print(dict.keys())
+	print(dict.values())
+
+	var inst = dict_to_inst(dict, true)
+	var equals = true
+	equals = equals && foo.number == inst.number
+	equals = equals && foo.bar.text == inst.bar.text
+	equals = equals && foo.bar.qux.decimal == inst.bar.qux.decimal
+	if not equals:
+		printerr("Can't revert from foo instance to dictionary properly")
+
+	# null in inner object
+	foo_bar_null.bar = null
+	obj = foo_bar_null
+	dict = inst_to_dict(obj)
+	dict_ok = true
+	dict_ok = dict_ok && dict.get("number") == 42
+	dict_ok = dict_ok && dict.get("bar") == null
+	if not dict_ok:
+		printerr("Can't convert foo_bar_null instance to dictionary properly")
+
+	dict = inst_to_dict(obj, true)
+	print(dict.keys())
+	print(dict.values())
+
+	inst = dict_to_inst(dict, true)
+	equals = true
+	equals = equals && foo.number == inst.number
+	equals = equals && foo.bar == null
+	if not equals:
+		printerr("Can't revert from foo_bar_null instance to dictionary properly")
+
+	var should_be_null = inst_to_dict(null)
+	if should_be_null != null:
+		printerr("It should return null")
+
+	print('ok')

--- a/modules/gdscript/tests/scripts/utility_functions/inst_to_dict.out
+++ b/modules/gdscript/tests/scripts/utility_functions/inst_to_dict.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+["@subpath", "@path", &"number", &"bar"]
+[^"", "res://utility_functions/foo.notest.gd", 42, { "@subpath": ^"", "@path": "res://utility_functions/bar.notest.gd", &"text": "lorem ipsum", &"qux": { "@subpath": ^"", "@path": "res://utility_functions/qux.notest.gd", &"decimal": 0.5 } }]
+["@subpath", "@path", &"number", &"bar"]
+[^"", "res://utility_functions/foo.notest.gd", 42, <null>]
+ok

--- a/modules/gdscript/tests/scripts/utility_functions/qux.notest.gd
+++ b/modules/gdscript/tests/scripts/utility_functions/qux.notest.gd
@@ -1,0 +1,7 @@
+extends Resource
+
+@export var decimal: float
+
+
+func _init(p_decimal = ""):
+	decimal = p_decimal

--- a/modules/gdscript/tests/scripts/utility_functions/qux.tres
+++ b/modules/gdscript/tests/scripts/utility_functions/qux.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://cqd4xsl30rr7c"]
+
+[ext_resource type="Script" path="./qux.notest.gd" id="1_qux"]
+
+[resource]
+script = ExtResource("1_qux")
+decimal = 0.5


### PR DESCRIPTION
Fixes #6533

Making GDScript inst_to_dict/dict_to_inst utility functions recursive.
Adding also a new macro to validate the number of the required arguments.
