### PR TITLE
Remove unnecessary `_3D_DISABLED` checks in `Performance`

### DIFF
--- a/main/performance.cpp
+++ b/main/performance.cpp
@@ -132,11 +132,9 @@ String Performance::get_monitor_name(Monitor p_monitor) const {
 		PNAME("physics_2d/active_objects"),
 		PNAME("physics_2d/collision_pairs"),
 		PNAME("physics_2d/islands"),
-#ifndef _3D_DISABLED
 		PNAME("physics_3d/active_objects"),
 		PNAME("physics_3d/collision_pairs"),
 		PNAME("physics_3d/islands"),
-#endif // _3D_DISABLED
 		PNAME("audio/driver/output_latency"),
 		PNAME("navigation/active_maps"),
 		PNAME("navigation/regions"),
@@ -280,11 +278,9 @@ Performance::MonitorType Performance::get_monitor_type(Monitor p_monitor) const 
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
-#ifndef _3D_DISABLED
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,
-#endif // _3D_DISABLED
 		MONITOR_TYPE_TIME,
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_QUANTITY,


### PR DESCRIPTION
The list will be indexed with a `Monitor` enum directly. So these entries should not be skipped when 3D is disabled, otherwise subsequent values will be misplaced.

Practically, these two methods in question are only used internally in editor code, and editor builds cannot disable 3D :)