### PR TITLE
Fix removing hidden lines in TextEdit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -421,6 +421,9 @@ void TextEdit::Text::remove_range(int p_from_line, int p_to_line) {
 
 	for (int i = p_from_line; i < p_to_line; i++) {
 		const Line &text_line = text[i];
+		if (text_line.hidden) {
+			continue;
+		}
 		if (text_line.height == max_line_height) {
 			max_line_height_dirty = true;
 		}


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/97595

When a line is hidden it is removed from the `total_visible_line_count`, removing a hidden line was removing it again.