### PR TITLE
Add FilterLineEdit to unify editor filter field navigation

### DIFF
--- a/editor/doc/editor_help_search.cpp
+++ b/editor/doc/editor_help_search.cpp
@@ -33,6 +33,7 @@
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
@@ -170,17 +171,6 @@ void EditorHelpSearch::_update_results() {
 	}
 }
 
-void EditorHelpSearch::_search_box_gui_input(const Ref<InputEvent> &p_event) {
-	// Redirect navigational key events to the tree.
-	Ref<InputEventKey> key = p_event;
-	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			results_tree->gui_input(key);
-			search_box->accept_event();
-		}
-	}
-}
-
 void EditorHelpSearch::_search_box_text_changed(const String &p_text) {
 	_update_results();
 }
@@ -241,9 +231,6 @@ void EditorHelpSearch::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const int icon_width = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 			results_tree->add_theme_constant_override("icon_max_width", icon_width);
-
-			search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
-			search_box->add_theme_icon_override("right_icon", get_editor_theme_icon(SNAME("Search")));
 
 			case_sensitive_button->set_button_icon(get_editor_theme_icon(SNAME("MatchCase")));
 			hierarchy_button->set_button_icon(get_editor_theme_icon(SNAME("ClassList")));
@@ -329,12 +316,10 @@ EditorHelpSearch::EditorHelpSearch() {
 	HBoxContainer *hbox = memnew(HBoxContainer);
 	vbox->add_child(hbox);
 
-	search_box = memnew(LineEdit);
+	search_box = memnew(FilterLineEdit);
 	search_box->set_accessibility_name(TTRC("Search"));
 	search_box->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	search_box->set_clear_button_enabled(true);
-	search_box->connect(SceneStringName(gui_input), callable_mp(this, &EditorHelpSearch::_search_box_gui_input));
 	search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorHelpSearch::_search_box_text_changed));
 	register_text_enter(search_box);
 	hbox->add_child(search_box);
