### PR TITLE
[4.4] Fix `RemoteTransform3D` to always use global rotation if `use_global_coordinates` is true

### DIFF
--- a/scene/3d/remote_transform_3d.cpp
+++ b/scene/3d/remote_transform_3d.cpp
@@ -68,7 +68,7 @@ void RemoteTransform3D::_update_remote() {
 			Transform3D our_trans = get_global_transform();
 
 			if (update_remote_rotation) {
-				n->set_rotation(our_trans.basis.get_euler_normalized(EulerOrder(n->get_rotation_order())));
+				n->set_global_rotation(our_trans.basis.get_euler_normalized(EulerOrder(n->get_rotation_order())));
 			}
 
 			if (update_remote_scale) {


### PR DESCRIPTION
Fixes #97470.

`RemoteTransform3D` would sometimes update the rotation of its target object according to local coordinates even when `use_global_coordinates` was true. This PR fixes that.

Incidentally, if the settings to update `Scale` `Position` and `Rotation` were all true, this bug wouldn't be triggered.