### PR TITLE
Fix incorrect depth comparison used to calculate volumetric fog shadowing

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -513,6 +513,7 @@ void main() {
 							shadow_sample.z = 1.0 + abs(shadow_sample.z);
 							vec3 pos = vec3(shadow_sample.xy / shadow_sample.z, shadow_len - omni_lights.data[light_index].shadow_bias);
 							pos.z *= omni_lights.data[light_index].inv_radius;
+							pos.z = 1.0 - pos.z;
 
 							pos.xy = pos.xy * 0.5 + 0.5;
 							pos.xy = uv_rect.xy + pos.xy * uv_rect.zw;


### PR DESCRIPTION
Fixes #95785. Added the depth reversal logic that was necessary for proper shadow tests with omnidirectional lights active in fog volumes. #88328 seems to be the one that broke it for now.

Pictures for comparison:

Before:
<img width="575" alt="Desktop Screenshot 2024 10 16 - 15 02 28 70" src="https://github.com/user-attachments/assets/ca3f4299-4783-4ae8-84e6-1aef2f2bc65c">
<img width="574" alt="Desktop Screenshot 2024 10 16 - 15 02 43 85" src="https://github.com/user-attachments/assets/d92d3d1f-f7fe-446d-b1f6-18ec16f9d03a">

After:
<img width="575" alt="Desktop Screenshot 2024 10 16 - 15 03 11 08" src="https://github.com/user-attachments/assets/085ab3e0-1e5b-46a5-8a24-a64154be79e4">
<img width="572" alt="Desktop Screenshot 2024 10 16 - 15 03 21 17" src="https://github.com/user-attachments/assets/4a9eb0da-190b-44d1-9a46-79a71c14105c">
