### PR TITLE
Fix Material storage dev-asserts on shutdown if it has pending updates.

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1506,6 +1506,8 @@ MaterialStorage::~MaterialStorage() {
 	memdelete_arr(global_shader_uniforms.buffer_dirty_regions);
 	glDeleteBuffers(1, &global_shader_uniforms.buffer);
 
+	material_update_list.clear();
+
 	singleton = nullptr;
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -1180,6 +1180,8 @@ MaterialStorage::~MaterialStorage() {
 	//def samplers
 	samplers_rd_free(default_samplers);
 
+	material_update_list.clear();
+
 	singleton = nullptr;
 }
 


### PR DESCRIPTION
This is caused by Material's SelfList not being emptied, hitting the dev assert in SelfList::List::~List().