### PR TITLE
Fix initial skin update timing in Skeleton3D

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -332,8 +332,8 @@ void MeshInstance3D::create_multiple_convex_collisions(const Ref<MeshConvexDecom
 
 void MeshInstance3D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
-			callable_mp(this, &MeshInstance3D::_resolve_skeleton_path).call_deferred();
+		case NOTIFICATION_ENTER_TREE: {
+			_resolve_skeleton_path();
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			if (mesh.is_valid()) {

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -324,6 +324,8 @@ void Skeleton3D::_notification(int p_what) {
 #ifndef DISABLE_DEPRECATED
 			setup_simulator();
 #endif // _DISABLE_DEPRECATED
+			update_flags = UPDATE_FLAG_POSE;
+			_notification(NOTIFICATION_UPDATE_SKELETON);
 		} break;
 		case NOTIFICATION_UPDATE_SKELETON: {
 			// Update bone transforms to apply unprocessed poses.


### PR DESCRIPTION
- Revert/Follow up https://github.com/godotengine/godot/pull/97489 to move the process to ENTER_TREE from READY
- Fixes https://github.com/godotengine/godot/issues/97982
- Fixes https://github.com/godotengine/godot/issues/98001

I have changed the update timing on the MeshInstance side in https://github.com/godotengine/godot/pull/97489 to READY, but now move it to the original timing as ENTER_TREE ~with calling deferred~. Instead, we will update the skin once before the deferred process in the skeleton.

This means that notifications for updates are called twice only in the first frame; once in the normal process and once in the deferred process, but this is probably not a serious problem since it is managed by the update flag, which is separate from the dirty flag.

Also, confirmed that https://github.com/godotengine/godot/issues/97459 does not recur.