### PR TITLE
Make the method selector dialog available via `EditorInterface`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -301,6 +301,15 @@
 				See also [method Window.set_unparent_when_invisible].
 			</description>
 		</method>
+		<method name="popup_method_selector">
+			<return type="void" />
+			<param index="0" name="object" type="Object" />
+			<param index="1" name="callback" type="Callable" />
+			<param index="2" name="current_value" type="String" default="&quot;&quot;" />
+			<description>
+				Pops up an editor dialog for selecting a method from [param object]. The [param callback] must take a single argument of type [String] which will contain the name of the selected method or be empty if the dialog is canceled. If [param current_value] is provided, the method will be selected automatically in the method list, if it exists.
+			</description>
+		</method>
 		<method name="popup_node_selector">
 			<return type="void" />
 			<param index="0" name="callback" type="Callable" />

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -66,12 +66,14 @@ class EditorInterface : public Object {
 	// Editor dialogs.
 
 	PropertySelector *property_selector = nullptr;
+	PropertySelector *method_selector = nullptr;
 	SceneTreeDialog *node_selector = nullptr;
 
 	void _node_selected(const NodePath &p_node_paths, const Callable &p_callback);
 	void _node_selection_canceled(const Callable &p_callback);
 	void _property_selected(const String &p_property_name, const Callable &p_callback);
 	void _property_selection_canceled(const Callable &p_callback);
+	void _method_selected(const String &p_property_name, const Callable &p_callback);
 	void _quick_open(const String &p_file_path, const Callable &p_callback);
 	void _call_dialog_callback(const Callable &p_callback, const Variant &p_selected, const String &p_context);
 
@@ -139,6 +141,7 @@ public:
 	void popup_node_selector(const Callable &p_callback, const TypedArray<StringName> &p_valid_types = TypedArray<StringName>(), Node *p_current_value = nullptr);
 	// Must use Vector<int> because exposing Vector<Variant::Type> is not supported.
 	void popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter = PackedInt32Array(), const String &p_current_value = String());
+	void popup_method_selector(Object *p_object, const Callable &p_callback, const String &p_current_value = String());
 	void popup_quick_open(const Callable &p_callback, const TypedArray<StringName> &p_base_types = TypedArray<StringName>());
 
 	// Editor docks.


### PR DESCRIPTION
We can select object properties with `EditorInterface.popup_property_selector` but there is no equivalent to select methods. This PR adds `EditorInterface.popup_method_selector` so we can use the method selector dialog.

```gdscript
@tool
extends EditorScript


func _run() -> void:
	EditorInterface.popup_method_selector(self, _method_selector, "_run")


static func _method_selector(method_name: String):
	print("Method: %s" % method_name)
```