### PR TITLE
Factorize bone attachment

### DIFF
--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -59,7 +59,7 @@
 		<member name="nodes/import_as_skeleton_bones" type="bool" setter="" getter="" default="false">
 			Treat all nodes in the imported scene as if they are bones within a single [Skeleton3D]. Can be used to guarantee that imported animations target skeleton bones rather than nodes. May also be used to assign the [code]"Root"[/code] bone in a [BoneMap]. See [url=$DOCS_URL/tutorials/assets_pipeline/retargeting_3d_skeletons.html]Retargeting 3D Skeletons[/url] for more information.
 		</member>
-		<member name="nodes/legacy_attachements_import" type="bool" setter="" getter="" default="false">
+		<member name="nodes/legacy_attachments_import" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], use the legacy import method creating a bone and a [BoneAttachment3D] for each mesh parented to a bone.
 		</member>
 		<member name="nodes/root_name" type="String" setter="" getter="" default="&quot;&quot;">

--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -59,6 +59,9 @@
 		<member name="nodes/import_as_skeleton_bones" type="bool" setter="" getter="" default="false">
 			Treat all nodes in the imported scene as if they are bones within a single [Skeleton3D]. Can be used to guarantee that imported animations target skeleton bones rather than nodes. May also be used to assign the [code]"Root"[/code] bone in a [BoneMap]. See [url=$DOCS_URL/tutorials/assets_pipeline/retargeting_3d_skeletons.html]Retargeting 3D Skeletons[/url] for more information.
 		</member>
+		<member name="nodes/legacy_attachements_import" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], use the legacy import method creating a bone and a [BoneAttachment3D] for each mesh parented to a bone.
+		</member>
 		<member name="nodes/root_name" type="String" setter="" getter="" default="&quot;&quot;">
 			Override for the root node name. If empty, the root node will use what the scene specifies, or the file name if the scene does not specify a root name.
 		</member>

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2381,6 +2381,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/apply_root_scale"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "nodes/root_scale", PROPERTY_HINT_RANGE, "0.001,1000,0.001"), 1.0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/import_as_skeleton_bones"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/legacy_attachements_import"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/use_node_type_suffixes"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/ensure_tangents"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/generate_lods"), true));

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2381,7 +2381,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/apply_root_scale"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "nodes/root_scale", PROPERTY_HINT_RANGE, "0.001,1000,0.001"), 1.0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/import_as_skeleton_bones"), false));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/legacy_attachements_import"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/legacy_attachments_import"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "nodes/use_node_type_suffixes"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/ensure_tangents"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/generate_lods"), true));

--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -101,7 +101,7 @@
 			The user-friendly name of the export image format. This is used when exporting the glTF file, including writing to a file and writing to a byte array.
 			By default, Godot allows the following options: "None", "PNG", "JPEG", "Lossless WebP", and "Lossy WebP". Support for more image formats can be added in [GLTFDocumentExtension] classes.
 		</member>
-		<member name="legacy_attachements_import" type="bool" setter="set_legacy_attachements_import" getter="get_legacy_attachements_import" default="false">
+		<member name="legacy_attachments_import" type="bool" setter="set_legacy_attachments_import" getter="get_legacy_attachments_import" default="true">
 			If [code]true[/code], use the legacy import method creating a bone and a [BoneAttachment3D] for each mesh parented to a bone.
 		</member>
 		<member name="lossy_quality" type="float" setter="set_lossy_quality" getter="get_lossy_quality" default="0.75">

--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -101,6 +101,9 @@
 			The user-friendly name of the export image format. This is used when exporting the glTF file, including writing to a file and writing to a byte array.
 			By default, Godot allows the following options: "None", "PNG", "JPEG", "Lossless WebP", and "Lossy WebP". Support for more image formats can be added in [GLTFDocumentExtension] classes.
 		</member>
+		<member name="legacy_attachements_import" type="bool" setter="set_legacy_attachements_import" getter="get_legacy_attachements_import" default="false">
+			If [code]true[/code], use the legacy import method creating a bone and a [BoneAttachment3D] for each mesh parented to a bone.
+		</member>
 		<member name="lossy_quality" type="float" setter="set_lossy_quality" getter="get_lossy_quality" default="0.75">
 			If [member image_format] is a lossy image format, this determines the lossy quality of the image. On a range of [code]0.0[/code] to [code]1.0[/code], where [code]0.0[/code] is the lowest quality and [code]1.0[/code] is the highest quality. A lossy quality of [code]1.0[/code] is not the same as lossless.
 		</member>

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -59,6 +59,11 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 		int32_t enum_option = p_options["gltf/embedded_image_handling"];
 		state->set_handle_binary_image(enum_option);
 	}
