### PR TITLE
Don't override auto translate mode of custom tooltip

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1059,7 +1059,7 @@
 		</member>
 		<member name="tooltip_auto_translate_mode" type="int" setter="set_tooltip_auto_translate_mode" getter="get_tooltip_auto_translate_mode" enum="Node.AutoTranslateMode" default="0">
 			Defines if tooltip text should automatically change to its translated version depending on the current locale. Uses the same auto translate mode as this control when set to [constant Node.AUTO_TRANSLATE_MODE_INHERIT].
-			[b]Note:[/b] When the tooltip is customized using [method _make_custom_tooltip], this auto translate mode is applied automatically to the returned control.
+			[b]Note:[/b] Tooltips customized using [method _make_custom_tooltip] do not use this auto translate mode automatically.
 		</member>
 		<member name="tooltip_text" type="String" setter="set_tooltip_text" getter="get_tooltip_text" default="&quot;&quot;">
 			The default tooltip text. The tooltip appears when the user's mouse cursor stays idle over this control for a few moments, provided that the [member mouse_filter] property is not [constant MOUSE_FILTER_IGNORE]. The time required for the tooltip to appear can be changed with the [member ProjectSettings.gui/timers/tooltip_delay_sec] option. See also [method get_tooltip].

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1478,12 +1478,12 @@ void Viewport::_gui_show_tooltip() {
 		gui.tooltip_label = memnew(Label);
 		gui.tooltip_label->set_theme_type_variation(SNAME("TooltipLabel"));
 		gui.tooltip_label->set_text(gui.tooltip_text);
+		gui.tooltip_label->set_auto_translate_mode(tooltip_owner->get_tooltip_auto_translate_mode());
 		base_tooltip = gui.tooltip_label;
 		panel->connect(SceneStringName(mouse_entered), callable_mp(this, &Viewport::_gui_cancel_tooltip));
 	}
 
 	base_tooltip->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
-	base_tooltip->set_auto_translate_mode(tooltip_owner->get_tooltip_auto_translate_mode());
 
 	panel->set_transient(true);
 	panel->set_flag(Window::FLAG_NO_FOCUS, true);


### PR DESCRIPTION
Currently, `tooltip_auto_translate_mode` is applied to tooltips unconditionally. This is an oversight of #97406.

If `_make_custom_tooltip()` wants to use a fixed auto translate mode, it has to add another layer of control node. This is quite cumbersome and adds unnecessary complexity.

One example is `BaseButton::make_custom_tooltip()`. When `shortcut_in_tooltip` is enabled, tooltip texts are translated manually, so the custom tooltip should always disable auto translate.

This PR makes `tooltip_auto_translate_mode` applied to default tooltip only. Custom tooltips returned by `_make_custom_tooltip()` won't be affected by it.