### PR TITLE
Fix crash when using non-`PackedScene` resource for POT generation

### DIFF
--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -32,7 +32,6 @@
 
 #include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
-#include "scene/gui/option_button.h"
 #include "scene/resources/packed_scene.h"
 
 void PackedSceneEditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
@@ -49,7 +48,9 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 		ERR_PRINT("Failed to load " + p_path);
 		return err;
 	}
-	Ref<SceneState> state = Ref<PackedScene>(loaded_res)->get_state();
+	Ref<PackedScene> packed_scene = loaded_res;
+	ERR_FAIL_COND_V_MSG(packed_scene.is_null(), ERR_FILE_UNRECOGNIZED, vformat("'%s' is not a valid PackedScene resource.", p_path));
+	Ref<SceneState> state = packed_scene->get_state();
 
 	Vector<String> parsed_strings;
 	Vector<Pair<NodePath, bool>> atr_owners;


### PR DESCRIPTION
Fixes a crash reported in https://github.com/godotengine/godot/issues/73565#issuecomment-1435763920, closes #76649

`.res` is a valid extension for `PackedScene`, but not all `.res` files are `PackedScene`s. There should be a null check.

---

To reproduce the crash:

1. Save any resource as `.res` and add it to the file list of POT Generation tab.
    - Or use this test project: [pot.zip](https://github.com/user-attachments/files/17157189/pot.zip)
2. Click the Generate POT button and choose a file name. The editor will crash when you click Save.
