### PR TITLE
Fix crash in Quick Open Dialog

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -489,6 +489,10 @@ void QuickOpenResultContainer::handle_search_box_input(const Ref<InputEvent> &p_
 }
 
 void QuickOpenResultContainer::_move_selection_index(Key p_key) {
+	// Don't move selection if there are no results.
+	if (num_visible_results <= 0) {
+		return;
+	}
 	const int max_index = num_visible_results - 1;
 
 	int idx = selection_index;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Don't move selection if there's no visible elements.

Fixes #98668 