### PR TITLE
[iOS] Add options to specify additional entitlements and capabilities in the export settings.

### DIFF
--- a/misc/dist/ios_xcode/godot_ios/godot_ios.entitlements
+++ b/misc/dist/ios_xcode/godot_ios/godot_ios.entitlements
@@ -2,6 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-$entitlements_push_notifications
+$entitlements_full
 </dict>
 </plist>

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -84,6 +84,9 @@
 		<member name="capabilities/access_wifi" type="bool" setter="" getter="">
 			If [code]true[/code], networking features related to Wi-Fi access are enabled. See [url=https://developer.apple.com/support/required-device-capabilities/]Required Device Capabilities[/url].
 		</member>
+		<member name="capabilities/additional" type="PackedStringArray" setter="" getter="">
+			Additional data added to the [code]UIRequiredDeviceCapabilities[/code] array of the [code]Info.plist[/code] file.
+		</member>
 		<member name="capabilities/performance_a12" type="bool" setter="" getter="">
 			Requires the graphics performance and features of the A12 Bionic and later chips (devices supporting all Vulkan renderer features).
 			Enabling this option limits supported devices to: iPhone XS, iPhone XR, iPad Mini (5th gen.), iPad Air (3rd gen.), iPad (8th gen) and newer.
@@ -92,14 +95,27 @@
 			Requires the graphics performance and features of the A17 Pro and later chips.
 			Enabling this option limits supported devices to: iPhone 15 Pro and newer.
 		</member>
-		<member name="capabilities/push_notifications" type="bool" setter="" getter="">
-			If [code]true[/code], push notifications are enabled. See [url=https://developer.apple.com/support/required-device-capabilities/]Required Device Capabilities[/url].
-		</member>
 		<member name="custom_template/debug" type="String" setter="" getter="">
 			Path to the custom export template. If left empty, default template is used.
 		</member>
 		<member name="custom_template/release" type="String" setter="" getter="">
 			Path to the custom export template. If left empty, default template is used.
+		</member>
+		<member name="entitlements/additional" type="String" setter="" getter="">
+			Additional data added to the root [code]&lt;dict&gt;[/code] section of the [url=https://developer.apple.com/documentation/bundleresources/entitlements].entitlements[/url] file. The value should be an XML section with pairs of key-value elements, for example:
+			[codeblock lang=text]
+			&lt;key&gt;key_name&lt;/key&gt;
+			&lt;string&gt;value&lt;/string&gt;
+			[/codeblock]
+		</member>
+		<member name="entitlements/game_center" type="bool" setter="" getter="">
+			Enable to allow access to Game Center features. [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_game-center]com.apple.developer.game-center[/url].
+		</member>
+		<member name="entitlements/increased_memory_limit" type="bool" setter="" getter="">
+			Enable if app may perform better with a higher memory limit. [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_kernel_increased-memory-limit]com.apple.developer.kernel.increased-memory-limit[/url].
+		</member>
+		<member name="entitlements/push_notifications" type="String" setter="" getter="">
+			Environment for Apple Push Notification service. See [url=https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment]aps-environment[/url].
 		</member>
 		<member name="icons/app_store_1024x1024" type="String" setter="" getter="">
 			App Store application icon file. If left empty, it will fallback to [member ProjectSettings.application/config/icon]. See [url=https://developer.apple.com/design/human-interface-guidelines/foundations/app-icons]App icons[/url].

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -76,11 +76,11 @@
 			Array of the additional command line arguments passed to the code signing tool.
 		</member>
 		<member name="codesign/entitlements/additional" type="String" setter="" getter="">
-			Additional data added to the root [code]&lt;dict&gt;[/code] section of the [url=https://developer.apple.com/documentation/bundleresources/entitlements].entitlements[/url] file. The value should be an XML section with pairs of key-value elements, e.g.:
-				[codeblock lang=text]
-				&lt;key&gt;key_name&lt;/key&gt;
-				&lt;string&gt;value&lt;/string&gt;
-				[/codeblock]
+			Additional data added to the root [code]&lt;dict&gt;[/code] section of the [url=https://developer.apple.com/documentation/bundleresources/entitlements].entitlements[/url] file. The value should be an XML section with pairs of key-value elements, for example:
+			[codeblock lang=text]
+			&lt;key&gt;key_name&lt;/key&gt;
+			&lt;string&gt;value&lt;/string&gt;
+			[/codeblock]
 		</member>
 		<member name="codesign/entitlements/address_book" type="bool" setter="" getter="">
 			Enable to allow access to contacts in the user's address book, if it's enabled you should also provide usage message in the [member privacy/address_book_usage_description] option. See [url=https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_personal-information_addressbook]com.apple.security.personal-information.addressbook[/url].


### PR DESCRIPTION
- Adds option to specify additional entitlements (same as for macOS).
- Adds option to specify additional `UIRequiredDeviceCapabilities`.
- Changes `aps-environment` entitlement from `bool` to `diabled,production,development` enum.
- Adds some `Game Center` and `Increased Memory Limit` entitlements.

Fixes https://github.com/godotengine/godot-proposals/issues/11109