### PR TITLE
Fix weird looking `recent_scenes` popup menu when the list of recent scenes is empty

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4570,13 +4570,14 @@ void EditorNode::_update_recent_scenes() {
 	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scenes", Array());
 	recent_scenes->clear();
 
-	String path;
-	for (int i = 0; i < rc.size(); i++) {
-		path = rc[i];
-		recent_scenes->add_item(path.replace("res://", ""), i);
-	}
+
 
 	if (rc.size() > 0) {
+		String path;
+		for (int i = 0; i < rc.size(); i++) {
+			path = rc[i];
+			recent_scenes->add_item(path.replace("res://", ""), i);
+		}
 		recent_scenes->add_separator();
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4576,8 +4576,12 @@ void EditorNode::_update_recent_scenes() {
 		recent_scenes->add_item(path.replace("res://", ""), i);
 	}
 
-	recent_scenes->add_separator();
+	if (rc.size() > 0) {
+		recent_scenes->add_separator();
+	}
+
 	recent_scenes->add_shortcut(ED_SHORTCUT("editor/clear_recent", TTR("Clear Recent Scenes")));
+	recent_scenes->set_item_disabled(0, rc.size() == 0);
 	recent_scenes->reset_size();
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4570,8 +4570,6 @@ void EditorNode::_update_recent_scenes() {
 	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scenes", Array());
 	recent_scenes->clear();
 
-
-
 	if (rc.size() > 0) {
 		String path;
 		for (int i = 0; i < rc.size(); i++) {


### PR DESCRIPTION
"Recent Scenes" popup menu now looks correctly when the list of recent scenes is empty.
Also made it inactive when there's nothing to clear.

# Before
![Screenshot from 2024-10-10 00-22-55](https://github.com/user-attachments/assets/b2d4dda2-bd27-4b47-9f81-c054f5bbd9b6)

# After
![Screenshot from 2024-10-10 00-21-19](https://github.com/user-attachments/assets/d8f3e4a1-69eb-45d2-828c-f137b80fb465)