### PR TITLE
Fix TabBar initialization issue and add tests

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -354,6 +354,8 @@ void TabBar::_notification(int p_what) {
 			if (scroll_to_selected) {
 				ensure_tab_visible(current);
 			}
+			// Set initialized even if no tabs were set.
+			initialized = true;
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
@@ -655,10 +657,10 @@ void TabBar::set_tab_count(int p_count) {
 	}
 
 	if (!initialized) {
-		if (queued_current != current) {
-			current = queued_current;
-		}
 		initialized = true;
+		if (queued_current != CURRENT_TAB_UNINITIALIZED && queued_current != current) {
+			set_current_tab(queued_current);
+		}
 	}
 
 	queue_redraw();
@@ -738,6 +740,13 @@ bool TabBar::select_next_available() {
 		}
 	}
 	return false;
+}
+
+void TabBar::set_tab_offset(int p_offset) {
+	ERR_FAIL_INDEX(p_offset, tabs.size());
+	offset = p_offset;
+	_update_cache();
+	queue_redraw();
 }
 
 int TabBar::get_tab_offset() const {

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -117,8 +117,9 @@ private:
 	bool scroll_to_selected = true;
 	int tabs_rearrange_group = -1;
 
+	static const int CURRENT_TAB_UNINITIALIZED = -2;
 	bool initialized = false;
-	int queued_current = -1;
+	int queued_current = CURRENT_TAB_UNINITIALIZED;
 
 	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 0.5;
 	const float GAMEPAD_EVENT_REPEAT_RATE_MS = 1.0 / 20;
@@ -249,6 +250,7 @@ public:
 	bool select_previous_available();
 	bool select_next_available();
 
+	void set_tab_offset(int p_offset);
 	int get_tab_offset() const;
 	bool get_offset_buttons_visible() const;
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -190,7 +190,7 @@ void TabContainer::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (!is_visible() || setup_current_tab > -2) {
+			if (!is_visible()) {
 				return;
 			}
 
@@ -200,7 +200,7 @@ void TabContainer::_notification(int p_what) {
 			// beat it to the punch and make sure that the correct node is the only one visible first.
 			// Otherwise, it can prevent a tab change done right before this container was made visible.
 			Vector<Control *> controls = _get_tab_controls();
-			int current = get_current_tab();
+			int current = setup_current_tab > -2 ? setup_current_tab : get_current_tab();
 			for (int i = 0; i < controls.size(); i++) {
 				controls[i]->set_visible(i == current);
 			}

--- a/tests/scene/test_tab_bar.h
+++ b/tests/scene/test_tab_bar.h
@@ -1,0 +1,864 @@
+/**************************************************************************/
+/*  test_tab_bar.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_TAB_BAR_H
+#define TEST_TAB_BAR_H
+
+#include "scene/gui/tab_bar.h"
+#include "scene/main/window.h"
+
+#include "tests/test_macros.h"
+
+namespace TestTabBar {
+static inline Array build_array() {
+	return Array();
+}
+template <typename... Targs>
+static inline Array build_array(Variant item, Targs... Fargs) {
+	Array a = build_array(Fargs...);
+	a.push_front(item);
+	return a;
+}
+
+TEST_CASE("[SceneTree][TabBar] tab operations") {
+	TabBar *tab_bar = memnew(TabBar);
+	SceneTree::get_singleton()->get_root()->add_child(tab_bar);
+	tab_bar->set_clip_tabs(false);
+	MessageQueue::get_singleton()->flush();
+
+	SIGNAL_WATCH(tab_bar, "tab_selected");
+	SIGNAL_WATCH(tab_bar, "tab_changed");
+
+	SUBCASE("[TabBar] no tabs") {
+		CHECK(tab_bar->get_tab_count() == 0);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+	}
+
+	SUBCASE("[TabBar] add tabs") {
+		tab_bar->add_tab("tab0");
+		CHECK(tab_bar->get_tab_count() == 1);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+
+		tab_bar->add_tab("tab1");
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_bar->add_tab("tab2");
+		CHECK(tab_bar->get_tab_count() == 3);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		CHECK(tab_bar->get_tab_title(0) == "tab0");
+		CHECK(tab_bar->get_tab_tooltip(0) == "");
+		CHECK(tab_bar->get_tab_text_direction(0) == Control::TEXT_DIRECTION_INHERITED);
+		CHECK_FALSE(tab_bar->is_tab_disabled(0));
+		CHECK_FALSE(tab_bar->is_tab_hidden(0));
+
+		CHECK(tab_bar->get_tab_title(1) == "tab1");
+		CHECK(tab_bar->get_tab_tooltip(1) == "");
+		CHECK(tab_bar->get_tab_text_direction(1) == Control::TEXT_DIRECTION_INHERITED);
+		CHECK_FALSE(tab_bar->is_tab_disabled(1));
+		CHECK_FALSE(tab_bar->is_tab_hidden(1));
+
+		CHECK(tab_bar->get_tab_title(2) == "tab2");
+		CHECK(tab_bar->get_tab_tooltip(2) == "");
+		CHECK(tab_bar->get_tab_text_direction(2) == Control::TEXT_DIRECTION_INHERITED);
+		CHECK_FALSE(tab_bar->is_tab_disabled(2));
+		CHECK_FALSE(tab_bar->is_tab_hidden(2));
+	}
+
+	SUBCASE("[TabBar] set tab count") {
+		// Adds multiple tabs at once.
+		tab_bar->set_tab_count(3);
+		CHECK(tab_bar->get_tab_count() == 3);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		CHECK(tab_bar->get_tab_title(0) == "");
+		CHECK(tab_bar->get_tab_tooltip(0) == "");
+		CHECK(tab_bar->get_tab_text_direction(0) == Control::TEXT_DIRECTION_INHERITED);
+		CHECK_FALSE(tab_bar->is_tab_disabled(0));
+		CHECK_FALSE(tab_bar->is_tab_hidden(0));
+
+		CHECK(tab_bar->get_tab_title(1) == "");
+		CHECK(tab_bar->get_tab_tooltip(1) == "");
+		CHECK(tab_bar->get_tab_text_direction(1) == Control::TEXT_DIRECTION_INHERITED);
+		CHECK_FALSE(tab_bar->is_tab_disabled(1));
+		CHECK_FALSE(tab_bar->is_tab_hidden(1));
+
+		CHECK(tab_bar->get_tab_title(2) == "");
+		CHECK(tab_bar->get_tab_tooltip(2) == "");
+		CHECK(tab_bar->get_tab_text_direction(2) == Control::TEXT_DIRECTION_INHERITED);
+		CHECK_FALSE(tab_bar->is_tab_disabled(2));
+		CHECK_FALSE(tab_bar->is_tab_hidden(2));
+
+		// Setting to less tabs than there are removes from the end.
+		tab_bar->set_tab_title(0, "tab0");
+		tab_bar->set_tab_title(1, "tab1");
+		tab_bar->set_tab_title(2, "tab2");
+
+		tab_bar->set_tab_count(2);
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		CHECK(tab_bar->get_tab_title(0) == "tab0");
+		CHECK(tab_bar->get_tab_title(1) == "tab1");
+
+		// Remove all tabs.
+		tab_bar->set_tab_count(0);
+		CHECK(tab_bar->get_tab_count() == 0);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+	}
+
+	SUBCASE("[TabBar] clear tabs") {
+		CHECK(tab_bar->get_tab_count() == 0);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+
+		tab_bar->set_tab_count(2);
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		tab_bar->clear_tabs();
+		CHECK(tab_bar->get_tab_count() == 0);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+	}
+
+	SUBCASE("[TabBar] remove tabs") {
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		tab_bar->set_current_tab(1);
+		CHECK(tab_bar->get_tab_count() == 3);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Remove first tab.
+		tab_bar->remove_tab(0);
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_tab_title(0) == "tab1");
+		CHECK(tab_bar->get_tab_title(1) == "tab2");
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Remove last tab.
+		tab_bar->remove_tab(1);
+		CHECK(tab_bar->get_tab_count() == 1);
+		CHECK(tab_bar->get_tab_title(0) == "tab1");
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Remove only tab.
+		tab_bar->remove_tab(0);
+		CHECK(tab_bar->get_tab_count() == 0);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK("tab_changed", build_array(build_array(-1)));
+
+		// Remove current tab when there are other tabs.
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		tab_bar->set_current_tab(1);
+		tab_bar->set_current_tab(2);
+		CHECK(tab_bar->get_tab_count() == 3);
+		CHECK(tab_bar->get_current_tab() == 2);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		tab_bar->remove_tab(2);
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+	}
+
+	SUBCASE("[TabBar] move tabs") {
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		tab_bar->set_current_tab(1);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Don't move if index is the same.
+		tab_bar->move_tab(0, 0);
+		CHECK(tab_bar->get_tab_title(0) == "tab0");
+		CHECK(tab_bar->get_tab_title(1) == "tab1");
+		CHECK(tab_bar->get_tab_title(2) == "tab2");
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Move the first tab to the end.
+		tab_bar->move_tab(0, 2);
+		CHECK(tab_bar->get_tab_title(0) == "tab1");
+		CHECK(tab_bar->get_tab_title(1) == "tab2");
+		CHECK(tab_bar->get_tab_title(2) == "tab0");
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 2);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Move the second tab to the front.
+		tab_bar->move_tab(1, 0);
+		CHECK(tab_bar->get_tab_title(0) == "tab2");
+		CHECK(tab_bar->get_tab_title(1) == "tab1");
+		CHECK(tab_bar->get_tab_title(2) == "tab0");
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 2);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+	}
+
+	SUBCASE("[TabBar] set current tab") {
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+
+		// Set the current tab.
+		tab_bar->set_current_tab(1);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+
+		// Set to same tab.
+		tab_bar->set_current_tab(1);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Out of bounds.
+		ERR_PRINT_OFF;
+		tab_bar->set_current_tab(-5);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_bar->set_current_tab(5);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		ERR_PRINT_ON;
+	}
+
+	SUBCASE("[TabBar] deselection enabled") {
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Setting deselect enabled doesn't change current tab.
+		tab_bar->set_deselect_enabled(true);
+		CHECK(tab_bar->get_deselect_enabled());
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Can deselect all tabs by setting current to -1.
+		tab_bar->set_current_tab(-1);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(-1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(-1)));
+
+		// Adding a tab will still set the current tab to 0.
+		tab_bar->clear_tabs();
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		CHECK(tab_bar->get_tab_count() == 3);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+
+		tab_bar->set_current_tab(-1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Disabling while at -1 will select the first available tab.
+		tab_bar->set_deselect_enabled(false);
+		CHECK_FALSE(tab_bar->get_deselect_enabled());
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+
+		// Cannot set to -1 if disabled.
+		ERR_PRINT_OFF;
+		tab_bar->set_current_tab(-1);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		ERR_PRINT_ON;
+
+		// Disabling while at -1 skips any disabled or hidden tabs.
+		tab_bar->set_deselect_enabled(true);
+		tab_bar->set_tab_disabled(0, true);
+		tab_bar->set_tab_hidden(1, true);
+		tab_bar->set_current_tab(-1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+		tab_bar->set_deselect_enabled(false);
+		CHECK(tab_bar->get_current_tab() == 2);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(2)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(2)));
+	}
+
+	SUBCASE("[TabBar] hidden tabs") {
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		tab_bar->set_current_tab(1);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		CHECK_FALSE(tab_bar->is_tab_hidden(1));
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		MessageQueue::get_singleton()->flush();
+		Vector<Rect2> tab_rects = {
+			tab_bar->get_tab_rect(0),
+			tab_bar->get_tab_rect(1),
+			tab_bar->get_tab_rect(2)
+		};
+
+		// Hiding a tab does not affect current tab.
+		tab_bar->set_tab_hidden(1, true);
+		CHECK(tab_bar->is_tab_hidden(1));
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// The tabs after are moved over.
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_bar->get_tab_rect(0) == tab_rects[0]);
+		CHECK(tab_bar->get_tab_rect(2) == tab_rects[1]);
+
+		// Unhiding a tab does not affect current tab.
+		tab_bar->set_tab_hidden(1, false);
+		CHECK_FALSE(tab_bar->is_tab_hidden(1));
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// The tabs are back where they were.
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_bar->get_tab_rect(0) == tab_rects[0]);
+		CHECK(tab_bar->get_tab_rect(1) == tab_rects[1]);
+		CHECK(tab_bar->get_tab_rect(2) == tab_rects[2]);
+	}
+
+	SUBCASE("[TabBar] disabled tabs") {
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		CHECK_FALSE(tab_bar->is_tab_disabled(1));
+		tab_bar->set_current_tab(1);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		CHECK_FALSE(tab_bar->is_tab_hidden(1));
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Disabling a tab does not affect current tab.
+		tab_bar->set_tab_disabled(1, true);
+		CHECK(tab_bar->is_tab_disabled(1));
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Enabling a tab does not affect current tab.
+		tab_bar->set_tab_disabled(1, false);
+		CHECK_FALSE(tab_bar->is_tab_disabled(1));
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+	}
+
+	SUBCASE("[TabBar] select next available") {
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		tab_bar->add_tab("tab3");
+		tab_bar->add_tab("tab4");
+		tab_bar->set_tab_disabled(2, true);
+		tab_bar->set_tab_hidden(3, true);
+		tab_bar->set_current_tab(0);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Selects the next tab.
+		CHECK(tab_bar->select_next_available());
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+
+		// Skips over disabled and hidden tabs.
+		CHECK(tab_bar->select_next_available());
+		CHECK(tab_bar->get_current_tab() == 4);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(4)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(4)));
+
+		// Does not wrap around.
+		CHECK_FALSE(tab_bar->select_next_available());
+		CHECK(tab_bar->get_current_tab() == 4);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Fails if there is only one valid tab.
+		tab_bar->remove_tab(0);
+		tab_bar->remove_tab(3);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		CHECK_FALSE(tab_bar->select_next_available());
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Fails if there are no valid tabs.
+		tab_bar->remove_tab(0);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		CHECK_FALSE(tab_bar->select_next_available());
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Fails if there are no tabs.
+		tab_bar->clear_tabs();
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		CHECK_FALSE(tab_bar->select_next_available());
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+	}
+
+	SUBCASE("[TabBar] select previous available") {
+		tab_bar->add_tab("tab0");
+		tab_bar->add_tab("tab1");
+		tab_bar->add_tab("tab2");
+		tab_bar->add_tab("tab3");
+		tab_bar->add_tab("tab4");
+		tab_bar->set_tab_disabled(1, true);
+		tab_bar->set_tab_hidden(2, true);
+		tab_bar->set_current_tab(4);
+		CHECK(tab_bar->get_current_tab() == 4);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Selects the previous tab.
+		CHECK(tab_bar->select_previous_available());
+		CHECK(tab_bar->get_current_tab() == 3);
+		CHECK(tab_bar->get_previous_tab() == 4);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(3)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(3)));
+
+		// Skips over disabled and hidden tabs.
+		CHECK(tab_bar->select_previous_available());
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 3);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+
+		// Does not wrap around.
+		CHECK_FALSE(tab_bar->select_previous_available());
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 3);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Fails if there is only one valid tab.
+		tab_bar->remove_tab(4);
+		tab_bar->remove_tab(3);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 2);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		CHECK_FALSE(tab_bar->select_previous_available());
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == 2);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Fails if there are no valid tabs.
+		tab_bar->remove_tab(0);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		CHECK_FALSE(tab_bar->select_previous_available());
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == 1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Fails if there are no tabs.
+		tab_bar->clear_tabs();
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		CHECK_FALSE(tab_bar->select_previous_available());
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+	}
+
+	SIGNAL_UNWATCH(tab_bar, "tab_selected");
+	SIGNAL_UNWATCH(tab_bar, "tab_changed");
+
+	memdelete(tab_bar);
+}
+
+TEST_CASE("[SceneTree][TabBar] initialization") {
+	TabBar *tab_bar = memnew(TabBar);
+
+	SIGNAL_WATCH(tab_bar, "tab_selected");
+	SIGNAL_WATCH(tab_bar, "tab_changed");
+
+	SUBCASE("[TabBar] current tab can be set before tabs are set") {
+		// This queues the current tab to update on when tabs are set.
+		tab_bar->set_current_tab(1);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_bar->set_tab_count(2);
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+
+		// Does not work again.
+		ERR_PRINT_OFF;
+		tab_bar->set_current_tab(2);
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_bar->set_tab_count(3);
+		CHECK(tab_bar->get_tab_count() == 3);
+		CHECK(tab_bar->get_current_tab() == 1);
+		CHECK(tab_bar->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		ERR_PRINT_ON;
+	}
+
+	SUBCASE("[TabBar] setting tabs works normally if no current tab was set") {
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+
+		tab_bar->set_tab_count(2);
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+	}
+
+	SUBCASE("[TabBar] cannot set current tab to an invalid value before tabs are set") {
+		tab_bar->set_current_tab(100);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// This will print an error message as if `set_current_tab` was called after.
+		ERR_PRINT_OFF;
+		tab_bar->set_tab_count(2);
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		ERR_PRINT_ON;
+	}
+
+	SUBCASE("[TabBar] setting the current tab before tabs only works when out of tree") {
+		tab_bar->set_current_tab(1);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		SceneTree::get_singleton()->get_root()->add_child(tab_bar);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_bar->get_tab_count() == 0);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Works normally.
+		tab_bar->set_tab_count(2);
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+	}
+
+	SIGNAL_UNWATCH(tab_bar, "tab_selected");
+	SIGNAL_UNWATCH(tab_bar, "tab_changed");
+
+	memdelete(tab_bar);
+}
+
+TEST_CASE("[SceneTree][TabBar] layout and offset") {
+	TabBar *tab_bar = memnew(TabBar);
+	SceneTree::get_singleton()->get_root()->add_child(tab_bar);
+
+	tab_bar->set_clip_tabs(false);
+	tab_bar->add_tab("tab0");
+	tab_bar->add_tab("tab1 ");
+	tab_bar->add_tab("tab2    ");
+	MessageQueue::get_singleton()->flush();
+	Size2 all_tabs_size = tab_bar->get_size();
+
+	Vector<Rect2> tab_rects = {
+		tab_bar->get_tab_rect(0),
+		tab_bar->get_tab_rect(1),
+		tab_bar->get_tab_rect(2)
+	};
+
+	SUBCASE("[TabBar] tabs are arranged next to each other") {
+		// Horizontal positions are next to each other.
+		CHECK(tab_rects[0].position.x == 0);
+		CHECK(tab_rects[1].position.x == tab_rects[0].size.x);
+		CHECK(tab_rects[2].position.x == tab_rects[1].position.x + tab_rects[1].size.x);
+
+		// Fills the entire width.
+		CHECK(tab_rects[2].position.x + tab_rects[2].size.x == all_tabs_size.x);
+
+		// Horizontal sizes are positive.
+		CHECK(tab_rects[0].size.x > 0);
+		CHECK(tab_rects[1].size.x > 0);
+		CHECK(tab_rects[2].size.x > 0);
+
+		// Vertical positions are at 0.
+		CHECK(tab_rects[0].position.y == 0);
+		CHECK(tab_rects[1].position.y == 0);
+		CHECK(tab_rects[2].position.y == 0);
+
+		// Vertical sizes are the same.
+		CHECK(tab_rects[0].size.y == tab_rects[1].size.y);
+		CHECK(tab_rects[1].size.y == tab_rects[2].size.y);
+	}
+
+	SUBCASE("[TabBar] tab alignment") {
+		// Add extra space so the alignment can be seen.
+		tab_bar->set_size(Size2(all_tabs_size.x + 100, all_tabs_size.y));
+
+		// Left alignment.
+		tab_bar->set_tab_alignment(TabBar::ALIGNMENT_LEFT);
+		MessageQueue::get_singleton()->flush();
+		tab_rects = {
+			tab_bar->get_tab_rect(0),
+			tab_bar->get_tab_rect(1),
+			tab_bar->get_tab_rect(2)
+		};
+		CHECK(tab_bar->get_tab_alignment() == TabBar::ALIGNMENT_LEFT);
+		CHECK(tab_rects[0].position.x == 0);
+		CHECK(tab_rects[1].position.x == tab_rects[0].size.x);
+		CHECK(tab_rects[2].position.x == tab_rects[1].position.x + tab_rects[1].size.x);
+
+		// Right alignment.
+		tab_bar->set_tab_alignment(TabBar::ALIGNMENT_RIGHT);
+		MessageQueue::get_singleton()->flush();
+		tab_rects = {
+			tab_bar->get_tab_rect(0),
+			tab_bar->get_tab_rect(1),
+			tab_bar->get_tab_rect(2)
+		};
+		CHECK(tab_bar->get_tab_alignment() == TabBar::ALIGNMENT_RIGHT);
+		CHECK(tab_rects[2].position.x == tab_bar->get_size().x - tab_rects[2].size.x);
+		CHECK(tab_rects[1].position.x == tab_rects[2].position.x - tab_rects[1].size.x);
+		CHECK(tab_rects[0].position.x == tab_rects[1].position.x - tab_rects[0].size.x);
+
+		// Center alignment.
+		tab_bar->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
+		MessageQueue::get_singleton()->flush();
+		tab_rects = {
+			tab_bar->get_tab_rect(0),
+			tab_bar->get_tab_rect(1),
+			tab_bar->get_tab_rect(2)
+		};
+		CHECK(tab_bar->get_tab_alignment() == TabBar::ALIGNMENT_CENTER);
+		float center_pos = tab_bar->get_size().x / 2;
+		CHECK(tab_rects[0].position.x == center_pos - all_tabs_size.x / 2);
+		CHECK(tab_rects[1].position.x == tab_rects[0].position.x + tab_rects[0].size.x);
+		CHECK(tab_rects[2].position.x == tab_rects[1].position.x + tab_rects[1].size.x);
+	}
+
+	SUBCASE("[TabBar] clip tabs") {
+		// Clip tabs disabled means all tabs are visible and the minimum size holds all of them.
+		tab_bar->set_clip_tabs(false);
+		CHECK_FALSE(tab_bar->get_clip_tabs());
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_bar->get_tab_offset() == 0);
+		CHECK(tab_bar->get_minimum_size() == tab_bar->get_size());
+		CHECK(tab_bar->get_size().x == tab_rects[0].size.x + tab_rects[1].size.x + tab_rects[2].size.x);
+		CHECK(tab_bar->get_size().y == MAX(tab_rects[0].size.y, MAX(tab_rects[1].size.y, tab_rects[2].size.y)));
+
+		tab_bar->set_clip_tabs(true);
+		CHECK(tab_bar->get_clip_tabs());
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_bar->get_tab_offset() == 0);
+
+		// Horizontal size and minimum size get set to 0.
+		CHECK(tab_bar->get_minimum_size().x == 0);
+		CHECK(tab_bar->get_minimum_size().y == all_tabs_size.y);
+		CHECK(tab_bar->get_size().x == 0);
+		CHECK(tab_bar->get_size().y == all_tabs_size.y);
+	}
+
+	SUBCASE("[TabBar] ensure tab visible") {
+		tab_bar->set_scroll_to_selected(false);
+		tab_bar->set_clip_tabs(true);
+
+		// Resize tab bar to only be able to fit 2 tabs.
+		const float offset_button_size = tab_bar->get_theme_icon("decrement_icon")->get_width() + tab_bar->get_theme_icon("increment_icon")->get_width();
+		tab_bar->set_size(Size2(tab_rects[2].size.x + tab_rects[1].size.x + offset_button_size, all_tabs_size.y));
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_bar->get_tab_offset() == 0);
+		CHECK(tab_bar->get_offset_buttons_visible());
+
+		// Scroll right to a tab that is not visible.
+		tab_bar->ensure_tab_visible(2);
+		CHECK(tab_bar->get_tab_offset() == 1);
+		CHECK(tab_bar->get_tab_rect(1).position.x == 0);
+		CHECK(tab_bar->get_tab_rect(2).position.x == tab_rects[1].size.x);
+
+		tab_bar->set_tab_offset(2);
+		CHECK(tab_bar->get_tab_offset() == 2);
+		CHECK(tab_bar->get_tab_rect(2).position.x == 0);
+
+		// Scroll left to a previous tab.
+		tab_bar->ensure_tab_visible(1);
+		CHECK(tab_bar->get_tab_offset() == 1);
+		CHECK(tab_bar->get_tab_rect(1).position.x == 0);
+		CHECK(tab_bar->get_tab_rect(2).position.x == tab_rects[1].size.x);
+
+		// Will not scroll if the tab is already visible.
+		tab_bar->ensure_tab_visible(2);
+		CHECK(tab_bar->get_tab_offset() == 1);
+		CHECK(tab_bar->get_tab_rect(1).position.x == 0);
+		CHECK(tab_bar->get_tab_rect(2).position.x == tab_rects[1].size.x);
+	}
+
+	memdelete(tab_bar);
+}
+
+// FIXME: Add tests for mouse click, keyboard navigation, and drag and drop.
+
+} // namespace TestTabBar
+
+#endif // TEST_TAB_BAR_H

--- a/tests/scene/test_tab_container.h
+++ b/tests/scene/test_tab_container.h
@@ -1,0 +1,671 @@
+/**************************************************************************/
+/*  test_tab_container.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_TAB_CONTAINER_H
+#define TEST_TAB_CONTAINER_H
+
+#include "scene/gui/tab_container.h"
+
+#include "tests/test_macros.h"
+
+namespace TestTabContainer {
+static inline Array build_array() {
+	return Array();
+}
+template <typename... Targs>
+static inline Array build_array(Variant item, Targs... Fargs) {
+	Array a = build_array(Fargs...);
+	a.push_front(item);
+	return a;
+}
+
+TEST_CASE("[SceneTree][TabContainer] tab operations") {
+	TabContainer *tab_container = memnew(TabContainer);
+	SceneTree::get_singleton()->get_root()->add_child(tab_container);
+	MessageQueue::get_singleton()->flush();
+	SIGNAL_WATCH(tab_container, "tab_selected");
+	SIGNAL_WATCH(tab_container, "tab_changed");
+
+	Control *tab0 = memnew(Control);
+	tab0->set_name("tab0");
+	Control *tab1 = memnew(Control);
+	tab1->set_name("tab1");
+	Control *tab2 = memnew(Control);
+	tab2->set_name("tab2");
+
+	SUBCASE("[TabContainer] add tabs by adding children") {
+		CHECK(tab_container->get_tab_count() == 0);
+		CHECK(tab_container->get_current_tab() == -1);
+		CHECK(tab_container->get_previous_tab() == -1);
+
+		// Add first tab child.
+		tab_container->add_child(tab0);
+		// MessageQueue::get_singleton()->flush();
+		CHECK(tab_container->get_tab_count() == 1);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+
+		// Add second tab child.
+		tab_container->add_child(tab1);
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Check default values, the title is the name of the child.
+		CHECK(tab_container->get_tab_control(0) == tab0);
+		CHECK(tab_container->get_tab_idx_from_control(tab0) == 0);
+		CHECK(tab_container->get_tab_title(0) == "tab0");
+		CHECK(tab_container->get_tab_tooltip(0) == "");
+		CHECK_FALSE(tab_container->is_tab_disabled(0));
+		CHECK_FALSE(tab_container->is_tab_hidden(0));
+
+		CHECK(tab_container->get_tab_control(1) == tab1);
+		CHECK(tab_container->get_tab_idx_from_control(tab1) == 1);
+		CHECK(tab_container->get_tab_title(1) == "tab1");
+		CHECK(tab_container->get_tab_tooltip(1) == "");
+		CHECK_FALSE(tab_container->is_tab_disabled(1));
+		CHECK_FALSE(tab_container->is_tab_hidden(1));
+	}
+
+	SUBCASE("[TabContainer] remove tabs by removing children") {
+		tab_container->add_child(tab0);
+		tab_container->add_child(tab1);
+		tab_container->add_child(tab2);
+		tab_container->set_current_tab(1);
+		CHECK(tab_container->get_tab_count() == 3);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Remove first tab.
+		tab_container->remove_child(tab0);
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_tab_title(0) == "tab1");
+		CHECK(tab_container->get_tab_title(1) == "tab2");
+		CHECK(tab_container->get_tab_idx_from_control(tab1) == 0);
+		CHECK(tab_container->get_tab_idx_from_control(tab2) == 1);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Remove last tab.
+		tab_container->remove_child(tab2);
+		CHECK(tab_container->get_tab_count() == 1);
+		CHECK(tab_container->get_tab_title(0) == "tab1");
+		CHECK(tab_container->get_tab_idx_from_control(tab1) == 0);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Remove only tab.
+		tab_container->remove_child(tab1);
+		CHECK(tab_container->get_tab_count() == 0);
+		CHECK(tab_container->get_current_tab() == -1);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK("tab_changed", build_array(build_array(-1)));
+
+		// Remove current tab when there are other tabs.
+		tab_container->add_child(tab0);
+		tab_container->add_child(tab1);
+		tab_container->add_child(tab2);
+		tab_container->set_current_tab(1);
+		tab_container->set_current_tab(2);
+		CHECK(tab_container->get_tab_count() == 3);
+		CHECK(tab_container->get_current_tab() == 2);
+		CHECK(tab_container->get_previous_tab() == 1);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		tab_container->remove_child(tab2);
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+	}
+
+	SUBCASE("[TabContainer] move tabs by moving children") {
+		tab_container->add_child(tab0);
+		tab_container->add_child(tab1);
+		tab_container->add_child(tab2);
+		tab_container->set_current_tab(1);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+
+		// Move the first tab to the end.
+		tab_container->move_child(tab0, 2);
+		CHECK(tab_container->get_tab_idx_from_control(tab0) == 2);
+		CHECK(tab_container->get_tab_idx_from_control(tab1) == 0);
+		CHECK(tab_container->get_tab_idx_from_control(tab2) == 1);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == 2);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Move the second tab to the front.
+		tab_container->move_child(tab2, 0);
+		CHECK(tab_container->get_tab_idx_from_control(tab0) == 2);
+		CHECK(tab_container->get_tab_idx_from_control(tab1) == 1);
+		CHECK(tab_container->get_tab_idx_from_control(tab2) == 0);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 2);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+	}
+
+	SUBCASE("[TabContainer] set current tab") {
+		tab_container->add_child(tab0);
+		tab_container->add_child(tab1);
+		tab_container->add_child(tab2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(0)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(0)));
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab0->is_visible());
+		CHECK_FALSE(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+
+		// Set the current tab.
+		tab_container->set_current_tab(1);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		MessageQueue::get_singleton()->flush();
+		CHECK_FALSE(tab0->is_visible());
+		CHECK(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+
+		// Set to same tab.
+		tab_container->set_current_tab(1);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK_FALSE("tab_changed");
+		MessageQueue::get_singleton()->flush();
+		CHECK_FALSE(tab0->is_visible());
+		CHECK(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+
+		// Out of bounds.
+		ERR_PRINT_OFF;
+		tab_container->set_current_tab(-5);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		MessageQueue::get_singleton()->flush();
+		CHECK_FALSE(tab0->is_visible());
+		CHECK(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+
+		tab_container->set_current_tab(5);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		MessageQueue::get_singleton()->flush();
+		CHECK_FALSE(tab0->is_visible());
+		CHECK(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+		ERR_PRINT_ON;
+	}
+
+	SUBCASE("[TabContainer] change current tab by changing visibility of children") {
+		tab_container->add_child(tab0);
+		tab_container->add_child(tab1);
+		tab_container->add_child(tab2);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab0->is_visible());
+		CHECK_FALSE(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+
+		// Show a child to make it the current tab.
+		tab1->show();
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		MessageQueue::get_singleton()->flush();
+		CHECK_FALSE(tab0->is_visible());
+		CHECK(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+
+		// Hide the visible child to select the next tab.
+		tab1->hide();
+		CHECK(tab_container->get_current_tab() == 2);
+		CHECK(tab_container->get_previous_tab() == 1);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(2)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(2)));
+		MessageQueue::get_singleton()->flush();
+		CHECK_FALSE(tab0->is_visible());
+		CHECK_FALSE(tab1->is_visible());
+		CHECK(tab2->is_visible());
+
+		// Hide the visible child to select the previous tab if there is no next.
+		tab2->hide();
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 2);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		MessageQueue::get_singleton()->flush();
+		CHECK_FALSE(tab0->is_visible());
+		CHECK(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+
+		// Cannot hide if there is only one valid child since deselection is not enabled.
+		tab_container->remove_child(tab1);
+		tab_container->remove_child(tab2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_DISCARD("tab_selected");
+		SIGNAL_DISCARD("tab_changed");
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab0->is_visible());
+
+		tab0->hide();
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab0->is_visible());
+
+		// Can hide the last tab if deselection is enabled.
+		tab_container->set_deselect_enabled(true);
+		tab0->hide();
+		CHECK(tab_container->get_current_tab() == -1);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(-1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(-1)));
+		MessageQueue::get_singleton()->flush();
+		CHECK_FALSE(tab0->is_visible());
+	}
+
+	SIGNAL_UNWATCH(tab_container, "tab_selected");
+	SIGNAL_UNWATCH(tab_container, "tab_changed");
+
+	memdelete(tab2);
+	memdelete(tab1);
+	memdelete(tab0);
+	memdelete(tab_container);
+}
+
+TEST_CASE("[SceneTree][TabContainer] initialization") {
+	TabContainer *tab_container = memnew(TabContainer);
+
+	Control *tab0 = memnew(Control);
+	tab0->set_name("tab0");
+	Control *tab1 = memnew(Control);
+	tab1->set_name("tab1 ");
+	Control *tab2 = memnew(Control);
+	tab2->set_name("tab2    ");
+
+	SIGNAL_WATCH(tab_container, "tab_selected");
+	SIGNAL_WATCH(tab_container, "tab_changed");
+
+	SUBCASE("[TabContainer] add children before entering tree") {
+		CHECK(tab_container->get_current_tab() == -1);
+		CHECK(tab_container->get_previous_tab() == -1);
+
+		tab_container->add_child(tab0);
+		CHECK(tab_container->get_tab_count() == 1);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+
+		tab_container->add_child(tab1);
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+
+		SceneTree::get_singleton()->get_root()->add_child(tab_container);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab0->is_visible());
+		CHECK_FALSE(tab1->is_visible());
+	}
+
+	SUBCASE("[TabContainer] current tab can be set before children are added") {
+		// Set the current tab before there are any tabs.
+		// This queues the current tab to update on entering the tree.
+		tab_container->set_current_tab(1);
+		CHECK(tab_container->get_current_tab() == -1);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_container->add_child(tab0);
+		CHECK(tab_container->get_tab_count() == 1);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+
+		tab_container->add_child(tab1);
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+
+		tab_container->add_child(tab2);
+		CHECK(tab_container->get_tab_count() == 3);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// Current tab is set when entering the tree.
+		SceneTree::get_singleton()->get_root()->add_child(tab_container);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_container->get_tab_count() == 3);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		CHECK_FALSE(tab0->is_visible());
+		CHECK(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+	}
+
+	SUBCASE("[TabContainer] cannot set current tab to an invalid value before tabs are set") {
+		tab_container->set_current_tab(100);
+		CHECK(tab_container->get_current_tab() == -1);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_container->add_child(tab0);
+		CHECK(tab_container->get_tab_count() == 1);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_container->add_child(tab1);
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		// This will print an error message as if `set_current_tab` was called after.
+		ERR_PRINT_OFF;
+		SceneTree::get_singleton()->get_root()->add_child(tab_container);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		ERR_PRINT_ON;
+	}
+
+	SUBCASE("[TabContainer] children visibility before entering tree") {
+		CHECK(tab_container->get_current_tab() == -1);
+		CHECK(tab_container->get_previous_tab() == -1);
+
+		// Adding a hidden child first will change visibility because it is the current tab.
+		tab0->hide();
+		tab_container->add_child(tab0);
+		CHECK(tab_container->get_tab_count() == 1);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab0->is_visible());
+
+		// Adding a visible child after will hide it because it is not the current tab.
+		tab_container->add_child(tab1);
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab0->is_visible());
+		CHECK_FALSE(tab1->is_visible());
+
+		// Can change current by showing child now after children have been added.
+		// This queues the current tab to update on entering the tree.
+		tab1->show();
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab0->is_visible());
+		CHECK(tab1->is_visible());
+
+		SceneTree::get_singleton()->get_root()->add_child(tab_container);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_container->get_tab_count() == 2);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		CHECK_FALSE(tab0->is_visible());
+		CHECK(tab1->is_visible());
+	}
+
+	SUBCASE("[TabContainer] setting current tab and changing child visibility after adding") {
+		tab_container->add_child(tab0);
+		tab_container->add_child(tab1);
+		tab_container->add_child(tab2);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+
+		tab2->show();
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_container->get_tab_count() == 3);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+		CHECK(tab0->is_visible());
+		CHECK_FALSE(tab1->is_visible());
+		CHECK(tab2->is_visible());
+
+		// Whichever happens last will have priority.
+		tab_container->set_current_tab(1);
+		CHECK(tab_container->get_current_tab() == 0);
+		CHECK(tab_container->get_previous_tab() == -1);
+
+		// Current tab is set when entering the tree.
+		SceneTree::get_singleton()->get_root()->add_child(tab_container);
+		MessageQueue::get_singleton()->flush();
+		CHECK(tab_container->get_tab_count() == 3);
+		CHECK(tab_container->get_current_tab() == 1);
+		CHECK(tab_container->get_previous_tab() == 0);
+		SIGNAL_CHECK("tab_selected", build_array(build_array(1)));
+		SIGNAL_CHECK("tab_changed", build_array(build_array(1)));
+		CHECK_FALSE(tab0->is_visible());
+		CHECK(tab1->is_visible());
+		CHECK_FALSE(tab2->is_visible());
+	}
+
+	SIGNAL_UNWATCH(tab_container, "tab_selected");
+	SIGNAL_UNWATCH(tab_container, "tab_changed");
+
+	memdelete(tab2);
+	memdelete(tab1);
+	memdelete(tab0);
+	memdelete(tab_container);
+}
+
+TEST_CASE("[SceneTree][TabContainer] layout and offset") {
+	TabContainer *tab_container = memnew(TabContainer);
+	SceneTree::get_singleton()->get_root()->add_child(tab_container);
+	tab_container->set_clip_tabs(false);
+
+	Control *tab0 = memnew(Control);
+	tab0->set_name("tab0");
+	Control *tab1 = memnew(Control);
+	tab1->set_name("tab1 ");
+	Control *tab2 = memnew(Control);
+	tab2->set_name("tab2    ");
+
+	tab_container->add_child(tab0);
+	tab_container->add_child(tab1);
+	tab_container->add_child(tab2);
+
+	MessageQueue::get_singleton()->flush();
+
+	Size2 all_tabs_size = tab_container->get_size();
+	const float side_margin = tab_container->get_theme_constant("side_margin");
+
+	TabBar *tab_bar = tab_container->get_tab_bar();
+
+	Vector<Rect2> tab_rects = {
+		tab_bar->get_tab_rect(0),
+		tab_bar->get_tab_rect(1),
+		tab_bar->get_tab_rect(2)
+	};
+
+	SUBCASE("[TabContainer] tabs are arranged next to each other") {
+		// Horizontal positions are next to each other.
+		CHECK(tab_rects[0].position.x == 0);
+		CHECK(tab_rects[1].position.x == tab_rects[0].size.x);
+		CHECK(tab_rects[2].position.x == tab_rects[1].position.x + tab_rects[1].size.x);
+
+		// Fills the entire width.
+		CHECK(tab_rects[2].position.x + tab_rects[2].size.x == all_tabs_size.x - side_margin);
+
+		// Horizontal sizes are positive.
+		CHECK(tab_rects[0].size.x > 0);
+		CHECK(tab_rects[1].size.x > 0);
+		CHECK(tab_rects[2].size.x > 0);
+
+		// Vertical positions are at 0.
+		CHECK(tab_rects[0].position.y == 0);
+		CHECK(tab_rects[1].position.y == 0);
+		CHECK(tab_rects[2].position.y == 0);
+
+		// Vertical sizes are the same.
+		CHECK(tab_rects[0].size.y == tab_rects[1].size.y);
+		CHECK(tab_rects[1].size.y == tab_rects[2].size.y);
+	}
+
+	SUBCASE("[TabContainer] tab position") {
+		float tab_height = tab_rects[0].size.y;
+		Ref<StyleBox> panel_style = tab_container->get_theme_stylebox("panel_style");
+
+		// Initial position, same as top position.
+		// Tab bar is at the top.
+		CHECK(tab_bar->get_anchor(SIDE_TOP) == 0);
+		CHECK(tab_bar->get_anchor(SIDE_BOTTOM) == 0);
+		CHECK(tab_bar->get_anchor(SIDE_LEFT) == 0);
+		CHECK(tab_bar->get_anchor(SIDE_RIGHT) == 1);
+		CHECK(tab_bar->get_offset(SIDE_TOP) == 0);
+		CHECK(tab_bar->get_offset(SIDE_BOTTOM) == tab_height);
+		CHECK(tab_bar->get_offset(SIDE_LEFT) == side_margin);
+		CHECK(tab_bar->get_offset(SIDE_RIGHT) == 0);
+
+		// Child is expanded and below the tab bar.
+		CHECK(tab0->get_anchor(SIDE_TOP) == 0);
+		CHECK(tab0->get_anchor(SIDE_BOTTOM) == 1);
+		CHECK(tab0->get_anchor(SIDE_LEFT) == 0);
+		CHECK(tab0->get_anchor(SIDE_RIGHT) == 1);
+		CHECK(tab0->get_offset(SIDE_TOP) == tab_height);
+		CHECK(tab0->get_offset(SIDE_BOTTOM) == 0);
+		CHECK(tab0->get_offset(SIDE_LEFT) == 0);
+		CHECK(tab0->get_offset(SIDE_RIGHT) == 0);
+
+		// Bottom position.
+		tab_container->set_tabs_position(TabContainer::POSITION_BOTTOM);
+		CHECK(tab_container->get_tabs_position() == TabContainer::POSITION_BOTTOM);
+		MessageQueue::get_singleton()->flush();
+
+		// Tab bar is at the bottom.
+		CHECK(tab_bar->get_anchor(SIDE_TOP) == 1);
+		CHECK(tab_bar->get_anchor(SIDE_BOTTOM) == 1);
+		CHECK(tab_bar->get_anchor(SIDE_LEFT) == 0);
+		CHECK(tab_bar->get_anchor(SIDE_RIGHT) == 1);
+		CHECK(tab_bar->get_offset(SIDE_TOP) == -tab_height);
+		CHECK(tab_bar->get_offset(SIDE_BOTTOM) == 0);
+		CHECK(tab_bar->get_offset(SIDE_LEFT) == side_margin);
+		CHECK(tab_bar->get_offset(SIDE_RIGHT) == 0);
+
+		// Child is expanded and above the tab bar.
+		CHECK(tab0->get_anchor(SIDE_TOP) == 0);
+		CHECK(tab0->get_anchor(SIDE_BOTTOM) == 1);
+		CHECK(tab0->get_anchor(SIDE_LEFT) == 0);
+		CHECK(tab0->get_anchor(SIDE_RIGHT) == 1);
+		CHECK(tab0->get_offset(SIDE_TOP) == 0);
+		CHECK(tab0->get_offset(SIDE_BOTTOM) == -tab_height);
+		CHECK(tab0->get_offset(SIDE_LEFT) == 0);
+		CHECK(tab0->get_offset(SIDE_RIGHT) == 0);
+
+		// Top position.
+		tab_container->set_tabs_position(TabContainer::POSITION_TOP);
+		CHECK(tab_container->get_tabs_position() == TabContainer::POSITION_TOP);
+		MessageQueue::get_singleton()->flush();
+
+		// Tab bar is at the top.
+		CHECK(tab_bar->get_anchor(SIDE_TOP) == 0);
+		CHECK(tab_bar->get_anchor(SIDE_BOTTOM) == 0);
+		CHECK(tab_bar->get_anchor(SIDE_LEFT) == 0);
+		CHECK(tab_bar->get_anchor(SIDE_RIGHT) == 1);
+		CHECK(tab_bar->get_offset(SIDE_TOP) == 0);
+		CHECK(tab_bar->get_offset(SIDE_BOTTOM) == tab_height);
+		CHECK(tab_bar->get_offset(SIDE_LEFT) == side_margin);
+		CHECK(tab_bar->get_offset(SIDE_RIGHT) == 0);
+
+		// Child is expanded and below the tab bar.
+		CHECK(tab0->get_anchor(SIDE_TOP) == 0);
+		CHECK(tab0->get_anchor(SIDE_BOTTOM) == 1);
+		CHECK(tab0->get_anchor(SIDE_LEFT) == 0);
+		CHECK(tab0->get_anchor(SIDE_RIGHT) == 1);
+		CHECK(tab0->get_offset(SIDE_TOP) == tab_height);
+		CHECK(tab0->get_offset(SIDE_BOTTOM) == 0);
+		CHECK(tab0->get_offset(SIDE_LEFT) == 0);
+		CHECK(tab0->get_offset(SIDE_RIGHT) == 0);
+	}
+
+	memdelete(tab_container);
+}
+
+// FIXME: Add tests for mouse click, keyboard navigation, and drag and drop.
+
+} // namespace TestTabContainer
+
+#endif // TEST_TAB_CONTAINER_H

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -376,6 +376,9 @@ public:
 
 	bool check_false(const String &p_name) {
 		bool has = _signals.has(p_name);
+		if (has) {
+			MESSAGE("Signal has " << _signals[p_name] << " expected none.");
+		}
 		discard_signal(p_name);
 		return !has;
 	}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -138,6 +138,8 @@
 #include "tests/scene/test_color_picker.h"
 #include "tests/scene/test_graph_node.h"
 #include "tests/scene/test_option_button.h"
+#include "tests/scene/test_tab_bar.h"
+#include "tests/scene/test_tab_container.h"
 #include "tests/scene/test_text_edit.h"
 #include "tests/scene/test_tree.h"
 #endif // ADVANCED_GUI_DISABLED


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/97253

Fixed TabContainer emitting multiple signals when being added to the tree if a child was made visible (for the `children visibility before entering tree` test).

Adds tests for TabBar and TabContainer.
Includes basic tests for adding and removing tabs, setting current tab, adding tabs when out of tree (important for initialization), and some layout tests.
This should help prevent regressions.
If there is too much, I can separate it into another PR.

TabBar and TabContainer both have a similar system to allow setting the current_tab before adding tabs, it might be possible to combine them in the future.

I had to make a public `set_tab_offset` since there was no other way to set the tab offset other than sending a mouse click to the offset buttons, `ensure_tab_visible` doesn't offer enough control. We should consider exposing it in the future.

Also added a debug message for if `SIGNAL_CHECK_FALSE` fails, it now says what the actual arguments are, just like `SIGNAL_CHECK`.
