### PR TITLE
Add `AudioServer.get_driver_name()` to get the actual audio driver name

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -110,6 +110,12 @@
 				Returns the volume of the bus at index [param bus_idx] in dB.
 			</description>
 		</method>
+		<method name="get_driver_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the name of the current audio driver. The default usually depends on the operating system, but may be overridden via the [code]--audio-driver[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url]. [code]--headless[/code] also automatically sets the audio driver to [code]Dummy[/code]. See also [member ProjectSettings.audio/driver/driver].
+			</description>
+		</method>
 		<method name="get_input_device_list">
 			<return type="PackedStringArray" />
 			<description>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -376,6 +376,7 @@
 		<member name="audio/driver/driver" type="String" setter="" getter="">
 			Specifies the audio driver to use. This setting is platform-dependent as each platform supports different audio drivers. If left empty, the default audio driver will be used.
 			The [code]Dummy[/code] audio driver disables all audio playback and recording, which is useful for non-game applications as it reduces CPU usage. It also prevents the engine from appearing as an application playing audio in the OS' audio mixer.
+			To query the value that is being used at run-time (which may be overridden by command-line arguments or headless mode), use [method AudioServer.get_driver_name].
 			[b]Note:[/b] The driver in use can be overridden at runtime via the [code]--audio-driver[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].
 		</member>
 		<member name="audio/driver/enable_input" type="bool" setter="" getter="" default="false">

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1440,6 +1440,10 @@ uint64_t AudioServer::get_mixed_frames() const {
 	return mix_frames;
 }
 
+String AudioServer::get_driver_name() const {
+	return AudioDriver::get_singleton()->get_name();
+}
+
 void AudioServer::notify_listener_changed() {
 	for (CallbackItem *ci : listener_changed_callback_list) {
 		ci->callback(ci->userdata);
@@ -1946,6 +1950,8 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_speaker_mode"), &AudioServer::get_speaker_mode);
 	ClassDB::bind_method(D_METHOD("get_mix_rate"), &AudioServer::get_mix_rate);
+
+	ClassDB::bind_method(D_METHOD("get_driver_name"), &AudioServer::get_driver_name);
 
 	ClassDB::bind_method(D_METHOD("get_output_device_list"), &AudioServer::get_output_device_list);
 	ClassDB::bind_method(D_METHOD("get_output_device"), &AudioServer::get_output_device);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -427,6 +427,8 @@ public:
 	uint64_t get_mix_count() const;
 	uint64_t get_mixed_frames() const;
 
+	String get_driver_name() const;
+
 	void notify_listener_changed();
 
 	virtual void init();


### PR DESCRIPTION
The project setting does not reflect CLI argument overrides (including `--headless` which sets the audio driver to `Dummy`), so it can't be reliably used to detect which audio driver is actually being used at run-time.
