### PR TITLE
Update the `production` build argument for Android Studio debug builds

### DIFF
--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -106,8 +106,8 @@ android {
         boolean devBuild = buildType == "dev"
         boolean debugSymbols = devBuild
         boolean runTests = devBuild
-        boolean productionBuild = !devBuild
         boolean storeRelease = buildType == "release"
+        boolean productionBuild = storeRelease
 
         def sconsTarget = flavorName
         if (sconsTarget == "template") {


### PR DESCRIPTION
Swappy is required for `production` build which breaks the Android Studio debug builds as those turns on the `production` argument. 
This PR updates the logic so that the `production` argument is only used by Android Studio for `release` builds.

Follow-up to https://github.com/godotengine/godot/pull/96439.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
