### PR TITLE
Add navigation layers to `AStar2D`, `AStar3D`, and `AStarGrid2D`

### DIFF
--- a/core/math/a_star.compat.inc
+++ b/core/math/a_star.compat.inc
@@ -38,9 +38,29 @@ Vector<Vector3> AStar3D::_get_point_path_bind_compat_88047(int64_t p_from_id, in
 	return get_point_path(p_from_id, p_to_id, false);
 }
 
+void AStar3D::_add_point_bind_compat_98324(int64_t p_id, const Vector3 &p_pos, real_t p_weight_scale) {
+	add_point(p_id, p_pos, p_weight_scale, 1);
+}
+
+int64_t AStar3D::_get_closest_point_bind_compat_98324(const Vector3 &p_point, bool p_include_disabled) const {
+	return get_closest_point(p_point, p_include_disabled, 1);
+}
+
+Vector<int64_t> AStar3D::_get_id_path_bind_compat_98324(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path) {
+	return get_id_path(p_from_id, p_to_id, p_allow_partial_path, 1);
+}
+
+Vector<Vector3> AStar3D::_get_point_path_bind_compat_98324(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path) {
+	return get_point_path(p_from_id, p_to_id, p_allow_partial_path, 1);
+}
+
 void AStar3D::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_id_path", "from_id", "to_id"), &AStar3D::_get_id_path_bind_compat_88047);
 	ClassDB::bind_compatibility_method(D_METHOD("get_point_path", "from_id", "to_id"), &AStar3D::_get_point_path_bind_compat_88047);
