### PR TITLE
Create NativeAOT Templates

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
@@ -31,6 +31,8 @@
       <Link>Sdk\SdkPackageVersions.props</Link>
     </None>
     <None Include="Sdk\Android.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\AndroidNativeAOT.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\AndroidNativeAOT.targets" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\iOSNativeAOT.props" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\iOSNativeAOT.targets" Pack="true" PackagePath="Sdk" />
   </ItemGroup>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Godot.NET.Sdk.csproj
@@ -30,6 +30,12 @@
     <None Include="$(GodotSdkPackageVersionsFilePath)" Pack="true" PackagePath="Sdk">
       <Link>Sdk\SdkPackageVersions.props</Link>
     </None>
+    <None Include="Sdk\WindowsNativeAOT.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\WindowsNativeAOT.targets" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\LinuxBsdNativeAOT.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\LinuxBsdNativeAOT.targets" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\MacosNativeAOT.props" Pack="true" PackagePath="Sdk" />
+    <None Include="Sdk\MacosNativeAOT.targets" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\Android.props" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\AndroidNativeAOT.props" Pack="true" PackagePath="Sdk" />
     <None Include="Sdk\AndroidNativeAOT.targets" Pack="true" PackagePath="Sdk" />

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/AndroidNativeAOT.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/AndroidNativeAOT.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <PublishAot>true</PublishAot>
+    <PublishAotUsingRuntimePack>true</PublishAotUsingRuntimePack>
+    <DisableUnsupportedError>true</DisableUnsupportedError> <!-- Needed as of .NET 8.0 -->
+    <UseNativeAOTRuntime>true</UseNativeAOTRuntime>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/AndroidNativeAOT.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/AndroidNativeAOT.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <TrimmerRootAssembly Include="GodotSharp" />
+    <TrimmerRootAssembly Include="$(TargetName)" />
+  </ItemGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/LinuxBsdNativeAOT.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/LinuxBsdNativeAOT.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <PublishAot>true</PublishAot>
+    <UseNativeAOTRuntime>true</UseNativeAOTRuntime>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/LinuxBsdNativeAOT.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/LinuxBsdNativeAOT.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <TrimmerRootAssembly Include="GodotSharp" />
+    <TrimmerRootAssembly Include="$(TargetName)" />
+  </ItemGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/MacosNativeAOT.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/MacosNativeAOT.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <PublishAot>true</PublishAot>
+    <UseNativeAOTRuntime>true</UseNativeAOTRuntime>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/MacosNativeAOT.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/MacosNativeAOT.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <TrimmerRootAssembly Include="GodotSharp" />
+    <TrimmerRootAssembly Include="$(TargetName)" />
+  </ItemGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -112,6 +112,7 @@
     <DefineConstants>$(GodotDefineConstants);$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)\Android.props" Condition=" '$(GodotTargetPlatform)' == 'android' " />
+  <Import Project="$(MSBuildThisFileDirectory)\Android.props" Condition=" '$(GodotTargetPlatform)' == 'android' And '$(NativeAotEnabled)' == 'false' " />
+  <Import Project="$(MSBuildThisFileDirectory)\AndroidNativeAOT.props" Condition=" '$(GodotTargetPlatform)' == 'android' And '$(NativeAotEnabled)' == 'true' " />
   <Import Project="$(MSBuildThisFileDirectory)\iOSNativeAOT.props" Condition=" '$(GodotTargetPlatform)' == 'ios' " />
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -64,6 +64,7 @@
   <PropertyGroup Condition=" '$(GodotTargetPlatform)' == '' ">
     <GodotTargetPlatform Condition=" $(RuntimeIdentifier.StartsWith('ios')) ">ios</GodotTargetPlatform>
     <GodotTargetPlatform Condition=" '$(GodotTargetPlatform)' == '' and $(RuntimeIdentifier.StartsWith('android')) ">android</GodotTargetPlatform>
