### PR TITLE
Fix Spinbox display does not round properly when using decimal custom arrow steps

### DIFF
--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -66,6 +66,7 @@ class SpinBox : public Range {
 	String suffix;
 	String last_updated_text;
 	double custom_arrow_step = 0.0;
+	bool use_custom_arrow_step = false;
 
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 
@@ -133,6 +134,7 @@ class SpinBox : public Range {
 
 	void _mouse_exited();
 	void _update_buttons_state_for_current_value();
+	void _set_step_no_signal(double p_step);
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #97561