### PR TITLE
Fix websocket dropping messages for WSLPeer

### DIFF
--- a/modules/websocket/packet_buffer.h
+++ b/modules/websocket/packet_buffer.h
@@ -104,6 +104,10 @@ public:
 		return _queued;
 	}
 
+	int space_left() const {
+		return _payload.space_left();
+	}
+
 	void clear() {
 		_payload.resize(0);
 		_packets.resize(0);

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -564,9 +564,14 @@ Error WSLPeer::connect_to_url(const String &p_url, Ref<TLSOptions> p_options) {
 ssize_t WSLPeer::_wsl_recv_callback(wslay_event_context_ptr ctx, uint8_t *data, size_t len, int flags, void *user_data) {
 	WSLPeer *peer = (WSLPeer *)user_data;
 	Ref<StreamPeer> conn = peer->connection;
+
 	if (conn.is_null()) {
 		wslay_event_set_error(ctx, WSLAY_ERR_CALLBACK_FAILURE);
 		return -1;
+	}
+	uint64_t space_left = peer->in_buffer.space_left();
+	if (space_left < peer->length_needed) {
+		return WSLAY_ERR_NOMEM;
 	}
 	int read = 0;
 	Error err = conn->get_partial_data(data, len, read);
@@ -580,6 +585,17 @@ ssize_t WSLPeer::_wsl_recv_callback(wslay_event_context_ptr ctx, uint8_t *data, 
 		return -1;
 	}
 	return read;
+}
+
+void WSLPeer::_wsl_on_frame_start_callback(wslay_event_context_ptr ctx, const wslay_event_on_frame_recv_start_arg *arg, void *user_data) {
+	WSLPeer *peer = (WSLPeer *)user_data;
+	Ref<StreamPeer> conn = peer->connection;
+	if (arg->opcode == WSLAY_TEXT_FRAME || arg->opcode == WSLAY_BINARY_FRAME) {
+		uint64_t space_left = peer->in_buffer.space_left();
+		if (space_left < arg->payload_length) {
+			peer->length_needed = arg->payload_length;
+		}
+	}
 }
 
 ssize_t WSLPeer::_wsl_send_callback(wslay_event_context_ptr ctx, const uint8_t *data, size_t len, int flags, void *user_data) {
@@ -643,7 +659,7 @@ wslay_event_callbacks WSLPeer::_wsl_callbacks = {
 	_wsl_recv_callback,
 	_wsl_send_callback,
 	_wsl_genmask_callback,
-	nullptr, /* on_frame_recv_start_callback */
+	_wsl_on_frame_start_callback, /* on_frame_recv_start_callback */
 	nullptr, /* on_frame_recv_callback */
 	nullptr, /* on_frame_recv_end_callback */
 	_wsl_msg_recv_callback

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -53,6 +53,7 @@ private:
 
 	// Callbacks.
 	static ssize_t _wsl_recv_callback(wslay_event_context_ptr ctx, uint8_t *data, size_t len, int flags, void *user_data);
+	static void _wsl_on_frame_start_callback(wslay_event_context_ptr ctx, const struct wslay_event_on_frame_recv_start_arg *arg, void *user_data);
 	static ssize_t _wsl_send_callback(wslay_event_context_ptr ctx, const uint8_t *data, size_t len, int flags, void *user_data);
 	static int _wsl_genmask_callback(wslay_event_context_ptr ctx, uint8_t *buf, size_t len, void *user_data);
 	static void _wsl_msg_recv_callback(wslay_event_context_ptr ctx, const struct wslay_event_on_msg_recv_arg *arg, void *user_data);
@@ -120,6 +121,8 @@ private:
 	void _clear();
 
 public:
+	uint64_t length_needed = 0;
+
 	static void initialize();
 	static void deinitialize();
 


### PR DESCRIPTION
Supercedes #98128
Fixes #70738

# Address WSLPeer dropping messages

Currently the behavior of wsl_peer allows messages that would be able to fit into the in_buffer to be dropped completely while being received.

To address this issue the method  `WSLPeer::_wsl_on_frame_start_callback` has been implemented as a callback from wslay. It is used to grab the size of the incoming message and use that size within `WSLPeer::_wsl_recv_callback` to refuse incoming packets for that message until space is available to hold the entire message.

>[Note] Within the current implementation the words 'Payload' and 'Message' are used interchangeably. Godot refers to them as messages and wslay refers to them as payloads.


## on_frame_recv_start_callback
This callback function is called with an argument that includes the incoming payload length. Using this length we can compare it to the free space currently in the in_buffer. This gives us the ability to wait on receiving the message untill enough space is available in the in_buffer to receive it.
```cpp
void WSLPeer::_wsl_on_frame_start_callback(wslay_event_context_ptr ctx, const wslay_event_on_frame_recv_start_arg *arg, void *user_data) {
	WSLPeer *peer = (WSLPeer *)user_data;
	Ref<StreamPeer> conn = peer->connection;
	if (arg->opcode == WSLAY_TEXT_FRAME || arg->opcode == WSLAY_BINARY_FRAME) {
		uint64_t space_left = peer->in_buffer.space_left();
		if (space_left < arg->payload_length) {
			peer->length_needed = arg->payload_length;
		}
	}
}
```

## uint64_t length_needed = 0;
This public member variable was introduced to store the size of the incoming message and is used when telling wslay to start accepting packets for the message.


## WSLPeer::_wsl_recv_callback
Using the `length_needed` variable defined by the `on_frame_recv_start_callback` we are able to check if the current space available is sufficient to accept the incoming message. If it's not we continue waiting until enough space has opened up.
```cpp
uint64_t space_left = peer->in_buffer.space_left();
if (space_left < peer->length_needed) {
	return WSLAY_ERR_NOMEM;
}
```

## space_left function
This function was added to the `PacketBuffer` class to allow callback functions in `wsl_peer.cpp` to get the current freespace in the in_buffer.
```cpp
int space_left() const {
	return _payload.space_left();
}
```

@RadenTheFolf

---
**This PR is generously donated by [Redot](https://redotengine.org/).**