### PR TITLE
Show GPU name when RenderingDevice is unsupported in the project creation dialog

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -986,7 +986,7 @@ ProjectDialog::ProjectDialog() {
 	rvb->add_child(renderer_info);
 
 	rd_not_supported = memnew(Label);
-	rd_not_supported->set_text(TTR("Rendering Device backend not available. Please use the Compatibility renderer."));
+	rd_not_supported->set_text(vformat(TTR("RenderingDevice-based methods not available on this GPU:\n%s\nPlease use the Compatibility renderer."), RenderingServer::get_singleton()->get_video_adapter_name()));
 	rd_not_supported->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	rd_not_supported->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	rd_not_supported->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/97416.

This helps diagnose issues on multi-GPU setups, particularly when only one of them supports RenderingDevice-based rendering methods.

This can be the case on old laptops with an Intell Haswell IGP and a NVIDIA Maxwell dedicated GPU, where the IGP does not support RenderingDevice but the dedicated GPU does. (In this case, Godot must be forced to run on the dedicated GPU to allow using RenderingDevice-based rendering methods.)

## Preview

*Ignore the GPU model name (it obviously supports Vulkan), I just changed the condition to get the dialog to show up.*

![Screenshot_20240926_153839](https://github.com/user-attachments/assets/3f1cb5c2-4f92-4406-a04b-32c341e8a0b9)


