### PR TITLE
Expose `get_editor_toaster` method to `EditorInterface`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -117,6 +117,12 @@
 				[b]Note:[/b] When creating custom editor UI, prefer accessing theme items directly from your GUI nodes using the [code]get_theme_*[/code] methods.
 			</description>
 		</method>
+		<method name="get_editor_toaster" qualifiers="const">
+			<return type="EditorToaster" />
+			<description>
+				Returns the editor's [EditorToaster].
+			</description>
+		</method>
 		<method name="get_editor_undo_redo" qualifiers="const">
 			<return type="EditorUndoRedoManager" />
 			<description>

--- a/doc/classes/EditorToaster.xml
+++ b/doc/classes/EditorToaster.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorToaster" inherits="HBoxContainer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Manages toast notifications within the editor.
+	</brief_description>
+	<description>
+		This object manages the functionality and display of toast notifications within the editor, ensuring timely and informative alerts are presented to users.
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_editor_toaster].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="push_toast">
+			<return type="void" />
+			<param index="0" name="message" type="String" />
+			<param index="1" name="severity" type="int" enum="EditorToaster.Severity" default="0" />
+			<param index="2" name="tooltip" type="String" default="&quot;&quot;" />
+			<description>
+				Pushes a toast notification to the editor for display.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="SEVERITY_INFO" value="0" enum="Severity">
+			Toast will display with an INFO severity.
+		</constant>
+		<constant name="SEVERITY_WARNING" value="1" enum="Severity">
+			Toast will display with a WARNING severity and have a corresponding color.
+		</constant>
+		<constant name="SEVERITY_ERROR" value="2" enum="Severity">
+			Toast will display with an ERROR severity and have a corresponding color.
+		</constant>
+	</constants>
+</class>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -43,6 +43,7 @@
 #include "editor/gui/editor_quick_open_dialog.h"
 #include "editor/gui/editor_run_bar.h"
 #include "editor/gui/editor_scene_tabs.h"
+#include "editor/gui/editor_toaster.h"
 #include "editor/gui/scene_tree_editor.h"
 #include "editor/inspector_dock.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
@@ -87,6 +88,10 @@ EditorSelection *EditorInterface::get_selection() const {
 
 Ref<EditorSettings> EditorInterface::get_editor_settings() const {
 	return EditorSettings::get_singleton();
+}
+
+EditorToaster *EditorInterface::get_editor_toaster() const {
+	return EditorToaster::get_singleton();
 }
 
 EditorUndoRedoManager *EditorInterface::get_editor_undo_redo() const {
@@ -581,6 +586,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
 	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
+	ClassDB::bind_method(D_METHOD("get_editor_toaster"), &EditorInterface::get_editor_toaster);
 	ClassDB::bind_method(D_METHOD("get_editor_undo_redo"), &EditorInterface::get_editor_undo_redo);
 
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -45,6 +45,7 @@ class EditorPlugin;
 class EditorResourcePreview;
 class EditorSelection;
 class EditorSettings;
+class EditorToaster;
 class EditorUndoRedoManager;
 class FileSystemDock;
 class Mesh;
@@ -104,6 +105,7 @@ public:
 	EditorResourcePreview *get_resource_previewer() const;
 	EditorSelection *get_selection() const;
 	Ref<EditorSettings> get_editor_settings() const;
+	EditorToaster *get_editor_toaster() const;
 	EditorUndoRedoManager *get_editor_undo_redo() const;
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -506,6 +506,14 @@ void EditorToaster::instant_close(Control *p_control) {
 	p_control->set_modulate(Color(1, 1, 1, 0));
 }
 
+void EditorToaster::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("push_toast", "message", "severity", "tooltip"), &EditorToaster::_popup_str, DEFVAL(EditorToaster::SEVERITY_INFO), DEFVAL(String()));
+
+	BIND_ENUM_CONSTANT(SEVERITY_INFO);
+	BIND_ENUM_CONSTANT(SEVERITY_WARNING);
+	BIND_ENUM_CONSTANT(SEVERITY_ERROR);
+}
+
 EditorToaster *EditorToaster::get_singleton() {
 	return singleton;
 }

--- a/editor/gui/editor_toaster.h
+++ b/editor/gui/editor_toaster.h
@@ -105,6 +105,7 @@ private:
 	void _toast_theme_changed(Control *p_control);
 
 protected:
+	static void _bind_methods();
 	static EditorToaster *singleton;
 
 	void _notification(int p_what);

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -52,6 +52,7 @@
 #include "editor/filesystem_dock.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_spin_slider.h"
+#include "editor/gui/editor_toaster.h"
 #include "editor/import/3d/resource_importer_obj.h"
 #include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/editor_import_plugin.h"
@@ -146,6 +147,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorSelection);
 	GDREGISTER_CLASS(EditorFileDialog);
 	GDREGISTER_CLASS(EditorSettings);
+	GDREGISTER_ABSTRACT_CLASS(EditorToaster);
 	GDREGISTER_CLASS(EditorNode3DGizmo);
 	GDREGISTER_CLASS(EditorNode3DGizmoPlugin);
 	GDREGISTER_ABSTRACT_CLASS(EditorResourcePreview);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11051

Exposes `get_editor_toaster` to `EditorInterface` (w/ `push_toast` method); for use in the editor.


# Preview (*editedx3*)
![image](https://github.com/user-attachments/assets/36f95c23-a53e-4a95-a0ef-39b0bfb6ed33)

![image](https://github.com/user-attachments/assets/da56f20b-b3c5-4cb4-83bf-7e0ef15b390c)