### PR TITLE
[Tests] Ensure tests use correct memory management

### DIFF
--- a/modules/jsonrpc/tests/test_jsonrpc.cpp
+++ b/modules/jsonrpc/tests/test_jsonrpc.cpp
@@ -47,9 +47,11 @@ void check_invalid(const Dictionary &p_dict) {
 }
 
 void check_invalid_string(const String &p_str) {
-	JSON json;
-	REQUIRE(json.parse(p_str) == OK);
-	const Dictionary &dict = json.get_data();
+	Ref<JSON> json;
+	json.instantiate();
+
+	REQUIRE(json->parse(p_str) == OK);
+	const Dictionary &dict = json->get_data();
 	check_invalid(dict);
 }
 
@@ -58,15 +60,17 @@ String TestClassJSONRPC::something(const String &p_in) {
 }
 
 void test_process_action(const Variant &p_in, const Variant &p_expected, bool p_process_array_elements) {
-	TestClassJSONRPC json_rpc = TestClassJSONRPC();
-	const Variant &observed = json_rpc.process_action(p_in, p_process_array_elements);
+	TestClassJSONRPC *json_rpc = memnew(TestClassJSONRPC);
+	const Variant &observed = json_rpc->process_action(p_in, p_process_array_elements);
 	CHECK(observed == p_expected);
+	memdelete(json_rpc);
 }
 
 void test_process_string(const String &p_in, const String &p_expected) {
-	TestClassJSONRPC json_rpc = TestClassJSONRPC();
-	const String &out_str = json_rpc.process_string(p_in);
+	TestClassJSONRPC *json_rpc = memnew(TestClassJSONRPC);
+	const String &out_str = json_rpc->process_string(p_in);
 	CHECK(out_str == p_expected);
+	memdelete(json_rpc);
 }
 
 void check_error_no_method(const Dictionary &p_dict) {
@@ -74,9 +78,10 @@ void check_error_no_method(const Dictionary &p_dict) {
 }
 
 void test_process_action_bad_method(const Dictionary &p_in) {
-	TestClassJSONRPC json_rpc = TestClassJSONRPC();
-	const Dictionary &out_dict = json_rpc.process_action(p_in);
+	TestClassJSONRPC *json_rpc = memnew(TestClassJSONRPC);
+	const Dictionary &out_dict = json_rpc->process_action(p_in);
 	check_error_no_method(out_dict);
+	memdelete(json_rpc);
 }
 
 void test_no_response(const Variant &p_in) {

--- a/modules/jsonrpc/tests/test_jsonrpc.h
+++ b/modules/jsonrpc/tests/test_jsonrpc.h
@@ -40,25 +40,29 @@ namespace TestJSONRPC {
 void check_invalid(const Dictionary &p_dict);
 
 TEST_CASE("[JSONRPC] process_action invalid") {
-	JSONRPC json_rpc = JSONRPC();
+	JSONRPC *json_rpc = memnew(JSONRPC);
 
-	check_invalid(json_rpc.process_action("String is invalid"));
-	check_invalid(json_rpc.process_action(1234));
-	check_invalid(json_rpc.process_action(false));
-	check_invalid(json_rpc.process_action(3.14159));
-	check_invalid(json_rpc.process_action(Array()));
+	check_invalid(json_rpc->process_action("String is invalid"));
+	check_invalid(json_rpc->process_action(1234));
+	check_invalid(json_rpc->process_action(false));
+	check_invalid(json_rpc->process_action(3.14159));
+	check_invalid(json_rpc->process_action(Array()));
+
+	memdelete(json_rpc);
 }
 
 void check_invalid_string(const String &p_str);
 
 TEST_CASE("[JSONRPC] process_string invalid") {
-	JSONRPC json_rpc = JSONRPC();
+	JSONRPC *json_rpc = memnew(JSONRPC);
 
-	check_invalid_string(json_rpc.process_string("\"String is invalid\""));
-	check_invalid_string(json_rpc.process_string("1234"));
-	check_invalid_string(json_rpc.process_string("false"));
-	check_invalid_string(json_rpc.process_string("3.14159"));
-	check_invalid_string(json_rpc.process_string("[]"));
+	check_invalid_string(json_rpc->process_string("\"String is invalid\""));
+	check_invalid_string(json_rpc->process_string("1234"));
+	check_invalid_string(json_rpc->process_string("false"));
+	check_invalid_string(json_rpc->process_string("3.14159"));
+	check_invalid_string(json_rpc->process_string("[]"));
+
+	memdelete(json_rpc);
 }
 
 class TestClassJSONRPC : public JSONRPC {

--- a/modules/noise/tests/test_fastnoise_lite.h
+++ b/modules/noise/tests/test_fastnoise_lite.h
@@ -72,29 +72,29 @@ Vector<Pair<size_t, size_t>> find_approx_equal_vec_pairs(std::initializer_list<V
 		CHECK_MESSAGE(equal_pairs.size() == 0, "All arguments should be pairwise distinct.");                      \
 	}
 
-Vector<real_t> get_noise_samples_1d(const FastNoiseLite &p_noise, size_t p_count = 32) {
+Vector<real_t> get_noise_samples_1d(const Ref<FastNoiseLite> &p_noise, size_t p_count = 32) {
 	Vector<real_t> result;
 	result.resize(p_count);
 	for (size_t i = 0; i < p_count; i++) {
-		result.write[i] = p_noise.get_noise_1d(i);
+		result.write[i] = p_noise->get_noise_1d(i);
 	}
 	return result;
 }
 
-Vector<real_t> get_noise_samples_2d(const FastNoiseLite &p_noise, size_t p_count = 32) {
+Vector<real_t> get_noise_samples_2d(const Ref<FastNoiseLite> &p_noise, size_t p_count = 32) {
 	Vector<real_t> result;
 	result.resize(p_count);
 	for (size_t i = 0; i < p_count; i++) {
-		result.write[i] = p_noise.get_noise_2d(i, i);
+		result.write[i] = p_noise->get_noise_2d(i, i);
 	}
 	return result;
 }
 
-Vector<real_t> get_noise_samples_3d(const FastNoiseLite &p_noise, size_t p_count = 32) {
+Vector<real_t> get_noise_samples_3d(const Ref<FastNoiseLite> &p_noise, size_t p_count = 32) {
 	Vector<real_t> result;
 	result.resize(p_count);
 	for (size_t i = 0; i < p_count; i++) {
-		result.write[i] = p_noise.get_noise_3d(i, i, i);
+		result.write[i] = p_noise->get_noise_3d(i, i, i);
 	}
 	return result;
 }
@@ -102,112 +102,115 @@ Vector<real_t> get_noise_samples_3d(const FastNoiseLite &p_noise, size_t p_count
 // The following test suite is rather for testing the wrapper code than the actual noise generation.
 
 TEST_CASE("[FastNoiseLite] Getter and setter") {
-	FastNoiseLite noise;
+	Ref<FastNoiseLite> noise;
+	noise.instantiate();
 
-	noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX_SMOOTH);
-	CHECK(noise.get_noise_type() == FastNoiseLite::NoiseType::TYPE_SIMPLEX_SMOOTH);
+	noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX_SMOOTH);
+	CHECK(noise->get_noise_type() == FastNoiseLite::NoiseType::TYPE_SIMPLEX_SMOOTH);
 
-	noise.set_seed(123);
-	CHECK(noise.get_seed() == 123);
+	noise->set_seed(123);
+	CHECK(noise->get_seed() == 123);
 
-	noise.set_frequency(0.123);
-	CHECK(noise.get_frequency() == doctest::Approx(0.123));
+	noise->set_frequency(0.123);
+	CHECK(noise->get_frequency() == doctest::Approx(0.123));
 
-	noise.set_offset(Vector3(1, 2, 3));
-	CHECK(noise.get_offset() == Vector3(1, 2, 3));
+	noise->set_offset(Vector3(1, 2, 3));
+	CHECK(noise->get_offset() == Vector3(1, 2, 3));
 
-	noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_PING_PONG);
-	CHECK(noise.get_fractal_type() == FastNoiseLite::FractalType::FRACTAL_PING_PONG);
+	noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_PING_PONG);
+	CHECK(noise->get_fractal_type() == FastNoiseLite::FractalType::FRACTAL_PING_PONG);
 
-	noise.set_fractal_octaves(2);
-	CHECK(noise.get_fractal_octaves() == 2);
+	noise->set_fractal_octaves(2);
+	CHECK(noise->get_fractal_octaves() == 2);
 
-	noise.set_fractal_lacunarity(1.123);
-	CHECK(noise.get_fractal_lacunarity() == doctest::Approx(1.123));
+	noise->set_fractal_lacunarity(1.123);
+	CHECK(noise->get_fractal_lacunarity() == doctest::Approx(1.123));
 
-	noise.set_fractal_gain(0.123);
-	CHECK(noise.get_fractal_gain() == doctest::Approx(0.123));
+	noise->set_fractal_gain(0.123);
+	CHECK(noise->get_fractal_gain() == doctest::Approx(0.123));
 
-	noise.set_fractal_weighted_strength(0.123);
-	CHECK(noise.get_fractal_weighted_strength() == doctest::Approx(0.123));
+	noise->set_fractal_weighted_strength(0.123);
+	CHECK(noise->get_fractal_weighted_strength() == doctest::Approx(0.123));
 
-	noise.set_fractal_ping_pong_strength(0.123);
-	CHECK(noise.get_fractal_ping_pong_strength() == doctest::Approx(0.123));
+	noise->set_fractal_ping_pong_strength(0.123);
+	CHECK(noise->get_fractal_ping_pong_strength() == doctest::Approx(0.123));
 
-	noise.set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_MANHATTAN);
-	CHECK(noise.get_cellular_distance_function() == FastNoiseLite::CellularDistanceFunction::DISTANCE_MANHATTAN);
+	noise->set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_MANHATTAN);
+	CHECK(noise->get_cellular_distance_function() == FastNoiseLite::CellularDistanceFunction::DISTANCE_MANHATTAN);
 
-	noise.set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_SUB);
-	CHECK(noise.get_cellular_return_type() == FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_SUB);
+	noise->set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_SUB);
+	CHECK(noise->get_cellular_return_type() == FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_SUB);
 
-	noise.set_cellular_jitter(0.123);
-	CHECK(noise.get_cellular_jitter() == doctest::Approx(0.123));
+	noise->set_cellular_jitter(0.123);
+	CHECK(noise->get_cellular_jitter() == doctest::Approx(0.123));
 
-	noise.set_domain_warp_enabled(true);
-	CHECK(noise.is_domain_warp_enabled() == true);
-	noise.set_domain_warp_enabled(false);
-	CHECK(noise.is_domain_warp_enabled() == false);
+	noise->set_domain_warp_enabled(true);
+	CHECK(noise->is_domain_warp_enabled() == true);
+	noise->set_domain_warp_enabled(false);
+	CHECK(noise->is_domain_warp_enabled() == false);
 
-	noise.set_domain_warp_type(FastNoiseLite::DomainWarpType::DOMAIN_WARP_SIMPLEX_REDUCED);
-	CHECK(noise.get_domain_warp_type() == FastNoiseLite::DomainWarpType::DOMAIN_WARP_SIMPLEX_REDUCED);
+	noise->set_domain_warp_type(FastNoiseLite::DomainWarpType::DOMAIN_WARP_SIMPLEX_REDUCED);
+	CHECK(noise->get_domain_warp_type() == FastNoiseLite::DomainWarpType::DOMAIN_WARP_SIMPLEX_REDUCED);
 
-	noise.set_domain_warp_amplitude(0.123);
-	CHECK(noise.get_domain_warp_amplitude() == doctest::Approx(0.123));
+	noise->set_domain_warp_amplitude(0.123);
+	CHECK(noise->get_domain_warp_amplitude() == doctest::Approx(0.123));
 
-	noise.set_domain_warp_frequency(0.123);
-	CHECK(noise.get_domain_warp_frequency() == doctest::Approx(0.123));
+	noise->set_domain_warp_frequency(0.123);
+	CHECK(noise->get_domain_warp_frequency() == doctest::Approx(0.123));
 
-	noise.set_domain_warp_fractal_type(FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_INDEPENDENT);
-	CHECK(noise.get_domain_warp_fractal_type() == FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_INDEPENDENT);
+	noise->set_domain_warp_fractal_type(FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_INDEPENDENT);
+	CHECK(noise->get_domain_warp_fractal_type() == FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_INDEPENDENT);
 
-	noise.set_domain_warp_fractal_octaves(2);
-	CHECK(noise.get_domain_warp_fractal_octaves() == 2);
+	noise->set_domain_warp_fractal_octaves(2);
+	CHECK(noise->get_domain_warp_fractal_octaves() == 2);
 
-	noise.set_domain_warp_fractal_lacunarity(1.123);
-	CHECK(noise.get_domain_warp_fractal_lacunarity() == doctest::Approx(1.123));
+	noise->set_domain_warp_fractal_lacunarity(1.123);
+	CHECK(noise->get_domain_warp_fractal_lacunarity() == doctest::Approx(1.123));
 
-	noise.set_domain_warp_fractal_gain(0.123);
-	CHECK(noise.get_domain_warp_fractal_gain() == doctest::Approx(0.123));
+	noise->set_domain_warp_fractal_gain(0.123);
+	CHECK(noise->get_domain_warp_fractal_gain() == doctest::Approx(0.123));
 }
 
 TEST_CASE("[FastNoiseLite] Basic noise generation") {
-	FastNoiseLite noise;
-	noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
-	noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_NONE);
-	noise.set_seed(123);
-	noise.set_offset(Vector3(10, 10, 10));
+	Ref<FastNoiseLite> noise;
+	noise.instantiate();
+
+	noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
+	noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_NONE);
+	noise->set_seed(123);
+	noise->set_offset(Vector3(10, 10, 10));
 
 	// 1D noise will be checked just in the cases where there's the possibility of
 	// finding a bug/regression in the wrapper function.
 	// (since it uses FastNoise's 2D noise generator with the Y coordinate set to 0).
 
 	SUBCASE("Determinacy of noise generation (all noise types)") {
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
-		CHECK(noise.get_noise_2d(0, 0) == doctest::Approx(noise.get_noise_2d(0, 0)));
-		CHECK(noise.get_noise_3d(0, 0, 0) == doctest::Approx(noise.get_noise_3d(0, 0, 0)));
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX_SMOOTH);
-		CHECK(noise.get_noise_2d(0, 0) == doctest::Approx(noise.get_noise_2d(0, 0)));
-		CHECK(noise.get_noise_3d(0, 0, 0) == doctest::Approx(noise.get_noise_3d(0, 0, 0)));
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_CELLULAR);
-		CHECK(noise.get_noise_2d(0, 0) == doctest::Approx(noise.get_noise_2d(0, 0)));
-		CHECK(noise.get_noise_3d(0, 0, 0) == doctest::Approx(noise.get_noise_3d(0, 0, 0)));
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_PERLIN);
-		CHECK(noise.get_noise_2d(0, 0) == doctest::Approx(noise.get_noise_2d(0, 0)));
-		CHECK(noise.get_noise_3d(0, 0, 0) == doctest::Approx(noise.get_noise_3d(0, 0, 0)));
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_VALUE);
-		CHECK(noise.get_noise_2d(0, 0) == doctest::Approx(noise.get_noise_2d(0, 0)));
-		CHECK(noise.get_noise_3d(0, 0, 0) == doctest::Approx(noise.get_noise_3d(0, 0, 0)));
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_VALUE_CUBIC);
-		CHECK(noise.get_noise_2d(0, 0) == doctest::Approx(noise.get_noise_2d(0, 0)));
-		CHECK(noise.get_noise_3d(0, 0, 0) == doctest::Approx(noise.get_noise_3d(0, 0, 0)));
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
+		CHECK(noise->get_noise_2d(0, 0) == doctest::Approx(noise->get_noise_2d(0, 0)));
+		CHECK(noise->get_noise_3d(0, 0, 0) == doctest::Approx(noise->get_noise_3d(0, 0, 0)));
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX_SMOOTH);
+		CHECK(noise->get_noise_2d(0, 0) == doctest::Approx(noise->get_noise_2d(0, 0)));
+		CHECK(noise->get_noise_3d(0, 0, 0) == doctest::Approx(noise->get_noise_3d(0, 0, 0)));
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_CELLULAR);
+		CHECK(noise->get_noise_2d(0, 0) == doctest::Approx(noise->get_noise_2d(0, 0)));
+		CHECK(noise->get_noise_3d(0, 0, 0) == doctest::Approx(noise->get_noise_3d(0, 0, 0)));
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_PERLIN);
+		CHECK(noise->get_noise_2d(0, 0) == doctest::Approx(noise->get_noise_2d(0, 0)));
+		CHECK(noise->get_noise_3d(0, 0, 0) == doctest::Approx(noise->get_noise_3d(0, 0, 0)));
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_VALUE);
+		CHECK(noise->get_noise_2d(0, 0) == doctest::Approx(noise->get_noise_2d(0, 0)));
+		CHECK(noise->get_noise_3d(0, 0, 0) == doctest::Approx(noise->get_noise_3d(0, 0, 0)));
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_VALUE_CUBIC);
+		CHECK(noise->get_noise_2d(0, 0) == doctest::Approx(noise->get_noise_2d(0, 0)));
+		CHECK(noise->get_noise_3d(0, 0, 0) == doctest::Approx(noise->get_noise_3d(0, 0, 0)));
 	}
 
 	SUBCASE("Different seeds should produce different noise") {
-		noise.set_seed(456);
+		noise->set_seed(456);
 		Vector<real_t> noise_seed_1_1d = get_noise_samples_1d(noise);
 		Vector<real_t> noise_seed_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_seed_1_3d = get_noise_samples_3d(noise);
-		noise.set_seed(123);
+		noise->set_seed(123);
 		Vector<real_t> noise_seed_2_1d = get_noise_samples_1d(noise);
 		Vector<real_t> noise_seed_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_seed_2_3d = get_noise_samples_3d(noise);
@@ -218,11 +221,11 @@ TEST_CASE("[FastNoiseLite] Basic noise generation") {
 	}
 
 	SUBCASE("Different frequencies should produce different noise") {
-		noise.set_frequency(0.1);
+		noise->set_frequency(0.1);
 		Vector<real_t> noise_frequency_1_1d = get_noise_samples_1d(noise);
 		Vector<real_t> noise_frequency_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_frequency_1_3d = get_noise_samples_3d(noise);
-		noise.set_frequency(1.0);
+		noise->set_frequency(1.0);
 		Vector<real_t> noise_frequency_2_1d = get_noise_samples_1d(noise);
 		Vector<real_t> noise_frequency_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_frequency_2_3d = get_noise_samples_3d(noise);
@@ -233,11 +236,11 @@ TEST_CASE("[FastNoiseLite] Basic noise generation") {
 	}
 
 	SUBCASE("Noise should be offset by the offset parameter") {
-		noise.set_offset(Vector3(1, 2, 3));
+		noise->set_offset(Vector3(1, 2, 3));
 		Vector<real_t> noise_offset_1_1d = get_noise_samples_1d(noise);
 		Vector<real_t> noise_offset_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_offset_1_3d = get_noise_samples_3d(noise);
-		noise.set_offset(Vector3(4, 5, 6));
+		noise->set_offset(Vector3(4, 5, 6));
 		Vector<real_t> noise_offset_2_1d = get_noise_samples_1d(noise);
 		Vector<real_t> noise_offset_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_offset_2_3d = get_noise_samples_3d(noise);
@@ -248,22 +251,22 @@ TEST_CASE("[FastNoiseLite] Basic noise generation") {
 	}
 
 	SUBCASE("Different noise types should produce different noise") {
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
 		Vector<real_t> noise_type_simplex_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_type_simplex_3d = get_noise_samples_3d(noise);
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX_SMOOTH);
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX_SMOOTH);
 		Vector<real_t> noise_type_simplex_smooth_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_type_simplex_smooth_3d = get_noise_samples_3d(noise);
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_CELLULAR);
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_CELLULAR);
 		Vector<real_t> noise_type_cellular_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_type_cellular_3d = get_noise_samples_3d(noise);
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_PERLIN);
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_PERLIN);
 		Vector<real_t> noise_type_perlin_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_type_perlin_3d = get_noise_samples_3d(noise);
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_VALUE);
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_VALUE);
 		Vector<real_t> noise_type_value_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_type_value_3d = get_noise_samples_3d(noise);
-		noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_VALUE_CUBIC);
+		noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_VALUE_CUBIC);
 		Vector<real_t> noise_type_value_cubic_2d = get_noise_samples_2d(noise);
 		Vector<real_t> noise_type_value_cubic_3d = get_noise_samples_3d(noise);
 
@@ -284,28 +287,30 @@ TEST_CASE("[FastNoiseLite] Basic noise generation") {
 }
 
 TEST_CASE("[FastNoiseLite] Fractal noise") {
-	FastNoiseLite noise;
-	noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
-	noise.set_offset(Vector3(10, 10, 10));
-	noise.set_frequency(0.01);
-	noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_FBM);
-	noise.set_fractal_octaves(4);
-	noise.set_fractal_lacunarity(2.0);
-	noise.set_fractal_gain(0.5);
-	noise.set_fractal_weighted_strength(0.5);
-	noise.set_fractal_ping_pong_strength(2.0);
+	Ref<FastNoiseLite> noise;
+	noise.instantiate();
+
+	noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
+	noise->set_offset(Vector3(10, 10, 10));
+	noise->set_frequency(0.01);
+	noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_FBM);
+	noise->set_fractal_octaves(4);
+	noise->set_fractal_lacunarity(2.0);
+	noise->set_fractal_gain(0.5);
+	noise->set_fractal_weighted_strength(0.5);
+	noise->set_fractal_ping_pong_strength(2.0);
 
 	SUBCASE("Different fractal types should produce different results") {
-		noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_NONE);
+		noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_NONE);
 		Vector<real_t> fractal_type_none_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_type_none_3d = get_noise_samples_3d(noise);
-		noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_FBM);
+		noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_FBM);
 		Vector<real_t> fractal_type_fbm_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_type_fbm_3d = get_noise_samples_3d(noise);
-		noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_RIDGED);
+		noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_RIDGED);
 		Vector<real_t> fractal_type_ridged_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_type_ridged_3d = get_noise_samples_3d(noise);
-		noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_PING_PONG);
+		noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_PING_PONG);
 		Vector<real_t> fractal_type_ping_pong_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_type_ping_pong_3d = get_noise_samples_3d(noise);
 
@@ -321,10 +326,10 @@ TEST_CASE("[FastNoiseLite] Fractal noise") {
 	}
 
 	SUBCASE("Different octaves should produce different results") {
-		noise.set_fractal_octaves(1.0);
+		noise->set_fractal_octaves(1.0);
 		Vector<real_t> fractal_octaves_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_octaves_1_3d = get_noise_samples_3d(noise);
-		noise.set_fractal_octaves(8.0);
+		noise->set_fractal_octaves(8.0);
 		Vector<real_t> fractal_octaves_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_octaves_2_3d = get_noise_samples_3d(noise);
 
@@ -333,10 +338,10 @@ TEST_CASE("[FastNoiseLite] Fractal noise") {
 	}
 
 	SUBCASE("Different lacunarity should produce different results") {
-		noise.set_fractal_lacunarity(1.0);
+		noise->set_fractal_lacunarity(1.0);
 		Vector<real_t> fractal_lacunarity_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_lacunarity_1_3d = get_noise_samples_3d(noise);
-		noise.set_fractal_lacunarity(2.0);
+		noise->set_fractal_lacunarity(2.0);
 		Vector<real_t> fractal_lacunarity_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_lacunarity_2_3d = get_noise_samples_3d(noise);
 
@@ -345,10 +350,10 @@ TEST_CASE("[FastNoiseLite] Fractal noise") {
 	}
 
 	SUBCASE("Different gain should produce different results") {
-		noise.set_fractal_gain(0.5);
+		noise->set_fractal_gain(0.5);
 		Vector<real_t> fractal_gain_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_gain_1_3d = get_noise_samples_3d(noise);
-		noise.set_fractal_gain(0.75);
+		noise->set_fractal_gain(0.75);
 		Vector<real_t> fractal_gain_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_gain_2_3d = get_noise_samples_3d(noise);
 
@@ -357,10 +362,10 @@ TEST_CASE("[FastNoiseLite] Fractal noise") {
 	}
 
 	SUBCASE("Different weights should produce different results") {
-		noise.set_fractal_weighted_strength(0.5);
+		noise->set_fractal_weighted_strength(0.5);
 		Vector<real_t> fractal_weighted_strength_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_weighted_strength_1_3d = get_noise_samples_3d(noise);
-		noise.set_fractal_weighted_strength(0.75);
+		noise->set_fractal_weighted_strength(0.75);
 		Vector<real_t> fractal_weighted_strength_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_weighted_strength_2_3d = get_noise_samples_3d(noise);
 
@@ -369,11 +374,11 @@ TEST_CASE("[FastNoiseLite] Fractal noise") {
 	}
 
 	SUBCASE("Different ping pong strength should produce different results") {
-		noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_PING_PONG);
-		noise.set_fractal_ping_pong_strength(0.5);
+		noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_PING_PONG);
+		noise->set_fractal_ping_pong_strength(0.5);
 		Vector<real_t> fractal_ping_pong_strength_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_ping_pong_strength_1_3d = get_noise_samples_3d(noise);
-		noise.set_fractal_ping_pong_strength(0.75);
+		noise->set_fractal_ping_pong_strength(0.75);
 		Vector<real_t> fractal_ping_pong_strength_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> fractal_ping_pong_strength_2_3d = get_noise_samples_3d(noise);
 
@@ -383,24 +388,26 @@ TEST_CASE("[FastNoiseLite] Fractal noise") {
 }
 
 TEST_CASE("[FastNoiseLite] Cellular noise") {
-	FastNoiseLite noise;
-	noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_NONE);
-	noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_CELLULAR);
-	noise.set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_EUCLIDEAN);
-	noise.set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE);
-	noise.set_frequency(1.0);
+	Ref<FastNoiseLite> noise;
+	noise.instantiate();
+
+	noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_NONE);
+	noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_CELLULAR);
+	noise->set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_EUCLIDEAN);
+	noise->set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE);
+	noise->set_frequency(1.0);
 
 	SUBCASE("Different distance functions should produce different results") {
-		noise.set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_EUCLIDEAN);
+		noise->set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_EUCLIDEAN);
 		Vector<real_t> cellular_distance_function_euclidean_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_distance_function_euclidean_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_EUCLIDEAN_SQUARED);
+		noise->set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_EUCLIDEAN_SQUARED);
 		Vector<real_t> cellular_distance_function_euclidean_squared_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_distance_function_euclidean_squared_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_MANHATTAN);
+		noise->set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_MANHATTAN);
 		Vector<real_t> cellular_distance_function_manhattan_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_distance_function_manhattan_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_HYBRID);
+		noise->set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_HYBRID);
 		Vector<real_t> cellular_distance_function_hybrid_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_distance_function_hybrid_3d = get_noise_samples_3d(noise);
 
@@ -416,25 +423,25 @@ TEST_CASE("[FastNoiseLite] Cellular noise") {
 	}
 
 	SUBCASE("Different return function types should produce different results") {
-		noise.set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_CELL_VALUE);
+		noise->set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_CELL_VALUE);
 		Vector<real_t> cellular_return_type_cell_value_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_return_type_cell_value_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE);
+		noise->set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE);
 		Vector<real_t> cellular_return_type_distance_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_return_type_distance_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2);
+		noise->set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2);
 		Vector<real_t> cellular_return_type_distance2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_return_type_distance2_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_ADD);
+		noise->set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_ADD);
 		Vector<real_t> cellular_return_type_distance2_add_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_return_type_distance2_add_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_SUB);
+		noise->set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_SUB);
 		Vector<real_t> cellular_return_type_distance2_sub_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_return_type_distance2_sub_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_MUL);
+		noise->set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_MUL);
 		Vector<real_t> cellular_return_type_distance2_mul_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_return_type_distance2_mul_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_DIV);
