### PR TITLE
Fix run instances dialog scaling bug

### DIFF
--- a/editor/run_instances_dialog.cpp
+++ b/editor/run_instances_dialog.cpp
@@ -156,7 +156,7 @@ Vector<String> RunInstancesDialog::_split_cmdline_args(const String &p_arg_strin
 }
 
 void RunInstancesDialog::popup_dialog() {
-	popup_centered(Vector2i(1200, 600) * EDSCALE);
+	popup_centered(Vector2(1200, 600) * EDSCALE);
 }
 
 int RunInstancesDialog::get_instance_count() const {


### PR DESCRIPTION
Fixes #98537

The EDSCALE variable (a float) was being multiplied to the Vector2i, and since Vector2i only has a * operator for int, EDSCALE would get rounded down. This meant that if the display scale was 0.75, it would get rounded to 0 and the dialog would open up with it's minimum size. With this change, the round happens after the multiplication.

