### PR TITLE
Add unescape import options for CSV Translation

### DIFF
--- a/doc/classes/ResourceImporterCSVTranslation.xml
+++ b/doc/classes/ResourceImporterCSVTranslation.xml
@@ -24,5 +24,11 @@
 		<member name="delimiter" type="int" setter="" getter="" default="0">
 			The delimiter to use in the CSV file. The default value matches the common CSV convention. Tab-separated values are sometimes called TSV files.
 		</member>
+		<member name="unescape_keys" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], message keys in the CSV file are unescaped using [method String.c_unescape] during the import process.
+		</member>
+		<member name="unescape_translations" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], message translations in the CSV file are unescaped using [method String.c_unescape] during the import process.
+		</member>
 	</members>
 </class>


### PR DESCRIPTION
Closes #47883

This PR adds two options to the CSV translation importer:

- `unescape_keys`: Whether to process escape sequences in the key column's text
- `unescape_translations`: Whether to process escape sequences in the translated text

They have different defaults to match the current behavior.

Test project: [csv-unescape.zip](https://github.com/user-attachments/files/17475390/csv-unescape.zip)