### PR TITLE
Set flag for 8 bone weights in GLTFDocument

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3046,6 +3046,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 					}
 				}
 				array[Mesh::ARRAY_WEIGHTS] = weights;
+				flags |= Mesh::ARRAY_FLAG_USE_8_BONE_WEIGHTS;
 			}
 
 			if (!indices.is_empty()) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

The glTF importer loads up to 8 bone weights, but does not set the according flag. This results in broken LODs.
Fixes #98650 and possibly also #78636 