+		noise->set_cellular_return_type(FastNoiseLite::CellularReturnType::RETURN_DISTANCE2_DIV);
 		Vector<real_t> cellular_return_type_distance2_div_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_return_type_distance2_div_3d = get_noise_samples_3d(noise);
 
@@ -456,10 +463,10 @@ TEST_CASE("[FastNoiseLite] Cellular noise") {
 	}
 
 	SUBCASE("Different cellular jitter should produce different results") {
-		noise.set_cellular_jitter(0.0);
+		noise->set_cellular_jitter(0.0);
 		Vector<real_t> cellular_jitter_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_jitter_1_3d = get_noise_samples_3d(noise);
-		noise.set_cellular_jitter(0.5);
+		noise->set_cellular_jitter(0.5);
 		Vector<real_t> cellular_jitter_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> cellular_jitter_2_3d = get_noise_samples_3d(noise);
 
@@ -469,20 +476,22 @@ TEST_CASE("[FastNoiseLite] Cellular noise") {
 }
 
 TEST_CASE("[FastNoiseLite] Domain warp") {
-	FastNoiseLite noise;
-	noise.set_frequency(1.0);
-	noise.set_domain_warp_amplitude(200.0);
-	noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
-	noise.set_domain_warp_enabled(true);
+	Ref<FastNoiseLite> noise;
+	noise.instantiate();
+
+	noise->set_frequency(1.0);
+	noise->set_domain_warp_amplitude(200.0);
+	noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_SIMPLEX);
+	noise->set_domain_warp_enabled(true);
 
 	SUBCASE("Different domain warp types should produce different results") {
-		noise.set_domain_warp_type(FastNoiseLite::DomainWarpType::DOMAIN_WARP_SIMPLEX);
+		noise->set_domain_warp_type(FastNoiseLite::DomainWarpType::DOMAIN_WARP_SIMPLEX);
 		Vector<real_t> domain_warp_type_simplex_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_type_simplex_3d = get_noise_samples_3d(noise);
-		noise.set_domain_warp_type(FastNoiseLite::DomainWarpType::DOMAIN_WARP_SIMPLEX_REDUCED);
+		noise->set_domain_warp_type(FastNoiseLite::DomainWarpType::DOMAIN_WARP_SIMPLEX_REDUCED);
 		Vector<real_t> domain_warp_type_simplex_reduced_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_type_simplex_reduced_3d = get_noise_samples_3d(noise);
-		noise.set_domain_warp_type(FastNoiseLite::DomainWarpType::DOMAIN_WARP_BASIC_GRID);
+		noise->set_domain_warp_type(FastNoiseLite::DomainWarpType::DOMAIN_WARP_BASIC_GRID);
 		Vector<real_t> domain_warp_type_basic_grid_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_type_basic_grid_3d = get_noise_samples_3d(noise);
 
@@ -496,10 +505,10 @@ TEST_CASE("[FastNoiseLite] Domain warp") {
 	}
 
 	SUBCASE("Different domain warp amplitude should produce different results") {
-		noise.set_domain_warp_amplitude(0.0);
+		noise->set_domain_warp_amplitude(0.0);
 		Vector<real_t> domain_warp_amplitude_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_amplitude_1_3d = get_noise_samples_3d(noise);
-		noise.set_domain_warp_amplitude(100.0);
+		noise->set_domain_warp_amplitude(100.0);
 		Vector<real_t> domain_warp_amplitude_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_amplitude_2_3d = get_noise_samples_3d(noise);
 
@@ -508,10 +517,10 @@ TEST_CASE("[FastNoiseLite] Domain warp") {
 	}
 
 	SUBCASE("Different domain warp frequency should produce different results") {
-		noise.set_domain_warp_frequency(0.1);
+		noise->set_domain_warp_frequency(0.1);
 		Vector<real_t> domain_warp_frequency_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_frequency_1_3d = get_noise_samples_3d(noise);
-		noise.set_domain_warp_frequency(2.0);
+		noise->set_domain_warp_frequency(2.0);
 		Vector<real_t> domain_warp_frequency_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_frequency_2_3d = get_noise_samples_3d(noise);
 
@@ -520,13 +529,13 @@ TEST_CASE("[FastNoiseLite] Domain warp") {
 	}
 
 	SUBCASE("Different domain warp fractal type should produce different results") {
-		noise.set_domain_warp_fractal_type(FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_NONE);
+		noise->set_domain_warp_fractal_type(FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_NONE);
 		Vector<real_t> domain_warp_fractal_type_none_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_fractal_type_none_3d = get_noise_samples_3d(noise);
-		noise.set_domain_warp_fractal_type(FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_PROGRESSIVE);
+		noise->set_domain_warp_fractal_type(FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_PROGRESSIVE);
 		Vector<real_t> domain_warp_fractal_type_progressive_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_fractal_type_progressive_3d = get_noise_samples_3d(noise);
-		noise.set_domain_warp_fractal_type(FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_INDEPENDENT);
+		noise->set_domain_warp_fractal_type(FastNoiseLite::DomainWarpFractalType::DOMAIN_WARP_FRACTAL_INDEPENDENT);
 		Vector<real_t> domain_warp_fractal_type_independent_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_fractal_type_independent_3d = get_noise_samples_3d(noise);
 
@@ -540,10 +549,10 @@ TEST_CASE("[FastNoiseLite] Domain warp") {
 	}
 
 	SUBCASE("Different domain warp fractal octaves should produce different results") {
-		noise.set_domain_warp_fractal_octaves(1);
+		noise->set_domain_warp_fractal_octaves(1);
 		Vector<real_t> domain_warp_fractal_octaves_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_fractal_octaves_1_3d = get_noise_samples_3d(noise);
-		noise.set_domain_warp_fractal_octaves(6);
+		noise->set_domain_warp_fractal_octaves(6);
 		Vector<real_t> domain_warp_fractal_octaves_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_fractal_octaves_2_3d = get_noise_samples_3d(noise);
 
@@ -552,10 +561,10 @@ TEST_CASE("[FastNoiseLite] Domain warp") {
 	}
 
 	SUBCASE("Different domain warp fractal lacunarity should produce different results") {
-		noise.set_domain_warp_fractal_lacunarity(0.5);
+		noise->set_domain_warp_fractal_lacunarity(0.5);
 		Vector<real_t> domain_warp_fractal_lacunarity_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_fractal_lacunarity_1_3d = get_noise_samples_3d(noise);
-		noise.set_domain_warp_fractal_lacunarity(5.0);
+		noise->set_domain_warp_fractal_lacunarity(5.0);
 		Vector<real_t> domain_warp_fractal_lacunarity_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_fractal_lacunarity_2_3d = get_noise_samples_3d(noise);
 
@@ -564,10 +573,10 @@ TEST_CASE("[FastNoiseLite] Domain warp") {
 	}
 
 	SUBCASE("Different domain warp fractal gain should produce different results") {
-		noise.set_domain_warp_fractal_gain(0.1);
+		noise->set_domain_warp_fractal_gain(0.1);
 		Vector<real_t> domain_warp_fractal_gain_1_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_fractal_gain_1_3d = get_noise_samples_3d(noise);
-		noise.set_domain_warp_fractal_gain(0.9);
+		noise->set_domain_warp_fractal_gain(0.9);
 		Vector<real_t> domain_warp_fractal_gain_2_2d = get_noise_samples_2d(noise);
 		Vector<real_t> domain_warp_fractal_gain_2_3d = get_noise_samples_3d(noise);
 
@@ -596,15 +605,17 @@ void compare_image_with_reference(const Ref<Image> &p_img, const Ref<Image> &p_r
 }
 
 TEST_CASE("[FastNoiseLite] Generating seamless 2D images (11x11px) and compare to reference images") {
-	FastNoiseLite noise;
-	noise.set_noise_type(FastNoiseLite::NoiseType::TYPE_CELLULAR);
-	noise.set_fractal_type(FastNoiseLite::FractalType::FRACTAL_NONE);
-	noise.set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_EUCLIDEAN);
-	noise.set_frequency(0.1);
-	noise.set_cellular_jitter(0.0);
+	Ref<FastNoiseLite> noise;
+	noise.instantiate();
+
+	noise->set_noise_type(FastNoiseLite::NoiseType::TYPE_CELLULAR);
+	noise->set_fractal_type(FastNoiseLite::FractalType::FRACTAL_NONE);
+	noise->set_cellular_distance_function(FastNoiseLite::CellularDistanceFunction::DISTANCE_EUCLIDEAN);
+	noise->set_frequency(0.1);
+	noise->set_cellular_jitter(0.0);
 
 	SUBCASE("Blend skirt 0.0") {
-		Ref<Image> img = noise.get_seamless_image(11, 11, false, false, 0.0);
+		Ref<Image> img = noise->get_seamless_image(11, 11, false, false, 0.0);
 
 		Ref<Image> ref_img_1 = memnew(Image);
 		ref_img_1->set_data(11, 11, false, Image::FORMAT_L8, ref_img_1_data);
@@ -613,7 +624,7 @@ TEST_CASE("[FastNoiseLite] Generating seamless 2D images (11x11px) and compare t
 	}
 
 	SUBCASE("Blend skirt 0.1") {
-		Ref<Image> img = noise.get_seamless_image(11, 11, false, false, 0.1);
+		Ref<Image> img = noise->get_seamless_image(11, 11, false, false, 0.1);
 
 		Ref<Image> ref_img_2 = memnew(Image);
 		ref_img_2->set_data(11, 11, false, Image::FORMAT_L8, ref_img_2_data);
@@ -622,7 +633,7 @@ TEST_CASE("[FastNoiseLite] Generating seamless 2D images (11x11px) and compare t
 	}
 
 	SUBCASE("Blend skirt 1.0") {
-		Ref<Image> img = noise.get_seamless_image(11, 11, false, false, 0.1);
+		Ref<Image> img = noise->get_seamless_image(11, 11, false, false, 0.1);
 
 		Ref<Image> ref_img_3 = memnew(Image);
 		ref_img_3->set_data(11, 11, false, Image::FORMAT_L8, ref_img_3_data);

--- a/modules/regex/tests/test_regex.h
+++ b/modules/regex/tests/test_regex.h
@@ -41,33 +41,41 @@ namespace TestRegEx {
 TEST_CASE("[RegEx] Initialization") {
 	const String pattern = "(?<vowel>[aeiou])";
 
-	RegEx re1(pattern);
-	CHECK(re1.is_valid());
-	CHECK(re1.get_pattern() == pattern);
-	CHECK(re1.get_group_count() == 1);
+	Ref<RegEx> re1;
+	re1.instantiate(pattern);
 
-	PackedStringArray names = re1.get_names();
+	CHECK(re1.is_valid());
+	CHECK(re1->is_valid());
+	CHECK(re1->get_pattern() == pattern);
+	CHECK(re1->get_group_count() == 1);
+
+	PackedStringArray names = re1->get_names();
 	CHECK(names.size() == 1);
 	CHECK(names[0] == "vowel");
 
-	RegEx re2;
-	CHECK(re2.is_valid() == false);
-	CHECK(re2.compile(pattern) == OK);
+	Ref<RegEx> re2;
+	re2.instantiate();
 	CHECK(re2.is_valid());
+	CHECK(re2->is_valid() == false);
+	CHECK(re2->compile(pattern) == OK);
+	CHECK(re2->is_valid());
 
-	CHECK(re1.get_pattern() == re2.get_pattern());
-	CHECK(re1.get_group_count() == re2.get_group_count());
+	CHECK(re1->get_pattern() == re2->get_pattern());
+	CHECK(re1->get_group_count() == re2->get_group_count());
 
-	names = re2.get_names();
+	names = re2->get_names();
 	CHECK(names.size() == 1);
 	CHECK(names[0] == "vowel");
 }
 
 TEST_CASE("[RegEx] Clearing") {
-	RegEx re("Godot");
+	Ref<RegEx> re;
+	re.instantiate("Godot");
+
 	REQUIRE(re.is_valid());
-	re.clear();
-	CHECK(re.is_valid() == false);
+	REQUIRE(re->is_valid());
+	re->clear();
+	CHECK(re->is_valid() == false);
 }
 
 TEST_CASE("[RegEx] Searching") {
@@ -75,25 +83,28 @@ TEST_CASE("[RegEx] Searching") {
 	const String vowels = "[aeiou]{1,2}";
 	const String numerics = "\\d";
 
-	RegEx re(vowels);
-	REQUIRE(re.is_valid());
+	Ref<RegEx> re;
+	re.instantiate(vowels);
 
-	Ref<RegExMatch> match = re.search(s);
+	REQUIRE(re.is_valid());
+	REQUIRE(re->is_valid());
+
+	Ref<RegExMatch> match = re->search(s);
 	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == "ea");
 
-	match = re.search(s, 1, 2);
+	match = re->search(s, 1, 2);
 	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == "e");
-	match = re.search(s, 2, 4);
+	match = re->search(s, 2, 4);
 	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == "a");
-	match = re.search(s, 3, 5);
+	match = re->search(s, 3, 5);
 	CHECK(match.is_null());
-	match = re.search(s, 6, 2);
+	match = re->search(s, 6, 2);
 	CHECK(match.is_null());
 
-	const Array all_results = re.search_all(s);
+	const Array all_results = re->search_all(s);
 	CHECK(all_results.size() == 2);
 	match = all_results[0];
 	REQUIRE(match.is_valid());
@@ -102,56 +113,72 @@ TEST_CASE("[RegEx] Searching") {
 	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == "i");
 
-	CHECK(re.compile(numerics) == OK);
-	CHECK(re.is_valid());
-	CHECK(re.search(s).is_null());
-	CHECK(re.search_all(s).size() == 0);
+	CHECK(re->compile(numerics) == OK);
+	CHECK(re->is_valid());
+	CHECK(re->search(s).is_null());
+	CHECK(re->search_all(s).size() == 0);
 }
 
 TEST_CASE("[RegEx] Substitution") {
 	const String s1 = "Double all the vowels.";
 
-	RegEx re1("(?<vowel>[aeiou])");
+	Ref<RegEx> re1;
+	re1.instantiate("(?<vowel>[aeiou])");
+
 	REQUIRE(re1.is_valid());
-	CHECK(re1.sub(s1, "$0$vowel", true) == "Doouublee aall thee vooweels.");
+	REQUIRE(re1->is_valid());
+	CHECK(re1->sub(s1, "$0$vowel", true) == "Doouublee aall thee vooweels.");
 
 	const String s2 = "Substitution with group.";
 
-	RegEx re2("Substitution (.+)");
+	Ref<RegEx> re2;
+	re2.instantiate("Substitution (.+)");
+
 	REQUIRE(re2.is_valid());
-	CHECK(re2.sub(s2, "Test ${1}") == "Test with group.");
+	REQUIRE(re2->is_valid());
+	CHECK(re2->sub(s2, "Test ${1}") == "Test with group.");
 
 	const String s3 = "Useless substitution";
 
-	RegEx re3("Anything");
+	Ref<RegEx> re3;
+	re3.instantiate("Anything");
+
 	REQUIRE(re3.is_valid());
-	CHECK(re3.sub(s3, "Something") == "Useless substitution");
+	REQUIRE(re3->is_valid());
+	CHECK(re3->sub(s3, "Something") == "Useless substitution");
 
 	const String s4 = "acacac";
 
-	RegEx re4("(a)(b){0}(c)");
+	Ref<RegEx> re4;
+	re4.instantiate("(a)(b){0}(c)");
+
 	REQUIRE(re4.is_valid());
-	CHECK(re4.sub(s4, "${1}.${3}.", true) == "a.c.a.c.a.c.");
+	REQUIRE(re4->is_valid());
+	CHECK(re4->sub(s4, "${1}.${3}.", true) == "a.c.a.c.a.c.");
 
 	const String s5 = "aaaa";
 
-	RegEx re5("a");
+	Ref<RegEx> re5;
+	re5.instantiate("a");
+
 	REQUIRE(re5.is_valid());
-	CHECK(re5.sub(s5, "b", true, 0, 2) == "bbaa");
-	CHECK(re5.sub(s5, "b", true, 1, 3) == "abba");
-	CHECK(re5.sub(s5, "b", true, 0, 0) == "aaaa");
-	CHECK(re5.sub(s5, "b", true, 1, 1) == "aaaa");
-	CHECK(re5.sub(s5, "cc", true, 0, 2) == "ccccaa");
-	CHECK(re5.sub(s5, "cc", true, 1, 3) == "acccca");
-	CHECK(re5.sub(s5, "", true, 0, 2) == "aa");
+	REQUIRE(re5->is_valid());
+	CHECK(re5->sub(s5, "b", true, 0, 2) == "bbaa");
+	CHECK(re5->sub(s5, "b", true, 1, 3) == "abba");
+	CHECK(re5->sub(s5, "b", true, 0, 0) == "aaaa");
+	CHECK(re5->sub(s5, "b", true, 1, 1) == "aaaa");
+	CHECK(re5->sub(s5, "cc", true, 0, 2) == "ccccaa");
+	CHECK(re5->sub(s5, "cc", true, 1, 3) == "acccca");
+	CHECK(re5->sub(s5, "", true, 0, 2) == "aa");
 
 	const String s6 = "property get_property set_property";
 
-	RegEx re6("(get_|set_)?property");
+	Ref<RegEx> re6;
+	re6.instantiate("(get_|set_)?property");
 	REQUIRE(re6.is_valid());
-	CHECK(re6.sub(s6, "$1new_property", true) == "new_property get_new_property set_new_property");
+	CHECK(re6->sub(s6, "$1new_property", true) == "new_property get_new_property set_new_property");
 	ERR_PRINT_OFF;
-	CHECK(re6.sub(s6, "$5new_property", true) == "new_property new_property new_property");
+	CHECK(re6->sub(s6, "$5new_property", true) == "new_property new_property new_property");
 	ERR_PRINT_ON;
 }
 
@@ -159,46 +186,59 @@ TEST_CASE("[RegEx] Substitution with empty input and/or replacement") {
 	const String s1 = "";
 	const String s2 = "gogogo";
 
-	RegEx re1("");
-	REQUIRE(re1.is_valid());
-	CHECK(re1.sub(s1, "") == "");
-	CHECK(re1.sub(s1, "a") == "a");
-	CHECK(re1.sub(s2, "") == "gogogo");
+	Ref<RegEx> re1;
+	re1.instantiate("");
 
-	RegEx re2("go");
+	REQUIRE(re1.is_valid());
+	REQUIRE(re1->is_valid());
+	CHECK(re1->sub(s1, "") == "");
+	CHECK(re1->sub(s1, "a") == "a");
+	CHECK(re1->sub(s2, "") == "gogogo");
+
+	Ref<RegEx> re2;
+	re2.instantiate("go");
+
 	REQUIRE(re2.is_valid());
-	CHECK(re2.sub(s2, "") == "gogo");
-	CHECK(re2.sub(s2, "", true) == "");
+	REQUIRE(re2->is_valid());
+	CHECK(re2->sub(s2, "") == "gogo");
+	CHECK(re2->sub(s2, "", true) == "");
 }
 
 TEST_CASE("[RegEx] Uninitialized use") {
 	const String s = "Godot";
 
-	RegEx re;
+	Ref<RegEx> re;
+	re.instantiate();
+
 	ERR_PRINT_OFF;
-	CHECK(re.search(s).is_null());
-	CHECK(re.search_all(s).size() == 0);
-	CHECK(re.sub(s, "") == "");
-	CHECK(re.get_group_count() == 0);
-	CHECK(re.get_names().size() == 0);
+	CHECK(re->search(s).is_null());
+	CHECK(re->search_all(s).size() == 0);
+	CHECK(re->sub(s, "") == "");
+	CHECK(re->get_group_count() == 0);
+	CHECK(re->get_names().size() == 0);
 	ERR_PRINT_ON
 }
 
 TEST_CASE("[RegEx] Empty pattern") {
 	const String s = "Godot";
 
-	RegEx re;
-	CHECK(re.compile("") == OK);
-	CHECK(re.is_valid());
+	Ref<RegEx> re;
+	re.instantiate();
+
+	CHECK(re->compile("") == OK);
+	CHECK(re->is_valid());
 }
 
 TEST_CASE("[RegEx] Complex Grouping") {
 	const String test = "https://docs.godotengine.org/en/latest/contributing/";
 
 	// Ignored protocol in grouping.
-	RegEx re("^(?:https?://)([a-zA-Z]{2,4})\\.([a-zA-Z][a-zA-Z0-9_\\-]{2,64})\\.([a-zA-Z]{2,4})");
+	Ref<RegEx> re;
+	re.instantiate("^(?:https?://)([a-zA-Z]{2,4})\\.([a-zA-Z][a-zA-Z0-9_\\-]{2,64})\\.([a-zA-Z]{2,4})");
+
 	REQUIRE(re.is_valid());
-	Ref<RegExMatch> expr = re.search(test);
+	REQUIRE(re->is_valid());
+	Ref<RegExMatch> expr = re->search(test);
 
 	CHECK(expr->get_group_count() == 3);
 
@@ -213,9 +253,12 @@ TEST_CASE("[RegEx] Number Expression") {
 	const String test = "(2.5e-3 + 35 + 46) / 2.8e0 = 28.9294642857";
 
 	// Not an exact regex for number but a good test.
-	RegEx re("([+-]?\\d+)(\\.\\d+([eE][+-]?\\d+)?)?");
+	Ref<RegEx> re;
+	re.instantiate("([+-]?\\d+)(\\.\\d+([eE][+-]?\\d+)?)?");
+
 	REQUIRE(re.is_valid());
-	Array number_match = re.search_all(test);
+	REQUIRE(re->is_valid());
+	Array number_match = re->search_all(test);
 
 	CHECK(number_match.size() == 5);
 
@@ -237,12 +280,15 @@ TEST_CASE("[RegEx] Number Expression") {
 TEST_CASE("[RegEx] Invalid end position") {
 	const String s = "Godot";
 
-	RegEx re("o");
+	Ref<RegEx> re;
+	re.instantiate("o");
+
 	REQUIRE(re.is_valid());
-	Ref<RegExMatch> match = re.search(s, 0, 10);
+	REQUIRE(re->is_valid());
+	Ref<RegExMatch> match = re->search(s, 0, 10);
 	CHECK(match->get_string(0) == "o");
 
-	const Array all_results = re.search_all(s, 0, 10);
+	const Array all_results = re->search_all(s, 0, 10);
 	CHECK(all_results.size() == 2);
 	match = all_results[0];
 	REQUIRE(match.is_valid());
@@ -251,14 +297,16 @@ TEST_CASE("[RegEx] Invalid end position") {
 	REQUIRE(match.is_valid());
 	CHECK(match->get_string(0) == String("o"));
 
-	CHECK(re.sub(s, "", true, 0, 10) == "Gdt");
+	CHECK(re->sub(s, "", true, 0, 10) == "Gdt");
 }
 
 TEST_CASE("[RegEx] Get match string list") {
 	const String s = "Godot Engine";
 
-	RegEx re("(Go)(dot)");
-	Ref<RegExMatch> match = re.search(s);
+	Ref<RegEx> re;
+	re.instantiate("(Go)(dot)");
+
+	Ref<RegExMatch> match = re->search(s);
 	REQUIRE(match.is_valid());
 	PackedStringArray result;
 	result.append("Godot");
@@ -270,16 +318,22 @@ TEST_CASE("[RegEx] Get match string list") {
 TEST_CASE("[RegEx] Match start and end positions") {
 	const String s = "Whole pattern";
 
-	RegEx re1("pattern");
+	Ref<RegEx> re1;
+	re1.instantiate("pattern");
+
 	REQUIRE(re1.is_valid());
-	Ref<RegExMatch> match = re1.search(s);
+	REQUIRE(re1->is_valid());
+	Ref<RegExMatch> match = re1->search(s);
 	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 6);
 	CHECK(match->get_end(0) == 13);
 
-	RegEx re2("(?<vowel>[aeiou])");
+	Ref<RegEx> re2;
+	re2.instantiate("(?<vowel>[aeiou])");
+
 	REQUIRE(re2.is_valid());
-	match = re2.search(s);
+	REQUIRE(re2->is_valid());
+	match = re2->search(s);
 	REQUIRE(match.is_valid());
 	CHECK(match->get_start("vowel") == 2);
 	CHECK(match->get_end("vowel") == 3);
@@ -288,10 +342,13 @@ TEST_CASE("[RegEx] Match start and end positions") {
 TEST_CASE("[RegEx] Asterisk search all") {
 	const String s = "Godot Engine";
 
-	RegEx re("o*");
+	Ref<RegEx> re;
+	re.instantiate("o*");
+
 	REQUIRE(re.is_valid());
+	REQUIRE(re->is_valid());
 	Ref<RegExMatch> match;
-	const Array all_results = re.search_all(s);
+	const Array all_results = re->search_all(s);
 	CHECK(all_results.size() == 13);
 
 	match = all_results[0];
@@ -312,9 +369,12 @@ TEST_CASE("[RegEx] Asterisk search all") {
 TEST_CASE("[RegEx] Simple lookahead") {
 	const String s = "Godot Engine";
 
-	RegEx re("o(?=t)");
+	Ref<RegEx> re;
+	re.instantiate("o(?=t)");
+
 	REQUIRE(re.is_valid());
-	Ref<RegExMatch> match = re.search(s);
+	REQUIRE(re->is_valid());
+	Ref<RegExMatch> match = re->search(s);
 	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 3);
 	CHECK(match->get_end(0) == 4);
@@ -323,13 +383,16 @@ TEST_CASE("[RegEx] Simple lookahead") {
 TEST_CASE("[RegEx] Lookahead groups empty matches") {
 	const String s = "12";
 
-	RegEx re("(?=(\\d+))");
+	Ref<RegEx> re;
+	re.instantiate("(?=(\\d+))");
+
 	REQUIRE(re.is_valid());
-	Ref<RegExMatch> match = re.search(s);
+	REQUIRE(re->is_valid());
+	Ref<RegExMatch> match = re->search(s);
 	CHECK(match->get_string(0) == "");
 	CHECK(match->get_string(1) == "12");
 
-	const Array all_results = re.search_all(s);
+	const Array all_results = re->search_all(s);
 	CHECK(all_results.size() == 2);
 
 	match = all_results[0];
@@ -346,9 +409,12 @@ TEST_CASE("[RegEx] Lookahead groups empty matches") {
 TEST_CASE("[RegEx] Simple lookbehind") {
 	const String s = "Godot Engine";
 
-	RegEx re("(?<=d)o");
+	Ref<RegEx> re;
+	re.instantiate("(?<=d)o");
+
 	REQUIRE(re.is_valid());
-	Ref<RegExMatch> match = re.search(s);
+	REQUIRE(re->is_valid());
+	Ref<RegExMatch> match = re->search(s);
 	REQUIRE(match.is_valid());
 	CHECK(match->get_start(0) == 3);
 	CHECK(match->get_end(0) == 4);
@@ -357,9 +423,12 @@ TEST_CASE("[RegEx] Simple lookbehind") {
 TEST_CASE("[RegEx] Simple lookbehind search all") {
 	const String s = "ababbaabab";
 
-	RegEx re("(?<=a)b");
+	Ref<RegEx> re;
+	re.instantiate("(?<=a)b");
+
 	REQUIRE(re.is_valid());
-	const Array all_results = re.search_all(s);
+	REQUIRE(re->is_valid());
+	const Array all_results = re->search_all(s);
 	CHECK(all_results.size() == 4);
 
 	Ref<RegExMatch> match = all_results[0];
@@ -386,11 +455,14 @@ TEST_CASE("[RegEx] Simple lookbehind search all") {
 TEST_CASE("[RegEx] Lookbehind groups empty matches") {
 	const String s = "abaaabab";
 
-	RegEx re("(?<=(b))");
+	Ref<RegEx> re;
+	re.instantiate("(?<=(b))");
+
 	REQUIRE(re.is_valid());
+	REQUIRE(re->is_valid());
 	Ref<RegExMatch> match;
 
-	const Array all_results = re.search_all(s);
+	const Array all_results = re->search_all(s);
 	CHECK(all_results.size() == 3);
 
 	match = all_results[0];

--- a/tests/core/input/test_input_event_key.h
+++ b/tests/core/input/test_input_event_key.h
@@ -38,74 +38,82 @@
 namespace TestInputEventKey {
 
 TEST_CASE("[InputEventKey] Key correctly registers being pressed") {
-	InputEventKey key;
-	key.set_pressed(true);
-	CHECK(key.is_pressed() == true);
+	Ref<InputEventKey> key;
+	key.instantiate();
 
-	key.set_pressed(false);
-	CHECK(key.is_pressed() == false);
+	key->set_pressed(true);
+	CHECK(key->is_pressed() == true);
+
+	key->set_pressed(false);
+	CHECK(key->is_pressed() == false);
 }
 
 TEST_CASE("[InputEventKey] Key correctly stores and retrieves keycode") {
-	InputEventKey key;
+	Ref<InputEventKey> key;
+	key.instantiate();
 
-	key.set_keycode(Key::ENTER);
-	CHECK(key.get_keycode() == Key::ENTER);
-	CHECK(key.get_keycode() != Key::PAUSE);
+	key->set_keycode(Key::ENTER);
+	CHECK(key->get_keycode() == Key::ENTER);
+	CHECK(key->get_keycode() != Key::PAUSE);
 
-	key.set_physical_keycode(Key::BACKSPACE);
-	CHECK(key.get_physical_keycode() == Key::BACKSPACE);
-	CHECK(key.get_physical_keycode() != Key::PAUSE);
+	key->set_physical_keycode(Key::BACKSPACE);
+	CHECK(key->get_physical_keycode() == Key::BACKSPACE);
+	CHECK(key->get_physical_keycode() != Key::PAUSE);
 }
 
 TEST_CASE("[InputEventKey] Key correctly stores and retrieves keycode with modifiers") {
-	InputEventKey key;
+	Ref<InputEventKey> key;
+	key.instantiate();
 
-	key.set_keycode(Key::ENTER);
-	key.set_ctrl_pressed(true);
+	key->set_keycode(Key::ENTER);
+	key->set_ctrl_pressed(true);
 
-	CHECK(key.get_keycode_with_modifiers() == (Key::ENTER | KeyModifierMask::CTRL));
-	CHECK(key.get_keycode_with_modifiers() != (Key::ENTER | KeyModifierMask::SHIFT));
-	CHECK(key.get_keycode_with_modifiers() != Key::ENTER);
+	CHECK(key->get_keycode_with_modifiers() == (Key::ENTER | KeyModifierMask::CTRL));
+	CHECK(key->get_keycode_with_modifiers() != (Key::ENTER | KeyModifierMask::SHIFT));
+	CHECK(key->get_keycode_with_modifiers() != Key::ENTER);
 
-	key.set_physical_keycode(Key::SPACE);
-	key.set_ctrl_pressed(true);
+	key->set_physical_keycode(Key::SPACE);
+	key->set_ctrl_pressed(true);
 
-	CHECK(key.get_physical_keycode_with_modifiers() == (Key::SPACE | KeyModifierMask::CTRL));
-	CHECK(key.get_physical_keycode_with_modifiers() != (Key::SPACE | KeyModifierMask::SHIFT));
-	CHECK(key.get_physical_keycode_with_modifiers() != Key::SPACE);
+	CHECK(key->get_physical_keycode_with_modifiers() == (Key::SPACE | KeyModifierMask::CTRL));
+	CHECK(key->get_physical_keycode_with_modifiers() != (Key::SPACE | KeyModifierMask::SHIFT));
+	CHECK(key->get_physical_keycode_with_modifiers() != Key::SPACE);
 }
 
 TEST_CASE("[InputEventKey] Key correctly stores and retrieves unicode") {
-	InputEventKey key;
+	Ref<InputEventKey> key;
+	key.instantiate();
 
-	key.set_unicode('x');
-	CHECK(key.get_unicode() == 'x');
-	CHECK(key.get_unicode() != 'y');
+	key->set_unicode('x');
+	CHECK(key->get_unicode() == 'x');
+	CHECK(key->get_unicode() != 'y');
 }
 
 TEST_CASE("[InputEventKey] Key correctly stores and retrieves location") {
-	InputEventKey key;
+	Ref<InputEventKey> key;
+	key.instantiate();
 
-	CHECK(key.get_location() == KeyLocation::UNSPECIFIED);
+	CHECK(key->get_location() == KeyLocation::UNSPECIFIED);
 
-	key.set_location(KeyLocation::LEFT);
-	CHECK(key.get_location() == KeyLocation::LEFT);
-	CHECK(key.get_location() != KeyLocation::RIGHT);
+	key->set_location(KeyLocation::LEFT);
+	CHECK(key->get_location() == KeyLocation::LEFT);
+	CHECK(key->get_location() != KeyLocation::RIGHT);
 }
 
 TEST_CASE("[InputEventKey] Key correctly stores and checks echo") {
-	InputEventKey key;
+	Ref<InputEventKey> key;
+	key.instantiate();
 
-	key.set_echo(true);
-	CHECK(key.is_echo() == true);
+	key->set_echo(true);
+	CHECK(key->is_echo() == true);
 
-	key.set_echo(false);
-	CHECK(key.is_echo() == false);
+	key->set_echo(false);
+	CHECK(key->is_echo() == false);
 }
 
 TEST_CASE("[InputEventKey] Key correctly converts itself to text") {
-	InputEventKey none_key;
+	Ref<InputEventKey> none_key;
+	none_key.instantiate();
 
 	// These next three tests test the functionality of getting a key that is set to None
 	// as text. These cases are a bit weird, since None has no textual representation
@@ -114,74 +122,76 @@ TEST_CASE("[InputEventKey] Key correctly converts itself to text") {
 	// understand the code, that is intended behavior.
 
 	// Key is None without a physical key.
-	none_key.set_keycode(Key::NONE);
-	CHECK(none_key.as_text() == "(unset)");
+	none_key->set_keycode(Key::NONE);
+	CHECK(none_key->as_text() == "(unset)");
 
 	// Key is none and has modifiers.
-	none_key.set_ctrl_pressed(true);
-	CHECK(none_key.as_text() == "Ctrl+(unset)");
+	none_key->set_ctrl_pressed(true);
+	CHECK(none_key->as_text() == "Ctrl+(unset)");
 
 	// Key is None WITH a physical key AND modifiers.
-	none_key.set_physical_keycode(Key::ENTER);
-	CHECK(none_key.as_text() == "Ctrl+Enter");
+	none_key->set_physical_keycode(Key::ENTER);
+	CHECK(none_key->as_text() == "Ctrl+Enter");
 
-	none_key.set_physical_keycode(Key::W);
-	CHECK(none_key.as_text() == "Ctrl+W - Physical");
+	none_key->set_physical_keycode(Key::W);
+	CHECK(none_key->as_text() == "Ctrl+W - Physical");
 
 	// Key is None WITH a physical key AND multiple modifiers, checks for correct ordering.
-	none_key.set_physical_keycode(Key::ENTER);
-	none_key.set_alt_pressed(true);
-	none_key.set_shift_pressed(true);
+	none_key->set_physical_keycode(Key::ENTER);
+	none_key->set_alt_pressed(true);
+	none_key->set_shift_pressed(true);
 #ifdef MACOS_ENABLED
-	CHECK(none_key.as_text() != "Ctrl+Shift+Option+Enter");
-	CHECK(none_key.as_text() == "Ctrl+Option+Shift+Enter");
+	CHECK(none_key->as_text() != "Ctrl+Shift+Option+Enter");
+	CHECK(none_key->as_text() == "Ctrl+Option+Shift+Enter");
 #else
-	CHECK(none_key.as_text() != "Ctrl+Shift+Alt+Enter");
-	CHECK(none_key.as_text() == "Ctrl+Alt+Shift+Enter");
+	CHECK(none_key->as_text() != "Ctrl+Shift+Alt+Enter");
+	CHECK(none_key->as_text() == "Ctrl+Alt+Shift+Enter");
 #endif
-	none_key.set_physical_keycode(Key::W);
+	none_key->set_physical_keycode(Key::W);
 #ifdef MACOS_ENABLED
-	CHECK(none_key.as_text() != "Ctrl+Shift+Option+W - Physical");
-	CHECK(none_key.as_text() == "Ctrl+Option+Shift+W - Physical");
+	CHECK(none_key->as_text() != "Ctrl+Shift+Option+W - Physical");
+	CHECK(none_key->as_text() == "Ctrl+Option+Shift+W - Physical");
 #else
-	CHECK(none_key.as_text() != "Ctrl+Shift+Alt+W - Physical");
-	CHECK(none_key.as_text() == "Ctrl+Alt+Shift+W - Physical");
+	CHECK(none_key->as_text() != "Ctrl+Shift+Alt+W - Physical");
+	CHECK(none_key->as_text() == "Ctrl+Alt+Shift+W - Physical");
 #endif
 
-	InputEventKey none_key2;
+	Ref<InputEventKey> none_key2;
+	none_key2.instantiate();
 
 	// Key is None without modifiers with a physical key.
-	none_key2.set_keycode(Key::NONE);
-	none_key2.set_physical_keycode(Key::W);
+	none_key2->set_keycode(Key::NONE);
+	none_key2->set_physical_keycode(Key::W);
 
-	CHECK(none_key2.as_text() == "W - Physical");
+	CHECK(none_key2->as_text() == "W - Physical");
 
-	none_key2.set_keycode(Key::NONE);
-	none_key2.set_physical_keycode(Key::ENTER);
+	none_key2->set_keycode(Key::NONE);
+	none_key2->set_physical_keycode(Key::ENTER);
 
-	CHECK(none_key2.as_text() == "Enter");
+	CHECK(none_key2->as_text() == "Enter");
 
-	InputEventKey key;
+	Ref<InputEventKey> key;
+	key.instantiate();
 
 	// Key has keycode.
-	key.set_keycode(Key::SPACE);
-	CHECK(key.as_text() != "");
-	CHECK(key.as_text() == "Space");
+	key->set_keycode(Key::SPACE);
+	CHECK(key->as_text() != "");
+	CHECK(key->as_text() == "Space");
 
 	// Key has keycode and modifiers.
-	key.set_ctrl_pressed(true);
-	CHECK(key.as_text() != "Space");
-	CHECK(key.as_text() == "Ctrl+Space");
+	key->set_ctrl_pressed(true);
+	CHECK(key->as_text() != "Space");
+	CHECK(key->as_text() == "Ctrl+Space");
 
 	// Key has keycode and multiple modifiers, checks for correct ordering.
-	key.set_alt_pressed(true);
-	key.set_shift_pressed(true);
+	key->set_alt_pressed(true);
+	key->set_shift_pressed(true);
 #ifdef MACOS_ENABLED
-	CHECK(key.as_text() != "Ctrl+Shift+Option+Space");
-	CHECK(key.as_text() == "Ctrl+Option+Shift+Space");
+	CHECK(key->as_text() != "Ctrl+Shift+Option+Space");
+	CHECK(key->as_text() == "Ctrl+Option+Shift+Space");
 #else
-	CHECK(key.as_text() != "Ctrl+Shift+Alt+Space");
-	CHECK(key.as_text() == "Ctrl+Alt+Shift+Space");
+	CHECK(key->as_text() != "Ctrl+Shift+Alt+Space");
+	CHECK(key->as_text() == "Ctrl+Alt+Shift+Space");
 #endif
 
 	// Since the keycode is set to Key::NONE upon initialization of the
@@ -190,44 +200,45 @@ TEST_CASE("[InputEventKey] Key correctly converts itself to text") {
 }
 
 TEST_CASE("[InputEventKey] Key correctly converts its state to a string representation") {
-	InputEventKey none_key;
+	Ref<InputEventKey> none_key;
+	none_key.instantiate();
 
-	CHECK(none_key.to_string() == "InputEventKey: keycode=(unset), mods=none, physical=false, location=unspecified, pressed=false, echo=false");
+	CHECK(none_key->to_string() == "InputEventKey: keycode=(unset), mods=none, physical=false, location=unspecified, pressed=false, echo=false");
 	// Set physical key to Escape.
-	none_key.set_physical_keycode(Key::ESCAPE);
-	CHECK(none_key.to_string() == "InputEventKey: keycode=4194305 (Escape), mods=none, physical=true, location=unspecified, pressed=false, echo=false");
+	none_key->set_physical_keycode(Key::ESCAPE);
+	CHECK(none_key->to_string() == "InputEventKey: keycode=4194305 (Escape), mods=none, physical=true, location=unspecified, pressed=false, echo=false");
 
-	InputEventKey key;
+	Ref<InputEventKey> key;
+	key.instantiate();
 
 	// Set physical to None, set keycode to Space.
-	key.set_keycode(Key::SPACE);
-	CHECK(key.to_string() == "InputEventKey: keycode=32 (Space), mods=none, physical=false, location=unspecified, pressed=false, echo=false");
+	key->set_keycode(Key::SPACE);
+	CHECK(key->to_string() == "InputEventKey: keycode=32 (Space), mods=none, physical=false, location=unspecified, pressed=false, echo=false");
 
 	// Set location
-	key.set_location(KeyLocation::RIGHT);
-	CHECK(key.to_string() == "InputEventKey: keycode=32 (Space), mods=none, physical=false, location=right, pressed=false, echo=false");
+	key->set_location(KeyLocation::RIGHT);
+	CHECK(key->to_string() == "InputEventKey: keycode=32 (Space), mods=none, physical=false, location=right, pressed=false, echo=false");
 
 	// Set pressed to true.
-	key.set_pressed(true);
-	CHECK(key.to_string() == "InputEventKey: keycode=32 (Space), mods=none, physical=false, location=right, pressed=true, echo=false");
+	key->set_pressed(true);
+	CHECK(key->to_string() == "InputEventKey: keycode=32 (Space), mods=none, physical=false, location=right, pressed=true, echo=false");
 
 	// set echo to true.
-	key.set_echo(true);
-	CHECK(key.to_string() == "InputEventKey: keycode=32 (Space), mods=none, physical=false, location=right, pressed=true, echo=true");
+	key->set_echo(true);
+	CHECK(key->to_string() == "InputEventKey: keycode=32 (Space), mods=none, physical=false, location=right, pressed=true, echo=true");
 
 	// Press Ctrl and Alt.
-	key.set_ctrl_pressed(true);
-	key.set_alt_pressed(true);
+	key->set_ctrl_pressed(true);
+	key->set_alt_pressed(true);
 #ifdef MACOS_ENABLED
-	CHECK(key.to_string() == "InputEventKey: keycode=32 (Space), mods=Ctrl+Option, physical=false, location=right, pressed=true, echo=true");
+	CHECK(key->to_string() == "InputEventKey: keycode=32 (Space), mods=Ctrl+Option, physical=false, location=right, pressed=true, echo=true");
 #else
-	CHECK(key.to_string() == "InputEventKey: keycode=32 (Space), mods=Ctrl+Alt, physical=false, location=right, pressed=true, echo=true");
+	CHECK(key->to_string() == "InputEventKey: keycode=32 (Space), mods=Ctrl+Alt, physical=false, location=right, pressed=true, echo=true");
 #endif
 }
 
 TEST_CASE("[InputEventKey] Key is correctly converted to reference") {
-	InputEventKey base_key;
-	Ref<InputEventKey> key_ref = base_key.create_reference(Key::ENTER);
+	Ref<InputEventKey> key_ref = InputEventKey::create_reference(Key::ENTER);
 
 	CHECK(key_ref->get_keycode() == Key::ENTER);
 }
@@ -236,18 +247,19 @@ TEST_CASE("[InputEventKey] Keys are correctly matched based on action") {
 	bool pressed = false;
 	float strength, raw_strength = 0.0;
 
-	InputEventKey key;
+	Ref<InputEventKey> key;
+	key.instantiate();
 
 	// Nullptr.
-	CHECK_MESSAGE(key.action_match(nullptr, false, 0.0f, &pressed, &strength, &raw_strength) == false, "nullptr as key reference should result in false");
+	CHECK_MESSAGE(key->action_match(nullptr, false, 0.0f, &pressed, &strength, &raw_strength) == false, "nullptr as key reference should result in false");
 
 	// Match on keycode.
-	key.set_keycode(Key::SPACE);
-	Ref<InputEventKey> match = key.create_reference(Key::SPACE);
-	Ref<InputEventKey> no_match = key.create_reference(Key::ENTER);
+	key->set_keycode(Key::SPACE);
+	Ref<InputEventKey> match = InputEventKey::create_reference(Key::SPACE);
+	Ref<InputEventKey> no_match = InputEventKey::create_reference(Key::ENTER);
 
-	CHECK(key.action_match(match, false, 0.0f, &pressed, &strength, &raw_strength) == true);
-	CHECK(key.action_match(no_match, false, 0.0f, &pressed, &strength, &raw_strength) == false);
+	CHECK(key->action_match(match, false, 0.0f, &pressed, &strength, &raw_strength) == true);
+	CHECK(key->action_match(no_match, false, 0.0f, &pressed, &strength, &raw_strength) == false);
 
 	// Check that values are correctly transferred to the pointers.
 	CHECK(pressed == false);
@@ -255,121 +267,134 @@ TEST_CASE("[InputEventKey] Keys are correctly matched based on action") {
 	CHECK(raw_strength < 0.5);
 
 	match->set_pressed(true);
-	key.action_match(match, false, 0.0f, &pressed, &strength, &raw_strength);
+	key->action_match(match, false, 0.0f, &pressed, &strength, &raw_strength);
 
 	CHECK(pressed == true);
 	CHECK(strength > 0.5);
 	CHECK(raw_strength > 0.5);
 
 	// Tests when keycode is None: Then you rely on physical keycode.
-	InputEventKey none_key;
-	none_key.set_physical_keycode(Key::SPACE);
+	Ref<InputEventKey> none_key;
+	none_key.instantiate();
 
-	Ref<InputEventKey> match_none = none_key.create_reference(Key::NONE);
+	none_key->set_physical_keycode(Key::SPACE);
+
+	Ref<InputEventKey> match_none = InputEventKey::create_reference(Key::NONE);
 	match_none->set_physical_keycode(Key::SPACE);
 
-	Ref<InputEventKey> no_match_none = none_key.create_reference(Key::NONE);
+	Ref<InputEventKey> no_match_none = InputEventKey::create_reference(Key::NONE);
 	no_match_none->set_physical_keycode(Key::ENTER);
 
-	CHECK(none_key.action_match(match_none, false, 0.0f, &pressed, &strength, &raw_strength) == true);
-	CHECK(none_key.action_match(no_match_none, false, 0.0f, &pressed, &strength, &raw_strength) == false);
+	CHECK(none_key->action_match(match_none, false, 0.0f, &pressed, &strength, &raw_strength) == true);
+	CHECK(none_key->action_match(no_match_none, false, 0.0f, &pressed, &strength, &raw_strength) == false);
 
 	// Test exact match.
-	InputEventKey key2, ref_key;
-	key2.set_keycode(Key::SPACE);
+	Ref<InputEventKey> key2;
+	key2.instantiate();
 
-	Ref<InputEventKey> match2 = ref_key.create_reference(Key::SPACE);
+	Ref<InputEventKey> ref_key;
+	ref_key.instantiate();
+
+	key2->set_keycode(Key::SPACE);
+
+	Ref<InputEventKey> match2 = InputEventKey::create_reference(Key::SPACE);
 
 	// Now both press Ctrl and Shift.
-	key2.set_ctrl_pressed(true);
-	key2.set_shift_pressed(true);
+	key2->set_ctrl_pressed(true);
+	key2->set_shift_pressed(true);
 
 	match2->set_ctrl_pressed(true);
 	match2->set_shift_pressed(true);
 
 	// Now they should match.
 	bool exact_match = true;
-	CHECK(key2.action_match(match2, exact_match, 0.0f, &pressed, &strength, &raw_strength) == true);
+	CHECK(key2->action_match(match2, exact_match, 0.0f, &pressed, &strength, &raw_strength) == true);
 
 	// Modify matching key such that it does no longer match in terms of modifiers: Shift
 	// is no longer pressed.
 	match2->set_shift_pressed(false);
 	CHECK(match2->is_shift_pressed() == false);
-	CHECK(key2.action_match(match2, exact_match, 0.0f, &pressed, &strength, &raw_strength) == false);
+	CHECK(key2->action_match(match2, exact_match, 0.0f, &pressed, &strength, &raw_strength) == false);
 }
 
 TEST_CASE("[IsMatch] Keys are correctly matched") {
 	// Key with NONE as keycode.
-	InputEventKey key;
-	key.set_keycode(Key::NONE);
-	key.set_physical_keycode(Key::SPACE);
+	Ref<InputEventKey> key;
+	key.instantiate();
+
+	key->set_keycode(Key::NONE);
+	key->set_physical_keycode(Key::SPACE);
 
 	// Nullptr.
-	CHECK(key.is_match(nullptr, false) == false);
+	CHECK(key->is_match(nullptr, false) == false);
 
-	Ref<InputEventKey> none_ref = key.create_reference(Key::NONE);
+	Ref<InputEventKey> none_ref = InputEventKey::create_reference(Key::NONE);
 
 	none_ref->set_physical_keycode(Key::SPACE);
-	CHECK(key.is_match(none_ref, false) == true);
+	CHECK(key->is_match(none_ref, false) == true);
 
 	none_ref->set_physical_keycode(Key::ENTER);
-	CHECK(key.is_match(none_ref, false) == false);
+	CHECK(key->is_match(none_ref, false) == false);
 
 	none_ref->set_physical_keycode(Key::SPACE);
 
-	key.set_ctrl_pressed(true);
+	key->set_ctrl_pressed(true);
 	none_ref->set_ctrl_pressed(false);
-	CHECK(key.is_match(none_ref, true) == false);
+	CHECK(key->is_match(none_ref, true) == false);
 
 	none_ref->set_ctrl_pressed(true);
-	CHECK(key.is_match(none_ref, true) == true);
+	CHECK(key->is_match(none_ref, true) == true);
 
 	// Ref with actual keycode.
-	InputEventKey key2;
-	key2.set_keycode(Key::SPACE);
+	Ref<InputEventKey> key2;
+	key2.instantiate();
 
-	Ref<InputEventKey> match = key2.create_reference(Key::SPACE);
-	Ref<InputEventKey> no_match = key2.create_reference(Key::ENTER);
+	key2->set_keycode(Key::SPACE);
 
-	CHECK(key2.is_match(match, false) == true);
-	CHECK(key2.is_match(no_match, false) == false);
+	Ref<InputEventKey> match = InputEventKey::create_reference(Key::SPACE);
+	Ref<InputEventKey> no_match = InputEventKey::create_reference(Key::ENTER);
+
+	CHECK(key2->is_match(match, false) == true);
+	CHECK(key2->is_match(no_match, false) == false);
 
 	// Now the keycode is the same, but the modifiers differ.
 	no_match->set_keycode(Key::SPACE);
 
-	key2.set_ctrl_pressed(true);
+	key2->set_ctrl_pressed(true);
 	match->set_ctrl_pressed(true);
 	no_match->set_shift_pressed(true);
 
-	CHECK(key2.is_match(match, true) == true);
-	CHECK(key2.is_match(no_match, true) == false);
+	CHECK(key2->is_match(match, true) == true);
+	CHECK(key2->is_match(no_match, true) == false);
 
 	// Physical key with location.
-	InputEventKey key3;
-	key3.set_keycode(Key::NONE);
-	key3.set_physical_keycode(Key::SHIFT);
+	Ref<InputEventKey> key3;
+	key3.instantiate();
 
-	Ref<InputEventKey> loc_ref = key.create_reference(Key::NONE);
+	key3->set_keycode(Key::NONE);
+	key3->set_physical_keycode(Key::SHIFT);
+
+	Ref<InputEventKey> loc_ref = InputEventKey::create_reference(Key::NONE);
 
 	loc_ref->set_keycode(Key::SHIFT);
 	loc_ref->set_physical_keycode(Key::SHIFT);
 
-	CHECK(key3.is_match(loc_ref, false) == true);
-	key3.set_location(KeyLocation::UNSPECIFIED);
-	CHECK(key3.is_match(loc_ref, false) == true);
+	CHECK(key3->is_match(loc_ref, false) == true);
+	key3->set_location(KeyLocation::UNSPECIFIED);
+	CHECK(key3->is_match(loc_ref, false) == true);
 
 	loc_ref->set_location(KeyLocation::LEFT);
-	CHECK(key3.is_match(loc_ref, false) == true);
+	CHECK(key3->is_match(loc_ref, false) == true);
 
-	key3.set_location(KeyLocation::LEFT);
-	CHECK(key3.is_match(loc_ref, false) == true);
+	key3->set_location(KeyLocation::LEFT);
+	CHECK(key3->is_match(loc_ref, false) == true);
 
-	key3.set_location(KeyLocation::RIGHT);
-	CHECK(key3.is_match(loc_ref, false) == false);
+	key3->set_location(KeyLocation::RIGHT);
+	CHECK(key3->is_match(loc_ref, false) == false);
 
 	// Keycode key with location.
-	key3.set_physical_keycode(Key::NONE);
-	key3.set_keycode(Key::SHIFT);
-	CHECK(key3.is_match(loc_ref, false) == true);
+	key3->set_physical_keycode(Key::NONE);
+	key3->set_keycode(Key::SHIFT);
+	CHECK(key3->is_match(loc_ref, false) == true);
 }
 } // namespace TestInputEventKey

--- a/tests/core/input/test_input_event_mouse.h
+++ b/tests/core/input/test_input_event_mouse.h
@@ -36,43 +36,46 @@
 namespace TestInputEventMouse {
 
 TEST_CASE("[InputEventMouse] Mouse button mask is set correctly") {
-	InputEventMouse mousekey;
+	Ref<InputEventMouse> mousekey;
+	mousekey.instantiate();
 
-	mousekey.set_button_mask(MouseButtonMask::LEFT);
-	CHECK(mousekey.get_button_mask().has_flag(MouseButtonMask::LEFT));
+	mousekey->set_button_mask(MouseButtonMask::LEFT);
+	CHECK(mousekey->get_button_mask().has_flag(MouseButtonMask::LEFT));
 
-	mousekey.set_button_mask(MouseButtonMask::MB_XBUTTON1);
-	CHECK(mousekey.get_button_mask().has_flag(MouseButtonMask::MB_XBUTTON1));
+	mousekey->set_button_mask(MouseButtonMask::MB_XBUTTON1);
+	CHECK(mousekey->get_button_mask().has_flag(MouseButtonMask::MB_XBUTTON1));
 
-	mousekey.set_button_mask(MouseButtonMask::MB_XBUTTON2);
-	CHECK(mousekey.get_button_mask().has_flag(MouseButtonMask::MB_XBUTTON2));
+	mousekey->set_button_mask(MouseButtonMask::MB_XBUTTON2);
+	CHECK(mousekey->get_button_mask().has_flag(MouseButtonMask::MB_XBUTTON2));
 
-	mousekey.set_button_mask(MouseButtonMask::MIDDLE);
-	CHECK(mousekey.get_button_mask().has_flag(MouseButtonMask::MIDDLE));
+	mousekey->set_button_mask(MouseButtonMask::MIDDLE);
+	CHECK(mousekey->get_button_mask().has_flag(MouseButtonMask::MIDDLE));
 
-	mousekey.set_button_mask(MouseButtonMask::RIGHT);
-	CHECK(mousekey.get_button_mask().has_flag(MouseButtonMask::RIGHT));
+	mousekey->set_button_mask(MouseButtonMask::RIGHT);
+	CHECK(mousekey->get_button_mask().has_flag(MouseButtonMask::RIGHT));
 }
 
 TEST_CASE("[InputEventMouse] Setting the mouse position works correctly") {
-	InputEventMouse mousekey;
+	Ref<InputEventMouse> mousekey;
+	mousekey.instantiate();
 
-	mousekey.set_position(Vector2{ 10, 10 });
-	CHECK(mousekey.get_position() == Vector2{ 10, 10 });
+	mousekey->set_position(Vector2{ 10, 10 });
+	CHECK(mousekey->get_position() == Vector2{ 10, 10 });
 
-	mousekey.set_position(Vector2{ -1, -1 });
-	CHECK(mousekey.get_position() == Vector2{ -1, -1 });
+	mousekey->set_position(Vector2{ -1, -1 });
+	CHECK(mousekey->get_position() == Vector2{ -1, -1 });
 }
 
 TEST_CASE("[InputEventMouse] Setting the global mouse position works correctly") {
-	InputEventMouse mousekey;
+	Ref<InputEventMouse> mousekey;
+	mousekey.instantiate();
 
-	mousekey.set_global_position(Vector2{ 10, 10 });
-	CHECK(mousekey.get_global_position() == Vector2{ 10, 10 });
-	CHECK(mousekey.get_global_position() != Vector2{ 1, 1 });
+	mousekey->set_global_position(Vector2{ 10, 10 });
+	CHECK(mousekey->get_global_position() == Vector2{ 10, 10 });
+	CHECK(mousekey->get_global_position() != Vector2{ 1, 1 });
 
-	mousekey.set_global_position(Vector2{ -1, -1 });
-	CHECK(mousekey.get_global_position() == Vector2{ -1, -1 });
-	CHECK(mousekey.get_global_position() != Vector2{ 1, 1 });
+	mousekey->set_global_position(Vector2{ -1, -1 });
+	CHECK(mousekey->get_global_position() == Vector2{ -1, -1 });
+	CHECK(mousekey->get_global_position() != Vector2{ 1, 1 });
 }
 } // namespace TestInputEventMouse

--- a/tests/core/input/test_shortcut.h
+++ b/tests/core/input/test_shortcut.h
@@ -42,10 +42,11 @@
 namespace TestShortcut {
 
 TEST_CASE("[Shortcut] Empty shortcut should have no valid events and text equal to None") {
-	Shortcut s;
+	Ref<Shortcut> s;
+	s.instantiate();
 
-	CHECK(s.get_as_text() == "None");
-	CHECK(s.has_valid_event() == false);
+	CHECK(s->get_as_text() == "None");
+	CHECK(s->has_valid_event() == false);
 }
 
 TEST_CASE("[Shortcut] Setting and getting an event should result in the same event as the input") {
@@ -62,11 +63,12 @@ TEST_CASE("[Shortcut] Setting and getting an event should result in the same eve
 	Ref<InputEvent> e2 = k2;
 	Array input_array = { e1, e2 };
 
-	Shortcut s;
-	s.set_events(input_array);
+	Ref<Shortcut> s;
+	s.instantiate();
+	s->set_events(input_array);
 
 	// Get result, read it out, check whether it equals the input.
-	Array result_array = s.get_events();
+	Array result_array = s->get_events();
 	Ref<InputEventKey> result1 = result_array.front();
 	Ref<InputEventKey> result2 = result_array.back();
 
@@ -91,11 +93,12 @@ TEST_CASE("[Shortcut] 'set_events_list' should result in the same events as the 
 	list.push_back(e1);
 	list.push_back(e2);
 
-	Shortcut s;
-	s.set_events_list(&list);
+	Ref<Shortcut> s;
+	s.instantiate();
+	s->set_events_list(&list);
 
 	// Get result, read it out, check whether it equals the input.
-	Array result_array = s.get_events();
+	Array result_array = s->get_events();
 	Ref<InputEventKey> result1 = result_array.front();
 	Ref<InputEventKey> result2 = result_array.back();
 
@@ -129,13 +132,14 @@ TEST_CASE("[Shortcut] 'matches_event' should correctly match the same event") {
 	Ref<InputEvent> e_copy = copy;
 
 	Array a = { e_original };
-	Shortcut s;
-	s.set_events(a);
+	Ref<Shortcut> s;
+	s.instantiate();
+	s->set_events(a);
 
-	CHECK(s.matches_event(e_similar_but_not_equal) == false);
-	CHECK(s.matches_event(e_different) == false);
+	CHECK(s->matches_event(e_similar_but_not_equal) == false);
+	CHECK(s->matches_event(e_different) == false);
 
-	CHECK(s.matches_event(e_copy) == true);
+	CHECK(s->matches_event(e_copy) == true);
 }
 
 TEST_CASE("[Shortcut] 'get_as_text' text representation should be correct") {
@@ -151,11 +155,12 @@ TEST_CASE("[Shortcut] 'get_as_text' text representation should be correct") {
 
 	Ref<InputEvent> key_event1 = same;
 	Array a = { key_event1 };
-	Shortcut s;
-	s.set_events(a);
+	Ref<Shortcut> s;
+	s.instantiate();
+	s->set_events(a);
 
-	CHECK(s.get_as_text() == same->as_text());
-	CHECK(s.get_as_text() != different->as_text());
+	CHECK(s->get_as_text() == same->as_text());
+	CHECK(s->get_as_text() != different->as_text());
 }
 
 TEST_CASE("[Shortcut] Event validity should be correctly checked.") {
@@ -171,10 +176,11 @@ TEST_CASE("[Shortcut] Event validity should be correctly checked.") {
 
 	Array a = { invalid_event, valid_event };
 
-	Shortcut s;
-	s.set_events(a);
+	Ref<Shortcut> s;
+	s.instantiate();
+	s->set_events(a);
 
-	CHECK(s.has_valid_event() == true);
+	CHECK(s->has_valid_event() == true);
 
 	Array b = { invalid_event };
 
@@ -208,11 +214,12 @@ TEST_CASE("[Shortcut] Equal arrays should be recognized as such.") {
 	Array different2 = { key_event1, key_event2 };
 	Array different3;
 
-	Shortcut s;
+	Ref<Shortcut> s;
+	s.instantiate();
 
-	CHECK(s.is_event_array_equal(same, same_as_same) == true);
-	CHECK(s.is_event_array_equal(same, different1) == false);
-	CHECK(s.is_event_array_equal(same, different2) == false);
-	CHECK(s.is_event_array_equal(same, different3) == false);
+	CHECK(s->is_event_array_equal(same, same_as_same) == true);
+	CHECK(s->is_event_array_equal(same, different1) == false);
+	CHECK(s->is_event_array_equal(same, different2) == false);
+	CHECK(s->is_event_array_equal(same, different3) == false);
 }
 } // namespace TestShortcut

--- a/tests/core/io/test_config_file.h
+++ b/tests/core/io/test_config_file.h
@@ -38,9 +38,10 @@
 namespace TestConfigFile {
 
 TEST_CASE("[ConfigFile] Parsing well-formatted files") {
-	ConfigFile config_file;
+	Ref<ConfigFile> config_file;
+	config_file.instantiate();
 	// Formatting is intentionally hand-edited to see how human-friendly the parser is.
-	const Error error = config_file.parse(R"(
+	const Error error = config_file->parse(R"(
 [player]
 
 name = "Unnamed Player"
@@ -64,34 +65,35 @@ antiAliasing = false
 
 	CHECK_MESSAGE(error == OK, "The configuration file should parse successfully.");
 	CHECK_MESSAGE(
-			String(config_file.get_value("player", "name")) == "Unnamed Player",
+			String(config_file->get_value("player", "name")) == "Unnamed Player",
 			"Reading `player/name` should return the expected value.");
 	CHECK_MESSAGE(
-			String(config_file.get_value("player", "tagline")) == "Waiting\nfor\nGodot",
+			String(config_file->get_value("player", "tagline")) == "Waiting\nfor\nGodot",
 			"Reading `player/tagline` should return the expected value.");
 	CHECK_MESSAGE(
-			Color(config_file.get_value("player", "color")).is_equal_approx(Color(0, 0.5, 1)),
+			Color(config_file->get_value("player", "color")).is_equal_approx(Color(0, 0.5, 1)),
 			"Reading `player/color` should return the expected value.");
 	CHECK_MESSAGE(
-			Vector2(config_file.get_value("player", "position")).is_equal_approx(Vector2(3, 4)),
+			Vector2(config_file->get_value("player", "position")).is_equal_approx(Vector2(3, 4)),
 			"Reading `player/position` should return the expected value.");
 	CHECK_MESSAGE(
-			bool(config_file.get_value("graphics", "antialiasing")),
+			bool(config_file->get_value("graphics", "antialiasing")),
 			"Reading `graphics/antialiasing` should return `true`.");
 	CHECK_MESSAGE(
-			bool(config_file.get_value("graphics", "antiAliasing")) == false,
+			bool(config_file->get_value("graphics", "antiAliasing")) == false,
 			"Reading `graphics/antiAliasing` should return `false`.");
 
 	// An empty ConfigFile is valid.
-	const Error error_empty = config_file.parse("");
+	const Error error_empty = config_file->parse("");
 	CHECK_MESSAGE(error_empty == OK,
 			"An empty configuration file should parse successfully.");
 }
 
 TEST_CASE("[ConfigFile] Parsing malformatted file") {
-	ConfigFile config_file;
+	Ref<ConfigFile> config_file;
+	config_file.instantiate();
 	ERR_PRINT_OFF;
-	const Error error = config_file.parse(R"(
+	const Error error = config_file->parse(R"(
 [player]
 
 name = "Unnamed Player"" ; Extraneous closing quote.
@@ -115,15 +117,17 @@ antialiasing = false ; Duplicate key.
 }
 
 TEST_CASE("[ConfigFile] Saving file") {
-	ConfigFile config_file;
-	config_file.set_value("player", "name", "Unnamed Player");
-	config_file.set_value("player", "tagline", "Waiting\nfor\nGodot");
-	config_file.set_value("player", "color", Color(0, 0.5, 1));
-	config_file.set_value("player", "position", Vector2(3, 4));
-	config_file.set_value("graphics", "antialiasing", true);
-	config_file.set_value("graphics", "antiAliasing", false);
-	config_file.set_value("quoted", String::utf8("静音"), 42);
-	config_file.set_value("quoted", "a=b", 7);
+	Ref<ConfigFile> config_file;
+	config_file.instantiate();
+
+	config_file->set_value("player", "name", "Unnamed Player");
+	config_file->set_value("player", "tagline", "Waiting\nfor\nGodot");
+	config_file->set_value("player", "color", Color(0, 0.5, 1));
+	config_file->set_value("player", "position", Vector2(3, 4));
+	config_file->set_value("graphics", "antialiasing", true);
+	config_file->set_value("graphics", "antiAliasing", false);
+	config_file->set_value("quoted", String::utf8("静音"), 42);
+	config_file->set_value("quoted", "a=b", 7);
 
 #ifdef WINDOWS_ENABLED
 	const String config_path = OS::get_singleton()->get_environment("TEMP").path_join("config.ini");
@@ -131,7 +135,7 @@ TEST_CASE("[ConfigFile] Saving file") {
 	const String config_path = "/tmp/config.ini";
 #endif
 
-	config_file.save(config_path);
+	config_file->save(config_path);
 
 	// Expected contents of the saved ConfigFile.
 	const String contents = String::utf8(R"([player]

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -158,66 +158,68 @@ TEST_CASE("[JSON] Stringify dictionaries") {
 TEST_CASE("[JSON] Parsing single data types") {
 	// Parsing a single data type as JSON is valid per the JSON specification.
 
-	JSON json;
+	Ref<JSON> json;
+	json.instantiate();
 
-	json.parse("null");
+	json->parse("null");
 	CHECK_MESSAGE(
-			json.get_error_line() == 0,
+			json->get_error_line() == 0,
 			"Parsing `null` as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			json.get_data() == Variant(),
+			json->get_data() == Variant(),
 			"Parsing a double quoted string as JSON should return the expected value.");
 
-	json.parse("true");
+	json->parse("true");
 	CHECK_MESSAGE(
-			json.get_error_line() == 0,
+			json->get_error_line() == 0,
 			"Parsing boolean `true` as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			json.get_data(),
+			json->get_data(),
 			"Parsing boolean `true` as JSON should return the expected value.");
 
-	json.parse("false");
+	json->parse("false");
 	CHECK_MESSAGE(
-			json.get_error_line() == 0,
+			json->get_error_line() == 0,
 			"Parsing boolean `false` as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			!json.get_data(),
+			!json->get_data(),
 			"Parsing boolean `false` as JSON should return the expected value.");
 
-	json.parse("123456");
+	json->parse("123456");
 	CHECK_MESSAGE(
-			json.get_error_line() == 0,
+			json->get_error_line() == 0,
 			"Parsing an integer number as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			(int)(json.get_data()) == 123456,
+			(int)(json->get_data()) == 123456,
 			"Parsing an integer number as JSON should return the expected value.");
 
-	json.parse("0.123456");
+	json->parse("0.123456");
 	CHECK_MESSAGE(
-			json.get_error_line() == 0,
+			json->get_error_line() == 0,
 			"Parsing a floating-point number as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			double(json.get_data()) == doctest::Approx(0.123456),
+			double(json->get_data()) == doctest::Approx(0.123456),
 			"Parsing a floating-point number as JSON should return the expected value.");
 
-	json.parse("\"hello\"");
+	json->parse("\"hello\"");
 	CHECK_MESSAGE(
-			json.get_error_line() == 0,
+			json->get_error_line() == 0,
 			"Parsing a double quoted string as JSON should parse successfully.");
 	CHECK_MESSAGE(
-			json.get_data() == "hello",
+			json->get_data() == "hello",
 			"Parsing a double quoted string as JSON should return the expected value.");
 }
 
 TEST_CASE("[JSON] Parsing arrays") {
-	JSON json;
+	Ref<JSON> json;
+	json.instantiate();
 
 	// JSON parsing fails if it's split over several lines (even if leading indentation is removed).
-	json.parse(R"(["Hello", "world.", "This is",["a","json","array.",[]], "Empty arrays ahoy:", [[["Gotcha!"]]]])");
+	json->parse(R"(["Hello", "world.", "This is",["a","json","array.",[]], "Empty arrays ahoy:", [[["Gotcha!"]]]])");
 
-	const Array array = json.get_data();
+	const Array array = json->get_data();
 	CHECK_MESSAGE(
-			json.get_error_line() == 0,
+			json->get_error_line() == 0,
 			"Parsing a JSON array should parse successfully.");
 	CHECK_MESSAGE(
 			array[0] == "Hello",
@@ -239,11 +241,12 @@ TEST_CASE("[JSON] Parsing arrays") {
 }
 
 TEST_CASE("[JSON] Parsing objects (dictionaries)") {
-	JSON json;
+	Ref<JSON> json;
+	json.instantiate();
 
-	json.parse(R"({"name": "Godot Engine", "is_free": true, "bugs": null, "apples": {"red": 500, "green": 0, "blue": -20}, "empty_object": {}})");
+	json->parse(R"({"name": "Godot Engine", "is_free": true, "bugs": null, "apples": {"red": 500, "green": 0, "blue": -20}, "empty_object": {}})");
 
-	const Dictionary dictionary = json.get_data();
+	const Dictionary dictionary = json->get_data();
 	CHECK_MESSAGE(
 			dictionary["name"] == "Godot Engine",
 			"The parsed JSON should contain the expected values.");
@@ -265,7 +268,8 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 	// Only certain escape sequences are valid according to the JSON specification.
 	// Others must result in a parsing error instead.
 
-	JSON json;
+	Ref<JSON> json;
+	json.instantiate();
 
 	TypedArray<String> valid_escapes = { "\";\"", "\\;\\", "/;/", "b;\b", "f;\f", "n;\n", "r;\r", "t;\t" };
 
@@ -278,13 +282,13 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 			String json_string = "\"\\";
 			json_string += valid_escape_string;
 			json_string += "\"";
-			json.parse(json_string);
+			json->parse(json_string);
 
 			CHECK_MESSAGE(
-					json.get_error_line() == 0,
+					json->get_error_line() == 0,
 					vformat("Parsing valid escape sequence `%s` as JSON should parse successfully.", valid_escape_string));
 
-			String json_value = json.get_data();
+			String json_value = json->get_data();
 			CHECK_MESSAGE(
 					json_value == valid_escape_value,
 					vformat("Parsing valid escape sequence `%s` as JSON should return the expected value.", valid_escape_string));
@@ -293,13 +297,13 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 
 	SUBCASE("Valid unicode escape sequences") {
 		String json_string = "\"\\u0020\"";
-		json.parse(json_string);
+		json->parse(json_string);
 
 		CHECK_MESSAGE(
-				json.get_error_line() == 0,
+				json->get_error_line() == 0,
 				vformat("Parsing valid unicode escape sequence with value `0020` as JSON should parse successfully."));
 
-		String json_value = json.get_data();
+		String json_value = json->get_data();
 		CHECK_MESSAGE(
 				json_value == " ",
 				vformat("Parsing valid unicode escape sequence with value `0020` as JSON should return the expected value."));
@@ -325,11 +329,11 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 			String json_string = "\"\\";
 			json_string += i;
 			json_string += "\"";
-			Error err = json.parse(json_string);
+			Error err = json->parse(json_string);
 
 			// TODO: Line number is currently kept on 0, despite an error occurring. This should be fixed in the JSON parser.
 			// CHECK_MESSAGE(
-			// 		json.get_error_line() != 0,
+			// 		json->get_error_line() != 0,
 			// 		vformat("Parsing invalid escape sequence with ASCII value `%d` as JSON should fail to parse.", i));
 			CHECK_MESSAGE(
 					err == ERR_PARSE_ERROR,
@@ -340,7 +344,8 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 }
 
 TEST_CASE("[JSON] Serialization") {
-	JSON json;
+	Ref<JSON> json;
+	json.instantiate();
 
 	struct FpTestCase {
 		double number;
@@ -395,7 +400,7 @@ TEST_CASE("[JSON] Serialization") {
 
 	SUBCASE("Floating point default precision") {
 		for (FpTestCase &test : fp_tests_default_precision) {
-			String json_value = json.stringify(test.number, "", true, false);
+			String json_value = json->stringify(test.number, "", true, false);
 
 			CHECK_MESSAGE(
 					json_value == test.json,
@@ -405,7 +410,7 @@ TEST_CASE("[JSON] Serialization") {
 
 	SUBCASE("Floating point full precision") {
 		for (FpTestCase &test : fp_tests_full_precision) {
-			String json_value = json.stringify(test.number, "", true, true);
+			String json_value = json->stringify(test.number, "", true, true);
 
 			CHECK_MESSAGE(
 					json_value == test.json,
@@ -415,7 +420,7 @@ TEST_CASE("[JSON] Serialization") {
 
 	SUBCASE("Signed integer") {
 		for (IntTestCase &test : int_tests) {
-			String json_value = json.stringify(test.number, "", true, true);
+			String json_value = json->stringify(test.number, "", true, true);
 
 			CHECK_MESSAGE(
 					json_value == test.json,

--- a/tests/core/io/test_pck_packer.h
+++ b/tests/core/io/test_pck_packer.h
@@ -40,14 +40,16 @@
 namespace TestPCKPacker {
 
 TEST_CASE("[PCKPacker] Pack an empty PCK file") {
-	PCKPacker pck_packer;
+	Ref<PCKPacker> pck_packer;
+	pck_packer.instantiate();
+
 	const String output_pck_path = TestUtils::get_temp_path("output_empty.pck");
 	CHECK_MESSAGE(
-			pck_packer.pck_start(output_pck_path) == OK,
+			pck_packer->pck_start(output_pck_path) == OK,
 			"Starting a PCK file should return an OK error code.");
 
 	CHECK_MESSAGE(
-			pck_packer.flush() == OK,
+			pck_packer->flush() == OK,
 			"Flushing the PCK should return an OK error code.");
 
 	Error err;
@@ -64,47 +66,53 @@ TEST_CASE("[PCKPacker] Pack an empty PCK file") {
 }
 
 TEST_CASE("[PCKPacker] Pack empty with zero alignment invalid") {
-	PCKPacker pck_packer;
+	Ref<PCKPacker> pck_packer;
+	pck_packer.instantiate();
+
 	const String output_pck_path = TestUtils::get_temp_path("output_empty.pck");
 	ERR_PRINT_OFF;
-	CHECK_MESSAGE(pck_packer.pck_start(output_pck_path, 0) != OK, "PCK with zero alignment should fail.");
+	CHECK_MESSAGE(pck_packer->pck_start(output_pck_path, 0) != OK, "PCK with zero alignment should fail.");
 	ERR_PRINT_ON;
 }
 
 TEST_CASE("[PCKPacker] Pack empty with invalid key") {
-	PCKPacker pck_packer;
+	Ref<PCKPacker> pck_packer;
+	pck_packer.instantiate();
+
 	const String output_pck_path = TestUtils::get_temp_path("output_empty.pck");
 	ERR_PRINT_OFF;
-	CHECK_MESSAGE(pck_packer.pck_start(output_pck_path, 32, "") != OK, "PCK with invalid key should fail.");
+	CHECK_MESSAGE(pck_packer->pck_start(output_pck_path, 32, "") != OK, "PCK with invalid key should fail.");
 	ERR_PRINT_ON;
 }
 
 TEST_CASE("[PCKPacker] Pack a PCK file with some files and directories") {
-	PCKPacker pck_packer;
+	Ref<PCKPacker> pck_packer;
+	pck_packer.instantiate();
+
 	const String output_pck_path = TestUtils::get_temp_path("output_with_files.pck");
 	CHECK_MESSAGE(
-			pck_packer.pck_start(output_pck_path) == OK,
+			pck_packer->pck_start(output_pck_path) == OK,
 			"Starting a PCK file should return an OK error code.");
 
 	const String base_dir = OS::get_singleton()->get_executable_path().get_base_dir();
 
 	CHECK_MESSAGE(
-			pck_packer.add_file("version.py", base_dir.path_join("../version.py"), "version.py") == OK,
+			pck_packer->add_file("version.py", base_dir.path_join("../version.py"), "version.py") == OK,
 			"Adding a file to the PCK should return an OK error code.");
 	CHECK_MESSAGE(
-			pck_packer.add_file("some/directories with spaces/to/create/icon.png", base_dir.path_join("../icon.png")) == OK,
+			pck_packer->add_file("some/directories with spaces/to/create/icon.png", base_dir.path_join("../icon.png")) == OK,
 			"Adding a file to a new subdirectory in the PCK should return an OK error code.");
 	CHECK_MESSAGE(
-			pck_packer.add_file("some/directories with spaces/to/create/icon.svg", base_dir.path_join("../icon.svg")) == OK,
+			pck_packer->add_file("some/directories with spaces/to/create/icon.svg", base_dir.path_join("../icon.svg")) == OK,
 			"Adding a file to an existing subdirectory in the PCK should return an OK error code.");
 	CHECK_MESSAGE(
-			pck_packer.add_file("some/directories with spaces/to/create/icon.png", base_dir.path_join("../logo.png")) == OK,
+			pck_packer->add_file("some/directories with spaces/to/create/icon.png", base_dir.path_join("../logo.png")) == OK,
 			"Overriding a non-flushed file to an existing subdirectory in the PCK should return an OK error code.");
 	CHECK_MESSAGE(
-			pck_packer.add_file_from_buffer("buffer/new.txt", String("Hello world!").to_utf8_buffer()) == OK,
+			pck_packer->add_file_from_buffer("buffer/new.txt", String("Hello world!").to_utf8_buffer()) == OK,
 			"Adding a file from a buffer to the PCK in a new subdirectory should return an OK error code.");
 	CHECK_MESSAGE(
-			pck_packer.flush() == OK,
+			pck_packer->flush() == OK,
 			"Flushing the PCK should return an OK error code.");
 
 	Error err;

--- a/tests/core/io/test_xml_parser.h
+++ b/tests/core/io/test_xml_parser.h
@@ -42,68 +42,71 @@ TEST_CASE("[XMLParser] End-to-end") {
 </top>";
 	Vector<uint8_t> buff = source.to_utf8_buffer();
 
-	XMLParser parser;
-	parser.open_buffer(buff);
+	Ref<XMLParser> parser;
+	parser.instantiate();
+
+	parser->open_buffer(buff);
 
 	// <?xml ...?> gets parsed as NODE_UNKNOWN
-	CHECK(parser.read() == OK);
-	CHECK(parser.get_node_type() == XMLParser::NodeType::NODE_UNKNOWN);
+	CHECK(parser->read() == OK);
+	CHECK(parser->get_node_type() == XMLParser::NodeType::NODE_UNKNOWN);
 
-	CHECK(parser.read() == OK);
-	CHECK(parser.get_node_type() == XMLParser::NodeType::NODE_ELEMENT);
-	CHECK(parser.get_node_name() == "top");
-	CHECK(parser.has_attribute("attr"));
-	CHECK(parser.get_named_attribute_value("attr") == "attr value");
+	CHECK(parser->read() == OK);
+	CHECK(parser->get_node_type() == XMLParser::NodeType::NODE_ELEMENT);
+	CHECK(parser->get_node_name() == "top");
+	CHECK(parser->has_attribute("attr"));
+	CHECK(parser->get_named_attribute_value("attr") == "attr value");
 
-	CHECK(parser.read() == OK);
-	CHECK(parser.get_node_type() == XMLParser::NodeType::NODE_TEXT);
-	CHECK(parser.get_node_data().lstrip(" \t") == "Text<AB>");
+	CHECK(parser->read() == OK);
+	CHECK(parser->get_node_type() == XMLParser::NodeType::NODE_TEXT);
+	CHECK(parser->get_node_data().lstrip(" \t") == "Text<AB>");
 
-	CHECK(parser.read() == OK);
-	CHECK(parser.get_node_type() == XMLParser::NodeType::NODE_ELEMENT_END);
-	CHECK(parser.get_node_name() == "top");
+	CHECK(parser->read() == OK);
+	CHECK(parser->get_node_type() == XMLParser::NodeType::NODE_ELEMENT_END);
+	CHECK(parser->get_node_name() == "top");
 
-	parser.close();
+	parser->close();
 }
 
 TEST_CASE("[XMLParser] Comments") {
-	XMLParser parser;
+	Ref<XMLParser> parser;
+	parser.instantiate();
 
 	SUBCASE("Missing end of comment") {
 		const String input = "<first></first><!-- foo";
-		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-		REQUIRE_EQ(parser.read(), OK);
-		REQUIRE_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
-		REQUIRE_EQ(parser.read(), OK);
-		REQUIRE_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
-		REQUIRE_EQ(parser.read(), OK);
-		CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_COMMENT);
-		CHECK_EQ(parser.get_node_name(), " foo");
+		REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser->read(), OK);
+		REQUIRE_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+		REQUIRE_EQ(parser->read(), OK);
+		REQUIRE_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
+		REQUIRE_EQ(parser->read(), OK);
+		CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_COMMENT);
+		CHECK_EQ(parser->get_node_name(), " foo");
 	}
 	SUBCASE("Bad start of comment") {
 		const String input = "<first></first><!-";
-		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-		REQUIRE_EQ(parser.read(), OK);
-		REQUIRE_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
-		REQUIRE_EQ(parser.read(), OK);
-		REQUIRE_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
-		REQUIRE_EQ(parser.read(), OK);
-		CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_COMMENT);
-		CHECK_EQ(parser.get_node_name(), "-");
+		REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser->read(), OK);
+		REQUIRE_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+		REQUIRE_EQ(parser->read(), OK);
+		REQUIRE_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
+		REQUIRE_EQ(parser->read(), OK);
+		CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_COMMENT);
+		CHECK_EQ(parser->get_node_name(), "-");
 	}
 	SUBCASE("Unblanced angle brackets in comment") {
 		const String input = "<!-- example << --><next-tag></next-tag>";
-		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-		REQUIRE_EQ(parser.read(), OK);
-		CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_COMMENT);
-		CHECK_EQ(parser.get_node_name(), " example << ");
+		REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser->read(), OK);
+		CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_COMMENT);
+		CHECK_EQ(parser->get_node_name(), " example << ");
 	}
 	SUBCASE("Doctype") {
 		const String input = "<!DOCTYPE greeting [<!ELEMENT greeting (#PCDATA)>]>";
-		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-		REQUIRE_EQ(parser.read(), OK);
-		CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_COMMENT);
-		CHECK_EQ(parser.get_node_name(), "DOCTYPE greeting [<!ELEMENT greeting (#PCDATA)>]");
+		REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser->read(), OK);
+		CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_COMMENT);
+		CHECK_EQ(parser->get_node_name(), "DOCTYPE greeting [<!ELEMENT greeting (#PCDATA)>]");
 	}
 }
 
@@ -139,94 +142,99 @@ TEST_CASE("[XMLParser] Premature endings") {
 			expected_name = "second";
 		}
 
-		XMLParser parser;
-		REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-		REQUIRE_EQ(parser.read(), OK);
-		REQUIRE_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
-		REQUIRE_EQ(parser.read(), OK);
-		REQUIRE_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
-		REQUIRE_EQ(parser.read(), OK);
-		CHECK_EQ(parser.get_node_type(), expected_type);
-		CHECK_EQ(parser.get_node_name(), expected_name);
+		Ref<XMLParser> parser;
+		parser.instantiate();
+
+		REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+		REQUIRE_EQ(parser->read(), OK);
+		REQUIRE_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+		REQUIRE_EQ(parser->read(), OK);
+		REQUIRE_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
+		REQUIRE_EQ(parser->read(), OK);
+		CHECK_EQ(parser->get_node_type(), expected_type);
+		CHECK_EQ(parser->get_node_name(), expected_name);
 	}
 
 	SUBCASE("With attributes and texts") {
-		XMLParser parser;
+		Ref<XMLParser> parser;
+		parser.instantiate();
 
 		SUBCASE("Incomplete start-tag attribute name") {
 			const String input = "<first></first><second attr1=\"foo\" attr2";
-			REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
-			CHECK_EQ(parser.get_node_name(), "second");
-			CHECK_EQ(parser.get_attribute_count(), 1);
-			CHECK_EQ(parser.get_attribute_name(0), "attr1");
-			CHECK_EQ(parser.get_attribute_value(0), "foo");
+			REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+			CHECK_EQ(parser->get_node_name(), "second");
+			CHECK_EQ(parser->get_attribute_count(), 1);
+			CHECK_EQ(parser->get_attribute_name(0), "attr1");
+			CHECK_EQ(parser->get_attribute_value(0), "foo");
 		}
 
 		SUBCASE("Incomplete start-tag attribute unquoted value") {
 			const String input = "<first></first><second attr1=\"foo\" attr2=bar";
-			REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
-			CHECK_EQ(parser.get_node_name(), "second");
-			CHECK_EQ(parser.get_attribute_count(), 1);
-			CHECK_EQ(parser.get_attribute_name(0), "attr1");
-			CHECK_EQ(parser.get_attribute_value(0), "foo");
+			REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+			CHECK_EQ(parser->get_node_name(), "second");
+			CHECK_EQ(parser->get_attribute_count(), 1);
+			CHECK_EQ(parser->get_attribute_name(0), "attr1");
+			CHECK_EQ(parser->get_attribute_value(0), "foo");
 		}
 
 		SUBCASE("Incomplete start-tag attribute quoted value") {
 			const String input = "<first></first><second attr1=\"foo\" attr2=\"bar";
-			REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
-			CHECK_EQ(parser.get_node_name(), "second");
-			CHECK_EQ(parser.get_attribute_count(), 2);
-			CHECK_EQ(parser.get_attribute_name(0), "attr1");
-			CHECK_EQ(parser.get_attribute_value(0), "foo");
-			CHECK_EQ(parser.get_attribute_name(1), "attr2");
-			CHECK_EQ(parser.get_attribute_value(1), "bar");
+			REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+			CHECK_EQ(parser->get_node_name(), "second");
+			CHECK_EQ(parser->get_attribute_count(), 2);
+			CHECK_EQ(parser->get_attribute_name(0), "attr1");
+			CHECK_EQ(parser->get_attribute_value(0), "foo");
+			CHECK_EQ(parser->get_attribute_name(1), "attr2");
+			CHECK_EQ(parser->get_attribute_value(1), "bar");
 		}
 
 		SUBCASE("Incomplete end-tag name") {
 			const String input = "<first></fir";
-			REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
-			CHECK_EQ(parser.get_node_name(), "fir");
+			REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
+			CHECK_EQ(parser->get_node_name(), "fir");
 		}
 
 		SUBCASE("Trailing text") {
 			const String input = "<first></first>example";
-			REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			REQUIRE_EQ(parser.read(), OK);
-			CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_TEXT);
-			CHECK_EQ(parser.get_node_data(), "example");
+			REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			REQUIRE_EQ(parser->read(), OK);
+			CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_TEXT);
+			CHECK_EQ(parser->get_node_data(), "example");
 		}
 	}
 }
 
 TEST_CASE("[XMLParser] CDATA") {
 	const String input = "<a><![CDATA[my cdata content goes here]]></a>";
-	XMLParser parser;
-	REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
-	REQUIRE_EQ(parser.read(), OK);
-	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
-	CHECK_EQ(parser.get_node_name(), "a");
-	REQUIRE_EQ(parser.read(), OK);
-	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_CDATA);
-	CHECK_EQ(parser.get_node_name(), "my cdata content goes here");
-	REQUIRE_EQ(parser.read(), OK);
-	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
-	CHECK_EQ(parser.get_node_name(), "a");
+	Ref<XMLParser> parser;
+	parser.instantiate();
+
+	REQUIRE_EQ(parser->open_buffer(input.to_utf8_buffer()), OK);
+	REQUIRE_EQ(parser->read(), OK);
+	CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+	CHECK_EQ(parser->get_node_name(), "a");
+	REQUIRE_EQ(parser->read(), OK);
+	CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_CDATA);
+	CHECK_EQ(parser->get_node_name(), "my cdata content goes here");
+	REQUIRE_EQ(parser->read(), OK);
+	CHECK_EQ(parser->get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
+	CHECK_EQ(parser->get_node_name(), "a");
 }
 } // namespace TestXMLParser

--- a/tests/core/math/test_astar.h
+++ b/tests/core/math/test_astar.h
@@ -66,8 +66,10 @@ public:
 };
 
 TEST_CASE("[AStar3D] ABC path") {
-	ABCX abcx;
-	Vector<int64_t> path = abcx.get_id_path(ABCX::A, ABCX::C);
+	Ref<ABCX> abcx;
+	abcx.instantiate();
+
+	Vector<int64_t> path = abcx->get_id_path(ABCX::A, ABCX::C);
 	REQUIRE(path.size() == 3);
 	CHECK(path[0] == ABCX::A);
 	CHECK(path[1] == ABCX::B);
@@ -75,8 +77,10 @@ TEST_CASE("[AStar3D] ABC path") {
 }
 
 TEST_CASE("[AStar3D] ABCX path") {
-	ABCX abcx;
-	Vector<int64_t> path = abcx.get_id_path(ABCX::X, ABCX::C);
+	Ref<ABCX> abcx;
+	abcx.instantiate();
+
+	Vector<int64_t> path = abcx->get_id_path(ABCX::X, ABCX::C);
 	REQUIRE(path.size() == 4);
 	CHECK(path[0] == ABCX::X);
 	CHECK(path[1] == ABCX::A);
@@ -85,61 +89,62 @@ TEST_CASE("[AStar3D] ABCX path") {
 }
 
 TEST_CASE("[AStar3D] Add/Remove") {
-	AStar3D a;
+	Ref<AStar3D> a;
+	a.instantiate();
 
 	// Manual tests.
-	a.add_point(1, Vector3(0, 0, 0));
-	a.add_point(2, Vector3(0, 1, 0));
-	a.add_point(3, Vector3(1, 1, 0));
-	a.add_point(4, Vector3(2, 0, 0));
-	a.connect_points(1, 2, true);
-	a.connect_points(1, 3, true);
-	a.connect_points(1, 4, false);
+	a->add_point(1, Vector3(0, 0, 0));
+	a->add_point(2, Vector3(0, 1, 0));
+	a->add_point(3, Vector3(1, 1, 0));
+	a->add_point(4, Vector3(2, 0, 0));
+	a->connect_points(1, 2, true);
+	a->connect_points(1, 3, true);
+	a->connect_points(1, 4, false);
 
-	CHECK(a.are_points_connected(2, 1));
-	CHECK(a.are_points_connected(4, 1));
-	CHECK(a.are_points_connected(2, 1, false));
-	CHECK_FALSE(a.are_points_connected(4, 1, false));
+	CHECK(a->are_points_connected(2, 1));
+	CHECK(a->are_points_connected(4, 1));
+	CHECK(a->are_points_connected(2, 1, false));
+	CHECK_FALSE(a->are_points_connected(4, 1, false));
 
-	a.disconnect_points(1, 2, true);
-	CHECK(a.get_point_connections(1).size() == 2); // 3, 4
-	CHECK(a.get_point_connections(2).size() == 0);
+	a->disconnect_points(1, 2, true);
+	CHECK(a->get_point_connections(1).size() == 2); // 3, 4
+	CHECK(a->get_point_connections(2).size() == 0);
 
-	a.disconnect_points(4, 1, false);
-	CHECK(a.get_point_connections(1).size() == 2); // 3, 4
-	CHECK(a.get_point_connections(4).size() == 0);
+	a->disconnect_points(4, 1, false);
+	CHECK(a->get_point_connections(1).size() == 2); // 3, 4
+	CHECK(a->get_point_connections(4).size() == 0);
 
-	a.disconnect_points(4, 1, true);
-	CHECK(a.get_point_connections(1).size() == 1); // 3
-	CHECK(a.get_point_connections(4).size() == 0);
+	a->disconnect_points(4, 1, true);
+	CHECK(a->get_point_connections(1).size() == 1); // 3
+	CHECK(a->get_point_connections(4).size() == 0);
 
-	a.connect_points(2, 3, false);
-	CHECK(a.get_point_connections(2).size() == 1); // 3
-	CHECK(a.get_point_connections(3).size() == 1); // 1
+	a->connect_points(2, 3, false);
+	CHECK(a->get_point_connections(2).size() == 1); // 3
+	CHECK(a->get_point_connections(3).size() == 1); // 1
 
-	a.connect_points(2, 3, true);
-	CHECK(a.get_point_connections(2).size() == 1); // 3
-	CHECK(a.get_point_connections(3).size() == 2); // 1, 2
+	a->connect_points(2, 3, true);
+	CHECK(a->get_point_connections(2).size() == 1); // 3
+	CHECK(a->get_point_connections(3).size() == 2); // 1, 2
 
-	a.disconnect_points(2, 3, false);
-	CHECK(a.get_point_connections(2).size() == 0);
-	CHECK(a.get_point_connections(3).size() == 2); // 1, 2
+	a->disconnect_points(2, 3, false);
+	CHECK(a->get_point_connections(2).size() == 0);
+	CHECK(a->get_point_connections(3).size() == 2); // 1, 2
 
-	a.connect_points(4, 3, true);
-	CHECK(a.get_point_connections(3).size() == 3); // 1, 2, 4
-	CHECK(a.get_point_connections(4).size() == 1); // 3
+	a->connect_points(4, 3, true);
+	CHECK(a->get_point_connections(3).size() == 3); // 1, 2, 4
+	CHECK(a->get_point_connections(4).size() == 1); // 3
 
-	a.disconnect_points(3, 4, false);
-	CHECK(a.get_point_connections(3).size() == 2); // 1, 2
-	CHECK(a.get_point_connections(4).size() == 1); // 3
+	a->disconnect_points(3, 4, false);
+	CHECK(a->get_point_connections(3).size() == 2); // 1, 2
+	CHECK(a->get_point_connections(4).size() == 1); // 3
 
-	a.remove_point(3);
-	CHECK(a.get_point_connections(1).size() == 0);
-	CHECK(a.get_point_connections(2).size() == 0);
-	CHECK(a.get_point_connections(4).size() == 0);
+	a->remove_point(3);
+	CHECK(a->get_point_connections(1).size() == 0);
+	CHECK(a->get_point_connections(2).size() == 0);
+	CHECK(a->get_point_connections(4).size() == 0);
 
-	a.add_point(0, Vector3(0, -1, 0));
-	a.add_point(3, Vector3(2, 1, 0));
+	a->add_point(0, Vector3(0, -1, 0));
+	a->add_point(3, Vector3(2, 1, 0));
 	// 0: (0, -1)
 	// 1: (0, 0)
 	// 2: (0, 1)
@@ -147,19 +152,19 @@ TEST_CASE("[AStar3D] Add/Remove") {
 	// 4: (2, 0)
 
 	// Tests for get_closest_position_in_segment.
-	a.connect_points(2, 3);
-	CHECK(a.get_closest_position_in_segment(Vector3(0.5, 0.5, 0)) == Vector3(0.5, 1, 0));
+	a->connect_points(2, 3);
+	CHECK(a->get_closest_position_in_segment(Vector3(0.5, 0.5, 0)) == Vector3(0.5, 1, 0));
 
-	a.connect_points(3, 4);
-	a.connect_points(0, 3);
-	a.connect_points(1, 4);
-	a.disconnect_points(1, 4, false);
-	a.disconnect_points(4, 3, false);
-	a.disconnect_points(3, 4, false);
+	a->connect_points(3, 4);
+	a->connect_points(0, 3);
+	a->connect_points(1, 4);
+	a->disconnect_points(1, 4, false);
+	a->disconnect_points(4, 3, false);
+	a->disconnect_points(3, 4, false);
 	// Remaining edges: <2, 3>, <0, 3>, <1, 4> (directed).
-	CHECK(a.get_closest_position_in_segment(Vector3(2, 0.5, 0)) == Vector3(1.75, 0.75, 0));
-	CHECK(a.get_closest_position_in_segment(Vector3(-1, 0.2, 0)) == Vector3(0, 0, 0));
-	CHECK(a.get_closest_position_in_segment(Vector3(3, 2, 0)) == Vector3(2, 1, 0));
+	CHECK(a->get_closest_position_in_segment(Vector3(2, 0.5, 0)) == Vector3(1.75, 0.75, 0));
+	CHECK(a->get_closest_position_in_segment(Vector3(-1, 0.2, 0)) == Vector3(0, 0, 0));
+	CHECK(a->get_closest_position_in_segment(Vector3(3, 2, 0)) == Vector3(2, 1, 0));
 
 	Math::seed(0);
 
@@ -172,20 +177,20 @@ TEST_CASE("[AStar3D] Add/Remove") {
 		}
 		if (Math::rand() % 2 == 1) {
 			// Add a (possibly existing) directed edge and confirm connectivity.
-			a.connect_points(u, v, false);
-			CHECK(a.are_points_connected(u, v, false));
+			a->connect_points(u, v, false);
+			CHECK(a->are_points_connected(u, v, false));
 		} else {
 			// Remove a (possibly nonexistent) directed edge and confirm disconnectivity.
-			a.disconnect_points(u, v, false);
-			CHECK_FALSE(a.are_points_connected(u, v, false));
+			a->disconnect_points(u, v, false);
+			CHECK_FALSE(a->are_points_connected(u, v, false));
 		}
 	}
 
 	// Random tests for point removal.
 	for (int i = 0; i < 20000; i++) {
-		a.clear();
+		a->clear();
 		for (int j = 0; j < 5; j++) {
-			a.add_point(j, Vector3(0, 0, 0));
+			a->add_point(j, Vector3(0, 0, 0));
 		}
 
 		// Add or remove random edges.
@@ -196,41 +201,43 @@ TEST_CASE("[AStar3D] Add/Remove") {
 				v = 4;
 			}
 			if (Math::rand() % 2 == 1) {
-				a.connect_points(u, v, false);
+				a->connect_points(u, v, false);
 			} else {
-				a.disconnect_points(u, v, false);
+				a->disconnect_points(u, v, false);
 			}
 		}
 
 		// Remove point 0.
-		a.remove_point(0);
+		a->remove_point(0);
 		// White box: this will check all edges remaining in the segments set.
 		for (int j = 1; j < 5; j++) {
-			CHECK_FALSE(a.are_points_connected(0, j, true));
+			CHECK_FALSE(a->are_points_connected(0, j, true));
 		}
 	}
 }
 
 TEST_CASE("[AStar3D] Path from disabled point is empty") {
-	AStar3D a;
+	Ref<AStar3D> a;
+	a.instantiate();
+
 	Vector3 p1(0, 0, 0);
 	Vector3 p2(0, 1, 0);
-	a.add_point(1, p1);
-	a.add_point(2, p2);
-	a.connect_points(1, 2);
+	a->add_point(1, p1);
+	a->add_point(2, p2);
+	a->connect_points(1, 2);
 
-	CHECK_EQ(a.get_id_path(1, 1), Vector<int64_t>{ 1 });
-	CHECK_EQ(a.get_id_path(1, 2), Vector<int64_t>{ 1, 2 });
+	CHECK_EQ(a->get_id_path(1, 1), Vector<int64_t>{ 1 });
+	CHECK_EQ(a->get_id_path(1, 2), Vector<int64_t>{ 1, 2 });
 
-	CHECK_EQ(a.get_point_path(1, 1), Vector<Vector3>{ p1 });
-	CHECK_EQ(a.get_point_path(1, 2), Vector<Vector3>{ p1, p2 });
+	CHECK_EQ(a->get_point_path(1, 1), Vector<Vector3>{ p1 });
+	CHECK_EQ(a->get_point_path(1, 2), Vector<Vector3>{ p1, p2 });
 
-	a.set_point_disabled(1, true);
+	a->set_point_disabled(1, true);
 
-	CHECK(a.get_id_path(1, 1).is_empty());
-	CHECK(a.get_id_path(1, 2).is_empty());
+	CHECK(a->get_id_path(1, 1).is_empty());
+	CHECK(a->get_id_path(1, 2).is_empty());
 
-	CHECK(a.get_point_path(1, 1).is_empty());
-	CHECK(a.get_point_path(1, 2).is_empty());
+	CHECK(a->get_point_path(1, 1).is_empty());
+	CHECK(a->get_point_path(1, 2).is_empty());
 }
 } // namespace TestAStar

--- a/tests/core/math/test_expression.h
+++ b/tests/core/math/test_expression.h
@@ -37,454 +37,464 @@
 namespace TestExpression {
 
 TEST_CASE("[Expression] Integer arithmetic") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	CHECK_MESSAGE(
-			expression.parse("-123456") == OK,
+			expression->parse("-123456") == OK,
 			"Integer identity should parse successfully.");
 	CHECK_MESSAGE(
-			int(expression.execute()) == -123456,
+			int(expression->execute()) == -123456,
 			"Integer identity should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("2 + 3") == OK,
+			expression->parse("2 + 3") == OK,
 			"Integer addition should parse successfully.");
 	CHECK_MESSAGE(
-			int(expression.execute()) == 5,
+			int(expression->execute()) == 5,
 			"Integer addition should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("999999999999 + 999999999999") == OK,
+			expression->parse("999999999999 + 999999999999") == OK,
 			"Large integer addition should parse successfully.");
 	CHECK_MESSAGE(
-			int64_t(expression.execute()) == 1'999'999'999'998,
+			int64_t(expression->execute()) == 1'999'999'999'998,
 			"Large integer addition should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("25 / 10") == OK,
+			expression->parse("25 / 10") == OK,
 			"Integer / integer division should parse successfully.");
 	CHECK_MESSAGE(
-			int(expression.execute()) == 2,
+			int(expression->execute()) == 2,
 			"Integer / integer division should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("2 * (6 + 14) / 2 - 5") == OK,
+			expression->parse("2 * (6 + 14) / 2 - 5") == OK,
 			"Integer multiplication-addition-subtraction-division should parse successfully.");
 	CHECK_MESSAGE(
-			int(expression.execute()) == 15,
+			int(expression->execute()) == 15,
 			"Integer multiplication-addition-subtraction-division should return the expected result.");
 }
 
 TEST_CASE("[Expression] Floating-point arithmetic") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	CHECK_MESSAGE(
-			expression.parse("-123.456") == OK,
+			expression->parse("-123.456") == OK,
 			"Float identity should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(-123.456),
+			double(expression->execute()) == doctest::Approx(-123.456),
 			"Float identity should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("2.0 + 3.0") == OK,
+			expression->parse("2.0 + 3.0") == OK,
 			"Float addition should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(5),
+			double(expression->execute()) == doctest::Approx(5),
 			"Float addition should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("3.0 / 10") == OK,
+			expression->parse("3.0 / 10") == OK,
 			"Float / integer division should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(0.3),
+			double(expression->execute()) == doctest::Approx(0.3),
 			"Float / integer division should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("3 / 10.0") == OK,
+			expression->parse("3 / 10.0") == OK,
 			"Basic integer / float division should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(0.3),
+			double(expression->execute()) == doctest::Approx(0.3),
 			"Basic integer / float division should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("3.0 / 10.0") == OK,
+			expression->parse("3.0 / 10.0") == OK,
 			"Float / float division should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(0.3),
+			double(expression->execute()) == doctest::Approx(0.3),
 			"Float / float division should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("2.5 * (6.0 + 14.25) / 2.0 - 5.12345") == OK,
+			expression->parse("2.5 * (6.0 + 14.25) / 2.0 - 5.12345") == OK,
 			"Float multiplication-addition-subtraction-division should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(20.18905),
+			double(expression->execute()) == doctest::Approx(20.18905),
 			"Float multiplication-addition-subtraction-division should return the expected result.");
 }
 
 TEST_CASE("[Expression] Floating-point notation") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	CHECK_MESSAGE(
-			expression.parse("2.") == OK,
+			expression->parse("2.") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(2.0),
+			double(expression->execute()) == doctest::Approx(2.0),
 			"The expression should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("(2.)") == OK,
+			expression->parse("(2.)") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(2.0),
+			double(expression->execute()) == doctest::Approx(2.0),
 			"The expression should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse(".3") == OK,
+			expression->parse(".3") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(0.3),
+			double(expression->execute()) == doctest::Approx(0.3),
 			"The expression should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("2.+5.") == OK,
+			expression->parse("2.+5.") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(7.0),
+			double(expression->execute()) == doctest::Approx(7.0),
 			"The expression should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse(".3-.8") == OK,
+			expression->parse(".3-.8") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(-0.5),
+			double(expression->execute()) == doctest::Approx(-0.5),
 			"The expression should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("2.+.2") == OK,
+			expression->parse("2.+.2") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(2.2),
+			double(expression->execute()) == doctest::Approx(2.2),
 			"The expression should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse(".0*0.") == OK,
+			expression->parse(".0*0.") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(0.0),
+			double(expression->execute()) == doctest::Approx(0.0),
 			"The expression should return the expected result.");
 }
 
 TEST_CASE("[Expression] Scientific notation") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	CHECK_MESSAGE(
-			expression.parse("2.e5") == OK,
+			expression->parse("2.e5") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			expression.parse("2.E5") == OK,
+			expression->parse("2.E5") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(200'000),
+			double(expression->execute()) == doctest::Approx(200'000),
 			"The expression should return the expected result.");
 
 	// The middle "e" is ignored here.
 	CHECK_MESSAGE(
-			expression.parse("2e5") == OK,
+			expression->parse("2e5") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(2e5),
+			double(expression->execute()) == doctest::Approx(2e5),
 			"The expression should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("2e.5") == OK,
+			expression->parse("2e.5") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(2),
+			double(expression->execute()) == doctest::Approx(2),
 			"The expression should return the expected result.");
 }
 
 TEST_CASE("[Expression] Underscored numeric literals") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	CHECK_MESSAGE(
-			expression.parse("1_000_000") == OK,
+			expression->parse("1_000_000") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			expression.parse("1_000.000") == OK,
+			expression->parse("1_000.000") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			expression.parse("0xff_99_00") == OK,
+			expression->parse("0xff_99_00") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			expression.parse("0Xff_99_00") == OK,
+			expression->parse("0Xff_99_00") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			expression.parse("0b10_11_00") == OK,
+			expression->parse("0b10_11_00") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			expression.parse("0B10_11_00") == OK,
+			expression->parse("0B10_11_00") == OK,
 			"The expression should parse successfully.");
 }
 
 TEST_CASE("[Expression] Built-in functions") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	CHECK_MESSAGE(
-			expression.parse("sqrt(pow(3, 2) + pow(4, 2))") == OK,
+			expression->parse("sqrt(pow(3, 2) + pow(4, 2))") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			int(expression.execute()) == 5,
+			int(expression->execute()) == 5,
 			"`sqrt(pow(3, 2) + pow(4, 2))` should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("snapped(sin(0.5), 0.01)") == OK,
+			expression->parse("snapped(sin(0.5), 0.01)") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			double(expression.execute()) == doctest::Approx(0.48),
+			double(expression->execute()) == doctest::Approx(0.48),
 			"`snapped(sin(0.5), 0.01)` should return the expected result.");
 
 	CHECK_MESSAGE(
-			expression.parse("pow(2.0, -2500)") == OK,
+			expression->parse("pow(2.0, -2500)") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_zero_approx(double(expression.execute())),
+			Math::is_zero_approx(double(expression->execute())),
 			"`pow(2.0, -2500)` should return the expected result (asymptotically zero).");
 }
 
 TEST_CASE("[Expression] Boolean expressions") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	CHECK_MESSAGE(
-			expression.parse("24 >= 12") == OK,
+			expression->parse("24 >= 12") == OK,
 			"The boolean expression should parse successfully.");
 	CHECK_MESSAGE(
-			bool(expression.execute()),
+			bool(expression->execute()),
 			"The boolean expression should evaluate to `true`.");
 
 	CHECK_MESSAGE(
-			expression.parse("1.0 < 1.25 && 1.25 < 2.0") == OK,
+			expression->parse("1.0 < 1.25 && 1.25 < 2.0") == OK,
 			"The boolean expression should parse successfully.");
 	CHECK_MESSAGE(
-			bool(expression.execute()),
+			bool(expression->execute()),
 			"The boolean expression should evaluate to `true`.");
 
 	CHECK_MESSAGE(
-			expression.parse("!2") == OK,
+			expression->parse("!2") == OK,
 			"The boolean expression should parse successfully.");
 	CHECK_MESSAGE(
-			!bool(expression.execute()),
+			!bool(expression->execute()),
 			"The boolean expression should evaluate to `false`.");
 
 	CHECK_MESSAGE(
-			expression.parse("!!2") == OK,
+			expression->parse("!!2") == OK,
 			"The boolean expression should parse successfully.");
 	CHECK_MESSAGE(
-			bool(expression.execute()),
+			bool(expression->execute()),
 			"The boolean expression should evaluate to `true`.");
 
 	CHECK_MESSAGE(
-			expression.parse("!0") == OK,
+			expression->parse("!0") == OK,
 			"The boolean expression should parse successfully.");
 	CHECK_MESSAGE(
-			bool(expression.execute()),
+			bool(expression->execute()),
 			"The boolean expression should evaluate to `true`.");
 
 	CHECK_MESSAGE(
-			expression.parse("!!0") == OK,
+			expression->parse("!!0") == OK,
 			"The boolean expression should parse successfully.");
 	CHECK_MESSAGE(
-			!bool(expression.execute()),
+			!bool(expression->execute()),
 			"The boolean expression should evaluate to `false`.");
 
 	CHECK_MESSAGE(
-			expression.parse("2 && 5") == OK,
+			expression->parse("2 && 5") == OK,
 			"The boolean expression should parse successfully.");
 	CHECK_MESSAGE(
-			bool(expression.execute()),
+			bool(expression->execute()),
 			"The boolean expression should evaluate to `true`.");
 
 	CHECK_MESSAGE(
-			expression.parse("0 || 0") == OK,
+			expression->parse("0 || 0") == OK,
 			"The boolean expression should parse successfully.");
 	CHECK_MESSAGE(
-			!bool(expression.execute()),
+			!bool(expression->execute()),
 			"The boolean expression should evaluate to `false`.");
 
 	CHECK_MESSAGE(
-			expression.parse("(2 <= 4) && (2 > 5)") == OK,
+			expression->parse("(2 <= 4) && (2 > 5)") == OK,
 			"The boolean expression should parse successfully.");
 	CHECK_MESSAGE(
-			!bool(expression.execute()),
+			!bool(expression->execute()),
 			"The boolean expression should evaluate to `false`.");
 }
 
 TEST_CASE("[Expression] Expressions with variables") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	PackedStringArray parameter_names = { "foo", "bar" };
 	CHECK_MESSAGE(
-			expression.parse("foo + bar + 50", parameter_names) == OK,
+			expression->parse("foo + bar + 50", parameter_names) == OK,
 			"The expression should parse successfully.");
 	Array values = { 60, 20 };
 	CHECK_MESSAGE(
-			int(expression.execute(values)) == 130,
+			int(expression->execute(values)) == 130,
 			"The expression should return the expected value.");
 
 	PackedStringArray parameter_names_invalid;
 	parameter_names_invalid.push_back("foo");
 	parameter_names_invalid.push_back("baz"); // Invalid parameter name.
 	CHECK_MESSAGE(
-			expression.parse("foo + bar + 50", parameter_names_invalid) == OK,
+			expression->parse("foo + bar + 50", parameter_names_invalid) == OK,
 			"The expression should parse successfully.");
 	Array values_invalid = { 60, 20 };
 	// Invalid parameters will parse successfully but print an error message when executing.
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			int(expression.execute(values_invalid)) == 0,
+			int(expression->execute(values_invalid)) == 0,
 			"The expression should return the expected value.");
 	ERR_PRINT_ON;
 
 	// Mismatched argument count (more values than parameters).
 	PackedStringArray parameter_names_mismatch = { "foo", "bar" };
 	CHECK_MESSAGE(
-			expression.parse("foo + bar + 50", parameter_names_mismatch) == OK,
+			expression->parse("foo + bar + 50", parameter_names_mismatch) == OK,
 			"The expression should parse successfully.");
 	Array values_mismatch = { 60, 20, 110 };
 	CHECK_MESSAGE(
-			int(expression.execute(values_mismatch)) == 130,
+			int(expression->execute(values_mismatch)) == 130,
 			"The expression should return the expected value.");
 
 	// Mismatched argument count (more parameters than values).
 	PackedStringArray parameter_names_mismatch2 = { "foo", "bar", "baz" };
 	CHECK_MESSAGE(
-			expression.parse("foo + bar + baz + 50", parameter_names_mismatch2) == OK,
+			expression->parse("foo + bar + baz + 50", parameter_names_mismatch2) == OK,
 			"The expression should parse successfully.");
 	Array values_mismatch2 = { 60, 20 };
 	// Having more parameters than values will parse successfully but print an
 	// error message when executing.
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			int(expression.execute(values_mismatch2)) == 0,
+			int(expression->execute(values_mismatch2)) == 0,
 			"The expression should return the expected value.");
 	ERR_PRINT_ON;
 }
 
 TEST_CASE("[Expression] Invalid expressions") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	CHECK_MESSAGE(
-			expression.parse("\\") == ERR_INVALID_PARAMETER,
+			expression->parse("\\") == ERR_INVALID_PARAMETER,
 			"The expression shouldn't parse successfully.");
 
 	CHECK_MESSAGE(
-			expression.parse("0++") == ERR_INVALID_PARAMETER,
+			expression->parse("0++") == ERR_INVALID_PARAMETER,
 			"The expression shouldn't parse successfully.");
 
 	CHECK_MESSAGE(
-			expression.parse("()") == ERR_INVALID_PARAMETER,
+			expression->parse("()") == ERR_INVALID_PARAMETER,
 			"The expression shouldn't parse successfully.");
 
 	CHECK_MESSAGE(
-			expression.parse("()()") == ERR_INVALID_PARAMETER,
+			expression->parse("()()") == ERR_INVALID_PARAMETER,
 			"The expression shouldn't parse successfully.");
 
 	CHECK_MESSAGE(
-			expression.parse("() - ()") == ERR_INVALID_PARAMETER,
+			expression->parse("() - ()") == ERR_INVALID_PARAMETER,
 			"The expression shouldn't parse successfully.");
 
 	CHECK_MESSAGE(
-			expression.parse("() * 12345") == ERR_INVALID_PARAMETER,
+			expression->parse("() * 12345") == ERR_INVALID_PARAMETER,
 			"The expression shouldn't parse successfully.");
 
 	CHECK_MESSAGE(
-			expression.parse("() * 12345") == ERR_INVALID_PARAMETER,
+			expression->parse("() * 12345") == ERR_INVALID_PARAMETER,
 			"The expression shouldn't parse successfully.");
 
 	CHECK_MESSAGE(
-			expression.parse("123'456") == ERR_INVALID_PARAMETER,
+			expression->parse("123'456") == ERR_INVALID_PARAMETER,
 			"The expression shouldn't parse successfully.");
 
 	CHECK_MESSAGE(
-			expression.parse("123\"456") == ERR_INVALID_PARAMETER,
+			expression->parse("123\"456") == ERR_INVALID_PARAMETER,
 			"The expression shouldn't parse successfully.");
 }
 
 TEST_CASE("[Expression] Unusual expressions") {
-	Expression expression;
+	Ref<Expression> expression;
+	expression.instantiate();
 
 	// Redundant parentheses don't cause a parse error as long as they're matched.
 	CHECK_MESSAGE(
-			expression.parse("(((((((((((((((666)))))))))))))))") == OK,
+			expression->parse("(((((((((((((((666)))))))))))))))") == OK,
 			"The expression should parse successfully.");
 
 	// Using invalid identifiers doesn't cause a parse error.
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			expression.parse("hello + hello") == OK,
+			expression->parse("hello + hello") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			int(expression.execute()) == 0,
+			int(expression->execute()) == 0,
 			"The expression should return the expected result.");
 	ERR_PRINT_ON;
 
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			expression.parse("$1.00 + ???5") == OK,
+			expression->parse("$1.00 + ???5") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			int(expression.execute()) == 0,
+			int(expression->execute()) == 0,
 			"The expression should return the expected result.");
 	ERR_PRINT_ON;
 
 	// Commas can't be used as a decimal parameter.
 	CHECK_MESSAGE(
-			expression.parse("123,456") == OK,
+			expression->parse("123,456") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			int(expression.execute()) == 123,
+			int(expression->execute()) == 123,
 			"The expression should return the expected result.");
 
 	// Spaces can't be used as a separator for large numbers.
 	CHECK_MESSAGE(
-			expression.parse("123 456") == OK,
+			expression->parse("123 456") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			int(expression.execute()) == 123,
+			int(expression->execute()) == 123,
 			"The expression should return the expected result.");
 
 	// Division by zero is accepted, even though it prints an error message normally.
 	CHECK_MESSAGE(
-			expression.parse("-25.4 / 0") == OK,
+			expression->parse("-25.4 / 0") == OK,
 			"The expression should parse successfully.");
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			Math::is_inf(double(expression.execute())),
+			Math::is_inf(double(expression->execute())),
 			"`-25.4 / 0` should return inf.");
 	ERR_PRINT_ON;
 
 	CHECK_MESSAGE(
-			expression.parse("0 / 0") == OK,
+			expression->parse("0 / 0") == OK,
 			"The expression should parse successfully.");
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			int(expression.execute()) == 0,
+			int(expression->execute()) == 0,
 			"`0 / 0` should return 0.");
 	ERR_PRINT_ON;
 
 	// The tests below currently crash the engine.
 	//
 	//CHECK_MESSAGE(
-	//		expression.parse("(-9223372036854775807 - 1) % -1") == OK,
+	//		expression->parse("(-9223372036854775807 - 1) % -1") == OK,
 	//		"The expression should parse successfully.");
 	//CHECK_MESSAGE(
-	//		int64_t(expression.execute()) == 0,
+	//		int64_t(expression->execute()) == 0,
 	//		"`(-9223372036854775807 - 1) % -1` should return the expected result.");
 	//
 	//CHECK_MESSAGE(
-	//		expression.parse("(-9223372036854775807 - 1) / -1") == OK,
+	//		expression->parse("(-9223372036854775807 - 1) / -1") == OK,
 	//		"The expression should parse successfully.");
 	//CHECK_MESSAGE(
-	//		int64_t(expression.execute()) == 0,
+	//		int64_t(expression->execute()) == 0,
 	//		"`(-9223372036854775807 - 1) / -1` should return the expected result.");
 }
 } // namespace TestExpression

--- a/tests/core/test_crypto.h
+++ b/tests/core/test_crypto.h
@@ -61,10 +61,12 @@ TEST_CASE("[Crypto] PackedByteArray constant time compare") {
 	const uint8_t hm2[] = { 80, 30, 144, 228, 108, 38, 188, 125, 150, 64, 165, 127, 221, 118, 144, 232, 45, 100, 15, 248, 193, 244, 245, 34, 116, 147, 132, 200, 110, 27, 38, 75 };
 	PackedByteArray p1 = raw_to_pba(hm1, std_size(hm1));
 	PackedByteArray p2 = raw_to_pba(hm2, std_size(hm2));
-	_MockCrypto crypto;
-	bool equal = crypto.constant_time_compare(p1, p1);
+	Ref<_MockCrypto> crypto;
+	crypto.instantiate();
+
+	bool equal = crypto->constant_time_compare(p1, p1);
 	CHECK(equal);
-	equal = crypto.constant_time_compare(p1, p2);
+	equal = crypto->constant_time_compare(p1, p2);
 	CHECK(!equal);
 }
 } // namespace TestCrypto

--- a/tests/core/test_hashing_context.h
+++ b/tests/core/test_hashing_context.h
@@ -37,7 +37,8 @@
 namespace TestHashingContext {
 
 TEST_CASE("[HashingContext] Default - MD5/SHA1/SHA256") {
-	HashingContext ctx;
+	Ref<HashingContext> ctx;
+	ctx.instantiate();
 
 	static const uint8_t md5_expected[] = {
 		0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04, 0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8, 0x42, 0x7e
@@ -51,24 +52,26 @@ TEST_CASE("[HashingContext] Default - MD5/SHA1/SHA256") {
 		0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55
 	};
 
-	CHECK(ctx.start(HashingContext::HASH_MD5) == OK);
-	PackedByteArray result = ctx.finish();
+	CHECK(ctx->start(HashingContext::HASH_MD5) == OK);
+	PackedByteArray result = ctx->finish();
 	REQUIRE(result.size() == 16);
 	CHECK(memcmp(result.ptr(), md5_expected, 16) == 0);
 
-	CHECK(ctx.start(HashingContext::HASH_SHA1) == OK);
-	result = ctx.finish();
+	CHECK(ctx->start(HashingContext::HASH_SHA1) == OK);
+	result = ctx->finish();
 	REQUIRE(result.size() == 20);
 	CHECK(memcmp(result.ptr(), sha1_expected, 20) == 0);
 
-	CHECK(ctx.start(HashingContext::HASH_SHA256) == OK);
-	result = ctx.finish();
+	CHECK(ctx->start(HashingContext::HASH_SHA256) == OK);
+	result = ctx->finish();
 	REQUIRE(result.size() == 32);
 	CHECK(memcmp(result.ptr(), sha256_expected, 32) == 0);
 }
 
 TEST_CASE("[HashingContext] Multiple updates - MD5/SHA1/SHA256") {
-	HashingContext ctx;
+	Ref<HashingContext> ctx;
+	ctx.instantiate();
+
 	const String s = "xyz";
 
 	const PackedByteArray s_byte_parts[] = {
@@ -89,73 +92,76 @@ TEST_CASE("[HashingContext] Multiple updates - MD5/SHA1/SHA256") {
 		0x98, 0x92, 0xc0, 0xb4, 0x2b, 0x86, 0xbb, 0xf1, 0xe7, 0x7a, 0x6f, 0xa1, 0x6c, 0x3c, 0x92, 0x82
 	};
 
-	CHECK(ctx.start(HashingContext::HASH_MD5) == OK);
-	CHECK(ctx.update(s_byte_parts[0]) == OK);
-	CHECK(ctx.update(s_byte_parts[1]) == OK);
-	CHECK(ctx.update(s_byte_parts[2]) == OK);
-	PackedByteArray result = ctx.finish();
+	CHECK(ctx->start(HashingContext::HASH_MD5) == OK);
+	CHECK(ctx->update(s_byte_parts[0]) == OK);
+	CHECK(ctx->update(s_byte_parts[1]) == OK);
+	CHECK(ctx->update(s_byte_parts[2]) == OK);
+	PackedByteArray result = ctx->finish();
 	REQUIRE(result.size() == 16);
 	CHECK(memcmp(result.ptr(), md5_expected, 16) == 0);
 
-	CHECK(ctx.start(HashingContext::HASH_SHA1) == OK);
-	CHECK(ctx.update(s_byte_parts[0]) == OK);
-	CHECK(ctx.update(s_byte_parts[1]) == OK);
-	CHECK(ctx.update(s_byte_parts[2]) == OK);
-	result = ctx.finish();
+	CHECK(ctx->start(HashingContext::HASH_SHA1) == OK);
+	CHECK(ctx->update(s_byte_parts[0]) == OK);
+	CHECK(ctx->update(s_byte_parts[1]) == OK);
+	CHECK(ctx->update(s_byte_parts[2]) == OK);
+	result = ctx->finish();
 	REQUIRE(result.size() == 20);
 	CHECK(memcmp(result.ptr(), sha1_expected, 20) == 0);
 
-	CHECK(ctx.start(HashingContext::HASH_SHA256) == OK);
-	CHECK(ctx.update(s_byte_parts[0]) == OK);
-	CHECK(ctx.update(s_byte_parts[1]) == OK);
-	CHECK(ctx.update(s_byte_parts[2]) == OK);
-	result = ctx.finish();
+	CHECK(ctx->start(HashingContext::HASH_SHA256) == OK);
+	CHECK(ctx->update(s_byte_parts[0]) == OK);
+	CHECK(ctx->update(s_byte_parts[1]) == OK);
+	CHECK(ctx->update(s_byte_parts[2]) == OK);
+	result = ctx->finish();
 	REQUIRE(result.size() == 32);
 	CHECK(memcmp(result.ptr(), sha256_expected, 32) == 0);
 }
 
 TEST_CASE("[HashingContext] Invalid use of start") {
-	HashingContext ctx;
+	Ref<HashingContext> ctx;
+	ctx.instantiate();
 
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			ctx.start(static_cast<HashingContext::HashType>(-1)) == ERR_UNAVAILABLE,
+			ctx->start(static_cast<HashingContext::HashType>(-1)) == ERR_UNAVAILABLE,
 			"Using invalid hash types should fail.");
 	ERR_PRINT_ON;
 
-	REQUIRE(ctx.start(HashingContext::HASH_MD5) == OK);
+	REQUIRE(ctx->start(HashingContext::HASH_MD5) == OK);
 
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			ctx.start(HashingContext::HASH_MD5) == ERR_ALREADY_IN_USE,
+			ctx->start(HashingContext::HASH_MD5) == ERR_ALREADY_IN_USE,
 			"Calling 'start' twice before 'finish' should fail.");
 	ERR_PRINT_ON;
 }
 
 TEST_CASE("[HashingContext] Invalid use of update") {
-	HashingContext ctx;
+	Ref<HashingContext> ctx;
+	ctx.instantiate();
 
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			ctx.update(PackedByteArray()) == ERR_UNCONFIGURED,
+			ctx->update(PackedByteArray()) == ERR_UNCONFIGURED,
 			"Calling 'update' before 'start' should fail.");
 	ERR_PRINT_ON;
 
-	REQUIRE(ctx.start(HashingContext::HASH_MD5) == OK);
+	REQUIRE(ctx->start(HashingContext::HASH_MD5) == OK);
 
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			ctx.update(PackedByteArray()) == FAILED,
+			ctx->update(PackedByteArray()) == FAILED,
 			"Calling 'update' with an empty byte array should fail.");
 	ERR_PRINT_ON;
 }
 
 TEST_CASE("[HashingContext] Invalid use of finish") {
-	HashingContext ctx;
+	Ref<HashingContext> ctx;
+	ctx.instantiate();
 
 	ERR_PRINT_OFF;
 	CHECK_MESSAGE(
-			ctx.finish() == PackedByteArray(),
+			ctx->finish() == PackedByteArray(),
 			"Calling 'finish' before 'start' should return an empty byte array.");
 	ERR_PRINT_ON;
 }

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -274,14 +274,15 @@ TEST_CASE("[Variant] Assignment To Bool from Int,Float,String,Vec2,Vec2i,Vec3,Ve
 	rid_v = bool_v;
 	CHECK(rid_v.get_type() == Variant::BOOL);
 
-	Object obj_one = Object();
-	Variant object_v = &obj_one;
+	Object *obj_one = memnew(Object);
+	Variant object_v = obj_one;
 	bool_v = true;
 	object_v = bool_v;
 	CHECK(object_v == Variant(true));
 	bool_v = false;
 	object_v = bool_v;
 	CHECK(object_v.get_type() == Variant::BOOL);
+	memdelete(obj_one);
 }
 
 TEST_CASE("[Variant] Assignment To Int from Bool,Float,String,Vec2,Vec2i,Vec3,Vec3i Vec4,Vec4i,Rect2,Rect2i,Trans2d,Trans3d,Color,Call,Plane,Basis,AABB,Quant,Proj,RID,and Object") {
@@ -453,14 +454,15 @@ TEST_CASE("[Variant] Assignment To Int from Bool,Float,String,Vec2,Vec2i,Vec3,Ve
 	rid_v = int_v;
 	CHECK(rid_v.get_type() == Variant::INT);
 
-	Object obj_one = Object();
-	Variant object_v = &obj_one;
+	Object *obj_one = memnew(Object);
+	Variant object_v = obj_one;
 	int_v = 2;
 	object_v = int_v;
 	CHECK(object_v == Variant(2));
 	int_v = -3;
 	object_v = int_v;
 	CHECK(object_v.get_type() == Variant::INT);
+	memdelete(obj_one);
 }
 
 TEST_CASE("[Variant] Assignment To Float from Bool,Int,String,Vec2,Vec2i,Vec3,Vec3i,Vec4,Vec4i,Rect2,Rect2i,Trans2d,Trans3d,Color,Call,Plane,Basis,AABB,Quant,Proj,RID,and Object") {
@@ -632,14 +634,15 @@ TEST_CASE("[Variant] Assignment To Float from Bool,Int,String,Vec2,Vec2i,Vec3,Ve
 	rid_v = float_v;
 	CHECK(rid_v.get_type() == Variant::FLOAT);
 
-	Object obj_one = Object();
-	Variant object_v = &obj_one;
+	Object *obj_one = memnew(Object);
+	Variant object_v = obj_one;
 	float_v = 1.5f;
 	object_v = float_v;
 	CHECK(object_v == Variant(1.5f));
 	float_v = -4.6f;
 	object_v = float_v;
 	CHECK(object_v.get_type() == Variant::FLOAT);
+	memdelete(obj_one);
 }
 
 TEST_CASE("[Variant] Assignment To String from Bool,Int,Float,Vec2,Vec2i,Vec3,Vec3i,Vec4,Vec4i,Rect2,Rect2i,Trans2d,Trans3d,Color,Call,Plane,Basis,AABB,Quant,Proj,RID,and Object") {
@@ -811,14 +814,15 @@ TEST_CASE("[Variant] Assignment To String from Bool,Int,Float,Vec2,Vec2i,Vec3,Ve
 	rid_v = string_v;
 	CHECK(rid_v.get_type() == Variant::STRING);
 
-	Object obj_one = Object();
-	Variant object_v = &obj_one;
+	Object *obj_one = memnew(Object);
+	Variant object_v = obj_one;
 	string_v = "Hello";
 	object_v = string_v;
 	CHECK(object_v == Variant("Hello"));
 	string_v = "Hello there";
 	object_v = string_v;
 	CHECK(object_v.get_type() == Variant::STRING);
+	memdelete(obj_one);
 }
 
 TEST_CASE("[Variant] Assignment To Vec2 from Bool,Int,Float,String,Vec2i,Vec3,Vec3i,Vec4,Vec4i,Rect2,Rect2i,Trans2d,Trans3d,Color,Call,Plane,Basis,AABB,Quant,Proj,RID,and Object") {
@@ -990,14 +994,15 @@ TEST_CASE("[Variant] Assignment To Vec2 from Bool,Int,Float,String,Vec2i,Vec3,Ve
 	rid_v = vec2_v;
 	CHECK(rid_v.get_type() == Variant::VECTOR2);
 
-	Object obj_one = Object();
-	Variant object_v = &obj_one;
+	Object *obj_one = memnew(Object);
+	Variant object_v = obj_one;
 	vec2_v = Vector2(2.2f, 3.5f);
 	object_v = vec2_v;
 	CHECK(object_v == Variant(Vector2(2.2f, 3.5f)));
 	vec2_v = Vector2(-5.4f, -7.9f);
 	object_v = vec2_v;
 	CHECK(object_v.get_type() == Variant::VECTOR2);
+	memdelete(obj_one);
 }
 
 TEST_CASE("[Variant] Assignment To Vec2i from Bool,Int,Float,String,Vec2,Vec3,Vec3i,Vec4,Vec4i,Rect2,Rect2i,Trans2d,Trans3d,Color,Call,Plane,Basis,AABB,Quant,Proj,RID,and Object") {
@@ -1169,14 +1174,15 @@ TEST_CASE("[Variant] Assignment To Vec2i from Bool,Int,Float,String,Vec2,Vec3,Ve
 	rid_v = vec2i_v;
 	CHECK(rid_v.get_type() == Variant::VECTOR2I);
 
-	Object obj_one = Object();
-	Variant object_v = &obj_one;
+	Object *obj_one = memnew(Object);
+	Variant object_v = obj_one;
 	vec2i_v = Vector2i(2, 3);
 	object_v = vec2i_v;
 	CHECK(object_v == Variant(Vector2i(2, 3)));
 	vec2i_v = Vector2i(-5, -7);
 	object_v = vec2i_v;
 	CHECK(object_v.get_type() == Variant::VECTOR2I);
+	memdelete(obj_one);
 }
 
 TEST_CASE("[Variant] Assignment To Vec3 from Bool,Int,Float,String,Vec2,Vec2i,Vec3i,Vec4,Vec4i,Rect2,Rect2i,Trans2d,Trans3d,Color,Call,Plane,Basis,AABB,Quant,Proj,RID,and Object") {
@@ -1348,14 +1354,15 @@ TEST_CASE("[Variant] Assignment To Vec3 from Bool,Int,Float,String,Vec2,Vec2i,Ve
 	rid_v = vec3_v;
 	CHECK(rid_v.get_type() == Variant::VECTOR3);
 
-	Object obj_one = Object();
-	Variant object_v = &obj_one;
+	Object *obj_one = memnew(Object);
+	Variant object_v = obj_one;
 	vec3_v = Vector3(2.2f, 3.5f, 5.3f);
 	object_v = vec3_v;
 	CHECK(object_v == Variant(Vector3(2.2f, 3.5f, 5.3f)));
 	vec3_v = Vector3(-5.4f, -7.9f, -2.1f);
 	object_v = vec3_v;
 	CHECK(object_v.get_type() == Variant::VECTOR3);
+	memdelete(obj_one);
 }
 
 TEST_CASE("[Variant] Assignment To Vec3i from Bool,Int,Float,String,Vec2,Vec2i,Vec3 and Color") {
@@ -1527,14 +1534,15 @@ TEST_CASE("[Variant] Assignment To Vec3i from Bool,Int,Float,String,Vec2,Vec2i,V
 	rid_v = vec3i_v;
 	CHECK(rid_v.get_type() == Variant::VECTOR3I);
 
-	Object obj_one = Object();
-	Variant object_v = &obj_one;
+	Object *obj_one = memnew(Object);
+	Variant object_v = obj_one;
 	vec3i_v = Vector3i(2, 3, 5);
 	object_v = vec3i_v;
 	CHECK(object_v == Variant(Vector3i(2, 3, 5)));
 	vec3i_v = Vector3i(-5, -7, -2);
 	object_v = vec3i_v;
 	CHECK(object_v.get_type() == Variant::VECTOR3I);
+	memdelete(obj_one);
 }
 
 TEST_CASE("[Variant] Assignment To Color from Bool,Int,Float,String,Vec2,Vec2i,Vec3,Vec3i,Vec4,Vec4i,Rect2,Rect2i,Trans2d,Trans3d,Color,Call,Plane,Basis,AABB,Quant,Proj,RID,and Object") {
@@ -1706,14 +1714,15 @@ TEST_CASE("[Variant] Assignment To Color from Bool,Int,Float,String,Vec2,Vec2i,V
 	rid_v = col_v;
 	CHECK(rid_v.get_type() == Variant::COLOR);
 
-	Object obj_one = Object();
-	Variant object_v = &obj_one;
+	Object *obj_one = memnew(Object);
+	Variant object_v = obj_one;
 	col_v = Color(0.25f, 0.4f, 0.78f);
 	object_v = col_v;
 	CHECK(object_v == Variant(Color(0.25f, 0.4f, 0.78f)));
 	col_v = Color(0.33f, 0.75f, 0.21f);
 	object_v = col_v;
 	CHECK(object_v.get_type() == Variant::COLOR);
+	memdelete(obj_one);
 }
 
 TEST_CASE("[Variant] array initializer list") {
@@ -2103,24 +2112,26 @@ TEST_CASE("[Variant] Identity comparison") {
 	CHECK(packed_vector3_array.identity_compare(packed_vector3_array));
 	CHECK_FALSE(packed_vector3_array.identity_compare(PackedVector3Array()));
 
-	Object obj_one = Object();
-	Variant obj_one_var = &obj_one;
-	Object obj_two = Object();
-	Variant obj_two_var = &obj_two;
+	Object *obj_one = memnew(Object);
+	Variant obj_one_var = obj_one;
+	Object *obj_two = memnew(Object);
+	Variant obj_two_var = obj_two;
 	CHECK(obj_one_var.identity_compare(obj_one_var));
 	CHECK_FALSE(obj_one_var.identity_compare(obj_two_var));
+	memdelete(obj_two);
+	memdelete(obj_one);
 
 	Variant obj_null_one_var = Variant((Object *)nullptr);
 	Variant obj_null_two_var = Variant((Object *)nullptr);
 	CHECK(obj_null_one_var.identity_compare(obj_null_one_var));
 	CHECK(obj_null_one_var.identity_compare(obj_null_two_var));
 
-	Object *freed_one = new Object();
+	Object *freed_one = memnew(Object);
 	Variant freed_one_var = freed_one;
-	delete freed_one;
-	Object *freed_two = new Object();
+	memdelete(freed_one);
+	Object *freed_two = memnew(Object);
 	Variant freed_two_var = freed_two;
-	delete freed_two;
+	memdelete(freed_two);
 	CHECK_FALSE(freed_one_var.identity_compare(freed_two_var));
 }
 

--- a/tests/scene/test_bit_map.h
+++ b/tests/scene/test_bit_map.h
@@ -36,54 +36,58 @@
 
 namespace TestBitmap {
 
-void reset_bit_map(BitMap &p_bm) {
-	Size2i size = p_bm.get_size();
-	p_bm.set_bit_rect(Rect2i(0, 0, size.width, size.height), false);
+void reset_bit_map(Ref<BitMap> &p_bm) {
+	Size2i size = p_bm->get_size();
+	p_bm->set_bit_rect(Rect2i(0, 0, size.width, size.height), false);
 }
 
 TEST_CASE("[BitMap] Create bit map") {
 	Size2i dim{ 256, 512 };
-	BitMap bit_map{};
-	bit_map.create(dim);
-	CHECK(bit_map.get_size() == Size2i(256, 512));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "This will go through the entire bitmask inside of bitmap, thus hopefully checking if the bitmask was correctly set up.");
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
+
+	bit_map->create(dim);
+	CHECK(bit_map->get_size() == Size2i(256, 512));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 0, "This will go through the entire bitmask inside of bitmap, thus hopefully checking if the bitmask was correctly set up.");
 
 	ERR_PRINT_OFF
 
 	dim = Size2i(0, 256);
-	bit_map.create(dim);
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(256, 512), "We should still have the same dimensions as before, because the new dimension is invalid.");
+	bit_map->create(dim);
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(256, 512), "We should still have the same dimensions as before, because the new dimension is invalid.");
 
 	dim = Size2i(512, 0);
-	bit_map.create(dim);
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(256, 512), "We should still have the same dimensions as before, because the new dimension is invalid.");
+	bit_map->create(dim);
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(256, 512), "We should still have the same dimensions as before, because the new dimension is invalid.");
 
 	dim = Size2i(46341, 46341);
-	bit_map.create(dim);
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(256, 512), "We should still have the same dimensions as before, because the new dimension is too large (46341*46341=2147488281).");
+	bit_map->create(dim);
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(256, 512), "We should still have the same dimensions as before, because the new dimension is too large (46341*46341=2147488281).");
 
 	ERR_PRINT_ON
 }
 
 TEST_CASE("[BitMap] Create bit map from image alpha") {
 	const Size2i dim{ 256, 256 };
-	BitMap bit_map{};
-	bit_map.create(dim);
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
+
+	bit_map->create(dim);
 
 	ERR_PRINT_OFF
 
 	const Ref<Image> null_img = nullptr;
-	bit_map.create_from_image_alpha(null_img);
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(256, 256), "Bitmap should have its old values because bitmap creation from a nullptr should fail.");
+	bit_map->create_from_image_alpha(null_img);
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(256, 256), "Bitmap should have its old values because bitmap creation from a nullptr should fail.");
 
 	Ref<Image> empty_img;
 	empty_img.instantiate();
-	bit_map.create_from_image_alpha(empty_img);
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(256, 256), "Bitmap should have its old values because bitmap creation from an empty image should fail.");
+	bit_map->create_from_image_alpha(empty_img);
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(256, 256), "Bitmap should have its old values because bitmap creation from an empty image should fail.");
 
 	Ref<Image> wrong_format_img = Image::create_empty(3, 3, false, Image::Format::FORMAT_DXT1);
-	bit_map.create_from_image_alpha(wrong_format_img);
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(256, 256), "Bitmap should have its old values because converting from a compressed image should fail.");
+	bit_map->create_from_image_alpha(wrong_format_img);
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(256, 256), "Bitmap should have its old values because converting from a compressed image should fail.");
 
 	ERR_PRINT_ON
 
@@ -97,78 +101,81 @@ TEST_CASE("[BitMap] Create bit map from image alpha") {
 	img->set_pixel(2, 0, Color(0, 0, 0, 1.f));
 
 	// Check different threshold values.
-	bit_map.create_from_image_alpha(img);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 5, "There are 5 values in the image that are smaller than the default threshold of 0.1.");
+	bit_map->create_from_image_alpha(img);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 5, "There are 5 values in the image that are smaller than the default threshold of 0.1.");
 
-	bit_map.create_from_image_alpha(img, 0.08f);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 6, "There are 6 values in the image that are smaller than the threshold of 0.08.");
+	bit_map->create_from_image_alpha(img, 0.08f);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 6, "There are 6 values in the image that are smaller than the threshold of 0.08.");
 
-	bit_map.create_from_image_alpha(img, 1);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "There are no values in the image that are smaller than the threshold of 1, there is one value equal to 1, but we check for inequality only.");
+	bit_map->create_from_image_alpha(img, 1);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 0, "There are no values in the image that are smaller than the threshold of 1, there is one value equal to 1, but we check for inequality only.");
 }
 
 TEST_CASE("[BitMap] Set bit") {
 	Size2i dim{ 256, 256 };
-	BitMap bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
 
 	// Setting a point before a bit map is created should not crash, because there are checks to see if we are out of bounds.
 	ERR_PRINT_OFF
 
-	bit_map.set_bitv(Point2i(128, 128), true);
+	bit_map->set_bitv(Point2i(128, 128), true);
 
-	bit_map.create(dim);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "All values should be initialized to false.");
-	bit_map.set_bitv(Point2i(128, 128), true);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 1, "One bit should be set to true.");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(128, 128)) == true, "The bit at (128,128) should be set to true");
+	bit_map->create(dim);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 0, "All values should be initialized to false.");
+	bit_map->set_bitv(Point2i(128, 128), true);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 1, "One bit should be set to true.");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(128, 128)) == true, "The bit at (128,128) should be set to true");
 
-	bit_map.set_bitv(Point2i(128, 128), false);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "The bit should now be set to false again");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(128, 128)) == false, "The bit at (128,128) should now be set to false again");
+	bit_map->set_bitv(Point2i(128, 128), false);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 0, "The bit should now be set to false again");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(128, 128)) == false, "The bit at (128,128) should now be set to false again");
 
-	bit_map.create(dim);
-	bit_map.set_bitv(Point2i(512, 512), true);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "Nothing should change as we were trying to edit a bit outside of the correct range.");
+	bit_map->create(dim);
+	bit_map->set_bitv(Point2i(512, 512), true);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 0, "Nothing should change as we were trying to edit a bit outside of the correct range.");
 
 	ERR_PRINT_ON
 }
 
 TEST_CASE("[BitMap] Get bit") {
 	const Size2i dim{ 256, 256 };
-	BitMap bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
 
 	ERR_PRINT_OFF
 
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(128, 128)) == false, "Trying to access a bit outside of the BitMap's range should always return false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(128, 128)) == false, "Trying to access a bit outside of the BitMap's range should always return false");
 
-	bit_map.create(dim);
-	CHECK(bit_map.get_bitv(Point2i(128, 128)) == false);
+	bit_map->create(dim);
+	CHECK(bit_map->get_bitv(Point2i(128, 128)) == false);
 
-	bit_map.set_bit_rect(Rect2i(-1, -1, 257, 257), true);
+	bit_map->set_bit_rect(Rect2i(-1, -1, 257, 257), true);
 
 	// Checking that range is [0, 256).
-	CHECK(bit_map.get_bitv(Point2i(-1, 0)) == false);
-	CHECK(bit_map.get_bitv(Point2i(0, 0)) == true);
-	CHECK(bit_map.get_bitv(Point2i(128, 128)) == true);
-	CHECK(bit_map.get_bitv(Point2i(255, 255)) == true);
-	CHECK(bit_map.get_bitv(Point2i(256, 256)) == false);
-	CHECK(bit_map.get_bitv(Point2i(257, 257)) == false);
+	CHECK(bit_map->get_bitv(Point2i(-1, 0)) == false);
+	CHECK(bit_map->get_bitv(Point2i(0, 0)) == true);
+	CHECK(bit_map->get_bitv(Point2i(128, 128)) == true);
+	CHECK(bit_map->get_bitv(Point2i(255, 255)) == true);
+	CHECK(bit_map->get_bitv(Point2i(256, 256)) == false);
+	CHECK(bit_map->get_bitv(Point2i(257, 257)) == false);
 
 	ERR_PRINT_ON
 }
 
 TEST_CASE("[BitMap] Set bit rect") {
 	const Size2i dim{ 256, 256 };
-	BitMap bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
 
 	// Although we have not setup the BitMap yet, this should not crash because we get an empty intersection inside of the method.
-	bit_map.set_bit_rect(Rect2i{ 0, 0, 128, 128 }, true);
+	bit_map->set_bit_rect(Rect2i{ 0, 0, 128, 128 }, true);
 
-	bit_map.create(dim);
-	CHECK(bit_map.get_true_bit_count() == 0);
+	bit_map->create(dim);
+	CHECK(bit_map->get_true_bit_count() == 0);
 
-	bit_map.set_bit_rect(Rect2i{ 0, 0, 256, 256 }, true);
-	CHECK(bit_map.get_true_bit_count() == 65536);
+	bit_map->set_bit_rect(Rect2i{ 0, 0, 256, 256 }, true);
+	CHECK(bit_map->get_true_bit_count() == 65536);
 
 	reset_bit_map(bit_map);
 
@@ -176,176 +183,181 @@ TEST_CASE("[BitMap] Set bit rect") {
 
 	ERR_PRINT_OFF
 
-	bit_map.set_bit_rect(Rect2i{ 128, 128, 256, 256 }, true);
-	CHECK(bit_map.get_true_bit_count() == 16384);
+	bit_map->set_bit_rect(Rect2i{ 128, 128, 256, 256 }, true);
+	CHECK(bit_map->get_true_bit_count() == 16384);
 
 	reset_bit_map(bit_map);
 
-	bit_map.set_bit_rect(Rect2i{ -128, -128, 256, 256 }, true);
-	CHECK(bit_map.get_true_bit_count() == 16384);
+	bit_map->set_bit_rect(Rect2i{ -128, -128, 256, 256 }, true);
+	CHECK(bit_map->get_true_bit_count() == 16384);
 
 	reset_bit_map(bit_map);
 
-	bit_map.set_bit_rect(Rect2i{ -128, -128, 512, 512 }, true);
-	CHECK(bit_map.get_true_bit_count() == 65536);
+	bit_map->set_bit_rect(Rect2i{ -128, -128, 512, 512 }, true);
+	CHECK(bit_map->get_true_bit_count() == 65536);
 
 	ERR_PRINT_ON
 }
 
 TEST_CASE("[BitMap] Get true bit count") {
 	const Size2i dim{ 256, 256 };
-	BitMap bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
 
-	CHECK(bit_map.get_true_bit_count() == 0);
+	CHECK(bit_map->get_true_bit_count() == 0);
 
-	bit_map.create(dim);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "Uninitialized bit map should have no true bits");
-	bit_map.set_bit_rect(Rect2i{ 0, 0, 256, 256 }, true);
-	CHECK(bit_map.get_true_bit_count() == 65536);
-	bit_map.set_bitv(Point2i{ 0, 0 }, false);
-	CHECK(bit_map.get_true_bit_count() == 65535);
-	bit_map.set_bit_rect(Rect2i{ 0, 0, 256, 256 }, false);
-	CHECK(bit_map.get_true_bit_count() == 0);
+	bit_map->create(dim);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 0, "Uninitialized bit map should have no true bits");
+	bit_map->set_bit_rect(Rect2i{ 0, 0, 256, 256 }, true);
+	CHECK(bit_map->get_true_bit_count() == 65536);
+	bit_map->set_bitv(Point2i{ 0, 0 }, false);
+	CHECK(bit_map->get_true_bit_count() == 65535);
+	bit_map->set_bit_rect(Rect2i{ 0, 0, 256, 256 }, false);
+	CHECK(bit_map->get_true_bit_count() == 0);
 }
 
 TEST_CASE("[BitMap] Get size") {
 	const Size2i dim{ 256, 256 };
-	BitMap bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
 
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(0, 0), "Uninitialized bit map should have a size of 0x0");
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(0, 0), "Uninitialized bit map should have a size of 0x0");
 
-	bit_map.create(dim);
-	CHECK(bit_map.get_size() == Size2i(256, 256));
+	bit_map->create(dim);
+	CHECK(bit_map->get_size() == Size2i(256, 256));
 
 	ERR_PRINT_OFF
-	bit_map.create(Size2i(-1, 0));
+	bit_map->create(Size2i(-1, 0));
 	ERR_PRINT_ON
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(256, 256), "Invalid size should not be accepted by create");
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(256, 256), "Invalid size should not be accepted by create");
 
-	bit_map.create(Size2i(256, 128));
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(256, 128), "Bitmap should have updated size");
+	bit_map->create(Size2i(256, 128));
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(256, 128), "Bitmap should have updated size");
 }
 
 TEST_CASE("[BitMap] Resize") {
 	const Size2i dim{ 128, 128 };
-	BitMap bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
 
-	bit_map.resize(dim);
-	CHECK(bit_map.get_size() == dim);
+	bit_map->resize(dim);
+	CHECK(bit_map->get_size() == dim);
 
-	bit_map.create(dim);
-	bit_map.set_bit_rect(Rect2i(0, 0, 10, 10), true);
-	bit_map.set_bit_rect(Rect2i(118, 118, 10, 10), true);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 200, "There should be 100 bits in the top left corner, and 100 bits in the bottom right corner");
-	bit_map.resize(Size2i(64, 64));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 50, "There should be 25 bits in the top left corner, and 25 bits in the bottom right corner");
+	bit_map->create(dim);
+	bit_map->set_bit_rect(Rect2i(0, 0, 10, 10), true);
+	bit_map->set_bit_rect(Rect2i(118, 118, 10, 10), true);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 200, "There should be 100 bits in the top left corner, and 100 bits in the bottom right corner");
+	bit_map->resize(Size2i(64, 64));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 50, "There should be 25 bits in the top left corner, and 25 bits in the bottom right corner");
 
