### PR TITLE
Rename internal EditorPlugin icon/name to match exposed methods

### DIFF
--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -274,7 +274,7 @@ class AudioBusesEditorPlugin : public EditorPlugin {
 	EditorAudioBuses *audio_bus_editor = nullptr;
 
 public:
-	virtual String get_name() const override { return "SampleLibrary"; }
+	virtual String get_plugin_name() const override { return "SampleLibrary"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_node) override;
 	virtual bool handles(Object *p_node) const override;

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -281,7 +281,7 @@ Vector<EditorPlugin *> EditorData::get_handling_sub_editors(Object *p_object) {
 
 EditorPlugin *EditorData::get_editor_by_name(const String &p_name) {
 	for (int i = editor_plugins.size() - 1; i > -1; i--) {
-		if (editor_plugins[i]->get_name() == p_name) {
+		if (editor_plugins[i]->get_plugin_name() == p_name) {
 			return editor_plugins[i];
 		}
 	}
@@ -320,7 +320,7 @@ Dictionary EditorData::get_editor_plugin_states() const {
 		if (state.is_empty()) {
 			continue;
 		}
-		metadata[editor_plugins[i]->get_name()] = state;
+		metadata[editor_plugins[i]->get_plugin_name()] = state;
 	}
 
 	return metadata;
@@ -348,7 +348,7 @@ void EditorData::set_editor_plugin_states(const Dictionary &p_states) {
 		String name = E->get();
 		int idx = -1;
 		for (int i = 0; i < editor_plugins.size(); i++) {
-			if (editor_plugins[i]->get_name() == name) {
+			if (editor_plugins[i]->get_plugin_name() == name) {
 				idx = i;
 				break;
 			}

--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -63,12 +63,12 @@ void EditorMainScreen::_notification(int p_what) {
 			for (int i = 0; i < buttons.size(); i++) {
 				Button *tb = buttons[i];
 				EditorPlugin *p_editor = editor_table[i];
-				Ref<Texture2D> icon = p_editor->get_icon();
+				Ref<Texture2D> icon = p_editor->get_plugin_icon();
 
 				if (icon.is_valid()) {
 					tb->set_button_icon(icon);
-				} else if (has_theme_icon(p_editor->get_name(), EditorStringName(EditorIcons))) {
-					tb->set_button_icon(get_theme_icon(p_editor->get_name(), EditorStringName(EditorIcons)));
+				} else if (has_theme_icon(p_editor->get_plugin_name(), EditorStringName(EditorIcons))) {
+					tb->set_button_icon(get_theme_icon(p_editor->get_plugin_name(), EditorStringName(EditorIcons)));
 				}
 			}
 		} break;
@@ -198,7 +198,7 @@ void EditorMainScreen::select(int p_index) {
 	EditorData &editor_data = EditorNode::get_editor_data();
 	int plugin_count = editor_data.get_editor_plugin_count();
 	for (int i = 0; i < plugin_count; i++) {
-		editor_data.get_editor_plugin(i)->notify_main_screen_changed(selected_plugin->get_name());
+		editor_data.get_editor_plugin(i)->notify_main_screen_changed(selected_plugin->get_plugin_name());
 	}
 
 	EditorNode::get_singleton()->update_distraction_free_mode();
@@ -236,12 +236,12 @@ void EditorMainScreen::add_main_plugin(EditorPlugin *p_editor) {
 	Button *tb = memnew(Button);
 	tb->set_toggle_mode(true);
 	tb->set_theme_type_variation("MainScreenButton");
-	tb->set_name(p_editor->get_name());
-	tb->set_text(p_editor->get_name());
+	tb->set_name(p_editor->get_plugin_name());
+	tb->set_text(p_editor->get_plugin_name());
 
-	Ref<Texture2D> icon = p_editor->get_icon();
-	if (icon.is_null() && has_theme_icon(p_editor->get_name(), EditorStringName(EditorIcons))) {
-		icon = get_editor_theme_icon(p_editor->get_name());
+	Ref<Texture2D> icon = p_editor->get_plugin_icon();
+	if (icon.is_null() && has_theme_icon(p_editor->get_plugin_name(), EditorStringName(EditorIcons))) {
+		icon = get_editor_theme_icon(p_editor->get_plugin_name());
 	}
 	if (icon.is_valid()) {
 		tb->set_button_icon(icon);
@@ -260,7 +260,7 @@ void EditorMainScreen::remove_main_plugin(EditorPlugin *p_editor) {
 	// Remove the main editor button and update the bindings of
 	// all buttons behind it to point to the correct main window.
 	for (int i = buttons.size() - 1; i >= 0; i--) {
-		if (p_editor->get_name() == buttons[i]->get_text()) {
+		if (p_editor->get_plugin_name() == buttons[i]->get_text()) {
 			if (buttons[i]->is_pressed()) {
 				select(EDITOR_SCRIPT);
 			}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2629,7 +2629,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		if (main_plugin && !skip_main_plugin) {
 			// Special case if use of external editor is true.
 			Resource *current_res = Object::cast_to<Resource>(current_obj);
-			if (main_plugin->get_name() == "Script" && current_res && !current_res->is_built_in() && (bool(EDITOR_GET("text_editor/external/use_external_editor")) || overrides_external_editor(current_obj))) {
+			if (main_plugin->get_plugin_name() == "Script" && current_res && !current_res->is_built_in() && (bool(EDITOR_GET("text_editor/external/use_external_editor")) || overrides_external_editor(current_obj))) {
 				if (!changing_scene) {
 					main_plugin->edit(current_obj);
 				}

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -157,7 +157,7 @@ public:
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { polygon_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
 	bool has_main_screen() const override { return false; }
-	virtual String get_name() const override { return klass; }
+	virtual String get_plugin_name() const override { return klass; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -299,7 +299,7 @@ public:
 	virtual Dictionary get_state() const override { return anim_editor->get_state(); }
 	virtual void set_state(const Dictionary &p_state) override { anim_editor->set_state(p_state); }
 
-	virtual String get_name() const override { return "Anim"; }
+	virtual String get_plugin_name() const override { return "Anim"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
@@ -333,7 +333,7 @@ public:
 	bool has_main_screen() const override { return false; }
 	virtual bool handles(Object *p_object) const override;
 
-	virtual String get_name() const override { return "AnimationTrackKeyEdit"; }
+	virtual String get_plugin_name() const override { return "AnimationTrackKeyEdit"; }
 
 	AnimationTrackKeyEditEditorPlugin();
 };
@@ -359,7 +359,7 @@ public:
 	bool has_main_screen() const override { return false; }
 	virtual bool handles(Object *p_object) const override;
 
-	virtual String get_name() const override { return "AnimationMarkerKeyEdit"; }
+	virtual String get_plugin_name() const override { return "AnimationMarkerKeyEdit"; }
 
 	AnimationMarkerKeyEditEditorPlugin();
 };

--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -100,7 +100,7 @@ class AnimationTreeEditorPlugin : public EditorPlugin {
 	Button *button = nullptr;
 
 public:
-	virtual String get_name() const override { return "AnimationTree"; }
+	virtual String get_plugin_name() const override { return "AnimationTree"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -342,7 +342,7 @@ class AssetLibraryEditorPlugin : public EditorPlugin {
 public:
 	static bool is_available();
 
-	virtual String get_name() const override { return "AssetLib"; }
+	virtual String get_plugin_name() const override { return "AssetLib"; }
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override {}
 	virtual bool handles(Object *p_object) const override { return false; }

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.h
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.h
@@ -41,7 +41,7 @@ private:
 	void _move_stream_array_element(Object *p_undo_redo, Object *p_edited, const String &p_array_prefix, int p_from_index, int p_to_pos);
 
 public:
-	virtual String get_name() const override { return "AudioStreamRandomizer"; }
+	virtual String get_plugin_name() const override { return "AudioStreamRandomizer"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/bone_map_editor_plugin.h
+++ b/editor/plugins/bone_map_editor_plugin.h
@@ -231,7 +231,7 @@ class BoneMapEditorPlugin : public EditorPlugin {
 	GDCLASS(BoneMapEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "BoneMap"; }
+	virtual String get_plugin_name() const override { return "BoneMap"; }
 	BoneMapEditorPlugin();
 };
 

--- a/editor/plugins/camera_3d_editor_plugin.h
+++ b/editor/plugins/camera_3d_editor_plugin.h
@@ -78,7 +78,7 @@ class Camera3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Camera3DEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "Camera3D"; }
+	virtual String get_plugin_name() const override { return "Camera3D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -604,7 +604,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_name() const override { return "2D"; }
+	virtual String get_plugin_name() const override { return "2D"; }
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/cast_2d_editor_plugin.h
+++ b/editor/plugins/cast_2d_editor_plugin.h
@@ -65,7 +65,7 @@ public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return cast_2d_editor->forward_canvas_gui_input(p_event); }
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { cast_2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
-	virtual String get_name() const override { return "Cast2D"; }
+	virtual String get_plugin_name() const override { return "Cast2D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -105,7 +105,7 @@ public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return collision_shape_2d_editor->forward_canvas_gui_input(p_event); }
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { collision_shape_2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
-	virtual String get_name() const override { return "CollisionShape2D"; }
+	virtual String get_plugin_name() const override { return "CollisionShape2D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_obj) override;
 	virtual bool handles(Object *p_obj) const override;

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -255,7 +255,7 @@ class ControlEditorPlugin : public EditorPlugin {
 	ControlEditorToolbar *toolbar = nullptr;
 
 public:
-	virtual String get_name() const override { return "Control"; }
+	virtual String get_plugin_name() const override { return "Control"; }
 
 	ControlEditorPlugin();
 };

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -188,7 +188,7 @@ class CurveEditorPlugin : public EditorPlugin {
 public:
 	CurveEditorPlugin();
 
-	virtual String get_name() const override { return "Curve"; }
+	virtual String get_plugin_name() const override { return "Curve"; }
 };
 
 class CurvePreviewGenerator : public EditorResourcePreviewGenerator {

--- a/editor/plugins/debugger_editor_plugin.h
+++ b/editor/plugins/debugger_editor_plugin.h
@@ -67,7 +67,7 @@ private:
 	void _menu_option(int p_option);
 
 public:
-	virtual String get_name() const override { return "Debugger"; }
+	virtual String get_plugin_name() const override { return "Debugger"; }
 	bool has_main_screen() const override { return false; }
 
 	DebuggerEditorPlugin(PopupMenu *p_menu);

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -307,13 +307,13 @@ void EditorPlugin::forward_3d_force_draw_over_viewport(Control *p_overlay) {
 	GDVIRTUAL_CALL(_forward_3d_force_draw_over_viewport, p_overlay);
 }
 
-String EditorPlugin::get_name() const {
+String EditorPlugin::get_plugin_name() const {
 	String name;
 	GDVIRTUAL_CALL(_get_plugin_name, name);
 	return name;
 }
 
-const Ref<Texture2D> EditorPlugin::get_icon() const {
+const Ref<Texture2D> EditorPlugin::get_plugin_icon() const {
 	Ref<Texture2D> icon;
 	GDVIRTUAL_CALL(_get_plugin_icon, icon);
 	return icon;

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -181,8 +181,8 @@ public:
 	virtual void forward_3d_draw_over_viewport(Control *p_overlay);
 	virtual void forward_3d_force_draw_over_viewport(Control *p_overlay);
 
-	virtual String get_name() const;
-	virtual const Ref<Texture2D> get_icon() const;
+	virtual String get_plugin_name() const;
+	virtual const Ref<Texture2D> get_plugin_icon() const;
 	virtual String get_plugin_version() const;
 	virtual void set_plugin_version(const String &p_version);
 	virtual bool has_main_screen() const;

--- a/editor/plugins/font_config_plugin.h
+++ b/editor/plugins/font_config_plugin.h
@@ -280,7 +280,7 @@ class FontEditorPlugin : public EditorPlugin {
 public:
 	FontEditorPlugin();
 
-	virtual String get_name() const override { return "Font"; }
+	virtual String get_plugin_name() const override { return "Font"; }
 };
 
 #endif // FONT_CONFIG_PLUGIN_H

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -136,7 +136,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_name() const override { return "Game"; }
+	virtual String get_plugin_name() const override { return "Game"; }
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override {}
 	virtual bool handles(Object *p_object) const override { return false; }

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
@@ -61,7 +61,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_name() const override { return "GPUParticlesCollisionSDF3D"; }
+	virtual String get_plugin_name() const override { return "GPUParticlesCollisionSDF3D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/gradient_editor_plugin.h
+++ b/editor/plugins/gradient_editor_plugin.h
@@ -138,7 +138,7 @@ class GradientEditorPlugin : public EditorPlugin {
 	GDCLASS(GradientEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "Gradient"; }
+	virtual String get_plugin_name() const override { return "Gradient"; }
 
 	GradientEditorPlugin();
 };

--- a/editor/plugins/input_event_editor_plugin.h
+++ b/editor/plugins/input_event_editor_plugin.h
@@ -70,7 +70,7 @@ class InputEventEditorPlugin : public EditorPlugin {
 	GDCLASS(InputEventEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "InputEvent"; }
+	virtual String get_plugin_name() const override { return "InputEvent"; }
 
 	InputEventEditorPlugin();
 };

--- a/editor/plugins/lightmap_gi_editor_plugin.h
+++ b/editor/plugins/lightmap_gi_editor_plugin.h
@@ -57,7 +57,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual String get_name() const override { return "LightmapGI"; }
+	virtual String get_plugin_name() const override { return "LightmapGI"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/material_editor_plugin.h
+++ b/editor/plugins/material_editor_plugin.h
@@ -131,7 +131,7 @@ class MaterialEditorPlugin : public EditorPlugin {
 	GDCLASS(MaterialEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "Material"; }
+	virtual String get_plugin_name() const override { return "Material"; }
 
 	MaterialEditorPlugin();
 };

--- a/editor/plugins/mesh_editor_plugin.h
+++ b/editor/plugins/mesh_editor_plugin.h
@@ -93,7 +93,7 @@ class MeshEditorPlugin : public EditorPlugin {
 	GDCLASS(MeshEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "Mesh"; }
+	virtual String get_plugin_name() const override { return "Mesh"; }
 
 	MeshEditorPlugin();
 };

--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -113,7 +113,7 @@ class MeshInstance3DEditorPlugin : public EditorPlugin {
 	MeshInstance3DEditor *mesh_editor = nullptr;
 
 public:
-	virtual String get_name() const override { return "MeshInstance3D"; }
+	virtual String get_plugin_name() const override { return "MeshInstance3D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/mesh_library_editor_plugin.h
+++ b/editor/plugins/mesh_library_editor_plugin.h
@@ -83,7 +83,7 @@ class MeshLibraryEditorPlugin : public EditorPlugin {
 	MeshLibraryEditor *mesh_library_editor = nullptr;
 
 public:
-	virtual String get_name() const override { return "MeshLibrary"; }
+	virtual String get_plugin_name() const override { return "MeshLibrary"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_node) override;
 	virtual bool handles(Object *p_node) const override;

--- a/editor/plugins/multimesh_editor_plugin.h
+++ b/editor/plugins/multimesh_editor_plugin.h
@@ -91,7 +91,7 @@ class MultiMeshEditorPlugin : public EditorPlugin {
 	MultiMeshEditor *multimesh_editor = nullptr;
 
 public:
-	virtual String get_name() const override { return "MultiMesh"; }
+	virtual String get_plugin_name() const override { return "MultiMesh"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/navigation_link_2d_editor_plugin.h
+++ b/editor/plugins/navigation_link_2d_editor_plugin.h
@@ -67,7 +67,7 @@ public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return editor->forward_canvas_gui_input(p_event); }
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { editor->forward_canvas_draw_over_viewport(p_overlay); }
 
-	virtual String get_name() const override { return "NavigationLink2D"; }
+	virtual String get_plugin_name() const override { return "NavigationLink2D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/navigation_obstacle_3d_editor_plugin.h
+++ b/editor/plugins/navigation_obstacle_3d_editor_plugin.h
@@ -124,7 +124,7 @@ public:
 
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override;
 
-	virtual String get_name() const override { return "NavigationObstacle3D"; }
+	virtual String get_plugin_name() const override { return "NavigationObstacle3DEditor"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -1013,7 +1013,7 @@ class Node3DEditorPlugin : public EditorPlugin {
 
 public:
 	Node3DEditor *get_spatial_editor() { return spatial_editor; }
-	virtual String get_name() const override { return "3D"; }
+	virtual String get_plugin_name() const override { return "3D"; }
 	bool has_main_screen() const override { return true; }
 	virtual void make_visible(bool p_visible) override;
 	virtual void edit(Object *p_object) override;

--- a/editor/plugins/occluder_instance_3d_editor_plugin.h
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.h
@@ -53,7 +53,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual String get_name() const override { return "OccluderInstance3D"; }
+	virtual String get_plugin_name() const override { return "OccluderInstance3D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/parallax_background_editor_plugin.h
+++ b/editor/plugins/parallax_background_editor_plugin.h
@@ -55,7 +55,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_name() const override { return "ParallaxBackground"; }
+	virtual String get_plugin_name() const override { return "ParallaxBackground"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -130,7 +130,7 @@ public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return path2d_editor->forward_gui_input(p_event); }
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) override { path2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
 
-	virtual String get_name() const override { return "Path2D"; }
+	virtual String get_plugin_name() const override { return "Path2D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -170,7 +170,7 @@ public:
 	inline static Path3DEditorPlugin *singleton = nullptr;
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override;
 
-	virtual String get_name() const override { return "Path3D"; }
+	virtual String get_plugin_name() const override { return "Path3D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/physical_bone_3d_editor_plugin.h
+++ b/editor/plugins/physical_bone_3d_editor_plugin.h
@@ -66,7 +66,7 @@ class PhysicalBone3DEditorPlugin : public EditorPlugin {
 	PhysicalBone3DEditor physical_bone_editor;
 
 public:
-	virtual String get_name() const override { return "PhysicalBone3D"; }
+	virtual String get_plugin_name() const override { return "PhysicalBone3D"; }
 	virtual bool handles(Object *p_object) const override { return p_object->is_class("PhysicalBone3D"); }
 	virtual void make_visible(bool p_visible) override;
 	virtual void edit(Object *p_node) override;

--- a/editor/plugins/polygon_3d_editor_plugin.h
+++ b/editor/plugins/polygon_3d_editor_plugin.h
@@ -104,7 +104,7 @@ class Polygon3DEditorPlugin : public EditorPlugin {
 public:
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return polygon_editor->forward_3d_gui_input(p_camera, p_event); }
 
-	virtual String get_name() const override { return "Polygon3DEditor"; }
+	virtual String get_plugin_name() const override { return "Polygon3DEditor"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/resource_preloader_editor_plugin.h
+++ b/editor/plugins/resource_preloader_editor_plugin.h
@@ -88,7 +88,7 @@ class ResourcePreloaderEditorPlugin : public EditorPlugin {
 	Button *button = nullptr;
 
 public:
-	virtual String get_name() const override { return "ResourcePreloader"; }
+	virtual String get_plugin_name() const override { return "ResourcePreloader"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4481,7 +4481,7 @@ void ScriptEditorPlugin::_focus_another_editor() {
 }
 
 void ScriptEditorPlugin::_save_last_editor(const String &p_editor) {
-	if (p_editor != get_name()) {
+	if (p_editor != get_plugin_name()) {
 		last_editor = p_editor;
 	}
 }

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -617,7 +617,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_name() const override { return "Script"; }
+	virtual String get_plugin_name() const override { return "Script"; }
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -130,7 +130,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_name() const override { return "Shader"; }
+	virtual String get_plugin_name() const override { return "Shader"; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;

--- a/editor/plugins/shader_file_editor_plugin.h
+++ b/editor/plugins/shader_file_editor_plugin.h
@@ -77,7 +77,7 @@ class ShaderFileEditorPlugin : public EditorPlugin {
 	Button *button = nullptr;
 
 public:
-	virtual String get_name() const override { return "ShaderFile"; }
+	virtual String get_plugin_name() const override { return "ShaderFile"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/skeleton_2d_editor_plugin.h
+++ b/editor/plugins/skeleton_2d_editor_plugin.h
@@ -69,7 +69,7 @@ class Skeleton2DEditorPlugin : public EditorPlugin {
 	Skeleton2DEditor *sprite_editor = nullptr;
 
 public:
-	virtual String get_name() const override { return "Skeleton2D"; }
+	virtual String get_plugin_name() const override { return "Skeleton2D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -264,7 +264,7 @@ public:
 	bool has_main_screen() const override { return false; }
 	virtual bool handles(Object *p_object) const override;
 
-	virtual String get_name() const override { return "Skeleton3D"; }
+	virtual String get_plugin_name() const override { return "Skeleton3D"; }
 
 	Skeleton3DEditorPlugin();
 };

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.h
@@ -46,7 +46,7 @@ class SkeletonIK3DEditorPlugin : public EditorPlugin {
 	void _play();
 
 public:
-	virtual String get_name() const override { return "SkeletonIK3D"; }
+	virtual String get_plugin_name() const override { return "SkeletonIK3D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -121,7 +121,7 @@ class Sprite2DEditorPlugin : public EditorPlugin {
 	Sprite2DEditor *sprite_editor = nullptr;
 
 public:
-	virtual String get_name() const override { return "Sprite2D"; }
+	virtual String get_plugin_name() const override { return "Sprite2D"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -286,7 +286,7 @@ class SpriteFramesEditorPlugin : public EditorPlugin {
 	Button *button = nullptr;
 
 public:
-	virtual String get_name() const override { return "SpriteFrames"; }
+	virtual String get_plugin_name() const override { return "SpriteFrames"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/style_box_editor_plugin.h
+++ b/editor/plugins/style_box_editor_plugin.h
@@ -70,7 +70,7 @@ class StyleBoxEditorPlugin : public EditorPlugin {
 	GDCLASS(StyleBoxEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "StyleBox"; }
+	virtual String get_plugin_name() const override { return "StyleBox"; }
 
 	StyleBoxEditorPlugin();
 };

--- a/editor/plugins/sub_viewport_preview_editor_plugin.h
+++ b/editor/plugins/sub_viewport_preview_editor_plugin.h
@@ -47,7 +47,7 @@ class SubViewportPreviewEditorPlugin : public EditorPlugin {
 	GDCLASS(SubViewportPreviewEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "SubViewportPreview"; }
+	virtual String get_plugin_name() const override { return "SubViewportPreview"; }
 
 	SubViewportPreviewEditorPlugin();
 };

--- a/editor/plugins/texture_3d_editor_plugin.h
+++ b/editor/plugins/texture_3d_editor_plugin.h
@@ -89,7 +89,7 @@ class Texture3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Texture3DEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "Texture3D"; }
+	virtual String get_plugin_name() const override { return "Texture3D"; }
 
 	Texture3DEditorPlugin();
 };

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -69,7 +69,7 @@ class TextureEditorPlugin : public EditorPlugin {
 	GDCLASS(TextureEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "Texture2D"; }
+	virtual String get_plugin_name() const override { return "Texture2D"; }
 
 	TextureEditorPlugin();
 };

--- a/editor/plugins/texture_layered_editor_plugin.h
+++ b/editor/plugins/texture_layered_editor_plugin.h
@@ -92,7 +92,7 @@ class TextureLayeredEditorPlugin : public EditorPlugin {
 	GDCLASS(TextureLayeredEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "TextureLayered"; }
+	virtual String get_plugin_name() const override { return "TextureLayered"; }
 
 	TextureLayeredEditorPlugin();
 };

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -175,7 +175,7 @@ class TextureRegionEditorPlugin : public EditorPlugin {
 	GDCLASS(TextureRegionEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "TextureRegion"; }
+	virtual String get_plugin_name() const override { return "TextureRegion"; }
 
 	TextureRegionEditorPlugin();
 };

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -473,7 +473,7 @@ class ThemeEditorPlugin : public EditorPlugin {
 	Button *button = nullptr;
 
 public:
-	virtual String get_name() const override { return "Theme"; }
+	virtual String get_plugin_name() const override { return "Theme"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/tool_button_editor_plugin.h
+++ b/editor/plugins/tool_button_editor_plugin.h
@@ -49,7 +49,7 @@ class ToolButtonEditorPlugin : public EditorPlugin {
 	GDCLASS(ToolButtonEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "ToolButtonEditorPlugin"; }
+	virtual String get_plugin_name() const override { return "ToolButtonEditorPlugin"; }
 
 	ToolButtonEditorPlugin();
 };

--- a/editor/plugins/voxel_gi_editor_plugin.h
+++ b/editor/plugins/voxel_gi_editor_plugin.h
@@ -61,7 +61,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_name() const override { return "VoxelGI"; }
+	virtual String get_plugin_name() const override { return "VoxelGI"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -98,7 +98,7 @@ class EditorPluginCSG : public EditorPlugin {
 	CSGShapeEditor *csg_shape_editor = nullptr;
 
 public:
-	virtual String get_name() const override { return "CSGShape3D"; }
+	virtual String get_plugin_name() const override { return "CSGShape3D"; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -41,7 +41,7 @@
 #include "editor/import/3d/scene_import_settings.h"
 #include "editor/themes/editor_scale.h"
 
-String SceneExporterGLTFPlugin::get_name() const {
+String SceneExporterGLTFPlugin::get_plugin_name() const {
 	return "ConvertGLTF2";
 }
 

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
@@ -52,7 +52,7 @@ class SceneExporterGLTFPlugin : public EditorPlugin {
 	void _export_scene_as_gltf(const String &p_file_path);
 
 public:
-	virtual String get_name() const override;
+	virtual String get_plugin_name() const override;
 	bool has_main_screen() const override;
 	SceneExporterGLTFPlugin();
 };

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -274,7 +274,7 @@ class GridMapEditorPlugin : public EditorPlugin {
 
 public:
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return grid_map_editor->forward_spatial_input_event(p_camera, p_event); }
-	virtual String get_name() const override { return "GridMap"; }
+	virtual String get_plugin_name() const override { return "GridMap"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.h
+++ b/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.h
@@ -102,7 +102,7 @@ class AudioStreamInteractiveEditorPlugin : public EditorPlugin {
 	GDCLASS(AudioStreamInteractiveEditorPlugin, EditorPlugin);
 
 public:
-	virtual String get_name() const override { return "AudioStreamInteractive"; }
+	virtual String get_plugin_name() const override { return "AudioStreamInteractive"; }
 
 	AudioStreamInteractiveEditorPlugin();
 };

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.h
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.h
@@ -74,7 +74,7 @@ class NavigationMeshEditorPlugin : public EditorPlugin {
 	NavigationMeshEditor *navigation_mesh_editor = nullptr;
 
 public:
-	virtual String get_name() const override { return "NavigationMesh"; }
+	virtual String get_plugin_name() const override { return "NavigationMesh"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/modules/noise/editor/noise_editor_plugin.cpp
+++ b/modules/noise/editor/noise_editor_plugin.cpp
@@ -139,7 +139,7 @@ public:
 
 /////////////////////////////////////////////////////////////////////////////////
 
-String NoiseEditorPlugin::get_name() const {
+String NoiseEditorPlugin::get_plugin_name() const {
 	return Noise::get_class_static();
 }
 

--- a/modules/noise/editor/noise_editor_plugin.h
+++ b/modules/noise/editor/noise_editor_plugin.h
@@ -39,7 +39,7 @@ class NoiseEditorPlugin : public EditorPlugin {
 	GDCLASS(NoiseEditorPlugin, EditorPlugin)
 
 public:
-	String get_name() const override;
+	String get_plugin_name() const override;
 
 	NoiseEditorPlugin();
 };

--- a/modules/openxr/editor/openxr_editor_plugin.h
+++ b/modules/openxr/editor/openxr_editor_plugin.h
@@ -47,7 +47,7 @@ class OpenXREditorPlugin : public EditorPlugin {
 #endif
 
 public:
-	virtual String get_name() const override { return "OpenXRPlugin"; }
+	virtual String get_plugin_name() const override { return "OpenXRPlugin"; }
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_node) override;
 	virtual bool handles(Object *p_node) const override;


### PR DESCRIPTION
Same as PR #98039 but for EditorPlugin.

```cpp
String EditorPlugin::get_name() const {
	String name;
	GDVIRTUAL_CALL(_get_plugin_name, name);
	return name;
}

const Ref<Texture2D> EditorPlugin::get_icon() const {
	Ref<Texture2D> icon;
	GDVIRTUAL_CALL(_get_plugin_icon, icon);
	return icon;
}
```

I noticed that the internal names of these functions were different from the names exposed to scripting. They were missing the `plugin` in the middle, in contrast to `get_plugin_version`.

This PR fixes the issue by renaming the internal functions, such that they look like this:

```cpp
String EditorPlugin::get_plugin_name() const {
	String name;
	GDVIRTUAL_CALL(_get_plugin_name, name);
	return name;
}

const Ref<Texture2D> EditorPlugin::get_plugin_icon() const {
	Ref<Texture2D> icon;
	GDVIRTUAL_CALL(_get_plugin_icon, icon);
	return icon;
}
```

This PR preserves API compatibility with GDScript/C#/GDExtension/etc, which already use the `_get_plugin_*` names, however third-party engine modules may need to be updated to support the new name.

I believe using a more verbose name is the better approach to take compared to simplifying the name. Using a more-unique name improves the ability to search for the function in the codebase using grep or global search, and significantly improves the speed at which IDEs can find all uses of it (since they usually find all tokens matching the name, and then do analysis to see which are actual matches). See also PR #36382 and PR #44263 for precedent.

Note, if third-party modules need to be compatible with both 4.3 and 4.4, that is easy to do with this:

```cpp
#if GODOT_VERSION_MAJOR == 4 && GODOT_VERSION_MINOR < 4
#define set_plugin_icon set_icon
#define set_plugin_name set_name
#endif
```