### PR TITLE
Don't flip playback control buttons in RTL layout

### DIFF
--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -437,11 +437,7 @@ void EditorVisualProfiler::_notification(int p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			if (is_layout_rtl()) {
-				activate->set_icon(get_editor_theme_icon(SNAME("PlayBackwards")));
-			} else {
-				activate->set_icon(get_editor_theme_icon(SNAME("Play")));
-			}
+			activate->set_icon(get_editor_theme_icon(SNAME("Play")));
 			clear_button->set_icon(get_editor_theme_icon(SNAME("Clear")));
 		} break;
 	}

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -326,11 +326,7 @@ Error EditorExportPlatform::_save_zip_patch_file(void *p_userdata, const String 
 Ref<ImageTexture> EditorExportPlatform::get_option_icon(int p_index) const {
 	Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
 	ERR_FAIL_COND_V(theme.is_null(), Ref<ImageTexture>());
-	if (EditorNode::get_singleton()->get_gui_base()->is_layout_rtl()) {
-		return theme->get_icon(SNAME("PlayBackwards"), EditorStringName(EditorIcons));
-	} else {
-		return theme->get_icon(SNAME("Play"), EditorStringName(EditorIcons));
-	}
+	return theme->get_icon(SNAME("Play"), EditorStringName(EditorIcons));
 }
 
 String EditorExportPlatform::find_export_template(const String &template_file_name, String *err) const {

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -2006,30 +2006,34 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 	HBoxContainer *hb = memnew(HBoxContainer);
 	add_child(hb);
 
+	HBoxContainer *playback_container = memnew(HBoxContainer);
+	playback_container->set_layout_direction(LAYOUT_DIRECTION_LTR);
+	hb->add_child(playback_container);
+
 	play_bw_from = memnew(Button);
 	play_bw_from->set_theme_type_variation("FlatButton");
 	play_bw_from->set_tooltip_text(TTR("Play Animation Backwards"));
-	hb->add_child(play_bw_from);
+	playback_container->add_child(play_bw_from);
 
 	play_bw = memnew(Button);
 	play_bw->set_theme_type_variation("FlatButton");
 	play_bw->set_tooltip_text(TTR("Play Animation Backwards from End"));
-	hb->add_child(play_bw);
+	playback_container->add_child(play_bw);
 
 	stop = memnew(Button);
 	stop->set_theme_type_variation("FlatButton");
 	stop->set_tooltip_text(TTR("Pause/Stop Animation"));
-	hb->add_child(stop);
+	playback_container->add_child(stop);
 
 	play = memnew(Button);
 	play->set_theme_type_variation("FlatButton");
 	play->set_tooltip_text(TTR("Play Animation from Start"));
-	hb->add_child(play);
+	playback_container->add_child(play);
 
 	play_from = memnew(Button);
 	play_from->set_theme_type_variation("FlatButton");
 	play_from->set_tooltip_text(TTR("Play Animation"));
-	hb->add_child(play_from);
+	playback_container->add_child(play_from);
 
 	frame = memnew(SpinBox);
 	hb->add_child(frame);

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1986,6 +1986,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	sub_vb->add_child(hfc);
 
 	playback_container = memnew(HBoxContainer);
+	playback_container->set_layout_direction(LAYOUT_DIRECTION_LTR);
 	hfc->add_child(playback_container);
 
 	play_bw_from = memnew(Button);
@@ -2013,7 +2014,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	play_from->set_tooltip_text(TTR("Play selected animation from current pos. (D)"));
 	playback_container->add_child(play_from);
 
-	playback_container->add_child(memnew(VSeparator));
+	hfc->add_child(memnew(VSeparator));
 
 	autoplay->connect(SceneStringName(pressed), callable_mp(this, &SpriteFramesEditor::_autoplay_pressed));
 	autoplay->set_toggle_mode(true);


### PR DESCRIPTION
I noticed that the direction Play buttons facing are inconsistent in the editor when using RTL layout. Some are facing left while some are facing right.

According to resources online, playback control symbols represent the direction of the tape being played, so they don't require any change in RTL layout.[^1]

This PR makes all play icons facing right.

| Before | After |
|---|---|
| ![visual-profiler-before](https://github.com/user-attachments/assets/f780e20f-1f14-403f-bd5c-78d4080a8872) | ![visual-profiler-after](https://github.com/user-attachments/assets/f6a37809-35d2-43f8-bf3e-7af744336b51) |
| ![run-export-before](https://github.com/user-attachments/assets/11b2ddff-5728-452d-b7d7-f056efbbcd98) | ![run-export-after](https://github.com/user-attachments/assets/b8eb130c-3461-4c4b-abde-837fcf71c40c) |

For AnimationPlayer and SpriteFrames playback controls, the icons are not flipped currently. This PR makes the order of these buttons the same as in LTR layout.

| Before | After |
|---|---|
| ![animation-player-before](https://github.com/user-attachments/assets/34f58aa1-ad7a-4a74-948e-31c6092cfe3a) | ![animation-player-after](https://github.com/user-attachments/assets/1ff0af96-1913-4e19-9308-ea5246adc203) |
| ![sprite-frames-before](https://github.com/user-attachments/assets/367c2f36-ec09-4dd8-b178-cd6617b20f17) | ![sprite-frames-after](https://github.com/user-attachments/assets/716598ae-f76a-41e4-bee9-2fb88af3b5e7) |
| Play / Step / Stop / Step backward / Play backward | Play backward  / Step backward / Stop / Step / Play |




[^1]: https://m2.material.io/design/usability/bidirectionality.html#mirroring-elements