### PR TITLE
Automatically set `text_editor/external/exec_flags` based on the editor specified in `exec_path` text box

### DIFF
--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -122,6 +122,7 @@ private:
 	void _load_default_visual_shader_editor_theme();
 	bool _save_text_editor_theme(const String &p_file);
 	bool _is_default_text_editor_theme(const String &p_theme_name);
+	static String _guess_exec_args_for_extenal_editor(const String &p_value);
 	const String _get_project_metadata_path() const;
 #ifndef DISABLE_DEPRECATED
 	void _remove_deprecated_settings();


### PR DESCRIPTION
Whenever `exec_path` is changed, a signal is emitted. On this signal, a method is called that searches the contents of the `exec_path` field for a predefined pattern using a regex. Upon a valid match, a value for `text_editor/external/exec_flags` is selected and this property is modified.

Values for exec_flags are taken from the [Using an external text editor](https://docs.godotengine.org/en/stable/tutorials/editor/external_editor.html) doc

Closes https://github.com/godotengine/godot-proposals/issues/10631 and closes https://github.com/JetBrains/godot-support/issues/226