### PR TITLE
Fix `Button` minimum size when `disabled` is toggled.

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -205,6 +205,7 @@ void BaseButton::set_disabled(bool p_disabled) {
 		status.pressing_inside = false;
 	}
 	queue_redraw();
+	update_minimum_size();
 }
 
 bool BaseButton::is_disabled() const {


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/95580