### PR TITLE
POT Generator: Add support for `TRANSLATORS:` and `NO_TRANSLATE` comments

### DIFF
--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -100,6 +100,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_get_comments" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="msgids_comment" type="String[]" />
+			<param index="1" name="msgids_context_plural_comment" type="String[]" />
+			<description>
+				If overridden, called after [method _parse_file] to get comments for the parsed entries. This method should fill the arrays with the same number of elements and in the same order as [method _parse_file].
+			</description>
+		</method>
 		<method name="_get_recognized_extensions" qualifiers="virtual const">
 			<return type="PackedStringArray" />
 			<description>

--- a/editor/editor_translation_parser.cpp
+++ b/editor/editor_translation_parser.cpp
@@ -31,7 +31,6 @@
 #include "editor_translation_parser.h"
 
 #include "core/error/error_macros.h"
-#include "core/io/file_access.h"
 #include "core/object/script_language.h"
 #include "core/templates/hash_set.h"
 
@@ -65,6 +64,21 @@ Error EditorTranslationParserPlugin::parse_file(const String &p_path, Vector<Str
 	}
 }
 
+void EditorTranslationParserPlugin::get_comments(Vector<String> *r_ids_comment, Vector<String> *r_ids_ctx_plural_comment) {
+	TypedArray<String> ids_comment;
+	TypedArray<String> ids_ctx_plural_comment;
+
+	if (GDVIRTUAL_CALL(_get_comments, ids_comment, ids_ctx_plural_comment)) {
+		for (int i = 0; i < ids_comment.size(); i++) {
+			r_ids_comment->append(ids_comment[i]);
+		}
+
+		for (int i = 0; i < ids_ctx_plural_comment.size(); i++) {
+			r_ids_ctx_plural_comment->append(ids_ctx_plural_comment[i]);
+		}
+	}
+}
+
 void EditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
 	Vector<String> extensions;
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, extensions)) {
@@ -78,6 +92,7 @@ void EditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_ex
 
 void EditorTranslationParserPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_parse_file, "path", "msgids", "msgids_context_plural");
+	GDVIRTUAL_BIND(_get_comments, "msgids_comment", "msgids_context_plural_comment");
 	GDVIRTUAL_BIND(_get_recognized_extensions);
 }
 

--- a/editor/editor_translation_parser.h
+++ b/editor/editor_translation_parser.h
@@ -43,10 +43,12 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL3(_parse_file, String, TypedArray<String>, TypedArray<Array>)
+	GDVIRTUAL2(_get_comments, TypedArray<String>, TypedArray<String>)
 	GDVIRTUAL0RC(Vector<String>, _get_recognized_extensions)
 
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural);
+	virtual void get_comments(Vector<String> *r_ids_comment, Vector<String> *r_ids_ctx_plural_comment);
 	virtual void get_recognized_extensions(List<String> *r_extensions) const;
 };
 

--- a/editor/pot_generator.h
+++ b/editor/pot_generator.h
@@ -44,13 +44,14 @@ class POTGenerator {
 		String ctx;
 		String plural;
 		HashSet<String> locations;
+		HashSet<String> comments;
 	};
 	// Store msgid as key and the additional data around the msgid - if it's under a context, has plurals and its file locations.
 	HashMap<String, Vector<MsgidData>> all_translation_strings;
 
 	void _write_to_pot(const String &p_file);
 	void _write_msgid(Ref<FileAccess> r_file, const String &p_id, bool p_plural);
-	void _add_new_msgid(const String &p_msgid, const String &p_context, const String &p_plural, const String &p_location);
+	void _add_new_msgid(const String &p_msgid, const String &p_context, const String &p_plural, const String &p_location, const String &p_comment);
 
 #ifdef DEBUG_POT
 	void _print_all_translation_strings();

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -51,6 +51,10 @@ Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Ve
 
 	ids = r_ids;
 	ids_ctx_plural = r_ids_ctx_plural;
+
+	ids_comment.clear();
+	ids_ctx_plural_comment.clear();
+
 	Ref<GDScript> gdscript = loaded_res;
 	String source_code = gdscript->get_source_code();
 
@@ -62,16 +66,88 @@ Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Ve
 	err = analyzer.analyze();
 	ERR_FAIL_COND_V_MSG(err, err, "Failed to analyze GDScript with GDScriptAnalyzer.");
 
+	comment_data = &parser.comment_data;
+
 	// Traverse through the parsed tree from GDScriptParser.
 	GDScriptParser::ClassNode *c = parser.get_tree();
 	_traverse_class(c);
 
