### PR TITLE
Tweak console error/warning print colors

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -974,34 +974,37 @@ void UnixTerminalLogger::log_error(const char *p_function, const char *p_file, i
 	// This prevents Godot from writing ANSI escape codes when redirecting
 	// stdout and stderr to a file.
 	const bool tty = isatty(fileno(stdout));
-	const char *gray = tty ? "\E[0;90m" : "";
 	const char *red = tty ? "\E[0;91m" : "";
-	const char *red_bold = tty ? "\E[1;31m" : "";
+	const char *red_bold = tty ? "\E[1;91m" : "";
+	const char *red_faint = tty ? "\E[2;91m" : "";
 	const char *yellow = tty ? "\E[0;93m" : "";
-	const char *yellow_bold = tty ? "\E[1;33m" : "";
+	const char *yellow_bold = tty ? "\E[1;93m" : "";
+	const char *yellow_faint = tty ? "\E[2;93m" : "";
 	const char *magenta = tty ? "\E[0;95m" : "";
-	const char *magenta_bold = tty ? "\E[1;35m" : "";
+	const char *magenta_bold = tty ? "\E[1;95m" : "";
+	const char *magenta_faint = tty ? "\E[2;95m" : "";
 	const char *cyan = tty ? "\E[0;96m" : "";
-	const char *cyan_bold = tty ? "\E[1;36m" : "";
+	const char *cyan_bold = tty ? "\E[1;96m" : "";
+	const char *cyan_faint = tty ? "\E[2;96m" : "";
 	const char *reset = tty ? "\E[0m" : "";
 
 	switch (p_type) {
 		case ERR_WARNING:
 			logf_error("%sWARNING:%s %s\n", yellow_bold, yellow, err_details);
-			logf_error("%s     at: %s (%s:%i)%s\n", gray, p_function, p_file, p_line, reset);
+			logf_error("%s     at: %s (%s:%i)%s\n", yellow_faint, p_function, p_file, p_line, reset);
 			break;
 		case ERR_SCRIPT:
 			logf_error("%sSCRIPT ERROR:%s %s\n", magenta_bold, magenta, err_details);
-			logf_error("%s          at: %s (%s:%i)%s\n", gray, p_function, p_file, p_line, reset);
+			logf_error("%s          at: %s (%s:%i)%s\n", magenta_faint, p_function, p_file, p_line, reset);
 			break;
 		case ERR_SHADER:
 			logf_error("%sSHADER ERROR:%s %s\n", cyan_bold, cyan, err_details);
-			logf_error("%s          at: %s (%s:%i)%s\n", gray, p_function, p_file, p_line, reset);
+			logf_error("%s          at: %s (%s:%i)%s\n", cyan_faint, p_function, p_file, p_line, reset);
 			break;
 		case ERR_ERROR:
 		default:
 			logf_error("%sERROR:%s %s\n", red_bold, red, err_details);
-			logf_error("%s   at: %s (%s:%i)%s\n", gray, p_function, p_file, p_line, reset);
+			logf_error("%s   at: %s (%s:%i)%s\n", red_faint, p_function, p_file, p_line, reset);
 			break;
 	}
 }

--- a/platform/macos/macos_terminal_logger.mm
+++ b/platform/macos/macos_terminal_logger.mm
@@ -46,35 +46,53 @@ void MacOSTerminalLogger::log_error(const char *p_function, const char *p_file, 
 		err_details = p_code;
 	}
 
