### PR TITLE
Add `Engine.get_build_system_info()` to get information about the build environment

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -184,6 +184,25 @@ gen_hash = env.CommandNoCache(
 )
 env.add_source_files(env.core_sources, gen_hash)
 
+# Generate buildsystem info
+gen_buildsystem_info = env.CommandNoCache(
+    "buildsystem.gen.h",
+    env.Value(
+        [
+            os.name,
+            env.using_gcc,
+            env.using_clang,
+            env.is_apple_clang,
+            env.msvc,
+            env.using_emcc,
+            env.compiler_version,
+            env["optimize"],
+            env["lto"],
+        ]
+    ),
+    env.Run(core_builders.buildsystem_info_builder),
+)
+
 # Generate AES256 script encryption key
 encryption_key = os.environ.get("SCRIPT_AES256_ENCRYPTION_KEY")
 if encryption_key:

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -31,6 +31,7 @@
 #include "engine.h"
 
 #include "core/authors.gen.h"
+#include "core/buildsystem.gen.h"
 #include "core/config/project_settings.h"
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
@@ -143,6 +144,17 @@ Dictionary Engine::get_version_info() const {
 	}
 	stringver += "-" + String(dict["status"]) + " (" + String(dict["build"]) + ")";
 	dict["string"] = stringver;
+
+	return dict;
+}
+
+Dictionary Engine::get_build_system_info() const {
+	Dictionary dict;
+	dict["os_name"] = BUILDSYSTEM_OS_NAME;
+	dict["compiler_name"] = BUILDSYSTEM_COMPILER_NAME;
+	dict["compiler_version"] = BUILDSYSTEM_COMPILER_VERSION;
+	dict["optimization_type"] = BUILDSYSTEM_OPTIMIZATION_TYPE;
+	dict["optimization_lto"] = BUILDSYSTEM_OPTIMIZATION_LTO;
 
 	return dict;
 }

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -180,6 +180,7 @@ public:
 #endif
 
 	Dictionary get_version_info() const;
+	Dictionary get_build_system_info() const;
 	Dictionary get_author_info() const;
 	TypedArray<Dictionary> get_copyright_info() const;
 	Dictionary get_donor_info() const;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1947,6 +1947,10 @@ Dictionary Engine::get_version_info() const {
 	return ::Engine::get_singleton()->get_version_info();
 }
 
+Dictionary Engine::get_build_system_info() const {
+	return ::Engine::get_singleton()->get_build_system_info();
+}
+
 Dictionary Engine::get_author_info() const {
 	return ::Engine::get_singleton()->get_author_info();
 }
@@ -2102,6 +2106,7 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_main_loop"), &Engine::get_main_loop);
 
 	ClassDB::bind_method(D_METHOD("get_version_info"), &Engine::get_version_info);
+	ClassDB::bind_method(D_METHOD("get_build_system_info"), &Engine::get_build_system_info);
 	ClassDB::bind_method(D_METHOD("get_author_info"), &Engine::get_author_info);
 	ClassDB::bind_method(D_METHOD("get_copyright_info"), &Engine::get_copyright_info);
 	ClassDB::bind_method(D_METHOD("get_donor_info"), &Engine::get_donor_info);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -600,6 +600,7 @@ public:
 	MainLoop *get_main_loop() const;
 
 	Dictionary get_version_info() const;
+	Dictionary get_build_system_info() const;
 	Dictionary get_author_info() const;
 	TypedArray<Dictionary> get_copyright_info() const;
 	Dictionary get_donor_info() const;

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -46,6 +46,42 @@ const uint64_t GODOT_VERSION_TIMESTAMP = {git_timestamp};
         )
 
 
+def buildsystem_info_builder(target, source, env):
+    with methods.generated_wrapper(str(target[0])) as file:
+        import platform
+
+        os_name = platform.system()
+        if os_name == "Darwin":
+            os_name = "macOS"
+
+        compiler_name = "unknown"
+        compiler_version = (
+            f"{env.compiler_version['major']}.{env.compiler_version['minor']}.{env.compiler_version['patch']}"
+        )
+        if env.using_gcc:
+            compiler_name = "gcc"
+        elif env.using_clang:
+            if env.is_apple_clang:
+                compiler_name = "apple-clang"
+                compiler_version = f"{env.compiler_version['apple_major']}.{env.compiler_version['apple_minor']}.{env.compiler_version['apple_patch1']}.{env.compiler_version['apple_patch2']}.{env.compiler_version['apple_patch3']}"
+            else:
+                compiler_name = "clang"
+        elif env.msvc:
+            compiler_name = "msvc"
+        elif env.using_emcc:
+            compiler_name = "emcc"
+
+        file.write(
+            f"""\
+#define BUILDSYSTEM_OS_NAME "{os_name}"
+#define BUILDSYSTEM_COMPILER_NAME "{compiler_name}"
+#define BUILDSYSTEM_COMPILER_VERSION "{compiler_version}"
+#define BUILDSYSTEM_OPTIMIZATION_TYPE "{env["optimize"]}"
+#define BUILDSYSTEM_OPTIMIZATION_LTO "{env["lto"]}"
+"""
+        )
+
+
 def encryption_key_builder(target, source, env):
     src = source[0].read() or "0" * 64
     try:

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -33,6 +33,18 @@
 				Returns the engine author information as a [Dictionary], where each entry is an [Array] of strings with the names of notable contributors to the Godot Engine: [code]lead_developers[/code], [code]founders[/code], [code]project_managers[/code], and [code]developers[/code].
 			</description>
 		</method>
