### PR TITLE
[GodotPhysics] Fix raycasts don't reliably collide with HeightMapShape3D

### DIFF
--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -1995,7 +1995,11 @@ bool GodotHeightMapShape3D::intersect_segment(const Vector3 &p_begin, const Vect
 			Vector3 bounds_from = p_begin / BOUNDS_CHUNK_SIZE;
 			Vector3 bounds_to = p_end / BOUNDS_CHUNK_SIZE;
 			Vector3 bounds_offset = local_origin / BOUNDS_CHUNK_SIZE;
-			return _intersect_grid_segment(_heightmap_chunk_cull_segment, bounds_from, bounds_to, bounds_grid_width, bounds_grid_depth, bounds_offset, r_point, r_normal);
+			// Plus 1 here to width and depth of the chunk because _intersect_grid_segment() is used by cell level as well,
+			// and in _intersect_grid_segment() the loop will exit 1 early because for cell point triangle lookup, it dose x + 1, z + 1 etc for the vertex.
+			int bounds_width = bounds_grid_width + 1;
+			int bounds_depth = bounds_grid_depth + 1;
+			return _intersect_grid_segment(_heightmap_chunk_cull_segment, bounds_from, bounds_to, bounds_width, bounds_depth, bounds_offset, r_point, r_normal);
 		}
 	}
 


### PR DESCRIPTION
* *Fixes https://github.com/godotengine/godot/issues/68238*

Tested this fix on both of the MRPs shared and it seems to work 
[heightmap_raycast_repro.zip](https://github.com/godotengine/godot/files/9933778/heightmap_raycast_repro.zip)
[raycastHeightmapBug.zip](https://github.com/godotengine/godot/files/12774149/raycastHeightmapBug.zip)

If there's cleaner way to fix this, or if I missed something, let me know thanks

Details:
Raycast with issue fall under this case where ray is long so it does query on higher level grid first
https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/modules/godot_physics_3d/godot_shape_3d.cpp#L1998
And issue looks to be in the loop here, it exit before it got to the chunk where the ray actually intersect
https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/modules/godot_physics_3d/godot_shape_3d.cpp#L1940-L1941
p_width and p_depth is the chunk's width and depth for this flow 
using [heightmap_raycast_repro.zip](https://github.com/godotengine/godot/files/9933778/heightmap_raycast_repro.zip) as example
p_width = ceil( width/chunk size) = ceil( (21/16) = 2
p_depth = ceil(depth/chunk size) = ceil( (21/16) = 2
 x = 1 or z = 1 should still be valid chunk, but it will exit here.

But can't directly change that line to `if ((x < 0) || (z < 0) || (x >= p_width) || (z >= p_depth))`
because `_intersect_grid_segment()` is used by cell level too, where in `_heightmap_cell_cull_segment`: 
https://github.com/godotengine/godot/blob/f7c567e2f56d6e63f4749387a67e5ea4903c4696/modules/godot_physics_3d/godot_shape_3d.cpp#L1754-L1755
it performs get point on the triangle with `p_state.x + 1`, `p_state.z + 1` etc so it will hit out of range on the edge cell if we change that line

This PR passes `bounds_grid_width + 1`, `bounds_grid_depth + 1` to `_intersect_grid_segment()` with a comment to explain this, 
if there's cleaner way let me know :sweat_smile:

