### PR TITLE
Fix `atr_n()` behavior when auto translation is disabled

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -743,8 +743,13 @@ public:
 	virtual void set_translation_domain(const StringName &p_domain) override;
 	void set_translation_domain_inherited();
 
-	_FORCE_INLINE_ String atr(const String p_message, const StringName p_context = "") const { return can_auto_translate() ? tr(p_message, p_context) : p_message; }
-	_FORCE_INLINE_ String atr_n(const String p_message, const StringName &p_message_plural, int p_n, const StringName p_context = "") const { return can_auto_translate() ? tr_n(p_message, p_message_plural, p_n, p_context) : p_message; }
+	_FORCE_INLINE_ String atr(const String &p_message, const StringName &p_context = "") const { return can_auto_translate() ? tr(p_message, p_context) : p_message; }
+	_FORCE_INLINE_ String atr_n(const String &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const {
+		if (can_auto_translate()) {
+			return tr_n(p_message, p_message_plural, p_n, p_context);
+		}
+		return p_n == 1 ? p_message : String(p_message_plural);
+	}
 
 	/* THREADING */
 


### PR DESCRIPTION
- Fixed the issue that when auto translation is disabled, `atr_n()` always returns the singular version currently.
- Changed `const String p_message` parameters to `const String &p_message`, should be compatible.

There are also inconsistencies about `String` vs `StringName` in the argument list. But fixing it breaks compat.