### PR TITLE
Clean up more `[b]Example:[/b]` lines from the class reference

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -55,7 +55,7 @@
 			<param index="1" name="progress" type="float" />
 			<description>
 				Sets [member frame] the [member frame_progress] to the given values. Unlike setting [member frame], this method does not reset the [member frame_progress] to [code]0.0[/code] implicitly.
-				[b]Example:[/b] Change the animation while keeping the same [member frame] and [member frame_progress].
+				[b]Example:[/b] Change the animation while keeping the same [member frame] and [member frame_progress]:
 				[codeblocks]
 				[gdscript]
 				var current_frame = animated_sprite.get_frame()

--- a/doc/classes/AnimatedSprite3D.xml
+++ b/doc/classes/AnimatedSprite3D.xml
@@ -54,7 +54,7 @@
 			<param index="1" name="progress" type="float" />
 			<description>
 				Sets [member frame] the [member frame_progress] to the given values. Unlike setting [member frame], this method does not reset the [member frame_progress] to [code]0.0[/code] implicitly.
-				[b]Example:[/b] Change the animation while keeping the same [member frame] and [member frame_progress].
+				[b]Example:[/b] Change the animation while keeping the same [member frame] and [member frame_progress]:
 				[codeblocks]
 				[gdscript]
 				var current_frame = animated_sprite.get_frame()

--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -132,7 +132,7 @@
 			<description>
 				Emitted when a [Shape2D] of the received [param area] enters a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param area_shape_index] contain indices of the interacting shapes from this area and the other area, respectively. [param area_rid] contains the [RID] of the other area. These values can be used with the [PhysicsServer2D].
-				[b]Example of getting the[/b] [CollisionShape2D] [b]node from the shape index:[/b]
+				[b]Example:[/b] Get the [CollisionShape2D] node from the shape index:
 				[codeblocks]
 				[gdscript]
 				var other_shape_owner = area.shape_find_owner(area_shape_index)
@@ -174,7 +174,7 @@
 			<description>
 				Emitted when a [Shape2D] of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody2D] or a [TileMap]. [TileMap]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param body_shape_index] contain indices of the interacting shapes from this area and the interacting body, respectively. [param body_rid] contains the [RID] of the body. These values can be used with the [PhysicsServer2D].
-				[b]Example of getting the[/b] [CollisionShape2D] [b]node from the shape index:[/b]
+				[b]Example:[/b] Get the [CollisionShape2D] node from the shape index:
 				[codeblocks]
 				[gdscript]
 				var body_shape_owner = body.shape_find_owner(body_shape_index)

--- a/doc/classes/Area3D.xml
+++ b/doc/classes/Area3D.xml
@@ -156,7 +156,7 @@
 			<description>
 				Emitted when a [Shape3D] of the received [param area] enters a shape of this area. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param area_shape_index] contain indices of the interacting shapes from this area and the other area, respectively. [param area_rid] contains the [RID] of the other area. These values can be used with the [PhysicsServer3D].
-				[b]Example of getting the[/b] [CollisionShape3D] [b]node from the shape index:[/b]
+				[b]Example:[/b] Get the [CollisionShape3D] node from the shape index:
 				[codeblocks]
 				[gdscript]
 				var other_shape_owner = area.shape_find_owner(area_shape_index)
@@ -198,7 +198,7 @@
 			<description>
 				Emitted when a [Shape3D] of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody3D] or a [GridMap]. [GridMap]s are detected if their [MeshLibrary] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param body_shape_index] contain indices of the interacting shapes from this area and the interacting body, respectively. [param body_rid] contains the [RID] of the body. These values can be used with the [PhysicsServer3D].
-				[b]Example of getting the[/b] [CollisionShape3D] [b]node from the shape index:[/b]
+				[b]Example:[/b] Get the [CollisionShape3D] node from the shape index:
 				[codeblocks]
 				[gdscript]
 				var body_shape_owner = body.shape_find_owner(body_shape_index)

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -303,7 +303,7 @@
 			<param index="1" name="weight" type="float" />
 			<description>
 				Performs a spherical-linear interpolation with the [param to] basis, given a [param weight]. Both this basis and [param to] should represent a rotation.
