### PR TITLE
Fix some flickering tooltips

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1921,7 +1921,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 						String tooltip = _gui_get_tooltip(over, gui.tooltip_control->get_global_transform_with_canvas().affine_inverse().xform(mpos));
 						tooltip = tooltip.strip_edges();
 
-						if (tooltip.is_empty() || tooltip != gui.tooltip_text) {
+						if (tooltip != gui.tooltip_text) {
 							_gui_cancel_tooltip();
 						} else {
 							is_tooltip_shown = true;


### PR DESCRIPTION
Fixes #98449

On mouse movement, `Viewport` cancels current tooltip if the control's tooltip text is empty. On Windows, it appears that a mouse movement event is automatically generated when a tooltip is shown, so a button's tooltip flickers if it's only showing shortcut information without actual `tooltip_text`.

The empty string check was introduced in #5803 to address another tooltip flickering issue :rofl: It seems to be a redundant check, testing for text change should be sufficient.