### PR TITLE
[.Net] Fix `ReflectionUtils.ConstructTypeName` Throws Exception on Empty Generic Types

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/ReflectionUtils.cs
@@ -125,6 +125,7 @@ internal class ReflectionUtils
         static void AppendGeneric(StringBuilder sb, Type type)
         {
             var genericArgs = type.GenericTypeArguments;
+            var genericArgsCount = type.GetGenericArguments().Length;
             var genericDefinition = type.GetGenericTypeDefinition();
 
             // Nullable<T>
@@ -148,12 +149,12 @@ internal class ReflectionUtils
                     // This is a hard coded tuple element length check.
                     if (genericArgs.Length != 8)
                     {
-                        AppendParamTypes(sb, genericArgs);
+                        AppendParamTypes(sb, genericArgs, genericArgsCount);
                         break;
                     }
                     else
                     {
-                        AppendParamTypes(sb, genericArgs.AsSpan(0, 7));
+                        AppendParamTypes(sb, genericArgs.AsSpan(0, 7), genericArgsCount);
                         sb.Append(", ");
 
                         // TRest should be a ValueTuple!
@@ -170,19 +171,33 @@ internal class ReflectionUtils
             var typeName = type.Name.AsSpan();
             sb.Append(typeName[..typeName.LastIndexOf('`')]);
             sb.Append('<');
-            AppendParamTypes(sb, genericArgs);
+            AppendParamTypes(sb, genericArgs, genericArgsCount);
             sb.Append('>');
 
-            static void AppendParamTypes(StringBuilder sb, ReadOnlySpan<Type> genericArgs)
+            static void AppendParamTypes(StringBuilder sb, ReadOnlySpan<Type> genericArgs, int genericArgsCount)
             {
-                int n = genericArgs.Length - 1;
-                for (int i = 0; i < n; i += 1)
+                if (genericArgsCount != genericArgs.Length)
                 {
-                    AppendType(sb, genericArgs[i]);
-                    sb.Append(", ");
+                    for (int i = 0; i < genericArgsCount - 1; i++)
+                    {
+                        sb.Append(',');
+                    }
+                    return;
                 }
 
-                AppendType(sb, genericArgs[n]);
+                bool isFirst = true;
+                for (int i = 0; i < genericArgs.Length; i += 1)
+                {
+                    if (isFirst)
+                    {
+                        isFirst = false;
+                    }
+                    else
+                    {
+                        sb.Append(", ");
+                    }
+                    AppendType(sb, genericArgs[i]);
+                }
             }
         }
 


### PR DESCRIPTION
Before this PR, certain use cases of the `ReflectionUtils.ConstructTypeName` will result in `System.IndexOutOfRangeException`, this PR fixes the issue by addressing the generic argument printing method previously based on false assumptions.

`ReflectionUtils.ConstructTypeName`, after this PR is now capable of handling the following situations:

```csharp
var type1 = typeof(List<>);
var type2 = typeof(Dictionary<,>);
var type3 = typeof(ValueTuple<,,,,>);
var type4 = type1.MakeGenericType(type1);
var type5 = type2.MakeGenericType(type1, type3);
var type6 = type3.MakeGenericType(type1, type2, type3, type4, type5);
var type7 = type2.MakeGenericType(typeof(int[,,,]), type6);

// List<>
Console.WriteLine(ReflectionUtils.ConstructTypeName(type1));

// Dictionary<,>
Console.WriteLine(ReflectionUtils.ConstructTypeName(type2));

// (,,,,)
Console.WriteLine(ReflectionUtils.ConstructTypeName(type3));

// List<List<>>
Console.WriteLine(ReflectionUtils.ConstructTypeName(type4));

// Dictionary<List<>, (,,,,)>
Console.WriteLine(ReflectionUtils.ConstructTypeName(type5));

// (List<>, Dictionary<,>, (,,,,), List<List<>>, Dictionary<List<>, (,,,,)>)
Console.WriteLine(ReflectionUtils.ConstructTypeName(type6));

// Dictionary<int[,,,], (List<>, Dictionary<,>, (,,,,), List<List<>>, Dictionary<List<>, (,,,,)>)>
Console.WriteLine(ReflectionUtils.ConstructTypeName(type7));
```