+	comment_data = nullptr;
+
 	return OK;
+}
+
+void GDScriptEditorTranslationParserPlugin::get_comments(Vector<String> *r_ids_comment, Vector<String> *r_ids_ctx_plural_comment) {
+	r_ids_comment->append_array(ids_comment);
+	r_ids_ctx_plural_comment->append_array(ids_ctx_plural_comment);
 }
 
 bool GDScriptEditorTranslationParserPlugin::_is_constant_string(const GDScriptParser::ExpressionNode *p_expression) {
 	ERR_FAIL_NULL_V(p_expression, false);
 	return p_expression->is_constant && p_expression->reduced_value.is_string();
+}
+
+String GDScriptEditorTranslationParserPlugin::_parse_comment(int p_line, bool &r_skip) const {
+	// Parse inline comment.
+	if (comment_data->has(p_line)) {
+		const String stripped_comment = comment_data->get(p_line).comment.trim_prefix("#").strip_edges();
+
+		if (stripped_comment.begins_with("TRANSLATORS:")) {
+			return stripped_comment.trim_prefix("TRANSLATORS:").strip_edges(true, false);
+		}
+		if (stripped_comment == "NO_TRANSLATE" || stripped_comment.begins_with("NO_TRANSLATE:")) {
+			r_skip = true;
+			return String();
+		}
+	}
+
+	// Parse multiline comment.
+	String multiline_comment;
+	for (int line = p_line - 1; comment_data->has(line) && comment_data->get(line).new_line; line--) {
+		const String stripped_comment = comment_data->get(line).comment.trim_prefix("#").strip_edges();
+
+		if (stripped_comment.is_empty()) {
+			continue;
+		}
+
+		if (multiline_comment.is_empty()) {
+			multiline_comment = stripped_comment;
+		} else {
+			multiline_comment = stripped_comment + "\n" + multiline_comment;
+		}
+
+		if (stripped_comment.begins_with("TRANSLATORS:")) {
+			return multiline_comment.trim_prefix("TRANSLATORS:").strip_edges(true, false);
+		}
+		if (stripped_comment == "NO_TRANSLATE" || stripped_comment.begins_with("NO_TRANSLATE:")) {
+			r_skip = true;
+			return String();
+		}
+	}
+
+	return String();
+}
+
+void GDScriptEditorTranslationParserPlugin::_add_id(const String &p_id, int p_line) {
+	bool skip = false;
+	const String comment = _parse_comment(p_line, skip);
+	if (skip) {
+		return;
+	}
+
+	ids->push_back(p_id);
+	ids_comment.push_back(comment);
+}
+
+void GDScriptEditorTranslationParserPlugin::_add_id_ctx_plural(const Vector<String> &p_id_ctx_plural, int p_line) {
+	bool skip = false;
+	const String comment = _parse_comment(p_line, skip);
+	if (skip) {
+		return;
+	}
+
+	ids_ctx_plural->push_back(p_id_ctx_plural);
+	ids_ctx_plural_comment.push_back(comment);
 }
 
 void GDScriptEditorTranslationParserPlugin::_traverse_class(const GDScriptParser::ClassNode *p_class) {
@@ -253,7 +329,7 @@ void GDScriptEditorTranslationParserPlugin::_assess_assignment(const GDScriptPar
 
 	if (assignee_name != StringName() && assignment_patterns.has(assignee_name) && _is_constant_string(p_assignment->assigned_value)) {
 		// If the assignment is towards one of the extract patterns (text, tooltip_text etc.), and the value is a constant string, we collect the string.
-		ids->push_back(p_assignment->assigned_value->reduced_value);
+		_add_id(p_assignment->assigned_value->reduced_value, p_assignment->assigned_value->start_line);
 	} else if (assignee_name == fd_filters) {
 		// Extract from `get_node("FileDialog").filters = <filter array>`.
 		_extract_fd_filter_array(p_assignment->assigned_value);
@@ -287,7 +363,7 @@ void GDScriptEditorTranslationParserPlugin::_assess_call(const GDScriptParser::C
 			}
 		}
 		if (extract_id_ctx_plural) {
-			ids_ctx_plural->push_back(id_ctx_plural);
+			_add_id_ctx_plural(id_ctx_plural, p_call->start_line);
 		}
 	} else if (function_name == trn_func || function_name == atrn_func) {
 		// Extract from `tr_n(id, plural, n, ctx)` or `atr_n(id, plural, n, ctx)`.
@@ -307,20 +383,20 @@ void GDScriptEditorTranslationParserPlugin::_assess_call(const GDScriptParser::C
 			}
 		}
 		if (extract_id_ctx_plural) {
-			ids_ctx_plural->push_back(id_ctx_plural);
+			_add_id_ctx_plural(id_ctx_plural, p_call->start_line);
 		}
 	} else if (first_arg_patterns.has(function_name)) {
 		if (!p_call->arguments.is_empty() && _is_constant_string(p_call->arguments[0])) {
-			ids->push_back(p_call->arguments[0]->reduced_value);
+			_add_id(p_call->arguments[0]->reduced_value, p_call->arguments[0]->start_line);
 		}
 	} else if (second_arg_patterns.has(function_name)) {
 		if (p_call->arguments.size() > 1 && _is_constant_string(p_call->arguments[1])) {
-			ids->push_back(p_call->arguments[1]->reduced_value);
+			_add_id(p_call->arguments[1]->reduced_value, p_call->arguments[1]->start_line);
 		}
 	} else if (function_name == fd_add_filter) {
 		// Extract the 'JPE Images' in this example - get_node("FileDialog").add_filter("*.jpg; JPE Images").
 		if (!p_call->arguments.is_empty()) {
-			_extract_fd_filter_string(p_call->arguments[0]);
+			_extract_fd_filter_string(p_call->arguments[0], p_call->arguments[0]->start_line);
 		}
 	} else if (function_name == fd_set_filter) {
 		// Extract from `get_node("FileDialog").set_filters(<filter array>)`.
@@ -330,12 +406,12 @@ void GDScriptEditorTranslationParserPlugin::_assess_call(const GDScriptParser::C
 	}
 }
 
