### PR TITLE
Separate Godot Physics (advanced) project settings from generic physics project settings

### DIFF
--- a/doc/classes/Joint2D.xml
+++ b/doc/classes/Joint2D.xml
@@ -19,7 +19,8 @@
 	<members>
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="0.0">
 			When [member node_a] and [member node_b] move in different directions the [member bias] controls how fast the joint pulls them back to their original position. The lower the [member bias] the more the two bodies can pull on the joint.
-			When set to [code]0[/code], the default value from [member ProjectSettings.physics/2d/solver/default_constraint_bias] is used.
+			When set to [code]0[/code], the default value defined by the [PhysicsServer2D] is used instead.
+			In GodotPhysics2D that default value is [member ProjectSettings.physics/godot_physics_2d/solver/default_constraint_bias].
 		</member>
 		<member name="disable_collision" type="bool" setter="set_exclude_nodes_from_collision" getter="get_exclude_nodes_from_collision" default="true">
 			If [code]true[/code], the two bodies bound together do not collide with each other.

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -998,31 +998,40 @@
 	</methods>
 	<constants>
 		<constant name="SPACE_PARAM_CONTACT_RECYCLE_RADIUS" value="0" enum="SpaceParameter">
-			Constant to set/get the maximum distance a pair of bodies has to move before their collision status has to be recalculated. The default value of this parameter is [member ProjectSettings.physics/2d/solver/contact_recycle_radius].
+			Constant to set/get the maximum distance a pair of bodies has to move before their collision status has to be recalculated.
+			In GodotPhysics2D the default value of this parameter is [member ProjectSettings.physics/godot_physics_2d/solver/contact_recycle_radius].
 		</constant>
 		<constant name="SPACE_PARAM_CONTACT_MAX_SEPARATION" value="1" enum="SpaceParameter">
-			Constant to set/get the maximum distance a shape can be from another before they are considered separated and the contact is discarded. The default value of this parameter is [member ProjectSettings.physics/2d/solver/contact_max_separation].
+			Constant to set/get the maximum distance a shape can be from another before they are considered separated and the contact is discarded.
+			In GodotPhysics2D the default value of this parameter is [member ProjectSettings.physics/godot_physics_2d/solver/contact_max_separation].
 		</constant>
 		<constant name="SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION" value="2" enum="SpaceParameter">
-			Constant to set/get the maximum distance a shape can penetrate another shape before it is considered a collision. The default value of this parameter is [member ProjectSettings.physics/2d/solver/contact_max_allowed_penetration].
+			Constant to set/get the maximum distance a shape can penetrate another shape before it is considered a collision.
+			In GodotPhysics2D the default value of this parameter is [member ProjectSettings.physics/godot_physics_2d/solver/contact_max_allowed_penetration].
 		</constant>
 		<constant name="SPACE_PARAM_CONTACT_DEFAULT_BIAS" value="3" enum="SpaceParameter">
-			Constant to set/get the default solver bias for all physics contacts. A solver bias is a factor controlling how much two objects "rebound", after overlapping, to avoid leaving them in that state because of numerical imprecision. The default value of this parameter is [member ProjectSettings.physics/2d/solver/default_contact_bias].
+			Constant to set/get the default solver bias for all physics contacts. A solver bias is a factor controlling how much two objects "rebound", after overlapping, to avoid leaving them in that state because of numerical imprecision.
+			In GodotPhysics2D the default value of this parameter is [member ProjectSettings.physics/godot_physics_2d/solver/default_contact_bias].
 		</constant>
 		<constant name="SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD" value="4" enum="SpaceParameter">
-			Constant to set/get the threshold linear velocity of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after the time given. The default value of this parameter is [member ProjectSettings.physics/2d/sleep_threshold_linear].
+			Constant to set/get the threshold linear velocity of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after the time given.
+			In GodotPhysics2D the default value of this parameter is [member ProjectSettings.physics/godot_physics_2d/sleep_threshold_linear].
 		</constant>
 		<constant name="SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD" value="5" enum="SpaceParameter">
-			Constant to set/get the threshold angular velocity of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after the time given. The default value of this parameter is [member ProjectSettings.physics/2d/sleep_threshold_angular].
+			Constant to set/get the threshold angular velocity of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after the time given.
+			In GodotPhysics2D the default value of this parameter is [member ProjectSettings.physics/godot_physics_2d/sleep_threshold_angular].
 		</constant>
 		<constant name="SPACE_PARAM_BODY_TIME_TO_SLEEP" value="6" enum="SpaceParameter">
