### PR TITLE
Sync filesystem before rename during atomic write

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -146,7 +146,7 @@ void FileAccessUnix::_sync() {
 	ERR_FAIL_COND(fd < 0);
 
 #ifdef __APPLE__
-	return fcntl(fd, F_BARRIERFSYNC);
+	fcntl(fd, F_BARRIERFSYNC);
 #else
 	int fsync_error;
 	do {

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -37,6 +37,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -142,7 +143,13 @@ void FileAccessUnix::_sync() {
 
 	fflush(f);
 	int fd = fileno(f);
-	fsync(fd);
+	ERR_FAIL_COND(fd < 0);
+
+	int fsync_error;
+	do {
+		fsync_error = fsync(fd);
+	} while (fsync_error < 0 && errno == EINTR);
+	ERR_FAIL_COND_MSG(fsync_error < 0, strerror(errno));
 }
 
 void FileAccessUnix::_close() {

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -145,11 +145,15 @@ void FileAccessUnix::_sync() {
 	int fd = fileno(f);
 	ERR_FAIL_COND(fd < 0);
 
+#ifdef __APPLE__
+	return fcntl(fd, F_BARRIERFSYNC);
+#else
 	int fsync_error;
 	do {
 		fsync_error = fsync(fd);
 	} while (fsync_error < 0 && errno == EINTR);
 	ERR_FAIL_COND_MSG(fsync_error < 0, strerror(errno));
+#endif
 }
 
 void FileAccessUnix::_close() {

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -137,11 +137,22 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
+void FileAccessUnix::_sync() {
+	ERR_FAIL_NULL(f);
+
+	fflush(f);
+	int fd = fileno(f);
+	fsync(fd);
+}
+
 void FileAccessUnix::_close() {
 	if (!f) {
 		return;
 	}
 
+	if (!save_path.is_empty()) {
+		_sync();
+	}
 	fclose(f);
 	f = nullptr;
 

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -49,6 +49,7 @@ class FileAccessUnix : public FileAccess {
 	String path;
 	String path_src;
 
+	void _sync();
 	void _close();
 
 public:

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -225,11 +225,23 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 	}
 }
 
+void FileAccessWindows::_sync() {
+	ERR_FAIL_NULL(f);
+
+	fflush(f);
+	int fd = _fileno(f);
+	HANDLE hf = (HANDLE)_get_osfhandle(fd);
+	FlushFileBuffers(hf);
+}
+
 void FileAccessWindows::_close() {
 	if (!f) {
 		return;
 	}
 
+	if (!save_path.is_empty()) {
+		_sync();
+	}
 	fclose(f);
 	f = nullptr;
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -230,8 +230,10 @@ void FileAccessWindows::_sync() {
 
 	fflush(f);
 	int fd = _fileno(f);
+	ERR_FAIL_COND(fd < 0);
 	HANDLE hf = (HANDLE)_get_osfhandle(fd);
-	FlushFileBuffers(hf);
+	ERR_FAIL_COND(hf == INVALID_HANDLE_VALUE);
+	ERR_FAIL_COND(!FlushFileBuffers(hf));
 }
 
 void FileAccessWindows::_close() {

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -48,6 +48,7 @@ class FileAccessWindows : public FileAccess {
 	String path_src;
 	String save_path;
 
+	void _sync();
 	void _close();
 
 	static HashSet<String> invalid_files;


### PR DESCRIPTION
Make sure the contents of the file are written to disk before renaming it on top of any existing file. In the event of power loss or OS crash, this ensures that the file will contain either the old version or the complete contents of the new version. Otherwise, the user could be left with an incompletely written file and data loss.

In each of the Windows and Unix implementations of `FileAcccess`, add an internal `sync()` operations that's called right before the rename if `is_backup_save_enabled()`. On Unix, `sync()` calls `fsync()` on the underlying file descriptor. On Windows, `sync()` calls `FlushFileBuffers()` on the underlying file handle.

This fixes #98360.