### PR TITLE
Add the ability for PackedScenes and GDScripts to have import files

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -516,6 +516,24 @@ bool ResourceFormatImporter::are_import_settings_valid(const String &p_path) con
 	return true;
 }
 
+bool ResourceFormatImporter::is_import_read_only(const String &p_path) const {
+	bool valid = true;
+	PathAndType pat;
+	_get_path_and_type(p_path, pat, &valid);
+
+	if (!valid) {
+		return false;
+	}
+
+	for (int i = 0; i < importers.size(); i++) {
+		if (importers[i]->get_importer_name() == pat.importer) {
+			return importers[i]->is_read_only();
+		}
+	}
+
+	return false;
+}
+
 String ResourceFormatImporter::get_import_settings_hash() const {
 	Vector<Ref<ResourceImporter>> sorted_importers = importers;
 
@@ -537,8 +555,6 @@ ResourceFormatImporter::ResourceFormatImporter() {
 //////////////
 
 void ResourceImporter::_bind_methods() {
-	BIND_ENUM_CONSTANT(IMPORT_ORDER_DEFAULT);
-	BIND_ENUM_CONSTANT(IMPORT_ORDER_SCENE);
 }
 
 /////

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -94,6 +94,7 @@ public:
 	void get_importers(List<Ref<ResourceImporter>> *r_importers);
 
 	bool are_import_settings_valid(const String &p_path) const;
+	bool is_import_read_only(const String &p_path) const;
 	String get_import_settings_hash() const;
 
 	String get_import_base_path(const String &p_for_file) const;
@@ -117,7 +118,7 @@ public:
 	virtual String get_save_extension() const = 0;
 	virtual String get_resource_type() const = 0;
 	virtual float get_priority() const { return 1.0; }
-	virtual int get_import_order() const { return IMPORT_ORDER_DEFAULT; }
+	virtual int get_import_order() const { return ResourceFormatLoader::IMPORT_ORDER_DEFAULT; }
 	virtual int get_format_version() const { return 0; }
 
 	struct ImportOption {
@@ -129,11 +130,6 @@ public:
 				default_value(p_default) {
 		}
 		ImportOption() {}
-	};
-
-	enum ImportOrder {
-		IMPORT_ORDER_DEFAULT = 0,
-		IMPORT_ORDER_SCENE = 100,
 	};
 
 	virtual bool has_advanced_options() const { return false; }
@@ -155,9 +151,9 @@ public:
 	virtual Error import_group_file(const String &p_group_file, const HashMap<String, HashMap<StringName, Variant>> &p_source_file_options, const HashMap<String, String> &p_base_paths) { return ERR_UNAVAILABLE; }
 	virtual bool are_import_settings_valid(const String &p_path, const Dictionary &p_meta) const { return true; }
 	virtual String get_import_settings_string() const { return String(); }
-};
 
-VARIANT_ENUM_CAST(ResourceImporter::ImportOrder);
+	virtual bool is_read_only() const { return true; }
+};
 
 class ResourceFormatImporterSaver : public ResourceFormatSaver {
 	GDCLASS(ResourceFormatImporterSaver, ResourceFormatSaver)

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -192,6 +192,9 @@ void ResourceFormatLoader::_bind_methods() {
 	BIND_ENUM_CONSTANT(CACHE_MODE_REPLACE);
 	BIND_ENUM_CONSTANT(CACHE_MODE_IGNORE_DEEP);
 	BIND_ENUM_CONSTANT(CACHE_MODE_REPLACE_DEEP);
+	BIND_ENUM_CONSTANT(IMPORT_ORDER_LOW_PRIORITY);
+	BIND_ENUM_CONSTANT(IMPORT_ORDER_DEFAULT);
+	BIND_ENUM_CONSTANT(IMPORT_ORDER_SCENE);
 
 	GDVIRTUAL_BIND(_get_recognized_extensions);
 	GDVIRTUAL_BIND(_recognize_path, "path", "type");
@@ -284,15 +287,24 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 	// Try all loaders and pick the first match for the type hint
 	bool found = false;
 	Ref<Resource> res;
+	int foundIndex = -1;
+	int importOrder = -1;
 	for (int i = 0; i < loader_count; i++) {
 		if (!loader[i]->recognize_path(p_path, p_type_hint)) {
 			continue;
 		}
-		found = true;
-		res = loader[i]->load(p_path, original_path, r_error, p_use_sub_threads, r_progress, p_cache_mode);
-		if (!res.is_null()) {
-			break;
+
+		int newImportOrder = loader[i]->get_import_order(p_path);
+
+		if (newImportOrder > importOrder) {
+			foundIndex = i;
+			importOrder = newImportOrder;
+			found = true;
 		}
+	}
+
+	if (found) {
+		res = loader[foundIndex]->load(p_path, original_path, r_error, p_use_sub_threads, r_progress, p_cache_mode);
 	}
 
 	load_paths_stack.resize(load_paths_stack.size() - 1);

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -54,6 +54,18 @@ public:
 		CACHE_MODE_REPLACE_DEEP,
 	};
 
+	/**
+	 * Implement get_import_order() in your import class
+	 * and return a value greater than 1 to override Godot's default importers and/or loaders.
+	 * Use IMPORT_ORDER_LOW_PRIORITY to have Godot default importers and/or loaders override yours
+	 * (e.g. generating import files for native types but still use their ResourceFormatLoaders)
+	 */
+	enum ImportOrder {
+		IMPORT_ORDER_LOW_PRIORITY = 0,
+		IMPORT_ORDER_DEFAULT = 1,
+		IMPORT_ORDER_SCENE = 100,
+	};
+
 protected:
 	static void _bind_methods();
 
@@ -85,13 +97,14 @@ public:
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map);
 	virtual bool is_import_valid(const String &p_path) const { return true; }
 	virtual bool is_imported(const String &p_path) const { return false; }
-	virtual int get_import_order(const String &p_path) const { return 0; }
+	virtual int get_import_order(const String &p_path) const { return IMPORT_ORDER_DEFAULT; }
 	virtual String get_import_group_file(const String &p_path) const { return ""; } //no group
 
 	virtual ~ResourceFormatLoader() {}
 };
 
 VARIANT_ENUM_CAST(ResourceFormatLoader::CacheMode)
