### PR TITLE
SceneImportSettings update_timer should be a oneshot.

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1917,6 +1917,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 
 	update_view_timer = memnew(Timer);
 	update_view_timer->set_wait_time(0.2);
+	update_view_timer->set_one_shot(true);
 	update_view_timer->connect("timeout", callable_mp(this, &SceneImportSettingsDialog::_update_view_gizmos));
 	add_child(update_view_timer);
 }


### PR DESCRIPTION
SceneImportSettings uses a timer to debounce updates, but the timer isn't a one shot.  This means after the first update is scheduled, the dialog keeps re-rendering even though no update has been requested.
