### PR TITLE
Fix quick open background panel style

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -709,7 +709,7 @@ void QuickOpenResultContainer::_notification(int p_what) {
 			file_details_path->add_theme_color_override(SceneStringName(font_color), text_color);
 			no_results_label->add_theme_color_override(SceneStringName(font_color), text_color);
 
-			panel_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("QuickOpenBackgroundPanel"), EditorStringName(EditorStyles)));
+			panel_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
 
 			if (content_display_mode == QuickOpenDisplayMode::LIST) {
 				display_mode_toggle->set_icon(get_editor_theme_icon(SNAME("FileThumbnail")));


### PR DESCRIPTION
Quick open result container tries to set the container stylebox override to `QuickOpenBackgroundPanel` which isn't defined in the editor theme. ~This adds the missing stylebox to make quick open look consistent with all other lists in editor~. Using Tree panel stylebox instead

| Master | PR |
|--------|--------|
|![master](https://github.com/user-attachments/assets/0f0feab3-8944-4ca3-b281-20aae2ee8c6f) |![pr](https://github.com/user-attachments/assets/778d3950-f4ae-4d42-9855-9affe60ba00c) |
