### PR TITLE
Rename `ClassDB::class_call_static_method` -> `class_call_static`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1540,7 +1540,7 @@ TypedArray<Dictionary> ClassDB::class_get_method_list(const StringName &p_class,
 	return ret;
 }
 
-Variant ClassDB::class_call_static_method(const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) {
+Variant ClassDB::class_call_static(const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) {
 	if (p_argcount < 2) {
 		r_call_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 		return Variant::NIL;
@@ -1681,7 +1681,7 @@ void ClassDB::_bind_methods() {
 
 	::ClassDB::bind_method(D_METHOD("class_get_method_list", "class", "no_inheritance"), &ClassDB::class_get_method_list, DEFVAL(false));
 
-	::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "class_call_static_method", &ClassDB::class_call_static_method, MethodInfo("class_call_static_method", PropertyInfo(Variant::STRING_NAME, "class"), PropertyInfo(Variant::STRING_NAME, "method")));
+	::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "class_call_static", &ClassDB::class_call_static, MethodInfo("class_call_static", PropertyInfo(Variant::STRING_NAME, "class"), PropertyInfo(Variant::STRING_NAME, "method")));
 
 	::ClassDB::bind_method(D_METHOD("class_get_integer_constant_list", "class", "no_inheritance"), &ClassDB::class_get_integer_constant_list, DEFVAL(false));
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -484,7 +484,7 @@ public:
 	int class_get_method_argument_count(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false) const;
 
 	TypedArray<Dictionary> class_get_method_list(const StringName &p_class, bool p_no_inheritance = false) const;
-	Variant class_call_static_method(const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error);
+	Variant class_call_static(const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error);
 
 	PackedStringArray class_get_integer_constant_list(const StringName &p_class, bool p_no_inheritance = false) const;
 	bool class_has_integer_constant(const StringName &p_class, const StringName &p_name) const;

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -16,7 +16,7 @@
 				Returns [code]true[/code] if objects can be instantiated from the specified [param class], otherwise returns [code]false[/code].
 			</description>
 		</method>
-		<method name="class_call_static_method" qualifiers="vararg">
+		<method name="class_call_static" qualifiers="vararg">
 			<return type="Variant" />
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="method" type="StringName" />


### PR DESCRIPTION
Small change as discussed in https://github.com/godotengine/godot/pull/93141#issuecomment-2442825542. The shorter name `class_call_static` is more consistent with `Object::call` and makes future extensibility (different call variants) easier.

Not breaking because the method was only introduced in the 4.4 cycle.