+VARIANT_ENUM_CAST(ResourceFormatLoader::ImportOrder)
 
 typedef void (*ResourceLoadErrorNotify)(const String &p_text);
 typedef void (*DependencyErrorNotify)(const String &p_loading, const String &p_which, const String &p_type);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -125,9 +125,11 @@
 #include "editor/import/resource_importer_bmfont.h"
 #include "editor/import/resource_importer_csv_translation.h"
 #include "editor/import/resource_importer_dynamic_font.h"
+#include "editor/import/resource_importer_gd_script.h"
 #include "editor/import/resource_importer_image.h"
 #include "editor/import/resource_importer_imagefont.h"
 #include "editor/import/resource_importer_layered_texture.h"
+#include "editor/import/resource_importer_packed_scene.h"
 #include "editor/import/resource_importer_shader_file.h"
 #include "editor/import/resource_importer_texture.h"
 #include "editor/import/resource_importer_texture_atlas.h"
@@ -1364,7 +1366,7 @@ void EditorNode::save_resource(const Ref<Resource> &p_resource) {
 
 	// If the resource has been imported, ask the user to use a different path in order to save it.
 	String path = p_resource->get_path();
-	if (path.is_resource_file() && !FileAccess::exists(path + ".import")) {
+	if (path.is_resource_file() && (!FileAccess::exists(path + ".import") || !ResourceFormatImporter::get_singleton()->is_import_read_only(path))) {
 		save_resource_in_path(p_resource, p_resource->get_path());
 	} else {
 		save_resource_as(p_resource);
@@ -1383,7 +1385,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 					return;
 				}
 			}
-		} else if (FileAccess::exists(path + ".import")) {
+		} else if (FileAccess::exists(path + ".import") && ResourceFormatImporter::get_singleton()->is_import_read_only(path)) {
 			show_warning(TTR("This resource can't be saved because it was imported from another file. Make it unique first."));
 			return;
 		}
