### PR TITLE
Make use of NavigationObstacle2D's transform

### DIFF
--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -106,6 +106,8 @@ public:
 	void set_carve_navigation_mesh(bool p_enabled);
 	bool get_carve_navigation_mesh() const;
 
+	PackedStringArray get_configuration_warnings() const override;
+
 private:
 	void _update_map(RID p_map);
 	void _update_position(const Vector2 p_position);


### PR DESCRIPTION
Fixes #95820 

2D version of #96730. Partially an enhancement and partially a fix because previously, editing a `NavigationObstacle2D` was broken if it or any of its ancestor nodes had a rotation, scale, or skew applied.

~~The only thing missing as far as I can tell is to modify `NavigationObstacle2DEditor` so that the vertices are transformed by the modified safe transform (which prevents non-uniform scaling), as discussed on RocketChat.~~

Edit: This should now be fully consistent and have feature parity with the 3D version of this PR. But I have not tested it extensively and the code may not be completely in line with Godot's conventions and guidelines, would need someone more familiar with the codebase to review and give feedback on it please 🙂