### PR TITLE
Fix incorrect handling of exported typed dictionaries containing nodes in .NET

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -731,6 +731,8 @@ namespace Godot.SourceGenerators
             {
                 var elementTypes = MarshalUtils.GetGenericElementTypes(type);
 
+                bool containsNodeType = false;
+
                 if (elementTypes == null)
                     return false; // Non-generic Dictionary, so there's no hint to add
                 Debug.Assert(elementTypes.Length == 2);
@@ -753,6 +755,7 @@ namespace Godot.SourceGenerators
                     if (hintRes)
                     {
                         keyHintString = (int)keyElementVariantType + "/" + (int)keyElementHint + ":";
+                        containsNodeType |= keyElementHint == PropertyHint.NodeType;
 
                         if (keyElementHintString != null)
                             keyHintString += keyElementHintString;
@@ -781,6 +784,7 @@ namespace Godot.SourceGenerators
                     if (hintRes)
                     {
                         valueHintString = (int)valueElementVariantType + "/" + (int)valueElementHint + ":";
+                        containsNodeType |= valueElementHint == PropertyHint.NodeType;
 
                         if (valueElementHintString != null)
                             valueHintString += valueElementHintString;
@@ -791,7 +795,7 @@ namespace Godot.SourceGenerators
                     }
                 }
 
-                hint = PropertyHint.DictionaryType;
+                hint = containsNodeType ? PropertyHint.TypeString : PropertyHint.DictionaryType;
 
                 hintString = keyHintString != null && valueHintString != null ? $"{keyHintString};{valueHintString}" : null;
                 return hintString != null;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -112,6 +112,8 @@ namespace Godot.NativeInterop
 
         public static partial void godotsharp_ref_destroy(ref godot_ref p_instance);
 
+        public static partial void godotsharp_ref_to_var(ref godot_ref p_ref, out godot_variant r_dest);
+
         public static partial void godotsharp_string_name_new_from_string(out godot_string_name r_dest,
             in godot_string p_name);
 
@@ -462,6 +464,24 @@ namespace Godot.NativeInterop
             in godot_variant p_key);
 
         public static partial void godotsharp_dictionary_make_read_only(ref godot_dictionary p_self);
+
+        public static partial void godotsharp_dictionary_set_typed(ref godot_dictionary p_self, uint p_key_type, in godot_string_name p_key_class_name, in godot_variant p_key_script, uint p_value_type, in godot_string_name p_value_class_name, in godot_variant p_value_script);
+
+        public static partial godot_bool godotsharp_dictionary_is_typed_key(ref godot_dictionary p_self);
+
+        public static partial godot_bool godotsharp_dictionary_is_typed_value(ref godot_dictionary p_self);
+
+        public static partial uint godotsharp_dictionary_get_typed_key_builtin(ref godot_dictionary p_self);
+
+        public static partial uint godotsharp_dictionary_get_typed_value_builtin(ref godot_dictionary p_self);
+
+        public static partial void godotsharp_dictionary_get_typed_key_class_name(ref godot_dictionary p_self, out godot_string_name r_dest);
+
+        public static partial void godotsharp_dictionary_get_typed_value_class_name(ref godot_dictionary p_self, out godot_string_name r_dest);
+
+        public static partial void godotsharp_dictionary_get_typed_key_script(ref godot_dictionary p_self, out godot_variant r_dest);
+
+        public static partial void godotsharp_dictionary_get_typed_value_script(ref godot_dictionary p_self, out godot_variant r_dest);
 
         public static partial void godotsharp_dictionary_to_string(ref godot_dictionary p_self, out godot_string r_str);
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -375,6 +375,10 @@ void godotsharp_ref_destroy(Ref<RefCounted> *p_instance) {
 	p_instance->~Ref();
 }
 
+void godotsharp_ref_to_var(const Ref<RefCounted> *p_ref, Variant *r_dest) {
+	*r_dest = Variant(p_ref->ptr());
+}
+
 void godotsharp_string_name_new_from_string(StringName *r_dest, const String *p_name) {
 	memnew_placement(r_dest, StringName(*p_name));
 }
@@ -1207,6 +1211,42 @@ void godotsharp_dictionary_make_read_only(Dictionary *p_self) {
 	p_self->make_read_only();
 }
 
