### PR TITLE
[Web] Remove warnings when setting vsync mode and screen keep on

### DIFF
--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -209,6 +209,7 @@ public:
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual void screen_set_keep_on(bool p_enable) override {}
 
 	virtual void virtual_keyboard_show(const String &p_existing_text, const Rect2 &p_screen_rect = Rect2(), VirtualKeyboardType p_type = KEYBOARD_TYPE_DEFAULT, int p_max_input_length = -1, int p_cursor_start = -1, int p_cursor_end = -1) override;
 	virtual void virtual_keyboard_hide() override;
@@ -265,6 +266,7 @@ public:
 
 	virtual bool can_any_window_draw() const override;
 
+	virtual void window_set_vsync_mode(VSyncMode p_vsync_mode, WindowID p_window = MAIN_WINDOW_ID) override {}
 	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_vsync_mode) const override;
 
 	// events


### PR DESCRIPTION
Fixes #98933

> [!WARNING]
> I'm a little torn about the solution. Either we shush the warnings on the web, or we make the editor check if the feature is supported (that's where I got the issues). I went the easy way, but I'm open to close this PR if needed.