### PR TITLE
Reduce allocations for NavMap synchronization

### DIFF
--- a/modules/navigation/3d/nav_mesh_queries_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_queries_3d.cpp
@@ -234,7 +234,7 @@ Vector<Vector3> NavMeshQueries3D::polygons_get_path(const LocalVector<gd::Polygo
 		// Takes the current least_cost_poly neighbors (iterating over its edges) and compute the traveled_distance.
 		for (const gd::Edge &edge : navigation_polys[least_cost_id].poly->edges) {
 			// Iterate over connections in this edge, then compute the new optimized travel distance assigned to this polygon.
-			for (int connection_index = 0; connection_index < edge.connections.size(); connection_index++) {
+			for (uint32_t connection_index = 0; connection_index < edge.connections.size(); connection_index++) {
 				const gd::Edge::Connection &connection = edge.connections[connection_index];
 
 				// Only consider the connection to another polygon if this polygon is in a region with compatible layers.

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -426,13 +426,8 @@ void NavMap::sync() {
 
 		_new_pm_polygon_count = polygon_count;
 
-		struct ConnectionPair {
-			gd::Edge::Connection connections[2];
-			int size = 0;
-		};
-
 		// Group all edges per key.
-		HashMap<gd::EdgeKey, ConnectionPair, gd::EdgeKey> connection_pairs_map;
+		connection_pairs_map.clear();
 		connection_pairs_map.reserve(polygons.size());
 		int free_edges_count = 0; // How many ConnectionPairs have only one Connection.
 
@@ -469,7 +464,7 @@ void NavMap::sync() {
 			}
 		}
 
-		LocalVector<gd::Edge::Connection> free_edges;
+		free_edges.clear();
 		free_edges.reserve(free_edges_count);
 
 		for (const KeyValue<gd::EdgeKey, ConnectionPair> &pair_it : connection_pairs_map) {

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -128,6 +128,14 @@ class NavMap : public NavRid {
 
 	HashMap<NavRegion *, LocalVector<gd::Edge::Connection>> region_external_connections;
 
+	struct ConnectionPair {
+		gd::Edge::Connection connections[2];
+		int size = 0;
+	};
+
+	HashMap<gd::EdgeKey, ConnectionPair, gd::EdgeKey> connection_pairs_map;
+	LocalVector<gd::Edge::Connection> free_edges;
+
 public:
 	NavMap();
 	~NavMap();

--- a/modules/navigation/nav_utils.h
+++ b/modules/navigation/nav_utils.h
@@ -94,7 +94,7 @@ struct Edge {
 	};
 
 	/// Connections from this edge to other polygons.
-	Vector<Connection> connections;
+	LocalVector<Connection> connections;
 };
 
 struct Polygon {


### PR DESCRIPTION
Improves navigation map sync performance by avoiding unnecessary memory allocations.

- Edges were still using old CoW Vectors.
- Map sync was creating new HashMaps / LocalVectors for every build data instead of reusing.

In a large test project this change dropped the sync time from ~400.000 usec down to ~300.000 usec.
Roughly a 20-30% improvement on average in the projects I tried.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
