### PR TITLE
Fix error when undo tile deletion in TileSetAtlasSourceEditor

### DIFF
--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6480,9 +6480,9 @@ int TileData::get_terrain_set() const {
 }
 
 void TileData::set_terrain(int p_terrain) {
-	ERR_FAIL_COND(terrain_set < 0);
 	ERR_FAIL_COND(p_terrain < -1);
-	if (tile_set) {
+	ERR_FAIL_COND(terrain_set < 0 && p_terrain != -1);
+	if (tile_set && terrain_set >= 0) {
 		ERR_FAIL_COND(p_terrain >= tile_set->get_terrains_count(terrain_set));
 	}
 	terrain = p_terrain;
@@ -6495,9 +6495,9 @@ int TileData::get_terrain() const {
 
 void TileData::set_terrain_peering_bit(TileSet::CellNeighbor p_peering_bit, int p_terrain_index) {
 	ERR_FAIL_INDEX(p_peering_bit, TileSet::CellNeighbor::CELL_NEIGHBOR_MAX);
-	ERR_FAIL_COND(terrain_set < 0);
 	ERR_FAIL_COND(p_terrain_index < -1);
-	if (tile_set) {
+	ERR_FAIL_COND(terrain_set < 0 && p_terrain_index != -1);
+	if (tile_set && terrain_set >= 0) {
 		ERR_FAIL_COND(p_terrain_index >= tile_set->get_terrains_count(terrain_set));
 		ERR_FAIL_COND(!is_valid_terrain_peering_bit(p_peering_bit));
 	}


### PR DESCRIPTION
Undoing tile deletion in `TileSetAtlasSourceEditor` produces this error:

```
ERROR: Condition "terrain_set < 0" is true.
   at: set_terrain (scene/resources/2d/tile_set.cpp:6483)
```

`set_terrain()` should allow setting `terrain` to invalid (-1) when `terrain_set` is also invalid.