### PR TITLE
Show correct icons in remote object inspector (EditorDebuggerRemoteObject)

### DIFF
--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_object_selector.h"
 
+#include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/editor_data.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -131,6 +132,19 @@ void EditorObjectSelector::update_path() {
 		Ref<Texture2D> obj_icon;
 		if (Object::cast_to<MultiNodeEdit>(obj)) {
 			obj_icon = EditorNode::get_singleton()->get_class_icon(Object::cast_to<MultiNodeEdit>(obj)->get_edited_class_name());
+		} else if (Object::cast_to<EditorDebuggerRemoteObject>(obj)) {
+			String class_name;
+			Ref<Script> base_script = obj->get_script();
+			if (base_script.is_valid()) {
+				class_name = base_script->get_global_name();
+
+				if (class_name.is_empty()) {
+					// If there is no class_name in this script we just take the script path.
+					class_name = base_script->get_path();
+				}
+			}
+
+			obj_icon = EditorNode::get_singleton()->get_class_icon(class_name.is_empty() ? Object::cast_to<EditorDebuggerRemoteObject>(obj)->type_name : class_name);
 		} else {
 			obj_icon = EditorNode::get_singleton()->get_object_icon(obj);
 		}


### PR DESCRIPTION
~~Used to implement https://github.com/godotengine/godot-proposals/issues/2084, used to fix #95209.~~ <- Better implemented in https://github.com/godotengine/godot/pull/88427.

~~This commit allows the remote scene view to display custom icons from classes (annotated with `@icon`) and allows the remote object inspector to display the correct class icon for an Object. These help a lot with readability.~~


This commit allows the remote object inspector (EditorDebuggerRemoteObject) to display the correct class icon for an Object.

---
| Before | After |
| ------------- | ------------- |
| <video src=https://github.com/user-attachments/assets/62f33b1f-942b-4e6c-b66f-7ccfce4cdb94></video> | <video src=https://github.com/user-attachments/assets/ba8d50b9-6613-4d75-833c-7deb3ae912b9></video>