### PR TITLE
C#: Fix StringName leak when converting `Variant` to `Signal` / `Callable`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/VariantUtils.cs
@@ -534,7 +534,10 @@ namespace Godot.NativeInterop
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Callable ConvertToCallable(in godot_variant p_var)
-            => Marshaling.ConvertCallableToManaged(ConvertToNativeCallable(p_var));
+        {
+            using var callable = ConvertToNativeCallable(p_var);
+            return Marshaling.ConvertCallableToManaged(callable);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static godot_signal ConvertToNativeSignal(in godot_variant p_var)
@@ -542,7 +545,10 @@ namespace Godot.NativeInterop
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Signal ConvertToSignal(in godot_variant p_var)
-            => Marshaling.ConvertSignalToManaged(ConvertToNativeSignal(p_var));
+        {
+            using var signal = ConvertToNativeSignal(p_var);
+            return Marshaling.ConvertSignalToManaged(signal);
+        }
 
         public static godot_array ConvertToNativeArray(in godot_variant p_var)
             => p_var.Type == Variant.Type.Array ?


### PR DESCRIPTION
- Fixes #96487

Currently,`Callable` and `Signal` do not hold native data (`godot_callable` / `godot_signal`), so they need to be disposed after marshaling.