### PR TITLE
Remove unnecessary condition in WAV importer

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -213,9 +213,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 				frames = remaining_bytes;
 			}
 
-			if (format_channels == 0) {
-				ERR_FAIL_COND_V(format_channels == 0, ERR_INVALID_DATA);
-			}
+			ERR_FAIL_COND_V(format_channels == 0, ERR_INVALID_DATA);
 			frames /= format_channels;
 			frames /= (format_bits >> 3);
 


### PR DESCRIPTION
The check could actually be completely removed as we error if `format_channels` is different from 1 and 2 + if data chunk is found before format chunk, but it is just safer to keep it for future code changes.