### PR TITLE
Fix `ControlEditorPopupButton` arrow position in RTL language

### DIFF
--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -31,7 +31,6 @@
 #include "control_editor_plugin.h"
 
 #include "editor/editor_node.h"
-#include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
@@ -511,6 +510,9 @@ void ControlEditorPopupButton::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 			if (arrow_icon.is_valid()) {
 				Vector2 arrow_pos = Point2(26, 0) * EDSCALE;
+				if (is_layout_rtl()) {
+					arrow_pos.x = get_size().x - arrow_pos.x - arrow_icon->get_width();
+				}
 				arrow_pos.y = get_size().y / 2 - arrow_icon->get_height() / 2;
 				draw_texture(arrow_icon, arrow_pos);
 			}


### PR DESCRIPTION
The arrow is custom drawn and was not adapted to RTL layout.

| Before | After |
|---|---|
| ![ksnip_20241009-090058](https://github.com/user-attachments/assets/3439fab0-38e5-47a9-b252-2624ea64ce64) | ![ksnip_20241009-090056](https://github.com/user-attachments/assets/f2b57bf6-ebaa-47a6-a7ce-13ac88f2a5a0) |

Also removed one redundant header include in that cpp file.