### PR TITLE
Add caching to `DisplayServer::can_create_rendering_device()`

### DIFF
--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -1229,6 +1229,12 @@ bool DisplayServer::can_create_rendering_device() {
 		return true;
 	}
 
+	if (created_rendering_device == RenderingDeviceCreationStatus::SUCCESS) {
+		return true;
+	} else if (created_rendering_device == RenderingDeviceCreationStatus::FAILURE) {
+		return false;
+	}
+
 	Error err;
 	RenderingContextDriver *rcd = nullptr;
 
@@ -1258,7 +1264,14 @@ bool DisplayServer::can_create_rendering_device() {
 			memdelete(rd);
 			rd = nullptr;
 			if (err == OK) {
+				// Creating a RenderingDevice is quite slow.
+				// Cache the result for future usage, so that it's much faster on subsequent calls.
+				created_rendering_device = RenderingDeviceCreationStatus::SUCCESS;
+				memdelete(rcd);
+				rcd = nullptr;
 				return true;
+			} else {
+				created_rendering_device = RenderingDeviceCreationStatus::FAILURE;
 			}
 		}
 

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -594,6 +594,16 @@ public:
 	static Vector<String> get_create_function_rendering_drivers(int p_index);
 	static DisplayServer *create(int p_index, const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, Error &r_error);
 
+	enum RenderingDeviceCreationStatus {
+		UNKNOWN,
+		SUCCESS,
+		FAILURE,
+	};
+
+	// Used to cache the result of `can_create_rendering_device()` when RenderingDevice isn't currently being used.
+	// This is done as creating a RenderingDevice is quite slow.
+	static inline RenderingDeviceCreationStatus created_rendering_device = RenderingDeviceCreationStatus::UNKNOWN;
+
 	static bool can_create_rendering_device();
 
 	DisplayServer();


### PR DESCRIPTION
This greatly speeds up the method when using the Compatibility rendering method, where this method is not guaranteed to return `true` in that case.

This is needed to ensure https://github.com/godotengine/godot/pull/97416 doesn't unnecessarily slow down the editor.
