### PR TITLE
Fix editor glitch when changing tabs with invisible TileMapLayer

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -4094,7 +4094,7 @@ void TileMapLayerEditor::_tab_changed(int p_tab_id) {
 
 	TileMapLayer *tile_map_layer = _get_edited_layer();
 	if (tile_map_layer) {
-		if (tile_map_layer->get_tile_set().is_valid()) {
+		if (tile_map_layer->get_tile_set().is_valid() && tile_map_layer->is_enabled() && tile_map_layer->is_visible_in_tree()) {
 			tabs_data[tabs_bar->get_current_tab()].panel->show();
 		}
 	}


### PR DESCRIPTION
Fixes #97851
When switching tabs it won't display the tab's contents anymore and keep the bottom panel as it was with the "invisible TileMapLayer" message.