### PR TITLE
Fix `AudioStreamPlayer.get_playback_position()` always returning `0` when using `AudioStreamInteractive`

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -1018,6 +1018,10 @@ int AudioStreamPlaybackInteractive::get_loop_count() const {
 }
 
 double AudioStreamPlaybackInteractive::get_playback_position() const {
+	if (playback_current != -1) {
+		const State &current_state = states[playback_current];
+		return current_state.playback->get_playback_position();
+	}
 	return 0.0;
 }
 


### PR DESCRIPTION
Fixes the problem mentioned in #97791. `AudioStreamPlayer.get_playback_position()` now returns the playback position of the current stream, or 0 if there is no current stream.

<i>Bugsquad edit:</i>
- Fix #97791