### PR TITLE
Get rid of easily removable uses of `const_cast`

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -40,7 +40,7 @@ int64_t AStar3D::get_available_point_id() const {
 		while (points.has(cur_new_id)) {
 			cur_new_id++;
 		}
-		const_cast<int64_t &>(last_free_id) = cur_new_id;
+		last_free_id = cur_new_id;
 	}
 
 	return last_free_id;

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -108,7 +108,7 @@ class AStar3D : public RefCounted {
 		}
 	};
 
-	int64_t last_free_id = 0;
+	mutable int64_t last_free_id = 0;
 	uint64_t pass = 1;
 
 	OAHashMap<int64_t, Point *> points;

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -222,7 +222,7 @@ struct PtrToArg<Ref<T>> {
 			return Ref<T>();
 		}
 		// p_ptr points to a RefCounted object
-		return Ref<T>(const_cast<T *>(*reinterpret_cast<T *const *>(p_ptr)));
+		return Ref<T>(*reinterpret_cast<T *const *>(p_ptr));
 	}
 
 	typedef Ref<T> EncodeT;

--- a/core/os/condition_variable.h
+++ b/core/os/condition_variable.h
@@ -57,12 +57,12 @@ class ConditionVariable {
 public:
 	template <typename BinaryMutexT>
 	_ALWAYS_INLINE_ void wait(const MutexLock<BinaryMutexT> &p_lock) const {
-		condition.wait(const_cast<THREADING_NAMESPACE::unique_lock<THREADING_NAMESPACE::mutex> &>(p_lock._get_lock()));
+		condition.wait(p_lock._get_lock());
 	}
 
 	template <int Tag>
 	_ALWAYS_INLINE_ void wait(const MutexLock<SafeBinaryMutex<Tag>> &p_lock) const {
-		condition.wait(const_cast<THREADING_NAMESPACE::unique_lock<THREADING_NAMESPACE::mutex> &>(p_lock.mutex._get_lock()));
+		condition.wait(p_lock.mutex._get_lock());
 	}
 
 	_ALWAYS_INLINE_ void notify_one() const {

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -160,7 +160,7 @@ MAKE_PTRARG_BY_REFERENCE(Variant);
 template <typename T>
 struct PtrToArg<T *> {
 	_FORCE_INLINE_ static T *convert(const void *p_ptr) {
-		return likely(p_ptr) ? const_cast<T *>(*reinterpret_cast<T *const *>(p_ptr)) : nullptr;
+		return likely(p_ptr) ? *reinterpret_cast<T *const *>(p_ptr) : nullptr;
 	}
 	typedef Object *EncodeT;
 	_FORCE_INLINE_ static void encode(T *p_var, void *p_ptr) {

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -957,7 +957,7 @@ void EditorHelpSearch::Runner::_match_method_name_and_push_back(Vector<DocData::
 				(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
 				(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
 				(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
-			method.doc = const_cast<DocData::MethodDoc *>(&p_methods[i]);
+			method.doc = &p_methods[i];
 			r_match_methods->push_back(method);
 		}
 	}

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -96,12 +96,12 @@ void EditorResourcePreviewGenerator::_bind_methods() {
 EditorResourcePreviewGenerator::EditorResourcePreviewGenerator() {
 }
 
-void EditorResourcePreviewGenerator::DrawRequester::request_and_wait(RID p_viewport) const {
+void EditorResourcePreviewGenerator::DrawRequester::request_and_wait(RID p_viewport) {
 	Callable request_vp_update_once = callable_mp(RS::get_singleton(), &RS::viewport_set_update_mode).bind(p_viewport, RS::VIEWPORT_UPDATE_ONCE);
 
 	if (EditorResourcePreview::get_singleton()->is_threaded()) {
 		RS::get_singleton()->connect(SNAME("frame_pre_draw"), request_vp_update_once, Object::CONNECT_ONE_SHOT);
-		RS::get_singleton()->request_frame_drawn_callback(callable_mp(const_cast<EditorResourcePreviewGenerator::DrawRequester *>(this), &EditorResourcePreviewGenerator::DrawRequester::_post_semaphore));
+		RS::get_singleton()->request_frame_drawn_callback(callable_mp(this, &EditorResourcePreviewGenerator::DrawRequester::_post_semaphore));
 
 		semaphore.wait();
 	} else {
@@ -119,13 +119,13 @@ void EditorResourcePreviewGenerator::DrawRequester::request_and_wait(RID p_viewp
 	}
 }
 
-void EditorResourcePreviewGenerator::DrawRequester::abort() const {
+void EditorResourcePreviewGenerator::DrawRequester::abort() {
 	if (EditorResourcePreview::get_singleton()->is_threaded()) {
 		semaphore.post();
 	}
 }
 
-Variant EditorResourcePreviewGenerator::DrawRequester::_post_semaphore() const {
+Variant EditorResourcePreviewGenerator::DrawRequester::_post_semaphore() {
 	semaphore.post();
 	return Variant(); // Needed because of how the callback is used.
 }

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -54,11 +54,11 @@ protected:
 	class DrawRequester : public Object {
 		Semaphore semaphore;
 
-		Variant _post_semaphore() const;
+		Variant _post_semaphore();
 
 	public:
-		void request_and_wait(RID p_viewport) const;
-		void abort() const;
+		void request_and_wait(RID p_viewport);
+		void abort();
 	};
 
 public:

--- a/editor/plugins/dedicated_server_export_plugin.cpp
+++ b/editor/plugins/dedicated_server_export_plugin.cpp
@@ -121,7 +121,7 @@ Ref<Resource> DedicatedServerExportPlugin::_customize_resource(const Ref<Resourc
 
 	if (p_resource.is_valid() && current_export_mode == EditorExportPreset::MODE_FILE_STRIP && p_resource->has_method("create_placeholder")) {
 		Callable::CallError err;
-		Ref<Resource> result = const_cast<Resource *>(p_resource.ptr())->callp("create_placeholder", nullptr, 0, err);
+		Ref<Resource> result = p_resource->callp("create_placeholder", nullptr, 0, err);
 		if (err.error == Callable::CallError::CALL_OK) {
 			return result;
 		}

--- a/editor/plugins/editor_preview_plugins.h
+++ b/editor/plugins/editor_preview_plugins.h
@@ -96,7 +96,7 @@ class EditorMaterialPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID light_instance2;
 	RID camera;
 	RID camera_attributes;
-	DrawRequester draw_requester;
+	mutable DrawRequester draw_requester;
 
 public:
 	virtual bool handles(const String &p_type) const override;
@@ -144,7 +144,7 @@ class EditorMeshPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID light_instance2;
 	RID camera;
 	RID camera_attributes;
-	DrawRequester draw_requester;
+	mutable DrawRequester draw_requester;
 
 public:
 	virtual bool handles(const String &p_type) const override;
@@ -162,7 +162,7 @@ class EditorFontPreviewPlugin : public EditorResourcePreviewGenerator {
 	RID viewport_texture;
 	RID canvas;
 	RID canvas_item;
-	DrawRequester draw_requester;
+	mutable DrawRequester draw_requester;
 
 public:
 	virtual bool handles(const String &p_type) const override;

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -57,7 +57,7 @@ TileMapEditorPlugin *tile_map_plugin_singleton = nullptr;
 TileSetEditorPlugin *tile_set_plugin_singleton = nullptr;
 
 void TilesEditorUtils::_preview_frame_started() {
-	RS::get_singleton()->request_frame_drawn_callback(callable_mp(const_cast<TilesEditorUtils *>(this), &TilesEditorUtils::_pattern_preview_done));
+	RS::get_singleton()->request_frame_drawn_callback(callable_mp(this, &TilesEditorUtils::_pattern_preview_done));
 }
 
 void TilesEditorUtils::_pattern_preview_done() {
@@ -130,7 +130,7 @@ void TilesEditorUtils::_thread() {
 				// Add the viewport at the last moment to avoid rendering too early.
 				callable_mp((Node *)EditorNode::get_singleton(), &Node::add_child).call_deferred(viewport, false, Node::INTERNAL_MODE_DISABLED);
 
-				RS::get_singleton()->connect(SNAME("frame_pre_draw"), callable_mp(const_cast<TilesEditorUtils *>(this), &TilesEditorUtils::_preview_frame_started), Object::CONNECT_ONE_SHOT);
+				RS::get_singleton()->connect(SNAME("frame_pre_draw"), callable_mp(this, &TilesEditorUtils::_preview_frame_started), Object::CONNECT_ONE_SHOT);
 
 				pattern_preview_done.wait();
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2329,7 +2329,7 @@ void VisualShaderEditor::_update_options_menu() {
 			if ((add_options[i].func != current_func && add_options[i].func != -1) || !_is_available(add_options[i].mode)) {
 				continue;
 			}
-			const_cast<AddOption &>(add_options[i]).temp_idx = i; // save valid id
+			add_options[i].temp_idx = i; // save valid id
 			if (add_options[i].is_custom) {
 				custom_options.push_back(add_options[i]);
 			} else {

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -398,7 +398,7 @@ class VisualShaderEditor : public ShaderEditor {
 		bool highend = false;
 		bool is_custom = false;
 		bool is_native = false;
-		int temp_idx = 0;
+		mutable int temp_idx = 0;
 
 		AddOption(const String &p_name = String(), const String &p_category = String(), const String &p_type = String(), const String &p_description = String(), const Vector<Variant> &p_ops = Vector<Variant>(), int p_return_type = -1, int p_mode = -1, int p_func = -1, bool p_highend = false) {
 			name = p_name;

--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -277,7 +277,7 @@ Error ENetConnection::dtls_server_setup(const Ref<TLSOptions> &p_options) {
 #ifdef GODOT_ENET
 	ERR_FAIL_NULL_V_MSG(host, ERR_UNCONFIGURED, "The ENetConnection instance isn't currently active.");
 	ERR_FAIL_COND_V(p_options.is_null() || !p_options->is_server(), ERR_INVALID_PARAMETER);
-	return enet_host_dtls_server_setup(host, const_cast<TLSOptions *>(p_options.ptr())) ? FAILED : OK;
+	return enet_host_dtls_server_setup(host, p_options.ptr()) ? FAILED : OK;
 #else
 	ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "ENet DTLS support not available in this build.");
 #endif
@@ -296,7 +296,7 @@ Error ENetConnection::dtls_client_setup(const String &p_hostname, const Ref<TLSO
 #ifdef GODOT_ENET
 	ERR_FAIL_NULL_V_MSG(host, ERR_UNCONFIGURED, "The ENetConnection instance isn't currently active.");
 	ERR_FAIL_COND_V(p_options.is_null() || p_options->is_server(), ERR_INVALID_PARAMETER);
-	return enet_host_dtls_client_setup(host, p_hostname.utf8().get_data(), const_cast<TLSOptions *>(p_options.ptr())) ? FAILED : OK;
+	return enet_host_dtls_client_setup(host, p_hostname.utf8().get_data(), p_options.ptr()) ? FAILED : OK;
 #else
 	ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "ENet DTLS support not available in this build.");
 #endif

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1834,7 +1834,7 @@ bool GDScriptInstance::get(const StringName &p_name, Variant &r_ret) const {
 				const Variant *args[1] = { &name };
 
 				Callable::CallError err;
-				Variant ret = const_cast<GDScriptFunction *>(E->value)->call(const_cast<GDScriptInstance *>(this), (const Variant **)args, 1, err);
+				Variant ret = E->value->call(const_cast<GDScriptInstance *>(this), (const Variant **)args, 1, err);
 				if (err.error == Callable::CallError::CALL_OK && ret.get_type() != Variant::NIL) {
 					r_ret = ret;
 					return true;
@@ -1893,7 +1893,7 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 			HashMap<StringName, GDScriptFunction *>::ConstIterator E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._get_property_list);
 			if (E) {
 				Callable::CallError err;
-				Variant ret = const_cast<GDScriptFunction *>(E->value)->call(const_cast<GDScriptInstance *>(this), nullptr, 0, err);
+				Variant ret = E->value->call(const_cast<GDScriptInstance *>(this), nullptr, 0, err);
 				if (err.error == Callable::CallError::CALL_OK) {
 					ERR_FAIL_COND_MSG(ret.get_type() != Variant::ARRAY, "Wrong type for _get_property_list, must be an array of dictionaries.");
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -3078,9 +3078,9 @@ void GDScriptCompiler::convert_to_initializer_type(Variant &p_variant, const GDS
 	if (member_t.is_hard_type() && init_t.is_hard_type() &&
 			member_t.kind == GDScriptParser::DataType::BUILTIN && init_t.kind == GDScriptParser::DataType::BUILTIN) {
 		if (Variant::can_convert_strict(init_t.builtin_type, member_t.builtin_type)) {
-			Variant *v = &p_node->initializer->reduced_value;
+			const Variant *v = &p_node->initializer->reduced_value;
 			Callable::CallError ce;
-			Variant::construct(member_t.builtin_type, p_variant, const_cast<const Variant **>(&v), 1, ce);
+			Variant::construct(member_t.builtin_type, p_variant, &v, 1, ce);
 		}
 	}
 }

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2631,7 +2631,7 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 		switch (base_type.kind) {
 			case GDScriptParser::DataType::CLASS:
 				if (base_type.class_type->has_function(p_method)) {
-					const GDScriptParser::FunctionNode *method = base_type.class_type->get_member(p_method).function;
+					GDScriptParser::FunctionNode *method = base_type.class_type->get_member(p_method).function;
 					if (!is_static || method->is_static) {
 						if (method->get_datatype().is_set() && !method->get_datatype().is_variant()) {
 							r_type.type = method->get_datatype();
@@ -2642,7 +2642,7 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 						const GDScriptParser::ExpressionNode *last_returned_value = nullptr;
 						GDScriptParser::CompletionContext c = p_context;
 						c.current_class = base_type.class_type;
-						c.current_function = const_cast<GDScriptParser::FunctionNode *>(method);
+						c.current_function = method;
 						c.current_suite = method->body;
 
 						_find_last_return_in_block(c, last_return_line, &last_returned_value);

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -239,7 +239,7 @@ void GodotPhysicsServer2D::space_set_active(RID p_space, bool p_active) {
 }
 
 bool GodotPhysicsServer2D::space_is_active(RID p_space) const {
-	const GodotSpace2D *space = space_owner.get_or_null(p_space);
+	GodotSpace2D *space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL_V(space, false);
 
 	return active_spaces.has(space);
@@ -1297,8 +1297,8 @@ void GodotPhysicsServer2D::step(real_t p_step) {
 	island_count = 0;
 	active_objects = 0;
 	collision_pairs = 0;
-	for (const GodotSpace2D *E : active_spaces) {
-		stepper->step(const_cast<GodotSpace2D *>(E), p_step);
+	for (GodotSpace2D *E : active_spaces) {
+		stepper->step(E, p_step);
 		island_count += E->get_island_count();
 		active_objects += E->get_active_objects();
 		collision_pairs += E->get_collision_pairs();
@@ -1318,9 +1318,8 @@ void GodotPhysicsServer2D::flush_queries() {
 
 	uint64_t time_beg = OS::get_singleton()->get_ticks_usec();
 
-	for (const GodotSpace2D *E : active_spaces) {
-		GodotSpace2D *space = const_cast<GodotSpace2D *>(E);
-		space->call_queries();
+	for (GodotSpace2D *E : active_spaces) {
+		E->call_queries();
 	}
 
 	flushing_queries = false;

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -56,7 +56,7 @@ class GodotPhysicsServer2D : public PhysicsServer2D {
 	bool flushing_queries = false;
 
 	GodotStep2D *stepper = nullptr;
-	HashSet<const GodotSpace2D *> active_spaces;
+	HashSet<GodotSpace2D *> active_spaces;
 
 	mutable RID_PtrOwner<GodotShape2D, true> shape_owner;
 	mutable RID_PtrOwner<GodotSpace2D, true> space_owner;

--- a/modules/godot_physics_2d/godot_shape_2d.cpp
+++ b/modules/godot_physics_2d/godot_shape_2d.cpp
@@ -37,8 +37,7 @@ void GodotShape2D::configure(const Rect2 &p_aabb) {
 	aabb = p_aabb;
 	configured = true;
 	for (const KeyValue<GodotShapeOwner2D *, int> &E : owners) {
-		GodotShapeOwner2D *co = const_cast<GodotShapeOwner2D *>(E.key);
-		co->_shape_changed();
+		E.key->_shape_changed();
 	}
 }
 

--- a/modules/godot_physics_2d/godot_step_2d.cpp
+++ b/modules/godot_physics_2d/godot_step_2d.cpp
@@ -48,7 +48,7 @@ void GodotStep2D::_populate_island(GodotBody2D *p_body, LocalVector<GodotBody2D 
 	}
 
 	for (const Pair<GodotConstraint2D *, int> &E : p_body->get_constraint_list()) {
-		GodotConstraint2D *constraint = const_cast<GodotConstraint2D *>(E.first);
+		GodotConstraint2D *constraint = E.first;
 		if (constraint->get_island_step() == _step) {
 			continue; // Already processed.
 		}

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -169,7 +169,7 @@ void GodotPhysicsServer3D::space_set_active(RID p_space, bool p_active) {
 }
 
 bool GodotPhysicsServer3D::space_is_active(RID p_space) const {
-	const GodotSpace3D *space = space_owner.get_or_null(p_space);
+	GodotSpace3D *space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL_V(space, false);
 
 	return active_spaces.has(space);
@@ -1638,8 +1638,8 @@ void GodotPhysicsServer3D::step(real_t p_step) {
 	island_count = 0;
 	active_objects = 0;
 	collision_pairs = 0;
-	for (const GodotSpace3D *E : active_spaces) {
-		stepper->step(const_cast<GodotSpace3D *>(E), p_step);
+	for (GodotSpace3D *E : active_spaces) {
+		stepper->step(E, p_step);
 		island_count += E->get_island_count();
 		active_objects += E->get_active_objects();
 		collision_pairs += E->get_collision_pairs();
@@ -1659,8 +1659,8 @@ void GodotPhysicsServer3D::flush_queries() {
 
 	uint64_t time_beg = OS::get_singleton()->get_ticks_usec();
 
-	for (const GodotSpace3D *E : active_spaces) {
-		GodotSpace3D *space = const_cast<GodotSpace3D *>(E);
+	for (GodotSpace3D *E : active_spaces) {
+		GodotSpace3D *space = E;
 		space->call_queries();
 	}
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -54,7 +54,7 @@ class GodotPhysicsServer3D : public PhysicsServer3D {
 	bool flushing_queries = false;
 
 	GodotStep3D *stepper = nullptr;
-	HashSet<const GodotSpace3D *> active_spaces;
+	HashSet<GodotSpace3D *> active_spaces;
 
 	mutable RID_PtrOwner<GodotShape3D, true> shape_owner;
 	mutable RID_PtrOwner<GodotSpace3D, true> space_owner;

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -69,7 +69,7 @@ void GodotShape3D::configure(const AABB &p_aabb) {
 	aabb = p_aabb;
 	configured = true;
 	for (const KeyValue<GodotShapeOwner3D *, int> &E : owners) {
-		GodotShapeOwner3D *co = const_cast<GodotShapeOwner3D *>(E.key);
+		GodotShapeOwner3D *co = E.key;
 		co->_shape_changed();
 	}
 }

--- a/modules/godot_physics_3d/godot_step_3d.cpp
+++ b/modules/godot_physics_3d/godot_step_3d.cpp
@@ -50,7 +50,7 @@ void GodotStep3D::_populate_island(GodotBody3D *p_body, LocalVector<GodotBody3D 
 	}
 
 	for (const KeyValue<GodotConstraint3D *, int> &E : p_body->get_constraint_map()) {
-		GodotConstraint3D *constraint = const_cast<GodotConstraint3D *>(E.key);
+		GodotConstraint3D *constraint = E.key;
 		if (constraint->get_island_step() == _step) {
 			continue; // Already processed.
 		}
@@ -88,8 +88,8 @@ void GodotStep3D::_populate_island(GodotBody3D *p_body, LocalVector<GodotBody3D 
 void GodotStep3D::_populate_island_soft_body(GodotSoftBody3D *p_soft_body, LocalVector<GodotBody3D *> &p_body_island, LocalVector<GodotConstraint3D *> &p_constraint_island) {
 	p_soft_body->set_island_step(_step);
 
-	for (const GodotConstraint3D *E : p_soft_body->get_constraints()) {
-		GodotConstraint3D *constraint = const_cast<GodotConstraint3D *>(E);
+	for (GodotConstraint3D *E : p_soft_body->get_constraints()) {
+		GodotConstraint3D *constraint = E;
 		if (constraint->get_island_step() == _step) {
 			continue; // Already processed.
 		}

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -4846,10 +4846,10 @@ double TextServerAdvanced::_shaped_text_fit_to_width(const RID &p_shaped, double
 
 	MutexLock lock(sd->mutex);
 	if (!sd->valid.is_set()) {
-		const_cast<TextServerAdvanced *>(this)->_shaped_text_shape(p_shaped);
+		_shaped_text_shape(p_shaped);
 	}
 	if (!sd->justification_ops_valid) {
-		const_cast<TextServerAdvanced *>(this)->_shaped_text_update_justification_ops(p_shaped);
+		_shaped_text_update_justification_ops(p_shaped);
 	}
 
 	sd->fit_width_minimum_reached = false;
@@ -5003,10 +5003,10 @@ double TextServerAdvanced::_shaped_text_tab_align(const RID &p_shaped, const Pac
 
 	MutexLock lock(sd->mutex);
 	if (!sd->valid.is_set()) {
-		const_cast<TextServerAdvanced *>(this)->_shaped_text_shape(p_shaped);
+		_shaped_text_shape(p_shaped);
 	}
 	if (!sd->line_breaks_valid) {
-		const_cast<TextServerAdvanced *>(this)->_shaped_text_update_breaks(p_shaped);
+		_shaped_text_update_breaks(p_shaped);
 	}
 
 	for (int i = 0; i < p_tab_stops.size(); i++) {
@@ -6596,7 +6596,7 @@ const Glyph *TextServerAdvanced::_shaped_text_sort_logical(const RID &p_shaped) 
 
 	MutexLock lock(sd->mutex);
 	if (!sd->valid.is_set()) {
-		const_cast<TextServerAdvanced *>(this)->_shaped_text_shape(p_shaped);
+		_shaped_text_shape(p_shaped);
 	}
 
 	if (!sd->sort_valid) {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -3625,10 +3625,10 @@ double TextServerFallback::_shaped_text_fit_to_width(const RID &p_shaped, double
 
 	MutexLock lock(sd->mutex);
 	if (!sd->valid.is_set()) {
-		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
+		_shaped_text_shape(p_shaped);
 	}
 	if (!sd->justification_ops_valid) {
-		const_cast<TextServerFallback *>(this)->_shaped_text_update_justification_ops(p_shaped);
+		_shaped_text_update_justification_ops(p_shaped);
 	}
 
 	int start_pos = 0;
@@ -3734,10 +3734,10 @@ double TextServerFallback::_shaped_text_tab_align(const RID &p_shaped, const Pac
 
 	MutexLock lock(sd->mutex);
 	if (!sd->valid.is_set()) {
-		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
+		_shaped_text_shape(p_shaped);
 	}
 	if (!sd->line_breaks_valid) {
-		const_cast<TextServerFallback *>(this)->_shaped_text_update_breaks(p_shaped);
+		_shaped_text_update_breaks(p_shaped);
 	}
 
 	for (int i = 0; i < p_tab_stops.size(); i++) {
@@ -4444,7 +4444,7 @@ const Glyph *TextServerFallback::_shaped_text_sort_logical(const RID &p_shaped) 
 
 	MutexLock lock(sd->mutex);
 	if (!sd->valid.is_set()) {
-		const_cast<TextServerFallback *>(this)->_shaped_text_shape(p_shaped);
+		_shaped_text_shape(p_shaped);
 	}
 
 	return sd->glyphs.ptr(); // Already in the logical order, return as is.

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -416,7 +416,7 @@ String OS_Android::get_data_path() const {
 	return get_user_data_dir();
 }
 
-void OS_Android::_load_system_font_config() {
+void OS_Android::_load_system_font_config() const {
 	font_aliases.clear();
 	fonts.clear();
 	font_names.clear();
@@ -541,7 +541,7 @@ void OS_Android::_load_system_font_config() {
 
 Vector<String> OS_Android::get_system_fonts() const {
 	if (!font_config_loaded) {
-		const_cast<OS_Android *>(this)->_load_system_font_config();
+		_load_system_font_config();
 	}
 	Vector<String> ret;
 	for (const String &E : font_names) {
@@ -552,7 +552,7 @@ Vector<String> OS_Android::get_system_fonts() const {
 
 Vector<String> OS_Android::get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale, const String &p_script, int p_weight, int p_stretch, bool p_italic) const {
 	if (!font_config_loaded) {
-		const_cast<OS_Android *>(this)->_load_system_font_config();
+		_load_system_font_config();
 	}
 	String font_name = p_font_name.to_lower();
 	if (font_aliases.has(font_name)) {
@@ -604,7 +604,7 @@ Vector<String> OS_Android::get_system_font_path_for_text(const String &p_font_na
 
 String OS_Android::get_system_font_path(const String &p_font_name, int p_weight, int p_stretch, bool p_italic) const {
 	if (!font_config_loaded) {
-		const_cast<OS_Android *>(this)->_load_system_font_config();
+		_load_system_font_config();
 	}
 	String font_name = p_font_name.to_lower();
 	if (font_aliases.has(font_name)) {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -75,15 +75,15 @@ private:
 		String filename;
 	};
 
-	HashMap<String, String> font_aliases;
-	List<FontInfo> fonts;
-	HashSet<String> font_names;
-	bool font_config_loaded = false;
+	mutable HashMap<String, String> font_aliases;
+	mutable List<FontInfo> fonts;
+	mutable HashSet<String> font_names;
+	mutable bool font_config_loaded = false;
 
 	GodotJavaWrapper *godot_java = nullptr;
 	GodotIOJavaWrapper *godot_io_java = nullptr;
 
-	void _load_system_font_config();
+	void _load_system_font_config() const;
 	String get_system_property(const char *key) const;
 
 public:

--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -101,7 +101,7 @@ void TTS_Linux::speech_event_callback(size_t p_msg_id, size_t p_client_id, SPDNo
 	}
 }
 
-void TTS_Linux::_load_voices() {
+void TTS_Linux::_load_voices() const {
 	if (!voices_loaded) {
 		SPDVoice **spd_voices = spd_list_synthesis_voices(synth);
 		if (spd_voices != nullptr) {
@@ -193,7 +193,7 @@ Array TTS_Linux::get_voices() const {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_NULL_V(synth, Array());
-	const_cast<TTS_Linux *>(this)->_load_voices();
+	_load_voices();
 
 	Array list;
 	for (const KeyValue<String, VoiceInfo> &E : voices) {

--- a/platform/linuxbsd/tts_linux.h
+++ b/platform/linuxbsd/tts_linux.h
@@ -59,8 +59,8 @@ class TTS_Linux : public Object {
 		String language;
 		String variant;
 	};
-	bool voices_loaded = false;
-	HashMap<String, VoiceInfo> voices;
+	mutable bool voices_loaded = false;
+	mutable HashMap<String, VoiceInfo> voices;
 
 	Thread init_thread;
 
@@ -71,7 +71,7 @@ class TTS_Linux : public Object {
 	static TTS_Linux *singleton;
 
 protected:
-	void _load_voices();
+	void _load_voices() const;
 	void _speech_event(int p_msg_id, int p_type);
 	void _speech_index_mark(int p_msg_id, int p_type, const String &p_index_mark);
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -175,16 +175,16 @@ private:
 		String name;
 		String code;
 	};
-	Vector<LayoutInfo> kbd_layouts;
-	int current_layout = 0;
-	bool keyboard_layout_dirty = true;
+	mutable Vector<LayoutInfo> kbd_layouts;
+	mutable int current_layout = 0;
+	mutable bool keyboard_layout_dirty = true;
 
 	WindowID window_mouseover_id = INVALID_WINDOW_ID;
 	WindowID last_focused_window = INVALID_WINDOW_ID;
 	WindowID window_id_counter = MAIN_WINDOW_ID;
 	float display_max_scale = 1.f;
-	Point2i origin;
-	bool displays_arrangement_dirty = true;
+	mutable Point2i origin;
+	mutable bool displays_arrangement_dirty = true;
 	bool is_resizing = false;
 
 	CursorShape cursor_shape = CURSOR_ARROW;
@@ -217,7 +217,7 @@ private:
 	WindowID _create_window(WindowMode p_mode, VSyncMode p_vsync_mode, const Rect2i &p_rect);
 	void _update_window_style(WindowData p_wd);
 
-	void _update_displays_arrangement();
+	void _update_displays_arrangement() const;
 	Point2i _get_native_screen_position(int p_screen) const;
 	static void _displays_arrangement_changed(CGDirectDisplayID display_id, CGDisplayChangeSummaryFlags flags, void *user_info);
 
@@ -225,7 +225,7 @@ private:
 	void _dispatch_input_event(const Ref<InputEvent> &p_event);
 	void _push_input(const Ref<InputEvent> &p_event);
 	void _process_key_events();
-	void _update_keyboard_layouts();
+	void _update_keyboard_layouts() const;
 	static void _keyboard_layout_changed(CFNotificationCenterRef center, void *observer, CFStringRef name, const void *object, CFDictionaryRef user_info);
 
 	static NSCursor *_cursor_from_selector(SEL p_selector, SEL p_fallback = nil);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -283,7 +283,7 @@ void DisplayServerMacOS::set_window_per_pixel_transparency_enabled(bool p_enable
 	}
 }
 
-void DisplayServerMacOS::_update_displays_arrangement() {
+void DisplayServerMacOS::_update_displays_arrangement() const {
 	origin = Point2i();
 
 	for (int i = 0; i < get_screen_count(); i++) {
@@ -309,7 +309,7 @@ Point2i DisplayServerMacOS::_get_screens_origin() const {
 	// to convert between macOS native screen coordinates and the ones expected by Godot.
 
 	if (displays_arrangement_dirty) {
-		const_cast<DisplayServerMacOS *>(this)->_update_displays_arrangement();
+		_update_displays_arrangement();
 	}
 
 	return origin;
@@ -470,7 +470,7 @@ void DisplayServerMacOS::_process_key_events() {
 	key_event_pos = 0;
 }
 
-void DisplayServerMacOS::_update_keyboard_layouts() {
+void DisplayServerMacOS::_update_keyboard_layouts() const {
 	kbd_layouts.clear();
 	current_layout = 0;
 
@@ -2935,14 +2935,14 @@ bool DisplayServerMacOS::get_swap_cancel_ok() {
 
 int DisplayServerMacOS::keyboard_get_layout_count() const {
 	if (keyboard_layout_dirty) {
-		const_cast<DisplayServerMacOS *>(this)->_update_keyboard_layouts();
+		_update_keyboard_layouts();
 	}
 	return kbd_layouts.size();
 }
 
 void DisplayServerMacOS::keyboard_set_current_layout(int p_index) {
 	if (keyboard_layout_dirty) {
-		const_cast<DisplayServerMacOS *>(this)->_update_keyboard_layouts();
+		_update_keyboard_layouts();
 	}
 
 	ERR_FAIL_INDEX(p_index, kbd_layouts.size());
@@ -2972,7 +2972,7 @@ void DisplayServerMacOS::keyboard_set_current_layout(int p_index) {
 
 int DisplayServerMacOS::keyboard_get_current_layout() const {
 	if (keyboard_layout_dirty) {
-		const_cast<DisplayServerMacOS *>(this)->_update_keyboard_layouts();
+		_update_keyboard_layouts();
 	}
 
 	return current_layout;
@@ -2980,7 +2980,7 @@ int DisplayServerMacOS::keyboard_get_current_layout() const {
 
 String DisplayServerMacOS::keyboard_get_layout_language(int p_index) const {
 	if (keyboard_layout_dirty) {
-		const_cast<DisplayServerMacOS *>(this)->_update_keyboard_layouts();
+		_update_keyboard_layouts();
 	}
 
 	ERR_FAIL_INDEX_V(p_index, kbd_layouts.size(), "");
@@ -2989,7 +2989,7 @@ String DisplayServerMacOS::keyboard_get_layout_language(int p_index) const {
 
 String DisplayServerMacOS::keyboard_get_layout_name(int p_index) const {
 	if (keyboard_layout_dirty) {
-		const_cast<DisplayServerMacOS *>(this)->_update_keyboard_layouts();
+		_update_keyboard_layouts();
 	}
 
 	ERR_FAIL_INDEX_V(p_index, kbd_layouts.size(), "");

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -126,8 +126,7 @@ bool PhysicsBody2D::test_move(const Transform2D &p_from, const Vector2 &p_motion
 	PhysicsServer2D::MotionResult *r = nullptr;
 	PhysicsServer2D::MotionResult temp_result;
 	if (r_collision.is_valid()) {
-		// Needs const_cast because method bindings don't support non-const Ref.
-		r = const_cast<PhysicsServer2D::MotionResult *>(&r_collision->result);
+		r = &r_collision->result;
 	} else {
 		r = &temp_result;
 	}

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -613,6 +613,7 @@ int Skeleton2D::get_bone_count() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), 0);
 
 	if (bone_setup_dirty) {
+		// TODO: Is this necessary? It doesn't seem to change bones.size()
 		const_cast<Skeleton2D *>(this)->_update_bone_setup();
 	}
 

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -167,8 +167,7 @@ bool PhysicsBody3D::test_move(const Transform3D &p_from, const Vector3 &p_motion
 	PhysicsServer3D::MotionResult *r = nullptr;
 	PhysicsServer3D::MotionResult temp_result;
 	if (r_collision.is_valid()) {
-		// Needs const_cast because method bindings don't support non-const Ref.
-		r = const_cast<PhysicsServer3D::MotionResult *>(&r_collision->result);
+		r = &r_collision->result;
 	} else {
 		r = &temp_result;
 	}

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -236,7 +236,7 @@ void Skeleton3D::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-void Skeleton3D::_update_process_order() {
+void Skeleton3D::_update_process_order() const {
 	if (!process_order_dirty) {
 		return;
 	}
@@ -280,7 +280,7 @@ void Skeleton3D::_update_process_order() {
 
 	process_order_dirty = false;
 
-	emit_signal("bone_list_changed");
+	const_cast<Skeleton3D *>(this)->emit_signal("bone_list_changed");
 }
 
 void Skeleton3D::_update_bone_names() const {
@@ -468,7 +468,7 @@ void Skeleton3D::_make_modifiers_dirty() {
 	_update_deferred(UPDATE_FLAG_MODIFIER);
 }
 
-void Skeleton3D::_update_bones_nested_set() {
+void Skeleton3D::_update_bones_nested_set() const {
 	nested_set_offset_to_bone_index.resize(bones.size());
 	bone_global_pose_dirty.resize(bones.size());
 	_make_bone_global_poses_dirty();
@@ -479,7 +479,7 @@ void Skeleton3D::_update_bones_nested_set() {
 	}
 }
 
-int Skeleton3D::_update_bone_nested_set(int p_bone, int p_offset) {
+int Skeleton3D::_update_bone_nested_set(int p_bone, int p_offset) const {
 	Bone &bone = bones[p_bone];
 	int offset = p_offset + 1;
 	int span = 1;
@@ -497,13 +497,13 @@ int Skeleton3D::_update_bone_nested_set(int p_bone, int p_offset) {
 	return span;
 }
 
-void Skeleton3D::_make_bone_global_poses_dirty() {
+void Skeleton3D::_make_bone_global_poses_dirty() const {
 	for (uint32_t i = 0; i < bone_global_pose_dirty.size(); i++) {
 		bone_global_pose_dirty[i] = true;
 	}
 }
 
-void Skeleton3D::_make_bone_global_pose_subtree_dirty(int p_bone) {
+void Skeleton3D::_make_bone_global_pose_subtree_dirty(int p_bone) const {
 	if (process_order_dirty) {
 		return;
 	}
@@ -522,7 +522,7 @@ void Skeleton3D::_make_bone_global_pose_subtree_dirty(int p_bone) {
 	}
 }
 
-void Skeleton3D::_update_bone_global_pose(int p_bone) {
+void Skeleton3D::_update_bone_global_pose(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
 
@@ -572,7 +572,7 @@ void Skeleton3D::_update_bone_global_pose(int p_bone) {
 Transform3D Skeleton3D::get_bone_global_pose(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Transform3D());
-	const_cast<Skeleton3D *>(this)->_update_bone_global_pose(p_bone);
+	_update_bone_global_pose(p_bone);
 	return bones[p_bone].global_pose;
 }
 
@@ -756,7 +756,7 @@ int Skeleton3D::get_bone_parent(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, -1);
 	if (process_order_dirty) {
-		const_cast<Skeleton3D *>(this)->_update_process_order();
+		_update_process_order();
 	}
 	return bones[p_bone].parent;
 }
@@ -765,14 +765,14 @@ Vector<int> Skeleton3D::get_bone_children(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Vector<int>());
 	if (process_order_dirty) {
-		const_cast<Skeleton3D *>(this)->_update_process_order();
+		_update_process_order();
 	}
 	return bones[p_bone].child_bones;
 }
 
 Vector<int> Skeleton3D::get_parentless_bones() const {
 	if (process_order_dirty) {
-		const_cast<Skeleton3D *>(this)->_update_process_order();
+		_update_process_order();
 	}
 	return parentless_bones;
 }
@@ -796,7 +796,7 @@ Transform3D Skeleton3D::get_bone_global_rest(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Transform3D());
 	if (rest_dirty) {
-		const_cast<Skeleton3D *>(this)->force_update_all_bone_transforms();
+		_force_update_all_bone_transforms();
 	}
 	return bones[p_bone].global_rest;
 }
@@ -921,7 +921,7 @@ void Skeleton3D::reset_bone_poses() {
 Transform3D Skeleton3D::get_bone_pose(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Transform3D());
-	const_cast<Skeleton3D *>(this)->bones[p_bone].update_pose_cache();
+	bones[p_bone].update_pose_cache();
 	return bones[p_bone].pose_cache;
 }
 
@@ -1037,20 +1037,28 @@ void Skeleton3D::force_update_deferred() {
 }
 
 void Skeleton3D::force_update_all_dirty_bones() {
+	_force_update_all_dirty_bones();
+}
+
+void Skeleton3D::_force_update_all_dirty_bones() const {
 	if (!dirty) {
 		return;
 	}
-	force_update_all_bone_transforms();
+	_force_update_all_bone_transforms();
 }
 
 void Skeleton3D::force_update_all_bone_transforms() {
+	_force_update_all_bone_transforms();
+}
+
+void Skeleton3D::_force_update_all_bone_transforms() const {
 	_update_process_order();
 	for (int i = 0; i < parentless_bones.size(); i++) {
-		force_update_bone_children_transforms(parentless_bones[i]);
+		_force_update_bone_children_transforms(parentless_bones[i]);
 	}
 	if (rest_dirty) {
 		rest_dirty = false;
-		emit_signal(SNAME("rest_updated"));
+		const_cast<Skeleton3D *>(this)->emit_signal(SNAME("rest_updated"));
 	} else {
 		rest_dirty = false;
 	}
@@ -1058,10 +1066,14 @@ void Skeleton3D::force_update_all_bone_transforms() {
 	if (updating) {
 		return;
 	}
-	emit_signal(SceneStringName(pose_updated));
+	const_cast<Skeleton3D *>(this)->emit_signal(SceneStringName(pose_updated));
 }
 
 void Skeleton3D::force_update_bone_children_transforms(int p_bone_idx) {
+	_force_update_bone_children_transforms(p_bone_idx);
+}
+
+void Skeleton3D::_force_update_bone_children_transforms(int p_bone_idx) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone_idx, bone_size);
 
@@ -1321,7 +1333,7 @@ Transform3D Skeleton3D::get_bone_global_pose_override(int p_bone) const {
 Transform3D Skeleton3D::get_bone_global_pose_no_override(int p_bone) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX_V(p_bone, bone_size, Transform3D());
-	const_cast<Skeleton3D *>(this)->force_update_all_dirty_bones();
+	_force_update_all_dirty_bones();
 	return bones[p_bone].pose_global_no_override;
 }
 

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -156,25 +156,25 @@ private:
 	HashSet<SkinReference *> skin_bindings;
 	void _skin_changed();
 
-	LocalVector<Bone> bones;
-	bool process_order_dirty = false;
+	mutable LocalVector<Bone> bones;
+	mutable bool process_order_dirty = false;
 
-	Vector<int> parentless_bones;
+	mutable Vector<int> parentless_bones;
 	AHashMap<String, int> name_to_bone_index;
 
 	mutable StringName concatenated_bone_names;
 	void _update_bone_names() const;
 
 	void _make_dirty();
-	bool dirty = false;
-	bool rest_dirty = false;
+	mutable bool dirty = false;
+	mutable bool rest_dirty = false;
 
 	bool show_rest_only = false;
 	float motion_scale = 1.0;
 
 	uint64_t version = 1;
 
-	void _update_process_order();
+	void _update_process_order() const;
 
 	// To process modifiers.
 	ModifierCallbackModeProcess modifier_callback_mode_process = MODIFIER_CALLBACK_MODE_PROCESS_IDLE;
@@ -184,16 +184,16 @@ private:
 	void _process_modifiers();
 	void _process_changed();
 	void _make_modifiers_dirty();
-	LocalVector<BonePoseBackup> bones_backup;
+	mutable LocalVector<BonePoseBackup> bones_backup;
 
 	// Global bone pose calculation.
-	LocalVector<int> nested_set_offset_to_bone_index; // Map from Bone::nested_set_offset to bone index.
-	LocalVector<bool> bone_global_pose_dirty; // Indexable with Bone::nested_set_offset.
-	void _update_bones_nested_set();
-	int _update_bone_nested_set(int p_bone, int p_offset);
-	void _make_bone_global_poses_dirty();
-	void _make_bone_global_pose_subtree_dirty(int p_bone);
-	void _update_bone_global_pose(int p_bone);
+	mutable LocalVector<int> nested_set_offset_to_bone_index; // Map from Bone::nested_set_offset to bone index.
+	mutable LocalVector<bool> bone_global_pose_dirty; // Indexable with Bone::nested_set_offset.
+	void _update_bones_nested_set() const;
+	int _update_bone_nested_set(int p_bone, int p_offset) const;
+	void _make_bone_global_poses_dirty() const;
+	void _make_bone_global_pose_subtree_dirty(int p_bone) const;
+	void _update_bone_global_pose(int p_bone) const;
 
 #ifndef DISABLE_DEPRECATED
 	void _add_bone_bind_compat_88791(const String &p_name);
@@ -283,8 +283,11 @@ public:
 	Ref<SkinReference> register_skin(const Ref<Skin> &p_skin);
 
 	void force_update_all_dirty_bones();
+	void _force_update_all_dirty_bones() const;
 	void force_update_all_bone_transforms();
+	void _force_update_all_bone_transforms() const;
 	void force_update_bone_children_transforms(int bone_idx);
+	void _force_update_bone_children_transforms(int bone_idx) const;
 	void force_update_deferred();
 
 	void set_modifier_callback_mode_process(ModifierCallbackModeProcess p_mode);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -745,7 +745,7 @@ void AnimationTree::_animation_node_removed(const ObjectID &p_oid, const StringN
 	_update_properties();
 }
 
-void AnimationTree::_update_properties_for_node(const String &p_base_path, Ref<AnimationNode> p_node) {
+void AnimationTree::_update_properties_for_node(const String &p_base_path, Ref<AnimationNode> p_node) const {
 	ERR_FAIL_COND(p_node.is_null());
 	if (!property_parent_map.has(p_base_path)) {
 		property_parent_map[p_base_path] = AHashMap<StringName, StringName>();
@@ -792,7 +792,7 @@ void AnimationTree::_update_properties_for_node(const String &p_base_path, Ref<A
 	}
 }
 
-void AnimationTree::_update_properties() {
+void AnimationTree::_update_properties() const {
 	if (!properties_dirty) {
 		return;
 	}
@@ -809,7 +809,7 @@ void AnimationTree::_update_properties() {
 
 	properties_dirty = false;
 
-	notify_property_list_changed();
+	const_cast<AnimationTree *>(this)->notify_property_list_changed();
 }
 
 void AnimationTree::_notification(int p_what) {
@@ -925,7 +925,7 @@ bool AnimationTree::_get(const StringName &p_name, Variant &r_ret) const {
 	}
 #endif // DISABLE_DEPRECATED
 	if (properties_dirty) {
-		const_cast<AnimationTree *>(this)->_update_properties();
+		_update_properties();
 	}
 
 	if (property_map.has(p_name)) {
@@ -938,7 +938,7 @@ bool AnimationTree::_get(const StringName &p_name, Variant &r_ret) const {
 
 void AnimationTree::_get_property_list(List<PropertyInfo> *p_list) const {
 	if (properties_dirty) {
-		const_cast<AnimationTree *>(this)->_update_properties();
+		_update_properties();
 	}
 
 	for (const PropertyInfo &E : properties) {

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -284,15 +284,15 @@ private:
 
 	friend class AnimationNode;
 
-	List<PropertyInfo> properties;
-	AHashMap<StringName, AHashMap<StringName, StringName>> property_parent_map;
-	AHashMap<ObjectID, StringName> property_reference_map;
-	AHashMap<StringName, Pair<Variant, bool>> property_map; // Property value and read-only flag.
+	mutable List<PropertyInfo> properties;
+	mutable AHashMap<StringName, AHashMap<StringName, StringName>> property_parent_map;
+	mutable AHashMap<ObjectID, StringName> property_reference_map;
+	mutable AHashMap<StringName, Pair<Variant, bool>> property_map; // Property value and read-only flag.
 
-	bool properties_dirty = true;
+	mutable bool properties_dirty = true;
 
-	void _update_properties();
-	void _update_properties_for_node(const String &p_base_path, Ref<AnimationNode> p_node);
+	void _update_properties() const;
+	void _update_properties_for_node(const String &p_base_path, Ref<AnimationNode> p_node) const;
 
 	void _tree_changed();
 	void _animation_node_renamed(const ObjectID &p_oid, const String &p_old_name, const String &p_new_name);
@@ -302,8 +302,8 @@ private:
 		uint64_t last_pass = 0;
 		real_t activity = 0.0;
 	};
-	HashMap<StringName, Vector<Activity>> input_activity_map;
-	HashMap<StringName, Vector<Activity> *> input_activity_map_get;
+	mutable HashMap<StringName, Vector<Activity>> input_activity_map;
+	mutable HashMap<StringName, Vector<Activity> *> input_activity_map_get;
 
 	NodePath animation_player;
 

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -488,7 +488,7 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 		paragraph = text_buf;
 	} else {
 		paragraph.instantiate();
-		const_cast<Button *>(this)->_shape(paragraph, p_text);
+		_shape(paragraph, p_text);
 	}
 
 	Size2 minsize = paragraph->get_size();
@@ -527,7 +527,7 @@ Size2 Button::get_minimum_size_for_text_and_icon(const String &p_text, Ref<Textu
 	return (theme_cache.align_to_largest_stylebox ? _get_largest_stylebox_size() : _get_current_stylebox()->get_minimum_size()) + minsize;
 }
 
-void Button::_shape(Ref<TextParagraph> p_paragraph, String p_text) {
+void Button::_shape(Ref<TextParagraph> p_paragraph, String p_text) const {
 	if (p_paragraph.is_null()) {
 		p_paragraph = text_buf;
 	}

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -103,7 +103,7 @@ private:
 		int line_spacing = 0;
 	} theme_cache;
 
-	void _shape(Ref<TextParagraph> p_paragraph = Ref<TextParagraph>(), String p_text = "");
+	void _shape(Ref<TextParagraph> p_paragraph = Ref<TextParagraph>(), String p_text = "") const;
 	void _texture_changed();
 
 protected:

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1672,7 +1672,7 @@ Size2 Control::get_custom_minimum_size() const {
 	return data.custom_minimum_size;
 }
 
-void Control::_update_minimum_size_cache() {
+void Control::_update_minimum_size_cache() const {
 	Size2 minsize = get_minimum_size();
 	minsize = minsize.max(data.custom_minimum_size);
 
@@ -1683,7 +1683,7 @@ void Control::_update_minimum_size_cache() {
 Size2 Control::get_combined_minimum_size() const {
 	ERR_READ_THREAD_GUARD_V(Size2());
 	if (!data.minimum_size_valid) {
-		const_cast<Control *>(this)->_update_minimum_size_cache();
+		_update_minimum_size_cache();
 	}
 	return data.minimum_size_cache;
 }
@@ -3059,11 +3059,11 @@ Control::LayoutDirection Control::get_layout_direction() const {
 bool Control::is_layout_rtl() const {
 	ERR_READ_THREAD_GUARD_V(false);
 	if (data.is_rtl_dirty) {
-		const_cast<Control *>(this)->data.is_rtl_dirty = false;
+		data.is_rtl_dirty = false;
 		if (data.layout_dir == LAYOUT_DIRECTION_INHERITED) {
 #ifdef TOOLS_ENABLED
 			if (is_part_of_edited_scene() && GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
-				const_cast<Control *>(this)->data.is_rtl = true;
+				data.is_rtl = true;
 				return data.is_rtl;
 			}
 			if (is_inside_tree()) {
@@ -3071,22 +3071,22 @@ bool Control::is_layout_rtl() const {
 				if (edited_scene_root == this) {
 					int proj_root_layout_direction = GLOBAL_GET(SNAME("internationalization/rendering/root_node_layout_direction"));
 					if (proj_root_layout_direction == 1) {
-						const_cast<Control *>(this)->data.is_rtl = false;
+						data.is_rtl = false;
 					} else if (proj_root_layout_direction == 2) {
-						const_cast<Control *>(this)->data.is_rtl = true;
+						data.is_rtl = true;
 					} else if (proj_root_layout_direction == 3) {
 						String locale = OS::get_singleton()->get_locale();
-						const_cast<Control *>(this)->data.is_rtl = TS->is_locale_right_to_left(locale);
+						data.is_rtl = TS->is_locale_right_to_left(locale);
 					} else {
 						String locale = TranslationServer::get_singleton()->get_tool_locale();
-						const_cast<Control *>(this)->data.is_rtl = TS->is_locale_right_to_left(locale);
+						data.is_rtl = TS->is_locale_right_to_left(locale);
 					}
 					return data.is_rtl;
 				}
 			}
 #else
 			if (GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
-				const_cast<Control *>(this)->data.is_rtl = true;
+				data.is_rtl = true;
 				return data.is_rtl;
 			}
 #endif // TOOLS_ENABLED
@@ -3094,35 +3094,35 @@ bool Control::is_layout_rtl() const {
 			while (parent_node) {
 				Control *parent_control = Object::cast_to<Control>(parent_node);
 				if (parent_control) {
-					const_cast<Control *>(this)->data.is_rtl = parent_control->is_layout_rtl();
+					data.is_rtl = parent_control->is_layout_rtl();
 					return data.is_rtl;
 				}
 
 				Window *parent_window = Object::cast_to<Window>(parent_node);
 				if (parent_window) {
-					const_cast<Control *>(this)->data.is_rtl = parent_window->is_layout_rtl();
+					data.is_rtl = parent_window->is_layout_rtl();
 					return data.is_rtl;
 				}
 				parent_node = parent_node->get_parent();
 			}
 
 			if (root_layout_direction == 1) {
-				const_cast<Control *>(this)->data.is_rtl = false;
+				data.is_rtl = false;
 			} else if (root_layout_direction == 2) {
-				const_cast<Control *>(this)->data.is_rtl = true;
+				data.is_rtl = true;
 			} else if (root_layout_direction == 3) {
 				String locale = OS::get_singleton()->get_locale();
-				const_cast<Control *>(this)->data.is_rtl = TS->is_locale_right_to_left(locale);
+				data.is_rtl = TS->is_locale_right_to_left(locale);
 			} else {
 				String locale = TranslationServer::get_singleton()->get_tool_locale();
-				const_cast<Control *>(this)->data.is_rtl = TS->is_locale_right_to_left(locale);
+				data.is_rtl = TS->is_locale_right_to_left(locale);
 			}
 		} else if (data.layout_dir == LAYOUT_DIRECTION_APPLICATION_LOCALE) {
 			if (GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
-				const_cast<Control *>(this)->data.is_rtl = true;
+				data.is_rtl = true;
 			} else {
 				String locale = TranslationServer::get_singleton()->get_tool_locale();
-				const_cast<Control *>(this)->data.is_rtl = TS->is_locale_right_to_left(locale);
+				data.is_rtl = TS->is_locale_right_to_left(locale);
 			}
 		} else if (data.layout_dir == LAYOUT_DIRECTION_SYSTEM_LOCALE) {
 			if (GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
@@ -3132,7 +3132,7 @@ bool Control::is_layout_rtl() const {
 				const_cast<Control *>(this)->data.is_rtl = TS->is_locale_right_to_left(locale);
 			}
 		} else {
-			const_cast<Control *>(this)->data.is_rtl = (data.layout_dir == LAYOUT_DIRECTION_RTL);
+			data.is_rtl = (data.layout_dir == LAYOUT_DIRECTION_RTL);
 		}
 	}
 	return data.is_rtl;

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -200,8 +200,8 @@ private:
 
 		Point2 pos_cache;
 		Size2 size_cache;
-		Size2 minimum_size_cache;
-		bool minimum_size_valid = false;
+		mutable Size2 minimum_size_cache;
+		mutable bool minimum_size_valid = false;
 
 		Size2 last_minimum_size;
 		bool updating_last_minimum_size = false;
@@ -258,8 +258,8 @@ private:
 		// Internationalization.
 
 		LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
-		bool is_rtl_dirty = true;
-		bool is_rtl = false;
+		mutable bool is_rtl_dirty = true;
+		mutable bool is_rtl = false;
 
 		bool localize_numeral_system = true;
 
@@ -299,7 +299,7 @@ private:
 	void _set_anchors_layout_preset(int p_preset);
 	int _get_anchors_layout_preset() const;
 
-	void _update_minimum_size_cache();
+	void _update_minimum_size_cache() const;
 	void _update_minimum_size();
 	void _size_changed();
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -107,7 +107,7 @@ int Label::get_line_height(int p_line) const {
 	}
 }
 
-void Label::_shape() {
+void Label::_shape() const {
 	Ref<StyleBox> style = theme_cache.normal_style;
 	int width = (get_size().width - style->get_minimum_size().width);
 
@@ -326,11 +326,11 @@ void Label::_shape() {
 	_update_visible();
 
 	if (autowrap_mode == TextServer::AUTOWRAP_OFF || !clip || overrun_behavior == TextServer::OVERRUN_NO_TRIMMING) {
-		update_minimum_size();
+		const_cast<Label *>(this)->update_minimum_size();
 	}
 }
 
-void Label::_update_visible() {
+void Label::_update_visible() const {
 	int line_spacing = settings.is_valid() ? settings->get_line_spacing() : theme_cache.line_spacing;
 	int paragraph_spacing = settings.is_valid() ? settings->get_paragraph_spacing() : theme_cache.paragraph_spacing;
 	Ref<StyleBox> style = theme_cache.normal_style;
@@ -395,14 +395,15 @@ inline void draw_glyph_outline(const Glyph &p_gl, const RID &p_canvas, const Col
 
 void Label::_ensure_shaped() const {
 	if (dirty || font_dirty || text_dirty) {
-		const_cast<Label *>(this)->_shape();
-	} else
+		_shape();
+	} else {
 		for (const Paragraph &para : paragraphs) {
 			if (para.lines_dirty || para.dirty) {
-				const_cast<Label *>(this)->_shape();
+				_shape();
 				return;
 			}
 		}
+	}
 }
 
 RID Label::get_line_rid(int p_line) const {

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -54,7 +54,7 @@ private:
 	bool clip = false;
 	String el_char = U"…";
 	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
-	Size2 minsize;
+	mutable Size2 minsize;
 	bool uppercase = false;
 
 	struct Paragraph {
@@ -66,11 +66,11 @@ private:
 		RID text_rid;
 		Vector<RID> lines_rid;
 	};
-	bool dirty = true;
-	bool font_dirty = true;
-	bool text_dirty = true;
-	Vector<Paragraph> paragraphs;
-	int total_line_count = 0;
+	mutable bool dirty = true;
+	mutable bool font_dirty = true;
+	mutable bool text_dirty = true;
+	mutable Vector<Paragraph> paragraphs;
+	mutable int total_line_count = 0;
 	String paragraph_separator = "\\n";
 
 	String language;
@@ -104,8 +104,8 @@ private:
 
 	Rect2 _get_line_rect(int p_para, int p_line) const;
 	void _ensure_shaped() const;
-	void _update_visible();
-	void _shape();
+	void _update_visible() const;
+	void _shape() const;
 	void _invalidate();
 
 protected:

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -232,7 +232,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 
 	for (int i = 0; i < items.size(); i++) {
 		Size2 item_size;
-		const_cast<PopupMenu *>(this)->_shape_item(i);
+		_shape_item(i);
 
 		Size2 icon_size = _get_item_icon_size(i);
 		item_size.height = _get_item_height(i);
@@ -946,7 +946,7 @@ void PopupMenu::_close_pressed() {
 	}
 }
 
-void PopupMenu::_shape_item(int p_idx) {
+void PopupMenu::_shape_item(int p_idx) const {
 	if (items.write[p_idx].dirty) {
 		items.write[p_idx].text_buf->clear();
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -112,7 +112,7 @@ class PopupMenu : public Popup {
 	Timer *minimum_lifetime_timer = nullptr;
 	Timer *submenu_timer = nullptr;
 	List<Rect2> autohide_areas;
-	Vector<Item> items;
+	mutable Vector<Item> items;
 	BitField<MouseButtonMask> initial_button_mask;
 	bool during_grabbed_click = false;
 	bool is_scrolling = false;
@@ -127,7 +127,7 @@ class PopupMenu : public Popup {
 	int _get_items_total_height() const;
 	Size2 _get_item_icon_size(int p_idx) const;
 
-	void _shape_item(int p_idx);
+	void _shape_item(int p_idx) const;
 
 	void _activate_submenu(int p_over, bool p_by_keyboard = false);
 	void _submenu_timeout();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2002,7 +2002,7 @@ void Tree::update_column(int p_col) {
 	columns.write[p_col].cached_minimum_width_dirty = true;
 }
 
-void Tree::update_item_cell(TreeItem *p_item, int p_col) {
+void Tree::update_item_cell(TreeItem *p_item, int p_col) const {
 	String valtext;
 
 	p_item->cells.write[p_col].text_buf->clear();
@@ -2090,7 +2090,7 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) {
 	p_item->cells.write[p_col].dirty = false;
 }
 
-void Tree::update_item_cache(TreeItem *p_item) {
+void Tree::update_item_cache(TreeItem *p_item) const {
 	for (int i = 0; i < p_item->cells.size(); i++) {
 		update_item_cell(p_item, i);
 	}
@@ -2342,7 +2342,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			Color icon_col = p_item->cells[i].icon_color;
 
 			if (p_item->cells[i].dirty) {
-				const_cast<Tree *>(this)->update_item_cell(p_item, i);
+				update_item_cell(p_item, i);
 			}
 
 			if (rtl) {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -517,8 +517,8 @@ private:
 	int get_item_height(TreeItem *p_item) const;
 	void _update_all();
 	void update_column(int p_col);
-	void update_item_cell(TreeItem *p_item, int p_col);
-	void update_item_cache(TreeItem *p_item);
+	void update_item_cell(TreeItem *p_item, int p_col) const;
+	void update_item_cache(TreeItem *p_item) const;
 	//void draw_item_text(String p_text,const Ref<Texture2D>& p_icon,int p_icon_max_w,bool p_tool,Rect2i p_rect,const Color& p_color);
 	void draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Color &p_color, const Color &p_icon_color, int p_ol_size, const Color &p_ol_color);
 	int draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 &p_draw_size, TreeItem *p_item, int &r_self_height);

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -108,7 +108,7 @@ void CanvasLayer::_update_xform() {
 	}
 }
 
-void CanvasLayer::_update_locrotscale() {
+void CanvasLayer::_update_locrotscale() const {
 	ofs = transform.columns[2];
 	rot = transform.get_rotation();
 	scale = transform.get_scale();
@@ -126,7 +126,7 @@ void CanvasLayer::set_offset(const Vector2 &p_offset) {
 
 Vector2 CanvasLayer::get_offset() const {
 	if (locrotscale_dirty) {
-		const_cast<CanvasLayer *>(this)->_update_locrotscale();
+		_update_locrotscale();
 	}
 
 	return ofs;
@@ -143,7 +143,7 @@ void CanvasLayer::set_rotation(real_t p_radians) {
 
 real_t CanvasLayer::get_rotation() const {
 	if (locrotscale_dirty) {
-		const_cast<CanvasLayer *>(this)->_update_locrotscale();
+		_update_locrotscale();
 	}
 
 	return rot;
@@ -160,7 +160,7 @@ void CanvasLayer::set_scale(const Vector2 &p_scale) {
 
 Vector2 CanvasLayer::get_scale() const {
 	if (locrotscale_dirty) {
-		const_cast<CanvasLayer *>(this)->_update_locrotscale();
+		_update_locrotscale();
 	}
 
 	return scale;

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -37,10 +37,10 @@ class Viewport;
 class CanvasLayer : public Node {
 	GDCLASS(CanvasLayer, Node);
 
-	bool locrotscale_dirty = false;
-	Vector2 ofs;
-	Size2 scale = Vector2(1, 1);
-	real_t rot = 0.0;
+	mutable bool locrotscale_dirty = false;
+	mutable Vector2 ofs;
+	mutable Size2 scale = Vector2(1, 1);
+	mutable real_t rot = 0.0;
 	int layer = 1;
 	Transform2D transform;
 	RID canvas;
@@ -58,7 +58,7 @@ class CanvasLayer : public Node {
 	float follow_viewport_scale = 1.0;
 
 	void _update_xform();
-	void _update_locrotscale();
+	void _update_locrotscale() const;
 	void _update_follow_viewport(bool p_force_exit = false);
 
 protected:

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2427,11 +2427,11 @@ void Viewport::_gui_update_mouse_over() {
 	gui.sending_mouse_enter_exit_notifications = false;
 }
 
-Window *Viewport::get_base_window() const {
+Window *Viewport::get_base_window() {
 	ERR_READ_THREAD_GUARD_V(nullptr);
 	ERR_FAIL_COND_V(!is_inside_tree(), nullptr);
 
-	Viewport *v = const_cast<Viewport *>(this);
+	Viewport *v = this;
 	Window *w = Object::cast_to<Window>(v);
 	while (!w) {
 		v = v->get_parent_viewport();
@@ -2456,7 +2456,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 		// No need for change.
 		return;
 	}
-	get_tree()->call_group("_viewports", "_gui_remove_focus_for_window", (Node *)get_base_window());
+	get_tree()->call_group("_viewports", "_gui_remove_focus_for_window", get_base_window());
 	if (p_control->is_inside_tree() && p_control->get_viewport() == this) {
 		gui.key_focus = p_control;
 		emit_signal(SNAME("gui_focus_changed"), p_control);
@@ -4972,7 +4972,7 @@ Viewport::Viewport() {
 	texture_rid = RenderingServer::get_singleton()->viewport_get_texture(viewport);
 
 	default_texture.instantiate();
-	default_texture->vp = const_cast<Viewport *>(this);
+	default_texture->vp = this;
 	viewport_textures.insert(default_texture.ptr());
 	default_texture->proxy = RS::get_singleton()->texture_proxy_create(texture_rid);
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -664,7 +664,7 @@ public:
 	Rect2i subwindow_get_popup_safe_rect(Window *p_window) const;
 
 	Viewport *get_parent_viewport() const;
-	Window *get_base_window() const;
+	Window *get_base_window();
 
 	void set_canvas_cull_mask(uint32_t p_layers);
 	uint32_t get_canvas_cull_mask() const;

--- a/scene/resources/audio_stream_polyphonic.cpp
+++ b/scene/resources/audio_stream_polyphonic.cpp
@@ -278,6 +278,21 @@ AudioStreamPlaybackPolyphonic::Stream *AudioStreamPlaybackPolyphonic::_find_stre
 	return &streams[index];
 }
 
+const AudioStreamPlaybackPolyphonic::Stream *AudioStreamPlaybackPolyphonic::_find_stream(int64_t p_id) const {
+	uint32_t index = static_cast<uint64_t>(p_id) >> INDEX_SHIFT;
+	if (index >= streams.size()) {
+		return nullptr;
+	}
+	if (!streams[index].active.is_set()) {
+		return nullptr; // Not active, no longer exists.
+	}
+	int64_t id = static_cast<uint64_t>(p_id) & ID_MASK;
+	if (streams[index].id != id) {
+		return nullptr;
+	}
+	return &streams[index];
+}
+
 void AudioStreamPlaybackPolyphonic::set_stream_volume(ID p_stream_id, float p_volume_db) {
 	Stream *s = _find_stream(p_stream_id);
 	if (!s) {
@@ -295,7 +310,7 @@ void AudioStreamPlaybackPolyphonic::set_stream_pitch_scale(ID p_stream_id, float
 }
 
 bool AudioStreamPlaybackPolyphonic::is_stream_playing(ID p_stream_id) const {
-	return const_cast<AudioStreamPlaybackPolyphonic *>(this)->_find_stream(p_stream_id) != nullptr;
+	return _find_stream(p_stream_id) != nullptr;
 }
 
 void AudioStreamPlaybackPolyphonic::stop_stream(ID p_stream_id) {

--- a/scene/resources/audio_stream_polyphonic.h
+++ b/scene/resources/audio_stream_polyphonic.h
@@ -88,6 +88,7 @@ class AudioStreamPlaybackPolyphonic : public AudioStreamPlayback {
 	Ref<AudioSamplePlayback> sample_playback;
 
 	_FORCE_INLINE_ Stream *_find_stream(int64_t p_id);
+	_FORCE_INLINE_ const Stream *_find_stream(int64_t p_id) const;
 
 	friend class AudioStreamPolyphonic;
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -499,6 +499,10 @@ void Curve::set_data(const Array p_input) {
 }
 
 void Curve::bake() {
+	_bake();
+}
+
+void Curve::_bake() const {
 	_baked_cache.clear();
 
 	_baked_cache.resize(_bake_resolution);
@@ -530,7 +534,7 @@ real_t Curve::sample_baked(real_t p_offset) const {
 
 	if (_baked_cache_dirty) {
 		// Last-second bake if not done already.
-		const_cast<Curve *>(this)->bake();
+		_bake();
 	}
 
 	// Special cases if the cache is too small.

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -133,6 +133,7 @@ public:
 	void set_data(Array input);
 
 	void bake();
+	void _bake() const;
 	int get_bake_resolution() const { return _bake_resolution; }
 	void set_bake_resolution(int p_resolution);
 	real_t sample_baked(real_t p_offset) const;
@@ -156,8 +157,8 @@ private:
 	void _remove_point(int p_index);
 
 	Vector<Point> _points;
-	bool _baked_cache_dirty = false;
-	Vector<real_t> _baked_cache;
+	mutable bool _baked_cache_dirty = false;
+	mutable Vector<real_t> _baked_cache;
 	int _bake_resolution = 100;
 	real_t _min_value = 0.0;
 	real_t _max_value = 1.0;

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -102,23 +102,24 @@ void Font::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "fallbacks", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("Font")), "set_fallbacks", "get_fallbacks");
 }
 
-void Font::_update_rids_fb(const Ref<Font> &p_f, int p_depth) const {
+void Font::_update_rids_fb(const Font *p_f, int p_depth) const {
 	ERR_FAIL_COND(p_depth > MAX_FALLBACK_DEPTH);
-	if (p_f.is_valid()) {
+	if (p_f != nullptr) {
 		RID rid = p_f->_get_rid();
 		if (rid.is_valid()) {
 			rids.push_back(rid);
 		}
 		const TypedArray<Font> &_fallbacks = p_f->get_fallbacks();
 		for (int i = 0; i < _fallbacks.size(); i++) {
-			_update_rids_fb(_fallbacks[i], p_depth + 1);
+			Ref<Font> fb_font = _fallbacks[i];
+			_update_rids_fb(fb_font.ptr(), p_depth + 1);
 		}
 	}
 }
 
 void Font::_update_rids() const {
 	rids.clear();
-	_update_rids_fb(const_cast<Font *>(this), 0);
+	_update_rids_fb(this, 0);
 	dirty_rids = false;
 }
 
@@ -2084,9 +2085,8 @@ void FontFile::set_data(const PackedByteArray &p_data) {
 
 PackedByteArray FontFile::get_data() const {
 	if (unlikely((size_t)data.size() != data_size)) {
-		PackedByteArray *data_w = const_cast<PackedByteArray *>(&data);
-		data_w->resize(data_size);
-		memcpy(data_w->ptrw(), data_ptr, data_size);
+		data.resize(data_size);
+		memcpy(data.ptrw(), data_ptr, data_size);
 	}
 	return data;
 }
@@ -2853,10 +2853,11 @@ void FontVariation::_update_rids() const {
 
 		const TypedArray<Font> &base_fallbacks = f->get_fallbacks();
 		for (int i = 0; i < base_fallbacks.size(); i++) {
-			_update_rids_fb(base_fallbacks[i], 0);
+			Ref<Font> fb_font = base_fallbacks[i];
+			_update_rids_fb(fb_font.ptr(), 0);
 		}
 	} else {
-		_update_rids_fb(const_cast<FontVariation *>(this), 0);
+		_update_rids_fb(this, 0);
 	}
 	dirty_rids = false;
 }
@@ -2903,7 +2904,7 @@ Ref<Font> FontVariation::get_base_font() const {
 
 Ref<Font> FontVariation::_get_base_font_or_default() const {
 	if (theme_font.is_valid()) {
-		theme_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids));
+		theme_font->disconnect_changed(callable_mp(static_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids));
 		theme_font.unref();
 	}
 
@@ -2937,7 +2938,7 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 			}
 			if (f.is_valid()) {
 				theme_font = f;
-				theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+				theme_font->connect_changed(callable_mp(static_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 			}
 			return f;
 		}
@@ -2947,7 +2948,7 @@ Ref<Font> FontVariation::_get_base_font_or_default() const {
 	if (!_is_base_cyclic(f, 0)) {
 		if (f.is_valid()) {
 			theme_font = f;
-			theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+			theme_font->connect_changed(callable_mp(static_cast<Font *>(const_cast<FontVariation *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 		}
 		return f;
 	}
@@ -3134,10 +3135,11 @@ void SystemFont::_update_rids() const {
 
 		const TypedArray<Font> &base_fallbacks = f->get_fallbacks();
 		for (int i = 0; i < base_fallbacks.size(); i++) {
-			_update_rids_fb(base_fallbacks[i], 0);
+			Ref<Font> fb_font = base_fallbacks[i];
+			_update_rids_fb(fb_font.ptr(), 0);
 		}
 	} else {
-		_update_rids_fb(const_cast<SystemFont *>(this), 0);
+		_update_rids_fb(this, 0);
 	}
 	dirty_rids = false;
 }
@@ -3271,7 +3273,7 @@ void SystemFont::reset_state() {
 
 Ref<Font> SystemFont::_get_base_font_or_default() const {
 	if (theme_font.is_valid()) {
-		theme_font->disconnect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids));
+		theme_font->disconnect_changed(callable_mp(static_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids));
 		theme_font.unref();
 	}
 
@@ -3300,7 +3302,7 @@ Ref<Font> SystemFont::_get_base_font_or_default() const {
 			}
 			if (f.is_valid()) {
 				theme_font = f;
-				theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+				theme_font->connect_changed(callable_mp(static_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 			}
 			return f;
 		}
@@ -3310,7 +3312,7 @@ Ref<Font> SystemFont::_get_base_font_or_default() const {
 	if (!_is_base_cyclic(f, 0)) {
 		if (f.is_valid()) {
 			theme_font = f;
-			theme_font->connect_changed(callable_mp(reinterpret_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
+			theme_font->connect_changed(callable_mp(static_cast<Font *>(const_cast<SystemFont *>(this)), &Font::_invalidate_rids), CONNECT_REFERENCE_COUNTED);
 		}
 		return f;
 	}

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -97,7 +97,7 @@ protected:
 
 	static void _bind_methods();
 
-	virtual void _update_rids_fb(const Ref<Font> &p_f, int p_depth) const;
+	virtual void _update_rids_fb(const Font *p_f, int p_depth) const;
 	virtual void _update_rids() const;
 	virtual void reset_state() override;
 
@@ -183,7 +183,7 @@ class FontFile : public Font {
 	// Font source data.
 	const uint8_t *data_ptr = nullptr;
 	size_t data_size = 0;
-	PackedByteArray data;
+	mutable PackedByteArray data;
 
 	TextServer::FontAntialiasing antialiasing = TextServer::FONT_ANTIALIASING_GRAY;
 	bool mipmaps = false;

--- a/scene/resources/text_line.cpp
+++ b/scene/resources/text_line.cpp
@@ -104,7 +104,7 @@ void TextLine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("hit_test", "coords"), &TextLine::hit_test);
 }
 
-void TextLine::_shape() {
+void TextLine::_shape() const {
 	// When a shaped text is invalidated by an external source, we want to reshape it.
 	if (!TS->shaped_text_is_ready(rid)) {
 		dirty = true;
@@ -217,7 +217,7 @@ bool TextLine::add_object(Variant p_key, const Size2 &p_size, InlineAlignment p_
 }
 
 bool TextLine::resize_object(Variant p_key, const Size2 &p_size, InlineAlignment p_inline_align, float p_baseline) {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 	return TS->shaped_text_resize_object(rid, p_key, p_size, p_inline_align, p_baseline);
 }
 
@@ -341,37 +341,37 @@ float TextLine::get_width() const {
 }
 
 Size2 TextLine::get_size() const {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 	return TS->shaped_text_get_size(rid);
 }
 
 float TextLine::get_line_ascent() const {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 	return TS->shaped_text_get_ascent(rid);
 }
 
 float TextLine::get_line_descent() const {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 	return TS->shaped_text_get_descent(rid);
 }
 
 float TextLine::get_line_width() const {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 	return TS->shaped_text_get_width(rid);
 }
 
 float TextLine::get_line_underline_position() const {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 	return TS->shaped_text_get_underline_position(rid);
 }
 
 float TextLine::get_line_underline_thickness() const {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 	return TS->shaped_text_get_underline_thickness(rid);
 }
 
 void TextLine::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color) const {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 
 	Vector2 ofs = p_pos;
 
@@ -418,7 +418,7 @@ void TextLine::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color) co
 }
 
 void TextLine::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size, const Color &p_color) const {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 
 	Vector2 ofs = p_pos;
 
@@ -465,7 +465,7 @@ void TextLine::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_si
 }
 
 int TextLine::hit_test(float p_coords) const {
-	const_cast<TextLine *>(this)->_shape();
+	_shape();
 
 	return TS->shaped_text_hit_test_position(rid, p_coords);
 }

--- a/scene/resources/text_line.h
+++ b/scene/resources/text_line.h
@@ -42,7 +42,7 @@ class TextLine : public RefCounted {
 private:
 	RID rid;
 
-	bool dirty = true;
+	mutable bool dirty = true;
 
 	float width = -1.0;
 	BitField<TextServer::JustificationFlag> flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA;
@@ -55,7 +55,7 @@ private:
 protected:
 	static void _bind_methods();
 
-	void _shape();
+	void _shape() const;
 
 public:
 	RID get_rid() const;

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -142,7 +142,7 @@ void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("hit_test", "coords"), &TextParagraph::hit_test);
 }
 
-void TextParagraph::_shape_lines() {
+void TextParagraph::_shape_lines() const {
 	// When a shaped text is invalidated by an external source, we want to reshape it.
 	if (!TS->shaped_text_is_ready(rid) || !TS->shaped_text_is_ready(dropcap_rid)) {
 		lines_dirty = true;
@@ -316,7 +316,7 @@ RID TextParagraph::get_rid() const {
 RID TextParagraph::get_line_rid(int p_line) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), RID());
 	return lines_rid[p_line];
 }
@@ -375,7 +375,7 @@ void TextParagraph::set_direction(TextServer::Direction p_direction) {
 TextServer::Direction TextParagraph::get_direction() const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	return TS->shaped_text_get_direction(rid);
 }
 
@@ -403,7 +403,7 @@ void TextParagraph::set_orientation(TextServer::Orientation p_orientation) {
 TextServer::Orientation TextParagraph::get_orientation() const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	return TS->shaped_text_get_orientation(rid);
 }
 
@@ -551,14 +551,14 @@ float TextParagraph::get_width() const {
 Size2 TextParagraph::get_non_wrapped_size() const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	return TS->shaped_text_get_size(rid);
 }
 
 Size2 TextParagraph::get_size() const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 
 	float h_offset = 0.f;
 	float v_offset = 0.f;
@@ -607,7 +607,7 @@ Size2 TextParagraph::get_size() const {
 int TextParagraph::get_line_count() const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	return (int)lines_rid.size();
 }
 
@@ -640,7 +640,7 @@ float TextParagraph::get_line_spacing() const {
 Array TextParagraph::get_line_objects(int p_line) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), Array());
 	return TS->shaped_text_get_objects(lines_rid[p_line]);
 }
@@ -648,7 +648,7 @@ Array TextParagraph::get_line_objects(int p_line) const {
 Rect2 TextParagraph::get_line_object_rect(int p_line, Variant p_key) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), Rect2());
 
 	Vector2 ofs;
@@ -739,7 +739,7 @@ Rect2 TextParagraph::get_line_object_rect(int p_line, Variant p_key) const {
 Size2 TextParagraph::get_line_size(int p_line) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), Size2());
 	return TS->shaped_text_get_size(lines_rid[p_line]);
 }
@@ -747,7 +747,7 @@ Size2 TextParagraph::get_line_size(int p_line) const {
 Vector2i TextParagraph::get_line_range(int p_line) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), Vector2i());
 	return TS->shaped_text_get_range(lines_rid[p_line]);
 }
@@ -755,7 +755,7 @@ Vector2i TextParagraph::get_line_range(int p_line) const {
 float TextParagraph::get_line_ascent(int p_line) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), 0.f);
 	return TS->shaped_text_get_ascent(lines_rid[p_line]);
 }
@@ -763,7 +763,7 @@ float TextParagraph::get_line_ascent(int p_line) const {
 float TextParagraph::get_line_descent(int p_line) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), 0.f);
 	return TS->shaped_text_get_descent(lines_rid[p_line]);
 }
@@ -771,7 +771,7 @@ float TextParagraph::get_line_descent(int p_line) const {
 float TextParagraph::get_line_width(int p_line) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), 0.f);
 	return TS->shaped_text_get_width(lines_rid[p_line]);
 }
@@ -779,7 +779,7 @@ float TextParagraph::get_line_width(int p_line) const {
 float TextParagraph::get_line_underline_position(int p_line) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), 0.f);
 	return TS->shaped_text_get_underline_position(lines_rid[p_line]);
 }
@@ -787,7 +787,7 @@ float TextParagraph::get_line_underline_position(int p_line) const {
 float TextParagraph::get_line_underline_thickness(int p_line) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= (int)lines_rid.size(), 0.f);
 	return TS->shaped_text_get_underline_thickness(lines_rid[p_line]);
 }
@@ -805,7 +805,7 @@ int TextParagraph::get_dropcap_lines() const {
 void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color, const Color &p_dc_color) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	Vector2 ofs = p_pos;
 	float h_offset = 0.f;
 	if (TS->shaped_text_get_orientation(dropcap_rid) == TextServer::ORIENTATION_HORIZONTAL) {
@@ -908,7 +908,7 @@ void TextParagraph::draw(RID p_canvas, const Vector2 &p_pos, const Color &p_colo
 void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size, const Color &p_color, const Color &p_dc_color) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	Vector2 ofs = p_pos;
 
 	float h_offset = 0.f;
@@ -1010,7 +1010,7 @@ void TextParagraph::draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outli
 int TextParagraph::hit_test(const Point2 &p_coords) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	Vector2 ofs;
 	if (TS->shaped_text_get_orientation(rid) == TextServer::ORIENTATION_HORIZONTAL) {
 		if (ofs.y < 0) {
@@ -1092,7 +1092,7 @@ void TextParagraph::draw_dropcap_outline(RID p_canvas, const Vector2 &p_pos, int
 void TextParagraph::draw_line(RID p_canvas, const Vector2 &p_pos, int p_line, const Color &p_color) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND(p_line < 0 || p_line >= (int)lines_rid.size());
 
 	Vector2 ofs = p_pos;
@@ -1108,7 +1108,7 @@ void TextParagraph::draw_line(RID p_canvas, const Vector2 &p_pos, int p_line, co
 void TextParagraph::draw_line_outline(RID p_canvas, const Vector2 &p_pos, int p_line, int p_outline_size, const Color &p_color) const {
 	_THREAD_SAFE_METHOD_
 
-	const_cast<TextParagraph *>(this)->_shape_lines();
+	_shape_lines();
 	ERR_FAIL_COND(p_line < 0 || p_line >= (int)lines_rid.size());
 
 	Vector2 ofs = p_pos;

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -42,14 +42,14 @@ class TextParagraph : public RefCounted {
 	_THREAD_SAFE_CLASS_
 
 private:
-	RID dropcap_rid;
-	int dropcap_lines = 0;
+	mutable RID dropcap_rid;
+	mutable int dropcap_lines = 0;
 	Rect2 dropcap_margins;
 
 	RID rid;
-	LocalVector<RID> lines_rid;
+	mutable LocalVector<RID> lines_rid;
 
-	bool lines_dirty = true;
+	mutable bool lines_dirty = true;
 
 	float line_spacing = 0.0;
 	float width = -1.0;
@@ -67,7 +67,7 @@ private:
 protected:
 	static void _bind_methods();
 
-	void _shape_lines();
+	void _shape_lines() const;
 
 public:
 	RID get_rid() const;

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2053,12 +2053,12 @@ Error VisualShader::_write_node(Type type, StringBuilder *p_global_code, StringB
 			String src_var = "n_out" + itos(from_node) + "p" + itos(from_port);
 
 			if (in_type == VisualShaderNode::PORT_TYPE_SAMPLER && out_type == VisualShaderNode::PORT_TYPE_SAMPLER) {
-				VisualShaderNode *ptr = const_cast<VisualShaderNode *>(graph[type].nodes[from_node].node.ptr());
+				Ref<VisualShaderNode> ref = graph[type].nodes[from_node].node;
 				// FIXME: This needs to be refactored at some point.
-				if (ptr->has_method("get_input_real_name")) {
-					inputs[i] = ptr->call("get_input_real_name");
-				} else if (ptr->has_method("get_parameter_name")) {
-					inputs[i] = ptr->call("get_parameter_name");
+				if (ref->has_method("get_input_real_name")) {
+					inputs[i] = ref->call("get_input_real_name");
+				} else if (ref->has_method("get_parameter_name")) {
+					inputs[i] = ref->call("get_parameter_name");
 				} else {
 					Ref<VisualShaderNodeReroute> reroute = graph[type].nodes[from_node].node;
 					if (reroute.is_valid()) {
@@ -2643,9 +2643,9 @@ void VisualShader::_update_shader() const {
 		VisualShaderNodeParameter *parameter = *itr;
 		if (used_parameter_names.has(parameter->get_parameter_name())) {
 			global_code += parameter->generate_global(get_mode(), Type(idx), -1);
-			const_cast<VisualShaderNodeParameter *>(parameter)->set_global_code_generated(true);
+			parameter->set_global_code_generated(true);
 		} else {
-			const_cast<VisualShaderNodeParameter *>(parameter)->set_global_code_generated(false);
+			parameter->set_global_code_generated(false);
 		}
 	}
 
@@ -2720,7 +2720,7 @@ void VisualShader::_update_shader() const {
 				if ((E.value.mode == VARYING_MODE_VERTEX_TO_FRAG_LIGHT && i == TYPE_VERTEX) || (E.value.mode == VARYING_MODE_FRAG_TO_LIGHT && i == TYPE_FRAGMENT)) {
 					bool found = false;
 					for (int key : varying_setters[i]) {
-						Ref<VisualShaderNodeVaryingSetter> setter = Object::cast_to<VisualShaderNodeVaryingSetter>(const_cast<VisualShaderNode *>(graph[i].nodes[key].node.ptr()));
+						Ref<VisualShaderNodeVaryingSetter> setter = graph[i].nodes[key].node;
 						if (setter.is_valid() && E.value.name == setter->get_varying_name()) {
 							found = true;
 							break;

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -760,7 +760,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	PhysicsServer2D::MotionResult *get_result_ptr() const { return const_cast<PhysicsServer2D::MotionResult *>(&result); }
+	PhysicsServer2D::MotionResult *get_result_ptr() { return &result; }
 
 	Vector2 get_travel() const;
 	Vector2 get_remainder() const;

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -966,7 +966,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	PhysicsServer3D::MotionResult *get_result_ptr() const { return const_cast<PhysicsServer3D::MotionResult *>(&result); }
+	PhysicsServer3D::MotionResult *get_result_ptr() { return &result; }
 
 	Vector3 get_travel() const;
 	Vector3 get_remainder() const;

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -276,7 +276,7 @@ void RendererSceneCull::_instance_pair(Instance *p_A, Instance *p_B) {
 }
 
 void RendererSceneCull::_instance_unpair(Instance *p_A, Instance *p_B) {
-	RendererSceneCull *self = (RendererSceneCull *)singleton;
+	RendererSceneCull *self = singleton;
 	Instance *A = p_A;
 	Instance *B = p_B;
 
@@ -363,7 +363,7 @@ void RendererSceneCull::_instance_unpair(Instance *p_A, Instance *p_B) {
 			}
 
 			lightmap_data->geometries.erase(A);
-			((RendererSceneCull *)self)->_instance_queue_update(A, false, false); //need to update capture
+			self->_instance_queue_update(A, false, false); //need to update capture
 		}
 
 	} else if (self->geometry_instance_pair_mask & (1 << RS::INSTANCE_VOXEL_GI) && B->base_type == RS::INSTANCE_VOXEL_GI && ((1 << A->base_type) & RS::INSTANCE_GEOMETRY_MASK)) {
@@ -489,7 +489,7 @@ void RendererSceneCull::scenario_add_viewport_visibility_mask(RID p_scenario, RI
 
 /* INSTANCING API */
 
-void RendererSceneCull::_instance_queue_update(Instance *p_instance, bool p_update_aabb, bool p_update_dependencies) {
+void RendererSceneCull::_instance_queue_update(Instance *p_instance, bool p_update_aabb, bool p_update_dependencies) const {
 	if (p_update_aabb) {
 		p_instance->update_aabb = true;
 	}
@@ -513,7 +513,7 @@ void RendererSceneCull::instance_initialize(RID p_rid) {
 	instance->self = p_rid;
 }
 
-void RendererSceneCull::_instance_update_mesh_instance(Instance *p_instance) {
+void RendererSceneCull::_instance_update_mesh_instance(Instance *p_instance) const {
 	bool needs_instance = RSG::mesh_storage->mesh_needs_instance(p_instance->base, p_instance->skeleton.is_valid());
 	if (needs_instance != p_instance->mesh_instance.is_valid()) {
 		if (needs_instance) {
@@ -1242,7 +1242,7 @@ Vector<ObjectID> RendererSceneCull::instances_cull_aabb(const AABB &p_aabb, RID 
 	Scenario *scenario = scenario_owner.get_or_null(p_scenario);
 	ERR_FAIL_NULL_V(scenario, instances);
 
-	const_cast<RendererSceneCull *>(this)->update_dirty_instances(); // check dirty instances before culling
+	update_dirty_instances(); // check dirty instances before culling
 
 	struct CullAABB {
 		Vector<ObjectID> instances;
@@ -1265,7 +1265,7 @@ Vector<ObjectID> RendererSceneCull::instances_cull_ray(const Vector3 &p_from, co
 	Vector<ObjectID> instances;
 	Scenario *scenario = scenario_owner.get_or_null(p_scenario);
 	ERR_FAIL_NULL_V(scenario, instances);
-	const_cast<RendererSceneCull *>(this)->update_dirty_instances(); // check dirty instances before culling
+	update_dirty_instances(); // check dirty instances before culling
 
 	struct CullRay {
 		Vector<ObjectID> instances;
@@ -1288,7 +1288,7 @@ Vector<ObjectID> RendererSceneCull::instances_cull_convex(const Vector<Plane> &p
 	Vector<ObjectID> instances;
 	Scenario *scenario = scenario_owner.get_or_null(p_scenario);
 	ERR_FAIL_NULL_V(scenario, instances);
-	const_cast<RendererSceneCull *>(this)->update_dirty_instances(); // check dirty instances before culling
+	update_dirty_instances(); // check dirty instances before culling
 
 	Vector<Vector3> points = Geometry3D::compute_convex_mesh_points(&p_convex[0], p_convex.size());
 
@@ -1531,7 +1531,7 @@ bool RendererSceneCull::_update_instance_visibility_depth(Instance *p_instance) 
 	return cycle_detected;
 }
 
-void RendererSceneCull::_update_instance_visibility_dependencies(Instance *p_instance) {
+void RendererSceneCull::_update_instance_visibility_dependencies(Instance *p_instance) const {
 	bool is_geometry_instance = ((1 << p_instance->base_type) & RS::INSTANCE_GEOMETRY_MASK) && p_instance->base_data;
 	bool has_visibility_range = p_instance->visibility_range_begin > 0.0 || p_instance->visibility_range_end > 0.0;
 	bool needs_visibility_cull = has_visibility_range && is_geometry_instance && p_instance->array_index != -1;
@@ -1671,7 +1671,7 @@ void RendererSceneCull::instance_geometry_set_shader_parameter(RID p_instance, c
 }
 
 Variant RendererSceneCull::instance_geometry_get_shader_parameter(RID p_instance, const StringName &p_parameter) const {
-	const Instance *instance = const_cast<RendererSceneCull *>(this)->instance_owner.get_or_null(p_instance);
+	const Instance *instance = instance_owner.get_or_null(p_instance);
 	ERR_FAIL_NULL_V(instance, Variant());
 
 	if (instance->instance_shader_uniforms.has(p_parameter)) {
@@ -1681,7 +1681,7 @@ Variant RendererSceneCull::instance_geometry_get_shader_parameter(RID p_instance
 }
 
 Variant RendererSceneCull::instance_geometry_get_shader_parameter_default_value(RID p_instance, const StringName &p_parameter) const {
-	const Instance *instance = const_cast<RendererSceneCull *>(this)->instance_owner.get_or_null(p_instance);
+	const Instance *instance = instance_owner.get_or_null(p_instance);
 	ERR_FAIL_NULL_V(instance, Variant());
 
 	if (instance->instance_shader_uniforms.has(p_parameter)) {
@@ -1699,10 +1699,10 @@ uint32_t RendererSceneCull::get_pipeline_compilations(RS::PipelineSource p_sourc
 }
 
 void RendererSceneCull::instance_geometry_get_shader_parameter_list(RID p_instance, List<PropertyInfo> *p_parameters) const {
-	const Instance *instance = const_cast<RendererSceneCull *>(this)->instance_owner.get_or_null(p_instance);
+	const Instance *instance = instance_owner.get_or_null(p_instance);
 	ERR_FAIL_NULL(instance);
 
-	const_cast<RendererSceneCull *>(this)->update_dirty_instances();
+	update_dirty_instances();
 
 	Vector<StringName> names;
 	for (const KeyValue<StringName, Instance::InstanceShaderParameter> &E : instance->instance_shader_uniforms) {
@@ -1715,7 +1715,7 @@ void RendererSceneCull::instance_geometry_get_shader_parameter_list(RID p_instan
 	}
 }
 
-void RendererSceneCull::_update_instance(Instance *p_instance) {
+void RendererSceneCull::_update_instance(Instance *p_instance) const {
 	p_instance->version++;
 
 	// When not using interpolation the transform is used straight.
@@ -2093,7 +2093,7 @@ void RendererSceneCull::_unpair_instance(Instance *p_instance) {
 	_update_instance_visibility_dependencies(p_instance);
 }
 
-void RendererSceneCull::_update_instance_aabb(Instance *p_instance) {
+void RendererSceneCull::_update_instance_aabb(Instance *p_instance) const {
 	AABB new_aabb;
 
 	ERR_FAIL_COND(p_instance->base_type != RS::INSTANCE_NONE && !p_instance->base.is_valid());
@@ -2168,7 +2168,7 @@ void RendererSceneCull::_update_instance_aabb(Instance *p_instance) {
 	p_instance->aabb = new_aabb;
 }
 
-void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance) {
+void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance) const {
 	bool first_set = p_instance->lightmap_sh.size() == 0;
 	p_instance->lightmap_sh.resize(9); //using SH
 	p_instance->lightmap_target_sh.resize(9); //using SH
@@ -4031,7 +4031,7 @@ void RendererSceneCull::render_particle_colliders() {
 	}
 }
 
-void RendererSceneCull::_update_instance_shader_uniforms_from_material(HashMap<StringName, Instance::InstanceShaderParameter> &isparams, const HashMap<StringName, Instance::InstanceShaderParameter> &existing_isparams, RID p_material) {
+void RendererSceneCull::_update_instance_shader_uniforms_from_material(HashMap<StringName, Instance::InstanceShaderParameter> &isparams, const HashMap<StringName, Instance::InstanceShaderParameter> &existing_isparams, RID p_material) const {
 	List<RendererMaterialStorage::InstanceShaderParam> plist;
 	RSG::material_storage->material_get_instance_shader_parameters(p_material, &plist);
 	for (const RendererMaterialStorage::InstanceShaderParam &E : plist) {
@@ -4059,7 +4059,7 @@ void RendererSceneCull::_update_instance_shader_uniforms_from_material(HashMap<S
 	}
 }
 
-void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
+void RendererSceneCull::_update_dirty_instance(Instance *p_instance) const {
 	if (p_instance->update_aabb) {
 		_update_instance_aabb(p_instance);
 	}
@@ -4293,7 +4293,7 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
 	p_instance->update_dependencies = false;
 }
 
-void RendererSceneCull::update_dirty_instances() {
+void RendererSceneCull::update_dirty_instances() const {
 	while (_instance_update_list.first()) {
 		_update_dirty_instance(_instance_update_list.first()->self());
 	}

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -370,7 +370,7 @@ public:
 	static void _instance_pair(Instance *p_A, Instance *p_B);
 	static void _instance_unpair(Instance *p_A, Instance *p_B);
 
-	void _instance_update_mesh_instance(Instance *p_instance);
+	void _instance_update_mesh_instance(Instance *p_instance) const;
 
 	virtual RID scenario_allocate();
 	virtual void scenario_initialize(RID p_rid);
@@ -396,7 +396,7 @@ public:
 				list_a(this), list_b(this) {}
 	};
 
-	PagedAllocator<InstancePair> pair_allocator;
+	mutable PagedAllocator<InstancePair> pair_allocator;
 
 	struct InstanceBaseData {
 		virtual ~InstanceBaseData() {}
@@ -651,8 +651,8 @@ public:
 		}
 	};
 
-	SelfList<Instance>::List _instance_update_list;
-	void _instance_queue_update(Instance *p_instance, bool p_update_aabb, bool p_update_dependencies = false);
+	mutable SelfList<Instance>::List _instance_update_list;
+	void _instance_queue_update(Instance *p_instance, bool p_update_aabb, bool p_update_dependencies = false) const;
 
 	struct InstanceGeometryData : public InstanceBaseData {
 		RenderGeometryInstance *geometry_instance = nullptr;
@@ -844,7 +844,7 @@ public:
 		}
 	};
 
-	uint64_t pair_pass = 1;
+	mutable uint64_t pair_pass = 1;
 
 	struct PairInstances {
 		Instance *instance = nullptr;
@@ -904,7 +904,7 @@ public:
 		}
 	};
 
-	HashSet<Instance *> heightfield_particle_colliders_update_list;
+	mutable HashSet<Instance *> heightfield_particle_colliders_update_list;
 
 	PagedArrayPool<Instance *> instance_cull_page_pool;
 	PagedArrayPool<RenderGeometryInstance *> geometry_instance_cull_page_pool;
@@ -1044,7 +1044,7 @@ public:
 
 	uint32_t thread_cull_threshold = 200;
 
-	RID_Owner<Instance, true> instance_owner;
+	mutable RID_Owner<Instance, true> instance_owner;
 
 	uint32_t geometry_instance_pair_mask = 0; // used in traditional forward, unnecessary on clustered
 
@@ -1078,7 +1078,7 @@ public:
 	virtual void instance_set_ignore_culling(RID p_instance, bool p_enabled);
 
 	bool _update_instance_visibility_depth(Instance *p_instance);
-	void _update_instance_visibility_dependencies(Instance *p_instance);
+	void _update_instance_visibility_dependencies(Instance *p_instance) const;
 
 	// don't use these in a game!
 	virtual Vector<ObjectID> instances_cull_aabb(const AABB &p_aabb, RID p_scenario = RID()) const;
@@ -1095,7 +1095,7 @@ public:
 	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index);
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias);
 
-	void _update_instance_shader_uniforms_from_material(HashMap<StringName, Instance::InstanceShaderParameter> &isparams, const HashMap<StringName, Instance::InstanceShaderParameter> &existing_isparams, RID p_material);
+	void _update_instance_shader_uniforms_from_material(HashMap<StringName, Instance::InstanceShaderParameter> &isparams, const HashMap<StringName, Instance::InstanceShaderParameter> &existing_isparams, RID p_material) const;
 
 	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &p_parameter, const Variant &p_value);
 	virtual void instance_geometry_get_shader_parameter_list(RID p_instance, List<PropertyInfo> *p_parameters) const;
@@ -1105,10 +1105,10 @@ public:
 	virtual void mesh_generate_pipelines(RID p_mesh, bool p_background_compilation);
 	virtual uint32_t get_pipeline_compilations(RS::PipelineSource p_source);
 
-	_FORCE_INLINE_ void _update_instance(Instance *p_instance);
-	_FORCE_INLINE_ void _update_instance_aabb(Instance *p_instance);
-	_FORCE_INLINE_ void _update_dirty_instance(Instance *p_instance);
-	_FORCE_INLINE_ void _update_instance_lightmap_captures(Instance *p_instance);
+	_FORCE_INLINE_ void _update_instance(Instance *p_instance) const;
+	_FORCE_INLINE_ void _update_instance_aabb(Instance *p_instance) const;
+	_FORCE_INLINE_ void _update_dirty_instance(Instance *p_instance) const;
+	_FORCE_INLINE_ void _update_instance_lightmap_captures(Instance *p_instance) const;
 	void _unpair_instance(Instance *p_instance);
 
 	void _light_instance_setup_directional_shadow(int p_shadow_index, Instance *p_instance, const Transform3D p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, bool p_cam_vaspect);
@@ -1193,7 +1193,7 @@ public:
 	void render_empty_scene(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_scenario, RID p_shadow_atlas);
 
 	void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, RenderingMethod::RenderInfo *r_render_info = nullptr);
-	void update_dirty_instances();
+	void update_dirty_instances() const;
 
 	void render_particle_colliders();
 	virtual void render_probes();


### PR DESCRIPTION
depends on https://github.com/godotengine/godot/pull/94864

gets rid of 138 instances of `const_cast` (greping for `"\Wconst_cast\W"` in all folders except thirdparty gave 282 instances before and 144 after) 

these were the simplest ones i could get rid of. its the reason its in a bulk commit