### PR TITLE
Optimize runtime 2d selection box

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -1622,7 +1622,7 @@ void RuntimeNodeSelect::_update_selection() {
 
 		const Color selection_color_2d = Color(1, 0.6, 0.4, 0.7);
 		for (int i = 0; i < 4; i++) {
-			RS::get_singleton()->canvas_item_add_line(sbox_2d_ci, endpoints[i], endpoints[(i + 1) % 4], selection_color_2d, Math::round(2.f));
+			RS::get_singleton()->canvas_item_add_line(sbox_2d_ci, endpoints[i], endpoints[(i + 1) % 4], selection_color_2d);
 		}
 	} else {
 #ifndef _3D_DISABLED


### PR DESCRIPTION
Make the 2d select box not change width with canvas scaling.
Before:
![图片](https://github.com/user-attachments/assets/903b6d66-5029-446f-b99e-a8de33c82136)

After:
![图片](https://github.com/user-attachments/assets/2c62321e-b7b7-4e07-a9ee-5cecc2cadffc)
