### PR TITLE
Fix animation editor snapping value not lowering as intended when holding shift

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -7353,16 +7353,17 @@ void AnimationTrackEditor::_update_snap_unit() {
 
 float AnimationTrackEditor::snap_time(float p_value, bool p_relative) {
 	if (is_snap_keys_enabled()) {
+		double current_snap = snap_unit;
 		if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
 			// Use more precise snapping when holding Shift.
-			snap_unit *= 0.25;
+			current_snap *= 0.25;
 		}
 
 		if (p_relative) {
-			double rel = Math::fmod(timeline->get_value(), snap_unit);
-			p_value = Math::snapped(p_value + rel, snap_unit) - rel;
+			double rel = Math::fmod(timeline->get_value(), current_snap);
+			p_value = Math::snapped(p_value + rel, current_snap) - rel;
 		} else {
-			p_value = Math::snapped(p_value, snap_unit);
+			p_value = Math::snapped(p_value, current_snap);
 		}
 	}
 


### PR DESCRIPTION
Closes #98609 
I have no idea what weird piece of code in "_update_snap_unit()" which breaks snapping was meant to do, but my guess is that it was made for limiting fractional part so I've replaced it with snapped() function.
Also fixed holding shift not lowering snap value as intended.