### PR TITLE
Prevent infinite recursion in first `_draw`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -120,10 +120,6 @@ void Node::_notification(int p_notification) {
 			}
 #endif
 
-			if (data.auto_translate_mode != AUTO_TRANSLATE_MODE_DISABLED) {
-				notification(NOTIFICATION_TRANSLATION_CHANGED);
-			}
-
 			if (data.input) {
 				add_to_group("_vp_input" + itos(get_viewport()->get_instance_id()));
 			}
@@ -144,6 +140,12 @@ void Node::_notification(int p_notification) {
 			// (this is to save the user from doing this manually each time).
 			if (get_tree()->is_physics_interpolation_enabled()) {
 				_set_physics_interpolation_reset_requested(true);
+			}
+		} break;
+
+		case NOTIFICATION_POST_ENTER_TREE: {
+			if (data.auto_translate_mode != AUTO_TRANSLATE_MODE_DISABLED) {
+				notification(NOTIFICATION_TRANSLATION_CHANGED);
 			}
 		} break;
 


### PR DESCRIPTION
Caused by size changes fired in some cases, mainly by auto-translation, and due to that `_redraw_callback` is called from a flush causing any queued methods to be fired immediately.

~Added `pending_update = false;` to the `_exit_canvas` method to ensure things behave reasonably in some edge cases like changing the `world_2d` or reparenting `self` *during* `_draw` which would otherwise never fire a redraw. This is not really reasonable use but I feel it's good to not introduce weird behavior in these cases.~

~The underlying cause here seems to be that when entering the tree a bunch of different calls are made including several that unconditionally resize the node. These are likely inefficient and could be improved but this offers a fix that ensures things behave reasonably in these cases.~

~So I'd say this is a functional fix, we can look at reducing unnecessary calls to `queue_redraw` and resizing calls on entering the tree etc. (it happens in things like `NOTIFY_TRANSLATION_CHANGED` and a bunch of others) but this should ensure things run smoothly.~

New fix, this fix avoids complex changes by deferring the translation notification, need confirmation that this won't break translation but in my testing it works with localization, and doesn't break.

MRP for testing:
[recursive_draw.zip](https://github.com/user-attachments/files/17090094/recursive_draw.zip)

* Fixes: https://github.com/godotengine/godot/issues/95810
* Fixes: https://github.com/godotengine/godot/issues/95709
* Fixes: https://github.com/godotengine/godot/issues/97507
* Fixes: https://github.com/godotengine/godot/issues/99443

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
