### PR TITLE
Discard additional redo on committing actions

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -48,7 +48,7 @@ void UndoRedo::Operation::delete_reference() {
 	}
 }
 
-void UndoRedo::_discard_redo() {
+void UndoRedo::discard_redo() {
 	if (current_action == actions.size() - 1) {
 		return;
 	}
@@ -89,7 +89,7 @@ void UndoRedo::create_action(const String &p_name, MergeMode p_mode, bool p_back
 	uint64_t ticks = OS::get_singleton()->get_ticks_msec();
 
 	if (action_level == 0) {
-		_discard_redo();
+		discard_redo();
 
 		// Check if the merge operation is valid
 		if (p_mode != MERGE_DISABLE && actions.size() && actions[actions.size() - 1].name == p_name && actions[actions.size() - 1].backward_undo_ops == p_backward_undo_ops && actions[actions.size() - 1].last_tick + 800 > ticks) {
@@ -288,7 +288,7 @@ void UndoRedo::end_force_keep_in_merge_ends() {
 }
 
 void UndoRedo::_pop_history_tail() {
-	_discard_redo();
+	discard_redo();
 
 	if (!actions.size()) {
 		return;
@@ -455,7 +455,7 @@ String UndoRedo::get_action_name(int p_id) {
 
 void UndoRedo::clear_history(bool p_increase_version) {
 	ERR_FAIL_COND(action_level > 0);
-	_discard_redo();
+	discard_redo();
 
 	while (actions.size()) {
 		_pop_history_tail();

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -129,6 +129,7 @@ public:
 	int get_current_action();
 	String get_action_name(int p_id);
 	void clear_history(bool p_increase_version = true);
+	void discard_redo();
 
 	bool has_undo() const;
 	bool has_redo() const;

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -264,6 +264,22 @@ void EditorUndoRedoManager::commit_action(bool p_execute) {
 		history.undo_stack.push_back(pending_action);
 	}
 
+	if (history.id != GLOBAL_HISTORY) {
+		// Clear global redo, to avoid unexpected actions when redoing.
+		History &global = get_or_create_history(GLOBAL_HISTORY);
+		global.redo_stack.clear();
+		global.undo_redo->discard_redo();
+	} else {
+		// On global actions, clear redo of all scenes instead.
+		for (KeyValue<int, History> &E : history_map) {
+			if (E.key == GLOBAL_HISTORY) {
+				continue;
+			}
+			E.value.redo_stack.clear();
+			E.value.undo_redo->discard_redo();
+		}
+	}
+
 	pending_action = Action();
 	is_committing = false;
 	emit_signal(SNAME("history_changed"));


### PR DESCRIPTION
Fixes #97376
When doing scene operation, global redo is discarded.
When doing global operation, all scenes' redo is discarded.