### PR TITLE
GDScript: support variable declarations as condition for if-statement

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -1501,13 +1501,16 @@ void GDScriptByteCodeGenerator::write_if(const Address &p_condition) {
 	append(0); // Jump destination, will be patched.
 }
 
-void GDScriptByteCodeGenerator::write_else() {
+void GDScriptByteCodeGenerator::write_else(int count) {
 	append_opcode(GDScriptFunction::OPCODE_JUMP); // Jump from true if block;
 	int else_jmp_addr = opcodes.size();
 	append(0); // Jump destination, will be patched.
 
-	patch_jump(if_jmp_addrs.back()->get());
-	if_jmp_addrs.pop_back();
+	for (int i = 0; i < count; i++) {
+		patch_jump(if_jmp_addrs.back()->get());
+		if_jmp_addrs.pop_back();
+	}
+
 	if_jmp_addrs.push_back(else_jmp_addr);
 }
 

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -532,7 +532,7 @@ public:
 	virtual void write_construct_typed_dictionary(const Address &p_target, const GDScriptDataType &p_key_type, const GDScriptDataType &p_value_type, const Vector<Address> &p_arguments) override;
 	virtual void write_await(const Address &p_target, const Address &p_operand) override;
 	virtual void write_if(const Address &p_condition) override;
-	virtual void write_else() override;
+	virtual void write_else(int count) override;
 	virtual void write_endif() override;
 	virtual void write_jump_if_shared(const Address &p_value) override;
 	virtual void write_end_jump_if_shared() override;

--- a/modules/gdscript/gdscript_codegen.h
+++ b/modules/gdscript/gdscript_codegen.h
@@ -145,7 +145,7 @@ public:
 	virtual void write_construct_typed_dictionary(const Address &p_target, const GDScriptDataType &p_key_type, const GDScriptDataType &p_value_type, const Vector<Address> &p_arguments) = 0;
 	virtual void write_await(const Address &p_target, const Address &p_operand) = 0;
 	virtual void write_if(const Address &p_condition) = 0;
-	virtual void write_else() = 0;
+	virtual void write_else(int) = 0;
 	virtual void write_endif() = 0;
 	virtual void write_jump_if_shared(const Address &p_value) = 0;
 	virtual void write_end_jump_if_shared() = 0;

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -155,7 +155,7 @@ class GDScriptCompiler {
 	GDScriptCodeGenerator::Address _parse_match_pattern(CodeGen &codegen, Error &r_error, const GDScriptParser::PatternNode *p_pattern, const GDScriptCodeGenerator::Address &p_value_addr, const GDScriptCodeGenerator::Address &p_type_addr, const GDScriptCodeGenerator::Address &p_previous_test, bool p_is_first, bool p_is_nested);
 	List<GDScriptCodeGenerator::Address> _add_block_locals(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block);
 	void _clear_block_locals(CodeGen &codegen, const List<GDScriptCodeGenerator::Address> &p_locals);
-	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals = true, bool p_clear_locals = true);
+	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals = true, bool p_clear_locals = true, int p_do_not_patch_if = 0);
 	GDScriptFunction *_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready = false, bool p_for_lambda = false);
 	GDScriptFunction *_make_static_initializer(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class);
 	Error _parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -922,6 +922,11 @@ public:
 		SuiteNode *true_block = nullptr;
 		SuiteNode *false_block = nullptr;
 
+		// Used for multiple conditions.
+		// Greater-than-zero value indicates the it is the top-most IfNode for a multiple-condition if-statement.
+		// Zero value indicates it is a generated IfNode for a single condition.
+		int condition_count = 0;
+
 		IfNode() {
 			type = IF;
 		}
@@ -1516,7 +1521,7 @@ private:
 	// Statements.
 	Node *parse_statement();
 	VariableNode *parse_variable(bool p_is_static);
-	VariableNode *parse_variable(bool p_is_static, bool p_allow_property);
+	VariableNode *parse_variable(bool p_is_static, bool p_allow_property, bool p_in_multiple_condition_if = false);
 	VariableNode *parse_property(VariableNode *p_variable, bool p_need_indent);
 	void parse_property_getter(VariableNode *p_variable);
 	void parse_property_setter(VariableNode *p_variable);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Implement https://github.com/godotengine/godot-proposals/issues/2727 for if-statement.

This implementation is simple and intuitive but not elegant.

Idea is to parse code like

```
if var a := foo():
    do_something(a)
else:
    do_other_thing()

if a > b, var c := bar(a, b), c > d:
    do_something(c)
else:
    do_other_thing()
```

into code llike

```
if true:
    var a := foo()
    if a:                           # jump address when !a will be patched to
        do_something(a)
else:                               # ... here
    do_other_thing()

if true:
    if a > b:                       # all of jump address when !(a>b)
        var c := bar(a, b)
        if c:                       # ... and jump address when !c
            if c > d:               # ... and jump address when !(c>d)
                do_something(c)
else:                               # ... will be patched to here
    do_other_thing()
```

Such transform will guarantee short-circuit evaluation and scope visibility.

Semantics will be ensured by patching jump addresses (as above) duration compilation.
