### PR TITLE
EditorInterface: Add `get_open_scene_roots` to retrieve all opened scenes root nodes

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -156,10 +156,16 @@
 				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
+		<method name="get_open_scene_roots" qualifiers="const">
+			<return type="Node[]" />
+			<description>
+				Returns an array with references to the root nodes of the currently opened scenes.
+			</description>
+		</method>
 		<method name="get_open_scenes" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>
-				Returns an [Array] with the file paths of the currently opened scenes.
+				Returns an array with the file paths of the currently opened scenes.
 			</description>
 		</method>
 		<method name="get_playing_scene" qualifiers="const">

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -667,12 +667,24 @@ PackedStringArray EditorInterface::get_open_scenes() const {
 	PackedStringArray ret;
 	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
 
-	int scns_amount = scenes.size();
-	for (int idx_scn = 0; idx_scn < scns_amount; idx_scn++) {
-		if (scenes[idx_scn].root == nullptr) {
+	for (EditorData::EditedScene &edited_scene : scenes) {
+		if (edited_scene.root == nullptr) {
 			continue;
 		}
-		ret.push_back(scenes[idx_scn].root->get_scene_file_path());
+		ret.push_back(edited_scene.root->get_scene_file_path());
+	}
+	return ret;
+}
+
+TypedArray<Node> EditorInterface::get_open_scene_roots() const {
+	TypedArray<Node> ret;
+	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
+
+	for (EditorData::EditedScene &edited_scene : scenes) {
+		if (edited_scene.root == nullptr) {
+			continue;
+		}
+		ret.push_back(edited_scene.root);
 	}
 	return ret;
 }
@@ -830,6 +842,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
 
 	ClassDB::bind_method(D_METHOD("get_open_scenes"), &EditorInterface::get_open_scenes);
+	ClassDB::bind_method(D_METHOD("get_open_scene_roots"), &EditorInterface::get_open_scene_roots);
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root);
 
 	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -171,6 +171,7 @@ public:
 	void reload_scene_from_path(const String &scene_path);
 
 	PackedStringArray get_open_scenes() const;
+	TypedArray<Node> get_open_scene_roots() const;
 	Node *get_edited_scene_root() const;
 
 	Error save_scene();


### PR DESCRIPTION
Added a single API `get_open_scenes_roots ` to `EditorInterface` to retrieve all opened scenes root nodes instead of scene file paths.

- Changes applied to **editor_interface.h** and **editor_interface.cpp**
- Documentation added to **EditorInterface.xml**

Credit : [TheAenema](https://github.com/TheAenema)
*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/10895