### PR TITLE
Expose the `EditorScriptHighlighter::_create()` method to GDExtension

### DIFF
--- a/doc/classes/EditorSyntaxHighlighter.xml
+++ b/doc/classes/EditorSyntaxHighlighter.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_create" qualifiers="virtual const">
+			<return type="EditorSyntaxHighlighter" />
+			<description>
+				Virtual method which creates a new instance of the syntax highlighter.
+			</description>
+		</method>
 		<method name="_get_name" qualifiers="virtual const">
 			<return type="String" />
 			<description>

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -86,9 +86,13 @@ PackedStringArray EditorSyntaxHighlighter::_get_supported_languages() const {
 
 Ref<EditorSyntaxHighlighter> EditorSyntaxHighlighter::_create() const {
 	Ref<EditorSyntaxHighlighter> syntax_highlighter;
-	syntax_highlighter.instantiate();
-	if (get_script_instance()) {
-		syntax_highlighter->set_script(get_script_instance()->get_script());
+	if (GDVIRTUAL_IS_OVERRIDDEN(_create)) {
+		GDVIRTUAL_CALL(_create, syntax_highlighter);
+	} else {
+		syntax_highlighter.instantiate();
+		if (get_script_instance()) {
+			syntax_highlighter->set_script(get_script_instance()->get_script());
+		}
 	}
 	return syntax_highlighter;
 }
@@ -98,6 +102,7 @@ void EditorSyntaxHighlighter::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_name)
 	GDVIRTUAL_BIND(_get_supported_languages)
+	GDVIRTUAL_BIND(_create)
 }
 
 ////

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -62,6 +62,7 @@ protected:
 
 	GDVIRTUAL0RC(String, _get_name)
 	GDVIRTUAL0RC(PackedStringArray, _get_supported_languages)
+	GDVIRTUAL0RC(Ref<EditorSyntaxHighlighter>, _create)
 
 public:
 	virtual String _get_name() const;


### PR DESCRIPTION
Possibly fixes https://github.com/godotengine/godot-cpp/issues/1636

I don't personally know this API, so I don't know if this is the right fix, but throwing this up here either as the fix (if the folks who know this API think this is the right way to do it), or as an example for someone else to take over.