### PR TITLE
Core: Support `char8_t`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,22 +1,21 @@
----
-Checks: >-
-  -*,
-  cppcoreguidelines-pro-type-member-init,
-  modernize-redundant-void-arg,
-  modernize-use-bool-literals,
-  modernize-use-default-member-init,
-  modernize-use-nullptr,
-  readability-braces-around-statements,
-  readability-redundant-member-init
-WarningsAsErrors: ''
+Checks:
+  - -*
+  - cppcoreguidelines-pro-type-member-init
+  - modernize-redundant-void-arg
+  - modernize-use-bool-literals
+  - modernize-use-default-member-init
+  - modernize-use-nullptr
+  - readability-braces-around-statements
+  - readability-redundant-member-init
 HeaderFileExtensions: ['', h, hh, hpp, hxx, inc, glsl]
 ImplementationFileExtensions: [c, cc, cpp, cxx, m, mm, java]
 HeaderFilterRegex: (core|doc|drivers|editor|main|modules|platform|scene|servers|tests)/
 FormatStyle: file
+ExtraArgs:
+  - -fchar8_t  # Recognize `char8_t` even when not compiling with clang.
 CheckOptions:
   cppcoreguidelines-pro-type-member-init.IgnoreArrays: true
   cppcoreguidelines-pro-type-member-init.UseAssignment: true
   modernize-use-bool-literals.IgnoreMacros: false
   modernize-use-default-member-init.IgnoreMacros: false
   modernize-use-default-member-init.UseAssignment: true
-...

--- a/SConstruct
+++ b/SConstruct
@@ -1082,6 +1082,12 @@ if env["ninja"]:
 if env["threads"]:
     env.Append(CPPDEFINES=["THREADS_ENABLED"])
 
+# Enable `char8_t` on C++17.
+if env.msvc:
+    env.Append(CXXFLAGS=["/Zc:char8_t"])
+else:
+    env.Append(CXXFLAGS=["-fchar8_t"])
+
 # Build subdirs, the build order is dependent on link order.
 Export("env")
 

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -41,6 +41,7 @@
 #ifndef __cplusplus
 typedef uint32_t char32_t;
 typedef uint16_t char16_t;
+typedef uint8_t char8_t;
 #endif
 
 #ifdef __cplusplus

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -59,8 +59,6 @@ static _FORCE_INLINE_ char32_t lower_case(char32_t c) {
 	return (is_ascii_upper_case(c) ? (c + ('a' - 'A')) : c);
 }
 
-const char CharString::_null = 0;
-const char16_t Char16String::_null = 0;
 const char32_t String::_null = 0;
 const char32_t String::_replacement_char = 0xfffd;
 
@@ -92,48 +90,58 @@ bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end) {
 	}
 }
 
