### PR TITLE
Add filter & sort to editor file dialog

### DIFF
--- a/editor/file_info.cpp
+++ b/editor/file_info.cpp
@@ -1,0 +1,61 @@
+/**************************************************************************/
+/*  file_info.cpp                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor/file_info.h"
+
+void sort_file_info_list(List<FileInfo> &r_file_list, FileSortOption p_file_sort_option) {
+	// Sort the file list if needed.
+	switch (p_file_sort_option) {
+		case FileSortOption::FILE_SORT_TYPE:
+			r_file_list.sort_custom<FileInfoTypeComparator>();
+			break;
+		case FileSortOption::FILE_SORT_TYPE_REVERSE:
+			r_file_list.sort_custom<FileInfoTypeComparator>();
+			r_file_list.reverse();
+			break;
+		case FileSortOption::FILE_SORT_MODIFIED_TIME:
+			r_file_list.sort_custom<FileInfoModifiedTimeComparator>();
+			break;
+		case FileSortOption::FILE_SORT_MODIFIED_TIME_REVERSE:
+			r_file_list.sort_custom<FileInfoModifiedTimeComparator>();
+			r_file_list.reverse();
+			break;
+		case FileSortOption::FILE_SORT_NAME_REVERSE:
+			r_file_list.sort();
+			r_file_list.reverse();
+			break;
+		case FileSortOption::FILE_SORT_NAME:
+			r_file_list.sort();
+			break;
+		default:
+			ERR_FAIL_MSG("Invalid file sort option.");
+			break;
+	}
+}

--- a/editor/file_info.h
+++ b/editor/file_info.h
@@ -1,0 +1,74 @@
+/**************************************************************************/
+/*  file_info.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef FILE_INFO_H
+#define FILE_INFO_H
+
+#include "core/variant/variant.h"
+
+enum class FileSortOption {
+	FILE_SORT_NAME = 0,
+	FILE_SORT_NAME_REVERSE = 1,
+	FILE_SORT_TYPE = 2,
+	FILE_SORT_TYPE_REVERSE = 3,
+	FILE_SORT_MODIFIED_TIME = 4,
+	FILE_SORT_MODIFIED_TIME_REVERSE = 5,
+	FILE_SORT_MAX = 6,
+};
+
+struct FileInfo {
+	String name;
+	String path;
+	String icon_path;
+	StringName type;
+	Vector<String> sources;
+	bool import_broken = false;
+	uint64_t modified_time = 0;
+
+	bool operator<(const FileInfo &p_fi) const {
+		return FileNoCaseComparator()(name, p_fi.name);
+	}
+};
+
+struct FileInfoTypeComparator {
+	bool operator()(const FileInfo &p_a, const FileInfo &p_b) const {
+		return FileNoCaseComparator()(p_a.name.get_extension() + p_a.type + p_a.name.get_basename(), p_b.name.get_extension() + p_b.type + p_b.name.get_basename());
+	}
+};
+
+struct FileInfoModifiedTimeComparator {
+	bool operator()(const FileInfo &p_a, const FileInfo &p_b) const {
+		return p_a.modified_time > p_b.modified_time;
+	}
+};
+
+void sort_file_info_list(List<FileInfo> &r_file_list, FileSortOption p_file_sort_option);
+
+#endif // FILE_INFO_H

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -33,6 +33,7 @@
 
 #include "editor/dependency_editor.h"
 #include "editor/editor_file_system.h"
+#include "editor/file_info.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/script_create_dialog.h"
 #include "scene/gui/box_container.h"
@@ -93,16 +94,6 @@ public:
 		DISPLAY_MODE_HSPLIT,
 	};
 
-	enum FileSortOption {
-		FILE_SORT_NAME = 0,
-		FILE_SORT_NAME_REVERSE,
-		FILE_SORT_TYPE,
-		FILE_SORT_TYPE_REVERSE,
-		FILE_SORT_MODIFIED_TIME,
-		FILE_SORT_MODIFIED_TIME_REVERSE,
-		FILE_SORT_MAX,
-	};
-
 	enum Overwrite {
 		OVERWRITE_UNDECIDED,
 		OVERWRITE_REPLACE,
@@ -146,7 +137,7 @@ private:
 	HashMap<String, Color> folder_colors;
 	Dictionary assigned_folder_colors;
 
-	FileSortOption file_sort = FILE_SORT_NAME;
+	FileSortOption file_sort = FileSortOption::FILE_SORT_NAME;
 
 	VBoxContainer *scanning_vb = nullptr;
 	ProgressBar *scanning_progress = nullptr;
@@ -335,25 +326,6 @@ private:
 	void _file_list_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _tree_empty_click(const Vector2 &p_pos, MouseButton p_button);
 	void _tree_empty_selected();
-
-	struct FileInfo {
-		String name;
-		String path;
-		String icon_path;
-		StringName type;
-		Vector<String> sources;
-		bool import_broken = false;
-		uint64_t modified_time = 0;
-
-		bool operator<(const FileInfo &fi) const {
-			return FileNoCaseComparator()(name, fi.name);
-		}
-	};
-
-	struct FileInfoTypeComparator;
-	struct FileInfoModifiedTimeComparator;
-
-	void _sort_file_info_list(List<FileSystemDock::FileInfo> &r_file_list);
 
 	void _search(EditorFileSystemDirectory *p_path, List<FileInfo> *matches, int p_max_items);
 

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -32,13 +32,15 @@
 #define EDITOR_FILE_DIALOG_H
 
 #include "core/io/dir_access.h"
+#include "editor/file_info.h"
 #include "scene/gui/dialogs.h"
 #include "scene/property_list_helper.h"
 
-class GridContainer;
 class DependencyRemoveDialog;
+class GridContainer;
 class HSplitContainer;
 class ItemList;
+class MenuButton;
 class OptionButton;
 class PopupMenu;
 class TextureRect;
@@ -127,6 +129,11 @@ private:
 	Button *favorite = nullptr;
 	Button *show_hidden = nullptr;
 
+	String search_string;
+	LineEdit *filter_box = nullptr;
+	FileSortOption file_sort = FileSortOption::FILE_SORT_NAME;
+	MenuButton *file_sort_button = nullptr;
+
 	Button *fav_up = nullptr;
 	Button *fav_down = nullptr;
 
@@ -164,6 +171,9 @@ private:
 		Ref<Texture2D> create_folder;
 		Ref<Texture2D> favorites_up;
 		Ref<Texture2D> favorites_down;
+
+		Ref<Texture2D> filter_box;
+		Ref<Texture2D> file_sort_button;
 
 		Ref<Texture2D> folder;
 		Color folder_icon_color;
@@ -226,6 +236,10 @@ private:
 	void _filter_selected(int);
 	void _make_dir();
 	void _make_dir_confirm();
+
+	void _focus_filter_box();
+	void _filter_changed(const String &p_text);
+	void _file_sort_popup(int p_id);
 
 	void _delete_items();
 	void _delete_files_global();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2721

On `EditorFileDialog`:
 * Add filter box that only shows folders and files in current directory that match
 * Add sort button to sort files and directories
 * Add a shortcut for CTRL+F for selecting the filter box

Also moved common code between `EditorFileDialog` and `FileSystemDock` to it's own file.

This tries to address comments on https://github.com/godotengine/godot/pull/48734 and change it to make it compatible with code on `master`.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
