### PR TITLE
Enable use of Labels as Values feature in Clang when not wrapped by GCC

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -227,7 +227,7 @@ void (*type_init_function_table[])(Variant *) = {
 	&VariantInitializer<PackedVector4Array>::init, // PACKED_VECTOR4_ARRAY.
 };
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #define OPCODES_TABLE                                    \
 	static const void *switch_table_ops[] = {            \
 		&&OPCODE_OPERATOR,                               \


### PR DESCRIPTION
Split off from #77233. Tested on top of #92316, using the benchmark:
```gdscript
@tool
extends EditorScript

func _run() -> void:
	static_run()

static func static_run() -> void:
	var time_before := Time.get_ticks_msec()

	var r : int
	for i in range(10000000):
		var next : int
		var first := 1
		var second := 2
		for c in range(40):
			next = first + second
			first = second
			second = next
		r = next
	print(r)

	var total_time := Time.get_ticks_msec() - time_before
	print("Time taken: " + str(total_time))
```

In dev build, no notable difference. But in release build with `lto=full`, times went down from 16-18 seconds, to 13 seconds, i.e. ~20% improvement in speed.