### PR TITLE
Add `#error` preprocessor directive to shading language

### DIFF
--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -191,6 +191,7 @@ private:
 	void process_elif(Tokenizer *p_tokenizer);
 	void process_else(Tokenizer *p_tokenizer);
 	void process_endif(Tokenizer *p_tokenizer);
+	void process_error(Tokenizer *p_tokenizer);
 	void process_if(Tokenizer *p_tokenizer);
 	void process_ifdef(Tokenizer *p_tokenizer);
 	void process_ifndef(Tokenizer *p_tokenizer);


### PR DESCRIPTION
`#error` is standard macro from GLSL, so I think it's not a bad idea to implement it to Godot shading language.

![изображение](https://github.com/user-attachments/assets/830d51d4-1517-42ef-a6b2-456708e31aa3)

Also, I've fixed some RTR translations to prevent invalid translation of the macro keywords.