### PR TITLE
Improve EditorToaster code

### DIFF
--- a/editor/gui/editor_toaster.h
+++ b/editor/gui/editor_toaster.h
@@ -31,8 +31,6 @@
 #ifndef EDITOR_TOASTER_H
 #define EDITOR_TOASTER_H
 
-#include "core/string/ustring.h"
-#include "core/templates/local_vector.h"
 #include "scene/gui/box_container.h"
 
 class Button;
@@ -76,6 +74,9 @@ private:
 		real_t remaining_time = 0.0;
 		bool popped = false;
 
+		// Buttons
+		Button *close_button = nullptr;
+
 		// Messages
 		String message;
 		String tooltip;
@@ -101,7 +102,7 @@ private:
 	void _set_notifications_enabled(bool p_enabled);
 	void _repop_old();
 	void _popup_str(const String &p_message, Severity p_severity, const String &p_tooltip);
-	void _close_button_theme_changed(Control *p_close_button);
+	void _toast_theme_changed(Control *p_control);
 
 protected:
 	static EditorToaster *singleton;


### PR DESCRIPTION
- Enable processing only when there are active toasts
- Rework how Close button is themed
  - The `theme_changed` signal is instead connected from the toast's PanelContainer
  - Close Button has an entry in Toast struct
  - Removed redundant icon assign
  - Helps #98778
- Use Toast& in some places instead of always accessing by key