### PR TITLE
Fix `emulate_mouse_from_touch` setting affecting editor

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3191,6 +3191,10 @@ Error Main::setup2(bool p_show_boot_logo) {
 			}
 
 			id->set_emulate_mouse_from_touch(bool(GLOBAL_DEF_BASIC("input_devices/pointing/emulate_mouse_from_touch", true)));
+
+			if (editor) {
+				id->set_emulate_mouse_from_touch(true);
+			}
 		}
 
 		OS::get_singleton()->benchmark_end_measure("Startup", "Setup Window and Boot");


### PR DESCRIPTION
Fixes #96784, #84207
Make `emulate_mouse_from_touch` always true in the editor.