### PR TITLE
Improve "No meshes to bake" LightmapGI error dialog in the editor

### DIFF
--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -93,10 +93,14 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 				file_dialog->popup_file_dialog();
 			} break;
 			case LightmapGI::BAKE_ERROR_NO_MESHES: {
-				EditorNode::get_singleton()->show_warning(TTR("No meshes to bake. Make sure they contain an UV2 channel and that the 'Bake Light' flag is on."));
+				EditorNode::get_singleton()->show_warning(
+						TTR("No meshes with lightmapping support to bake. Make sure they contain UV2 data and their Global Illumination property is set to Static.") +
+						String::utf8("\n\n•  ") + TTR("To import a scene with lightmapping support, set Meshes > Light Baking to Static Lightmaps in the Import dock.") +
+						String::utf8("\n•  ") + TTR("To enable lightmapping support on a primitive mesh, edit the PrimitiveMesh resource in the inspector and check Add UV2.") +
+						String::utf8("\n•  ") + TTR("To enable lightmapping support on a CSG mesh, select the root CSG node and choose CSG > Bake Mesh Instance at the top of the 3D editor viewport.\nSelect the generated MeshInstance3D node and choose Mesh > Unwrap UV2 for Lightmap/AO at the top of the 3D editor viewport."));
 			} break;
 			case LightmapGI::BAKE_ERROR_CANT_CREATE_IMAGE: {
-				EditorNode::get_singleton()->show_warning(TTR("Failed creating lightmap images, make sure path is writable."));
+				EditorNode::get_singleton()->show_warning(TTR("Failed creating lightmap images. Make sure the lightmap destination path is writable."));
 			} break;
 			case LightmapGI::BAKE_ERROR_NO_SCENE_ROOT: {
 				EditorNode::get_singleton()->show_warning(TTR("No editor scene root found."));
@@ -108,7 +112,7 @@ void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
 				EditorNode::get_singleton()->show_warning(TTR("Maximum texture size is too small for the lightmap images.\nWhile this can be fixed by increasing the maximum texture size, it is recommended you split the scene into more objects instead."));
 			} break;
 			case LightmapGI::BAKE_ERROR_LIGHTMAP_TOO_SMALL: {
-				EditorNode::get_singleton()->show_warning(TTR("Failed creating lightmap images. Make sure all meshes selected to bake have `lightmap_size_hint` value set high enough, and `texel_scale` value of LightmapGI is not too low."));
+				EditorNode::get_singleton()->show_warning(TTR("Failed creating lightmap images. Make sure all meshes to bake have the Lightmap Size Hint property set high enough, and the LightmapGI's Texel Scale value is not too low."));
 			} break;
 			case LightmapGI::BAKE_ERROR_ATLAS_TOO_SMALL: {
 				EditorNode::get_singleton()->show_warning(TTR("Failed fitting a lightmap image into an atlas. This should never happen and should be reported."));


### PR DESCRIPTION
The error dialog now gives advice on the steps to follow to enable lightmapping support on imported scenes, primitive meshes and CSG meshes.

The old message referred to a property that was removed in Godot 4.0 (in fact, it may never have existed under the precise name stated in the dialog).

## Preview

![image](https://github.com/user-attachments/assets/a7495aec-bed0-4e10-b8d0-46d0eca6316e)
