### PR TITLE
Add step out to script debugger

### DIFF
--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -224,6 +224,10 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 			script_debugger->set_depth(0);
 			script_debugger->set_lines_left(1);
 			break;
+		} else if (line == "o" || line == "out") {
+			script_debugger->set_depth(1);
+			script_debugger->set_lines_left(1);
+			break;
 		} else if (line == "fin" || line == "finish") {
 			String current_function = script_lang->debug_get_stack_level_function(0);
 

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -458,6 +458,11 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 				script_debugger->set_lines_left(1);
 				break;
 
+			} else if (command == "out") {
+				script_debugger->set_depth(1);
+				script_debugger->set_lines_left(1);
+				break;
+
 			} else if (command == "continue") {
 				script_debugger->set_depth(-1);
 				script_debugger->set_lines_left(-1);

--- a/editor/debugger/debugger_editor_plugin.cpp
+++ b/editor/debugger/debugger_editor_plugin.cpp
@@ -47,6 +47,7 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
 
 	ED_SHORTCUT("debugger/step_into", TTRC("Step Into"), Key::F11);
 	ED_SHORTCUT("debugger/step_over", TTRC("Step Over"), Key::F10);
+	ED_SHORTCUT("debugger/step_out", TTRC("Step Out"), KeyModifierMask::ALT | Key::F11);
 	ED_SHORTCUT("debugger/break", TTRC("Break"));
 	ED_SHORTCUT("debugger/continue", TTRC("Continue"), Key::F12);
 	ED_SHORTCUT("debugger/debug_with_external_editor", TTRC("Debug with External Editor"));

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -111,6 +111,13 @@ void ScriptEditorDebugger::debug_ignore_error_breaks() {
 	_put_msg("set_ignore_error_breaks", msg);
 }
 
+void ScriptEditorDebugger::debug_out() {
+	ERR_FAIL_COND(!is_breaked());
+
+	_put_msg("out", Array(), debugging_thread_id);
+	_clear_execution();
+}
+
 void ScriptEditorDebugger::debug_next() {
 	ERR_FAIL_COND(!is_breaked());
 
@@ -1049,6 +1056,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			copy->set_button_icon(get_editor_theme_icon(SNAME("ActionCopy")));
 			step->set_button_icon(get_editor_theme_icon(SNAME("DebugStep")));
 			next->set_button_icon(get_editor_theme_icon(SNAME("DebugNext")));
+			out->set_button_icon(get_editor_theme_icon(SNAME("DebugOut")));
 			dobreak->set_button_icon(get_editor_theme_icon(SNAME("Pause")));
 			docontinue->set_button_icon(get_editor_theme_icon(SNAME("DebugContinue")));
 			vmem_notice_icon->set_texture(get_editor_theme_icon(SNAME("NodeInfo")));
@@ -1221,6 +1229,7 @@ void ScriptEditorDebugger::_update_buttons_state() {
 	vmem_refresh->set_disabled(!active);
 	step->set_disabled(!active || !is_breaked() || !is_debuggable());
 	next->set_disabled(!active || !is_breaked() || !is_debuggable());
+	out->set_disabled(!active || !is_breaked() || !is_debuggable());
 	copy->set_disabled(!active || !is_breaked());
 	docontinue->set_disabled(!active || !is_breaked());
 	dobreak->set_disabled(!active || is_breaked());
@@ -2039,6 +2048,13 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		next->set_tooltip_text(TTR("Step Over"));
 		next->set_shortcut(ED_GET_SHORTCUT("debugger/step_over"));
 		next->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::debug_next));
+
+		out = memnew(Button);
+		out->set_theme_type_variation(SceneStringName(FlatButton));
+		hbc->add_child(out);
+		out->set_tooltip_text(TTRC("Step Out"));
+		out->set_shortcut(ED_GET_SHORTCUT("debugger/step_out"));
+		out->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::debug_out));
 
 		hbc->add_child(memnew(VSeparator));
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -125,6 +125,7 @@ private:
 	Button *copy = nullptr;
 	Button *step = nullptr;
 	Button *next = nullptr;
+	Button *out = nullptr;
 	Button *dobreak = nullptr;
 	Button *docontinue = nullptr;
 	// Reference to "Remote" tab in scene tree. Needed by _live_edit_set and buttons state.
@@ -315,6 +316,7 @@ public:
 	void debug_ignore_error_breaks();
 	void debug_copy();
 
+	void debug_out();
 	void debug_next();
 	void debug_step();
 	void debug_break();

--- a/editor/icons/DebugOut.svg
+++ b/editor/icons/DebugOut.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#ff5f5f" d="M3 15V5H1l1.5-2L4 1l1.5 2L7 5H5v10z"/><path fill="#e0e0e0" d="M7 1v2h8V1Zm2 4v2h6V5Zm0 4v2h6V9Zm-2 4v2h8v-2z"/></svg>


### PR DESCRIPTION
Implementation for proposal https://github.com/godotengine/godot-proposals/issues/2815

![image](https://github.com/user-attachments/assets/10d55d0f-30d3-4bc4-941d-ee765e4e2964)

The debugger and gdscript vm are already setup to be able to handle step out. This PR adds the appropriate debugger protocol, the corresponding button, icon, and key-bind ~~(default to Shift+F11)~~.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/2815*

 edit, key-bind now defaults to Alt+F11 see https://github.com/godotengine/godot/pull/97758#issuecomment-2530394412 