### PR TITLE
Fix script editor wrongly replaces and quotes non-ASCII letters

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4626,7 +4626,7 @@ bool String::is_absolute_path() const {
 
 String String::validate_ascii_identifier() const {
 	if (is_empty()) {
-		return "_"; // Empty string is not a valid identifier;
+		return "_"; // Empty string is not a valid identifier.
 	}
 
 	String result;
@@ -4640,6 +4640,29 @@ String String::validate_ascii_identifier() const {
 	char32_t *buffer = result.ptrw();
 	for (int i = 0; i < len; i++) {
 		if (!is_ascii_identifier_char(buffer[i])) {
+			buffer[i] = '_';
+		}
+	}
+
+	return result;
+}
+
+String String::validate_unicode_identifier() const {
+	if (is_empty()) {
+		return "_"; // Empty string is not a valid identifier.
+	}
+
+	String result;
+	if (is_unicode_identifier_start(operator[](0))) {
+		result = *this;
+	} else {
+		result = "_" + *this;
+	}
+
+	int len = result.length();
+	char32_t *buffer = result.ptrw();
+	for (int i = 0; i < len; i++) {
+		if (!is_unicode_identifier_continue(buffer[i])) {
 			buffer[i] = '_';
 		}
 	}

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -460,6 +460,7 @@ public:
 	static String get_invalid_node_name_characters(bool p_allow_internal = false);
 	String validate_node_name() const;
 	String validate_ascii_identifier() const;
+	String validate_unicode_identifier() const;
 	String validate_filename() const;
 
 	bool is_valid_ascii_identifier() const;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1813,9 +1813,9 @@ static String _get_dropped_resource_line(const Ref<Resource> &p_resource, bool p
 	}
 
 	if (is_script) {
-		variable_name = variable_name.to_pascal_case().validate_ascii_identifier();
+		variable_name = variable_name.to_pascal_case().validate_unicode_identifier();
 	} else {
-		variable_name = variable_name.to_snake_case().to_upper().validate_ascii_identifier();
+		variable_name = variable_name.to_snake_case().to_upper().validate_unicode_identifier();
 	}
 	return vformat("const %s = preload(%s)", variable_name, _quote_drop_data(path));
 }
@@ -1927,13 +1927,13 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 					path = sn->get_path_to(node);
 				}
 				for (const String &segment : path.split("/")) {
-					if (!segment.is_valid_ascii_identifier()) {
+					if (!segment.is_valid_unicode_identifier()) {
 						path = _quote_drop_data(path);
 						break;
 					}
 				}
 
-				String variable_name = String(node->get_name()).to_snake_case().validate_ascii_identifier();
+				String variable_name = String(node->get_name()).to_snake_case().validate_unicode_identifier();
 				if (use_type) {
 					StringName class_name = node->get_class_name();
 					Ref<Script> node_script = node->get_script();

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -97,8 +97,8 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 	}
 
 	processed_template = processed_template.replace("_BASE_", p_base_class_name)
-								 .replace("_CLASS_SNAKE_CASE_", p_class_name.to_snake_case().validate_ascii_identifier())
-								 .replace("_CLASS_", p_class_name.to_pascal_case().validate_ascii_identifier())
+								 .replace("_CLASS_SNAKE_CASE_", p_class_name.to_snake_case().validate_unicode_identifier())
+								 .replace("_CLASS_", p_class_name.to_pascal_case().validate_unicode_identifier())
 								 .replace("_TS_", _get_indentation());
 	scr->set_source_code(processed_template);
 	return scr;

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1888,7 +1888,7 @@ TEST_CASE("[String] validate_node_name") {
 	CHECK(name_with_invalid_chars.validate_node_name() == "Name with invalid characters ____removed!");
 }
 
-TEST_CASE("[String] validate_identifier") {
+TEST_CASE("[String] validate_ascii_identifier") {
 	String empty_string;
 	CHECK(empty_string.validate_ascii_identifier() == "_");
 
@@ -1900,6 +1900,20 @@ TEST_CASE("[String] validate_identifier") {
 
 	String name_with_invalid_chars = U"Invalid characters:@*#&世界";
 	CHECK(name_with_invalid_chars.validate_ascii_identifier() == "Invalid_characters_______");
+}
+
+TEST_CASE("[String] validate_unicode_identifier") {
+	String empty_string;
+	CHECK(empty_string.validate_unicode_identifier() == "_");
+
+	String numeric_only = "12345";
+	CHECK(numeric_only.validate_unicode_identifier() == "_12345");
+
+	String name_with_spaces = "Name with spaces";
+	CHECK(name_with_spaces.validate_unicode_identifier() == "Name_with_spaces");
+
+	String name_with_invalid_chars = U"Invalid characters:@*#&世界";
+	CHECK(name_with_invalid_chars.validate_unicode_identifier() == U"Invalid_characters_____世界");
 }
 
 TEST_CASE("[String] Variant indexed get") {


### PR DESCRIPTION
Fixes #92899

- Variable names generated when Ctrl-drop files into the script editor
- Variable names and `$`/`%` paths generated when Ctrl-drop nodes into the script editor
- Class names generated when using a script template

After this PR, `String::validate_ascii_identifier()` is not used anymore in the codebase except for some related tests. We could remove this method completed after some time if it is still not used.