-	bit_map.create(dim);
+	bit_map->create(dim);
 	ERR_PRINT_OFF
-	bit_map.resize(Size2i(-1, 128));
+	bit_map->resize(Size2i(-1, 128));
 	ERR_PRINT_ON
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(128, 128), "When an invalid size is given the bit map will keep its size");
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(128, 128), "When an invalid size is given the bit map will keep its size");
 
-	bit_map.create(dim);
-	bit_map.set_bit_rect(Rect2i(0, 0, 10, 10), true);
-	bit_map.set_bit_rect(Rect2i(118, 118, 10, 10), true);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 200, "There should be 100 bits in the top left corner, and 100 bits in the bottom right corner");
-	bit_map.resize(Size2i(256, 256));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 800, "There should still be 100 bits in the bottom right corner, and all new bits should be initialized to false");
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(256, 256), "The bitmap should now be 256x256");
+	bit_map->create(dim);
+	bit_map->set_bit_rect(Rect2i(0, 0, 10, 10), true);
+	bit_map->set_bit_rect(Rect2i(118, 118, 10, 10), true);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 200, "There should be 100 bits in the top left corner, and 100 bits in the bottom right corner");
+	bit_map->resize(Size2i(256, 256));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 800, "There should still be 100 bits in the bottom right corner, and all new bits should be initialized to false");
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(256, 256), "The bitmap should now be 256x256");
 }
 
 TEST_CASE("[BitMap] Grow and shrink mask") {
 	const Size2i dim{ 256, 256 };
-	BitMap bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
+
 	ERR_PRINT_OFF
-	bit_map.grow_mask(100, Rect2i(0, 0, 128, 128)); // Check if method does not crash when working with an uninitialized bit map.
+	bit_map->grow_mask(100, Rect2i(0, 0, 128, 128)); // Check if method does not crash when working with an uninitialized bit map.
 	ERR_PRINT_ON
-	CHECK_MESSAGE(bit_map.get_size() == Size2i(0, 0), "Size should still be equal to 0x0");
+	CHECK_MESSAGE(bit_map->get_size() == Size2i(0, 0), "Size should still be equal to 0x0");
 
-	bit_map.create(dim);
+	bit_map->create(dim);
 
-	bit_map.set_bit_rect(Rect2i(96, 96, 64, 64), true);
+	bit_map->set_bit_rect(Rect2i(96, 96, 64, 64), true);
 
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 4096, "Creating a square of 64x64 should be 4096 bits");
-	bit_map.grow_mask(0, Rect2i(0, 0, 256, 256));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 4096, "Growing with size of 0 should not change any bits");
-
-	reset_bit_map(bit_map);
-
-	bit_map.set_bit_rect(Rect2i(96, 96, 64, 64), true);
-
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(95, 128)) == false, "Bits just outside of the square should not be set");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(160, 128)) == false, "Bits just outside of the square should not be set");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(128, 95)) == false, "Bits just outside of the square should not be set");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(128, 160)) == false, "Bits just outside of the square should not be set");
-	bit_map.grow_mask(1, Rect2i(0, 0, 256, 256));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 4352, "We should have 4*64 (perimeter of square) more bits set to true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(95, 128)) == true, "Bits that were just outside of the square should now be set to true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(160, 128)) == true, "Bits that were just outside of the square should now be set to true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(128, 95)) == true, "Bits that were just outside of the square should now be set to true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(128, 160)) == true, "Bits that were just outside of the square should now be set to true");
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 4096, "Creating a square of 64x64 should be 4096 bits");
+	bit_map->grow_mask(0, Rect2i(0, 0, 256, 256));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 4096, "Growing with size of 0 should not change any bits");
 
 	reset_bit_map(bit_map);
 
