### PR TITLE
2D: Fix various issues and minor performance optimizations

### DIFF
--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -35,9 +35,21 @@
 #include "hash_map.h"
 #include "list.h"
 
-template <typename TKey, typename TData, typename Hasher = HashMapHasherDefault, typename Comparator = HashMapComparatorDefault<TKey>>
+#if defined(__GNUC__) && !defined(__clang__)
+#define ADDRESS_DIAGNOSTIC_WARNING_DISABLE \
+	_Pragma("GCC diagnostic push");        \
+	_Pragma("GCC diagnostic ignored \"-Waddress\"");
+
+#define ADDRESS_DIAGNOSTIC_POP \
+	_Pragma("GCC diagnostic pop");
+#else
+#define ADDRESS_DIAGNOSTIC_WARNING_DISABLE
+#define ADDRESS_DIAGNOSTIC_POP
+#endif
+
+template <typename TKey, typename TData, typename Hasher = HashMapHasherDefault, typename Comparator = HashMapComparatorDefault<TKey>, void (*BeforeEvict)(TKey &, TData &) = nullptr>
 class LRUCache {
-private:
+public:
 	struct Pair {
 		TKey key;
 		TData data;
@@ -51,16 +63,22 @@ private:
 
 	typedef typename List<Pair>::Element *Element;
 
+private:
 	List<Pair> _list;
 	HashMap<TKey, Element, Hasher, Comparator> _map;
 	size_t capacity;
 
 public:
-	const TData *insert(const TKey &p_key, const TData &p_value) {
+	const Pair *insert(const TKey &p_key, const TData &p_value) {
 		Element *e = _map.getptr(p_key);
 		Element n = _list.push_front(Pair(p_key, p_value));
 
 		if (e) {
+			ADDRESS_DIAGNOSTIC_WARNING_DISABLE;
+			if constexpr (BeforeEvict != nullptr) {
+				BeforeEvict((*e)->get().key, (*e)->get().data);
+			}
+			ADDRESS_DIAGNOSTIC_POP;
 			_list.erase(*e);
 			_map.erase(p_key);
 		}
@@ -68,11 +86,16 @@ public:
 
 		while (_map.size() > capacity) {
 			Element d = _list.back();
+			ADDRESS_DIAGNOSTIC_WARNING_DISABLE
+			if constexpr (BeforeEvict != nullptr) {
+				BeforeEvict(d->get().key, d->get().data);
+			}
+			ADDRESS_DIAGNOSTIC_POP
 			_map.erase(d->get().key);
 			_list.pop_back();
 		}
 
-		return &n->get().data;
+		return &n->get();
 	}
 
 	void clear() {
@@ -82,6 +105,17 @@ public:
 
 	bool has(const TKey &p_key) const {
 		return _map.getptr(p_key);
+	}
+
+	bool erase(const TKey &p_key) {
+		Element *e = _map.getptr(p_key);
+		if (!e) {
+			return false;
+		}
+		_list.move_to_front(*e);
+		_map.erase(p_key);
+		_list.pop_front();
+		return true;
 	}
 
 	const TData &get(const TKey &p_key) {
@@ -109,6 +143,11 @@ public:
 			capacity = p_capacity;
 			while (_map.size() > capacity) {
 				Element d = _list.back();
+				ADDRESS_DIAGNOSTIC_WARNING_DISABLE;
+				if constexpr (BeforeEvict != nullptr) {
+					BeforeEvict(d->get().key, d->get().data);
+				}
+				ADDRESS_DIAGNOSTIC_POP;
 				_map.erase(d->get().key);
 				_list.pop_back();
 			}
@@ -123,5 +162,8 @@ public:
 		capacity = p_capacity;
 	}
 };
+
+#undef ADDRESS_DIAGNOSTIC_WARNING_DISABLE
+#undef ADDRESS_DIAGNOSTIC_POP
 
 #endif // LRU_H

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2367,6 +2367,10 @@
 		<member name="rendering/2d/batching/item_buffer_size" type="int" setter="" getter="" default="16384">
 			Maximum number of canvas item commands that can be batched into a single draw call.
 		</member>
+		<member name="rendering/2d/batching/uniform_set_cache_size" type="int" setter="" getter="" default="256">
+			Maximum number of uniform sets that will be cached by the 2D renderer when batching draw calls.
+			[b]Note:[/b] A project that uses a large number of unique sprite textures per frame may benefit from increasing this value.
+		</member>
 		<member name="rendering/2d/sdf/oversize" type="int" setter="" getter="" default="1">
 			Controls how much of the original viewport size should be covered by the 2D signed distance field. This SDF can be sampled in [CanvasItem] shaders and is used for [GPUParticles2D] collision. Higher values allow portions of occluders located outside the viewport to still be taken into account in the generated signed distance field, at the cost of performance. If you notice particles falling through [LightOccluder2D]s as the occluders leave the viewport, increase this setting.
 			The percentage specified is added on each axis and on both sides. For example, with the default setting of 120%, the signed distance field will cover 20% of the viewport's size outside the viewport on each side (top, right, bottom, left).

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -28,7 +28,7 @@ layout(location = 11) in vec4 weight_attrib;
 
 layout(location = 4) out flat uint instance_index_interp;
 
-#endif // USE_ATTRIBUTES
+#endif // !USE_ATTRIBUTES
 
 layout(location = 0) out vec2 uv_interp;
 layout(location = 1) out vec4 color_interp;
@@ -322,11 +322,7 @@ vec4 light_compute(
 #ifdef USE_NINEPATCH
 
 float map_ninepatch_axis(float pixel, float draw_size, float tex_pixel_size, float margin_begin, float margin_end, int np_repeat, inout int draw_center) {
-#ifdef USE_ATTRIBUTES
-	const InstanceData draw_data = instances.data[params.base_instance_index];
-#else
 	const InstanceData draw_data = instances.data[instance_index];
-#endif // USE_ATTRIBUTES
 
 	float tex_size = 1.0 / tex_pixel_size;
 
@@ -567,7 +563,7 @@ void main() {
 
 	if (specular_shininess_used || (using_light && normal_used && bool(draw_data.flags & FLAGS_DEFAULT_SPECULAR_MAP_USED))) {
 		specular_shininess = texture(sampler2D(specular_texture, texture_sampler), uv);
-		specular_shininess *= unpackUnorm4x8(draw_data.specular_shininess);
+		specular_shininess *= unpackUnorm4x8(params.specular_shininess);
 		specular_shininess_used = true;
 	} else {
 		specular_shininess = vec4(1.0);

--- a/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
@@ -37,7 +37,7 @@ struct InstanceData {
 	vec2 world_y;
 	vec2 world_ofs;
 	uint flags;
-	uint specular_shininess;
+	uint pad2;
 #ifdef USE_PRIMITIVE
 	vec2 points[3];
 	vec2 uvs[3];
@@ -57,8 +57,8 @@ struct InstanceData {
 layout(push_constant, std430) uniform Params {
 	uint base_instance_index; // base index to instance data
 	uint sc_packed_0;
-	uint pad2;
-	uint pad3;
+	uint specular_shininess;
+	uint pad;
 }
 params;
 
@@ -68,7 +68,7 @@ params;
 
 // Pull the constants from the draw call's push constants.
 uint sc_packed_0() {
-	return draw_call.sc_packed_0;
+	return params.sc_packed_0;
 }
 
 #else

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -122,7 +122,6 @@ private:
 		Size2i size_cache = Size2i(1, 1);
 		bool use_normal_cache = false;
 		bool use_specular_cache = false;
-		bool cleared_cache = true;
 
 		void clear_cache();
 		~CanvasTexture();

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3569,6 +3569,7 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/2d/shadow_atlas/size", PROPERTY_HINT_RANGE, "128,16384"), 2048);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/2d/batching/item_buffer_size", PROPERTY_HINT_RANGE, "128,1048576,1"), 16384);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/2d/batching/uniform_set_cache_size", PROPERTY_HINT_RANGE, "256,1048576,1"), 256);
 
 	// Number of commands that can be drawn per frame.
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/gl_compatibility/item_buffer_size", PROPERTY_HINT_RANGE, "128,1048576,1"), 16384);


### PR DESCRIPTION
# Summary

This PR includes a number of important bug fixes and a performance improvement for managing the texture state and `DrawData` in uniform set 3.

Another important change in this PR is to move the `specular_shininess` to `PushConstant` state, allowing the field to be used for #97058.

Closing #97340 in favour of this, noting that this PR will not address font rendering improvements, which will require separate work. It does improve the performance of text rendering of the test in [this comment](https://github.com/godotengine/godot/pull/92797#issuecomment-2309051165) from 40 fps to 76 fps, due to the minor CPU optimisations included in this PR.

# Bugfixes

- As noted in [this comment](https://github.com/godotengine/godot/issues/97586#issuecomment-2380882016), fixes #97586 for the forward+ renderer, but not compatibility
- Closes #97593 which is a forward+ issue only
- Fixes #97774
- Fixes #98005
