### PR TITLE
Refresh Filesystem Dock after android build template is created

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -34,6 +34,7 @@
 #include "core/io/json.h"
 #include "core/io/zip_io.h"
 #include "core/version.h"
+#include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
@@ -876,7 +877,7 @@ Error ExportTemplateManager::install_android_template_from_file(const String &p_
 
 	ProgressDialog::get_singleton()->end_task("uncompress_src");
 	unzClose(pkg);
-
+	EditorFileSystem::get_singleton()->scan_changes();
 	return OK;
 }
 


### PR DESCRIPTION
**Issue:** Currently, after creating an android build template, filesystem dock is not updated to show the newly created android folder. It is only updated after some other actions (eg. editor focus_out and focus_in). This is not a major bug, but this seems kinda annoying.

**Fix:** This PR scan changes and refresh filesystem_dock after android build template is created.