### PR TITLE
[3.x] Input: add retire option to `is_action_just_pressed()`

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -59,7 +59,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_mouse_button_pressed", "button"), &Input::is_mouse_button_pressed);
 	ClassDB::bind_method(D_METHOD("is_joy_button_pressed", "device", "button"), &Input::is_joy_button_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action", "exact"), &Input::is_action_pressed, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action", "exact"), &Input::is_action_just_pressed, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("is_action_just_pressed", "action", "exact", "retire"), &Input::is_action_just_pressed, DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("is_action_just_released", "action", "exact"), &Input::is_action_just_released, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_action_strength", "action", "exact"), &Input::get_action_strength, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_action_raw_strength", "action", "exact"), &Input::get_action_raw_strength, DEFVAL(false));

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -84,7 +84,7 @@ public:
 	virtual bool is_mouse_button_pressed(int p_button) const = 0;
 	virtual bool is_joy_button_pressed(int p_device, int p_button) const = 0;
 	virtual bool is_action_pressed(const StringName &p_action, bool p_exact = false) const = 0;
-	virtual bool is_action_just_pressed(const StringName &p_action, bool p_exact = false) const = 0;
+	virtual bool is_action_just_pressed(const StringName &p_action, bool p_exact = false, bool p_retire = false) = 0;
 	virtual bool is_action_just_released(const StringName &p_action, bool p_exact = false) const = 0;
 	virtual float get_action_strength(const StringName &p_action, bool p_exact = false) const = 0;
 	virtual float get_action_raw_strength(const StringName &p_action, bool p_exact = false) const = 0;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -201,14 +201,16 @@
 				By default, the deadzone is automatically calculated from the average of the action deadzones. However, you can override the deadzone to be whatever you want (on the range of 0 to 1).
 			</description>
 		</method>
-		<method name="is_action_just_pressed" qualifiers="const">
+		<method name="is_action_just_pressed">
 			<return type="bool" />
 			<argument index="0" name="action" type="String" />
 			<argument index="1" name="exact" type="bool" default="false" />
+			<argument index="2" name="retire" type="bool" default="false" />
 			<description>
 				Returns [code]true[/code] when the user has [i]started[/i] pressing the action event in the current frame or physics tick. It will only return [code]true[/code] on the frame or tick that the user pressed down the button.
 				This is useful for code that needs to run only once when an action is pressed, instead of every frame while it's pressed.
 				If [code]exact[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				If [code]retire[/code] is [code]true[/code], [method is_action_just_pressed] will no longer return [code]true[/code] for a pressed action for subsequent calls on the same frame or tick, unless the action is re-pressed.
 				[b]Note:[/b] Returning [code]true[/code] does not imply that the action is [i]still[/i] pressed. An action can be pressed and released again rapidly, and [code]true[/code] will still be returned so as not to miss input.
 				[b]Note:[/b] Due to keyboard ghosting, [method is_action_just_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
 			</description>

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -230,7 +230,7 @@ public:
 	virtual bool is_mouse_button_pressed(int p_button) const;
 	virtual bool is_joy_button_pressed(int p_device, int p_button) const;
 	virtual bool is_action_pressed(const StringName &p_action, bool p_exact = false) const;
-	virtual bool is_action_just_pressed(const StringName &p_action, bool p_exact = false) const;
+	virtual bool is_action_just_pressed(const StringName &p_action, bool p_exact = false, bool p_retire = false);
 	virtual bool is_action_just_released(const StringName &p_action, bool p_exact = false) const;
 	virtual float get_action_strength(const StringName &p_action, bool p_exact = false) const;
 	virtual float get_action_raw_strength(const StringName &p_action, bool p_exact = false) const;


### PR DESCRIPTION
Retired actions will no longer return `true` to `is_action_just_pressed()` in the same frame / tick (unless re-pressed).

The retiring version would thus be:
```
if Input.is_action_just_pressed("wheel_up", false, true):
```
instead of:
```
if Input.is_action_just_pressed("wheel_up"):
```

Fixes #97526

## Notes
* Adds an optional argument to cancel actions after their first reading for "just pressed".
* This is backward compatible, but considerably simplifies dealing with the problem in #97526 of duplicate "just presses" during `_input()`.
* I also considered adding a new function `retire_action_just_pressed()` but this would have ended up duplicating the existing `is_action_just_pressed()` version in this PR (minus the `retire` argument).
* The advantage of a separate function would be removing the somewhat confusing `false` required for `p_exact`, but neither is completely ideal.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