+		<method name="get_build_system_info" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns the build system environment that was used to compile this Godot binary, as a [Dictionary] containing the following entries:
+				- [code]os_name[/code] - Name of the operating system used to compile Godot, as a string (can differ from the binary's target platform)
+				- [code]compiler_name[/code] - Compiler name (can be [code]"gcc"[/code], [code]"clang"[/code], [code]"apple-clang"[/code], [code]"msvc"[/code], [code]"emcc"[/code] or [code]"unknown"[/code])
+				- [code]compiler_version[/code] - Compiler version number, as a string
+				- [code]optimization_type[/code] - Compiler optimization type (can be [code]"none"[/code], [code]"debug"[/code], [code]"speed_trace"[/code], [code]"speed"[/code], [code]"size"[/code], [code]"custom"[/code])
+				- [code]optimization_lto[/code] - Link-time optimization level (can be [code]"none"[/code], [code]"thin"[/code], [code]"full"[/code])
+				See also [method get_version_info].
+			</description>
+		</method>
 		<method name="get_copyright_info" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>
@@ -198,6 +210,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
+				See also [method get_build_system_info].
 			</description>
 		</method>
 		<method name="get_write_movie_path" qualifiers="const">

--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -4,8 +4,6 @@ from misc.utility.scons_hints import *
 import os
 from pathlib import Path
 
-import methods
-
 Import("env")
 
 env_d3d12_rdd = env.Clone()
@@ -156,7 +154,7 @@ else:
     extra_defines += [
         "HAVE_STRUCT_TIMESPEC",
     ]
-    if methods.using_gcc(env) and methods.get_compiler_version(env)["major"] < 13:
+    if env.using_gcc and env.compiler_version["major"] < 13:
         # `region` & `endregion` not recognized as valid pragmas.
         env_d3d12_rdd.Append(CCFLAGS=["-Wno-unknown-pragmas"])
         env.Append(CCFLAGS=["-Wno-unknown-pragmas"])

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5542,6 +5542,18 @@ String EditorNode::_get_system_info() const {
 		driver_name = "Metal";
 	}
 
+	const Dictionary build_system_info = Engine::get_singleton()->get_build_system_info();
+	String compiler_name = String(build_system_info["compiler_name"]).capitalize();
+	if (compiler_name == "Gcc") {
+		compiler_name = "GCC";
+	} else if (compiler_name == "Msvc") {
+		compiler_name = "MSVC";
+	}
+	String build_system_string = ("Compiled on " + String(build_system_info["os_name"]) +
+			" with " + compiler_name + " " + String(build_system_info["compiler_version"]) +
+			", optimization: " + String(build_system_info["optimization_type"]) +
+			", LTO: " + String(build_system_info["optimization_lto"]));
+
 	// Join info.
 	Vector<String> info;
 	info.push_back(godot_version);
@@ -5597,6 +5609,8 @@ String EditorNode::_get_system_info() const {
 		// If the memory info is available, display it.
 		info.push_back(vformat("%s memory", String::humanize_size(system_ram)));
 	}
+
+	info.push_back(build_system_string);
 
 	return String(" - ").join(info);
 }

--- a/methods.py
+++ b/methods.py
@@ -108,7 +108,7 @@ def redirect_emitter(target, source, env):
 
 def disable_warnings(self):
     # 'self' is the environment
-    if self.msvc and not using_clang(self):
+    if self.msvc and not self.using_clang:
         self["WARNLEVEL"] = "/w"
     else:
         self["WARNLEVEL"] = "-w"
@@ -662,7 +662,7 @@ def is_apple_clang(env):
 
     if env["platform"] not in ["macos", "ios"]:
         return False
-    if not using_clang(env):
+    if not env.using_clang:
         return False
     try:
         version = (
@@ -705,7 +705,7 @@ def get_compiler_version(env):
         "apple_patch3": -1,
     }
 
