### PR TITLE
LOD: Remove "Raycast Normals" and associated "Normal Split Angle" settings

### DIFF
--- a/doc/classes/ImporterMesh.xml
+++ b/doc/classes/ImporterMesh.xml
@@ -49,7 +49,8 @@
 			<param index="2" name="bone_transform_array" type="Array" />
 			<description>
 				Generates all lods for this ImporterMesh.
-				[param normal_merge_angle] and [param normal_split_angle] are in degrees and used in the same way as the importer settings in [code]lods[/code]. As a good default, use 25 and 60 respectively.
+				[param normal_merge_angle] is in degrees and used in the same way as the importer settings in [code]lods[/code].
+				[param normal_split_angle] is not used and only remains for compatibility with older versions of the API.
 				The number of generated lods can be accessed using [method get_surface_lod_count], and each LOD is available in [method get_surface_lod_size] and [method get_surface_lod_indices].
 				[param bone_transform_array] is an [Array] which can be either empty or contain [Transform3D]s which, for each of the mesh's bone IDs, will apply mesh skinning when generating the LOD mesh variations. This is usually used to account for discrepancies in scale between the mesh itself and its skinning data.
 			</description>

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -539,7 +539,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 
 	if (p_generate_lods) {
 		// Use normal merge/split angles that match the defaults used for 3D scene importing.
-		mesh->generate_lods(60.0f, 25.0f, {});
+		mesh->generate_lods(60.0f, {});
 	}
 
 	if (p_generate_shadow_mesh) {

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2043,9 +2043,7 @@ void ResourceImporterScene::get_internal_import_options(InternalImportCategory p
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/shadow_meshes", PROPERTY_HINT_ENUM, "Default,Enable,Disable"), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/lightmap_uv", PROPERTY_HINT_ENUM, "Default,Enable,Disable"), 0));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "generate/lods", PROPERTY_HINT_ENUM, "Default,Enable,Disable"), 0));
-			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "lods/normal_split_angle", PROPERTY_HINT_RANGE, "0,180,0.1,degrees"), 25.0f));
 			r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "lods/normal_merge_angle", PROPERTY_HINT_RANGE, "0,180,0.1,degrees"), 60.0f));
-			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "lods/raycast_normals", PROPERTY_HINT_NONE, ""), false));
 		} break;
 		case INTERNAL_IMPORT_CATEGORY_MATERIAL: {
 			r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "use_external/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
@@ -2474,9 +2472,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 				//do mesh processing
 
 				bool generate_lods = p_generate_lods;
-				float split_angle = 25.0f;
 				float merge_angle = 60.0f;
-				bool raycast_normals = false;
 				bool create_shadow_meshes = p_create_shadow_meshes;
 				bool bake_lightmaps = p_light_bake_mode == LIGHT_BAKE_STATIC_LIGHTMAPS;
 				String save_to_file;
@@ -2523,16 +2519,8 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 						}
 					}
 
-					if (mesh_settings.has("lods/normal_split_angle")) {
-						split_angle = mesh_settings["lods/normal_split_angle"];
-					}
-
 					if (mesh_settings.has("lods/normal_merge_angle")) {
 						merge_angle = mesh_settings["lods/normal_merge_angle"];
-					}
-
-					if (mesh_settings.has("lods/raycast_normals")) {
-						raycast_normals = mesh_settings["lods/raycast_normals"];
 					}
 
 					if (bool(mesh_settings.get("save_to_file/enabled", false))) {
@@ -2583,7 +2571,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 
 				if (generate_lods) {
 					Array skin_pose_transform_array = _get_skinned_pose_transforms(src_mesh_node);
-					src_mesh_node->get_mesh()->generate_lods(merge_angle, split_angle, skin_pose_transform_array, raycast_normals);
+					src_mesh_node->get_mesh()->generate_lods(merge_angle, skin_pose_transform_array);
 				}
 
 				if (create_shadow_meshes) {

--- a/scene/resources/3d/importer_mesh.h
+++ b/scene/resources/3d/importer_mesh.h
@@ -68,9 +68,6 @@ class ImporterMesh : public Resource {
 				return l.distance < r.distance;
 			}
 		};
-
-		void split_normals(const LocalVector<int> &p_indices, const LocalVector<Vector3> &p_normals);
-		static void _split_normals(Array &r_arrays, const LocalVector<int> &p_indices, const LocalVector<Vector3> &p_normals);
 	};
 	Vector<Surface> surfaces;
 	Vector<String> blend_shapes;
@@ -118,7 +115,7 @@ public:
 
 	void optimize_indices_for_cache();
 
-	void generate_lods(float p_normal_merge_angle, float p_normal_split_angle, Array p_skin_pose_transform_array, bool p_raycast_normals = false);
+	void generate_lods(float p_normal_merge_angle, Array p_skin_pose_transform_array);
 
 	void create_shadow_mesh();
 	Ref<ImporterMesh> get_shadow_mesh() const;


### PR DESCRIPTION
"Raycast Normals" was introduced in 4.4 dev and defaulted to "false". The limited testing results at the time suggested that raycasting generally reduces normal quality compared to native simplifier results, at the same time increasing vertex memory and import time.

To play it safe, we introduced a setting that defaulted to false, with the goal of removing it later in 4.4 development cycle if no regressions are noticed. Since we already had three dev snapshots and no reports, this change removes the setting and associated code.

"Normal Split Angle" was only used when raycast normals were enabled; this change removes it from the settings, but keeps it in the script binding for compatibility.

`split_normals` helper was only used in this code path and is also removed for simplicity; it is unlikely that this code will be useful as is, as it can only regenerate normals without fixing tangents or updating positions.

Note that documentation was updated to *not* mention the "suggested" values for merge normals angle in the script binding. The recommendation given by the documentation was reversed from the default (which is 60 and 25, not 25 and 60!), and 60 seems too aggressive to recommend even if that's the current import default.

Tested by importing existing projects (both with default settings and with overridden merge angle per mesh); meshes import the same after this change. If a mesh had "raycast normals" setting enabled, it will now import without it as the setting was removed; this is the same as the transition from any 4.3 project to earlier 4.4 dev builds so no new behavior is introduced unless raycast normals were enabled in 4.4 dev which would be unusual.