### PR TITLE
[3.6] CI: Update Ubuntu runners to 24.04, but keep 22.04 for Linux builds

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -14,18 +14,11 @@ concurrency:
 
 jobs:
   android-template:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     name: Template (target=release, tools=no)
 
     steps:
       - uses: actions/checkout@v4
-
-      # Azure repositories are not reliable, we need to prevent azure giving us packages.
-      - name: Make apt sources.list use the default Ubuntu repositories
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
-          sudo apt-get update
 
       - name: Set up Java 17
         uses: actions/setup-java@v4

--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   javascript-template:
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
     name: Template (target=release, tools=no)
 
     steps:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -14,7 +14,8 @@ concurrency:
 
 jobs:
   build-linux:
-    runs-on: "ubuntu-20.04"
+    # Stay one LTS before latest to increase portability of Linux artifacts.
+    runs-on: "ubuntu-22.04"
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -62,14 +63,13 @@ jobs:
       - name: Linux dependencies
         shell: bash
         run: |
-          # Azure repositories are not reliable, we need to prevent azure giving us packages.
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          # Azure repositories are flaky, remove them.
+          sudo rm -f /etc/apt/sources.list.d/{azure,microsoft}*
           sudo apt-get update
-          # The actual dependencies
-          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-              libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev \
-              libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip \
+          # The actual dependencies.
+          sudo apt-get install --no-install-recommends build-essential pkg-config libx11-dev \
+              libxcursor-dev libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev \
+              libpulse-dev libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip \
               libspeechd-dev speech-dispatcher
 
       - name: Free disk space on runner

--- a/.github/workflows/server_builds.yml
+++ b/.github/workflows/server_builds.yml
@@ -14,7 +14,8 @@ concurrency:
 
 jobs:
   build-server:
-    runs-on: "ubuntu-20.04"
+    # Stay one LTS before latest to increase portability of Linux artifacts.
+    runs-on: "ubuntu-22.04"
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -36,14 +37,14 @@ jobs:
       - name: Linux dependencies
         shell: bash
         run: |
-          # Azure repositories are not reliable, we need to prevent azure giving us packages.
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          # Azure repositories are flaky, remove them.
+          sudo rm -f /etc/apt/sources.list.d/{azure,microsoft}*
           sudo apt-get update
-          # The actual dependencies
-          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-              libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev \
-              libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip
+          # The actual dependencies.
+          sudo apt-get install --no-install-recommends build-essential pkg-config libx11-dev \
+              libxcursor-dev libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev \
+              libpulse-dev libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip \
+              libspeechd-dev speech-dispatcher
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -9,26 +9,20 @@ concurrency:
 jobs:
   static-checks:
     name: Static Checks (clang-format, black format, file format, documentation checks)
-    runs-on: ubuntu-20.04
+    runs-on: "ubuntu-24.04"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Azure repositories are not reliable, we need to prevent Azure giving us packages.
-      - name: Make apt sources.list use the default Ubuntu repositories
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/*
-          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main"
-          sudo apt-get update
-
       - name: Install dependencies
         run: |
-          sudo apt-get install -qq dos2unix clang-format-15 libxml2-utils python3-pip moreutils
+          # Azure repositories are flaky, remove them.
+          sudo rm -f /etc/apt/sources.list.d/{azure,microsoft}*
+          sudo apt-get update
+          sudo apt-get install -qq dos2unix libxml2-utils python3-pip moreutils
           sudo update-alternatives --remove-all clang-format || true
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100
-          sudo pip3 install black==22.3.0 pygments
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-16 100
+          sudo pip3 install black==24.10.0 pygments
 
       # This needs to happen before Python and npm execution; it must happen before any extra files are written.
       - name: .gitignore checks (gitignore_check.sh)

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -713,15 +713,16 @@ PoolByteArray HTTPClient::read_response_body_chunk() {
 				chunk_left -= rec;
 
 				if (chunk_left == 0) {
-					if (chunk[chunk.size() - 2] != '\r' || chunk[chunk.size() - 1] != '\n') {
+					const int chunk_size = chunk.size();
+					if (chunk[chunk_size - 2] != '\r' || chunk[chunk_size - 1] != '\n') {
 						ERR_PRINT("HTTP Invalid chunk terminator (not \\r\\n)");
 						status = STATUS_CONNECTION_ERROR;
 						break;
 					}
 
-					ret.resize(chunk.size() - 2);
+					ret.resize(chunk_size - 2);
 					PoolByteArray::Write w = ret.write();
-					memcpy(w.ptr(), chunk.ptr(), chunk.size() - 2);
+					memcpy(w.ptr(), chunk.ptr(), chunk_size - 2);
 					chunk.clear();
 				}
 

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -105,8 +105,21 @@ Error PacketPeerUDP::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 		return ERR_UNAVAILABLE;
 	}
 
+/* Bogus GCC warning here:
+ * In member function 'int RingBuffer<T>::read(T*, int, bool) [with T = unsigned char]',
+ *     inlined from 'virtual Error PacketPeerUDP::get_packet(const uint8_t**, int&)' at core/io/packet_peer_udp.cpp:112:9,
+ *     inlined from 'virtual Error PacketPeerUDP::get_packet(const uint8_t**, int&)' at core/io/packet_peer_udp.cpp:99:7:
+ * Error: ./core/ring_buffer.h:68:46: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
+ *   68 |                                 p_buf[dst++] = read[pos + i];
+ *      |                                 ~~~~~~~~~~~~~^~~~~~~
+ */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wstringop-overflow=0"
+#endif
+
 	uint32_t size = 0;
