### PR TITLE
Add FileSystem & FIleSystemProtocol to allow custom path prefixes (custom://)

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -36,6 +36,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/file_access_pack.h"
+#include "core/io/filesystem.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_uid.h"
 #include "core/object/script_language.h"
@@ -154,17 +155,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 	}
 
 	// Check if we have a special path (like res://) or a protocol identifier.
-	int p = path.find("://");
-	bool found = false;
-	if (p > 0) {
-		found = true;
-		for (int i = 0; i < p; i++) {
-			if (!is_ascii_alphanumeric_char(path[i])) {
-				found = false;
-				break;
-			}
-		}
-	}
+	bool found = FileSystem::try_find_protocol_in_path(path, nullptr, nullptr);
 	if (found) {
 		return path;
 	}
@@ -256,26 +247,7 @@ void ProjectSettings::add_hidden_prefix(const String &p_prefix) {
 }
 
 String ProjectSettings::globalize_path(const String &p_path) const {
-	if (p_path.begins_with("res://")) {
-		if (!resource_path.is_empty()) {
-			return p_path.replace("res:/", resource_path);
-		}
-		return p_path.replace("res://", "");
-	} else if (p_path.begins_with("uid://")) {
-		const String path = ResourceUID::uid_to_path(p_path);
-		if (!resource_path.is_empty()) {
-			return path.replace("res:/", resource_path);
-		}
-		return path.replace("res://", "");
-	} else if (p_path.begins_with("user://")) {
-		String data_dir = OS::get_singleton()->get_user_data_dir();
-		if (!data_dir.is_empty()) {
-			return p_path.replace("user:/", data_dir);
-		}
-		return p_path.replace("user://", "");
-	}
-
-	return p_path;
+	return FileSystem::get_singleton()->globalize_path_or_fallback(p_path);
 }
 
 bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -36,53 +36,18 @@
 #include "core/io/file_access_compressed.h"
 #include "core/io/file_access_encrypted.h"
 #include "core/io/file_access_pack.h"
+#include "core/io/filesystem.h"
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
 #include "core/os/time.h"
-
-FileAccess::CreateFunc FileAccess::create_func[ACCESS_MAX] = {};
 
 FileAccess::FileCloseFailNotify FileAccess::close_fail_notify = nullptr;
 
 bool FileAccess::backup_save = false;
 thread_local Error FileAccess::last_file_open_error = OK;
 
-Ref<FileAccess> FileAccess::create(AccessType p_access) {
-	ERR_FAIL_INDEX_V(p_access, ACCESS_MAX, nullptr);
-	ERR_FAIL_NULL_V(create_func[p_access], nullptr);
-
-	Ref<FileAccess> ret = create_func[p_access]();
-	ret->_set_access_type(p_access);
-	return ret;
-}
-
 bool FileAccess::exists(const String &p_name) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && PackedData::get_singleton()->has_path(p_name)) {
-		return true;
-	}
-
-	// Using file_exists because it's faster than trying to open the file.
-	Ref<FileAccess> ret = create_for_path(p_name);
-	return ret->file_exists(p_name);
-}
-
-void FileAccess::_set_access_type(AccessType p_access) {
-	_access_type = p_access;
-}
-
-Ref<FileAccess> FileAccess::create_for_path(const String &p_path) {
-	Ref<FileAccess> ret;
-	if (p_path.begins_with("res://") || p_path.begins_with("uid://")) {
-		ret = create(ACCESS_RESOURCES);
-	} else if (p_path.begins_with("user://")) {
-		ret = create(ACCESS_USERDATA);
-	} else if (p_path.begins_with("pipe://")) {
-		ret = create(ACCESS_PIPE);
-	} else {
-		ret = create(ACCESS_FILESYSTEM);
-	}
-
-	return ret;
+	return FileSystem::get_singleton()->file_exists(p_name);
 }
 
 Ref<FileAccess> FileAccess::create_temp(int p_mode_flags, const String &p_prefix, const String &p_extension, bool p_keep, Error *r_error) {
@@ -158,35 +123,8 @@ void FileAccess::_delete_temp() {
 	DirAccess::remove_absolute(_temp_path);
 }
 
-Error FileAccess::reopen(const String &p_path, int p_mode_flags) {
-	return open_internal(p_path, p_mode_flags);
-}
-
 Ref<FileAccess> FileAccess::open(const String &p_path, int p_mode_flags, Error *r_error) {
-	//try packed data first
-
-	Ref<FileAccess> ret;
-	if (!(p_mode_flags & WRITE) && PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled()) {
-		ret = PackedData::get_singleton()->try_open_path(p_path);
-		if (ret.is_valid()) {
-			if (r_error) {
-				*r_error = OK;
-			}
-			return ret;
-		}
-	}
-
-	ret = create_for_path(p_path);
-	Error err = ret->open_internal(p_path, p_mode_flags);
-
-	if (r_error) {
-		*r_error = err;
-	}
-	if (err != OK) {
-		ret.unref();
-	}
-
-	return ret;
+	return FileSystem::get_singleton()->open_file(p_path, p_mode_flags, r_error);
 }
 
 Ref<FileAccess> FileAccess::_open(const String &p_path, ModeFlags p_mode_flags) {
@@ -248,57 +186,24 @@ Error FileAccess::get_open_error() {
 	return last_file_open_error;
 }
 
-FileAccess::CreateFunc FileAccess::get_create_func(AccessType p_access) {
-	return create_func[p_access];
+void FileAccess::set_path_disguise(const String &p_path) {
+	has_path_disguise = true;
+	path_disguise = p_path;
+}
+void FileAccess::clear_path_disguise() {
+	has_path_disguise = false;
+	path_disguise = String();
 }
 
-FileAccess::AccessType FileAccess::get_access_type() const {
-	return _access_type;
-}
-
-String FileAccess::fix_path(const String &p_path) const {
-	// Helper used by file accesses that use a single filesystem.
-
-	String r_path = p_path.replace_char('\\', '/');
-
-	switch (_access_type) {
-		case ACCESS_RESOURCES: {
-			if (ProjectSettings::get_singleton()) {
-				if (r_path.begins_with("uid://")) {
-					r_path = ResourceUID::uid_to_path(r_path);
-				}
-
-				if (r_path.begins_with("res://")) {
-					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
-					if (!resource_path.is_empty()) {
-						return r_path.replace("res:/", resource_path);
-					}
-					return r_path.replace("res://", "");
-				}
-			}
-
-		} break;
-		case ACCESS_USERDATA: {
-			if (r_path.begins_with("user://")) {
-				String data_dir = OS::get_singleton()->get_user_data_dir();
-				if (!data_dir.is_empty()) {
-					return r_path.replace("user:/", data_dir);
-				}
-				return r_path.replace("user://", "");
-			}
-
-		} break;
-		case ACCESS_PIPE: {
-			return r_path;
-		} break;
-		case ACCESS_FILESYSTEM: {
-			return r_path;
-		} break;
-		case ACCESS_MAX:
-			break; // Can't happen, but silences warning
+String FileAccess::get_path() const {
+	if (has_path_disguise) {
+		return path_disguise;
 	}
+	return _get_path();
+}
 
-	return r_path;
+String FileAccess::get_path_absolute() const {
+	return _get_path();
 }
 
 /* these are all implemented for ease of porting, then can later be optimized */
@@ -658,105 +563,39 @@ bool FileAccess::store_double(double p_dest) {
 }
 
 uint64_t FileAccess::get_modified_time(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return 0;
-	}
-
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, vformat("Cannot create FileAccess for path '%s'.", p_file));
-
-	return fa->_get_modified_time(p_file);
+	return FileSystem::get_singleton()->get_modified_time(p_file);
 }
 
 uint64_t FileAccess::get_access_time(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return 0;
-	}
-
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, "Cannot create FileAccess for path '" + p_file + "'.");
-
-	return fa->_get_access_time(p_file);
+	return FileSystem::get_singleton()->get_access_time(p_file);
 }
 
 int64_t FileAccess::get_size(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return PackedData::get_singleton()->get_size(p_file);
-	}
-
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), -1, "Cannot create FileAccess for path '" + p_file + "'.");
-
-	return fa->_get_size(p_file);
+	return FileSystem::get_singleton()->get_size(p_file);
 }
 
 BitField<FileAccess::UnixPermissionFlags> FileAccess::get_unix_permissions(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return 0;
-	}
-
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), 0, vformat("Cannot create FileAccess for path '%s'.", p_file));
-
-	return fa->_get_unix_permissions(p_file);
+	return FileSystem::get_singleton()->get_unix_permissions(p_file);
 }
 
 Error FileAccess::set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return ERR_UNAVAILABLE;
-	}
-
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_file));
-
-	Error err = fa->_set_unix_permissions(p_file, p_permissions);
-	return err;
+	return FileSystem::get_singleton()->set_unix_permissions(p_file, p_permissions);
 }
 
 bool FileAccess::get_hidden_attribute(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return false;
-	}
-
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("Cannot create FileAccess for path '%s'.", p_file));
-
-	return fa->_get_hidden_attribute(p_file);
+	return FileSystem::get_singleton()->get_hidden_attribute(p_file);
 }
 
 Error FileAccess::set_hidden_attribute(const String &p_file, bool p_hidden) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return ERR_UNAVAILABLE;
-	}
-
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_file));
-
-	Error err = fa->_set_hidden_attribute(p_file, p_hidden);
-	return err;
+	return FileSystem::get_singleton()->set_hidden_attribute(p_file, p_hidden);
 }
 
 bool FileAccess::get_read_only_attribute(const String &p_file) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return false;
-	}
-
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("Cannot create FileAccess for path '%s'.", p_file));
-
-	return fa->_get_read_only_attribute(p_file);
+	return FileSystem::get_singleton()->get_read_only_attribute(p_file);
 }
 
 Error FileAccess::set_read_only_attribute(const String &p_file, bool p_ro) {
-	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_file) || PackedData::get_singleton()->has_directory(p_file))) {
-		return ERR_UNAVAILABLE;
-	}
-
-	Ref<FileAccess> fa = create_for_path(p_file);
-	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, vformat("Cannot create FileAccess for path '%s'.", p_file));
-
-	Error err = fa->_set_read_only_attribute(p_file, p_ro);
-	return err;
+	return FileSystem::get_singleton()->set_read_only_attribute(p_file, p_ro);
 }
 
 bool FileAccess::store_string(const String &p_string) {

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -45,14 +45,6 @@ class FileAccess : public RefCounted {
 	GDCLASS(FileAccess, RefCounted);
 
 public:
-	enum AccessType : int32_t {
-		ACCESS_RESOURCES,
-		ACCESS_USERDATA,
-		ACCESS_FILESYSTEM,
-		ACCESS_PIPE,
-		ACCESS_MAX
-	};
-
 	enum ModeFlags : int32_t {
 		READ = 1,
 		WRITE = 2,
@@ -85,7 +77,6 @@ public:
 
 	typedef void (*FileCloseFailNotify)(const String &);
 
-	typedef Ref<FileAccess> (*CreateFunc)();
 #ifdef BIG_ENDIAN_ENABLED
 	bool big_endian = true;
 #else
@@ -93,24 +84,10 @@ public:
 #endif
 	bool real_is_double = false;
 
-	virtual BitField<UnixPermissionFlags> _get_unix_permissions(const String &p_file) = 0;
-	virtual Error _set_unix_permissions(const String &p_file, BitField<UnixPermissionFlags> p_permissions) = 0;
-
-	virtual bool _get_hidden_attribute(const String &p_file) = 0;
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) = 0;
-	virtual bool _get_read_only_attribute(const String &p_file) = 0;
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) = 0;
-
 protected:
 	static void _bind_methods();
 
-	AccessType get_access_type() const;
-	virtual String fix_path(const String &p_path) const;
 	virtual Error open_internal(const String &p_path, int p_mode_flags) = 0; ///< open a file
-	virtual uint64_t _get_modified_time(const String &p_file) = 0;
-	virtual uint64_t _get_access_time(const String &p_file) = 0;
-	virtual int64_t _get_size(const String &p_file) = 0;
-	virtual void _set_access_type(AccessType p_access);
 
 	static FileCloseFailNotify close_fail_notify;
 
@@ -139,14 +116,14 @@ private:
 	static bool backup_save;
 	thread_local static Error last_file_open_error;
 
-	AccessType _access_type = ACCESS_FILESYSTEM;
-	static CreateFunc create_func[ACCESS_MAX]; /** default file access creation function for a platform */
-	template <typename T>
-	static Ref<FileAccess> _create_builtin() {
-		return memnew(T);
-	}
-
 	static Ref<FileAccess> _open(const String &p_path, ModeFlags p_mode_flags);
+
+	bool has_path_disguise = false;
+	String path_disguise;
+
+protected:
+	// returns raw path
+	virtual String _get_path() const { return ""; }
 
 	bool _is_temp_file = false;
 	bool _temp_keep_after_use = false;
@@ -156,17 +133,27 @@ private:
 	static Ref<FileAccess> _create_temp(int p_mode_flags, const String &p_prefix = "", const String &p_extension = "", bool p_keep = false);
 
 public:
+	// protocols like res:// and user:// use path disguise to make the file show protocol-prefixed paths.
+	// this replaces path_src variables which keeps a copy of the given path.
+	void set_path_disguise(const String &p_path);
+	void clear_path_disguise();
+
+	// returns whether the file is from os://
+	virtual bool is_os_file() const { return false; }
+
 	static void set_file_close_fail_notify_callback(FileCloseFailNotify p_cbk) { close_fail_notify = p_cbk; }
 
 	virtual bool is_open() const = 0; ///< true when file is open
 
-	virtual String get_path() const { return ""; } /// returns the path for the current open file
-	virtual String get_path_absolute() const { return ""; } /// returns the absolute path for the current open file
+	// shows disguised path when the file path is disguised
+	String get_path() const;
+	// ignores file path disguise and shows the real path.
+	String get_path_absolute() const;
 
-	virtual void seek(uint64_t p_position) = 0; ///< seek to a given position
+	virtual void seek(uint64_t p_position) = 0;
 	virtual void seek_end(int64_t p_position = 0) = 0; ///< seek from the end of file with negative offset
-	virtual uint64_t get_position() const = 0; ///< get position in the file
-	virtual uint64_t get_length() const = 0; ///< get size of the file
+	virtual uint64_t get_position() const = 0;
+	virtual uint64_t get_length() const = 0;
 
 	virtual bool eof_reached() const = 0; ///< reading passed EOF
 
@@ -227,12 +214,6 @@ public:
 
 	virtual void close() = 0;
 
-	virtual bool file_exists(const String &p_name) = 0; ///< return true if a file exists
-
-	virtual Error reopen(const String &p_path, int p_mode_flags); ///< does not change the AccessType
-
-	static Ref<FileAccess> create(AccessType p_access); /// Create a file access (for the current platform) this is the only portable way of accessing files.
-	static Ref<FileAccess> create_for_path(const String &p_path);
 	static Ref<FileAccess> open(const String &p_path, int p_mode_flags, Error *r_error = nullptr); /// Create a file access (for the current platform) this is the only portable way of accessing files.
 	static Ref<FileAccess> create_temp(int p_mode_flags, const String &p_prefix = "", const String &p_extension = "", bool p_keep = false, Error *r_error = nullptr);
 
@@ -241,7 +222,6 @@ public:
 	static Ref<FileAccess> open_compressed(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode = COMPRESSION_FASTLZ);
 	static Error get_open_error();
 
-	static CreateFunc get_create_func(AccessType p_access);
 	static bool exists(const String &p_name); ///< return true if a file exists
 	static uint64_t get_modified_time(const String &p_file);
 	static uint64_t get_access_time(const String &p_file);
@@ -267,12 +247,6 @@ public:
 	static PackedByteArray _get_file_as_bytes(const String &p_path) { return get_file_as_bytes(p_path, &last_file_open_error); }
 	static String _get_file_as_string(const String &p_path) { return get_file_as_string(p_path, &last_file_open_error); }
 
-	template <typename T>
-	static void make_default(AccessType p_access) {
-		create_func[p_access] = _create_builtin<T>;
-	}
-
-public:
 	FileAccess() {}
 	virtual ~FileAccess();
 };

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -30,6 +30,14 @@
 
 #include "file_access_compressed.h"
 
