### PR TITLE
Fix `CheckButton` mirrored icon in editor theme

### DIFF
--- a/editor/icons/GuiToggleOffMirrored.svg
+++ b/editor/icons/GuiToggleOffMirrored.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="38" height="16"><rect width="36" height="14" x="1" y="1" fill="gray" rx="7"/><circle cx="8" cy="8" r="5" fill="#b3b3b3"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="38" height="16"><g fill="#e0e0e0"><rect width="36" height="14" x="1" y="1" fill-opacity=".2" rx="7"/><circle cx="30" cy="8" r="5"/></g></svg>


### PR DESCRIPTION
A "typo" introduced in #77939 :)

When the editor is using RTL language, the "off" icon of `CheckButton` is wrong. It's not mirrored and is using colors for the disabled version.

CC @MewPurPur