### PR TITLE
Rework BaseMaterial3D deep parallax implementation and add new features

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -244,6 +244,10 @@
 		<member name="grow_amount" type="float" setter="set_grow" getter="get_grow" default="0.0">
 			Grows object vertices in the direction of their normals. Only effective if [member grow] is [code]true[/code].
 		</member>
+		<member name="heightmap_correct_shadow_receive" type="bool" setter="set_heightmap_deep_parallax_correct_shadow_receive" getter="is_heightmap_deep_parallax_correcting_shadow_receive">
+			If [code]true[/code], makes the material receive shadows at the correct height according to the deep parallax effect. This means the silhouette from the received shadows will match the material's shape. This also allows the material to receive self-shadowing from lights, which can be visible at grazing angles if the shadow is sharp enough (this works best with [OmniLight3D] and [SpotLight3D]). This internally makes the deep parallax effect write to [code]LIGHT_VERTEX[/code] in the shader. Enabling this has a small performance impact.
+			[b]Note:[/b] Enabling this can result in self-shadowing artifacts if the lights have a shadow bias that is too low, or if the material has a [member heightmap_scale] that is too high. Enabling [member heightmap_write_depth] at the same time can alleviate those self-shadowing artifacts, with the associated performance cost of that feature.
+		</member>
 		<member name="heightmap_deep_parallax" type="bool" setter="set_heightmap_deep_parallax" getter="is_heightmap_deep_parallax_enabled" default="false">
 			If [code]true[/code], uses parallax occlusion mapping to represent depth in the material instead of simple offset mapping (see [member heightmap_enabled]). This results in a more convincing depth effect, but is much more expensive on the GPU. Only enable this on materials where it makes a significant visual difference.
 		</member>
@@ -277,6 +281,15 @@
 			The texture to use as a height map. See also [member heightmap_enabled].
 			For best results, the texture should be normalized (with [member heightmap_scale] reduced to compensate). In [url=https://gimp.org]GIMP[/url], this can be done using [b]Colors &gt; Auto &gt; Equalize[/b]. If the texture only uses a small part of its available range, the parallax effect may look strange, especially when the camera moves.
 			[b]Note:[/b] To reduce memory usage and improve loading times, you may be able to use a lower-resolution heightmap texture as most heightmaps are only comprised of low-frequency data.
+		</member>
+		<member name="heightmap_trim_edges" type="bool" setter="set_heightmap_deep_parallax_trim_edges" getter="is_heightmap_deep_parallax_trimming_edges">
+			If [code]true[/code], makes the material able to change its silhouette according to the deep parallax effect. shadows at the correct height according to the deep parallax effect. This means the silhouette from the received shadows will match the material's shape. This internally makes the deep parallax effect write to [code]LIGHT_VERTEX[/code] in the shader. See also [member heightmap_write_depth].
+			[b]Note:[/b] Enabling this can result in artifacts depending on the mesh's UV layout. This effect may not look correct on all meshes as a result.
+			[b]Note:[/b] Enabling this prevents the depth prepass from working, which has a moderate performance impact.
+		</member>
+		<member name="heightmap_write_depth" type="bool" setter="set_heightmap_deep_parallax_write_depth" getter="is_heightmap_deep_parallax_writing_depth">
+			If [code]true[/code], makes the material's silhouette able to correctly interact with other meshes in the scene according to the deep parallax effect. This allows the material to better blend in with other materials in the scene, regardless of whether the other material has deep parallax enabled. This internally makes the deep parallax effect write to [code]DEPTH[/code] in the shader. See also [member heightmap_trim_edges].
+			[b]Note:[/b] Enabling this enables depth writing and prevents the depth prepass from working, which has a significant performance impact
 		</member>
 		<member name="metallic" type="float" setter="set_metallic" getter="get_metallic" default="0.0">
 			A high value makes the material appear more like a metal. Non-metals use their albedo as the diffuse color and add diffuse to the specular reflection. With non-metals, the reflection appears on top of the albedo color. Metals use their albedo as a multiplier to the specular reflection and set the diffuse color to black resulting in a tinted reflection. Materials work better when fully metal or fully non-metal, values between [code]0[/code] and [code]1[/code] should only be used for blending between metal and non-metal sections. To alter the amount of reflection use [member roughness].

--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -289,7 +289,7 @@
 		</member>
 		<member name="heightmap_write_depth" type="bool" setter="set_heightmap_deep_parallax_write_depth" getter="is_heightmap_deep_parallax_writing_depth">
 			If [code]true[/code], makes the material's silhouette able to correctly interact with other meshes in the scene according to the deep parallax effect. This allows the material to better blend in with other materials in the scene, regardless of whether the other material has deep parallax enabled. This internally makes the deep parallax effect write to [code]DEPTH[/code] in the shader. See also [member heightmap_trim_edges].
-			[b]Note:[/b] Enabling this enables depth writing and prevents the depth prepass from working, which has a significant performance impact
+			[b]Note:[/b] Enabling this enables depth writing and prevents the depth prepass from working, which has a significant performance impact.
 		</member>
 		<member name="metallic" type="float" setter="set_metallic" getter="get_metallic" default="0.0">
 			A high value makes the material appear more like a metal. Non-metals use their albedo as the diffuse color and add diffuse to the specular reflection. With non-metals, the reflection appears on top of the albedo color. Metals use their albedo as a multiplier to the specular reflection and set the diffuse color to black resulting in a tinted reflection. Materials work better when fully metal or fully non-metal, values between [code]0[/code] and [code]1[/code] should only be used for blending between metal and non-metal sections. To alter the amount of reflection use [member roughness].

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1507,6 +1507,18 @@ vec4 triplanar_texture(sampler2D p_sampler, vec3 p_weights, vec3 p_triplanar_pos
 )";
 	}
 