+	ClassDB::bind_compatibility_method(D_METHOD("add_point", "id", "position", "weight_scale"), &AStar3D::_add_point_bind_compat_98324, DEFVAL(1.0));
+	ClassDB::bind_compatibility_method(D_METHOD("get_closest_point", "to_position", "include_disabled"), &AStar3D::_get_closest_point_bind_compat_98324, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("get_id_path", "from_id", "to_id", "allow_partial_path"), &AStar3D::_get_id_path_bind_compat_98324, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("get_point_path", "from_id", "to_id", "allow_partial_path"), &AStar3D::_get_point_path_bind_compat_98324, DEFVAL(false));
 }
 
 Vector<int64_t> AStar2D::_get_id_path_bind_compat_88047(int64_t p_from_id, int64_t p_to_id) {
@@ -51,9 +71,29 @@ Vector<Vector2> AStar2D::_get_point_path_bind_compat_88047(int64_t p_from_id, in
 	return get_point_path(p_from_id, p_to_id, false);
 }
 
+void AStar2D::_add_point_bind_compat_98324(int64_t p_id, const Vector2 &p_pos, real_t p_weight_scale) {
+	add_point(p_id, p_pos, p_weight_scale, 1);
+}
+
+int64_t AStar2D::_get_closest_point_bind_compat_98324(const Vector2 &p_point, bool p_include_disabled) const {
+	return get_closest_point(p_point, p_include_disabled, 1);
+}
+
+Vector<int64_t> AStar2D::_get_id_path_bind_compat_98324(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path) {
+	return get_id_path(p_from_id, p_to_id, p_allow_partial_path, 1);
+}
+
+Vector<Vector2> AStar2D::_get_point_path_bind_compat_98324(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path) {
+	return get_point_path(p_from_id, p_to_id, p_allow_partial_path, 1);
+}
+
 void AStar2D::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_id_path", "from_id", "to_id"), &AStar2D::_get_id_path_bind_compat_88047);
 	ClassDB::bind_compatibility_method(D_METHOD("get_point_path", "from_id", "to_id"), &AStar2D::_get_point_path_bind_compat_88047);
+	ClassDB::bind_compatibility_method(D_METHOD("add_point", "id", "position", "weight_scale"), &AStar2D::_add_point_bind_compat_98324, DEFVAL(1.0));
+	ClassDB::bind_compatibility_method(D_METHOD("get_closest_point", "to_position", "include_disabled"), &AStar2D::_get_closest_point_bind_compat_98324, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("get_id_path", "from_id", "to_id", "allow_partial_path"), &AStar2D::_get_id_path_bind_compat_98324, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("get_point_path", "from_id", "to_id", "allow_partial_path"), &AStar2D::_get_point_path_bind_compat_98324, DEFVAL(false));
 }
 
 #endif // DISABLE_DEPRECATED

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -60,6 +60,7 @@ class AStar3D : public RefCounted {
 		real_t f_score = 0;
 		uint64_t open_pass = 0;
 		uint64_t closed_pass = 0;
+		uint32_t point_layers = 1;
 
 		// Used for getting closest_point_of_last_pathing_call.
 		real_t abs_g_score = 0;
@@ -115,7 +116,7 @@ class AStar3D : public RefCounted {
 	HashSet<Segment, Segment> segments;
 	Point *last_closest_point = nullptr;
 
-	bool _solve(Point *begin_point, Point *end_point, bool p_allow_partial_path);
+	bool _solve(Point *begin_point, Point *end_point, bool p_allow_partial_path, uint32_t p_point_layers);
 
 protected:
 	static void _bind_methods();
@@ -129,13 +130,17 @@ protected:
 #ifndef DISABLE_DEPRECATED
 	Vector<int64_t> _get_id_path_bind_compat_88047(int64_t p_from_id, int64_t p_to_id);
 	Vector<Vector3> _get_point_path_bind_compat_88047(int64_t p_from_id, int64_t p_to_id);
+	void _add_point_bind_compat_98324(int64_t p_id, const Vector3 &p_pos, real_t p_weight_scale = 1);
+	int64_t _get_closest_point_bind_compat_98324(const Vector3 &p_point, bool p_include_disabled = false) const;
+	Vector<int64_t> _get_id_path_bind_compat_98324(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false);
+	Vector<Vector3> _get_point_path_bind_compat_98324(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false);
 	static void _bind_compatibility_methods();
 #endif
 
 public:
 	int64_t get_available_point_id() const;
 
-	void add_point(int64_t p_id, const Vector3 &p_pos, real_t p_weight_scale = 1);
+	void add_point(int64_t p_id, const Vector3 &p_pos, real_t p_weight_scale = 1, uint32_t p_point_layers = 1);
 	Vector3 get_point_position(int64_t p_id) const;
 	void set_point_position(int64_t p_id, const Vector3 &p_pos);
 	real_t get_point_weight_scale(int64_t p_id) const;
@@ -148,6 +153,9 @@ public:
 	void set_point_disabled(int64_t p_id, bool p_disabled = true);
 	bool is_point_disabled(int64_t p_id) const;
 
+	void set_point_layers(int64_t p_id, uint32_t p_point_layers);
+	uint32_t get_point_layers(int64_t p_id) const;
+
 	void connect_points(int64_t p_id, int64_t p_with_id, bool bidirectional = true);
 	void disconnect_points(int64_t p_id, int64_t p_with_id, bool bidirectional = true);
 	bool are_points_connected(int64_t p_id, int64_t p_with_id, bool bidirectional = true) const;
@@ -157,11 +165,11 @@ public:
 	void reserve_space(int64_t p_num_nodes);
 	void clear();
 
-	int64_t get_closest_point(const Vector3 &p_point, bool p_include_disabled = false) const;
+	int64_t get_closest_point(const Vector3 &p_point, bool p_include_disabled = false, uint32_t p_point_layers = 1) const;
 	Vector3 get_closest_position_in_segment(const Vector3 &p_point) const;
 
-	Vector<Vector3> get_point_path(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false);
-	Vector<int64_t> get_id_path(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false);
+	Vector<Vector3> get_point_path(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false, uint32_t p_point_layers = 1);
+	Vector<int64_t> get_id_path(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false, uint32_t p_point_layers = 1);
 
 	AStar3D() {}
 	~AStar3D();
@@ -171,7 +179,7 @@ class AStar2D : public RefCounted {
 	GDCLASS(AStar2D, RefCounted);
 	AStar3D astar;
 
-	bool _solve(AStar3D::Point *begin_point, AStar3D::Point *end_point, bool p_allow_partial_path);
+	bool _solve(AStar3D::Point *begin_point, AStar3D::Point *end_point, bool p_allow_partial_path, uint32_t p_point_layers);
 
 protected:
 	static void _bind_methods();
@@ -185,13 +193,17 @@ protected:
 #ifndef DISABLE_DEPRECATED
 	Vector<int64_t> _get_id_path_bind_compat_88047(int64_t p_from_id, int64_t p_to_id);
 	Vector<Vector2> _get_point_path_bind_compat_88047(int64_t p_from_id, int64_t p_to_id);
+	void _add_point_bind_compat_98324(int64_t p_id, const Vector2 &p_pos, real_t p_weight_scale = 1);
+	int64_t _get_closest_point_bind_compat_98324(const Vector2 &p_point, bool p_include_disabled = false) const;
+	Vector<int64_t> _get_id_path_bind_compat_98324(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false);
+	Vector<Vector2> _get_point_path_bind_compat_98324(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false);
 	static void _bind_compatibility_methods();
 #endif
 
 public:
 	int64_t get_available_point_id() const;
 
-	void add_point(int64_t p_id, const Vector2 &p_pos, real_t p_weight_scale = 1);
+	void add_point(int64_t p_id, const Vector2 &p_pos, real_t p_weight_scale = 1, uint32_t p_point_layers = 1);
 	Vector2 get_point_position(int64_t p_id) const;
 	void set_point_position(int64_t p_id, const Vector2 &p_pos);
 	real_t get_point_weight_scale(int64_t p_id) const;
@@ -204,6 +216,9 @@ public:
 	void set_point_disabled(int64_t p_id, bool p_disabled = true);
 	bool is_point_disabled(int64_t p_id) const;
 
+	void set_point_layers(int64_t p_id, uint32_t p_point_layers);
+	uint32_t get_point_layers(int64_t p_id) const;
+
 	void connect_points(int64_t p_id, int64_t p_with_id, bool p_bidirectional = true);
 	void disconnect_points(int64_t p_id, int64_t p_with_id, bool p_bidirectional = true);
 	bool are_points_connected(int64_t p_id, int64_t p_with_id, bool p_bidirectional = true) const;
@@ -213,11 +228,11 @@ public:
 	void reserve_space(int64_t p_num_nodes);
 	void clear();
 
-	int64_t get_closest_point(const Vector2 &p_point, bool p_include_disabled = false) const;
+	int64_t get_closest_point(const Vector2 &p_point, bool p_include_disabled = false, uint32_t p_point_layers = 1) const;
 	Vector2 get_closest_position_in_segment(const Vector2 &p_point) const;
 
-	Vector<Vector2> get_point_path(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false);
-	Vector<int64_t> get_id_path(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false);
+	Vector<Vector2> get_point_path(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false, uint32_t p_point_layers = 1);
+	Vector<int64_t> get_id_path(int64_t p_from_id, int64_t p_to_id, bool p_allow_partial_path = false, uint32_t p_point_layers = 1);
 
 	AStar2D() {}
 	~AStar2D() {}

--- a/core/math/a_star_grid_2d.compat.inc
+++ b/core/math/a_star_grid_2d.compat.inc
@@ -40,9 +40,19 @@ Vector<Vector2> AStarGrid2D::_get_point_path_bind_compat_88047(const Vector2i &p
 	return get_point_path(p_from_id, p_to_id, false);
 }
 
+TypedArray<Vector2i> AStarGrid2D::_get_id_path_bind_compat_98324(const Vector2i &p_from_id, const Vector2i &p_to_id, bool p_allow_partial_path) {
+	return get_id_path(p_from_id, p_to_id, p_allow_partial_path, 1);
+}
+
+Vector<Vector2> AStarGrid2D::_get_point_path_bind_compat_98324(const Vector2i &p_from_id, const Vector2i &p_to_id, bool p_allow_partial_path) {
+	return get_point_path(p_from_id, p_to_id, p_allow_partial_path, 1);
+}
+
 void AStarGrid2D::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_id_path", "from_id", "to_id"), &AStarGrid2D::_get_id_path_bind_compat_88047);
 	ClassDB::bind_compatibility_method(D_METHOD("get_point_path", "from_id", "to_id"), &AStarGrid2D::_get_point_path_bind_compat_88047);
+	ClassDB::bind_compatibility_method(D_METHOD("get_id_path", "from_id", "to_id", "allow_partial_path"), &AStarGrid2D::_get_id_path_bind_compat_98324, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("get_point_path", "from_id", "to_id", "allow_partial_path"), &AStarGrid2D::_get_point_path_bind_compat_98324, DEFVAL(false));
 }
 
 #endif // DISABLE_DEPRECATED

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -87,6 +87,7 @@ private:
 		real_t f_score = 0;
 		uint64_t open_pass = 0;
 		uint64_t closed_pass = 0;
+		uint32_t point_layers = 1;
 
 		// Used for getting last_closest_point.
 		real_t abs_g_score = 0;
@@ -159,7 +160,7 @@ private: // Internal routines.
 
 	void _get_nbors(Point *p_point, LocalVector<Point *> &r_nbors);
 	Point *_jump(Point *p_from, Point *p_to);
-	bool _solve(Point *p_begin_point, Point *p_end_point, bool p_allow_partial_path);
+	bool _solve(Point *p_begin_point, Point *p_end_point, bool p_allow_partial_path, uint32_t p_point_layers);
 	Point *_forced_successor(int32_t p_x, int32_t p_y, int32_t p_dx, int32_t p_dy, bool p_inclusive = false);
 
 protected:
@@ -174,6 +175,8 @@ protected:
 #ifndef DISABLE_DEPRECATED
 	TypedArray<Vector2i> _get_id_path_bind_compat_88047(const Vector2i &p_from, const Vector2i &p_to);
 	Vector<Vector2> _get_point_path_bind_compat_88047(const Vector2i &p_from, const Vector2i &p_to);
+	TypedArray<Vector2i> _get_id_path_bind_compat_98324(const Vector2i &p_from_id, const Vector2i &p_to_id, bool p_allow_partial_path = false);
+	Vector<Vector2> _get_point_path_bind_compat_98324(const Vector2i &p_from_id, const Vector2i &p_to_id, bool p_allow_partial_path = false);
 	static void _bind_compatibility_methods();
 #endif
 
@@ -214,6 +217,9 @@ public:
 	void set_point_solid(const Vector2i &p_id, bool p_solid = true);
 	bool is_point_solid(const Vector2i &p_id) const;
 
+	void set_point_layers(const Vector2i &p_id, uint32_t p_point_layers);
+	uint32_t get_point_layers(const Vector2i &p_id) const;
+
 	void set_point_weight_scale(const Vector2i &p_id, real_t p_weight_scale);
 	real_t get_point_weight_scale(const Vector2i &p_id) const;
 
@@ -224,8 +230,8 @@ public:
 
 	Vector2 get_point_position(const Vector2i &p_id) const;
 	TypedArray<Dictionary> get_point_data_in_region(const Rect2i &p_region) const;
-	Vector<Vector2> get_point_path(const Vector2i &p_from, const Vector2i &p_to, bool p_allow_partial_path = false);
-	TypedArray<Vector2i> get_id_path(const Vector2i &p_from, const Vector2i &p_to, bool p_allow_partial_path = false);
+	Vector<Vector2> get_point_path(const Vector2i &p_from, const Vector2i &p_to, bool p_allow_partial_path = false, uint32_t p_point_layers = 1);
+	TypedArray<Vector2i> get_id_path(const Vector2i &p_from, const Vector2i &p_to, bool p_allow_partial_path = false, uint32_t p_point_layers = 1);
 };
 
 VARIANT_ENUM_CAST(AStarGrid2D::DiagonalMode);

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -33,8 +33,10 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<param index="2" name="weight_scale" type="float" default="1.0" />
+			<param index="3" name="navigation_layers" type="int" default="1" />
 			<description>
 				Adds a new point at the given position with the given identifier. The [param id] must be 0 or larger, and the [param weight_scale] must be 0.0 or greater.
+				The [param navigation_layers] is a bitmask and can be set to specify which navigation layers the point is a part of. The default is layer 1.
 				The [param weight_scale] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point. Thus, all else being equal, the algorithm prefers points with lower [param weight_scale]s to form a path.
 				[codeblocks]
 				[gdscript]
@@ -106,8 +108,9 @@
 			<return type="int" />
 			<param index="0" name="to_position" type="Vector2" />
 			<param index="1" name="include_disabled" type="bool" default="false" />
+			<param index="2" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns the ID of the closest point to [param to_position], optionally taking disabled points into account. Returns [code]-1[/code] if there are no points in the points pool.
+				Returns the ID of the closest point to [param to_position], optionally taking disabled points into account or specific navigation layers bitmask. Returns [code]-1[/code] if there are no points in the points pool.
 				[b]Note:[/b] If several points are the closest to [param to_position], the one with the smallest ID will be returned, ensuring a deterministic result.
 			</description>
 		</method>
@@ -140,8 +143,9 @@
 			<param index="0" name="from_id" type="int" />
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="allow_partial_path" type="bool" default="false" />
+			<param index="3" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns an array with the IDs of the points that form the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
+				Returns an array with the IDs of the points that form the path found by AStar2D between the given points using the given [param navigation_layers]. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] When [param allow_partial_path] is [code]true[/code] and [param to_id] is disabled the search may take an unusually long time to finish.
 				[codeblocks]
