### PR TITLE
Add type filters to AnimationPlayer's "Add Track"

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5297,6 +5297,28 @@ void AnimationTrackEditor::_add_track(int p_type) {
 		return;
 	}
 	adding_track_type = p_type;
+	Vector<StringName> valid_types;
+	switch (adding_track_type) {
+		case Animation::TYPE_BLEND_SHAPE: {
+			// Blend Shape is a property of MeshInstance3D.
+			valid_types.push_back(SNAME("MeshInstance3D"));
+		} break;
+		case Animation::TYPE_POSITION_3D:
+		case Animation::TYPE_ROTATION_3D:
+		case Animation::TYPE_SCALE_3D: {
+			// 3D Properties come from nodes inheriting Node3D.
+			valid_types.push_back(SNAME("Node3D"));
+		} break;
+		case Animation::TYPE_AUDIO: {
+			valid_types.push_back(SNAME("AudioStreamPlayer"));
+			valid_types.push_back(SNAME("AudioStreamPlayer2D"));
+			valid_types.push_back(SNAME("AudioStreamPlayer3D"));
+		} break;
+		case Animation::TYPE_ANIMATION: {
+			valid_types.push_back(SNAME("AnimationPlayer"));
+		} break;
+	}
+	pick_track->set_valid_types(valid_types);
 	pick_track->popup_scenetree_dialog(nullptr, root_node);
 	pick_track->get_filter_line_edit()->clear();
 	pick_track->get_filter_line_edit()->grab_focus();

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1684,24 +1684,30 @@ void SceneTreeDialog::_show_all_nodes_changed(bool p_button_pressed) {
 }
 
 void SceneTreeDialog::set_valid_types(const Vector<StringName> &p_valid) {
-	if (p_valid.is_empty()) {
-		return;
+	if (allowed_types_hbox) {
+		allowed_types_hbox->queue_free();
+		allowed_types_hbox = nullptr;
+		valid_type_icons.clear();
 	}
 
 	tree->set_valid_types(p_valid);
 
-	HBoxContainer *hbox = memnew(HBoxContainer);
-	content->add_child(hbox);
-	content->move_child(hbox, 0);
+	if (p_valid.is_empty()) {
+		return;
+	}
+
+	allowed_types_hbox = memnew(HBoxContainer);
+	content->add_child(allowed_types_hbox);
+	content->move_child(allowed_types_hbox, 0);
 
 	{
 		Label *label = memnew(Label);
-		hbox->add_child(label);
+		allowed_types_hbox->add_child(label);
 		label->set_text(TTR("Allowed:"));
 	}
 
 	HFlowContainer *hflow = memnew(HFlowContainer);
-	hbox->add_child(hflow);
+	allowed_types_hbox->add_child(hflow);
 	hflow->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	for (const StringName &type : p_valid) {
@@ -1735,6 +1741,9 @@ void SceneTreeDialog::set_valid_types(const Vector<StringName> &p_valid) {
 	}
 
 	show_all_nodes->show();
+	if (is_inside_tree()) {
+		_update_valid_type_icons();
+	}
 }
 
 void SceneTreeDialog::_notification(int p_what) {
@@ -1753,16 +1762,20 @@ void SceneTreeDialog::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
-			filter->set_right_icon(get_editor_theme_icon(SNAME("Search")));
-			for (TextureRect *trect : valid_type_icons) {
-				trect->set_custom_minimum_size(Vector2(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)), 0));
-				trect->set_texture(trect->get_meta("icon"));
-			}
+			_update_valid_type_icons();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect(SceneStringName(confirmed), callable_mp(this, &SceneTreeDialog::_select));
 		} break;
+	}
+}
+
+void SceneTreeDialog::_update_valid_type_icons() {
+	filter->set_right_icon(get_editor_theme_icon(SNAME("Search")));
+	for (TextureRect *trect : valid_type_icons) {
+		trect->set_custom_minimum_size(Vector2(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)), 0));
+		trect->set_texture(trect->get_meta("icon"));
 	}
 }
 

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -199,6 +199,7 @@ class SceneTreeDialog : public ConfirmationDialog {
 	LineEdit *filter = nullptr;
 	CheckButton *show_all_nodes = nullptr;
 	LocalVector<TextureRect *> valid_type_icons;
+	HBoxContainer *allowed_types_hbox = nullptr;
 
 	void _select();
 	void _cancel();
@@ -208,6 +209,7 @@ class SceneTreeDialog : public ConfirmationDialog {
 	void _show_all_nodes_changed(bool p_button_pressed);
 
 protected:
+	void _update_valid_type_icons();
 	void _notification(int p_what);
 	static void _bind_methods();
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

(My first contribution btw)

Adds type filters to the SceneTreeDialogs that come from AnimationPlayer's "Add Track" button.
The Add Track button has several types of tracks that require specific node types, but currently present a full SceneTreeDialog, and throw an error if you provide the wrong type.

Fixes https://github.com/godotengine/godot/issues/55944 which describes this issue specifically for Audio tracks.

![image](https://github.com/user-attachments/assets/6e478f10-8946-4dcb-aaf1-3ca6c2a7d6d8)
> The SceneTreeDialog that appears when Add Track > Audio Playback Track is selected. Now with the correct filters!

- Property, Call Method, Bezier Curve have no filters
- Blend Shape has a Meshinstance3D filter
- 3D Position, Rotation, Scale tracks have a Node3D filter
- Audio has AudioStreamPlayer(2D/3D) filter
- Animation has AnimationPlayer filter


I've tested the SceneTreeDialog in the inspector (export nodepath), works the same as usual. However, I'm not sure where else to find the prompts for the SceneTreeDialog in the editor for further testing. 
I see it's in a few different places in the code such as:
- EditorInterface
- EditorPropertyNodePath (The one I tested)
- MultiMeshEditor
- Particles3DEditorPlugin
- ReplicationEditor
All these examples set filters once after creating the dialog, so they should be unaffected.


---

Related, I did notice the SceneTreeDialog's set_valid_types was not set up correctly to be called on the same instance of SceneTreeDialog multiple times. 
Seems the current workaround was deleting and recreating it.
See also this comment: https://github.com/godotengine/godot/blob/61accf060515416da07d913580419fd8c8490f7b/editor/editor_interface.cpp#L283-L290

I took a stab at fixing this issue, clearing the filter's label and types before setting it.
Fixed the icons not showing up, but it calls _notification() directly to update the icon sizes. Would like some feedback on that too, seems unusual for the codebase.

