### PR TITLE
Add `Gradient::interpolate` static method

### DIFF
--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -307,6 +307,7 @@
 			<param index="1" name="weight" type="float" />
 			<description>
 				Returns the linear interpolation between this color's components and [param to]'s components. The interpolation factor [param weight] should be between 0.0 and 1.0 (inclusive). See also [method @GlobalScope.lerp].
+				[b]Note:[/b] Interpolating [url=https://en.wikipedia.org/wiki/SRGB]sRGB[/url] color space values (i.e. standard computer colors) directly often leads to [url=https://bottosson.github.io/posts/colorwrong/]visually wrong results[/url]. For physically or perceptually accurate blending, see [method Gradient.interpolate].
 				[codeblocks]
 				[gdscript]
 				var red = Color(1.0, 0.0, 0.0)

--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -38,6 +38,24 @@
 				Returns the number of colors in the gradient.
 			</description>
 		</method>
+		<method name="interpolate" qualifiers="static">
+			<return type="Color" />
+			<param index="0" name="from" type="Color" />
+			<param index="1" name="to" type="Color" />
+			<param index="2" name="weight" type="float" />
+			<param index="3" name="interpolation_color_space" type="int" enum="Gradient.ColorSpace" default="1" />
+			<param index="4" name="interpolation_mode" type="int" enum="Gradient.InterpolationMode" default="0" />
+			<description>
+				Returns the interpolated color between [param from] and [param to] specified by [param weight], [param interpolation_color_space], and [param interpolation_mode].
+				[b]Note:[/b] Prefer this method to [method Color.lerp] if you need to interpolate [url=https://en.wikipedia.org/wiki/SRGB]sRGB[/url] colors correctly.
+				[codeblocks]
+				[gdscript]
+				var physically_correct = Gradient.interpolate(Color.GREEN, Color.MAGENTA, 0.5, Gradient.GRADIENT_COLOR_SPACE_LINEAR_SRGB, Gradient.GRADIENT_INTERPOLATE_LINEAR)
+				var perceptually_correct = Gradient.interpolate(Color.GREEN, Color.MAGENTA, 0.5, Gradient.GRADIENT_COLOR_SPACE_OKLAB, Gradient.GRADIENT_INTERPOLATE_LINEAR)
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="remove_point">
 			<return type="void" />
 			<param index="0" name="point" type="int" />

--- a/scene/resources/gradient.cpp
+++ b/scene/resources/gradient.cpp
@@ -30,6 +30,8 @@
 
 #include "gradient.h"
 
+thread_local Ref<Gradient> Gradient::_interpolation_gradient = Ref<Gradient>(nullptr);
+
 Gradient::Gradient() {
 	//Set initial gradient transition from black to white
 	points.resize(2);
@@ -43,6 +45,8 @@ Gradient::~Gradient() {
 }
 
 void Gradient::_bind_methods() {
+	ClassDB::bind_static_method(SNAME("Gradient"), D_METHOD("interpolate", "from", "to", "weight", "interpolation_color_space", "interpolation_mode"), &Gradient::interpolate, DEFVAL(ColorSpace::GRADIENT_COLOR_SPACE_LINEAR_SRGB), DEFVAL(InterpolationMode::GRADIENT_INTERPOLATE_LINEAR));
+
 	ClassDB::bind_method(D_METHOD("add_point", "offset", "color"), &Gradient::add_point);
 	ClassDB::bind_method(D_METHOD("remove_point", "point"), &Gradient::remove_point);
 
@@ -224,4 +228,15 @@ Color Gradient::get_color(int pos) {
 
 int Gradient::get_point_count() const {
 	return points.size();
+}
+
+Color Gradient::interpolate(const Color &p_from, const Color &p_to, float p_weight, ColorSpace p_interpolation_color_space, InterpolationMode p_interpolation_mode) {
+	if (_interpolation_gradient.is_null()) {
+		_interpolation_gradient.instantiate();
+	}
+	_interpolation_gradient->set_color(0, p_from);
+	_interpolation_gradient->set_color(1, p_to);
+	_interpolation_gradient->set_interpolation_color_space(p_interpolation_color_space);
+	_interpolation_gradient->set_interpolation_mode(p_interpolation_mode);
+	return _interpolation_gradient->get_color_at_offset(p_weight);
 }

--- a/scene/resources/gradient.h
+++ b/scene/resources/gradient.h
@@ -61,6 +61,8 @@ public:
 	};
 
 private:
+	thread_local static Ref<Gradient> _interpolation_gradient;
+
 	Vector<Point> points;
 	bool is_sorted = true;
 	InterpolationMode interpolation_mode = GRADIENT_INTERPOLATE_LINEAR;
@@ -238,6 +240,8 @@ public:
 	}
 
 	int get_point_count() const;
+
+	static Color interpolate(const Color &p_from, const Color &p_to, float p_weight, ColorSpace p_interpolation_color_space = ColorSpace::GRADIENT_COLOR_SPACE_LINEAR_SRGB, InterpolationMode p_interpolation_mode = InterpolationMode::GRADIENT_INTERPOLATE_LINEAR);
 };
 
 VARIANT_ENUM_CAST(Gradient::InterpolationMode);


### PR DESCRIPTION
Follow up to #97375

This PR adds the `Gradient::interpolate()` static method in order to offer to users a better way to quickly interpolate physically or perceptually color values. It adds a note to the documentation for `Color::lerp()` too.

```c++
Color Gradient::interpolate(const Color &p_from, const Color &p_to, float p_weight, Gradient::ColorSpace p_interpolation_color_space = Gradient::ColorSpace::GRADIENT_COLOR_SPACE_LINEAR_SRGB, Gradient::InterpolationMode p_interpolation_mode = Gradient::InterpolationMode::GRADIENT_INTERPOLATE_LINEAR)
```

I chose to create a static method in `Gradient` (instead of `Color`) because:
1. `Gradient` already has color space management.
2. Makes it easier to point people to an alternative to `Color::lerp`.
3. `Gradient` already takes as input sRGB values.
4. This implementation makes extensive use of the `Gradient` resource, see the equivalent GDScript code below.

I struggled to figure out how to explain properly in the documentation the use of `Color::lerp` without having to resort to a big block of code. This PR makes it simple: you want accurate sRGB color interpolation? Use `Gradient::interpolate`. This static function is just a useful shortcut to something that people can already do, but in a WAY LESS verbose fashion:

```gdscript
var gradient:  = Gradient.new()
gradient.set_color(0, color_one)
gradient.set_offset(0, 0.0)
gradient.set_color(1, color_two)
gradient.set_offset(1, 1.0)
gradient.interpolation_color_space = color_space
gradient.interpolation_mode = interpolation_mode
var result: = gradient.sample(weight)
```

**Example project:**
[gradient-interpolate.zip](https://github.com/user-attachments/files/17103949/gradient-interpolate.zip)

<img width="688" alt="Capture d’écran, le 2024-09-23 à 16 37 48" src="https://github.com/user-attachments/assets/2a5a1c93-a687-4c67-97e6-11a360cb9061">
