### PR TITLE
Fix `InputEventKey` test failure under certain system languages

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -363,6 +363,9 @@ struct GodotTestCaseListener : public doctest::IReporter {
 #ifdef TOOLS_ENABLED
 		if (EditorSettings::get_singleton()) {
 			EditorSettings::destroy();
+
+			// Instantiating the EditorSettings singleton sets the locale to the editor's language.
+			TranslationServer::get_singleton()->set_locale("en");
 		}
 #endif // TOOLS_ENABLED
 


### PR DESCRIPTION
Closes #98572

`InputEventKey.as_text()` uses `RTR()` for its returned text so it is locale-dependent.

When some other test cases being run need `EditorSettings`, the application locale switches to match system locale and editor translations are loaded. So `as_text()` tests fail if the system language is not English.

<details><summary>Test case failure output for <code>zh_CN</code></summary>

```
===============================================================================
./tests/core/input/test_input_event_key.h:108:
TEST CASE:  [InputEventKey] Key correctly converts itself to text

./tests/core/input/test_input_event_key.h:119: ERROR: CHECK( none_key.as_text() == "(Unset)" ) is NOT correct!
  values: CHECK( (未设置) == (Unset) )

./tests/core/input/test_input_event_key.h:123: ERROR: CHECK( none_key.as_text() == "Ctrl+(Unset)" ) is NOT correct!
  values: CHECK( Ctrl+(未设置) == Ctrl+(Unset) )

./tests/core/input/test_input_event_key.h:127: ERROR: CHECK( none_key.as_text() == "Ctrl+Enter (Physical)" ) is NOT correct!
  values: CHECK( Ctrl+Enter (物理) == Ctrl+Enter (Physical) )

./tests/core/input/test_input_event_key.h:135: ERROR: CHECK( none_key2.as_text() == "Enter (Physical)" ) is NOT correct!
  values: CHECK( Enter (物理) == Enter (Physical) )

===============================================================================
./tests/core/input/test_input_event_key.h:154:
TEST CASE:  [InputEventKey] Key correctly converts its state to a string representation

./tests/core/input/test_input_event_key.h:157: ERROR: CHECK( none_key.to_string() == "InputEventKey: keycode=(Unset), mods=none, physical=false, location=unspecified, pressed=false, echo=false" ) is NOT correct!
  values: CHECK( InputEventKey: keycode=(未设置), mods=none, physical=false, location=unspecified, pressed=false, echo=false == InputEventKey: keycode=(Unset), mods=none, physical=false, location=unspecified, pressed=false, echo=false )

ERROR: Index p_gutter = 2 is out of bounds (text.size() = 1).
   at: remove_gutter (scene/gui/text_edit.cpp:452)
===============================================================================
[doctest] test cases:    1056 |    1054 passed | 2 failed | 1 skipped
[doctest] assertions: 2412041 | 2412036 passed | 5 failed |
[doctest] Status: FAILURE!
```
</details>

It works fine if `InputEventKey` test cases are run separately via CLI filters like `-tc='[InputEventKey]*'` because `EditorSettings` won't be instantiated.

This PR sets application locale back to `en` when such test cases end (i.e., when destroying the `EditorSettings` singleton instantiated).