### PR TITLE
Add `CATEGORY_UNDEFINED` option in Android export

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1898,7 +1898,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/unique_name", PROPERTY_HINT_PLACEHOLDER_TEXT, "ext.domain.name"), "com.example.$genname", false, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name [default if blank]"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/signed"), true));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "package/app_category", PROPERTY_HINT_ENUM, "Accessibility,Audio,Game,Image,Maps,News,Productivity,Social,Video"), APP_CATEGORY_GAME));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "package/app_category", PROPERTY_HINT_ENUM, "Accessibility,Audio,Game,Image,Maps,News,Productivity,Social,Video,Undefined"), APP_CATEGORY_GAME));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/retain_data_on_uninstall"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/exclude_from_recents"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/show_in_android_tv"), false));

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -88,6 +88,8 @@ int _get_app_category_value(int category_index) {
 			return 7;
 		case APP_CATEGORY_SOCIAL:
 			return 4;
+		case APP_CATEGORY_UNDEFINED:
+			return -1;
 		case APP_CATEGORY_VIDEO:
 			return 2;
 		case APP_CATEGORY_GAME:
@@ -311,17 +313,21 @@ String _get_application_tag(const Ref<EditorExportPlatform> &p_export_platform, 
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
 			"        android:allowBackup=\"%s\"\n"
 			"        android:icon=\"@mipmap/icon\"\n"
-			"        android:appCategory=\"%s\"\n"
 			"        android:isGame=\"%s\"\n"
 			"        android:hasFragileUserData=\"%s\"\n"
-			"        android:requestLegacyExternalStorage=\"%s\"\n"
-			"        tools:replace=\"android:allowBackup,android:appCategory,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n"
-			"        tools:ignore=\"GoogleAppIndexingWarning\">\n\n",
+			"        android:requestLegacyExternalStorage=\"%s\"\n",
 			bool_to_string(p_preset->get("user_data_backup/allow")),
-			_get_app_category_label(app_category_index),
 			bool_to_string(is_game),
 			bool_to_string(p_preset->get("package/retain_data_on_uninstall")),
 			bool_to_string(p_has_read_write_storage_permission));
+	if (app_category_index != APP_CATEGORY_UNDEFINED) {
+		manifest_application_text += vformat("        android:appCategory=\"%s\"\n", _get_app_category_label(app_category_index));
+		manifest_application_text += "        tools:replace=\"android:allowBackup,android:appCategory,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n";
+	} else {
+		manifest_application_text += "        tools:remove=\"android:appCategory\"\n";
+		manifest_application_text += "        tools:replace=\"android:allowBackup,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n";
+	}
+	manifest_application_text += "        tools:ignore=\"GoogleAppIndexingWarning\">\n\n";
 
 	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	for (int i = 0; i < export_plugins.size(); i++) {

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -55,6 +55,7 @@ static const int APP_CATEGORY_NEWS = 5;
 static const int APP_CATEGORY_PRODUCTIVITY = 6;
 static const int APP_CATEGORY_SOCIAL = 7;
 static const int APP_CATEGORY_VIDEO = 8;
+static const int APP_CATEGORY_UNDEFINED = 9;
 
 // Supported XR modes.
 // This should match the entries in 'platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java'


### PR DESCRIPTION
The app category is optional in Android, but currently, there is no option in the Godot editor to leave it undefined. In this PR, I have introduced a new category, UNDEFINED. When this category is selected, the `appCategory` will not be defined in the Android manifest file.

I have implemented logic to remove this attribute completely during the Gradle build export. However, in the normal export, I am setting its value to `-1` instead.