-				[b]Example:[/b] Smoothly rotate a [Node3D] to the target basis over time, with a [Tween].
+				[b]Example:[/b] Smoothly rotate a [Node3D] to the target basis over time, with a [Tween]:
 				[codeblock]
 				var start_basis = Basis.IDENTITY
 				var target_basis = Basis.IDENTITY.rotated(Vector3.UP, TAU / 2)

--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -5,13 +5,13 @@
 	</brief_description>
 	<description>
 		[Button] is the standard themed button. It can contain text and an icon, and it will display them according to the current [Theme].
-		[b]Example of creating a button and assigning an action when pressed by code:[/b]
+		[b]Example:[/b] Create a button and connect a method that will be called when the button is pressed:
 		[codeblocks]
 		[gdscript]
 		func _ready():
 		    var button = Button.new()
 		    button.text = "Click me"
-		    button.pressed.connect(self._button_pressed)
+		    button.pressed.connect(_button_pressed)
 		    add_child(button)
 
 		func _button_pressed():
@@ -33,7 +33,7 @@
 		[/csharp]
 		[/codeblocks]
 		See also [BaseButton] which contains common properties and methods associated with this node.
-		[b]Note:[/b] Buttons do not interpret touch input and therefore don't support multitouch, since mouse emulation can only press one button at a given time. Use [TouchScreenButton] for buttons that trigger gameplay movement or actions.
+		[b]Note:[/b] Buttons do not detect touch input and therefore don't support multitouch, since mouse emulation can only press one button at a given time. Use [TouchScreenButton] for buttons that trigger gameplay movement or actions.
 	</description>
 	<tutorials>
 		<link title="2D Dodge The Creeps Demo">https://godotengine.org/asset-library/asset/2712</link>

--- a/doc/classes/CallbackTweener.xml
+++ b/doc/classes/CallbackTweener.xml
@@ -16,7 +16,7 @@
 			<param index="0" name="delay" type="float" />
 			<description>
 				Makes the callback call delayed by given time in seconds.
-				[b]Example:[/b] Call [method Node.queue_free] after 2 seconds.
+				[b]Example:[/b] Call [method Node.queue_free] after 2 seconds:
 				[codeblock]
 				var tween = get_tree().create_tween()
 				tween.tween_callback(queue_free).set_delay(2)

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -333,7 +333,7 @@
 			<param index="9" name="orientation" type="int" enum="TextServer.Orientation" default="0" />
 			<description>
 				Draws [param text] using the specified [param font] at the [param pos] (bottom-left corner using the baseline of the font). The text will have its color multiplied by [param modulate]. If [param width] is greater than or equal to 0, the text will be clipped if it exceeds the specified width.
-				[b]Example using the default project font:[/b]
+				[b]Example:[/b] Draw "Hello world", using the project's default font:
 				[codeblocks]
 				[gdscript]
 				# If using this method in a script that redraws constantly, move the

--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -69,7 +69,7 @@
 			<param index="0" name="slide_idx" type="int" />
 			<description>
 				Returns a [KinematicCollision2D], which contains information about a collision that occurred during the last call to [method move_and_slide]. Since the body can collide several times in a single call to [method move_and_slide], you must specify the index of the collision in the range 0 to ([method get_slide_collision_count] - 1).
-				[b]Example usage:[/b]
+				[b]Example:[/b] Iterate through the collisions with a [code]for[/code] loop:
 				[codeblocks]
 				[gdscript]
 				for i in get_slide_collision_count():

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -120,8 +120,8 @@
 			<return type="void" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>
-				Virtual method to be implemented by the user. Use this method to process and accept inputs on UI elements. See [method accept_event].
-				[b]Example usage for clicking a control:[/b]
+				Virtual method to be implemented by the user. Override this method to handle and accept inputs on UI elements. See also [method accept_event].
+				[b]Example:[/b] Click on the control to print a message:
 				[codeblocks]
 				[gdscript]
 				func _gui_input(event):
