### PR TITLE
[Editor] Fix order of editor features

### DIFF
--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -43,37 +43,37 @@
 const char *EditorFeatureProfile::feature_names[FEATURE_MAX] = {
 	TTRC("3D Editor"),
 	TTRC("Script Editor"),
-	TTRC("Game View"),
 	TTRC("Asset Library"),
 	TTRC("Scene Tree Editing"),
 	TTRC("Node Dock"),
 	TTRC("FileSystem Dock"),
 	TTRC("Import Dock"),
 	TTRC("History Dock"),
+	TTRC("Game View"),
 };
 
 const char *EditorFeatureProfile::feature_descriptions[FEATURE_MAX] = {
 	TTRC("Allows to view and edit 3D scenes."),
 	TTRC("Allows to edit scripts using the integrated script editor."),
-	TTRC("Provides tools for selecting and debugging nodes at runtime."),
 	TTRC("Provides built-in access to the Asset Library."),
 	TTRC("Allows editing the node hierarchy in the Scene dock."),
 	TTRC("Allows to work with signals and groups of the node selected in the Scene dock."),
 	TTRC("Allows to browse the local file system via a dedicated dock."),
 	TTRC("Allows to configure import settings for individual assets. Requires the FileSystem dock to function."),
 	TTRC("Provides an overview of the editor's and each scene's undo history."),
+	TTRC("Provides tools for selecting and debugging nodes at runtime."),
 };
 
 const char *EditorFeatureProfile::feature_identifiers[FEATURE_MAX] = {
 	"3d",
 	"script",
-	"game",
 	"asset_lib",
 	"scene_tree",
 	"node_dock",
 	"filesystem_dock",
 	"import_dock",
 	"history_dock",
+	"game",
 };
 
 void EditorFeatureProfile::set_disable_class(const StringName &p_class, bool p_disabled) {


### PR DESCRIPTION
Order was broken after adding `Game View`

The new entry in the enum was added earlier at first, but was moved to the end to preserve compatibility, the associated strings were missed in the process

Regression from:
* https://github.com/godotengine/godot/pull/97257

---

* Fixes: https://github.com/godotengine/godot/issues/98981
* Fixes: https://github.com/godotengine/godot/issues/98987

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
