### PR TITLE
[3.x] Do not auto add default script and country codes to the locale. 

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -261,6 +261,10 @@ void TranslationServer::init_locale_info() {
 }
 
 String TranslationServer::standardize_locale(const String &p_locale) const {
+	return _standardize_locale(p_locale, false);
+}
+
+String TranslationServer::_standardize_locale(const String &p_locale, bool p_add_defaults) const {
 	// Replaces '-' with '_' for macOS style locales.
 	String univ_locale = p_locale.replace("-", "_");
 
@@ -322,24 +326,26 @@ String TranslationServer::standardize_locale(const String &p_locale) const {
 	}
 
 	// Add script code base on language and country codes for some ambiguous cases.
-	if (script.empty()) {
-		for (int i = 0; i < locale_script_info.size(); i++) {
-			const LocaleScriptInfo &info = locale_script_info[i];
-			if (info.name == lang) {
-				if (country.empty() || info.supported_countries.has(country)) {
-					script = info.script;
-					break;
+	if (p_add_defaults) {
+		if (script.empty()) {
+			for (int i = 0; i < locale_script_info.size(); i++) {
+				const LocaleScriptInfo &info = locale_script_info[i];
+				if (info.name == lang) {
+					if (country.empty() || info.supported_countries.has(country)) {
+						script = info.script;
+						break;
+					}
 				}
 			}
 		}
-	}
-	if (!script.empty() && country.empty()) {
-		// Add conntry code based on script for some ambiguous cases.
-		for (int i = 0; i < locale_script_info.size(); i++) {
-			const LocaleScriptInfo &info = locale_script_info[i];
-			if (info.name == lang && info.script == script) {
-				country = info.default_country;
-				break;
+		if (!script.empty() && country.empty()) {
+			// Add conntry code based on script for some ambiguous cases.
+			for (int i = 0; i < locale_script_info.size(); i++) {
+				const LocaleScriptInfo &info = locale_script_info[i];
+				if (info.name == lang && info.script == script) {
+					country = info.default_country;
+					break;
+				}
 			}
 		}
 	}
@@ -359,8 +365,8 @@ String TranslationServer::standardize_locale(const String &p_locale) const {
 }
 
 int TranslationServer::compare_locales(const String &p_locale_a, const String &p_locale_b) const {
-	String locale_a = standardize_locale(p_locale_a);
-	String locale_b = standardize_locale(p_locale_b);
+	String locale_a = _standardize_locale(p_locale_a, true);
+	String locale_b = _standardize_locale(p_locale_b, true);
 
 	if (locale_a == locale_b) {
 		// Exact match.

--- a/core/translation.h
+++ b/core/translation.h
@@ -122,6 +122,7 @@ public:
 
 	int compare_locales(const String &p_locale_a, const String &p_locale_b) const;
 	String standardize_locale(const String &p_locale) const;
+	String _standardize_locale(const String &p_locale, bool p_add_defaults) const;
 
 	Vector<String> get_all_languages() const;
 	String get_language_name(const String &p_language) const;


### PR DESCRIPTION
This is a 3.x backport for the locale fix here: https://github.com/godotengine/godot/pull/67931

To fix the bug here: https://github.com/godotengine/godot/issues/67829

Which was introduced between 3.5 and 3.6

Couldn't do a simple cherry-pick because the files were moved around.