### PR TITLE
Add new test cases for `Timer` autostart and paused behavior

### DIFF
--- a/tests/scene/test_timer.h
+++ b/tests/scene/test_timer.h
@@ -212,6 +212,46 @@ TEST_CASE("[SceneTree][Timer] Check Timer timeout signal") {
 	memdelete(test_timer);
 }
 
+// Test case for timer autostart feature.
+// Ensures that when autostart is enabled, the timer starts automatically when added to scene.
+TEST_CASE("[SceneTree][Timer] Autostart behavior") {
+    Timer *test_timer = memnew(Timer);
+    test_timer->set_autostart(true);
+
+    // Adding the timer to the scene should trigger autostart
+    SceneTree::get_singleton()->get_root()->add_child(test_timer);
+
+    // Timer should be running immediately
+    CHECK_FALSE(test_timer->is_stopped());
+    CHECK(test_timer->get_time_left() > 0.0);
+
+    memdelete(test_timer);
+}
+
+//Test case for Paused Timer Behavior.
+// Ensures that when  a Timer is paused, it doesn't process time, and the time left remains unchanged until resumed. 
+TEST_CASE("[SceneTree][Timer] Paused Timer doesn't process") {
+    Timer *test_timer = memnew(Timer);
+    SceneTree::get_singleton()->get_root()->add_child(test_timer);
+
+    // Start the timer and then pause it
+    test_timer->set_wait_time(2.0);
+    test_timer->start();
+    test_timer->set_paused(true);
+
+    // Simulate passing time
+    SceneTree::get_singleton()->process(1.0);
+
+    // Check that the time left has not decreased due to the paused state
+    CHECK(Math::is_equal_approx(test_timer->get_time_left(), 2.0));
+
+    test_timer->set_paused(false);
+    SceneTree::get_singleton()->process(1.0);
+    CHECK(Math::is_equal_approx(test_timer->get_time_left(), 1.0));
+
+    memdelete(test_timer);
+}
+
 } // namespace TestTimer
 
 #endif // TEST_TIMER_H


### PR DESCRIPTION
This pull request adds new unit tests for the `Timer` class to help improve test coverage as part of issue #43440. The tests cover the following scenarios:

- **Autostart behavior**: Ensures that when the `autostart` property is enabled, the timer starts automatically when added to the scene.
- **Paused timer behavior**: Confirms that when a timer is paused, it doesn't process time and that the remaining time is preserved correctly until the timer is resumed.

Link to pull request issue: https://github.com/godotengine/godot/issues/43440

Thanks! 
