### PR TITLE
Create and add icons to Scripts Editor scripts panel context menu items

### DIFF
--- a/editor/icons/SidePanel.svg
+++ b/editor/icons/SidePanel.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="m2 0h12c1.097 0 2 .903 2 2v12c0 1.097-.903 2-2 2h-12c-1.097 0-2-.903-2-2v-12c0-1.097.903-2 2-2zm0 2v12h12v-12zm4 1v10h-3v-10z"/></svg>

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3355,10 +3355,10 @@ void ScriptEditor::_make_script_list_context_menu() {
 
 	ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(selected));
 	if (se) {
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/save"), FILE_SAVE);
+		context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Save")), ED_GET_SHORTCUT("script_editor/save"), FILE_SAVE);
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/save_as"), FILE_SAVE_AS);
 	}
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_file"), FILE_CLOSE);
+	context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Close")), ED_GET_SHORTCUT("script_editor/close_file"), FILE_CLOSE);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_all"), CLOSE_ALL);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_other_tabs"), CLOSE_OTHER_TABS);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/close_docs"), CLOSE_DOCS);
@@ -3368,19 +3368,19 @@ void ScriptEditor::_make_script_list_context_menu() {
 		if (scr.is_valid()) {
 			if (!scr.is_null() && scr->is_tool()) {
 				context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/reload_script_soft"), FILE_TOOL_RELOAD_SOFT);
-				context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/run_file"), FILE_RUN);
+				context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Play")), ED_GET_SHORTCUT("script_editor/run_file"), FILE_RUN);
 				context_menu->add_separator();
 			}
 		}
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/copy_path"), FILE_COPY_PATH);
-		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/show_in_file_system"), SHOW_IN_FILE_SYSTEM);
+		context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("ShowInFileSystem")), ED_GET_SHORTCUT("script_editor/show_in_file_system"), SHOW_IN_FILE_SYSTEM);
 		context_menu->add_separator();
 	}
 
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_move_up"), WINDOW_MOVE_UP);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_move_down"), WINDOW_MOVE_DOWN);
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/window_sort"), WINDOW_SORT);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/toggle_scripts_panel"), TOGGLE_SCRIPTS_PANEL);
+	context_menu->add_icon_shortcut(get_editor_theme_icon(SNAME("SidePanel")), ED_GET_SHORTCUT("script_editor/toggle_scripts_panel"), TOGGLE_SCRIPTS_PANEL);
 
 	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_ALL), tab_container->get_tab_count() <= 0);
 	context_menu->set_item_disabled(context_menu->get_item_index(CLOSE_OTHER_TABS), tab_container->get_tab_count() <= 1);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Rework of #97306.
I've split up the work into individual PRs for a simpler merging process.

For accessibility purposes and consistency with the Scene dock's node context menu, this PR adds icons to the Scripts Editor's scripts panel context menu:
<img width="193" alt="scripts_context_menu" src="https://github.com/user-attachments/assets/edfe35e4-1902-40d5-a14b-c3df66984798">


Some menu items do not have existing appropriate icons, so this PR also adds several new icons:
- `SaveAs.svg` ![SaveAs](https://github.com/user-attachments/assets/aa0c1a99-cc9b-4354-8de5-e1798c481162)
- `SidePanel.svg` ![SidePanel](https://github.com/user-attachments/assets/333871d9-bad5-479d-b34b-b3e7ca3ea1fc)
- `HelpClose.svg` ![HelpClose](https://github.com/user-attachments/assets/6c7f3e80-6a6a-49d3-ba33-b28418c3f9ee)
- `ListCloseAll.svg` ![ListCloseAll](https://github.com/user-attachments/assets/9060e54c-fc02-49f1-8591-9c9ca04c4fdc)
- `ListCloseOthers.svg` ![ListCloseOthers](https://github.com/user-attachments/assets/9466b14a-86c3-4455-90d8-1c4a56f55d30)

I've tried following the documentation's guidelines on creating new icons, but please do feel free to suggest improvements!