### PR TITLE
Add PackedArrayRef classes, instances of PackedArrayRefRAII.

### DIFF
--- a/core/variant/packed_array_ref.h
+++ b/core/variant/packed_array_ref.h
@@ -1,0 +1,141 @@
+/**************************************************************************/
+/*  packed_array_ref.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef PACKED_ARRAY_REF_H
+#define PACKED_ARRAY_REF_H
+
+#include "core/os/memory.h"
+#include "core/templates/vector.h"
+
+struct PackedArrayRefBase {
+	SafeRefCount refcount;
+	_FORCE_INLINE_ PackedArrayRefBase *reference() {
+		if (refcount.ref()) {
+			return this;
+		} else {
+			return nullptr;
+		}
+	}
+	static _FORCE_INLINE_ PackedArrayRefBase *reference_from(PackedArrayRefBase *p_base, PackedArrayRefBase *p_from) {
+		if (p_base == p_from) {
+			return p_base; //same thing, do nothing
+		}
+
+		if (p_from->reference()) {
+			if (p_base->refcount.unref()) {
+				memdelete(p_base);
+			}
+			return p_from;
+		} else {
+			return p_base; //keep, could not reference new
+		}
+	}
+	static _FORCE_INLINE_ void destroy(PackedArrayRefBase *p_array) {
+		if (p_array->refcount.unref()) {
+			memdelete(p_array);
+		}
+	}
+	_FORCE_INLINE_ virtual ~PackedArrayRefBase() {} //needs virtual destructor, but make inline
+};
+
+template <typename T>
+struct PackedArrayRef : public PackedArrayRefBase {
+	Vector<T> array;
+	static _FORCE_INLINE_ PackedArrayRef<T> *create() {
+		return memnew(PackedArrayRef<T>);
+	}
+	static _FORCE_INLINE_ PackedArrayRef<T> *create(const Vector<T> &p_from) {
+		return memnew(PackedArrayRef<T>(p_from));
+	}
+
+	static _FORCE_INLINE_ const Vector<T> &get_array(PackedArrayRefBase *p_base) {
+		return static_cast<PackedArrayRef<T> *>(p_base)->array;
+	}
+	static _FORCE_INLINE_ Vector<T> *get_array_ptr(const PackedArrayRefBase *p_base) {
+		return &const_cast<PackedArrayRef<T> *>(static_cast<const PackedArrayRef<T> *>(p_base))->array;
+	}
+
+	_FORCE_INLINE_ PackedArrayRef(const Vector<T> &p_from) {
+		array = p_from;
+		refcount.init();
+	}
+	_FORCE_INLINE_ PackedArrayRef(const PackedArrayRef<T> &p_from) {
+		array = p_from.array;
+		refcount.init();
+	}
+	_FORCE_INLINE_ PackedArrayRef() {
+		refcount.init();
+	}
+};
+
+template <typename T>
+struct PackedArrayRefRAII {
+	PackedArrayRef<T> *ref = nullptr;
+
+	PackedArrayRefRAII() {
+		ref = PackedArrayRef<T>::create();
+	}
+
+	PackedArrayRefRAII(PackedArrayRefRAII<T> &p_from) {
+		if (p_from.ref) {
+			ref = dynamic_cast<PackedArrayRef<T> *>(p_from.ref->reference());
+		}
+	}
+
+	explicit PackedArrayRefRAII(const Vector<T> &p_from) {
+		ref = PackedArrayRef<T>::create(p_from);
+	}
+
+	explicit PackedArrayRefRAII(PackedArrayRef<T> &p_from) {
+		ref = dynamic_cast<PackedArrayRef<T> *>(p_from.reference());
+	}
+
+	explicit PackedArrayRefRAII(PackedArrayRef<T> *p_from) {
+		if (p_from) {
+			ref = dynamic_cast<PackedArrayRef<T> *>(p_from->reference());
+		}
+	}
+
+	~PackedArrayRefRAII() {
+		if (ref) {
+			PackedArrayRefBase::destroy(ref);
+		}
+	}
+
+	Vector<T> *operator->() {
+		return &ref->get_array_ptr(*this);
+	}
+
+	Vector<T> &operator*() {
+		return ref->get_array_ptr(*this);
+	}
+};
+
+#endif // PACKED_ARRAY_REF_H

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2349,6 +2349,86 @@ Variant::operator PackedVector4Array() const {
 	}
 }
 
+Variant::operator PackedByteArrayRef() {
+	if (type == PACKED_BYTE_ARRAY) {
+		return PackedByteArrayRef(static_cast<PackedArrayRef<uint8_t> *>(_data.packed_array));
+	} else {
+		return PackedByteArrayRef(_convert_array_from_variant<PackedByteArray>(*this));
+	}
+}
+
+Variant::operator PackedInt32ArrayRef() {
+	if (type == PACKED_INT32_ARRAY) {
+		return PackedInt32ArrayRef(static_cast<PackedArrayRef<int32_t> *>(_data.packed_array));
+	} else {
+		return PackedInt32ArrayRef(_convert_array_from_variant<PackedInt32Array>(*this));
+	}
+}
+
+Variant::operator PackedInt64ArrayRef() {
+	if (type == PACKED_INT64_ARRAY) {
+		return PackedInt64ArrayRef(static_cast<PackedArrayRef<int64_t> *>(_data.packed_array));
+	} else {
+		return PackedInt64ArrayRef(_convert_array_from_variant<PackedInt64Array>(*this));
+	}
+}
+
+Variant::operator PackedFloat32ArrayRef() {
+	if (type == PACKED_FLOAT32_ARRAY) {
+		return PackedFloat32ArrayRef(static_cast<PackedArrayRef<float> *>(_data.packed_array));
+	} else {
+		return PackedFloat32ArrayRef(_convert_array_from_variant<PackedFloat32Array>(*this));
+	}
+}
+
+Variant::operator PackedFloat64ArrayRef() {
+	if (type == PACKED_FLOAT64_ARRAY) {
+		return PackedFloat64ArrayRef(static_cast<PackedArrayRef<double> *>(_data.packed_array));
+	} else {
+		return PackedFloat64ArrayRef(_convert_array_from_variant<PackedFloat64Array>(*this));
+	}
+}
+
+Variant::operator PackedStringArrayRef() {
+	if (type == PACKED_STRING_ARRAY) {
+		return PackedStringArrayRef(static_cast<PackedArrayRef<String> *>(_data.packed_array));
+	} else {
+		return PackedStringArrayRef(_convert_array_from_variant<PackedStringArray>(*this));
+	}
+}
+
+Variant::operator PackedVector2ArrayRef() {
+	if (type == PACKED_VECTOR2_ARRAY) {
+		return PackedVector2ArrayRef(static_cast<PackedArrayRef<Vector2> *>(_data.packed_array));
+	} else {
+		return PackedVector2ArrayRef(_convert_array_from_variant<PackedVector2Array>(*this));
+	}
+}
+
+Variant::operator PackedVector3ArrayRef() {
+	if (type == PACKED_VECTOR3_ARRAY) {
+		return PackedVector3ArrayRef(static_cast<PackedArrayRef<Vector3> *>(_data.packed_array));
+	} else {
+		return PackedVector3ArrayRef(_convert_array_from_variant<PackedVector3Array>(*this));
+	}
+}
+
+Variant::operator PackedColorArrayRef() {
+	if (type == PACKED_COLOR_ARRAY) {
+		return PackedColorArrayRef(static_cast<PackedArrayRef<Color> *>(_data.packed_array));
+	} else {
+		return PackedColorArrayRef(_convert_array_from_variant<PackedColorArray>(*this));
+	}
+}
+
+Variant::operator PackedVector4ArrayRef() {
+	if (type == PACKED_VECTOR4_ARRAY) {
+		return PackedVector4ArrayRef(static_cast<PackedArrayRef<Vector4> *>(_data.packed_array));
+	} else {
+		return PackedVector4ArrayRef(_convert_array_from_variant<PackedVector4Array>(*this));
+	}
+}
+
 /* helpers */
 
 Variant::operator Vector<::RID>() const {
@@ -2694,6 +2774,56 @@ Variant::Variant(const PackedColorArray &p_color_array) :
 Variant::Variant(const PackedVector4Array &p_vector4_array) :
 		type(PACKED_VECTOR4_ARRAY) {
 	_data.packed_array = PackedArrayRef<Vector4>::create(p_vector4_array);
+}
+
+Variant::Variant(PackedByteArrayRef &p_byte_array) :
+		type(PACKED_BYTE_ARRAY) {
+	_data.packed_array = p_byte_array.ref->reference();
+}
+
+Variant::Variant(PackedInt32ArrayRef &p_int32_array) :
+		type(PACKED_INT32_ARRAY) {
+	_data.packed_array = p_int32_array.ref->reference();
+}
+
+Variant::Variant(PackedInt64ArrayRef &p_int64_array) :
+		type(PACKED_INT64_ARRAY) {
+	_data.packed_array = p_int64_array.ref->reference();
+}
+
+Variant::Variant(PackedFloat32ArrayRef &p_float32_array) :
+		type(PACKED_FLOAT32_ARRAY) {
+	_data.packed_array = p_float32_array.ref->reference();
+}
+
+Variant::Variant(PackedFloat64ArrayRef &p_float64_array) :
+		type(PACKED_FLOAT64_ARRAY) {
+	_data.packed_array = p_float64_array.ref->reference();
+}
+
+Variant::Variant(PackedStringArrayRef &p_string_array) :
+		type(PACKED_STRING_ARRAY) {
+	_data.packed_array = p_string_array.ref->reference();
+}
+
+Variant::Variant(PackedVector2ArrayRef &p_vector2_array) :
+		type(PACKED_VECTOR2_ARRAY) {
+	_data.packed_array = p_vector2_array.ref->reference();
+}
+
+Variant::Variant(PackedVector3ArrayRef &p_vector3_array) :
+		type(PACKED_VECTOR3_ARRAY) {
+	_data.packed_array = p_vector3_array.ref->reference();
+}
+
+Variant::Variant(PackedColorArrayRef &p_color_array) :
+		type(PACKED_COLOR_ARRAY) {
+	_data.packed_array = p_color_array.ref->reference();
+}
+
+Variant::Variant(PackedVector4ArrayRef &p_vector4_array) :
+		type(PACKED_VECTOR4_ARRAY) {
+	_data.packed_array = p_vector4_array.ref->reference();
 }
 
 /* helpers */

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -60,6 +60,7 @@
 #include "core/variant/array.h"
 #include "core/variant/callable.h"
 #include "core/variant/dictionary.h"
+#include "core/variant/packed_array_ref.h"
 
 class Object;
 class RefCounted;
@@ -81,6 +82,18 @@ typedef Vector<Vector2> PackedVector2Array;
 typedef Vector<Vector3> PackedVector3Array;
 typedef Vector<Color> PackedColorArray;
 typedef Vector<Vector4> PackedVector4Array;
+
+typedef PackedArrayRefRAII<uint8_t> PackedByteArrayRef;
+typedef PackedArrayRefRAII<int32_t> PackedInt32ArrayRef;
+typedef PackedArrayRefRAII<int64_t> PackedInt64ArrayRef;
+typedef PackedArrayRefRAII<float> PackedFloat32ArrayRef;
+typedef PackedArrayRefRAII<double> PackedFloat64ArrayRef;
+typedef PackedArrayRefRAII<real_t> PackedRealArrayRef;
+typedef PackedArrayRefRAII<String> PackedStringArrayRef;
+typedef PackedArrayRefRAII<Vector2> PackedVector2ArrayRef;
+typedef PackedArrayRefRAII<Vector3> PackedVector3ArrayRef;
+typedef PackedArrayRefRAII<Color> PackedColorArrayRef;
+typedef PackedArrayRefRAII<Vector4> PackedVector4ArrayRef;
 
 class Variant {
 public:
@@ -192,64 +205,6 @@ private:
 			} else {
 				unref();
 			}
-		}
-	};
-
-	/* array helpers */
-	struct PackedArrayRefBase {
-		SafeRefCount refcount;
-		_FORCE_INLINE_ PackedArrayRefBase *reference() {
-			if (refcount.ref()) {
-				return this;
-			} else {
-				return nullptr;
-			}
-		}
-		static _FORCE_INLINE_ PackedArrayRefBase *reference_from(PackedArrayRefBase *p_base, PackedArrayRefBase *p_from) {
-			if (p_base == p_from) {
-				return p_base; //same thing, do nothing
-			}
-
-			if (p_from->reference()) {
-				if (p_base->refcount.unref()) {
-					memdelete(p_base);
-				}
-				return p_from;
-			} else {
-				return p_base; //keep, could not reference new
-			}
-		}
-		static _FORCE_INLINE_ void destroy(PackedArrayRefBase *p_array) {
-			if (p_array->refcount.unref()) {
-				memdelete(p_array);
-			}
-		}
-		_FORCE_INLINE_ virtual ~PackedArrayRefBase() {} //needs virtual destructor, but make inline
-	};
-
-	template <typename T>
-	struct PackedArrayRef : public PackedArrayRefBase {
-		Vector<T> array;
-		static _FORCE_INLINE_ PackedArrayRef<T> *create() {
-			return memnew(PackedArrayRef<T>);
-		}
-		static _FORCE_INLINE_ PackedArrayRef<T> *create(const Vector<T> &p_from) {
-			return memnew(PackedArrayRef<T>(p_from));
-		}
-
-		static _FORCE_INLINE_ const Vector<T> &get_array(PackedArrayRefBase *p_base) {
-			return static_cast<PackedArrayRef<T> *>(p_base)->array;
-		}
-		static _FORCE_INLINE_ Vector<T> *get_array_ptr(const PackedArrayRefBase *p_base) {
-			return &const_cast<PackedArrayRef<T> *>(static_cast<const PackedArrayRef<T> *>(p_base))->array;
-		}
-
-		_FORCE_INLINE_ PackedArrayRef(const Vector<T> &p_from) {
-			array = p_from;
-			refcount.init();
-		}
-		_FORCE_INLINE_ PackedArrayRef() {
-			refcount.init();
 		}
 	};
 
