### PR TITLE
Add toggle to hide filtered out parents in the "SceneTree" dock

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -241,6 +241,9 @@
 		<member name="docks/scene_tree/center_node_on_reparent" type="bool" setter="" getter="">
 			If [code]true[/code], new node created when reparenting node(s) will be positioned at the average position of the selected node(s).
 		</member>
+		<member name="docks/scene_tree/hide_filtered_out_parents" type="bool" setter="" getter="">
+			If [code]true[/code], the scene tree dock will only show nodes that match the filter, without showing parents that don't. This settings can also be changed in the Scene dock's top menu.
+		</member>
 		<member name="docks/scene_tree/start_create_dialog_fully_expanded" type="bool" setter="" getter="">
 			If [code]true[/code], the Create dialog (Create New Node/Create New Resource) will start with all its sections expanded. Otherwise, sections will be collapsed until the user starts searching (which will automatically expand sections as needed).
 		</member>

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -40,6 +40,18 @@ class EditorDebuggerTree : public Tree {
 	GDCLASS(EditorDebuggerTree, Tree);
 
 private:
+	struct ParentItem {
+		TreeItem *tree_item;
+		int child_count;
+		bool matches_filter;
+
+		ParentItem(TreeItem *p_tree_item = nullptr, int p_child_count = 0, bool p_matches_filter = false) {
+			tree_item = p_tree_item;
+			child_count = p_child_count;
+			matches_filter = p_matches_filter;
+		}
+	};
+
 	enum ItemMenu {
 		ITEM_MENU_SAVE_REMOTE_NODE,
 		ITEM_MENU_COPY_NODE_PATH,
@@ -56,7 +68,6 @@ private:
 	EditorFileDialog *file_dialog = nullptr;
 	String last_filter;
 
-	String _get_path(TreeItem *p_item);
 	void _scene_tree_folded(Object *p_obj);
 	void _scene_tree_selected();
 	void _scene_tree_rmb_selected(const Vector2 &p_position, MouseButton p_button);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -633,6 +633,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("docks/scene_tree/start_create_dialog_fully_expanded", false);
 	_initial_set("docks/scene_tree/auto_expand_to_selected", true);
 	_initial_set("docks/scene_tree/center_node_on_reparent", false);
+	_initial_set("docks/scene_tree/hide_filtered_out_parents", true);
 
 	// FileSystem
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "docks/filesystem/thumbnail_size", 64, "32,128,16")

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -952,47 +952,60 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 		return false;
 	}
 
+	// Now find other reasons to keep this Node, too.
+	PackedStringArray terms = filter.to_lower().split_spaces();
+	bool keep = _item_matches_all_terms(p_parent, terms);
+
+	bool selectable = keep;
+	bool is_root = p_parent == tree->get_root();
+
+	if (keep) {
+		Node *n = get_node(p_parent->get_metadata(0));
+		if (!p_parent->is_visible() || (is_root && tree->is_root_hidden())) {
+			// Place back moved out children from when this item has hidden.
+			HashMap<Node *, CachedNode>::Iterator I = node_cache.get(n, false);
+			if (I && I->value.has_moved_children) {
+				_update_node_subtree(I->value.node, nullptr, true);
+			}
+		}
+
+		if (!valid_types.is_empty()) {
+			selectable = false;
+			for (const StringName &E : valid_types) {
+				if (n->is_class(E) ||
+						EditorNode::get_singleton()->is_object_of_custom_type(n, E)) {
+					selectable = true;
+					break;
+				} else {
+					Ref<Script> node_script = n->get_script();
+					while (node_script.is_valid()) {
+						if (node_script->get_path() == E) {
+							selectable = true;
+							break;
+						}
+						node_script = node_script->get_base_script();
+					}
+					if (selectable) {
+						break;
+					}
+				}
+			}
+		}
+	}
+
 	bool keep_for_children = false;
 	for (TreeItem *child = p_parent->get_first_child(); child; child = child->get_next()) {
 		// Always keep if at least one of the children are kept.
 		keep_for_children = _update_filter(child, p_scroll_to_selected) || keep_for_children;
 	}
 
