### PR TITLE
Allow seconds snapping to use minimum intervals of 0.0001 once more

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -63,7 +63,7 @@
 
 constexpr double FPS_DECIMAL = 1.0;
 constexpr double SECOND_DECIMAL = 0.0001;
-constexpr double FACTOR = 0.0625;
+constexpr double FPS_STEP_FRACTION = 0.0625;
 
 void AnimationTrackKeyEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_obj"), &AnimationTrackKeyEdit::_update_obj);
@@ -5017,6 +5017,8 @@ void AnimationTrackEditor::_snap_mode_changed(int p_mode) {
 		key_edit->set_use_fps(use_fps);
 	}
 	marker_edit->set_use_fps(use_fps);
+	// To ensure that the conversion results are consistent between serialization and load, the value is snapped with 0.0625 to be a rational number when FPS mode is used.
+	step->set_step(use_fps ? FPS_STEP_FRACTION : SECOND_DECIMAL);
 	_update_step_spinbox();
 }
 
@@ -5144,12 +5146,12 @@ void AnimationTrackEditor::_update_step(double p_new_step) {
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Change Animation Step"));
-	// To ensure that the conversion results are consistent between serialization and load, the value is snapped with 0.0625 to be a rational number.
-	// step_value must also be less than or equal to 1000 to ensure that no error accumulates due to interactions with retrieving values from inner range.
-	double step_value = MIN(1000.0, Math::snapped(p_new_step, FACTOR));
+	double step_value = p_new_step;
 	if (timeline->is_using_fps()) {
 		if (step_value != 0.0) {
-			step_value = 1.0 / step_value;
+			// step_value must also be less than or equal to 1000 to ensure that no error accumulates due to interactions with retrieving values from inner range.
+			step_value = 1.0 / MIN(1000.0, p_new_step);
+			;
 		}
 		timeline->queue_redraw();
 	}


### PR DESCRIPTION
closes #97832, also clears up some of the naming conventions used. Confirmed that entering values when `seconds` is selected where the fractional part is less than 0.0001 floors, while fractional values greater than that are retained. Doesn't revert previous behaviors for FPS, which still clamp to the nearest 1/16.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
