### PR TITLE
[macOS] Fix menu crash when used from opened native dialog.

### DIFF
--- a/platform/macos/godot_menu_delegate.mm
+++ b/platform/macos/godot_menu_delegate.mm
@@ -102,7 +102,11 @@
 					} else {
 						// Otherwise redirect event to the engine.
 						if (DisplayServer::get_singleton()) {
-							[[[NSApplication sharedApplication] keyWindow] sendEvent:event];
+							if ([[NSApplication sharedApplication] keyWindow].sheet) {
+								[[[[NSApplication sharedApplication] keyWindow] sheetParent] sendEvent:event];
+							} else {
+								[[[NSApplication sharedApplication] keyWindow] sendEvent:event];
+							}
 						}
 					}
 


### PR DESCRIPTION
Part of https://github.com/godotengine/godot/pull/97636

Fixes https://github.com/godotengine/godot/issues/97437 (fixes crash)