### PR TITLE
New TileMapPattern GUI

### DIFF
--- a/doc/classes/TileMapPattern.xml
+++ b/doc/classes/TileMapPattern.xml
@@ -6,6 +6,7 @@
 	<description>
 		This resource holds a set of cells to help bulk manipulations of [TileMap].
 		A pattern always start at the [code](0,0)[/code] coordinates and cannot have cells with negative coordinates.
+		TileMapPatterns are stored and added to a [TileSet], they are not stored inside of a [TileMapLayer]. Use [method TileMapLayer.get_pattern] to get a pattern from your TileMapLayer in code. Use [method TileSet.get_pattern] to get a stored pattern from a pattern set.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -29,6 +30,12 @@
 			<param index="0" name="coords" type="Vector2i" />
 			<description>
 				Returns the tile source ID of the cell at [param coords].
+			</description>
+		</method>
+		<method name="get_pattern_set_index" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the index of the pattern set this pattern belongs to.
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -48,9 +48,17 @@
 		<method name="add_pattern">
 			<return type="int" />
 			<param index="0" name="pattern" type="TileMapPattern" />
-			<param index="1" name="index" type="int" default="-1" />
+			<param index="1" name="pattern_set_index" type="int" />
+			<param index="2" name="pattern_index" type="int" default="-1" />
 			<description>
-				Adds a [TileMapPattern] to be stored in the TileSet resource. If provided, insert it at the given [param index].
+				Adds a [TileMapPattern] to be stored in one of the pattern sets inside of the TileSet resource.
+			</description>
+		</method>
+		<method name="add_pattern_set">
+			<return type="void" />
+			<param index="0" name="pattern_set_index" type="int" default="-1" />
+			<description>
+				Adds a new pattern set at the provided index. Appends a pattern set to the top-most index if no parameter is provided. You should probably use the GUI in the TileMap to do this instead.
 			</description>
 		</method>
 		<method name="add_physics_layer">
@@ -191,17 +199,25 @@
 				Returns the occlusion layers count.
 			</description>
 		</method>
-		<method name="get_pattern">
+		<method name="get_pattern" qualifiers="const">
 			<return type="TileMapPattern" />
-			<param index="0" name="index" type="int" default="-1" />
+			<param index="0" name="pattern_set_index" type="int" />
+			<param index="1" name="pattern_index" type="int" />
 			<description>
-				Returns the [TileMapPattern] at the given [param index].
+				Returns the [TileMapPattern] that is at the pattern_set_index and pattern_index.
 			</description>
 		</method>
-		<method name="get_patterns_count">
+		<method name="get_pattern_sets_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of [TileMapPattern] this tile set handles.
+				Get the number of pattern sets stored in this [TileSet].
+			</description>
+		</method>
+		<method name="get_patterns_count" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="pattern_set_index" type="int" />
+			<description>
+				Returns the number of [TileMapPattern] inside of the pattern set at the index.
 			</description>
 		</method>
 		<method name="get_physics_layer_collision_layer" qualifiers="const">
@@ -361,6 +377,14 @@
 				Moves the occlusion layer at index [param layer_index] to the given position [param to_position] in the array. Also updates the atlas tiles accordingly.
 			</description>
 		</method>
+		<method name="move_pattern_set">
+			<return type="void" />
+			<param index="0" name="from_index" type="int" />
+			<param index="1" name="to_index" type="int" />
+			<description>
+				Move the pattern set from one pattern set index to another. You should probably use the TileMap GUI for this instead.
+			</description>
+		</method>
 		<method name="move_physics_layer">
 			<return type="void" />
 			<param index="0" name="layer_index" type="int" />
@@ -426,9 +450,17 @@
 		</method>
 		<method name="remove_pattern">
 			<return type="void" />
-			<param index="0" name="index" type="int" />
+			<param index="0" name="pattern_set_index" type="int" />
+			<param index="1" name="pattern_index" type="int" />
 			<description>
-				Remove the [TileMapPattern] at the given index.
+				Remove the [TileMapPattern] at the given indices.
+			</description>
+		</method>
+		<method name="remove_pattern_set">
+			<return type="void" />
+			<param index="0" name="pattern_set_index" type="int" />
+			<description>
+				Removes the pattern set at the provided index. You should probably use the TileMap GUI for this instead.
 			</description>
 		</method>
 		<method name="remove_physics_layer">

