### PR TITLE
Add warnings for unsupported features in Generic6DOFJoint3D

### DIFF
--- a/scene/2d/physics/joints/joint_2d.cpp
+++ b/scene/2d/physics/joints/joint_2d.cpp
@@ -76,15 +76,15 @@ void Joint2D::_update_joint(bool p_only_free) {
 	bool valid = false;
 
 	if (node_a && !body_a && node_b && !body_b) {
-		warning = RTR("Node A and Node B must be PhysicsBody2Ds");
+		warning = RTR("Node A and Node B must be PhysicsBody2Ds.");
 	} else if (node_a && !body_a) {
-		warning = RTR("Node A must be a PhysicsBody2D");
+		warning = RTR("Node A must be a PhysicsBody2D.");
 	} else if (node_b && !body_b) {
-		warning = RTR("Node B must be a PhysicsBody2D");
+		warning = RTR("Node B must be a PhysicsBody2D.");
 	} else if (!body_a || !body_b) {
-		warning = RTR("Joint is not connected to two PhysicsBody2Ds");
+		warning = RTR("Joint is not connected to two PhysicsBody2Ds.");
 	} else if (body_a == body_b) {
-		warning = RTR("Node A and Node B must be different PhysicsBody2Ds");
+		warning = RTR("Node A and Node B must be different PhysicsBody2Ds.");
 	} else {
 		warning = String();
 		valid = true;

--- a/scene/3d/physics/joints/generic_6dof_joint_3d.cpp
+++ b/scene/3d/physics/joints/generic_6dof_joint_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "generic_6dof_joint_3d.h"
 
+#include "core/config/project_settings.h"
+
 void Generic6DOFJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_param_x", "param", "value"), &Generic6DOFJoint3D::set_param_x);
 	ClassDB::bind_method(D_METHOD("get_param_x", "param"), &Generic6DOFJoint3D::get_param_x);
@@ -196,6 +198,29 @@ void Generic6DOFJoint3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(FLAG_MAX);
 }
 
+PackedStringArray Generic6DOFJoint3D::get_configuration_warnings() const {
+	PackedStringArray warnings = Joint3D::get_configuration_warnings();
+
+	const String physics_engine = GLOBAL_GET("physics/3d/physics_engine");
+	const bool using_godot_physics = physics_engine == "DEFAULT" || physics_engine == "GodotPhysics3D";
+
+	if (using_godot_physics) {
+		if (get_flag_x(FLAG_ENABLE_LINEAR_MOTOR) || get_flag_y(FLAG_ENABLE_LINEAR_MOTOR) || get_flag_z(FLAG_ENABLE_LINEAR_MOTOR)) {
+			warnings.push_back(RTR("Linear motors are not supported in GodotPhysics3D.\nTo use linear motors in Generic6DOFJoint3D, install a third-party physics engine that supports linear motors and switch to it in the project settings."));
+		}
+
+		if (get_flag_x(FLAG_ENABLE_LINEAR_SPRING) || get_flag_y(FLAG_ENABLE_LINEAR_SPRING) || get_flag_z(FLAG_ENABLE_LINEAR_SPRING)) {
+			warnings.push_back(RTR("Linear springs are not supported in GodotPhysics3D.\nTo use linear springs in Generic6DOFJoint3D, install a third-party physics engine that supports linear springs and switch to it in the project settings."));
+		}
+
+		if (get_flag_x(FLAG_ENABLE_ANGULAR_SPRING) || get_flag_y(FLAG_ENABLE_ANGULAR_SPRING) || get_flag_z(FLAG_ENABLE_ANGULAR_SPRING)) {
+			warnings.push_back(RTR("Angular springs are not supported in GodotPhysics3D.\nTo use angular springs in Generic6DOFJoint3D, install a third-party physics engine that supports angular springs and switch to it in the project settings."));
+		}
+	}
+
+	return warnings;
+}
+
 void Generic6DOFJoint3D::set_param_x(Param p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_param, PARAM_MAX);
 	params_x[p_param] = p_value;
@@ -245,6 +270,7 @@ void Generic6DOFJoint3D::set_flag_x(Flag p_flag, bool p_enabled) {
 	if (is_configured()) {
 		PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(get_rid(), Vector3::AXIS_X, PhysicsServer3D::G6DOFJointAxisFlag(p_flag), p_enabled);
 	}
+	update_configuration_warnings();
 	update_gizmos();
 }
 
@@ -259,6 +285,7 @@ void Generic6DOFJoint3D::set_flag_y(Flag p_flag, bool p_enabled) {
 	if (is_configured()) {
 		PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(get_rid(), Vector3::AXIS_Y, PhysicsServer3D::G6DOFJointAxisFlag(p_flag), p_enabled);
 	}
+	update_configuration_warnings();
 	update_gizmos();
 }
 
@@ -273,6 +300,7 @@ void Generic6DOFJoint3D::set_flag_z(Flag p_flag, bool p_enabled) {
 	if (is_configured()) {
 		PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(get_rid(), Vector3::AXIS_Z, PhysicsServer3D::G6DOFJointAxisFlag(p_flag), p_enabled);
 	}
+	update_configuration_warnings();
 	update_gizmos();
 }
 

--- a/scene/3d/physics/joints/generic_6dof_joint_3d.h
+++ b/scene/3d/physics/joints/generic_6dof_joint_3d.h
@@ -83,6 +83,7 @@ protected:
 
 	virtual void _configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) override;
 	static void _bind_methods();
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 public:
 	void set_param_x(Param p_param, real_t p_value);

--- a/scene/3d/physics/joints/joint_3d.cpp
+++ b/scene/3d/physics/joints/joint_3d.cpp
@@ -74,15 +74,15 @@ void Joint3D::_update_joint(bool p_only_free) {
 	PhysicsBody3D *body_b = Object::cast_to<PhysicsBody3D>(node_b);
 
 	if (node_a && !body_a && node_b && !body_b) {
-		warning = RTR("Node A and Node B must be PhysicsBody3Ds");
+		warning = RTR("Node A and Node B must be PhysicsBody3Ds.");
 	} else if (node_a && !body_a) {
-		warning = RTR("Node A must be a PhysicsBody3D");
+		warning = RTR("Node A must be a PhysicsBody3D.");
 	} else if (node_b && !body_b) {
-		warning = RTR("Node B must be a PhysicsBody3D");
+		warning = RTR("Node B must be a PhysicsBody3D.");
 	} else if (!body_a && !body_b) {
-		warning = RTR("Joint is not connected to any PhysicsBody3Ds");
+		warning = RTR("Joint is not connected to any PhysicsBody3Ds.");
 	} else if (body_a == body_b) {
-		warning = RTR("Node A and Node B must be different PhysicsBody3Ds");
+		warning = RTR("Node A and Node B must be different PhysicsBody3Ds.");
 	} else {
 		warning = String();
 	}


### PR DESCRIPTION
These node configuration warnings are only displayed if using GodotPhysics3D, not a third-party physics engine.

This also adds missing periods to Joint3D node configuration warnings.

- See https://github.com/godotengine/godot/issues/66335.