-			Constant to set/get the maximum time of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after this time. The default value of this parameter is [member ProjectSettings.physics/2d/time_before_sleep].
+			Constant to set/get the maximum time of activity. A body marked as potentially inactive for both linear and angular velocity will be put to sleep after this time.
+			In GodotPhysics2D the default value of this parameter is [member ProjectSettings.physics/godot_physics_2d/time_before_sleep].
 		</constant>
 		<constant name="SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS" value="7" enum="SpaceParameter">
-			Constant to set/get the default solver bias for all physics constraints. A solver bias is a factor controlling how much two objects "rebound", after violating a constraint, to avoid leaving them in that state because of numerical imprecision. The default value of this parameter is [member ProjectSettings.physics/2d/solver/default_constraint_bias].
+			Constant to set/get the default solver bias for all physics constraints. A solver bias is a factor controlling how much two objects "rebound", after violating a constraint, to avoid leaving them in that state because of numerical imprecision.
+			In GodotPhysics2D the default value of this parameter is [member ProjectSettings.physics/godot_physics_2d/solver/default_constraint_bias].
 		</constant>
 		<constant name="SPACE_PARAM_SOLVER_ITERATIONS" value="8" enum="SpaceParameter">
-			Constant to set/get the number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance. The default value of this parameter is [member ProjectSettings.physics/2d/solver/solver_iterations].
+			Constant to set/get the number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance.
+			In GodotPhysics2D the default value of this parameter is [member ProjectSettings.physics/godot_physics_2d/solver/solver_iterations].
 		</constant>
 		<constant name="SHAPE_WORLD_BOUNDARY" value="0" enum="ShapeType">
 			This is the constant for creating world boundary shapes. A world boundary shape is an [i]infinite[/i] line with an origin point, and a normal. Thus, it can be used for front/behind checks.
@@ -1179,15 +1188,15 @@
 		</constant>
 		<constant name="JOINT_PARAM_BIAS" value="0" enum="JointParam">
 			Constant to set/get how fast the joint pulls the bodies back to satisfy the joint constraint. The lower the value, the more the two bodies can pull on the joint. The default value of this parameter is [code]0.0[/code].
-			[b]Note:[/b] In Godot Physics, this parameter is only used for pin joints and groove joints.
+			[b]Note:[/b] In GodotPhysics2D this parameter is only used for pin joints and groove joints.
 		</constant>
 		<constant name="JOINT_PARAM_MAX_BIAS" value="1" enum="JointParam">
 			Constant to set/get the maximum speed with which the joint can apply corrections. The default value of this parameter is [code]3.40282e+38[/code].
-			[b]Note:[/b] In Godot Physics, this parameter is only used for groove joints.
+			[b]Note:[/b] In GodotPhysics2D this parameter is only used for groove joints.
 		</constant>
 		<constant name="JOINT_PARAM_MAX_FORCE" value="2" enum="JointParam">
 			Constant to set/get the maximum force that the joint can use to act on the two bodies. The default value of this parameter is [code]3.40282e+38[/code].
-			[b]Note:[/b] In Godot Physics, this parameter is only used for groove joints.
+			[b]Note:[/b] In GodotPhysics2D this parameter is only used for groove joints.
 		</constant>
 		<constant name="PIN_JOINT_SOFTNESS" value="0" enum="PinJointParam">
 			Constant to set/get a how much the bond of the pin joint can flex. The default value of this parameter is [code]0.0[/code].

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1006,7 +1006,7 @@
 			<param index="0" name="shape" type="RID" />
 			<description>
 				Returns the collision margin for the shape.
-				[b]Note:[/b] This is not used in Godot Physics, so will always return [code]0[/code].
+				[b]Note:[/b] This is not used in GodotPhysics3D, so will always return [code]0[/code].
 			</description>
 		</method>
 		<method name="shape_get_type" qualifiers="const">
@@ -1030,7 +1030,7 @@
 			<param index="1" name="margin" type="float" />
 			<description>
 				Sets the collision margin for the shape.
-				[b]Note:[/b] This is not used in Godot Physics.
+				[b]Note:[/b] This is not used in GodotPhysics3D.
 			</description>
 		</method>
 		<method name="slider_joint_get_param" qualifiers="const">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2267,35 +2267,6 @@
 		<member name="physics/2d/run_on_separate_thread" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the 2D physics server runs on a separate thread, making better use of multi-core CPUs. If [code]false[/code], the 2D physics server runs on the main thread. Running the physics server on a separate thread can increase performance, but restricts API access to only physics process.
 		</member>
