### PR TITLE
[TileMapLayer] Add set_cells to set multiple cells at once

### DIFF
--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -220,6 +220,16 @@
 				If [param source_id] is set to [code]-1[/code], [param atlas_coords] to [code]Vector2i(-1, -1)[/code], or [param alternative_tile] to [code]-1[/code], the cell will be erased. An erased cell gets [b]all[/b] its identifiers automatically set to their respective invalid values, namely [code]-1[/code], [code]Vector2i(-1, -1)[/code] and [code]-1[/code].
 			</description>
 		</method>
+		<method name="set_cells">
+			<return type="void" />
+			<param index="0" name="cells" type="Vector2i[]" />
+			<param index="1" name="source_id" type="int" default="-1" />
+			<param index="2" name="atlas_coords" type="Vector2i" default="Vector2i(-1, -1)" />
+			<param index="3" name="alternative_tile" type="int" default="0" />
+			<description>
+				Sets the tile identifiers for all the cells inside the [param cells] array.
+			</description>
+		</method>
 		<method name="set_cells_terrain_connect">
 			<return type="void" />
 			<param index="0" name="cells" type="Vector2i[]" />

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1783,6 +1783,7 @@ void TileMapLayer::_bind_methods() {
 	// --- Cells manipulation ---
 	// Generic cells manipulations and access.
 	ClassDB::bind_method(D_METHOD("set_cell", "coords", "source_id", "atlas_coords", "alternative_tile"), &TileMapLayer::set_cell, DEFVAL(TileSet::INVALID_SOURCE), DEFVAL(TileSetSource::INVALID_ATLAS_COORDS), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("set_cells", "cells", "source_id", "atlas_coords", "alternative_tile"), &TileMapLayer::set_cells, DEFVAL(TileSet::INVALID_SOURCE), DEFVAL(TileSetSource::INVALID_ATLAS_COORDS), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("erase_cell", "coords"), &TileMapLayer::erase_cell);
 	ClassDB::bind_method(D_METHOD("fix_invalid_tiles"), &TileMapLayer::fix_invalid_tiles);
 	ClassDB::bind_method(D_METHOD("clear"), &TileMapLayer::clear);
@@ -2380,6 +2381,13 @@ void TileMapLayer::set_cell(const Vector2i &p_coords, int p_source_id, const Vec
 	_queue_internal_update();
 
 	used_rect_cache_dirty = true;
+}
+
+void TileMapLayer::set_cells(TypedArray<Vector2i> p_coords_array, int p_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile) {
+	for (const Variant &variant : p_coords_array) {
+		const Vector2i &E = variant;
+		set_cell(E, p_source_id, p_atlas_coords, p_alternative_tile);
+	}
 }
 
 void TileMapLayer::erase_cell(const Vector2i &p_coords) {

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -428,6 +428,7 @@ public:
 	// --- Cells manipulation ---
 	// Generic cells manipulations and data access.
 	void set_cell(const Vector2i &p_coords, int p_source_id = TileSet::INVALID_SOURCE, const Vector2i &p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = 0);
+	void set_cells(TypedArray<Vector2i> p_coords_array, int p_source_id = TileSet::INVALID_SOURCE, const Vector2i &p_atlas_coords = TileSetSource::INVALID_ATLAS_COORDS, int p_alternative_tile = 0);
 	void erase_cell(const Vector2i &p_coords);
 	void fix_invalid_tiles();
 	void clear();


### PR DESCRIPTION
Adds `TileMapLayer::set_cells` to set multiple cells at once using an array of `Vector2i` positions, similar to `TileMapLayer::set_cells_terrain_connect` and `TileMapLayer::set_cells_terrain_path`.

**Why?** It's ~3 times faster than setting each tile manually in GDScript.