### PR TITLE
Give the barrier pool its own mutex to avoid a deadlock with transfer workers.

### DIFF
--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1285,6 +1285,7 @@ private:
 	LocalVector<uint32_t> transfer_worker_pool_available_list;
 	LocalVector<RDD::TextureBarrier> transfer_worker_pool_texture_barriers;
 	BinaryMutex transfer_worker_pool_mutex;
+	BinaryMutex transfer_worker_pool_texture_barriers_mutex;
 	ConditionVariable transfer_worker_pool_condition;
 
 	TransferWorker *_acquire_transfer_worker(uint32_t p_transfer_size, uint32_t p_required_align, uint32_t &r_staging_offset);
@@ -1299,6 +1300,7 @@ private:
 	void _check_transfer_worker_vertex_array(VertexArray *p_vertex_array);
 	void _check_transfer_worker_index_array(IndexArray *p_index_array);
 	void _submit_transfer_workers(RDD::CommandBufferID p_draw_command_buffer = RDD::CommandBufferID());
+	void _submit_transfer_barriers(RDD::CommandBufferID p_draw_command_buffer);
 	void _wait_for_transfer_workers();
 	void _free_transfer_workers();
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/99043.

Sharing a single mutex for the barriers vector that is used before the start of each frame led into a possible deadlock if during the process of acquiring a transfer worker, there's no available workers due to a low processor count (or an big queue of threaded buffer/texture loading), so an existing worker must be waited on and flushed. This could lead into a deadlock if the frame was also waiting on said worker to finish processing before going ahead with drawing the frame, as the pool mutex was locked.

The fix itself makes sense and should be a pretty safe merge.