@@ -434,6 +389,17 @@ public:
 	operator PackedColorArray() const;
 	operator PackedVector4Array() const;
 
+	operator PackedByteArrayRef();
+	operator PackedInt32ArrayRef();
+	operator PackedInt64ArrayRef();
+	operator PackedFloat32ArrayRef();
+	operator PackedFloat64ArrayRef();
+	operator PackedStringArrayRef();
+	operator PackedVector2ArrayRef();
+	operator PackedVector3ArrayRef();
+	operator PackedColorArrayRef();
+	operator PackedVector4ArrayRef();
+
 	operator Vector<::RID>() const;
 	operator Vector<Plane>() const;
 	operator Vector<Face3>() const;
@@ -499,6 +465,17 @@ public:
 	Variant(const PackedVector3Array &p_vector3_array);
 	Variant(const PackedColorArray &p_color_array);
 	Variant(const PackedVector4Array &p_vector4_array);
+
+	Variant(PackedByteArrayRef &p_byte_array);
+	Variant(PackedInt32ArrayRef &p_int32_array);
+	Variant(PackedInt64ArrayRef &p_int64_array);
+	Variant(PackedFloat32ArrayRef &p_float32_array);
+	Variant(PackedFloat64ArrayRef &p_float64_array);
+	Variant(PackedStringArrayRef &p_string_array);
+	Variant(PackedVector2ArrayRef &p_vector2_array);
+	Variant(PackedVector3ArrayRef &p_vector3_array);
+	Variant(PackedColorArrayRef &p_color_array);
+	Variant(PackedVector4ArrayRef &p_vector4_array);
 
 	Variant(const Vector<::RID> &p_array); // helper
 	Variant(const Vector<Plane> &p_array); // helper

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -186,26 +186,26 @@ public:
 	_FORCE_INLINE_ static const Array *get_array(const Variant *v) { return reinterpret_cast<const Array *>(v->_data._mem); }
 
 	// Typed arrays.
