### PR TITLE
GLTF: Fix bad pointer to ImporterMeshInstance3D root node at runtime

### DIFF
--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
@@ -43,6 +43,29 @@ void GLTFDocumentExtensionConvertImporterMesh::_copy_meta(Object *p_src_object, 
 	}
 }
 
+MeshInstance3D *GLTFDocumentExtensionConvertImporterMesh::convert_importer_mesh_instance_3d(ImporterMeshInstance3D *p_importer_mesh_instance_3d) {
+	// Convert the node itself first.
+	MeshInstance3D *mesh_instance_node_3d = memnew(MeshInstance3D);
+	ERR_FAIL_NULL_V(p_importer_mesh_instance_3d, mesh_instance_node_3d);
+	mesh_instance_node_3d->set_name(p_importer_mesh_instance_3d->get_name());
+	mesh_instance_node_3d->set_transform(p_importer_mesh_instance_3d->get_transform());
+	mesh_instance_node_3d->set_skin(p_importer_mesh_instance_3d->get_skin());
+	mesh_instance_node_3d->set_skeleton_path(p_importer_mesh_instance_3d->get_skeleton_path());
+	mesh_instance_node_3d->set_visible(p_importer_mesh_instance_3d->is_visible());
+	p_importer_mesh_instance_3d->replace_by(mesh_instance_node_3d);
+	_copy_meta(p_importer_mesh_instance_3d, mesh_instance_node_3d);
+	// Convert the mesh data in the mesh resource.
+	Ref<ImporterMesh> importer_mesh = p_importer_mesh_instance_3d->get_mesh();
+	if (importer_mesh.is_valid()) {
+		Ref<ArrayMesh> array_mesh = importer_mesh->get_mesh();
+		mesh_instance_node_3d->set_mesh(array_mesh);
+		_copy_meta(importer_mesh.ptr(), array_mesh.ptr());
+	} else {
+		WARN_PRINT("glTF: ImporterMeshInstance3D does not have a valid mesh. This should not happen. Continuing anyway.");
+	}
+	return mesh_instance_node_3d;
+}
+
 Error GLTFDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_state, Node *p_root) {
 	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
@@ -54,24 +77,8 @@ Error GLTFDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_sta
 		Node *node = E->get();
 		ImporterMeshInstance3D *importer_mesh_3d = Object::cast_to<ImporterMeshInstance3D>(node);
 		if (importer_mesh_3d) {
-			Ref<ImporterMesh> mesh = importer_mesh_3d->get_mesh();
-			if (mesh.is_valid()) {
-				MeshInstance3D *mesh_instance_node_3d = memnew(MeshInstance3D);
-				Ref<ArrayMesh> array_mesh = mesh->get_mesh();
-				mesh_instance_node_3d->set_name(node->get_name());
-				mesh_instance_node_3d->set_transform(importer_mesh_3d->get_transform());
-				mesh_instance_node_3d->set_mesh(array_mesh);
-				mesh_instance_node_3d->set_skin(importer_mesh_3d->get_skin());
-				mesh_instance_node_3d->set_skeleton_path(importer_mesh_3d->get_skeleton_path());
-				mesh_instance_node_3d->set_visible(importer_mesh_3d->is_visible());
-				node->replace_by(mesh_instance_node_3d);
-				_copy_meta(importer_mesh_3d, mesh_instance_node_3d);
-				_copy_meta(mesh.ptr(), array_mesh.ptr());
-				delete_queue.push_back(node);
-				node = mesh_instance_node_3d;
-			} else {
-				WARN_PRINT("glTF: ImporterMeshInstance3D does not have a valid mesh. This should not happen. Continuing anyway.");
-			}
+			delete_queue.push_back(importer_mesh_3d);
+			node = convert_importer_mesh_instance_3d(importer_mesh_3d);
 		}
 		int child_count = node->get_child_count();
 		for (int i = 0; i < child_count; i++) {

--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.h
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.h
@@ -33,6 +33,8 @@
 
 #include "gltf_document_extension.h"
 
+class MeshInstance3D;
+
 class GLTFDocumentExtensionConvertImporterMesh : public GLTFDocumentExtension {
 	GDCLASS(GLTFDocumentExtensionConvertImporterMesh, GLTFDocumentExtension);
 
@@ -40,6 +42,7 @@ protected:
 	static void _copy_meta(Object *p_src_object, Object *p_dst_object);
 
 public:
+	static MeshInstance3D *convert_importer_mesh_instance_3d(ImporterMeshInstance3D *p_importer_mesh_instance_3d);
 	Error import_post(Ref<GLTFState> p_state, Node *p_root) override;
 };
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -30,6 +30,7 @@
 
 #include "gltf_document.h"
 
+#include "extensions/gltf_document_extension_convert_importer_mesh.h"
 #include "extensions/gltf_spec_gloss.h"
 #include "gltf_state.h"
 #include "skin_tool.h"
@@ -8467,6 +8468,11 @@ Node *GLTFDocument::generate_scene(Ref<GLTFState> p_state, float p_bake_fps, boo
 			err = ext->import_node(p_state, gltf_node, node_json, E.value);
 			ERR_CONTINUE(err != OK);
 		}
+	}
+	ImporterMeshInstance3D *root_importer_mesh = Object::cast_to<ImporterMeshInstance3D>(root);
+	if (unlikely(root_importer_mesh)) {
+		root = GLTFDocumentExtensionConvertImporterMesh::convert_importer_mesh_instance_3d(root_importer_mesh);
+		memdelete(root_importer_mesh);
 	}
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/98038

This bug was caused by the root node getting deleted by `GLTFDocumentExtensionConvertImporterMesh` at runtime only. I added some code to handle this in `GLTFDocument::generate_scene`, which calls a function in that long-named class which used to be a part of `import_post` but is now its own function (this is more readable anyway, IMO). I also enhanced the function a bit, now it will do a partial convert instead of giving up if the mesh is somehow null.

Note that in this PR, I opted for a specific solution, not a general one. In general, we do not expect that users should be replacing nodes after the scene has been generated, instead they should just generate the correct nodes the first time. The `ImporterMeshInstance3D` class in Godot is the one big exception to this rule.