### PR TITLE
Cache layout direction for `Control`

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -258,6 +258,9 @@ private:
 		// Internationalization.
 
 		LayoutDirection layout_dir = LAYOUT_DIRECTION_INHERITED;
+		mutable LayoutDirection resolved_layout_dir = LAYOUT_DIRECTION_APPLICATION_LOCALE;
+		mutable bool is_resolved_layout_dir_dirty = true;
+
 		mutable bool is_rtl_dirty = true;
 		mutable bool is_rtl = false;
 
@@ -325,7 +328,8 @@ private:
 
 	// Extra properties.
 
-	static int root_layout_direction;
+	// Root layout direction is never LAYOUT_DIRECTION_INHERITED.
+	static LayoutDirection root_layout_direction;
 
 	String get_tooltip_text() const;
 
@@ -634,6 +638,9 @@ public:
 	void set_layout_direction(LayoutDirection p_direction);
 	LayoutDirection get_layout_direction() const;
 	virtual bool is_layout_rtl() const;
+
+	// LAYOUT_DIRECTION_INHERITED is resolved into other enumerators.
+	LayoutDirection get_resolved_layout_direction() const;
 
 	void set_localize_numeral_system(bool p_enable);
 	bool is_localizing_numeral_system() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -39,10 +39,18 @@
 
 // Editor integration.
 
-int Window::root_layout_direction = 0;
+Window::LayoutDirection Window::root_layout_direction = Window::LAYOUT_DIRECTION_APPLICATION_LOCALE;
+
+static Window::LayoutDirection _to_layout_direction(int p_root_dir) {
+	// Root node layout direction skips LAYOUT_DIRECTION_INHERIT.
+	int shifted = p_root_dir + 1;
+	ERR_FAIL_INDEX_V(shifted, Window::LAYOUT_DIRECTION_MAX, Window::LAYOUT_DIRECTION_APPLICATION_LOCALE);
+	ERR_FAIL_COND_V(shifted == Window::LAYOUT_DIRECTION_INHERITED, Window::LAYOUT_DIRECTION_APPLICATION_LOCALE);
+	return (Window::LayoutDirection)shifted;
+}
 
 void Window::set_root_layout_direction(int p_root_dir) {
-	root_layout_direction = p_root_dir;
+	root_layout_direction = _to_layout_direction(p_root_dir);
 }
 
 // Dynamic properties.
@@ -2645,76 +2653,85 @@ Window::LayoutDirection Window::get_layout_direction() const {
 	return layout_dir;
 }
 
