### PR TITLE
Expose `TranslationServer::standardize_locale` `add_default` param publicly

### DIFF
--- a/core/string/translation_server.compat.inc
+++ b/core/string/translation_server.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  translation_server.compat.inc                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+String TranslationServer::_standardize_locale_bind_compat_98972(const String &p_locale) const {
+	return standardize_locale(p_locale, false);
+}
+
+void TranslationServer::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("standardize_locale", "locale"), &TranslationServer::_standardize_locale_bind_compat_98972);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "translation_server.h"
+#include "translation_server.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
@@ -218,8 +219,8 @@ TranslationServer::Locale::Locale(const TranslationServer &p_server, const Strin
 	}
 }
 
-String TranslationServer::standardize_locale(const String &p_locale) const {
-	return Locale(*this, p_locale, false).operator String();
+String TranslationServer::standardize_locale(const String &p_locale, bool p_add_defaults) const {
+	return Locale(*this, p_locale, p_add_defaults).operator String();
 }
 
 int TranslationServer::compare_locales(const String &p_locale_a, const String &p_locale_b) const {
@@ -591,7 +592,7 @@ void TranslationServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tool_locale"), &TranslationServer::get_tool_locale);
 
 	ClassDB::bind_method(D_METHOD("compare_locales", "locale_a", "locale_b"), &TranslationServer::compare_locales);
-	ClassDB::bind_method(D_METHOD("standardize_locale", "locale"), &TranslationServer::standardize_locale);
+	ClassDB::bind_method(D_METHOD("standardize_locale", "locale", "add_defaults"), &TranslationServer::standardize_locale, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("get_all_languages"), &TranslationServer::get_all_languages);
 	ClassDB::bind_method(D_METHOD("get_language_name", "language"), &TranslationServer::get_language_name);

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -52,9 +52,13 @@ class TranslationServer : public Object {
 
 	static inline TranslationServer *singleton = nullptr;
 	bool _load_translations(const String &p_from);
-	String _standardize_locale(const String &p_locale, bool p_add_defaults) const;
 
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	String _standardize_locale_bind_compat_98972(const String &p_locale) const;
+	static void _bind_compatibility_methods();
+#endif
 
 	struct LocaleScriptInfo {
 		String name;
@@ -129,7 +133,7 @@ public:
 	void set_pseudolocalization_enabled(bool p_enabled);
 	void reload_pseudolocalization();
 
-	String standardize_locale(const String &p_locale) const;
+	String standardize_locale(const String &p_locale, bool p_add_defaults = false) const;
 
 	int compare_locales(const String &p_locale_a, const String &p_locale_b) const;
 

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -160,8 +160,9 @@
 		<method name="standardize_locale" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="locale" type="String" />
+			<param index="1" name="add_defaults" type="bool" default="false" />
 			<description>
-				Returns a [param locale] string standardized to match known locales (e.g. [code]en-US[/code] would be matched to [code]en_US[/code]).
+				Returns a [param locale] string standardized to match known locales (e.g. [code]en-US[/code] would be matched to [code]en_US[/code]). If [param add_defaults] is [code]true[/code], the locale may have a default script or country added.
 			</description>
 		</method>
 		<method name="translate" qualifiers="const">

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -122,3 +122,10 @@ GH-98918
 Validate extension JSON: Error: Field 'classes/FileAccess/methods/open_encrypted/arguments': size changed value in new API, from 3 to 4.
 
 Optional argument added to allow setting initialization vector. Compatibility method registered.
+
+
+GH-98972
+--------
+Validate extension JSON: Error: Field 'classes/TranslationServer/methods/standardize_locale/arguments': size changed value in new API, from 1 to 2.
+
+Optional argument added. Compatibility method registered.

--- a/tests/core/string/test_translation_server.h
+++ b/tests/core/string/test_translation_server.h
@@ -104,6 +104,36 @@ TEST_CASE("[TranslationServer] Locale operations") {
 	res = ts->standardize_locale(loc);
 
 	CHECK(res == "de_DE");
+
+	// No added defaults.
+	loc = "es_ES";
+	res = ts->standardize_locale(loc, true);
+
+	CHECK(res == "es_ES");
+
+	// Add default script.
+	loc = "az_AZ";
+	res = ts->standardize_locale(loc, true);
+
+	CHECK(res == "az_Latn_AZ");
+
+	// Add default country.
+	loc = "pa_Arab";
+	res = ts->standardize_locale(loc, true);
+
+	CHECK(res == "pa_Arab_PK");
+
+	// Add default script and country.
+	loc = "zh";
+	res = ts->standardize_locale(loc, true);
+
+	CHECK(res == "zh_Hans_CN");
+
+	// Explicitly don't add defaults.
+	loc = "zh";
+	res = ts->standardize_locale(loc, false);
+
+	CHECK(res == "zh");
 }
 
 TEST_CASE("[TranslationServer] Comparing locales") {


### PR DESCRIPTION
Comparing locales can have surprising outcomes since it standardizes locales with defaults. For example, zh and zh_CN result in an exact match since the defaults change them both to zh_Hans_CN. Expose the add_default parameter publicly with a default of false so the fully standardized locale can be inspected.

Closes: https://github.com/godotengine/godot-proposals/issues/11119