### PR TITLE
Make TranslationServer singleton variable inline.

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -387,8 +387,6 @@ StringName TranslationServer::translate_plural(const StringName &p_message, cons
 	return main_domain->translate_plural(p_message, p_message_plural, p_n, p_context);
 }
 
-TranslationServer *TranslationServer::singleton = nullptr;
-
 bool TranslationServer::_load_translations(const String &p_from) {
 	if (ProjectSettings::get_singleton()->has_setting(p_from)) {
 		const Vector<String> &translation_names = GLOBAL_GET(p_from);

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -48,7 +48,7 @@ class TranslationServer : public Object {
 
 	bool enabled = true;
 
-	static TranslationServer *singleton;
+	static inline TranslationServer *singleton = nullptr;
 	bool _load_translations(const String &p_from);
 	String _standardize_locale(const String &p_locale, bool p_add_defaults) const;
 


### PR DESCRIPTION
This change avoids the problem known as 'Static Initialization Order Fiasco' (SIOF).
We ran into this issue in a customized Godot build, but could hit anyone.

See the following PR for more explanation: https://github.com/godotengine/godot/pull/94683

Developed by [Migeran](https://migeran.com)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
