### PR TITLE
Web: Remove deprecated worker.js file

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -59,7 +59,7 @@ for ext in sys_env["JS_EXTERNS"]:
     sys_env["ENV"]["EMCC_CLOSURE_ARGS"] += " --externs " + ext.abspath
 
 build = []
-build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm", "#bin/godot${PROGSUFFIX}.worker.js"]
+build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]
 if env["dlink_enabled"]:
     # Reset libraries. The main runtime will only link emscripten libraries, not godot ones.
     sys_env["LIBS"] = []
@@ -108,6 +108,5 @@ js_wrapped = env.Textfile("#bin/godot", [env.File(f) for f in wrap_list], TEXTFI
 
 # 0 - unwrapped js file (use wrapped one instead)
 # 1 - wasm file
-# 2 - worker file
-# 3 - wasm side (when dlink is enabled).
-env.CreateTemplateZip(js_wrapped, build[1], build[2], build[3] if len(build) > 3 else None)
+# 2 - wasm side (when dlink is enabled).
+env.CreateTemplateZip(js_wrapped, build[1], build[2] if len(build) > 2 else None)

--- a/platform/web/emscripten_helpers.py
+++ b/platform/web/emscripten_helpers.py
@@ -30,7 +30,7 @@ def create_engine_file(env, target, source, externs, threads_enabled):
     return env.Substfile(target=target, source=[env.File(s) for s in source], SUBST_DICT=subst_dict)
 
 
-def create_template_zip(env, js, wasm, worker, side):
+def create_template_zip(env, js, wasm, side):
     binary_name = "godot.editor" if env.editor_build else "godot"
     zip_dir = env.Dir(env.GetTemplateZipPath())
     in_files = [
@@ -45,9 +45,6 @@ def create_template_zip(env, js, wasm, worker, side):
         zip_dir.File(binary_name + ".audio.worklet.js"),
         zip_dir.File(binary_name + ".audio.position.worklet.js"),
     ]
-    if env["threads"]:
-        in_files.append(worker)
-        out_files.append(zip_dir.File(binary_name + ".worker.js"))
     # Dynamic linking (extensions) specific.
     if env["dlink_enabled"]:
         in_files.append(side)  # Side wasm (contains the actual Godot code).
@@ -66,8 +63,6 @@ def create_template_zip(env, js, wasm, worker, side):
             "logo.svg",
             "favicon.png",
         ]
-        if env["threads"]:
-            cache.append("godot.editor.worker.js")
         opt_cache = ["godot.editor.wasm"]
         subst_dict = {
             "___GODOT_VERSION___": get_build_version(False),

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -214,9 +214,6 @@ Error EditorExportPlatformWeb::_add_manifest_icon(const String &p_path, const St
 }
 
 Error EditorExportPlatformWeb::_build_pwa(const Ref<EditorExportPreset> &p_preset, const String p_path, const Vector<SharedObject> &p_shared_objects) {
-	List<String> preset_features;
-	get_preset_features(p_preset, &preset_features);
-
 	String proj_name = GLOBAL_GET("application/config/name");
 	if (proj_name.is_empty()) {
 		proj_name = "Godot Game";
@@ -243,9 +240,6 @@ Error EditorExportPlatformWeb::_build_pwa(const Ref<EditorExportPreset> &p_prese
 		cache_files.push_back(name + ".apple-touch-icon.png");
 	}
 
-	if (preset_features.find("threads")) {
-		cache_files.push_back(name + ".worker.js");
-	}
 	cache_files.push_back(name + ".audio.worklet.js");
 	cache_files.push_back(name + ".audio.position.worklet.js");
 	replaces["___GODOT_CACHE___"] = Variant(cache_files).to_json_string();
@@ -839,7 +833,6 @@ Error EditorExportPlatformWeb::_export_project(const Ref<EditorExportPreset> &p_
 		DirAccess::remove_file_or_error(basepath + ".html");
 		DirAccess::remove_file_or_error(basepath + ".offline.html");
 		DirAccess::remove_file_or_error(basepath + ".js");
-		DirAccess::remove_file_or_error(basepath + ".worker.js");
 		DirAccess::remove_file_or_error(basepath + ".audio.worklet.js");
 		DirAccess::remove_file_or_error(basepath + ".audio.position.worklet.js");
 		DirAccess::remove_file_or_error(basepath + ".service.worker.js");

--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -295,8 +295,6 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 			'locateFile': function (path) {
 				if (!path.startsWith('godot.')) {
 					return path;
-				} else if (path.endsWith('.worker.js')) {
-					return `${loadPath}.worker.js`;
 				} else if (path.endsWith('.audio.worklet.js')) {
 					return `${loadPath}.audio.worklet.js`;
 				} else if (path.endsWith('.audio.position.worklet.js')) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Remove godot.<PROGSUFFIX>.worker.js. As far as I can tell this file is deprecated. The ci pulls this file from build cache, and when the build artifact is examined, the worker.js file has a dummy description inside (see linked issue). 

This all points to the web .worker.js file as having been removed.

Fixes #98973 