### PR TITLE
[Editor] Fix float value used for integer performance monitors

### DIFF
--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -81,6 +81,9 @@ void EditorPerformanceProfiler::Monitor::reset() {
 
 String EditorPerformanceProfiler::_create_label(float p_value, Performance::MonitorType p_type) {
 	switch (p_type) {
+		case Performance::MONITOR_TYPE_QUANTITY: {
+			return TS->format_number(itos(p_value));
+		}
 		case Performance::MONITOR_TYPE_MEMORY: {
 			return String::humanize_size(p_value);
 		}


### PR DESCRIPTION
closes https://github.com/godotengine/godot/issues/99000

Added a check for `MONITOR_TYPE_QUANTITY` and applied formatting using `ustring::itos`

![image](https://github.com/user-attachments/assets/43e7b2c9-d417-441c-b289-70a2271b0aba)

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/99577*