### PR TITLE
Avoid infinite recursion between AnimationPlayer and AnimationMixer

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -36,7 +36,7 @@
 bool AnimationPlayer::_set(const StringName &p_name, const Variant &p_value) {
 	String name = p_name;
 	if (name.begins_with("playback/play")) { // For backward compatibility.
-		set_current_animation(p_value);
+		_set_current_animation(p_value);
 	} else if (name.begins_with("next/")) {
 		String which = name.get_slicec('/', 1);
 		animation_set_next(which, p_value);
@@ -582,16 +582,10 @@ bool AnimationPlayer::is_playing() const {
 }
 
 void AnimationPlayer::set_current_animation(const String &p_animation) {
-	if (p_animation == "[stop]" || p_animation.is_empty()) {
-		stop();
-	} else if (!is_playing()) {
-		play(p_animation);
-	} else if (playback.assigned != p_animation) {
-		float speed = playback.current.speed_scale;
-		play(p_animation, -1.0, speed, signbit(speed));
-	} else {
-		// Same animation, do not replay from start.
+	if (p_animation.is_empty() || p_animation == "[stop]") {
+		return;
 	}
+	_set_current_animation(p_animation);
 }
 
 String AnimationPlayer::get_current_animation() const {
@@ -939,6 +933,19 @@ void AnimationPlayer::_rename_animation(const StringName &p_from_name, const Str
 
 	if (autoplay == p_from_name) {
 		autoplay = p_to_name;
+	}
+}
+
+void AnimationPlayer::_set_current_animation(const String &p_animation) {
+	if (p_animation.is_empty() || p_animation == "[stop]") {
+		stop();
+	} else if (!is_playing()) {
+		play(p_animation);
+	} else if (playback.assigned != p_animation) {
+		float speed = playback.current.speed_scale;
+		play(p_animation, -1.0, speed, signbit(speed));
+	} else {
+		// Same animation, do not replay from start.
 	}
 }
 

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -124,6 +124,8 @@ private:
 	void _stop_internal(bool p_reset, bool p_keep_state);
 	void _check_immediately_after_start();
 
+	void _set_current_animation(const String &p_animation);
+
 	float get_current_blend_amount();
 
 	bool playing = false;


### PR DESCRIPTION
In theory `AnimationPlayer.current_animation` shouldn't be setted directly but in normal cases that don't cause any problem unless the animation key set `current_animation` to an empty string, in this case will start an infinite recursion between `AnimationPlayer` calling `AnimationMixer::_blend_process` and `AnimationMixer` setting the current animation to a empty string which will never stop until the engine crashes. This fix makes `AnimationMixer` ignore these animation keys (that would do nothing anyways) and avoid the crash.

Fix: #98076