### PR TITLE
Fix `is_playing` on `AudioStreamPlaybackInteractive` when the last clip is done

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -885,12 +885,19 @@ void AudioStreamPlaybackInteractive::_mix_internal(int p_frames) {
 		mix_buffer[i] = AudioFrame(0, 0);
 	}
 
+	bool any_active = false;
 	for (int i = 0; i < stream->clip_count; i++) {
 		if (!states[i].active) {
 			continue;
 		}
 
 		_mix_internal_state(i, p_frames);
+
+		any_active = states[i].active || any_active;
+	}
+	if (!any_active) {
+		active = false;
+		playback_current = -1;
 	}
 }
 


### PR DESCRIPTION
When playing some clips with `AudioStreamPlaybackInteractive`, `is_playing` is never set to false, even when the last clip is done playing. This PR fixes that.