### PR TITLE
Remove verbose prints from CameraServer on Linux due to being printed every second

### DIFF
--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -134,17 +134,14 @@ bool CameraLinux::_is_video_capture_device(int p_file_descriptor) {
 	struct v4l2_capability capability;
 
 	if (ioctl(p_file_descriptor, VIDIOC_QUERYCAP, &capability) == -1) {
-		print_verbose("Cannot query device");
 		return false;
 	}
 
 	if (!(capability.capabilities & V4L2_CAP_VIDEO_CAPTURE)) {
-		print_verbose(vformat("%s is no video capture device\n", String((char *)capability.card)));
 		return false;
 	}
 
 	if (!(capability.capabilities & V4L2_CAP_STREAMING)) {
-		print_verbose(vformat("%s does not support streaming", String((char *)capability.card)));
 		return false;
 	}
 


### PR DESCRIPTION
Verbose prints were looking like this, with `(camera name) is no video capture device` being printed once per second (in both the editor and project):

```
Loading resource: res://polyhaven/gray_rocks_arm_1k.jpg
Using present mode: Enabled
OBS Virtual Camera is no video capture device

OBS Virtual Camera is no video capture device

OBS Virtual Camera is no video capture device

OBS Virtual Camera is no video capture device
```

We could alternatively find a way to print the message only once per device name, but it would be more involved. I can look into doing this if it'd help significantly with troubleshooting webcam-related issues.
