### PR TITLE
Fix `PathFollow3D` not first updating with `0.0` as value

### DIFF
--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -266,6 +266,7 @@ void PathFollow3D::update_transform() {
 void PathFollow3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
+			progress_initialized = false;
 			Node *parent = get_parent();
 			if (parent) {
 				path = Object::cast_to<Path3D>(parent);
@@ -395,10 +396,11 @@ void PathFollow3D::_bind_methods() {
 
 void PathFollow3D::set_progress(real_t p_progress) {
 	ERR_FAIL_COND(!isfinite(p_progress));
-	if (progress == p_progress) {
+	if (progress == p_progress && progress_initialized) {
 		return;
 	}
 	progress = p_progress;
+	progress_initialized = true;
 
 	if (path) {
 		if (path->get_curve().is_valid()) {

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -76,6 +76,7 @@ public:
 
 private:
 	Path3D *path = nullptr;
+	bool progress_initialized = false;
 	real_t progress = 0.0;
 	real_t h_offset = 0.0;
 	real_t v_offset = 0.0;


### PR DESCRIPTION
> [!WARNING]
> If there's no issues with #98642, that PR should be merged and this one should be closed.

Fixes #98602

The reason behind the bug was that `progress` was first initialized with the value `0.0`, and it rejected manually setting this value to `0.0` because it was the same as previously set.

With a `progress_initialized` flag, it's easier to track the first initialization.