+bool FileAccessCompressed::is_os_file() const {
+	if (f.is_valid()) {
+		return f->is_os_file();
+	} else {
+		return false;
+	}
+}
+
 void FileAccessCompressed::configure(const String &p_magic, Compression::Mode p_mode, uint32_t p_block_size) {
 	magic = p_magic.ascii().get_data();
 	magic = (magic + "    ").substr(0, 4);
@@ -164,17 +172,9 @@ bool FileAccessCompressed::is_open() const {
 	return f.is_valid();
 }
 
-String FileAccessCompressed::get_path() const {
+String FileAccessCompressed::_get_path() const {
 	if (f.is_valid()) {
 		return f->get_path();
-	} else {
-		return "";
-	}
-}
-
-String FileAccessCompressed::get_path_absolute() const {
-	if (f.is_valid()) {
-		return f->get_path_absolute();
 	} else {
 		return "";
 	}
@@ -327,80 +327,6 @@ bool FileAccessCompressed::store_buffer(const uint8_t *p_src, uint64_t p_length)
 
 	write_pos += p_length;
 	return true;
-}
-
-bool FileAccessCompressed::file_exists(const String &p_name) {
-	Ref<FileAccess> fa = FileAccess::open(p_name, FileAccess::READ);
-	if (fa.is_null()) {
-		return false;
-	}
-	return true;
-}
-
-uint64_t FileAccessCompressed::_get_modified_time(const String &p_file) {
-	if (f.is_valid()) {
-		return f->get_modified_time(p_file);
-	} else {
-		return 0;
-	}
-}
-
-uint64_t FileAccessCompressed::_get_access_time(const String &p_file) {
-	if (f.is_valid()) {
-		return f->get_access_time(p_file);
-	} else {
-		return 0;
-	}
-}
-
-int64_t FileAccessCompressed::_get_size(const String &p_file) {
-	if (f.is_valid()) {
-		return f->get_size(p_file);
-	} else {
-		return -1;
-	}
-}
-
-BitField<FileAccess::UnixPermissionFlags> FileAccessCompressed::_get_unix_permissions(const String &p_file) {
-	if (f.is_valid()) {
-		return f->_get_unix_permissions(p_file);
-	}
-	return 0;
-}
-
-Error FileAccessCompressed::_set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
-	if (f.is_valid()) {
-		return f->_set_unix_permissions(p_file, p_permissions);
-	}
-	return FAILED;
-}
-
-bool FileAccessCompressed::_get_hidden_attribute(const String &p_file) {
-	if (f.is_valid()) {
-		return f->_get_hidden_attribute(p_file);
-	}
-	return false;
-}
-
-Error FileAccessCompressed::_set_hidden_attribute(const String &p_file, bool p_hidden) {
-	if (f.is_valid()) {
-		return f->_set_hidden_attribute(p_file, p_hidden);
-	}
-	return FAILED;
-}
-
-bool FileAccessCompressed::_get_read_only_attribute(const String &p_file) {
-	if (f.is_valid()) {
-		return f->_get_read_only_attribute(p_file);
-	}
-	return false;
-}
-
-Error FileAccessCompressed::_set_read_only_attribute(const String &p_file, bool p_ro) {
-	if (f.is_valid()) {
-		return f->_set_read_only_attribute(p_file, p_ro);
-	}
-	return FAILED;
 }
 
 void FileAccessCompressed::close() {

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -64,16 +64,18 @@ class FileAccessCompressed : public FileAccess {
 
 	void _close();
 
+protected:
+	virtual String _get_path() const override; /// returns the path for the current open file
+
 public:
+	virtual bool is_os_file() const override;
+
 	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, uint32_t p_block_size = 4096);
 
 	Error open_after_magic(Ref<FileAccess> p_base);
 
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
-
-	virtual String get_path() const override; /// returns the path for the current open file
-	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file
+	virtual bool is_open() const override; ///< true when file is opens
 
 	virtual void seek(uint64_t p_position) override; ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
@@ -89,19 +91,6 @@ public:
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override;
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override;
-
-	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
-
-	virtual uint64_t _get_modified_time(const String &p_file) override;
-	virtual uint64_t _get_access_time(const String &p_file) override;
-	virtual int64_t _get_size(const String &p_file) override;
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override;
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override;
-
-	virtual bool _get_hidden_attribute(const String &p_file) override;
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override;
-	virtual bool _get_read_only_attribute(const String &p_file) override;
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override;
 
 	virtual void close() override;
 

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -41,6 +41,14 @@ void FileAccessEncrypted::deinitialize() {
 	}
 }
 
+bool FileAccessEncrypted::is_os_file() const {
+	if (file.is_valid()) {
+		return file->is_os_file();
+	} else {
+		return false;
+	}
+}
+
 Error FileAccessEncrypted::open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic, const Vector<uint8_t> &p_iv) {
 	ERR_FAIL_COND_V_MSG(file.is_valid(), ERR_ALREADY_IN_USE, vformat("Can't open file while another file from path '%s' is open.", file->get_path_absolute()));
 	ERR_FAIL_COND_V(p_key.size() != 32, ERR_INVALID_PARAMETER);
@@ -179,17 +187,9 @@ bool FileAccessEncrypted::is_open() const {
 	return file.is_valid();
 }
 
-String FileAccessEncrypted::get_path() const {
+String FileAccessEncrypted::_get_path() const {
 	if (file.is_valid()) {
 		return file->get_path();
-	} else {
-		return "";
-	}
-}
-
-String FileAccessEncrypted::get_path_absolute() const {
-	if (file.is_valid()) {
-		return file->get_path_absolute();
 	} else {
 		return "";
 	}
@@ -268,80 +268,6 @@ void FileAccessEncrypted::flush() {
 	ERR_FAIL_COND_MSG(!writing, "File has not been opened in write mode.");
 
 	// encrypted files keep data in memory till close()
-}
-
-bool FileAccessEncrypted::file_exists(const String &p_name) {
-	Ref<FileAccess> fa = FileAccess::open(p_name, FileAccess::READ);
-	if (fa.is_null()) {
-		return false;
-	}
-	return true;
-}
-
-uint64_t FileAccessEncrypted::_get_modified_time(const String &p_file) {
-	if (file.is_valid()) {
-		return file->get_modified_time(p_file);
-	} else {
-		return 0;
-	}
-}
-
-uint64_t FileAccessEncrypted::_get_access_time(const String &p_file) {
-	if (file.is_valid()) {
-		return file->get_access_time(p_file);
-	} else {
-		return 0;
-	}
-}
-
-int64_t FileAccessEncrypted::_get_size(const String &p_file) {
-	if (file.is_valid()) {
-		return file->get_size(p_file);
-	} else {
-		return -1;
-	}
-}
-
-BitField<FileAccess::UnixPermissionFlags> FileAccessEncrypted::_get_unix_permissions(const String &p_file) {
-	if (file.is_valid()) {
-		return file->_get_unix_permissions(p_file);
-	}
-	return 0;
-}
-
-Error FileAccessEncrypted::_set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
-	if (file.is_valid()) {
-		return file->_set_unix_permissions(p_file, p_permissions);
-	}
-	return FAILED;
-}
-
-bool FileAccessEncrypted::_get_hidden_attribute(const String &p_file) {
-	if (file.is_valid()) {
-		return file->_get_hidden_attribute(p_file);
-	}
-	return false;
-}
-
-Error FileAccessEncrypted::_set_hidden_attribute(const String &p_file, bool p_hidden) {
-	if (file.is_valid()) {
-		return file->_set_hidden_attribute(p_file, p_hidden);
-	}
-	return FAILED;
-}
-
-bool FileAccessEncrypted::_get_read_only_attribute(const String &p_file) {
-	if (file.is_valid()) {
-		return file->_get_read_only_attribute(p_file);
-	}
-	return false;
-}
-
-Error FileAccessEncrypted::_set_read_only_attribute(const String &p_file, bool p_ro) {
-	if (file.is_valid()) {
-		return file->_set_read_only_attribute(p_file, p_ro);
-	}
-	return FAILED;
 }
 
 void FileAccessEncrypted::close() {

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -31,6 +31,7 @@
 #include "file_access_memory.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/filesystem.h"
 
 static HashMap<String, Vector<uint8_t>> *files = nullptr;
 
@@ -63,7 +64,7 @@ Ref<FileAccess> FileAccessMemory::create() {
 }
 
 bool FileAccessMemory::file_exists(const String &p_name) {
-	String name = fix_path(p_name);
+	String name = FileSystem::fix_path(p_name);
 	//name = DirAccess::normalize_path(name);
 
 	return files && (files->find(name) != nullptr);
@@ -79,7 +80,7 @@ Error FileAccessMemory::open_custom(const uint8_t *p_data, uint64_t p_len) {
 Error FileAccessMemory::open_internal(const String &p_path, int p_mode_flags) {
 	ERR_FAIL_NULL_V(files, ERR_FILE_NOT_FOUND);
 
-	String name = fix_path(p_path);
+	String name = FileSystem::fix_path(p_path);
 	//name = DirAccess::normalize_path(name);
 
 	HashMap<String, Vector<uint8_t>>::Iterator E = files->find(name);

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -62,19 +62,7 @@ public:
 	virtual void flush() override;
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
-	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
-
-	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
-	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
-	virtual int64_t _get_size(const String &p_file) override { return -1; }
-
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return FAILED; }
-
-	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
-	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
+	bool file_exists(const String &p_name); ///< return true if a file exists
 
 	virtual void close() override {}
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -31,6 +31,7 @@
 #include "file_access_pack.h"
 
 #include "core/io/file_access_encrypted.h"
+#include "core/io/filesystem.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "core/version.h"
@@ -341,9 +342,7 @@ bool PackedSourceDirectory::try_open_pack(const String &p_path, bool p_replace_f
 }
 
 Ref<FileAccess> PackedSourceDirectory::get_file(const String &p_path, PackedData::PackedFile *p_file) {
-	Ref<FileAccess> ret = FileAccess::create_for_path(p_path);
-	ret->reopen(p_path, FileAccess::READ);
-	return ret;
+	return FileSystem::get_singleton()->open_file(p_path, FileAccess::READ);
 }
 
 void PackedSourceDirectory::add_directory(const String &p_path, bool p_replace_files) {
@@ -453,10 +452,6 @@ void FileAccessPack::flush() {
 
 bool FileAccessPack::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_V(false);
-}
-
-bool FileAccessPack::file_exists(const String &p_name) {
-	return false;
 }
 
 void FileAccessPack::close() {

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -165,16 +165,6 @@ class FileAccessPack : public FileAccess {
 
 	Ref<FileAccess> f;
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override;
-	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
-	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
-	virtual int64_t _get_size(const String &p_file) override { return -1; }
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return FAILED; }
-
-	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
-	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
 
 public:
 	virtual bool is_open() const override;
@@ -195,8 +185,6 @@ public:
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override;
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override;
-
-	virtual bool file_exists(const String &p_name) override;
 
 	virtual void close() override;
 

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -99,18 +99,7 @@ public:
 	virtual void flush() override;
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override;
 
-	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
-
-	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
-	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
-	virtual int64_t _get_size(const String &p_file) override { return -1; }
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return FAILED; }
-
-	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
-	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
+	bool file_exists(const String &p_name); ///< return true if a file exists
 
 	virtual void close() override;
 

--- a/core/io/filesystem.cpp
+++ b/core/io/filesystem.cpp
@@ -1,0 +1,420 @@
+/**************************************************************************/
+/*  filesystem.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "filesystem.h"
+#include "filesystem_protocol_resources.h"
+#include "filesystem_protocol_uid.h"
+#include "filesystem_protocol_user.h"
+
+FileSystem *FileSystem::singleton = nullptr;
+FileSystem *FileSystem::get_singleton() {
+	return singleton;
+}
+FileSystem::FileSystem() {
+	singleton = this;
+
+	underlying_protocol_name_for_resources = protocol_name_os;
+	underlying_protocol_name_for_user = protocol_name_os;
+}
+FileSystem::~FileSystem() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
+const String FileSystem::protocol_name_os = "os";
+const String FileSystem::protocol_name_pipe = "pipe";
+const String FileSystem::protocol_name_resources = "res";
+const String FileSystem::protocol_name_user = "user";
+const String FileSystem::protocol_name_uid = "uid";
+const String FileSystem::protocol_name_gdscript = "gdscript";
+const String FileSystem::protocol_name_memory = "mem";
+
+void FileSystem::register_protocols() {
+	// Register user://
+	Ref<FileSystemProtocol> protocol_os_for_user = get_protocol_or_null(underlying_protocol_name_for_user);
+	ERR_FAIL_COND_MSG(protocol_os_for_user.is_null(), "Cannot get " + underlying_protocol_name_for_user + ":// protocol handler! Make sure you have registered it in OS_XXX::initialize_filesystem()!");
+
+	Ref<FileSystemProtocolUser> protocol_user = Ref<FileSystemProtocolUser>();
+	protocol_user.instantiate(protocol_os_for_user);
+	add_protocol(protocol_name_user, protocol_user);
+
+	// Register res://
+	Ref<FileSystemProtocol> protocol_os_for_res = get_protocol_or_null(underlying_protocol_name_for_resources);
+	ERR_FAIL_COND_MSG(protocol_os_for_res.is_null(), "Cannot get " + underlying_protocol_name_for_resources + ":// protocol handler! Make sure you have registered it in OS_XXX::initialize_filesystem()!");
+
+	Ref<FileSystemProtocolResources> protocol_resources = Ref<FileSystemProtocolResources>();
+	protocol_resources.instantiate(protocol_os_for_res);
+	add_protocol(protocol_name_resources, protocol_resources);
+
+	// Register uid://
+	Ref<FileSystemProtocolUID> protocol_uid = Ref<FileSystemProtocolUID>();
+	protocol_uid.instantiate(protocol_resources);
+	add_protocol(protocol_name_uid, protocol_uid);
+
+	// gdscript:// represents a script instance in memory.
+	// We reserve it and make it a placeholder which fails all accesses silently
+	// to prevent stepping in the old code.
+	Ref<FileSystemProtocol> protocol_gdscript = Ref<FileSystemProtocol>();
+	protocol_gdscript.instantiate();
+	add_protocol(protocol_name_gdscript, protocol_gdscript);
+}
+
+bool FileSystem::has_protocol(const String &p_name) const {
+	_THREAD_SAFE_METHOD_
+
+	return protocols.has(p_name);
+}
+bool FileSystem::remove_protocol(const String &p_name) {
+	_THREAD_SAFE_METHOD_
+
+	bool erased = protocols.erase(p_name);
+	ERR_FAIL_COND_V_MSG(!erased, false, "No FileSystemProtocol with the name " + p_name + " is registered.");
+	return erased;
+}
+bool FileSystem::add_protocol(const String &p_name, const Ref<FileSystemProtocol> &p_protocol) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND_V_MSG(protocols.has(p_name), false, "FileSystemProtocol with the name " + p_name + " is already registered.");
+	protocols[p_name] = p_protocol;
+	return true;
+}
+Ref<FileSystemProtocol> FileSystem::get_protocol_or_null(const String &p_name) const {
+	_THREAD_SAFE_METHOD_
+
+	HashMap<String, Ref<FileSystemProtocol>>::ConstIterator iter = protocols.find(p_name);
+	if (!iter) {
+		return Ref<FileSystemProtocol>();
+	}
+	return iter->value;
+}
+Ref<FileSystemProtocol> FileSystem::get_protocol(const String &p_name) const {
+	Ref<FileSystemProtocol> protocol = get_protocol_or_null(p_name);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), Ref<FileSystemProtocol>(), "FileSystemProtocol with name " + p_name + " doesn't exist!");
+	return protocol;
+}
+
+bool FileSystem::try_find_protocol_in_path(const String &p_path, int *r_protocol_name_end, int *r_file_path_start) {
+	int index = p_path.find("://");
+	if (index < 0) {
+		return false;
+	}
+
+	for (int i = 0; i < index; i++) {
+		if (!is_ascii_protocol_name_char(p_path[i])) {
+			return false;
+		}
+	}
+
+	if (r_protocol_name_end) {
+		*r_protocol_name_end = index;
+	}
+	if (r_file_path_start) {
+		*r_file_path_start = index + 3;
+	}
+	return true;
+}
+
+String FileSystem::fix_path(const String &p_path) {
+	String r_path = p_path.replace("\\", "/");
+
+	return r_path;
+}
+
+void FileSystem::set_os_path_case_mismatch_checker(OSPathCaseMismatchChecker p_checker) {
+	os_path_case_mismatch_checker = p_checker;
+}
+
+bool FileSystem::split_path(const String &p_path, String *r_protocol_name, String *r_file_path) {
+	int protocol_name_end;
+	int file_path_start;
+	if (!try_find_protocol_in_path(p_path, &protocol_name_end, &file_path_start)) {
+		if (r_protocol_name != nullptr) {
+			*r_protocol_name = "";
+		}
+		if (r_file_path != nullptr) {
+			*r_file_path = p_path;
+		}
+		return false;
+	}
+
+	if (r_protocol_name != nullptr) {
+		*r_protocol_name = p_path.substr(0, protocol_name_end);
+	}
+	if (r_file_path != nullptr) {
+		*r_file_path = p_path.substr(file_path_start);
+	}
+	return true;
+}
+
+void FileSystem::process_path(const String &p_path, String *r_protocol_name, Ref<FileSystemProtocol> *r_protocol, String *r_file_path) const {
+	// protocol name is needed for fetching protocol objects
+	String protocol_name = "";
+	bool has_protcol_part = split_path(p_path, &protocol_name, r_file_path);
+	if (!has_protcol_part) {
+		protocol_name = protocol_name_os;
+	}
+	if (r_protocol_name != nullptr) {
+		*r_protocol_name = protocol_name;
+	}
+	if (r_protocol != nullptr) {
+		*r_protocol = get_protocol_or_null(protocol_name);
+	}
+	return;
+}
+
+String FileSystem::globalize_path(const String &p_path) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), String(), "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->globalize_path(file_path);
+}
+
+String FileSystem::globalize_path_or_fallback(const String &p_path) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), file_path, "Unknown filesystem protocol " + protocol_name);
+
+	String result = protocol->globalize_path(file_path);
+	if (result.is_empty()) {
+		return file_path;
+	}
+
+	return result;
+}
+
+Ref<FileAccess> FileSystem::open_file(const String &p_path, int p_mode_flags, Error *r_error) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), Ref<FileAccess>(), "Unknown filesystem protocol " + protocol_name);
+
+	Error err;
+	Ref<FileAccess> file = protocol->open_file(file_path, p_mode_flags, err);
+	if (file.is_valid()) {
+		protocol->disguise_file(file, protocol_name, file_path);
+	}
+	if (r_error) {
+		*r_error = err;
+	}
+
+#if TOOLS_ENABLED
+	// Some platforms can be case insensitive, but other platforms are typically sensitive to it.
+	// To ease cross-platform development, we issue a warning if users try to access a file using
+	// the wrong case (which *works* on some platforms, but won't on others),
+	// we only check for relative OS paths, or non-OS paths like res:// and user://,
+	// since other paths aren't likely to be portable anyway.
+	// This feature is elevated from Windows FileAccess to here, because protocol prefixs
+	// are stripped from the path when given to FileAccesses.
+	if (!err && os_path_case_mismatch_checker) {
+		Ref<FileSystemProtocol> protocol_os = get_protocol(protocol_name_os);
+		if (protocol != protocol_os || file_path.is_relative_path()) {
+			String check_file_path = "";
+			String check_base_path = "";
+			bool can_check = true;
+
+			if (protocol == protocol_os) {
+				// open path is a relative OS path.
+				check_file_path = file_path;
+
+			} else if (file->is_os_file()) {
+				// open path is a non-OS path, but the open file is pointed OS.
+				check_file_path = file->get_path_absolute();
+				// globalize base path to OS absolute path.
+				check_base_path = protocol->globalize_path("");
+
+				// both paths should have valid OS path for the check to continue
+				can_check = !check_file_path.is_empty() && !check_base_path.is_empty();
+
+			} else {
+				can_check = false;
+			}
+
+			String check_file_rel_path;
+			if (can_check) {
+				// get the relative path from the base path to file path.
+				check_file_rel_path = check_base_path.path_to_file(check_file_path);
+				// file path should be in sub-tree of base path for the check to continue
+				can_check = check_file_rel_path != check_file_path;
+			}
+
+			if (can_check) {
+				String proper_rel_path;
+				bool mismatch = (*os_path_case_mismatch_checker)(check_base_path, check_file_path, proper_rel_path);
+				if (mismatch) {
+					String proper_path = "";
+					if (!protocol_name.is_empty()) {
+						proper_path = protocol_name + "://";
+					}
+					proper_path += proper_rel_path;
+					WARN_PRINT("Case mismatch opening requested file '" + p_path + "', stored as '" + proper_path + "' in the filesystem. This file will not open when exported to other case-sensitive platforms.");
+				}
+			}
+		}
+	}
+#endif
+
+	return file;
+}
+bool FileSystem::file_exists(const String &p_path) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), false, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->file_exists(file_path);
+}
+
+Error FileSystem::get_open_error() const {
+	return open_error;
+}
+Ref<FileAccess> FileSystem::_open_file(const String &p_path, int p_mode_flags) {
+	return open_file(p_path, p_mode_flags, &open_error);
+}
+
+uint64_t FileSystem::get_modified_time(const String &p_path) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), 0, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->get_modified_time(file_path);
+}
+
+uint64_t FileSystem::get_access_time(const String &p_path) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), 0, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->get_access_time(file_path);
+}
+int64_t FileSystem::get_size(const String &p_path) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), 0, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->get_size(file_path);
+}
+
+BitField<FileAccess::UnixPermissionFlags> FileSystem::get_unix_permissions(const String &p_path) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), 0, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->get_unix_permissions(file_path);
+}
+Error FileSystem::set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), ERR_FILE_BAD_PATH, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->set_unix_permissions(file_path, p_permissions);
+}
+bool FileSystem::get_hidden_attribute(const String &p_path) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), false, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->get_hidden_attribute(file_path);
+}
+Error FileSystem::set_hidden_attribute(const String &p_path, bool p_hidden) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), ERR_FILE_BAD_PATH, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->set_hidden_attribute(file_path, p_hidden);
+}
+bool FileSystem::get_read_only_attribute(const String &p_path) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), false, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->get_read_only_attribute(file_path);
+}
+Error FileSystem::set_read_only_attribute(const String &p_path, bool p_ro) const {
+	String protocol_name = String();
+	Ref<FileSystemProtocol> protocol = Ref<FileSystemProtocol>();
+	String file_path = String();
+	process_path(p_path, &protocol_name, &protocol, &file_path);
+	ERR_FAIL_COND_V_MSG(protocol.is_null(), ERR_FILE_BAD_PATH, "Unknown filesystem protocol " + protocol_name);
+
+	return protocol->set_read_only_attribute(file_path, p_ro);
+}
+
+void FileSystem::set_underlying_protocol_name_for_resources(const String &name) {
+	underlying_protocol_name_for_resources = name;
+}
+void FileSystem::set_underlying_protocol_name_for_user(const String &name) {
+	underlying_protocol_name_for_user = name;
+}
+
+void FileSystem::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("has_protocol", "name"), &FileSystem::has_protocol);
+	ClassDB::bind_method(D_METHOD("remove_protocol", "name"), &FileSystem::remove_protocol);
+	ClassDB::bind_method(D_METHOD("add_protocol", "name", "protocol"), &FileSystem::add_protocol);
+	ClassDB::bind_method(D_METHOD("get_protocol_or_null", "name"), &FileSystem::get_protocol_or_null);
+	ClassDB::bind_method(D_METHOD("get_protocol", "name"), &FileSystem::get_protocol);
+
+	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &FileSystem::globalize_path);
+
+	ClassDB::bind_method(D_METHOD("get_open_error"), &FileSystem::get_open_error);
+	ClassDB::bind_method(D_METHOD("open_file", "path", "mode_flags"), &FileSystem::_open_file);
+	ClassDB::bind_method(D_METHOD("file_exists", "name"), &FileSystem::file_exists);
+
+	ClassDB::bind_method(D_METHOD("get_modified_time", "path"), &FileSystem::get_modified_time);
+	ClassDB::bind_method(D_METHOD("get_unix_permissions", "path"), &FileSystem::get_unix_permissions);
+	ClassDB::bind_method(D_METHOD("set_unix_permissions", "path", "permissions"), &FileSystem::set_unix_permissions);
+	ClassDB::bind_method(D_METHOD("get_hidden_attribute", "path"), &FileSystem::get_hidden_attribute);
+	ClassDB::bind_method(D_METHOD("set_hidden_attribute", "path", "hidden"), &FileSystem::set_hidden_attribute);
+	ClassDB::bind_method(D_METHOD("get_read_only_attribute", "path"), &FileSystem::get_read_only_attribute);
+	ClassDB::bind_method(D_METHOD("set_read_only_attribute", "path", "ro"), &FileSystem::set_read_only_attribute);
+}

--- a/core/io/filesystem.h
+++ b/core/io/filesystem.h
@@ -1,0 +1,123 @@
+/**************************************************************************/
+/*  filesystem.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/file_access.h"
+#include "core/object/ref_counted.h"
+#include "filesystem_protocol.h"
+
+class FileSystem : public Object {
+	GDCLASS(FileSystem, Object);
+
+protected:
+	static void _bind_methods();
+
+public:
+	typedef bool (*OSPathCaseMismatchChecker)(const String &p_base_path, const String &p_rel_path, String &r_proper_rel_path);
+
+private:
+	static FileSystem *singleton;
+
+	_THREAD_SAFE_CLASS_
+
+	HashMap<String, Ref<FileSystemProtocol>> protocols;
+
+	// for paths that doesn't have the protocol part, it fallsback to os://
+	// if r_protocol returns null ref, the protocol of the path targeted is invalid.
+	void process_path(const String &p_path, String *r_protocol_name, Ref<FileSystemProtocol> *r_protocol, String *r_file_path) const;
+
+	Error open_error = OK;
+	Ref<FileAccess> _open_file(const String &p_path, int p_mode_flags);
+
+	friend class Main;
+
+	void register_protocols();
+
+	String underlying_protocol_name_for_resources;
+	String underlying_protocol_name_for_user;
+
+	OSPathCaseMismatchChecker os_path_case_mismatch_checker = nullptr;
+
+public:
+	// out values are only valid when method returns true
+	static bool try_find_protocol_in_path(const String &p_path, int *r_protocol_name_end, int *r_file_path_start);
+	// returns whether it found a protocol present in the path
+	static bool split_path(const String &p_path, String *r_protocol_name, String *r_file_path);
+
+	static const String protocol_name_os;
+	static const String protocol_name_pipe;
+	static const String protocol_name_resources;
+	static const String protocol_name_user;
+	static const String protocol_name_uid;
+	static const String protocol_name_gdscript;
+	static const String protocol_name_memory;
+
+	FileSystem();
+	~FileSystem();
+	static FileSystem *get_singleton();
+
+	bool has_protocol(const String &p_protocol) const;
+	bool add_protocol(const String &p_name, const Ref<FileSystemProtocol> &p_protocol);
+	bool remove_protocol(const String &p_name);
+	Ref<FileSystemProtocol> get_protocol(const String &p_name) const;
+	Ref<FileSystemProtocol> get_protocol_or_null(const String &p_name) const;
+
+	// Basic path fix.
+	static String fix_path(const String &p_path);
+
+	void set_os_path_case_mismatch_checker(OSPathCaseMismatchChecker p_checker);
+
+	Error get_open_error() const;
+
+	// If failed, returns empty string
+	// !! NOT !! the same behavior as the original ProjectSettings::globalize_path
+	String globalize_path(const String &path) const;
+
+	// If failed, returns file path without protocol part
+	// The same behavior as the original ProjectSettings:globalize_path
+	String globalize_path_or_fallback(const String &path) const;
+
+	Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error *r_error = nullptr) const;
+	bool file_exists(const String &p_path) const;
+
+	uint64_t get_modified_time(const String &p_path) const;
+	uint64_t get_access_time(const String &p_path) const;
+	int64_t get_size(const String &p_path) const;
+	BitField<FileAccess::UnixPermissionFlags> get_unix_permissions(const String &p_path) const;
+	Error set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const;
+	bool get_hidden_attribute(const String &p_path) const;
+	Error set_hidden_attribute(const String &p_path, bool p_hidden) const;
+	bool get_read_only_attribute(const String &p_path) const;
+	Error set_read_only_attribute(const String &p_path, bool p_ro) const;
+
+	void set_underlying_protocol_name_for_resources(const String &name);
+	void set_underlying_protocol_name_for_user(const String &name);
+};

--- a/core/io/filesystem_protocol.cpp
+++ b/core/io/filesystem_protocol.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol.cpp                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,70 +28,36 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#include "filesystem_protocol.h"
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+Error FileSystemProtocol::get_open_error() const {
+	return open_error;
+}
+Ref<FileAccess> FileSystemProtocol::_open_file(const String &p_path, int p_mode_flags) {
+	return open_file(p_path, p_mode_flags, open_error);
+}
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
+Ref<FileAccess> FileSystemProtocol::open_file(const String &p_path, int p_mode_flags, Error &r_error) const {
+	r_error = ERR_FILE_NOT_FOUND;
+	return Ref<FileAccess>();
+}
 
-class FileAccessEncrypted : public FileAccess {
-public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+void FileSystemProtocol::disguise_file(const Ref<FileAccess> &p_file, const String &p_protocol_name, const String &p_path) const {
+	p_file->set_path_disguise(p_protocol_name + "://" + p_path);
+}
 
-private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
+void FileSystemProtocol::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &FileSystemProtocol::globalize_path);
 
-	void _close();
+	ClassDB::bind_method(D_METHOD("get_open_error"), &FileSystemProtocol::get_open_error);
+	ClassDB::bind_method(D_METHOD("open_file", "path", "mode_flags"), &FileSystemProtocol::_open_file);
+	ClassDB::bind_method(D_METHOD("file_exists", "name"), &FileSystemProtocol::file_exists);
 
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
-
-public:
-	virtual bool is_os_file() const override;
-
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
-
-	Vector<uint8_t> get_iv() const { return iv; }
-
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
-
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
-};
+	ClassDB::bind_method(D_METHOD("get_modified_time", "path"), &FileSystemProtocol::get_modified_time);
+	ClassDB::bind_method(D_METHOD("get_unix_permissions", "path"), &FileSystemProtocol::get_unix_permissions);
+	ClassDB::bind_method(D_METHOD("set_unix_permissions", "path", "permissions"), &FileSystemProtocol::set_unix_permissions);
+	ClassDB::bind_method(D_METHOD("get_hidden_attribute", "path"), &FileSystemProtocol::get_hidden_attribute);
+	ClassDB::bind_method(D_METHOD("set_hidden_attribute", "path", "hidden"), &FileSystemProtocol::set_hidden_attribute);
+	ClassDB::bind_method(D_METHOD("get_read_only_attribute", "path"), &FileSystemProtocol::get_read_only_attribute);
+	ClassDB::bind_method(D_METHOD("set_read_only_attribute", "path", "ro"), &FileSystemProtocol::set_read_only_attribute);
+}

--- a/core/io/filesystem_protocol.h
+++ b/core/io/filesystem_protocol.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol.h                                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,68 +30,37 @@
 
 #pragma once
 
-#include "core/crypto/crypto_core.h"
 #include "core/io/file_access.h"
+#include "core/object/ref_counted.h"
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
-
-class FileAccessEncrypted : public FileAccess {
-public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+// File paths without the protocol part are sent in.
+class FileSystemProtocol : public RefCounted {
+	GDCLASS(FileSystemProtocol, RefCounted);
 
 private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
-
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
+	Error open_error;
+	Ref<FileAccess> _open_file(const String &p_path, int p_mode_flags);
 
 protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
+	static void _bind_methods();
 
 public:
-	virtual bool is_os_file() const override;
+	Error get_open_error() const;
 
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
+	virtual String globalize_path(const String &p_path) const { return String(); }
 
-	Vector<uint8_t> get_iv() const { return iv; }
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const;
+	virtual bool file_exists(const String &p_path) const { return false; }
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
+	virtual void disguise_file(const Ref<FileAccess> &p_file, const String &p_protocol_name, const String &p_path) const;
 
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
+	virtual uint64_t get_modified_time(const String &p_path) const { return 0; }
+	virtual uint64_t get_access_time(const String &p_path) const { return 0; }
+	virtual int64_t get_size(const String &p_path) const { return -1; }
+	virtual BitField<FileAccess::UnixPermissionFlags> get_unix_permissions(const String &p_path) const { return 0; }
+	virtual Error set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const { return ERR_UNAVAILABLE; }
+	virtual bool get_hidden_attribute(const String &p_path) const { return false; }
+	virtual Error set_hidden_attribute(const String &p_path, bool p_hidden) const { return ERR_UNAVAILABLE; }
+	virtual bool get_read_only_attribute(const String &p_path) const { return false; }
+	virtual Error set_read_only_attribute(const String &p_path, bool p_ro) const { return ERR_UNAVAILABLE; }
 };

--- a/core/io/filesystem_protocol_resources.cpp
+++ b/core/io/filesystem_protocol_resources.cpp
@@ -1,0 +1,149 @@
+/**************************************************************************/
+/*  filesystem_protocol_resources.cpp                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "filesystem_protocol_resources.h"
+#include "core/config/project_settings.h"
+#include "core/io/file_access_pack.h"
+#include "core/io/filesystem.h"
+#include "core/os/os.h"
+
+FileSystemProtocolResources::FileSystemProtocolResources() {}
+FileSystemProtocolResources::FileSystemProtocolResources(const Ref<FileSystemProtocol> &p_protocol_os) {
+	set_protocol_os(p_protocol_os);
+}
+void FileSystemProtocolResources::set_protocol_os(const Ref<FileSystemProtocol> &p_protocol_os) {
+	protocol_os = p_protocol_os;
+}
+
+String FileSystemProtocolResources::globalize_path(const String &p_path) const {
+	String resource_path = ProjectSettings::get_singleton()->get_resource_path();
+	if (!resource_path.is_empty()) {
+		return resource_path + "/" + p_path;
+	} else {
+		return String();
+	}
+}
+Ref<FileAccess> FileSystemProtocolResources::open_file(const String &p_path, int p_mode_flags, Error &r_error) const {
+	//try packed data first
+	if (!(p_mode_flags & FileAccess::WRITE) && PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled()) {
+		Ref<FileAccess> file = PackedData::get_singleton()->try_open_path("res://" + p_path);
+		if (file.is_valid()) {
+			r_error = OK;
+			return file;
+		}
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->open_file(path, p_mode_flags, r_error);
+}
+bool FileSystemProtocolResources::file_exists(const String &p_path) const {
+	// TODO: Replace this with resource mounting stack
+
+	//try packed data first
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && PackedData::get_singleton()->has_path("res://" + p_path)) {
+		return true;
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->file_exists(path);
+}
+
+uint64_t FileSystemProtocolResources::get_modified_time(const String &p_path) const {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return 0;
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->get_modified_time(path);
+}
+uint64_t FileSystemProtocolResources::get_access_time(const String &p_path) const {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return 0;
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->get_access_time(path);
+}
+int64_t FileSystemProtocolResources::get_size(const String &p_path) const {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return PackedData::get_singleton()->get_size(p_path);
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->get_size(path);
+}
+BitField<FileAccess::UnixPermissionFlags> FileSystemProtocolResources::get_unix_permissions(const String &p_path) const {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return 0;
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->get_unix_permissions(path);
+}
+Error FileSystemProtocolResources::set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return ERR_UNAVAILABLE;
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->set_unix_permissions(path, p_permissions);
+}
+bool FileSystemProtocolResources::get_hidden_attribute(const String &p_path) const {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return false;
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->get_hidden_attribute(path);
+}
+Error FileSystemProtocolResources::set_hidden_attribute(const String &p_path, bool p_hidden) const {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return ERR_UNAVAILABLE;
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->set_hidden_attribute(path, p_hidden);
+}
+bool FileSystemProtocolResources::get_read_only_attribute(const String &p_path) const {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return false;
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->get_read_only_attribute(path);
+}
+Error FileSystemProtocolResources::set_read_only_attribute(const String &p_path, bool p_ro) const {
+	if (PackedData::get_singleton() && !PackedData::get_singleton()->is_disabled() && (PackedData::get_singleton()->has_path(p_path) || PackedData::get_singleton()->has_directory(p_path))) {
+		return ERR_UNAVAILABLE;
+	}
+
+	String path = globalize_path(p_path);
+	return protocol_os->set_read_only_attribute(path, p_ro);
+}

--- a/core/io/filesystem_protocol_resources.h
+++ b/core/io/filesystem_protocol_resources.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_resources.h                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,68 +30,32 @@
 
 #pragma once
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#include "core/io/filesystem_protocol.h"
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
-
-class FileAccessEncrypted : public FileAccess {
-public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+class FileSystemProtocolResources : public FileSystemProtocol {
+	GDCLASS(FileSystemProtocolResources, FileSystemProtocol);
 
 private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
-
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
+	Ref<FileSystemProtocol> protocol_os;
 
 public:
-	virtual bool is_os_file() const override;
+	FileSystemProtocolResources();
+	FileSystemProtocolResources(const Ref<FileSystemProtocol> &p_protocol_os);
 
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
+	void set_protocol_os(const Ref<FileSystemProtocol> &p_protocol_os);
 
-	Vector<uint8_t> get_iv() const { return iv; }
+	virtual String globalize_path(const String &p_path) const override;
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const override;
+	virtual bool file_exists(const String &p_path) const override;
 
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
+	virtual uint64_t get_modified_time(const String &p_path) const override;
+	virtual uint64_t get_access_time(const String &p_path) const override;
+	virtual int64_t get_size(const String &p_path) const override;
+	virtual BitField<FileAccess::UnixPermissionFlags> get_unix_permissions(const String &p_path) const override;
+	virtual Error set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const override;
+	virtual bool get_hidden_attribute(const String &p_path) const override;
+	virtual Error set_hidden_attribute(const String &p_path, bool p_hidden) const override;
+	virtual bool get_read_only_attribute(const String &p_path) const override;
+	virtual Error set_read_only_attribute(const String &p_path, bool p_ro) const override;
 };

--- a/core/io/filesystem_protocol_uid.cpp
+++ b/core/io/filesystem_protocol_uid.cpp
@@ -1,0 +1,87 @@
+/**************************************************************************/
+/*  filesystem_protocol_uid.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "filesystem_protocol_uid.h"
+#include "core/io/filesystem.h"
+#include "core/os/os.h"
+
+FileSystemProtocolUID::FileSystemProtocolUID() {}
+FileSystemProtocolUID::FileSystemProtocolUID(const Ref<FileSystemProtocol> &p_protocol_res) {
+	set_protocol_resources(p_protocol_res);
+}
+
+void FileSystemProtocolUID::set_protocol_resources(const Ref<FileSystemProtocol> &p_protocol_res) {
+	this->protocol_res = p_protocol_res;
+}
+
+String FileSystemProtocolUID::get_next_path(const String &p_path) const {
+	return ResourceUID::uid_to_path(p_path);
+}
+
+String FileSystemProtocolUID::globalize_path(const String &p_path) const {
+	return protocol_res->globalize_path(get_next_path(p_path));
+}
+Ref<FileAccess> FileSystemProtocolUID::open_file(const String &p_path, int p_mode_flags, Error &r_error) const {
+	String path = globalize_path(p_path);
+	return protocol_res->open_file(path, p_mode_flags, r_error);
+}
+bool FileSystemProtocolUID::file_exists(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_res->file_exists(path);
+}
+
+uint64_t FileSystemProtocolUID::get_modified_time(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_res->get_modified_time(path);
+}
+BitField<FileAccess::UnixPermissionFlags> FileSystemProtocolUID::get_unix_permissions(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_res->get_unix_permissions(path);
+}
+Error FileSystemProtocolUID::set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const {
+	String path = globalize_path(p_path);
+	return protocol_res->set_unix_permissions(path, p_permissions);
+}
+bool FileSystemProtocolUID::get_hidden_attribute(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_res->get_hidden_attribute(path);
+}
+Error FileSystemProtocolUID::set_hidden_attribute(const String &p_path, bool p_hidden) const {
+	String path = globalize_path(p_path);
+	return protocol_res->set_hidden_attribute(path, p_hidden);
+}
+bool FileSystemProtocolUID::get_read_only_attribute(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_res->get_read_only_attribute(path);
+}
+Error FileSystemProtocolUID::set_read_only_attribute(const String &p_path, bool p_ro) const {
+	String path = globalize_path(p_path);
+	return protocol_res->set_read_only_attribute(path, p_ro);
+}

--- a/core/io/filesystem_protocol_uid.h
+++ b/core/io/filesystem_protocol_uid.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_uid.h                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,68 +30,31 @@
 
 #pragma once
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#include "core/io/filesystem_protocol.h"
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
-
-class FileAccessEncrypted : public FileAccess {
-public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+class FileSystemProtocolUID : public FileSystemProtocol {
+	GDCLASS(FileSystemProtocolUID, FileSystemProtocol);
 
 private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
-
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
+	Ref<FileSystemProtocol> protocol_res;
+	String get_next_path(const String &p_path) const;
 
 public:
-	virtual bool is_os_file() const override;
+	FileSystemProtocolUID();
+	FileSystemProtocolUID(const Ref<FileSystemProtocol> &p_protocol_res);
 
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
+	void set_protocol_resources(const Ref<FileSystemProtocol> &p_protocol_res);
 
-	Vector<uint8_t> get_iv() const { return iv; }
+	virtual String globalize_path(const String &p_path) const override;
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const override;
+	virtual bool file_exists(const String &p_path) const override;
 
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
+	virtual uint64_t get_modified_time(const String &p_path) const override;
+	virtual BitField<FileAccess::UnixPermissionFlags> get_unix_permissions(const String &p_path) const override;
+	virtual Error set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const override;
+	virtual bool get_hidden_attribute(const String &p_path) const override;
+	virtual Error set_hidden_attribute(const String &p_path, bool p_hidden) const override;
+	virtual bool get_read_only_attribute(const String &p_path) const override;
+	virtual Error set_read_only_attribute(const String &p_path, bool p_ro) const override;
 };

--- a/core/io/filesystem_protocol_user.cpp
+++ b/core/io/filesystem_protocol_user.cpp
@@ -1,0 +1,87 @@
+/**************************************************************************/
+/*  filesystem_protocol_user.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "filesystem_protocol_user.h"
+#include "core/io/filesystem.h"
+#include "core/os/os.h"
+
+FileSystemProtocolUser::FileSystemProtocolUser() {}
+FileSystemProtocolUser::FileSystemProtocolUser(const Ref<FileSystemProtocol> &p_protocol_os) {
+	set_protocol_os(p_protocol_os);
+}
+void FileSystemProtocolUser::set_protocol_os(const Ref<FileSystemProtocol> &p_protocol_os) {
+	protocol_os = p_protocol_os;
+}
+
+String FileSystemProtocolUser::globalize_path(const String &p_path) const {
+	String data_dir = OS::get_singleton()->get_user_data_dir();
+	if (!data_dir.is_empty()) {
+		return data_dir + "/" + p_path;
+	} else {
+		return String();
+	}
+}
+Ref<FileAccess> FileSystemProtocolUser::open_file(const String &p_path, int p_mode_flags, Error &r_error) const {
+	String path = globalize_path(p_path);
+	return protocol_os->open_file(path, p_mode_flags, r_error);
+}
+bool FileSystemProtocolUser::file_exists(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_os->file_exists(path);
+}
+
+uint64_t FileSystemProtocolUser::get_modified_time(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_os->get_modified_time(path);
+}
+BitField<FileAccess::UnixPermissionFlags> FileSystemProtocolUser::get_unix_permissions(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_os->get_unix_permissions(path);
+}
+Error FileSystemProtocolUser::set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const {
+	String path = globalize_path(p_path);
+	return protocol_os->set_unix_permissions(path, p_permissions);
+}
+bool FileSystemProtocolUser::get_hidden_attribute(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_os->get_hidden_attribute(path);
+}
+Error FileSystemProtocolUser::set_hidden_attribute(const String &p_path, bool p_hidden) const {
+	String path = globalize_path(p_path);
+	return protocol_os->set_hidden_attribute(path, p_hidden);
+}
+bool FileSystemProtocolUser::get_read_only_attribute(const String &p_path) const {
+	String path = globalize_path(p_path);
+	return protocol_os->get_read_only_attribute(path);
+}
+Error FileSystemProtocolUser::set_read_only_attribute(const String &p_path, bool p_ro) const {
+	String path = globalize_path(p_path);
+	return protocol_os->set_read_only_attribute(path, p_ro);
+}

--- a/core/io/filesystem_protocol_user.h
+++ b/core/io/filesystem_protocol_user.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_user.h                                            */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,68 +30,30 @@
 
 #pragma once
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#include "core/io/filesystem_protocol.h"
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
-
-class FileAccessEncrypted : public FileAccess {
-public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+class FileSystemProtocolUser : public FileSystemProtocol {
+	GDCLASS(FileSystemProtocolUser, FileSystemProtocol);
 
 private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
-
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
+	Ref<FileSystemProtocol> protocol_os;
 
 public:
-	virtual bool is_os_file() const override;
+	FileSystemProtocolUser();
+	FileSystemProtocolUser(const Ref<FileSystemProtocol> &p_protocol_os);
 
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
+	void set_protocol_os(const Ref<FileSystemProtocol> &p_protocol_os);
 
-	Vector<uint8_t> get_iv() const { return iv; }
+	virtual String globalize_path(const String &p_path) const override;
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const override;
+	virtual bool file_exists(const String &p_path) const override;
 
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
+	virtual uint64_t get_modified_time(const String &p_path) const override;
+	virtual BitField<FileAccess::UnixPermissionFlags> get_unix_permissions(const String &p_path) const override;
+	virtual Error set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const override;
+	virtual bool get_hidden_attribute(const String &p_path) const override;
+	virtual Error set_hidden_attribute(const String &p_path, bool p_hidden) const override;
+	virtual bool get_read_only_attribute(const String &p_path) const override;
+	virtual Error set_read_only_attribute(const String &p_path, bool p_ro) const override;
 };

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -34,6 +34,7 @@
 #include "core/core_bind.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/io/filesystem.h"
 #include "core/io/resource_importer.h"
 #include "core/object/script_language.h"
 #include "core/os/condition_variable.h"
@@ -343,8 +344,7 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 			vformat("Failed loading resource: %s. Make sure resources have been imported by opening the project in the editor at least once.", p_path));
 
 #ifdef TOOLS_ENABLED
-	Ref<FileAccess> file_check = FileAccess::create(FileAccess::ACCESS_RESOURCES);
-	if (!file_check->file_exists(p_path)) {
+	if (!FileSystem::get_singleton()->file_exists(p_path)) {
 		if (r_error) {
 			*r_error = ERR_FILE_NOT_FOUND;
 		}

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -114,6 +114,8 @@ protected:
 	void add_logger(Logger *p_logger);
 
 	virtual void initialize() = 0;
+	virtual void initialize_filesystem() = 0;
+	virtual void initialize_filesystem_additional() {}
 	virtual void initialize_joypads() = 0;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) = 0;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -46,6 +46,8 @@
 #include "core/io/dir_access.h"
 #include "core/io/dtls_server.h"
 #include "core/io/file_access_encrypted.h"
+#include "core/io/filesystem.h"
+#include "core/io/filesystem_protocol.h"
 #include "core/io/http_client.h"
 #include "core/io/image_loader.h"
 #include "core/io/json.h"
@@ -249,6 +251,7 @@ void register_core_types() {
 	GDREGISTER_CLASS(ResourceFormatLoader);
 	GDREGISTER_CLASS(ResourceFormatSaver);
 
+	GDREGISTER_ABSTRACT_CLASS(FileSystemProtocol);
 	GDREGISTER_ABSTRACT_CLASS(FileAccess);
 	GDREGISTER_ABSTRACT_CLASS(DirAccess);
 	GDREGISTER_CLASS(CoreBind::Thread);
@@ -335,6 +338,9 @@ void register_early_core_singletons() {
 
 	GDREGISTER_CLASS(Time);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Time", Time::get_singleton()));
+
+	GDREGISTER_CLASS(FileSystem);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("FileSystem", FileSystem::get_singleton()));
 }
 
 void register_core_singletons() {

--- a/core/string/char_utils.h
+++ b/core/string/char_utils.h
@@ -108,6 +108,10 @@ constexpr bool is_ascii_alphanumeric_char(char32_t p_char) {
 	return (p_char >= 'a' && p_char <= 'z') || (p_char >= 'A' && p_char <= 'Z') || (p_char >= '0' && p_char <= '9');
 }
 
+constexpr bool is_ascii_protocol_name_char(char32_t p_char) {
+	return (p_char >= 'a' && p_char <= 'z') || (p_char >= 'A' && p_char <= 'Z') || (p_char >= '0' && p_char <= '9') || p_char == '_' || p_char == '-';
+}
+
 constexpr bool is_ascii_identifier_char(char32_t p_char) {
 	return (p_char >= 'a' && p_char <= 'z') || (p_char >= 'A' && p_char <= 'Z') || (p_char >= '0' && p_char <= '9') || p_char == '_';
 }

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -31,6 +31,7 @@
 #include "ustring.h"
 
 #include "core/crypto/crypto_core.h"
+#include "core/io/filesystem.h"
 #include "core/math/color.h"
 #include "core/math/math_funcs.h"
 #include "core/object/object.h"
@@ -4586,23 +4587,12 @@ String String::simplify_path() const {
 	String drive;
 
 	// Check if we have a special path (like res://) or a protocol identifier.
-	int p = s.find("://");
-	bool found = false;
-	if (p > 0) {
-		bool only_chars = true;
-		for (int i = 0; i < p; i++) {
-			if (!is_ascii_alphanumeric_char(s[i])) {
-				only_chars = false;
-				break;
-			}
-		}
-		if (only_chars) {
-			found = true;
-			drive = s.substr(0, p + 3);
-			s = s.substr(p + 3);
-		}
-	}
-	if (!found) {
+	int file_path_start = 0;
+	bool found = FileSystem::try_find_protocol_in_path(s, nullptr, &file_path_start);
+	if (found) {
+		drive = s.substr(0, file_path_start);
+		s = s.substr(file_path_start);
+	} else {
 		if (is_network_share_path()) {
 			// Network path, beginning with // or \\.
 			drive = s.substr(0, 2);
@@ -4613,7 +4603,7 @@ String String::simplify_path() const {
 			s = s.substr(1);
 		} else {
 			// Windows-style drive path, like C:/ or C:\.
-			p = s.find(":/");
+			int p = s.find(":/");
 			if (p == -1) {
 				p = s.find(":\\");
 			}
@@ -5287,13 +5277,19 @@ String String::path_to(const String &p_path) const {
 		dst += "/";
 	}
 
-	if (src.begins_with("res://") && dst.begins_with("res://")) {
-		src = src.replace("res://", "/");
-		dst = dst.replace("res://", "/");
+	int src_protocol_end, src_file_start, dst_protocol_end, dst_file_start;
+	bool src_protocol_found = FileSystem::try_find_protocol_in_path(src, &src_protocol_end, &src_file_start);
+	bool dst_protocol_found = FileSystem::try_find_protocol_in_path(dst, &dst_protocol_end, &dst_file_start);
+	String src_protocol_name, dst_protocol_name;
+	bool both_protocol_found = src_protocol_found && dst_protocol_found;
+	if (both_protocol_found) {
+		src_protocol_name = src.substr(0, src_protocol_end);
+		dst_protocol_name = dst.substr(0, dst_protocol_end);
+	}
 
-	} else if (src.begins_with("user://") && dst.begins_with("user://")) {
-		src = src.replace("user://", "/");
-		dst = dst.replace("user://", "/");
+	if (both_protocol_found && src_protocol_name == dst_protocol_name) {
+		src = src.substr(src_file_start);
+		dst = dst.substr(dst_file_start);
 
 	} else if (src.begins_with("/") && dst.begins_with("/")) {
 		//nothing

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -44,7 +44,6 @@ class FileAccessUnix : public FileAccess {
 	mutable Error last_error = OK;
 	String save_path;
 	String path;
-	String path_src;
 
 	void _close();
 
@@ -52,15 +51,17 @@ class FileAccessUnix : public FileAccess {
 	String get_real_path() const; // Returns the resolved real path for the current open file.
 #endif
 
+protected:
+	virtual String _get_path() const override; /// returns the path for the current open file
+
 public:
+	virtual bool is_os_file() const override { return true; }
+
 	typedef void (*CloseNotificationFunc)(const String &p_file, int p_flags);
 	static CloseNotificationFunc close_notification_func;
 
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
-
-	virtual String get_path() const override; /// returns the path for the current open file
-	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file
 
 	virtual void seek(uint64_t p_position) override; ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
@@ -76,19 +77,6 @@ public:
 	virtual Error resize(int64_t p_length) override;
 	virtual void flush() override;
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual bool file_exists(const String &p_path) override; ///< return true if a file exists
-
-	virtual uint64_t _get_modified_time(const String &p_file) override;
-	virtual uint64_t _get_access_time(const String &p_file) override;
-	virtual int64_t _get_size(const String &p_file) override;
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override;
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override;
-
-	virtual bool _get_hidden_attribute(const String &p_file) override;
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override;
-	virtual bool _get_read_only_attribute(const String &p_file) override;
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override;
 
 	virtual void close() override;
 

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -46,7 +46,7 @@ Error FileAccessUnixPipe::open_existing(int p_rfd, int p_wfd, bool p_blocking) {
 	// Open pipe using handles created by pipe(fd) call in the OS.execute_with_pipe.
 	_close();
 
-	path_src = String();
+	path = String();
 	unlink_on_close = false;
 	ERR_FAIL_COND_V_MSG(fd[0] >= 0 || fd[1] >= 0, ERR_ALREADY_IN_USE, "Pipe is already in use.");
 	fd[0] = p_rfd;
@@ -64,10 +64,9 @@ Error FileAccessUnixPipe::open_existing(int p_rfd, int p_wfd, bool p_blocking) {
 Error FileAccessUnixPipe::open_internal(const String &p_path, int p_mode_flags) {
 	_close();
 
-	path_src = p_path;
 	ERR_FAIL_COND_V_MSG(fd[0] >= 0 || fd[1] >= 0, ERR_ALREADY_IN_USE, "Pipe is already in use.");
 
-	path = String("/tmp/") + p_path.replace("pipe://", "").replace_char('/', '_');
+	path = String("/tmp/") + p_path.replace("/", "_");
 	const CharString path_utf8 = path.utf8();
 
 	struct stat st = {};
@@ -125,12 +124,8 @@ bool FileAccessUnixPipe::is_open() const {
 	return (fd[0] >= 0 || fd[1] >= 0);
 }
 
-String FileAccessUnixPipe::get_path() const {
-	return path_src;
-}
-
-String FileAccessUnixPipe::get_path_absolute() const {
-	return path_src;
+String FileAccessUnixPipe::_get_path() const {
+	return path;
 }
 
 uint64_t FileAccessUnixPipe::get_length() const {

--- a/drivers/unix/file_access_unix_pipe.h
+++ b/drivers/unix/file_access_unix_pipe.h
@@ -44,18 +44,17 @@ class FileAccessUnixPipe : public FileAccess {
 
 	mutable Error last_error = OK;
 	String path;
-	String path_src;
 
 	void _close();
+
+protected:
+	virtual String _get_path() const override; /// returns the path for the current open file
 
 public:
 	Error open_existing(int p_rfd, int p_wfd, bool p_blocking);
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 
 	virtual bool is_open() const override; ///< true when file is open
-
-	virtual String get_path() const override; /// returns the path for the current open file
-	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file
 
 	virtual void seek(uint64_t p_position) override {}
 	virtual void seek_end(int64_t p_position = 0) override {}
@@ -71,19 +70,6 @@ public:
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override {}
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual bool file_exists(const String &p_path) override { return false; }
-
-	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
-	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
-	virtual int64_t _get_size(const String &p_file) override { return -1; }
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return ERR_UNAVAILABLE; }
-
-	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
-	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
 
 	virtual void close() override;
 

--- a/drivers/unix/filesystem_protocol_os_unix.cpp
+++ b/drivers/unix/filesystem_protocol_os_unix.cpp
@@ -1,0 +1,250 @@
+/**************************************************************************/
+/*  filesystem_protocol_os_unix.cpp                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef UNIX_ENABLED
+
+#include "filesystem_protocol_os_unix.h"
+#include "core/io/filesystem.h"
+#include "file_access_unix.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+String FileSystemProtocolOSUnix::fix_path(const String &p_path) {
+	String r_path = FileSystem::fix_path(p_path);
+	return r_path;
+}
+
+bool FileSystemProtocolOSUnix::file_exists_static(const String &p_path) {
+	struct stat st = {};
+	const CharString filename_utf8 = fix_path(p_path).utf8();
+
+	// Does the name exist at all?
+	if (stat(filename_utf8.get_data(), &st)) {
+		return false;
+	}
+
+	// See if we have access to the file
+	if (access(filename_utf8.get_data(), F_OK)) {
+		return false;
+	}
+
+	// See if this is a regular file
+	switch (st.st_mode & S_IFMT) {
+		case S_IFLNK:
+		case S_IFREG:
+			return true;
+		default:
+			return false;
+	}
+}
+BitField<FileAccess::UnixPermissionFlags> FileSystemProtocolOSUnix::get_unix_permissions_static(const String &p_path) {
+	String path = fix_path(p_path);
+	struct stat status = {};
+	int err = stat(path.utf8().get_data(), &status);
+
+	if (!err) {
+		return status.st_mode & 0xFFF; //only permissions
+	} else {
+		ERR_FAIL_V_MSG(0, "Failed to get unix permissions for: " + p_path + ".");
+	}
+}
+Error FileSystemProtocolOSUnix::set_unix_permissions_static(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
+	String path = fix_path(p_path);
+
+	int err = chmod(path.utf8().get_data(), p_permissions);
+	if (!err) {
+		return OK;
+	}
+
+	return FAILED;
+}
+uint64_t FileSystemProtocolOSUnix::get_modified_time_static(const String &p_path) {
+	String file = fix_path(p_path);
+	struct stat st = {};
+	int err = stat(file.utf8().get_data(), &st);
+
+	if (!err) {
+		uint64_t modified_time = 0;
+		if ((st.st_mode & S_IFMT) == S_IFLNK || (st.st_mode & S_IFMT) == S_IFREG || (st.st_mode & S_IFDIR) == S_IFDIR) {
+			modified_time = st.st_mtime;
+		}
+#ifdef ANDROID_ENABLED
+		// Workaround for GH-101007
+		//FIXME: After saving, all timestamps (st_mtime, st_ctime, st_atime) are set to the same value.
+		// After exporting or after some time, only 'modified_time' resets to a past timestamp.
+		uint64_t created_time = st.st_ctime;
+		if (modified_time < created_time) {
+			modified_time = created_time;
+		}
+#endif
+		return modified_time;
+	} else {
+		return 0;
+	}
+}
+
+uint64_t FileSystemProtocolOSUnix::get_access_time_static(const String &p_path) {
+	String file = fix_path(p_path);
+	struct stat st = {};
+	int err = stat(file.utf8().get_data(), &st);
+
+	if (!err) {
+		if ((st.st_mode & S_IFMT) == S_IFLNK || (st.st_mode & S_IFMT) == S_IFREG || (st.st_mode & S_IFDIR) == S_IFDIR) {
+			return st.st_atime;
+		}
+	}
+	ERR_FAIL_V_MSG(0, "Failed to get access time for: " + p_path + "");
+}
+int64_t FileSystemProtocolOSUnix::get_size_static(const String &p_path) {
+	String file = fix_path(p_path);
+	struct stat st = {};
+	int err = stat(file.utf8().get_data(), &st);
+
+	if (!err) {
+		if ((st.st_mode & S_IFMT) == S_IFLNK || (st.st_mode & S_IFMT) == S_IFREG) {
+			return st.st_size;
+		}
+	}
+	ERR_FAIL_V_MSG(-1, "Failed to get size for: " + p_path + "");
+}
+
+bool FileSystemProtocolOSUnix::get_hidden_attribute_static(const String &p_path) {
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+	String path = fix_path(p_path);
+
+	struct stat st = {};
+	int err = stat(path.utf8().get_data(), &st);
+	ERR_FAIL_COND_V_MSG(err, false, "Failed to get attributes for: " + p_path);
+
+	return (st.st_flags & UF_HIDDEN);
+#else
+	return false;
+#endif
+}
+Error FileSystemProtocolOSUnix::set_hidden_attribute_static(const String &p_path, bool p_hidden) {
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+	String path = fix_path(p_path);
+
+	struct stat st = {};
+	int err = stat(path.utf8().get_data(), &st);
+	ERR_FAIL_COND_V_MSG(err, FAILED, "Failed to get attributes for: " + p_path);
+
+	if (p_hidden) {
+		err = chflags(path.utf8().get_data(), st.st_flags | UF_HIDDEN);
+	} else {
+		err = chflags(path.utf8().get_data(), st.st_flags & ~UF_HIDDEN);
+	}
+	ERR_FAIL_COND_V_MSG(err, FAILED, "Failed to set attributes for: " + p_path);
+	return OK;
+#else
+	return ERR_UNAVAILABLE;
+#endif
+}
+bool FileSystemProtocolOSUnix::get_read_only_attribute_static(const String &p_path) {
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+	String path = fix_path(p_path);
+
+	struct stat st = {};
+	int err = stat(path.utf8().get_data(), &st);
+	ERR_FAIL_COND_V_MSG(err, false, "Failed to get attributes for: " + p_path);
+
+	return st.st_flags & UF_IMMUTABLE;
+#else
+	return false;
+#endif
+}
+Error FileSystemProtocolOSUnix::set_read_only_attribute_static(const String &p_path, bool p_ro) {
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)
+	String path = fix_path(p_path);
+
+	struct stat st = {};
+	int err = stat(path.utf8().get_data(), &st);
+	ERR_FAIL_COND_V_MSG(err, FAILED, "Failed to get attributes for: " + p_path);
+
+	if (p_ro) {
+		err = chflags(path.utf8().get_data(), st.st_flags | UF_IMMUTABLE);
+	} else {
+		err = chflags(path.utf8().get_data(), st.st_flags & ~UF_IMMUTABLE);
+	}
+	ERR_FAIL_COND_V_MSG(err, FAILED, "Failed to set attributes for: " + p_path);
+	return OK;
+#else
+	return ERR_UNAVAILABLE;
+#endif
+}
+
+Ref<FileAccess> FileSystemProtocolOSUnix::open_file(const String &p_path, int p_mode_flags, Error &r_error) const {
+	Ref<FileAccessUnix> file = Ref<FileAccessUnix>();
+	file.instantiate();
+
+	r_error = file->open_internal(p_path, p_mode_flags);
+
+	if (r_error != OK) {
+		file.unref();
+	}
+
+	return file;
+}
+bool FileSystemProtocolOSUnix::file_exists(const String &p_path) const {
+	return file_exists_static(p_path);
+}
+
+uint64_t FileSystemProtocolOSUnix::get_modified_time(const String &p_path) const {
+	return get_modified_time_static(p_path);
+}
+uint64_t FileSystemProtocolOSUnix::get_access_time(const String &p_path) const {
+	return get_access_time_static(p_path);
+}
+int64_t FileSystemProtocolOSUnix::get_size(const String &p_path) const {
+	return get_size_static(p_path);
+}
+BitField<FileAccess::UnixPermissionFlags> FileSystemProtocolOSUnix::get_unix_permissions(const String &p_path) const {
+	return get_unix_permissions_static(p_path);
+}
+Error FileSystemProtocolOSUnix::set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const {
+	return set_unix_permissions_static(p_path, p_permissions);
+}
+bool FileSystemProtocolOSUnix::get_hidden_attribute(const String &p_path) const {
+	return get_hidden_attribute_static(p_path);
+}
+Error FileSystemProtocolOSUnix::set_hidden_attribute(const String &p_path, bool p_hidden) const {
+	return set_hidden_attribute_static(p_path, p_hidden);
+}
+bool FileSystemProtocolOSUnix::get_read_only_attribute(const String &p_path) const {
+	return get_read_only_attribute_static(p_path);
+}
+Error FileSystemProtocolOSUnix::set_read_only_attribute(const String &p_path, bool p_ro) const {
+	return set_read_only_attribute_static(p_path, p_ro);
+}
+#endif // WINDOWS_ENABLED

--- a/drivers/unix/filesystem_protocol_os_unix.h
+++ b/drivers/unix/filesystem_protocol_os_unix.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_os_unix.h                                         */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,68 +30,38 @@
 
 #pragma once
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#ifdef UNIX_ENABLED
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
+#include "core/io/filesystem_protocol.h"
 
-class FileAccessEncrypted : public FileAccess {
+class FileSystemProtocolOSUnix : public FileSystemProtocol {
 public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+	static String fix_path(const String &p_path);
+	static bool file_exists_static(const String &p_path);
+	static uint64_t get_modified_time_static(const String &p_path);
+	static uint64_t get_access_time_static(const String &p_path);
+	static int64_t get_size_static(const String &p_path);
+	static BitField<FileAccess::UnixPermissionFlags> get_unix_permissions_static(const String &p_path);
+	static Error set_unix_permissions_static(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions);
+	static bool get_hidden_attribute_static(const String &p_path);
+	static Error set_hidden_attribute_static(const String &p_path, bool p_hidden);
+	static bool get_read_only_attribute_static(const String &p_path);
+	static Error set_read_only_attribute_static(const String &p_path, bool p_ro);
 
-private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const override;
+	virtual bool file_exists(const String &p_path) const override;
 
-	void _close();
+	// OS files don't need to be disguised when they are opened directly.
+	virtual void disguise_file(const Ref<FileAccess> &p_file, const String &p_protocol_name, const String &p_path) const override {}
 
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
-
-public:
-	virtual bool is_os_file() const override;
-
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
-
-	Vector<uint8_t> get_iv() const { return iv; }
-
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
-
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
+	virtual uint64_t get_modified_time(const String &p_path) const override;
+	virtual uint64_t get_access_time(const String &p_path) const override;
+	virtual int64_t get_size(const String &p_path) const override;
+	virtual BitField<FileAccess::UnixPermissionFlags> get_unix_permissions(const String &p_path) const override;
+	virtual Error set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const override;
+	virtual bool get_hidden_attribute(const String &p_path) const override;
+	virtual Error set_hidden_attribute(const String &p_path, bool p_hidden) const override;
+	virtual bool get_read_only_attribute(const String &p_path) const override;
+	virtual Error set_read_only_attribute(const String &p_path, bool p_ro) const override;
 };
+#endif // UNIX_ENABLED

--- a/drivers/unix/filesystem_protocol_pipe_unix.cpp
+++ b/drivers/unix/filesystem_protocol_pipe_unix.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_pipe_unix.cpp                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,70 +28,22 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifdef UNIX_ENABLED
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#include "filesystem_protocol_pipe_unix.h"
+#include "core/io/filesystem.h"
+#include "file_access_unix_pipe.h"
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
+Ref<FileAccess> FileSystemProtocolPipeUnix::open_file(const String &p_path, int p_mode_flags, Error &r_error) const {
+	Ref<FileAccessUnixPipe> file = Ref<FileAccessUnixPipe>();
+	file.instantiate();
 
-class FileAccessEncrypted : public FileAccess {
-public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+	r_error = file->open_internal(p_path, p_mode_flags);
 
-private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
+	if (r_error != OK) {
+		file.unref();
+	}
 
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
-
-public:
-	virtual bool is_os_file() const override;
-
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
-
-	Vector<uint8_t> get_iv() const { return iv; }
-
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
-
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
-};
+	return file;
+}
+#endif // UNIX_ENABLED

--- a/drivers/unix/filesystem_protocol_pipe_unix.h
+++ b/drivers/unix/filesystem_protocol_pipe_unix.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_pipe_unix.h                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,68 +30,12 @@
 
 #pragma once
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#ifdef UNIX_ENABLED
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
+#include "core/io/filesystem_protocol.h"
 
-class FileAccessEncrypted : public FileAccess {
+class FileSystemProtocolPipeUnix : public FileSystemProtocol {
 public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
-
-private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
-
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
-
-public:
-	virtual bool is_os_file() const override;
-
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
-
-	Vector<uint8_t> get_iv() const { return iv; }
-
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
-
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const override;
 };
+#endif // UNIX_ENABLED

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -86,6 +86,8 @@ protected:
 public:
 	OS_Unix();
 
+	virtual void initialize_filesystem() override;
+
 	virtual Vector<String> get_video_adapter_driver_info() const override;
 
 	virtual String get_stdin_string(int64_t p_buffer_size = 1024) override;

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -32,6 +32,7 @@
 
 #include "dir_access_windows.h"
 #include "file_access_windows.h"
+#include "filesystem_protocol_os_windows.h"
 
 #include "core/config/project_settings.h"
 #include "core/os/memory.h"
@@ -188,7 +189,7 @@ Error DirAccessWindows::change_dir(String p_dir) {
 Error DirAccessWindows::make_dir(String p_dir) {
 	GLOBAL_LOCK_FUNCTION
 
-	if (FileAccessWindows::is_path_invalid(p_dir)) {
+	if (FileSystemProtocolOSWindows::is_path_invalid(p_dir)) {
 #ifdef DEBUG_ENABLED
 		WARN_PRINT("The path :" + p_dir + " is a reserved Windows system pipe, so it can't be used for creating directories.");
 #endif

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -44,22 +44,18 @@ class FileAccessWindows : public FileAccess {
 	mutable int prev_op = 0;
 	mutable Error last_error = OK;
 	String path;
-	String path_src;
 	String save_path;
 
 	void _close();
 
-	static HashSet<String> invalid_files;
+protected:
+	virtual String _get_path() const override; /// returns the path for the current open file
 
 public:
-	static bool is_path_invalid(const String &p_path);
+	virtual bool is_os_file() const override { return true; }
 
-	virtual String fix_path(const String &p_path) const override;
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
-
-	virtual String get_path() const override; /// returns the path for the current open file
-	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file
 
 	virtual void seek(uint64_t p_position) override; ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
@@ -76,23 +72,7 @@ public:
 	virtual void flush() override;
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
 
-	virtual bool file_exists(const String &p_name) override; ///< return true if a file exists
-
-	uint64_t _get_modified_time(const String &p_file) override;
-	uint64_t _get_access_time(const String &p_file) override;
-	int64_t _get_size(const String &p_file) override;
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override;
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override;
-
-	virtual bool _get_hidden_attribute(const String &p_file) override;
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override;
-	virtual bool _get_read_only_attribute(const String &p_file) override;
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override;
-
 	virtual void close() override;
-
-	static void initialize();
-	static void finalize();
 
 	FileAccessWindows() {}
 	virtual ~FileAccessWindows();

--- a/drivers/windows/file_access_windows_pipe.cpp
+++ b/drivers/windows/file_access_windows_pipe.cpp
@@ -39,7 +39,7 @@ Error FileAccessWindowsPipe::open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_bl
 	// Open pipe using handles created by CreatePipe(rfd, wfd, NULL, 4096) call in the OS.execute_with_pipe.
 	_close();
 
-	path_src = String();
+	path = String();
 	ERR_FAIL_COND_V_MSG(fd[0] != nullptr || fd[1] != nullptr, ERR_ALREADY_IN_USE, "Pipe is already in use.");
 	fd[0] = p_rfd;
 	fd[1] = p_wfd;
@@ -57,10 +57,9 @@ Error FileAccessWindowsPipe::open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_bl
 Error FileAccessWindowsPipe::open_internal(const String &p_path, int p_mode_flags) {
 	_close();
 
-	path_src = p_path;
 	ERR_FAIL_COND_V_MSG(fd[0] != nullptr || fd[1] != nullptr, ERR_ALREADY_IN_USE, "Pipe is already in use.");
 
-	path = String("\\\\.\\pipe\\LOCAL\\") + p_path.replace("pipe://", "").replace_char('/', '_');
+	path = String("\\\\.\\pipe\\LOCAL\\") + p_path.replace("/", "_");
 
 	HANDLE h = CreateFileW((LPCWSTR)path.utf16().get_data(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
 	if (h == INVALID_HANDLE_VALUE) {
@@ -94,12 +93,8 @@ bool FileAccessWindowsPipe::is_open() const {
 	return (fd[0] != nullptr || fd[1] != nullptr);
 }
 
-String FileAccessWindowsPipe::get_path() const {
-	return path_src;
-}
-
-String FileAccessWindowsPipe::get_path_absolute() const {
-	return path_src;
+String FileAccessWindowsPipe::_get_path() const {
+	return path;
 }
 
 uint64_t FileAccessWindowsPipe::get_length() const {

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -43,18 +43,17 @@ class FileAccessWindowsPipe : public FileAccess {
 	mutable Error last_error = OK;
 
 	String path;
-	String path_src;
 
 	void _close();
+
+protected:
+	virtual String _get_path() const override; /// returns the path for the current open file
 
 public:
 	Error open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_blocking);
 
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
-
-	virtual String get_path() const override; /// returns the path for the current open file
-	virtual String get_path_absolute() const override; /// returns the absolute path for the current open file
 
 	virtual void seek(uint64_t p_position) override {}
 	virtual void seek_end(int64_t p_position = 0) override {}
@@ -70,19 +69,6 @@ public:
 	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
 	virtual void flush() override {}
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual bool file_exists(const String &p_name) override { return false; }
-
-	uint64_t _get_modified_time(const String &p_file) override { return 0; }
-	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
-	virtual int64_t _get_size(const String &p_file) override { return -1; }
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return ERR_UNAVAILABLE; }
-
-	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
-	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
 
 	virtual void close() override;
 

--- a/drivers/windows/filesystem_protocol_os_windows.cpp
+++ b/drivers/windows/filesystem_protocol_os_windows.cpp
@@ -1,0 +1,353 @@
+/**************************************************************************/
+/*  filesystem_protocol_os_windows.cpp                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef WINDOWS_ENABLED
+
+#include "filesystem_protocol_os_windows.h"
+#include "core/io/filesystem.h"
+#include "file_access_windows.h"
+
+#include <share.h> // _SH_DENYNO
+#include <shlwapi.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+HashSet<String> FileSystemProtocolOSWindows::invalid_files;
+void FileSystemProtocolOSWindows::initialize() {
+	static const char *reserved_files[]{
+		"con", "prn", "aux", "nul", "com0", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9", "lpt0", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9", nullptr
+	};
+	int reserved_file_index = 0;
+	while (reserved_files[reserved_file_index] != nullptr) {
+		invalid_files.insert(reserved_files[reserved_file_index]);
+		reserved_file_index++;
+	}
+
+	_setmaxstdio(8192);
+	print_verbose(vformat("Maximum number of file handles: %d", _getmaxstdio()));
+}
+void FileSystemProtocolOSWindows::finalize() {
+	invalid_files.clear();
+}
+
+bool FileSystemProtocolOSWindows::is_path_invalid(const String &p_path) {
+	// Check for invalid operating system file.
+	String fname = p_path.get_file().to_lower();
+
+	int dot = fname.find_char('.');
+	if (dot != -1) {
+		fname = fname.substr(0, dot);
+	}
+	return invalid_files.has(fname);
+}
+
+String FileSystemProtocolOSWindows::fix_path(const String &p_path, bool p_always_unc) {
+	String r_path = p_path;
+	if (r_path.is_relative_path()) {
+		Char16String current_dir_name;
+		size_t str_len = GetCurrentDirectoryW(0, nullptr);
+		current_dir_name.resize(str_len + 1);
+		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
+		r_path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(r_path);
+	}
+	r_path = r_path.simplify_path();
+	r_path = r_path.replace_char('/', '\\');
+	if ((p_always_unc || r_path.size() >= MAX_PATH) && !r_path.is_network_share_path() && !r_path.begins_with(R"(\\?\)")) {
+		r_path = R"(\\?\)" + r_path;
+	}
+	return r_path;
+}
+
+bool FileSystemProtocolOSWindows::file_exists_static(const String &p_path) {
+	if (is_path_invalid(p_path)) {
+		return false;
+	}
+
+	String filename = fix_path(p_path);
+	DWORD file_attr = GetFileAttributesW((LPCWSTR)(filename.utf16().get_data()));
+	return (file_attr != INVALID_FILE_ATTRIBUTES) && !(file_attr & FILE_ATTRIBUTE_DIRECTORY);
+}
+BitField<FileAccess::UnixPermissionFlags> FileSystemProtocolOSWindows::get_unix_permissions_static(const String &p_path) {
+	return 0;
+}
+Error FileSystemProtocolOSWindows::set_unix_permissions_static(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) {
+	return ERR_UNAVAILABLE;
+}
+uint64_t FileSystemProtocolOSWindows::get_modified_time_static(const String &p_path) {
+	if (is_path_invalid(p_path)) {
+		return 0;
+	}
+
+	String file = fix_path(p_path);
+	if (file.ends_with("\\") && file != "\\") {
+		file = file.substr(0, file.length() - 1);
+	}
+
+	HANDLE handle = CreateFileW((LPCWSTR)(file.utf16().get_data()), FILE_READ_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+
+	if (handle != INVALID_HANDLE_VALUE) {
+		FILETIME ft_create, ft_write;
+
+		bool status = GetFileTime(handle, &ft_create, nullptr, &ft_write);
+
+		CloseHandle(handle);
+
+		if (status) {
+			uint64_t ret = 0;
+
+			// If write time is invalid, fallback to creation time.
+			if (ft_write.dwHighDateTime == 0 && ft_write.dwLowDateTime == 0) {
+				ret = ft_create.dwHighDateTime;
+				ret <<= 32;
+				ret |= ft_create.dwLowDateTime;
+			} else {
+				ret = ft_write.dwHighDateTime;
+				ret <<= 32;
+				ret |= ft_write.dwLowDateTime;
+			}
+
+			const uint64_t WINDOWS_TICKS_PER_SECOND = 10000000;
+			const uint64_t TICKS_TO_UNIX_EPOCH = 116444736000000000LL;
+
+			if (ret >= TICKS_TO_UNIX_EPOCH) {
+				return (ret - TICKS_TO_UNIX_EPOCH) / WINDOWS_TICKS_PER_SECOND;
+			}
+		}
+	}
+
+	return 0;
+}
+
+uint64_t FileSystemProtocolOSWindows::get_access_time_static(const String &p_path) {
+	if (is_path_invalid(p_path)) {
+		return 0;
+	}
+
+	String file = fix_path(p_path);
+	if (file.ends_with("\\") && file != "\\") {
+		file = file.substr(0, file.length() - 1);
+	}
+
+	HANDLE handle = CreateFileW((LPCWSTR)(file.utf16().get_data()), FILE_READ_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+
+	if (handle != INVALID_HANDLE_VALUE) {
+		FILETIME ft_create, ft_access;
+
+		bool status = GetFileTime(handle, &ft_create, &ft_access, nullptr);
+
+		CloseHandle(handle);
+
+		if (status) {
+			uint64_t ret = 0;
+
+			// If access time is invalid, fallback to creation time.
+			if (ft_access.dwHighDateTime == 0 && ft_access.dwLowDateTime == 0) {
+				ret = ft_create.dwHighDateTime;
+				ret <<= 32;
+				ret |= ft_create.dwLowDateTime;
+			} else {
+				ret = ft_access.dwHighDateTime;
+				ret <<= 32;
+				ret |= ft_access.dwLowDateTime;
+			}
+
+			const uint64_t WINDOWS_TICKS_PER_SECOND = 10000000;
+			const uint64_t TICKS_TO_UNIX_EPOCH = 116444736000000000LL;
+
+			if (ret >= TICKS_TO_UNIX_EPOCH) {
+				return (ret - TICKS_TO_UNIX_EPOCH) / WINDOWS_TICKS_PER_SECOND;
+			}
+		}
+	}
+
+	ERR_FAIL_V_MSG(0, "Failed to get access time for: " + p_path + "");
+}
+
+int64_t FileSystemProtocolOSWindows::get_size_static(const String &p_path) {
+	if (is_path_invalid(p_path)) {
+		return 0;
+	}
+
+	String file = fix_path(p_path);
+	if (file.ends_with("\\") && file != "\\") {
+		file = file.substr(0, file.length() - 1);
+	}
+
+	DWORD file_attr = GetFileAttributesW((LPCWSTR)(file.utf16().get_data()));
+	HANDLE handle = CreateFileW((LPCWSTR)(file.utf16().get_data()), FILE_READ_ATTRIBUTES, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+
+	if (handle != INVALID_HANDLE_VALUE && !(file_attr & FILE_ATTRIBUTE_DIRECTORY)) {
+		LARGE_INTEGER fsize;
+
+		bool status = GetFileSizeEx(handle, &fsize);
+
+		CloseHandle(handle);
+
+		if (status) {
+			return (int64_t)fsize.QuadPart;
+		}
+	}
+	ERR_FAIL_V_MSG(-1, "Failed to get size for: " + p_path + "");
+}
+
+bool FileSystemProtocolOSWindows::get_hidden_attribute_static(const String &p_path) {
+	String file = fix_path(p_path);
+
+	DWORD attrib = GetFileAttributesW((LPCWSTR)file.utf16().get_data());
+	ERR_FAIL_COND_V_MSG(attrib == INVALID_FILE_ATTRIBUTES, false, "Failed to get attributes for: " + p_path);
+	return (attrib & FILE_ATTRIBUTE_HIDDEN);
+}
+Error FileSystemProtocolOSWindows::set_hidden_attribute_static(const String &p_path, bool p_hidden) {
+	String file = fix_path(p_path);
+	const Char16String &file_utf16 = file.utf16();
+
+	DWORD attrib = GetFileAttributesW((LPCWSTR)file_utf16.get_data());
+	ERR_FAIL_COND_V_MSG(attrib == INVALID_FILE_ATTRIBUTES, FAILED, "Failed to get attributes for: " + p_path);
+	BOOL ok;
+	if (p_hidden) {
+		ok = SetFileAttributesW((LPCWSTR)file_utf16.get_data(), attrib | FILE_ATTRIBUTE_HIDDEN);
+	} else {
+		ok = SetFileAttributesW((LPCWSTR)file_utf16.get_data(), attrib & ~FILE_ATTRIBUTE_HIDDEN);
+	}
+	ERR_FAIL_COND_V_MSG(!ok, FAILED, "Failed to set attributes for: " + p_path);
+
+	return OK;
+}
+bool FileSystemProtocolOSWindows::get_read_only_attribute_static(const String &p_path) {
+	String file = fix_path(p_path);
+
+	DWORD attrib = GetFileAttributesW((LPCWSTR)file.utf16().get_data());
+	ERR_FAIL_COND_V_MSG(attrib == INVALID_FILE_ATTRIBUTES, false, "Failed to get attributes for: " + p_path);
+	return (attrib & FILE_ATTRIBUTE_READONLY);
+}
+Error FileSystemProtocolOSWindows::set_read_only_attribute_static(const String &p_path, bool p_ro) {
+	String file = fix_path(p_path);
+	const Char16String &file_utf16 = file.utf16();
+
+	DWORD attrib = GetFileAttributesW((LPCWSTR)file_utf16.get_data());
+	ERR_FAIL_COND_V_MSG(attrib == INVALID_FILE_ATTRIBUTES, FAILED, "Failed to get attributes for: " + p_path);
+	BOOL ok;
+	if (p_ro) {
+		ok = SetFileAttributesW((LPCWSTR)file_utf16.get_data(), attrib | FILE_ATTRIBUTE_READONLY);
+	} else {
+		ok = SetFileAttributesW((LPCWSTR)file_utf16.get_data(), attrib & ~FILE_ATTRIBUTE_READONLY);
+	}
+	ERR_FAIL_COND_V_MSG(!ok, FAILED, "Failed to set attributes for: " + p_path);
+
+	return OK;
+}
+
+// Windows is case-insensitive in the default configuration, but other platforms are typically sensitive to it.
+bool FileSystemProtocolOSWindows::check_path_case_mismatch(const String &p_base_path, const String &p_rel_path, String &r_proper_rel_path) {
+#if !TOOLS_ENABLED
+	return false;
+#else
+	String working_path = p_base_path;
+	String file_path = p_rel_path;
+	String proper_path = "";
+
+	working_path = FileSystemProtocolOSWindows::fix_path(working_path);
+
+	WIN32_FIND_DATAW d;
+	Vector<String> parts = file_path.simplify_path().split("/");
+
+	bool mismatch = false;
+
+	for (const String &part : parts) {
+		working_path = working_path + "\\" + part;
+
+		HANDLE fnd = FindFirstFileW((LPCWSTR)(working_path.utf16().get_data()), &d);
+		if (fnd == INVALID_HANDLE_VALUE) {
+			mismatch = false;
+			break;
+		}
+
+		const String fname = String::utf16((const char16_t *)(d.cFileName));
+
+		FindClose(fnd);
+
+		if (!mismatch) {
+			mismatch = (part != fname && part.findn(fname) == 0);
+		}
+
+		proper_path = proper_path.path_join(fname);
+	}
+
+	if (!mismatch) {
+		r_proper_rel_path = proper_path;
+	}
+	return mismatch;
+#endif
+}
+
+Ref<FileAccess> FileSystemProtocolOSWindows::open_file(const String &p_path, int p_mode_flags, Error &r_error) const {
+	Ref<FileAccessWindows> file = Ref<FileAccessWindows>();
+	file.instantiate();
+
+	r_error = file->open_internal(p_path, p_mode_flags);
+
+	if (r_error != OK) {
+		file.unref();
+	}
+
+	return file;
+}
+bool FileSystemProtocolOSWindows::file_exists(const String &p_path) const {
+	return file_exists_static(p_path);
+}
+
+uint64_t FileSystemProtocolOSWindows::get_modified_time(const String &p_path) const {
+	return get_modified_time_static(p_path);
+}
+uint64_t FileSystemProtocolOSWindows::get_access_time(const String &p_path) const {
+	return get_access_time_static(p_path);
+}
+int64_t FileSystemProtocolOSWindows::get_size(const String &p_path) const {
+	return get_size_static(p_path);
+}
+BitField<FileAccess::UnixPermissionFlags> FileSystemProtocolOSWindows::get_unix_permissions(const String &p_path) const {
+	return get_unix_permissions_static(p_path);
+}
+Error FileSystemProtocolOSWindows::set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const {
+	return set_unix_permissions_static(p_path, p_permissions);
+}
+bool FileSystemProtocolOSWindows::get_hidden_attribute(const String &p_path) const {
+	return get_hidden_attribute_static(p_path);
+}
+Error FileSystemProtocolOSWindows::set_hidden_attribute(const String &p_path, bool p_hidden) const {
+	return set_hidden_attribute_static(p_path, p_hidden);
+}
+bool FileSystemProtocolOSWindows::get_read_only_attribute(const String &p_path) const {
+	return get_read_only_attribute_static(p_path);
+}
+Error FileSystemProtocolOSWindows::set_read_only_attribute(const String &p_path, bool p_ro) const {
+	return set_read_only_attribute_static(p_path, p_ro);
+}
+#endif // WINDOWS_ENABLED

--- a/drivers/windows/filesystem_protocol_os_windows.h
+++ b/drivers/windows/filesystem_protocol_os_windows.h
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  filesystem_protocol_os_windows.h                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef WINDOWS_ENABLED
+
+#include "core/io/filesystem_protocol.h"
+
+class FileSystemProtocolOSWindows : public FileSystemProtocol {
+private:
+	static HashSet<String> invalid_files;
+
+public:
+	static void initialize();
+	static void finalize();
+
+	static String fix_path(const String &p_path, bool p_always_unc = true);
+	static bool is_path_invalid(const String &p_path);
+	static bool file_exists_static(const String &p_path);
+	static uint64_t get_modified_time_static(const String &p_path);
+	static uint64_t get_access_time_static(const String &p_path);
+	static int64_t get_size_static(const String &p_path);
+	static BitField<FileAccess::UnixPermissionFlags> get_unix_permissions_static(const String &p_path);
+	static Error set_unix_permissions_static(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions);
+	static bool get_hidden_attribute_static(const String &p_path);
+	static Error set_hidden_attribute_static(const String &p_path, bool p_hidden);
+	static bool get_read_only_attribute_static(const String &p_path);
+	static Error set_read_only_attribute_static(const String &p_path, bool p_ro);
+
+	static bool check_path_case_mismatch(const String &p_base_path, const String &p_rel_path, String &r_proper_rel_path);
+
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const override;
+	virtual bool file_exists(const String &p_path) const override;
+
+	// OS files don't need to be disguised when they are opened directly.
+	virtual void disguise_file(const Ref<FileAccess> &p_file, const String &p_protocol_name, const String &p_path) const override {}
+
+	virtual uint64_t get_modified_time(const String &p_path) const override;
+	virtual uint64_t get_access_time(const String &p_path) const override;
+	virtual int64_t get_size(const String &p_path) const override;
+	virtual BitField<FileAccess::UnixPermissionFlags> get_unix_permissions(const String &p_path) const override;
+	virtual Error set_unix_permissions(const String &p_path, BitField<FileAccess::UnixPermissionFlags> p_permissions) const override;
+	virtual bool get_hidden_attribute(const String &p_path) const override;
+	virtual Error set_hidden_attribute(const String &p_path, bool p_hidden) const override;
+	virtual bool get_read_only_attribute(const String &p_path) const override;
+	virtual Error set_read_only_attribute(const String &p_path, bool p_ro) const override;
+};
+#endif // WINDOWS_ENABLED

--- a/drivers/windows/filesystem_protocol_pipe_windows.cpp
+++ b/drivers/windows/filesystem_protocol_pipe_windows.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_pipe_windows.cpp                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,70 +28,22 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifdef WINDOWS_ENABLED
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#include "filesystem_protocol_pipe_windows.h"
+#include "core/io/filesystem.h"
+#include "file_access_windows_pipe.h"
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
+Ref<FileAccess> FileSystemProtocolPipeWindows::open_file(const String &p_path, int p_mode_flags, Error &r_error) const {
+	Ref<FileAccessWindowsPipe> file = Ref<FileAccessWindowsPipe>();
+	file.instantiate();
 
-class FileAccessEncrypted : public FileAccess {
-public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+	r_error = file->open_internal(p_path, p_mode_flags);
 
-private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
+	if (r_error != OK) {
+		file.unref();
+	}
 
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
-
-public:
-	virtual bool is_os_file() const override;
-
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
-
-	Vector<uint8_t> get_iv() const { return iv; }
-
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
-
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
-};
+	return file;
+}
+#endif // WINDOWS_ENABLED

--- a/drivers/windows/filesystem_protocol_pipe_windows.h
+++ b/drivers/windows/filesystem_protocol_pipe_windows.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_pipe_windows.h                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,68 +30,12 @@
 
 #pragma once
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#ifdef WINDOWS_ENABLED
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
+#include "core/io/filesystem_protocol.h"
 
-class FileAccessEncrypted : public FileAccess {
+class FileSystemProtocolPipeWindows : public FileSystemProtocol {
 public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
-
-private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
-
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
-
-public:
-	virtual bool is_os_file() const override;
-
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
-
-	Vector<uint8_t> get_iv() const { return iv; }
-
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
-
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const override;
 };
+#endif // WINDOWS_ENABLED

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -32,6 +32,7 @@
 
 #include "core/io/config_file.h"
 #include "core/io/file_access.h"
+#include "core/io/filesystem.h"
 #include "editor/editor_inspector.h"
 #include "editor/editor_paths.h"
 
@@ -132,8 +133,7 @@ void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p
 void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path) {
 	ERR_FAIL_NULL(p_scene);
 
-	Ref<FileAccess> file_check = FileAccess::create(FileAccess::ACCESS_RESOURCES);
-	if (!file_check->file_exists(p_path)) { //This can happen when creating scene from FilesystemDock. It has path, but no file.
+	if (!FileSystem::get_singleton()->file_exists(p_path)) { //This can happen when creating scene from FilesystemDock. It has path, but no file.
 		return;
 	}
 

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -1013,9 +1013,11 @@ void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<
 		buffer += conservative.get_line(f);
 	}
 
-	// Now the modified contents are in the buffer, rewrite the file with our changes.
+	f.unref();
 
-	Error err = f->reopen(fpath, FileAccess::WRITE);
+	// Now the modified contents are in the buffer, rewrite the file with our changes.
+	Error err;
+	f = FileAccess::open(fpath, FileAccess::WRITE, &err);
 	ERR_FAIL_COND_MSG(err != OK, "Cannot create file in path '" + fpath + "'.");
 
 	f->store_string(buffer);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -42,6 +42,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access_pack.h"
 #include "core/io/file_access_zip.h"
+#include "core/io/filesystem.h"
 #include "core/io/image.h"
 #include "core/io/image_loader.h"
 #include "core/io/ip.h"
@@ -159,6 +160,7 @@ static Input *input = nullptr;
 static InputMap *input_map = nullptr;
 static TranslationServer *translation_server = nullptr;
 static Performance *performance = nullptr;
+static FileSystem *filesystem = nullptr;
 static PackedData *packed_data = nullptr;
 #ifdef MINIZIP_ENABLED
 static ZipArchive *zip_packed_data = nullptr;
@@ -719,6 +721,11 @@ Error Main::test_setup() {
 
 	globals = memnew(ProjectSettings);
 
+	filesystem = memnew(FileSystem);
+	OS::get_singleton()->initialize_filesystem();
+	filesystem->register_protocols();
+	OS::get_singleton()->initialize_filesystem_additional();
+
 	register_core_settings(); // Here globals are present.
 
 	translation_server = memnew(TranslationServer);
@@ -890,6 +897,9 @@ void Main::test_cleanup() {
 	if (globals) {
 		memdelete(globals);
 	}
+	if (filesystem) {
+		memdelete(filesystem);
+	}
 
 	unregister_core_driver_types();
 	unregister_core_extensions();
@@ -979,6 +989,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	input_map = memnew(InputMap);
 	globals = memnew(ProjectSettings);
+
+	filesystem = memnew(FileSystem);
+	OS::get_singleton()->initialize_filesystem();
+	filesystem->register_protocols();
+	OS::get_singleton()->initialize_filesystem_additional();
 
 	register_core_settings(); //here globals are present
 
@@ -2116,7 +2131,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// and even if file logging is disabled in the Project Settings.
 	// `--log-file` can be used with any path (including absolute paths outside the project folder),
 	// so check for filesystem access if it's used.
-	if (FileAccess::get_create_func(!log_file.is_empty() ? FileAccess::ACCESS_FILESYSTEM : FileAccess::ACCESS_USERDATA) &&
+	if (FileSystem::get_singleton()->has_protocol(!log_file.is_empty() ? FileSystem::protocol_name_os : FileSystem::protocol_name_user) &&
 			(!log_file.is_empty() || (!project_manager && !editor && GLOBAL_GET("debug/file_logging/enable_file_logging")))) {
 		// Don't create logs for the project manager as they would be written to
 		// the current working directory, which is inconvenient.
@@ -2829,6 +2844,9 @@ error:
 	}
 	if (globals) {
 		memdelete(globals);
+	}
+	if (filesystem) {
+		memdelete(filesystem);
 	}
 	if (packed_data) {
 		memdelete(packed_data);
@@ -5024,6 +5042,9 @@ void Main::cleanup(bool p_force) {
 #endif // PHYSICS_2D_DISABLED
 	if (globals) {
 		memdelete(globals);
+	}
+	if (filesystem) {
+		memdelete(filesystem);
 	}
 
 	if (OS::get_singleton()->is_restart_on_exit_set()) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -38,6 +38,7 @@
 #include "core/config/project_settings.h"
 #include "core/core_constants.h"
 #include "core/io/file_access.h"
+#include "core/io/filesystem.h"
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
@@ -4672,9 +4673,7 @@ void GDScriptAnalyzer::reduce_preload(GDScriptParser::PreloadNode *p_preload) {
 		}
 		p_preload->resolved_path = p_preload->resolved_path.simplify_path();
 		if (!ResourceLoader::exists(p_preload->resolved_path)) {
-			Ref<FileAccess> file_check = FileAccess::create(FileAccess::ACCESS_RESOURCES);
-
-			if (file_check->file_exists(p_preload->resolved_path)) {
+			if (FileSystem::get_singleton()->file_exists(p_preload->resolved_path)) {
 				push_error(vformat(R"(Preload file "%s" has no resource loaders (unrecognized file extension).)", p_preload->resolved_path), p_preload->path);
 			} else {
 				push_error(vformat(R"(Preload file "%s" does not exist.)", p_preload->resolved_path), p_preload->path);

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -32,6 +32,7 @@
 
 #include "../gdscript.h"
 #include "../gdscript_analyzer.h"
+#include "core/io/filesystem.h"
 #include "editor/editor_settings.h"
 #include "gdscript_language_protocol.h"
 #include "gdscript_workspace.h"
@@ -198,7 +199,7 @@ void ExtendGDScriptParser::update_document_links(const String &p_code) {
 	document_links.clear();
 
 	GDScriptTokenizerText scr_tokenizer;
-	Ref<FileAccess> fs = FileAccess::create(FileAccess::ACCESS_RESOURCES);
+	FileSystem *fs = FileSystem::get_singleton();
 	scr_tokenizer.set_source_code(p_code);
 	while (true) {
 		GDScriptTokenizer::Token token = scr_tokenizer.scan();

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -38,6 +38,8 @@
 #include "editor/plugins/script_text_editor.h"
 #include "servers/display_server.h"
 
+#include "core/io/filesystem.h"
+
 void GDScriptTextDocument::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("didOpen"), &GDScriptTextDocument::didOpen);
 	ClassDB::bind_method(D_METHOD("didClose"), &GDScriptTextDocument::didClose);
@@ -473,10 +475,6 @@ Variant GDScriptTextDocument::signatureHelp(const Dictionary &p_params) {
 	return ret;
 }
 
-GDScriptTextDocument::GDScriptTextDocument() {
-	file_checker = FileAccess::create(FileAccess::ACCESS_RESOURCES);
-}
-
 void GDScriptTextDocument::sync_script_content(const String &p_path, const String &p_content) {
 	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(p_path);
 	GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_script(path, p_content);
@@ -496,7 +494,7 @@ Array GDScriptTextDocument::find_symbols(const LSP::TextDocumentPositionParams &
 		location.uri = symbol->uri;
 		location.range = symbol->selectionRange;
 		const String &path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(symbol->uri);
-		if (file_checker->file_exists(path)) {
+		if (FileSystem::get_singleton()->file_exists(path)) {
 			arr.push_back(location.to_json());
 		}
 		r_list.push_back(symbol);

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -42,8 +42,6 @@ class GDScriptTextDocument : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	Ref<FileAccess> file_checker;
-
 	Array native_member_completions;
 
 private:
@@ -79,6 +77,4 @@ public:
 	Variant signatureHelp(const Dictionary &p_params);
 
 	void initialize();
-
-	GDScriptTextDocument();
 };

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -743,7 +743,6 @@ Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_p
 		if (buffer_data.is_empty()) {
 			return OK;
 		}
-		file->create(FileAccess::ACCESS_RESOURCES);
 		file->store_buffer(buffer_data.ptr(), buffer_data.size());
 		gltf_buffer["uri"] = filename;
 		gltf_buffer["byteLength"] = buffer_data.size();
@@ -775,7 +774,6 @@ Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_
 		if (buffer_data.is_empty()) {
 			return OK;
 		}
-		file->create(FileAccess::ACCESS_RESOURCES);
 		file->store_buffer(buffer_data.ptr(), buffer_data.size());
 		gltf_buffer["uri"] = filename;
 		gltf_buffer["byteLength"] = buffer_data.size();
@@ -8121,7 +8119,6 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 		const uint32_t binary_chunk_length = ((binary_data_length + 3) & (~3));
 		const uint32_t binary_chunk_type = 0x004E4942; //BIN
 
-		file->create(FileAccess::ACCESS_RESOURCES);
 		file->store_32(magic);
 		file->store_32(p_state->major_version); // version
 		uint32_t total_length = header_size + chunk_header_size + text_chunk_length;
@@ -8153,7 +8150,6 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 		ERR_FAIL_COND_V(file.is_null(), FAILED);
 
-		file->create(FileAccess::ACCESS_RESOURCES);
 		String json = Variant(p_state->json).to_json_string();
 		file->store_string(json);
 	}

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -13,6 +13,8 @@ android_files = [
     "android_input_handler.cpp",
     "file_access_android.cpp",
     "file_access_filesystem_jandroid.cpp",
+    "filesystem_protocol_os_android.cpp",
+    "filesystem_protocol_os_jandroid.cpp",
     "audio_driver_opensl.cpp",
     "dir_access_jandroid.cpp",
     "tts_android.cpp",

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -31,6 +31,7 @@
 #include "file_access_android.h"
 
 #include "core/string/print_string.h"
+#include "filesystem_protocol_os_android.h"
 #include "thread_jandroid.h"
 
 #include <android/asset_manager_jni.h>
@@ -38,24 +39,17 @@
 AAssetManager *FileAccessAndroid::asset_manager = nullptr;
 jobject FileAccessAndroid::j_asset_manager = nullptr;
 
-String FileAccessAndroid::get_path() const {
-	return path_src;
-}
-
-String FileAccessAndroid::get_path_absolute() const {
+String FileAccessAndroid::_get_path() const {
 	return absolute_path;
 }
 
 Error FileAccessAndroid::open_internal(const String &p_path, int p_mode_flags) {
 	_close();
 
-	path_src = p_path;
-	String path = fix_path(p_path).simplify_path();
+	String path = FileSystemProtocolOSAndroid::fix_path(p_path).simplify_path();
 	absolute_path = path;
 	if (path.begins_with("/")) {
 		path = path.substr(1);
-	} else if (path.begins_with("res://")) {
-		path = path.substr(6);
 	}
 
 	ERR_FAIL_COND_V(p_mode_flags & FileAccess::WRITE, ERR_UNAVAILABLE); //can't write on android..
@@ -132,10 +126,6 @@ uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const 
 	return r;
 }
 
-int64_t FileAccessAndroid::_get_size(const String &p_file) {
-	return AAsset_getLength64(asset);
-}
-
 Error FileAccessAndroid::get_error() const {
 	return eof ? ERR_FILE_EOF : OK; // not sure what else it may happen
 }
@@ -146,24 +136,6 @@ void FileAccessAndroid::flush() {
 
 bool FileAccessAndroid::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_V(false);
-}
-
-bool FileAccessAndroid::file_exists(const String &p_path) {
-	String path = fix_path(p_path).simplify_path();
-	if (path.begins_with("/")) {
-		path = path.substr(1);
-	} else if (path.begins_with("res://")) {
-		path = path.substr(6);
-	}
-
-	AAsset *at = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);
-
-	if (!at) {
-		return false;
-	}
-
-	AAsset_close(at);
-	return true;
 }
 
 void FileAccessAndroid::close() {

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -46,18 +46,20 @@ class FileAccessAndroid : public FileAccess {
 	mutable uint64_t pos = 0;
 	mutable bool eof = false;
 	String absolute_path;
-	String path_src;
 
 	void _close();
 
+	friend class FileSystemProtocolOSAndroid;
+
+protected:
+	/// returns the path for the current open file
+	virtual String _get_path() const override;
+
 public:
+	virtual bool is_os_file() const override { return true; }
+
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; // open a file
 	virtual bool is_open() const override; // true when file is open
-
-	/// returns the path for the current open file
-	virtual String get_path() const override;
-	/// returns the absolute path for the current open file
-	virtual String get_path_absolute() const override;
 
 	virtual void seek(uint64_t p_position) override; // seek to a given position
 	virtual void seek_end(int64_t p_position = 0) override; // seek from the end of file
@@ -73,19 +75,6 @@ public:
 
 	virtual void flush() override;
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override;
-
-	virtual bool file_exists(const String &p_path) override; // return true if a file exists
-
-	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
-	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
-	virtual int64_t _get_size(const String &p_file) override;
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return ERR_UNAVAILABLE; }
-
-	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
-	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
 
 	virtual void close() override;
 

--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -30,6 +30,7 @@
 
 #include "file_access_filesystem_jandroid.h"
 
+#include "filesystem_protocol_os_jandroid.h"
 #include "thread_jandroid.h"
 
 #include "core/os/os.h"
@@ -57,11 +58,7 @@ jmethodID FileAccessFilesystemJAndroid::_file_last_accessed = nullptr;
 jmethodID FileAccessFilesystemJAndroid::_file_resize = nullptr;
 jmethodID FileAccessFilesystemJAndroid::_file_size = nullptr;
 
-String FileAccessFilesystemJAndroid::get_path() const {
-	return path_src;
-}
-
-String FileAccessFilesystemJAndroid::get_path_absolute() const {
+String FileAccessFilesystemJAndroid::_get_path() const {
 	return absolute_path;
 }
 
@@ -74,7 +71,7 @@ Error FileAccessFilesystemJAndroid::open_internal(const String &p_path, int p_mo
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL_V(env, ERR_UNCONFIGURED);
 
-		String path = fix_path(p_path).simplify_path();
+		String path = FileSystemProtocolOSJAndroid::fix_path(p_path).simplify_path();
 		jstring js = env->NewStringUTF(path.utf8().get_data());
 		int res = env->CallIntMethod(file_access_handler, _file_open, js, p_mode_flags);
 		env->DeleteLocalRef(js);
@@ -85,7 +82,6 @@ Error FileAccessFilesystemJAndroid::open_internal(const String &p_path, int p_mo
 		}
 
 		id = res;
-		path_src = p_path;
 		absolute_path = path;
 		return OK;
 	} else {
@@ -281,66 +277,6 @@ void FileAccessFilesystemJAndroid::flush() {
 		ERR_FAIL_NULL(env);
 		ERR_FAIL_COND_MSG(!is_open(), "File must be opened before use.");
 		env->CallVoidMethod(file_access_handler, _file_flush, id);
-	}
-}
-
-bool FileAccessFilesystemJAndroid::file_exists(const String &p_path) {
-	if (_file_exists) {
-		JNIEnv *env = get_jni_env();
-		ERR_FAIL_NULL_V(env, false);
-
-		String path = fix_path(p_path).simplify_path();
-		jstring js = env->NewStringUTF(path.utf8().get_data());
-		bool result = env->CallBooleanMethod(file_access_handler, _file_exists, js);
-		env->DeleteLocalRef(js);
-		return result;
-	} else {
-		return false;
-	}
-}
-
-uint64_t FileAccessFilesystemJAndroid::_get_modified_time(const String &p_file) {
-	if (_file_last_modified) {
-		JNIEnv *env = get_jni_env();
-		ERR_FAIL_NULL_V(env, 0);
-
-		String path = fix_path(p_file).simplify_path();
-		jstring js = env->NewStringUTF(path.utf8().get_data());
-		uint64_t result = env->CallLongMethod(file_access_handler, _file_last_modified, js);
-		env->DeleteLocalRef(js);
-		return result;
-	} else {
-		return 0;
-	}
-}
-
-uint64_t FileAccessFilesystemJAndroid::_get_access_time(const String &p_file) {
-	if (_file_last_accessed) {
-		JNIEnv *env = get_jni_env();
-		ERR_FAIL_NULL_V(env, 0);
-
-		String path = fix_path(p_file).simplify_path();
-		jstring js = env->NewStringUTF(path.utf8().get_data());
-		uint64_t result = env->CallLongMethod(file_access_handler, _file_last_accessed, js);
-		env->DeleteLocalRef(js);
-		return result;
-	} else {
-		return 0;
-	}
-}
-
-int64_t FileAccessFilesystemJAndroid::_get_size(const String &p_file) {
-	if (_file_size) {
-		JNIEnv *env = get_jni_env();
-		ERR_FAIL_NULL_V(env, -1);
-
-		String path = fix_path(p_file).simplify_path();
-		jstring js = env->NewStringUTF(path.utf8().get_data());
-		int64_t result = env->CallLongMethod(file_access_handler, _file_size, js);
-		env->DeleteLocalRef(js);
-		return result;
-	} else {
-		return -1;
 	}
 }
 

--- a/platform/android/file_access_filesystem_jandroid.h
+++ b/platform/android/file_access_filesystem_jandroid.h
@@ -57,19 +57,21 @@ class FileAccessFilesystemJAndroid : public FileAccess {
 
 	int id;
 	String absolute_path;
-	String path_src;
 
 	void _close(); ///< close a file
 	void _set_eof(bool eof);
 
+	friend class FileSystemProtocolOSJAndroid;
+
+protected:
+	/// returns the path for the current open file
+	virtual String _get_path() const override;
+
 public:
+	virtual bool is_os_file() const override { return true; }
+
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
-
-	/// returns the path for the current open file
-	virtual String get_path() const override;
-	/// returns the absolute path for the current open file
-	virtual String get_path_absolute() const override;
 
 	virtual void seek(uint64_t p_position) override; ///< seek to a given position
 	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
@@ -87,21 +89,8 @@ public:
 	virtual void flush() override;
 	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override;
 
-	virtual bool file_exists(const String &p_path) override; ///< return true if a file exists
-
 	static void setup(jobject p_file_access_handler);
 	static void terminate();
-
-	virtual uint64_t _get_modified_time(const String &p_file) override;
-	virtual uint64_t _get_access_time(const String &p_file) override;
-	virtual int64_t _get_size(const String &p_file) override;
-	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
-	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return ERR_UNAVAILABLE; }
-
-	virtual bool _get_hidden_attribute(const String &p_file) override { return false; }
-	virtual Error _set_hidden_attribute(const String &p_file, bool p_hidden) override { return ERR_UNAVAILABLE; }
-	virtual bool _get_read_only_attribute(const String &p_file) override { return false; }
-	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override { return ERR_UNAVAILABLE; }
 
 	virtual void close() override;
 

--- a/platform/android/filesystem_protocol_os_android.h
+++ b/platform/android/filesystem_protocol_os_android.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_os_android.h                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,68 +30,13 @@
 
 #pragma once
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#include "core/io/filesystem_protocol.h"
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
-
-class FileAccessEncrypted : public FileAccess {
+class FileSystemProtocolOSAndroid : public FileSystemProtocol {
 public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+	static String fix_path(const String &p_path);
 
-private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
-
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
-
-public:
-	virtual bool is_os_file() const override;
-
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
-
-	Vector<uint8_t> get_iv() const { return iv; }
-
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
-
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const override;
+	virtual bool file_exists(const String &p_path) const override;
+	virtual int64_t get_size(const String &p_path) const override;
 };

--- a/platform/android/filesystem_protocol_os_jandroid.cpp
+++ b/platform/android/filesystem_protocol_os_jandroid.cpp
@@ -1,0 +1,112 @@
+/**************************************************************************/
+/*  filesystem_protocol_os_jandroid.cpp                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "filesystem_protocol_os_jandroid.h"
+#include "core/io/filesystem.h"
+#include "file_access_filesystem_jandroid.h"
+#include "thread_jandroid.h"
+
+String FileSystemProtocolOSJAndroid::fix_path(const String &p_path) {
+	String r_path = FileSystem::fix_path(p_path);
+	return r_path;
+}
+
+Ref<FileAccess> FileSystemProtocolOSJAndroid::open_file(const String &p_path, int p_mode_flags, Error &r_error) const {
+	Ref<FileAccessFilesystemJAndroid> file = Ref<FileAccessFilesystemJAndroid>();
+	file.instantiate();
+
+	r_error = file->open_internal(p_path, p_mode_flags);
+
+	if (r_error != OK) {
+		file.unref();
+	}
+
+	return file;
+}
+
+bool FileSystemProtocolOSJAndroid::file_exists(const String &p_path) const {
+	if (FileAccessFilesystemJAndroid::_file_exists) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, false);
+
+		String path = fix_path(p_path).simplify_path();
+		jstring js = env->NewStringUTF(path.utf8().get_data());
+		bool result = env->CallBooleanMethod(FileAccessFilesystemJAndroid::file_access_handler, FileAccessFilesystemJAndroid::_file_exists, js);
+		env->DeleteLocalRef(js);
+		return result;
+	} else {
+		return false;
+	}
+}
+
+uint64_t FileSystemProtocolOSJAndroid::get_modified_time(const String &p_file) const {
+	if (FileAccessFilesystemJAndroid::_file_last_modified) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, false);
+
+		String path = fix_path(p_file).simplify_path();
+		jstring js = env->NewStringUTF(path.utf8().get_data());
+		uint64_t result = env->CallLongMethod(FileAccessFilesystemJAndroid::file_access_handler, FileAccessFilesystemJAndroid::_file_last_modified, js);
+		env->DeleteLocalRef(js);
+		return result;
+	} else {
+		return 0;
+	}
+}
+
+uint64_t FileSystemProtocolOSJAndroid::get_access_time(const String &p_file) const {
+	if (FileAccessFilesystemJAndroid::_file_last_accessed) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, 0);
+
+		String path = fix_path(p_file).simplify_path();
+		jstring js = env->NewStringUTF(path.utf8().get_data());
+		uint64_t result = env->CallLongMethod(FileAccessFilesystemJAndroid::file_access_handler, FileAccessFilesystemJAndroid::_file_last_accessed, js);
+		env->DeleteLocalRef(js);
+		return result;
+	} else {
+		return 0;
+	}
+}
+
+int64_t FileSystemProtocolOSJAndroid::get_size(const String &p_file) const {
+	if (FileAccessFilesystemJAndroid::_file_size) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, -1);
+
+		String path = fix_path(p_file).simplify_path();
+		jstring js = env->NewStringUTF(path.utf8().get_data());
+		int64_t result = env->CallLongMethod(FileAccessFilesystemJAndroid::file_access_handler, FileAccessFilesystemJAndroid::_file_size, js);
+		env->DeleteLocalRef(js);
+		return result;
+	} else {
+		return -1;
+	}
+}

--- a/platform/android/filesystem_protocol_os_jandroid.h
+++ b/platform/android/filesystem_protocol_os_jandroid.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  file_access_encrypted.h                                               */
+/*  filesystem_protocol_os_jandroid.h                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,68 +30,15 @@
 
 #pragma once
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/file_access.h"
+#include "core/io/filesystem_protocol.h"
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
-
-class FileAccessEncrypted : public FileAccess {
+class FileSystemProtocolOSJAndroid : public FileSystemProtocol {
 public:
-	enum Mode : int32_t {
-		MODE_READ,
-		MODE_WRITE_AES256,
-		MODE_MAX
-	};
+	static String fix_path(const String &p_path);
 
-private:
-	Vector<uint8_t> iv;
-	Vector<uint8_t> key;
-	bool writing = false;
-	Ref<FileAccess> file;
-	uint64_t base = 0;
-	uint64_t length = 0;
-	Vector<uint8_t> data;
-	mutable uint64_t pos = 0;
-	mutable bool eofed = false;
-	bool use_magic = true;
-
-	void _close();
-
-	static CryptoCore::RandomGenerator *_fae_static_rng;
-
-protected:
-	virtual String _get_path() const override; /// returns the path for the current open file
-
-public:
-	virtual bool is_os_file() const override;
-
-	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
-	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
-
-	Vector<uint8_t> get_iv() const { return iv; }
-
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
-	virtual bool is_open() const override; ///< true when file is open
-
-	virtual void seek(uint64_t p_position) override; ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0) override; ///< seek from the end of file
-	virtual uint64_t get_position() const override; ///< get position in the file
-	virtual uint64_t get_length() const override; ///< get size of the file
-
-	virtual bool eof_reached() const override; ///< reading passed EOF
-
-	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const override;
-
-	virtual Error get_error() const override; ///< get last error
-
-	virtual Error resize(int64_t p_length) override { return ERR_UNAVAILABLE; }
-	virtual void flush() override;
-	virtual bool store_buffer(const uint8_t *p_src, uint64_t p_length) override; ///< store an array of bytes
-
-	virtual void close() override;
-
-	static void deinitialize();
-
-	FileAccessEncrypted() {}
-	~FileAccessEncrypted();
+	virtual Ref<FileAccess> open_file(const String &p_path, int p_mode_flags, Error &r_error) const override;
+	virtual bool file_exists(const String &p_path) const override;
+	virtual uint64_t get_modified_time(const String &p_file) const override;
+	virtual uint64_t get_access_time(const String &p_path) const override;
+	virtual int64_t get_size(const String &p_path) const override;
 };

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -34,12 +34,15 @@
 #include "display_server_android.h"
 #include "file_access_android.h"
 #include "file_access_filesystem_jandroid.h"
+#include "filesystem_protocol_os_android.h"
+#include "filesystem_protocol_os_jandroid.h"
 #include "java_godot_io_wrapper.h"
 #include "java_godot_wrapper.h"
 #include "net_socket_android.h"
 
 #include "core/config/project_settings.h"
 #include "core/extension/gdextension_manager.h"
+#include "core/io/filesystem.h"
 #include "core/io/xml_parser.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
@@ -47,6 +50,7 @@
 #include "editor/editor_node.h"
 #include "editor/plugins/game_view_plugin.h"
 #endif
+#include "drivers/unix/filesystem_protocol_os_unix.h"
 #include "main/main.h"
 #include "scene/main/scene_tree.h"
 #include "servers/rendering_server.h"
@@ -90,17 +94,50 @@ void OS_Android::alert(const String &p_alert, const String &p_title) {
 void OS_Android::initialize_core() {
 	OS_Unix::initialize_core();
 
+	NetSocketAndroid::make_default();
+}
+
+void OS_Android::initialize() {
+	initialize_core();
+}
+
+const String OS_Android::filesystem_protocol_name_os_unix = "os-unix";
+const String OS_Android::filesystem_protocol_name_os_android = "os-android";
+const String OS_Android::filesystem_protocol_name_os_jandroid = "os-jandroid";
+
+void OS_Android::initialize_filesystem() {
+	FileSystem *fs = FileSystem::get_singleton();
+
+	// Unix
+	Ref<FileSystemProtocolOSUnix> protocol_os_unix = Ref<FileSystemProtocolOSUnix>();
+	protocol_os_unix.instantiate();
+	fs->add_protocol(filesystem_protocol_name_os_unix, protocol_os_unix);
+
+	// Android
+	Ref<FileSystemProtocolOSAndroid> protocol_os_android = Ref<FileSystemProtocolOSAndroid>();
+	protocol_os_android.instantiate();
+	fs->add_protocol(filesystem_protocol_name_os_android, protocol_os_android);
+
+	// Filesystem JAndroid
+	Ref<FileSystemProtocolOSJAndroid> protocol_os_jandroid = Ref<FileSystemProtocolOSJAndroid>();
+	protocol_os_jandroid.instantiate();
+	fs->add_protocol(filesystem_protocol_name_os_jandroid, protocol_os_jandroid);
+	// JAndroid is the main protocol for direct OS file accessing
+	fs->add_protocol(FileSystem::protocol_name_os, protocol_os_jandroid);
+
+	// user:// uses Unix
+	fs->set_underlying_protocol_name_for_user(filesystem_protocol_name_os_unix);
+
+	// res:// uses Unix or Android depending on apk expansion usage
 #ifdef TOOLS_ENABLED
-	FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_RESOURCES);
+	fs->set_underlying_protocol_name_for_resources(filesystem_protocol_name_os_unix);
 #else
 	if (use_apk_expansion) {
-		FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_RESOURCES);
+		fs->set_underlying_protocol_name_for_resources(filesystem_protocol_name_os_unix);
 	} else {
-		FileAccess::make_default<FileAccessAndroid>(FileAccess::ACCESS_RESOURCES);
+		fs->set_underlying_protocol_name_for_resources(filesystem_protocol_name_os_android);
 	}
 #endif
-	FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_USERDATA);
-	FileAccess::make_default<FileAccessFilesystemJAndroid>(FileAccess::ACCESS_FILESYSTEM);
 
 #ifdef TOOLS_ENABLED
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_RESOURCES);
@@ -113,12 +150,6 @@ void OS_Android::initialize_core() {
 #endif
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_USERDATA);
 	DirAccess::make_default<DirAccessJAndroid>(DirAccess::ACCESS_FILESYSTEM);
-
-	NetSocketAndroid::make_default();
-}
-
-void OS_Android::initialize() {
-	initialize_core();
 }
 
 void OS_Android::initialize_joypads() {
@@ -936,7 +967,7 @@ Error OS_Android::setup_remote_filesystem(const String &p_server_host, int p_por
 	Error err = OS_Unix::setup_remote_filesystem(p_server_host, p_port, p_password, r_project_path);
 	if (err == OK) {
 		remote_fs_dir = r_project_path;
-		FileAccess::make_default<FileAccessFilesystemJAndroid>(FileAccess::ACCESS_RESOURCES);
+		FileSystem::get_singleton()->set_underlying_protocol_name_for_resources(filesystem_protocol_name_os_jandroid);
 	}
 	return err;
 }

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -91,6 +91,10 @@ public:
 	static const int DEFAULT_WINDOW_WIDTH = 800;
 	static const int DEFAULT_WINDOW_HEIGHT = 600;
 
+	static const String filesystem_protocol_name_os_unix;
+	static const String filesystem_protocol_name_os_android;
+	static const String filesystem_protocol_name_os_jandroid;
+
 #ifdef TOOLS_ENABLED
 	Error sign_apk(const String &p_input_path, const String &p_output_path, const String &p_keystore_path, const String &p_keystore_user, const String &p_keystore_password);
 	Error verify_apk(const String &p_apk_path);
@@ -99,6 +103,7 @@ public:
 	virtual void initialize_core() override;
 	virtual void initialize() override;
 
+	virtual void initialize_filesystem() override;
 	virtual void initialize_joypads() override;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) override;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -38,11 +38,14 @@
 
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
+#include "core/io/filesystem.h"
 #include "core/io/marshalls.h"
 #include "core/version_generated.gen.h"
 #include "drivers/windows/dir_access_windows.h"
 #include "drivers/windows/file_access_windows.h"
 #include "drivers/windows/file_access_windows_pipe.h"
+#include "drivers/windows/filesystem_protocol_os_windows.h"
+#include "drivers/windows/filesystem_protocol_pipe_windows.h"
 #include "drivers/windows/ip_windows.h"
 #include "drivers/windows/net_socket_winsock.h"
 #include "drivers/windows/thread_windows.h"
@@ -105,23 +108,6 @@ __declspec(dllexport) void NoHotPatch() {} // Disable Nahimic code injection.
 #ifndef DWRITE_FONT_WEIGHT_SEMI_LIGHT
 #define DWRITE_FONT_WEIGHT_SEMI_LIGHT (DWRITE_FONT_WEIGHT)350
 #endif
-
-static String fix_path(const String &p_path) {
-	String path = p_path;
-	if (p_path.is_relative_path()) {
-		Char16String current_dir_name;
-		size_t str_len = GetCurrentDirectoryW(0, nullptr);
-		current_dir_name.resize(str_len + 1);
-		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
-		path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(path);
-	}
-	path = path.simplify_path();
-	path = path.replace_char('/', '\\');
-	if (path.size() >= MAX_PATH && !path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
-		path = R"(\\?\)" + path;
-	}
-	return path;
-}
 
 static String format_error_message(DWORD id) {
 	LPWSTR messageBuffer = nullptr;
@@ -267,14 +253,6 @@ void OS_Windows::initialize() {
 	init_thread_win();
 #endif
 
-	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_RESOURCES);
-	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_USERDATA);
-	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_FILESYSTEM);
-	FileAccess::make_default<FileAccessWindowsPipe>(FileAccess::ACCESS_PIPE);
-	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_RESOURCES);
-	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_USERDATA);
-	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_FILESYSTEM);
-
 	NetSocketWinSock::make_default();
 
 	// We need to know how often the clock is updated
@@ -324,8 +302,24 @@ void OS_Windows::initialize() {
 	} else if (!dwrite2_init) {
 		print_verbose("Unable to load IDWriteFactory2, automatic system font fallback is disabled.");
 	}
+}
+void OS_Windows::initialize_filesystem() {
+	FileSystem *fs = FileSystem::get_singleton();
+	FileSystemProtocolOSWindows::initialize();
 
-	FileAccessWindows::initialize();
+	Ref<FileSystemProtocolOSWindows> protocol_os = Ref<FileSystemProtocolOSWindows>();
+	protocol_os.instantiate();
+	fs->add_protocol(FileSystem::protocol_name_os, protocol_os);
+
+	Ref<FileSystemProtocolPipeWindows> protocol_pipe = Ref<FileSystemProtocolPipeWindows>();
+	protocol_pipe.instantiate();
+	fs->add_protocol(FileSystem::protocol_name_pipe, protocol_pipe);
+
+	fs->set_os_path_case_mismatch_checker(&FileSystemProtocolOSWindows::check_path_case_mismatch);
+
+	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_RESOURCES);
+	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_USERDATA);
+	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_FILESYSTEM);
 }
 
 void OS_Windows::delete_main_loop() {
@@ -372,7 +366,7 @@ void OS_Windows::finalize_core() {
 		_remove_temp_library(temp_libraries.last()->key);
 	}
 
-	FileAccessWindows::finalize();
+	FileSystemProtocolOSWindows::finalize();
 
 	timeEndPeriod(1);
 
@@ -504,8 +498,8 @@ Error OS_Windows::open_dynamic_library(const String &p_path, void *&p_library_ha
 	bool has_dll_directory_api = ((add_dll_directory != nullptr) && (remove_dll_directory != nullptr));
 	DLL_DIRECTORY_COOKIE cookie = nullptr;
 
-	String dll_path = fix_path(load_path);
-	String dll_dir = fix_path(ProjectSettings::get_singleton()->globalize_path(load_path.get_base_dir()));
+	String dll_path = FileSystemProtocolOSWindows::fix_path(load_path);
+	String dll_dir = FileSystemProtocolOSWindows::fix_path(ProjectSettings::get_singleton()->globalize_path(load_path.get_base_dir()));
 	if (p_data != nullptr && p_data->also_set_library_path && has_dll_directory_api) {
 		cookie = add_dll_directory((LPCWSTR)(dll_dir.utf16().get_data()));
 	}
@@ -1231,7 +1225,7 @@ Dictionary OS_Windows::execute_with_pipe(const String &p_path, const List<String
 
 	Dictionary ret;
 
-	String path = p_path.is_absolute_path() ? fix_path(p_path) : p_path;
+	String path = p_path.is_absolute_path() ? FileSystemProtocolOSWindows::fix_path(p_path) : p_path;
 	String command = _quote_command_line_argument(path);
 	for (const String &E : p_arguments) {
 		command += " " + _quote_command_line_argument(E);
@@ -1337,7 +1331,7 @@ Dictionary OS_Windows::execute_with_pipe(const String &p_path, const List<String
 }
 
 Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments, String *r_pipe, int *r_exitcode, bool read_stderr, Mutex *p_pipe_mutex, bool p_open_console) {
-	String path = p_path.is_absolute_path() ? fix_path(p_path) : p_path;
+	String path = p_path.is_absolute_path() ? FileSystemProtocolOSWindows::fix_path(p_path) : p_path;
 	String command = _quote_command_line_argument(path);
 	for (const String &E : p_arguments) {
 		command += " " + _quote_command_line_argument(E);
@@ -1479,7 +1473,7 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 }
 
 Error OS_Windows::create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id, bool p_open_console) {
-	String path = p_path.is_absolute_path() ? fix_path(p_path) : p_path;
+	String path = p_path.is_absolute_path() ? FileSystemProtocolOSWindows::fix_path(p_path) : p_path;
 	String command = _quote_command_line_argument(path);
 	for (const String &E : p_arguments) {
 		command += " " + _quote_command_line_argument(E);
@@ -2150,7 +2144,7 @@ Error OS_Windows::shell_show_in_file_manager(String p_path, bool p_open_folder) 
 	if (!p_path.is_quoted()) {
 		p_path = p_path.quote();
 	}
-	p_path = fix_path(p_path);
+	p_path = FileSystemProtocolOSWindows::fix_path(p_path);
 
 	INT_PTR ret = OK;
 	if (open_folder) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -142,6 +142,7 @@ class OS_Windows : public OS {
 	// functions used by main to initialize/deinitialize the OS
 protected:
 	virtual void initialize() override;
+	virtual void initialize_filesystem() override;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) override;
 	virtual void delete_main_loop() override;


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/11032
closes https://github.com/godotengine/godot-proposals/issues/6307

This PR is a refactor of the Godot FileAccess system. It adds FileSystem and FileSystemProtocol to manage file path prefixes.

FileAccess access type and create_funcs are removed now. Different FileAccess types only deals with their targeted file source now, which means different platform's OS FileAccess now only handles paths that are in the os filesystem. They don't need to handle res:// user:// anymore, in fact, they don't even know about other protocols now. Platforms now implement their own OS protocol and OS FileAccess and register the os protocol to the FileSystem.

Current-file-unrelated methods like `file_exists(path)` and `get_modified_time(path)` are also moved to FileSystemProtocol. The original implementation instantiates a FileAccess, calls the method and immediately throws it away. This change can theoretically improve the performance with simple file operations.

By pre-defining some FileSystemProtocols that remaps paths, users can easily register a protocol prefix that remaps file paths.

Next, I'll move current-directory-unrelated methods to FileSystemProtocol. Making calls to those absolute directory methods will become cheaper. DirAccess can also just become a simple wrapper of FileSystemProtocols.

# Issues
<details>
<summary>(Fixed) gdscript://</summary>

### Solution
As far as I can tell, `gdscript://object_id.gd` represents a gdscript instance in memory.
To prevent stepping in old code, gdscript protocol is reserved. It fails all accesses silently.
### Descripton
Introduced by #71197 
This is the reason that GDScript test fails. It expects hardcoded console output. During the test, GDScript system requires a resource load for the file path prefixed `gdscript://`, which would silently fail and return false in the old FileAccess implementation. But in FileSystem, an error message of `Unknown filesystem protocol gdscript` generates, thus failing the test.
I don't think muting the error message is a good approach, if anyone adds a gdscript protocol, GDScript system would break because of this.
</details>

## non-OS DirAccess change_dir to aboslute OS paths
```py
DirAccess.make_dir_recursive_absolute("user://test")

# Get the aboslute OS path for user://test
# might be `%APPDATA%\Godot\app_userdata\GameName\test` on Windows
# or `~/.local/share/godot/app_userdata/GameName/test` on Linux
var absolute_path = ProjectSettings.globalize_path("user://test")


var dir = DirAccess.open("user://")

# This won't work as expected, DirAccess forbids you switch to directories outside user://
dir.change_dir("/any/other/path/on/disk")

# But this works, even if the given absolute path is not a path with user:// prefix
dir.change_dir(absolute_path)

# Current path is now user://test
print(dir.get_current_path())
```
This is caused by how change_dir handles protocol prefixes. It converts current path and target path to OS absolute paths, does the CWD changing to verify the path, and finally strip the specific protocol's root path from the aboslute path and add the protocol prefix.

It doesn't seem to be a by-design behavior for a DirAccess which handles prefixed paths to successfully change into an aboslute OS path. This seems to only be a weird edge case caused by the original implementation.

This won't work anymore after this PR, because every protocol handler are only given the path under that prefix now. You can only change_dir to a relative path or an absolute path with that prefix now.

# Todo
- [x] Add `FileSystem` & `FileSystemProtocol`
- [x] Move current-file-unrelated methods of `FileAccess` to `FileSystemProtocol`
- [ ] Move current-directory-unrelated methods of `DirAccess` to `FileSystemProtocol`
- [ ] Write documents

## Move hard-coded protocols to FileSystemProtocol
`os://` and `pipe://` are implemented and registered by different OS platforms.
- [x] `res://`
- [x] `user://`
- [x] `uid://`
* `mem://` if #98287 is merged

## Platform supports
Create `FileSystemProtocolOS` and `FileSystemProtocolPipe`.
Cleanup `FileAccessPlatform` and `FileAccessPlatformPipe`.
Add `OS_Platform::initialize_filesystem()`.
Remove previous `FileAccess::make_default` calls from `OS_Platform::initialize()`
- [x] Windows
- [x] Linux
- [x] Android
- [ ] MacOS (For DirAccess)

# Future Tasks
* Add `FileAccessProtocolRemap`
* Expose FileSystemProtocol to GDVirtual