### PR TITLE
Import custom attributes with GLTFDocumentExtension

### DIFF
--- a/modules/gltf/config.py
+++ b/modules/gltf/config.py
@@ -13,6 +13,7 @@ def get_doc_classes():
         "EditorSceneFormatImporterGLTF",
         "GLTFAccessor",
         "GLTFAnimation",
+        "GLTFAttributeMap",
         "GLTFBufferView",
         "GLTFCamera",
         "GLTFDocument",

--- a/modules/gltf/doc_classes/GLTFAttributeMap.xml
+++ b/modules/gltf/doc_classes/GLTFAttributeMap.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GLTFAttributeMap" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Controls how glTF attributes are mapped on import.
+	</brief_description>
+	<description>
+		Controls how glTF attributes are mapped to the resulting [Mesh]. Used by [method GLTFDocumentExtension._import_get_attribute_map].
+		Multiplexing is supported with [code]CUSTOM*[/code] attributes. Setting [code]custom*[/code] and [code]custom*_mux[/code] will combine them into the one array.
+		A pair of [code]custom*[/code] and [code]custom*_mux[/code] attributes must total no larger than [code]vec4[/code]. For instance, you can set [member custom0] to a scalar and [member custom0_mux] to a [code]vec3[/code], but you cannot set [member custom0] to a [code]vec2[/code] and [member custom0_mux] to a [code]vec3[/code] (as this would require 5 values).
+		If the [code]custom*_mux[/code] attribute that is requested is missing, it will act like only the first was set.
+		[b]Note:[/b] It may be necessary to disable [code]generate_lods[/code] in the mesh import settings to preserve custom data.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="color" type="String" setter="set_color" getter="get_color" default="&quot;COLOR_0&quot;">
+			Targets [constant Mesh.ARRAY_COLOR]. Supported attributes: vec3, vec4.
+		</member>
+		<member name="custom0" type="String" setter="set_custom0" getter="get_custom0" default="&quot;TEXCOORD_2&quot;">
+			Targets [constant Mesh.ARRAY_CUSTOM0]. Supported attributes: float, vec2, vec3, vec4.
+		</member>
+		<member name="custom0_mux" type="String" setter="set_custom0_mux" getter="get_custom0_mux" default="&quot;TEXCOORD_3&quot;">
+			Targets [constant Mesh.ARRAY_CUSTOM0]. Supported attributes: float, vec2, vec3.
+		</member>
+		<member name="custom1" type="String" setter="set_custom1" getter="get_custom1" default="&quot;TEXCOORD_4&quot;">
+			Targets [constant Mesh.ARRAY_CUSTOM1]. Supported attributes: float, vec2, vec3, vec4.
+		</member>
+		<member name="custom1_mux" type="String" setter="set_custom1_mux" getter="get_custom1_mux" default="&quot;TEXCOORD_5&quot;">
+			Targets [constant Mesh.ARRAY_CUSTOM1]. Supported attributes: float, vec2, vec3.
+		</member>
+		<member name="custom2" type="String" setter="set_custom2" getter="get_custom2" default="&quot;TEXCOORD_6&quot;">
+			Targets [constant Mesh.ARRAY_CUSTOM2]. Supported attributes: float, vec2, vec3, vec4.
+		</member>
+		<member name="custom2_mux" type="String" setter="set_custom2_mux" getter="get_custom2_mux" default="&quot;TEXCOORD_7&quot;">
+			Targets [constant Mesh.ARRAY_CUSTOM2]. Supported attributes: float, vec2, vec3.
+		</member>
+		<member name="custom3" type="String" setter="set_custom3" getter="get_custom3" default="&quot;&quot;">
+			Targets [constant Mesh.ARRAY_CUSTOM3]. Supported attributes: float, vec2, vec3, vec4.
+		</member>
+		<member name="custom3_mux" type="String" setter="set_custom3_mux" getter="get_custom3_mux" default="&quot;&quot;">
+			Targets [constant Mesh.ARRAY_CUSTOM3]. Supported attributes: float, vec2, vec3.
+		</member>
+		<member name="uv" type="String" setter="set_uv" getter="get_uv" default="&quot;TEXCOORD_0&quot;">
+			Targets [constant Mesh.ARRAY_TEX_UV]. Supported attributes: vec2.
+			[b]Note:[/b] The importer may use ARRAY_TEX_UV to generate tangents.
+		</member>
+		<member name="uv2" type="String" setter="set_uv2" getter="get_uv2" default="&quot;TEXCOORD_1&quot;">
+			Targets [constant Mesh.ARRAY_TEX_UV2]. Supported attributes: vec2.
+		</member>
+	</members>
+</class>

