### PR TITLE
Fix duplicated Delete shortcut entries in Tiles Editor

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1699,7 +1699,7 @@ void TileSetAtlasSourceEditor::_menu_option(int p_option) {
 
 void TileSetAtlasSourceEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	// Check for shortcuts.
-	if (ED_IS_SHORTCUT("tiles_editor/delete_tile", p_event)) {
+	if (ED_IS_SHORTCUT("tiles_editor/delete", p_event)) {
 		if (tools_button_group->get_pressed_button() == tool_select_button && !selection.is_empty()) {
 			_menu_option(TILE_DELETE);
 			accept_event();
@@ -2711,7 +2711,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 	tile_atlas_control_unscaled->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 
 	alternative_tile_popup_menu = memnew(PopupMenu);
-	alternative_tile_popup_menu->add_shortcut(ED_SHORTCUT("tiles_editor/delete_tile", TTR("Delete"), Key::KEY_DELETE), TILE_DELETE);
+	alternative_tile_popup_menu->add_shortcut(ED_GET_SHORTCUT("tiles_editor/delete"), TILE_DELETE);
 	alternative_tile_popup_menu->connect(SceneStringName(id_pressed), callable_mp(this, &TileSetAtlasSourceEditor::_menu_option));
 	tile_atlas_view->add_child(alternative_tile_popup_menu);
 


### PR DESCRIPTION
I'm not sure if this is intended or a leftover from the tiles editor refactoring, but the TileSetAtlasSourceEditor uses different shortcuts for deleting the selected base tile and deleting the selected alternative tile. Their default key bindings are the same, only named differently (but display names are both Delete).

This results in two identical Delete shortcuts in the editor's shortcut list:

![image](https://github.com/user-attachments/assets/89777a7a-fc94-418c-bc8c-93c6a943dc69)

This PR merges `tiles_editor/delete_tile` into `tiles_editor/delete`.