### PR TITLE
Fix physics_sync only allowing one transform change per physics frame

### DIFF
--- a/scene/2d/physics/animatable_body_2d.h
+++ b/scene/2d/physics/animatable_body_2d.h
@@ -40,6 +40,7 @@ private:
 	bool sync_to_physics = true;
 
 	Transform2D last_valid_transform;
+	Transform2D transform_accumulator;
 
 	static void _body_state_changed_callback(void *p_instance, PhysicsDirectBodyState2D *p_state);
 	void _body_state_changed(PhysicsDirectBodyState2D *p_state);

--- a/scene/3d/physics/animatable_body_3d.h
+++ b/scene/3d/physics/animatable_body_3d.h
@@ -43,6 +43,7 @@ private:
 	bool sync_to_physics = true;
 
 	Transform3D last_valid_transform;
+	Transform3D transform_accumulator;
 
 	static void _body_state_changed_callback(void *p_instance, PhysicsDirectBodyState3D *p_state);
 	void _body_state_changed(PhysicsDirectBodyState3D *p_state);


### PR DESCRIPTION
Fixes #76685, fixes #98970
If the transform was set multiple times per frame, every attempt prior to the last would be overwritten by the final call from AnimatableBody's `NOTIFICATION_LOCAL_TRANSFORM_CHANGED`. This adds a member variable that accumulates those changes instead.

A bit worried about slowness though. I don't have a good sense for performance, but it seems expensive. It runs inverse, orthonormalize and matrix mults as many times as the transform is set on each AnimatableBody, which could be quite a lot of times per frame. 