### PR TITLE
Handle scroll events in RichtTextLabel

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2067,16 +2067,27 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 
+		bool scroll_value_modified = false;
+		double prev_scroll = vscroll->get_value();
+
 		if (b->get_button_index() == MouseButton::WHEEL_UP) {
 			if (scroll_active) {
 				vscroll->scroll(-vscroll->get_page() * b->get_factor() * 0.5 / 8);
+				scroll_value_modified = true;
 			}
 		}
 		if (b->get_button_index() == MouseButton::WHEEL_DOWN) {
 			if (scroll_active) {
 				vscroll->scroll(vscroll->get_page() * b->get_factor() * 0.5 / 8);
+				scroll_value_modified = true;
 			}
 		}
+
+		if (scroll_value_modified && vscroll->get_value() != prev_scroll) {
+			accept_event();
+			return;
+		}
+
 		if (b->get_button_index() == MouseButton::RIGHT && context_menu_enabled) {
 			_update_context_menu();
 			menu->set_position(get_screen_position() + b->get_position());


### PR DESCRIPTION
Allows scrolling RichTextLabel inside ScrollContainer.

Before:

https://github.com/user-attachments/assets/a51f0c54-e01a-43c6-aafa-205949a3c9ba

After:

https://github.com/user-attachments/assets/65059d17-591e-4d1a-83f7-a8e64bb68298

The code is adapted from ScrollContainer.
https://github.com/godotengine/godot/blob/1917bc3454e58fc56750b00e04aa25cb94d8d266/scene/gui/scroll_container.cpp#L119-L163
