### PR TITLE
Improved readability of AbstractPolygon2DEditor and its derived classes by changing the name of _get_node & _set_node

### DIFF
--- a/editor/plugins/collision_polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.cpp
@@ -30,12 +30,12 @@
 
 #include "collision_polygon_2d_editor_plugin.h"
 
-Node2D *CollisionPolygon2DEditor::_get_node() const {
-	return node;
+Node2D *CollisionPolygon2DEditor::_get_target_node() const {
+	return target_polygon;
 }
 
-void CollisionPolygon2DEditor::_set_node(Node *p_polygon) {
-	node = Object::cast_to<CollisionPolygon2D>(p_polygon);
+void CollisionPolygon2DEditor::_set_target_node(Node2D *p_node) {
+	target_polygon = Object::cast_to<CollisionPolygon2D>(p_node);
 }
 
 CollisionPolygon2DEditor::CollisionPolygon2DEditor() {}

--- a/editor/plugins/collision_polygon_2d_editor_plugin.h
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.h
@@ -37,11 +37,11 @@
 class CollisionPolygon2DEditor : public AbstractPolygon2DEditor {
 	GDCLASS(CollisionPolygon2DEditor, AbstractPolygon2DEditor);
 
-	CollisionPolygon2D *node = nullptr;
+	CollisionPolygon2D *target_polygon = nullptr;
 
 protected:
-	virtual Node2D *_get_node() const override;
-	virtual void _set_node(Node *p_polygon) override;
+	virtual Node2D *_get_target_node() const override;
+	virtual void _set_target_node(Node2D *p_node) override;
 
 public:
 	CollisionPolygon2DEditor();

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -34,24 +34,24 @@
 #include "editor/editor_undo_redo_manager.h"
 
 Ref<OccluderPolygon2D> LightOccluder2DEditor::_ensure_occluder() const {
-	Ref<OccluderPolygon2D> occluder = node->get_occluder_polygon();
+	Ref<OccluderPolygon2D> occluder = target_occluder->get_occluder_polygon();
 	if (!occluder.is_valid()) {
 		occluder = Ref<OccluderPolygon2D>(memnew(OccluderPolygon2D));
-		node->set_occluder_polygon(occluder);
+		target_occluder->set_occluder_polygon(occluder);
 	}
 	return occluder;
 }
 
-Node2D *LightOccluder2DEditor::_get_node() const {
-	return node;
+Node2D *LightOccluder2DEditor::_get_target_node() const {
+	return target_occluder;
 }
 
-void LightOccluder2DEditor::_set_node(Node *p_polygon) {
-	node = Object::cast_to<LightOccluder2D>(p_polygon);
+void LightOccluder2DEditor::_set_target_node(Node2D *p_node) {
+	target_occluder = Object::cast_to<LightOccluder2D>(p_node);
 }
 
 bool LightOccluder2DEditor::_is_line() const {
-	Ref<OccluderPolygon2D> occluder = node->get_occluder_polygon();
+	Ref<OccluderPolygon2D> occluder = target_occluder->get_occluder_polygon();
 	if (occluder.is_valid()) {
 		return !occluder->is_closed();
 	} else {
@@ -60,7 +60,7 @@ bool LightOccluder2DEditor::_is_line() const {
 }
 
 int LightOccluder2DEditor::_get_polygon_count() const {
-	Ref<OccluderPolygon2D> occluder = node->get_occluder_polygon();
+	Ref<OccluderPolygon2D> occluder = target_occluder->get_occluder_polygon();
 	if (occluder.is_valid()) {
 		return occluder->get_polygon().size();
 	} else {
@@ -69,7 +69,7 @@ int LightOccluder2DEditor::_get_polygon_count() const {
 }
 
 Variant LightOccluder2DEditor::_get_polygon(int p_idx) const {
-	Ref<OccluderPolygon2D> occluder = node->get_occluder_polygon();
+	Ref<OccluderPolygon2D> occluder = target_occluder->get_occluder_polygon();
 	if (occluder.is_valid()) {
 		return occluder->get_polygon();
 	} else {
@@ -90,18 +90,18 @@ void LightOccluder2DEditor::_action_set_polygon(int p_idx, const Variant &p_prev
 }
 
 bool LightOccluder2DEditor::_has_resource() const {
-	return node && node->get_occluder_polygon().is_valid();
+	return target_occluder && target_occluder->get_occluder_polygon().is_valid();
 }
 
 void LightOccluder2DEditor::_create_resource() {
-	if (!node) {
+	if (!target_occluder) {
 		return;
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Create Occluder Polygon"));
-	undo_redo->add_do_method(node, "set_occluder_polygon", Ref<OccluderPolygon2D>(memnew(OccluderPolygon2D)));
-	undo_redo->add_undo_method(node, "set_occluder_polygon", Variant(Ref<RefCounted>()));
+	undo_redo->add_do_method(target_occluder, "set_occluder_polygon", Ref<OccluderPolygon2D>(memnew(OccluderPolygon2D)));
+	undo_redo->add_undo_method(target_occluder, "set_occluder_polygon", Variant(Ref<RefCounted>()));
 	undo_redo->commit_action();
 
 	_menu_option(MODE_CREATE);

--- a/editor/plugins/light_occluder_2d_editor_plugin.h
+++ b/editor/plugins/light_occluder_2d_editor_plugin.h
@@ -37,13 +37,13 @@
 class LightOccluder2DEditor : public AbstractPolygon2DEditor {
 	GDCLASS(LightOccluder2DEditor, AbstractPolygon2DEditor);
 
-	LightOccluder2D *node = nullptr;
+	LightOccluder2D *target_occluder = nullptr;
 
 	Ref<OccluderPolygon2D> _ensure_occluder() const;
 
 protected:
-	virtual Node2D *_get_node() const override;
-	virtual void _set_node(Node *p_polygon) override;
+	virtual Node2D *_get_target_node() const override;
+	virtual void _set_target_node(Node2D *p_node) override;
 
 	virtual bool _is_line() const override;
 	virtual int _get_polygon_count() const override;

--- a/editor/plugins/line_2d_editor_plugin.cpp
+++ b/editor/plugins/line_2d_editor_plugin.cpp
@@ -33,12 +33,12 @@
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 
-Node2D *Line2DEditor::_get_node() const {
-	return node;
+Node2D *Line2DEditor::_get_target_node() const {
+	return target_line;
 }
 
-void Line2DEditor::_set_node(Node *p_line) {
-	node = Object::cast_to<Line2D>(p_line);
+void Line2DEditor::_set_target_node(Node2D *p_node) {
+	target_line = Object::cast_to<Line2D>(p_node);
 }
 
 bool Line2DEditor::_is_line() const {
@@ -46,18 +46,17 @@ bool Line2DEditor::_is_line() const {
 }
 
 Variant Line2DEditor::_get_polygon(int p_idx) const {
-	return _get_node()->get("points");
+	return target_line->get("points");
 }
 
 void Line2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
-	_get_node()->set("points", p_polygon);
+	target_line->set("points", p_polygon);
 }
 
 void Line2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
-	Node2D *_node = _get_node();
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(_node, "set_points", p_polygon);
-	undo_redo->add_undo_method(_node, "set_points", p_previous);
+	undo_redo->add_do_method(target_line, "set_points", p_polygon);
+	undo_redo->add_undo_method(target_line, "set_points", p_previous);
 }
 
 Line2DEditor::Line2DEditor() {}

--- a/editor/plugins/line_2d_editor_plugin.h
+++ b/editor/plugins/line_2d_editor_plugin.h
@@ -37,11 +37,11 @@
 class Line2DEditor : public AbstractPolygon2DEditor {
 	GDCLASS(Line2DEditor, AbstractPolygon2DEditor);
 
-	Line2D *node = nullptr;
+	Line2D *target_line = nullptr;
 
 protected:
-	virtual Node2D *_get_node() const override;
-	virtual void _set_node(Node *p_line) override;
+	virtual Node2D *_get_target_node() const override;
+	virtual void _set_target_node(Node2D *p_node) override;
 
 	virtual bool _is_line() const override;
 	virtual Variant _get_polygon(int p_idx) const override;

--- a/editor/plugins/navigation_obstacle_2d_editor_plugin.cpp
+++ b/editor/plugins/navigation_obstacle_2d_editor_plugin.cpp
@@ -33,38 +33,38 @@
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 
-Node2D *NavigationObstacle2DEditor::_get_node() const {
-	return node;
+Node2D *NavigationObstacle2DEditor::_get_target_node() const {
+	return target_obstacle;
 }
 
-void NavigationObstacle2DEditor::_set_node(Node *p_polygon) {
-	node = Object::cast_to<NavigationObstacle2D>(p_polygon);
+void NavigationObstacle2DEditor::_set_target_node(Node2D *p_node) {
+	target_obstacle = Object::cast_to<NavigationObstacle2D>(p_node);
 }
 
 Variant NavigationObstacle2DEditor::_get_polygon(int p_idx) const {
-	return node->get_vertices();
+	return target_obstacle->get_vertices();
 }
 
 void NavigationObstacle2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
-	node->set_vertices(p_polygon);
+	target_obstacle->set_vertices(p_polygon);
 }
 
 void NavigationObstacle2DEditor::_action_add_polygon(const Variant &p_polygon) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(node, "set_vertices", p_polygon);
-	undo_redo->add_undo_method(node, "set_vertices", node->get_vertices());
+	undo_redo->add_do_method(target_obstacle, "set_vertices", p_polygon);
+	undo_redo->add_undo_method(target_obstacle, "set_vertices", target_obstacle->get_vertices());
 }
 
 void NavigationObstacle2DEditor::_action_remove_polygon(int p_idx) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(node, "set_vertices", Variant(Vector<Vector2>()));
-	undo_redo->add_undo_method(node, "set_vertices", node->get_vertices());
+	undo_redo->add_do_method(target_obstacle, "set_vertices", Variant(Vector<Vector2>()));
+	undo_redo->add_undo_method(target_obstacle, "set_vertices", target_obstacle->get_vertices());
 }
 
 void NavigationObstacle2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(node, "set_vertices", p_polygon);
-	undo_redo->add_undo_method(node, "set_vertices", node->get_vertices());
+	undo_redo->add_do_method(target_obstacle, "set_vertices", p_polygon);
+	undo_redo->add_undo_method(target_obstacle, "set_vertices", target_obstacle->get_vertices());
 }
 
 NavigationObstacle2DEditor::NavigationObstacle2DEditor() {}

--- a/editor/plugins/navigation_obstacle_2d_editor_plugin.h
+++ b/editor/plugins/navigation_obstacle_2d_editor_plugin.h
@@ -37,11 +37,11 @@
 class NavigationObstacle2DEditor : public AbstractPolygon2DEditor {
 	GDCLASS(NavigationObstacle2DEditor, AbstractPolygon2DEditor);
 
-	NavigationObstacle2D *node = nullptr;
+	NavigationObstacle2D *target_obstacle = nullptr;
 
 protected:
-	virtual Node2D *_get_node() const override;
-	virtual void _set_node(Node *p_polygon) override;
+	virtual Node2D *_get_target_node() const override;
+	virtual void _set_target_node(Node2D *p_node) override;
 
 	virtual Variant _get_polygon(int p_idx) const override;
 	virtual void _set_polygon(int p_idx, const Variant &p_polygon) const override;

--- a/editor/plugins/navigation_polygon_editor_plugin.h
+++ b/editor/plugins/navigation_polygon_editor_plugin.h
@@ -45,7 +45,7 @@ class NavigationPolygonEditor : public AbstractPolygon2DEditor {
 
 	GDCLASS(NavigationPolygonEditor, AbstractPolygon2DEditor);
 
-	NavigationRegion2D *node = nullptr;
+	NavigationRegion2D *target_region = nullptr;
 
 	Ref<NavigationPolygon> _ensure_navpoly() const;
 
@@ -68,8 +68,8 @@ class NavigationPolygonEditor : public AbstractPolygon2DEditor {
 protected:
 	void _notification(int p_what);
 
-	virtual Node2D *_get_node() const override;
-	virtual void _set_node(Node *p_polygon) override;
+	virtual Node2D *_get_target_node() const override;
+	virtual void _set_target_node(Node2D *p_node) override;
 
 	virtual int _get_polygon_count() const override;
 	virtual Variant _get_polygon(int p_idx) const override;

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -76,7 +76,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	Button *uv_edit_mode[4];
 	Ref<ButtonGroup> uv_edit_group;
 
-	Polygon2D *node = nullptr;
+	Polygon2D *target_polygon = nullptr;
 
 	UVMode uv_mode;
 	AcceptDialog *uv_edit = nullptr;
@@ -163,8 +163,8 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	int _get_polygon_count() const override;
 
 protected:
-	virtual Node2D *_get_node() const override;
-	virtual void _set_node(Node *p_polygon) override;
+	virtual Node2D *_get_target_node() const override;
+	virtual void _set_target_node(Node2D *p_node) override;
 
 	virtual Vector2 _get_offset(int p_idx) const override;
 


### PR DESCRIPTION
In `AbstractPolygon2DEditor`:

- `_get_node` abstract method renamed to `_get_target_node`
- `_set_node` abstract method renamed to `_set_target_node`, now takes a `Node2D` parameter to match the return type of `_get_target_node`
- Moved `Vertex` & `PosVertex` out of `AbstractPolygon2DEditor` and added aliases back to them

In the various derived classes of `AbstractPolygon2DEditor`:

- Updated names of overrides of `_get_target_node` & `_set_target_node`
- `node` members renamed to appropriate names following the `target_*` format (for instance, `Line2DEditor` now has a `target_line` member)