### PR TITLE
[GraphEdit] Make connections a property

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -130,8 +130,10 @@
 			<param index="1" name="from_port" type="int" />
 			<param index="2" name="to_node" type="StringName" />
 			<param index="3" name="to_port" type="int" />
+			<param index="4" name="keep_alive" type="bool" default="false" />
 			<description>
 				Create a connection between the [param from_port] of the [param from_node] [GraphNode] and the [param to_port] of the [param to_node] [GraphNode]. If the connection already exists, no connection is created.
+				Connections with [param keep_alive] set to [code]false[/code] may be deleted automatically if invalid during a redraw.
 			</description>
 		</method>
 		<method name="detach_graph_element_from_frame">
@@ -172,7 +174,16 @@
 			<param index="1" name="max_distance" type="float" default="4.0" />
 			<description>
 				Returns the closest connection to the given point in screen space. If no connection is found within [param max_distance] pixels, an empty [Dictionary] is returned.
-				A connection consists in a structure of the form [code]{ from_port: 0, from_node: "GraphNode name 0", to_port: 1, to_node: "GraphNode name 1" }[/code].
+				A connection is represented as a [Dictionary] in the form of:
+				[codeblock]
+				{
+				    from_node: StringName,
+				    from_port: int,
+				    to_node: StringName,
+				    to_port: int,
+				    keep_alive: bool
+				}
+				[/codeblock]
 				For example, getting a connection at a given mouse position can be achieved like this:
 				[codeblocks]
 				[gdscript]
@@ -197,17 +208,21 @@
 				Returns the points which would make up a connection between [param from_node] and [param to_node].
 			</description>
 		</method>
-		<method name="get_connection_list" qualifiers="const">
-			<return type="Dictionary[]" />
-			<description>
-				Returns an [Array] containing the list of connections. A connection consists in a structure of the form [code]{ from_port: 0, from_node: "GraphNode name 0", to_port: 1, to_node: "GraphNode name 1" }[/code].
-			</description>
-		</method>
 		<method name="get_connections_intersecting_with_rect" qualifiers="const">
 			<return type="Dictionary[]" />
 			<param index="0" name="rect" type="Rect2" />
 			<description>
-				Returns an [Array] containing the list of connections that intersect with the given [Rect2]. A connection consists in a structure of the form [code]{ from_port: 0, from_node: "GraphNode name 0", to_port: 1, to_node: "GraphNode name 1" }[/code].
+				Returns an [Array] containing the list of connections that intersect with the given [Rect2].
+				A connection is represented as a [Dictionary] in the form of:
+				[codeblock]
+				{
+				    from_node: StringName,
+				    from_port: int,
+				    to_node: StringName,
+				    to_port: int,
+				    keep_alive: bool
+				}
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_element_frame">
@@ -295,6 +310,20 @@
 		</member>
 		<member name="connection_lines_thickness" type="float" setter="set_connection_lines_thickness" getter="get_connection_lines_thickness" default="4.0">
 			The thickness of the lines between the nodes.
+		</member>
+		<member name="connections" type="Dictionary[]" setter="set_connections" getter="get_connection_list" default="[]">
+			The connections between [GraphNode]s.
+			A connection is represented as a [Dictionary] in the form of:
+			[codeblock]
+			{
+			    from_node: StringName,
+			    from_port: int,
+			    to_node: StringName,
+			    to_port: int,
+			    keep_alive: bool
+			}
+			[/codeblock]
+			Connections with [code]keep_alive[/code] set to [code]false[/code] may be deleted automatically if invalid during a redraw.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="grid_pattern" type="int" setter="set_grid_pattern" getter="get_grid_pattern" enum="GraphEdit.GridPattern" default="0">

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -236,3 +236,10 @@ Validate extension JSON: Error: Field 'classes/EditorInterface/methods/open_scen
 
 Added optional argument to open_scene_from_path to create a new inherited scene.
 Compatibility method registered.
+
+
+GH-97449
+--------
+Validate extension JSON: Error: Field 'classes/GraphEdit/methods/connect_node/arguments': size changed value in new API, from 4 to 5.
+
+Added optional argument to connect_node to specify whether the connection should be automatically deleted if invalid. Compatibility method registered.

--- a/scene/gui/graph_edit.compat.inc
+++ b/scene/gui/graph_edit.compat.inc
@@ -42,10 +42,15 @@ PackedVector2Array GraphEdit::_get_connection_line_bind_compat_86158(const Vecto
 	return get_connection_line(p_from, p_to);
 }
 
+Error GraphEdit::_connect_node_bind_compat_97449(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port) {
+	return connect_node(p_from, p_from_port, p_to, p_to_port);
+}
+
 void GraphEdit::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("is_arrange_nodes_button_hidden"), &GraphEdit::_is_arrange_nodes_button_hidden_bind_compat_81582);
 	ClassDB::bind_compatibility_method(D_METHOD("set_arrange_nodes_button_hidden", "enable"), &GraphEdit::_set_arrange_nodes_button_hidden_bind_compat_81582);
 	ClassDB::bind_compatibility_method(D_METHOD("get_connection_line", "from_node", "to_node"), &GraphEdit::_get_connection_line_bind_compat_86158);
