### PR TITLE
Fix `font_hover_pressed_color` and `icon_hover_pressed_color` not working for no stylebox use on `Button`

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -298,19 +298,12 @@ void Button::_notification(int p_what) {
 					}
 				} break;
 				case DRAW_HOVER_PRESSED: {
-					// Edge case for CheckButton and CheckBox.
-					if (has_theme_stylebox("hover_pressed")) {
-						if (has_theme_color(SNAME("font_hover_pressed_color"))) {
-							font_color = theme_cache.font_hover_pressed_color;
-						}
-						if (has_theme_color(SNAME("icon_hover_pressed_color"))) {
-							icon_modulate_color = theme_cache.icon_hover_pressed_color;
-						}
-
-						break;
+					font_color = theme_cache.font_hover_pressed_color;
+					if (has_theme_color(SNAME("icon_hover_pressed_color"))) {
+						icon_modulate_color = theme_cache.icon_hover_pressed_color;
 					}
-				}
-					[[fallthrough]];
+
+				} break;
 				case DRAW_PRESSED: {
 					if (has_theme_color(SNAME("font_pressed_color"))) {
 						font_color = theme_cache.font_pressed_color;


### PR DESCRIPTION
Fixes #83393 

I encountered this as I was working on my own project and I highly doubt this is a design choice. The issue is basically that the Button node cannot make use of ```font_hover_pressed_color``` and ```icon_hover_pressed_color``` unless a ```hover_pressed``` stylebox is assigned to it. This is especially noticeable whenever you are working with toggleable buttons. I now changed it so that you **don't** need to have a ```hover_pressed``` stylebox to make use of ```font_hover_pressed_color``` and ```icon_hover_pressed_color```.

![colors](https://github.com/user-attachments/assets/e211a9da-1dee-41bc-b251-d188e78c2d9a) ![buttons](https://github.com/user-attachments/assets/3ef287da-833f-4d21-99c1-6bd752c42503)

![show](https://github.com/user-attachments/assets/74cecdc7-3be4-4396-8544-d0ddfc1ebbac)

### Code

I think it is evident this was an oversight in the previous code judging by the commented line which suggests that the if statement was put in place as an edge case for CheckButton and CheckBox. This if statement and the comment itself were most likely copied from the function ```Button::_get_current_stylebox()``` of the same file (old line 145) which **does** need to make sure the proper stylebox is assigned. In our case however, we do not need the stylebox in order to make use of this feature so I simply removed the if statement. As you can see, CheckButton and CheckBox are unaffected by this change so the if statement didn't have a reason to be there in the first place.