### PR TITLE
Fix LightmapGI not working with MultiMeshes

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1871,6 +1871,7 @@
 			<param index="1" name="lightmap" type="RID" />
 			<param index="2" name="lightmap_uv_scale" type="Rect2" />
 			<param index="3" name="lightmap_slice" type="int" />
+			<param index="4" name="sub_instance" type="int" default="-1" />
 			<description>
 				Sets the lightmap GI instance to use for the specified 3D geometry instance. The lightmap UV scale for the specified instance (equivalent to [member GeometryInstance3D.gi_lightmap_scale]) and lightmap atlas slice must also be specified.
 			</description>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -465,6 +465,9 @@ void RasterizerSceneGLES3::_geometry_instance_update(RenderGeometryInstance *p_g
 		if (mesh_storage->multimesh_uses_custom_data(ginstance->data->base)) {
 			ginstance->base_flags |= INSTANCE_DATA_FLAG_MULTIMESH_HAS_CUSTOM_DATA;
 		}
+		if (mesh_storage->multimesh_uses_lightmap(ginstance->data->base)) {
+			ginstance->base_flags |= INSTANCE_DATA_FLAG_USE_LIGHTMAP;
+		}
 
 	} else if (ginstance->data->base_type == RS::INSTANCE_PARTICLES) {
 		ginstance->base_flags |= INSTANCE_DATA_FLAG_PARTICLES;
@@ -3392,7 +3395,9 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						uint32_t shadow_id = MAX_DIRECTIONAL_LIGHTS - 1 - (pass - int32_t(inst->light_passes.size()));
 						if (pass == 0 && inst->lightmap_instance.is_valid() && scene_state.directional_lights[shadow_id].bake_mode == RenderingServer::LIGHT_BAKE_STATIC) {
 							// Disable additive lighting with a static light and a lightmap.
-							spec_constants &= ~SceneShaderGLES3::USE_ADDITIVE_LIGHTING;
+							if ((inst->data->base_type != RS::INSTANCE_MULTIMESH) || (inst->data->base_type == RS::INSTANCE_MULTIMESH && mesh_storage->multimesh_uses_lightmap(inst->data->base))) {
+								spec_constants &= ~SceneShaderGLES3::USE_ADDITIVE_LIGHTING;
+							}
 						}
 						if (scene_state.directional_shadows[shadow_id].shadow_split_offsets[0] == scene_state.directional_shadows[shadow_id].shadow_split_offsets[1]) {
 							// Orthogonal, do nothing.
@@ -3654,6 +3659,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 
 				GLuint instance_buffer = 0;
 				uint32_t stride = 0;
+				uint32_t instance_count = 0;
 				if (inst->flags_cache & INSTANCE_DATA_FLAG_PARTICLES) {
 					instance_buffer = particles_storage->particles_get_gl_buffer(inst->data->base);
 					stride = 16; // 12 bytes for instance transform and 4 bytes for packed color and custom.
@@ -3695,6 +3701,14 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 					glVertexAttribI4ui(15, default_color, default_color, default_custom, default_custom);
 				}
 
+				if ((inst->flags_cache & INSTANCE_DATA_FLAG_USE_LIGHTMAP) && (inst->flags_cache & INSTANCE_DATA_FLAG_MULTIMESH)) {
+					instance_count = mesh_storage->multimesh_get_instance_count(inst->data->base);
+					uint32_t lightmap_offset = stride * instance_count * sizeof(float);
+					glEnableVertexAttribArray(2);
+					glVertexAttribPointer(2, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), CAST_INT_TO_UCHAR_PTR(lightmap_offset));
+					glVertexAttribDivisor(2, 1);
+				}
+
 				if (use_wireframe) {
 					glDrawElementsInstanced(GL_LINES, count, GL_UNSIGNED_INT, nullptr, inst->instance_count);
 				} else {
@@ -3722,6 +3736,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 				glDisableVertexAttribArray(13);
 				glDisableVertexAttribArray(14);
 				glDisableVertexAttribArray(15);
+				glDisableVertexAttribArray(2);
 			}
 		}
 		if constexpr (p_pass_mode == PASS_MODE_COLOR) {

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -186,6 +186,7 @@ struct MultiMesh {
 	RS::MultimeshTransformFormat xform_format = RS::MULTIMESH_TRANSFORM_3D;
 	bool uses_colors = false;
 	bool uses_custom_data = false;
+	bool uses_lightmap = false;
 	int visible_instances = -1;
 	AABB aabb;
 	AABB custom_aabb;
@@ -511,6 +512,7 @@ public:
 	virtual void _multimesh_instance_set_transform_2d(RID p_multimesh, int p_index, const Transform2D &p_transform) override;
 	virtual void _multimesh_instance_set_color(RID p_multimesh, int p_index, const Color &p_color) override;
 	virtual void _multimesh_instance_set_custom_data(RID p_multimesh, int p_index, const Color &p_color) override;
+	virtual void _multimesh_instance_set_lightmap(RID p_multimesh, int p_index, const Rect2 &p_position, int p_slice) override;
 
 	virtual RID _multimesh_get_mesh(RID p_multimesh) const override;
 	virtual void _multimesh_set_custom_aabb(RID p_multimesh, const AABB &p_aabb) override;
@@ -549,6 +551,11 @@ public:
 		MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
 		ERR_FAIL_NULL_V(multimesh, false);
 		return multimesh->uses_custom_data;
+	}
+
+	_FORCE_INLINE_ bool multimesh_uses_lightmap(RID p_multimesh) const {
+		MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+		return multimesh->uses_lightmap;
 	}
 
 	_FORCE_INLINE_ uint32_t multimesh_get_instances_to_draw(RID p_multimesh) const {

--- a/editor/plugins/mesh_editor_uv_tools.cpp
+++ b/editor/plugins/mesh_editor_uv_tools.cpp
@@ -1,0 +1,282 @@
+/**************************************************************************/
+/*  mesh_editor_uv_tools.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "mesh_editor_uv_tools.h"
+
+#include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/aspect_ratio_container.h"
+#include "scene/gui/dialogs.h"
+#include "scene/resources/3d/primitive_meshes.h"
+
+struct MeshInstance3DEditorEdgeSort {
+	Vector2 a;
+	Vector2 b;
+
+	static uint32_t hash(const MeshInstance3DEditorEdgeSort &p_edge) {
+		uint32_t h = hash_murmur3_one_32(HashMapHasherDefault::hash(p_edge.a));
+		return hash_fmix32(hash_murmur3_one_32(HashMapHasherDefault::hash(p_edge.b), h));
+	}
+
+	bool operator==(const MeshInstance3DEditorEdgeSort &p_b) const {
+		return a == p_b.a && b == p_b.b;
+	}
+
+	MeshInstance3DEditorEdgeSort() {}
+	MeshInstance3DEditorEdgeSort(const Vector2 &p_a, const Vector2 &p_b) {
+		if (p_a < p_b) {
+			a = p_a;
+			b = p_b;
+		} else {
+			b = p_a;
+			a = p_b;
+		}
+	}
+};
+
+void MeshEditorUVTools::create_uv_lines(Ref<Mesh> p_mesh, int p_layer) {
+	ERR_FAIL_COND(p_mesh.is_null());
+
+	HashSet<MeshInstance3DEditorEdgeSort, MeshInstance3DEditorEdgeSort> edges;
+	uv_lines.clear();
+	for (int i = 0; i < p_mesh->get_surface_count(); i++) {
+		if (p_mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
+			continue;
+		}
+		Array a = p_mesh->surface_get_arrays(i);
+
+		Vector<Vector2> uv = a[p_layer == 0 ? Mesh::ARRAY_TEX_UV : Mesh::ARRAY_TEX_UV2];
+		if (uv.is_empty()) {
+			err_dialog->set_text(vformat(TTR("Mesh has no UV in layer %d."), p_layer + 1));
+			err_dialog->popup_centered();
+			return;
+		}
+
+		const Vector2 *r = uv.ptr();
+
+		Vector<int> indices = a[Mesh::ARRAY_INDEX];
+		const int *ri = nullptr;
+
+		int ic;
+
+		if (indices.size()) {
+			ic = indices.size();
+			ri = indices.ptr();
+		} else {
+			ic = uv.size();
+		}
+
+		for (int j = 0; j < ic; j += 3) {
+			for (int k = 0; k < 3; k++) {
+				MeshInstance3DEditorEdgeSort edge;
+				if (ri) {
+					edge.a = r[ri[j + k]];
+					edge.b = r[ri[j + ((k + 1) % 3)]];
+				} else {
+					edge.a = r[j + k];
+					edge.b = r[j + ((k + 1) % 3)];
+				}
+
+				if (edges.has(edge)) {
+					continue;
+				}
+
+				uv_lines.push_back(edge.a);
+				uv_lines.push_back(edge.b);
+				edges.insert(edge);
+			}
+		}
+	}
+
+	debug_uv_dialog->popup_centered();
+}
+
+void MeshEditorUVTools::create_uv2(Node3D *p_node, Ref<Mesh> p_mesh) {
+	Ref<Mesh> mesh2 = p_mesh;
+	if (mesh2.is_null()) {
+		err_dialog->set_text(TTR("No mesh to unwrap."));
+		err_dialog->popup_centered();
+		return;
+	}
+
+	// Test if we are allowed to unwrap this mesh resource.
+	String path = mesh2->get_path();
+	int srpos = path.find("::");
+	if (srpos != -1) {
+		String base = path.substr(0, srpos);
+		if (ResourceLoader::get_resource_type(base) == "PackedScene") {
+			if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
+				err_dialog->set_text(TTR("Mesh cannot unwrap UVs because it does not belong to the edited scene. Make it unique first."));
+				err_dialog->popup_centered();
+				return;
+			}
+		} else {
+			if (FileAccess::exists(path + ".import")) {
+				err_dialog->set_text(TTR("Mesh cannot unwrap UVs because it belongs to another resource which was imported from another file type. Make it unique first."));
+				err_dialog->popup_centered();
+				return;
+			}
+		}
+	} else {
+		if (FileAccess::exists(path + ".import")) {
+			err_dialog->set_text(TTR("Mesh cannot unwrap UVs because it was imported from another file type. Make it unique first."));
+			err_dialog->popup_centered();
+			return;
+		}
+	}
+
+	Ref<PrimitiveMesh> primitive_mesh = mesh2;
+	if (primitive_mesh.is_valid()) {
+		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+		ur->create_action(TTR("Unwrap UV2"));
+		ur->add_do_method(*primitive_mesh, "set_add_uv2", true);
+		ur->add_undo_method(*primitive_mesh, "set_add_uv2", primitive_mesh->get_add_uv2());
+		ur->commit_action();
+	} else {
+		Ref<ArrayMesh> array_mesh = mesh2;
+		if (array_mesh.is_null()) {
+			err_dialog->set_text(TTR("Contained Mesh is not of type ArrayMesh."));
+			err_dialog->popup_centered();
+			return;
+		}
+
+		// Preemptively evaluate common fail cases for lightmap unwrapping.
+		{
+			if (array_mesh->get_blend_shape_count() > 0) {
+				err_dialog->set_text(TTR("Can't unwrap mesh with blend shapes."));
+				err_dialog->popup_centered();
+				return;
+			}
+
+			for (int i = 0; i < array_mesh->get_surface_count(); i++) {
+				Mesh::PrimitiveType primitive = array_mesh->surface_get_primitive_type(i);
+
+				if (primitive != Mesh::PRIMITIVE_TRIANGLES) {
+					err_dialog->set_text(TTR("Only triangles are supported for lightmap unwrap."));
+					err_dialog->popup_centered();
+					return;
+				}
+
+				uint64_t format = array_mesh->surface_get_format(i);
+				if (!(format & Mesh::ArrayFormat::ARRAY_FORMAT_NORMAL)) {
+					err_dialog->set_text(TTR("Normals are required for lightmap unwrap."));
+					err_dialog->popup_centered();
+					return;
+				}
+			}
+		}
+
+		Ref<ArrayMesh> unwrapped_mesh = array_mesh->duplicate(false);
+
+		Error err = unwrapped_mesh->lightmap_unwrap(p_node->get_global_transform());
+		if (err != OK) {
+			err_dialog->set_text(TTR("UV Unwrap failed, mesh may not be manifold?"));
+			err_dialog->popup_centered();
+			return;
+		}
+
+		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+		ur->create_action(TTR("Unwrap UV2"));
+
+		ur->add_do_method(p_node, "set_mesh", unwrapped_mesh);
+		ur->add_do_reference(p_node);
+		ur->add_do_reference(array_mesh.ptr());
+
+		ur->add_undo_method(p_node, "set_mesh", array_mesh);
+		ur->add_undo_reference(unwrapped_mesh.ptr());
+
+		ur->commit_action();
+	}
+}
+
+void MeshEditorUVTools::debug_uv_draw() {
+	if (uv_lines.is_empty()) {
+		return;
+	}
+
+	debug_uv->set_clip_contents(true);
+	debug_uv->draw_rect(
+			Rect2(Vector2(), debug_uv->get_size()),
+			get_theme_color(SNAME("dark_color_3"), EditorStringName(Editor)));
+
+	Color mono_color = get_theme_color(SNAME("mono_color"), EditorStringName(Editor));
+	// Draw an outline to represent the UV2's beginning and end area (useful on Black OLED theme).
+	// Top-left coordinate needs to be `(1, 1)` to prevent `clip_contents` from clipping the top and left lines.
+	debug_uv->draw_rect(
+			Rect2(Vector2(1, 1), debug_uv->get_size() - Vector2(1, 1)),
+			mono_color * Color(1, 1, 1, 0.125),
+			false,
+			Math::round(EDSCALE));
+
+	for (int x = 1; x <= 7; x++) {
+		debug_uv->draw_line(
+				Vector2(debug_uv->get_size().x * 0.125 * x, 0),
+				Vector2(debug_uv->get_size().x * 0.125 * x, debug_uv->get_size().y),
+				mono_color * Color(1, 1, 1, 0.125),
+				Math::round(EDSCALE));
+	}
+
+	for (int y = 1; y <= 7; y++) {
+		debug_uv->draw_line(
+				Vector2(0, debug_uv->get_size().y * 0.125 * y),
+				Vector2(debug_uv->get_size().x, debug_uv->get_size().y * 0.125 * y),
+				mono_color * Color(1, 1, 1, 0.125),
+				Math::round(EDSCALE));
+	}
+
+	debug_uv->draw_set_transform(Vector2(), 0, debug_uv->get_size());
+
+	// Use a translucent color to allow overlapping triangles to be visible.
+	// Divide line width by the drawing scale set above, so that line width is consistent regardless of dialog size.
+	// Aspect ratio is preserved by the parent AspectRatioContainer, so we only need to check the X size which is always equal to Y.
+	debug_uv->draw_multiline(
+			uv_lines,
+			mono_color * Color(1, 1, 1, 0.5),
+			Math::round(EDSCALE) / debug_uv->get_size().x);
+}
+
+MeshEditorUVTools::MeshEditorUVTools() {
+	err_dialog = memnew(AcceptDialog);
+	add_child(err_dialog);
+
+	debug_uv_dialog = memnew(AcceptDialog);
+	debug_uv_dialog->set_title(TTR("UV Channel Debug"));
+	add_child(debug_uv_dialog);
+
+	debug_uv_arc = memnew(AspectRatioContainer);
+	debug_uv_dialog->add_child(debug_uv_arc);
+
+	debug_uv = memnew(Control);
+	debug_uv->set_custom_minimum_size(Size2(600, 600) * EDSCALE);
+	debug_uv->connect(SceneStringName(draw), callable_mp(this, &MeshEditorUVTools::debug_uv_draw));
+	debug_uv_arc->add_child(debug_uv);
+}

--- a/editor/plugins/mesh_editor_uv_tools.h
+++ b/editor/plugins/mesh_editor_uv_tools.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  multimesh_editor_plugin.h                                             */
+/*  mesh_editor_uv_tools.h                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,78 +30,25 @@
 
 #pragma once
 
-#include "editor/plugins/editor_plugin.h"
-#include "editor/plugins/mesh_editor_uv_tools.h"
-#include "scene/3d/multimesh_instance_3d.h"
-#include "scene/gui/slider.h"
-#include "scene/gui/spin_box.h"
+#include "scene/gui/control.h"
 
 class AcceptDialog;
-class ConfirmationDialog;
-class MenuButton;
-class OptionButton;
-class SceneTreeDialog;
 class AspectRatioContainer;
+class Mesh;
 
-class MultiMeshEditor : public Control {
-	GDCLASS(MultiMeshEditor, Control);
-
-	friend class MultiMeshEditorPlugin;
+class MeshEditorUVTools : public Control {
+	GDCLASS(MeshEditorUVTools, Control);
 
 	AcceptDialog *err_dialog = nullptr;
-	MenuButton *options = nullptr;
-	MultiMeshInstance3D *_last_pp_node = nullptr;
-	bool browsing_source = false;
-
-	Panel *panel = nullptr;
-	MultiMeshInstance3D *node = nullptr;
-
-	LineEdit *surface_source = nullptr;
-	LineEdit *mesh_source = nullptr;
-
-	SceneTreeDialog *std = nullptr;
-
-	ConfirmationDialog *populate_dialog = nullptr;
-	OptionButton *populate_axis = nullptr;
-	HSlider *populate_rotate_random = nullptr;
-	HSlider *populate_tilt_random = nullptr;
-	SpinBox *populate_scale_random = nullptr;
-	SpinBox *populate_scale = nullptr;
-	SpinBox *populate_amount = nullptr;
-
-	MeshEditorUVTools *uv_tools = nullptr;
-
-	enum Menu {
-		MENU_OPTION_POPULATE,
-		MENU_OPTION_CREATE_UV2,
-		MENU_OPTION_DEBUG_UV1,
-		MENU_OPTION_DEBUG_UV2,
-	};
-
-	void _browsed(const NodePath &p_path);
-	void _menu_option(int);
-	void _populate();
-	void _browse(bool p_source);
-
-protected:
-	void _node_removed(Node *p_node);
+	AcceptDialog *debug_uv_dialog = nullptr;
+	AspectRatioContainer *debug_uv_arc = nullptr;
+	Control *debug_uv = nullptr;
+	Vector<Vector2> uv_lines;
 
 public:
-	void edit(MultiMeshInstance3D *p_multimesh);
-	MultiMeshEditor();
-};
+	void debug_uv_draw();
+	void create_uv_lines(Ref<Mesh> p_mesh, int p_layer);
+	void create_uv2(Node3D *p_node, Ref<Mesh> p_mesh);
 
-class MultiMeshEditorPlugin : public EditorPlugin {
-	GDCLASS(MultiMeshEditorPlugin, EditorPlugin);
-
-	MultiMeshEditor *multimesh_editor = nullptr;
-
-public:
-	virtual String get_plugin_name() const override { return "MultiMesh"; }
-	bool has_main_screen() const override { return false; }
-	virtual void edit(Object *p_object) override;
-	virtual bool handles(Object *p_object) const override;
-	virtual void make_visible(bool p_visible) override;
-
-	MultiMeshEditorPlugin();
+	MeshEditorUVTools();
 };

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
@@ -35,18 +35,15 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector/multi_node_edit.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
-#include "editor/themes/editor_scale.h"
 #include "scene/3d/navigation/navigation_region_3d.h"
 #include "scene/3d/physics/collision_shape_3d.h"
 #include "scene/3d/physics/static_body_3d.h"
-#include "scene/gui/aspect_ratio_container.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/spin_box.h"
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
 #include "scene/resources/3d/convex_polygon_shape_3d.h"
-#include "scene/resources/3d/primitive_meshes.h"
 
 void MeshInstance3DEditor::_node_removed(Node *p_node) {
 	if (p_node == node) {
@@ -245,95 +242,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				err_dialog->popup_centered();
 				return;
 			}
-
-			// Test if we are allowed to unwrap this mesh resource.
-			String path = mesh2->get_path();
-			int srpos = path.find("::");
-			if (srpos != -1) {
-				String base = path.substr(0, srpos);
-				if (ResourceLoader::get_resource_type(base) == "PackedScene") {
-					if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
-						err_dialog->set_text(TTR("Mesh cannot unwrap UVs because it does not belong to the edited scene. Make it unique first."));
-						err_dialog->popup_centered();
-						return;
-					}
-				} else {
-					if (FileAccess::exists(path + ".import")) {
-						err_dialog->set_text(TTR("Mesh cannot unwrap UVs because it belongs to another resource which was imported from another file type. Make it unique first."));
-						err_dialog->popup_centered();
-						return;
-					}
-				}
-			} else {
-				if (FileAccess::exists(path + ".import")) {
-					err_dialog->set_text(TTR("Mesh cannot unwrap UVs because it was imported from another file type. Make it unique first."));
-					err_dialog->popup_centered();
-					return;
-				}
-			}
-
-			Ref<PrimitiveMesh> primitive_mesh = mesh2;
-			if (primitive_mesh.is_valid()) {
-				EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-				ur->create_action(TTR("Unwrap UV2"));
-				ur->add_do_method(*primitive_mesh, "set_add_uv2", true);
-				ur->add_undo_method(*primitive_mesh, "set_add_uv2", primitive_mesh->get_add_uv2());
-				ur->commit_action();
-			} else {
-				Ref<ArrayMesh> array_mesh = mesh2;
-				if (array_mesh.is_null()) {
-					err_dialog->set_text(TTR("Contained Mesh is not of type ArrayMesh."));
-					err_dialog->popup_centered();
-					return;
-				}
-
-				// Preemptively evaluate common fail cases for lightmap unwrapping.
-				{
-					if (array_mesh->get_blend_shape_count() > 0) {
-						err_dialog->set_text(TTR("Can't unwrap mesh with blend shapes."));
-						err_dialog->popup_centered();
-						return;
-					}
-
-					for (int i = 0; i < array_mesh->get_surface_count(); i++) {
-						Mesh::PrimitiveType primitive = array_mesh->surface_get_primitive_type(i);
-
-						if (primitive != Mesh::PRIMITIVE_TRIANGLES) {
-							err_dialog->set_text(TTR("Only triangles are supported for lightmap unwrap."));
-							err_dialog->popup_centered();
-							return;
-						}
-
-						uint64_t format = array_mesh->surface_get_format(i);
-						if (!(format & Mesh::ArrayFormat::ARRAY_FORMAT_NORMAL)) {
-							err_dialog->set_text(TTR("Normals are required for lightmap unwrap."));
-							err_dialog->popup_centered();
-							return;
-						}
-					}
-				}
-
-				Ref<ArrayMesh> unwrapped_mesh = array_mesh->duplicate(false);
-
-				Error err = unwrapped_mesh->lightmap_unwrap(node->get_global_transform());
-				if (err != OK) {
-					err_dialog->set_text(TTR("UV Unwrap failed, mesh may not be manifold?"));
-					err_dialog->popup_centered();
-					return;
-				}
-
-				EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
-				ur->create_action(TTR("Unwrap UV2"));
-
-				ur->add_do_method(node, "set_mesh", unwrapped_mesh);
-				ur->add_do_reference(node);
-				ur->add_do_reference(array_mesh.ptr());
-
-				ur->add_undo_method(node, "set_mesh", array_mesh);
-				ur->add_undo_reference(unwrapped_mesh.ptr());
-
-				ur->commit_action();
-			}
+			uv_tools->create_uv2(node, mesh2);
 		} break;
 		case MENU_OPTION_DEBUG_UV1: {
 			Ref<Mesh> mesh2 = node->get_mesh();
@@ -342,7 +251,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				err_dialog->popup_centered();
 				return;
 			}
-			_create_uv_lines(0);
+			uv_tools->create_uv_lines(mesh2, 0);
 		} break;
 		case MENU_OPTION_DEBUG_UV2: {
 			Ref<Mesh> mesh2 = node->get_mesh();
@@ -351,137 +260,9 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				err_dialog->popup_centered();
 				return;
 			}
-			_create_uv_lines(1);
+			uv_tools->create_uv_lines(mesh2, 1);
 		} break;
 	}
-}
-
-struct MeshInstance3DEditorEdgeSort {
-	Vector2 a;
-	Vector2 b;
-
-	static uint32_t hash(const MeshInstance3DEditorEdgeSort &p_edge) {
-		uint32_t h = hash_murmur3_one_32(HashMapHasherDefault::hash(p_edge.a));
-		return hash_fmix32(hash_murmur3_one_32(HashMapHasherDefault::hash(p_edge.b), h));
-	}
-
-	bool operator==(const MeshInstance3DEditorEdgeSort &p_b) const {
-		return a == p_b.a && b == p_b.b;
-	}
-
-	MeshInstance3DEditorEdgeSort() {}
-	MeshInstance3DEditorEdgeSort(const Vector2 &p_a, const Vector2 &p_b) {
-		if (p_a < p_b) {
-			a = p_a;
-			b = p_b;
-		} else {
-			b = p_a;
-			a = p_b;
-		}
-	}
-};
-
-void MeshInstance3DEditor::_create_uv_lines(int p_layer) {
-	Ref<Mesh> mesh = node->get_mesh();
-	ERR_FAIL_COND(mesh.is_null());
-
-	HashSet<MeshInstance3DEditorEdgeSort, MeshInstance3DEditorEdgeSort> edges;
-	uv_lines.clear();
-	for (int i = 0; i < mesh->get_surface_count(); i++) {
-		if (mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
-			continue;
-		}
-		Array a = mesh->surface_get_arrays(i);
-
-		Vector<Vector2> uv = a[p_layer == 0 ? Mesh::ARRAY_TEX_UV : Mesh::ARRAY_TEX_UV2];
-		if (uv.is_empty()) {
-			err_dialog->set_text(vformat(TTR("Mesh has no UV in layer %d."), p_layer + 1));
-			err_dialog->popup_centered();
-			return;
-		}
-
-		const Vector2 *r = uv.ptr();
-
-		Vector<int> indices = a[Mesh::ARRAY_INDEX];
-		const int *ri = nullptr;
-
-		int ic;
-
-		if (indices.size()) {
-			ic = indices.size();
-			ri = indices.ptr();
-		} else {
-			ic = uv.size();
-		}
-
-		for (int j = 0; j < ic; j += 3) {
-			for (int k = 0; k < 3; k++) {
-				MeshInstance3DEditorEdgeSort edge;
-				if (ri) {
-					edge.a = r[ri[j + k]];
-					edge.b = r[ri[j + ((k + 1) % 3)]];
-				} else {
-					edge.a = r[j + k];
-					edge.b = r[j + ((k + 1) % 3)];
-				}
-
-				if (edges.has(edge)) {
-					continue;
-				}
-
-				uv_lines.push_back(edge.a);
-				uv_lines.push_back(edge.b);
-				edges.insert(edge);
-			}
-		}
-	}
-
-	debug_uv_dialog->popup_centered();
-}
-
-void MeshInstance3DEditor::_debug_uv_draw() {
-	if (uv_lines.is_empty()) {
-		return;
-	}
-
-	debug_uv->set_clip_contents(true);
-	debug_uv->draw_rect(
-			Rect2(Vector2(), debug_uv->get_size()),
-			get_theme_color(SNAME("dark_color_3"), EditorStringName(Editor)));
-
-	// Draw an outline to represent the UV2's beginning and end area (useful on Black OLED theme).
-	// Top-left coordinate needs to be `(1, 1)` to prevent `clip_contents` from clipping the top and left lines.
-	debug_uv->draw_rect(
-			Rect2(Vector2(1, 1), debug_uv->get_size() - Vector2(1, 1)),
-			get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.125),
-			false,
-			Math::round(EDSCALE));
-
-	for (int x = 1; x <= 7; x++) {
-		debug_uv->draw_line(
-				Vector2(debug_uv->get_size().x * 0.125 * x, 0),
-				Vector2(debug_uv->get_size().x * 0.125 * x, debug_uv->get_size().y),
-				get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.125),
-				Math::round(EDSCALE));
-	}
-
-	for (int y = 1; y <= 7; y++) {
-		debug_uv->draw_line(
-				Vector2(0, debug_uv->get_size().y * 0.125 * y),
-				Vector2(debug_uv->get_size().x, debug_uv->get_size().y * 0.125 * y),
-				get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.125),
-				Math::round(EDSCALE));
-	}
-
-	debug_uv->draw_set_transform(Vector2(), 0, debug_uv->get_size());
-
-	// Use a translucent color to allow overlapping triangles to be visible.
-	// Divide line width by the drawing scale set above, so that line width is consistent regardless of dialog size.
-	// Aspect ratio is preserved by the parent AspectRatioContainer, so we only need to check the X size which is always equal to Y.
-	debug_uv->draw_multiline(
-			uv_lines,
-			get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.5),
-			Math::round(EDSCALE) / debug_uv->get_size().x);
 }
 
 void MeshInstance3DEditor::_create_navigation_mesh() {
@@ -655,17 +436,8 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	err_dialog = memnew(AcceptDialog);
 	add_child(err_dialog);
 
-	debug_uv_dialog = memnew(AcceptDialog);
-	debug_uv_dialog->set_title(TTR("UV Channel Debug"));
-	add_child(debug_uv_dialog);
-
-	debug_uv_arc = memnew(AspectRatioContainer);
-	debug_uv_dialog->add_child(debug_uv_arc);
-
-	debug_uv = memnew(Control);
-	debug_uv->set_custom_minimum_size(Size2(600, 600) * EDSCALE);
-	debug_uv->connect(SceneStringName(draw), callable_mp(this, &MeshInstance3DEditor::_debug_uv_draw));
-	debug_uv_arc->add_child(debug_uv);
+	uv_tools = memnew(MeshEditorUVTools);
+	add_child(uv_tools);
 
 	navigation_mesh_dialog = memnew(ConfirmationDialog);
 	navigation_mesh_dialog->set_title(TTR("Create NavigationMesh"));

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.h
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.h
@@ -31,11 +31,11 @@
 #pragma once
 
 #include "editor/plugins/editor_plugin.h"
+#include "editor/plugins/mesh_editor_uv_tools.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/option_button.h"
 
 class AcceptDialog;
-class AspectRatioContainer;
 class ConfirmationDialog;
 class MenuButton;
 class SpinBox;
@@ -78,12 +78,9 @@ class MeshInstance3DEditor : public Control {
 
 	AcceptDialog *err_dialog = nullptr;
 
-	AcceptDialog *debug_uv_dialog = nullptr;
-	AspectRatioContainer *debug_uv_arc = nullptr;
-	Control *debug_uv = nullptr;
-	Vector<Vector2> uv_lines;
-
 	ConfirmationDialog *navigation_mesh_dialog = nullptr;
+
+	MeshEditorUVTools *uv_tools = nullptr;
 
 	void _create_collision_shape();
 	Vector<Ref<Shape3D>> create_shape_from_mesh(Ref<Mesh> p_mesh, int p_option, bool p_verbose);
@@ -91,10 +88,7 @@ class MeshInstance3DEditor : public Control {
 	void _create_outline_mesh();
 	void _create_navigation_mesh();
 
-	void _create_uv_lines(int p_layer);
 	friend class MeshInstance3DEditorPlugin;
-
-	void _debug_uv_draw();
 
 protected:
 	void _node_removed(Node *p_node);

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -328,3 +328,10 @@ GH-108825
 Validate extension JSON: Error: Field 'classes/EditorExportPlatformExtension/methods/_get_option_icon/return_value': type changed value in new API, from "ImageTexture" to "Texture2D".
 
 Return type changed to allow returning both ImageTexture and SVGTexture. Compatibility method registered.
+
+
+GH-97755
+--------
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/instance_geometry_set_lightmap/arguments': size changed value in new API, from 4 to 5.
+
+Optional argument added to allow specifying lightmap slice and scale for multimesh instances.

--- a/scene/3d/multimesh_instance_3d.cpp
+++ b/scene/3d/multimesh_instance_3d.cpp
@@ -97,6 +97,27 @@ Array MultiMeshInstance3D::get_meshes() const {
 	return results;
 }
 
+Array MultiMeshInstance3D::get_bake_meshes() {
+	ERR_FAIL_COND_V(multimesh.is_null() || multimesh->get_mesh().is_null(), Array());
+	ERR_FAIL_COND_V(multimesh->get_transform_format() != MultiMesh::TransformFormat::TRANSFORM_3D, Array());
+
+	Ref<Mesh> mesh = multimesh->get_mesh();
+	ERR_FAIL_COND_V(mesh.is_null(), Array());
+
+	int count = multimesh->get_visible_instance_count();
+	if (count == -1) {
+		count = multimesh->get_instance_count();
+	}
+
+	Array results;
+	for (int i = 0; i < count; i++) {
+		results.push_back(mesh);
+		results.push_back(this->get_global_transform() * multimesh->get_instance_transform(i));
+	}
+
+	return results;
+}
+
 AABB MultiMeshInstance3D::get_aabb() const {
 	if (multimesh.is_null()) {
 		return AABB();

--- a/scene/3d/multimesh_instance_3d.h
+++ b/scene/3d/multimesh_instance_3d.h
@@ -57,6 +57,7 @@ public:
 	Array get_meshes() const;
 
 	virtual AABB get_aabb() const override;
+	Array get_bake_meshes();
 
 private:
 #ifndef NAVIGATION_3D_DISABLED

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -162,6 +162,7 @@ public:
 	virtual void _multimesh_instance_set_transform_2d(RID p_multimesh, int p_index, const Transform2D &p_transform) override {}
 	virtual void _multimesh_instance_set_color(RID p_multimesh, int p_index, const Color &p_color) override {}
 	virtual void _multimesh_instance_set_custom_data(RID p_multimesh, int p_index, const Color &p_color) override {}
+	virtual void _multimesh_instance_set_lightmap(RID p_multimesh, int p_index, const Rect2 &p_position, int p_slice) override {}
 
 	virtual void _multimesh_set_custom_aabb(RID p_multimesh, const AABB &p_aabb) override {}
 	virtual AABB _multimesh_get_custom_aabb(RID p_multimesh) const override { return AABB(); }

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1968,6 +1968,13 @@ void RenderForwardMobile::_fill_instance_data(RenderListType p_render_list, uint
 		instance_data.set_compressed_aabb(surface_aabb);
 		instance_data.set_uv_scale(uv_scale);
 
+		if (inst->data->base_type == RS::INSTANCE_MULTIMESH) {
+			// Since lightmap_uv scale is unused with mulitmesh we can use it to pass the offset to
+			// the start of the lightmap data.
+			uint32_t lightmap_offset = RendererRD::MeshStorage::get_singleton()->_multimesh_get_lightmap_offset(inst->data->base);
+			memcpy(&instance_data.lightmap_uv_scale[0], &lightmap_offset, sizeof(lightmap_offset));
+		}
+
 		RenderElementInfo &element_info = rl->element_info[p_offset + i];
 
 		// Sets lod_index and uses_lightmap at once.
@@ -2051,7 +2058,9 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 				if (lightmap_cull_index >= 0) {
 					inst->gi_offset_cache = inst->lightmap_slice_index << 16;
 					inst->gi_offset_cache |= lightmap_cull_index;
-					flags |= INSTANCE_DATA_FLAG_USE_LIGHTMAP;
+					if ((inst->data->base_type != RS::INSTANCE_MULTIMESH) || (inst->data->base_type == RS::INSTANCE_MULTIMESH && mesh_storage->_multimesh_uses_lightmap(inst->data->base))) {
+						flags |= INSTANCE_DATA_FLAG_USE_LIGHTMAP;
+					}
 					if (scene_state.lightmap_has_sh[lightmap_cull_index]) {
 						flags |= INSTANCE_DATA_FLAG_USE_SH_LIGHTMAP;
 					}

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1510,7 +1510,7 @@ void RendererSceneCull::_update_instance_visibility_dependencies(Instance *p_ins
 	}
 }
 
-void RendererSceneCull::instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index) {
+void RendererSceneCull::instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index, int p_sub_instance) {
 	Instance *instance = instance_owner.get_or_null(p_instance);
 	ERR_FAIL_NULL(instance);
 
@@ -1538,6 +1538,10 @@ void RendererSceneCull::instance_geometry_set_lightmap(RID p_instance, RID p_lig
 		InstanceGeometryData *geom = static_cast<InstanceGeometryData *>(instance->base_data);
 		ERR_FAIL_NULL(geom->geometry_instance);
 		geom->geometry_instance->set_use_lightmap(lightmap_instance_rid, p_lightmap_uv_scale, p_slice_index);
+
+		if (instance->base_type == RS::INSTANCE_MULTIMESH && p_sub_instance != -1) {
+			RSG::mesh_storage->multimesh_instance_set_lightmap(instance->base, p_sub_instance, p_lightmap_uv_scale, p_slice_index);
+		}
 	}
 }
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1058,7 +1058,7 @@ public:
 
 	virtual void instance_geometry_set_visibility_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin, RS::VisibilityRangeFadeMode p_fade_mode);
 
-	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index);
+	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index, int p_sub_instance = -1);
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias);
 
 	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &p_parameter, const Variant &p_value);

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -110,7 +110,7 @@ public:
 	virtual void instance_geometry_set_material_overlay(RID p_instance, RID p_material) = 0;
 
 	virtual void instance_geometry_set_visibility_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin, RS::VisibilityRangeFadeMode p_fade_mode) = 0;
-	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index) = 0;
+	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index, int p_sub_instance = -1) = 0;
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias) = 0;
 	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &p_parameter, const Variant &p_value) = 0;
 	virtual void instance_geometry_get_shader_parameter_list(RID p_instance, List<PropertyInfo> *p_parameters) const = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -400,6 +400,7 @@ public:
 	FUNC3(multimesh_instance_set_transform_2d, RID, int, const Transform2D &)
 	FUNC3(multimesh_instance_set_color, RID, int, const Color &)
 	FUNC3(multimesh_instance_set_custom_data, RID, int, const Color &)
+	FUNC4(multimesh_instance_set_lightmap, RID, int, const Rect2 &, int)
 
 	FUNC2(multimesh_set_custom_aabb, RID, const AABB &)
 	FUNC1RC(AABB, multimesh_get_custom_aabb, RID)
@@ -918,7 +919,7 @@ public:
 	FUNC2(instance_geometry_set_material_overlay, RID, RID)
 
 	FUNC6(instance_geometry_set_visibility_range, RID, float, float, float, float, VisibilityRangeFadeMode)
-	FUNC4(instance_geometry_set_lightmap, RID, RID, const Rect2 &, int)
+	FUNC5(instance_geometry_set_lightmap, RID, RID, const Rect2 &, int, int)
 	FUNC2(instance_geometry_set_lod_bias, RID, float)
 	FUNC2(instance_geometry_set_transparency, RID, float)
 	FUNC3(instance_geometry_set_shader_parameter, RID, const StringName &, const Variant &)

--- a/servers/rendering/storage/mesh_storage.cpp
+++ b/servers/rendering/storage/mesh_storage.cpp
@@ -175,6 +175,10 @@ void RendererMeshStorage::multimesh_instance_set_custom_data(RID p_multimesh, in
 	_multimesh_instance_set_custom_data(p_multimesh, p_index, p_color);
 }
 
+void RendererMeshStorage::multimesh_instance_set_lightmap(RID p_multimesh, int p_index, const Rect2 &p_position, int p_slice) {
+	_multimesh_instance_set_lightmap(p_multimesh, p_index, p_position, p_slice);
+}
+
 void RendererMeshStorage::multimesh_set_custom_aabb(RID p_multimesh, const AABB &p_aabb) {
 	_multimesh_set_custom_aabb(p_multimesh, p_aabb);
 }

--- a/servers/rendering/storage/mesh_storage.h
+++ b/servers/rendering/storage/mesh_storage.h
@@ -132,6 +132,7 @@ public:
 	virtual void multimesh_instance_set_transform_2d(RID p_multimesh, int p_index, const Transform2D &p_transform);
 	virtual void multimesh_instance_set_color(RID p_multimesh, int p_index, const Color &p_color);
 	virtual void multimesh_instance_set_custom_data(RID p_multimesh, int p_index, const Color &p_color);
+	virtual void multimesh_instance_set_lightmap(RID p_multimesh, int p_index, const Rect2 &p_position, int p_slice);
 
 	virtual void multimesh_set_custom_aabb(RID p_multimesh, const AABB &p_aabb);
 	virtual AABB multimesh_get_custom_aabb(RID p_multimesh) const;
@@ -171,6 +172,7 @@ public:
 	virtual void _multimesh_instance_set_transform_2d(RID p_multimesh, int p_index, const Transform2D &p_transform) = 0;
 	virtual void _multimesh_instance_set_color(RID p_multimesh, int p_index, const Color &p_color) = 0;
 	virtual void _multimesh_instance_set_custom_data(RID p_multimesh, int p_index, const Color &p_color) = 0;
+	virtual void _multimesh_instance_set_lightmap(RID p_multimesh, int p_index, const Rect2 &p_position, int p_slice) = 0;
 
 	virtual void _multimesh_set_custom_aabb(RID p_multimesh, const AABB &p_aabb) = 0;
 	virtual AABB _multimesh_get_custom_aabb(RID p_multimesh) const = 0;

--- a/servers/rendering_server.compat.inc
+++ b/servers/rendering_server.compat.inc
@@ -58,6 +58,10 @@ void RenderingServer::_instance_reset_physics_interpolation_bind_compat_104269(R
 	WARN_PRINT_ONCE("instance_reset_physics_interpolation() is deprecated.");
 }
 
+void RenderingServer::_instance_geometry_set_lightmap_bind_compat_97755(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index) {
+	instance_geometry_set_lightmap(p_instance, p_lightmap, p_lightmap_uv_scale, p_slice_index, -1);
+}
+
 void RenderingServer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("multimesh_allocate_data", "multimesh", "instances", "transform_format", "color_format", "custom_data_format"), &RenderingServer::_multimesh_allocate_data_bind_compat_99455, DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("environment_set_fog", "env", "enable", "light_color", "light_energy", "sun_scatter", "density", "height", "height_density", "aerial_perspective", "sky_affect"), &RenderingServer::_environment_set_fog_bind_compat_84792);
@@ -66,6 +70,7 @@ void RenderingServer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("canvas_item_add_circle", "item", "pos", "radius", "color"), &RenderingServer::_canvas_item_add_circle_bind_compat_84523);
 	ClassDB::bind_compatibility_method(D_METHOD("instance_set_interpolated", "instance", "interpolated"), &RenderingServer::_instance_set_interpolated_bind_compat_104269);
 	ClassDB::bind_compatibility_method(D_METHOD("instance_reset_physics_interpolation", "instance"), &RenderingServer::_instance_reset_physics_interpolation_bind_compat_104269);
+	ClassDB::bind_compatibility_method(D_METHOD("instance_geometry_set_lightmap", "instance", "lightmap", "lightmap_uv_scale", "lightmap_slice"), &RenderingServer::_instance_geometry_set_lightmap_bind_compat_97755);
 }
 
 #endif

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3203,7 +3203,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_material_override", "instance", "material"), &RenderingServer::instance_geometry_set_material_override);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_material_overlay", "instance", "material"), &RenderingServer::instance_geometry_set_material_overlay);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_visibility_range", "instance", "min", "max", "min_margin", "max_margin", "fade_mode"), &RenderingServer::instance_geometry_set_visibility_range);
-	ClassDB::bind_method(D_METHOD("instance_geometry_set_lightmap", "instance", "lightmap", "lightmap_uv_scale", "lightmap_slice"), &RenderingServer::instance_geometry_set_lightmap);
+	ClassDB::bind_method(D_METHOD("instance_geometry_set_lightmap", "instance", "lightmap", "lightmap_uv_scale", "lightmap_slice", "sub_instance"), &RenderingServer::instance_geometry_set_lightmap, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_lod_bias", "instance", "lod_bias"), &RenderingServer::instance_geometry_set_lod_bias);
 
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_shader_parameter", "instance", "parameter", "value"), &RenderingServer::instance_geometry_set_shader_parameter);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -89,6 +89,7 @@ protected:
 	void _canvas_item_add_circle_bind_compat_84523(RID p_item, const Point2 &p_pos, float p_radius, const Color &p_color);
 	void _instance_set_interpolated_bind_compat_104269(RID p_instance, bool p_interpolated);
 	void _instance_reset_physics_interpolation_bind_compat_104269(RID p_instance);
+	void _instance_geometry_set_lightmap_bind_compat_97755(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index);
 
 	static void _bind_compatibility_methods();
 #endif
@@ -490,6 +491,7 @@ public:
 	virtual void multimesh_instance_set_transform_2d(RID p_multimesh, int p_index, const Transform2D &p_transform) = 0;
 	virtual void multimesh_instance_set_color(RID p_multimesh, int p_index, const Color &p_color) = 0;
 	virtual void multimesh_instance_set_custom_data(RID p_multimesh, int p_index, const Color &p_color) = 0;
+	virtual void multimesh_instance_set_lightmap(RID p_multimesh, int p_index, const Rect2 &p_position, int p_slice) = 0;
 
 	virtual RID multimesh_get_mesh(RID p_multimesh) const = 0;
 	virtual AABB multimesh_get_aabb(RID p_multimesh) const = 0;
@@ -1500,7 +1502,7 @@ public:
 	virtual void instance_geometry_set_material_override(RID p_instance, RID p_material) = 0;
 	virtual void instance_geometry_set_material_overlay(RID p_instance, RID p_material) = 0;
 	virtual void instance_geometry_set_visibility_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin, VisibilityRangeFadeMode p_fade_mode) = 0;
-	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice) = 0;
+	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice, int p_sub_instance = -1) = 0;
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias) = 0;
 	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency) = 0;
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot/issues/56027

This commit adds support for calling get_meshes on the multimesh_instance_3d.  The order of the transform and mesh differs from get_bake_meshes from gridmap so swap the other so they match.  This appears to fix the issue.

This fixes uses the attempt from https://github.com/godotengine/godot/issues/56027#issuecomment-2192837710 but fixes the ordering in the return so the bake works correctly.