### PR TITLE
Fix `GraphEdit` connections not updating when a child of `GraphNode` goes invisible or changes size

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -277,6 +277,11 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="slot_sizes_changed">
+			<description>
+				Emitted when any slot's size might have changed.
+			</description>
+		</signal>
 		<signal name="slot_updated">
 			<param index="0" name="slot_index" type="int" />
 			<description>

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -689,6 +689,7 @@ void GraphEdit::add_child_notify(Node *p_child) {
 		GraphNode *graph_node = Object::cast_to<GraphNode>(graph_element);
 		if (graph_node) {
 			graph_node->connect("slot_updated", callable_mp(this, &GraphEdit::_graph_node_slot_updated).bind(graph_element));
+			graph_node->connect("slot_sizes_changed", callable_mp(this, &GraphEdit::_graph_node_rect_changed).bind(graph_node));
 			graph_node->connect(SceneStringName(item_rect_changed), callable_mp(this, &GraphEdit::_graph_node_rect_changed).bind(graph_node));
 			_ensure_node_order_from(graph_node);
 		}
@@ -744,6 +745,7 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 		GraphNode *graph_node = Object::cast_to<GraphNode>(graph_element);
 		if (graph_node) {
 			graph_node->disconnect("slot_updated", callable_mp(this, &GraphEdit::_graph_node_slot_updated));
+			graph_node->disconnect("slot_sizes_changed", callable_mp(this, &GraphEdit::_graph_node_rect_changed));
 			graph_node->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &GraphEdit::_graph_node_rect_changed));
 
 			// Invalidate all adjacent connections, so that they are removed before the next redraw.

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -202,10 +202,6 @@ void GraphNode::_resort() {
 		selected_slot = -1;
 	}
 
-	if (children_count == 0) {
-		return;
-	}
-
 	int stretch_max = new_size.height - (children_count - 1) * separation;
 	int stretch_diff = stretch_max - stretch_min;
 
@@ -293,6 +289,7 @@ void GraphNode::_resort() {
 	queue_accessibility_update();
 	queue_redraw();
 	port_pos_dirty = true;
+	emit_signal(SNAME("slot_sizes_changed"));
 }
 
 void GraphNode::draw_port(int p_slot_index, Point2i p_pos, bool p_left, const Color &p_color) {
@@ -986,7 +983,7 @@ void GraphNode::_port_pos_update() {
 	int slot_index = 0;
 
 	for (int i = 0; i < get_child_count(false); i++) {
-		Control *child = as_sortable_control(get_child(i, false), SortableVisibilityMode::IGNORE);
+		Control *child = as_sortable_control(get_child(i, false), SortableVisibilityMode::VISIBLE_IN_TREE);
 		if (!child) {
 			continue;
 		}
@@ -1238,6 +1235,7 @@ void GraphNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_invalid_connection_type"), "set_ignore_invalid_connection_type", "is_ignoring_valid_connection_type");
 
 	ADD_SIGNAL(MethodInfo("slot_updated", PropertyInfo(Variant::INT, "slot_index")));
+	ADD_SIGNAL(MethodInfo("slot_sizes_changed"));
 
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, GraphNode, panel);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_STYLEBOX, GraphNode, panel_selected);


### PR DESCRIPTION
Fixes #96939