### PR TITLE
Fix `AudioStreamPlayback`'s `_stop()` not being called when `AudioStreamPlayer`'s `stop()` is called

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1248,6 +1248,8 @@ void AudioServer::stop_playback_stream(Ref<AudioStreamPlayback> p_playback) {
 		return;
 	}
 
+	p_playback->stop();
+
 	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
 	if (!playback_node) {
 		return;


### PR DESCRIPTION
Small fix that resolves #97466 , although I am not very familiar with that part of the code, and where and how the line would be best implemented, because I have very little idea what the rest of the code in the relevant method is about. (Note: Done with assistance from anvilfolk in the Contributor's Chat)