### PR TITLE
OpenXR: Allow GDExtensions to implement `_on_pre_draw_viewport()` and `_on_post_draw_viewport()`

### DIFF
--- a/modules/openxr/doc_classes/OpenXRExtensionWrapperExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRExtensionWrapperExtension.xml
@@ -90,6 +90,21 @@
 				Called right after the main swapchains are (re)created.
 			</description>
 		</method>
+		<method name="_on_post_draw_viewport" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="viewport" type="RID" />
+			<description>
+				Called right after the given viewport is rendered.
+				[b]Note:[/b] The draw commands might only be queued at this point, not executed.
+			</description>
+		</method>
+		<method name="_on_pre_draw_viewport" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="viewport" type="RID" />
+			<description>
+				Called right before the given viewport is rendered.
+			</description>
+		</method>
 		<method name="_on_pre_render" qualifiers="virtual">
 			<return type="void" />
 			<description>

--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.cpp
@@ -51,6 +51,8 @@ void OpenXRExtensionWrapperExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_on_process);
 	GDVIRTUAL_BIND(_on_pre_render);
 	GDVIRTUAL_BIND(_on_main_swapchains_created);
+	GDVIRTUAL_BIND(_on_pre_draw_viewport, "viewport");
+	GDVIRTUAL_BIND(_on_post_draw_viewport, "viewport");
 	GDVIRTUAL_BIND(_on_session_destroyed);
 	GDVIRTUAL_BIND(_on_state_idle);
 	GDVIRTUAL_BIND(_on_state_ready);
@@ -206,6 +208,14 @@ void OpenXRExtensionWrapperExtension::on_main_swapchains_created() {
 
 void OpenXRExtensionWrapperExtension::on_session_destroyed() {
 	GDVIRTUAL_CALL(_on_session_destroyed);
+}
+
+void OpenXRExtensionWrapperExtension::on_pre_draw_viewport(RID p_render_target) {
+	GDVIRTUAL_CALL(_on_pre_draw_viewport, p_render_target);
+}
+
+void OpenXRExtensionWrapperExtension::on_post_draw_viewport(RID p_render_target) {
+	GDVIRTUAL_CALL(_on_post_draw_viewport, p_render_target);
 }
 
 void OpenXRExtensionWrapperExtension::on_state_idle() {

--- a/modules/openxr/extensions/openxr_extension_wrapper_extension.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper_extension.h
@@ -88,6 +88,8 @@ public:
 	virtual void on_pre_render() override;
 	virtual void on_main_swapchains_created() override;
 	virtual void on_session_destroyed() override;
+	virtual void on_pre_draw_viewport(RID p_render_target) override;
+	virtual void on_post_draw_viewport(RID p_render_target) override;
 
 	GDVIRTUAL0(_on_register_metadata);
 	GDVIRTUAL0(_on_before_instance_created);
@@ -98,6 +100,8 @@ public:
 	GDVIRTUAL0(_on_pre_render);
 	GDVIRTUAL0(_on_main_swapchains_created);
 	GDVIRTUAL0(_on_session_destroyed);
+	GDVIRTUAL1(_on_pre_draw_viewport, RID);
+	GDVIRTUAL1(_on_post_draw_viewport, RID);
 
 	virtual void on_state_idle() override;
 	virtual void on_state_ready() override;


### PR DESCRIPTION
For some reason, `OpenXRExtensionWrapperExtension` doesn't expose `_on_pre_draw_viewport()` and `_on_post_draw_viewport()`, despite exposing all other virtual methods.

I don't think there's any reason for this, I think it was just an accidental omission.