### PR TITLE
Add auto translate mode for cells in `Tree`

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -73,6 +73,13 @@
 				Removes the button at index [param button_index] in column [param column].
 			</description>
 		</method>
+		<method name="get_auto_translate_mode" qualifiers="const">
+			<return type="int" enum="Node.AutoTranslateMode" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns the column's auto translate mode.
+			</description>
+		</method>
 		<method name="get_autowrap_mode" qualifiers="const">
 			<return type="int" enum="TextServer.AutowrapMode" />
 			<param index="0" name="column" type="int" />
@@ -491,6 +498,15 @@
 			<param index="0" name="column" type="int" />
 			<description>
 				Selects the given [param column].
+			</description>
+		</method>
+		<method name="set_auto_translate_mode">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="mode" type="int" enum="Node.AutoTranslateMode" />
+			<description>
+				Sets the given column's auto translate mode to [param mode].
+				All columns use [constant Node.AUTO_TRANSLATE_MODE_INHERIT] by default, which uses the same auto translate mode as the [Tree] itself.
 			</description>
 		</method>
 		<method name="set_autowrap_mode">

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -64,6 +64,7 @@ private:
 		Rect2i icon_region;
 		String text;
 		String xl_text;
+		Node::AutoTranslateMode auto_translate_mode = Node::AUTO_TRANSLATE_MODE_INHERIT;
 		bool edit_multiline = false;
 		String suffix;
 		Ref<TextParagraph> text_buf;
@@ -210,6 +211,10 @@ public:
 	void set_cell_mode(int p_column, TreeCellMode p_mode);
 	TreeCellMode get_cell_mode(int p_column) const;
 
+	/* auto translate mode */
+	void set_auto_translate_mode(int p_column, Node::AutoTranslateMode p_mode);
+	Node::AutoTranslateMode get_auto_translate_mode(int p_column) const;
+
 	/* multiline editable */
 	void set_edit_multiline(int p_column, bool p_multiline);
 	bool is_edit_multiline(int p_column) const;
@@ -221,6 +226,8 @@ public:
 	bool is_indeterminate(int p_column) const;
 
 	void propagate_check(int p_column, bool p_emit_signal = true);
+
+	String atr(int p_column, const String &p_text) const;
 
 private:
 	// Check helpers.


### PR DESCRIPTION
Make i18n for `Tree` easier if only _some_ cells need auto translation.

Otherwise users have to either rebuild the entire tree when locale is changed, or manually keep track of those special `TreeItem`s.

![Peek 2024-09-23 15-42](https://github.com/user-attachments/assets/97e57ea6-98a4-4fa9-aac8-78ae8d8f9c4a)

Test project: [tree-at.zip](https://github.com/user-attachments/files/17210279/tree-at.zip)


---

~A separate `AutoTranslateMode` is created because `AUTO_TRANSLATE_MODE_INHERIT` could mean "the same as its parent `TreeItem`. I don't see practical use of this behavior, but could be implemented in the future.~

`AUTO_TRANSLATE_MODE_INHERIT` means "the same auto translate mode as the `Tree`".