--- a/modules/gltf/doc_classes/GLTFDocumentExtension.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtension.xml
@@ -112,6 +112,14 @@
 				Returns an array of the glTF extensions supported by this GLTFDocumentExtension class. This is used to validate if a glTF file with required extensions can be loaded.
 			</description>
 		</method>
+		<method name="_import_get_attribute_map" qualifiers="virtual">
+			<return type="GLTFAttributeMap" />
+			<param index="0" name="state" type="GLTFState" />
+			<param index="1" name="mesh_index" type="int" />
+			<description>
+				Part of the import process. Allows any mesh to be processed with a custom [GLTFAttributeMap]. Make this function return [code]null[/code] to ignore.
+			</description>
+		</method>
 		<method name="_import_node" qualifiers="virtual">
 			<return type="int" enum="Error" />
 			<param index="0" name="state" type="GLTFState" />

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -288,6 +288,11 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	} else {
 		parameters_map["export_def_bones"] = false;
 	}
+	if (p_options.has(SNAME("blender/meshes/export_attributes")) && p_options[SNAME("blender/meshes/export_attributes")]) {
+		parameters_map["export_attributes"] = true;
+	} else {
+		parameters_map["export_attributes"] = false;
+	}
 	if (p_options.has(SNAME("blender/nodes/modifiers")) && p_options[SNAME("blender/nodes/modifiers")]) {
 		parameters_map["export_apply"] = true;
 	} else {
@@ -380,6 +385,7 @@ void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, Li
 	ADD_OPTION_BOOL("blender/meshes/tangents", true);
 	ADD_OPTION_ENUM("blender/meshes/skins", "None,4 Influences (Compatible),All Influences", BLEND_BONE_INFLUENCES_ALL);
 	ADD_OPTION_BOOL("blender/meshes/export_bones_deforming_mesh_only", false);
+	ADD_OPTION_BOOL("blender/meshes/export_attributes", false);
 	ADD_OPTION_BOOL("blender/materials/unpack_enabled", true);
 	ADD_OPTION_ENUM("blender/materials/export_materials", "Placeholder,Export,Named Placeholder", BLEND_MATERIAL_EXPORT_EXPORT);
 	ADD_OPTION_BOOL("blender/animation/limit_playback", true);

--- a/modules/gltf/extensions/gltf_attribute_map.cpp
+++ b/modules/gltf/extensions/gltf_attribute_map.cpp
@@ -1,0 +1,156 @@
+/**************************************************************************/
+/*  gltf_attribute_map.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gltf_attribute_map.h"
+
+void GLTFAttributeMap::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_color"), &GLTFAttributeMap::get_color);
+	ClassDB::bind_method(D_METHOD("set_color", "color"), &GLTFAttributeMap::set_color);
+	ClassDB::bind_method(D_METHOD("get_uv"), &GLTFAttributeMap::get_uv);
+	ClassDB::bind_method(D_METHOD("set_uv", "uv"), &GLTFAttributeMap::set_uv);
+	ClassDB::bind_method(D_METHOD("get_uv2"), &GLTFAttributeMap::get_uv2);
+	ClassDB::bind_method(D_METHOD("set_uv2", "uv2"), &GLTFAttributeMap::set_uv2);
+	ClassDB::bind_method(D_METHOD("get_custom0"), &GLTFAttributeMap::get_custom0);
+	ClassDB::bind_method(D_METHOD("set_custom0", "custom0"), &GLTFAttributeMap::set_custom0);
+	ClassDB::bind_method(D_METHOD("get_custom0_mux"), &GLTFAttributeMap::get_custom0_mux);
+	ClassDB::bind_method(D_METHOD("set_custom0_mux", "custom0_mux"), &GLTFAttributeMap::set_custom0_mux);
+	ClassDB::bind_method(D_METHOD("get_custom1"), &GLTFAttributeMap::get_custom1);
+	ClassDB::bind_method(D_METHOD("set_custom1", "custom1"), &GLTFAttributeMap::set_custom1);
+	ClassDB::bind_method(D_METHOD("get_custom1_mux"), &GLTFAttributeMap::get_custom1_mux);
+	ClassDB::bind_method(D_METHOD("set_custom1_mux", "custom1_mux"), &GLTFAttributeMap::set_custom1_mux);
+	ClassDB::bind_method(D_METHOD("get_custom2"), &GLTFAttributeMap::get_custom2);
+	ClassDB::bind_method(D_METHOD("set_custom2", "custom2"), &GLTFAttributeMap::set_custom2);
+	ClassDB::bind_method(D_METHOD("get_custom2_mux"), &GLTFAttributeMap::get_custom2_mux);
+	ClassDB::bind_method(D_METHOD("set_custom2_mux", "custom2_mux"), &GLTFAttributeMap::set_custom2_mux);
+	ClassDB::bind_method(D_METHOD("get_custom3"), &GLTFAttributeMap::get_custom3);
+	ClassDB::bind_method(D_METHOD("set_custom3", "custom3"), &GLTFAttributeMap::set_custom3);
+	ClassDB::bind_method(D_METHOD("get_custom3_mux"), &GLTFAttributeMap::get_custom3_mux);
+	ClassDB::bind_method(D_METHOD("set_custom3_mux", "custom3_mux"), &GLTFAttributeMap::set_custom3_mux);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "color"), "set_color", "get_color");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "uv"), "set_uv", "get_uv");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "uv2"), "set_uv2", "get_uv2");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom0"), "set_custom0", "get_custom0");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom0_mux"), "set_custom0_mux", "get_custom0_mux");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom1"), "set_custom1", "get_custom1");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom1_mux"), "set_custom1_mux", "get_custom1_mux");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom2"), "set_custom2", "get_custom2");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom2_mux"), "set_custom2_mux", "get_custom2_mux");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom3"), "set_custom3", "get_custom3");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "custom3_mux"), "set_custom3_mux", "get_custom3_mux");
+}
+
+String GLTFAttributeMap::get_color() const {
+	return _color;
+}
+
+void GLTFAttributeMap::set_color(const String &p_color) {
+	_color = p_color;
+}
+
+String GLTFAttributeMap::get_uv() const {
+	return _uv;
+}
+
+void GLTFAttributeMap::set_uv(const String &p_uv) {
+	_uv = p_uv;
+}
+
+String GLTFAttributeMap::get_uv2() const {
+	return _uv2;
+}
+
+void GLTFAttributeMap::set_uv2(const String &p_uv2) {
+	_uv2 = p_uv2;
+}
+
+String GLTFAttributeMap::get_custom0() const {
+	return _custom[0];
+}
+
+void GLTFAttributeMap::set_custom0(const String &p_custom0) {
+	_custom[0] = p_custom0;
+}
+
+String GLTFAttributeMap::get_custom0_mux() const {
+	return _custom_mux[0];
+}
+
+void GLTFAttributeMap::set_custom0_mux(const String &p_custom0_mux) {
+	_custom_mux[0] = p_custom0_mux;
+}
+
+String GLTFAttributeMap::get_custom1() const {
+	return _custom[1];
+}
+
+void GLTFAttributeMap::set_custom1(const String &p_custom1) {
+	_custom[1] = p_custom1;
+}
+
+String GLTFAttributeMap::get_custom1_mux() const {
+	return _custom_mux[1];
+}
+
+void GLTFAttributeMap::set_custom1_mux(const String &p_custom1_mux) {
+	_custom_mux[1] = p_custom1_mux;
+}
+
+String GLTFAttributeMap::get_custom2() const {
+	return _custom[2];
+}
+
+void GLTFAttributeMap::set_custom2(const String &p_custom2) {
+	_custom[2] = p_custom2;
+}
+
+String GLTFAttributeMap::get_custom2_mux() const {
+	return _custom_mux[2];
+}
+
+void GLTFAttributeMap::set_custom2_mux(const String &p_custom2_mux) {
+	_custom_mux[2] = p_custom2_mux;
+}
+
+String GLTFAttributeMap::get_custom3() const {
+	return _custom[3];
+}
+
+void GLTFAttributeMap::set_custom3(const String &p_custom3) {
+	_custom[3] = p_custom3;
+}
+
+String GLTFAttributeMap::get_custom3_mux() const {
+	return _custom_mux[3];
+}
+
+void GLTFAttributeMap::set_custom3_mux(const String &p_custom3_mux) {
+	_custom_mux[3] = p_custom3_mux;
+}

--- a/modules/gltf/extensions/gltf_attribute_map.h
+++ b/modules/gltf/extensions/gltf_attribute_map.h
@@ -1,0 +1,94 @@
+/**************************************************************************/
+/*  gltf_attribute_map.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource.h"
+
+class GLTFAttributeMap : public Resource {
+	GDCLASS(GLTFAttributeMap, Resource);
+
+protected:
+	static void _bind_methods();
+
+private:
+	friend class GLTFDocument;
+
+	String _color = "COLOR_0";
+	String _uv = "TEXCOORD_0";
+	String _uv2 = "TEXCOORD_1";
+
+	String _custom[4]{
+		"TEXCOORD_2",
+		"TEXCOORD_4",
+		"TEXCOORD_6",
+		""
+	};
+	String _custom_mux[4]{
+		"TEXCOORD_3",
+		"TEXCOORD_5",
+		"TEXCOORD_7",
+		""
+	};
+
+public:
+	String get_color() const;
+	void set_color(const String &p_color);
+
+	String get_uv() const;
+	void set_uv(const String &p_uv);
+
+	String get_uv2() const;
+	void set_uv2(const String &p_uv2);
+
+	String get_custom0() const;
+	void set_custom0(const String &p_custom0);
+
+	String get_custom0_mux() const;
+	void set_custom0_mux(const String &p_custom0_mux);
+
+	String get_custom1() const;
+	void set_custom1(const String &p_custom1);
+
+	String get_custom1_mux() const;
+	void set_custom1_mux(const String &p_custom1_mux);
+
+	String get_custom2() const;
+	void set_custom2(const String &p_custom2);
+
+	String get_custom2_mux() const;
+	void set_custom2_mux(const String &p_custom2_mux);
+
+	String get_custom3() const;
+	void set_custom3(const String &p_custom3);
+
+	String get_custom3_mux() const;
+	void set_custom3_mux(const String &p_custom3_mux);
+};

--- a/modules/gltf/extensions/gltf_document_extension.cpp
+++ b/modules/gltf/extensions/gltf_document_extension.cpp
@@ -33,6 +33,7 @@
 void GLTFDocumentExtension::_bind_methods() {
 	// Import process.
 	GDVIRTUAL_BIND(_import_preflight, "state", "extensions");
+	GDVIRTUAL_BIND(_import_get_attribute_map, "state", "mesh_index");
 	GDVIRTUAL_BIND(_get_supported_extensions);
 	GDVIRTUAL_BIND(_parse_node_extensions, "state", "gltf_node", "extensions");
 	GDVIRTUAL_BIND(_parse_image_data, "state", "image_data", "mime_type", "ret_image");
@@ -64,6 +65,12 @@ Error GLTFDocumentExtension::import_preflight(Ref<GLTFState> p_state, const Vect
 	Error err = OK;
 	GDVIRTUAL_CALL(_import_preflight, p_state, p_extensions, err);
 	return err;
+}
+
+Ref<GLTFAttributeMap> GLTFDocumentExtension::import_get_attribute_map(Ref<GLTFState> p_state, GLTFMeshIndex p_index) {
+	Ref<GLTFAttributeMap> ret;
+	GDVIRTUAL_CALL(_import_get_attribute_map, p_state, p_index, ret);
+	return ret;
 }
 
 Vector<String> GLTFDocumentExtension::get_supported_extensions() {

--- a/modules/gltf/extensions/gltf_document_extension.h
+++ b/modules/gltf/extensions/gltf_document_extension.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "../gltf_state.h"
+#include "gltf_attribute_map.h"
 
 #include "scene/3d/node_3d.h"
 
@@ -43,6 +44,7 @@ protected:
 public:
 	// Import process.
 	virtual Error import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions);
+	virtual Ref<GLTFAttributeMap> import_get_attribute_map(Ref<GLTFState> p_state, GLTFMeshIndex p_index);
 	virtual Vector<String> get_supported_extensions();
 	virtual Error parse_node_extensions(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, const Dictionary &p_extensions);
 	virtual Error parse_image_data(Ref<GLTFState> p_state, const PackedByteArray &p_image_data, const String &p_mime_type, Ref<Image> r_image);
@@ -69,6 +71,7 @@ public:
 
 	// Import process.
 	GDVIRTUAL2R(Error, _import_preflight, Ref<GLTFState>, Vector<String>);
+	GDVIRTUAL2R(Ref<GLTFAttributeMap>, _import_get_attribute_map, Ref<GLTFState>, GLTFMeshIndex);
 	GDVIRTUAL0R(Vector<String>, _get_supported_extensions);
 	GDVIRTUAL3R(Error, _parse_node_extensions, Ref<GLTFState>, Ref<GLTFNode>, Dictionary);
 	GDVIRTUAL4R(Error, _parse_image_data, Ref<GLTFState>, PackedByteArray, String, Ref<Image>);

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -30,6 +30,7 @@
 
 #include "register_types.h"
 
+#include "extensions/gltf_attribute_map.h"
 #include "extensions/gltf_document_extension_convert_importer_mesh.h"
 #include "extensions/gltf_document_extension_texture_ktx.h"
 #include "extensions/gltf_document_extension_texture_webp.h"
@@ -108,6 +109,7 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		// glTF API available at runtime.
 		GDREGISTER_CLASS(GLTFAccessor);
 		GDREGISTER_CLASS(GLTFAnimation);
+		GDREGISTER_CLASS(GLTFAttributeMap);
 		GDREGISTER_CLASS(GLTFBufferView);
 		GDREGISTER_CLASS(GLTFCamera);
 		GDREGISTER_CLASS(GLTFDocument);


### PR DESCRIPTION
## Proposal
Import ARRAY_CUSTOM# attributes with GLTFDocumentExtension using a function to specify layer name. Also added "Export Attributes" checkbox to the blender importer.
https://github.com/godotengine/godot-proposals/issues/10892

## Test Project
![image](https://github.com/user-attachments/assets/ae93dc78-5555-479f-9d81-8a2036a56099)
[custom_attrib_test.zip](https://github.com/user-attachments/files/23870955/custom_attrib_test.zip)

## changes
- Ability to combine 2 attributes per CUSTOM
- Created new GLTFAttributeMap resource to deal with the sheer number of possibilities
```gdscript
extends GLTFDocumentExtension

func _import_get_attribute_map(state: GLTFState, mesh_index: int) -> GLTFAttributeMap:
	var attrmap := GLTFAttributeMap.new()

	var mesh_name: String = state.json["meshes"][mesh_index]["name"]
	match mesh_name:
		"mesh_1": attrmap.color = "COLOR_1"
		"mesh_2": attrmap.color = "_MY_DATA"
		"custom":
			attrmap.custom0 = "_ROCK"
			attrmap.custom1 = "_MUD"
			attrmap.custom2 = ""
			attrmap.custom3 = "_GRASS"
			attrmap.custom3_mux = "_SNOW"

	return attrmap
```

## Supported attributes
- Mesh.ARRAY_TEX_UV (vec2)
- Mesh.ARRAY_TEX_UV2 (vec2)
- Mesh.ARRAY_COLOR (vec3, vec4)
- Mesh.ARRAY_CUSTOM# (scalar, vec2, vec3, vec4)