### PR TITLE
Document safety with `ResourceLoader` and `ConfigFile` when loading potentially untrusted files

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1357,6 +1357,7 @@
 				GD.Print(dict["a"]);                              // Prints 1
 				[/csharp]
 				[/codeblocks]
+				[b]Warning:[/b] Using this function on untrusted Strings can allow remote code execution. Use with caution.
 			</description>
 		</method>
 		<method name="tan">

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -164,15 +164,16 @@
 			<description>
 				Loads the config file specified as a parameter. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
-				[b]Warning:[/b] Loading Data from a Config File may allow for remote code execution. This is non-trivial to midigate, but storing a [readme] file in the same directory can warn users against downloading untrusted configurations:
+				[b]Warning:[/b] Loading Data from a Config File may allow for remote code execution. This is non-trivial to midigate, but storing a [code]readme[/code] file in the same directory can warn users against downloading untrusted configurations:
 				[codeblocks]
 				[gdscript]
 				var config_path = "user://"
 				var config_file_name = "my_game.config"
-				# check if configuration has been initialized:
+				# Check if configuration has been initialized:
 				if not FileAccess.file_exists("%s%s" % [config_path, config_file_name]):
-					var readme := FileAccess.open("%s%s" % [config_path, "README.txt"], FileAccess.WRITE)
-					readme.store_string("Caution: It is not advised to use Config-files you find online, as malicious files may compromise your device. ")
+				    var readme = FileAccess.open("%s%s" % [config_path, "README.txt"], FileAccess.WRITE)
+				    readme.store_string("Caution: It is not advised to use Config-files you find online, as malicious files may compromise your device.")
+				    readme.close()
 				[/gdscript]
 				[/codeblocks]
 			</description>

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -164,7 +164,7 @@
 			<description>
 				Loads the config file specified as a parameter. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
-				[b]Warning:[/b] Loading Data from a Config File may allow for remote code execution. This is non-trivial to midigate, but storing a [code]readme[/code] file in the same directory can warn users against downloading untrusted configurations:
+				[b]Warning:[/b] Loading data from a config fie may allow for remote code execution. This is non-trivial to mitigate, but storing a [code]readme[/code] file in the same directory can warn users against downloading untrusted configurations:
 				[codeblocks]
 				[gdscript]
 				var config_path = "user://"
@@ -172,7 +172,7 @@
 				# Check if configuration has been initialized:
 				if not FileAccess.file_exists("%s%s" % [config_path, config_file_name]):
 				    var readme = FileAccess.open("%s%s" % [config_path, "README.txt"], FileAccess.WRITE)
-				    readme.store_string("Caution: It is not advised to use Config-files you find online, as malicious files may compromise your device.")
+				    readme.store_string("Caution: It is not advised to use config files you find online, as malicious files may compromise your device.")
 				    readme.close()
 				[/gdscript]
 				[/codeblocks]

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -164,7 +164,7 @@
 			<description>
 				Loads the config file specified as a parameter. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
-				[b]Warning:[/b] Loading data from a config fie may allow for remote code execution. This is non-trivial to mitigate, but storing a [code]readme[/code] file in the same directory can warn users against downloading untrusted configurations:
+				[b]Warning:[/b] Loading data from a config file may allow for remote code execution. This is non-trivial to mitigate, but storing a [code]readme[/code] file in the same directory can warn users against downloading untrusted configurations:
 				[codeblocks]
 				[gdscript]
 				var config_path = "user://"

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -164,6 +164,17 @@
 			<description>
 				Loads the config file specified as a parameter. The file's contents are parsed and loaded in the [ConfigFile] object which the method was called on.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
