### PR TITLE
Improve `make_canvas_position_local()` description

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -533,9 +533,13 @@
 		</method>
 		<method name="make_canvas_position_local" qualifiers="const">
 			<return type="Vector2" />
-			<param index="0" name="screen_point" type="Vector2" />
+			<param index="0" name="viewport_point" type="Vector2" />
 			<description>
-				Assigns [param screen_point] as this node's new local transform.
+				Transforms [param viewport_point] from the viewport's coordinates to this node's local coordinates.
+				For the opposite operation, use [method get_global_transform_with_canvas].
+				[codeblock]
+				var viewport_point = get_global_transform_with_canvas() * local_point
+				[/codeblock]
 			</description>
 		</method>
 		<method name="make_input_local" qualifiers="const">

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1253,7 +1253,7 @@ void CanvasItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("force_update_transform"), &CanvasItem::force_update_transform);
 
-	ClassDB::bind_method(D_METHOD("make_canvas_position_local", "screen_point"), &CanvasItem::make_canvas_position_local);
+	ClassDB::bind_method(D_METHOD("make_canvas_position_local", "viewport_point"), &CanvasItem::make_canvas_position_local);
 	ClassDB::bind_method(D_METHOD("make_input_local", "event"), &CanvasItem::make_input_local);
 
 	ClassDB::bind_method(D_METHOD("set_visibility_layer", "layer"), &CanvasItem::set_visibility_layer);


### PR DESCRIPTION
- Made the description more clear
- Renamed argument to `canvas_point`, which is more accurate