### PR TITLE
Don't tint editor bottom panel icons when hovered or pressed

### DIFF
--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -98,8 +98,6 @@ private:
 			toggle_button->set_pressed(true);
 			toggle_button->set_text(itos(message_count));
 			toggle_button->set_tooltip_text(TTR(p_tooltip));
-			// Don't tint the icon even when in "pressed" state.
-			toggle_button->add_theme_color_override("icon_color_pressed", Color(1, 1, 1, 1));
 			toggle_button->set_focus_mode(FOCUS_NONE);
 			// When toggled call the callback and pass the MessageType this button is for.
 			toggle_button->connect(SceneStringName(toggled), p_toggled_callback.bind(type));

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1901,6 +1901,12 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		p_theme->set_stylebox(SceneStringName(pressed), "BottomPanelButton", menu_transparent_style);
 		p_theme->set_stylebox("hover_pressed", "BottomPanelButton", main_screen_button_hover);
 		p_theme->set_stylebox("hover", "BottomPanelButton", main_screen_button_hover);
+		// Don't tint the icon even when in "pressed" state.
+		p_theme->set_color("icon_pressed_color", "BottomPanelButton", Color(1, 1, 1, 1));
+		Color icon_hover_color = p_config.icon_normal_color * (p_config.dark_theme ? 1.15 : 1.0);
+		icon_hover_color.a = 1.0;
+		p_theme->set_color("icon_hover_color", "BottomPanelButton", icon_hover_color);
+		p_theme->set_color("icon_hover_pressed_color", "BottomPanelButton", icon_hover_color);
 	}
 
 	// Editor GUI widgets.
@@ -1998,6 +2004,7 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 			Color icon_hover_color = p_config.icon_normal_color * (p_config.dark_theme ? 1.15 : 1.0);
 			icon_hover_color.a = 1.0;
 			p_theme->set_color("icon_hover_color", "EditorLogFilterButton", icon_hover_color);
+			p_theme->set_color("icon_hover_pressed_color", "EditorLogFilterButton", icon_hover_color);
 
 			// When pressed, add a small bottom border to the buttons to better show their active state,
 			// similar to active tabs.

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -236,14 +236,14 @@ void FileDialog::_notification(int p_what) {
 			dir_prev->add_theme_color_override("icon_normal_color", theme_cache.icon_normal_color);
 			dir_prev->add_theme_color_override("icon_hover_color", theme_cache.icon_hover_color);
 			dir_prev->add_theme_color_override("icon_focus_color", theme_cache.icon_focus_color);
-			dir_prev->add_theme_color_override("icon_color_pressed", theme_cache.icon_pressed_color);
+			dir_prev->add_theme_color_override("icon_pressed_color", theme_cache.icon_pressed_color);
 			dir_prev->end_bulk_theme_override();
 
 			dir_next->begin_bulk_theme_override();
 			dir_next->add_theme_color_override("icon_normal_color", theme_cache.icon_normal_color);
 			dir_next->add_theme_color_override("icon_hover_color", theme_cache.icon_hover_color);
 			dir_next->add_theme_color_override("icon_focus_color", theme_cache.icon_focus_color);
-			dir_next->add_theme_color_override("icon_color_pressed", theme_cache.icon_pressed_color);
+			dir_next->add_theme_color_override("icon_pressed_color", theme_cache.icon_pressed_color);
 			dir_next->end_bulk_theme_override();
 
 			refresh->begin_bulk_theme_override();


### PR DESCRIPTION
This prevents the error/warning icons from turning gray or green, making them hard to recognize. A similar mechanism is already used for EditorLog filter button icons.

This also fixes typos in FileDialog theme color assignment (`icon_color_pressed` instead of `icon_pressed_color`). The exposed theme item names remain the same. `icon_hover_pressed_color` is now set for EditorLogFilterButton as well, so you get a subtle visual feedback when hovering the buttons when they're already pressed.

This was mentioned in a proposal issue or discussion recently, but I can't find it right now.

- This closes #98540.

## Preview

### Before

https://github.com/user-attachments/assets/a28ed40f-5ecc-4a22-8448-64b39725acd9

### After

https://github.com/user-attachments/assets/736198fc-12fd-40f2-822f-f9cf1d3e1b80

