### PR TITLE
Add auto translate mode for items in `ItemList`

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -73,6 +73,13 @@
 				[b]Note:[/b] The returned value is unreliable if called right after modifying the [ItemList], before it redraws in the next frame.
 			</description>
 		</method>
+		<method name="get_item_auto_translate_mode" qualifiers="const">
+			<return type="int" enum="Node.AutoTranslateMode" />
+			<param index="0" name="idx" type="int" />
+			<description>
+				Returns item's auto translate mode.
+			</description>
+		</method>
 		<method name="get_item_custom_bg_color" qualifiers="const">
 			<return type="Color" />
 			<param index="0" name="idx" type="int" />
@@ -228,6 +235,15 @@
 			<description>
 				Select the item at the specified index.
 				[b]Note:[/b] This method does not trigger the item selection signal.
+			</description>
+		</method>
+		<method name="set_item_auto_translate_mode">
+			<return type="void" />
+			<param index="0" name="idx" type="int" />
+			<param index="1" name="mode" type="int" enum="Node.AutoTranslateMode" />
+			<description>
+				Sets the auto translate mode of the item associated with the specified index.
+				Items use [constant Node.AUTO_TRANSLATE_MODE_INHERIT] by default, which uses the same auto translate mode as the [ItemList] itself.
 			</description>
 		</method>
 		<method name="set_item_custom_bg_color">

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -32,7 +32,6 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
-#include "core/string/translation.h"
 #include "scene/theme/theme_db.h"
 
 void ItemList::_shape_text(int p_idx) {
@@ -58,12 +57,12 @@ int ItemList::add_item(const String &p_item, const Ref<Texture2D> &p_texture, bo
 	Item item;
 	item.icon = p_texture;
 	item.text = p_item;
-	item.xl_text = atr(p_item);
 	item.selectable = p_selectable;
 	items.push_back(item);
 	int item_id = items.size() - 1;
 
-	_shape_text(items.size() - 1);
+	items.write[item_id].xl_text = _atr(item_id, p_item);
+	_shape_text(item_id);
 
 	queue_redraw();
 	shape_changed = true;
@@ -95,7 +94,7 @@ void ItemList::set_item_text(int p_idx, const String &p_text) {
 	}
 
 	items.write[p_idx].text = p_text;
-	items.write[p_idx].xl_text = atr(p_text);
+	items.write[p_idx].xl_text = _atr(p_idx, p_text);
 	_shape_text(p_idx);
 	queue_redraw();
 	shape_changed = true;
@@ -139,6 +138,24 @@ void ItemList::set_item_language(int p_idx, const String &p_language) {
 String ItemList::get_item_language(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, items.size(), "");
 	return items[p_idx].language;
+}
+
+void ItemList::set_item_auto_translate_mode(int p_idx, AutoTranslateMode p_mode) {
+	if (p_idx < 0) {
+		p_idx += get_item_count();
+	}
+	ERR_FAIL_INDEX(p_idx, items.size());
+	if (items[p_idx].auto_translate_mode != p_mode) {
+		items.write[p_idx].auto_translate_mode = p_mode;
+		items.write[p_idx].xl_text = _atr(p_idx, items[p_idx].text);
+		_shape_text(p_idx);
+		queue_redraw();
+	}
+}
+
+Node::AutoTranslateMode ItemList::get_item_auto_translate_mode(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, items.size(), AUTO_TRANSLATE_MODE_INHERIT);
+	return items[p_idx].auto_translate_mode;
 }
 
 void ItemList::set_item_tooltip_enabled(int p_idx, const bool p_enabled) {
@@ -1022,7 +1039,7 @@ void ItemList::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			for (int i = 0; i < items.size(); i++) {
-				items.write[i].xl_text = atr(items[i].text);
+				items.write[i].xl_text = _atr(i, items[i].text);
 				_shape_text(i);
 			}
 			shape_changed = true;
@@ -1509,6 +1526,23 @@ void ItemList::_mouse_exited() {
 	}
 }
 
+String ItemList::_atr(int p_idx, const String &p_text) const {
+	ERR_FAIL_INDEX_V(p_idx, items.size(), atr(p_text));
+	switch (items[p_idx].auto_translate_mode) {
+		case AUTO_TRANSLATE_MODE_INHERIT: {
+			return atr(p_text);
+		} break;
+		case AUTO_TRANSLATE_MODE_ALWAYS: {
+			return tr(p_text);
+		} break;
+		case AUTO_TRANSLATE_MODE_DISABLED: {
+			return p_text;
+		} break;
+	}
+
+	ERR_FAIL_V_MSG(atr(p_text), "Unexpected auto translate mode: " + itos(items[p_idx].auto_translate_mode));
+}
+
 int ItemList::get_item_at_position(const Point2 &p_pos, bool p_exact) const {
 	Vector2 pos = p_pos;
 	pos -= theme_cache.panel_style->get_offset();
@@ -1747,6 +1781,9 @@ void ItemList::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_item_language", "idx", "language"), &ItemList::set_item_language);
 	ClassDB::bind_method(D_METHOD("get_item_language", "idx"), &ItemList::get_item_language);
+
+	ClassDB::bind_method(D_METHOD("set_item_auto_translate_mode", "idx", "mode"), &ItemList::set_item_auto_translate_mode);
+	ClassDB::bind_method(D_METHOD("get_item_auto_translate_mode", "idx"), &ItemList::get_item_auto_translate_mode);
 
 	ClassDB::bind_method(D_METHOD("set_item_icon_transposed", "idx", "transposed"), &ItemList::set_item_icon_transposed);
 	ClassDB::bind_method(D_METHOD("is_item_icon_transposed", "idx"), &ItemList::is_item_icon_transposed);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -62,6 +62,7 @@ private:
 		Ref<TextParagraph> text_buf;
 		String language;
 		TextDirection text_direction = TEXT_DIRECTION_AUTO;
+		AutoTranslateMode auto_translate_mode = AUTO_TRANSLATE_MODE_INHERIT;
 
 		bool selectable = true;
 		bool selected = false;
@@ -159,6 +160,8 @@ private:
 	void _shape_text(int p_idx);
 	void _mouse_exited();
 
+	String _atr(int p_idx, const String &p_text) const;
+
 protected:
 	void _notification(int p_what);
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -182,6 +185,9 @@ public:
 
 	void set_item_language(int p_idx, const String &p_language);
 	String get_item_language(int p_idx) const;
+
+	void set_item_auto_translate_mode(int p_idx, AutoTranslateMode p_mode);
+	AutoTranslateMode get_item_auto_translate_mode(int p_idx) const;
 
 	void set_item_icon(int p_idx, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_item_icon(int p_idx) const;


### PR DESCRIPTION
Make i18n for `ItemList` easier if only some items need auto translation. Similar to #97353.

Otherwise users have to either rebuild the entire list when locale is changed, or manually keep track of those special items.

![Peek 2024-09-27 10-25](https://github.com/user-attachments/assets/d8986de7-b50a-40ef-b8b9-af7d0c4d31de)

Test project: [itemlist-at.zip](https://github.com/user-attachments/files/17158161/itemlist-at.zip)