+	if (p_options.has("nodes/legacy_attachements_import")) {
+		gltf->set_legacy_attachements_import((bool)p_options["nodes/legacy_attachements_import"]);
+	} else {
+		gltf->set_legacy_attachements_import(true);
+	}
 	if (p_options.has(SNAME("nodes/import_as_skeleton_bones")) ? (bool)p_options[SNAME("nodes/import_as_skeleton_bones")] : false) {
 		state->set_import_as_skeleton_bones(true);
 	}

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -59,11 +59,6 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 		int32_t enum_option = p_options["gltf/embedded_image_handling"];
 		state->set_handle_binary_image(enum_option);
 	}
-	if (p_options.has("nodes/legacy_attachements_import")) {
-		gltf->set_legacy_attachements_import((bool)p_options["nodes/legacy_attachements_import"]);
-	} else {
-		gltf->set_legacy_attachements_import(true);
-	}
 	if (p_options.has(SNAME("nodes/import_as_skeleton_bones")) ? (bool)p_options[SNAME("nodes/import_as_skeleton_bones")] : false) {
 		state->set_import_as_skeleton_bones(true);
 	}

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3328,12 +3328,12 @@ int GLTFDocument::get_naming_version() const {
 	return _naming_version;
 }
 
-void GLTFDocument::set_legacy_attachements_import(bool p_legacy_attachements_import) {
-	_legacy_attachements_import = p_legacy_attachements_import;
+void GLTFDocument::set_legacy_attachments_import(bool p_legacy_attachments_import) {
+	_legacy_attachments_import = p_legacy_attachments_import;
 }
 
-bool GLTFDocument::get_legacy_attachements_import() const {
-	return _legacy_attachements_import;
+bool GLTFDocument::get_legacy_attachments_import() const {
+	return _legacy_attachments_import;
 }
 
 void GLTFDocument::set_image_format(const String &p_image_format) {
@@ -5132,7 +5132,7 @@ BoneAttachment3D *GLTFDocument::_generate_bone_attachment(Ref<GLTFState> p_state
 	Ref<GLTFNode> gltf_node = p_state->nodes[p_node_index];
 	Ref<GLTFNode> bone_node = p_state->nodes[p_bone_index];
 	BoneAttachment3D *bone_attachment = memnew(BoneAttachment3D);
-	print_verbose("glTF: Creating bone attachment for: " + _legacy_attachements_import ? gltf_node->get_name() : bone_node->get_name());
+	print_verbose("glTF: Creating bone attachment for: " + gltf_node->get_name());
 
 	ERR_FAIL_COND_V(!bone_node->joint, nullptr);
 
@@ -5614,7 +5614,7 @@ void GLTFDocument::_convert_mesh_instance_to_gltf(MeshInstance3D *p_scene_parent
 void GLTFDocument::_generate_scene_node(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index, Node *p_scene_parent, Node *p_scene_root) {
 	Ref<GLTFNode> gltf_node = p_state->nodes[p_node_index];
 
-	if (gltf_node->skeleton >= 0 && (gltf_node->mesh < 0 || _legacy_attachements_import)) {
+	if (gltf_node->skeleton >= 0 && (gltf_node->mesh < 0 || _legacy_attachments_import)) {
 		_generate_skeleton_bone_node(p_state, p_node_index, p_scene_parent, p_scene_root);
 		return;
 	}
@@ -5630,7 +5630,7 @@ void GLTFDocument::_generate_scene_node(Ref<GLTFState> p_state, const GLTFNodeIn
 	if (non_bone_parented_to_skeleton && gltf_node->skin < 0) {
 		// Bone Attachment - Parent Case
 		Ref<GLTFNode> bone_node = p_state->nodes[gltf_node->parent];
-		BoneAttachment3D *bone_attachment = (_legacy_attachements_import) ? nullptr : Object::cast_to<BoneAttachment3D>(p_scene_parent->find_child(bone_node->get_name().validate_node_name(), true));
+		BoneAttachment3D *bone_attachment = (_legacy_attachments_import) ? nullptr : Object::cast_to<BoneAttachment3D>(p_scene_parent->find_child(bone_node->get_name().validate_node_name(), true));
 		if (bone_attachment == nullptr) {
 			bone_attachment = _generate_bone_attachment(p_state, active_skeleton, p_node_index, gltf_node->parent);
 
@@ -5642,7 +5642,7 @@ void GLTFDocument::_generate_scene_node(Ref<GLTFState> p_state, const GLTFNodeIn
 			bone_attachment->set_owner(p_scene_root);
 
 			// There is no gltf_node that represent this, so just directly create a unique name
-			bone_attachment->set_name((_legacy_attachements_import) ? gltf_node->get_name() : bone_node->get_name());
+			bone_attachment->set_name((_legacy_attachments_import) ? gltf_node->get_name() : bone_node->get_name());
 		}
 		// We change the scene_parent to our bone attachment now. We do not set current_node because we want to make the node
 		// and attach it to the bone_attachment

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -78,7 +78,7 @@ private:
 	int _naming_version = 1;
 	String _image_format = "PNG";
 	float _lossy_quality = 0.75f;
-	bool _legacy_attachements_import = false;
+	bool _legacy_attachments_import = false;
 	Ref<GLTFDocumentExtension> _image_save_extension;
 	RootNodeMode _root_node_mode = RootNodeMode::ROOT_NODE_MODE_SINGLE_ROOT;
 
@@ -98,8 +98,8 @@ public:
 
 	void set_naming_version(int p_version);
 	int get_naming_version() const;
-	void set_legacy_attachements_import(bool p_legacy_attachements_import);
-	bool get_legacy_attachements_import() const;
+	void set_legacy_attachments_import(bool p_legacy_attachments_import);
+	bool get_legacy_attachments_import() const;
 	void set_image_format(const String &p_image_format);
 	String get_image_format() const;
 	void set_lossy_quality(float p_lossy_quality);

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -78,6 +78,7 @@ private:
 	int _naming_version = 1;
 	String _image_format = "PNG";
 	float _lossy_quality = 0.75f;
+	bool _legacy_attachements_import = false;
 	Ref<GLTFDocumentExtension> _image_save_extension;
 	RootNodeMode _root_node_mode = RootNodeMode::ROOT_NODE_MODE_SINGLE_ROOT;
 
@@ -97,6 +98,8 @@ public:
 
 	void set_naming_version(int p_version);
 	int get_naming_version() const;
+	void set_legacy_attachements_import(bool p_legacy_attachements_import);
+	bool get_legacy_attachements_import() const;
 	void set_image_format(const String &p_image_format);
 	String get_image_format() const;
 	void set_lossy_quality(float p_lossy_quality);

--- a/modules/gltf/skin_tool.cpp
+++ b/modules/gltf/skin_tool.cpp
@@ -575,7 +575,7 @@ Error SkinTool::_create_skeletons(
 				Vector<SkinNodeIndex> child_nodes;
 				for (int i = 0; i < node->children.size(); ++i) {
 					const SkinNodeIndex child_i = node->children[i];
-					if (nodes[child_i]->skeleton == skel_i) {
+					if (nodes[child_i]->skeleton == skel_i && nodes[child_i]->mesh < 0) {
 						child_nodes.push_back(child_i);
 					}
 				}


### PR DESCRIPTION
Aiming to solve #75917
Just set things in order to avoid creating bones for nodes that are meshes, this also implied to rework `BoneAttachement3D` creation.
I factorized everything so meshes attached to the same bone are now sharing the same `BoneAttachement3D`.

Tested using a blender model, not sure if this will fit GLTF file coming from other modelization tool.
![model](https://github.com/user-attachments/assets/923a36f0-7dd8-45fb-9cf0-80758f69016e)

|  BEFORE  |  AFTER  |
| -----------------------  |  ---------------------   |
|  ![before](https://github.com/user-attachments/assets/58435e68-ad0f-49f6-80ff-662c4425108b)  |  ![after](https://github.com/user-attachments/assets/f204eb10-1bd9-4845-9ddd-902db215870a)