-	uint8_t ipv6[16];
+	uint8_t ipv6[16] = {};
 	rb.read(ipv6, 16, true);
 	packet_ip.set_ipv6(ipv6);
 	rb.read((uint8_t *)&packet_port, 4, true);
@@ -115,6 +128,11 @@ Error PacketPeerUDP::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 	--queue_count;
 	*r_buffer = packet_buffer;
 	r_buffer_size = size;
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 	return OK;
 }
 

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -213,12 +213,12 @@ void StreamPeer::put_var(const Variant &p_variant, bool p_full_objects) {
 }
 
 uint8_t StreamPeer::get_u8() {
-	uint8_t buf[1];
+	uint8_t buf[1] = {};
 	get_data(buf, 1);
 	return buf[0];
 }
 int8_t StreamPeer::get_8() {
-	uint8_t buf[1];
+	uint8_t buf[1] = {};
 	get_data(buf, 1);
 	return buf[0];
 }

--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -59,6 +59,7 @@ import sys
 sys.modules["_elementtree"] = None
 import xml.etree.ElementTree as ET
 
+
 ## override the parser to get the line number
 class LineNumberingParser(ET.XMLParser):
     def _start(self, *args, **kwargs):

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -3,6 +3,7 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
+
 import os
 import os.path
 import shutil

--- a/editor/icons/editor_icons_builders.py
+++ b/editor/icons/editor_icons_builders.py
@@ -3,6 +3,7 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
+
 import os
 from platform_methods import subprocess_main
 from compat import StringIO

--- a/gles_builders.py
+++ b/gles_builders.py
@@ -3,6 +3,7 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
+
 from platform_methods import subprocess_main
 import re
 

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -3,6 +3,7 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
+
 from platform_methods import subprocess_main
 from compat import byte_to_str
 from collections import OrderedDict

--- a/modules/denoise/resource_to_cpp.py
+++ b/modules/denoise/resource_to_cpp.py
@@ -19,6 +19,7 @@
 import os
 from array import array
 
+
 # Generates a C++ file from the specified binary resource file
 def generate(in_path, out_path):
 

--- a/modules/gdnative/gdnative_builders.py
+++ b/modules/gdnative/gdnative_builders.py
@@ -3,6 +3,7 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
+
 import json
 from platform_methods import subprocess_main
 

--- a/platform/osx/platform_osx_builders.py
+++ b/platform/osx/platform_osx_builders.py
@@ -3,6 +3,7 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
+
 import os
 from platform_methods import subprocess_main
 

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -3,6 +3,7 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
+
 import os
 from platform_methods import subprocess_main
 

--- a/platform/x11/platform_x11_builders.py
+++ b/platform/x11/platform_x11_builders.py
@@ -3,6 +3,7 @@
 All such functions are invoked in a subprocess on Windows to prevent build flakiness.
 
 """
+
 import os
 from platform_methods import subprocess_main
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1269,7 +1269,8 @@ void TileMap::_set_tile_data(const PoolVector<int> &p_data) {
 	for (int i = 0; i < c; i += offset) {
 		const uint8_t *ptr = (const uint8_t *)&r[i];
 		uint8_t local[12];
-		for (int j = 0; j < ((format == FORMAT_2) ? 12 : 8); j++) {
+		const int buffer_size = (format == FORMAT_2) ? 12 : 8;
+		for (int j = 0; j < buffer_size; j++) {
 			local[j] = ptr[j];
 		}
 

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -1,6 +1,7 @@
 """Functions used to generate scu build source files during build time
 
 """
+
 import glob, os
 import math
 from pathlib import Path
@@ -158,6 +159,7 @@ def find_section_name(sub_folder):
 # These will automatically be placed in their own separate scu file,
 # which is slow like a normal build, but prevents the naming conflicts.
 # Ideally in these situations, the source code should be changed to prevent naming conflicts.
+
 
 # "extension" will usually be cpp, but can also be set to c (for e.g. third party libraries that use c)
 def process_folder(folders, sought_exceptions=[], includes_per_scu=0, extension="cpp"):


### PR DESCRIPTION
This makes it easier to keep checks passing and in sync.

Cherry-pick of #98896.