### PR TITLE
Update bcdec to latest version

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -652,7 +652,7 @@ Collection of single-file libraries used in Godot components.
 
 - `bcdec.h`
   * Upstream: https://github.com/iOrange/bcdec
-  * Version: git (026acf98ea271045cb10713daa96ba98528badb7, 2022)
+  * Version: git (3b29f8f44466c7d59852670f82f53905cf627d48, 2024)
   * License: MIT
 - `clipper.{cpp,hpp}`
   * Upstream: https://sourceforge.net/projects/polyclipping


### PR DESCRIPTION
Updates bcdec to the newest version, this improves the accuracy and speed of BC1/BC2/BC3 endpoint interpolation.