### PR TITLE
Add editor setting to enable or disable zooming with ctrl + Mouse wheel

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1245,6 +1245,12 @@
 			The speed of scrolling in lines per second when [member text_editor/behavior/navigation/smooth_scrolling] is [code]true[/code]. Higher values make the script scroll by faster when using the mouse wheel.
 			[b]Note:[/b] You can hold down [kbd]Alt[/kbd] while using the mouse wheel to temporarily scroll 5 times faster.
 		</member>
+		<member name="text_editor/behavior/zoom/zoom_scroll_shortcut" type="bool" setter="" getter="">
+			If [code]true[/code], allows zooming in the script and text-based shader editor with
+			[kbd]Windows: Ctrl + Scroll wheel[/kbd].
+			[kbd]Mac: CMD + Scroll wheel[/kbd].
+			[kbd]Linux: Option + Scroll wheel[/kbd].
+		</member>
 		<member name="text_editor/completion/add_node_path_literals" type="bool" setter="" getter="">
 			If [code]true[/code], uses [NodePath] instead of [String] when appropriate for code autocompletion or for drag and dropping object properties into the script editor.
 		</member>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -882,7 +882,7 @@ void CodeTextEditor::input(const Ref<InputEvent> &event) {
 void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> mb = p_event;
 
-	if (mb.is_valid()) {
+	if (mb.is_valid() && zoom_shortcut_enabled) {
 		if (mb->is_pressed() && mb->is_command_or_control_pressed()) {
 			if (mb->get_button_index() == MouseButton::WHEEL_UP) {
 				_zoom_in();
@@ -898,7 +898,7 @@ void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventMagnifyGesture> magnify_gesture = p_event;
-	if (magnify_gesture.is_valid()) {
+	if (magnify_gesture.is_valid() && zoom_shortcut_enabled) {
 		_zoom_to(zoom_factor * powf(magnify_gesture->get_factor(), 0.25f));
 		accept_event();
 		return;
@@ -1098,6 +1098,9 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_use_default_word_separators(EDITOR_GET("text_editor/behavior/navigation/use_default_word_separators"));
 	text_editor->set_use_custom_word_separators(EDITOR_GET("text_editor/behavior/navigation/use_custom_word_separators"));
 	text_editor->set_custom_word_separators(EDITOR_GET("text_editor/behavior/navigation/custom_word_separators"));
+
+	// Behavior: Zoom
+	zoom_shortcut_enabled = EDITOR_GET("text_editor/behavior/zoom/zoom_scroll_shortcut");
 
 	// Behavior: Indent
 	set_indent_using_spaces(EDITOR_GET("text_editor/behavior/indent/type"));

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -177,6 +177,7 @@ class CodeTextEditor : public VBoxContainer {
 	bool code_complete_enabled = true;
 	Timer *code_complete_timer = nullptr;
 	int code_complete_timer_line = 0;
+	bool zoom_shortcut_enabled = true;
 
 	float zoom_factor = 1.0f;
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -696,6 +696,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save", true);
 	_initial_set("text_editor/behavior/files/open_dominant_script_on_scene_change", false, true);
 
+	// Behavior: Zoom
+	_initial_set("text_editor/behavior/zoom/zoom_scroll_shortcut", true);
+
 	// Script list
 	_initial_set("text_editor/script_list/show_members_overview", true, true);
 	_initial_set("text_editor/script_list/sort_members_outline_alphabetically", false, true);


### PR DESCRIPTION
Re-submit https://github.com/godotengine/godot/pull/94480
Fixes https://github.com/godotengine/godot-proposals/issues/7997

I updated the tooltip text to include mac and linux:
If [code]true[/code], allows zooming in the script and text-based shader editor with
[kbd]Windows: Ctrl + Scroll wheel[/kbd].
[kbd]Mac: CMD + Scroll wheel[/kbd].
[kbd]Linux: Option + Scroll wheel[/kbd].

I think the best solution is to add a the ctrl+scrollwhell as a shortcut setting, and users can configure the shortcut. However, the shortcut settings currently does not support mouse events. I also couldn't figure out where the shortcut settings are added/removed. If someone can point me to a direction to start, I can try to create a new PR to let the shortcut setting to support mouse events, then add ctrl+scrollwheel as a shortcut. 
