### PR TITLE
Add Variant value pointer getter functions, similar to get_validated_object.

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2183,6 +2183,302 @@ Object *Variant::get_validated_object() const {
 	}
 }
 
+bool *Variant::get_bool() {
+	if (type == BOOL) {
+		return &_data._bool;
+	} else {
+		return nullptr;
+	}
+}
+
+int64_t *Variant::get_int() {
+	if (type == INT) {
+		return &_data._int;
+	} else {
+		return nullptr;
+	}
+}
+
+double *Variant::get_float() {
+	if (type == FLOAT) {
+		return &_data._float;
+	} else {
+		return nullptr;
+	}
+}
+
+String *Variant::get_string() {
+	if (type == STRING) {
+		return reinterpret_cast<String *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Vector2 *Variant::get_vector2() {
+	if (type == VECTOR2) {
+		return reinterpret_cast<Vector2 *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Vector2i *Variant::get_vector2i() {
+	if (type == VECTOR2I) {
+		return reinterpret_cast<Vector2i *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Rect2 *Variant::get_rect2() {
+	if (type == RECT2) {
+		return reinterpret_cast<Rect2 *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Rect2i *Variant::get_rect2i() {
+	if (type == RECT2I) {
+		return reinterpret_cast<Rect2i *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Transform2D *Variant::get_transform2d() {
+	if (type == TRANSFORM2D) {
+		return _data._transform2d;
+	} else {
+		return nullptr;
+	}
+}
+
+Vector3 *Variant::get_vector3() {
+	if (type == VECTOR3) {
+		return reinterpret_cast<Vector3 *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Vector3i *Variant::get_vector3i() {
+	if (type == VECTOR3I) {
+		return reinterpret_cast<Vector3i *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Vector4 *Variant::get_vector4() {
+	if (type == VECTOR4) {
+		return reinterpret_cast<Vector4 *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Vector4i *Variant::get_vector4i() {
+	if (type == VECTOR4I) {
+		return reinterpret_cast<Vector4i *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Plane *Variant::get_plane() {
+	if (type == PLANE) {
+		return reinterpret_cast<Plane *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+::AABB *Variant::get_aabb() {
+	if (type == AABB) {
+		return _data._aabb;
+	} else {
+		return nullptr;
+	}
+}
+
+Quaternion *Variant::get_quaternion() {
+	if (type == QUATERNION) {
+		return reinterpret_cast<Quaternion *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Basis *Variant::get_basis() {
+	if (type == BASIS) {
+		return _data._basis;
+	} else {
+		return nullptr;
+	}
+}
+
+Transform3D *Variant::get_transform3d() {
+	if (type == TRANSFORM3D) {
+		return _data._transform3d;
+	} else {
+		return nullptr;
+	}
+}
+
+Projection *Variant::get_projection() {
+	if (type == PROJECTION) {
+		return _data._projection;
+	} else {
+		return nullptr;
+	}
+}
+
+Color *Variant::get_color() {
+	if (type == COLOR) {
+		return reinterpret_cast<Color *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+::RID *Variant::get_rid() {
+	if (type == RID) {
+		return reinterpret_cast<::RID *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Callable *Variant::get_callable() {
+	if (type == CALLABLE) {
+		return reinterpret_cast<Callable *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Signal *Variant::get_signal() {
+	if (type == SIGNAL) {
+		return reinterpret_cast<Signal *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+StringName *Variant::get_string_name() {
+	if (type == STRING_NAME) {
+		return reinterpret_cast<StringName *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+NodePath *Variant::get_node_path() {
+	if (type == NODE_PATH) {
+		return reinterpret_cast<NodePath *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Dictionary *Variant::get_dictionary() {
+	if (type == DICTIONARY) {
+		return reinterpret_cast<Dictionary *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+Array *Variant::get_array() {
+	if (type == ARRAY) {
+		return reinterpret_cast<Array *>(_data._mem);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedByteArray *Variant::get_packed_byte_array() {
+	if (type == PACKED_BYTE_ARRAY) {
+		return PackedArrayRef<uint8_t>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedInt32Array *Variant::get_packed_int32_array() {
+	if (type == PACKED_INT32_ARRAY) {
+		return PackedArrayRef<int32_t>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedInt64Array *Variant::get_packed_int64_array() {
+	if (type == PACKED_INT64_ARRAY) {
+		return PackedArrayRef<int64_t>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedFloat32Array *Variant::get_packed_float32_array() {
+	if (type == PACKED_FLOAT32_ARRAY) {
+		return PackedArrayRef<float>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedFloat64Array *Variant::get_packed_float64_array() {
+	if (type == PACKED_FLOAT64_ARRAY) {
+		return PackedArrayRef<double>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedStringArray *Variant::get_packed_string_array() {
+	if (type == PACKED_STRING_ARRAY) {
+		return PackedArrayRef<String>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedVector2Array *Variant::get_packed_vector2_array() {
+	if (type == PACKED_VECTOR2_ARRAY) {
+		return PackedArrayRef<Vector2>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedVector3Array *Variant::get_packed_vector3_array() {
+	if (type == PACKED_VECTOR3_ARRAY) {
+		return PackedArrayRef<Vector3>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedColorArray *Variant::get_packed_color_array() {
+	if (type == PACKED_COLOR_ARRAY) {
+		return PackedArrayRef<Color>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
+PackedVector4Array *Variant::get_packed_vector4_array() {
+	if (type == PACKED_VECTOR4_ARRAY) {
+		return PackedArrayRef<Vector4>::get_array_ptr(_data.packed_array);
+	} else {
+		return nullptr;
+	}
+}
+
 Variant::operator Dictionary() const {
 	if (type == DICTIONARY) {
 		return *reinterpret_cast<const Dictionary *>(_data._mem);

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -449,6 +449,50 @@ public:
 	Object *get_validated_object() const;
 	Object *get_validated_object_with_check(bool &r_previously_freed) const;
 
+	bool *get_bool();
+	int64_t *get_int();
+	double *get_float();
+
+	String *get_string();
+	Vector2 *get_vector2();
+	Vector2i *get_vector2i();
+	Rect2 *get_rect2();
+	Rect2i *get_rect2i();
+	Transform2D *get_transform2d();
+	Vector3 *get_vector3();
+	Vector3i *get_vector3i();
+	Vector4 *get_vector4();
+	Vector4i *get_vector4i();
+	Plane *get_plane();
+	::AABB *get_aabb();
+	Quaternion *get_quaternion();
+	Basis *get_basis();
+	Transform3D *get_transform3d();
+	Projection *get_projection();
+	Color *get_color();
+
+	::RID *get_rid();
+
+	Callable *get_callable();
+	Signal *get_signal();
+
+	StringName *get_string_name();
+	NodePath *get_node_path();
+
+	Dictionary *get_dictionary();
+	Array *get_array();
+
+	PackedByteArray *get_packed_byte_array();
+	PackedInt32Array *get_packed_int32_array();
+	PackedInt64Array *get_packed_int64_array();
+	PackedFloat32Array *get_packed_float32_array();
+	PackedFloat64Array *get_packed_float64_array();
+	PackedStringArray *get_packed_string_array();
+	PackedVector2Array *get_packed_vector2_array();
+	PackedVector3Array *get_packed_vector3_array();
+	PackedColorArray *get_packed_color_array();
+	PackedVector4Array *get_packed_vector4_array();
+
 	Variant(bool p_bool);
 	Variant(int64_t p_int64);
 	Variant(int32_t p_int32);


### PR DESCRIPTION
Adds the ability to interact with Variant's underlying types in a strongly typed fashion.

Related to #98373: They two fill similar, but still somewhat orthogonal, use-cases. 

Related to https://github.com/godotengine/godot-proposals/issues/10830. This PR does not close the proposal, but partially addresses its use-cases. For more information, see my discussion with @dsnopek in the proposal.