### PR TITLE
CI: Support merge queues with default runner

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,5 +1,5 @@
 name: 🔗 GHA
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 concurrency:
   group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-runner


### PR DESCRIPTION
While I'm *extremely* confident that this isn't how this would be handled long-term, it ultimately opens the door for checks via [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue). Literally no other changes, just enabling the functionality.