### PR TITLE
[Docs] Clarify that `String` parsing methods don't support num separators

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -67,11 +67,13 @@
 				print("101".bin_to_int())   # Prints 5
 				print("0b101".bin_to_int()) # Prints 5
 				print("-0b10".bin_to_int()) # Prints -2
+				print("1_0".bin_to_int())   # Prints 0 (number separators are not supported)
 				[/gdscript]
 				[csharp]
 				GD.Print("101".BinToInt());   // Prints 5
 				GD.Print("0b101".BinToInt()); // Prints 5
 				GD.Print("-0b10".BinToInt()); // Prints -2
+				GD.Print("1_0".BinToInt());   // Prints 0 (number separators are not supported)
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -385,10 +387,12 @@
 				[gdscript]
 				print("0xff".hex_to_int()) # Prints 255
 				print("ab".hex_to_int())   # Prints 171
+				print("a_b".hex_to_int())  # Prints 0 (number separators are not supported)
 				[/gdscript]
 				[csharp]
 				GD.Print("0xff".HexToInt()); // Prints 255
 				GD.Print("ab".HexToInt());   // Prints 171
+				GD.Print("a_b".HexToInt());  // Prints 0 (number separators are not supported)
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -486,6 +490,7 @@
 				print("24".is_valid_float())    # Prints true
 				print("7e3".is_valid_float())   # Prints true
 				print("Hello".is_valid_float()) # Prints false
+				print("2_4".is_valid_float())   # Prints false (number separators are not supported)
 				[/codeblock]
 			</description>
 		</method>
@@ -499,6 +504,7 @@
 				print("A08E".is_valid_hex_number())    # Prints true
 				print("-AbCdEf".is_valid_hex_number()) # Prints true
 				print("2.5".is_valid_hex_number())     # Prints false
+				print("2_5".is_valid_hex_number())     # Prints false (number separators are not supported)
 
 				print("0xDEADC0DE".is_valid_hex_number(true)) # Prints true
 				[/codeblock]
@@ -532,6 +538,7 @@
 				print("Hi".is_valid_int())   # Prints false
 				print("+3".is_valid_int())   # Prints true
 				print("-12".is_valid_int())  # Prints true
+				print("1_2".is_valid_int())  # Prints false (number separators are not supported)
 				[/codeblock]
 			</description>
 		</method>
@@ -1025,6 +1032,7 @@
 				var c = "12xy3".to_float()  # c is 12.0
 				var d = "1e3".to_float()    # d is 1000.0
 				var e = "Hello!".to_float() # e is 0.0
+				var f = "1_2".to_float()    # f is 1.0 (number separators are not supported)
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -61,11 +61,13 @@
 				print("101".bin_to_int())   # Prints 5
 				print("0b101".bin_to_int()) # Prints 5
 				print("-0b10".bin_to_int()) # Prints -2
+				print("1_0".bin_to_int())   # Prints 0 (number separators are not supported)
 				[/gdscript]
 				[csharp]
 				GD.Print("101".BinToInt());   // Prints 5
 				GD.Print("0b101".BinToInt()); // Prints 5
 				GD.Print("-0b10".BinToInt()); // Prints -2
+				GD.Print("1_0".BinToInt());   // Prints 0 (number separators are not supported)
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -368,10 +370,12 @@
 				[gdscript]
 				print("0xff".hex_to_int()) # Prints 255
 				print("ab".hex_to_int())   # Prints 171
+				print("a_b".hex_to_int())  # Prints 0 (number separators are not supported)
 				[/gdscript]
 				[csharp]
 				GD.Print("0xff".HexToInt()); // Prints 255
 				GD.Print("ab".HexToInt());   // Prints 171
+				GD.Print("a_b".HexToInt());  // Prints 0 (number separators are not supported)
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -461,6 +465,7 @@
 				print("24".is_valid_float())    # Prints true
 				print("7e3".is_valid_float())   # Prints true
 				print("Hello".is_valid_float()) # Prints false
+				print("2_4".is_valid_float())   # Prints false (number separators are not supported)
 				[/codeblock]
 			</description>
 		</method>
@@ -474,6 +479,7 @@
 				print("A08E".is_valid_hex_number())    # Prints true
 				print("-AbCdEf".is_valid_hex_number()) # Prints true
 				print("2.5".is_valid_hex_number())     # Prints false
+				print("2_5".is_valid_hex_number())     # Prints false (number separators are not supported)
 
 				print("0xDEADC0DE".is_valid_hex_number(true)) # Prints true
 				[/codeblock]
@@ -507,6 +513,7 @@
 				print("Hi".is_valid_int())   # Prints false
 				print("+3".is_valid_int())   # Prints true
 				print("-12".is_valid_int())  # Prints true
+				print("1_2".is_valid_int())  # Prints false (number separators are not supported)
 				[/codeblock]
 			</description>
 		</method>
@@ -933,6 +940,7 @@
 				var c = "12xy3".to_float()  # c is 12.0
 				var d = "1e3".to_float()    # d is 1000.0
 				var e = "Hello!".to_float() # e is 0.0
+				var f = "1_2".to_float()    # f is 1.0 (number separators are not supported)
 				[/codeblock]
 			</description>
 		</method>


### PR DESCRIPTION
Even if we chose to implement this in the future it'd be good to clear this up in 4.2 and 4.3, might easily be confusing as:
* `to_int` *does* ignore these
* GDScript allows them

Can explicitly clarify the case in `Expression` but I think that class needs a more general clarification on how it works and what it does actually support so leaving it for now.

See:
* https://github.com/godotengine/godot/issues/97324
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