-	bit_map.set_bit_rect(Rect2i(127, 127, 1, 1), true);
+	bit_map->set_bit_rect(Rect2i(96, 96, 64, 64), true);
 
-	CHECK(bit_map.get_true_bit_count() == 1);
-	bit_map.grow_mask(32, Rect2i(0, 0, 256, 256));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 3209, "Creates a circle around the initial bit with a radius of 32 bits. Any bit that has a distance within this radius will be set to true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(95, 128)) == false, "Bits just outside of the square should not be set");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(160, 128)) == false, "Bits just outside of the square should not be set");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(128, 95)) == false, "Bits just outside of the square should not be set");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(128, 160)) == false, "Bits just outside of the square should not be set");
+	bit_map->grow_mask(1, Rect2i(0, 0, 256, 256));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 4352, "We should have 4*64 (perimeter of square) more bits set to true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(95, 128)) == true, "Bits that were just outside of the square should now be set to true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(160, 128)) == true, "Bits that were just outside of the square should now be set to true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(128, 95)) == true, "Bits that were just outside of the square should now be set to true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(128, 160)) == true, "Bits that were just outside of the square should now be set to true");
 
 	reset_bit_map(bit_map);
 
-	bit_map.set_bit_rect(Rect2i(127, 127, 1, 1), true);
+	bit_map->set_bit_rect(Rect2i(127, 127, 1, 1), true);
+
+	CHECK(bit_map->get_true_bit_count() == 1);
+	bit_map->grow_mask(32, Rect2i(0, 0, 256, 256));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 3209, "Creates a circle around the initial bit with a radius of 32 bits. Any bit that has a distance within this radius will be set to true");
+
+	reset_bit_map(bit_map);
+
+	bit_map->set_bit_rect(Rect2i(127, 127, 1, 1), true);
 	for (int i = 0; i < 32; i++) {
-		bit_map.grow_mask(1, Rect2i(0, 0, 256, 256));
+		bit_map->grow_mask(1, Rect2i(0, 0, 256, 256));
 	}
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 2113, "Creates a diamond around the initial bit with diagonals that are 65 bits long.");
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 2113, "Creates a diamond around the initial bit with diagonals that are 65 bits long.");
 
 	reset_bit_map(bit_map);
 
