### PR TITLE
Add multiple specialization constants to Forward+ and Mobile.

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -395,6 +395,10 @@ void RenderForwardClustered::_render_list_template(RenderingDevice::DrawListID p
 		RID xforms_uniform_set = surf->owner->transforms_uniform_set;
 
 		SceneShaderForwardClustered::ShaderSpecialization pipeline_specialization = p_params->base_specialization;
+		pipeline_specialization.multimesh = bool(surf->owner->base_flags & INSTANCE_DATA_FLAG_MULTIMESH);
+		pipeline_specialization.multimesh_format_2d = bool(surf->owner->base_flags & INSTANCE_DATA_FLAG_MULTIMESH_FORMAT_2D);
+		pipeline_specialization.multimesh_has_color = bool(surf->owner->base_flags & INSTANCE_DATA_FLAG_MULTIMESH_HAS_COLOR);
+		pipeline_specialization.multimesh_has_custom_data = bool(surf->owner->base_flags & INSTANCE_DATA_FLAG_MULTIMESH_HAS_CUSTOM_DATA);
 
 		if constexpr (p_pass_mode == PASS_MODE_COLOR) {
 			pipeline_specialization.use_light_soft_shadows = element_info.uses_softshadow;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -374,6 +374,10 @@ void SceneShaderForwardClustered::ShaderData::_create_pipeline(PipelineKey p_pip
 	sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_INT;
 	specialization_constants.push_back(sc);
 
+	sc.constant_id = 1;
+	sc.int_value = p_pipeline_key.shader_specialization.packed_1;
+	specialization_constants.push_back(sc);
+
 	RID shader_rid = get_shader_variant(p_pipeline_key.version, p_pipeline_key.color_pass_flags, p_pipeline_key.ubershader);
 	ERR_FAIL_COND(shader_rid.is_null());
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -117,7 +117,17 @@ public:
 			uint32_t packed_0;
 		};
 
-		uint32_t packed_1;
+		union {
+			struct {
+				uint32_t multimesh : 1;
+				uint32_t multimesh_format_2d : 1;
+				uint32_t multimesh_has_color : 1;
+				uint32_t multimesh_has_custom_data : 1;
+			};
+
+			uint32_t packed_1;
+		};
+
 		uint32_t packed_2;
 	};
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -237,6 +237,7 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 			"VERSION:", p_pipeline_key.version,
 			"SPEC PACKED #0:", p_pipeline_key.shader_specialization.packed_0,
 			"SPEC PACKED #1:", p_pipeline_key.shader_specialization.packed_1,
+			"SPEC PACKED #2:", p_pipeline_key.shader_specialization.packed_2,
 			"RENDER PASS:", p_pipeline_key.render_pass,
 			"WIREFRAME:", p_pipeline_key.wireframe);
 #endif

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -65,25 +65,35 @@ public:
 				uint32_t use_directional_soft_shadows : 1;
 				uint32_t decal_use_mipmaps : 1;
 				uint32_t projector_use_mipmaps : 1;
-				uint32_t disable_omni_lights : 1;
-				uint32_t disable_spot_lights : 1;
-				uint32_t disable_reflection_probes : 1;
-				uint32_t disable_directional_lights : 1;
-				uint32_t disable_decals : 1;
 				uint32_t disable_fog : 1;
 				uint32_t use_depth_fog : 1;
-				uint32_t is_multimesh : 1;
 				uint32_t use_lightmap_bicubic_filter : 1;
+				uint32_t multimesh : 1;
+				uint32_t multimesh_format_2d : 1;
+				uint32_t multimesh_has_color : 1;
+				uint32_t multimesh_has_custom_data : 1;
+				uint32_t scene_use_ambient_cubemap : 1;
+				uint32_t scene_use_reflection_cubemap : 1;
+				uint32_t scene_roughness_limiter_enabled : 1;
+				uint32_t padding : 5;
 				uint32_t soft_shadow_samples : 6;
 				uint32_t penumbra_shadow_samples : 6;
