### PR TITLE
Android: Fix immersive mode issue

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -745,6 +745,7 @@ class Godot(private val context: Context) {
 
 		runOnUiThread {
 			registerSensorsIfNeeded()
+			enableImmersiveMode(useImmersive.get(), true)
 		}
 
 		for (plugin in pluginRegistry.allPlugins) {


### PR DESCRIPTION
- Fixes #97351 

This PR resolves this issue, but the exact cause remains unclear. Interestingly, this issue only seems to occur on older Android versions; so far, it’s reproducible on Android 10 and 11 but not on Android 14.

The issue is likely due to Android 10 and 11 handling immersive mode differently than Android 14. On these versions, the initial immersive mode activation may not fully take effect due to timing or UI initialization quirks, causing the system bars to reappear on the first screen touch. 

This PR solves this issue by re-enabling the immersive mode `onGodotMainLoopStarted()`

Test apk ARM64: [Demo app.zip](https://github.com/user-attachments/files/17662098/Demo.app.zip)

Test apk ARM32: [demo app (arm32).zip](https://github.com/user-attachments/files/17676691/demo.app.arm32.zip)


