### PR TITLE
[.NET] Use `ObjectID` when converting `Variant` to `GodotObject`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/InteropStructs.cs
@@ -447,6 +447,12 @@ namespace Godot.NativeInterop
             get => _data._m_obj_data.obj;
         }
 
+        public readonly ulong ObjectId
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _data._m_obj_data.id;
+        }
+
         public void Dispose()
         {
             switch (Type)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -485,7 +485,14 @@ namespace Godot.NativeInterop
                 NativeFuncs.godotsharp_variant_as_rid(p_var);
 
         public static IntPtr ConvertToGodotObjectPtr(in godot_variant p_var)
-            => p_var.Type == Variant.Type.Object ? p_var.Object : IntPtr.Zero;
+        {
+            if (p_var.Type != Variant.Type.Object || p_var.ObjectId == 0)
+            {
+                return IntPtr.Zero;
+            }
+
+            return NativeFuncs.godotsharp_instance_from_id(p_var.ObjectId);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static GodotObject ConvertToGodotObject(in godot_variant p_var)


### PR DESCRIPTION
Use the `ObjectID` when converting `Variant` to `GodotObject` to avoid invalid Object pointers.

- Similar to https://github.com/godotengine/godot/pull/97119 and https://github.com/godotengine/godot-cpp/pull/1591.
- Fixes https://github.com/godotengine/godot/issues/92355.
- Supersedes https://github.com/godotengine/godot/pull/92572.