-		<member name="physics/2d/sleep_threshold_angular" type="float" setter="" getter="" default="0.139626">
-			Threshold angular velocity under which a 2D physics body will be considered inactive. See [constant PhysicsServer2D.SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD].
-		</member>
-		<member name="physics/2d/sleep_threshold_linear" type="float" setter="" getter="" default="2.0">
-			Threshold linear velocity under which a 2D physics body will be considered inactive. See [constant PhysicsServer2D.SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD].
-		</member>
-		<member name="physics/2d/solver/contact_max_allowed_penetration" type="float" setter="" getter="" default="0.3">
-			Maximum distance a shape can penetrate another shape before it is considered a collision. See [constant PhysicsServer2D.SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION].
-		</member>
-		<member name="physics/2d/solver/contact_max_separation" type="float" setter="" getter="" default="1.5">
-			Maximum distance a shape can be from another before they are considered separated and the contact is discarded. See [constant PhysicsServer2D.SPACE_PARAM_CONTACT_MAX_SEPARATION].
-		</member>
-		<member name="physics/2d/solver/contact_recycle_radius" type="float" setter="" getter="" default="1.0">
-			Maximum distance a pair of bodies has to move before their collision status has to be recalculated. See [constant PhysicsServer2D.SPACE_PARAM_CONTACT_RECYCLE_RADIUS].
-		</member>
-		<member name="physics/2d/solver/default_constraint_bias" type="float" setter="" getter="" default="0.2">
-			Default solver bias for all physics constraints. Defines how much bodies react to enforce constraints. See [constant PhysicsServer2D.SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS].
-			Individual constraints can have a specific bias value (see [member Joint2D.bias]).
-		</member>
-		<member name="physics/2d/solver/default_contact_bias" type="float" setter="" getter="" default="0.8">
-			Default solver bias for all physics contacts. Defines how much bodies react to enforce contact separation. See [constant PhysicsServer2D.SPACE_PARAM_CONTACT_DEFAULT_BIAS].
-			Individual shapes can have a specific bias value (see [member Shape2D.custom_solver_bias]).
-		</member>
-		<member name="physics/2d/solver/solver_iterations" type="int" setter="" getter="" default="16">
-			Number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance. See [constant PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS].
-		</member>
-		<member name="physics/2d/time_before_sleep" type="float" setter="" getter="" default="0.5">
-			Time (in seconds) of inactivity before which a 2D physics body will put to sleep. See [constant PhysicsServer2D.SPACE_PARAM_BODY_TIME_TO_SLEEP].
-		</member>
 		<member name="physics/3d/default_angular_damp" type="float" setter="" getter="" default="0.1">
 			The default rotational motion damping in 3D. Damping is used to gradually slow down physical objects over time. RigidBodies will fall back to this value when combining their own damping values and no area damping value is present.
 			Suggested values are in the range [code]0[/code] to [code]30[/code]. At value [code]0[/code] objects will keep moving with the same velocity. Greater values will stop the object faster. A value equal to or greater than the physics tick rate ([member physics/common/physics_ticks_per_second]) will bring the object to a stop in one iteration.
@@ -2350,31 +2321,6 @@
 			If [code]true[/code], the 3D physics server runs on a separate thread, making better use of multi-core CPUs. If [code]false[/code], the 3D physics server runs on the main thread. Running the physics server on a separate thread can increase performance, but restricts API access to only physics process.
 			[b]Note:[/b] When [member physics/3d/physics_engine] is set to [code]Jolt Physics[/code], enabling this setting will prevent the 3D physics server from being able to provide any context when reporting errors and warnings, and will instead always refer to nodes as [code]&lt;unknown&gt;[/code].
 		</member>
-		<member name="physics/3d/sleep_threshold_angular" type="float" setter="" getter="" default="0.139626">
-			Threshold angular velocity under which a 3D physics body will be considered inactive. See [constant PhysicsServer3D.SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD].
-		</member>
-		<member name="physics/3d/sleep_threshold_linear" type="float" setter="" getter="" default="0.1">
-			Threshold linear velocity under which a 3D physics body will be considered inactive. See [constant PhysicsServer3D.SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD].
-		</member>
-		<member name="physics/3d/solver/contact_max_allowed_penetration" type="float" setter="" getter="" default="0.01">
-			Maximum distance a shape can penetrate another shape before it is considered a collision. See [constant PhysicsServer3D.SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION].
-		</member>
-		<member name="physics/3d/solver/contact_max_separation" type="float" setter="" getter="" default="0.05">
-			Maximum distance a shape can be from another before they are considered separated and the contact is discarded. See [constant PhysicsServer3D.SPACE_PARAM_CONTACT_MAX_SEPARATION].
-		</member>
-		<member name="physics/3d/solver/contact_recycle_radius" type="float" setter="" getter="" default="0.01">
-			Maximum distance a pair of bodies has to move before their collision status has to be recalculated. See [constant PhysicsServer3D.SPACE_PARAM_CONTACT_RECYCLE_RADIUS].
-		</member>
-		<member name="physics/3d/solver/default_contact_bias" type="float" setter="" getter="" default="0.8">
-			Default solver bias for all physics contacts. Defines how much bodies react to enforce contact separation. See [constant PhysicsServer3D.SPACE_PARAM_CONTACT_DEFAULT_BIAS].
-			Individual shapes can have a specific bias value (see [member Shape3D.custom_solver_bias]).
-		</member>
-		<member name="physics/3d/solver/solver_iterations" type="int" setter="" getter="" default="16">
-			Number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance. See [constant PhysicsServer3D.SPACE_PARAM_SOLVER_ITERATIONS].
-		</member>
-		<member name="physics/3d/time_before_sleep" type="float" setter="" getter="" default="0.5">
-			Time (in seconds) of inactivity before which a 3D physics body will put to sleep. See [constant PhysicsServer3D.SPACE_PARAM_BODY_TIME_TO_SLEEP].
-		</member>
 		<member name="physics/common/enable_object_picking" type="bool" setter="" getter="" default="true">
 			Enables [member Viewport.physics_object_picking] on the root viewport.
 		</member>
