### PR TITLE
Remove unnecessary `reload_from_file` when updating documentation.

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2079,15 +2079,9 @@ void EditorFileSystem::_update_script_documentation() {
 		for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 			ScriptLanguage *lang = ScriptServer::get_language(i);
 			if (lang->supports_documentation() && efd->files[index]->type == lang->get_type()) {
-				bool should_reload_script = _should_reload_script(path);
 				Ref<Script> scr = ResourceLoader::load(path);
 				if (scr.is_null()) {
 					continue;
-				}
-				if (should_reload_script) {
-					// Reloading the script from disk. Otherwise, the ResourceLoader::load will
-					// return the last loaded version of the script (without the modifications).
-					scr->reload_from_file();
 				}
 				for (const DocData::ClassDoc &cd : scr->get_documentation()) {
 					EditorHelp::get_doc_data()->add_doc(cd);
@@ -2107,25 +2101,6 @@ void EditorFileSystem::_update_script_documentation() {
 	memdelete_notnull(ep);
 
 	update_script_paths_documentation.clear();
-}
-
-bool EditorFileSystem::_should_reload_script(const String &p_path) {
-	if (first_scan) {
-		return false;
-	}
-
-	Ref<Script> scr = ResourceCache::get_ref(p_path);
-	if (scr.is_null()) {
-		// Not a script or not already loaded.
-		return false;
-	}
-
-	// Scripts are reloaded via the script editor if they are currently opened.
-	if (ScriptEditor::get_singleton()->get_open_scripts().has(scr)) {
-		return false;
-	}
-
-	return true;
 }
 
 void EditorFileSystem::_process_update_pending() {

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -301,7 +301,6 @@ class EditorFileSystem : public Node {
 	void _update_script_documentation();
 	void _process_update_pending();
 	void _process_removed_files(const HashSet<String> &p_processed_files);
-	bool _should_reload_script(const String &p_path);
 
 	Mutex update_scene_mutex;
 	HashSet<String> update_scene_paths;


### PR DESCRIPTION
After modifying the `.gd` file with an external editor, it triggers `should_reload_script`.
The purpose is to prevent the cached version from being read by the line `Ref<Script> scr = ResourceLoader::load(path);` at line 2082. 
However, now it is already the new script. 
The potentially related PR #97168.