### PR TITLE
Add note to `CanvasItem.clip_children` about nesting

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -594,6 +594,7 @@
 	<members>
 		<member name="clip_children" type="int" setter="set_clip_children_mode" getter="get_clip_children_mode" enum="CanvasItem.ClipChildrenMode" default="0">
 			Allows the current node to clip child nodes, essentially acting as a mask.
+			[b]Note:[/b] Clipping nodes cannot be nested or placed within [CanvasGroup]s. If an ancestor of this node clips its children or is a [CanvasGroup], then this node's clip mode should be set to [constant CLIP_CHILDREN_DISABLED] to avoid unexpected behavior.
 		</member>
 		<member name="light_mask" type="int" setter="set_light_mask" getter="get_light_mask" default="1">
 			The rendering layers in which this [CanvasItem] responds to [Light2D] nodes.


### PR DESCRIPTION
I ran into an issue over the last few days that I eventually figured out was due to CanvasItems that clipped their children not being able to be nested. This doesn't appear to be noted in the documentation; the closest thing I could find was [the page for CanvasGroup implying it](https://docs.godotengine.org/en/latest/classes/class_canvasgroup.html).

This PR adds a note to the documentation for `CanvasItem.clip_children` explaining that clipping can't be nested, and that children of a clipping node must have `CLIP_CHILDREN_DISABLED` as their clip mode. It appears on the tooltip for the "Clip Children" in the Inspector:
![CleanShot 2024-11-07 at 20 14 42@2x](https://github.com/user-attachments/assets/72f937f4-857f-4347-9d46-6981dc4094cd)
