### PR TITLE
Add method to get last path cost to `AStar2D`, `AStar3D`, and `AStarGrid2D`

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -549,6 +549,14 @@ bool AStar3D::is_point_disabled(int64_t p_id) const {
 	return !p->enabled;
 }
 
+real_t AStar3D::get_last_cost() const {
+	if (last_closest_point == nullptr) {
+		return -1;
+	}
+
+	return last_closest_point->g_score;
+}
+
 void AStar3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_available_point_id"), &AStar3D::get_available_point_id);
 	ClassDB::bind_method(D_METHOD("add_point", "id", "position", "weight_scale"), &AStar3D::add_point, DEFVAL(1.0));
@@ -560,6 +568,7 @@ void AStar3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_point", "id"), &AStar3D::has_point);
 	ClassDB::bind_method(D_METHOD("get_point_connections", "id"), &AStar3D::get_point_connections);
 	ClassDB::bind_method(D_METHOD("get_point_ids"), &AStar3D::get_point_ids);
+	ClassDB::bind_method(D_METHOD("get_last_cost"), &AStar3D::get_last_cost);
 
 	ClassDB::bind_method(D_METHOD("set_point_disabled", "id", "disabled"), &AStar3D::set_point_disabled, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_point_disabled", "id"), &AStar3D::is_point_disabled);
@@ -888,6 +897,10 @@ bool AStar2D::_solve(AStar3D::Point *begin_point, AStar3D::Point *end_point, boo
 	return found_route;
 }
 
+real_t AStar2D::get_last_cost() const {
+	return astar.get_last_cost();
+}
+
 void AStar2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_available_point_id"), &AStar2D::get_available_point_id);
 	ClassDB::bind_method(D_METHOD("add_point", "id", "position", "weight_scale"), &AStar2D::add_point, DEFVAL(1.0));
@@ -899,6 +912,7 @@ void AStar2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_point", "id"), &AStar2D::has_point);
 	ClassDB::bind_method(D_METHOD("get_point_connections", "id"), &AStar2D::get_point_connections);
 	ClassDB::bind_method(D_METHOD("get_point_ids"), &AStar2D::get_point_ids);
+	ClassDB::bind_method(D_METHOD("get_last_cost"), &AStar2D::get_last_cost);
 
 	ClassDB::bind_method(D_METHOD("set_point_disabled", "id", "disabled"), &AStar2D::set_point_disabled, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("is_point_disabled", "id"), &AStar2D::is_point_disabled);

--- a/core/math/a_star.h
+++ b/core/math/a_star.h
@@ -144,6 +144,7 @@ public:
 	bool has_point(int64_t p_id) const;
 	Vector<int64_t> get_point_connections(int64_t p_id);
 	PackedInt64Array get_point_ids();
+	real_t get_last_cost() const;
 
 	void set_point_disabled(int64_t p_id, bool p_disabled = true);
 	bool is_point_disabled(int64_t p_id) const;
@@ -200,6 +201,7 @@ public:
 	bool has_point(int64_t p_id) const;
 	Vector<int64_t> get_point_connections(int64_t p_id);
 	PackedInt64Array get_point_ids();
+	real_t get_last_cost() const;
 
 	void set_point_disabled(int64_t p_id, bool p_disabled = true);
 	bool is_point_disabled(int64_t p_id) const;

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -734,6 +734,14 @@ TypedArray<Vector2i> AStarGrid2D::get_id_path(const Vector2i &p_from_id, const V
 	return path;
 }
 
+real_t AStarGrid2D::get_last_cost() const {
+	if (last_closest_point == nullptr) {
+		return -1;
+	}
+
+	return last_closest_point->g_score;
+}
+
 void AStarGrid2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_region", "region"), &AStarGrid2D::set_region);
 	ClassDB::bind_method(D_METHOD("get_region"), &AStarGrid2D::get_region);
@@ -769,6 +777,7 @@ void AStarGrid2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_point_data_in_region", "region"), &AStarGrid2D::get_point_data_in_region);
 	ClassDB::bind_method(D_METHOD("get_point_path", "from_id", "to_id", "allow_partial_path"), &AStarGrid2D::get_point_path, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_id_path", "from_id", "to_id", "allow_partial_path"), &AStarGrid2D::get_id_path, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("get_last_cost"), &AStarGrid2D::get_last_cost);
 
 	GDVIRTUAL_BIND(_estimate_cost, "from_id", "end_id")
 	GDVIRTUAL_BIND(_compute_cost, "from_id", "to_id")

--- a/core/math/a_star_grid_2d.h
+++ b/core/math/a_star_grid_2d.h
@@ -226,6 +226,7 @@ public:
 	TypedArray<Dictionary> get_point_data_in_region(const Rect2i &p_region) const;
 	Vector<Vector2> get_point_path(const Vector2i &p_from, const Vector2i &p_to, bool p_allow_partial_path = false);
 	TypedArray<Vector2i> get_id_path(const Vector2i &p_from, const Vector2i &p_to, bool p_allow_partial_path = false);
+	real_t get_last_cost() const;
 };
 
 VARIANT_ENUM_CAST(AStarGrid2D::DiagonalMode);

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -176,6 +176,12 @@
 				If you change the 2nd point's weight to 3, then the result will be [code][1, 4, 3][/code] instead, because now even though the distance is longer, it's "easier" to get through point 4 than through point 2.
 			</description>
 		</method>
+		<method name="get_last_cost" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the total cost of the last path found through [method get_id_path] or [method get_point_path]. Returns -1 if there was no last path calculated.
+			</description>
+		</method>
 		<method name="get_point_capacity" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -204,6 +204,12 @@
 				If you change the 2nd point's weight to 3, then the result will be [code][1, 4, 3][/code] instead, because now even though the distance is longer, it's "easier" to get through point 4 than through point 2.
 			</description>
 		</method>
+		<method name="get_last_cost" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the total cost of the last path found through [method get_id_path] or [method get_point_path]. Returns -1 if there was no last path calculated.
+			</description>
+		</method>
 		<method name="get_point_capacity" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -82,6 +82,12 @@
 				[b]Note:[/b] When [param allow_partial_path] is [code]true[/code] and [param to_id] is solid the search may take an unusually long time to finish.
 			</description>
 		</method>
+		<method name="get_last_cost" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the total cost of the last path found through [method get_id_path] or [method get_point_path]. Returns -1 if there was no last path calculated.
+			</description>
+		</method>
 		<method name="get_point_data_in_region" qualifiers="const">
 			<return type="Dictionary[]" />
 			<param index="0" name="region" type="Rect2i" />


### PR DESCRIPTION
Adds a method to return the last total pathfinding cost to `AStar2D`, `AStar3D`, and `AStarGrid2D`. This method returns the `g_score` of the last closest point. This enables it to work both with `allow_partial_path` if the end point was unreachable, or with normal pathfinding. `g_score` is used instead of `f_score` as it is more accurate if the path was unreachable but still executed. If the end point was unreachable and `allow_partial_path` is false, it will return -1. It also returns -1 if a pathfind action has not been performed yet, such as after first instantiating the class. 

Closes: https://github.com/godotengine/godot-proposals/issues/5667

Obsoletes: https://github.com/godotengine/godot/pull/64150

This PR performed a entire path find operation to return the score, instead of reading it from the last closest point. It was last updated Aug 11, 2022.

# Example:
**Download**: [astar_test_pathcost.zip](https://github.com/user-attachments/files/17469950/astar_test_pathcost.zip)


Video:

[astar-path-cost.webm](https://github.com/user-attachments/assets/42659bb8-d125-4347-9c89-16606609635d)



Blue tiles are 0.5 cost, red tiles are 2 cost, normal tiles are 1 cost. Cost is displayed in a UI element. Towards the end you can see that when clicking on a solid/disabled tile, without partial path the value will return -1 but with it returns the cost of the path closest.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
