### PR TITLE
Expose `Texture2D::is_pixel_opaque()`

### DIFF
--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -145,5 +145,13 @@
 				Returns [code]true[/code] if this [Texture2D] has an alpha channel.
 			</description>
 		</method>
+		<method name="is_pixel_opaque" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="x" type="int" />
+			<param index="1" name="y" type="int" />
+			<description>
+				Returns [code]true[/code] if the pixel at [code](x, y)[/code] is opaque.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -104,6 +104,7 @@ void Texture2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_rect_region", "canvas_item", "rect", "src_rect", "modulate", "transpose", "clip_uv"), &Texture2D::draw_rect_region, DEFVAL(Color(1, 1, 1)), DEFVAL(false), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_image"), &Texture2D::get_image);
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Texture2D::create_placeholder);
+	ClassDB::bind_method(D_METHOD("is_pixel_opaque", "x", "y"), &Texture2D::is_pixel_opaque);
 
 	ADD_GROUP("", "");
 


### PR DESCRIPTION
This resolves #98315 by binding the method, which was not bound previously.

Note; the issue specifically mentions ImageTexture as also having this problem, but when I bound both Texture2D's is_pixel_opaque() _and_ ImageTexture's, Godot threw an error, so I went with only binding Texture2D's is_pixel_opaque().

I haven't checked _every_ class that derives from Texture2D, but I have checked two, and they either had their own implementations of is_pixel_opaque(), or none at all, so those _might_ be fine.

I am not very confident in anything, not especially my understanding of what I'm doing here, so if I've skipped a step or caused a regression somehow, please let me know, thank you for your time :)