### PR TITLE
[Web] Use `-Oz` instead of `-Os` when optimizing for size

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -770,8 +770,12 @@ else:
         env.Append(CCFLAGS=["-O2"])
         env.Append(LINKFLAGS=["-O2"])
     elif env["optimize"] == "size":
-        env.Append(CCFLAGS=["-Os"])
-        env.Append(LINKFLAGS=["-Os"])
+        if methods.using_emcc(env):
+            env.Append(CCFLAGS=["-Oz"])
+            env.Append(LINKFLAGS=["-Oz"])
+        else:
+            env.Append(CCFLAGS=["-Os"])
+            env.Append(LINKFLAGS=["-Os"])
     elif env["optimize"] == "debug":
         env.Append(CCFLAGS=["-Og"])
         env.Append(LINKFLAGS=["-Og"])


### PR DESCRIPTION
LLVM has an Oz optimization flag, which they define as:

`Like -Os (and thus -O2), but reduces code size further.`

I've tested this, on a release builds, and the result is ~25% smaller uncompressed size, and ~10% smaller when compressed.

I found out while evaluating the impact of LTO builds (#96851), and, while in the case of `Os` the LTO actually produces larger builds, in the case of `Oz` there is a (small) reduction in size (I'll add all the tests in #96851).

For now:

Oz, no LTO:
```
26M	lto-extract/none-oz/godot.wasm
7,0M	lto-extract/none-oz/godot.web.template_release.wasm32.nothreads.zip
```

Oz LTO:
```
24M	full-oz/godot.wasm
7,0M	full-oz/godot.web.template_release.wasm32.nothreads.zip
```

Os no LTO:
```
34M	none/godot.wasm
7,7M	none/godot.web.template_release.wasm32.nothreads.zip
```

Os LTO:
```
35M	full/godot.wasm
7,9M	full/godot.web.template_release.wasm32.nothreads.zip
```