### PR TITLE
Windows: Integrate `INVALID_HANDLE_VALUE`

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -282,7 +282,7 @@ Error DirAccessWindows::rename(String p_path, String p_new_path) {
 		uint64_t id = OS::get_singleton()->get_ticks_usec();
 		while (true) {
 			tmpfile_utf16 = (path + itos(id++) + ".tmp").utf16();
-			HANDLE handle = CreateFileW((LPCWSTR)tmpfile_utf16.get_data(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+			HANDLE handle = CreateFileW((LPCWSTR)tmpfile_utf16.get_data(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, INVALID_HANDLE_VALUE);
 			if (handle != INVALID_HANDLE_VALUE) {
 				CloseHandle(handle);
 				break;

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -193,7 +193,7 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 		uint64_t id = OS::get_singleton()->get_ticks_usec();
 		while (true) {
 			tmpfile = path + itos(id++) + ".tmp";
-			HANDLE handle = CreateFileW((LPCWSTR)tmpfile.utf16().get_data(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+			HANDLE handle = CreateFileW((LPCWSTR)tmpfile.utf16().get_data(), GENERIC_WRITE, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, INVALID_HANDLE_VALUE);
 			if (handle != INVALID_HANDLE_VALUE) {
 				CloseHandle(handle);
 				break;
@@ -413,7 +413,7 @@ uint64_t FileAccessWindows::_get_modified_time(const String &p_file) {
 		file = file.substr(0, file.length() - 1);
 	}
 
-	HANDLE handle = CreateFileW((LPCWSTR)(file.utf16().get_data()), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+	HANDLE handle = CreateFileW((LPCWSTR)(file.utf16().get_data()), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, INVALID_HANDLE_VALUE);
 
 	if (handle != INVALID_HANDLE_VALUE) {
 		FILETIME ft_create, ft_write;

--- a/drivers/windows/file_access_windows_pipe.cpp
+++ b/drivers/windows/file_access_windows_pipe.cpp
@@ -40,7 +40,7 @@ Error FileAccessWindowsPipe::open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_bl
 	_close();
 
 	path_src = String();
-	ERR_FAIL_COND_V_MSG(fd[0] != nullptr || fd[1] != nullptr, ERR_ALREADY_IN_USE, "Pipe is already in use.");
+	ERR_FAIL_COND_V_MSG(fd[0] != INVALID_HANDLE_VALUE || fd[1] != INVALID_HANDLE_VALUE, ERR_ALREADY_IN_USE, "Pipe is already in use.");
 	fd[0] = p_rfd;
 	fd[1] = p_wfd;
 
@@ -58,11 +58,11 @@ Error FileAccessWindowsPipe::open_internal(const String &p_path, int p_mode_flag
 	_close();
 
 	path_src = p_path;
-	ERR_FAIL_COND_V_MSG(fd[0] != nullptr || fd[1] != nullptr, ERR_ALREADY_IN_USE, "Pipe is already in use.");
+	ERR_FAIL_COND_V_MSG(fd[0] != INVALID_HANDLE_VALUE || fd[1] != INVALID_HANDLE_VALUE, ERR_ALREADY_IN_USE, "Pipe is already in use.");
 
 	path = String("\\\\.\\pipe\\LOCAL\\") + p_path.replace("pipe://", "").replace("/", "_");
 
-	HANDLE h = CreateFileW((LPCWSTR)path.utf16().get_data(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+	HANDLE h = CreateFileW((LPCWSTR)path.utf16().get_data(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, INVALID_HANDLE_VALUE);
 	if (h == INVALID_HANDLE_VALUE) {
 		h = CreateNamedPipeW((LPCWSTR)path.utf16().get_data(), PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_NOWAIT, 1, 4096, 4096, 0, nullptr);
 		if (h == INVALID_HANDLE_VALUE) {
@@ -79,19 +79,19 @@ Error FileAccessWindowsPipe::open_internal(const String &p_path, int p_mode_flag
 }
 
 void FileAccessWindowsPipe::_close() {
-	if (fd[0] == nullptr) {
+	if (fd[0] == INVALID_HANDLE_VALUE) {
 		return;
 	}
 	if (fd[1] != fd[0]) {
 		CloseHandle(fd[1]);
 	}
 	CloseHandle(fd[0]);
-	fd[0] = nullptr;
-	fd[1] = nullptr;
+	fd[0] = INVALID_HANDLE_VALUE;
+	fd[1] = INVALID_HANDLE_VALUE;
 }
 
 bool FileAccessWindowsPipe::is_open() const {
-	return (fd[0] != nullptr || fd[1] != nullptr);
+	return (fd[0] != INVALID_HANDLE_VALUE || fd[1] != INVALID_HANDLE_VALUE);
 }
 
 String FileAccessWindowsPipe::get_path() const {
@@ -103,7 +103,7 @@ String FileAccessWindowsPipe::get_path_absolute() const {
 }
 
 uint64_t FileAccessWindowsPipe::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
-	ERR_FAIL_COND_V_MSG(fd[0] == nullptr, -1, "Pipe must be opened before use.");
+	ERR_FAIL_COND_V_MSG(fd[0] == INVALID_HANDLE_VALUE, -1, "Pipe must be opened before use.");
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
 	DWORD read = 0;
@@ -120,7 +120,7 @@ Error FileAccessWindowsPipe::get_error() const {
 }
 
 void FileAccessWindowsPipe::store_buffer(const uint8_t *p_src, uint64_t p_length) {
-	ERR_FAIL_COND_MSG(fd[1] == nullptr, "Pipe must be opened before use.");
+	ERR_FAIL_COND_MSG(fd[1] == INVALID_HANDLE_VALUE, "Pipe must be opened before use.");
 	ERR_FAIL_COND(!p_src && p_length > 0);
 
 	DWORD read = -1;

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -39,7 +39,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 class FileAccessWindowsPipe : public FileAccess {
-	HANDLE fd[2] = { nullptr, nullptr };
+	HANDLE fd[2] = { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE };
 
 	mutable Error last_error = OK;
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -735,7 +735,7 @@ Error DisplayServerWindows::_file_dialog_with_options_show(const String &p_title
 		GetWindowRect(fd->hwnd_owner, &crect);
 		fd->wrect = Rect2i(crect.left, crect.top, crect.right - crect.left, crect.bottom - crect.top);
 	} else {
-		fd->hwnd_owner = nullptr;
+		fd->hwnd_owner = (HWND)INVALID_HANDLE_VALUE;
 		fd->wrect = Rect2i(CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT);
 	}
 	fd->appid = appname;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -555,7 +555,7 @@ class DisplayServerWindows : public DisplayServer {
 	HashMap<IndicatorID, IndicatorData> indicators;
 
 	struct FileDialogData {
-		HWND hwnd_owner = 0;
+		HWND hwnd_owner = (HWND)INVALID_HANDLE_VALUE;
 		Rect2i wrect;
 		String appid;
 		String title;

--- a/platform/windows/native_menu_windows.cpp
+++ b/platform/windows/native_menu_windows.cpp
@@ -158,7 +158,7 @@ Size2 NativeMenuWindows::get_size(const RID &p_rid) const {
 	int count = GetMenuItemCount(md->menu);
 	for (int i = 0; i < count; i++) {
 		RECT rect;
-		if (GetMenuItemRect(nullptr, md->menu, i, &rect)) {
+		if (GetMenuItemRect((HWND)INVALID_HANDLE_VALUE, md->menu, i, &rect)) {
 			size.x = MAX(size.x, rect.right - rect.left);
 			size.y += rect.bottom - rect.top;
 		}
@@ -992,7 +992,7 @@ void NativeMenuWindows::set_item_submenu(const RID &p_rid, int p_idx, const RID 
 		if (p_submenu_rid.is_valid()) {
 			item.hSubMenu = md_sub->menu;
 		} else {
-			item.hSubMenu = nullptr;
+			item.hSubMenu = (HMENU)INVALID_HANDLE_VALUE;
 		}
 		SetMenuItemInfoW(md->menu, p_idx, true, &item);
 	}
@@ -1095,7 +1095,7 @@ void NativeMenuWindows::set_item_icon(const RID &p_rid, int p_idx, const Ref<Tex
 				item_data->bmp = _make_bitmap(item_data->img);
 			} else {
 				item_data->img = Ref<Image>();
-				item_data->bmp = nullptr;
+				item_data->bmp = (HBITMAP)INVALID_HANDLE_VALUE;
 			}
 			item.hbmpItem = item_data->bmp;
 			SetMenuItemInfoW(md->menu, p_idx, true, &item);

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -139,13 +139,13 @@ void RedirectIOToConsole() {
 
 	if (AttachConsole(ATTACH_PARENT_PROCESS)) {
 		// Restore redirection (Note: if not redirected it's NULL handles not INVALID_HANDLE_VALUE).
-		if (h_stdin != nullptr) {
+		if (h_stdin != INVALID_HANDLE_VALUE) {
 			SetStdHandle(STD_INPUT_HANDLE, h_stdin);
 		}
-		if (h_stdout != nullptr) {
+		if (h_stdout != INVALID_HANDLE_VALUE) {
 			SetStdHandle(STD_OUTPUT_HANDLE, h_stdout);
 		}
-		if (h_stderr != nullptr) {
+		if (h_stderr != INVALID_HANDLE_VALUE) {
 			SetStdHandle(STD_ERROR_HANDLE, h_stderr);
 		}
 
@@ -908,9 +908,9 @@ Dictionary OS_Windows::execute_with_pipe(const String &p_path, const List<String
 	}
 
 	// Create pipes.
-	HANDLE pipe_in[2] = { nullptr, nullptr };
-	HANDLE pipe_out[2] = { nullptr, nullptr };
-	HANDLE pipe_err[2] = { nullptr, nullptr };
+	HANDLE pipe_in[2] = { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE };
+	HANDLE pipe_out[2] = { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE };
+	HANDLE pipe_err[2] = { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE };
 
 	SECURITY_ATTRIBUTES sa;
 	sa.nLength = sizeof(SECURITY_ATTRIBUTES);
@@ -981,7 +981,7 @@ Dictionary OS_Windows::execute_with_pipe(const String &p_path, const List<String
 
 	Ref<FileAccessWindowsPipe> err_pipe;
 	err_pipe.instantiate();
-	err_pipe->open_existing(pipe_err[0], nullptr, p_blocking);
+	err_pipe->open_existing(pipe_err[0], INVALID_HANDLE_VALUE, p_blocking);
 
 	ret["stdio"] = main_pipe;
 	ret["stderr"] = err_pipe;
@@ -1005,7 +1005,7 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 	LPSTARTUPINFOW si_w = (LPSTARTUPINFOW)&pi.si;
 
 	bool inherit_handles = false;
-	HANDLE pipe[2] = { nullptr, nullptr };
+	HANDLE pipe[2] = { INVALID_HANDLE_VALUE, INVALID_HANDLE_VALUE };
 	if (r_pipe) {
 		// Create pipe for StdOut and StdErr.
 		SECURITY_ATTRIBUTES sa;
@@ -1650,7 +1650,7 @@ String OS_Windows::get_stdin_string() {
 }
 
 Error OS_Windows::shell_open(const String &p_uri) {
-	INT_PTR ret = (INT_PTR)ShellExecuteW(nullptr, nullptr, (LPCWSTR)(p_uri.utf16().get_data()), nullptr, nullptr, SW_SHOWNORMAL);
+	INT_PTR ret = (INT_PTR)ShellExecuteW((HWND)INVALID_HANDLE_VALUE, nullptr, (LPCWSTR)(p_uri.utf16().get_data()), nullptr, nullptr, SW_SHOWNORMAL);
 	if (ret > 32) {
 		return OK;
 	} else {
@@ -1686,9 +1686,9 @@ Error OS_Windows::shell_show_in_file_manager(String p_path, bool p_open_folder) 
 
 	INT_PTR ret = OK;
 	if (open_folder) {
-		ret = (INT_PTR)ShellExecuteW(nullptr, nullptr, L"explorer.exe", LPCWSTR(p_path.utf16().get_data()), nullptr, SW_SHOWNORMAL);
+		ret = (INT_PTR)ShellExecuteW((HWND)INVALID_HANDLE_VALUE, nullptr, L"explorer.exe", LPCWSTR(p_path.utf16().get_data()), nullptr, SW_SHOWNORMAL);
 	} else {
-		ret = (INT_PTR)ShellExecuteW(nullptr, nullptr, L"explorer.exe", LPCWSTR((String("/select,") + p_path).utf16().get_data()), nullptr, SW_SHOWNORMAL);
+		ret = (INT_PTR)ShellExecuteW((HWND)INVALID_HANDLE_VALUE, nullptr, L"explorer.exe", LPCWSTR((String("/select,") + p_path).utf16().get_data()), nullptr, SW_SHOWNORMAL);
 	}
 
 	if (ret > 32) {

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -67,7 +67,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 		{
 			// The custom LoadLibraryExW is used instead of open_dynamic_library
 			// to avoid loading the original PDB into the debugger.
-			HMODULE library_ptr = LoadLibraryExW((LPCWSTR)(p_dll_path.utf16().get_data()), nullptr, LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE);
+			HMODULE library_ptr = LoadLibraryExW((LPCWSTR)(p_dll_path.utf16().get_data()), INVALID_HANDLE_VALUE, LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE);
 
 			ERR_FAIL_NULL_V_MSG(library_ptr, ERR_FILE_CANT_OPEN, vformat("Failed to load library '%s'.", p_dll_path));
 


### PR DESCRIPTION
- Followup to #93401

As mentioned in [this comment](https://github.com/godotengine/godot/pull/93401#issuecomment-2454641586) from the above PR, the use of `0` wasn't strictly correct wrt Win32 Handles. While that much might've been true, I didn't want to include potentially functional changes in a `clang-tidy` update; now that the above has been merged, this can be safely tackled. The instances that clang-tidy caught were easy conversions, but there were a few other areas I noticed where handle syntax was using `nullptr` instead of `INVALID_HANDLE_VALUE`, so those were converted as well. It's entirely possible there's more instances than this, but this should largely cover the initial concern