+void godotsharp_dictionary_set_typed(Dictionary *p_self, uint32_t p_key_type, const StringName *p_key_class_name, const Variant *p_key_script, uint32_t p_value_type, const StringName *p_value_class_name, const Variant *p_value_script) {
+	p_self->set_typed(p_key_type, *p_key_class_name, *p_key_script, p_value_type, *p_value_class_name, *p_value_script);
+}
+
+bool godotsharp_dictionary_is_typed_key(const Dictionary *p_self) {
+	return p_self->is_typed_key();
+}
+
+bool godotsharp_dictionary_is_typed_value(const Dictionary *p_self) {
+	return p_self->is_typed_value();
+}
+
+uint32_t godotsharp_dictionary_get_typed_key_builtin(const Dictionary *p_self) {
+	return p_self->get_typed_key_builtin();
+}
+
+uint32_t godotsharp_dictionary_get_typed_value_builtin(const Dictionary *p_self) {
+	return p_self->get_typed_value_builtin();
+}
+
+void godotsharp_dictionary_get_typed_key_class_name(const Dictionary *p_self, StringName *r_dest) {
+	memnew_placement(r_dest, StringName(p_self->get_typed_key_class_name()));
+}
+
+void godotsharp_dictionary_get_typed_value_class_name(const Dictionary *p_self, StringName *r_dest) {
+	memnew_placement(r_dest, StringName(p_self->get_typed_value_class_name()));
+}
+
+void godotsharp_dictionary_get_typed_key_script(const Dictionary *p_self, Variant *r_dest) {
+	memnew_placement(r_dest, Variant(p_self->get_typed_key_script()));
+}
+
+void godotsharp_dictionary_get_typed_value_script(const Dictionary *p_self, Variant *r_dest) {
+	memnew_placement(r_dest, Variant(p_self->get_typed_value_script()));
+}
+
 void godotsharp_dictionary_to_string(const Dictionary *p_self, String *r_str) {
 	*r_str = Variant(*p_self).operator String();
 }
@@ -1470,6 +1510,7 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_array_filter_godot_objects_by_non_native,
 	(void *)godotsharp_ref_new_from_ref_counted_ptr,
 	(void *)godotsharp_ref_destroy,
+	(void *)godotsharp_ref_to_var,
 	(void *)godotsharp_string_name_new_from_string,
 	(void *)godotsharp_node_path_new_from_string,
 	(void *)godotsharp_string_name_as_string,
@@ -1610,6 +1651,15 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_dictionary_recursive_equal,
 	(void *)godotsharp_dictionary_remove_key,
 	(void *)godotsharp_dictionary_make_read_only,
+	(void *)godotsharp_dictionary_set_typed,
+	(void *)godotsharp_dictionary_is_typed_key,
+	(void *)godotsharp_dictionary_is_typed_value,
+	(void *)godotsharp_dictionary_get_typed_key_builtin,
+	(void *)godotsharp_dictionary_get_typed_value_builtin,
+	(void *)godotsharp_dictionary_get_typed_key_class_name,
+	(void *)godotsharp_dictionary_get_typed_value_class_name,
+	(void *)godotsharp_dictionary_get_typed_key_script,
+	(void *)godotsharp_dictionary_get_typed_value_script,
 	(void *)godotsharp_dictionary_to_string,
 	(void *)godotsharp_string_simplify_path,
 	(void *)godotsharp_string_to_camel_case,

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -124,6 +124,40 @@ Ref<Resource> SceneState::get_remap_resource(const Ref<Resource> &p_resource, Ha
 	return remap_resource;
 }
 
+static void _parse_dictionary_hint_string(const String &p_hint_string, Variant::Type &r_key_subtype, PropertyHint &r_key_subtype_hint, String *r_key_class_name, Variant::Type &r_value_subtype, PropertyHint &r_value_subtype_hint, String *r_value_class_name) {
+	r_key_subtype = Variant::NIL;
+	r_key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+	r_value_subtype = Variant::NIL;
+	r_value_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
+
+	int key_value_separator = p_hint_string.find(";");
+	if (key_value_separator >= 0) {
+		int key_subtype_separator = p_hint_string.find(":");
+		String key_subtype_string = p_hint_string.substr(0, key_subtype_separator);
+		int key_slash_pos = key_subtype_string.find("/");
+		if (key_slash_pos >= 0) {
+			r_key_subtype_hint = PropertyHint(key_subtype_string.get_slice("/", 1).to_int());
+			key_subtype_string = key_subtype_string.substr(0, key_slash_pos);
+		}
+		r_key_subtype = Variant::Type(key_subtype_string.to_int());
+		if (r_key_class_name != nullptr) {
+			*r_key_class_name = p_hint_string.substr(key_subtype_separator + 1, key_value_separator - (key_subtype_separator + 1));
+		}
+
+		int value_subtype_separator = p_hint_string.find(":", key_value_separator) - (key_value_separator + 1);
+		String value_subtype_string = p_hint_string.substr(key_value_separator + 1, value_subtype_separator);
+		int value_slash_pos = value_subtype_string.find("/");
+		if (value_slash_pos >= 0) {
+			r_value_subtype_hint = PropertyHint(value_subtype_string.get_slice("/", 1).to_int());
+			value_subtype_string = value_subtype_string.substr(0, value_slash_pos);
+		}
+		r_value_subtype = Variant::Type(value_subtype_string.to_int());
+		if (r_value_class_name != nullptr) {
+			*r_value_class_name = p_hint_string.substr(key_value_separator + 1 + value_subtype_separator + 1);
+		}
+	}
+}
+
 Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	// Nodes where instantiation failed (because something is missing.)
 	List<Node *> stray_instances;
