### PR TITLE
Fix iOS audio driver attempting to start output too early

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -250,7 +250,7 @@ OSStatus AudioDriverCoreAudio::input_callback(void *inRefCon,
 }
 
 void AudioDriverCoreAudio::start() {
-	if (!active) {
+	if (!active && audio_unit != nullptr) {
 		OSStatus result = AudioOutputUnitStart(audio_unit);
 		if (result != noErr) {
 			ERR_PRINT("AudioOutputUnitStart failed, code: " + itos(result));


### PR DESCRIPTION
Fixes #87560.

The code for audio output resuming when returning from the background in `OS_IOS::on_focus_in` caused iOS builds to throw an error on startup, since the same function is also called on the initial launch, when not all the necessary components exist yet. This adds a null pointer check to prevent the invalid attempt. The audio output will still start once the AudioServer is initialized.