### PR TITLE
Remove direct render include in `ExternalTexture`

### DIFF
--- a/scene/resources/external_texture.cpp
+++ b/scene/resources/external_texture.cpp
@@ -30,9 +30,6 @@
 
 #include "external_texture.h"
 
-#include "drivers/gles3/storage/texture_storage.h"
-#include "servers/rendering/rendering_server_globals.h"
-
 void ExternalTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &ExternalTexture::set_size);
 	ClassDB::bind_method(D_METHOD("get_external_texture_id"), &ExternalTexture::get_external_texture_id);


### PR DESCRIPTION
This include introduces `windows/platform_gl.h` into the include hierarchy which adds defines which break building on MSVC

See:
* https://github.com/godotengine/godot/pull/96982#issuecomment-2365172598

Related to:
* https://github.com/godotengine/godot/pull/96525

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
