### PR TITLE
Fix Android app permissions for SDK levels earlier than 28

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/utils/PermissionsUtil.java
@@ -108,7 +108,7 @@ public final class PermissionsUtil {
 				} else {
 					PermissionInfo permissionInfo = getPermissionInfo(activity, permission);
 					int protectionLevel = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P ? permissionInfo.getProtection() : permissionInfo.protectionLevel;
-					if (protectionLevel == PermissionInfo.PROTECTION_DANGEROUS && ContextCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
+					if ((protectionLevel & PermissionInfo.PROTECTION_DANGEROUS) == PermissionInfo.PROTECTION_DANGEROUS && ContextCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
 						Log.d(TAG, "Requesting permission " + permission);
 						requestedPermissions.add(permission);
 					}
@@ -174,7 +174,7 @@ public final class PermissionsUtil {
 				try {
 					PermissionInfo permissionInfo = getPermissionInfo(activity, permissionName);
 					int protectionLevel = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P ? permissionInfo.getProtection() : permissionInfo.protectionLevel;
-					if (protectionLevel == PermissionInfo.PROTECTION_DANGEROUS && ContextCompat.checkSelfPermission(activity, permissionName) != PackageManager.PERMISSION_GRANTED) {
+					if ((protectionLevel & PermissionInfo.PROTECTION_DANGEROUS) == PermissionInfo.PROTECTION_DANGEROUS && ContextCompat.checkSelfPermission(activity, permissionName) != PackageManager.PERMISSION_GRANTED) {
 						activity.requestPermissions(new String[] { permissionName }, REQUEST_SINGLE_PERMISSION_REQ_CODE);
 						return false;
 					}
@@ -259,7 +259,7 @@ public final class PermissionsUtil {
 				} else {
 					PermissionInfo permissionInfo = getPermissionInfo(context, manifestPermission);
 					int protectionLevel = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P ? permissionInfo.getProtection() : permissionInfo.protectionLevel;
-					if (protectionLevel == PermissionInfo.PROTECTION_DANGEROUS && ContextCompat.checkSelfPermission(context, manifestPermission) == PackageManager.PERMISSION_GRANTED) {
+					if ((protectionLevel & PermissionInfo.PROTECTION_DANGEROUS) == PermissionInfo.PROTECTION_DANGEROUS && ContextCompat.checkSelfPermission(context, manifestPermission) == PackageManager.PERMISSION_GRANTED) {
 						grantedPermissions.add(manifestPermission);
 					}
 				}


### PR DESCRIPTION
Fixes #98229

The root of the problem is a change introduced in [PermissionInfo](https://developer.android.com/reference/android/content/pm/PermissionInfo) in Android P. Before, the protection level consisted of the level itself and a set of flags. From Android P onwards, protection level and flags are queried separately. This is what Godot relies on currently to query what permissions the app needs and if they're currently granted. It fails for earlier Android versions because it doesn't separate the flags from the protection level before doing these checks.

This PR is backwards compatible and if accepted, I'd like it to be backported to Godot 4.3.