-	// Now find other reasons to keep this Node, too.
-	PackedStringArray terms = filter.to_lower().split_spaces();
-	bool keep = _item_matches_all_terms(p_parent, terms);
-
-	bool selectable = keep;
-	if (keep && !valid_types.is_empty()) {
-		selectable = false;
-		Node *n = get_node(p_parent->get_metadata(0));
-
-		for (const StringName &E : valid_types) {
-			if (n->is_class(E) ||
-					EditorNode::get_singleton()->is_object_of_custom_type(n, E)) {
-				selectable = true;
-				break;
-			} else {
-				Ref<Script> node_script = n->get_script();
-				while (node_script.is_valid()) {
-					if (node_script->get_path() == E) {
-						selectable = true;
-						break;
-					}
-					node_script = node_script->get_base_script();
-				}
-				if (selectable) {
-					break;
-				}
-			}
+	if (!is_root) {
+		if (show_all_nodes) {
+			p_parent->set_visible(keep_for_children || keep);
+		} else {
+			// Show only selectable nodes, or parents of selectable.
+			p_parent->set_visible(keep_for_children || selectable);
 		}
-	}
-
-	if (show_all_nodes) {
-		p_parent->set_visible(keep_for_children || keep);
-	} else {
-		// Show only selectable nodes, or parents of selectable.
-		p_parent->set_visible(keep_for_children || selectable);
 	}
 
 	if (selectable) {
@@ -1002,24 +1015,67 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 		} else {
 			p_parent->set_custom_color(0, custom_color);
 		}
+
 		p_parent->set_selectable(0, true);
 	} else if (keep_for_children) {
-		p_parent->set_custom_color(0, get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
-		p_parent->set_selectable(0, false);
-		p_parent->deselect(0);
+		p_parent->set_visible(!hide_filtered_out_parents || is_root);
+
+		if (!p_parent->is_visible()) {
+			TreeItem *filtered_parent = p_parent->get_parent();
+			while (filtered_parent) {
+				if (filtered_parent == tree->get_root() || (filtered_parent->is_selectable(0) && filtered_parent->is_visible())) {
+					break;
+				}
+				filtered_parent = filtered_parent->get_parent();
+			}
+
+			if (filtered_parent) {
+				for (Variant &item : p_parent->get_children()) {
+					TreeItem *ti = Object::cast_to<TreeItem>(item);
+					bool is_selected = ti->is_selected(0);
+
+					p_parent->remove_child(ti);
+					filtered_parent->add_child(ti);
+					TreeItem *prev = p_parent->get_prev();
+					if (prev) {
+						ti->move_after(prev);
+					}
+
+					if (is_selected) {
+						ti->select(0);
+					}
+
+					HashMap<Node *, CachedNode>::Iterator I = node_cache.get(get_node(p_parent->get_metadata(0)), false);
+					if (I) {
+						I->value.has_moved_children = true;
+					}
+				}
+
+				return false;
+			}
+		} else {
+			p_parent->set_custom_color(0, get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor)));
+			p_parent->set_selectable(0, false);
+			p_parent->deselect(0);
+		}
+	}
+	if (is_root) {
+		tree->set_hide_root(hide_filtered_out_parents && !selectable);
+		if (tree->is_root_hidden()) {
+			p_parent->set_collapsed(false);
+		}
 	}
 
 	if (editor_selection) {
 		Node *n = get_node(p_parent->get_metadata(0));
 		if (selectable) {
 			if (p_scroll_to_selected && n && editor_selection->is_selected(n)) {
-				tree->scroll_to_item(p_parent);
+				// Needs to be deferred to account for possible root visibility change.
+				callable_mp(tree, &Tree::scroll_to_item).call_deferred(p_parent, false);
 			}
-		} else {
-			if (n && p_parent->is_selected(0)) {
-				editor_selection->remove_node(n);
-				p_parent->deselect(0);
-			}
+		} else if (n && p_parent->is_selected(0)) {
+			editor_selection->remove_node(n);
+			p_parent->deselect(0);
 		}
 	}
 
@@ -1889,19 +1945,37 @@ void SceneTreeEditor::set_auto_expand_selected(bool p_auto, bool p_update_settin
 	auto_expand_selected = p_auto;
 }
 
