### PR TITLE
Use `Dictionary.get_key_list` where appropriate

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -463,9 +463,10 @@ void DependencyRemoveDialog::_find_localization_remaps_of_removed_files(Vector<R
 				p_removed.push_back(dep);
 			}
 
-			Array remap_keys = remaps.keys();
-			for (int j = 0; j < remap_keys.size(); j++) {
-				PackedStringArray remapped_files = remaps[remap_keys[j]];
+			List<Variant> remap_keys;
+			remaps.get_key_list(&remap_keys);
+			for (const Variant &remap_key : remap_keys) {
+				PackedStringArray remapped_files = remaps[remap_key];
 				for (int k = 0; k < remapped_files.size(); k++) {
 					int splitter_pos = remapped_files[k].rfind_char(':');
 					String res_path = remapped_files[k].substr(0, splitter_pos);
@@ -473,7 +474,7 @@ void DependencyRemoveDialog::_find_localization_remaps_of_removed_files(Vector<R
 						String locale_name = remapped_files[k].substr(splitter_pos + 1);
 
 						RemovedDependency dep;
-						dep.file = vformat(TTR("Localization remap for path '%s' and locale '%s'."), remap_keys[j], locale_name);
+						dep.file = vformat(TTR("Localization remap for path '%s' and locale '%s'."), remap_key, locale_name);
 						dep.file_type = "";
 						dep.dependency = path;
 						dep.dependency_folder = files.value;

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -294,9 +294,9 @@ void EditorCommandPalette::register_shortcuts_as_command() {
 
 	// Load command use history.
 	Dictionary command_history = EditorSettings::get_singleton()->get_project_metadata("command_palette", "command_history", Dictionary());
-	Array history_entries = command_history.keys();
-	for (int i = 0; i < history_entries.size(); i++) {
-		const String &history_key = history_entries[i];
+	List<Variant> history_entries;
+	command_history.get_key_list(&history_entries);
+	for (const String history_key : history_entries) {
 		if (commands.has(history_key)) {
 			commands[history_key].last_used = command_history[history_key];
 		}

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1568,7 +1568,9 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	}
 
 	Dictionary int_export = get_internal_export_files(p_preset, p_debug);
-	for (const Variant &int_name : int_export.keys()) {
+	List<Variant> keys;
+	int_export.get_key_list(&keys);
+	for (const Variant &int_name : keys) {
 		const PackedByteArray &array = int_export[int_name];
 		err = save_proxy.save_file(p_udata, int_name, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
 		if (err != OK) {

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -208,9 +208,9 @@ void EditorExportPreset::update_value_overrides() {
 
 		Dictionary plugin_overrides = export_plugins[i]->_get_export_options_overrides(platform);
 		if (!plugin_overrides.is_empty()) {
-			Array keys = plugin_overrides.keys();
-			for (int x = 0; x < keys.size(); x++) {
-				StringName key = keys[x];
+			List<Variant> keys;
+			plugin_overrides.get_key_list(&keys);
+			for (const StringName key : keys) {
 				Variant value = plugin_overrides[key];
 				if (new_value_overrides.has(key) && new_value_overrides[key] != value) {
 					WARN_PRINT_ED(vformat("Editor export plugin '%s' overrides pre-existing export option override '%s' with new value.", export_plugins[i]->get_name(), key));

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2942,12 +2942,13 @@ static Error convert_path_to_uid(ResourceUID::ID p_source_id, const String &p_ha
 }
 
 Error ResourceImporterScene::_check_resource_save_paths(ResourceUID::ID p_source_id, const String &p_hash_suffix, const Dictionary &p_data) {
-	Array keys = p_data.keys();
-	for (int di = 0; di < keys.size(); di++) {
-		Dictionary settings = p_data[keys[di]];
+	List<Variant> keys;
+	p_data.get_key_list(&keys);
+	for (const Variant &key : keys) {
+		Dictionary settings = p_data[key];
 
 		if (bool(settings.get("save_to_file/enabled", false)) && settings.has("save_to_file/path")) {
-			String to_hash = keys[di].operator String() + p_hash_suffix;
+			String to_hash = key.operator String() + p_hash_suffix;
 			Error ret = convert_path_to_uid(p_source_id, to_hash, settings, "save_to_file/path", "save_to_file/fallback_path");
 			ERR_FAIL_COND_V_MSG(ret != OK, ret, vformat("Resource save path %s not valid. Ensure parent directory has been created.", settings.has("save_to_file/path")));
 		}
@@ -2957,7 +2958,7 @@ Error ResourceImporterScene::_check_resource_save_paths(ResourceUID::ID p_source
 			for (int si = 0; si < slice_count; si++) {
 				if (bool(settings.get("slice_" + itos(si + 1) + "/save_to_file/enabled", false)) &&
 						settings.has("slice_" + itos(si + 1) + "/save_to_file/path")) {
-					String to_hash = keys[di].operator String() + p_hash_suffix + itos(si + 1);
+					String to_hash = key.operator String() + p_hash_suffix + itos(si + 1);
 					Error ret = convert_path_to_uid(p_source_id, to_hash, settings,
 							"slice_" + itos(si + 1) + "/save_to_file/path",
 							"slice_" + itos(si + 1) + "/save_to_file/fallback_path");

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -436,9 +436,10 @@ void LocalizationEditor::_filesystem_files_moved(const String &p_old_file, const
 	}
 
 	// Check for the Array elements of the values.
-	Array remap_keys = remaps.keys();
-	for (int i = 0; i < remap_keys.size(); i++) {
-		PackedStringArray remapped_files = remaps[remap_keys[i]];
+	List<Variant> remap_keys;
+	remaps.get_key_list(&remap_keys);
+	for (const Variant &remap_key : remap_keys) {
+		PackedStringArray remapped_files = remaps[remap_key];
 		bool remapped_files_updated = false;
 
 		for (int j = 0; j < remapped_files.size(); j++) {
@@ -452,12 +453,12 @@ void LocalizationEditor::_filesystem_files_moved(const String &p_old_file, const
 				remapped_files.remove_at(j + 1);
 				remaps_changed = true;
 				remapped_files_updated = true;
-				print_verbose(vformat("Changed remap value \"%s\" to \"%s\" of key \"%s\" due to a moved file.", res_path + ":" + locale_name, remapped_files[j], remap_keys[i]));
+				print_verbose(vformat("Changed remap value \"%s\" to \"%s\" of key \"%s\" due to a moved file.", res_path + ":" + locale_name, remapped_files[j], remap_key));
 			}
 		}
 
 		if (remapped_files_updated) {
-			remaps[remap_keys[i]] = remapped_files;
+			remaps[remap_key] = remapped_files;
 		}
 	}
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8097,7 +8097,8 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 	PhysicsDirectSpaceState3D *ss = get_tree()->get_root()->get_world_3d()->get_direct_space_state();
 	PhysicsDirectSpaceState3D::RayResult result;
 
-	Array keys = snap_data.keys();
+	List<Variant> keys;
+	snap_data.get_key_list(&keys);
 
 	// The maximum height an object can travel to be snapped
 	const float max_snap_height = 500.0;
@@ -8108,8 +8109,8 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 	if (keys.size()) {
 		// For snapping to be performed, there must be solid geometry under at least one of the selected nodes.
 		// We need to check this before snapping to register the undo/redo action only if needed.
-		for (int i = 0; i < keys.size(); i++) {
-			Node *node = Object::cast_to<Node>(keys[i]);
+		for (const Variant &key : keys) {
+			Node *node = Object::cast_to<Node>(key);
 			Node3D *sp = Object::cast_to<Node3D>(node);
 			Dictionary d = snap_data[node];
 			Vector3 from = d["from"];
@@ -8131,8 +8132,8 @@ void Node3DEditor::_snap_selected_nodes_to_floor() {
 			undo_redo->create_action(TTR("Snap Nodes to Floor"));
 
 			// Perform snapping if at least one node can be snapped
-			for (int i = 0; i < keys.size(); i++) {
-				Node *node = Object::cast_to<Node>(keys[i]);
+			for (const Variant &key : keys) {
+				Node *node = Object::cast_to<Node>(key);
 				Node3D *sp = Object::cast_to<Node3D>(node);
 				Dictionary d = snap_data[node];
 				Vector3 from = d["from"];

--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -92,9 +92,9 @@ bpy.ops.export_scene.gltf(**opts['gltf_options'])
 
 String dict_to_python(const Dictionary &p_dict) {
 	String entries;
-	Array dict_keys = p_dict.keys();
-	for (int i = 0; i < dict_keys.size(); i++) {
-		const String key = dict_keys[i];
+	List<Variant> dict_keys;
+	p_dict.get_key_list(&dict_keys);
+	for (const String key : dict_keys) {
 		String value;
 		Variant raw_value = p_dict[key];
 
@@ -125,9 +125,9 @@ String dict_to_python(const Dictionary &p_dict) {
 
 String dict_to_xmlrpc(const Dictionary &p_dict) {
 	String members;
-	Array dict_keys = p_dict.keys();
-	for (int i = 0; i < dict_keys.size(); i++) {
-		const String key = dict_keys[i];
+	List<Variant> dict_keys;
+	p_dict.get_key_list(&dict_keys);
+	for (const String key : dict_keys) {
 		String value;
 		Variant raw_value = p_dict[key];
 

--- a/modules/gltf/gltf_template_convert.h
+++ b/modules/gltf/gltf_template_convert.h
@@ -84,9 +84,10 @@ static Dictionary to_dictionary(const HashMap<K, V> &p_inp) {
 template <typename K, typename V>
 static void set_from_dictionary(HashMap<K, V> &r_out, const Dictionary &p_inp) {
 	r_out.clear();
-	Array keys = p_inp.keys();
-	for (int i = 0; i < keys.size(); i++) {
-		r_out[keys[i]] = p_inp[keys[i]];
+	List<Variant> keys;
+	p_inp.get_key_list(&keys);
+	for (const Variant &key : keys) {
+		r_out[key] = p_inp[key];
 	}
 }
 } //namespace GLTFTemplateConvert

--- a/modules/gltf/structures/gltf_skin.cpp
+++ b/modules/gltf/structures/gltf_skin.cpp
@@ -145,9 +145,10 @@ Dictionary GLTFSkin::get_joint_i_to_name() {
 
 void GLTFSkin::set_joint_i_to_name(Dictionary p_joint_i_to_name) {
 	joint_i_to_name = HashMap<int, StringName>();
-	Array keys = p_joint_i_to_name.keys();
-	for (int i = 0; i < keys.size(); i++) {
-		joint_i_to_name[keys[i]] = p_joint_i_to_name[keys[i]];
+	List<Variant> keys;
+	p_joint_i_to_name.get_key_list(&keys);
+	for (const Variant &key : keys) {
+		joint_i_to_name[key] = p_joint_i_to_name[key];
 	}
 }
 
@@ -205,19 +206,25 @@ Error GLTFSkin::from_dictionary(const Dictionary &dict) {
 	ERR_FAIL_COND_V(!dict.has("joint_i_to_bone_i"), ERR_INVALID_DATA);
 	Dictionary joint_i_to_bone_i_dict = dict["joint_i_to_bone_i"];
 	joint_i_to_bone_i.clear();
-	for (int i = 0; i < joint_i_to_bone_i_dict.keys().size(); ++i) {
-		int key = joint_i_to_bone_i_dict.keys()[i];
-		int value = joint_i_to_bone_i_dict[key];
-		joint_i_to_bone_i[key] = value;
+	{
+		List<Variant> keys;
+		joint_i_to_bone_i_dict.get_key_list(&keys);
+		for (int key : keys) {
+			int value = joint_i_to_bone_i_dict[key];
+			joint_i_to_bone_i[key] = value;
+		}
 	}
 
 	ERR_FAIL_COND_V(!dict.has("joint_i_to_name"), ERR_INVALID_DATA);
 	Dictionary joint_i_to_name_dict = dict["joint_i_to_name"];
 	joint_i_to_name.clear();
-	for (int i = 0; i < joint_i_to_name_dict.keys().size(); ++i) {
-		int key = joint_i_to_name_dict.keys()[i];
-		StringName value = joint_i_to_name_dict[key];
-		joint_i_to_name[key] = value;
+	{
+		List<Variant> keys;
+		joint_i_to_name_dict.get_key_list(&keys);
+		for (int key : keys) {
+			StringName value = joint_i_to_name_dict[key];
+			joint_i_to_name[key] = value;
+		}
 	}
 	if (dict.has("godot_skin")) {
 		godot_skin = dict["godot_skin"];

--- a/modules/openxr/editor/openxr_select_runtime.cpp
+++ b/modules/openxr/editor/openxr_select_runtime.cpp
@@ -54,9 +54,9 @@ void OpenXRSelectRuntime::_update_items() {
 	set_item_metadata(index, "");
 	index++;
 
-	Array keys = runtimes.keys();
-	for (int i = 0; i < keys.size(); i++) {
-		String key = keys[i];
+	List<Variant> keys;
+	runtimes.get_key_list(&keys);
+	for (const String key : keys) {
 		String path = runtimes[key];
 		String adj_path = path.replace("~", home_folder);
 

--- a/modules/openxr/extensions/openxr_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper.cpp
@@ -80,9 +80,9 @@ HashMap<String, bool *> OpenXRExtensionWrapper::get_requested_extensions() {
 
 	if (GDVIRTUAL_CALL(_get_requested_extensions, request_extension)) {
 		HashMap<String, bool *> result;
-		Array keys = request_extension.keys();
-		for (int i = 0; i < keys.size(); i++) {
-			String key = keys.get(i);
+		List<Variant> keys;
+		request_extension.get_key_list(&keys);
+		for (const String key : keys) {
 			GDExtensionPtr<bool> value = VariantCaster<GDExtensionPtr<bool>>::cast(request_extension.get(key, GDExtensionPtr<bool>(nullptr)));
 			result.insert(key, value);
 		}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1247,9 +1247,10 @@ void CodeEdit::add_auto_brace_completion_pair(const String &p_open_key, const St
 void CodeEdit::set_auto_brace_completion_pairs(const Dictionary &p_auto_brace_completion_pairs) {
 	auto_brace_completion_pairs.clear();
 
-	Array keys = p_auto_brace_completion_pairs.keys();
-	for (int i = 0; i < keys.size(); i++) {
-		add_auto_brace_completion_pair(keys[i], p_auto_brace_completion_pairs[keys[i]]);
+	List<Variant> keys;
+	p_auto_brace_completion_pairs.get_key_list(&keys);
+	for (const Variant &key : keys) {
+		add_auto_brace_completion_pair(key, p_auto_brace_completion_pairs[key]);
 	}
 }
 


### PR DESCRIPTION
Using a `List<Variant>` when just doing normal iteration is more perfomant than `Array` with the intervening interface

Left cases which rely on the index alone to not make complicated iteration code
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
