### PR TITLE
Add loongarch64 support for Linux/*BSD

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -248,6 +248,9 @@ String Engine::get_architecture_name() const {
 	return "ppc";
 #endif
 
+#elif defined(__loongarch64)
+	return "loongarch64";
+
 #elif defined(__wasm__)
 #if defined(__wasm64__)
 	return "wasm64";

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -518,6 +518,10 @@ bool OS::has_feature(const String &p_feature) {
 	if (p_feature == "wasm") {
 		return true;
 	}
+#elif defined(__loongarch64)
+	if (p_feature == "loongarch64") {
+		return true;
+	}
 #endif
 
 #if defined(IOS_SIMULATOR)

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -235,6 +235,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["linuxbsd"] = "Linux/*BSD";
 	capitalize_string_remaps["lod"] = "LOD";
 	capitalize_string_remaps["lods"] = "LODs";
+	capitalize_string_remaps["loongarch64"] = "loongarch64";
 	capitalize_string_remaps["lowpass"] = "Low-pass";
 	capitalize_string_remaps["macos"] = "macOS";
 	capitalize_string_remaps["mb"] = "(MB)"; // Unit.

--- a/editor/plugins/gdextension_export_plugin.h
+++ b/editor/plugins/gdextension_export_plugin.h
@@ -73,6 +73,7 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 	all_archs.insert("ppc32");
 	all_archs.insert("ppc64");
 	all_archs.insert("wasm32");
+	all_archs.insert("loongarch64");
 	all_archs.insert("universal");
 
 	HashSet<String> archs;

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -73,7 +73,7 @@ def get_flags():
 
 def configure(env: "SConsEnvironment"):
     # Validate arch.
-    supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64"]
+    supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "loongarch64"]
     validate_arch(env["arch"], get_name(), supported_arches)
 
     ## Build type

--- a/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
+++ b/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
@@ -11,7 +11,7 @@
 	<members>
 		<member name="binary_format/architecture" type="String" setter="" getter="">
 			Application executable architecture.
-			Supported architectures: [code]x86_32[/code], [code]x86_64[/code], [code]arm64[/code], [code]arm32[/code], [code]rv64[/code], [code]ppc64[/code], and [code]ppc32[/code].
+			Supported architectures: [code]x86_32[/code], [code]x86_64[/code], [code]arm64[/code], [code]arm32[/code], [code]rv64[/code], [code]ppc64[/code], [code]ppc32[/code], and [code]loongarch64[/code].
 			Official export templates include [code]x86_32[/code] and [code]x86_64[/code] binaries only.
 		</member>
 		<member name="binary_format/embed_pck" type="bool" setter="" getter="">

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -180,7 +180,7 @@ bool EditorExportPlatformLinuxBSD::get_export_option_visibility(const EditorExpo
 void EditorExportPlatformLinuxBSD::get_export_options(List<ExportOption> *r_options) const {
 	EditorExportPlatformPC::get_export_options(r_options);
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32,arm64,arm32,rv64,ppc64,ppc32"), "x86_64"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "binary_format/architecture", PROPERTY_HINT_ENUM, "x86_64,x86_32,arm64,arm32,rv64,ppc64,ppc32,loongarch64"), "x86_64"));
 
 	String run_script = "#!/usr/bin/env bash\n"
 						"export DISPLAY=:0\n"
@@ -282,6 +282,8 @@ String EditorExportPlatformLinuxBSD::_get_exe_arch(const String &p_path) const {
 			return "arm64";
 		case 0x00f3:
 			return "rv64";
+		case 0x0102:
+			return "loongarch64";
 		default:
 			return "unknown";
 	}

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -184,7 +184,7 @@ String OS_LinuxBSD::get_processor_name() const {
 
 	while (!f->eof_reached()) {
 		const String line = f->get_line();
-		if (line.contains("model name")) {
+		if (line.to_lower().contains("model name")) {
 			return line.split(":")[1].strip_edges();
 		}
 	}

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -16,7 +16,7 @@ compatibility_platform_aliases = {
 }
 
 # CPU architecture options.
-architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32"]
+architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32", "loongarch64"]
 architecture_aliases = {
     "x86": "x86_32",
     "x64": "x86_64",
@@ -31,6 +31,7 @@ architecture_aliases = {
     "ppcle": "ppc32",
     "ppc": "ppc32",
     "ppc64le": "ppc64",
+    "loong64": "loongarch64",
 }
 
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This PR add support for 64 bit [LoongArch](https://en.wikipedia.org/wiki/Loongson#Loongson_3_LoongArch_processors) CPU architecture.

Tested on Loongson 3A6000 with AMD RX590.