### PR TITLE
Improve synchronization of rendering after changes from transfer queues.

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -366,6 +366,15 @@ public:
 	/**** FRAMEBUFFER ****/
 	/*********************/
 
+	struct Framebuffer {
+		VkFramebuffer vk_framebuffer = VK_NULL_HANDLE;
+
+		// Only filled in by a framebuffer created by a swap chain. Unused otherwise.
+		VkImage swap_chain_image = VK_NULL_HANDLE;
+		VkImageSubresourceRange swap_chain_image_subresource_range = {};
+		bool swap_chain_acquired = false;
+	};
+
 	virtual FramebufferID framebuffer_create(RenderPassID p_render_pass, VectorView<TextureID> p_attachments, uint32_t p_width, uint32_t p_height) override final;
 	virtual void framebuffer_free(FramebufferID p_framebuffer) override final;
 

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -151,6 +151,8 @@ public:
 	struct ResourceTracker {
 		uint32_t reference_count = 0;
 		int64_t command_frame = -1;
+		BitField<RDD::PipelineStageBits> previous_frame_stages;
+		BitField<RDD::PipelineStageBits> current_frame_stages;
 		int32_t read_full_command_list_index = -1;
 		int32_t read_slice_command_list_index = -1;
 		int32_t write_command_or_list_index = -1;
@@ -174,8 +176,9 @@ public:
 
 		_FORCE_INLINE_ void reset_if_outdated(int64_t new_command_frame) {
 			if (new_command_frame != command_frame) {
-				usage_access.clear();
 				command_frame = new_command_frame;
+				previous_frame_stages = current_frame_stages;
+				current_frame_stages.clear();
 				read_full_command_list_index = -1;
 				read_slice_command_list_index = -1;
 				write_command_or_list_index = -1;


### PR DESCRIPTION
After transfer queues were merged, some new unexpected synchronization errors popped up that were previously not encountered because the setup queue was introducing its own barriers and forcing most of the caches to be flushed through a global memory barrier.

These changes introduce proper synchronization tracking for usages on the _previous_ frame, as the hazards were not visible inside the same frame but rather between frames. This has fixed some flickering that was visible in the TPS Demo in Mobile that did not happen before #90400 was merged.

This PR also fixes an error where debug labels were not being properly closed each frame, leading to the labels leaking into the next frames and causing them to keep growing in depth.