+	ClassDB::bind_compatibility_method(D_METHOD("connect_node", "from_node", "from_port", "to_node", "to_port"), &GraphEdit::_connect_node_bind_compat_97449);
 }
 
 #endif

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -120,6 +120,7 @@ public:
 		int from_port = 0;
 		int to_port = 0;
 		float activity = 0.0;
+		bool keep_alive = true;
 
 	private:
 		struct Cache {
@@ -238,7 +239,7 @@ private:
 	bool updating = false;
 	bool awaiting_scroll_offset_update = false;
 
-	List<Ref<Connection>> connections;
+	Vector<Ref<Connection>> connections;
 	HashMap<StringName, List<Ref<Connection>>> connection_map;
 	Ref<Connection> hovered_connection;
 
@@ -339,6 +340,7 @@ private:
 
 	bool is_in_port_hotzone(const Vector2 &p_pos, const Vector2 &p_mouse_pos, const Vector2i &p_port_size, bool p_left);
 
+	void set_connections(const TypedArray<Dictionary> &p_connections);
 	TypedArray<Dictionary> _get_connection_list() const;
 	Dictionary _get_closest_connection_at_point(const Vector2 &p_point, float p_max_distance = 4.0) const;
 	TypedArray<Dictionary> _get_connections_intersecting_with_rect(const Rect2 &p_rect) const;
@@ -362,6 +364,7 @@ private:
 	bool _is_arrange_nodes_button_hidden_bind_compat_81582() const;
 	void _set_arrange_nodes_button_hidden_bind_compat_81582(bool p_enable);
 	PackedVector2Array _get_connection_line_bind_compat_86158(const Vector2 &p_from, const Vector2 &p_to);
+	Error _connect_node_bind_compat_97449(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 #endif
 
 protected:
@@ -397,14 +400,14 @@ public:
 	void _update_graph_frame(GraphFrame *p_frame);
 
 	// Connection related methods.
-	Error connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
+	Error connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port, bool keep_alive = false);
 	bool is_node_connected(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	int get_connection_count(const StringName &p_node, int p_port);
 	void disconnect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
-	void clear_connections();
 
 	void force_connection_drag_end();
-	const List<Ref<Connection>> &get_connection_list() const;
+	const Vector<Ref<Connection>> &get_connections() const;
+	void clear_connections();
 	virtual PackedVector2Array get_connection_line(const Vector2 &p_from, const Vector2 &p_to) const;
 	Ref<Connection> get_closest_connection_at_point(const Vector2 &p_point, float p_max_distance = 4.0) const;
 	List<Ref<Connection>> get_connections_intersecting_with_rect(const Rect2 &p_rect) const;

--- a/scene/gui/graph_edit_arranger.cpp
+++ b/scene/gui/graph_edit_arranger.cpp
@@ -65,7 +65,7 @@ void GraphEditArranger::arrange_nodes() {
 	float gap_v = 100.0f;
 	float gap_h = 100.0f;
 
-	List<Ref<GraphEdit::Connection>> connection_list = graph_edit->get_connection_list();
+	const Vector<Ref<GraphEdit::Connection>> connection_list = graph_edit->get_connections();
 
 	for (int i = graph_edit->get_child_count() - 1; i >= 0; i--) {
 		GraphNode *graph_element = Object::cast_to<GraphNode>(graph_edit->get_child(i));
@@ -438,7 +438,7 @@ float GraphEditArranger::_calculate_threshold(const StringName &p_v, const Strin
 	if (p_v == p_w) {
 		int min_order = MAX_ORDER;
 		Ref<GraphEdit::Connection> incoming;
-		List<Ref<GraphEdit::Connection>> connection_list = graph_edit->get_connection_list();
+		const Vector<Ref<GraphEdit::Connection>> connection_list = graph_edit->get_connections();
 		for (const Ref<GraphEdit::Connection> &connection : connection_list) {
 			if (connection->to_node == p_w) {
 				ORDER(connection->from_node, r_layers);
@@ -469,7 +469,7 @@ float GraphEditArranger::_calculate_threshold(const StringName &p_v, const Strin
 		// This time, pick an outgoing edge and repeat as above!
 		int min_order = MAX_ORDER;
 		Ref<GraphEdit::Connection> outgoing;
-		List<Ref<GraphEdit::Connection>> connection_list = graph_edit->get_connection_list();
+		const Vector<Ref<GraphEdit::Connection>> connection_list = graph_edit->get_connections();
 		for (const Ref<GraphEdit::Connection> &connection : connection_list) {
 			if (connection->from_node == p_w) {
 				ORDER(connection->to_node, r_layers);


### PR DESCRIPTION
Fixes #97015
After investigating the issue above, I found no obvious reasons why connections shouldn't be a property.

**Main changes:**
- The connections array is now a property and can be modified via the inspector (although that is a bit finicky due to the fact that dead/invalid connections are removed after each update, so can't add connections right now through the inspector). This means connections are now properly serialized/deserialized.

**Additional refactoring/optimization:**
- Use `Vector` instead of `List` internally for connections (this also removes unreadable list element access, e.g. E->get()->...)
- Make names of local variables of type `Ref<Connection>` consistent (`c` -> `conn`)
- Method declaration order

Note: In order to avoid breaking compatibility, I kept the name `get_connection_list` (just for scripting), but since this name is kind of weird and GraphEdit is still experimental we could change it for consistency.