### PR TITLE
Rewrite index optimization code for maximum efficiency

### DIFF
--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -535,8 +535,6 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 		}
 	}
 
-	mesh->optimize_indices_for_cache();
-
 	if (p_generate_lods) {
 		// Use normal merge/split angles that match the defaults used for 3D scene importing.
 		mesh->generate_lods(60.0f, {});
@@ -545,6 +543,8 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 	if (p_generate_shadow_mesh) {
 		mesh->create_shadow_mesh();
 	}
+
+	mesh->optimize_indices();
 
 	if (p_single_mesh && mesh->get_surface_count() > 0) {
 		r_meshes.push_back(mesh);

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2567,8 +2567,6 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 					}
 				}
 
-				src_mesh_node->get_mesh()->optimize_indices_for_cache();
-
 				if (generate_lods) {
 					Array skin_pose_transform_array = _get_skinned_pose_transforms(src_mesh_node);
 					src_mesh_node->get_mesh()->generate_lods(merge_angle, skin_pose_transform_array);
@@ -2577,6 +2575,8 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 				if (create_shadow_meshes) {
 					src_mesh_node->get_mesh()->create_shadow_mesh();
 				}
+
+				src_mesh_node->get_mesh()->optimize_indices();
 
 				if (!save_to_file.is_empty()) {
 					Ref<Mesh> existing = ResourceCache::get_ref(save_to_file);

--- a/modules/meshoptimizer/register_types.cpp
+++ b/modules/meshoptimizer/register_types.cpp
@@ -40,10 +40,10 @@ void initialize_meshoptimizer_module(ModuleInitializationLevel p_level) {
 	}
 
 	SurfaceTool::optimize_vertex_cache_func = meshopt_optimizeVertexCache;
+	SurfaceTool::optimize_vertex_fetch_remap_func = meshopt_optimizeVertexFetchRemap;
 	SurfaceTool::simplify_func = meshopt_simplify;
 	SurfaceTool::simplify_with_attrib_func = meshopt_simplifyWithAttributes;
 	SurfaceTool::simplify_scale_func = meshopt_simplifyScale;
-	SurfaceTool::simplify_sloppy_func = meshopt_simplifySloppy;
 	SurfaceTool::generate_remap_func = meshopt_generateVertexRemap;
 	SurfaceTool::remap_vertex_func = meshopt_remapVertexBuffer;
 	SurfaceTool::remap_index_func = meshopt_remapIndexBuffer;
@@ -55,9 +55,9 @@ void uninitialize_meshoptimizer_module(ModuleInitializationLevel p_level) {
 	}
 
 	SurfaceTool::optimize_vertex_cache_func = nullptr;
+	SurfaceTool::optimize_vertex_fetch_remap_func = nullptr;
 	SurfaceTool::simplify_func = nullptr;
 	SurfaceTool::simplify_scale_func = nullptr;
-	SurfaceTool::simplify_sloppy_func = nullptr;
 	SurfaceTool::generate_remap_func = nullptr;
 	SurfaceTool::remap_vertex_func = nullptr;
 	SurfaceTool::remap_index_func = nullptr;

--- a/scene/resources/3d/importer_mesh.h
+++ b/scene/resources/3d/importer_mesh.h
@@ -113,7 +113,7 @@ public:
 
 	void set_surface_material(int p_surface, const Ref<Material> &p_material);
 
-	void optimize_indices_for_cache();
+	void optimize_indices();
 
 	void generate_lods(float p_normal_merge_angle, Array p_skin_pose_transform_array);
 

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -33,10 +33,10 @@
 #define EQ_VERTEX_DIST 0.00001
 
 SurfaceTool::OptimizeVertexCacheFunc SurfaceTool::optimize_vertex_cache_func = nullptr;
+SurfaceTool::OptimizeVertexFetchRemapFunc SurfaceTool::optimize_vertex_fetch_remap_func = nullptr;
 SurfaceTool::SimplifyFunc SurfaceTool::simplify_func = nullptr;
 SurfaceTool::SimplifyWithAttribFunc SurfaceTool::simplify_with_attrib_func = nullptr;
 SurfaceTool::SimplifyScaleFunc SurfaceTool::simplify_scale_func = nullptr;
-SurfaceTool::SimplifySloppyFunc SurfaceTool::simplify_sloppy_func = nullptr;
 SurfaceTool::GenerateRemapFunc SurfaceTool::generate_remap_func = nullptr;
 SurfaceTool::RemapVertexFunc SurfaceTool::remap_vertex_func = nullptr;
 SurfaceTool::RemapIndexFunc SurfaceTool::remap_index_func = nullptr;

--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -90,14 +90,14 @@ public:
 
 	typedef void (*OptimizeVertexCacheFunc)(unsigned int *destination, const unsigned int *indices, size_t index_count, size_t vertex_count);
 	static OptimizeVertexCacheFunc optimize_vertex_cache_func;
+	typedef size_t (*OptimizeVertexFetchRemapFunc)(unsigned int *destination, const unsigned int *indices, size_t index_count, size_t vertex_count);
+	static OptimizeVertexFetchRemapFunc optimize_vertex_fetch_remap_func;
 	typedef size_t (*SimplifyFunc)(unsigned int *destination, const unsigned int *indices, size_t index_count, const float *vertex_positions, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error, unsigned int options, float *r_error);
 	static SimplifyFunc simplify_func;
 	typedef size_t (*SimplifyWithAttribFunc)(unsigned int *destination, const unsigned int *indices, size_t index_count, const float *vertex_data, size_t vertex_count, size_t vertex_stride, const float *attributes, size_t attribute_stride, const float *attribute_weights, size_t attribute_count, const unsigned char *vertex_lock, size_t target_index_count, float target_error, unsigned int options, float *result_error);
 	static SimplifyWithAttribFunc simplify_with_attrib_func;
 	typedef float (*SimplifyScaleFunc)(const float *vertex_positions, size_t vertex_count, size_t vertex_positions_stride);
 	static SimplifyScaleFunc simplify_scale_func;
-	typedef size_t (*SimplifySloppyFunc)(unsigned int *destination, const unsigned int *indices, size_t index_count, const float *vertex_positions_data, size_t vertex_count, size_t vertex_positions_stride, size_t target_index_count, float target_error, float *out_result_error);
-	static SimplifySloppyFunc simplify_sloppy_func;
 	typedef size_t (*GenerateRemapFunc)(unsigned int *destination, const unsigned int *indices, size_t index_count, const void *vertices, size_t vertex_count, size_t vertex_size);
 	static GenerateRemapFunc generate_remap_func;
 	typedef void (*RemapVertexFunc)(void *destination, const void *vertices, size_t vertex_count, size_t vertex_size, const unsigned int *remap);
@@ -222,7 +222,9 @@ public:
 
 	void clear();
 
-	LocalVector<Vertex> &get_vertex_array() { return vertex_array; }
+	LocalVector<Vertex> &get_vertex_array() {
+		return vertex_array;
+	}
 
 	void create_from_triangle_arrays(const Array &p_arrays);
 	void create_from_arrays(const Array &p_arrays, Mesh::PrimitiveType p_primitive_type = Mesh::PRIMITIVE_TRIANGLES);


### PR DESCRIPTION
While all the previous fixes to optimizeVertexCache invocation fixed the vertex transform efficiency, the import code still was missing two crucial recommendations from meshoptimizer documentation:

- All meshes should be optimized for vertex fetch (this reorders vertices for maximum fetch efficiency)
- When LODs are used with a shared vertex buffer, the vertex order should be generated by doing a vertex fetch optimization on the concatenated index buffer from coarse to fine LODs; this maximizes fetch efficiency for coarse LODs

The last point is especially important for Mali GPUs; unlike other GPUs where vertex order affects fetch efficiency but not shading, these GPUs have various vertex shading quirks (depending on the GPU generation) that really require compact index ranges for each LOD, which requires the second optimization mentioned above. However all of these also help desktop GPUs and other mobile GPUs as well.

Because this optimization is "global" in the sense that it affects all LODs and all vertex arrays in concert, I've taken this opportunity to isolate all optimization code in this function and pull it out of `generate_lods` and `create_shadow_mesh`; this doesn't change the vertex cache efficiency, but makes the code cleaner. Consequently, `optimize_indices` should be called after other functions like `create_shadow_mesh` / `generate_lods`.

This required exposing `meshopt_optimizeVertexFetchRemap`; as a drive-by, `meshopt_simplifySloppy` was never used so it's not exposed anymore - this will simplify future meshopt upgrades if they end up changing the function's interface.

Future optimizations, if any, can likely be done in this function without changing any of the external code; for example, input mesh geometry in some GLTF assets is inefficiently indexed; these issues should be fixable in the future by just changing `optimize_indices`.

I would expect that this has significant performance benefits for geometry heavy scenes with LODs on ARM Mali in particular (as the way these GPUs do vertex shading is all sorts of strange), but I don't have that GPU to test. That said, this has benefits for desktop GPUs as well. Testing on my AMD Radeon 7900 GRE, using this geometry heavy scene (3M triangles in view):

![image](https://github.com/user-attachments/assets/e52fbe8e-1ce0-4ea5-a5b1-7971a8c83635)

... I get 1.19 ms GPU time on this PR, vs 1.47 ms GPU time on master. Using "Disable LOD" view on the same camera (17.2M triangles in view), I get 4.20ms GPU time on this PR, vs 4.34ms GPU time on master. This essentially proves that this change does not regress the performance on base level of detail - in fact slightly improving it - and improves this further for LODs; as usual, gains will be dependent on GPU and scene in question (on TPS demo I only see around ~1% improvement in GPU frame time on 7900 GRE for example, but that level has comparatively few LODs and more complex shading).

As before, this change does not change the appearance of the objects in any way - it just changes the vertex order which is not observable. It needs a little bit of extra code to run in import time. A reimport of the model used in this scene takes ~870ms on this PR vs ~860ms on master, so the extra cost should not be noticeable - the most significant cost here is LOD generation (which didn't change), followed by vertex cache optimization (which didn't change, just moved into the new function); the only new cost is remap table generation and remapping which is comparatively quick.

It may make sense to expose the new `optimize_indices` function to scripts now but I'm not sure if this is useful as I'm still fuzzy on the use cases of script-driven imports. Let me know if you'd like me to do this in this PR.

I've tested this on a few glTF models, TPS demo, the MRP from the example with line lists that regressed before, and an MRP from some old issue about blend shapes to make sure this also works with blend shapes (it does). Unsure what else to test on, but should hopefully be correct :)