### PR TITLE
[RTL] Keep tag stack between `append_text` calls.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3187,6 +3187,10 @@ void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline)
 		stack_externally_modified = true;
 	}
 
+	if (p_enter && !parsing_bbcode.load() && !tag_stack.is_empty()) {
+		tag_stack.push_back(U"?");
+	}
+
 	p_item->parent = current;
 	p_item->E = current->subitems.push_back(p_item);
 	p_item->index = current_idx++;
@@ -4065,6 +4069,9 @@ void RichTextLabel::pop() {
 		current_frame = static_cast<ItemFrame *>(current)->parent_frame;
 	}
 	current = current->parent;
+	if (!parsing_bbcode.load() && !tag_stack.is_empty()) {
+		tag_stack.pop_back();
+	}
 }
 
 void RichTextLabel::pop_context() {
@@ -4077,8 +4084,14 @@ void RichTextLabel::pop_context() {
 		if (current->type == ITEM_FRAME) {
 			current_frame = static_cast<ItemFrame *>(current)->parent_frame;
 		} else if (current->type == ITEM_CONTEXT) {
+			if (!parsing_bbcode.load() && !tag_stack.is_empty()) {
+				tag_stack.pop_back();
+			}
 			current = current->parent;
 			return;
+		}
+		if (!parsing_bbcode.load() && !tag_stack.is_empty()) {
+			tag_stack.pop_back();
 		}
 		current = current->parent;
 	}
@@ -4099,6 +4112,7 @@ void RichTextLabel::clear() {
 
 	stack_externally_modified = false;
 
+	tag_stack.clear();
 	main->_clear_children();
 	current = main;
 	current_frame = main;
@@ -4278,10 +4292,9 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 	_stop_thread();
 	MutexLock data_lock(data_mutex);
 
+	parsing_bbcode.store(true);
+
 	int pos = 0;
-
-	List<String> tag_stack;
-
 	int indent_level = 0;
 
 	bool in_bold = false;
@@ -5425,6 +5438,8 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			}
 		}
 	}
+
+	parsing_bbcode.store(false);
 }
 
 void RichTextLabel::scroll_to_selection() {
@@ -6866,6 +6881,7 @@ RichTextLabel::RichTextLabel(const String &p_text) {
 	updating.store(false);
 	validating.store(false);
 	stop_thread.store(false);
+	parsing_bbcode.store(false);
 
 	set_clip_contents(true);
 }

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -457,6 +457,7 @@ private:
 	std::atomic<bool> updating;
 	std::atomic<bool> validating;
 	std::atomic<double> loaded;
+	std::atomic<bool> parsing_bbcode;
 
 	uint64_t loading_started = 0;
 	int progress_delay = 1000;
@@ -507,6 +508,7 @@ private:
 	void _texture_changed(RID p_item);
 
 	RID_PtrOwner<Item> items;
+	List<String> tag_stack;
 
 	String language;
 	TextDirection text_direction = TEXT_DIRECTION_AUTO;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/97965
Fixes #37774

Allow subsequent `append_text` calls to close tags opened by previous calls.

Note: `push_*` / `pop` can be used in between `append_text` calls, but not mixed: 
<details>
  <summary> Examples: </summary>

```gdscript
	# This will work.
	rtl.append_text("norm [b] bl");
	rtl.push_italics()
	rtl.add_text(" bi ")
	rtl.pop()
	rtl.append_text("bl [/b] norm")

	# This won't.
	rtl.push_italics()
	rtl.add_text("ital")
	rtl.append_text("[/i]norm")
```

</details>