+	if (features[FEATURE_HEIGHT_MAPPING]) {
+		code += R"(
+vec4 height_texture(sampler2D p_sampler, vec2 uv) {
+)";
+		if (flags[FLAG_INVERT_HEIGHTMAP]) {
+			code += "	return texture(p_sampler, uv);\n";
+		} else {
+			code += "	return 1.0 - texture(p_sampler, uv);\n";
+		}
+		code += "}\n";
+	}
+
 	// Generate fragment shader.
 	code += R"(
 void fragment() {)";
@@ -1554,51 +1566,113 @@ void fragment() {)";
 			// Multiply the heightmap scale by 0.01 to improve heightmap scale usability.
 			code += R"(
 		// Height Deep Parallax: Enabled
-		float num_layers = mix(float(heightmap_max_layers), float(heightmap_min_layers), abs(dot(vec3(0.0, 0.0, 1.0), view_dir)));
-		float layer_depth = 1.0 / num_layers;
-		float current_layer_depth = 0.0;
-		vec2 p = view_dir.xy * heightmap_scale * 0.01;
-		vec2 delta = p / num_layers;
+
+		vec3 view_direction = normalize(VIEW);
+		mat3 tangent_basis = mat3(
+				TANGENT,
+				-BINORMAL,
+				NORMAL);
+
+		vec3 tangent_view_dir = transpose(tangent_basis) * view_direction;
+
 		vec2 ofs = base_uv;
