### PR TITLE
Fix monochrome icon, add warning when it's not specified

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1693,7 +1693,7 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	path = static_cast<String>(p_preset->get(launcher_adaptive_icon_monochrome_option)).strip_edges();
 	if (!path.is_empty()) {
 		print_verbose("Loading adaptive monochrome icon from " + path);
-		ImageLoader::load_image(path, background);
+		ImageLoader::load_image(path, monochrome);
 	}
 }
 
@@ -1777,6 +1777,12 @@ String EditorExportPlatformAndroid::get_export_option_warning(const EditorExport
 
 			if (!is_package_name_valid(pn, &pn_err)) {
 				return TTR("Invalid package name:") + " " + pn_err;
+			}
+		} else if (p_name == launcher_adaptive_icon_monochrome_option) {
+			String monochrome_icon_path = p_preset->get(launcher_adaptive_icon_monochrome_option);
+
+			if (monochrome_icon_path.is_empty()) {
+				return TTR("No adaptive monochrome icon specified; default Godot monochrome icon will be used.");
 			}
 		} else if (p_name == "gradle_build/use_gradle_build") {
 			bool gradle_build_enabled = p_preset->get("gradle_build/use_gradle_build");


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix small typo which resulted in setting adaptive background icon to monochrome one if monochrome is specified.