@@ -2398,6 +2344,60 @@
 			The number of fixed iterations per second. This controls how often physics simulation and [method Node._physics_process] methods are run. See also [member application/run/max_fps].
 			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_ticks_per_second] instead.
 			[b]Note:[/b] Only [member physics/common/max_physics_steps_per_frame] physics ticks may be simulated per rendered frame at most. If more physics ticks have to be simulated per rendered frame to keep up with rendering, the project will appear to slow down (even if [code]delta[/code] is used consistently in physics calculations). Therefore, it is recommended to also increase [member physics/common/max_physics_steps_per_frame] if increasing [member physics/common/physics_ticks_per_second] significantly above its default value.
+		</member>
+		<member name="physics/godot_physics_2d/sleep_threshold_angular" type="float" setter="" getter="" default="0.139626">
+			Threshold angular velocity under which a 2D physics body will be considered inactive. See [constant PhysicsServer2D.SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD].
+		</member>
+		<member name="physics/godot_physics_2d/sleep_threshold_linear" type="float" setter="" getter="" default="2.0">
+			Threshold linear velocity under which a 2D physics body will be considered inactive. See [constant PhysicsServer2D.SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD].
+		</member>
+		<member name="physics/godot_physics_2d/solver/contact_max_allowed_penetration" type="float" setter="" getter="" default="0.3">
+			Maximum distance a shape can penetrate another shape before it is considered a collision. See [constant PhysicsServer2D.SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION].
+		</member>
+		<member name="physics/godot_physics_2d/solver/contact_max_separation" type="float" setter="" getter="" default="1.5">
+			Maximum distance a shape can be from another before they are considered separated and the contact is discarded. See [constant PhysicsServer2D.SPACE_PARAM_CONTACT_MAX_SEPARATION].
+		</member>
+		<member name="physics/godot_physics_2d/solver/contact_recycle_radius" type="float" setter="" getter="" default="1.0">
+			Maximum distance a pair of bodies has to move before their collision status has to be recalculated. See [constant PhysicsServer2D.SPACE_PARAM_CONTACT_RECYCLE_RADIUS].
+		</member>
+		<member name="physics/godot_physics_2d/solver/default_constraint_bias" type="float" setter="" getter="" default="0.2">
+			Default solver bias for all physics constraints. Defines how much bodies react to enforce constraints. See [constant PhysicsServer2D.SPACE_PARAM_CONSTRAINT_DEFAULT_BIAS].
+			Individual constraints can have a specific bias value (see [member Joint2D.bias]).
+		</member>
+		<member name="physics/godot_physics_2d/solver/default_contact_bias" type="float" setter="" getter="" default="0.8">
+			Default solver bias for all physics contacts. Defines how much bodies react to enforce contact separation. See [constant PhysicsServer2D.SPACE_PARAM_CONTACT_DEFAULT_BIAS].
+			Individual shapes can have a specific bias value (see [member Shape2D.custom_solver_bias]).
+		</member>
+		<member name="physics/godot_physics_2d/solver/solver_iterations" type="int" setter="" getter="" default="16">
+			Number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance. See [constant PhysicsServer2D.SPACE_PARAM_SOLVER_ITERATIONS].
+		</member>
+		<member name="physics/godot_physics_2d/time_before_sleep" type="float" setter="" getter="" default="0.5">
+			Time (in seconds) of inactivity before which a 2D physics body will put to sleep. See [constant PhysicsServer2D.SPACE_PARAM_BODY_TIME_TO_SLEEP].
+		</member>
+		<member name="physics/godot_physics_3d/sleep_threshold_angular" type="float" setter="" getter="" default="0.139626">
+			Threshold angular velocity under which a 3D physics body will be considered inactive. See [constant PhysicsServer3D.SPACE_PARAM_BODY_ANGULAR_VELOCITY_SLEEP_THRESHOLD].
+		</member>
+		<member name="physics/godot_physics_3d/sleep_threshold_linear" type="float" setter="" getter="" default="0.1">
+			Threshold linear velocity under which a 3D physics body will be considered inactive. See [constant PhysicsServer3D.SPACE_PARAM_BODY_LINEAR_VELOCITY_SLEEP_THRESHOLD].
+		</member>
+		<member name="physics/godot_physics_3d/solver/contact_max_allowed_penetration" type="float" setter="" getter="" default="0.01">
+			Maximum distance a shape can penetrate another shape before it is considered a collision. See [constant PhysicsServer3D.SPACE_PARAM_CONTACT_MAX_ALLOWED_PENETRATION].
+		</member>
+		<member name="physics/godot_physics_3d/solver/contact_max_separation" type="float" setter="" getter="" default="0.05">
+			Maximum distance a shape can be from another before they are considered separated and the contact is discarded. See [constant PhysicsServer3D.SPACE_PARAM_CONTACT_MAX_SEPARATION].
+		</member>
+		<member name="physics/godot_physics_3d/solver/contact_recycle_radius" type="float" setter="" getter="" default="0.01">
+			Maximum distance a pair of bodies has to move before their collision status has to be recalculated. See [constant PhysicsServer3D.SPACE_PARAM_CONTACT_RECYCLE_RADIUS].
+		</member>
+		<member name="physics/godot_physics_3d/solver/default_contact_bias" type="float" setter="" getter="" default="0.8">
+			Default solver bias for all physics contacts. Defines how much bodies react to enforce contact separation. See [constant PhysicsServer3D.SPACE_PARAM_CONTACT_DEFAULT_BIAS].
+			Individual shapes can have a specific bias value (see [member Shape3D.custom_solver_bias]).
+		</member>
+		<member name="physics/godot_physics_3d/solver/solver_iterations" type="int" setter="" getter="" default="16">
+			Number of solver iterations for all contacts and constraints. The greater the number of iterations, the more accurate the collisions will be. However, a greater number of iterations requires more CPU power, which can decrease performance. See [constant PhysicsServer3D.SPACE_PARAM_SOLVER_ITERATIONS].
+		</member>
+		<member name="physics/godot_physics_3d/time_before_sleep" type="float" setter="" getter="" default="0.5">
+			Time (in seconds) of inactivity before which a 3D physics body will put to sleep. See [constant PhysicsServer3D.SPACE_PARAM_BODY_TIME_TO_SLEEP].
 		</member>
 		<member name="physics/jolt_physics_3d/collisions/active_edge_threshold" type="float" setter="" getter="" default="0.872665">
 			The maximum angle, in radians, between two adjacent triangles in a [ConcavePolygonShape3D] or [HeightMapShape3D] for which the edge between those triangles is considered inactive.

