### PR TITLE
SCons: Bump C standard: `C11`→`C17`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -799,8 +799,8 @@ if env["lto"] != "none":
 # This needs to come after `configure`, otherwise we don't have env.msvc.
 if not env.msvc:
     # Specifying GNU extensions support explicitly, which are supported by
-    # both GCC and Clang. Both currently default to gnu11 and gnu++17.
-    env.Prepend(CFLAGS=["-std=gnu11"])
+    # both GCC and Clang. Both currently default to gnu17 and gnu++17.
+    env.Prepend(CFLAGS=["-std=gnu17"])
     env.Prepend(CXXFLAGS=["-std=gnu++17"])
 else:
     # MSVC started offering C standard support with Visual Studio 2019 16.8, which covers all
@@ -809,7 +809,7 @@ else:
     if cc_version_major < 16:
         print_warning("Visual Studio 2017 cannot specify a C-Standard.")
     else:
-        env.Prepend(CFLAGS=["/std:c11"])
+        env.Prepend(CFLAGS=["/std:c17"])
     # MSVC is non-conforming with the C++ standard by default, so we enable more conformance.
     # Note that this is still not complete conformance, as certain Windows-related headers
     # don't compile under complete conformance.


### PR DESCRIPTION
As the leap from C11 to C17 is fairly minor, functioning mostly as a bugfix release[^1], it feels like a reasonable addition now that the C-Standard is properly added in msvc builds. The only context where the C-Standard wouldn't be updated is for anyone using VS2017, but they're already not specifying a C-Standard outright so it's not exactly dealbreaking.

[^1]: https://en.wikipedia.org/wiki/C17_(C_standard_revision)#Changes_from_C11