### PR TITLE
Core: Fix `Callable.get_bound_arguments{,_count}()` return incorrect data

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -206,25 +206,31 @@ int Callable::get_bound_arguments_count() const {
 	}
 }
 
-void Callable::get_bound_arguments_ref(Vector<Variant> &r_arguments, int &r_argcount) const {
+void Callable::get_bound_arguments_ref(Vector<Variant> &r_arguments) const {
 	if (!is_null() && is_custom()) {
-		custom->get_bound_arguments(r_arguments, r_argcount);
+		custom->get_bound_arguments(r_arguments);
 	} else {
 		r_arguments.clear();
-		r_argcount = 0;
 	}
 }
 
 Array Callable::get_bound_arguments() const {
 	Vector<Variant> arr;
-	int ac;
-	get_bound_arguments_ref(arr, ac);
+	get_bound_arguments_ref(arr);
 	Array ret;
 	ret.resize(arr.size());
 	for (int i = 0; i < arr.size(); i++) {
 		ret[i] = arr[i];
 	}
 	return ret;
+}
+
+int Callable::get_unbound_arguments_count() const {
+	if (!is_null() && is_custom()) {
+		return custom->get_unbound_arguments_count();
+	} else {
+		return 0;
+	}
 }
 
 CallableCustom *Callable::get_custom() const {
@@ -464,9 +470,12 @@ int CallableCustom::get_bound_arguments_count() const {
 	return 0;
 }
 
-void CallableCustom::get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const {
-	r_arguments = Vector<Variant>();
-	r_argcount = 0;
+void CallableCustom::get_bound_arguments(Vector<Variant> &r_arguments) const {
+	r_arguments.clear();
+}
+
+int CallableCustom::get_unbound_arguments_count() const {
+	return 0;
 }
 
 CallableCustom::CallableCustom() {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -111,8 +111,9 @@ public:
 	CallableCustom *get_custom() const;
 	int get_argument_count(bool *r_is_valid = nullptr) const;
 	int get_bound_arguments_count() const;
-	void get_bound_arguments_ref(Vector<Variant> &r_arguments, int &r_argcount) const; // Internal engine use, the exposed one is below.
+	void get_bound_arguments_ref(Vector<Variant> &r_arguments) const; // Internal engine use, the exposed one is below.
 	Array get_bound_arguments() const;
+	int get_unbound_arguments_count() const;
 
 	uint32_t hash() const;
 
@@ -158,7 +159,8 @@ public:
 	virtual const Callable *get_base_comparator() const;
 	virtual int get_argument_count(bool &r_is_valid) const;
 	virtual int get_bound_arguments_count() const;
-	virtual void get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const;
+	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const;
+	virtual int get_unbound_arguments_count() const;
 
 	CallableCustom();
 	virtual ~CallableCustom() {}

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -55,7 +55,8 @@ public:
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_argument_count(bool &r_is_valid) const override;
 	virtual int get_bound_arguments_count() const override;
-	virtual void get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const override;
+	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const override;
+	virtual int get_unbound_arguments_count() const override;
 	Callable get_callable() { return callable; }
 	Vector<Variant> get_binds() { return binds; }
 
@@ -84,7 +85,8 @@ public:
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_argument_count(bool &r_is_valid) const override;
 	virtual int get_bound_arguments_count() const override;
-	virtual void get_bound_arguments(Vector<Variant> &r_arguments, int &r_argcount) const override;
+	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const override;
+	virtual int get_unbound_arguments_count() const override;
 
 	Callable get_callable() { return callable; }
 	int get_unbinds() { return argcount; }

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3668,18 +3668,20 @@ String Variant::get_call_error_text(Object *p_base, const StringName &p_method, 
 
 String Variant::get_callable_error_text(const Callable &p_callable, const Variant **p_argptrs, int p_argcount, const Callable::CallError &ce) {
 	Vector<Variant> binds;
-	int args_bound;
-	p_callable.get_bound_arguments_ref(binds, args_bound);
-	if (args_bound <= 0) {
-		return get_call_error_text(p_callable.get_object(), p_callable.get_method(), p_argptrs, MAX(0, p_argcount + args_bound), ce);
+	p_callable.get_bound_arguments_ref(binds);
+
+	int args_unbound = p_callable.get_unbound_arguments_count();
+
+	if (p_argcount - args_unbound < 0) {
+		return "Callable unbinds " + itos(args_unbound) + " arguments, but called with " + itos(p_argcount);
 	} else {
 		Vector<const Variant *> argptrs;
-		argptrs.resize(p_argcount + binds.size());
-		for (int i = 0; i < p_argcount; i++) {
+		argptrs.resize(p_argcount - args_unbound + binds.size());
+		for (int i = 0; i < p_argcount - args_unbound; i++) {
 			argptrs.write[i] = p_argptrs[i];
 		}
 		for (int i = 0; i < binds.size(); i++) {
-			argptrs.write[i + p_argcount] = &binds[i];
+			argptrs.write[i + p_argcount - args_unbound] = &binds[i];
 		}
 		return get_call_error_text(p_callable.get_object(), p_callable.get_method(), (const Variant **)argptrs.ptr(), argptrs.size(), ce);
 	}

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2116,6 +2116,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_function(Callable, get_argument_count, _VariantCall::func_Callable_get_argument_count, sarray(), varray());
 	bind_method(Callable, get_bound_arguments_count, sarray(), varray());
 	bind_method(Callable, get_bound_arguments, sarray(), varray());
+	bind_method(Callable, get_unbound_arguments_count, sarray(), varray());
 	bind_method(Callable, hash, sarray(), varray());
 	bind_method(Callable, bindv, sarray("arguments"), varray());
 	bind_method(Callable, unbind, sarray("argcount"), varray());

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -155,13 +155,21 @@
 		<method name="get_bound_arguments" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Return the bound arguments (as long as [method get_bound_arguments_count] is greater than zero), or empty (if [method get_bound_arguments_count] is less than or equal to zero).
+				Returns the array of arguments bound via successive [method bind] or [method unbind] calls. These arguments will be added [i]after[/i] the arguments passed to the call, from which [method get_unbound_arguments_count] arguments on the right have been previously excluded.
+				[codeblock]
+				func get_effective_arguments(callable, call_args):
+				    assert(call_args.size() - callable.get_unbound_arguments_count() &gt;= 0)
+				    var result = call_args.slice(0, call_args.size() - callable.get_unbound_arguments_count())
+				    result.append_array(callable.get_bound_arguments())
+				    return result
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_bound_arguments_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the total amount of arguments bound (or unbound) via successive [method bind] or [method unbind] calls. If the amount of arguments unbound is greater than the ones bound, this function returns a value less than zero.
+				Returns the total amount of arguments bound via successive [method bind] or [method unbind] calls. This is the same as the size of the array returned by [method get_bound_arguments]. See [method get_bound_arguments] for details.
+				[b]Note:[/b] The [method get_bound_arguments_count] and [method get_unbound_arguments_count] methods can both return positive values.
 			</description>
 		</method>
 		<method name="get_method" qualifiers="const">
@@ -180,6 +188,13 @@
 			<return type="int" />
 			<description>
 				Returns the ID of this [Callable]'s object (see [method Object.get_instance_id]).
+			</description>
+		</method>
+		<method name="get_unbound_arguments_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total amount of arguments unbound via successive [method bind] or [method unbind] calls. See [method get_bound_arguments] for details.
+				[b]Note:[/b] The [method get_bound_arguments_count] and [method get_unbound_arguments_count] methods can both return positive values.
 			</description>
 		</method>
 		<method name="hash" qualifiers="const">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3055,11 +3055,12 @@ void Node::_duplicate_signals(const Node *p_original, Node *p_copy) const {
 				if (copy && copytarget && E.callable.get_method() != StringName()) {
 					Callable copy_callable = Callable(copytarget, E.callable.get_method());
 					if (!copy->is_connected(E.signal.get_name(), copy_callable)) {
-						int arg_count = E.callable.get_bound_arguments_count();
-						if (arg_count > 0) {
+						int unbound_arg_count = E.callable.get_unbound_arguments_count();
+						if (unbound_arg_count > 0) {
+							copy_callable = copy_callable.unbind(unbound_arg_count);
+						}
+						if (E.callable.get_bound_arguments_count() > 0) {
 							copy_callable = copy_callable.bindv(E.callable.get_bound_arguments());
-						} else if (arg_count < 0) {
-							copy_callable = copy_callable.unbind(-arg_count);
 						}
 						copy->connect(E.signal.get_name(), copy_callable, E.flags);
 					}


### PR DESCRIPTION
* Fixes #98695.

<details>
<summary>Test script</summary>

```gdscript
@tool
extends EditorScript

func f(a = 0, b = 0, c = 0, d = 0, e = 0, f = 0, g = 0, h = 0):
    return [a, b, c, d, e, f, g, h]

#func get_effective_arguments(callable: Callable, call_args: Array) -> Array:
    #assert(call_args.size() - callable.get_unbound_arguments_count() >= 0)
    #var result = call_args.slice(0, call_args.size() - callable.get_unbound_arguments_count())
    #result.append_array(callable.get_bound_arguments())
    #return result

func test(c: Callable) -> void:
    print("%d %d %-9s %s" % [
    #print("%d %d %d %-9s %s %s" % [
        c.get_argument_count(),
        #c.get_unbound_arguments_count(),
        c.get_bound_arguments_count(),
        c.get_bound_arguments(),
        c.call(7, 8, 9),
        #get_effective_arguments(c, [7, 8, 9])
    ])

func _run() -> void:
    test(f)
    test(f.bind(1, 2))
    test(f.bind(1, 2).unbind(1))
    test(f.bind(1, 2).unbind(1).bind(3, 4))
    test(f.bind(1, 2).unbind(1).bind(3, 4).unbind(1))
    print("---")
    test(f.bind(1).bind(2).bind(3).unbind(1))
    test(f.bind(1).bind(2).unbind(1).bind(3))
    test(f.bind(1).unbind(1).bind(2).bind(3))
    test(f.unbind(1).bind(1).bind(2).bind(3))
    print("---")
    test(f.unbind(1).unbind(1).unbind(1).bind(1, 2, 3))
    test(f.unbind(1).unbind(1).bind(1, 2, 3).unbind(1))
    test(f.unbind(1).bind(1, 2, 3).unbind(1).unbind(1))
    test(f.bind(1, 2, 3).unbind(1).unbind(1).unbind(1))
```

</details>

Before:

```
8 0 []        [7, 8, 9, 0, 0, 0, 0, 0]
6 2 [1, 2]    [7, 8, 9, 1, 2, 0, 0, 0]
7 1 [1]       [7, 8, 1, 2, 0, 0, 0, 0]
5 3 [1, 3, 4] [7, 8, 9, 3, 1, 2, 0, 0]
6 2 [1, 3]    [7, 8, 3, 1, 2, 0, 0, 0]
---
6 2 [1, 2]    [7, 8, 3, 2, 1, 0, 0, 0]
6 2 [1, 3]    [7, 8, 9, 2, 1, 0, 0, 0]
6 2 [2, 3]    [7, 8, 9, 3, 1, 0, 0, 0]
6 2 [2, 3]    [7, 8, 9, 3, 2, 0, 0, 0]
---
8 0 [2, 3]    [7, 8, 9, 0, 0, 0, 0, 0]
8 0 [2]       [7, 8, 1, 0, 0, 0, 0, 0]
8 0 []        [7, 1, 2, 0, 0, 0, 0, 0]
8 0 []        [1, 2, 3, 0, 0, 0, 0, 0]
```

After:

```
8 0 0 []        [7, 8, 9, 0, 0, 0, 0, 0] [7, 8, 9]
6 0 2 [1, 2]    [7, 8, 9, 1, 2, 0, 0, 0] [7, 8, 9, 1, 2]
7 1 2 [1, 2]    [7, 8, 1, 2, 0, 0, 0, 0] [7, 8, 1, 2]
5 0 3 [3, 1, 2] [7, 8, 9, 3, 1, 2, 0, 0] [7, 8, 9, 3, 1, 2]
6 1 3 [3, 1, 2] [7, 8, 3, 1, 2, 0, 0, 0] [7, 8, 3, 1, 2]
---
6 1 3 [3, 2, 1] [7, 8, 3, 2, 1, 0, 0, 0] [7, 8, 3, 2, 1]
6 0 2 [2, 1]    [7, 8, 9, 2, 1, 0, 0, 0] [7, 8, 9, 2, 1]
6 0 2 [3, 1]    [7, 8, 9, 3, 1, 0, 0, 0] [7, 8, 9, 3, 1]
6 0 2 [3, 2]    [7, 8, 9, 3, 2, 0, 0, 0] [7, 8, 9, 3, 2]
---
8 0 0 []        [7, 8, 9, 0, 0, 0, 0, 0] [7, 8, 9]
8 1 1 [1]       [7, 8, 1, 0, 0, 0, 0, 0] [7, 8, 1]
8 2 2 [1, 2]    [7, 1, 2, 0, 0, 0, 0, 0] [7, 1, 2]
8 3 3 [1, 2, 3] [1, 2, 3, 0, 0, 0, 0, 0] [1, 2, 3]
```

Note: This is probably unrelated and may not be a bug, but `get_argument_count()` can return negative values ​​for variadic functions, as in the test.