### PR TITLE
[Codestyle] Set clang-format `RemoveSemicolon` rule to `true`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -183,7 +183,7 @@ PackConstructorInitializers: NextLine
 # ReflowComments: true
 # RemoveBracesLLVM: false
 # RemoveParentheses: Leave
-# RemoveSemicolon: false
+RemoveSemicolon: true
 # RequiresClausePosition: OwnLine
 # RequiresExpressionIndentation: OuterScope
 # SeparateDefinitionBlocks: Leave
@@ -231,7 +231,7 @@ SpacesInLineCommentPrefix:
 #   InEmptyParentheses: false
 #   Other: false
 # SpacesInSquareBrackets: false
-Standard: c++17
+Standard: c++20
 # StatementAttributeLikeMacros:
 #   - Q_EMIT
 # StatementMacros:

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -57,3 +57,6 @@ df61dc4b2bd54a5a40c515493c76f5a458e5b541
 
 # Style: Apply new `clang-format` fixes
 b37fc1014abf7adda70dc30b0822d775b3a4433f
+
+# Set clang-format `RemoveSemicolon` rule to `true`
+0d350e71086fffce0553811739aae9f6ad66136c

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     rev: v19.1.0
     hooks:
       - id: clang-format
-        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc|java|glsl)$
+        files: \.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|inc|java)$
         types_or: [text]
         exclude: |
           (?x)^(
@@ -20,6 +20,17 @@ repos:
             platform/android/java/editor/src/main/java/com/android/.*|
             platform/android/java/lib/src/com/.*
           )
+      - id: clang-format
+        name: clang-format-glsl
+        files: \.(glsl)$
+        types_or: [text]
+        exclude: |
+          (?x)^(
+            tests/python_build/.*|
+            platform/android/java/editor/src/main/java/com/android/.*|
+            platform/android/java/lib/src/com/.*
+          )
+        args: ["-style=file:misc/utility/.clang-format-glsl"]
 
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -468,11 +468,11 @@ Error OS::set_thread_name(const String &p_name) {
 
 ::Thread::ID OS::get_thread_caller_id() const {
 	return ::Thread::get_caller_id();
-};
+}
 
 ::Thread::ID OS::get_main_thread_id() const {
 	return ::Thread::get_main_id();
-};
+}
 
 bool OS::has_feature(const String &p_feature) const {
 	const bool *value_ptr = feature_cache.getptr(p_feature);

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -106,7 +106,7 @@ public:
 	_FORCE_INLINE_ static EngineDebugger *get_singleton() { return singleton; }
 	_FORCE_INLINE_ static bool is_active() { return singleton != nullptr && script_debugger != nullptr; }
 
-	_FORCE_INLINE_ static ScriptDebugger *get_script_debugger() { return script_debugger; };
+	_FORCE_INLINE_ static ScriptDebugger *get_script_debugger() { return script_debugger; }
 
 	static void initialize(const String &p_uri, bool p_skip_breakpoints, const Vector<String> &p_breakpoints, void (*p_allow_focus_steal_fn)());
 	static void deinitialize();

--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -96,8 +96,8 @@ public:
 
 	virtual bool file_exists(String p_file) = 0;
 	virtual bool dir_exists(String p_dir) = 0;
-	virtual bool is_readable(String p_dir) { return true; };
-	virtual bool is_writable(String p_dir) { return true; };
+	virtual bool is_readable(String p_dir) { return true; }
+	virtual bool is_writable(String p_dir) { return true; }
 	static bool exists(const String &p_dir);
 	virtual uint64_t get_space_left() = 0;
 

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -215,8 +215,8 @@ public:
 	static bool get_read_only_attribute(const String &p_file);
 	static Error set_read_only_attribute(const String &p_file, bool p_ro);
 
-	static void set_backup_save(bool p_enable) { backup_save = p_enable; };
-	static bool is_backup_save_enabled() { return backup_save; };
+	static void set_backup_save(bool p_enable) { backup_save = p_enable; }
+	static bool is_backup_save_enabled() { return backup_save; }
 
 	static String get_md5(const String &p_file);
 	static String get_sha256(const String &p_file);

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -51,7 +51,7 @@ struct _IP_ResolverPrivate {
 			response.clear();
 			type = IP::TYPE_NONE;
 			hostname = "";
-		};
+		}
 
 		QueueItem() {
 			clear();

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -222,7 +222,7 @@ public:
 	static ThreadLoadStatus load_threaded_get_status(const String &p_path, float *r_progress = nullptr);
 	static Ref<Resource> load_threaded_get(const String &p_path, Error *r_error = nullptr);
 
-	static bool is_within_load() { return load_nesting > 0; };
+	static bool is_within_load() { return load_nesting > 0; }
 
 	static void resource_changed_connect(Resource *p_source, const Callable &p_callable, uint32_t p_flags);
 	static void resource_changed_disconnect(Resource *p_source, const Callable &p_callable);

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -223,7 +223,7 @@ struct [[nodiscard]] Basis {
 
 	static Basis looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
 
-	Basis(const Quaternion &p_quaternion) { set_quaternion(p_quaternion); };
+	Basis(const Quaternion &p_quaternion) { set_quaternion(p_quaternion); }
 	Basis(const Quaternion &p_quaternion, const Vector3 &p_scale) { set_quaternion_scale(p_quaternion, p_scale); }
 
 	Basis(const Vector3 &p_axis, real_t p_angle) { set_axis_angle(p_axis, p_angle); }

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -76,7 +76,7 @@ struct _AtlasWorkRect {
 	Size2i s;
 	Point2i p;
 	int idx = 0;
-	_FORCE_INLINE_ bool operator<(const _AtlasWorkRect &p_r) const { return s.width > p_r.s.width; };
+	_FORCE_INLINE_ bool operator<(const _AtlasWorkRect &p_r) const { return s.width > p_r.s.width; }
 };
 
 struct _AtlasWorkRectResult {

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -40,7 +40,7 @@ struct [[nodiscard]] Plane {
 	real_t d = 0;
 
 	void set_normal(const Vector3 &p_normal);
-	_FORCE_INLINE_ Vector3 get_normal() const { return normal; };
+	_FORCE_INLINE_ Vector3 get_normal() const { return normal; }
 
 	void normalize();
 	Plane normalized() const;

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -109,7 +109,7 @@ public:
 	_FORCE_INLINE_ StringName get_instance_class() const { return instance_class; }
 	_FORCE_INLINE_ void set_instance_class(const StringName &p_class) { instance_class = p_class; }
 
-	_FORCE_INLINE_ int get_argument_count() const { return argument_count; };
+	_FORCE_INLINE_ int get_argument_count() const { return argument_count; }
 
 #ifdef TOOLS_ENABLED
 	virtual bool is_valid() const { return true; }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -685,22 +685,22 @@ protected:
 	_ALWAYS_INLINE_ const ObjectGDExtension *_get_extension() const { return _extension; }
 	_ALWAYS_INLINE_ GDExtensionClassInstancePtr _get_extension_instance() const { return _extension_instance; }
 	virtual void _initialize_classv() { initialize_class(); }
-	virtual bool _setv(const StringName &p_name, const Variant &p_property) { return false; };
-	virtual bool _getv(const StringName &p_name, Variant &r_property) const { return false; };
-	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const {};
-	virtual void _validate_propertyv(PropertyInfo &p_property) const {};
-	virtual bool _property_can_revertv(const StringName &p_name) const { return false; };
-	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_property) const { return false; };
+	virtual bool _setv(const StringName &p_name, const Variant &p_property) { return false; }
+	virtual bool _getv(const StringName &p_name, Variant &r_property) const { return false; }
+	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const {}
+	virtual void _validate_propertyv(PropertyInfo &p_property) const {}
+	virtual bool _property_can_revertv(const StringName &p_name) const { return false; }
+	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_property) const { return false; }
 	virtual void _notificationv(int p_notification, bool p_reversed) {}
 
 	static void _bind_methods();
 	static void _bind_compatibility_methods() {}
-	bool _set(const StringName &p_name, const Variant &p_property) { return false; };
-	bool _get(const StringName &p_name, Variant &r_property) const { return false; };
-	void _get_property_list(List<PropertyInfo> *p_list) const {};
-	void _validate_property(PropertyInfo &p_property) const {};
-	bool _property_can_revert(const StringName &p_name) const { return false; };
-	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; };
+	bool _set(const StringName &p_name, const Variant &p_property) { return false; }
+	bool _get(const StringName &p_name, Variant &r_property) const { return false; }
+	void _get_property_list(List<PropertyInfo> *p_list) const {}
+	void _validate_property(PropertyInfo &p_property) const {}
+	bool _property_can_revert(const StringName &p_name) const { return false; }
+	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return false; }
 	void _notification(int p_notification) {}
 
 	_FORCE_INLINE_ static void (*_get_bind_methods())() {

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -446,8 +446,8 @@ public:
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = nullptr) const override;
 	virtual void validate_property(PropertyInfo &p_property) const override {}
 
-	virtual bool property_can_revert(const StringName &p_name) const override { return false; };
-	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const override { return false; };
+	virtual bool property_can_revert(const StringName &p_name) const override { return false; }
+	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const override { return false; }
 
 	virtual void get_method_list(List<MethodInfo> *p_list) const override;
 	virtual bool has_method(const StringName &p_method) const override;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -176,14 +176,14 @@ public:
 	void set_delta_smoothing(bool p_enabled);
 	bool is_delta_smoothing_enabled() const;
 
-	virtual Vector<String> get_system_fonts() const { return Vector<String>(); };
-	virtual String get_system_font_path(const String &p_font_name, int p_weight = 400, int p_stretch = 100, bool p_italic = false) const { return String(); };
-	virtual Vector<String> get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale = String(), const String &p_script = String(), int p_weight = 400, int p_stretch = 100, bool p_italic = false) const { return Vector<String>(); };
+	virtual Vector<String> get_system_fonts() const { return Vector<String>(); }
+	virtual String get_system_font_path(const String &p_font_name, int p_weight = 400, int p_stretch = 100, bool p_italic = false) const { return String(); }
+	virtual Vector<String> get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale = String(), const String &p_script = String(), int p_weight = 400, int p_stretch = 100, bool p_italic = false) const { return Vector<String>(); }
 	virtual String get_executable_path() const;
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false) = 0;
 	virtual Dictionary execute_with_pipe(const String &p_path, const List<String> &p_arguments, bool p_blocking = true) { return Dictionary(); }
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) = 0;
-	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) { return create_process(get_executable_path(), p_arguments, r_child_id); };
+	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) { return create_process(get_executable_path(), p_arguments, r_child_id); }
 	virtual Error kill(const ProcessID &p_pid) = 0;
 	virtual int get_process_id() const;
 	virtual bool is_process_running(const ProcessID &p_pid) const = 0;

--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -123,7 +123,7 @@ String TranslationDomain::_double_vowels(const String &p_message) const {
 		}
 	}
 	return res;
-};
+}
 
 String TranslationDomain::_replace_with_accented_string(const String &p_message) const {
 	String res;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -118,7 +118,7 @@ public:
 	Char16String &operator+=(char16_t p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char16_t *get_data() const;
-	operator const char16_t *() const { return get_data(); };
+	operator const char16_t *() const { return get_data(); }
 
 protected:
 	void copy_from(const char16_t *p_cstr);
@@ -160,7 +160,7 @@ public:
 	CharString &operator+=(char p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char *get_data() const;
-	operator const char *() const { return get_data(); };
+	operator const char *() const { return get_data(); }
 
 protected:
 	void copy_from(const char *p_cstr);

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -241,7 +241,7 @@ public:
 
 	_FORCE_INLINE_ CowData() {}
 	_FORCE_INLINE_ ~CowData();
-	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); };
+	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); }
 };
 
 template <typename T>

--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -89,7 +89,7 @@ public:
 		CRASH_COND(!e);
 		_list.move_to_front(*e);
 		return (*e)->get().data;
-	};
+	}
 
 	const TData *getptr(const TKey &p_key) {
 		Element *e = _map.getptr(p_key);

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -76,7 +76,7 @@ public:
 		}
 		const T &get() const {
 			return value;
-		};
+		}
 		Element() {}
 	};
 

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -315,4 +315,6 @@ struct BuildIndexSequence<0, Is...> : IndexSequence<Is...> {};
 #define ___gd_is_defined(val) ____gd_is_defined(__GDARG_PLACEHOLDER_##val)
 #define GD_IS_DEFINED(x) ___gd_is_defined(x)
 
+#define FORCE_SEMICOLON ;
+
 #endif // TYPEDEFS_H

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -89,7 +89,7 @@ class AudioDriverCoreAudio : public AudioDriver {
 public:
 	virtual const char *get_name() const override {
 		return "CoreAudio";
-	};
+	}
 
 	virtual Error init() override;
 	virtual void start() override;

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -6585,7 +6585,7 @@ static Error create_command_signature(ID3D12Device *device, D3D12_INDIRECT_ARGUM
 	HRESULT res = device->CreateCommandSignature(&cs_desc, nullptr, IID_PPV_ARGS(r_cmd_sig->GetAddressOf()));
 	ERR_FAIL_COND_V_MSG(!SUCCEEDED(res), ERR_CANT_CREATE, "CreateCommandSignature failed with error " + vformat("0x%08ux", (uint64_t)res) + ".");
 	return OK;
-};
+}
 
 Error RenderingDeviceDriverD3D12::_initialize_frames(uint32_t p_frame_count) {
 	Error err;

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -110,7 +110,7 @@ public:
 	PFNEGLIMAGETARGETTEXTURE2DOESPROC eglEGLImageTargetTexture2DOES = nullptr;
 #endif
 
-	static Config *get_singleton() { return singleton; };
+	static Config *get_singleton() { return singleton; }
 
 	Config();
 	~Config();

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -306,8 +306,8 @@ public:
 
 	/* Light API */
 
-	Light *get_light(RID p_rid) { return light_owner.get_or_null(p_rid); };
-	bool owns_light(RID p_rid) { return light_owner.owns(p_rid); };
+	Light *get_light(RID p_rid) { return light_owner.get_or_null(p_rid); }
+	bool owns_light(RID p_rid) { return light_owner.owns(p_rid); }
 
 	void _light_initialize(RID p_rid, RS::LightType p_type);
 
@@ -434,8 +434,8 @@ public:
 
 	/* LIGHT INSTANCE API */
 
-	LightInstance *get_light_instance(RID p_rid) { return light_instance_owner.get_or_null(p_rid); };
-	bool owns_light_instance(RID p_rid) { return light_instance_owner.owns(p_rid); };
+	LightInstance *get_light_instance(RID p_rid) { return light_instance_owner.get_or_null(p_rid); }
+	bool owns_light_instance(RID p_rid) { return light_instance_owner.owns(p_rid); }
 
 	virtual RID light_instance_create(RID p_light) override;
 	virtual void light_instance_free(RID p_light_instance) override;
@@ -633,8 +633,8 @@ public:
 
 	/* PROBE API */
 
-	ReflectionProbe *get_reflection_probe(RID p_rid) { return reflection_probe_owner.get_or_null(p_rid); };
-	bool owns_reflection_probe(RID p_rid) { return reflection_probe_owner.owns(p_rid); };
+	ReflectionProbe *get_reflection_probe(RID p_rid) { return reflection_probe_owner.get_or_null(p_rid); }
+	bool owns_reflection_probe(RID p_rid) { return reflection_probe_owner.owns(p_rid); }
 
 	virtual RID reflection_probe_allocate() override;
 	virtual void reflection_probe_initialize(RID p_rid) override;
@@ -715,8 +715,8 @@ public:
 
 	/* LIGHTMAP CAPTURE */
 
-	Lightmap *get_lightmap(RID p_rid) { return lightmap_owner.get_or_null(p_rid); };
-	bool owns_lightmap(RID p_rid) { return lightmap_owner.owns(p_rid); };
+	Lightmap *get_lightmap(RID p_rid) { return lightmap_owner.get_or_null(p_rid); }
+	bool owns_lightmap(RID p_rid) { return lightmap_owner.owns(p_rid); }
 
 	virtual RID lightmap_allocate() override;
 	virtual void lightmap_initialize(RID p_rid) override;
@@ -739,15 +739,15 @@ public:
 
 	/* LIGHTMAP INSTANCE */
 
-	LightmapInstance *get_lightmap_instance(RID p_rid) { return lightmap_instance_owner.get_or_null(p_rid); };
-	bool owns_lightmap_instance(RID p_rid) { return lightmap_instance_owner.owns(p_rid); };
+	LightmapInstance *get_lightmap_instance(RID p_rid) { return lightmap_instance_owner.get_or_null(p_rid); }
+	bool owns_lightmap_instance(RID p_rid) { return lightmap_instance_owner.owns(p_rid); }
 
 	virtual RID lightmap_instance_create(RID p_lightmap) override;
 	virtual void lightmap_instance_free(RID p_lightmap) override;
 	virtual void lightmap_instance_set_transform(RID p_lightmap, const Transform3D &p_transform) override;
 
 	/* SHADOW ATLAS API */
-	bool owns_shadow_atlas(RID p_rid) { return shadow_atlas_owner.owns(p_rid); };
+	bool owns_shadow_atlas(RID p_rid) { return shadow_atlas_owner.owns(p_rid); }
 
 	virtual RID shadow_atlas_create() override;
 	virtual void shadow_atlas_free(RID p_atlas) override;

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -576,8 +576,8 @@ public:
 
 	/* SHADER API */
 
-	Shader *get_shader(RID p_rid) { return shader_owner.get_or_null(p_rid); };
-	bool owns_shader(RID p_rid) { return shader_owner.owns(p_rid); };
+	Shader *get_shader(RID p_rid) { return shader_owner.get_or_null(p_rid); }
+	bool owns_shader(RID p_rid) { return shader_owner.owns(p_rid); }
 
 	void _shader_make_dirty(Shader *p_shader);
 
@@ -598,8 +598,8 @@ public:
 
 	/* MATERIAL API */
 
-	Material *get_material(RID p_rid) { return material_owner.get_or_null(p_rid); };
-	bool owns_material(RID p_rid) { return material_owner.owns(p_rid); };
+	Material *get_material(RID p_rid) { return material_owner.get_or_null(p_rid); }
+	bool owns_material(RID p_rid) { return material_owner.owns(p_rid); }
 
 	void _material_queue_update(Material *material, bool p_uniform, bool p_texture);
 	void _update_queued_materials();

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -280,8 +280,8 @@ public:
 
 	/* MESH API */
 
-	Mesh *get_mesh(RID p_rid) { return mesh_owner.get_or_null(p_rid); };
-	bool owns_mesh(RID p_rid) { return mesh_owner.owns(p_rid); };
+	Mesh *get_mesh(RID p_rid) { return mesh_owner.get_or_null(p_rid); }
+	bool owns_mesh(RID p_rid) { return mesh_owner.owns(p_rid); }
 
 	virtual RID mesh_allocate() override;
 	virtual void mesh_initialize(RID p_rid) override;
@@ -443,8 +443,8 @@ public:
 
 	/* MESH INSTANCE API */
 
-	MeshInstance *get_mesh_instance(RID p_rid) { return mesh_instance_owner.get_or_null(p_rid); };
-	bool owns_mesh_instance(RID p_rid) { return mesh_instance_owner.owns(p_rid); };
+	MeshInstance *get_mesh_instance(RID p_rid) { return mesh_instance_owner.get_or_null(p_rid); }
+	bool owns_mesh_instance(RID p_rid) { return mesh_instance_owner.owns(p_rid); }
 
 	virtual RID mesh_instance_create(RID p_base) override;
 	virtual void mesh_instance_free(RID p_rid) override;
@@ -492,8 +492,8 @@ public:
 
 	/* MULTIMESH API */
 
-	MultiMesh *get_multimesh(RID p_rid) { return multimesh_owner.get_or_null(p_rid); };
-	bool owns_multimesh(RID p_rid) { return multimesh_owner.owns(p_rid); };
+	MultiMesh *get_multimesh(RID p_rid) { return multimesh_owner.get_or_null(p_rid); }
+	bool owns_multimesh(RID p_rid) { return multimesh_owner.owns(p_rid); }
 
 	virtual RID _multimesh_allocate() override;
 	virtual void _multimesh_initialize(RID p_rid) override;
@@ -571,8 +571,8 @@ public:
 
 	/* SKELETON API */
 
-	Skeleton *get_skeleton(RID p_rid) { return skeleton_owner.get_or_null(p_rid); };
-	bool owns_skeleton(RID p_rid) { return skeleton_owner.owns(p_rid); };
+	Skeleton *get_skeleton(RID p_rid) { return skeleton_owner.get_or_null(p_rid); }
+	bool owns_skeleton(RID p_rid) { return skeleton_owner.owns(p_rid); }
 
 	virtual RID skeleton_allocate() override;
 	virtual void skeleton_initialize(RID p_rid) override;

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2452,7 +2452,7 @@ Point2i TextureStorage::render_target_get_position(RID p_render_target) const {
 	ERR_FAIL_NULL_V(rt, Point2i());
 
 	return rt->position;
-};
+}
 
 void TextureStorage::render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -478,8 +478,8 @@ public:
 
 	/* Canvas Texture API */
 