--- a/editor/plugins/tiles/tile_map_layer_editor.h
+++ b/editor/plugins/tiles/tile_map_layer_editor.h
@@ -66,9 +66,9 @@ public:
 	};
 
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return false; };
-	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) {}
-	virtual void tile_set_changed() {}
-	virtual void edit(ObjectID p_tile_map_layer_id) {}
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) {};
+	virtual void tile_set_changed() {};
+	virtual void edit(ObjectID p_tile_map_layer_id) {};
 };
 
 class TileMapLayerEditorTilesPlugin : public TileMapLayerSubEditorPlugin {
@@ -92,7 +92,6 @@ private:
 	Button *line_tool_button = nullptr;
 	Button *rect_tool_button = nullptr;
 	Button *bucket_tool_button = nullptr;
-
 	HBoxContainer *tools_settings = nullptr;
 
 	VSeparator *tools_settings_vsep = nullptr;
@@ -152,6 +151,7 @@ private:
 
 	///// Selection system. /////
 	RBSet<Vector2i> tile_map_selection;
+	// Could this be made into a resource, then carried as a Ref<TileMapPattern>?
 	Ref<TileMapPattern> tile_map_clipboard;
 	Ref<TileMapPattern> selection_pattern;
 	Ref<TileMapPattern> erase_pattern;
@@ -166,8 +166,6 @@ private:
 	void _update_tileset_selection_from_selection_pattern();
 	void _update_fix_selected_and_hovered();
 	void _fix_invalid_tiles_in_tile_map_selection();
-
-	void patterns_item_list_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
 
 	///// Bottom panel common ////
 	void _tab_changed();
@@ -214,14 +212,51 @@ private:
 	void _scenes_list_multi_selected(int p_index, bool p_selected);
 	void _scenes_list_lmb_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
 
-	///// Bottom panel patterns ////
+	///// Bottom panel patterns GUI ////
 	VBoxContainer *patterns_bottom_panel = nullptr;
+
+	Tree *pattern_sets_display = nullptr;
+	TreeItem *root = nullptr;
+
+	PopupMenu *pattern_set_tree_menu = nullptr;
+	PopupMenu *delete_pattern_set_menu = nullptr;
+	Label *pattern_sets_help_label = nullptr;
+
 	ItemList *patterns_item_list = nullptr;
+	PopupMenu *delete_pattern_menu = nullptr;
 	Label *patterns_help_label = nullptr;
-	void _patterns_item_list_gui_input(const Ref<InputEvent> &p_event);
-	void _pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture);
-	bool select_last_pattern = false;
+	LineEdit *item_line_editor = nullptr;
+
+	void _update_pattern_sets();
 	void _update_patterns_list();
+	void _pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture);
+	void _patterns_item_list_gui_input(const Ref<InputEvent> &p_event);
+
+	void _pattern_sets_display_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
+	void _pattern_set_menu_id_pressed(int p_id);
+
+	void _pattern_set_selected(const Vector2 &p_pos, MouseButton p_mouse_button_index);
+	void _delete_pattern_set_menu_id_pressed(int p_id);
+
+	void _rename_pattern_set();
+	void _rename_pattern_set_submitted(String p_new_text);
+
+	// Used for swapping pattern sets in the pattern_sets_display using drag and drop functionality.
+	Variant _get_drag_data_fw(const Point2 &p_point, Control *p_from_control);
+	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control) const;
+	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from_control);
+
+	void _pattern_clicked(int p_item_index, const Vector2 &p_pos, MouseButton p_mouse_button_index);
+	void _delete_pattern_menu_id_pressed(int p_id);
+	void _rename_pattern(int p_item_index);
+	void _rename_pattern_submitted(String p_new_text);
+
+	// Used for swapping patterns in the patterns_item_list using drag and drop functionality.
+	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
+	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
+	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
+
+	bool select_last_pattern = false;
 
 	// General
 	void _update_theme();
@@ -321,7 +356,6 @@ private:
 	void _update_terrains_tree();
 	void _update_tiles_list();
 	void _update_theme();
-
 	// Update callback
 	virtual void tile_set_changed() override;
 
@@ -344,11 +378,11 @@ private:
 
 	ObjectID edited_tile_map_layer_id;
 	bool is_multi_node_edit = false;
-	Vector<TileMapLayer *> tile_map_layers_in_scene_cache;
+
 	bool layers_in_scene_list_cache_needs_update = false;
 	TileMapLayer *_get_edited_layer() const;
 	void _find_tile_map_layers_in_scene(Node *p_current, const Node *p_owner, Vector<TileMapLayer *> &r_list) const;
-	void _update_tile_map_layers_in_scene_list_cache();
+
 	void _node_change(Node *p_node);
 
 	// Vector to keep plugins.
