### PR TITLE
Add `load_from_file()` to `AudioStreamMP3`

### DIFF
--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -34,6 +34,8 @@
 
 #include "audio_stream_mp3.h"
 
+#include "resource_importer_mp3.h"
+
 #include "core/io/file_access.h"
 
 int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
@@ -314,7 +316,13 @@ Ref<AudioSample> AudioStreamMP3::generate_sample() const {
 	return sample;
 }
 
+Ref<AudioStreamMP3> AudioStreamMP3::load_from_file(const String &p_path) {
+	return ResourceImporterMP3::import_mp3(p_path);
+}
+
 void AudioStreamMP3::_bind_methods() {
+	ClassDB::bind_static_method("AudioStreamMP3", D_METHOD("load_from_file", "path"), &AudioStreamMP3::load_from_file);
+
 	ClassDB::bind_method(D_METHOD("set_data", "data"), &AudioStreamMP3::set_data);
 	ClassDB::bind_method(D_METHOD("get_data"), &AudioStreamMP3::get_data);
 

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -114,6 +114,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	static Ref<AudioStreamMP3> load_from_file(const String &p_path);
 	void set_loop(bool p_enable);
 	virtual bool has_loop() const override;
 

--- a/modules/minimp3/doc_classes/AudioStreamMP3.xml
+++ b/modules/minimp3/doc_classes/AudioStreamMP3.xml
@@ -8,6 +8,15 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="load_from_file" qualifiers="static">
+			<return type="AudioStreamMP3" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Creates a new [AudioStreamMP3] instance from the given file path. The file must be in the MP3 format.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="bar_beats" type="int" setter="set_bar_beats" getter="get_bar_beats" default="4">
 		</member>


### PR DESCRIPTION
I noticed in the [docs](https://docs.godotengine.org/en/stable/tutorials/io/runtime_file_loading_and_saving.html#audio-video-files) while working on my own project that `AudioStreamMP3` was missing `load_from_file()`, which ogg already has.
This PR adds that missing function so that it matches ogg.

I wanted to add it to WAV as well, but I can do it in a later PR.
