### PR TITLE
Fix wording in description of `store_line` and `store_string`

### DIFF
--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -474,7 +474,7 @@
 			<return type="void" />
 			<param index="0" name="line" type="String" />
 			<description>
-				Appends [param line] to the file followed by a line return character ([code]\n[/code]), encoding the text as UTF-8.
+				Stores [param line] in the file followed by a newline character ([code]\n[/code]), encoding the text as UTF-8.
 			</description>
 		</method>
 		<method name="store_pascal_string">
@@ -496,7 +496,7 @@
 			<return type="void" />
 			<param index="0" name="string" type="String" />
 			<description>
-				Appends [param string] to the file without a line return, encoding the text as UTF-8.
+				Stores [param string] in the file without a newline character ([code]\n[/code]), encoding the text as UTF-8.
 				[b]Note:[/b] This method is intended to be used to write text files. The string is stored as a UTF-8 encoded buffer without string length or terminating zero, which means that it can't be loaded back easily. If you want to store a retrievable string in a binary file, consider using [method store_pascal_string] instead. For retrieving strings from a text file, you can use [code]get_buffer(length).get_string_from_utf8()[/code] (if you know the length) or [method get_as_text].
 			</description>
 		</method>


### PR DESCRIPTION
As pointed out by https://github.com/godotengine/godot-docs-user-notes/discussions/200#discussioncomment-10941053, using "Append" here creates confusion. It was changed in #42442.

This PR changes it back to "Store", like how other `store_*()` methods are described.