### PR TITLE
Fix `String::is_valid_hex_number`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5150,6 +5150,10 @@ bool String::is_valid_hex_number(bool p_with_prefix) const {
 		from += 2;
 	}
 
+	if (from == len) {
+		return false;
+	}
+
 	for (int i = from; i < len; i++) {
 		char32_t c = operator[](i);
 		if (is_hex_digit(c)) {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Proposal to fix inconsistent Behavior in `is_valid_hex_number(true)` for empty hex strings with value signed prefix.

Fixes: #99057

In the updated code, an additional if statement returns `false` for an empty prefix string, as the loop that follows would incorrectly return `true` in this case.

Comparison: (screenshots from issue MRP):

Old behavior:
![ad2331acf234681c6f9af7346c444f80](https://github.com/user-attachments/assets/cea35f1f-9e75-419b-b554-a249a16ccdaf)

New behavior (now return `false` for empty prefixed input):
![4772611e8d46ba5c5d03f3712fe4ef59](https://github.com/user-attachments/assets/85a3c5e9-ec0d-4ee9-9617-0b85c0823a82)



