### PR TITLE
Add functionality to extrapolate axis in Node3D Editor

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -472,6 +472,8 @@ private:
 	Point2 _get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const;
 
 	Vector3 _get_instance_position(const Point2 &p_pos) const;
+	static Vector3 _guess_orthagonal_vector(const Vector3 p_vector);
+	static Transform3D _get_extrapolated_axis_transform(const Transform3D p_transform);
 	static AABB _calculate_spatial_bounds(const Node3D *p_parent, const Node3D *p_top_level_parent = nullptr);
 
 	Node *_sanitize_preview_node(Node *p_node) const;


### PR DESCRIPTION
Partially fixes #93007

When manipulating `Node3D` in the editor, you tend to get errors if any of the `Scale` axis are set to 0. I've added code to prevent these errors from popping up. 

While this prevents some error spam, it doesn't fix the fact you can't seem to manipulate the `Node3D` with a the gizmo while any of the `Scale` axis are set to 0.