### PR TITLE
[Visual Shader] Fix nodes' relative positions changed in a different display scale.

### DIFF
--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -539,7 +539,7 @@ void VisualShaderGraphPlugin::update_frames(VisualShader::Type p_type, int p_nod
 
 void VisualShaderGraphPlugin::set_node_position(VisualShader::Type p_type, int p_id, const Vector2 &p_position) {
 	if (editor->get_current_shader_type() == p_type && links.has(p_id)) {
-		links[p_id].graph_element->set_position_offset(p_position);
+		links[p_id].graph_element->set_position_offset(p_position * editor->cached_theme_base_scale);
 	}
 }
 
@@ -736,7 +736,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool
 		expression = expression_node->get_expression();
 	}
 
-	node->set_position_offset(visual_shader->get_node_position(p_type, p_id));
+	node->set_position_offset(visual_shader->get_node_position(p_type, p_id) * editor->cached_theme_base_scale);
 
 	node->connect("dragged", callable_mp(editor, &VisualShaderEditor::_node_dragged).bind(p_id));
 
@@ -4169,7 +4169,7 @@ void VisualShaderEditor::_update_varyings() {
 
 void VisualShaderEditor::_node_dragged(const Vector2 &p_from, const Vector2 &p_to, int p_node) {
 	VisualShader::Type type = get_current_shader_type();
-	drag_buffer.push_back({ type, p_node, p_from, p_to });
+	drag_buffer.push_back({ type, p_node, p_from / cached_theme_base_scale, p_to / cached_theme_base_scale });
 	if (!drag_dirty) {
 		callable_mp(this, &VisualShaderEditor::_nodes_dragged).call_deferred();
 	}
@@ -5340,6 +5340,8 @@ void VisualShaderEditor::_notification(int p_what) {
 
 			tools->set_button_icon(get_editor_theme_icon(SNAME("Tools")));
 			preview_tools->set_button_icon(get_editor_theme_icon(SNAME("Tools")));
+
+			cached_theme_base_scale = get_theme_default_base_scale();
 
 			if (is_visible_in_tree()) {
 				_update_graph();

--- a/editor/shader/visual_shader_editor_plugin.h
+++ b/editor/shader/visual_shader_editor_plugin.h
@@ -290,6 +290,8 @@ class VisualShaderEditor : public ShaderEditor {
 	VBoxContainer *param_vbox = nullptr;
 	VBoxContainer *param_vbox2 = nullptr;
 
+	float cached_theme_base_scale = 1.0f;
+
 	enum ShaderModeFlags {
 		MODE_FLAGS_SPATIAL_CANVASITEM = 1,
 		MODE_FLAGS_SKY = 2,


### PR DESCRIPTION
Node positions are not affected by theme scale but their sizes are. Fix this by multiplying GraphElements' positions by the theme scale.

Fix #97484 .

It is worth discussing whether is GraphEdit responsible for maintaining a consistent relative distance between GraphElements under different DPIs.

But in any case, before GraphEdit makes such compatibility-breaking changes, it is worthwhile to make Visual Shader Editor work properly at different DPIs.

## Before:

Graph with 100% display scale:

![屏幕截图 2024-09-29 231628](https://github.com/user-attachments/assets/c0c95e70-aa49-460e-986c-005adc049e1e)

Graph with 200% display scale:

![屏幕截图 2024-09-29 231955](https://github.com/user-attachments/assets/a8398854-8db2-4d14-9474-0cb9894b194c)

## After

Graph with 200% display scale:

![屏幕截图 2024-09-29 231715](https://github.com/user-attachments/assets/eb90bc0b-54a7-4ff1-8acc-7dc78feb382b)

