### PR TITLE
Improve quality of mesh and material resource previews in the editor

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -362,6 +362,9 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_DISABLED);
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
 	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
+	// Use 4× MSAA and 4× SSAA to avoid aliasing on edges and improve texture quality, which helps with thumbnail recognition.
+	RS::get_singleton()->viewport_set_msaa_3d(viewport, RenderingServer::VIEWPORT_MSAA_4X);
+	RS::get_singleton()->viewport_set_scaling_3d_scale(viewport, 2.0);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
@@ -786,6 +789,9 @@ EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_DISABLED);
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
 	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
+	// Use 4× MSAA and 4× SSAA to avoid aliasing on edges and improve texture quality, which helps with thumbnail recognition.
+	RS::get_singleton()->viewport_set_msaa_3d(viewport, RenderingServer::VIEWPORT_MSAA_4X);
+	RS::get_singleton()->viewport_set_scaling_3d_scale(viewport, 2.0);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);


### PR DESCRIPTION
This uses a combination of MSAA and SSAA to make thumbnails smoother while also improving texture sampling quality[^1]. Thumbnail generation time is largely unaffected since most of the time is spent doing things on the CPU anyway, and the thumbnail resolution is still 128×128 (although the 3D buffer is internally 256×256 now).

[^1]: Texture sampling improves thanks to SSAA, which works on textures that are viewed from any angle, including head-on angles (something anisotropic filtering cannot handle).

Tested in all rendering methods.

## Preview

### Mesh

Before | After
-|-
![Before](https://github.com/user-attachments/assets/4047d845-0947-4597-927f-1c17842f758e) | ![After](https://github.com/user-attachments/assets/8a173be0-e03a-4083-a199-a23c15d50e61)

### Material

Before | After
-|-
![Before](https://github.com/user-attachments/assets/02617c27-ef74-43c4-8a67-4966e75a521d) | ![After](https://github.com/user-attachments/assets/a8777e26-4c9b-46cb-a01a-889e9eea02a5)


At 200% editor scale, thumbnails can look really clean now:

![Screenshot_20240925_234506](https://github.com/user-attachments/assets/cc2cb757-5afd-4925-8e4b-f7f9ea45acc6)

