### PR TITLE
[macOS] Add native "Edit" menu.

### DIFF
--- a/doc/classes/NativeMenu.xml
+++ b/doc/classes/NativeMenu.xml
@@ -401,6 +401,14 @@
 				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
+		<method name="get_system_menu_no_default_items" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="menu_id" type="int" enum="NativeMenu.SystemMenus" />
+			<description>
+				Returns [code]true[/code] if the system menu with the given [param menu_id] has no default items.
+				[b]Note:[/b] This method is implemented only on macOS.
+			</description>
+		</method>
 		<method name="has_feature" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="feature" type="int" enum="NativeMenu.Feature" />
@@ -720,7 +728,76 @@
 				[b]Note:[/b] This method is implemented only on macOS.
 			</description>
 		</method>
+		<method name="set_system_menu_hidden">
+			<return type="void" />
+			<param index="0" name="menu_id" type="int" enum="NativeMenu.SystemMenus" />
+			<param index="1" name="hidden" type="bool" />
+			<description>
+				Hides/shows the system menu with the given [param menu_id]. Only system menus with no default items can be hidden.
+				[b]Note:[/b] This method is implemented only on macOS.
+			</description>
+		</method>
+		<method name="set_system_menu_name">
+			<return type="void" />
+			<param index="0" name="menu_id" type="int" enum="NativeMenu.SystemMenus" />
+			<param index="1" name="string" type="String" />
+			<description>
+				Sets the name of the system menu with the given [param menu_id] to [param string]. If [param string] is an empty string, the default name for the menu is restored.
+				[b]Note:[/b] On macOS, only [constant FILE_MENU_ID] can be renamed.
+				[b]Note:[/b] This method is implemented only on macOS.
+			</description>
+		</method>
 	</methods>
+	<members>
+		<member name="can_copy" type="bool" setter="set_can_copy" getter="get_can_copy">
+			If [code]true[/code], enables the standard "Copy" menu item.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="can_cut" type="bool" setter="set_can_cut" getter="get_can_cut">
+			If [code]true[/code], enables the standard "Cut" menu item.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="can_paste" type="bool" setter="set_can_paste" getter="get_can_paste">
+			If [code]true[/code], enables the standard "Paste" menu item.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="can_redo" type="bool" setter="set_can_redo" getter="get_can_redo">
+			If [code]true[/code], enables the standard "Redo" menu item.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="can_undo" type="bool" setter="set_can_undo" getter="get_can_undo">
+			If [code]true[/code], enables the standard "Undo" menu item.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="copy" type="Callable" setter="set_copy_callback" getter="get_copy_callback">
+			The callable to emit when the standard "Copy" menu item is selected. If not set, the [code]"ui_copy"[/code] action is triggered.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="cut" type="Callable" setter="set_cut_callback" getter="get_cut_callback">
+			The callable to emit when the standard "Cut" menu item is selected. If not set, the [code]"ui_cut"[/code] action is triggered.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="paste" type="Callable" setter="set_paste_callback" getter="get_paste_callback">
+			The callable to emit when the standard "Paste" menu item is selected. If not set, the [code]"ui_paste"[/code] action is triggered.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="redo" type="Callable" setter="set_redo_callback" getter="get_redo_callback">
+			The callable to emit when the standard "Redo" menu item is selected. If not set, the [code]"ui_redo"[/code] action is triggered.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="redo_description" type="String" setter="set_redo_description" getter="get_redo_description">
+			The custom text to use for the standard "Redo" menu item.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="undo" type="Callable" setter="set_undo_callback" getter="get_undo_callback">
+			The callable to emit when the standard "Undo" menu item is selected. If not set, the [code]"ui_undo"[/code] action is triggered.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+		<member name="undo_description" type="String" setter="set_undo_description" getter="get_undo_description">
+			The custom text to use for the standard "Undo" menu item.
+			[b]Note:[/b] This property is implemented only on macOS.
+		</member>
+	</members>
 	<constants>
 		<constant name="FEATURE_GLOBAL_MENU" value="0" enum="Feature">
 			[NativeMenu] supports native global main menu.
@@ -736,6 +813,9 @@
 		</constant>
 		<constant name="FEATURE_KEY_CALLBACK" value="4" enum="Feature">
 			[NativeMenu] supports menu item accelerator/key callback.
+		</constant>
+		<constant name="FEATURE_COPY_CUT_PASTE_CALLBACK" value="5" enum="Feature">
+			[NativeMenu] supports setting callbacks for "Copy", "Cut", and "Paste" standard items. See [member can_copy], [member can_cut], [member can_paste], [member can_undo], [member can_redo], [member copy], [member cut], [member paste], [member undo], and [member redo].
 		</constant>
 		<constant name="INVALID_MENU_ID" value="0" enum="SystemMenus">
 			Invalid special system menu ID.
@@ -754,6 +834,12 @@
 		</constant>
 		<constant name="DOCK_MENU_ID" value="5" enum="SystemMenus">
 			Dock icon right-click menu ID (on macOS this menu include standard application control items and a list of open windows).
