### PR TITLE
Fix parser bug for typed dictionaries with custom classes as values

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3833,8 +3833,11 @@ Ref<GDScriptParserRef> GDScriptAnalyzer::ensure_cached_external_parser_for_class
 	}
 
 	String script_path = p_class->get_datatype().script_path;
+	Ref<GDScriptParserRef> parser_ref = parser->get_depended_parser_for(script_path);
+	if (parser_ref.is_valid()) {
+		return parser_ref;
+	}
 
-	Ref<GDScriptParserRef> parser_ref;
 	for (const GDScriptParser::ClassNode *look_class = p_from_class; look_class != nullptr; look_class = look_class->base_type.class_type) {
 		if (parser->has_class(look_class)) {
 			parser_ref = find_cached_external_parser_for_class(p_class, parser);


### PR DESCRIPTION
Edit: Superseded by #98400

Fixes #96881

I assume that this was an oversight during a larger refactorization since `script_path` was defined and initialized but never used. I added what I assume to be its originally intended use and it fixes the the bug for me.