@@ -227,13 +231,21 @@
 				Returns an array of all point IDs.
 			</description>
 		</method>
+		<method name="get_point_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns the navigation layers bitmask for the specified point.
+			</description>
+		</method>
 		<method name="get_point_path">
 			<return type="PackedVector2Array" />
 			<param index="0" name="from_id" type="int" />
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="allow_partial_path" type="bool" default="false" />
+			<param index="3" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns an array with the points that are in the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
+				Returns an array with the points that are in the path found by AStar2D between the given points using the given [param navigation_layers]. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] This method is not thread-safe. If called from a [Thread], it will return an empty array and will print an error message.
 				Additionally, when [param allow_partial_path] is [code]true[/code] and [param to_id] is disabled the search may take an unusually long time to finish.
@@ -287,6 +299,14 @@
 			<param index="1" name="disabled" type="bool" default="true" />
 			<description>
 				Disables or enables the specified point for pathfinding. Useful for making a temporary obstacle.
+			</description>
+		</method>
+		<method name="set_point_layers">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="navigation_layers" type="int" />
+			<description>
+				Sets the points navigation layers with the given [param navigation_layers] bitmask.
 			</description>
 		</method>
 		<method name="set_point_position">

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -62,8 +62,10 @@
 			<param index="0" name="id" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<param index="2" name="weight_scale" type="float" default="1.0" />
