### PR TITLE
Expose CameraFeed setters

### DIFF
--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -45,6 +45,34 @@
 				[code]copy[/code] will result in FEED_YCBCR
 			</description>
 		</method>
+		<method name="set_name">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Sets the camera's name.
+			</description>
+		</method>
+		<method name="set_position">
+			<return type="void" />
+			<param index="0" name="position" type="int" enum="CameraFeed.FeedPosition" />
+			<description>
+				Sets the position of this camera.
+			</description>
+		</method>
+		<method name="set_rgb_image">
+			<return type="void" />
+			<param index="0" name="rgb_image" type="Image" />
+			<description>
+				Sets RGB image for this feed.
+			</description>
+		</method>
+		<method name="set_ycbcr_image">
+			<return type="void" />
+			<param index="0" name="ycbcr_image" type="Image" />
+			<description>
+				Sets YCbCr image for this feed.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="feed_is_active" type="bool" setter="set_active" getter="is_active" default="false">

--- a/modules/camera/buffer_decoder.cpp
+++ b/modules/camera/buffer_decoder.cpp
@@ -105,7 +105,7 @@ void SeparateYuyvBufferDecoder::decode(StreamingBuffer p_buffer) {
 		cbcr_image.instantiate(width, height, false, Image::FORMAT_RGB8, cbcr_image_data);
 	}
 
-	camera_feed->set_YCbCr_imgs(y_image, cbcr_image);
+	camera_feed->set_ycbcr_images(y_image, cbcr_image);
 }
 
 YuyvToGrayscaleBufferDecoder::YuyvToGrayscaleBufferDecoder(CameraFeed *p_camera_feed) :
@@ -133,7 +133,7 @@ void YuyvToGrayscaleBufferDecoder::decode(StreamingBuffer p_buffer) {
 		image.instantiate(width, height, false, Image::FORMAT_RGB8, image_data);
 	}
 
-	camera_feed->set_RGB_img(image);
+	camera_feed->set_rgb_image(image);
 }
 
 YuyvToRgbBufferDecoder::YuyvToRgbBufferDecoder(CameraFeed *p_camera_feed) :
@@ -176,7 +176,7 @@ void YuyvToRgbBufferDecoder::decode(StreamingBuffer p_buffer) {
 		image.instantiate(width, height, false, Image::FORMAT_RGB8, image_data);
 	}
 
-	camera_feed->set_RGB_img(image);
+	camera_feed->set_rgb_image(image);
 }
 
 CopyBufferDecoder::CopyBufferDecoder(CameraFeed *p_camera_feed, bool p_rgba) :
@@ -195,7 +195,7 @@ void CopyBufferDecoder::decode(StreamingBuffer p_buffer) {
 		image.instantiate(width, height, false, rgba ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8, image_data);
 	}
 
-	camera_feed->set_RGB_img(image);
+	camera_feed->set_rgb_image(image);
 }
 
 JpegBufferDecoder::JpegBufferDecoder(CameraFeed *p_camera_feed) :
@@ -207,6 +207,6 @@ void JpegBufferDecoder::decode(StreamingBuffer p_buffer) {
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
 	memcpy(dst, p_buffer.start, p_buffer.length);
 	if (image->load_jpg_from_buffer(image_data) == OK) {
-		camera_feed->set_RGB_img(image);
+		camera_feed->set_rgb_image(image);
 	}
 }

--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -182,7 +182,7 @@
 		}
 
 		// set our texture...
-		feed->set_YCbCr_imgs(img[0], img[1]);
+		feed->set_ycbcr_images(img[0], img[1]);
 	}
 
 	// and unlock

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -33,26 +33,23 @@
 #include "servers/rendering_server.h"
 
 void CameraFeed::_bind_methods() {
-	// The setters prefixed with _ are only exposed so we can have feeds through GDExtension!
-	// They should not be called by the end user.
-
 	ClassDB::bind_method(D_METHOD("get_id"), &CameraFeed::get_id);
 
 	ClassDB::bind_method(D_METHOD("is_active"), &CameraFeed::is_active);
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &CameraFeed::set_active);
 
 	ClassDB::bind_method(D_METHOD("get_name"), &CameraFeed::get_name);
