### PR TITLE
Add auto start to particle emitters

### DIFF
--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -171,6 +171,9 @@
 		<member name="emitting" type="bool" setter="set_emitting" getter="is_emitting" default="true">
 			If [code]true[/code], particles are being emitted. [member emitting] can be used to start and stop particles from emitting. However, if [member one_shot] is [code]true[/code] setting [member emitting] to [code]true[/code] will not restart the emission cycle until after all active particles finish processing. You can use the [signal finished] signal to be notified once all active particles finish processing.
 		</member>
+		<member name="auto_start" type="bool" setter="set_auto_start" getter="get_auto_start" default="false">
+			If [code]true[/code], it will start emitting once it is placed in the scene.
+		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">
 			How rapidly particles in an emission cycle are emitted. If greater than [code]0[/code], there will be a gap in emissions before the next cycle begins.
 		</member>

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -171,7 +171,7 @@
 		<member name="emitting" type="bool" setter="set_emitting" getter="is_emitting" default="true">
 			If [code]true[/code], particles are being emitted. [member emitting] can be used to start and stop particles from emitting. However, if [member one_shot] is [code]true[/code] setting [member emitting] to [code]true[/code] will not restart the emission cycle until after all active particles finish processing. You can use the [signal finished] signal to be notified once all active particles finish processing.
 		</member>
-		<member name="auto_start" type="bool" setter="set_auto_start" getter="get_auto_start" default="false">
+		<member name="autostart" type="bool" setter="set_autostart" getter="get_autostart" default="false">
 			If [code]true[/code], it will start emitting once it is placed in the scene.
 		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -190,6 +190,9 @@
 		<member name="emitting" type="bool" setter="set_emitting" getter="is_emitting" default="true">
 			If [code]true[/code], particles are being emitted. [member emitting] can be used to start and stop particles from emitting. However, if [member one_shot] is [code]true[/code] setting [member emitting] to [code]true[/code] will not restart the emission cycle until after all active particles finish processing. You can use the [signal finished] signal to be notified once all active particles finish processing.
 		</member>
+		<member name="auto_start" type="bool" setter="set_auto_start" getter="get_auto_start" default="false">
+			If [code]true[/code], it will start emitting once it is placed in the scene.
+		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">
 			How rapidly particles in an emission cycle are emitted. If greater than [code]0[/code], there will be a gap in emissions before the next cycle begins.
 		</member>

--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -190,7 +190,7 @@
 		<member name="emitting" type="bool" setter="set_emitting" getter="is_emitting" default="true">
 			If [code]true[/code], particles are being emitted. [member emitting] can be used to start and stop particles from emitting. However, if [member one_shot] is [code]true[/code] setting [member emitting] to [code]true[/code] will not restart the emission cycle until after all active particles finish processing. You can use the [signal finished] signal to be notified once all active particles finish processing.
 		</member>
-		<member name="auto_start" type="bool" setter="set_auto_start" getter="get_auto_start" default="false">
+		<member name="autostart" type="bool" setter="set_autostart" getter="get_autostart" default="false">
 			If [code]true[/code], it will start emitting once it is placed in the scene.
 		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">

--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -69,7 +69,7 @@
 			[b]Note:[/b] For [member one_shot] emitters, due to the particles being computed on the GPU, there may be a short period after receiving the [signal finished] signal during which setting this to [code]true[/code] will not restart the emission cycle.
 			[b]Tip:[/b] If your [member one_shot] emitter needs to immediately restart emitting particles once [signal finished] signal is received, consider calling [method restart] instead of setting [member emitting].
 		</member>
-		<member name="auto_start" type="bool" setter="set_auto_start" getter="get_auto_start" default="false">
+		<member name="autostart" type="bool" setter="set_autostart" getter="get_autostart" default="false">
 			If [code]true[/code], it will start emitting once it is placed in the scene.
 		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">

--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -69,6 +69,9 @@
 			[b]Note:[/b] For [member one_shot] emitters, due to the particles being computed on the GPU, there may be a short period after receiving the [signal finished] signal during which setting this to [code]true[/code] will not restart the emission cycle.
 			[b]Tip:[/b] If your [member one_shot] emitter needs to immediately restart emitting particles once [signal finished] signal is received, consider calling [method restart] instead of setting [member emitting].
 		</member>
+		<member name="auto_start" type="bool" setter="set_auto_start" getter="get_auto_start" default="false">
+			If [code]true[/code], it will start emitting once it is placed in the scene.
+		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">
 			How rapidly particles in an emission cycle are emitted. If greater than [code]0[/code], there will be a gap in emissions before the next cycle begins.
 		</member>

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -100,7 +100,7 @@
 			[b]Note:[/b] For [member one_shot] emitters, due to the particles being computed on the GPU, there may be a short period after receiving the [signal finished] signal during which setting this to [code]true[/code] will not restart the emission cycle.
 			[b]Tip:[/b] If your [member one_shot] emitter needs to immediately restart emitting particles once [signal finished] signal is received, consider calling [method restart] instead of setting [member emitting].
 		</member>
