### PR TITLE
LightmapGI: Clean up and improve lightmap atlas storage

### DIFF
--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -43,8 +43,12 @@ class LightmapGIData : public Resource {
 	GDCLASS(LightmapGIData, Resource);
 	RES_BASE_EXTENSION("lmbake")
 
-	Ref<TextureLayered> light_texture;
-	TypedArray<TextureLayered> light_textures;
+	// The 'merged' texture atlases actually used by the renderer.
+	Ref<TextureLayered> combined_light_texture;
+
+	// The temporary texture atlas arrays which are used for storage.
+	// If a single atlas is too large, it's split and recombined during loading.
+	TypedArray<TextureLayered> storage_light_textures;
 
 	bool uses_spherical_harmonics = false;
 	bool interior = false;
@@ -244,6 +248,8 @@ private:
 
 	void _plot_triangle_into_octree(GenProbesOctree *p_cell, float p_cell_size, const Vector3 *p_triangle);
 	void _gen_new_positions_from_octree(const GenProbesOctree *p_cell, float p_cell_size, const Vector<Vector3> &probe_positions, LocalVector<Vector3> &new_probe_positions, HashMap<Vector3i, bool> &positions_used, const AABB &p_bounds);
+
+	BakeError _save_and_reimport_atlas_textures(const Ref<Lightmapper> p_lightmapper, const String &p_base_name, TypedArray<TextureLayered> &r_textures, bool p_compress = false) const;
 
 protected:
 	void _validate_property(PropertyInfo &p_property) const;


### PR DESCRIPTION
Excerpt from #85653

Godot's lightmap storage has gone through several iterations, with the current one working like this:
Storage-wise, the lightmaps are an array of layered textures. This is due to how layered textures are imported into the engine (A single image is loaded, then split into several smaller ones based on the defined layer count. Since the size limit of an image is 16K, large lightmaps may exceed that limit and the image will fail to load. As a solution, the lightmap textures are split into several layered textures at the end of the baking process). 
When loaded, the engine recombines them into a single layered texture, which is then used for rendering.

The older methods are still kept for compatibility, though the 'old-style' texture references are still saved, which can result in the same image being loaded multiple times.

Additionally, the lightmap exposed in the editor inspector is still the old one, which only allowed a single layered texture.



This PR cleans up some parts of this process, namely by renaming the internal class members to be less confusing, adding comments, as well as ensuring the 'old-style' lightmaps are only loaded, but not saved.
Additionally, a new function was added for the splitting process described above. This will make it easier to add features like shadowmasks or LDR-packed directional data in the future.