### PR TITLE
Add `Tween.tween_subtween` method for nesting tweens within each other

### DIFF
--- a/doc/classes/SubtweenTweener.xml
+++ b/doc/classes/SubtweenTweener.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SubtweenTweener" inherits="Tweener" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Runs a [Tween] nested within another [Tween].
+	</brief_description>
+	<description>
+		[SubtweenTweener] is used to execute a [Tween] as one step in a sequence defined by another [Tween]. See [method Tween.tween_subtween] for more usage information.
+		[b]Note:[/b] [method Tween.tween_subtween] is the only correct way to create [SubtweenTweener]. Any [SubtweenTweener] created manually will not function correctly.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="set_delay">
+			<return type="SubtweenTweener" />
+			<param index="0" name="delay" type="float" />
+			<description>
+				Sets the time in seconds after which the [SubtweenTweener] will start running the subtween. By default there's no delay.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -473,6 +473,27 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="tween_subtween">
+			<return type="SubtweenTweener" />
+			<param index="0" name="subtween" type="Tween" />
+			<description>
+				Creates and appends a [SubtweenTweener]. This method can be used to nest [param subtween] within this [Tween], allowing for the creation of more complex and composable sequences.
+				[codeblock]
+				# Subtween will rotate the object.
+				var subtween = create_tween()
+				subtween.tween_property(self, "rotation_degrees", 45.0, 1.0)
+				subtween.tween_property(self, "rotation_degrees", 0.0, 1.0)
+
+				# Parent tween will execute the subtween as one of its steps.
+				var tween = create_tween()
+				tween.tween_property(self, "position:x", 500, 3.0)
+				tween.tween_subtween(subtween)
+				tween.tween_property(self, "position:x", 300, 2.0)
+				[/codeblock]
+				[b]Note:[/b] The methods [method pause], [method stop], and [method set_loops] can cause the parent [Tween] to get stuck on the subtween step; see the documentation for those methods for more information.
+				[b]Note:[/b] The pause and process modes set by [method set_pause_mode] and [method set_process_mode] on [param subtween] will be overridden by the parent [Tween]'s settings.
+			</description>
+		</method>
 	</methods>
 	<signals>
 		<signal name="finished">

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -154,6 +154,25 @@ Ref<MethodTweener> Tween::tween_method(const Callable &p_callback, const Variant
 	return tweener;
 }
 
+Ref<SubtweenTweener> Tween::tween_subtween(const Ref<Tween> &p_subtween) {
+	CHECK_VALID();
+
+	// Ensure that the subtween being added is not null.
+	ERR_FAIL_COND_V(p_subtween.is_null(), nullptr);
+
+	Ref<SubtweenTweener> tweener;
+	tweener.instantiate(p_subtween);
+
+	// Remove the tween from its parent tree, if it has one.
+	// If the user created this tween without a parent tree attached,
+	// then this step isn't necessary.
+	if (tweener->subtween->parent_tree != nullptr) {
+		tweener->subtween->parent_tree->remove_tween(tweener->subtween);
+	}
+	append(tweener);
+	return tweener;
+}
+
 void Tween::append(Ref<Tweener> p_tweener) {
 	p_tweener->set_tween(this);
 
@@ -447,6 +466,7 @@ void Tween::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("tween_interval", "time"), &Tween::tween_interval);
 	ClassDB::bind_method(D_METHOD("tween_callback", "callback"), &Tween::tween_callback);
 	ClassDB::bind_method(D_METHOD("tween_method", "method", "from", "to", "duration"), &Tween::tween_method);
+	ClassDB::bind_method(D_METHOD("tween_subtween", "subtween"), &Tween::tween_subtween);
 
 	ClassDB::bind_method(D_METHOD("custom_step", "delta"), &Tween::custom_step);
 	ClassDB::bind_method(D_METHOD("stop"), &Tween::stop);
