### PR TITLE
Make pressing Enter confirm project creation/import in the project manager

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -1024,8 +1024,14 @@ ProjectDialog::ProjectDialog() {
 	add_child(fdialog_install);
 
 	project_name->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_project_name_changed).unbind(1));
+	project_name->connect(SceneStringName(text_submitted), callable_mp(this, &ProjectDialog::ok_pressed).unbind(1));
+
 	project_path->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_project_path_changed).unbind(1));
+	project_path->connect(SceneStringName(text_submitted), callable_mp(this, &ProjectDialog::ok_pressed).unbind(1));
+
 	install_path->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_install_path_changed).unbind(1));
+	install_path->connect(SceneStringName(text_submitted), callable_mp(this, &ProjectDialog::ok_pressed).unbind(1));
+
 	fdialog_install->connect("dir_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
 	fdialog_install->connect("file_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
 

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -141,5 +141,6 @@ SceneStringNames::SceneStringNames() {
 	confirmed = StaticCString::create("confirmed");
 
 	text_changed = StaticCString::create("text_changed");
+	text_submitted = StaticCString::create("text_submitted");
 	value_changed = StaticCString::create("value_changed");
 }

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -154,6 +154,7 @@ public:
 	StringName confirmed;
 
 	StringName text_changed;
+	StringName text_submitted;
 	StringName value_changed;
 };
 


### PR DESCRIPTION
This makes the project manager more friendly to keyboard usage.

You can now create projects more easily without touching the mouse by opening the project manager, pressing <kbd>Ctrl + N</kbd> (shortcut for the **Create** button), entering a project name and pressing <kbd>Enter</kbd>.