### PR TITLE
Add custom preview environment support

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -39,6 +39,7 @@
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
+#include "editor/editor_properties.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
@@ -6239,6 +6240,8 @@ Dictionary Node3DEditor::get_state() const {
 
 		pd["sun_rotation"] = sun_rotation;
 
+		pd["environ_type_id"] = environ_type->get_selected();
+
 		pd["environ_sky_color"] = environ_sky_color->get_pick_color();
 		pd["environ_ground_color"] = environ_ground_color->get_pick_color();
 		pd["environ_energy"] = environ_energy->get_value();
@@ -6246,8 +6249,10 @@ Dictionary Node3DEditor::get_state() const {
 		pd["environ_tonemap_enabled"] = environ_tonemap_button->is_pressed();
 		pd["environ_ao_enabled"] = environ_ao_button->is_pressed();
 		pd["environ_gi_enabled"] = environ_gi_button->is_pressed();
-		pd["sun_max_distance"] = sun_max_distance->get_value();
 
+		pd["environ_custom_path"] = environ_property_bag->get("environ_custom_path");
+
+		pd["sun_max_distance"] = sun_max_distance->get_value();
 		pd["sun_color"] = sun_color->get_pick_color();
 		pd["sun_energy"] = sun_energy->get_value();
 
@@ -6371,6 +6376,9 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 		Dictionary pd = d["preview_sun_env"];
 		sun_rotation = pd["sun_rotation"];
 
+		environ_type->select((int)pd["environ_type_id"]);
+		preview_environment_type = (int)pd["environ_type_id"];
+
 		environ_sky_color->set_pick_color(pd["environ_sky_color"]);
 		environ_ground_color->set_pick_color(pd["environ_ground_color"]);
 		environ_energy->set_value(pd["environ_energy"]);
@@ -6378,8 +6386,11 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 		environ_tonemap_button->set_pressed(pd["environ_tonemap_enabled"]);
 		environ_ao_button->set_pressed(pd["environ_ao_enabled"]);
 		environ_gi_button->set_pressed(pd["environ_gi_enabled"]);
-		sun_max_distance->set_value(pd["sun_max_distance"]);
 
+		environ_property_bag->set(SNAME("environ_custom_path"), pd["environ_custom_path"]);
+		environ_custom_path->update_property();
+
+		sun_max_distance->set_value(pd["sun_max_distance"]);
 		sun_color->set_pick_color(pd["sun_color"]);
 		sun_energy->set_value(pd["sun_energy"]);
 
@@ -6387,16 +6398,14 @@ void Node3DEditor::set_state(const Dictionary &p_state) {
 		environ_button->set_pressed(pd["environ_enabled"]);
 
 		sun_environ_updating = false;
-
-		_preview_settings_changed();
-		_update_preview_environment();
 	} else {
 		_load_default_preview_settings();
 		sun_button->set_pressed(true);
 		environ_button->set_pressed(true);
-		_preview_settings_changed();
-		_update_preview_environment();
 	}
+
+	_preview_settings_changed();
+	_update_preview_environment();
 }
 
 void Node3DEditor::edit(Node3D *p_spatial) {
@@ -7902,6 +7911,20 @@ void Node3DEditor::_sun_environ_settings_pressed() {
 	sun_environ_popup->grab_focus();
 }
 
+void Node3DEditor::_preview_environ_type_item_selected(int p_index) {
+	preview_environment_type = p_index;
+	_update_preview_environment();
+}
+
+void Node3DEditor::_preview_environ_custom_path_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing) {
+	if (p_property != SNAME("environ_custom_path")) {
+		return;
+	}
+	environ_property_bag->set(SNAME("environ_custom_path"), p_value);
+	_preview_settings_changed();
+	_update_preview_environment();
+}
+
 void Node3DEditor::_add_sun_to_scene(bool p_already_added_environment) {
 	sun_environ_popup->hide();
 
@@ -8498,10 +8521,19 @@ void Node3DEditor::_preview_settings_changed() {
 		sky_material->set_ground_bottom_color(environ_ground_color->get_pick_color());
 		sky_material->set_ground_horizon_color(hz_color);
 
-		environment->set_ssao_enabled(environ_ao_button->is_pressed());
-		environment->set_glow_enabled(environ_glow_button->is_pressed());
-		environment->set_sdfgi_enabled(environ_gi_button->is_pressed());
-		environment->set_tonemapper(environ_tonemap_button->is_pressed() ? Environment::TONE_MAPPER_FILMIC : Environment::TONE_MAPPER_LINEAR);
+		generated_environment->set_ssao_enabled(environ_ao_button->is_pressed());
+		generated_environment->set_glow_enabled(environ_glow_button->is_pressed());
+		generated_environment->set_sdfgi_enabled(environ_gi_button->is_pressed());
+		generated_environment->set_tonemapper(environ_tonemap_button->is_pressed() ? Environment::TONE_MAPPER_FILMIC : Environment::TONE_MAPPER_LINEAR);
+	}
+
+	{ // Custom environment.
+		Variant custom_path = environ_property_bag->get(SNAME("environ_custom_path"));
+		if (custom_path.is_string() && !String(custom_path).is_empty()) {
+			custom_environment = ResourceLoader::load(custom_path);
+		} else {
+			custom_environment = Ref<Environment>(nullptr);
+		}
 	}
 }
 
@@ -8570,6 +8602,24 @@ void Node3DEditor::_update_preview_environment() {
 	bool disable_env = world_env_count > 0 || !environ_button->is_pressed();
 
 	environ_button->set_disabled(world_env_count > 0);
+
+	switch (preview_environment_type) {
+		case PREVIEW_ENVIRONMENT_GENERATED: {
+			environ_generated_vb->show();
+			environ_custom_vb->hide();
+			preview_environment->set_environment(generated_environment);
+		} break;
+
+		case PREVIEW_ENVIRONMENT_CUSTOM: {
+			environ_generated_vb->hide();
+			environ_custom_vb->show();
+			preview_environment->set_environment(custom_environment);
+		} break;
+
+		default: {
+			ERR_FAIL_MSG(vformat("Invalid preview environment type: %s", preview_environment_type));
+		}
+	}
 
 	if (disable_env) {
 		if (preview_environment->get_parent()) {
@@ -9159,37 +9209,58 @@ void fragment() {
 		sc->set_v_size_flags(SIZE_EXPAND_FILL);
 		sun_environ_hb->add_child(sc);
 
+		environ_property_bag = memnew(EnvironmentPropertyBag);
+		environ_property_bag->set(SNAME("environ_custom_path"), "");
+
 		environ_vb = memnew(VBoxContainer);
 		sun_environ_hb->add_child(environ_vb);
-		environ_vb->set_custom_minimum_size(Size2(200 * EDSCALE, 0));
+		environ_vb->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
 		environ_vb->hide();
 
 		environ_title = memnew(Label);
 		environ_title->set_theme_type_variation("HeaderMedium");
-
 		environ_vb->add_child(environ_title);
 		environ_title->set_text(TTR("Preview Environment"));
 		environ_title->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 
+		environ_type_vb = memnew(VBoxContainer);
+		environ_vb->add_child(environ_type_vb);
+		environ_type_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+		environ_type = memnew(OptionButton);
+		environ_type_vb->add_margin_child(TTR("Type"), environ_type);
+		environ_type->set_h_size_flags(SIZE_EXPAND_FILL);
+		environ_type->add_item(TTR("Generated"));
+		environ_type->add_item(TTR("Custom"));
+		environ_type->connect(SNAME("item_selected"), callable_mp(this, &Node3DEditor::_preview_environ_type_item_selected));
+
+		HSeparator *type_separator = memnew(HSeparator);
+		type_separator->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
+		sc->set_h_size_flags(SIZE_EXPAND_FILL);
+		environ_type_vb->add_child(type_separator);
+
+		environ_generated_vb = memnew(VBoxContainer);
+		environ_vb->add_child(environ_generated_vb);
+		environ_generated_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+		environ_generated_vb->set_v_size_flags(SIZE_EXPAND_FILL);
 		environ_sky_color = memnew(ColorPickerButton);
 		environ_sky_color->set_edit_alpha(false);
 		environ_sky_color->connect("color_changed", callable_mp(this, &Node3DEditor::_preview_settings_changed).unbind(1));
 		environ_sky_color->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(environ_sky_color->get_picker()));
-		environ_vb->add_margin_child(TTR("Sky Color"), environ_sky_color);
+		environ_generated_vb->add_margin_child(TTR("Sky Color"), environ_sky_color);
 		environ_ground_color = memnew(ColorPickerButton);
 		environ_ground_color->connect("color_changed", callable_mp(this, &Node3DEditor::_preview_settings_changed).unbind(1));
 		environ_ground_color->set_edit_alpha(false);
 		environ_ground_color->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(environ_ground_color->get_picker()));
-		environ_vb->add_margin_child(TTR("Ground Color"), environ_ground_color);
+		environ_generated_vb->add_margin_child(TTR("Ground Color"), environ_ground_color);
 		environ_energy = memnew(EditorSpinSlider);
 		environ_energy->set_max(8.0);
 		environ_energy->set_min(0);
 		environ_energy->set_step(0.05);
 		environ_energy->connect(SceneStringName(value_changed), callable_mp(this, &Node3DEditor::_preview_settings_changed).unbind(1));
-		environ_vb->add_margin_child(TTR("Sky Energy"), environ_energy);
+		environ_generated_vb->add_margin_child(TTR("Sky Energy"), environ_energy);
+
 		HBoxContainer *fx_vb = memnew(HBoxContainer);
 		fx_vb->set_h_size_flags(SIZE_EXPAND_FILL);
-
 		environ_ao_button = memnew(Button);
 		environ_ao_button->set_text(TTR("AO"));
 		environ_ao_button->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -9214,14 +9285,28 @@ void fragment() {
 		environ_gi_button->set_toggle_mode(true);
 		environ_gi_button->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_preview_settings_changed), CONNECT_DEFERRED);
 		fx_vb->add_child(environ_gi_button);
-		environ_vb->add_margin_child(TTR("Post Process"), fx_vb);
+		environ_generated_vb->add_margin_child(TTR("Post Process"), fx_vb);
 
 		environ_add_to_scene = memnew(Button);
 		environ_add_to_scene->set_text(TTR("Add Environment to Scene"));
 		environ_add_to_scene->set_tooltip_text(TTR("Adds a WorldEnvironment node matching the preview environment settings to the current scene.\nHold Shift while clicking to also add the preview sun to the current scene."));
 		environ_add_to_scene->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_add_environment_to_scene).bind(false));
