### PR TITLE
Add "OpenGL 3", "GLES" and "Linux/*BSD" to editor property capitalization

### DIFF
--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -198,6 +198,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["gi"] = "GI";
 	capitalize_string_remaps["gl"] = "GL";
 	capitalize_string_remaps["glb"] = "GLB";
+	capitalize_string_remaps["gles"] = "GLES";
 	capitalize_string_remaps["gles2"] = "GLES2";
 	capitalize_string_remaps["gles3"] = "GLES3";
 	capitalize_string_remaps["gltf"] = "glTF";
@@ -231,6 +232,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["kb"] = "(KB)"; // Unit.
 	capitalize_string_remaps["lcd"] = "LCD";
 	capitalize_string_remaps["ldr"] = "LDR";
+	capitalize_string_remaps["linuxbsd"] = "Linux/*BSD";
 	capitalize_string_remaps["lod"] = "LOD";
 	capitalize_string_remaps["lods"] = "LODs";
 	capitalize_string_remaps["lowpass"] = "Low-pass";
@@ -248,6 +250,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["oidn"] = "OIDN";
 	capitalize_string_remaps["ok"] = "OK";
 	capitalize_string_remaps["opengl"] = "OpenGL";
+	capitalize_string_remaps["opengl3"] = "OpenGL 3";
 	capitalize_string_remaps["opentype"] = "OpenType";
 	capitalize_string_remaps["openxr"] = "OpenXR";
 	capitalize_string_remaps["osslsigncode"] = "osslsigncode";


### PR DESCRIPTION
This is required to capitalize the following settings:

- **Fallback to OpenGL 3** project setting
- **Fallback to GLES** project setting
- **Linux/\*BSD** category in the Editor Settings

## Preview

*Note that "ANGLE" can't be capitalized here, because it's often used to refer as an angle, not as the graphics API translation library.*

![Screenshot_20241026_151740](https://github.com/user-attachments/assets/e70fdc83-9c80-4e0e-a043-7974e7197fa7)

![Screenshot_20241026_151746](https://github.com/user-attachments/assets/50120898-0129-4f54-b87a-e2338053886e)

![image](https://github.com/user-attachments/assets/5d8fac6c-b158-40aa-b696-8545bc87af4e)
