### PR TITLE
Fix: Exports with mono and C# scripts can corrupt the build results

### DIFF
--- a/core/extension/gdextension_compat_hashes.cpp
+++ b/core/extension/gdextension_compat_hashes.cpp
@@ -1013,6 +1013,10 @@ void GDExtensionCompatHashes::initialize() {
 	// clang-format on
 }
 
+bool GDExtensionCompatHashes::initialized() {
+	return !mappings.is_empty();
+}
+
 void GDExtensionCompatHashes::finalize() {
 	mappings.clear();
 }

--- a/core/extension/gdextension_compat_hashes.h
+++ b/core/extension/gdextension_compat_hashes.h
@@ -48,6 +48,7 @@ class GDExtensionCompatHashes {
 
 public:
 	static void initialize();
+	static bool initialized();
 	static void finalize();
 	static bool lookup_current_hash(const StringName &p_class, const StringName &p_method, uint32_t p_legacy_hash, uint32_t *r_current_hash);
 	static bool get_legacy_hashes(const StringName &p_class, const StringName &p_method, Array &r_hashes, bool p_check_valid = true);

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -31,6 +31,7 @@
 #include "class_db.h"
 
 #include "core/config/engine.h"
+#include "core/extension/gdextension_compat_hashes.h"
 #include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
 #include "core/os/mutex.h"
@@ -1061,6 +1062,19 @@ MethodBind *ClassDB::get_method_with_compatibility(const StringName &p_class, co
 			}
 			if ((*method)->get_hash() == p_hash) {
 				return *method;
+			} else {
+#ifndef DISABLE_DEPRECATED
+				if (!GDExtensionCompatHashes::initialized()) {
+					GDExtensionCompatHashes::initialize();
+				}
+				Array legacy_hashes;
+				// don't let p_check_valid = true to avoid stackoverflow
+				if (GDExtensionCompatHashes::get_legacy_hashes(p_class, p_name, legacy_hashes, false)) {
+					if (legacy_hashes.has(p_hash)) {
+						return *method;
+					}
+				}
+#endif
 			}
 		}
 


### PR DESCRIPTION
Fixes #97920

When a function of that name is found but the hashes are not equal, make `ClassDB::get_method_compatibility_hashes` try to match it using a legacy version of the hash.

