### PR TITLE
Add warning for assigning BOOL properties during explicit typing (not only for INT's)

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5946,11 +5946,16 @@ bool GDScriptAnalyzer::is_type_compatible(const GDScriptParser::DataType &p_targ
 			if (p_source.kind == GDScriptParser::DataType::BUILTIN && p_source.builtin_type == Variant::INT) {
 				parser->push_warning(p_source_node, GDScriptWarning::INT_AS_ENUM_WITHOUT_CAST);
 			}
+
+			if (p_source.kind == GDScriptParser::DataType::BUILTIN && p_source.builtin_type == Variant::BOOL) {
+				parser->push_warning(p_source_node, GDScriptWarning::BOOL_AS_ENUM_WITHOUT_CAST);
+			}
 		}
 	}
 #endif
 	return check_type_compatibility(p_target, p_source, p_allow_implicit_conversion, p_source_node);
 }
+
 
 // TODO: Add safe/unsafe return variable (for variant cases)
 bool GDScriptAnalyzer::check_type_compatibility(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source, bool p_allow_implicit_conversion, const GDScriptParser::Node *p_source_node) {
@@ -5996,16 +6001,26 @@ bool GDScriptAnalyzer::check_type_compatibility(const GDScriptParser::DataType &
 	}
 
 	if (p_target.kind == GDScriptParser::DataType::ENUM) {
-		if (p_source.kind == GDScriptParser::DataType::BUILTIN && p_source.builtin_type == Variant::INT) {
-			return true;
-		}
-		if (p_source.kind == GDScriptParser::DataType::ENUM) {
-			if (p_source.native_type == p_target.native_type) {
-				return true;
-			}
-		}
-		return false;
-	}
+    // Allow int to enum.
+    if (p_source.kind == GDScriptParser::DataType::BUILTIN && p_source.builtin_type == Variant::INT) {
+        return true;
+    }
+
+    // New addition: Allow bool to enum.
+    if (p_source.kind == GDScriptParser::DataType::BUILTIN && p_source.builtin_type == Variant::BOOL) {
+        return true; // Accept bool for enum assignment.
+    }
+
+    // Check if the source is an enum with the same native type.
+    if (p_source.kind == GDScriptParser::DataType::ENUM) {
+        if (p_source.native_type == p_target.native_type) {
+            return true;
+        }
+    }
+
+    return false; // Return false if none of the above conditions are met.
+}
+
 
 	// From here on the target type is an object, so we have to test polymorphism.
 

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -125,6 +125,8 @@ String GDScriptWarning::get_message() const {
 			return "Narrowing conversion (float is converted to int and loses precision).";
 		case INT_AS_ENUM_WITHOUT_CAST:
 			return "Integer used when an enum value is expected. If this is intended cast the integer to the enum type.";
+		case BOOL_AS_ENUM_WITHOUT_CAST:
+    		return "Boolean used when an enum value is expected. If this is intended, cast the boolean to the enum type.";
 		case INT_AS_ENUM_WITHOUT_MATCH:
 			CHECK_SYMBOLS(3);
 			return vformat(R"(Cannot %s %s as Enum "%s": no enum member has matching value.)", symbols[0], symbols[1], symbols[2]);
@@ -229,6 +231,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"INTEGER_DIVISION",
 		"NARROWING_CONVERSION",
 		"INT_AS_ENUM_WITHOUT_CAST",
+		"BOOL_AS_ENUM_WITHOUT_CAST",
 		"INT_AS_ENUM_WITHOUT_MATCH",
 		"ENUM_VARIABLE_WITHOUT_DEFAULT",
 		"EMPTY_FILE",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -78,6 +78,7 @@ public:
 		INTEGER_DIVISION, // Integer divide by integer, decimal part is discarded.
 		NARROWING_CONVERSION, // Float value into an integer slot, precision is lost.
 		INT_AS_ENUM_WITHOUT_CAST, // An integer value was used as an enum value without casting.
+		BOOL_AS_ENUM_WITHOUT_CAST, // A bool value was used as an enum value without casting.
 		INT_AS_ENUM_WITHOUT_MATCH, // An integer value was used as an enum value without matching enum member.
 		ENUM_VARIABLE_WITHOUT_DEFAULT, // A variable with an enum type does not have a default value. The default will be set to `0` instead of the first enum value.
 		EMPTY_FILE, // A script file is empty.
@@ -132,6 +133,7 @@ public:
 		WARN, // INTEGER_DIVISION
 		WARN, // NARROWING_CONVERSION
 		WARN, // INT_AS_ENUM_WITHOUT_CAST
+		WARN, // BOOL_AS_ENUM_WITHOUT_CAST
 		WARN, // INT_AS_ENUM_WITHOUT_MATCH
 		WARN, // ENUM_VARIABLE_WITHOUT_DEFAULT
 		WARN, // EMPTY_FILE


### PR DESCRIPTION
<!--

Solution relates to #98830 

This solution adds a new warning in the GDScript analyzer to alert users when a bool is used as an enum without explicit casting, similar to the existing INT_AS_ENUM_WITHOUT_CAST warning. The analyzer now issues a warning to guide developers toward proper casting for type clarity and safety, instead of a parse error. 

In the current version of Godot, this only works for ENUM's of type INT.
Also, it is currently possible to cast INT's for explicit BOOL ENUM without parse errors or warnings
Example: 
![579e6bc74d436dd6bcb71992d22fca29](https://github.com/user-attachments/assets/686508aa-91d6-4936-b8e5-93f29cad492a)


Example of proposal:
The BOOL now gives similar warning as it would give for INT if declared to an ENUM type.
![a914f0ab64ea9ad164d6dc162ae9c0e4](https://github.com/user-attachments/assets/a61be32a-5439-42a8-9ff9-4eb036949371)
![082d10d2951ed8cd8605b186cc2dff5b](https://github.com/user-attachments/assets/6c8fdedf-8c84-4aad-a8b5-a5d9c55e6258)

-->

Solution relates to #98830 

This solution adds a new warning in the GDScript analyzer to alert users when a bool is used as an enum without explicit casting, similar to the existing INT_AS_ENUM_WITHOUT_CAST warning. The analyzer now issues a warning to guide developers toward proper casting for type clarity and safety, instead of a parse error. 

In the current version of Godot, this only works for ENUM's of type INT.
Also, it is currently possible to cast INT's for explicit BOOL ENUM without parse errors or warnings
Example: 
![579e6bc74d436dd6bcb71992d22fca29](https://github.com/user-attachments/assets/686508aa-91d6-4936-b8e5-93f29cad492a)


Example of proposal:
The BOOL now gives similar warning as it would give for INT if declared to an ENUM type.
![a914f0ab64ea9ad164d6dc162ae9c0e4](https://github.com/user-attachments/assets/a61be32a-5439-42a8-9ff9-4eb036949371)
![082d10d2951ed8cd8605b186cc2dff5b](https://github.com/user-attachments/assets/6c8fdedf-8c84-4aad-a8b5-a5d9c55e6258)
