### PR TITLE
Add `activate_feed` and `deactivate_feed` virtual bind to CameraFeed

### DIFF
--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -10,6 +10,18 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_activate_feed" qualifiers="virtual">
+			<return type="bool" />
+			<description>
+				Called when the camera feed is activated.
+			</description>
+		</method>
+		<method name="_deactivate_feed" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the camera feed is deactivated.
+			</description>
+		</method>
 		<method name="get_datatype" qualifiers="const">
 			<return type="int" enum="CameraFeed.FeedDataType" />
 			<description>

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -58,6 +58,9 @@ void CameraFeed::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_formats"), &CameraFeed::get_formats);
 	ClassDB::bind_method(D_METHOD("set_format", "index", "parameters"), &CameraFeed::set_format);
 
+	GDVIRTUAL_BIND(_activate_feed);
+	GDVIRTUAL_BIND(_deactivate_feed);
+
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 	ADD_SIGNAL(MethodInfo("format_changed"));
 
@@ -273,12 +276,13 @@ void CameraFeed::set_external(int p_width, int p_height) {
 }
 
 bool CameraFeed::activate_feed() {
-	// nothing to do here
-	return true;
+	bool ret = true;
+	GDVIRTUAL_CALL(_activate_feed, ret);
+	return ret;
 }
 
 void CameraFeed::deactivate_feed() {
-	// nothing to do here
+	GDVIRTUAL_CALL(_deactivate_feed);
 }
 
 bool CameraFeed::set_format(int p_index, const Dictionary &p_parameters) {

--- a/servers/camera/camera_feed.h
+++ b/servers/camera/camera_feed.h
@@ -123,6 +123,9 @@ public:
 
 	virtual bool activate_feed();
 	virtual void deactivate_feed();
+
+	GDVIRTUAL0R(bool, _activate_feed)
+	GDVIRTUAL0(_deactivate_feed)
 };
 
 VARIANT_ENUM_CAST(CameraFeed::FeedDataType);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Follow up of #97534

In order to implement custom CameraFeed in GDExtension, `activate_feed` and `deactivate_feed` need to be override-able by its subclasses, so that their behaviour can be reached when `set_active` is called.

This PR adds virtual bind for these two methods, such that they are exposed to GDExtension binding.