### PR TITLE
Fix grammar mistake in Shortcut documentation

### DIFF
--- a/doc/classes/Shortcut.xml
+++ b/doc/classes/Shortcut.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Shortcuts are commonly used for interacting with a [Control] element from an [InputEvent] (also known as hotkeys).
-		One shortcut can contain multiple [InputEvent]'s, allowing the possibility of triggering one action with multiple different inputs.
+		One shortcut can contain multiple [InputEvent]s, allowing the possibility of triggering one action with multiple different inputs.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Apostrophes should not be used to form the plural under most conditions.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
