### PR TITLE
[GDExtension] Improve error messages during export.

### DIFF
--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -222,9 +222,15 @@ Error EditorExportPlatformPC::export_project_data(const Ref<EditorExportPreset> 
 				err = da->make_dir_recursive(target_path);
 				if (err == OK) {
 					err = da->copy_dir(src_path, target_path, -1, true);
+					if (err != OK) {
+						add_message(EXPORT_MESSAGE_ERROR, TTR("GDExtension"), TTR(vformat("Failed to copy shared object \"%s\".", src_path)));
+					}
 				}
 			} else {
 				err = da->copy(src_path, target_path);
+				if (err != OK) {
+					add_message(EXPORT_MESSAGE_ERROR, TTR("GDExtension"), TTR(vformat("Failed to copy shared object \"%s\".", src_path)));
+				}
 				if (err == OK) {
 					err = sign_shared_object(p_preset, p_debug, target_path);
 				}

--- a/editor/plugins/gdextension_export_plugin.h
+++ b/editor/plugins/gdextension_export_plugin.h
@@ -127,7 +127,10 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 			for (const String &E : p_features) {
 				features_vector.append(E);
 			}
-			ERR_FAIL_MSG(vformat("No suitable library found for GDExtension: %s. Possible feature flags for your platform: %s", p_path, String(", ").join(features_vector)));
+			if (get_export_platform().is_valid()) {
+				get_export_platform()->add_message(EditorExportPlatform::EXPORT_MESSAGE_WARNING, TTR("GDExtension"), vformat(TTR("No suitable library found for GDExtension: \"%s\". Possible feature flags for your platform: %s"), p_path, String(", ").join(features_vector)));
+			}
+			return;
 		}
 
 		Vector<SharedObject> dependencies_shared_objects = GDExtensionLibraryLoader::find_extension_dependencies(p_path, config, [p_features](String p_feature) { return p_features.has(p_feature); });


### PR DESCRIPTION
- Shows `No suitable library found for GDExtension: %s.` in the export results window instead of only printing in the log (shown when library for the export target is not supported by GDExtension).
- Shows `Failed to copy shared object %s.` instead of `Unknown error 7` when files are listed in the `.gdextension` but are missing.