### PR TITLE
Docs: Add link to SpringArm3D tutorial

### DIFF
--- a/doc/classes/SpringArm3D.xml
+++ b/doc/classes/SpringArm3D.xml
@@ -7,6 +7,7 @@
 		[SpringArm3D] casts a ray or a shape along its Z axis and moves all its direct children to the collision point, with an optional margin. This is useful for 3rd person cameras that move closer to the player when inside a tight space (you may need to exclude the player's collider from the [SpringArm3D]'s collision check).
 	</description>
 	<tutorials>
+		<link title="Third-person camera with spring arm">$DOCS_URL/tutorials/3d/spring_arm.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_excluded_object">


### PR DESCRIPTION
Links to the tutorial added in https://github.com/godotengine/godot-docs/pull/10156.