### PR TITLE
Use dithering when performing SSR roughness to improve quality

### DIFF
--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -1525,6 +1525,8 @@ void SSEffects::screen_space_reflection(Ref<RenderSceneBuffersRD> p_render_buffe
 			push_constant.view_index = v;
 			push_constant.orthogonal = p_projections[v].is_orthogonal();
 			push_constant.edge_tolerance = Math::sin(Math::deg_to_rad(15.0));
+			constexpr int taa_phase_count = 16;
+			push_constant.taa_frame_count = (RSG::rasterizer->get_frame_number() % taa_phase_count) / float(taa_phase_count);
 			push_constant.proj_info[0] = -2.0f / (p_ssr_buffers.size.width * p_projections[v].columns[0][0]);
 			push_constant.proj_info[1] = -2.0f / (p_ssr_buffers.size.height * p_projections[v].columns[1][1]);
 			push_constant.proj_info[2] = (1.0f - p_projections[v].columns[0][2]) / p_projections[v].columns[0][0];

--- a/servers/rendering/renderer_rd/effects/ss_effects.h
+++ b/servers/rendering/renderer_rd/effects/ss_effects.h
@@ -490,6 +490,12 @@ private:
 		int32_t screen_size[2]; //  8 - 40
 		uint32_t vertical; //  4 - 44
 		uint32_t steps; //  4 - 48
+
+		// Used to add break up samples over multiple frames. Value is an integer from 0 to taa_phase_count -1.
+		float taa_frame_count; // 4 - 52
+		uint32_t pad0; // 4 - 56
+		uint32_t pad1; // 4 - 60
+		uint32_t pad2; // 4 - 64
 	};
 
 	enum SSRReflectionMode {


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/97428.

This works best when TAA or FSR2 is enabled to jitter the result every frame, letting TAA accumulation do its work.

**Testing project:** https://github.com/Calinou/godot-ssr-test

## Preview

*TAA is enabled on all screenshots. Images should be compared by opening them in a new tab, so that they can be viewed at 1:1 size.*

### Before

Low quality | Medium quality | High quality
-|-|-
![ssr_taa_before_low png webp](https://github.com/user-attachments/assets/7fcb40c9-450c-45f3-8944-d6a7f022177d) | ![ssr_taa_before_medium png webp](https://github.com/user-attachments/assets/15a8001c-7747-4eb4-9cf0-d6b9bc2c99bc) | ![ssr_taa_before_high png webp](https://github.com/user-attachments/assets/9afebdf0-e6e9-440a-884c-ca1a52035b2e)

### After

*Low and Medium quality settings now resemble High quality more closely, with less visible blockiness.*

Low quality | Medium quality | High quality
-|-|-
![ssr_taa_after_low png webp](https://github.com/user-attachments/assets/548b7aa9-8c32-4ca5-92b4-62fadbed4795) | ![ssr_taa_after_medium png webp](https://github.com/user-attachments/assets/418fee2a-6c3a-4a91-938c-8254522a9cfd) | ![ssr_taa_after_high png webp](https://github.com/user-attachments/assets/b4c0d5fe-1b6c-4b83-a289-38c5265e28b5)

## TODO

- [ ] Use the TAA frame count from camera data, so that the jitter is disabled when TAA is disabled and the TAA frame count varies according to the Halton sequence length.
  - I'm not sure how to pass this from RendererSceneCull to SSEffects.
- [ ] Improve appearance when using FSR2, which has a harder time smoothing out dithering patterns that change over time.
  - See https://github.com/godotengine/godot/pull/61834#issuecomment-2372215710. I don't know how to apply this to SSR jittering, since it's slightly different in concept (no disk rotation is involved).