-)";
-			if (flags[FLAG_INVERT_HEIGHTMAP]) {
-				code += "		float depth = texture(texture_heightmap, ofs).r;\n";
-			} else {
-				code += "		float depth = 1.0 - texture(texture_heightmap, ofs).r;\n";
+		vec2 final_tex_coords;
+		float offset;
+		{
+			const float HEIGHT_SCALE_FACTOR = 0.01;
+
+			float num_layers = mix(float(heightmap_max_layers), float(heightmap_min_layers), abs(dot(vec3(0.0, 0.0, 1.0), tangent_view_dir)));
+			// Calculate the size of each layer.
+			float layer_depth = 1.0 / num_layers;
+			// Depth of current layer.
+			float current_layer_depth = 0.0;
+			// The amount to shift the texture coordinates per layer (from vector P).
+			vec2 P = tangent_view_dir.xy / tangent_view_dir.z * heightmap_scale * HEIGHT_SCALE_FACTOR;
+			vec2 delta_tex_coords = P / num_layers * 0.5;
+
+			// Get initial values.
+			vec2 current_tex_coords = ofs;
+			float current_depth_map_value = height_texture(texture_heightmap, current_tex_coords).r;
+
+			while (current_layer_depth < current_depth_map_value) {
+				// Shift texture coordinates along direction of P.
+				current_tex_coords -= delta_tex_coords;
+				// Get depthmap value at current texture coordinates.
+				current_depth_map_value = height_texture(texture_heightmap, current_tex_coords).r;
+				// Get depth of next layer.
+				current_layer_depth += layer_depth;
 			}
-			code += R"(
-		float current_depth = 0.0;
-		while (current_depth < depth) {
-			ofs -= delta;
-)";
-			if (flags[FLAG_INVERT_HEIGHTMAP]) {
-				code += "			depth = texture(texture_heightmap, ofs).r;\n";
-			} else {
-				code += "			depth = 1.0 - texture(texture_heightmap, ofs).r;\n";
-			}
-			code += R"(
-			current_depth += layer_depth;
+
+			// Get texture coordinates before collision (reverse operations).
+			vec2 prev_tex_coords = current_tex_coords + delta_tex_coords;
+
+			// Get depth after and before collision for linear interpolation.
+			float after_depth = current_depth_map_value - current_layer_depth;
+			float before_depth = height_texture(texture_heightmap, prev_tex_coords).r - current_layer_depth + layer_depth;
+
+			// Interpolate texture coordinates to make low layer counts look smoother.
+			float weight = after_depth / (after_depth - before_depth);
+
+			offset = current_layer_depth / abs(dot(vec3(0.0, 0.0, 1.0), tangent_view_dir)) * heightmap_scale * HEIGHT_SCALE_FACTOR;
+			ofs = prev_tex_coords * weight + current_tex_coords * (1.0 - weight);
 		}
-
-		vec2 prev_ofs = ofs + delta;
-		float after_depth = depth - current_depth;
 )";
-			if (flags[FLAG_INVERT_HEIGHTMAP]) {
-				code += "		float before_depth = texture(texture_heightmap, prev_ofs).r - current_depth + layer_depth;\n";
-			} else {
-				code += "		float before_depth = (1.0 - texture(texture_heightmap, prev_ofs).r) - current_depth + layer_depth;\n";
+			if (heightmap_parallax_trim_edges) {
+				code += R"(
+
+		// Height Deep Parallax Trim Edges: Enabled
+		// Discard if outside UV bounds to make depth visible on the mesh's edges.
+		// We undo the UV1 scale/offset here so that texture repeat can work.
+		vec2 ofs_unscaled = ofs / uv1_scale.xy - uv1_offset.xy;
+		if (ofs_unscaled.x > 1.0 || ofs_unscaled.y > 1.0 || ofs_unscaled.x < 0.0 || ofs_unscaled.y < 0.0) {
+			discard;
+		})";
 			}
+
 			code += R"(
-		float weight = after_depth / (after_depth - before_depth);
-		ofs = mix(ofs, prev_ofs, weight);
+#if CURRENT_RENDERER == RENDERER_COMPATIBILITY
+		vec4 view_position = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, FRAGCOORD.z * 2.0 - 1.0, 1.0);
+#else
+		vec4 view_position = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, FRAGCOORD.z, 1.0);
+#endif
+		view_position.xyz /= view_position.w;
+		view_position.xyz -= offset * view_direction;
+
+		vec4 ndc_position = PROJECTION_MATRIX * vec4(view_position.xyz, 1.0);
+		ndc_position.xyz /= ndc_position.w;
 )";
 
