### PR TITLE
[3.x] Backport "Cleanup function state connections when destroying instance" for Godot 3

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -83,7 +83,12 @@ void GDScript::_clear_pending_func_states() {
 		// Order matters since clearing the stack may already cause
 		// the GDSCriptFunctionState to be destroyed and thus removed from the list.
 		pending_func_states.remove(E);
-		E->self()->_clear_stack();
+		GDScriptFunctionState *state = E->self();
+		ObjectID state_id = state->get_instance_id();
+		state->_clear_connections();
+		if (ObjectDB::get_instance(state_id)) {
+			state->_clear_stack();
+		}
 	}
 	GDScriptLanguage::get_singleton()->lock.unlock();
 }
@@ -1372,7 +1377,12 @@ GDScriptInstance::~GDScriptInstance() {
 		// Order matters since clearing the stack may already cause
 		// the GDSCriptFunctionState to be destroyed and thus removed from the list.
 		pending_func_states.remove(E);
-		E->self()->_clear_stack();
+		GDScriptFunctionState *state = E->self();
+		ObjectID state_id = state->get_instance_id();
+		state->_clear_connections();
+		if (ObjectDB::get_instance(state_id)) {
+			state->_clear_stack();
+		}
 	}
 
 	if (script.is_valid() && owner) {

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1855,6 +1855,15 @@ void GDScriptFunctionState::_clear_stack() {
 	}
 }
 
+void GDScriptFunctionState::_clear_connections() {
+	List<Object::Connection> conns;
+	get_signals_connected_to_this(&conns);
+	for (List<Object::Connection>::Element *E = conns.front(); E; E = E->next()) {
+		Object::Connection &c = E->get();
+		c.source->disconnect(c.signal, c.target, c.method);
+	}
+}
+
 void GDScriptFunctionState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("resume", "arg"), &GDScriptFunctionState::resume, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("is_valid", "extended_check"), &GDScriptFunctionState::is_valid, DEFVAL(false));

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -375,6 +375,7 @@ public:
 	Variant resume(const Variant &p_arg = Variant());
 
 	void _clear_stack();
+	void _clear_connections();
 
 	GDScriptFunctionState();
 	~GDScriptFunctionState();


### PR DESCRIPTION
This PR back-ports #65910 to make sure objects with pending `yield` request on signals disconnect. This should be a direct translation of the Godot 4 code.

I believe this closes the following:
- closes #74695
- closes #47703
- closes #71998 