+    <GodotTargetPlatform Condition=" '$(GodotTargetPlatform)' == '' and $(RuntimeIdentifier.StartsWith('linux-bionic')) ">android</GodotTargetPlatform>
     <GodotTargetPlatform Condition=" '$(GodotTargetPlatform)' == '' and $(RuntimeIdentifier.StartsWith('browser')) ">web</GodotTargetPlatform>
 
     <GodotTargetPlatform Condition=" '$(GodotTargetPlatform)' == '' and $(RuntimeIdentifier.StartsWith('linux')) ">linuxbsd</GodotTargetPlatform>
@@ -112,6 +113,9 @@
     <DefineConstants>$(GodotDefineConstants);$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
+  <Import Project="$(MSBuildThisFileDirectory)\WindowsNativeAOT.props" Condition=" '$(GodotTargetPlatform)' == 'windows' And '$(NativeAotEnabled)' == 'true' " />
+  <Import Project="$(MSBuildThisFileDirectory)\LinuxBsdNativeAOT.props" Condition=" '$(GodotTargetPlatform)' == 'linuxbsd' And '$(NativeAotEnabled)' == 'true' " />
+  <Import Project="$(MSBuildThisFileDirectory)\MacosNativeAOT.props" Condition=" '$(GodotTargetPlatform)' == 'macos' And '$(NativeAotEnabled)' == 'true' " />
   <Import Project="$(MSBuildThisFileDirectory)\Android.props" Condition=" '$(GodotTargetPlatform)' == 'android' And '$(NativeAotEnabled)' == 'false' " />
   <Import Project="$(MSBuildThisFileDirectory)\AndroidNativeAOT.props" Condition=" '$(GodotTargetPlatform)' == 'android' And '$(NativeAotEnabled)' == 'true' " />
   <Import Project="$(MSBuildThisFileDirectory)\iOSNativeAOT.props" Condition=" '$(GodotTargetPlatform)' == 'ios' " />

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -21,8 +21,15 @@
     <PackageReference Include="GodotSharpEditor" Version="$(PackageVersion_GodotSharp)" Condition=" '$(Configuration)' == 'Debug' " />
   </ItemGroup>
 
+  <!-- Windows-specific build targets -->
+  <Import Project="$(MSBuildThisFileDirectory)\WindowsNativeAOT.targets" Condition=" '$(GodotTargetPlatform)' == 'windows' And '$(NativeAotEnabled)' == 'true' " />
+  <!-- LinuxBsd-specific build targets -->
+  <Import Project="$(MSBuildThisFileDirectory)\LinuxBsdNativeAOT.targets" Condition=" '$(GodotTargetPlatform)' == 'linuxbsd' And '$(NativeAotEnabled)' == 'true' " />
+  <!-- Macos-specific build targets -->
+  <Import Project="$(MSBuildThisFileDirectory)\MacosNativeAOT.targets" Condition=" '$(GodotTargetPlatform)' == 'macos' And '$(NativeAotEnabled)' == 'true' " />
+  <!-- Android-specific build targets -->
+  <Import Project="$(MSBuildThisFileDirectory)\AndroidNativeAOT.targets" Condition=" '$(GodotTargetPlatform)' == 'android' And '$(NativeAotEnabled)' == 'true' " />
   <!-- iOS-specific build targets -->
   <Import Project="$(MSBuildThisFileDirectory)\iOSNativeAOT.targets" Condition=" '$(GodotTargetPlatform)' == 'ios' " />
-  <Import Project="$(MSBuildThisFileDirectory)\AndroidNativeAOT.targets" Condition=" '$(GodotTargetPlatform)' == 'android' And '$(NativeAotEnabled)' == 'true' " />
 
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -23,5 +23,6 @@
 
   <!-- iOS-specific build targets -->
   <Import Project="$(MSBuildThisFileDirectory)\iOSNativeAOT.targets" Condition=" '$(GodotTargetPlatform)' == 'ios' " />
+  <Import Project="$(MSBuildThisFileDirectory)\AndroidNativeAOT.targets" Condition=" '$(GodotTargetPlatform)' == 'android' And '$(NativeAotEnabled)' == 'true' " />
 
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/WindowsNativeAOT.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/WindowsNativeAOT.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <PublishAot>true</PublishAot>
+    <UseNativeAOTRuntime>true</UseNativeAOTRuntime>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+</Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/WindowsNativeAOT.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/WindowsNativeAOT.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <TrimmerRootAssembly Include="GodotSharp" />
+    <TrimmerRootAssembly Include="$(TargetName)" />
+  </ItemGroup>
+</Project>

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildInfo.cs
@@ -15,6 +15,7 @@ namespace GodotTools.Build
         public string Configuration { get; private set; }
         public string? RuntimeIdentifier { get; private set; }
         public string? PublishOutputDir { get; private set; }
