### PR TITLE
Windows: Expand `godot.natvis` type coverage

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -60,6 +60,9 @@ sources += res_obj
 prog = env.add_program("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
 arrange_program_clean(prog)
 
+if env.msvc:
+    env.Depends(prog, "godot.natvis")
+
 # Build console wrapper app.
 if env["windows_subsystem"] == "gui":
     env_wrap = env.Clone()

--- a/platform/windows/godot.natvis
+++ b/platform/windows/godot.natvis
@@ -30,16 +30,6 @@
 		</Expand>
 	</Type>
 
-	<Type Name="TypedArray&lt;*&gt;">
-		<Expand>
-			<Item Name="[size]"> _p->array._cowdata._ptr ? (((const unsigned long long *)(_p->array._cowdata._ptr))[-1]) : 0</Item>
-			<ArrayItems>
-				<Size>_p->array._cowdata._ptr ? (((const unsigned long long *)(_p->array._cowdata._ptr))[-1]) : 0</Size>
-				<ValuePointer >(Variant *) _p->array._cowdata._ptr</ValuePointer>
-			</ArrayItems>
-		</Expand>
-	</Type>
-
 	<Type Name="Dictionary">
 		<Expand>
 			<Item Name="[size]">_p &amp;&amp; _p->variant_map.head_element ? _p->variant_map.num_elements : 0</Item>
@@ -153,7 +143,7 @@
 	<Type Name="HashMapElement&lt;*,*&gt;" IncludeView="MapHelper">
 		<DisplayString>{data.value}</DisplayString>
 		<Expand>
-			<Item Name="[key]"  >($T1 *) &amp;data.key</Item>
+			<Item Name="[key]">($T1 *) &amp;data.key</Item>
 			<Item Name="[value]">($T2 *) &amp;data.value</Item>
 		</Expand>
 	</Type>
@@ -285,39 +275,164 @@
 	</Type>
 
 	<Type Name="Vector2">
-		<DisplayString>{{{x},{y}}}</DisplayString>
+		<DisplayString>({x,g}, {y,g})</DisplayString>
 		<Expand>
-			<Item Name="x">x</Item>
-			<Item Name="y">y</Item>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+		</Expand>
+	</Type>
+	<Type Name="Vector2i">
+		<DisplayString>({x}, {y})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
 		</Expand>
 	</Type>
 
 	<Type Name="Vector3">
-		<DisplayString>{{{x},{y},{z}}}</DisplayString>
+		<DisplayString>({x,g}, {y,g}, {z,g})</DisplayString>
 		<Expand>
-			<Item Name="x">x</Item>
-			<Item Name="y">y</Item>
-			<Item Name="z">z</Item>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+		</Expand>
+	</Type>
+	<Type Name="Vector3i">
+		<DisplayString>({x}, {y}, {z})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Vector4">
+		<DisplayString>({x,g}, {y,g}, {z,g}, {w,g})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+			<Item Name="[w]">w</Item>
+		</Expand>
+	</Type>
+	<Type Name="Vector4i">
+		<DisplayString>({x}, {y}, {z}, {w})</DisplayString>
+		<Expand>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+			<Item Name="[w]">w</Item>
 		</Expand>
 	</Type>
 
 	<Type Name="Quaternion">
-		<DisplayString>Quaternion {{{x},{y},{z},{w}}}</DisplayString>
+		<DisplayString>({x,g}, {y,g}, {z,g}, {w,g})</DisplayString>
 		<Expand>
-			<Item Name="x">x</Item>
-			<Item Name="y">y</Item>
-			<Item Name="z">z</Item>
-			<Item Name="w">w</Item>
+			<Item Name="[x]">x</Item>
+			<Item Name="[y]">y</Item>
+			<Item Name="[z]">z</Item>
+			<Item Name="[w]">w</Item>
 		</Expand>
 	</Type>
 
 	<Type Name="Color">
-		<DisplayString>Color {{{r},{g},{b},{a}}}</DisplayString>
+		<DisplayString>({r,g}, {g,g}, {b,g}, {a,g})</DisplayString>
 		<Expand>
-			<Item Name="red">r</Item>
-			<Item Name="green">g</Item>
-			<Item Name="blue">b</Item>
-			<Item Name="alpha">a</Item>
+			<Item Name="[red]">r</Item>
+			<Item Name="[green]">g</Item>
+			<Item Name="[blue]">b</Item>
+			<Item Name="[alpha]">a</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Rect2">
+		<DisplayString>[P: {position}, S: {size}]</DisplayString>
+		<Expand>
+			<Item Name="[position]">position,nr</Item>
+			<Item Name="[size]">size,nr</Item>
+		</Expand>
+	</Type>
+	<Type Name="Rect2i">
+		<DisplayString>[P: {position}, S: {size}]</DisplayString>
+		<Expand>
+			<Item Name="[position]">position,nr</Item>
+			<Item Name="[size]">size,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="AABB">
+		<DisplayString>[P: {position}, S: {size}]</DisplayString>
+		<Expand>
+			<Item Name="[position]">position,nr</Item>
+			<Item Name="[size]">size,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Plane">
+		<DisplayString>[N: {normal}, D: {d,g}]</DisplayString>
+		<Expand>
+			<Item Name="[normal]">normal,nr</Item>
+			<Item Name="[d]">d</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Basis">
+		<DisplayString>[X: {rows[0]}, Y: {rows[1]}, Z: {rows[2]}]</DisplayString>
+		<Expand>
+			<Item Name="[x]">rows[0],nr</Item>
+			<Item Name="[y]">rows[1],nr</Item>
+			<Item Name="[z]">rows[2],nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Transform2D">
+		<DisplayString>[X: {columns[0]}, Y: {columns[1]}, O: {columns[2]}]</DisplayString>
+		<Expand>
+			<Item Name="[x]">columns[0],nr</Item>
+			<Item Name="[y]">columns[1],nr</Item>
+			<Item Name="[origin]">columns[2],nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Transform3D">
+		<!-- Can't call column functions, so just pretend we can via obscene code duplication. -->
+		<DisplayString>[X: ({basis.rows[0].x,g}, {basis.rows[1].x,g}, {basis.rows[2].x,g}), Y: ({basis.rows[0].y,g}, {basis.rows[1].y,g}, {basis.rows[2].y,g}), Z: ({basis.rows[0].z,g}, {basis.rows[1].z,g}, {basis.rows[2].z,g}), O: {origin}]</DisplayString>
+		<Expand>
+			<Synthetic Name="[x]">
+				<DisplayString>({basis.rows[0].x,g}, {basis.rows[1].x,g}, {basis.rows[2].x,g})</DisplayString>
+				<Expand>
+					<Item Name="[x]">basis.rows[0].x</Item>
+					<Item Name="[y]">basis.rows[1].x</Item>
+					<Item Name="[z]">basis.rows[2].x</Item>
+				</Expand>
+			</Synthetic>
+			<Synthetic Name="[y]">
+				<DisplayString>({basis.rows[0].y,g}, {basis.rows[1].y,g}, {basis.rows[2].y,g})</DisplayString>
+				<Expand>
+					<Item Name="[x]">basis.rows[0].y</Item>
+					<Item Name="[y]">basis.rows[1].y</Item>
+					<Item Name="[z]">basis.rows[2].y</Item>
+				</Expand>
+			</Synthetic>
+			<Synthetic Name="[z]">
+				<DisplayString>({basis.rows[0].z,g}, {basis.rows[1].z,g}, {basis.rows[2].z,g})</DisplayString>
+				<Expand>
+					<Item Name="[x]">basis.rows[0].z</Item>
+					<Item Name="[y]">basis.rows[1].z</Item>
+					<Item Name="[z]">basis.rows[2].z</Item>
+				</Expand>
+			</Synthetic>
+			<Item Name="[origin]">origin,nr</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="Projection">
+		<DisplayString>[X: {columns[0]}, Y: {columns[1]}, Z: {columns[2]}, W: {columns[3]}]</DisplayString>
+		<Expand>
+			<Item Name="[x]">columns[0],nr</Item>
+			<Item Name="[y]">columns[1],nr</Item>
+			<Item Name="[z]">columns[2],nr</Item>
+			<Item Name="[w]">columns[3],nr</Item>
 		</Expand>
 	</Type>
 </AutoVisualizer>


### PR DESCRIPTION
Adds several new types to `godot.natvis`, particularly the Variant structs. Makes the display string representation equivalent to their String operator output where possible. Additionally, this adds `godot.natvis` as a dependancy to the executable itself, meaning editing *just* that file will trigger a relink on build. Also in testing, TypedArray already inherits debug display from Array, so that redundant section was removed