-		environ_vb->add_spacer();
-		environ_vb->add_child(environ_add_to_scene);
+		environ_generated_vb->add_spacer();
+		environ_generated_vb->add_child(environ_add_to_scene);
+
+		environ_custom_vb = memnew(VBoxContainer);
+		environ_vb->add_child(environ_custom_vb);
+		environ_custom_vb->set_h_size_flags(SIZE_EXPAND_FILL);
+		environ_custom_vb->set_v_size_flags(SIZE_EXPAND_FILL);
+		environ_custom_vb->hide();
+		Vector<String> extensions = Vector<String>({ "*.tres", "*.*" });
+		environ_custom_path = memnew(EditorPropertyPath);
+		environ_custom_vb->add_child(environ_custom_path);
+		environ_custom_path->set_h_size_flags(SIZE_EXPAND_FILL);
+		environ_custom_path->set_label(TTR("Path"));
+		environ_custom_path->set_object_and_property(environ_property_bag, SNAME("environ_custom_path"));
+		environ_custom_path->setup(extensions, false, false);
+		environ_custom_path->connect("property_changed", callable_mp(this, &Node3DEditor::_preview_environ_custom_path_changed));
 
 		environ_state = memnew(Label);
 		sun_environ_hb->add_child(environ_state);
@@ -9233,8 +9318,8 @@ void fragment() {
 		preview_sun->set_shadow(true);
 		preview_sun->set_shadow_mode(DirectionalLight3D::SHADOW_PARALLEL_4_SPLITS);
 		preview_environment = memnew(WorldEnvironment);
-		environment.instantiate();
-		preview_environment->set_environment(environment);
+		generated_environment.instantiate();
+		preview_environment->set_environment(generated_environment);
 		if (GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
 			camera_attributes.instantiate();
 			preview_environment->set_camera_attributes(camera_attributes);
@@ -9243,8 +9328,8 @@ void fragment() {
 		sky.instantiate();
 		sky_material.instantiate();
 		sky->set_material(sky_material);
-		environment->set_sky(sky);
-		environment->set_background(Environment::BG_SKY);
+		generated_environment->set_sky(sky);
+		generated_environment->set_background(Environment::BG_SKY);
 
 		_load_default_preview_settings();
 		_preview_settings_changed();
@@ -9260,6 +9345,26 @@ Node3DEditor::~Node3DEditor() {
 	if (preview_env_dangling && preview_environment) {
 		memdelete(preview_environment);
 	}
+	memdelete(environ_property_bag);
+}
+
+String Node3DEditor::EnvironmentPropertyBag::get_environ_custom_path() const {
+	return environ_custom_path;
+}
+
+void Node3DEditor::EnvironmentPropertyBag::set_environ_custom_path(const String &p_environ_custom_path) {
+	if (p_environ_custom_path == "<null>") {
+		environ_custom_path = "";
+	} else {
+		environ_custom_path = p_environ_custom_path;
+	}
+}
+
+void Node3DEditor::EnvironmentPropertyBag::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_environ_custom_path"), &Node3DEditor::EnvironmentPropertyBag::get_environ_custom_path);
+	ClassDB::bind_method(D_METHOD("set_environ_custom_path", "environ_custom_path"), &Node3DEditor::EnvironmentPropertyBag::set_environ_custom_path);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "environ_custom_path"), "set_environ_custom_path", "get_environ_custom_path");
 }
 
 void Node3DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -32,6 +32,7 @@
 #define NODE_3D_EDITOR_PLUGIN_H
 
 #include "core/math/dynamic_bvh.h"
