### PR TITLE
[Android] Implement support for accent color retrieval

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -185,7 +185,7 @@
 			<return type="Color" />
 			<description>
 				Returns OS theme accent color. Returns [code]Color(0, 0, 0, 0)[/code], if accent color is unknown.
-				[b]Note:[/b] This method is implemented on macOS and Windows.
+				[b]Note:[/b] This method is implemented on macOS, Windows, and Android.
 			</description>
 		</method>
 		<method name="get_base_color" qualifiers="const">

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -203,6 +203,12 @@ void DisplayServerAndroid::emit_file_picker_callback(bool p_ok, const Vector<Str
 	}
 }
 
+Color DisplayServerAndroid::get_accent_color() const {
+	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
+	ERR_FAIL_NULL_V(godot_java, Color(0, 0, 0, 0));
+	return godot_java->get_accent_color();
+}
+
 TypedArray<Rect2> DisplayServerAndroid::get_display_cutouts() const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	ERR_FAIL_NULL_V(godot_io_java, Array());

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -125,6 +125,8 @@ public:
 	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, const FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback) override;
 	void emit_file_picker_callback(bool p_ok, const Vector<String> &p_selected_paths);
 
+	virtual Color get_accent_color() const override;
+
 	virtual TypedArray<Rect2> get_display_cutouts() const override;
 	virtual Rect2i get_display_safe_area() const override;
 

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -925,6 +925,12 @@ class Godot(private val context: Context) {
 		}
 	}
 
+	@Keep
+	private fun getAccentColor(): Int {
+		val value = TypedValue()
+		context.theme.resolveAttribute(android.R.attr.colorAccent, value, true)
+		return value.data
+	}
 
 	/**
 	 * Destroys the Godot Engine and kill the process it's running in.

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -64,6 +64,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_alert = p_env->GetMethodID(godot_class, "alert", "(Ljava/lang/String;Ljava/lang/String;)V");
 	_is_dark_mode_supported = p_env->GetMethodID(godot_class, "isDarkModeSupported", "()Z");
 	_is_dark_mode = p_env->GetMethodID(godot_class, "isDarkMode", "()Z");
+	_get_accent_color = p_env->GetMethodID(godot_class, "getAccentColor", "()I");
 	_get_clipboard = p_env->GetMethodID(godot_class, "getClipboard", "()Ljava/lang/String;");
 	_set_clipboard = p_env->GetMethodID(godot_class, "setClipboard", "(Ljava/lang/String;)V");
 	_has_clipboard = p_env->GetMethodID(godot_class, "hasClipboard", "()Z");
@@ -211,6 +212,23 @@ bool GodotJavaWrapper::is_dark_mode() {
 		return env->CallBooleanMethod(godot_instance, _is_dark_mode);
 	} else {
 		return false;
+	}
+}
+
+Color GodotJavaWrapper::get_accent_color() {
+	if (_get_accent_color) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, Color(0, 0, 0, 0));
+		int accent_color = env->CallIntMethod(godot_instance, _get_accent_color);
+
+		// Convert ARGB to RGBA.
+		int alpha = (accent_color >> 24) & 0xFF;
+		int red = (accent_color >> 16) & 0xFF;
+		int green = (accent_color >> 8) & 0xFF;
+		int blue = accent_color & 0xFF;
+		return Color(red / 255.0f, green / 255.0f, blue / 255.0f, alpha / 255.0f);
+	} else {
+		return Color(0, 0, 0, 0);
 	}
 }
 

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -34,6 +34,7 @@
 #include "java_godot_view_wrapper.h"
 #include "string_android.h"
 
+#include "core/math/color.h"
 #include "core/templates/list.h"
 
 #include <android/log.h>
@@ -55,6 +56,7 @@ private:
 	jmethodID _alert = nullptr;
 	jmethodID _is_dark_mode_supported = nullptr;
 	jmethodID _is_dark_mode = nullptr;
+	jmethodID _get_accent_color = nullptr;
 	jmethodID _get_clipboard = nullptr;
 	jmethodID _set_clipboard = nullptr;
 	jmethodID _has_clipboard = nullptr;
@@ -99,6 +101,7 @@ public:
 	void alert(const String &p_message, const String &p_title);
 	bool is_dark_mode_supported();
 	bool is_dark_mode();
+	Color get_accent_color();
 	bool has_get_clipboard();
 	String get_clipboard();
 	bool has_set_clipboard();


### PR DESCRIPTION
This PR brings get_accent_color() support to Android, aligning with existing functionality currently available only on macOS and Windows. It enables users to customize the app’s appearance by aligning it with the system accent color.
