### PR TITLE
Fix top-Level CollisionShapes with Area2D

### DIFF
--- a/core/extension/gdextension_special_compat_hashes.cpp
+++ b/core/extension/gdextension_special_compat_hashes.cpp
@@ -624,13 +624,13 @@ void GDExtensionSpecialCompatHashes::initialize() {
 	});
 	mappings.insert("PhysicsServer2D", {
 #ifdef REAL_T_IS_DOUBLE
-		{ "area_add_shape", 754862190, 3597527023 },
+		{ "area_add_shape", 754862190, 2227993816 },
 		{ "body_add_shape", 754862190, 3597527023 },
 		{ "body_apply_impulse", 34330743, 1124035137 },
 		{ "body_apply_force", 34330743, 1124035137 },
 		{ "body_add_constant_force", 34330743, 1124035137 },
 #else
-		{ "area_add_shape", 754862190, 339056240 },
+		{ "area_add_shape", 754862190, 2986419922 },
 		{ "body_add_shape", 754862190, 339056240 },
 		{ "body_apply_impulse", 34330743, 205485391 },
 		{ "body_apply_force", 34330743, 205485391 },

--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -134,8 +134,9 @@
 			<return type="void" />
 			<param index="0" name="owner_id" type="int" />
 			<param index="1" name="shape" type="Shape2D" />
+			<param index="2" name="top_level" type="bool" default="false" />
 			<description>
-				Adds a [Shape2D] to the shape owner.
+				Adds a [Shape2D] to the shape owner. The [param top_level] parameter is only used if the [CollisionObject2D] owning the shape owner is an [Area2D]. If it is [code]true[/code], it makes the shape owner's transform independent from the collision object's transform.
 			</description>
 		</method>
 		<method name="shape_owner_clear_shapes">
@@ -218,8 +219,10 @@
 			<return type="void" />
 			<param index="0" name="owner_id" type="int" />
 			<param index="1" name="transform" type="Transform2D" />
+			<param index="2" name="top_level" type="bool" default="false" />
 			<description>
-				Sets the [Transform2D] of the given shape owner.
+				Sets the [Transform2D] of the given shape owner. The [param top_level] parameter is only used if the [CollisionObject2D] owning the shape owner is an [Area2D]. If it is [code]true[/code], it makes the shape owner's transform independent from the collision object's transform.
+				[b]Note:[/b] [param top_level] has a default value of [code]false[/code], you must pass it [code]true[/code] every time you call this function otherwise your shape owner will revert to being NOT top-level.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -22,8 +22,9 @@
 			<param index="1" name="shape" type="RID" />
 			<param index="2" name="transform" type="Transform2D" default="Transform2D(1, 0, 0, 1, 0, 0)" />
 			<param index="3" name="disabled" type="bool" default="false" />
+			<param index="4" name="top_level" type="bool" default="false" />
 			<description>
-				Adds a shape to the area, with the given local transform. The shape (together with its [param transform] and [param disabled] properties) is added to an array of shapes, and the shapes of an area are usually referenced by their index in this array.
+				Adds a shape to the area, with the given local transform (or [b]global[/b] transform if [param top_level] is set to [code]true[/code]). The shape (together with its [param transform], [param disabled] and [param top_level] properties) is added to an array of shapes, and the shapes of an area are usually referenced by their index in this array.
 			</description>
 		</method>
 		<method name="area_attach_canvas_instance_id">
@@ -221,8 +222,9 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="top_level" type="bool" default="false" />
 			<description>
-				Sets the local transform matrix of the area's shape with the given index.
+				Sets the local transform (or [b]global[/b] if [param top_level] is set to [code]true[/code]) matrix of the area's shape with the given index.
 			</description>
 		</method>
 		<method name="area_set_space">

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -16,6 +16,7 @@
 			<param index="1" name="shape" type="RID" />
 			<param index="2" name="transform" type="Transform2D" />
 			<param index="3" name="disabled" type="bool" />
+			<param index="4" name="top_level" type="bool" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_add_shape].
 			</description>
@@ -211,6 +212,7 @@
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="top_level" type="bool" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_set_shape_transform].
 			</description>

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -309,3 +309,16 @@ Validate extension JSON: API was removed: classes/EditorSceneFormatImporter/meth
 
 This virtual method, and the internal public `get_import_flags`, were never used by the engine, since it was open sourced.
 So we're removing it despite the compat breakage as there's no way for users to rely on this affecting engine behavior.
