### PR TITLE
Add doc gen for structs.

### DIFF
--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -127,6 +127,30 @@ void DocData::property_doc_from_scriptmemberinfo(DocData::PropertyDoc &p_propert
 	p_property.overridden = false;
 }
 
+void DocData::struct_doc_from_structinfo(DocData::StructDoc &p_struct, const StructInfo &p_structinfo) {
+	p_struct.name = p_structinfo.name;
+	// TODO: what about description?
+
+	p_struct.properties.resize(p_structinfo.count);
+	for (int i = 0; i < p_structinfo.count; i++) {
+		PropertyDoc property_doc;
+		property_doc.name = p_structinfo.names[i];
+		Variant::Type type = p_structinfo.types[i];
+		if (type == Variant::OBJECT) {
+			property_doc.type = p_structinfo.class_names[i];
+		} else if (type == Variant::NIL) {
+			property_doc.type = "Variant";
+		} else {
+			property_doc.type = Variant::get_type_name(type);
+		}
+		if (type != Variant::OBJECT) {
+			property_doc.default_value = get_default_value_string(p_structinfo.default_values[i]);
+		}
+		// TODO: what about description?
+		p_struct.properties.write[i] = property_doc;
+	}
+}
+
 void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const MethodInfo &p_methodinfo, const String &p_desc) {
 	p_method.name = p_methodinfo.name;
 	p_method.description = p_desc;

--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -698,6 +698,67 @@ public:
 		}
 	};
 
+	struct StructDoc {
+		String name;
+		String description;
+		Vector<PropertyDoc> properties;
+		bool is_deprecated = false;
+		bool is_experimental = false;
+		bool operator<(const StructDoc &p_struct) const {
+			return name < p_struct.name;
+		}
+		static StructDoc from_dict(const Dictionary &p_dict) {
+			StructDoc doc;
+
+			if (p_dict.has("name")) {
+				doc.name = p_dict["name"];
+			}
+
+			if (p_dict.has("description")) {
+				doc.description = p_dict["description"];
+			}
+
+			Array properties;
+			if (p_dict.has("properties")) {
+				properties = p_dict["properties"];
+			}
+			for (int i = 0; i < properties.size(); i++) {
+				doc.properties.push_back(PropertyDoc::from_dict(properties[i]));
+			}
+
+			if (p_dict.has("is_experimental")) {
+				doc.is_experimental = p_dict["is_experimental"];
+			}
+
+			return doc;
+		}
+		static Dictionary to_dict(const StructDoc &p_doc) {
+			Dictionary dict;
+
+			if (!p_doc.name.is_empty()) {
+				dict["name"] = p_doc.name;
+			}
+
+			if (!p_doc.description.is_empty()) {
+				dict["description"] = p_doc.description;
+			}
+
+			if (!p_doc.properties.is_empty()) {
+				Array properties;
+				for (int i = 0; i < p_doc.properties.size(); i++) {
+					properties.push_back(PropertyDoc::to_dict(p_doc.properties[i]));
+				}
+				dict["properties"] = properties;
+			}
+
+			dict["is_deprecated"] = p_doc.is_deprecated;
+
+			dict["is_experimental"] = p_doc.is_experimental;
+
+			return dict;
+		}
+	};
+
 	struct ClassDoc {
 		String name;
 		String inherits;
@@ -713,6 +774,7 @@ public:
 		HashMap<String, EnumDoc> enums;
 		Vector<PropertyDoc> properties;
 		Vector<MethodDoc> annotations;
+		Vector<StructDoc> structs;
 		Vector<ThemeItemDoc> theme_properties;
 		bool is_deprecated = false;
 		String deprecated_message;
@@ -816,6 +878,14 @@ public:
 			}
 			for (int i = 0; i < annotations.size(); i++) {
 				doc.annotations.push_back(MethodDoc::from_dict(annotations[i]));
+			}
+
+			Array structs;
+			if (p_dict.has("structs")) {
+				structs = p_dict["structs"];
+			}
+			for (int i = 0; i < structs.size(); i++) {
+				doc.structs.push_back(StructDoc::from_dict(structs[i]));
 			}
 
 			Array theme_properties;
@@ -947,6 +1017,13 @@ public:
 				dict["annotations"] = annotations;
 			}
 
