### PR TITLE
Docs: Add link to 2D lights and shadows from CanvasModulate

### DIFF
--- a/doc/classes/CanvasModulate.xml
+++ b/doc/classes/CanvasModulate.xml
@@ -7,6 +7,7 @@
 		[CanvasModulate] applies a color tint to all nodes on a canvas. Only one can be used to tint a canvas, but [CanvasLayer]s can be used to render things independently.
 	</description>
 	<tutorials>
+		<link title="2D lights and shadows">$DOCS_URL/tutorials/2d/2d_lights_and_shadows.html</link>
 	</tutorials>
 	<members>
 		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(1, 1, 1, 1)" keywords="colour">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/8652.

[2D lights and shadows](https://docs.godotengine.org/en/latest/tutorials/2d/2d_lights_and_shadows.html) is indeed the best (and only) tutorial for use of CanvasModulate.