### PR TITLE
Metal: Multiview support

### DIFF
--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -96,6 +96,9 @@ void MDCommandBuffer::bind_pipeline(RDD::PipelineID p_pipeline) {
 		MDRenderPipeline *rp = (MDRenderPipeline *)p;
 
 		if (render.encoder == nil) {
+			// This error would happen if the render pass failed.
+			ERR_FAIL_NULL_MSG(render.desc, "Render pass descriptor is null.");
+
 			// This condition occurs when there are no attachments when calling render_next_subpass()
 			// and is due to the SUPPORTS_FRAGMENT_SHADER_WITH_ONLY_SIDE_EFFECTS flag.
 			render.desc.defaultRasterSampleCount = static_cast<NSUInteger>(rp->sample_count);
@@ -223,8 +226,9 @@ void MDCommandBuffer::render_bind_uniform_set(RDD::UniformSetID p_uniform_set, R
 void MDCommandBuffer::render_clear_attachments(VectorView<RDD::AttachmentClear> p_attachment_clears, VectorView<Rect2i> p_rects) {
 	DEV_ASSERT(type == MDCommandBufferStateType::Render);
 
-	uint32_t vertex_count = p_rects.size() * 6;
+	const MDSubpass &subpass = render.get_subpass();
 
+	uint32_t vertex_count = p_rects.size() * 6 * subpass.view_count;
 	simd::float4 vertices[vertex_count];
 	simd::float4 clear_colors[ClearAttKey::ATTACHMENT_COUNT];
 
@@ -235,6 +239,9 @@ void MDCommandBuffer::render_clear_attachments(VectorView<RDD::AttachmentClear> 
 
 	ClearAttKey key;
 	key.sample_count = render.pass->get_sample_count();
+	if (subpass.view_count > 1) {
+		key.enable_layered_rendering();
+	}
 
 	float depth_value = 0;
 	uint32_t stencil_value = 0;
@@ -245,7 +252,7 @@ void MDCommandBuffer::render_clear_attachments(VectorView<RDD::AttachmentClear> 
 		if (attClear.aspect.has_flag(RDD::TEXTURE_ASPECT_COLOR_BIT)) {
 			attachment_index = attClear.color_attachment;
 		} else {
-			attachment_index = render.pass->subpasses[render.current_subpass].depth_stencil_reference.attachment;
+			attachment_index = subpass.depth_stencil_reference.attachment;
 		}
 
 		MDAttachment const &mda = render.pass->attachments[attachment_index];
@@ -309,6 +316,13 @@ void MDCommandBuffer::render_clear_attachments(VectorView<RDD::AttachmentClear> 
 
 void MDCommandBuffer::_render_set_dirty_state() {
 	_render_bind_uniform_sets();
+
+	MDSubpass const &subpass = render.get_subpass();
+	if (subpass.view_count > 1) {
+		uint32_t view_range[2] = { 0, subpass.view_count };
+		[render.encoder setVertexBytes:view_range length:sizeof(view_range) atIndex:VIEW_MASK_BUFFER_INDEX];
+		[render.encoder setFragmentBytes:view_range length:sizeof(view_range) atIndex:VIEW_MASK_BUFFER_INDEX];
+	}
 
 	if (render.dirty.has_flag(RenderState::DIRTY_PIPELINE)) {
 		[render.encoder setRenderPipelineState:render.pipeline->state];
@@ -492,36 +506,40 @@ uint32_t MDCommandBuffer::_populate_vertices(simd::float4 *p_vertices, uint32_t 
 	simd::float4 vtx;
 
 	uint32_t idx = p_index;
-	vtx.z = 0.0;
-	vtx.w = (float)1;
+	uint32_t endLayer = render.get_subpass().view_count;
 
-	// Top left vertex - First triangle.
-	vtx.y = topPos;
-	vtx.x = leftPos;
-	p_vertices[idx++] = vtx;
+	for (uint32_t layer = 0; layer < endLayer; layer++) {
+		vtx.z = 0.0;
+		vtx.w = (float)layer;
 
-	// Bottom left vertex.
-	vtx.y = bottomPos;
-	vtx.x = leftPos;
-	p_vertices[idx++] = vtx;
+		// Top left vertex - First triangle.
+		vtx.y = topPos;
+		vtx.x = leftPos;
+		p_vertices[idx++] = vtx;
 
-	// Bottom right vertex.
-	vtx.y = bottomPos;
-	vtx.x = rightPos;
-	p_vertices[idx++] = vtx;
+		// Bottom left vertex.
+		vtx.y = bottomPos;
+		vtx.x = leftPos;
+		p_vertices[idx++] = vtx;
 
-	// Bottom right vertex - Second triangle.
-	p_vertices[idx++] = vtx;
+		// Bottom right vertex.
+		vtx.y = bottomPos;
+		vtx.x = rightPos;
+		p_vertices[idx++] = vtx;
 
-	// Top right vertex.
-	vtx.y = topPos;
-	vtx.x = rightPos;
-	p_vertices[idx++] = vtx;
+		// Bottom right vertex - Second triangle.
+		p_vertices[idx++] = vtx;
 
-	// Top left vertex.
-	vtx.y = topPos;
-	vtx.x = leftPos;
-	p_vertices[idx++] = vtx;
+		// Top right vertex.
+		vtx.y = topPos;
+		vtx.x = rightPos;
+		p_vertices[idx++] = vtx;
+
+		// Top left vertex.
+		vtx.y = topPos;
+		vtx.x = leftPos;
+		p_vertices[idx++] = vtx;
+	}
 
 	return idx;
 }
@@ -548,8 +566,7 @@ void MDCommandBuffer::render_begin_pass(RDD::RenderPassID p_render_pass, RDD::Fr
 
 void MDCommandBuffer::_end_render_pass() {
 	MDFrameBuffer const &fb_info = *render.frameBuffer;
-	MDRenderPass const &pass_info = *render.pass;
-	MDSubpass const &subpass = pass_info.subpasses[render.current_subpass];
+	MDSubpass const &subpass = render.get_subpass();
 
 	PixelFormats &pf = device_driver->get_pixel_formats();
 
@@ -557,11 +574,11 @@ void MDCommandBuffer::_end_render_pass() {
 		uint32_t color_index = subpass.color_references[i].attachment;
 		uint32_t resolve_index = subpass.resolve_references[i].attachment;
 		DEV_ASSERT((color_index == RDD::AttachmentReference::UNUSED) == (resolve_index == RDD::AttachmentReference::UNUSED));
-		if (color_index == RDD::AttachmentReference::UNUSED || !fb_info.textures[color_index]) {
+		if (color_index == RDD::AttachmentReference::UNUSED || !fb_info.has_texture(color_index)) {
 			continue;
 		}
 
-		id<MTLTexture> resolve_tex = fb_info.textures[resolve_index];
+		id<MTLTexture> resolve_tex = fb_info.get_texture(resolve_index);
 
 		CRASH_COND_MSG(!flags::all(pf.getCapabilities(resolve_tex.pixelFormat), kMTLFmtCapsResolve), "not implemented: unresolvable texture types");
 		// see: https://github.com/KhronosGroup/MoltenVK/blob/d20d13fe2735adb845636a81522df1b9d89c0fba/MoltenVK/MoltenVK/GPUObjects/MVKRenderPass.mm#L407
@@ -572,7 +589,7 @@ void MDCommandBuffer::_end_render_pass() {
 
 void MDCommandBuffer::_render_clear_render_area() {
 	MDRenderPass const &pass = *render.pass;
-	MDSubpass const &subpass = pass.subpasses[render.current_subpass];
+	MDSubpass const &subpass = render.get_subpass();
 
 	// First determine attachments that should be cleared.
 	LocalVector<RDD::AttachmentClear> clears;
@@ -619,9 +636,14 @@ void MDCommandBuffer::render_next_subpass() {
 
 	MDFrameBuffer const &fb = *render.frameBuffer;
 	MDRenderPass const &pass = *render.pass;
-	MDSubpass const &subpass = pass.subpasses[render.current_subpass];
+	MDSubpass const &subpass = render.get_subpass();
 
 	MTLRenderPassDescriptor *desc = MTLRenderPassDescriptor.renderPassDescriptor;
+
+	if (subpass.view_count > 1) {
+		desc.renderTargetArrayLength = subpass.view_count;
+	}
+
 	PixelFormats &pf = device_driver->get_pixel_formats();
 
 	uint32_t attachmentCount = 0;
@@ -638,7 +660,7 @@ void MDCommandBuffer::render_next_subpass() {
 		bool has_resolve = resolveIdx != RDD::AttachmentReference::UNUSED;
 		bool can_resolve = true;
 		if (resolveIdx != RDD::AttachmentReference::UNUSED) {
-			id<MTLTexture> resolve_tex = fb.textures[resolveIdx];
+			id<MTLTexture> resolve_tex = fb.get_texture(resolveIdx);
 			can_resolve = flags::all(pf.getCapabilities(resolve_tex.pixelFormat), kMTLFmtCapsResolve);
 			if (can_resolve) {
 				ca.resolveTexture = resolve_tex;
@@ -649,7 +671,9 @@ void MDCommandBuffer::render_next_subpass() {
 
 		MDAttachment const &attachment = pass.attachments[idx];
 
-		id<MTLTexture> tex = fb.textures[idx];
+		id<MTLTexture> tex = fb.get_texture(idx);
+		ERR_FAIL_NULL_MSG(tex, "Frame buffer color texture is null.");
+
 		if ((attachment.type & MDAttachmentType::Color)) {
 			if (attachment.configureDescriptor(ca, pf, subpass, tex, render.is_rendering_entire_area, has_resolve, can_resolve, false)) {
 				Color clearColor = render.clear_values[idx].color;
@@ -662,7 +686,8 @@ void MDCommandBuffer::render_next_subpass() {
 		attachmentCount += 1;
 		uint32_t idx = subpass.depth_stencil_reference.attachment;
 		MDAttachment const &attachment = pass.attachments[idx];
-		id<MTLTexture> tex = fb.textures[idx];
+		id<MTLTexture> tex = fb.get_texture(idx);
+		ERR_FAIL_NULL_MSG(tex, "Frame buffer depth / stencil texture is null.");
 		if (attachment.type & MDAttachmentType::Depth) {
 			MTLRenderPassDepthAttachmentDescriptor *da = desc.depthAttachment;
 			if (attachment.configureDescriptor(da, pf, subpass, tex, render.is_rendering_entire_area, false, false, false)) {
@@ -702,7 +727,14 @@ void MDCommandBuffer::render_draw(uint32_t p_vertex_count,
 		uint32_t p_base_vertex,
 		uint32_t p_first_instance) {
 	DEV_ASSERT(type == MDCommandBufferStateType::Render);
+	ERR_FAIL_NULL_MSG(render.pipeline, "No pipeline set for render command buffer.");
+
 	_render_set_dirty_state();
+
+	MDSubpass const &subpass = render.get_subpass();
+	if (subpass.view_count > 1) {
+		p_instance_count *= subpass.view_count;
+	}
 
 	DEV_ASSERT(render.dirty == 0);
 
@@ -751,7 +783,14 @@ void MDCommandBuffer::render_draw_indexed(uint32_t p_index_count,
 		int32_t p_vertex_offset,
 		uint32_t p_first_instance) {
 	DEV_ASSERT(type == MDCommandBufferStateType::Render);
+	ERR_FAIL_NULL_MSG(render.pipeline, "No pipeline set for render command buffer.");
+
 	_render_set_dirty_state();
+
+	MDSubpass const &subpass = render.get_subpass();
+	if (subpass.view_count > 1) {
+		p_instance_count *= subpass.view_count;
+	}
 
 	id<MTLRenderCommandEncoder> enc = render.encoder;
 
@@ -770,6 +809,8 @@ void MDCommandBuffer::render_draw_indexed(uint32_t p_index_count,
 
 void MDCommandBuffer::render_draw_indexed_indirect(RDD::BufferID p_indirect_buffer, uint64_t p_offset, uint32_t p_draw_count, uint32_t p_stride) {
 	DEV_ASSERT(type == MDCommandBufferStateType::Render);
+	ERR_FAIL_NULL_MSG(render.pipeline, "No pipeline set for render command buffer.");
+
 	_render_set_dirty_state();
 
 	id<MTLRenderCommandEncoder> enc = render.encoder;
@@ -794,6 +835,8 @@ void MDCommandBuffer::render_draw_indexed_indirect_count(RDD::BufferID p_indirec
 
 void MDCommandBuffer::render_draw_indirect(RDD::BufferID p_indirect_buffer, uint64_t p_offset, uint32_t p_draw_count, uint32_t p_stride) {
 	DEV_ASSERT(type == MDCommandBufferStateType::Render);
+	ERR_FAIL_NULL_MSG(render.pipeline, "No pipeline set for render command buffer.");
+
 	_render_set_dirty_state();
 
 	id<MTLRenderCommandEncoder> enc = render.encoder;
@@ -811,6 +854,42 @@ void MDCommandBuffer::render_draw_indirect(RDD::BufferID p_indirect_buffer, uint
 
 void MDCommandBuffer::render_draw_indirect_count(RDD::BufferID p_indirect_buffer, uint64_t p_offset, RDD::BufferID p_count_buffer, uint64_t p_count_buffer_offset, uint32_t p_max_draw_count, uint32_t p_stride) {
 	ERR_FAIL_MSG("not implemented");
+}
+
+void MDCommandBuffer::render_end_pass() {
+	DEV_ASSERT(type == MDCommandBufferStateType::Render);
+
+	render.end_encoding();
+	render.reset();
+	type = MDCommandBufferStateType::None;
+}
+
+#pragma mark - RenderState
+
+void MDCommandBuffer::RenderState::reset() {
+	pass = nil;
+	frameBuffer = nil;
+	pipeline = nil;
+	current_subpass = UINT32_MAX;
+	render_area = {};
+	is_rendering_entire_area = false;
+	desc = nil;
+	encoder = nil;
+	index_buffer = nil;
+	index_type = MTLIndexTypeUInt16;
+	dirty = DIRTY_NONE;
+	uniform_sets.clear();
+	uniform_set_mask = 0;
+	clear_values.clear();
+	viewports.clear();
+	scissors.clear();
+	blend_constants.reset();
+	vertex_buffers.clear();
+	vertex_offsets.clear();
+	// Keep the keys, as they are likely to be used again.
+	for (KeyValue<StageResourceUsage, LocalVector<__unsafe_unretained id<MTLResource>>> &kv : resource_usage) {
+		kv.value.clear();
+	}
 }
 
 void MDCommandBuffer::RenderState::end_encoding() {
@@ -842,6 +921,8 @@ void MDCommandBuffer::RenderState::end_encoding() {
 	encoder = nil;
 }
 
+#pragma mark - ComputeState
+
 void MDCommandBuffer::ComputeState::end_encoding() {
 	if (encoder == nil) {
 		return;
@@ -860,14 +941,6 @@ void MDCommandBuffer::ComputeState::end_encoding() {
 
 	[encoder endEncoding];
 	encoder = nil;
-}
-
-void MDCommandBuffer::render_end_pass() {
-	DEV_ASSERT(type == MDCommandBufferStateType::Render);
-
-	render.end_encoding();
-	render.reset();
-	type = MDCommandBufferStateType::None;
 }
 
 #pragma mark - Compute
@@ -943,8 +1016,11 @@ void MDComputeShader::encode_push_constant_data(VectorView<uint32_t> p_data, MDC
 	[enc setBytes:ptr length:length atIndex:push_constants.binding];
 }
 
-MDRenderShader::MDRenderShader(CharString p_name, Vector<UniformSet> p_sets, MDLibrary *_Nonnull p_vert, MDLibrary *_Nonnull p_frag) :
-		MDShader(p_name, p_sets), vert(p_vert), frag(p_frag) {
+MDRenderShader::MDRenderShader(CharString p_name,
+		bool p_needs_view_mask_buffer,
+		Vector<UniformSet> p_sets,
+		MDLibrary *_Nonnull p_vert, MDLibrary *_Nonnull p_frag) :
+		MDShader(p_name, p_sets), needs_view_mask_buffer(p_needs_view_mask_buffer), vert(p_vert), frag(p_frag) {
 }
 
 void MDRenderShader::encode_push_constant_data(VectorView<uint32_t> p_data, MDCommandBuffer *p_cb) {
@@ -1279,7 +1355,7 @@ typedef struct {
 
 typedef struct {
     float4 v_position [[position]];
-    uint layer;
+    uint layer%s;
 } VaryingsPos;
 
 vertex VaryingsPos vertClear(AttributesPos attributes [[stage_in]], constant ClearColorsIn& ccIn [[buffer(0)]]) {
@@ -1288,7 +1364,7 @@ vertex VaryingsPos vertClear(AttributesPos attributes [[stage_in]], constant Cle
     varyings.layer = uint(attributes.a_position.w);
     return varyings;
 }
-)", ClearAttKey::DEPTH_INDEX];
+)", p_key.is_layered_rendering_enabled() ? " [[render_target_array_index]]" : "", ClearAttKey::DEPTH_INDEX];
 
 		return new_func(msl, @"vertClear", nil);
 	}
@@ -1578,7 +1654,7 @@ void ShaderCacheEntry::notify_free() const {
 				   self->_library = library;
 				   self->_error = error;
 				   if (error) {
-					   ERR_PRINT(String(U"Error compiling shader %s: %s").format(entry->name.get_data(), error.localizedDescription.UTF8String));
+					   ERR_PRINT(vformat(U"Error compiling shader %s: %s", entry->name.get_data(), error.localizedDescription.UTF8String));
 				   }
 
 				   {

--- a/drivers/metal/rendering_context_driver_metal.mm
+++ b/drivers/metal/rendering_context_driver_metal.mm
@@ -134,7 +134,7 @@ public:
 		frame_buffers.resize(p_desired_framebuffer_count);
 		for (uint32_t i = 0; i < p_desired_framebuffer_count; i++) {
 			// Reserve space for the drawable texture.
-			frame_buffers[i].textures.resize(1);
+			frame_buffers[i].set_texture_count(1);
 		}
 
 		return OK;
@@ -154,7 +154,7 @@ public:
 		id<CAMetalDrawable> drawable = layer.nextDrawable;
 		ERR_FAIL_NULL_V_MSG(drawable, RDD::FramebufferID(), "no drawable available");
 		drawables[rear] = drawable;
-		frame_buffer.textures.write[0] = drawable.texture;
+		frame_buffer.set_texture(0, drawable.texture);
 
 		return RDD::FramebufferID(&frame_buffer);
 	}
@@ -165,7 +165,7 @@ public:
 		}
 
 		// Release texture and drawable.
-		frame_buffers[front].textures.write[0] = nil;
+		frame_buffers[front].unset_texture(0);
 		id<MTLDrawable> drawable = drawables[front];
 		drawables[front] = nil;
 

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -239,7 +239,13 @@ private:
 	friend struct PushConstantData;
 
 private:
-	Error _reflect_spirv16(VectorView<ShaderStageSPIRVData> p_spirv, ShaderReflection &r_reflection);
+	/// Contains additional metadata about the shader.
+	struct ShaderMeta {
+		/// Indicates whether the shader uses multiview.
+		bool has_multiview = false;
+	};
+
+	Error _reflect_spirv16(VectorView<ShaderStageSPIRVData> p_spirv, ShaderReflection &r_reflection, ShaderMeta &r_shader_meta);
 
 public:
 	virtual String shader_get_binary_cache_key() override final;

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -1026,7 +1026,7 @@ void RenderingDeviceDriverMetal::framebuffer_free(FramebufferID p_framebuffer) {
 
 #pragma mark - Shader
 
-const uint32_t SHADER_BINARY_VERSION = 1;
+const uint32_t SHADER_BINARY_VERSION = 2;
 
 // region Serialization
 
@@ -1503,6 +1503,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0)) ShaderBinaryData {
 	uint32_t fragment_output_mask = UINT32_MAX;
 	uint32_t spirv_specialization_constants_ids_mask = UINT32_MAX;
 	uint32_t is_compute = UINT32_MAX;
+	uint32_t needs_view_mask_buffer = UINT32_MAX;
 	ComputeSize compute_local_size;
 	PushConstantData push_constant;
 	LocalVector<ShaderStageData> stages;
@@ -1523,6 +1524,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0)) ShaderBinaryData {
 		size += sizeof(uint32_t); // fragment_output_mask
 		size += sizeof(uint32_t); // spirv_specialization_constants_ids_mask
 		size += sizeof(uint32_t); // is_compute
+		size += sizeof(uint32_t); // needs_view_mask_buffer
 		size += compute_local_size.serialize_size(); // compute_local_size
 		size += push_constant.serialize_size(); // push_constant
 		size += sizeof(uint32_t); // stages.size()
@@ -1547,6 +1549,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0)) ShaderBinaryData {
 		p_writer.write(fragment_output_mask);
 		p_writer.write(spirv_specialization_constants_ids_mask);
 		p_writer.write(is_compute);
+		p_writer.write(needs_view_mask_buffer);
 		p_writer.write(compute_local_size);
 		p_writer.write(push_constant);
 		p_writer.write(VectorView(stages));
@@ -1561,6 +1564,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0)) ShaderBinaryData {
 		p_reader.read(fragment_output_mask);
 		p_reader.read(spirv_specialization_constants_ids_mask);
 		p_reader.read(is_compute);
+		p_reader.read(needs_view_mask_buffer);
 		p_reader.read(compute_local_size);
 		p_reader.read(push_constant);
 		p_reader.read(stages);
@@ -1572,14 +1576,16 @@ struct API_AVAILABLE(macos(11.0), ios(14.0)) ShaderBinaryData {
 // endregion
 
 String RenderingDeviceDriverMetal::shader_get_binary_cache_key() {
-	return "Metal-SV" + uitos(SHADER_BINARY_VERSION);
+	static const String cache_key = "Metal-SV" + uitos(SHADER_BINARY_VERSION);
+	return cache_key;
 }
 
-Error RenderingDeviceDriverMetal::_reflect_spirv16(VectorView<ShaderStageSPIRVData> p_spirv, ShaderReflection &r_reflection) {
+Error RenderingDeviceDriverMetal::_reflect_spirv16(VectorView<ShaderStageSPIRVData> p_spirv, ShaderReflection &r_reflection, ShaderMeta &r_shader_meta) {
 	using namespace spirv_cross;
 	using spirv_cross::Resource;
 
 	r_reflection = {};
+	r_shader_meta = {};
 
 	for (uint32_t i = 0; i < p_spirv.size(); i++) {
 		ShaderStageSPIRVData const &v = p_spirv[i];
@@ -1811,6 +1817,20 @@ Error RenderingDeviceDriverMetal::_reflect_spirv16(VectorView<ShaderStageSPIRVDa
 			}
 		}
 
+		for (const BuiltInResource &res : resources.builtin_inputs) {
+			if (res.builtin == spv::BuiltInViewIndex || res.builtin == spv::BuiltInViewportIndex) {
+				r_shader_meta.has_multiview = true;
+			}
+		}
+
+		if (!r_shader_meta.has_multiview) {
+			for (const BuiltInResource &res : resources.builtin_outputs) {
+				if (res.builtin == spv::BuiltInViewIndex || res.builtin == spv::BuiltInViewportIndex) {
+					r_shader_meta.has_multiview = true;
+				}
+			}
+		}
+
 		// Specialization constants.
 		for (SpecializationConstant const &constant : compiler.get_specialization_constants()) {
 			int32_t existing = -1;
@@ -1874,7 +1894,8 @@ Vector<uint8_t> RenderingDeviceDriverMetal::shader_compile_binary_from_spirv(Vec
 	using spirv_cross::Resource;
 
 	ShaderReflection spirv_data;
-	ERR_FAIL_COND_V(_reflect_spirv16(p_spirv, spirv_data), Result());
+	ShaderMeta shader_meta;
+	ERR_FAIL_COND_V(_reflect_spirv16(p_spirv, spirv_data, shader_meta), Result());
 
 	ShaderBinaryData bin_data{};
 	if (!p_shader_name.is_empty()) {
@@ -1893,6 +1914,7 @@ Vector<uint8_t> RenderingDeviceDriverMetal::shader_compile_binary_from_spirv(Vec
 	bin_data.is_compute = spirv_data.is_compute;
 	bin_data.push_constant.size = spirv_data.push_constant_size;
 	bin_data.push_constant.stages = (ShaderStageUsage)(uint8_t)spirv_data.push_constant_stages;
+	bin_data.needs_view_mask_buffer = shader_meta.has_multiview ? 1 : 0;
 
 	for (uint32_t i = 0; i < spirv_data.uniform_sets.size(); i++) {
 		const ::Vector<ShaderUniform> &spirv_set = spirv_data.uniform_sets[i];
@@ -1947,6 +1969,11 @@ Vector<uint8_t> RenderingDeviceDriverMetal::shader_compile_binary_from_spirv(Vec
 	msl_options.pad_fragment_output_components = true;
 	msl_options.r32ui_alignment_constant_id = R32UI_ALIGNMENT_CONSTANT_ID;
 	msl_options.agx_manual_cube_grad_fixup = true;
+	if (shader_meta.has_multiview) {
+		msl_options.multiview = true;
+		msl_options.multiview_layered_rendering = true;
+		msl_options.view_mask_buffer_index = VIEW_MASK_BUFFER_INDEX;
+	}
 
 	CompilerGLSL::Options options{};
 	options.vertex.flip_vert_y = true;
@@ -2448,7 +2475,7 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_bytecode(const Vect
 #endif
 		shader = cs;
 	} else {
-		MDRenderShader *rs = new MDRenderShader(binary_data.shader_name, uniform_sets, libraries[ShaderStage::SHADER_STAGE_VERTEX], libraries[ShaderStage::SHADER_STAGE_FRAGMENT]);
+		MDRenderShader *rs = new MDRenderShader(binary_data.shader_name, (bool)binary_data.needs_view_mask_buffer, uniform_sets, libraries[ShaderStage::SHADER_STAGE_VERTEX], libraries[ShaderStage::SHADER_STAGE_FRAGMENT]);
 
 		uint32_t *vert_binding = binary_data.push_constant.msl_binding.getptr(SHADER_STAGE_VERTEX);
 		if (vert_binding) {
@@ -2956,6 +2983,7 @@ RDD::RenderPassID RenderingDeviceDriverMetal::render_pass_create(VectorView<Atta
 	for (uint32_t i = 0; i < subpass_count; i++) {
 		MDSubpass &subpass = subpasses.write[i];
 		subpass.subpass_index = i;
+		subpass.view_count = p_view_count;
 		subpass.input_references = p_subpasses[i].input_references;
 		subpass.color_references = p_subpasses[i].color_references;
 		subpass.depth_stencil_reference = p_subpasses[i].depth_stencil_reference;
@@ -3675,8 +3703,7 @@ void RenderingDeviceDriverMetal::set_object_name(ObjectType p_type, ID p_driver_
 uint64_t RenderingDeviceDriverMetal::get_resource_native_handle(DriverResource p_type, ID p_driver_id) {
 	switch (p_type) {
 		case DRIVER_RESOURCE_LOGICAL_DEVICE: {
-			uintptr_t devicePtr = (uintptr_t)(__bridge void *)device;
-			return (uint64_t)devicePtr;
+			return (uint64_t)(uintptr_t)(__bridge void *)device;
 		}
 		case DRIVER_RESOURCE_PHYSICAL_DEVICE: {
 			return 0;
@@ -3685,7 +3712,7 @@ uint64_t RenderingDeviceDriverMetal::get_resource_native_handle(DriverResource p
 			return 0;
 		}
 		case DRIVER_RESOURCE_COMMAND_QUEUE: {
-			return 0;
+			return (uint64_t)(uintptr_t)(__bridge void *)device_queue;
 		}
 		case DRIVER_RESOURCE_QUEUE_FAMILY: {
 			return 0;
@@ -3702,15 +3729,20 @@ uint64_t RenderingDeviceDriverMetal::get_resource_native_handle(DriverResource p
 		case DRIVER_RESOURCE_SAMPLER: {
 			return p_driver_id.id;
 		}
-		case DRIVER_RESOURCE_UNIFORM_SET:
+		case DRIVER_RESOURCE_UNIFORM_SET: {
 			return 0;
+		}
 		case DRIVER_RESOURCE_BUFFER: {
 			return p_driver_id.id;
 		}
-		case DRIVER_RESOURCE_COMPUTE_PIPELINE:
-			return 0;
-		case DRIVER_RESOURCE_RENDER_PIPELINE:
-			return 0;
+		case DRIVER_RESOURCE_COMPUTE_PIPELINE: {
+			MDComputePipeline *pipeline = (MDComputePipeline *)(p_driver_id.id);
+			return (uint64_t)(uintptr_t)(__bridge void *)pipeline->state;
+		}
+		case DRIVER_RESOURCE_RENDER_PIPELINE: {
+			MDRenderPipeline *pipeline = (MDRenderPipeline *)(p_driver_id.id);
+			return (uint64_t)(uintptr_t)(__bridge void *)pipeline->state;
+		}
 		default: {
 			return 0;
 		}
@@ -3842,7 +3874,7 @@ uint64_t RenderingDeviceDriverMetal::api_trait_get(ApiTrait p_trait) {
 bool RenderingDeviceDriverMetal::has_feature(Features p_feature) {
 	switch (p_feature) {
 		case SUPPORTS_MULTIVIEW:
-			return false;
+			return multiview_capabilities.is_supported;
 		case SUPPORTS_FSR_HALF_FLOAT:
 			return true;
 		case SUPPORTS_ATTACHMENT_VRS:
@@ -3951,6 +3983,18 @@ Error RenderingDeviceDriverMetal::initialize(uint32_t p_device_index, uint32_t p
 
 	metal_device_properties = memnew(MetalDeviceProperties(device));
 	pixel_formats = memnew(PixelFormats(device));
+	if (metal_device_properties->features.layeredRendering) {
+		multiview_capabilities.is_supported = true;
+		multiview_capabilities.max_view_count = metal_device_properties->limits.maxViewports;
+		// NOTE: I'm not sure what the limit is as I don't see it referenced anywhere
+		multiview_capabilities.max_instance_count = UINT32_MAX;
+
+		print_verbose("- Metal multiview supported:");
+		print_verbose("  max view count: " + itos(multiview_capabilities.max_view_count));
+		print_verbose("  max instances: " + itos(multiview_capabilities.max_instance_count));
+	} else {
+		print_verbose("- Metal multiview not supported");
+	}
 
 	// Check required features and abort if any of them is missing.
 	if (!metal_device_properties->features.imageCubeArray) {


### PR DESCRIPTION
This PR adds multi-view support for the Metal rendering device driver.

# Testing

## GodotStereoDemo

A screenshot of XR enabled and rendering multiple views, thanks to @BastiaanOlij 

![CleanShot 2024-11-04 at 09 28 46@2x](https://github.com/user-attachments/assets/c2801e10-4794-4168-a260-242700059aae)


## Clearing attachments

It is not easy to test clearing a subset of an attachment when multi-view is enabled in Godot outside of XR, so I validated it by creating a multi-view frame buffer and clearing it and then validating the output in the Metal Debugger. 

The following screenshot has the following properties:

* A 1024x1024 frame buffer with a view count of 2.
* Clear rect of `{ x=10, y=10, w=50, h=50 }`
* Clear colour of `Color.AQUAMARINE`
* Clear depth of `0.5`

![CleanShot 2024-11-04 at 09 20 22@2x](https://github.com/user-attachments/assets/1d467c6d-2b37-4180-99c5-60a3f9f27276)

In this screenshot, we can see the following:

* Two views of a multi-view frame buffer, ❶ and ❷
* The colour texture, ❸ and ❹, is cleared to aquamarine at the rectangle 10, 10, 60, 60
* The depth texture, ❺ and ❻, is cleared to 0.5 at the rectangle 10, 10, 60, 60

The GDScript to set up the multi-view frame buffer:

```gdscript
var framebuffer2: RID
var clearColors2 := PackedColorArray([Color.AQUAMARINE])
var framebuf_texture
var d_framebuf_texture

func create_multiview():
	
	rd = RenderingServer.get_rendering_device()
	
	
	#  <<  --  FRAMEBUFFER  --  >>
	
	var attachments = []
	
	#  <<  -- COLOR  -- >>
	
	var tex_format := RDTextureFormat.new()
	tex_format.texture_type = RenderingDevice.TEXTURE_TYPE_2D_ARRAY
	tex_format.height = 1024
	tex_format.width = 1024
	tex_format.array_layers = 2
	tex_format.format = RenderingDevice.DATA_FORMAT_R8G8B8A8_UNORM
	tex_format.usage_bits = RenderingDevice.TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RenderingDevice.TEXTURE_USAGE_CAN_COPY_FROM_BIT  

	var tex_view := RDTextureView.new()
	framebuf_texture = rd.texture_create(tex_format, tex_view)
	print("framebuffe texture : ", rd.texture_is_valid(framebuf_texture))
	
	var af := RDAttachmentFormat.new()
	af.set_format(tex_format.format)
	af.set_samples(RenderingDevice.TEXTURE_SAMPLES_1)
	af.usage_flags = tex_format.usage_bits
	attachments.push_back(af)
	
	#  WORKS, but is actually slower than with texture_get_data()
	
	#t2drd = Texture2DRD.new()
	#t2drd.texture_rd_rid = RID()
	#t2drd.texture_rd_rid = framebuf_texture	
	
	#  <<  --  DEPTH  --  >>
	
	var dtex_format := RDTextureFormat.new()
	var dtex_view := RDTextureView.new()
	dtex_format.texture_type = RenderingDevice.TEXTURE_TYPE_2D_ARRAY
	dtex_format.height = 1024
	dtex_format.width = 1024
	dtex_format.array_layers = 2
	dtex_format.format = RenderingDevice.DATA_FORMAT_D16_UNORM
	dtex_format.usage_bits = RenderingDevice.TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
	d_framebuf_texture = rd.texture_create(dtex_format, dtex_view)
	print("depth buffer texture : ", rd.texture_is_valid(d_framebuf_texture))
	
	
	var daf := RDAttachmentFormat.new()
	daf.set_format(dtex_format.format)
	daf.set_samples(RenderingDevice.TEXTURE_SAMPLES_1)
	daf.usage_flags = dtex_format.usage_bits
	attachments.push_back(daf)
	
	# ---
	
	var framebuf_format := rd.framebuffer_format_create(attachments, 2)
	framebuffer2 = rd.framebuffer_create([framebuf_texture, d_framebuf_texture], framebuf_format, 2)
	print("framebuffer : ", rd.framebuffer_is_valid(framebuffer2))
```

and some code to clear it:

```gdscript
func draw_test():
	var dlist := rd.draw_list_begin(framebuffer2,
		RenderingDevice.INITIAL_ACTION_CLEAR, RenderingDevice.FINAL_ACTION_READ,
		RenderingDevice.INITIAL_ACTION_CLEAR, RenderingDevice.FINAL_ACTION_READ,
		clearColors2, 0.5, 3, Rect2(10, 10, 50, 50))
	rd.draw_list_end()
```