### PR TITLE
Make the "Quick Open" dialog available via `EditorInterface`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -343,6 +343,14 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="popup_quick_open">
+			<return type="void" />
+			<param index="0" name="callback" type="Callable" />
+			<param index="1" name="base_types" type="StringName[]" default="[]" />
+			<description>
+				Pops up an editor dialog for quick selecting a resource file. The [param callback] must take a single argument of type [String] which will contain the path of the selected resource or be empty if the dialog is canceled. If [param base_types] is provided, the dialog will only show resources that match these types. Only types deriving from [Resource] are supported.
+			</description>
+		</method>
 		<method name="reload_scene_from_path">
 			<return type="void" />
 			<param index="0" name="scene_filepath" type="String" />

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -72,6 +72,7 @@ class EditorInterface : public Object {
 	void _node_selection_canceled(const Callable &p_callback);
 	void _property_selected(const String &p_property_name, const Callable &p_callback);
 	void _property_selection_canceled(const Callable &p_callback);
+	void _quick_open(const String &p_file_path, const Callable &p_callback);
 	void _call_dialog_callback(const Callable &p_callback, const Variant &p_selected, const String &p_context);
 
 	// Editor tools.
@@ -138,6 +139,7 @@ public:
 	void popup_node_selector(const Callable &p_callback, const TypedArray<StringName> &p_valid_types = TypedArray<StringName>(), Node *p_current_value = nullptr);
 	// Must use Vector<int> because exposing Vector<Variant::Type> is not supported.
 	void popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter = PackedInt32Array(), const String &p_current_value = String());
+	void popup_quick_open(const Callable &p_callback, const TypedArray<StringName> &p_base_types = TypedArray<StringName>());
 
 	// Editor docks.
 


### PR DESCRIPTION
Allows to use the "Quick Open" dialog in tool scripts via the `EditorInterface` without exposing internal classes. Works the same as other editor popups added in https://github.com/godotengine/godot/pull/81655.
```gdscript
@tool
extends EditorScript

func _run():
	EditorInterface.popup_quick_open(_on_selected, "Texture2D", true, false, "Select Textures")

static func _on_selected(paths: PackedStringArray):
	print("Paths: %s" % paths)
```
* Closes: https://github.com/godotengine/godot-proposals/issues/3745