### PR TITLE
Add `*.tmp` to auto-generated `.gitignore` 

### DIFF
--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -368,6 +368,7 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 			f->store_line("# Godot 4+ specific ignores");
 			f->store_line(".godot/");
 			f->store_line("/android/");
+			f->store_line("*.tmp");
 		}
 		f = FileAccess::open(p_dir.path_join(".gitattributes"), FileAccess::WRITE);
 		if (f.is_null()) {


### PR DESCRIPTION
Added `*.tmp` to the .gitignore file automatically generated by the editor VCS interface.
The editor will sometimes generate `.tmp` files, such as `mah57E1.tmp`.