### PR TITLE
Fix more miscellaneous oddities around the class reference

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -991,8 +991,8 @@
 				[codeblock]
 				var a = rand_from_seed(4)
 
-				print(a[0])	# Prints 2879024997
-				print(a[1])	# Prints 4
+				print(a[0]) # Prints 2879024997
+				print(a[1]) # Prints 4
 				[/codeblock]
 			</description>
 		</method>
@@ -2992,7 +2992,7 @@
 		<constant name="PROPERTY_USAGE_SCRIPT_DEFAULT_VALUE" value="32768" enum="PropertyUsageFlags" is_bitfield="true" deprecated="This flag is not used by the engine.">
 		</constant>
 		<constant name="PROPERTY_USAGE_CLASS_IS_ENUM" value="65536" enum="PropertyUsageFlags" is_bitfield="true">
-			The property is an enum, i.e. it only takes named integer constants from its associated enumeration.
+			The property is a variable of enum type, i.e. it only takes named integer constants from its associated enumeration.
 		</constant>
 		<constant name="PROPERTY_USAGE_NIL_IS_VARIANT" value="131072" enum="PropertyUsageFlags" is_bitfield="true">
 			If property has [code]nil[/code] as default value, its type will be [Variant].

--- a/doc/classes/AudioEffectSpectrumAnalyzer.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzer.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		This audio effect does not affect sound output, but can be used for real-time audio visualizations.
-		This resource configures an [AudioEffectSpectrumAnalyzerInstance], which performs the actual analysis at runtime. An instance can be acquired with [method AudioServer.get_bus_effect_instance].
+		This resource configures an [AudioEffectSpectrumAnalyzerInstance], which performs the actual analysis at runtime. An instance can be obtained with [method AudioServer.get_bus_effect_instance].
 		See also [AudioStreamGenerator] for procedurally generating sounds.
 	</description>
 	<tutorials>

--- a/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
+++ b/doc/classes/AudioEffectSpectrumAnalyzerInstance.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		The runtime part of an [AudioEffectSpectrumAnalyzer], which can be used to query the magnitude of a frequency range on its host bus.
-		An instance of this class can be acquired with [method AudioServer.get_bus_effect_instance].
+		An instance of this class can be obtained with [method AudioServer.get_bus_effect_instance].
 	</description>
 	<tutorials>
 		<link title="Audio Spectrum Visualizer Demo">https://godotengine.org/asset-library/asset/2762</link>

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -633,7 +633,7 @@
 		</member>
 		<member name="y_sort_enabled" type="bool" setter="set_y_sort_enabled" getter="is_y_sort_enabled" default="false">
 			If [code]true[/code], this and child [CanvasItem] nodes with a higher Y position are rendered in front of nodes with a lower Y position. If [code]false[/code], this and child [CanvasItem] nodes are rendered normally in scene tree order.
-			With Y-sorting enabled on a parent node ('A') but disabled on a child node ('B'), the child node ('B') is sorted but its children ('C1', 'C2', etc) render together on the same Y position as the child node ('B'). This allows you to organize the render order of a scene without changing the scene tree.
+			With Y-sorting enabled on a parent node ('A') but disabled on a child node ('B'), the child node ('B') is sorted but its children ('C1', 'C2', etc.) render together on the same Y position as the child node ('B'). This allows you to organize the render order of a scene without changing the scene tree.
 			Nodes sort relative to each other only if they are on the same [member z_index].
 		</member>
 		<member name="z_as_relative" type="bool" setter="set_z_as_relative" getter="is_z_relative" default="true">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -168,7 +168,7 @@
 				The returned node must be of type [Control] or Control-derived. It can have child nodes of any type. It is freed when the tooltip disappears, so make sure you always provide a new instance (if you want to use a pre-existing node from your scene tree, you can duplicate it and pass the duplicated instance). When [code]null[/code] or a non-Control node is returned, the default tooltip will be used instead.
 				The returned node will be added as child to a [PopupPanel], so you should only provide the contents of that panel. That [PopupPanel] can be themed using [method Theme.set_stylebox] for the type [code]"TooltipPanel"[/code] (see [member tooltip_text] for an example).
 				[b]Note:[/b] The tooltip is shrunk to minimal size. If you want to ensure it's fully visible, you might want to set its [member custom_minimum_size] to some non-zero value.
