### PR TITLE
[.Net] Stop Reloading Scripts that have Empty Paths

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -715,11 +715,16 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 		// If someone removes a script from a node, deletes the script, builds, adds a script to the
 		// same node, then builds again, the script might have no path and also no script_class. In
 		// that case, we can't (and don't need to) reload it.
-		if (scr->get_path().is_empty() && !scr->valid) {
+
+		bool is_path_empty = scr->get_path().is_empty();
+
+		if (is_path_empty && !scr->valid) {
 			continue;
 		}
 
-		to_reload.push_back(scr);
+		if (!is_path_empty) {
+			to_reload.push_back(scr);
+		}
 
 		// Script::instances are deleted during managed object disposal, which happens on domain finalize.
 		// Only placeholders are kept. Therefore we need to keep a copy before that happens.


### PR DESCRIPTION
fixes #98094

Before this PR, Godot Editor will try to reload scripts that do not have a path but are valid, that is, scripts from an external source such as ProjectReferences or Nuget Packages.
These external types are never visible to Godot Editor; they are only registered to GodotSharp when they are the ancestors of scripts under the Project Directory.

However, during an Assembly Unloading & Loading, the mono module will queue these types to the `to_reload` list and attempt to reload them, which causes duplicate key exceptions in the `ScriptTypeBiMap` as they are already registered by GodotSharp when loading children types.

This PR adds a check to avoid a valid script instance with no script path from entering the `to_reload` list, which resolves the issue.

This PR also improves the robustness of ScriptTypeBiMap by ensuring that dirty data does not enter the internal dictionaries when the `Add` and `Remove` methods fail.