### PR TITLE
[SCons] Remove MAXLINELENGTH override for MSVC

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -390,8 +390,6 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
         env.AppendUnique(CPPDEFINES=["R128_STDC_ONLY"])
         env.extra_suffix = ".llvm" + env.extra_suffix
 
-    env["MAXLINELENGTH"] = 8192  # Windows Vista and beyond, so always applicable.
-
     if env["silence_msvc"] and not env.GetOption("clean"):
         from tempfile import mkstemp
 


### PR DESCRIPTION
It's not clear what is the actual max value that Windows support, but despite their claim of it being 8191 we have been seeing failure with just 8150.
