### PR TITLE
[Web] Prevent default key inputs only if the key is not modified

### DIFF
--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -454,6 +454,13 @@ mergeInto(LibraryManager.library, GodotInputDragDrop);
 const GodotInput = {
 	$GodotInput__deps: ['$GodotRuntime', '$GodotConfig', '$GodotEventListeners', '$GodotInputGamepads', '$GodotInputDragDrop', '$GodotIME'],
 	$GodotInput: {
+		skipPreventDefaultKeyCodes: [
+			// All 24 function keys.
+			'F1', 'F2', 'F3', 'F4', 'F5', 'F6',
+			'F7', 'F8', 'F9', 'F10', 'F11', 'F12',
+			'F13', 'F14', 'F15', 'F16', 'F17', 'F18',
+			'F19', 'F20', 'F21', 'F22', 'F23', 'F24',
+		],
 		getModifiers: function (evt) {
 			return (evt.shiftKey + 0) + ((evt.altKey + 0) << 1) + ((evt.ctrlKey + 0) << 2) + ((evt.metaKey + 0) << 3);
 		},
@@ -569,7 +576,10 @@ const GodotInput = {
 			GodotRuntime.stringToHeap(evt.code, code, 32);
 			GodotRuntime.stringToHeap(evt.key, key, 32);
 			func(pressed, evt.repeat, modifiers);
-			evt.preventDefault();
+			const modified = evt.altKey || evt.ctrlKey || evt.shiftKey || evt.metaKey;
+			if (!modified && !GodotInput.skipPreventDefaultKeyCodes.includes(evt.code) && evt.cancelable) {
+				evt.preventDefault();
+			}
 		}
 		GodotEventListeners.add(GodotConfig.canvas, 'keydown', key_cb.bind(null, 1), false);
 		GodotEventListeners.add(GodotConfig.canvas, 'keyup', key_cb.bind(null, 0), false);


### PR DESCRIPTION
This PR changes how keyboard input is neutralized from having side effects in the browser.

Beforehand, every key input default behavior would be prevented, no matter which one they were. Unfortunately, it leaves some issues, such as not being able to spawn the developer tools, or worst even, not being able to refresh the browser nor being able to quit it via keyboard shortcuts.

This PR inspires itself [from the behavior of Phaser.js](https://github.com/phaserjs/phaser/blob/57965916e369a7d7879eaf7dabb66ebf9f69e660/src/input/keyboard/KeyboardManager.js#L198-L203).

If a key is being modified by Alt, Shift, Control, or Meta, we don't prevent default. This would reenable most browser shortcuts.

I also added function keys to the list of keys that cannot be "prevented".

Follow-up to #86178
Fixes #86175