### PR TITLE
Add `--run` command line argument to run a project when pointing to `project.godot`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -514,6 +514,7 @@ void Main::print_help(const char *p_binary) {
 #ifdef TOOLS_ENABLED
 	print_help_option("-e, --editor", "Start the editor instead of running the scene.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("-p, --project-manager", "Start the project manager, even if a project is auto-detected.\n", CLI_OPTION_AVAILABILITY_EDITOR);
+	print_help_option("-r, --run", "Run the scene instead of starting the editor when pointing to a \"project.godot\" file.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--recovery-mode", "Start the editor in recovery mode, which disables features that can typically cause startup crashes, such as tool scripts, editor plugins, GDExtension addons, and others.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--debug-server <uri>", "Start the editor debug server (<protocol>://<host/IP>[:port], e.g. tcp://127.0.0.1:6007)\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--dap-port <port>", "Use the specified port for the GDScript Debugger Adaptor protocol. Recommended port range [1024, 49151].\n", CLI_OPTION_AVAILABILITY_EDITOR);
@@ -1401,6 +1402,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			project_manager = true;
 		} else if (arg == "--recovery-mode") { // Enables recovery mode.
 			recovery_mode = true;
+		} else if (arg == "-r" || arg == "--run") {
+			// Runs the main scene, even if the editor would be started when pointing to a `.godot` file.
+			editor = false;
 		} else if (arg == "--debug-server") {
 			if (N) {
 				debug_server_uri = N->get();


### PR DESCRIPTION
This allows running the project directly without having to edit the rest of the command line.
I've had to juggle a lot with the command line over the years, so hopefully this will allow us to spare our <kbd>Alt + Backspace</kbd> keys a bit :slightly_smiling_face:

Previously, to run a project instead of opening it in the editor, you would have to change the following:

```bash
godot path/to/project.godot
# Or:
godot --path path/to/
```

Into:

```
godot --path path/to/
# Or:
godot --path path/to/ --editor
```

You can now do the following:

```bash
godot path/to/project.godot --run
```

It is still possible to specify a scene to run directly with this approach (scene path is relative to the project root):

    godot path/to/project.godot path/to/scene.tscn --run

When not specifying `--run`, the above command will open the scene in the editor (this also works in `master`).