### PR TITLE
[macOS] Pin Vulkan version in download script

### DIFF
--- a/misc/scripts/install_vulkan_sdk_macos.sh
+++ b/misc/scripts/install_vulkan_sdk_macos.sh
@@ -3,8 +3,20 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# These can be found in https://vulkan.lunarg.com/sdk/home/
+SDK_URL="https://sdk.lunarg.com/sdk/download/1.3.296.0/mac/vulkansdk-macos-1.3.296.0.zip"
+SDK_HASH="393fd11f65a4001f12fd34fdd009c38045220ca3f735bc686d97822152b0f33c"
+
 # Download and install the Vulkan SDK.
-curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip" -o /tmp/vulkan-sdk.zip
+curl -L $SDK_URL -o /tmp/vulkan-sdk.zip
+
+DL_HASH=$(shasum -a 256 /tmp/vulkan-sdk.zip | awk '{print $1}')
+if [ "$SDK_HASH" != "$DL_HASH" ]; then
+  echo "SDK_HASH: $SDK_HASH";
+  echo "DL_HASH:  $DL_HASH";
+  exit 1;
+fi
+
 unzip /tmp/vulkan-sdk.zip -d /tmp
 /tmp/InstallVulkan.app/Contents/MacOS/InstallVulkan \
     --accept-licenses --default-answer --confirm-command install


### PR DESCRIPTION
This should help prevent inconsistent CI results like what happened in the following checks 😄 

https://github.com/godotengine/godot/actions/runs/11222724075/job/31195803603?pr=97951

https://github.com/godotengine/godot/actions/runs/11239565581/job/31246955479

The issue was quickly identified in #97981 so builds weren't broken for long thankfully!

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
