### PR TITLE
Editor: Update Freelook Base Speed MAX value to 10000

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -941,7 +941,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/freelook/freelook_navigation_scheme", 0, "Default,Partially Axis-Locked (id Tech),Fully Axis-Locked (Minecraft)")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_sensitivity", 0.25, "0.01,2,0.001")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_inertia", 0.0, "0,1,0.001")
-	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_base_speed", 5.0, "0,10,0.01,or_greater")
+	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/freelook/freelook_base_speed", 5.0, "0,10000,0.01,or_greater")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/freelook/freelook_activation_modifier", 0, "None,Shift,Alt,Meta,Ctrl")
 	_initial_set("editors/3d/freelook/freelook_speed_zoom_link", false);
 


### PR DESCRIPTION
I regularly use godot without access to a mouse and deal with scenes that require large traversal speeds.

The previous maximum value in Editor Settings -> Editors -> 3D -> Freelook was '10'.

As of Godot 4.3, it is possible to hold Right-Click and Scroll up/down to increase and decrease the freelook speed.
Devices without the capability to scroll up/down (touchpad/trackpad) are unable to adjust the speed before this change.

In my practical use case 3000 is sufficient, but I figured it doesn't hurt to match the scroll up/down which has a maximum of 10000 currently.

Note: This bug https://github.com/godotengine/godot/issues/42054 still applies. When testing this PR you need to restart Godot after changing the value within your Editor Settings before the change is applied.