### PR TITLE
Add a project setting to automatically add Editor's WorldEnvironment, DirectionalLight3D, and/or Camera3D to a 3D scene when running project with Run Current Scene/Run Specific Scene

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1012,6 +1012,9 @@
 		<member name="editor/naming/script_name_casing" type="int" setter="" getter="" default="0">
 			When generating script file names from the selected node, set the type of casing to use in this project. This is mostly an editor setting.
 		</member>
+		<member name="editor/run/add_preview_nodes_when_running_scene" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], when using Run Current Scene or Run Specific Scene, the editor's preview Environment, Sun and Camera will be duplicated and added to the scene if no other [WorldEnvironment], [DirectionalLight3D] or [Camera3D] nodes are present. This will also be disabled for the [WorldEnvironment] and [DirectionalLight3D] if the preview Environment/Sun is toggled off.
+		</member>
 		<member name="editor/run/main_run_args" type="String" setter="" getter="" default="&quot;&quot;">
 			The command-line arguments to append to Godot's own command line when running the project. This doesn't affect the editor itself.
 			It is possible to make another executable run Godot by using the [code]%command%[/code] placeholder. The placeholder will be replaced with Godot's own command line. Program-specific arguments should be placed [i]before[/i] the placeholder, whereas Godot-specific arguments should be placed [i]after[/i] the placeholder.

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_debugger_node.h"
 
+#include "core/config/project_settings.h"
 #include "core/object/undo_redo.h"
 #include "editor/debugger/editor_debugger_tree.h"
 #include "editor/debugger/script_editor_debugger.h"
@@ -405,6 +406,13 @@ void EditorDebuggerNode::_notification(int p_what) {
 				} // Will arrive too late, how does the regular run work?
 
 				debugger->update_live_edit_root();
+
+#ifndef _3D_DISABLED
+				// Adds the preview WorldEnvironment, DirectionalLight3D, Camera3D nodes from the Editor if they are not present in the current scene when using RUN_CURRENT or RUN_CUSTOM.
+				if (GLOBAL_GET("editor/run/add_preview_nodes_when_running_scene")) {
+					debugger->add_preview_nodes_to_current_3d_scene();
+				}
+#endif // _3D_DISABLED
 			}
 		} break;
 	}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -35,6 +35,7 @@
 #include "core/debugger/remote_debugger.h"
 #include "core/io/marshalls.h"
 #include "core/string/ustring.h"
+#include "core/variant/variant_utility.h"
 #include "core/version.h"
 #include "editor/debugger/debug_adapter/debug_adapter_protocol.h"
 #include "editor/debugger/editor_expression_evaluator.h"
@@ -42,12 +43,14 @@
 #include "editor/debugger/editor_profiler.h"
 #include "editor/debugger/editor_visual_profiler.h"
 #include "editor/editor_file_system.h"
+#include "editor/editor_interface.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_property_name_processor.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_run_bar.h"
 #include "editor/inspector_dock.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/editor_debugger_plugin.h"
@@ -55,6 +58,8 @@
 #include "editor/themes/editor_scale.h"
 #include "main/performance.h"
 #include "scene/3d/camera_3d.h"
+#include "scene/3d/light_3d.h"
+#include "scene/3d/world_environment.h"
 #include "scene/debugger/scene_debugger.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/grid_container.h"
@@ -65,6 +70,7 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/tree.h"
+#include "scene/resources/packed_scene.h"
 #include "servers/debugger/servers_debugger.h"
 #include "servers/display_server.h"
 