+
+
+
+GH-99017
+--------
+Validate extension JSON: Error: Field 'classes/CollisionObject2D/methods/shape_owner_add_shape/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/CollisionObject2D/methods/shape_owner_set_transform/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/PhysicsServer2D/methods/area_add_shape/arguments': size changed value in new API, from 4 to 5.
+Validate extension JSON: Error: Field 'classes/PhysicsServer2D/methods/area_set_shape_transform/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/PhysicsServer2DExtension/methods/_area_add_shape/arguments': size changed value in new API, from 4 to 5.
+Validate extension JSON: Error: Field 'classes/PhysicsServer2DExtension/methods/_area_set_shape_transform/arguments': size changed value in new API, from 3 to 4.
+
+Added an optional argument to register CollisionShapes2D as top level. Compatibility method registered.

--- a/modules/godot_physics_2d/godot_area_pair_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_pair_2d.cpp
@@ -122,7 +122,14 @@ GodotAreaPair2D::~GodotAreaPair2D() {
 bool GodotArea2Pair2D::setup(real_t p_step) {
 	bool result_a = area_a->collides_with(area_b);
 	bool result_b = area_b->collides_with(area_a);
-	if ((result_a || result_b) && !GodotCollisionSolver2D::solve(area_a->get_shape(shape_a), area_a->get_transform() * area_a->get_shape_transform(shape_a), Vector2(), area_b->get_shape(shape_b), area_b->get_transform() * area_b->get_shape_transform(shape_b), Vector2(), nullptr, this)) {
+
+	bool a_indpdt_xform = area_a->get_shape_xform_independance(shape_a);
+	bool b_indpdt_xform = area_b->get_shape_xform_independance(shape_b);
+
+	Transform2D transform_a = a_indpdt_xform ? area_a->get_shape_transform(shape_a) : (area_a->get_transform() * area_a->get_shape_transform(shape_a));
+	Transform2D transform_b = b_indpdt_xform ? area_b->get_shape_transform(shape_b) : (area_b->get_transform() * area_b->get_shape_transform(shape_b));
+
+	if ((result_a || result_b) && !GodotCollisionSolver2D::solve(area_a->get_shape(shape_a), transform_a, Vector2(), area_b->get_shape(shape_b), transform_b, Vector2(), nullptr, this)) {
 		result_a = false;
 		result_b = false;
 	}

--- a/modules/godot_physics_2d/godot_collision_object_2d.h
+++ b/modules/godot_physics_2d/godot_collision_object_2d.h
@@ -56,6 +56,7 @@ private:
 	struct Shape {
 		Transform2D xform;
 		Transform2D xform_inv;
+		bool indpdt_xform;
 		GodotBroadPhase2D::ID bpid = 0;
 		Rect2 aabb_cache; //for rayqueries
 		GodotShape2D *shape = nullptr;
@@ -108,9 +109,13 @@ public:
 	void _shape_changed() override;
 
 	_FORCE_INLINE_ Type get_type() const { return type; }
-	void add_shape(GodotShape2D *p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false);
+	void add_shape(GodotShape2D *p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false, bool p_indpdt_xform = false);
 	void set_shape(int p_index, GodotShape2D *p_shape);
-	void set_shape_transform(int p_index, const Transform2D &p_transform);
+	void set_shape_transform(int p_index, const Transform2D &p_transform, bool p_indpdt_xform = false);
+	void set_shape_xform_independance(int p_index, bool p_indpt) {
+		ERR_FAIL_INDEX(p_index, shapes.size());
+		shapes.write[p_index].indpdt_xform = p_indpt;
+	}
 
 	_FORCE_INLINE_ int get_shape_count() const { return shapes.size(); }
 	_FORCE_INLINE_ GodotShape2D *get_shape(int p_index) const {
@@ -128,6 +133,10 @@ public:
 	_FORCE_INLINE_ const Rect2 &get_shape_aabb(int p_index) const {
 		CRASH_BAD_INDEX(p_index, shapes.size());
 		return shapes[p_index].aabb_cache;
+	}
+	_FORCE_INLINE_ bool get_shape_xform_independance(int p_index) const {
+		CRASH_BAD_INDEX(p_index, shapes.size());
+		return shapes[p_index].indpdt_xform;
 	}
 
 	_FORCE_INLINE_ const Transform2D &get_transform() const { return transform; }

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -320,14 +320,14 @@ RID GodotPhysicsServer2D::area_get_space(RID p_area) const {
 	return space->get_self();
 }
 
-void GodotPhysicsServer2D::area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform, bool p_disabled) {
+void GodotPhysicsServer2D::area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform, bool p_disabled, bool p_indpdt_xform) {
 	GodotArea2D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
 	GodotShape2D *shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL(shape);
 
-	area->add_shape(shape, p_transform, p_disabled);
+	area->add_shape(shape, p_transform, p_disabled, p_indpdt_xform);
 }
 
 void GodotPhysicsServer2D::area_set_shape(RID p_area, int p_shape_idx, RID p_shape) {
@@ -341,11 +341,11 @@ void GodotPhysicsServer2D::area_set_shape(RID p_area, int p_shape_idx, RID p_sha
 	area->set_shape(p_shape_idx, shape);
 }
 
-void GodotPhysicsServer2D::area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform) {
+void GodotPhysicsServer2D::area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform, bool p_indpdt_xform) {
 	GodotArea2D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
-	area->set_shape_transform(p_shape_idx, p_transform);
+	area->set_shape_transform(p_shape_idx, p_transform, p_indpdt_xform);
 }
 
 void GodotPhysicsServer2D::area_set_shape_disabled(RID p_area, int p_shape, bool p_disabled) {

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -126,9 +126,9 @@ public:
 	virtual void area_set_space(RID p_area, RID p_space) override;
 	virtual RID area_get_space(RID p_area) const override;
 
-	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) override;
+	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false, bool p_indpdt_xform = false) override;
 	virtual void area_set_shape(RID p_area, int p_shape_idx, RID p_shape) override;
-	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform) override;
+	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform, bool p_indpdt_xform) override;
 
 	virtual int area_get_shape_count(RID p_area) const override;
 	virtual RID area_get_shape(RID p_area, int p_shape_idx) const override;

--- a/scene/2d/physics/collision_object_2d.compat.inc
+++ b/scene/2d/physics/collision_object_2d.compat.inc
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  collision_object_2d.compat.inc                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void CollisionObject2D::_shape_owner_add_shape_compat_99017(uint32_t p_owner, const Ref<Shape2D> &p_shape) {
+	shape_owner_add_shape(p_owner, p_shape, false);
+}
+
+void CollisionObject2D::_shape_owner_set_transform_compat_99017(uint32_t p_owner, const Transform2D &p_transform) {
+	shape_owner_set_transform(p_owner, p_transform, false);
+}
+
+void CollisionObject2D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("shape_owner_add_shape", "owner_id", "shape"), &CollisionObject2D::_shape_owner_add_shape_compat_99017);
+	ClassDB::bind_compatibility_method(D_METHOD("shape_owner_set_transform", "owner_id", "transform"), &CollisionObject2D::_shape_owner_set_transform_compat_99017);
+}
+
+#endif

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -391,7 +391,7 @@ PackedInt32Array CollisionObject2D::_get_shape_owners() {
 	return ret;
 }
 
