### PR TITLE
Make PopupMenu hide after its parent window loss focus

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -650,6 +650,10 @@
 		<member name="hide_on_item_selection" type="bool" setter="set_hide_on_item_selection" getter="is_hide_on_item_selection" default="true">
 			If [code]true[/code], hides the [PopupMenu] when an item is selected.
 		</member>
+		<member name="hide_on_parent_unfocused" type="bool" setter="set_hide_on_parent_unfocused" getter="is_hide_on_parent_unfocused" default="true">
+			If [code]true[/code], hides the [PopupMenu] when its transient parent loses focus.
+			[b]Note:[/b] On Windows and macOS popups automatically hides themselves after minimizing their parent window.
+		</member>
 		<member name="hide_on_state_item_selection" type="bool" setter="set_hide_on_state_item_selection" getter="is_hide_on_state_item_selection" default="false">
 			If [code]true[/code], hides the [PopupMenu] when a state item is selected.
 		</member>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -709,6 +709,8 @@
 			If [code]true[/code], the [Window] will override the OS window style to display sharp corners.
 			[b]Note:[/b] This property is implemented only on Windows (11).
 			[b]Note:[/b] This property only works with native windows.
+		<member name="return_to_transient" type="bool" setter = "set_return_to_transient" getter="is_return_to_transient" default="false">
+			If [code]true[/code], the [Window] will return to its transient parent after closing.
 		</member>
 		<member name="size" type="Vector2i" setter="set_size" getter="get_size" default="Vector2i(100, 100)">
 			The window's size in pixels.

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -463,6 +463,12 @@ void PopupMenu::_parent_focused() {
 	}
 }
 
+void PopupMenu::_parent_unfocused() {
+	if (hide_on_parent_unfocused && !is_embedded()) {
+		hide();
+	}
+}
+
 void PopupMenu::_submenu_timeout() {
 	if (mouse_over == submenu_over) {
 		_activate_submenu(mouse_over);
@@ -1221,6 +1227,10 @@ void PopupMenu::_notification(int p_what) {
 			if (system_menu_id != NativeMenu::INVALID_MENU_ID) {
 				unbind_global_menu();
 			}
+
+			if (Window *p = get_transient_parent()) {
+				p->disconnect(SceneStringName(focus_exited), callable_mp(this, &PopupMenu::_parent_unfocused));
+			}
 			[[fallthrough]];
 		}
 
@@ -1311,6 +1321,10 @@ void PopupMenu::_notification(int p_what) {
 			}
 			if (system_menu_id != NativeMenu::INVALID_MENU_ID) {
 				bind_global_menu();
+			}
+
+			if (Window *p = get_transient_parent()) {
+				p->connect(SceneStringName(focus_exited), callable_mp(this, &PopupMenu::_parent_unfocused));
 			}
 		} break;
 
@@ -2993,6 +3007,14 @@ bool PopupMenu::is_hide_on_checkable_item_selection() const {
 	return hide_on_checkable_item_selection;
 }
 
+void PopupMenu::set_hide_on_parent_unfocused(bool p_enabled) {
+	hide_on_parent_unfocused = p_enabled;
+}
+
+bool PopupMenu::is_hide_on_parent_unfocused() const {
+	return hide_on_parent_unfocused;
+}
+
 void PopupMenu::set_hide_on_multistate_item_selection(bool p_enabled) {
 	hide_on_multistate_item_selection = p_enabled;
 }
@@ -3199,6 +3221,9 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hide_on_checkable_item_selection", "enable"), &PopupMenu::set_hide_on_checkable_item_selection);
 	ClassDB::bind_method(D_METHOD("is_hide_on_checkable_item_selection"), &PopupMenu::is_hide_on_checkable_item_selection);
 
+	ClassDB::bind_method(D_METHOD("set_hide_on_parent_unfocused", "enable"), &PopupMenu::set_hide_on_parent_unfocused);
+	ClassDB::bind_method(D_METHOD("is_hide_on_parent_unfocused"), &PopupMenu::is_hide_on_parent_unfocused);
+
 	ClassDB::bind_method(D_METHOD("set_hide_on_state_item_selection", "enable"), &PopupMenu::set_hide_on_multistate_item_selection);
 	ClassDB::bind_method(D_METHOD("is_hide_on_state_item_selection"), &PopupMenu::is_hide_on_multistate_item_selection);
 
@@ -3214,6 +3239,7 @@ void PopupMenu::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_item_selection"), "set_hide_on_item_selection", "is_hide_on_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_checkable_item_selection"), "set_hide_on_checkable_item_selection", "is_hide_on_checkable_item_selection");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_parent_unfocused"), "set_hide_on_parent_unfocused", "is_hide_on_parent_unfocused");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_state_item_selection"), "set_hide_on_state_item_selection", "is_hide_on_state_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "submenu_popup_delay", PROPERTY_HINT_NONE, "suffix:s"), "set_submenu_popup_delay", "get_submenu_popup_delay");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_search"), "set_allow_search", "get_allow_search");

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -162,6 +162,7 @@ class PopupMenu : public Popup {
 	bool hide_on_item_selection = true;
 	bool hide_on_checkable_item_selection = true;
 	bool hide_on_multistate_item_selection = false;
+	bool hide_on_parent_unfocused = true;
 	Vector2 moved;
 
 	HashMap<Ref<Shortcut>, int> shortcut_refcount;
@@ -240,6 +241,7 @@ class PopupMenu : public Popup {
 	void _native_popup(const Rect2i &p_rect);
 	String _atr(int p_idx, const String &p_text) const;
 	void _submenu_hidden();
+	void _parent_unfocused();
 
 protected:
 	virtual void _pre_popup() override;
@@ -398,6 +400,9 @@ public:
 
 	void set_hide_on_checkable_item_selection(bool p_enabled);
 	bool is_hide_on_checkable_item_selection() const;
+
+	void set_hide_on_parent_unfocused(bool p_enabled);
+	bool is_hide_on_parent_unfocused() const;
 
 	void set_hide_on_multistate_item_selection(bool p_enabled);
 	bool is_hide_on_multistate_item_selection() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -718,7 +718,7 @@ void Window::_clear_window() {
 	window_id = DisplayServer::INVALID_WINDOW_ID;
 
 	// If closing window was focused and has a parent, return focus.
-	if (had_focus && transient_parent) {
+	if (return_to_transient && had_focus && transient_parent) {
 		transient_parent->grab_focus();
 	}
 
@@ -1094,6 +1094,16 @@ void Window::set_transient_to_focused(bool p_transient_to_focused) {
 bool Window::is_transient_to_focused() const {
 	ERR_READ_THREAD_GUARD_V(false);
 	return transient_to_focused;
+}
+
+void Window::set_return_to_transient(bool p_return_to_transient) {
+	ERR_MAIN_THREAD_GUARD;
+	return_to_transient = p_return_to_transient;
+}
+
+bool Window::is_return_to_transient() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return return_to_transient;
 }
 
 void Window::set_exclusive(bool p_exclusive) {
@@ -1892,6 +1902,10 @@ Window *Window::get_parent_visible_window() const {
 		vp = vp->get_parent()->get_viewport();
 	}
 	return window;
+}
+
+Window *Window::get_transient_parent() const {
+	return transient_parent;
 }
 
 void Window::popup_on_parent(const Rect2i &p_parent_rect) {
@@ -3203,6 +3217,9 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_transient_to_focused", "enable"), &Window::set_transient_to_focused);
 	ClassDB::bind_method(D_METHOD("is_transient_to_focused"), &Window::is_transient_to_focused);
 
+	ClassDB::bind_method(D_METHOD("set_return_to_transient", "enable"), &Window::set_return_to_transient);
+	ClassDB::bind_method(D_METHOD("is_return_to_transient"), &Window::is_return_to_transient);
+
 	ClassDB::bind_method(D_METHOD("set_exclusive", "exclusive"), &Window::set_exclusive);
 	ClassDB::bind_method(D_METHOD("is_exclusive"), &Window::is_exclusive);
 
@@ -3353,6 +3370,7 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "wrap_controls"), "set_wrap_controls", "is_wrapping_controls");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transient"), "set_transient", "is_transient");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transient_to_focused"), "set_transient_to_focused", "is_transient_to_focused");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "return_to_transient"), "set_return_to_transient", "is_return_to_transient");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exclusive"), "set_exclusive", "is_exclusive");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "unresizable"), "set_flag", "get_flag", FLAG_RESIZE_DISABLED);
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "borderless"), "set_flag", "get_flag", FLAG_BORDERLESS);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -136,6 +136,7 @@ private:
 
 	bool transient = false;
 	bool transient_to_focused = false;