-	_FORCE_INLINE_ static PackedByteArray *get_byte_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedByteArray *get_byte_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedInt32Array *get_int32_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedInt32Array *get_int32_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedInt64Array *get_int64_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedInt64Array *get_int64_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedFloat32Array *get_float32_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<float> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedFloat32Array *get_float32_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<float> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedFloat64Array *get_float64_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<double> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedFloat64Array *get_float64_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<double> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedStringArray *get_string_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<String> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedStringArray *get_string_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<String> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedVector2Array *get_vector2_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedVector2Array *get_vector2_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedVector3Array *get_vector3_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedVector3Array *get_vector3_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedColorArray *get_color_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedColorArray *get_color_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedVector4Array *get_vector4_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedVector4Array *get_vector4_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedByteArray *get_byte_array(Variant *v) { return &static_cast<PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedByteArray *get_byte_array(const Variant *v) { return &static_cast<const PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedInt32Array *get_int32_array(Variant *v) { return &static_cast<PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedInt32Array *get_int32_array(const Variant *v) { return &static_cast<const PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedInt64Array *get_int64_array(Variant *v) { return &static_cast<PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedInt64Array *get_int64_array(const Variant *v) { return &static_cast<const PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedFloat32Array *get_float32_array(Variant *v) { return &static_cast<PackedArrayRef<float> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedFloat32Array *get_float32_array(const Variant *v) { return &static_cast<const PackedArrayRef<float> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedFloat64Array *get_float64_array(Variant *v) { return &static_cast<PackedArrayRef<double> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedFloat64Array *get_float64_array(const Variant *v) { return &static_cast<const PackedArrayRef<double> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedStringArray *get_string_array(Variant *v) { return &static_cast<PackedArrayRef<String> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedStringArray *get_string_array(const Variant *v) { return &static_cast<const PackedArrayRef<String> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedVector2Array *get_vector2_array(Variant *v) { return &static_cast<PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedVector2Array *get_vector2_array(const Variant *v) { return &static_cast<const PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedVector3Array *get_vector3_array(Variant *v) { return &static_cast<PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedVector3Array *get_vector3_array(const Variant *v) { return &static_cast<const PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedColorArray *get_color_array(Variant *v) { return &static_cast<PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedColorArray *get_color_array(const Variant *v) { return &static_cast<const PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static PackedVector4Array *get_vector4_array(Variant *v) { return &static_cast<PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
+	_FORCE_INLINE_ static const PackedVector4Array *get_vector4_array(const Variant *v) { return &static_cast<const PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
 
 	_FORCE_INLINE_ static Object **get_object(Variant *v) { return (Object **)&v->_get_obj().obj; }
 	_FORCE_INLINE_ static const Object **get_object(const Variant *v) { return (const Object **)&v->_get_obj().obj; }
@@ -279,43 +279,43 @@ public:
 		v->type = Variant::ARRAY;
 	}
 	_FORCE_INLINE_ static void init_byte_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<uint8_t>::create(Vector<uint8_t>());
+		v->_data.packed_array = PackedArrayRef<uint8_t>::create(Vector<uint8_t>());
 		v->type = Variant::PACKED_BYTE_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_int32_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<int32_t>::create(Vector<int32_t>());
+		v->_data.packed_array = PackedArrayRef<int32_t>::create(Vector<int32_t>());
 		v->type = Variant::PACKED_INT32_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_int64_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<int64_t>::create(Vector<int64_t>());
+		v->_data.packed_array = PackedArrayRef<int64_t>::create(Vector<int64_t>());
 		v->type = Variant::PACKED_INT64_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_float32_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<float>::create(Vector<float>());
+		v->_data.packed_array = PackedArrayRef<float>::create(Vector<float>());
 		v->type = Variant::PACKED_FLOAT32_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_float64_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<double>::create(Vector<double>());
+		v->_data.packed_array = PackedArrayRef<double>::create(Vector<double>());
 		v->type = Variant::PACKED_FLOAT64_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_string_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<String>::create(Vector<String>());
+		v->_data.packed_array = PackedArrayRef<String>::create(Vector<String>());
 		v->type = Variant::PACKED_STRING_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_vector2_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<Vector2>::create(Vector<Vector2>());
+		v->_data.packed_array = PackedArrayRef<Vector2>::create(Vector<Vector2>());
 		v->type = Variant::PACKED_VECTOR2_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_vector3_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<Vector3>::create(Vector<Vector3>());
+		v->_data.packed_array = PackedArrayRef<Vector3>::create(Vector<Vector3>());
 		v->type = Variant::PACKED_VECTOR3_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_color_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<Color>::create(Vector<Color>());
+		v->_data.packed_array = PackedArrayRef<Color>::create(Vector<Color>());
 		v->type = Variant::PACKED_COLOR_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_vector4_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<Vector4>::create(Vector<Vector4>());
+		v->_data.packed_array = PackedArrayRef<Vector4>::create(Vector<Vector4>());
 		v->type = Variant::PACKED_VECTOR4_ARRAY;
 	}
 	_FORCE_INLINE_ static void init_object(Variant *v) {

--- a/platform/windows/godot.natvis
+++ b/platform/windows/godot.natvis
@@ -177,16 +177,16 @@
 		<DisplayString Condition="type == Variant::OBJECT">{*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj}</DisplayString>
 		<DisplayString Condition="type == Variant::DICTIONARY">{*(Dictionary *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::ARRAY">{*(Array *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_BYTE_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_INT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_BYTE_ARRAY">{reinterpret_cast&lt;const PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_INT32_ARRAY">{reinterpret_cast&lt;const PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array}</DisplayString>
 		<DisplayString Condition="type == Variant::PACKED_INT64_ARRAY">{*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_FLOAT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_FLOAT64_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_STRING_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_VECTOR2_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_VECTOR3_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_COLOR_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_VECTOR4_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_FLOAT32_ARRAY">{reinterpret_cast&lt;const PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_FLOAT64_ARRAY">{reinterpret_cast&lt;const PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_STRING_ARRAY">{reinterpret_cast&lt;const PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_VECTOR2_ARRAY">{reinterpret_cast&lt;const PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_VECTOR3_ARRAY">{reinterpret_cast&lt;const PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_COLOR_ARRAY">{reinterpret_cast&lt;const PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_VECTOR4_ARRAY">{reinterpret_cast&lt;const PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array}</DisplayString>
 		<DisplayString Condition="type &lt; 0 || type >= Variant::VARIANT_MAX">[INVALID]</DisplayString>
 
 		<StringView Condition="type == Variant::STRING &amp;&amp; ((String *)(_data._mem))->_cowdata._ptr">((String *)(_data._mem))->_cowdata._ptr,s32</StringView>
@@ -212,16 +212,16 @@
 			<Item Name="[value]" Condition="type == Variant::OBJECT">*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj</Item>
 			<Item Name="[value]" Condition="type == Variant::DICTIONARY">*(Dictionary *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::ARRAY">*(Array *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_BYTE_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_INT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_BYTE_ARRAY">reinterpret_cast&lt;const PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_INT32_ARRAY">reinterpret_cast&lt;const PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array</Item>
 			<Item Name="[value]" Condition="type == Variant::PACKED_INT64_ARRAY">*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT64_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_STRING_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR2_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR3_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_COLOR_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR4_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT32_ARRAY">reinterpret_cast&lt;const PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT64_ARRAY">reinterpret_cast&lt;const PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_STRING_ARRAY">reinterpret_cast&lt;const PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR2_ARRAY">reinterpret_cast&lt;const PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR3_ARRAY">reinterpret_cast&lt;const PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_COLOR_ARRAY">reinterpret_cast&lt;const PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR4_ARRAY">reinterpret_cast&lt;const PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array</Item>
 
 		</Expand>
 	</Type>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10830.

The use-case of these new objects are explained in the proposal, but in short: They allow strongly typed in-place modification of Packed arrays. In-place modification without this PR is only possible through Variant's stringy interfaces. 

This PR compiles, but I have not yet tested the behavior. In particular:

- [ ] `PackedArrayRefRAII` classes should be especially useful in GDExtensions, and thus should be exposed to them. I have not not done this before yet so I'll have to take another look at that.