-void CollisionObject2D::shape_owner_set_transform(uint32_t p_owner, const Transform2D &p_transform) {
+void CollisionObject2D::shape_owner_set_transform(uint32_t p_owner, const Transform2D &p_transform, bool p_indpdt_xform) {
 	ERR_FAIL_COND(!shapes.has(p_owner));
 
 	ShapeData &sd = shapes[p_owner];
@@ -399,7 +399,7 @@ void CollisionObject2D::shape_owner_set_transform(uint32_t p_owner, const Transf
 	sd.xform = p_transform;
 	for (int i = 0; i < sd.shapes.size(); i++) {
 		if (area) {
-			PhysicsServer2D::get_singleton()->area_set_shape_transform(rid, sd.shapes[i].index, sd.xform);
+			PhysicsServer2D::get_singleton()->area_set_shape_transform(rid, sd.shapes[i].index, sd.xform, p_indpdt_xform);
 		} else {
 			PhysicsServer2D::get_singleton()->body_set_shape_transform(rid, sd.shapes[i].index, sd.xform);
 		}
@@ -418,7 +418,7 @@ Object *CollisionObject2D::shape_owner_get_owner(uint32_t p_owner) const {
 	return ObjectDB::get_instance(shapes[p_owner].owner_id);
 }
 
-void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape) {
+void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape, bool p_shape_indpdt_xform) {
 	ERR_FAIL_COND(!shapes.has(p_owner));
 	ERR_FAIL_COND(p_shape.is_null());
 
@@ -427,7 +427,7 @@ void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2
 	s.index = total_subshapes;
 	s.shape = p_shape;
 	if (area) {
-		PhysicsServer2D::get_singleton()->area_add_shape(rid, p_shape->get_rid(), sd.xform, sd.disabled);
+		PhysicsServer2D::get_singleton()->area_add_shape(rid, p_shape->get_rid(), sd.xform, sd.disabled, p_shape_indpdt_xform);
 	} else {
 		PhysicsServer2D::get_singleton()->body_add_shape(rid, p_shape->get_rid(), sd.xform, sd.disabled);
 	}
@@ -610,7 +610,7 @@ void CollisionObject2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_shape_owner", "owner"), &CollisionObject2D::create_shape_owner);
 	ClassDB::bind_method(D_METHOD("remove_shape_owner", "owner_id"), &CollisionObject2D::remove_shape_owner);
 	ClassDB::bind_method(D_METHOD("get_shape_owners"), &CollisionObject2D::_get_shape_owners);
-	ClassDB::bind_method(D_METHOD("shape_owner_set_transform", "owner_id", "transform"), &CollisionObject2D::shape_owner_set_transform);
+	ClassDB::bind_method(D_METHOD("shape_owner_set_transform", "owner_id", "transform", "top_level"), &CollisionObject2D::shape_owner_set_transform, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("shape_owner_get_transform", "owner_id"), &CollisionObject2D::shape_owner_get_transform);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_owner", "owner_id"), &CollisionObject2D::shape_owner_get_owner);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_disabled", "owner_id", "disabled"), &CollisionObject2D::shape_owner_set_disabled);
@@ -619,7 +619,7 @@ void CollisionObject2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_shape_owner_one_way_collision_enabled", "owner_id"), &CollisionObject2D::is_shape_owner_one_way_collision_enabled);
 	ClassDB::bind_method(D_METHOD("shape_owner_set_one_way_collision_margin", "owner_id", "margin"), &CollisionObject2D::shape_owner_set_one_way_collision_margin);
 	ClassDB::bind_method(D_METHOD("get_shape_owner_one_way_collision_margin", "owner_id"), &CollisionObject2D::get_shape_owner_one_way_collision_margin);
-	ClassDB::bind_method(D_METHOD("shape_owner_add_shape", "owner_id", "shape"), &CollisionObject2D::shape_owner_add_shape);
+	ClassDB::bind_method(D_METHOD("shape_owner_add_shape", "owner_id", "shape", "top_level"), &CollisionObject2D::shape_owner_add_shape, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("shape_owner_get_shape_count", "owner_id"), &CollisionObject2D::shape_owner_get_shape_count);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_shape", "owner_id", "shape_id"), &CollisionObject2D::shape_owner_get_shape);
 	ClassDB::bind_method(D_METHOD("shape_owner_get_shape_index", "owner_id", "shape_id"), &CollisionObject2D::shape_owner_get_shape_index);

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -32,6 +32,8 @@
 
 #include "scene/resources/world_2d.h"
 
+#include "collision_object_2d.compat.inc"
+
 void CollisionObject2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {

--- a/scene/2d/physics/collision_object_2d.h
+++ b/scene/2d/physics/collision_object_2d.h
@@ -140,7 +140,7 @@ public:
 	void get_shape_owners(List<uint32_t> *r_owners);
 	PackedInt32Array _get_shape_owners();
 
-	void shape_owner_set_transform(uint32_t p_owner, const Transform2D &p_transform);
+	void shape_owner_set_transform(uint32_t p_owner, const Transform2D &p_transform, bool p_indpdt_xform = false);
 	Transform2D shape_owner_get_transform(uint32_t p_owner) const;
 	Object *shape_owner_get_owner(uint32_t p_owner) const;
 
@@ -153,7 +153,7 @@ public:
 	void shape_owner_set_one_way_collision_margin(uint32_t p_owner, real_t p_margin);
 	real_t get_shape_owner_one_way_collision_margin(uint32_t p_owner) const;
 
-	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape);
+	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape, bool p_shape_indpdt_xform = false);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
 	Ref<Shape2D> shape_owner_get_shape(uint32_t p_owner, int p_shape) const;
 	int shape_owner_get_shape_index(uint32_t p_owner, int p_shape) const;

--- a/scene/2d/physics/collision_object_2d.h
+++ b/scene/2d/physics/collision_object_2d.h
@@ -111,6 +111,13 @@ protected:
 
 	virtual void _space_changed(const RID &p_new_space);
 
+#ifndef DISABLE_DEPRECATED
+	void _shape_owner_add_shape_compat_99017(uint32_t p_owner, const Ref<Shape2D> &p_shape);
+	void _shape_owner_set_transform_compat_99017(uint32_t p_owner, const Transform2D &p_transform);
+
+	static void _bind_compatibility_methods();
+#endif
+
 	GDVIRTUAL3(_input_event, Viewport *, Ref<InputEvent>, int)
 	GDVIRTUAL0(_mouse_enter)
 	GDVIRTUAL0(_mouse_exit)

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -40,7 +40,7 @@ void CollisionShape2D::_shape_changed() {
 }
 
 void CollisionShape2D::_update_in_shape_owner(bool p_xform_only) {
-	collision_object->shape_owner_set_transform(owner_id, get_transform());
+	collision_object->shape_owner_set_transform(owner_id, get_transform(), is_set_as_top_level());
 	if (p_xform_only) {
 		return;
 	}
@@ -56,7 +56,7 @@ void CollisionShape2D::_notification(int p_what) {
 			if (collision_object) {
 				owner_id = collision_object->create_shape_owner(this);
 				if (shape.is_valid()) {
-					collision_object->shape_owner_add_shape(owner_id, shape);
+					collision_object->shape_owner_add_shape(owner_id, shape, is_set_as_top_level());
 				}
 				_update_in_shape_owner();
 			}
@@ -72,6 +72,7 @@ void CollisionShape2D::_notification(int p_what) {
 			if (collision_object) {
 				_update_in_shape_owner(true);
 			}
+			update_configuration_warnings(); // Only needed for the top level warning
 		} break;
 
 		case NOTIFICATION_UNPARENTED: {
@@ -180,6 +181,10 @@ PackedStringArray CollisionShape2D::get_configuration_warnings() const {
 	}
 	if (one_way_collision && Object::cast_to<Area2D>(col_object)) {
 		warnings.push_back(RTR("The One Way Collision property will be ignored when the collision object is an Area2D."));
+	}
+	if (is_set_as_top_level()) {
+		// If removing this, also remove update_configuration_warnings in NOTIFICATION_LOCAL_TRANSFORM_CHANGED
+		warnings.push_back(RTR("Top-Level on CollisionShape2D is in development and might not work as expected"));
 	}
 
 	Ref<ConvexPolygonShape2D> convex = shape;

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -168,9 +168,9 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_area_set_space, "area", "space");
 	GDVIRTUAL_BIND(_area_get_space, "area");
 
-	GDVIRTUAL_BIND(_area_add_shape, "area", "shape", "transform", "disabled");
+	GDVIRTUAL_BIND(_area_add_shape, "area", "shape", "transform", "disabled", "top_level");
 	GDVIRTUAL_BIND(_area_set_shape, "area", "shape_idx", "shape");
-	GDVIRTUAL_BIND(_area_set_shape_transform, "area", "shape_idx", "transform");
+	GDVIRTUAL_BIND(_area_set_shape_transform, "area", "shape_idx", "transform", "top_level");
 	GDVIRTUAL_BIND(_area_set_shape_disabled, "area", "shape_idx", "disabled");
 
 	GDVIRTUAL_BIND(_area_get_shape_count, "area");

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -244,9 +244,9 @@ public:
 	EXBIND2(area_set_space, RID, RID)
 	EXBIND1RC(RID, area_get_space, RID)
 
-	EXBIND4(area_add_shape, RID, RID, const Transform2D &, bool)
+	EXBIND5(area_add_shape, RID, RID, const Transform2D &, bool, bool)
 	EXBIND3(area_set_shape, RID, int, RID)
-	EXBIND3(area_set_shape_transform, RID, int, const Transform2D &)
+	EXBIND4(area_set_shape_transform, RID, int, const Transform2D &, bool)
 	EXBIND3(area_set_shape_disabled, RID, int, bool)
 
 	EXBIND1RC(int, area_get_shape_count, RID)

--- a/servers/physics_server_2d.compat.inc
+++ b/servers/physics_server_2d.compat.inc
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  physics_server_2d.compat.inc                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void PhysicsServer2D::_area_add_shape_bind_compat_99017(RID p_area, RID p_shape, const Transform2D &p_transform, bool p_disabled) {
+	area_add_shape(p_area, p_shape, p_transform, p_disabled, false);
+}
+
+void PhysicsServer2D::_area_set_shape_transform_compat_99017(RID p_area, int p_shape_idx, const Transform2D &p_transform) {
+	area_set_shape_transform(p_area, p_shape_idx, p_transform, false);
+}
+
+void PhysicsServer2D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("area_add_shape", "area", "shape", "transform", "disabled"), &PhysicsServer2D::_area_add_shape_bind_compat_99017, DEFVAL(Transform2D()), DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("area_set_shape_transform", "area", "shape_idx", "transform"), &PhysicsServer2D::_area_set_shape_transform_compat_99017);
+}
+
+#endif

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -380,6 +380,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(const Ref<Phy
 	Vector<ShapeResult> sr;
 	sr.resize(p_max_results);
 	int rc = intersect_shape(p_shape_query->get_parameters(), sr.ptrw(), sr.size());
+	print_line("Intersect shape was called");
 	TypedArray<Dictionary> ret;
 	ret.resize(rc);
 	for (int i = 0; i < rc; i++) {
@@ -642,9 +643,9 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("area_set_space", "area", "space"), &PhysicsServer2D::area_set_space);
 	ClassDB::bind_method(D_METHOD("area_get_space", "area"), &PhysicsServer2D::area_get_space);
 
-	ClassDB::bind_method(D_METHOD("area_add_shape", "area", "shape", "transform", "disabled"), &PhysicsServer2D::area_add_shape, DEFVAL(Transform2D()), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("area_add_shape", "area", "shape", "transform", "disabled", "top_level"), &PhysicsServer2D::area_add_shape, DEFVAL(Transform2D()), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("area_set_shape", "area", "shape_idx", "shape"), &PhysicsServer2D::area_set_shape);
-	ClassDB::bind_method(D_METHOD("area_set_shape_transform", "area", "shape_idx", "transform"), &PhysicsServer2D::area_set_shape_transform);
+	ClassDB::bind_method(D_METHOD("area_set_shape_transform", "area", "shape_idx", "transform", "top_level"), &PhysicsServer2D::area_set_shape_transform, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("area_set_shape_disabled", "area", "shape_idx", "disabled"), &PhysicsServer2D::area_set_shape_disabled);
 
 	ClassDB::bind_method(D_METHOD("area_get_shape_count", "area"), &PhysicsServer2D::area_get_shape_count);

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -33,6 +33,8 @@
 #include "core/config/project_settings.h"
 #include "core/variant/typed_array.h"
 
+#include "physics_server_2d.compat.inc"
+
 PhysicsServer2D *PhysicsServer2D::singleton = nullptr;
 
 void PhysicsDirectBodyState2D::integrate_forces() {

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -308,9 +308,9 @@ public:
 		AREA_SPACE_OVERRIDE_REPLACE_COMBINE // Discards all previous calculations, then keeps combining
 	};
 
-	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) = 0;
+	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false, bool p_indpdt_xform = false) = 0;
 	virtual void area_set_shape(RID p_area, int p_shape_idx, RID p_shape) = 0;
