### PR TITLE
Docs: Link to GlobalScope string methods from String class ref

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -6,6 +6,7 @@
 	<description>
 		This is the built-in string Variant type (and the one used by GDScript). Strings may contain any number of Unicode characters, and expose methods useful for manipulating and generating strings. Strings are reference-counted and use a copy-on-write approach (every modification to a string returns a new [String]), so passing them around is cheap in resources.
 		Some string methods have corresponding variations. Variations suffixed with [code]n[/code] ([method countn], [method findn], [method replacen], etc.) are [b]case-insensitive[/b] (they make no distinction between uppercase and lowercase letters). Method variations prefixed with [code]r[/code] ([method rfind], [method rsplit], etc.) are reversed, and start from the end of the string, instead of the beginning.
+		To convert any Variant to or from a string, see [method @GlobalScope.str], [method @GlobalScope.str_to_var], and [method @GlobalScope.var_to_str].
 		[b]Note:[/b] In a boolean context, a string will evaluate to [code]false[/code] if it is empty ([code]""[/code]). Otherwise, a string will always evaluate to [code]true[/code].
 	</description>
 	<tutorials>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/10132. If this PR is not approved, the original issue should be closed as not planned.

Adds links to the `@GlobalScope` functions `str()`, `str_to_var()`, and `var_to_str()` from the `String` class ref. These are the only three `@GlobalScope` functions that are clearly related to strings, rather than just using strings incidentally.

These three functions are of interest to users looking at the string documentation. These functions could just as easily have been implemented as static functions `String.from()`, `String.to_var()`, and `String.from_var()`. So it's due to implementation choices and the class reference's inflexibility that these functions are not currently shown on the `String` class reference. All that, and the fact that at least one user noticed their absence in the `String` class ref, makes them worth linking.

I personally don't mind the status quo in which these functions are not linked from the `String` page. One way or another, this PR should close the original issue, as either implemented or not planned.