### PR TITLE
Keep advanced toggle on when searching for settings

### DIFF
--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -31,11 +31,14 @@
 #ifndef EDITOR_SECTIONED_INSPECTOR_H
 #define EDITOR_SECTIONED_INSPECTOR_H
 
-#include "editor/editor_inspector.h"
 #include "scene/gui/split_container.h"
-#include "scene/gui/tree.h"
 
+class CheckButton;
+class EditorInspector;
+class LineEdit;
 class SectionedInspectorFilter;
+class Tree;
+class TreeItem;
 
 class SectionedInspector : public HSplitContainer {
 	GDCLASS(SectionedInspector, HSplitContainer);
@@ -48,6 +51,7 @@ class SectionedInspector : public HSplitContainer {
 	HashMap<String, TreeItem *> section_map;
 	EditorInspector *inspector = nullptr;
 	LineEdit *search_box = nullptr;
+	CheckButton *advanced_toggle = nullptr;
 
 	String selected_category;
 
@@ -57,9 +61,12 @@ class SectionedInspector : public HSplitContainer {
 	void _section_selected();
 
 	void _search_changed(const String &p_what);
+	void _advanced_toggled(bool p_toggled_on);
 
 public:
 	void register_search_box(LineEdit *p_box);
+	void register_advanced_toggle(CheckButton *p_toggle);
+
 	EditorInspector *get_inspector();
 	void edit(Object *p_object);
 	String get_full_item_path(const String &p_item);
@@ -67,7 +74,6 @@ public:
 	void set_current_section(const String &p_section);
 	String get_current_section() const;
 
-	void set_restrict_to_basic_settings(bool p_restrict);
 	void update_category_list();
 
 	SectionedInspector();

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -33,6 +33,7 @@
 #include "core/input/input_map.h"
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
+#include "editor/editor_inspector.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_property_name_processor.h"
@@ -806,7 +807,6 @@ void EditorSettingsDialog::_focus_current_search_box() {
 
 void EditorSettingsDialog::_advanced_toggled(bool p_button_pressed) {
 	EditorSettings::get_singleton()->set("_editor_settings_advanced_mode", p_button_pressed);
-	inspector->set_restrict_to_basic_settings(!p_button_pressed);
 }
 
 void EditorSettingsDialog::_editor_restart() {
@@ -860,8 +860,8 @@ EditorSettingsDialog::EditorSettingsDialog() {
 
 	inspector = memnew(SectionedInspector);
 	inspector->get_inspector()->set_use_filter(true);
-	inspector->set_restrict_to_basic_settings(!use_advanced);
 	inspector->register_search_box(search_box);
+	inspector->register_advanced_toggle(advanced_switch);
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_general->add_child(inspector);
 	inspector->get_inspector()->connect("property_edited", callable_mp(this, &EditorSettingsDialog::_settings_property_edited));

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -33,11 +33,8 @@
 #include "core/config/project_settings.h"
 #include "core/io/resource_importer.h"
 #include "editor/action_map_editor.h"
-#include "editor/editor_autoload_settings.h"
+#include "editor/editor_inspector.h"
 #include "editor/editor_sectioned_inspector.h"
-#include "editor/localization_editor.h"
-#include "editor/plugins/editor_plugin_settings.h"
-#include "editor/shader_globals_editor.h"
 #include "scene/gui/center_container.h"
 
 class ImportDefaultsEditorSettings : public Object {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -31,7 +31,7 @@
 #include "project_settings_editor.h"
 
 #include "core/config/project_settings.h"
-#include "editor/editor_log.h"
+#include "editor/editor_inspector.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -106,7 +106,6 @@ void ProjectSettingsEditor::_update_advanced(bool p_is_advanced) {
 void ProjectSettingsEditor::_advanced_toggled(bool p_button_pressed) {
 	EditorSettings::get_singleton()->set_project_metadata("project_settings", "advanced_mode", p_button_pressed);
 	_update_advanced(p_button_pressed);
-	general_settings_inspector->set_restrict_to_basic_settings(!p_button_pressed);
 }
 
 void ProjectSettingsEditor::_setting_selected(const String &p_path) {
@@ -688,6 +687,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	general_settings_inspector = memnew(SectionedInspector);
 	general_settings_inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	general_settings_inspector->register_search_box(search_box);
+	general_settings_inspector->register_advanced_toggle(advanced);
 	general_settings_inspector->get_inspector()->set_use_filter(true);
 	general_settings_inspector->get_inspector()->connect("property_selected", callable_mp(this, &ProjectSettingsEditor::_setting_selected));
 	general_settings_inspector->get_inspector()->connect("property_edited", callable_mp(this, &ProjectSettingsEditor::_setting_edited));
@@ -771,11 +771,10 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	bool use_advanced = EditorSettings::get_singleton()->get_project_metadata("project_settings", "advanced_mode", false);
 
 	if (use_advanced) {
-		advanced->set_pressed_no_signal(true);
+		advanced->set_pressed(true);
 	}
 
 	_update_advanced(use_advanced);
-	general_settings_inspector->set_restrict_to_basic_settings(!use_advanced);
 
 	import_defaults_editor = memnew(ImportDefaultsEditor);
 	import_defaults_editor->set_name(TTR("Import Defaults"));

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -31,6 +31,7 @@
 #include "shader_globals_editor.h"
 
 #include "core/config/project_settings.h"
+#include "editor/editor_inspector.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "servers/rendering/shader_language.h"


### PR DESCRIPTION
When searching for settings, advanced settings are always shown which is the desired behavior. But it's confusing that the "Advanced Settings" toggle button says off at that time and does nothing when toggled.

This PR makes the "Advanced Settings" toggle button disabled and always in the on position on when searching.

![Peek 2024-09-21 21-18](https://github.com/user-attachments/assets/b14e100d-2777-4271-a755-73c2ccb342d3)

Also cleaned header includes in related files.