### PR TITLE
Fix touch screen events on Linux being misattributed to the main window

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4404,6 +4404,25 @@ void DisplayServerX11::process_events() {
 		if (XGetEventData(x11_display, &event.xcookie)) {
 			if (event.xcookie.type == GenericEvent && event.xcookie.extension == xi.opcode) {
 				XIDeviceEvent *event_data = (XIDeviceEvent *)event.xcookie.data;
+
+				// Use the XIDeviceEvent's window for touch events as the XEvent's window is inaccurate
+				if (event_data->evtype >= XI_TouchBegin &&
+						event_data->evtype <= XI_TouchOwnership &&
+						event.xany.window != event_data->event) {
+					window_id = MAIN_WINDOW_ID;
+					for (const KeyValue<WindowID, WindowData> &E : windows) {
+						if (event_data->event == E.value.x11_window) {
+							window_id = E.key;
+							break;
+						}
+						if (event_data->event == E.value.x11_xim_window) {
+							window_id = E.key;
+							ime_window_event = true;
+							break;
+						}
+					}
+				}
+
 				switch (event_data->evtype) {
 					case XI_HierarchyChanged:
 					case XI_DeviceChanged: {


### PR DESCRIPTION
Simple test case: 
[TouchTestCaseSrc.zip](https://github.com/user-attachments/files/17440066/TouchTestCaseSrc.zip)

<details>
<summary>
System info on the machine i tested with
</summary>

Operating System: Arch Linux 
KDE Plasma Version: 6.1.5
KDE Frameworks Version: 6.6.0
Qt Version: 6.7.3
Kernel Version: 6.11.1-arch1-1 (64-bit)
Graphics Platform: Wayland
Processors: 16 × AMD Ryzen 7 5825U with Radeon Graphics
Memory: 15.0 GiB of RAM
Graphics Processor: AMD Radeon Graphics
Manufacturer: Dell Inc.
Product Name: Inspiron 16 5625
System Version: 1.10.0

</details>

Fixes #77653 
