### PR TITLE
GDScript: Allow trying to reload shallow script when instantiated

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -208,8 +208,13 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 Variant GDScript::_new(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	/* STEP 1, CREATE */
 
+	if (!valid && shallow && !reloading && is_root_script()) {
+		reload(true);
+	}
+
 	if (!valid) {
-		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+		ERR_FAIL_COND_V_MSG(!valid, Variant(), "Can't instantiate invalid script.");
+		r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
 		return Variant();
 	}
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -63,6 +63,7 @@ class GDScript : public Script {
 	bool valid = false;
 	bool reloading = false;
 	bool _is_abstract = false;
+	bool shallow = true;
 
 	struct MemberInfo {
 		int index = 0;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2710,6 +2710,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 	parsing_classes.insert(p_script);
 
+	p_script->shallow = false;
 	p_script->clearing = true;
 
 	p_script->cancel_pending_functions(true);


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/95789

this allows automatically compiling scripts on demand when calling `script.new()` in a very limited way to avoid errors from the wrong order of compiling dependencies that would otherwise be more difficult to solve

i looked back at the solution i mentioned in https://github.com/godotengine/godot/issues/95789#issuecomment-2308740522
and i think the solution i mentioned is actually fine, the gdscript compiler is not designed for multithreading, so, without accounting for that the logic is simple:
when a script is created it has a `bool shallow` set to `true`
while reloading, `reloading` is set to `true` like usual
at the beginning of compilation, `shallow` is set to `false`
then when instantiating a not-valid shallow root script that is not currently reloading, tries to reload it

also adds a better error message and call error