### PR TITLE
Allow accessing EditorSettings at runtime using debugger

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -223,11 +223,6 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		args.push_back(p_scene);
 	}
 
-	// Pass the debugger stop shortcut to the running instance(s).
-	String shortcut;
-	VariantWriter::write_to_string(ED_GET_SHORTCUT("editor/stop_running_project"), shortcut);
-	OS::get_singleton()->set_environment("__GODOT_EDITOR_STOP_SHORTCUT__", shortcut);
-
 	String exec = OS::get_singleton()->get_executable_path();
 	int instance_count = RunInstancesDialog::get_singleton()->get_instance_count();
 	for (int i = 0; i < instance_count; i++) {

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -36,6 +36,8 @@
 #include "core/io/resource.h"
 #include "core/os/thread_safe.h"
 #include "core/templates/rb_set.h"
+#include "editor/plugins/editor_debugger_plugin.h"
+#include "editor/plugins/editor_plugin.h"
 
 class EditorPlugin;
 
@@ -207,6 +209,26 @@ public:
 #endif
 
 	EditorSettings();
+};
+
+class EditorSettingsDebugger : public EditorDebuggerPlugin {
+	GDCLASS(EditorSettingsDebugger, EditorDebuggerPlugin);
+
+public:
+	virtual bool capture(const String &p_message, const Array &p_data, int p_session) override;
+	virtual bool has_capture(const String &p_capture) const override;
+};
+
+class EditorSettingsDebuggerPlugin : public EditorPlugin {
+	GDCLASS(EditorSettingsDebuggerPlugin, EditorPlugin);
+
+	Ref<EditorSettingsDebugger> debugger;
+
+protected:
+	void _notification(int p_what);
+
+public:
+	EditorSettingsDebuggerPlugin();
 };
 
 //not a macro any longer

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -214,6 +214,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<CPUParticles3DEditorPlugin>();
 	EditorPlugins::add_by_type<CurveEditorPlugin>();
 	EditorPlugins::add_by_type<DebugAdapterServer>();
+	EditorPlugins::add_by_type<EditorSettingsDebuggerPlugin>();
 	EditorPlugins::add_by_type<FontEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticles3DEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticlesCollisionSDF3DEditorPlugin>();

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -32,16 +32,13 @@
 #define SCENE_DEBUGGER_H
 
 #include "core/input/shortcut.h"
-#include "core/object/ref_counted.h"
-#include "core/string/ustring.h"
-#include "core/templates/pair.h"
-#include "core/variant/array.h"
 #include "scene/gui/view_panner.h"
-#include "scene/resources/mesh.h"
 
+class ArrayMesh;
+class InputEventWithModifiers;
+class Node;
 class PopupMenu;
 class Script;
-class Node;
 
 class SceneDebugger {
 private:
@@ -67,6 +64,15 @@ public:
 	static Error parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);
 	static void add_to_cache(const String &p_filename, Node *p_node);
 	static void remove_from_cache(const String &p_filename, Node *p_node);
+#endif
+
+#ifdef TOOLS_ENABLED
+private:
+	HashMap<Pair<String, ObjectID>, Callable, PairHash<String, ObjectID>> editor_settings_requests;
+
+public:
+	static void request_editor_setting(const String &p_setting, const Object *p_requester, const Callable &p_callback);
+	static void request_editor_shortcut(const String &p_shortcut, const Object *p_requester, const Callable &p_callback);
 #endif
 };
 
@@ -210,6 +216,7 @@ private:
 	Ref<ViewPanner> panner;
 	Vector2 view_2d_offset;
 	real_t view_2d_zoom = 1.0;
+	bool warped_panning = true;
 
 	RID sbox_2d_canvas;
 	RID sbox_2d_ci;
@@ -270,7 +277,10 @@ private:
 	NodeType node_select_type = NODE_TYPE_2D;
 	SelectMode node_select_mode = SELECT_MODE_SINGLE;
 
+	HashMap<String, Variant> received_settings;
+
 	void _setup();
