### PR TITLE
Fix delete dialog ok button text in GroupsEditor

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -735,6 +735,7 @@ void GroupsEditor::_show_rename_group_dialog() {
 void GroupsEditor::_show_remove_group_dialog() {
 	if (!remove_group_dialog) {
 		remove_group_dialog = memnew(ConfirmationDialog);
+		remove_group_dialog->set_ok_button_text(TTR("Delete"));
 		remove_group_dialog->connect(SceneStringName(confirmed), callable_mp(this, &GroupsEditor::_confirm_delete));
 
 		VBoxContainer *vbox = memnew(VBoxContainer);


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/97317 but for GroupsEditor
