### PR TITLE
[Web] Don't cache emsdk

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -8,7 +8,6 @@ env:
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no use_closure_compiler=yes strict_checks=yes
   EM_VERSION: 3.1.64
-  EM_CACHE_FOLDER: emsdk-cache
 
 concurrency:
   group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-web
@@ -46,8 +45,7 @@ jobs:
         uses: mymindstorm/setup-emsdk@v14
         with:
           version: ${{ env.EM_VERSION }}
-          actions-cache-folder: ${{ env.EM_CACHE_FOLDER }}
-          cache-key: emsdk-${{ matrix.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}
+          no-cache: true
 
       - name: Verify Emscripten setup
         run: |


### PR DESCRIPTION
Due to how caching works between branches, and this cache being identical for the same version, having this cached doesn't really help. Unfortunately unifying these cache entries doesn't work because of this, so I think it's better to just not cache them at all, downloading emsdk doesn't seem to take much time either (especially since I think CI caches downloads in other ways already) so this won't really hurt performance wise

But saves us a sizable amount of cache space

I've made a 3.x specific version as well and will open a PR for that if this is approved

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
