### PR TITLE
[3.x] Fix button click detection when `Tree` is rotated

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1722,7 +1722,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, bool
 				cache.click_id = c.buttons[j].id;
 				cache.click_item = p_item;
 				cache.click_column = col;
-				cache.click_pos = get_global_mouse_position() - get_global_position();
+				cache.click_pos = get_local_mouse_position();
 				update();
 				//emit_signal("button_pressed");
 				return -1;


### PR DESCRIPTION
`3.x` version of #98299

The problem is a bit different, but the cause is the same. In `3.x`, the `button_pressed` signal is emitted, but its `TreeItem` parameter might be wrong since the click position detection is wrongly calculated.

MRP: [test-3.zip](https://github.com/user-attachments/files/17437323/test-3.zip)
