### PR TITLE
Check RenderingDevice availability to display LightmapGI configuration warnings

### DIFF
--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -179,6 +179,23 @@ LightmapGIEditorPlugin::LightmapGIEditorPlugin() {
 	// when the editor theme updates.
 	bake->set_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("Bake"), EditorStringName(EditorIcons)));
 	bake->set_text(TTR("Bake Lightmaps"));
+
+#ifdef MODULE_LIGHTMAPPER_RD_ENABLED
+	// Disable lightmap baking if not supported on the current GPU.
+	if (!DisplayServer::get_singleton()->can_create_rendering_device()) {
+		bake->set_disabled(true);
+		bake->set_tooltip_text(vformat(TTR("Lightmap baking is not supported on this GPU (%s)."), RenderingServer::get_singleton()->get_video_adapter_name()));
+	}
+#else
+	// Disable lightmap baking if the module is disabled at compile-time.
+	bake->set_disabled(true);
+#if defined(ANDROID_ENABLED) || defined(IOS_ENABLED)
+	bake->set_tooltip_text(vformat(TTR("Lightmaps cannot be baked on %s."), OS::get_singleton()->get_name()));
+#else
+	bake->set_tooltip_text(TTR("Lightmaps cannot be baked, as the `lightmapper_rd` module was disabled at compile-time."));
+#endif
+#endif // MODULE_LIGHTMAPPER_RD_ENABLED
+
 	bake->hide();
 	bake->connect(SceneStringName(pressed), Callable(this, "_bake"));
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, bake);

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1602,8 +1602,17 @@ Ref<CameraAttributes> LightmapGI::get_camera_attributes() const {
 PackedStringArray LightmapGI::get_configuration_warnings() const {
 	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
 
-	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
-		warnings.push_back(RTR("Lightmap can only be baked from a device that supports the RD backends. Lightmap baking may fail."));
+#ifndef MODULE_LIGHTMAPPER_RD_ENABLED
+#if defined(ANDROID_ENABLED) || defined(IOS_ENABLED)
+	warnings.push_back(vformat(RTR("Lightmaps cannot be baked on %s. Rendering existing baked lightmaps will still work."), OS::get_singleton()->get_name()));
+#else
+	warnings.push_back(RTR("Lightmaps cannot be baked, as the `lightmapper_rd` module was disabled at compile-time. Rendering existing baked lightmaps will still work."));
+#endif
+	return warnings;
+#endif
+
+	if (!DisplayServer::get_singleton()->can_create_rendering_device()) {
+		warnings.push_back(vformat(RTR("Lightmaps can only be baked from a GPU that supports the RenderingDevice backends.\nYour GPU (%s) does not support RenderingDevice, as it does not support Vulkan, Direct3D 12, or Metal.\nLightmap baking will not be available on this device, although rendering existing baked lightmaps will work."), RenderingServer::get_singleton()->get_video_adapter_name()));
 		return warnings;
 	}
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/87386
and https://github.com/godotengine/godot/pull/91172.

We can now check whether RenderingDevice can be created (which is not guaranteed when using the Compatibility rendering method), so the warning can be displayed only when relevant.

This also disables the Bake Lightmaps button with a tooltip if baking is not available.

## Preview

*Ignore the GPU model name (it obviously supports Vulkan), I just changed the condition to get the dialog to show up.*

![Screenshot_20240924_184651](https://github.com/user-attachments/assets/8506ff78-c30f-4f41-95ee-b5134a5ec6f0)

**Edit:** Now displays dedicated warnings if `lightmapper_rd` was disabled at compile-time, including a specific message for mobile platforms.

![Screenshot_20240928_233734](https://github.com/user-attachments/assets/0de7c899-4317-464f-accd-7a84bfb0da13)

![Screenshot_20240928_234202](https://github.com/user-attachments/assets/fb6ad419-31f9-4d99-9b8b-2f8b5a2e8bd9)
