### PR TITLE
Add Conservative Rasterization support to RenderingDevice

### DIFF
--- a/doc/classes/RDPipelineRasterizationState.xml
+++ b/doc/classes/RDPipelineRasterizationState.xml
@@ -27,6 +27,9 @@
 		<member name="discard_primitives" type="bool" setter="set_discard_primitives" getter="get_discard_primitives" default="false">
 			If [code]true[/code], primitives are discarded immediately before the rasterization stage.
 		</member>
+		<member name="enable_conservative_rasterization" type="bool" setter="set_enable_conservative_rasterization" getter="get_enable_conservative_rasterization" default="false">
+			If [code]true[/code], primitive coverage is over-estimated during rasterization (any fragment containing part of the primitive will be included). May not be supported on all hardware.
+		</member>
 		<member name="enable_depth_clamp" type="bool" setter="set_enable_depth_clamp" getter="get_enable_depth_clamp" default="false">
 			If [code]true[/code], clamps depth values according to the minimum and maximum depth of the associated viewport.
 		</member>

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5634,7 +5634,7 @@ RDD::PipelineID RenderingDeviceDriverD3D12::render_pipeline_create(
 		(&pipeline_desc.RasterizerState)->SlopeScaledDepthBias = 0.0f;
 	}
 	(&pipeline_desc.RasterizerState)->ForcedSampleCount = 0;
-	(&pipeline_desc.RasterizerState)->ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
+	(&pipeline_desc.RasterizerState)->ConservativeRaster = p_rasterization_state.enable_conservative_rasterization ? D3D12_CONSERVATIVE_RASTERIZATION_MODE_ON : D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
 	(&pipeline_desc.RasterizerState)->MultisampleEnable = TEXTURE_SAMPLES_COUNT[p_multisample_state.sample_count] != 1;
 	(&pipeline_desc.RasterizerState)->AntialiasedLineEnable = true;
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -498,6 +498,7 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 	_register_requested_device_extension(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME, false);
 	_register_requested_device_extension(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME, false);
 	_register_requested_device_extension(VK_EXT_ASTC_DECODE_MODE_EXTENSION_NAME, false);
+	_register_requested_device_extension(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME, false);
 
 	if (Engine::get_singleton()->is_generate_spirv_debug_info_enabled()) {
 		_register_requested_device_extension(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME, true);
@@ -4584,6 +4585,17 @@ RDD::PipelineID RenderingDeviceDriverVulkan::render_pipeline_create(
 	rasterization_state_create_info.depthBiasClamp = p_rasterization_state.depth_bias_clamp;
 	rasterization_state_create_info.depthBiasSlopeFactor = p_rasterization_state.depth_bias_slope_factor;
 	rasterization_state_create_info.lineWidth = p_rasterization_state.line_width;
+
+	VkPipelineRasterizationConservativeStateCreateInfoEXT conservativeStateCreateInfoExt = {};
+	if (p_rasterization_state.enable_conservative_rasterization) {
+		if (enabled_device_extension_names.has(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME)) {
+			conservativeStateCreateInfoExt.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT;
+			conservativeStateCreateInfoExt.conservativeRasterizationMode = VkConservativeRasterizationModeEXT::VK_CONSERVATIVE_RASTERIZATION_MODE_OVERESTIMATE_EXT;
+			rasterization_state_create_info.pNext = &conservativeStateCreateInfoExt;
+		} else {
+			WARN_PRINT(vformat("enable_conservative_rasterization is true but %s is not available.", VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME));
+		}
+	}
 
 	// Multisample.
 	VkPipelineMultisampleStateCreateInfo multisample_state_create_info = {};

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -533,6 +533,7 @@ public:
 	RD_SETGET(float, depth_bias_slope_factor)
 	RD_SETGET(float, line_width)
 	RD_SETGET(uint32_t, patch_control_points)
+	RD_SETGET(bool, enable_conservative_rasterization)
 
 protected:
 	static void _bind_methods() {
@@ -547,6 +548,7 @@ protected:
 		RD_BIND(Variant::FLOAT, RDPipelineRasterizationState, depth_bias_slope_factor);
 		RD_BIND(Variant::FLOAT, RDPipelineRasterizationState, line_width);
 		RD_BIND(Variant::INT, RDPipelineRasterizationState, patch_control_points);
+		RD_BIND(Variant::BOOL, RDPipelineRasterizationState, enable_conservative_rasterization);
 	}
 };
 

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -666,6 +666,7 @@ public:
 		float depth_bias_slope_factor = 0.0f;
 		float line_width = 1.0f;
 		uint32_t patch_control_points = 1;
+		bool enable_conservative_rasterization = false;
 	};
 
 	struct PipelineMultisampleState {


### PR DESCRIPTION
This adds a new option `enable_conservative_rasterization` to RDPipelineRasterizationState.

In Vulkan this is implemented with `VK_EXT_conservative_rasterization` (which is optional).
In D3D12 no extra device options are needed.

Conservative Rasterization is not supported on all hardware (Metal, most mobile GPUs), currently no method is exposed to check for availability (this could be added as a `RenderingDevice::Features` flag, but these aren't exposed to user code anyway). Enabling conservative rasterization on unsupported hardware is a no-op.

Closes: https://github.com/godotengine/godot-proposals/issues/10927

[Example project for testing](https://github.com/user-attachments/files/17281085/conservative_raster_example.zip)

