### PR TITLE
`AudioStreamPlaybackInteractive`: Add `clip_started`, `clip_ended` signals

### DIFF
--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
@@ -36,4 +36,18 @@
 			</description>
 		</method>
 	</methods>
+	<signals>
+		<signal name="clip_ended">
+			<param index="0" name="clip_idx" type="int" />
+			<description>
+				Emitted when a clip ends playing because of a transition or the last clip is done playing.
+			</description>
+		</signal>
+		<signal name="clip_started">
+			<param index="0" name="clip_idx" type="int" />
+			<description>
+				Emitted when a clip starts playing because of a transition or the first time the stream is played.
+			</description>
+		</signal>
+	</signals>
 </class>


### PR DESCRIPTION
This PR:

* Adds `clip_started` and `clip_ended` signals to `AudioStreamPlaybackInteractive`

Any questions or suggestions are more than welcome.