### PR TITLE
Don't use Separate Physics Thread in Editor

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2862,7 +2862,6 @@ void Node3DEditorViewport::_notification(int p_what) {
 			bool vp_visible = is_visible_in_tree();
 
 			set_process(vp_visible);
-			set_physics_process(vp_visible);
 
 			if (vp_visible) {
 				orthogonal = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_ORTHOGONAL));
@@ -3082,14 +3081,10 @@ void Node3DEditorViewport::_notification(int p_what) {
 				float locked_half_width = locked_label->get_size().width / 2.0f;
 				locked_label->set_anchor_and_offset(SIDE_LEFT, 0.5f, -locked_half_width);
 			}
-		} break;
 
-		case NOTIFICATION_PHYSICS_PROCESS: {
 			if (collision_reposition) {
-				List<Node *> &selection = editor_selection->get_selected_node_list();
-
-				if (selection.size() == 1) {
-					Node3D *first_selected_node = Object::cast_to<Node3D>(selection.front()->get());
+				if (editor_selection->get_selected_node_list().size() == 1) {
+					Node3D *first_selected_node = Object::cast_to<Node3D>(editor_selection->get_selected_node_list().front()->get());
 					double snap = EDITOR_GET("interface/inspector/default_float_step");
 					int snap_step_decimals = Math::range_step_decimals(snap);
 					set_message(TTR("Translating:") + " (" + String::num(first_selected_node->get_global_position().x, snap_step_decimals) + ", " +
@@ -8115,7 +8110,7 @@ void Node3DEditor::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_PHYSICS_PROCESS: {
+		case NOTIFICATION_PROCESS: {
 			if (do_snap_selected_nodes_to_floor) {
 				_snap_selected_nodes_to_floor();
 				do_snap_selected_nodes_to_floor = false;
@@ -9321,12 +9316,9 @@ void Node3DEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		spatial_editor->show();
 		spatial_editor->set_process(true);
-		spatial_editor->set_physics_process(true);
-
 	} else {
 		spatial_editor->hide();
 		spatial_editor->set_process(false);
-		spatial_editor->set_physics_process(false);
 	}
 }
 

--- a/modules/godot_physics_2d/register_types.cpp
+++ b/modules/godot_physics_2d/register_types.cpp
@@ -36,7 +36,7 @@
 
 static PhysicsServer2D *_createGodotPhysics2DCallback() {
 #ifdef THREADS_ENABLED
-	bool using_threads = GLOBAL_GET("physics/2d/run_on_separate_thread");
+	bool using_threads = GLOBAL_GET("physics/2d/run_on_separate_thread") && !Engine::get_singleton()->is_editor_hint();
 #else
 	bool using_threads = false;
 #endif

--- a/modules/godot_physics_3d/register_types.cpp
+++ b/modules/godot_physics_3d/register_types.cpp
@@ -36,7 +36,7 @@
 
 static PhysicsServer3D *_createGodotPhysics3DCallback() {
 #ifdef THREADS_ENABLED
-	bool using_threads = GLOBAL_GET("physics/3d/run_on_separate_thread");
+	bool using_threads = GLOBAL_GET("physics/3d/run_on_separate_thread") && !Engine::get_singleton()->is_editor_hint();
 #else
 	bool using_threads = false;
 #endif


### PR DESCRIPTION
Reverts only the _physics_process_ stuff from https://github.com/godotengine/godot/pull/67411
Fixes https://github.com/godotengine/godot/issues/94106

This might be a dumb change and I'll delete this PR if it is, but this commit makes it so if you have enabled the Project Setting: "Run on Separate Thread" (physics/3d/run_on_separate_thread) or (physics/2d/run_on_separate_thread), that this **still** applies when running your game, but **not** in the Editor.

I think this makes sense as we don't do much physics processing in the Editor for this to be enabled, but I'd love some opinions.