### PR TITLE
Fix mouse emulation always sending events to the main window

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -690,6 +690,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 				button_event->set_canceled(st->is_canceled());
 				button_event->set_button_index(MouseButton::LEFT);
 				button_event->set_double_click(st->is_double_tap());
+				button_event->set_window_id(st->get_window_id());
 
 				BitField<MouseButtonMask> ev_bm = mouse_button_mask;
 				if (st->is_pressed()) {
@@ -727,6 +728,7 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			motion_event->set_velocity(sd->get_velocity());
 			motion_event->set_screen_velocity(sd->get_screen_velocity());
 			motion_event->set_button_mask(mouse_button_mask);
+			motion_event->set_window_id(sd->get_window_id());
 
 			_parse_input_event_impl(motion_event, true);
 		}


### PR DESCRIPTION
Simple test case: 
[TouchTestCaseSrc.zip](https://github.com/user-attachments/files/17440066/TouchTestCaseSrc.zip)

<details>
<summary>
System info on the machine i tested with
</summary>

Operating System: Arch Linux 
KDE Plasma Version: 6.1.5
KDE Frameworks Version: 6.6.0
Qt Version: 6.7.3
Kernel Version: 6.11.1-arch1-1 (64-bit)
Graphics Platform: Wayland
Processors: 16 × AMD Ryzen 7 5825U with Radeon Graphics
Memory: 15.0 GiB of RAM
Graphics Processor: AMD Radeon Graphics
Manufacturer: Dell Inc.
Product Name: Inspiron 16 5625
System Version: 1.10.0

</details>

Fixes #91099
