### PR TITLE
Add ability to disable shadow blur on `StyleBoxFlat`

### DIFF
--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -165,8 +165,8 @@
 		<member name="shadow_offset" type="Vector2" setter="set_shadow_offset" getter="get_shadow_offset" default="Vector2(0, 0)">
 			The shadow offset in pixels. Adjusts the position of the shadow relatively to the stylebox.
 		</member>
-		<member name="shadow_size" type="int" setter="set_shadow_size" getter="get_shadow_size" default="0">
-			The shadow size in pixels.
+		<member name="shadow_size" type="int" setter="set_shadow_size" getter="get_shadow_size" default="-1">
+			The shadow size in pixels. A size of [code]-1[/code] disables drawing of the shadow entirely.
 		</member>
 		<member name="skew" type="Vector2" setter="set_skew" getter="get_skew" default="Vector2(0, 0)">
 			If set to a non-zero value on either axis, [member skew] distorts the StyleBox horizontally and/or vertically. This can be used for "futuristic"-style UIs. Positive values skew the StyleBox towards the right (X axis) and upwards (Y axis), while negative values skew the StyleBox towards the left (X axis) and downwards (Y axis).

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -369,7 +369,7 @@ Rect2 StyleBoxFlat::get_draw_rect(const Rect2 &p_rect) const {
 
 void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	bool draw_border = (border_width[0] > 0) || (border_width[1] > 0) || (border_width[2] > 0) || (border_width[3] > 0);
-	bool draw_shadow = (shadow_size > 0);
+	bool draw_shadow = (shadow_size > -1);
 	if (!draw_border && !draw_center && !draw_shadow) {
 		return;
 	}
@@ -622,7 +622,7 @@ void StyleBoxFlat::_bind_methods() {
 
 	ADD_GROUP("Shadow", "shadow_");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "shadow_color"), "set_shadow_color", "get_shadow_color");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_size", PROPERTY_HINT_RANGE, "0,100,1,or_greater,suffix:px"), "set_shadow_size", "get_shadow_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_size", PROPERTY_HINT_RANGE, "-1,100,1,or_greater,suffix:px"), "set_shadow_size", "get_shadow_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "shadow_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_shadow_offset", "get_shadow_offset");
 
 	ADD_GROUP("Anti Aliasing", "anti_aliasing_");

--- a/scene/resources/style_box_flat.h
+++ b/scene/resources/style_box_flat.h
@@ -50,7 +50,7 @@ class StyleBoxFlat : public StyleBox {
 	bool anti_aliased = true;
 
 	int corner_detail = 8;
-	int shadow_size = 0;
+	int shadow_size = -1;
 	Point2 shadow_offset;
 	real_t aa_size = 1;
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/96667

There was no way to implement this PR without any compatibility breakages, so I did it in the way that I see the most fit.
The alternative to this implementation would be to add a new boolean property, something like "shadow_enabled" - this would break compatibility even more than my implementation because all old styleboxes with shadows created prior to this version would have their shadows disabled due to a default value of `false`

What I opted to do was change the behavior of `shadow_size`
The previous behavior had a value of `0` disable shadows.
The new behavior has a value of `-1` disable shadows. A value of `0` now disables the feathering on the shadows and leaves them completely rigid.

This breaks compatibility but it should not effect pre-existing projects *unless they are setting this value through code*. To my knowledge, default values are not saved into the PackedScene and the value of `0` is the default value. Now, when changed to this version, the default value will instead become `-1` due to not having any default value previously saved. Therefore, all editor-saved scenes will maintain their correct shadow displays when upgraded.

This PR is a simple change that is good for stylized UI

With this PR:
Shadow size of 0, now allows unblurred shadows instead of "0 = disabled"
![image](https://github.com/user-attachments/assets/3e5f3394-64dc-48ae-9e64-3e904c65673a)
Shadow size of 1, works as it previously did
![image](https://github.com/user-attachments/assets/f990cdfa-f15a-4bad-8174-f53cb9e25832)
