### PR TITLE
Raise the number of file handles on Windows

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -525,6 +525,9 @@ void FileAccessWindows::initialize() {
 		invalid_files.insert(reserved_files[reserved_file_index]);
 		reserved_file_index++;
 	}
+
+	_setmaxstdio(8192);
+	print_verbose(vformat("Maximum number of file handles: %d", _getmaxstdio()));
 }
 
 void FileAccessWindows::finalize() {


### PR DESCRIPTION
This raises the number to the maximum value according to the docs, which is 8192. The default is 512.

This should avoid many file access errors that happen in big projects during heavy operations dealing with many resources.

A better fix woul be to rewrite `FileAccessWindows` so it uses the Win32 API directly. However, this already brings value.

I think both MSVC and MinGW support this. MSVC does for sure. Let's see what CI thinks about MinGW.