### PR TITLE
Fix `is_inside_tree` error with CPUParticles3D

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -647,7 +647,7 @@ static real_t rand_from_seed(uint32_t &seed) {
 }
 
 void CPUParticles3D::_update_internal() {
-	if (particles.is_empty() || !is_visible_in_tree()) {
+	if (particles.is_empty() || !is_inside_tree() || !is_visible_in_tree()) {
 		_set_redraw(false);
 		return;
 	}


### PR DESCRIPTION
Fix #97970
