### PR TITLE
Allow mesh Vertex Colors to be imported from Blender file even when not used by material

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -195,7 +195,7 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	}
 	if (blender_major_version > 4 || (blender_major_version == 4 && blender_minor_version >= 2)) {
 		if (p_options.has(SNAME("blender/meshes/colors")) && p_options[SNAME("blender/meshes/colors")]) {
-			parameters_map["export_vertex_color"] = "MATERIAL";
+			parameters_map["export_vertex_color"] = "ACTIVE";
 		} else {
 			parameters_map["export_vertex_color"] = "NONE";
 		}


### PR DESCRIPTION
Fixes  #97953

Vertex Colours were not being imported in Blender files if they were on meshes that didn't have materials attached. This is because `export_vertex_color` was set to `MATERIAL` (see here: https://docs.blender.org/api/current/bpy.ops.export_scene.html ). This PR switches the option to `ACTIVE` so that Vertex Colors get imported even when the mesh they're on doesn't use a material (check linked Issue for screenshots).