@@ -539,9 +573,38 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			Dictionary paths = dnp.value;
 
 			bool valid;
-			Dictionary dict = dnp.base->get(dnp.property, &valid);
+			Variant property_value = dnp.base->get(dnp.property, &valid);
 			ERR_CONTINUE_EDMSG(!valid, vformat("Failed to get property '%s' from node '%s'.", dnp.property, dnp.base->get_name()));
-			dict = dict.duplicate();
+
+			Dictionary dict;
+			if (property_value.get_type() != Variant::DICTIONARY) {
+				// The value of the property is currently not a dictionary.
+				// This can happen if we have an exported dictionary from .NET with its default value of null.
+				// This means we have to find the property in the property list and parse out the key and value types.
+
+				List<PropertyInfo> all_dnp_base_props;
+				dnp.base->get_property_list(&all_dnp_base_props);
+				for (const PropertyInfo &dnp_base_prop : all_dnp_base_props) {
+					if (dnp_base_prop.name == dnp.property) {
+						if (dnp_base_prop.type == Variant::DICTIONARY) {
+							Variant::Type key_subtype;
+							PropertyHint key_subtype_hint;
+							String key_class_name;
+							Variant::Type value_subtype;
+							PropertyHint value_subtype_hint;
+							String value_class_name;
+
+							_parse_dictionary_hint_string(dnp_base_prop.hint_string, key_subtype, key_subtype_hint, &key_class_name, value_subtype, value_subtype_hint, &value_class_name);
+
+							dict.set_typed(key_subtype, StringName(key_class_name), Variant(), value_subtype, StringName(value_class_name), Variant());
+						}
+						break;
+					}
+				}
+			} else {
+				dict = property_value;
+				dict = dict.duplicate();
+			}
 			bool convert_key = dict.get_typed_key_builtin() == Variant::OBJECT &&
 					ClassDB::is_parent_class(dict.get_typed_key_class_name(), "Node");
 			bool convert_value = dict.get_typed_value_builtin() == Variant::OBJECT &&
