### PR TITLE
Improve core and GDScript VM multithreading performance

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2262,7 +2262,7 @@ uint32_t ObjectDB::slot_max = 0;
 uint32_t ObjectDB::block_max = 0;
 uint64_t ObjectDB::validator_counter = 0;
 
-int ObjectDB::blocks_max_sizes[OBJECTDB_MAX_BLOCKS] = {
+uint32_t ObjectDB::blocks_max_sizes[OBJECTDB_MAX_BLOCKS] = {
 	0,
 	128,
 	256,
@@ -2300,7 +2300,7 @@ int ObjectDB::get_object_count() {
 
 ObjectID ObjectDB::add_instance(Object *p_object) {
 	mutex.lock();
-	if(slot_count == blocks_max_sizes[block_count] && blocks[block_count + 1] != nullptr) {
+	if (slot_count == blocks_max_sizes[block_count] && blocks[block_count + 1] != nullptr) {
 		slot_count = 0;
 		block_count++;
 	}

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -998,20 +998,21 @@ void postinitialize_handler(Object *p_object);
 
 class ObjectDB {
 // This needs to add up to 63, 1 bit is for reference.
-#define OBJECTDB_VALIDATOR_BITS 34
+#define OBJECTDB_VALIDATOR_BITS 32
 #define OBJECTDB_VALIDATOR_MASK ((uint64_t(1) << OBJECTDB_VALIDATOR_BITS) - 1)
 #define OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS 5
-#define OBJECTDB_SLOT_MAX_COUNT_BITS 24
+#define OBJECTDB_SLOT_MAX_COUNT_BITS 26
+#define OBJECTDB_SLOT_MAX_POSITION_BITS (OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS + OBJECTDB_SLOT_MAX_COUNT_BITS)
 #define OBJECTDB_SLOT_MAX_BLOCKS_COUNT_MASK ((uint64_t(1) << OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS) - 1)
-#define OBJECTDB_SLOT_MAX_POSITION_MASK ((uint64_t(1) << (OBJECTDB_SLOT_MAX_COUNT_BITS + OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS)) - 1)
-#define OBJECTDB_REFERENCE_BIT (uint64_t(1) << (OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS + OBJECTDB_SLOT_MAX_COUNT_BITS + OBJECTDB_VALIDATOR_BITS))
-#define OBJECTDB_MAX_BLOCKS 22
+#define OBJECTDB_SLOT_MAX_POSITION_MASK ((uint64_t(1) << OBJECTDB_SLOT_MAX_POSITION_BITS) - 1)
+#define OBJECTDB_REFERENCE_BIT (uint64_t(1) << (OBJECTDB_SLOT_MAX_POSITION_BITS + OBJECTDB_VALIDATOR_BITS))
+#define OBJECTDB_MAX_BLOCKS 32
 
 	union NextFree {
-		uint32_t position : 29;
+		uint32_t position : OBJECTDB_SLOT_MAX_POSITION_BITS;
 		struct {
-			uint32_t block_number : 5;
-			uint32_t block_position : 22;
+			uint32_t block_number : OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS;
+			uint32_t block_position : OBJECTDB_SLOT_MAX_COUNT_BITS;
 		};
 	};
 
@@ -1023,7 +1024,7 @@ class ObjectDB {
 	};
 
 	static ObjectSlot *blocks[OBJECTDB_MAX_BLOCKS];
-	static uint32_t blocks_max_sizes[OBJECTDB_MAX_BLOCKS];
+	static const uint32_t blocks_max_sizes[OBJECTDB_MAX_BLOCKS];
 
 	static uint32_t slot_count;
 	static uint32_t block_count;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -1007,9 +1007,8 @@ class ObjectDB {
 #define OBJECTDB_REFERENCE_BIT (uint64_t(1) << (OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS + OBJECTDB_SLOT_MAX_COUNT_BITS + OBJECTDB_VALIDATOR_BITS))
 #define OBJECTDB_MAX_BLOCKS 22
 
-
 	union NextFree {
-		uint32_t position:29;
+		uint32_t position : 29;
 		struct {
 			uint32_t block_number : 5;
 			uint32_t block_position : 22;
@@ -1024,7 +1023,7 @@ class ObjectDB {
 	};
 
 	static ObjectSlot *blocks[OBJECTDB_MAX_BLOCKS];
-	static int blocks_max_sizes[OBJECTDB_MAX_BLOCKS];
+	static uint32_t blocks_max_sizes[OBJECTDB_MAX_BLOCKS];
 
 	static uint32_t slot_count;
 	static uint32_t block_count;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -1002,14 +1002,17 @@ class ObjectDB {
 #define OBJECTDB_VALIDATOR_MASK ((uint64_t(1) << OBJECTDB_VALIDATOR_BITS) - 1)
 #define OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS 5
 #define OBJECTDB_SLOT_MAX_COUNT_BITS 24
-#define OBJECTDB_SLOT_MAX_COUNT_MASK ((uint64_t(1) << OBJECTDB_SLOT_MAX_COUNT_BITS) - 1)
-#define OBJECTDB_REFERENCE_BIT (uint64_t(1) << (OBJECTDB_SLOT_MAX_COUNT_BITS + OBJECTDB_VALIDATOR_BITS))
+#define OBJECTDB_SLOT_MAX_BLOCKS_COUNT_MASK ((uint64_t(1) << OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS) - 1)
+#define OBJECTDB_SLOT_MAX_POSITION_MASK ((uint64_t(1) << (OBJECTDB_SLOT_MAX_COUNT_BITS + OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS)) - 1)
+#define OBJECTDB_REFERENCE_BIT (uint64_t(1) << (OBJECTDB_SLOT_MAX_BLOCKS_COUNT_BITS + OBJECTDB_SLOT_MAX_COUNT_BITS + OBJECTDB_VALIDATOR_BITS))
+#define OBJECTDB_MAX_BLOCKS 22
+
 
 	union NextFree {
-		uint32_t slot : 27;
+		uint32_t position:29;
 		struct {
-			uint16_t block_number : 5;
-			uint16_t block_position : 22;
+			uint32_t block_number : 5;
+			uint32_t block_position : 22;
 		};
 	};
 
@@ -1020,11 +1023,15 @@ class ObjectDB {
 		Object *object = nullptr;
 	};
 
-	static ObjectSlot *blocks[];
-	static int blocks_max_sizes[];
+	static ObjectSlot *blocks[OBJECTDB_MAX_BLOCKS];
+	static int blocks_max_sizes[OBJECTDB_MAX_BLOCKS];
 
 	static uint32_t slot_count;
 	static uint32_t block_count;
+
+	static uint32_t slot_max;
+	static uint32_t block_max;
+
 	static BinaryMutex mutex;
 	static uint64_t validator_counter;
 

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -178,9 +178,7 @@ void *Memory::realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align) {
 }
 
 void Memory::free_static(void *p_ptr, bool p_pad_align) {
-	if(p_ptr == nullptr) {
-		printf("Null \n");
-	}
+	ERR_FAIL_NULL(p_ptr);
 
 	uint8_t *mem = (uint8_t *)p_ptr;
 

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -178,7 +178,9 @@ void *Memory::realloc_static(void *p_memory, size_t p_bytes, bool p_pad_align) {
 }
 
 void Memory::free_static(void *p_ptr, bool p_pad_align) {
-	ERR_FAIL_NULL(p_ptr);
+	if(p_ptr == nullptr) {
+		printf("Null \n");
+	}
 
 	uint8_t *mem = (uint8_t *)p_ptr;
 

--- a/core/os/rw_lock.cpp
+++ b/core/os/rw_lock.cpp
@@ -37,9 +37,9 @@
 
 int RWLock::threads_number = -1;
 
-struct RWLock::ThreadData {
-	uint8_t _offset[128 - sizeof(BinaryMutex) / 2];
-	SpinLock mtx;
+struct RWLock::ThreadMutex {
+	uint8_t _offset[64];
+	BinaryMutex mtx;
 };
 
 int RWLock::get_thread_pos() {
@@ -53,9 +53,9 @@ void RWLock::init() const {
 			threads_number = 1;
 		}
 	}
-	threads_data = (ThreadData *)memalloc(sizeof(ThreadData) * threads_number);
+	threads_data = (ThreadMutex *)memalloc(sizeof(ThreadMutex) * threads_number);
 	for (int i = 0; i < threads_number; i++) {
-		memnew_placement(&threads_data[i], ThreadData());
+		memnew_placement(&threads_data[i], ThreadMutex());
 	}
 }
 
@@ -113,7 +113,7 @@ void RWLock::write_unlock() {
 RWLock::~RWLock() {
 	if (threads_data != nullptr) {
 		for (int i = 0; i < threads_number; i++) {
-			threads_data[i].~ThreadData();
+			threads_data[i].~ThreadMutex();
 		}
 		memfree(threads_data);
 		threads_data = nullptr;

--- a/core/os/rw_lock.h
+++ b/core/os/rw_lock.h
@@ -48,7 +48,6 @@ class RWLock {
 	static int threads_number;
 
 	mutable ThreadMutex *threads_data = nullptr;
-	mutable THREADING_NAMESPACE::shared_timed_mutex mutex; // Used when OS singletom == nullptr;
 
 	static int get_thread_pos();
 
@@ -67,6 +66,7 @@ public:
 	// Unlock the RWLock, let other threads continue.
 	void write_unlock();
 
+	RWLock();
 	~RWLock();
 };
 

--- a/core/os/rw_lock.h
+++ b/core/os/rw_lock.h
@@ -43,11 +43,11 @@
 #endif
 
 class RWLock {
-	struct ThreadData;
+	struct ThreadMutex;
 
 	static int threads_number;
 
-	mutable ThreadData *threads_data = nullptr;
+	mutable ThreadMutex *threads_data = nullptr;
 	mutable THREADING_NAMESPACE::shared_timed_mutex mutex; // Used when OS singletom == nullptr;
 
 	static int get_thread_pos();

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1102,6 +1102,9 @@ void Variant::ObjData::ref_pointer(Object *p_object) {
 
 	if (p_object) {
 		*this = ObjData{ p_object->get_instance_id(), p_object };
+		if(id.is_null()) {
+			print_line("Id == 0");
+		}
 		if (p_object->is_ref_counted()) {
 			RefCounted *reference = static_cast<RefCounted *>(p_object);
 			if (!reference->init_ref()) {

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1072,7 +1072,7 @@ bool Variant::is_null() const {
 	}
 }
 
-void Variant::ObjData::ref(const ObjData &p_from) {
+void Variant::ObjData::ref(const ObjData &p_from, bool p_is_weak_ref_old, bool p_is_weak_ref) {
 	// Mirrors Ref::ref in refcounted.h
 	if (p_from.id == id) {
 		return;
@@ -1081,7 +1081,7 @@ void Variant::ObjData::ref(const ObjData &p_from) {
 	ObjData cleanup_ref = *this;
 
 	*this = p_from;
-	if (id.is_ref_counted()) {
+	if (!p_is_weak_ref && id.is_ref_counted()) {
 		RefCounted *reference = static_cast<RefCounted *>(obj);
 		// Assuming reference is not null because id.is_ref_counted() was true.
 		if (!reference->reference()) {
@@ -1089,10 +1089,10 @@ void Variant::ObjData::ref(const ObjData &p_from) {
 		}
 	}
 
-	cleanup_ref.unref();
+	cleanup_ref.unref(p_is_weak_ref_old);
 }
 
-void Variant::ObjData::ref_pointer(Object *p_object) {
+void Variant::ObjData::ref_pointer(Object *p_object, bool p_is_weak_ref_old, bool p_is_weak_ref) {
 	// Mirrors Ref::ref_pointer in refcounted.h
 	if (p_object == obj) {
 		return;
@@ -1102,10 +1102,7 @@ void Variant::ObjData::ref_pointer(Object *p_object) {
 
 	if (p_object) {
 		*this = ObjData{ p_object->get_instance_id(), p_object };
-		if(id.is_null()) {
-			print_line("Id == 0");
-		}
-		if (p_object->is_ref_counted()) {
+		if (!p_is_weak_ref && p_object->is_ref_counted()) {
 			RefCounted *reference = static_cast<RefCounted *>(p_object);
 			if (!reference->init_ref()) {
 				*this = ObjData();
@@ -1115,12 +1112,12 @@ void Variant::ObjData::ref_pointer(Object *p_object) {
 		*this = ObjData();
 	}
 
-	cleanup_ref.unref();
+	cleanup_ref.unref(p_is_weak_ref_old);
 }
 
-void Variant::ObjData::unref() {
+void Variant::ObjData::unref(bool p_is_weak_ref) {
 	// Mirrors Ref::unref in refcounted.h
-	if (id.is_ref_counted()) {
+	if (!p_is_weak_ref && id.is_ref_counted()) {
 		RefCounted *reference = static_cast<RefCounted *>(obj);
 		// Assuming reference is not null because id.is_ref_counted() was true.
 		if (reference->unreference()) {
@@ -1132,7 +1129,7 @@ void Variant::ObjData::unref() {
 
 void Variant::reference(const Variant &p_variant) {
 	if (type == OBJECT && p_variant.type == OBJECT) {
-		_get_obj().ref(p_variant._get_obj());
+		_get_obj().ref(p_variant._get_obj(), is_weak_ref, p_variant.is_weak_ref);
 		return;
 	}
 
@@ -1220,7 +1217,7 @@ void Variant::reference(const Variant &p_variant) {
 		} break;
 		case OBJECT: {
 			memnew_placement(_data._mem, ObjData);
-			_get_obj().ref(p_variant._get_obj());
+			_get_obj().ref(p_variant._get_obj(), is_weak_ref, p_variant.is_weak_ref);
 		} break;
 		case CALLABLE: {
 			memnew_placement(_data._mem, Callable(*reinterpret_cast<const Callable *>(p_variant._data._mem)));
@@ -1419,7 +1416,7 @@ void Variant::_clear_internal() {
 			reinterpret_cast<NodePath *>(_data._mem)->~NodePath();
 		} break;
 		case OBJECT: {
-			_get_obj().unref();
+			_get_obj().unref(is_weak_ref);
 		} break;
 		case RID: {
 			// Not much need probably.
@@ -2626,7 +2623,14 @@ Variant::Variant(const ::RID &p_rid) :
 Variant::Variant(const Object *p_object) :
 		type(OBJECT) {
 	_get_obj() = ObjData();
-	_get_obj().ref_pointer(const_cast<Object *>(p_object));
+	_get_obj().ref_pointer(const_cast<Object *>(p_object), true, false);
+}
+
+Variant::Variant(const RefCounted *p_object, bool p_is_weak_ref) :
+		type(OBJECT) {
+	_get_obj() = ObjData();
+	_get_obj().ref_pointer((Object *)p_object, true, p_is_weak_ref);
+	is_weak_ref = p_is_weak_ref;
 }
 
 Variant::Variant(const Callable &p_callable) :
@@ -2848,7 +2852,7 @@ void Variant::operator=(const Variant &p_variant) {
 			*reinterpret_cast<::RID *>(_data._mem) = *reinterpret_cast<const ::RID *>(p_variant._data._mem);
 		} break;
 		case OBJECT: {
-			_get_obj().ref(p_variant._get_obj());
+			_get_obj().ref(p_variant._get_obj(), is_weak_ref, p_variant.is_weak_ref);
 		} break;
 		case CALLABLE: {
 			*reinterpret_cast<Callable *>(_data._mem) = *reinterpret_cast<const Callable *>(p_variant._data._mem);

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -175,22 +175,23 @@ private:
 	// and PackedArray/Array/Dictionary (platform-dependent).
 
 	Type type = NIL;
+	bool is_weak_ref = false;
 
 	struct ObjData {
 		ObjectID id;
 		Object *obj = nullptr;
 
-		void ref(const ObjData &p_from);
-		void ref_pointer(Object *p_object);
-		void ref_pointer(RefCounted *p_object);
-		void unref();
+		void ref(const ObjData &p_from, bool p_is_weak_ref_old, bool p_is_weak_ref);
+		void ref_pointer(Object *p_object, bool p_is_weak_ref_old, bool is_weak_ref);
+		void ref_pointer(RefCounted *p_object, bool p_is_weak_ref_old, bool p_is_weak_ref);
+		void unref(bool p_is_weak_ref);
 
 		template <typename T>
-		_ALWAYS_INLINE_ void ref(const Ref<T> &p_from) {
+		_ALWAYS_INLINE_ void ref(const Ref<T> &p_from, bool p_is_weak_ref_old, bool p_is_weak_ref) {
 			if (p_from.is_valid()) {
-				ref(ObjData{ p_from->get_instance_id(), p_from.ptr() });
+				ref(ObjData{ p_from->get_instance_id(), p_from.ptr() }, p_is_weak_ref_old, p_is_weak_ref);
 			} else {
-				unref();
+				unref(p_is_weak_ref_old);
 			}
 		}
 	};
@@ -326,6 +327,7 @@ private:
 			_clear_internal();
 		}
 		type = NIL;
+		is_weak_ref = false;
 	}
 
 	static void _register_variant_operators();
@@ -484,6 +486,7 @@ public:
 	Variant(const NodePath &p_node_path);
 	Variant(const ::RID &p_rid);
 	Variant(const Object *p_object);
+	Variant(const RefCounted *p_object, bool p_is_weak_ref = false);
 	Variant(const Callable &p_callable);
 	Variant(const Signal &p_signal);
 	Variant(const Dictionary &p_dictionary);

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -328,20 +328,20 @@ public:
 	}
 
 	_FORCE_INLINE_ static void object_assign(Variant *v, const Variant *vo) {
-		v->_get_obj().ref(vo->_get_obj());
+		v->_get_obj().ref(vo->_get_obj(), v->is_weak_ref, vo->is_weak_ref);
 	}
 
-	_FORCE_INLINE_ static void object_assign(Variant *v, Object *o) {
-		v->_get_obj().ref_pointer(o);
+	_FORCE_INLINE_ static void object_assign(Variant *v, Object *o, bool p_is_weak_ref = false) {
+		v->_get_obj().ref_pointer(o, v->is_weak_ref, p_is_weak_ref);
 	}
 
-	_FORCE_INLINE_ static void object_assign(Variant *v, const Object *o) {
-		v->_get_obj().ref_pointer(const_cast<Object *>(o));
+	_FORCE_INLINE_ static void object_assign(Variant *v, const Object *o, bool p_is_weak_ref = false) {
+		v->_get_obj().ref_pointer(const_cast<Object *>(o), v->is_weak_ref, p_is_weak_ref);
 	}
 
 	template <typename T>
-	_FORCE_INLINE_ static void object_assign(Variant *v, const Ref<T> &r) {
-		v->_get_obj().ref(r);
+	_FORCE_INLINE_ static void object_assign(Variant *v, const Ref<T> &r, bool p_is_weak_ref = false) {
+		v->_get_obj().ref(r, v->is_weak_ref, p_is_weak_ref);
 	}
 
 	_FORCE_INLINE_ static void object_reset_data(Variant *v) {

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -842,7 +842,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				bool result = false;
 				if (value->get_type() == Variant::ARRAY) {
@@ -865,13 +865,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 5];
 				int key_native_type_idx = _code_ptr[ip + 6];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
-				const StringName key_native_type = _global_names_ptr[key_native_type_idx];
+				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
 				GET_VARIANT_PTR(value_script_type, 3);
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 7];
 				int value_native_type_idx = _code_ptr[ip + 8];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
-				const StringName value_native_type = _global_names_ptr[value_native_type_idx];
+				const StringName &value_native_type = _global_names_ptr[value_native_type_idx];
 
 				bool result = false;
 				if (value->get_type() == Variant::DICTIONARY) {
@@ -893,7 +893,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				int native_type_idx = _code_ptr[ip + 3];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				bool was_freed = false;
 				Object *object = value->get_validated_object_with_check(was_freed);
@@ -1416,7 +1416,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				if (src->get_type() != Variant::ARRAY) {
 #ifdef DEBUG_ENABLED
@@ -1451,13 +1451,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 5];
 				int key_native_type_idx = _code_ptr[ip + 6];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
-				const StringName key_native_type = _global_names_ptr[key_native_type_idx];
+				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
 				GET_VARIANT_PTR(value_script_type, 3);
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 7];
 				int value_native_type_idx = _code_ptr[ip + 8];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
-				const StringName value_native_type = _global_names_ptr[value_native_type_idx];
+				const StringName &value_native_type = _global_names_ptr[value_native_type_idx];
 
 				if (src->get_type() != Variant::DICTIONARY) {
 #ifdef DEBUG_ENABLED
@@ -1771,7 +1771,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 2];
 				int native_type_idx = _code_ptr[ip + 3];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				Array array;
 				array.resize(argc);
@@ -1824,13 +1824,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 2];
 				int key_native_type_idx = _code_ptr[ip + 3];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
-				const StringName key_native_type = _global_names_ptr[key_native_type_idx];
+				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
 				GET_INSTRUCTION_ARG(value_script_type, argc * 2 + 2);
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int value_native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
-				const StringName value_native_type = _global_names_ptr[value_native_type_idx];
+				const StringName &value_native_type = _global_names_ptr[value_native_type_idx];
 
 				Dictionary dict;
 
@@ -2340,7 +2340,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GD_ERR_BREAK(argc < 0);
 
 				GD_ERR_BREAK(_code_ptr[ip + 2] < 0 || _code_ptr[ip + 2] >= _global_names_count);
-				StringName function = _global_names_ptr[_code_ptr[ip + 2]];
+				const StringName &function = _global_names_ptr[_code_ptr[ip + 2]];
 
 				Variant **argptrs = instruction_args;
 
@@ -2770,7 +2770,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 3];
 				int native_type_idx = _code_ptr[ip + 4];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName native_type = _global_names_ptr[native_type_idx];
+				const StringName &native_type = _global_names_ptr[native_type_idx];
 
 				if (r->get_type() != Variant::ARRAY) {
 #ifdef DEBUG_ENABLED
@@ -2806,13 +2806,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int key_native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
-				const StringName key_native_type = _global_names_ptr[key_native_type_idx];
+				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
 				GET_VARIANT_PTR(value_script_type, 2);
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 6];
 				int value_native_type_idx = _code_ptr[ip + 7];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
-				const StringName value_native_type = _global_names_ptr[value_native_type_idx];
+				const StringName &value_native_type = _global_names_ptr[value_native_type_idx];
 
 				if (r->get_type() != Variant::DICTIONARY) {
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -618,7 +618,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		memnew_placement(&stack[ADDR_STACK_SELF], Variant);
 		script = _script;
 	}
-	memnew_placement(&stack[ADDR_STACK_CLASS], Variant(script));
+	memnew_placement(&stack[ADDR_STACK_CLASS], Variant(script, true));
 	memnew_placement(&stack[ADDR_STACK_NIL], Variant);
 
 	String err_text;


### PR DESCRIPTION
# When multithreading is slower than single-threading?

Multithreading is slow if many threads are working on shared data. The problem arises if one thread changes the data used by other threads, due to which the cache in these threads becomes invalid, and the processor work with cache memory of the 3rd level.
An even bigger problem becomes when shared data are atomic types with which only one thread can work (`RefCounted`, `SpinLock`, `Mutex`).

# What and how was improved?

**ObjectDB lock-free**
The `get_instance` method now does not use `SpinLock`. Similar to this PR: #97465.

The class now allocates blocks. Each block is an `ObjectSlot` array. The size of the blocks increases exponentially.
This gets rid of the `realloc` that was used before and required `SpinLock` to get an `Object`.

**RWLock**
`RWLock` was improved. Now each thread has its own mutex for reading data. All mutexes are locked during write. Before that, `shared_timed_mutex` was used, which was shared by all threads.

**StringName assignment**
Assigning one `StringName` to another `StringName` uses the atomic operations `ref`, `unref`. 

In the method `Object::_call_bind` and `_call_deferred_bind`, `VariantInternal` was used, which received `StringName` without using ref.
In `gdscript_vm` c++ references were used instead of assignments.

**Weak Variant for RefCounted**
https://github.com/godotengine/godot/blob/533c616cb86ff7bb940d58ffbbcc1a3eca0aa33d/modules/gdscript/gdscript_vm.cpp#L621

Each time any GDScript method is called, `reference` is called in one common `script` variable. Also, when the method ends, the Variant is destroyed, which causes an unreference.
Therefore, I implemented the constructor of a weak `Variant` from `RefCounted` so that the Variant doesn't count the number of references that point to it. 

In order to use this you need to pass the optional true parameter to constructor like this: `Variant(script, true)`.

# What wasn't improved?
One bottleneck remains `_ObjectDebugLock`, but I did not change it because it is not used in the release build.

# Performance testing.
MRP [Multithreading_Test.zip](https://github.com/user-attachments/files/17493456/Multithreading_Test.zip). This is the same as in #58279, but for 4.3+ versions. 

For testing, compile `scons scu_build=yes target=template release to=full`.
While loop where calculations are performed on many threads:
``` python
while(count > 0):
	count -= 1
	
	#Comment/uncomment these lines to test different functions
	some_val += 1
	some_val = sin(some_val)
	some_val = _increment(some_val)
	some_val += noise.get_noise_2d(1,1)
	##Unique function per thread
	call(name, some_val)
```
Master:

https://github.com/user-attachments/assets/d9fc8be4-7954-4633-b2e5-761f179fed0f

CurrentPR:

https://github.com/user-attachments/assets/ef6aa9bc-dbcb-40c2-8401-dc25c46bbd6f

Blue shows the number of cycle iterations per u_sec.
Red shows the total number of iterations of all threads per u_sec.

Also here https://github.com/godotengine/godot-demo-projects/tree/master/3d/voxel, because multithreading is used, the average `Mesh` generation time is improved by 58%.

Fixes #58279
Fixes #65404