### PR TITLE
[LineEdit] Implement input mask support.

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -309,6 +309,23 @@
 			If [code]true[/code], the [LineEdit] doesn't display decoration.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="input_mask" type="String" setter="set_input_mask" getter="get_input_mask" default="&quot;&quot;">
+			The text input mask. This is a template string composed of the following characters:
+			- [code]A[/code] - mask for an ASCII alphabet character ([code]A-Z[/code], [code]a-z[/code]).
+			- [code]N[/code] - mask for an ASCII alphanumeric character ([code]0-9[/code], [code]A-Z[/code], [code]a-z[/code]).
+			- [code]9[/code] - mask for an ASCII number character ([code]0-9[/code]).
+			- [code]D[/code] - mask for an ASCII number character greater than zero ([code]1-9[/code]).
+			- [code]#[/code] - mask for a plus/minus sign ([code]+[/code], [code]-[/code]).
+			- [code]H[/code] - mask for a hexadecimal number character ([code]0-9[/code], [code]A-F[/code], [code]a-f[/code]).
+			- [code]B[/code] - mask for a binary number character ([code]0[/code], [code]1[/code]).
+			- [code]X[/code] - mask for any other character.
+			- [code]&gt;[/code] - control character, all following characters are converted to uppercase.
+			- [code]&lt;[/code] - control character, all following characters are converted to lowercase.
+			- [code]![/code] - control character, disable case conversion for all following characters.
+			- [code];[/code] - control character, when followed by the single character, terminates the mask and sets the blank character  (the default blank character is space).
+			- [code]\[/code] - control character, used to escape the mask and control characters.
+			- All other characters are used as separators.
+		</member>
 		<member name="keep_editing_on_text_submit" type="bool" setter="set_keep_editing_on_text_submit" getter="is_editing_kept_on_text_submit" default="false">
 			If [code]true[/code], the [LineEdit] will not exit edit mode when text is submitted by pressing [code]ui_text_submit[/code] action (by default: [kbd]Enter[/kbd] or [kbd]Kp Enter[/kbd]).
 		</member>
@@ -345,6 +362,9 @@
 			[b]Note:[/b] This method is only implemented on Linux.
 		</member>
 		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" overrides="Control" enum="Control.CursorShape" default="1" />
+		<member name="overtype_mode_enabled" type="bool" setter="set_overtype_mode_enabled" getter="is_overtype_mode_enabled" default="false">
+			If [code]true[/code], enables overtype mode. In this mode, typing overrides existing text instead of inserting text. The [member ProjectSettings.input/ui_text_toggle_insert_mode] action toggles overtype mode.
+		</member>
 		<member name="placeholder_text" type="String" setter="set_placeholder" getter="get_placeholder" default="&quot;&quot;">
 			Text shown when the [LineEdit] is empty. It is [b]not[/b] the [LineEdit]'s default value (see [member text]).
 		</member>
@@ -551,6 +571,9 @@
 		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			Default font color.
+		</theme_item>
+		<theme_item name="font_mask_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 0.6)">
+			Font color for the static characters composing the [member input_mask].
 		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			The tint of text outline of the [LineEdit].

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -473,6 +473,7 @@ void EditorThemeManager::_create_shared_styles(const Ref<EditorTheme> &p_theme, 
 		p_config.font_disabled_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.35);
 		p_config.font_readonly_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.65);
 		p_config.font_placeholder_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.6);
+		p_config.font_mask_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.6);
 		p_config.font_outline_color = Color(0, 0, 0, 0);
 
 		p_theme->set_color(SceneStringName(font_color), EditorStringName(Editor), p_config.font_color);
