### PR TITLE
Fix freeze on non-thread-safe custom importers

### DIFF
--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -148,7 +148,7 @@ public:
 	virtual String get_option_group_file() const { return String(); }
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) = 0;
-	virtual bool can_import_threaded() const { return true; }
+	virtual bool can_import_threaded() const { return false; }
 	virtual void import_threaded_begin() {}
 	virtual void import_threaded_end() {}
 

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -124,7 +124,8 @@
 			<return type="bool" />
 			<description>
 				Tells whether this importer can be run in parallel on threads, or, on the contrary, it's only safe for the editor to call it from the main thread, for one file at a time.
-				If this method is not overridden, it will return [code]true[/code] by default (i.e., safe for parallel importing).
+				If this method is not overridden, it will return [code]false[/code] by default.
+				If this importer's implementation is thread-safe and can be run in parallel, override this with [code]true[/code] to optimize for concurrency.
 			</description>
 		</method>
 		<method name="_get_import_options" qualifiers="virtual const">

--- a/editor/import/3d/resource_importer_obj.h
+++ b/editor/import/3d/resource_importer_obj.h
@@ -63,9 +63,6 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
-	// Threaded import can currently cause deadlocks, see GH-48265.
-	virtual bool can_import_threaded() const override { return false; }
-
 	ResourceImporterOBJ();
 };
 

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -304,8 +304,6 @@ public:
 	virtual bool has_advanced_options() const override;
 	virtual void show_advanced_options(const String &p_path) override;
 
-	virtual bool can_import_threaded() const override { return false; }
-
 	ResourceImporterScene(const String &p_scene_import_type = "PackedScene", bool p_singleton = false);
 	~ResourceImporterScene();
 

--- a/editor/import/resource_importer_bitmask.h
+++ b/editor/import/resource_importer_bitmask.h
@@ -50,6 +50,8 @@ public:
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterBitMap();
 	~ResourceImporterBitMap();
 };

--- a/editor/import/resource_importer_bmfont.h
+++ b/editor/import/resource_importer_bmfont.h
@@ -50,6 +50,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterBMFont();
 };
 

--- a/editor/import/resource_importer_csv_translation.h
+++ b/editor/import/resource_importer_csv_translation.h
@@ -51,6 +51,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterCSVTranslation();
 };
 

--- a/editor/import/resource_importer_dynamic_font.h
+++ b/editor/import/resource_importer_dynamic_font.h
@@ -60,6 +60,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterDynamicFont();
 };
 

--- a/editor/import/resource_importer_image.h
+++ b/editor/import/resource_importer_image.h
@@ -52,6 +52,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterImage();
 };
 

--- a/editor/import/resource_importer_imagefont.h
+++ b/editor/import/resource_importer_imagefont.h
@@ -50,6 +50,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterImageFont();
 };
 

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -117,6 +117,8 @@ public:
 	virtual bool are_import_settings_valid(const String &p_path, const Dictionary &p_meta) const override;
 	virtual String get_import_settings_string() const override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	void set_mode(Mode p_mode) { mode = p_mode; }
 
 	ResourceImporterLayeredTexture(bool p_singleton = false);

--- a/editor/import/resource_importer_shader_file.h
+++ b/editor/import/resource_importer_shader_file.h
@@ -51,6 +51,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterShaderFile();
 };
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -102,6 +102,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	void update_imports();
 
 	virtual bool are_import_settings_valid(const String &p_path, const Dictionary &p_meta) const override;

--- a/editor/import/resource_importer_texture_atlas.h
+++ b/editor/import/resource_importer_texture_atlas.h
@@ -67,6 +67,8 @@ public:
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 	virtual Error import_group_file(const String &p_group_file, const HashMap<String, HashMap<StringName, Variant>> &p_source_file_options, const HashMap<String, String> &p_base_paths) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterTextureAtlas();
 };
 

--- a/editor/import/resource_importer_wav.h
+++ b/editor/import/resource_importer_wav.h
@@ -142,6 +142,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterWAV();
 };
 

--- a/modules/minimp3/resource_importer_mp3.h
+++ b/modules/minimp3/resource_importer_mp3.h
@@ -59,6 +59,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterMP3();
 };
 

--- a/modules/vorbis/resource_importer_ogg_vorbis.h
+++ b/modules/vorbis/resource_importer_ogg_vorbis.h
@@ -65,6 +65,8 @@ public:
 
 	virtual Error import(const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
+	virtual bool can_import_threaded() const override { return true; }
+
 	ResourceImporterOggVorbis();
 };
 


### PR DESCRIPTION
Godot currently assumes that all importers are thread-safe, leading to non-deterministic, OS and hardware-dependent deadlocks. Several of Godot's built-in importers already override this false assumption in order to avoid freezing the editor:

- https://github.com/godotengine/godot/blob/92e51fca7247c932f95a1662aefc28aca96e8de6/editor/import/3d/resource_importer_obj.h#L66-L67
- https://github.com/godotengine/godot/blob/92e51fca7247c932f95a1662aefc28aca96e8de6/editor/import/3d/resource_importer_scene.h#L307

This updates the `EditorImportPlugin` implementation and documentation to make custom importers safe to use by default, while still allowing them to opt into threaded concurrency optimizations _if_ they are actually thread-safe.

Fixes https://github.com/godotengine/godot/issues/85237