### PR TITLE
Add signal cell_changed for TileMapLayer cell updates

### DIFF
--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -309,6 +309,11 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="cell_changed">
+			<description>
+				Emitted when a cell in this this [TileMapLayer] changes.
+			</description>
+		</signal>
 		<signal name="changed">
 			<description>
 				Emitted when this [TileMapLayer]'s properties changes. This includes modified cells, properties, or changes made to its assigned [TileSet].

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1878,6 +1878,7 @@ void TileMapLayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_visibility_mode", PROPERTY_HINT_ENUM, "Default,Force Show,Force Hide"), "set_navigation_visibility_mode", "get_navigation_visibility_mode");
 
 	ADD_SIGNAL(MethodInfo(CoreStringName(changed)));
+	ADD_SIGNAL(MethodInfo("cell_changed"));
 
 	ADD_PROPERTY_DEFAULT("tile_map_data_format", TileMapDataFormat::TILE_MAP_DATA_FORMAT_1);
 
@@ -2377,6 +2378,7 @@ void TileMapLayer::set_cell(const Vector2i &p_coords, int p_source_id, const Vec
 	if (!E->value.dirty_list_element.in_list()) {
 		dirty.cell_list.add(&(E->value.dirty_list_element));
 	}
+	emit_signal(StaticCString::create("cell_changed"), pk);
 	_queue_internal_update();
 
 	used_rect_cache_dirty = true;


### PR DESCRIPTION
I have opened a proposal https://github.com/godotengine/godot-proposals/issues/10917 for this as a quality of life update so `@tool`s that need to work with cell updates do not need to cache get_used_cells() and implement _process() in order to act on cell updates.