### PR TITLE
GDScript: Fix cached parser error when using typed Dictionaries

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -165,6 +165,10 @@ public:
 			container_element_types.write[p_index] = DataType(p_type);
 		}
 
+		_FORCE_INLINE_ int get_container_element_type_count() const {
+			return container_element_types.size();
+		}
+
 		_FORCE_INLINE_ DataType get_container_element_type(int p_index) const {
 			ERR_FAIL_INDEX_V(p_index, container_element_types.size(), get_variant_type());
 			return container_element_types[p_index];


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/96881

a small mistake from https://github.com/godotengine/godot/pull/94871 where i only checked the first of the container types

also added a message to `ensure_cached_external_parser_for_class` explaining its function 