### PR TITLE
SCons: Bump minimum Python version to 3.8

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -129,7 +129,7 @@ jobs:
         uses: ./.github/actions/godot-deps
         with:
           # Sync with Ensure*Version in SConstruct.
-          python-version: 3.6
+          python-version: 3.8
           scons-version: 3.1.2
 
       - name: Setup GCC problem matcher

--- a/SConstruct
+++ b/SConstruct
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 EnsureSConsVersion(3, 1, 2)
-EnsurePythonVersion(3, 6)
+EnsurePythonVersion(3, 8)
 
 # System
 import atexit

--- a/core/SCsub
+++ b/core/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/config/SCsub
+++ b/core/config/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import zlib
 
 

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/debugger/SCsub
+++ b/core/debugger/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/error/SCsub
+++ b/core/error/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/extension/SCsub
+++ b/core/extension/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import zlib
 
 

--- a/core/extension/make_wrappers.py
+++ b/core/extension/make_wrappers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 proto_mod = """
 #define MODBIND$VER($RETTYPE m_name$ARG) \\
 virtual $RETVAL _##m_name($FUNCARGS) $CONST; \\

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/input/input_builders.py
+++ b/core/input/input_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 from collections import OrderedDict
 
 

--- a/core/io/SCsub
+++ b/core/io/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/math/SCsub
+++ b/core/math/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 proto = """#define GDVIRTUAL$VER($RET m_name $ARG)\\
 	StringName _gdvirtual_##m_name##_sn = #m_name;\\
 	mutable bool _gdvirtual_##m_name##_initialized = false;\\

--- a/core/os/SCsub
+++ b/core/os/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/string/SCsub
+++ b/core/string/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/templates/SCsub
+++ b/core/templates/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/core/variant/SCsub
+++ b/core/variant/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import fnmatch
 import math
@@ -7,7 +8,6 @@ import platform
 import re
 import sys
 import xml.etree.ElementTree as ET
-from typing import Dict, List, Set
 
 ################################################################################
 #                                    Config                                    #
@@ -188,7 +188,7 @@ class ClassStatus:
         self.name: str = name
         self.has_brief_description: bool = True
         self.has_description: bool = True
