### PR TITLE
Add support for BGRA textures with Texture*RD

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2269,6 +2269,16 @@ void TextureStorage::_texture_format_from_rd(RD::DataFormat p_rd_format, Texture
 			r_format.swizzle_b = RD::TEXTURE_SWIZZLE_B;
 			r_format.swizzle_a = RD::TEXTURE_SWIZZLE_A;
 		} break;
+		case RD::DATA_FORMAT_B8G8R8A8_UNORM:
+		case RD::DATA_FORMAT_B8G8R8A8_SRGB: {
+			r_format.image_format = Image::FORMAT_RGBA8;
+			r_format.rd_format = RD::DATA_FORMAT_B8G8R8A8_UNORM;
+			r_format.rd_format_srgb = RD::DATA_FORMAT_B8G8R8A8_SRGB;
+			r_format.swizzle_r = RD::TEXTURE_SWIZZLE_R;
+			r_format.swizzle_g = RD::TEXTURE_SWIZZLE_G;
+			r_format.swizzle_b = RD::TEXTURE_SWIZZLE_B;
+			r_format.swizzle_a = RD::TEXTURE_SWIZZLE_A;
+		} break;
 		case RD::DATA_FORMAT_B4G4R4A4_UNORM_PACK16: {
 			r_format.image_format = Image::FORMAT_RGBA4444;
 			r_format.rd_format = RD::DATA_FORMAT_B4G4R4A4_UNORM_PACK16;


### PR DESCRIPTION
### Description

Adds the ability to use BGRA textures created with RenderingDevice with classes such as Texture2DRD, which removes the need to unnecessarily convert from BGRA to RGBA.

### Motivation and Context

I am creating a native GDExtension plugin for Godot that allows the ability to capture the screen, or specific windows, or possibly a game, as a texture, which is updated every frame. The over-arching goal is to give streamers the ability to composite their stream almost entirely in Godot if they so choose, allowing the ability for streamers to create some totally sick streamer setups.

However, after getting my plugin working, I noticed that BGRA textures created via `RenderingDevice::texture_create()` are not supported when you use them with `Texture2DRD::set_texture_rd_rid()`, even though they are supported by the device. This seems to be an unnecessary and arbitrary limitation due to the fact that Image::Format enum does not have BGRA.

This fix eliminates a completely unnecessary format conversion when one has a genuine need for BGRA texture support and needs to update textures frequently. Manually converting BGRA to RGBA every frame here would be an absolutely wasteful and pointless performance hit, especially when capturing 4K monitors which have a very large texture size, so I would preferably like to patch Godot to support BGRA so we don't have to do a conversion every frame.

```gd
var rd = RenderingServer.get_rendering_device()
	
var format = RDTextureFormat.new()
format.format = RenderingDevice.DATA_FORMAT_B8G8R8A8_UNORM
# [...]
	
var rd_rid = rd.texture_create(format, RDTextureView.new()) # Succeeds because BGRA is supported here
var tex = Texture2DRD.new()
tex.texture_rd_rid = rd_rid # Failed because BGRA was not supported here
````

### How Has This Been Tested?

I tested this with capturing in real time and it works without issue. This should also not cause any sort of regression or affect anyone else because Godot did not originally allow this before this PR, thus no one's workflows should be affected by this.