### PR TITLE
Show file names in remove files confirmation dialog

### DIFF
--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -31,6 +31,7 @@
 #ifndef DEPENDENCY_EDITOR_H
 #define DEPENDENCY_EDITOR_H
 
+#include "scene/gui/box_container.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/tab_container.h"
@@ -98,6 +99,8 @@ class DependencyRemoveDialog : public ConfirmationDialog {
 
 	Label *text = nullptr;
 	Tree *owners = nullptr;
+	VBoxContainer *vb_owners = nullptr;
+	ItemList *files_to_delete_list = nullptr;
 
 	HashMap<String, String> all_remove_files;
 	Vector<String> dirs_to_delete;
@@ -122,6 +125,7 @@ class DependencyRemoveDialog : public ConfirmationDialog {
 	void _find_all_removed_dependencies(EditorFileSystemDirectory *efsd, Vector<RemovedDependency> &p_removed);
 	void _find_localization_remaps_of_removed_files(Vector<RemovedDependency> &p_removed);
 	void _build_removed_dependency_tree(const Vector<RemovedDependency> &p_removed);
+	void _show_files_to_delete_list();
 
 	void ok_pressed() override;
 


### PR DESCRIPTION
Closes #85261
Supersedes #85290

Thanks to @jsjtxietian that implemented most of the code. I just rebased the original PR and did some tweaks to adjust `ItemList` and `Tree` sizes.

![MultipleFiles](https://github.com/user-attachments/assets/b4001b4d-1638-44e7-99ea-0b2f6b0ae11b)
![Directories](https://github.com/user-attachments/assets/b685e9c9-b6b8-491d-901b-2df359fd3f0e)
![MultipleFiles](https://github.com/user-attachments/assets/7229faa9-820d-4f3f-843f-5ec9ed7e85d4)