-	CanvasTexture *get_canvas_texture(RID p_rid) { return canvas_texture_owner.get_or_null(p_rid); };
-	bool owns_canvas_texture(RID p_rid) { return canvas_texture_owner.owns(p_rid); };
+	CanvasTexture *get_canvas_texture(RID p_rid) { return canvas_texture_owner.get_or_null(p_rid); }
+	bool owns_canvas_texture(RID p_rid) { return canvas_texture_owner.owns(p_rid); }
 
 	virtual RID canvas_texture_allocate() override;
 	virtual void canvas_texture_initialize(RID p_rid) override;
@@ -499,8 +499,8 @@ public:
 			return texture_owner.get_or_null(texture->proxy_to);
 		}
 		return texture;
-	};
-	bool owns_texture(RID p_rid) { return texture_owner.owns(p_rid); };
+	}
+	bool owns_texture(RID p_rid) { return texture_owner.owns(p_rid); }
 
 	void texture_2d_initialize_from_texture(RID p_texture, Texture &p_tex) {
 		texture_owner.initialize_rid(p_texture, p_tex);
@@ -618,8 +618,8 @@ public:
 
 	static GLuint system_fbo;
 
-	RenderTarget *get_render_target(RID p_rid) { return render_target_owner.get_or_null(p_rid); };
-	bool owns_render_target(RID p_rid) { return render_target_owner.owns(p_rid); };
+	RenderTarget *get_render_target(RID p_rid) { return render_target_owner.get_or_null(p_rid); }
+	bool owns_render_target(RID p_rid) { return render_target_owner.owns(p_rid); }
 
 	void check_backbuffer(RenderTarget *rt, const bool uses_screen_texture, const bool uses_depth_texture);
 

--- a/drivers/gles3/storage/utilities.h
+++ b/drivers/gles3/storage/utilities.h
@@ -165,8 +165,8 @@ public:
 
 	/* VISIBILITY NOTIFIER */
 
-	VisibilityNotifier *get_visibility_notifier(RID p_rid) { return visibility_notifier_owner.get_or_null(p_rid); };
-	bool owns_visibility_notifier(RID p_rid) const { return visibility_notifier_owner.owns(p_rid); };
+	VisibilityNotifier *get_visibility_notifier(RID p_rid) { return visibility_notifier_owner.get_or_null(p_rid); }
+	bool owns_visibility_notifier(RID p_rid) const { return visibility_notifier_owner.owns(p_rid); }
 
 	virtual RID visibility_notifier_allocate() override;
 	virtual void visibility_notifier_initialize(RID p_notifier) override;

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -841,7 +841,7 @@ public:
 				if (!enabled)
 					return;
 				[p_enc setStencilFrontReferenceValue:front_reference backReferenceValue:back_reference];
-			};
+			}
 		} stencil;
 
 		struct {
@@ -855,7 +855,7 @@ public:
 				//if (!enabled)
 				//	return;
 				[p_enc setBlendColorRed:r green:g blue:b alpha:a];
-			};
+			}
 		} blend;
 
 		_FORCE_INLINE_ void apply(id<MTLRenderCommandEncoder> __unsafe_unretained p_enc) const {

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -410,7 +410,7 @@ public:
 	virtual uint64_t api_trait_get(ApiTrait p_trait) override final;
 	virtual bool has_feature(Features p_feature) override final;
 	virtual const MultiviewCapabilities &get_multiview_capabilities() override final;
-	virtual String get_api_name() const override final { return "Metal"; };
+	virtual String get_api_name() const override final { return "Metal"; }
 	virtual String get_api_version() const override final;
 	virtual String get_pipeline_cache_uuid() const override final;
 	virtual const Capabilities &get_capabilities() const override final;

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -100,7 +100,7 @@ class AudioDriverPulseAudio : public AudioDriver {
 public:
 	virtual const char *get_name() const override {
 		return "PulseAudio";
-	};
+	}
 
 	virtual Error init() override;
 	virtual void start() override;

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -85,7 +85,7 @@ public:
 			_In_ const WAVEFORMATEX *pFormat,
 			/* [annotation][in] */
 			_In_opt_ LPCGUID AudioSessionGuid) = 0;
-};
+}
 __CRT_UUID_DECL(IAudioClient3, 0x7ED4EE07, 0x8E67, 0x4CD4, 0x8C, 0x1A, 0x2B, 0x7A, 0x59, 0x87, 0xAD, 0x42)
 
 #endif // __IAudioClient3_INTERFACE_DEFINED__

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -716,7 +716,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	struct SelectedKey {
 		int track = 0;
 		int key = 0;
-		bool operator<(const SelectedKey &p_key) const { return track == p_key.track ? key < p_key.key : track < p_key.track; };
+		bool operator<(const SelectedKey &p_key) const { return track == p_key.track ? key < p_key.key : track < p_key.track; }
 	};
 
 	struct KeyInfo {

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -48,7 +48,7 @@ public:
 	List<PropertyInfo> prop_list;
 	HashMap<StringName, Variant> prop_values;
 
-	ObjectID get_remote_object_id() { return remote_object_id; };
+	ObjectID get_remote_object_id() { return remote_object_id; }
 	String get_title();
 
 	Variant get_variant(const StringName &p_name);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -932,7 +932,7 @@ public:
 	void dim_editor(bool p_dimming);
 	bool is_editor_dimmed() const;
 
-	void edit_current() { _edit_current(); };
+	void edit_current() { _edit_current(); }
 
 	bool has_scenes_in_session();
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2638,7 +2638,7 @@ EditorPropertyColor::EditorPropertyColor() {
 void EditorPropertyNodePath::_set_read_only(bool p_read_only) {
 	assign->set_disabled(p_read_only);
 	menu->set_disabled(p_read_only);
-};
+}
 
 Variant EditorPropertyNodePath::_get_cache_value(const StringName &p_prop, bool &r_valid) const {
 	if (p_prop == get_edited_property()) {

--- a/editor/export/codesign.h
+++ b/editor/export/codesign.h
@@ -166,7 +166,7 @@ public:
 
 	virtual int get_size() const override;
 
-	virtual uint32_t get_index_type() const override { return 0x00000002; };
+	virtual uint32_t get_index_type() const override { return 0x00000002; }
 	virtual void write_to_file(Ref<FileAccess> p_file) const override;
 };
 
@@ -188,7 +188,7 @@ public:
 
 	virtual int get_size() const override;
 
-	virtual uint32_t get_index_type() const override { return 0x00000005; };
+	virtual uint32_t get_index_type() const override { return 0x00000005; }
 	virtual void write_to_file(Ref<FileAccess> p_file) const override;
 };
 
@@ -210,7 +210,7 @@ public:
 
 	virtual int get_size() const override;
 
-	virtual uint32_t get_index_type() const override { return 0x00000007; };
+	virtual uint32_t get_index_type() const override { return 0x00000007; }
 	virtual void write_to_file(Ref<FileAccess> p_file) const override;
 };
 
@@ -311,7 +311,7 @@ public:
 	virtual PackedByteArray get_hash_sha256() const override;
 
 	virtual int get_size() const override;
-	virtual uint32_t get_index_type() const override { return 0x00000000; };
+	virtual uint32_t get_index_type() const override { return 0x00000000; }
 
 	virtual void write_to_file(Ref<FileAccess> p_file) const override;
 };
@@ -330,7 +330,7 @@ public:
 	virtual PackedByteArray get_hash_sha256() const override;
 
 	virtual int get_size() const override;
-	virtual uint32_t get_index_type() const override { return 0x00010000; };
+	virtual uint32_t get_index_type() const override { return 0x00010000; }
 
 	virtual void write_to_file(Ref<FileAccess> p_file) const override;
 };

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -216,7 +216,7 @@ public:
 
 	Ref<EditorExportPreset> get_current_preset() const;
 
-	bool is_exporting() const { return exporting; };
+	bool is_exporting() const { return exporting; }
 
 	ProjectExportDialog();
 	~ProjectExportDialog();

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -402,7 +402,7 @@ public:
 	FileSortOption get_file_sort() const { return file_sort; }
 
 	void set_file_list_display_mode(FileListDisplayMode p_mode);
-	FileListDisplayMode get_file_list_display_mode() const { return file_list_display_mode; };
+	FileListDisplayMode get_file_list_display_mode() const { return file_list_display_mode; }
 
 	Tree *get_tree_control() { return tree; }
 

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -350,7 +350,7 @@ void EditorFileDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 
 void EditorFileDialog::set_enable_multiple_selection(bool p_enable) {
 	item_list->set_select_mode(p_enable ? ItemList::SELECT_MULTI : ItemList::SELECT_SINGLE);
-};
+}
 
 Vector<String> EditorFileDialog::get_selected_files() const {
 	Vector<String> list;
@@ -360,7 +360,7 @@ Vector<String> EditorFileDialog::get_selected_files() const {
 		}
 	}
 	return list;
-};
+}
 
 void EditorFileDialog::update_dir() {
 	if (drives->is_visible()) {

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -566,7 +566,7 @@ EditorToaster::EditorToaster() {
 
 	eh.errfunc = _error_handler;
 	add_error_handler(&eh);
-};
+}
 
 EditorToaster::~EditorToaster() {
 	singleton = nullptr;

--- a/editor/import/3d/collada.h
+++ b/editor/import/3d/collada.h
@@ -359,7 +359,7 @@ public:
 			for (int i = 0; i < children.size(); i++) {
 				memdelete(children[i]);
 			}
-		};
+		}
 	};
 
 	struct NodeSkeleton : public Node {

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -113,7 +113,7 @@ class InspectorDock : public VBoxContainer {
 
 	void _new_resource();
 	void _load_resource(const String &p_type = "");
-	void _open_resource_selector() { _load_resource(); }; // just used to call from arg-less signal
+	void _open_resource_selector() { _load_resource(); } // just used to call from arg-less signal
 	void _resource_file_selected(const String &p_file);
 	void _save_resource(bool save_as);
 	void _unref_resource();

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1397,7 +1397,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_timeline_o
 	}
 
 	track_editor->set_anim_pos(pos);
-};
+}
 
 void AnimationPlayerEditor::_animation_player_changed(Object *p_pl) {
 	_update_player();

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -157,7 +157,7 @@ ControlPositioningWarning::ControlPositioningWarning() {
 
 void EditorPropertyAnchorsPreset::_set_read_only(bool p_read_only) {
 	options->set_disabled(p_read_only);
-};
+}
 
 void EditorPropertyAnchorsPreset::_option_selected(int p_which) {
 	int64_t val = options->get_item_metadata(p_which);
@@ -221,7 +221,7 @@ void EditorPropertySizeFlags::_set_read_only(bool p_read_only) {
 		check->set_disabled(p_read_only);
 	}
 	flag_presets->set_disabled(p_read_only);
-};
+}
 
 void EditorPropertySizeFlags::_preset_selected(int p_which) {
 	int preset = flag_presets->get_item_id(p_which);

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -241,7 +241,7 @@ protected:
 	static ControlEditorToolbar *singleton;
 
 public:
-	bool is_anchors_mode_enabled() { return anchors_mode; };
+	bool is_anchors_mode_enabled() { return anchors_mode; }
 
 	static ControlEditorToolbar *get_singleton() { return singleton; }
 

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -168,7 +168,7 @@ protected:
 
 	virtual Vector2 _get_offset(int p_idx) const override;
 
-	virtual bool _has_uv() const override { return true; };
+	virtual bool _has_uv() const override { return true; }
 	virtual void _commit_action() override;
 
 	void _notification(int p_what);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -351,12 +351,12 @@ void Skeleton3DEditor::set_keyable(const bool p_keyable) {
 	} else {
 		animation_hb->hide();
 	}
-};
+}
 
 void Skeleton3DEditor::set_bone_options_enabled(const bool p_bone_options_enabled) {
 	skeleton_options->get_popup()->set_item_disabled(SKELETON_OPTION_RESET_SELECTED_POSES, !p_bone_options_enabled);
 	skeleton_options->get_popup()->set_item_disabled(SKELETON_OPTION_SELECTED_POSES_TO_RESTS, !p_bone_options_enabled);
-};
+}
 
 void Skeleton3DEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("update_all"), &Skeleton3DEditor::update_all);

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -228,14 +228,14 @@ public:
 
 	void move_skeleton_bone(NodePath p_skeleton_path, int32_t p_selected_boneidx, int32_t p_target_boneidx);
 
-	Skeleton3D *get_skeleton() const { return skeleton; };
+	Skeleton3D *get_skeleton() const { return skeleton; }
 
 	bool is_edit_mode() const { return edit_mode; }
 
 	void update_bone_original();
-	Vector3 get_bone_original_position() const { return bone_original_position; };
-	Quaternion get_bone_original_rotation() const { return bone_original_rotation; };
-	Vector3 get_bone_original_scale() const { return bone_original_scale; };
+	Vector3 get_bone_original_position() const { return bone_original_position; }
+	Quaternion get_bone_original_rotation() const { return bone_original_rotation; }
+	Vector3 get_bone_original_scale() const { return bone_original_scale; }
 
 	Skeleton3DEditor(EditorInspectorPluginSkeleton *e_plugin, Skeleton3D *skeleton);
 	~Skeleton3DEditor();

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -496,13 +496,13 @@ void TileAtlasView::set_atlas_source(TileSet *p_tile_set, TileSetAtlasSource *p_
 
 float TileAtlasView::get_zoom() const {
 	return zoom_widget->get_zoom();
-};
+}
 
 void TileAtlasView::set_transform(float p_zoom, Vector2i p_panning) {
 	zoom_widget->set_zoom(p_zoom);
 	panning = p_panning;
 	_update_zoom_and_panning();
-};
+}
 
 void TileAtlasView::set_padding(Side p_side, int p_padding) {
 	ERR_FAIL_COND(p_padding < 0);

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -135,8 +135,8 @@ public:
 	void set_padding(Side p_side, int p_padding);
 
 	// Left side.
-	void set_texture_grid_visible(bool p_visible) { base_tiles_texture_grid->set_visible(p_visible); };
-	void set_tile_shape_grid_visible(bool p_visible) { base_tiles_shape_grid->set_visible(p_visible); };
+	void set_texture_grid_visible(bool p_visible) { base_tiles_texture_grid->set_visible(p_visible); }
+	void set_tile_shape_grid_visible(bool p_visible) { base_tiles_shape_grid->set_visible(p_visible); }
 
 	Vector2i get_atlas_tile_coords_at_pos(const Vector2 p_pos, bool p_clamp = false) const;
 
@@ -148,7 +148,7 @@ public:
 		}
 		p_control->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 		p_control->set_mouse_filter(Control::MOUSE_FILTER_PASS);
-	};
+	}
 
 	// Right side.
 	Vector3i get_alternative_tile_at_pos(const Vector2 p_pos) const;
@@ -162,7 +162,7 @@ public:
 		}
 		p_control->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 		p_control->set_mouse_filter(Control::MOUSE_FILTER_PASS);
-	};
+	}
 
 	// Redraw everything.
 	void queue_redraw();

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -1100,11 +1100,10 @@ void TileDataDefaultEditor::forward_draw_over_atlas(TileAtlasView *p_tile_atlas_
 		}
 		p_canvas_item->draw_set_transform_matrix(Transform2D());
 	}
-};
+}
 
 void TileDataDefaultEditor::forward_draw_over_alternatives(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_set_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) {
-
-};
+}
 
 void TileDataDefaultEditor::forward_painting_atlas_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_set_atlas_source, const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseMotion> mm = p_event;

--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -62,7 +62,7 @@ public:
 	void set_tile_set(Ref<TileSet> p_tile_set);
 
 	// Input to handle painting.
