### PR TITLE
Docs: Update TileSet to reference TileMapLayer instead of TileMap

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -4,7 +4,7 @@
 		Tile library for tilemaps.
 	</brief_description>
 	<description>
-		A TileSet is a library of tiles for a [TileMap]. A TileSet handles a list of [TileSetSource], each of them storing a set of tiles.
+		A TileSet is a library of tiles for a [TileMapLayer]. A TileSet handles a list of [TileSetSource], each of them storing a set of tiles.
 		Tiles can either be from a [TileSetAtlasSource], which renders tiles out of a texture with support for physics, navigation, etc., or from a [TileSetScenesCollectionSource], which exposes scene-based tiles.
 		Tiles are referenced by using three IDs: their source ID, their atlas coordinates ID, and their alternative tile ID.
 		A TileSet can be configured so that its tiles expose more or fewer properties. To do so, the TileSet resources use property layers, which you can add or remove depending on your needs.


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-docs/issues/9931 and closes https://github.com/godotengine/godot-docs/issues/9759.

There are still plenty of other references to TileMap that should now be references to TileMapLayer, but I'm not enough of an expert in the area to fix all of those.