### PR TITLE
ExternalTexture: Avoid error when destroyed without having been used

### DIFF
--- a/scene/resources/external_texture.h
+++ b/scene/resources/external_texture.h
@@ -38,9 +38,12 @@ class ExternalTexture : public Texture2D {
 	GDCLASS(ExternalTexture, Texture2D);
 
 private:
-	RID texture;
+	mutable RID texture;
+	mutable bool using_placeholder = false;
 	Size2 size = Size2(256, 256);
 	uint64_t external_buffer = 0;
+
+	void _ensure_created() const;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Untested, please give it a go.

Fixes #97694.