### PR TITLE
Fix immediate mesh modifications that don't call set_mesh

### DIFF
--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -54,7 +54,20 @@ void MeshInstance2D::_bind_methods() {
 }
 
 void MeshInstance2D::set_mesh(const Ref<Mesh> &p_mesh) {
+	if (mesh == p_mesh) {
+		return;
+	}
+
+	if (mesh.is_valid()) {
+		mesh->disconnect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+	}
+
 	mesh = p_mesh;
+
+	if (mesh.is_valid()) {
+		mesh->connect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+	}
+
 	queue_redraw();
 }
 

--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -312,6 +312,8 @@ void ImmediateMesh::surface_end() {
 	uses_uv2s = false;
 
 	surface_active = false;
+
+	emit_changed();
 }
 
 void ImmediateMesh::clear_surfaces() {


### PR DESCRIPTION
Mesh_instance_2d has no way to know when the mesh had been modified unless you called set_mesh.  This meant that you could modify the underlying mesh without it knowing which could result in incorrect result.

Modified mesh_instance_2d to be more similar to mesh_instance_3d which connects to the changed signal of the mesh and reacts occordingly.

Resolves [94151](https://github.com/godotengine/godot/issues/94151)
