### PR TITLE
Clear warning in the scene tree by creating an LightOccluder2D polygon

### DIFF
--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -90,6 +90,7 @@ void OccluderPolygon2D::set_polygon(const Vector<Vector2> &p_polygon) {
 	rect_cache_dirty = true;
 	RS::get_singleton()->canvas_occluder_polygon_set_shape(occ_polygon, p_polygon, closed);
 	emit_changed();
+	update_configuration_warning();
 }
 
 Vector<Vector2> OccluderPolygon2D::get_polygon() const {


### PR DESCRIPTION
fixes  [#21225](https://github.com/godotengine/godot/issues/21225)

This commit fixes an UI bug which leads to a persistent warning in scene tree. LightOccluder2D requires a polygon to work and shows a warning in scene tree when this polygon is absent. Adding a polygon did not clear this warning. Before this fix the only way to get rid of the warning was to reload the complete scene.

The inspector issue mentioned in #21225 that polygon updates aren't reflected seems to be fixed in v4.3 and is therefore not part of this commit.