### PR TITLE
Add additional parameter to dap to select a custom scene to run

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -92,6 +92,10 @@ Dictionary DebugAdapterParser::prepare_error_response(const Dictionary &p_params
 			error = "wrong_path";
 			error_desc = "The editor and client are working on different paths; the client is on \"{clientPath}\", but the editor is on \"{editorPath}\"";
 			break;
+		case DAP::ErrorType::WRONG_SCENE:
+			error = "wrong_scene";
+			error_desc = "Could not find \"{scenePath}\"";
+			break;
 		case DAP::ErrorType::NOT_RUNNING:
 			error = "not_running";
 			error_desc = "Can't attach to a running session since there isn't one.";
@@ -195,7 +199,17 @@ Dictionary DebugAdapterParser::_launch_process(const Dictionary &p_params) const
 
 	String platform_string = args.get("platform", "host");
 	if (platform_string == "host") {
-		EditorRunBar::get_singleton()->play_main_scene();
+		if (args.has("scene")) {
+			String scene = args["scene"];
+			if (!is_valid_path(scene)) {
+				Dictionary variables;
+				variables["scenePath"] = scene;
+				return prepare_error_response(p_params, DAP::ErrorType::WRONG_SCENE, variables);
+			}
+			EditorRunBar::get_singleton()->play_custom_scene(scene);
+		} else {
+			EditorRunBar::get_singleton()->play_main_scene();
+		}
 	} else {
 		int device = args.get("device", -1);
 		int idx = -1;

--- a/editor/debugger/debug_adapter/debug_adapter_types.h
+++ b/editor/debugger/debug_adapter/debug_adapter_types.h
@@ -39,6 +39,7 @@ namespace DAP {
 enum ErrorType {
 	UNKNOWN,
 	WRONG_PATH,
+	WRONG_SCENE,
 	NOT_RUNNING,
 	TIMEOUT,
 	UNKNOWN_PLATFORM,


### PR DESCRIPTION
A small addition to the DAP interface to allow a client to pass a `scene` parameter that points to a local `tscn` file.

Example config for nvim with a simple picker to select the custom scene to run.
```lua
local dap = require('dap')
dap.configurations.gdscript = {
  {
    type = "godot",
    request = "launch",
    name = "Launch scene",
    scene = function()
      local path = vim.fn.input({
        prompt = 'Path to scene: ',
        default = vim.fn.getcwd() .. '/',
        completion = 'file'
      })
      return (path and path ~= "") and path or dap.ABORT
    end
  }
}
```
