### PR TITLE
Enable automatic translation of context menus in `TextEdit`, `LineEdit`, and `RichTextLabel`

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2642,6 +2642,7 @@ Key LineEdit::_get_menu_action_accelerator(const String &p_action) {
 
 void LineEdit::_generate_context_menu() {
 	menu = memnew(PopupMenu);
+	menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	add_child(menu, false, INTERNAL_MODE_FRONT);
 
 	menu_dir = memnew(PopupMenu);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -6516,6 +6516,7 @@ Size2 RichTextLabel::get_minimum_size() const {
 // Context menu.
 void RichTextLabel::_generate_context_menu() {
 	menu = memnew(PopupMenu);
+	menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	add_child(menu, false, INTERNAL_MODE_FRONT);
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &RichTextLabel::menu_option));
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7366,6 +7366,7 @@ Key TextEdit::_get_menu_action_accelerator(const String &p_action) {
 
 void TextEdit::_generate_context_menu() {
 	menu = memnew(PopupMenu);
+	menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_ALWAYS);
 	add_child(menu, false, INTERNAL_MODE_FRONT);
 
 	menu_dir = memnew(PopupMenu);


### PR DESCRIPTION
Set automatic translation of context menus in `TextEdit`, `LineEdit` and `RichTextLabel` to Always to avoid having to use additional script code to enable automatic translation when localizing context menu content.