### PR TITLE
Check for duplicate input events when adding to action

### DIFF
--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -32,6 +32,7 @@
 #define ACTION_MAP_EDITOR_H
 
 #include "scene/gui/control.h"
+#include "scene/gui/dialogs.h"
 
 class Button;
 class HBoxContainer;
@@ -78,6 +79,7 @@ private:
 
 	InputEventConfigurationDialog *event_config_dialog = nullptr;
 	AcceptDialog *message = nullptr;
+	ConfirmationDialog *accept_warning = nullptr;
 
 	// Filtering and Adding actions
 
@@ -92,6 +94,7 @@ private:
 	Button *add_button = nullptr;
 
 	void _event_config_confirmed();
+	void _event_add_edit_confirmed();
 
 	void _add_action_pressed();
 	void _add_edit_text_changed(const String &p_name);


### PR DESCRIPTION
Addresses #95283.

Displays a warning message when a duplicate Input Event is added to an Action in the Input Map. 
Up for any suggestions if we want to handle this differently.

---

Attempting to add Keyboard Input **A** to **move_left**. (_Shown Below_)

![image](https://github.com/user-attachments/assets/6b151a6f-e5a1-4ff0-b1b2-7d7cb1121e44)
