### PR TITLE
SCons: Make builders prettier, utilize `constexpr`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -968,8 +968,6 @@ if env.editor_build:
         print_error("Not all modules required by editor builds are enabled.")
         Exit(255)
 
-env.version_info = methods.get_version_info(env.module_version_string)
-
 env["PROGSUFFIX_WRAP"] = suffix + env.module_version_string + ".console" + env["PROGSUFFIX"]
 env["PROGSUFFIX"] = suffix + env.module_version_string + env["PROGSUFFIX"]
 env["OBJSUFFIX"] = suffix + env["OBJSUFFIX"]

--- a/core/SCsub
+++ b/core/SCsub
@@ -167,10 +167,9 @@ env.add_source_files(env.core_sources, "*.cpp")
 
 # Generate disabled classes
 def disabled_class_builder(target, source, env):
-    with methods.generated_wrapper(target) as file:
+    with methods.generated_wrapper(str(target[0])) as file:
         for c in source[0].read():
-            cs = c.strip()
-            if cs != "":
+            if cs := c.strip():
                 file.write(f"#define ClassDB_Disable_{cs} 1\n")
 
 
@@ -179,7 +178,7 @@ env.CommandNoCache("disabled_classes.gen.h", env.Value(env.disabled_classes), en
 
 # Generate version info
 def version_info_builder(target, source, env):
-    with methods.generated_wrapper(target) as file:
+    with methods.generated_wrapper(str(target[0])) as file:
         file.write(
             """\
 #define VERSION_SHORT_NAME "{short_name}"
@@ -193,35 +192,37 @@ def version_info_builder(target, source, env):
 #define VERSION_WEBSITE "{website}"
 #define VERSION_DOCS_BRANCH "{docs_branch}"
 #define VERSION_DOCS_URL "https://docs.godotengine.org/en/" VERSION_DOCS_BRANCH
-""".format(**env.version_info)
+""".format(**source[0].read())
         )
 
 
-env.CommandNoCache("version_generated.gen.h", env.Value(env.version_info), env.Run(version_info_builder))
+env.CommandNoCache(
+    "version_generated.gen.h",
+    env.Value(methods.get_version_info(env.module_version_string)),
+    env.Run(version_info_builder),
+)
 
 
 # Generate version hash
 def version_hash_builder(target, source, env):
-    with methods.generated_wrapper(target) as file:
+    with methods.generated_wrapper(str(target[0])) as file:
         file.write(
             """\
 #include "core/version.h"
 
 const char *const VERSION_HASH = "{git_hash}";
 const uint64_t VERSION_TIMESTAMP = {git_timestamp};
-""".format(**env.version_info)
+""".format(**source[0].read())
         )
 
 
-gen_hash = env.CommandNoCache(
-    "version_hash.gen.cpp", env.Value(env.version_info["git_hash"]), env.Run(version_hash_builder)
-)
+gen_hash = env.CommandNoCache("version_hash.gen.cpp", env.Value(methods.get_git_info()), env.Run(version_hash_builder))
 env.add_source_files(env.core_sources, gen_hash)
 
 
 # Generate AES256 script encryption key
 def encryption_key_builder(target, source, env):
-    with methods.generated_wrapper(target) as file:
+    with methods.generated_wrapper(str(target[0])) as file:
         file.write(
             f"""\
 #include "core/config/project_settings.h"
@@ -251,30 +252,21 @@ env.add_source_files(env.core_sources, gen_encrypt)
 
 
 # Certificates
-env.Depends(
-    "#core/io/certs_compressed.gen.h",
-    ["#thirdparty/certs/ca-certificates.crt", env.Value(env["builtin_certs"]), env.Value(env["system_certs_path"])],
-)
 env.CommandNoCache(
     "#core/io/certs_compressed.gen.h",
-    "#thirdparty/certs/ca-certificates.crt",
+    ["#thirdparty/certs/ca-certificates.crt", env.Value(env["builtin_certs"]), env.Value(env["system_certs_path"])],
     env.Run(core_builders.make_certs_header),
 )
 
 # Authors
-env.Depends("#core/authors.gen.h", "../AUTHORS.md")
-env.CommandNoCache("#core/authors.gen.h", "../AUTHORS.md", env.Run(core_builders.make_authors_header))
+env.CommandNoCache("#core/authors.gen.h", "#AUTHORS.md", env.Run(core_builders.make_authors_header))
 
 # Donors
-env.Depends("#core/donors.gen.h", "../DONORS.md")
-env.CommandNoCache("#core/donors.gen.h", "../DONORS.md", env.Run(core_builders.make_donors_header))
+env.CommandNoCache("#core/donors.gen.h", "#DONORS.md", env.Run(core_builders.make_donors_header))
 
 # License
-env.Depends("#core/license.gen.h", ["../COPYRIGHT.txt", "../LICENSE.txt"])
 env.CommandNoCache(
-    "#core/license.gen.h",
-    ["../COPYRIGHT.txt", "../LICENSE.txt"],
-    env.Run(core_builders.make_license_header),
+    "#core/license.gen.h", ["#COPYRIGHT.txt", "#LICENSE.txt"], env.Run(core_builders.make_license_header)
 )
 
 # Chain load SCsubs

--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -1,52 +1,37 @@
-import zlib
+import methods
 
 
 def run(target, source, env):
-    src = str(source[0])
-    dst = str(target[0])
-    with open(src, "rb") as f, open(dst, "w", encoding="utf-8", newline="\n") as g:
-        buf = f.read()
-        decomp_size = len(buf)
+    buffer = methods.get_buffer(str(source[0]))
+    decomp_size = len(buffer)
+    buffer = methods.compress_buffer(buffer)
 
-        # Use maximum zlib compression level to further reduce file size
-        # (at the cost of initial build times).
-        buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
-
-        g.write(
-            """/* THIS FILE IS GENERATED DO NOT EDIT */
-#pragma once
-
+    with methods.generated_wrapper(str(target[0])) as file:
+        file.write(f"""\
 #ifdef TOOLS_ENABLED
 
 #include "core/io/compression.h"
 #include "core/io/file_access.h"
 #include "core/string/ustring.h"
 
-"""
-        )
+inline constexpr int _gdextension_interface_data_compressed_size = {len(buffer)};
+inline constexpr int _gdextension_interface_data_uncompressed_size = {decomp_size};
+inline constexpr unsigned char _gdextension_interface_data_compressed[] = {{
+	{methods.format_buffer(buffer, 1)}
+}};
 
-        g.write("static const int _gdextension_interface_data_compressed_size = " + str(len(buf)) + ";\n")
-        g.write("static const int _gdextension_interface_data_uncompressed_size = " + str(decomp_size) + ";\n")
-        g.write("static const unsigned char _gdextension_interface_data_compressed[] = {\n")
-        for i in range(len(buf)):
-            g.write("\t" + str(buf[i]) + ",\n")
-        g.write("};\n")
-
-        g.write(
-            """
-class GDExtensionInterfaceDump {
-    public:
-        static void generate_gdextension_interface_file(const String &p_path) {
-            Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
-            ERR_FAIL_COND_MSG(fa.is_null(), vformat("Cannot open file '%s' for writing.", p_path));
-            Vector<uint8_t> data;
-            data.resize(_gdextension_interface_data_uncompressed_size);
-            int ret = Compression::decompress(data.ptrw(), _gdextension_interface_data_uncompressed_size, _gdextension_interface_data_compressed, _gdextension_interface_data_compressed_size, Compression::MODE_DEFLATE);
-            ERR_FAIL_COND_MSG(ret == -1, "Compressed file is corrupt.");
-            fa->store_buffer(data.ptr(), data.size());
-        };
-};
+class GDExtensionInterfaceDump {{
+	public:
+		static void generate_gdextension_interface_file(const String &p_path) {{
+			Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
+			ERR_FAIL_COND_MSG(fa.is_null(), vformat("Cannot open file '%s' for writing.", p_path));
+			Vector<uint8_t> data;
+			data.resize(_gdextension_interface_data_uncompressed_size);
+			int ret = Compression::decompress(data.ptrw(), _gdextension_interface_data_uncompressed_size, _gdextension_interface_data_compressed, _gdextension_interface_data_compressed_size, Compression::MODE_DEFLATE);
+			ERR_FAIL_COND_MSG(ret == -1, "Compressed file is corrupt.");
+			fa->store_buffer(data.ptr(), data.size());
+		}};
+}};
 
 #endif // TOOLS_ENABLED
-"""
-        )
+""")

--- a/core/input/input_builders.py
+++ b/core/input/input_builders.py
@@ -2,18 +2,22 @@
 
 from collections import OrderedDict
 
+import methods
+
 
 def make_default_controller_mappings(target, source, env):
-    dst = str(target[0])
-    with open(dst, "w", encoding="utf-8", newline="\n") as g:
-        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        g.write('#include "core/typedefs.h"\n')
-        g.write('#include "core/input/default_controller_mappings.h"\n')
+    with methods.generated_wrapper(str(target[0])) as file:
+        file.write("""\
+#include "core/input/default_controller_mappings.h"
+
+#include "core/typedefs.h"
+
+""")
 
         # ensure mappings have a consistent order
-        platform_mappings: dict = OrderedDict()
-        for src_path in source:
-            with open(str(src_path), "r", encoding="utf-8") as f:
+        platform_mappings = OrderedDict()
+        for src_path in map(str, source):
+            with open(src_path, "r", encoding="utf-8") as f:
                 # read mapping file and skip header
                 mapping_file_lines = f.readlines()[2:]
 
@@ -32,28 +36,28 @@ def make_default_controller_mappings(target, source, env):
                     line_parts = line.split(",")
                     guid = line_parts[0]
                     if guid in platform_mappings[current_platform]:
-                        g.write(
+                        file.write(
                             "// WARNING: DATABASE {} OVERWROTE PRIOR MAPPING: {} {}\n".format(
                                 src_path, current_platform, platform_mappings[current_platform][guid]
                             )
                         )
                     platform_mappings[current_platform][guid] = line
 
-        platform_variables = {
-            "Linux": "#ifdef LINUXBSD_ENABLED",
-            "Windows": "#ifdef WINDOWS_ENABLED",
-            "Mac OS X": "#ifdef MACOS_ENABLED",
-            "Android": "#ifdef ANDROID_ENABLED",
-            "iOS": "#ifdef IOS_ENABLED",
-            "Web": "#ifdef WEB_ENABLED",
+        PLATFORM_VARIABLES = {
+            "Linux": "LINUXBSD",
+            "Windows": "WINDOWS",
+            "Mac OS X": "MACOS",
+            "Android": "ANDROID",
+            "iOS": "IOS",
+            "Web": "WEB",
         }
 
-        g.write("const char* DefaultControllerMappings::mappings[] = {\n")
+        file.write("const char *DefaultControllerMappings::mappings[] = {\n")
         for platform, mappings in platform_mappings.items():
-            variable = platform_variables[platform]
-            g.write("{}\n".format(variable))
+            variable = PLATFORM_VARIABLES[platform]
+            file.write(f"#ifdef {variable}_ENABLED\n")
             for mapping in mappings.values():
-                g.write('\t"{}",\n'.format(mapping))
-            g.write("#endif\n")
+                file.write(f'\t"{mapping}",\n')
+            file.write(f"#endif // {variable}_ENABLED\n")
 
-        g.write("\tnullptr\n};\n")
+        file.write("\tnullptr\n};\n")

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -5,7 +5,6 @@ Import("env")
 
 env.editor_sources = []
 
-import glob
 import os
 
 import editor_builders
@@ -17,17 +16,16 @@ if env.editor_build:
     def doc_data_class_path_builder(target, source, env):
         paths = dict(sorted(source[0].read().items()))
         data = "\n".join([f'\t{{"{key}", "{value}"}},' for key, value in paths.items()])
-        with methods.generated_wrapper(target) as file:
+        with methods.generated_wrapper(str(target[0])) as file:
             file.write(
                 f"""\
-static const int _doc_data_class_path_count = {len(paths)};
-
 struct _DocDataClassPath {{
 	const char *name;
 	const char *path;
 }};
 
-static const _DocDataClassPath _doc_data_class_paths[{len(env.doc_class_path) + 1}] = {{
+inline constexpr int _doc_data_class_path_count = {len(paths)};
+inline constexpr _DocDataClassPath _doc_data_class_paths[{len(env.doc_class_path) + 1}] = {{
 {data}
 	{{nullptr, nullptr}},
 }};
@@ -42,7 +40,7 @@ static const _DocDataClassPath _doc_data_class_paths[{len(env.doc_class_path) + 
         exp_inc = "\n".join([f'#include "platform/{p}/export/export.h"' for p in platforms])
         exp_reg = "\n".join([f"\tregister_{p}_exporter();" for p in platforms])
         exp_type = "\n".join([f"\tregister_{p}_exporter_types();" for p in platforms])
-        with methods.generated_wrapper(target) as file:
+        with methods.generated_wrapper(str(target[0])) as file:
             file.write(
                 f"""\
 #include "register_exporters.h"
@@ -83,7 +81,6 @@ void register_exporter_types() {{
             docs += Glob(d + "/*.xml")  # Custom.
 
     docs = sorted(docs)
-    env.Depends("#editor/doc_data_compressed.gen.h", docs)
     env.CommandNoCache(
         "#editor/doc_data_compressed.gen.h",
         docs,
@@ -97,40 +94,31 @@ void register_exporter_types() {{
     # Generated with `make include-list` for each resource.
 
     # Editor translations
-    tlist = glob.glob(env.Dir("#editor/translations/editor").abspath + "/*.po")
-    env.Depends("#editor/editor_translations.gen.h", tlist)
     env.CommandNoCache(
         "#editor/editor_translations.gen.h",
-        tlist,
-        env.Run(editor_builders.make_editor_translations_header),
+        Glob("#editor/translations/editor/*"),
+        env.Run(editor_builders.make_translations_header),
     )
 
     # Property translations
-    tlist = glob.glob(env.Dir("#editor/translations/properties").abspath + "/*.po")
-    env.Depends("#editor/property_translations.gen.h", tlist)
     env.CommandNoCache(
         "#editor/property_translations.gen.h",
-        tlist,
-        env.Run(editor_builders.make_property_translations_header),
+        Glob("#editor/translations/properties/*"),
+        env.Run(editor_builders.make_translations_header),
     )
 
     # Documentation translations
-    tlist = glob.glob(env.Dir("#doc/translations").abspath + "/*.po")
-    env.Depends("#editor/doc_translations.gen.h", tlist)
     env.CommandNoCache(
         "#editor/doc_translations.gen.h",
-        tlist,
-        env.Run(editor_builders.make_doc_translations_header),
+        Glob("#doc/translations/*"),
+        env.Run(editor_builders.make_translations_header),
     )
 
     # Extractable translations
-    tlist = glob.glob(env.Dir("#editor/translations/extractable").abspath + "/*.po")
-    tlist.extend(glob.glob(env.Dir("#editor/translations/extractable").abspath + "/extractable.pot"))
-    env.Depends("#editor/extractable_translations.gen.h", tlist)
     env.CommandNoCache(
         "#editor/extractable_translations.gen.h",
-        tlist,
-        env.Run(editor_builders.make_extractable_translations_header),
+        Glob("#editor/translations/extractable/*"),
+        env.Run(editor_builders.make_translations_header),
     )
 
     env.add_source_files(env.editor_sources, "*.cpp")

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -2,141 +2,95 @@
 
 import os
 import os.path
-import shutil
 import subprocess
 import tempfile
 import uuid
-import zlib
 
-from methods import print_warning
+import methods
 
 
 def make_doc_header(target, source, env):
-    dst = str(target[0])
-    with open(dst, "w", encoding="utf-8", newline="\n") as g:
-        buf = ""
-        docbegin = ""
-        docend = ""
-        for src in source:
-            src = str(src)
-            if not src.endswith(".xml"):
-                continue
-            with open(src, "r", encoding="utf-8") as f:
-                content = f.read()
-            buf += content
+    buffer = b"".join([methods.get_buffer(src) for src in map(str, source)])
+    decomp_size = len(buffer)
+    buffer = methods.compress_buffer(buffer)
 
-        buf = (docbegin + buf + docend).encode("utf-8")
-        decomp_size = len(buf)
-
-        # Use maximum zlib compression level to further reduce file size
-        # (at the cost of initial build times).
-        buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
-
-        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        g.write("#ifndef _DOC_DATA_RAW_H\n")
-        g.write("#define _DOC_DATA_RAW_H\n")
-        g.write('static const char *_doc_data_hash = "' + str(hash(buf)) + '";\n')
-        g.write("static const int _doc_data_compressed_size = " + str(len(buf)) + ";\n")
-        g.write("static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n")
-        g.write("static const unsigned char _doc_data_compressed[] = {\n")
-        for i in range(len(buf)):
-            g.write("\t" + str(buf[i]) + ",\n")
-        g.write("};\n")
-
-        g.write("#endif")
+    with methods.generated_wrapper(str(target[0])) as file:
+        file.write(f"""\
+inline constexpr const char *_doc_data_hash = "{hash(buffer)}";
+inline constexpr int _doc_data_compressed_size = {len(buffer)};
+inline constexpr int _doc_data_uncompressed_size = {decomp_size};
+inline constexpr const unsigned char _doc_data_compressed[] = {{
+	{methods.format_buffer(buffer, 1)}
+}};
+""")
 
 
-def make_translations_header(target, source, env, category):
-    dst = str(target[0])
+def make_translations_header(target, source, env):
+    category = os.path.basename(str(target[0])).split("_")[0]
+    sorted_paths = sorted([src.abspath for src in source], key=lambda path: os.path.splitext(os.path.basename(path))[0])
 
-    with open(dst, "w", encoding="utf-8", newline="\n") as g:
-        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        g.write("#ifndef _{}_TRANSLATIONS_H\n".format(category.upper()))
-        g.write("#define _{}_TRANSLATIONS_H\n".format(category.upper()))
+    xl_names = []
+    msgfmt = env.Detect("msgfmt")
+    if not msgfmt:
+        methods.print_warning("msgfmt not found, using .po files instead of .mo")
 
-        sorted_paths = sorted([str(x) for x in source], key=lambda path: os.path.splitext(os.path.basename(path))[0])
-
-        msgfmt_available = shutil.which("msgfmt") is not None
-
-        if not msgfmt_available:
-            print_warning("msgfmt is not found, using .po files instead of .mo")
-
-        xl_names = []
-        for i in range(len(sorted_paths)):
-            name = os.path.splitext(os.path.basename(sorted_paths[i]))[0]
+    with methods.generated_wrapper(str(target[0])) as file:
+        for path in sorted_paths:
+            name = os.path.splitext(os.path.basename(path))[0]
             # msgfmt erases non-translated messages, so avoid using it if exporting the POT.
-            if msgfmt_available and name != category:
+            if msgfmt and name != category:
                 mo_path = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex + ".mo")
-                cmd = "msgfmt " + sorted_paths[i] + " --no-hash -o " + mo_path
+                cmd = f"{msgfmt} {path} --no-hash -o {mo_path}"
                 try:
                     subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
-                    with open(mo_path, "rb") as f:
-                        buf = f.read()
+                    buffer = methods.get_buffer(mo_path)
                 except OSError as e:
-                    print_warning(
+                    methods.print_warning(
                         "msgfmt execution failed, using .po file instead of .mo: path=%r; [%s] %s"
-                        % (sorted_paths[i], e.__class__.__name__, e)
+                        % (path, e.__class__.__name__, e)
                     )
-                    with open(sorted_paths[i], "rb") as f:
-                        buf = f.read()
+                    buffer = methods.get_buffer(path)
                 finally:
                     try:
-                        os.remove(mo_path)
+                        if os.path.exists(mo_path):
+                            os.remove(mo_path)
                     except OSError as e:
                         # Do not fail the entire build if it cannot delete a temporary file.
-                        print_warning(
+                        methods.print_warning(
                             "Could not delete temporary .mo file: path=%r; [%s] %s" % (mo_path, e.__class__.__name__, e)
                         )
             else:
-                with open(sorted_paths[i], "rb") as f:
-                    buf = f.read()
-
+                buffer = methods.get_buffer(path)
                 if name == category:
                     name = "source"
 
-            decomp_size = len(buf)
-            # Use maximum zlib compression level to further reduce file size
-            # (at the cost of initial build times).
-            buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
+            decomp_size = len(buffer)
+            buffer = methods.compress_buffer(buffer)
 
-            g.write("static const unsigned char _{}_translation_{}_compressed[] = {{\n".format(category, name))
-            for j in range(len(buf)):
-                g.write("\t" + str(buf[j]) + ",\n")
+            file.write(f"""\
+inline constexpr const unsigned char _{category}_translation_{name}_compressed[] = {{
+	{methods.format_buffer(buffer, 1)}
+}};
 
-            g.write("};\n")
+""")
 
-            xl_names.append([name, len(buf), str(decomp_size)])
+            xl_names.append([name, len(buffer), decomp_size])
 
-        g.write("struct {}TranslationList {{\n".format(category.capitalize()))
-        g.write("\tconst char* lang;\n")
-        g.write("\tint comp_size;\n")
-        g.write("\tint uncomp_size;\n")
-        g.write("\tconst unsigned char* data;\n")
-        g.write("};\n\n")
-        g.write("static {}TranslationList _{}_translations[] = {{\n".format(category.capitalize(), category))
+        file.write(f"""\
+struct {category.capitalize()}TranslationList {{
+	const char* lang;
+	int comp_size;
+	int uncomp_size;
+	const unsigned char* data;
+}};
+
+inline constexpr {category.capitalize()}TranslationList _{category}_translations[] = {{
+""")
+
         for x in xl_names:
-            g.write(
-                '\t{{ "{}", {}, {}, _{}_translation_{}_compressed }},\n'.format(
-                    x[0], str(x[1]), str(x[2]), category, x[0]
-                )
-            )
-        g.write("\t{nullptr, 0, 0, nullptr}\n")
-        g.write("};\n")
+            file.write(f'\t{{ "{x[0]}", {x[1]}, {x[2]}, _{category}_translation_{x[0]}_compressed }},\n')
 
-        g.write("#endif")
-
-
-def make_editor_translations_header(target, source, env):
-    make_translations_header(target, source, env, "editor")
-
-
-def make_property_translations_header(target, source, env):
-    make_translations_header(target, source, env, "property")
-
-
-def make_doc_translations_header(target, source, env):
-    make_translations_header(target, source, env, "doc")
-
-
-def make_extractable_translations_header(target, source, env):
-    make_translations_header(target, source, env, "extractable")
+        file.write("""\
+	{ nullptr, 0, 0, nullptr },
+};
+""")

--- a/editor/editor_translation.cpp
+++ b/editor/editor_translation.cpp
@@ -42,7 +42,7 @@
 Vector<String> get_editor_locales() {
 	Vector<String> locales;
 
-	EditorTranslationList *etl = _editor_translations;
+	const EditorTranslationList *etl = _editor_translations;
 	while (etl->data) {
 		const String &locale = etl->lang;
 		locales.push_back(locale);
@@ -56,7 +56,7 @@ Vector<String> get_editor_locales() {
 void load_editor_translations(const String &p_locale) {
 	const Ref<TranslationDomain> domain = TranslationServer::get_singleton()->get_or_add_domain("godot.editor");
 
-	EditorTranslationList *etl = _editor_translations;
+	const EditorTranslationList *etl = _editor_translations;
 	while (etl->data) {
 		if (etl->lang == p_locale) {
 			Vector<uint8_t> data;
@@ -84,7 +84,7 @@ void load_editor_translations(const String &p_locale) {
 void load_property_translations(const String &p_locale) {
 	const Ref<TranslationDomain> domain = TranslationServer::get_singleton()->get_or_add_domain("godot.properties");
 
-	PropertyTranslationList *etl = _property_translations;
+	const PropertyTranslationList *etl = _property_translations;
 	while (etl->data) {
 		if (etl->lang == p_locale) {
 			Vector<uint8_t> data;
@@ -112,7 +112,7 @@ void load_property_translations(const String &p_locale) {
 void load_doc_translations(const String &p_locale) {
 	const Ref<TranslationDomain> domain = TranslationServer::get_singleton()->get_or_add_domain("godot.documentation");
 
-	DocTranslationList *dtl = _doc_translations;
+	const DocTranslationList *dtl = _doc_translations;
 	while (dtl->data) {
 		if (dtl->lang == p_locale) {
 			Vector<uint8_t> data;
@@ -140,7 +140,7 @@ void load_doc_translations(const String &p_locale) {
 void load_extractable_translations(const String &p_locale) {
 	const Ref<TranslationDomain> domain = TranslationServer::get_singleton()->get_or_add_domain("godot.editor");
 
-	ExtractableTranslationList *etl = _extractable_translations;
+	const ExtractableTranslationList *etl = _extractable_translations;
 	while (etl->data) {
 		if (etl->lang == p_locale) {
 			Vector<uint8_t> data;
@@ -166,7 +166,7 @@ void load_extractable_translations(const String &p_locale) {
 }
 
 Vector<Vector<String>> get_extractable_message_list() {
-	ExtractableTranslationList *etl = _extractable_translations;
+	const ExtractableTranslationList *etl = _extractable_translations;
 	Vector<Vector<String>> list;
 
 	while (etl->data) {

--- a/editor/themes/SCsub
+++ b/editor/themes/SCsub
@@ -3,17 +3,14 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-import glob
-
 import editor_theme_builders
 
 # Fonts
-flist = glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.ttf")
-flist.extend(glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.otf"))
-flist.extend(glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.woff"))
-flist.extend(glob.glob(env.Dir("#thirdparty").abspath + "/fonts/*.woff2"))
+flist = Glob("#thirdparty/fonts/*.ttf")
+flist.extend(Glob("#thirdparty/fonts/*.otf"))
+flist.extend(Glob("#thirdparty/fonts/*.woff"))
+flist.extend(Glob("#thirdparty/fonts/*.woff2"))
 flist.sort()
-env.Depends("#editor/themes/builtin_fonts.gen.h", flist)
 env.CommandNoCache(
     "#editor/themes/builtin_fonts.gen.h",
     flist,

--- a/editor/themes/editor_theme_builders.py
+++ b/editor/themes/editor_theme_builders.py
@@ -2,28 +2,20 @@
 
 import os
 
+import methods
+
 
 def make_fonts_header(target, source, env):
-    dst = str(target[0])
+    with methods.generated_wrapper(str(target[0])) as file:
+        for src in map(str, source):
+            # Saving uncompressed, since FreeType will reference from memory pointer.
+            buffer = methods.get_buffer(src)
+            name = os.path.splitext(os.path.basename(src))[0]
 
-    with open(dst, "w", encoding="utf-8", newline="\n") as g:
-        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        g.write("#ifndef _EDITOR_FONTS_H\n")
-        g.write("#define _EDITOR_FONTS_H\n")
+            file.write(f"""\
+inline constexpr int _font_{name}_size = {len(buffer)};
+inline constexpr unsigned char _font_{name}[] = {{
+	{methods.format_buffer(buffer, 1)}
+}};
 
-        # Saving uncompressed, since FreeType will reference from memory pointer.
-        for i in range(len(source)):
-            file = str(source[i])
-            with open(file, "rb") as f:
-                buf = f.read()
-
-            name = os.path.splitext(os.path.basename(file))[0]
-
-            g.write("static const int _font_" + name + "_size = " + str(len(buf)) + ";\n")
-            g.write("static const unsigned char _font_" + name + "[] = {\n")
-            for j in range(len(buf)):
-                g.write("\t" + str(buf[j]) + ",\n")
-
-            g.write("};\n")
-
-        g.write("#endif")
+""")

--- a/main/SCsub
+++ b/main/SCsub
@@ -17,7 +17,6 @@ if env["steamapi"] and env.editor_build:
 if env["tests"]:
     env_main.Append(CPPDEFINES=["TESTS_ENABLED"])
 
-env_main.Depends("#main/splash.gen.h", "#main/splash.png")
 env_main.CommandNoCache(
     "#main/splash.gen.h",
     "#main/splash.png",
@@ -25,14 +24,12 @@ env_main.CommandNoCache(
 )
 
 if env_main.editor_build and not env_main["no_editor_splash"]:
-    env_main.Depends("#main/splash_editor.gen.h", "#main/splash_editor.png")
     env_main.CommandNoCache(
         "#main/splash_editor.gen.h",
         "#main/splash_editor.png",
         env.Run(main_builders.make_splash_editor),
     )
 
-env_main.Depends("#main/app_icon.gen.h", "#main/app_icon.png")
 env_main.CommandNoCache(
     "#main/app_icon.gen.h",
     "#main/app_icon.png",

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -1,60 +1,42 @@
 """Functions used to generate source files during build time"""
 
+import methods
+
 
 def make_splash(target, source, env):
-    src = str(source[0])
-    dst = str(target[0])
+    buffer = methods.get_buffer(str(source[0]))
 
-    with open(src, "rb") as f:
-        buf = f.read()
-
-    with open(dst, "w", encoding="utf-8", newline="\n") as g:
-        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        g.write("#ifndef BOOT_SPLASH_H\n")
-        g.write("#define BOOT_SPLASH_H\n")
+    with methods.generated_wrapper(str(target[0])) as file:
         # Use a neutral gray color to better fit various kinds of projects.
-        g.write("static const Color boot_splash_bg_color = Color(0.14, 0.14, 0.14);\n")
-        g.write("static const unsigned char boot_splash_png[] = {\n")
-        for i in range(len(buf)):
-            g.write(str(buf[i]) + ",\n")
-        g.write("};\n")
-        g.write("#endif")
+        file.write(f"""\
+static const Color boot_splash_bg_color = Color(0.14, 0.14, 0.14);
+inline constexpr const unsigned char boot_splash_png[] = {{
+	{methods.format_buffer(buffer, 1)}
+}};
+""")
 
 
 def make_splash_editor(target, source, env):
-    src = str(source[0])
-    dst = str(target[0])
+    buffer = methods.get_buffer(str(source[0]))
 
-    with open(src, "rb") as f:
-        buf = f.read()
-
-    with open(dst, "w", encoding="utf-8", newline="\n") as g:
-        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        g.write("#ifndef BOOT_SPLASH_EDITOR_H\n")
-        g.write("#define BOOT_SPLASH_EDITOR_H\n")
+    with methods.generated_wrapper(str(target[0])) as file:
         # The editor splash background color is taken from the default editor theme's background color.
         # This helps achieve a visually "smoother" transition between the splash screen and the editor.
-        g.write("static const Color boot_splash_editor_bg_color = Color(0.125, 0.145, 0.192);\n")
-        g.write("static const unsigned char boot_splash_editor_png[] = {\n")
-        for i in range(len(buf)):
-            g.write(str(buf[i]) + ",\n")
-        g.write("};\n")
-        g.write("#endif")
+        file.write(f"""\
+static const Color boot_splash_editor_bg_color = Color(0.125, 0.145, 0.192);
+inline constexpr const unsigned char boot_splash_editor_png[] = {{
+	{methods.format_buffer(buffer, 1)}
+}};
+""")
 
 
 def make_app_icon(target, source, env):
-    src = str(source[0])
-    dst = str(target[0])
+    buffer = methods.get_buffer(str(source[0]))
 
-    with open(src, "rb") as f:
-        buf = f.read()
-
-    with open(dst, "w", encoding="utf-8", newline="\n") as g:
-        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        g.write("#ifndef APP_ICON_H\n")
-        g.write("#define APP_ICON_H\n")
-        g.write("static const unsigned char app_icon_png[] = {\n")
-        for i in range(len(buf)):
-            g.write(str(buf[i]) + ",\n")
-        g.write("};\n")
-        g.write("#endif")
+    with methods.generated_wrapper(str(target[0])) as file:
+        # Use a neutral gray color to better fit various kinds of projects.
+        file.write(f"""\
+inline constexpr const unsigned char app_icon_png[] = {{
+	{methods.format_buffer(buffer, 1)}
+}};
+""")

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -17,8 +17,9 @@ Export("env_modules")
 
 # Header with MODULE_*_ENABLED defines.
 def modules_enabled_builder(target, source, env):
-    with methods.generated_wrapper(target) as file:
-        for module in source[0].read():
+    modules = sorted(source[0].read())
+    with methods.generated_wrapper(str(target[0])) as file:
+        for module in modules:
             file.write(f"#define MODULE_{module.upper()}_ENABLED\n")
 
 
@@ -29,14 +30,26 @@ modules_enabled = env.CommandNoCache(
 
 def register_module_types_builder(target, source, env):
     modules = source[0].read()
-    mod_inc = "\n".join([f'#include "{p}/register_types.h"' for p in modules.values()])
+    mod_inc = "\n".join([f'#include "{value}/register_types.h"' for value in modules.values()])
     mod_init = "\n".join(
-        [f"#ifdef MODULE_{n.upper()}_ENABLED\n\tinitialize_{n}_module(p_level);\n#endif" for n in modules.keys()]
+        [
+            f"""\
+#ifdef MODULE_{key.upper()}_ENABLED
+	initialize_{key}_module(p_level);
+#endif"""
+            for key in modules.keys()
+        ]
     )
     mod_uninit = "\n".join(
-        [f"#ifdef MODULE_{n.upper()}_ENABLED\n\tuninitialize_{n}_module(p_level);\n#endif" for n in modules.keys()]
+        [
+            f"""\
+#ifdef MODULE_{key.upper()}_ENABLED
+	uninitialize_{key}_module(p_level);
+#endif"""
+            for key in modules.keys()
+        ]
     )
-    with methods.generated_wrapper(target) as file:
+    with methods.generated_wrapper(str(target[0])) as file:
         file.write(
             f"""\
 #include "register_module_types.h"
@@ -88,9 +101,10 @@ for name, path in env.module_list.items():
 if env["tests"]:
 
     def modules_tests_builder(target, source, env):
-        with methods.generated_wrapper(target) as file:
-            for header in source:
-                file.write('#include "{}"\n'.format(os.path.normpath(header.path).replace("\\", "/")))
+        headers = sorted([os.path.relpath(src.path, methods.base_folder_path).replace("\\", "/") for src in source])
+        with methods.generated_wrapper(str(target[0])) as file:
+            for header in headers:
+                file.write(f'#include "{header}"\n')
 
     env.CommandNoCache("modules_tests.gen.h", test_headers, env.Run(modules_tests_builder))
 

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
+import methods
+
 Import("env")
 Import("env_modules")
 
@@ -8,28 +10,21 @@ env_text_server_adv = env_modules.Clone()
 
 
 def make_icu_data(target, source, env):
-    dst = target[0].srcnode().abspath
+    buffer = methods.get_buffer(str(source[0]))
+    with methods.generated_wrapper(str(target[0])) as file:
+        file.write(f"""\
+/* (C) 2016 and later: Unicode, Inc. and others. */
+/* License & terms of use: https://www.unicode.org/copyright.html */
 
-    with open(dst, "w", encoding="utf-8", newline="\n") as g:
-        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        g.write("/* (C) 2016 and later: Unicode, Inc. and others. */\n")
-        g.write("/* License & terms of use: https://www.unicode.org/copyright.html */\n")
-        g.write("#ifndef _ICU_DATA_H\n")
-        g.write("#define _ICU_DATA_H\n")
-        g.write('#include "unicode/utypes.h"\n')
-        g.write('#include "unicode/udata.h"\n')
-        g.write('#include "unicode/uversion.h"\n')
+#include <unicode/utypes.h>
+#include <unicode/udata.h>
+#include <unicode/uversion.h>
 
-        with open(source[0].srcnode().abspath, "rb") as f:
-            buf = f.read()
-
-        g.write('extern "C" U_EXPORT const size_t U_ICUDATA_SIZE = ' + str(len(buf)) + ";\n")
-        g.write('extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = {\n')
-        for i in range(len(buf)):
-            g.write("\t" + str(buf[i]) + ",\n")
-
-        g.write("};\n")
-        g.write("#endif")
+extern "C" U_EXPORT const size_t U_ICUDATA_SIZE = {len(buffer)};
+extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = {{
+	{methods.format_buffer(buffer, 1)}
+}};
+""")
 
 
 # Thirdparty source files

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -18,10 +18,10 @@ def export_icon_builder(target, source, env):
     platform = src_path.parent.parent.stem
     with open(str(source[0]), "r") as file:
         svg = file.read()
-    with methods.generated_wrapper(target) as file:
+    with methods.generated_wrapper(str(target[0])) as file:
         file.write(
             f"""\
-static const char *_{platform}_{src_name}_svg = {methods.to_raw_cstring(svg)};
+inline constexpr const char *_{platform}_{src_name}_svg = {methods.to_raw_cstring(svg)};
 """
         )
 
@@ -37,7 +37,7 @@ def register_platform_apis_builder(target, source, env):
     api_inc = "\n".join([f'#include "{p}/api/api.h"' for p in platforms])
     api_reg = "\n".join([f"\tregister_{p}_api();" for p in platforms])
     api_unreg = "\n".join([f"\tunregister_{p}_api();" for p in platforms])
-    with methods.generated_wrapper(target) as file:
+    with methods.generated_wrapper(str(target[0])) as file:
         file.write(
             f"""\
 #include "register_platform_apis.h"

--- a/scene/theme/SCsub
+++ b/scene/theme/SCsub
@@ -9,7 +9,6 @@ env.add_source_files(env.scene_sources, "*.cpp")
 
 SConscript("icons/SCsub")
 
-env.Depends("#scene/theme/default_font.gen.h", "#thirdparty/fonts/OpenSans_SemiBold.woff2")
 env.CommandNoCache(
     "#scene/theme/default_font.gen.h",
     "#thirdparty/fonts/OpenSans_SemiBold.woff2",

--- a/scene/theme/default_theme_builders.py
+++ b/scene/theme/default_theme_builders.py
@@ -1,30 +1,21 @@
 """Functions used to generate source files during build time"""
 
 import os
-import os.path
+
+import methods
 
 
 def make_fonts_header(target, source, env):
-    dst = str(target[0])
+    with methods.generated_wrapper(str(target[0])) as file:
+        for src in map(str, source):
+            # Saving uncompressed, since FreeType will reference from memory pointer.
+            buffer = methods.get_buffer(src)
+            name = os.path.splitext(os.path.basename(src))[0]
 
-    with open(dst, "w", encoding="utf-8", newline="\n") as g:
-        g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-        g.write("#ifndef _DEFAULT_FONTS_H\n")
-        g.write("#define _DEFAULT_FONTS_H\n")
+            file.write(f"""\
+inline constexpr int _font_{name}_size = {len(buffer)};
+inline constexpr unsigned char _font_{name}[] = {{
+	{methods.format_buffer(buffer, 1)}
+}};
 
-        # Saving uncompressed, since FreeType will reference from memory pointer.
-        for i in range(len(source)):
-            file = str(source[i])
-            with open(file, "rb") as f:
-                buf = f.read()
-
-            name = os.path.splitext(os.path.basename(file))[0]
-
-            g.write("static const int _font_" + name + "_size = " + str(len(buf)) + ";\n")
-            g.write("static const unsigned char _font_" + name + "[] = {\n")
-            for j in range(len(buf)):
-                g.write("\t" + str(buf[j]) + ",\n")
-
-            g.write("};\n")
-
-        g.write("#endif")
+""")

--- a/scene/theme/icons/default_theme_icons_builders.py
+++ b/scene/theme/icons/default_theme_icons_builders.py
@@ -1,51 +1,35 @@
 """Functions used to generate source files during build time"""
 
 import os
-from io import StringIO
 
-from methods import to_raw_cstring
+import methods
 
 
 # See also `editor/icons/editor_icons_builders.py`.
 def make_default_theme_icons_action(target, source, env):
-    dst = str(target[0])
-    svg_icons = [str(x) for x in source]
+    icons_names = []
+    icons_raw = []
 
-    with StringIO() as icons_string, StringIO() as s:
-        for svg in svg_icons:
-            with open(svg, "r") as svgf:
-                icons_string.write("\t%s,\n" % to_raw_cstring(svgf.read()))
+    for src in map(str, source):
+        with open(src, encoding="utf-8", newline="\n") as file:
+            icons_raw.append(methods.to_raw_cstring(file.read()))
 
-        s.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n\n")
-        s.write('#include "modules/modules_enabled.gen.h"\n\n')
-        s.write("#ifndef _DEFAULT_THEME_ICONS_H\n")
-        s.write("#define _DEFAULT_THEME_ICONS_H\n")
-        s.write("static const int default_theme_icons_count = {};\n\n".format(len(svg_icons)))
-        s.write("#ifdef MODULE_SVG_ENABLED\n")
-        s.write("static const char *default_theme_icons_sources[] = {\n")
-        s.write(icons_string.getvalue())
-        s.write("};\n")
-        s.write("#endif // MODULE_SVG_ENABLED\n\n")
-        s.write("static const char *default_theme_icons_names[] = {\n")
+        name = os.path.splitext(os.path.basename(src))[0]
+        icons_names.append(f'"{name}"')
 
-        index = 0
-        for f in svg_icons:
-            fname = str(f)
+    icons_names_str = ",\n\t".join(icons_names)
+    icons_raw_str = ",\n\t".join(icons_raw)
 
-            # Trim the `.svg` extension from the string.
-            icon_name = os.path.basename(fname)[:-4]
+    with methods.generated_wrapper(str(target[0])) as file:
+        file.write(f"""\
+#include "modules/modules_enabled.gen.h"
 
-            s.write('\t"{0}"'.format(icon_name))
+inline constexpr int default_theme_icons_count = {len(icons_names)};
+inline constexpr const char *default_theme_icons_sources[] = {{
+	{icons_raw_str}
+}};
 
-            if fname != svg_icons[-1]:
-                s.write(",")
-            s.write("\n")
-
-            index += 1
-
-        s.write("};\n")
-
-        s.write("#endif\n")
-
-        with open(dst, "w", encoding="utf-8", newline="\n") as f:
-            f.write(s.getvalue())
+inline constexpr const char *default_theme_icons_names[] = {{
+	{icons_names_str}
+}};
+""")


### PR DESCRIPTION
While a healthy chunk of the generated scripts are using the new wrapper formatting, that isn't the case for everything in the repo. Specifically, scripts that were part of the SCons pipeline already weren't included in the native generation PR[^1]. While a bit later than I initially intended, this is a followup to that PR to apply the same glowup to other builders. In addition to cleaning up the build scripts themselves, the actual contents of the generated files were updated to utilize `constexpr` where appropriate. This deliberately excludes the shader builders, as those necessitate a more involved pass & I'd rather not get hung up on that when the rest of the bulk changes remain fairly isolated.

[^1]: #91624