+		</constant>
+		<constant name="EDIT_MENU_ID" value="6" enum="SystemMenus">
+			"Edit" menu ID (on macOS this menu includes "Cut", "Copy", and "Paste" items).
+		</constant>
+		<constant name="FILE_MENU_ID" value="7" enum="SystemMenus">
+			"File" menu ID (on macOS this menu is empty, hidden by default, and shown before the "Edit" menu).
 		</constant>
 	</constants>
 </class>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7383,6 +7383,9 @@ EditorNode::EditorNode() {
 
 	file_menu = memnew(PopupMenu);
 	file_menu->set_name(TTR("Scene"));
+	if (global_menu && NativeMenu::get_singleton()->has_system_menu(NativeMenu::FILE_MENU_ID)) {
+		file_menu->set_system_menu(NativeMenu::FILE_MENU_ID);
+	}
 	main_menu->add_child(file_menu);
 	main_menu->set_menu_tooltip(0, TTR("Operations with scene files."));
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -222,6 +222,8 @@ private:
 	WindowID _create_window(WindowMode p_mode, VSyncMode p_vsync_mode, const Rect2i &p_rect);
 	void _update_window_style(WindowData p_wd, WindowID p_window);
 
+	void _get_action_key(const StringName &p_name, String &r_keycode, unsigned int &r_keymask) const;
+
 	void _update_displays_arrangement() const;
 	Point2i _get_native_screen_position(int p_screen) const;
 	static void _displays_arrangement_changed(CGDirectDisplayID display_id, CGDisplayChangeSummaryFlags flags, void *user_info);

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -43,6 +43,7 @@
 #import "tts_macos.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input_map.h"
 #include "core/io/marshalls.h"
 #include "core/math/geometry_2d.h"
 #include "core/os/keyboard.h"
@@ -3677,6 +3678,34 @@ bool DisplayServerMacOS::mouse_process_popups(bool p_close) {
 	return closed;
 }
 
+void DisplayServerMacOS::_get_action_key(const StringName &p_name, String &r_keycode, unsigned int &r_keymask) const {
+	r_keycode = String();
+	r_keymask = 0;
+
+	const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(p_name);
+	if (!events) {
+		return;
+	}
+	const List<Ref<InputEvent>>::Element *first_event = events->front();
+	if (!first_event) {
+		return;
+	}
+	const Ref<InputEventKey> event = first_event->get();
+	if (event.is_null()) {
+		return;
+	}
+	if (event->get_keycode() != Key::NONE) {
+		r_keycode = KeyMappingMacOS::keycode_get_native_string(event->get_keycode() & KeyModifierMask::CODE_MASK);
+		r_keymask = KeyMappingMacOS::keycode_get_native_mask(event->get_keycode_with_modifiers());
+	} else if (event->get_physical_keycode() != Key::NONE) {
+		r_keycode = KeyMappingMacOS::keycode_get_native_string(event->get_physical_keycode() & KeyModifierMask::CODE_MASK);
+		r_keymask = KeyMappingMacOS::keycode_get_native_mask(event->get_physical_keycode_with_modifiers());
+	} else if (event->get_key_label() != Key::NONE) {
+		r_keycode = KeyMappingMacOS::keycode_get_native_string(event->get_key_label() & KeyModifierMask::CODE_MASK);
+		r_keymask = KeyMappingMacOS::keycode_get_native_mask(event->get_key_label_with_modifiers());
+	}
+}
+
 DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
 	KeyMappingMacOS::initialize();
 
@@ -3764,6 +3793,45 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 	title = [NSString stringWithFormat:NSLocalizedString(@"Quit %@", nil), nsappname];
 	[application_menu addItemWithTitle:title action:@selector(terminate:) keyEquivalent:@"q"];
 
+	NSMenu *file_menu = [[NSMenu alloc] initWithTitle:NSLocalizedString(@"File", nil)];
+	menu_item = [file_menu addItemWithTitle:@"_start_" action:nil keyEquivalent:@""];
+	menu_item.hidden = YES;
+	menu_item.tag = MENU_TAG_START;
+	menu_item = [file_menu addItemWithTitle:@"_end_" action:nil keyEquivalent:@""];
+	menu_item.hidden = YES;
+	menu_item.tag = MENU_TAG_END;
+
+	NSMenu *edit_menu = [[NSMenu alloc] initWithTitle:NSLocalizedString(@"Edit", nil)];
+	[edit_menu setAutoenablesItems:NO];
+	[edit_menu setDelegate:menu_delegate];
+	String keycode;
+	unsigned int keymask = 0;
+
+	_get_action_key("ui_undo", keycode, keymask);
+	NSMenuItem *undo_menu_item = [edit_menu addItemWithTitle:NSLocalizedString(@"Undo", nil) action:@selector(undo:) keyEquivalent:[NSString stringWithUTF8String:keycode.utf8().get_data()]];
+	[undo_menu_item setKeyEquivalentModifierMask:keymask];
+	_get_action_key("ui_redo", keycode, keymask);
+	NSMenuItem *redo_menu_item = [edit_menu addItemWithTitle:NSLocalizedString(@"Redo", nil) action:@selector(redo:) keyEquivalent:[NSString stringWithUTF8String:keycode.utf8().get_data()]];
+	[redo_menu_item setKeyEquivalentModifierMask:keymask];
+	[edit_menu addItem:[NSMenuItem separatorItem]];
+
+	_get_action_key("ui_cut", keycode, keymask);
+	NSMenuItem *cut_menu_item = [edit_menu addItemWithTitle:NSLocalizedString(@"Cut", nil) action:@selector(cut:) keyEquivalent:[NSString stringWithUTF8String:keycode.utf8().get_data()]];
+	[cut_menu_item setKeyEquivalentModifierMask:keymask];
+	_get_action_key("ui_copy", keycode, keymask);
+	NSMenuItem *copy_menu_item = [edit_menu addItemWithTitle:NSLocalizedString(@"Copy", nil) action:@selector(copy:) keyEquivalent:[NSString stringWithUTF8String:keycode.utf8().get_data()]];
+	[copy_menu_item setKeyEquivalentModifierMask:keymask];
+	_get_action_key("ui_paste", keycode, keymask);
+	NSMenuItem *paste_menu_item = [edit_menu addItemWithTitle:NSLocalizedString(@"Paste", nil) action:@selector(paste:) keyEquivalent:[NSString stringWithUTF8String:keycode.utf8().get_data()]];
+	[paste_menu_item setKeyEquivalentModifierMask:keymask];
+	[edit_menu addItem:[NSMenuItem separatorItem]];
+	menu_item = [edit_menu addItemWithTitle:@"_start_" action:nil keyEquivalent:@""];
+	menu_item.hidden = YES;
+	menu_item.tag = MENU_TAG_START;
+	menu_item = [edit_menu addItemWithTitle:@"_end_" action:nil keyEquivalent:@""];
+	menu_item.hidden = YES;
+	menu_item.tag = MENU_TAG_END;
+
 	NSMenu *window_menu = [[NSMenu alloc] initWithTitle:NSLocalizedString(@"Window", nil)];
 	[window_menu addItemWithTitle:NSLocalizedString(@"Minimize", nil) action:@selector(performMiniaturize:) keyEquivalent:@"m"];
 	[window_menu addItemWithTitle:NSLocalizedString(@"Zoom", nil) action:@selector(performZoom:) keyEquivalent:@""];
@@ -3793,6 +3861,13 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 	menu_item = [main_menu addItemWithTitle:@"" action:nil keyEquivalent:@""];
 	[main_menu setSubmenu:application_menu forItem:menu_item];
 
+	NSMenuItem *file_menu_item = [main_menu addItemWithTitle:NSLocalizedString(@"File", nil) action:nil keyEquivalent:@""];
+	file_menu_item.hidden = YES;
+	[main_menu setSubmenu:file_menu forItem:file_menu_item];
+
+	menu_item = [main_menu addItemWithTitle:NSLocalizedString(@"Edit", nil) action:nil keyEquivalent:@""];
+	[main_menu setSubmenu:edit_menu forItem:menu_item];
+
 	menu_item = [main_menu addItemWithTitle:NSLocalizedString(@"Window", nil) action:nil keyEquivalent:@""];
 	[main_menu setSubmenu:window_menu forItem:menu_item];
 
@@ -3801,7 +3876,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 
 	[main_menu setAutoenablesItems:NO];
 
-	native_menu->_register_system_menus(main_menu, application_menu, window_menu, help_menu, dock_menu);
+	native_menu->_register_system_menus(main_menu, application_menu, window_menu, help_menu, dock_menu, edit_menu, file_menu, file_menu_item, copy_menu_item, cut_menu_item, paste_menu_item, undo_menu_item, redo_menu_item);
 
 	//!!!!!!!!!!!!!!!!!!!!!!!!!!
 	//TODO - do Vulkan and OpenGL support checks, driver selection and fallback

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -337,6 +337,43 @@
 	return NO;
 }
 
