### PR TITLE
Clean up two recently introduced WebGL errors

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -2184,7 +2184,9 @@ void RasterizerCanvasGLES3::canvas_begin(RID p_to_render_target, bool p_to_backb
 		glBindFramebuffer(GL_FRAMEBUFFER, render_target->fbo);
 		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
 		glBindTexture(GL_TEXTURE_2D, render_target->backbuffer);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, p_backbuffer_has_mipmaps ? render_target->mipmap_count - 1 : 0);
+		if (render_target->backbuffer != 0) {
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, p_backbuffer_has_mipmaps ? render_target->mipmap_count - 1 : 0);
+		}
 	}
 
 	if (render_target->is_transparent || p_to_backbuffer) {

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -349,9 +349,6 @@ RasterizerGLES3::RasterizerGLES3() {
 		}
 	}
 
-	// Disable OpenGL linear to sRGB conversion, because Godot will always do this conversion itself.
-	glDisable(GL_FRAMEBUFFER_SRGB);
-
 	// OpenGL needs to be initialized before initializing the Rasterizers
 	config = memnew(GLES3::Config);
 	utilities = memnew(GLES3::Utilities);
@@ -368,6 +365,11 @@ RasterizerGLES3::RasterizerGLES3() {
 	fog = memnew(GLES3::Fog);
 	canvas = memnew(RasterizerCanvasGLES3());
 	scene = memnew(RasterizerSceneGLES3());
+
+	// Disable OpenGL linear to sRGB conversion, because Godot will always do this conversion itself.
+	if (config->srgb_framebuffer_supported) {
+		glDisable(GL_FRAMEBUFFER_SRGB);
+	}
 }
 
 RasterizerGLES3::~RasterizerGLES3() {

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -88,6 +88,7 @@ Config::Config() {
 		etc2_supported = false;
 		s3tc_supported = true;
 		rgtc_supported = true; //RGTC - core since OpenGL version 3.0
+		srgb_framebuffer_supported = true;
 	} else {
 		float_texture_supported = extensions.has("GL_EXT_color_buffer_float");
 		etc2_supported = true;
@@ -100,6 +101,7 @@ Config::Config() {
 		s3tc_supported = extensions.has("GL_EXT_texture_compression_dxt1") || extensions.has("GL_EXT_texture_compression_s3tc") || extensions.has("WEBGL_compressed_texture_s3tc");
 #endif
 		rgtc_supported = extensions.has("GL_EXT_texture_compression_rgtc") || extensions.has("GL_ARB_texture_compression_rgtc") || extensions.has("EXT_texture_compression_rgtc");
+		srgb_framebuffer_supported = extensions.has("GL_EXT_sRGB_write_control");
 	}
 
 	glGetIntegerv(GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, &max_vertex_texture_image_units);

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -79,6 +79,7 @@ public:
 	bool astc_supported = false;
 	bool astc_hdr_supported = false;
 	bool astc_layered_supported = false;
+	bool srgb_framebuffer_supported = false;
 
 	bool force_vertex_shading = false;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/97369

There are 2 errors here:
1. `glTexParameteri` can only be called on an existing texture (unlike `glBindTexture` which is immediately above it)
2. `GL_FRAMEBUFFER_SRGB` is only available on desktop platforms. On Mobile/Web attempting to disable it results in an error. Unless the [`EXT_sRGB_write_control`](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_sRGB_write_control.txt) extension is available. In which case `GL_FRAMEBUFFER_SRGB_EXT` is available (the same value as `GL_FRAMEBUFFER_SRGB`) AND it is enabled by default :skull: . Therefore, we have to check for the extension and then only disable when its available.

CC @dsnopek with respect to the `GL_FRAMEBUFFER_SRGB` code