-	virtual Control *get_toolbar() { return nullptr; };
+	virtual Control *get_toolbar() { return nullptr; }
 	virtual void forward_draw_over_atlas(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) {}
 	virtual void forward_draw_over_alternatives(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) {}
 	virtual void forward_painting_atlas_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, const Ref<InputEvent> &p_event) {}
@@ -238,7 +238,7 @@ protected:
 	virtual void _setup_undo_redo_action(TileSetAtlasSource *p_tile_set_atlas_source, const HashMap<TileMapCell, Variant, TileMapCell> &p_previous_values, const Variant &p_new_value);
 
 public:
-	virtual Control *get_toolbar() override { return toolbar; };
+	virtual Control *get_toolbar() override { return toolbar; }
 	virtual void forward_draw_over_atlas(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) override;
 	virtual void forward_draw_over_alternatives(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) override;
 	virtual void forward_painting_atlas_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, const Ref<InputEvent> &p_event) override;
@@ -375,7 +375,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual Control *get_toolbar() override { return toolbar; };
+	virtual Control *get_toolbar() override { return toolbar; }
 	virtual void forward_draw_over_atlas(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) override;
 	virtual void forward_draw_over_alternatives(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) override;
 	virtual void forward_painting_atlas_gui_input(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_atlas_source, const Ref<InputEvent> &p_event) override;

--- a/editor/plugins/tiles/tile_map_layer_editor.h
+++ b/editor/plugins/tiles/tile_map_layer_editor.h
@@ -63,9 +63,9 @@ public:
 
 	virtual Vector<TabData> get_tabs() const {
 		return Vector<TabData>();
-	};
+	}
 
-	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return false; };
+	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return false; }
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) {}
 	virtual void tile_set_changed() {}
 	virtual void edit(ObjectID p_tile_map_layer_id) {}

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -80,7 +80,7 @@ public:
 		int get_id() const;
 
 		void edit(Ref<TileSet> p_tile_set, Ref<TileSetAtlasSource> p_tile_set_atlas_source, int p_source_id);
-		Ref<TileSetAtlasSource> get_edited() { return tile_set_atlas_source; };
+		Ref<TileSetAtlasSource> get_edited() { return tile_set_atlas_source; }
 	};
 
 	// -- Proxy object for a tile, needed by the inspector --
@@ -101,8 +101,8 @@ public:
 		static void _bind_methods();
 
 	public:
-		Ref<TileSetAtlasSource> get_edited_tile_set_atlas_source() const { return tile_set_atlas_source; };
-		RBSet<TileSelection> get_edited_tiles() const { return tiles; };
+		Ref<TileSetAtlasSource> get_edited_tile_set_atlas_source() const { return tile_set_atlas_source; }
+		RBSet<TileSelection> get_edited_tiles() const { return tiles; }
 
 		// Update the proxyed object.
 		void edit(Ref<TileSetAtlasSource> p_tile_set_atlas_source, const RBSet<TileSelection> &p_tiles = RBSet<TileSelection>());

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1270,7 +1270,7 @@ bool ProjectConverter3To4::test_single_array(const char *p_array[][2], bool p_ig
 		}
 	}
 	return valid;
-};
+}
 
 // Returns arguments from given function execution, this cannot be really done as regex.
 // `abc(d,e(f,g),h)` -> [d], [e(f,g)], [h]
@@ -1469,7 +1469,7 @@ void ProjectConverter3To4::rename_colors(Vector<SourceLine> &source_lines, const
 			}
 		}
 	}
-};
+}
 
 // Convert hexadecimal colors from ARGB to RGBA
 void ProjectConverter3To4::convert_hexadecimal_colors(Vector<SourceLine> &source_lines, const RegExContainer &reg_container) {
@@ -1566,7 +1566,7 @@ void ProjectConverter3To4::rename_classes(Vector<SourceLine> &source_lines, cons
 			}
 		}
 	}
-};
+}
 
 Vector<String> ProjectConverter3To4::check_for_rename_classes(Vector<String> &lines, const RegExContainer &reg_container) {
 	Vector<String> found_renames;
@@ -1618,7 +1618,7 @@ void ProjectConverter3To4::rename_gdscript_functions(Vector<SourceLine> &source_
 			process_gdscript_line(line, reg_container, builtin);
 		}
 	}
-};
+}
 
 Vector<String> ProjectConverter3To4::check_for_rename_gdscript_functions(Vector<String> &lines, const RegExContainer &reg_container, bool builtin) {
 	int current_line = 1;
@@ -2438,7 +2438,7 @@ void ProjectConverter3To4::rename_csharp_functions(Vector<SourceLine> &source_li
 			process_csharp_line(line, reg_container);
 		}
 	}
-};
+}
 
 Vector<String> ProjectConverter3To4::check_for_rename_csharp_functions(Vector<String> &lines, const RegExContainer &reg_container) {
 	int current_line = 1;
@@ -2847,7 +2847,7 @@ void ProjectConverter3To4::custom_rename(Vector<SourceLine> &source_lines, const
 			line = reg.sub(line, to, true);
 		}
 	}
-};
+}
 
 Vector<String> ProjectConverter3To4::check_for_custom_rename(Vector<String> &lines, const String &from, const String &to) {
 	Vector<String> found_renames;

--- a/editor/rename_dialog.h
+++ b/editor/rename_dialog.h
@@ -49,7 +49,7 @@ class TabContainer;
 class RenameDialog : public ConfirmationDialog {
 	GDCLASS(RenameDialog, ConfirmationDialog);
 
-	virtual void ok_pressed() override { rename(); };
+	virtual void ok_pressed() override { rename(); }
 	void _cancel_pressed() {}
 	void _features_toggled(bool pressed);
 	void _insert_text(const String &text);

--- a/editor/surface_upgrade_tool.h
+++ b/editor/surface_upgrade_tool.h
@@ -54,9 +54,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	static SurfaceUpgradeTool *get_singleton() { return singleton; };
+	static SurfaceUpgradeTool *get_singleton() { return singleton; }
 
-	bool is_show_requested() const { return show_requested; };
+	bool is_show_requested() const { return show_requested; }
 	void show_popup() { _show_popup(); }
 
 	void prepare_upgrade();

--- a/editor/themes/editor_color_map.h
+++ b/editor/themes/editor_color_map.h
@@ -50,8 +50,8 @@ public:
 	static void add_conversion_color_pair(const String &p_from_color, const String &p_to_color);
 	static void add_conversion_exception(const StringName &p_icon_name);
 
-	static HashMap<Color, Color> &get_color_conversion_map() { return color_conversion_map; };
-	static HashSet<StringName> &get_color_conversion_exceptions() { return color_conversion_exceptions; };
+	static HashMap<Color, Color> &get_color_conversion_map() { return color_conversion_map; }
+	static HashSet<StringName> &get_color_conversion_exceptions() { return color_conversion_exceptions; }
 
 	static void create();
 	static void finish();

--- a/misc/utility/.clang-format-glsl
+++ b/misc/utility/.clang-format-glsl
@@ -1,0 +1,42 @@
+# GLSL-specific rules.
+# The rules should be the same as .clang-format, except those explicitly mentioned.
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignOperands: DontAlign
+AlignTrailingComments:
+  Kind: Never
+  OverEmptyLines: 0
+AllowAllParametersOfDeclarationOnNextLine: false
+BreakConstructorInitializers: AfterColon
+ColumnLimit: 0
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: false
+IncludeCategories:
+  - Regex: ^".*"$
+    Priority: 1
+  - Regex: ^<.*\.h>$
+    Priority: 2
+  - Regex: ^<.*>$
+    Priority: 3
+IndentCaseLabels: true
+IndentWidth: 4
+JavaImportGroups:
+  - org.godotengine
+  - android
+  - androidx
+  - com.android
+  - com.google
+  - java
+  - javax
+KeepEmptyLinesAtTheStartOfBlocks: false
+ObjCBlockIndentWidth: 4
+PackConstructorInitializers: NextLine
+RemoveSemicolon: false # Differs from base .clang-format
+SpacesInLineCommentPrefix:
+  Minimum: 0
+  Maximum: -1
+Standard: c++20
+TabWidth: 4
+UseTab: Always

--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -161,7 +161,7 @@ bool CameraLinux::_can_query_format(int p_file_descriptor, int p_type) {
 
 CameraLinux::CameraLinux() {
 	camera_thread.start(CameraLinux::camera_thread_func, this);
-};
+}
 
 CameraLinux::~CameraLinux() {
 	exit_flag.set();

--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -212,12 +212,12 @@ public:
 
 AVCaptureDevice *CameraFeedMacOS::get_device() const {
 	return device;
-};
+}
 
 CameraFeedMacOS::CameraFeedMacOS() {
 	device = nullptr;
 	capture_session = nullptr;
-};
+}
 
 void CameraFeedMacOS::set_device(AVCaptureDevice *p_device) {
 	device = p_device;
@@ -231,7 +231,7 @@ void CameraFeedMacOS::set_device(AVCaptureDevice *p_device) {
 	} else if ([p_device position] == AVCaptureDevicePositionFront) {
 		position = CameraFeed::FEED_FRONT;
 	};
-};
+}
 
 bool CameraFeedMacOS::activate_feed() {
 	if (capture_session) {
@@ -257,7 +257,7 @@ bool CameraFeedMacOS::activate_feed() {
 	};
 
 	return true;
-};
+}
 
 void CameraFeedMacOS::deactivate_feed() {
 	// end camera capture if we have one
@@ -265,7 +265,7 @@ void CameraFeedMacOS::deactivate_feed() {
 		[capture_session cleanup];
 		capture_session = nullptr;
 	};
-};
+}
 
 //////////////////////////////////////////////////////////////////////////
 // MyDeviceNotifications - This is a little helper class gets notifications
@@ -351,7 +351,7 @@ void CameraMacOS::update_feeds() {
 			add_feed(newfeed);
 		};
 	};
-};
+}
 
 CameraMacOS::CameraMacOS() {
 	// Find available cameras we have at this time
@@ -359,4 +359,4 @@ CameraMacOS::CameraMacOS() {
 
 	// should only have one of these....
 	device_notifications = [[MyDeviceNotifications alloc] initForServer:this];
-};
+}

--- a/modules/camera/camera_win.cpp
+++ b/modules/camera/camera_win.cpp
@@ -64,13 +64,13 @@ CameraFeedWindows::~CameraFeedWindows() {
 	};
 
 	///@TODO free up anything used by this
-};
+}
 
 bool CameraFeedWindows::activate_feed() {
 	///@TODO this should activate our camera and start the process of capturing frames
 
 	return true;
-};
+}
 
 ///@TODO we should probably have a callback method here that is being called by the
 // camera API which provides frames and call back into the CameraServer to update our texture
@@ -91,4 +91,4 @@ CameraWindows::CameraWindows() {
 	add_active_cameras();
 
 	// need to add something that will react to devices being connected/removed...
-};
+}

--- a/modules/gdscript/gdscript_tokenizer_buffer.h
+++ b/modules/gdscript/gdscript_tokenizer_buffer.h
@@ -79,7 +79,7 @@ public:
 	virtual bool is_past_cursor() const override;
 	virtual void push_expression_indented_block() override; // For lambdas, or blocks inside expressions.
 	virtual void pop_expression_indented_block() override; // For lambdas, or blocks inside expressions.
-	virtual bool is_text() override { return false; };
+	virtual bool is_text() override { return false; }
 
 #ifdef TOOLS_ENABLED
 	virtual const HashMap<int, CommentData> &get_comments() const override {

--- a/modules/godot_physics_2d/godot_joints_2d.h
+++ b/modules/godot_physics_2d/godot_joints_2d.h
@@ -70,7 +70,7 @@ public:
 				body->remove_constraint(this, i);
 			}
 		}
-	};
+	}
 };
 
 class GodotPinJoint2D : public GodotJoint2D {

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -116,7 +116,7 @@ void GodotPhysicsServer2D::shape_set_data(RID p_shape, const Variant &p_data) {
 	GodotShape2D *shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 	shape->set_data(p_data);
-};
+}
 
 void GodotPhysicsServer2D::shape_set_custom_solver_bias(RID p_shape, real_t p_bias) {
 	GodotShape2D *shape = shape_owner.get_or_null(p_shape);
@@ -128,14 +128,14 @@ PhysicsServer2D::ShapeType GodotPhysicsServer2D::shape_get_type(RID p_shape) con
 	const GodotShape2D *shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_V(shape, SHAPE_CUSTOM);
 	return shape->get_type();
-};
+}
 
 Variant GodotPhysicsServer2D::shape_get_data(RID p_shape) const {
 	const GodotShape2D *shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_V(shape, Variant());
 	ERR_FAIL_COND_V(!shape->is_configured(), Variant());
 	return shape->get_data();
-};
+}
 
 real_t GodotPhysicsServer2D::shape_get_custom_solver_bias(RID p_shape) const {
 	const GodotShape2D *shape = shape_owner.get_or_null(p_shape);
@@ -226,7 +226,7 @@ RID GodotPhysicsServer2D::space_create() {
 	area->set_priority(-1);
 
 	return id;
-};
+}
 
 void GodotPhysicsServer2D::space_set_active(RID p_space, bool p_active) {
 	GodotSpace2D *space = space_owner.get_or_null(p_space);
@@ -445,13 +445,13 @@ void GodotPhysicsServer2D::area_set_param(RID p_area, AreaParameter p_param, con
 	GodotArea2D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 	area->set_param(p_param, p_value);
-};
+}
 
 void GodotPhysicsServer2D::area_set_transform(RID p_area, const Transform2D &p_transform) {
 	GodotArea2D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 	area->set_transform(p_transform);
-};
+}
 
 Variant GodotPhysicsServer2D::area_get_param(RID p_area, AreaParameter p_param) const {
 	if (space_owner.owns(p_area)) {
@@ -462,14 +462,14 @@ Variant GodotPhysicsServer2D::area_get_param(RID p_area, AreaParameter p_param) 
 	ERR_FAIL_NULL_V(area, Variant());
 
 	return area->get_param(p_param);
-};
+}
 
 Transform2D GodotPhysicsServer2D::area_get_transform(RID p_area) const {
 	GodotArea2D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_V(area, Transform2D());
 
 	return area->get_transform();
-};
+}
 
 void GodotPhysicsServer2D::area_set_pickable(RID p_area, bool p_pickable) {
 	GodotArea2D *area = area_owner.get_or_null(p_area);
@@ -551,7 +551,7 @@ void GodotPhysicsServer2D::body_set_space(RID p_body, RID p_space) {
 
 	body->clear_constraint_list();
 	body->set_space(space);
-};
+}
 
 RID GodotPhysicsServer2D::body_get_space(RID p_body) const {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
@@ -562,7 +562,7 @@ RID GodotPhysicsServer2D::body_get_space(RID p_body) const {
 		return RID();
 	}
 	return space->get_self();
-};
+}
 
 void GodotPhysicsServer2D::body_set_mode(RID p_body, BodyMode p_mode) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
@@ -570,14 +570,14 @@ void GodotPhysicsServer2D::body_set_mode(RID p_body, BodyMode p_mode) {
 	FLUSH_QUERY_CHECK(body);
 
 	body->set_mode(p_mode);
-};
+}
 
 PhysicsServer2D::BodyMode GodotPhysicsServer2D::body_get_mode(RID p_body) const {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_V(body, BODY_MODE_STATIC);
 
 	return body->get_mode();
-};
+}
 
 void GodotPhysicsServer2D::body_add_shape(RID p_body, RID p_shape, const Transform2D &p_transform, bool p_disabled) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
@@ -902,7 +902,7 @@ void GodotPhysicsServer2D::body_set_axis_velocity(RID p_body, const Vector2 &p_a
 	v += p_axis_velocity;
 	body->set_linear_velocity(v);
 	body->wakeup();
-};
+}
 
 void GodotPhysicsServer2D::body_add_collision_exception(RID p_body, RID p_body_b) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
@@ -910,7 +910,7 @@ void GodotPhysicsServer2D::body_add_collision_exception(RID p_body, RID p_body_b
 
 	body->add_exception(p_body_b);
 	body->wakeup();
-};
+}
 
 void GodotPhysicsServer2D::body_remove_collision_exception(RID p_body, RID p_body_b) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
@@ -918,7 +918,7 @@ void GodotPhysicsServer2D::body_remove_collision_exception(RID p_body, RID p_bod
 
 	body->remove_exception(p_body_b);
 	body->wakeup();
-};
+}
 
 void GodotPhysicsServer2D::body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
@@ -927,31 +927,31 @@ void GodotPhysicsServer2D::body_get_collision_exceptions(RID p_body, List<RID> *
 	for (int i = 0; i < body->get_exceptions().size(); i++) {
 		p_exceptions->push_back(body->get_exceptions()[i]);
 	}
-};
+}
 
 void GodotPhysicsServer2D::body_set_contacts_reported_depth_threshold(RID p_body, real_t p_threshold) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
-};
+}
 
 real_t GodotPhysicsServer2D::body_get_contacts_reported_depth_threshold(RID p_body) const {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_V(body, 0);
 	return 0;
-};
+}
 
 void GodotPhysicsServer2D::body_set_omit_force_integration(RID p_body, bool p_omit) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_omit_force_integration(p_omit);
-};
+}
 
 bool GodotPhysicsServer2D::body_is_omitting_force_integration(RID p_body) const {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_V(body, false);
 	return body->get_omit_force_integration();
-};
+}
 
 void GodotPhysicsServer2D::body_set_max_contacts_reported(RID p_body, int p_contacts) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -106,7 +106,7 @@ void GodotPhysicsServer3D::shape_set_data(RID p_shape, const Variant &p_data) {
 	GodotShape3D *shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 	shape->set_data(p_data);
-};
+}
 
 void GodotPhysicsServer3D::shape_set_custom_solver_bias(RID p_shape, real_t p_bias) {
 	GodotShape3D *shape = shape_owner.get_or_null(p_shape);
@@ -118,14 +118,14 @@ PhysicsServer3D::ShapeType GodotPhysicsServer3D::shape_get_type(RID p_shape) con
 	const GodotShape3D *shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_V(shape, SHAPE_CUSTOM);
 	return shape->get_type();
-};
+}
 
 Variant GodotPhysicsServer3D::shape_get_data(RID p_shape) const {
 	const GodotShape3D *shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_V(shape, Variant());
 	ERR_FAIL_COND_V(!shape->is_configured(), Variant());
 	return shape->get_data();
-};
+}
 
 void GodotPhysicsServer3D::shape_set_margin(RID p_shape, real_t p_margin) {
 }
