### PR TITLE
Add `EditorHelpBitTooltip` as a child of `p_target` to avoid jitter

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -3868,7 +3868,7 @@ void EditorHelpBitTooltip::show_tooltip(EditorHelpBit *p_help_bit, Control *p_ta
 	EditorHelpBitTooltip *tooltip = memnew(EditorHelpBitTooltip(p_target));
 	p_help_bit->connect("request_hide", callable_mp(tooltip, &EditorHelpBitTooltip::_safe_queue_free));
 	tooltip->add_child(p_help_bit);
-	p_target->get_viewport()->add_child(tooltip);
+	p_target->add_child(tooltip);
 	p_help_bit->update_content_height();
 	tooltip->popup_under_cursor();
 }


### PR DESCRIPTION
Previously the tooltip popup was added as a child of the `p_target`‘s viewport (usually the root window), which caused the root window to recalculate the window size, that could cause jitter issues on i3wm if the actual width of the root window was less than `1024`.

Fixes #98135.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
