### PR TITLE
Preserve origin vector on `TRANSFORM` matrix at scale/rotation changing for visual shader particles

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2914,12 +2914,12 @@ void VisualShader::_update_shader() const {
 		global_compute_code += "	return mat3(vec3(oc * axis.x * axis.x + c, oc * axis.x * axis.y - axis.z * s, oc * axis.z * axis.x + axis.y * s), vec3(oc * axis.x * axis.y + axis.z * s, oc * axis.y * axis.y + c, oc * axis.y * axis.z - axis.x * s), vec3(oc * axis.z * axis.x - axis.y * s, oc * axis.y * axis.z + axis.x * s, oc * axis.z * axis.z + c));\n";
 		global_compute_code += "}\n\n";
 
-		global_compute_code += "mat4 __build_rotation_mat4(vec3 axis, float angle) {\n";
+		global_compute_code += "mat4 __build_rotation_mat4(vec3 axis, float angle, vec4 origin) {\n";
 		global_compute_code += "	axis = normalize(axis);\n";
 		global_compute_code += "	float s = sin(angle);\n";
 		global_compute_code += "	float c = cos(angle);\n";
 		global_compute_code += "	float oc = 1.0 - c;\n";
-		global_compute_code += "	return mat4(vec4(oc * axis.x * axis.x + c, oc * axis.x * axis.y - axis.z * s, oc * axis.z * axis.x + axis.y * s, 0), vec4(oc * axis.x * axis.y + axis.z * s, oc * axis.y * axis.y + c, oc * axis.y * axis.z - axis.x * s, 0), vec4(oc * axis.z * axis.x - axis.y * s, oc * axis.y * axis.z + axis.x * s, oc * axis.z * axis.z + c, 0), vec4(0, 0, 0, 1));\n";
+		global_compute_code += "	return mat4(vec4(oc * axis.x * axis.x + c, oc * axis.x * axis.y - axis.z * s, oc * axis.z * axis.x + axis.y * s, 0), vec4(oc * axis.x * axis.y + axis.z * s, oc * axis.y * axis.y + c, oc * axis.y * axis.z - axis.x * s, 0), vec4(oc * axis.z * axis.x - axis.y * s, oc * axis.y * axis.z + axis.x * s, oc * axis.z * axis.z + c, 0), origin);\n";
 		global_compute_code += "}\n\n";
 
 		global_compute_code += "vec2 __get_random_unit_vec2(inout uint seed) {\n";

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -1403,24 +1403,38 @@ String VisualShaderNodeParticleOutput::generate_code(Shader::Mode p_mode, Visual
 				rotation_axis = 5;
 				rotation = 6;
 			}
-			String op;
-			if (shader_type == VisualShader::TYPE_START) {
-				op = "*=";
-			} else {
-				op = "=";
-			}
 
-			if (!p_input_vars[rotation].is_empty()) { // rotation_axis & angle_in_radians
-				String axis;
+			String axis;
+			if (!p_input_vars[rotation].is_empty()) { // rotation_axis
 				if (p_input_vars[rotation_axis].is_empty()) {
 					axis = "vec3(0, 1, 0)";
 				} else {
 					axis = p_input_vars[rotation_axis];
 				}
-				code += tab + "TRANSFORM " + op + " __build_rotation_mat4(" + axis + ", " + p_input_vars[rotation] + ");\n";
 			}
-			if (!p_input_vars[scale].is_empty()) { // scale
-				code += tab + "TRANSFORM " + op + " mat4(vec4(" + p_input_vars[scale] + ", 0, 0, 0), vec4(0, " + p_input_vars[scale] + ", 0, 0), vec4(0, 0, " + p_input_vars[scale] + ", 0), vec4(0, 0, 0, 1));\n";
+
+			if (shader_type == VisualShader::TYPE_PROCESS) {
+				if (!p_input_vars[rotation].is_empty()) { // angle_in_radians
+					if (!p_input_vars[scale].is_empty()) { // scale
+						code += tab + "TRANSFORM = ";
+						code += "mat4(vec4(1, 0, 0, 0), vec4(0, 1, 0, 0), vec4(0, 0, 1, 0), TRANSFORM[3])";
+						code += " * ";
+						code += "mat4(vec4(" + p_input_vars[scale] + ", 0, 0, 0), vec4(0, " + p_input_vars[scale] + ", 0, 0), vec4(0, 0, " + p_input_vars[scale] + ", 0), vec4(0, 0, 0, 1))";
+						code += " * ";
+						code += "__build_rotation_mat4(" + axis + ", " + p_input_vars[rotation] + ", vec4(0, 0, 0, 1));\n";
+					} else {
+						code += tab + "TRANSFORM = __build_rotation_mat4(" + axis + ", " + p_input_vars[rotation] + ", TRANSFORM[3]);\n";
+					}
+				} else if (!p_input_vars[scale].is_empty()) { // scale
+					code += tab + "TRANSFORM = mat4(vec4(" + p_input_vars[scale] + ", 0, 0, 0), vec4(0, " + p_input_vars[scale] + ", 0, 0), vec4(0, 0, " + p_input_vars[scale] + ", 0), TRANSFORM[3]);\n";
+				}
+			} else {
+				if (!p_input_vars[scale].is_empty()) { // scale
+					code += tab + "TRANSFORM *= mat4(vec4(" + p_input_vars[scale] + ", 0, 0, 0), vec4(0, " + p_input_vars[scale] + ", 0, 0), vec4(0, 0, " + p_input_vars[scale] + ", 0), vec4(0.0, 0.0, 0.0, 1.0));\n";
+				}
+				if (!p_input_vars[rotation].is_empty()) { // angle_in_radians
+					code += tab + "TRANSFORM *= __build_rotation_mat4(" + axis + ", " + p_input_vars[rotation] + ", vec4(0, 0, 0, 1));\n";
+				}
 			}
 		}
 		if (!p_input_vars[0].is_empty()) { // Active (end).


### PR DESCRIPTION
This change is needed to make Scale/Rotation outputs actually useful in process function, without it, each particle TRANSFORM position (origin) will be reset every time the process function executes and the user has connection to these ports.

So with this change it's working properly (origin is preserved):

![vs_preserve_origin](https://github.com/user-attachments/assets/73d7491a-9678-4e32-a09a-2b9c40545c3e)

without this change, the position is stuck (which, I think, is not what the end user desired):

![vs_preserve_origin_old](https://github.com/user-attachments/assets/7f54fdd6-55c1-411b-b2b6-a527c4c3360a)

Also, I've fixed the possibility of changing scale and rotation at the same time.

![vs_preserve_origin2](https://github.com/user-attachments/assets/f5b880ec-65f4-40bc-9df7-58a6c059e1a4)

Test project:

[Test.zip](https://github.com/user-attachments/files/17449914/Test.zip)

