### PR TITLE
Remove Godot's boot splash on android

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3428,7 +3428,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 void Main::setup_boot_logo() {
 	MAIN_PRINT("Main: Load Boot Image");
 
-#if !defined(TOOLS_ENABLED) && defined(WEB_ENABLED)
+#if !defined(TOOLS_ENABLED) && (defined(WEB_ENABLED) || defined(ANDROID_ENABLED))
 	bool show_logo = false;
 #else
 	bool show_logo = true;

--- a/platform/android/java/app/src/com/godot/game/GodotApp.java
+++ b/platform/android/java/app/src/com/godot/game/GodotApp.java
@@ -58,7 +58,8 @@ public class GodotApp extends GodotActivity {
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
-		SplashScreen.installSplashScreen(this);
+		SplashScreen splashScreen = SplashScreen.installSplashScreen(this);
 		super.onCreate(savedInstanceState);
+		splashScreen.setKeepOnScreenCondition(() -> !getGodot().isGodotAppReady());
 	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -102,6 +102,7 @@ class Godot(private val context: Context) {
 		fun isEditorBuild() = BuildConfig.FLAVOR == EDITOR_FLAVOR
 	}
 
+	var isGodotAppReady: Boolean = false
 	private val mSensorManager: SensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
 	private val mClipboard: ClipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 	private val vibratorService: Vibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
@@ -740,6 +741,7 @@ class Godot(private val context: Context) {
 			plugin.onGodotMainLoopStarted()
 		}
 		primaryHost?.onGodotMainLoopStarted()
+		isGodotAppReady = true
 	}
 
 	/**


### PR DESCRIPTION
After the update to the SplashScreen logic in this PR https://github.com/godotengine/godot/pull/92965, we now have two splash screens on Android. This dual splash screen setup does not provide a polished user experience.

This PR solves that problem by removing the second splash screen that is previously rendered by the engine. Now, only the Android system splash screen will be used, ensuring a consistent and streamlined startup.

<details><summary>Demo Video</summary>
<p>

https://github.com/user-attachments/assets/7121fd9f-d151-4d3e-b14b-fc87411fa77f


</p>
</details> 