+void SceneTreeEditor::set_hide_filtered_out_parents(bool p_hide, bool p_update_settings) {
+	if (p_hide == hide_filtered_out_parents) {
+		return;
+	}
+
+	if (p_update_settings) {
+		EditorSettings::get_singleton()->set("docks/scene_tree/hide_filtered_out_parents", p_hide);
+	}
+	hide_filtered_out_parents = p_hide;
+
+	if (hide_filtered_out_parents) {
+		_update_filter();
+	} else {
+		node_cache.force_update = true;
+		_update_tree();
+	}
+}
+
 void SceneTreeEditor::set_connect_to_script_mode(bool p_enable) {
 	connect_to_script_mode = p_enable;
-	update_tree();
+	_update_tree();
 }
 
 void SceneTreeEditor::set_connecting_signal(bool p_enable) {
 	connecting_signal = p_enable;
-	update_tree();
+	_update_tree();
 }
 
 void SceneTreeEditor::set_update_when_invisible(bool p_enable) {
 	update_when_invisible = p_enable;
-	update_tree();
+	_update_tree();
 }
 
 void SceneTreeEditor::_bind_methods() {

--- a/editor/gui/scene_tree_editor.h
+++ b/editor/gui/scene_tree_editor.h
@@ -126,6 +126,7 @@ class SceneTreeEditor : public Control {
 	Node *revoke_node = nullptr;
 
 	bool auto_expand_selected = true;
+	bool hide_filtered_out_parents = false;
 	bool connect_to_script_mode = false;
 	bool connecting_signal = false;
 	bool update_when_invisible = true;
@@ -243,9 +244,10 @@ public:
 	void set_show_enabled_subscene(bool p_show) { show_enabled_subscene = p_show; }
 	void set_valid_types(const Vector<StringName> &p_valid);
 
-	void update_tree() { _update_tree(); }
+	inline void update_tree() { _update_tree(); }
 
 	void set_auto_expand_selected(bool p_auto, bool p_update_settings);
+	void set_hide_filtered_out_parents(bool p_hide, bool p_update_settings);
 	void set_connect_to_script_mode(bool p_enable);
 	void set_connecting_signal(bool p_enable);
 	void set_update_when_invisible(bool p_enable);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1242,6 +1242,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 		case TOOL_CENTER_PARENT: {
 			EditorSettings::get_singleton()->set("docks/scene_tree/center_node_on_reparent", !EDITOR_GET("docks/scene_tree/center_node_on_reparent"));
 		} break;
+		case TOOL_HIDE_FILTERED_OUT_PARENTS: {
+			scene_tree->set_hide_filtered_out_parents(!EDITOR_GET("docks/scene_tree/hide_filtered_out_parents"), true);
+		} break;
 		case TOOL_SCENE_EDITABLE_CHILDREN: {
 			if (!profile_allow_editing) {
 				break;
@@ -1667,6 +1670,7 @@ void SceneTreeDock::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			clear_inherit_confirm->connect(SceneStringName(confirmed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_SCENE_CLEAR_INHERITANCE_CONFIRM, false));
 			scene_tree->set_auto_expand_selected(EDITOR_GET("docks/scene_tree/auto_expand_to_selected"), false);
+			scene_tree->set_hide_filtered_out_parents(EDITOR_GET("docks/scene_tree/hide_filtered_out_parents"), false);
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -1676,6 +1680,7 @@ void SceneTreeDock::_notification(int p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (EditorSettings::get_singleton()->check_changed_settings_in_group("docks/scene_tree")) {
 				scene_tree->set_auto_expand_selected(EDITOR_GET("docks/scene_tree/auto_expand_to_selected"), false);
+				scene_tree->set_hide_filtered_out_parents(EDITOR_GET("docks/scene_tree/hide_filtered_out_parents"), false);
 			}
 		} break;
 
@@ -3961,12 +3966,16 @@ void SceneTreeDock::_update_tree_menu() {
 
 	tree_menu->add_separator();
 	tree_menu->add_check_item(TTR("Auto Expand to Selected"), TOOL_AUTO_EXPAND);
-	tree_menu->set_item_checked(tree_menu->get_item_index(TOOL_AUTO_EXPAND), EDITOR_GET("docks/scene_tree/auto_expand_to_selected"));
+	tree_menu->set_item_checked(-1, EDITOR_GET("docks/scene_tree/auto_expand_to_selected"));
 
 	tree_menu->add_check_item(TTR("Center Node on Reparent"), TOOL_CENTER_PARENT);
-	tree_menu->set_item_checked(tree_menu->get_item_index(TOOL_CENTER_PARENT), EDITOR_GET("docks/scene_tree/center_node_on_reparent"));
-	tree_menu->set_item_tooltip(tree_menu->get_item_index(TOOL_CENTER_PARENT), TTR("If enabled, Reparent to New Node will create the new node in the center of the selected nodes, if possible."));
+	tree_menu->set_item_checked(-1, EDITOR_GET("docks/scene_tree/center_node_on_reparent"));
+	tree_menu->set_item_tooltip(-1, TTR("If enabled, Reparent to New Node will create the new node in the center of the selected nodes, if possible."));
 
+	tree_menu->add_check_item(TTR("Hide Filtered Out Parents"), TOOL_HIDE_FILTERED_OUT_PARENTS);
+	tree_menu->set_item_checked(-1, EDITOR_GET("docks/scene_tree/hide_filtered_out_parents"));
+
+	tree_menu->add_separator();
 	PopupMenu *resource_list = memnew(PopupMenu);
 	resource_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	resource_list->connect("about_to_popup", callable_mp(this, &SceneTreeDock::_list_all_subresources).bind(resource_list));

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -94,7 +94,7 @@ class SceneTreeDock : public VBoxContainer {
 		TOOL_CREATE_USER_INTERFACE,
 		TOOL_CREATE_FAVORITE,
 		TOOL_CENTER_PARENT,
-
+		TOOL_HIDE_FILTERED_OUT_PARENTS,
 	};
 
 	enum {


### PR DESCRIPTION
In large scenes (and especially in the remote tree), showing nodes that match the filter with parents that do not can be annoying if multiple results are from different hierarchies, as this creates unnecessary pollution. This PR adds a toggle in the menu of the "SceneTree" dock to hide those parents, purely showing only matched nodes.

|Disabled|Enabled|
|-|-|
|![image](https://github.com/user-attachments/assets/b20bfa7b-cec3-4f37-a268-470d69a1363c)|![image](https://github.com/user-attachments/assets/212c99a2-69f2-49c9-bfc7-b932db59fe75)|

Closes https://github.com/godotengine/godot-proposals/issues/10043.

**Sponsored By:** 🐺 Lone Wolf Technology / 🍀 W4 Games.