### PR TITLE
[XR Editor] Update the set of excluded permissions

### DIFF
--- a/platform/android/java/editor/src/horizonos/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/horizonos/java/org/godotengine/editor/GodotEditor.kt
@@ -45,14 +45,14 @@ open class GodotEditor : BaseGodotEditor() {
 
 		internal val XR_RUN_GAME_INFO = EditorWindowInfo(GodotXRGame::class.java, 1667, ":GodotXRGame")
 
-		internal const val USE_SCENE_PERMISSION = "com.oculus.permission.USE_SCENE"
+		internal val USE_SCENE_PERMISSIONS = listOf("com.oculus.permission.USE_SCENE", "horizonos.permission.USE_SCENE")
 	}
 
 	override fun getExcludedPermissions(): MutableSet<String> {
 		val excludedPermissions = super.getExcludedPermissions()
 		// The USE_SCENE permission is requested when the "xr/openxr/enabled" project setting
 		// is enabled.
-		excludedPermissions.add(USE_SCENE_PERMISSION)
+		excludedPermissions.addAll(USE_SCENE_PERMISSIONS)
 		return excludedPermissions
 	}
 

--- a/platform/android/java/editor/src/horizonos/java/org/godotengine/editor/GodotXRGame.kt
+++ b/platform/android/java/editor/src/horizonos/java/org/godotengine/editor/GodotXRGame.kt
@@ -69,7 +69,7 @@ open class GodotXRGame: GodotGame() {
 			val automaticPermissionsRequestEnabled = automaticallyRequestPermissionsSetting.isNullOrEmpty() ||
 				automaticallyRequestPermissionsSetting.toBoolean()
 			if (automaticPermissionsRequestEnabled) {
-				permissionsToEnable.add(USE_SCENE_PERMISSION)
+				permissionsToEnable.addAll(USE_SCENE_PERMISSIONS)
 			}
 		}
 


### PR DESCRIPTION
A few permissions including the `USE_SCENE` permission are being renamed with the launch of the Meta Spatial SDK, so we update the excluded list to avoid requesting them on app start.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
