### PR TITLE
Clarify CanvasItem's visibility signal descriptions (followup)

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -648,7 +648,7 @@
 		</signal>
 		<signal name="hidden">
 			<description>
-				Emitted when the [CanvasItem] becomes hidden, either because its own [member visible] property was set to [code]false[/code] or the [member visible] property of one of its [CanvasItem] ancestors was set to [code]false[/code].
+				Emitted when the [CanvasItem] is hidden, i.e. it's no longer visible in the tree (see [method is_visible_in_tree]).
 			</description>
 		</signal>
 		<signal name="item_rect_changed">
@@ -658,7 +658,7 @@
 		</signal>
 		<signal name="visibility_changed">
 			<description>
-				Emitted when the [CanvasItem]'s visibility changes, either because its own [member visible] property changed or because the visility of one of its [CanvasItem] ancestors changed (equivalent to a change in [method is_visible_in_tree]).
+				Emitted when the [CanvasItem]'s visibility changes, either because its own [member visible] property changed or because its visibility in the tree changed (see [method is_visible_in_tree]).
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
Follow-up to: https://github.com/godotengine/godot/pull/97223#discussion_r1771560521

Simplifies the signal descriptions of `CanvasItem`'s `hidden` and `visibility_changed`. I tried a couple different ways of having the description for `hidden` refer to the `visibility_changed` description, but as `hidden` is just above it, it would read weird? idk.

~~It's curious that the `hidden` signal still exists even though the `visibility_changed` signal (albeit together with a simple check to `is_visible_in_tree` in the connected callable) essentially supersedes it, but I don't know any C++ to deprecate the signal and start a transition to remove it. Perhaps someone else could pick that up.~~