### PR TITLE
AudioStreamImport: Allow waveform resize

### DIFF
--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -580,12 +580,10 @@ AudioStreamImportSettingsDialog::AudioStreamImportSettingsDialog() {
 	bar_beats_edit->set_max(32);
 	bar_beats_edit->connect(SceneStringName(value_changed), callable_mp(this, &AudioStreamImportSettingsDialog::_settings_changed).unbind(1));
 	interactive_hb->add_child(bar_beats_edit);
-	interactive_hb->add_spacer();
 	main_vbox->add_margin_child(TTR("Music Playback:"), interactive_hb);
 
 	color_rect = memnew(ColorRect);
-	main_vbox->add_margin_child(TTR("Preview:"), color_rect);
-
+	main_vbox->add_margin_child(TTR("Preview:"), color_rect, true);
 	color_rect->set_custom_minimum_size(Size2(600, 200) * EDSCALE);
 	color_rect->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 


### PR DESCRIPTION
Allow waveform view to resize according to dialog size change:

| Before | Now |
| :---: | :---: |
| ![image](https://github.com/user-attachments/assets/a10edbbe-2480-40a0-acbc-a709dfb58092) | ![image](https://github.com/user-attachments/assets/e42960c3-ab71-4093-b73d-43e8a36fb5e2) |

_Production edit: set the images in a table for easier comprehension_