-		<member name="auto_start" type="bool" setter="set_auto_start" getter="get_auto_start" default="false">
+		<member name="autostart" type="bool" setter="set_autostart" getter="get_autostart" default="false">
 			If [code]true[/code], it will start emitting once it is placed in the scene.
 		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -100,6 +100,9 @@
 			[b]Note:[/b] For [member one_shot] emitters, due to the particles being computed on the GPU, there may be a short period after receiving the [signal finished] signal during which setting this to [code]true[/code] will not restart the emission cycle.
 			[b]Tip:[/b] If your [member one_shot] emitter needs to immediately restart emitting particles once [signal finished] signal is received, consider calling [method restart] instead of setting [member emitting].
 		</member>
+		<member name="auto_start" type="bool" setter="set_auto_start" getter="get_auto_start" default="false">
+			If [code]true[/code], it will start emitting once it is placed in the scene.
+		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">
 			Time ratio between each emission. If [code]0[/code], particles are emitted continuously. If [code]1[/code], all particles are emitted simultaneously.
 		</member>

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -100,7 +100,7 @@
 			[b]Note:[/b] For [member one_shot] emitters, due to the particles being computed on the GPU, there may be a short period after receiving the [signal finished] signal during which setting this to [code]true[/code] will not restart the emission cycle.
 			[b]Tip:[/b] If your [member one_shot] emitter needs to immediately restart emitting particles once [signal finished] signal is received, consider calling [method restart] instead of setting [member emitting].
 		</member>
-		<member name="autostart" type="bool" setter="set_autostart" getter="get_autostart" default="false">
+		<member name="autostart" type="bool" setter="set_autostart" getter="get_autostart" default="false">
 			If [code]true[/code], it will start emitting once it is placed in the scene.
 		</member>
 		<member name="explosiveness" type="float" setter="set_explosiveness_ratio" getter="get_explosiveness_ratio" default="0.0">

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -48,6 +48,10 @@ void CPUParticles2D::set_emitting(bool p_emitting) {
 	}
 }
 
+void CPUParticles2D::set_auto_start(bool p_auto_start) {
+	auto_start = p_auto_start;
+}
+
 void CPUParticles2D::set_amount(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of particles must be greater than 0.");
 
@@ -102,6 +106,10 @@ void CPUParticles2D::set_speed_scale(double p_scale) {
 
 bool CPUParticles2D::is_emitting() const {
 	return emitting;
+}
+
+bool CPUParticles2D::get_auto_start() const {
+	return auto_start;
 }
 
 int CPUParticles2D::get_amount() const {
@@ -1101,6 +1109,9 @@ void CPUParticles2D::_update_render_thread() {
 void CPUParticles2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			if (auto_start) {
+				set_emitting(true);
+			}
 			set_process_internal(emitting);
 		} break;
 
@@ -1251,6 +1262,7 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 
 void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &CPUParticles2D::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_auto_start", "auto_start"), &CPUParticles2D::set_auto_start);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &CPUParticles2D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &CPUParticles2D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &CPUParticles2D::set_one_shot);
@@ -1263,6 +1275,7 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fractional_delta", "enable"), &CPUParticles2D::set_fractional_delta);
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &CPUParticles2D::set_speed_scale);
 
+	ClassDB::bind_method(D_METHOD("get_auto_start"), &CPUParticles2D::get_auto_start);
 	ClassDB::bind_method(D_METHOD("is_emitting"), &CPUParticles2D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &CPUParticles2D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &CPUParticles2D::get_lifetime);
@@ -1286,6 +1299,7 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart"), &CPUParticles2D::restart);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_start"), "set_auto_start", "get_auto_start");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lifetime", PROPERTY_HINT_RANGE, "0.01,600.0,0.01,or_greater,suffix:s"), "set_lifetime", "get_lifetime");

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -41,6 +41,13 @@ void CPUParticles2D::set_emitting(bool p_emitting) {
 		return;
 	}
 
