### PR TITLE
Keep existing `VectorCompose` input values when setting vector type

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -4878,19 +4878,22 @@ void VisualShaderNodeVectorCompose::set_op_type(OpType p_op_type) {
 		case OP_TYPE_VECTOR_3D: {
 			float p1 = get_input_port_default_value(0);
 			float p2 = get_input_port_default_value(1);
+			float p3 = get_input_port_default_value(2);
 
 			set_input_port_default_value(0, p1);
 			set_input_port_default_value(1, p2);
-			set_input_port_default_value(2, 0.0);
+			set_input_port_default_value(2, p3);
 		} break;
 		case OP_TYPE_VECTOR_4D: {
 			float p1 = get_input_port_default_value(0);
 			float p2 = get_input_port_default_value(1);
+			float p3 = get_input_port_default_value(2);
+			float p4 = get_input_port_default_value(3);
 
 			set_input_port_default_value(0, p1);
 			set_input_port_default_value(1, p2);
-			set_input_port_default_value(2, 0.0);
-			set_input_port_default_value(3, 0.0);
+			set_input_port_default_value(2, p3);
+			set_input_port_default_value(3, p4);
 		} break;
 		default:
 			break;


### PR DESCRIPTION
`VisualShaderNodeVectorCompose::set_op_type` would zero out input port default values for z and w when using vector 3D/4D, updated to keep values for all ports.

Zeroing out z and w would cause values for 4D vectors to be lost when loading the visual shader - 3D vectors were not affected by this, since 3D is the default op type, which caused this step to be skipped during loading.  However, both 3D and 4D were affected when changing the op type from the drop down in editor.  For example, changing from 3D (1, 2, 3) to 4D would result in (1, 2, 0, 0), and changing from 4D (1, 2, 3, 4) to 3D would result in (1, 2, 0), losing previously set values.

Fixes #97359

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
