### PR TITLE
GDScript: Fix `GDScriptCache::get_full_script()` uses non-remapped path

### DIFF
--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -297,6 +297,7 @@ Vector<uint8_t> GDScriptCache::get_binary_tokens(const String &p_path) {
 
 Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, Error &r_error, const String &p_owner) {
 	MutexLock lock(singleton->mutex);
+
 	if (!p_owner.is_empty()) {
 		singleton->dependencies[p_owner].insert(p_path);
 	}
@@ -307,7 +308,7 @@ Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, Error &r_e
 		return singleton->shallow_gdscript_cache[p_path];
 	}
 
-	String remapped_path = ResourceLoader::path_remap(p_path);
+	const String remapped_path = ResourceLoader::path_remap(p_path);
 
 	Ref<GDScript> script;
 	script.instantiate();
@@ -332,6 +333,7 @@ Ref<GDScript> GDScriptCache::get_shallow_script(const String &p_path, Error &r_e
 	}
 
 	singleton->shallow_gdscript_cache[p_path] = script;
+
 	return script;
 }
 
@@ -359,16 +361,18 @@ Ref<GDScript> GDScriptCache::get_full_script(const String &p_path, Error &r_erro
 		}
 	}
 
+	const String remapped_path = ResourceLoader::path_remap(p_path);
+
 	if (p_update_from_disk) {
-		if (p_path.get_extension().to_lower() == "gdc") {
-			Vector<uint8_t> buffer = get_binary_tokens(p_path);
+		if (remapped_path.get_extension().to_lower() == "gdc") {
+			Vector<uint8_t> buffer = get_binary_tokens(remapped_path);
 			if (buffer.is_empty()) {
 				r_error = ERR_FILE_CANT_READ;
 				return script;
 			}
 			script->set_binary_tokens_source(buffer);
 		} else {
-			r_error = script->load_source_code(p_path);
+			r_error = script->load_source_code(remapped_path);
 			if (r_error) {
 				return script;
 			}


### PR DESCRIPTION
* Fixes #97467.

This PR fixes an inconsistency between `GDScriptCache::get_shallow_script()` and `GDScriptCache::get_full_script()`. `Resource`, FQCN, and `GDScriptCache` use canonical paths. Only `GDScript::load_source_code()`, `GDScriptCache::get_source_code()`, and `GDScriptCache::get_binary_tokens()` deal with actual paths.

**Note:** The existence of both `GDScript::load_source_code()` and `GDScriptCache::get_source_code()` may indicate a need for refactoring.