### PR TITLE
Make Game toolbar a debugger tab

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -801,17 +801,6 @@ void EditorDebuggerNode::live_debug_reparent_node(const NodePath &p_at, const No
 	});
 }
 
-void EditorDebuggerNode::set_camera_override(CameraOverride p_override) {
-	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
-		dbg->set_camera_override(p_override);
-	});
-	camera_override = p_override;
-}
-
-EditorDebuggerNode::CameraOverride EditorDebuggerNode::get_camera_override() {
-	return camera_override;
-}
-
 void EditorDebuggerNode::add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin) {
 	ERR_FAIL_COND_MSG(p_plugin.is_null(), "Debugger plugin is null.");
 	ERR_FAIL_COND_MSG(debugger_plugins.has(p_plugin), "Debugger plugin already exists.");

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -48,13 +48,6 @@ class UndoRedo;
 class EditorDebuggerNode : public MarginContainer {
 	GDCLASS(EditorDebuggerNode, MarginContainer);
 
-public:
-	enum CameraOverride {
-		OVERRIDE_NONE,
-		OVERRIDE_INGAME,
-		OVERRIDE_EDITORS,
-	};
-
 private:
 	enum Options {
 		DEBUG_NEXT,
@@ -111,7 +104,6 @@ private:
 	bool keep_open = false;
 	String current_uri;
 
-	CameraOverride camera_override = OVERRIDE_NONE;
 	HashMap<Breakpoint, bool, Breakpoint> breakpoints;
 
 	HashSet<Ref<EditorDebuggerPlugin>> debugger_plugins;
@@ -204,9 +196,6 @@ public:
 	void live_debug_restore_node(ObjectID p_id, const NodePath &p_at, int p_at_pos);
 	void live_debug_duplicate_node(const NodePath &p_at, const String &p_new_name);
 	void live_debug_reparent_node(const NodePath &p_at, const NodePath &p_new_place, const String &p_new_name, int p_at_pos);
-
-	void set_camera_override(CameraOverride p_override);
-	CameraOverride get_camera_override();
 
 	String get_server_uri() const;
 

--- a/editor/debugger/editor_performance_profiler.h
+++ b/editor/debugger/editor_performance_profiler.h
@@ -32,12 +32,13 @@
 #define EDITOR_PERFORMANCE_PROFILER_H
 
 #include "core/templates/hash_map.h"
-#include "core/templates/rb_map.h"
 #include "main/performance.h"
-#include "scene/gui/control.h"
-#include "scene/gui/label.h"
 #include "scene/gui/split_container.h"
-#include "scene/gui/tree.h"
+
+class Button;
+class EditorFileDialog;
+class Tree;
+class TreeItem;
 
 class EditorPerformanceProfiler : public HSplitContainer {
 	GDCLASS(EditorPerformanceProfiler, HSplitContainer);
@@ -63,6 +64,9 @@ private:
 
 	HashMap<StringName, TreeItem *> base_map;
 	Tree *monitor_tree = nullptr;
+	EditorFileDialog *file_dialog = nullptr;
+	Button *export_csv_button = nullptr;
+	Button *deselect_all_button = nullptr;
 	Control *monitor_draw = nullptr;
 	Label *info_message = nullptr;
 	StringName marker_key;
@@ -79,6 +83,10 @@ private:
 	TreeItem *_create_monitor_item(const StringName &p_monitor_name, TreeItem *p_base);
 	void _marker_input(const Ref<InputEvent> &p_event);
 
+	List<float> *_get_monitor_data(const StringName &p_name);
+	void _export_csv(const String &p_path);
+	void _deselect_all();
+
 protected:
 	void _notification(int p_what);
 
@@ -86,7 +94,6 @@ public:
 	void reset();
 	void update_monitors(const Vector<StringName> &p_names);
 	void add_profile_frame(const Vector<float> &p_values);
-	List<float> *get_monitor_data(const StringName &p_name);
 	EditorPerformanceProfiler();
 };
 

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -31,17 +31,17 @@
 #ifndef EDITOR_PROFILER_H
 #define EDITOR_PROFILER_H
 
+#include "editor/gui/editor_file_dialog.h"
 #include "scene/gui/box_container.h"
-#include "scene/gui/button.h"
-#include "scene/gui/check_button.h"
-#include "scene/gui/label.h"
-#include "scene/gui/option_button.h"
-#include "scene/gui/spin_box.h"
-#include "scene/gui/split_container.h"
-#include "scene/gui/texture_rect.h"
-#include "scene/gui/tree.h"
 
+class Button;
+class CheckButton;
+class HSplitContainer;
 class ImageTexture;
+class OptionButton;
+class SpinBox;
+class TextureRect;
+class Tree;
 
 class EditorProfiler : public VBoxContainer {
 	GDCLASS(EditorProfiler, VBoxContainer);
@@ -121,6 +121,9 @@ private:
 
 	SpinBox *cursor_metric_edit = nullptr;
 
+	EditorFileDialog *file_dialog = nullptr;
+	Button *export_csv_button = nullptr;
+
 	Vector<Metric> frame_metrics;
 	int total_metrics = 0;
 	int last_metric = -1;
@@ -168,6 +171,8 @@ private:
 
 	Metric _get_frame_metric(int index);
 
+	void _export_csv(const String &p_path) const;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -181,8 +186,6 @@ public:
 	void disable_seeking();
 
 	void clear();
-
-	Vector<Vector<String>> get_data_as_csv() const;
 
 	EditorProfiler();
 };

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -35,7 +35,6 @@
 #include "core/os/os.h"
 #include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/debugger/editor_debugger_node.h"
-#include "editor/debugger/editor_debugger_server.h"
 #include "scene/gui/button.h"
 #include "scene/gui/margin_container.h"
 
@@ -65,6 +64,13 @@ class ScriptEditorDebugger : public MarginContainer {
 	friend class DebugAdapterProtocol;
 	friend class DebugAdapterParser;
 
+public:
+	enum CameraOverride {
+		OVERRIDE_NONE,
+		OVERRIDE_INGAME,
+		OVERRIDE_EDITORS,
+	};
+
 private:
 	enum MessageType {
 		MESSAGE_ERROR,
@@ -87,13 +93,6 @@ private:
 
 	AcceptDialog *msgdialog = nullptr;
 
-	LineEdit *clicked_ctrl = nullptr;
-	LineEdit *clicked_ctrl_type = nullptr;
-	LineEdit *live_edit_root = nullptr;
-	Button *le_set = nullptr;
-	Button *le_clear = nullptr;
-	Button *export_csv = nullptr;
-
 	VBoxContainer *errors_tab = nullptr;
 	Tree *error_tree = nullptr;
 	Button *expand_all_button = nullptr;
@@ -105,11 +104,6 @@ private:
 	PopupMenu *breakpoints_menu = nullptr;
 
 	EditorFileDialog *file_dialog = nullptr;
-	enum FileDialogPurpose {
-		SAVE_MONITORS_CSV,
-		SAVE_VRAM_CSV,
-	};
-	FileDialogPurpose file_dialog_purpose;
 
 	int error_count;
 	int warning_count;
@@ -183,7 +177,7 @@ private:
 
 	void _select_thread(int p_index);
 
-	EditorDebuggerNode::CameraOverride camera_override;
+	CameraOverride camera_override;
 
 	void _stack_dump_frame_selected();
 
@@ -203,9 +197,6 @@ private:
 	int _get_node_path_cache(const NodePath &p_path);
 
 	int _get_res_path_cache(const String &p_path);
-
-	void _live_edit_set();
-	void _live_edit_clear();
 
 	void _method_changed(Object *p_base, const StringName &p_name, const Variant **p_args, int p_argcount);
 	void _property_changed(Object *p_base, const StringName &p_property, const Variant &p_value);
@@ -227,7 +218,6 @@ private:
 	void _tab_changed(int p_tab);
 
 	void _put_msg(const String &p_message, const Array &p_data, uint64_t p_thread_id = Thread::MAIN_ID);
-	void _export_csv();
 
 	void _clear_execution();
 	void _stop_and_notify();
@@ -252,6 +242,7 @@ public:
 
 	// Needed by _live_edit_set, buttons state.
 	void set_editor_remote_tree(const Tree *p_tree) { editor_remote_tree = p_tree; }
+	const Tree *get_editor_remote_tree() const { return editor_remote_tree; }
 
 	void request_remote_tree();
 	const SceneDebuggerTree *get_remote_tree();
@@ -299,8 +290,8 @@ public:
 	void live_debug_duplicate_node(const NodePath &p_at, const String &p_new_name);
 	void live_debug_reparent_node(const NodePath &p_at, const NodePath &p_new_place, const String &p_new_name, int p_at_pos);
 
-	EditorDebuggerNode::CameraOverride get_camera_override() const;
-	void set_camera_override(EditorDebuggerNode::CameraOverride p_override);
+	CameraOverride get_camera_override() const;
+	void set_camera_override(CameraOverride p_override);
 
 	void set_breakpoint(const String &p_path, int p_line, bool p_enabled);
 

--- a/editor/plugins/editor_debugger_plugin.cpp
+++ b/editor/plugins/editor_debugger_plugin.cpp
@@ -30,8 +30,6 @@
 
 #include "editor_debugger_plugin.h"
 
-#include "editor/debugger/script_editor_debugger.h"
-
 void EditorDebuggerSession::_breaked(bool p_really_did, bool p_can_debug, const String &p_message, bool p_has_stackdump) {
 	if (p_really_did) {
 		emit_signal(SNAME("breaked"), p_can_debug);
@@ -104,6 +102,26 @@ bool EditorDebuggerSession::is_active() {
 void EditorDebuggerSession::set_breakpoint(const String &p_path, int p_line, bool p_enabled) {
 	ERR_FAIL_NULL_MSG(debugger, "Plugin is not attached to debugger.");
 	debugger->set_breakpoint(p_path, p_line, p_enabled);
+}
+
+ScriptEditorDebugger::CameraOverride EditorDebuggerSession::get_camera_override() const {
+	ERR_FAIL_NULL_V_MSG(debugger, ScriptEditorDebugger::OVERRIDE_NONE, "Plugin is not attached to debugger.");
+	return debugger->get_camera_override();
+}
+
+void EditorDebuggerSession::set_camera_override(ScriptEditorDebugger::CameraOverride p_override) {
+	ERR_FAIL_NULL_MSG(debugger, "Plugin is not attached to debugger.");
+	debugger->set_camera_override(p_override);
+}
+
+const Tree *EditorDebuggerSession::get_editor_remote_tree() const {
+	ERR_FAIL_NULL_V_MSG(debugger, nullptr, "Plugin is not attached to debugger.");
+	return debugger->get_editor_remote_tree();
+}
+
+void EditorDebuggerSession::update_live_edit_root() {
+	ERR_FAIL_NULL_MSG(debugger, "Plugin is not attached to debugger.");
+	debugger->update_live_edit_root();
 }
 
 void EditorDebuggerSession::detach_debugger() {

--- a/editor/plugins/editor_debugger_plugin.h
+++ b/editor/plugins/editor_debugger_plugin.h
@@ -31,9 +31,8 @@
 #ifndef EDITOR_DEBUGGER_PLUGIN_H
 #define EDITOR_DEBUGGER_PLUGIN_H
 
+#include "editor/debugger/script_editor_debugger.h"
 #include "scene/gui/control.h"
-
-class ScriptEditorDebugger;
 
 class EditorDebuggerSession : public RefCounted {
 	GDCLASS(EditorDebuggerSession, RefCounted);
@@ -63,6 +62,12 @@ public:
 	bool is_active();
 
 	void set_breakpoint(const String &p_path, int p_line, bool p_enabled);
+
+	ScriptEditorDebugger::CameraOverride get_camera_override() const;
+	void set_camera_override(ScriptEditorDebugger::CameraOverride p_override);
+
+	const Tree *get_editor_remote_tree() const;
+	void update_live_edit_root();
 
 	EditorDebuggerSession(ScriptEditorDebugger *p_debugger);
 	~EditorDebuggerSession();

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -31,51 +31,13 @@
 #ifndef GAME_VIEW_PLUGIN_H
 #define GAME_VIEW_PLUGIN_H
 
-#include "editor/debugger/editor_debugger_node.h"
 #include "editor/plugins/editor_debugger_plugin.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/debugger/scene_debugger.h"
 #include "scene/gui/box_container.h"
 
-class GameViewDebugger : public EditorDebuggerPlugin {
-	GDCLASS(GameViewDebugger, EditorDebuggerPlugin);
-
-private:
-	Vector<Ref<EditorDebuggerSession>> sessions;
-
-	int node_type = RuntimeNodeSelect::NODE_TYPE_NONE;
-	bool selection_visible = true;
-	int select_mode = RuntimeNodeSelect::SELECT_MODE_SINGLE;
-	EditorDebuggerNode::CameraOverride camera_override_mode = EditorDebuggerNode::OVERRIDE_INGAME;
-
-	void _session_started(Ref<EditorDebuggerSession> p_session);
-	void _session_stopped();
-
-protected:
-	static void _bind_methods();
-
-public:
-	void set_suspend(bool p_enabled);
-	void next_frame();
-
-	void set_node_type(int p_type);
-	void set_select_mode(int p_mode);
-
-	void set_selection_visible(bool p_visible);
-
-	void set_camera_override(bool p_enabled);
-	void set_camera_manipulate_mode(EditorDebuggerNode::CameraOverride p_mode);
-
-	void reset_camera_2d_position();
-	void reset_camera_3d_position();
-
-	virtual void setup_session(int p_session_id) override;
-
-	GameViewDebugger() {}
-};
-
-class GameView : public VBoxContainer {
-	GDCLASS(GameView, VBoxContainer);
+class GameTab : public VBoxContainer {
+	GDCLASS(GameTab, VBoxContainer);
 
 	enum {
 		CAMERA_RESET_2D,
@@ -84,28 +46,35 @@ class GameView : public VBoxContainer {
 		CAMERA_MODE_EDITORS,
 	};
 
-	Ref<GameViewDebugger> debugger;
+	Ref<EditorDebuggerSession> session;
 
-	int active_sessions = 0;
+	int node_type = RuntimeNodeSelect::NODE_TYPE_NONE;
+	bool selection_visible = true;
+	int select_mode = RuntimeNodeSelect::SELECT_MODE_SINGLE;
+	ScriptEditorDebugger::CameraOverride camera_override_mode = ScriptEditorDebugger::OVERRIDE_INGAME;
 
+	// Toolbar.
 	Button *suspend_button = nullptr;
 	Button *next_frame_button = nullptr;
-
 	Button *node_type_button[RuntimeNodeSelect::NODE_TYPE_MAX];
 	Button *select_mode_button[RuntimeNodeSelect::SELECT_MODE_MAX];
-
 	Button *hide_selection = nullptr;
-
 	Button *camera_override_button = nullptr;
 	MenuButton *camera_override_menu = nullptr;
 
-	Panel *panel = nullptr;
+	// Game input controls.
+	LineEdit *clicked_ctrl = nullptr;
+	LineEdit *clicked_ctrl_type = nullptr;
+	LineEdit *live_edit_root = nullptr;
+	Button *live_edit_set_button = nullptr;
+	Button *live_edit_clear_button = nullptr;
 
 	void _sessions_changed();
 
 	void _update_debugger_buttons();
 
 	void _suspend_button_toggled(bool p_pressed);
+	void _next_frame_button_pressed();
 
 	void _node_type_pressed(int p_option);
 	void _select_mode_pressed(int p_option);
@@ -115,6 +84,12 @@ class GameView : public VBoxContainer {
 	void _camera_override_button_toggled(bool p_pressed);
 	void _camera_override_menu_id_pressed(int p_id);
 
+	void _live_edit_set_button_pressed();
+	void _live_edit_clear_button_pressed();
+
+	void _on_start();
+	void _on_stop();
+
 protected:
 	void _notification(int p_what);
 
@@ -122,6 +97,31 @@ public:
 	void set_state(const Dictionary &p_state);
 	Dictionary get_state() const;
 
+	void on_click_ctrl(const String &p_ctrl, const String &p_ctrl_type);
+
+	GameTab(Ref<EditorDebuggerSession> p_session);
+};
+
+class GameViewDebugger : public EditorDebuggerPlugin {
+	GDCLASS(GameViewDebugger, EditorDebuggerPlugin);
+
+	HashMap<int, GameTab *> tabs;
+
+public:
+	virtual void setup_session(int p_session_id) override;
+	virtual bool capture(const String &p_message, const Array &p_data, int p_session) override;
+	virtual bool has_capture(const String &p_capture) const override;
+
+	void set_state(const Dictionary &p_state);
+	Dictionary get_state() const;
+};
+
+class GameView : public VBoxContainer {
+	GDCLASS(GameView, VBoxContainer);
+
+	Panel *panel = nullptr;
+
+public:
 	GameView(Ref<GameViewDebugger> p_debugger);
 };
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11108

Move the toolbar in Game view to the new Game tab in debugger panel, merging with the Misc tab.

The basic idea is that features such as being able to pick up objects in the game and override the game camera are independent from the Game view. They are debugger features. By moving the toolbar out of the Game view, platforms that do not support window embeding can simply disable the Game screen without affecting the above features.

![screenshot](https://github.com/user-attachments/assets/b877f549-ea79-44d6-860c-ec4830a1ce55)

Also made the toolbar's debugging features per session.

Features in the old Misc tab are moved to other tabs:
- "User clicked control" and "Live edit root" are moved into the Game tab.
- The "Export measures as CSV" button saves data from the "Profiler" tab and the "Monitor" tab. This button is moved into these tabs.
  - Top-right corner of the Profiler tab:
    ![Profiler](https://github.com/user-attachments/assets/72b2e3fa-f1a1-489d-9b65-a3442ce903de)
  - Bottom-left corner of the Monitors tab:
    ![Monitors](https://github.com/user-attachments/assets/358f81dd-9099-4ec6-a2e7-616b428d7c48)

The Game view is now empty. Waiting for the window embeding feature.

If discoverability matters, I think a button to open the Game tab could be added to the Game view.