### PR TITLE
Update docs for `Tween.stop` to clarify behavior

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -280,6 +280,22 @@
 			<return type="void" />
 			<description>
 				Stops the tweening and resets the [Tween] to its initial state. This will not remove any appended [Tweener]s.
+				[b]Note:[/b] This does [i]not[/i] reset targets of [PropertyTweener]s to their values when the [Tween] first started.
+				[codeblock]
+				var tween = create_tween()
+
+				# Will move from 0 to 500 over 1 second.
+				position.x = 0.0
+				tween.tween_property(self, "position:x", 500, 1.0)
+
+				# Will be at (about) 250 when the timer finishes.
+				await get_tree().create_timer(0.5).timeout
+
+				# Will now move from (about) 250 to 500 over 1 second,
+				# thus at half the speed as before.
+				tween.stop()
+				tween.play()
+				[/codeblock]
 				[b]Note:[/b] If a Tween is stopped and not bound to any node, it will exist indefinitely until manually started or invalidated. If you lose a reference to such Tween, you can retrieve it using [method SceneTree.get_processed_tweens].
 			</description>
 		</method>


### PR DESCRIPTION
This PR resolves https://github.com/godotengine/godot-docs/issues/10196 by noting that the initial state of PropertyTweeners' targets is not restored when a Tween is stopped with `stop`. Currently, it states that the Tween is reset to "its initial state", which I believe could easily be misinterpreted as the objects involved in the Tween being moved back to their original positions/properties.

A short code example is included to demonstrate what this means/how it behaves.