### PR TITLE
Ensure `handle_modes` is given default values rather than flagging error if undefined

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -321,8 +321,12 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				Vector<real_t> times = d["times"];
 				Vector<real_t> values = d["points"];
 #ifdef TOOLS_ENABLED
-				ERR_FAIL_COND_V(!d.has("handle_modes"), false);
-				Vector<int> handle_modes = d["handle_modes"];
+				Vector<int> handle_modes;
+				if (d.has("handle_modes")) {
+					handle_modes = d["handle_modes"];
+				} else {
+					handle_modes.resize_zeroed(times.size());
+				}
 #endif // TOOLS_ENABLED
 
 				ERR_FAIL_COND_V(times.size() * 5 != values.size(), false);


### PR DESCRIPTION
Fixes #66964

Bezier animations weren't being properly converted to from Godot 3.x to 4.x, raising errors such as `Condition "!d.has("handle_modes")" is true. Returning: false`. This seems to be because 4.x expected a `Handle Mode` to be defined for each individual key, whereas in Godot 3.x seems to have the Handle Mode as an Editor setting. When Godot 4.x opened a Godot 3.x project, it looked for `handle_modes` that weren't there, and failed when it couldn't find them. To fix this, I've changed it so that if `handle_modes` is not defined, they are all initialised to 0. (This corresponds to `Free` is also the default when creating animations in the Editor)

This fix should make it a lot easier to import Bezier animations from Godot 3.x to 4.x.