### PR TITLE
Fix various editor easing property issues

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1698,7 +1698,6 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 		val = CLAMP(val, -1'000'000, 1'000'000);
 
 		emit_changed(get_edited_property(), val);
-		easing_draw->queue_redraw();
 	}
 }
 
@@ -1750,6 +1749,9 @@ void EditorPropertyEasing::_draw_easing() {
 }
 
 void EditorPropertyEasing::update_property() {
+	float val = get_edited_property_value();
+	spin->set_value_no_signal(val);
+
 	easing_draw->queue_redraw();
 }
 
@@ -1757,7 +1759,6 @@ void EditorPropertyEasing::_set_preset(int p_preset) {
 	static const float preset_value[EASING_MAX] = { 0.0, 1.0, 2.0, 0.5, -2.0, -0.5 };
 
 	emit_changed(get_edited_property(), preset_value[p_preset]);
-	easing_draw->queue_redraw();
 }
 
 void EditorPropertyEasing::_setup_spin() {
@@ -1767,12 +1768,6 @@ void EditorPropertyEasing::_setup_spin() {
 }
 
 void EditorPropertyEasing::_spin_value_changed(double p_value) {
-	// 0 is a singularity, but both positive and negative values
-	// are otherwise allowed. Enforce 0+ as workaround.
-	if (Math::is_zero_approx(p_value)) {
-		p_value = 0.00001;
-	}
-
 	// Limit to a reasonable value to prevent the curve going into infinity,
 	// which can cause crashes and other issues.
 	p_value = CLAMP(p_value, -1'000'000, 1'000'000);


### PR DESCRIPTION
Fixes #94778, fixes #74316.

This commit fixes _various_ issues with the easing property in the editor. 
Tested with various PROPERTY_HINT_EXP_EASING properties, in AnimationPlayer and @export_exp_easing.

- **Fixes setting easing to 0 (from default value) without slider.**
- **Fixes undo not reverting to default value correctly.**
- Removes 2 unneeded queue_redraws()

| Before | After |
| ------------- | ------------- |
|  <video src=https://github.com/user-attachments/assets/0c6d1d13-8bd2-4ffd-ba4f-ceb7a44efb2b>  | <video src=https://github.com/user-attachments/assets/36bd8b77-2517-4485-9431-4f6ff587f60b>