+	if (p_emitting && !one_shot) {
+		autostart = false;
+		notify_property_list_changed();
+	} else {
+		notify_property_list_changed();
+	}
+
 	emitting = p_emitting;
 	if (emitting) {
 		active = true;
@@ -77,6 +84,13 @@ void CPUParticles2D::set_lifetime(double p_lifetime) {
 
 void CPUParticles2D::set_one_shot(bool p_one_shot) {
 	one_shot = p_one_shot;
+
+	if (emitting && !one_shot) {
+		autostart = false;
+		notify_property_list_changed();
+	} else {
+		notify_property_list_changed();
+	}
 }
 
 void CPUParticles2D::set_pre_process_time(double p_time) {
@@ -543,7 +557,7 @@ void CPUParticles2D::_validate_property(PropertyInfo &p_property) const {
 
 	if (p_property.name == "autostart") {
 		if (emitting && !one_shot) {
-			p_property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
 		}
 	}
 

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -48,8 +48,8 @@ void CPUParticles2D::set_emitting(bool p_emitting) {
 	}
 }
 
-void CPUParticles2D::set_auto_start(bool p_auto_start) {
-	auto_start = p_auto_start;
+void CPUParticles2D::set_autostart(bool p_autostart) {
+	autostart = p_autostart;
 }
 
 void CPUParticles2D::set_amount(int p_amount) {
@@ -108,8 +108,8 @@ bool CPUParticles2D::is_emitting() const {
 	return emitting;
 }
 
-bool CPUParticles2D::get_auto_start() const {
-	return auto_start;
+bool CPUParticles2D::get_autostart() const {
+	return autostart;
 }
 
 int CPUParticles2D::get_amount() const {
@@ -1109,7 +1109,7 @@ void CPUParticles2D::_update_render_thread() {
 void CPUParticles2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			if (auto_start) {
+			if (autostart) {
 				set_emitting(true);
 			}
 			set_process_internal(emitting);
@@ -1262,7 +1262,7 @@ void CPUParticles2D::convert_from_particles(Node *p_particles) {
 
 void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &CPUParticles2D::set_emitting);
-	ClassDB::bind_method(D_METHOD("set_auto_start", "auto_start"), &CPUParticles2D::set_auto_start);
+	ClassDB::bind_method(D_METHOD("set_autostart", "autostart"), &CPUParticles2D::set_autostart);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &CPUParticles2D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &CPUParticles2D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &CPUParticles2D::set_one_shot);
@@ -1275,7 +1275,7 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fractional_delta", "enable"), &CPUParticles2D::set_fractional_delta);
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &CPUParticles2D::set_speed_scale);
 
-	ClassDB::bind_method(D_METHOD("get_auto_start"), &CPUParticles2D::get_auto_start);
+	ClassDB::bind_method(D_METHOD("get_autostart"), &CPUParticles2D::get_autostart);
 	ClassDB::bind_method(D_METHOD("is_emitting"), &CPUParticles2D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &CPUParticles2D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &CPUParticles2D::get_lifetime);
@@ -1299,7 +1299,7 @@ void CPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart"), &CPUParticles2D::restart);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_start"), "set_auto_start", "get_auto_start");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "get_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lifetime", PROPERTY_HINT_RANGE, "0.01,600.0,0.01,or_greater,suffix:s"), "set_lifetime", "get_lifetime");

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -540,6 +540,13 @@ void CPUParticles2D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name.begins_with("scale_curve_") && !split_scale) {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
+
+	if (p_property.name == "autostart") {
+		if (emitting && !one_shot) {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+	}
+
 }
 
 static uint32_t idhash(uint32_t x) {
@@ -1108,10 +1115,17 @@ void CPUParticles2D::_update_render_thread() {
 
 void CPUParticles2D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_READY: {
+#ifdef TOOLS_ENABLED
+			if (is_part_of_edited_scene()) {
+				break;
+			}
+#endif
 			if (autostart) {
 				set_emitting(true);
 			}
+		} break;
+		case NOTIFICATION_ENTER_TREE: {
 			set_process_internal(emitting);
 		} break;
 

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -79,7 +79,7 @@ public:
 private:
 	bool emitting = false;
 	bool active = false;
-	bool auto_start = false;
+	bool autostart = false;
 
 	struct Particle {
 		Transform2D transform;
@@ -198,7 +198,7 @@ protected:
 
 public:
 	void set_emitting(bool p_emitting);
-	void set_auto_start(bool p_auto_start);
+	void set_autostart(bool p_autostart);
 	void set_amount(int p_amount);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -210,7 +210,7 @@ public:
 	void set_speed_scale(double p_scale);
 
 	bool is_emitting() const;
-	bool get_auto_start() const;
+	bool get_autostart() const;
 	int get_amount() const;
 	double get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -79,6 +79,7 @@ public:
 private:
 	bool emitting = false;
 	bool active = false;
+	bool auto_start = false;
 
 	struct Particle {
 		Transform2D transform;
@@ -197,6 +198,7 @@ protected:
 
 public:
 	void set_emitting(bool p_emitting);
+	void set_auto_start(bool p_auto_start);
 	void set_amount(int p_amount);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -208,6 +210,7 @@ public:
 	void set_speed_scale(double p_scale);
 
 	bool is_emitting() const;
+	bool get_auto_start() const;
 	int get_amount() const;
 	double get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -67,6 +67,10 @@ void GPUParticles2D::set_emitting(bool p_emitting) {
 	RS::get_singleton()->particles_set_emitting(particles, p_emitting);
 }
 
+void GPUParticles2D::set_auto_start(bool p_auto_start) {
+	auto_start = p_auto_start;
+}
+
 void GPUParticles2D::set_amount(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of particles cannot be smaller than 1.");
 	amount = p_amount;
@@ -237,6 +241,10 @@ void GPUParticles2D::set_speed_scale(double p_scale) {
 
 bool GPUParticles2D::is_emitting() const {
 	return emitting;
+}
+
+bool GPUParticles2D::get_auto_start() const {
+	return auto_start;
 }
 
 int GPUParticles2D::get_amount() const {
@@ -679,6 +687,9 @@ void GPUParticles2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
+			if (auto_start) {
+				set_emitting(true);
+			}
 			if (sub_emitter != NodePath()) {
 				_attach_sub_emitter();
 			}
@@ -715,6 +726,7 @@ void GPUParticles2D::_notification(int p_what) {
 			if (one_shot) {
 				time += get_process_delta_time();
 				if (time > emission_time) {
+					emitting = false;
 					if (!active) {
 						set_process_internal(false);
 					}
@@ -748,6 +760,7 @@ void GPUParticles2D::_notification(int p_what) {
 
 void GPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &GPUParticles2D::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_auto_start", "auto_start"), &GPUParticles2D::set_auto_start);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &GPUParticles2D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &GPUParticles2D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "secs"), &GPUParticles2D::set_one_shot);
@@ -764,6 +777,7 @@ void GPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_base_size", "size"), &GPUParticles2D::set_collision_base_size);
 	ClassDB::bind_method(D_METHOD("set_interp_to_end", "interp"), &GPUParticles2D::set_interp_to_end);
 
+	ClassDB::bind_method(D_METHOD("get_auto_start"), &GPUParticles2D::get_auto_start);
 	ClassDB::bind_method(D_METHOD("is_emitting"), &GPUParticles2D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &GPUParticles2D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &GPUParticles2D::get_lifetime);
@@ -817,6 +831,8 @@ void GPUParticles2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
 	ADD_PROPERTY_DEFAULT("emitting", true); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_start"), "set_auto_start", "get_auto_start");
+	ADD_PROPERTY_DEFAULT("auto_start", false); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "amount_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_amount_ratio", "get_amount_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "sub_emitter", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "GPUParticles2D"), "set_sub_emitter", "get_sub_emitter");

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -43,6 +43,12 @@
 void GPUParticles2D::set_emitting(bool p_emitting) {
 	// Do not return even if `p_emitting == emitting` because `emitting` is just an approximation.
 
+	if (p_emitting && !one_shot) {
+		autostart = false;
+		notify_property_list_changed();
+	} else {
+		notify_property_list_changed();
+	}
 	if (p_emitting && one_shot) {
 		if (!active && !emitting) {
 			// Last cycle ended.
@@ -78,6 +84,7 @@ void GPUParticles2D::set_amount(int p_amount) {
 }
 
 void GPUParticles2D::set_lifetime(double p_lifetime) {
+
 	ERR_FAIL_COND_MSG(p_lifetime <= 0, "Particles lifetime must be greater than 0.");
 	lifetime = p_lifetime;
 	RS::get_singleton()->particles_set_lifetime(particles, lifetime);
@@ -85,6 +92,12 @@ void GPUParticles2D::set_lifetime(double p_lifetime) {
 
 void GPUParticles2D::set_one_shot(bool p_enable) {
 	one_shot = p_enable;
+	if (emitting && !one_shot) {
+		autostart = false;
+		notify_property_list_changed();
+	} else {
+		notify_property_list_changed();
+	}
 	RS::get_singleton()->particles_set_one_shot(particles, one_shot);
 
 	if (is_emitting()) {
@@ -394,7 +407,7 @@ Ref<Texture2D> GPUParticles2D::get_texture() const {
 void GPUParticles2D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "autostart") {
 		if (emitting && !one_shot) {
-			p_property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
 		}
 	}
 }

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -715,7 +715,6 @@ void GPUParticles2D::_notification(int p_what) {
 			if (one_shot) {
 				time += get_process_delta_time();
 				if (time > emission_time) {
-					emitting = false;
 					if (!active) {
 						set_process_internal(false);
 					}

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -392,6 +392,11 @@ Ref<Texture2D> GPUParticles2D::get_texture() const {
 }
 
 void GPUParticles2D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "autostart") {
+		if (emitting && !one_shot) {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+	}
 }
 
 void GPUParticles2D::emit_particle(const Transform2D &p_transform2d, const Vector2 &p_velocity2d, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) {
@@ -556,6 +561,16 @@ void GPUParticles2D::convert_from_particles(Node *p_particles) {
 
 void GPUParticles2D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+#ifdef TOOLS_ENABLED
+			if (is_part_of_edited_scene()) {
+				break;
+			}
+#endif
+			if (autostart) {
+				set_emitting(true);
+			}
+		} break;
 		case NOTIFICATION_DRAW: {
 			RID texture_rid;
 			Size2 size;
@@ -687,9 +702,6 @@ void GPUParticles2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			if (autostart) {
-				set_emitting(true);
-			}
 			if (sub_emitter != NodePath()) {
 				_attach_sub_emitter();
 			}

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -67,8 +67,8 @@ void GPUParticles2D::set_emitting(bool p_emitting) {
 	RS::get_singleton()->particles_set_emitting(particles, p_emitting);
 }
 
-void GPUParticles2D::set_auto_start(bool p_auto_start) {
-	auto_start = p_auto_start;
+void GPUParticles2D::set_autostart(bool p_autostart) {
+	autostart = p_autostart;
 }
 
 void GPUParticles2D::set_amount(int p_amount) {
@@ -243,8 +243,8 @@ bool GPUParticles2D::is_emitting() const {
 	return emitting;
 }
 
-bool GPUParticles2D::get_auto_start() const {
-	return auto_start;
+bool GPUParticles2D::get_autostart() const {
+	return autostart;
 }
 
 int GPUParticles2D::get_amount() const {
@@ -687,7 +687,7 @@ void GPUParticles2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			if (auto_start) {
+			if (autostart) {
 				set_emitting(true);
 			}
 			if (sub_emitter != NodePath()) {
@@ -760,7 +760,7 @@ void GPUParticles2D::_notification(int p_what) {
 
 void GPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &GPUParticles2D::set_emitting);
-	ClassDB::bind_method(D_METHOD("set_auto_start", "auto_start"), &GPUParticles2D::set_auto_start);
+	ClassDB::bind_method(D_METHOD("set_autostart", "autostart"), &GPUParticles2D::set_autostart);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &GPUParticles2D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &GPUParticles2D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "secs"), &GPUParticles2D::set_one_shot);
@@ -777,7 +777,7 @@ void GPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_collision_base_size", "size"), &GPUParticles2D::set_collision_base_size);
 	ClassDB::bind_method(D_METHOD("set_interp_to_end", "interp"), &GPUParticles2D::set_interp_to_end);
 
-	ClassDB::bind_method(D_METHOD("get_auto_start"), &GPUParticles2D::get_auto_start);
+	ClassDB::bind_method(D_METHOD("get_autostart"), &GPUParticles2D::get_autostart);
 	ClassDB::bind_method(D_METHOD("is_emitting"), &GPUParticles2D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &GPUParticles2D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &GPUParticles2D::get_lifetime);
@@ -831,8 +831,8 @@ void GPUParticles2D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
 	ADD_PROPERTY_DEFAULT("emitting", true); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_start"), "set_auto_start", "get_auto_start");
-	ADD_PROPERTY_DEFAULT("auto_start", false); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "get_autostart");
+	ADD_PROPERTY_DEFAULT("autostart", false); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "amount_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_amount_ratio", "get_amount_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "sub_emitter", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "GPUParticles2D"), "set_sub_emitter", "get_sub_emitter");

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -46,7 +46,7 @@ public:
 
 private:
 	RID particles;
-
+	bool auto_start = false;
 	bool emitting = false;
 	bool active = false;
 	bool signal_canceled = false;
@@ -103,6 +103,7 @@ protected:
 
 public:
 	void set_emitting(bool p_emitting);
+	void set_auto_start(bool p_auto_start);
 	void set_amount(int p_amount);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_enable);
@@ -125,6 +126,7 @@ public:
 #endif
 
 	bool is_emitting() const;
+	bool get_auto_start() const;
 	int get_amount() const;
 	double get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -46,7 +46,7 @@ public:
 
 private:
 	RID particles;
-	bool auto_start = false;
+	bool autostart = false;
 	bool emitting = false;
 	bool active = false;
 	bool signal_canceled = false;
@@ -103,7 +103,7 @@ protected:
 
 public:
 	void set_emitting(bool p_emitting);
-	void set_auto_start(bool p_auto_start);
+	void set_autostart(bool p_autostart);
 	void set_amount(int p_amount);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_enable);
@@ -126,7 +126,7 @@ public:
 #endif
 
 	bool is_emitting() const;
-	bool get_auto_start() const;
+	bool get_autostart() const;
 	int get_amount() const;
 	double get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -578,6 +578,12 @@ void CPUParticles3D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name.begins_with("scale_curve_") && !split_scale) {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
+
+	if (p_property.name == "autostart") {
+		if (emitting && !one_shot) {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+	}
 }
 
 static uint32_t idhash(uint32_t x) {
@@ -1304,10 +1310,17 @@ void CPUParticles3D::_update_render_thread() {
 
 void CPUParticles3D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_READY: {
+#ifdef TOOLS_ENABLED
+			if (is_part_of_edited_scene()) {
+				break;
+			}
+#endif
 			if (autostart) {
 				set_emitting(true);
 			}
+		} break;
+		case NOTIFICATION_ENTER_TREE: {
 			set_process_internal(emitting);
 
 			// first update before rendering to avoid one frame delay after emitting starts

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -59,8 +59,8 @@ void CPUParticles3D::set_emitting(bool p_emitting) {
 	}
 }
 
-void CPUParticles3D::set_auto_start(bool p_auto_start) {
-	auto_start = p_auto_start;
+void CPUParticles3D::set_autostart(bool p_autostart) {
+	autostart = p_autostart;
 }
 
 void CPUParticles3D::set_amount(int p_amount) {
@@ -126,8 +126,8 @@ bool CPUParticles3D::is_emitting() const {
 	return emitting;
 }
 
-bool CPUParticles3D::get_auto_start() const {
-	return auto_start;
+bool CPUParticles3D::get_autostart() const {
+	return autostart;
 }
 
 int CPUParticles3D::get_amount() const {
@@ -1305,7 +1305,7 @@ void CPUParticles3D::_update_render_thread() {
 void CPUParticles3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			if (auto_start) {
+			if (autostart) {
 				set_emitting(true);
 			}
 			set_process_internal(emitting);
@@ -1455,7 +1455,7 @@ void CPUParticles3D::convert_from_particles(Node *p_particles) {
 
 void CPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &CPUParticles3D::set_emitting);
-	ClassDB::bind_method(D_METHOD("set_auto_start", "auto_start"), &CPUParticles3D::set_auto_start);
+	ClassDB::bind_method(D_METHOD("set_autostart", "autostart"), &CPUParticles3D::set_autostart);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &CPUParticles3D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &CPUParticles3D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &CPUParticles3D::set_one_shot);
@@ -1469,7 +1469,7 @@ void CPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fractional_delta", "enable"), &CPUParticles3D::set_fractional_delta);
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &CPUParticles3D::set_speed_scale);
 
-	ClassDB::bind_method(D_METHOD("get_auto_start"), &CPUParticles3D::get_auto_start);
+	ClassDB::bind_method(D_METHOD("get_autostart"), &CPUParticles3D::get_autostart);
 	ClassDB::bind_method(D_METHOD("is_emitting"), &CPUParticles3D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &CPUParticles3D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &CPUParticles3D::get_lifetime);
@@ -1494,7 +1494,7 @@ void CPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart"), &CPUParticles3D::restart);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_start"), "set_auto_start", "get_auto_start");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "get_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lifetime", PROPERTY_HINT_RANGE, "0.01,600.0,0.01,or_greater,exp,suffix:s"), "set_lifetime", "get_lifetime");

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -59,6 +59,10 @@ void CPUParticles3D::set_emitting(bool p_emitting) {
 	}
 }
 
+void CPUParticles3D::set_auto_start(bool p_auto_start) {
+	auto_start = p_auto_start;
+}
+
 void CPUParticles3D::set_amount(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of particles must be greater than 0.");
 
@@ -120,6 +124,10 @@ void CPUParticles3D::set_speed_scale(double p_scale) {
 
 bool CPUParticles3D::is_emitting() const {
 	return emitting;
+}
+
+bool CPUParticles3D::get_auto_start() const {
+	return auto_start;
 }
 
 int CPUParticles3D::get_amount() const {
@@ -1297,6 +1305,9 @@ void CPUParticles3D::_update_render_thread() {
 void CPUParticles3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			if (auto_start) {
+				set_emitting(true);
+			}
 			set_process_internal(emitting);
 
 			// first update before rendering to avoid one frame delay after emitting starts
@@ -1444,6 +1455,7 @@ void CPUParticles3D::convert_from_particles(Node *p_particles) {
 
 void CPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &CPUParticles3D::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_auto_start", "auto_start"), &CPUParticles3D::set_auto_start);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &CPUParticles3D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &CPUParticles3D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &CPUParticles3D::set_one_shot);
@@ -1457,6 +1469,7 @@ void CPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fractional_delta", "enable"), &CPUParticles3D::set_fractional_delta);
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &CPUParticles3D::set_speed_scale);
 
+	ClassDB::bind_method(D_METHOD("get_auto_start"), &CPUParticles3D::get_auto_start);
 	ClassDB::bind_method(D_METHOD("is_emitting"), &CPUParticles3D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &CPUParticles3D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &CPUParticles3D::get_lifetime);
@@ -1481,6 +1494,7 @@ void CPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("restart"), &CPUParticles3D::restart);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_start"), "set_auto_start", "get_auto_start");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
 	ADD_GROUP("Time", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lifetime", PROPERTY_HINT_RANGE, "0.01,600.0,0.01,or_greater,exp,suffix:s"), "set_lifetime", "get_lifetime");

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -47,6 +47,13 @@ void CPUParticles3D::set_emitting(bool p_emitting) {
 		return;
 	}
 
+	if (p_emitting && !one_shot) {
+		autostart = false;
+		notify_property_list_changed();
+	} else {
+		notify_property_list_changed();
+	}
+
 	emitting = p_emitting;
 	if (emitting) {
 		active = true;
@@ -90,6 +97,13 @@ void CPUParticles3D::set_lifetime(double p_lifetime) {
 
 void CPUParticles3D::set_one_shot(bool p_one_shot) {
 	one_shot = p_one_shot;
+
+	if (emitting && !one_shot) {
+		autostart = false;
+		notify_property_list_changed();
+	} else {
+		notify_property_list_changed();
+	}
 }
 
 void CPUParticles3D::set_pre_process_time(double p_time) {
@@ -581,7 +595,7 @@ void CPUParticles3D::_validate_property(PropertyInfo &p_property) const {
 
 	if (p_property.name == "autostart") {
 		if (emitting && !one_shot) {
-			p_property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
 		}
 	}
 }

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -81,6 +81,7 @@ public:
 
 private:
 	bool emitting = false;
+	bool auto_start = false;
 	bool active = false;
 
 	struct Particle {
@@ -206,6 +207,7 @@ public:
 	AABB get_aabb() const override;
 
 	void set_emitting(bool p_emitting);
+	void set_auto_start(bool p_auto_start);
 	void set_amount(int p_amount);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -218,6 +220,7 @@ public:
 	void set_speed_scale(double p_scale);
 
 	bool is_emitting() const;
+	bool get_auto_start() const;
 	int get_amount() const;
 	double get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -81,7 +81,7 @@ public:
 
 private:
 	bool emitting = false;
-	bool auto_start = false;
+	bool autostart = false;
 	bool active = false;
 
 	struct Particle {
@@ -207,7 +207,7 @@ public:
 	AABB get_aabb() const override;
 
 	void set_emitting(bool p_emitting);
-	void set_auto_start(bool p_auto_start);
+	void set_autostart(bool p_autostart);
 	void set_amount(int p_amount);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -220,7 +220,7 @@ public:
 	void set_speed_scale(double p_scale);
 
 	bool is_emitting() const;
-	bool get_auto_start() const;
+	bool get_autostart() const;
 	int get_amount() const;
 	double get_lifetime() const;
 	bool get_one_shot() const;

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -429,6 +429,12 @@ void GPUParticles3D::_validate_property(PropertyInfo &p_property) const {
 			return;
 		}
 	}
+
+	if (p_property.name == "autostart") {
+		if (emitting && !one_shot) {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+	}
 }
 
 void GPUParticles3D::emit_particle(const Transform3D &p_transform, const Vector3 &p_velocity, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) {
@@ -464,6 +470,16 @@ NodePath GPUParticles3D::get_sub_emitter() const {
 
 void GPUParticles3D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+#ifdef TOOLS_ENABLED
+			if (is_part_of_edited_scene()) {
+				break;
+			}
+#endif
+			if (autostart) {
+				set_emitting(true);
+			}
+		} break;
 		// Use internal process when emitting and one_shot is on so that when
 		// the shot ends the editor can properly update.
 		case NOTIFICATION_INTERNAL_PROCESS: {
@@ -502,9 +518,6 @@ void GPUParticles3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			set_process_internal(false);
 			set_physics_process_internal(false);
-			if (autostart) {
-				set_emitting(true);
-			}
 			if (sub_emitter != NodePath()) {
 				_attach_sub_emitter();
 			}

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -68,6 +68,10 @@ void GPUParticles3D::set_emitting(bool p_emitting) {
 	RS::get_singleton()->particles_set_emitting(particles, p_emitting);
 }
 
+void GPUParticles3D::set_auto_start(bool p_auto_start) {
+	auto_start = p_auto_start;
+}
+
 void GPUParticles3D::set_amount(int p_amount) {
 	ERR_FAIL_COND_MSG(p_amount < 1, "Amount of particles cannot be smaller than 1.");
 	amount = p_amount;
@@ -145,6 +149,10 @@ void GPUParticles3D::set_collision_base_size(real_t p_size) {
 
 bool GPUParticles3D::is_emitting() const {
 	return emitting;
+}
+
+bool GPUParticles3D::get_auto_start() const {
+	return auto_start;
 }
 
 int GPUParticles3D::get_amount() const {
@@ -494,6 +502,9 @@ void GPUParticles3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			set_process_internal(false);
 			set_physics_process_internal(false);
+			if (auto_start) {
+				set_emitting(true);
+			}
 			if (sub_emitter != NodePath()) {
 				_attach_sub_emitter();
 			}
@@ -672,6 +683,7 @@ float GPUParticles3D::get_amount_ratio() const {
 
 void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &GPUParticles3D::set_emitting);
+	ClassDB::bind_method(D_METHOD("set_auto_start", "auto_start"), &GPUParticles3D::set_auto_start);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &GPUParticles3D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &GPUParticles3D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &GPUParticles3D::set_one_shot);
@@ -689,6 +701,7 @@ void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_interp_to_end", "interp"), &GPUParticles3D::set_interp_to_end);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &GPUParticles3D::is_emitting);
+	ClassDB::bind_method(D_METHOD("get_auto_start"), &GPUParticles3D::get_auto_start);
 	ClassDB::bind_method(D_METHOD("get_amount"), &GPUParticles3D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &GPUParticles3D::get_lifetime);
 	ClassDB::bind_method(D_METHOD("get_one_shot"), &GPUParticles3D::get_one_shot);
@@ -744,6 +757,8 @@ void GPUParticles3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
 	ADD_PROPERTY_DEFAULT("emitting", true); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_start"), "set_auto_start", "get_auto_start");
+	ADD_PROPERTY_DEFAULT("auto_start", false); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "amount_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_amount_ratio", "get_amount_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "sub_emitter", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "GPUParticles3D"), "set_sub_emitter", "get_sub_emitter");

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -42,6 +42,13 @@ AABB GPUParticles3D::get_aabb() const {
 void GPUParticles3D::set_emitting(bool p_emitting) {
 	// Do not return even if `p_emitting == emitting` because `emitting` is just an approximation.
 
+	if (p_emitting && !one_shot) {
+		autostart = false;
+		notify_property_list_changed();
+	} else {
+		notify_property_list_changed();
+	}
+
 	if (p_emitting && one_shot) {
 		if (!active && !emitting) {
 			// Last cycle ended.
@@ -90,7 +97,15 @@ void GPUParticles3D::set_interp_to_end(float p_interp) {
 }
 
 void GPUParticles3D::set_one_shot(bool p_one_shot) {
+
 	one_shot = p_one_shot;
+
+	if (emitting && !one_shot) {
+		autostart = false;
+		notify_property_list_changed();
+	} else {
+		notify_property_list_changed();
+	}
 	RS::get_singleton()->particles_set_one_shot(particles, one_shot);
 
 	if (is_emitting()) {
@@ -432,7 +447,7 @@ void GPUParticles3D::_validate_property(PropertyInfo &p_property) const {
 
 	if (p_property.name == "autostart") {
 		if (emitting && !one_shot) {
-			p_property.usage = PROPERTY_USAGE_NONE;
+			p_property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
 		}
 	}
 }

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -68,8 +68,8 @@ void GPUParticles3D::set_emitting(bool p_emitting) {
 	RS::get_singleton()->particles_set_emitting(particles, p_emitting);
 }
 
-void GPUParticles3D::set_auto_start(bool p_auto_start) {
-	auto_start = p_auto_start;
+void GPUParticles3D::set_autostart(bool p_autostart) {
+	autostart = p_autostart;
 }
 
 void GPUParticles3D::set_amount(int p_amount) {
@@ -151,8 +151,8 @@ bool GPUParticles3D::is_emitting() const {
 	return emitting;
 }
 
-bool GPUParticles3D::get_auto_start() const {
-	return auto_start;
+bool GPUParticles3D::get_autostart() const {
+	return autostart;
 }
 
 int GPUParticles3D::get_amount() const {
@@ -502,7 +502,7 @@ void GPUParticles3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			set_process_internal(false);
 			set_physics_process_internal(false);
-			if (auto_start) {
+			if (autostart) {
 				set_emitting(true);
 			}
 			if (sub_emitter != NodePath()) {
@@ -683,7 +683,7 @@ float GPUParticles3D::get_amount_ratio() const {
 
 void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_emitting", "emitting"), &GPUParticles3D::set_emitting);
-	ClassDB::bind_method(D_METHOD("set_auto_start", "auto_start"), &GPUParticles3D::set_auto_start);
+	ClassDB::bind_method(D_METHOD("set_autostart", "autostart"), &GPUParticles3D::set_autostart);
 	ClassDB::bind_method(D_METHOD("set_amount", "amount"), &GPUParticles3D::set_amount);
 	ClassDB::bind_method(D_METHOD("set_lifetime", "secs"), &GPUParticles3D::set_lifetime);
 	ClassDB::bind_method(D_METHOD("set_one_shot", "enable"), &GPUParticles3D::set_one_shot);
@@ -701,7 +701,7 @@ void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_interp_to_end", "interp"), &GPUParticles3D::set_interp_to_end);
 
 	ClassDB::bind_method(D_METHOD("is_emitting"), &GPUParticles3D::is_emitting);
-	ClassDB::bind_method(D_METHOD("get_auto_start"), &GPUParticles3D::get_auto_start);
+	ClassDB::bind_method(D_METHOD("get_autostart"), &GPUParticles3D::get_autostart);
 	ClassDB::bind_method(D_METHOD("get_amount"), &GPUParticles3D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &GPUParticles3D::get_lifetime);
 	ClassDB::bind_method(D_METHOD("get_one_shot"), &GPUParticles3D::get_one_shot);
@@ -757,8 +757,8 @@ void GPUParticles3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "emitting"), "set_emitting", "is_emitting");
 	ADD_PROPERTY_DEFAULT("emitting", true); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_start"), "set_auto_start", "get_auto_start");
-	ADD_PROPERTY_DEFAULT("auto_start", false); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "get_autostart");
+	ADD_PROPERTY_DEFAULT("autostart", false); // Workaround for doctool in headless mode, as dummy rasterizer always returns false.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "amount", PROPERTY_HINT_RANGE, "1,1000000,1,exp"), "set_amount", "get_amount");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "amount_ratio", PROPERTY_HINT_RANGE, "0,1,0.0001"), "set_amount_ratio", "get_amount_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "sub_emitter", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "GPUParticles3D"), "set_sub_emitter", "get_sub_emitter");

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -61,6 +61,7 @@ private:
 	RID particles;
 
 	bool emitting = false;
+	bool auto_start = false;
 	bool active = false;
 	bool signal_canceled = false;
 	bool one_shot = false;
@@ -111,6 +112,7 @@ public:
 	AABB get_aabb() const override;
 
 	void set_emitting(bool p_emitting);
+	void set_auto_start(bool p_auto_start);
 	void set_amount(int p_amount);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -127,6 +129,7 @@ public:
 	void set_interp_to_end(float p_interp);
 
 	bool is_emitting() const;
+	bool get_auto_start() const;
 	int get_amount() const;
 
 	double get_lifetime() const;

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -61,7 +61,7 @@ private:
 	RID particles;
 
 	bool emitting = false;
-	bool auto_start = false;
+	bool autostart = false;
 	bool active = false;
 	bool signal_canceled = false;
 	bool one_shot = false;
@@ -112,7 +112,7 @@ public:
 	AABB get_aabb() const override;
 
 	void set_emitting(bool p_emitting);
-	void set_auto_start(bool p_auto_start);
+	void set_autostart(bool p_autostart);
 	void set_amount(int p_amount);
 	void set_lifetime(double p_lifetime);
 	void set_one_shot(bool p_one_shot);
@@ -129,7 +129,7 @@ public:
 	void set_interp_to_end(float p_interp);
 
 	bool is_emitting() const;
-	bool get_auto_start() const;
+	bool get_autostart() const;
 	int get_amount() const;
 
 	double get_lifetime() const;


### PR DESCRIPTION
This fixes the issue where if the Emitting flag is true and the One shot flag is true then Emitting flag is set to false when the emitter has finished and it won't be started if instantiated into the game.  Setting this flag to true will ensure that the emitter is started when added to the game.

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/97213*