### PR TITLE
GDScript: Implement soft access restriction for members prefixed with `_` and `__` (as warning by default)

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -469,11 +469,23 @@
 			Specifies the maximum number of log files allowed (used for rotation). Set to [code]1[/code] to disable log file rotation.
 			If the [code]--log-file &lt;file&gt;[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url] is used, log rotation is always disabled.
 		</member>
+		<member name="debug/gdscript/warnings/accessing_private_member" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a member beginning with [code]__[/code] is accessed from outside the class.
+		</member>
+		<member name="debug/gdscript/warnings/accessing_protected_member" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a member beginning with [code]_[/code] is accessed from outside the class or the super class where it is defined.
+		</member>
 		<member name="debug/gdscript/warnings/assert_always_false" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an [code]assert[/code] call always evaluates to [code]false[/code].
 		</member>
 		<member name="debug/gdscript/warnings/assert_always_true" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when an [code]assert[/code] call always evaluates to [code]true[/code].
+		</member>
+		<member name="debug/gdscript/warnings/calling_private_method" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a method beginning with [code]__[/code] is called from outside the class.
+		</member>
+		<member name="debug/gdscript/warnings/calling_protected_method" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a method beginning with [code]_[/code] is called from outside the class or the super class where it is defined.
 		</member>
 		<member name="debug/gdscript/warnings/confusable_capture_reassignment" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a local variable captured by a lambda is reassigned, since this does not modify the outer local variable.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -616,6 +616,9 @@
 		<member name="debug/gdscript/warnings/unused_private_class_variable" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a private member variable is never used.
 		</member>
