### PR TITLE
[Debugger] Better settings configuration for RuntimeNodeSelect and Window quit

### DIFF
--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -147,3 +147,37 @@ bool DebuggerMarshalls::OutputError::deserialize(const Array &p_arr) {
 	CHECK_END(p_arr, idx, "OutputError");
 	return true;
 }
+
+Array DebuggerMarshalls::serialize_key_shortcut(const Ref<Shortcut> &p_shortcut) {
+	ERR_FAIL_COND_V(p_shortcut.is_null(), Array());
+	Array keys;
+	for (const Ref<InputEvent> ev : p_shortcut->get_events()) {
+		const Ref<InputEventKey> kev = ev;
+		ERR_CONTINUE(kev.is_null());
+		if (kev->get_physical_keycode() != Key::NONE) {
+			keys.push_back(true);
+			keys.push_back(kev->get_physical_keycode_with_modifiers());
+		} else {
+			keys.push_back(false);
+			keys.push_back(kev->get_keycode_with_modifiers());
+		}
+	}
+	return keys;
+}
+
+Ref<Shortcut> DebuggerMarshalls::deserialize_key_shortcut(const Array &p_keys) {
+	Array key_events;
+	ERR_FAIL_COND_V(p_keys.size() % 2 != 0, Ref<Shortcut>());
+	for (int i = 0; i < p_keys.size(); i += 2) {
+		ERR_CONTINUE(p_keys[i].get_type() != Variant::BOOL);
+		ERR_CONTINUE(p_keys[i + 1].get_type() != Variant::INT);
+		key_events.push_back(InputEventKey::create_reference((Key)p_keys[i + 1].operator int(), p_keys[i].operator bool()));
+	}
+	if (key_events.is_empty()) {
+		return Ref<Shortcut>();
+	}
+	Ref<Shortcut> shortcut;
+	shortcut.instantiate();
+	shortcut->set_events(key_events);
+	return shortcut;
+}

--- a/core/debugger/debugger_marshalls.h
+++ b/core/debugger/debugger_marshalls.h
@@ -31,6 +31,7 @@
 #ifndef DEBUGGER_MARSHALLS_H
 #define DEBUGGER_MARSHALLS_H
 
+#include "core/input/shortcut.h"
 #include "core/object/script_language.h"
 
 struct DebuggerMarshalls {
@@ -68,6 +69,9 @@ struct DebuggerMarshalls {
 		Array serialize();
 		bool deserialize(const Array &p_arr);
 	};
+
+	static Array serialize_key_shortcut(const Ref<Shortcut> &p_shortcut);
+	static Ref<Shortcut> deserialize_key_shortcut(const Array &p_keys);
 };
 
 #endif // DEBUGGER_MARSHALLS_H

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1033,6 +1033,9 @@ void ScriptEditorDebugger::start(Ref<RemoteDebuggerPeer> p_peer) {
 	_update_buttons_state();
 	emit_signal(SNAME("started"));
 
+	Array quit_keys = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("editor/stop_running_project"));
+	_put_msg("scene:setup_scene", quit_keys);
+
 	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false)) {
 		profiler->set_profiling(true);
 	}

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -223,11 +223,6 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		args.push_back(p_scene);
 	}
 
