### PR TITLE
Fix Skeleton doesn't update skin after deactivating modifiers when it has only one modifier

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -1032,6 +1032,10 @@ Ref<SkinReference> Skeleton3D::register_skin(const Ref<Skin> &p_skin) {
 	return skin_ref;
 }
 
+void Skeleton3D::force_update_deferred() {
+	_make_dirty();
+}
+
 void Skeleton3D::force_update_all_dirty_bones() {
 	if (!dirty) {
 		return;

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -284,6 +284,7 @@ public:
 	void force_update_all_dirty_bones();
 	void force_update_all_bone_transforms();
 	void force_update_bone_children_transforms(int bone_idx);
+	void force_update_deferred();
 
 	void set_modifier_callback_mode_process(ModifierCallbackModeProcess p_mode);
 	ModifierCallbackModeProcess get_modifier_callback_mode_process() const;

--- a/scene/3d/skeleton_modifier_3d.cpp
+++ b/scene/3d/skeleton_modifier_3d.cpp
@@ -75,6 +75,17 @@ void SkeletonModifier3D::_skeleton_changed(Skeleton3D *p_old, Skeleton3D *p_new)
 	//
 }
 
+void SkeletonModifier3D::_force_update_skeleton_skin() {
+	if (!is_inside_tree()) {
+		return;
+	}
+	Skeleton3D *skeleton = get_skeleton();
+	if (!skeleton) {
+		return;
+	}
+	skeleton->force_update_deferred();
+}
+
 /* Process */
 
 void SkeletonModifier3D::set_active(bool p_active) {
@@ -83,6 +94,7 @@ void SkeletonModifier3D::set_active(bool p_active) {
 	}
 	active = p_active;
 	_set_active(active);
+	_force_update_skeleton_skin();
 }
 
 bool SkeletonModifier3D::is_active() const {
@@ -118,6 +130,10 @@ void SkeletonModifier3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_PARENTED: {
 			_update_skeleton();
+		} break;
+		case NOTIFICATION_EXIT_TREE:
+		case NOTIFICATION_UNPARENTED: {
+			_force_update_skeleton_skin();
 		} break;
 	}
 }

--- a/scene/3d/skeleton_modifier_3d.h
+++ b/scene/3d/skeleton_modifier_3d.h
@@ -50,6 +50,7 @@ protected:
 
 	void _update_skeleton();
 	void _update_skeleton_path();
+	void _force_update_skeleton_skin();
 
 	virtual void _skeleton_changed(Skeleton3D *p_old, Skeleton3D *p_new);
 


### PR DESCRIPTION
After deactivating SkeletonModifier, no skin update occurred because the pose in the Skeleton was considered unchanged.

Add an API `force_update_deferred()` to Skeleton3D to call `_make_dirty()` for reserving Skeleton updates public, so that skin updates are reserved when the Active parameter is changed. I suppose we could make `_make_dirty()` public directly, but I worried because the name "_make_dirty()" is used as a private function in other classes as well.

Before:

https://github.com/user-attachments/assets/6f523a03-f9e5-48ff-a08b-39fcfb2f4d36

After:

https://github.com/user-attachments/assets/d6cc41b9-285f-4e51-a246-f0031bbd5f60


