### PR TITLE
Fix and improve editor state persistence for the VisualShader editor

### DIFF
--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -186,11 +186,6 @@
 			</description>
 		</method>
 	</methods>
-	<members>
-		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2(0, 0)">
-			The offset vector of the whole graph.
-		</member>
-	</members>
 	<constants>
 		<constant name="TYPE_VERTEX" value="0" enum="Type">
 			A vertex shader, operating on vertices.

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -454,6 +454,7 @@ void ShaderEditorPlugin::_close_shader(int p_index) {
 	Control *c = shader_tabs->get_tab_control(p_index);
 	VisualShaderEditor *vs_editor = Object::cast_to<VisualShaderEditor>(c);
 	if (vs_editor) {
+		vs_editor->save_editor_layout();
 		file_menu->get_parent()->remove_child(file_menu);
 		menu_hb->add_child(file_menu);
 		menu_hb->move_child(file_menu, 0);

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -321,3 +321,11 @@ Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/a
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments': size changed value in new API, from 11 to 12.
 
 Optional argument added. Compatibility methods registered.
+
+
+GH-98566
+--------
+Validate extension JSON: API was removed: classes/VisualShader/methods/set_graph_offset
+Validate extension JSON: API was removed: classes/VisualShader/methods/get_graph_offset
+
+The graph_offset property was removed from the resource. This information is now stored in `vs_editor_cache.cfg`.

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -115,11 +115,11 @@ Vector2 GraphEditMinimap::_get_render_size() {
 }
 
 Vector2 GraphEditMinimap::_get_graph_offset() {
-	return Vector2(ge->h_scrollbar->get_min(), ge->v_scrollbar->get_min());
+	return ge->min_scroll_offset;
 }
 
 Vector2 GraphEditMinimap::_get_graph_size() {
-	Vector2 graph_size = Vector2(ge->h_scrollbar->get_max(), ge->v_scrollbar->get_max()) - Vector2(ge->h_scrollbar->get_min(), ge->v_scrollbar->get_min());
+	Vector2 graph_size = ge->max_scroll_offset - ge->min_scroll_offset;
 
 	if (graph_size.width == 0) {
 		graph_size.width = 1;
@@ -411,17 +411,25 @@ String GraphEdit::get_connections_description(const StringName &p_node, int p_po
 
 void GraphEdit::set_scroll_offset(const Vector2 &p_offset) {
 	setting_scroll_offset = true;
-	h_scrollbar->set_value(p_offset.x);
-	v_scrollbar->set_value(p_offset.y);
-	_update_scroll();
+	scroll_offset = p_offset.clamp(min_scroll_offset, max_scroll_offset - get_size());
+	if (!awaiting_scroll_offset_update) {
+		callable_mp(this, &GraphEdit::_update_scroll_offset).call_deferred();
+		awaiting_scroll_offset_update = true;
+	}
+	minimap->queue_redraw();
+	queue_redraw();
+	_update_scrollbars();
+	callable_mp(this, &GraphEdit::_update_top_connection_layer).call_deferred();
 	setting_scroll_offset = false;
 }
 
 Vector2 GraphEdit::get_scroll_offset() const {
-	return Vector2(h_scrollbar->get_value(), v_scrollbar->get_value());
+	return scroll_offset;
 }
 
-void GraphEdit::_scroll_moved(double) {
+void GraphEdit::_scrollbar_moved(double) {
+	scroll_offset.x = h_scrollbar->get_value();
+	scroll_offset.y = v_scrollbar->get_value();
 	if (!awaiting_scroll_offset_update) {
 		callable_mp(this, &GraphEdit::_update_scroll_offset).call_deferred();
 		awaiting_scroll_offset_update = true;
@@ -443,14 +451,14 @@ void GraphEdit::_update_scroll_offset() {
 		}
 
 		Point2 pos = graph_element->get_position_offset() * zoom;
-		pos -= Point2(h_scrollbar->get_value(), v_scrollbar->get_value());
+		pos -= scroll_offset;
 		graph_element->set_position(pos);
 		if (graph_element->get_scale() != Vector2(zoom, zoom)) {
 			graph_element->set_scale(Vector2(zoom, zoom));
 		}
 	}
 
-	connections_layer->set_position(-Point2(h_scrollbar->get_value(), v_scrollbar->get_value()));
+	connections_layer->set_position(-scroll_offset);
 	set_block_minimum_size_adjust(false);
 	awaiting_scroll_offset_update = false;
 
@@ -460,14 +468,18 @@ void GraphEdit::_update_scroll_offset() {
 	}
 }
 
-void GraphEdit::_update_scroll() {
+void GraphEdit::_update_scrollbars() {
 	if (updating) {
 		return;
 	}
 	updating = true;
 
+	h_scrollbar->set_value_no_signal(scroll_offset.x);
+	v_scrollbar->set_value_no_signal(scroll_offset.y);
+
 	set_block_minimum_size_adjust(true);
 
+	// Determine the graph "canvas" size in screen space.
 	Rect2 screen_rect;
 	for (int i = 0; i < get_child_count(); i++) {
 		GraphElement *graph_element = Object::cast_to<GraphElement>(get_child(i));
@@ -483,6 +495,9 @@ void GraphEdit::_update_scroll() {
 
 	screen_rect.position -= get_size();
 	screen_rect.size += get_size() * 2.0;
+
+	min_scroll_offset = screen_rect.position;
+	max_scroll_offset = screen_rect.position + screen_rect.size;
 
 	h_scrollbar->set_min(screen_rect.position.x);
 	h_scrollbar->set_max(screen_rect.position.x + screen_rect.size.width);
@@ -849,7 +864,7 @@ void GraphEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESIZED: {
-			_update_scroll();
+			_update_scrollbars();
 			minimap->queue_redraw();
 			callable_mp(this, &GraphEdit::_update_top_connection_layer).call_deferred();
 		} break;
@@ -1714,7 +1729,7 @@ void GraphEdit::_top_layer_draw() {
 }
 
 void GraphEdit::_update_top_connection_layer() {
-	_update_scroll();
+	_update_scrollbars();
 
 	if (!connecting) {
 		dragged_connection_line->clear_points();
@@ -2302,9 +2317,15 @@ void GraphEdit::key_input(const Ref<InputEvent> &p_ev) {
 void GraphEdit::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event) {
 	ERR_FAIL_NULL_MSG(connections_layer, "connections_layer is missing.");
 
-	h_scrollbar->set_value(h_scrollbar->get_value() - p_scroll_vec.x);
-	v_scrollbar->set_value(v_scrollbar->get_value() - p_scroll_vec.y);
+	scroll_offset = (scroll_offset - p_scroll_vec).clamp(min_scroll_offset, max_scroll_offset - get_size());
 
+	if (!awaiting_scroll_offset_update) {
+		callable_mp(this, &GraphEdit::_update_scroll_offset).call_deferred();
+		awaiting_scroll_offset_update = true;
+	}
+	minimap->queue_redraw();
+	queue_redraw();
+	callable_mp(this, &GraphEdit::_update_top_connection_layer).call_deferred();
 	connections_layer->queue_redraw();
 }
 
@@ -2406,7 +2427,7 @@ void GraphEdit::set_zoom_custom(float p_zoom, const Vector2 &p_center) {
 		return;
 	}
 
-	Vector2 scrollbar_offset = (Vector2(h_scrollbar->get_value(), v_scrollbar->get_value()) + p_center) / zoom;
+	Point2 zoom_anchor = (scroll_offset + p_center) / zoom;
 
 	zoom = p_zoom;
 
@@ -2415,14 +2436,12 @@ void GraphEdit::set_zoom_custom(float p_zoom, const Vector2 &p_center) {
 	zoom_minus_button->set_disabled(zoom == zoom_min);
 	zoom_plus_button->set_disabled(zoom == zoom_max);
 
-	_update_scroll();
+	_update_scrollbars();
 	minimap->queue_redraw();
 	connections_layer->queue_redraw();
 
 	if (is_visible_in_tree()) {
-		Vector2 offset = scrollbar_offset * zoom - p_center;
-		h_scrollbar->set_value(offset.x);
-		v_scrollbar->set_value(offset.y);
+		scroll_offset = zoom_anchor * zoom - p_center;
 	}
 
 	_update_zoom_label();
@@ -3193,8 +3212,8 @@ GraphEdit::GraphEdit() {
 	v_scrollbar->set_min(-10000);
 	v_scrollbar->set_max(10000);
 
-	h_scrollbar->connect(SceneStringName(value_changed), callable_mp(this, &GraphEdit::_scroll_moved));
-	v_scrollbar->connect(SceneStringName(value_changed), callable_mp(this, &GraphEdit::_scroll_moved));
+	h_scrollbar->connect(SceneStringName(value_changed), callable_mp(this, &GraphEdit::_scrollbar_moved));
+	v_scrollbar->connect(SceneStringName(value_changed), callable_mp(this, &GraphEdit::_scrollbar_moved));
 
 	// Toolbar menu.
 

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -228,6 +228,10 @@ private:
 	float zoom_min = 0.0;
 	float zoom_max = 0.0;
 
+	Vector2 min_scroll_offset;
+	Vector2 max_scroll_offset;
+	Vector2 scroll_offset;
+
 	bool box_selecting = false;
 	bool box_selection_mode_additive = false;
 	Point2 box_selecting_from;
@@ -327,9 +331,9 @@ private:
 	void _ensure_node_order_from_root(const StringName &p_node);
 	void _ensure_node_order_from(Node *p_node);
 
-	void _update_scroll();
+	void _update_scrollbars();
 	void _update_scroll_offset();
-	void _scroll_moved(double);
+	void _scrollbar_moved(double);
 	virtual void gui_input(const Ref<InputEvent> &p_ev) override;
 	void _top_connection_layer_input(const Ref<InputEvent> &p_ev);
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -822,14 +822,6 @@ VisualShaderNodeCustom::VisualShaderNodeCustom() {
 
 /////////////////////////////////////////////////////////
 
-void VisualShader::set_shader_type(Type p_type) {
-	current_type = p_type;
-}
-
-VisualShader::Type VisualShader::get_shader_type() const {
-	return current_type;
-}
-
 void VisualShader::add_varying(const String &p_name, VaryingMode p_mode, VaryingType p_type) {
 	ERR_FAIL_COND(!p_name.is_valid_ascii_identifier());
 	ERR_FAIL_INDEX((int)p_mode, (int)VARYING_MODE_MAX);
@@ -1464,14 +1456,6 @@ void VisualShader::set_mode(Mode p_mode) {
 
 	_queue_update();
 	notify_property_list_changed();
-}
-
-void VisualShader::set_graph_offset(const Vector2 &p_offset) {
-	graph_offset = p_offset;
-}
-
-Vector2 VisualShader::get_graph_offset() const {
-	return graph_offset;
 }
 
 Shader::Mode VisualShader::get_mode() const {
@@ -3157,9 +3141,6 @@ void VisualShader::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_node_connections", "type"), &VisualShader::_get_node_connections);
 
-	ClassDB::bind_method(D_METHOD("set_graph_offset", "offset"), &VisualShader::set_graph_offset);
-	ClassDB::bind_method(D_METHOD("get_graph_offset"), &VisualShader::get_graph_offset);
-
 	ClassDB::bind_method(D_METHOD("attach_node_to_frame", "type", "id", "frame"), &VisualShader::attach_node_to_frame);
 	ClassDB::bind_method(D_METHOD("detach_node_from_frame", "type", "id"), &VisualShader::detach_node_from_frame);
 
@@ -3172,8 +3153,6 @@ void VisualShader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_has_preview_shader_parameter", "name"), &VisualShader::_has_preview_shader_parameter);
 
 	ClassDB::bind_method(D_METHOD("_update_shader"), &VisualShader::_update_shader);
-
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "graph_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_graph_offset", "get_graph_offset");
 
 	ADD_PROPERTY_DEFAULT("code", ""); // Inherited from Shader, prevents showing default code as override in docs.
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -114,8 +114,6 @@ public:
 	};
 
 private:
-	Type current_type;
-
 	struct Node {
 		Ref<VisualShaderNode> node;
 		Vector2 position;
@@ -132,8 +130,6 @@ private:
 	mutable String previous_code;
 
 	TypedArray<Dictionary> _get_node_connections(Type p_type) const;
-
-	Vector2 graph_offset;
 
 	HashMap<String, int> modes;
 	HashSet<StringName> flags;
@@ -180,9 +176,6 @@ protected:
 	virtual void reset_state() override;
 
 public: // internal methods
-	void set_shader_type(Type p_type);
-	Type get_shader_type() const;
-
 	enum {
 		NODE_ID_INVALID = -1,
 		NODE_ID_OUTPUT = 0,
@@ -248,9 +241,6 @@ public: // internal methods
 	virtual Mode get_mode() const override;
 
 	virtual bool is_text_shader() const override;
-
-	void set_graph_offset(const Vector2 &p_offset);
-	Vector2 get_graph_offset() const;
 
 	String generate_preview_shader(Type p_type, int p_node, int p_port, Vector<DefaultTextureParam> &r_default_tex_params) const;
 


### PR DESCRIPTION
This PR implements editor state preservation for the VisualShader editor while addressing related design issues.

Previously, the `scroll_offset` (essentially the view position of the `GraphEdit` node used in the VisualShader editor) was saved in the `VisualShader` resource, which could create Git noise when multiple people work on the same project. If one person opens the shader and just pans around, the resource would change. Since the scroll offset is more accurately part of the editor state than the `VisualShader` resource itself, it is now saved as project metadata. The same goes for the currently edited type/stage. Additionally, the zoom level is now also persistent.

For saving the scroll offset and zoom level, a debounce timer was added to reduce disk access.

### TODO:
- [x] Use the UID instead of the resource path as the key.
- [x] Save the state per type! (this was overlooked by me since the graph_offset was also not saved per type/stage before - but since it has never worked correctly no one ever noticed)

### GraphEdit refactoring: Scrolling/Panning

Currently, `GraphEdit` uses the scrollbars to manage and track the scroll/panning offset as well as to control how far the view can pan/scroll. Data like this should not be stored in or managed by child control nodes but rather directly within `GraphEdit`. Scrollbars should function purely as UI components, signaling user interactions and reflecting changes from the parent node. After all, they provide just another way to pan the view and GraphEdit should theoretically be functional without them.

This part could be split into another PR if desired (since the changes shouldn't alter the behavior), however I have only tested it in conjunction with the above.

### Additional refactoring
- Renamed several methods to improve descriptiveness and clarity, and correct misleading terminology.
- Removed redundant `VisualShaderGraphPlugin::get_shader_type` method.
- Removed redundant `updating` member.