-    if env.msvc and not using_clang(env):
+    if env.msvc and not env.using_clang:
         try:
             # FIXME: `-latest` works for most cases, but there are edge-cases where this would
             # benefit from a more nuanced search.

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -3,7 +3,7 @@ import platform
 import sys
 from typing import TYPE_CHECKING
 
-from methods import get_compiler_version, print_error, print_info, print_warning, using_gcc
+from methods import print_error, print_info, print_warning, using_gcc
 from platform_methods import detect_arch, validate_arch
 
 if TYPE_CHECKING:
@@ -113,8 +113,7 @@ def configure(env: "SConsEnvironment"):
     if env["linker"] != "default":
         print("Using linker program: " + env["linker"])
         if env["linker"] == "mold" and using_gcc(env):  # GCC < 12.1 doesn't support -fuse-ld=mold.
-            cc_version = get_compiler_version(env)
-            cc_semver = (cc_version["major"], cc_version["minor"])
+            cc_semver = (env.compiler_version["major"], env.compiler_version["minor"])
             if cc_semver < (12, 1):
                 found_wrapper = False
                 for path in ["/usr/libexec", "/usr/local/libexec", "/usr/lib", "/usr/local/lib"]:

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -2,7 +2,7 @@ import os
 import sys
 from typing import TYPE_CHECKING
 
-from methods import detect_darwin_sdk_path, get_compiler_version, is_apple_clang, print_error, print_warning
+from methods import detect_darwin_sdk_path, print_error, print_warning
 from platform_methods import detect_arch, detect_mvk, validate_arch
 
 if TYPE_CHECKING:
@@ -91,12 +91,11 @@ def configure(env: "SConsEnvironment"):
     env.Append(CCFLAGS=["-ffp-contract=off"])
     env.Append(CCFLAGS=["-fobjc-arc"])
 
-    cc_version = get_compiler_version(env)
-    cc_version_major = cc_version["apple_major"]
-    cc_version_minor = cc_version["apple_minor"]
+    cc_version_major = env.compiler_version["apple_major"]
+    cc_version_minor = env.compiler_version["apple_minor"]
 
     # Workaround for Xcode 15 linker bug.
-    if is_apple_clang(env) and cc_version_major == 1500 and cc_version_minor == 0:
+    if env.is_apple_clang and cc_version_major == 1500 and cc_version_minor == 0:
         env.Prepend(LINKFLAGS=["-ld_classic"])
 
     if env.dev_build:

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -15,7 +15,7 @@ from emscripten_helpers import (
 )
 from SCons.Util import WhereIs
 
-from methods import get_compiler_version, print_error, print_info, print_warning
+from methods import print_error, print_info, print_warning
 from platform_methods import validate_arch
 
 if TYPE_CHECKING:
@@ -96,7 +96,7 @@ def library_emitter(target, source, env):
     # Make every source file dependent on the compiler version.
     # This makes sure that when emscripten is updated, that the cached files
     # aren't used and are recompiled instead.
-    env.Depends(source, env.Value(get_compiler_version(env)))
+    env.Depends(source, env.Value(env.compiler_version))
     return target, source
 
 
@@ -108,8 +108,7 @@ def configure(env: "SConsEnvironment"):
     env["RANLIB"] = "emranlib"
 
     # Get version info for checks below.
-    cc_version = get_compiler_version(env)
-    cc_semver = (cc_version["major"], cc_version["minor"], cc_version["patch"])
+    cc_semver = (env.compiler_version["major"], env.compiler_version["minor"], env.compiler_version["patch"])
 
     # Minimum emscripten requirements.
     if cc_semver < (4, 0, 0):


### PR DESCRIPTION
This returns a Dictionary with the following keys:

- `os_name`
- `compiler_name`
- `compiler_version`
- `optimization_level`
- `optimization_lto`

This is also mentioned in the editor's **Copy System Info** copied information. For example, on my system using a debug build, it now returns:

> Godot v4.6.dev (19e2b2eb0) - Fedora Linux 42 (KDE Plasma Desktop Edition) on X11 - X11 display driver, Multi-window, 1 monitor - Vulkan (Forward+) - dedicated NVIDIA GeForce RTX 5090 (nvidia; 580.82.09) - AMD Ryzen 9 9950X3D 16-Core Processor (32 threads) - 62.33 GiB memory - Compiled on Linux with GCC 15.2.1, optimization: none, LTO: none

- This closes https://github.com/godotengine/godot-proposals/issues/10788.

## TODO

- [ ] ~~Mention this information on startup when running a binary with `--verbose`.~~
  - This will be done in https://github.com/godotengine/godot/pull/75025 instead if this PR is merged.