### PR TITLE
Rename `Vector4.components` -> `coord` for consistency

### DIFF
--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -55,16 +55,16 @@ struct [[nodiscard]] Vector4 {
 			real_t z;
 			real_t w;
 		};
-		real_t components[4] = { 0, 0, 0, 0 };
+		real_t coord[4] = { 0, 0, 0, 0 };
 	};
 
 	_FORCE_INLINE_ real_t &operator[](int p_axis) {
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return components[p_axis];
+		return coord[p_axis];
 	}
 	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
-		return components[p_axis];
+		return coord[p_axis];
 	}
 
 	Vector4::Axis min_axis_index() const;


### PR DESCRIPTION
This brings it in line with all the other vectors:

- [Vector2.coord](https://github.com/godotengine/godot/blob/master/core/math/vector2.h#L60)
- [Vector2i.coord](https://github.com/godotengine/godot/blob/master/core/math/vector2i.h#L60)
- [Vector3.coord](https://github.com/godotengine/godot/blob/master/core/math/vector3.h#L58)
- [Vector3i.coord](https://github.com/godotengine/godot/blob/master/core/math/vector3i.h#L56)
- [Vector4i.coord](https://github.com/godotengine/godot/blob/master/core/math/vector4i.h#L58)

I'm guessing this naming happened when Vector4 was copied from [Color](https://github.com/godotengine/godot/blob/master/core/math/color.h#L46), as it's essentially the same struct layout, just with different functions.

This is obviously a potentially breaking change. I didn't find any other references in core to 'components', though at least godot-cpp has named their `Vector4.components` property after this one (see https://github.com/godotengine/godot-cpp/pull/1608), so godot-cpp users may be affected.
