### PR TITLE
SCons: Fix MSVC decode error

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -807,7 +807,7 @@ def get_compiler_version(env):
 
     if env.msvc and not using_clang(env):
         try:
-            args = [env["VSWHERE"], "-latest", "-products", "*", "-requires", "Microsoft.Component.MSBuild"]
+            args = [env["VSWHERE"], "-latest", "-products", "*", "-requires", "Microsoft.Component.MSBuild", "-utf8"]
             version = subprocess.check_output(args, encoding="utf-8").strip()
             for line in version.splitlines():
                 split = line.split(":", 1)


### PR DESCRIPTION
- (Probably) Fixes #97614

I'm not positive why a unicode decode error is occuring, but I'm fairly confident that recognizing the initial encoding as `sys.stdout.encoding` would fix it. Otherwise, the decode process might have to happen later.