### PR TITLE
Optimize `SceneTreeEditor::_update_node_tooltip()`

### DIFF
--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -56,24 +56,32 @@ StringBuilder &StringBuilder::append(const char *p_cstring) {
 	return *this;
 }
 
+void StringBuilder::clear() {
+	string_length = 0;
+	strings.clear();
+	c_strings.clear();
+	appended_strings.clear();
+	buffer_persist.clear();
+}
+
 String StringBuilder::as_string() const {
 	if (string_length == 0) {
 		return "";
 	}
 
-	char32_t *buffer = memnew_arr(char32_t, string_length);
+	buffer_persist.resize(string_length);
 
 	int current_position = 0;
 
 	int godot_string_elem = 0;
 	int c_string_elem = 0;
 
-	for (int i = 0; i < appended_strings.size(); i++) {
+	for (uint32_t i = 0; i < appended_strings.size(); i++) {
 		if (appended_strings[i] == -1) {
 			// Godot string
 			const String &s = strings[godot_string_elem];
 
-			memcpy(buffer + current_position, s.ptr(), s.length() * sizeof(char32_t));
+			memcpy(buffer_persist.ptr() + current_position, s.ptr(), s.length() * sizeof(char32_t));
 
 			current_position += s.length();
 
@@ -82,7 +90,7 @@ String StringBuilder::as_string() const {
 			const char *s = c_strings[c_string_elem];
 
 			for (int32_t j = 0; j < appended_strings[i]; j++) {
-				buffer[current_position + j] = s[j];
+				buffer_persist[current_position + j] = s[j];
 			}
 
 			current_position += appended_strings[i];
@@ -91,9 +99,5 @@ String StringBuilder::as_string() const {
 		}
 	}
 
-	String final_string = String(buffer, string_length);
-
-	memdelete_arr(buffer);
-
-	return final_string;
+	return String(buffer_persist.ptr(), string_length);
 }

--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -61,7 +61,6 @@ void StringBuilder::clear() {
 	strings.clear();
 	c_strings.clear();
 	appended_strings.clear();
-	buffer_persist.clear();
 }
 
 String StringBuilder::as_string() const {
@@ -69,7 +68,8 @@ String StringBuilder::as_string() const {
 		return "";
 	}
 
-	buffer_persist.resize(string_length);
+	String buffer = String();
+	buffer.resize(string_length + 1);
 
 	int current_position = 0;
 
@@ -81,7 +81,7 @@ String StringBuilder::as_string() const {
 			// Godot string
 			const String &s = strings[godot_string_elem];
 
-			memcpy(buffer_persist.ptr() + current_position, s.ptr(), s.length() * sizeof(char32_t));
+			memcpy(buffer.ptrw() + current_position, s.ptr(), s.length() * sizeof(char32_t));
 
 			current_position += s.length();
 
@@ -90,7 +90,7 @@ String StringBuilder::as_string() const {
 			const char *s = c_strings[c_string_elem];
 
 			for (int32_t j = 0; j < appended_strings[i]; j++) {
-				buffer_persist[current_position + j] = s[j];
+				buffer[current_position + j] = s[j];
 			}
 
 			current_position += appended_strings[i];
@@ -99,5 +99,7 @@ String StringBuilder::as_string() const {
 		}
 	}
 
-	return String(buffer_persist.ptr(), string_length);
+	buffer[current_position] = 0;
+
+	return buffer;
 }

--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -68,7 +68,7 @@ String StringBuilder::as_string() const {
 		return "";
 	}
 
-	String buffer = String();
+	String buffer;
 	buffer.resize(string_length + 1);
 
 	int current_position = 0;

--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -70,6 +70,7 @@ String StringBuilder::as_string() const {
 
 	String buffer;
 	buffer.resize(string_length + 1);
+	char32_t *buffer_ptr = buffer.ptrw();
 
 	int current_position = 0;
 
@@ -81,7 +82,7 @@ String StringBuilder::as_string() const {
 			// Godot string
 			const String &s = strings[godot_string_elem];
 
-			memcpy(buffer.ptrw() + current_position, s.ptr(), s.length() * sizeof(char32_t));
+			memcpy(buffer_ptr + current_position, s.ptr(), s.length() * sizeof(char32_t));
 
 			current_position += s.length();
 
@@ -90,7 +91,7 @@ String StringBuilder::as_string() const {
 			const char *s = c_strings[c_string_elem];
 
 			for (int32_t j = 0; j < appended_strings[i]; j++) {
-				buffer[current_position + j] = s[j];
+				buffer_ptr[current_position + j] = s[j];
 			}
 
 			current_position += appended_strings[i];
@@ -99,7 +100,7 @@ String StringBuilder::as_string() const {
 		}
 	}
 
-	buffer[current_position] = 0;
+	buffer_ptr[current_position] = 0;
 
 	return buffer;
 }

--- a/core/string/string_builder.h
+++ b/core/string/string_builder.h
@@ -32,21 +32,24 @@
 #define STRING_BUILDER_H
 
 #include "core/string/ustring.h"
-#include "core/templates/vector.h"
+#include "core/templates/local_vector.h"
 
 class StringBuilder {
 	uint32_t string_length = 0;
 
-	Vector<String> strings;
-	Vector<const char *> c_strings;
+	LocalVector<String> strings;
+	LocalVector<const char *> c_strings;
 
 	// -1 means it's a Godot String
 	// a natural number means C string.
-	Vector<int32_t> appended_strings;
+	LocalVector<int32_t> appended_strings;
+
+	mutable LocalVector<char32_t> buffer_persist;
 
 public:
 	StringBuilder &append(const String &p_string);
 	StringBuilder &append(const char *p_cstring);
+	void clear();
 
 	_FORCE_INLINE_ StringBuilder &operator+(const String &p_string) {
 		return append(p_string);

--- a/core/string/string_builder.h
+++ b/core/string/string_builder.h
@@ -44,8 +44,6 @@ class StringBuilder {
 	// a natural number means C string.
 	LocalVector<int32_t> appended_strings;
 
-	mutable LocalVector<char32_t> buffer_persist;
-
 public:
 	StringBuilder &append(const String &p_string);
 	StringBuilder &append(const char *p_cstring);


### PR DESCRIPTION
split to 2 commit to make review easier.

Make `SceneTreeEditor::_update_node_tooltip()` reuse the string build buffer instead of alloc buffer/tmp string everytime.

1st commit: make `StringBuilder` suitable for multi time use by reusing the buffer in `as_string()` method.

2nd commit: use a static `StringBuilder` for string concat.

performance:

bench with [ManyNodes.zip](https://github.com/user-attachments/files/17247180/ManyNodes.zip), test time to open `ManyNodes.tscn` (100k nodes).

Master branch: (about 9.5s)

![master](https://github.com/user-attachments/assets/42634142-9bc9-44a0-9606-2bc0718fd790)

This PR: (about 9.0s)

![pr](https://github.com/user-attachments/assets/9d553f92-0b97-4eba-bf16-7d212a5b4d76)

This PR without changes applied to `StringBuilder`: (about 9.5s)

![sb](https://github.com/user-attachments/assets/02794e44-01b7-4a14-a15a-d02e2fdbb24e)