-void GDScriptEditorTranslationParserPlugin::_extract_fd_filter_string(const GDScriptParser::ExpressionNode *p_expression) {
+void GDScriptEditorTranslationParserPlugin::_extract_fd_filter_string(const GDScriptParser::ExpressionNode *p_expression, int p_line) {
 	// Extract the name in "extension ; name".
 	if (_is_constant_string(p_expression)) {
 		PackedStringArray arr = p_expression->reduced_value.operator String().split(";", true);
 		ERR_FAIL_COND_MSG(arr.size() != 2, "Argument for setting FileDialog has bad format.");
-		ids->push_back(arr[1].strip_edges());
+		_add_id(arr[1].strip_edges(), p_line);
 	}
 }
 
@@ -355,7 +431,7 @@ void GDScriptEditorTranslationParserPlugin::_extract_fd_filter_array(const GDScr
 
 	if (array_node) {
 		for (int i = 0; i < array_node->elements.size(); i++) {
-			_extract_fd_filter_string(array_node->elements[i]);
+			_extract_fd_filter_string(array_node->elements[i], array_node->elements[i]->start_line);
 		}
 	}
 }

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.h
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.h
@@ -32,15 +32,22 @@
 #define GDSCRIPT_TRANSLATION_PARSER_PLUGIN_H
 
 #include "../gdscript_parser.h"
+#include "../gdscript_tokenizer.h"
 
+#include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
 #include "editor/editor_translation_parser.h"
 
 class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlugin {
 	GDCLASS(GDScriptEditorTranslationParserPlugin, EditorTranslationParserPlugin);
 
+	const HashMap<int, GDScriptTokenizer::CommentData> *comment_data = nullptr;
+
 	Vector<String> *ids = nullptr;
 	Vector<Vector<String>> *ids_ctx_plural = nullptr;
+
+	Vector<String> ids_comment;
+	Vector<String> ids_ctx_plural_comment;
 
 	// List of patterns used for extracting translation strings.
 	StringName tr_func = "tr";
@@ -57,6 +64,11 @@ class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlug
 
 	static bool _is_constant_string(const GDScriptParser::ExpressionNode *p_expression);
 
+	String _parse_comment(int p_line, bool &r_skip) const;
+
+	void _add_id(const String &p_id, int p_line);
+	void _add_id_ctx_plural(const Vector<String> &p_id_ctx_plural, int p_line);
+
 	void _traverse_class(const GDScriptParser::ClassNode *p_class);
 	void _traverse_function(const GDScriptParser::FunctionNode *p_func);
 	void _traverse_block(const GDScriptParser::SuiteNode *p_suite);
@@ -65,11 +77,12 @@ class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlug
 	void _assess_assignment(const GDScriptParser::AssignmentNode *p_assignment);
 	void _assess_call(const GDScriptParser::CallNode *p_call);
 
-	void _extract_fd_filter_string(const GDScriptParser::ExpressionNode *p_expression);
+	void _extract_fd_filter_string(const GDScriptParser::ExpressionNode *p_expression, int p_line);
 	void _extract_fd_filter_array(const GDScriptParser::ExpressionNode *p_expression);
 
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) override;
+	virtual void get_comments(Vector<String> *r_ids_comment, Vector<String> *r_ids_ctx_plural_comment) override;
 	virtual void get_recognized_extensions(List<String> *r_extensions) const override;
 
 	GDScriptEditorTranslationParserPlugin();

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -409,6 +409,10 @@ Error GDScriptParser::parse(const String &p_source_code, const String &p_script_
 	parse_program();
 	pop_multiline();
 
+#ifdef TOOLS_ENABLED
+	comment_data = tokenizer->get_comments();
+#endif
+
 	memdelete(text_tokenizer);
 	tokenizer = nullptr;
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1597,6 +1597,8 @@ public:
 
 #ifdef TOOLS_ENABLED
 	static HashMap<String, String> theme_color_names;
+
+	HashMap<int, GDScriptTokenizer::CommentData> comment_data;
 #endif // TOOLS_ENABLED
 
 	GDScriptParser();


### PR DESCRIPTION
* Closes godotengine/godot-proposals#8555.
* Closes godotengine/godot-proposals#8917.
* Closes godotengine/godot-proposals#10590.
* Supersedes #87401.

<details>
<summary>Example</summary>

```gdscript
extends Node

func _ready() -> void:
    print(tr("tr1"))
    print(tr("tr2", "ctx_a"))
    print(tr("tr3")) # NO_TRANSLATE
    print(tr("tr4")) # TRANSLATORS: Message 4
    # TRANSLATORS: Message 5
    print(tr("tr5"))
    # Above comment.
    # TRANSLATORS: Message 6 Line 1
    # Message 6 Line 2
    # Message 6 Line 3
    print(tr("tr6"))
    # Above comment.
    # TRANSLATORS: Message 7 Line 1
    # Message 7 Line 2
    # Message 7 Line 3
    print(tr_n("tr_n7", "tr_n7_plural", 0, "ctx_b"))

    print(tr("tr8", "ctx_c")) # TRANSLATORS: Message 8.1
    print(tr("tr8", "ctx_c")) # TRANSLATORS: Message 8.1
    print(tr("tr8", "ctx_c")) # TRANSLATORS: Message 8.2
    print(tr("tr8", "ctx_d")) # TRANSLATORS: Message 8.3

    # TRANSLATORS: Message 9

    # Empty line ^^
    print(tr("tr9"))

    print(tr("tr10")) # TRANSLATORS: Message 10
    print(tr("tr11"))
```

```pot
# LANGUAGE translation for temp for the following files:
# res://node.gd
#
# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
#
#, fuzzy
msgid ""
msgstr ""
"Project-Id-Version: temp\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8-bit\n"

#: node.gd
msgid "tr1"
msgstr ""

#: node.gd
msgctxt "ctx_a"
msgid "tr2"
msgstr ""

#. TRANSLATORS: Message 4
#: node.gd
msgid "tr4"
msgstr ""

#. TRANSLATORS: Message 5
#: node.gd
msgid "tr5"
msgstr ""

#. TRANSLATORS: Message 6 Line 1
#. Message 6 Line 2
#. Message 6 Line 3
#: node.gd
msgid "tr6"
msgstr ""

#. TRANSLATORS: Message 7 Line 1
#. Message 7 Line 2
#. Message 7 Line 3
#: node.gd
msgctxt "ctx_b"
msgid "tr_n7"
msgid_plural "tr_n7_plural"
msgstr[0] ""
msgstr[1] ""

#. TRANSLATORS: Message 8.1
#. Message 8.2
#: node.gd
msgctxt "ctx_c"
msgid "tr8"
msgstr ""

#. TRANSLATORS: Message 8.3
#: node.gd
msgctxt "ctx_d"
msgid "tr8"
msgstr ""

#: node.gd
msgid "tr9"
msgstr ""

#. TRANSLATORS: Message 10
#: node.gd
msgid "tr10"
msgstr ""

#: node.gd
msgid "tr11"
msgstr ""
```

</details>