### PR TITLE
Fix root type failing to change if user provides a global class inherited from another global class.

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3022,7 +3022,9 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		Ref<Script> root_script = nullptr;
 		if (ScriptServer::is_global_class(root_type)) {
 			root_script = ResourceLoader::load(ScriptServer::get_global_class_path(root_type));
-			root_type = ScriptServer::get_global_class_base(root_type);
+			// Global class script loaded, recursively check for native class the script inherits from.
+			// Needed for ClassDB::instantiate() as it expects native class.
+			root_type = ScriptServer::get_global_class_native_base(root_type);
 		}
 		if (scene->get_class_name() != root_type) {
 			// If the user specified a Godot node type that does not match


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77076

Finds the inherited native class (built-in) of the user provided global class (GDScript) by recursively checking up its inheritance chain until a valid native class is found. Previously it was only checking the class it directly extended from which could be another global class. Importing scenes expects a native class for `_internal_instantiate()` to work.