### PR TITLE
Add permission methods to CameraServer

### DIFF
--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -37,11 +37,23 @@
 				Returns the number of [CameraFeed]s registered.
 			</description>
 		</method>
+		<method name="permission_granted">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if camera permission is granted. Always returns [code]true[/code] if no permission is required to access cameras.
+			</description>
+		</method>
 		<method name="remove_feed">
 			<return type="void" />
 			<param index="0" name="feed" type="CameraFeed" />
 			<description>
 				Removes the specified camera [param feed].
+			</description>
+		</method>
+		<method name="request_permission">
+			<return type="void" />
+			<description>
+				Requests camera permission. No-op if permission is already granted or no permission is required to access cameras.
 			</description>
 		</method>
 	</methods>
@@ -56,6 +68,12 @@
 			<param index="0" name="id" type="int" />
 			<description>
 				Emitted when a [CameraFeed] is removed (e.g. a webcam is unplugged).
+			</description>
+		</signal>
+		<signal name="request_permission_result">
+			<param index="0" name="granted" type="bool" />
+			<description>
+				Emitted when a user responds to a camera permission request.
 			</description>
 		</signal>
 	</signals>

--- a/modules/camera/camera_macos.h
+++ b/modules/camera/camera_macos.h
@@ -41,6 +41,9 @@ public:
 	CameraMacOS();
 
 	void update_feeds();
+
+	bool permission_granted() override;
+	void request_permission() override;
 };
 
 #endif // CAMERA_MACOS_H

--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -39,6 +39,9 @@
 CameraServer::CreateFunc CameraServer::create_func = nullptr;
 
 void CameraServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("permission_granted"), &CameraServer::permission_granted);
+	ClassDB::bind_method(D_METHOD("request_permission"), &CameraServer::request_permission);
+
 	ClassDB::bind_method(D_METHOD("get_feed", "index"), &CameraServer::get_feed);
 	ClassDB::bind_method(D_METHOD("get_feed_count"), &CameraServer::get_feed_count);
 	ClassDB::bind_method(D_METHOD("feeds"), &CameraServer::get_feeds);
@@ -48,6 +51,7 @@ void CameraServer::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("camera_feed_added", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("camera_feed_removed", PropertyInfo(Variant::INT, "id")));
+	ADD_SIGNAL(MethodInfo("request_permission_result", PropertyInfo(Variant::BOOL, "granted")));
 
 	BIND_ENUM_CONSTANT(FEED_RGBA_IMAGE);
 	BIND_ENUM_CONSTANT(FEED_YCBCR_IMAGE);

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -89,6 +89,10 @@ public:
 		return server;
 	}
 
+	// Camera permission.
+	virtual bool permission_granted() { return true; }
+	virtual void request_permission() {}
+
 	// Right now we identify our feed by it's ID when it's used in the background.
 	// May see if we can change this to purely relying on CameraFeed objects or by name.
 	int get_free_id();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/10829

Two methods are added to `CameraServer`:

- `permission_granted`: Returns `true` if camera permission is granted. Always returns `true` if no permission is required to access cameras.
- `request_permission`: Requests camera permission. No-op if permission is already granted or no permission is required to access cameras.

Add signal `request_permission_result` to `CameraServer` for indicating if permission request is granted or not.

`CameraMacOS` has implemented these methods in the PR as the example.