### PR TITLE
GUI: Only cancel completion with the `ui_cancel` action

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -570,10 +570,6 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		} else {
 			update_code_completion = (allow_unicode_handling && k->get_unicode() >= 32);
 		}
-
-		if (!update_code_completion) {
-			cancel_code_completion();
-		}
 	}
 
 	/* MISC */


### PR DESCRIPTION
Fixes #97640

`update_code_completion` will be used to determine whether options need to be refiltered, and in this context it makes sense to not do that with unicode characters from the C0 group, but I don't see a reason why they should cancel completion.
