### PR TITLE
Add initial GDScript formatter along with tests and front-ends

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -384,6 +384,7 @@ public:
 
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) { return ERR_UNAVAILABLE; }
 
+	virtual String format_code(const String &p_code) { return p_code; }
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const = 0;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) = 0;
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) {}

--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -120,6 +120,7 @@ void ScriptLanguageExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_complete_code, "code", "path", "owner");
 	GDVIRTUAL_BIND(_lookup_code, "code", "symbol", "path", "owner");
+	GDVIRTUAL_BIND(_format_code, "code");
 	GDVIRTUAL_BIND(_auto_indent_code, "code", "from_line", "to_line");
 
 	GDVIRTUAL_BIND(_add_global_constant, "name", "value");

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -490,6 +490,13 @@ public:
 		return result;
 	}
 
+	GDVIRTUAL1RC(String, _format_code, const String &)
+	virtual String format_code(const String &p_code) override {
+		String ret = p_code;
+		GDVIRTUAL_CALL(_format_code, p_code, ret);
+		return ret;
+	}
+
 	GDVIRTUAL3RC_REQUIRED(String, _auto_indent_code, const String &, int, int)
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override {
 		String ret;

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1224,6 +1224,9 @@
 		<member name="text_editor/behavior/files/trim_trailing_whitespace_on_save" type="bool" setter="" getter="">
 			If [code]true[/code], trims trailing whitespace when saving a script. Trailing whitespace refers to tab and space characters placed at the end of lines. Since these serve no practical purpose, they can and should be removed to make version control diffs less noisy.
 		</member>
+		<member name="text_editor/behavior/formatter/enabled" type="bool" setter="" getter="" experimental="Currently, no code formatter is implemented. Therefore, it does not format anything.">
+			If [code]true[/code], the experimental code formatter can be used to auto-format GDScript files.
+		</member>
 		<member name="text_editor/behavior/general/empty_selection_clipboard" type="bool" setter="" getter="">
 			If [code]true[/code], copying or cutting without a selection is performed on all lines with a caret. Otherwise, copy and cut require a selection.
 		</member>

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -137,6 +137,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="_format_code" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="code" type="String" />
+			<description>
+				Returns the formatted source code (e.g. with consistent indentation, spacing and punctuation across the file). Depending on the complexity of the language, you may have to call an external program to achieve this.
+			</description>
+		</method>
 		<method name="_frame" qualifiers="virtual">
 			<return type="void" />
 			<description>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -708,6 +708,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/indent/auto_indent", true);
 	_initial_set("text_editor/behavior/indent/indent_wrapped_lines", true);
 
+	// Behavior: Formatter
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/behavior/formatter/enabled", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
+
 	// Behavior: Files
 	_initial_set("text_editor/behavior/files/trim_trailing_whitespace_on_save", false);
 	_initial_set("text_editor/behavior/files/trim_final_newlines_on_save", true);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -193,6 +193,7 @@ public:
 	virtual void clear_executing_line() = 0;
 	virtual void trim_trailing_whitespace() = 0;
 	virtual void trim_final_newlines() = 0;
+	virtual void format_code() = 0;
 	virtual void insert_final_newline() = 0;
 	virtual void convert_indent() = 0;
 	virtual void ensure_focus() = 0;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -441,6 +441,40 @@ void ScriptTextEditor::trim_trailing_whitespace() {
 	code_editor->trim_trailing_whitespace();
 }
 
+void ScriptTextEditor::format_code() {
+	CodeEdit *tx = code_editor->get_text_editor();
+	const String original = tx->get_text();
+	Ref<Script> scr = script;
+
+	const String formatted_code = scr->get_language()->format_code(original);
+
+	if (formatted_code == original) {
+		return;
+	}
+
+	const Vector<String> original_lines = original.split("\n");
+	const Vector<String> formatted_lines = formatted_code.split("\n");
+
+	tx->begin_complex_operation();
+
+	const int end = MIN(original_lines.size(), formatted_lines.size());
+	for (int i = 0; i < end; ++i) {
+		if (original_lines[i] == formatted_lines[i]) {
+			continue;
+		}
+		tx->set_line(i, formatted_lines[i]);
+	}
+	if (original_lines.size() > formatted_lines.size()) {
+		tx->remove_text(formatted_lines.size() - 1, 0, original_lines.size() - 1, tx->get_line_width(original_lines.size() - 1));
+	} else if (original_lines.size() < formatted_lines.size()) {
+		Vector remainder{ tx->get_line(tx->get_line_count() - 1) };
+		remainder.append_array(formatted_lines.slice(tx->get_line_count()));
+		tx->set_line(tx->get_line_count() - 1, String("\n").join(remainder));
+	}
+
+	tx->end_complex_operation();
+}
+
 void ScriptTextEditor::trim_final_newlines() {
 	code_editor->trim_final_newlines();
 }
@@ -1539,6 +1573,9 @@ void ScriptTextEditor::_edit_option(int p_op) {
 		case EDIT_TRIM_FINAL_NEWLINES: {
 			trim_final_newlines();
 		} break;
+		case EDIT_FORMAT_CODE: {
+			format_code();
+		} break;
 		case EDIT_CONVERT_INDENT_TO_SPACES: {
 			code_editor->set_indent_using_spaces(true);
 			convert_indent();
@@ -2416,6 +2453,9 @@ void ScriptTextEditor::_enable_code_editor() {
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("ui_text_completion_query"), EDIT_COMPLETE);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_trailing_whitespace"), EDIT_TRIM_TRAILING_WHITESAPCE);
 	edit_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_text_editor/trim_final_newlines"), EDIT_TRIM_FINAL_NEWLINES);
+	if (EDITOR_GET("text_editor/behavior/formatter/enabled")) {
+		edit_menu->get_popup()->add_shortcut(ED_SHORTCUT("script_text_editor/format_code", TTR("Format Code"), KeyModifierMask::SHIFT | KeyModifierMask::ALT | Key::F), EDIT_FORMAT_CODE);
+	}
 	{
 		PopupMenu *sub_menu = memnew(PopupMenu);
 		sub_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/convert_indent_to_spaces"), EDIT_CONVERT_INDENT_TO_SPACES);

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -119,6 +119,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 		EDIT_AUTO_INDENT,
 		EDIT_TRIM_TRAILING_WHITESAPCE,
 		EDIT_TRIM_FINAL_NEWLINES,
+		EDIT_FORMAT_CODE,
 		EDIT_CONVERT_INDENT_TO_SPACES,
 		EDIT_CONVERT_INDENT_TO_TABS,
 		EDIT_TOGGLE_COMMENT,
@@ -232,6 +233,7 @@ public:
 	virtual void ensure_focus() override;
 	virtual void trim_trailing_whitespace() override;
 	virtual void trim_final_newlines() override;
+	virtual void format_code() override;
 	virtual void insert_final_newline() override;
 	virtual void convert_indent() override;
 	virtual void tag_saved_version() override;

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -135,6 +135,7 @@ public:
 	virtual void clear_executing_line() override;
 	virtual void trim_trailing_whitespace() override;
 	virtual void trim_final_newlines() override;
+	virtual void format_code() override {}
 	virtual void insert_final_newline() override;
 	virtual void convert_indent() override;
 	virtual void ensure_focus() override;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -131,6 +131,7 @@
 
 #ifdef MODULE_GDSCRIPT_ENABLED
 #include "modules/gdscript/gdscript.h"
+#include "modules/gdscript/gdscript_formatter.h"
 #if defined(TOOLS_ENABLED) && !defined(GDSCRIPT_NO_LSP)
 #include "modules/gdscript/language_server/gdscript_language_server.h"
 #endif // TOOLS_ENABLED && !GDSCRIPT_NO_LSP
@@ -668,6 +669,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("-s, --script <script>", "Run a script.\n");
 	print_help_option("--main-loop <main_loop_name>", "Run a MainLoop specified by its global class name.\n");
 	print_help_option("--check-only", "Only parse for errors and quit (use with --script).\n");
+	print_help_option("--format", "Format the script in-place (use with --script) or check if the file is formatted correctly (use with --script --check-only).\n");
 #ifdef TOOLS_ENABLED
 	print_help_option("--import", "Starts the editor, waits for any resources to be imported, and then quits.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--export-release <preset> <path>", "Export the project in release mode using the given preset and output path. The preset name should match one defined in \"export_presets.cfg\".\n", CLI_OPTION_AVAILABILITY_EDITOR);
@@ -3578,6 +3580,9 @@ int Main::start() {
 	String script;
 	String main_loop_type;
 	bool check_only = false;
+#ifdef MODULE_GDSCRIPT_ENABLED
+	bool format = false;
+#endif
 
 #ifdef TOOLS_ENABLED
 	String doc_tool_path;
@@ -3608,6 +3613,10 @@ int Main::start() {
 		// Designed to override and pass arguments to the unit test handler.
 		if (E->get() == "--check-only") {
 			check_only = true;
+#ifdef MODULE_GDSCRIPT_ENABLED
+		} else if (E->get() == "--format") {
+			format = true;
+#endif
 #ifdef TOOLS_ENABLED
 		} else if (E->get() == "--no-docbase") {
 			gen_flags.set_flag(DocTools::GENERATE_FLAG_SKIP_BASIC_TYPES);
@@ -3873,6 +3882,26 @@ int Main::start() {
 	if (!script.is_empty()) {
 		Ref<Script> script_res = ResourceLoader::load(script);
 		ERR_FAIL_COND_V_MSG(script_res.is_null(), EXIT_FAILURE, "Can't load script: " + script);
+
+#ifdef MODULE_GDSCRIPT_ENABLED
+		// TODO: Implement using ScriptLanguage interface to keep it script language agnostic, see https://github.com/godotengine/godot/pull/97383#discussion_r1785205514.
+		if (format) {
+			ERR_FAIL_COND_V_MSG(Ref<GDScript>(script_res).is_null(), EXIT_FAILURE, "Given script is not GDScript.");
+			if (check_only) {
+				GDScriptFormatter formatter;
+				String formattedCode;
+				if (formatter.format(script_res->get_source_code(), formattedCode) != OK)
+					return EXIT_FAILURE;
+				if (script_res->get_source_code() != formattedCode) {
+					print_line("Would reformat the script."); // TODO: Print diff.
+					return EXIT_FAILURE;
+				}
+				return EXIT_SUCCESS;
+			} else {
+				ERR_FAIL_V_MSG(EXIT_FAILURE, "Formatting in-place is not supported yet.");
+			}
+		}
+#endif
 
 		if (check_only) {
 			return script_res->is_valid() ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -595,6 +595,7 @@ public:
 	virtual Error lookup_code(const String &p_code, const String &p_symbol, const String &p_path, Object *p_owner, LookupResult &r_result) override;
 #endif
 	virtual String _get_indentation() const;
+	virtual String format_code(const String &p_code) override;
 	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) override;
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) override;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -31,6 +31,7 @@
 #include "gdscript.h"
 
 #include "gdscript_analyzer.h"
+#include "gdscript_formatter.h"
 #include "gdscript_parser.h"
 #include "gdscript_tokenizer.h"
 #include "gdscript_utility_functions.h"
@@ -3598,6 +3599,16 @@ String GDScriptLanguage::_get_indentation() const {
 	}
 #endif
 	return "\t";
+}
+
+String GDScriptLanguage::format_code(const String &p_code) {
+	GDScriptFormatter formatter;
+	String formatted_code;
+	Error err = formatter.format(p_code, formatted_code);
+	if (err == OK) {
+		return formatted_code;
+	}
+	return p_code;
 }
 
 void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_to_line) const {

--- a/modules/gdscript/gdscript_formatter.cpp
+++ b/modules/gdscript/gdscript_formatter.cpp
@@ -1,0 +1,36 @@
+/**************************************************************************/
+/*  gdscript_formatter.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_formatter.h"
+
+Error GDScriptFormatter::format(const String &p_code, String &r_formatted_code) {
+	r_formatted_code = p_code;
+	return OK;
+}

--- a/modules/gdscript/gdscript_formatter.h
+++ b/modules/gdscript/gdscript_formatter.h
@@ -1,0 +1,42 @@
+/**************************************************************************/
+/*  gdscript_formatter.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef GDSCRIPT_FORMATTER_H
+#define GDSCRIPT_FORMATTER_H
+
+#include "core/error/error_list.h"
+#include "core/string/string_name.h"
+
+class GDScriptFormatter {
+public:
+	Error format(const String &p_code, String &r_formatted_code);
+};
+
+#endif // GDSCRIPT_FORMATTER_H

--- a/modules/gdscript/tests/test_formatter.h
+++ b/modules/gdscript/tests/test_formatter.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  test_formatter.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_FORMATTER_H
+#define TEST_FORMATTER_H
+
+#include "../gdscript_formatter.h"
+
+#include "tests/test_macros.h"
+
+namespace GDScriptTests {
+
+TEST_SUITE("[Modules][GDScript][Formatter][Basic]") {
+	TEST_CASE("Formatting empty file should succeed") {
+		GDScriptFormatter formatter;
+		String code;
+		String output;
+		CHECK_EQ(formatter.format(code, output), OK);
+	}
+
+	TEST_CASE("Formatting dummy 'pass' should succeed and yield correct outcome") {
+		GDScriptFormatter formatter;
+		String code = "pass";
+		String output;
+		CHECK_EQ(formatter.format(code, output), OK);
+		CHECK_EQ(output, "pass");
+	}
+}
+} //namespace GDScriptTests
+
+#endif // TEST_FORMATTER_H


### PR DESCRIPTION
This PR is the first PR in the series of PRs aiming to implement the GDScript formatter within the engine - partially from scratch and partially by reusing https://github.com/godotengine/godot/pull/76211.

Rationale: https://github.com/godotengine/godot/pull/76211#issuecomment-1909043515

In particular, it lays the groundwork for adding GDScript formatting capability to the engine by introducing:
 - a very minimal GDScript noop formatter
 - unit tests covering noop formatter
 - ability to format the code from the editor (from the `Edit` menu or via `SHIFT+ALT+F` shortcut)
 - ability to check file formatting via commandline (e.g. using `./bin/godot.linuxbsd.editor.x86_64 --headless --format --check-only -s script.gd`

The in-editor functionality is currently hidden behind an editor setting that is disabled by default.

#### Tentative plan for followup PRs:

1. Add test runner similar to the one for parser that would be able to turn input-output GDScript file pairs (similar to [this](https://github.com/Scony/godot-gdscript-toolkit/tree/master/tests/formatter/input-output-pairs)) into tests.
2. Add the most important safety checks to the formatter:
   - correctness check that asserts the parse tree before and after formatting is the same (with some minor exceptions)
   - stability check that asserts the following - `format_code(format_code(code)) == format_code(code)` i.e. once the code is formatted, any further formatting attempt won't change the formatting
3. Extend formatter to actually format very simple statements and blocks
4. Extend formatter to preserve and format comments correctly and add comment persistence safety check
5. Extend formatter to support very simple expressions
6. Extend formatter to support basic strategies
7. (...)
8. Enable formatter by default in the builds without tests and add exposed ~editor~ project settings that can alter the formatter behavior