### PR TITLE
Fix completion of defines after `#if` statement

### DIFF
--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -1407,6 +1407,10 @@ Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filen
 				ScriptLanguage::CodeCompletionOption option("defined", ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
 				r_completion_options->push_back(option);
 
+				for (const KeyValue<String, Define *> &E : state->defines) {
+					ScriptLanguage::CodeCompletionOption option2(E.key, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
+					r_completion_options->push_back(option2);
+				}
 			} break;
 			case COMPLETION_TYPE_INCLUDE_PATH: {
 				if (p_include_completion_func && r_completion_options) {


### PR DESCRIPTION
Before:

![изображение](https://github.com/user-attachments/assets/097c0ab6-2b28-4485-915d-2eb64db2409a)

After:

![изображение](https://github.com/user-attachments/assets/bb81224d-8e9f-4545-8207-2a26bfe429ef)
