### PR TITLE
Fix light culling mask behavior in Mobile and Compat renderers

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3036,6 +3036,10 @@ void RendererSceneCull::_scene_cull(CullData &cull_data, InstanceCullResult &cul
 
 						for (const Instance *E : geom->lights) {
 							InstanceLightData *light = static_cast<InstanceLightData *>(E->base_data);
+							if (!(RSG::light_storage->light_get_cull_mask(E->base) & idata.layer_mask)) {
+								continue;
+							}
+
 							instance_pair_buffer[idx++] = light->instance;
 							if (idx == MAX_INSTANCE_PAIRS) {
 								break;


### PR DESCRIPTION
Fixes #94643. Added logic which checks the light's culling mask settings before proceeding with lighting calculations to wherever not present (namely the Forward-Mobile and Compatibility renderers). Just a simple port of the one already used in the Forward-Plus renderer.

Pictures for comparison:

<details>
<summary>MRP:</summary>
Compatibility: <br/>
<img width="577" alt="bug-compat" src="https://github.com/user-attachments/assets/c5715113-ff41-499b-9758-6719442f3356">
<br>Forward+: <br/>
<img width="575" alt="bug-fplus" src="https://github.com/user-attachments/assets/e52828ec-e190-4de0-9ed5-20222c62267c">
<br>Forward-Mobile: <br/>
<img width="573" alt="bug-mobilee" src="https://github.com/user-attachments/assets/8e8d1d75-4428-4070-8149-f7de596eafff">
</details>

<details>
<summary>Fixed:</summary>
Compatibility: <br/>
<img width="576" alt="fix-compat" src="https://github.com/user-attachments/assets/16dfc752-b105-452d-b154-91b07417bf90">
<br>Forward+: <br/>
<img width="575" alt="fix-fplus" src="https://github.com/user-attachments/assets/b4120477-b517-4334-87c6-9cfec2a6ccbb">
<br>Forward-Mobile: <br/>
<img width="577" alt="fix-mobile" src="https://github.com/user-attachments/assets/b132a97a-3dba-479c-943a-72676f9f7e74">

</details>

(Also fixes the bug in editor mode too)

- *Production edit: This closes https://github.com/godotengine/godot/issues/82263.*