### PR TITLE
Fix `_make_custom_tooltip` receiving translated tooltip

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1400,7 +1400,7 @@ String Viewport::_gui_get_tooltip(Control *p_control, const Vector2 &p_pos, Cont
 	String tooltip;
 
 	while (p_control) {
-		tooltip = p_control->atr(p_control->get_tooltip(pos));
+		tooltip = p_control->get_tooltip(pos);
 
 		// Temporary solution for PopupMenus.
 		PopupMenu *menu = Object::cast_to<PopupMenu>(this);


### PR DESCRIPTION
Tooltip text could be pure data instead of text-to-display in order to do customization via `_make_custom_tooltip()`. Thus, we should not translate them immediately through `atr()`.

Tooltips are child nodes of their owner control, so auto translation would do the translation when appropriate.

MRP: [tooltip.zip](https://github.com/user-attachments/files/17082543/tooltip.zip) - `_make_custom_tooltip()` should receive "Before Translation".
