### PR TITLE
Add note about LightmapGI only baking nodes under its parent

### DIFF
--- a/doc/classes/LightmapGI.xml
+++ b/doc/classes/LightmapGI.xml
@@ -10,6 +10,7 @@
 		[b]Note:[/b] Due to how lightmaps work, most properties only have a visible effect once lightmaps are baked again.
 		[b]Note:[/b] Lightmap baking on [CSGShape3D]s and [PrimitiveMesh]es is not supported, as these cannot store UV2 data required for baking.
 		[b]Note:[/b] If no custom lightmappers are installed, [LightmapGI] can only be baked from devices that support the Forward+ or Mobile rendering backends.
+		[b]Note:[/b] The [LightmapGI] node only bakes light data for child nodes of its parent. Nodes further up the hierarchy of the scene will not be baked.
 	</description>
 	<tutorials>
 		<link title="Using Lightmap global illumination">$DOCS_URL/tutorials/3d/global_illumination/using_lightmap_gi.html</link>


### PR DESCRIPTION
`LightmapGI`'s documentation currently doesn't mention the fact it only bakes nodes under its parent. 
This can make the user think there is something wrong with their scene setup or 3D models, as it refuses to bake when the user's models / world isn't under the same parent as the `LightmapGI`.

I personally encountered this issue because I tried adding a `LightmapGI` underneath a blank node called "Environment" under which a `WorldEnvironment` was also present, and the `LightmapGI` complained about having nothing to bake.

Made for the [godotengine/godot-docs#9694](https://github.com/godotengine/godot-docs/issues/9694) issue
Linked PR: [godotengine/godot-docs#10247](https://github.com/godotengine/godot-docs/pull/10247)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
