### PR TITLE
Remove button number limit from Windows `dialog_show()` implementation.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2743,7 +2743,7 @@ Error DisplayServerWindows::dialog_show(String p_title, String p_description, Ve
 	config.pszWindowTitle = (LPCWSTR)(title.get_data());
 	config.pszContent = (LPCWSTR)(message.get_data());
 
-	const int button_count = MIN((int)buttons.size(), 8);
+	const int button_count = buttons.size();
 	config.cButtons = button_count;
 
 	// No dynamic stack array size :(


### PR DESCRIPTION
Tested on Windows 11, it can handle much more buttons and 8 seems to be completely arbitrary limit (also, there's no limit in macOS implementation). Practically, it's only limited by the screen size.