### PR TITLE
Fix occlusion culling by using depth instead of Euclidean distance when selecting the closest point

### DIFF
--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -72,7 +72,7 @@ public:
 				return false;
 			}
 
-			float min_depth = -closest_point_view.z * 0.95f;
+			float min_depth = FLT_MAX;
 
 			Vector2 rect_min = Vector2(FLT_MAX, FLT_MAX);
 			Vector2 rect_max = Vector2(FLT_MIN, FLT_MIN);
@@ -85,6 +85,7 @@ public:
 
 				Plane vp = Plane(view, 1.0);
 				Plane projected = p_cam_projection.xform4(vp);
+				min_depth = MIN(min_depth, -view.z);
 
 				float w = projected.d;
 				if (w < 1.0) {


### PR DESCRIPTION
Resolves #94210

The occlusion culler uses a point to compare with the depth mipmap to determine if an object is occluded or not. The occlusion culler currently chooses the point with the shortest Euclidean distance to the camera. While not entirely inaccurate, it can drift when compared to the actual closest point to the camera in terms of depth.

This inaccuracy increases when an object's AABB is skewed (relative to the camera perspective) and partially occluded by other objects, as seen in the MRP in #94210 and the 2D example below.

![Screenshot from 2024-10-01 21-37-13](https://github.com/user-attachments/assets/1fd72a06-6dd5-46b2-9fef-cdaed8f997fe)

There were two possible solutions to this problem, and this PR implements the second solution.

Possible solutions:
1. Convert the entire occlusion culling algorithm to use Euclidean distance.
2. Select the closest point based on depth.

Although the first solution seems drastic, it mostly involved removing and simplifying code. It also had the benefit of being a bit more accurate (more likely to cull objects that can be culled) compared to solution 2. However, I eventually dropped this approach because it did not work well with an orthogonal camera, and fixing this began to drift out of the original issue's scope. A discussion on this might still be valuable, as it could lead to improved performance in most use cases (non-orthogonal cameras) compared to the second solution.

Implementing the second solution meant cycling through the corners of the object's AABB and determining the closest point. This approach is guaranteed to always provide an accurate depth when the object is fully within the view frustum. In cases where part of the object is outside the view frustum, it could provide closer values. Therefore, when it is inaccurate, it would still tend to favor drawing the object.

With the added accuracy of this fix, I think it would be worthwhile to retune the occlusion culling algorithm.

MRP used during testing provided by @unfa:
[MRP.zip](https://github.com/user-attachments/files/17215572/MRP.zip)