-	bit_map.set_bit_rect(Rect2i(123, 123, 10, 10), true);
+	bit_map->set_bit_rect(Rect2i(123, 123, 10, 10), true);
 
-	CHECK(bit_map.get_true_bit_count() == 100);
-	bit_map.grow_mask(-11, Rect2i(0, 0, 256, 256));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 0, "Shrinking by more than the width of the square should totally remove it.");
-
-	reset_bit_map(bit_map);
-	bit_map.set_bit_rect(Rect2i(96, 96, 64, 64), true);
-
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(96, 129)) == true, "Bits on the edge of the square should be true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(159, 129)) == true, "Bits on the edge of the square should be true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(129, 96)) == true, "Bits on the edge of the square should be true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(129, 159)) == true, "Bits on the edge of the square should be true");
-	bit_map.grow_mask(-1, Rect2i(0, 0, 256, 256));
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 3844, "Shrinking by 1 should set 4*63=252 bits to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(96, 129)) == false, "Bits that were on the edge of the square should now be set to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(159, 129)) == false, "Bits that were on the edge of the square should now be set to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(129, 96)) == false, "Bits that were on the edge of the square should now be set to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(129, 159)) == false, "Bits that were on the edge of the square should now be set to false");
+	CHECK(bit_map->get_true_bit_count() == 100);
+	bit_map->grow_mask(-11, Rect2i(0, 0, 256, 256));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 0, "Shrinking by more than the width of the square should totally remove it.");
 
 	reset_bit_map(bit_map);
