### PR TITLE
Disable auto translation in EditorDirDialog

### DIFF
--- a/editor/gui/editor_dir_dialog.cpp
+++ b/editor/gui/editor_dir_dialog.cpp
@@ -215,8 +215,9 @@ EditorDirDialog::EditorDirDialog() {
 	makedir->connect(SceneStringName(pressed), callable_mp(this, &EditorDirDialog::_make_dir));
 
 	tree = memnew(Tree);
-	vb->add_child(tree);
+	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	vb->add_child(tree);
 	tree->connect("item_activated", callable_mp(this, &EditorDirDialog::_item_activated));
 	tree->connect("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed), CONNECT_DEFERRED);
 


### PR DESCRIPTION
Fixes folder names translated when moving files.
![image](https://github.com/user-attachments/assets/962d9d32-5545-46d1-be22-9b51d0fd861b)
