### PR TITLE
Document `SceneTree.reload_current_scene` effect on resources

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -190,6 +190,7 @@
 			<description>
 				Reloads the currently active scene, replacing [member current_scene] with a new instance of its original [PackedScene].
 				Returns [constant OK] on success, [constant ERR_UNCONFIGURED] if no [member current_scene] is defined, [constant ERR_CANT_OPEN] if [member current_scene] cannot be loaded into a [PackedScene], or [constant ERR_CANT_CREATE] if the scene cannot be instantiated.
+				[b]Note:[/b] References to external [RefCounted] objects will not decreased during the process. This means that [Resource]s will not be removed from the cache and reloaded unless [member Resource.resource_local_to_scene] is [code]true[/code].
 			</description>
 		</method>
 		<method name="set_group">


### PR DESCRIPTION
`SceneTree.reload_current_scene` instantiates the new scene while the previous is still in memory so references to `RefCounted` objects (not just `Resource`s) will not be decreased during the process. If the scene is the unique holder of a reference, like in the case of a resource, we would expect it to be freed but this is not the case.

Documents https://github.com/godotengine/godot/issues/97361