### PR TITLE
[Editor] Prevent `TOOLS` .NET `DefineConstants` being overridden by the user

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.props
@@ -103,15 +103,6 @@
     <GodotDefineConstants>$(GodotDefineConstants);$(GodotPlatformConstants);$(GodotVersionConstants)</GodotDefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- ExportDebug also defines DEBUG like Debug does. -->
-    <DefineConstants Condition=" '$(Configuration)' == 'ExportDebug' ">$(DefineConstants);DEBUG</DefineConstants>
-    <!-- Debug defines TOOLS to differentiate between Debug and ExportDebug configurations. -->
-    <DefineConstants Condition=" '$(Configuration)' == 'Debug' ">$(DefineConstants);TOOLS</DefineConstants>
-
-    <DefineConstants>$(GodotDefineConstants);$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)\Android.props" Condition=" '$(GodotTargetPlatform)' == 'android' " />
   <Import Project="$(MSBuildThisFileDirectory)\iOSNativeAOT.props" Condition=" '$(GodotTargetPlatform)' == 'ios' " />
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -10,6 +10,19 @@
     <DefineConstants Condition=" '$(GodotFloat64)' == 'true' ">GODOT_REAL_T_IS_DOUBLE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
+  <!--
+  We are defining ExportDebug and Debug in Sdk.targets to ensure that the user cannot
+  override the DefineConstants property in their csproj file and break the editor functionality.
+  -->
+  <PropertyGroup>
+    <!-- ExportDebug also defines DEBUG like Debug does. -->
+    <DefineConstants Condition=" '$(Configuration)' == 'ExportDebug' ">$(DefineConstants);DEBUG</DefineConstants>
+    <!-- Debug defines TOOLS to differentiate between Debug and ExportDebug configurations. -->
+    <DefineConstants Condition=" '$(Configuration)' == 'Debug' ">$(DefineConstants);TOOLS</DefineConstants>
+
+    <DefineConstants>$(GodotDefineConstants);$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
   <!-- C# source generators -->
   <ItemGroup Condition=" '$(DisableImplicitGodotGeneratorReferences)' != 'true' ">
     <PackageReference Include="Godot.SourceGenerators" Version="$(PackageVersion_Godot_SourceGenerators)" />


### PR DESCRIPTION
Related #78513
Closes #98124

As mentioned [here](https://github.com/godotengine/godot/issues/98124#issuecomment-2408789969), the `TOOLS` compiler symbol is crucial for C# editor functionality; the absence of `TOOLS` can lead to data loss and editor malfunctions (all C# script exports become `null` and Ineditable) without a proper error message.

This PR ensures that the `TOOLS` are always included in the editor, so even if the user overrides the `DefineConstants` (by accident or intentionally), the rest of the dotnet editor stays functional.

Thanks Raulsntos for [suggesting the better solution](https://github.com/godotengine/godot/pull/98153#pullrequestreview-2634832608).