+#include "editor/editor_properties.h"
 #include "editor/plugins/editor_plugin.h"
 #include "editor/plugins/node_3d_editor_gizmos.h"
 #include "editor/themes/editor_scale.h"
@@ -811,9 +812,9 @@ private:
 	void _snap_selected_nodes_to_floor();
 
 	// Preview Sun and Environment
-
 	uint32_t world_env_count = 0;
 	uint32_t directional_light_count = 0;
+	uint8_t preview_environment_type = 0;
 
 	Button *sun_button = nullptr;
 	Label *sun_state = nullptr;
@@ -837,10 +838,33 @@ private:
 	Ref<Shader> sun_direction_shader;
 	Ref<ShaderMaterial> sun_direction_material;
 
+	class EnvironmentPropertyBag : public Object {
+		GDCLASS(EnvironmentPropertyBag, Object);
+
+		String environ_custom_path;
+
+	protected:
+		static void _bind_methods();
+
+	public:
+		String get_environ_custom_path() const;
+		void set_environ_custom_path(const String &p_environ_custom_path);
+	};
+	EnvironmentPropertyBag *environ_property_bag = nullptr;
+
 	Button *environ_button = nullptr;
 	Label *environ_state = nullptr;
 	Label *environ_title = nullptr;
 	VBoxContainer *environ_vb = nullptr;
