### PR TITLE
Docs: Note that C# does not have "copy constructors" for variant types

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -26,6 +26,7 @@
 			<param index="0" name="from" type="AABB" />
 			<description>
 				Constructs an [AABB] as a copy of the given [AABB].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="AABB">

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -32,6 +32,7 @@
 			<param index="0" name="from" type="Basis" />
 			<description>
 				Constructs a [Basis] as a copy of the given [Basis].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Basis">

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -43,6 +43,7 @@
 			<param index="0" name="from" type="Color" />
 			<description>
 				Constructs a [Color] as a copy of the given [Color].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Color">

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -21,6 +21,7 @@
 			<param index="0" name="from" type="Plane" />
 			<description>
 				Constructs a [Plane] as a copy of the given [Plane].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Plane">

--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -22,6 +22,7 @@
 			<param index="0" name="from" type="Projection" />
 			<description>
 				Constructs a [Projection] as a copy of the given [Projection].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Projection">

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -29,6 +29,7 @@
 			<param index="0" name="from" type="Quaternion" />
 			<description>
 				Constructs a [Quaternion] as a copy of the given [Quaternion].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Quaternion">

--- a/doc/classes/RID.xml
+++ b/doc/classes/RID.xml
@@ -22,6 +22,7 @@
 			<param index="0" name="from" type="RID" />
 			<description>
 				Constructs a [RID] as a copy of the given [RID].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 	</constructors>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -26,6 +26,7 @@
 			<param index="0" name="from" type="Rect2" />
 			<description>
 				Constructs a [Rect2] as a copy of the given [Rect2].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Rect2">

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -25,6 +25,7 @@
 			<param index="0" name="from" type="Rect2i" />
 			<description>
 				Constructs a [Rect2i] as a copy of the given [Rect2i].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Rect2i">

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -27,6 +27,7 @@
 			<param index="0" name="from" type="Transform2D" />
 			<description>
 				Constructs a [Transform2D] as a copy of the given [Transform2D].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Transform2D">

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -28,6 +28,7 @@
 			<param index="0" name="from" type="Transform3D" />
 			<description>
 				Constructs a [Transform3D] as a copy of the given [Transform3D].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Transform3D">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -29,6 +29,7 @@
 			<param index="0" name="from" type="Vector2" />
 			<description>
 				Constructs a [Vector2] as a copy of the given [Vector2].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Vector2">

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -25,6 +25,7 @@
 			<param index="0" name="from" type="Vector2i" />
 			<description>
 				Constructs a [Vector2i] as a copy of the given [Vector2i].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Vector2i">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -29,6 +29,7 @@
 			<param index="0" name="from" type="Vector3" />
 			<description>
 				Constructs a [Vector3] as a copy of the given [Vector3].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Vector3">

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -25,6 +25,7 @@
 			<param index="0" name="from" type="Vector3i" />
 			<description>
 				Constructs a [Vector3i] as a copy of the given [Vector3i].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Vector3i">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -23,6 +23,7 @@
 			<param index="0" name="from" type="Vector4" />
 			<description>
 				Constructs a [Vector4] as a copy of the given [Vector4].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Vector4">

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -22,6 +22,7 @@
 			<param index="0" name="from" type="Vector4i" />
 			<description>
 				Constructs a [Vector4i] as a copy of the given [Vector4i].
+				[b]Note:[/b] In C#, this constructor is not available.
 			</description>
 		</constructor>
 		<constructor name="Vector4i">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/10148.

This PR notes that constructors of the form `public Basis(Basis from)` are not available in C#.

To create a copy of a struct variant type in C#, the following syntax with a "copy constructor" is not available:
```csharp
Basis original = Basis.Identity;
Basis copy = new Basis(original);
```
Instead, the following syntax can be used:
```csharp
Basis original = Basis.Identity;
Basis copy = original;
```
