### PR TITLE
Windows: Fix duplicate .exe extension with mingw on Linux/macOS

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -719,9 +719,6 @@ def configure_mingw(env: "SConsEnvironment"):
 
     ## Compiler configuration
 
-    if os.name != "nt":
-        env["PROGSUFFIX"] = env["PROGSUFFIX"] + ".exe"  # for linux cross-compilation
-
     if env["arch"] == "x86_32":
         if env["use_static_cpp"]:
             env.Append(LINKFLAGS=["-static"])


### PR DESCRIPTION
This old hack is no longer needed and now wrong after #98105.

Fixes #98967.