### PR TITLE
Avoid duplicating signals from scene instances into packed scenes (reverted)

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -572,7 +572,7 @@ public:
 		CONNECT_PERSIST = 2, // hint for scene to save this connection
 		CONNECT_ONE_SHOT = 4,
 		CONNECT_REFERENCE_COUNTED = 8,
-		CONNECT_INHERITED = 16, // Used in editor builds.
+		CONNECT_INHERITED = 16, // Whether or not the connection is in an instance of a scene.
 	};
 
 	struct Connection {

--- a/tests/scene/test_packed_scene.h
+++ b/tests/scene/test_packed_scene.h
@@ -56,6 +56,69 @@ TEST_CASE("[PackedScene] Pack Scene and Retrieve State") {
 	memdelete(scene);
 }
 
+TEST_CASE("[PackedScene] Signals Preserved when Packing Scene") {
+	// Create main scene
+	// root
+	// `- sub_node (local)
+	// `- sub_scene (instance of another scene)
+	//    `- sub_scene_node (owned by sub_scene)
+	Node *main_scene_root = memnew(Node);
+	Node *sub_node = memnew(Node);
+	Node *sub_scene_root = memnew(Node);
+	Node *sub_scene_node = memnew(Node);
+
+	main_scene_root->add_child(sub_node);
+	sub_node->set_owner(main_scene_root);
+
+	sub_scene_root->add_child(sub_scene_node);
+	sub_scene_node->set_owner(sub_scene_root);
+
+	main_scene_root->add_child(sub_scene_root);
+	sub_scene_root->set_owner(main_scene_root);
+
+	SUBCASE("Signals that should be saved") {
+		int main_flags = Object::CONNECT_PERSIST;
+		// sub node to a node in main scene
+		sub_node->connect("ready", callable_mp(main_scene_root, &Node::is_ready), main_flags);
+		// subscene root to a node in main scene
+		sub_scene_root->connect("ready", callable_mp(main_scene_root, &Node::is_ready), main_flags);
+		//subscene root to subscene root (connected within main scene)
+		sub_scene_root->connect("ready", callable_mp(sub_scene_root, &Node::is_ready), main_flags);
+
+		// Pack the scene.
+		Ref<PackedScene> packed_scene;
+		packed_scene.instantiate();
+		const Error err = packed_scene->pack(main_scene_root);
+		CHECK(err == OK);
+
+		// Make sure the right connections are in packed scene.
+		Ref<SceneState> state = packed_scene->get_state();
+		CHECK_EQ(state->get_connection_count(), 3);
+	}
+
+	SUBCASE("Signals that should not be saved") {
+		int subscene_flags = Object::CONNECT_PERSIST | Object::CONNECT_INHERITED;
+		// subscene node to itself
+		sub_scene_node->connect("ready", callable_mp(sub_scene_node, &Node::is_ready), subscene_flags);
+		// subscene node to subscene root
+		sub_scene_node->connect("ready", callable_mp(sub_scene_root, &Node::is_ready), subscene_flags);
+		//subscene root to subscene root (connected within sub scene)
+		sub_scene_root->connect("ready", callable_mp(sub_scene_root, &Node::is_ready), subscene_flags);
+
+		// Pack the scene.
+		Ref<PackedScene> packed_scene;
+		packed_scene.instantiate();
+		const Error err = packed_scene->pack(main_scene_root);
+		CHECK(err == OK);
+
+		// Make sure the right connections are in packed scene.
+		Ref<SceneState> state = packed_scene->get_state();
+		CHECK_EQ(state->get_connection_count(), 0);
+	}
+
+	memdelete(main_scene_root);
+}
+
 TEST_CASE("[PackedScene] Clear Packed Scene") {
 	// Create a scene to pack.
 	Node *scene = memnew(Node);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
#### EDIT: This PR was partially reverted by https://github.com/godotengine/godot/pull/100235 so the issues are not fixed. https://github.com/godotengine/godot/pull/100965 has been created as a follow up

Fixes #48064 and fixes #86532

When packing a tree of nodes to a  `PackedScene`, signal connections originating from the root node of a scene instance within that tree would get duplicated into the PackedScene and cause "duplicate signal" errors when instantiating it.