+	OptionButton *environ_type = nullptr;
+	enum PreviewEnvironmentType {
+		PREVIEW_ENVIRONMENT_GENERATED,
+		PREVIEW_ENVIRONMENT_CUSTOM,
+		PREVIEW_ENVIRONMENT_MAX,
+	};
+	VBoxContainer *environ_type_vb = nullptr;
+
+	VBoxContainer *environ_generated_vb = nullptr;
 	ColorPickerButton *environ_sky_color = nullptr;
 	ColorPickerButton *environ_ground_color = nullptr;
 	EditorSpinSlider *environ_energy = nullptr;
@@ -850,15 +874,19 @@ private:
 	Button *environ_gi_button = nullptr;
 	Button *environ_add_to_scene = nullptr;
 
+	VBoxContainer *environ_custom_vb = nullptr;
+	EditorPropertyPath *environ_custom_path = nullptr;
+
 	Button *sun_environ_settings = nullptr;
 
 	DirectionalLight3D *preview_sun = nullptr;
 	bool preview_sun_dangling = false;
 	WorldEnvironment *preview_environment = nullptr;
 	bool preview_env_dangling = false;
-	Ref<Environment> environment;
+	Ref<Environment> generated_environment;
 	Ref<CameraAttributesPractical> camera_attributes;
 	Ref<ProceduralSkyMaterial> sky_material;
