### PR TITLE
Update Inspector when renaming a file via File System Dock

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7808,11 +7808,12 @@ EditorNode::EditorNode() {
 	// Instantiate and place editor docks.
 
 	memnew(SceneTreeDock(scene_root, editor_selection, editor_data));
+	memnew(FileSystemDock);
 	memnew(InspectorDock(editor_data));
 	memnew(ImportDock);
 	memnew(NodeDock);
 
-	FileSystemDock *filesystem_dock = memnew(FileSystemDock);
+	FileSystemDock *filesystem_dock = FileSystemDock::get_singleton();
 	filesystem_dock->connect("inherit", callable_mp(this, &EditorNode::_inherit_request));
 	filesystem_dock->connect("instantiate", callable_mp(this, &EditorNode::_instantiate_request));
 	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_editor_layout));

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -399,6 +399,21 @@ void InspectorDock::_resource_selected(const Ref<Resource> &p_res, const String 
 	EditorNode::get_singleton()->push_item(r.operator->(), p_property);
 }
 
+void InspectorDock::_files_moved(const String &p_old_file, const String &p_new_file) {
+	// Because only the file name is shown, we care about changes on the file name.
+	if (p_old_file.get_file() == p_new_file.get_file()) {
+		return;
+	}
+
+	ObjectID current_id = EditorNode::get_singleton()->get_editor_selection_history()->get_current();
+	Ref<Resource> res(current_id.is_valid() ? ObjectDB::get_instance(current_id) : nullptr);
+	// We only care about updating the path if the current object is the one being renamed.
+	if (res.is_valid() && p_old_file == res->get_path()) {
+		res->set_path(p_new_file);
+		object_selector->update_path();
+	}
+}
+
 void InspectorDock::_edit_forward() {
 	if (EditorNode::get_singleton()->get_editor_selection_history()->next()) {
 		EditorNode::get_singleton()->edit_current();
@@ -822,6 +837,8 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	inspector->set_use_filter(true);
 
 	inspector->connect("resource_selected", callable_mp(this, &InspectorDock::_resource_selected));
+
+	FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &InspectorDock::_files_moved));
 
 	set_process_shortcut_input(true);
 }

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -124,6 +124,7 @@ class InspectorDock : public VBoxContainer {
 	void _info_pressed();
 	void _resource_created();
 	void _resource_selected(const Ref<Resource> &p_res, const String &p_property);
+	void _files_moved(const String &p_old_file, const String &p_new_file);
 	void _edit_forward();
 	void _edit_back();
 	void _menu_collapseall();


### PR DESCRIPTION
Fixes #56803

Connecting `FileSystemDock` `files_moved` signal to `InspectorDock` and then checking if we need to update or not the object stored on `EditorSelectionHistory`.

![InspectorFileNameUpdate](https://github.com/user-attachments/assets/c344349c-9b4c-4b0b-a3f1-9c005d0b602b)