### PR TITLE
Add a new pre-commit step: `comment_style`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,6 +161,12 @@ repos:
         files: \.(h|hpp|hh|hxx)$
         exclude: ^.*/(thread|platform_config|platform_gl)\.h$
 
+      - id: comment-style
+        name: comment-style
+        language: python
+        entry: python misc/scripts/comment_style.py
+        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm)$
+
       - id: file-format
         name: file-format
         language: python

--- a/misc/scripts/comment_style.py
+++ b/misc/scripts/comment_style.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import re
+import sys
+
+if len(sys.argv) < 2:
+    print("Invalid usage of comment_style.py, it should be called with a path to one or multiple files.")
+    sys.exit(1)
+
+IS_COMMENT = re.compile(r"// .*?\w")
+CARET_COMMENT = re.compile(r"// *\^")
+PLUS_COMMENT = re.compile(r"// *\+")
+COMMENTS_TO_SKIP = [CARET_COMMENT, PLUS_COMMENT]
+
+fixes = []
+
+for file in sys.argv[1:]:
+    with open(file.strip(), "rt", encoding="utf-8", newline="\n") as f:
+        lines = f.readlines()
+
+    for idx, line in enumerate(lines):
+        sline = line.strip()
+        m = IS_COMMENT.match(sline)
+        if m is not None:
+            # Check if we should skip this comment
+            if any(regex.match(sline) is not None for regex in COMMENTS_TO_SKIP):
+                continue
+
+            # If the next line is also a comment it's hard to know if a `.` is needed, so it's better to skip it
+            # and let a reviewer catch it
+            if (idx + 1) < len(lines) and IS_COMMENT.match(lines[idx + 1]) is not None:
+                continue
+
+            # It's a comment, check if ends with any of this characters
+            if not sline.endswith((".", ":", ",", ";")):
+                # Files are not 0 indexed
+                fixes.append((file, idx + 1, sline, sline + "."))
+
+if fixes:
+    for fix in fixes:
+        file, idx, line_with_error, line_fixed = fix
+        print(f"REQUIRES MANUAL CHANGES: {file}:{idx}")
+        print(f"- {line_with_error}")
+        print(f"+ {line_fixed}")
+    sys.exit(1)

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -37,6 +37,7 @@
 
 namespace TestString {
 
+// lala
 int u32scmp(const char32_t *l, const char32_t *r) {
 	for (; *l == *r && *l && *r; l++, r++) {
 		// Continue.


### PR DESCRIPTION
Add a new pre-commit step: `comment_style`
This new pre-commit step aims to check and fail on some cases in which a comment doesn't end with a period.

@AThousandShips this is my humble attempt to make you happier because you don't need to add comments to my PRs mentioning that I should add a period at the end of my comments.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
