### PR TITLE
OpenXR: change bindings to 'flatten' source paths

### DIFF
--- a/modules/openxr/action_map/openxr_action_map.cpp
+++ b/modules/openxr/action_map/openxr_action_map.cpp
@@ -576,20 +576,15 @@ PackedStringArray OpenXRActionMap::get_top_level_paths(const Ref<OpenXRAction> p
 		const OpenXRInteractionProfileMetadata::InteractionProfile *profile = OpenXRInteractionProfileMetadata::get_singleton()->get_profile(ip->get_interaction_profile_path());
 
 		if (profile != nullptr) {
-			for (int j = 0; j < ip->get_binding_count(); j++) {
-				Ref<OpenXRIPBinding> binding = ip->get_binding(j);
-				if (binding->get_action() == p_action) {
-					PackedStringArray paths = binding->get_paths();
+			Vector<Ref<OpenXRIPBinding>> bindings = ip->get_bindings_for_action(p_action);
+			for (const Ref<OpenXRIPBinding> &binding : bindings) {
+				String binding_path = binding->get_binding_path();
+				const OpenXRInteractionProfileMetadata::IOPath *io_path = profile->get_io_path(binding_path);
+				if (io_path != nullptr) {
+					String top_path = io_path->top_level_path;
 
-					for (int k = 0; k < paths.size(); k++) {
-						const OpenXRInteractionProfileMetadata::IOPath *io_path = profile->get_io_path(paths[k]);
-						if (io_path != nullptr) {
-							String top_path = io_path->top_level_path;
-
-							if (!arr.has(top_path)) {
-								arr.push_back(top_path);
-							}
-						}
+					if (!arr.has(top_path)) {
+						arr.push_back(top_path);
 					}
 				}
 			}

--- a/modules/openxr/action_map/openxr_interaction_profile.h
+++ b/modules/openxr/action_map/openxr_interaction_profile.h
@@ -41,26 +41,29 @@ class OpenXRIPBinding : public Resource {
 
 private:
 	Ref<OpenXRAction> action;
-	PackedStringArray paths;
+	String binding_path;
 
 protected:
 	static void _bind_methods();
 
 public:
-	static Ref<OpenXRIPBinding> new_binding(const Ref<OpenXRAction> p_action, const char *p_paths); // Helper function for adding a new binding
+	static Ref<OpenXRIPBinding> new_binding(const Ref<OpenXRAction> p_action, const String &p_binding_path); // Helper function for adding a new binding.
 
-	void set_action(const Ref<OpenXRAction> p_action); // Set the action for this binding
-	Ref<OpenXRAction> get_action() const; // Get the action for this binding
+	void set_action(const Ref<OpenXRAction> p_action); // Set the action for this binding.
+	Ref<OpenXRAction> get_action() const; // Get the action for this binding.
 
-	int get_path_count() const; // Get the number of io paths
-	void set_paths(const PackedStringArray p_paths); // Set our paths (for loading from resource)
-	PackedStringArray get_paths() const; // Get our paths (for saving to resource)
+	void set_binding_path(const String &path);
+	String get_binding_path() const;
 
-	void parse_paths(const String p_paths); // Parse a comma separated string of io paths.
-
-	bool has_path(const String p_path) const; // Has this io path
-	void add_path(const String p_path); // Add an io path
-	void remove_path(const String p_path); // Remove an io path
+	// Deprecated.
+#ifndef DISABLE_DEPRECATED
+	void set_paths(const PackedStringArray p_paths); // Set our paths (for loading from resource), needed for loading old action maps.
+	PackedStringArray get_paths() const; // Get our paths (for saving to resource), needed for converted old action maps.
+	int get_path_count() const; // Get the number of io paths.
+	bool has_path(const String p_path) const; // Has this io path.
+	void add_path(const String p_path); // Add an io path.
+	void remove_path(const String p_path); // Remove an io path.
+#endif // DISABLE_DEPRECATED
 
 	// TODO add validation that we can display in the interface that checks if no two paths belong to the same top level path
 
@@ -88,11 +91,12 @@ public:
 	void set_bindings(Array p_bindings); // Set the bindings (for loading from a resource)
 	Array get_bindings() const; // Get the bindings (for saving to a resource)
 
-	Ref<OpenXRIPBinding> get_binding_for_action(const Ref<OpenXRAction> p_action) const; // Get our binding record for a given action
+	Ref<OpenXRIPBinding> find_binding(const Ref<OpenXRAction> p_action, const String &p_binding_path) const; // Get our binding record
+	Vector<Ref<OpenXRIPBinding>> get_bindings_for_action(const Ref<OpenXRAction> p_action) const; // Get our binding record for a given action
 	void add_binding(Ref<OpenXRIPBinding> p_binding); // Add a binding object
 	void remove_binding(Ref<OpenXRIPBinding> p_binding); // Remove a binding object
 
-	void add_new_binding(const Ref<OpenXRAction> p_action, const char *p_paths); // Create a new binding for this profile
+	void add_new_binding(const Ref<OpenXRAction> p_action, const String &p_paths); // Create a new binding for this profile
 	void remove_binding_for_action(const Ref<OpenXRAction> p_action); // Remove all bindings for this action
 	bool has_binding_for_action(const Ref<OpenXRAction> p_action); // Returns true if we have a binding for this action
 

--- a/modules/openxr/doc_classes/OpenXRIPBinding.xml
+++ b/modules/openxr/doc_classes/OpenXRIPBinding.xml
@@ -4,32 +4,32 @@
 		Defines a binding between an [OpenXRAction] and an XR input or output.
 	</brief_description>
 	<description>
-		This binding resource binds an [OpenXRAction] to inputs or outputs. As most controllers have left hand and right versions that are handled by the same interaction profile we can specify multiple bindings. For instance an action "Fire" could be bound to both "/user/hand/left/input/trigger" and "/user/hand/right/input/trigger".
+		This binding resource binds an [OpenXRAction] to an input or output. As most controllers have left hand and right versions that are handled by the same interaction profile we can specify multiple bindings. For instance an action "Fire" could be bound to both "/user/hand/left/input/trigger" and "/user/hand/right/input/trigger". This would require two binding entries.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="add_path">
+		<method name="add_path" deprecated="Binding is for a single path.">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
 			<description>
 				Add an input/output path to this binding.
 			</description>
 		</method>
-		<method name="get_path_count" qualifiers="const">
+		<method name="get_path_count" qualifiers="const" deprecated="Binding is for a single path.">
 			<return type="int" />
 			<description>
 				Get the number of input/output paths in this binding.
 			</description>
 		</method>
-		<method name="has_path" qualifiers="const">
+		<method name="has_path" qualifiers="const" deprecated="Binding is for a single path.">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
 			<description>
 				Returns [code]true[/code] if this input/output path is part of this binding.
 			</description>
 		</method>
-		<method name="remove_path">
+		<method name="remove_path" deprecated="Binding is for a single path.">
 			<return type="void" />
 			<param index="0" name="path" type="String" />
 			<description>
@@ -39,9 +39,13 @@
 	</methods>
 	<members>
 		<member name="action" type="OpenXRAction" setter="set_action" getter="get_action">
-			[OpenXRAction] that is bound to these paths.
+			[OpenXRAction] that is bound to [member binding_path].
 		</member>
-		<member name="paths" type="PackedStringArray" setter="set_paths" getter="get_paths" default="PackedStringArray()">
+		<member name="binding_path" type="String" setter="set_binding_path" getter="get_binding_path" default="&quot;&quot;">
+			Binding path that defines the input or output bound to [member action].
+			[b]Note:[/b] Binding paths are suggestions, an XR runtime may choose to bind the action to a different input or output emulating this input or output.
+		</member>
+		<member name="paths" type="PackedStringArray" setter="set_paths" getter="get_paths" deprecated="Use [member binding_path] instead.">
 			Paths that define the inputs or outputs bound on the device.
 		</member>
 	</members>

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -300,10 +300,7 @@ void OpenXRInterface::_load_action_map() {
 						continue;
 					}
 
-					PackedStringArray paths = xr_binding->get_paths();
-					for (int k = 0; k < paths.size(); k++) {
-						openxr_api->interaction_profile_add_binding(ip, action->action_rid, paths[k]);
-					}
+					openxr_api->interaction_profile_add_binding(ip, action->action_rid, xr_binding->get_binding_path());
 				}
 
 				// Now submit our suggestions


### PR DESCRIPTION
Our OpenXR action map currently stores multiple input/output paths (now called source paths) per action in an interaction profile.

This causes an issue with upcoming binding modifiers (see #97140).

This PR will "flatten" this structure so one binding records a single binding between an action and a source path. 
If multiple paths should be bound, multiple binding entries are needed.

This is technically a breaking change in that the action map will be altered in such a way that it can't be loaded by older versions of Godot, but it is required to implement future modifiers.

*Contributed by Khronos Group through the Godot Integration Project*
