### PR TITLE
Expose `EditorExport` through the `EditorInterface` singleton

### DIFF
--- a/doc/classes/EditorExport.xml
+++ b/doc/classes/EditorExport.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorExport" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Hosts data related to a project's export configuration.
+	</brief_description>
+	<description>
+		Editor-only singleton that hosts a project's [EditorExportPlatform], [EditorExportPreset], and [EditorExportPlugin] objects. Use this class to retrieve information about a project's export configuration.
+	</description>
+	<tutorials>
+		<link title="Export">$DOCS_URL/tutorials/export/index.html</link>
+	</tutorials>
+	<methods>
+		<method name="get_export_platform">
+			<return type="EditorExportPlatform" />
+			<param index="0" name="idx" type="int" />
+			<description>
+				Returns the [EditorExportPlatform] at index [param idx]. [param idx] must be equal to or greater than [code]0[/code] and less than the result of [method get_export_platform_count].
+			</description>
+		</method>
+		<method name="get_export_platform_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of unique platforms available for export. This includes platforms that do not have an export preset in the current project.
+			</description>
+		</method>
+		<method name="get_export_preset">
+			<return type="EditorExportPreset" />
+			<param index="0" name="idx" type="int" />
+			<description>
+				Returns the [EditorExportPreset] at index [param idx]. [param idx] must be equal to or greater than [code]0[/code] and less than the result of [method get_export_preset_count].
+			</description>
+		</method>
+		<method name="get_export_preset_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of export presets in the project.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="export_presets_runnable_updated">
+			<description>
+				Emitted when the [code]runnable[/code] property of an [EditorExportPreset] has been updated or when an [EditorExportPreset] has been added to or removed from the project.
+			</description>
+		</signal>
+		<signal name="export_presets_updated">
+			<description>
+				Emitted when the properties of an [EditorExportPreset] have been updated.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -158,6 +158,20 @@
 				Returns the name of the export operating system handled by this [EditorExportPlatform] class, as a friendly string. Possible return values are [code]Windows[/code], [code]Linux[/code], [code]macOS[/code], [code]Android[/code], [code]iOS[/code], and [code]Web[/code].
 			</description>
 		</method>
+		<method name="get_platform_features" qualifiers="const">
+			<return type="String[]" />
+			<description>
+				Returns feature tags that are specific to the export platform. Some feature tags that may be included in this list are [code]mobile[/code], [code]pc[/code], [code]web[/code], [code]android[/code], [code]ios[/code], [code]linux[/code], [code]macos[/code], and [code]windows[/code].
+			</description>
+		</method>
+		<method name="get_preset_features" qualifiers="const">
+			<return type="String[]" />
+			<param index="0" name="preset" type="EditorExportPreset" />
+			<description>
+				Returns feature tags that are specific to [param preset], excluding custom features. Some feature tags that may be included in this list are texture formats ([code]etc2[/code], [code]bptc[/code], [code]s3tc[/code]), architectures ([code]x86_64[/code], [code]x86_32[/code], [code]arm64[/code], [code]arm32[/code], [code]rv64[/code], [code]riscv[/code], [code]ppc64[/code], [code]ppc[/code], [code]wasm32[/code], [code]wasm64[/code], [code]universal[/code]), and other features ([code]threads[/code], [code]nothreads[/code]).
+				Use [method EditorExportPreset.get_custom_features] to get the custom features of an export preset.
+			</description>
+		</method>
 		<method name="get_worst_message_type" qualifiers="const">
 			<return type="int" enum="EditorExportPlatform.ExportMessageType" />
 			<description>

--- a/doc/classes/EditorExportPreset.xml
+++ b/doc/classes/EditorExportPreset.xml
@@ -115,6 +115,12 @@
 				Returns the list of packs on which to base a patch export on.
 			</description>
 		</method>
+		<method name="get_platform" qualifiers="const">
+			<return type="EditorExportPlatform" />
+			<description>
+				Returns the [EditorExportPlatform] for this export preset.
+			</description>
+		</method>
 		<method name="get_preset_name" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -83,6 +83,12 @@
 				Returns the edited (current) scene's root [Node].
 			</description>
 		</method>
