### PR TITLE
Fix error when stopping empty animation player.

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -777,7 +777,7 @@ void AnimationPlayer::_stop_internal(bool p_reset, bool p_keep_state) {
 	_clear_caches();
 	Playback &c = playback;
 	// c.blend.clear();
-	double start = get_section_start_time();
+	double start = c.current.from ? get_section_start_time() : 0;
 	if (p_reset) {
 		c.blend.clear();
 		if (p_keep_state) {


### PR DESCRIPTION
Fix #97714 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
