### PR TITLE
Fix using `Edit` on exported `Node` property

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2662,14 +2662,19 @@ void EditorPropertyNodePath::_node_selected(const NodePath &p_path) {
 		path = base_node->get_path().rel_path_to(p_path);
 	}
 
+	_submit_relative_node_path(path);
+}
+
+void EditorPropertyNodePath::_submit_relative_node_path(const NodePath &p_path) {
+	Node *base_node = get_base_node();
 	if (editing_node) {
 		if (!base_node) {
-			emit_changed(get_edited_property(), get_tree()->get_edited_scene_root()->get_node(path));
+			emit_changed(get_edited_property(), get_tree()->get_edited_scene_root()->get_node(p_path));
 		} else {
-			emit_changed(get_edited_property(), base_node->get_node(path));
+			emit_changed(get_edited_property(), base_node->get_node(p_path));
 		}
 	} else {
-		emit_changed(get_edited_property(), path);
+		emit_changed(get_edited_property(), p_path);
 	}
 	update_property();
 }
@@ -2748,7 +2753,7 @@ void EditorPropertyNodePath::_accept_text() {
 
 void EditorPropertyNodePath::_text_submitted(const String &p_text) {
 	NodePath np = p_text;
-	emit_changed(get_edited_property(), np);
+	_submit_relative_node_path(np);
 	edit->hide();
 	assign->show();
 	menu->show();

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -630,6 +630,7 @@ class EditorPropertyNodePath : public EditorProperty {
 	Vector<StringName> valid_types;
 	void _node_selected(const NodePath &p_path);
 	void _node_assign();
+	void _submit_relative_node_path(const NodePath &p_path);
 	Node *get_base_node();
 	void _update_menu();
 	void _menu_option(int p_idx);


### PR DESCRIPTION
Fixes #93808

The property box for an exported `Node` from GDScript can be edited by either through selecting a node in a dialog box, or editing the text node path. Unfortunately, editing the node path via text editing was broken. I've unified some of the code for handling both methods, and it should work now.