### PR TITLE
Fix `Input::remove_joy_mapping`

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1602,9 +1602,6 @@ void Input::parse_mapping(const String &p_mapping) {
 		return;
 	}
 
-	CharString uid;
-	uid.resize(17);
-
 	mapping.uid = entry[0];
 	mapping.name = entry[1];
 
@@ -1712,44 +1709,29 @@ void Input::add_joy_mapping(const String &p_mapping, bool p_update_existing) {
 }
 
 void Input::remove_joy_mapping(const String &p_guid) {
-	int fallback_mapping_offset = 0; // Fix the fallback, if we invalidate its index.
+	int index_removed = 0;
 
 	for (int i = map_db.size() - 1; i >= 0; i--) {
 		if (p_guid == map_db[i].uid) {
 			map_db.remove_at(i);
+			index_removed = i;
 
 			if (i == fallback_mapping) {
 				fallback_mapping = -1;
 				WARN_PRINT_ONCE(vformat("Removed fallback joypad input mapping \"%s\". This could lead to joypads not working as intended.", p_guid));
-			} else if (i < fallback_mapping) {
-				fallback_mapping_offset--;
 			}
 		}
-	}
-
-	if (fallback_mapping_offset < 0) {
-		fallback_mapping += fallback_mapping_offset;
 	}
 
 	for (KeyValue<int, Joypad> &E : joy_names) {
 		Joypad &joy = E.value;
-		int mapping;
 
 		if (joy.uid == p_guid) {
-			mapping = -1;
-		} else if (joy.mapping == (fallback_mapping - fallback_mapping_offset)) {
-			// Fix the mapping for the joypad that uses an outdated fallback index.
-			mapping = fallback_mapping;
-		} else {
-			// Re-validate the joypad's correct mapping. Fix it if necessary.
-			mapping = fallback_mapping;
-			for (int i = 0; i < map_db.size(); i++) {
-				if (joy.uid == map_db[i].uid) {
-					mapping = i;
-				}
-			}
+			_set_joypad_mapping(joy, -1);
+		} else if (joy.mapping > index_removed) {
+			// The map_db update offset this joypad's mapping reference, update it:
+			_set_joypad_mapping(joy, map_db[joy.mapping - 1]);
 		}
-		_set_joypad_mapping(joy, mapping);
 	}
 }
 

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1712,16 +1712,44 @@ void Input::add_joy_mapping(const String &p_mapping, bool p_update_existing) {
 }
 
 void Input::remove_joy_mapping(const String &p_guid) {
+	int fallback_mapping_offset = 0; // Fix the fallback, if we invalidate its index.
+
 	for (int i = map_db.size() - 1; i >= 0; i--) {
 		if (p_guid == map_db[i].uid) {
 			map_db.remove_at(i);
+
+			if (i == fallback_mapping) {
+				fallback_mapping = -1;
+				WARN_PRINT_ONCE(vformat("Removed fallback joypad input mapping \"%s\". This could lead to joypads not working as intended.", p_guid));
+			} else if (i < fallback_mapping) {
+				fallback_mapping_offset--;
+			}
 		}
 	}
+
+	if (fallback_mapping_offset < 0) {
+		fallback_mapping += fallback_mapping_offset;
+	}
+
 	for (KeyValue<int, Joypad> &E : joy_names) {
 		Joypad &joy = E.value;
+		int mapping;
+
 		if (joy.uid == p_guid) {
-			_set_joypad_mapping(joy, -1);
+			mapping = -1;
+		} else if (joy.mapping == (fallback_mapping - fallback_mapping_offset)) {
+			// Fix the mapping for the joypad that uses an outdated fallback index.
+			mapping = fallback_mapping;
+		} else {
+			// Re-validate the joypad's correct mapping. Fix it if necessary.
+			mapping = fallback_mapping;
+			for (int i = 0; i < map_db.size(); i++) {
+				if (joy.uid == map_db[i].uid) {
+					mapping = i;
+				}
+			}
 		}
+		_set_joypad_mapping(joy, mapping);
 	}
 }
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -184,7 +184,7 @@ private:
 
 	HashSet<uint32_t> ignored_device_ids;
 
-	int fallback_mapping = -1;
+	int fallback_mapping = -1; // Index of the guid in map_db.
 
 	CursorShape default_shape = CURSOR_ARROW;
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -311,7 +311,7 @@
 			<return type="void" />
 			<param index="0" name="guid" type="String" />
 			<description>
-				Removes all mappings from the internal database that match the given GUID.
+				Removes all mappings from the internal database that match the given GUID. All currently connected joypads that use this GUID will become unmapped.
 			</description>
 		</method>
 		<method name="set_accelerometer">

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -312,6 +312,7 @@
 			<param index="0" name="guid" type="String" />
 			<description>
 				Removes all mappings from the internal database that match the given GUID. All currently connected joypads that use this GUID will become unmapped.
+				On Android, Godot will map to an internal fallback mapping.
 			</description>
 		</method>
 		<method name="set_accelerometer">


### PR DESCRIPTION
Erasing a joypad mapping can invalidate other attached joypads and the fallback mapping guid

Fixes #91257 (cannot confirm crash on Linux. Untested on Windows where it was observed)

If this PR is merged, it needs to be cherry-picked/backported to all supported Godot versions, afaik.

**NOTE**
* ~~I'm not sure if I handled `fallback_mapping` correctly, because according to `Input::is_joy_known` the fallback does not count as a known device… Therefore, feedback on this would be nice~~
  * ~~If it's only meant as an internal fallback, a more minimal change of this PR to the fallback logic would be to deny removing the mapping for that one. Then I could remove the setter and getter for the fallback.~~ -> **Removed bindings**
* ~~I renamed some members in windows joypad file to differentiate between direct INPUT and direct X. I found `d_joypads`, and it feels like the `d_` prefix was meant as a direct input abbreviation. So I used that. I'm open to alternative naming convention, though. Some renaming should happen to untangle INPUT and X.~~ -> **Renaming is done in another PR**