### PR TITLE
Fix script editor not underlining Unicode identifiers when Ctrl-hovered

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1265,7 +1265,7 @@ void TextEdit::_notification(int p_what) {
 					}
 
 					if (!clipped && lookup_symbol_word.length() != 0) { // Highlight word
-						if (is_ascii_alphabet_char(lookup_symbol_word[0]) || lookup_symbol_word[0] == '_' || lookup_symbol_word[0] == '.') {
+						if (is_unicode_identifier_start(lookup_symbol_word[0]) || lookup_symbol_word[0] == '.') {
 							Color highlight_underline_color = !editable ? theme_cache.font_readonly_color : theme_cache.font_color;
 							int lookup_symbol_word_col = _get_column_pos_of_word(lookup_symbol_word, str, SEARCH_MATCH_CASE | SEARCH_WHOLE_WORDS, 0);
 							int lookup_symbol_word_len = lookup_symbol_word.length();


### PR DESCRIPTION
In addition to the `symbol_validate` workflow, `TextEdit` has another layer of restriction that only allows underlining symbols whose first character matches the rules of an ASCII identifier (clicking the symbol works fine though).

| Before | After |
|---|---|
| ![Peek 2024-09-21 14-07](https://github.com/user-attachments/assets/9c507ff6-e43c-4a22-8f17-aeb4511e8493) | ![Peek 2024-09-21 14-09](https://github.com/user-attachments/assets/c11a02ac-b4e3-4eb0-b202-59e78d8eacfb) |

I wonder if this restriction could be lifted. But making it accept Unicode identifiers should be relatively safer.