### PR TITLE
Improve `_begin_customize_scenes` description

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -27,6 +27,7 @@
 			<description>
 				Return [code]true[/code] if this plugin will customize scenes based on the platform and features used.
 				When enabled, [method _get_customization_configuration_hash] and [method _customize_scene] will be called and must be implemented.
+				[b]Note:[/b] [method _customize_scene] will only be called for scenes that have been modified since the last export.
 			</description>
 		</method>
 		<method name="_customize_resource" qualifiers="virtual">


### PR DESCRIPTION
This PR Improves `_begin_customize_scenes()` description and clears confusion about `_customize_scene()` not being called.

Closes https://github.com/godotengine/godot/issues/96104