+	void _receive_setting(const String &p_setting, const Variant &p_value);
 
 	void _node_set_type(NodeType p_type);
 	void _select_set_mode(SelectMode p_mode);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -34,7 +34,7 @@
 #include "core/debugger/engine_debugger.h"
 #include "core/input/shortcut.h"
 #include "core/string/translation_server.h"
-#include "core/variant/variant_parser.h"
+#include "scene/debugger/scene_debugger.h"
 #include "scene/gui/control.h"
 #include "scene/theme/theme_db.h"
 #include "scene/theme/theme_owner.h"
@@ -1287,6 +1287,12 @@ void Window::_notification(int p_what) {
 
 			_invalidate_theme_cache();
 			_update_theme_item_cache();
+
+#ifdef TOOLS_ENABLED
+			if (EngineDebugger::is_active()) {
+				SceneDebugger::request_editor_shortcut("editor/stop_running_project", this, callable_mp(this, &Window::_stop_shortcut_callback));
+			}
+#endif
 		} break;
 
 		case NOTIFICATION_PARENTED: {
@@ -1631,30 +1637,7 @@ bool Window::_can_consume_input_events() const {
 
 void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	ERR_MAIN_THREAD_GUARD;
-	if (EngineDebugger::is_active()) {
-		// Quit from game window using the stop shortcut (F8 by default).
-		// The custom shortcut is provided via environment variable when running from the editor.
-		if (debugger_stop_shortcut.is_null()) {
-			String shortcut_str = OS::get_singleton()->get_environment("__GODOT_EDITOR_STOP_SHORTCUT__");
-			if (!shortcut_str.is_empty()) {
-				Variant shortcut_var;
-
-				VariantParser::StreamString ss;
-				ss.s = shortcut_str;
-
-				String errs;
-				int line;
-				VariantParser::parse(&ss, shortcut_var, errs, line);
-				debugger_stop_shortcut = shortcut_var;
-			}
-
-			if (debugger_stop_shortcut.is_null()) {
-				// Define a default shortcut if it wasn't provided or is invalid.
-				debugger_stop_shortcut.instantiate();
-				debugger_stop_shortcut->set_events({ (Variant)InputEventKey::create_reference(Key::F8) });
-			}
-		}
-
+	if (EngineDebugger::is_active() && debugger_stop_shortcut.is_valid()) {
 		Ref<InputEventKey> k = p_ev;
 		if (k.is_valid() && k->is_pressed() && !k->is_echo() && debugger_stop_shortcut->matches_event(k)) {
 			EngineDebugger::get_singleton()->send_message("request_quit", Array());
@@ -2808,6 +2791,10 @@ void Window::_mouse_leave_viewport() {
 		mouse_in_window = false;
 		_propagate_window_notification(this, NOTIFICATION_WM_MOUSE_EXIT);
 	}
+}
+
+void Window::_stop_shortcut_callback(const String &p_setting, const Variant &p_value) {
+	debugger_stop_shortcut = p_value;
 }
 
 void Window::_bind_methods() {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -241,6 +241,8 @@ private:
 
 	Ref<Shortcut> debugger_stop_shortcut;
 
+	void _stop_shortcut_callback(const String &p_setting, const Variant &p_value);
+
 	static int root_layout_direction;
 
 protected:


### PR DESCRIPTION
This PR adds a way to read EditorSettings in running project. It works like this:
- Object requests a setting using `SceneDebugger::request_editor_setting()` or `SceneDebugger::request_editor_shortcut()`
  - The method takes setting/shortcut name and a callback
- SceneDebugger will store the request in a HashMap
- Then it sends a message to a new EditorSettingsDebugger, which sends back the setting value
- SceneDebugger receives the message and passes the value where requested using callbacks

This allowed for some cleanup:
- Removed `__GODOT_EDITOR_STOP_SHORTCUT__` environment variable
  - Window receives the stop shortcut via debugger request
- 2D Panner in Game debugger now uses editor settings for panning at runtime
  - We can do the same for 3D, but I'm not familiar enough to know what settings are needed. CC @Calinou 