### PR TITLE
Fix Headless --import --quit crashes editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3378,6 +3378,8 @@ void EditorNode::unload_editor_addons() {
 		remove_editor_plugin(E.value, false);
 		memdelete(E.value);
 	}
+
+	addon_name_to_plugin.clear();
 }
 
 void EditorNode::_discard_changes(const String &p_str) {


### PR DESCRIPTION
Fixes this issue here:

https://github.com/godotengine/godot/issues/98062

``addon_name_to_plugin.clear();`` should be called due to the fact each plugin in ``addon_name_to_plugin`` was just deleted in the preceding for loop.  Future attempts to access the items in ``addon_name_to_plugin`` after ``memdelete`` was called result in crashes.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/98062*