### PR TITLE
Fix to occlusion culling where all math is based on Euclidean distance.

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -181,17 +181,7 @@ void RaycastOcclusionCull::RaycastHZBuffer::sort_rays(const Vector3 &p_camera_di
 					}
 					int k = tile_i * TILE_SIZE + tile_j;
 					int tile_index = i * tile_grid_size.x + j;
-					float d = camera_rays[tile_index].ray.tfar[k];
-
-					if (!p_orthogonal) {
-						const float &dir_x = camera_rays[tile_index].ray.dir_x[k];
-						const float &dir_y = camera_rays[tile_index].ray.dir_y[k];
-						const float &dir_z = camera_rays[tile_index].ray.dir_z[k];
-						float cos_theta = p_camera_dir.x * dir_x + p_camera_dir.y * dir_y + p_camera_dir.z * dir_z;
-						d *= cos_theta;
-					}
-
-					mips[0][y * buffer_size.x + x] = d;
+					mips[0][y * buffer_size.x + x] = camera_rays[tile_index].ray.tfar[k];
 				}
 			}
 		}

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -72,7 +72,7 @@ public:
 				return false;
 			}
 
-			float min_depth = -closest_point_view.z * 0.95f;
+			float min_depth = (closest_point - p_cam_position).length();
 
 			Vector2 rect_min = Vector2(FLT_MAX, FLT_MAX);
 			Vector2 rect_max = Vector2(FLT_MIN, FLT_MIN);
@@ -82,6 +82,10 @@ public:
 				Vector3 nc = Vector3(1, 1, 1) - c;
 				Vector3 corner = Vector3(p_bounds[0] * c.x + p_bounds[3] * nc.x, p_bounds[1] * c.y + p_bounds[4] * nc.y, p_bounds[2] * c.z + p_bounds[5] * nc.z);
 				Vector3 view = p_cam_inv_transform.xform(corner);
+
+				if (p_cam_projection.is_orthogonal()) {
+					min_depth = MIN(min_depth, view.z);
+				}
 
 				Plane vp = Plane(view, 1.0);
 				Plane projected = p_cam_projection.xform4(vp);


### PR DESCRIPTION
Alternative solution to #94210. Main discussion can be found here #97712

The occlusion culler uses a point to compare with the depth mipmap to determine if an object is occluded or not. The occlusion culler currently chooses the point with the shortest Euclidean distance to the camera. While not entirely inaccurate, it can drift when compared to the actual closest point to the camera in terms of depth.

This inaccuracy increases when an object's AABB is skewed (relative to the camera perspective) and partially occluded by other objects, as seen in the MRP in #94210 and the 2D example below.

![Screenshot from 2024-10-01 21-37-13](https://github.com/user-attachments/assets/1fd72a06-6dd5-46b2-9fef-cdaed8f997fe)

There were two possible solutions to this problem, and this PR implements the first solution.

Possible solutions:
1. Convert the entire occlusion culling algorithm to use Euclidean distance.
2. Select the closest point based on depth. (#97712)

This PR converts the depthmap used for occlusion culling to euclidean distance. Additionally logic is then added for an orthogonal camera. 

_bugsquad edit: Fixes https://github.com/godotengine/godot/issues/94210_