### PR TITLE
Fix editing of some properties in `CodeHighlighter`

### DIFF
--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -442,7 +442,6 @@ Color CodeHighlighter::get_keyword_color(const String &p_keyword) const {
 }
 
 void CodeHighlighter::set_keyword_colors(const Dictionary p_keywords) {
-	keywords.clear();
 	keywords = p_keywords;
 	clear_highlighting_cache();
 }
@@ -476,7 +475,6 @@ Color CodeHighlighter::get_member_keyword_color(const String &p_member_keyword) 
 }
 
 void CodeHighlighter::set_member_keyword_colors(const Dictionary &p_member_keywords) {
-	member_keywords.clear();
 	member_keywords = p_member_keywords;
 	clear_highlighting_cache();
 }


### PR DESCRIPTION
Unforeseen regression from:
* https://github.com/godotengine/godot/pull/88231

These clear operations serve little direct purpose and break editing, while there might be some way to handle the editing of the dictionary differently there's no reason for these clears, and it solves the underlying issue.

* Fixes: https://github.com/godotengine/godot/issues/97411
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
