### PR TITLE
Don't create rendering device or parse glsl shader in headless mode

### DIFF
--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -36,11 +36,16 @@
 
 #include "bc1.glsl.gen.h"
 #include "bc6h.glsl.gen.h"
+#include "servers/display_server.h"
 
 static Mutex betsy_mutex;
 static BetsyCompressor *betsy = nullptr;
 
 void BetsyCompressor::_init() {
+	if (!DisplayServer::can_create_rendering_device()) {
+		return;
+	}
+
 	// Create local RD.
 	RenderingContextDriver *rcd = nullptr;
 	RenderingDevice *rd = RenderingServer::get_singleton()->create_local_rendering_device();
@@ -176,6 +181,11 @@ static String get_shader_name(BetsyFormat p_format) {
 
 Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 	uint64_t start_time = OS::get_singleton()->get_ticks_msec();
+
+	// Return an error so that the compression can fall back to cpu compression
+	if (compress_rd == nullptr) {
+		return ERR_CANT_CREATE;
+	}
 
 	if (r_img->is_compressed()) {
 		return ERR_INVALID_DATA;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -1229,6 +1229,10 @@ void DisplayServer::_input_set_custom_mouse_cursor_func(const Ref<Resource> &p_i
 }
 
 bool DisplayServer::can_create_rendering_device() {
+	if (get_singleton()->get_name() == "headless") {
+		return false;
+	}
+
 #if defined(RD_ENABLED)
 	RenderingDevice *device = RenderingDevice::get_singleton();
 	if (device) {

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -31,7 +31,10 @@
 #include "rendering_device_binds.h"
 
 Error RDShaderFile::parse_versions_from_text(const String &p_text, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata) {
-	ERR_FAIL_NULL_V(RenderingDevice::get_singleton(), ERR_UNAVAILABLE);
+	ERR_FAIL_NULL_V_MSG(
+			RenderingDevice::get_singleton(),
+			ERR_UNAVAILABLE,
+			"Cannot import custom .glsl shaders when running without a RenderingDevice. This can happen if you are using the headless more or the Compatibility backend.");
 
 	Vector<String> lines = p_text.split("\n");
 


### PR DESCRIPTION
This PR resolves: https://github.com/godotengine/godot/issues/98246

It appears that some recent code changes were made that parse glsl shaders in new locations as well as some logic surrounding ``DisplayServer::can_create_rendering_device``.  Both of which introduced problems when running on a machine that does not have a gpu.  This may not be the correct solution so please leave your comments and / or open a different pr with the proper fix.  This at least fixed it for me though.  Without further ado, here is the explanation for my changes:


```cpp
bool DisplayServer::can_create_rendering_device() {
	if (get_singleton()->get_name() == "headless") {
		return false;
	}
```

^ We can't create a DisplayServer in headless mode... at least I don't think we can.  I'm mostly going off my intuitive understanding of the word ``Display`` and regarding the fact that there is no display on a headless server without a gpu.  But that is grammatical rather than technical reasoning which I know does not necessarily apply in the world of software.

```cpp
void BetsyCompressor::_init() {
	if (!DisplayServer::can_create_rendering_device()) {
		return;
	}
```

^ Don't try to initalize a new BetsyCompressor in headless mode.  I found that for whatever reason, BetsyCompressor was trying to hook into the gpu on my device and crashing if it couldn't find one.  This may or may not be the correct solution.

```
Error RDShaderFile::parse_versions_from_text(const String &p_text, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata) {
	ERR_FAIL_COND_V_EDMSG((DisplayServer::get_singleton()->get_name() == "headless"), ERR_UNAVAILABLE, "Cannot import custom .glsl shaders when running in headless mode.");
	ERR_FAIL_NULL_V(RenderingDevice::get_singleton(), ERR_UNAVAILABLE);
```

^ This is really the only change that I'm fairly confident in.  I actually copied this ``ERROR_FAIL`` from a different area of code that prevents glsl imports in headless mode

https://github.com/godotengine/godot/blob/04692d83cb8f61002f18ea1d954df8c558ee84f7/editor/import/resource_importer_shader_file.cpp#L95

And if you notice, that is actually preventing ``shader_file->parse_versions_from_text`` from being called on line 106: https://github.com/godotengine/godot/blob/04692d83cb8f61002f18ea1d954df8c558ee84f7/editor/import/resource_importer_shader_file.cpp#L106C8-L106C44

This is introduces a crash.  So we might as well copy that check to the root cause method as well for stability purposes.  Which is what I did in my change :)

**NOTE:**

The change I said I was "confident in" will no longer be necessary when this issue gets resolved: https://github.com/godotengine/godot/issues/94734

Which also happens to be an issue I opened 😎.  But until then, this change is necessary to prevent crashes and increase stability.

I look forward to hearing your guys thoughts!  As always, thanks for the awesome engine! :)