### PR TITLE
Update Camera2D::set_zoom() function error message

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -108,7 +108,7 @@ void Camera2D::_update_process_callback() {
 
 void Camera2D::set_zoom(const Vector2 &p_zoom) {
 	// Setting zoom to zero causes 'affine_invert' issues
-	ERR_FAIL_COND_MSG(Math::is_zero_approx(p_zoom.x) || Math::is_zero_approx(p_zoom.y), "Zoom level must be different from 0 (can be negative).");
+	ERR_FAIL_COND_MSG(p_zoom.x == 0 || p_zoom.y == 0, "Zoom level must be different from 0 (can be negative).");
 
 	zoom = p_zoom;
 	zoom_scale = Vector2(1, 1) / zoom;


### PR DESCRIPTION
Updated it so that the error condition is accurate to what the error description describes, and the editor won't be flooded with errors if you have a non-zero low zoom level.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
