### PR TITLE
Fix runtime crash during type inference for autoload scenes

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4536,16 +4536,30 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 				if (GDScriptLanguage::get_singleton()->has_any_global_constant(name)) {
 					Variant constant = GDScriptLanguage::get_singleton()->get_any_global_constant(name);
 					Node *node = Object::cast_to<Node>(constant);
+					Ref<GDScriptParserRef> single_parser;
 					if (node != nullptr) {
 						Ref<GDScript> scr = node->get_script();
 						if (scr.is_valid()) {
-							Ref<GDScriptParserRef> single_parser = parser->get_depended_parser_for(scr->get_script_path());
-							if (single_parser.is_valid()) {
-								Error err = single_parser->raise_status(GDScriptParserRef::INHERITANCE_SOLVED);
-								if (err == OK) {
-									result = type_from_metatype(single_parser->get_parser()->head->get_datatype());
-								}
-							}
+							single_parser = parser->get_depended_parser_for(scr->get_script_path());
+						}
+					} else {
+						// Singleton name exists but does not yet have a node assigned, assume that is because we
+						// are currently in the process of loading it. If this is the first script loaded in the scene,
+						// temporarily write its path as a value for the singleton so other scripts loaded as
+						// dependencies can use it to resolve the type of the singleton identifier.
+						String autoload_script_path;
+						if (constant.is_string()) {
+							autoload_script_path = static_cast<String>(constant);
+						} else {
+							autoload_script_path = parser->script_path;
+							GDScriptLanguage::get_singleton()->add_named_global_constant(name, autoload_script_path);
+						}
+						single_parser = parser->get_depended_parser_for(autoload_script_path);
+					}
+					if (single_parser.is_valid()) {
+						Error err = single_parser->raise_status(GDScriptParserRef::INHERITANCE_SOLVED);
+						if (err == OK) {
+							result = type_from_metatype(single_parser->get_parser()->head->get_datatype());
 						}
 					}
 				}


### PR DESCRIPTION
Fixes #77643
Fixes #98270
Fixes #104158

This is a quick and dirty fix to the obscure bug described in the issues above ([I describe the exact problem here](https://github.com/godotengine/godot/issues/77643#issuecomment-2422965019)). It's dirty because it relies on the shaky assumption that if the node of the autoload singleton is retrieved as `null` that means we are in the middle of instantiating that very scene, and because I temporarily store the scene's root node's script path in the value for the autoload, which it is not meant for. So I don't expect this to be merged as-is, just want to kickstart a discussion about possible solutions. 

How shaky is the assumption described above? Can it be relied upon after all?

If the approach in principle is okay, what would be a better place to temporarily store the script path?