### PR TITLE
Move Vulkan includes to a central `godot_vulkan.h` header

### DIFF
--- a/drivers/vulkan/godot_vulkan.h
+++ b/drivers/vulkan/godot_vulkan.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_context_driver_vulkan_android.cpp                           */
+/*  godot_vulkan.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,38 +28,15 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "rendering_context_driver_vulkan_android.h"
+#ifndef GODOT_VULKAN_H
+#define GODOT_VULKAN_H
 
-#ifdef VULKAN_ENABLED
+#ifdef USE_VOLK
+#include <volk.h>
+#else
+#include <stdint.h>
+#define VK_NO_STDINT_H
+#include <vulkan/vulkan.h>
+#endif
 
-#include "drivers/vulkan/godot_vulkan.h"
-
-const char *RenderingContextDriverVulkanAndroid::_get_platform_surface_extension() const {
-	return VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
-}
-
-RenderingContextDriver::SurfaceID RenderingContextDriverVulkanAndroid::surface_create(const void *p_platform_data) {
-	const WindowPlatformData *wpd = (const WindowPlatformData *)(p_platform_data);
-
-	VkAndroidSurfaceCreateInfoKHR create_info = {};
-	create_info.sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
-	create_info.window = wpd->window;
-
-	VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
-	VkResult err = vkCreateAndroidSurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
-
-	Surface *surface = memnew(Surface);
-	surface->vk_surface = vk_surface;
-	return SurfaceID(surface);
-}
-
-bool RenderingContextDriverVulkanAndroid::_use_validation_layers() const {
-	TightLocalVector<const char *> layer_names;
-	Error err = _find_validation_layers(layer_names);
-
-	// On Android, we use validation layers automatically if they were explicitly linked with the app.
-	return (err == OK) && !layer_names.is_empty();
-}
-
-#endif // VULKAN_ENABLED
+#endif // GODOT_VULKAN_H

--- a/drivers/vulkan/rendering_context_driver_vulkan.h
+++ b/drivers/vulkan/rendering_context_driver_vulkan.h
@@ -40,11 +40,7 @@
 #define VK_TRACK_DEVICE_MEMORY
 #endif
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 
 class RenderingContextDriverVulkan : public RenderingContextDriver {
 public:

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -43,11 +43,7 @@
 #endif
 #include "thirdparty/vulkan/vk_mem_alloc.h"
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 
 // Design principles:
 // - Vulkan structs are zero-initialized and fields not requiring a non-zero value are omitted (except in cases where expresivity reasons apply).

--- a/drivers/vulkan/vulkan_hooks.h
+++ b/drivers/vulkan/vulkan_hooks.h
@@ -31,11 +31,7 @@
 #ifndef VULKAN_HOOKS_H
 #define VULKAN_HOOKS_H
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 
 class VulkanHooks {
 private:

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -41,11 +41,7 @@
 #if defined(VULKAN_ENABLED)
 #import "rendering_context_driver_vulkan_ios.h"
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 #endif // VULKAN_ENABLED
 
 #if defined(METAL_ENABLED)

--- a/platform/ios/os_ios.mm
+++ b/platform/ios/os_ios.mm
@@ -56,11 +56,7 @@
 #import <QuartzCore/CAMetalLayer.h>
 
 #if defined(VULKAN_ENABLED)
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 #endif // VULKAN_ENABLED
 #endif
 

--- a/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.cpp
+++ b/platform/linuxbsd/wayland/rendering_context_driver_vulkan_wayland.cpp
@@ -32,11 +32,7 @@
 
 #include "rendering_context_driver_vulkan_wayland.h"
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 
 const char *RenderingContextDriverVulkanWayland::_get_platform_surface_extension() const {
 	return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;

--- a/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.cpp
+++ b/platform/linuxbsd/x11/rendering_context_driver_vulkan_x11.cpp
@@ -32,11 +32,7 @@
 
 #include "rendering_context_driver_vulkan_x11.h"
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 
 const char *RenderingContextDriverVulkanX11::_get_platform_surface_extension() const {
 	return VK_KHR_XLIB_SURFACE_EXTENSION_NAME;

--- a/platform/windows/rendering_context_driver_vulkan_windows.cpp
+++ b/platform/windows/rendering_context_driver_vulkan_windows.cpp
@@ -34,11 +34,7 @@
 
 #include "rendering_context_driver_vulkan_windows.h"
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 
 const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
 	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;

--- a/thirdparty/vulkan/patches/VKEnumStringHelper-use-godot-vulkan.patch
+++ b/thirdparty/vulkan/patches/VKEnumStringHelper-use-godot-vulkan.patch
@@ -1,17 +1,13 @@
 diff --git a/thirdparty/vulkan/vk_enum_string_helper.h b/thirdparty/vulkan/vk_enum_string_helper.h
-index 9d2af46344..d61dbb1290 100644
+index 8026787ad4..7a54b12a38 100644
 --- a/thirdparty/vulkan/vk_enum_string_helper.h
 +++ b/thirdparty/vulkan/vk_enum_string_helper.h
-@@ -13,7 +13,11 @@
+@@ -13,7 +13,7 @@
  #ifdef __cplusplus
  #include <string>
  #endif
 -#include <vulkan/vulkan.h>
-+#ifdef USE_VOLK
-+    #include <volk.h>
-+#else
-+    #include <vulkan/vulkan.h>
-+#endif
++#include "drivers/vulkan/godot_vulkan.h"
  static inline const char* string_VkResult(VkResult input_value) {
      switch (input_value) {
          case VK_SUCCESS:

--- a/thirdparty/vulkan/patches/VMA-use-godot-vulkan.patch
+++ b/thirdparty/vulkan/patches/VMA-use-godot-vulkan.patch
@@ -1,17 +1,18 @@
 diff --git a/thirdparty/vulkan/vk_mem_alloc.h b/thirdparty/vulkan/vk_mem_alloc.h
-index 711f486571..e5eaa80e74 100644
+index 2307325d4e..ecb84094b9 100644
 --- a/thirdparty/vulkan/vk_mem_alloc.h
 +++ b/thirdparty/vulkan/vk_mem_alloc.h
-@@ -127,7 +127,11 @@ See documentation chapter: \ref statistics.
+@@ -122,12 +122,12 @@ for user-defined purpose without allocating any real GPU memory.
+ See documentation chapter: \ref statistics.
+ */
+ 
++#include "drivers/vulkan/godot_vulkan.h"
+ 
+ #ifdef __cplusplus
  extern "C" {
  #endif
  
 -#include <vulkan/vulkan.h>
-+#ifdef USE_VOLK
-+    #include <volk.h>
-+#else
-+    #include <vulkan/vulkan.h>
-+#endif
  
  #if !defined(VMA_VULKAN_VERSION)
      #if defined(VK_VERSION_1_3)

--- a/thirdparty/vulkan/vk_enum_string_helper.h
+++ b/thirdparty/vulkan/vk_enum_string_helper.h
@@ -13,11 +13,7 @@
 #ifdef __cplusplus
 #include <string>
 #endif
-#ifdef USE_VOLK
-    #include <volk.h>
-#else
-    #include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 static inline const char* string_VkResult(VkResult input_value) {
     switch (input_value) {
         case VK_SUCCESS:

--- a/thirdparty/vulkan/vk_mem_alloc.h
+++ b/thirdparty/vulkan/vk_mem_alloc.h
@@ -122,16 +122,12 @@ for user-defined purpose without allocating any real GPU memory.
 See documentation chapter: \ref statistics.
 */
 
+#include "drivers/vulkan/godot_vulkan.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifdef USE_VOLK
-    #include <volk.h>
-#else
-    #include <vulkan/vulkan.h>
-#endif
 
 #if !defined(VMA_VULKAN_VERSION)
     #if defined(VK_VERSION_1_3)


### PR DESCRIPTION
Also fixes Vulkan build problem with recent Clang.

Developed by [Migeran](https://migeran.com/), sponsored by [Xibbon Inc.](https://xibbon.com/)

Fixes #96918.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
