### PR TITLE
Allow tooltips to show true value

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -40,9 +40,9 @@
 String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {
 	if (!read_only && grabber->is_visible()) {
 		Key key = (OS::get_singleton()->has_feature("macos") || OS::get_singleton()->has_feature("web_macos") || OS::get_singleton()->has_feature("web_ios")) ? Key::META : Key::CTRL;
-		return TS->format_number(rtos(get_value())) + "\n\n" + vformat(TTR("Hold %s to round to integers.\nHold Shift for more precise changes."), find_keycode_name(key));
+		return TS->format_number(rtos(true_value)) + "\n\n" + vformat(TTR("Hold %s to round to integers.\nHold Shift for more precise changes."), find_keycode_name(key));
 	}
-	return TS->format_number(rtos(get_value()));
+	return TS->format_number(rtos(true_value));
 }
 
 String EditorSpinSlider::get_text_value() const {
@@ -142,6 +142,12 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 			accept_event();
 		}
 	}
+}
+
+void EditorSpinSlider::_value_changed_notify() {
+	_value_changed(true_value);
+	emit_signal(SceneStringName(value_changed), true_value);
+	queue_redraw();
 }
 
 void EditorSpinSlider::_grab_start() {
@@ -744,6 +750,24 @@ void EditorSpinSlider::_ensure_input_popup() {
 	if (is_inside_tree()) {
 		_update_value_input_stylebox();
 	}
+}
+
+void EditorSpinSlider::set_value(double p_val) {
+	bool true_value_changed = p_val != true_value;
+	true_value = p_val;
+	Range::set_value(p_val);
+	if (true_value_changed && is_inside_tree()) {
+		_value_changed_notify();
+	}
+}
+
+void EditorSpinSlider::set_value_no_signal(double p_val) {
+	true_value = p_val;
+	Range::set_value_no_signal(p_val);
+}
+
+double EditorSpinSlider::get_value() const {
+	return true_value;
 }
 
 EditorSpinSlider::EditorSpinSlider() {

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -72,6 +72,10 @@ class EditorSpinSlider : public Range {
 	bool flat = false;
 	bool editing_integer = false;
 
+	double true_value = 0.0;
+
+	void _value_changed_notify() override;
+
 	void _grab_start();
 	void _grab_end();
 
@@ -101,6 +105,9 @@ protected:
 	void _focus_entered();
 
 public:
+	void set_value(double p_val) override;
+	void set_value_no_signal(double p_val) override;
+
 	String get_tooltip(const Point2 &p_pos) const override;
 
 	String get_text_value() const;
@@ -128,5 +135,8 @@ public:
 	LineEdit *get_line_edit();
 
 	virtual Size2 get_minimum_size() const override;
+
+	double get_value() const override;
+
 	EditorSpinSlider();
 };

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -57,7 +57,7 @@ class Range : public Control {
 
 	void _share(Node *p_range);
 
-	void _value_changed_notify();
+	virtual void _value_changed_notify();
 	void _changed_notify(const char *p_what = "");
 	void _set_value_no_signal(double p_val);
 
@@ -72,15 +72,15 @@ protected:
 	GDVIRTUAL1(_value_changed, double)
 
 public:
-	void set_value(double p_val);
-	void set_value_no_signal(double p_val);
+	virtual void set_value(double p_val);
+	virtual void set_value_no_signal(double p_val);
 	void set_min(double p_min);
 	void set_max(double p_max);
 	void set_step(double p_step);
 	void set_page(double p_page);
 	void set_as_ratio(double p_value);
 
-	double get_value() const;
+	virtual double get_value() const;
 	double get_min() const;
 	double get_max() const;
 	double get_step() const;


### PR DESCRIPTION
Fix #86371 

https://github.com/user-attachments/assets/1e8b5c24-30d6-4b82-b2fc-0fa6642df82e

Add a new variable to store the true value. When the range is in the editor, the value_changed signal will emit if the true value changed. When the range is in game, the behavior remains the same.

[editorspinslidertooltip.zip](https://github.com/user-attachments/files/17379707/editorspinslidertooltip.zip)


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