+// MARK: Edit menu actions
+
+- (void)undo:(id)sender {
+	if (NativeMenu::get_singleton()) {
+		NativeMenuMacOS *nmenu = (NativeMenuMacOS *)NativeMenu::get_singleton();
+		nmenu->_undo_action(window_id);
+	}
+}
+
+- (void)redo:(id)sender {
+	if (NativeMenu::get_singleton()) {
+		NativeMenuMacOS *nmenu = (NativeMenuMacOS *)NativeMenu::get_singleton();
+		nmenu->_redo_action(window_id);
+	}
+}
+
+- (void)copy:(id)sender {
+	if (NativeMenu::get_singleton()) {
+		NativeMenuMacOS *nmenu = (NativeMenuMacOS *)NativeMenu::get_singleton();
+		nmenu->_copy_action(window_id);
+	}
+}
+
+- (void)cut:(id)sender {
+	if (NativeMenu::get_singleton()) {
+		NativeMenuMacOS *nmenu = (NativeMenuMacOS *)NativeMenu::get_singleton();
+		nmenu->_cut_action(window_id);
+	}
+}
+
+- (void)paste:(id)sender {
+	if (NativeMenu::get_singleton()) {
+		NativeMenuMacOS *nmenu = (NativeMenuMacOS *)NativeMenu::get_singleton();
+		nmenu->_paste_action(window_id);
+	}
+}
+
 // MARK: Focus
 
 - (BOOL)canBecomeKeyView {

--- a/platform/macos/native_menu_macos.h
+++ b/platform/macos/native_menu_macos.h
@@ -33,6 +33,7 @@
 #include "core/templates/hash_map.h"
 #include "core/templates/rid_owner.h"
 #include "servers/display/native_menu.h"
+#include "servers/display_server.h"
 
 #import <AppKit/AppKit.h>
 #import <ApplicationServices/ApplicationServices.h>
@@ -57,12 +58,40 @@ class NativeMenuMacOS : public NativeMenu {
 	NSMenu *window_menu_ns = nullptr;
 	NSMenu *help_menu_ns = nullptr;
 	NSMenu *dock_menu_ns = nullptr;
+	NSMenu *edit_menu_ns = nullptr;
+	NSMenu *file_menu_ns = nullptr;
+
+	NSMenuItem *file_menu_item = nullptr;
 
 	RID main_menu;
 	RID application_menu;
 	RID window_menu;
 	RID help_menu;
 	RID dock_menu;
+	RID edit_menu;
+	RID file_menu;
+
+	NSMenuItem *copy_item = nullptr;
+	bool can_copy = true;
+	Callable copy_cb;
+
+	NSMenuItem *cut_item = nullptr;
+	bool can_cut = true;
+	Callable cut_cb;
+
+	NSMenuItem *paste_item = nullptr;
+	bool can_paste = true;
+	Callable paste_cb;
+
+	NSMenuItem *undo_item = nullptr;
+	bool can_undo = true;
+	Callable undo_cb;
+	String undo_description;
+
+	NSMenuItem *redo_item = nullptr;
+	bool can_redo = true;
+	Callable redo_cb;
+	String redo_description;
 
 	int _get_system_menu_start(const NSMenu *p_menu) const;
 	int _get_system_menu_count(const NSMenu *p_menu) const;
@@ -70,8 +99,15 @@ class NativeMenuMacOS : public NativeMenu {
 	NSMenuItem *_menu_add_item(NSMenu *p_menu, const String &p_label, Key p_accel, int p_index, int *r_out);
 
 public:
-	void _register_system_menus(NSMenu *p_main_menu, NSMenu *p_application_menu, NSMenu *p_window_menu, NSMenu *p_help_menu, NSMenu *p_dock_menu);
+	void _register_system_menus(NSMenu *p_main_menu, NSMenu *p_application_menu, NSMenu *p_window_menu, NSMenu *p_help_menu, NSMenu *p_dock_menu, NSMenu *p_edit_menu, NSMenu *p_file_menu, NSMenuItem *p_file_menu_item, NSMenuItem *p_copy_item, NSMenuItem *p_cut_item, NSMenuItem *p_paste_item, NSMenuItem *p_undo_item, NSMenuItem *p_redo_item);
 	NSMenu *_get_dock_menu();
+
+	void _process_ui_event(DisplayServer::WindowID p_window_id, const StringName &p_name);
+	void _copy_action(DisplayServer::WindowID p_window_id);
+	void _cut_action(DisplayServer::WindowID p_window_id);
+	void _paste_action(DisplayServer::WindowID p_window_id);
+	void _undo_action(DisplayServer::WindowID p_window_id);
+	void _redo_action(DisplayServer::WindowID p_window_id);
 
 	void _menu_need_update(NSMenu *p_menu);
 	void _menu_open(NSMenu *p_menu);
@@ -82,6 +118,10 @@ public:
 
 	virtual bool has_system_menu(SystemMenus p_menu_id) const override;
 	virtual RID get_system_menu(SystemMenus p_menu_id) const override;
+
+	virtual bool get_system_menu_no_default_items(SystemMenus p_menu_id) const override;
+	virtual void set_system_menu_name(SystemMenus p_menu_id, const String &p_string) override;
+	virtual void set_system_menu_hidden(SystemMenus p_menu_id, bool p_hidden) override;
 
 	virtual RID create_menu() override;
 	virtual bool has_menu(const RID &p_rid) const override;
@@ -155,6 +195,37 @@ public:
 
 	virtual void remove_item(const RID &p_rid, int p_idx) override;
 	virtual void clear(const RID &p_rid) override;
+
+	virtual void set_can_copy(bool p_enabled) override;
+	virtual bool get_can_copy() const override;
+	virtual void set_copy_callback(const Callable &p_callback) override;
+	virtual Callable get_copy_callback() const override;
+
+	virtual void set_can_cut(bool p_enabled) override;
+	virtual bool get_can_cut() const override;
+	virtual void set_cut_callback(const Callable &p_callback) override;
+	virtual Callable get_cut_callback() const override;
+
+	virtual void set_can_paste(bool p_enabled) override;
+	virtual bool get_can_paste() const override;
+	virtual void set_paste_callback(const Callable &p_callback) override;
+	virtual Callable get_paste_callback() const override;
+
+	virtual void set_can_undo(bool p_enabled) override;
+	virtual bool get_can_undo() const override;
+	virtual void set_undo_callback(const Callable &p_callback) override;
+	virtual Callable get_undo_callback() const override;
+
+	virtual void set_undo_description(const String &p_description) override;
+	virtual String get_undo_description() const override;
+
+	virtual void set_can_redo(bool p_enabled) override;
+	virtual bool get_can_redo() const override;
+	virtual void set_redo_callback(const Callable &p_callback) override;
+	virtual Callable get_redo_callback() const override;
+
+	virtual void set_redo_description(const String &p_description) override;
+	virtual String get_redo_description() const override;
 
 	NativeMenuMacOS();
 	~NativeMenuMacOS();

--- a/platform/macos/native_menu_macos.mm
+++ b/platform/macos/native_menu_macos.mm
@@ -34,9 +34,10 @@
 #import "godot_menu_item.h"
 #import "key_mapping_macos.h"
 
+#include "core/input/input_map.h"
 #include "scene/resources/image_texture.h"
 
-void NativeMenuMacOS::_register_system_menus(NSMenu *p_main_menu, NSMenu *p_application_menu, NSMenu *p_window_menu, NSMenu *p_help_menu, NSMenu *p_dock_menu) {
+void NativeMenuMacOS::_register_system_menus(NSMenu *p_main_menu, NSMenu *p_application_menu, NSMenu *p_window_menu, NSMenu *p_help_menu, NSMenu *p_dock_menu, NSMenu *p_edit_menu, NSMenu *p_file_menu, NSMenuItem *p_file_menu_item, NSMenuItem *p_copy_item, NSMenuItem *p_cut_item, NSMenuItem *p_paste_item, NSMenuItem *p_undo_item, NSMenuItem *p_redo_item) {
 	{
 		MenuData *md = memnew(MenuData);
 		md->menu = p_main_menu;
@@ -44,6 +45,30 @@ void NativeMenuMacOS::_register_system_menus(NSMenu *p_main_menu, NSMenu *p_appl
 		main_menu = menus.make_rid(md);
 		main_menu_ns = p_main_menu;
 		menu_lookup[md->menu] = main_menu;
+	}
+	{
+		MenuData *md = memnew(MenuData);
+		md->menu = p_file_menu;
+		md->is_system = true;
+		file_menu = menus.make_rid(md);
+		file_menu_ns = p_file_menu;
+		menu_lookup[md->menu] = file_menu;
+
+		file_menu_item = p_file_menu_item;
+	}
+	{
+		MenuData *md = memnew(MenuData);
+		md->menu = p_edit_menu;
+		md->is_system = true;
+		edit_menu = menus.make_rid(md);
+		edit_menu_ns = p_edit_menu;
+		menu_lookup[md->menu] = edit_menu;
+
+		copy_item = p_copy_item;
+		cut_item = p_cut_item;
+		paste_item = p_paste_item;
+		undo_item = p_undo_item;
+		redo_item = p_redo_item;
 	}
 	{
 		MenuData *md = memnew(MenuData);
@@ -97,19 +122,166 @@ void NativeMenuMacOS::_menu_open(NSMenu *p_menu) {
 	}
 }
 
+void NativeMenuMacOS::_process_ui_event(DisplayServer::WindowID p_window_id, const StringName &p_name) {
+	DisplayServerMacOS *ds = (DisplayServerMacOS *)DisplayServer::get_singleton();
+	if (!ds) {
+		return;
+	}
+	const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(p_name);
+	if (!events) {
+		return;
+	}
+	const List<Ref<InputEvent>>::Element *first_event = events->front();
+	if (!first_event) {
+		return;
+	}
+
+	const Ref<InputEventKey> event = first_event->get();
+	if (event.is_null()) {
+		return;
+	}
+
+	DisplayServerMacOS::KeyEvent ke;
+	ke.window_id = p_window_id;
+	ke.macos_state = 0;
+	if (event->is_ctrl_pressed()) {
+		ke.macos_state |= NSEventModifierFlagControl;
+	}
+	if (event->is_shift_pressed()) {
+		ke.macos_state |= NSEventModifierFlagShift;
+	}
+	if (event->is_alt_pressed()) {
+		ke.macos_state |= NSEventModifierFlagOption;
+	}
+	if (event->is_meta_pressed()) {
+		ke.macos_state |= NSEventModifierFlagCommand;
+	}
+	ke.pressed = true;
+	ke.echo = false;
+	ke.raw = false;
+	ke.keycode = event->get_keycode();
+	ke.physical_keycode = event->get_physical_keycode();
+	ke.key_label = event->get_key_label();
+	ke.unicode = event->get_unicode();
+
+	ds->push_to_key_event_buffer(ke);
+}
+
+void NativeMenuMacOS::_copy_action(DisplayServer::WindowID p_window_id) {
+	if (copy_cb.is_valid()) {
+		Variant ret;
+		Callable::CallError ce;
+
+		copy_cb.callp(nullptr, 0, ret, ce);
+		if (ce.error == Callable::CallError::CALL_OK) {
+			return;
+		} else {
+			ERR_PRINT(vformat("Failed to execute menu copy callback: %s.", Variant::get_callable_error_text(copy_cb, nullptr, 0, ce)));
+		}
+	}
+	_process_ui_event(p_window_id, "ui_copy");
+}
+
+void NativeMenuMacOS::_cut_action(DisplayServer::WindowID p_window_id) {
+	if (cut_cb.is_valid()) {
+		Variant ret;
+		Callable::CallError ce;
+
+		cut_cb.callp(nullptr, 0, ret, ce);
+		if (ce.error == Callable::CallError::CALL_OK) {
+			return;
+		} else {
+			ERR_PRINT(vformat("Failed to execute menu cut callback: %s.", Variant::get_callable_error_text(cut_cb, nullptr, 0, ce)));
+		}
+	}
+	_process_ui_event(p_window_id, "ui_cut");
+}
+
+void NativeMenuMacOS::_paste_action(DisplayServer::WindowID p_window_id) {
+	if (paste_cb.is_valid()) {
+		Variant ret;
+		Callable::CallError ce;
+
+		paste_cb.callp(nullptr, 0, ret, ce);
+		if (ce.error == Callable::CallError::CALL_OK) {
+			return;
+		} else {
+			ERR_PRINT(vformat("Failed to execute menu paste callback: %s.", Variant::get_callable_error_text(paste_cb, nullptr, 0, ce)));
+		}
+	}
+	_process_ui_event(p_window_id, "ui_paste");
+}
+
+void NativeMenuMacOS::_undo_action(DisplayServer::WindowID p_window_id) {
+	if (undo_cb.is_valid()) {
+		Variant ret;
+		Callable::CallError ce;
+
+		undo_cb.callp(nullptr, 0, ret, ce);
+		if (ce.error == Callable::CallError::CALL_OK) {
+			return;
+		} else {
+			ERR_PRINT(vformat("Failed to execute menu undo callback: %s.", Variant::get_callable_error_text(undo_cb, nullptr, 0, ce)));
+		}
+	}
+	_process_ui_event(p_window_id, "ui_undo");
+}
+
+void NativeMenuMacOS::_redo_action(DisplayServer::WindowID p_window_id) {
+	if (redo_cb.is_valid()) {
+		Variant ret;
+		Callable::CallError ce;
+
+		redo_cb.callp(nullptr, 0, ret, ce);
+		if (ce.error == Callable::CallError::CALL_OK) {
+			return;
+		} else {
+			ERR_PRINT(vformat("Failed to execute menu redo callback: %s.", Variant::get_callable_error_text(redo_cb, nullptr, 0, ce)));
+		}
+	}
+	_process_ui_event(p_window_id, "ui_redo");
+}
+
 void NativeMenuMacOS::_menu_need_update(NSMenu *p_menu) {
 	if (menu_lookup.has(p_menu)) {
 		MenuData *md = menus.get_or_null(menu_lookup[p_menu]);
 		if (md) {
+			Variant ret;
+			Callable::CallError ce;
 			// Note: "is_open" flag is set by "_menu_open", this method is always called before menu is shown, but might be called for the other reasons as well.
 			if (md->open_cb.is_valid()) {
-				Variant ret;
-				Callable::CallError ce;
-
 				// Callback is called directly, since it's expected to modify menu items before it's shown.
 				md->open_cb.callp(nullptr, 0, ret, ce);
 				if (ce.error != Callable::CallError::CALL_OK) {
 					ERR_PRINT(vformat("Failed to execute menu open callback: %s.", Variant::get_callable_error_text(md->open_cb, nullptr, 0, ce)));
+				}
+			}
+			if (p_menu == edit_menu_ns) {
+				if ([[NSApplication sharedApplication] keyWindow].sheet) {
+					[copy_item setEnabled:YES];
+					[cut_item setEnabled:YES];
+					[paste_item setEnabled:YES];
+					[undo_item setEnabled:YES];
+					[redo_item setEnabled:YES];
+					[undo_item setTitle:NSLocalizedString(@"Undo", nil)];
+					[redo_item setTitle:NSLocalizedString(@"Redo", nil)];
+				} else {
+					// Copy item.
+					[copy_item setEnabled:can_copy];
+					[cut_item setEnabled:can_cut];
+					[paste_item setEnabled:can_paste];
+					[undo_item setEnabled:can_undo];
+					[redo_item setEnabled:can_redo];
+					if (undo_description.is_empty()) {
+						[undo_item setTitle:NSLocalizedString(@"Undo", nil)];
+					} else {
+						[undo_item setTitle:[NSString stringWithUTF8String:undo_description.utf8().get_data()]];
+					}
+					if (redo_description.is_empty()) {
+						[redo_item setTitle:NSLocalizedString(@"Redo", nil)];
+					} else {
+						[redo_item setTitle:[NSString stringWithUTF8String:redo_description.utf8().get_data()]];
+					}
 				}
 			}
 		}
@@ -160,10 +332,10 @@ bool NativeMenuMacOS::_is_menu_opened(NSMenu *p_menu) const {
 }
 
 int NativeMenuMacOS::_get_system_menu_start(const NSMenu *p_menu) const {
-	if (p_menu == [NSApp mainMenu]) { // Skip Apple menu.
-		return 1;
+	if (p_menu == [NSApp mainMenu]) { // Skip Apple, File and Edit menu.
+		return 3;
 	}
-	if (p_menu == application_menu_ns || p_menu == window_menu_ns || p_menu == help_menu_ns) {
+	if (p_menu == application_menu_ns || p_menu == window_menu_ns || p_menu == help_menu_ns || p_menu == edit_menu_ns || p_menu == file_menu_ns) {
 		int count = [p_menu numberOfItems];
 		for (int i = 0; i < count; i++) {
 			NSMenuItem *menu_item = [p_menu itemAtIndex:i];
@@ -176,10 +348,10 @@ int NativeMenuMacOS::_get_system_menu_start(const NSMenu *p_menu) const {
 }
 
 int NativeMenuMacOS::_get_system_menu_count(const NSMenu *p_menu) const {
-	if (p_menu == [NSApp mainMenu]) { // Skip Apple, Window and Help menu.
-		return [p_menu numberOfItems] - 3;
+	if (p_menu == [NSApp mainMenu]) { // Skip Apple, File, Edit, Window and Help menu.
+		return [p_menu numberOfItems] - 5;
 	}
-	if (p_menu == application_menu_ns || p_menu == window_menu_ns || p_menu == help_menu_ns) {
+	if (p_menu == application_menu_ns || p_menu == window_menu_ns || p_menu == help_menu_ns || p_menu == edit_menu_ns || p_menu == file_menu_ns) {
 		int start = 0;
 		int count = [p_menu numberOfItems];
 		for (int i = 0; i < count; i++) {
@@ -202,6 +374,7 @@ bool NativeMenuMacOS::has_feature(Feature p_feature) const {
 		case FEATURE_OPEN_CLOSE_CALLBACK:
 		case FEATURE_HOVER_CALLBACK:
 		case FEATURE_KEY_CALLBACK:
+		case FEATURE_COPY_CUT_PASTE_CALLBACK:
 			return true;
 		default:
 			return false;
@@ -215,6 +388,8 @@ bool NativeMenuMacOS::has_system_menu(SystemMenus p_menu_id) const {
 		case WINDOW_MENU_ID:
 		case HELP_MENU_ID:
 		case DOCK_MENU_ID:
+		case EDIT_MENU_ID:
+		case FILE_MENU_ID:
 			return true;
 		default:
 			return false;
@@ -233,8 +408,34 @@ RID NativeMenuMacOS::get_system_menu(SystemMenus p_menu_id) const {
 			return help_menu;
 		case DOCK_MENU_ID:
 			return dock_menu;
+		case EDIT_MENU_ID:
+			return edit_menu;
+		case FILE_MENU_ID:
+			return file_menu;
 		default:
 			return RID();
+	}
+}
+
+bool NativeMenuMacOS::get_system_menu_no_default_items(SystemMenus p_menu_id) const {
+	return p_menu_id == FILE_MENU_ID;
+}
+
+void NativeMenuMacOS::set_system_menu_name(SystemMenus p_menu_id, const String &p_string) {
+	if (p_menu_id == FILE_MENU_ID) {
+		if (p_string.is_empty()) {
+			[file_menu_item setTitle:NSLocalizedString(@"File", nil)];
+			[file_menu_ns setTitle:NSLocalizedString(@"File", nil)];
+		} else {
+			[file_menu_item setTitle:[NSString stringWithUTF8String:p_string.utf8().get_data()]];
+			[file_menu_ns setTitle:[NSString stringWithUTF8String:p_string.utf8().get_data()]];
+		}
+	}
+}
+
+void NativeMenuMacOS::set_system_menu_hidden(SystemMenus p_menu_id, bool p_hidden) {
+	if (p_menu_id == FILE_MENU_ID) {
+		file_menu_item.hidden = p_hidden;
 	}
 }
 
@@ -1291,7 +1492,7 @@ void NativeMenuMacOS::clear(const RID &p_rid) {
 	ERR_FAIL_NULL(md);
 	ERR_FAIL_COND_MSG(_is_menu_opened(md->menu), "Can't remove open menu!");
 
-	if (p_rid == application_menu || p_rid == window_menu || p_rid == help_menu) {
+	if (p_rid == application_menu || p_rid == window_menu || p_rid == help_menu || p_rid == edit_menu || p_rid == file_menu) {
 		int start = _get_system_menu_start(md->menu);
 		int count = _get_system_menu_count(md->menu);
 		for (int i = start + count - 1; i >= start; i--) {
@@ -1302,11 +1503,23 @@ void NativeMenuMacOS::clear(const RID &p_rid) {
 	}
 
 	if (p_rid == main_menu) {
-		// Restore Apple, Window and Help menu.
+		// Restore Apple, File, Edit, Window and Help menu.
 		MenuData *md_app = menus.get_or_null(application_menu);
 		if (md_app) {
 			NSMenuItem *menu_item = [md->menu addItemWithTitle:@"" action:nil keyEquivalent:@""];
 			[md->menu setSubmenu:md_app->menu forItem:menu_item];
+		}
+		MenuData *md_file = menus.get_or_null(file_menu);
+		if (md_file) {
+			NSMenuItem *menu_item = [md->menu addItemWithTitle:@"File" action:nil keyEquivalent:@""];
+			menu_item.hidden = YES;
+			[md->menu setSubmenu:md_file->menu forItem:menu_item];
+			file_menu_item = menu_item;
+		}
+		MenuData *md_edit = menus.get_or_null(edit_menu);
+		if (md_edit) {
+			NSMenuItem *menu_item = [md->menu addItemWithTitle:@"Edit" action:nil keyEquivalent:@""];
+			[md->menu setSubmenu:md_edit->menu forItem:menu_item];
 		}
 		MenuData *md_win = menus.get_or_null(window_menu);
 		if (md_win) {
@@ -1319,6 +1532,102 @@ void NativeMenuMacOS::clear(const RID &p_rid) {
 			[md->menu setSubmenu:md_hlp->menu forItem:menu_item];
 		}
 	}
+}
+
+void NativeMenuMacOS::set_can_copy(bool p_enabled) {
+	can_copy = p_enabled;
+}
+
+bool NativeMenuMacOS::get_can_copy() const {
+	return can_copy;
+}
+
+void NativeMenuMacOS::set_copy_callback(const Callable &p_callback) {
+	copy_cb = p_callback;
+}
+
+Callable NativeMenuMacOS::get_copy_callback() const {
+	return copy_cb;
+}
+
+void NativeMenuMacOS::set_can_cut(bool p_enabled) {
+	can_cut = p_enabled;
+}
+
+bool NativeMenuMacOS::get_can_cut() const {
+	return can_cut;
+}
+
+void NativeMenuMacOS::set_cut_callback(const Callable &p_callback) {
+	cut_cb = p_callback;
+}
+
+Callable NativeMenuMacOS::get_cut_callback() const {
+	return cut_cb;
+}
+
+void NativeMenuMacOS::set_can_paste(bool p_enabled) {
+	can_paste = p_enabled;
+}
+
+bool NativeMenuMacOS::get_can_paste() const {
+	return can_paste;
+}
+
+void NativeMenuMacOS::set_paste_callback(const Callable &p_callback) {
+	paste_cb = p_callback;
+}
+
+Callable NativeMenuMacOS::get_paste_callback() const {
+	return paste_cb;
+}
+
+void NativeMenuMacOS::set_can_undo(bool p_enabled) {
+	can_undo = p_enabled;
+}
+
+bool NativeMenuMacOS::get_can_undo() const {
+	return can_undo;
+}
+
+void NativeMenuMacOS::set_undo_callback(const Callable &p_callback) {
+	undo_cb = p_callback;
+}
+
+Callable NativeMenuMacOS::get_undo_callback() const {
+	return undo_cb;
+}
+
+void NativeMenuMacOS::set_can_redo(bool p_enabled) {
+	can_redo = p_enabled;
+}
+
+bool NativeMenuMacOS::get_can_redo() const {
+	return can_redo;
+}
+
+void NativeMenuMacOS::set_redo_callback(const Callable &p_callback) {
+	redo_cb = p_callback;
+}
+
+Callable NativeMenuMacOS::get_redo_callback() const {
+	return redo_cb;
+}
+
+void NativeMenuMacOS::set_undo_description(const String &p_description) {
+	undo_description = p_description;
+}
+
+String NativeMenuMacOS::get_undo_description() const {
+	return undo_description;
+}
+
+void NativeMenuMacOS::set_redo_description(const String &p_description) {
+	redo_description = p_description;
+}
+
+String NativeMenuMacOS::get_redo_description() const {
+	return redo_description;
 }
 
 NativeMenuMacOS::NativeMenuMacOS() {}
@@ -1343,6 +1652,28 @@ NativeMenuMacOS::~NativeMenuMacOS() {
 			menu_lookup.erase(md->menu);
 			md->menu = nullptr;
 			application_menu_ns = nullptr;
+			memdelete(md);
+		}
+	}
+	if (file_menu.is_valid()) {
+		MenuData *md = menus.get_or_null(file_menu);
+		if (md) {
+			clear(file_menu);
+			menus.free(file_menu);
+			menu_lookup.erase(md->menu);
+			md->menu = nullptr;
+			file_menu_ns = nullptr;
+			memdelete(md);
+		}
+	}
+	if (edit_menu.is_valid()) {
+		MenuData *md = menus.get_or_null(edit_menu);
+		if (md) {
+			clear(edit_menu);
+			menus.free(edit_menu);
+			menu_lookup.erase(md->menu);
+			md->menu = nullptr;
+			edit_menu_ns = nullptr;
 			memdelete(md);
 		}
 	}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -99,6 +99,10 @@ RID PopupMenu::bind_global_menu() {
 		} else {
 			system_menus[system_menu_id] = this;
 			system_menu = nmenu->get_system_menu(system_menu_id);
+			nmenu->set_system_menu_name(system_menu_id, get_name());
+			if (nmenu->get_system_menu_no_default_items(system_menu_id)) {
+				nmenu->set_system_menu_hidden(system_menu_id, false);
+			}
 			global_menu = system_menu;
 		}
 	} else {
@@ -154,6 +158,12 @@ void PopupMenu::unbind_global_menu() {
 
 	if (global_menu == system_menu && system_menus[system_menu_id] == this) {
 		system_menus.erase(system_menu_id);
+		NativeMenu *nmenu = NativeMenu::get_singleton();
+
+		nmenu->set_system_menu_name(system_menu_id, String());
+		if (nmenu->get_system_menu_no_default_items(system_menu_id)) {
+			nmenu->set_system_menu_hidden(system_menu_id, true);
+		}
 	}
 
 	for (int i = 0; i < items.size(); i++) {

--- a/servers/display/native_menu.cpp
+++ b/servers/display/native_menu.cpp
@@ -41,6 +41,10 @@ void NativeMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_system_menu", "menu_id"), &NativeMenu::get_system_menu);
 	ClassDB::bind_method(D_METHOD("get_system_menu_name", "menu_id"), &NativeMenu::get_system_menu_name);
 
+	ClassDB::bind_method(D_METHOD("get_system_menu_no_default_items", "menu_id"), &NativeMenu::get_system_menu_no_default_items);
+	ClassDB::bind_method(D_METHOD("set_system_menu_name", "menu_id", "string"), &NativeMenu::set_system_menu_name);
+	ClassDB::bind_method(D_METHOD("set_system_menu_hidden", "menu_id", "hidden"), &NativeMenu::set_system_menu_hidden);
+
 	ClassDB::bind_method(D_METHOD("create_menu"), &NativeMenu::create_menu);
 	ClassDB::bind_method(D_METHOD("has_menu", "rid"), &NativeMenu::has_menu);
 	ClassDB::bind_method(D_METHOD("free_menu", "rid"), &NativeMenu::free_menu);
@@ -113,11 +117,55 @@ void NativeMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_item", "rid", "idx"), &NativeMenu::remove_item);
 	ClassDB::bind_method(D_METHOD("clear", "rid"), &NativeMenu::clear);
 
+	ClassDB::bind_method(D_METHOD("set_can_copy", "enabled"), &NativeMenu::set_can_copy);
+	ClassDB::bind_method(D_METHOD("get_can_copy"), &NativeMenu::get_can_copy);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "can_copy", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_can_copy", "get_can_copy");
+	ClassDB::bind_method(D_METHOD("set_copy_callback", "callback"), &NativeMenu::set_copy_callback);
+	ClassDB::bind_method(D_METHOD("get_copy_callback"), &NativeMenu::get_copy_callback);
+	ADD_PROPERTY(PropertyInfo(Variant::CALLABLE, "copy", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_copy_callback", "get_copy_callback");
+
+	ClassDB::bind_method(D_METHOD("set_can_cut", "enabled"), &NativeMenu::set_can_cut);
+	ClassDB::bind_method(D_METHOD("get_can_cut"), &NativeMenu::get_can_cut);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "can_cut", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_can_cut", "get_can_cut");
+	ClassDB::bind_method(D_METHOD("set_cut_callback", "callback"), &NativeMenu::set_cut_callback);
+	ClassDB::bind_method(D_METHOD("get_cut_callback"), &NativeMenu::get_cut_callback);
+	ADD_PROPERTY(PropertyInfo(Variant::CALLABLE, "cut", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_cut_callback", "get_cut_callback");
+
+	ClassDB::bind_method(D_METHOD("set_can_paste", "enabled"), &NativeMenu::set_can_paste);
+	ClassDB::bind_method(D_METHOD("get_can_paste"), &NativeMenu::get_can_paste);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "can_paste", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_can_paste", "get_can_paste");
+	ClassDB::bind_method(D_METHOD("set_paste_callback", "callback"), &NativeMenu::set_paste_callback);
+	ClassDB::bind_method(D_METHOD("get_paste_callback"), &NativeMenu::get_paste_callback);
+	ADD_PROPERTY(PropertyInfo(Variant::CALLABLE, "paste", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_paste_callback", "get_paste_callback");
+
+	ClassDB::bind_method(D_METHOD("set_can_undo", "enabled"), &NativeMenu::set_can_undo);
+	ClassDB::bind_method(D_METHOD("get_can_undo"), &NativeMenu::get_can_undo);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "can_undo", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_can_undo", "get_can_undo");
+	ClassDB::bind_method(D_METHOD("set_undo_callback", "callback"), &NativeMenu::set_undo_callback);
+	ClassDB::bind_method(D_METHOD("get_undo_callback"), &NativeMenu::get_undo_callback);
+	ADD_PROPERTY(PropertyInfo(Variant::CALLABLE, "undo", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_undo_callback", "get_undo_callback");
+
+	ClassDB::bind_method(D_METHOD("set_undo_description", "description"), &NativeMenu::set_undo_description);
+	ClassDB::bind_method(D_METHOD("get_undo_description"), &NativeMenu::get_undo_description);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "undo_description", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_undo_description", "get_undo_description");
+
+	ClassDB::bind_method(D_METHOD("set_can_redo", "enabled"), &NativeMenu::set_can_redo);
+	ClassDB::bind_method(D_METHOD("get_can_redo"), &NativeMenu::get_can_redo);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "can_redo", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_can_redo", "get_can_redo");
+	ClassDB::bind_method(D_METHOD("set_redo_callback", "callback"), &NativeMenu::set_redo_callback);
+	ClassDB::bind_method(D_METHOD("get_redo_callback"), &NativeMenu::get_redo_callback);
+	ADD_PROPERTY(PropertyInfo(Variant::CALLABLE, "redo", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_redo_callback", "get_redo_callback");
+
+	ClassDB::bind_method(D_METHOD("set_redo_description", "description"), &NativeMenu::set_redo_description);
+	ClassDB::bind_method(D_METHOD("get_redo_description"), &NativeMenu::get_redo_description);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "redo_description", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_redo_description", "get_redo_description");
+
 	BIND_ENUM_CONSTANT(FEATURE_GLOBAL_MENU);
 	BIND_ENUM_CONSTANT(FEATURE_POPUP_MENU);
 	BIND_ENUM_CONSTANT(FEATURE_OPEN_CLOSE_CALLBACK);
 	BIND_ENUM_CONSTANT(FEATURE_HOVER_CALLBACK);
 	BIND_ENUM_CONSTANT(FEATURE_KEY_CALLBACK);
+	BIND_ENUM_CONSTANT(FEATURE_COPY_CUT_PASTE_CALLBACK);
 
 	BIND_ENUM_CONSTANT(INVALID_MENU_ID);
 	BIND_ENUM_CONSTANT(MAIN_MENU_ID);
@@ -125,6 +173,8 @@ void NativeMenu::_bind_methods() {
 	BIND_ENUM_CONSTANT(WINDOW_MENU_ID);
 	BIND_ENUM_CONSTANT(HELP_MENU_ID);
 	BIND_ENUM_CONSTANT(DOCK_MENU_ID);
+	BIND_ENUM_CONSTANT(EDIT_MENU_ID);
+	BIND_ENUM_CONSTANT(FILE_MENU_ID);
 }
 
 bool NativeMenu::has_feature(Feature p_feature) const {
@@ -152,9 +202,25 @@ String NativeMenu::get_system_menu_name(SystemMenus p_menu_id) const {
 			return "Help menu";
 		case DOCK_MENU_ID:
 			return "Dock menu";
+		case EDIT_MENU_ID:
+			return "Edit menu";
+		case FILE_MENU_ID:
+			return "File menu";
 		default:
 			return "Invalid";
 	}
+}
+
+bool NativeMenu::get_system_menu_no_default_items(SystemMenus p_menu_id) const {
+	return false;
+}
+
+void NativeMenu::set_system_menu_name(SystemMenus p_menu_id, const String &p_string) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+void NativeMenu::set_system_menu_hidden(SystemMenus p_menu_id, bool p_hidden) {
+	WARN_PRINT("Global menus are not supported on this platform.");
 }
 
 RID NativeMenu::create_menu() {
@@ -448,4 +514,112 @@ void NativeMenu::remove_item(const RID &p_rid, int p_idx) {
 
 void NativeMenu::clear(const RID &p_rid) {
 	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+void NativeMenu::set_can_copy(bool p_enabled) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+bool NativeMenu::get_can_copy() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return true;
+}
+
+void NativeMenu::set_copy_callback(const Callable &p_callback) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+Callable NativeMenu::get_copy_callback() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return Callable();
+}
+
+void NativeMenu::set_can_cut(bool p_enabled) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+bool NativeMenu::get_can_cut() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return true;
+}
+
+void NativeMenu::set_cut_callback(const Callable &p_callback) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+Callable NativeMenu::get_cut_callback() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return Callable();
+}
+
+void NativeMenu::set_can_paste(bool p_enabled) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+bool NativeMenu::get_can_paste() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return true;
+}
+
+void NativeMenu::set_paste_callback(const Callable &p_callback) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+Callable NativeMenu::get_paste_callback() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return Callable();
+}
+
+void NativeMenu::set_can_undo(bool p_enabled) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+bool NativeMenu::get_can_undo() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return true;
+}
+
+void NativeMenu::set_undo_callback(const Callable &p_callback) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+Callable NativeMenu::get_undo_callback() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return Callable();
+}
+
+void NativeMenu::set_can_redo(bool p_enabled) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+bool NativeMenu::get_can_redo() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return true;
+}
+
+void NativeMenu::set_redo_callback(const Callable &p_callback) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+Callable NativeMenu::get_redo_callback() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return Callable();
+}
+
+void NativeMenu::set_undo_description(const String &p_description) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+String NativeMenu::get_undo_description() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return String();
+}
+
+void NativeMenu::set_redo_description(const String &p_description) {
+	WARN_PRINT("Global menus are not supported on this platform.");
+}
+
+String NativeMenu::get_redo_description() const {
+	WARN_PRINT("Global menus are not supported on this platform.");
+	return String();
 }

--- a/servers/display/native_menu.h
+++ b/servers/display/native_menu.h
@@ -54,6 +54,7 @@ public:
 		FEATURE_OPEN_CLOSE_CALLBACK,
 		FEATURE_HOVER_CALLBACK,
 		FEATURE_KEY_CALLBACK,
+		FEATURE_COPY_CUT_PASTE_CALLBACK,
 	};
 
 	enum SystemMenus {
@@ -63,6 +64,8 @@ public:
 		WINDOW_MENU_ID,
 		HELP_MENU_ID,
 		DOCK_MENU_ID,
+		EDIT_MENU_ID,
+		FILE_MENU_ID,
 	};
 
 	virtual bool has_feature(Feature p_feature) const;
@@ -70,6 +73,10 @@ public:
 	virtual bool has_system_menu(SystemMenus p_menu_id) const;
 	virtual RID get_system_menu(SystemMenus p_menu_id) const;
 	virtual String get_system_menu_name(SystemMenus p_menu_id) const;
+
+	virtual bool get_system_menu_no_default_items(SystemMenus p_menu_id) const;
+	virtual void set_system_menu_name(SystemMenus p_menu_id, const String &p_string);
+	virtual void set_system_menu_hidden(SystemMenus p_menu_id, bool p_hidden);
 
 	virtual RID create_menu();
 	virtual bool has_menu(const RID &p_rid) const;
@@ -143,6 +150,37 @@ public:
 
 	virtual void remove_item(const RID &p_rid, int p_idx);
 	virtual void clear(const RID &p_rid);
+
+	virtual void set_can_copy(bool p_enabled);
+	virtual bool get_can_copy() const;
+	virtual void set_copy_callback(const Callable &p_callback);
+	virtual Callable get_copy_callback() const;
+
+	virtual void set_can_cut(bool p_enabled);
+	virtual bool get_can_cut() const;
+	virtual void set_cut_callback(const Callable &p_callback);
+	virtual Callable get_cut_callback() const;
+
+	virtual void set_can_paste(bool p_enabled);
+	virtual bool get_can_paste() const;
+	virtual void set_paste_callback(const Callable &p_callback);
+	virtual Callable get_paste_callback() const;
+
+	virtual void set_can_undo(bool p_enabled);
+	virtual bool get_can_undo() const;
+	virtual void set_undo_callback(const Callable &p_callback);
+	virtual Callable get_undo_callback() const;
+
+	virtual void set_undo_description(const String &p_description);
+	virtual String get_undo_description() const;
+
+	virtual void set_can_redo(bool p_enabled);
+	virtual bool get_can_redo() const;
+	virtual void set_redo_callback(const Callable &p_callback);
+	virtual Callable get_redo_callback() const;
+
+	virtual void set_redo_description(const String &p_description);
+	virtual String get_redo_description() const;
 
 	NativeMenu() {
 		singleton = this;


### PR DESCRIPTION
- Adds default "Edit" menu (and some extra functions for native menu to show it after "Scene" in the editor).
- Adds handlers for native cut/copy/paste actions to the content view (redirected as key presses to Godot event handler).

Fixes https://github.com/godotengine/godot/issues/97437 (~I was not able to reproduce crash, but copy-paste now works in native file dialogs~, *Edit: reproduced with updated info and added a fix*).