### PR TITLE
Fix `region_filter_clip_enabled` to avoid sprite bleeding for interpolated sprite sheets

### DIFF
--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -76,7 +76,7 @@
 			If [code]true[/code], texture is cut from a larger atlas texture. See [member region_rect].
 		</member>
 		<member name="region_filter_clip_enabled" type="bool" setter="set_region_filter_clip_enabled" getter="is_region_filter_clip_enabled" default="false">
-			If [code]true[/code], the outermost pixels get blurred out. [member region_enabled] must be [code]true[/code].
+			If [code]true[/code], the area outside of the [member region_rect] is clipped to avoid bleeding of the surrounding texture pixels. [member region_enabled] must be [code]true[/code].
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2(0, 0, 0, 0)">
 			The region of the atlas texture to display. [member region_enabled] must be [code]true[/code].

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -579,7 +579,8 @@ void main() {
 
 #endif
 	if (bool(read_draw_data_flags & FLAGS_CLIP_RECT_UV)) {
-		uv = clamp(uv, read_draw_data_src_rect.xy, read_draw_data_src_rect.xy + abs(read_draw_data_src_rect.zw));
+		vec2 half_texpixel = read_draw_data_color_texture_pixel_size * 0.5;
+		uv = clamp(uv, read_draw_data_src_rect.xy + half_texpixel, read_draw_data_src_rect.xy + abs(read_draw_data_src_rect.zw) - half_texpixel);
 	}
 
 #endif

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -493,7 +493,8 @@ void main() {
 
 #endif
 	if (bool(draw_data.flags & FLAGS_CLIP_RECT_UV)) {
-		uv = clamp(uv, draw_data.src_rect.xy, draw_data.src_rect.xy + abs(draw_data.src_rect.zw));
+		vec2 half_texpixel = draw_data.color_texture_pixel_size * 0.5;
+		uv = clamp(uv, draw_data.src_rect.xy + half_texpixel, draw_data.src_rect.xy + abs(draw_data.src_rect.zw) - half_texpixel);
 	}
 
 #endif


### PR DESCRIPTION
Fixes #87847

This PR modifies the fix done in #12828 to reintroduce the `half_texpixel` offset but fix the bug in the original implementation that led to #11417.

My understanding is that the intent of this code was originally to clamp the UV-coordinates to the centers of the outermost texels, which achieves the desired effect of avoiding any sprite bleeding caused by linear interpolation. I believe this was conceptually correct, but a math error resulted in #11417.