+				[b]Warning:[/b] Loading Data from a Config File may allow for remote code execution. This is non-trivial to midigate, but storing a [readme] file in the same directory can warn users against downloading untrusted configurations:
+				[codeblocks]
+				[gdscript]
+				var config_path = "user://"
+				var config_file_name = "my_game.config"
+				# check if configuration has been initialized:
+				if not FileAccess.file_exists("%s%s" % [config_path, config_file_name]):
+					var readme := FileAccess.open("%s%s" % [config_path, "README.txt"], FileAccess.WRITE)
+					readme.store_string("Caution: It is not advised to use Config-files you find online, as malicious files may compromise your device. ")
+				[/gdscript]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="load_encrypted">

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -87,7 +87,7 @@
 				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
 				Returns an empty resource if no [ResourceFormatLoader] could handle the file, and prints an error if no file is found at the specified path.
 				GDScript has a simplified [method @GDScript.load] built-in method which can be used in most situations, leaving the use of [ResourceLoader] for more advanced scenarios.
-				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. See the [url=$DOCS_URL/tutorials/io/saving_games.html] "Saving Games" tutorial[/url] for more info.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. See the [url=$DOCS_URL/tutorials/io/saving_games.html]"Saving Games" tutorial[/url] for more info.
 				[b]Note:[/b] If [member ProjectSettings.editor/export/convert_text_resources_to_binary] is [code]true[/code], [method @GDScript.load] will not be able to read converted files in an exported project. If you rely on run-time loading of files present within the PCK, set [member ProjectSettings.editor/export/convert_text_resources_to_binary] to [code]false[/code].
 				[b]Note:[/b] Relative paths will be prefixed with [code]"res://"[/code] before loading, to avoid unexpected results make sure your paths are absolute.
 			</description>
@@ -107,7 +107,7 @@
 			<description>
 				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path]. See [enum ThreadLoadStatus] for possible return values.
 				An array variable can optionally be passed via [param progress], and will return a one-element array containing the percentage of completion of the threaded loading.
-				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted.  See the [url=$DOCS_URL/tutorials/io/saving_games.html] "Saving Games" tutorial[/url] for more info.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. See the [url=$DOCS_URL/tutorials/io/saving_games.html]"Saving Games" tutorial[/url] for more info.
 				[b]Note:[/b] The recommended way of using this method is to call it during different frames (e.g., in [method Node._process], instead of a loop).
 			</description>
 		</method>
@@ -120,7 +120,7 @@
 			<description>
 				Loads the resource using threads. If [param use_sub_threads] is [code]true[/code], multiple threads will be used to load the resource, which makes loading faster, but may affect the main thread (and thus cause game slowdowns).
 				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
-				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted.  See the [url=$DOCS_URL/tutorials/io/saving_games.html] "Saving Games" tutorial[/url] for more info.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. See the [url=$DOCS_URL/tutorials/io/saving_games.html]"Saving Games" tutorial[/url] for more info.
 			</description>
 		</method>
 		<method name="remove_resource_format_loader">

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -6,11 +6,11 @@
 	<description>
 		A singleton used to load resource files from the filesystem.
 		It uses the many [ResourceFormatLoader] classes registered in the engine (either built-in or from a plugin) to load files into memory and convert them to a format that can be used by the engine.
-		[b]See also:[/b] If you want to load player data, look at <link title="Saving Games">$DOCS_URL/tutorials/io/saving_games.html</link> instead for information on saving and loading game progression.
 		[b]Note:[/b] You have to import the files into the engine first to load them using [method load]. If you want to load [Image]s at run-time, you may use [method Image.load]. If you want to import audio files, you can use the snippet described in [member AudioStreamMP3.data].
 	</description>
 	<tutorials>
 		<link title="Operating System Testing Demo">https://godotengine.org/asset-library/asset/2789</link>
+		<link title="See also: Saving Games for safely loading player data">$DOCS_URL/tutorials/io/saving_games.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_resource_format_loader">

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -87,7 +87,7 @@
 				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
 				Returns an empty resource if no [ResourceFormatLoader] could handle the file, and prints an error if no file is found at the specified path.
 				GDScript has a simplified [method @GDScript.load] built-in method which can be used in most situations, leaving the use of [ResourceLoader] for more advanced scenarios.
