### PR TITLE
Improve lambda hotswapping when uniquely named

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1405,14 +1405,15 @@ GDScript::UpdatableFuncPtr::~UpdatableFuncPtr() {
 }
 
 void GDScript::_recurse_replace_function_ptrs(const HashMap<GDScriptFunction *, GDScriptFunction *> &p_replacements) const {
-	MutexLock lock(func_ptrs_to_update_mutex);
-	for (UpdatableFuncPtr *updatable : func_ptrs_to_update) {
-		HashMap<GDScriptFunction *, GDScriptFunction *>::ConstIterator replacement = p_replacements.find(updatable->ptr);
-		if (replacement) {
-			updatable->ptr = replacement->value;
-		} else {
-			// Probably a lambda from another reload, ignore.
-			updatable->ptr = nullptr;
+	{
+		MutexLock lock(func_ptrs_to_update_mutex);
+		for (UpdatableFuncPtr *updatable : func_ptrs_to_update) {
+			HashMap<GDScriptFunction *, GDScriptFunction *>::ConstIterator replacement = p_replacements.find(updatable->ptr);
+			if (replacement) {
+				updatable->ptr = replacement->value;
+			} else {
+				updatable->ptr = nullptr;
+			}
 		}
 	}
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -3197,129 +3197,113 @@ void GDScriptCompiler::make_scripts(GDScript *p_script, const GDScriptParser::Cl
 	}
 }
 
-GDScriptCompiler::FunctionLambdaInfo GDScriptCompiler::_get_function_replacement_info(GDScriptFunction *p_func, int p_index, int p_depth, GDScriptFunction *p_parent_func) {
-	FunctionLambdaInfo info;
-	info.function = p_func;
-	info.parent = p_parent_func;
-	info.script = p_func->get_script();
-	info.name = p_func->get_name();
-	info.line = p_func->_initial_line;
-	info.index = p_index;
-	info.depth = p_depth;
-	info.capture_count = 0;
-	info.use_self = false;
-	info.arg_count = p_func->_argument_count;
-	info.default_arg_count = p_func->_default_arg_count;
-	info.sublambdas = _get_function_lambda_replacement_info(p_func, p_depth, p_parent_func);
-
-	ERR_FAIL_NULL_V(info.script, info);
-	GDScript::LambdaInfo *extra_info = info.script->lambda_info.getptr(p_func);
-	if (extra_info != nullptr) {
-		info.capture_count = extra_info->capture_count;
-		info.use_self = extra_info->use_self;
-	} else {
-		info.capture_count = 0;
-		info.use_self = false;
-	}
-
-	return info;
-}
-
-Vector<GDScriptCompiler::FunctionLambdaInfo> GDScriptCompiler::_get_function_lambda_replacement_info(GDScriptFunction *p_func, int p_depth, GDScriptFunction *p_parent_func) {
-	Vector<FunctionLambdaInfo> result;
-	// Only scrape the lambdas inside p_func.
+void GDScriptCompiler::LambdaSourceInfoList::collect_function_lambda_replacement_info(GDScriptFunction *p_func) {
+	// Only collect the lambdas inside.
 	for (int i = 0; i < p_func->lambdas.size(); ++i) {
-		result.push_back(_get_function_replacement_info(p_func->lambdas[i], i, p_depth + 1, p_func));
+		GDScriptFunction *lambda = p_func->lambdas[i];
+		LambdaSourceInfo &info = infos[lambda->get_name()].push_back({})->get();
+
+		info.function = lambda;
+		info.parent = p_func;
+		info.script = lambda->get_script();
+		info.name = lambda->get_name();
+		info.is_static = lambda->is_static();
+		info.use_self = false;
+		info.capture_count = 0;
+		info.arg_count = lambda->get_argument_count();
+		info.default_arg_count = lambda->get_default_argument_count();
+		info.sublambdas.collect_function_lambda_replacement_info(lambda);
+
+		if (info.script) {
+			GDScript::LambdaInfo *extra_info = info.script->lambda_info.getptr(lambda);
+			if (extra_info != nullptr) {
+				info.capture_count = extra_info->capture_count;
+				info.use_self = extra_info->use_self;
+			} else {
+				info.capture_count = 0;
+				info.use_self = false;
+			}
+		}
 	}
-	return result;
 }
 
-GDScriptCompiler::ScriptLambdaInfo GDScriptCompiler::_get_script_lambda_replacement_info(GDScript *p_script) {
-	ScriptLambdaInfo info;
-
+void GDScriptCompiler::ScriptLambdaInfo::collect_script_lambda_replacement_info(GDScript *p_script) {
 	if (p_script->implicit_initializer) {
-		info.implicit_initializer_info = _get_function_lambda_replacement_info(p_script->implicit_initializer);
+		initializers.collect_function_lambda_replacement_info(p_script->implicit_initializer);
 	}
 	if (p_script->implicit_ready) {
-		info.implicit_ready_info = _get_function_lambda_replacement_info(p_script->implicit_ready);
+		initializers.collect_function_lambda_replacement_info(p_script->implicit_ready);
 	}
 	if (p_script->static_initializer) {
-		info.static_initializer_info = _get_function_lambda_replacement_info(p_script->static_initializer);
+		initializers.collect_function_lambda_replacement_info(p_script->static_initializer);
 	}
 
 	for (const KeyValue<StringName, GDScriptFunction *> &E : p_script->member_functions) {
-		info.member_function_infos.insert(E.key, _get_function_lambda_replacement_info(E.value));
+		member_functions[E.key].collect_function_lambda_replacement_info(E.value);
 	}
 
 	for (const KeyValue<StringName, Ref<GDScript>> &KV : p_script->get_subclasses()) {
-		info.subclass_info.insert(KV.key, _get_script_lambda_replacement_info(KV.value.ptr()));
+		subclasses[KV.key].collect_script_lambda_replacement_info(KV.value.ptr());
 	}
-
-	return info;
 }
 
-bool GDScriptCompiler::_do_function_infos_match(const FunctionLambdaInfo &p_old_info, const FunctionLambdaInfo *p_new_info) {
-	if (p_new_info == nullptr) {
+bool GDScriptCompiler::LambdaSourceInfo::can_be_replaced_by(const LambdaSourceInfo &p_new_info) const {
+	if (p_new_info.capture_count != capture_count || p_new_info.use_self != use_self) {
 		return false;
 	}
 
-	if (p_new_info->capture_count != p_old_info.capture_count || p_new_info->use_self != p_old_info.use_self) {
+	if (p_new_info.script != script) {
 		return false;
 	}
 
-	int old_required_arg_count = p_old_info.arg_count - p_old_info.default_arg_count;
-	int new_required_arg_count = p_new_info->arg_count - p_new_info->default_arg_count;
-	if (new_required_arg_count > old_required_arg_count || p_new_info->arg_count < old_required_arg_count) {
+	int old_required_arg_count = arg_count - default_arg_count;
+	int new_required_arg_count = p_new_info.arg_count - p_new_info.default_arg_count;
+	if (new_required_arg_count > old_required_arg_count || p_new_info.arg_count < old_required_arg_count) {
 		return false;
 	}
 
 	return true;
 }
 
-void GDScriptCompiler::_get_function_ptr_replacements(HashMap<GDScriptFunction *, GDScriptFunction *> &r_replacements, const FunctionLambdaInfo &p_old_info, const FunctionLambdaInfo *p_new_info) {
-	ERR_FAIL_COND(r_replacements.has(p_old_info.function));
-	if (!_do_function_infos_match(p_old_info, p_new_info)) {
-		p_new_info = nullptr;
-	}
+void GDScriptCompiler::_collect_function_ptr_replacements(HashMap<GDScriptFunction *, GDScriptFunction *> &r_replacements, LambdaSourceInfoList &p_old, LambdaSourceInfoList *p_new) {
+	for (KeyValue<StringName, List<LambdaSourceInfo>> &old_named_infos : p_old.infos) {
+		HashMap<StringName, List<LambdaSourceInfo>>::Iterator new_named_infos_it = p_new->infos.find(old_named_infos.key);
+		bool sizes_equal = new_named_infos_it && new_named_infos_it->value.size() == old_named_infos.value.size();
 
-	r_replacements.insert(p_old_info.function, p_new_info != nullptr ? p_new_info->function : nullptr);
-	_get_function_ptr_replacements(r_replacements, p_old_info.sublambdas, p_new_info != nullptr ? &p_new_info->sublambdas : nullptr);
+		List<LambdaSourceInfo>::Element *old_info_E = old_named_infos.value.front();
+		List<LambdaSourceInfo>::Element *new_info_E = new_named_infos_it ? new_named_infos_it->value.front() : nullptr;
+
+		while (old_info_E) {
+			LambdaSourceInfo &old_info = old_info_E->get();
+			LambdaSourceInfo *new_info = nullptr;
+			if (new_info_E && sizes_equal) {
+				new_info = &new_info_E->get();
+			}
+
+			if (new_info && old_info.can_be_replaced_by(*new_info)) {
+				r_replacements[old_info.function] = new_info->function;
+			}
+
+			// This must be run on every `old_info.sublambdas` whether or not we have new info.
+			_collect_function_ptr_replacements(r_replacements, old_info.sublambdas, new_info ? &new_info->sublambdas : nullptr);
+			old_info_E = old_info_E->next();
+			if (new_info_E) {
+				new_info_E = new_info_E->next();
+			}
+		}
+	}
 }
 
-void GDScriptCompiler::_get_function_ptr_replacements(HashMap<GDScriptFunction *, GDScriptFunction *> &r_replacements, const Vector<FunctionLambdaInfo> &p_old_infos, const Vector<FunctionLambdaInfo> *p_new_infos) {
-	for (int i = 0; i < p_old_infos.size(); ++i) {
-		const FunctionLambdaInfo &old_info = p_old_infos[i];
-		const FunctionLambdaInfo *new_info = nullptr;
-		if (p_new_infos != nullptr && p_new_infos->size() == p_old_infos.size()) {
-			// For now only attempt if the size is the same.
-			new_info = &p_new_infos->get(i);
-		}
-		_get_function_ptr_replacements(r_replacements, old_info, new_info);
-	}
-}
+void GDScriptCompiler::_collect_function_ptr_replacements(HashMap<GDScriptFunction *, GDScriptFunction *> &r_replacements, ScriptLambdaInfo &p_old_info, ScriptLambdaInfo *p_new_info) {
+	_collect_function_ptr_replacements(r_replacements, p_old_info.initializers, p_new_info ? &p_new_info->initializers : nullptr);
 
-void GDScriptCompiler::_get_function_ptr_replacements(HashMap<GDScriptFunction *, GDScriptFunction *> &r_replacements, const ScriptLambdaInfo &p_old_info, const ScriptLambdaInfo *p_new_info) {
-	_get_function_ptr_replacements(r_replacements, p_old_info.implicit_initializer_info, p_new_info != nullptr ? &p_new_info->implicit_initializer_info : nullptr);
-	_get_function_ptr_replacements(r_replacements, p_old_info.implicit_ready_info, p_new_info != nullptr ? &p_new_info->implicit_ready_info : nullptr);
-	_get_function_ptr_replacements(r_replacements, p_old_info.static_initializer_info, p_new_info != nullptr ? &p_new_info->static_initializer_info : nullptr);
-
-	for (const KeyValue<StringName, Vector<FunctionLambdaInfo>> &old_kv : p_old_info.member_function_infos) {
-		_get_function_ptr_replacements(r_replacements, old_kv.value, p_new_info != nullptr ? p_new_info->member_function_infos.getptr(old_kv.key) : nullptr);
+	for (KeyValue<StringName, LambdaSourceInfoList> &old_kv : p_old_info.member_functions) {
+		_collect_function_ptr_replacements(r_replacements, old_kv.value, p_new_info ? p_new_info->member_functions.getptr(old_kv.key) : nullptr);
 	}
-	for (int i = 0; i < p_old_info.other_function_infos.size(); ++i) {
-		const FunctionLambdaInfo &old_other_info = p_old_info.other_function_infos[i];
-		const FunctionLambdaInfo *new_other_info = nullptr;
-		if (p_new_info != nullptr && p_new_info->other_function_infos.size() == p_old_info.other_function_infos.size()) {
-			// For now only attempt if the size is the same.
-			new_other_info = &p_new_info->other_function_infos[i];
-		}
-		// Needs to be called on all old lambdas, even if there's no replacement.
-		_get_function_ptr_replacements(r_replacements, old_other_info, new_other_info);
-	}
-	for (const KeyValue<StringName, ScriptLambdaInfo> &old_kv : p_old_info.subclass_info) {
-		const ScriptLambdaInfo &old_subinfo = old_kv.value;
-		const ScriptLambdaInfo *new_subinfo = p_new_info != nullptr ? p_new_info->subclass_info.getptr(old_kv.key) : nullptr;
-		_get_function_ptr_replacements(r_replacements, old_subinfo, new_subinfo);
+	for (KeyValue<StringName, ScriptLambdaInfo> &old_kv : p_old_info.subclasses) {
+		ScriptLambdaInfo &old_subinfo = old_kv.value;
+		ScriptLambdaInfo *new_subinfo = p_new_info ? p_new_info->subclasses.getptr(old_kv.key) : nullptr;
+		_collect_function_ptr_replacements(r_replacements, old_subinfo, new_subinfo);
 	}
 }
 
@@ -3333,7 +3317,8 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 
 	source = p_script->get_path();
 
-	ScriptLambdaInfo old_lambda_info = _get_script_lambda_replacement_info(p_script);
+	ScriptLambdaInfo old_lambda_info;
+	old_lambda_info.collect_script_lambda_replacement_info(p_script);
 
 	// Create scripts for subclasses beforehand so they can be referenced
 	make_scripts(p_script, root, p_keep_state);
@@ -3350,10 +3335,11 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 		return err;
 	}
 
-	ScriptLambdaInfo new_lambda_info = _get_script_lambda_replacement_info(p_script);
+	ScriptLambdaInfo new_lambda_info;
+	new_lambda_info.collect_script_lambda_replacement_info(p_script);
 
 	HashMap<GDScriptFunction *, GDScriptFunction *> func_ptr_replacements;
-	_get_function_ptr_replacements(func_ptr_replacements, old_lambda_info, &new_lambda_info);
+	_collect_function_ptr_replacements(func_ptr_replacements, old_lambda_info, &new_lambda_info);
 	main_script->_recurse_replace_function_ptrs(func_ptr_replacements);
 
 	if (has_static_data && !root->annotated_static_unload) {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2304,6 +2304,9 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	if (p_func) {
 		if (p_func->identifier) {
 			func_name = p_func->identifier->name;
+		} else if (p_func->source_lambda && p_func->source_lambda->parent_variable) {
+			GDScriptParser::AssignableNode *parent_variable = p_func->source_lambda->parent_variable;
+			func_name = vformat("<anonymous lambda(%s)>", parent_variable->identifier->name);
 		} else {
 			func_name = "<anonymous lambda>";
 		}

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -594,6 +594,7 @@ public:
 	_FORCE_INLINE_ bool is_vararg() const { return _vararg_index >= 0; }
 	_FORCE_INLINE_ MethodInfo get_method_info() const { return method_info; }
 	_FORCE_INLINE_ int get_argument_count() const { return _argument_count; }
+	_FORCE_INLINE_ int get_default_argument_count() const { return _default_arg_count; }
 	_FORCE_INLINE_ Variant get_rpc_config() const { return rpc_config; }
 	_FORCE_INLINE_ int get_max_stack_size() const { return _stack_size; }
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -937,9 +937,8 @@ bool GDScriptParser::has_class(const GDScriptParser::ClassNode *p_class) const {
 GDScriptParser::ClassNode *GDScriptParser::parse_class(bool p_is_static) {
 	ClassNode *n_class = alloc_node<ClassNode>();
 
-	ClassNode *previous_class = current_class;
-	current_class = n_class;
-	n_class->outer = previous_class;
+	n_class->outer = current_class;
+	ScopedSet scoped_set_current_class(current_class, n_class);
 
 	if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier for the class name after "class".)")) {
 		n_class->identifier = parse_identifier();
@@ -963,7 +962,6 @@ GDScriptParser::ClassNode *GDScriptParser::parse_class(bool p_is_static) {
 	bool multiline = match(GDScriptTokenizer::Token::NEWLINE);
 
 	if (multiline && !consume(GDScriptTokenizer::Token::INDENT, R"(Expected indented block after class declaration.)")) {
-		current_class = previous_class;
 		complete_extents(n_class);
 		return n_class;
 	}
@@ -983,7 +981,6 @@ GDScriptParser::ClassNode *GDScriptParser::parse_class(bool p_is_static) {
 		consume(GDScriptTokenizer::Token::DEDENT, R"(Missing unindent at the end of the class body.)");
 	}
 
-	current_class = previous_class;
 	return n_class;
 }
 
@@ -1106,6 +1103,8 @@ void GDScriptParser::parse_class_member(T *(GDScriptParser::*p_parse_function)(b
 }
 
 void GDScriptParser::parse_class_body(bool p_is_multiline) {
+	ScopedSet scoped_set_current_variable(current_variable, nullptr);
+
 	bool class_end = false;
 	bool next_is_static = false;
 	while (!class_end && !is_at_end()) {
@@ -1225,6 +1224,8 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static) {
 
 GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, bool p_allow_property) {
 	VariableNode *variable = alloc_node<VariableNode>();
+
+	ScopedSet scoped_set_current_variable(current_variable, variable);
 
 	if (!consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected variable name after "var".)")) {
 		complete_extents(variable);
@@ -1462,6 +1463,8 @@ void GDScriptParser::parse_property_getter(VariableNode *p_variable) {
 GDScriptParser::ConstantNode *GDScriptParser::parse_constant(bool p_is_static) {
 	ConstantNode *constant = alloc_node<ConstantNode>();
 
+	ScopedSet scoped_set_current_variable(current_variable, constant);
+
 	if (!consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected constant name after "const".)")) {
 		complete_extents(constant);
 		return nullptr;
@@ -1505,6 +1508,9 @@ GDScriptParser::ParameterNode *GDScriptParser::parse_parameter() {
 	}
 
 	ParameterNode *parameter = alloc_node<ParameterNode>();
+
+	ScopedSet scoped_set_current_variable(current_variable, parameter);
+
 	parameter->identifier = parse_identifier();
 
 	if (match(GDScriptTokenizer::Token::COLON)) {
@@ -1919,6 +1925,8 @@ bool GDScriptParser::register_annotation(const MethodInfo &p_info, uint32_t p_ta
 }
 
 GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, SuiteNode *p_suite, bool p_for_lambda) {
+	ScopedSet scoped_set_current_variable(current_variable, nullptr);
+
 	SuiteNode *suite = p_suite != nullptr ? p_suite : alloc_node<SuiteNode>();
 	suite->parent_block = current_suite;
 	suite->parent_function = current_function;
@@ -3705,6 +3713,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_lambda(ExpressionNode *p_p
 	LambdaNode *lambda = alloc_node<LambdaNode>();
 	lambda->parent_function = current_function;
 	lambda->parent_lambda = current_lambda;
+	lambda->parent_variable = current_variable;
 
 	FunctionNode *function = alloc_node<FunctionNode>();
 	function->source_lambda = lambda;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -946,6 +946,7 @@ public:
 		FunctionNode *function = nullptr;
 		FunctionNode *parent_function = nullptr;
 		LambdaNode *parent_lambda = nullptr;
+		AssignableNode *parent_variable = nullptr;
 		Vector<IdentifierNode *> captures;
 		HashMap<StringName, int> captures_indices;
 		bool use_self = false;
@@ -1338,6 +1339,22 @@ public:
 	};
 
 private:
+	template <typename T>
+	class ScopedSet {
+		T *var;
+		T old_value;
+
+	public:
+		template <typename TNew>
+		ScopedSet(T &p_var, const TNew &p_new_value) :
+				var(&p_var), old_value(p_var) {
+			p_var = p_new_value;
+		}
+		~ScopedSet() {
+			*var = old_value;
+		}
+	};
+
 	friend class GDScriptAnalyzer;
 	friend class GDScriptParserRef;
 
@@ -1396,6 +1413,7 @@ private:
 	FunctionNode *current_function = nullptr;
 	LambdaNode *current_lambda = nullptr;
 	SuiteNode *current_suite = nullptr;
+	AssignableNode *current_variable = nullptr;
 
 	CompletionContext completion_context;
 	List<CompletionCall> completion_call_stack;

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -207,19 +207,21 @@ int GDScriptTestRunner::run_tests() {
 		if (print_filenames) {
 			print_line(test.get_source_relative_filepath());
 		}
-		GDScriptTest::TestResult result = test.run_test();
-
-		String expected = FileAccess::get_file_as_string(test.get_output_file());
+		for (GDScriptTest::TestResult &result : test.run_test()) {
+			String source_file = result.source_test->get_source_file();
+			String output_file = result.source_test->get_output_file();
+			String expected = FileAccess::get_file_as_string(output_file);
 #ifndef DEBUG_ENABLED
-		expected = strip_warnings(expected);
+			expected = strip_warnings(expected);
 #endif
-		INFO(test.get_source_file());
-		if (!result.passed) {
-			INFO(expected);
-			failed++;
-		}
+			INFO(source_file);
+			if (!result.passed) {
+				INFO(expected);
+				failed++;
+			}
 
-		CHECK_MESSAGE(result.passed, (result.passed ? String() : result.output));
+			CHECK_MESSAGE(result.passed, (result.passed ? String() : result.output));
+		}
 	}
 
 	return failed;
@@ -304,7 +306,8 @@ bool GDScriptTestRunner::make_tests_for_dir(const String &p_dir) {
 				}
 #endif
 
-				String out_file = next.get_basename() + ".out";
+				String script_file_basename = next.get_basename();
+				String out_file = script_file_basename + ".out";
 				ERR_FAIL_COND_V_MSG(!is_generating && !dir->file_exists(out_file), false, "Could not find output file for " + next);
 
 				if (next.ends_with(".bin.gd")) {
@@ -319,6 +322,22 @@ bool GDScriptTestRunner::make_tests_for_dir(const String &p_dir) {
 					GDScriptTest test(current_dir.path_join(next), current_dir.path_join(out_file), source_dir);
 					if (binary_tokens) {
 						test.set_tokenizer_mode(GDScriptTest::TOKENIZER_BUFFER);
+					}
+					for (int i = 1; true; ++i) {
+						String hotswap_file = script_file_basename + ".swap" + String::num_int64(i);
+						if (!dir->file_exists(hotswap_file)) {
+							break;
+						}
+
+						// Arbitrary safety limit.
+						ERR_FAIL_COND_V_MSG(i >= 1000, false, "Too many hotswap files!");
+						String hotswap_out_file = hotswap_file + ".out";
+						ERR_FAIL_COND_V_MSG(!is_generating && !dir->file_exists(hotswap_out_file), false, "Could not find output file for " + hotswap_file);
+						GDScriptTest hotswap_test(current_dir.path_join(hotswap_file), current_dir.path_join(hotswap_out_file), source_dir);
+						if (binary_tokens) {
+							test.set_tokenizer_mode(GDScriptTest::TOKENIZER_BUFFER);
+						}
+						test.add_hotswap_test(hotswap_test);
 					}
 					tests.push_back(test);
 				}
@@ -512,27 +531,26 @@ String GDScriptTest::get_text_for_status(GDScriptTest::TestStatus p_status) cons
 	return "";
 }
 
-GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
-	disable_stdout();
-
+GDScriptTest::TestResult GDScriptTest::execute_test_code(Ref<GDScript> &p_script, Object *&p_obj, Ref<RefCounted> &p_obj_ref, GDScriptInstance *&p_instance, bool p_is_hotreload, bool p_is_generating) {
 	TestResult result;
+	result.source_test = this;
 	result.status = GDTEST_OK;
 	result.output = String();
 	result.passed = false;
 
 	Error err = OK;
 
-	// Create script.
-	Ref<GDScript> script;
-	script.instantiate();
-	script->set_path(source_file);
+	if (p_script.is_null()) {
+		p_script.instantiate();
+	}
+	p_script->set_path(source_file);
 	if (tokenizer_mode == TOKENIZER_TEXT) {
-		err = script->load_source_code(source_file);
+		err = p_script->load_source_code(source_file);
 	} else {
 		String code = FileAccess::get_file_as_string(source_file, &err);
 		if (!err) {
 			Vector<uint8_t> buffer = GDScriptTokenizerBuffer::parse_code_string(code, GDScriptTokenizerBuffer::COMPRESS_ZSTD);
-			script->set_binary_tokens_source(buffer);
+			p_script->set_binary_tokens_source(buffer);
 		}
 	}
 	if (err != OK) {
@@ -545,9 +563,9 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	// Test parsing.
 	GDScriptParser parser;
 	if (tokenizer_mode == TOKENIZER_TEXT) {
-		err = parser.parse(script->get_source_code(), source_file, false);
+		err = parser.parse(p_script->get_source_code(), source_file, false);
 	} else {
-		err = parser.parse_binary(script->get_binary_tokens_source(), source_file);
+		err = parser.parse_binary(p_script->get_binary_tokens_source(), source_file);
 	}
 	if (err != OK) {
 		enable_stdout();
@@ -594,7 +612,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 
 	// Test compiling.
 	GDScriptCompiler compiler;
-	err = compiler.compile(&parser, script.ptr(), false);
+	err = compiler.compile(&parser, p_script.ptr(), p_is_hotreload);
 	if (err != OK) {
 		enable_stdout();
 		result.status = GDTEST_COMPILER_ERROR;
@@ -618,7 +636,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	}
 
 	// Test running.
-	const HashMap<StringName, GDScriptFunction *>::ConstIterator test_function_element = script->get_member_functions().find(GDScriptTestRunner::test_function_name);
+	const HashMap<StringName, GDScriptFunction *>::ConstIterator test_function_element = p_script->get_member_functions().find(GDScriptTestRunner::test_function_name);
 	if (!test_function_element) {
 		enable_stdout();
 		result.status = GDTEST_LOAD_ERROR;
@@ -635,7 +653,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	add_print_handler(&_print_handler);
 	add_error_handler(&_error_handler);
 
-	err = script->reload();
+	err = p_script->reload(p_is_hotreload);
 	if (err) {
 		enable_stdout();
 		result.status = GDTEST_LOAD_ERROR;
@@ -646,18 +664,19 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		ERR_FAIL_V_MSG(result, "\nCould not reload script: '" + source_file + "'");
 	}
 
-	// Create object instance for test.
-	Object *obj = ClassDB::instantiate(script->get_native()->get_name());
-	Ref<RefCounted> obj_ref;
-	if (obj->is_ref_counted()) {
-		obj_ref = Ref<RefCounted>(Object::cast_to<RefCounted>(obj));
+	if (!p_instance) {
+		// Create object instance for test.
+		p_obj = ClassDB::instantiate(p_script->get_native()->get_name());
+		if (p_obj->is_ref_counted()) {
+			p_obj_ref = Ref<RefCounted>(Object::cast_to<RefCounted>(p_obj));
+		}
+		p_obj->set_script(p_script);
+		p_instance = static_cast<GDScriptInstance *>(p_obj->get_script_instance());
 	}
-	obj->set_script(script);
-	GDScriptInstance *instance = static_cast<GDScriptInstance *>(obj->get_script_instance());
 
 	// Call test function.
 	Callable::CallError call_err;
-	instance->callp(GDScriptTestRunner::test_function_name, nullptr, 0, call_err);
+	p_instance->callp(GDScriptTestRunner::test_function_name, nullptr, 0, call_err);
 
 	// Tear down output handlers.
 	remove_print_handler(&_print_handler);
@@ -676,37 +695,59 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		result.passed = check_output(result.output);
 	}
 
-	if (obj_ref.is_null()) {
+	return result;
+}
+
+Vector<GDScriptTest::TestResult> GDScriptTest::execute_test_code(bool p_is_generating) {
+	disable_stdout();
+
+	Ref<GDScript> script;
+	Object *obj = nullptr;
+	Ref<RefCounted> obj_ref;
+	GDScriptInstance *instance = nullptr;
+
+	Vector<TestResult> test_results;
+	test_results.push_back(execute_test_code(script, obj, obj_ref, instance, false, p_is_generating));
+
+	for (GDScriptTest &hotswap_test : hotswap_tests) {
+		test_results.push_back(hotswap_test.execute_test_code(script, obj, obj_ref, instance, true, p_is_generating));
+	}
+
+	if (obj && obj_ref.is_null()) {
 		memdelete(obj);
 	}
+	obj = nullptr;
+	obj_ref = nullptr;
+	instance = nullptr;
 
 	enable_stdout();
 
 	GDScriptCache::remove_script(script->get_path());
 
-	return result;
+	return test_results;
 }
 
-GDScriptTest::TestResult GDScriptTest::run_test() {
+Vector<GDScriptTest::TestResult> GDScriptTest::run_test() {
 	return execute_test_code(false);
 }
 
 bool GDScriptTest::generate_output() {
-	TestResult result = execute_test_code(true);
-	if (result.status == GDTEST_LOAD_ERROR) {
-		return false;
+	for (TestResult &result : execute_test_code(true)) {
+		if (result.status == GDTEST_LOAD_ERROR) {
+			return false;
+		}
+
+		Error err = OK;
+		Ref<FileAccess> out_file = FileAccess::open(result.source_test->output_file, FileAccess::WRITE, &err);
+		if (err != OK) {
+			return false;
+		}
+
+		String output = result.output.strip_edges(); // TODO: may be hacky.
+		output += "\n"; // Make sure to insert newline for CI static checks.
+
+		out_file->store_string(output);
 	}
-
-	Error err = OK;
-	Ref<FileAccess> out_file = FileAccess::open(output_file, FileAccess::WRITE, &err);
-	if (err != OK) {
-		return false;
-	}
-
-	String output = result.output.strip_edges(); // TODO: may be hacky.
-	output += "\n"; // Make sure to insert newline for CI static checks.
-
-	out_file->store_string(output);
 
 	return true;
 }

--- a/modules/gdscript/tests/gdscript_test_runner.h
+++ b/modules/gdscript/tests/gdscript_test_runner.h
@@ -56,6 +56,7 @@ public:
 	};
 
 	struct TestResult {
+		GDScriptTest *source_test;
 		TestStatus status;
 		String output;
 		bool passed;
@@ -79,6 +80,7 @@ private:
 	String source_file;
 	String output_file;
 	String base_dir;
+	Vector<GDScriptTest> hotswap_tests;
 
 	PrintHandlerList _print_handler;
 	ErrorHandlerList _error_handler;
@@ -90,18 +92,20 @@ private:
 	bool check_output(const String &p_output) const;
 	String get_text_for_status(TestStatus p_status) const;
 
-	TestResult execute_test_code(bool p_is_generating);
+	TestResult execute_test_code(Ref<GDScript> &p_script, Object *&p_obj, Ref<RefCounted> &p_obj_ref, GDScriptInstance *&p_instance, bool p_is_hotreload, bool p_is_generating);
+	Vector<TestResult> execute_test_code(bool p_is_generating);
 
 public:
 	static void print_handler(void *p_this, const String &p_message, bool p_error, bool p_rich);
 	static void error_handler(void *p_this, const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_explanation, bool p_editor_notify, ErrorHandlerType p_type);
-	TestResult run_test();
+	Vector<TestResult> run_test();
 	bool generate_output();
 
 	const String &get_source_file() const { return source_file; }
 	const String get_source_relative_filepath() const { return source_file.trim_prefix(base_dir); }
 	const String &get_output_file() const { return output_file; }
 
+	void add_hotswap_test(const GDScriptTest &hotswap_test) { hotswap_tests.push_back(hotswap_test); }
 	void set_tokenizer_mode(TokenizerMode p_tokenizer_mode) { tokenizer_mode = p_tokenizer_mode; }
 	TokenizerMode get_tokenizer_mode() const { return tokenizer_mode; }
 

--- a/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.gd
+++ b/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.gd
@@ -1,0 +1,30 @@
+var member1 := func():
+	return "Member 1"
+
+var local1: Callable
+
+var param1: Callable
+
+var anon1: Callable
+var anon2: Callable
+
+func test():
+	var _v1 = func(): return "Local 1"
+	local1 = _v1
+
+	print(local1.call())
+
+	print(member1.call())
+
+	test_parameters()
+
+	print(param1.call())
+
+	anon1 = func(): return "Anonymous 1"
+	anon2 = func(): return "Anonymous 2"
+
+	print(anon1.call())
+	print(anon2.call())
+
+func test_parameters(_v1 = func(): return "Param 1"):
+	param1 = _v1

--- a/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.out
+++ b/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+Local 1
+Member 1
+Param 1
+Anonymous 1
+Anonymous 2

--- a/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.swap1
+++ b/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.swap1
@@ -1,0 +1,49 @@
+var member1 := func():
+	return "Member 1 Hotswap 1"
+
+var member2 := func():
+	return "Member 2 Hotswap 1"
+
+var local1: Callable
+var local2: Callable
+
+var param1: Callable
+var param2: Callable
+
+var anon1: Callable
+var anon2: Callable
+
+func test():
+	var _v1 = func(): return "Local 1 Hotswap 1"
+	var _v2 = func(): return "Local 2 Hotswap 1"
+	# Only set local2 here, local1 has already been set.
+	local2 = _v2
+
+	print(local1.call())
+	print(local2.call())
+
+
+	print(member1.call())
+	if member2:
+		print(member2.call())
+	else:
+		print(member2)
+
+	test_parameters()
+
+	print(param1.call())
+	print(param2.call())
+
+	# Only set anon2 here, anon1 has already been set.
+	sink(func(): return "Anonymous 1 Hotswap 1")
+	sink(func(): return "Anonymous 2 Hotswap 1")
+
+	print(anon1.call())
+	print(anon2.call())
+
+func test_parameters(_v1 = func(): return "Param 1 Hotswap 1", _v2 = func(): return "Param 2 Hotswap 1"):
+	# Only set param2 here, param1 has already been set.
+	param2 = _v2
+
+func sink(_v):
+	pass

--- a/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.swap1.out
+++ b/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.swap1.out
@@ -1,0 +1,9 @@
+GDTEST_OK
+Local 1 Hotswap 1
+Local 2 Hotswap 1
+Member 1 Hotswap 1
+<null>
+Param 1 Hotswap 1
+Param 2 Hotswap 1
+Anonymous 1 Hotswap 1
+Anonymous 2 Hotswap 1

--- a/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.swap2
+++ b/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.swap2
@@ -1,0 +1,48 @@
+var member2 := func():
+	return "Member 2 Hotswap 2"
+
+var member1 := func():
+	return "Member 1 Hotswap 2"
+
+var local1: Callable
+var local2: Callable
+
+var param1: Callable
+var param2: Callable
+
+var anon1: Callable
+var anon2: Callable
+
+func test():
+	var _v2 = func(): return "Local 2 Hotswap 2"
+	var _v1 = func(): return "Local 1 Hotswap 2"
+	# local1 and local2 have already been set.
+
+	print(local1.call())
+	print(local2.call())
+
+	print(member1.call())
+	if member2:
+		print(member2.call())
+	else:
+		print(member2)
+
+	test_parameters()
+
+	print(param1.call())
+	print(param2.call())
+
+	# Only set anon2 here, anon1 has already been set.
+	# No way for compiler to tell that theyve been swapped, so anon1 and anon2's output will be swapped.
+	sink(func(): return "Anonymous 2 Hotswap 2")
+	sink(func(): return "Anonymous 1 Hotswap 2")
+
+	print(anon1.call())
+	print(anon2.call())
+
+func test_parameters(_v2 = func(): return "Param 2 Hotswap 2", _v1 = func(): return "Param 1 Hotswap 2"):
+	# param1 and param2 have already been set.
+	pass
+
+func sink(_v):
+	pass

--- a/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.swap2.out
+++ b/modules/gdscript/tests/scripts/hotswap/hotswap_lambda.swap2.out
@@ -1,0 +1,9 @@
+GDTEST_OK
+Local 1 Hotswap 2
+Local 2 Hotswap 2
+Member 1 Hotswap 2
+<null>
+Param 1 Hotswap 2
+Param 2 Hotswap 2
+Anonymous 2 Hotswap 2
+Anonymous 1 Hotswap 2

--- a/modules/gdscript/tests/scripts/runtime/features/lambda_get_method.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/lambda_get_method.gd
@@ -10,7 +10,7 @@ func test():
 		foo()
 
 	print(lambda_self.get_method())  # Should print "test".
-	print(anon_lambda_self.get_method())  # Should print "<anonymous lambda>".
+	print(anon_lambda_self.get_method())  # Should print "<anonymous lambda(anon_lambda_self)>".
 
 	var lambda_non_self := func test() -> void:
 		pass
@@ -18,4 +18,4 @@ func test():
 		pass
 
 	print(lambda_non_self.get_method())  # Should print "test".
-	print(anon_lambda_non_self.get_method())  # Should print "<anonymous lambda>".
+	print(anon_lambda_non_self.get_method())  # Should print "<anonymous lambda(anon_lambda_non_self)>".

--- a/modules/gdscript/tests/scripts/runtime/features/lambda_get_method.out
+++ b/modules/gdscript/tests/scripts/runtime/features/lambda_get_method.out
@@ -1,5 +1,5 @@
 GDTEST_OK
 test
-<anonymous lambda>
+<anonymous lambda(anon_lambda_self)>
 test
-<anonymous lambda>
+<anonymous lambda(anon_lambda_non_self)>


### PR DESCRIPTION
this PR makes lambda hotswapping more stable when lambdas are named, or when a lambda is the initializer for a member, variable, or parameter 

+now all script member initializer lambdas can be swapped (between `implicit_initializer`, `implicit_ready_info` (`@onready` vars), and `static_initializer`)
+added the ability to test hot-reloading scripts and added tests :3
+anonymous lambdas include the name of the variable they initialize, `<anonymous lambda(member_var)>`
++this formatting is up for debate but it doesn't seem like it matters that much 
++it, however, may be that adding the variable name to the anonymous lambda name is undesirable, seems fine to me but i wanted to point that out 

i've split this into 2 commits that add the features needed to implement this, and then the actual change 

partially fixes https://github.com/godotengine/godot/issues/97834
