### PR TITLE
Fix Occlusion Culling not working for an orthogonal camera.

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -140,7 +140,7 @@ void RaycastOcclusionCull::RaycastHZBuffer::_generate_camera_rays(const CameraRa
 
 			Vector3 dir;
 			if (p_data->camera_orthogonal) {
-				dir = -p_data->camera_dir;
+				dir = p_data->camera_dir;
 				tile.ray.org_x[j] = pixel_pos.x - dir.x * p_data->z_near;
 				tile.ray.org_y[j] = pixel_pos.y - dir.y * p_data->z_near;
 				tile.ray.org_z[j] = pixel_pos.z - dir.z * p_data->z_near;

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -84,7 +84,7 @@ public:
 				Vector3 view = p_cam_inv_transform.xform(corner);
 
 				if (p_cam_projection.is_orthogonal()) {
-					min_depth = MIN(min_depth, view.z);
+					min_depth = MIN(min_depth, -view.z);
 				}
 
 				Plane vp = Plane(view, 1.0);


### PR DESCRIPTION
Fixes #98561

This issue was caused by two problems:
 - The directions generated for the raycasts used for the depth map to determine occlusion pointed in the wrong direction.
 - The minimum depth value calculated using an object’s AABB and used by _is_occluded() to determine occlusion was negative (a bug I introduced in #98257 🙈).

This PR fixes both.

MRP: [mrp.zip](https://github.com/user-attachments/files/17531592/mrp.zip)