### PR TITLE
Move D3D12 fence `SetEventOnCompletion` call to `fence_wait` to avoid stalling on some platforms

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -2192,6 +2192,7 @@ RDD::FenceID RenderingDeviceDriverD3D12::fence_create() {
 
 Error RenderingDeviceDriverD3D12::fence_wait(FenceID p_fence) {
 	FenceInfo *fence = (FenceInfo *)(p_fence.id);
+	fence->d3d_fence->SetEventOnCompletion(fence->fence_value, fence->event_handle);
 	DWORD res = WaitForSingleObjectEx(fence->event_handle, INFINITE, FALSE);
 #ifdef PIX_ENABLED
 	PIXNotifyWakeFromFenceSignal(fence->event_handle);
@@ -2286,7 +2287,6 @@ Error RenderingDeviceDriverD3D12::command_queue_execute_and_present(CommandQueue
 			FenceInfo *fence = (FenceInfo *)(p_cmd_fence.id);
 			fence->fence_value++;
 			command_queue->d3d_queue->Signal(fence->d3d_fence.Get(), fence->fence_value);
-			fence->d3d_fence->SetEventOnCompletion(fence->fence_value, fence->event_handle);
 		}
 	}
 


### PR DESCRIPTION
This is a weird one and hasn't been reported upstream. 

Basically `SetEventOnCompletion()` should be fine to call anytime after the `Signal()` and before we wait on the fence. The [docs](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12fence-seteventoncompletion) don't indicate that it should stall, but in testing, it appears that there are cases where it will stall until GPU work finishes. In any case, all the [official samples](https://github.com/Microsoft/DirectX-Graphics-Samples) call `SetEventOnCompletion()` immediately before `WaitForSingleObjectEx()` so we should do the same. 

In testing with our complex 3D test project on the affected hardware we get roughly double the performance from this change. 