### PR TITLE
Fix Add Metadata dialog not focusing name field by default

### DIFF
--- a/editor/add_metadata_dialog.cpp
+++ b/editor/add_metadata_dialog.cpp
@@ -64,7 +64,6 @@ AddMetadataDialog::AddMetadataDialog() {
 }
 
 void AddMetadataDialog::_complete_init(const StringName &p_title) {
-	add_meta_name->grab_focus();
 	add_meta_name->set_text("");
 	validation_panel->update();
 
@@ -90,6 +89,7 @@ void AddMetadataDialog::open(const StringName p_title, List<StringName> &p_exist
 	this->_existing_metas = p_existing_metas;
 	_complete_init(p_title);
 	popup_centered();
+	add_meta_name->grab_focus();
 }
 
 StringName AddMetadataDialog::get_meta_name() {


### PR DESCRIPTION
This is a recent regression introduced when this dialog is moved into a separate file.