+		<member name="debug/gdscript/warnings/unused_protected_class_variable" type="int" setter="" getter="" default="1">
+			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a protected member variable is never used.
+		</member>
 		<member name="debug/gdscript/warnings/unused_signal" type="int" setter="" getter="" default="1">
 			When set to [code]warn[/code] or [code]error[/code], produces a warning or an error respectively when a signal is declared but never explicitly used in the class.
 		</member>

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -343,7 +343,6 @@ void GDScriptAnalyzer::get_class_node_current_scope_classes(GDScriptParser::Clas
 
 #ifdef DEBUG_ENABLED
 void GDScriptAnalyzer::check_access_private_member(GDScriptParser::IdentifierNode *p_identifier, const bool p_is_call) {
-
 	if (p_identifier == nullptr) {
 		return;
 	}
@@ -358,7 +357,6 @@ void GDScriptAnalyzer::check_access_private_member(GDScriptParser::IdentifierNod
 	}
 }
 #endif
-
 
 Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_class, const GDScriptParser::Node *p_source) {
 	if (p_source == nullptr && parser->has_class(p_class)) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -343,6 +343,7 @@ void GDScriptAnalyzer::get_class_node_current_scope_classes(GDScriptParser::Clas
 
 #ifdef DEBUG_ENABLED
 void GDScriptAnalyzer::check_access_private_member(GDScriptParser::IdentifierNode *p_identifier, const bool p_is_call) {
+
 	if (p_identifier == nullptr) {
 		return;
 	}
@@ -357,6 +358,7 @@ void GDScriptAnalyzer::check_access_private_member(GDScriptParser::IdentifierNod
 	}
 }
 #endif
+
 
 Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_class, const GDScriptParser::Node *p_source) {
 	if (p_source == nullptr && parser->has_class(p_class)) {
@@ -3528,15 +3530,18 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			push_error("Cannot use `super()` inside a lambda.", p_call);
 		}
 
+#ifdef DEBUG_ENABLED
 		GDScriptParser::IdentifierNode *identifier = static_cast<GDScriptParser::IdentifierNode *>(p_call->callee);
 		check_access_private_member(identifier);
+#endif
 	} else if (callee_type == GDScriptParser::Node::IDENTIFIER) {
 		base_type = parser->current_class->get_datatype();
 		base_type.is_meta_type = false;
 		is_self = true;
-
+#ifdef DEBUG_ENABLED
 		GDScriptParser::IdentifierNode *identifier = static_cast<GDScriptParser::IdentifierNode *>(p_call->callee);
 		check_access_private_member(identifier);
+#endif
 	} else if (callee_type == GDScriptParser::Node::SUBSCRIPT) {
 		GDScriptParser::SubscriptNode *subscript = static_cast<GDScriptParser::SubscriptNode *>(p_call->callee);
 		if (subscript->base == nullptr) {
@@ -3570,8 +3575,9 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			base_type = subscript->base->get_datatype();
 			is_self = subscript->base->type == GDScriptParser::Node::SELF;
 		}
-
+#ifdef DEBUG_ENABLED
 		check_access_private_member(subscript->attribute);
+#endif
 	} else {
 		// Invalid call. Error already sent in parser.
 		// TODO: Could check if Callable here too.

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -356,7 +356,7 @@ void GDScriptAnalyzer::check_access_private_member(GDScriptParser::IdentifierNod
 		parser->push_warning(p_identifier, p_is_call ? GDScriptWarning::CALLING_UNDERLINE_PREFIXED_METHOD : GDScriptWarning::ACCESSING_UNDERLINE_PREFIXED_MEMBER, p_identifier->name);
 	}
 }
-#endif
+#endif // DEBUG_ENABLED
 
 Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_class, const GDScriptParser::Node *p_source) {
 	if (p_source == nullptr && parser->has_class(p_class)) {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -68,6 +68,7 @@ class GDScriptAnalyzer {
 
 #ifdef DEBUG_ENABLED
 	void check_access_private_member(GDScriptParser::IdentifierNode *p_identifier, const bool p_is_call = false);
+	void warn_unused_private_protected_class_variable(const GDScriptParser::Node *p_node, const GDScriptParser::IdentifierNode *p_identifier);
 #endif
 
 	Error resolve_class_inheritance(GDScriptParser::ClassNode *p_class, const GDScriptParser::Node *p_source = nullptr);

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -66,6 +66,10 @@ class GDScriptAnalyzer {
 
 	void get_class_node_current_scope_classes(GDScriptParser::ClassNode *p_node, List<GDScriptParser::ClassNode *> *p_list, GDScriptParser::Node *p_source);
 
+#ifdef DEBUG_ENABLED
+	void check_access_private_member(GDScriptParser::IdentifierNode *p_identifier, const bool p_is_call = false);
+#endif
+
 	Error resolve_class_inheritance(GDScriptParser::ClassNode *p_class, const GDScriptParser::Node *p_source = nullptr);
 	Error resolve_class_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive);
 	GDScriptParser::DataType resolve_datatype(GDScriptParser::TypeNode *p_type);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -98,6 +98,8 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
 		// Onready annotation.
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
+
+		// register_annotation(MethodInfo("@virtual"), AnnotationInfo::FUNCTION, &GDScriptParser::virtual_annotation);
 		// Export annotations.
 		register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
 		register_annotation(MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_ENUM, Variant::NIL>, varray(), true);
@@ -4282,6 +4284,16 @@ bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_ta
 	current_class->onready_used = true;
 	return true;
 }
+// bool GDScriptParser::virtual_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+//	ERR_FAIL_COND_V_MSG(p_target->type != Node::FUNCTION, false, R"("@virtual" annotation can only be applied to class methods.)");
+//	FunctionNode *method = static_cast<FunctionNode *>(p_target);
+//	if (method->is_virtual) {
+//		push_error(R"("@virtual" annotation can only be applied to a method once.)", p_annotation);
+//		return false;
+//	}
+//	method->is_virtual = true;
+//	return true;
+// }
 
 static String _get_annotation_error_string(const StringName &p_annotation_name, const Vector<Variant::Type> &p_expected_types, const GDScriptParser::DataType &p_provided_type) {
 	Vector<String> types;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -336,8 +336,8 @@ public:
 			VARIABLE,
 			WHILE,
 		};
-
 		Type type = NONE;
+
 		int start_line = 0, end_line = 0;
 		int start_column = 0, end_column = 0;
 		int leftmost_column = 0, rightmost_column = 0;
@@ -855,6 +855,7 @@ public:
 		SuiteNode *body = nullptr;
 		bool is_static = false; // For lambdas it's determined in the analyzer.
 		bool is_coroutine = false;
+		bool is_virtual = false; // Only used for warning system, which allows a user to call a virtual method whose name begins with `_` or multiple `_`s.
 		Variant rpc_config;
 		MethodInfo info;
 		LambdaNode *source_lambda = nullptr;
@@ -1509,6 +1510,7 @@ private:
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	// bool virtual_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -917,6 +917,12 @@ public:
 		};
 		Source source = UNDEFINED_SOURCE;
 
+		enum IdentifierAccess {
+			ACCESS_PUBLIC,
+			ACCESS_PRIVATE,
+			ACCESS_PROTECTED,
+		};
+
 		union {
 			ParameterNode *parameter_source = nullptr;
 			IdentifierNode *bind_source;
@@ -930,6 +936,17 @@ public:
 		FunctionNode *source_function = nullptr; // TODO: Rename to disambiguate `function_source`.
 
 		int usages = 0; // Useful for binds/iterator variable.
+
+		IdentifierAccess get_access() const {
+			String str_name = String(name);
+			if (str_name.begins_with("__")) {
+				return ACCESS_PRIVATE;
+			} else if (str_name.begins_with("_")) {
+				return ACCESS_PROTECTED;
+			} else {
+				return ACCESS_PUBLIC;
+			}
+		}
 
 		IdentifierNode() {
 			type = IDENTIFIER;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -796,6 +796,20 @@ public:
 			members.push_back(Member(p_annotation_node));
 		}
 
+		Vector<StringName> get_super_class_fqcns() const {
+			Vector<StringName> ret;
+
+			const ClassNode *iterated_class = base_type.class_type;
+			while (iterated_class) {
+				if (iterated_class->datatype.kind == DataType::SCRIPT || iterated_class->datatype.kind == DataType::CLASS) {
+					ret.append(iterated_class->fqcn);
+				}
+				iterated_class = iterated_class->base_type.class_type;
+			}
+
+			return ret;
+		}
+
 		ClassNode() {
 			type = CLASS;
 		}
@@ -855,7 +869,7 @@ public:
 		SuiteNode *body = nullptr;
 		bool is_static = false; // For lambdas it's determined in the analyzer.
 		bool is_coroutine = false;
-		bool is_virtual = false; // Only used for warning system, which allows a user to call a virtual method whose name begins with `_` or multiple `_`s.
+		// bool is_virtual = false;
 		Variant rpc_config;
 		MethodInfo info;
 		LambdaNode *source_lambda = nullptr;

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -162,6 +162,12 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value is using "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
+		case ACCESSING_UNDERLINE_PREFIXED_MEMBER:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(Trying accessing the member "%s" prefixed with "_", which would be a private member.)", symbols[0]);
+		case CALLING_UNDERLINE_PREFIXED_METHOD:
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(Trying calling the method "%s()" prefixed with "_", which would be a private method.)*", symbols[0]);
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -238,6 +244,8 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"NATIVE_METHOD_OVERRIDE",
 		"GET_NODE_DEFAULT_WITHOUT_ONREADY",
 		"ONREADY_WITH_EXPORT",
+		"ACCESSING_UNDERLINE_PREFIXED_MEMBER",
+		"CALLING_UNDERLINE_PREFIXED_METHOD",
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -51,6 +51,7 @@ String GDScriptWarning::get_message() const {
 			CHECK_SYMBOLS(1);
 			return vformat(R"(The local constant "%s" is declared but never used in the block. If this is intended, prefix it with an underscore: "_%s".)", symbols[0], symbols[0]);
 		case UNUSED_PRIVATE_CLASS_VARIABLE:
+		case UNUSED_PROTECTED_CLASS_VARIABLE:
 			CHECK_SYMBOLS(1);
 			return vformat(R"(The class variable "%s" is declared but never used in the class.)", symbols[0]);
 		case UNUSED_PARAMETER:
@@ -162,12 +163,18 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value is using "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
-		case ACCESSING_UNDERLINE_PREFIXED_MEMBER:
+		case ACCESSING_PRIVATE_MEMBER:
 			CHECK_SYMBOLS(1);
-			return vformat(R"(Trying accessing the member "%s" prefixed with "_", which would be a private member.)", symbols[0]);
-		case CALLING_UNDERLINE_PREFIXED_METHOD:
+			return vformat(R"(Trying accessing the member "%s" prefixed with "__", which would be a private member.)", symbols[0]);
+		case CALLING_PRIVATE_METHOD:
 			CHECK_SYMBOLS(1);
-			return vformat(R"*(Trying calling the method "%s()" prefixed with "_", which would be a private method.)*", symbols[0]);
+			return vformat(R"*(Trying calling the method "%s()" prefixed with "__", which would be a private method.)*", symbols[0]);
+		case ACCESSING_PROTECTED_MEMBER:
+			CHECK_SYMBOLS(1);
+			return vformat(R"(Trying accessing the member "%s" prefixed with "_", which would be a protected member.)", symbols[0]);
+		case CALLING_PROTECTED_METHOD:
+			CHECK_SYMBOLS(1);
+			return vformat(R"*(Trying calling the method "%s()" prefixed with "_", which would be a protected method.)*", symbols[0]);
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -205,6 +212,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"UNUSED_VARIABLE",
 		"UNUSED_LOCAL_CONSTANT",
 		"UNUSED_PRIVATE_CLASS_VARIABLE",
+		"UNUSED_PROTECTED_CLASS_VARIABLE",
 		"UNUSED_PARAMETER",
 		"UNUSED_SIGNAL",
 		"SHADOWED_VARIABLE",
@@ -244,8 +252,10 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"NATIVE_METHOD_OVERRIDE",
 		"GET_NODE_DEFAULT_WITHOUT_ONREADY",
 		"ONREADY_WITH_EXPORT",
-		"ACCESSING_UNDERLINE_PREFIXED_MEMBER",
-		"CALLING_UNDERLINE_PREFIXED_METHOD",
+		"ACCESSING_PRIVATE_MEMBER",
+		"CALLING_PRIVATE_METHOD",
+		"ACCESSING_PROTECTED_MEMBER",
+		"CALLING_PROTECTED_METHOD",
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -50,7 +50,8 @@ public:
 		UNASSIGNED_VARIABLE_OP_ASSIGN, // Variable never assigned but used in an assignment operation (+=, *=, etc).
 		UNUSED_VARIABLE, // Local variable is declared but never used.
 		UNUSED_LOCAL_CONSTANT, // Local constant is declared but never used.
-		UNUSED_PRIVATE_CLASS_VARIABLE, // Class variable is declared private ("_" prefix) but never used in the class.
+		UNUSED_PRIVATE_CLASS_VARIABLE, // Class variable is declared private ("__" prefix) but never used in the class.
+		UNUSED_PROTECTED_CLASS_VARIABLE, // Class variable is declared private ("__" prefix) but never used in the class.
 		UNUSED_PARAMETER, // Function parameter is never used.
 		UNUSED_SIGNAL, // Signal is defined but never explicitly used in the class.
 		SHADOWED_VARIABLE, // A local variable/constant shadows a current class member.
@@ -90,8 +91,10 @@ public:
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
-		ACCESSING_UNDERLINE_PREFIXED_MEMBER, // A member prefixed with `_` is being accessed, whether the member exists or not.
-		CALLING_UNDERLINE_PREFIXED_METHOD, // A method prefixed with `_` is being called, whether the method exists or not. Will not thrown if the method is moditied by `@virtual`.
+		ACCESSING_PRIVATE_MEMBER, // A member prefixed with `__` is being accessed, whether the member exists or not.
+		CALLING_PRIVATE_METHOD, // A method prefixed with `__` is being called, whether the method exists or not.
+		ACCESSING_PROTECTED_MEMBER, // A member prefixed with `_` is being accessed, whether the member exists or not.
+		CALLING_PROTECTED_METHOD, // A method prefixed with `_` is being called, whether the method exists or not.
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -110,6 +113,7 @@ public:
 		WARN, // UNUSED_VARIABLE
 		WARN, // UNUSED_LOCAL_CONSTANT
 		WARN, // UNUSED_PRIVATE_CLASS_VARIABLE
+		WARN, // UNUSED_PROTECTED_CLASS_VARIABLE
 		WARN, // UNUSED_PARAMETER
 		WARN, // UNUSED_SIGNAL
 		WARN, // SHADOWED_VARIABLE
@@ -149,8 +153,10 @@ public:
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
-		WARN, // ACCESSING_UNDERLINE_PREFIXED_MEMBER
-		WARN, // CALLING_UNDERLINE_PREFIXED_METHOD
+		WARN, // ACCESSING_PRIVATE_MEMBER
+		WARN, // CALLING_PRIVATE_METHOD
+		WARN, // ACCESSING_PROTECTED_MEMBER
+		WARN, // CALLING_PROTECTED_METHOD
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -90,6 +90,8 @@ public:
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
+		ACCESSING_UNDERLINE_PREFIXED_MEMBER, // A member prefixed with `_` is being accessed, whether the member exists or not.
+		CALLING_UNDERLINE_PREFIXED_METHOD, // A method prefixed with `_` is being called, whether the method exists or not. Will not thrown if the method is moditied by `@virtual`.
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -147,6 +149,8 @@ public:
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
+		WARN, // ACCESSING_UNDERLINE_PREFIXED_MEMBER
+		WARN, // CALLING_UNDERLINE_PREFIXED_METHOD
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_function_typecheck.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_function_typecheck.gd
@@ -26,7 +26,6 @@ class InnerClass:
 		print("Inner")
 
 		var o := EnumFunctionTypecheckOuterClass.new()
-
 		_d = o.outer_outer_no_class(EnumFunctionTypecheckOuterClass.MyEnum.V1)
 		print()
 		_d = o.outer_outer_class(EnumFunctionTypecheckOuterClass.MyEnum.V1)

--- a/modules/gdscript/tests/scripts/analyzer/features/virtual_method_implemented.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/virtual_method_implemented.gd
@@ -5,6 +5,7 @@ class BaseClass:
 class SuperClassMethodsRecognized extends BaseClass:
 	func _init():
 		# Recognizes super class methods.
+		@warning_ignore("calling_protected_method")
 		var _x = _get_property_list()
 
 class SuperMethodsRecognized extends BaseClass:
@@ -16,6 +17,8 @@ class SuperMethodsRecognized extends BaseClass:
 
 func test():
 	var test1 = SuperClassMethodsRecognized.new()
+	@warning_ignore("calling_protected_method")
 	print(test1._get_property_list()) # Calls base class's method.
 	var test2 = SuperMethodsRecognized.new()
+	@warning_ignore("calling_protected_method")
 	print(test2._get_property_list())

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_warnings.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_warnings.gd
@@ -10,7 +10,9 @@ class A extends Node:
 	var get_node_default_without_onready = $Node
 
 @warning_ignore("unused_private_class_variable")
-var _unused_private_class_variable
+var __unused_private_class_variable
+@warning_ignore("unused_protected_class_variable")
+var _unused_protected_class_variable
 
 @warning_ignore("onready_with_export")
 @onready @export var onready_with_export = 1
@@ -36,7 +38,7 @@ func test_warnings(unused_private_class_variable):
 	print(unassigned_variable)
 
 	var _unassigned_variable_op_assign
-	@warning_ignore("unassigned_variable_op_assign")
+	@warning_ignore("unassigned_variable_op_assign", "accessing_protected_member")
 	_unassigned_variable_op_assign += t
 
 	@warning_ignore("unused_variable")
@@ -150,6 +152,86 @@ func test_unsafe_void_return() -> void:
 @warning_ignore("native_method_override")
 func get_class():
 	pass
+
+class AccessTestA:
+	@warning_ignore("unused_protected_class_variable")
+	static var _static_a = null
+	@warning_ignore("unused_private_class_variable")
+	static var __static_b = null
+
+	@warning_ignore("unused_protected_class_variable")
+	var _a = null
+	@warning_ignore("unused_private_class_variable")
+	var __b = null
+
+	func _call_a():
+		pass
+
+	func __call_b():
+		pass
+
+	func _call_a_ret():
+		return null
+
+	func __call_b_ret():
+		return null
+
+	static func _static_call_a():
+		pass
+
+	static func __static_call_b():
+		pass
+
+	static func _static_call_a_ret():
+		return null
+
+	static func __static_call_b_ret():
+		return null
+
+class AccessTestB:
+	func _init():
+		var cls_a = AccessTestA.new()
+		@warning_ignore("accessing_protected_member")
+		AccessTestA._static_a = null
+		@warning_ignore("accessing_private_member")
+		AccessTestA.__static_b = null
+		@warning_ignore("accessing_protected_member")
+		cls_a._a = null
+		@warning_ignore("accessing_private_member")
+		cls_a.__b = null
+		@warning_ignore("calling_protected_method")
+		cls_a._call_a()
+		@warning_ignore("calling_private_method")
+		cls_a.__call_b()
+
+		@warning_ignore("unused_variable", "calling_protected_method")
+		var t1 = cls_a._call_a_ret()
+		@warning_ignore("unused_variable", "calling_private_method")
+		var t2 = cls_a.__call_b_ret()
+		@warning_ignore("calling_protected_method")
+		AccessTestA._static_call_a()
+		@warning_ignore("calling_private_method")
+		AccessTestA.__static_call_b()
+		@warning_ignore("unused_variable", "calling_protected_method")
+		var t3 = AccessTestA._static_call_a_ret()
+		@warning_ignore("unused_variable", "calling_private_method")
+		var t4 = AccessTestA.__static_call_b_ret()
+
+class AccessTestC extends AccessTestA:
+	func _init():
+		@warning_ignore("accessing_private_member")
+		AccessTestA.__static_b = null
+		@warning_ignore("accessing_private_member")
+		__b = null
+		@warning_ignore("calling_private_method")
+		__call_b()
+
+		@warning_ignore("unused_variable", "calling_private_method")
+		var t1 = __call_b_ret()
+		@warning_ignore("calling_private_method")
+		AccessTestA.__static_call_b()
+		@warning_ignore("unused_variable", "calling_private_method")
+		var t2 = AccessTestA.__static_call_b_ret()
 
 # We don't want to execute it because of errors, just analyze.
 func test():

--- a/modules/gdscript/tests/scripts/analyzer/warnings/private_protected_members.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/private_protected_members.gd
@@ -1,0 +1,80 @@
+class A:
+    @warning_ignore("unused_protected_class_variable")
+    static var _static_a = null
+    @warning_ignore("unused_private_class_variable")
+    static var __static_b = null
+
+    @warning_ignore("unused_protected_class_variable")
+    var _a = null
+    @warning_ignore("unused_private_class_variable")
+    var __b = null
+
+    func _call_a():
+        pass
+
+    func __call_b():
+        pass
+
+    func _call_a_ret():
+        return null
+
+    func __call_b_ret():
+        return null
+
+    static func _static_call_a():
+        pass
+
+    static func __static_call_b():
+        pass
+
+    static func _static_call_a_ret():
+        return null
+
+    static func __static_call_b_ret():
+        return null
+
+class B:
+    func _init():
+        var cls_a = A.new()
+        A._static_a = null
+        A.__static_b = null
+        cls_a._a = null
+        cls_a.__b = null
+        cls_a._call_a()
+        cls_a.__call_b()
+
+        @warning_ignore("unused_variable")
+        var t1 = cls_a._call_a_ret()
+        @warning_ignore("unused_variable")
+        var t2 = cls_a.__call_b_ret()
+
+        A._static_call_a()
+        A.__static_call_b()
+        @warning_ignore("unused_variable")
+        var t3 = A._static_call_a_ret()
+        @warning_ignore("unused_variable")
+        var t4 = A.__static_call_b_ret()
+
+class C extends A:
+    func _init():
+        A._static_a = null
+        A.__static_b = null
+        _a = null
+        __b = null
+        _call_a()
+        __call_b()
+
+        @warning_ignore("unused_variable")
+        var t1 = _call_a_ret()
+        @warning_ignore("unused_variable")
+        var t2 = __call_b_ret()
+
+        _static_call_a()
+        __static_call_b()
+        @warning_ignore("unused_variable")
+        var t3 = _static_call_a_ret()
+        @warning_ignore("unused_variable")
+        var t4 = __static_call_b_ret()
+
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/private_protected_members.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/private_protected_members.out
@@ -1,0 +1,19 @@
+GDTEST_OK
+~~ WARNING at line 39: (ACCESSING_PROTECTED_MEMBER) Trying accessing the member "_static_a" prefixed with "_", which would be a protected member.
+~~ WARNING at line 40: (ACCESSING_PRIVATE_MEMBER) Trying accessing the member "__static_b" prefixed with "__", which would be a private member.
+~~ WARNING at line 41: (ACCESSING_PROTECTED_MEMBER) Trying accessing the member "_a" prefixed with "_", which would be a protected member.
+~~ WARNING at line 42: (ACCESSING_PRIVATE_MEMBER) Trying accessing the member "__b" prefixed with "__", which would be a private member.
+~~ WARNING at line 43: (CALLING_PROTECTED_METHOD) Trying calling the method "_call_a()" prefixed with "_", which would be a protected method.
+~~ WARNING at line 44: (CALLING_PRIVATE_METHOD) Trying calling the method "__call_b()" prefixed with "__", which would be a private method.
+~~ WARNING at line 47: (CALLING_PROTECTED_METHOD) Trying calling the method "_call_a_ret()" prefixed with "_", which would be a protected method.
+~~ WARNING at line 49: (CALLING_PRIVATE_METHOD) Trying calling the method "__call_b_ret()" prefixed with "__", which would be a private method.
+~~ WARNING at line 51: (CALLING_PROTECTED_METHOD) Trying calling the method "_static_call_a()" prefixed with "_", which would be a protected method.
+~~ WARNING at line 52: (CALLING_PRIVATE_METHOD) Trying calling the method "__static_call_b()" prefixed with "__", which would be a private method.
+~~ WARNING at line 54: (CALLING_PROTECTED_METHOD) Trying calling the method "_static_call_a_ret()" prefixed with "_", which would be a protected method.
+~~ WARNING at line 56: (CALLING_PRIVATE_METHOD) Trying calling the method "__static_call_b_ret()" prefixed with "__", which would be a private method.
+~~ WARNING at line 61: (ACCESSING_PRIVATE_MEMBER) Trying accessing the member "__static_b" prefixed with "__", which would be a private member.
+~~ WARNING at line 63: (ACCESSING_PRIVATE_MEMBER) Trying accessing the member "__b" prefixed with "__", which would be a private member.
+~~ WARNING at line 65: (CALLING_PRIVATE_METHOD) Trying calling the method "__call_b()" prefixed with "__", which would be a private method.
+~~ WARNING at line 70: (CALLING_PRIVATE_METHOD) Trying calling the method "__call_b_ret()" prefixed with "__", which would be a private method.
+~~ WARNING at line 73: (CALLING_PRIVATE_METHOD) Trying calling the method "__static_call_b()" prefixed with "__", which would be a private method.
+~~ WARNING at line 77: (CALLING_PRIVATE_METHOD) Trying calling the method "__static_call_b_ret()" prefixed with "__", which would be a private method.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/unused_private_class_variable.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/unused_private_class_variable.gd
@@ -1,10 +1,16 @@
 # GH-72135
 
 var _a
-@warning_ignore("unused_private_class_variable")
+@warning_ignore("unused_protected_class_variable")
 var _b
-@warning_ignore("unused_private_class_variable") var _c
+@warning_ignore("unused_protected_class_variable") var _c
 var _d
+
+var __e
+@warning_ignore("unused_private_class_variable")
+var __f
+@warning_ignore("unused_private_class_variable") var __g
+var __h
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/unused_private_class_variable.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/unused_private_class_variable.out
@@ -1,3 +1,5 @@
 GDTEST_OK
-~~ WARNING at line 3: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "_a" is declared but never used in the class.
-~~ WARNING at line 7: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "_d" is declared but never used in the class.
+~~ WARNING at line 3: (UNUSED_PROTECTED_CLASS_VARIABLE) The class variable "_a" is declared but never used in the class.
+~~ WARNING at line 7: (UNUSED_PROTECTED_CLASS_VARIABLE) The class variable "_d" is declared but never used in the class.
+~~ WARNING at line 9: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "__e" is declared but never used in the class.
+~~ WARNING at line 13: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "__h" is declared but never used in the class.

--- a/modules/gdscript/tests/scripts/parser/features/warning_ignore_regions.gd
+++ b/modules/gdscript/tests/scripts/parser/features/warning_ignore_regions.gd
@@ -1,11 +1,18 @@
 @warning_ignore_start("unreachable_code", "narrowing_conversion")
 
 var _a = 1
-@warning_ignore_start("unused_private_class_variable")
+@warning_ignore_start("unused_protected_class_variable")
 var _b = 2
 var _c = 3
-@warning_ignore_restore("unused_private_class_variable")
+@warning_ignore_restore("unused_protected_class_variable")
 var _d = 4
+
+var __e = 5
+@warning_ignore_start("unused_private_class_variable")
+var __f = 6
+var __g = 7
+@warning_ignore_restore("unused_private_class_variable")
+var __h = 8
 
 func test():
 	return

--- a/modules/gdscript/tests/scripts/parser/features/warning_ignore_regions.out
+++ b/modules/gdscript/tests/scripts/parser/features/warning_ignore_regions.out
@@ -1,6 +1,8 @@
 GDTEST_OK
-~~ WARNING at line 3: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "_a" is declared but never used in the class.
-~~ WARNING at line 8: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "_d" is declared but never used in the class.
-~~ WARNING at line 13: (UNUSED_VARIABLE) The local variable "a" is declared but never used in the block. If this is intended, prefix it with an underscore: "_a".
-~~ WARNING at line 18: (UNUSED_VARIABLE) The local variable "d" is declared but never used in the block. If this is intended, prefix it with an underscore: "_d".
-~~ WARNING at line 22: (NARROWING_CONVERSION) Narrowing conversion (float is converted to int and loses precision).
+~~ WARNING at line 3: (UNUSED_PROTECTED_CLASS_VARIABLE) The class variable "_a" is declared but never used in the class.
+~~ WARNING at line 8: (UNUSED_PROTECTED_CLASS_VARIABLE) The class variable "_d" is declared but never used in the class.
+~~ WARNING at line 10: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "__e" is declared but never used in the class.
+~~ WARNING at line 15: (UNUSED_PRIVATE_CLASS_VARIABLE) The class variable "__h" is declared but never used in the class.
+~~ WARNING at line 20: (UNUSED_VARIABLE) The local variable "a" is declared but never used in the block. If this is intended, prefix it with an underscore: "_a".
+~~ WARNING at line 25: (UNUSED_VARIABLE) The local variable "d" is declared but never used in the block. If this is intended, prefix it with an underscore: "_d".
+~~ WARNING at line 29: (NARROWING_CONVERSION) Narrowing conversion (float is converted to int and loses precision).

--- a/modules/gdscript/tests/scripts/runtime/features/onready_base_before_subclass.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/onready_base_before_subclass.gd
@@ -14,5 +14,6 @@ class B extends A:
 
 func test():
 	var node := B.new()
+	@warning_ignore("calling_protected_method")
 	node._ready()
 	node.free()

--- a/modules/gdscript/tests/scripts/runtime/features/self_destruction.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/self_destruction.gd
@@ -41,7 +41,7 @@ func test():
 
 	# Signal handling.
 	obj = MyObj.new(nullify_obj)
-	@warning_ignore("return_value_discarded")
+	@warning_ignore("return_value_discarded", "accessing_protected_member")
 	some_signal.connect(obj._on_some_signal)
 	some_signal.emit()
 	print(obj)


### PR DESCRIPTION
Supersedes: #98136
Closes: https://github.com/godotengine/godot-proposals/issues/641

After the discussion with some devs, with the philosophy of "implementing new features without game crashing". Here is the temporary discussion result **in my opinion**:  

Rather than keywords and annotations, it's better to keep the original form that `_` as prefix of private/protected members. There are three reasons for that:

# Reasons

1. Based on @HolonProduction and KaiN's opinions, a virutal method should be **private or protected**, but normally it is protected, so a virtual method that begins with `_` should be a *protected* method. At first, I thought this would be redundant, until the moment I imagined encapsulation on calling a custom virtual method:
```GDScript
func _custom_virtual():
    <contents>

## Wrapper and encapsulator function to call the custom virtual method:
func call_custom_virtual():
    <some preparations related to the virtual method>
    _custom_virtual()
```
When you need to call a custom virtual method, it is better to call it through a wrapper.
2. From the perspective of technical reasons, `private` and `protect` need to do checks during the reduction. The original pr did checks by retracing the source `GDScriptParser::Node`, and even to retrace not only its super classes, but also the head attributes, which is much more performance-costly. However, by operating on `p_identifier->name`, we do not need to trace back what its `GDScriptParser::Node` is and where it comes from; Instead, we just check if the class or the super classes has the member or the method. For protected identifiers, we just iterate the super classes of `parser->current_class`, which greatly reduces the consumption of CPU performance. Compared with the implementation of original pr, this is of balanced cost.
3. Based on the philosophy of "implementing new features without crashing the games", I turned the error into a warning. Of course you can turn it back to an error in GDScript warning settings. However, due to the fact that this pr is merely a soft implementation of access restriction, this does not break the runtime or throw an error if there is any invalid interclass access, so if your game runs out of your expectation, it's time to check your code, especially maybe somewhere you referenced a `_`-prefixed variable?

# Implementation effect

When you trying to access a `_`-prefixed (or `__`-prefixed) identifier outside the class that defines it, a warning (by default) will be thrown at the bottom of the script editor about trying accessing a private/protected member externally.

**Note:** For attributes, this also take the invalid ones into consideration, e.g.:

```GDScript
class A:
    var _test = 1

class B:
    var a = A.new()

    func _init():
        a._tet = 2 # This is, in fact, an invalid attribute and may cause runtime error. However, this would be considered as warning of accessing private/protected member externally as well.
````

For protected members, this warning would be eliminated if the accessor class is derived from the class where the target identifier is declared.

# Discussions

I know that this would bring to thumbups from those who think this is correct, or thumbdowns from those who think that I'm standing for official devs. No matter what this post will be given with, feel free to share and discuss your ideas here.

# Plans
- [x] ~~Distinguishing color for `_`-or-`__`-prefixed members in auto-completion.~~(Off-topic)
- [x] ~~Distinguishing color for `_`-or-`__`-prefixed exported members in the editor inspector.~~(Off-topic)
- [x] ~~Introducing `__` as the prefix of protected members (or private ones, needs to be discussed)~~ I implement this before the For protected identifiers, we just iterate the super classes of `parser->current_class`. discussion on this. If this is no more needed, I'll remove this feature.
- [x] Unit tests for members prefixed with `_` and `__`.
- [ ] Peer reviews and tests.