### PR TITLE
Add note to RayCast3D docs about `_ready()`

### DIFF
--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -8,7 +8,7 @@
 		[RayCast3D] can ignore some objects by adding them to an exception list, by making its detection reporting ignore [Area3D]s ([member collide_with_areas]) or [PhysicsBody3D]s ([member collide_with_bodies]), or by configuring physics layers.
 		[RayCast3D] calculates intersection every physics frame, and it holds the result until the next physics frame. For an immediate raycast, or if you want to configure a [RayCast3D] multiple times within the same physics frame, use [method force_raycast_update].
 		To sweep over a region of 3D space, you can approximate the region with multiple [RayCast3D]s or use [ShapeCast3D].
-		[b]Note:[/b] [RayCast3D] needs at least one physics frame to compute collision data. Therefore, collision data may not be available during the [method Node._ready] function. Calling method force_raycast_update] in [method Node._ready] may not resolve this issue. Instead, perform collision checks in [method Node._physics_process] which runs after the physics engine updates all physics bodies, or use [method Object.call_deferred] to delay the execution of your code.
+		[b]Note:[/b] [RayCast3D] needs at least one physics frame to compute collision data. Therefore, collision data may not be available during the [method Node._ready] function. Calling [method force_raycast_update] in [method Node._ready] may not resolve this issue. Instead, perform collision checks in [method Node._physics_process] which runs after the physics engine updates all physics bodies, or use [method Object.call_deferred] to delay the execution of your code.
 	</description>
 	<tutorials>
 		<link title="Ray-casting">$DOCS_URL/tutorials/physics/ray-casting.html</link>

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -8,6 +8,7 @@
 		[RayCast3D] can ignore some objects by adding them to an exception list, by making its detection reporting ignore [Area3D]s ([member collide_with_areas]) or [PhysicsBody3D]s ([member collide_with_bodies]), or by configuring physics layers.
 		[RayCast3D] calculates intersection every physics frame, and it holds the result until the next physics frame. For an immediate raycast, or if you want to configure a [RayCast3D] multiple times within the same physics frame, use [method force_raycast_update].
 		To sweep over a region of 3D space, you can approximate the region with multiple [RayCast3D]s or use [ShapeCast3D].
+		[b]Note:[/b] [code]RayCast3D[/code] needs at least one physics frame to compute collision data. Therefore, collision data may not be available during the _ready() function. Calling force_raycast_update() in _ready() may not resolve this issue. Instead, perform collision checks in [code]_physics_process()[/code] which runs after the physics engine updates all physics bodies, or use [code]call_deferred()[/code] to delay the execution of your code. 
 	</description>
 	<tutorials>
 		<link title="Ray-casting">$DOCS_URL/tutorials/physics/ray-casting.html</link>

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -8,7 +8,7 @@
 		[RayCast3D] can ignore some objects by adding them to an exception list, by making its detection reporting ignore [Area3D]s ([member collide_with_areas]) or [PhysicsBody3D]s ([member collide_with_bodies]), or by configuring physics layers.
 		[RayCast3D] calculates intersection every physics frame, and it holds the result until the next physics frame. For an immediate raycast, or if you want to configure a [RayCast3D] multiple times within the same physics frame, use [method force_raycast_update].
 		To sweep over a region of 3D space, you can approximate the region with multiple [RayCast3D]s or use [ShapeCast3D].
-		[b]Note:[/b] [code]RayCast3D[/code] needs at least one physics frame to compute collision data. Therefore, collision data may not be available during the _ready() function. Calling force_raycast_update() in _ready() may not resolve this issue. Instead, perform collision checks in [code]_physics_process()[/code] which runs after the physics engine updates all physics bodies, or use [code]call_deferred()[/code] to delay the execution of your code. 
+		[b]Note:[/b] [RayCast3D] needs at least one physics frame to compute collision data. Therefore, collision data may not be available during the [method Node._ready] function. Calling method force_raycast_update] in [method Node._ready] may not resolve this issue. Instead, perform collision checks in [method Node._physics_process] which runs after the physics engine updates all physics bodies, or use [method Object.call_deferred] to delay the execution of your code.
 	</description>
 	<tutorials>
 		<link title="Ray-casting">$DOCS_URL/tutorials/physics/ray-casting.html</link>


### PR DESCRIPTION
Note in RayCast3D docs about why `_ready()` does not work with raycasts.

Addresses the issues [#96025](https://github.com/godotengine/godot/issues/96025) and [#95354](https://github.com/godotengine/godot/issues/95354).
