### PR TITLE
Warn on unknown command line arguments (reverted)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1801,6 +1801,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "--" || arg == "++") {
 			adding_user_args = true;
 		} else {
+			if (!FileAccess::exists(arg) && !DirAccess::exists(arg)) {
+				// Warn if the argument isn't recognized by Godot *and* the file/folder
+				// specified by a positional argument doesn't exist.
+				// This allows projects to read file or folder paths as a positional argument
+				// without printing a warning, as this scenario can't make use of user command line arguments.
+				WARN_PRINT(vformat("Unknown command line argument \"%s\". User arguments should be passed after a -- or ++ separator, e.g. \"-- %s\".", arg, arg));
+			}
 			main_args.push_back(arg);
 		}
 


### PR DESCRIPTION
This eases troubleshooting when working with command line arguments.

Warnings are only printed if the argument does not exist as a file or directory path (relative or absolute). This allows positional arguments to keep working as they are now, without printing warnings when a project reads positional arguments to perform operations on files (e.g. when drag-and-dropping a file onto a project executable).

This now prints a warning:

    godot --non-existent-argument

This still doesn't print a warning, as it's an user argument (projects can check for invalid arguments on their own):

    godot -- --non-existent-argument

This doesn't print a warning if the file/folder path exists:

    godot /path/to/file.txt

A warning is still printed if the file/folder doesn't exist. Drag-and-drop associations always refer to existing files/folders, so that scenario was unlikely to be encountered.

- This closes https://github.com/godotengine/godot-proposals/issues/10789.
