### PR TITLE
Emit `filesystem_changed` only once per frame

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2376,8 +2376,16 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 		if (!is_scanning()) {
 			_process_update_pending();
 		}
-		call_deferred(SNAME("emit_signal"), "filesystem_changed"); // Update later
+		if (!filesystem_changed_queued) {
+			filesystem_changed_queued = true;
+			callable_mp(this, &EditorFileSystem::_notify_filesystem_changed).call_deferred();
+		}
 	}
+}
+
+void EditorFileSystem::_notify_filesystem_changed() {
+	emit_signal("filesystem_changed");
+	filesystem_changed_queued = false;
 }
 
 HashSet<String> EditorFileSystem::get_valid_extensions() const {

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -180,6 +180,7 @@ class EditorFileSystem : public Node {
 	EditorFileSystemDirectory *new_filesystem = nullptr;
 	ScannedDirectory *first_scan_root_dir = nullptr;
 
+	bool filesystem_changed_queued = false;
 	bool scanning = false;
 	bool importing = false;
 	bool first_scan = true;
@@ -189,6 +190,7 @@ class EditorFileSystem : public Node {
 	bool revalidate_import_files = false;
 	int nb_files_total = 0;
 
+	void _notify_filesystem_changed();
 	void _scan_filesystem();
 	void _first_scan_filesystem();
 	void _first_scan_process_scripts(const ScannedDirectory *p_scan_dir, List<String> &p_gdextension_extensions, HashSet<String> &p_existing_class_names, HashSet<String> &p_extensions);


### PR DESCRIPTION
This PR makes it so that only one deferred signal is emitted instead of dozens for each updated file. This was done in order to avoid unnecessary `FileSystemDock::update_all`, which was writing millions of items to the `EditorResourcePreview`
https://github.com/godotengine/godot/blob/61accf060515416da07d913580419fd8c8490f7b/editor/filesystem_dock.cpp#L338-L341
 and creating huge memory usage.

Tested on MRP from  #97610.
Before that, it used 9GB of RAM.
Now it use 1GB.
Also, the import time improved 2-3 times.

Closes #97610
Edit: Does not help #95979