@@ -1498,6 +1504,60 @@ void ScriptEditorDebugger::set_camera_override(CameraOverride p_override) {
 	_put_msg("scene:override_cameras", msg);
 
 	camera_override = p_override;
+}
+
+void ScriptEditorDebugger::add_preview_nodes_to_current_3d_scene() {
+	Array msg;
+	const Node3DEditor *editor = Node3DEditor::get_singleton();
+	const Ref<PackedScene> current_running_scene = ResourceLoader::load(EditorRunBar::get_singleton()->get_playing_scene());
+	if (current_running_scene.is_null()) {
+		return;
+	}
+
+	const Ref<SceneState> scene_state = current_running_scene->get_state();
+
+	// Make sure we have a root node.
+	ERR_FAIL_COND(scene_state->get_node_count() < 1);
+
+	// If the root node isn't a 3D node, check if we have an inherited scene as the root node or return.
+	if (!ClassDB::is_parent_class(scene_state->get_node_type(0), "Node3D")) {
+		const Ref<SceneState> base_state = current_running_scene->get_state()->get_base_scene_state();
+
+		// If our inherited scene does not inherit a 3D node, return.
+		if (base_state.is_valid()) {
+			if (!ClassDB::is_parent_class(base_state->get_node_type(0), "Node3D")) {
+				return;
+			}
+		} else {
+			return;
+		}
+	}
+
+	// Check to see if nodes already exists in the current scene and if the preview Environment/Sun buttons are not pressed.
+	bool should_add_world_environment = true;
+	bool should_add_directional_light_3d = true;
+	bool should_add_camera_3d = true;
+	for (int i = 0; i < scene_state->get_node_count(); i++) {
+		if (scene_state->get_node_type(i) == "WorldEnvironment" || !editor->is_environ_button_pressed()) {
+			should_add_world_environment = false;
+		}
+		if (scene_state->get_node_type(i) == "DirectionalLight3D" || !editor->is_sun_button_pressed()) {
+			should_add_directional_light_3d = false;
+		}
+		if (scene_state->get_node_type(i) == "Camera3D") {
+			should_add_camera_3d = false;
+		}
+	}
+
+	msg.push_back(should_add_world_environment);
+	msg.push_back(should_add_directional_light_3d);
+	msg.push_back(should_add_camera_3d);
+
+	// Serialize WorldEnvironment, DirectionalLight3D and Camera3D nodes to bytes and send to running game.
+	msg.push_back(VariantUtilityFunctions::var_to_bytes_with_objects(editor->get_preview_environment()->duplicate()));
+	msg.push_back(VariantUtilityFunctions::var_to_bytes_with_objects(editor->get_preview_sun()->duplicate()));
+	msg.push_back(VariantUtilityFunctions::var_to_bytes_with_objects(EditorInterface::get_singleton()->get_editor_viewport_3d(0)->get_camera_3d()->duplicate()));
+	_put_msg("scene:add_preview_nodes_to_current_3d_scene", msg);
 }
 
 void ScriptEditorDebugger::set_breakpoint(const String &p_path, int p_line, bool p_enabled) {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -302,6 +302,8 @@ public:
 	EditorDebuggerNode::CameraOverride get_camera_override() const;
 	void set_camera_override(EditorDebuggerNode::CameraOverride p_override);
 
+	void add_preview_nodes_to_current_3d_scene();
+
 	void set_breakpoint(const String &p_path, int p_line, bool p_enabled);
 
 	void update_live_edit_root();

--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -484,6 +484,10 @@ HBoxContainer *EditorRunBar::get_buttons_container() {
 	return main_hbox;
 }
 
+EditorRunBar::RunMode EditorRunBar::get_run_mode() const {
+	return current_mode;
+}
+
 void EditorRunBar::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("play_pressed"));
 	ADD_SIGNAL(MethodInfo("stop_pressed"));

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -42,16 +42,20 @@ class HBoxContainer;
 class AcceptDialog;
 
 class EditorRunBar : public MarginContainer {
-	GDCLASS(EditorRunBar, MarginContainer);
-
-	static EditorRunBar *singleton;
-
+public:
 	enum RunMode {
 		STOPPED = 0,
 		RUN_MAIN,
 		RUN_CURRENT,
 		RUN_CUSTOM,
 	};
+
+	RunMode get_run_mode() const;
+
+private:
+	GDCLASS(EditorRunBar, MarginContainer);
+
+	static EditorRunBar *singleton;
 
 	PanelContainer *main_panel = nullptr;
 	HBoxContainer *main_hbox = nullptr;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6199,6 +6199,29 @@ Node3DEditorViewportContainer::Node3DEditorViewportContainer() {
 	dragging_h = false;
 }
 
+WorldEnvironment *Node3DEditor::get_preview_environment() const {
+	return preview_environment;
+}
+
+DirectionalLight3D *Node3DEditor::get_preview_sun() const {
+	return preview_sun;
+}
+
+bool Node3DEditor::is_environ_button_pressed() const {
+	if (environ_button->is_disabled()) {
+		return false;
+	}
+
+	return environ_button->is_pressed();
+}
+
+bool Node3DEditor::is_sun_button_pressed() const {
+	if (sun_button->is_disabled()) {
+		return false;
+	}
+
+	return sun_button->is_pressed();
+}
 ///////////////////////////////////////////////////////////////////
 
 Node3DEditor *Node3DEditor::singleton = nullptr;

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -625,6 +625,12 @@ class Node3DEditor : public VBoxContainer {
 	GDCLASS(Node3DEditor, VBoxContainer);
 
 public:
+	WorldEnvironment *get_preview_environment() const;
+	DirectionalLight3D *get_preview_sun() const;
+
+	bool is_environ_button_pressed() const;
+	bool is_sun_button_pressed() const;
+
 	static const unsigned int VIEWPORTS_COUNT = 4;
 
 	enum ToolMode {

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -272,6 +272,7 @@ void register_editor_types() {
 
 	// For correct doc generation.
 	GLOBAL_DEF("editor/run/main_run_args", "");
+	GLOBAL_DEF("editor/run/add_preview_nodes_when_running_scene", true);
 
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "editor/script/templates_search_path", PROPERTY_HINT_DIR), "res://script_templates");
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6735
Closes https://github.com/godotengine/godot-proposals/issues/5801
Closes https://github.com/godotengine/godot-proposals/issues/5800
Closes https://github.com/godotengine/godot-proposals/issues/10144 (maybe)
Closes https://github.com/godotengine/godot-proposals/issues/7992 (maybe)

![image](https://github.com/user-attachments/assets/9312fe45-5550-4fd3-80d8-bcfe005884d9)

This commit adds a Project Setting (_ENABLED BY DEFAULT_) that when running the project with **Run Current Scene** or **Run Specific Scene**, adds the preview WorldEnvironment, DirectionalLight3D and/or Camera3D nodes from the Editor into the running game. This will NOT add any preview nodes if they already exist in the scene tree before running. This does NOT affect running a game normally.

I tried to adapt this the best I could to the discussion in https://github.com/godotengine/godot-proposals/issues/5800, but am up to modify it in any way I should.

### Some notes:

1. Code wise, I couldn't find a better way to pass the editor nodes through the debugger message than (**var_to_bytes_with_objects**) but chances are I missed something, is there a better way to do this?
2. Would we want to update this to update when the Environment/Sun preview button is toggled, as it stands right now it is only read when the game is started.
3. Should there / is there a naming convention for nodes added from the Editor into a running scene? Right now I just called the nodes "WorldEnvironmentPreview", "SunPreview" and "Camera3DPreview".

![image](https://github.com/user-attachments/assets/05af7c79-d5b3-4acf-bb25-37f506ec5593)

![image](https://github.com/user-attachments/assets/84efa994-1c2a-438c-9e4e-925846fdc404)

---
| Before | After |
| ------------- | ------------- |
| <video src=https://github.com/user-attachments/assets/280db324-3a45-4d25-a92c-53017e8bce11></video> | <video src=https://github.com/user-attachments/assets/918ba845-b320-485e-b977-5f437a3611f6></video>
