### PR TITLE
Fix double free in QuickOpenDialog deconstructor

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -223,13 +223,16 @@ QuickOpenResultContainer::QuickOpenResultContainer() {
 }
 
 QuickOpenResultContainer::~QuickOpenResultContainer() {
-	for (QuickOpenResultItem *E : result_items) {
-		memdelete(E);
+	if (never_opened) {
+		for (QuickOpenResultItem *E : result_items) {
+			memdelete(E);
+		}
 	}
 }
 
 void QuickOpenResultContainer::init(const Vector<StringName> &p_base_types) {
 	base_types = p_base_types;
+	never_opened = false;
 
 	const int display_mode_behavior = EDITOR_GET("filesystem/quick_open_dialog/default_display_mode");
 	const bool adaptive_display_mode = (display_mode_behavior == 0);
@@ -574,13 +577,9 @@ void QuickOpenResultContainer::_toggle_display_mode() {
 void QuickOpenResultContainer::_set_display_mode(QuickOpenDisplayMode p_display_mode) {
 	content_display_mode = p_display_mode;
 
-	const bool first_time = !list->is_visible() && !grid->is_visible();
-
-	if (!first_time) {
-		const bool show_list = (content_display_mode == QuickOpenDisplayMode::LIST);
-		if ((show_list && list->is_visible()) || (!show_list && grid->is_visible())) {
-			return;
-		}
+	const bool show_list = (content_display_mode == QuickOpenDisplayMode::LIST);
+	if ((show_list && list->is_visible()) || (!show_list && grid->is_visible())) {
+		return;
 	}
 
 	hide();
@@ -595,6 +594,8 @@ void QuickOpenResultContainer::_set_display_mode(QuickOpenDisplayMode p_display_
 		prev_root = Object::cast_to<CanvasItem>(list);
 		next_root = Object::cast_to<CanvasItem>(grid);
 	}
+
+	const bool first_time = !list->is_visible() && !grid->is_visible();
 
 	prev_root->hide();
 	for (QuickOpenResultItem *item : result_items) {

--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -96,7 +96,9 @@ private:
 	int selection_index = -1;
 	int num_visible_results = 0;
 	int max_total_results = 0;
+
 	bool showing_history = false;
+	bool never_opened = true;
 
 	QuickOpenDisplayMode content_display_mode = QuickOpenDisplayMode::LIST;
 	Vector<QuickOpenResultItem *> result_items;


### PR DESCRIPTION
Before opening the dialog, the result nodes are created but not assigned to either the list or grid container. In this case we must free them manually (well I wouldn't care but the sanitizer complains). But if you open the dialog once, the results will be parented to one container, and therefore automatically freed. The double free resulted in a segfault.

I considered adding the results to one container at startup, but the current method also fetches theme icons so i can't do it in the constructor so this is the simplest way out.

Should fix #97733 