### PR TITLE
Add examples to PacketPeerUDP class documentation

### DIFF
--- a/doc/classes/PacketPeerUDP.xml
+++ b/doc/classes/PacketPeerUDP.xml
@@ -4,7 +4,32 @@
 		UDP packet peer.
 	</brief_description>
 	<description>
-		UDP packet peer. Can be used to send raw UDP packets as well as [Variant]s.
+		UDP packet peer. Can be used to send and receive raw UDP packets as well as [Variant]s.
+		[b]Example:[/b] Send a packet:
+		[codeblock]
+		var peer = PacketPeerUDP.new()
+
+		# Optionally, you can select the local port used to send the packet.
+		peer.bind(4444)
+
+		peer.set_dest_address("1.1.1.1", 4433)
+		peer.put_packet("hello".to_utf8_buffer())
+		[/codeblock]
+		[b]Example:[/b] Listen for packets:
+		[codeblock]
+		var peer
+
+		func _ready():
+		    peer = PacketPeerUDP.new()
+		    peer.bind(4433)
+
+
+		func _process(_delta):
+		    if peer.get_available_packet_count() &gt; 0:
+		        var array_bytes = peer.get_packet()
+		        var packet_string = array_bytes.get_string_from_ascii()
+		        print("Received message: ", packet_string)
+		[/codeblock]
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
 	</description>
 	<tutorials>


### PR DESCRIPTION
- Minor change to PacketPeerUDP class description
- Add usage examples to PacketPeerUDP class description, about sending and receiving packets.

Currently to understand how to properly use PacketPeerUDP you need to read through both the methods of the class and the methods of PacketPeer. This is why I added examples for what I believe are the main things you would be using the class.

P.S.: The PacketPeerUDP.bind() method documentation needs updating, as it doesn't just affect the listening port, but also affects the port used to send packets (I showcase this in the example). This is not documented. However I'm not well versed in the actual code of this method, so I'm not sure how to precisely exaplain its exact function. This is why I haven't made changes to the bind method description.