@@ -381,6 +366,7 @@ EditorHelpSearch::EditorHelpSearch() {
 
 	// Create the results tree.
 	results_tree = memnew(Tree);
+	search_box->set_forward_control(results_tree);
 	results_tree->set_accessibility_name(TTRC("Search Results"));
 	results_tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	results_tree->set_columns(2);

--- a/editor/doc/editor_help_search.h
+++ b/editor/doc/editor_help_search.h
@@ -35,6 +35,8 @@
 #include "scene/gui/option_button.h"
 #include "scene/gui/tree.h"
 
+class FilterLineEdit;
+
 class EditorHelpSearch : public ConfirmationDialog {
 	GDCLASS(EditorHelpSearch, ConfirmationDialog);
 
@@ -53,7 +55,7 @@ class EditorHelpSearch : public ConfirmationDialog {
 		SEARCH_SHOW_HIERARCHY = 1 << 30
 	};
 
-	LineEdit *search_box = nullptr;
+	FilterLineEdit *search_box = nullptr;
 	Button *case_sensitive_button = nullptr;
 	Button *hierarchy_button = nullptr;
 	OptionButton *filter_combo = nullptr;
@@ -77,7 +79,6 @@ class EditorHelpSearch : public ConfirmationDialog {
 
 	void _update_results();
 
-	void _search_box_gui_input(const Ref<InputEvent> &p_event);
 	void _search_box_text_changed(const String &p_text);
 	void _filter_combo_item_selected(int p_option);
 	void _confirmed();

--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -32,12 +32,17 @@
 
 #include "core/io/resource_loader.h"
 #include "core/object/class_db.h"
+#include "editor/doc/editor_help.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/file_system/editor_paths.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/button.h"
+#include "scene/gui/item_list.h"
+#include "scene/gui/tree.h"
 
 void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String &p_current_type, const String &p_current_name) {
 	_fill_type_list();
@@ -539,10 +544,7 @@ void CreateDialog::_sbox_input(const Ref<InputEvent> &p_event) {
 	// Redirect navigational key events to the tree.
 	Ref<InputEventKey> key = p_event;
 	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			search_options->gui_input(key);
-			search_box->accept_event();
-		} else if (key->is_action_pressed("ui_select", true)) {
+		if (key->is_action_pressed("ui_select", true)) {
 			TreeItem *ti = search_options->get_selected();
 			if (ti) {
 				ti->set_collapsed(!ti->is_collapsed());
@@ -577,7 +579,6 @@ void CreateDialog::_notification(int p_what) {
 			favorites->add_theme_constant_override("icon_max_width", icon_width);
 			recent->set_fixed_icon_size(Size2(icon_width, icon_width));
 
-			search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			favorite->set_button_icon(get_editor_theme_icon(SNAME("Favorites")));
 		} break;
 	}
@@ -923,12 +924,10 @@ CreateDialog::CreateDialog() {
 	vbc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vsc_right->add_child(vbc);
 
-	search_box = memnew(LineEdit);
+	search_box = memnew(FilterLineEdit);
 	search_box->set_accessibility_name(TTRC("Search"));
-	search_box->set_clear_button_enabled(true);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search_box->connect(SceneStringName(text_changed), callable_mp(this, &CreateDialog::_text_changed));
-	search_box->connect(SceneStringName(gui_input), callable_mp(this, &CreateDialog::_sbox_input));
 
 	HBoxContainer *search_hb = memnew(HBoxContainer);
 	search_hb->add_child(search_box);
@@ -941,6 +940,7 @@ CreateDialog::CreateDialog() {
 	vbc->add_margin_child(TTR("Search:"), search_hb);
 
 	search_options = memnew(Tree);
+	search_box->set_forward_control(search_options);
 	search_options->set_accessibility_name(TTRC("Matches:"));
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	search_options->connect("item_activated", callable_mp(this, &CreateDialog::_confirmed));

--- a/editor/gui/create_dialog.h
+++ b/editor/gui/create_dialog.h
@@ -30,12 +30,14 @@
 
 #pragma once
 
-#include "editor/doc/editor_help.h"
-#include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
-#include "scene/gui/item_list.h"
-#include "scene/gui/line_edit.h"
-#include "scene/gui/tree.h"
+
+class Button;
+class EditorHelpBit;
+class FilterLineEdit;
+class ItemList;
+class Tree;
+class TreeItem;
 
 class CreateDialog : public ConfirmationDialog {
 	GDCLASS(CreateDialog, ConfirmationDialog);
@@ -51,7 +53,7 @@ class CreateDialog : public ConfirmationDialog {
 		PackedStringArray search_keywords;
 	};
 
-	LineEdit *search_box = nullptr;
+	FilterLineEdit *search_box = nullptr;
 	Tree *search_options = nullptr;
 
 	String base_type;

--- a/editor/gui/filter_line_edit.cpp
+++ b/editor/gui/filter_line_edit.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  property_selector.h                                                   */
+/*  filter_line_edit.cpp                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,59 +28,37 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#include "filter_line_edit.h"
 
-#include "scene/gui/dialogs.h"
+void FilterLineEdit::_notification(int p_what) {
+	if (p_what == NOTIFICATION_THEME_CHANGED) {
+		set_right_icon(get_editor_theme_icon(SNAME("Search")));
+	}
+}
 
-class EditorHelpBit;
-class FilterLineEdit;
-class LineEdit;
-class Tree;
-class TreeItem;
+void FilterLineEdit::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_NULL(forward_control);
 
-class PropertySelector : public ConfirmationDialog {
-	GDCLASS(PropertySelector, ConfirmationDialog);
+	Ref<InputEventKey> key = p_event;
+	if (key.is_null()) {
+		LineEdit::gui_input(p_event);
+		return;
+	}
 
-	FilterLineEdit *search_box = nullptr;
-	Tree *search_options = nullptr;
+	// Redirect navigational key events to the control.
+	if (key->is_action(SNAME("ui_up"), true) || key->is_action(SNAME("ui_down"), true) || key->is_action(SNAME("ui_page_up")) || key->is_action(SNAME("ui_page_down"))) {
+		forward_control->gui_input(key);
+		accept_event();
+		return;
+	}
+	LineEdit::gui_input(p_event);
+}
 
-	void _text_changed(const String &p_newtext);
-	void _update_search();
-	void _confirmed();
-	void _item_selected();
-	void _hide_requested();
+void FilterLineEdit::set_forward_control(Control *p_control) {
+	ERR_FAIL_NULL(p_control);
+	forward_control = p_control;
+}
 
-	EditorHelpBit *help_bit = nullptr;
-
-	bool properties = false;
-	String selected;
-	Variant::Type type = Variant::NIL;
-	String base_type;
-	ObjectID script;
-	Object *instance = nullptr;
-	bool virtuals_only = false;
-
-	Vector<Variant::Type> type_filter;
-
-	void _create_subproperties(TreeItem *p_parent_item, Variant::Type p_type);
-	void _create_subproperty(TreeItem *p_parent_item, const String &p_name, Variant::Type p_type);
-
-protected:
-	void _notification(int p_what);
-	static void _bind_methods();
-
-public:
-	void select_method_from_base_type(const String &p_base, const String &p_current = "", bool p_virtuals_only = false);
-	void select_method_from_script(const Ref<Script> &p_script, const String &p_current = "");
-	void select_method_from_basic_type(Variant::Type p_type, const String &p_current = "");
-	void select_method_from_instance(Object *p_instance, const String &p_current = "");
-
-	void select_property_from_base_type(const String &p_base, const String &p_current = "");
-	void select_property_from_script(const Ref<Script> &p_script, const String &p_current = "");
-	void select_property_from_basic_type(Variant::Type p_type, const String &p_current = "");
-	void select_property_from_instance(Object *p_instance, const String &p_current = "");
-
-	void set_type_filter(const Vector<Variant::Type> &p_type_filter);
-
-	PropertySelector();
-};
+FilterLineEdit::FilterLineEdit() {
+	set_clear_button_enabled(true);
+}

--- a/editor/gui/filter_line_edit.h
+++ b/editor/gui/filter_line_edit.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  property_selector.h                                                   */
+/*  filter_line_edit.h                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,57 +30,20 @@
 
 #pragma once
 
-#include "scene/gui/dialogs.h"
+#include "scene/gui/line_edit.h"
 
-class EditorHelpBit;
-class FilterLineEdit;
-class LineEdit;
-class Tree;
-class TreeItem;
+class FilterLineEdit : public LineEdit {
+	GDCLASS(FilterLineEdit, LineEdit);
 
-class PropertySelector : public ConfirmationDialog {
-	GDCLASS(PropertySelector, ConfirmationDialog);
-
-	FilterLineEdit *search_box = nullptr;
-	Tree *search_options = nullptr;
-
-	void _text_changed(const String &p_newtext);
-	void _update_search();
-	void _confirmed();
-	void _item_selected();
-	void _hide_requested();
-
-	EditorHelpBit *help_bit = nullptr;
-
-	bool properties = false;
-	String selected;
-	Variant::Type type = Variant::NIL;
-	String base_type;
-	ObjectID script;
-	Object *instance = nullptr;
-	bool virtuals_only = false;
-
-	Vector<Variant::Type> type_filter;
-
-	void _create_subproperties(TreeItem *p_parent_item, Variant::Type p_type);
-	void _create_subproperty(TreeItem *p_parent_item, const String &p_name, Variant::Type p_type);
+	Control *forward_control = nullptr;
 
 protected:
 	void _notification(int p_what);
-	static void _bind_methods();
+
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
-	void select_method_from_base_type(const String &p_base, const String &p_current = "", bool p_virtuals_only = false);
-	void select_method_from_script(const Ref<Script> &p_script, const String &p_current = "");
-	void select_method_from_basic_type(Variant::Type p_type, const String &p_current = "");
-	void select_method_from_instance(Object *p_instance, const String &p_current = "");
+	void set_forward_control(Control *p_control);
 
-	void select_property_from_base_type(const String &p_base, const String &p_current = "");
-	void select_property_from_script(const Ref<Script> &p_script, const String &p_current = "");
-	void select_property_from_basic_type(Variant::Type p_type, const String &p_current = "");
-	void select_property_from_instance(Object *p_instance, const String &p_current = "");
-
-	void set_type_filter(const Vector<Variant::Type> &p_type_filter);
-
-	PropertySelector();
+	FilterLineEdit();
 };

--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -32,39 +32,13 @@
 
 #include "editor/doc/editor_help.h"
 #include "editor/editor_node.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/themes/editor_scale.h"
-#include "scene/gui/line_edit.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/tree.h"
 
 void PropertySelector::_text_changed(const String &p_newtext) {
 	_update_search();
-}
-
-void PropertySelector::_sbox_input(const Ref<InputEvent> &p_event) {
-	// Redirect navigational key events to the tree.
-	Ref<InputEventKey> key = p_event;
-	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			search_options->gui_input(key);
-			search_box->accept_event();
-
-			TreeItem *root = search_options->get_root();
-			if (!root->get_first_child()) {
-				return;
-			}
-
-			TreeItem *current = search_options->get_selected();
-
-			TreeItem *item = search_options->get_next_selected(root);
-			while (item) {
-				item->deselect(0);
-				item = search_options->get_next_selected(item);
-			}
-
-			current->select(0);
-		}
-	}
 }
 
 void PropertySelector::_update_search() {
@@ -670,14 +644,13 @@ PropertySelector::PropertySelector() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
 
-	search_box = memnew(LineEdit);
+	search_box = memnew(FilterLineEdit);
 	search_box->set_accessibility_name(TTRC("Search:"));
-	search_box->set_clear_button_enabled(true);
-	search_box->connect(SceneStringName(text_changed), callable_mp(this, &PropertySelector::_text_changed));
-	search_box->connect(SceneStringName(gui_input), callable_mp(this, &PropertySelector::_sbox_input));
 	vbc->add_margin_child(TTRC("Search:"), search_box);
+	search_box->connect(SceneStringName(text_changed), callable_mp(this, &PropertySelector::_text_changed));
 
 	search_options = memnew(Tree);
+	search_box->set_forward_control(search_options);
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	search_options->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	MarginContainer *mc = vbc->add_margin_child(TTRC("Matches:"), search_options, true);

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -41,6 +41,7 @@
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_spin_slider.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/gui/progress_dialog.h"
 #include "editor/inspector/editor_resource_picker.h"
 #include "editor/settings/editor_command_palette.h"
@@ -2233,17 +2234,6 @@ void ThemeTypeDialog::_add_type_filter_cbk(const String &p_value) {
 	_update_add_type_options(p_value);
 }
 
-void ThemeTypeDialog::_type_filter_input(const Ref<InputEvent> &p_event) {
-	// Redirect navigational key events to the item list.
-	Ref<InputEventKey> key = p_event;
-	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			add_type_options->gui_input(key);
-			add_type_filter->accept_event();
-		}
-	}
-}
-
 void ThemeTypeDialog::_add_type_options_cbk(int p_index) {
 	add_type_filter->set_text(add_type_options->get_item_text(p_index));
 	add_type_filter->set_caret_column(add_type_filter->get_text().length());
@@ -2312,11 +2302,10 @@ ThemeTypeDialog::ThemeTypeDialog() {
 	add_type_filter_label->set_text(TTR("Filter the list of types or create a new custom type:"));
 	add_type_vb->add_child(add_type_filter_label);
 
-	add_type_filter = memnew(LineEdit);
+	add_type_filter = memnew(FilterLineEdit);
 	add_type_vb->add_child(add_type_filter);
 	add_type_filter->connect(SceneStringName(text_changed), callable_mp(this, &ThemeTypeDialog::_add_type_filter_cbk));
 	add_type_filter->connect(SceneStringName(text_submitted), callable_mp(this, &ThemeTypeDialog::_add_type_dialog_entered));
-	add_type_filter->connect(SceneStringName(gui_input), callable_mp(this, &ThemeTypeDialog::_type_filter_input));
 
 	Label *add_type_options_label = memnew(Label);
 	add_type_options_label->set_text(TTR("Available Node-based types:"));
@@ -2328,6 +2317,7 @@ ThemeTypeDialog::ThemeTypeDialog() {
 	add_type_vb->add_child(mc);
 
 	add_type_options = memnew(ItemList);
+	add_type_filter->set_forward_control(add_type_options);
 	add_type_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	add_type_options->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTH);
 	mc->add_child(add_type_options);

--- a/editor/scene/gui/theme_editor_plugin.h
+++ b/editor/scene/gui/theme_editor_plugin.h
@@ -41,6 +41,7 @@
 class Button;
 class CheckButton;
 class EditorFileDialog;
+class FilterLineEdit;
 class ItemList;
 class Label;
 class LineEdit;
@@ -295,7 +296,7 @@ class ThemeTypeDialog : public ConfirmationDialog {
 
 	String pre_submitted_value;
 
-	LineEdit *add_type_filter = nullptr;
+	FilterLineEdit *add_type_filter = nullptr;
 	ItemList *add_type_options = nullptr;
 	ConfirmationDialog *add_type_confirmation = nullptr;
 
@@ -305,7 +306,6 @@ class ThemeTypeDialog : public ConfirmationDialog {
 	void _update_add_type_options(const String &p_filter = "");
 
 	void _add_type_filter_cbk(const String &p_value);
-	void _type_filter_input(const Ref<InputEvent> &p_event);
 	void _add_type_options_cbk(int p_index);
 	void _add_type_dialog_entered(const String &p_value);
 	void _add_type_dialog_activated(int p_index);

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -40,11 +40,14 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/file_system/editor_file_system.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/2d/node_2d.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/check_button.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
@@ -2338,7 +2341,6 @@ void SceneTreeDialog::_notification(int p_what) {
 }
 
 void SceneTreeDialog::_update_valid_type_icons() {
-	filter->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 	for (TextureRect *trect : valid_type_icons) {
 		trect->set_custom_minimum_size(Vector2(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)), 0));
 		trect->set_texture(trect->get_meta("icon"));
@@ -2365,21 +2367,14 @@ void SceneTreeDialog::_filter_changed(const String &p_filter) {
 	tree->set_filter(p_filter);
 }
 
-void SceneTreeDialog::_on_filter_gui_input(const Ref<InputEvent> &p_event) {
-	// Redirect navigational key events to the tree.
-	Ref<InputEventKey> key = p_event;
-	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			tree->get_scene_tree()->gui_input(key);
-			filter->accept_event();
-		}
-	}
-}
-
 void SceneTreeDialog::_bind_methods() {
 	ClassDB::bind_method("_cancel", &SceneTreeDialog::_cancel);
 
 	ADD_SIGNAL(MethodInfo("selected", PropertyInfo(Variant::NODE_PATH, "path")));
+}
+
+LineEdit *SceneTreeDialog::get_filter_line_edit() {
+	return filter;
 }
 
 SceneTreeDialog::SceneTreeDialog() {
@@ -2390,13 +2385,11 @@ SceneTreeDialog::SceneTreeDialog() {
 	HBoxContainer *filter_hbc = memnew(HBoxContainer);
 	content->add_child(filter_hbc);
 
-	filter = memnew(LineEdit);
+	filter = memnew(FilterLineEdit);
 	filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTRC("Filter Nodes"));
-	filter->set_clear_button_enabled(true);
 	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect(SceneStringName(text_changed), callable_mp(this, &SceneTreeDialog::_filter_changed));
-	filter->connect(SceneStringName(gui_input), callable_mp(this, &SceneTreeDialog::_on_filter_gui_input));
 
 	register_text_enter(filter);
 
@@ -2416,6 +2409,7 @@ SceneTreeDialog::SceneTreeDialog() {
 	content->add_child(mc);
 
 	tree = memnew(SceneTreeEditor(false, false, true));
+	filter->set_forward_control(tree->get_scene_tree());
 	tree->set_update_when_invisible(false);
 	tree->get_scene_tree()->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
 	tree->get_scene_tree()->connect("item_activated", callable_mp(this, &SceneTreeDialog::_select));

--- a/editor/scene/scene_tree_editor.h
+++ b/editor/scene/scene_tree_editor.h
@@ -30,12 +30,14 @@
 
 #pragma once
 
-#include "scene/gui/check_box.h"
-#include "scene/gui/check_button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tree.h"
 
+class CheckBox;
+class CheckButton;
 class EditorSelection;
+class FilterLineEdit;
+class Label;
 class TextureRect;
 class Timer;
 
@@ -272,7 +274,7 @@ class SceneTreeDialog : public ConfirmationDialog {
 
 	VBoxContainer *content = nullptr;
 	SceneTreeEditor *tree = nullptr;
-	LineEdit *filter = nullptr;
+	FilterLineEdit *filter = nullptr;
 	CheckButton *show_all_nodes = nullptr;
 	LocalVector<TextureRect *> valid_type_icons;
 	HBoxContainer *allowed_types_hbox = nullptr;
@@ -281,7 +283,6 @@ class SceneTreeDialog : public ConfirmationDialog {
 	void _cancel();
 	void _selected_changed();
 	void _filter_changed(const String &p_filter);
-	void _on_filter_gui_input(const Ref<InputEvent> &p_event);
 	void _show_all_nodes_changed(bool p_button_pressed);
 
 protected:
@@ -294,7 +295,7 @@ public:
 	void set_valid_types(const Vector<StringName> &p_valid);
 
 	SceneTreeEditor *get_scene_tree() { return tree; }
-	LineEdit *get_filter_line_edit() { return filter; }
+	LineEdit *get_filter_line_edit();
 
 	SceneTreeDialog();
 };

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -42,6 +42,7 @@
 #include "core/version.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
+#include "editor/doc/editor_help.h"
 #include "editor/doc/editor_help_search.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/filesystem_dock.h"
@@ -55,11 +56,11 @@
 #include "editor/gui/code_editor.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_toaster.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/gui/window_wrapper.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/scene/editor_scene_tabs.h"
-#include "editor/script/editor_script.h"
 #include "editor/script/find_in_files.h"
 #include "editor/script/script_text_editor.h"
 #include "editor/script/syntax_highlighters.h"
@@ -91,17 +92,6 @@ void ScriptEditorQuickOpen::popup_dialog(const Vector<String> &p_functions, bool
 
 void ScriptEditorQuickOpen::_text_changed(const String &p_newtext) {
 	_update_search();
-}
-
-void ScriptEditorQuickOpen::_sbox_input(const Ref<InputEvent> &p_event) {
-	// Redirect navigational key events to the tree.
-	Ref<InputEventKey> key = p_event;
-	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			search_options->gui_input(key);
-			search_box->accept_event();
-		}
-	}
 }
 
 void ScriptEditorQuickOpen::_update_search() {
@@ -137,12 +127,6 @@ void ScriptEditorQuickOpen::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			connect(SceneStringName(confirmed), callable_mp(this, &ScriptEditorQuickOpen::_confirmed));
-
-			search_box->set_clear_button_enabled(true);
-			[[fallthrough]];
-		}
-		case NOTIFICATION_VISIBILITY_CHANGED: {
-			search_box->set_right_icon(search_options->get_editor_theme_icon(SNAME("Search")));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -156,23 +140,26 @@ void ScriptEditorQuickOpen::_bind_methods() {
 }
 
 ScriptEditorQuickOpen::ScriptEditorQuickOpen() {
-	VBoxContainer *vbc = memnew(VBoxContainer);
-	add_child(vbc);
-	search_box = memnew(LineEdit);
-	vbc->add_margin_child(TTRC("Search:"), search_box);
-	search_box->connect(SceneStringName(text_changed), callable_mp(this, &ScriptEditorQuickOpen::_text_changed));
-	search_box->connect(SceneStringName(gui_input), callable_mp(this, &ScriptEditorQuickOpen::_sbox_input));
-	search_options = memnew(Tree);
-	vbc->add_margin_child(TTRC("Matches:"), search_options, true);
 	set_ok_button_text(TTRC("Open"));
 	get_ok_button()->set_disabled(true);
-	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect("item_activated", callable_mp(this, &ScriptEditorQuickOpen::_confirmed));
+
+	VBoxContainer *vbc = memnew(VBoxContainer);
+	add_child(vbc);
+
+	search_box = memnew(FilterLineEdit);
+	vbc->add_margin_child(TTRC("Search:"), search_box);
+	search_box->connect(SceneStringName(text_changed), callable_mp(this, &ScriptEditorQuickOpen::_text_changed));
+	register_text_enter(search_box);
+
+	search_options = memnew(Tree);
+	search_box->set_forward_control(search_options);
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
 	search_options->add_theme_constant_override("draw_guides", 1);
+	vbc->add_margin_child(TTRC("Matches:"), search_options, true);
+	search_options->connect("item_activated", callable_mp(this, &ScriptEditorQuickOpen::_confirmed));
 }
 
 /////////////////////////////////

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -40,6 +40,7 @@
 class CodeTextEditor;
 class EditorFileDialog;
 class EditorHelpSearch;
+class FilterLineEdit;
 class FindReplaceBar;
 class HSplitContainer;
 class ItemList;
@@ -55,13 +56,12 @@ class ScriptEditorBase;
 class ScriptEditorQuickOpen : public ConfirmationDialog {
 	GDCLASS(ScriptEditorQuickOpen, ConfirmationDialog);
 
-	LineEdit *search_box = nullptr;
+	FilterLineEdit *search_box = nullptr;
 	Tree *search_options = nullptr;
 	String function;
 
 	void _update_search();
 
-	void _sbox_input(const Ref<InputEvent> &p_event);
 	Vector<String> functions;
 
 	void _confirmed();

--- a/editor/settings/editor_command_palette.cpp
+++ b/editor/settings/editor_command_palette.cpp
@@ -34,10 +34,9 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_toaster.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
-#include "scene/gui/control.h"
-#include "scene/gui/line_edit.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/tree.h"
 
@@ -166,10 +165,6 @@ void EditorCommandPalette::_notification(int p_what) {
 			}
 		} break;
 
-		case NOTIFICATION_THEME_CHANGED: {
-			command_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
-		} break;
-
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (!EditorSettings::get_singleton()->check_changed_settings_in_group("shortcuts")) {
 				break;
@@ -182,17 +177,6 @@ void EditorCommandPalette::_notification(int p_what) {
 				}
 			}
 		} break;
-	}
-}
-
-void EditorCommandPalette::_sbox_input(const Ref<InputEvent> &p_event) {
-	// Redirect navigational key events to the tree.
-	Ref<InputEventKey> key = p_event;
-	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			search_options->gui_input(key);
-			command_search_box->accept_event();
-		}
 	}
 }
 
@@ -344,13 +328,11 @@ EditorCommandPalette::EditorCommandPalette() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
 
-	command_search_box = memnew(LineEdit);
-	command_search_box->set_placeholder(TTR("Filter Commands"));
+	command_search_box = memnew(FilterLineEdit);
+	command_search_box->set_placeholder(TTRC("Filter Commands"));
 	command_search_box->set_accessibility_name(TTRC("Filter Commands"));
-	command_search_box->connect(SceneStringName(gui_input), callable_mp(this, &EditorCommandPalette::_sbox_input));
-	command_search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorCommandPalette::_update_command_search));
 	command_search_box->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	command_search_box->set_clear_button_enabled(true);
+	command_search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorCommandPalette::_update_command_search));
 	MarginContainer *margin_container_csb = memnew(MarginContainer);
 	margin_container_csb->add_child(command_search_box);
 	vbc->add_child(margin_container_csb);
@@ -363,6 +345,7 @@ EditorCommandPalette::EditorCommandPalette() {
 	vbc->add_child(mc);
 
 	search_options = memnew(Tree);
+	command_search_box->set_forward_control(search_options);
 	search_options->connect("item_activated", callable_mp(this, &EditorCommandPalette::_confirmed));
 	search_options->connect(SceneStringName(item_selected), callable_mp((BaseButton *)get_ok_button(), &BaseButton::set_disabled).bind(false));
 	search_options->connect("nothing_selected", callable_mp((BaseButton *)get_ok_button(), &BaseButton::set_disabled).bind(true));

--- a/editor/settings/editor_command_palette.h
+++ b/editor/settings/editor_command_palette.h
@@ -30,15 +30,17 @@
 
 #pragma once
 
-#include "core/input/shortcut.h"
 #include "scene/gui/dialogs.h"
-#include "scene/gui/tree.h"
+
+class FilterLineEdit;
+class Shortcut;
+class Tree;
 
 class EditorCommandPalette : public ConfirmationDialog {
 	GDCLASS(EditorCommandPalette, ConfirmationDialog);
 
 	static EditorCommandPalette *singleton;
-	LineEdit *command_search_box = nullptr;
+	FilterLineEdit *command_search_box = nullptr;
 	Tree *search_options = nullptr;
 
 	struct Command {
@@ -78,7 +80,6 @@ class EditorCommandPalette : public ConfirmationDialog {
 
 	void _update_command_search(const String &search_text);
 	float _score_path(const String &p_search, const String &p_path);
-	void _sbox_input(const Ref<InputEvent> &p_event);
 	void _confirmed();
 	void _add_command(String p_command_name, String p_key_name, Callable p_binded_action, String p_shortcut_text = "None");
 	void _save_history() const;

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -43,7 +43,7 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/gui/editor_toaster.h"
-#include "editor/inspector/editor_properties.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/inspector/editor_properties_vector.h"
 #include "editor/scene/curve_editor_plugin.h"
 #include "editor/scene/material_editor_plugin.h"
@@ -5200,17 +5200,6 @@ void VisualShaderEditor::_show_remove_varying_dialog() {
 	remove_varying_dialog->set_position(remove_varying_dialog->get_position() - difference);
 }
 
-void VisualShaderEditor::_sbox_input(const Ref<InputEvent> &p_event) {
-	// Redirect navigational key events to the tree.
-	Ref<InputEventKey> key = p_event;
-	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			members->gui_input(key);
-			node_filter->accept_event();
-		}
-	}
-}
-
 void VisualShaderEditor::_param_filter_changed(const String &p_text) {
 	param_filter_name = p_text;
 
@@ -5303,8 +5292,6 @@ void VisualShaderEditor::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
-			node_filter->set_clear_button_enabled(true);
-
 			// collapse tree by default
 
 			TreeItem *category = members->get_root()->get_first_child();
@@ -5327,7 +5314,6 @@ void VisualShaderEditor::_notification(int p_what) {
 			highend_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 
 			param_filter->set_right_icon(Control::get_editor_theme_icon(SNAME("Search")));
-			node_filter->set_right_icon(Control::get_editor_theme_icon(SNAME("Search")));
 
 			code_preview_button->set_button_icon(Control::get_editor_theme_icon(SNAME("Shader")));
 			shader_preview_button->set_button_icon(Control::get_editor_theme_icon(SNAME("SubViewport")));
@@ -6939,10 +6925,9 @@ VisualShaderEditor::VisualShaderEditor() {
 	HBoxContainer *filter_hb = memnew(HBoxContainer);
 	members_vb->add_child(filter_hb);
 
-	node_filter = memnew(LineEdit);
+	node_filter = memnew(FilterLineEdit);
 	filter_hb->add_child(node_filter);
 	node_filter->connect(SceneStringName(text_changed), callable_mp(this, &VisualShaderEditor::_member_filter_changed));
-	node_filter->connect(SceneStringName(gui_input), callable_mp(this, &VisualShaderEditor::_sbox_input));
 	node_filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	node_filter->set_placeholder(TTR("Search"));
 
@@ -6954,6 +6939,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	tools->get_popup()->add_item(TTR("Collapse All"), COLLAPSE_ALL);
 
 	members = memnew(Tree);
+	node_filter->set_forward_control(members);
 	members_vb->add_child(members);
 	SET_DRAG_FORWARDING_GCD(members, VisualShaderEditor);
 	members->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // TODO: Implement proper translation switch.

--- a/editor/shader/visual_shader_editor_plugin.h
+++ b/editor/shader/visual_shader_editor_plugin.h
@@ -42,6 +42,7 @@
 class CodeEdit;
 class ColorPicker;
 class CurveEditor;
+class FilterLineEdit;
 class GraphElement;
 class GraphFrame;
 class HFlowContainer;
@@ -375,7 +376,7 @@ class VisualShaderEditor : public ShaderEditor {
 
 	Tree *members = nullptr;
 	AcceptDialog *alert = nullptr;
-	LineEdit *node_filter = nullptr;
+	FilterLineEdit *node_filter = nullptr;
 	RichTextLabel *node_desc = nullptr;
 	Label *highend_label = nullptr;
 
@@ -605,7 +606,6 @@ class VisualShaderEditor : public ShaderEditor {
 	void _graph_gui_input(const Ref<InputEvent> &p_event);
 
 	void _member_filter_changed(const String &p_text);
-	void _sbox_input(const Ref<InputEvent> &p_event);
 	void _member_selected();
 	void _member_create();
 	void _member_cancel();

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -39,16 +39,20 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/gui/editor_zoom_widget.h"
+#include "editor/gui/filter_line_edit.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/item_list.h"
 #include "scene/gui/label.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/separator.h"
+#include "scene/gui/slider.h"
+#include "scene/gui/spin_box.h"
 #include "scene/main/window.h"
 
 void GridMapEditor::_configure() {
@@ -971,17 +975,6 @@ void GridMapEditor::_text_changed(const String &p_text) {
 	update_palette();
 }
 
-void GridMapEditor::_sbox_input(const Ref<InputEvent> &p_event) {
-	// Redirect navigational key events to the item list.
-	Ref<InputEventKey> key = p_event;
-	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
-			mesh_library_palette->gui_input(key);
-			search_box->accept_event();
-		}
-	}
-}
-
 void GridMapEditor::_mesh_library_palette_input(const Ref<InputEvent> &p_ie) {
 	const Ref<InputEventMouseButton> mb = p_ie;
 
@@ -1234,7 +1227,6 @@ void GridMapEditor::_update_theme() {
 	rotate_x_button->set_button_icon(get_theme_icon(SNAME("RotateLeft"), EditorStringName(EditorIcons)));
 	rotate_y_button->set_button_icon(get_theme_icon(SNAME("ToolRotate"), EditorStringName(EditorIcons)));
 	rotate_z_button->set_button_icon(get_theme_icon(SNAME("RotateRight"), EditorStringName(EditorIcons)));
-	search_box->set_right_icon(get_theme_icon(SNAME("Search"), EditorStringName(EditorIcons)));
 	mode_thumbnail->set_button_icon(get_theme_icon(SNAME("FileThumbnail"), EditorStringName(EditorIcons)));
 	mode_list->set_button_icon(get_theme_icon(SNAME("FileList"), EditorStringName(EditorIcons)));
 	options->set_button_icon(get_theme_icon(SNAME("Tools"), EditorStringName(EditorIcons)));
@@ -1604,14 +1596,13 @@ GridMapEditor::GridMapEditor() {
 	floor->connect(SceneStringName(mouse_exited), callable_mp(this, &GridMapEditor::_floor_mouse_exited));
 	floor->get_line_edit()->connect(SceneStringName(mouse_exited), callable_mp(this, &GridMapEditor::_floor_mouse_exited));
 
-	search_box = memnew(LineEdit);
+	search_box = memnew(FilterLineEdit);
 	search_box->add_theme_constant_override("minimum_character_width", 10);
+	search_box->set_h_size_flags(SIZE_EXPAND_FILL);
 	search_box->set_placeholder(TTR("Filter Meshes"));
 	search_box->set_accessibility_name(TTRC("Filter Meshes"));
-	search_box->set_clear_button_enabled(true);
 	toolbar->add_child(search_box);
 	search_box->connect(SceneStringName(text_changed), callable_mp(this, &GridMapEditor::_text_changed));
-	search_box->connect(SceneStringName(gui_input), callable_mp(this, &GridMapEditor::_sbox_input));
 
 	zoom_widget = memnew(EditorZoomWidget);
 	toolbar->add_child(zoom_widget);
@@ -1645,6 +1636,7 @@ GridMapEditor::GridMapEditor() {
 	add_child(mc);
 
 	mesh_library_palette = memnew(ItemList);
+	search_box->set_forward_control(mesh_library_palette);
 	mesh_library_palette->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	mesh_library_palette->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTH);
 	mc->add_child(mesh_library_palette);

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -34,16 +34,18 @@
 
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/item_list.h"
-#include "scene/gui/slider.h"
-#include "scene/gui/spin_box.h"
 
+class Button;
 class ConfirmationDialog;
+class FilterLineEdit;
+class HSlider;
+class ItemList;
 class MenuButton;
 class Node3DEditorPlugin;
 class ButtonGroup;
 class EditorZoomWidget;
 class BaseButton;
+class SpinBox;
 
 class GridMapEditor : public VBoxContainer {
 	GDCLASS(GridMapEditor, VBoxContainer);
@@ -93,7 +95,7 @@ class GridMapEditor : public VBoxContainer {
 	EditorZoomWidget *zoom_widget = nullptr;
 	Button *mode_thumbnail = nullptr;
 	Button *mode_list = nullptr;
-	LineEdit *search_box = nullptr;
+	FilterLineEdit *search_box = nullptr;
 	HSlider *size_slider = nullptr;
 	ConfirmationDialog *settings_dialog = nullptr;
 	VBoxContainer *settings_vbc = nullptr;
@@ -228,7 +230,6 @@ class GridMapEditor : public VBoxContainer {
 	void _update_theme();
 
 	void _text_changed(const String &p_text);
-	void _sbox_input(const Ref<InputEvent> &p_event);
 	void _mesh_library_palette_input(const Ref<InputEvent> &p_ie);
 
 	void _icon_size_changed(float p_value);


### PR DESCRIPTION
Follow-up to #96400
The repetitive code for handling input forwarding was extracted to a new class.
Also tweaked some includes.