### PR TITLE
Add missing checks for non-3D builds in scene debugger

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -289,8 +289,10 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 		} else if (p_msg == "runtime_node_select_reset_camera_2d") {
 			runtime_node_select->_reset_camera_2d();
 
+#ifndef _3D_DISABLED
 		} else if (p_msg == "runtime_node_select_reset_camera_3d") {
 			runtime_node_select->_reset_camera_3d();
+#endif // _3D_DISABLED
 
 		} else {
 			return ERR_SKIP;


### PR DESCRIPTION
Follow-up to:
* https://github.com/godotengine/godot/pull/97257

Makes building work on 3D disabled builds
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