-	// Pass the debugger stop shortcut to the running instance(s).
-	String shortcut;
-	VariantWriter::write_to_string(ED_GET_SHORTCUT("editor/stop_running_project"), shortcut);
-	OS::get_singleton()->set_environment("__GODOT_EDITOR_STOP_SHORTCUT__", shortcut);
-
 	String exec = OS::get_singleton()->get_executable_path();
 	int instance_count = RunInstancesDialog::get_singleton()->get_instance_count();
 	for (int i = 0; i < instance_count; i++) {

--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "game_view_plugin.h"
 
+#include "core/debugger/debugger_marshalls.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
@@ -40,7 +41,15 @@
 #include "scene/gui/separator.h"
 
 void GameViewDebugger::_session_started(Ref<EditorDebuggerSession> p_session) {
-	p_session->send_message("scene:runtime_node_select_setup", Array());
+	Array setup_data;
+	Dictionary settings;
+	settings["editors/panning/2d_editor_panning_scheme"] = EDITOR_GET("editors/panning/2d_editor_panning_scheme");
+	settings["editors/panning/simple_panning"] = EDITOR_GET("editors/panning/simple_panning");
+	settings["editors/panning/warped_mouse_panning"] = EDITOR_GET("editors/panning/warped_mouse_panning");
+	settings["editors/panning/2d_editor_pan_speed"] = EDITOR_GET("editors/panning/2d_editor_pan_speed");
+	settings["canvas_item_editor/pan_view"] = DebuggerMarshalls::serialize_key_shortcut(ED_GET_SHORTCUT("canvas_item_editor/pan_view"));
+	setup_data.append(settings);
+	p_session->send_message("scene:runtime_node_select_setup", setup_data);
 
 	Array type;
 	type.append(node_type);

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -57,6 +57,8 @@ public:
 
 #ifdef DEBUG_ENABLED
 private:
+	static void _handle_input(const Ref<InputEvent> &p_event, const Ref<Shortcut> &p_shortcut);
+
 	static void _save_node(ObjectID id, const String &p_path);
 	static void _set_node_owner_recursive(Node *p_node, Node *p_owner);
 	static void _set_object_property(ObjectID p_id, const String &p_property, const Variant &p_value);

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -202,6 +202,7 @@ private:
 	PopupMenu *selection_list = nullptr;
 	bool selection_visible = true;
 	bool selection_update_queued = false;
+	bool warped_panning = false;
 
 	bool camera_override = false;
 
@@ -272,7 +273,7 @@ private:
 	NodeType node_select_type = NODE_TYPE_2D;
 	SelectMode node_select_mode = SELECT_MODE_SINGLE;
 
-	void _setup();
+	void _setup(const Dictionary &p_settings);
 
 	void _node_set_type(NodeType p_type);
 	void _select_set_mode(SelectMode p_mode);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -31,10 +31,8 @@
 #include "window.h"
 
 #include "core/config/project_settings.h"
-#include "core/debugger/engine_debugger.h"
 #include "core/input/shortcut.h"
 #include "core/string/translation_server.h"
-#include "core/variant/variant_parser.h"
 #include "scene/gui/control.h"
 #include "scene/theme/theme_db.h"
 #include "scene/theme/theme_owner.h"
@@ -1631,35 +1629,6 @@ bool Window::_can_consume_input_events() const {
 
 void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	ERR_MAIN_THREAD_GUARD;
-	if (EngineDebugger::is_active()) {
-		// Quit from game window using the stop shortcut (F8 by default).
-		// The custom shortcut is provided via environment variable when running from the editor.
-		if (debugger_stop_shortcut.is_null()) {
-			String shortcut_str = OS::get_singleton()->get_environment("__GODOT_EDITOR_STOP_SHORTCUT__");
-			if (!shortcut_str.is_empty()) {
-				Variant shortcut_var;
-
-				VariantParser::StreamString ss;
-				ss.s = shortcut_str;
-
-				String errs;
-				int line;
-				VariantParser::parse(&ss, shortcut_var, errs, line);
-				debugger_stop_shortcut = shortcut_var;
-			}
-
-			if (debugger_stop_shortcut.is_null()) {
-				// Define a default shortcut if it wasn't provided or is invalid.
-				debugger_stop_shortcut.instantiate();
-				debugger_stop_shortcut->set_events({ (Variant)InputEventKey::create_reference(Key::F8) });
-			}
-		}
-
-		Ref<InputEventKey> k = p_ev;
-		if (k.is_valid() && k->is_pressed() && !k->is_echo() && debugger_stop_shortcut->matches_event(k)) {
-			EngineDebugger::get_singleton()->send_message("request_quit", Array());
-		}
-	}
 
 	if (exclusive_child != nullptr) {
 		if (!is_embedding_subwindows()) { // Not embedding, no need for event.


### PR DESCRIPTION
Supersedes #98823 .
Supersedes #92516

- Move quit shortcut hack introduced in #47744 to the debugger.
- Respect editor settings for panning at runtime.

Draft status:
- ~Like #98823 and #47744 this allows unchecked code execution~ Fixed by only serializing the key/physical key.
- ~Might deserve some general SceneDebugger/ScriptEditorDebugger refactoring to properly use EditorDebuggerPlugins.~ Better done in its own PR.