-				uint32_t directional_soft_shadow_samples : 6;
 			};
 
 			uint32_t packed_0;
 		};
 
 		union {
-			uint32_t directional_penumbra_shadow_samples : 6;
+			struct {
+				uint32_t directional_soft_shadow_samples : 6;
+				uint32_t directional_penumbra_shadow_samples : 6;
+				uint32_t omni_lights : 4;
+				uint32_t spot_lights : 4;
+				uint32_t reflection_probes : 4;
+				uint32_t directional_lights : 4;
+				uint32_t decals : 4;
+			};
+
 			uint32_t packed_1;
 		};
 

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -59,6 +59,10 @@ uint sc_packed_0() {
 	return draw_call.sc_packed_0;
 }
 
+uint sc_packed_1() {
+	return draw_call.sc_packed_1;
+}
+
 uint uc_cull_mode() {
 	return (draw_call.uc_packed_0 >> 0) & 3U;
 }
@@ -67,9 +71,14 @@ uint uc_cull_mode() {
 
 // Pull the constants from the pipeline's specialization constants.
 layout(constant_id = 0) const uint pso_sc_packed_0 = 0;
+layout(constant_id = 1) const uint pso_sc_packed_1 = 0;
 
 uint sc_packed_0() {
 	return pso_sc_packed_0;
+}
+
+uint sc_packed_1() {
+	return pso_sc_packed_1;
 }
 
 #endif
@@ -122,6 +131,22 @@ uint sc_directional_penumbra_shadow_samples() {
 	return (sc_packed_0() >> 26) & 63U;
 }
 
+bool sc_multimesh() {
+	return ((sc_packed_1() >> 0) & 1U) != 0;
+}
+
+bool sc_multimesh_format_2d() {
+	return ((sc_packed_1() >> 1) & 1U) != 0;
+}
+
+bool sc_multimesh_has_color() {
+	return ((sc_packed_1() >> 2) & 1U) != 0;
+}
+
+bool sc_multimesh_has_custom_data() {
+	return ((sc_packed_1() >> 3) & 1U) != 0;
+}
+
 float sc_luminance_multiplier() {
 	// Not used in clustered renderer but we share some code with the mobile renderer that requires this.
 	return 1.0;
@@ -144,10 +169,6 @@ layout(set = 0, binding = 2) uniform sampler shadow_sampler;
 #define INSTANCE_FLAGS_USE_SH_LIGHTMAP (1 << 9)
 #define INSTANCE_FLAGS_USE_VOXEL_GI (1 << 10)
 #define INSTANCE_FLAGS_PARTICLES (1 << 11)
-#define INSTANCE_FLAGS_MULTIMESH (1 << 12)
-#define INSTANCE_FLAGS_MULTIMESH_FORMAT_2D (1 << 13)
-#define INSTANCE_FLAGS_MULTIMESH_HAS_COLOR (1 << 14)
-#define INSTANCE_FLAGS_MULTIMESH_HAS_CUSTOM_DATA (1 << 15)
 #define INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT 16
 #define INSTANCE_FLAGS_FADE_SHIFT 24
 //3 bits of stride

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -95,56 +95,80 @@ bool sc_projector_use_mipmaps() {
 	return ((sc_packed_0() >> 4) & 1U) != 0;
 }
 
-bool sc_disable_omni_lights() {
+bool sc_disable_fog() {
 	return ((sc_packed_0() >> 5) & 1U) != 0;
 }
 
-bool sc_disable_spot_lights() {
+bool sc_use_depth_fog() {
 	return ((sc_packed_0() >> 6) & 1U) != 0;
 }
 
-bool sc_disable_reflection_probes() {
+bool sc_use_lightmap_bicubic_filter() {
 	return ((sc_packed_0() >> 7) & 1U) != 0;
 }
 
-bool sc_disable_directional_lights() {
+bool sc_multimesh() {
 	return ((sc_packed_0() >> 8) & 1U) != 0;
 }
 
-bool sc_disable_decals() {
+bool sc_multimesh_format_2d() {
 	return ((sc_packed_0() >> 9) & 1U) != 0;
 }
 
-bool sc_disable_fog() {
+bool sc_multimesh_has_color() {
 	return ((sc_packed_0() >> 10) & 1U) != 0;
 }
 
-bool sc_use_depth_fog() {
+bool sc_multimesh_has_custom_data() {
 	return ((sc_packed_0() >> 11) & 1U) != 0;
 }
 
-bool sc_is_multimesh() {
+bool sc_scene_use_ambient_cubemap() {
 	return ((sc_packed_0() >> 12) & 1U) != 0;
 }
 
-bool sc_use_lightmap_bicubic_filter() {
+bool sc_scene_use_reflection_cubemap() {
 	return ((sc_packed_0() >> 13) & 1U) != 0;
 }
 
-uint sc_soft_shadow_samples() {
-	return (sc_packed_0() >> 14) & 63U;
+bool sc_scene_roughness_limiter_enabled() {
+	return ((sc_packed_0() >> 14) & 1U) != 0;
 }
 
-uint sc_penumbra_shadow_samples() {
+uint sc_soft_shadow_samples() {
 	return (sc_packed_0() >> 20) & 63U;
 }
 
-uint sc_directional_soft_shadow_samples() {
+uint sc_penumbra_shadow_samples() {
 	return (sc_packed_0() >> 26) & 63U;
 }
 
-uint sc_directional_penumbra_shadow_samples() {
+uint sc_directional_soft_shadow_samples() {
 	return (sc_packed_1() >> 0) & 63U;
+}
+
+uint sc_directional_penumbra_shadow_samples() {
+	return (sc_packed_1() >> 6) & 63U;
+}
+
+uint sc_omni_lights() {
+	return (sc_packed_1() >> 12) & 15U;
+}
+
+uint sc_spot_lights() {
+	return (sc_packed_1() >> 16) & 15U;
+}
+
+uint sc_reflection_probes() {
+	return (sc_packed_1() >> 20) & 15U;
+}
+
+uint sc_directional_lights() {
+	return (sc_packed_1() >> 24) & 15U;
+}
+
+uint sc_decals() {
+	return (sc_packed_1() >> 28) & 15U;
 }
 
 float sc_luminance_multiplier() {
@@ -166,10 +190,6 @@ layout(set = 0, binding = 2) uniform sampler shadow_sampler;
 #define INSTANCE_FLAGS_USE_SH_LIGHTMAP (1 << 9)
 #define INSTANCE_FLAGS_USE_VOXEL_GI (1 << 10)
 #define INSTANCE_FLAGS_PARTICLES (1 << 11)
-#define INSTANCE_FLAGS_MULTIMESH (1 << 12)
-#define INSTANCE_FLAGS_MULTIMESH_FORMAT_2D (1 << 13)
-#define INSTANCE_FLAGS_MULTIMESH_HAS_COLOR (1 << 14)
-#define INSTANCE_FLAGS_MULTIMESH_HAS_CUSTOM_DATA (1 << 15)
 #define INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT 16
 //3 bits of stride
 #define INSTANCE_FLAGS_PARTICLE_TRAIL_MASK 0xFF


### PR DESCRIPTION
Since https://github.com/godotengine/godot/pull/90400 is now merged, it is now possible for us to further specialize shaders without adding stutters when the configuration of the scene changes.

I turned the following dynamic attributes of the shader into specialization constants and got some measurable improvements in frame time already. Most of these specializations are focused on the mobile renderer.

- Omni light count
- Spot light count
- Directional light count
- Reflection probe count
- Multimesh format
- Ambient cubemap toggle
- Reflection cubemap toggle
- Scene roughness limiter

[TPS Demo from here](https://github.com/godotengine/godot/pull/90284)

Average GPU Time in Mali-G78
- `master`: 31.2ms
- `mobile-scs`: 28.6ms

Further improvements could be found as I dig deeper into the shader for more optimization opportunities.

---

Contributed by [W4 Games](https://w4games.com/). 🍀