### PR TITLE
Optimized shrink options to binaryen wasm-opt pass

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -285,6 +285,9 @@ def configure(env: "SConsEnvironment"):
     env.Append(CCFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
     env.Append(LINKFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
 
+    # Run wasm-opt binaryen maximum shrink options
+    env.Append(LINKFLAGS=["-sBINARYEN_EXTRA_PASSES='-Oz'"])
+
     # Allow increasing memory buffer size during runtime. This is efficient
     # when using WebAssembly (in comparison to asm.js) and works well for
     # us since we don't know requirements at compile-time.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Alternative to https://github.com/godotengine/godot/pull/97407 which runs wasm-opt with maximum shrink-level (2) / Oz.