### PR TITLE
Fix OpenXR module failing to build on Linux when Wayland is disabled

### DIFF
--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -64,7 +64,7 @@ HashMap<String, bool *> OpenXROpenGLExtension::get_requested_extensions() {
 #else
 	request_extensions[XR_KHR_OPENGL_ENABLE_EXTENSION_NAME] = nullptr;
 #endif
-#if defined(LINUXBSD_ENABLED) && defined(EGL_ENABLED)
+#if defined(LINUXBSD_ENABLED) && defined(EGL_ENABLED) && defined(WAYLAND_ENABLED)
 	request_extensions[XR_MNDX_EGL_ENABLE_EXTENSION_NAME] = &egl_extension_enabled;
 #endif
 
@@ -135,7 +135,7 @@ XrGraphicsBindingOpenGLESAndroidKHR OpenXROpenGLExtension::graphics_binding_gl;
 #ifdef X11_ENABLED
 XrGraphicsBindingOpenGLXlibKHR OpenXROpenGLExtension::graphics_binding_gl;
 #endif
-#ifdef EGL_ENABLED
+#if defined(EGL_ENABLED) && defined(WAYLAND_ENABLED)
 XrGraphicsBindingEGLMNDX OpenXROpenGLExtension::graphics_binding_egl;
 #endif
 #endif

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.h
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.h
@@ -68,7 +68,7 @@ private:
 #ifdef X11_ENABLED
 	static XrGraphicsBindingOpenGLXlibKHR graphics_binding_gl;
 #endif
-#ifdef EGL_ENABLED
+#if defined(EGL_ENABLED) && defined(WAYLAND_ENABLED)
 	static XrGraphicsBindingEGLMNDX graphics_binding_egl;
 
 	bool egl_extension_enabled = false;


### PR DESCRIPTION
This should fix [compile errors found by sudo.juan in the Godot Contributors Chat](https://chat.godotengine.org/channel/general?msg=GFEEZCtYBJTiZPBcF)

#97771 suggests that the OpenXR module is only meant to use EGL when Wayland is enabled. However, only some references to EGL are excluded from compilation when Wayland is disabled, with the few that are not excluded leading to compile errors. This PR fixes the incomplete preprocessor checks that cause these errors.