+			<param index="3" name="navigation_layers" type="int" default="1" />
 			<description>
 				Adds a new point at the given position with the given identifier. The [param id] must be 0 or larger, and the [param weight_scale] must be 0.0 or greater.
+				The [param navigation_layers] is a bitmask and can be set to specify which navigation layers the point is a part of. The default is layer 1.
 				The [param weight_scale] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point. Thus, all else being equal, the algorithm prefers points with lower [param weight_scale]s to form a path.
 				[codeblocks]
 				[gdscript]
@@ -135,8 +137,9 @@
 			<return type="int" />
 			<param index="0" name="to_position" type="Vector3" />
 			<param index="1" name="include_disabled" type="bool" default="false" />
+			<param index="2" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns the ID of the closest point to [param to_position], optionally taking disabled points into account. Returns [code]-1[/code] if there are no points in the points pool.
+				Returns the ID of the closest point to [param to_position], optionally taking disabled points into account or specific navigation layers. Returns [code]-1[/code] if there are no points in the points pool.
 				[b]Note:[/b] If several points are the closest to [param to_position], the one with the smallest ID will be returned, ensuring a deterministic result.
 			</description>
 		</method>
@@ -169,8 +172,9 @@
 			<param index="0" name="from_id" type="int" />
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="allow_partial_path" type="bool" default="false" />
+			<param index="3" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns an array with the IDs of the points that form the path found by AStar3D between the given points. The array is ordered from the starting point to the ending point of the path.
+				Returns an array with the IDs of the points that form the path found by AStar3D between the given points using the given [param navigation_layers]. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] When [param allow_partial_path] is [code]true[/code] and [param to_id] is disabled the search may take an unusually long time to finish.
 				[codeblocks]
