### PR TITLE
Metal: expose MTLDevice

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -3667,7 +3667,8 @@ void RenderingDeviceDriverMetal::set_object_name(ObjectType p_type, ID p_driver_
 uint64_t RenderingDeviceDriverMetal::get_resource_native_handle(DriverResource p_type, ID p_driver_id) {
 	switch (p_type) {
 		case DRIVER_RESOURCE_LOGICAL_DEVICE: {
-			return 0;
+			uintptr_t devicePtr = (uintptr_t)(__bridge void *)device;
+			return (uint64_t)devicePtr;
 		}
 		case DRIVER_RESOURCE_PHYSICAL_DEVICE: {
 			return 0;


### PR DESCRIPTION
expose [MTLDevice](https://developer.apple.com/documentation/metal/mtldevice)

The equivalent over at Vulkan is https://github.com/godotengine/godot/blob/e4e024ab88efe74677769395886bc1b09eccbac7/drivers/vulkan/rendering_device_driver_vulkan.cpp#L5184-L5188

loosely related to #97304 