--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -77,7 +77,8 @@
 	<members>
 		<member name="custom_solver_bias" type="float" setter="set_custom_solver_bias" getter="get_custom_solver_bias" default="0.0">
 			The shape's custom solver bias. Defines how much bodies react to enforce contact separation when this shape is involved.
-			When set to [code]0[/code], the default value from [member ProjectSettings.physics/2d/solver/default_contact_bias] is used.
+			When set to [code]0[/code], the default value defined by the [PhysicsServer2D] is used instead.
+			In GodotPhysics2D that default value is [member ProjectSettings.physics/godot_physics_2d/solver/default_contact_bias].
 		</member>
 	</members>
 </class>

--- a/doc/classes/Shape3D.xml
+++ b/doc/classes/Shape3D.xml
@@ -21,10 +21,11 @@
 	<members>
 		<member name="custom_solver_bias" type="float" setter="set_custom_solver_bias" getter="get_custom_solver_bias" default="0.0">
 			The shape's custom solver bias. Defines how much bodies react to enforce contact separation when this shape is involved.
-			When set to [code]0[/code], the default value from [member ProjectSettings.physics/3d/solver/default_contact_bias] is used.
+			When set to [code]0[/code], the default value defined by the [PhysicsServer3D] is used instead.
+			In GodotPhysics3D that default value is [member ProjectSettings.physics/godot_physics_3d/solver/default_contact_bias].
 		</member>
 		<member name="margin" type="float" setter="set_margin" getter="get_margin" default="0.04">