@@ -411,6 +445,10 @@ protected:
 	void _draw_shape(Control *p_control, Rect2 p_region, TileSet::TileShape p_shape, TileSet::TileOffsetAxis p_offset_axis, Color p_color);
 
 public:
+	// Determine the amount of TileMapLayers in the scene tree.
+	inline static Vector<TileMapLayer *> tile_map_layers_in_scene_cache;
+	void _update_tile_map_layers_in_scene_list_cache();
+	Vector<TileMapLayer *> get_tile_map_layers_in_scene() const;
 	bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -387,7 +387,6 @@ void TileSetEditor::_notification(int p_what) {
 				}
 
 				_update_sources_list();
-				_update_patterns_list();
 
 				sources_add_button->set_disabled(read_only);
 				sources_advanced_menu_button->set_disabled(read_only);
@@ -405,6 +404,7 @@ void TileSetEditor::_notification(int p_what) {
 	}
 }
 
+/* Previously used for displaying the simple and earlier pattern system. With some modification this can be used to display the newer advanced one.
 void TileSetEditor::_patterns_item_list_gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(!tile_set.is_valid());
 
@@ -419,6 +419,7 @@ void TileSetEditor::_patterns_item_list_gui_input(const Ref<InputEvent> &p_event
 		for (int i = 0; i < selected.size(); i++) {
 			int pattern_index = selected[i];
 			undo_redo->add_do_method(*tile_set, "remove_pattern", pattern_index);
+			//Change this to "tileset_clipboard
 			undo_redo->add_undo_method(*tile_set, "add_pattern", tile_set->get_pattern(pattern_index), pattern_index);
 		}
 		undo_redo->commit_action();
@@ -438,7 +439,36 @@ void TileSetEditor::_pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Tex
 
 void TileSetEditor::_update_patterns_list() {
 	ERR_FAIL_COND(!tile_set.is_valid());
+	TreeItem *pattern_set;
+	int sel_pattern_set_index;
 
+	// If this display update function was called by a pattern set being clicked on, get the selected pattern set and it's index. Then update to display the patterns inside of that specific pattern set.
+	if (pattern_sets_display->get_selected() != nullptr) {
+		pattern_set = pattern_sets_display->get_selected();
+		Dictionary metadata_dict = pattern_set->get_metadata(0);
+		sel_pattern_set_index = metadata_dict["pattern_set"];
+		patterns_item_list->clear();
+
+		if (pattern_set && pattern_set->get_metadata(0)) {
+			ERR_FAIL_INDEX(sel_pattern_set_index, tile_set->get_pattern_sets_count());
+			// Create the item's to display in the item list
+			for (int i = 0; i < tile_set->get_patterns_count(sel_pattern_set_index); i++) {
+				int pattern_id = patterns_item_list->add_item("");
+				patterns_item_list->set_item_metadata(pattern_id, tile_set->get_pattern(sel_pattern_set_index, pattern_id));
+				patterns_item_list->set_item_tooltip(pattern_id, vformat(TTR("Index: %d"), i));
+
+				// Name the pattern. Assign a default name if the user did not set a custom name.
+				Ref<TileMapPattern> current_pattern = patterns_item_list->get_item_metadata(i);
+				patterns_item_list->set_item_text(pattern_id, current_pattern->get_name());
+				if (current_pattern->get_name().is_empty()) {
+					patterns_item_list->set_item_text(pattern_id, vformat(TTR("Pattern %d"), pattern_id));
+				}
+				TilesEditorUtils::get_singleton()->queue_pattern_preview(tile_set, tile_set->get_pattern(sel_pattern_set_index, pattern_id), callable_mp(this, &TileMapEditorTilesPlugin::_pattern_preview_done));
+			}
+			// Update the label visibility.
+			patterns_help_label->set_visible(patterns_item_list->get_item_count() == 0);
+		}
+	}
 	// Recreate the items.
 	patterns_item_list->clear();
 	for (int i = 0; i < tile_set->get_patterns_count(); i++) {
@@ -451,14 +481,13 @@ void TileSetEditor::_update_patterns_list() {
 	// Update the label visibility.
 	patterns_help_label->set_visible(patterns_item_list->get_item_count() == 0);
 }
-
+*/
 void TileSetEditor::_tile_set_changed() {
 	tile_set_changed_needs_update = true;
 }
 
 void TileSetEditor::_tab_changed(int p_tab_changed) {
 	split_container->set_visible(p_tab_changed == 0);
-	patterns_item_list->set_visible(p_tab_changed == 1);
 }
 
 void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_edited, const String &p_array_prefix, int p_from_index, int p_to_pos) {
@@ -746,7 +775,6 @@ void TileSetEditor::edit(Ref<TileSet> p_tile_set) {
 		} else {
 			_update_sources_list();
 		}
-		_update_patterns_list();
 	}
 }
 
