### PR TITLE
Fix: Correct Solution File Resolution for GodotSharp

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -96,7 +96,6 @@ namespace GodotTools.Internals
 
             if (solutionFiles.Length == 0)
             {
-                GD.PrintErr($"No solution files found in directory: {globalizedPath}");
                 return Path.Combine(globalizedPath, $"{assemblyName}.sln");
             }
 
@@ -140,7 +139,6 @@ namespace GodotTools.Internals
                 }
                 catch (Exception ex)
                 {
-                    GD.PrintErr($"Failed to parse solution '{solutionPath}': {ex.Message}");
                     continue;
                 }
             }
@@ -156,7 +154,6 @@ namespace GodotTools.Internals
             }
             else
             {
-                GD.PrintErr($"No solution containing a project with assembly name '{assemblyName}' was found in {globalizedPath}");
                 return Path.Combine(globalizedPath, $"{assemblyName}.sln");
             }
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Internals/GodotSharpDirs.cs
@@ -4,6 +4,10 @@ using Godot;
 using Godot.NativeInterop;
 using GodotTools.Core;
 using static GodotTools.Internals.Globals;
+using Microsoft.Build.Construction;
+using System.Collections.Generic;
+using System.Linq;
+using System;
 
 namespace GodotTools.Internals
 {
@@ -79,11 +83,82 @@ namespace GodotTools.Internals
             // The csproj should be in the same folder as project.godot.
             string csprojParentDir = "res://";
 
-            _projectSlnPath = Path.Combine(ProjectSettings.GlobalizePath(slnParentDir),
-                string.Concat(_projectAssemblyName, ".sln"));
+            _projectSlnPath = FindSolutionFileWithAssemblyName(slnParentDir, _projectAssemblyName);
 
             _projectCsProjPath = Path.Combine(ProjectSettings.GlobalizePath(csprojParentDir),
                 string.Concat(_projectAssemblyName, ".csproj"));
+        }
+
+        private static string FindSolutionFileWithAssemblyName(string directory, string assemblyName)
+        {
+            string globalizedPath = ProjectSettings.GlobalizePath(directory);
+            string[] solutionFiles = Directory.GetFiles(globalizedPath, "*.sln");
+
+            if (solutionFiles.Length == 0)
+            {
+                GD.PrintErr($"No solution files found in directory: {globalizedPath}");
+                return Path.Combine(globalizedPath, $"{assemblyName}.sln");
+            }
+
+            List<string> matchingSolutions = new List<string>();
+
+            foreach (string solutionPath in solutionFiles)
+            {
+                try
+                {
+                    var solution = SolutionFile.Parse(solutionPath);
+
+                    foreach (var project in solution.ProjectsInOrder)
+                    {
+                        if (project.ProjectType == SolutionProjectType.SolutionFolder)
+                            continue;
+
+                        if (File.Exists(project.AbsolutePath))
+                        {
+                            var projectRoot = ProjectRootElement.Open(project.AbsolutePath);
+                            var assemblyNameProperty = projectRoot.Properties
+                                .FirstOrDefault(p => p.Name.Equals("AssemblyName", StringComparison.OrdinalIgnoreCase));
+
+                            if (assemblyNameProperty != null &&
+                                assemblyNameProperty.Value.Equals(assemblyName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                matchingSolutions.Add(solutionPath);
+                                break;
+                            }
+
+                            if (assemblyNameProperty == null)
+                            {
+                                string projectNameWithoutExtension = Path.GetFileNameWithoutExtension(project.AbsolutePath);
+                                if (projectNameWithoutExtension.Equals(assemblyName, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    matchingSolutions.Add(solutionPath);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    GD.PrintErr($"Failed to parse solution '{solutionPath}': {ex.Message}");
+                    continue;
+                }
+            }
+
+            if (matchingSolutions.Count == 1)
+            {
+                return matchingSolutions.Single();
+            }
+            else if (matchingSolutions.Count > 1)
+            {
+                GD.PrintErr($"Multiple solutions containing a project with assembly name '{assemblyName}' were found in {globalizedPath}. Please ensure only one solution contains the assembly.");
+                return Path.Combine(globalizedPath, $"{assemblyName}.sln");
+            }
+            else
+            {
+                GD.PrintErr($"No solution containing a project with assembly name '{assemblyName}' was found in {globalizedPath}");
+                return Path.Combine(globalizedPath, $"{assemblyName}.sln");
+            }
         }
 
         private static string? _projectAssemblyName;


### PR DESCRIPTION
Fixes: [#98804](https://github.com/godotengine/godot/issues/98804)

Updated the GodotSharpDirs.cs class to correctly assign the _projectSlnPath field. Previously, the implementation assumed that the solution file was named {assemblyName}.sln by concatenating the solution directory path with the assembly name. While this approach works for single-project solutions, it fails for multi-project solutions where the solution name typically differs from the assembly name, leading to build and export issues.

This PR introduces the FindSolutionFileWithAssemblyName() method, which searches all .sln files within the solution directory using Microsoft.Build to identify the one containing a project with the specified assembly name. If no matching solution is found, it falls back to the original behavior of constructing the solution path by combining the directory path and assembly name.

This has the added benefit if, during project reorganization, the solution name changes, it will still semi-intelligently update the solution name.

