### PR TITLE
Fix undefined `memcpy` in `AudioStreamWAV::get_data()`

### DIFF
--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -584,7 +584,7 @@ void AudioStreamWAV::set_data(const Vector<uint8_t> &p_data) {
 Vector<uint8_t> AudioStreamWAV::get_data() const {
 	Vector<uint8_t> pv;
 
-	if (!data.is_empty()) {
+	if (data_bytes != 0) {
 		pv.resize(data_bytes);
 		memcpy(pv.ptrw(), data.ptr() + DATA_PAD, data_bytes);
 	}


### PR DESCRIPTION
Fixes #97720. In the get_data() function of the AudioStreamWAV, memcpy is called on an undefined pointer due to assuming there is data after some padding bytes (which isn't true for an empty buffer). This was fixed by checking if there is actually any data to copy instead of checking if the buffer (including padding) is not empty (which should never be true).