### PR TITLE
Move expression evaluator to a plugin

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -530,7 +530,10 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 			} else if (command == "set_skip_breakpoints") {
 				ERR_FAIL_COND(data.is_empty());
 				script_debugger->set_skip_breakpoints(data[0]);
+#ifdef DEBUG_ENABLED
 			} else if (command == "evaluate") {
+				ERR_FAIL_COND(data.size() < 2);
+
 				String expression_str = data[0];
 				int frame = data[1];
 
@@ -564,7 +567,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				stvar.value = return_val;
 				stvar.type = 3;
 
-				send_message("evaluation_return", stvar.serialize());
+				send_message("evaluation_return:", stvar.serialize());
 			} else {
 				bool captured = false;
 				ERR_CONTINUE(_try_capture(command, data, captured) != OK);
@@ -572,6 +575,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 					WARN_PRINT("Unknown message received from debugger: " + command);
 				}
 			}
+#endif
 		} else {
 			OS::get_singleton()->delay_usec(10000);
 			if (Thread::get_caller_id() == Thread::get_main_id()) {

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -37,7 +37,6 @@
 #include "core/string/ustring.h"
 #include "core/version.h"
 #include "editor/debugger/debug_adapter/debug_adapter_protocol.h"
-#include "editor/debugger/editor_expression_evaluator.h"
 #include "editor/debugger/editor_performance_profiler.h"
 #include "editor/debugger/editor_profiler.h"
 #include "editor/debugger/editor_visual_profiler.h"
@@ -812,8 +811,6 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 		if (EditorFileSystem::get_singleton()) {
 			EditorFileSystem::get_singleton()->update_file(p_data[0]);
 		}
-	} else if (p_msg == "evaluation_return") {
-		expression_evaluator->add_value(p_data);
 	} else {
 		int colon_index = p_msg.find_char(':');
 		ERR_FAIL_COND_MSG(colon_index < 1, "Invalid message received");
@@ -857,7 +854,6 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			error_tree->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditorDebugger::_error_selected));
 			error_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_error_activated));
 			breakpoints_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_breakpoint_tree_clicked));
-			connect("started", callable_mp(expression_evaluator, &EditorExpressionEvaluator::on_start));
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -2012,13 +2008,6 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		file_dialog = memnew(EditorFileDialog);
 		file_dialog->connect("file_selected", callable_mp(this, &ScriptEditorDebugger::_file_selected));
 		add_child(file_dialog);
-	}
-
-	{ // Expression evaluator
-		expression_evaluator = memnew(EditorExpressionEvaluator);
-		expression_evaluator->set_name(TTR("Evaluator"));
-		expression_evaluator->set_editor_debugger(this);
-		tabs->add_child(expression_evaluator);
 	}
 
 	{ //profiler

--- a/editor/plugins/expression_evaluator_editor_plugin.h
+++ b/editor/plugins/expression_evaluator_editor_plugin.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_expression_evaluator.h                                         */
+/*  expression_evaluator_editor_plugin.h                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,9 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef EDITOR_EXPRESSION_EVALUATOR_H
-#define EDITOR_EXPRESSION_EVALUATOR_H
+#ifndef EXPRESSION_EVALUATOR_EDITOR_PLUGIN_H
+#define EXPRESSION_EVALUATOR_EDITOR_PLUGIN_H
 
+#include "editor/plugins/editor_debugger_plugin.h"
+#include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
 
 class Button;
@@ -44,7 +46,7 @@ class EditorExpressionEvaluator : public VBoxContainer {
 	GDCLASS(EditorExpressionEvaluator, VBoxContainer)
 
 private:
-	Ref<RemoteDebuggerPeer> peer;
+	Ref<EditorDebuggerSession> session;
 
 	LineEdit *expression_input = nullptr;
 	CheckBox *clear_on_run_checkbox = nullptr;
@@ -58,20 +60,37 @@ private:
 
 	void _remote_object_selected(ObjectID p_id);
 	void _on_expression_input_changed(const String &p_expression);
-	void _on_debugger_breaked(bool p_breaked, bool p_can_debug);
-	void _on_debugger_clear_execution(Ref<Script> p_stack_script);
+
+public:
+    void set_can_evaluate(bool p_enabled);
+	void on_start();
+
+	void add_value(const Array &p_array);
+
+	EditorExpressionEvaluator(const Ref<EditorDebuggerSession> &p_session);
+};
+
+class ExpressionEvaluatorDebugger : public EditorDebuggerPlugin {
+	GDCLASS(ExpressionEvaluatorDebugger, EditorDebuggerPlugin);
+
+	HashMap<int, EditorExpressionEvaluator *> evaluators;
+
+public:
+	void setup_session(int p_idx) override;
+	bool capture(const String &p_message, const Array &p_data, int p_session) override;
+	bool has_capture(const String &p_capture) const override;
+};
+
+class ExpressionEvaluatorEditorPlugin : public EditorPlugin {
+	GDCLASS(ExpressionEvaluatorEditorPlugin, EditorPlugin);
+
+	Ref<ExpressionEvaluatorDebugger> plugin;
 
 protected:
-	ScriptEditorDebugger *editor_debugger = nullptr;
-
 	void _notification(int p_what);
 
 public:
-	void on_start();
-	void set_editor_debugger(ScriptEditorDebugger *p_editor_debugger);
-	void add_value(const Array &p_array);
-
-	EditorExpressionEvaluator();
+	ExpressionEvaluatorEditorPlugin();
 };
 
-#endif // EDITOR_EXPRESSION_EVALUATOR_H
+#endif // EXPRESSION_EVALUATOR_EDITOR_PLUGIN_H

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -82,6 +82,7 @@
 #include "editor/plugins/editor_context_menu_plugin.h"
 #include "editor/plugins/editor_debugger_plugin.h"
 #include "editor/plugins/editor_resource_tooltip_plugins.h"
+#include "editor/plugins/expression_evaluator_editor_plugin.h"
 #include "editor/plugins/font_config_plugin.h"
 #include "editor/plugins/gpu_particles_2d_editor_plugin.h"
 #include "editor/plugins/gpu_particles_3d_editor_plugin.h"
@@ -217,6 +218,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<CPUParticles3DEditorPlugin>();
 	EditorPlugins::add_by_type<CurveEditorPlugin>();
 	EditorPlugins::add_by_type<DebugAdapterServer>();
+	EditorPlugins::add_by_type<ExpressionEvaluatorEditorPlugin>();
 	EditorPlugins::add_by_type<FontEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticles3DEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticlesCollisionSDF3DEditorPlugin>();


### PR DESCRIPTION
Follow-up to #97647

It moves the evaluator to a plugin. It should be identical, though I've ran into some issues (see comments).