-				[b]Note:[/b] The node (and any relevant children) should be [member CanvasItem.visible] when returned, otherwise, the viewport that instantiates it will not be able to calculate its minimum size reliably.
+				[b]Note:[/b] The node (and any relevant children) should have their [member CanvasItem.visible] set to [code]true[/code] when returned, otherwise, the viewport that instantiates it will not be able to calculate its minimum size reliably.
 				[b]Example:[/b] Use a constructed node as a tooltip:
 				[codeblocks]
 				[gdscript]
@@ -559,7 +559,7 @@
 		<method name="grab_click_focus">
 			<return type="void" />
 			<description>
-				Creates an [InputEventMouseButton] that attempts to click the control. If the event is received, the control acquires focus.
+				Creates an [InputEventMouseButton] that attempts to click the control. If the event is received, the control gains focus.
 				[codeblocks]
 				[gdscript]
 				func _process(delta):

--- a/doc/classes/EditorNode3DGizmoPlugin.xml
+++ b/doc/classes/EditorNode3DGizmoPlugin.xml
@@ -54,7 +54,7 @@
 			<return type="EditorNode3DGizmo" />
 			<param index="0" name="for_node_3d" type="Node3D" />
 			<description>
-				Override this method to return a custom [EditorNode3DGizmo] for the spatial nodes of your choice, return [code]null[/code] for the rest of nodes. See also [method _has_gizmo].
+				Override this method to return a custom [EditorNode3DGizmo] for the 3D nodes of your choice, return [code]null[/code] for the rest of nodes. See also [method _has_gizmo].
 			</description>
 		</method>
 		<method name="_get_gizmo_name" qualifiers="virtual const">

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -416,7 +416,7 @@
 			<param index="1" name="title" type="String" />
 			<param index="2" name="shortcut" type="Shortcut" default="null" />
 			<description>
-				Adds a control to the bottom panel (together with Output, Debug, Animation, etc). Returns a reference to the button added. It's up to you to hide/show the button when needed. When your plugin is deactivated, make sure to remove your custom control with [method remove_control_from_bottom_panel] and free it with [method Node.queue_free].
+				Adds a control to the bottom panel (together with Output, Debug, Animation, etc.). Returns a reference to the button added. It's up to you to hide/show the button when needed. When your plugin is deactivated, make sure to remove your custom control with [method remove_control_from_bottom_panel] and free it with [method Node.queue_free].
 				Optionally, you can specify a shortcut parameter. When pressed, this shortcut will toggle the bottom panel's visibility. See the default editor bottom panel shortcuts in the Editor Settings for inspiration. Per convention, they all use [kbd]Alt[/kbd] modifier.
 			</description>
 		</method>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -29,7 +29,7 @@
 			<description>
 				Adds an item to the item list with specified text. Returns the index of an added item.
 				Specify an [param icon], or use [code]null[/code] as the [param icon] for a list item with no icon.
-				If selectable is [code]true[/code], the list item will be selectable.
+				If [param selectable] is [code]true[/code], the list item will be selectable.
 			</description>
 		</method>
 		<method name="clear">

--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -66,7 +66,7 @@
 		</member>
 		<member name="quality" type="int" setter="set_bake_quality" getter="get_bake_quality" enum="LightmapGI.BakeQuality" default="1">
 			The quality preset to use when baking lightmaps. This affects bake times, but output file sizes remain mostly identical across quality levels.
-			To further speed up bake times, decrease [member bounces], disable [member use_denoiser] and increase the lightmap texel size on 3D scenes in the Import doc.
+			To further speed up bake times, decrease [member bounces], disable [member use_denoiser] and increase the lightmap texel size on 3D scenes in the Import dock.
 		</member>
 		<member name="texel_scale" type="float" setter="set_texel_scale" getter="get_texel_scale" default="1.0">
 			Scales the lightmap texel density of all meshes for the current bake. This is a multiplier that builds upon the existing lightmap texel size defined in each imported 3D scene, along with the per-mesh density multiplier (which is designed to be used when the same mesh is used at different scales). Lower values will result in faster bake times.

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -88,7 +88,7 @@
 			<param index="3" name="arguments" type="Array" default="[]" />
 			<description>
 				Sends an RPC to the target [param peer]. The given [param method] will be called on the remote [param object] with the provided [param arguments]. The RPC may also be called locally depending on the implementation and RPC configuration. See [method Node.rpc] and [method Node.rpc_config].
