### PR TITLE
Fix incorrect `KEY_MODIFIER_MASK` value

### DIFF
--- a/core/os/keyboard.h
+++ b/core/os/keyboard.h
@@ -249,7 +249,7 @@ enum class Key {
 
 enum class KeyModifierMask {
 	CODE_MASK = ((1 << 23) - 1), ///< Apply this mask to any keycode to remove modifiers.
-	MODIFIER_MASK = (0x7F << 22), ///< Apply this mask to isolate modifiers.
+	MODIFIER_MASK = (0x7F << 24), ///< Apply this mask to isolate modifiers.
 	//RESERVED = (1 << 23),
 	CMD_OR_CTRL = (1 << 24),
 	SHIFT = (1 << 25),

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2365,7 +2365,7 @@
 		<constant name="KEY_CODE_MASK" value="8388607" enum="KeyModifierMask" is_bitfield="true">
 			Key Code mask.
 		</constant>
-		<constant name="KEY_MODIFIER_MASK" value="532676608" enum="KeyModifierMask" is_bitfield="true">
+		<constant name="KEY_MODIFIER_MASK" value="2130706432" enum="KeyModifierMask" is_bitfield="true">
 			Modifier key mask.
 		</constant>
 		<constant name="KEY_MASK_CMD_OR_CTRL" value="16777216" enum="KeyModifierMask" is_bitfield="true">

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -261,3 +261,10 @@ Validate extension JSON: Error: Field 'classes/PointLight2D/properties/texture':
 
 Property hints modified to disallow resource types that don't work. The types allowed are now more restricted, but this change only impacts the editor and not the actual exposed API. No adjustments should be necessary.
 Decal properties were previously changed from Texture to Texture2D in 4.2, so we need to silence those warnings too.
+
+
+GH-98441
+--------
+Validate extension JSON: Error: Field 'global_enums/KeyModifierMask/values/KEY_MODIFIER_MASK': value changed value in new API, from 5.32677e+08 to 2130706432.
+
+Key modifier mask value corrected. API change documented for compatibility.


### PR DESCRIPTION
This pull request fixes an incorrect value assignment for `MODIFIER_MASK` in keyboard.h and @GlobalScope.xml.

- Updated the `MODIFIER_MASK` to `0x7E << 22` to isolate modifier keys correctly, ensuring that it does not interfere with the `Key.SPECIAL` value.

I tested the solution by checking that the result of the `AND` operation between `MODIFIER_MASK` and `CODE_MASK` returned `0`, confirming that the modifier mask is now correctly configured.

(Sorry for the confusion with the previous PR; I'm new to this and accidentally included others' changes, so I created this new one for clarity.)

Fixes https://github.com/godotengine/godot/issues/89775