### PR TITLE
Improve blurred content of embedded windows

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1259,6 +1259,10 @@ void Window::_update_viewport_size() {
 	notification(NOTIFICATION_WM_SIZE_CHANGED);
 
 	if (embedder) {
+		float scale = MIN(embedder->stretch_transform.get_scale().width, embedder->stretch_transform.get_scale().height);
+		Size2 s = Size2(final_size.width * scale, final_size.height * scale).ceil();
+		RS::get_singleton()->viewport_set_global_canvas_transform(get_viewport_rid(), global_canvas_transform * scale * content_scale_factor);
+		RS::get_singleton()->viewport_set_size(get_viewport_rid(), s.width, s.height);
 		embedder->_sub_window_update(this);
 	}
 }


### PR DESCRIPTION
Helps: #54030
Helps: #95387

I honestly don't know if I'm doing it the right way, but the issue seems to be forgotten and after a flurry of attempts I'm getting good results.
before:
![图片](https://github.com/user-attachments/assets/997ef5ff-3d87-4316-a191-bbc2bf9f4d3a)
after:
![图片](https://github.com/user-attachments/assets/5f74e24a-7bdb-4036-907e-8a021d6ac72a)
example:
[embedded-window.zip](https://github.com/user-attachments/files/17233855/embedded-window.zip)
