### PR TITLE
Expose path properties save UID internally if referencing a resource

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -462,8 +462,24 @@ void EditorPropertyPath::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyPath::_path_selected(const String &p_path) {
-	emit_changed(get_edited_property(), p_path);
+	String full_path = p_path;
+	ResourceUID::ID id = ResourceLoader::get_resource_uid(full_path);
+
+	if (id != ResourceUID::INVALID_ID) {
+		full_path = ResourceUID::get_singleton()->id_to_text(id);
+	}
+
+	emit_changed(get_edited_property(), full_path);
 	update_property();
+}
+
+String EditorPropertyPath::_get_path_text() {
+	String full_path = get_edited_property_value();
+	if (full_path.begins_with("uid://")) {
+		full_path = ResourceUID::get_singleton()->get_id_path(ResourceUID::get_singleton()->text_to_id(full_path));
+	}
+
+	return full_path;
 }
 
 void EditorPropertyPath::_path_pressed() {
@@ -474,7 +490,7 @@ void EditorPropertyPath::_path_pressed() {
 		add_child(dialog);
 	}
 
-	String full_path = get_edited_property_value();
+	String full_path = _get_path_text();
 
 	dialog->clear_filters();
 
@@ -502,7 +518,7 @@ void EditorPropertyPath::_path_pressed() {
 }
 
 void EditorPropertyPath::update_property() {
-	String full_path = get_edited_property_value();
+	String full_path = _get_path_text();
 	path->set_text(full_path);
 	path->set_tooltip_text(full_path);
 }
@@ -547,8 +563,7 @@ void EditorPropertyPath::_drop_data_fw(const Point2 &p_point, const Variant &p_d
 		return;
 	}
 
-	emit_changed(get_edited_property(), filesPaths[0]);
-	update_property();
+	_path_selected(filesPaths[0]);
 }
 
 bool EditorPropertyPath::_can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -142,6 +142,8 @@ class EditorPropertyPath : public EditorProperty {
 	LineEdit *path = nullptr;
 	Button *path_edit = nullptr;
 
+	String _get_path_text();
+
 	void _path_selected(const String &p_path);
 	void _path_pressed();
 	void _path_focus_exited();


### PR DESCRIPTION
Currently, if a user or some resource exposes a path in a script, if this references a resource path it will be saved as a full path.

This will make refactoring not work if the resource pointed towards changes location or is renamed.

This change makes it so an uid:// path is saved internally in case a path to a resource has been selected, effectively making it refactor proof.

Screenshots:

Property is edited as a path:
![image](https://github.com/user-attachments/assets/b25f792e-3787-4229-bf88-7ae9ad69e36a)
But value is saved as UID if a resource.
![image](https://github.com/user-attachments/assets/14703645-fb30-4fc7-ba8b-060bd1326a5e)

Fixes #97931
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
