### PR TITLE
Better logic for Environment settings in the inspector

### DIFF
--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1093,88 +1093,108 @@ void Environment::_update_adjustment() {
 // Private methods, constructor and destructor
 
 void Environment::_validate_property(PropertyInfo &p_property) const {
-	if (p_property.name == "sky" || p_property.name == "sky_custom_fov" || p_property.name == "sky_rotation" || p_property.name == "ambient_light_sky_contribution") {
-		if (bg_mode != BG_SKY && ambient_source != AMBIENT_SOURCE_SKY && reflection_source != REFLECTION_SOURCE_SKY) {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
+	if (p_property.type == Variant::NIL) {
+		return;
 	}
 
-	if (p_property.name == "fog_depth_curve" || p_property.name == "fog_depth_begin" || p_property.name == "fog_depth_end") {
-		if (fog_mode == FOG_MODE_EXPONENTIAL) {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	}
+	// Background
 
-	if (p_property.name == "ambient_light_color" || p_property.name == "ambient_light_energy") {
-		if (ambient_source == AMBIENT_SOURCE_DISABLED) {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	}
-
-	if (p_property.name == "ambient_light_sky_contribution") {
-		if (ambient_source == AMBIENT_SOURCE_DISABLED || ambient_source == AMBIENT_SOURCE_COLOR) {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	}
-
-	if (p_property.name == "fog_aerial_perspective") {
-		if (bg_mode != BG_SKY) {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	}
-
-	if (p_property.name == "tonemap_white" && tone_mapper == TONE_MAPPER_LINEAR) {
+	if (p_property.name == "background_color" && bg_mode != BG_COLOR) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-	}
-
-	if (p_property.name == "glow_intensity" && glow_blend_mode == GLOW_BLEND_MODE_MIX) {
-		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-	}
-
-	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
-		// Hide glow properties we do not support in GL Compatibility.
-		if (p_property.name.begins_with("glow_levels") || p_property.name == "glow_normalized" || p_property.name == "glow_strength" || p_property.name == "glow_mix" || p_property.name == "glow_blend_mode" || p_property.name == "glow_map_strength" || p_property.name == "glow_map") {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	} else {
-		if (p_property.name == "glow_mix" && glow_blend_mode != GLOW_BLEND_MODE_MIX) {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	}
-
-	if (p_property.name == "background_color") {
-		if (bg_mode != BG_COLOR && ambient_source != AMBIENT_SOURCE_COLOR) {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	}
-
-	if (p_property.name == "background_canvas_max_layer") {
-		if (bg_mode != BG_CANVAS) {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
-	}
-
-	if (p_property.name == "background_camera_feed_id") {
-		if (bg_mode != BG_CAMERA_FEED) {
-			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
-		}
+		return;
 	}
 
 	if (p_property.name == "background_intensity" && !GLOBAL_GET("rendering/lights_and_shadows/use_physical_light_units")) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	if (p_property.name == "background_canvas_max_layer" && bg_mode != BG_CANVAS) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	if (p_property.name == "background_camera_feed_id" && bg_mode != BG_CAMERA_FEED) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	// Sky
+
+	if ((p_property.name == "sky" || p_property.name.begins_with("sky_")) && (bg_mode != BG_SKY && ambient_source != AMBIENT_SOURCE_SKY && reflection_source != REFLECTION_SOURCE_SKY)) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	// Ambient Light
+
+	if ((p_property.name == "ambient_light_color" || p_property.name == "ambient_light_energy") && (ambient_source != AMBIENT_SOURCE_BG || bg_mode != BG_SKY) && ambient_source != AMBIENT_SOURCE_SKY && ambient_source != AMBIENT_SOURCE_COLOR) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	if (p_property.name == "ambient_light_sky_contribution" && (ambient_source != AMBIENT_SOURCE_BG || bg_mode != BG_SKY) && ambient_source != AMBIENT_SOURCE_SKY) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	// Tonemap
+
+	if (p_property.name == "tonemap_white" && tone_mapper == TONE_MAPPER_LINEAR) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	// Glow
+
+	if (p_property.name == "glow_intensity" && glow_blend_mode == GLOW_BLEND_MODE_MIX) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	if (p_property.name == "glow_mix" && glow_blend_mode != GLOW_BLEND_MODE_MIX) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+#if 0
+	if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
+		// Hide glow properties we do not support in GL Compatibility.
+		if (p_property.name.begins_with("glow_levels")
+				|| p_property.name == "glow_normalized"
+				|| p_property.name == "glow_strength"
+				|| p_property.name == "glow_mix"
+				|| p_property.name == "glow_blend_mode"
+				|| p_property.name == "glow_map_strength"
+				|| p_property.name == "glow_map") {
+			p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+			return;
+		}
+	}
+#endif
+
+	// Fog
+
+	if (p_property.name == "fog_aerial_perspective" && bg_mode != BG_SKY) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
+	}
+
+	if ((p_property.name == "fog_depth_curve" || p_property.name == "fog_depth_begin" || p_property.name == "fog_depth_end") && fog_mode != FOG_MODE_DEPTH) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+		return;
 	}
 
 	static const char *hide_prefixes[] = {
-		"fog_",
-		"volumetric_fog_",
 		"ssr_",
 		"ssao_",
 		"ssil_",
 		"sdfgi_",
 		"glow_",
+		"fog_",
+		"volumetric_fog_",
 		"adjustment_",
 		nullptr
-
 	};
 
 	const char **prefixes = hide_prefixes;


### PR DESCRIPTION
# Info

I have updated the `Environment::_validate_property` function in the `scene/resources/environment.cpp` file so that it correctly hides the controls in the inspector depending on the options selected.

Previously, some controls in `Background` and `Ambient Light` were displayed even when changing them did not affect the lighting in any way, which was misleading. For example, the `ambient_light_color` and `ambient_light_energy` fields were displayed, even when the ambient lighting source was set to `Background` which did not point to `Sky`. In other example, changing `ambient_light_color` to `Color` caused the `background_color` field to appear in the `Background` group for no reason.

Below is a list of the new validation rules and some notes.

# Validation

### Early returns

First of all, if property type is `NIL` (inspector group name), we return immediately. Later inside the function, every time property usage is set to `PROPERTY_USAGE_NO_EDITOR`, there is also no need to continue.

### Background

- `background_color` is visible **only** if `bg_mode` is `BG_COLOR`
- `background_energy_multiplier` is visible always (there are cases when it's doing nothing but they're very rare, for example when `Background` is `Keep` and both `Ambient` and `Reflected` are `Disabled`)
- `background_intensity` is visible **only** if `Use Physical Light Units` is enabled
- `background_canvas_max_layer` is visible **only** if `bg_mode` is `BG_CANVAS`
- `background_camera_feed_id` is visible **only** if `bg_mode` is `BG_CAMERA_FEED`

### Sky

This is pretty straightforward. The whole group should be visible **only** if `Background`, `Ambient Light` or `Reflected Light` are set to `Sky`.

### Ambient Light

- `ambient_light_color` is visible when (one of below):
	- `ambient_source` is `AMBIENT_SOURCE_BG` and `bg_mode` is `BG_SKY`
	- `ambient_source` is `AMBIENT_SOURCE_SKY`
	- `ambient_source` is `AMBIENT_SOURCE_COLOR`
- `ambient_light_sky_contribution` is visible when (one of below):
	- `ambient_source` is `AMBIENT_SOURCE_BG` and `bg_mode` is `BG_SKY`
	- `ambient_source` is `AMBIENT_SOURCE_SKY`
- `ambient_light_energy` is the same as `ambient_light_color`

### Tonemap

- `tonemap_white` is visible when `tonemap_mode` is **not** `TONE_MAPPER_LINEAR`.

### Glow

- `glow_intensity` is visible if `glow_blend_mode` is **not** `GLOW_BLEND_MODE_MIX`
- `glow_mix` is visible **only** if `glow_blend_mode` is `GLOW_BLEND_MODE_MIX`

Note, I disabled the rules added by @BastiaanOlij which are hiding some controls in the `Glow` group in Compatibility mode. This is the only place that checks the renderer mode, other unsupported elements like `SSR`, `SSAO`, `SSIL`, etc. are always displayed, which creates inconsistency. I would add that controls that do not work specifically in Compatibility mode have information about this fact in their tooltips. Hiding controls just because the editor is running in a different mode prevents the user from quickly editing `Environment` without reloading the project.

### Fog

- `fog_aerial_perspective` is visible if `bg_mode` is `BG_SKY`
- `fog_depth_curve`, `fog_depth_begin` and `fog_depth_end` are visible if `fog_mode` is `FOG_MODE_DEPTH`

# Example project for testing

[WorldEnvironment-Test.zip](https://github.com/user-attachments/files/17605413/WorldEnvironment-Test.zip)

# All properties list for reference

### `Background`
- background_mode
- background_color
- background_energy_multiplier
- background_intensity
- background_canvas_max_layer
- background_camera_feed_id

### `Sky`
- sky
- sky_custom_fov
- sky_rotation

### `Ambient Light`
- ambient_light_source
- ambient_light_color
- ambient_light_sky_contribution
- ambient_light_energy

### `Reflected Light`
- reflected_light_source

### `Tonemap`
- tonemap_mode
- tonemap_exposure
- tonemap_white

### `SSR`
- ssr_enabled
- ssr_max_steps
- ssr_fade_in
- ssr_fade_out
- ssr_depth_tolerance

### `SSAO`
- ssao_enabled
- ssao_radius
- ssao_intensity
- ssao_power
- ssao_detail
- ssao_horizon
- ssao_sharpness
- ssao_light_affect
- ssao_ao_channel_affect

### `SSIL`
- ssil_enabled
- ssil_radius
- ssil_intensity
- ssil_sharpness
- ssil_normal_rejection

### `SDFGI`
- sdfgi_enabled
- sdfgi_use_occlusion
- sdfgi_read_sky_light
- sdfgi_bounce_feedback
- sdfgi_cascades
- sdfgi_min_cell_size
- sdfgi_cascade0_distance
- sdfgi_max_distance
- sdfgi_y_scale
- sdfgi_energy
- sdfgi_normal_bias
- sdfgi_probe_bias

### `Glow`
- glow_enabled
- glow_levels/1
- glow_levels/2
- glow_levels/3
- glow_levels/4
- glow_levels/5
- glow_levels/6
- glow_levels/7
- glow_normalized
- glow_intensity
- glow_strength
- glow_mix
- glow_bloom
- glow_blend_mode
- glow_hdr_threshold
- glow_hdr_scale
- glow_hdr_luminance_cap
- glow_map_strength
- glow_map

### `Fog`
- fog_enabled
- fog_mode
- fog_light_color
- fog_light_energy
- fog_sun_scatter
- fog_density
- fog_aerial_perspective
- fog_sky_affect
- fog_height
- fog_height_density
- fog_depth_curve
- fog_depth_begin
- fog_depth_end

### `Volumetric Fog`
- volumetric_fog_enabled
- volumetric_fog_density
- volumetric_fog_albedo
- volumetric_fog_emission
- volumetric_fog_emission_energy
- volumetric_fog_gi_inject
- volumetric_fog_anisotropy
- volumetric_fog_length
- volumetric_fog_detail_spread
- volumetric_fog_ambient_inject
- volumetric_fog_sky_affect

### `Temporal Reprojection`
- volumetric_fog_temporal_reprojection_enabled
- volumetric_fog_temporal_reprojection_amount

### `Adjustments`
- adjustment_enabled
- adjustment_brightness
- adjustment_contrast
- adjustment_saturation
- adjustment_color_correction

### `Resource`
- resource_local_to_scene
- resource_path
- resource_name
- resource_scene_unique_id
