### PR TITLE
Use surface extents for swap chain extents.

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2895,8 +2895,6 @@ Error RenderingDeviceDriverVulkan::swap_chain_resize(CommandQueueID p_cmd_queue,
 			surface_capabilities.currentExtent.height = width;
 			surface_capabilities.currentExtent.width = height;
 		}
-
-		native_display_size = surface_capabilities.currentExtent;
 	}
 
 	VkExtent2D extent;
@@ -2991,7 +2989,7 @@ Error RenderingDeviceDriverVulkan::swap_chain_resize(CommandQueueID p_cmd_queue,
 	swap_create_info.minImageCount = desired_swapchain_images;
 	swap_create_info.imageFormat = swap_chain->format;
 	swap_create_info.imageColorSpace = swap_chain->color_space;
-	swap_create_info.imageExtent = native_display_size;
+	swap_create_info.imageExtent = extent;
 	swap_create_info.imageArrayLayers = 1;
 	swap_create_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 	swap_create_info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -366,7 +366,6 @@ private:
 	};
 
 	void _swap_chain_release(SwapChain *p_swap_chain);
-	VkExtent2D native_display_size;
 
 public:
 	virtual SwapChainID swap_chain_create(RenderingContextDriver::SurfaceID p_surface) override final;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/98779

This PR just uses the calculated surface extents instead of the current extents which are sometimes the special value UINT32_MAX.