### PR TITLE
Fix `engine_type_colors`'s description

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1395,7 +1395,7 @@
 			The script editor's documentation comment color. In GDScript, this is used for comments starting with [code]##[/code]. In C#, this is used for comments starting with [code]///[/code] or [code]/**[/code].
 		</member>
 		<member name="text_editor/theme/highlighting/engine_type_color" type="Color" setter="" getter="">
-			The script editor's engine type color ([Vector2], [Vector3], [Color], ...).
+			The script editor's engine type color ([Object], [Mesh], [Node], ...).
 		</member>
 		<member name="text_editor/theme/highlighting/executing_line_color" type="Color" setter="" getter="">
 			The script editor's color for the debugger's executing line icon (displayed in the gutter).


### PR DESCRIPTION
in editor>editor settings>Text Editor>Theme, if you hover hover over "Engine Type Color", it has "Vector2", "Vector3"and "Color" as example but these are not Engine types. and their color is controlled by the "Base Type Color" setting. I discovered this while trying to customize my editor a bit more.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