-			The collision margin for the shape. This is not used in Godot Physics.
+			The collision margin for the shape. This is not used in GodotPhysics3D.
 			Collision margins allow collision detection to be more efficient by adding an extra shell around shapes. Collision algorithms are more expensive when objects overlap by more than their margin, so a higher value for margins is better for performance, at the cost of accuracy around edges as it makes them less sharp.
 		</member>
 	</members>

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -1217,15 +1217,15 @@ GodotPhysicsDirectSpaceState2D *GodotSpace2D::get_direct_state() {
 }
 
 GodotSpace2D::GodotSpace2D() {
-	body_linear_velocity_sleep_threshold = GLOBAL_GET("physics/2d/sleep_threshold_linear");
-	body_angular_velocity_sleep_threshold = GLOBAL_GET("physics/2d/sleep_threshold_angular");
-	body_time_to_sleep = GLOBAL_GET("physics/2d/time_before_sleep");
-	solver_iterations = GLOBAL_GET("physics/2d/solver/solver_iterations");
-	contact_recycle_radius = GLOBAL_GET("physics/2d/solver/contact_recycle_radius");
-	contact_max_separation = GLOBAL_GET("physics/2d/solver/contact_max_separation");
-	contact_max_allowed_penetration = GLOBAL_GET("physics/2d/solver/contact_max_allowed_penetration");
-	contact_bias = GLOBAL_GET("physics/2d/solver/default_contact_bias");
-	constraint_bias = GLOBAL_GET("physics/2d/solver/default_constraint_bias");
+	body_linear_velocity_sleep_threshold = GLOBAL_GET("physics/godot_physics_2d/sleep_threshold_linear");
+	body_angular_velocity_sleep_threshold = GLOBAL_GET("physics/godot_physics_2d/sleep_threshold_angular");
+	body_time_to_sleep = GLOBAL_GET("physics/godot_physics_2d/time_before_sleep");
+	solver_iterations = GLOBAL_GET("physics/godot_physics_2d/solver/solver_iterations");
+	contact_recycle_radius = GLOBAL_GET("physics/godot_physics_2d/solver/contact_recycle_radius");
+	contact_max_separation = GLOBAL_GET("physics/godot_physics_2d/solver/contact_max_separation");
+	contact_max_allowed_penetration = GLOBAL_GET("physics/godot_physics_2d/solver/contact_max_allowed_penetration");
+	contact_bias = GLOBAL_GET("physics/godot_physics_2d/solver/default_contact_bias");
+	constraint_bias = GLOBAL_GET("physics/godot_physics_2d/solver/default_constraint_bias");
 
 	broadphase = GodotBroadPhase2D::create_func();
 	broadphase->set_pair_callback(_broadphase_pair, this);

--- a/modules/godot_physics_2d/register_types.cpp
+++ b/modules/godot_physics_2d/register_types.cpp
@@ -53,6 +53,34 @@ void initialize_godot_physics_2d_module(ModuleInitializationLevel p_level) {
 	}
 	PhysicsServer2DManager::get_singleton()->register_server("GodotPhysics2D", callable_mp_static(_createGodotPhysics2DCallback));
 	PhysicsServer2DManager::get_singleton()->set_default_server("GodotPhysics2D");
+
+#ifndef DISABLE_DEPRECATED
+#define MOVE_PROJECT_SETTING(m_old_setting, m_new_setting)                                                                               \
+	if (!ProjectSettings::get_singleton()->has_setting(m_new_setting) && ProjectSettings::get_singleton()->has_setting(m_old_setting)) { \
+		Variant value = GLOBAL_GET(m_old_setting);                                                                                       \
+		ProjectSettings::get_singleton()->set_setting(m_new_setting, value);                                                             \
+		ProjectSettings::get_singleton()->clear(m_old_setting);                                                                          \
+	}
+	MOVE_PROJECT_SETTING("physics/2d/sleep_threshold_linear", "physics/godot_physics_2d/sleep_threshold_linear")
+	MOVE_PROJECT_SETTING("physics/2d/sleep_threshold_angular", "physics/godot_physics_2d/sleep_threshold_angular")
+	MOVE_PROJECT_SETTING("physics/2d/time_before_sleep", "physics/godot_physics_2d/time_before_sleep")
+	MOVE_PROJECT_SETTING("physics/2d/solver/solver_iterations", "physics/godot_physics_2d/solver/solver_iterations")
+	MOVE_PROJECT_SETTING("physics/2d/solver/contact_recycle_radius", "physics/godot_physics_2d/solver/contact_recycle_radius")
+	MOVE_PROJECT_SETTING("physics/2d/solver/contact_max_separation", "physics/godot_physics_2d/solver/contact_max_separation")
+	MOVE_PROJECT_SETTING("physics/2d/solver/contact_max_allowed_penetration", "physics/godot_physics_2d/solver/contact_max_allowed_penetration")
+	MOVE_PROJECT_SETTING("physics/2d/solver/default_contact_bias", "physics/godot_physics_2d/solver/default_contact_bias")
+	MOVE_PROJECT_SETTING("physics/2d/solver/default_constraint_bias", "physics/godot_physics_2d/solver/default_constraint_bias")
+#endif
+
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_2d/sleep_threshold_linear", PROPERTY_HINT_RANGE, "0,10,0.001,or_greater"), 2.0);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_2d/sleep_threshold_angular", PROPERTY_HINT_RANGE, "0,90,0.1,radians_as_degrees"), Math::deg_to_rad(8.0));
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_2d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater,suffix:s"), 0.5);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/godot_physics_2d/solver/solver_iterations", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), 16);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_2d/solver/contact_recycle_radius", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), 1.0);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_2d/solver/contact_max_separation", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), 1.5);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_2d/solver/contact_max_allowed_penetration", PROPERTY_HINT_RANGE, "0.01,10,0.01,or_greater"), 0.3);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_2d/solver/default_contact_bias", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.8);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_2d/solver/default_constraint_bias", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.2);
 }
 
 void uninitialize_godot_physics_2d_module(ModuleInitializationLevel p_level) {

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -1257,14 +1257,14 @@ GodotPhysicsDirectSpaceState3D *GodotSpace3D::get_direct_state() {
 }
 
 GodotSpace3D::GodotSpace3D() {
-	body_linear_velocity_sleep_threshold = GLOBAL_GET("physics/3d/sleep_threshold_linear");
-	body_angular_velocity_sleep_threshold = GLOBAL_GET("physics/3d/sleep_threshold_angular");
-	body_time_to_sleep = GLOBAL_GET("physics/3d/time_before_sleep");
-	solver_iterations = GLOBAL_GET("physics/3d/solver/solver_iterations");
-	contact_recycle_radius = GLOBAL_GET("physics/3d/solver/contact_recycle_radius");
-	contact_max_separation = GLOBAL_GET("physics/3d/solver/contact_max_separation");
-	contact_max_allowed_penetration = GLOBAL_GET("physics/3d/solver/contact_max_allowed_penetration");
-	contact_bias = GLOBAL_GET("physics/3d/solver/default_contact_bias");
+	body_linear_velocity_sleep_threshold = GLOBAL_GET("physics/godot_physics_3d/sleep_threshold_linear");
+	body_angular_velocity_sleep_threshold = GLOBAL_GET("physics/godot_physics_3d/sleep_threshold_angular");
+	body_time_to_sleep = GLOBAL_GET("physics/godot_physics_3d/time_before_sleep");
+	solver_iterations = GLOBAL_GET("physics/godot_physics_3d/solver/solver_iterations");
+	contact_recycle_radius = GLOBAL_GET("physics/godot_physics_3d/solver/contact_recycle_radius");
+	contact_max_separation = GLOBAL_GET("physics/godot_physics_3d/solver/contact_max_separation");
+	contact_max_allowed_penetration = GLOBAL_GET("physics/godot_physics_3d/solver/contact_max_allowed_penetration");
+	contact_bias = GLOBAL_GET("physics/godot_physics_3d/solver/default_contact_bias");
 
 	broadphase = GodotBroadPhase3D::create_func();
 	broadphase->set_pair_callback(_broadphase_pair, this);

--- a/modules/godot_physics_3d/register_types.cpp
+++ b/modules/godot_physics_3d/register_types.cpp
@@ -52,6 +52,32 @@ void initialize_godot_physics_3d_module(ModuleInitializationLevel p_level) {
 	}
 	PhysicsServer3DManager::get_singleton()->register_server("GodotPhysics3D", callable_mp_static(_createGodotPhysics3DCallback));
 	PhysicsServer3DManager::get_singleton()->set_default_server("GodotPhysics3D");
+
+#ifndef DISABLE_DEPRECATED
+#define MOVE_PROJECT_SETTING(m_old_setting, m_new_setting)                                                                               \
+	if (!ProjectSettings::get_singleton()->has_setting(m_new_setting) && ProjectSettings::get_singleton()->has_setting(m_old_setting)) { \
+		Variant value = GLOBAL_GET(m_old_setting);                                                                                       \
+		ProjectSettings::get_singleton()->set_setting(m_new_setting, value);                                                             \
+		ProjectSettings::get_singleton()->clear(m_old_setting);                                                                          \
+	}
+	MOVE_PROJECT_SETTING("physics/3d/sleep_threshold_linear", "physics/godot_physics_3d/sleep_threshold_linear")
+	MOVE_PROJECT_SETTING("physics/3d/sleep_threshold_angular", "physics/godot_physics_3d/sleep_threshold_angular")
+	MOVE_PROJECT_SETTING("physics/3d/time_before_sleep", "physics/godot_physics_3d/time_before_sleep")
+	MOVE_PROJECT_SETTING("physics/3d/solver/solver_iterations", "physics/godot_physics_3d/solver/solver_iterations")
+	MOVE_PROJECT_SETTING("physics/3d/solver/contact_recycle_radius", "physics/godot_physics_3d/solver/contact_recycle_radius")
+	MOVE_PROJECT_SETTING("physics/3d/solver/contact_max_separation", "physics/godot_physics_3d/solver/contact_max_separation")
+	MOVE_PROJECT_SETTING("physics/3d/solver/contact_max_allowed_penetration", "physics/godot_physics_3d/solver/contact_max_allowed_penetration")
+	MOVE_PROJECT_SETTING("physics/3d/solver/default_contact_bias", "physics/godot_physics_3d/solver/default_contact_bias")
+#endif
+
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_3d/sleep_threshold_linear", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater"), 0.1);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_3d/sleep_threshold_angular", PROPERTY_HINT_RANGE, "0,90,0.1,radians_as_degrees"), Math::deg_to_rad(8.0));
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_3d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 0.5);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/godot_physics_3d/solver/solver_iterations", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), 16);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_3d/solver/contact_recycle_radius", PROPERTY_HINT_RANGE, "0,0.1,0.001,or_greater"), 0.01);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_3d/solver/contact_max_separation", PROPERTY_HINT_RANGE, "0,0.1,0.001,or_greater"), 0.05);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_3d/solver/contact_max_allowed_penetration", PROPERTY_HINT_RANGE, "0.001,0.1,0.001,or_greater"), 0.01);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/godot_physics_3d/solver/default_contact_bias", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.8);
 }
 
 void uninitialize_godot_physics_3d_module(ModuleInitializationLevel p_level) {

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -899,16 +899,7 @@ PhysicsServer2D::PhysicsServer2D() {
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/default_linear_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"), 0.1);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/default_angular_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"), 1.0);
 
