### PR TITLE
Fix button text autowrap overflow when inside a container

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -30,9 +30,7 @@
 
 #include "button.h"
 
-#include "core/string/translation.h"
 #include "scene/theme/theme_db.h"
-#include "servers/rendering_server.h"
 
 Size2 Button::get_minimum_size() const {
 	Ref<Texture2D> _icon = icon;
@@ -437,6 +435,9 @@ void Button::_notification(int p_what) {
 				text_buf->set_alignment(align_rtl_checked);
 
 				float text_buf_width = Math::ceil(MAX(1.0f, drawable_size_remained.width)); // The space's width filled by the text_buf.
+				if (autowrap_mode != TextServer::AUTOWRAP_OFF && !Math::is_equal_approx(text_buf_width, text_buf->get_width())) {
+					update_minimum_size();
+				}
 				text_buf->set_width(text_buf_width);
 
 				Point2 text_ofs;


### PR DESCRIPTION
Fixes #97355

The width of `Paragraph` is only set when drawing. When autowrap is enabled, a change in paragraph width changes the minimum height.

Also removed two unused header includes.