### PR TITLE
Fix Add button style in GroupsEditor

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -840,7 +840,7 @@ GroupsEditor::GroupsEditor() {
 	add_child(hbc);
 
 	add = memnew(Button);
-	add->set_flat(true);
+	add->set_theme_type_variation("FlatMenuButton");
 	add->set_tooltip_text(TTR("Add a new group."));
 	add->connect(SceneStringName(pressed), callable_mp(this, &GroupsEditor::_show_add_group_dialog));
 	hbc->add_child(add);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/97318


[Screencast_20240922_111900.webm](https://github.com/user-attachments/assets/cb72bf22-50bb-4b09-b7b6-c695b3cb4828)