@@ -851,51 +914,36 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				}
 			}
 		} else if (E.type == Variant::DICTIONARY && E.hint == PROPERTY_HINT_TYPE_STRING) {
-			int key_value_separator = E.hint_string.find(";");
-			if (key_value_separator >= 0) {
-				int key_subtype_separator = E.hint_string.find(":");
-				String key_subtype_string = E.hint_string.substr(0, key_subtype_separator);
-				int key_slash_pos = key_subtype_string.find("/");
-				PropertyHint key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
-				if (key_slash_pos >= 0) {
-					key_subtype_hint = PropertyHint(key_subtype_string.get_slice("/", 1).to_int());
-					key_subtype_string = key_subtype_string.substr(0, key_slash_pos);
-				}
-				Variant::Type key_subtype = Variant::Type(key_subtype_string.to_int());
-				bool convert_key = key_subtype == Variant::OBJECT && key_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+			Variant::Type key_subtype;
+			PropertyHint key_subtype_hint;
+			Variant::Type value_subtype;
+			PropertyHint value_subtype_hint;
 
-				int value_subtype_separator = E.hint_string.find(":", key_value_separator) - (key_value_separator + 1);
-				String value_subtype_string = E.hint_string.substr(key_value_separator + 1, value_subtype_separator);
-				int value_slash_pos = value_subtype_string.find("/");
-				PropertyHint value_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
-				if (value_slash_pos >= 0) {
-					value_subtype_hint = PropertyHint(value_subtype_string.get_slice("/", 1).to_int());
-					value_subtype_string = value_subtype_string.substr(0, value_slash_pos);
-				}
-				Variant::Type value_subtype = Variant::Type(value_subtype_string.to_int());
-				bool convert_value = value_subtype == Variant::OBJECT && value_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+			_parse_dictionary_hint_string(E.hint_string, key_subtype, key_subtype_hint, nullptr, value_subtype, value_subtype_hint, nullptr);
 
-				if (convert_key || convert_value) {
-					use_deferred_node_path_bit = true;
-					Dictionary dict = value;
-					Dictionary new_dict;
-					for (int i = 0; i < dict.size(); i++) {
-						Variant new_key = dict.get_key_at_index(i);
-						if (convert_key && new_key.get_type() == Variant::OBJECT) {
-							if (Node *n = Object::cast_to<Node>(new_key)) {
-								new_key = p_node->get_path_to(n);
-							}
+			bool convert_key = key_subtype == Variant::OBJECT && key_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+			bool convert_value = value_subtype == Variant::OBJECT && value_subtype_hint == PROPERTY_HINT_NODE_TYPE;
+
+			if (convert_key || convert_value) {
+				use_deferred_node_path_bit = true;
+				Dictionary dict = value;
+				Dictionary new_dict;
+				for (int i = 0; i < dict.size(); i++) {
+					Variant new_key = dict.get_key_at_index(i);
+					if (convert_key && new_key.get_type() == Variant::OBJECT) {
+						if (Node *n = Object::cast_to<Node>(new_key)) {
+							new_key = p_node->get_path_to(n);
 						}
-						Variant new_value = dict.get_value_at_index(i);
-						if (convert_value && new_value.get_type() == Variant::OBJECT) {
-							if (Node *n = Object::cast_to<Node>(new_value)) {
-								new_value = p_node->get_path_to(n);
-							}
-						}
-						new_dict[new_key] = new_value;
 					}
-					value = new_dict;
+					Variant new_value = dict.get_value_at_index(i);
+					if (convert_value && new_value.get_type() == Variant::OBJECT) {
+						if (Node *n = Object::cast_to<Node>(new_value)) {
+							new_value = p_node->get_path_to(n);
+						}
+					}
+					new_dict[new_key] = new_value;
 				}
+				value = new_dict;
 			}
 		}
 


### PR DESCRIPTION
This should fix #97850. This pull request consists of multiple commits because there are multiple distinct bugs that needed to be fixed.

As observed [here](https://github.com/godotengine/godot/issues/97850#issuecomment-2395450615), the scene is written with a copy of the node selected in the inspector instead of a path to it. The reason for this is that the property hint that the scene serializer looks for to rewrite node references as paths is [PROPERTY_HINT_TYPE_STRING](https://github.com/godotengine/godot/blob/db66bd35af704fe0d83ba9348b8c50a48e51b2ba/scene/resources/packed_scene.cpp#L853), but the code generation for exposing .NET properties to Godot [does not account for this](https://github.com/godotengine/godot/blob/db66bd35af704fe0d83ba9348b8c50a48e51b2ba/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs#L794). That's fixed [here](https://github.com/godotengine/godot/commit/d6d129a716815382c5fa9c1962ffc660d8af4f94).

With that first bug fixed, another one reveals itself: the nodes in the exported dictionary are all nulled out on the .NET side of things. Looking further with `Get(nameof(Controls))`, what is happening is that the node paths that are stored in the scene are not being turned back into node references. The scene reader is getting an untyped dictionary, [which causes the relevant `get_typed_*_builtin` to not return `Variant::OBJECT`](https://github.com/godotengine/godot/blob/db66bd35af704fe0d83ba9348b8c50a48e51b2ba/scene/resources/packed_scene.cpp#L545-L548). The fix is to [call `set_typed` on typed dictionaries from .NET](https://github.com/godotengine/godot/commit/8aabfe0ad126c2c3ad356b5a68aff19a1b607a0d) so Godot also sees them as typed dictionaries.

These two fixes are still not enough because if no default non-null value is provided for the exported dictionary, which is the case in the MRP given, the scene reader still fails to convert node paths to the expected node type. That's fixed [here](https://github.com/godotengine/godot/commit/d6d129a716815382c5fa9c1962ffc).

Here's an updated MRP with a patched scene, because the first bug makes changes to the scene that are not easily reverted automatically: [MRP-97850-patched-scene.zip](https://github.com/user-attachments/files/17283258/MRP-97850-patched-scene.zip)

Do note that because of #97190, the scene will not load correctly if you open it before building the project, so make sure you do that.