@@ -156,7 +156,7 @@ RID GodotPhysicsServer3D::space_create() {
 	space->set_static_global_body(sgb);
 
 	return id;
-};
+}
 
 void GodotPhysicsServer3D::space_set_active(RID p_space, bool p_active) {
 	GodotSpace3D *space = space_owner.get_or_null(p_space);
@@ -354,13 +354,13 @@ void GodotPhysicsServer3D::area_set_param(RID p_area, AreaParameter p_param, con
 	GodotArea3D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 	area->set_param(p_param, p_value);
-};
+}
 
 void GodotPhysicsServer3D::area_set_transform(RID p_area, const Transform3D &p_transform) {
 	GodotArea3D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 	area->set_transform(p_transform);
-};
+}
 
 Variant GodotPhysicsServer3D::area_get_param(RID p_area, AreaParameter p_param) const {
 	if (space_owner.owns(p_area)) {
@@ -371,14 +371,14 @@ Variant GodotPhysicsServer3D::area_get_param(RID p_area, AreaParameter p_param) 
 	ERR_FAIL_NULL_V(area, Variant());
 
 	return area->get_param(p_param);
-};
+}
 
 Transform3D GodotPhysicsServer3D::area_get_transform(RID p_area) const {
 	GodotArea3D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_V(area, Transform3D());
 
 	return area->get_transform();
-};
+}
 
 void GodotPhysicsServer3D::area_set_collision_layer(RID p_area, uint32_t p_layer) {
 	GodotArea3D *area = area_owner.get_or_null(p_area);
@@ -444,7 +444,7 @@ RID GodotPhysicsServer3D::body_create() {
 	RID rid = body_owner.make_rid(body);
 	body->set_self(rid);
 	return rid;
-};
+}
 
 void GodotPhysicsServer3D::body_set_space(RID p_body, RID p_space) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
@@ -462,7 +462,7 @@ void GodotPhysicsServer3D::body_set_space(RID p_body, RID p_space) {
 
 	body->clear_constraint_map();
 	body->set_space(space);
-};
+}
 
 RID GodotPhysicsServer3D::body_get_space(RID p_body) const {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
@@ -473,21 +473,21 @@ RID GodotPhysicsServer3D::body_get_space(RID p_body) const {
 		return RID();
 	}
 	return space->get_self();
-};
+}
 
 void GodotPhysicsServer3D::body_set_mode(RID p_body, BodyMode p_mode) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_mode(p_mode);
-};
+}
 
 PhysicsServer3D::BodyMode GodotPhysicsServer3D::body_get_mode(RID p_body) const {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_V(body, BODY_MODE_STATIC);
 
 	return body->get_mode();
-};
+}
 
 void GodotPhysicsServer3D::body_add_shape(RID p_body, RID p_shape, const Transform3D &p_transform, bool p_disabled) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
@@ -836,7 +836,7 @@ void GodotPhysicsServer3D::body_add_collision_exception(RID p_body, RID p_body_b
 
 	body->add_exception(p_body_b);
 	body->wakeup();
-};
+}
 
 void GodotPhysicsServer3D::body_remove_collision_exception(RID p_body, RID p_body_b) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
@@ -844,7 +844,7 @@ void GodotPhysicsServer3D::body_remove_collision_exception(RID p_body, RID p_bod
 
 	body->remove_exception(p_body_b);
 	body->wakeup();
-};
+}
 
 void GodotPhysicsServer3D::body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
@@ -853,31 +853,31 @@ void GodotPhysicsServer3D::body_get_collision_exceptions(RID p_body, List<RID> *
 	for (int i = 0; i < body->get_exceptions().size(); i++) {
 		p_exceptions->push_back(body->get_exceptions()[i]);
 	}
-};
+}
 
 void GodotPhysicsServer3D::body_set_contacts_reported_depth_threshold(RID p_body, real_t p_threshold) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
-};
+}
 
 real_t GodotPhysicsServer3D::body_get_contacts_reported_depth_threshold(RID p_body) const {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_V(body, 0);
 	return 0;
-};
+}
 
 void GodotPhysicsServer3D::body_set_omit_force_integration(RID p_body, bool p_omit) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
 	body->set_omit_force_integration(p_omit);
-};
+}
 
 bool GodotPhysicsServer3D::body_is_omitting_force_integration(RID p_body) const {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL_V(body, false);
 	return body->get_omit_force_integration();
-};
+}
 
 void GodotPhysicsServer3D::body_set_max_contacts_reported(RID p_body, int p_contacts) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
@@ -1770,4 +1770,4 @@ GodotPhysicsServer3D::GodotPhysicsServer3D(bool p_using_threads) {
 	GodotBroadPhase3D::create_func = GodotBroadPhase3DBVH::_create;
 
 	using_threads = p_using_threads;
-};
+}

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -1121,7 +1121,7 @@ struct AABBQueryResult {
 
 	_FORCE_INLINE_ bool operator()(void *p_data) {
 		return result_callback(soft_body->get_node_index(p_data), userdata);
-	};
+	}
 };
 
 void GodotSoftBody3D::query_aabb(const AABB &p_aabb, GodotSoftBody3D::QueryResultCallback p_result_callback, void *p_userdata) {
@@ -1140,7 +1140,7 @@ struct RayQueryResult {
 
 	_FORCE_INLINE_ bool operator()(void *p_data) {
 		return result_callback(soft_body->get_face_index(p_data), userdata);
-	};
+	}
 };
 
 void GodotSoftBody3D::query_ray(const Vector3 &p_from, const Vector3 &p_to, GodotSoftBody3D::QueryResultCallback p_result_callback, void *p_userdata) {

--- a/modules/mbedtls/crypto_mbedtls.h
+++ b/modules/mbedtls/crypto_mbedtls.h
@@ -57,7 +57,7 @@ public:
 	virtual Error save(const String &p_path, bool p_public_only);
 	virtual String save_to_string(bool p_public_only);
 	virtual Error load_from_string(const String &p_string_key, bool p_public_only);
-	virtual bool is_public_only() const { return public_only; };
+	virtual bool is_public_only() const { return public_only; }
 
 	CryptoKeyMbedTLS() {
 		mbedtls_pk_init(&pkey);

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -37,11 +37,11 @@
 
 StringName MobileVRInterface::get_name() const {
 	return "Native mobile";
-};
+}
 
 uint32_t MobileVRInterface::get_capabilities() const {
 	return XRInterface::XR_STEREO;
-};
+}
 
 Vector3 MobileVRInterface::scale_magneto(const Vector3 &p_magnetometer) {
 	// Our magnetometer doesn't give us nice clean data.
@@ -98,7 +98,7 @@ Vector3 MobileVRInterface::scale_magneto(const Vector3 &p_magnetometer) {
 	};
 
 	return mag_scaled;
-};
+}
 
 Basis MobileVRInterface::combine_acc_mag(const Vector3 &p_grav, const Vector3 &p_magneto) {
 	// yup, stock standard cross product solution...
@@ -117,7 +117,7 @@ Basis MobileVRInterface::combine_acc_mag(const Vector3 &p_grav, const Vector3 &p
 	acc_mag_m3.rows[2] = magneto;
 
 	return acc_mag_m3;
-};
+}
 
 void MobileVRInterface::set_position_from_sensors() {
 	_THREAD_SAFE_METHOD_
@@ -215,7 +215,7 @@ void MobileVRInterface::set_position_from_sensors() {
 	head_transform.basis = orientation.orthonormalized();
 
 	last_ticks = ticks;
-};
+}
 
 void MobileVRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_eye_height", "eye_height"), &MobileVRInterface::set_eye_height);
@@ -280,51 +280,51 @@ Rect2 MobileVRInterface::get_offset_rect() const {
 
 void MobileVRInterface::set_iod(const double p_iod) {
 	intraocular_dist = p_iod;
-};
+}
 
 double MobileVRInterface::get_iod() const {
 	return intraocular_dist;
-};
+}
 
 void MobileVRInterface::set_display_width(const double p_display_width) {
 	display_width = p_display_width;
-};
+}
 
 double MobileVRInterface::get_display_width() const {
 	return display_width;
-};
+}
 
 void MobileVRInterface::set_display_to_lens(const double p_display_to_lens) {
 	display_to_lens = p_display_to_lens;
-};
+}
 
 double MobileVRInterface::get_display_to_lens() const {
 	return display_to_lens;
-};
+}
 
 void MobileVRInterface::set_oversample(const double p_oversample) {
 	oversample = p_oversample;
-};
+}
 
 double MobileVRInterface::get_oversample() const {
 	return oversample;
-};
+}
 
 void MobileVRInterface::set_k1(const double p_k1) {
 	k1 = p_k1;
-};
+}
 
 double MobileVRInterface::get_k1() const {
 	return k1;
-};
+}
 
 void MobileVRInterface::set_k2(const double p_k2) {
 	k2 = p_k2;
-};
+}
 
 double MobileVRInterface::get_k2() const {
 	return k2;
-};
+}
 
 float MobileVRInterface::get_vrs_min_radius() const {
 	return xr_vrs.get_vrs_min_radius();
@@ -345,7 +345,7 @@ void MobileVRInterface::set_vrs_strength(float p_vrs_strength) {
 uint32_t MobileVRInterface::get_view_count() {
 	// needs stereo...
 	return 2;
-};
+}
 
 XRInterface::TrackingStatus MobileVRInterface::get_tracking_status() const {
 	return tracking_state;
@@ -353,7 +353,7 @@ XRInterface::TrackingStatus MobileVRInterface::get_tracking_status() const {
 
 bool MobileVRInterface::is_initialized() const {
 	return (initialized);
-};
+}
 
 bool MobileVRInterface::initialize() {
 	XRServer *xr_server = XRServer::get_singleton();
@@ -387,7 +387,7 @@ bool MobileVRInterface::initialize() {
 	};
 
 	return true;
-};
+}
 
 void MobileVRInterface::uninitialize() {
 	if (initialized) {
@@ -408,7 +408,7 @@ void MobileVRInterface::uninitialize() {
 
 		initialized = false;
 	};
-};
+}
 
 Dictionary MobileVRInterface::get_system_info() {
 	Dictionary dict;
@@ -442,7 +442,7 @@ Size2 MobileVRInterface::get_render_target_size() {
 	target_size.y *= oversample;
 
 	return target_size;
-};
+}
 
 Transform3D MobileVRInterface::get_camera_transform() {
 	_THREAD_SAFE_METHOD_
@@ -463,7 +463,7 @@ Transform3D MobileVRInterface::get_camera_transform() {
 	}
 
 	return transform_for_eye;
-};
+}
 
 Transform3D MobileVRInterface::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	_THREAD_SAFE_METHOD_
@@ -497,7 +497,7 @@ Transform3D MobileVRInterface::get_transform_for_view(uint32_t p_view, const Tra
 	};
 
 	return transform_for_eye;
-};
+}
 
 Projection MobileVRInterface::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
 	_THREAD_SAFE_METHOD_
@@ -508,7 +508,7 @@ Projection MobileVRInterface::get_projection_for_view(uint32_t p_view, double p_
 	eye.set_for_hmd(p_view + 1, p_aspect, intraocular_dist, display_width, display_to_lens, oversample, p_z_near, p_z_far);
 
 	return eye;
-};
+}
 
 Vector<BlitToScreen> MobileVRInterface::post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) {
 	_THREAD_SAFE_METHOD_
@@ -571,7 +571,7 @@ void MobileVRInterface::process() {
 			head->set_pose("default", head_transform, Vector3(), Vector3(), tracking_confidence);
 		}
 	};
-};
+}
 
 RID MobileVRInterface::get_vrs_texture() {
 	PackedVector2Array eye_foci;
@@ -597,4 +597,4 @@ MobileVRInterface::~MobileVRInterface() {
 	if (is_initialized()) {
 		uninitialize();
 	};
-};
+}

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -97,19 +97,19 @@ private:
 	float floor_decimals(const float p_value, const float p_decimals) {
 		float power_of_10 = pow(10.0f, p_decimals);
 		return floor(p_value * power_of_10) / power_of_10;
-	};
+	}
 
 	Vector3 floor_decimals(const Vector3 &p_vector, const float p_decimals) {
 		return Vector3(floor_decimals(p_vector.x, p_decimals), floor_decimals(p_vector.y, p_decimals), floor_decimals(p_vector.z, p_decimals));
-	};
+	}
 
 	Vector3 low_pass(const Vector3 &p_vector, const Vector3 &p_last_vector, const float p_factor) {
 		return p_vector + (p_factor * (p_last_vector - p_vector));
-	};
+	}
 
 	Vector3 scrub(const Vector3 &p_vector, const Vector3 &p_last_vector, const float p_decimals, const float p_factor) {
 		return low_pass(floor_decimals(p_vector, p_decimals), p_last_vector, p_factor);
-	};
+	}
 
 	void set_position_from_sensors();
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -500,8 +500,8 @@ Vector<ScriptLanguage::StackInfo> CSharpLanguage::debug_get_current_stack_info()
 	}
 	_recursion_flag_ = true;
 	SCOPE_EXIT {
-		_recursion_flag_ = false;
-	};
+		_recursion_flag_ = false; // clang-format off
+	}; // clang-format on
 
 	if (!gdmono || !gdmono->is_runtime_initialized()) {
 		return Vector<StackInfo>();

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -52,14 +52,14 @@ public:
 
 	virtual void set_target_peer(int p_peer_id) override {}
 	virtual int get_packet_peer() const override { return 0; }
-	virtual TransferMode get_packet_mode() const override { return TRANSFER_MODE_RELIABLE; };
+	virtual TransferMode get_packet_mode() const override { return TRANSFER_MODE_RELIABLE; }
 	virtual int get_packet_channel() const override { return 0; }
 	virtual void disconnect_peer(int p_peer, bool p_force = false) override {}
 	virtual bool is_server() const override { return true; }
 	virtual void poll() override {}
 	virtual void close() override {}
 	virtual int get_unique_id() const override { return TARGET_PEER_SERVER; }
-	virtual ConnectionStatus get_connection_status() const override { return CONNECTION_CONNECTED; };
+	virtual ConnectionStatus get_connection_status() const override { return CONNECTION_CONNECTED; }
 };
 
 class SceneMultiplayer : public MultiplayerAPI {

--- a/modules/navigation/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/2d/nav_mesh_generator_2d.cpp
@@ -755,7 +755,7 @@ void NavMeshGenerator2D::generator_parse_source_geometry_data(Ref<NavigationPoly
 	for (Node *E : parse_nodes) {
 		generator_parse_geometry_node(p_navigation_mesh, p_source_geometry_data, E, recurse_children);
 	}
-};
+}
 
 static void generator_recursive_process_polytree_items(List<TPPLPoly> &p_tppl_in_polygon, const Clipper2Lib::PolyPathD *p_polypath_item) {
 	using namespace Clipper2Lib;

--- a/modules/navigation/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_generator_3d.cpp
@@ -660,7 +660,7 @@ void NavMeshGenerator3D::generator_parse_source_geometry_data(const Ref<Navigati
 	for (Node *parse_node : parse_nodes) {
 		generator_parse_geometry_node(p_navigation_mesh, p_source_geometry_data, parse_node, recurse_children);
 	}
-};
+}
 
 void NavMeshGenerator3D::generator_bake_from_source_geometry_data(Ref<NavigationMesh> p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data) {
 	if (p_navigation_mesh.is_null() || p_source_geometry_data.is_null()) {

--- a/modules/navigation/nav_agent.cpp
+++ b/modules/navigation/nav_agent.cpp
@@ -308,7 +308,7 @@ void NavAgent::set_avoidance_priority(real_t p_priority) {
 		rvo_agent_2d.avoidance_priority_ = avoidance_priority;
 	}
 	agent_dirty = true;
-};
+}
 
 bool NavAgent::check_dirty() {
 	const bool was_dirty = agent_dirty;

--- a/modules/navigation/nav_agent.h
+++ b/modules/navigation/nav_agent.h
@@ -130,13 +130,13 @@ public:
 	const Vector3 &get_velocity_forced() const { return velocity_forced; }
 
 	void set_avoidance_layers(uint32_t p_layers);
-	uint32_t get_avoidance_layers() const { return avoidance_layers; };
+	uint32_t get_avoidance_layers() const { return avoidance_layers; }
 
 	void set_avoidance_mask(uint32_t p_mask);
-	uint32_t get_avoidance_mask() const { return avoidance_mask; };
+	uint32_t get_avoidance_mask() const { return avoidance_mask; }
 
 	void set_avoidance_priority(real_t p_priority);
-	real_t get_avoidance_priority() const { return avoidance_priority; };
+	real_t get_avoidance_priority() const { return avoidance_priority; }
 
 	void set_paused(bool p_paused);
 	bool get_paused() const;

--- a/modules/navigation/nav_link.cpp
+++ b/modules/navigation/nav_link.cpp
@@ -57,7 +57,7 @@ void NavLink::set_enabled(bool p_enabled) {
 
 	// TODO: This should not require a full rebuild as the link has not really changed.
 	link_dirty = true;
-};
+}
 
 void NavLink::set_bidirectional(bool p_bidirectional) {
 	if (bidirectional == p_bidirectional) {

--- a/modules/navigation/nav_obstacle.h
+++ b/modules/navigation/nav_obstacle.h
@@ -92,7 +92,7 @@ public:
 	bool is_map_changed();
 
 	void set_avoidance_layers(uint32_t p_layers);
-	uint32_t get_avoidance_layers() const { return avoidance_layers; };
+	uint32_t get_avoidance_layers() const { return avoidance_layers; }
 
 	void set_paused(bool p_paused);
 	bool get_paused() const;

--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -59,7 +59,7 @@ void NavRegion::set_enabled(bool p_enabled) {
 
 	// TODO: This should not require a full rebuild as the region has not really changed.
 	polygons_dirty = true;
-};
+}
 
 void NavRegion::set_use_edge_connections(bool p_enabled) {
 	if (use_edge_connections != p_enabled) {

--- a/modules/navigation/nav_region.h
+++ b/modules/navigation/nav_region.h
@@ -94,7 +94,7 @@ public:
 	gd::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
 	Vector3 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
 
-	real_t get_surface_area() const { return surface_area; };
+	real_t get_surface_area() const { return surface_area; }
 
 	bool sync();
 

--- a/modules/noise/tests/test_noise_texture_2d.h
+++ b/modules/noise/tests/test_noise_texture_2d.h
@@ -44,7 +44,7 @@ class NoiseTextureTester : public RefCounted {
 
 public:
 	NoiseTextureTester(const NoiseTexture2D *const p_texture) :
-			texture{ p_texture } {};
+			texture{ p_texture } {}
 
 	Color compute_average_color(const Ref<Image> &p_noise_image) {
 		Color r_avg_color{};

--- a/modules/noise/tests/test_noise_texture_3d.h
+++ b/modules/noise/tests/test_noise_texture_3d.h
@@ -44,7 +44,7 @@ class NoiseTexture3DTester : public RefCounted {
 
 public:
 	NoiseTexture3DTester(const NoiseTexture3D *const p_texture) :
-			texture{ p_texture } {};
+			texture{ p_texture } {}
 
 	Color compute_average_color(const Ref<Image> &p_noise_image) {
 		Color r_avg_color{};

--- a/modules/openxr/editor/openxr_action_editor.h
+++ b/modules/openxr/editor/openxr_action_editor.h
@@ -68,7 +68,7 @@ protected:
 	void _do_set_action_type(OpenXRAction::ActionType p_action_type);
 
 public:
-	Ref<OpenXRAction> get_action() { return action; };
+	Ref<OpenXRAction> get_action() { return action; }
 	OpenXRActionEditor(Ref<OpenXRAction> p_action);
 };
 

--- a/modules/openxr/editor/openxr_action_set_editor.h
+++ b/modules/openxr/editor/openxr_action_set_editor.h
@@ -87,7 +87,7 @@ protected:
 	void _do_remove_action_editor(OpenXRActionEditor *p_action_editor);
 
 public:
-	Ref<OpenXRActionSet> get_action_set() { return action_set; };
+	Ref<OpenXRActionSet> get_action_set() { return action_set; }
 	void set_focus_on_entry();
 
 	void remove_all_actions();

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1294,7 +1294,7 @@ bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
 	}
 
 	return true;
-};
+}
 
 void OpenXRAPI::destroy_session() {
 	// TODO need to figure out if we're still rendering our current frame
@@ -2353,7 +2353,7 @@ void OpenXRAPI::post_draw_viewport(RID p_render_target) {
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_post_draw_viewport(p_render_target);
 	}
-};
+}
 
 void OpenXRAPI::end_frame() {
 	XrResult result;

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -396,12 +396,12 @@ private:
 	}
 
 public:
-	XrInstance get_instance() const { return instance; };
-	XrSystemId get_system_id() const { return system_id; };
-	XrSession get_session() const { return session; };
-	OpenXRGraphicsExtensionWrapper *get_graphics_extension() const { return graphics_extension; };
-	String get_runtime_name() const { return runtime_name; };
-	String get_runtime_version() const { return runtime_version; };
+	XrInstance get_instance() const { return instance; }
+	XrSystemId get_system_id() const { return system_id; }
+	XrSession get_session() const { return session; }
+	OpenXRGraphicsExtensionWrapper *get_graphics_extension() const { return graphics_extension; }
+	String get_runtime_name() const { return runtime_name; }
+	String get_runtime_version() const { return runtime_version; }
 
 	// helper method to convert an XrPosef to a Transform3D
 	Transform3D transform_from_pose(const XrPosef &p_pose);

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -160,11 +160,11 @@ void OpenXRInterface::_bind_methods() {
 
 StringName OpenXRInterface::get_name() const {
 	return StringName("OpenXR");
-};
+}
 
 uint32_t OpenXRInterface::get_capabilities() const {
 	return XRInterface::XR_VR + XRInterface::XR_STEREO;
-};
+}
 
 PackedStringArray OpenXRInterface::get_suggested_tracker_names() const {
 	// These are hardcoded in OpenXR, note that they will only be available if added to our action map
@@ -611,7 +611,7 @@ bool OpenXRInterface::initialize_on_startup() const {
 
 bool OpenXRInterface::is_initialized() const {
 	return initialized;
-};
+}
 
 bool OpenXRInterface::initialize() {
 	XRServer *xr_server = XRServer::get_singleton();

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -156,11 +156,11 @@ bool TextServerFallback::_has(const RID &p_rid) {
 
 String TextServerFallback::_get_support_data_filename() const {
 	return "";
-};
+}
 
 String TextServerFallback::_get_support_data_info() const {
 	return "Not supported";
-};
+}
 
 bool TextServerFallback::_load_support_data(const String &p_filename) {
 	return false; // No extra data used.
@@ -4728,7 +4728,7 @@ void TextServerFallback::_update_settings() {
 TextServerFallback::TextServerFallback() {
 	_insert_feature_sets();
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextServerFallback::_update_settings));
-};
+}
 
 void TextServerFallback::_cleanup() {
 	for (const KeyValue<SystemFontKey, SystemFontCache> &E : system_fonts) {
@@ -4747,4 +4747,4 @@ TextServerFallback::~TextServerFallback() {
 		FT_Done_FreeType(ft_library);
 	}
 #endif
-};
+}

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -645,7 +645,7 @@ VideoStreamPlaybackTheora::~VideoStreamPlaybackTheora() {
 	memdelete(thread_sem);
 #endif
 	clear();
-};
+}
 
 void VideoStreamTheora::_bind_methods() {}
 

