### PR TITLE
Add support for MIDI output 

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -305,12 +305,19 @@ PackedStringArray OS::get_connected_midi_inputs() {
 	return ::OS::get_singleton()->get_connected_midi_inputs();
 }
 
+PackedStringArray OS::get_connected_midi_outputs() {
+	return ::OS::get_singleton()->get_connected_midi_outputs();
+}
+
 void OS::open_midi_inputs() {
 	::OS::get_singleton()->open_midi_inputs();
 }
 
 void OS::close_midi_inputs() {
 	::OS::get_singleton()->close_midi_inputs();
+}
+void OS::send_midi(Ref<InputEventMIDI> p_event) {
+	::OS::get_singleton()->send_midi(p_event);
 }
 
 void OS::set_use_file_access_save_and_swap(bool p_enable) {
@@ -756,8 +763,10 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_entropy", "size"), &OS::get_entropy);
 	ClassDB::bind_method(D_METHOD("get_system_ca_certificates"), &OS::get_system_ca_certificates);
 	ClassDB::bind_method(D_METHOD("get_connected_midi_inputs"), &OS::get_connected_midi_inputs);
+	ClassDB::bind_method(D_METHOD("get_connected_midi_outputs"), &OS::get_connected_midi_outputs);
 	ClassDB::bind_method(D_METHOD("open_midi_inputs"), &OS::open_midi_inputs);
 	ClassDB::bind_method(D_METHOD("close_midi_inputs"), &OS::close_midi_inputs);
+	ClassDB::bind_method(D_METHOD("send_midi", "event"), &OS::send_midi);
 
 	ClassDB::bind_method(D_METHOD("alert", "text", "title"), &OS::alert, DEFVAL("Alert!"));
 	ClassDB::bind_method(D_METHOD("crash", "message"), &OS::crash);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -34,6 +34,7 @@
 #include "core/io/logger.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/input/input_event.h"
 #include "core/object/class_db.h"
 #include "core/object/script_backtrace.h"
 #include "core/os/semaphore.h"
@@ -191,8 +192,10 @@ public:
 	};
 
 	virtual PackedStringArray get_connected_midi_inputs();
+	virtual PackedStringArray get_connected_midi_outputs();
 	virtual void open_midi_inputs();
 	virtual void close_midi_inputs();
+	virtual void send_midi(Ref<InputEventMIDI> p_event);
 
 	void set_low_processor_usage_mode(bool p_enabled);
 	bool is_in_low_processor_usage_mode() const;

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1861,6 +1861,46 @@ int InputEventMIDI::get_controller_value() const {
 	return controller_value;
 }
 
+PackedByteArray InputEventMIDI::get_midi_bytes() const {
+	PackedByteArray result;
+	result.append(static_cast<uint8_t>(static_cast<int>(message) << 4 | (channel & 0xF)));
+	switch (message) {
+		case MIDIMessage::NOTE_OFF:
+		case MIDIMessage::NOTE_ON:
+			result.append(pitch);
+			result.append(velocity);
+			break;
+		case MIDIMessage::AFTERTOUCH:
+			result.append(pitch);
+			result.append(pressure);
+			break;
+		case MIDIMessage::CONTROL_CHANGE:
+			result.append(controller_number);
+			result.append(controller_value);
+			break;
+		case MIDIMessage::PITCH_BEND:
+			result.append(pitch | 0x80);
+			result.append(pitch >> 7);
+			break;
+		case MIDIMessage::SONG_POSITION_POINTER:
+			result.resize(3);
+			break;
+		case MIDIMessage::PROGRAM_CHANGE:
+			result.append(instrument);
+			break;
+		case MIDIMessage::CHANNEL_PRESSURE:
+			result.append(pressure);
+			break;
+		case MIDIMessage::QUARTER_FRAME:
+		case MIDIMessage::SONG_SELECT:
+			result.resize(2);
+			break;
+		default:
+			break;
+	}
+	return result;
+}
+
 String InputEventMIDI::as_text() const {
 	return vformat(RTR("MIDI Input on Channel=%s Message=%s"), itos(channel), itos((int64_t)message));
 }

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -573,6 +573,8 @@ public:
 	void set_controller_value(const int p_controller_value);
 	int get_controller_value() const;
 
+	PackedByteArray get_midi_bytes() const;
+
 	virtual String as_text() const override;
 	virtual String _to_string() override;
 

--- a/core/os/midi_driver.cpp
+++ b/core/os/midi_driver.cpp
@@ -202,3 +202,7 @@ void MIDIDriver::Parser::parse_fragment(uint8_t p_fragment) {
 PackedStringArray MIDIDriver::get_connected_inputs() const {
 	return connected_input_names;
 }
+
+PackedStringArray MIDIDriver::get_connected_outputs() const {
+	return connected_output_names;
+}

--- a/core/os/midi_driver.h
+++ b/core/os/midi_driver.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "core/input/input_enums.h"
+#include "core/input/input_event.h"
 #include "core/typedefs.h"
 #include "core/variant/variant.h"
 
@@ -98,6 +98,7 @@ protected:
 	};
 
 	PackedStringArray connected_input_names;
