### PR TITLE
[Web] Ensure editor crossorigin isolation headers

### DIFF
--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -76,6 +76,7 @@ def create_template_zip(env, js, wasm, worker, side):
             "___GODOT_OPT_CACHE___": json.dumps(opt_cache),
             "___GODOT_OFFLINE_PAGE___": "offline.html",
             "___GODOT_THREADS_ENABLED___": "true" if env["threads"] else "false",
+            "___GODOT_ENSURE_CROSSORIGIN_ISOLATION_HEADERS___": "true",
         }
         html = env.Substfile(target="#bin/godot${PROGSUFFIX}.html", source=html, SUBST_DICT=subst_dict)
         in_files.append(html)


### PR DESCRIPTION
Follow-up to #86089.

An error prevents the registration of the service worker for the editor Web build.

<img width="1114" alt="Capture d’écran, le 2024-11-06 à 13 23 15" src="https://github.com/user-attachments/assets/72c67c85-701f-4383-ae43-279377157960">

This PR ensures that `___GODOT_ENSURE_CROSSORIGIN_ISOLATION_HEADERS___` is being replaced in the service worker for the editor build.