@@ -2506,7 +2508,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		int subr_idx = current_res->get_path().find("::");
 		if (subr_idx != -1) {
 			String base_path = current_res->get_path().substr(0, subr_idx);
-			if (FileAccess::exists(base_path + ".import")) {
+			if (FileAccess::exists(base_path + ".import") && ResourceFormatImporter::get_singleton()->is_import_read_only(base_path)) {
 				if (!base_path.is_resource_file()) {
 					if (get_edited_scene() && get_edited_scene()->get_scene_file_path() == base_path) {
 						info_is_warning = true;
@@ -2517,7 +2519,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 				editable_info = TTR("This resource belongs to a scene that was instantiated or inherited.\nChanges to it must be made inside the original scene.");
 			}
 		} else if (current_res->get_path().is_resource_file()) {
-			if (FileAccess::exists(current_res->get_path() + ".import")) {
+			if (FileAccess::exists(current_res->get_path() + ".import") && ResourceFormatImporter::get_singleton()->is_import_read_only(current_res->get_path())) {
 				editable_info = TTR("This resource was imported, so it's not editable. Change its settings in the import panel and then re-import.");
 			}
 		}
@@ -2542,7 +2544,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 
 		if (get_edited_scene() && !get_edited_scene()->get_scene_file_path().is_empty()) {
 			String source_scene = get_edited_scene()->get_scene_file_path();
-			if (FileAccess::exists(source_scene + ".import")) {
+			if (FileAccess::exists(source_scene + ".import") && ResourceFormatImporter::get_singleton()->is_import_read_only(source_scene)) {
 				editable_info = TTR("This scene was imported, so changes to it won't be kept.\nInstantiating or inheriting it will allow you to make changes to it.\nPlease read the documentation relevant to importing scenes to better understand this workflow.");
 				info_is_warning = true;
 			}
@@ -3935,7 +3937,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 			}
 		}
 
-		if (!p_force_open_imported && FileAccess::exists(p_scene + ".import")) {
+		if (!p_force_open_imported && FileAccess::exists(p_scene + ".import") && ResourceFormatImporter::get_singleton()->is_import_read_only(p_scene)) {
 			open_imported->set_text(vformat(TTR("Scene '%s' was automatically imported, so it can't be modified.\nTo make changes to it, a new inherited scene can be created."), p_scene.get_file()));
 			open_imported->popup_centered();
 			new_inherited_button->grab_focus();
@@ -4477,18 +4479,18 @@ bool EditorNode::is_resource_read_only(Ref<Resource> p_resource, bool p_foreign_
 				if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
 					// If we have not flagged foreign resources as writable or the base scene the resource is
 					// part was imported, it can be considered read-only.
-					if (!p_foreign_resources_are_writable || FileAccess::exists(base + ".import")) {
+					if (!p_foreign_resources_are_writable || (FileAccess::exists(base + ".import") && ResourceFormatImporter::get_singleton()->is_import_read_only(base))) {
 						return true;
 					}
 				}
 			} else {
 				// If a corresponding .import file exists for the base file, we assume it to be imported and should therefore treated as read-only.
-				if (FileAccess::exists(base + ".import")) {
+				if (FileAccess::exists(base + ".import") && ResourceFormatImporter::get_singleton()->is_import_read_only(base)) {
 					return true;
 				}
 			}
 		}
-	} else if (FileAccess::exists(path + ".import")) {
+	} else if (FileAccess::exists(path + ".import") && ResourceFormatImporter::get_singleton()->is_import_read_only(path)) {
 		// The resource is not a subresource, but if it has an .import file, it's imported so treat it as read only.
 		return true;
 	}
@@ -6905,6 +6907,14 @@ EditorNode::EditorNode() {
 		Ref<ResourceImporterBitMap> import_bitmap;
 		import_bitmap.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_bitmap);
+
+		Ref<ResourceImporterPackedScene> import_packed_scene;
+		import_packed_scene.instantiate();
+		ResourceFormatImporter::get_singleton()->add_importer(import_packed_scene);
+
+		Ref<ResourceImporterGDScript> import_gd_script;
+		import_gd_script.instantiate();
+		ResourceFormatImporter::get_singleton()->add_importer(import_gd_script);
 	}
 
 	{

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -31,6 +31,7 @@
 #include "editor_properties.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/resource_importer.h"
 #include "editor/create_dialog.h"
 #include "editor/editor_node.h"
 #include "editor/editor_properties_array_dict.h"
@@ -2965,7 +2966,7 @@ void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource,
 		if (p_inspect) {
 			if (extensions.find(parent.get_extension()) && (!EditorNode::get_singleton()->get_edited_scene() || EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path() != parent)) {
 				// If the resource belongs to another (non-imported) scene, edit it in that scene instead.
-				if (!FileAccess::exists(parent + ".import")) {
+				if (!FileAccess::exists(parent + ".import") || !ResourceFormatImporter::get_singleton()->is_import_read_only(parent)) {
 					callable_mp(EditorNode::get_singleton(), &EditorNode::edit_foreign_resource).call_deferred(p_resource);
 					return;
 				}

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -35,6 +35,7 @@
 #include "core/extension/gdextension.h"
 #include "core/io/file_access_encrypted.h"
 #include "core/io/file_access_pack.h" // PACK_HEADER_MAGIC, PACK_FORMAT_VERSION
+#include "core/io/resource_importer.h"
 #include "core/io/zip_io.h"
 #include "core/version.h"
 #include "editor/editor_file_system.h"
@@ -1249,7 +1250,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		if (has_import_file) {
 			String importer_type = config->get_value("remap", "importer");
 
-			if (importer_type == "keep") {
+			if (importer_type == "keep" || !ResourceFormatImporter::get_singleton()->is_import_read_only(path)) {
 				// Just keep file as-is.
 				Vector<uint8_t> array = FileAccess::get_file_as_bytes(path);
 				err = p_func(p_udata, path, array, idx, total, enc_in_filters, enc_ex_filters, key);

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -285,7 +285,7 @@ public:
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 	// Import scenes *after* everything else (such as textures).
-	virtual int get_import_order() const override { return ResourceImporter::IMPORT_ORDER_SCENE; }
+	virtual int get_import_order() const override { return ResourceFormatImporter::IMPORT_ORDER_SCENE; }
 
 	void _pre_fix_global(Node *p_scene, const HashMap<StringName, Variant> &p_options) const;
 	Node *_pre_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &r_collision_map, Pair<PackedVector3Array, PackedInt32Array> *r_occluder_arrays, List<Pair<NodePath, Node *>> &r_node_renames, const HashMap<StringName, Variant> &p_options);

--- a/editor/import/resource_importer_gd_script.cpp
+++ b/editor/import/resource_importer_gd_script.cpp
@@ -1,0 +1,86 @@
+/**************************************************************************/
+/*  resource_importer_gd_script.cpp                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resource_importer_gd_script.h"
+
+String ResourceImporterGDScript::get_importer_name() const {
+	return "GDScript";
+}
+
+String ResourceImporterGDScript::get_visible_name() const {
+	return "GDScript";
+}
+
+void ResourceImporterGDScript::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("gd");
+}
+
+String ResourceImporterGDScript::get_save_extension() const {
+	return "rgd";
+}
+
+String ResourceImporterGDScript::get_resource_type() const {
+	return "GDScript";
+}
+
+bool ResourceImporterGDScript::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
+	return true;
+}
+
+bool ResourceImporterGDScript::is_read_only() const {
+	return false;
+}
+
+int ResourceImporterGDScript::get_import_order() const {
+	return ResourceFormatImporter::IMPORT_ORDER_LOW_PRIORITY;
+}
+
+int ResourceImporterGDScript::get_preset_count() const {
+	return 0;
+}
+
+String ResourceImporterGDScript::get_preset_name(int p_idx) const {
+	return String();
+}
+
+void ResourceImporterGDScript::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
+}
+
+Error ResourceImporterGDScript::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+	//make an empty import file in .godot/imported folder (won't be used during export)
+	Error err;
+	Ref<FileAccess> f = FileAccess::open(p_save_path + ".rgd", FileAccess::WRITE, &err);
+	ERR_FAIL_COND_V_MSG(err, ERR_CANT_OPEN, "Cannot save gd script import file '" + p_save_path + "'.rgd");
+
+	return OK;
+}
+
+ResourceImporterGDScript::ResourceImporterGDScript() {
+}

--- a/editor/import/resource_importer_gd_script.h
+++ b/editor/import/resource_importer_gd_script.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  resource_importer_gd_script.h                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RESOURCE_IMPORTER_GD_SCRIPT_H
+#define RESOURCE_IMPORTER_GD_SCRIPT_H
+
+#include "core/io/resource_importer.h"
+
+class ResourceImporterGDScript : public ResourceImporter {
+	GDCLASS(ResourceImporterGDScript, ResourceImporter);
+
+public:
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual String get_save_extension() const override;
+	virtual String get_resource_type() const override;
+	virtual String get_importer_name() const override;
+	virtual String get_visible_name() const override;
+	virtual int get_preset_count() const override;
+	virtual String get_preset_name(int p_idx) const override;
+	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
+	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
+	virtual bool is_read_only() const override;
+	virtual int get_import_order() const override;
+
+	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+
+	ResourceImporterGDScript();
+};
+
+#endif // RESOURCE_IMPORTER_GD_SCRIPT_H

--- a/editor/import/resource_importer_packed_scene.cpp
+++ b/editor/import/resource_importer_packed_scene.cpp
@@ -1,0 +1,86 @@
+/**************************************************************************/
+/*  resource_importer_packed_scene.cpp                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resource_importer_packed_scene.h"
+
+String ResourceImporterPackedScene::get_importer_name() const {
+	return "PackedScene";
+}
+
+String ResourceImporterPackedScene::get_visible_name() const {
+	return "PackedScene";
+}
+
+void ResourceImporterPackedScene::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("tscn");
+}
+
+String ResourceImporterPackedScene::get_save_extension() const {
+	return "rtscn";
+}
+
+String ResourceImporterPackedScene::get_resource_type() const {
+	return "PackedScene";
+}
+
+bool ResourceImporterPackedScene::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
+	return true;
+}
+
+bool ResourceImporterPackedScene::is_read_only() const {
+	return false;
+}
+
+int ResourceImporterPackedScene::get_import_order() const {
+	return ResourceFormatImporter::IMPORT_ORDER_LOW_PRIORITY;
+}
+
+int ResourceImporterPackedScene::get_preset_count() const {
+	return 0;
+}
+
+String ResourceImporterPackedScene::get_preset_name(int p_idx) const {
+	return String();
+}
+
+void ResourceImporterPackedScene::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
+}
+
+Error ResourceImporterPackedScene::import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+	//make an empty import file in .godot/imported folder (won't be used during export)
+	Error err;
+	Ref<FileAccess> f = FileAccess::open(p_save_path + ".rtscn", FileAccess::WRITE, &err);
+	ERR_FAIL_COND_V_MSG(err, ERR_CANT_OPEN, "Cannot save packed scene import file '" + p_save_path + "'.rtscn");
+
+	return OK;
+}
+
+ResourceImporterPackedScene::ResourceImporterPackedScene() {
+}

--- a/editor/import/resource_importer_packed_scene.h
+++ b/editor/import/resource_importer_packed_scene.h
@@ -1,0 +1,57 @@
+/**************************************************************************/
+/*  resource_importer_packed_scene.h                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef RESOURCE_IMPORTER_PACKED_SCENE_H
+#define RESOURCE_IMPORTER_PACKED_SCENE_H
+
+#include "core/io/resource_importer.h"
+
+class ResourceImporterPackedScene : public ResourceImporter {
+	GDCLASS(ResourceImporterPackedScene, ResourceImporter);
+
+public:
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual String get_save_extension() const override;
+	virtual String get_resource_type() const override;
+	virtual String get_importer_name() const override;
+	virtual String get_visible_name() const override;
+	virtual int get_preset_count() const override;
+	virtual String get_preset_name(int p_idx) const override;
+	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
+	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
+	virtual bool is_read_only() const override;
+	virtual int get_import_order() const override;
+
+	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+
+	ResourceImporterPackedScene();
+};
+
+#endif // RESOURCE_IMPORTER_PACKED_SCENE_H


### PR DESCRIPTION
I added the ability for PackedScenes and GDScripts to have import files. To accomplish that I had to make two fundamental changes to Godot:

1. Add the concept of "read only or not" to "resource assets" (resource assets = assets with import files). Previously Godot assumed any resource asset was read only. PackedScenes and GDScripts are not read only and can be edited/saved directly. In addition on export we want to use those assets directly not their corresponding files in the .godot folder (e.g. for a texture on export Godot wouldn't use the reference resource asset "someTexture.png" file but the corresponding encoded etc2/dxt/etc texture in the .godot folder.  For packedscenes/gdscripts though we want to use the reference resource asset).

2. When loading assets, use the "import order" on asset loaders to pick the right one instead of picking the first one Godot finds (see ResourceLoader::_load in resource_loader.cpp). We do this because by creating importers for PackedScenes and GDScripts, we are also creating loaders for those asset types. But PackedScenes and GDScripts already have native loaders, so we need to make sure those "native loaders" get picked over our "importing loaders". We do this by setting our importing loaders with a lower import order and changing ResourceLoader to use those orders when finding the right loader to choose.

This is "step one" in my effort to add "pack file tags" to facilitate exporting many pack files (https://github.com/godotengine/godot-proposals/issues/10580).  I tested this change with various godot projects and exporting to Windows/Android platforms.

 
![importer_example](https://github.com/user-attachments/assets/ba57f0a6-3327-4688-a94b-5b2f8c25c679)
![scene_import_file](https://github.com/user-attachments/assets/90ece1c2-e220-4448-b08f-5edf194d4fcd)
![gdscript_import_file](https://github.com/user-attachments/assets/67d74a1b-e86c-48b3-895e-1a26b89ae49a)

