### PR TITLE
Add an option to toggle gizmo subscene visibility in the 2D and 3D editor

### DIFF
--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -207,6 +207,13 @@
 				Sets the gizmo's hidden state. If [code]true[/code], the gizmo will be hidden. If [code]false[/code], it will be shown.
 			</description>
 		</method>
+		<method name="set_hidden_subscenes">
+			<return type="void" />
+			<param index="0" name="hidden_subscenes" type="bool" />
+			<description>
+				Sets any gizmos in subscenes' states to the hidden state. If [code]true[/code], any subscene gizmos will be hidden. If [code]false[/code], they will be shown.
+			</description>
+		</method>
 		<method name="set_node_3d">
 			<return type="void" />
 			<param index="0" name="node" type="Node" />

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3768,7 +3768,9 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 		_draw_invisible_nodes_positions(p_node->get_child(i), parent_xform, canvas_xform);
 	}
 
-	if (show_position_gizmos && ci && !ci->_edit_use_rect() && (!editor_selection->is_selected(ci) || _is_node_locked(ci))) {
+	const bool is_hidden_subscene_gizmo = hide_subscene_gizmos && !p_node->get_scene_file_path().is_empty();
+
+	if (!is_hidden_subscene_gizmo && show_position_gizmos && ci && !ci->_edit_use_rect() && (!editor_selection->is_selected(ci) || _is_node_locked(ci))) {
 		Transform2D xform = transform * canvas_xform * parent_xform;
 
 		// Draw the node's position
@@ -3899,17 +3901,17 @@ void CanvasItemEditor::_draw_locks_and_groups(Node *p_node, const Transform2D &p
 	}
 
 	RID viewport_ci = viewport->get_canvas_item();
+	const bool is_hidden_subscene_gizmo = hide_subscene_gizmos && !p_node->get_scene_file_path().is_empty();
 	if (ci) {
 		real_t offset = 0;
 
 		Ref<Texture2D> lock = get_editor_theme_icon(SNAME("LockViewport"));
-		if (show_lock_gizmos && p_node->has_meta("_edit_lock_")) {
+		if (!is_hidden_subscene_gizmo && show_lock_gizmos && p_node->has_meta("_edit_lock_")) {
 			lock->draw(viewport_ci, (transform * canvas_xform * parent_xform).xform(Point2(0, 0)) + Point2(offset, 0));
 			offset += lock->get_size().x;
 		}
-
 		Ref<Texture2D> group = get_editor_theme_icon(SNAME("GroupViewport"));
-		if (show_group_gizmos && ci->has_meta("_edit_group_")) {
+		if (!is_hidden_subscene_gizmo && show_group_gizmos && ci->has_meta("_edit_group_")) {
 			group->draw(viewport_ci, (transform * canvas_xform * parent_xform).xform(Point2(0, 0)) + Point2(offset, 0));
 			//offset += group->get_size().x;
 		}
@@ -4390,6 +4392,12 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			show_viewport = !show_viewport;
 			int idx = view_menu->get_popup()->get_item_index(SHOW_VIEWPORT);
 			view_menu->get_popup()->set_item_checked(idx, show_viewport);
+			viewport->queue_redraw();
+		} break;
+		case HIDE_SUBSCENE_GIZMOS: {
+			hide_subscene_gizmos = !hide_subscene_gizmos;
+			int idx = gizmos_menu->get_item_index(HIDE_SUBSCENE_GIZMOS);
+			gizmos_menu->set_item_checked(idx, hide_subscene_gizmos);
 			viewport->queue_redraw();
 		} break;
 		case SHOW_POSITION_GIZMOS: {
@@ -5515,6 +5523,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	gizmos_menu->set_name("GizmosMenu");
 	gizmos_menu->connect(SceneStringName(id_pressed), callable_mp(this, &CanvasItemEditor::_popup_callback));
 	gizmos_menu->set_hide_on_checkable_item_selection(false);
+	gizmos_menu->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/hide_subscene_gizmos", TTR("Hide Subscene Gizmos")), HIDE_SUBSCENE_GIZMOS);
 	gizmos_menu->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/show_position_gizmos", TTR("Position")), SHOW_POSITION_GIZMOS);
 	gizmos_menu->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/show_lock_gizmos", TTR("Lock")), SHOW_LOCK_GIZMOS);
 	gizmos_menu->add_check_shortcut(ED_SHORTCUT("canvas_item_editor/show_group_gizmos", TTR("Group")), SHOW_GROUP_GIZMOS);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -147,7 +147,8 @@ private:
 		VIEW_FRAME_TO_SELECTION,
 		PREVIEW_CANVAS_SCALE,
 		SKELETON_MAKE_BONES,
-		SKELETON_SHOW_BONES
+		SKELETON_SHOW_BONES,
+		HIDE_SUBSCENE_GIZMOS,
 	};
 
 	enum DragType {
@@ -214,6 +215,7 @@ private:
 	bool show_origin = true;
 	bool show_viewport = true;
 	bool show_helpers = false;
+	bool hide_subscene_gizmos = false;
 	bool show_position_gizmos = true;
 	bool show_lock_gizmos = true;
 	bool show_group_gizmos = true;

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -209,7 +209,7 @@ void EditorNode3DGizmo::set_node_3d(Node3D *p_node) {
 	spatial_node = p_node;
 }
 
-void EditorNode3DGizmo::Instance::create_instance(Node3D *p_base, bool p_hidden) {
+void EditorNode3DGizmo::Instance::create_instance(Node3D *p_base, bool p_hidden, bool p_hide_subscenes) {
 	instance = RS::get_singleton()->instance_create2(mesh->get_rid(), p_base->get_world_3d()->get_scenario());
 	RS::get_singleton()->instance_attach_object_instance_id(instance, p_base->get_instance_id());
 	if (skin_reference.is_valid()) {
@@ -220,6 +220,9 @@ void EditorNode3DGizmo::Instance::create_instance(Node3D *p_base, bool p_hidden)
 	}
 	RS::get_singleton()->instance_geometry_set_cast_shadows_setting(instance, RS::SHADOW_CASTING_SETTING_OFF);
 	int layer = p_hidden ? 0 : 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER;
+	if (p_hide_subscenes) {
+		layer = 0;
+	}
 	RS::get_singleton()->instance_set_layer_mask(instance, layer); //gizmos are 26
 	RS::get_singleton()->instance_geometry_set_flag(instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
 	RS::get_singleton()->instance_geometry_set_flag(instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
@@ -236,7 +239,7 @@ void EditorNode3DGizmo::add_mesh(const Ref<Mesh> &p_mesh, const Ref<Material> &p
 	ins.material = p_material;
 	ins.xform = p_xform;
 	if (valid) {
-		ins.create_instance(spatial_node, hidden);
+		ins.create_instance(spatial_node, hidden, (hide_subscenes && !(spatial_node->get_owner() == spatial_node->get_tree()->get_edited_scene_root())));
 		RS::get_singleton()->instance_set_transform(ins.instance, spatial_node->get_global_transform() * ins.xform);
 		if (ins.material.is_valid()) {
 			RS::get_singleton()->instance_geometry_set_material_override(ins.instance, p_material->get_rid());
@@ -320,7 +323,7 @@ void EditorNode3DGizmo::add_vertices(const Vector<Vector3> &p_vertices, const Re
 
 	ins.mesh = mesh;
 	if (valid) {
-		ins.create_instance(spatial_node, hidden);
+		ins.create_instance(spatial_node, hidden, (hide_subscenes && !(spatial_node->get_owner() == spatial_node->get_tree()->get_edited_scene_root())));
 		RS::get_singleton()->instance_set_transform(ins.instance, spatial_node->get_global_transform());
 	}
 
@@ -377,7 +380,7 @@ void EditorNode3DGizmo::add_unscaled_billboard(const Ref<Material> &p_material, 
 
 	ins.mesh = mesh;
 	if (valid) {
-		ins.create_instance(spatial_node, hidden);
+		ins.create_instance(spatial_node, hidden, (hide_subscenes && !(spatial_node->get_owner() == spatial_node->get_tree()->get_edited_scene_root())));
 		RS::get_singleton()->instance_set_transform(ins.instance, spatial_node->get_global_transform());
 	}
 
@@ -462,7 +465,7 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 	ins.mesh = mesh;
 	ins.extra_margin = true;
 	if (valid) {
-		ins.create_instance(spatial_node, hidden);
+		ins.create_instance(spatial_node, hidden, (hide_subscenes && !(spatial_node->get_owner() == spatial_node->get_tree()->get_edited_scene_root())));
 		RS::get_singleton()->instance_set_transform(ins.instance, spatial_node->get_global_transform());
 	}
 	instances.push_back(ins);
@@ -507,7 +510,7 @@ bool EditorNode3DGizmo::intersect_frustum(const Camera3D *p_camera, const Vector
 	ERR_FAIL_NULL_V(spatial_node, false);
 	ERR_FAIL_COND_V(!valid, false);
 
-	if (hidden && !gizmo_plugin->is_selectable_when_hidden()) {
+	if ((hidden && !gizmo_plugin->is_selectable_when_hidden()) || (hide_subscenes && !(spatial_node->get_owner() == spatial_node->get_tree()->get_edited_scene_root()))) {
 		return false;
 	}
 
@@ -588,7 +591,7 @@ void EditorNode3DGizmo::handles_intersect_ray(Camera3D *p_camera, const Vector2 
 	ERR_FAIL_NULL(spatial_node);
 	ERR_FAIL_COND(!valid);
 
-	if (hidden) {
+	if (hidden || (hide_subscenes && !(spatial_node->get_owner() == spatial_node->get_tree()->get_edited_scene_root()))) {
 		return;
 	}
 
@@ -647,7 +650,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 	ERR_FAIL_NULL_V(spatial_node, false);
 	ERR_FAIL_COND_V(!valid, false);
 
-	if (hidden && !gizmo_plugin->is_selectable_when_hidden()) {
+	if ((hidden && !gizmo_plugin->is_selectable_when_hidden()) || (hide_subscenes && !(spatial_node->get_owner() == spatial_node->get_tree()->get_edited_scene_root()))) {
 		return false;
 	}
 
@@ -791,7 +794,7 @@ void EditorNode3DGizmo::create() {
 	valid = true;
 
 	for (int i = 0; i < instances.size(); i++) {
-		instances.write[i].create_instance(spatial_node, hidden);
+		instances.write[i].create_instance(spatial_node, hidden, (hide_subscenes && !(spatial_node->get_owner() == spatial_node->get_tree()->get_edited_scene_root())));
 	}
 
 	bvh_node_id = Node3DEditor::get_singleton()->insert_gizmo_bvh_node(
@@ -831,6 +834,14 @@ void EditorNode3DGizmo::free() {
 	valid = false;
 }
 
+void EditorNode3DGizmo::set_hidden_subscenes(bool p_subscenes) {
+	hide_subscenes = (p_subscenes && !(spatial_node->get_owner() == spatial_node->get_tree()->get_edited_scene_root()));
+	int layer = hide_subscenes ? 0 : 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER;
+	for (const Instance &instance : instances) {
+		RS::get_singleton()->instance_set_layer_mask(instance.instance, layer);
+	}
+}
+
 void EditorNode3DGizmo::set_hidden(bool p_hidden) {
 	hidden = p_hidden;
 	int layer = hidden ? 0 : 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER;
@@ -854,6 +865,7 @@ void EditorNode3DGizmo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_node_3d"), &EditorNode3DGizmo::get_node_3d);
 	ClassDB::bind_method(D_METHOD("get_plugin"), &EditorNode3DGizmo::get_plugin);
 	ClassDB::bind_method(D_METHOD("clear"), &EditorNode3DGizmo::clear);
+	ClassDB::bind_method(D_METHOD("set_hidden_subscenes", "hidden_subscenes"), &EditorNode3DGizmo::set_hidden_subscenes);
 	ClassDB::bind_method(D_METHOD("set_hidden", "hidden"), &EditorNode3DGizmo::set_hidden);
 	ClassDB::bind_method(D_METHOD("is_subgizmo_selected", "id"), &EditorNode3DGizmo::is_subgizmo_selected);
 	ClassDB::bind_method(D_METHOD("get_subgizmo_selection"), &EditorNode3DGizmo::get_subgizmo_selection);
@@ -1059,6 +1071,7 @@ Ref<EditorNode3DGizmo> EditorNode3DGizmoPlugin::get_gizmo(Node3D *p_spatial) {
 
 	ref->set_plugin(this);
 	ref->set_node_3d(p_spatial);
+	ref->set_hidden_subscenes(hidden_subscenes);
 	ref->set_hidden(current_state == HIDDEN);
 
 	current_gizmos.insert(ref.ptr());
@@ -1197,6 +1210,13 @@ void EditorNode3DGizmoPlugin::commit_subgizmos(const EditorNode3DGizmo *p_gizmo,
 	}
 
 	GDVIRTUAL_CALL(_commit_subgizmos, Ref<EditorNode3DGizmo>(p_gizmo), p_ids, restore, p_cancel);
+}
+
+void EditorNode3DGizmoPlugin::set_state_subscenes(bool p_hidden_subscenes) {
+	hidden_subscenes = p_hidden_subscenes;
+	for (EditorNode3DGizmo *current : current_gizmos) {
+		current->set_hidden_subscenes(hidden_subscenes);
+	}
 }
 
 void EditorNode3DGizmoPlugin::set_state(int p_state) {

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -52,7 +52,7 @@ class EditorNode3DGizmo : public Node3DGizmo {
 		bool extra_margin = false;
 		Transform3D xform;
 
-		void create_instance(Node3D *p_base, bool p_hidden = false);
+		void create_instance(Node3D *p_base, bool p_hidden = false, bool p_hide_subscenes = false);
 	};
 
 	bool selected;
@@ -70,6 +70,7 @@ class EditorNode3DGizmo : public Node3DGizmo {
 
 	bool valid;
 	bool hidden;
+	bool hide_subscenes;
 	Vector<Instance> instances;
 	Node3D *spatial_node = nullptr;
 
@@ -140,6 +141,7 @@ public:
 
 	virtual bool is_editable() const;
 
+	void set_hidden_subscenes(bool p_subscenes);
 	void set_hidden(bool p_hidden);
 	void set_plugin(EditorNode3DGizmoPlugin *p_plugin);
 
@@ -156,6 +158,7 @@ public:
 	static const int ON_TOP = 2;
 
 protected:
+	bool hidden_subscenes;
 	int current_state;
 	HashSet<EditorNode3DGizmo *> current_gizmos;
 	HashMap<String, Vector<Ref<StandardMaterial3D>>> materials;
@@ -215,6 +218,7 @@ public:
 	virtual void commit_subgizmos(const EditorNode3DGizmo *p_gizmo, const Vector<int> &p_ids, const Vector<Transform3D> &p_restore, bool p_cancel = false);
 
 	Ref<EditorNode3DGizmo> get_gizmo(Node3D *p_spatial);
+	void set_state_subscenes(bool p_hidden_subscenes);
 	void set_state(int p_state);
 	int get_state() const;
 	void unregister_gizmo(EditorNode3DGizmo *p_gizmo);

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -644,6 +644,7 @@ private:
 	RID origin_mesh;
 	RID origin_multimesh;
 	RID origin_instance;
+	bool hide_gizmo_subscenes = false;
 	bool origin_enabled = false;
 	RID grid[3];
 	RID grid_instance[3];
@@ -721,7 +722,8 @@ private:
 		MENU_UNLOCK_SELECTED,
 		MENU_GROUP_SELECTED,
 		MENU_UNGROUP_SELECTED,
-		MENU_SNAP_TO_FLOOR
+		MENU_SNAP_TO_FLOOR,
+		MENU_HIDE_SUBSCENES,
 	};
 
 	Button *tool_button[TOOL_MAX];
@@ -798,6 +800,7 @@ private:
 	void _node_removed(Node *p_node);
 	Vector<Ref<EditorNode3DGizmoPlugin>> gizmo_plugins_by_priority;
 	Vector<Ref<EditorNode3DGizmoPlugin>> gizmo_plugins_by_name;
+	bool hide_subscene_gizmos = false;
 
 	void _register_all_gizmos();
 


### PR DESCRIPTION
Accidentally closed previous PR renaming branch, once again opening PR referencing issue [#8220](https://github.com/godotengine/godot-proposals/issues/8220) ([Previous PR](https://github.com/godotengine/godot/pull/98351)) but adjusted the implementation to a checkbox next to the gizmo option in view, allowing gizmos subscenes to be hidden or shown on demand.
![image](https://github.com/user-attachments/assets/b657a708-349e-4102-a0ea-46600bcf2c4e)
![image](https://github.com/user-attachments/assets/adb1819b-ffbe-49a2-b101-c235772a1b2e)
2D implementation:
![image](https://github.com/user-attachments/assets/dae30dd0-52b5-43af-a991-a6480fb80fe9)
![image](https://github.com/user-attachments/assets/a961a3e7-1802-4561-bc04-de83952115c1)

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/8220* Closes #14462