### PR TITLE
Remove `s3tc` feature tag from `arm64` macOS exports

### DIFF
--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -155,7 +155,6 @@ public:
 
 	virtual void get_platform_features(List<String> *r_features) const override {
 		r_features->push_back("pc");
-		r_features->push_back("s3tc");
 		r_features->push_back("macos");
 	}
 


### PR DESCRIPTION
The `s3tc` feature tag is [conditionally added as a preset feature for macOS](https://github.com/godotengine/godot/blob/04692d83cb8f61002f18ea1d954df8c558ee84f7/platform/macos/export/export_plugin.cpp#L59-L67), depending on the architecture.

These conditions appear to be accidentally overridden by platform features, which always include this feature.

This PR's change seems correct based on the commit notes of 28f51ba547722d1283882ec5dee9bcab070bc33e, which added the architecture-related conditions. When writing the documentation of #98251 I noticed that macOS was the only platform that included a texture format feature tag, so this alerted me to believe that something was out-of-place. All other texture format feature tags in Godot are added as "preset features", not "platform" features.

This PR does not actually resolve any issues that I am aware of, so this is a hypothetical fix/improvement. Testing of exports on an `arm64` macOS device is needed...