--- a/modules/webrtc/webrtc_peer_connection_js.cpp
+++ b/modules/webrtc/webrtc_peer_connection_js.cpp
@@ -150,5 +150,5 @@ WebRTCPeerConnectionJS::~WebRTCPeerConnectionJS() {
 		godot_js_rtc_pc_destroy(_js_id);
 		_js_id = 0;
 	}
-};
+}
 #endif

--- a/modules/websocket/emws_peer.h
+++ b/modules/websocket/emws_peer.h
@@ -84,7 +84,7 @@ public:
 	virtual int get_available_packet_count() const override;
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override;
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-	virtual int get_max_packet_size() const override { return packet_buffer.size(); };
+	virtual int get_max_packet_size() const override { return packet_buffer.size(); }
 
 	// WebSocketPeer
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) override;

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -127,7 +127,7 @@ public:
 	virtual int get_available_packet_count() const override;
 	virtual Error get_packet(const uint8_t **r_buffer, int &r_buffer_size) override;
 	virtual Error put_packet(const uint8_t *p_buffer, int p_buffer_size) override;
-	virtual int get_max_packet_size() const override { return packet_buffer.size(); };
+	virtual int get_max_packet_size() const override { return packet_buffer.size(); }
 
 	// WebSocketPeer
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) override;

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -271,19 +271,19 @@ void WebXRInterfaceJS::_set_environment_blend_mode(String p_blend_mode_string) {
 
 StringName WebXRInterfaceJS::get_name() const {
 	return "WebXR";
-};
+}
 
 uint32_t WebXRInterfaceJS::get_capabilities() const {
 	return XRInterface::XR_STEREO | XRInterface::XR_MONO | XRInterface::XR_VR | XRInterface::XR_AR;
-};
+}
 
 uint32_t WebXRInterfaceJS::get_view_count() {
 	return godot_webxr_get_view_count();
-};
+}
 
 bool WebXRInterfaceJS::is_initialized() const {
 	return (initialized);
-};
+}
 
 bool WebXRInterfaceJS::initialize() {
 	XRServer *xr_server = XRServer::get_singleton();
@@ -333,7 +333,7 @@ bool WebXRInterfaceJS::initialize() {
 	};
 
 	return true;
-};
+}
 
 void WebXRInterfaceJS::uninitialize() {
 	if (initialized) {
@@ -378,7 +378,7 @@ void WebXRInterfaceJS::uninitialize() {
 		environment_blend_mode = XRInterface::XR_ENV_BLEND_MODE_OPAQUE;
 		initialized = false;
 	};
-};
+}
 
 Dictionary WebXRInterfaceJS::get_system_info() {
 	Dictionary dict;
@@ -427,7 +427,7 @@ Size2 WebXRInterfaceJS::get_render_target_size() {
 	render_targetsize.height = (float)js_size[1];
 
 	return render_targetsize;
-};
+}
 
 Transform3D WebXRInterfaceJS::get_camera_transform() {
 	Transform3D camera_transform;
@@ -445,7 +445,7 @@ Transform3D WebXRInterfaceJS::get_camera_transform() {
 	}
 
 	return camera_transform;
-};
+}
 
 Transform3D WebXRInterfaceJS::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	XRServer *xr_server = XRServer::get_singleton();
@@ -464,7 +464,7 @@ Transform3D WebXRInterfaceJS::get_transform_for_view(uint32_t p_view, const Tran
 	transform_for_view.origin *= world_scale;
 
 	return p_cam_transform * xr_server->get_reference_frame() * transform_for_view;
-};
+}
 
 Projection WebXRInterfaceJS::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
 	Projection view;
@@ -527,7 +527,7 @@ Vector<BlitToScreen> WebXRInterfaceJS::post_draw_viewport(RID p_render_target, c
 	texture_storage->render_target_set_reattach_textures(p_render_target, false);
 
 	return blit_to_screen;
-};
+}
 
 RID WebXRInterfaceJS::_get_color_texture() {
 	unsigned int texture_id = godot_webxr_get_color_texture();
@@ -608,7 +608,7 @@ void WebXRInterfaceJS::process() {
 			_update_input_source(i);
 		}
 	};
-};
+}
 
 void WebXRInterfaceJS::_update_input_source(int p_input_source_id) {
 	XRServer *xr_server = XRServer::get_singleton();
@@ -871,13 +871,13 @@ WebXRInterfaceJS::WebXRInterfaceJS() {
 	initialized = false;
 	session_mode = "inline";
 	requested_reference_space_types = "local";
-};
+}
 
 WebXRInterfaceJS::~WebXRInterfaceJS() {
 	// and make sure we cleanup if we haven't already
 	if (initialized) {
 		uninitialize();
 	};
-};
+}
 
 #endif // WEB_ENABLED

--- a/platform/ios/ios.mm
+++ b/platform/ios/ios.mm
@@ -42,7 +42,7 @@ void iOS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("supports_haptic_engine"), &iOS::supports_haptic_engine);
 	ClassDB::bind_method(D_METHOD("start_haptic_engine"), &iOS::start_haptic_engine);
 	ClassDB::bind_method(D_METHOD("stop_haptic_engine"), &iOS::stop_haptic_engine);
-};
+}
 
 bool iOS::supports_haptic_engine() {
 	if (@available(iOS 13, *)) {

--- a/platform/linuxbsd/crash_handler_linuxbsd.h
+++ b/platform/linuxbsd/crash_handler_linuxbsd.h
@@ -38,7 +38,7 @@ public:
 	void initialize();
 
 	void disable();
-	bool is_disabled() const { return disabled; };
+	bool is_disabled() const { return disabled; }
 
 	CrashHandler();
 	~CrashHandler();

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -55,7 +55,7 @@ class EditorExportPlatformLinuxBSD : public EditorExportPlatformPC {
 			ssh_args = p_ssh_arg;
 			cmd_args = p_cmd_args;
 			wait = p_wait;
-		};
+		}
 	};
 
 	Ref<ImageTexture> run_icon;

--- a/platform/macos/crash_handler_macos.h
+++ b/platform/macos/crash_handler_macos.h
@@ -38,7 +38,7 @@ public:
 	void initialize();
 
 	void disable();
-	bool is_disabled() const { return disabled; };
+	bool is_disabled() const { return disabled; }
 
 	CrashHandler();
 	~CrashHandler();

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -76,7 +76,7 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 			ssh_args = p_ssh_arg;
 			cmd_args = p_cmd_args;
 			wait = p_wait;
-		};
+		}
 	};
 
 	Ref<ImageTexture> run_icon;

--- a/platform/windows/crash_handler_windows.h
+++ b/platform/windows/crash_handler_windows.h
@@ -51,7 +51,7 @@ public:
 	void initialize();
 
 	void disable();
-	bool is_disabled() const { return disabled; };
+	bool is_disabled() const { return disabled; }
 
 	CrashHandler();
 	~CrashHandler();

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -316,8 +316,8 @@ public:
 	}
 
 	// IFileDialogEvents methods
-	HRESULT STDMETHODCALLTYPE OnFileOk(IFileDialog *) { return S_OK; };
-	HRESULT STDMETHODCALLTYPE OnFolderChange(IFileDialog *) { return S_OK; };
+	HRESULT STDMETHODCALLTYPE OnFileOk(IFileDialog *) { return S_OK; }
+	HRESULT STDMETHODCALLTYPE OnFolderChange(IFileDialog *) { return S_OK; }
 
 	HRESULT STDMETHODCALLTYPE OnFolderChanging(IFileDialog *p_pfd, IShellItem *p_item) {
 		if (root.is_empty()) {
@@ -336,11 +336,11 @@ public:
 		return S_OK;
 	}
 
-	HRESULT STDMETHODCALLTYPE OnHelp(IFileDialog *) { return S_OK; };
-	HRESULT STDMETHODCALLTYPE OnSelectionChange(IFileDialog *) { return S_OK; };
-	HRESULT STDMETHODCALLTYPE OnShareViolation(IFileDialog *, IShellItem *, FDE_SHAREVIOLATION_RESPONSE *) { return S_OK; };
-	HRESULT STDMETHODCALLTYPE OnTypeChange(IFileDialog *pfd) { return S_OK; };
-	HRESULT STDMETHODCALLTYPE OnOverwrite(IFileDialog *, IShellItem *, FDE_OVERWRITE_RESPONSE *) { return S_OK; };
+	HRESULT STDMETHODCALLTYPE OnHelp(IFileDialog *) { return S_OK; }
+	HRESULT STDMETHODCALLTYPE OnSelectionChange(IFileDialog *) { return S_OK; }
+	HRESULT STDMETHODCALLTYPE OnShareViolation(IFileDialog *, IShellItem *, FDE_SHAREVIOLATION_RESPONSE *) { return S_OK; }
+	HRESULT STDMETHODCALLTYPE OnTypeChange(IFileDialog *pfd) { return S_OK; }
+	HRESULT STDMETHODCALLTYPE OnOverwrite(IFileDialog *, IShellItem *, FDE_OVERWRITE_RESPONSE *) { return S_OK; }
 
 	// IFileDialogControlEvents methods
 	HRESULT STDMETHODCALLTYPE OnItemSelected(IFileDialogCustomize *p_pfdc, DWORD p_ctl_id, DWORD p_item_idx) {
@@ -350,14 +350,14 @@ public:
 		return S_OK;
 	}
 
-	HRESULT STDMETHODCALLTYPE OnButtonClicked(IFileDialogCustomize *, DWORD) { return S_OK; };
+	HRESULT STDMETHODCALLTYPE OnButtonClicked(IFileDialogCustomize *, DWORD) { return S_OK; }
 	HRESULT STDMETHODCALLTYPE OnCheckButtonToggled(IFileDialogCustomize *p_pfdc, DWORD p_ctl_id, BOOL p_checked) {
 		if (ctls.has(p_ctl_id)) {
 			selected[ctls[p_ctl_id]] = (bool)p_checked;
 		}
 		return S_OK;
 	}
-	HRESULT STDMETHODCALLTYPE OnControlActivating(IFileDialogCustomize *, DWORD) { return S_OK; };
+	HRESULT STDMETHODCALLTYPE OnControlActivating(IFileDialogCustomize *, DWORD) { return S_OK; }
 
 	Dictionary get_selected() {
 		return selected;

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -59,7 +59,7 @@ class EditorExportPlatformWindows : public EditorExportPlatformPC {
 			ssh_args = p_ssh_arg;
 			cmd_args = p_cmd_args;
 			wait = p_wait;
-		};
+		}
 	};
 
 	Ref<ImageTexture> run_icon;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1363,7 +1363,7 @@ public:
 		locale = p_locale;
 		n_sub = p_nsub;
 		rtl = p_rtl;
-	};
+	}
 
 	virtual ~FallbackTextAnalysisSource() {}
 };

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -115,11 +115,11 @@ void Camera2D::set_zoom(const Vector2 &p_zoom) {
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
 	smoothed_camera_pos = old_smoothed_camera_pos;
-};
+}
 
 Vector2 Camera2D::get_zoom() const {
 	return zoom;
-};
+}
 
 Transform2D Camera2D::get_camera_transform() {
 	if (!get_tree()) {

--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -84,7 +84,7 @@ public:
 	real_t get_radius() const { return radius; }
 
 	void set_vertices(const Vector<Vector2> &p_vertices);
-	const Vector<Vector2> &get_vertices() const { return vertices; };
+	const Vector<Vector2> &get_vertices() const { return vertices; }
 
 	void set_avoidance_layers(uint32_t p_layers);
 	uint32_t get_avoidance_layers() const;
@@ -96,7 +96,7 @@ public:
 	bool get_avoidance_layer_value(int p_layer_number) const;
 
 	void set_velocity(const Vector2 p_velocity);
-	Vector2 get_velocity() const { return velocity; };
+	Vector2 get_velocity() const { return velocity; }
 
 	void _avoidance_done(Vector3 p_new_velocity); // Dummy
 

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -946,7 +946,7 @@ void TileMapLayer::_physics_draw_cell_debug(const RID &p_canvas_item, const Vect
 			rs->canvas_item_add_set_transform(p_canvas_item, Transform2D());
 		}
 	}
-};
+}
 #endif // DEBUG_ENABLED
 
 /////////////////////////////// Navigation //////////////////////////////////////

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -377,7 +377,7 @@ void Camera3D::set_projection(ProjectionType p_mode) {
 
 RID Camera3D::get_camera() const {
 	return camera;
-};
+}
 
 void Camera3D::make_current() {
 	current = true;
@@ -423,7 +423,7 @@ bool Camera3D::is_current() const {
 Vector3 Camera3D::project_ray_normal(const Point2 &p_pos) const {
 	Vector3 ray = project_local_ray_normal(p_pos);
 	return get_camera_transform().basis.xform(ray).normalized();
-};
+}
 
 Vector3 Camera3D::project_local_ray_normal(const Point2 &p_pos) const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
@@ -441,7 +441,7 @@ Vector3 Camera3D::project_local_ray_normal(const Point2 &p_pos) const {
 	}
 
 	return ray;
-};
+}
 
 Vector3 Camera3D::project_ray_origin(const Point2 &p_pos) const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
@@ -470,7 +470,7 @@ Vector3 Camera3D::project_ray_origin(const Point2 &p_pos) const {
 	} else {
 		return get_camera_transform().origin;
 	};