-	ClassDB::bind_method(D_METHOD("_set_name", "name"), &CameraFeed::set_name);
+	ClassDB::bind_method(D_METHOD("set_name", "name"), &CameraFeed::set_name);
 
 	ClassDB::bind_method(D_METHOD("get_position"), &CameraFeed::get_position);
-	ClassDB::bind_method(D_METHOD("_set_position", "position"), &CameraFeed::set_position);
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &CameraFeed::set_position);
 
 	// Note, for transform some feeds may override what the user sets (such as ARKit)
 	ClassDB::bind_method(D_METHOD("get_transform"), &CameraFeed::get_transform);
 	ClassDB::bind_method(D_METHOD("set_transform", "transform"), &CameraFeed::set_transform);
 
-	ClassDB::bind_method(D_METHOD("_set_RGB_img", "rgb_img"), &CameraFeed::set_RGB_img);
-	ClassDB::bind_method(D_METHOD("_set_YCbCr_img", "ycbcr_img"), &CameraFeed::set_YCbCr_img);
+	ClassDB::bind_method(D_METHOD("set_rgb_image", "rgb_image"), &CameraFeed::set_rgb_image);
+	ClassDB::bind_method(D_METHOD("set_ycbcr_image", "ycbcr_image"), &CameraFeed::set_ycbcr_image);
 
 	ClassDB::bind_method(D_METHOD("get_datatype"), &CameraFeed::get_datatype);
 
@@ -175,7 +172,7 @@ CameraFeed::~CameraFeed() {
 	RenderingServer::get_singleton()->free(texture[CameraServer::FEED_CBCR_IMAGE]);
 }
 
-void CameraFeed::set_RGB_img(const Ref<Image> &p_rgb_img) {
+void CameraFeed::set_rgb_image(const Ref<Image> &p_rgb_img) {
 	ERR_FAIL_COND(p_rgb_img.is_null());
 	if (active) {
 		int new_width = p_rgb_img->get_width();
@@ -198,7 +195,7 @@ void CameraFeed::set_RGB_img(const Ref<Image> &p_rgb_img) {
 	}
 }
 
-void CameraFeed::set_YCbCr_img(const Ref<Image> &p_ycbcr_img) {
+void CameraFeed::set_ycbcr_image(const Ref<Image> &p_ycbcr_img) {
 	ERR_FAIL_COND(p_ycbcr_img.is_null());
 	if (active) {
 		int new_width = p_ycbcr_img->get_width();
@@ -221,7 +218,7 @@ void CameraFeed::set_YCbCr_img(const Ref<Image> &p_ycbcr_img) {
 	}
 }
 
-void CameraFeed::set_YCbCr_imgs(const Ref<Image> &p_y_img, const Ref<Image> &p_cbcr_img) {
+void CameraFeed::set_ycbcr_images(const Ref<Image> &p_y_img, const Ref<Image> &p_cbcr_img) {
 	ERR_FAIL_COND(p_y_img.is_null());
 	ERR_FAIL_COND(p_cbcr_img.is_null());
 	if (active) {

--- a/servers/camera/camera_feed.h
+++ b/servers/camera/camera_feed.h
@@ -110,9 +110,9 @@ public:
 	virtual ~CameraFeed();
 
 	FeedDataType get_datatype() const;
-	void set_RGB_img(const Ref<Image> &p_rgb_img);
-	void set_YCbCr_img(const Ref<Image> &p_ycbcr_img);
-	void set_YCbCr_imgs(const Ref<Image> &p_y_img, const Ref<Image> &p_cbcr_img);
+	void set_rgb_image(const Ref<Image> &p_rgb_img);
+	void set_ycbcr_image(const Ref<Image> &p_ycbcr_img);
+	void set_ycbcr_images(const Ref<Image> &p_y_img, const Ref<Image> &p_cbcr_img);
 
 	virtual bool set_format(int p_index, const Dictionary &p_parameters);
 	virtual Array get_formats() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes #97504

In Godot 3.x, `CameraFeed` setters like `_set_position`, `_set_RGB_img` are exposed to GDNative for implementing custom camera feeds, but they are no longer visible in GDExtension due to methods starting with underscore being ignored in `extension_api_dump.cpp`

The PR simply removes underscore for these setters, exposing them to end users as the result. I'm not sure if there are better approach.