### PR TITLE
Add normalization button to Quaternion inspector

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -83,7 +83,7 @@ Quaternion Quaternion::normalized() const {
 }
 
 bool Quaternion::is_normalized() const {
-	return Math::is_equal_approx(length_squared(), 1, (real_t)UNIT_EPSILON); //use less epsilon
+	return Math::is_equal_approx(length_squared(), 1, (real_t)0.01/*UNIT_EPSILON*/); //use less epsilon // 0.01 is a temporary fix for precision errors
 }
 
 Quaternion Quaternion::inverse() const {

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -83,7 +83,7 @@ Quaternion Quaternion::normalized() const {
 }
 
 bool Quaternion::is_normalized() const {
-	return Math::is_equal_approx(length_squared(), 1, (real_t)0.01/*UNIT_EPSILON*/); //use less epsilon // 0.01 is a temporary fix for precision errors
+	return Math::is_equal_approx(length(), 1, (real_t)UNIT_EPSILON); //use less epsilon
 }
 
 Quaternion Quaternion::inverse() const {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1941,6 +1941,21 @@ void EditorPropertyQuaternion::_set_read_only(bool p_read_only) {
 	}
 }
 
+void EditorPropertyQuaternion::_edit_normalize_quaternion_value() {
+	if (normalize_quaternion_bttn->is_pressed()) {
+		Quaternion temp;
+		for (int i = 0; i < 4; i++) {
+			temp[i] = (real_t)spin[i]->get_value();
+		}
+		temp = temp.normalized();
+		for (int i = 0; i < 4; i++) {
+			spin[i]->set_value_no_signal((double)temp[i]);
+		}
+		_value_changed(-1, "");
+		update_property();
+	}
+}
+
 void EditorPropertyQuaternion::_edit_custom_value() {
 	if (edit_button->is_pressed()) {
 		edit_custom_bc->show();
@@ -2025,6 +2040,7 @@ void EditorPropertyQuaternion::_notification(int p_what) {
 				euler[i]->add_theme_color_override("label_color", colors[i]);
 			}
 			edit_button->set_icon(get_editor_theme_icon(SNAME("Edit")));
+			normalize_quaternion_bttn->set_icon(get_editor_theme_icon(SNAME("Key")));
 			euler_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("property_color"), SNAME("EditorProperty")));
 			warning->set_icon(get_editor_theme_icon(SNAME("NodeWarning")));
 			warning->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
@@ -2065,6 +2081,7 @@ EditorPropertyQuaternion::EditorPropertyQuaternion() {
 
 	VBoxContainer *bc = memnew(VBoxContainer);
 	edit_custom_bc = memnew(VBoxContainer);
+	normalize_quaternion = memnew(VBoxContainer);
 	BoxContainer *edit_custom_layout;
 	if (horizontal) {
 		default_layout = memnew(HBoxContainer);
@@ -2076,10 +2093,12 @@ EditorPropertyQuaternion::EditorPropertyQuaternion() {
 	}
 	edit_custom_bc->hide();
 	add_child(bc);
+	normalize_quaternion->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_custom_bc->set_h_size_flags(SIZE_EXPAND_FILL);
 	default_layout->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit_custom_layout->set_h_size_flags(SIZE_EXPAND_FILL);
 	bc->add_child(default_layout);
+	bc->add_child(normalize_quaternion);
 	bc->add_child(edit_custom_bc);
 
 	static const char *desc[4] = { "x", "y", "z", "w" };
@@ -2094,6 +2113,12 @@ EditorPropertyQuaternion::EditorPropertyQuaternion() {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
 	}
+
+	normalize_quaternion_bttn = memnew(Button);
+	normalize_quaternion_bttn->set_flat(true);
+	default_layout->add_child(normalize_quaternion_bttn);
+	normalize_quaternion_bttn->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyQuaternion::_edit_normalize_quaternion_value));
+	add_focusable(normalize_quaternion_bttn);
 
 	warning = memnew(Button);
 	warning->set_text(TTR("Temporary Euler may be changed implicitly!"));

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -487,14 +487,17 @@ class EditorPropertyQuaternion : public EditorProperty {
 	AcceptDialog *warning_dialog = nullptr;
 
 	Label *euler_label = nullptr;
+	VBoxContainer *normalize_quaternion = nullptr;
 	VBoxContainer *edit_custom_bc = nullptr;
 	EditorSpinSlider *euler[3];
 	Button *edit_button = nullptr;
+	Button *normalize_quaternion_bttn = nullptr;
 
 	Vector3 edit_euler;
 
 	void _value_changed(double p_val, const String &p_name);
 	void _edit_custom_value();
+	void _edit_normalize_quaternion_value();
 	void _custom_value_changed(double p_val);
 	void _warning_pressed();
 

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -865,7 +865,7 @@ void Skeleton3D::set_bone_pose_rotation(int p_bone, const Quaternion &p_rotation
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
 
-	bones[p_bone].pose_rotation = p_rotation;
+	bones[p_bone].pose_rotation = p_rotation.normalized();
 	bones[p_bone].pose_cache_dirty = true;
 	if (is_inside_tree()) {
 		_make_dirty();

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -865,7 +865,9 @@ void Skeleton3D::set_bone_pose_rotation(int p_bone, const Quaternion &p_rotation
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
 
-	//ERR_FAIL_COND_EDMSG(!p_rotation.is_normalized(), "The quaternion bone " + get_bone_name(p_bone) + " pose rotation must be normalized.");
+	if(!p_rotation.is_normalized()) {
+		WARN_PRINT_ED("The quaternion bone " + get_bone_name(p_bone) + " pose rotation must be normalized.");
+	}
 
 	bones[p_bone].pose_rotation = p_rotation;
 	bones[p_bone].pose_cache_dirty = true;

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -865,7 +865,7 @@ void Skeleton3D::set_bone_pose_rotation(int p_bone, const Quaternion &p_rotation
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
 
-	if(!p_rotation.is_normalized()) {
+	if (!p_rotation.is_normalized()) {
 		WARN_PRINT_ED("The quaternion bone " + get_bone_name(p_bone) + " pose rotation must be normalized.");
 	}
 

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -865,7 +865,9 @@ void Skeleton3D::set_bone_pose_rotation(int p_bone, const Quaternion &p_rotation
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
 
-	bones[p_bone].pose_rotation = p_rotation.normalized();
+	//ERR_FAIL_COND_EDMSG(!p_rotation.is_normalized(), "The quaternion bone " + get_bone_name(p_bone) + " pose rotation must be normalized.");
+
+	bones[p_bone].pose_rotation = p_rotation;
 	bones[p_bone].pose_cache_dirty = true;
 	if (is_inside_tree()) {
 		_make_dirty();


### PR DESCRIPTION
Fix for issue [Changing bone euler rotation sets non-normalized quaternion #98090](https://github.com/godotengine/godot/issues/98090)

I haven't received much advice while working on this issue so I went with the most straight forward solution, I have made more clarifications of what I did on the comment section of the issue and would appreciate any feedback if my solution is not sufficient.

* *Bugsquad edit, related: https://github.com/godotengine/godot/issues/98090*