### PR TITLE
In make_rst.py, include the parent class in 'Inherits:' even if it is not known.

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -949,13 +949,17 @@ def make_rst_class(class_def: ClassDef, state: State, dry_run: bool, output_dir:
             inherits = class_def.inherits.strip()
             f.write(f'**{translate("Inherits:")}** ')
             first = True
-            while inherits in state.classes:
+            while inherits is not None:
                 if not first:
                     f.write(" **<** ")
                 else:
                     first = False
 
                 f.write(make_type(inherits, state))
+
+                if inherits not in state.classes:
+                    break  # Parent unknown.
+
                 inode = state.classes[inherits].inherits
                 if inode:
                     inherits = inode.strip()


### PR DESCRIPTION
With this PR, in the rare case that a parent class has not yet been documented, it will still appear in "Inherits:", as in:

![SCR-20240922-selz](https://github.com/user-attachments/assets/10f8214b-c8a0-414f-bbe2-1903f00f8a6c)

This is related to https://github.com/godotengine/godot-proposals/issues/10733: When the script is used for a gdextension codebase, the script will not be aware of the parent class. This mitigates the issue of an empty "Inherits:" notation (the current state):

![SCR-20240922-sezk](https://github.com/user-attachments/assets/02bb6d5f-1987-4bac-9f98-0ca15969898c)

Additionally, an error will now be printed through `make_type`, where this mistake was silently ignored before.