### PR TITLE
Calculate pixel snap in canvas space instead of world space

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -262,14 +262,14 @@ void main() {
 
 	color_interp = color;
 
+	vertex = (canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
+
 	if (use_pixel_snap) {
 		vertex = floor(vertex + 0.5);
 		// precision issue on some hardware creates artifacts within texture
 		// offset uv by a small amount to avoid
 		uv += 1e-5;
 	}
-
-	vertex = (canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
 
 	vertex_interp = vertex;
 	uv_interp = uv;

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -214,14 +214,14 @@ void main() {
 
 	color_interp = color;
 
+	vertex = (canvas_data.canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
+
 	if (canvas_data.use_pixel_snap) {
 		vertex = floor(vertex + 0.5);
 		// precision issue on some hardware creates artifacts within texture
 		// offset uv by a small amount to avoid
 		uv += 1e-5;
 	}
-
-	vertex = (canvas_data.canvas_transform * vec4(vertex, 0.0, 1.0)).xy;
 
 	vertex_interp = vertex;
 	uv_interp = uv;


### PR DESCRIPTION

This ensures that you are actually snapping to pixels in the viewport and not an arbitrary amount

Fixes: https://github.com/godotengine/godot/issues/67164 and maybe others

During the 4.0 rewrite, we added the concept of a world matrix. In Godot 3, we didn't transform into world space ever. The modelview matrix transformed directly from model space into canvas space. In Godot 4 we do that transform in 2 stages and pixel snap was mistakenly done _before_ the transformation to canvas space. 

Accordingly, what this actually was doing was snapping to world space units instead of pixels. If your camera was aligned with world space such that a world space unit was the same as a canvas unit, it worked ok. But as soon as you zoom or rotate it would break. 

Here is an MRP that really highlights the issue, it's adapted from https://github.com/godotengine/godot/issues/71074. Basically all it takes is a highly zoomed in camera. When running this in 4.3, the grid turns into a mess, and the player movement jumps several pixel at a time. With this PR it looks perfect.
[PixelSnapMRP.zip](https://github.com/user-attachments/files/17082329/PixelSnapMRP.zip)

_before_
<img width="555" alt="Screenshot 2024-09-20 at 6 03 25 PM" src="https://github.com/user-attachments/assets/f7bef51e-f26b-4235-91c6-bb542d507d3b">

_after_
<img width="553" alt="Screenshot 2024-09-20 at 6 04 13 PM" src="https://github.com/user-attachments/assets/802647ea-d739-4b39-af20-35db2bc27efb">
