### PR TITLE
Proof of concept: forward declare shader files so they don't cause recompilation waterfalls

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -39,6 +39,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/templates/sort_array.h"
+#include "drivers/gles3/shaders/scene.glsl.gen.h"
 #include "servers/rendering/rendering_server_default.h"
 #include "servers/rendering/rendering_server_globals.h"
 
@@ -3263,7 +3264,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			}
 
 			if (prev_shader != shader || prev_variant != instance_variant || spec_constants != prev_spec_constants) {
-				bool success = material_storage->shaders.scene_shader.version_bind_shader(shader->version, instance_variant, spec_constants);
+				bool success = material_storage->shaders.scene_shader->version_bind_shader(shader->version, instance_variant, spec_constants);
 				if (!success) {
 					break;
 				}
@@ -3275,7 +3276,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 					opaque_prepass_threshold = 0.1;
 				}
 
-				material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::OPAQUE_PREPASS_THRESHOLD, opaque_prepass_threshold, shader->version, instance_variant, spec_constants);
+				material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::OPAQUE_PREPASS_THRESHOLD, opaque_prepass_threshold, shader->version, instance_variant, spec_constants);
 
 				prev_shader = shader;
 				prev_variant = instance_variant;
@@ -3293,8 +3294,8 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 							uint32_t light_id = inst->light_passes[pass].light_id;
 							bool is_omni = inst->light_passes[pass].is_omni;
 							SceneShaderGLES3::Uniforms uniform_name = is_omni ? SceneShaderGLES3::OMNI_LIGHT_INDEX : SceneShaderGLES3::SPOT_LIGHT_INDEX;
-							material_storage->shaders.scene_shader.version_set_uniform(uniform_name, uint32_t(light_id), shader->version, instance_variant, spec_constants);
-							material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::POSITIONAL_SHADOW_INDEX, uint32_t(shadow_id), shader->version, instance_variant, spec_constants);
+							material_storage->shaders.scene_shader->version_set_uniform(uniform_name, uint32_t(light_id), shader->version, instance_variant, spec_constants);
+							material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::POSITIONAL_SHADOW_INDEX, uint32_t(shadow_id), shader->version, instance_variant, spec_constants);
 
 							glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 3);
 							RID light_instance_rid = inst->light_passes[pass].light_instance_rid;
@@ -3308,7 +3309,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						}
 					} else {
 						uint32_t shadow_id = MAX_DIRECTIONAL_LIGHTS - 1 - (pass - int32_t(inst->light_passes.size()));
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::DIRECTIONAL_SHADOW_INDEX, shadow_id, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::DIRECTIONAL_SHADOW_INDEX, shadow_id, shader->version, instance_variant, spec_constants);
 
 						GLuint tex = GLES3::LightStorage::get_singleton()->directional_shadow_get_texture();
 						glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 3);
