### PR TITLE
Disable `cursor_metric_edit` initially in VisualProfiler

### DIFF
--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -69,6 +69,7 @@ void EditorVisualProfiler::add_frame_metric(const Metric &p_metric) {
 
 	updating_frame = true;
 	clear_button->set_disabled(false);
+	cursor_metric_edit->set_editable(true);
 	cursor_metric_edit->set_max(frame_metrics[last_metric].frame_number);
 	cursor_metric_edit->set_min(MAX(int64_t(frame_metrics[last_metric].frame_number) - frame_metrics.size(), 0));
 
@@ -106,6 +107,7 @@ void EditorVisualProfiler::clear() {
 	graph_limit = 1000.0f / CLAMP(int(EDITOR_GET("debugger/profiler_target_fps")), 1, 1000);
 
 	updating_frame = true;
+	cursor_metric_edit->set_editable(false);
 	cursor_metric_edit->set_min(0);
 	cursor_metric_edit->set_max(0);
 	cursor_metric_edit->set_value(0);
@@ -782,6 +784,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
+	cursor_metric_edit->set_editable(false);
 	hb->add_child(cursor_metric_edit);
 	cursor_metric_edit->connect(SceneStringName(value_changed), callable_mp(this, &EditorVisualProfiler::_cursor_metric_changed));
 


### PR DESCRIPTION
Disables cursor_metric_edit initially in Visual Profiler same as in Profiler

![Screenshot from 2024-10-06 09-38-09](https://github.com/user-attachments/assets/d8d5049f-0c8a-4d07-b3af-d193f806b0d8)
