### PR TITLE
Clarify `TextEdit.is_caret_visible()` behavior in the class reference

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -764,7 +764,8 @@
 			<return type="bool" />
 			<param index="0" name="caret_index" type="int" default="0" />
 			<description>
-				Returns [code]true[/code] if the caret is visible on the screen.
+				Returns [code]true[/code] if the caret is visible, [code]false[/code] otherwise. A caret will be considered hidden if it is outside the scrollable area when scrolling is enabled.
+				[b]Note:[/b] [method is_caret_visible] does not account for a caret being off-screen if it is still within the scrollable area. It will return [code]true[/code] even if the caret is off-screen as long as it meets [TextEdit]'s own conditions for being visible. This includes uses of [member scroll_fit_content_width] and [member scroll_fit_content_height] that cause the [TextEdit] to expand beyond the viewport's bounds.
 			</description>
 		</method>
 		<method name="is_dragging_cursor" qualifiers="const">


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/211#discussioncomment-10992453.

**Testing project:** [test-textedit-caret-visible.zip](https://github.com/user-attachments/files/17478194/test-textedit-caret-visible.zip)