@@ -254,13 +258,21 @@
 				Returns an array of all point IDs.
 			</description>
 		</method>
+		<method name="get_point_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Returns the navigation layers bitmask for the specified point.
+			</description>
+		</method>
 		<method name="get_point_path">
 			<return type="PackedVector3Array" />
 			<param index="0" name="from_id" type="int" />
 			<param index="1" name="to_id" type="int" />
 			<param index="2" name="allow_partial_path" type="bool" default="false" />
+			<param index="3" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns an array with the points that are in the path found by AStar3D between the given points. The array is ordered from the starting point to the ending point of the path.
+				Returns an array with the points that are in the path found by AStar3D between the given points using the given [param navigation_layers]. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] This method is not thread-safe. If called from a [Thread], it will return an empty array and will print an error message.
 				Additionally, when [param allow_partial_path] is [code]true[/code] and [param to_id] is disabled the search may take an unusually long time to finish.
@@ -314,6 +326,14 @@
 			<param index="1" name="disabled" type="bool" default="true" />
 			<description>
 				Disables or enables the specified point for pathfinding. Useful for making a temporary obstacle.
+			</description>
+		</method>
+		<method name="set_point_layers">
+			<return type="void" />
+			<param index="0" name="id" type="int" />
+			<param index="1" name="navigation_layers" type="int" />
+			<description>
+				Sets the points navigation layers with the given [param navigation_layers] bitmask.
 			</description>
 		</method>
 		<method name="set_point_position">

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -76,8 +76,9 @@
 			<param index="0" name="from_id" type="Vector2i" />
 			<param index="1" name="to_id" type="Vector2i" />
 			<param index="2" name="allow_partial_path" type="bool" default="false" />
