### PR TITLE
Add `linux-bionic` RID export option to support NativeAOT on Android

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -37,8 +37,28 @@ namespace GodotTools.Export
 
         public override Godot.Collections.Array<Godot.Collections.Dictionary> _GetExportOptions(EditorExportPlatform platform)
         {
-            return new Godot.Collections.Array<Godot.Collections.Dictionary>()
+            var exportOptionList = new Godot.Collections.Array<Godot.Collections.Dictionary>();
+
+            if (platform.GetOsName().Equals(OS.Platforms.Android, StringComparison.OrdinalIgnoreCase))
             {
+                exportOptionList.Add
+                (
+                    new Godot.Collections.Dictionary()
+                    {
+                        {
+                            "option", new Godot.Collections.Dictionary()
+                            {
+                                { "name", "dotnet/android_use_linux_bionic" },
+                                { "type", (int)Variant.Type.Bool }
+                            }
+                        },
+                        { "default_value", false }
+                    }
+                );
+            }
+
+            exportOptionList.Add
+            (
                 new Godot.Collections.Dictionary()
                 {
                     {
@@ -49,7 +69,10 @@ namespace GodotTools.Export
                         }
                     },
                     { "default_value", false }
-                },
+                }
+            );
+            exportOptionList.Add
+            (
                 new Godot.Collections.Dictionary()
                 {
                     {
@@ -60,7 +83,10 @@ namespace GodotTools.Export
                         }
                     },
                     { "default_value", true }
-                },
+                }
+            );
+            exportOptionList.Add
+            (
                 new Godot.Collections.Dictionary()
                 {
                     {
@@ -72,7 +98,8 @@ namespace GodotTools.Export
                     },
                     { "default_value", false }
                 }
-            };
+            );
+            return exportOptionList;
         }
 
         private void AddExceptionMessage(EditorExportPlatform platform, Exception exception)
@@ -158,11 +185,12 @@ namespace GodotTools.Export
                 throw new NotImplementedException("Target platform not yet implemented.");
             }
 
+            bool useAndroidLinuxBionic = (bool)GetOption("dotnet/android_use_linux_bionic");
             PublishConfig publishConfig = new()
             {
                 BuildConfig = isDebug ? "ExportDebug" : "ExportRelease",
                 IncludeDebugSymbols = (bool)GetOption("dotnet/include_debug_symbols"),
-                RidOS = DetermineRuntimeIdentifierOS(platform),
+                RidOS = DetermineRuntimeIdentifierOS(platform, useAndroidLinuxBionic),
                 Archs = new List<string>(),
                 UseTempDir = platform != OS.Platforms.iOS, // xcode project links directly to files in the publish dir, so use one that sticks around.
                 BundleOutputs = true,
@@ -335,6 +363,14 @@ namespace GodotTools.Export
 
                                         if (IsSharedObject(fileName))
                                         {
+                                            if (fileName.EndsWith(".so") && !fileName.StartsWith("lib"))
+                                            {
+                                                // Add 'lib' prefix required for all native libraries in Android.
+                                                string newPath = string.Concat(path.AsSpan(0, path.Length - fileName.Length), "lib", fileName);
+                                                Godot.DirAccess.RenameAbsolute(path, newPath);
+                                                path = newPath;
+                                            }
+
                                             AddSharedObject(path, tags: new string[] { arch },
                                                 Path.Join(projectDataDirName,
                                                     Path.GetRelativePath(publishOutputDir,
@@ -450,8 +486,14 @@ namespace GodotTools.Export
             return path;
         }
 
-        private string DetermineRuntimeIdentifierOS(string platform)
-            => OS.DotNetOSPlatformMap[platform];
+        private string DetermineRuntimeIdentifierOS(string platform, bool useAndroidLinuxBionic)
+        {
+            if (platform == OS.Platforms.Android && useAndroidLinuxBionic)
+            {
+                return OS.DotNetOS.LinuxBionic;
+            }
+            return OS.DotNetOSPlatformMap[platform];
+        }
 
         private string DetermineRuntimeIdentifierArch(string arch)
         {

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -55,6 +55,7 @@ namespace GodotTools.Utils
             public const string Linux = "linux";
             public const string Win10 = "win10";
             public const string Android = "android";
+            public const string LinuxBionic = "linux-bionic";
             public const string iOS = "ios";
             public const string iOSSimulator = "iossimulator";
             public const string Browser = "browser";
@@ -99,7 +100,6 @@ namespace GodotTools.Utils
             [Platforms.iOS] = DotNetOS.iOS,
             [Platforms.Web] = DotNetOS.Browser
         };
-
         private static bool IsOS(string name)
         {
             Internal.godot_icall_Utils_OS_GetPlatformName(out godot_string dest);

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -416,6 +416,8 @@ godot_plugins_initialize_fn try_load_native_aot_library(void *&r_aot_dll_handle)
 	String native_aot_so_path = GodotSharpDirs::get_api_assemblies_dir().path_join(assembly_name + ".dll");
 #elif defined(MACOS_ENABLED) || defined(IOS_ENABLED)
 	String native_aot_so_path = GodotSharpDirs::get_api_assemblies_dir().path_join(assembly_name + ".dylib");
+#elif defined(ANDROID_ENABLED)
+	String native_aot_so_path = "lib" + assembly_name + ".so";
 #elif defined(UNIX_ENABLED)
 	String native_aot_so_path = GodotSharpDirs::get_api_assemblies_dir().path_join(assembly_name + ".so");
 #else

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2058,6 +2058,9 @@ bool EditorExportPlatformAndroid::get_export_option_visibility(const EditorExpor
 		return false;
 	}
 
+	if (p_option == "dotnet/android_use_linux_bionic") {
+		return advanced_options_enabled;
+	}
 	return true;
 }
 


### PR DESCRIPTION
Supersedes #97901

Resolves #97775

@raulsntos hopefully I'm homing in to your design goals!

This time around I just replace the RID, as you mentioned, with the `linux-bionic` one when it's enabled for Android, which should be the only platform that the option shows up for.