-	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform) = 0;
+	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform, bool p_indpdt_xform) = 0;
 
 	virtual int area_get_shape_count(RID p_area) const = 0;
 	virtual RID area_get_shape(RID p_area, int p_shape_idx) const = 0;

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -214,6 +214,13 @@ class PhysicsServer2D : public Object {
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	virtual void _area_add_shape_bind_compat_99017(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false);
+	virtual void _area_set_shape_transform_compat_99017(RID p_area, int p_shape_idx, const Transform2D &p_transform);
+
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	static PhysicsServer2D *get_singleton();
 

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -166,9 +166,9 @@ public:
 	virtual void area_set_space(RID p_area, RID p_space) override {}
 	virtual RID area_get_space(RID p_area) const override { return RID(); }
 
-	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false) override {}
+	virtual void area_add_shape(RID p_area, RID p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false, bool p_indpdt_xform = false) override {}
 	virtual void area_set_shape(RID p_area, int p_shape_idx, RID p_shape) override {}
-	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform) override {}
+	virtual void area_set_shape_transform(RID p_area, int p_shape_idx, const Transform2D &p_transform, bool p_indpdt_xform) override {}
 
 	virtual int area_get_shape_count(RID p_area) const override { return 0; }
 	virtual RID area_get_shape(RID p_area, int p_shape_idx) const override { return RID(); }

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -129,9 +129,9 @@ public:
 	FUNC2(area_set_space, RID, RID);
 	FUNC1RC(RID, area_get_space, RID);
 