@@ -3319,15 +3320,15 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 				// Pass light count and array of light indices for base pass.
 				if ((prev_inst != inst || prev_shader != shader || prev_variant != instance_variant) && pass == 0) {
 					// Rebind the light indices.
-					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::OMNI_LIGHT_COUNT, inst->omni_light_gl_cache.size(), shader->version, instance_variant, spec_constants);
-					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::SPOT_LIGHT_COUNT, inst->spot_light_gl_cache.size(), shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::OMNI_LIGHT_COUNT, inst->omni_light_gl_cache.size(), shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::SPOT_LIGHT_COUNT, inst->spot_light_gl_cache.size(), shader->version, instance_variant, spec_constants);
 
 					if (inst->omni_light_gl_cache.size()) {
-						glUniform1uiv(material_storage->shaders.scene_shader.version_get_uniform(SceneShaderGLES3::OMNI_LIGHT_INDICES, shader->version, instance_variant, spec_constants), inst->omni_light_gl_cache.size(), inst->omni_light_gl_cache.ptr());
+						glUniform1uiv(material_storage->shaders.scene_shader->version_get_uniform(SceneShaderGLES3::OMNI_LIGHT_INDICES, shader->version, instance_variant, spec_constants), inst->omni_light_gl_cache.size(), inst->omni_light_gl_cache.ptr());
 					}
 
 					if (inst->spot_light_gl_cache.size()) {
-						glUniform1uiv(material_storage->shaders.scene_shader.version_get_uniform(SceneShaderGLES3::SPOT_LIGHT_INDICES, shader->version, instance_variant, spec_constants), inst->spot_light_gl_cache.size(), inst->spot_light_gl_cache.ptr());
+						glUniform1uiv(material_storage->shaders.scene_shader->version_get_uniform(SceneShaderGLES3::SPOT_LIGHT_INDICES, shader->version, instance_variant, spec_constants), inst->spot_light_gl_cache.size(), inst->spot_light_gl_cache.ptr());
 					}
 
 					if (inst->lightmap_instance.is_valid()) {
@@ -3338,14 +3339,14 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
 						glBindTexture(GL_TEXTURE_2D_ARRAY, tex);
 
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::LIGHTMAP_SLICE, inst->lightmap_slice_index, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::LIGHTMAP_SLICE, inst->lightmap_slice_index, shader->version, instance_variant, spec_constants);
 
 						Vector4 uv_scale(inst->lightmap_uv_scale.position.x, inst->lightmap_uv_scale.position.y, inst->lightmap_uv_scale.size.x, inst->lightmap_uv_scale.size.y);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::LIGHTMAP_UV_SCALE, uv_scale, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::LIGHTMAP_UV_SCALE, uv_scale, shader->version, instance_variant, spec_constants);
 
 						if (lightmap_bicubic_upscale) {
 							Vector2 light_texture_size(lm->light_texture_size.x, lm->light_texture_size.y);
-							material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::LIGHTMAP_TEXTURE_SIZE, light_texture_size, shader->version, instance_variant, spec_constants);
+							material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::LIGHTMAP_TEXTURE_SIZE, light_texture_size, shader->version, instance_variant, spec_constants);
 						}
 
 						float exposure_normalization = 1.0;
@@ -3353,7 +3354,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 							float enf = RSG::camera_attributes->camera_attributes_get_exposure_normalization_factor(p_render_data->camera_attributes);
 							exposure_normalization = enf / lm->baked_exposure;
 						}
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::LIGHTMAP_EXPOSURE_NORMALIZATION, exposure_normalization, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::LIGHTMAP_EXPOSURE_NORMALIZATION, exposure_normalization, shader->version, instance_variant, spec_constants);
 
 						if (lm->uses_spherical_harmonics) {
 							Basis to_lm = li->transform.basis.inverse() * p_render_data->cam_transform.basis;
@@ -3369,10 +3370,10 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 								(GLfloat)to_lm.rows[1][2],
 								(GLfloat)to_lm.rows[2][2],
 							};
-							glUniformMatrix3fv(material_storage->shaders.scene_shader.version_get_uniform(SceneShaderGLES3::LIGHTMAP_NORMAL_XFORM, shader->version, instance_variant, spec_constants), 1, GL_FALSE, matrix);
+							glUniformMatrix3fv(material_storage->shaders.scene_shader->version_get_uniform(SceneShaderGLES3::LIGHTMAP_NORMAL_XFORM, shader->version, instance_variant, spec_constants), 1, GL_FALSE, matrix);
 						}
 					} else if (inst->lightmap_sh) {
-						glUniform4fv(material_storage->shaders.scene_shader.version_get_uniform(SceneShaderGLES3::LIGHTMAP_CAPTURES, shader->version, instance_variant, spec_constants), 9, reinterpret_cast<const GLfloat *>(inst->lightmap_sh->sh));
+						glUniform4fv(material_storage->shaders.scene_shader->version_get_uniform(SceneShaderGLES3::LIGHTMAP_CAPTURES, shader->version, instance_variant, spec_constants), 9, reinterpret_cast<const GLfloat *>(inst->lightmap_sh->sh));
 					}
 
 					prev_inst = inst;