+			<param index="3" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns an array with the IDs of the points that form the path found by AStar2D between the given points. The array is ordered from the starting point to the ending point of the path.
+				Returns an array with the IDs of the points that form the path found by AStar2D between the given points using the given [param navigation_layers]. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] When [param allow_partial_path] is [code]true[/code] and [param to_id] is solid the search may take an unusually long time to finish.
 			</description>
@@ -89,13 +90,21 @@
 				Returns an array of dictionaries with point data ([code]id[/code]: [Vector2i], [code]position[/code]: [Vector2], [code]solid[/code]: [bool], [code]weight_scale[/code]: [float]) within a [param region].
 			</description>
 		</method>
+		<method name="get_point_layers" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="id" type="Vector2i" />
+			<description>
+				Returns the navigation layers bitmask for the specified point.
+			</description>
+		</method>
 		<method name="get_point_path">
 			<return type="PackedVector2Array" />
 			<param index="0" name="from_id" type="Vector2i" />
 			<param index="1" name="to_id" type="Vector2i" />
 			<param index="2" name="allow_partial_path" type="bool" default="false" />
+			<param index="3" name="navigation_layers" type="int" default="1" />
 			<description>
-				Returns an array with the points that are in the path found by [AStarGrid2D] between the given points. The array is ordered from the starting point to the ending point of the path.
+				Returns an array with the points that are in the path found by [AStarGrid2D] between the given points using the given [param navigation_layers]. The array is ordered from the starting point to the ending point of the path.
 				If there is no valid path to the target, and [param allow_partial_path] is [code]true[/code], returns a path to the point closest to the target that can be reached.
 				[b]Note:[/b] This method is not thread-safe. If called from a [Thread], it will return an empty array and will print an error message.
 				Additionally, when [param allow_partial_path] is [code]true[/code] and [param to_id] is solid the search may take an unusually long time to finish.
@@ -141,6 +150,14 @@
 			<param index="0" name="id" type="Vector2i" />
 			<description>
 				Returns [code]true[/code] if a point is disabled for pathfinding. By default, all points are enabled.
+			</description>
+		</method>
+		<method name="set_point_layers">
+			<return type="void" />
+			<param index="0" name="id" type="Vector2i" />
+			<param index="1" name="navigation_layers" type="int" />
+			<description>
+				Sets the points navigation layers with the given [param navigation_layers] bitmask.
 			</description>
 		</method>
 		<method name="set_point_solid">

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -95,3 +95,20 @@ Validate extension JSON: Error: Field 'classes/InputMap/methods/add_action/argum
 
 Default deadzone value was changed. No adjustments should be necessary.
 Compatibility method registered.
