### PR TITLE
Implement editor indent settings per project (type and size)

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "code_editor.h"
 
+#include "core/config/project_settings.h"
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/string/string_builder.h"
@@ -1599,6 +1600,9 @@ void CodeTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
 
 void CodeTextEditor::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &CodeTextEditor::update_editor_settings));
+		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			if (toggle_scripts_button->is_visible()) {
 				update_toggle_scripts_button();
@@ -1748,6 +1752,12 @@ float CodeTextEditor::get_zoom_factor() {
 }
 
 void CodeTextEditor::_bind_methods() {
+	EditorSettings *ed = EditorSettings::get_singleton();
+	int default_indent_type = ed->get("editor/text_editor/behavior/indent/type");
+	int default_indent_size = ed->get("text_editor/behavior/indent/size");
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/text_editor/behavior/indent/type", PROPERTY_HINT_ENUM, "Tabs,Spaces"), default_indent_type);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/text_editor/behavior/indent/size", PROPERTY_HINT_RANGE, "1,64,1"), default_indent_size);
+
 	ADD_SIGNAL(MethodInfo("validate_script"));
 	ADD_SIGNAL(MethodInfo("load_theme_settings"));
 	ADD_SIGNAL(MethodInfo("show_errors_panel"));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1419,8 +1419,10 @@ Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_re
 }
 
 Variant _EDITOR_GET(const String &p_setting) {
-	ERR_FAIL_COND_V(!EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting), Variant());
-	return EditorSettings::get_singleton()->get(p_setting);
+	String project_override_setting = String("editor/" + p_setting);
+	ERR_FAIL_COND_V(!ProjectSettings::get_singleton() || !EditorSettings::get_singleton() || !EditorSettings::get_singleton()->has_setting(p_setting), Variant());
+	Variant def_val = EditorSettings::get_singleton()->get(p_setting);
+	return ProjectSettings::get_singleton()->get_setting(project_override_setting, def_val);
 }
 
 bool EditorSettings::_property_can_revert(const StringName &p_name) const {


### PR DESCRIPTION
Closes #80763. 

About PR #69012.  Indentation settings (type and size) are part of a coding style / standard, not just an user settings. So they should be configured also per project. The rest of the editor settings are mostly user preferences, which should not be overridden in project settings (no one will be pleased when somebody will destroy his editor UX). 

So my approach is to prepare a curated list of overridable editor settings, which are mostly related to coding style/standard. This PR adds possibilty to configure indent type and size - a base and most important factors of a coding style related to a project.

EDIT: Going that way we can use better wording, i.e. prefix these settings with `coding_style` instead of `editor` (i.e. `coding_style/indent/type` and `coding_style/indent/size`), but this will introduce a new method for accessing editor settings related to the coding style (like _CODING_STYLE_GET instead of a modified _EDITOR_GET) 

![image](https://github.com/user-attachments/assets/94c91813-0621-4349-9e22-b939c1ba525f)
