### PR TITLE
[Web] Fix PWA callback assignment causing crash in sandboxed iframes

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -363,24 +363,28 @@ window.addEventListener('load', () => {
 		btn.style.display = '';
 	}
 	if ('serviceWorker' in navigator) {
-		navigator.serviceWorker.register('service.worker.js').then(function (reg) {
-			if (reg.waiting) {
-				notifyUpdate(reg.waiting);
-			}
-			reg.addEventListener('updatefound', function () {
-				const update = reg.installing;
-				update.addEventListener('statechange', function () {
-					if (update.state === 'installed') {
-						// It's a new install, claim and perform aggressive caching.
-						if (!reg.active) {
-							update.postMessage('claim');
-						} else {
-							notifyUpdate(update);
+		try {
+			navigator.serviceWorker.register('service.worker.js').then(function (reg) {
+				if (reg.waiting) {
+					notifyUpdate(reg.waiting);
+				}
+				reg.addEventListener('updatefound', function () {
+					const update = reg.installing;
+					update.addEventListener('statechange', function () {
+						if (update.state === 'installed') {
+							// It's a new install, claim and perform aggressive caching.
+							if (!reg.active) {
+								update.postMessage('claim');
+							} else {
+								notifyUpdate(update);
+							}
 						}
-					}
+					});
 				});
 			});
-		});
+		} catch (e) {
+			console.error('Error while registering service worker:', e);
+		}
 	}
 
 	const missing = Engine.getMissingFeatures({

--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -152,9 +152,15 @@ const engine = new Engine(GODOT_CONFIG);
 
 	if (missing.length !== 0) {
 		if (GODOT_CONFIG['serviceWorker'] && GODOT_CONFIG['ensureCrossOriginIsolationHeaders'] && 'serviceWorker' in navigator) {
+			let serviceWorkerRegistrationPromise;
+			try {
+				serviceWorkerRegistrationPromise = navigator.serviceWorker.getRegistration();
+			} catch (err) {
+				serviceWorkerRegistrationPromise = Promise.reject(new Error('Service worker registration failed.'));
+			}
 			// There's a chance that installing the service worker would fix the issue
 			Promise.race([
-				navigator.serviceWorker.getRegistration().then((registration) => {
+				serviceWorkerRegistrationPromise.then((registration) => {
 					if (registration != null) {
 						return Promise.reject(new Error('Service worker already exists.'));
 					}

--- a/platform/web/js/engine/engine.js
+++ b/platform/web/js/engine/engine.js
@@ -241,7 +241,11 @@ const Engine = (function () {
 			 */
 			installServiceWorker: function () {
 				if (this.config.serviceWorker && 'serviceWorker' in navigator) {
-					return navigator.serviceWorker.register(this.config.serviceWorker);
+					try {
+						return navigator.serviceWorker.register(this.config.serviceWorker);
+					} catch (e) {
+						return Promise.reject(e);
+					}
 				}
 				return Promise.resolve();
 			},

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -441,8 +441,12 @@ const GodotPWA = {
 	godot_js_pwa_cb__sig: 'vi',
 	godot_js_pwa_cb: function (p_update_cb) {
 		if ('serviceWorker' in navigator) {
-			const cb = GodotRuntime.get_func(p_update_cb);
-			navigator.serviceWorker.getRegistration().then(GodotPWA.updateState.bind(null, cb));
+			try {
+				const cb = GodotRuntime.get_func(p_update_cb);
+				navigator.serviceWorker.getRegistration().then(GodotPWA.updateState.bind(null, cb));
+			} catch (e) {
+				GodotRuntime.error('Failed to assign PWA callback', e);
+			}
 		}
 	},
 
@@ -450,12 +454,17 @@ const GodotPWA = {
 	godot_js_pwa_update__sig: 'i',
 	godot_js_pwa_update: function () {
 		if ('serviceWorker' in navigator && GodotPWA.hasUpdate) {
-			navigator.serviceWorker.getRegistration().then(function (reg) {
-				if (!reg || !reg.waiting) {
-					return;
-				}
-				reg.waiting.postMessage('update');
-			});
+			try {
+				navigator.serviceWorker.getRegistration().then(function (reg) {
+					if (!reg || !reg.waiting) {
+						return;
+					}
+					reg.waiting.postMessage('update');
+				});
+			} catch (e) {
+				GodotRuntime.error(e);
+				return 1;
+			}
 			return 0;
 		}
 		return 1;


### PR DESCRIPTION
Pull Request: Fix Service Worker Error in Sandboxed Iframe (#98068)
# Summary

This PR addresses the issue where the service worker callback fails in a sandboxed iframe, preventing the execution of Godot web builds. The solution introduces error handling for the service worker registration process, ensuring that any SecurityError or other exceptions are caught and logged appropriately without breaking the application.
Changes Made

- Error Handling: Wrapped the service worker registration calls in try-catch blocks to gracefully handle potential errors.
  - In the `godot_js_pwa_cb` function:
            Implemented a try-catch to manage errors during the assignment of the PWA callback. This prevents the application from crashing and logs any failures to the console.
  - In the `godot_js_pwa_update` function:
            Added a try-catch block around the service worker update logic to catch any errors and log them appropriately.
            
### Testing

Tested using https://github.com/thedinosoar/godot-iframe-test.git

* *Bugsquad edit, fixes: #98068*