### PR TITLE
[4.3] Fix animation snapping in seconds mode

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -7052,25 +7052,23 @@ void AnimationTrackEditor::_update_snap_unit() {
 	if (timeline->is_using_fps()) {
 		snap_unit = 1.0 / step->get_value();
 	} else {
-		double integer;
-		double fraction = Math::modf(step->get_value(), &integer);
-		fraction = 1.0 / Math::round(1.0 / fraction);
-		snap_unit = integer + fraction;
+		snap_unit = step->get_value();
 	}
 }
 
 float AnimationTrackEditor::snap_time(float p_value, bool p_relative) {
 	if (is_snap_enabled()) {
+		double current_snap = snap_unit;
 		if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
 			// Use more precise snapping when holding Shift.
-			snap_unit *= 0.25;
+			current_snap *= 0.25;
 		}
 
 		if (p_relative) {
-			double rel = Math::fmod(timeline->get_value(), snap_unit);
-			p_value = Math::snapped(p_value + rel, snap_unit) - rel;
+			double rel = Math::fmod(timeline->get_value(), current_snap);
+			p_value = Math::snapped(p_value + rel, current_snap) - rel;
 		} else {
-			p_value = Math::snapped(p_value, snap_unit);
+			p_value = Math::snapped(p_value, current_snap);
 		}
 	}
 


### PR DESCRIPTION
Closes #98609 for 4.3 branch as TokageItLab suggested to do

Fixes animation snapping rounding to weird values in seconds mode + fixes holding shift not lowering snap value as intended.