+			if (!p_doc.structs.is_empty()) {
+				Array structs;
+				for (int i = 0; i < p_doc.structs.size(); i++) {
+					structs.push_back(StructDoc::to_dict(p_doc.structs[i]));
+				}
+			}
+
 			if (!p_doc.theme_properties.is_empty()) {
 				Array theme_properties;
 				for (int i = 0; i < p_doc.theme_properties.size(); i++) {
@@ -982,6 +1059,7 @@ public:
 	static void return_doc_from_retinfo(DocData::MethodDoc &p_method, const PropertyInfo &p_retinfo);
 	static void argument_doc_from_arginfo(DocData::ArgumentDoc &p_argument, const PropertyInfo &p_arginfo);
 	static void property_doc_from_scriptmemberinfo(DocData::PropertyDoc &p_property, const ScriptMemberInfo &p_memberinfo);
+	static void struct_doc_from_structinfo(DocData::StructDoc &p_struct, const StructInfo &p_structinfo);
 	static void method_doc_from_methodinfo(DocData::MethodDoc &p_method, const MethodInfo &p_methodinfo, const String &p_desc);
 	static void constant_doc_from_variant(DocData::ConstantDoc &p_const, const StringName &p_name, const Variant &p_value, const String &p_desc);
 	static void signal_doc_from_methodinfo(DocData::MethodDoc &p_signal, const MethodInfo &p_methodinfo, const String &p_desc);

--- a/doc/class.xsd
+++ b/doc/class.xsd
@@ -196,6 +196,37 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
+				<xs:element name="structs" minOccurs="0">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="struct" maxOccurs="unbounded" minOccurs="0">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="member" maxOccurs="unbounded" minOccurs="0">
+											<xs:complexType>
+												<xs:simpleContent>
+													<xs:extension base="xs:string">
+														<xs:attribute type="xs:string" name="name" use="required"/>
+														<xs:attribute type="xs:string" name="type" use="required"/>
+														<xs:attribute type="xs:string" name="default" use="required"/>
+														<xs:attribute type="xs:string" name="enum" use="optional" />
+														<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
+														<xs:attribute type="xs:boolean" name="is_deprecated" use="optional" />
+														<xs:attribute type="xs:boolean" name="is_experimental" use="optional" />
+													</xs:extension>
+												</xs:simpleContent>
+											</xs:complexType>
+										</xs:element>
+										<xs:element type="xs:string" name="description" minOccurs="0"/>
+									</xs:sequence>
+									<xs:attribute type="xs:string" name="name" use="required"/>
+									<xs:attribute type="xs:boolean" name="is_deprecated" use="optional" />
+									<xs:attribute type="xs:boolean" name="is_experimental" use="optional" />
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
 				<xs:element name="annotations" minOccurs="0">
 					<xs:complexType>
 						<xs:sequence>

--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -66,6 +66,7 @@ table_columns = [
     "description",
     "methods",
     "constants",
+    "structs",
     "members",
     "theme_items",
     "signals",
@@ -78,6 +79,7 @@ table_column_names = [
     "Desc.",
     "Methods",
     "Constants",
+    "Structs",
     "Members",
     "Theme Items",
     "Signals",
@@ -191,6 +193,7 @@ class ClassStatus:
         self.progresses: Dict[str, ClassStatusProgress] = {
             "methods": ClassStatusProgress(),
             "constants": ClassStatusProgress(),
+            "structs": ClassStatusProgress(),
             "members": ClassStatusProgress(),
             "theme_items": ClassStatusProgress(),
             "signals": ClassStatusProgress(),
@@ -239,7 +242,7 @@ class ClassStatus:
         )
         items_progress = ClassStatusProgress()
 
-        for k in ["methods", "constants", "members", "theme_items", "signals", "constructors", "operators"]:
+        for k in ["methods", "constants", "structs", "members", "theme_items", "signals", "constructors", "operators"]:
             items_progress += self.progresses[k]
             output[k] = self.progresses[k].to_configured_colored_string()
 
@@ -284,7 +287,7 @@ class ClassStatus:
                     descr = sub_tag.find("description")
                     has_descr = (descr is not None) and (descr.text is not None) and len(descr.text.strip()) > 0
                     status.progresses[tag.tag].increment(is_deprecated or is_experimental or has_descr)
-            elif tag.tag in ["constants", "members", "theme_items"]:
+            elif tag.tag in ["constants", "structs", "members", "theme_items"]:
                 for sub_tag in list(tag):
                     if sub_tag.text is not None:
                         is_deprecated = "deprecated" in sub_tag.attrib
@@ -327,7 +330,7 @@ for arg in sys.argv[1:]:
         sys.exit(1)
 
 if flags["i"]:
-    for r in ["methods", "constants", "members", "signals", "theme_items"]:
+    for r in ["methods", "constants", "structs", "members", "signals", "theme_items"]:
         index = table_columns.index(r)
         del table_column_names[index]
         del table_columns[index]

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -44,6 +44,7 @@ BASE_STRINGS = [
     "Theme Properties",
     "Signals",
     "Enumerations",
+    "Structs",
     "Constants",
     "Annotations",
     "Property Descriptions",
@@ -69,6 +70,7 @@ BASE_STRINGS = [
     "There is currently no description for this class. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
     "There is currently no description for this signal. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
     "There is currently no description for this enum. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
+    "There is currently no description for this struct. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
     "There is currently no description for this constant. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
     "There is currently no description for this annotation. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
     "There is currently no description for this property. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
@@ -342,6 +344,30 @@ class State:
 
                     enum_def.values[constant_name] = constant_def
 
+        structs = class_root.find("structs")
+        if structs is not None:
+            for struct in structs:
+                assert struct.tag == "struct"
+
+                struct_name = struct.attrib["name"]
+                if struct_name in class_def.structs:
+                    print_error(f'{class_name}.xml: Duplicate struct "{struct_name}".', self)
+                    continue
+                struct_def = StructDef(struct_name)
+
+                for member in struct.findall("member"):
+                    member_name = member.attrib["name"]
+                    if member_name in class_def.structs:
+                        print_error(f'{class_name}.xml: Duplicate struct "{struct_name}".', self)
+                        continue
+                    member_type = TypeName(member.attrib["type"])
+                    member_default = member.attrib.get("default", None)
+                    if member_default is not None:
+                        member_default = f"``{member_default}``"
+                    struct_def.members[member_name] = ParameterDef(method_name, member_type, member_default)
+
+                class_def.structs[struct_name] = struct_def
+
         annotations = class_root.find("annotations")
         if annotations is not None:
             for annotation in annotations:
@@ -577,6 +603,13 @@ class EnumDef(DefinitionBase):
         self.is_bitfield = bitfield
 
 
+class StructDef(DefinitionBase):
+    def __init__(self, name: str) -> None:
+        super().__init__("struct", name)
+
+        self.members: OrderedDict[str, ParameterDef] = OrderedDict()
+
+
 class ThemeItemDef(DefinitionBase):
     def __init__(
         self, name: str, type_name: TypeName, data_name: str, text: Optional[str], default_value: Optional[str]
@@ -598,6 +631,7 @@ class ClassDef(DefinitionBase):
 
         self.constants: OrderedDict[str, ConstantDef] = OrderedDict()
         self.enums: OrderedDict[str, EnumDef] = OrderedDict()
+        self.structs: OrderedDict[str, StructDef] = OrderedDict()
         self.properties: OrderedDict[str, PropertyDef] = OrderedDict()
         self.constructors: OrderedDict[str, List[MethodDef]] = OrderedDict()
         self.methods: OrderedDict[str, List[MethodDef]] = OrderedDict()
@@ -1219,6 +1253,32 @@ def make_rst_class(class_def: ClassDef, state: State, dry_run: bool, output_dir:
 
                 f.write("\n\n")
 
+        # Struct descriptions
+        if len(class_def.structs) > 0:
+            f.write(make_separator(True))
+            f.write(".. rst-class:: classref-descriptions-group\n\n")
+            f.write(make_heading("Structs", "-"))
+
+            index = 0
+
+            for struct_def in class_def.structs.values():
+                if index != 0:
+                    f.write(make_separator())
+
+                # Create struct signature and anchor point.
+
+                f.write(f".. _struct_{class_name}_{struct_def.name}:\n\n")
+                f.write(".. rst-class:: classref-struct\n\n")
+                f.write(f"struct **{struct_def.name}**:\n\n")
+
+                # Write struct members
+                for member_name, member in struct_def.members.items():
+                    f.write(f".. _struct_{class_name}_{struct_def.name}_member_{member_name}:\n\n")
+                    f.write(".. rst-class:: classref-struct-member\n\n")
+                    f.write(f"{member.type_name.to_rst(state)} **{member_name}** = ``{member.default_value}``\n\n")
+
+                index += 1
+
         # Annotation descriptions
         if len(class_def.annotations) > 0:
             f.write(make_separator(True))
@@ -1512,9 +1572,13 @@ def make_type(klass: str, state: State) -> str:
     def resolve_type(link_type: str) -> str:
         if link_type in state.classes:
             return f":ref:`{link_type}<class_{link_type}>`"
-        else:
-            print_error(f'{state.current_class}.xml: Unresolved type "{link_type}".', state)
-            return f"``{link_type}``"
+
+        for class_name, class_def in state.classes.items():  # Check structs
+            if link_type in class_def.structs:
+                return f":ref:`{link_type}<struct_{class_name}_link_type>`"
+
+        print_error(f'{state.current_class}.xml: Unresolved type "{link_type}".', state)
+        return f"``{link_type}``"
 
     if klass.endswith("[]"):  # Typed array, strip [] to link to contained type.
         return f":ref:`Array<class_Array>`\\[{resolve_type(klass[:-len('[]')])}\\]"
@@ -1554,6 +1618,27 @@ def make_enum(t: str, is_bitfield: bool, state: State) -> str:
     # Don't fail for `Vector3.Axis`, as this enum is a special case which is expected not to be resolved.
     if f"{c}.{e}" != "Vector3.Axis":
         print_error(f'{state.current_class}.xml: Unresolved enum "{t}".', state)
+
+    return t
+
+
+def make_struct(t: str, state: State) -> str:
+    p = t.find(".")
+    if p >= 0:
+        c = t[0:p]
+        e = t[p + 1 :]
+        # Variant structs live in GlobalScope but still use periods.
+        if c == "Variant":
+            c = "@GlobalScope"
+            e = "Variant." + e
+    else:
+        c = state.current_class
+        e = t
+        if c in state.classes and e not in state.classes[c].structs:
+            c = "@GlobalScope"
+
+    if c in state.classes and e in state.classes[c].structs:
+        return f":ref:`{e}<struct_{c}_{e}>`"
 
     return t
 
@@ -1797,6 +1882,7 @@ RESERVED_CROSSLINK_TAGS = [
     "signal",
     "constant",
     "enum",
+    "struct",
     "annotation",
     "theme_item",
     "param",
@@ -2113,6 +2199,12 @@ def format_text_block(
                                 state,
                             )
 
+                        elif target_name in class_def.structs:
+                            print_warning(
+                                f'{state.current_class}.xml: Found a code string "{inside_code_text}" that matches the {target_class_name}.{target_name} struct in {context_name}. {code_warning_if_intended_string}',
+                                state,
+                            )
+
                         else:
                             for enum in class_def.enums.values():
                                 if target_name in enum.values:
@@ -2151,6 +2243,7 @@ def format_text_block(
                         or tag_state.name == "member"
                         or tag_state.name == "signal"
                         or tag_state.name == "annotation"
+                        or tag_state.name == "struct"
                         or tag_state.name == "theme_item"
                         or tag_state.name == "constant"
                     ):
@@ -2211,6 +2304,12 @@ def format_text_block(
                                     state,
                                 )
 
+                            elif tag_state.name == "struct" and target_name not in class_def.structs:
+                                print_error(
+                                    f'{state.current_class}.xml: Unresolved struct reference "{link_target}" in {context_name}.',
+                                    state,
+                                )
+
                             elif tag_state.name == "theme_item":
                                 if target_name not in class_def.theme_items:
                                     print_error(
@@ -2265,6 +2364,11 @@ def format_text_block(
 
                     elif tag_state.name == "enum":
                         tag_text = make_enum(link_target, False, state)
+                        escape_pre = True
+                        escape_post = True
+
+                    elif tag_state.name == "struct":
+                        tag_text = make_struct(link_target, state)
                         escape_pre = True
                         escape_post = True
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -110,6 +110,8 @@ class EditorHelp : public VBoxContainer {
 	HashMap<String, int> annotation_line;
 	HashMap<String, int> enum_line;
 	HashMap<String, HashMap<String, int>> enum_values_line;
+	HashMap<String, int> struct_line;
+	HashMap<String, HashMap<String, int>> struct_members_line;
 	int description_line = 0;
 
 	RichTextLabel *class_desc = nullptr;


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot/pull/82198. That PR implements the new Struct type based on Reduz's proposal https://github.com/godotengine/godot-proposals/issues/7329 in core. This PR updates all the doc gen tooling to support Structs.

It is still very much a work in progress and currently not a stable branch.