### PR TITLE
Lookup scripts from all assemblies. Lookup scripts after loaded assembly

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotPluginsInitializerGenerator.cs
@@ -43,6 +43,7 @@ namespace GodotPlugins.Game
                 ManagedCallbacks.Create(outManagedCallbacks);
 
                 ScriptManagerBridge.LookupScriptsInAssembly(typeof(global::GodotPlugins.Game.Main).Assembly);
+                AppDomain.CurrentDomain.AssemblyLoad += OnAssemblyLoad;
 
                 return godot_bool.True;
             }
@@ -51,6 +52,11 @@ namespace GodotPlugins.Game
                 global::System.Console.Error.WriteLine(e);
                 return false.ToGodotBool();
             }
+        }
+
+        private static void OnAssemblyLoad(object obj, AssemblyLoadEventArgs args)
+        {
+            ScriptManagerBridge.LookupScriptsInAssembly(args.LoadedAssembly);
         }
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where Godot would not find scripts from other compiled DLLs in the solution. I haven't tested this #75352 issue, but godot can find scripts located outside the main DLL.

The code is taken from #90338, but it didn't work because there was a typo:
```csharp
foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
{
    ScriptManagerBridge.LookupScriptsInAssembly(projectAssembly);
}
```
Changed to:
```csharp
foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
{
    ScriptManagerBridge.LookupScriptsInAssembly(assembly);
}
```

As written in #90338, all .csproj files must be in the folder with the .sln file.

An example godot project that works with a solution that uses a separate folder to compile to a separate DLL:
[test-project.zip](https://github.com/user-attachments/files/17522016/test-project.zip)