-/*************************************************************************/
-/*  Char16String                                                         */
-/*************************************************************************/
-
-bool Char16String::operator<(const Char16String &p_right) const {
+template <typename T>
+bool CharStringT<T>::operator<(const CharStringT<T> &p_other) const {
 	if (length() == 0) {
-		return p_right.length() != 0;
+		return p_other.length() != 0;
 	}
 
-	return is_str_less(get_data(), p_right.get_data());
+	return is_str_less(get_data(), p_other.get_data());
 }
 
-Char16String &Char16String::operator+=(char16_t p_char) {
+template <typename T>
+bool CharStringT<T>::operator==(const CharStringT<T> &p_other) const {
+	if (length() != p_other.length()) {
+		return false;
+	}
+	if (length() == 0) {
+		return true;
+	}
+
+	size_t len = length();
+	const T *src = get_data();
+	const T *dst = p_other.get_data();
+
+	/* Compare char by char */
+	for (size_t i = 0; i < len; i++) {
+		if (src[i] != dst[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+template <typename T>
+CharStringT<T> &CharStringT<T>::operator+=(T p_char) {
 	const int lhs_len = length();
 	resize(lhs_len + 2);
 
-	char16_t *dst = ptrw();
+	T *dst = ptrw();
 	dst[lhs_len] = p_char;
 	dst[lhs_len + 1] = 0;
 
 	return *this;
 }
 
-void Char16String::operator=(const char16_t *p_cstr) {
-	copy_from(p_cstr);
-}
-
-const char16_t *Char16String::get_data() const {
-	if (size()) {
-		return &operator[](0);
-	} else {
-		return u"";
-	}
-}
-
-void Char16String::copy_from(const char16_t *p_cstr) {
+template <typename T>
+void CharStringT<T>::copy_from(const T *p_cstr) {
 	if (!p_cstr) {
 		resize(0);
 		return;
 	}
 
-	const char16_t *s = p_cstr;
+	const T *s = p_cstr;
 	for (; *s; s++) {
 	}
 	size_t len = s - p_cstr;
@@ -145,81 +153,16 @@ void Char16String::copy_from(const char16_t *p_cstr) {
 
 	Error err = resize(++len); // include terminating null char
 
-	ERR_FAIL_COND_MSG(err != OK, "Failed to copy char16_t string.");
-
-	memcpy(ptrw(), p_cstr, len * sizeof(char16_t));
-}
-
-/*************************************************************************/
-/*  CharString                                                           */
-/*************************************************************************/
-
-bool CharString::operator<(const CharString &p_right) const {
-	if (length() == 0) {
-		return p_right.length() != 0;
-	}
-
-	return is_str_less(get_data(), p_right.get_data());
-}
-
-bool CharString::operator==(const CharString &p_right) const {
-	if (length() == 0) {
-		// True if both have length 0, false if only p_right has a length
-		return p_right.length() == 0;
-	} else if (p_right.length() == 0) {
-		// False due to unequal length
-		return false;
-	}
-
-	return strcmp(ptr(), p_right.ptr()) == 0;
-}
-
-CharString &CharString::operator+=(char p_char) {
-	const int lhs_len = length();
-	resize(lhs_len + 2);
-
-	char *dst = ptrw();
-	dst[lhs_len] = p_char;
-	dst[lhs_len + 1] = 0;
-
-	return *this;
-}
-
-void CharString::operator=(const char *p_cstr) {
-	copy_from(p_cstr);
-}
-
-const char *CharString::get_data() const {
-	if (size()) {
-		return &operator[](0);
-	} else {
-		return "";
-	}
-}
-
-void CharString::copy_from(const char *p_cstr) {
-	if (!p_cstr) {
-		resize(0);
-		return;
-	}
-
-	size_t len = strlen(p_cstr);
-
-	if (len == 0) {
-		resize(0);
-		return;
-	}
-
-	Error err = resize(++len); // include terminating null char
-
 	ERR_FAIL_COND_MSG(err != OK, "Failed to copy C-string.");
 
-	memcpy(ptrw(), p_cstr, len);
+	memcpy(ptrw(), p_cstr, len * sizeof(T));
 }
 
-/*************************************************************************/
-/*  String                                                               */
-/*************************************************************************/
+template class CharStringT<char>;
+template class CharStringT<char8_t>;
+template class CharStringT<char16_t>;
+template class CharStringT<char32_t>;
+template class CharStringT<wchar_t>;
 
 Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r_path, String &r_fragment) const {
 	// Splits the URL into scheme, host, port, path, fragment. Strip credentials when present.
@@ -376,22 +319,38 @@ void String::copy_from(const char *p_cstr, const int p_clip_to) {
 
 void String::copy_from(const wchar_t *p_cstr) {
 #ifdef WINDOWS_ENABLED
-	// wchar_t is 16-bit, parse as UTF-16
-	parse_utf16((const char16_t *)p_cstr);
+	// wchar_t is 16-bit
+	copy_from((const char16_t *)p_cstr);
 #else
-	// wchar_t is 32-bit, copy directly
+	// wchar_t is 32-bit
 	copy_from((const char32_t *)p_cstr);
 #endif
 }
 
 void String::copy_from(const wchar_t *p_cstr, const int p_clip_to) {
 #ifdef WINDOWS_ENABLED
-	// wchar_t is 16-bit, parse as UTF-16
-	parse_utf16((const char16_t *)p_cstr, p_clip_to);
+	// wchar_t is 16-bit
+	copy_from((const char16_t *)p_cstr, p_clip_to);
 #else
-	// wchar_t is 32-bit, copy directly
+	// wchar_t is 32-bit
 	copy_from((const char32_t *)p_cstr, p_clip_to);
 #endif
+}
+
+void String::copy_from(const char8_t *p_cstr) {
+	parse_utf8((const char *)p_cstr);
+}
+
+void String::copy_from(const char8_t *p_cstr, const int p_clip_to) {
+	parse_utf8((const char *)p_cstr, p_clip_to);
+}
+
+void String::copy_from(const char16_t *p_cstr) {
+	parse_utf16(p_cstr);
+}
+
+void String::copy_from(const char16_t *p_cstr, const int p_clip_to) {
+	parse_utf16(p_cstr, p_clip_to);
 }
 
 void String::copy_from(const char32_t &p_char) {
@@ -490,6 +449,14 @@ void String::operator=(const char *p_str) {
 	copy_from(p_str);
 }
 
+void String::operator=(const char8_t *p_str) {
+	copy_from(p_str);
+}
+
+void String::operator=(const char16_t *p_str) {
+	copy_from(p_str);
+}
+
 void String::operator=(const char32_t *p_str) {
 	copy_from(p_str);
 }
@@ -519,11 +486,29 @@ String operator+(const char *p_chr, const String &p_str) {
 String operator+(const wchar_t *p_chr, const String &p_str) {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	String tmp = String::utf16((const char16_t *)p_chr);
+	String tmp = (const char16_t *)p_chr;
 #else
 	// wchar_t is 32-bit
 	String tmp = (const char32_t *)p_chr;
 #endif
+	tmp += p_str;
+	return tmp;
+}
+
+String operator+(const char8_t *p_chr, const String &p_str) {
+	String tmp = p_chr;
+	tmp += p_str;
+	return tmp;
+}
+
+String operator+(const char16_t *p_chr, const String &p_str) {
+	String tmp = p_chr;
+	tmp += p_str;
+	return tmp;
+}
+
+String operator+(const char32_t *p_chr, const String &p_str) {
+	String tmp = p_chr;
 	tmp += p_str;
 	return tmp;
 }
@@ -588,11 +573,21 @@ String &String::operator+=(const char *p_str) {
 String &String::operator+=(const wchar_t *p_str) {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	*this += String::utf16((const char16_t *)p_str);
+	*this += String((const char16_t *)p_str);
 #else
 	// wchar_t is 32-bit
 	*this += String((const char32_t *)p_str);
 #endif
+	return *this;
+}
+
+String &String::operator+=(const char8_t *p_str) {
+	*this += String(p_str);
+	return *this;
+}
+
+String &String::operator+=(const char16_t *p_str) {
+	*this += String(p_str);
 	return *this;
 }
 
@@ -659,11 +654,19 @@ bool String::operator==(const char *p_str) const {
 bool String::operator==(const wchar_t *p_str) const {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit, parse as UTF-16
-	return *this == String::utf16((const char16_t *)p_str);
+	return *this == (const char16_t *)p_str;
 #else
 	// wchar_t is 32-bit, compare char by char
 	return *this == (const char32_t *)p_str;
 #endif
+}
+
+bool String::operator==(const char8_t *p_str) const {
+	return *this == String(p_str);
+}
+
+bool String::operator==(const char16_t *p_str) const {
+	return *this == String(p_str);
 }
 
 bool String::operator==(const char32_t *p_str) const {
@@ -745,13 +748,25 @@ bool operator==(const char *p_chr, const String &p_str) {
 	return p_str == p_chr;
 }
 
+bool operator==(const char8_t *p_chr, const String &p_str) {
+	return p_str == p_chr;
+}
+
+bool operator==(const char16_t *p_chr, const String &p_str) {
+	return p_str == p_chr;
+}
+
+bool operator==(const char32_t *p_chr, const String &p_str) {
+	return p_str == p_chr;
+}
+
 bool operator==(const wchar_t *p_chr, const String &p_str) {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	return p_str == String::utf16((const char16_t *)p_chr);
+	return p_str == (const char16_t *)p_chr;
 #else
-	// wchar_t is 32-bi
-	return p_str == String((const char32_t *)p_chr);
+	// wchar_t is 32-bit
+	return p_str == (const char32_t *)p_chr;
 #endif
 }
 
@@ -759,12 +774,24 @@ bool operator!=(const char *p_chr, const String &p_str) {
 	return !(p_str == p_chr);
 }
 
+bool operator!=(const char8_t *p_chr, const String &p_str) {
+	return !(p_str == p_chr);
+}
+
+bool operator!=(const char16_t *p_chr, const String &p_str) {
+	return !(p_str == p_chr);
+}
+
+bool operator!=(const char32_t *p_chr, const String &p_str) {
+	return !(p_str == p_chr);
+}
+
 bool operator!=(const wchar_t *p_chr, const String &p_str) {
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	return !(p_str == String::utf16((const char16_t *)p_chr));
+	return !(p_str == String((const char16_t *)p_chr));
 #else
-	// wchar_t is 32-bi
+	// wchar_t is 32-bit
 	return !(p_str == String((const char32_t *)p_chr));
 #endif
 }
@@ -774,6 +801,14 @@ bool String::operator!=(const char *p_str) const {
 }
 
 bool String::operator!=(const wchar_t *p_str) const {
+	return (!(*this == p_str));
+}
+
+bool String::operator!=(const char8_t *p_str) const {
+	return (!(*this == p_str));
+}
+
+bool String::operator!=(const char16_t *p_str) const {
 	return (!(*this == p_str));
 }
 
@@ -817,11 +852,33 @@ bool String::operator<(const wchar_t *p_str) const {
 
 #ifdef WINDOWS_ENABLED
 	// wchar_t is 16-bit
-	return is_str_less(get_data(), String::utf16((const char16_t *)p_str).get_data());
+	return is_str_less(get_data(), String((const char16_t *)p_str).get_data());
 #else
 	// wchar_t is 32-bit
 	return is_str_less(get_data(), (const char32_t *)p_str);
 #endif
+}
+
+bool String::operator<(const char8_t *p_str) const {
+	if (is_empty() && p_str[0] == 0) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+
+	return is_str_less(get_data(), String(p_str).get_data());
+}
+
+bool String::operator<(const char16_t *p_str) const {
+	if (is_empty() && p_str[0] == 0) {
+		return false;
+	}
+	if (is_empty()) {
+		return true;
+	}
+
+	return is_str_less(get_data(), String(p_str).get_data());
 }
 
 bool String::operator<(const char32_t *p_str) const {
@@ -2514,6 +2571,14 @@ String::String(const wchar_t *p_str) {
 	copy_from(p_str);
 }
 
+String::String(const char8_t *p_str) {
+	copy_from(p_str);
+}
+
+String::String(const char16_t *p_str) {
+	copy_from(p_str);
+}
+
 String::String(const char32_t *p_str) {
 	copy_from(p_str);
 }
@@ -2523,6 +2588,14 @@ String::String(const char *p_str, int p_clip_to_len) {
 }
 
 String::String(const wchar_t *p_str, int p_clip_to_len) {
+	copy_from(p_str, p_clip_to_len);
+}
+
+String::String(const char8_t *p_str, int p_clip_to_len) {
+	copy_from(p_str, p_clip_to_len);
+}
+
+String::String(const char16_t *p_str, int p_clip_to_len) {
 	copy_from(p_str, p_clip_to_len);
 }
 
@@ -2689,6 +2762,68 @@ int64_t String::to_int(const wchar_t *p_str, int p_len) {
 
 	for (int i = 0; i < to; i++) {
 		wchar_t c = p_str[i];
+		if (is_digit(c)) {
+			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
+			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+			integer *= 10;
+			integer += c - '0';
+
+		} else if (c == '-' && integer == 0) {
+			sign = -sign;
+		} else if (c != ' ') {
+			break;
+		}
+	}
+
+	return integer * sign;
+}
+
+int64_t String::to_int(const char8_t *p_str, int p_len) {
+	int to = 0;
+	if (p_len >= 0) {
+		to = p_len;
+	} else {
+		while (p_str[to] != 0 && p_str[to] != '.') {
+			to++;
+		}
+	}
+
+	int64_t integer = 0;
+	int64_t sign = 1;
+
+	for (int i = 0; i < to; i++) {
+		char c = p_str[i];
+		if (is_digit(c)) {
+			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
+			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
+			integer *= 10;
+			integer += c - '0';
+
+		} else if (c == '-' && integer == 0) {
+			sign = -sign;
+		} else if (c != ' ') {
+			break;
+		}
+	}
+
+	return integer * sign;
+}
+
+int64_t String::to_int(const char16_t *p_str, int p_len) {
+	int to = 0;
+	if (p_len >= 0) {
+		to = p_len;
+	} else {
+		while (p_str[to] != 0 && p_str[to] != '.') {
+			to++;
+		}
+	}
+
+	int64_t integer = 0;
+	int64_t sign = 1;
+
+	for (int i = 0; i < to; i++) {
+		char16_t c = p_str[i];
 		if (is_digit(c)) {
 			bool overflow = (integer > INT64_MAX / 10) || (integer == INT64_MAX / 10 && ((sign == 1 && c > '7') || (sign == -1 && c > '8')));
 			ERR_FAIL_COND_V_MSG(overflow, sign == 1 ? INT64_MAX : INT64_MIN, "Cannot represent " + String(p_str).substr(0, to) + " as a 64-bit signed integer, since the value is " + (sign == 1 ? "too large." : "too small."));
@@ -2957,6 +3092,14 @@ double String::to_float(const char *p_str) {
 	return built_in_strtod<char>(p_str);
 }
 
+double String::to_float(const char8_t *p_str, const char8_t **r_end) {
+	return built_in_strtod<char8_t>(p_str, (char8_t **)r_end);
+}
+
+double String::to_float(const char16_t *p_str, const char16_t **r_end) {
+	return built_in_strtod<char16_t>(p_str, (char16_t **)r_end);
+}
+
 double String::to_float(const char32_t *p_str, const char32_t **r_end) {
 	return built_in_strtod<char32_t>(p_str, (char32_t **)r_end);
 }
@@ -3098,6 +3241,48 @@ uint32_t String::hash(const wchar_t *p_cstr) {
 	while (c) {
 		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
 		c = static_cast<wide_unsigned>(*p_cstr++);
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const char8_t *p_cstr, int p_len) {
+	uint32_t hashv = 5381;
+	for (int i = 0; i < p_len; i++) {
+		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const char8_t *p_cstr) {
+	uint32_t hashv = 5381;
+	uint32_t c = *p_cstr++;
+
+	while (c) {
+		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		c = *p_cstr++;
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const char16_t *p_cstr, int p_len) {
+	uint32_t hashv = 5381;
+	for (int i = 0; i < p_len; i++) {
+		hashv = ((hashv << 5) + hashv) + p_cstr[i]; /* hash * 33 + c */
+	}
+
+	return hashv;
+}
+
+uint32_t String::hash(const char16_t *p_cstr) {
+	uint32_t hashv = 5381;
+	uint32_t c = *p_cstr++;
+
+	while (c) {
+		hashv = ((hashv << 5) + hashv) + c; /* hash * 33 + c */
+		c = *p_cstr++;
 	}
 
 	return hashv;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -39,19 +39,19 @@
 #include "core/typedefs.h"
 #include "core/variant/array.h"
 
-/*************************************************************************/
-/*  CharProxy                                                            */
-/*************************************************************************/
+class String;
+template <typename T>
+class CharStringT;
 
 template <typename T>
 class CharProxy {
-	friend class Char16String;
-	friend class CharString;
 	friend class String;
+	template <typename TS>
+	friend class CharStringT;
 
 	const int _index;
 	CowData<T> &_cowdata;
-	static const T _null = 0;
+	static constexpr T _null = 0;
 
 	_FORCE_INLINE_ CharProxy(const int &p_index, CowData<T> &p_cowdata) :
 			_index(p_index),
@@ -83,92 +83,59 @@ public:
 	}
 };
 
-/*************************************************************************/
-/*  Char16String                                                         */
-/*************************************************************************/
+template <typename T>
+class CharStringT {
+	friend class String;
 
-class Char16String {
-	CowData<char16_t> _cowdata;
-	static const char16_t _null;
+	CowData<T> _cowdata;
+	static constexpr T _null = 0;
 
 public:
-	_FORCE_INLINE_ char16_t *ptrw() { return _cowdata.ptrw(); }
-	_FORCE_INLINE_ const char16_t *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
+	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
-	Error resize(int p_size) { return _cowdata.resize(p_size); }
+	_FORCE_INLINE_ Error resize(int p_size) { return _cowdata.resize(p_size); }
 
-	_FORCE_INLINE_ char16_t get(int p_index) const { return _cowdata.get(p_index); }
-	_FORCE_INLINE_ void set(int p_index, const char16_t &p_elem) { _cowdata.set(p_index, p_elem); }
-	_FORCE_INLINE_ const char16_t &operator[](int p_index) const {
+	_FORCE_INLINE_ T get(int p_index) const { return _cowdata.get(p_index); }
+	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
+	_FORCE_INLINE_ const T &operator[](int p_index) const {
 		if (unlikely(p_index == _cowdata.size())) {
 			return _null;
 		}
 
 		return _cowdata.get(p_index);
 	}
-	_FORCE_INLINE_ CharProxy<char16_t> operator[](int p_index) { return CharProxy<char16_t>(p_index, _cowdata); }
+	_FORCE_INLINE_ CharProxy<T> operator[](int p_index) { return CharProxy<T>(p_index, _cowdata); }
 
-	_FORCE_INLINE_ Char16String() {}
-	_FORCE_INLINE_ Char16String(const Char16String &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ void operator=(const Char16String &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ Char16String(const char16_t *p_cstr) { copy_from(p_cstr); }
+	_FORCE_INLINE_ CharStringT() {}
+	_FORCE_INLINE_ CharStringT(const CharStringT<T> &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ void operator=(const CharStringT<T> &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ CharStringT(const T *p_cstr) { copy_from(p_cstr); }
+	_FORCE_INLINE_ void operator=(const T *p_cstr) { copy_from(p_cstr); }
 
-	void operator=(const char16_t *p_cstr);
-	bool operator<(const Char16String &p_right) const;
-	Char16String &operator+=(char16_t p_char);
-	int length() const { return size() ? size() - 1 : 0; }
-	const char16_t *get_data() const;
-	operator const char16_t *() const { return get_data(); };
+	bool operator==(const CharStringT<T> &p_other) const;
+	_FORCE_INLINE_ bool operator!=(const CharStringT<T> &p_other) const { return !(*this == p_other); }
+	bool operator<(const CharStringT<T> &p_other) const;
+	CharStringT<T> &operator+=(T p_char);
 
-protected:
-	void copy_from(const char16_t *p_cstr);
-};
-
-/*************************************************************************/
-/*  CharString                                                           */
-/*************************************************************************/
-
-class CharString {
-	CowData<char> _cowdata;
-	static const char _null;
-
-public:
-	_FORCE_INLINE_ char *ptrw() { return _cowdata.ptrw(); }
-	_FORCE_INLINE_ const char *ptr() const { return _cowdata.ptr(); }
-	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
-	Error resize(int p_size) { return _cowdata.resize(p_size); }
-
-	_FORCE_INLINE_ char get(int p_index) const { return _cowdata.get(p_index); }
-	_FORCE_INLINE_ void set(int p_index, const char &p_elem) { _cowdata.set(p_index, p_elem); }
-	_FORCE_INLINE_ const char &operator[](int p_index) const {
-		if (unlikely(p_index == _cowdata.size())) {
-			return _null;
+	_FORCE_INLINE_ int length() const { return size() ? size() - 1 : 0; }
+	_FORCE_INLINE_ const T *get_data() const {
+		if (size()) {
+			return &operator[](0);
 		}
-
-		return _cowdata.get(p_index);
+		return &_null;
 	}
-	_FORCE_INLINE_ CharProxy<char> operator[](int p_index) { return CharProxy<char>(p_index, _cowdata); }
-
-	_FORCE_INLINE_ CharString() {}
-	_FORCE_INLINE_ CharString(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ void operator=(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ CharString(const char *p_cstr) { copy_from(p_cstr); }
-
-	void operator=(const char *p_cstr);
-	bool operator<(const CharString &p_right) const;
-	bool operator==(const CharString &p_right) const;
-	CharString &operator+=(char p_char);
-	int length() const { return size() ? size() - 1 : 0; }
-	const char *get_data() const;
-	operator const char *() const { return get_data(); };
+	_FORCE_INLINE_ operator const T *() const { return get_data(); };
 
 protected:
-	void copy_from(const char *p_cstr);
+	void copy_from(const T *p_cstr);
 };
 
-/*************************************************************************/
-/*  String                                                               */
-/*************************************************************************/
+using CharString = CharStringT<char>;
+using Char8String = CharStringT<char8_t>;
+using Char16String = CharStringT<char16_t>;
+using Char32String = CharStringT<char32_t>;
+using CharWideString = CharStringT<wchar_t>;
 
 struct StrRange {
 	const char32_t *c_str;
@@ -189,6 +156,10 @@ class String {
 	void copy_from(const char *p_cstr, const int p_clip_to);
 	void copy_from(const wchar_t *p_cstr);
 	void copy_from(const wchar_t *p_cstr, const int p_clip_to);
+	void copy_from(const char8_t *p_cstr);
+	void copy_from(const char8_t *p_cstr, const int p_clip_to);
+	void copy_from(const char16_t *p_cstr);
+	void copy_from(const char16_t *p_cstr, const int p_clip_to);
 	void copy_from(const char32_t *p_cstr);
 	void copy_from(const char32_t *p_cstr, const int p_clip_to);
 
@@ -232,30 +203,40 @@ public:
 	String operator+(const String &p_str) const;
 	String operator+(char32_t p_char) const;
 
-	String &operator+=(const String &);
+	String &operator+=(const String &p_str);
 	String &operator+=(char32_t p_char);
 	String &operator+=(const char *p_str);
 	String &operator+=(const wchar_t *p_str);
+	String &operator+=(const char8_t *p_str);
+	String &operator+=(const char16_t *p_str);
 	String &operator+=(const char32_t *p_str);
 
 	/* Compatibility Operators */
 
 	void operator=(const char *p_str);
 	void operator=(const wchar_t *p_str);
+	void operator=(const char8_t *p_str);
+	void operator=(const char16_t *p_str);
 	void operator=(const char32_t *p_str);
 
 	bool operator==(const char *p_str) const;
 	bool operator==(const wchar_t *p_str) const;
+	bool operator==(const char8_t *p_str) const;
+	bool operator==(const char16_t *p_str) const;
 	bool operator==(const char32_t *p_str) const;
 	bool operator==(const StrRange &p_str_range) const;
 
 	bool operator!=(const char *p_str) const;
 	bool operator!=(const wchar_t *p_str) const;
+	bool operator!=(const char8_t *p_str) const;
+	bool operator!=(const char16_t *p_str) const;
 	bool operator!=(const char32_t *p_str) const;
 
-	bool operator<(const char32_t *p_str) const;
 	bool operator<(const char *p_str) const;
 	bool operator<(const wchar_t *p_str) const;
+	bool operator<(const char8_t *p_str) const;
+	bool operator<(const char16_t *p_str) const;
+	bool operator<(const char32_t *p_str) const;
 
 	bool operator<(const String &p_str) const;
 	bool operator<=(const String &p_str) const;
@@ -348,10 +329,14 @@ public:
 
 	static int64_t to_int(const char *p_str, int p_len = -1);
 	static int64_t to_int(const wchar_t *p_str, int p_len = -1);
+	static int64_t to_int(const char8_t *p_str, int p_len = -1);
+	static int64_t to_int(const char16_t *p_str, int p_len = -1);
 	static int64_t to_int(const char32_t *p_str, int p_len = -1, bool p_clamp = false);
 
 	static double to_float(const char *p_str);
 	static double to_float(const wchar_t *p_str, const wchar_t **r_end = nullptr);
+	static double to_float(const char8_t *p_str, const char8_t **r_end = nullptr);
+	static double to_float(const char16_t *p_str, const char16_t **r_end = nullptr);
 	static double to_float(const char32_t *p_str, const char32_t **r_end = nullptr);
 	static uint32_t num_characters(int64_t p_int);
 
@@ -413,6 +398,10 @@ public:
 
 	static uint32_t hash(const char32_t *p_cstr, int p_len); /* hash the string */
 	static uint32_t hash(const char32_t *p_cstr); /* hash the string */
+	static uint32_t hash(const char16_t *p_cstr, int p_len); /* hash the string */
+	static uint32_t hash(const char16_t *p_cstr); /* hash the string */
+	static uint32_t hash(const char8_t *p_cstr, int p_len); /* hash the string */
+	static uint32_t hash(const char8_t *p_cstr); /* hash the string */
 	static uint32_t hash(const wchar_t *p_cstr, int p_len); /* hash the string */
 	static uint32_t hash(const wchar_t *p_cstr); /* hash the string */
 	static uint32_t hash(const char *p_cstr, int p_len); /* hash the string */
@@ -491,20 +480,32 @@ public:
 
 	String(const char *p_str);
 	String(const wchar_t *p_str);
+	String(const char8_t *p_str);
+	String(const char16_t *p_str);
 	String(const char32_t *p_str);
 	String(const char *p_str, int p_clip_to_len);
 	String(const wchar_t *p_str, int p_clip_to_len);
+	String(const char8_t *p_str, int p_clip_to_len);
+	String(const char16_t *p_str, int p_clip_to_len);
 	String(const char32_t *p_str, int p_clip_to_len);
 	String(const StrRange &p_range);
 };
 
 bool operator==(const char *p_chr, const String &p_str);
 bool operator==(const wchar_t *p_chr, const String &p_str);
+bool operator==(const char8_t *p_chr, const String &p_str);
+bool operator==(const char16_t *p_chr, const String &p_str);
+bool operator==(const char32_t *p_chr, const String &p_str);
 bool operator!=(const char *p_chr, const String &p_str);
 bool operator!=(const wchar_t *p_chr, const String &p_str);
-
+bool operator!=(const char8_t *p_chr, const String &p_str);
+bool operator!=(const char16_t *p_chr, const String &p_str);
+bool operator!=(const char32_t *p_chr, const String &p_str);
 String operator+(const char *p_chr, const String &p_str);
 String operator+(const wchar_t *p_chr, const String &p_str);
+String operator+(const char8_t *p_chr, const String &p_str);
+String operator+(const char16_t *p_chr, const String &p_str);
+String operator+(const char32_t *p_chr, const String &p_str);
 String operator+(char32_t p_chr, const String &p_str);
 
 String itos(int64_t p_val);

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -41,8 +41,8 @@
 template <typename T>
 class Vector;
 class String;
-class Char16String;
-class CharString;
+template <typename T>
+class CharStringT;
 template <typename T, typename V>
 class VMap;
 
@@ -59,8 +59,8 @@ class CowData {
 	template <typename TV>
 	friend class Vector;
 	friend class String;
-	friend class Char16String;
-	friend class CharString;
+	template <typename TS>
+	friend class CharStringT;
 	template <typename TV, typename VV>
 	friend class VMap;
 

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2515,14 +2515,29 @@ Variant::Variant(const String &p_string) :
 	memnew_placement(_data._mem, String(p_string));
 }
 
-Variant::Variant(const char *const p_cstring) :
+Variant::Variant(const char *p_cstring) :
 		type(STRING) {
-	memnew_placement(_data._mem, String((const char *)p_cstring));
+	memnew_placement(_data._mem, String(p_cstring));
 }
 
-Variant::Variant(const char32_t *p_wstring) :
+Variant::Variant(const wchar_t *p_wstring) :
 		type(STRING) {
 	memnew_placement(_data._mem, String(p_wstring));
+}
+
+Variant::Variant(const char8_t *p_c8string) :
+		type(STRING) {
+	memnew_placement(_data._mem, String(p_c8string));
+}
+
+Variant::Variant(const char16_t *p_c16string) :
+		type(STRING) {
+	memnew_placement(_data._mem, String(p_c16string));
+}
+
+Variant::Variant(const char32_t *p_c32string) :
+		type(STRING) {
+	memnew_placement(_data._mem, String(p_c32string));
 }
 
 Variant::Variant(const Vector3 &p_vector3) :

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -463,8 +463,11 @@ public:
 	Variant(const ObjectID &p_id);
 	Variant(const String &p_string);
 	Variant(const StringName &p_string);
-	Variant(const char *const p_cstring);
-	Variant(const char32_t *p_wstring);
+	Variant(const char *p_cstring);
+	Variant(const wchar_t *p_wstring);
+	Variant(const char8_t *p_c8string);
+	Variant(const char16_t *p_c16string);
+	Variant(const char32_t *p_c32string);
 	Variant(const Vector2 &p_vector2);
 	Variant(const Vector2i &p_vector2i);
 	Variant(const Rect2 &p_rect2);


### PR DESCRIPTION
- Requires #89950
- Requires #98439

One of the additions to C++20 is the new type `char8_t`[^1], functioning as the UTF-8 equivalent to `char16_t` and `char32_t`. Despite being a C++20 feature, this type can be safely backported to C++17 using `-fchar8_t` (`/Zc:char8_t` on msvc). While this exists with the intent to replace `char` with `char8_t` in UTF-8 contexts, that would be a *very* wide-reaching change which would necessitate a more granular approach. Instead, this simply extends character-type support introduced in the above two PRs to include `char8_t`.

[^1]: https://en.cppreference.com/w/cpp/language/types#char8_t