-        self.progresses: Dict[str, ClassStatusProgress] = {
+        self.progresses: dict[str, ClassStatusProgress] = {
             "methods": ClassStatusProgress(),
             "constants": ClassStatusProgress(),
             "members": ClassStatusProgress(),
@@ -223,8 +223,8 @@ class ClassStatus:
             sum += self.progresses[k].total
         return sum < 1
 
-    def make_output(self) -> Dict[str, str]:
-        output: Dict[str, str] = {}
+    def make_output(self) -> dict[str, str]:
+        output: dict[str, str] = {}
         output["name"] = color("name", self.name)
 
         ok_string = color("part_good", "OK")
@@ -305,8 +305,8 @@ class ClassStatus:
 #                                  Arguments                                   #
 ################################################################################
 
-input_file_list: List[str] = []
-input_class_list: List[str] = []
+input_file_list: list[str] = []
+input_class_list: list[str] = []
 merged_file: str = ""
 
 for arg in sys.argv[1:]:
@@ -381,8 +381,8 @@ if len(input_file_list) < 1 or flags["h"]:
 #                               Parse class list                               #
 ################################################################################
 
-class_names: List[str] = []
-classes: Dict[str, ET.Element] = {}
+class_names: list[str] = []
+classes: dict[str, ET.Element] = {}
 
 for file in input_file_list:
     tree = ET.parse(file)
@@ -398,7 +398,7 @@ class_names.sort()
 if len(input_class_list) < 1:
     input_class_list = ["*"]
 
-filtered_classes_set: Set[str] = set()
+filtered_classes_set: set[str] = set()
 for pattern in input_class_list:
     filtered_classes_set |= set(fnmatch.filter(class_names, pattern))
 filtered_classes = list(filtered_classes_set)
@@ -428,7 +428,7 @@ for cn in filtered_classes:
         continue
 
     out = status.make_output()
-    row: List[str] = []
+    row: list[str] = []
     for column in table_columns:
         if column in out:
             row.append(out[column])
@@ -465,7 +465,7 @@ if flags["a"]:
     # without having to scroll back to the top.
     table.append(table_column_names)
 
-table_column_sizes: List[int] = []
+table_column_sizes: list[int] = []
 for row in table:
     for cell_i, cell in enumerate(row):
         if cell_i >= len(table_column_sizes):

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # This script makes RST files from the XML class reference for use with the online docs.
+from __future__ import annotations
 
 import argparse
 import os
@@ -8,7 +9,7 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, TextIO, Tuple, Union
+from typing import Any, TextIO
 
 # Import hardcoded version information from version.py
 root_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")
@@ -88,11 +89,11 @@ BASE_STRINGS = [
     "This theme property may be changed or removed in future versions.",
     "[b]Note:[/b] The returned array is [i]copied[/i] and any changes to it will not update the original property value. See [%s] for more details.",
 ]
-strings_l10n: Dict[str, str] = {}
+strings_l10n: dict[str, str] = {}
 
-STYLES: Dict[str, str] = {}
+STYLES: dict[str, str] = {}
 
-CLASS_GROUPS: Dict[str, str] = {
+CLASS_GROUPS: dict[str, str] = {
     "global": "Globals",
     "node": "Nodes",
     "resource": "Resources",
@@ -100,21 +101,21 @@ CLASS_GROUPS: Dict[str, str] = {
     "editor": "Editor-only",
     "variant": "Variant types",
 }
-CLASS_GROUPS_BASE: Dict[str, str] = {
+CLASS_GROUPS_BASE: dict[str, str] = {
     "node": "Node",
     "resource": "Resource",
     "object": "Object",
     "variant": "Variant",
 }
 # Sync with editor\register_editor_types.cpp
-EDITOR_CLASSES: List[str] = [
+EDITOR_CLASSES: list[str] = [
     "FileSystemDock",
     "ScriptCreateDialog",
     "ScriptEditor",
     "ScriptEditorBase",
 ]
 # Sync with the types mentioned in https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_differences.html
-CLASSES_WITH_CSHARP_DIFFERENCES: List[str] = [
+CLASSES_WITH_CSHARP_DIFFERENCES: list[str] = [
     "@GlobalScope",
     "String",
     "StringName",
@@ -146,7 +147,7 @@ CLASSES_WITH_CSHARP_DIFFERENCES: List[str] = [
     "Variant",
 ]
 
-PACKED_ARRAY_TYPES: List[str] = [
+PACKED_ARRAY_TYPES: list[str] = [
     "PackedByteArray",
     "PackedColorArray",
     "PackedFloat32Array",
@@ -424,7 +425,7 @@ class State:
 
         self.current_class = ""
 
-    def parse_params(self, root: ET.Element, context: str) -> List["ParameterDef"]:
+    def parse_params(self, root: ET.Element, context: str) -> list["ParameterDef"]:
         param_elements = root.findall("param")
         params: Any = [None] * len(param_elements)
 
@@ -442,7 +443,7 @@ class State:
 
             params[index] = ParameterDef(param_name, type_name, default)
 
-        cast: List[ParameterDef] = params
+        cast: list[ParameterDef] = params
 
         return cast
 
@@ -460,7 +461,7 @@ class TagState:
 
 
 class TypeName:
-    def __init__(self, type_name: str, enum: Optional[str] = None, is_bitfield: bool = False) -> None:
+    def __init__(self, type_name: str, enum: str | None = None, is_bitfield: bool = False) -> None:
         self.type_name = type_name
         self.enum = enum
         self.is_bitfield = is_bitfield
@@ -486,8 +487,8 @@ class DefinitionBase:
     ) -> None:
         self.definition_name = definition_name
         self.name = name
-        self.deprecated: Optional[str] = None
-        self.experimental: Optional[str] = None
+        self.deprecated: str | None = None
+        self.experimental: str | None = None
 
 
 class PropertyDef(DefinitionBase):
@@ -495,11 +496,11 @@ class PropertyDef(DefinitionBase):
         self,
         name: str,
         type_name: TypeName,
-        setter: Optional[str],
-        getter: Optional[str],
-        text: Optional[str],
-        default_value: Optional[str],
-        overrides: Optional[str],
+        setter: str | None,
+        getter: str | None,
+        text: str | None,
+        default_value: str | None,
+        overrides: str | None,
     ) -> None:
         super().__init__("property", name)
 
@@ -512,7 +513,7 @@ class PropertyDef(DefinitionBase):
 
 
 class ParameterDef(DefinitionBase):
-    def __init__(self, name: str, type_name: TypeName, default_value: Optional[str]) -> None:
+    def __init__(self, name: str, type_name: TypeName, default_value: str | None) -> None:
         super().__init__("parameter", name)
 
         self.type_name = type_name
@@ -520,7 +521,7 @@ class ParameterDef(DefinitionBase):
 
 
 class SignalDef(DefinitionBase):
-    def __init__(self, name: str, parameters: List[ParameterDef], description: Optional[str]) -> None:
+    def __init__(self, name: str, parameters: list[ParameterDef], description: str | None) -> None:
         super().__init__("signal", name)
 
         self.parameters = parameters
@@ -531,9 +532,9 @@ class AnnotationDef(DefinitionBase):
     def __init__(
         self,
         name: str,
-        parameters: List[ParameterDef],
-        description: Optional[str],
-        qualifiers: Optional[str],
+        parameters: list[ParameterDef],
+        description: str | None,
+        qualifiers: str | None,
     ) -> None:
         super().__init__("annotation", name)
 
@@ -547,9 +548,9 @@ class MethodDef(DefinitionBase):
         self,
         name: str,
         return_type: TypeName,
-        parameters: List[ParameterDef],
-        description: Optional[str],
-        qualifiers: Optional[str],
+        parameters: list[ParameterDef],
+        description: str | None,
+        qualifiers: str | None,
     ) -> None:
         super().__init__("method", name)
 
@@ -560,7 +561,7 @@ class MethodDef(DefinitionBase):
 
 
 class ConstantDef(DefinitionBase):
-    def __init__(self, name: str, value: str, text: Optional[str], bitfield: bool) -> None:
+    def __init__(self, name: str, value: str, text: str | None, bitfield: bool) -> None:
         super().__init__("constant", name)
 
         self.value = value
@@ -579,7 +580,7 @@ class EnumDef(DefinitionBase):
 
 class ThemeItemDef(DefinitionBase):
     def __init__(
-        self, name: str, type_name: TypeName, data_name: str, text: Optional[str], default_value: Optional[str]
+        self, name: str, type_name: TypeName, data_name: str, text: str | None, default_value: str | None
     ) -> None:
         super().__init__("theme property", name)
 
@@ -599,17 +600,17 @@ class ClassDef(DefinitionBase):
         self.constants: OrderedDict[str, ConstantDef] = OrderedDict()
         self.enums: OrderedDict[str, EnumDef] = OrderedDict()
         self.properties: OrderedDict[str, PropertyDef] = OrderedDict()
-        self.constructors: OrderedDict[str, List[MethodDef]] = OrderedDict()
-        self.methods: OrderedDict[str, List[MethodDef]] = OrderedDict()
-        self.operators: OrderedDict[str, List[MethodDef]] = OrderedDict()
+        self.constructors: OrderedDict[str, list[MethodDef]] = OrderedDict()
+        self.methods: OrderedDict[str, list[MethodDef]] = OrderedDict()
+        self.operators: OrderedDict[str, list[MethodDef]] = OrderedDict()
         self.signals: OrderedDict[str, SignalDef] = OrderedDict()
-        self.annotations: OrderedDict[str, List[AnnotationDef]] = OrderedDict()
+        self.annotations: OrderedDict[str, list[AnnotationDef]] = OrderedDict()
         self.theme_items: OrderedDict[str, ThemeItemDef] = OrderedDict()
-        self.inherits: Optional[str] = None
-        self.brief_description: Optional[str] = None
-        self.description: Optional[str] = None
-        self.tutorials: List[Tuple[str, str]] = []
-        self.keywords: Optional[str] = None
+        self.inherits: str | None = None
+        self.brief_description: str | None = None
+        self.description: str | None = None
+        self.tutorials: list[tuple[str, str]] = []
+        self.keywords: str | None = None
 
         # Used to match the class with XML source for output filtering purposes.
         self.filepath: str = ""
@@ -655,7 +656,7 @@ class ClassDef(DefinitionBase):
 # which don't necessarily need C# examples.
 class ScriptLanguageParityCheck:
     def __init__(self) -> None:
-        self.hit_map: OrderedDict[str, List[Tuple[DefinitionBase, str]]] = OrderedDict()
+        self.hit_map: OrderedDict[str, list[tuple[DefinitionBase, str]]] = OrderedDict()
         self.hit_count = 0
 
     def add_hit(self, class_name: str, context: DefinitionBase, error: str, state: State) -> None:
@@ -746,7 +747,7 @@ def main() -> None:
 
     print("Checking for errors in the XML class reference...")
 
-    file_list: List[str] = []
+    file_list: list[str] = []
 
     for path in args.path:
         # Cut off trailing slashes so os.path.basename doesn't choke.
@@ -770,7 +771,7 @@ def main() -> None:
 
             file_list.append(path)
 
-    classes: Dict[str, Tuple[ET.Element, str]] = {}
+    classes: dict[str, tuple[ET.Element, str]] = {}
     state = State()
 
     for cur_file in file_list:
@@ -803,7 +804,7 @@ def main() -> None:
 
     print("Generating the RST class reference...")
 
-    grouped_classes: Dict[str, List[str]] = {}
+    grouped_classes: dict[str, list[str]] = {}
 
     for class_name, class_def in state.classes.items():
         if args.filter and not pattern.search(class_def.filepath):
@@ -968,7 +969,7 @@ def make_rst_class(class_def: ClassDef, state: State, dry_run: bool, output_dir:
             f.write("\n\n")
 
         # Descendants
-        inherited: List[str] = []
+        inherited: list[str] = []
         for c in state.classes.values():
             if c.inherits and c.inherits.strip() == class_name:
                 inherited.append(c.name)
@@ -1029,7 +1030,7 @@ def make_rst_class(class_def: ClassDef, state: State, dry_run: bool, output_dir:
         ### REFERENCE TABLES ###
 
         # Reused container for reference tables.
-        ml: List[Tuple[Optional[str], ...]] = []
+        ml: list[tuple[str | None, ...]] = []
 
         # Properties reference table
         if len(class_def.properties) > 0:
@@ -1563,8 +1564,8 @@ def make_enum(t: str, is_bitfield: bool, state: State) -> str:
 
 
 def make_method_signature(
-    class_def: ClassDef, definition: Union[AnnotationDef, MethodDef, SignalDef], ref_type: str, state: State
-) -> Tuple[str, str]:
+    class_def: ClassDef, definition: AnnotationDef | MethodDef | SignalDef, ref_type: str, state: State
+) -> tuple[str, str]:
     ret_type = ""
 
     if isinstance(definition, MethodDef):
@@ -1630,7 +1631,7 @@ def make_setter_signature(class_def: ClassDef, property_def: PropertyDef, state:
         setter = class_def.methods[property_def.setter][0]
     # Otherwise we fake it with the information we have available.
     else:
-        setter_params: List[ParameterDef] = []
+        setter_params: list[ParameterDef] = []
         setter_params.append(ParameterDef("value", property_def.type_name, None))
         setter = MethodDef(property_def.setter, TypeName("void"), setter_params, None, None)
 
@@ -1647,7 +1648,7 @@ def make_getter_signature(class_def: ClassDef, property_def: PropertyDef, state:
         getter = class_def.methods[property_def.getter][0]
     # Otherwise we fake it with the information we have available.
     else:
-        getter_params: List[ParameterDef] = []
+        getter_params: list[ParameterDef] = []
         getter = MethodDef(property_def.getter, property_def.type_name, getter_params, None, None)
 
     ret_type, signature = make_method_signature(class_def, getter, "", state)
@@ -1744,7 +1745,7 @@ def make_link(url: str, title: str) -> str:
     return f"`{url} <{url}>`__"
 
 
-def make_rst_index(grouped_classes: Dict[str, List[str]], dry_run: bool, output_dir: str) -> None:
+def make_rst_index(grouped_classes: dict[str, list[str]], dry_run: bool, output_dir: str) -> None:
     with open(
         os.devnull if dry_run else os.path.join(output_dir, "index.rst"), "w", encoding="utf-8", newline="\n"
     ) as f:
@@ -1807,7 +1808,7 @@ RESERVED_CROSSLINK_TAGS = [
 ]
 
 
-def is_in_tagset(tag_text: str, tagset: List[str]) -> bool:
+def is_in_tagset(tag_text: str, tagset: list[str]) -> bool:
     for tag in tagset:
         # Complete match.
         if tag_text == tag:
@@ -1849,7 +1850,7 @@ def get_tag_and_args(tag_text: str) -> TagState:
     return TagState(tag_text, tag_name, arguments, closing)
 
 
-def parse_link_target(link_target: str, state: State, context_name: str) -> List[str]:
+def parse_link_target(link_target: str, state: State, context_name: str) -> list[str]:
     if link_target.find(".") != -1:
         return link_target.split(".")
     else:
@@ -2128,7 +2129,7 @@ def format_text_block(
 
                     valid_param_context = isinstance(context, (MethodDef, SignalDef, AnnotationDef))
                     if valid_param_context:
-                        context_params: List[ParameterDef] = context.parameters  # type: ignore
+                        context_params: list[ParameterDef] = context.parameters  # type: ignore
                         for param_def in context_params:
                             if param_def.name == inside_code_text:
                                 print_warning(
@@ -2280,7 +2281,7 @@ def format_text_block(
                                 state,
                             )
                         else:
-                            context_params: List[ParameterDef] = context.parameters  # type: ignore
+                            context_params: list[ParameterDef] = context.parameters  # type: ignore
                             found = False
                             for param_def in context_params:
                                 if param_def.name == link_target:
@@ -2445,7 +2446,7 @@ def format_text_block(
     return text
 
 
-def format_context_name(context: Union[DefinitionBase, None]) -> str:
+def format_context_name(context: DefinitionBase | None) -> str:
     context_name: str = "unknown context"
     if context is not None:
         context_name = f'{context.definition_name} "{context.name}" description'
@@ -2487,9 +2488,7 @@ def escape_rst(text: str, until_pos: int = -1) -> str:
     return text
 
 
-def format_codeblock(
-    tag_state: TagState, post_text: str, indent_level: int, state: State
-) -> Union[Tuple[str, int], None]:
+def format_codeblock(tag_state: TagState, post_text: str, indent_level: int, state: State) -> tuple[str, int] | None:
     end_pos = post_text.find("[/" + tag_state.name + "]")
     if end_pos == -1:
         print_error(
@@ -2531,7 +2530,7 @@ def format_codeblock(
     return (f"\n[{opening_formatted}]{code_text}{post_text}", len(f"\n[{opening_formatted}]{code_text}"))
 
 
-def format_table(f: TextIO, data: List[Tuple[Optional[str], ...]], remove_empty_columns: bool = False) -> None:
+def format_table(f: TextIO, data: list[tuple[str | None, ...]], remove_empty_columns: bool = False) -> None:
     if len(data) == 0:
         return
 

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 from methods import print_error

--- a/drivers/alsa/SCsub
+++ b/drivers/alsa/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/alsamidi/SCsub
+++ b/drivers/alsamidi/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/backtrace/SCsub
+++ b/drivers/backtrace/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/coreaudio/SCsub
+++ b/drivers/coreaudio/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/coremidi/SCsub
+++ b/drivers/coremidi/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 import os

--- a/drivers/egl/SCsub
+++ b/drivers/egl/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/gles3/SCsub
+++ b/drivers/gles3/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/gles3/effects/SCsub
+++ b/drivers/gles3/effects/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/gles3/environment/SCsub
+++ b/drivers/gles3/environment/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/gles3/shaders/effects/SCsub
+++ b/drivers/gles3/shaders/effects/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/gles3/storage/SCsub
+++ b/drivers/gles3/storage/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/pulseaudio/SCsub
+++ b/drivers/pulseaudio/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/wasapi/SCsub
+++ b/drivers/wasapi/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/windows/SCsub
+++ b/drivers/windows/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/winmidi/SCsub
+++ b/drivers/winmidi/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/drivers/xaudio2/SCsub
+++ b/drivers/xaudio2/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/debugger/SCsub
+++ b/editor/debugger/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/debugger/debug_adapter/SCsub
+++ b/editor/debugger/debug_adapter/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os
 import os.path
 import shutil

--- a/editor/export/SCsub
+++ b/editor/export/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/gui/SCsub
+++ b/editor/gui/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/icons/editor_icons_builders.py
+++ b/editor/icons/editor_icons_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os
 from io import StringIO
 

--- a/editor/import/SCsub
+++ b/editor/import/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/plugins/SCsub
+++ b/editor/plugins/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/plugins/gizmos/SCsub
+++ b/editor/plugins/gizmos/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/plugins/tiles/SCsub
+++ b/editor/plugins/tiles/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/project_manager/SCsub
+++ b/editor/project_manager/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/template_builders.py
+++ b/editor/template_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os
 from io import StringIO
 

--- a/editor/themes/SCsub
+++ b/editor/themes/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/editor/themes/editor_theme_builders.py
+++ b/editor/themes/editor_theme_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os
 
 

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -1,7 +1,8 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os.path
-from typing import Optional
 
 from methods import print_error, to_raw_cstring
 
@@ -193,8 +194,8 @@ def build_gles3_header(
     filename: str,
     include: str,
     class_suffix: str,
-    optional_output_filename: Optional[str] = None,
-    header_data: Optional[GLES3HeaderStruct] = None,
+    optional_output_filename: str | None = None,
+    header_data: GLES3HeaderStruct | None = None,
 ):
     header_data = header_data or GLES3HeaderStruct()
     include_file_in_gles3_header(filename, header_data, 0)

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -1,7 +1,8 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os.path
-from typing import Optional
 
 from methods import print_error, to_raw_cstring
 
@@ -93,7 +94,7 @@ def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth:
 
 
 def build_rd_header(
-    filename: str, optional_output_filename: Optional[str] = None, header_data: Optional[RDHeaderStruct] = None
+    filename: str, optional_output_filename: str | None = None, header_data: RDHeaderStruct | None = None
 ) -> None:
     header_data = header_data or RDHeaderStruct()
     include_file_in_rd_header(filename, header_data, 0)
@@ -175,7 +176,7 @@ def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, dept
 
 
 def build_raw_header(
-    filename: str, optional_output_filename: Optional[str] = None, header_data: Optional[RAWHeaderStruct] = None
+    filename: str, optional_output_filename: str | None = None, header_data: RAWHeaderStruct | None = None
 ):
     header_data = header_data or RAWHeaderStruct()
     include_file_in_raw_header(filename, header_data, 0)

--- a/main/SCsub
+++ b/main/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 
 def make_splash(target, source, env):
     src = str(source[0])

--- a/methods.py
+++ b/methods.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import glob
 import os
@@ -5,10 +7,10 @@ import re
 import subprocess
 import sys
 from collections import OrderedDict
+from collections.abc import Generator
 from enum import Enum
 from io import StringIO, TextIOWrapper
 from pathlib import Path
-from typing import Generator, List, Optional, Union
 
 # Get the "Godot" folder name ahead of time
 base_folder_path = str(os.path.abspath(Path(__file__).parent)) + "/"
@@ -1515,7 +1517,7 @@ def generate_copyright_header(filename: str) -> str:
 @contextlib.contextmanager
 def generated_wrapper(
     path,  # FIXME: type with `Union[str, Node, List[Node]]` when pytest conflicts are resolved
-    guard: Optional[bool] = None,
+    guard: bool | None = None,
     prefix: str = "",
     suffix: str = "",
 ) -> Generator[TextIOWrapper, None, None]:
@@ -1582,13 +1584,13 @@ def generated_wrapper(
         file.write("\n")
 
 
-def to_raw_cstring(value: Union[str, List[str]]) -> str:
+def to_raw_cstring(value: str | list[str]) -> str:
     MAX_LITERAL = 16 * 1024
 
     if isinstance(value, list):
         value = "\n".join(value) + "\n"
 
-    split: List[bytes] = []
+    split: list[bytes] = []
     offset = 0
     encoded = value.encode()
 

--- a/misc/scripts/check_ci_log.py
+++ b/misc/scripts/check_ci_log.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import sys
 

--- a/misc/scripts/copyright_headers.py
+++ b/misc/scripts/copyright_headers.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import os
 import sys

--- a/misc/scripts/dotnet_format.py
+++ b/misc/scripts/dotnet_format.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import glob
 import os

--- a/misc/scripts/file_format.py
+++ b/misc/scripts/file_format.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import sys
 

--- a/misc/scripts/header_guards.py
+++ b/misc/scripts/header_guards.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import sys
 from pathlib import Path

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import annotations
 
 import os
 import shutil

--- a/misc/utility/godot_gdb_pretty_print.py
+++ b/misc/utility/godot_gdb_pretty_print.py
@@ -22,6 +22,8 @@ and acquire a `Value` object using `gdb.selected_frame().read_var("variable name
 From there you can figure out how to print it nicely.
 """
 
+from __future__ import annotations
+
 import re
 
 import gdb  # type: ignore

--- a/misc/utility/scons_hints.py
+++ b/misc/utility/scons_hints.py
@@ -7,6 +7,8 @@ SCons build, as proxies are almost always utilized instead. Rather, this is
 a means of tracing back what those proxies are calling to in the first place.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 import os

--- a/modules/astcenc/SCsub
+++ b/modules/astcenc/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/astcenc/config.py
+++ b/modules/astcenc/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     # Godot only uses it in the editor, but ANGLE depends on it and we had
     # to remove the copy from prebuilt ANGLE libs to solve symbol clashes.

--- a/modules/basis_universal/SCsub
+++ b/modules/basis_universal/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/basis_universal/config.py
+++ b/modules/basis_universal/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     env.module_add_dependencies("basis_universal", ["jpg"])
     return True

--- a/modules/bcdec/SCsub
+++ b/modules/bcdec/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/bcdec/config.py
+++ b/modules/bcdec/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/betsy/SCsub
+++ b/modules/betsy/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/betsy/config.py
+++ b/modules/betsy/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return env.editor_build
 

--- a/modules/bmp/SCsub
+++ b/modules/bmp/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/bmp/config.py
+++ b/modules/bmp/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/camera/SCsub
+++ b/modules/camera/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/camera/config.py
+++ b/modules/camera/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return platform == "macos" or platform == "windows" or platform == "linuxbsd"
 

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/csg/config.py
+++ b/modules/csg/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return not env["disable_3d"]
 

--- a/modules/cvtt/SCsub
+++ b/modules/cvtt/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/cvtt/config.py
+++ b/modules/cvtt/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return env.editor_build
 

--- a/modules/dds/SCsub
+++ b/modules/dds/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/dds/config.py
+++ b/modules/dds/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/enet/config.py
+++ b/modules/enet/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/etcpak/SCsub
+++ b/modules/etcpak/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/etcpak/config.py
+++ b/modules/etcpak/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return env.editor_build
 

--- a/modules/fbx/SCsub
+++ b/modules/fbx/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/fbx/config.py
+++ b/modules/fbx/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     env.module_add_dependencies("fbx", ["gltf"])
     return not env["disable_3d"]

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/freetype/config.py
+++ b/modules/freetype/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/gdscript/config.py
+++ b/modules/gdscript/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     env.module_add_dependencies("gdscript", ["jsonrpc", "websocket"], True)
     return True

--- a/modules/gdscript/editor/script_templates/SCsub
+++ b/modules/gdscript/editor/script_templates/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/glslang/SCsub
+++ b/modules/glslang/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/glslang/config.py
+++ b/modules/glslang/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     # glslang is only needed when Vulkan, Direct3D 12 or Metal-based renderers are available,
     # as OpenGL doesn't use glslang.

--- a/modules/gltf/SCsub
+++ b/modules/gltf/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/gltf/config.py
+++ b/modules/gltf/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return not env["disable_3d"]
 

--- a/modules/gltf/extensions/SCsub
+++ b/modules/gltf/extensions/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/godot_physics_2d/SCsub
+++ b/modules/godot_physics_2d/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/godot_physics_2d/config.py
+++ b/modules/godot_physics_2d/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/godot_physics_3d/SCsub
+++ b/modules/godot_physics_3d/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/godot_physics_3d/config.py
+++ b/modules/godot_physics_3d/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return not env["disable_3d"]
 

--- a/modules/godot_physics_3d/joints/SCsub
+++ b/modules/godot_physics_3d/joints/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/gridmap/config.py
+++ b/modules/gridmap/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return not env["disable_3d"]
 

--- a/modules/hdr/SCsub
+++ b/modules/hdr/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/hdr/config.py
+++ b/modules/hdr/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/interactive_music/SCsub
+++ b/modules/interactive_music/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/interactive_music/config.py
+++ b/modules/interactive_music/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/jpg/config.py
+++ b/modules/jpg/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/jsonrpc/SCsub
+++ b/modules/jsonrpc/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/jsonrpc/config.py
+++ b/modules/jsonrpc/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/ktx/SCsub
+++ b/modules/ktx/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/ktx/config.py
+++ b/modules/ktx/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     env.module_add_dependencies("ktx", ["basis_universal"])
     return True

--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/lightmapper_rd/config.py
+++ b/modules/lightmapper_rd/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return env.editor_build and platform not in ["android", "ios"]
 

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/mbedtls/config.py
+++ b/modules/mbedtls/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/meshoptimizer/SCsub
+++ b/modules/meshoptimizer/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/meshoptimizer/config.py
+++ b/modules/meshoptimizer/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     # Having this on release by default, it's small and a lot of users like to do procedural stuff
     return not env["disable_3d"]

--- a/modules/minimp3/SCsub
+++ b/modules/minimp3/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/minimp3/config.py
+++ b/modules/minimp3/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/mobile_vr/SCsub
+++ b/modules/mobile_vr/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/mobile_vr/config.py
+++ b/modules/mobile_vr/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return not env["disable_3d"]
 

--- a/modules/mono/SCsub
+++ b/modules/mono/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 import build_scripts.mono_configure as mono_configure

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python3
+from __future__ import annotations
 
 import os
 import os.path
 import shlex
 import subprocess
 from dataclasses import dataclass
-from typing import List, Optional
 
 
 def find_dotnet_cli():
@@ -151,7 +151,7 @@ def find_any_msbuild_tool(mono_prefix):
     return None
 
 
-def run_msbuild(tools: ToolsLocation, sln: str, chdir_to: str, msbuild_args: Optional[List[str]] = None):
+def run_msbuild(tools: ToolsLocation, sln: str, chdir_to: str, msbuild_args: list[str] | None = None):
     using_msbuild_mono = False
 
     # Preference order: dotnet CLI > Standalone MSBuild > Mono's MSBuild

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def is_desktop(platform):
     return platform in ["windows", "macos", "linuxbsd"]
 

--- a/modules/mono/config.py
+++ b/modules/mono/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     if env["arch"].startswith("rv"):
         return False

--- a/modules/mono/editor/script_templates/SCsub
+++ b/modules/mono/editor/script_templates/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/msdfgen/SCsub
+++ b/modules/msdfgen/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/msdfgen/config.py
+++ b/modules/msdfgen/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     env.module_add_dependencies("msdfgen", ["freetype"])
     return True

--- a/modules/multiplayer/SCsub
+++ b/modules/multiplayer/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/multiplayer/config.py
+++ b/modules/multiplayer/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/navigation/SCsub
+++ b/modules/navigation/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/navigation/config.py
+++ b/modules/navigation/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return not env["disable_3d"]
 

--- a/modules/noise/SCsub
+++ b/modules/noise/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/noise/config.py
+++ b/modules/noise/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/ogg/SCsub
+++ b/modules/ogg/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/ogg/config.py
+++ b/modules/ogg/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/openxr/action_map/SCsub
+++ b/modules/openxr/action_map/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/openxr/config.py
+++ b/modules/openxr/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     if platform in ("linuxbsd", "windows", "android", "macos"):
         return env["openxr"] and not env["disable_3d"]

--- a/modules/openxr/editor/SCsub
+++ b/modules/openxr/editor/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/openxr/extensions/SCsub
+++ b/modules/openxr/extensions/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/openxr/scene/SCsub
+++ b/modules/openxr/scene/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     # Supported architectures and platforms depend on the Embree library.
     if env["arch"] == "arm64" and platform == "windows" and env.msvc:

--- a/modules/raycast/godot_update_embree.py
+++ b/modules/raycast/godot_update_embree.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 import os
 import re
@@ -5,7 +7,8 @@ import shutil
 import stat
 import subprocess
 import sys
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 git_tag = "v4.3.1"
 

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/regex/config.py
+++ b/modules/regex/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/svg/config.py
+++ b/modules/svg/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/text_server_adv/config.py
+++ b/modules/text_server_adv/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 import atexit

--- a/modules/text_server_adv/gdextension_build/methods.py
+++ b/modules/text_server_adv/gdextension_build/methods.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from enum import Enum

--- a/modules/text_server_fb/SCsub
+++ b/modules/text_server_fb/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/text_server_fb/config.py
+++ b/modules/text_server_fb/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 import atexit

--- a/modules/text_server_fb/gdextension_build/methods.py
+++ b/modules/text_server_fb/gdextension_build/methods.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from enum import Enum

--- a/modules/tga/SCsub
+++ b/modules/tga/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/tga/config.py
+++ b/modules/tga/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/theora/config.py
+++ b/modules/theora/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     if env["arch"].startswith("rv"):
         return False

--- a/modules/tinyexr/SCsub
+++ b/modules/tinyexr/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/tinyexr/config.py
+++ b/modules/tinyexr/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return env.editor_build
 

--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/upnp/config.py
+++ b/modules/upnp/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/vhacd/SCsub
+++ b/modules/vhacd/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/vhacd/config.py
+++ b/modules/vhacd/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return not env["disable_3d"]
 

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/vorbis/config.py
+++ b/modules/vorbis/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     env.module_add_dependencies("vorbis", ["ogg"])
     return True

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/webp/config.py
+++ b/modules/webp/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/webrtc/SCsub
+++ b/modules/webrtc/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/webrtc/config.py
+++ b/modules/webrtc/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/websocket/config.py
+++ b/modules/websocket/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return True
 

--- a/modules/webxr/SCsub
+++ b/modules/webxr/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/webxr/config.py
+++ b/modules/webxr/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return env["opengl3"] and not env["disable_3d"]
 

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/xatlas_unwrap/config.py
+++ b/modules/xatlas_unwrap/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return env.editor_build and platform not in ["android", "ios"]
 

--- a/modules/zip/SCsub
+++ b/modules/zip/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/modules/zip/config.py
+++ b/modules/zip/config.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def can_build(env, platform):
     return env["minizip"]
 

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 from glob import glob

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 import subprocess

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 import subprocess
@@ -53,7 +55,7 @@ def get_min_sdk_version(platform):
     return int(platform.split("-")[1])
 
 
-def get_android_ndk_root(env: "SConsEnvironment"):
+def get_android_ndk_root(env: SConsEnvironment):
     return env["ANDROID_HOME"] + "/ndk/" + get_ndk_version()
 
 
@@ -77,7 +79,7 @@ def get_flags():
 
 # Check if Android NDK version is installed
 # If not, install it.
-def install_ndk_if_needed(env: "SConsEnvironment"):
+def install_ndk_if_needed(env: SConsEnvironment):
     sdk_root = env["ANDROID_HOME"]
     if not os.path.exists(get_android_ndk_root(env)):
         extension = ".bat" if os.name == "nt" else ""
@@ -105,7 +107,7 @@ def detect_swappy():
     return has_swappy
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -58,7 +60,7 @@ def get_flags():
     }
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 import sys
@@ -71,7 +73,7 @@ def get_flags():
     }
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/linuxbsd/platform_linuxbsd_builders.py
+++ b/platform/linuxbsd/platform_linuxbsd_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os
 
 

--- a/platform/linuxbsd/wayland/SCsub
+++ b/platform/linuxbsd/wayland/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/platform/linuxbsd/x11/SCsub
+++ b/platform/linuxbsd/x11/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")
@@ -27,7 +29,9 @@ def generate_bundle(target, source, env):
         target_bin = lipo(bin_dir + "/" + prefix, env.extra_suffix + env.module_version_string)
 
         # Assemble .app bundle and update version info.
-        app_dir = Dir("#bin/" + (prefix + env.extra_suffix + env.module_version_string).replace(".", "_") + ".app").abspath
+        app_dir = Dir(
+            "#bin/" + (prefix + env.extra_suffix + env.module_version_string).replace(".", "_") + ".app"
+        ).abspath
         templ = Dir("#misc/dist/macos_tools.app").abspath
         if os.path.exists(app_dir):
             shutil.rmtree(app_dir)

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -65,7 +67,7 @@ def get_flags():
     }
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/macos/platform_macos_builders.py
+++ b/platform/macos/platform_macos_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os
 
 

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 from methods import print_error

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from typing import TYPE_CHECKING
@@ -84,7 +86,7 @@ def get_flags():
     }
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["wasm32"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 

--- a/platform/web/serve.py
+++ b/platform/web/serve.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import argparse
 import contextlib

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import subprocess
@@ -245,7 +247,7 @@ def get_flags():
     }
 
 
-def setup_msvc_manual(env: "SConsEnvironment"):
+def setup_msvc_manual(env: SConsEnvironment):
     """Running from VCVARS environment"""
 
     env_arch = detect_build_env_arch()
@@ -260,7 +262,7 @@ def setup_msvc_manual(env: "SConsEnvironment"):
     print("Using VCVARS-determined MSVC, arch %s" % (env_arch))
 
 
-def setup_msvc_auto(env: "SConsEnvironment"):
+def setup_msvc_auto(env: SConsEnvironment):
     """Set up MSVC using SCons's auto-detection logic"""
 
     # If MSVC_VERSION is set by SCons, we know MSVC is installed.
@@ -302,7 +304,7 @@ def setup_msvc_auto(env: "SConsEnvironment"):
     print("Using SCons-detected MSVC version %s, arch %s" % (env["MSVC_VERSION"], env["arch"]))
 
 
-def setup_mingw(env: "SConsEnvironment"):
+def setup_mingw(env: SConsEnvironment):
     """Set up env for use with mingw"""
 
     env_arch = detect_build_env_arch()
@@ -333,7 +335,7 @@ def setup_mingw(env: "SConsEnvironment"):
     print("Using MinGW, arch %s" % (env["arch"]))
 
 
-def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
+def configure_msvc(env: SConsEnvironment, vcvars_msvc_config):
     """Configure env to work with MSVC"""
 
     ## Build type
@@ -670,7 +672,7 @@ def tempfile_arg_esc_func(arg):
     return WINPATHSEP_RE.sub(r"/\1", arg)
 
 
-def configure_mingw(env: "SConsEnvironment"):
+def configure_mingw(env: SConsEnvironment):
     # Workaround for MinGW. See:
     # https://www.scons.org/wiki/LongCmdLinesOnWin32
     env.use_windows_spawn_fix()
@@ -900,7 +902,7 @@ def configure_mingw(env: "SConsEnvironment"):
     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/windows/msvs.py
+++ b/platform/windows/msvs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import methods
 
 

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os
 
 

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import platform
 import subprocess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,27 +1,30 @@
 [tool.mypy]
-ignore_missing_imports = true
 disallow_any_generics = true
+explicit_package_bases = true
+ignore_missing_imports = true
+namespace_packages = true
 no_implicit_optional = true
 pretty = true
 show_column_numbers = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true
-namespace_packages = true
-explicit_package_bases = true
 exclude = ["thirdparty/"]
 python_version = "3.8"
 
 [tool.ruff]
-extend-exclude = ["thirdparty"]
+extend-exclude = ["thirdparty", "version.py"]
 extend-include = ["SConstruct", "SCsub"]
 line-length = 120
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.lint]
 extend-select = [
-	"I", # isort
+	"I",     # isort
+	"UP006", # Use {to} instead of {from} for type annotation
+	"UP007", # Use `X | Y` for type annotations
 ]
+extend-safe-fixes = ["UP006", "UP007"]
 
 [tool.ruff.lint.per-file-ignores]
 "{SConstruct,SCsub}" = [
@@ -31,6 +34,7 @@ extend-select = [
 ]
 
 [tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
 sections = { metadata = ["misc.utility.scons_hints"] }
 section-order = [
 	"future",

--- a/scene/2d/SCsub
+++ b/scene/2d/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/2d/physics/SCsub
+++ b/scene/2d/physics/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/2d/physics/joints/SCsub
+++ b/scene/2d/physics/joints/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/3d/physics/SCsub
+++ b/scene/3d/physics/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/3d/physics/joints/SCsub
+++ b/scene/3d/physics/joints/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/animation/SCsub
+++ b/scene/animation/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/audio/SCsub
+++ b/scene/audio/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/debugger/SCsub
+++ b/scene/debugger/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/gui/SCsub
+++ b/scene/gui/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/main/SCsub
+++ b/scene/main/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/resources/2d/SCsub
+++ b/scene/resources/2d/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/resources/3d/SCsub
+++ b/scene/resources/3d/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/theme/SCsub
+++ b/scene/theme/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/theme/default_theme_builders.py
+++ b/scene/theme/default_theme_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os
 import os.path
 

--- a/scene/theme/icons/SCsub
+++ b/scene/theme/icons/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/scene/theme/icons/default_theme_icons_builders.py
+++ b/scene/theme/icons/default_theme_icons_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate source files during build time"""
 
+from __future__ import annotations
+
 import os
 from io import StringIO
 

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -1,5 +1,7 @@
 """Functions used to generate scu build source files during build time"""
 
+from __future__ import annotations
+
 import glob
 import math
 import os

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/audio/SCsub
+++ b/servers/audio/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/audio/effects/SCsub
+++ b/servers/audio/effects/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/camera/SCsub
+++ b/servers/camera/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/debugger/SCsub
+++ b/servers/debugger/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/display/SCsub
+++ b/servers/display/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/extensions/SCsub
+++ b/servers/extensions/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/movie_writer/SCsub
+++ b/servers/movie_writer/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/navigation/SCsub
+++ b/servers/navigation/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/SCsub
+++ b/servers/rendering/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/dummy/SCsub
+++ b/servers/rendering/dummy/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/dummy/storage/SCsub
+++ b/servers/rendering/dummy/storage/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/SCsub
+++ b/servers/rendering/renderer_rd/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/effects/SCsub
+++ b/servers/rendering/renderer_rd/effects/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/environment/SCsub
+++ b/servers/rendering/renderer_rd/environment/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/forward_clustered/SCsub
+++ b/servers/rendering/renderer_rd/forward_clustered/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/forward_mobile/SCsub
+++ b/servers/rendering/renderer_rd/forward_mobile/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/shaders/SCsub
+++ b/servers/rendering/renderer_rd/shaders/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/shaders/effects/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/shaders/environment/SCsub
+++ b/servers/rendering/renderer_rd/shaders/environment/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/spirv-reflect/SCsub
+++ b/servers/rendering/renderer_rd/spirv-reflect/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/renderer_rd/storage_rd/SCsub
+++ b/servers/rendering/renderer_rd/storage_rd/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/rendering/storage/SCsub
+++ b/servers/rendering/storage/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/text/SCsub
+++ b/servers/text/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/servers/xr/SCsub
+++ b/servers/xr/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/tests/SCsub
+++ b/tests/SCsub
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 from misc.utility.scons_hints import *
 
 Import("env")

--- a/tests/create_test.py
+++ b/tests/create_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import argparse
 import os

--- a/tests/python_build/conftest.py
+++ b/tests/python_build/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from pathlib import Path

--- a/tests/python_build/test_gles3_builder.py
+++ b/tests/python_build/test_gles3_builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import pytest

--- a/tests/python_build/test_glsl_builder.py
+++ b/tests/python_build/test_glsl_builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import pytest


### PR DESCRIPTION
As briefly touched on in a PR bumping GHA's Ubuntu version from 20.04[^1], Python 3.6 is no longer included in those future Ubuntu builds. While it's somewhat arbitrary on which version should be used for a prospective upgrade, let alone if one should happen at all, 3.8 was proposed and that feels like the safest bet to me. Both 3.6 and 3.8 are EOL, but only relatively recently for 3.8; this *should* still cover our bases for all supported platform baselines.

3.7/3.8 bring quite a lot of QOL goodies, such as assignment operators[^2] and f-string self-documentation[^3]. But by far the biggest addition comes with `from __future__ import annotations`, which make several issues relating to type-hints more streamlined. This even includes syntax additions that would otherwise require 3.9 or 3.10, such as:
- `Optional[str]` becomes `str | None`
- `Union[str, int]` becomes `str | int`
- `List[str]` becomes `list[str]` (and all other "simple" container types that required import before)

As such, I've added to `pyproject.toml` the above as a required import—a relatively common practice on modern python repos. This *does* make for a LOT of files changed, but 99% of that is just an extra import for python files. Anything beyond that was updating type-hints to utilize modern syntax. **No functional changes** were made in this PR.

[^1]: https://github.com/godotengine/godot/pull/98898#issuecomment-2460153094
[^2]: https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions
[^3]: https://docs.python.org/3/whatsnew/3.8.html#f-strings-support-for-self-documenting-expressions-and-debugging