### PR TITLE
GDScript: Remove some unnecessary booleans

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -148,11 +148,10 @@ void GDScript::_super_implicit_constructor(GDScript *p_script, GDScriptInstance 
 	}
 }
 
-GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_is_ref_counted, Callable::CallError &r_error) {
+GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, Callable::CallError &r_error) {
 	/* STEP 1, CREATE */
 
 	GDScriptInstance *instance = memnew(GDScriptInstance);
-	instance->base_ref_counted = p_is_ref_counted;
 	instance->members.resize(member_indices.size());
 	instance->script = Ref<GDScript>(this);
 	instance->owner = p_owner;
@@ -235,7 +234,7 @@ Variant GDScript::_new(const Variant **p_args, int p_argcount, Callable::CallErr
 		ref = Ref<RefCounted>(r);
 	}
 
-	GDScriptInstance *instance = _create_instance(p_args, p_argcount, owner, r != nullptr, r_error);
+	GDScriptInstance *instance = _create_instance(p_args, p_argcount, owner, r_error);
 	if (!instance) {
 		if (ref.is_null()) {
 			memdelete(owner); //no owner, sorry
@@ -422,7 +421,7 @@ ScriptInstance *GDScript::instance_create(Object *p_this) {
 	}
 
 	Callable::CallError unchecked_error;
-	return _create_instance(nullptr, 0, p_this, Object::cast_to<RefCounted>(p_this) != nullptr, unchecked_error);
+	return _create_instance(nullptr, 0, p_this, unchecked_error);
 }
 
 PlaceHolderScriptInstance *GDScript::placeholder_instance_create(Object *p_this) {
@@ -694,7 +693,7 @@ void GDScript::_static_default_init() {
 	for (const KeyValue<StringName, MemberInfo> &E : static_variables_indices) {
 		const GDScriptDataType &type = E.value.data_type;
 		// Only initialize builtin types, which are not expected to be `null`.
-		if (!type.has_type || type.kind != GDScriptDataType::BUILTIN) {
+		if (type.kind != GDScriptDataType::BUILTIN) {
 			continue;
 		}
 		if (type.builtin_type == Variant::ARRAY && type.has_container_element_type(0)) {
@@ -1025,7 +1024,7 @@ bool GDScript::_set(const StringName &p_name, const Variant &p_value) {
 		if (E) {
 			const MemberInfo *member = &E->value;
 			Variant value = p_value;
-			if (member->data_type.has_type && !member->data_type.is_type(value)) {
+			if (!member->data_type.is_type(value)) {
 				const Variant *args = &p_value;
 				Callable::CallError err;
 				Variant::construct(member->data_type.builtin_type, value, &args, 1, err);
@@ -1685,7 +1684,7 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 		if (E) {
 			const GDScript::MemberInfo *member = &E->value;
 			Variant value = p_value;
-			if (member->data_type.has_type && !member->data_type.is_type(value)) {
+			if (!member->data_type.is_type(value)) {
 				const Variant *args = &p_value;
 				Callable::CallError err;
 				Variant::construct(member->data_type.builtin_type, value, &args, 1, err);
@@ -1712,7 +1711,7 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 			if (E) {
 				const GDScript::MemberInfo *member = &E->value;
 				Variant value = p_value;
-				if (member->data_type.has_type && !member->data_type.is_type(value)) {
+				if (!member->data_type.is_type(value)) {
 					const Variant *args = &p_value;
 					Callable::CallError err;
 					Variant::construct(member->data_type.builtin_type, value, &args, 1, err);
@@ -2168,11 +2167,6 @@ void GDScriptInstance::reload_members() {
 	}
 
 #endif
-}
-
-GDScriptInstance::GDScriptInstance() {
-	owner = nullptr;
-	base_ref_counted = false;
 }
 
 GDScriptInstance::~GDScriptInstance() {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -194,7 +194,7 @@ private:
 
 	GDScriptFunction *_super_constructor(GDScript *p_script);
 	void _super_implicit_constructor(GDScript *p_script, GDScriptInstance *p_instance, Callable::CallError &r_error);
-	GDScriptInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_is_ref_counted, Callable::CallError &r_error);
+	GDScriptInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, Callable::CallError &r_error);
 
 	String _get_debug_path() const;
 
@@ -374,7 +374,6 @@ class GDScriptInstance : public ScriptInstance {
 	HashMap<StringName, int> member_indices_cache; //used only for hot script reloading
 #endif
 	Vector<Variant> members;
-	bool base_ref_counted;
 
 	SelfList<GDScriptFunctionState>::List pending_func_states;
 
@@ -414,7 +413,7 @@ public:
 
 	virtual const Variant get_rpc_config() const;
 
-	GDScriptInstance();
+	GDScriptInstance() {}
 	~GDScriptInstance();
 };
 

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -65,7 +65,7 @@ uint32_t GDScriptByteCodeGenerator::add_or_get_name(const StringName &p_name) {
 
 uint32_t GDScriptByteCodeGenerator::add_temporary(const GDScriptDataType &p_type) {
 	Variant::Type temp_type = Variant::NIL;
-	if (p_type.has_type && p_type.kind == GDScriptDataType::BUILTIN) {
+	if (p_type.kind == GDScriptDataType::BUILTIN) {
 		switch (p_type.builtin_type) {
 			case Variant::NIL:
 			case Variant::BOOL:
@@ -423,10 +423,10 @@ void GDScriptByteCodeGenerator::set_initial_line(int p_line) {
 }
 
 #define HAS_BUILTIN_TYPE(m_var) \
-	(m_var.type.has_type && m_var.type.kind == GDScriptDataType::BUILTIN)
+	(m_var.type.kind == GDScriptDataType::BUILTIN)
 
 #define IS_BUILTIN_TYPE(m_var, m_type) \
-	(m_var.type.has_type && m_var.type.kind == GDScriptDataType::BUILTIN && m_var.type.builtin_type == m_type && m_type != Variant::NIL)
+	(m_var.type.kind == GDScriptDataType::BUILTIN && m_var.type.builtin_type == m_type && m_type != Variant::NIL)
 
 void GDScriptByteCodeGenerator::write_type_adjust(const Address &p_target, Variant::Type p_new_type) {
 	switch (p_new_type) {
@@ -1070,7 +1070,6 @@ GDScriptByteCodeGenerator::CallTarget GDScriptByteCodeGenerator::get_call_target
 	if (p_target.mode == Address::NIL) {
 		GDScriptDataType type;
 		if (p_type != Variant::NIL) {
-			type.has_type = true;
 			type.kind = GDScriptDataType::BUILTIN;
 			type.builtin_type = p_type;
 		}
@@ -1551,7 +1550,6 @@ void GDScriptByteCodeGenerator::start_for(const GDScriptDataType &p_iterator_typ
 
 	if (p_is_range) {
 		GDScriptDataType int_type;
-		int_type.has_type = true;
 		int_type.kind = GDScriptDataType::BUILTIN;
 		int_type.builtin_type = Variant::INT;
 
@@ -1618,7 +1616,7 @@ void GDScriptByteCodeGenerator::write_for(const Address &p_variable, bool p_use_
 	if (p_is_range) {
 		begin_opcode = GDScriptFunction::OPCODE_ITERATE_BEGIN_RANGE;
 		iterate_opcode = GDScriptFunction::OPCODE_ITERATE_RANGE;
-	} else if (container.type.has_type) {
+	} else if (container.type.has_type()) {
 		if (container.type.kind == GDScriptDataType::BUILTIN) {
 			switch (container.type.builtin_type) {
 				case Variant::INT:
@@ -1834,11 +1832,11 @@ void GDScriptByteCodeGenerator::write_newline(int p_line) {
 }
 
 void GDScriptByteCodeGenerator::write_return(const Address &p_return_value) {
-	if (!function->return_type.has_type || p_return_value.type.has_type) {
+	if (!function->return_type.has_type() || p_return_value.type.has_type()) {
 		// Either the function is untyped or the return value is also typed.
 
 		// If this is a typed function, then we need to check for potential conversions.
-		if (function->return_type.has_type) {
+		if (function->return_type.has_type()) {
 			if (function->return_type.kind == GDScriptDataType::BUILTIN && function->return_type.builtin_type == Variant::ARRAY && function->return_type.has_container_element_type(0)) {
 				// Typed array.
 				const GDScriptDataType &element_type = function->return_type.get_container_element_type(0);
@@ -1958,7 +1956,7 @@ void GDScriptByteCodeGenerator::clear_address(const Address &p_address) {
 	// Do not check `is_local_dirty()` here! Always clear the address since the codegen doesn't track the compiler.
 	// Also, this method is used to initialize local variables of built-in types, since they cannot be `null`.
 
-	if (p_address.type.has_type && p_address.type.kind == GDScriptDataType::BUILTIN) {
+	if (p_address.type.kind == GDScriptDataType::BUILTIN) {
 		switch (p_address.type.builtin_type) {
 			case Variant::BOOL:
 				write_assign_false(p_address);

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -101,7 +101,6 @@ class GDScriptCompiler {
 
 		GDScriptCodeGenerator::Address add_constant(const Variant &p_constant) {
 			GDScriptDataType type;
-			type.has_type = true;
 			type.kind = GDScriptDataType::BUILTIN;
 			type.builtin_type = p_constant.get_type();
 			if (type.builtin_type == Variant::OBJECT) {

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -48,29 +48,27 @@ public:
 	Vector<GDScriptDataType> container_element_types;
 
 	enum Kind {
-		UNINITIALIZED,
+		VARIANT, // Can be any type.
 		BUILTIN,
 		NATIVE,
 		SCRIPT,
 		GDSCRIPT,
 	};
 
-	Kind kind = UNINITIALIZED;
+	Kind kind = VARIANT;
 
-	bool has_type = false;
 	Variant::Type builtin_type = Variant::NIL;
 	StringName native_type;
 	Script *script_type = nullptr;
 	Ref<Script> script_type_ref;
 
-	bool is_type(const Variant &p_variant, bool p_allow_implicit_conversion = false) const {
-		if (!has_type) {
-			return true; // Can't type check
-		}
+	_FORCE_INLINE_ bool has_type() const { return kind != VARIANT; }
 
+	bool is_type(const Variant &p_variant, bool p_allow_implicit_conversion = false) const {
 		switch (kind) {
-			case UNINITIALIZED:
-				break;
+			case VARIANT: {
+				return true;
+			} break;
 			case BUILTIN: {
 				Variant::Type var_type = p_variant.get_type();
 				bool valid = builtin_type == var_type;
@@ -182,7 +180,7 @@ public:
 	}
 
 	bool can_contain_object() const {
-		if (has_type && kind == BUILTIN) {
+		if (kind == BUILTIN) {
 			switch (builtin_type) {
 				case Variant::ARRAY:
 					if (has_container_element_type(0)) {
@@ -236,7 +234,6 @@ public:
 
 	bool operator==(const GDScriptDataType &p_other) const {
 		return kind == p_other.kind &&
-				has_type == p_other.has_type &&
 				builtin_type == p_other.builtin_type &&
 				native_type == p_other.native_type &&
 				(script_type == p_other.script_type || script_type_ref == p_other.script_type_ref) &&
@@ -249,7 +246,6 @@ public:
 
 	void operator=(const GDScriptDataType &p_other) {
 		kind = p_other.kind;
-		has_type = p_other.has_type;
 		builtin_type = p_other.builtin_type;
 		native_type = p_other.native_type;
 		script_type = p_other.script_type;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -575,7 +575,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 		const int non_vararg_arg_count = MIN(p_argcount, _argument_count);
 		for (int i = 0; i < non_vararg_arg_count; i++) {
-			if (!argument_types[i].has_type) {
+			if (!argument_types[i].has_type()) {
 				memnew_placement(&stack[i + FIXED_ADDRESSES_MAX], Variant(*p_args[i]));
 				continue;
 			}


### PR DESCRIPTION
1. Remove `GDScriptDataType::has_type` and replace it with `kind = VARIANT`. This is cleaner because it allows us to avoid inconsistent states.
2. Remove unused `GDScriptInstance::base_ref_counted` field. If we need this again for some reason, there are the `owner` and `script` fields.