-	// PhysicsServer2D
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/sleep_threshold_linear", PROPERTY_HINT_RANGE, "0,10,0.001,or_greater"), 2.0);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/sleep_threshold_angular", PROPERTY_HINT_RANGE, "0,90,0.1,radians_as_degrees"), Math::deg_to_rad(8.0));
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater,suffix:s"), 0.5);
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/2d/solver/solver_iterations", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), 16);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/contact_recycle_radius", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), 1.0);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/contact_max_separation", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), 1.5);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/contact_max_allowed_penetration", PROPERTY_HINT_RANGE, "0.01,10,0.01,or_greater"), 0.3);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/default_contact_bias", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.8);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/2d/solver/default_constraint_bias", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.2);
+	// Other implementation-specific settings are defined by the respective modules (or GDExtensions).
 }
 
 PhysicsServer2D::~PhysicsServer2D() {

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -1129,15 +1129,7 @@ PhysicsServer3D::PhysicsServer3D() {
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/default_linear_damp", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), 0.1);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/default_angular_damp", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), 0.1);
 
-	// PhysicsServer3D
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/sleep_threshold_linear", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater"), 0.1);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/sleep_threshold_angular", PROPERTY_HINT_RANGE, "0,90,0.1,radians_as_degrees"), Math::deg_to_rad(8.0));
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/time_before_sleep", PROPERTY_HINT_RANGE, "0,5,0.01,or_greater"), 0.5);
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/3d/solver/solver_iterations", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), 16);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/solver/contact_recycle_radius", PROPERTY_HINT_RANGE, "0,0.1,0.001,or_greater"), 0.01);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/solver/contact_max_separation", PROPERTY_HINT_RANGE, "0,0.1,0.001,or_greater"), 0.05);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/solver/contact_max_allowed_penetration", PROPERTY_HINT_RANGE, "0.001,0.1,0.001,or_greater"), 0.01);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/3d/solver/default_contact_bias", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.8);
+	// Other implementation-specific settings are defined by the respective modules (or GDExtensions).
 }
 
 PhysicsServer3D::~PhysicsServer3D() {


### PR DESCRIPTION
This is to avoid having a bunch of seemingly generic (advanced) project settings that actually have no effect in other physics server implementations (coming from modules/GDExtensions like Jolt, Box2D, Rapier, etc.).

These Godot Physics specific (advanced) settings are moved from `Physics / 2D` and `Physics / 3D` to `Physics / Godot Physics 2D` and `Physics / Godot Physics 3D` respectively. This is consistent with how existing GDExtensions like Jolt, Box2D and Rapier store their implementation-specific settings.

**Preserves compatibility** by moving the old setting's value (if it exists and the new setting does not yet have a value) to the new setting (and removing the old setting).

Note: currently all the Godot Physics specific settings are marked "advanced" (as they probably should be).

Note: *reading* any of these (advanced) settings in a script using `ProjectSettings.get_setting` with the old setting name will obviously fail, but this is such a corner case that I doubt anyone is doing that with these advanced settings (including physics enthusiasts).