### PR TITLE
Additional macOS codesign entitlements and print verbose

### DIFF
--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -75,6 +75,13 @@
 		<member name="codesign/custom_options" type="PackedStringArray" setter="" getter="">
 			Array of the additional command line arguments passed to the code signing tool.
 		</member>
+		<member name="codesign/entitlements/additional" type="String" setter="" getter="">
+			Additional data added to the root [code]&lt;dict&gt;[/code] section of the [url=https://developer.apple.com/documentation/bundleresources/entitlements].entitlements[/url] file. The value should be an XML section with pairs of key-value elements, e.g.:
+				[codeblock lang=text]
+				&lt;key&gt;key_name&lt;/key&gt;
+				&lt;string&gt;value&lt;/string&gt;
+				[/codeblock]
+		</member>
 		<member name="codesign/entitlements/address_book" type="bool" setter="" getter="">
 			Enable to allow access to contacts in the user's address book, if it's enabled you should also provide usage message in the [member privacy/address_book_usage_description] option. See [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_personal-information_addressbook]com.apple.security.personal-information.addressbook[/url].
 		</member>


### PR DESCRIPTION
This PR adds 2 additional things for macos exports:

1. You can add additional entitlements that the godot editor doesn't cover via the new ``codesign/entitlements/additional`` property.  This behaves similarly to the ``application/additional_plist_content`` property for adding additional plist elements the godot editor gui doesn't cover.
    - Reasoning: We need to add "login with apple" capability to my macos application.  This entitlement is not covered in the list of entitlement check boxes.  This makes it easy to add additional entitlements that the godot editor doesn't cover via its checkbox gui.
2. When exporting in verbose mode, the value of the entitlement files is printed.  This is useful because godot treats these as temporary files and deletes them after exporting.  By printing them during the export process, users can more effectively debug potential entitlement issues with their application.  It also has the added benefit of acting as a template for a custom entitlement file if users wish to go the route of manually managing an entitlement file.

As always, Lange Studios thanks you for the awesome engine!  Please let me know if you have any feedback on the PR or wish us to change anything :)