-};
+}
 
 bool Camera3D::is_position_behind(const Vector3 &p_pos) const {
 	Transform3D t = get_global_transform();

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -95,7 +95,7 @@ public:
 	real_t get_height() const { return height; }
 
 	void set_vertices(const Vector<Vector3> &p_vertices);
-	const Vector<Vector3> &get_vertices() const { return vertices; };
+	const Vector<Vector3> &get_vertices() const { return vertices; }
 
 	void set_avoidance_layers(uint32_t p_layers);
 	uint32_t get_avoidance_layers() const;
@@ -107,7 +107,7 @@ public:
 	bool get_use_3d_avoidance() const { return use_3d_avoidance; }
 
 	void set_velocity(const Vector3 p_velocity);
-	Vector3 get_velocity() const { return velocity; };
+	Vector3 get_velocity() const { return velocity; }
 
 	void _avoidance_done(Vector3 p_new_velocity); // Dummy
 

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -233,8 +233,8 @@ public:
 #ifdef TOOLS_ENABLED
 	virtual Transform3D get_global_gizmo_transform() const;
 	virtual Transform3D get_local_gizmo_transform() const;
-	virtual void set_transform_gizmo_visible(bool p_enabled) { data.transform_gizmo_visible = p_enabled; };
-	virtual bool is_transform_gizmo_visible() const { return data.transform_gizmo_visible; };
+	virtual void set_transform_gizmo_visible(bool p_enabled) { data.transform_gizmo_visible = p_enabled; }
+	virtual bool is_transform_gizmo_visible() const { return data.transform_gizmo_visible; }
 #endif
 	virtual void reparent(Node *p_parent, bool p_keep_global_transform = true) override;
 

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -89,7 +89,7 @@ PackedStringArray XRCamera3D::get_configuration_warnings() const {
 	}
 
 	return warnings;
-};
+}
 
 Vector3 XRCamera3D::project_local_ray_normal(const Point2 &p_pos) const {
 	// get our XRServer
@@ -114,7 +114,7 @@ Vector3 XRCamera3D::project_local_ray_normal(const Point2 &p_pos) const {
 	ray = Vector3(((cpos.x / viewport_size.width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (cpos.y / viewport_size.height)) * 2.0 - 1.0) * screen_he.y, -get_near()).normalized();
 
 	return ray;
-};
+}
 
 Point2 XRCamera3D::unproject_position(const Vector3 &p_pos) const {
 	// get our XRServer
@@ -144,7 +144,7 @@ Point2 XRCamera3D::unproject_position(const Vector3 &p_pos) const {
 	res.y = (-p.normal.y * 0.5 + 0.5) * viewport_size.y;
 
 	return res;
-};
+}
 
 Vector3 XRCamera3D::project_position(const Point2 &p_point, real_t p_z_depth) const {
 	// get our XRServer
@@ -174,7 +174,7 @@ Vector3 XRCamera3D::project_position(const Point2 &p_point, real_t p_z_depth) co
 	Vector3 p(point.x, point.y, -p_z_depth);
 
 	return get_camera_transform().xform(p);
-};
+}
 
 Vector<Plane> XRCamera3D::get_frustum() const {
 	// get our XRServer
@@ -193,7 +193,7 @@ Vector<Plane> XRCamera3D::get_frustum() const {
 	// TODO Just use the first view for now, this is mostly for debugging so we may look into using our combined projection here.
 	Projection cm = xr_interface->get_projection_for_view(0, viewport_size.aspect(), get_near(), get_far());
 	return cm.get_projection_planes(get_camera_transform());
-};
+}
 
 XRCamera3D::XRCamera3D() {
 	XRServer *xr_server = XRServer::get_singleton();
@@ -240,7 +240,7 @@ void XRNode3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("trigger_haptic_pulse", "action_name", "frequency", "amplitude", "duration_sec", "delay_sec"), &XRNode3D::trigger_haptic_pulse);
 
 	ADD_SIGNAL(MethodInfo("tracking_changed", PropertyInfo(Variant::BOOL, "tracking")));
-};
+}
 
 void XRNode3D::_validate_property(PropertyInfo &p_property) const {
 	XRServer *xr_server = XRServer::get_singleton();
@@ -499,7 +499,7 @@ void XRController3D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
 	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "value")));
 	ADD_SIGNAL(MethodInfo("profile_changed", PropertyInfo(Variant::STRING, "role")));
-};
+}
 
 void XRController3D::_bind_tracker() {
 	XRNode3D::_bind_tracker();

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -158,7 +158,7 @@ private:
 	LiveEditor() {
 		singleton = this;
 		live_edit_root = NodePath("/root");
-	};
+	}
 
 	static LiveEditor *singleton;
 

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -41,9 +41,9 @@ public:
 
 	virtual String get_name() const = 0;
 
-	virtual int get_slider_count() const { return 3; };
+	virtual int get_slider_count() const { return 3; }
 	virtual float get_slider_step() const = 0;
-	virtual float get_spinbox_arrow_step() const { return get_slider_step(); };
+	virtual float get_spinbox_arrow_step() const { return get_slider_step(); }
 	virtual String get_slider_label(int idx) const = 0;
 	virtual float get_slider_max(int idx) const = 0;
 	virtual float get_slider_value(int idx) const = 0;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -120,11 +120,11 @@ void Control::_edit_set_state(const Dictionary &p_state) {
 void Control::_edit_set_position(const Point2 &p_position) {
 	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint(), "This function can only be used from editor plugins.");
 	set_position(p_position, ControlEditorToolbar::get_singleton()->is_anchors_mode_enabled() && get_parent_control());
-};
+}
 
 Point2 Control::_edit_get_position() const {
 	return get_position();
-};
+}
 
 void Control::_edit_set_scale(const Size2 &p_scale) {
 	set_scale(p_scale);

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -64,7 +64,7 @@ class Range : public Control {
 
 protected:
 	virtual void _value_changed(double p_value);
-	void _notify_shared_value_changed() { shared->emit_value_changed(); };
+	void _notify_shared_value_changed() { shared->emit_value_changed(); }
 
 	static void _bind_methods();
 

--- a/scene/gui/rich_text_effect.h
+++ b/scene/gui/rich_text_effect.h
@@ -79,20 +79,20 @@ public:
 	Color get_color() { return color; }
 	void set_color(Color p_color) { color = p_color; }
 
-	uint32_t get_glyph_index() const { return glyph_index; };
-	void set_glyph_index(uint32_t p_glyph_index) { glyph_index = p_glyph_index; };
+	uint32_t get_glyph_index() const { return glyph_index; }
+	void set_glyph_index(uint32_t p_glyph_index) { glyph_index = p_glyph_index; }
 
-	uint16_t get_glyph_flags() const { return glyph_flags; };
-	void set_glyph_flags(uint16_t p_glyph_flags) { glyph_flags = p_glyph_flags; };
+	uint16_t get_glyph_flags() const { return glyph_flags; }
+	void set_glyph_flags(uint16_t p_glyph_flags) { glyph_flags = p_glyph_flags; }
 
-	uint8_t get_glyph_count() const { return glyph_count; };
-	void set_glyph_count(uint8_t p_glyph_count) { glyph_count = p_glyph_count; };
+	uint8_t get_glyph_count() const { return glyph_count; }
+	void set_glyph_count(uint8_t p_glyph_count) { glyph_count = p_glyph_count; }
 
-	int32_t get_relative_index() const { return relative_index; };
-	void set_relative_index(int32_t p_relative_index) { relative_index = p_relative_index; };
+	int32_t get_relative_index() const { return relative_index; }
+	void set_relative_index(int32_t p_relative_index) { relative_index = p_relative_index; }
 
-	RID get_font() const { return font; };
-	void set_font(RID p_font) { font = p_font; };
+	RID get_font() const { return font; }
+	void set_font(RID p_font) { font = p_font; }
 
 	Dictionary get_environment() { return environment; }
 	void set_environment(Dictionary p_environment) { environment = p_environment; }

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -461,7 +461,7 @@ void ScrollContainer::update_scrollbars() {
 
 void ScrollContainer::_scroll_moved(float) {
 	queue_sort();
-};
+}
 
 void ScrollContainer::set_h_scroll(int p_pos) {
 	h_scroll->set_value(p_pos);
@@ -625,7 +625,7 @@ void ScrollContainer::_bind_methods() {
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_STYLEBOX, ScrollContainer, panel_style, "panel");
 
 	GLOBAL_DEF("gui/common/default_scroll_deadzone", 0);
-};
+}
 
 ScrollContainer::ScrollContainer() {
 	h_scroll = memnew(HScrollBar);
@@ -641,4 +641,4 @@ ScrollContainer::ScrollContainer() {
 	deadzone = GLOBAL_GET("gui/common/default_scroll_deadzone");
 
 	set_clip_contents(true);
-};
+}

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -693,9 +693,9 @@ protected:
 	void _set_symbol_lookup_word(const String &p_symbol);
 
 	// Theme items.
-	virtual Color _get_brace_mismatch_color() const { return Color(); };
-	virtual Color _get_code_folding_color() const { return Color(); };
-	virtual Ref<Texture2D> _get_folded_eol_icon() const { return Ref<Texture2D>(); };
+	virtual Color _get_brace_mismatch_color() const { return Color(); }
+	virtual Color _get_code_folding_color() const { return Color(); }
+	virtual Ref<Texture2D> _get_folded_eol_icon() const { return Ref<Texture2D>(); }
 
 	/* Text manipulation */
 

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -340,11 +340,11 @@ Ref<BitMap> TextureButton::get_click_mask() const {
 
 Ref<Texture2D> TextureButton::get_texture_focused() const {
 	return focused;
-};
+}
 
 void TextureButton::set_texture_focused(const Ref<Texture2D> &p_focused) {
 	focused = p_focused;
-};
+}
 
 void TextureButton::_set_texture(Ref<Texture2D> *p_destination, const Ref<Texture2D> &p_texture) {
 	DEV_ASSERT(p_destination);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1101,7 +1101,7 @@ void TreeItem::clear_children() {
 	first_child = nullptr;
 	last_child = nullptr;
 	children_cache.clear();
-};
+}
 
 int TreeItem::get_index() {
 	int idx = 0;
@@ -4829,7 +4829,7 @@ void Tree::clear() {
 	_determine_hovered_item();
 
 	queue_redraw();
-};
+}
 
 void Tree::set_hide_root(bool p_enabled) {
 	if (hide_root == p_enabled) {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -211,20 +211,20 @@ public:
 	virtual Size2 _edit_get_scale() const = 0;
 
 	// Used to rotate the node
-	virtual bool _edit_use_rotation() const { return false; };
+	virtual bool _edit_use_rotation() const { return false; }
 	virtual void _edit_set_rotation(real_t p_rotation) {}
-	virtual real_t _edit_get_rotation() const { return 0.0; };
+	virtual real_t _edit_get_rotation() const { return 0.0; }
 
 	// Used to resize/move the node
-	virtual bool _edit_use_rect() const { return false; }; // MAYBE REPLACE BY A _edit_get_editmode()
+	virtual bool _edit_use_rect() const { return false; } // MAYBE REPLACE BY A _edit_get_editmode()
 	virtual void _edit_set_rect(const Rect2 &p_rect) {}
-	virtual Rect2 _edit_get_rect() const { return Rect2(0, 0, 0, 0); };
-	virtual Size2 _edit_get_minimum_size() const { return Size2(-1, -1); }; // LOOKS WEIRD
+	virtual Rect2 _edit_get_rect() const { return Rect2(0, 0, 0, 0); }
+	virtual Size2 _edit_get_minimum_size() const { return Size2(-1, -1); } // LOOKS WEIRD
 
 	// Used to set a pivot
-	virtual bool _edit_use_pivot() const { return false; };
+	virtual bool _edit_use_pivot() const { return false; }
 	virtual void _edit_set_pivot(const Point2 &p_pivot) {}
-	virtual Point2 _edit_get_pivot() const { return Point2(); };
+	virtual Point2 _edit_get_pivot() const { return Point2(); }
 
 	virtual Transform2D _edit_get_transform() const;
 #endif
@@ -375,7 +375,7 @@ public:
 	TextureRepeat get_texture_repeat_in_tree() const;
 
 	// Used by control nodes to retrieve the parent's anchorable area
-	virtual Rect2 get_anchorable_rect() const { return Rect2(0, 0, 0, 0); };
+	virtual Rect2 get_anchorable_rect() const { return Rect2(0, 0, 0, 0); }
 
 	int get_canvas_layer() const;
 	CanvasLayer *get_canvas_layer_node() const;

--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -245,7 +245,7 @@ Dictionary InstancePlaceholder::get_stored_values(bool p_with_order) {
 	}
 
 	return ret;
-};
+}
 
 void InstancePlaceholder::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_stored_values", "with_order"), &InstancePlaceholder::get_stored_values, DEFVAL(false));

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -374,7 +374,7 @@ public:
 	bool is_wrapping_controls() const;
 	void child_controls_changed();
 
-	Window *get_exclusive_child() const { return exclusive_child; };
+	Window *get_exclusive_child() const { return exclusive_child; }
 	Window *get_parent_visible_window() const;
 	Viewport *get_parent_viewport() const;
 

--- a/scene/resources/2d/navigation_mesh_source_geometry_data_2d.cpp
+++ b/scene/resources/2d/navigation_mesh_source_geometry_data_2d.cpp
@@ -43,7 +43,7 @@ void NavigationMeshSourceGeometryData2D::clear() {
 bool NavigationMeshSourceGeometryData2D::has_data() {
 	RWLockRead read_lock(geometry_rwlock);
 	return traversable_outlines.size();
-};
+}
 
 void NavigationMeshSourceGeometryData2D::clear_projected_obstructions() {
 	RWLockWrite write_lock(geometry_rwlock);

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -174,13 +174,13 @@ void TileMapPattern::set_size(const Size2i &p_size) {
 
 bool TileMapPattern::is_empty() const {
 	return pattern.is_empty();
-};
+}
 
 void TileMapPattern::clear() {
 	size = Size2i();
 	pattern.clear();
 	emit_changed();
-};
+}
 
 bool TileMapPattern::_set(const StringName &p_name, const Variant &p_value) {
 	if (p_name == "tile_data") {
@@ -571,11 +571,11 @@ void TileSet::set_uv_clipping(bool p_uv_clipping) {
 
 bool TileSet::is_uv_clipping() const {
 	return uv_clipping;
-};
+}
 
 int TileSet::get_occlusion_layers_count() const {
 	return occlusion_layers.size();
-};
+}
 
 void TileSet::add_occlusion_layer(int p_index) {
 	if (p_index < 0) {
@@ -3691,7 +3691,7 @@ Array TileSet::compatibility_tilemap_map(int p_tile_id, Vector2i p_coords, bool 
 			return cannot_convert_array;
 			break;
 	}
-};
+}
 
 #endif // DISABLE_DEPRECATED
 
@@ -4432,7 +4432,7 @@ TileSet *TileSetSource::get_tile_set() const {
 
 void TileSetSource::reset_state() {
 	tile_set = nullptr;
-};
+}
 
 void TileSetSource::_bind_methods() {
 	// Base tiles

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -278,7 +278,7 @@ public:
 		bool operator==(const TerrainsPattern &p_terrains_pattern) const;
 		bool operator!=(const TerrainsPattern &p_terrains_pattern) const {
 			return !operator==(p_terrains_pattern);
-		};
+		}
 
 		void set_terrain(int p_terrain);
 		int get_terrain() const;
@@ -812,8 +812,8 @@ public:
 
 	// Scenes accessors. Lot are similar to "Alternative tiles".
 	int get_scene_tiles_count() { return get_alternative_tiles_count(Vector2i()); }
-	int get_scene_tile_id(int p_index) { return get_alternative_tile_id(Vector2i(), p_index); };
-	bool has_scene_tile_id(int p_id) { return has_alternative_tile(Vector2i(), p_id); };
+	int get_scene_tile_id(int p_index) { return get_alternative_tile_id(Vector2i(), p_index); }
+	bool has_scene_tile_id(int p_id) { return has_alternative_tile(Vector2i(), p_id); }
 	int create_scene_tile(Ref<PackedScene> p_packed_scene = Ref<PackedScene>(), int p_id_override = -1);
 	void set_scene_tile_id(int p_id, int p_new_id);
 	void set_scene_tile_scene(int p_id, Ref<PackedScene> p_packed_scene);

--- a/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
@@ -71,7 +71,7 @@ void NavigationMeshSourceGeometryData3D::append_arrays(const Vector<float> &p_ve
 bool NavigationMeshSourceGeometryData3D::has_data() {
 	RWLockRead read_lock(geometry_rwlock);
 	return vertices.size() && indices.size();
-};
+}
 
 void NavigationMeshSourceGeometryData3D::clear() {
 	RWLockWrite write_lock(geometry_rwlock);

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -545,7 +545,7 @@ private:
 		ContourPoint(const Vector2 &p_pt, bool p_sharp) {
 			point = p_pt;
 			sharp = p_sharp;
-		};
+		}
 	};
 
 	struct ContourInfo {

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1048,7 +1048,7 @@ int Animation::find_track(const NodePath &p_path, const TrackType p_type) const 
 		}
 	};
 	return -1;
-};
+}
 
 Animation::TrackType Animation::get_cache_type(TrackType p_type) {
 	if (p_type == Animation::TYPE_BEZIER) {

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -487,7 +487,7 @@ void CameraAttributesPhysical::_bind_methods() {
 	ADD_GROUP("Auto Exposure", "auto_exposure_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_min_exposure_value", PROPERTY_HINT_RANGE, "-16.0,16.0,0.01,or_greater,suffix:EV100"), "set_auto_exposure_min_exposure_value", "get_auto_exposure_min_exposure_value");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "auto_exposure_max_exposure_value", PROPERTY_HINT_RANGE, "-16.0,16.0,0.01,or_greater,suffix:EV100"), "set_auto_exposure_max_exposure_value", "get_auto_exposure_max_exposure_value");