@@ -142,13 +142,13 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				The event won't trigger if:
-				* clicking outside the control (see [method _has_point]);
-				* control has [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
-				* control is obstructed by another [Control] on top of it, which doesn't have [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
-				* control's parent has [member mouse_filter] set to [constant MOUSE_FILTER_STOP] or has accepted the event;
-				* it happens outside the parent's rectangle and the parent has either [member clip_contents] enabled.
-				[b]Note:[/b] Event position is relative to the control origin.
+				If the [param event] inherits [InputEventMouse], this method will [b]not[/b] be called when:
+				- the control's [member mouse_filter] is set to [constant MOUSE_FILTER_IGNORE];
+				- the control is obstructed by another control on top, that doesn't have [member mouse_filter] set to [constant MOUSE_FILTER_IGNORE];
+				- the control's parent has [member mouse_filter] set to [constant MOUSE_FILTER_STOP] or has accepted the event;
+				- the control's parent has [member clip_contents] enabled and the [param event]'s position is outside the parent's rectangle;
+				- the [param event]'s position is outside the control (see [method _has_point]).
+				[b]Note:[/b] The [param event]'s position is relative to this control's origin.
 			</description>
 		</method>
 		<method name="_has_point" qualifiers="virtual const">
@@ -169,7 +169,7 @@
 				The returned node will be added as child to a [PopupPanel], so you should only provide the contents of that panel. That [PopupPanel] can be themed using [method Theme.set_stylebox] for the type [code]"TooltipPanel"[/code] (see [member tooltip_text] for an example).
 				[b]Note:[/b] The tooltip is shrunk to minimal size. If you want to ensure it's fully visible, you might want to set its [member custom_minimum_size] to some non-zero value.
 				[b]Note:[/b] The node (and any relevant children) should be [member CanvasItem.visible] when returned, otherwise, the viewport that instantiates it will not be able to calculate its minimum size reliably.
-				[b]Example of usage with a custom-constructed node:[/b]
+				[b]Example:[/b] Use a constructed node as a tooltip:
 				[codeblocks]
 				[gdscript]
 				func _make_custom_tooltip(for_text):
@@ -186,7 +186,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				[b]Example of usage with a custom scene instance:[/b]
+				[b]Example:[/b] Usa a scene instance as a tooltip:
 				[codeblocks]
 				[gdscript]
 				func _make_custom_tooltip(for_text):
@@ -228,7 +228,7 @@
 			<description>
 				Creates a local override for a theme [Color] with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_color_override].
 				See also [method get_theme_color].
-				[b]Example of overriding a label's color and resetting it later:[/b]
+				[b]Example:[/b] Override a [Label]'s color and reset it later:
 				[codeblocks]
 				[gdscript]
 				# Given the child Label node "MyLabel", override its font color with a custom value.
@@ -292,10 +292,10 @@
 			<description>
 				Creates a local override for a theme [StyleBox] with the specified [param name]. Local overrides always take precedence when fetching theme items for the control. An override can be removed with [method remove_theme_stylebox_override].
 				See also [method get_theme_stylebox].
-				[b]Example of modifying a property in a StyleBox by duplicating it:[/b]
+				[b]Example:[/b] Modify a property in a [StyleBox] by duplicating it:
 				[codeblocks]
 				[gdscript]
-				# The snippet below assumes the child node MyButton has a StyleBoxFlat assigned.
+				# The snippet below assumes the child node "MyButton" has a StyleBoxFlat assigned.
 				# Resources are shared across instances, so we need to duplicate it
 				# to avoid modifying the appearance of all other buttons.
 				var new_stylebox_normal = $MyButton.get_theme_stylebox("normal").duplicate()
@@ -306,7 +306,7 @@
 				$MyButton.remove_theme_stylebox_override("normal")
 				[/gdscript]
 				[csharp]
