### PR TITLE
Print error when `globalize_path()` fails

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -258,18 +258,14 @@ void ProjectSettings::add_hidden_prefix(const String &p_prefix) {
 
 String ProjectSettings::globalize_path(const String &p_path) const {
 	if (p_path.begins_with("res://")) {
-		if (!resource_path.is_empty()) {
-			return p_path.replace("res:/", resource_path);
-		}
-		return p_path.replace("res://", "");
-	} else if (p_path.begins_with("user://")) {
-		String data_dir = OS::get_singleton()->get_user_data_dir();
-		if (!data_dir.is_empty()) {
-			return p_path.replace("user:/", data_dir);
-		}
-		return p_path.replace("user://", "");
+		ERR_FAIL_COND_V_MSG(resource_path.is_empty(), p_path.replace("res://", ""), "Can't globalize `res://` paths in exported project.");
+		return p_path.replace("res:/", resource_path);
 	}
-
+	if (p_path.begins_with("user://")) {
+		String data_dir = OS::get_singleton()->get_user_data_dir();
+		ERR_FAIL_COND_V(data_dir.is_empty(), p_path.replace("user://", ""));
+		return p_path.replace("user:/", data_dir);
+	}
 	return p_path;
 }
 


### PR DESCRIPTION
`globalize_path()` is documented to return an absolute filesystem path. However, there is no reasonable filesystem path to return for `res://` paths in an exported project.

Currently when a `res://` path is provided in an exported project, `globalize_path()` simply strips the prefix and returns a relative path silently.

This PR adds an error print on failures like this so it's easier for users to debug.