### PR TITLE
[3.x] Add warning when calling `is_action_just_pressed()` from `_input()`

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -111,6 +111,12 @@ bool InputDefault::is_action_pressed(const StringName &p_action, bool p_exact) c
 }
 
 bool InputDefault::is_action_just_pressed(const StringName &p_action, bool p_exact) const {
+#ifdef TOOLS_ENABLED
+	if (_currently_parsing_input) {
+		WARN_PRINT_ONCE("Prefer InputEvent.is_action_pressed() within input event callbacks to prevent detecting duplicates.");
+	}
+#endif
+
 	ERR_FAIL_COND_V_MSG(!InputMap::get_singleton()->has_action(p_action), false, InputMap::get_singleton()->suggest_actions(p_action));
 	const Map<StringName, Action>::Element *E = action_state.find(p_action);
 	if (!E) {
@@ -132,6 +138,12 @@ bool InputDefault::is_action_just_pressed(const StringName &p_action, bool p_exa
 }
 
 bool InputDefault::is_action_just_released(const StringName &p_action, bool p_exact) const {
+#ifdef TOOLS_ENABLED
+	if (_currently_parsing_input) {
+		WARN_PRINT_ONCE("Prefer InputEvent.is_action_released() within input event callbacks to prevent detecting duplicates.");
+	}
+#endif
+
 	ERR_FAIL_COND_V_MSG(!InputMap::get_singleton()->has_action(p_action), false, InputMap::get_singleton()->suggest_actions(p_action));
 	const Map<StringName, Action>::Element *E = action_state.find(p_action);
 	if (!E) {
@@ -326,6 +338,10 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 	// This function does the final delivery of the input event to user land.
 	// Regardless where the event came from originally, this has to happen on the main thread.
 	DEV_ASSERT(Thread::get_caller_id() == Thread::get_main_id());
+
+#ifdef TOOLS_ENABLED
+	InputGuard guard(_currently_parsing_input);
+#endif
 
 	// Notes on mouse-touch emulation:
 	// - Emulated mouse events are parsed, that is, re-routed to this method, so they make the same effects

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -114,6 +114,20 @@ class InputDefault : public Input {
 
 	CursorShape default_shape;
 
+#ifdef TOOLS_ENABLED
+	// Simple single-threaded detection of whether
+	// inside `_parse_input_event_impl()`.
+	bool _currently_parsing_input = false;
+	class InputGuard {
+		bool &_currently_parsing;
+
+	public:
+		InputGuard(bool &r_currently_parsing) :
+				_currently_parsing(r_currently_parsing) { _currently_parsing = true; }
+		~InputGuard() { _currently_parsing = false; }
+	};
+#endif
+
 public:
 	enum HatMask {
 		HAT_MASK_CENTER = 0,


### PR DESCRIPTION
Calling `is_action_just_pressed()` and `is_action_just_released()` from `_input()` is liable to cause duplicate detection bugs in user code.

Helps address #97526 .
Helps address #80158 .

## Notes
* This warning prompts users to query `event.is_action_pressed()` (and released) instead of the `just_pressed()` methods from within `_input()`.
* This prevents the possibility of `is_action_just_pressed()` reporting multiple trues when multiple calls to `_input()` occur within the same frame or physics tick.
* This may fire on some existing projects (in a non-spamming fashion) but likely is showing a bug that users didn't know existed in their project.
* The guard is simple single threaded, as the parsing is always done from main thread, so should be no need for mutex.
* Also applicable in 4.x (will need separate PR in case differences there).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
