### PR TITLE
Force `RDD::id` to be always `uint64_t`

### DIFF
--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -120,9 +120,9 @@ struct VersatileResourceTemplate {
 class RenderingDeviceDriver : public RenderingDeviceCommons {
 public:
 	struct ID {
-		size_t id = 0;
+		uint64_t id = 0;
 		_ALWAYS_INLINE_ ID() = default;
-		_ALWAYS_INLINE_ ID(size_t p_id) :
+		_ALWAYS_INLINE_ ID(uint64_t p_id) :
 				id(p_id) {}
 	};
 
@@ -138,11 +138,9 @@ public:
 		_ALWAYS_INLINE_ bool operator!=(const m_name##ID &p_other) const { return id != p_other.id; } \
 		_ALWAYS_INLINE_ m_name##ID(const m_name##ID &p_other) : ID(p_other.id) {}                     \
 		_ALWAYS_INLINE_ explicit m_name##ID(uint64_t p_int) : ID(p_int) {}                            \
-		_ALWAYS_INLINE_ explicit m_name##ID(void *p_ptr) : ID((size_t)p_ptr) {}                       \
+		_ALWAYS_INLINE_ explicit m_name##ID(void *p_ptr) : ID((uint64_t)p_ptr) {}                     \
 		_ALWAYS_INLINE_ m_name##ID() = default;                                                       \
-	};                                                                                                \
-	/* Ensure type-punnable to pointer. Makes some things easier.*/                                   \
-	static_assert(sizeof(m_name##ID) == sizeof(void *));
+	};
 
 	// Id types declared before anything else to prevent cyclic dependencies between the different concerns.
 	DEFINE_ID(Buffer);


### PR DESCRIPTION
On Vulkan, some handles are meant to always be u64, even on 32-bit architectures such as arm32.

Fixes #98654

# Testing methodology

Testing this is hard, because most platforms Godot is meant to be run on are already 64-bit.
Effectively this only affects arm32.

My particular worry is what if at some point Godot does the following? (or similar)

```cpp
void * ptr = (void *)buffer.id; // Ooops! This is downgraded from 64 to 32 bit
buffer.id = (size_t)ptr;
```

More bizarre stuff such as memcpy could be happening.

To check for this very particular scenario I was afraid of, I devised a much larger patch I'm including here:

[arch32_test.patch.zip](https://github.com/user-attachments/files/17653996/arch32_test.patch.zip)

Which changes RenderingDeviceDriver::id to private and is a RenderingDeviceDriver::id[3]; where I store the value in id[1].

This way, if Godot were to make such horrible type punning (or other dangerous raw manipulation), the value would be lost even on an x64 machine.

I tested this patch, and Godot ran fine. I tested 3 different projects, but not thoroughly.

So far this change appears to be harmless. But I can never be 100% certain. Type punning Vulkan & D3D12 handles as RenderingDeviceDriver::id was not the best idea to begin with. But it is what we have.

Hopefully CI will agree.