-				// The snippet below assumes the child node MyButton has a StyleBoxFlat assigned.
+				// The snippet below assumes the child node "MyButton" has a StyleBoxFlat assigned.
 				// Resources are shared across instances, so we need to duplicate it
 				// to avoid modifying the appearance of all other buttons.
 				StyleBoxFlat newStyleboxNormal = GetNode&lt;Button&gt;("MyButton").GetThemeStylebox("normal").Duplicate() as StyleBoxFlat;
@@ -446,7 +446,7 @@
 			<description>
 				Returns the position of this [Control] in global screen coordinates (i.e. taking window position into account). Mostly useful for editor plugins.
 				Equals to [member global_position] if the window is embedded (see [member Viewport.gui_embed_subwindows]).
-				[b]Example usage for showing a popup:[/b]
+				[b]Example:[/b] Show a popup at the mouse position:
 				[codeblock]
 				popup_menu.position = get_screen_position() + get_local_mouse_position()
 				popup_menu.reset_size()

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -153,7 +153,7 @@
 			<param index="1" name="option_name" type="StringName" />
 			<param index="2" name="options" type="Dictionary" />
 			<description>
-				This method can be overridden to hide specific import options if conditions are met. This is mainly useful for hiding options that depend on others if one of them is disabled. For example:
+				This method can be overridden to hide specific import options if conditions are met. This is mainly useful for hiding options that depend on others if one of them is disabled.
 				[codeblocks]
 				[gdscript]
 				func _get_option_visibility(option, options):

--- a/doc/classes/EditorScenePostImport.xml
+++ b/doc/classes/EditorScenePostImport.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Imported scenes can be automatically modified right after import by setting their [b]Custom Script[/b] Import property to a [code]tool[/code] script that inherits from this class.
-		The [method _post_import] callback receives the imported scene's root node and returns the modified version of the scene. Usage example:
+		The [method _post_import] callback receives the imported scene's root node and returns the modified version of the scene:
 		[codeblocks]
 		[gdscript]
 		@tool # Needed so it runs in editor.

--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -6,7 +6,7 @@
 	<description>
 		Scripts extending this class and implementing its [method _run] method can be executed from the Script Editor's [b]File &gt; Run[/b] menu option (or by pressing [kbd]Ctrl + Shift + X[/kbd]) while the editor is running. This is useful for adding custom in-editor functionality to Godot. For more complex additions, consider using [EditorPlugin]s instead.
 		[b]Note:[/b] Extending scripts need to have [code]tool[/code] mode enabled.
-		[b]Example script:[/b]
+		[b]Example:[/b] Running the following script prints "Hello from the Godot Editor!":
 		[codeblocks]
 		[gdscript]
 		@tool

--- a/doc/classes/EditorTranslationParserPlugin.xml
+++ b/doc/classes/EditorTranslationParserPlugin.xml
@@ -69,8 +69,7 @@
 		msgidsContextPlural.Add(new Godot.Collections.Array{"Only with context", "a friendly context", ""});
 		[/csharp]
 		[/codeblocks]
