### PR TITLE
Fix uneditable `LineEdit`, `TextEdit` and `CodeEdit` virtual keyboard popup on mobile

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -548,7 +548,9 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				pending_select_all_on_focus = false;
 			}
 
-			show_virtual_keyboard();
+			if (editable) {
+				show_virtual_keyboard();
+			}
 		}
 
 		queue_redraw();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1598,7 +1598,9 @@ void TextEdit::_notification(int p_what) {
 				draw_caret = true;
 			}
 
-			_show_virtual_keyboard();
+			if (editable) {
+				_show_virtual_keyboard();
+			}
 		} break;
 
 		case NOTIFICATION_FOCUS_EXIT: {
@@ -2001,7 +2003,9 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				}
 			}
 
-			_show_virtual_keyboard();
+			if (editable) {
+				_show_virtual_keyboard();
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #97993 