### PR TITLE
Fix mouse clamping in Animation Bezier Editor box select

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1501,11 +1501,6 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		box_selection_to = mm->get_position();
-
-		if (get_local_mouse_position().y < 0) {
-			// Avoid cursor from going too above, so it does not lose focus with viewport.
-			warp_mouse(Vector2(get_local_mouse_position().x, 0));
-		}
 		queue_redraw();
 	}
 


### PR DESCRIPTION
The mouse was warped to prevent it from going over the 2D/3D editor, since it grabs mouse focus on mouse over. This is no longer necessary, it keeps focus while the mouse is down.
This matches the behavior with the regular Animation Track Editor box select.