### PR TITLE
GDScript: Fix annotation parsing adding new annotation entries

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1624,15 +1624,17 @@ GDScriptParser::AnnotationNode *GDScriptParser::parse_annotation(uint32_t p_vali
 		valid = false;
 	}
 
-	annotation->info = &valid_annotations[annotation->name];
+	if (valid) {
+		annotation->info = &valid_annotations[annotation->name];
 
-	if (!annotation->applies_to(p_valid_targets)) {
-		if (annotation->applies_to(AnnotationInfo::SCRIPT)) {
-			push_error(vformat(R"(Annotation "%s" must be at the top of the script, before "extends" and "class_name".)", annotation->name));
-		} else {
-			push_error(vformat(R"(Annotation "%s" is not allowed in this level.)", annotation->name));
+		if (!annotation->applies_to(p_valid_targets)) {
+			if (annotation->applies_to(AnnotationInfo::SCRIPT)) {
+				push_error(vformat(R"(Annotation "%s" must be at the top of the script, before "extends" and "class_name".)", annotation->name));
+			} else {
+				push_error(vformat(R"(Annotation "%s" is not allowed in this level.)", annotation->name));
+			}
+			valid = false;
 		}
-		valid = false;
 	}
 
 	if (check(GDScriptTokenizer::Token::PARENTHESIS_OPEN)) {

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_inapplicable.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_inapplicable.gd
@@ -1,0 +1,3 @@
+@export
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_inapplicable.out
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_inapplicable.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Annotation "@export" cannot be applied to a function.

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_unrecognized.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_unrecognized.gd
@@ -1,0 +1,3 @@
+@hello_world
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_unrecognized.out
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_unrecognized.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Unrecognized annotation: "@hello_world".


### PR DESCRIPTION
Fixes #98145

The code was indexing the annotation map regardless of the previous check which apparently introduces new entries. So the right error was only emitted for the first parsing but for any subsequent parsing the name would be present in the map.