### PR TITLE
Metal: Implement `texture_create_from_extension`

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -358,7 +358,11 @@ RDD::TextureID RenderingDeviceDriverMetal::texture_create(const TextureFormat &p
 }
 
 RDD::TextureID RenderingDeviceDriverMetal::texture_create_from_extension(uint64_t p_native_texture, TextureType p_type, DataFormat p_format, uint32_t p_array_layers, bool p_depth_stencil) {
-	ERR_FAIL_V_MSG(RDD::TextureID(), "not implemented");
+	id<MTLTexture> obj = (__bridge id<MTLTexture>)(void *)(uintptr_t)p_native_texture;
+
+	// We only need to create a RDD::TextureID for an existing, natively-provided texture.
+
+	return rid::make(obj);
 }
 
 RDD::TextureID RenderingDeviceDriverMetal::texture_create_shared(TextureID p_original_texture, const TextureView &p_view) {


### PR DESCRIPTION
This PR implements `texture_create_from_extension()` for Metal.

The Vulkan device driver implements `texture_create_from_extension()` to handle externally backed textures (OpenXR module, or otherwise), which takes an incoming `VkImage`, creates a view, and returns it as `TextureID`.

https://github.com/godotengine/godot/blob/e4e024ab88efe74677769395886bc1b09eccbac7/drivers/vulkan/rendering_device_driver_vulkan.cpp#L1745-L1750

For Metal, there is no exact equivalent to Vulkan's `VkImageView`, so for this driver we only need to cast the incoming handle to `id<MTLTexture>`, then return as `TextureID`. 

Parameters `p_type`, `p_format`, `p_array_layers`, `p_depth_stencil` are ignored - `MTLTexture` (and the callee) already have this information and is only relevant when reinterpreting or remaping the texture in different ways.

The use of `__bridge` with `void*` in the casting is to signal we are not transferring ownership, and is a safe cast to bridge from C-style memory to Objective-C memory management (but correct me if I'm wrong).

loosely related to #96860