+	bit_map->set_bit_rect(Rect2i(96, 96, 64, 64), true);
 
-	bit_map.set_bit_rect(Rect2i(125, 125, 1, 6), true);
-	bit_map.set_bit_rect(Rect2i(130, 125, 1, 6), true);
-	bit_map.set_bit_rect(Rect2i(125, 130, 6, 1), true);
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(96, 129)) == true, "Bits on the edge of the square should be true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(159, 129)) == true, "Bits on the edge of the square should be true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(129, 96)) == true, "Bits on the edge of the square should be true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(129, 159)) == true, "Bits on the edge of the square should be true");
+	bit_map->grow_mask(-1, Rect2i(0, 0, 256, 256));
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 3844, "Shrinking by 1 should set 4*63=252 bits to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(96, 129)) == false, "Bits that were on the edge of the square should now be set to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(159, 129)) == false, "Bits that were on the edge of the square should now be set to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(129, 96)) == false, "Bits that were on the edge of the square should now be set to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(129, 159)) == false, "Bits that were on the edge of the square should now be set to false");
 
-	CHECK(bit_map.get_true_bit_count() == 16);
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(125, 131)) == false, "Bits that are on the edge of the shape should be set to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(131, 131)) == false, "Bits that are on the edge of the shape should be set to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(125, 124)) == false, "Bits that are on the edge of the shape should be set to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(130, 124)) == false, "Bits that are on the edge of the shape should be set to false");
-	bit_map.grow_mask(1, Rect2i(0, 0, 256, 256));
-	CHECK(bit_map.get_true_bit_count() == 48);
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(125, 131)) == true, "Bits that were on the edge of the shape should now be set to true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(131, 130)) == true, "Bits that were on the edge of the shape should now be set to true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(125, 124)) == true, "Bits that were on the edge of the shape should now be set to true");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(130, 124)) == true, "Bits that were on the edge of the shape should now be set to true");
+	reset_bit_map(bit_map);
 
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(124, 124)) == false, "Bits that are on the edge of the shape should be set to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(126, 124)) == false, "Bits that are on the edge of the shape should be set to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(124, 131)) == false, "Bits that are on the edge of the shape should be set to false");
-	CHECK_MESSAGE(bit_map.get_bitv(Point2i(131, 131)) == false, "Bits that are on the edge of the shape should be set to false");
+	bit_map->set_bit_rect(Rect2i(125, 125, 1, 6), true);
+	bit_map->set_bit_rect(Rect2i(130, 125, 1, 6), true);
+	bit_map->set_bit_rect(Rect2i(125, 130, 6, 1), true);
+
+	CHECK(bit_map->get_true_bit_count() == 16);
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(125, 131)) == false, "Bits that are on the edge of the shape should be set to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(131, 131)) == false, "Bits that are on the edge of the shape should be set to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(125, 124)) == false, "Bits that are on the edge of the shape should be set to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(130, 124)) == false, "Bits that are on the edge of the shape should be set to false");
+	bit_map->grow_mask(1, Rect2i(0, 0, 256, 256));
+	CHECK(bit_map->get_true_bit_count() == 48);
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(125, 131)) == true, "Bits that were on the edge of the shape should now be set to true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(131, 130)) == true, "Bits that were on the edge of the shape should now be set to true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(125, 124)) == true, "Bits that were on the edge of the shape should now be set to true");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(130, 124)) == true, "Bits that were on the edge of the shape should now be set to true");
+
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(124, 124)) == false, "Bits that are on the edge of the shape should be set to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(126, 124)) == false, "Bits that are on the edge of the shape should be set to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(124, 131)) == false, "Bits that are on the edge of the shape should be set to false");
+	CHECK_MESSAGE(bit_map->get_bitv(Point2i(131, 131)) == false, "Bits that are on the edge of the shape should be set to false");
 }
 
 TEST_CASE("[BitMap] Blit") {
@@ -353,126 +365,132 @@ TEST_CASE("[BitMap] Blit") {
 	Point2i bit_map_size{ 256, 256 };
 	Point2i blit_size{ 32, 32 };
 
-	BitMap bit_map{};
-	Ref<BitMap> blit_bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
+
+	Ref<BitMap> blit_bit_map;
 
 	// Testing null reference to blit bit map.
 	ERR_PRINT_OFF
-	bit_map.blit(blit_pos, blit_bit_map);
+	bit_map->blit(blit_pos, blit_bit_map);
 	ERR_PRINT_ON
 
 	blit_bit_map.instantiate();
 
 	// Testing if uninitialized blit bit map and uninitialized bit map does not crash
-	bit_map.blit(blit_pos, blit_bit_map);
+	bit_map->blit(blit_pos, blit_bit_map);
 
 	// Testing if uninitialized bit map does not crash
 	blit_bit_map->create(blit_size);
-	bit_map.blit(blit_pos, blit_bit_map);
+	bit_map->blit(blit_pos, blit_bit_map);
 
 	// Testing if uninitialized bit map does not crash
 	blit_bit_map.unref();
 	blit_bit_map.instantiate();
 	CHECK_MESSAGE(blit_bit_map->get_size() == Point2i(0, 0), "Size should be cleared by unref and instance calls.");
-	bit_map.create(bit_map_size);
-	bit_map.blit(Point2i(128, 128), blit_bit_map);
+	bit_map->create(bit_map_size);
+	bit_map->blit(Point2i(128, 128), blit_bit_map);
 
 	// Testing if both initialized does not crash.
 	blit_bit_map->create(blit_size);
-	bit_map.blit(blit_pos, blit_bit_map);
+	bit_map->blit(blit_pos, blit_bit_map);
 
-	bit_map.set_bit_rect(Rect2i{ 127, 127, 3, 3 }, true);
-	CHECK(bit_map.get_true_bit_count() == 9);
-	bit_map.blit(Point2i(112, 112), blit_bit_map);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 9, "No bits should have been changed, as the blit bit map only contains falses");
+	bit_map->set_bit_rect(Rect2i{ 127, 127, 3, 3 }, true);
+	CHECK(bit_map->get_true_bit_count() == 9);
+	bit_map->blit(Point2i(112, 112), blit_bit_map);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 9, "No bits should have been changed, as the blit bit map only contains falses");
 
