### PR TITLE
[GDExtension] Improve macOS library loading/export.

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -439,6 +439,11 @@ bool OS::has_feature(const String &p_feature) {
 	}
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
+#if defined(MACOS_ENABLED)
+	if (p_feature == "universal") {
+		return true;
+	}
+#endif
 	if (p_feature == "x86_64") {
 		return true;
 	}
@@ -452,6 +457,11 @@ bool OS::has_feature(const String &p_feature) {
 	}
 #elif defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
 #if defined(__aarch64__) || defined(_M_ARM64)
+#if defined(MACOS_ENABLED)
+	if (p_feature == "universal") {
+		return true;
+	}
+#endif
 	if (p_feature == "arm64") {
 		return true;
 	}

--- a/editor/plugins/gdextension_export_plugin.h
+++ b/editor/plugins/gdextension_export_plugin.h
@@ -77,12 +77,14 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 
 	HashSet<String> archs;
 	HashSet<String> features_wo_arch;
+	Vector<String> features_vector;
 	for (const String &tag : p_features) {
 		if (all_archs.has(tag)) {
 			archs.insert(tag);
 		} else {
 			features_wo_arch.insert(tag);
 		}
+		features_vector.append(tag);
 	}
 
 	if (archs.is_empty()) {
@@ -90,11 +92,22 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 	}
 
 	HashSet<String> libs_added;
+	struct FoundLibInfo {
+		int count = 0;
+		Vector<String> libs;
+	};
+	HashMap<String, FoundLibInfo> libs_found;
+	for (const String &arch_tag : archs) {
+		if (arch_tag != "universal") {
+			libs_found[arch_tag] = FoundLibInfo();
+		}
+	}
 
 	for (const String &arch_tag : archs) {
 		PackedStringArray tags;
 		String library_path = GDExtensionLibraryLoader::find_extension_library(
 				p_path, config, [features_wo_arch, arch_tag](const String &p_feature) { return features_wo_arch.has(p_feature) || (p_feature == arch_tag); }, &tags);
+
 		if (libs_added.has(library_path)) {
 			continue; // Universal library, already added for another arch, do not duplicate.
 		}
@@ -122,20 +135,36 @@ void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p
 				String linker_flags = "-Wl,-U,_" + entry_symbol;
 				add_ios_linker_flags(linker_flags);
 			}
-		} else {
-			Vector<String> features_vector;
-			for (const String &E : p_features) {
-				features_vector.append(E);
+
+			// Update found library info.
+			if (arch_tag == "universal") {
+				for (const String &sub_arch_tag : archs) {
+					if (sub_arch_tag != "universal") {
+						libs_found[sub_arch_tag].count++;
+						libs_found[sub_arch_tag].libs.push_back(library_path);
+					}
+				}
+			} else {
+				libs_found[arch_tag].count++;
+				libs_found[arch_tag].libs.push_back(library_path);
 			}
-			if (get_export_platform().is_valid()) {
-				get_export_platform()->add_message(EditorExportPlatform::EXPORT_MESSAGE_WARNING, TTR("GDExtension"), vformat(TTR("No suitable library found for GDExtension: \"%s\". Possible feature flags for your platform: %s"), p_path, String(", ").join(features_vector)));
-			}
-			return;
 		}
 
 		Vector<SharedObject> dependencies_shared_objects = GDExtensionLibraryLoader::find_extension_dependencies(p_path, config, [p_features](String p_feature) { return p_features.has(p_feature); });
 		for (const SharedObject &shared_object : dependencies_shared_objects) {
 			_add_shared_object(shared_object);
+		}
+	}
+
+	for (const KeyValue<String, FoundLibInfo> &E : libs_found) {
+		if (E.value.count == 0) {
+			if (get_export_platform().is_valid()) {
+				get_export_platform()->add_message(EditorExportPlatform::EXPORT_MESSAGE_WARNING, TTR("GDExtension"), vformat(TTR("No \"%s\" library found for GDExtension: \"%s\". Possible feature flags for your platform: %s"), E.key, p_path, String(", ").join(features_vector)));
+			}
+		} else if (E.value.count > 1) {
+			if (get_export_platform().is_valid()) {
+				get_export_platform()->add_message(EditorExportPlatform::EXPORT_MESSAGE_WARNING, TTR("GDExtension"), vformat(TTR("Multiple \"%s\" libraries found for GDExtension: \"%s\": \"%s\"."), E.key, p_path, String(", ").join(E.value.libs)));
+			}
 		}
 	}
 }

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -65,6 +65,11 @@ void EditorExportPlatformMacOS::get_preset_features(const Ref<EditorExportPreset
 	} else {
 		ERR_PRINT("Invalid architecture");
 	}
+
+	if (architecture == "universal") {
+		r_features->push_back("x86_64");
+		r_features->push_back("arm64");
+	}
 }
 
 String EditorExportPlatformMacOS::get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/11084

- Adds support for loading libraries with explicitly specified `universal` tag (previously was only supported during export).
- Adds support for exporting separate `x86_64`/`arm64` libraries.
- Adds warning if multiple libs for the same architecture were found (e.g, both `universal` and `arm64`).
- Do not stop extension export if only library for some of supported architectures exist.