### PR TITLE
Disable auto translation of `FileDialog`'s file list

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1586,6 +1586,7 @@ FileDialog::FileDialog() {
 	vbox->add_child(hbc);
 
 	tree = memnew(Tree);
+	tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tree->set_hide_root(true);
 	vbox->add_margin_child(ETR("Directories & Files:"), tree, true);
 


### PR DESCRIPTION
Test project: [test-4.zip](https://github.com/user-attachments/files/17596089/test-4.zip)
