### PR TITLE
[DRAFT] GDExtension: Support hot-reloading in game

### DIFF
--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -75,6 +75,7 @@ private:
 	int last_reset = 0;
 	bool reload_all_scripts = false;
 	Array script_paths_to_reload;
+	bool reload_extensions = false;
 
 	// Make handlers and send_message thread safe.
 	Mutex mutex;

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/remote_debugger.h"
+#include "core/extension/gdextension_manager.h"
 #include "core/io/marshalls.h"
 #include "core/string/ustring.h"
 #include "core/version.h"
@@ -865,6 +866,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			error_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_error_activated));
 			breakpoints_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_breakpoint_tree_clicked));
 			connect("started", callable_mp(expression_evaluator, &EditorExpressionEvaluator::on_start));
+			GDExtensionManager::get_singleton()->connect("extensions_reloaded", callable_mp(this, &ScriptEditorDebugger::reload_extensions));
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
@@ -1543,6 +1545,12 @@ void ScriptEditorDebugger::reload_all_scripts() {
 
 void ScriptEditorDebugger::reload_scripts(const Vector<String> &p_script_paths) {
 	_put_msg("reload_scripts", Variant(p_script_paths).operator Array(), debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
+}
+
+void ScriptEditorDebugger::reload_extensions() {
+	if (is_session_active()) {
+		_put_msg("reload_extensions", Array(), debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);
+	}
 }
 
 bool ScriptEditorDebugger::is_skip_breakpoints() {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -306,6 +306,7 @@ public:
 
 	void reload_all_scripts();
 	void reload_scripts(const Vector<String> &p_script_paths);
+	void reload_extensions();
 
 	bool is_skip_breakpoints();
 

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -219,6 +219,10 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		args.push_back("--skip-breakpoints");
 	}
 
+	if (GLOBAL_GET("editor/run/enable_extension_reloading")) {
+		args.push_back("--gdextension-reload");
+	}
+
 	if (!p_scene.is_empty()) {
 		args.push_back(p_scene);
 	}

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -272,6 +272,7 @@ void register_editor_types() {
 
 	// For correct doc generation.
 	GLOBAL_DEF("editor/run/main_run_args", "");
+	GLOBAL_DEF("editor/run/enable_extension_reloading", false);
 
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "editor/script/templates_search_path", PROPERTY_HINT_DIR), "res://script_templates");
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1009,6 +1009,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	bool use_custom_res = true;
 	bool force_res = false;
 	bool delta_smoothing_override = false;
+	bool gdextension_reload_in_game = false;
 
 	String default_renderer = "";
 	String default_renderer_mobile = "";
@@ -1791,6 +1792,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing <port> argument for --dap-port <port>.\n");
 				goto error;
 			}
+		} else if (arg == "--gdextension-reload") {
+			gdextension_reload_in_game = true;
 #endif // TOOLS_ENABLED
 		} else if (arg == "--" || arg == "++") {
 			adding_user_args = true;
@@ -1862,6 +1865,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 	if (editor) {
 		Engine::get_singleton()->set_editor_hint(true);
+	}
+	if (editor || gdextension_reload_in_game) {
 		Engine::get_singleton()->set_extension_reloading_enabled(true);
 	}
 #endif


### PR DESCRIPTION
This adds a project setting (`editor/run/enable_extension_reloading`) that will enable hot-reloading GDExtensions in the game when run with the play button from the editor. (Currently, hot-reloading only happens in the editor itself, which is nice because you can see properties/signals/etc update, but doesn't let you "live edit" the game as it's running.)

It works in some really rudimentary testing on Linux.

However, I'm pretty sure this is going to have problems on Windows with the DLL copying stuff. I'd like to do more testing, including on multiple platforms, before taking this out of draft.