-				[b]Note:[/b] Prefer using [method Node.rpc], [method Node.rpc_id], or [code]my_method.rpc(peer, arg1, arg2, ...)[/code] (in GDScript), since they are faster. This method is mostly useful in conjunction with [MultiplayerAPIExtension] when augmenting or replacing the multiplayer capabilities.
+				[b]Note:[/b] Prefer using [method Node.rpc], [method Node.rpc_id], or [code]my_method.rpc(peer, arg1, arg2, ...)[/code] (in GDScript), since they are faster. This method is mostly useful in conjunction with [MultiplayerAPIExtension] when extending or replacing the multiplayer capabilities.
 			</description>
 		</method>
 		<method name="set_default_interface" qualifiers="static">

--- a/doc/classes/MultiplayerAPIExtension.xml
+++ b/doc/classes/MultiplayerAPIExtension.xml
@@ -4,14 +4,14 @@
 		Base class used for extending the [MultiplayerAPI].
 	</brief_description>
 	<description>
-		This class can be used to augment or replace the default [MultiplayerAPI] implementation via script or extensions.
-		The following example augment the default implementation ([SceneMultiplayer]) by logging every RPC being made, and every object being configured for replication.
+		This class can be used to extend or replace the default [MultiplayerAPI] implementation via script or extensions.
+		The following example extend the default implementation ([SceneMultiplayer]) by logging every RPC being made, and every object being configured for replication.
 		[codeblocks]
 		[gdscript]
 		extends MultiplayerAPIExtension
 		class_name LogMultiplayer
 
-		# We want to augment the default SceneMultiplayer.
+		# We want to extend the default SceneMultiplayer.
 		var base_multiplayer = SceneMultiplayer.new()
 
 		func _init():
@@ -49,7 +49,7 @@
 		        print("Removing node %s from the spawn list. Spawner: %s" % [object, config])
 		    return base_multiplayer.object_configuration_remove(object, config)
 
-		# These can be optional, but in our case we want to augment SceneMultiplayer, so forward everything.
+		# These can be optional, but in our case we want to extend SceneMultiplayer, so forward everything.
 		func _set_multiplayer_peer(p_peer: MultiplayerPeer):
 		    base_multiplayer.multiplayer_peer = p_peer
 
@@ -69,7 +69,7 @@
 		# autoload.gd
 		func _enter_tree():
 		    # Sets our custom multiplayer as the main one in SceneTree.
-		get_tree().set_multiplayer(LogMultiplayer.new())
+		    get_tree().set_multiplayer(LogMultiplayer.new())
 		[/gdscript]
 		[/codeblocks]
 		Native extensions can alternatively use the [method MultiplayerAPI.set_default_interface] method during initialization to configure themselves as the default implementation.

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -343,7 +343,7 @@
 				    return "Welcome to Godot 4!"
 
 				func _init():
-				    print(self)       # Prints Welcome to Godot 4!"
+				    print(self)       # Prints "Welcome to Godot 4!"
 				    var a = str(self) # a is "Welcome to Godot 4!"
 				[/codeblock]
 			</description>
@@ -406,7 +406,7 @@
 			<param index="0" name="signal" type="String" />
 			<param index="1" name="arguments" type="Array" default="[]" />
 			<description>