-				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. Read the "Saving Games" tutorial for further guidance.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. See the [url=$DOCS_URL/tutorials/io/saving_games.html] "Saving Games" tutorial[/url] for more info.
 				[b]Note:[/b] If [member ProjectSettings.editor/export/convert_text_resources_to_binary] is [code]true[/code], [method @GDScript.load] will not be able to read converted files in an exported project. If you rely on run-time loading of files present within the PCK, set [member ProjectSettings.editor/export/convert_text_resources_to_binary] to [code]false[/code].
 				[b]Note:[/b] Relative paths will be prefixed with [code]"res://"[/code] before loading, to avoid unexpected results make sure your paths are absolute.
 			</description>
@@ -107,7 +107,7 @@
 			<description>
 				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path]. See [enum ThreadLoadStatus] for possible return values.
 				An array variable can optionally be passed via [param progress], and will return a one-element array containing the percentage of completion of the threaded loading.
-				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. Read the "Saving Games" tutorial for further guidance.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted.  See the [url=$DOCS_URL/tutorials/io/saving_games.html] "Saving Games" tutorial[/url] for more info.
 				[b]Note:[/b] The recommended way of using this method is to call it during different frames (e.g., in [method Node._process], instead of a loop).
 			</description>
 		</method>
@@ -120,7 +120,7 @@
 			<description>
 				Loads the resource using threads. If [param use_sub_threads] is [code]true[/code], multiple threads will be used to load the resource, which makes loading faster, but may affect the main thread (and thus cause game slowdowns).
 				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
-				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. Read the "Saving Games" tutorial for further guidance.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted.  See the [url=$DOCS_URL/tutorials/io/saving_games.html] "Saving Games" tutorial[/url] for more info.
 			</description>
 		</method>
 		<method name="remove_resource_format_loader">

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -6,6 +6,7 @@
 	<description>
 		A singleton used to load resource files from the filesystem.
 		It uses the many [ResourceFormatLoader] classes registered in the engine (either built-in or from a plugin) to load files into memory and convert them to a format that can be used by the engine.
+		[b]See also:[/b] If you want to load player data, look at <link title="Saving Games">$DOCS_URL/tutorials/io/saving_games.html</link> instead for information on saving and loading game progression.
 		[b]Note:[/b] You have to import the files into the engine first to load them using [method load]. If you want to load [Image]s at run-time, you may use [method Image.load]. If you want to import audio files, you can use the snippet described in [member AudioStreamMP3.data].
 	</description>
 	<tutorials>
@@ -86,6 +87,7 @@
 				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
 				Returns an empty resource if no [ResourceFormatLoader] could handle the file, and prints an error if no file is found at the specified path.
 				GDScript has a simplified [method @GDScript.load] built-in method which can be used in most situations, leaving the use of [ResourceLoader] for more advanced scenarios.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. Read the "Saving Games" tutorial for further guidance.
 				[b]Note:[/b] If [member ProjectSettings.editor/export/convert_text_resources_to_binary] is [code]true[/code], [method @GDScript.load] will not be able to read converted files in an exported project. If you rely on run-time loading of files present within the PCK, set [member ProjectSettings.editor/export/convert_text_resources_to_binary] to [code]false[/code].
 				[b]Note:[/b] Relative paths will be prefixed with [code]"res://"[/code] before loading, to avoid unexpected results make sure your paths are absolute.
 			</description>
@@ -105,6 +107,7 @@
 			<description>
 				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path]. See [enum ThreadLoadStatus] for possible return values.
 				An array variable can optionally be passed via [param progress], and will return a one-element array containing the percentage of completion of the threaded loading.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. Read the "Saving Games" tutorial for further guidance.
 				[b]Note:[/b] The recommended way of using this method is to call it during different frames (e.g., in [method Node._process], instead of a loop).
 			</description>
 		</method>
