### PR TITLE
Fix scripts panel state not being saved when toggle button is used

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1672,6 +1672,7 @@ void CodeTextEditor::_set_show_warnings_panel(bool p_show) {
 void CodeTextEditor::_toggle_files_pressed() {
 	ERR_FAIL_NULL(toggle_files_list);
 	toggle_files_list->set_visible(!toggle_files_list->is_visible());
+	EditorSettings::get_singleton()->set_project_metadata("files_panel", "show_files_panel", toggle_files_list->is_visible());
 	update_toggle_files_button();
 }
 


### PR DESCRIPTION
Fix for #98860

When using ctrl + \ or right clicking toggle/hide to toggle the script panel the change would be saved, but when pressing the toggle button the change would not be saved.

The goal of this change is to make it so pressing the toggle button will also save the setting.

*Bugsquad edit: fixes #98860*