@@ -819,7 +847,7 @@ TileSetEditor::TileSetEditor() {
 	tabs_bar->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
 	tabs_bar->set_clip_tabs(false);
 	tabs_bar->add_tab(TTR("Tile Sources"));
-	tabs_bar->add_tab(TTR("Patterns"));
+	//tabs_bar->add_tab(TTR("Patterns"));
 	tabs_bar->connect("tab_changed", callable_mp(this, &TileSetEditor::_tab_changed));
 
 	tile_set_toolbar = memnew(HBoxContainer);
@@ -946,7 +974,7 @@ TileSetEditor::TileSetEditor() {
 	patterns_item_list->set_max_text_lines(2);
 	patterns_item_list->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
 	patterns_item_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	patterns_item_list->connect(SceneStringName(gui_input), callable_mp(this, &TileSetEditor::_patterns_item_list_gui_input));
+	//patterns_item_list->connect("gui_input", callable_mp(this, &TileSetEditor::_patterns_item_list_gui_input));
 	main_vb->add_child(patterns_item_list);
 	patterns_item_list->hide();
 

--- a/editor/plugins/tiles/tile_set_editor.h
+++ b/editor/plugins/tiles/tile_set_editor.h
@@ -94,11 +94,19 @@ private:
 	// Patterns.
 	ItemList *patterns_item_list = nullptr;
 	Label *patterns_help_label = nullptr;
-	void _patterns_item_list_gui_input(const Ref<InputEvent> &p_event);
+	//void _patterns_item_list_gui_input(const Ref<InputEvent> &p_event);
+	/*
+	Tree *pattern_sets_display = nullptr;
+	TreeItem *root = nullptr;
+	Label *pattern_sets_help_label = nullptr;
+
+
+
+
 	void _pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture);
 	bool select_last_pattern = false;
 	void _update_patterns_list();
-
+	*/
 	// Expanded editor.
 	PanelContainer *expanded_area = nullptr;
 	Control *expanded_editor = nullptr;

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -95,3 +95,15 @@ Validate extension JSON: Error: Field 'classes/InputMap/methods/add_action/argum
 
 Default deadzone value was changed. No adjustments should be necessary.
 Compatibility method registered.
+
+GH-97345
+--------
+Validate extension JSON: Error: Field 'classes/TileSet/methods/add_pattern/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/TileSet/methods/get_pattern': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/TileSet/methods/get_pattern/arguments': default_value was removed.
+Validate extension JSON: Error: Field 'classes/TileSet/methods/get_pattern/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/TileSet/methods/get_patterns_count': is_const changed value in new API, from false to true.
+Validate extension JSON: Error: Field 'classes/TileSet/methods/remove_pattern/arguments': size changed value in new API, from 1 to 2.
+
+Added pattern_set_index parameter to add_pattern, get_pattern, remove_pattern, as well as get_patterns_count. New TileMapPatterns GUI allows storing patterns inside of different pattern sets. 
+Compatibility method registered.

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -555,6 +555,7 @@ Vector2i TileMap::map_pattern(const Vector2i &p_position_in_tilemap, const Vecto
 
 void TileMap::set_pattern(int p_layer, const Vector2i &p_position, const Ref<TileMapPattern> p_pattern) {
 	TILEMAP_CALL_FOR_LAYER(p_layer, set_pattern, p_position, p_pattern);
+	// The above code is needed because tiles_editor_plugin.cpp's _thread function used for saving patterns to the tileset patterns list depends on (deprecated) TileMap functionality.
 }
 
 HashMap<Vector2i, TileSet::TerrainsPattern> TileMap::terrain_fill_constraints(int p_layer, const Vector<Vector2i> &p_to_replace, int p_terrain_set, const RBSet<TerrainConstraint> &p_constraints) {

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 #include "tile_map_layer.h"
-
+#include "core/core_string_names.h"
 #include "core/io/marshalls.h"
 #include "scene/2d/tile_map.h"
 #include "scene/gui/control.h"
@@ -2543,6 +2543,11 @@ Ref<TileMapPattern> TileMapLayer::get_pattern(TypedArray<Vector2i> p_coords_arra
 		min = min.min(p_coords_array[i]);
 	}
 
+	Vector2i max;
+	for (int i = 0; i < p_coords_array.size(); i++) {
+		max = max.max(p_coords_array[i]);
+	}
+
 	Vector<Vector2i> coords_in_pattern_array;
 	coords_in_pattern_array.resize(p_coords_array.size());
 	Vector2i ensure_positive_offset;
@@ -2578,7 +2583,7 @@ Ref<TileMapPattern> TileMapLayer::get_pattern(TypedArray<Vector2i> p_coords_arra
 		Vector2i coords_in_pattern = coords_in_pattern_array[i];
 		output->set_cell(coords_in_pattern + ensure_positive_offset, get_cell_source_id(coords), get_cell_atlas_coords(coords), get_cell_alternative_tile(coords));
 	}
-
+	output->set_size((max + Vector2i(1, 1)) - min);
 	return output;
 }
 

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -30,7 +30,6 @@
 
 #ifndef TILE_MAP_LAYER_H
 #define TILE_MAP_LAYER_H
-
 #include "scene/resources/2d/tile_set.h"
 
 class TileSetAtlasSource;
@@ -90,7 +89,7 @@ public:
 
 	TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, int p_terrain); // For the center terrain bit
 	TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit, int p_terrain); // For peering bits
-	TerrainConstraint() {}
+	TerrainConstraint() {};
 };
 
 #ifdef DEBUG_ENABLED
