### PR TITLE
Do not update editor gizmo transforms if they are hidden and not selectable

### DIFF
--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -814,6 +814,11 @@ void EditorNode3DGizmo::create() {
 void EditorNode3DGizmo::transform() {
 	ERR_FAIL_NULL(spatial_node);
 	ERR_FAIL_COND(!valid);
+
+	if (hidden && !gizmo_plugin->is_selectable_when_hidden()) {
+		return;
+	}
+
 	for (int i = 0; i < instances.size(); i++) {
 		RS::get_singleton()->instance_set_transform(instances[i].instance, spatial_node->get_global_transform() * instances[i].xform);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

While profiling a project in the editor where I was moving a lot of nodes arounds at the same time, I noticed that this particular function was using up a lot of CPU time, even though the majority of the gizmos were hidden.

If moving around several hundred CollisionShape3Ds even when the gizmo is not visible, this function becomes noticeable. After this PR, it doesn't register, which should improve editor performance.

![image](https://github.com/user-attachments/assets/52e29f58-05bc-46f7-81dd-205a8a43bed4)

