### PR TITLE
Add default value of editor propetry `export/android/android_sdk_path` for Windows, Linux, and macOS 

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -700,6 +700,10 @@ void OS::benchmark_dump() {
 #endif
 }
 
+String OS::get_default_android_sdk_path() const {
+	return String();
+}
+
 OS::OS() {
 	singleton = this;
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -346,7 +346,7 @@ public:
 	virtual void load_platform_gdextensions() const {}
 
 	// TODO: Create similar method for Java SDK
-	virtual String get_default_android_sdk_path() const = 0;
+	virtual String get_default_android_sdk_path() const;
 
 	OS();
 	virtual ~OS();

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -344,7 +344,7 @@ public:
 	// Load GDExtensions specific to this platform.
 	// This is invoked by the GDExtensionManager after loading GDExtensions specified by the project.
 	virtual void load_platform_gdextensions() const {}
-	
+
 	// TODO: Create similar method for Java SDK
 	virtual String get_default_android_sdk_path() const = 0;
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -345,7 +345,7 @@ public:
 	// This is invoked by the GDExtensionManager after loading GDExtensions specified by the project.
 	virtual void load_platform_gdextensions() const {}
 	
-	// TODO: Similar method for Java SDK
+	// TODO: Create similar method for Java SDK
 	virtual String get_default_android_sdk_path() const = 0;
 
 	OS();

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -344,6 +344,9 @@ public:
 	// Load GDExtensions specific to this platform.
 	// This is invoked by the GDExtensionManager after loading GDExtensions specified by the project.
 	virtual void load_platform_gdextensions() const {}
+	
+	// TODO: Similar method for Java SDK
+	virtual String get_default_android_sdk_path() const = 0;
 
 	OS();
 	virtual ~OS();

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -52,7 +52,9 @@ void register_android_exporter() {
 #ifndef ANDROID_ENABLED
 	EDITOR_DEF_BASIC("export/android/java_sdk_path", OS::get_singleton()->get_environment("JAVA_HOME"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/java_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
-	EDITOR_DEF_BASIC("export/android/android_sdk_path", OS::get_singleton()->get_environment("ANDROID_HOME"));
+
+	EDITOR_DEF_BASIC("export/android/android_sdk_path", OS::get_singleton()->has_environment("ANDROID_HOME") ? OS::get_singleton()->get_environment("ANDROID_HOME") : OS::get_singleton()->get_default_android_sdk_path());
+	
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 	EDITOR_DEF("export/android/force_system_user", false);
 

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -54,7 +54,7 @@ void register_android_exporter() {
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/java_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 
 	EDITOR_DEF_BASIC("export/android/android_sdk_path", OS::get_singleton()->has_environment("ANDROID_HOME") ? OS::get_singleton()->get_environment("ANDROID_HOME") : OS::get_singleton()->get_default_android_sdk_path());
-	
+
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 	EDITOR_DEF("export/android/force_system_user", false);
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -1180,6 +1180,10 @@ String OS_LinuxBSD::get_system_ca_certificates() {
 	return f->get_as_text();
 }
 
+String OS_LinuxBSD::get_default_android_sdk_path() const {
+	return OS::get_singleton()->get_environment("HOME") + "/Android/Sdk";
+}
+
 OS_LinuxBSD::OS_LinuxBSD() {
 	main_loop = nullptr;
 

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -138,6 +138,8 @@ public:
 
 	virtual String get_system_ca_certificates() override;
 
+	virtual String get_default_android_sdk_path() const override;
+
 	OS_LinuxBSD();
 	~OS_LinuxBSD();
 };

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -126,6 +126,9 @@ public:
 	virtual Error move_to_trash(const String &p_path) override;
 
 	virtual String get_system_ca_certificates() override;
+
+	virtual String get_default_android_sdk_path() const override;
+
 	virtual OS::PreferredTextureFormat get_preferred_texture_format() const override;
 
 	void run();

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -763,6 +763,10 @@ String OS_MacOS::get_system_ca_certificates() {
 	return certs;
 }
 
+String OS_MacOS::get_default_android_sdk_path() const {
+	return OS::get_singleton()->get_environment("HOME") + "/Library/Android/Sdk";
+}
+
 OS::PreferredTextureFormat OS_MacOS::get_preferred_texture_format() const {
 	// macOS supports both formats on ARM. Prefer S3TC/BPTC
 	// for better compatibility with x86 platforms.

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2005,7 +2005,7 @@ String OS_Windows::get_system_ca_certificates() {
 }
 
 String OS_Windows::get_default_android_sdk_path() const {
-	return OS::get_singleton()->get_environment("LOCALAPPDATA") + "/Android/Sdk";
+	return OS::get_singleton()->get_environment("LOCALAPPDATA") + "\\Android\\Sdk";
 }
 
 OS_Windows::OS_Windows(HINSTANCE _hInstance) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2004,6 +2004,10 @@ String OS_Windows::get_system_ca_certificates() {
 	return certs;
 }
 
+String OS_Windows::get_default_android_sdk_path() const {
+	return OS::get_singleton()->get_environment("LOCALAPPDATA") + "/Android/Sdk";
+}
+
 OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	hInstance = _hInstance;
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -237,6 +237,8 @@ public:
 
 	virtual String get_system_ca_certificates() override;
 
+	virtual String get_default_android_sdk_path() const override;
+
 	void set_main_window(HWND p_main_window) { main_window = p_main_window; }
 
 	HINSTANCE get_hinstance() { return hInstance; }


### PR DESCRIPTION
It was always annoying to me to start android development in Godot because it doesn't work out of the box, despite the fact that it's completely possible (Android Studio is a prove).
In particular, for some reason, I always need to manually set Android SDK path, which is almost (if not completely) always the same within each OS family.

So now Godot has default value of Android SDK path for every supported OS:
* **Windows:** *%LOCALAPPDATA%\Android\Sdk*
* **Linux:** *$HOME/Android/Sdk*
* **macOS:** *$HOME/Library/Android/Sdk*

Tested on Linux and Windows (through wine), and compiled successfully for macOS.