### PR TITLE
Trim a few no-break and zero-width spaces from codebase

### DIFF
--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -104,7 +104,7 @@
 			<param index="1" name="progress" type="Array" default="[]" />
 			<description>
 				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path]. See [enum ThreadLoadStatus] for possible return values.
-				An array variable can optionally be passed via [param progress], and will return a one-element array containing the ratio of completion of the threaded loading (between [code]0.0[/code] and [code]1.0[/code]).
+				An array variable can optionally be passed via [param progress], and will return a one-element array containing the ratio of completion of the threaded loading (between [code]0.0[/code] and [code]1.0[/code]).
 				[b]Note:[/b] The recommended way of using this method is to call it during different frames (e.g., in [method Node._process], instead of a loop).
 			</description>
 		</method>

--- a/misc/dist/linux/org.godotengine.Godot.appdata.xml
+++ b/misc/dist/linux/org.godotengine.Godot.appdata.xml
@@ -6,7 +6,7 @@
   <project_license>MIT</project_license>
   <name>Godot Engine</name>
   <summary>Multi-platform 2D and 3D game engine with a feature-rich editor</summary>
-  ​<launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
+  <launchable type="desktop-id">org.godotengine.Godot.desktop</launchable>
   <description>
     <p>
       Godot is an advanced, feature-packed, multi-platform 2D and 3D game


### PR DESCRIPTION
These were found by accident and through trial-and-error, until I figured the catch-all RegEx `[^\S \t]+`.