### PR TITLE
Add Unit Test cases for `Sky`

### DIFF
--- a/tests/scene/test_sky.h
+++ b/tests/scene/test_sky.h
@@ -1,0 +1,141 @@
+/**************************************************************************/
+/*  test_sky.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_SKY_H
+#define TEST_SKY_H
+
+#include "scene/resources/sky.h"
+
+#include "tests/test_macros.h"
+
+namespace TestSky {
+
+TEST_CASE("[SceneTree][Sky] Constructor") {
+	Sky *test_sky = memnew(Sky);
+
+	CHECK(test_sky->get_process_mode() == Sky::PROCESS_MODE_AUTOMATIC);
+	CHECK(test_sky->get_radiance_size() == Sky::RADIANCE_SIZE_256);
+	CHECK(test_sky->get_material().is_null());
+	memdelete(test_sky);
+}
+
+TEST_CASE("[SceneTree][Sky] Radiance size setter and getter") {
+	Sky *test_sky = memnew(Sky);
+
+	// Check default.
+	CHECK(test_sky->get_radiance_size() == Sky::RADIANCE_SIZE_256);
+
+	test_sky->set_radiance_size(Sky::RADIANCE_SIZE_1024);
+	CHECK(test_sky->get_radiance_size() == Sky::RADIANCE_SIZE_1024);
+
+	ERR_PRINT_OFF;
+	// Check setting invalid radiance size.
+	test_sky->set_radiance_size(Sky::RADIANCE_SIZE_MAX);
+	ERR_PRINT_ON;
+
+	CHECK(test_sky->get_radiance_size() == Sky::RADIANCE_SIZE_1024);
+
+	memdelete(test_sky);
+}
+
+TEST_CASE("[SceneTree][Sky] Process mode setter and getter") {
+	Sky *test_sky = memnew(Sky);
+
+	// Check default.
+	CHECK(test_sky->get_process_mode() == Sky::PROCESS_MODE_AUTOMATIC);
+
+	test_sky->set_process_mode(Sky::PROCESS_MODE_INCREMENTAL);
+	CHECK(test_sky->get_process_mode() == Sky::PROCESS_MODE_INCREMENTAL);
+
+	memdelete(test_sky);
+}
+
+TEST_CASE("[SceneTree][Sky] Material setter and getter") {
+	Sky *test_sky = memnew(Sky);
+	Ref<Material> material = memnew(Material);
+
+	SUBCASE("Material passed to the class should remain the same") {
+		test_sky->set_material(material);
+		CHECK(test_sky->get_material() == material);
+	}
+	SUBCASE("Material passed many times to the class should remain the same") {
+		test_sky->set_material(material);
+		test_sky->set_material(material);
+		test_sky->set_material(material);
+		CHECK(test_sky->get_material() == material);
+	}
+	SUBCASE("Material rewrite testing") {
+		Ref<Material> material1 = memnew(Material);
+		Ref<Material> material2 = memnew(Material);
+
+		test_sky->set_material(material1);
+		test_sky->set_material(material2);
+		CHECK_MESSAGE(test_sky->get_material() != material1,
+				"After rewrite, second material should be in class.");
+		CHECK_MESSAGE(test_sky->get_material() == material2,
+				"After rewrite, second material should be in class.");
+	}
+
+	SUBCASE("Assign same material to two skys") {
+		Sky *sky2 = memnew(Sky);
+
+		test_sky->set_material(material);
+		sky2->set_material(material);
+		CHECK_MESSAGE(test_sky->get_material() == sky2->get_material(),
+				"Both skys should have the same material.");
+		memdelete(sky2);
+	}
+
+	SUBCASE("Swapping materials between two skys") {
+		Sky *sky2 = memnew(Sky);
+		Ref<Material> material1 = memnew(Material);
+		Ref<Material> material2 = memnew(Material);
+
+		test_sky->set_material(material1);
+		sky2->set_material(material2);
+		CHECK(test_sky->get_material() == material1);
+		CHECK(sky2->get_material() == material2);
+
+		// Do the swap.
+		Ref<Material> temp = test_sky->get_material();
+		test_sky->set_material(sky2->get_material());
+		sky2->set_material(temp);
+
+		CHECK(test_sky->get_material() == material2);
+		CHECK(sky2->get_material() == material1);
+		memdelete(sky2);
+	}
+
+	memdelete(test_sky);
+}
+
+} // namespace TestSky
+
+#endif // TEST_SKY_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -161,6 +161,7 @@
 #include "tests/scene/test_path_follow_3d.h"
 #include "tests/scene/test_primitives.h"
 #include "tests/scene/test_skeleton_3d.h"
+#include "tests/scene/test_sky.h"
 #endif // _3D_DISABLED
 
 #include "modules/modules_tests.gen.h"


### PR DESCRIPTION
https://github.com/godotengine/godot/issues/43440.

Adds several test cases for the `Sky` class.

Essentially just tests adds test coverage for the constructors default values and the setter and getter (and error behavior for `set_radiance_size`)