@@ -483,6 +484,7 @@ void EditorThemeManager::_create_shared_styles(const Ref<EditorTheme> &p_theme, 
 		p_theme->set_color("font_disabled_color", EditorStringName(Editor), p_config.font_disabled_color);
 		p_theme->set_color("font_readonly_color", EditorStringName(Editor), p_config.font_readonly_color);
 		p_theme->set_color("font_placeholder_color", EditorStringName(Editor), p_config.font_placeholder_color);
+		p_theme->set_color("font_mask_color", EditorStringName(Editor), p_config.font_mask_color);
 		p_theme->set_color("font_outline_color", EditorStringName(Editor), p_config.font_outline_color);
 #ifndef DISABLE_DEPRECATED // Used before 4.3.
 		p_theme->set_color("readonly_font_color", EditorStringName(Editor), p_config.font_readonly_color);
@@ -1229,6 +1231,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_color("font_selected_color", "LineEdit", p_config.mono_color);
 		p_theme->set_color("font_uneditable_color", "LineEdit", p_config.font_readonly_color);
 		p_theme->set_color("font_placeholder_color", "LineEdit", p_config.font_placeholder_color);
+		p_theme->set_color("font_mask_color", "LineEdit", p_config.font_mask_color);
 		p_theme->set_color("font_outline_color", "LineEdit", p_config.font_outline_color);
 		p_theme->set_color("caret_color", "LineEdit", p_config.font_color);
 		p_theme->set_color("selection_color", "LineEdit", p_config.selection_color);

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -110,6 +110,7 @@ class EditorThemeManager {
 		Color font_disabled_color;
 		Color font_readonly_color;
 		Color font_placeholder_color;
+		Color font_mask_color;
 		Color font_outline_color;
 
 		Color icon_normal_color;

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -102,6 +102,7 @@ private:
 	AltInputMode alt_mode = ALT_INPUT_NONE;
 	bool alt_start = false;
 	bool alt_start_no_hold = false;
+	bool overtype_mode = false;
 	uint32_t alt_code = 0;
 
 	String undo_text;
@@ -153,6 +154,7 @@ private:
 
 	bool middle_mouse_paste_enabled = true;
 
+	bool ignore_next_event = false;
 	bool drag_action = false;
 	bool drag_caret_force_displayed = false;
 
@@ -208,6 +210,7 @@ private:
 		int font_outline_size;
 		Color font_outline_color;
 		Color font_placeholder_color;
+		Color font_mask_color;
 		int caret_width = 0;
 		Color caret_color;
 		int minimum_character_width = 0;
@@ -219,6 +222,38 @@ private:
 
 		float base_scale = 1.0;
 	} theme_cache;
+
+	char32_t blank = ' ';
+
+	enum MaskClass {
+		MASK_CLASS_STATIC,
+		MASK_CLASS_ALPHA,
+		MASK_CLASS_ALPHA_NUM,
+		MASK_CLASS_NUM,
+		MASK_CLASS_NUM_NON_ZERO,
+		MASK_CLASS_SIGN,
+		MASK_CLASS_HEX,
+		MASK_CLASS_BIN,
+		MASK_CLASS_ANY,
+	};
+
+	enum MaskCase {
+		MASK_CASE_UPPER,
+		MASK_CASE_LOWER,
+		MASK_CASE_ANY,
+	};
+
+	struct MaskElement {
+		MaskClass char_class = MASK_CLASS_ANY;
+		MaskCase char_case = MASK_CASE_ANY;
+		char32_t value = 0;
+	};
+
+	Vector<MaskElement> mask;
+	String mask_src;
+
+	void _parse_mask(const String &p_mask);
+	String _apply_mask(const String &p_text) const;
 
 	void _close_ime_window();
 	void _update_ime_window_position();
@@ -360,6 +395,12 @@ public:
 
 	void insert_text_at_caret(String p_text);
 	void clear();
+
+	void set_overtype_mode_enabled(bool p_enabled);
+	bool is_overtype_mode_enabled() const;
+
+	void set_input_mask(const String &p_input_mask);
+	String get_input_mask() const;
 
 	void set_caret_mid_grapheme_enabled(const bool p_enabled);
 	bool is_caret_mid_grapheme_enabled() const;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -105,6 +105,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	const Color control_font_focus_color = Color(0.95, 0.95, 0.95);
 	const Color control_font_disabled_color = control_font_color * Color(1, 1, 1, 0.5);
 	const Color control_font_placeholder_color = Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.6f);
+	const Color control_font_mask_color = control_font_placeholder_color;
 	const Color control_font_pressed_color = Color(1, 1, 1);
 	const Color control_selection_color = Color(0.5, 0.5, 0.5);
 
@@ -423,6 +424,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_selected_color", "LineEdit", control_font_pressed_color);
 	theme->set_color("font_uneditable_color", "LineEdit", control_font_disabled_color);
 	theme->set_color("font_placeholder_color", "LineEdit", control_font_placeholder_color);
+	theme->set_color("font_mask_color", "LineEdit", control_font_mask_color);
 	theme->set_color("font_outline_color", "LineEdit", Color(0, 0, 0));
 	theme->set_color("caret_color", "LineEdit", control_font_hover_color);
 	theme->set_color("selection_color", "LineEdit", control_selection_color);


### PR DESCRIPTION
Adds support for input mask to the `LineEdit`, similar to the [Qt feature](https://doc.qt.io/qt-6/qlineedit.html#inputMask-prop) with the same name (and using the same mask format).

https://github.com/user-attachments/assets/8b10469e-a899-4091-b787-6a5a9118e119

Closes https://github.com/godotengine/godot-proposals/issues/7193

