### PR TITLE
Expose `Input.warp_mouse_motion()` to scripting

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -191,6 +191,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &Input::set_mouse_mode);
 	ClassDB::bind_method(D_METHOD("get_mouse_mode"), &Input::get_mouse_mode);
 	ClassDB::bind_method(D_METHOD("warp_mouse", "position"), &Input::warp_mouse);
+	ClassDB::bind_method(D_METHOD("warp_mouse_motion", "motion", "rect"), &Input::warp_mouse_motion);
 	ClassDB::bind_method(D_METHOD("action_press", "action", "strength"), &Input::action_press, DEFVAL(1.f));
 	ClassDB::bind_method(D_METHOD("action_release", "action"), &Input::action_release);
 	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Input::set_default_cursor_shape, DEFVAL(CURSOR_ARROW));

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -825,7 +825,17 @@
 			<description>
 				Sets the mouse position to the specified vector, provided in pixels and relative to an origin at the upper left corner of the currently focused Window Manager game window.
 				Mouse position is clipped to the limits of the screen resolution, or to the limits of the game window if [enum MouseMode] is set to [constant MOUSE_MODE_CONFINED] or [constant MOUSE_MODE_CONFINED_HIDDEN].
-				[b]Note:[/b] [method warp_mouse] is only supported on Windows, macOS and Linux. It has no effect on Android, iOS and Web.
+				[b]Note:[/b] [method warp_mouse] is only supported on Windows, macOS, and Linux. It has no effect on Android, iOS, and Web.
+			</description>
+		</method>
+		<method name="warp_mouse_motion">
+			<return type="Vector2" />
+			<param index="0" name="motion" type="InputEventMouseMotion" />
+			<param index="1" name="rect" type="Rect2" />
+			<description>
+				When the given mouse [param motion] moves the mouse past the boundary defined by the global [param rect], this method warps the mouse to the opposite side of the boundary. For example, this function is used by the 3D editor when orbiting to prevent the mouse getting stuck at the edge, instead the mouse is teleported to the other side of the 3D editor viewport and can continue moving freely in all directions.
+				This function is wrapper around [method warp_mouse], which will be called when the mouse needs to be warped. The returned value is the corrected relative mouse motion that should be used instead of the original [param motion]'s relative motion.
+				[b]Note:[/b] Like [method warp_mouse], [method warp_mouse_motion] is only supported on Windows, macOS, and Linux. It has no effect on Android, iOS, and Web.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
This function is used in the editor, and I would find it useful to have for writing my own editor code. I was using this function in an engine module, but I found the same function missing from GDExtension because it's not exposed.