### PR TITLE
[Legacy color picker] Use zoomed preview at the mouse position instead of Label.

### DIFF
--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -126,8 +126,11 @@ private:
 	Popup *picker_window = nullptr;
 	// Legacy color picking.
 	TextureRect *picker_texture_rect = nullptr;
-	Label *picker_preview_label = nullptr;
+	TextureRect *picker_texture_zoom = nullptr;
+	Panel *picker_preview = nullptr;
+	Panel *picker_preview_color = nullptr;
 	Ref<StyleBoxFlat> picker_preview_style_box;
+	Ref<StyleBoxFlat> picker_preview_style_box_color;
 	Color picker_color;
 
 	MarginContainer *internal_margin = nullptr;


### PR DESCRIPTION
Replaces the label with a 3x zoom preview that is following mouse cursor.

https://github.com/user-attachments/assets/861aa3ff-d189-4854-859b-b31d6bd310b5

Can be combined with https://github.com/godotengine/godot/pull/88950 to do the same for a normal color picker.