### PR TITLE
Unify editor version buttons

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -33,15 +33,11 @@
 #include "core/authors.gen.h"
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
-#include "core/os/time.h"
-#include "core/version.h"
 #include "editor/editor_string_names.h"
+#include "editor/gui/editor_version_button.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/item_list.h"
 #include "scene/resources/style_box.h"
-
-// The metadata key used to store and retrieve the version text to copy to the clipboard.
-const String EditorAbout::META_TEXT_TO_COPY = "text_to_copy";
 
 void EditorAbout::_notification(int p_what) {
 	switch (p_what) {
@@ -79,10 +75,6 @@ void EditorAbout::_license_tree_selected() {
 	TreeItem *selected = _tpl_tree->get_selected();
 	_tpl_text->scroll_to_line(0);
 	_tpl_text->set_text(selected->get_metadata(0));
-}
-
-void EditorAbout::_version_button_pressed() {
-	DisplayServer::get_singleton()->clipboard_set(version_btn->get_meta(META_TEXT_TO_COPY));
 }
 
 void EditorAbout::_item_with_website_selected(int p_id, ItemList *p_il) {
@@ -198,25 +190,7 @@ EditorAbout::EditorAbout() {
 	Control *v_spacer = memnew(Control);
 	version_info_vbc->add_child(v_spacer);
 
-	version_btn = memnew(LinkButton);
-	String hash = String(VERSION_HASH);
-	if (hash.length() != 0) {
-		hash = " " + vformat("[%s]", hash.left(9));
-	}
-	version_btn->set_text(VERSION_FULL_NAME + hash);
-	// Set the text to copy in metadata as it slightly differs from the button's text.
-	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
-	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	String build_date;
-	if (VERSION_TIMESTAMP > 0) {
-		build_date = Time::get_singleton()->get_datetime_string_from_unix_time(VERSION_TIMESTAMP, true) + " UTC";
-	} else {
-		build_date = TTR("(unknown)");
-	}
-	version_btn->set_tooltip_text(vformat(TTR("Git commit date: %s\nClick to copy the version number."), build_date));
-
-	version_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorAbout::_version_button_pressed));
-	version_info_vbc->add_child(version_btn);
+	version_info_vbc->add_child(memnew(EditorVersionButton(EditorVersionButton::FORMAT_WITH_NAME_AND_BUILD)));
 
 	Label *about_text = memnew(Label);
 	about_text->set_v_size_flags(Control::SIZE_SHRINK_CENTER);

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -33,7 +33,6 @@
 
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
-#include "scene/gui/link_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
@@ -49,16 +48,12 @@
 class EditorAbout : public AcceptDialog {
 	GDCLASS(EditorAbout, AcceptDialog);
 
-	static const String META_TEXT_TO_COPY;
-
 private:
 	void _license_tree_selected();
-	void _version_button_pressed();
 	void _item_with_website_selected(int p_id, ItemList *p_il);
 	void _item_list_resized(ItemList *p_il);
 	ScrollContainer *_populate_list(const String &p_name, const List<String> &p_sections, const char *const *const p_src[], int p_single_column_flags = 0, bool p_allow_website = false);
 
-	LinkButton *version_btn = nullptr;
 	Tree *_tpl_tree = nullptr;
 	RichTextLabel *license_text_label = nullptr;
 	RichTextLabel *_tpl_text = nullptr;

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_bottom_panel.h"
 
-#include "core/os/time.h"
-#include "core/version.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_about.h"
 #include "editor/editor_command_palette.h"
@@ -39,13 +37,10 @@
 #include "editor/editor_string_names.h"
 #include "editor/engine_update_label.h"
 #include "editor/gui/editor_toaster.h"
+#include "editor/gui/editor_version_button.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
-#include "scene/gui/link_button.h"
-
-// The metadata key used to store and retrieve the version text to copy to the clipboard.
-static const String META_TEXT_TO_COPY = "text_to_copy";
 
 void EditorBottomPanel::_notification(int p_what) {
 	switch (p_what) {
@@ -108,10 +103,6 @@ void EditorBottomPanel::_switch_to_item(bool p_visible, int p_idx) {
 
 void EditorBottomPanel::_expand_button_toggled(bool p_pressed) {
 	EditorNode::get_top_split()->set_visible(!p_pressed);
-}
-
-void EditorBottomPanel::_version_button_pressed() {
-	DisplayServer::get_singleton()->clipboard_set(version_btn->get_meta(META_TEXT_TO_COPY));
 }
 
 bool EditorBottomPanel::_button_drag_hover(const Vector2 &, const Variant &, Button *p_button, Control *p_control) {
@@ -262,25 +253,9 @@ EditorBottomPanel::EditorBottomPanel() {
 	editor_toaster = memnew(EditorToaster);
 	bottom_hbox->add_child(editor_toaster);
 
-	version_btn = memnew(LinkButton);
-	version_btn->set_text(VERSION_FULL_CONFIG);
-	String hash = String(VERSION_HASH);
-	if (hash.length() != 0) {
-		hash = " " + vformat("[%s]", hash.left(9));
-	}
-	// Set the text to copy in metadata as it slightly differs from the button's text.
-	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
+	EditorVersionButton *version_btn = memnew(EditorVersionButton(EditorVersionButton::FORMAT_BASIC));
 	// Fade out the version label to be less prominent, but still readable.
 	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
-	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-	String build_date;
-	if (VERSION_TIMESTAMP > 0) {
-		build_date = Time::get_singleton()->get_datetime_string_from_unix_time(VERSION_TIMESTAMP, true) + " UTC";
-	} else {
-		build_date = TTR("(unknown)");
-	}
-	version_btn->set_tooltip_text(vformat(TTR("Git commit date: %s\nClick to copy the version information."), build_date));
-	version_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorBottomPanel::_version_button_pressed));
 	version_btn->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	bottom_hbox->add_child(version_btn);
 

--- a/editor/gui/editor_version_button.h
+++ b/editor/gui/editor_version_button.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_bottom_panel.h                                                 */
+/*  editor_version_button.h                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,56 +28,34 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef EDITOR_BOTTOM_PANEL_H
-#define EDITOR_BOTTOM_PANEL_H
+#ifndef EDITOR_VERSION_BUTTON_H
+#define EDITOR_VERSION_BUTTON_H
 
-#include "scene/gui/panel_container.h"
+#include "scene/gui/link_button.h"
 
-class Button;
-class ConfigFile;
-class EditorToaster;
-class HBoxContainer;
-class VBoxContainer;
+class EditorVersionButton : public LinkButton {
+	GDCLASS(EditorVersionButton, LinkButton);
 
-class EditorBottomPanel : public PanelContainer {
-	GDCLASS(EditorBottomPanel, PanelContainer);
-
-	struct BottomPanelItem {
-		String name;
-		Control *control = nullptr;
-		Button *button = nullptr;
+public:
+	enum VersionFormat {
+		// 4.3.2.stable
+		FORMAT_BASIC,
+		// v4.3.2.stable.mono [HASH]
+		FORMAT_WITH_BUILD,
+		// Godot Engine v4.3.2.stable.mono.official [HASH]
+		FORMAT_WITH_NAME_AND_BUILD,
 	};
 
-	Vector<BottomPanelItem> items;
-
-	VBoxContainer *item_vbox = nullptr;
-	HBoxContainer *bottom_hbox = nullptr;
-	HBoxContainer *button_hbox = nullptr;
-	EditorToaster *editor_toaster = nullptr;
-	Button *expand_button = nullptr;
-	Control *last_opened_control = nullptr;
-
-	void _switch_by_control(bool p_visible, Control *p_control);
-	void _switch_to_item(bool p_visible, int p_idx);
-	void _expand_button_toggled(bool p_pressed);
-
-	bool _button_drag_hover(const Vector2 &, const Variant &, Button *p_button, Control *p_control);
+private:
+	VersionFormat format = FORMAT_WITH_NAME_AND_BUILD;
 
 protected:
 	void _notification(int p_what);
 
+	virtual void pressed() override;
+
 public:
-	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;
-	void load_layout_from_config(Ref<ConfigFile> p_config_file, const String &p_section);
-
-	Button *add_item(String p_text, Control *p_item, const Ref<Shortcut> &p_shortcut = nullptr, bool p_at_front = false);
-	void remove_item(Control *p_item);
-	void make_item_visible(Control *p_item, bool p_visible = true);
-	void move_item_to_end(Control *p_item);
-	void hide_bottom_panel();
-	void toggle_last_opened_bottom_panel();
-
-	EditorBottomPanel();
+	EditorVersionButton(VersionFormat p_format);
 };
 
-#endif // EDITOR_BOTTOM_PANEL_H
+#endif // EDITOR_VERSION_BUTTON_H

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -38,7 +38,6 @@
 #include "core/io/stream_peer_tls.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
-#include "core/os/time.h"
 #include "core/version.h"
 #include "editor/editor_about.h"
 #include "editor/editor_settings.h"
@@ -46,6 +45,7 @@
 #include "editor/engine_update_label.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_title_bar.h"
+#include "editor/gui/editor_version_button.h"
 #include "editor/plugins/asset_library_editor_plugin.h"
 #include "editor/project_manager/project_dialog.h"
 #include "editor/project_manager/project_list.h"
@@ -396,12 +396,6 @@ void ProjectManager::_restart_confirmed() {
 
 	_dim_window();
 	get_tree()->quit();
-}
-
-// Footer.
-
-void ProjectManager::_version_button_pressed() {
-	DisplayServer::get_singleton()->clipboard_set(version_btn->get_text());
 }
 
 // Project list.
@@ -1459,23 +1453,9 @@ ProjectManager::ProjectManager() {
 		update_label->connect("offline_clicked", callable_mp(this, &ProjectManager::_show_quick_settings));
 #endif
 
-		version_btn = memnew(LinkButton);
-		String hash = String(VERSION_HASH);
-		if (hash.length() != 0) {
-			hash = " " + vformat("[%s]", hash.left(9));
-		}
-		version_btn->set_text("v" VERSION_FULL_BUILD + hash);
+		EditorVersionButton *version_btn = memnew(EditorVersionButton(EditorVersionButton::FORMAT_WITH_BUILD));
 		// Fade the version label to be less prominent, but still readable.
 		version_btn->set_self_modulate(Color(1, 1, 1, 0.6));
-		version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
-		String build_date;
-		if (VERSION_TIMESTAMP > 0) {
-			build_date = Time::get_singleton()->get_datetime_string_from_unix_time(VERSION_TIMESTAMP, true) + " UTC";
-		} else {
-			build_date = TTR("(unknown)");
-		}
-		version_btn->set_tooltip_text(vformat(TTR("Git commit date: %s\nClick to copy the version information."), build_date));
-		version_btn->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_version_button_pressed));
 		footer_bar->add_child(version_btn);
 	}
 

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -41,7 +41,6 @@ class EditorFileDialog;
 class EditorTitleBar;
 class HFlowContainer;
 class LineEdit;
-class LinkButton;
 class MarginContainer;
 class OptionButton;
 class PanelContainer;
@@ -123,12 +122,6 @@ class ProjectManager : public Control {
 
 	void _show_quick_settings();
 	void _restart_confirmed();
-
-	// Footer.
-
-	LinkButton *version_btn = nullptr;
-
-	void _version_button_pressed();
 
 	// Project list.
 


### PR DESCRIPTION
There're three places that show a version button in the editor with slightly different texts:

|                 | Text                                      | Tooltip                                                       |
|-----------------|-------------------------------------------|---------------------------------------------------------------|
| Main Editor     | 4.4.dev                                   | Git commit date: %s<br>Click to copy the version information. |
| Project Manager | v4.4.dev.custom_build [HASH]              | Git commit date: %s<br>Click to copy the version information. |
| About Dialog    | Godot Engine v4.4.dev.custom_build [HASH] | Git commit date: %s<br>Click to copy the version number.      |

The text copied by clicking the button is the same `v4.4.dev.custom_build [HASH]`.

This PR adds a dedicated `EditorVersionButton` to avoid repeating version button logic.

- Uses the "copy the version information" version for tooltip.
- Button text can be selected by an enum. 