### PR TITLE
Docs: Add notes about C# differences in Variant constructors

### DIFF
--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -25,6 +25,7 @@
 			<return type="Basis" />
 			<description>
 				Constructs a [Basis] identical to the [constant IDENTITY].
+				[b]Note:[/b] In C#, this constructs a [Basis] with all of its components set to [constant Vector3.ZERO].
 			</description>
 		</constructor>
 		<constructor name="Basis">

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -19,7 +19,7 @@
 			<return type="Color" />
 			<description>
 				Constructs a default [Color] from opaque black. This is the same as [constant BLACK].
-				[b]Note:[/b] in C#, constructs an empty color with all of its components set to [code]0.0[/code] (transparent black).
+				[b]Note:[/b] In C#, this constructs a [Color] with all of its components set to [code]0.0[/code] (transparent black).
 			</description>
 		</constructor>
 		<constructor name="Color">

--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -14,7 +14,8 @@
 		<constructor name="Projection">
 			<return type="Projection" />
 			<description>
-				Constructs a default-initialized [Projection] set to [constant IDENTITY].
+				Constructs a default-initialized [Projection] identical to [constant IDENTITY].
+				[b]Note:[/b] In C#, this constructs a [Projection] identical to [constant ZERO].
 			</description>
 		</constructor>
 		<constructor name="Projection">

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -22,6 +22,7 @@
 			<return type="Quaternion" />
 			<description>
 				Constructs a [Quaternion] identical to the [constant IDENTITY].
+				[b]Note:[/b] In C#, this constructs a [Quaternion] with all of its components set to [code]0.0[/code].
 			</description>
 		</constructor>
 		<constructor name="Quaternion">

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -20,6 +20,7 @@
 			<return type="Transform2D" />
 			<description>
 				Constructs a [Transform2D] identical to [constant IDENTITY].
+				[b]Note:[/b] In C#, this constructs a [Transform2D] with all of its components set to [constant Vector2.ZERO].
 			</description>
 		</constructor>
 		<constructor name="Transform2D">

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -21,6 +21,7 @@
 			<return type="Transform3D" />
 			<description>
 				Constructs a [Transform3D] identical to the [constant IDENTITY].
+				[b]Note:[/b] In C#, this constructs a [Transform3D] with its [member origin] and the components of its [member basis] set to [constant Vector3.ZERO].
 			</description>
 		</constructor>
 		<constructor name="Transform3D">


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/10138.

The difference between C# and GDScipt was already noted in the `Color` default constructor. This PR adds similar notes to the other variant types with different default constructor behavior: `Basis`, `Projection`, `Quaternion`, `Transform2D`, `Transform3D`.