### PR TITLE
Docs: Link to Project Settings tutorial from ProjectSettings class

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -10,6 +10,7 @@
 		[b]Overriding:[/b] Any project setting can be overridden by creating a file named [code]override.cfg[/code] in the project's root directory. This can also be used in exported projects by placing this file in the same directory as the project binary. Overriding will still take the base project settings' [url=$DOCS_URL/tutorials/export/feature_tags.html]feature tags[/url] in account. Therefore, make sure to [i]also[/i] override the setting with the desired feature tags if you want them to override base project settings on all platforms and configurations.
 	</description>
 	<tutorials>
+		<link title="Project Settings">$DOCS_URL/tutorials/editor/project_settings.html</link>
 		<link title="3D Physics Tests Demo">https://godotengine.org/asset-library/asset/2747</link>
 		<link title="3D Platformer Demo">https://godotengine.org/asset-library/asset/2748</link>
 		<link title="Operating System Testing Demo">https://godotengine.org/asset-library/asset/2789</link>


### PR DESCRIPTION
Pretty self-explanatory. Note that the [Project Settings](https://docs.godotengine.org/en/latest/tutorials/editor/project_settings.html) manual page is currently barebones, and is about the Project Settings window rather than the ProjectSettings class. But if you're looking at one you probably want to know about the other. 