-		} else {
-			if (flags[FLAG_INVERT_HEIGHTMAP]) {
-				code += "		float depth = texture(texture_heightmap, base_uv).r;\n";
-			} else {
-				code += "		float depth = 1.0 - texture(texture_heightmap, base_uv).r;\n";
+			if (heightmap_parallax_correct_shadow_receive) {
+				code += R"(
+		// Height Deep Parallax Correct Shadow Receive: Enabled
+		LIGHT_VERTEX -= offset * view_direction;
+)";
 			}
+
+			if (heightmap_parallax_write_depth) {
+				code += R"(
+		// Height Deep Parallax Write Depth: Enabled
+)";
+				if (!heightmap_parallax_trim_edges) {
+					code += R"(
+		if (false) {
+			// Calling `discard` anywhere prevents the depth prepass from running,
+			// as it breaks writing to depth.
+			discard;
+		}
+)";
+				}
+
+				code += R"(
+#if CURRENT_RENDERER == RENDERER_COMPATIBILITY
+		DEPTH = ndc_position.z * 0.5 + 0.5;
+#else
+		DEPTH = ndc_position.z;
+#endif
+)";
+			}
+		} else {
+			code += "		float depth = height_texture(texture_heightmap, base_uv).r;\n";
 			// Use offset limiting to improve the appearance of non-deep parallax.
 			// This reduces the impression of depth, but avoids visible warping in the distance.
 			// Multiply the heightmap scale by 0.01 to improve heightmap scale usability.
@@ -2660,7 +2734,12 @@ void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
-	if ((p_property.name == "heightmap_min_layers" || p_property.name == "heightmap_max_layers") && !deep_parallax) {
+	if ((p_property.name == "heightmap_min_layers" ||
+				p_property.name == "heightmap_max_layers" ||
+				p_property.name == "heightmap_correct_shadow_receive" ||
+				p_property.name == "heightmap_write_depth" ||
+				p_property.name == "heightmap_trim_edges") &&
+			!deep_parallax) {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 
@@ -2904,6 +2983,45 @@ void BaseMaterial3D::set_heightmap_deep_parallax_flip_binormal(bool p_flip) {
 
 bool BaseMaterial3D::get_heightmap_deep_parallax_flip_binormal() const {
 	return heightmap_parallax_flip_binormal;
+}
+
+void BaseMaterial3D::set_heightmap_deep_parallax_correct_shadow_receive(bool p_enable) {
+	if (heightmap_parallax_correct_shadow_receive == p_enable) {
+		return;
+	}
+
+	heightmap_parallax_correct_shadow_receive = p_enable;
+	_queue_shader_change();
+}
+
+bool BaseMaterial3D::is_heightmap_deep_parallax_correcting_shadow_receive() const {
+	return heightmap_parallax_correct_shadow_receive;
+}
+
+void BaseMaterial3D::set_heightmap_deep_parallax_write_depth(bool p_enable) {
+	if (heightmap_parallax_write_depth == p_enable) {
+		return;
+	}
+
+	heightmap_parallax_write_depth = p_enable;
+	_queue_shader_change();
+}
+
+bool BaseMaterial3D::is_heightmap_deep_parallax_writing_depth() const {
+	return heightmap_parallax_write_depth;
+}
+
+void BaseMaterial3D::set_heightmap_deep_parallax_trim_edges(bool p_enable) {
+	if (heightmap_parallax_trim_edges == p_enable) {
+		return;
+	}
+
+	heightmap_parallax_trim_edges = p_enable;
+	_queue_shader_change();
+}
+
+bool BaseMaterial3D::is_heightmap_deep_parallax_trimming_edges() const {
+	return heightmap_parallax_trim_edges;
 }
 
 void BaseMaterial3D::set_grow_enabled(bool p_enable) {
@@ -3513,6 +3631,15 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_heightmap_deep_parallax_flip_binormal", "flip"), &BaseMaterial3D::set_heightmap_deep_parallax_flip_binormal);
 	ClassDB::bind_method(D_METHOD("get_heightmap_deep_parallax_flip_binormal"), &BaseMaterial3D::get_heightmap_deep_parallax_flip_binormal);
 
+	ClassDB::bind_method(D_METHOD("set_heightmap_deep_parallax_correct_shadow_receive", "enable"), &BaseMaterial3D::set_heightmap_deep_parallax_correct_shadow_receive);
+	ClassDB::bind_method(D_METHOD("is_heightmap_deep_parallax_correcting_shadow_receive"), &BaseMaterial3D::is_heightmap_deep_parallax_correcting_shadow_receive);
+
+	ClassDB::bind_method(D_METHOD("set_heightmap_deep_parallax_write_depth", "enable"), &BaseMaterial3D::set_heightmap_deep_parallax_write_depth);
+	ClassDB::bind_method(D_METHOD("is_heightmap_deep_parallax_writing_depth"), &BaseMaterial3D::is_heightmap_deep_parallax_writing_depth);
+
+	ClassDB::bind_method(D_METHOD("set_heightmap_deep_parallax_trim_edges", "enable"), &BaseMaterial3D::set_heightmap_deep_parallax_trim_edges);
+	ClassDB::bind_method(D_METHOD("is_heightmap_deep_parallax_trimming_edges"), &BaseMaterial3D::is_heightmap_deep_parallax_trimming_edges);
+
 	ClassDB::bind_method(D_METHOD("set_grow", "amount"), &BaseMaterial3D::set_grow);
 	ClassDB::bind_method(D_METHOD("get_grow"), &BaseMaterial3D::get_grow);
 
@@ -3683,6 +3810,9 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "heightmap_max_layers", PROPERTY_HINT_RANGE, "1,64,1"), "set_heightmap_deep_parallax_max_layers", "get_heightmap_deep_parallax_max_layers");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "heightmap_flip_tangent"), "set_heightmap_deep_parallax_flip_tangent", "get_heightmap_deep_parallax_flip_tangent");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "heightmap_flip_binormal"), "set_heightmap_deep_parallax_flip_binormal", "get_heightmap_deep_parallax_flip_binormal");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "heightmap_correct_shadow_receive"), "set_heightmap_deep_parallax_correct_shadow_receive", "is_heightmap_deep_parallax_correcting_shadow_receive");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "heightmap_write_depth"), "set_heightmap_deep_parallax_write_depth", "is_heightmap_deep_parallax_writing_depth");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "heightmap_trim_edges"), "set_heightmap_deep_parallax_trim_edges", "is_heightmap_deep_parallax_trimming_edges");
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "heightmap_texture", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), "set_texture", "get_texture", TEXTURE_HEIGHTMAP);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "heightmap_flip_texture"), "set_flag", "get_flag", FLAG_INVERT_HEIGHTMAP);
 
