### PR TITLE
Android: Update exported app and editor theme

### DIFF
--- a/platform/android/java/app/res/values/themes.xml
+++ b/platform/android/java/app/res/values/themes.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-	<style name="GodotAppMainTheme" parent="@android:style/Theme.Black.NoTitleBar"/>
+	<style name="GodotAppMainTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
+		<item name ="android:windowDrawsSystemBarBackgrounds">false</item>
+	</style>
 
 	<style name="GodotAppSplashTheme" parent="Theme.SplashScreen">
 		<!-- Set the splash screen background, animated icon, and animation

--- a/platform/android/java/editor/src/main/res/values/themes.xml
+++ b/platform/android/java/editor/src/main/res/values/themes.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<style name="GodotEditorTheme" parent="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+	<style name="GodotEditorTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen">
+		<item name ="android:windowDrawsSystemBarBackgrounds">false</item>
 	</style>
 
 	<style name="GodotEditorSplashScreenTheme" parent="Theme.SplashScreen.IconBackground">


### PR DESCRIPTION
- Implements and Closes godotengine/godot-proposals#11071
- Resolves https://github.com/godotengine/godot/issues/85110

This PR switches the theme for Android exported app to `Theme.DeviceDefault.NoActionBar` to better match the device’s default style. This makes the dialogs feel more consistent with the system theme, creating a smoother and more familiar experience for users.
<details><summary>Size comparission of old and new apk</summary>
<p>

![Screenshot 2024-11-06 221339](https://github.com/user-attachments/assets/93cb5594-0f8d-4c98-98a9-bd50baed6082)

</p>
</details> 

<details><summary>Before and After images of native dialogs</summary>
<p>

### Before this PR
![before](https://github.com/user-attachments/assets/6c391d80-789a-4cf2-9db5-9498d8025479)

### After this PR, tested on a Xiaomi device
![xiaomi_after](https://github.com/user-attachments/assets/cce686a6-eab1-45d3-87cb-ffee8bceb968)

### After this PR, tested on a Motorola device
![motorola_after](https://github.com/user-attachments/assets/5e570536-2adf-4b79-af22-43b797bc966a)

</p>
</details> 

### Test Apk: [demo app.zip](https://github.com/user-attachments/files/17650673/demo.app.zip)

EDIT: Now It also updates the theme for Android editor.