+
+
+GH-98324
+--------
+Validate extension JSON: Error: Field 'classes/AStar2D/methods/add_point/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/AStar2D/methods/get_closest_point/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/AStar2D/methods/get_id_path/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/AStar2D/methods/get_point_path/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/AStar3D/methods/add_point/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/AStar3D/methods/get_closest_point/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/AStar3D/methods/get_id_path/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/AStar3D/methods/get_point_path/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/AStarGrid2D/methods/get_id_path/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/AStarGrid2D/methods/get_point_path/arguments': size changed value in new API, from 3 to 4.
+
+Added navigation layer argument to these methods. Default argument was added.
+Compatibility methods registered.


### PR DESCRIPTION
Adds navigation layers to `AStar2D`, `AStar3D`, and `AStarGrid2D`. By default, all points will be on layer one and all functions that now take a layer argument will default to layer 1, so existing implementations should not be impacted.

`AStar2D::add_point` and `AStar3D::add_point` now have an optional argument to specify the layer bitmask when adding the point. 
`get_id_path`, `get_point_path` for all support specifying a layer to use. Points that are not on that layer are ignored for pathfinding, as if they were disabled. This also means you can actually disable a point if you set it's layer to 0, but I kept the disabled functionality as a way to disable a point for all layers and preserve the point's layer data at the same time.
`get_closest_point` for `AStar2D` and `AStar3D` will respect the provided layer, and only return the closest point with the matching layer.
`AStarGrid2D` seems to constantly remake the points whenever you call update. I believe this will wipe out any custom layers you set as well, which may be an issue and should maybe be mentioned in the docs? I couldn't think of a way to preserve this data given the update function first clears all points. Open to suggestions on this!

### Rational:
Instead of having to make duplicate AStar objects if some agents have slightly different path options, you can now use the same overall map data for 32 distinct path options. This greatly simplifies code for users.
For example, in my project the map is the same once generated but some units can only travel on some tiles. Water tiles, for example, cannot be traversed by land units and vice versa. Air units can traverse all types. Previously I've had to use 3 separate AStar objects and switch which one I am using based on the unit. After adding layers, I can just specify which layers the points on are to represent land, sea, air during generation, and then for pathfinding specify which layers the agent uses and use one map instead of duplicating the entire thing.

# Example:
**Download:** [astar_test.zip](https://github.com/user-attachments/files/17441130/astar_test.zip)


This project features two agents, a Red and Blue. The Red and Blue tiles can be traversed only by those agents respectively. The project also has use UI elements to view the layers of the point the mouse is over and showcase the `get_closest_point` function respecting the layer option. It pulls the layer from the currently selected character in the option box.

[astar_navigation_layers.webm](https://github.com/user-attachments/assets/500d8299-e800-43a6-8aa3-2a5a87a2e898)

By default all "open" tiles have been set to layer 2 and 3 (so the value will display 6). Gray "obstacle" tiles are set to layer 0. The red character is on layer 3 (value 4) and the blue character is on layer 2 (value 2). Towards the end, you can that I have my mouse over tile 6,7 (id 497) but the "closest point" in the UI is "496" as that tile is on a different layer from the red character.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

## Outstanding questions:
1) I noticed some of the physics layer implementations have a distinct `mask` and `mask_value` function, where the former takes a bitmask and the later takes a layer as an int 1-32. Should I mirror that and have two functions, one to change the bitmask directly and one to specify the layer? Setting layer by direct int is a bit easier, but would not support multiple layers for "shared" points, so I'm not sure if that extra function would be considered a nice utility or just bloat.
2) What should we do about `AStarGrid2D::update` wiping out any saved layer changes? Just add a documentation note about it? Change that function to remember all the layers for all points and somehow reapply them?

Previous questions, leaving here for community knowledge reasons
- I need to add the compat functions, but I am not sure the proper procedure when a function already has one. I added one for `get_id_path` and `get_point_path` in a previous PR, and this one will be modifying those functions again. Is the correct approach to entirely remove those old compat methods and replace them with the new ones, or do I create separate compat functions and bind them again? I couldn't find a clear instruction on this.
**-> I was told they get additional ones, which I have now added.**

Closes: https://github.com/godotengine/godot-proposals/issues/5188