### PR TITLE
[macOS] Update Vulkan SDK install script.

### DIFF
--- a/misc/scripts/install_vulkan_sdk_macos.sh
+++ b/misc/scripts/install_vulkan_sdk_macos.sh
@@ -4,19 +4,13 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Download and install the Vulkan SDK.
-curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.dmg" -o /tmp/vulkan-sdk.dmg
-hdiutil attach /tmp/vulkan-sdk.dmg -mountpoint /Volumes/vulkan-sdk
-/Volumes/vulkan-sdk/InstallVulkan.app/Contents/MacOS/InstallVulkan \
+curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip" -o /tmp/vulkan-sdk.zip
+unzip /tmp/vulkan-sdk.zip -d /tmp
+/tmp/InstallVulkan.app/Contents/MacOS/InstallVulkan \
     --accept-licenses --default-answer --confirm-command install
 
-cnt=5
-until hdiutil detach -force /Volumes/vulkan-sdk
-do
-   [[ cnt -eq "0" ]] && break
-   sleep 1
-   ((cnt--))
-done
 
-rm -f /tmp/vulkan-sdk.dmg
+rm -rf /tmp/InstallVulkan.app
+rm -f /tmp/vulkan-sdk.zip
 
 echo 'Vulkan SDK installed successfully! You can now build Godot by running "scons".'


### PR DESCRIPTION
Latest version of [SDK](https://vulkan.lunarg.com/sdk/home#mac) switched from DMG to ZIP.