### PR TITLE
Allow multiple platform API files

### DIFF
--- a/platform/SCsub
+++ b/platform/SCsub
@@ -60,7 +60,7 @@ register_platform_apis = env.CommandNoCache(
 )
 env.add_source_files(env.platform_sources, register_platform_apis)
 for platform in env.platform_apis:
-    env.add_source_files(env.platform_sources, f"{platform}/api/api.cpp")
+    env.add_source_files(env.platform_sources, f"{platform}/api/*.cpp")
 
 lib = env.add_library("platform", env.platform_sources)
 env.Prepend(LIBS=[lib])


### PR DESCRIPTION
Currently, platforms can implement a public API. This is hardcoded to be built from `{platform}/api.h` and `{platform}/api.cpp`.

While this works and is useful, some platforms provide a fairly large API. Trying to keep all that in those two files becomes painful quickly.

This simple change allows one to split up the API implementation into multiple files. It changes nothing for existing implementations, but optionally allows one to have e.g. `api/achievements.cpp`, `api/networking.cpp` and `api/specialplatformstorage.cpp` be also included in the build, without having to modify the Godot source or build system when adding a custom platform implementation.