### PR TITLE
Rationalize busy waits

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2903,9 +2903,9 @@ void EditorFileSystem::reimport_file_with_custom_parameters(const String &p_file
 }
 
 void EditorFileSystem::_reimport_thread(uint32_t p_index, ImportThreadData *p_import_data) {
-	int current_max = p_import_data->reimport_from + int(p_index);
-	p_import_data->max_index.exchange_if_greater(current_max);
-	_reimport_file(p_import_data->reimport_files[current_max].path);
+	int file_idx = p_import_data->reimport_from + int(p_index);
+	_reimport_file(p_import_data->reimport_files[file_idx].path);
+	p_import_data->imported_sem->post();
 }
 
 void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
@@ -2984,6 +2984,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 #endif
 
 	int from = 0;
+	Semaphore imported_sem;
 	for (int i = 0; i < reimport_files.size(); i++) {
 		if (groups_to_reimport.has(reimport_files[i].path)) {
 			from = i + 1;
@@ -3007,21 +3008,27 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 					importer->import_threaded_begin();
 
 					ImportThreadData tdata;
-					tdata.max_index.set(from);
 					tdata.reimport_from = from;
 					tdata.reimport_files = reimport_files.ptr();
+					tdata.imported_sem = &imported_sem;
 
-					WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &EditorFileSystem::_reimport_thread, &tdata, i - from + 1, -1, false, vformat(TTR("Import resources of type: %s"), reimport_files[from].importer));
-					int current_index = from - 1;
-					do {
-						if (current_index < tdata.max_index.get()) {
-							current_index = tdata.max_index.get();
-							ep->step(reimport_files[current_index].path.get_file(), current_index, false);
+					int item_count = i - from + 1;
+					WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &EditorFileSystem::_reimport_thread, &tdata, item_count, -1, false, vformat(TTR("Import resources of type: %s"), reimport_files[from].importer));
+
+					int imported_count = 0;
+					while (true) {
+						ep->step(reimport_files[imported_count].path.get_file(), from + imported_count, false);
+						imported_sem.wait();
+						do {
+							imported_count++;
+						} while (imported_sem.try_wait());
+						if (imported_count == item_count) {
+							break;
 						}
-						OS::get_singleton()->delay_usec(1);
-					} while (!WorkerThreadPool::get_singleton()->is_group_task_completed(group_task));
+					}
 
 					WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
+					DEV_ASSERT(!imported_sem.try_wait());
 
 					importer->import_threaded_end();
 				}

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -327,7 +327,7 @@ class EditorFileSystem : public Node {
 	struct ImportThreadData {
 		const ImportFile *reimport_files;
 		int reimport_from;
-		SafeNumeric<int> max_index;
+		Semaphore *imported_sem = nullptr;
 	};
 
 	void _reimport_thread(uint32_t p_index, ImportThreadData *p_import_data);

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -394,9 +394,7 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 	if (p_replace_previous) {
 		// Force sync last line update (skip if number of unprocessed log messages is too large to avoid editor lag).
 		if (log->get_pending_paragraphs() < 100) {
-			while (!log->is_finished()) {
-				::OS::get_singleton()->delay_usec(1);
-			}
+			log->wait_until_finished();
 		}
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5454,7 +5454,6 @@ bool EditorNode::immediate_confirmation_dialog(const String &p_text, const Strin
 	cd->popup_centered();
 
 	while (true) {
-		OS::get_singleton()->delay_usec(1);
 		DisplayServer::get_singleton()->process_events();
 		Main::iteration();
 		if (singleton->immediate_dialog_confirmed || !cd->is_visible()) {

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -577,7 +577,6 @@ bool EditorFileSystemImportFormatSupportQueryBlend::query() {
 	confirmed = false;
 
 	while (true) {
-		OS::get_singleton()->delay_usec(1);
 		DisplayServer::get_singleton()->process_events();
 		Main::iteration();
 		if (!configure_blender_dialog->is_visible() || confirmed) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2801,10 +2801,7 @@ void RichTextLabel::_thread_end() {
 void RichTextLabel::_stop_thread() {
 	if (threaded) {
 		stop_thread.store(true);
-		if (task != WorkerThreadPool::INVALID_TASK_ID) {
-			WorkerThreadPool::get_singleton()->wait_for_task_completion(task);
-			task = WorkerThreadPool::INVALID_TASK_ID;
-		}
+		wait_until_finished();
 	}
 }
 
@@ -2826,6 +2823,13 @@ bool RichTextLabel::is_finished() const {
 
 bool RichTextLabel::is_updating() const {
 	return updating.load() || validating.load();
+}
+
+void RichTextLabel::wait_until_finished() {
+	if (task != WorkerThreadPool::INVALID_TASK_ID) {
+		WorkerThreadPool::get_singleton()->wait_for_task_completion(task);
+		task = WorkerThreadPool::INVALID_TASK_ID;
+	}
 }
 
 void RichTextLabel::set_threaded(bool p_threaded) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -792,6 +792,7 @@ public:
 	int get_pending_paragraphs() const;
 	bool is_finished() const;
 	bool is_updating() const;
+	void wait_until_finished();
 
 	void set_threaded(bool p_threaded);
 	bool is_threaded() const;


### PR DESCRIPTION
~Using the yield primitive lets the OS know our intent better than a microwait. This _may_ improve energy efficiency and/or performance.~

---

**2024-10-31:**

@lyuma's comment about the specific cases made me realize we don't even need to discuss how to implement a yield mechanism, since there's no real need for that.

So, I've updated the PR addressing each case of `delay_usec(1)` in loops:
- `EditorFileSystem`: It was used to poll for the status of the batched import. I've overhauled it so a semaphore controls it instead.
- `EditogLog`: I've added a non-polling sync mechanism to `RichTextLabel`. (By the way, `RichTextLabel` threading warrants further threading improvements, but that's out of the scope of this PR.)
- `EditorNode::immediate_confirmation_dialog()`, `EditorFileSystemImportFormatSupportQueryBlend`: They are already using main loop iterations, so pacing is implicit.
- ~`HTTPRequest`: In threaded mode, it uses blocking sockets, so the loop isn't really going to run freely. Therefore, I've just removed the relevant call. (Is blocking not supported somewhere?)~