### PR TITLE
[4.2] GLTF: Preserve node visibility on import

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -2173,6 +2173,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 
 		mesh_node->set_layer_mask(src_mesh_node->get_layer_mask());
 		mesh_node->set_cast_shadows_setting(src_mesh_node->get_cast_shadows_setting());
+		mesh_node->set_visible(src_mesh_node->is_visible());
 		mesh_node->set_visibility_range_begin(src_mesh_node->get_visibility_range_begin());
 		mesh_node->set_visibility_range_begin_margin(src_mesh_node->get_visibility_range_begin_margin());
 		mesh_node->set_visibility_range_end(src_mesh_node->get_visibility_range_end());

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -307,6 +307,7 @@ void SceneImportSettings::_fill_scene(Node *p_node, TreeItem *p_parent_item) {
 		mesh_node->set_transform(src_mesh_node->get_transform());
 		mesh_node->set_skin(src_mesh_node->get_skin());
 		mesh_node->set_skeleton_path(src_mesh_node->get_skeleton_path());
+		mesh_node->set_visible(src_mesh_node->is_visible());
 		if (src_mesh_node->get_mesh().is_valid()) {
 			Ref<ImporterMesh> editor_mesh = src_mesh_node->get_mesh();
 			mesh_node->set_mesh(editor_mesh->get_mesh());

--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
@@ -46,17 +46,18 @@ Error GLTFDocumentExtensionConvertImporterMesh::import_post(Ref<GLTFState> p_sta
 	while (!queue.is_empty()) {
 		List<Node *>::Element *E = queue.front();
 		Node *node = E->get();
-		ImporterMeshInstance3D *mesh_3d = cast_to<ImporterMeshInstance3D>(node);
-		if (mesh_3d) {
+		ImporterMeshInstance3D *importer_mesh_3d = Object::cast_to<ImporterMeshInstance3D>(node);
+		if (importer_mesh_3d) {
 			MeshInstance3D *mesh_instance_node_3d = memnew(MeshInstance3D);
-			Ref<ImporterMesh> mesh = mesh_3d->get_mesh();
+			Ref<ImporterMesh> mesh = importer_mesh_3d->get_mesh();
 			if (mesh.is_valid()) {
 				Ref<ArrayMesh> array_mesh = mesh->get_mesh();
 				mesh_instance_node_3d->set_name(node->get_name());
-				mesh_instance_node_3d->set_transform(mesh_3d->get_transform());
+				mesh_instance_node_3d->set_transform(importer_mesh_3d->get_transform());
 				mesh_instance_node_3d->set_mesh(array_mesh);
-				mesh_instance_node_3d->set_skin(mesh_3d->get_skin());
-				mesh_instance_node_3d->set_skeleton_path(mesh_3d->get_skeleton_path());
+				mesh_instance_node_3d->set_skin(importer_mesh_3d->get_skin());
+				mesh_instance_node_3d->set_skeleton_path(importer_mesh_3d->get_skeleton_path());
+				mesh_instance_node_3d->set_visible(importer_mesh_3d->is_visible());
 				node->replace_by(mesh_instance_node_3d);
 				delete_queue.push_back(node);
 				node = mesh_instance_node_3d;


### PR DESCRIPTION
Backport of PR #98874 for Godot 4.2. Due to conflicts, #98877 could not be automatically cherry-picked.

I also included the rename of `ImporterMeshInstance3D *mesh_3d` to `importer_mesh_3d` because 1) Improved readability and 2) May decrease friction in future backports to have this code similar to master.