-				Adds a user-defined [param signal]. Optional arguments for the signal can be added as an [Array] of dictionaries, each defining a [code]name[/code] [String] and a [code]type[/code] [int] (see [enum Variant.Type]). See also [method has_user_signal] and [method remove_user_signal].
+				Adds a user-defined signal named [param signal]. Optional arguments for the signal can be added as an [Array] of dictionaries, each defining a [code]name[/code] [String] and a [code]type[/code] [int] (see [enum Variant.Type]). See also [method has_user_signal] and [method remove_user_signal].
 				[codeblocks]
 				[gdscript]
 				add_user_signal("hurt", [

--- a/doc/classes/RenderData.xml
+++ b/doc/classes/RenderData.xml
@@ -19,7 +19,7 @@
 		<method name="get_environment" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Returns the [RID] of the environments object in the [RenderingServer] being used to render this viewport.
+				Returns the [RID] of the environment object in the [RenderingServer] being used to render this viewport.
 			</description>
 		</method>
 		<method name="get_render_scene_buffers" qualifiers="const">

--- a/doc/classes/RenderSceneBuffersRD.xml
+++ b/doc/classes/RenderSceneBuffersRD.xml
@@ -52,7 +52,7 @@
 			<param index="2" name="view_name" type="StringName" />
 			<param index="3" name="view" type="RDTextureView" />
 			<description>
-				Create a new texture view for an existing texture and cache this under the given view_name. Will return the existing teture view if it already exists. Will error if the source texture doesn't exist.
+				Create a new texture view for an existing texture and cache this under the given [param view_name]. Will return the existing texture view if it already exists. Will error if the source texture doesn't exist.
 			</description>
 		</method>
 		<method name="get_color_layer">

--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -140,7 +140,7 @@
 			<param index="0" name="flip" type="bool" default="false" />
 			<description>
 				Generates normals from vertices so you do not have to do it manually. If [param flip] is [code]true[/code], the resulting normals will be inverted. [method generate_normals] should be called [i]after[/i] generating geometry and [i]before[/i] committing the mesh using [method commit] or [method commit_to_arrays]. For correct display of normal-mapped surfaces, you will also have to generate tangents using [method generate_tangents].
-				[b]Note:[/b] [method generate_normals] only works if the primitive type to be set to [constant Mesh.PRIMITIVE_TRIANGLES].
+				[b]Note:[/b] [method generate_normals] only works if the primitive type is set to [constant Mesh.PRIMITIVE_TRIANGLES].
 				[b]Note:[/b] [method generate_normals] takes smooth groups into account. To generate smooth normals, set the smooth group to a value greater than or equal to [code]0[/code] using [method set_smooth_group] or leave the smooth group at the default of [code]0[/code]. To generate flat normals, set the smooth group to [code]-1[/code] using [method set_smooth_group] prior to adding vertices.
 			</description>
 		</method>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -316,7 +316,7 @@
 			See also [member ProjectSettings.rendering/anti_aliasing/quality/msaa_2d] and [method RenderingServer.viewport_set_msaa_2d].
 		</member>
 		<member name="msaa_3d" type="int" setter="set_msaa_3d" getter="get_msaa_3d" enum="Viewport.MSAA" default="0">
-			The multisample antialiasing mode for 3D rendering. A higher number results in smoother edges at the cost of significantly worse performance. A value of [constant Viewport.MSAA_2X] or [constant Viewport.MSAA_4X] is best unless targeting very high-end systems. See also bilinear scaling 3d [member scaling_3d_mode] for supersampling, which provides higher quality but is much more expensive. This has no effect on shader-induced aliasing or texture aliasing.
+			The multisample antialiasing mode for 3D rendering. A higher number results in smoother edges at the cost of significantly worse performance. A value of [constant Viewport.MSAA_2X] or [constant Viewport.MSAA_4X] is best unless targeting very high-end systems. See also bilinear scaling 3D [member scaling_3d_mode] for supersampling, which provides higher quality but is much more expensive. This has no effect on shader-induced aliasing or texture aliasing.
 			See also [member ProjectSettings.rendering/anti_aliasing/quality/msaa_3d] and [method RenderingServer.viewport_set_msaa_3d].
 		</member>
 		<member name="own_world_3d" type="bool" setter="set_use_own_world_3d" getter="is_using_own_world_3d" default="false">
@@ -357,7 +357,7 @@
 			[b]Note:[/b] If this is set to [code]0[/code], no positional shadows will be visible at all. This can improve performance significantly on low-end systems by reducing both the CPU and GPU load (as fewer draw calls are needed to draw the scene without shadows).
 		</member>
 		<member name="scaling_3d_mode" type="int" setter="set_scaling_3d_mode" getter="get_scaling_3d_mode" enum="Viewport.Scaling3DMode" default="0">
-			Sets scaling 3d mode. Bilinear scaling renders at different resolution to either undersample or supersample the viewport. FidelityFX Super Resolution 1.0, abbreviated to FSR, is an upscaling technology that produces high quality images at fast framerates by using a spatially aware upscaling algorithm. FSR is slightly more expensive than bilinear, but it produces significantly higher image quality. FSR should be used where possible.
+			Sets scaling 3D mode. Bilinear scaling renders at different resolution to either undersample or supersample the viewport. FidelityFX Super Resolution 1.0, abbreviated to FSR, is an upscaling technology that produces high quality images at fast framerates by using a spatially aware upscaling algorithm. FSR is slightly more expensive than bilinear, but it produces significantly higher image quality. FSR should be used where possible.
 			To control this property on the root viewport, set the [member ProjectSettings.rendering/scaling_3d/mode] project setting.
 		</member>
 		<member name="scaling_3d_scale" type="float" setter="set_scaling_3d_scale" getter="get_scaling_3d_scale" default="1.0">

--- a/doc/classes/XRCamera3D.xml
+++ b/doc/classes/XRCamera3D.xml
@@ -4,7 +4,7 @@
 		A camera node with a few overrules for AR/VR applied, such as location tracking.
 	</brief_description>
 	<description>
-		This is a helper spatial node for our camera; note that, if stereoscopic rendering is applicable (VR-HMD), most of the camera properties are ignored, as the HMD information overrides them. The only properties that can be trusted are the near and far planes.
+		This is a helper 3D node for our camera. Note that, if stereoscopic rendering is applicable (VR-HMD), most of the camera properties are ignored, as the HMD information overrides them. The only properties that can be trusted are the near and far planes.
 		The position and orientation of this node is automatically updated by the XR Server to represent the location of the HMD if such tracking is available and can thus be used by game logic. Note that, in contrast to the XR Controller, the render thread has access to the most up-to-date tracking data of the HMD and the location of the XRCamera3D can lag a few milliseconds behind what is used for rendering as a result.
 	</description>
 	<tutorials>

--- a/doc/classes/XRController3D.xml
+++ b/doc/classes/XRController3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="XRController3D" inherits="XRNode3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A spatial node representing a spatially-tracked controller.
+		A 3D node representing a spatially-tracked controller.
 	</brief_description>
 	<description>
-		This is a helper spatial node that is linked to the tracking of controllers. It also offers several handy passthroughs to the state of buttons and such on the controllers.
+		This is a helper 3D node that is linked to the tracking of controllers. It also offers several handy passthroughs to the state of buttons and such on the controllers.
 		Controllers are linked by their ID. You can create controller nodes before the controllers are available. If your game always uses two controllers (one for each hand), you can predefine the controllers with ID 1 and 2; they will become active as soon as the controllers are identified. If you expect additional controllers to be used, you should react to the signals and add XRController3D nodes to your scene.
 		The position of the controller node is automatically updated by the [XRServer]. This makes this node ideal to add child nodes to visualize the controller.
 		As many XR runtimes now use a configurable action map all inputs are named.

--- a/doc/classes/XRNode3D.xml
+++ b/doc/classes/XRNode3D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="XRNode3D" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A spatial node that has its position automatically updated by the [XRServer].
+		A 3D node that has its position automatically updated by the [XRServer].
 	</brief_description>
 	<description>
 		This node can be bound to a specific pose of a [XRPositionalTracker] and will automatically have its [member Node3D.transform] updated by the [XRServer]. Nodes of this type must be added as children of the [XROrigin3D] node.

--- a/modules/gltf/doc_classes/GLTFAccessor.xml
+++ b/modules/gltf/doc_classes/GLTFAccessor.xml
@@ -102,13 +102,13 @@
 			Component type "UNSIGNED_INT". The value is [code]0x1405[/code] which comes from OpenGL. This indicates data is stored in 4-byte or 32-bit unsigned integers. This is a core part of the glTF specification.
 		</constant>
 		<constant name="COMPONENT_TYPE_SINGLE_FLOAT" value="5126" enum="GLTFComponentType">
-			Component type "FLOAT". The value is [code]0x1406[/code] which comes from OpenGL. This indicates data is stored in 4-byte or 32-bit floating point numbers. This is a core part of the glTF specification.
+			Component type "FLOAT". The value is [code]0x1406[/code] which comes from OpenGL. This indicates data is stored in 4-byte or 32-bit floating-point numbers. This is a core part of the glTF specification.
 		</constant>
 		<constant name="COMPONENT_TYPE_DOUBLE_FLOAT" value="5130" enum="GLTFComponentType">
-			Component type "DOUBLE". The value is [code]0x140A[/code] which comes from OpenGL. This indicates data is stored in 8-byte or 64-bit floating point numbers. This is NOT a core part of the glTF specification, and may not be supported by all glTF importers. May be used by some extensions including [code]KHR_interactivity[/code].
+			Component type "DOUBLE". The value is [code]0x140A[/code] which comes from OpenGL. This indicates data is stored in 8-byte or 64-bit floating-point numbers. This is NOT a core part of the glTF specification, and may not be supported by all glTF importers. May be used by some extensions including [code]KHR_interactivity[/code].
 		</constant>
 		<constant name="COMPONENT_TYPE_HALF_FLOAT" value="5131" enum="GLTFComponentType">
-			Component type "HALF_FLOAT". The value is [code]0x140B[/code] which comes from OpenGL. This indicates data is stored in 2-byte or 16-bit floating point numbers. This is NOT a core part of the glTF specification, and may not be supported by all glTF importers. May be used by some extensions including [code]KHR_interactivity[/code].
+			Component type "HALF_FLOAT". The value is [code]0x140B[/code] which comes from OpenGL. This indicates data is stored in 2-byte or 16-bit floating-point numbers. This is NOT a core part of the glTF specification, and may not be supported by all glTF importers. May be used by some extensions including [code]KHR_interactivity[/code].
 		</constant>
 		<constant name="COMPONENT_TYPE_SIGNED_LONG" value="5134" enum="GLTFComponentType">
 			Component type "LONG". The value is [code]0x140E[/code] which comes from OpenGL. This indicates data is stored in 8-byte or 64-bit signed integers. This is NOT a core part of the glTF specification, and may not be supported by all glTF importers. May be used by some extensions including [code]KHR_interactivity[/code].

--- a/modules/openxr/doc_classes/OpenXRExtensionWrapperExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRExtensionWrapperExtension.xml
@@ -235,7 +235,7 @@
 			<return type="int" />
 			<param index="0" name="next_pointer" type="void*" />
 			<description>
-				Adds additional data structures when interogating OpenXR system abilities.
+				Adds additional data structures when querying OpenXR system abilities.
 			</description>
 		</method>
 		<method name="_set_viewport_composition_layer_and_get_next_pointer" qualifiers="virtual">


### PR DESCRIPTION
Continuation of #95774
See also https://github.com/godotengine/godot/pull/89036

This PR addressed yet another huge chunk of class reference oddities I remembered to note down for later while localizing the class reference. Some of these are clear typos, some are inconsistencies, some are just awkward.

I decided to separate this from the original because these may be more prickly.

Of particular note:
- Fix some things that were fixed in https://github.com/godotengine/godot/pull/89036 but came back in full force because I cannot be behind every contributor's back.
- **PROPERTY_USAGE_CLASS_IS_ENUM** called the property an "enum", whereas it's probably closer to an [enum type variable](https://learn.microsoft.com/en-us/cpp/c-language/c-enumeration-declarations?view=msvc-170), which is less ambiguous.
- Replace the few uses of "_acquire_", "_interrogate_", and "_augment_" with more common verbs.
- Replace leftover references to "spatial node" from 3.x.
- **NEVER** write "_The node (and any relevant children) should be [member CanvasItem.visible]_" ever again. I'm going to cry.

For the descriptions affected, not many tweaks have been made this time. Who knows when this will be merged anyway.