### PR TITLE
Run autoload first pass before MainLoop initializes

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3790,6 +3790,21 @@ int Main::start() {
 	}
 #endif
 
+	if (!project_manager && !editor) { // game
+		HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
+
+		//first pass, add the constants so they exist before any script is loaded (including MainLoop scripts)
+		for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
+			const ProjectSettings::AutoloadInfo &info = E.value;
+
+			if (info.is_singleton) {
+				for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+					ScriptServer::get_language(i)->add_global_constant(info.name, Variant());
+				}
+			}
+		}
+	}
+
 	MainLoop *main_loop = nullptr;
 	if (editor) {
 		main_loop = memnew(SceneTree);
@@ -3911,17 +3926,6 @@ int Main::start() {
 				//autoload
 				OS::get_singleton()->benchmark_begin_measure("Startup", "Load Autoloads");
 				HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
-
-				//first pass, add the constants so they exist before any script is loaded
-				for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
-					const ProjectSettings::AutoloadInfo &info = E.value;
-
-					if (info.is_singleton) {
-						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
-							ScriptServer::get_language(i)->add_global_constant(info.name, Variant());
-						}
-					}
-				}
 
 				//second pass, load into global constants
 				List<Node *> to_add;


### PR DESCRIPTION
You can't reference any singleton identifiers in MainLoop scripts because they are not registered as global constants when MainLoop is initialized.
Moving the first pass of autoloads (which registered all autoloaded singleton identifiers as null) to the place before MainLoop initialzes fixes this problem.
Closes #97926