### PR TITLE
Fix comparison of callables

### DIFF
--- a/core/variant/callable_bind.cpp
+++ b/core/variant/callable_bind.cpp
@@ -43,7 +43,7 @@ bool CallableCustomBind::_equal_func(const CallableCustom *p_a, const CallableCu
 	const CallableCustomBind *a = static_cast<const CallableCustomBind *>(p_a);
 	const CallableCustomBind *b = static_cast<const CallableCustomBind *>(p_b);
 
-	if (!(a->callable != b->callable)) {
+	if (a->callable != b->callable) {
 		return false;
 	}
 
@@ -185,7 +185,7 @@ bool CallableCustomUnbind::_equal_func(const CallableCustom *p_a, const Callable
 	const CallableCustomUnbind *a = static_cast<const CallableCustomUnbind *>(p_a);
 	const CallableCustomUnbind *b = static_cast<const CallableCustomUnbind *>(p_b);
 
-	if (!(a->callable != b->callable)) {
+	if (a->callable != b->callable) {
 		return false;
 	}
 


### PR DESCRIPTION
There was a mistake in the conditions that made it impossible to compare callables.

Is it worth adding an argument comparison?

```
if (a->binds != b->binds) {
     return false
}
```

because 
```
func foo(): pass

func _ready():
    var a = foo.bind(1)
    var b = foo.bind("a")
    print(a == b) # will be true if we don't compare arguments