### PR TITLE
[3.x] Cache results for `TranslationServer.compare_locales()`

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -365,32 +365,46 @@ String TranslationServer::_standardize_locale(const String &p_locale, bool p_add
 }
 
 int TranslationServer::compare_locales(const String &p_locale_a, const String &p_locale_b) const {
+	if (p_locale_a == p_locale_b) {
+		// Exact match.
+		return 10;
+	}
+
+	const String cache_key = p_locale_a + "|" + p_locale_b;
+	const int *cached_result = locale_compare_cache.getptr(cache_key);
+	if (cached_result) {
+		return *cached_result;
+	}
+
 	String locale_a = _standardize_locale(p_locale_a, true);
 	String locale_b = _standardize_locale(p_locale_b, true);
 
 	if (locale_a == locale_b) {
 		// Exact match.
+		locale_compare_cache.set(cache_key, 10);
 		return 10;
 	}
 
 	Vector<String> locale_a_elements = locale_a.split("_");
 	Vector<String> locale_b_elements = locale_b.split("_");
-	if (locale_a_elements[0] == locale_b_elements[0]) {
-		// Matching language, both locales have extra parts.
-		// Return number of matching elements.
-		int matching_elements = 1;
-		for (int i = 1; i < locale_a_elements.size(); i++) {
-			for (int j = 1; j < locale_b_elements.size(); j++) {
-				if (locale_a_elements[i] == locale_b_elements[j]) {
-					matching_elements++;
-				}
-			}
-		}
-		return matching_elements;
-	} else {
+	if (locale_a_elements[0] != locale_b_elements[0]) {
 		// No match.
+		locale_compare_cache.set(cache_key, 0);
 		return 0;
 	}
+
+	// Matching language, both locales have extra parts.
+	// Return number of matching elements.
+	int matching_elements = 1;
+	for (int i = 1; i < locale_a_elements.size(); i++) {
+		for (int j = 1; j < locale_b_elements.size(); j++) {
+			if (locale_a_elements[i] == locale_b_elements[j]) {
+				matching_elements++;
+			}
+		}
+	}
+	locale_compare_cache.set(cache_key, matching_elements);
+	return matching_elements;
 }
 
 String TranslationServer::get_locale_name(const String &p_locale) const {

--- a/core/translation.h
+++ b/core/translation.h
@@ -87,6 +87,8 @@ class TranslationServer : public Object {
 	Ref<Translation> tool_translation;
 	Ref<Translation> doc_translation;
 
+	mutable HashMap<String, int> locale_compare_cache;
+
 	bool enabled;
 
 	static TranslationServer *singleton;


### PR DESCRIPTION
Resolves #98228

The score for the match between two locales does not change with external circumstances. We can cache the result to avoid doing heavy string operations like `split()` repeatedly.

FPS is about seven times what it was before the change using the MRP [here](https://github.com/godotengine/godot/issues/98228#issuecomment-2416576623):

| Build | Before | After |
|---|---|---|
| dev       | 3    | 23  |
| release | 30 | 210 |