### PR TITLE
Remove PrefersNonDefaultGPU from linux desktop file

### DIFF
--- a/misc/dist/linux/org.godotengine.Godot.desktop
+++ b/misc/dist/linux/org.godotengine.Godot.desktop
@@ -17,7 +17,6 @@ Comment[zh_CN]=多平台 2D 和 3D 游戏引擎，带有功能丰富的编辑器
 Exec=godot %f
 Icon=godot
 Terminal=false
-PrefersNonDefaultGPU=true
 Type=Application
 MimeType=application/x-godot-project;
 Categories=Development;IDE;


### PR DESCRIPTION
very small fix, PrefersNonDefaultGPU is currently very broken, see https://github.com/ValveSoftware/steam-for-linux/issues/9940

a fix has been proposed to switcheroo-control however its essentially become unmaintained and until then the flag results in undesired behavior.