### PR TITLE
Fix `InputEvent` device id clash (reverted)

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -35,9 +35,6 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 
-const int InputEvent::DEVICE_ID_EMULATION = -1;
-const int InputEvent::DEVICE_ID_INTERNAL = -2;
-
 void InputEvent::set_device(int p_device) {
 	device = p_device;
 	emit_changed();

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -62,8 +62,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	static const int DEVICE_ID_EMULATION;
-	static const int DEVICE_ID_INTERNAL;
+	inline static constexpr int DEVICE_ID_EMULATION = -1;
+	inline static constexpr int DEVICE_ID_INTERNAL = -2;
+	inline static constexpr int DEVICE_ID_ALL_DEVICES = -3; // Signify that a given Action can be triggered by any device.
 
 	void set_device(int p_device);
 	int get_device() const;

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -38,8 +38,6 @@
 
 InputMap *InputMap::singleton = nullptr;
 
-int InputMap::ALL_DEVICES = -1;
-
 void InputMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_action", "action"), &InputMap::has_action);
 	ClassDB::bind_method(D_METHOD("get_actions"), &InputMap::_get_actions);
@@ -162,7 +160,7 @@ List<Ref<InputEvent>>::Element *InputMap::_find_event(Action &p_action, const Re
 	int i = 0;
 	for (List<Ref<InputEvent>>::Element *E = p_action.inputs.front(); E; E = E->next()) {
 		int device = E->get()->get_device();
-		if (device == ALL_DEVICES || device == p_event->get_device()) {
+		if (device == InputEvent::DEVICE_ID_ALL_DEVICES || device == p_event->get_device()) {
 			if (E->get()->action_match(p_event, p_exact_match, p_action.deadzone, r_pressed, r_strength, r_raw_strength)) {
 				if (r_event_index) {
 					*r_event_index = i;

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -43,11 +43,6 @@ class InputMap : public Object {
 	GDCLASS(InputMap, Object);
 
 public:
-	/**
-	 * A special value used to signify that a given Action can be triggered by any device
-	 */
-	static int ALL_DEVICES;
-
 	struct Action {
 		int id;
 		float deadzone;

--- a/editor/event_listener_line_edit.cpp
+++ b/editor/event_listener_line_edit.cpp
@@ -121,7 +121,7 @@ String EventListenerLineEdit::get_event_text(const Ref<InputEvent> &p_event, boo
 }
 
 String EventListenerLineEdit::get_device_string(int p_device) {
-	if (p_device == InputMap::ALL_DEVICES) {
+	if (p_device == InputEvent::DEVICE_ID_ALL_DEVICES) {
 		return TTR("All Devices");
 	}
 	return TTR("Device") + " " + itos(p_device);

--- a/editor/input_event_configuration_dialog.cpp
+++ b/editor/input_event_configuration_dialog.cpp
@@ -551,18 +551,18 @@ void InputEventConfigurationDialog::_input_list_item_selected() {
 }
 
 void InputEventConfigurationDialog::_device_selection_changed(int p_option_button_index) {
-	// Subtract 1 as option index 0 corresponds to "All Devices" (value of -1)
-	// and option index 1 corresponds to device 0, etc...
-	event->set_device(p_option_button_index - 1);
+	// Option index 0 corresponds to "All Devices" (value of -3).
+	// Otherwise subtract 1 as option index 1 corresponds to device 0, etc...
+	event->set_device(p_option_button_index == 0 ? InputEvent::DEVICE_ID_ALL_DEVICES : p_option_button_index - 1);
 	event_as_text->set_text(EventListenerLineEdit::get_event_text(event, true));
 }
 
 void InputEventConfigurationDialog::_set_current_device(int p_device) {
-	device_id_option->select(p_device + 1);
+	device_id_option->select(p_device == InputEvent::DEVICE_ID_ALL_DEVICES ? 0 : p_device + 1);
 }
 
 int InputEventConfigurationDialog::_get_current_device() const {
-	return device_id_option->get_selected() - 1;
+	return device_id_option->get_selected() == 0 ? InputEvent::DEVICE_ID_ALL_DEVICES : device_id_option->get_selected() - 1;
 }
 
 void InputEventConfigurationDialog::_notification(int p_what) {
@@ -705,11 +705,12 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 
 	device_id_option = memnew(OptionButton);
 	device_id_option->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	for (int i = -1; i < 8; i++) {
+	device_id_option->add_item(EventListenerLineEdit::get_device_string(InputEvent::DEVICE_ID_ALL_DEVICES));
+	for (int i = 0; i < 8; i++) {
 		device_id_option->add_item(EventListenerLineEdit::get_device_string(i));
 	}
 	device_id_option->connect(SceneStringName(item_selected), callable_mp(this, &InputEventConfigurationDialog::_device_selection_changed));
-	_set_current_device(InputMap::ALL_DEVICES);
+	_set_current_device(InputEvent::DEVICE_ID_ALL_DEVICES);
 	device_container->add_child(device_id_option);
 
 	device_container->hide();


### PR DESCRIPTION
`InputMap::ALL_DEVICES` and `InputEvent::DEVICE_ID_EMULATION` have the same value `-1`, but since both are used for device ids of input events, there could potentially be cases, where they are clashing.

Change value of `InputMap::All_DEVICES` so that it's different from `InputEvent::DEVICE_ID_EMULATION`. `InputEvent::DEVICE_ID_EMULATION` is part of the API and can't be changed without potentially breaking projects.

Gather all special device constants in a single location inside `InputEvent`.

Add a converter to project settings, that takes care of adjusting project files during loading.

Relevant PRs:
- #17967
- #26851