### PR TITLE
C#: Add IntersectsRay to `Aabb`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -525,19 +525,21 @@ namespace Godot
             real_t tmin = -1e20f;
             real_t tmax = 1e20f;
 
+            Vector3 end = _position + _size;
+
             for (int i = 0; i < 3; i++)
             {
                 if (dir[i] == 0)
                 {
-                    if ((from[i] < Position[i]) || (from[i] > End[i]))
+                    if ((from[i] < _position[i]) || (from[i] > end[i]))
                     {
                         return false;
                     }
                 }
                 else
                 { // ray not parallel to planes in this direction
-                    real_t t1 = (Position[i] - from[i]) / dir[i];
-                    real_t t2 = (End[i] - from[i]) / dir[i];
+                    real_t t1 = (_position[i] - from[i]) / dir[i];
+                    real_t t2 = (end[i] - from[i]) / dir[i];
 
                     if (t1 > t2)
                     {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -522,8 +522,8 @@ namespace Godot
         {
             if (HasPoint(from)) return true;
 
-            real_t tmin = -1e20f;
-            real_t tmax = 1e20f;
+            real_t tmin = real_t.MinValue;
+            real_t tmax = real_t.MaxValue;
 
             for (int i = 0; i < 3; i++)
             {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -173,10 +173,10 @@ namespace Godot
                 case 7:
                     return new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z + _size.Z);
                 default:
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(idx),
-                            $"Index is {idx}, but a value from 0 to 7 is expected.");
-                    }
+                {
+                    throw new ArgumentOutOfRangeException(nameof(idx),
+                        $"Index is {idx}, but a value from 0 to 7 is expected.");
+                }
             }
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -535,7 +535,8 @@ namespace Godot
                     }
                 }
                 else
-                { // ray not parallel to planes in this direction
+                {
+                // Ray is not parallel to planes in this direction.
                     real_t t1 = (Position[i] - from[i]) / dir[i];
                     real_t t2 = (End[i] - from[i]) / dir[i];
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -522,8 +522,8 @@ namespace Godot
         {
             if (HasPoint(from)) return true;
 
-            real_t tmin = -1e20;
-            real_t tmax = 1e20;
+            real_t tmin = -1e20f;
+            real_t tmax = 1e20f;
 
             for (int i = 0; i < 3; i++)
             {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Aabb.cs
@@ -173,10 +173,10 @@ namespace Godot
                 case 7:
                     return new Vector3(_position.X + _size.X, _position.Y + _size.Y, _position.Z + _size.Z);
                 default:
-                {
-                    throw new ArgumentOutOfRangeException(nameof(idx),
-                        $"Index is {idx}, but a value from 0 to 7 is expected.");
-                }
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(idx),
+                            $"Index is {idx}, but a value from 0 to 7 is expected.");
+                    }
             }
         }
 
@@ -507,6 +507,62 @@ namespace Godot
             }
 
             return under && over;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if the <see cref="Aabb"/> intersects
+        /// the ray along <paramref name="dir"/> positioned at <paramref name="from"/>.
+        /// </summary>
+        /// <param name="origin">The origin of the ray.</param>
+        /// <param name="dir">The direction of the ray.</param>
+        /// <returns>
+        /// A <see langword="bool"/> for whether or not the <see cref="Aabb"/> intersects the ray.
+        /// </returns>
+        public readonly bool IntersectsRay(Vector3 from, Vector3 dir)
+        {
+            if (HasPoint(from)) return true;
+
+            real_t tmin = -1e20;
+            real_t tmax = 1e20;
+
+            for (int i = 0; i < 3; i++)
+            {
+                if (dir[i] == 0)
+                {
+                    if ((from[i] < Position[i]) || (from[i] > End[i]))
+                    {
+                        return false;
+                    }
+                }
+                else
+                { // ray not parallel to planes in this direction
+                    real_t t1 = (Position[i] - from[i]) / dir[i];
+                    real_t t2 = (End[i] - from[i]) / dir[i];
+
+                    if (t1 > t2)
+                    {
+                        (t2, t1) = (t1, t2);
+                    }
+                    if (t1 >= tmin)
+                    {
+                        tmin = t1;
+                    }
+                    if (t2 < tmax)
+                    {
+                        if (t2 < 0)
+                        {
+                            return false;
+                        }
+                        tmax = t2;
+                    }
+                    if (tmin > tmax)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
- Add `IntersectsRay`
  - Use `intersects_ray` implementation without inside/normal/intersection point calculation