### PR TITLE
Curve: Check for finiteness before performing calculations in `sample_baked()` functions

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -479,6 +479,9 @@ void Curve::set_bake_resolution(int p_resolution) {
 }
 
 real_t Curve::sample_baked(real_t p_offset) const {
+	// Make sure that p_offset is finite.
+	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_offset), 0, "Offset is non-finite");
+
 	if (_baked_cache_dirty) {
 		// Last-second bake if not done already
 		const_cast<Curve *>(this)->bake();
@@ -981,6 +984,9 @@ Transform2D Curve2D::_sample_posture(Interval p_interval) const {
 }
 
 Vector2 Curve2D::sample_baked(real_t p_offset, bool p_cubic) const {
+	// Make sure that p_offset is finite.
+	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_offset), Vector2(), "Offset is non-finite");
+
 	if (baked_cache_dirty) {
 		_bake();
 	}
@@ -1000,6 +1006,9 @@ Vector2 Curve2D::sample_baked(real_t p_offset, bool p_cubic) const {
 }
 
 Transform2D Curve2D::sample_baked_with_rotation(real_t p_offset, bool p_cubic) const {
+	// Make sure that p_offset is finite.
+	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_offset), Transform2D(), "Offset is non-finite");
+
 	if (baked_cache_dirty) {
 		_bake();
 	}
@@ -1881,6 +1890,9 @@ Basis Curve3D::get_point_baked_posture(int p_index, bool p_apply_tilt) const {
 #endif
 
 Vector3 Curve3D::sample_baked(real_t p_offset, bool p_cubic) const {
+	// Make sure that p_offset is finite.
+	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_offset), Vector3(), "Offset is non-finite");
+
 	if (baked_cache_dirty) {
 		_bake();
 	}
@@ -1900,6 +1912,9 @@ Vector3 Curve3D::sample_baked(real_t p_offset, bool p_cubic) const {
 }
 
 Transform3D Curve3D::sample_baked_with_rotation(real_t p_offset, bool p_cubic, bool p_apply_tilt) const {
+	// Make sure that p_offset is finite.
+	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_offset), Transform3D(), "Offset is non-finite");
+
 	if (baked_cache_dirty) {
 		_bake();
 	}
@@ -1929,6 +1944,9 @@ Transform3D Curve3D::sample_baked_with_rotation(real_t p_offset, bool p_cubic, b
 }
 
 real_t Curve3D::sample_baked_tilt(real_t p_offset) const {
+	// Make sure that p_offset is finite.
+	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_offset), 0, "Offset is non-finite");
+
 	if (baked_cache_dirty) {
 		_bake();
 	}
@@ -1948,6 +1966,9 @@ real_t Curve3D::sample_baked_tilt(real_t p_offset) const {
 }
 
 Vector3 Curve3D::sample_baked_up_vector(real_t p_offset, bool p_apply_tilt) const {
+	// Make sure that p_offset is finite.
+	ERR_FAIL_COND_V_MSG(!Math::is_finite(p_offset), Vector3(0, 1, 0), "Offset is non-finite");
+
 	if (baked_cache_dirty) {
 		_bake();
 	}


### PR DESCRIPTION
Prevented crash in Curve2D::_find_interval() and Curve3D::_find_interval() by checking for finiteness before performing any mathematical operations. Resolves https://github.com/godotengine/godot/issues/98372. This is my first time contributing, please let me know if anything needs to be changed.