-		[b]Note:[/b] If you override parsing logic for standard script types (GDScript, C#, etc.), it would be better to load the [code]path[/code] argument using [method ResourceLoader.load]. This is because built-in scripts are loaded as [Resource] type, not [FileAccess] type.
-		For example:
+		[b]Note:[/b] If you override parsing logic for standard script types (GDScript, C#, etc.), it would be better to load the [code]path[/code] argument using [method ResourceLoader.load]. This is because built-in scripts are loaded as [Resource] type, not [FileAccess] type. For example:
 		[codeblocks]
 		[gdscript]
 		func _parse_file(path, msgids, msgids_context_plural):

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -8,7 +8,7 @@
 		Can be used to make HTTP requests, i.e. download or upload files or web content via HTTP.
 		[b]Warning:[/b] See the notes and warnings on [HTTPClient] for limitations, especially regarding TLS security.
 		[b]Note:[/b] When exporting to Android, make sure to enable the [code]INTERNET[/code] permission in the Android export preset before exporting the project or using one-click deploy. Otherwise, network communication of any kind will be blocked by Android.
-		[b]Example of contacting a REST API and printing one of its returned fields:[/b]
+		[b]Example:[/b] Contact a REST API and print one of its returned fields:
 		[codeblocks]
 		[gdscript]
 		func _ready():
@@ -80,7 +80,7 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		[b]Example of loading and displaying an image using HTTPRequest:[/b]
+		[b]Example:[/b] Load an image using [HTTPRequest] and display it:
 		[codeblocks]
 		[gdscript]
 		func _ready():
@@ -150,7 +150,7 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		[b]Gzipped response bodies[/b]: HTTPRequest will automatically handle decompression of response bodies. A [code]Accept-Encoding[/code] header will be automatically added to each of your requests, unless one is already specified. Any response with a [code]Content-Encoding: gzip[/code] header will automatically be decompressed and delivered to you as uncompressed bytes.
+		[b]Note:[/b] [HTTPRequest] nodes will automatically handle decompression of response bodies. A [code]Accept-Encoding[/code] header will be automatically added to each of your requests, unless one is already specified. Any response with a [code]Content-Encoding: gzip[/code] header will automatically be decompressed and delivered to you as uncompressed bytes.
 	</description>
 	<tutorials>
 		<link title="Making HTTP requests">$DOCS_URL/tutorials/networking/http_request_class.html</link>

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -57,7 +57,7 @@
 			<description>
 				Constructs a [NodePath] from a [String]. The created path is absolute if prefixed with a slash (see [method is_absolute]).
 				The "subnames" optionally included after the path to the target node can point to properties, and can also be nested.
-				Examples of strings that could be node paths:
+				The following strings can be valid node paths:
 				[codeblock]
 				# Points to the Sprite2D node.
 				"Level/RigidBody2D/Sprite2D"

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -53,7 +53,7 @@
 				Creates a new process that runs independently of Godot. It will not terminate when Godot terminates. The path specified in [param path] must exist and be an executable file or macOS [code].app[/code] bundle. The path is resolved based on the current platform. The [param arguments] are used in the given order and separated by a space.
 				On Windows, if [param open_console] is [code]true[/code] and the process is a console app, a new terminal window will be opened.
 				If the process is successfully created, this method returns its process ID, which you can use to monitor the process (and potentially terminate it with [method kill]). Otherwise, this method returns [code]-1[/code].
-				For example, running another instance of the project:
+				[b]Example:[/b] Run another instance of the project:
 				[codeblocks]
 				[gdscript]
 				var pid = OS.create_process(OS.get_executable_path(), [])
@@ -182,7 +182,7 @@
 				Command-line arguments can be written in any form, including both [code]--key value[/code] and [code]--key=value[/code] forms so they can be properly parsed, as long as custom command-line arguments do not conflict with engine arguments.
 				You can also incorporate environment variables using the [method get_environment] method.
 				You can set [member ProjectSettings.editor/run/main_run_args] to define command-line arguments to be passed by the editor when running the project.
-				Here's a minimal example on how to parse command-line arguments into a [Dictionary] using the [code]--key=value[/code] form for arguments:
+				[b]Example:[/b] Parse command-line arguments into a [Dictionary] using the [code]--key=value[/code] form for arguments:
 				[codeblocks]
 				[gdscript]
 				var arguments = {}

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -7,7 +7,7 @@
 		A simplified interface to a scene file. Provides access to operations and checks that can be performed on the scene resource itself.
 		Can be used to save a node to a file. When saving, the node as well as all the nodes it owns get saved (see [member Node.owner] property).
 		[b]Note:[/b] The node doesn't need to own itself.
-		[b]Example of loading a saved scene:[/b]
+		[b]Example:[/b] Load a saved scene:
 		[codeblocks]
 		[gdscript]
 		# Use load() instead of preload() if the path isn't known at compile-time.
@@ -22,7 +22,7 @@
 		AddChild(scene);
 		[/csharp]
 		[/codeblocks]
-		[b]Example of saving a node with different owners:[/b] The following example creates 3 objects: [Node2D] ([code]node[/code]), [RigidBody2D] ([code]body[/code]) and [CollisionObject2D] ([code]collision[/code]). [code]collision[/code] is a child of [code]body[/code] which is a child of [code]node[/code]. Only [code]body[/code] is owned by [code]node[/code] and [method pack] will therefore only save those two nodes, but not [code]collision[/code].
+		[b]Example:[/b] Save a node with different owners. The following example creates 3 objects: [Node2D] ([code]node[/code]), [RigidBody2D] ([code]body[/code]) and [CollisionObject2D] ([code]collision[/code]). [code]collision[/code] is a child of [code]body[/code] which is a child of [code]node[/code]. Only [code]body[/code] is owned by [code]node[/code] and [method pack] will therefore only save those two nodes, but not [code]collision[/code].
 		[codeblocks]
 		[gdscript]
 		# Create the objects.

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -135,8 +135,6 @@
 				Adds a new multistate item with text [param label].
 				Contrarily to normal binary items, multistate items can have more than two states, as defined by [param max_states]. The default value is defined by [param default_state].
 				An [param id] can optionally be provided, as well as an accelerator ([param accel]). If no [param id] is provided, one will be created from the index. If no [param accel] is provided, then the default value of 0 (corresponding to [constant @GlobalScope.KEY_NONE]) will be assigned to the item (which means it won't have any accelerator). See [method get_item_accelerator] for more info on accelerators.
-				[b]Note:[/b] Multistate items don't update their state automatically and must be done manually. See [method toggle_item_multistate], [method set_item_multistate] and [method get_item_multistate] for more info on how to control it.
-				Example usage:
 				[codeblock]
 				func _ready():
 				    add_multistate_item("Item", 3, 0)
@@ -152,6 +150,7 @@
 				                    print("Third state")
 				        )
 				[/codeblock]
+				[b]Note:[/b] Multistate items don't update their state automatically and must be done manually. See [method toggle_item_multistate], [method set_item_multistate] and [method get_item_multistate] for more info on how to control it.
 			</description>
 		</method>
 		<method name="add_radio_check_item">

--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -18,7 +18,8 @@
 		<method name="get_mesh_arrays" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns mesh arrays used to constitute surface of [Mesh]. The result can be passed to [method ArrayMesh.add_surface_from_arrays] to create a new surface. For example:
+				Returns the mesh arrays used to make up the surface of this primitive mesh.
+				[b]Example:[/b] Pass the result to [method ArrayMesh.add_surface_from_arrays] to create a new surface:
 				[codeblocks]
 				[gdscript]
 				var c = CylinderMesh.new()

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -102,7 +102,7 @@
 			<param index="0" name="name" type="StringName" />
 			<description>
 				Similar to [method get_setting], but applies feature tag overrides if any exists and is valid.
-				[b]Example:[/b]	If the setting override [code]"application/config/name.windows"[/code] exists, and the following code is executed on a [i]Windows[/i] operating system, the overridden setting is printed instead:
+				[b]Example:[/b] If the setting override [code]"application/config/name.windows"[/code] exists, and the following code is executed on a [i]Windows[/i] operating system, the overridden setting is printed instead:
 				[codeblocks]
 				[gdscript]
 				print(ProjectSettings.get_setting_with_override("application/config/name"))

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1592,7 +1592,7 @@
 			<return type="RID" />
 			<description>
 				Returns the RID of a 256×256 texture with a testing pattern on it (in [constant Image.FORMAT_RGB8] format). This texture will be created and returned on the first call to [method get_test_texture], then it will be cached for subsequent calls. See also [method get_white_texture].
-				Example of getting the test texture and applying it to a [Sprite2D] node:
+				[b]Example:[/b] Get the test texture and apply it to a [Sprite2D] node:
 				[codeblock]
 				var texture_rid = RenderingServer.get_test_texture()
 				var texture = ImageTexture.create_from_image(RenderingServer.texture_2d_get(texture_rid))
@@ -1633,7 +1633,7 @@
 			<return type="RID" />
 			<description>
 				Returns the ID of a 4×4 white texture (in [constant Image.FORMAT_RGB8] format). This texture will be created and returned on the first call to [method get_white_texture], then it will be cached for subsequent calls. See also [method get_test_texture].
-				Example of getting the white texture and applying it to a [Sprite2D] node:
+				[b]Example:[/b] Get the white texture and apply it to a [Sprite2D] node:
 				[codeblock]
 				var texture_rid = RenderingServer.get_white_texture()
 				var texture = ImageTexture.create_from_image(RenderingServer.texture_2d_get(texture_rid))
@@ -3495,7 +3495,7 @@
 			<param index="0" name="texture" type="RID" />
 			<description>
 				Returns an [Image] instance from the given [param texture] [RID].
-				Example of getting the test texture from [method get_test_texture] and applying it to a [Sprite2D] node:
+				[b]Example:[/b] Get the test texture from [method get_test_texture] and apply it to a [Sprite2D] node:
 				[codeblock]
 				var texture_rid = RenderingServer.get_test_texture()
 				var texture = ImageTexture.create_from_image(RenderingServer.texture_2d_get(texture_rid))

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -24,7 +24,7 @@
 			<return type="void" />
 			<description>
 				Override this method to customize the newly duplicated resource created from [method PackedScene.instantiate], if the original's [member resource_local_to_scene] is set to [code]true[/code].
-				[b]Example:[/b] Set a random [code]damage[/code] value to every local resource from an instantiated scene.
+				[b]Example:[/b] Set a random [code]damage[/code] value to every local resource from an instantiated scene:
 				[codeblock]
 				extends Resource
 

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -225,8 +225,8 @@
 			<return type="void" />
 			<param index="0" name="effect" type="Variant" />
 			<description>
-				Installs a custom effect. This can also be done in the RichTextLabel inspector using the [member custom_effects] property. [param effect] should be a valid [RichTextEffect].
-				Example RichTextEffect:
+				Installs a custom effect. This can also be done in the Inspector through the [member custom_effects] property. [param effect] should be a valid [RichTextEffect].
+				[b]Example:[/b] With the following script extending from [RichTextEffect]:
 				[codeblock]
 				# effect.gd
 				class_name MyCustomEffect
@@ -236,7 +236,7 @@
 
 				# ...
 				[/codeblock]
-				Registering the above effect in RichTextLabel from script:
+				The above effect can be installed in [RichTextLabel] from a script:
 				[codeblock]
 				# rich_text_label.gd
 				extends RichTextLabel

--- a/doc/classes/SyntaxHighlighter.xml
+++ b/doc/classes/SyntaxHighlighter.xml
@@ -41,11 +41,11 @@
 			<return type="Dictionary" />
 			<param index="0" name="line" type="int" />
 			<description>
-				Returns syntax highlighting data for a single line. If the line is not cached, calls [method _get_line_syntax_highlighting] to calculate the data.
-				The return [Dictionary] is column number to [Dictionary]. The column number notes the start of a region, the region will end if another region is found, or at the end of the line. The nested [Dictionary] contains the data for that region, currently only the key "color" is supported.
-				[b]Example return:[/b]
+				Returns the syntax highlighting data for the line at index [param line]. If the line is not cached, calls [method _get_line_syntax_highlighting] first to calculate the data.
+				Each entry is a column number containing a nested [Dictionary]. The column number denotes the start of a region, the region will end if another region is found, or at the end of the line. The nested [Dictionary] contains the data for that region. Currently only the key [code]"color"[/code] is supported.
+				[b]Example:[/b] Possible return value. This means columns [code]0[/code] to [code]4[/code] should be red, and columns [code]5[/code] to the end of the line should be green:
 				[codeblock]
-				var color_map = {
+				{
 				    0: {
 				        "color": Color(1, 0, 0)
 				    },
@@ -54,7 +54,6 @@
 				    }
 				}
 				[/codeblock]
-				This will color columns 0-4 red, and columns 5-eol in green.
 			</description>
 		</method>
 		<method name="get_text_edit" qualifiers="const">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -124,7 +124,6 @@
 			<return type="void" />
 			<description>
 				Starts an edit for multiple carets. The edit must be ended with [method end_multicaret_edit]. Multicaret edits can be used to edit text at multiple carets and delay merging the carets until the end, so the caret indexes aren't affected immediately. [method begin_multicaret_edit] and [method end_multicaret_edit] can be nested, and the merge will happen at the last [method end_multicaret_edit].
-				Example usage:
 				[codeblock]
 				begin_complex_operation()
 				begin_multicaret_edit()

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -720,8 +720,6 @@
 			<param index="0" name="files" type="PackedStringArray" />
 			<description>
 				Emitted when files are dragged from the OS file manager and dropped in the game window. The argument is a list of file paths.
-				Note that this method only works with native windows, i.e. the main window and [Window]-derived nodes when [member Viewport.gui_embed_subwindows] is disabled in the main viewport.
-				Example usage:
 				[codeblock]
 				func _ready():
 				    get_viewport().files_dropped.connect(on_files_dropped)
@@ -729,6 +727,7 @@
 				func on_files_dropped(files):
 				    print(files)
 				[/codeblock]
+				[b]Note:[/b] This signal only works with native windows, i.e. the main window and [Window]-derived nodes when [member Viewport.gui_embed_subwindows] is disabled in the main viewport.
 			</description>
 		</signal>
 		<signal name="focus_entered">

--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -16,11 +16,10 @@
 			<return type="Variant" />
 			<description>
 				Returns a new instance of the script.
-				For example:
 				[codeblock]
 				var MyClass = load("myclass.gd")
 				var instance = MyClass.new()
-				assert(instance.get_script() == MyClass)
+				print(instance.get_script() == MyClass) # Prints true
 				[/codeblock]
 			</description>
 		</method>

--- a/modules/regex/doc_classes/RegEx.xml
+++ b/modules/regex/doc_classes/RegEx.xml
@@ -34,14 +34,14 @@
 		    print(result.get_string("digit"))
 		# Would print 01 03 0 3f 42
 		[/codeblock]
-		[b]Example of splitting a string using a RegEx:[/b]
+		[b]Example:[/b] Split a string using a RegEx:
 		[codeblock]
 		var regex = RegEx.new()
 		regex.compile("\\S+") # Negated whitespace character class.
 		var results = []
 		for result in regex.search_all("One  Two \n\tThree"):
 		    results.push_back(result.get_string())
-		# The `results` array now contains "One", "Two", "Three".
+		# The `results` array now contains "One", "Two", and "Three".
 		[/codeblock]
 		[b]Note:[/b] Godot's regex implementation is based on the [url=https://www.pcre.org/]PCRE2[/url] library. You can view the full pattern reference [url=https://www.pcre.org/current/doc/html/pcre2pattern.html]here[/url].
 		[b]Tip:[/b] You can use [url=https://regexr.com/]Regexr[/url] to test regular expressions online.


### PR DESCRIPTION
Continuation of https://github.com/godotengine/godot/pull/95749, see prior PR for similar reasoning.

This PR continues the effort to standardise the `[b]Example:[/b]` somewhat, instead of bolding the entire line describing the example below.
It also replaces some lines similar to `For example:` with `[b]Example:[/b]`. This is not exhaustive at all, as oftentimes doing this change makes readability worse, but whenever possible... sure, why not?

The descriptions affected by this have received tweaks to justify a localization update. Notably:
- `Control._gui_input()` has been changed drastically
- `SyntaxHighlighter.get_line_syntax_highlighting()` has been changed drastically
- A note in HTTPRequest was made into an actual note
- A note in PopupMenu was shifted to the bottom
- A note in Window was shifted to the bottom
