### PR TITLE
Android & iOS: Enable strict aliasing

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -171,9 +171,7 @@ def configure(env: "SConsEnvironment"):
     env["AS"] = compiler_path + "/clang"
 
     env.Append(
-        CCFLAGS=(
-            "-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing".split()
-        )
+        CCFLAGS=("-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden".split())
     )
 
     if get_min_sdk_version(env["ndk_platform"]) >= 24:

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -134,7 +134,7 @@ def configure(env: "SConsEnvironment"):
     elif env["arch"] == "arm64":
         env.Append(
             CCFLAGS=(
-                "-fobjc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing"
+                "-fobjc-arc -arch arm64 -fmessage-length=0"
                 " -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits"
                 " -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies"
                 " -isysroot $IOS_SDK_PATH".split()


### PR DESCRIPTION
For some reason, these platforms were being built with the strict aliasing rule disabled, which can prevent certain optimizations. All the other platforms are built without them, so it should be fine.

The only reason I can think of why this is necessary is that the code didn't work well otherwise because `-fno-strict-aliasing` was compensating for an overrelyance on memory ordering on non-ARM platforms. That wouldn't be a long-term good reason for it, though.