### PR TITLE
[Web] Disable UNIX sockets

### DIFF
--- a/drivers/unix/net_socket_unix.h
+++ b/drivers/unix/net_socket_unix.h
@@ -37,7 +37,7 @@
 
 #include <sys/socket.h>
 
-class NetSocketPosix : public NetSocket {
+class NetSocketUnix : public NetSocket {
 private:
 	int _sock = -1;
 	IP::Type _ip_type = IP::TYPE_NONE;
@@ -93,8 +93,8 @@ public:
 	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 
-	NetSocketPosix();
-	~NetSocketPosix() override;
+	NetSocketUnix();
+	~NetSocketUnix() override;
 };
 
 #endif // UNIX_ENABLED && !UNIX_SOCKET_UNAVAILABLE

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -167,7 +167,9 @@ void OS_Unix::initialize_core() {
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_USERDATA);
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_FILESYSTEM);
 
-	NetSocketPosix::make_default();
+#ifndef UNIX_SOCKET_UNAVAILABLE
+	NetSocketUnix::make_default();
+#endif
 	IPUnix::make_default();
 	process_map = memnew((HashMap<ProcessID, ProcessInfo>));
 
@@ -176,7 +178,9 @@ void OS_Unix::initialize_core() {
 
 void OS_Unix::finalize_core() {
 	memdelete(process_map);
-	NetSocketPosix::cleanup();
+#ifndef UNIX_SOCKET_UNAVAILABLE
+	NetSocketUnix::cleanup();
+#endif
 }
 
 Vector<String> OS_Unix::get_video_adapter_driver_info() const {

--- a/platform/android/net_socket_android.cpp
+++ b/platform/android/net_socket_android.cpp
@@ -84,7 +84,7 @@ NetSocketAndroid::~NetSocketAndroid() {
 }
 
 void NetSocketAndroid::close() {
-	NetSocketPosix::close();
+	NetSocketUnix::close();
 	if (wants_broadcast) {
 		multicast_lock_release();
 	}
@@ -96,7 +96,7 @@ void NetSocketAndroid::close() {
 }
 
 Error NetSocketAndroid::set_broadcasting_enabled(bool p_enabled) {
-	Error err = NetSocketPosix::set_broadcasting_enabled(p_enabled);
+	Error err = NetSocketUnix::set_broadcasting_enabled(p_enabled);
 	if (err != OK) {
 		return err;
 	}
@@ -115,7 +115,7 @@ Error NetSocketAndroid::set_broadcasting_enabled(bool p_enabled) {
 }
 
 Error NetSocketAndroid::join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
-	Error err = NetSocketPosix::join_multicast_group(p_multi_address, p_if_name);
+	Error err = NetSocketUnix::join_multicast_group(p_multi_address, p_if_name);
 	if (err != OK) {
 		return err;
 	}
@@ -129,7 +129,7 @@ Error NetSocketAndroid::join_multicast_group(const IPAddress &p_multi_address, c
 }
 
 Error NetSocketAndroid::leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
-	Error err = NetSocketPosix::leave_multicast_group(p_multi_address, p_if_name);
+	Error err = NetSocketUnix::leave_multicast_group(p_multi_address, p_if_name);
 	if (err != OK) {
 		return err;
 	}

--- a/platform/android/net_socket_android.h
+++ b/platform/android/net_socket_android.h
@@ -44,7 +44,7 @@
  * the lock when broadcasting is enabled/disabled on a socket, or that socket
  * joins/leaves a multicast group.
  */
-class NetSocketAndroid : public NetSocketPosix {
+class NetSocketAndroid : public NetSocketUnix {
 private:
 	static jobject net_utils;
 	static jclass cls;

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -201,7 +201,7 @@ def configure(env: "SConsEnvironment"):
         sys.exit(255)
 
     env.Prepend(CPPPATH=["#platform/web"])
-    env.Append(CPPDEFINES=["WEB_ENABLED", "UNIX_ENABLED"])
+    env.Append(CPPDEFINES=["WEB_ENABLED", "UNIX_ENABLED", "UNIX_SOCKET_UNAVAILABLE"])
 
     if env["opengl3"]:
         env.AppendUnique(CPPDEFINES=["GLES3_ENABLED"])


### PR DESCRIPTION
They are not supported anyway, emscripten has an emulation layer that implements them over WebSocket/WebRTC, which is really surprising for users, and also not very useful since we have proper WebSocket and WebRTC support.

This can make the build smaller, if we also disable the UPNP module (which will otherwise include a third party library referencing "socket" thus forcing emscripten to include the compatibility layer)

Fixes #98389