### PR TITLE
Documentation: Add tip to use more specific return type for `_iter_get()`

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -198,6 +198,7 @@
 			<param index="0" name="iter" type="Variant" />
 			<description>
 				Returns the current iterable value. [param iter] stores the iteration state, but unlike [method _iter_init] and [method _iter_next] the state is supposed to be read-only, so there is no [Array] wrapper.
+				[b]Tip:[/b] In GDScript, you can use a subtype of [Variant] as the return type for [method _iter_get]. The specified type will be used to set the type of the iterator variable in [code]for[/code] loops, enhancing type safety.
 			</description>
 		</method>
 		<method name="_iter_init" qualifiers="virtual">


### PR DESCRIPTION
* It was implemented in #71279.

Code:

https://github.com/godotengine/godot/blob/3576e840c7c699dbd21c9c02ec652dafc48e764c/modules/gdscript/gdscript_analyzer.cpp#L2217-L2229

Test:

[`modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_iterator.gd`](https://github.com/godotengine/godot/blob/master/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_iterator.gd)
[`modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_iterator.out`](https://github.com/godotengine/godot/blob/master/modules/gdscript/tests/scripts/analyzer/errors/for_loop_on_hard_iterator.out)

Example:

* https://github.com/godotengine/godot-proposals/issues/10902#issuecomment-2394348105