### PR TITLE
Ignore `threaded_cull_minimum_instances` for single threaded exports.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2692,7 +2692,7 @@
 			[b]Note:[/b] This setting is only effective when using the Compatibility rendering method, not Forward+ and Mobile.
 		</member>
 		<member name="rendering/limits/spatial_indexer/threaded_cull_minimum_instances" type="int" setter="" getter="" default="1000">
-			The minimum number of instances that must be present in a scene to enable culling computations on multiple threads. If a scene has fewer instances than this number, culling is done on a single thread.
+			The minimum number of instances that must be present in a scene to enable culling computations on multiple threads. If a scene has fewer instances than this number, culling is done on a single thread. Only applicable to exports which use threads- this will have no effect on single threaded web exports, for instance.
 		</member>
 		<member name="rendering/limits/spatial_indexer/update_iterations_per_frame" type="int" setter="" getter="" default="10">
 		</member>

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3222,7 +3222,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 				continue;
 			}
 
-			if (visibility_cull_data.cull_count > thread_cull_threshold) {
+			if (thread_cull_threshold != -1 && visibility_cull_data.cull_count > thread_cull_threshold) {
 				WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &RendererSceneCull::_visibility_cull_threaded, &visibility_cull_data, WorkerThreadPool::get_singleton()->get_thread_count(), -1, true, SNAME("VisibilityCullInstances"));
 				WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 			} else {
@@ -3324,7 +3324,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		uint64_t time_from = OS::get_singleton()->get_ticks_usec();
 #endif
 
-		if (cull_to > thread_cull_threshold) {
+		if (thread_cull_threshold != -1 && cull_to > thread_cull_threshold) {
 			//multiple threads
 			for (InstanceCullResult &thread : scene_cull_result_threads) {
 				thread.clear();
@@ -4524,8 +4524,12 @@ RendererSceneCull::RendererSceneCull() {
 	}
 
 	indexer_update_iterations = GLOBAL_GET("rendering/limits/spatial_indexer/update_iterations_per_frame");
+#ifdef THREADS_ENABLED
 	thread_cull_threshold = GLOBAL_GET("rendering/limits/spatial_indexer/threaded_cull_minimum_instances");
 	thread_cull_threshold = MAX(thread_cull_threshold, (uint32_t)WorkerThreadPool::get_singleton()->get_thread_count()); //make sure there is at least one thread per CPU
+#else
+	thread_cull_threshold = -1; // For single-threaded exports- value of -1 should always skip culling threshold
+#endif
 	RendererSceneOcclusionCull::HZBuffer::occlusion_jitter_enabled = GLOBAL_GET("rendering/occlusion_culling/jitter_projection");
 
 	dummy_occlusion_culling = memnew(RendererSceneOcclusionCull);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3222,7 +3222,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 				continue;
 			}
 
-			if (thread_cull_threshold != -1 && visibility_cull_data.cull_count > thread_cull_threshold) {
+			if (thread_cull_threshold != 0 && visibility_cull_data.cull_count > thread_cull_threshold) {
 				WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &RendererSceneCull::_visibility_cull_threaded, &visibility_cull_data, WorkerThreadPool::get_singleton()->get_thread_count(), -1, true, SNAME("VisibilityCullInstances"));
 				WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 			} else {
@@ -3324,7 +3324,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		uint64_t time_from = OS::get_singleton()->get_ticks_usec();
 #endif
 
-		if (thread_cull_threshold != -1 && cull_to > thread_cull_threshold) {
+		if (thread_cull_threshold != 0 && cull_to > thread_cull_threshold) {
 			//multiple threads
 			for (InstanceCullResult &thread : scene_cull_result_threads) {
 				thread.clear();
@@ -4528,7 +4528,7 @@ RendererSceneCull::RendererSceneCull() {
 	thread_cull_threshold = GLOBAL_GET("rendering/limits/spatial_indexer/threaded_cull_minimum_instances");
 	thread_cull_threshold = MAX(thread_cull_threshold, (uint32_t)WorkerThreadPool::get_singleton()->get_thread_count()); //make sure there is at least one thread per CPU
 #else
-	thread_cull_threshold = -1; // For single-threaded exports- value of -1 should always skip culling threshold
+	thread_cull_threshold = 0; // For single-threaded exports- value of 0 should always skip culling threshold
 #endif
 	RendererSceneOcclusionCull::HZBuffer::occlusion_jitter_enabled = GLOBAL_GET("rendering/occlusion_culling/jitter_projection");
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/88192 present in 4.3+ where more Node3Ds than `threaded_cull_minimum_instances` in single-threaded web exports cause all instances to stop being rendered. In order to always go down the single threaded code path, this commit overrides the value of `threaded_cull_minimum_instances` when building for single-threaded exports so that the multi-threaded culling code is never executed.

Validated on 4.4.dev with minimal project: 
[96968_minimal_repro.zip](https://github.com/user-attachments/files/17350774/96968_minimal_repro.zip)