@@ -3390,14 +3391,14 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						RID probe_rid = light_storage->reflection_probe_instance_get_probe(inst->reflection_probe_rid_cache[0]);
 						GLES3::ReflectionProbe *probe = light_storage->get_reflection_probe(probe_rid);
 
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_USE_BOX_PROJECT, probe->box_projection, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_BOX_EXTENTS, probe->size * 0.5, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_BOX_OFFSET, probe->origin_offset, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_EXTERIOR, !probe->interior, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_INTENSITY, probe->intensity, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_AMBIENT_MODE, int(probe->ambient_mode), shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_AMBIENT_COLOR, probe->ambient_color * probe->ambient_color_energy, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_LOCAL_MATRIX, inst->reflection_probes_local_transform_cache[0], shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE1_USE_BOX_PROJECT, probe->box_projection, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE1_BOX_EXTENTS, probe->size * 0.5, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE1_BOX_OFFSET, probe->origin_offset, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE1_EXTERIOR, !probe->interior, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE1_INTENSITY, probe->intensity, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE1_AMBIENT_MODE, int(probe->ambient_mode), shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE1_AMBIENT_COLOR, probe->ambient_color * probe->ambient_color_energy, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE1_LOCAL_MATRIX, inst->reflection_probes_local_transform_cache[0], shader->version, instance_variant, spec_constants);
 
 						glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 7);
 						glBindTexture(GL_TEXTURE_CUBE_MAP, light_storage->reflection_probe_instance_get_texture(inst->reflection_probe_rid_cache[0]));
@@ -3408,14 +3409,14 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						RID probe_rid = light_storage->reflection_probe_instance_get_probe(inst->reflection_probe_rid_cache[1]);
 						GLES3::ReflectionProbe *probe = light_storage->get_reflection_probe(probe_rid);
 
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_USE_BOX_PROJECT, probe->box_projection, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_BOX_EXTENTS, probe->size * 0.5, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_BOX_OFFSET, probe->origin_offset, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_EXTERIOR, !probe->interior, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_INTENSITY, probe->intensity, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_AMBIENT_MODE, int(probe->ambient_mode), shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_AMBIENT_COLOR, probe->ambient_color * probe->ambient_color_energy, shader->version, instance_variant, spec_constants);
-						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_LOCAL_MATRIX, inst->reflection_probes_local_transform_cache[1], shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE2_USE_BOX_PROJECT, probe->box_projection, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE2_BOX_EXTENTS, probe->size * 0.5, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE2_BOX_OFFSET, probe->origin_offset, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE2_EXTERIOR, !probe->interior, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE2_INTENSITY, probe->intensity, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE2_AMBIENT_MODE, int(probe->ambient_mode), shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE2_AMBIENT_COLOR, probe->ambient_color * probe->ambient_color_energy, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::REFPROBE2_LOCAL_MATRIX, inst->reflection_probes_local_transform_cache[1], shader->version, instance_variant, spec_constants);
 
 						glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 8);
 						glBindTexture(GL_TEXTURE_CUBE_MAP, light_storage->reflection_probe_instance_get_texture(inst->reflection_probe_rid_cache[1]));
@@ -3425,24 +3426,24 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 				}
 			}
 
-			material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::WORLD_TRANSFORM, world_transform, shader->version, instance_variant, spec_constants);
+			material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::WORLD_TRANSFORM, world_transform, shader->version, instance_variant, spec_constants);
 			{
 				GLES3::Mesh::Surface *s = reinterpret_cast<GLES3::Mesh::Surface *>(surf->surface);
 				if (s->format & RS::ARRAY_FLAG_COMPRESS_ATTRIBUTES) {
-					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_POSITION, s->aabb.position, shader->version, instance_variant, spec_constants);
-					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_SIZE, s->aabb.size, shader->version, instance_variant, spec_constants);
-					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::UV_SCALE, s->uv_scale, shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_POSITION, s->aabb.position, shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_SIZE, s->aabb.size, shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::UV_SCALE, s->uv_scale, shader->version, instance_variant, spec_constants);
 				} else {
-					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_POSITION, Vector3(0.0, 0.0, 0.0), shader->version, instance_variant, spec_constants);
-					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_SIZE, Vector3(1.0, 1.0, 1.0), shader->version, instance_variant, spec_constants);
-					material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::UV_SCALE, Vector4(0.0, 0.0, 0.0, 0.0), shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_POSITION, Vector3(0.0, 0.0, 0.0), shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::COMPRESSED_AABB_SIZE, Vector3(1.0, 1.0, 1.0), shader->version, instance_variant, spec_constants);
+					material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::UV_SCALE, Vector4(0.0, 0.0, 0.0, 0.0), shader->version, instance_variant, spec_constants);
 				}
 			}
 
