### PR TITLE
Fix `CONTAINER_PROJECT_SETTING_TAB_RIGHT` option of `EditorPlugin`

### DIFF
--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -153,7 +153,6 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 		} break;
 		case CONTAINER_PROJECT_SETTING_TAB_RIGHT: {
 			ProjectSettingsEditor::get_singleton()->get_tabs()->add_child(p_control);
-			ProjectSettingsEditor::get_singleton()->get_tabs()->move_child(p_control, 1);
 
 		} break;
 	}


### PR DESCRIPTION
This fixes incorrect behaviour when using the [`CONTAINER_PROJECT_SETTING_TAB_RIGHT`](https://docs.godotengine.org/en/stable/classes/class_editorplugin.html#enum-editorplugin-customcontrolcontainer) option with [`EditorPlugin.add_control_to_container`](https://docs.godotengine.org/en/stable/classes/class_editorplugin.html#class-editorplugin-method-add-control-to-container).

Example:
``` GDScript
add_control_to_container(CONTAINER_PROJECT_SETTING_TAB_RIGHT, control)
```

Before this PR:
![image](https://github.com/user-attachments/assets/91b6e847-3875-4af8-8769-c74d210954ab)

After this PR:
![image](https://github.com/user-attachments/assets/78ed51a3-a2ad-44af-b0ca-301f64813f52)