### PR TITLE
[3.x] Fix `Button` not listing `hover_pressed` stylebox

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -113,6 +113,9 @@
 		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is being hovered.
 		</theme_item>
+		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is being hovered and pressed.
+		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [Button].
 		</theme_item>

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -230,6 +230,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("normal", "Button", sb_button_normal);
 	theme->set_stylebox("pressed", "Button", sb_button_pressed);
 	theme->set_stylebox("hover", "Button", sb_button_hover);
+	theme->set_stylebox("hover_pressed", "Button", sb_button_hover);
 	theme->set_stylebox("disabled", "Button", sb_button_disabled);
 	theme->set_stylebox("focus", "Button", sb_button_focus);
 


### PR DESCRIPTION
Theme items in `3.x` are listed according to entries in the default theme.

The default theme did not add `hover_pressed` stylebox for `Button`, so the theme item is missing in the inspector & in the theme editor.

This creates a confusing situation that setting all styleboxes for `Button` still results in a broken toggle button appearance, even `CheckBox` and `CheckButton` are affected (as they have toggle mode on by default).

![Peek 2024-10-25 12-35](https://github.com/user-attachments/assets/bba3137d-01d2-464c-9989-98ece86d4947)