+	// Disable color codes if stdout is not a TTY.
+	// This prevents Godot from writing ANSI escape codes when redirecting
+	// stdout and stderr to a file.
+	const bool tty = isatty(fileno(stdout));
+	const char *red = tty ? "\E[0;91m" : "";
+	const char *red_bold = tty ? "\E[1;91m" : "";
+	const char *red_faint = tty ? "\E[2;91m" : "";
+	const char *yellow = tty ? "\E[0;93m" : "";
+	const char *yellow_bold = tty ? "\E[1;93m" : "";
+	const char *yellow_faint = tty ? "\E[2;93m" : "";
+	const char *magenta = tty ? "\E[0;95m" : "";
+	const char *magenta_bold = tty ? "\E[1;95m" : "";
+	const char *magenta_faint = tty ? "\E[2;95m" : "";
+	const char *cyan = tty ? "\E[0;96m" : "";
+	const char *cyan_bold = tty ? "\E[1;96m" : "";
+	const char *cyan_faint = tty ? "\E[2;96m" : "";
+	const char *reset = tty ? "\E[0m" : "";
+
 	switch (p_type) {
 		case ERR_WARNING:
 			os_log_info(OS_LOG_DEFAULT,
 					"WARNING: %{public}s\nat: %{public}s (%{public}s:%i)",
 					err_details, p_function, p_file, p_line);
-			logf_error("\E[1;33mWARNING:\E[0;93m %s\n", err_details);
-			logf_error("\E[0;90m     at: %s (%s:%i)\E[0m\n", p_function, p_file, p_line);
+			logf_error("%sWARNING:%s %s\n", yellow_bold, yellow, err_details);
+			logf_error("%s     at: %s (%s:%i)%s\n", yellow_faint, p_function, p_file, p_line, reset);
 			break;
 		case ERR_SCRIPT:
 			os_log_error(OS_LOG_DEFAULT,
 					"SCRIPT ERROR: %{public}s\nat: %{public}s (%{public}s:%i)",
 					err_details, p_function, p_file, p_line);
-			logf_error("\E[1;35mSCRIPT ERROR:\E[0;95m %s\n", err_details);
-			logf_error("\E[0;90m          at: %s (%s:%i)\E[0m\n", p_function, p_file, p_line);
+			logf_error("%sSCRIPT ERROR:%s %s\n", magenta_bold, magenta, err_details);
+			logf_error("%s          at: %s (%s:%i)%s\n", magenta_faint, p_function, p_file, p_line, reset);
 			break;
 		case ERR_SHADER:
 			os_log_error(OS_LOG_DEFAULT,
 					"SHADER ERROR: %{public}s\nat: %{public}s (%{public}s:%i)",
 					err_details, p_function, p_file, p_line);
-			logf_error("\E[1;36mSHADER ERROR:\E[0;96m %s\n", err_details);
-			logf_error("\E[0;90m          at: %s (%s:%i)\E[0m\n", p_function, p_file, p_line);
+			logf_error("%sSHADER ERROR:%s %s\n", cyan_bold, cyan, err_details);
+			logf_error("%s          at: %s (%s:%i)%s\n", cyan_faint, p_function, p_file, p_line, reset);
 			break;
 		case ERR_ERROR:
 		default:
 			os_log_error(OS_LOG_DEFAULT,
 					"ERROR: %{public}s\nat: %{public}s (%{public}s:%i)",
 					err_details, p_function, p_file, p_line);
-			logf_error("\E[1;31mERROR:\E[0;91m %s\n", err_details);
-			logf_error("\E[0;90m   at: %s (%s:%i)\E[0m\n", p_function, p_file, p_line);
+			logf_error("%sERROR:%s %s\n", red_bold, red, err_details);
+			logf_error("%s   at: %s (%s:%i)%s\n", red_faint, p_function, p_file, p_line, reset);
 			break;
 	}
 }

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -81,76 +81,51 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 	if (!hCon || hCon == INVALID_HANDLE_VALUE) {
 		StdLogger::log_error(p_function, p_file, p_line, p_code, p_rationale, p_type);
 	} else {
-		CONSOLE_SCREEN_BUFFER_INFO sbi; //original
-		GetConsoleScreenBufferInfo(hCon, &sbi);
-
-		WORD current_bg = sbi.wAttributes & (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
-
-		uint32_t basecol = 0;
-		switch (p_type) {
-			case ERR_ERROR:
-				basecol = FOREGROUND_RED;
-				break;
-			case ERR_WARNING:
-				basecol = FOREGROUND_RED | FOREGROUND_GREEN;
-				break;
-			case ERR_SCRIPT:
-				basecol = FOREGROUND_RED | FOREGROUND_BLUE;
-				break;
-			case ERR_SHADER:
-				basecol = FOREGROUND_GREEN | FOREGROUND_BLUE;
-				break;
-		}
-
-		basecol |= current_bg;
-
-		SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
-		switch (p_type) {
-			case ERR_ERROR:
-				logf_error("ERROR:");
-				break;
-			case ERR_WARNING:
-				logf_error("WARNING:");
-				break;
-			case ERR_SCRIPT:
-				logf_error("SCRIPT ERROR:");
-				break;
-			case ERR_SHADER:
-				logf_error("SHADER ERROR:");
-				break;
-		}
-
-		SetConsoleTextAttribute(hCon, basecol);
+		const char *err_details;
 		if (p_rationale && p_rationale[0]) {
-			logf_error(" %s\n", p_rationale);
+			err_details = p_rationale;
 		} else {
-			logf_error(" %s\n", p_code);
+			err_details = p_code;
 		}
 
-		// `FOREGROUND_INTENSITY` alone results in gray text.
-		SetConsoleTextAttribute(hCon, FOREGROUND_INTENSITY);
+		// Disable color codes if stdout is not a TTY.
+		// This prevents Godot from writing ANSI escape codes when redirecting
+		// stdout and stderr to a file.
+		//
+		// FIXME: Is there a way to check whether stdout is a TTY on Windows?
+		const char *red = "\E[0;91m";
+		const char *red_bold = "\E[1;91m";
+		const char *red_faint = "\E[2;91m";
+		const char *yellow = "\E[0;93m";
+		const char *yellow_bold = "\E[1;93m";
+		const char *yellow_faint = "\E[2;93m";
+		const char *magenta = "\E[0;95m";
+		const char *magenta_bold = "\E[1;95m";
+		const char *magenta_faint = "\E[2;95m";
+		const char *cyan = "\E[0;96m";
+		const char *cyan_bold = "\E[1;96m";
+		const char *cyan_faint = "\E[2;96m";
+		const char *reset = "\E[0m";
+
 		switch (p_type) {
-			case ERR_ERROR:
-				logf_error("   at: ");
-				break;
 			case ERR_WARNING:
-				logf_error("     at: ");
+				logf_error("%sWARNING:%s %s\n", yellow_bold, yellow, err_details);
+				logf_error("%s     at: %s (%s:%i)%s\n", yellow_faint, p_function, p_file, p_line, reset);
 				break;
 			case ERR_SCRIPT:
-				logf_error("          at: ");
+				logf_error("%sSCRIPT ERROR:%s %s\n", magenta_bold, magenta, err_details);
+				logf_error("%s          at: %s (%s:%i)%s\n", magenta_faint, p_function, p_file, p_line, reset);
 				break;
 			case ERR_SHADER:
-				logf_error("          at: ");
+				logf_error("%sSHADER ERROR:%s %s\n", cyan_bold, cyan, err_details);
+				logf_error("%s          at: %s (%s:%i)%s\n", cyan_faint, p_function, p_file, p_line, reset);
+				break;
+			case ERR_ERROR:
+			default:
+				logf_error("%sERROR:%s %s\n", red_bold, red, err_details);
+				logf_error("%s   at: %s (%s:%i)%s\n", red_faint, p_function, p_file, p_line, reset);
 				break;
 		}
-
-		if (p_rationale && p_rationale[0]) {
-			logf_error("(%s:%i)\n", p_file, p_line);
-		} else {
-			logf_error("%s (%s:%i)\n", p_function, p_file, p_line);
-		}
-
-		SetConsoleTextAttribute(hCon, sbi.wAttributes);
 	}
 }
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/35301.

___

- Colorize the "at:" line in the same color as the error/warning, but in a more faint color.
- Standardize the console coloring code across platforms (since ANSI escape codes can now be used on Windows).

## Preview

### VS Code terminal

#### Dark theme

Before | After
-|-
![VS Code dark before](https://github.com/user-attachments/assets/02993fa8-4e6c-4a49-b7f5-98bec3c03d45) | ![VS Code dark after](https://github.com/user-attachments/assets/c83e27e3-445a-40f3-adf2-e9f669bd4597)

#### Light theme

Before | After
-|-
![VS Code light before](https://github.com/user-attachments/assets/9ee83e63-7870-48e2-820f-0cfa61e631e0) | ![VS Code light after](https://github.com/user-attachments/assets/d3d9b7b5-77d2-4c77-9155-177cc40d7ba4)


### kitty

Before | After
-|-
![kitty before](https://github.com/user-attachments/assets/0d38abbd-2c94-4e67-afa8-8b1145de26c9) | ![kitty after](https://github.com/user-attachments/assets/5828d03f-68e4-490e-a626-ae5d55563dac)

*Keywords for easier searching: color, terminal, commandline, command line, CLI*