### PR TITLE
Update ViewportTexture path relative to its local scene instead of the Viewport owner

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -489,18 +489,14 @@ int Viewport::_sub_window_find(Window *p_window) const {
 }
 
 void Viewport::_update_viewport_path() {
-	if (viewport_textures.is_empty()) {
+	if (!is_inside_tree()) {
 		return;
 	}
 
-	Node *scene_root = get_scene_file_path().is_empty() ? get_owner() : this;
-	if (!scene_root && is_inside_tree()) {
-		scene_root = get_tree()->get_edited_scene_root();
-	}
-	if (scene_root && (scene_root == this || scene_root->is_ancestor_of(this))) {
-		NodePath path_in_scene = scene_root->get_path_to(this);
-		for (ViewportTexture *E : viewport_textures) {
-			E->path = path_in_scene;
+	for (ViewportTexture *E : viewport_textures) {
+		Node *loc_scene = E->get_local_scene();
+		if (loc_scene) {
+			E->path = loc_scene->get_path_to(this);
 		}
 	}
 }


### PR DESCRIPTION
Currently, `ViewportTexture::_setup_local_to_scene` retrieves the `Viewport` a `ViewportTexture` points to like this:
```C++
Node *vpn = p_loc_scene->get_node_or_null(path);
```
That is, the path stored within the `ViewportTexture` is assumed to be relative to its local scene.

But in the function `Viewport::_update_viewport_path`, which is used to maintain a valid path, the path is set relative to the owner of the Viewport. The local scene of the `ViewportTexture` and the owner of the `Viewport` don't have to be the same. This is for example the case if the owner of the `Viewport` is an editable instance (`editable_children` enabled).

This PR fixes the behaviour of `Viewport::_update_viewport_path` and updates the path to be relative to the local scene. Please note, that while the behaviour is correct now, `Viewport::_update_viewport_path` is still not always called when it needs to be. One example is when you instantiate a scene that contains a `ViewportTexture` and enable `editable_children` on it. The path should be updated now but it isn't. It will be wrong until you either set it manually again or cause `Viewport::_update_viewport_path` to be called.

This fix is crucial because if you suffer from this issue, the `ViewportTexture` path will be set invalid whenever you open the scene that contains the `ViewportTexture` and you have to reassign the `ViewportTexture` path whenever that happens...

Partly fixes:
https://github.com/godotengine/godot/issues/96816
https://github.com/godotengine/godot/issues/87809
https://github.com/godotengine/godot/issues/74331 (This is a very generic issue. `ViewportTexture` has so many issues, that it is difficult to know which one this is about)
https://github.com/godotengine/godot/issues/84607
Fixes https://github.com/godotengine/godot/issues/98117

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
