### PR TITLE
Add renderer state defines to shader preprocessor

### DIFF
--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -132,6 +132,7 @@ private:
 	struct Define {
 		Vector<String> arguments;
 		String body;
+		bool is_builtin = false;
 	};
 
 	struct Branch {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10764

implements 4 built-in defines to shader preprocessor:

- `CURRENT_RENDERER` is either `0`, `1`, `2` (depends on current renderer)
- `RENDERER_COMPATIBILITY` is `0`
- `RENDERER_MOBILE` is `1`
- `RENDERER_FORWARD_PLUS` is `2`

Using it is simple:

![изображение](https://github.com/user-attachments/assets/d4b5b696-fc23-474e-9c20-9eb8dfcf8ec9)
