### PR TITLE
StringLikeVariantOrder: Compare in-place

### DIFF
--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -166,23 +166,48 @@ public:
 	static StringName search(const String &p_name);
 
 	struct AlphCompare {
-		_FORCE_INLINE_ bool operator()(const StringName &l, const StringName &r) const {
+		template <typename LT, typename RT>
+		_FORCE_INLINE_ bool operator()(const LT &l, const RT &r) const {
+			return compare(l, r);
+		}
+		_FORCE_INLINE_ static bool compare(const StringName &l, const StringName &r) {
 			const char *l_cname = l._data ? l._data->cname : "";
 			const char *r_cname = r._data ? r._data->cname : "";
 
 			if (l_cname) {
 				if (r_cname) {
-					return is_str_less(l_cname, r_cname);
+					return str_compare(l_cname, r_cname) < 0;
 				} else {
-					return is_str_less(l_cname, r._data->name.ptr());
+					return str_compare(l_cname, r._data->name.ptr()) < 0;
 				}
 			} else {
 				if (r_cname) {
-					return is_str_less(l._data->name.ptr(), r_cname);
+					return str_compare(l._data->name.ptr(), r_cname) < 0;
 				} else {
-					return is_str_less(l._data->name.ptr(), r._data->name.ptr());
+					return str_compare(l._data->name.ptr(), r._data->name.ptr()) < 0;
 				}
 			}
+		}
+		_FORCE_INLINE_ static bool compare(const String &l, const StringName &r) {
+			const char *r_cname = r._data ? r._data->cname : "";
+
+			if (r_cname) {
+				return str_compare(l.get_data(), r_cname) < 0;
+			} else {
+				return str_compare(l.get_data(), r._data->name.ptr()) < 0;
+			}
+		}
+		_FORCE_INLINE_ static bool compare(const StringName &l, const String &r) {
+			const char *l_cname = l._data ? l._data->cname : "";
+
+			if (l_cname) {
+				return str_compare(l_cname, r.get_data()) < 0;
+			} else {
+				return str_compare(l._data->name.ptr(), r.get_data()) < 0;
+			}
+		}
+		_FORCE_INLINE_ static bool compare(const String &l, const String &r) {
+			return str_compare(l.get_data(), r.get_data()) < 0;
 		}
 	};
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -97,7 +97,7 @@ bool Char16String::operator<(const Char16String &p_right) const {
 		return p_right.length() != 0;
 	}
 
-	return is_str_less(get_data(), p_right.get_data());
+	return str_compare(get_data(), p_right.get_data()) < 0;
 }
 
 Char16String &Char16String::operator+=(char16_t p_char) {
@@ -155,7 +155,7 @@ bool CharString::operator<(const CharString &p_right) const {
 		return p_right.length() != 0;
 	}
 
-	return is_str_less(get_data(), p_right.get_data());
+	return str_compare(get_data(), p_right.get_data()) < 0;
 }
 
 bool CharString::operator==(const CharString &p_right) const {
@@ -640,7 +640,7 @@ bool String::operator<(const char *p_str) const {
 	if (is_empty()) {
 		return true;
 	}
-	return is_str_less(get_data(), p_str);
+	return str_compare(get_data(), p_str) < 0;
 }
 
 bool String::operator<(const wchar_t *p_str) const {
@@ -653,10 +653,10 @@ bool String::operator<(const wchar_t *p_str) const {
 
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	return is_str_less(get_data(), String::utf16((const char16_t *)p_str).get_data());
+	return str_compare(get_data(), String::utf16((const char16_t *)p_str).get_data()) < 0;
 #else
 	// wchar_t is 32-bit
-	return is_str_less(get_data(), (const char32_t *)p_str);
+	return str_compare(get_data(), (const char32_t *)p_str) < 0;
 #endif
 }
 
@@ -668,7 +668,7 @@ bool String::operator<(const char32_t *p_str) const {
 		return true;
 	}
 
-	return is_str_less(get_data(), p_str);
+	return str_compare(get_data(), p_str) < 0;
 }
 
 bool String::operator<(const String &p_str) const {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -695,21 +695,13 @@ struct FileNoCaseComparator {
 };
 
 template <typename L, typename R>
-_FORCE_INLINE_ bool is_str_less(const L *l_ptr, const R *r_ptr) {
+_FORCE_INLINE_ int64_t str_compare(const L *l_ptr, const R *r_ptr) {
 	while (true) {
 		const char32_t l = *l_ptr;
 		const char32_t r = *r_ptr;
 
-		if (l == 0 && r == 0) {
-			return false;
-		} else if (l == 0) {
-			return true;
-		} else if (r == 0) {
-			return false;
-		} else if (l < r) {
-			return true;
-		} else if (l > r) {
-			return false;
+		if (l == 0 || l != r) {
+			return static_cast<int64_t>(l) - static_cast<int64_t>(r);
 		}
 
 		l_ptr++;

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3406,6 +3406,26 @@ bool StringLikeVariantComparator::compare(const Variant &p_lhs, const Variant &p
 	return false;
 }
 
+bool StringLikeVariantOrder::compare(const Variant &p_lhs, const Variant &p_rhs) {
+	if (p_lhs.get_type() == Variant::STRING) {
+		const String &lhs = *VariantInternal::get_string(&p_lhs);
+		if (p_rhs.get_type() == Variant::STRING) {
+			return StringName::AlphCompare::compare(lhs, *VariantInternal::get_string(&p_rhs));
+		} else if (p_rhs.get_type() == Variant::STRING_NAME) {
+			return StringName::AlphCompare::compare(lhs, *VariantInternal::get_string_name(&p_rhs));
+		}
+	} else if (p_lhs.get_type() == Variant::STRING_NAME) {
+		const StringName &lhs = *VariantInternal::get_string_name(&p_lhs);
+		if (p_rhs.get_type() == Variant::STRING) {
+			return StringName::AlphCompare::compare(lhs, *VariantInternal::get_string(&p_rhs));
+		} else if (p_rhs.get_type() == Variant::STRING_NAME) {
+			return StringName::AlphCompare::compare(lhs, *VariantInternal::get_string_name(&p_rhs));
+		}
+	}
+
+	return p_lhs < p_rhs;
+}
+
 bool Variant::is_ref_counted() const {
 	return type == OBJECT && _get_obj().id.is_ref_counted();
 }

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -909,12 +909,7 @@ struct StringLikeVariantComparator {
 };
 
 struct StringLikeVariantOrder {
-	static _ALWAYS_INLINE_ bool compare(const Variant &p_lhs, const Variant &p_rhs) {
-		if (p_lhs.is_string() && p_rhs.is_string()) {
-			return p_lhs.operator String() < p_rhs.operator String();
-		}
-		return p_lhs < p_rhs;
-	}
+	static bool compare(const Variant &p_lhs, const Variant &p_rhs);
 
 	_ALWAYS_INLINE_ bool operator()(const Variant &p_lhs, const Variant &p_rhs) const {
 		return compare(p_lhs, p_rhs);


### PR DESCRIPTION
uses in-place string comparisons for `StringLikeVariantOrder` from https://github.com/godotengine/godot/pull/97542

+changed `is_str_less` into a simpler and more flexible function `str_compare`
+used `StringName::AlphCompare` to hold the functions needed

+also, a byproduct of changing from `is_str_less` to `str_compare` is 20% faster sorting of `PackedStringArray`s or `Array[String]`) in a `production=yes target=template_release` build, awesome side effect :+1:
++my test: [stringordertest.zip](https://github.com/user-attachments/files/17515901/stringordertest.zip)
