### PR TITLE
Fix a few more super calls in `get_configuration_warnings` methods

### DIFF
--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -418,7 +418,7 @@ Vector2 PointLight2D::get_texture_offset() const {
 }
 
 PackedStringArray PointLight2D::get_configuration_warnings() const {
-	PackedStringArray warnings = Node2D::get_configuration_warnings();
+	PackedStringArray warnings = Light2D::get_configuration_warnings();
 
 	if (!texture.is_valid()) {
 		warnings.push_back(RTR("A texture with the shape of the light must be supplied to the \"Texture\" property."));

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -641,7 +641,7 @@ void RigidBody2D::_notification(int p_what) {
 PackedStringArray RigidBody2D::get_configuration_warnings() const {
 	Transform2D t = get_transform();
 
-	PackedStringArray warnings = CollisionObject2D::get_configuration_warnings();
+	PackedStringArray warnings = PhysicsBody2D::get_configuration_warnings();
 
 	if (ABS(t.columns[0].length() - 1.0) > 0.05 || ABS(t.columns[1].length() - 1.0) > 0.05) {
 		warnings.push_back(RTR("Size changes to RigidBody2D will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -659,7 +659,7 @@ void RigidBody3D::_reload_physics_characteristics() {
 }
 
 PackedStringArray RigidBody3D::get_configuration_warnings() const {
-	PackedStringArray warnings = CollisionObject3D::get_configuration_warnings();
+	PackedStringArray warnings = PhysicsBody3D::get_configuration_warnings();
 
 	Vector3 scale = get_transform().get_basis().get_scale();
 	if (ABS(scale.x - 1.0) > 0.05 || ABS(scale.y - 1.0) > 0.05 || ABS(scale.z - 1.0) > 0.05) {

--- a/scene/main/missing_node.cpp
+++ b/scene/main/missing_node.cpp
@@ -84,17 +84,17 @@ bool MissingNode::is_recording_properties() const {
 
 PackedStringArray MissingNode::get_configuration_warnings() const {
 	// The mere existence of this node is warning.
-	PackedStringArray ret;
+	PackedStringArray warnings = Node::get_configuration_warnings();
 	if (!original_scene.is_empty()) {
-		ret.push_back(vformat(RTR("This node was an instance of scene '%s', which was no longer available when this scene was loaded."), original_scene));
-		ret.push_back(vformat(RTR("Saving current scene will discard instance and all its properties, including editable children edits (if existing).")));
+		warnings.push_back(vformat(RTR("This node was an instance of scene '%s', which was no longer available when this scene was loaded."), original_scene));
+		warnings.push_back(vformat(RTR("Saving current scene will discard instance and all its properties, including editable children edits (if existing).")));
 	} else if (!original_class.is_empty()) {
-		ret.push_back(vformat(RTR("This node was saved as class type '%s', which was no longer available when this scene was loaded."), original_class));
-		ret.push_back(RTR("Data from the original node is kept as a placeholder until this type of node is available again. It can hence be safely re-saved without risk of data loss."));
+		warnings.push_back(vformat(RTR("This node was saved as class type '%s', which was no longer available when this scene was loaded."), original_class));
+		warnings.push_back(RTR("Data from the original node is kept as a placeholder until this type of node is available again. It can hence be safely re-saved without risk of data loss."));
 	} else {
-		ret.push_back(RTR("Unrecognized missing node. Check scene dependency errors for details."));
+		warnings.push_back(RTR("Unrecognized missing node. Check scene dependency errors for details."));
 	}
-	return ret;
+	return warnings;
 }
 
 void MissingNode::_bind_methods() {


### PR DESCRIPTION
A few missed last pass and one incorrect from that pass

Follow-up to:
* https://github.com/godotengine/godot/pull/93353

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
