### PR TITLE
Prevent stack-use-after-scope in rendering_device_driver_metal.mm

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -1978,7 +1978,8 @@ Vector<uint8_t> RenderingDeviceDriverMetal::shader_compile_binary_from_spirv(Vec
 
 		ERR_FAIL_COND_V_MSG(compiler.get_entry_points_and_stages().size() != 1, Result(), "Expected a single entry point and stage.");
 
-		EntryPoint &entry_point_stage = compiler.get_entry_points_and_stages().front();
+		SmallVector<EntryPoint> entry_pts_stages = compiler.get_entry_points_and_stages();
+		EntryPoint &entry_point_stage = entry_pts_stages.front();
 		SPIREntryPoint &entry_point = compiler.get_entry_point(entry_point_stage.name, entry_point_stage.execution_model);
 
 		// Process specialization constants.


### PR DESCRIPTION
This fixes a stack-use-after-scope error that I was getting on MacOS with sanitizers:

<img width="813" alt="image" src="https://github.com/user-attachments/assets/507e8ed5-b553-4ab8-b922-0323d0edaf43">

The problem is when it tries to get a reference from get_entry_points_and_stages().front(), but since the SmallVector<EntryPoint> that get_entry_points_and_stages() passes back  is dynamically created, it deconstructs right after front() passes back that reference, thus we keep a reference to something that is no longer in scope.


<img width="853" alt="image" src="https://github.com/user-attachments/assets/2a025875-d810-4e96-9187-2828efc6c887">

Keeping that vector in scope fixes the issue.

[asan.log](https://github.com/user-attachments/files/17686213/asan.log)