+	PackedStringArray connected_output_names;
 
 public:
 	static MIDIDriver *get_singleton();
@@ -106,7 +107,11 @@ public:
 	virtual ~MIDIDriver() = default;
 
 	virtual Error open() = 0;
+	virtual Error send(Ref<InputEventMIDI> p_event) {
+		return Error::FAILED;
+	}
 	virtual void close() = 0;
 
 	PackedStringArray get_connected_inputs() const;
+	PackedStringArray get_connected_outputs() const;
 };

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -671,6 +671,15 @@ PackedStringArray OS::get_connected_midi_inputs() {
 	ERR_FAIL_V_MSG(list, vformat("MIDI input isn't supported on %s.", OS::get_singleton()->get_name()));
 }
 
+PackedStringArray OS::get_connected_midi_outputs() {
+	if (MIDIDriver::get_singleton()) {
+		return MIDIDriver::get_singleton()->get_connected_outputs();
+	}
+
+	PackedStringArray list;
+	ERR_FAIL_V_MSG(list, vformat("MIDI output isn't supported on %s.", OS::get_singleton()->get_name()));
+}
+
 void OS::open_midi_inputs() {
 	if (MIDIDriver::get_singleton()) {
 		MIDIDriver::get_singleton()->open();
@@ -685,6 +694,10 @@ void OS::close_midi_inputs() {
 	} else {
 		ERR_PRINT(vformat("MIDI input isn't supported on %s.", OS::get_singleton()->get_name()));
 	}
+}
+
+Error OS::send_midi(Ref<InputEventMIDI> p_event) {
+	return MIDIDriver::get_singleton()->send(p_event);
 }
 
 uint64_t OS::get_frame_delay(bool p_can_draw) const {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/config/engine.h"
+#include "core/input/input_event.h"
 #include "core/io/logger.h"
 #include "core/io/remote_filesystem_client.h"
 #include "core/os/process_id.h"
@@ -182,8 +183,10 @@ public:
 	virtual String get_system_ca_certificates() { return ""; } // Concatenated certificates in PEM format.
 
 	virtual PackedStringArray get_connected_midi_inputs();
+	virtual PackedStringArray get_connected_midi_outputs();
 	virtual void open_midi_inputs();
 	virtual void close_midi_inputs();
+	virtual Error send_midi(Ref<InputEventMIDI> p_event);
 
 	virtual Rect2 calculate_boot_screen_rect(const Size2 &p_window_size, const Size2 &p_imgrect_size) const;
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -255,10 +255,17 @@
 		<method name="get_connected_midi_inputs">
 			<return type="PackedStringArray" />
 			<description>
-				Returns an array of connected MIDI device names, if they exist. Returns an empty array if the system MIDI driver has not previously been initialized with [method open_midi_inputs]. See also [method close_midi_inputs].
+				Returns an array of connected MIDI input device names, if they exist. Returns an empty array if the system MIDI driver has not previously been initialized with [method open_midi_inputs]. See also [method close_midi_inputs].
 				[b]Note:[/b] This method is implemented on Linux, macOS, Windows, and Web.
 				[b]Note:[/b] On the Web platform, Web MIDI needs to be supported by the browser. [url=https://caniuse.com/midi]For the time being[/url], it is currently supported by all major browsers, except Safari.
 				[b]Note:[/b] On the Web platform, using MIDI input requires a browser permission to be granted first. This permission request is performed when calling [method open_midi_inputs]. The browser will refrain from processing MIDI input until the user accepts the permission request.
+			</description>
+		</method>
+		<method name="get_connected_midi_outputs">
+			<return type="PackedStringArray" />
+			<description>
+				Returns an array of connected MIDI output device names, if they exist. Returns an empty array if the system MIDI driver has not previously been initialized with [method open_midi_inputs]. See also [method close_midi_inputs].
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
 			</description>
 		</method>
 		<method name="get_data_dir" qualifiers="const">
@@ -823,6 +830,14 @@
 			<return type="void" />
 			<description>
 				On macOS (sandboxed applications only), this function clears list of user selected folders accessible to the application.
+			</description>
+		</method>
+		<method name="send_midi">
+			<return type="void" />
+			<param index="0" name="event" type="InputEventMIDI" />
+			<description>
+				Send the MIDI [param event] to the device specieid in the events device_id.
+				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
 			</description>
 		</method>
 		<method name="set_environment" qualifiers="const">

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -92,18 +92,28 @@ Error MIDIDriverALSAMidi::open() {
 
 		if (name != nullptr) {
 			snd_rawmidi_t *midi_in;
-			int ret = snd_rawmidi_open(&midi_in, nullptr, name, SND_RAWMIDI_NONBLOCK);
+			snd_rawmidi_t *midi_out;
+			int ret = snd_rawmidi_open(&midi_in, &midi_out, name, SND_RAWMIDI_NONBLOCK);
 			if (ret >= 0) {
 				// Get display name.
-				snd_rawmidi_info_t *info;
-				snd_rawmidi_info_malloc(&info);
-				snd_rawmidi_info(midi_in, info);
-				connected_input_names.push_back(snd_rawmidi_info_get_name(info));
-				snd_rawmidi_info_free(info);
-
-				connected_inputs.push_back(InputConnection(device_index, midi_in));
-				// Only increment device_index for successfully connected devices.
-				device_index++;
+				if (midi_in != nullptr) {
+					snd_rawmidi_info_t *info;
+					snd_rawmidi_info_malloc(&info);
+					snd_rawmidi_info(midi_in, info);
+					connected_input_names.push_back(snd_rawmidi_info_get_name(info));
+					snd_rawmidi_info_free(info);
+					connected_inputs.push_back(InputConnection(device_index, midi_in));
+					// Only increment device_index for successfully connected devices.
+					device_index++;
+				}
+				if (midi_out != nullptr) {
+					snd_rawmidi_info_t *info;
+					snd_rawmidi_info_malloc(&info);
+					snd_rawmidi_info(midi_out, info);
+					connected_output_names.push_back(snd_rawmidi_info_get_name(info));
+					connected_outputs.push_back(midi_out);
+					snd_rawmidi_info_free(info);
+				}
 			}
 		}
 
@@ -132,6 +142,15 @@ void MIDIDriverALSAMidi::close() {
 
 	connected_inputs.clear();
 	connected_input_names.clear();
+}
+
+Error MIDIDriverALSAMidi::send(Ref<InputEventMIDI> p_event) {
+	ERR_FAIL_COND_V(p_event.is_null(), ERR_INVALID_PARAMETER);
+	int device_id = p_event->get_device();
+	ERR_FAIL_INDEX_V(device_id, connected_outputs.size(), ERR_PARAMETER_RANGE_ERROR);
+	PackedByteArray packet = p_event->get_midi_bytes();
+	snd_rawmidi_write(connected_outputs[device_id], packet.ptrw(), packet.size());
+	return OK;
 }
 
 void MIDIDriverALSAMidi::lock() const {

--- a/drivers/alsamidi/midi_driver_alsamidi.h
+++ b/drivers/alsamidi/midi_driver_alsamidi.h
@@ -56,6 +56,7 @@ class MIDIDriverALSAMidi : public MIDIDriver {
 	};
 
 	Vector<InputConnection> connected_inputs;
+	Vector<snd_rawmidi_t *> connected_outputs;
 
 	SafeFlag exit_thread;
 
@@ -67,6 +68,7 @@ class MIDIDriverALSAMidi : public MIDIDriver {
 public:
 	virtual Error open() override;
 	virtual void close() override;
+	virtual Error send(Ref<InputEventMIDI> p_event) override;
 
 	MIDIDriverALSAMidi();
 	virtual ~MIDIDriverALSAMidi();

--- a/drivers/coremidi/midi_driver_coremidi.h
+++ b/drivers/coremidi/midi_driver_coremidi.h
@@ -43,6 +43,7 @@
 class MIDIDriverCoreMidi : public MIDIDriver {
 	MIDIClientRef client = 0;
 	MIDIPortRef port_in;
+	MIDIPortRef port_out;
 
 	struct InputConnection {
 		InputConnection() = default;
@@ -61,6 +62,7 @@ class MIDIDriverCoreMidi : public MIDIDriver {
 public:
 	virtual Error open() override;
 	virtual void close() override;
+	virtual Error send(Ref<InputEventMIDI> p_event) override;
 
 	MIDIDriverCoreMidi() = default;
 	virtual ~MIDIDriverCoreMidi();

--- a/drivers/winmidi/midi_driver_winmidi.h
+++ b/drivers/winmidi/midi_driver_winmidi.h
@@ -41,12 +41,14 @@
 
 class MIDIDriverWinMidi : public MIDIDriver {
 	Vector<HMIDIIN> connected_sources;
+	Vector<HMIDIOUT> connected_sinks;
 
 	static void CALLBACK read(HMIDIIN hMidiIn, UINT wMsg, DWORD_PTR dwInstance, DWORD_PTR dwParam1, DWORD_PTR dwParam2);
 
 public:
 	virtual Error open() override;
 	virtual void close() override;
+	virtual Error send(Ref<InputEventMIDI> p_event) override;
 
 	MIDIDriverWinMidi() = default;
 	virtual ~MIDIDriverWinMidi();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/2321

Currently the API is very simple, a new method is created `OS.send_midi` that accepts a InputEventMIDI and sends it to the midi device specified in the event.  Output device IDs can be found in `OS.get_connected_midi_outputs`.  To use this API you first need to open MIDI with `OS.open_midi_inputs` which now opens both inputs and outputs.

I've tested the code on OSX and Windows, but haven't been able to find a linux machine with ALSA set up in a way Godot seems to be able to see the midi devices for, so the ALSA code is just my best guess currently.

**TODO**

- [x] Test on Linux
- [x] Discuss API, especially wrt (https://github.com/godotengine/godot-proposals/issues/8761)
- [x] Additional testing on OSX and Windows




