### PR TITLE
Add shortcuts for inspector previous, next, and history buttons

### DIFF
--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -694,6 +694,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	backward_button->set_flat(true);
 	general_options_hb->add_child(backward_button);
 	backward_button->set_tooltip_text(TTR("Go to previous edited object in history."));
+	backward_button->set_shortcut(ED_SHORTCUT("property_editor/previous_object", TTR("Go to Previous Edited Object"), KeyModifierMask::ALT | Key::LEFT));
 	backward_button->set_disabled(true);
 	backward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_back));
 
@@ -701,6 +702,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	forward_button->set_flat(true);
 	general_options_hb->add_child(forward_button);
 	forward_button->set_tooltip_text(TTR("Go to next edited object in history."));
+	forward_button->set_shortcut(ED_SHORTCUT("property_editor/next_object", TTR("Go to Next Edited Object"), KeyModifierMask::ALT | Key::RIGHT));
 	forward_button->set_disabled(true);
 	forward_button->connect(SceneStringName(pressed), callable_mp(this, &InspectorDock::_edit_forward));
 
@@ -709,6 +711,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	history_menu->set_flat(false);
 	history_menu->set_theme_type_variation("FlatMenuButton");
 	history_menu->set_tooltip_text(TTR("History of recently edited objects."));
+	history_menu->set_shortcut(ED_SHORTCUT("property_editor/show_history", TTR("Show Edited Object History"), KeyModifierMask::CTRL | Key::H));
 	general_options_hb->add_child(history_menu);
 	history_menu->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_history));
 	history_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &InspectorDock::_select_history));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Adds keyboard shortcuts for several buttons in the inspector:
- "Go to Previous Edited Object" - Alt + Left Arrow
- "Go to Next Edited Object" - Alt + Right Arrow
- "Show Edited Object History" - Ctrl + H