### PR TITLE
Close toasts instantly when Close button is pressed

### DIFF
--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -375,7 +375,7 @@ Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_
 	if (p_time > 0.0) {
 		Button *close_button = memnew(Button);
 		close_button->set_flat(true);
-		close_button->connect(SceneStringName(pressed), callable_mp(this, &EditorToaster::close).bind(panel));
+		close_button->connect(SceneStringName(pressed), callable_mp(this, &EditorToaster::instant_close).bind(panel));
 		hbox_container->add_child(close_button);
 
 		toast.close_button = close_button;
@@ -499,6 +499,11 @@ void EditorToaster::close(Control *p_control) {
 	ERR_FAIL_COND(!toasts.has(p_control));
 	toasts[p_control].remaining_time = -1.0;
 	toasts[p_control].popped = false;
+}
+
+void EditorToaster::instant_close(Control *p_control) {
+	close(p_control);
+	p_control->set_modulate(Color(1, 1, 1, 0));
 }
 
 EditorToaster *EditorToaster::get_singleton() {

--- a/editor/gui/editor_toaster.h
+++ b/editor/gui/editor_toaster.h
@@ -115,6 +115,7 @@ public:
 	Control *popup(Control *p_control, Severity p_severity = SEVERITY_INFO, double p_time = 0.0, const String &p_tooltip = String());
 	void popup_str(const String &p_message, Severity p_severity = SEVERITY_INFO, const String &p_tooltip = String());
 	void close(Control *p_control);
+	void instant_close(Control *p_control);
 
 	EditorToaster();
 	~EditorToaster();


### PR DESCRIPTION
Makes the toast close instantly instead of fading.

https://github.com/user-attachments/assets/80bf3980-74a7-4eb7-a161-6263c00cc706

Toasts closed by timeout are still fading.