### PR TITLE
Add vulkan error checks in command_queue_execute_and_present

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2611,7 +2611,10 @@ Error RenderingDeviceDriverVulkan::command_queue_execute_and_present(CommandQueu
 		// it'll lead to very low performance in Android by entering an endless loop where it'll always resize the swap chain
 		// every frame.
 
-		ERR_FAIL_COND_V(err != VK_SUCCESS && err != VK_SUBOPTIMAL_KHR, FAILED);
+		ERR_FAIL_COND_V_MSG(
+				err != VK_SUCCESS && err != VK_SUBOPTIMAL_KHR,
+				FAILED,
+				"QueuePresentKHR failed with error: " + get_vulkan_result(err));
 	}
 
 	return OK;
@@ -5425,6 +5428,23 @@ void RenderingDeviceDriverVulkan::print_lost_device_info() {
 	}
 #endif
 	on_device_lost();
+}
+
+inline String RenderingDeviceDriverVulkan::get_vulkan_result(VkResult err) {
+#if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
+	if (err == VK_ERROR_OUT_OF_HOST_MEMORY) {
+		return "VK_ERROR_OUT_OF_HOST_MEMORY";
+	} else if (err == VK_ERROR_OUT_OF_DEVICE_MEMORY) {
+		return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
+	} else if (err == VK_ERROR_DEVICE_LOST) {
+		return "VK_ERROR_DEVICE_LOST";
+	} else if (err == VK_ERROR_SURFACE_LOST_KHR) {
+		return "VK_ERROR_SURFACE_LOST_KHR";
+	} else if (err == VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT) {
+		return "VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT";
+	}
+#endif
+	return itos(err);
 }
 
 /********************/

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -656,6 +656,7 @@ public:
 	virtual void command_insert_breadcrumb(CommandBufferID p_cmd_buffer, uint32_t p_data) override final;
 	void print_lost_device_info();
 	void on_device_lost() const;
+	static String get_vulkan_result(VkResult err);
 
 	/********************/
 	/**** SUBMISSION ****/


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This PR adds error checks for all possible errors that can arise from `vkQueuePresentKHR`

Currently when `device_functions.QueuePresentKHR()` returns an error, the error message looks like this:
```
ERROR: Condition "err != VK_SUCCESS && err != VK_SUBOPTIMAL_KHR" is true. Returning: FAILED
   at: command_queue_execute_and_present (drivers/vulkan/rendering_device_driver_vulkan.cpp:2344)
```
According to the vulkan docs ([here](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkQueuePresentKHR.html)): vkQueuePresentKHR returns one of these error values:

    On success, this command returns:

        VK_SUCCESS
        VK_SUBOPTIMAL_KHR

    On failure, this command returns:

        VK_ERROR_OUT_OF_HOST_MEMORY
        VK_ERROR_OUT_OF_DEVICE_MEMORY
        VK_ERROR_DEVICE_LOST
        VK_ERROR_OUT_OF_DATE_KHR
        VK_ERROR_SURFACE_LOST_KHR
        VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT

Note: VK_ERROR_OUT_OF_DATE_KHR is already handled in command_queue_execute_and_present.
So the error has to be one of these:

    VK_ERROR_OUT_OF_HOST_MEMORY
    VK_ERROR_OUT_OF_DEVICE_MEMORY
    VK_ERROR_DEVICE_LOST
    VK_ERROR_SURFACE_LOST_KHR
    VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT


Unfortunately there's no way to know which error it is from the editor.
This PR ensures that the error message includes the error type to allow for further troubleshooting.