@@ -117,6 +120,7 @@
 			<description>
 				Loads the resource using threads. If [param use_sub_threads] is [code]true[/code], multiple threads will be used to load the resource, which makes loading faster, but may affect the main thread (and thus cause game slowdowns).
 				The [param cache_mode] property defines whether and how the cache should be used or updated when loading the resource. See [enum CacheMode] for details.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. Read the "Saving Games" tutorial for further guidance.
 			</description>
 		</method>
 		<method name="remove_resource_format_loader">

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -170,7 +170,7 @@
 				[/codeblock]
 				[b]Important:[/b] Relative paths are [i]not[/i] relative to the script calling this method, instead it is prefixed with [code]"res://"[/code]. Loading from relative paths might not work as expected.
 				This function is a simplified version of [method ResourceLoader.load], which can be used for more advanced scenarios.
-				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. [b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. Read the "Saving Games" tutorial for further guidance.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted.  See the [url=$DOCS_URL/tutorials/io/saving_games.html] "Saving Games" tutorial[/url] for more info.
 				[b]Note:[/b] Files have to be imported into the engine first to load them using this function. If you want to load [Image]s at run-time, you may use [method Image.load]. If you want to import audio files, you can use the snippet described in [member AudioStreamMP3.data].
 				[b]Note:[/b] If [member ProjectSettings.editor/export/convert_text_resources_to_binary] is [code]true[/code], [method @GDScript.load] will not be able to read converted files in an exported project. If you rely on run-time loading of files present within the PCK, set [member ProjectSettings.editor/export/convert_text_resources_to_binary] to [code]false[/code].
 			</description>

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -170,6 +170,7 @@
 				[/codeblock]
 				[b]Important:[/b] Relative paths are [i]not[/i] relative to the script calling this method, instead it is prefixed with [code]"res://"[/code]. Loading from relative paths might not work as expected.
 				This function is a simplified version of [method ResourceLoader.load], which can be used for more advanced scenarios.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. [b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. Read the "Saving Games" tutorial for further guidance.
 				[b]Note:[/b] Files have to be imported into the engine first to load them using this function. If you want to load [Image]s at run-time, you may use [method Image.load]. If you want to import audio files, you can use the snippet described in [member AudioStreamMP3.data].
 				[b]Note:[/b] If [member ProjectSettings.editor/export/convert_text_resources_to_binary] is [code]true[/code], [method @GDScript.load] will not be able to read converted files in an exported project. If you rely on run-time loading of files present within the PCK, set [member ProjectSettings.editor/export/convert_text_resources_to_binary] to [code]false[/code].
 			</description>

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -170,7 +170,7 @@
 				[/codeblock]
 				[b]Important:[/b] Relative paths are [i]not[/i] relative to the script calling this method, instead it is prefixed with [code]"res://"[/code]. Loading from relative paths might not work as expected.
 				This function is a simplified version of [method ResourceLoader.load], which can be used for more advanced scenarios.
-				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted.  See the [url=$DOCS_URL/tutorials/io/saving_games.html] "Saving Games" tutorial[/url] for more info.
+				[b]Warning:[/b] Do not use this for save files, as it may lead to remote code execution when users share saves. You should only use this to load files that you know are trusted. See the [url=$DOCS_URL/tutorials/io/saving_games.html]"Saving Games" tutorial[/url] for more info.
 				[b]Note:[/b] Files have to be imported into the engine first to load them using this function. If you want to load [Image]s at run-time, you may use [method Image.load]. If you want to import audio files, you can use the snippet described in [member AudioStreamMP3.data].
 				[b]Note:[/b] If [member ProjectSettings.editor/export/convert_text_resources_to_binary] is [code]true[/code], [method @GDScript.load] will not be able to read converted files in an exported project. If you rely on run-time loading of files present within the PCK, set [member ProjectSettings.editor/export/convert_text_resources_to_binary] to [code]false[/code].
 			</description>


### PR DESCRIPTION
This issue is already mentioned in the wiki when you look up the comments under the [saving games](https://docs.godotengine.org/en/stable/tutorials/io/saving_games.html) tutorial, however I think it is nice to add these safeguards until a proper solution has been implemented.

~~I don't know if pointing users to tutorials in the way I did is common practice in the Godot Docs. After all: the tutorial is strictly speaking kind of unrelated. but I cannot link to to a tutorial in a description because it is a simple field and will raise compile errors.~~ -> was resolved by review