### PR TITLE
Fix crash when file logger is set to write to a relative location.

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -164,7 +164,7 @@ void RotatedFileLogger::rotate_file() {
 			clear_old_backups();
 		}
 	} else {
-		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_USERDATA);
+		Ref<DirAccess> da = DirAccess::create_for_path(base_path);
 		if (da.is_valid()) {
 			da->make_dir_recursive(base_path.get_base_dir());
 		}


### PR DESCRIPTION
Logger crashes when the destination path folder does not exist, and the path is a relative path, but not with the "user://" prefix.

With this PR, you'll be able to set paths relative to working directory or executable path (by not prefixing anything) or relative to the project at developer time (by prefixing with "res://")

Fixes https://github.com/godotengine/godot/issues/98522