-			material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::MODEL_FLAGS, inst->flags_cache, shader->version, instance_variant, spec_constants);
+			material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::MODEL_FLAGS, inst->flags_cache, shader->version, instance_variant, spec_constants);
 
 			if (p_pass_mode == PASS_MODE_MATERIAL) {
-				material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::UV_OFFSET, p_params->uv_offset, shader->version, instance_variant, spec_constants);
+				material_storage->shaders.scene_shader->version_set_uniform(SceneShaderGLES3::UV_OFFSET, p_params->uv_offset, shader->version, instance_variant, spec_constants);
 			}
 
 			// Can be index count or vertex count
@@ -4122,9 +4123,10 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 		global_defines += "\n#define MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS " + itos(MAX_DIRECTIONAL_LIGHTS) + "\n";
 		global_defines += "\n#define MAX_FORWARD_LIGHTS " + itos(config->max_lights_per_object) + "u\n";
 		global_defines += "\n#define MAX_ROUGHNESS_LOD " + itos(sky_globals.roughness_layers - 1) + ".0\n";
-		material_storage->shaders.scene_shader.initialize(global_defines);
-		scene_globals.shader_default_version = material_storage->shaders.scene_shader.version_create();
-		material_storage->shaders.scene_shader.version_bind_shader(scene_globals.shader_default_version, SceneShaderGLES3::MODE_COLOR);
+		material_storage->shaders.scene_shader = memnew(SceneShaderGLES3);
+		material_storage->shaders.scene_shader->initialize(global_defines);
+		scene_globals.shader_default_version = material_storage->shaders.scene_shader->version_create();
+		material_storage->shaders.scene_shader->version_bind_shader(scene_globals.shader_default_version, SceneShaderGLES3::MODE_COLOR);
 	}
 
 	{
@@ -4273,7 +4275,7 @@ RasterizerSceneGLES3::~RasterizerSceneGLES3() {
 	memdelete_arr(scene_state.directional_shadows);
 
 	// Scene Shader
-	GLES3::MaterialStorage::get_singleton()->shaders.scene_shader.version_free(scene_globals.shader_default_version);
+	GLES3::MaterialStorage::get_singleton()->shaders.scene_shader->version_free(scene_globals.shader_default_version);
 	RSG::material_storage->material_free(scene_globals.default_material);
 	RSG::material_storage->shader_free(scene_globals.default_shader);
 

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -39,6 +39,7 @@
 
 #include "drivers/gles3/rasterizer_canvas_gles3.h"
 #include "drivers/gles3/rasterizer_gles3.h"
+#include "drivers/gles3/shaders/scene.glsl.gen.h"
 #include "servers/rendering/storage/variant_converters.h"
 
 using namespace GLES3;
@@ -2969,7 +2970,7 @@ void SceneShaderData::set_code(const String &p_code) {
 	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
 
 	if (version.is_null()) {
-		version = MaterialStorage::get_singleton()->shaders.scene_shader.version_create();
+		version = MaterialStorage::get_singleton()->shaders.scene_shader->version_create();
 	}
 
 	blend_mode = BlendMode(blend_modei);
@@ -3035,8 +3036,8 @@ void SceneShaderData::set_code(const String &p_code) {
 
 	LocalVector<ShaderGLES3::TextureUniformData> texture_uniform_data = get_texture_uniform_data(gen_code.texture_uniforms);
 
-	MaterialStorage::get_singleton()->shaders.scene_shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines, texture_uniform_data);
-	ERR_FAIL_COND(!MaterialStorage::get_singleton()->shaders.scene_shader.version_is_valid(version));
+	MaterialStorage::get_singleton()->shaders.scene_shader->version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines, texture_uniform_data);
+	ERR_FAIL_COND(!MaterialStorage::get_singleton()->shaders.scene_shader->version_is_valid(version));
 
 	ubo_size = gen_code.uniform_total_size;
 	ubo_offsets = gen_code.uniform_offsets;
@@ -3067,7 +3068,7 @@ bool SceneShaderData::casts_shadows() const {
 }
 
 RS::ShaderNativeSourceCode SceneShaderData::get_native_source_code() const {
-	return MaterialStorage::get_singleton()->shaders.scene_shader.version_get_native_source_code(version);
+	return MaterialStorage::get_singleton()->shaders.scene_shader->version_get_native_source_code(version);
 }
 
 SceneShaderData::SceneShaderData() {
@@ -3077,7 +3078,7 @@ SceneShaderData::SceneShaderData() {
 
 SceneShaderData::~SceneShaderData() {
 	if (version.is_valid()) {
-		MaterialStorage::get_singleton()->shaders.scene_shader.version_free(version);
+		MaterialStorage::get_singleton()->shaders.scene_shader->version_free(version);
 	}
 }
 

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -44,8 +44,9 @@
 
 #include "drivers/gles3/shaders/canvas.glsl.gen.h"
 #include "drivers/gles3/shaders/particles.glsl.gen.h"
-#include "drivers/gles3/shaders/scene.glsl.gen.h"
 #include "drivers/gles3/shaders/sky.glsl.gen.h"
+
+class SceneShaderGLES3;
 
 namespace GLES3 {
 
@@ -542,7 +543,7 @@ public:
 	struct Shaders {
 		CanvasShaderGLES3 canvas_shader;
 		SkyShaderGLES3 sky_shader;
-		SceneShaderGLES3 scene_shader;
+		SceneShaderGLES3 *scene_shader;
 		ParticlesShaderGLES3 particles_process_shader;
 
 		ShaderCompiler compiler_canvas;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -33,6 +33,7 @@
 #include "core/object/worker_thread_pool.h"
 #include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"
 #include "servers/rendering/renderer_rd/renderer_compositor_rd.h"
+#include "servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl.gen.h"
 #include "servers/rendering/renderer_rd/storage_rd/light_storage.h"
 #include "servers/rendering/renderer_rd/storage_rd/mesh_storage.h"
 #include "servers/rendering/renderer_rd/storage_rd/particles_storage.h"
@@ -1717,7 +1718,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		if (p_render_data->scene_data->view_count > 1) {
 			color_pass_flags |= COLOR_PASS_FLAG_MULTIVIEW;
 			// Try enabling here in case is_xr_enabled() returns false.
-			scene_shader.shader.enable_group(SceneShaderForwardClustered::SHADER_GROUP_MULTIVIEW);
+			scene_shader.shader->enable_group(SceneShaderForwardClustered::SHADER_GROUP_MULTIVIEW);
 		}
 
 		color_framebuffer = rb_data->get_color_pass_fb(color_pass_flags);

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -41,7 +41,6 @@
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
 #include "servers/rendering/renderer_rd/shaders/forward_clustered/best_fit_normal.glsl.gen.h"
-#include "servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl.gen.h"
 #include "servers/rendering/renderer_rd/storage_rd/utilities.h"
 
 #define RB_SCOPE_FORWARD_CLUSTERED SNAME("forward_clustered")

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -32,7 +32,8 @@
 #define SCENE_SHADER_FORWARD_CLUSTERED_H
 
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
-#include "servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl.gen.h"
+
+class SceneForwardClusteredShaderRD;
 
 namespace RendererSceneRenderImplementation {
 
@@ -224,7 +225,7 @@ public:
 		return static_cast<SceneShaderForwardClustered *>(singleton)->_create_material_func(static_cast<ShaderData *>(p_shader));
 	}
 
-	SceneForwardClusteredShaderRD shader;
+	SceneForwardClusteredShaderRD *shader;
 	ShaderCompiler compiler;
 
 	RID default_shader;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -34,11 +34,12 @@
 #include "servers/rendering/renderer_canvas_render.h"
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/renderer_rd/pipeline_cache_rd.h"
-#include "servers/rendering/renderer_rd/shaders/canvas.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/canvas_occlusion.glsl.gen.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/shader_compiler.h"
+
+class CanvasShaderRD;
 
 class RendererCanvasRenderRD : public RendererCanvasRender {
 	enum {
@@ -144,7 +145,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	};
 
 	struct {
-		CanvasShaderRD canvas_shader;
+		CanvasShaderRD *canvas_shader;
 		RID default_version;
 		RID default_version_rd_shader;
 		RID quad_index_buffer;

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.h
@@ -31,7 +31,6 @@
 #ifndef RENDER_SCENE_BUFFERS_RD_H
 #define RENDER_SCENE_BUFFERS_RD_H
 
-#include "../effects/fsr2.h"
 #include "../effects/vrs.h"
 #include "../framebuffer_cache_rd.h"
 #include "core/templates/hash_map.h"

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -34,6 +34,7 @@
 #include "../framebuffer_cache_rd.h"
 #include "material_storage.h"
 #include "servers/rendering/renderer_rd/renderer_scene_render_rd.h"
+#include "servers/rendering/renderer_rd/shaders/canvas_sdf.glsl.gen.h"
 
 using namespace RendererRD;
 
@@ -525,18 +526,20 @@ TextureStorage::TextureStorage() {
 		sdf_modes.push_back("\n#define MODE_STORE\n");
 		sdf_modes.push_back("\n#define MODE_STORE_SHRINK\n");
 
-		rt_sdf.shader.initialize(sdf_modes);
+		rt_sdf.shader = memnew(CanvasSdfShaderRD);
+		rt_sdf.shader->initialize(sdf_modes);
 
-		rt_sdf.shader_version = rt_sdf.shader.version_create();
+		rt_sdf.shader_version = rt_sdf.shader->version_create();
 
 		for (int i = 0; i < RenderTargetSDF::SHADER_MAX; i++) {
-			rt_sdf.pipelines[i] = RD::get_singleton()->compute_pipeline_create(rt_sdf.shader.version_get_shader(rt_sdf.shader_version, i));
+			rt_sdf.pipelines[i] = RD::get_singleton()->compute_pipeline_create(rt_sdf.shader->version_get_shader(rt_sdf.shader_version, i));
 		}
 	}
 }
 
 TextureStorage::~TextureStorage() {
-	rt_sdf.shader.version_free(rt_sdf.shader_version);
+	rt_sdf.shader->version_free(rt_sdf.shader_version);
+	memdelete(rt_sdf.shader);
 
 	free_decal_data();
 
@@ -3716,12 +3719,12 @@ void TextureStorage::_render_target_allocate_sdf(RenderTarget *rt) {
 			uniforms.push_back(u);
 		}
 
-		rt->sdf_buffer_process_uniform_sets[0] = RD::get_singleton()->uniform_set_create(uniforms, rt_sdf.shader.version_get_shader(rt_sdf.shader_version, 0), 0);
+		rt->sdf_buffer_process_uniform_sets[0] = RD::get_singleton()->uniform_set_create(uniforms, rt_sdf.shader->version_get_shader(rt_sdf.shader_version, 0), 0);
 		RID aux2 = uniforms.write[2].get_id(0);
 		RID aux3 = uniforms.write[3].get_id(0);
 		uniforms.write[2].set_id(0, aux3);
 		uniforms.write[3].set_id(0, aux2);
-		rt->sdf_buffer_process_uniform_sets[1] = RD::get_singleton()->uniform_set_create(uniforms, rt_sdf.shader.version_get_shader(rt_sdf.shader_version, 0), 0);
+		rt->sdf_buffer_process_uniform_sets[1] = RD::get_singleton()->uniform_set_create(uniforms, rt_sdf.shader->version_get_shader(rt_sdf.shader_version, 0), 0);
 	}
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -34,11 +34,12 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/paged_array.h"
 #include "core/templates/rid_owner.h"
-#include "servers/rendering/renderer_rd/shaders/canvas_sdf.glsl.gen.h"
 #include "servers/rendering/renderer_rd/storage_rd/forward_id_storage.h"
 #include "servers/rendering/rendering_server_default.h"
 #include "servers/rendering/storage/texture_storage.h"
 #include "servers/rendering/storage/utilities.h"
+
+class CanvasSdfShaderRD;
 
 namespace RendererRD {
 
@@ -446,7 +447,7 @@ private:
 			int32_t pad[2];
 		};
 
-		CanvasSdfShaderRD shader;
+		CanvasSdfShaderRD *shader = nullptr;
 		RID shader_version;
 		RID pipelines[SHADER_MAX];
 	} rt_sdf;


### PR DESCRIPTION
This is purely a benefit for engine developers. Currently when making a change to a shader file we end up recompiling a bunch of random files due to long include chains. We certainly should improve our include chains so changing one rendering file doesn't require main.cpp to recompile. However, in the meantime, avoiding 

This is what a single change to scene_forward_clustered.glsl looks like:
```
scons: Building targets ...
[  3%] Generating servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl.gen.h ...
[ 99%] progress_finish(["progress_finish"], [])
[100%] Compiling servers/rendering/renderer_rd/effects/tone_mapper.cpp ...
[100%] Compiling servers/rendering/renderer_rd/environment/fog.cpp ...
[100%] Compiling servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp ...
[100%] Compiling servers/rendering/renderer_rd/shader_rd.cpp ...
[100%] Compiling servers/rendering/renderer_rd/effects/copy_effects.cpp ...
[100%] Compiling servers/rendering/renderer_rd/effects/resolve.cpp ...
[100%] Compiling servers/rendering/renderer_rd/renderer_compositor_rd.cpp ...
[100%] Compiling platform/macos/display_server_macos.mm ...
[100%] Compiling servers/rendering/renderer_rd/effects/vrs.cpp ...
[100%] Compiling servers/rendering/renderer_rd/environment/gi.cpp ...
[100%] Compiling servers/rendering/renderer_rd/effects/ss_effects.cpp ...
[100%] Compiling servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp ...
[100%] Compiling servers/rendering/renderer_rd/effects/debug_effects.cpp ...
[100%] Compiling servers/rendering/renderer_rd/storage_rd/particles_storage.cpp ...
[100%] Compiling servers/rendering/renderer_rd/renderer_scene_render_rd.cpp ...
[100%] Compiling servers/rendering/renderer_rd/effects/bokeh_dof.cpp ...
[100%] Compiling servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp ...
[100%] Compiling servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp ...
[100%] Compiling servers/rendering/renderer_rd/environment/sky.cpp ...
[100%] Linking Static Library servers/libservers.macos.editor.dev.arm64.a ...
[100%] Ranlib Library servers/libservers.macos.editor.dev.arm64.a ...
[100%] Linking Program bin/godot.macos.editor.dev.arm64 ...
[100%] scons: done building targets.
[Time elapsed: 00:00:24.94]
 *  Terminal will be reused by tasks, press any key to close it.
```

There is no reason we should be recompiling the canvas render file or the mobile render file when we make a small change to the clustered renderer shader. 

After this change, it reduces to:

```
scons: Building targets ...
[ 89%] Generating servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl.gen.h ...
[ 99%] progress_finish(["progress_finish"], [])
[100%] Compiling servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp ...
[100%] Compiling servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp ...
[100%] Linking Static Library servers/libservers.macos.editor.dev.arm64.a ...
[100%] Ranlib Library servers/libservers.macos.editor.dev.arm64.a ...
[100%] Linking Program bin/godot.macos.editor.dev.arm64 ...
[100%] scons: done building targets.
[Time elapsed: 00:00:14.70]
 *  Terminal will be reused by tasks, press any key to close it. 
```

Much better!

Note, in both cases the majority of compile time is taken up by linking. 

Opening as draft for now until I move more shaders to this style. 