### PR TITLE
[macOS] Fix generated bundle name for templates

### DIFF
--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -96,7 +96,14 @@ def generate_bundle(target, source, env):
             shutil.copy(dbg_target_bin, app_dir + "/Contents/MacOS/godot_macos_debug.universal")
 
         # ZIP .app bundle.
-        zip_dir = Dir("#bin/" + (app_prefix + env.extra_suffix + env.module_version_string).replace(".", "_")).abspath
+        zip_name = app_prefix
+        if env["target"] == "template_debug":
+            zip_name += ".template_debug"
+        elif env["target"] == "template_release":
+            zip_name += ".template_release"
+        zip_name += env.extra_suffix + env.module_version_string
+
+        zip_dir = Dir("#bin/" + zip_name.replace(".", "_")).abspath
         shutil.make_archive(zip_dir, "zip", root_dir=bin_dir, base_dir="macos_template.app")
         shutil.rmtree(app_dir)
 


### PR DESCRIPTION
Currently, if you build using the following scons commands, both of these will result in generating `bin/godot_macos_dev.zip`.

```console
scons platform=macos target=template_debug generate_bundle=yes
scons platform=macos target=template_release generate_bundle=yes
```

Unfortunately, it makes it so that if you're building the editor and the templates at the same time, the latter built template will overwrite the former one.

```console
# The template debug artifact will be overwritten.
scons platform=macOS target=editor generate_bundle=yes && scons platform=macos target=template_debug generate_bundle=yes && scons platform=macos target=template_release generate_bundle=yes
```

This PR adds a prefix to the generated template bundle (the zip file).

<img width="280" alt="Capture d’écran, le 2024-10-29 à 13 11 58" src="https://github.com/user-attachments/assets/e27f4461-d76a-4dec-aea9-217e1fff1413">

_**TL;DR** Instead of generating 2 times the highlighted file, the previous command will generate the 2 files on top instead._