-};
+}
 
 CameraAttributesPhysical::CameraAttributesPhysical() {
 	_update_exposure();

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -45,23 +45,23 @@ void MeshConvexDecompositionSettings::set_max_concavity(real_t p_max_concavity) 
 
 real_t MeshConvexDecompositionSettings::get_max_concavity() const {
 	return max_concavity;
-};
+}
 
 void MeshConvexDecompositionSettings::set_symmetry_planes_clipping_bias(real_t p_symmetry_planes_clipping_bias) {
 	symmetry_planes_clipping_bias = CLAMP(p_symmetry_planes_clipping_bias, 0.0, 1.0);
-};
+}
 
 real_t MeshConvexDecompositionSettings::get_symmetry_planes_clipping_bias() const {
 	return symmetry_planes_clipping_bias;
-};
+}
 
 void MeshConvexDecompositionSettings::set_revolution_axes_clipping_bias(real_t p_revolution_axes_clipping_bias) {
 	revolution_axes_clipping_bias = CLAMP(p_revolution_axes_clipping_bias, 0.0, 1.0);
-};
+}
 
 real_t MeshConvexDecompositionSettings::get_revolution_axes_clipping_bias() const {
 	return revolution_axes_clipping_bias;
-};
+}
 
 void MeshConvexDecompositionSettings::set_min_volume_per_convex_hull(real_t p_min_volume_per_convex_hull) {
 	min_volume_per_convex_hull = CLAMP(p_min_volume_per_convex_hull, 0.0001, 0.01);

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -113,7 +113,7 @@ private:
 		SmoothGroupVertex(const Vertex &p_vertex) {
 			vertex = p_vertex.vertex;
 			smooth_group = p_vertex.smooth_group;
-		};
+		}
 	};
 
 	struct SmoothGroupVertexHasher {

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -152,7 +152,7 @@ public:
 
 	int hit_test(const Point2 &p_coords) const;
 
-	Mutex &get_mutex() const { return _thread_safe_; };
+	Mutex &get_mutex() const { return _thread_safe_; }
 
 	TextParagraph(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language = "", float p_width = -1.f, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL);
 	TextParagraph();

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -61,7 +61,7 @@ class AudioDriverDummy : public AudioDriver {
 public:
 	virtual const char *get_name() const override {
 		return "Dummy";
-	};
+	}
 
 	virtual Error init() override;
 	virtual void start() override;

--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -53,13 +53,13 @@ void CameraServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEED_YCBCR_IMAGE);
 	BIND_ENUM_CONSTANT(FEED_Y_IMAGE);
 	BIND_ENUM_CONSTANT(FEED_CBCR_IMAGE);
-};
+}
 
 CameraServer *CameraServer::singleton = nullptr;
 
 CameraServer *CameraServer::get_singleton() {
 	return singleton;
-};
+}
 
 int CameraServer::get_free_id() {
 	bool id_exists = true;
@@ -77,7 +77,7 @@ int CameraServer::get_free_id() {
 	};
 
 	return newid;
-};
+}
 
 int CameraServer::get_feed_index(int p_id) {
 	for (int i = 0; i < feeds.size(); i++) {
@@ -87,7 +87,7 @@ int CameraServer::get_feed_index(int p_id) {
 	};
 
 	return -1;
-};
+}
 
 Ref<CameraFeed> CameraServer::get_feed_by_id(int p_id) {
 	int index = get_feed_index(p_id);
@@ -97,7 +97,7 @@ Ref<CameraFeed> CameraServer::get_feed_by_id(int p_id) {
 	} else {
 		return feeds[index];
 	}
-};
+}
 
 void CameraServer::add_feed(const Ref<CameraFeed> &p_feed) {
 	ERR_FAIL_COND(p_feed.is_null());
@@ -109,7 +109,7 @@ void CameraServer::add_feed(const Ref<CameraFeed> &p_feed) {
 
 	// let whomever is interested know
 	emit_signal(SNAME("camera_feed_added"), p_feed->get_id());
-};
+}
 
 void CameraServer::remove_feed(const Ref<CameraFeed> &p_feed) {
 	for (int i = 0; i < feeds.size(); i++) {
@@ -126,17 +126,17 @@ void CameraServer::remove_feed(const Ref<CameraFeed> &p_feed) {
 			return;
 		};
 	};
-};
+}
 
 Ref<CameraFeed> CameraServer::get_feed(int p_index) {
 	ERR_FAIL_INDEX_V(p_index, feeds.size(), nullptr);
 
 	return feeds[p_index];
-};
+}
 
 int CameraServer::get_feed_count() {
 	return feeds.size();
-};
+}
 
 TypedArray<CameraFeed> CameraServer::get_feeds() {
 	TypedArray<CameraFeed> return_feeds;
@@ -148,7 +148,7 @@ TypedArray<CameraFeed> CameraServer::get_feeds() {
 	};
 
 	return return_feeds;
-};
+}
 
 RID CameraServer::feed_texture(int p_id, CameraServer::FeedImage p_texture) {
 	int index = get_feed_index(p_id);
@@ -157,12 +157,12 @@ RID CameraServer::feed_texture(int p_id, CameraServer::FeedImage p_texture) {
 	Ref<CameraFeed> feed = get_feed(index);
 
 	return feed->get_texture(p_texture);
-};
+}
 
 CameraServer::CameraServer() {
 	singleton = this;
-};
+}
 
 CameraServer::~CameraServer() {
 	singleton = nullptr;
-};
+}

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -87,7 +87,7 @@ public:
 	static CameraServer *create() {
 		CameraServer *server = create_func ? create_func() : memnew(CameraServer);
 		return server;
-	};
+	}
 
 	// Right now we identify our feed by it's ID when it's used in the background.
 	// May see if we can change this to purely relying on CameraFeed objects or by name.

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -550,7 +550,7 @@ DisplayServer::ScreenOrientation DisplayServer::screen_get_orientation(int p_scr
 
 float DisplayServer::screen_get_scale(int p_screen) const {
 	return 1.0f;
-};
+}
 
 bool DisplayServer::is_touchscreen_available() const {
 	return Input::get_singleton() && Input::get_singleton()->is_emulating_touch_from_mouse();

--- a/servers/display_server_headless.h
+++ b/servers/display_server_headless.h
@@ -72,7 +72,7 @@ public:
 	// that don't affect the project's behavior in headless mode.
 
 	int get_screen_count() const override { return 0; }
-	int get_primary_screen() const override { return 0; };
+	int get_primary_screen() const override { return 0; }
 	Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return Point2i(); }
 	Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return Size2i(); }
 	Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override { return Rect2i(); }
@@ -141,7 +141,7 @@ public:
 
 	void window_request_attention(WindowID p_window = MAIN_WINDOW_ID) override {}
 	void window_move_to_foreground(WindowID p_window = MAIN_WINDOW_ID) override {}
-	bool window_is_focused(WindowID p_window = MAIN_WINDOW_ID) const override { return true; };
+	bool window_is_focused(WindowID p_window = MAIN_WINDOW_ID) const override { return true; }
 
 	bool window_can_draw(WindowID p_window = MAIN_WINDOW_ID) const override { return false; }
 

--- a/servers/navigation_server_2d_dummy.h
+++ b/servers/navigation_server_2d_dummy.h
@@ -58,7 +58,7 @@ public:
 	TypedArray<RID> map_get_agents(RID p_map) const override { return TypedArray<RID>(); }
 	TypedArray<RID> map_get_obstacles(RID p_map) const override { return TypedArray<RID>(); }
 	void map_force_update(RID p_map) override {}
-	Vector2 map_get_random_point(RID p_map, uint32_t p_naviation_layers, bool p_uniformly) const override { return Vector2(); };
+	Vector2 map_get_random_point(RID p_map, uint32_t p_naviation_layers, bool p_uniformly) const override { return Vector2(); }
 	uint32_t map_get_iteration_id(RID p_map) const override { return 0; }
 
 	RID region_create() override { return RID(); }
@@ -84,7 +84,7 @@ public:
 	Vector2 region_get_connection_pathway_start(RID p_region, int p_connection_id) const override { return Vector2(); }
 	Vector2 region_get_connection_pathway_end(RID p_region, int p_connection_id) const override { return Vector2(); }
 	Vector2 region_get_closest_point(RID p_region, const Vector2 &p_point) const override { return Vector2(); }
-	Vector2 region_get_random_point(RID p_region, uint32_t p_navigation_layers, bool p_uniformly) const override { return Vector2(); };
+	Vector2 region_get_random_point(RID p_region, uint32_t p_navigation_layers, bool p_uniformly) const override { return Vector2(); }
 
 	RID link_create() override { return RID(); }
 	void link_set_map(RID p_link, RID p_map) override {}

--- a/servers/rendering/dummy/rasterizer_dummy.h
+++ b/servers/rendering/dummy/rasterizer_dummy.h
@@ -66,14 +66,14 @@ protected:
 	RasterizerSceneDummy scene;
 
 public:
-	RendererUtilities *get_utilities() override { return &utilities; };
-	RendererLightStorage *get_light_storage() override { return &light_storage; };
-	RendererMaterialStorage *get_material_storage() override { return &material_storage; };
-	RendererMeshStorage *get_mesh_storage() override { return &mesh_storage; };
-	RendererParticlesStorage *get_particles_storage() override { return &particles_storage; };
-	RendererTextureStorage *get_texture_storage() override { return &texture_storage; };
-	RendererGI *get_gi() override { return &gi; };
-	RendererFog *get_fog() override { return &fog; };
+	RendererUtilities *get_utilities() override { return &utilities; }
+	RendererLightStorage *get_light_storage() override { return &light_storage; }
+	RendererMaterialStorage *get_material_storage() override { return &material_storage; }
+	RendererMeshStorage *get_mesh_storage() override { return &mesh_storage; }
+	RendererParticlesStorage *get_particles_storage() override { return &particles_storage; }
+	RendererTextureStorage *get_texture_storage() override { return &texture_storage; }
+	RendererGI *get_gi() override { return &gi; }
+	RendererFog *get_fog() override { return &fog; }
 	RendererCanvasRender *get_canvas() override { return &canvas; }
 	RendererSceneRender *get_scene() override { return &scene; }
 

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -92,7 +92,7 @@ public:
 	virtual RID shader_get_default_texture_parameter(RID p_shader, const StringName &p_name, int p_index) const override { return RID(); }
 	virtual Variant shader_get_parameter_default(RID p_material, const StringName &p_param) const override { return Variant(); }
 
-	virtual RS::ShaderNativeSourceCode shader_get_native_source_code(RID p_shader) const override { return RS::ShaderNativeSourceCode(); };
+	virtual RS::ShaderNativeSourceCode shader_get_native_source_code(RID p_shader) const override { return RS::ShaderNativeSourceCode(); }
 
 	/* MATERIAL API */
 	virtual RID material_allocate() override { return RID(); }

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -64,7 +64,7 @@ public:
 
 	/* MESH API */
 
-	bool owns_mesh(RID p_rid) { return mesh_owner.owns(p_rid); };
+	bool owns_mesh(RID p_rid) { return mesh_owner.owns(p_rid); }
 
 	virtual RID mesh_allocate() override;
 	virtual void mesh_initialize(RID p_rid) override;

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -53,7 +53,7 @@ public:
 
 	/* Canvas Texture API */
 
-	virtual RID canvas_texture_allocate() override { return RID(); };
+	virtual RID canvas_texture_allocate() override { return RID(); }
 	virtual void canvas_texture_initialize(RID p_rid) override {}
 	virtual void canvas_texture_free(RID p_rid) override {}
 
@@ -65,13 +65,13 @@ public:
 
 	/* Texture API */
 
-	bool owns_texture(RID p_rid) { return texture_owner.owns(p_rid); };
+	bool owns_texture(RID p_rid) { return texture_owner.owns(p_rid); }
 
 	virtual RID texture_allocate() override {
 		DummyTexture *texture = memnew(DummyTexture);
 		ERR_FAIL_NULL_V(texture, RID());
 		return texture_owner.make_rid(texture);
-	};
+	}
 
 	virtual void texture_free(RID p_rid) override {
 		// delete the texture
@@ -79,13 +79,13 @@ public:
 		ERR_FAIL_NULL(texture);
 		texture_owner.free(p_rid);
 		memdelete(texture);
-	};
+	}
 
 	virtual void texture_2d_initialize(RID p_texture, const Ref<Image> &p_image) override {
 		DummyTexture *t = texture_owner.get_or_null(p_texture);
 		ERR_FAIL_NULL(t);
 		t->image = p_image->duplicate();
-	};
+	}
 	virtual void texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) override {}
 	virtual void texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) override {}
 	virtual void texture_external_initialize(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override {}
@@ -107,15 +107,15 @@ public:
 		DummyTexture *t = texture_owner.get_or_null(p_texture);
 		ERR_FAIL_NULL_V(t, Ref<Image>());
 		return t->image;
-	};
-	virtual Ref<Image> texture_2d_layer_get(RID p_texture, int p_layer) const override { return Ref<Image>(); };
-	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const override { return Vector<Ref<Image>>(); };
+	}
+	virtual Ref<Image> texture_2d_layer_get(RID p_texture, int p_layer) const override { return Ref<Image>(); }
+	virtual Vector<Ref<Image>> texture_3d_get(RID p_texture) const override { return Vector<Ref<Image>>(); }
 
-	virtual void texture_replace(RID p_texture, RID p_by_texture) override { texture_free(p_by_texture); };
+	virtual void texture_replace(RID p_texture, RID p_by_texture) override { texture_free(p_by_texture); }
 	virtual void texture_set_size_override(RID p_texture, int p_width, int p_height) override {}
 
 	virtual void texture_set_path(RID p_texture, const String &p_path) override {}
-	virtual String texture_get_path(RID p_texture) const override { return String(); };
+	virtual String texture_get_path(RID p_texture) const override { return String(); }
 
 	virtual Image::Format texture_get_format(RID p_texture) const override { return Image::FORMAT_MAX; }
 
@@ -127,11 +127,11 @@ public:
 
 	virtual void texture_set_force_redraw_if_visible(RID p_texture, bool p_enable) override {}
 
-	virtual Size2 texture_size_with_proxy(RID p_proxy) override { return Size2(); };
+	virtual Size2 texture_size_with_proxy(RID p_proxy) override { return Size2(); }
 
 	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RS::TextureLayeredType p_layer_type = RS::TEXTURE_LAYERED_2D_ARRAY) override {}
-	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const override { return RID(); };
-	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const override { return 0; };
+	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const override { return RID(); }
+	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const override { return 0; }
 
 	/* DECAL API */
 	virtual RID decal_allocate() override { return RID(); }

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -124,7 +124,7 @@ public:
 	virtual RenderingDevice::DeviceType get_video_adapter_type() const override { return RenderingDevice::DeviceType::DEVICE_TYPE_OTHER; }
 	virtual String get_video_adapter_api_version() const override { return String(); }
 
-	virtual Size2i get_maximum_viewport_size() const override { return Size2i(); };
+	virtual Size2i get_maximum_viewport_size() const override { return Size2i(); }
 };
 
 } // namespace RendererDummy

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -106,7 +106,7 @@ public:
 	virtual double get_total_time() const = 0;
 	virtual bool can_create_resources_async() const = 0;
 
-	static bool is_low_end() { return low_end; };
+	static bool is_low_end() { return low_end; }
 	virtual bool is_xr_enabled() const;
 
 	static RendererCompositor *get_singleton() { return singleton; }

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -157,7 +157,7 @@ RendererRD::MaterialStorage::ShaderData *Fog::_create_fog_shader_func() {
 
 RendererRD::MaterialStorage::ShaderData *Fog::_create_fog_shader_funcs() {
 	return Fog::get_singleton()->_create_fog_shader_func();
-};
+}
 
 RendererRD::MaterialStorage::MaterialData *Fog::_create_fog_material_func(FogShaderData *p_shader) {
 	FogMaterialData *material_data = memnew(FogMaterialData);
@@ -168,7 +168,7 @@ RendererRD::MaterialStorage::MaterialData *Fog::_create_fog_material_func(FogSha
 
 RendererRD::MaterialStorage::MaterialData *Fog::_create_fog_material_funcs(RendererRD::MaterialStorage::ShaderData *p_shader) {
 	return Fog::get_singleton()->_create_fog_material_func(static_cast<FogShaderData *>(p_shader));
-};
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // FOG VOLUMES INSTANCE

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -233,7 +233,7 @@ public:
 
 	/* FOG VOLUMES */
 
-	bool owns_fog_volume(RID p_rid) { return fog_volume_owner.owns(p_rid); };
+	bool owns_fog_volume(RID p_rid) { return fog_volume_owner.owns(p_rid); }
 
 	virtual RID fog_volume_allocate() override;
 	virtual void fog_volume_initialize(RID p_rid) override;
@@ -250,7 +250,7 @@ public:
 
 	/* FOG VOLUMES INSTANCE */
 
-	bool owns_fog_volume_instance(RID p_rid) { return fog_volume_instance_owner.owns(p_rid); };
+	bool owns_fog_volume_instance(RID p_rid) { return fog_volume_instance_owner.owns(p_rid); }
 
 	RID fog_volume_instance_create(RID p_fog_volume);
 	void fog_instance_free(RID p_rid);

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -467,7 +467,7 @@ public:
 
 	/* VOXEL GI API */
 
-	bool owns_voxel_gi(RID p_rid) { return voxel_gi_owner.owns(p_rid); };
+	bool owns_voxel_gi(RID p_rid) { return voxel_gi_owner.owns(p_rid); }
 
 	virtual RID voxel_gi_allocate() override;
 	virtual void voxel_gi_free(RID p_voxel_gi) override;
@@ -524,14 +524,14 @@ public:
 		VoxelGIInstance *voxel_gi = voxel_gi_instance_owner.get_or_null(p_probe);
 		ERR_FAIL_NULL_V(voxel_gi, RID());
 		return voxel_gi->texture;
-	};
+	}
 
 	_FORCE_INLINE_ void voxel_gi_instance_set_render_index(RID p_probe, uint32_t p_index) {
 		VoxelGIInstance *voxel_gi = voxel_gi_instance_owner.get_or_null(p_probe);
 		ERR_FAIL_NULL(voxel_gi);
 
 		voxel_gi->render_index = p_index;
-	};
+	}
 
 	bool voxel_gi_instance_owns(RID p_rid) const {
 		return voxel_gi_instance_owner.owns(p_rid);

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -701,7 +701,7 @@ RendererRD::MaterialStorage::ShaderData *SkyRD::_create_sky_shader_func() {
 RendererRD::MaterialStorage::ShaderData *SkyRD::_create_sky_shader_funcs() {
 	// !BAS! Why isn't _create_sky_shader_func not just static too?
 	return static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton)->sky._create_sky_shader_func();
-};
+}
 
 RendererRD::MaterialStorage::MaterialData *SkyRD::_create_sky_material_func(SkyShaderData *p_shader) {
 	SkyMaterialData *material_data = memnew(SkyMaterialData);
@@ -713,7 +713,7 @@ RendererRD::MaterialStorage::MaterialData *SkyRD::_create_sky_material_func(SkyS
 RendererRD::MaterialStorage::MaterialData *SkyRD::_create_sky_material_funcs(RendererRD::MaterialStorage::ShaderData *p_shader) {
 	// !BAS! same here, we could just make _create_sky_material_func static?
 	return static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton)->sky._create_sky_material_func(static_cast<SkyShaderData *>(p_shader));
-};
+}
 
 SkyRD::SkyRD() {
 	roughness_layers = GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers");

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -103,7 +103,7 @@ protected:
 	static RendererCompositorRD *singleton;
 
 public:
-	RendererUtilities *get_utilities() { return utilities; };
+	RendererUtilities *get_utilities() { return utilities; }
 	RendererLightStorage *get_light_storage() { return light_storage; }
 	RendererMaterialStorage *get_material_storage() { return material_storage; }
 	RendererMeshStorage *get_mesh_storage() { return mesh_storage; }

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -78,7 +78,7 @@ protected:
 
 	////////////////////////////////
 
-	virtual RendererRD::ForwardIDStorage *create_forward_id_storage() { return memnew(RendererRD::ForwardIDStorage); };
+	virtual RendererRD::ForwardIDStorage *create_forward_id_storage() { return memnew(RendererRD::ForwardIDStorage); }
 
 	void _update_vrs(Ref<RenderSceneBuffersRD> p_render_buffers);
 

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1049,7 +1049,7 @@ void LightStorage::reflection_probe_free(RID p_rid) {
 	ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_rid);
 	reflection_probe->dependency.deleted_notify(p_rid);
 	reflection_probe_owner.free(p_rid);
-};
+}
 
 void LightStorage::reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode) {
 	ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_probe);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -590,7 +590,7 @@ public:
 
 	/* LIGHT INSTANCE API */
 
