### PR TITLE
Fix soft shadows by increasing the bit count for specialization constants.

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -108,10 +108,10 @@ public:
 				uint32_t projector_use_mipmaps : 1;
 				uint32_t use_depth_fog : 1;
 				uint32_t use_lightmap_bicubic_filter : 1;
-				uint32_t soft_shadow_samples : 4;
-				uint32_t penumbra_shadow_samples : 4;
-				uint32_t directional_soft_shadow_samples : 4;
-				uint32_t directional_penumbra_shadow_samples : 4;
+				uint32_t soft_shadow_samples : 6;
+				uint32_t penumbra_shadow_samples : 6;
+				uint32_t directional_soft_shadow_samples : 6;
+				uint32_t directional_penumbra_shadow_samples : 6;
 			};
 
 			uint32_t packed_0;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -322,7 +322,12 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 	specialization_constants.push_back(sc);
 
 	sc.constant_id = 1;
-	sc.float_value = p_pipeline_key.shader_specialization.packed_1;
+	sc.int_value = p_pipeline_key.shader_specialization.packed_1;
+	sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_INT;
+	specialization_constants.push_back(sc);
+
+	sc.constant_id = 2;
+	sc.float_value = p_pipeline_key.shader_specialization.packed_2;
 	sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_FLOAT;
 	specialization_constants.push_back(sc);
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -74,22 +74,23 @@ public:
 				uint32_t use_depth_fog : 1;
 				uint32_t is_multimesh : 1;
 				uint32_t use_lightmap_bicubic_filter : 1;
-				uint32_t pad : 2;
-				uint32_t soft_shadow_samples : 4;
-				uint32_t penumbra_shadow_samples : 4;
-				uint32_t directional_soft_shadow_samples : 4;
-				uint32_t directional_penumbra_shadow_samples : 4;
+				uint32_t soft_shadow_samples : 6;
+				uint32_t penumbra_shadow_samples : 6;
+				uint32_t directional_soft_shadow_samples : 6;
 			};
 
 			uint32_t packed_0;
 		};
 
 		union {
-			float luminance_multiplier;
-			float packed_1;
+			uint32_t directional_penumbra_shadow_samples : 6;
+			uint32_t packed_1;
 		};
 
-		uint32_t packed_2;
+		union {
+			float luminance_multiplier;
+			float packed_2;
+		};
 	};
 
 	struct UbershaderConstants {

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -107,19 +107,19 @@ bool sc_use_lightmap_bicubic_filter() {
 }
 
 uint sc_soft_shadow_samples() {
-	return (sc_packed_0() >> 8) & 15U;
+	return (sc_packed_0() >> 8) & 63U;
 }
 
 uint sc_penumbra_shadow_samples() {
-	return (sc_packed_0() >> 12) & 15U;
+	return (sc_packed_0() >> 14) & 63U;
 }
 
 uint sc_directional_soft_shadow_samples() {
-	return (sc_packed_0() >> 16) & 15U;
+	return (sc_packed_0() >> 20) & 63U;
 }
 
 uint sc_directional_penumbra_shadow_samples() {
-	return (sc_packed_0() >> 20) & 15U;
+	return (sc_packed_0() >> 26) & 63U;
 }
 
 float sc_luminance_multiplier() {

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -22,8 +22,8 @@ layout(push_constant, std430) uniform DrawCall {
 	uint pad;
 #ifdef UBERSHADER
 	uint sc_packed_0;
-	float sc_packed_1;
-	uint sc_packed_2;
+	uint sc_packed_1;
+	float sc_packed_2;
 	uint uc_packed_0;
 #endif
 }
@@ -42,8 +42,12 @@ uint sc_packed_0() {
 	return draw_call.sc_packed_0;
 }
 
-float sc_packed_1() {
+uint sc_packed_1() {
 	return draw_call.sc_packed_1;
+}
+
+float sc_packed_2() {
+	return draw_call.sc_packed_2;
 }
 
 uint uc_cull_mode() {
@@ -54,14 +58,19 @@ uint uc_cull_mode() {
 
 // Pull the constants from the pipeline's specialization constants.
 layout(constant_id = 0) const uint pso_sc_packed_0 = 0;
-layout(constant_id = 1) const float pso_sc_packed_1 = 2.0;
+layout(constant_id = 1) const uint pso_sc_packed_1 = 0;
+layout(constant_id = 2) const float pso_sc_packed_2 = 2.0;
 
 uint sc_packed_0() {
 	return pso_sc_packed_0;
 }
 
-float sc_packed_1() {
+uint sc_packed_1() {
 	return pso_sc_packed_1;
+}
+
+float sc_packed_2() {
+	return pso_sc_packed_2;
 }
 
 #endif
@@ -123,23 +132,23 @@ bool sc_use_lightmap_bicubic_filter() {
 }
 
 uint sc_soft_shadow_samples() {
-	return (sc_packed_0() >> 16) & 15U;
+	return (sc_packed_0() >> 14) & 63U;
 }
 
 uint sc_penumbra_shadow_samples() {
-	return (sc_packed_0() >> 20) & 15U;
+	return (sc_packed_0() >> 20) & 63U;
 }
 
 uint sc_directional_soft_shadow_samples() {
-	return (sc_packed_0() >> 24) & 15U;
+	return (sc_packed_0() >> 26) & 63U;
 }
 
 uint sc_directional_penumbra_shadow_samples() {
-	return (sc_packed_0() >> 28) & 15U;
+	return (sc_packed_1() >> 0) & 63U;
 }
 
 float sc_luminance_multiplier() {
-	return sc_packed_1();
+	return sc_packed_2();
 }
 
 /* Set 0: Base Pass (never changes) */


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/97839.

The previous amount of bits could not hold the possible 16 and 32 amount of samples. The amount has been expanded to the bare minimum required to hold this value, as space for these constants must be as small as possible for optimization reasons.