@@ -3999,6 +4129,9 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	set_heightmap_deep_parallax_min_layers(8);
 	set_heightmap_deep_parallax_max_layers(32);
 	set_heightmap_deep_parallax_flip_tangent(false); //also sets binormal
+	set_heightmap_deep_parallax_correct_shadow_receive(true);
+	set_heightmap_deep_parallax_write_depth(false);
+	set_heightmap_deep_parallax_trim_edges(false);
 
 	set_z_clip_scale(1.0);
 	set_fov_override(75.0);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1630,11 +1630,7 @@ void fragment() {)";
 			}
 
 			code += R"(
-#if CURRENT_RENDERER == RENDERER_COMPATIBILITY
-		vec4 view_position = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, FRAGCOORD.z * 2.0 - 1.0, 1.0);
-#else
 		vec4 view_position = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, FRAGCOORD.z, 1.0);
-#endif
 		view_position.xyz /= view_position.w;
 		view_position.xyz -= offset * view_direction;
 
@@ -1664,11 +1660,7 @@ void fragment() {)";
 				}
 
 				code += R"(
-#if CURRENT_RENDERER == RENDERER_COMPATIBILITY
-		DEPTH = ndc_position.z * 0.5 + 0.5;
-#else
 		DEPTH = ndc_position.z;
