### PR TITLE
Clarify `ResourceLoader.load_threaded_get_status()` completion ratio description

### DIFF
--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -104,7 +104,7 @@
 			<param index="1" name="progress" type="Array" default="[]" />
 			<description>
 				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path]. See [enum ThreadLoadStatus] for possible return values.
-				An array variable can optionally be passed via [param progress], and will return a one-element array containing the percentage of completion of the threaded loading.
+				An array variable can optionally be passed via [param progress], and will return a one-element array containing the ratio of completion of the threaded loading (between [code]0.0[/code] and [code]1.0[/code]).
 				[b]Note:[/b] The recommended way of using this method is to call it during different frames (e.g., in [method Node._process], instead of a loop).
 			</description>
 		</method>


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/108#discussioncomment-11159934.
