### PR TITLE
Add option to not delete nodes created by `MultiplayerSpawner` when its authority peer disconnects

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -178,6 +178,16 @@ void SceneMultiplayer::clear() {
 	relay_buffer->clear();
 }
 
+void SceneMultiplayer::set_delete_spawned_nodes_on_peer_exit(bool value) {
+    if (replicator) {
+        replicator->set_delete_spawned_nodes_on_peer_exit(value);
+    }
+}
+
+bool SceneMultiplayer::get_delete_spawned_nodes_on_peer_exit() const {
+    return replicator ? replicator->get_delete_spawned_nodes_on_peer_exit() : true;
+}
+
 void SceneMultiplayer::set_root_path(const NodePath &p_path) {
 	ERR_FAIL_COND_MSG(!p_path.is_absolute() && !p_path.is_empty(), "SceneMultiplayer root path must be absolute.");
 	root_path = p_path;

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -674,6 +674,9 @@ void SceneMultiplayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_max_delta_packet_size"), &SceneMultiplayer::get_max_delta_packet_size);
 	ClassDB::bind_method(D_METHOD("set_max_delta_packet_size", "size"), &SceneMultiplayer::set_max_delta_packet_size);
 
+	ClassDB::bind_method(D_METHOD("set_delete_spawned_nodes_on_peer_exit", "value"), &SceneMultiplayer::set_delete_spawned_nodes_on_peer_exit);
+	ClassDB::bind_method(D_METHOD("get_delete_spawned_nodes_on_peer_exit"), &SceneMultiplayer::get_delete_spawned_nodes_on_peer_exit);
+
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "root_path"), "set_root_path", "get_root_path");
 	ADD_PROPERTY(PropertyInfo(Variant::CALLABLE, "auth_callback"), "set_auth_callback", "get_auth_callback");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auth_timeout", PROPERTY_HINT_RANGE, "0,30,0.1,or_greater,suffix:s"), "set_auth_timeout", "get_auth_timeout");

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -179,13 +179,11 @@ void SceneMultiplayer::clear() {
 }
 
 void SceneMultiplayer::set_delete_spawned_nodes_on_peer_exit(bool value) {
-    if (replicator.is_valid()) {
-        replicator->set_delete_spawned_nodes_on_peer_exit(value);
-    }
+    replicator->set_delete_spawned_nodes_on_peer_exit(value);
 }
 
 bool SceneMultiplayer::get_delete_spawned_nodes_on_peer_exit() const {
-    return replicator.is_valid() ? replicator->get_delete_spawned_nodes_on_peer_exit() : true;
+    return replicator->get_delete_spawned_nodes_on_peer_exit();
 }
 
 void SceneMultiplayer::set_root_path(const NodePath &p_path) {

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -179,13 +179,13 @@ void SceneMultiplayer::clear() {
 }
 
 void SceneMultiplayer::set_delete_spawned_nodes_on_peer_exit(bool value) {
-    if (replicator) {
+    if (replicator.is_valid()) {
         replicator->set_delete_spawned_nodes_on_peer_exit(value);
     }
 }
 
 bool SceneMultiplayer::get_delete_spawned_nodes_on_peer_exit() const {
-    return replicator ? replicator->get_delete_spawned_nodes_on_peer_exit() : true;
+    return replicator.is_valid() ? replicator->get_delete_spawned_nodes_on_peer_exit() : true;
 }
 
 void SceneMultiplayer::set_root_path(const NodePath &p_path) {

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -37,9 +37,6 @@
 
 #include "scene/main/multiplayer_api.h"
 
-#include "scene_multiplayer.h"
-#include "scene_replication_interface.h"
-
 class OfflineMultiplayerPeer : public MultiplayerPeer {
 	GDCLASS(OfflineMultiplayerPeer, MultiplayerPeer);
 
@@ -64,8 +61,6 @@ public:
 	virtual int get_unique_id() const override { return TARGET_PEER_SERVER; }
 	virtual ConnectionStatus get_connection_status() const override { return CONNECTION_CONNECTED; };
 
-	void set_delete_spawned_nodes_on_peer_exit(bool value);
-	bool get_delete_spawned_nodes_on_peer_exit() const;
 };
 
 class SceneMultiplayer : public MultiplayerAPI {
@@ -107,6 +102,9 @@ public:
 		CMD_MASK = 7, // 0x7 -> 0b00000111
 	};
 
+	void set_delete_spawned_nodes_on_peer_exit(bool p_value);
+	bool get_delete_spawned_nodes_on_peer_exit() const;
+
 private:
 	struct PendingPeer {
 		bool local = false;
@@ -131,7 +129,10 @@ private:
 	Ref<StreamPeerBuffer> relay_buffer;
 
 	Ref<SceneCacheInterface> cache;
+
+
 	Ref<SceneReplicationInterface> replicator;
+
 	Ref<SceneRPCInterface> rpc;
 
 #ifdef DEBUG_ENABLED

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -37,6 +37,9 @@
 
 #include "scene/main/multiplayer_api.h"
 
+#include "scene_multiplayer.h"
+#include "scene_replication_interface.h"
+
 class OfflineMultiplayerPeer : public MultiplayerPeer {
 	GDCLASS(OfflineMultiplayerPeer, MultiplayerPeer);
 

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -60,6 +60,9 @@ public:
 	virtual void close() override {}
 	virtual int get_unique_id() const override { return TARGET_PEER_SERVER; }
 	virtual ConnectionStatus get_connection_status() const override { return CONNECTION_CONNECTED; };
+
+	void set_delete_spawned_nodes_on_peer_exit(bool value);
+	bool get_delete_spawned_nodes_on_peer_exit() const;
 };
 
 class SceneMultiplayer : public MultiplayerAPI {

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -79,6 +79,9 @@ private:
 	// Pending local spawn information (handles spawning nested nodes during ready).
 	HashSet<ObjectID> spawn_queue;
 
+	// Determines if MultiplayerSpawner clears spawned nodes when its multiplayer authority disconnects.
+	bool delete_spawned_nodes_on_peer_exit = true;
+
 	// Pending remote spawn information.
 	ObjectID pending_spawn;
 	int pending_spawn_remote = 0;
@@ -145,6 +148,10 @@ public:
 
 	void set_max_delta_packet_size(int p_size);
 	int get_max_delta_packet_size() const;
+
+	// New getter and setter for the delete_spawned_nodes_on_peer_exit property
+ 	void set_delete_spawned_nodes_on_peer_exit(bool value);
+ 	bool get_delete_spawned_nodes_on_peer_exit() const;
 
 	SceneReplicationInterface(SceneMultiplayer *p_multiplayer, SceneCacheInterface *p_cache) {
 		multiplayer = p_multiplayer;

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -150,8 +150,8 @@ public:
 	int get_max_delta_packet_size() const;
 
 	// New getter and setter for the delete_spawned_nodes_on_peer_exit property
- 	void set_delete_spawned_nodes_on_peer_exit(bool value);
- 	bool get_delete_spawned_nodes_on_peer_exit() const;
+ 	virtual void set_delete_spawned_nodes_on_peer_exit(bool value);
+ 	virtual bool get_delete_spawned_nodes_on_peer_exit() const;
 
 	SceneReplicationInterface(SceneMultiplayer *p_multiplayer, SceneCacheInterface *p_cache) {
 		multiplayer = p_multiplayer;


### PR DESCRIPTION
Very simple option that you can set using "multiplayer.set_delete_spawned_nodes_on_peer_exit(false)", which prevents a MultiplayerSpawner from automatically deleting all that is has spawned when its multiplayer authority peer disconnects.
