### PR TITLE
[.Net] Add Reminder for External Node Types

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Inspector/ExternalTypeReminder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Inspector/ExternalTypeReminder.cs
@@ -1,0 +1,35 @@
+using Godot;
+using GodotTools.Internals;
+
+namespace GodotTools.Inspector;
+
+public partial class ExternalTypeReminder : HBoxContainer
+{
+    public override void _Ready()
+    {
+        SetAnchorsPreset(LayoutPreset.TopWide);
+
+        var iconTexture = GetThemeIcon("NodeInfo", "EditorIcons");
+
+        var icon = new TextureRect()
+        {
+            Texture = iconTexture,
+            ExpandMode = TextureRect.ExpandModeEnum.FitWidthProportional,
+            CustomMinimumSize = iconTexture.GetSize(),
+        };
+
+        icon.SizeFlagsVertical = SizeFlags.ShrinkCenter;
+
+        var label = new Label()
+        {
+            Text = "This inspector inherits an external type. Please build the C# project when the external type changes.".TTR(),
+            AutowrapMode = TextServer.AutowrapMode.WordSmart,
+            CustomMinimumSize = new Vector2(100f, 0f),
+        };
+
+        label.SizeFlagsHorizontal = SizeFlags.Fill | SizeFlags.Expand;
+
+        AddChild(icon);
+        AddChild(label);
+    }
+}

--- a/modules/mono/editor/GodotTools/GodotTools/Inspector/InspectorPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Inspector/InspectorPlugin.cs
@@ -31,9 +31,9 @@ namespace GodotTools.Inspector
 
                 if (string.IsNullOrEmpty(scriptPath))
                 {
-                    // Generic types used empty paths in older versions of Godot
-                    // so we assume your project is out of sync.
-                    AddCustomControl(new InspectorOutOfSyncWarning());
+                    // Types from an external source (PackageReference or ProjectReference)
+                    // uses empty paths, in such case we do not show out of sync warning.
+                    AddCustomControl(new ExternalTypeReminder());
                     break;
                 }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -217,7 +217,6 @@ namespace Godot.Bridge
             // not a global class. But if the script is not a global class it must return an empty
             // outClassName string since it should not have a name.
             string scriptPathStr = Marshaling.ConvertStringToManaged(*scriptPath);
-            Debug.Assert(!string.IsNullOrEmpty(scriptPathStr), "Script path can't be empty.");
 
             if (!_pathTypeBiMap.TryGetScriptType(scriptPathStr, out Type? scriptType))
             {


### PR DESCRIPTION
Before this pull request, Godot always considered user scripts as `legacy generic type` if they didn't have a `scriptPath` and will display 'out of sync' warnings for them.

However, this is also true for user scripts that inherit external C# projects or NuGet package types.

This PR removes the `DebugAssert` on the empty `scriptPath` check and implements a separate reminder message for the user script when it inherits an external type.

**Before**

[![image](https://github.com/user-attachments/assets/af64abb6-81f1-427b-94b9-bdc08d73442b)](https://github.com/user-attachments/assets/291cc0db-0cc0-4ada-86ab-b0d64b822cc7)

**After**

https://github.com/user-attachments/assets/3e896c95-8c39-47cd-ad12-4978fc611170

**MRP**

[MRP_Script_Path.zip](https://github.com/user-attachments/files/17113697/MRP_Script_Path.zip)

Closes #97405 
Closes #88536 