-bool Window::is_layout_rtl() const {
-	ERR_READ_THREAD_GUARD_V(false);
-	if (layout_dir == LAYOUT_DIRECTION_INHERITED) {
+Window::LayoutDirection Window::get_resolved_layout_direction() const {
+	switch (layout_dir) {
+		case LAYOUT_DIRECTION_APPLICATION_LOCALE: {
+			if (GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
+				return LAYOUT_DIRECTION_RTL;
+			}
+			return LAYOUT_DIRECTION_APPLICATION_LOCALE;
+		} break;
+
+		case LAYOUT_DIRECTION_SYSTEM_LOCALE: {
+			if (GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
+				return LAYOUT_DIRECTION_RTL;
+			}
+			return LAYOUT_DIRECTION_SYSTEM_LOCALE;
+		} break;
+
+		case LAYOUT_DIRECTION_INHERITED: {
 #ifdef TOOLS_ENABLED
-		if (is_part_of_edited_scene() && GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
-			return true;
-		}
-		if (is_inside_tree()) {
-			Node *edited_scene_root = get_tree()->get_edited_scene_root();
-			if (edited_scene_root == this) {
-				int proj_root_layout_direction = GLOBAL_GET(SNAME("internationalization/rendering/root_node_layout_direction"));
-				if (proj_root_layout_direction == 1) {
-					return false;
-				} else if (proj_root_layout_direction == 2) {
-					return true;
-				} else if (proj_root_layout_direction == 3) {
-					String locale = OS::get_singleton()->get_locale();
-					return TS->is_locale_right_to_left(locale);
-				} else {
-					String locale = TranslationServer::get_singleton()->get_tool_locale();
-					return TS->is_locale_right_to_left(locale);
+			if (is_part_of_edited_scene() && GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
+				return LAYOUT_DIRECTION_RTL;
+			}
+			if (is_inside_tree()) {
+				Node *edited_scene_root = get_tree()->get_edited_scene_root();
+				if (edited_scene_root == this) {
+					return _to_layout_direction(GLOBAL_GET(SNAME("internationalization/rendering/root_node_layout_direction")));
 				}
 			}
-		}
 #else
-		if (GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
-			return true;
-		}
+			if (GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
+				return LAYOUT_DIRECTION_RTL;
+			}
 #endif
-		Node *parent_node = get_parent();
-		while (parent_node) {
-			Control *parent_control = Object::cast_to<Control>(parent_node);
-			if (parent_control) {
-				return parent_control->is_layout_rtl();
+			Node *parent_node = get_parent();
+			while (parent_node) {
+				Control *parent_control = Object::cast_to<Control>(parent_node);
+				if (parent_control) {
+					return (LayoutDirection)parent_control->get_resolved_layout_direction();
+				}
+
+				Window *parent_window = Object::cast_to<Window>(parent_node);
+				if (parent_window) {
+					return parent_window->get_resolved_layout_direction();
+				}
+				parent_node = parent_node->get_parent();
 			}
 
-			Window *parent_window = Object::cast_to<Window>(parent_node);
-			if (parent_window) {
-				return parent_window->is_layout_rtl();
-			}
-			parent_node = parent_node->get_parent();
-		}
+			return root_layout_direction;
+		} break;
 
-		if (root_layout_direction == 1) {
+		default: {
+			return layout_dir;
+		} break;
+	}
+}
+
+bool Window::is_layout_rtl() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	switch (get_resolved_layout_direction()) {
+		case LAYOUT_DIRECTION_APPLICATION_LOCALE: {
+			const String &locale = TranslationServer::get_singleton()->get_tool_locale();
+			return TS->is_locale_right_to_left(locale);
+		} break;
+
+		case LAYOUT_DIRECTION_LTR: {
 			return false;
-		} else if (root_layout_direction == 2) {
+		} break;
+
+		case LAYOUT_DIRECTION_RTL: {
 			return true;
-		} else if (root_layout_direction == 3) {
-			String locale = OS::get_singleton()->get_locale();
+		} break;
+
+		case LAYOUT_DIRECTION_SYSTEM_LOCALE: {
+			const String &locale = OS::get_singleton()->get_locale();
 			return TS->is_locale_right_to_left(locale);
-		} else {
-			String locale = TranslationServer::get_singleton()->get_tool_locale();
-			return TS->is_locale_right_to_left(locale);
-		}
-	} else if (layout_dir == LAYOUT_DIRECTION_APPLICATION_LOCALE) {
-		if (GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
-			return true;
-		} else {
-			String locale = TranslationServer::get_singleton()->get_tool_locale();
-			return TS->is_locale_right_to_left(locale);
-		}
-	} else if (layout_dir == LAYOUT_DIRECTION_SYSTEM_LOCALE) {
-		if (GLOBAL_GET(SNAME("internationalization/rendering/force_right_to_left_layout_direction"))) {
-			return true;
-		} else {
-			String locale = OS::get_singleton()->get_locale();
-			return TS->is_locale_right_to_left(locale);
-		}
-	} else {
-		return (layout_dir == LAYOUT_DIRECTION_RTL);
+		} break;
+
+		default: {
+			ERR_FAIL_V_MSG(false, "Unexpected layout direction");
+		} break;
 	}
 }
 

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -241,7 +241,8 @@ private:
 
 	Ref<Shortcut> debugger_stop_shortcut;
 
-	static int root_layout_direction;
+	// Root layout direction is never LAYOUT_DIRECTION_INHERITED.
+	static LayoutDirection root_layout_direction;
 
 protected:
 	virtual Rect2i _popup_adjust_rect() const { return Rect2i(); }
@@ -406,6 +407,9 @@ public:
 	void set_layout_direction(LayoutDirection p_direction);
 	LayoutDirection get_layout_direction() const;
 	bool is_layout_rtl() const;
+
+	// LAYOUT_DIRECTION_INHERITED is resolved into other enumerators.
+	LayoutDirection get_resolved_layout_direction() const;
 
 #ifndef DISABLE_DEPRECATED
 	void set_auto_translate(bool p_enable);


### PR DESCRIPTION
Currently, `is_layout_rtl()` re-resolves inherited layout direction whenever locale changes. This is for most cases unnecessary because the actual layout direction (one of LTR, RTL, System Locale, and Application Locale) does not change when locale changes.

In this PR:

- The logic for resolving inherited layout direction & forcing RTL layout direction is extracted from `is_layout_rtl()` into a dedicated `get_resolved_layout_direction()`
    - `Control` caches resolved layout direction
- Use `LayoutDirection` enum to store root node layout direction settings so that it could be used directly later

This is a preparation for #97918.