### PR TITLE
Fix untyped dictionary .NET debug visualization showing keys as values

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs
@@ -174,7 +174,7 @@ namespace Godot.Collections
             var keys = Array.CreateTakingOwnershipOfDisposableValue(keysArray);
 
             godot_array valuesArray;
-            NativeFuncs.godotsharp_dictionary_keys(ref self, out valuesArray);
+            NativeFuncs.godotsharp_dictionary_values(ref self, out valuesArray);
             var values = Array.CreateTakingOwnershipOfDisposableValue(valuesArray);
 
             int count = NativeFuncs.godotsharp_dictionary_count(ref self);


### PR DESCRIPTION
I couldn't find an issue talking about this, but this fix is so small that I figured I'd just submit it without an issue to link to.

Here's what `Godot.Collections.Dictionary` looks like in Rider's debugger:
![image](https://github.com/user-attachments/assets/2b31e203-a634-412d-acb7-dd54f2c3434b)

With this fix, I get the expected result:
![image](https://github.com/user-attachments/assets/b02c4a32-dee9-4489-8fb1-5a0cfc4235f6)

MRP: [DictionaryDebugView.zip](https://github.com/user-attachments/files/17283661/DictionaryDebugView.zip)
