### PR TITLE
Core: Fix `String::num_int64()`, uint64 for valid base check

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1850,6 +1850,8 @@ String String::num(double p_num, int p_decimals) {
 }
 
 String String::num_int64(int64_t p_num, int base, bool capitalize_hex) {
+	ERR_FAIL_COND_V_MSG(base < 2 || base > 36, "", "Cannot convert to base " + itos(base) + ", since the value is " + (base < 2 ? "less than 2." : "greater than 36."));
+
 	bool sign = p_num < 0;
 
 	int64_t n = p_num;
@@ -1888,6 +1890,8 @@ String String::num_int64(int64_t p_num, int base, bool capitalize_hex) {
 }
 
 String String::num_uint64(uint64_t p_num, int base, bool capitalize_hex) {
+	ERR_FAIL_COND_V_MSG(base < 2 || base > 36, "", "Cannot convert to base " + itos(base) + ", since the value is " + (base < 2 ? "less than 2." : "greater than 36."));
+
 	uint64_t n = p_num;
 
 	int chars = 0;

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -460,11 +460,27 @@ TEST_CASE("[String] Number to string") {
 	CHECK(String::num(-0.0) == "-0"); // Includes sign even for zero.
 	CHECK(String::num(3.141593) == "3.141593");
 	CHECK(String::num(3.141593, 3) == "3.142");
+	CHECK(String::num(42.100023, 4) == "42.1"); // No trailing zeros.
 	CHECK(String::num_scientific(30000000) == "3e+07");
+
+	// String::num_int64 tests.
 	CHECK(String::num_int64(3141593) == "3141593");
+	CHECK(String::num_int64(-3141593) == "-3141593");
 	CHECK(String::num_int64(0xA141593, 16) == "a141593");
 	CHECK(String::num_int64(0xA141593, 16, true) == "A141593");
-	CHECK(String::num(42.100023, 4) == "42.1"); // No trailing zeros.
+	ERR_PRINT_OFF;
+	CHECK(String::num_int64(3141593, 1) == ""); // Invalid base < 2.
+	CHECK(String::num_int64(3141593, 37) == ""); // Invalid base > 36.
+	ERR_PRINT_ON;
+
+	// String::num_uint64 tests.
+	CHECK(String::num_uint64(4294967295) == "4294967295");
+	CHECK(String::num_uint64(0xF141593, 16) == "f141593");
+	CHECK(String::num_uint64(0xF141593, 16, true) == "F141593");
+	ERR_PRINT_OFF;
+	CHECK(String::num_uint64(4294967295, 1) == ""); // Invalid base < 2.
+	CHECK(String::num_uint64(4294967295, 37) == ""); // Invalid base > 36.
+	ERR_PRINT_ON;
 
 	// String::num_real tests.
 	CHECK(String::num_real(1.0) == "1.0");


### PR DESCRIPTION
Add valid base check for `String::num_int64` and `String::num_uint64` to ensure that the `base` parameter is within the valid range [2, 36]. Previously, `String::num_uint64` conversion with base 0 or 1 caused Godot to crash, instead of returning an error. 

Fixes #98347 

## Tests
`String::num_int64`
  - [x] base < 2 returns an empty string and prints an error message
  - [x] base > 36 returns an empty string and prints an error message 

`String::num_uint64`
  - [x] no previous unit tests on `num_uint64` - added basic functionality tests 
  - [x] base < 2 returns an empty string and prints an error message
  - [x] base > 36 returns an empty string and prints an error message 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
