### PR TITLE
Restore `arc_tolerance` value when using Clipper2's `InflatePaths`

### DIFF
--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -35,7 +35,8 @@
 #define STB_RECT_PACK_IMPLEMENTATION
 #include "thirdparty/misc/stb_rect_pack.h"
 
-#define PRECISION 5 // Based on CMP_EPSILON.
+const int clipper_precision = 5; // Based on CMP_EPSILON.
+const double clipper_scale = Math::pow(10.0, clipper_precision);
 
 Vector<Vector<Vector2>> Geometry2D::decompose_polygon_in_convex(const Vector<Point2> &polygon) {
 	Vector<Vector<Vector2>> decomp;
@@ -224,7 +225,7 @@ Vector<Vector<Point2>> Geometry2D::_polypaths_do_operation(PolyBooleanOperation 
 		path_b[i] = PointD(p_polypath_b[i].x, p_polypath_b[i].y);
 	}
 
-	ClipperD clp(PRECISION); // Scale points up internally to attain the desired precision.
+	ClipperD clp(clipper_precision); // Scale points up internally to attain the desired precision.
 	clp.PreserveCollinear(false); // Remove redundant vertices.
 	if (is_a_open) {
 		clp.AddOpenSubject({ path_a });
@@ -298,9 +299,10 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 	}
 
 	// Inflate/deflate.
-	PathsD paths = InflatePaths({ polypath }, p_delta, jt, et, 2.0, PRECISION, 0.0);
-	// Here the miter_limit = 2.0 and arc_tolerance = 0.0 are Clipper2 defaults,
-	// and the PRECISION is used to scale points up internally, to attain the desired precision.
+	PathsD paths = InflatePaths({ polypath }, p_delta, jt, et, 2.0, clipper_precision, 0.25 * clipper_scale);
+	// Here the points are scaled up internally and
+	// the arc_tolerance is scaled accordingly
+	// to attain the desired precision.
 
 	Vector<Vector<Point2>> polypaths;
 	for (PathsD::size_type i = 0; i < paths.size(); ++i) {


### PR DESCRIPTION
This was missed when upgrading from Clipper to Clipper2.

The value used to be passed as the second argument to the [ClipperOffset constructor](https://angusj.com/delphi/clipper/documentation/Docs/Units/ClipperLib/Classes/ClipperOffset/Methods/Constructor.htm) here (with an inaccurate/outdated comment, as the default is `0.25` unscaled):

https://github.com/godotengine/godot/blob/a8bc9f3e78788bdf0be7348fcbfac15c127f1f48/core/math/geometry_2d.cpp#L293

Now we set the same parameter in Clipper2 by passing it to [`InflatePaths`](https://github.com/godotengine/godot/blob/4c4e67334412f73c9deba5e5d29afa8651418af2/thirdparty/clipper2/include/clipper2/clipper.h#L135-L137).

- Fixes https://github.com/godotengine/godot/issues/97964

The MRP now yields results and timings of the same order of magnitude as with Clipper in 4.2.2:

```
4.2.2 offset join round:
execution time: 46034
result size: 23 

4.2.2 offset join miter:
execution time: 24829
result size: 7 

4.4 offset join round:
execution time: 51572
result size: 25

4.4 offset join miter:
execution time: 25920
result size: 7 
```