### PR TITLE
[3.x] Document that `Input.is_action` should not be used during input-handling

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -211,6 +211,7 @@
 				If [code]exact[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 				[b]Note:[/b] Returning [code]true[/code] does not imply that the action is [i]still[/i] pressed. An action can be pressed and released again rapidly, and [code]true[/code] will still be returned so as not to miss input.
 				[b]Note:[/b] Due to keyboard ghosting, [method is_action_just_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
+				[b]Note:[/b] During input handling (e.g. [method Node._input]), use [method InputEvent.is_action_pressed] instead to query the action state of the current event.
 			</description>
 		</method>
 		<method name="is_action_just_released" qualifiers="const">
@@ -221,6 +222,7 @@
 				Returns [code]true[/code] when the user [i]stops[/i] pressing the action event in the current frame or physics tick. It will only return [code]true[/code] on the frame or tick that the user releases the button.
 				If [code]exact[/code] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
 				[b]Note:[/b] Returning [code]true[/code] does not imply that the action is [i]still[/i] not pressed. An action can be released and pressed again rapidly, and [code]true[/code] will still be returned so as not to miss input.
+				[b]Note:[/b] During input handling (e.g. [method Node._input]), use [method InputEvent.is_action_released] instead to query the action state of the current event.
 			</description>
 		</method>
 		<method name="is_action_pressed" qualifiers="const">


### PR DESCRIPTION
In most cases `InputEvent.is_action*` is more appropriate during input-handling.

Backport of #80185 .
Helps address #97526 .
Helps address #80158 .

## Notes
* This confusion has come up in master and 3.x.
* Whether to go forward with this depends on whether we intend to use an alternative automated approach (e.g. https://github.com/godotengine/godot-proposals/issues/10843)
* Ideally this documentation would be used in combination with a `WARN_PRINT_ONCE` or similar if e.g. `Input.is_action_just_pressed()` is used withing `_input()`, but that should be a separate PR.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