-	FUNC4(area_add_shape, RID, RID, const Transform2D &, bool);
+	FUNC5(area_add_shape, RID, RID, const Transform2D &, bool, bool);
 	FUNC3(area_set_shape, RID, int, RID);
-	FUNC3(area_set_shape_transform, RID, int, const Transform2D &);
+	FUNC4(area_set_shape_transform, RID, int, const Transform2D &, bool);
 	FUNC3(area_set_shape_disabled, RID, int, bool);
 
 	FUNC1RC(int, area_get_shape_count, RID);


### PR DESCRIPTION
Very first godot PR, and even time looking at godotengine's code, please roast anything as needed as my understanding is quite limited.

In the physics server, shapes are simple data structure without reference to the canvas, mostly just the shape itself (circle/rect/...) and its transform. This transform was always expected to be relative to the parent object's transform, meaning that a CollisionShape2D marked as top level would never behave as such.

By adding a new field to these shapes (indpdt_xform) representing whether it is top_level, the final tranform computations done in GodotArea2Pair2D (that get then passed to the collision solver) can be adjusted to be relative or not.

For the update of the `top_level` field, since it causes a change in the final transform, i decided to piggy back on top of the `set_shape_transform` functions, meaning that any needed update would be triggered. Also, I didn't create a new specialized `set_shape_top_level` function as that could have lead to needing some change in the `CollisionShape2D::_update_in_shape_owner` to avoid triggering multiple changes to `GodotPhysicsServer2D::godot_singleton->pending_shape_update_list` lower down the line. I feel like `transform` and `top_level` are very linked, but feel free to contest that choice.
Because the signature of some functions have been changed, I made sure to set default values in the different bindings to avoid gdscript compatibility breakage, even though some of those default values are definitely counter-intuitive to use (i.e. the `set_shape_transform` has a default value of false for `top_level` meaning if it is created as top level and then the transform is updated without care, the top level might be lost).
I also added a warning to CollisionShape2D nodes with `top_level` (saying that it is experimental) based on  @rburing 's recommendations.


As a first step, this PR only add this top_level feature to collision shapes working with areas, not bodies. 

I have quite a limited view and understanding of the whole physics engine, I tested my changes in multiple ways and couldn't find something breaking. Please notify me of any doubts you might have regarding normal behaviour.

* *Bugsquad edit, fixes: #98741*