### PR TITLE
Clarify that switching animation won't emit `animation_finished`

### DIFF
--- a/doc/classes/AnimationMixer.xml
+++ b/doc/classes/AnimationMixer.xml
@@ -318,6 +318,7 @@
 			<description>
 				Notifies when an animation finished playing.
 				[b]Note:[/b] This signal is not emitted if an animation is looping.
+				[b]Note:[/b] This signal is not emitted when switching to another animation during playback.
 			</description>
 		</signal>
 		<signal name="animation_libraries_updated">


### PR DESCRIPTION
Some users expect that `animation_finished` will be emitted when switching animation in the middle of playback.