### PR TITLE
Add RichTextLabel theme items to adjust underline/strikethrough offset/thickness

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -825,6 +825,12 @@
 		<theme_item name="shadow_outline_size" data_type="constant" type="int" default="1">
 			The size of the shadow outline.
 		</theme_item>
+		<theme_item name="strikethrough_offset" data_type="constant" type="int" default="0">
+			The offset for the strikethrough position in pixels. Positive values move the strikethrough downwards, while negative values move it upwards.
+		</theme_item>
+		<theme_item name="strikethrough_thickness" data_type="constant" type="int" default="0">
+			The strikethrough's thickness in pixels. If set to [code]0[/code], the value from the font metadata is used instead (and is automatically scaled according to the base font size).
+		</theme_item>
 		<theme_item name="table_h_separation" data_type="constant" type="int" default="3">
 			The horizontal separation of elements in a table.
 		</theme_item>
@@ -836,6 +842,12 @@
 		</theme_item>
 		<theme_item name="text_highlight_v_padding" data_type="constant" type="int" default="3">
 			The vertical padding around boxes drawn by the [code][fgcolor][/code] and [code][bgcolor][/code] tags. This does not affect the appearance of text selection.
+		</theme_item>
+		<theme_item name="underline_offset" data_type="constant" type="int" default="0">
+			The offset for the underline position in pixels. This value is added to the underline position defined in the font metadata. Positive values move the underline downwards, while negative values move it upwards.
+		</theme_item>
+		<theme_item name="underline_thickness" data_type="constant" type="int" default="0">
+			The underline's thickness in pixels. If set to [code]0[/code], the value from the font metadata is used instead (and is automatically scaled according to the base font size).
 		</theme_item>
 		<theme_item name="bold_font" data_type="font" type="Font">
 			The font used for bold text.

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -910,8 +910,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 		RID rid = l.text_buf->get_line_rid(line);
 		double l_ascent = TS->shaped_text_get_ascent(rid);
 		Size2 l_size = TS->shaped_text_get_size(rid);
-		double upos = TS->shaped_text_get_underline_position(rid);
-		double uth = TS->shaped_text_get_underline_thickness(rid);
+		double upos = TS->shaped_text_get_underline_position(rid) + theme_cache.underline_offset;
+		double uth = theme_cache.underline_thickness ? theme_cache.underline_thickness : TS->shaped_text_get_underline_thickness(rid);
+		double sth = theme_cache.strikethrough_thickness ? theme_cache.strikethrough_thickness : TS->shaped_text_get_underline_thickness(rid);
 
 		off.y += l_ascent;
 
@@ -1108,9 +1109,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 					}
 					if (_find_strikethrough(it)) {
 						if (st_started && font_color != st_color_prev) {
-							float y_off = -l_ascent + l_size.y / 2;
-							float underline_width = MAX(1.0, uth * theme_cache.base_scale);
-							draw_line(st_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), st_color, underline_width);
+							float y_off = (-l_ascent + l_size.y / 2) + theme_cache.strikethrough_offset;
+							float strikethrough_width = MAX(1.0, sth * theme_cache.base_scale);
+							draw_line(st_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), st_color, strikethrough_width);
 							st_start = p_ofs + Vector2(off_step.x, off_step.y);
 							st_color_prev = font_color;
 							st_color = font_color;
@@ -1124,9 +1125,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 						}
 					} else if (st_started) {
 						st_started = false;
-						float y_off = -l_ascent + l_size.y / 2;
-						float underline_width = MAX(1.0, uth * theme_cache.base_scale);
-						draw_line(st_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), st_color, underline_width);
+						float y_off = (-l_ascent + l_size.y / 2) + theme_cache.strikethrough_offset;
+						float strikethrough_width = MAX(1.0, sth * theme_cache.base_scale);
+						draw_line(st_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), st_color, strikethrough_width);
 					}
 				}
 				if (step == DRAW_STEP_SHADOW || step == DRAW_STEP_OUTLINE || step == DRAW_STEP_TEXT) {
@@ -1321,9 +1322,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 							}
 							if (st_started) {
 								st_started = false;
-								float y_off = -l_ascent + l_size.y / 2;
-								float underline_width = MAX(1.0, uth * theme_cache.base_scale);
-								draw_line(st_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), st_color, underline_width);
+								float y_off = upos + theme_cache.strikethrough_offset;
+								float strikethrough_width = MAX(1.0, sth * theme_cache.base_scale);
+								draw_line(st_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), st_color, strikethrough_width);
 							}
 						}
 						off_step.x += glyphs[i].advance;
@@ -1399,9 +1400,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 				}
 				if (st_started) {
 					st_started = false;
-					float y_off = -l_ascent + l_size.y / 2;
-					float underline_width = MAX(1.0, uth * theme_cache.base_scale);
-					draw_line(st_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), st_color, underline_width);
+					float y_off = (-l_ascent + l_size.y / 2) + theme_cache.strikethrough_offset;
+					float strikethrough_width = MAX(1.0, sth * theme_cache.base_scale);
+					draw_line(st_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), st_color, strikethrough_width);
 				}
 			}
 		}
@@ -6370,6 +6371,11 @@ void RichTextLabel::_bind_methods() {
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, RichTextLabel, text_highlight_h_padding);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, RichTextLabel, text_highlight_v_padding);
+
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, RichTextLabel, underline_offset);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, RichTextLabel, underline_thickness);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, RichTextLabel, strikethrough_offset);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, RichTextLabel, strikethrough_thickness);
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, RichTextLabel, table_h_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, RichTextLabel, table_v_separation);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -662,6 +662,11 @@ private:
 		int text_highlight_h_padding;
 		int text_highlight_v_padding;
 
+		int underline_offset;
+		int underline_thickness;
+		int strikethrough_offset;
+		int strikethrough_thickness;
+
 		int table_h_separation;
 		int table_v_separation;
 		Color table_odd_row_bg;


### PR DESCRIPTION
Offsets and custom thicknesses are **not** relative to the font size. We might want to change this so that the behavior is more similar to the default, but I'm submitting this for discussion.

- This closes https://github.com/godotengine/godot-proposals/issues/10803.

**Testing project:** [test_richtextlabel_underline_strikethrough.zip](https://github.com/user-attachments/files/17104369/test_richtextlabel_underline_strikethrough.zip)

## Preview

![image](https://github.com/user-attachments/assets/cf39a06b-e361-4de5-b3e4-4ab26b93d9f1)