### PR TITLE
Allow `Control` to show custom tooltip when tooltip text is empty

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1448,7 +1448,11 @@ void Viewport::_gui_show_tooltip() {
 			&tooltip_owner);
 	gui.tooltip_text = gui.tooltip_text.strip_edges();
 
-	if (gui.tooltip_text.is_empty()) {
+	// Controls can implement `make_custom_tooltip` to provide their own tooltip.
+	// This should be a Control node which will be added as child to a TooltipPanel.
+	Control *base_tooltip = tooltip_owner ? tooltip_owner->make_custom_tooltip(gui.tooltip_text) : nullptr;
+
+	if (gui.tooltip_text.is_empty() && !base_tooltip) {
 		return; // Nothing to show.
 	}
 
@@ -1468,10 +1472,6 @@ void Viewport::_gui_show_tooltip() {
 
 	// Ensure no opaque background behind the panel as its StyleBox can be partially transparent (e.g. corners).
 	panel->set_transparent_background(true);
-
-	// Controls can implement `make_custom_tooltip` to provide their own tooltip.
-	// This should be a Control node which will be added as child to a TooltipPanel.
-	Control *base_tooltip = tooltip_owner->make_custom_tooltip(gui.tooltip_text);
 
 	// If no custom tooltip is given, use a default implementation.
 	if (!base_tooltip) {


### PR DESCRIPTION
Fixes #97944
Fixes #97990

In #97397, I changed the implementation of button's `shortcut_in_tooltip` from overriding `get_tooltip()` to overriding `make_custom_tooltip()`. However, if a button only has shortcut and no actual tooltip text, then the viewport assumes that the tooltip is not needed and `make_custom_tooltip()` is no longer called.

This PR makes the tooltip displayed when the tooltip text is not empty or `make_custom_tooltip()` returns a valid control.

This is useful when you want to make a customized tooltip without meaningful tooltip text.