@@ -510,6 +530,11 @@ Tween::Tween() {
 
 Tween::Tween(bool p_valid) {
 	valid = p_valid;
+}
+
+Tween::Tween(SceneTree *p_parent_tree) {
+	parent_tree = p_parent_tree;
+	valid = true;
 }
 
 Ref<PropertyTweener> PropertyTweener::from(const Variant &p_value) {
@@ -853,4 +878,52 @@ MethodTweener::MethodTweener(const Callable &p_callback, const Variant &p_from, 
 
 MethodTweener::MethodTweener() {
 	ERR_FAIL_MSG("MethodTweener can't be created directly. Use the tween_method() method in Tween.");
+}
+
+void SubtweenTweener::start() {
+	elapsed_time = 0;
+	finished = false;
+
+	// Reset the subtween.
+	subtween->stop();
+	subtween->play();
+}
+
+bool SubtweenTweener::step(double &r_delta) {
+	if (finished) {
+		return false;
+	}
+
+	elapsed_time += r_delta;
+
+	if (elapsed_time < delay) {
+		r_delta = 0;
+		return true;
+	}
+
+	if (!subtween->step(r_delta)) {
+		r_delta = elapsed_time - delay - subtween->get_total_time();
+		_finish();
+		return false;
+	}
+
+	r_delta = 0;
+	return true;
+}
+
+Ref<SubtweenTweener> SubtweenTweener::set_delay(double p_delay) {
+	delay = p_delay;
+	return this;
+}
+
+void SubtweenTweener::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_delay", "delay"), &SubtweenTweener::set_delay);
+}
+
+SubtweenTweener::SubtweenTweener(const Ref<Tween> &p_subtween) {
+	subtween = p_subtween;
+}
+
+SubtweenTweener::SubtweenTweener() {
+	ERR_FAIL_MSG("SubtweenTweener can't be created directly. Use the tween_subtween() method in Tween.");
 }

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -35,6 +35,7 @@
 
 class Tween;
 class Node;
+class SceneTree;
 
 class Tweener : public RefCounted {
 	GDCLASS(Tweener, RefCounted);
@@ -60,6 +61,7 @@ class PropertyTweener;
 class IntervalTweener;
 class CallbackTweener;
 class MethodTweener;
+class SubtweenTweener;
 
 class Tween : public RefCounted {
 	GDCLASS(Tween, RefCounted);
@@ -109,6 +111,7 @@ private:
 	EaseType default_ease = EaseType::EASE_IN_OUT;
 	ObjectID bound_node;
 
+	SceneTree *parent_tree = nullptr;
 	Vector<List<Ref<Tweener>>> tweeners;
 	double total_time = 0;
 	int current_step = -1;
@@ -145,6 +148,7 @@ public:
 	Ref<IntervalTweener> tween_interval(double p_time);
 	Ref<CallbackTweener> tween_callback(const Callable &p_callback);
 	Ref<MethodTweener> tween_method(const Callable &p_callback, const Variant p_from, Variant p_to, double p_duration);
+	Ref<SubtweenTweener> tween_subtween(const Ref<Tween> &p_subtween);
 	void append(Ref<Tweener> p_tweener);
 
 	bool custom_step(double p_delta);
@@ -187,6 +191,7 @@ public:
 
 	Tween();
 	Tween(bool p_valid);
+	Tween(SceneTree *p_parent_tree);
 };
 
 VARIANT_ENUM_CAST(Tween::TweenPauseMode);
@@ -303,6 +308,26 @@ private:
 	Callable callback;
 
 	Ref<RefCounted> ref_copy;
+};
+
+class SubtweenTweener : public Tweener {
+	GDCLASS(SubtweenTweener, Tweener);
+
+public:
+	Ref<Tween> subtween;
+	void start() override;
+	bool step(double &r_delta) override;
+
+	Ref<SubtweenTweener> set_delay(double p_delay);
+
+	SubtweenTweener(const Ref<Tween> &p_subtween);
+	SubtweenTweener();
+
+protected:
+	static void _bind_methods();
+
+private:
+	double delay = 0;
 };
 
 #endif // TWEEN_H

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1583,9 +1583,15 @@ Ref<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, bool p_process_a
 
 Ref<Tween> SceneTree::create_tween() {
 	_THREAD_SAFE_METHOD_
-	Ref<Tween> tween = memnew(Tween(true));
+	Ref<Tween> tween;
+	tween.instantiate(this);
 	tweens.push_back(tween);
 	return tween;
+}
+
+bool SceneTree::remove_tween(const Ref<Tween> &p_tween) {
+	_THREAD_SAFE_METHOD_
+	return tweens.erase(p_tween);
 }
 
 TypedArray<Tween> SceneTree::get_processed_tweens() {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -411,6 +411,7 @@ public:
 
 	Ref<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false);
 	Ref<Tween> create_tween();
+	bool remove_tween(const Ref<Tween> &p_tween);
 	TypedArray<Tween> get_processed_tweens();
 
 	//used by Main::start, don't use otherwise

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -504,6 +504,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(IntervalTweener);
 	GDREGISTER_CLASS(CallbackTweener);
 	GDREGISTER_CLASS(MethodTweener);
+	GDREGISTER_CLASS(SubtweenTweener);
 
 	GDREGISTER_ABSTRACT_CLASS(AnimationMixer);
 	GDREGISTER_CLASS(AnimationPlayer);


### PR DESCRIPTION
This is an implementation of https://github.com/godotengine/godot-proposals/issues/11022, which adds the `tween_subtween` method to the `Tween` class. Using this method, `Tween` objects can be nested within each other and scheduled to play at specified points.

It's not fully complete yet (see the to do list below), but I wanted to get a draft posted with the core functionality so that others could give their thoughts on it. I'm especially unsure about the method used to remove a `Tween` from the `SceneTree`'s `tweens` list once it is made into a subtween.

## Example usage

![](https://user-images.githubusercontent.com/14253836/139410111-b07cce83-70b1-4ad8-acfd-7af05f3e9ef7.png)

```gdscript
extends Sprite2D

var speed := 5.0

func _ready():		
	# Holds the sequence of 5-then-6
	var subtween_5_6: Tween = create_tween()
	subtween_5_6.tween_property(self, "rotation_degrees", 80.0, 0.4 * speed) # 5
	subtween_5_6.tween_property(self, "rotation_degrees", -20.0, 0.6 * speed) # 6
	
	# Holds subsequence of 4 at the same time as 5-then-6
	var subtween_4_5_6: Tween = create_tween()
	subtween_4_5_6.tween_property(self, "position:x", 100, 1.0 * speed) # 4
	subtween_4_5_6.parallel().tween_subtween(subtween_5_6) # 5-then-6

	# Overall tween
	var tween: Tween = create_tween()
	tween.tween_property(self, "position:x", 100, 1.0 * speed) # 1
	tween.tween_property(self, "position:x", 300, 0.5 * speed) # 2
	tween.parallel().tween_property(self, "rotation_degrees", 45.0, 0.3 * speed) # 3
	tween.tween_subtween(subtween_4_5_6) # 4 and 5-then-6
```

https://github.com/user-attachments/assets/91259762-a6b2-4b52-8ba4-58777b81b985


## Example project

[tween-subtween.zip](https://github.com/user-attachments/files/17605459/tween-subtween.zip)

Inside this project are several `*_test` folders; you can open them and run the scenes inside to see demos of the method in action.

## To do

- [x] Confirm that the approach to removing `Tween`s from the `SceneTree` is okay, or improve it if necessary
- [x] Add functions for parity with other `Tweener` subclasses
   - ~~`set_trans`~~ Infeasible due to the way default transitions and tween evaluation is implemented
   - ~~`set_ease`~~ Infeasible due to the way default transitions and tween evaluation is implemented
   - [x] `set_delay`
   - ~~`set_custom_interpolator`~~ May be out of scope for now, and not necessary enough (possibly best to implement on `Tween` itself?)
- [x] Confirm that the behavior of `Tween` features like loops, play, pause, etc doesn't break when in a parent `Tween`
   - [x] Loops (note that an infinitely looping subtween will cause that step of the parent tween to never finish)
   - [x] Play/Pause (note that a paused subtween will cause that step of the parent tween to never finish)
   - [x] Stop
   - [x] Kill
   - [x] Set speed scale
- [x] Reset subtween when parent tween resets in loop
- [x] Documentation
   - [x] Add a code example in the documentation for `Tween.tween_subtween`
   - [x] Add note to `Tween.play` and `Tween.pause` that a paused subtween will result in the parent tween never moving past that step
   - [x] Add note to `Tween.set_loops` that an infinitely-looping subtween will result in the parent tween never moving past that step
   - [x] Add notes to `Tween.set_pause_mode` and `Tween.set_process_mode` that they will not have an effect when the tween is a subtween

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/11022*