### PR TITLE
Move skin registration process into deferred on ready

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -332,8 +332,8 @@ void MeshInstance3D::create_multiple_convex_collisions(const Ref<MeshConvexDecom
 
 void MeshInstance3D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
-			_resolve_skeleton_path();
+		case NOTIFICATION_READY: {
+			callable_mp(this, &MeshInstance3D::_resolve_skeleton_path).call_deferred();
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			if (mesh.is_valid()) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/97459

Since the initial update of the skin is done in the skeleton's deferred process, it seems that the process that searches for the skeleton when the skin is first loaded into the tree should also be moved to the deferred process.

However, I am not so familiar with the Skin deformation process in MeshInstance3D, so I am not sure if this is really the correct fix. Although, I think it is safe since this just move the process timing on loading, but please review/test carefully. cc @fire @MajorMcDoom