### PR TITLE
Translate main thread name in the editor instead of running project

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -419,7 +419,7 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 	msg.push_back(error_str);
 	ERR_FAIL_NULL(script_lang);
 	msg.push_back(script_lang->debug_get_stack_level_count() > 0);
-	msg.push_back(Thread::get_caller_id() == Thread::get_main_id() ? String(RTR("Main Thread")) : itos(Thread::get_caller_id()));
+	msg.push_back(Thread::get_caller_id());
 	if (allow_focus_steal_fn) {
 		allow_focus_steal_fn();
 	}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -329,8 +329,10 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 	if (p_msg == "debug_enter") {
 		ERR_FAIL_COND(p_data.size() != 4);
 
+		const Thread::ID caller_id = p_data[3];
+
 		ThreadDebugged td;
-		td.name = p_data[3];
+		td.name = (caller_id == Thread::get_main_id()) ? TTR("Main Thread") : itos(caller_id);
 		td.error = p_data[1];
 		td.can_debug = p_data[0];
 		td.has_stackdump = p_data[2];
@@ -1917,6 +1919,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		thread_hb->add_child(memnew(Label(TTR("Thread:"))));
 		threads = memnew(OptionButton);
 		thread_hb->add_child(threads);
+		threads->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		threads->set_h_size_flags(SIZE_EXPAND_FILL);
 		threads->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditorDebugger::_select_thread));
 


### PR DESCRIPTION
Fixes #97853

Thread name is generated by the debugger in the running project. So it's affected by the project's pseudo-localization settings.

https://github.com/godotengine/godot/blob/44fa552343722bb048e2d7c6d3661174a95a8a3c/core/debugger/remote_debugger.cpp#L422

Since the ID of main thread is fixed, we can simply send the ID instead of the name, then generate and translate the "Main Thread" text in the editor.

This changes the fourth field of the `debug_enter` message from a string to the thread ID.