### PR TITLE
Cleanup of action map dialogs

### DIFF
--- a/modules/openxr/editor/openxr_select_action_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_action_dialog.cpp
@@ -66,7 +66,7 @@ void OpenXRSelectActionDialog::_on_select_action(const String p_action) {
 void OpenXRSelectActionDialog::open() {
 	ERR_FAIL_COND(action_map.is_null());
 
-	// out with the old...
+	// Out with the old.
 	while (main_vb->get_child_count() > 0) {
 		memdelete(main_vb->get_child(0));
 	}
@@ -74,6 +74,7 @@ void OpenXRSelectActionDialog::open() {
 	selected_action = "";
 	action_buttons.clear();
 
+	// In with the new.
 	Array action_sets = action_map->get_action_sets();
 	for (int i = 0; i < action_sets.size(); i++) {
 		Ref<OpenXRActionSet> action_set = action_sets[i];

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
@@ -66,15 +66,15 @@ void OpenXRSelectInteractionProfileDialog::_on_select_interaction_profile(const 
 void OpenXRSelectInteractionProfileDialog::open(PackedStringArray p_do_not_include) {
 	int available_count = 0;
 
-	// out with the old...
-	while (main_vb->get_child_count() > 0) {
-		memdelete(main_vb->get_child(0));
+	// Out with the old.
+	while (main_vb->get_child_count() > 1) {
+		memdelete(main_vb->get_child(1));
 	}
 
 	selected_interaction_profile = "";
 	ip_buttons.clear();
 
-	// in with the new
+	// In with the new.
 	PackedStringArray interaction_profiles = OpenXRInteractionProfileMetadata::get_singleton()->get_interaction_profile_paths();
 	for (int i = 0; i < interaction_profiles.size(); i++) {
 		const String &path = interaction_profiles[i];
@@ -82,6 +82,7 @@ void OpenXRSelectInteractionProfileDialog::open(PackedStringArray p_do_not_inclu
 			Button *ip_button = memnew(Button);
 			ip_button->set_flat(true);
 			ip_button->set_text(OpenXRInteractionProfileMetadata::get_singleton()->get_profile(path)->display_name);
+			ip_button->set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 			ip_button->connect(SceneStringName(pressed), callable_mp(this, &OpenXRSelectInteractionProfileDialog::_on_select_interaction_profile).bind(path));
 			main_vb->add_child(ip_button);
 
@@ -90,22 +91,15 @@ void OpenXRSelectInteractionProfileDialog::open(PackedStringArray p_do_not_inclu
 		}
 	}
 
-	if (available_count == 0) {
-		// give warning that we have all profiles selected
-
-	} else {
-		// TODO maybe if we only have one, auto select it?
-
-		popup_centered();
-	}
+	all_selected->set_visible(available_count == 0);
+	get_cancel_button()->set_visible(available_count > 0);
+	popup_centered();
 }
 
 void OpenXRSelectInteractionProfileDialog::ok_pressed() {
-	if (selected_interaction_profile == "") {
-		return;
+	if (selected_interaction_profile != "") {
+		emit_signal("interaction_profile_selected", selected_interaction_profile);
 	}
-
-	emit_signal("interaction_profile_selected", selected_interaction_profile);
 
 	hide();
 }
@@ -118,6 +112,10 @@ OpenXRSelectInteractionProfileDialog::OpenXRSelectInteractionProfileDialog() {
 	add_child(scroll);
 
 	main_vb = memnew(VBoxContainer);
-	// main_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	main_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	scroll->add_child(main_vb);
+
+	all_selected = memnew(Label);
+	all_selected->set_text(TTR("All interaction profiles have been added to the action map."));
+	main_vb->add_child(all_selected);
 }

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.h
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.h
@@ -51,6 +51,7 @@ private:
 
 	VBoxContainer *main_vb = nullptr;
 	ScrollContainer *scroll = nullptr;
+	Label *all_selected = nullptr;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Just a few cleanup things to improve some of the dialogs in the action map.

The add profile dialog now nicely left aligns the available profiles:
![image](https://github.com/user-attachments/assets/6b207ea4-1bbc-44f0-9ee1-1ae074cdc993)

Once all profiles are added, we're told there are no more profiles to add:
![image](https://github.com/user-attachments/assets/896ae354-a628-4137-9b77-5ec4eba07291)

*Contributed by Khronos Group through the Godot Integration Project*