### PR TITLE
Improve `TextureProgressBar.set_radial_initial_angle()` by removing loops

### DIFF
--- a/doc/classes/TextureProgressBar.xml
+++ b/doc/classes/TextureProgressBar.xml
@@ -42,6 +42,7 @@
 		</member>
 		<member name="radial_initial_angle" type="float" setter="set_radial_initial_angle" getter="get_radial_initial_angle" default="0.0">
 			Starting angle for the fill of [member texture_progress] if [member fill_mode] is [constant FILL_CLOCKWISE], [constant FILL_COUNTER_CLOCKWISE], or [constant FILL_CLOCKWISE_AND_COUNTER_CLOCKWISE]. When the node's [code]value[/code] is equal to its [code]min_value[/code], the texture doesn't show up at all. When the [code]value[/code] increases, the texture fills and tends towards [member radial_fill_degrees].
+			[b]Note:[/b] [member radial_initial_angle] is wrapped between [code]0[/code] and [code]360[/code] degrees (inclusive).
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="1" />
 		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -608,11 +608,10 @@ int TextureProgressBar::get_fill_mode() {
 }
 
 void TextureProgressBar::set_radial_initial_angle(float p_angle) {
-	while (p_angle > 360) {
-		p_angle -= 360;
-	}
-	while (p_angle < 0) {
-		p_angle += 360;
+	ERR_FAIL_COND_MSG(!Math::is_finite(p_angle), "Angle is non-finite.");
+
+	if (p_angle < 0.0 || p_angle > 360.0) {
+		p_angle = Math::fposmodp(p_angle, 360.0f);
 	}
 
 	if (rad_init_angle == p_angle) {

--- a/tests/scene/test_texture_progress_bar.h
+++ b/tests/scene/test_texture_progress_bar.h
@@ -1,0 +1,92 @@
+/**************************************************************************/
+/*  test_texture_progress_bar.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_TEXTURE_PROGRESS_BAR_H
+#define TEST_TEXTURE_PROGRESS_BAR_H
+
+#include "scene/gui/texture_progress_bar.h"
+
+#include "tests/test_macros.h"
+
+namespace TestTextureProgressBar {
+
+TEST_CASE("[SceneTree][TextureProgressBar]") {
+	TextureProgressBar *texture_progress_bar = memnew(TextureProgressBar);
+
+	SUBCASE("[TextureProgressBar] set_radial_initial_angle() should wrap angle between 0 and 360 degrees (inclusive).") {
+		texture_progress_bar->set_radial_initial_angle(0.0);
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)0.0));
+
+		texture_progress_bar->set_radial_initial_angle(360.0);
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)360.0));
+
+		texture_progress_bar->set_radial_initial_angle(30.5);
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
+
+		texture_progress_bar->set_radial_initial_angle(-30.5);
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)(360 - 30.5)));
+
+		texture_progress_bar->set_radial_initial_angle(36000 + 30.5);
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
+
+		texture_progress_bar->set_radial_initial_angle(-(36000 + 30.5));
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)(360 - 30.5)));
+	}
+
+	SUBCASE("[TextureProgressBar] set_radial_initial_angle() should not set non-finite values.") {
+		texture_progress_bar->set_radial_initial_angle(30.5);
+
+		ERR_PRINT_OFF;
+		texture_progress_bar->set_radial_initial_angle(INFINITY);
+		ERR_PRINT_ON;
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
+
+		ERR_PRINT_OFF;
+		texture_progress_bar->set_radial_initial_angle(-INFINITY);
+		ERR_PRINT_ON;
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
+
+		ERR_PRINT_OFF;
+		texture_progress_bar->set_radial_initial_angle(NAN);
+		ERR_PRINT_ON;
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
+
+		ERR_PRINT_OFF;
+		texture_progress_bar->set_radial_initial_angle(-NAN);
+		ERR_PRINT_ON;
+		CHECK(Math::is_equal_approx(texture_progress_bar->get_radial_initial_angle(), (float)30.5));
+	}
+
+	memdelete(texture_progress_bar);
+}
+
+} // namespace TestTextureProgressBar
+
+#endif // TEST_TEXTURE_PROGRESS_BAR_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -130,6 +130,7 @@
 #include "tests/scene/test_physics_material.h"
 #include "tests/scene/test_sprite_frames.h"
 #include "tests/scene/test_style_box_texture.h"
+#include "tests/scene/test_texture_progress_bar.h"
 #include "tests/scene/test_theme.h"
 #include "tests/scene/test_timer.h"
 #include "tests/scene/test_viewport.h"


### PR DESCRIPTION
Replace two while loops with if and `fposmodp`.
Document `radial_initial_angle` wrapping.
Infinite numbers will cause error and will not change `radial_initial_angle` value.
Add testcase for set_radial_initial_angle() argument wrapping and skipping non-finite values.

Should fix https://github.com/godotengine/godot/issues/60338.
