### PR TITLE
Check for duplicate input events when adding to action

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -56,6 +56,15 @@ void ActionMapEditor::_event_config_confirmed() {
 	Dictionary new_action = current_action.duplicate();
 	Array events = new_action["events"].duplicate();
 
+	// Check for duplicate events on action
+	for (Ref<InputEvent> event : events) {
+		if (ev->is_match(event, true)) {
+			warning->set_text(TTR(vformat("Action \"%s\" already has an Event with this Input.", current_action_name)));
+			warning->popup_centered();
+			return;
+		}
+	}
+
 	if (current_action_event_index == -1) {
 		// Add new event
 		events.push_back(ev);
@@ -620,4 +629,9 @@ ActionMapEditor::ActionMapEditor() {
 
 	message = memnew(AcceptDialog);
 	add_child(message);
+
+	warning = memnew(AcceptDialog);
+	add_child(warning);
+	warning->set_title(TTR("Input Configuration Warning!"));
+	warning->set_flag(Window::FLAG_POPUP, true);
 }

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -59,7 +59,8 @@ void ActionMapEditor::_event_config_confirmed() {
 	// Check for duplicate events on action
 	for (Ref<InputEvent> event : events) {
 		if (ev->is_match(event, true)) {
-			show_message(TTR(vformat("Action \"%s\" already has an Event with this Input.", current_action_name)));
+			warning->set_text(TTR(vformat("Action \"%s\" already has an Event with this Input.", current_action_name)));
+			warning->popup_centered();
 			return;
 		}
 	}
@@ -628,4 +629,9 @@ ActionMapEditor::ActionMapEditor() {
 
 	message = memnew(AcceptDialog);
 	add_child(message);
+
+	warning = memnew(AcceptDialog);
+	add_child(warning);
+	warning->set_title(TTR("Input Configuration Warning!"));
+	warning->set_flag(Window::FLAG_POPUP, true);
 }

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -59,8 +59,7 @@ void ActionMapEditor::_event_config_confirmed() {
 	// Check for duplicate events on action
 	for (Ref<InputEvent> event : events) {
 		if (ev->is_match(event, true)) {
-			warning->set_text(TTR(vformat("Action \"%s\" already has an Event with this Input.", current_action_name)));
-			warning->popup_centered();
+			show_message(TTR(vformat("Action \"%s\" already has an Event with this Input.", current_action_name)));
 			return;
 		}
 	}
@@ -629,9 +628,4 @@ ActionMapEditor::ActionMapEditor() {
 
 	message = memnew(AcceptDialog);
 	add_child(message);
-
-	warning = memnew(AcceptDialog);
-	add_child(warning);
-	warning->set_title(TTR("Input Configuration Warning!"));
-	warning->set_flag(Window::FLAG_POPUP, true);
 }

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -78,6 +78,7 @@ private:
 
 	InputEventConfigurationDialog *event_config_dialog = nullptr;
 	AcceptDialog *message = nullptr;
+	AcceptDialog *warning = nullptr;
 
 	// Filtering and Adding actions
 

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -78,7 +78,6 @@ private:
 
 	InputEventConfigurationDialog *event_config_dialog = nullptr;
 	AcceptDialog *message = nullptr;
-	AcceptDialog *warning = nullptr;
 
 	// Filtering and Adding actions
 


### PR DESCRIPTION
Addresses #95283.

Displays a warning message when a duplicate Input Event is added to an Action in the Input Map. 
Up for any suggestions if we want to handle this differently.

---

Attempting to add Keyboard Input **A** to **move_left**. (_Shown Below_)

![image](https://github.com/user-attachments/assets/1ff89c8a-9ea1-4edb-a82b-4082243ef724)