+		<method name="get_editor_export" qualifiers="const">
+			<return type="EditorExport" />
+			<description>
+				Returns the [EditorExport] singleton.
+			</description>
+		</method>
 		<method name="get_editor_main_screen" qualifiers="const">
 			<return type="VBoxContainer" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -93,6 +93,10 @@ EditorUndoRedoManager *EditorInterface::get_editor_undo_redo() const {
 	return EditorUndoRedoManager::get_singleton();
 }
 
+EditorExport *EditorInterface::get_editor_export() const {
+	return EditorExport::get_singleton();
+}
+
 TypedArray<Texture2D> EditorInterface::_make_mesh_previews(const TypedArray<Mesh> &p_meshes, int p_preview_size) {
 	Vector<Ref<Mesh>> meshes;
 
@@ -557,6 +561,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
 	ClassDB::bind_method(D_METHOD("get_editor_undo_redo"), &EditorInterface::get_editor_undo_redo);
+	ClassDB::bind_method(D_METHOD("get_editor_export"), &EditorInterface::get_editor_export);
 
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -46,6 +46,7 @@ class EditorResourcePreview;
 class EditorSelection;
 class EditorSettings;
 class EditorUndoRedoManager;
+class EditorExport;
 class FileSystemDock;
 class Mesh;
 class Node;
@@ -103,6 +104,7 @@ public:
 	EditorSelection *get_selection() const;
 	Ref<EditorSettings> get_editor_settings() const;
 	EditorUndoRedoManager *get_editor_undo_redo() const;
+	EditorExport *get_editor_export() const;
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
 

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -120,8 +120,16 @@ void EditorExport::emit_presets_runnable_changed() {
 }
 
 void EditorExport::_bind_methods() {
+	_export_presets_updated = StringName("export_presets_updated", true);
+	_export_presets_runnable_updated = StringName("export_presets_runnable_updated", true);
+
 	ADD_SIGNAL(MethodInfo(_export_presets_updated));
 	ADD_SIGNAL(MethodInfo(_export_presets_runnable_updated));
+
+	ClassDB::bind_method(D_METHOD("get_export_platform_count"), &EditorExport::get_export_platform_count);
+	ClassDB::bind_method(D_METHOD("get_export_platform", "idx"), &EditorExport::get_export_platform);
+	ClassDB::bind_method(D_METHOD("get_export_preset_count"), &EditorExport::get_export_preset_count);
+	ClassDB::bind_method(D_METHOD("get_export_preset", "idx"), &EditorExport::get_export_preset);
 }
 
 void EditorExport::add_export_platform(const Ref<EditorExportPlatform> &p_platform) {
@@ -139,7 +147,7 @@ void EditorExport::remove_export_platform(const Ref<EditorExportPlatform> &p_pla
 	should_reload_presets = true;
 }
 
-int EditorExport::get_export_platform_count() {
+int EditorExport::get_export_platform_count() const {
 	return export_platforms.size();
 }
 
@@ -441,9 +449,6 @@ EditorExport::EditorExport() {
 	save_timer->set_wait_time(0.8);
 	save_timer->set_one_shot(true);
 	save_timer->connect("timeout", callable_mp(this, &EditorExport::_save));
-
-	_export_presets_updated = StringName("export_presets_updated", true);
-	_export_presets_runnable_updated = StringName("export_presets_runnable_updated", true);
 
 	singleton = this;
 	set_process(true);

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -65,7 +65,7 @@ public:
 	static EditorExport *get_singleton() { return singleton; }
 
 	void add_export_platform(const Ref<EditorExportPlatform> &p_platform);
-	int get_export_platform_count();
+	int get_export_platform_count() const;
 	Ref<EditorExportPlatform> get_export_platform(int p_idx);
 	void remove_export_platform(const Ref<EditorExportPlatform> &p_platform);
 

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -530,6 +530,26 @@ HashSet<String> EditorExportPlatform::get_features(const Ref<EditorExportPreset>
 	return result;
 }
 
+TypedArray<String> EditorExportPlatform::get_platform_features_as_array() const {
+	List<String> feature_list;
+	get_platform_features(&feature_list);
+	TypedArray<String> result;
+	for (const String &E : feature_list) {
+		result.push_back(E);
+	}
+	return result;
+}
+
+TypedArray<String> EditorExportPlatform::get_preset_features_as_array(const Ref<EditorExportPreset> &p_preset) const {
+	List<String> feature_list;
+	get_preset_features(p_preset, &feature_list);
+	TypedArray<String> result;
+	for (const String &E : feature_list) {
+		result.push_back(E);
+	}
+	return result;
+}
+
 EditorExportPlatform::ExportNotifier::ExportNotifier(EditorExportPlatform &p_platform, const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	HashSet<String> features = p_platform.get_features(p_preset, p_debug);
 	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
@@ -2294,6 +2314,9 @@ void EditorExportPlatform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("ssh_run_on_remote", "host", "port", "ssh_arg", "cmd_args", "output", "port_fwd"), &EditorExportPlatform::_ssh_run_on_remote, DEFVAL(Array()), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("ssh_run_on_remote_no_wait", "host", "port", "ssh_args", "cmd_args", "port_fwd"), &EditorExportPlatform::_ssh_run_on_remote_no_wait, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("ssh_push_to_remote", "host", "port", "scp_args", "src_file", "dst_file"), &EditorExportPlatform::ssh_push_to_remote);
+
+	ClassDB::bind_method(D_METHOD("get_platform_features"), &EditorExportPlatform::get_platform_features_as_array);
+	ClassDB::bind_method(D_METHOD("get_preset_features", "preset"), &EditorExportPlatform::get_preset_features_as_array);
 
 	ClassDB::bind_static_method("EditorExportPlatform", D_METHOD("get_forced_export_files"), &EditorExportPlatform::get_forced_export_files);
 

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -197,6 +197,8 @@ protected:
 	void _unload_patches();
 
 public:
+	TypedArray<String> get_platform_features_as_array() const;
+	TypedArray<String> get_preset_features_as_array(const Ref<EditorExportPreset> &p_preset) const;
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const = 0;
 
 	struct ExportOption {

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -65,6 +65,8 @@ void EditorExportPreset::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has", "property"), &EditorExportPreset::has);
 
+	ClassDB::bind_method(D_METHOD("get_platform"), &EditorExportPreset::get_platform);
+
 	ClassDB::bind_method(D_METHOD("get_files_to_export"), &EditorExportPreset::get_files_to_export);
 	ClassDB::bind_method(D_METHOD("get_customized_files"), &EditorExportPreset::get_customized_files);
 	ClassDB::bind_method(D_METHOD("get_customized_files_count"), &EditorExportPreset::get_customized_files_count);

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -45,6 +45,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_translation_parser.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/export/editor_export.h"
 #include "editor/export/editor_export_platform.h"
 #include "editor/export/editor_export_platform_extension.h"
 #include "editor/export/editor_export_platform_pc.h"
@@ -158,6 +159,7 @@ void register_editor_types() {
 	GDREGISTER_ABSTRACT_CLASS(ScriptEditorBase);
 	GDREGISTER_CLASS(EditorSyntaxHighlighter);
 	GDREGISTER_ABSTRACT_CLASS(EditorInterface);
+	GDREGISTER_ABSTRACT_CLASS(EditorExport);
 	GDREGISTER_CLASS(EditorExportPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatform);
 	GDREGISTER_ABSTRACT_CLASS(EditorExportPlatformPC);


### PR DESCRIPTION
Exposes `EditorExport` through the `EditorInterface` singleton. Also exposes functions relating to feature tags of platforms and presets, similar to the existing [`EditorExportPreset.get_custom_features()`](https://docs.godotengine.org/en/latest/classes/class_editorexportpreset.html#class-editorexportpreset-method-get-custom-features) function.

**Background**
Many properties of `EditorExportPlatform` `EditorExportPreset` and have been exposed in #90782, but it is currently not possible to iterate through these in some types of editor plugins and tools. Many of the newly exposed properties could be used in editor tools, such as my [Resource Remaps](https://github.com/allenwp/godot-resource-remaps) plugin, which loads custom and platform feature tags.

**Related PRs**
Feature tags in scripting: #86747

**Implementation**
I have kept the scripting API similar to the C++ API, but that does mean there are some style differences between getting custom features (existing function that returns a comma delimited `String`) and getting the platform/preset features (new functions that return a `TypedArray<String>`).