### PR TITLE
Add horizontal and vertical separation to `ScrollContainer` theme constants.

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -107,6 +107,12 @@
 		</constant>
 	</constants>
 	<theme_items>
+		<theme_item name="h_separation" data_type="constant" type="int" default="0">
+			The horizontal separation applied when the vertical scroll bar is visible.
+		</theme_item>
+		<theme_item name="v_separation" data_type="constant" type="int" default="0">
+			The vertical separation applied when the horizontal scroll bar is visible.
+		</theme_item>
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The background [StyleBox] of the [ScrollContainer].
 		</theme_item>

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -60,7 +60,7 @@ Size2 ScrollContainer::get_minimum_size() const {
 		min_size.x = largest_child_min_size.x;
 		bool v_scroll_show = vertical_scroll_mode == SCROLL_MODE_SHOW_ALWAYS || vertical_scroll_mode == SCROLL_MODE_RESERVE || (vertical_scroll_mode == SCROLL_MODE_AUTO && largest_child_min_size.y > size.y);
 		if (v_scroll_show && v_scroll->get_parent() == this) {
-			min_size.x += v_scroll->get_minimum_size().x;
+			min_size.x += v_scroll->get_minimum_size().x + theme_cache.h_separation;
 		}
 	}
 
@@ -68,7 +68,7 @@ Size2 ScrollContainer::get_minimum_size() const {
 		min_size.y = largest_child_min_size.y;
 		bool h_scroll_show = horizontal_scroll_mode == SCROLL_MODE_SHOW_ALWAYS || horizontal_scroll_mode == SCROLL_MODE_RESERVE || (horizontal_scroll_mode == SCROLL_MODE_AUTO && largest_child_min_size.x > size.x);
 		if (h_scroll_show && h_scroll->get_parent() == this) {
-			min_size.y += h_scroll->get_minimum_size().y;
+			min_size.y += h_scroll->get_minimum_size().y + theme_cache.v_separation;
 		}
 	}
 
@@ -258,18 +258,18 @@ void ScrollContainer::_update_scrollbar_position() {
 		return;
 	}
 
-	Size2 hmin = h_scroll->is_visible() ? h_scroll->get_combined_minimum_size() : Size2();
-	Size2 vmin = v_scroll->is_visible() ? v_scroll->get_combined_minimum_size() : Size2();
+	Size2 hmin = h_scroll->is_visible() ? h_scroll->get_combined_minimum_size() + Size2(0, theme_cache.v_separation) : Size2();
+	Size2 vmin = v_scroll->is_visible() ? v_scroll->get_combined_minimum_size() + Size2(theme_cache.h_separation, 0) : Size2();
 
 	int lmar = is_layout_rtl() ? theme_cache.panel_style->get_margin(SIDE_RIGHT) : theme_cache.panel_style->get_margin(SIDE_LEFT);
 	int rmar = is_layout_rtl() ? theme_cache.panel_style->get_margin(SIDE_LEFT) : theme_cache.panel_style->get_margin(SIDE_RIGHT);
 
 	h_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, lmar);
 	h_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -rmar - vmin.width);
-	h_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -hmin.height - theme_cache.panel_style->get_margin(SIDE_BOTTOM));
+	h_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -hmin.height - theme_cache.panel_style->get_margin(SIDE_BOTTOM) + theme_cache.v_separation);
 	h_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -theme_cache.panel_style->get_margin(SIDE_BOTTOM));
 
-	v_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -vmin.width - rmar);
+	v_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -vmin.width - rmar + theme_cache.h_separation);
 	v_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -rmar);
 	v_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, theme_cache.panel_style->get_margin(SIDE_TOP));
 	v_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -hmin.height - theme_cache.panel_style->get_margin(SIDE_BOTTOM));
@@ -288,8 +288,8 @@ void ScrollContainer::ensure_control_visible(Control *p_control) {
 
 	Rect2 global_rect = get_global_rect();
 	Rect2 other_rect = p_control->get_global_rect();
-	float side_margin = v_scroll->is_visible() ? v_scroll->get_size().x : 0.0f;
-	float bottom_margin = h_scroll->is_visible() ? h_scroll->get_size().y : 0.0f;
+	float side_margin = v_scroll->is_visible() ? v_scroll->get_size().x + theme_cache.h_separation : 0.0f;
+	float bottom_margin = h_scroll->is_visible() ? h_scroll->get_size().y + theme_cache.v_separation : 0.0f;
 
 	Vector2 diff = Vector2(MAX(MIN(other_rect.position.x - (is_layout_rtl() ? side_margin : 0.0f), global_rect.position.x), other_rect.position.x + other_rect.size.x - global_rect.size.x + (!is_layout_rtl() ? side_margin : 0.0f)),
 			MAX(MIN(other_rect.position.y, global_rect.position.y), other_rect.position.y + other_rect.size.y - global_rect.size.y + bottom_margin));
@@ -308,11 +308,11 @@ void ScrollContainer::_reposition_children() {
 	bool rtl = is_layout_rtl();
 
 	if (_is_h_scroll_visible() || horizontal_scroll_mode == SCROLL_MODE_RESERVE) {
-		size.y -= h_scroll->get_minimum_size().y;
+		size.y -= theme_cache.v_separation + h_scroll->get_minimum_size().y;
 	}
 
 	if (_is_v_scroll_visible() || vertical_scroll_mode == SCROLL_MODE_RESERVE) {
-		size.x -= v_scroll->get_minimum_size().x;
+		size.x -= theme_cache.h_separation + v_scroll->get_minimum_size().x;
 	}
 
 	for (int i = 0; i < get_child_count(); i++) {
@@ -334,7 +334,7 @@ void ScrollContainer::_reposition_children() {
 		}
 		r.position += ofs;
 		if (rtl && _is_v_scroll_visible()) {
-			r.position.x += v_scroll->get_minimum_size().x;
+			r.position.x += theme_cache.h_separation + v_scroll->get_minimum_size().x;
 		}
 		r.position = r.position.floor();
 		fit_child_in_rect(c, r);
@@ -623,6 +623,8 @@ void ScrollContainer::_bind_methods() {
 	BIND_ENUM_CONSTANT(SCROLL_MODE_RESERVE);
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollContainer, panel_style, "panel");
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, h_separation);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, v_separation);
 
 	GLOBAL_DEF("gui/common/default_scroll_deadzone", 0);
 };

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -72,6 +72,8 @@ private:
 
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;
+		int h_separation = 0;
+		int v_separation = 0;
 	} theme_cache;
 
 	void _cancel_drag();


### PR DESCRIPTION
It's hard to make such separation in code, since the `ScrollContainer` doesn't provide signals to tell when the `ScrollBar` becomes visible or hidden, so this will save us from adding two extra dummy spacers which will also need an extra `HBoxContainer` and `VBoxContainer` and to show/hide the spacers when size is changed after checking if the `HScrollBar` or the `VScrollBar` is visible.

https://github.com/user-attachments/assets/ff2d9efa-575a-41ba-ac87-4722bacc720f

