### PR TITLE
Skip Vulkan SDK installation in macOS if it is already installed.

### DIFF
--- a/misc/scripts/install_vulkan_sdk_macos.sh
+++ b/misc/scripts/install_vulkan_sdk_macos.sh
@@ -3,6 +3,11 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+if [ -d "$HOME/VulkanSDK" ]; then
+   echo "Vulkan SDK was already installed. Skipping installation."
+   exit 0
+fi
+
 # Download and install the Vulkan SDK.
 curl -L "https://sdk.lunarg.com/sdk/download/latest/mac/vulkan-sdk.zip" -o /tmp/vulkan-sdk.zip
 unzip /tmp/vulkan-sdk.zip -d /tmp


### PR DESCRIPTION
Skip installation of Vulkan SDK if it is already installed.
This is useful when setting up user-hosted workers that run under the same environment every time.