### PR TITLE
Add to `TextEdit` END key state support

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2558,7 +2558,7 @@ void TextEdit::_move_caret_up(bool p_select) {
 		int cur_wrap_index = get_caret_wrap_index(i);
 		if (cur_wrap_index > 0) {
 			set_caret_line(get_caret_line(i), true, false, cur_wrap_index - 1, i);
-		} else if (get_caret_line(i) == 0) {
+		} else if (get_caret_line(i) == 0 && !_is_caret_at_eol(i)) {
 			set_caret_column(0, i == 0, i);
 		} else {
 			int new_line = get_caret_line(i) - get_next_visible_line_offset_from(get_caret_line(i) - 1, -1);
@@ -2584,7 +2584,7 @@ void TextEdit::_move_caret_down(bool p_select) {
 		int cur_wrap_index = get_caret_wrap_index(i);
 		if (cur_wrap_index < get_line_wrap_count(get_caret_line(i))) {
 			set_caret_line(get_caret_line(i), i == 0, false, cur_wrap_index + 1, i);
-		} else if (get_caret_line(i) == get_last_unhidden_line()) {
+		} else if (get_caret_line(i) == get_last_unhidden_line() && !_is_caret_at_eol(i)) {
 			set_caret_column(text[get_caret_line(i)].length());
 		} else {
 			int new_line = get_caret_line(i) + get_next_visible_line_offset_from(CLAMP(get_caret_line(i) + 1, 0, text.size() - 1), 1);
@@ -2646,6 +2646,9 @@ void TextEdit::_move_caret_to_line_end(bool p_select) {
 		} else {
 			set_caret_column(row_end_col, i == 0, i);
 		}
+
+		// Setting this to flag the caret is at the end of line.
+		carets.write[i].last_fit_x = INT_MAX;
 	}
 	merge_overlapping_carets();
 }
@@ -2848,7 +2851,9 @@ void TextEdit::_move_caret_document_end(bool p_select) {
 	}
 
 	set_caret_line(get_last_unhidden_line(), true, false, -1);
-	set_caret_column(text[get_caret_line()].length());
+	if (!_is_caret_at_eol(0)) {
+		set_caret_column(text[get_caret_line()].length());
+	}
 }
 
 bool TextEdit::_clear_carets_and_selection() {
@@ -4905,7 +4910,9 @@ void TextEdit::collapse_carets(int p_from_line, int p_from_column, int p_to_line
 			if (is_caret_in) {
 				// Caret was in the collapsed area.
 				set_caret_line(collapse_line, false, true, -1, i);
-				set_caret_column(collapse_column, false, i);
+				if (!_is_caret_at_eol(i)) {
+					set_caret_column(collapse_column, false, i);
+				}
 				if (is_in_mulitcaret_edit() && get_caret_count() > 1) {
 					multicaret_edit_ignore_carets.insert(i);
 				}
@@ -4918,7 +4925,9 @@ void TextEdit::collapse_carets(int p_from_line, int p_from_column, int p_to_line
 				// Selection was completely encapsulated.
 				deselect(i);
 				set_caret_line(collapse_line, false, true, -1, i);
-				set_caret_column(collapse_column, false, i);
+				if (!_is_caret_at_eol(i)) {
+					set_caret_column(collapse_column, false, i);
+				}
 				if (is_in_mulitcaret_edit() && get_caret_count() > 1) {
 					multicaret_edit_ignore_carets.insert(i);
 				}
@@ -4926,7 +4935,9 @@ void TextEdit::collapse_carets(int p_from_line, int p_from_column, int p_to_line
 			} else if (is_caret_in) {
 				// Only caret was inside.
 				set_caret_line(collapse_line, false, true, -1, i);
-				set_caret_column(collapse_column, false, i);
+				if (!_is_caret_at_eol(i)) {
+					set_caret_column(collapse_column, false, i);
+				}
 				any_collapsed = true;
 			} else if (is_origin_in) {
 				// Only selection origin was inside.
@@ -5125,8 +5136,13 @@ void TextEdit::set_caret_line(int p_line, bool p_adjust_viewport, bool p_can_be_
 			}
 		}
 	} else {
-		// Clamp the column.
-		n_col = MIN(get_caret_column(p_caret), get_line(p_line).length());
+		// Keep the caret at the end of the line.
+		if (_is_caret_at_eol(p_caret)) {
+			n_col = get_line(p_line).length();
+		} else {
+			// Clamp the column.
+			n_col = MIN(get_caret_column(p_caret), get_line(p_line).length());
+		}
 	}
 	caret_moved = (caret_moved || get_caret_column(p_caret) != n_col);
 	carets.write[p_caret].column = n_col;
@@ -7604,7 +7620,7 @@ int TextEdit::_get_char_pos_for_line(int p_px, int p_line, int p_wrap_index) con
 	if (is_layout_rtl()) {
 		p_px = TS->shaped_text_get_size(text_rid).x - p_px + wrap_indent;
 	} else {
-		p_px -= wrap_indent;
+		p_px -= (int)wrap_indent;
 	}
 	int ofs = TS->shaped_text_hit_test_position(text_rid, p_px);
 	if (!caret_mid_grapheme_enabled) {
@@ -7752,6 +7768,10 @@ void TextEdit::_cancel_drag_and_drop_text() {
 	if (selection_drag_attempt && get_viewport()) {
 		get_viewport()->gui_cancel_drag();
 	}
+}
+
+bool TextEdit::_is_caret_at_eol(int p_caret) {
+	return carets[p_caret].last_fit_x == INT_MAX;
 }
 
 /* Selection */

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -461,6 +461,8 @@ private:
 
 	void _cancel_drag_and_drop_text();
 
+	bool _is_caret_at_eol(int p_caret = 0);
+
 	/* Selection. */
 	SelectionMode selecting_mode = SelectionMode::SELECTION_MODE_NONE;
 

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -5674,6 +5674,44 @@ func _ready():
 	memdelete(code_edit);
 }
 
+TEST_CASE("[SceneTree][CodeEdit] End key state behavior on folded block") {
+	const String text = R"(extends Node
+
+func some_function(param1, param2, param3):
+	local_const = 5
+
+	if param1 < local_const:
+		print(">" + param1)
+	elif param2 > 5:
+		print(param2)
+	else:
+		print("Fail!")
+		print("No!")
+
+	for i in range(20):
+		print("line longer than for loop")
+		print(i)
+)";
+
+	CodeEdit *code_edit = memnew(CodeEdit);
+	SceneTree::get_singleton()->get_root()->add_child(code_edit);
+	code_edit->grab_focus();
+	code_edit->set_line_folding_enabled(true);
+	code_edit->set_text(text);
+	code_edit->set_caret_line(15); // print(i)
+	code_edit->set_caret_column(0);
+
+	SEND_GUI_ACTION("ui_text_caret_line_end");
+	code_edit->fold_line(13); // for i in range(20):
+	CHECK(code_edit->get_caret_column() == code_edit->get_line(13).length()); // for i in range(20):
+	SEND_GUI_ACTION("ui_text_caret_up");
+	SEND_GUI_ACTION("ui_text_caret_up");
+	SEND_GUI_ACTION("ui_text_caret_up");
+	CHECK(code_edit->get_caret_column() == code_edit->get_line(10).length()); // print("Fail!")
+
+	memdelete(code_edit);
+}
+
 } // namespace TestCodeEdit
 
 #endif // TEST_CODE_EDIT_H

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -148,6 +148,10 @@ int register_test_command(String p_command, TestFunc p_function);
 #define SEND_GUI_ACTION(m_action)                                                                     \
 	{                                                                                                 \
 		const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(m_action); \
+		if (events == nullptr) {                                                                      \
+			FAIL("Invalid " #m_action " action");                                                     \
+			return;                                                                                   \
+		}                                                                                             \
 		const List<Ref<InputEvent>>::Element *first_event = events->front();                          \
 		Ref<InputEventKey> event = first_event->get()->duplicate();                                   \
 		event->set_pressed(true);                                                                     \


### PR DESCRIPTION
Supersedes #60239 (based on the discussions on that PR and re implemented to support multiple carets)
Closes https://github.com/godotengine/godot-proposals/issues/10930

When the caret is set to the end of a line through `ui_text_caret_line_end` an internal state is kept in order to always keep the caret at the end of each line while is being moved through the different lines of the text. Also add a unit test for `CodeEdit` to check if END key state is kept on folding.
Also preventing a SIGEV when `SEND_GUI_ACTION` is called with a non existing action.

![EndKeyState](https://github.com/user-attachments/assets/45c2cdfa-86f0-4435-af4d-01507c11b086)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
