### PR TITLE
[C#] Change generated On{SignalName} to EmitSignal{SignalName}

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/EventSignals_ScriptSignals.generated.cs
@@ -32,7 +32,7 @@ partial class EventSignals
         add => backing_MySignal += value;
         remove => backing_MySignal -= value;
 }
-    protected void OnMySignal(string str, int num)
+    protected void EmitSignalMySignal(string str, int num)
     {
         EmitSignal(SignalName.MySignal, str, num);
     }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -282,7 +282,7 @@ namespace Godot.SourceGenerators
                     .Append(" -= value;\n")
                     .Append("}\n");
 
-                // Generate On{EventName} method to raise the event
+                // Generate EmitSignal{EventName} method to raise the event
 
                 var invokeMethodSymbol = signalDelegate.InvokeMethodData.Method;
                 int paramCount = invokeMethodSymbol.Parameters.Length;
@@ -291,7 +291,7 @@ namespace Godot.SourceGenerators
                     "private" :
                     "protected";
 
-                source.Append($"    {raiseMethodModifiers} void On{signalName}(");
+                source.Append($"    {raiseMethodModifiers} void EmitSignal{signalName}(");
                 for (int i = 0; i < paramCount; i++)
                 {
                     var paramSymbol = invokeMethodSymbol.Parameters[i];

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -3228,10 +3228,10 @@ Error BindingsGenerator::_generate_cs_signal(const BindingsGenerator::TypeInterf
 
 		p_output.append(CLOSE_BLOCK_L1);
 
-		// Generate On{EventName} method to raise the event.
+		// Generate EmitSignal{EventName} method to raise the event.
 		if (!p_itype.is_singleton) {
 			p_output.append(MEMBER_BEGIN "protected void ");
-			p_output << "On" << p_isignal.proxy_name;
+			p_output << "EmitSignal" << p_isignal.proxy_name;
 			if (is_parameterless) {
 				p_output.append("()\n" OPEN_BLOCK_L1 INDENT2);
 				p_output << "EmitSignal(SignalName." << p_isignal.proxy_name << ");\n";


### PR DESCRIPTION
Change the generated `On{SignalName}`, which is introduced in #68233 , to `EmitSignal{SignalName}` 
Editor already generates `_on_{signal_name}` for signal callbacks.
Having `On{SignalName}` introduces confusion and **will likely break user code**, since Godot users are already familiar with `on signal name` for signal callback functions.

Using `EmitSignal{SignalName}` conforms to Godot's name of raising signals `emit_signal`.
The terms and names are consistent between defining signals (using [Signal] attribute) and emitting signals (using EmitSignalName methods). Also it kinda looks great in the intellisense list, like:
* EmitSignal (Godot's original emit_signal)
* EmitSignalPressed
* EmitSignalChanged