### PR TITLE
Fix `Camera3D::project_position()` when `depth == zfar`

### DIFF
--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -528,9 +528,12 @@ Vector3 Camera3D::project_position(const Point2 &p_point, real_t p_z_depth) cons
 	}
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
-	Projection cm = _get_camera_projection(p_z_depth);
+	Projection cm = _get_camera_projection(_near);
 
-	Vector2 vp_he = cm.get_viewport_half_extents();
+	Plane z_slice(Vector3(0, 0, 1), -p_z_depth);
+	Vector3 res;
+	z_slice.intersect_3(cm.get_projection_plane(Projection::Planes::PLANE_RIGHT), cm.get_projection_plane(Projection::Planes::PLANE_TOP), &res);
+	Vector2 vp_he(res.x, res.y);
 
 	Vector2 point;
 	point.x = (p_point.x / viewport_size.x) * 2.0 - 1.0;

--- a/tests/scene/test_camera_3d.h
+++ b/tests/scene/test_camera_3d.h
@@ -231,10 +231,13 @@ TEST_CASE("[SceneTree][Camera3D] Project/Unproject position") {
 			test_camera->set_orthogonal(5.0f, 0.5f, 1000.0f);
 			// Center.
 			CHECK(test_camera->project_position(Vector2(200, 100), 0.5f).is_equal_approx(Vector3(0, 0, -0.5f)));
+			CHECK(test_camera->project_position(Vector2(200, 100), test_camera->get_far()).is_equal_approx(Vector3(0, 0, -test_camera->get_far())));
 			// Top left.
 			CHECK(test_camera->project_position(Vector2(0, 0), 1.5f).is_equal_approx(Vector3(-5.0f, 2.5f, -1.5f)));
+			CHECK(test_camera->project_position(Vector2(0, 0), test_camera->get_near()).is_equal_approx(Vector3(-5.0f, 2.5f, -test_camera->get_near())));
 			// Bottom right.
 			CHECK(test_camera->project_position(Vector2(400, 200), 5.0f).is_equal_approx(Vector3(5.0f, -2.5f, -5.0f)));
+			CHECK(test_camera->project_position(Vector2(400, 200), test_camera->get_far()).is_equal_approx(Vector3(5.0f, -2.5f, -test_camera->get_far())));
 		}
 
 		SUBCASE("Perspective projection") {
@@ -242,12 +245,15 @@ TEST_CASE("[SceneTree][Camera3D] Project/Unproject position") {
 			// Center.
 			CHECK(test_camera->project_position(Vector2(200, 100), 0.5f).is_equal_approx(Vector3(0, 0, -0.5f)));
 			CHECK(test_camera->project_position(Vector2(200, 100), 100.0f).is_equal_approx(Vector3(0, 0, -100.0f)));
+			CHECK(test_camera->project_position(Vector2(200, 100), test_camera->get_far()).is_equal_approx(Vector3(0, 0, -1.0f) * test_camera->get_far()));
 			// 3/4th way to Top left.
 			CHECK(test_camera->project_position(Vector2(100, 50), 0.5f).is_equal_approx(Vector3(-SQRT3 * 0.5f, SQRT3 * 0.25f, -0.5f)));
 			CHECK(test_camera->project_position(Vector2(100, 50), 1.0f).is_equal_approx(Vector3(-SQRT3, SQRT3 * 0.5f, -1.0f)));
+			CHECK(test_camera->project_position(Vector2(100, 50), test_camera->get_near()).is_equal_approx(Vector3(-SQRT3, SQRT3 * 0.5f, -1.0f) * test_camera->get_near()));
 			// 3/4th way to Bottom right.
 			CHECK(test_camera->project_position(Vector2(300, 150), 0.5f).is_equal_approx(Vector3(SQRT3 * 0.5f, -SQRT3 * 0.25f, -0.5f)));
 			CHECK(test_camera->project_position(Vector2(300, 150), 1.0f).is_equal_approx(Vector3(SQRT3, -SQRT3 * 0.5f, -1.0f)));
+			CHECK(test_camera->project_position(Vector2(300, 150), test_camera->get_far()).is_equal_approx(Vector3(SQRT3, -SQRT3 * 0.5f, -1.0f) * test_camera->get_far()));
 		}
 	}
 


### PR DESCRIPTION
Fixes #95786.
Edit : Fixes #46010

This PR computes the viewport half-extents directly by finding the intersection of the camera top and right planes with a camera-facing plane positioned at the user provided depth.

Without this PR, a second projection matrix was built from the camera projection by overriding its near distance with the user provided depth (`Projection cm = _get_camera_projection(p_z_depth);`).
When `p_z_depth` equals the camera far distance, the near and far distances become equal and :
- if the camera is in `PROJECTION_PERSPECTIVE` mode, a subsequent call to `Projection::set_perspective()` [returns an identity projection](https://github.com/godotengine/godot/blob/ff9fb0abea2027c35f0a024297c780648cc806bc/core/math/projection.cpp#L263C1-L265C3). This leads to an incorrect projection of the user provided position to the view space. This is the case that is reported in #95786
- if the camera is in `PROJECTION_FRUSTUM` mode, a subsequent call to `Projection::set_frustum()` [raises an exception](https://github.com/godotengine/godot/blob/ff9fb0abea2027c35f0a024297c780648cc806bc/core/math/projection.cpp#L367)
- if the camera is in `PROJECTION_ORTHOGONAL` mode, a subsequent call to `Projection::set_orthogonal()` generates a [division by zero](https://github.com/godotengine/godot/blob/ff9fb0abea2027c35f0a024297c780648cc806bc/core/math/projection.cpp#L351C2-L352C61).

This PR also updates unit tests of class `Camera3D` to add the case where the provided depth = zfar.

**Note :**

After this PR, `Camera3D::_get_camera_projection(real_t p_near)` is now exclusively called with its own camera's near value across the code (this PR removes the one and only case it was called with an user provided `p_near`).

It could be worth considering removing this function's parameter for the sake of code simplicity.
Note that it's a `protected` function member which means that it could be theoritically used in user modules by classes inheriting `Camera3D`.
I can definitely make this change in this PR or in another one if there is a consensus on making this small breaking change.