-	bool owns_light_instance(RID p_rid) { return light_instance_owner.owns(p_rid); };
+	bool owns_light_instance(RID p_rid) { return light_instance_owner.owns(p_rid); }
 
 	virtual RID light_instance_create(RID p_light) override;
 	virtual void light_instance_free(RID p_light) override;
@@ -811,7 +811,7 @@ public:
 
 	/* REFLECTION PROBE */
 
-	bool owns_reflection_probe(RID p_rid) { return reflection_probe_owner.owns(p_rid); };
+	bool owns_reflection_probe(RID p_rid) { return reflection_probe_owner.owns(p_rid); }
 
 	virtual RID reflection_probe_allocate() override;
 	virtual void reflection_probe_initialize(RID p_reflection_probe) override;
@@ -953,7 +953,7 @@ public:
 
 	/* LIGHTMAP */
 
-	bool owns_lightmap(RID p_rid) { return lightmap_owner.owns(p_rid); };
+	bool owns_lightmap(RID p_rid) { return lightmap_owner.owns(p_rid); }
 
 	virtual RID lightmap_allocate() override;
 	virtual void lightmap_initialize(RID p_lightmap) override;
@@ -1019,7 +1019,7 @@ public:
 
 	/* LIGHTMAP INSTANCE */
 
-	bool owns_lightmap_instance(RID p_rid) { return lightmap_instance_owner.owns(p_rid); };
+	bool owns_lightmap_instance(RID p_rid) { return lightmap_instance_owner.owns(p_rid); }
 
 	virtual RID lightmap_instance_create(RID p_lightmap) override;
 	virtual void lightmap_instance_free(RID p_lightmap) override;
@@ -1039,7 +1039,7 @@ public:
 
 	/* SHADOW ATLAS API */
 
-	bool owns_shadow_atlas(RID p_rid) { return shadow_atlas_owner.owns(p_rid); };
+	bool owns_shadow_atlas(RID p_rid) { return shadow_atlas_owner.owns(p_rid); }
 
 	virtual RID shadow_atlas_create() override;
 	virtual void shadow_atlas_free(RID p_atlas) override;

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -254,7 +254,7 @@ private:
 
 	MaterialDataRequestFunction material_data_request_func[SHADER_TYPE_MAX];
 	mutable RID_Owner<Material, true> material_owner;
-	Material *get_material(RID p_rid) { return material_owner.get_or_null(p_rid); };
+	Material *get_material(RID p_rid) { return material_owner.get_or_null(p_rid); }
 
 	SelfList<Material>::List material_update_list;
 	Mutex material_update_list_mutex;
@@ -403,7 +403,7 @@ public:
 
 	/* SHADER API */
 
-	bool owns_shader(RID p_rid) { return shader_owner.owns(p_rid); };
+	bool owns_shader(RID p_rid) { return shader_owner.owns(p_rid); }
 
 	virtual RID shader_allocate() override;
 	virtual void shader_initialize(RID p_shader) override;
@@ -423,7 +423,7 @@ public:
 
 	/* MATERIAL API */
 
-	bool owns_material(RID p_rid) { return material_owner.owns(p_rid); };
+	bool owns_material(RID p_rid) { return material_owner.owns(p_rid); }
 
 	void _material_queue_update(Material *material, bool p_uniform, bool p_texture);
 	void _update_queued_materials();

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -351,7 +351,7 @@ public:
 
 	/* MESH API */
 
-	bool owns_mesh(RID p_rid) { return mesh_owner.owns(p_rid); };
+	bool owns_mesh(RID p_rid) { return mesh_owner.owns(p_rid); }
 
 	virtual RID mesh_allocate() override;
 	virtual void mesh_initialize(RID p_mesh) override;
@@ -616,7 +616,7 @@ public:
 
 	/* MESH INSTANCE API */
 
-	bool owns_mesh_instance(RID p_rid) const { return mesh_instance_owner.owns(p_rid); };
+	bool owns_mesh_instance(RID p_rid) const { return mesh_instance_owner.owns(p_rid); }
 
 	virtual RID mesh_instance_create(RID p_base) override;
 	virtual void mesh_instance_free(RID p_rid) override;
@@ -628,7 +628,7 @@ public:
 
 	/* MULTIMESH API */
 
-	bool owns_multimesh(RID p_rid) { return multimesh_owner.owns(p_rid); };
+	bool owns_multimesh(RID p_rid) { return multimesh_owner.owns(p_rid); }
 
 	virtual RID _multimesh_allocate() override;
 	virtual void _multimesh_initialize(RID p_multimesh) override;
@@ -737,7 +737,7 @@ public:
 
 	/* SKELETON API */
 
-	bool owns_skeleton(RID p_rid) const { return skeleton_owner.owns(p_rid); };
+	bool owns_skeleton(RID p_rid) const { return skeleton_owner.owns(p_rid); }
 
 	virtual RID skeleton_allocate() override;
 	virtual void skeleton_initialize(RID p_skeleton) override;

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -195,7 +195,7 @@ private:
 
 	// Textures can be created from threads, so this RID_Owner is thread safe.
 	mutable RID_Owner<Texture, true> texture_owner;
-	Texture *get_texture(RID p_rid) { return texture_owner.get_or_null(p_rid); };
+	Texture *get_texture(RID p_rid) { return texture_owner.get_or_null(p_rid); }
 
 	struct TextureToRDFormat {
 		RD::DataFormat format;
@@ -439,7 +439,7 @@ private:
 	};
 
 	mutable RID_Owner<RenderTarget> render_target_owner;
-	RenderTarget *get_render_target(RID p_rid) const { return render_target_owner.get_or_null(p_rid); };
+	RenderTarget *get_render_target(RID p_rid) const { return render_target_owner.get_or_null(p_rid); }
 
 	void _clear_render_target(RenderTarget *rt);
 	void _update_render_target(RenderTarget *rt);
@@ -486,7 +486,7 @@ public:
 
 	/* Canvas Texture API */
 
-	bool owns_canvas_texture(RID p_rid) { return canvas_texture_owner.owns(p_rid); };
+	bool owns_canvas_texture(RID p_rid) { return canvas_texture_owner.owns(p_rid); }
 
 	virtual RID canvas_texture_allocate() override;
 	virtual void canvas_texture_initialize(RID p_rid) override;
@@ -502,7 +502,7 @@ public:
 
 	/* Texture API */
 
-	bool owns_texture(RID p_rid) const { return texture_owner.owns(p_rid); };
+	bool owns_texture(RID p_rid) const { return texture_owner.owns(p_rid); }
 
 	virtual RID texture_allocate() override;
 	virtual void texture_free(RID p_rid) override;
@@ -591,7 +591,7 @@ public:
 
 	void update_decal_atlas();
 
-	bool owns_decal(RID p_rid) const { return decal_owner.owns(p_rid); };
+	bool owns_decal(RID p_rid) const { return decal_owner.owns(p_rid); }
 
 	RID decal_atlas_get_texture() const;
 	RID decal_atlas_get_texture_srgb() const;
@@ -731,7 +731,7 @@ public:
 
 	/* RENDER TARGET API */
 
-	bool owns_render_target(RID p_rid) const { return render_target_owner.owns(p_rid); };
+	bool owns_render_target(RID p_rid) const { return render_target_owner.owns(p_rid); }
 
 	virtual RID render_target_create() override;
 	virtual void render_target_free(RID p_rid) override;

--- a/servers/rendering/renderer_rd/storage_rd/utilities.h
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.h
@@ -77,8 +77,8 @@ public:
 
 	/* VISIBILITY NOTIFIER */
 
-	VisibilityNotifier *get_visibility_notifier(RID p_rid) { return visibility_notifier_owner.get_or_null(p_rid); };
-	bool owns_visibility_notifier(RID p_rid) const { return visibility_notifier_owner.owns(p_rid); };
+	VisibilityNotifier *get_visibility_notifier(RID p_rid) { return visibility_notifier_owner.get_or_null(p_rid); }
+	bool owns_visibility_notifier(RID p_rid) const { return visibility_notifier_owner.owns(p_rid); }
 
 	virtual RID visibility_notifier_allocate() override;
 	virtual void visibility_notifier_initialize(RID p_notifier) override;

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -234,11 +234,11 @@ public:
 
 	RendererSceneOcclusionCull() {
 		singleton = this;
-	};
+	}
 
 	virtual ~RendererSceneOcclusionCull() {
 		singleton = nullptr;
-	};
+	}
 };
 
 #endif // RENDERER_SCENE_OCCLUSION_CULL_H

--- a/servers/rendering/storage/camera_attributes_storage.h
+++ b/servers/rendering/storage/camera_attributes_storage.h
@@ -72,8 +72,8 @@ public:
 	RendererCameraAttributes();
 	~RendererCameraAttributes();
 
-	CameraAttributes *get_camera_attributes(RID p_rid) { return camera_attributes_owner.get_or_null(p_rid); };
-	bool owns_camera_attributes(RID p_rid) { return camera_attributes_owner.owns(p_rid); };
+	CameraAttributes *get_camera_attributes(RID p_rid) { return camera_attributes_owner.get_or_null(p_rid); }
+	bool owns_camera_attributes(RID p_rid) { return camera_attributes_owner.owns(p_rid); }
 
 	RID camera_attributes_allocate();
 	void camera_attributes_initialize(RID p_rid);

--- a/servers/rendering/storage/render_scene_buffers.cpp
+++ b/servers/rendering/storage/render_scene_buffers.cpp
@@ -81,7 +81,7 @@ void RenderSceneBuffersExtension::_bind_methods() {
 
 void RenderSceneBuffersExtension::configure(const RenderSceneBuffersConfiguration *p_config) {
 	GDVIRTUAL_CALL(_configure, p_config);
-};
+}
 
 void RenderSceneBuffersExtension::set_fsr_sharpness(float p_fsr_sharpness) {
 	GDVIRTUAL_CALL(_set_fsr_sharpness, p_fsr_sharpness);

--- a/servers/text/text_server_dummy.h
+++ b/servers/text/text_server_dummy.h
@@ -88,7 +88,7 @@ public:
 	virtual int64_t font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const override { return 0; }
 	virtual bool font_has_char(const RID &p_font_rid, int64_t p_char) const override { return false; }
 	virtual String font_get_supported_chars(const RID &p_font_rid) const override { return String(); }
-	virtual PackedInt32Array font_get_supported_glyphs(const RID &p_font_rid) const override { return PackedInt32Array(); };
+	virtual PackedInt32Array font_get_supported_glyphs(const RID &p_font_rid) const override { return PackedInt32Array(); }
 	virtual void font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const override {}
 	virtual void font_draw_glyph_outline(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const override {}
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -544,8 +544,8 @@ public:
 	virtual PackedInt32Array string_get_word_breaks(const String &p_string, const String &p_language = "", int64_t p_chars_per_line = 0) const = 0;
 	virtual PackedInt32Array string_get_character_breaks(const String &p_string, const String &p_language = "") const;
 
-	virtual int64_t is_confusable(const String &p_string, const PackedStringArray &p_dict) const { return -1; };
-	virtual bool spoof_check(const String &p_string) const { return false; };
+	virtual int64_t is_confusable(const String &p_string, const PackedStringArray &p_dict) const { return -1; }
+	virtual bool spoof_check(const String &p_string) const { return false; }
 
 	virtual String strip_diacritics(const String &p_string) const;
 	virtual bool is_valid_identifier(const String &p_string) const;

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -108,7 +108,7 @@ void XRInterface::_bind_methods() {
 	BIND_ENUM_CONSTANT(XR_ENV_BLEND_MODE_OPAQUE);
 	BIND_ENUM_CONSTANT(XR_ENV_BLEND_MODE_ADDITIVE);
 	BIND_ENUM_CONSTANT(XR_ENV_BLEND_MODE_ALPHA_BLEND);
-};
+}
 
 bool XRInterface::is_primary() {
 	XRServer *xr_server = XRServer::get_singleton();
@@ -155,7 +155,7 @@ PackedVector3Array XRInterface::get_play_area() const {
 	// Note implementation is responsible for applying our reference frame and world scale to the raw data.
 	// `play_area_changed` should be emitted if play area data is available and either the reference frame or world scale changes.
 	return PackedVector3Array();
-};
+}
 
 /** these will only be implemented on AR interfaces, so we want dummies for VR **/
 bool XRInterface::get_anchor_detection_is_enabled() const {

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -138,7 +138,7 @@ public:
 	virtual RID get_depth_texture(); /* obtain depth output texture (if applicable, used for reprojection) */
 	virtual RID get_velocity_texture(); /* obtain velocity output texture (if applicable, used for spacewarp) */
 	virtual void pre_render() {}
-	virtual bool pre_draw_viewport(RID p_render_target) { return true; }; /* inform XR interface we are about to start our viewport draw process */
+	virtual bool pre_draw_viewport(RID p_render_target) { return true; } /* inform XR interface we are about to start our viewport draw process */
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) = 0; /* inform XR interface we finished our viewport draw process */
 	virtual void end_frame() {}
 

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -61,7 +61,7 @@ void XRPositionalTracker::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("input_float_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
 	ADD_SIGNAL(MethodInfo("input_vector2_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "vector")));
 	ADD_SIGNAL(MethodInfo("profile_changed", PropertyInfo(Variant::STRING, "role")));
-};
+}
 
 void XRPositionalTracker::set_tracker_profile(const String &p_profile) {
 	if (profile != p_profile) {
@@ -77,12 +77,12 @@ String XRPositionalTracker::get_tracker_profile() const {
 
 XRPositionalTracker::TrackerHand XRPositionalTracker::get_tracker_hand() const {
 	return tracker_hand;
-};
+}
 
 void XRPositionalTracker::set_tracker_hand(const XRPositionalTracker::TrackerHand p_hand) {
 	ERR_FAIL_INDEX(p_hand, TRACKER_HAND_MAX);
 	tracker_hand = p_hand;
-};
+}
 
 bool XRPositionalTracker::has_pose(const StringName &p_action_name) const {
 	return poses.has(p_action_name);

--- a/servers/xr/xr_tracker.cpp
+++ b/servers/xr/xr_tracker.cpp
@@ -42,24 +42,24 @@ void XRTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tracker_desc"), &XRTracker::get_tracker_desc);
 	ClassDB::bind_method(D_METHOD("set_tracker_desc", "description"), &XRTracker::set_tracker_desc);
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "description"), "set_tracker_desc", "get_tracker_desc");
-};
+}
 
 void XRTracker::set_tracker_type(XRServer::TrackerType p_type) {
 	type = p_type;
-};
+}
 
 XRServer::TrackerType XRTracker::get_tracker_type() const {
 	return type;
-};
+}
 
 void XRTracker::set_tracker_name(const StringName &p_name) {
 	// Note: this should not be changed after the tracker is registered with the XRServer!
 	name = p_name;
-};
+}
 
 StringName XRTracker::get_tracker_name() const {
 	return name;
-};
+}
 
 void XRTracker::set_tracker_desc(const String &p_desc) {
 	description = p_desc;

--- a/tests/core/config/test_project_settings.h
+++ b/tests/core/config/test_project_settings.h
@@ -40,7 +40,7 @@ class TestProjectSettingsInternalsAccessor {
 public:
 	static String &resource_path() {
 		return ProjectSettings::get_singleton()->resource_path;
-	};
+	}
 };
 
 namespace TestProjectSettings {

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -95,10 +95,10 @@ public:
 	}
 	bool property_can_revert(const StringName &p_name) const override {
 		return false;
-	};
+	}
 	bool property_get_revert(const StringName &p_name, Variant &r_ret) const override {
 		return false;
-	};
+	}
 	void get_method_list(List<MethodInfo> *p_list) const override {
 	}
 	bool has_method(const StringName &p_method) const override {


### PR DESCRIPTION
- ~~Introduces the `FORCE_SEMICOLON` macro to force a semi-colon to be inserted (and bypass clang-format).~~ (been replaced by turning off and on the checks for the sole exception in the codebase), as mentioned here: https://github.com/godotengine/godot/pull/97934#issuecomment-2430512526)
  - ~~See https://github.com/godotengine/godot/pull/97934#pullrequestreview-2352373936 for an example.~~
- Sets clang-format `Standard` rule to `c++20` 
  - (as there's currently [a c++20 feature](https://en.cppreference.com/w/cpp/language/constraints) [in the codebase](https://github.com/godotengine/godot/blob/db66bd35af704fe0d83ba9348b8c50a48e51b2ba/drivers/metal/rendering_device_driver_metal.mm#L1035-L1043) that messes up with semi-colons otherwise)
- adds clang-format-glsl check, that is the same as the usual clang-format, but with certain rules set to keep compatibility.

This should fix the superfluous semi-colons issue that takes a lot of time for some reviewers to flag in PRs.