### PR TITLE
Add a pin toggle to prevent involuntary bottom editor switching

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1091,9 +1091,11 @@
 		</member>
 		<member name="run/bottom_panel/action_on_play" type="int" setter="" getter="">
 			The action to execute on the bottom panel when running the project.
+			[b]Note:[/b] This option won't do anything if the bottom panel switching is locked using the pin button in the corner of the bottom panel.
 		</member>
 		<member name="run/bottom_panel/action_on_stop" type="int" setter="" getter="">
 			The action to execute on the bottom panel when stopping the project.
+			[b]Note:[/b] This option won't do anything if the bottom panel switching is locked using the pin button in the corner of the bottom panel.
 		</member>
 		<member name="run/output/always_clear_output_on_play" type="bool" setter="" getter="">
 			If [code]true[/code], the editor will clear the Output panel when running the project.

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -49,16 +49,19 @@ class EditorBottomPanel : public PanelContainer {
 	};
 
 	Vector<BottomPanelItem> items;
+	bool lock_panel_switching = false;
 
 	VBoxContainer *item_vbox = nullptr;
 	HBoxContainer *bottom_hbox = nullptr;
 	HBoxContainer *button_hbox = nullptr;
 	EditorToaster *editor_toaster = nullptr;
+	Button *pin_button = nullptr;
 	Button *expand_button = nullptr;
 	Control *last_opened_control = nullptr;
 
-	void _switch_by_control(bool p_visible, Control *p_control);
-	void _switch_to_item(bool p_visible, int p_idx);
+	void _switch_by_control(bool p_visible, Control *p_control, bool p_ignore_lock = false);
+	void _switch_to_item(bool p_visible, int p_idx, bool p_ignore_lock = false);
+	void _pin_button_toggled(bool p_pressed);
 	void _expand_button_toggled(bool p_pressed);
 
 	bool _button_drag_hover(const Vector2 &, const Variant &, Button *p_button, Control *p_control);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/737a9d5b-8c1a-4d26-9fd8-e1ca48341d3b)

This PR adds a lock button to the bottom panel, that when toggled, stops switching of one bottom editor to another.
That means if you have the "Output" tab open, then you select an `AnimationPlayer` node, having the lock enabled will stop it from switching to the "Animation" tab.

**Sponsored By:** 🐺 Lone Wolf Technology / 🍀 W4 Games.

*Production edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/9218.
- Closes https://github.com/godotengine/godot-proposals/issues/9265.