### PR TITLE
Register Engine, OS, ProjectSettings, and Time singletons in time for `INITIZATION_LEVEL_CORE`

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -536,9 +536,14 @@ bool OS::has_feature(const String &p_feature) {
 		return true;
 	}
 
-	if (has_server_feature_callback && has_server_feature_callback(p_feature)) {
-		return true;
+	if (has_server_feature_callback) {
+		return has_server_feature_callback(p_feature);
 	}
+#ifdef DEBUG_ENABLED
+	else if (is_stdout_verbose()) {
+		WARN_PRINT_ONCE("Server features cannot be checked before RenderingServer has been created. If you are checking a server feature, consider moving your OS::has_feature call after INITIALIZATION_LEVEL_SERVERS.");
+	}
+#endif
 
 	if (ProjectSettings::get_singleton()->has_custom_feature(p_feature)) {
 		return true;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -313,17 +313,28 @@ void register_core_settings() {
 	GLOBAL_DEF("threading/worker_pool/low_priority_thread_ratio", 0.3);
 }
 
+void register_early_core_singletons() {
+	GDREGISTER_CLASS(core_bind::Engine);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Engine", core_bind::Engine::get_singleton()));
+
+	GDREGISTER_CLASS(ProjectSettings);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
+
+	GDREGISTER_CLASS(core_bind::OS);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("OS", core_bind::OS::get_singleton()));
+
+	GDREGISTER_CLASS(Time);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("Time", Time::get_singleton()));
+}
+
 void register_core_singletons() {
 	OS::get_singleton()->benchmark_begin_measure("Core", "Register Singletons");
 
-	GDREGISTER_CLASS(ProjectSettings);
 	GDREGISTER_ABSTRACT_CLASS(IP);
 	GDREGISTER_CLASS(core_bind::Geometry2D);
 	GDREGISTER_CLASS(core_bind::Geometry3D);
 	GDREGISTER_CLASS(core_bind::ResourceLoader);
 	GDREGISTER_CLASS(core_bind::ResourceSaver);
-	GDREGISTER_CLASS(core_bind::OS);
-	GDREGISTER_CLASS(core_bind::Engine);
 	GDREGISTER_CLASS(core_bind::special::ClassDB);
 	GDREGISTER_CLASS(core_bind::Marshalls);
 	GDREGISTER_CLASS(TranslationServer);
@@ -331,23 +342,18 @@ void register_core_singletons() {
 	GDREGISTER_CLASS(InputMap);
 	GDREGISTER_CLASS(Expression);
 	GDREGISTER_CLASS(core_bind::EngineDebugger);
-	GDREGISTER_CLASS(Time);
 
-	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("IP", IP::get_singleton(), "IP"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry2D", core_bind::Geometry2D::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry3D", core_bind::Geometry3D::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceLoader", core_bind::ResourceLoader::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceSaver", core_bind::ResourceSaver::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("OS", core_bind::OS::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Engine", core_bind::Engine::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ClassDB", _classdb));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Marshalls", core_bind::Marshalls::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TranslationServer", TranslationServer::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", Input::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("EngineDebugger", core_bind::EngineDebugger::get_singleton()));
-	Engine::get_singleton()->add_singleton(Engine::Singleton("Time", Time::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GDExtensionManager", GDExtensionManager::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceUID", ResourceUID::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("WorkerThreadPool", worker_thread_pool));

--- a/core/register_core_types.h
+++ b/core/register_core_types.h
@@ -34,6 +34,7 @@
 void register_core_types();
 void register_core_settings();
 void register_core_extensions();
+void register_early_core_singletons();
 void register_core_singletons();
 void unregister_core_types();
 void unregister_core_extensions();

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1540,7 +1540,8 @@ DWRITE_FONT_STRETCH OS_Windows::_stretch_to_dw(int p_stretch) const {
 }
 
 Vector<String> OS_Windows::get_system_font_path_for_text(const String &p_font_name, const String &p_text, const String &p_locale, const String &p_script, int p_weight, int p_stretch, bool p_italic) const {
-	if (!dwrite2_init) {
+	// This may be called before TextServerManager has been created, which would cause a crash downstream if we do not check here
+	if (!dwrite2_init || !TextServerManager::get_singleton()) {
 		return Vector<String>();
 	}
 


### PR DESCRIPTION
This PR registers the `Engine`, `ProjectSettings`, `OS`, and `Time` singletons to ClassDB earlier so that GDExtensions can access them during `INITIALIZATION_LEVEL_CORE`. Previously, these were only accessible in `INITIALIZATION_LEVEL_SCENE` and later.

Addresses [GIP#9134](https://github.com/godotengine/godot-proposals/issues/9134).

This is done by:
- Using `GDREGISTER_CLASS` and calling `Engine::add_singleton` for the 4 singletons before `register_core_extensions()`.
- Setting Engine and OS values earlier _when possible_ (e.g., `Engine::set_project_manager_hint`.
- Adding a null check for `TextServerManager::get_singleton` in `OS_Windows::get_system_font_path_for_text` to prevent a crash since Windows needs the `TextServerManager` to get the text direction, which is not created until after `INITIALIZATION_LEVEL_CORE`.


**Caveats:**
While the exposed singleton methods are all safe to call, they may not return the expected value if they depend on later setup. These exceptions include:
- The order of `GLOBAL_DEF`, etc. calls for project settings unrelated to the 4 singletons is mostly untouched, meaning many defaults are not set until after `INITIALIZATION_LEVEL_CORE` (e.g., `rendering/*` settings from `RenderingServer::init()`).
- `OS::has_feature` will still return false for any server feature until `RenderingServer` has been created.
- `OS_Windows::get_system_font_path_for_text` depends on the `TextServer` and will return the empty string until it is created.

**Notes on dependencies and code-paths of exposed singleton methods:** [[Google Sheets Link]](https://docs.google.com/spreadsheets/d/19gnuqFmEcC65Krp6WUHAgspfWd7XaG3G)