### PR TITLE
Make `_make_custom_tooltip` receive raw tooltip for buttons with shortcut enabled

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -75,6 +75,7 @@
 		</member>
 		<member name="shortcut_in_tooltip" type="bool" setter="set_shortcut_in_tooltip" getter="is_shortcut_in_tooltip_enabled" default="true">
 			If [code]true[/code], the button will add information about its shortcut in the tooltip.
+			[b]Note:[/b] This property does nothing when the tooltip control is customized using [method Control._make_custom_tooltip].
 		</member>
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" default="false">
 			If [code]true[/code], the button is in toggle mode. Makes the button flip state between pressed and unpressed each time its area is clicked.

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -134,7 +134,7 @@ public:
 	void set_shortcut(const Ref<Shortcut> &p_shortcut);
 	Ref<Shortcut> get_shortcut() const;
 
-	virtual String get_tooltip(const Point2 &p_pos) const override;
+	virtual Control *make_custom_tooltip(const String &p_text) const override;
 
 	void set_button_group(const Ref<ButtonGroup> &p_group);
 	Ref<ButtonGroup> get_button_group() const;


### PR DESCRIPTION
Similar to #97265: Tooltip text can be used to pass pure data to `_make_custom_tooltip()`, so the text should not be altered before that.

This PR makes the tooltip control show shortcut info instead of adding shortcut info to the tooltip text.

Also fixed a bug that the shortcut's name is not affected by auto translation. Test project: [test-4.zip](https://github.com/user-attachments/files/17133602/test-4.zip)