-	bit_map.create(bit_map_size);
+	bit_map->create(bit_map_size);
 	blit_bit_map->create(blit_size);
 	blit_bit_map->set_bit_rect(Rect2i(15, 15, 3, 3), true);
 	CHECK(blit_bit_map->get_true_bit_count() == 9);
 
-	CHECK(bit_map.get_true_bit_count() == 0);
-	bit_map.blit(Point2i(112, 112), blit_bit_map);
-	CHECK_MESSAGE(bit_map.get_true_bit_count() == 9, "All true bits should have been moved to the bit map");
+	CHECK(bit_map->get_true_bit_count() == 0);
+	bit_map->blit(Point2i(112, 112), blit_bit_map);
+	CHECK_MESSAGE(bit_map->get_true_bit_count() == 9, "All true bits should have been moved to the bit map");
 	for (int x = 127; x < 129; ++x) {
 		for (int y = 127; y < 129; ++y) {
-			CHECK_MESSAGE(bit_map.get_bitv(Point2i(x, y)) == true, "All true bits should have been moved to the bit map");
+			CHECK_MESSAGE(bit_map->get_bitv(Point2i(x, y)) == true, "All true bits should have been moved to the bit map");
 		}
 	}
 }
 
 TEST_CASE("[BitMap] Convert to image") {
 	const Size2i dim{ 256, 256 };
-	BitMap bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
+
 	Ref<Image> img;
 
 	ERR_PRINT_OFF
-	img = bit_map.convert_to_image();
+	img = bit_map->convert_to_image();
 	ERR_PRINT_ON
 	CHECK_MESSAGE(img.is_valid(), "We should receive a valid Image Object even if BitMap is not created yet");
 	CHECK_MESSAGE(img->get_format() == Image::FORMAT_L8, "We should receive a valid Image Object even if BitMap is not created yet");
 	CHECK_MESSAGE(img->get_size() == (Size2i(0, 0)), "Image should have no width or height, because BitMap has not yet been created");
 
-	bit_map.create(dim);
-	img = bit_map.convert_to_image();
+	bit_map->create(dim);
+	img = bit_map->convert_to_image();
 	CHECK_MESSAGE(img->get_size() == dim, "Image should have the same dimensions as the BitMap");
 	CHECK_MESSAGE(img->get_pixel(0, 0).is_equal_approx(Color(0, 0, 0)), "BitMap is initialized to all 0's, so Image should be all black");
 
 	reset_bit_map(bit_map);
-	bit_map.set_bit_rect(Rect2i(0, 0, 128, 128), true);
-	img = bit_map.convert_to_image();
+	bit_map->set_bit_rect(Rect2i(0, 0, 128, 128), true);
+	img = bit_map->convert_to_image();
 	CHECK_MESSAGE(img->get_pixel(0, 0).is_equal_approx(Color(1, 1, 1)), "BitMap's top-left quadrant is all 1's, so Image should be white");
 	CHECK_MESSAGE(img->get_pixel(255, 255).is_equal_approx(Color(0, 0, 0)), "All other quadrants were 0's, so these should be black");
 }
 
 TEST_CASE("[BitMap] Clip to polygon") {
 	const Size2i dim{ 256, 256 };
-	BitMap bit_map{};
+	Ref<BitMap> bit_map;
+	bit_map.instantiate();
+
 	Vector<Vector<Vector2>> polygons;
 
 	ERR_PRINT_OFF
-	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
+	polygons = bit_map->clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
 	ERR_PRINT_ON
 	CHECK_MESSAGE(polygons.size() == 0, "We should have no polygons, because the BitMap was not initialized");
 
-	bit_map.create(dim);
-	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
+	bit_map->create(dim);
+	polygons = bit_map->clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
 	CHECK_MESSAGE(polygons.size() == 0, "We should have no polygons, because the BitMap was all 0's");
 
 	reset_bit_map(bit_map);
-	bit_map.set_bit_rect(Rect2i(0, 0, 64, 64), true);
-	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
+	bit_map->set_bit_rect(Rect2i(0, 0, 64, 64), true);
+	polygons = bit_map->clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
 	CHECK_MESSAGE(polygons.size() == 1, "We should have exactly 1 polygon");
 	CHECK_MESSAGE(polygons[0].size() == 4, "The polygon should have exactly 4 points");
 
 	reset_bit_map(bit_map);
-	bit_map.set_bit_rect(Rect2i(0, 0, 32, 32), true);
-	bit_map.set_bit_rect(Rect2i(64, 64, 32, 32), true);
-	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
+	bit_map->set_bit_rect(Rect2i(0, 0, 32, 32), true);
+	bit_map->set_bit_rect(Rect2i(64, 64, 32, 32), true);
+	polygons = bit_map->clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
 	CHECK_MESSAGE(polygons.size() == 2, "We should have exactly 2 polygons");
 	CHECK_MESSAGE(polygons[0].size() == 4, "The polygon should have exactly 4 points");
 	CHECK_MESSAGE(polygons[1].size() == 4, "The polygon should have exactly 4 points");
 
 	reset_bit_map(bit_map);
-	bit_map.set_bit_rect(Rect2i(124, 112, 8, 32), true);
-	bit_map.set_bit_rect(Rect2i(112, 124, 32, 8), true);
-	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 256, 256));
+	bit_map->set_bit_rect(Rect2i(124, 112, 8, 32), true);
+	bit_map->set_bit_rect(Rect2i(112, 124, 32, 8), true);
+	polygons = bit_map->clip_opaque_to_polygons(Rect2i(0, 0, 256, 256));
 	CHECK_MESSAGE(polygons.size() == 1, "We should have exactly 1 polygon");
 	CHECK_MESSAGE(polygons[0].size() == 12, "The polygon should have exactly 12 points");
 
 	reset_bit_map(bit_map);
