### PR TITLE
Fix delete dialog ok button text in SceneTreeDock

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -4645,6 +4645,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	set_process_shortcut_input(true);
 
 	delete_dialog = memnew(ConfirmationDialog);
+	delete_dialog->set_ok_button_text(TTR("Delete"));
 	add_child(delete_dialog);
 	delete_dialog->connect(SceneStringName(confirmed), callable_mp(this, &SceneTreeDock::_delete_confirm).bind(false));
 


### PR DESCRIPTION
Instead of ok_button_text just saying OK in the delete node dialog, it now says Delete.

![Screenshot_20240922_035159](https://github.com/user-attachments/assets/fbbb28f4-e963-4e1c-9b90-8d173098b720)