+	bool return_to_transient = false;
 	bool exclusive = false;
 	bool wrap_controls = false;
 	bool updating_child_controls = false;
@@ -357,6 +358,9 @@ public:
 	void set_transient_to_focused(bool p_transient_to_focused);
 	bool is_transient_to_focused() const;
 
+	void set_return_to_transient(bool p_return_to_transient);
+	bool is_return_to_transient() const;
+
 	void set_exclusive(bool p_exclusive);
 	bool is_exclusive() const;
 
@@ -408,6 +412,7 @@ public:
 	Window *get_parent_visible_window() const;
 	Window *get_non_popup_window() const;
 	Viewport *get_parent_viewport() const;
+	Window *get_transient_parent() const;
 
 	virtual void popup(const Rect2i &p_screen_rect = Rect2i());
 	void popup_on_parent(const Rect2i &p_parent_rect);


### PR DESCRIPTION
Previously `PopupMenu`s were still on screen after their parent was minimized. It was quite annoying, especially in *Editor*, because it limits its fps to 1 per second when minimized, even if one of the popup menus is still visible. It's also worth mentioning that no other app I use behaves like this. Their popups always hide after minimizing the main window or they can't just be minimized while popup is visible.

# Before
https://github.com/user-attachments/assets/632e1957-c731-46b6-8749-e64a220e4fe9

# After
https://github.com/user-attachments/assets/6d9b0e1e-421f-495f-b422-0267a104f8a2

I decided to fix this  by adding two flags which are also visible from scripts:
* `Window::return_to_transient` (default: `false`)
* `PopupMenu::hide_on_parent_unfocused` (default: `true`)

Also I had to add auxiliary const method `Window::get_transient_parent()` to be able to use the "focus_exited" signal of the parent window from its child popup.

Previous behavior can be achieved by setting `return_to_transient` to `true` and `hide_on_parent_unfocused` to `false`.

Three things I'm not sure about are:
* naming of the `PopupMenu::hide_on_parent_unfocused` and related stuff (I chose this name because there is `Popup::_parent_focused()` method.
* using thread guards in setter and getter of the `Window::return_to_transient` flag. Honestly, I don't even know what exactly do `ERR_MAIN_THREAD_GUARD` and `ERR_READ_THREAD_GUARD_V` macros do
* Haven't tested on .NET version of Godot.