### PR TITLE
Improve Mesh UV1/UV2 preview in the editor

### DIFF
--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -36,6 +36,7 @@
 #include "scene/gui/option_button.h"
 
 class AcceptDialog;
+class AspectRatioContainer;
 class ConfirmationDialog;
 class MenuButton;
 class SpinBox;
@@ -79,6 +80,7 @@ class MeshInstance3DEditor : public Control {
 	AcceptDialog *err_dialog = nullptr;
 
 	AcceptDialog *debug_uv_dialog = nullptr;
+	AspectRatioContainer *debug_uv_arc = nullptr;
 	Control *debug_uv = nullptr;
 	Vector<Vector2> uv_lines;
 


### PR DESCRIPTION
- Use an AspectRatioContainer to prevent stretching that occurs depending on the dialog size.
- Draw UV bounds and a grid at 1/8th increments.
- Scale lines according to editor scale for better visibility on hiDPI displays.

While investigating https://github.com/godotengine/godot/issues/98685, I've made a number of improvements to better troubleshoot UV layouts.

## Preview

### Dark theme, 200% scale

![Dark](https://github.com/user-attachments/assets/2f418c2a-14af-43e6-8349-1f51f9e558b0)

### Light theme, 100% scale

![Light](https://github.com/user-attachments/assets/053c9e20-79e1-430f-89e1-1424e7efeff0)

### Black (OLED) theme, 100% scale, increased dialog size

*Stretching the dialog now preserves the UV's display aspect ratio.*

![Black](https://github.com/user-attachments/assets/bdce8ea3-fead-46a5-a896-90950a61e10d)
