### PR TITLE
smol-v: update to 2024 to support SPIR-V 1.6

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -432,7 +432,7 @@ License: BSD-3-clause
 Files: ./thirdparty/misc/smolv.cpp
  ./thirdparty/misc/smolv.h
 Comment: SMOL-V
-Copyright: 2016-2020, Aras Pranckevicius
+Copyright: 2016-2024, Aras Pranckevicius
 License: public-domain or Unlicense or Expat
 
 Files: ./thirdparty/misc/stb_rect_pack.h

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -709,7 +709,7 @@ Collection of single-file libraries used in Godot components.
   * Modifications: use `const char*` instead of `char*` for input string
 - `smolv.{cpp,h}`
   * Upstream: https://github.com/aras-p/smol-v
-  * Version: git (4b52c165c13763051a18e80ffbc2ee436314ceb2, 2020)
+  * Version: git (9dd54c379ac29fa148cb1b829bb939ba7381d8f4, 2024)
   * License: Public Domain or MIT
 - `stb_rect_pack.h`
   * Upstream: https://github.com/nothings/stb

--- a/thirdparty/misc/smolv.cpp
+++ b/thirdparty/misc/smolv.cpp
@@ -1,5 +1,5 @@
 // smol-v - public domain - https://github.com/aras-p/smol-v
-// authored 2016-2020 by Aras Pranckevicius
+// authored 2016-2024 by Aras Pranckevicius
 // no warranty implied; use at your own risk
 // See end of file for license information.
 
@@ -1197,8 +1197,8 @@ static bool smolv_CheckGenericHeader(const uint32_t* words, size_t wordCount, ui
 	if (headerMagic != expectedMagic)
 		return false;
 	uint32_t headerVersion = words[1] & versionMask;
-	if (headerVersion < 0x00010000 || headerVersion > 0x00010500)
-		return false; // only support 1.0 through 1.5
+	if (headerVersion < 0x00010000 || headerVersion > 0x00010600)
+		return false; // only support 1.0 through 1.6
 	
 	return true;
 }
@@ -2071,7 +2071,7 @@ void smolv::StatsPrint(const Stats* stats)
 // This software is available under 2 licenses -- choose whichever you prefer.
 // ------------------------------------------------------------------------------
 // ALTERNATIVE A - MIT License
-// Copyright (c) 2016-2020 Aras Pranckevicius
+// Copyright (c) 2016-2024 Aras Pranckevicius
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to

--- a/thirdparty/misc/smolv.h
+++ b/thirdparty/misc/smolv.h
@@ -1,5 +1,5 @@
 // smol-v - public domain - https://github.com/aras-p/smol-v
-// authored 2016-2020 by Aras Pranckevicius
+// authored 2016-2024 by Aras Pranckevicius
 // no warranty implied; use at your own risk
 // See end of file for license information.
 //
@@ -132,7 +132,7 @@ namespace smolv
 // This software is available under 2 licenses -- choose whichever you prefer.
 // ------------------------------------------------------------------------------
 // ALTERNATIVE A - MIT License
-// Copyright (c) 2016-2020 Aras Pranckevicius
+// Copyright (c) 2016-2024 Aras Pranckevicius
 // Permission is hereby granted, free of charge, to any person obtaining a copy of
 // this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to


### PR DESCRIPTION
Update smol-v to 2024 version to support SPIR-V 1.6

- *Production edit: See https://github.com/aras-p/smol-v/issues/13.*