### PR TITLE
Add warning in scene tree when nested CanvasItems try to clip children

### DIFF
--- a/scene/2d/canvas_group.cpp
+++ b/scene/2d/canvas_group.cpp
@@ -64,6 +64,38 @@ bool CanvasGroup::is_using_mipmaps() const {
 	return use_mipmaps;
 }
 
+PackedStringArray CanvasGroup::get_configuration_warnings() const {
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
+
+	if (is_inside_tree()) {
+		bool warned_about_ancestor_clipping = false;
+		bool warned_about_canvasgroup_ancestor = false;
+		Node *n = get_parent();
+		while (n) {
+			CanvasItem *as_canvas_item = Object::cast_to<CanvasItem>(n);
+			if (!warned_about_ancestor_clipping && as_canvas_item && as_canvas_item->get_clip_children_mode() != CLIP_CHILDREN_DISABLED) {
+				warnings.push_back(vformat(RTR("Ancestor \"%s\" clips its children, so this CanvasGroup will not function properly."), as_canvas_item->get_name()));
+				warned_about_ancestor_clipping = true;
+			}
+
+			CanvasGroup *as_canvas_group = Object::cast_to<CanvasGroup>(n);
+			if (!warned_about_canvasgroup_ancestor && as_canvas_group) {
+				warnings.push_back(vformat(RTR("Ancestor \"%s\" is a CanvasGroup, so this CanvasGroup will not function properly."), as_canvas_group->get_name()));
+				warned_about_canvasgroup_ancestor = true;
+			}
+
+			// Only break out early once both warnings have been triggered, so
+			// that the user is aware of both possible reasons for clipping not working.
+			if (warned_about_ancestor_clipping && warned_about_canvasgroup_ancestor) {
+				break;
+			}
+			n = n->get_parent();
+		}
+	}
+
+	return warnings;
+}
+
 void CanvasGroup::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fit_margin", "fit_margin"), &CanvasGroup::set_fit_margin);
 	ClassDB::bind_method(D_METHOD("get_fit_margin"), &CanvasGroup::get_fit_margin);

--- a/scene/2d/canvas_group.h
+++ b/scene/2d/canvas_group.h
@@ -51,6 +51,8 @@ public:
 	void set_use_mipmaps(bool p_use_mipmaps);
 	bool is_using_mipmaps() const;
 
+	virtual PackedStringArray get_configuration_warnings() const override;
+
 	CanvasGroup();
 	~CanvasGroup();
 };

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -398,6 +398,8 @@ public:
 	int get_canvas_layer() const;
 	CanvasLayer *get_canvas_layer_node() const;
 
+	virtual PackedStringArray get_configuration_warnings() const override;
+
 	CanvasItem();
 	~CanvasItem();
 };


### PR DESCRIPTION
This PR provides a partial solution to https://github.com/godotengine/godot-proposals/issues/11113 by displaying a configuration warning in the scene tree when a CanvasItem attempting to clip its children has an ancestor CanvasItem that also clips its children:

![CleanShot 2024-11-07 at 21 19 58@2x](https://github.com/user-attachments/assets/734492e9-3e5f-4592-887e-6ff10343bda2)

> [!WARNING]
> The warning notably appears on the child node attempting to clip, not on the parent that is successfully(?) clipping. This does mean that if there is a scene instance that contains within it a clipping node, the error may still be invisible to the user:
> 
> ![CleanShot 2024-11-07 at 21 48 54@2x](https://github.com/user-attachments/assets/13717098-a7dc-4a8b-90e5-a6da4e3312ea)
> 
> Placing a warning on the parent node would fix this, but it would also require each parent to do a recursive walk of its descendants in the best (and hopefully usual) case of no nested clipping. I feel like the performance penalty that this would incur would be a bit too much.

A fair number of files had to be modified so that this PR worked for all of those classes that inherited from CanvasItem; previously, their `get_configuration_warnings` methods assumed that the relevant superclass for them to call was Node, but since this PR adds `get_configuration_warnings` to CanvasLayer, which is in between them and Node, they had to be updated.
