### PR TITLE
Fix heap-use-after-free when ctrl-clicking controls in a container

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1464,10 +1464,12 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 				List<CanvasItem *> selection = _get_edited_canvas_items(false, true, &has_locked_items);
 
 				// Remove not movable nodes
-				for (CanvasItem *E : selection) {
-					if (!_is_node_movable(E, true)) {
+				for (List<CanvasItem *>::Element *E = selection.front(); E;) {
+					List<CanvasItem *>::Element *N = E->next();
+					if (!_is_node_movable(E->get(), true)) {
 						selection.erase(E);
 					}
+					E = N;
 				}
 
 				drag_selection = selection;


### PR DESCRIPTION
To reproduce the crash, use an asan enabled build. Put two controls inside a VBoxContainer, select one, and ctrl-select the other.

<details><summary>heap-use-after-free error reported by asan</summary>

```
==49827==ERROR: AddressSanitizer: heap-use-after-free on address 0x504001d8a168 at pc 0x566a4ae385ed bp 0x7ffd25b317a0 sp 0x7ffd25b31790
READ of size 8 at 0x504001d8a168 thread T0
    #0 0x566a4ae385ec in List<CanvasItem*, DefaultAllocator>::Element::next() core/templates/list.h:71
    #1 0x566a4ae2fcdf in List<CanvasItem*, DefaultAllocator>::Iterator::operator++() core/templates/list.h:173
    #2 0x566a4ad9dfdb in CanvasItemEditor::_gui_input_rotate(Ref<InputEvent> const&) editor/plugins/canvas_item_editor_plugin.cpp:1467
    #3 0x566a4adb785c in CanvasItemEditor::_gui_input_viewport(Ref<InputEvent> const&) editor/plugins/canvas_item_editor_plugin.cpp:2666
    #4 0x566a4ae55792 in void call_with_variant_args_helper<CanvasItemEditor, Ref<InputEvent> const&, 0ul>(CanvasItemEditor*, void (CanvasItemEditor::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:304
    #5 0x566a4ae52868 in void call_with_variant_args<CanvasItemEditor, Ref<InputEvent> const&>(CanvasItemEditor*, void (CanvasItemEditor::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:418
    #6 0x566a4ae4a018 in CallableCustomMethodPointer<CanvasItemEditor, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:107
    #7 0x566a51006050 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #8 0x566a5188bf6f in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1200
    #9 0x566a4bf1603c in Node::emit_signalp(StringName const&, Variant const**, int) scene/main/node.cpp:3974
    #10 0x566a4a11d47e in Error Object::emit_signal<Ref<InputEvent> >(StringName const&, Ref<InputEvent>) core/object/object.h:920
    #11 0x566a4c37abe9 in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1811
    #12 0x566a4c0246b3 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1573
    #13 0x566a4c027ea4 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1802
    #14 0x566a4c039448 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:3176
    #15 0x566a4c115f6b in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1680
    #16 0x566a4c1b6de2 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:304
    #17 0x566a4c1a3bf0 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:418
    #18 0x566a4c18e8f6 in CallableCustomMethodPointer<Window, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:107
    #19 0x566a51006050 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #20 0x566a45998ff7 in Variant Callable::call<Ref<InputEvent> >(Ref<InputEvent>) const core/variant/variant.h:905
    #21 0x566a45964cbc in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:4063
    #22 0x566a459647c4 in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:4039
    #23 0x566a50f0120d in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:802
    #24 0x566a50f04b86 in Input::flush_buffered_events() core/input/input.cpp:1083
    #25 0x566a45972eca in DisplayServerX11::process_events() platform/linuxbsd/x11/display_server_x11.cpp:5199
    #26 0x566a45905af4 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:958
    #27 0x566a458f4976 in main platform/linuxbsd/godot_linuxbsd.cpp:85
    #28 0x7fc349945e07  (/usr/lib/libc.so.6+0x25e07) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #29 0x7fc349945ecb in __libc_start_main (/usr/lib/libc.so.6+0x25ecb) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #30 0x566a458f4564 in _start (/home/timothy/repos/godot-master/bin/godot.linuxbsd.editor.dev.x86_64.san+0x8d9c564) (BuildId: 7e7b7e7009b47020215dcc1a8a60232b7fb2f39a)

0x504001d8a168 is located 24 bytes inside of 48-byte region [0x504001d8a150,0x504001d8a180)
freed by thread T0 here:
    #0 0x7fc349cfc282 in free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x566a509cd692 in Memory::free_static(void*, bool) core/os/memory.cpp:201
    #2 0x566a458f60e7 in DefaultAllocator::free(void*) core/os/memory.h:97
    #3 0x566a4ab7ed5a in void memdelete_allocator<List<CanvasItem*, DefaultAllocator>::Element, DefaultAllocator>(List<CanvasItem*, DefaultAllocator>::Element*) core/os/memory.h:155
    #4 0x566a4ab7ece3 in List<CanvasItem*, DefaultAllocator>::_Data::erase(List<CanvasItem*, DefaultAllocator>::Element const*) core/templates/list.h:247
    #5 0x566a4ab7e96f in List<CanvasItem*, DefaultAllocator>::erase(List<CanvasItem*, DefaultAllocator>::Element const*) core/templates/list.h:435
    #6 0x566a4ae30c8b in List<CanvasItem*, DefaultAllocator>::erase(CanvasItem* const&) core/templates/list.h:453
    #7 0x566a4ad9dfcc in CanvasItemEditor::_gui_input_rotate(Ref<InputEvent> const&) editor/plugins/canvas_item_editor_plugin.cpp:1469
    #8 0x566a4adb785c in CanvasItemEditor::_gui_input_viewport(Ref<InputEvent> const&) editor/plugins/canvas_item_editor_plugin.cpp:2666
    #9 0x566a4ae55792 in void call_with_variant_args_helper<CanvasItemEditor, Ref<InputEvent> const&, 0ul>(CanvasItemEditor*, void (CanvasItemEditor::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:304
    #10 0x566a4ae52868 in void call_with_variant_args<CanvasItemEditor, Ref<InputEvent> const&>(CanvasItemEditor*, void (CanvasItemEditor::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:418
    #11 0x566a4ae4a018 in CallableCustomMethodPointer<CanvasItemEditor, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:107
    #12 0x566a51006050 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #13 0x566a5188bf6f in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1200
    #14 0x566a4bf1603c in Node::emit_signalp(StringName const&, Variant const**, int) scene/main/node.cpp:3974
    #15 0x566a4a11d47e in Error Object::emit_signal<Ref<InputEvent> >(StringName const&, Ref<InputEvent>) core/object/object.h:920
    #16 0x566a4c37abe9 in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1811
    #17 0x566a4c0246b3 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1573
    #18 0x566a4c027ea4 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1802
    #19 0x566a4c039448 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:3176
    #20 0x566a4c115f6b in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1680
    #21 0x566a4c1b6de2 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:304
    #22 0x566a4c1a3bf0 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:418
    #23 0x566a4c18e8f6 in CallableCustomMethodPointer<Window, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:107
    #24 0x566a51006050 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #25 0x566a45998ff7 in Variant Callable::call<Ref<InputEvent> >(Ref<InputEvent>) const core/variant/variant.h:905
    #26 0x566a45964cbc in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:4063
    #27 0x566a459647c4 in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:4039
    #28 0x566a50f0120d in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:802
    #29 0x566a50f04b86 in Input::flush_buffered_events() core/input/input.cpp:1083

previously allocated by thread T0 here:
    #0 0x7fc349cfd891 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x566a509ccae6 in Memory::alloc_static(unsigned long, bool) core/os/memory.cpp:108
    #2 0x566a458f60c8 in DefaultAllocator::alloc(unsigned long) core/os/memory.h:96
    #3 0x566a509cc833 in operator new(unsigned long, void* (*)(unsigned long)) core/os/memory.cpp:45
    #4 0x566a4ae2f785 in List<CanvasItem*, DefaultAllocator>::push_back(CanvasItem* const&) core/templates/list.h:296
    #5 0x566a4ad905b3 in CanvasItemEditor::_get_edited_canvas_items(bool, bool, bool*) const editor/plugins/canvas_item_editor_plugin.cpp:805
    #6 0x566a4ad9deec in CanvasItemEditor::_gui_input_rotate(Ref<InputEvent> const&) editor/plugins/canvas_item_editor_plugin.cpp:1464
    #7 0x566a4adb785c in CanvasItemEditor::_gui_input_viewport(Ref<InputEvent> const&) editor/plugins/canvas_item_editor_plugin.cpp:2666
    #8 0x566a4ae55792 in void call_with_variant_args_helper<CanvasItemEditor, Ref<InputEvent> const&, 0ul>(CanvasItemEditor*, void (CanvasItemEditor::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:304
    #9 0x566a4ae52868 in void call_with_variant_args<CanvasItemEditor, Ref<InputEvent> const&>(CanvasItemEditor*, void (CanvasItemEditor::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:418
    #10 0x566a4ae4a018 in CallableCustomMethodPointer<CanvasItemEditor, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:107
    #11 0x566a51006050 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #12 0x566a5188bf6f in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1200
    #13 0x566a4bf1603c in Node::emit_signalp(StringName const&, Variant const**, int) scene/main/node.cpp:3974
    #14 0x566a4a11d47e in Error Object::emit_signal<Ref<InputEvent> >(StringName const&, Ref<InputEvent>) core/object/object.h:920
    #15 0x566a4c37abe9 in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1811
    #16 0x566a4c0246b3 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1573
    #17 0x566a4c027ea4 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1802
    #18 0x566a4c039448 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:3176
    #19 0x566a4c115f6b in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1680
    #20 0x566a4c1b6de2 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:304
    #21 0x566a4c1a3bf0 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:418
    #22 0x566a4c18e8f6 in CallableCustomMethodPointer<Window, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:107
    #23 0x566a51006050 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #24 0x566a45998ff7 in Variant Callable::call<Ref<InputEvent> >(Ref<InputEvent>) const core/variant/variant.h:905
    #25 0x566a45964cbc in DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:4063
    #26 0x566a459647c4 in DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) platform/linuxbsd/x11/display_server_x11.cpp:4039
    #27 0x566a50f0120d in Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) core/input/input.cpp:802
    #28 0x566a50f04b86 in Input::flush_buffered_events() core/input/input.cpp:1083
    #29 0x566a45972eca in DisplayServerX11::process_events() platform/linuxbsd/x11/display_server_x11.cpp:5199

SUMMARY: AddressSanitizer: heap-use-after-free core/templates/list.h:71 in List<CanvasItem*, DefaultAllocator>::Element::next()
Shadow bytes around the buggy address:
  0x504001d89e80: fa fa 00 00 00 00 00 00 fa fa fd fd fd fd fd fa
  0x504001d89f00: fa fa 00 00 00 00 00 fa fa fa 00 00 00 00 00 fa
  0x504001d89f80: fa fa 00 00 00 00 00 00 fa fa 00 00 00 00 00 00
  0x504001d8a000: fa fa 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
  0x504001d8a080: fa fa fa fa fa fa fa fa fa fa 00 00 00 00 00 fa
=>0x504001d8a100: fa fa 00 00 00 00 00 fa fa fa fd fd fd[fd]fd fd
  0x504001d8a180: fa fa fa fa fa fa fa fa fa fa fd fd fd fd fd fd
  0x504001d8a200: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x504001d8a280: fa fa fa fa fa fa fa fa fa fa 00 00 00 00 00 fa
  0x504001d8a300: fa fa 00 00 00 00 00 00 fa fa 00 00 00 00 00 00
  0x504001d8a380: fa fa 00 00 00 00 00 00 fa fa 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==49827==ABORTING
```
</details>