### PR TITLE
Don't pseudolocalize empty strings

### DIFF
--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -389,6 +389,10 @@ void TranslationDomain::set_pseudolocalization_suffix(const String &p_suffix) {
 }
 
 StringName TranslationDomain::pseudolocalize(const StringName &p_message) const {
+	if (p_message.is_empty()) {
+		return p_message;
+	}
+
 	String message = p_message;
 	int length = message.length();
 	if (pseudolocalization.override_enabled) {


### PR DESCRIPTION
Originally brought up [here](https://github.com/godotengine/godot/pull/96230#issuecomment-2364511689).

Example of unwanted pseudolocalizations:

- Icon only buttons.
- Empty placeholder texts.
- Regular menu separator (without text).