### PR TITLE
Fix `AudioStreamWAV::save_to_wav` adding extra '.wav' to file if existing ext is not lower case

### DIFF
--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -624,7 +624,7 @@ Error AudioStreamWAV::save_to_wav(const String &p_path) {
 	}
 
 	String file_path = p_path;
-	if (!(file_path.substr(file_path.length() - 4, 4) == ".wav")) {
+	if (file_path.substr(file_path.length() - 4, 4).to_lower() != ".wav") {
 		file_path += ".wav";
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #98719

Pretty simple: if the file_path passed in contains an upper-case extension (e.g. ".WAV"), it would add an extra ".wav" on top of that. A simple `.to_lower()` fixes this.