### PR TITLE
Fix occlusion culling for double builds by enforcing float conversion for Embree.

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.h
+++ b/modules/raycast/raycast_occlusion_cull.h
@@ -109,7 +109,7 @@ private:
 	struct OccluderInstance {
 		RID occluder;
 		LocalVector<uint32_t> indices;
-		LocalVector<Vector3> xformed_vertices;
+		LocalVector<float> xformed_vertices;
 		Transform3D xform;
 		bool enabled = true;
 		bool removed = false;
@@ -126,7 +126,7 @@ private:
 			uint32_t vertex_count;
 			Transform3D xform;
 			const Vector3 *read;
-			Vector3 *write = nullptr;
+			float *write = nullptr;
 		};
 
 		Thread *commit_thread = nullptr;
@@ -144,7 +144,7 @@ private:
 		void _update_dirty_instance_thread(int p_idx, RID *p_instances);
 		void _update_dirty_instance(int p_idx, RID *p_instances);
 		void _transform_vertices_thread(uint32_t p_thread, TransformThreadData *p_data);
-		void _transform_vertices_range(const Vector3 *p_read, Vector3 *p_write, const Transform3D &p_xform, int p_from, int p_to);
+		void _transform_vertices_range(const Vector3 *p_read, float *p_write, const Transform3D &p_xform, int p_from, int p_to);
 		static void _commit_scene(void *p_ud);
 		void free();
 		void update();


### PR DESCRIPTION
Fixes #94638

Embree does not support double precision for its geometry buffer. I therefore created a simple float struct to force the conversion from double to float.