### PR TITLE
Always replace empty scene when opening new tab

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -632,6 +632,18 @@ int EditorData::add_edited_scene(int p_at_pos) {
 	if (current_edited_scene < 0) {
 		current_edited_scene = 0;
 	}
+
+	// Remove placeholder empty scene.
+	if (get_edited_scene_count() > 1) {
+		for (int i = 0; i < get_edited_scene_count() - 1; i++) {
+			bool unsaved = EditorUndoRedoManager::get_singleton()->is_history_unsaved(get_scene_history_id(i));
+			if (!unsaved && get_scene_path(i).is_empty() && get_edited_scene_root(i) == nullptr) {
+				remove_scene(i);
+				p_at_pos--;
+			}
+		}
+	}
+
 	return p_at_pos;
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3906,17 +3906,6 @@ int EditorNode::new_scene() {
 	int idx = editor_data.add_edited_scene(-1);
 	_set_current_scene(idx); // Before trying to remove an empty scene, set the current tab index to the newly added tab index.
 
-	// Remove placeholder empty scene.
-	if (editor_data.get_edited_scene_count() > 1) {
-		for (int i = 0; i < editor_data.get_edited_scene_count() - 1; i++) {
-			bool unsaved = EditorUndoRedoManager::get_singleton()->is_history_unsaved(editor_data.get_scene_history_id(i));
-			if (!unsaved && editor_data.get_scene_path(i).is_empty() && editor_data.get_edited_scene_root(i) == nullptr) {
-				editor_data.remove_scene(i);
-				idx--;
-			}
-		}
-	}
-
 	editor_data.clear_editor_states();
 	scene_tabs->update_scene_tabs();
 	return idx;


### PR DESCRIPTION
Opening new scene had a special code for handling "placeholder empty scenes". I moved this code to the `add_edited_scene()`, so every time a scene tab is opened (e.g. when loading scene, opening recent scene etc.), the empty tab is replaced.

Closes #33319

https://github.com/user-attachments/assets/80b98dae-55a4-455f-a1ff-ce78182bd8b6

