### PR TITLE
Fix `MultiMesh` errors in editor and resource duplication

### DIFF
--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -195,6 +195,9 @@ Vector<Color> MultiMesh::_get_custom_data_array() const {
 #endif // DISABLE_DEPRECATED
 
 void MultiMesh::set_buffer(const Vector<float> &p_buffer) {
+	if (instance_count == 0) {
+		return;
+	}
 	RS::get_singleton()->multimesh_set_buffer(multimesh, p_buffer);
 }
 


### PR DESCRIPTION
The `buffer` property of a `MultiMesh` can't be set when there are no instances, but no instances are the default so it causes issues with the editor and resource duplication.

Trying to set the property in the editor gives this error:

> rendering/renderer_rd/storage_rd/mesh_storage.cpp:1935 - Condition "p_buffer.size() != (multimesh->instances * (int)multimesh->stride_cache)" is true.

When the `MultiMesh` is a `resource_local_to_scene`, the engine gives this error every time it instantiates a scene with it:

> Buffer argument is not a valid buffer of any type.

- Fixes: https://github.com/godotengine/godot/issues/68592