### PR TITLE
[3.x] Fix error when non-ASCII characters in resource pack path

### DIFF
--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -43,7 +43,7 @@ static void *godot_open(void *data, const char *p_fname, int mode) {
 		return nullptr;
 	}
 
-	FileAccess *f = FileAccess::open(p_fname, FileAccess::READ);
+	FileAccess *f = FileAccess::open(String::utf8(p_fname), FileAccess::READ);
 	ERR_FAIL_COND_V(!f, nullptr);
 
 	return f;


### PR DESCRIPTION
This was fixed for version 4 in this PR: #78935
Cherry-picking for 3.x to fix the bug as well. 