### PR TITLE
Fix for Tilemap rendering incorrectly when positioned exactly on .5 and other texture issues

### DIFF
--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -216,10 +216,10 @@ void main() {
 
 	if (canvas_data.use_pixel_snap) {
 		vertex = floor(vertex + 0.5);
-		// precision issue on some hardware creates artifacts within texture
-		// offset uv by a small amount to avoid
-		uv += 1e-5;
 	}
+	// precision issue on some hardware creates artifacts within texture
+	// offset uv by a small amount to avoid
+	uv += 1e-5;
 
 	vertex_interp = vertex;
 	uv_interp = uv;


### PR DESCRIPTION
Fixes: #76517 and many others including ones detailed in the comments of it including issues outside of Tilemaps/Tilesets like Sprite issues

More sorting will likely be required to find which issues get solved by this though.

Minimal reproducable example provided by #76517:
- Originally (offset wrongly when not at an exact pixel measurement whether it's because the camera's at 0.5 or the tilemap is):
![image](https://github.com/user-attachments/assets/b04b4ed7-fb4a-42d8-8e65-b5983b297bcc)
- Now (works and renders properly):
![image](https://github.com/user-attachments/assets/18db8430-b0d5-4bbc-9e25-81ce3ae321bc)


It offset the UV in the vertex shader to deal with precision issues without `use_pixel_snap` needing to be enabled. I decided to do this to minimize the amount of change required in this PR by going down this route, although I can make some larger changes to the internal functions to get it to instead use `use_pixel_snap` if the Godot team decides that that would be a better choice.