+        public bool NativeAotEnabled { get; private set; }
         public bool Restore { get; private set; }
         public bool Rebuild { get; private set; }
         public bool OnlyClean { get; private set; }
@@ -71,13 +72,14 @@ namespace GodotTools.Build
         }
 
         public BuildInfo(string solution, string project, string configuration, string runtimeIdentifier,
-            string publishOutputDir, bool restore, bool rebuild, bool onlyClean)
+            string publishOutputDir, bool nativeAotEnabled, bool restore, bool rebuild, bool onlyClean)
         {
             Solution = solution;
             Project = project;
             Configuration = configuration;
             RuntimeIdentifier = runtimeIdentifier;
             PublishOutputDir = publishOutputDir;
+            NativeAotEnabled = nativeAotEnabled;
             Restore = restore;
             Rebuild = rebuild;
             OnlyClean = onlyClean;

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -293,11 +293,12 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
+            bool nativeAotEnabled,
             bool includeDebugSymbols = true
         )
         {
             var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, GodotSharpDirs.ProjectCsProjPath, configuration,
-                runtimeIdentifier, publishOutputDir, restore: true, rebuild: false, onlyClean: false);
+                runtimeIdentifier, publishOutputDir, nativeAotEnabled, restore: true, rebuild: false, onlyClean: false);
 
             if (!includeDebugSymbols)
             {
@@ -306,6 +307,9 @@ namespace GodotTools.Build
             }
 
             buildInfo.CustomProperties.Add($"GodotTargetPlatform={platform}");
+
+            string nativeAotEnabledString = nativeAotEnabled.ToString();
+            buildInfo.CustomProperties.Add($"NativeAotEnabled={nativeAotEnabledString.ToLowerInvariant()}");
 
             if (Internal.GodotIsRealTDouble())
                 buildInfo.CustomProperties.Add("GodotFloat64=true");
@@ -329,9 +333,10 @@ namespace GodotTools.Build
             string platform,
             string runtimeIdentifier,
             string publishOutputDir,
+            bool nativeAotEnabled,
             bool includeDebugSymbols = true
         ) => PublishProjectBlocking(CreatePublishBuildInfo(configuration,
-            platform, runtimeIdentifier, publishOutputDir, includeDebugSymbols));
+            platform, runtimeIdentifier, publishOutputDir, nativeAotEnabled, includeDebugSymbols));
 
         public static bool GenerateXCFrameworkBlocking(
             List<string> outputPaths,

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -169,7 +169,7 @@ namespace GodotTools.Export
                 throw new NotImplementedException("Target platform not yet implemented.");
             }
 
-            bool enableNativeAot = ((bool)GetOption("dotnet/enable_native_aot") && platform == OS.Platforms.Android);
+            bool enableNativeAot = ((bool)GetOption("dotnet/enable_native_aot") || platform == OS.Platforms.iOS);
 
             PublishConfig publishConfig = new()
             {

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -71,6 +71,17 @@ namespace GodotTools.Export
                         }
                     },
                     { "default_value", false }
+                },
+                new Godot.Collections.Dictionary()
+                {
+                    {
+                        "option", new Godot.Collections.Dictionary()
+                        {
+                            { "name", "dotnet/runtime_identifier" },
+                            { "type", (int)Variant.Type.String }
+                        }
+                    },
+                    { "default_value", "" }
                 }
             };
         }
