### PR TITLE
Fix physics platform behavior regression

### DIFF
--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -60,8 +60,13 @@ bool CharacterBody3D::move_and_slide() {
 
 			// We need to check the platform_rid object still exists before accessing.
 			// A valid RID is no guarantee that the object has not been deleted.
-			if (ObjectDB::get_instance(platform_object_id)) {
-				//this approach makes sure there is less delay between the actual body velocity and the one we saved
+
+			// We can only perform the ObjectDB lifetime check on Object derived objects.
+			// Note that physics also creates RIDs for non-Object derived objects, these cannot
+			// be lifetime checked through ObjectDB, and therefore there is a still a vulnerability
+			// to dangling RIDs (access after free) in this scenario.
+			if (platform_object_id.is_null() || ObjectDB::get_instance(platform_object_id)) {
+				// This approach makes sure there is less delay between the actual body velocity and the one we saved.
 				bs = PhysicsServer3D::get_singleton()->body_get_direct_state(platform_rid);
 			}
 


### PR DESCRIPTION
Lifetime checks for stored `RIDs` for collision objects assumed they had valid `object_ids`. It turns out that some are not derived from `Object` and thus checking `ObjectDB` returns false for some valid `RIDs`. To account for this we only perform lifetime checks on valid `object_ids`.

Fixes #97293

## Discussion
Although the original MRP in #74732 had valid object ids, it turns out that physics also stores `RIDs` for objects which are not in `ObjectDB`. This means we can't lifetime check them with `ObjectDB`, and the same vulnerability exists for accessing dangling `RIDs` that caused the original issue.

This should ideally be closed as the current design is unsafe, although there are no reports afaik of this occurring in the wild (although such errors may not result in crash and may only be seen in e.g. asan build).

Making completely safe in this situation is out of scope for this PR, and as stated in the original issue, would involve e.g.
* RID database
* Clearing stored RID references on deletion of objects (e.g. #77616 )

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
