### PR TITLE
[.NET] Re-order DotnetFinder so it searches path first before hard coded locations and add support for lookup by EditorSettings override

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -20,12 +20,12 @@ namespace GodotTools.Build
         private static Process LaunchBuild(BuildInfo buildInfo, Action<string?>? stdOutHandler,
             Action<string?>? stdErrHandler)
         {
-            string? dotnetPath = DotNetFinder.FindDotNetExe();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
+
+            string? dotnetPath = DotNetFinder.FindDotNetExe(editorSettings.GetSetting(GodotSharpEditor.Settings.OverrideDotnetExecutable).As<string>());
 
             if (dotnetPath == null)
                 throw new FileNotFoundException("Cannot find the dotnet executable.");
-
-            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             var startInfo = new ProcessStartInfo(dotnetPath);
 
@@ -91,12 +91,12 @@ namespace GodotTools.Build
         private static Process LaunchPublish(BuildInfo buildInfo, Action<string?>? stdOutHandler,
             Action<string?>? stdErrHandler)
         {
-            string? dotnetPath = DotNetFinder.FindDotNetExe();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
+
+            string? dotnetPath = DotNetFinder.FindDotNetExe(editorSettings.GetSetting(GodotSharpEditor.Settings.OverrideDotnetExecutable).As<string>());
 
             if (dotnetPath == null)
                 throw new FileNotFoundException("Cannot find the dotnet executable.");
-
-            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             var startInfo = new ProcessStartInfo(dotnetPath);
 

--- a/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/DotNetFinder.cs
@@ -11,8 +11,21 @@ namespace GodotTools.Build
 {
     public static class DotNetFinder
     {
-        public static string? FindDotNetExe()
+        public static string? FindDotNetExe(string? overrideDotnetExecutable)
         {
+            if (string.IsNullOrEmpty(overrideDotnetExecutable) == false)
+            {
+                if (File.Exists(overrideDotnetExecutable))
+                {
+                    return overrideDotnetExecutable;
+                }
+            }
+
+            string? pathDotnet = OS.PathWhich("dotnet");
+            if (pathDotnet != null)
+            {
+                return pathDotnet;
+            }
             // In the future, this method may do more than just search in PATH. We could look in
             // known locations or use Godot's linked nethost to search from the hostfxr location.
 
@@ -33,11 +46,12 @@ namespace GodotTools.Build
                 }
             }
 
-            return OS.PathWhich("dotnet");
+            return null;
         }
 
         public static bool TryFindDotNetSdk(
             Version expectedVersion,
+            string? overrideDotnetExecutable,
             [NotNullWhen(true)] out Version? version,
             [NotNullWhen(true)] out string? path
         )
@@ -45,7 +59,7 @@ namespace GodotTools.Build
             version = null;
             path = null;
 
-            string? dotNetExe = FindDotNetExe();
+            string? dotNetExe = FindDotNetExe(overrideDotnetExecutable);
 
             if (string.IsNullOrEmpty(dotNetExe))
                 return false;

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -34,6 +34,7 @@ namespace GodotTools
             public const string NoConsoleLogging = "dotnet/build/no_console_logging";
             public const string CreateBinaryLog = "dotnet/build/create_binary_log";
             public const string ProblemsLayout = "dotnet/build/problems_layout";
+            public const string OverrideDotnetExecutable = "dotnet/build/override_dotnet_executable";
         }
 
 #nullable disable
@@ -264,8 +265,7 @@ namespace GodotTools
                         GodotSharpDirs.ProjectSlnPath,
                         line >= 0 ? $"{scriptPath};{line + 1};{col + 1}" : scriptPath
                     };
-
-                    string command = DotNetFinder.FindDotNetExe() ?? "dotnet";
+                    string command = DotNetFinder.FindDotNetExe(_editorSettings.GetSetting(GodotSharpEditor.Settings.OverrideDotnetExecutable).As<string>()) ?? "dotnet";
 
                     try
                     {
@@ -456,9 +456,14 @@ namespace GodotTools
 
             var dotNetSdkSearchVersion = Environment.Version;
 
+            _editorSettings = EditorInterface.Singleton.GetEditorSettings();
+
+            string? dotnetExecutableEditorSettings = _editorSettings.GetSetting(GodotSharpEditor.Settings.OverrideDotnetExecutable)
+                .As<string>();
+
             // First we try to find the .NET Sdk ourselves to make sure we get the
             // correct version first, otherwise pick the latest.
-            if (DotNetFinder.TryFindDotNetSdk(dotNetSdkSearchVersion, out var sdkVersion, out string? sdkPath))
+            if (DotNetFinder.TryFindDotNetSdk(dotNetSdkSearchVersion, dotnetExecutableEditorSettings, out var sdkVersion, out string? sdkPath))
             {
                 if (Godot.OS.IsStdOutVerbose())
                     Console.WriteLine($"Found .NET Sdk version '{sdkVersion}': {sdkPath}");
@@ -482,8 +487,6 @@ namespace GodotTools
             }
 
             var editorBaseControl = EditorInterface.Singleton.GetBaseControl();
-
-            _editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             _errorDialog = new AcceptDialog();
             _errorDialog.SetUnparentWhenInvisible(true);
@@ -542,6 +545,7 @@ namespace GodotTools
             EditorDef(Settings.VerbosityLevel, Variant.From(VerbosityLevelId.Normal));
             EditorDef(Settings.NoConsoleLogging, false);
             EditorDef(Settings.CreateBinaryLog, false);
+            EditorDef(Settings.OverrideDotnetExecutable, "");
             EditorDef(Settings.ProblemsLayout, Variant.From(BuildProblemsView.ProblemsLayout.Tree));
 
             string settingsHintStr = "Disabled";


### PR DESCRIPTION
Implemented EditorSettings override for where to access dotnet and re-ordered DotnetFinder's search for dotnet, so it checks the path variable first before checking the hard coded locations.

Fixes: https://github.com/godotengine/godot/issues/97501
Implements Proposal: https://github.com/godotengine/godot-proposals/issues/1941