### PR TITLE
`DirAccessPack`: Fix `file_exists` and `dir_exists` in exported projects

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -544,8 +544,6 @@ String DirAccessPack::get_current_dir(bool p_include_drive) const {
 }
 
 bool DirAccessPack::file_exists(String p_file) {
-	p_file = fix_path(p_file);
-
 	PackedData::PackedDir *pd = _find_dir(p_file.get_base_dir());
 	if (!pd) {
 		return false;
@@ -554,8 +552,6 @@ bool DirAccessPack::file_exists(String p_file) {
 }
 
 bool DirAccessPack::dir_exists(String p_dir) {
-	p_dir = fix_path(p_dir);
-
 	return _find_dir(p_dir) != nullptr;
 }
 


### PR DESCRIPTION
Fixes #87552

The `fix_path()` calls were added in #31440 as a hotfix for a similar problem.

At that time, `dir_exists()` simply checks if the given path is a key of the `subdirs` map of the current directory. That's why `dir_exists()` did not work for absolute paths and using `fix_path()` to strip `res://` prefix solved the problem.

In 4.0, #40748 improved the `DirAccessPack` API with a better way to find subdirectories: `_find_dir()`. This method supports both relative and absolute paths. But since `fix_path()` is still called for the incoming parameters, absolute paths always become relative paths, so it might be checking the wrong directory depending on the current directory of `DirAccess`.