@@ -275,7 +274,7 @@ private:
 
 	// Properties.
 	HashMap<Vector2i, CellData> tile_map_layer_data;
-
+	Vector<TileMapLayer *> tile_map_layers_in_scene;
 	bool enabled = true;
 	Ref<TileSet> tile_set;
 
@@ -446,6 +445,7 @@ public:
 	bool is_cell_transposed(const Vector2i &p_coords) const;
 
 	// Patterns.
+
 	Ref<TileMapPattern> get_pattern(TypedArray<Vector2i> p_coords_array);
 	void set_pattern(const Vector2i &p_position, const Ref<TileMapPattern> p_pattern);
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4514,6 +4514,10 @@ Size2 Tree::get_minimum_size() const {
 	return min_size + content_min_size;
 }
 
+LineEdit *Tree::get_line_editor() const {
+	return line_editor;
+}
+
 TreeItem *Tree::create_item(TreeItem *p_parent, int p_index) {
 	ERR_FAIL_COND_V(blocked > 0, nullptr);
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -820,6 +820,7 @@ public:
 
 	Size2 get_minimum_size() const override;
 
+	LineEdit *get_line_editor() const;
 	Tree();
 	~Tree();
 };

--- a/scene/resources/2d/tile_set.compat.inc
+++ b/scene/resources/2d/tile_set.compat.inc
@@ -40,6 +40,29 @@ Ref<OccluderPolygon2D> TileData::_get_occluder_bind_compat_84660(int p_layer_id)
 	return get_occluder_polygon(p_layer_id, 0, false, false, false);
 }
 
+void TileSet::_add_pattern_bind_compat_97345(Ref<TileMapPattern> pattern, int index) {
+	add_pattern(pattern, 0, index);
+}
+
+Ref<TileMapPattern> TileSet::_get_pattern_bind_compat_97345(int index) {
+	return get_pattern(0, index);
+}
+
+void TileSet::_remove_pattern_bind_compat_97345(int index) {
+	remove_pattern(0, index);
+}
+
+int TileSet::_get_patterns_count_bind_compat_97345() {
+	return get_patterns_count(0);
+}
+
+void TileSet::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("add_pattern", "pattern", "pattern_set_index", "pattern_index"), &TileSet::_add_pattern_bind_compat_97345);
+	ClassDB::bind_compatibility_method(D_METHOD("get_pattern", "pattern_set_index", "pattern_index"), &TileSet::_get_pattern_bind_compat_97345);
+	ClassDB::bind_compatibility_method(D_METHOD("remove_pattern", "pattern_set_index", "pattern_index"), &TileSet::_get_pattern_bind_compat_97345);
+	ClassDB::bind_compatibility_method(D_METHOD("get_patterns_count", "pattern_set_index"), &TileSet::_get_patterns_count_bind_compat_97345);
+}
+
 void TileData::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_navigation_polygon"), &TileData::_get_navigation_polygon_bind_compat_84660);
 	ClassDB::bind_compatibility_method(D_METHOD("get_occluder"), &TileData::_get_occluder_bind_compat_84660);


### PR DESCRIPTION
Pull request with a cleaner commit history similar to PR #95826 https://github.com/godotengine/godot/pull/95826. The difference is that it doesn't contain the multilayer TileMapPattern system in favor of just adding a new TileMapPattern GUI that is backwards compatible with the old TileMapPattern system (A new pattern set is created and all old patterns are imported to it). 
