### PR TITLE
Update explanation of `bool match(expr: String)` and `bool matchn(expr: String)`

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -616,14 +616,14 @@
 			<return type="bool" />
 			<param index="0" name="expr" type="String" />
 			<description>
-				Does a simple expression match (also called "glob" or "globbing"), where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). An empty string or empty expression always evaluates to [code]false[/code].
+				Does a simple expression match (also called "glob" or "globbing"), where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). Returns [code]true[/code] if the string matches the pattern [code]expr[/code]. An empty string or empty expression always evaluates to [code]false[/code].
 			</description>
 		</method>
 		<method name="matchn" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="expr" type="String" />
 			<description>
-				Does a simple [b]case-insensitive[/b] expression match, where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). An empty string or empty expression always evaluates to [code]false[/code].
+				Does a simple [b]case-insensitive[/b] expression match, where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). Returns [code]true[/code] if the string matches the pattern [code]expr[/code]. An empty string or empty expression always evaluates to [code]false[/code].
 			</description>
 		</method>
 		<method name="md5_buffer" qualifiers="const">

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -616,14 +616,14 @@
 			<return type="bool" />
 			<param index="0" name="expr" type="String" />
 			<description>
-				Does a simple expression match (also called "glob" or "globbing"), where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). Returns [code]true[/code] if the string matches the pattern [code]expr[/code]. An empty string or empty expression always evaluates to [code]false[/code].
+				Does a simple expression match (also called "glob" or "globbing"), where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). Returns [code]true[/code] if the string matches the pattern [code skip-lint]expr[/code]. An empty string or empty expression always evaluates to [code]false[/code].
 			</description>
 		</method>
 		<method name="matchn" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="expr" type="String" />
 			<description>
-				Does a simple [b]case-insensitive[/b] expression match, where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). Returns [code]true[/code] if the string matches the pattern [code]expr[/code]. An empty string or empty expression always evaluates to [code]false[/code].
+				Does a simple [b]case-insensitive[/b] expression match, where [code]*[/code] matches zero or more arbitrary characters and [code]?[/code] matches any single character except a period ([code].[/code]). Returns [code]true[/code] if the string matches the pattern [code skip-lint]expr[/code]. An empty string or empty expression always evaluates to [code]false[/code].
 			</description>
 		</method>
 		<method name="md5_buffer" qualifiers="const">


### PR DESCRIPTION
This commit fixes https://github.com/godotengine/godot-docs/issues/10050

Added explanation to indicate `expr` argument is a wildcard pattern.