-	bit_map.set_bit_rect(Rect2i(124, 112, 8, 32), true);
-	bit_map.set_bit_rect(Rect2i(112, 124, 32, 8), true);
-	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
+	bit_map->set_bit_rect(Rect2i(124, 112, 8, 32), true);
+	bit_map->set_bit_rect(Rect2i(112, 124, 32, 8), true);
+	polygons = bit_map->clip_opaque_to_polygons(Rect2i(0, 0, 128, 128));
 	CHECK_MESSAGE(polygons.size() == 1, "We should have exactly 1 polygon");
 	CHECK_MESSAGE(polygons[0].size() == 6, "The polygon should have exactly 6 points");
 
 	reset_bit_map(bit_map);
-	bit_map.set_bit_rect(Rect2i(0, 0, 64, 64), true);
-	bit_map.set_bit_rect(Rect2i(64, 64, 64, 64), true);
-	bit_map.set_bit_rect(Rect2i(192, 128, 64, 64), true);
-	bit_map.set_bit_rect(Rect2i(128, 192, 64, 64), true);
-	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 256, 256));
+	bit_map->set_bit_rect(Rect2i(0, 0, 64, 64), true);
+	bit_map->set_bit_rect(Rect2i(64, 64, 64, 64), true);
+	bit_map->set_bit_rect(Rect2i(192, 128, 64, 64), true);
+	bit_map->set_bit_rect(Rect2i(128, 192, 64, 64), true);
+	polygons = bit_map->clip_opaque_to_polygons(Rect2i(0, 0, 256, 256));
 	CHECK_MESSAGE(polygons.size() == 4, "We should have exactly 4 polygons");
 	CHECK_MESSAGE(polygons[0].size() == 4, "The polygon should have exactly 4 points");
 	CHECK_MESSAGE(polygons[1].size() == 4, "The polygon should have exactly 4 points");
@@ -480,21 +498,21 @@ TEST_CASE("[BitMap] Clip to polygon") {
 	CHECK_MESSAGE(polygons[3].size() == 4, "The polygon should have exactly 4 points");
 
 	reset_bit_map(bit_map);
-	bit_map.set_bit(0, 0, true);
-	bit_map.set_bit(2, 0, true);
-	bit_map.set_bit_rect(Rect2i(1, 1, 1, 2), true);
-	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 3, 3));
+	bit_map->set_bit(0, 0, true);
+	bit_map->set_bit(2, 0, true);
+	bit_map->set_bit_rect(Rect2i(1, 1, 1, 2), true);
+	polygons = bit_map->clip_opaque_to_polygons(Rect2i(0, 0, 3, 3));
 	CHECK_MESSAGE(polygons.size() == 3, "We should have exactly 3 polygons");
 	CHECK_MESSAGE(polygons[0].size() == 4, "The polygon should have exactly 4 points");
 	CHECK_MESSAGE(polygons[1].size() == 4, "The polygon should have exactly 4 points");
 	CHECK_MESSAGE(polygons[2].size() == 4, "The polygon should have exactly 4 points");
 
 	reset_bit_map(bit_map);
-	bit_map.set_bit_rect(Rect2i(0, 0, 2, 1), true);
-	bit_map.set_bit_rect(Rect2i(0, 2, 3, 1), true);
-	bit_map.set_bit(0, 1, true);
-	bit_map.set_bit(2, 1, true);
-	polygons = bit_map.clip_opaque_to_polygons(Rect2i(0, 0, 4, 4));
+	bit_map->set_bit_rect(Rect2i(0, 0, 2, 1), true);
+	bit_map->set_bit_rect(Rect2i(0, 2, 3, 1), true);
+	bit_map->set_bit(0, 1, true);
+	bit_map->set_bit(2, 1, true);
+	polygons = bit_map->clip_opaque_to_polygons(Rect2i(0, 0, 4, 4));
 	CHECK_MESSAGE(polygons.size() == 1, "We should have exactly 1 polygon");
 	CHECK_MESSAGE(polygons[0].size() == 6, "The polygon should have exactly 6 points");
 }

--- a/tests/scene/test_convert_transform_modifier_3d.h
+++ b/tests/scene/test_convert_transform_modifier_3d.h
@@ -38,35 +38,37 @@
 namespace TestConvertTransformModifier3D {
 
 Transform3D make_random_transform_3d(int p_seed) {
-	RandomNumberGenerator rng;
-	rng.set_seed(p_seed);
+	Ref<RandomNumberGenerator> rng;
+	rng.instantiate();
+
+	rng->set_seed(p_seed);
 
 	Vector3 pos;
-	pos.x = rng.randf_range(-10.0, 10.0);
-	rng.set_seed(++p_seed);
-	pos.y = rng.randf_range(-10.0, 10.0);
-	rng.set_seed(++p_seed);
-	pos.z = rng.randf_range(-10.0, 10.0);
-	rng.set_seed(++p_seed);
+	pos.x = rng->randf_range(-10.0, 10.0);
+	rng->set_seed(++p_seed);
+	pos.y = rng->randf_range(-10.0, 10.0);
+	rng->set_seed(++p_seed);
+	pos.z = rng->randf_range(-10.0, 10.0);
+	rng->set_seed(++p_seed);
 
 	Quaternion rot;
-	rot.x = rng.randf_range(-1.0, 1.0);
-	rng.set_seed(++p_seed);
-	rot.y = rng.randf_range(-1.0, 1.0);
-	rng.set_seed(++p_seed);
-	rot.z = rng.randf_range(-1.0, 1.0);
-	rng.set_seed(++p_seed);
-	rot.w = rng.randf_range(-1.0, 1.0);
-	rng.set_seed(++p_seed);
+	rot.x = rng->randf_range(-1.0, 1.0);
+	rng->set_seed(++p_seed);
+	rot.y = rng->randf_range(-1.0, 1.0);
+	rng->set_seed(++p_seed);
+	rot.z = rng->randf_range(-1.0, 1.0);
+	rng->set_seed(++p_seed);
+	rot.w = rng->randf_range(-1.0, 1.0);
+	rng->set_seed(++p_seed);
 	rot = rot.normalized();
 
 	Vector3 scl;
-	scl.x = rng.randf_range(0.5, 2.0);
-	rng.set_seed(++p_seed);
-	scl.y = rng.randf_range(0.5, 2.0);
-	rng.set_seed(++p_seed);
-	scl.z = rng.randf_range(0.5, 2.0);
-	rng.set_seed(++p_seed);
+	scl.x = rng->randf_range(0.5, 2.0);
+	rng->set_seed(++p_seed);
+	scl.y = rng->randf_range(0.5, 2.0);
+	rng->set_seed(++p_seed);
+	scl.z = rng->randf_range(0.5, 2.0);
+	rng->set_seed(++p_seed);
 
 	return Transform3D(Basis(rot).scaled(scl), pos);
 }

--- a/tests/scene/test_copy_transform_modifier_3d.h
+++ b/tests/scene/test_copy_transform_modifier_3d.h
@@ -38,35 +38,37 @@
 namespace TestCopyTransformModifier3D {
 
 Transform3D make_random_transform_3d(int p_seed) {
-	RandomNumberGenerator rng;
-	rng.set_seed(p_seed);
+	Ref<RandomNumberGenerator> rng;
+	rng.instantiate();
+
+	rng->set_seed(p_seed);
 
 	Vector3 pos;
-	pos.x = rng.randf_range(-10.0, 10.0);
-	rng.set_seed(++p_seed);
-	pos.y = rng.randf_range(-10.0, 10.0);
-	rng.set_seed(++p_seed);
-	pos.z = rng.randf_range(-10.0, 10.0);
-	rng.set_seed(++p_seed);
+	pos.x = rng->randf_range(-10.0, 10.0);
+	rng->set_seed(++p_seed);
+	pos.y = rng->randf_range(-10.0, 10.0);
+	rng->set_seed(++p_seed);
+	pos.z = rng->randf_range(-10.0, 10.0);
+	rng->set_seed(++p_seed);
 
 	Quaternion rot;
-	rot.x = rng.randf_range(-1.0, 1.0);
-	rng.set_seed(++p_seed);
-	rot.y = rng.randf_range(-1.0, 1.0);
-	rng.set_seed(++p_seed);
-	rot.z = rng.randf_range(-1.0, 1.0);
-	rng.set_seed(++p_seed);
-	rot.w = rng.randf_range(-1.0, 1.0);
-	rng.set_seed(++p_seed);
+	rot.x = rng->randf_range(-1.0, 1.0);
+	rng->set_seed(++p_seed);
+	rot.y = rng->randf_range(-1.0, 1.0);
+	rng->set_seed(++p_seed);
+	rot.z = rng->randf_range(-1.0, 1.0);
+	rng->set_seed(++p_seed);
+	rot.w = rng->randf_range(-1.0, 1.0);
+	rng->set_seed(++p_seed);
 	rot = rot.normalized();
 
 	Vector3 scl;
-	scl.x = rng.randf_range(0.5, 2.0);
-	rng.set_seed(++p_seed);
-	scl.y = rng.randf_range(0.5, 2.0);
-	rng.set_seed(++p_seed);
-	scl.z = rng.randf_range(0.5, 2.0);
-	rng.set_seed(++p_seed);
+	scl.x = rng->randf_range(0.5, 2.0);
+	rng->set_seed(++p_seed);
+	scl.y = rng->randf_range(0.5, 2.0);
+	rng->set_seed(++p_seed);
+	scl.z = rng->randf_range(0.5, 2.0);
+	rng->set_seed(++p_seed);
 
 	return Transform3D(Basis(rot).scaled(scl), pos);
 }

--- a/tests/scene/test_packed_scene.h
+++ b/tests/scene/test_packed_scene.h
@@ -42,12 +42,14 @@ TEST_CASE("[PackedScene] Pack Scene and Retrieve State") {
 	scene->set_name("TestScene");
 
 	// Pack the scene.
-	PackedScene packed_scene;
-	const Error err = packed_scene.pack(scene);
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+
+	const Error err = packed_scene->pack(scene);
 	CHECK(err == OK);
 
 	// Retrieve the packed state.
-	Ref<SceneState> state = packed_scene.get_state();
+	Ref<SceneState> state = packed_scene->get_state();
 	CHECK(state.is_valid());
 	CHECK(state->get_node_count() == 1);
 	CHECK(state->get_node_name(0) == "TestScene");
@@ -127,14 +129,16 @@ TEST_CASE("[PackedScene] Clear Packed Scene") {
 	scene->set_name("TestScene");
 
 	// Pack the scene.
-	PackedScene packed_scene;
-	packed_scene.pack(scene);
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+
+	packed_scene->pack(scene);
 
 	// Clear the packed scene.
-	packed_scene.clear();
+	packed_scene->clear();
 
 	// Check if it has been cleared.
-	Ref<SceneState> state = packed_scene.get_state();
+	Ref<SceneState> state = packed_scene->get_state();
 	CHECK_FALSE(state->get_node_count() == 1);
 
 	memdelete(scene);
@@ -146,11 +150,13 @@ TEST_CASE("[PackedScene] Can Instantiate Packed Scene") {
 	scene->set_name("TestScene");
 
 	// Pack the scene.
-	PackedScene packed_scene;
-	packed_scene.pack(scene);
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+
+	packed_scene->pack(scene);
 
 	// Check if the packed scene can be instantiated.
-	const bool can_instantiate = packed_scene.can_instantiate();
+	const bool can_instantiate = packed_scene->can_instantiate();
 	CHECK(can_instantiate == true);
 
 	memdelete(scene);
@@ -162,11 +168,13 @@ TEST_CASE("[PackedScene] Instantiate Packed Scene") {
 	scene->set_name("TestScene");
 
 	// Pack the scene.
-	PackedScene packed_scene;
-	packed_scene.pack(scene);
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+
+	packed_scene->pack(scene);
 
 	// Instantiate the packed scene.
-	Node *instance = packed_scene.instantiate();
+	Node *instance = packed_scene->instantiate();
 	CHECK(instance != nullptr);
 	CHECK(instance->get_name() == "TestScene");
 
@@ -196,11 +204,13 @@ TEST_CASE("[PackedScene] Instantiate Packed Scene With Children") {
 	scene->add_child(child3);
 
 	// Pack the scene.
-	PackedScene packed_scene;
-	packed_scene.pack(scene);
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+
+	packed_scene->pack(scene);
 
 	// Instantiate the packed scene.
-	Node *instance = packed_scene.instantiate();
+	Node *instance = packed_scene->instantiate();
 	CHECK(instance != nullptr);
 	CHECK(instance->get_name() == "TestScene");
 
@@ -221,15 +231,17 @@ TEST_CASE("[PackedScene] Set Path") {
 	scene->set_name("TestScene");
 
 	// Pack the scene.
-	PackedScene packed_scene;
-	packed_scene.pack(scene);
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+
+	packed_scene->pack(scene);
 
 	// Set a new path for the packed scene.
 	const String new_path = "NewTestPath";
-	packed_scene.set_path(new_path);
+	packed_scene->set_path(new_path);
 
 	// Check if the path has been set correctly.
-	Ref<SceneState> state = packed_scene.get_state();
+	Ref<SceneState> state = packed_scene->get_state();
 	CHECK(state.is_valid());
 	CHECK(state->get_path() == new_path);
 
@@ -242,18 +254,20 @@ TEST_CASE("[PackedScene] Replace State") {
 	scene->set_name("TestScene");
 
 	// Pack the scene.
-	PackedScene packed_scene;
-	packed_scene.pack(scene);
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+
+	packed_scene->pack(scene);
 
 	// Create another scene state to replace with.
 	Ref<SceneState> new_state = memnew(SceneState);
 	new_state->set_path("NewPath");
 
 	// Replace the state.
-	packed_scene.replace_state(new_state);
+	packed_scene->replace_state(new_state);
 
 	// Check if the state has been replaced.
-	Ref<SceneState> state = packed_scene.get_state();
+	Ref<SceneState> state = packed_scene->get_state();
 	CHECK(state.is_valid());
 	CHECK(state == new_state);
 
@@ -266,14 +280,16 @@ TEST_CASE("[PackedScene] Recreate State") {
 	scene->set_name("TestScene");
 
 	// Pack the scene.
-	PackedScene packed_scene;
-	packed_scene.pack(scene);
+	Ref<PackedScene> packed_scene;
+	packed_scene.instantiate();
+
+	packed_scene->pack(scene);
 
 	// Recreate the state.
-	packed_scene.recreate_state();
+	packed_scene->recreate_state();
 
 	// Check if the state has been recreated.
-	Ref<SceneState> state = packed_scene.get_state();
+	Ref<SceneState> state = packed_scene->get_state();
 	CHECK(state.is_valid());
 	CHECK(state->get_node_count() == 0); // Since the state was recreated, it should be empty.
 

--- a/tests/scene/test_sprite_frames.h
+++ b/tests/scene/test_sprite_frames.h
@@ -38,36 +38,38 @@ namespace TestSpriteFrames {
 const String test_animation_name = "GodotTest";
 
 TEST_CASE("[SpriteFrames] Constructor methods") {
-	const SpriteFrames frames;
+	const Ref<SpriteFrames> frames = memnew(SpriteFrames);
 	CHECK_MESSAGE(
-			frames.get_animation_names().size() == 1,
+			frames->get_animation_names().size() == 1,
 			"Should be initialized with 1 entry.");
 	CHECK_MESSAGE(
-			frames.get_animation_names().get(0) == "default",
+			frames->get_animation_names().get(0) == "default",
 			"Should be initialized with default entry.");
 }
 
 TEST_CASE("[SpriteFrames] Animation addition, list getter, renaming, removal, and retrieval") {
-	SpriteFrames frames;
+	Ref<SpriteFrames> frames;
+	frames.instantiate();
+
 	Vector<String> test_names = { "default", "2", "1", "3" };
 
 	// "default" is there already
-	frames.add_animation("2");
-	frames.add_animation("1");
-	frames.add_animation("3");
+	frames->add_animation("2");
+	frames->add_animation("1");
+	frames->add_animation("3");
 
 	for (int i = 0; i < test_names.size(); i++) {
 		CHECK_MESSAGE(
-				frames.has_animation(test_names[i]),
+				frames->has_animation(test_names[i]),
 				"Add animation properly worked for each value");
 	}
 
 	CHECK_MESSAGE(
-			!frames.has_animation("999"),
+			!frames->has_animation("999"),
 			"Return false when checking for animation that does not exist");
 
 	List<StringName> sname_list;
-	frames.get_animation_list(&sname_list);
+	frames->get_animation_list(&sname_list);
 
 	CHECK_MESSAGE(
 			sname_list.size() == test_names.size(),
@@ -81,7 +83,7 @@ TEST_CASE("[SpriteFrames] Animation addition, list getter, renaming, removal, an
 	}
 
 	// get_animation_names() sorts the results.
-	Vector<String> string_vector = frames.get_animation_names();
+	Vector<String> string_vector = frames->get_animation_names();
 	test_names.sort();
 
 	for (int i = 0; i < test_names.size(); i++) {
@@ -92,107 +94,109 @@ TEST_CASE("[SpriteFrames] Animation addition, list getter, renaming, removal, an
 
 	// These error handling cases should not crash.
 	ERR_PRINT_OFF;
-	frames.rename_animation("This does not exist", "0");
+	frames->rename_animation("This does not exist", "0");
 	ERR_PRINT_ON;
 
 	CHECK_MESSAGE(
-			!frames.has_animation("0"),
+			!frames->has_animation("0"),
 			"Correctly handles rename error when entry does not exist");
 
 	// These error handling cases should not crash.
 	ERR_PRINT_OFF;
-	frames.rename_animation("3", "1");
+	frames->rename_animation("3", "1");
 	ERR_PRINT_ON;
 
 	CHECK_MESSAGE(
-			frames.has_animation("3"),
+			frames->has_animation("3"),
 			"Correctly handles rename error when entry exists, but new name already exists");
 
 	ERR_PRINT_OFF;
-	frames.add_animation("1");
+	frames->add_animation("1");
 	ERR_PRINT_ON;
 
 	CHECK_MESSAGE(
-			frames.get_animation_names().size() == 4,
+			frames->get_animation_names().size() == 4,
 			"Correctly does not add when entry already exists");
 
-	frames.rename_animation("3", "9");
+	frames->rename_animation("3", "9");
 
 	CHECK_MESSAGE(
-			frames.has_animation("9"),
+			frames->has_animation("9"),
 			"Animation renamed correctly");
 
-	frames.remove_animation("9");
+	frames->remove_animation("9");
 
 	CHECK_MESSAGE(
-			!frames.has_animation("9"),
+			!frames->has_animation("9"),
 			"Animation removed correctly");
 
-	frames.clear_all();
+	frames->clear_all();
 
 	CHECK_MESSAGE(
-			frames.get_animation_names().size() == 1,
+			frames->get_animation_names().size() == 1,
 			"Clear all removed all animations and re-added the default animation entry");
 }
 
 TEST_CASE("[SpriteFrames] Animation Speed getter and setter") {
-	SpriteFrames frames;
+	Ref<SpriteFrames> frames;
+	frames.instantiate();
 
-	frames.add_animation(test_animation_name);
+	frames->add_animation(test_animation_name);
 
 	CHECK_MESSAGE(
-			frames.get_animation_speed(test_animation_name) == 5.0,
+			frames->get_animation_speed(test_animation_name) == 5.0,
 			"Sets new animation to default speed");
 
-	frames.set_animation_speed(test_animation_name, 123.0004);
+	frames->set_animation_speed(test_animation_name, 123.0004);
 
 	CHECK_MESSAGE(
-			frames.get_animation_speed(test_animation_name) == 123.0004,
+			frames->get_animation_speed(test_animation_name) == 123.0004,
 			"Sets animation to positive double");
 
 	// These error handling cases should not crash.
 	ERR_PRINT_OFF;
-	frames.get_animation_speed("This does not exist");
-	frames.set_animation_speed("This does not exist", 100);
-	frames.set_animation_speed(test_animation_name, -999.999);
+	frames->get_animation_speed("This does not exist");
+	frames->set_animation_speed("This does not exist", 100);
+	frames->set_animation_speed(test_animation_name, -999.999);
 	ERR_PRINT_ON;
 
 	CHECK_MESSAGE(
-			frames.get_animation_speed(test_animation_name) == 123.0004,
+			frames->get_animation_speed(test_animation_name) == 123.0004,
 			"Prevents speed of animation being set to a negative value");
 
-	frames.set_animation_speed(test_animation_name, 0.0);
+	frames->set_animation_speed(test_animation_name, 0.0);
 
 	CHECK_MESSAGE(
-			frames.get_animation_speed(test_animation_name) == 0.0,
+			frames->get_animation_speed(test_animation_name) == 0.0,
 			"Sets animation to zero");
 }
 
 TEST_CASE("[SpriteFrames] Animation Loop getter and setter") {
-	SpriteFrames frames;
+	Ref<SpriteFrames> frames;
+	frames.instantiate();
 
-	frames.add_animation(test_animation_name);
+	frames->add_animation(test_animation_name);
 
 	CHECK_MESSAGE(
-			frames.get_animation_loop(test_animation_name),
+			frames->get_animation_loop(test_animation_name),
 			"Sets new animation to default loop value.");
 
-	frames.set_animation_loop(test_animation_name, true);
+	frames->set_animation_loop(test_animation_name, true);
 
 	CHECK_MESSAGE(
-			frames.get_animation_loop(test_animation_name),
+			frames->get_animation_loop(test_animation_name),
 			"Sets animation loop to true");
 
-	frames.set_animation_loop(test_animation_name, false);
+	frames->set_animation_loop(test_animation_name, false);
 
 	CHECK_MESSAGE(
-			!frames.get_animation_loop(test_animation_name),
+			!frames->get_animation_loop(test_animation_name),
 			"Sets animation loop to false");
 
 	// These error handling cases should not crash.
 	ERR_PRINT_OFF;
-	frames.get_animation_loop("This does not exist");
-	frames.set_animation_loop("This does not exist", false);
+	frames->get_animation_loop("This does not exist");
+	frames->set_animation_loop("This does not exist", false);
 	ERR_PRINT_ON;
 }
 
@@ -201,45 +205,46 @@ TEST_CASE("[SpriteFrames] Frame addition, removal, and retrieval") {
 	Ref<Texture2D> dummy_frame1;
 	dummy_frame1.instantiate();
 
-	SpriteFrames frames;
-	frames.add_animation(test_animation_name);
-	frames.add_animation("1");
-	frames.add_animation("2");
+	Ref<SpriteFrames> frames;
+	frames.instantiate();
+	frames->add_animation(test_animation_name);
+	frames->add_animation("1");
+	frames->add_animation("2");
 
 	CHECK_MESSAGE(
-			frames.get_frame_count(test_animation_name) == 0,
+			frames->get_frame_count(test_animation_name) == 0,
 			"Animation has a default frame count of 0");
 
-	frames.add_frame(test_animation_name, dummy_frame1, 1.0, 0);
-	frames.add_frame(test_animation_name, dummy_frame1, 1.0, 1);
-	frames.add_frame(test_animation_name, dummy_frame1, 1.0, 2);
+	frames->add_frame(test_animation_name, dummy_frame1, 1.0, 0);
+	frames->add_frame(test_animation_name, dummy_frame1, 1.0, 1);
+	frames->add_frame(test_animation_name, dummy_frame1, 1.0, 2);
 
 	CHECK_MESSAGE(
-			frames.get_frame_count(test_animation_name) == 3,
+			frames->get_frame_count(test_animation_name) == 3,
 			"Adds multiple frames");
 
-	frames.remove_frame(test_animation_name, 1);
-	frames.remove_frame(test_animation_name, 0);
+	frames->remove_frame(test_animation_name, 1);
+	frames->remove_frame(test_animation_name, 0);
 
 	CHECK_MESSAGE(
-			frames.get_frame_count(test_animation_name) == 1,
+			frames->get_frame_count(test_animation_name) == 1,
 			"Removes multiple frames");
 
 	// These error handling cases should not crash.
 	ERR_PRINT_OFF;
-	frames.add_frame("does not exist", dummy_frame1, 1.0, 0);
-	frames.remove_frame(test_animation_name, -99);
-	frames.remove_frame("does not exist", 0);
+	frames->add_frame("does not exist", dummy_frame1, 1.0, 0);
+	frames->remove_frame(test_animation_name, -99);
+	frames->remove_frame("does not exist", 0);
 	ERR_PRINT_ON;
 
 	CHECK_MESSAGE(
-			frames.get_frame_count(test_animation_name) == 1,
+			frames->get_frame_count(test_animation_name) == 1,
 			"Handles bad values when adding or removing frames.");
 
-	frames.clear(test_animation_name);
+	frames->clear(test_animation_name);
 
 	CHECK_MESSAGE(
-			frames.get_frame_count(test_animation_name) == 0,
+			frames->get_frame_count(test_animation_name) == 0,
 			"Clears frames.");
 }
 } // namespace TestSpriteFrames


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
* Ensures `RefCounted` types use `Ref`
* Ensures other engine types use pointers and `memnew/memdelete`

Separated into some specific sub-cases for ease of review, if these cases are not considered valid or relevant, will squash the ones that are kept

This ensures that all relevant memory management (and inheritance) is handled correctly, though there doesn't seem to be any direct issues currently it might cause issues in edge cases or with changes to memory management internals, regardless these types should always be handled by pointer or `Ref`