### PR TITLE
Improve graph's detection of intersection between draw lists.

### DIFF
--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -649,7 +649,7 @@ private:
 	static bool _is_write_usage(ResourceUsage p_usage);
 	static RDD::TextureLayout _usage_to_image_layout(ResourceUsage p_usage);
 	static RDD::BarrierAccessBits _usage_to_access_bits(ResourceUsage p_usage);
-	bool _check_command_intersection(ResourceTracker *p_resource_tracker, int32_t p_previous_command_index, int32_t p_command_index) const;
+	bool _check_command_intersection(ResourceTracker *p_resource_tracker, int32_t p_previous_command_index, int32_t p_command_index, bool &r_intersection_partial_coverage) const;
 	int32_t _add_to_command_list(int32_t p_command_index, int32_t p_list_index);
 	void _add_adjacent_command(int32_t p_previous_command_index, int32_t p_command_index, RecordedCommand *r_command);
 	int32_t _add_to_slice_read_list(int32_t p_command_index, Rect2i p_subresources, int32_t p_list_index);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/99040.

Marking it as a draft for now as there's something I wish to investigate as the ordering between the draw passes are still a bit odd: the render pass for the closest PSSM split is not batched together with the rest and performed afterwards due to a dependency in some particular resource. This is not new to this PR however but it'd be nice to fix it anyway.

The main improvement it makes is that the render graph was erroneously clearing the write list in cases where the new draw list doesn't actually cover all the regions the previous commands were writing to. This changes the logic to make it so it'll not opt to do that logic unless full coverage of all the previous draw lists is guaranteed.