+	Ref<Environment> custom_environment;
 
 	bool sun_environ_updating = false;
 
@@ -867,6 +895,8 @@ private:
 
 	void _preview_settings_changed();
 	void _sun_environ_settings_pressed();
+	void _preview_environ_type_item_selected(int p_index);
+	void _preview_environ_custom_path_changed(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing);
 
 	void _add_sun_to_scene(bool p_already_added_environment = false);
 	void _add_environment_to_scene(bool p_already_added_sun = false);


### PR DESCRIPTION
> [!NOTE]
> This PR is built upon #97747.

# Custom preview environment support

This PR adds the ability to set custom preview environments to scenes. 

| Generated type | Custom type |
| :---: | :---: |
| <img width="574" alt="Capture d’écran, le 2024-10-03 à 14 02 49" src="https://github.com/user-attachments/assets/0548d8d6-f916-49f7-84fa-1d01537a219b"> | <img width="574" alt="Capture d’écran, le 2024-10-03 à 14 02 55" src="https://github.com/user-attachments/assets/5cc7d44f-1b05-4789-b5e8-b949eedfd7fc"> |

## Preview
[custom_preview_large.webm](https://github.com/user-attachments/assets/fe15766f-a90d-4a59-abd6-c3203d27cead)

## Comparison
| Generated sky preview | With environment disabled | With custom preview environment |
| :---: | :---: | :---: |
| <img width="394" alt="Capture d’écran, le 2024-10-03 à 12 24 16" src="https://github.com/user-attachments/assets/93ebb77a-feba-45fe-bb99-a12420321461"> | <img width="394" alt="Capture d’écran, le 2024-10-03 à 12 24 25" src="https://github.com/user-attachments/assets/cf6414dc-3ea8-4be1-9174-63988c1f4cfe"> <br><br>  _**Note:** it seems that the pure black ambient light is a bug of the Compatibility renderer, as there's ambient light in Forward+, see below_ <br><br> <img width="394" alt="Capture d’écran, le 2024-10-03 à 12 55 48" src="https://github.com/user-attachments/assets/3beb5da1-50b3-4e1f-a002-1b382b480369"> | <img width="394" alt="Capture d’écran, le 2024-10-03 à 12 24 43" src="https://github.com/user-attachments/assets/ea4af9e2-76df-46b3-b38b-be85ef16a659"> |

## Why it's needed
As per @clayjohn's [comment on the state of default environment](https://github.com/godotengine/godot/issues/97731#issuecomment-2388849418), I think we should offer users a way to set a custom environment to the scene without having to resort to add an `WorldEnvironment` node manually in each scene.