### PR TITLE
Expose property editor instantiation to EditorPlugin

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -613,6 +613,19 @@
 				Minimizes the bottom panel.
 			</description>
 		</method>
+		<method name="instantiate_property_editor">
+			<return type="EditorProperty" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="type" type="int" enum="Variant.Type" />
+			<param index="2" name="path" type="String" />
+			<param index="3" name="hint" type="int" enum="PropertyHint" default="0" />
+			<param index="4" name="hint_string" type="String" default="&quot;&quot;" />
+			<param index="5" name="usage" type="int" default="6" />
+			<param index="6" name="wide" type="bool" default="false" />
+			<description>
+				Instantiate a property editor for a specific object property, similar to how it works in the inspector.
+			</description>
+		</method>
 		<method name="make_bottom_panel_item_visible">
 			<return type="void" />
 			<param index="0" name="item" type="Control" />

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -472,6 +472,10 @@ void EditorPlugin::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_p
 	EditorInspector::remove_inspector_plugin(p_plugin);
 }
 
+EditorProperty *EditorPlugin::instantiate_property_editor(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
+	return EditorInspector::instantiate_property_editor(p_object, p_type, p_path, p_hint, p_hint_text, p_usage, p_wide);
+}
+
 void EditorPlugin::add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(!p_importer.is_valid());
 	ResourceImporterScene::add_scene_importer(p_importer, p_first_priority);
@@ -639,6 +643,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_force_draw_over_forwarding_enabled"), &EditorPlugin::set_force_draw_over_forwarding_enabled);
 	ClassDB::bind_method(D_METHOD("add_context_menu_plugin", "slot", "plugin"), &EditorPlugin::add_context_menu_plugin);
 	ClassDB::bind_method(D_METHOD("remove_context_menu_plugin", "plugin"), &EditorPlugin::remove_context_menu_plugin);
+
+	ClassDB::bind_method(D_METHOD("instantiate_property_editor", "object", "type", "path", "hint", "hint_string", "usage", "wide"), &EditorPlugin::instantiate_property_editor, DEFVAL(PROPERTY_HINT_NONE), DEFVAL(""), DEFVAL(PROPERTY_USAGE_DEFAULT), DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorPlugin::get_editor_interface);
 	ClassDB::bind_method(D_METHOD("get_script_create_dialog"), &EditorPlugin::get_script_create_dialog);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -53,6 +53,7 @@ class EditorScenePostImportPlugin;
 class EditorToolAddons;
 class EditorTranslationParserPlugin;
 class EditorUndoRedoManager;
+class EditorProperty;
 class ScriptCreateDialog;
 
 class EditorPlugin : public Node {
@@ -234,6 +235,8 @@ public:
 
 	void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
+
+	EditorProperty *instantiate_property_editor(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false);
 
 	void add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority = false);
 	void remove_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer);


### PR DESCRIPTION
Expose property editor instantiation to EditorPlugin. This is an already existing functin in Inspector, so it was just exposed to plugins.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
