### PR TITLE
Fix Mobile Renderer - Shadow Disabled and User Vertex Lighting flags

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -105,10 +105,6 @@ layout(location = 6) mediump out vec3 binormal_interp;
 layout(location = 7) highp out vec4 diffuse_light_interp;
 layout(location = 8) highp out vec4 specular_light_interp;
 
-layout(constant_id = 9) const bool sc_disable_omni_lights = false;
-layout(constant_id = 10) const bool sc_disable_spot_lights = false;
-layout(constant_id = 12) const bool sc_disable_directional_lights = false;
-
 #include "../scene_forward_vertex_lights_inc.glsl"
 #endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 #ifdef MATERIAL_UNIFORMS_USED
@@ -1606,7 +1602,6 @@ void main() {
 #endif
 #undef BIAS_FUNC
 			}
-#endif
 
 			if (i < 4) {
 				shadow0 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << (i * 8);
@@ -1614,6 +1609,7 @@ void main() {
 				shadow1 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << ((i - 4) * 8);
 			}
 		}
+#endif // SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
 		for (uint i = 0; i < scene_data.directional_light_count; i++) {


### PR DESCRIPTION
Fixes #98102 Forward Mobile Renderer fix. Corrects preprocessor directive, also removes redefinition of method names as parameters which must predate the ubershader work.

To test toggle the two shader flags in Mobile mode and watch the console to confirm no fireworks, visual checks look good:
USE_VERTEX_LIGHTING - uber shader bug
Shadows Disabled - preprocessor order bug

Adjusted both here as the issue crept in under the vertex lighting change and I wanted to confirm no gremlins with the two interacting, was confused when I couldn't switch on the vertex lighting at all.