### PR TITLE
Fix renaming nodes on X11

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -2998,11 +2998,7 @@ bool DisplayServerX11::window_is_focused(WindowID p_window) const {
 
 	const WindowData &wd = windows[p_window];
 
-	Window focused_window;
-	int focus_ret_state;
-	XGetInputFocus(x11_display, &focused_window, &focus_ret_state);
-
-	return wd.x11_window == focused_window;
+	return wd.focused;
 }
 
 bool DisplayServerX11::window_can_draw(WindowID p_window) const {
@@ -3050,7 +3046,7 @@ void DisplayServerX11::window_set_ime_active(const bool p_active, WindowID p_win
 		XWindowAttributes xwa;
 		XSync(x11_display, False);
 		XGetWindowAttributes(x11_display, wd.x11_xim_window, &xwa);
-		if (xwa.map_state == IsViewable) {
+		if (xwa.map_state == IsViewable && _window_focus_check()) {
 			_set_input_focus(wd.x11_xim_window, RevertToParent);
 		}
 		XSetICFocus(wd.xic);
@@ -4319,7 +4315,7 @@ bool DisplayServerX11::_window_focus_check() {
 
 	bool has_focus = false;
 	for (const KeyValue<int, DisplayServerX11::WindowData> &wid : windows) {
-		if (wid.value.x11_window == focused_window) {
+		if (wid.value.x11_window == focused_window || (wid.value.xic && wid.value.ime_active && wid.value.x11_xim_window == focused_window)) {
 			has_focus = true;
 			break;
 		}

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -103,7 +103,7 @@ void LineEdit::_close_ime_window() {
 
 void LineEdit::_update_ime_window_position() {
 	DisplayServer::WindowID wid = get_window() ? get_window()->get_window_id() : DisplayServer::INVALID_WINDOW_ID;
-	if (wid == DisplayServer::INVALID_WINDOW_ID || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME) || !DisplayServer::get_singleton()->window_is_focused(wid)) {
+	if (wid == DisplayServer::INVALID_WINDOW_ID || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 		return;
 	}
 	DisplayServer::get_singleton()->window_set_ime_active(true, wid);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2958,7 +2958,7 @@ void TextEdit::_close_ime_window() {
 
 void TextEdit::_update_ime_window_position() {
 	DisplayServer::WindowID wid = get_window() ? get_window()->get_window_id() : DisplayServer::INVALID_WINDOW_ID;
-	if (wid == DisplayServer::INVALID_WINDOW_ID || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME) || !DisplayServer::get_singleton()->window_is_focused(wid)) {
+	if (wid == DisplayServer::INVALID_WINDOW_ID || !DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_IME)) {
 		return;
 	}
 	DisplayServer::get_singleton()->window_set_ime_active(true, wid);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/97211

This effectively reverts PR https://github.com/godotengine/godot/pull/93682 and PR https://github.com/godotengine/godot/pull/96829, and takes a completely different approach at fixing issue https://github.com/godotengine/godot/issues/88847.

The fix here is much simpler. It looks like the issue with `_window_focus_check()` in that case was just that we were only checking if the main windows had input focus, but weren't also checking the XIM windows.

I've tested this on:

- i3 (on both Ubuntu 22.04 and Fedora 40)
- GNOME (both XOrg and XWayland on Fedora 40)

Testing the following issues / use cases

- Switching focus away from the project manager (was issue https://github.com/godotengine/godot/issues/95824)
- Renaming nodes in the scene tree via F2 (was issue https://github.com/godotengine/godot/issues/97211)
- Opening "Find in Files" via CTRL+SHIFT+F (was issue https://github.com/godotengine/godot/issues/88847)
- Pressing F1 while in the code editor (was brought up on PR https://github.com/godotengine/godot/pull/96829)

I'm going to try to get an environment going to test XFCE (for testing issue https://github.com/godotengine/godot/issues/74378) and KDE as well. If anyone else has access to another environment help testing would be appreciated!