-#endif
 )";
 			}
 		} else {

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -383,6 +383,9 @@ private:
 		// booleans
 		uint64_t invalid_key : 1;
 		uint64_t deep_parallax : 1;
+		uint64_t heightmap_parallax_correct_shadow_receive : 1;
+		uint64_t heightmap_parallax_write_depth : 1;
+		uint64_t heightmap_parallax_trim_edges : 1;
 		uint64_t grow : 1;
 		uint64_t proximity_fade : 1;
 		uint64_t orm : 1;
@@ -434,6 +437,9 @@ private:
 		mk.specular_mode = specular_mode;
 		mk.billboard_mode = billboard_mode;
 		mk.deep_parallax = deep_parallax;
+		mk.heightmap_parallax_correct_shadow_receive = heightmap_parallax_correct_shadow_receive;
+		mk.heightmap_parallax_write_depth = heightmap_parallax_write_depth;
+		mk.heightmap_parallax_trim_edges = heightmap_parallax_trim_edges;
 		mk.grow = grow_enabled;
 		mk.proximity_fade = proximity_fade_enabled;
 		mk.distance_fade = distance_fade;
@@ -586,6 +592,9 @@ private:
 	int deep_parallax_max_layers = 0;
 	bool heightmap_parallax_flip_tangent = false;
 	bool heightmap_parallax_flip_binormal = false;
+	bool heightmap_parallax_correct_shadow_receive = true;
+	bool heightmap_parallax_write_depth = false;
+	bool heightmap_parallax_trim_edges = false;
 
 	bool proximity_fade_enabled = false;
 	float proximity_fade_distance = 0.0f;
@@ -701,6 +710,15 @@ public:
 
 	void set_heightmap_deep_parallax_flip_binormal(bool p_flip);
 	bool get_heightmap_deep_parallax_flip_binormal() const;
+
+	void set_heightmap_deep_parallax_correct_shadow_receive(bool p_enable);
+	bool is_heightmap_deep_parallax_correcting_shadow_receive() const;
+
+	void set_heightmap_deep_parallax_write_depth(bool p_enable);
+	bool is_heightmap_deep_parallax_writing_depth() const;
+
+	void set_heightmap_deep_parallax_trim_edges(bool p_enable);
+	bool is_heightmap_deep_parallax_trimming_edges() const;
 
 	void set_subsurface_scattering_strength(float p_subsurface_scattering_strength);
 	float get_subsurface_scattering_strength() const;


### PR DESCRIPTION
The deep parallax effect now features built-in interpolation to make low layer counts look better. It also integrates Z correction for a more convincing depth effect at oblique angles.

The new features are disabled by default, but allow for greater realism at a performance cost. Each of them can be enabled separately:

- **Correct Shadow Receive:** This allows the material to receive shadows (and even cast self-shadows) according to the deep parallax effect. Self-shadowing is powered by the existing shadow map system, so it works best with sharp shadows such as the ones cast by OmniLight3D and SpotLight3D, especially when placed at grazing angles. This only has a small performance cost, but it can cause self-shadowing artifacts if lights have a shadow bias that's too low or if the material has a heightmap scale that's too high. Enabling **Write Depth** at the same time can alleviate those self-shadowing artifacts, with the associated performance cost of that feature.
  - For a self-shadowing implementation that works directly in the shader (without even needing lights to have shadows enabled), https://github.com/godotengine/godot-proposals/issues/8671 would have to be implemented first.

- **Write Depth:** This allows the material to correctly interact with other materials in the scene, regardless of whether the other materials have deep parallax enabled. This has a significant performance cost.

- **Trim Edges:** This allows the material to have its silhouette affected by the deep parallax effect. This works best with certain UV layouts, but it can have artifacts if the UV layout has visible seams. This has a moderate performance cost.

Thanks to @sphynx-owner who made the [initial implementation](https://github.com/sphynx-owner/parallax-mapping) and Tentabrobpy from the Godot VFX Discord for further assistance :slightly_smiling_face:

- This closes https://github.com/godotengine/godot/pull/62002 by superseding it and partially addresses https://github.com/godotengine/godot-proposals/issues/1843.

**Testing project:** https://github.com/Calinou/godot-parallax-test-4.0

## Preview

![Parallax 1](https://github.com/user-attachments/assets/3c1c11f4-a85c-4968-9f6f-51ce97976b27) | ![Parallax 2](https://github.com/user-attachments/assets/fd6489c8-4bb3-4eb6-8943-1f642ae96191)
-|-
![Parallax 3](https://github.com/user-attachments/assets/99a46690-b8b0-4cb1-8db6-a465ad44d59a) | ![Parallax 4](https://github.com/user-attachments/assets/04140729-7985-44ad-b870-aea4a4517e12)

https://github.com/user-attachments/assets/dd05ffc9-a40e-4caa-8562-c9df72c06be0

https://github.com/user-attachments/assets/5571e5e3-002d-436d-86f9-e77c8ae1c291

### Comparison with default settings

### 8/32 layers (default quality)

Before | After
-|-
![Before](https://github.com/user-attachments/assets/228df17b-e802-4021-bcf5-221169ca93f3) | ![After](https://github.com/user-attachments/assets/e85d34c5-03fb-4875-8adc-13c61f1d4458)

### 64/64 layers (maximum quality)

Before | After
-|-
![Before](https://github.com/user-attachments/assets/30ec7021-d8b4-446f-9ca8-c7a888ee5370) | ![After](https://github.com/user-attachments/assets/6d01558d-95a1-4361-9e31-43c9e27856ed)

### Visual impact of each feature being toggled

None | CSR[^1] | WD[^2] | 
-|-|-
![none png webp](https://github.com/user-attachments/assets/42730844-5656-4cda-90a7-9575357c4c67) | ![csr png webp](https://github.com/user-attachments/assets/041d5ffe-498c-4c56-810e-3d13f9fd1c57) | ![wd png webp](https://github.com/user-attachments/assets/f4642b84-209a-4613-a57f-f2524a571e77)

TE[^3] | CSR[^1] + WD[^2] | CSR[^1] + TE[^3] |
-|-|-
![te png webp](https://github.com/user-attachments/assets/159d3777-0b3f-495a-8a58-568357c8c991) | ![csr_wd png webp](https://github.com/user-attachments/assets/a11ae028-2f1f-4b89-8474-f31e4ee48462) | ![csr_te png webp](https://github.com/user-attachments/assets/34afa493-b20c-4002-bbbf-9f5cd0d91af5)

WD[^2] + TE[^3] | CSR[^1] + WD[^2] + TE[^3]
-|-
![wd_te png webp](https://github.com/user-attachments/assets/ccd596f2-fa73-4ced-b379-4480ddea3a75) | ![csr_wd_te png webp](https://github.com/user-attachments/assets/32d6cf8a-4a9a-4ea3-b100-881d1c301f23)

[^1]: Correct Shadow Receive
[^2]: Write Depth
[^3]: Trim Edges

## Benchmark

<details open>

<summary>PC specifications</summary>

- **CPU:** Intel Core i9-13900K
- **GPU:** NVIDIA GeForce RTX 4090
- **RAM:** 64 GB (2×32 GB DDR5-5800 C30)
- **SSD:** Solidigm P44 Pro 2 TB
- **OS:** Linux (Fedora 40)
</details>

*Measured using the [test scene](https://github.com/Calinou/godot-parallax-test-4.0
) shown in the Before/After comparison before. Materials cover most (but not all) of the view. Using a 3840×2160 viewport.*

Features | Performance
-|-
None | 843 FPS (1.19 mspf)
CSR[^1] | 856 FPS (1.17 mspf)
WD[^2] | 351 FPS (2.85 mspf)
TE[^3] | 689 FPS (1.45 mspf)
CSR[^1] + WD[^2] | 350 FPS (2.86 mspf)
CSR[^1] + TE[^3] | 689 FPS (1.45 mspf)
WD[^2] + TE[^3] | 341 FPS (2.93 mspf)
CSR[^1] + WD[^2] + TE[^3] | 344 FPS (2.91 mspf)

## TODO

- [ ] Investigate **Correct Shadow Receive** not having a visible effect when using the Compatibility rendering method. Is it due to an engine bug?
- [ ] Investigate **Write Depth** being broken when using the Compatibility rendering method.  Is it due to an engine bug, or is some kind of specific adjustment needed here?
  - Since this is a demanding feature, it could also always be disabled when using Compatibility. 
  - **Edit:** Possible hint at why it's broken: https://github.com/godotengine/godot/pull/100211#discussion_r1876524444
- [ ] When **Write Depth** is enabled, see if we can disable the depth prepass without having to use `discard` within `if (false)`. Since **Write Depth** does not actually require using `discard`, doing so would probably improve performance a bit. For reference, the Mobile rendering method (which lacks a depth prepass) works fine without this `discard` statement (although removing it reintroduces the occasional self-shadowing artifacts that occur when **Correct Shadow Receive** is enabled).
  - [ ] Or, better, see if the depth prepass can be kept when **Write Depth** is enabled, by having the depth prepass shrink the material's vertices (only within the depth prepass), so that it can still be effective and improve performance significantly.
- [ ] Check the interactions with the UV Scale property again to ensure **Correct Shadow Receive** looks as good as possible regardless of the scale. Right now, it can get a bit off when the scale is changed from the default (i.e. when the texture tiles more often), although it's not too noticeable during actual gameplay.
- [ ] Consider combining **Correct Shadow Receive** and **Write Depth** into a single enum option, since there isn't much point in having **Write Depth** enabled but not **Correct Shadow Receive**. This means there would be 3 options provided: **Disabled**, **Correct Shadow Receive**, **Correct Shadow Receive + Write Depth**.