### PR TITLE
Document the differences between GDScript and GlobalScope

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -6,7 +6,7 @@
 	<description>
 		A list of global scope enumerated constants and built-in functions. This is all that resides in the globals, constants regarding error codes, keycodes, property hints, etc.
 		Singletons are also documented here, since they can be accessed from anywhere.
-		For the entries related to GDScript which can be accessed in any script see [@GDScript].
+		For the entries that can only be accessed from scripts written in GDScript, see [@GDScript].
 	</description>
 	<tutorials>
 		<link title="Random number generation">$DOCS_URL/tutorials/math/random_number_generation.html</link>

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -4,8 +4,8 @@
 		Built-in GDScript constants, functions, and annotations.
 	</brief_description>
 	<description>
-		A list of GDScript-specific utility functions and annotations accessible from any script.
-		For the list of the global functions and constants see [@GlobalScope].
+		A list of utility functions and annotations accessible from any script written in GDScript.
+		For the list of global functions and constants that can be accessed in any scripting language, see [@GlobalScope].
 	</description>
 	<tutorials>
 		<link title="GDScript exports">$DOCS_URL/tutorials/scripting/gdscript/gdscript_exports.html</link>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Changed some wording in the documentation to make things seem more clear. The original wording used the words "in any script", and although it can be inferred with context clues that it is talking about GDScript specific code, it is not easy to parse from a glance as the sentence also used "related to" which may be vague.

Also moved GDScript specific to the end of the description for GDScript and added "which work in any language" when refering to GlobalScope in the same file to improve in readability as the difference was not clear prior.