### PR TITLE
Add icons for many context menu options

### DIFF
--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -179,9 +179,9 @@ void EditorSceneTabs::_update_context_menu() {
 
 	if (tab_id >= 0) {
 		scene_tabs_context_menu->add_separator();
-		scene_tabs_context_menu->add_item(TTR("Show in FileSystem"), EditorNode::FILE_SHOW_IN_FILESYSTEM);
+		scene_tabs_context_menu->add_icon_item(get_editor_theme_icon(SNAME("ShowInFileSystem")), TTR("Show in FileSystem"), EditorNode::FILE_SHOW_IN_FILESYSTEM);
 		_disable_menu_option_if(EditorNode::FILE_SHOW_IN_FILESYSTEM, !ResourceLoader::exists(EditorNode::get_editor_data().get_scene_path(tab_id)));
-		scene_tabs_context_menu->add_item(TTR("Play This Scene"), EditorNode::FILE_RUN_SCENE);
+		scene_tabs_context_menu->add_icon_item(get_editor_theme_icon(SNAME("PlayScene")), TTR("Play This Scene"), EditorNode::FILE_RUN_SCENE);
 		_disable_menu_option_if(EditorNode::FILE_RUN_SCENE, no_root_node);
 
 		scene_tabs_context_menu->add_separator();

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -436,6 +436,7 @@ void InspectorDock::_notification(int p_what) {
 			PopupMenu *resource_extra_popup = resource_extra_button->get_popup();
 			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_EDIT_CLIPBOARD), get_editor_theme_icon(SNAME("ActionPaste")));
 			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_COPY), get_editor_theme_icon(SNAME("ActionCopy")));
+			resource_extra_popup->set_item_icon(resource_extra_popup->get_item_index(RESOURCE_SHOW_IN_FILESYSTEM), get_editor_theme_icon(SNAME("ShowInFileSystem")));
 
 			if (is_layout_rtl()) {
 				backward_button->set_icon(get_editor_theme_icon(SNAME("Forward")));

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1754,6 +1754,8 @@ void ScriptEditor::_notification(int p_what) {
 
 			recent_scripts->reset_size();
 
+			file_menu->get_popup()->set_item_icon(file_menu->get_popup()->get_item_idx_from_text(TTR("Show in FileSystem")), get_editor_theme_icon(SNAME("ShowInFileSystem")));
+
 			if (is_inside_tree()) {
 				_update_script_names();
 			}
@@ -3353,10 +3355,10 @@ void ScriptEditor::_make_script_list_context_menu() {
 
 	ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(selected));
 	if (se) {
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/save"), FILE_SAVE);
+		context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Save")), ED_GET_SHORTCUT("script_editor/save"), FILE_SAVE);
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/save_as"), FILE_SAVE_AS);
 	}
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_file"), FILE_CLOSE);
+	context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Close")), ED_GET_SHORTCUT("script_editor/close_file"), FILE_CLOSE);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_all"), CLOSE_ALL);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_other_tabs"), CLOSE_OTHER_TABS);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_docs"), CLOSE_DOCS);
@@ -3370,14 +3372,14 @@ void ScriptEditor::_make_script_list_context_menu() {
 				context_menu->add_separator();
 			}
 		}
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/copy_path"), FILE_COPY_PATH);
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/show_in_file_system"), SHOW_IN_FILE_SYSTEM);
+		context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ActionCopy")), ED_GET_SHORTCUT("script_editor/copy_path"), FILE_COPY_PATH);
+		context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ShowInFileSystem")), ED_GET_SHORTCUT("script_editor/show_in_file_system"), SHOW_IN_FILE_SYSTEM);
 		context_menu->add_separator();
 	}
 
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_move_up"), WINDOW_MOVE_UP);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_move_down"), WINDOW_MOVE_DOWN);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_sort"), WINDOW_SORT);
+	context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("MoveUp")), ED_GET_SHORTCUT("script_editor/window_move_up"), WINDOW_MOVE_UP);
+	context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("MoveDown")), ED_GET_SHORTCUT("script_editor/window_move_down"), WINDOW_MOVE_DOWN);
+	context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Sort")), ED_GET_SHORTCUT("script_editor/window_sort"), WINDOW_SORT);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/toggle_scripts_panel"), TOGGLE_SCRIPTS_PANEL);
 
 	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_ALL), tab_container->get_tab_count() <= 0);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -405,7 +405,7 @@ void ShaderEditorPlugin::_setup_popup_menu(PopupMenuType p_type, PopupMenu *p_me
 		if (p_type == CONTEXT_VALID_ITEM) {
 			p_menu->add_separator();
 			p_menu->add_item(TTR("Copy Script Path"), COPY_PATH);
-			p_menu->add_item(TTR("Show in FileSystem"), SHOW_IN_FILE_SYSTEM);
+			p_menu->add_icon_item(shader_list->get_editor_theme_icon(SNAME("ShowInFileSystem")), TTR("Show in FileSystem"), SHOW_IN_FILE_SYSTEM);
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Added many icons for various context menu options:
- Editor Scene Tab Menu:
    - Show in FileSystem
    - Play This Scene
- Inspector Dock Menu:
    - Resource Show in FileSystem
- Script Editor File Menu:
    - Show in FileSystem
- Script Editor Scripts List Menu:
    - Save
    - Close
    - Copy Script Path
    - Show in FileSystem
    - Move Up
    - Move Down
    - Sort
- Shader Editor Scripts List Menu:
    - Show in FileSystem