### PR TITLE
Windows - display every log message in Visual Studio Output window

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -179,27 +179,8 @@ void OS_Windows::initialize_debugging() {
 	SetConsoleCtrlHandler(HandlerRoutine, TRUE);
 }
 
-#ifdef WINDOWS_DEBUG_OUTPUT_ENABLED
-static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type) {
-	String err_str;
-	if (p_errorexp && p_errorexp[0]) {
-		err_str = String::utf8(p_errorexp) + "\n";
-	} else {
-		err_str = String::utf8(p_file) + ":" + itos(p_line) + " - " + String::utf8(p_error) + "\n";
-	}
-
-	OutputDebugStringW((LPCWSTR)err_str.utf16().ptr());
-}
-#endif
-
 void OS_Windows::initialize() {
 	crash_handler.initialize();
-
-#ifdef WINDOWS_DEBUG_OUTPUT_ENABLED
-	error_handlers.errfunc = _error_handler;
-	error_handlers.userdata = this;
-	add_error_handler(&error_handlers);
-#endif
 
 	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_RESOURCES);
 	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_USERDATA);
@@ -304,10 +285,6 @@ void OS_Windows::finalize_core() {
 
 	memdelete(process_map);
 	NetSocketPosix::cleanup();
-
-#ifdef WINDOWS_DEBUG_OUTPUT_ENABLED
-	remove_error_handler(&error_handlers);
-#endif
 }
 
 Error OS_Windows::get_entropy(uint8_t *r_buffer, int p_bytes) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -60,11 +60,6 @@
 #include <windows.h>
 #include <windowsx.h>
 
-#ifdef DEBUG_ENABLED
-// forward error messages to OutputDebugString
-#define WINDOWS_DEBUG_OUTPUT_ENABLED
-#endif
-
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x4
 #endif
@@ -112,10 +107,6 @@ class OS_Windows : public OS {
 #endif
 
 	CrashHandler crash_handler;
-
-#ifdef WINDOWS_DEBUG_OUTPUT_ENABLED
-	ErrorHandlerList error_handlers;
-#endif
 
 	HWND main_window;
 

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -69,6 +69,8 @@ void WindowsTerminalLogger::logv(const char *p_format, va_list p_list, bool p_er
 
 #ifdef DEBUG_ENABLED
 	FlushFileBuffers(h);
+
+	OutputDebugStringA(cstr_buf.ptr());
 #endif
 }
 


### PR DESCRIPTION
Moved `OutputDebugString` function call from the error handler to Windows terminal logger.

In practice the log from the engine (not only the errors and warnings) should be visible in the Visual Studio Output window when debugging the executable built as template_debug or editor.
The old error handler was removed because it would duplicate the error message.

It should fix https://github.com/godotengine/godot-proposals/issues/8648 but I haven't test it myself.