### PR TITLE
Fix Linux builds with separate debug symbols file when there is a space in the path.

### DIFF
--- a/platform/linuxbsd/platform_linuxbsd_builders.py
+++ b/platform/linuxbsd/platform_linuxbsd_builders.py
@@ -5,6 +5,6 @@ import os
 
 def make_debug_linuxbsd(target, source, env):
     dst = str(target[0])
-    os.system("objcopy --only-keep-debug {0} {0}.debugsymbols".format(dst))
-    os.system("strip --strip-debug --strip-unneeded {0}".format(dst))
-    os.system("objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(dst))
+    os.system('objcopy --only-keep-debug "{0}" "{0}.debugsymbols"'.format(dst))
+    os.system('strip --strip-debug --strip-unneeded "{0}"'.format(dst))
+    os.system('objcopy --add-gnu-debuglink="{0}.debugsymbols" "{0}"'.format(dst))


### PR DESCRIPTION
Building the engine in linux with symbols fails if the repo is at a path with spaces in any of the parent folder names.

Black autoformatter breaks this string when applying the autoformat, that's why I add the lines that disable black from formatting those lines.