### PR TITLE
Support object inspection through DAP

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -30,7 +30,6 @@
 
 #include "debug_adapter_parser.h"
 
-#include "core/variant/variant.h"
 #include "editor/debugger/debug_adapter/debug_adapter_types.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -33,8 +33,8 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/io/json.h"
+#include "core/io/marshalls.h"
 #include "editor/debugger/script_editor_debugger.h"
-#include "editor/doc_tools.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
@@ -186,6 +186,8 @@ void DebugAdapterProtocol::reset_stack_info() {
 
 	stackframe_list.clear();
 	variable_list.clear();
+	object_list.clear();
+	object_pending_set.clear();
 }
 
 int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
@@ -671,10 +673,164 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			variable_list.insert(id, arr);
 			return id;
 		}
+		case Variant::OBJECT: {
+			// Objects have to be requested from the debuggee. This has do be done
+			// in a lazy way, as retrieving object properties takes time.
+			EncodedObjectAsID *encoded_obj = Object::cast_to<EncodedObjectAsID>(p_var);
+
+			// Object may be null; in that case, return early.
+			if (!encoded_obj) {
+				return 0;
+			}
+
+			// Object may have been already requested.
+			ObjectID object_id = encoded_obj->get_object_id();
+			if (object_list.has(object_id)) {
+				return object_list[object_id];
+			}
+
+			// Queue requesting the object.
+			int id = variable_id++;
+			object_list.insert(object_id, id);
+			return id;
+		}
 		default:
 			// Simple atomic stuff, or too complex to be manipulated
 			return 0;
 	}
