### PR TITLE
Add support for `inf` and `nan` values to `JSON::stringify` and `JSON::parse_string`

### DIFF
--- a/core/extension/gdextension_compat_hashes.cpp
+++ b/core/extension/gdextension_compat_hashes.cpp
@@ -470,6 +470,7 @@ void GDExtensionCompatHashes::initialize() {
 	});
 	mappings.insert("JSON", {
 		{ "stringify", 2656701787, 462733549 },
+		{ "stringify", 967569410, 2656701787 },
 	});
 	mappings.insert("JavaScriptBridge", {
 		{ "download_buffer", 4123979296, 3352272093 },

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -73,7 +73,7 @@ class JSON : public Resource {
 	static const char *tk_name[];
 
 	static String _make_indent(const String &p_indent, int p_size);
-	static String _stringify(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, HashSet<const void *> &p_markers, bool p_full_precision = false);
+	static String _stringify(const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, HashSet<const void *> &p_markers, bool p_full_precision = false, bool p_allow_nonfinite = false);
 	static Error _get_token(const char32_t *p_str, int &index, int p_len, Token &r_token, int &line, String &r_err_str);
 	static Error _parse_value(Variant &value, Token &token, const char32_t *p_str, int &index, int p_len, int &line, int p_depth, String &r_err_str);
 	static Error _parse_array(Array &array, const char32_t *p_str, int &index, int p_len, int &line, int p_depth, String &r_err_str);
@@ -87,7 +87,7 @@ public:
 	Error parse(const String &p_json_string, bool p_keep_text = false);
 	String get_parsed_text() const;
 
-	static String stringify(const Variant &p_var, const String &p_indent = "", bool p_sort_keys = true, bool p_full_precision = false);
+	static String stringify(const Variant &p_var, const String &p_indent = "", bool p_sort_keys = true, bool p_full_precision = false, bool p_allow_nonfinite = false);
 	static Variant parse_string(const String &p_json_string);
 
 	inline Variant get_data() const { return data; }

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -89,10 +89,12 @@
 			<param index="1" name="indent" type="String" default="&quot;&quot;" />
 			<param index="2" name="sort_keys" type="bool" default="true" />
 			<param index="3" name="full_precision" type="bool" default="false" />
+			<param index="4" name="allow_nonfinite" type="bool" default="false" />
 			<description>
 				Converts a [Variant] var to JSON text and returns the result. Useful for serializing data to store or send over the network.
 				[b]Note:[/b] The JSON specification does not define integer or float types, but only a [i]number[/i] type. Therefore, converting a Variant to JSON text will convert all numerical values to [float] types.
 				[b]Note:[/b] If [param full_precision] is [code]true[/code], when stringifying floats, the unreliable digits are stringified in addition to the reliable digits to guarantee exact decoding.
+				[b]Note:[/b] If [param allow_nonfinite] is [code]true[/code], when stringifying the floating point values [code]INF[/code], [code]-INF[/code], and [code]NAN[/code], the values are encoding using the keywords [code]Infinity[/code], [code]-Infinity[/code], and [code]-NaN[/code] which are not compliant to the JSON standard.
 				The [param indent] parameter controls if and how something is indented; its contents will be used where there should be an indent in the output. Even spaces like [code]"   "[/code] will work. [code]\t[/code] and [code]\n[/code] can also be used for a tab indent, or to make a newline for each indent respectively.
 				[b]Example output:[/b]
 				[codeblock]


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/89777

This is my first time ever contributing to Godot, I'm sorry if I did anything wrong.

This PR adds an optional extra parameter to `JSON::stringify`  called `allow_nonfinite`, defaulting to `false`

Also adding support for the parsing of the following keywords in `JSON::parse_string`:
- NaN
- Infinity
- -Infinity
- inf
- -inf

In `JSON::stringify`, regarding the new `allow_nonfinite` parameter:
When set to true, the following will occur:
- NAN values become the keyword `NaN`
- INF values become the keyword `Infinity`
- -INF values become the keyword `-Infinity`

This is based on a somewhat common nonstandard extension that is compatible with, at the minimum, Python's own JSON functions and a few other places. (See here https://evanhahn.com/pythons-nonstandard-json-encoding/)
The rationale of these keywords is to not be arbitrary, and instead the commonly supported.

The previous behavior of `JSON::stringify` with these values was to just directly place the keywords `inf`, `-inf`, and `nan` into the JSON, which would break when attempting to decode. 
The default value of `false` removes this behavior in this PR to still allow standard-compliant JSON. This PR fixes the previous default behavior of decoding breaking entirely when these values were used. It'll also allow the loading of the keywords `inf`, `-inf`, and `nan` which previously would not parse correctly.

The new behavior of `JSON::stringify` with `allow_nonfinite` set to `false` is to replace INF, -INF, and NAN values with:
- INF becomes `1e9999`
- -INF becomes `-1e9999`
- NAN becomes `null`
(the exponent values become their respective INF counterparts when parsed, it just isn't very explicit looking at it)
These are all compliant to the JSON standard.

ALSO: while testing this I found an issue of full_precision not being included recursively inside the contained arrays or dictionaries. This fixes that, it was necessary for this PR since the new parameter also must be included recursively.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
