### PR TITLE
Add `InputMap.is_builtin_action()`

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -56,6 +56,7 @@ void InputMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("action_get_events", "action"), &InputMap::_action_get_events);
 	ClassDB::bind_method(D_METHOD("event_is_action", "event", "action", "exact_match"), &InputMap::event_is_action, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("load_from_project_settings"), &InputMap::load_from_project_settings);
+	ClassDB::bind_method(D_METHOD("is_builtin_action", "action"), &InputMap::is_builtin_action);
 }
 
 /**
@@ -126,6 +127,11 @@ void InputMap::add_action(const StringName &p_action, float p_deadzone) {
 
 void InputMap::erase_action(const StringName &p_action) {
 	ERR_FAIL_COND_MSG(!input_map.has(p_action), suggest_actions(p_action));
+
+	// Make debugging easier. It's still allowed to keep compatibility.
+	if (is_builtin_action(p_action)) {
+		WARN_PRINT("Erasing built-in action \"" + String(p_action) + "\".");
+	}
 
 	input_map.erase(p_action);
 }
@@ -418,7 +424,11 @@ String InputMap::get_builtin_display_name(const String &p_name) const {
 	return p_name;
 }
 
-const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
+bool InputMap::is_builtin_action(const StringName &p_action) const {
+	return get_builtins().has(p_action);
+}
+
+const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() const {
 	// Return cache if it has already been built.
 	if (default_builtin_cache.size()) {
 		return default_builtin_cache;
@@ -792,7 +802,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	return default_builtin_cache;
 }
 
-const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_feature_overrides_applied() {
+const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins_with_feature_overrides_applied() const {
 	if (default_builtin_with_overrides_cache.size() > 0) {
 		return default_builtin_with_overrides_cache;
 	}

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -32,7 +32,6 @@
 #define INPUT_MAP_H
 
 #include "core/input/input_event.h"
-#include "core/object/class_db.h"
 #include "core/object/object.h"
 #include "core/templates/hash_map.h"
 
@@ -60,8 +59,8 @@ private:
 	static InputMap *singleton;
 
 	mutable HashMap<StringName, Action> input_map;
-	HashMap<String, List<Ref<InputEvent>>> default_builtin_cache;
-	HashMap<String, List<Ref<InputEvent>>> default_builtin_with_overrides_cache;
+	mutable HashMap<String, List<Ref<InputEvent>>> default_builtin_cache;
+	mutable HashMap<String, List<Ref<InputEvent>>> default_builtin_with_overrides_cache;
 
 	List<Ref<InputEvent>>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool p_exact_match = false, bool *r_pressed = nullptr, float *r_strength = nullptr, float *r_raw_strength = nullptr, int *r_event_index = nullptr) const;
 
@@ -106,10 +105,12 @@ public:
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 #endif
 
+	bool is_builtin_action(const StringName &p_action) const;
+
 	String get_builtin_display_name(const String &p_name) const;
 	// Use an Ordered Map so insertion order is preserved. We want the elements to be 'grouped' somewhat.
-	const HashMap<String, List<Ref<InputEvent>>> &get_builtins();
-	const HashMap<String, List<Ref<InputEvent>>> &get_builtins_with_feature_overrides_applied();
+	const HashMap<String, List<Ref<InputEvent>>> &get_builtins() const;
+	const HashMap<String, List<Ref<InputEvent>>> &get_builtins_with_feature_overrides_applied() const;
 
 	InputMap();
 	~InputMap();

--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -78,6 +78,7 @@
 			<param index="0" name="action" type="StringName" />
 			<description>
 				Removes an action from the [InputMap].
+				[b]Warning:[/b] Removing built-in actions can lead to many [Control] nodes not working properly. See also [method is_builtin_action].
 			</description>
 		</method>
 		<method name="event_is_action" qualifiers="const">
@@ -101,6 +102,13 @@
 			<param index="0" name="action" type="StringName" />
 			<description>
 				Returns [code]true[/code] if the [InputMap] has a registered action with the given name.
+			</description>
+		</method>
+		<method name="is_builtin_action" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="action" type="StringName" />
+			<description>
+				Returns [code]true[/code] if [param action] is the name of a built-in action.
 			</description>
 		</method>
 		<method name="load_from_project_settings">

--- a/tests/core/input/test_input_event.h
+++ b/tests/core/input/test_input_event.h
@@ -96,6 +96,12 @@ TEST_CASE("[InputEvent][SceneTree] Test methods that interact with the InputMap"
 	CHECK(iejm->is_action_pressed(mock_action));
 
 	InputMap::get_singleton()->erase_action(mock_action);
+
+	CHECK_EQ(InputMap::get_singleton()->is_builtin_action("ui_accept"), true);
+	CHECK_EQ(InputMap::get_singleton()->is_builtin_action("ui_text_submit"), true);
+	CHECK_EQ(InputMap::get_singleton()->is_builtin_action("ui_this_is_not_builtin"), false);
+	CHECK_EQ(InputMap::get_singleton()->is_builtin_action("move_forward"), false);
+	CHECK_EQ(InputMap::get_singleton()->is_builtin_action(""), false);
 }
 
 TEST_CASE("[InputEvent] Test xformed_by") {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11016

This PR:

- Adds `is_builtin_action()` to check if a name is the name of a built-in action.
- Makes `erase_action()` warn about removing a built-in action.
- Makes `default_builtin_cache` and `default_builtin_with_overrides_cache` mutable since caches are expected to be modified in const methods.
- Removes a redundant header include.