+}
+
+void DebugAdapterProtocol::parse_object(SceneDebuggerObject &p_obj) {
+	// If the object is not on the pending list, we weren't expecting it. Ignore it.
+	ObjectID object_id = p_obj.id;
+	if (!object_pending_set.erase(object_id)) {
+		return;
+	}
+
+	// Populate DAP::Variable's with the object's properties. These properties will be divided by categories.
+	Array properties;
+	Array script_members;
+	Array script_constants;
+	Array script_node;
+	DAP::Variable node_type;
+	Array node_properties;
+
+	for (SceneDebuggerObject::SceneDebuggerProperty &property : p_obj.properties) {
+		PropertyInfo &info = property.first;
+
+		// Script members ("Members/" prefix)
+		if (info.name.begins_with("Members/")) {
+			info.name = info.name.trim_prefix("Members/");
+			script_members.push_back(parse_object_variable(property));
+		}
+
+		// Script constants ("Constants/" prefix)
+		else if (info.name.begins_with("Constants/")) {
+			info.name = info.name.trim_prefix("Constants/");
+			script_constants.push_back(parse_object_variable(property));
+		}
+
+		// Script node ("Node/" prefix)
+		else if (info.name.begins_with("Node/")) {
+			info.name = info.name.trim_prefix("Node/");
+			script_node.push_back(parse_object_variable(property));
+		}
+
+		// Regular categories (with type Variant::NIL)
+		else if (info.type == Variant::NIL) {
+			if (!node_properties.is_empty()) {
+				node_type.value = itos(node_properties.size());
+				variable_list.insert(node_type.variablesReference, node_properties.duplicate());
+				properties.push_back(node_type.to_json());
+			}
+
+			node_type.name = info.name;
+			node_type.type = "Category";
+			node_type.variablesReference = variable_id++;
+			node_properties.clear();
+		}
+
+		// Regular properties.
+		else {
+			node_properties.push_back(parse_object_variable(property));
+		}
+	}
+
+	// Add the last category.
+	if (!node_properties.is_empty()) {
+		node_type.value = itos(node_properties.size());
+		variable_list.insert(node_type.variablesReference, node_properties.duplicate());
+		properties.push_back(node_type.to_json());
+	}
+
+	// Add the script categories, in reverse order to be at the front of the array:
+	// ( [members; constants; node; category1; category2; ...] )
+	if (!script_node.is_empty()) {
+		DAP::Variable node;
+		node.name = "Node";
+		node.type = "Category";
+		node.value = itos(script_node.size());
+		node.variablesReference = variable_id++;
+		variable_list.insert(node.variablesReference, script_node);
+		properties.push_front(node.to_json());
+	}
+
+	if (!script_constants.is_empty()) {
+		DAP::Variable constants;
+		constants.name = "Constants";
+		constants.type = "Category";
+		constants.value = itos(script_constants.size());
+		constants.variablesReference = variable_id++;
+		variable_list.insert(constants.variablesReference, script_constants);
+		properties.push_front(constants.to_json());
+	}
+
+	if (!script_members.is_empty()) {
+		DAP::Variable members;
+		members.name = "Members";
+		members.type = "Category";
+		members.value = itos(script_members.size());
+		members.variablesReference = variable_id++;
+		variable_list.insert(members.variablesReference, script_members);
+		properties.push_front(members.to_json());
+	}
+
+	ERR_FAIL_COND(!object_list.has(object_id));
+	variable_list.insert(object_list[object_id], properties);
+}
+
+const Variant DebugAdapterProtocol::parse_object_variable(const SceneDebuggerObject::SceneDebuggerProperty &p_property) {
+	const PropertyInfo &info = p_property.first;
+	const Variant &value = p_property.second;
+
+	DAP::Variable var;
+	var.name = info.name;
+	var.type = Variant::get_type_name(info.type);
+	var.value = value;
+	var.variablesReference = parse_variant(value);
+
+	return var.to_json();
+}
+
+ObjectID DebugAdapterProtocol::search_object_id(DAPVarID p_var_id) {
+	for (const KeyValue<ObjectID, DAPVarID> &E : object_list) {
+		if (E.value == p_var_id) {
+			return E.key;
+		}
+	}
+	return ObjectID();
+}
+
+bool DebugAdapterProtocol::request_remote_object(const ObjectID &p_object_id) {
+	// If the object is already on the pending list, we don't need to request it again.
+	if (object_pending_set.has(p_object_id)) {
+		return false;
+	}
+
+	EditorDebuggerNode::get_singleton()->get_default_debugger()->request_remote_object(p_object_id);
+	object_pending_set.insert(p_object_id);
+
+	return true;
 }
 
 bool DebugAdapterProtocol::process_message(const String &p_text) {
@@ -984,6 +1140,14 @@ void DebugAdapterProtocol::on_debug_data(const String &p_msg, const Array &p_dat
 	// Ignore data that is already handled by DAP
 	if (p_msg == "debug_enter" || p_msg == "debug_exit" || p_msg == "stack_dump" || p_msg == "stack_frame_vars" || p_msg == "stack_frame_var" || p_msg == "output" || p_msg == "request_quit") {
 		return;
+	}
+
+	if (p_msg == "scene:inspect_object") {
+		// An object was requested from the debuggee; parse it.
+		SceneDebuggerObject remote_obj;
+		remote_obj.deserialize(p_data);
+
+		parse_object(remote_obj);
 	}
 
 	notify_custom_data(p_msg, p_data);

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -35,7 +35,6 @@
 #include "core/io/stream_peer_tcp.h"
 #include "core/io/tcp_server.h"
 
-#include "core/object/object_id.h"
 #include "debug_adapter_parser.h"
 #include "debug_adapter_types.h"
 #include "scene/debugger/scene_debugger.h"
@@ -117,7 +116,7 @@ private:
 	bool _processing_stackdump = false;
 	int _remaining_vars = 0;
 	int _current_frame = 0;
-	uint64_t _request_timeout = 1000;
+	uint64_t _request_timeout = 5000;
 	bool _sync_breakpoints = false;
 
 	String _current_request;

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -31,9 +31,11 @@
 #ifndef DEBUG_ADAPTER_PROTOCOL_H
 #define DEBUG_ADAPTER_PROTOCOL_H
 
+#include "core/debugger/debugger_marshalls.h"
 #include "core/io/stream_peer_tcp.h"
 #include "core/io/tcp_server.h"
 
+#include "core/object/object_id.h"
 #include "debug_adapter_parser.h"
 #include "debug_adapter_types.h"
 #include "scene/debugger/scene_debugger.h"
@@ -103,9 +105,11 @@ private:
 	int parse_variant(const Variant &p_var);
 	void parse_object(SceneDebuggerObject &p_obj);
 	const Variant parse_object_variable(const SceneDebuggerObject::SceneDebuggerProperty &p_property);
+	void parse_evaluation(DebuggerMarshalls::ScriptStackVariable &p_var);
 
 	ObjectID search_object_id(DAPVarID p_var_id);
 	bool request_remote_object(const ObjectID &p_object_id);
+	bool request_remote_evaluate(const String &p_eval, int p_stack_frame);
 
 	bool _initialized = false;
 	bool _processing_breakpoint = false;
@@ -128,6 +132,9 @@ private:
 
 	HashMap<ObjectID, DAPVarID> object_list;
 	HashSet<ObjectID> object_pending_set;
+
+	HashMap<String, DAP::Variable> eval_list;
+	HashSet<String> eval_pending_list;
 
 public:
 	friend class DebugAdapterServer;

--- a/editor/debugger/editor_expression_evaluator.cpp
+++ b/editor/debugger/editor_expression_evaluator.cpp
@@ -64,10 +64,7 @@ void EditorExpressionEvaluator::_evaluate() {
 		return;
 	}
 
-	Array expr_data;
-	expr_data.push_back(expression);
-	expr_data.push_back(editor_debugger->get_stack_script_frame());
-	editor_debugger->send_message("evaluate", expr_data);
+	editor_debugger->request_remote_evaluate(expression, editor_debugger->get_stack_script_frame());
 
 	expression_input->clear();
 }

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -253,6 +253,13 @@ const SceneDebuggerTree *ScriptEditorDebugger::get_remote_tree() {
 	return scene_tree;
 }
 
+void ScriptEditorDebugger::request_remote_evaluate(const String &p_expression, int p_stack_frame) {
+	Array msg;
+	msg.push_back(p_expression);
+	msg.push_back(p_stack_frame);
+	_put_msg("evaluate", msg);
+}
+
 void ScriptEditorDebugger::update_remote_object(ObjectID p_obj_id, const String &p_prop, const Variant &p_value) {
 	Array msg;
 	msg.push_back(p_obj_id);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -254,6 +254,8 @@ public:
 	void request_remote_tree();
 	const SceneDebuggerTree *get_remote_tree();
 
+	void request_remote_evaluate(const String &p_expression, int p_stack_frame);
+
 	void start(Ref<RemoteDebuggerPeer> p_peer);
 	void stop();
 


### PR DESCRIPTION
Closes #97182.

Implements object inspection through DAP. All object properties are bundled in Categories for organization, similarly to what is shown from Godot:
![image](https://github.com/user-attachments/assets/cfe49b57-0f61-43cd-9a4d-cb546ec7543f)
![image](https://github.com/user-attachments/assets/2ca3b3ab-c02f-4cd2-994c-70edddea4aee)

Object inspection is done in a lazy fashion, as the performance impact of querying them is quite significant. DAP IDs are generated for detected object types when parsing `Variant`s, and information is only requested from the debuggee when an explicit `variables` request is made.
