### PR TITLE
Avoid unnecessary `Dictionary` conversions in `GDScriptInstance::validate_property`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1835,14 +1835,14 @@ Variant::Type GDScriptInstance::get_property_type(const StringName &p_name, bool
 }
 
 void GDScriptInstance::validate_property(PropertyInfo &p_property) const {
-	Variant property = (Dictionary)p_property;
-	const Variant *args[1] = { &property };
-
 	const GDScript *sptr = script.ptr();
 	while (sptr) {
 		if (likely(sptr->valid)) {
 			HashMap<StringName, GDScriptFunction *>::ConstIterator E = sptr->member_functions.find(GDScriptLanguage::get_singleton()->strings._validate_property);
 			if (E) {
+				Variant property = (Dictionary)p_property;
+				const Variant *args[1] = { &property };
+
 				Callable::CallError err;
 				Variant ret = E->value->call(const_cast<GDScriptInstance *>(this), args, 1, err);
 				if (err.error == Callable::CallError::CALL_OK) {


### PR DESCRIPTION
Updated `GDScriptInstance::validate_property` to only convert `PropertyInfo` to `Dictionary` if `_validate_property` function is found.

This can make `Node.duplicate` around 4-5x faster for nodes that have gdscript attached, when the script doesn't override `_validate_property`.  Compared with scripts below:

TestClass:
```gdscript
class_name TestClass extends Node2D

var a
var b
var c
var d

#func _validate_property(property: Dictionary) -> void:
#	pass
```

Main Scene:
```gdscript
extends Node

func _ready():
	var node := TestClass.new()
	var start := Time.get_ticks_msec()
	for i in 1000:
		add_child(node.duplicate())
	var end := Time.get_ticks_msec()
	print("%dms" % (end - start))
```

Old:
```
139ms
238ms (_validate_property uncommented)
```

New:
```
28ms
239ms (_validate_property uncommented)
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
