### PR TITLE
Fix closing Theme Editor not actually closing it

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2386,7 +2386,7 @@ void EditorNode::hide_unused_editors(const Object *p_editing_owner) {
 		// This is to sweep properties that were removed from the inspector.
 		List<ObjectID> to_remove;
 		for (KeyValue<ObjectID, HashSet<EditorPlugin *>> &kv : active_plugins) {
-			const Object *context = ObjectDB::get_instance(kv.key);
+			Object *context = ObjectDB::get_instance(kv.key);
 			if (context) {
 				// In case of self-owning plugins, they are disabled here if they can auto hide.
 				const EditorPlugin *self_owning = Object::cast_to<EditorPlugin>(context);
@@ -2395,7 +2395,7 @@ void EditorNode::hide_unused_editors(const Object *p_editing_owner) {
 				}
 			}
 
-			if (!context) {
+			if (!context || context->call(SNAME("_should_stop_editing"))) {
 				to_remove.push_back(kv.key);
 				for (EditorPlugin *plugin : kv.value) {
 					if (plugin->can_auto_hide()) {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3179,6 +3179,10 @@ void EditorPropertyResource::_update_preferred_shader() {
 	}
 }
 
+bool EditorPropertyResource::_should_stop_editing() const {
+	return !resource_picker->is_toggle_pressed();
+}
+
 void EditorPropertyResource::_viewport_selected(const NodePath &p_path) {
 	Node *to_node = get_node(p_path);
 	if (!Object::cast_to<Viewport>(to_node)) {
@@ -3355,6 +3359,10 @@ void EditorPropertyResource::_notification(int p_what) {
 			}
 		} break;
 	}
+}
+
+void EditorPropertyResource::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_should_stop_editing"), &EditorPropertyResource::_should_stop_editing);
 }
 
 EditorPropertyResource::EditorPropertyResource() {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -683,10 +683,12 @@ class EditorPropertyResource : public EditorProperty {
 
 	void _open_editor_pressed();
 	void _update_preferred_shader();
+	bool _should_stop_editing() const;
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
+	static void _bind_methods();
 
 public:
 	virtual void update_property() override;

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -956,6 +956,10 @@ void EditorResourcePicker::set_toggle_pressed(bool p_pressed) {
 	assign_button->set_pressed(p_pressed);
 }
 
+bool EditorResourcePicker::is_toggle_pressed() const {
+	return assign_button->is_pressed();
+}
+
 void EditorResourcePicker::set_editable(bool p_editable) {
 	editable = p_editable;
 	assign_button->set_disabled(!editable && !edited_resource.is_valid());

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -137,6 +137,7 @@ public:
 	void set_toggle_mode(bool p_enable);
 	bool is_toggle_mode() const;
 	void set_toggle_pressed(bool p_pressed);
+	bool is_toggle_pressed() const;
 
 	void set_editable(bool p_editable);
 	bool is_editable() const;

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3596,6 +3596,13 @@ void ThemeEditor::_theme_close_button_cbk() {
 	}
 }
 
+void ThemeEditor::_scene_closed(const String &p_path) {
+	if (theme.is_valid() && theme->is_built_in() && theme->get_path().get_slice("::", 0) == p_path) {
+		theme = Ref<Theme>();
+		EditorNode::get_singleton()->hide_unused_editors(plugin);
+	}
+}
+
 void ThemeEditor::_add_preview_button_cbk() {
 	preview_scene_dialog->popup_file_dialog();
 }
@@ -3679,7 +3686,10 @@ void ThemeEditor::_preview_control_picked(String p_class_name) {
 
 void ThemeEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_READY: {
+			EditorNode::get_singleton()->connect("scene_closed", callable_mp(this, &ThemeEditor::_scene_closed));
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			preview_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("ThemeEditorPreviewFG"), EditorStringName(EditorStyles)));
 			preview_tabs->add_theme_style_override("tab_unselected", get_theme_stylebox(SNAME("ThemeEditorPreviewBG"), EditorStringName(EditorStyles)));
@@ -3807,71 +3817,7 @@ void ThemeEditorPlugin::make_visible(bool p_visible) {
 }
 
 bool ThemeEditorPlugin::can_auto_hide() const {
-	Ref<Theme> edited_theme = theme_editor->theme;
-	if (edited_theme.is_null()) {
-		return true;
-	}
-
-	Ref<Resource> edited_resource = Ref<Resource>(InspectorDock::get_inspector_singleton()->get_next_edited_object());
-	if (edited_resource.is_null()) {
-		return true;
-	}
-
-	// Don't hide if edited resource used by this theme.
-	Ref<StyleBox> sbox = edited_resource;
-	if (sbox.is_valid()) {
-		List<StringName> type_list;
-		edited_theme->get_stylebox_type_list(&type_list);
-
-		for (const StringName &E : type_list) {
-			List<StringName> list;
-			edited_theme->get_stylebox_list(E, &list);
-
-			for (const StringName &F : list) {
-				if (edited_theme->get_stylebox(F, E) == sbox) {
-					return false;
-				}
-			}
-		}
-		return true;
-	}
-
-	Ref<Texture2D> tex = edited_resource;
-	if (tex.is_valid()) {
-		List<StringName> type_list;
-		edited_theme->get_icon_type_list(&type_list);
-
-		for (const StringName &E : type_list) {
-			List<StringName> list;
-			edited_theme->get_icon_list(E, &list);
-
-			for (const StringName &F : list) {
-				if (edited_theme->get_icon(F, E) == tex) {
-					return false;
-				}
-			}
-		}
-		return true;
-	}
-
-	Ref<Font> fnt = edited_resource;
-	if (fnt.is_valid()) {
-		List<StringName> type_list;
-		edited_theme->get_font_type_list(&type_list);
-
-		for (const StringName &E : type_list) {
-			List<StringName> list;
-			edited_theme->get_font_list(E, &list);
-
-			for (const StringName &F : list) {
-				if (edited_theme->get_font(F, E) == fnt) {
-					return false;
-				}
-			}
-		}
-		return true;
-	}
-	return true;
+	return theme_editor->theme.is_null();
 }
 
 ThemeEditorPlugin::ThemeEditorPlugin() {

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -445,6 +445,7 @@ class ThemeEditor : public VBoxContainer {
 	void _theme_save_button_cbk(bool p_save_as);
 	void _theme_edit_button_cbk();
 	void _theme_close_button_cbk();
+	void _scene_closed(const String &p_path);
 
 	void _add_preview_button_cbk();
 	void _preview_scene_dialog_cbk(const String &p_path);


### PR DESCRIPTION
Fixes #97278

The issue has uncovered a bug in editor closing logic. Folding a resource will call the editor to stop editing it, but the actual unediting code assumed that the EditorPropertyResource no longer exists (which can happen when inspector updates, e.g. when editing another object). Which means the resource wasn't actually unedited.

I wasn't sure how to solve it properly, so I just added `_should_stop_editing` internal method. It's meant for editor contexts to inform whether they are still editing the object or not. EditorPropertyResource will return true when it's folded, so folding a property now properly stops editing it.

Then there is ThemeEditorPlugin, which used the self-owning mechanism added in #81523, but the method for determining whether the editor should be hidden was overly complex and assumed that the Theme is opened in the inspector. I changed it to simply stay open while it edits a valid theme. Which means that Theme Editor will keep Theme reference until you explicitly press Close button; it no longer automatically disappears. Not sure if that's expected behavior, but it's at least convenient 🤔

~~The remaining problem is that when you close the scene, a built-in Theme can still remain referenced, resulting in potential data loss. Not sure about a solution for this one (maybe some WeakRef?), but it's *probably* fine for now.~~ Solved it with `theme_closed` signal, which will automatically close editor if it edits built-in Theme.