### PR TITLE
Properly utilize surface information when creating pipelines and vertex arrays in canvas renderer

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2901,22 +2901,12 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 				RS::PrimitiveType primitive = mesh_storage->mesh_surface_get_primitive(surface);
 				ERR_CONTINUE(primitive < 0 || primitive >= RS::PRIMITIVE_MAX);
 
-				uint64_t input_mask = p_shader_data->get_vertex_input_mask(pipeline_key.variant, pipeline_key.ubershader);
-
 				RID vertex_array;
-				RD::VertexFormatID vertex_format = RD::INVALID_FORMAT_ID;
-
-				if (mesh_instance.is_valid()) {
-					mesh_storage->mesh_instance_surface_get_vertex_arrays_and_format(mesh_instance, j, input_mask, false, vertex_array, vertex_format);
-				} else {
-					mesh_storage->mesh_surface_get_vertex_arrays_and_format(surface, input_mask, false, vertex_array, vertex_format);
-				}
-
 				pipeline_key.variant = primitive == RS::PRIMITIVE_POINTS ? SHADER_VARIANT_ATTRIBUTES_POINTS : SHADER_VARIANT_ATTRIBUTES;
 				pipeline_key.render_primitive = _primitive_type_to_render_primitive(primitive);
-				pipeline_key.vertex_format_id = vertex_format;
+				pipeline_key.vertex_format_id = RD::INVALID_FORMAT_ID;
 
-				pipeline = _get_pipeline_specialization_or_ubershader(p_shader_data, pipeline_key, push_constant);
+				pipeline = _get_pipeline_specialization_or_ubershader(p_shader_data, pipeline_key, push_constant, mesh_instance, surface, j, &vertex_array);
 				RD::get_singleton()->draw_list_bind_render_pipeline(p_draw_list, pipeline);
 
 				push_constant.base_instance_index = p_batch->start;

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -1147,11 +1147,11 @@ RD::VertexFormatID MeshStorage::_mesh_surface_generate_vertex_format(uint64_t p_
 	uint32_t normal_tangent_stride = 0;
 	uint32_t attribute_stride = 0;
 	uint32_t skin_stride = 0;
-	RD::VertexAttribute vd;
 
 	r_position_stride = 0;
 
 	for (int i = 0; i < RS::ARRAY_INDEX; i++) {
+		RD::VertexAttribute vd;
 		vd.location = i;
 
 		if (!(p_surface_format & (1ULL << i))) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/97793

The deleted code was unnecessary as it should be calculated within `_get_pipeline_specialization_or_ubershader()`. BUT `_get_pipeline_specialization_or_ubershader()` needs everything to be passed in, which was missing.

Finally, the VertexAttribute variable needs to be reset while inside the loop otherwise variables leak between attributes. This didn't impact the 3D renderers because they disable any unused attributes.

CC @YeldhamDev @stuartcarnie @DarioSamo 