### PR TITLE
Reduce allocations when solving path in `AStarGrid2D`

### DIFF
--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -503,6 +503,7 @@ bool AStarGrid2D::_solve(Point *p_begin_point, Point *p_end_point, bool p_allow_
 
 	LocalVector<Point *> open_list;
 	SortArray<Point *, SortPoints> sorter;
+	LocalVector<Point *> nbors;
 
 	p_begin_point->g_score = 0;
 	p_begin_point->f_score = _estimate_cost(p_begin_point->id, p_end_point->id);
@@ -528,7 +529,7 @@ bool AStarGrid2D::_solve(Point *p_begin_point, Point *p_end_point, bool p_allow_
 		open_list.remove_at(open_list.size() - 1);
 		p->closed_pass = pass; // Mark the point as closed.
 
-		LocalVector<Point *> nbors;
+		nbors.clear();
 		_get_nbors(p, nbors);
 
 		for (Point *e : nbors) {


### PR DESCRIPTION
Improves path solving performance in `AStarGrid2D`.

| Test | Before | After |
|--|--|--|
| astar_grid_500_times_500_points | 5176ms | 2647ms |

Benchmark: [astar_grid_2d.gd.zip](https://github.com/user-attachments/files/17265994/astar_grid_2d.gd.zip)
