### PR TITLE
Fix crash in ScriptCreateDialog due to no default language selected

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -854,7 +854,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	gc->add_child(memnew(Label(TTR("Language:"))));
 	gc->add_child(language_menu);
 
-	default_language = -1;
+	default_language = 0;
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		String lang = ScriptServer::get_language(i)->get_name();
 		language_menu->add_item(lang);
@@ -862,10 +862,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 			default_language = i;
 		}
 	}
-	if (default_language >= 0) {
-		language_menu->select(default_language);
-	}
-
+	language_menu->select(default_language);
 	language_menu->connect(SceneStringName(item_selected), callable_mp(this, &ScriptCreateDialog::_language_changed));
 
 	/* Inherits */


### PR DESCRIPTION
The editor crashes when opening `Attach Script`  dialog if the editor is built with `module_gdscript_enabled=no`, since the `default_language` and `language_menu->get_selected()` are left as `-1` in this situation.

`GDScript` is always preferred if it's enabled, otherwise the first in the language list as a fallback is enough, I assume?

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
