### PR TITLE
Add variant_interpolate variant utility function to gdextension inter…

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -40,6 +40,7 @@
 #include "core/object/worker_thread_pool.h"
 #include "core/os/memory.h"
 #include "core/variant/variant.h"
+#include "core/variant/variant_utility.h"
 #include "core/version.h"
 
 #include <string.h>
@@ -526,6 +527,21 @@ static GDExtensionBool gdextension_variant_can_convert(GDExtensionVariantType p_
 
 static GDExtensionBool gdextension_variant_can_convert_strict(GDExtensionVariantType p_from, GDExtensionVariantType p_to) {
 	return Variant::can_convert_strict((Variant::Type)p_from, (Variant::Type)p_to);
+}
+
+static void gdextension_variant_interpolate(GDExtensionConstVariantPtr p_from, GDExtensionConstVariantPtr p_to, float p_weight, GDExtensionVariantPtr r_dest, GDExtensionCallError *r_error) {
+	const Variant *from = (const Variant *)p_from;
+	const Variant *to = (const Variant *)p_to;
+	Variant *dest = (Variant *)r_dest;
+
+	Callable::CallError error;
+	*dest = VariantUtilityFunctions::lerp(*from, *to, p_weight, error);
+
+	if (r_error) {
+		r_error->error = (GDExtensionCallErrorType)(error.error);
+		r_error->argument = error.argument;
+		r_error->expected = error.expected;
+	}
 }
 
 // Variant interaction.
@@ -1622,6 +1638,7 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(variant_get_type_name);
 	REGISTER_INTERFACE_FUNC(variant_can_convert);
 	REGISTER_INTERFACE_FUNC(variant_can_convert_strict);
+	REGISTER_INTERFACE_FUNC(variant_interpolate);
 	REGISTER_INTERFACE_FUNC(get_variant_from_type_constructor);
 	REGISTER_INTERFACE_FUNC(get_variant_to_type_constructor);
 	REGISTER_INTERFACE_FUNC(variant_get_ptr_operator_evaluator);

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -1360,6 +1360,20 @@ typedef GDExtensionBool (*GDExtensionInterfaceVariantCanConvert)(GDExtensionVari
 typedef GDExtensionBool (*GDExtensionInterfaceVariantCanConvertStrict)(GDExtensionVariantType p_from, GDExtensionVariantType p_to);
 
 /**
+ * @name variant_interpolate
+ * @since 4.4
+ *
+ * Interpolates between the values of two Variants using a given weight.
+ *
+ * @param p_from The Variant to interpolate from.
+ * @param p_to The Variant to interpolate towards.
+ * @param p_weight The weight that dictates how far to interpolate the value of p_from towards the value of p_to.
+ * @param r_dest A pointer to the destination Variant.
+ * @param r_error A pointer to a GDExtensionCallError struct that will receive error information.
+ */
+typedef void (*GDExtensionInterfaceVariantInterpolate)(GDExtensionConstVariantPtr p_from, GDExtensionConstVariantPtr p_to, float p_weight, GDExtensionVariantPtr r_dest, GDExtensionCallError *r_error);
+
+/**
  * @name get_variant_from_type_constructor
  * @since 4.1
  *


### PR DESCRIPTION
This change adds a variant_interpolate function to the gdextension interface that uses the existing variant_utility lerp function to interpolate between the values of two Variants. This allows gdextensions to access this variant_utility function.