### PR TITLE
Fix normals of very large `SphereMesh` and `CapsuleMesh`

### DIFF
--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -448,7 +448,7 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 			y = 0.0;
 		} else {
 			w = Math::sin(0.5 * Math_PI * v);
-			y = Math::cos(0.5 * Math_PI * v) * radius;
+			y = Math::cos(0.5 * Math_PI * v);
 		}
 
 		for (i = 0; i <= radial_segments; i++) {
@@ -463,9 +463,9 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 				z = Math::cos(u * Math_TAU);
 			}
 
-			Vector3 p = Vector3(x * radius * w, y, -z * radius * w);
-			points.push_back(p + Vector3(0.0, 0.5 * height - radius, 0.0));
-			normals.push_back(p.normalized());
+			Vector3 p = Vector3(x * w, y, -z * w);
+			points.push_back(p * radius + Vector3(0.0, 0.5 * height - radius, 0.0));
+			normals.push_back(p);
 			ADD_TANGENT(-z, 0.0, -x, 1.0)
 			uvs.push_back(Vector2(u, v * onethird));
 			if (p_add_uv2) {
@@ -544,10 +544,10 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 		v /= (rings + 1);
 		if (j == (rings + 1)) {
 			w = 0.0;
-			y = -radius;
+			y = -1.0;
 		} else {
 			w = Math::cos(0.5 * Math_PI * v);
-			y = -Math::sin(0.5 * Math_PI * v) * radius;
+			y = -Math::sin(0.5 * Math_PI * v);
 		}
 
 		for (i = 0; i <= radial_segments; i++) {
@@ -562,9 +562,9 @@ void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const floa
 				z = Math::cos(u * Math_TAU);
 			}
 
-			Vector3 p = Vector3(x * radius * w, y, -z * radius * w);
-			points.push_back(p + Vector3(0.0, -0.5 * height + radius, 0.0));
-			normals.push_back(p.normalized());
+			Vector3 p = Vector3(x * w, y, -z * w);
+			points.push_back(p * radius + Vector3(0.0, -0.5 * height + radius, 0.0));
+			normals.push_back(p);
 			ADD_TANGENT(-z, 0.0, -x, 1.0)
 			uvs.push_back(Vector2(u, twothirds + v * onethird));
 			if (p_add_uv2) {
@@ -1941,14 +1941,14 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 	int i, j, prevrow, thisrow, point;
 	float x, y, z;
 
-	float scale = height * (is_hemisphere ? 1.0 : 0.5);
+	float scale = height / radius * (is_hemisphere ? 1.0 : 0.5);
 
 	// Only used if we calculate UV2
 	float circumference = radius * Math_TAU;
 	float horizontal_length = circumference + p_uv2_padding;
 	float center_h = 0.5 * circumference / horizontal_length;
 
-	float height_v = scale * Math_PI / ((scale * Math_PI) + p_uv2_padding);
+	float height_v = scale * Math_PI / ((scale * Math_PI) + p_uv2_padding / radius);
 
 	// set our bounding box
 
@@ -1975,10 +1975,10 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 		v /= (rings + 1);
 		if (j == (rings + 1)) {
 			w = 0.0;
-			y = -scale;
+			y = -1.0;
 		} else {
 			w = Math::sin(Math_PI * v);
-			y = Math::cos(Math_PI * v) * scale;
+			y = Math::cos(Math_PI * v);
 		}
 
 		for (i = 0; i <= radial_segments; i++) {
@@ -1997,9 +1997,9 @@ void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int
 				points.push_back(Vector3(x * radius * w, 0.0, z * radius * w));
 				normals.push_back(Vector3(0.0, -1.0, 0.0));
 			} else {
-				Vector3 p = Vector3(x * radius * w, y, z * radius * w);
-				points.push_back(p);
-				Vector3 normal = Vector3(x * w * scale, radius * (y / scale), z * w * scale);
+				Vector3 p = Vector3(x * w, y * scale, z * w);
+				points.push_back(p * radius);
+				Vector3 normal = Vector3(x * w * scale, y, z * w * scale);
 				normals.push_back(normal.normalized());
 			}
 			ADD_TANGENT(z, 0.0, -x, 1.0)


### PR DESCRIPTION
`SphereMesh` and `CapsuleMesh` compute their sphere normals by normalizing the vertex position.
Normalizing involves squaring the vertex coordinates, which generate `INFINITE` values if at least one of the coordinates is larger than `sqrt(MAX_FLOAT_VALUE)`.
With 32 bit floats, this threshold value is ~`1.84E19`. With 64 bit floats it's ~`1.34E154`.

~This PR fixes this behavior by dividing the vertex position by the radius *before* normalizing.
This doesn't change the end result of the normalization, but avoid running into the floating point precision issue.~

**[EDIT]** This PR fixes this behavior by working with unit length vectors all the way down, and scaling with radius only to calculate vertex positions.
Radius is not involved anymore in normal computation logic, which avoids running into the floating point precision issue.

I tested the other primitives and all of them are fine with normals.

| | Normals with this PR | Normals without |
|-|---|---|
|`SphereMesh` of radius `1E28` | ![Capture d’écran du 2024-10-28 11-28-51](https://github.com/user-attachments/assets/428e9084-5047-4760-add9-b26fb605ac1b) |![Capture d’écran du 2024-10-28 11-34-38](https://github.com/user-attachments/assets/fc309aff-fac9-44bc-a658-665b69213062) |
|`CapsuleMesh` of radius `1E28` |![Capture d’écran du 2024-10-28 11-31-19](https://github.com/user-attachments/assets/0c9ff423-eb64-43d1-b2b6-ab3a208d4a57) |![Capture d’écran du 2024-10-28 11-34-23](https://github.com/user-attachments/assets/4abb598c-979f-4027-a812-88974b795dd6)|

Note : I stumbled upon this issue by working on #95944.
Being able to render very large primitives can be useful in very large worlds (space sims, terrain generation ...).