### PR TITLE
Fix a typo in make_rst.py (Packedfloat64Array -> PackedFloat64Array)

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -150,7 +150,7 @@ PACKED_ARRAY_TYPES: List[str] = [
     "PackedByteArray",
     "PackedColorArray",
     "PackedFloat32Array",
-    "Packedfloat64Array",
+    "PackedFloat64Array",
     "PackedInt32Array",
     "PackedInt64Array",
     "PackedStringArray",


### PR DESCRIPTION
Judging by how it's used, this may add the 
```
The returned array is copied and any changes to it will not update the original property value
```
note to a few function docs.