@@ -225,7 +236,18 @@ namespace GodotTools.Export
                 foreach (string arch in config.Archs)
                 {
                     string ridArch = DetermineRuntimeIdentifierArch(arch);
-                    string runtimeIdentifier = $"{ridOS}-{ridArch}";
+                    string overriddenRuntimeIdentifier = (string)GetOption("dotnet/runtime_identifier");
+                    string runtimeIdentifier;
+
+                    if (overriddenRuntimeIdentifier == "")
+                    {
+                        runtimeIdentifier = $"{ridOS}-{ridArch}";
+                    }
+                    else 
+                    {
+                        runtimeIdentifier = overriddenRuntimeIdentifier;
+                    }
+
                     string projectDataDirName = $"data_{GodotSharpDirs.CSharpProjectName}_{platform}_{arch}";
                     if (platform == OS.Platforms.MacOS)
                     {

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -55,6 +55,7 @@ namespace GodotTools.Utils
             public const string Linux = "linux";
             public const string Win10 = "win10";
             public const string Android = "android";
+            public const string NativeAotAndroid = "linux-bionic";
             public const string iOS = "ios";
             public const string iOSSimulator = "iossimulator";
             public const string Browser = "browser";
@@ -96,6 +97,17 @@ namespace GodotTools.Utils
             // Godot has a single export profile for both, named LinuxBSD.
             [Platforms.LinuxBSD] = DotNetOS.Linux,
             [Platforms.Android] = DotNetOS.Android,
+            [Platforms.iOS] = DotNetOS.iOS,
+            [Platforms.Web] = DotNetOS.Browser
+        };
+
+        // NativeAOT uses linux RID on android 
+        public static readonly Dictionary<string, string> DotNetOSNativeAotPlatformMap = new Dictionary<string, string> 
+        {
+            [Platforms.Windows] = DotNetOS.Win,
+            [Platforms.MacOS] = DotNetOS.OSX,
+            [Platforms.LinuxBSD] = DotNetOS.Linux,
+            [Platforms.Android] = DotNetOS.NativeAotAndroid,
             [Platforms.iOS] = DotNetOS.iOS,
             [Platforms.Web] = DotNetOS.Browser
         };

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1963,6 +1963,10 @@ bool EditorExportPlatformAndroid::get_export_option_visibility(const EditorExpor
 		return false;
 	}
 
+	if (p_option == "dotnet/enable_native_aot") {
+		return advanced_options_enabled;
+	}
+
 	return true;
 }
 

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -249,6 +249,11 @@ bool EditorExportPlatformIOS::get_export_option_visibility(const EditorExportPre
 		return false;
 	}
 
+	// Hide NativeAOT option as it's enabled by default.
+	if (p_option == "dotnet/enable_native_aot") {
+		return false;
+	}
+
 	if (p_preset == nullptr) {
 		return true;
 	}

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -174,6 +174,9 @@ bool EditorExportPlatformLinuxBSD::get_export_option_visibility(const EditorExpo
 	if (p_option == "dotnet/embed_build_outputs") {
 		return advanced_options_enabled;
 	}
+	if (p_option == "dotnet/enable_native_aot") {
+		return advanced_options_enabled;
+	}
 	return true;
 }
 

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -344,6 +344,11 @@ bool EditorExportPlatformMacOS::get_export_option_visibility(const EditorExportP
 		return false;
 	}
 
+	bool advanced_options_enabled = p_preset->are_advanced_options_enabled();
+	if (p_option == "dotnet/enable_native_aot") {
+		return advanced_options_enabled;
+	}
+
 	return true;
 }
 

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -401,6 +401,10 @@ bool EditorExportPlatformWindows::get_export_option_visibility(const EditorExpor
 	if (p_option == "dotnet/embed_build_outputs") {
 		return advanced_options_enabled;
 	}
+
+	if (p_option == "dotnet/enable_native_aot") {
+		return advanced_options_enabled;
+	}
 	return true;
 }
 


### PR DESCRIPTION
Supersedes #97776

Resolves #97775

@raulsntos I think I've addressed most of your concerns. The only concern I'm not sure how to address yet is for the architectures where `NativeAOT` isn't supported. On the Windows export dialog there's a dropdown that has a selectable architecture while on Android they are options that can all be selected at the same time. Should there be a warning that prevents the user from exporting if there's even a single architecture that is selected where `NativeAOT` isn't supported, or allow the user to still export but fall back to a disabled `NativeAOT` just for the unsupported architectures? 