### PR TITLE
Show correct icons in remote object inspector (EditorDebuggerRemoteObject)

### DIFF
--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_object_selector.h"
 
+#include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/editor_data.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -131,6 +132,18 @@ void EditorObjectSelector::update_path() {
 		Ref<Texture2D> obj_icon;
 		if (Object::cast_to<MultiNodeEdit>(obj)) {
 			obj_icon = EditorNode::get_singleton()->get_class_icon(Object::cast_to<MultiNodeEdit>(obj)->get_edited_class_name());
+		} else if (obj->is_class("EditorDebuggerRemoteObject")) {
+			String class_name;
+			Ref<Script> script_base = obj->get_script();
+
+			if (script_base.is_valid()) {
+				class_name = script_base->get_global_name();
+			}
+			if (class_name.is_empty()) {
+				class_name = Object::cast_to<EditorDebuggerRemoteObject>(obj)->type_name;
+			}
+
+			obj_icon = EditorNode::get_singleton()->get_class_icon(class_name);
 		} else {
 			obj_icon = EditorNode::get_singleton()->get_object_icon(obj);
 		}


### PR DESCRIPTION
This commit allows the remote object inspector to display the correct class icon for an Object. This helps a lot with readability when viewing remote nodes.

---

| Before | After |
| ------------- | ------------- |
| <video src=https://github.com/user-attachments/assets/62f33b1f-942b-4e6c-b66f-7ccfce4cdb94></video> | <video src=https://github.com/user-attachments/assets/ba8d50b9-6613-4d75-833c-7deb3ae912b9></video>



