### PR TITLE
Create `.editorconfig` file only on project creation

### DIFF
--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -257,22 +257,6 @@ EditorPaths::EditorPaths() {
 			}
 		}
 
-		// Check that `.editorconfig` file exists.
-		String project_editorconfig_path = "res://.editorconfig";
-		if (!FileAccess::exists(project_editorconfig_path)) {
-			Ref<FileAccess> f = FileAccess::open(project_editorconfig_path, FileAccess::WRITE);
-			if (f.is_valid()) {
-				f->store_line("root = true");
-				f->store_line("");
-				f->store_line("[*]");
-				f->store_line("charset = utf-8");
-				f->close();
-			} else {
-				ERR_PRINT("Failed to create file " + project_editorconfig_path.quote() + ".");
-			}
-			FileAccess::set_hidden_attribute(project_editorconfig_path, true);
-		}
-
 		Engine::get_singleton()->set_shader_cache_path(project_data_dir);
 
 		// Editor metadata dir.

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -552,6 +552,21 @@ void ProjectDialog::ok_pressed() {
 		fa_icon->store_string(get_default_project_icon());
 
 		EditorVCSInterface::create_vcs_metadata_files(EditorVCSInterface::VCSMetadata(vcs_metadata_selection->get_selected()), path);
+
+		// Ensures external editors and IDEs use UTF-8 encoding.
+		const String editor_config_path = path.path_join(".editorconfig");
+		Ref<FileAccess> f = FileAccess::open(editor_config_path, FileAccess::WRITE);
+		if (f.is_null()) {
+			// .editorconfig isn't so critical.
+			ERR_PRINT("Couldn't create .editorconfig in project path.");
+		} else {
+			f->store_line("root = true");
+			f->store_line("");
+			f->store_line("[*]");
+			f->store_line("charset = utf-8");
+			f->close();
+			FileAccess::set_hidden_attribute(editor_config_path, true);
+		}
 	}
 
 	// Two cases for importing a ZIP.

--- a/modules/gdscript/tests/scripts/.editorconfig
+++ b/modules/gdscript/tests/scripts/.editorconfig
@@ -1,5 +1,3 @@
-# This file is required to workaround `.editorconfig` autogeneration (see #96845).
-
 # Some tests handle invalid syntax deliberately; exclude relevant attributes.
 
 [parser/features/mixed_indentation_on_blank_lines.gd]


### PR DESCRIPTION
Instead of always generating one when missing, this PR creates `.editorconfig` on project creation.

* _Bugsquad edit:_ Closes #97796.