### PR TITLE
Update documentation's "Prints" comments after #47502

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -46,8 +46,8 @@
 				[gdscript]
 				var box = AABB(Vector3(5, 0, 5), Vector3(-20, -10, -5))
 				var absolute = box.abs()
-				print(absolute.position) # Prints (-15, -10, 0)
-				print(absolute.size)     # Prints (20, 10, 5)
+				print(absolute.position) # Prints (-15.0, -10.0, 0.0)
+				print(absolute.size)     # Prints (20.0, 10.0, 5.0)
 				[/gdscript]
 				[csharp]
 				var box = new Aabb(new Vector3(5, 0, 5), new Vector3(-20, -10, -5));
@@ -96,12 +96,12 @@
 				var box = AABB(Vector3(0, 0, 0), Vector3(5, 2, 5))
 
 				box = box.expand(Vector3(10, 0, 0))
-				print(box.position) # Prints (0, 0, 0)
-				print(box.size)     # Prints (10, 2, 5)
+				print(box.position) # Prints (0.0, 0.0, 0.0)
+				print(box.size)     # Prints (10.0, 2.0, 5.0)
 
 				box = box.expand(Vector3(-5, 0, 5))
-				print(box.position) # Prints (-5, 0, 0)
-				print(box.size)     # Prints (15, 2, 5)
+				print(box.position) # Prints (-5.0, 0.0, 0.0)
+				print(box.size)     # Prints (15.0, 2.0, 5.0)
 				[/gdscript]
 				[csharp]
 				var box = new Aabb(new Vector3(0, 0, 0), new Vector3(5, 2, 5));
@@ -138,15 +138,15 @@
 				[gdscript]
 				var box = AABB(Vector3(0, 0, 0), Vector3(2, 4, 8))
 
-				print(box.get_longest_axis())       # Prints (0, 0, 1)
+				print(box.get_longest_axis())       # Prints (0.0, 0.0, 1.0)
 				print(box.get_longest_axis_index()) # Prints 2
-				print(box.get_longest_axis_size())  # Prints 8
+				print(box.get_longest_axis_size())  # Prints 8.0
 				[/gdscript]
 				[csharp]
 				var box = new Aabb(new Vector3(0, 0, 0), new Vector3(2, 4, 8));
 
 				GD.Print(box.GetLongestAxis());      // Prints (0, 0, 1)
-				GD.Print(box.GetLongestAxisIndex()); // Prints 2
+				GD.Print(box.GetLongestAxisIndex()); // Prints Z
 				GD.Print(box.GetLongestAxisSize());  // Prints 8
 				[/csharp]
 				[/codeblocks]
@@ -175,15 +175,15 @@
 				[gdscript]
 				var box = AABB(Vector3(0, 0, 0), Vector3(2, 4, 8))
 
-				print(box.get_shortest_axis())       # Prints (1, 0, 0)
+				print(box.get_shortest_axis())       # Prints (1.0, 0.0, 0.0)
 				print(box.get_shortest_axis_index()) # Prints 0
-				print(box.get_shortest_axis_size())  # Prints 2
+				print(box.get_shortest_axis_size())  # Prints 2.0
 				[/gdscript]
 				[csharp]
 				var box = new Aabb(new Vector3(0, 0, 0), new Vector3(2, 4, 8));
 
 				GD.Print(box.GetShortestAxis());      // Prints (1, 0, 0)
-				GD.Print(box.GetShortestAxisIndex()); // Prints 0
+				GD.Print(box.GetShortestAxisIndex()); // Prints X
 				GD.Print(box.GetShortestAxisSize());  // Prints 2
 				[/csharp]
 				[/codeblocks]
@@ -225,12 +225,12 @@
 				[codeblocks]
 				[gdscript]
 				var a = AABB(Vector3(4, 4, 4), Vector3(8, 8, 8)).grow(4)
-				print(a.position) # Prints (0, 0, 0)
-				print(a.size)     # Prints (16, 16, 16)
+				print(a.position) # Prints (0.0, 0.0, 0.0)
+				print(a.size)     # Prints (16.0, 16.0, 16.0)
 
 				var b = AABB(Vector3(0, 0, 0), Vector3(8, 4, 2)).grow(2)
-				print(b.position) # Prints (-2, -2, -2)
-				print(b.size)     # Prints (12, 8, 6)
+				print(b.position) # Prints (-2.0, -2.0, -2.0)
+				print(b.size)     # Prints (12.0, 8.0, 6.0)
 				[/gdscript]
 				[csharp]
 				var a = new Aabb(new Vector3(4, 4, 4), new Vector3(8, 8, 8)).Grow(4);
@@ -275,8 +275,8 @@
 				var box2 = AABB(Vector3(2, 0, 2), Vector3(8, 4, 4))
 
 				var intersection = box1.intersection(box2)
-				print(intersection.position) # Prints (2, 0, 2)
-				print(intersection.size)     # Prints (3, 2, 4)
+				print(intersection.position) # Prints (2.0, 0.0, 2.0)
+				print(intersection.size)     # Prints (3.0, 2.0, 4.0)
 				[/gdscript]
 				[csharp]
 				var box1 = new Aabb(new Vector3(0, 0, 0), new Vector3(5, 2, 8));

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -12,8 +12,8 @@
 		astar_grid.region = Rect2i(0, 0, 32, 32)
 		astar_grid.cell_size = Vector2(16, 16)
 		astar_grid.update()
-		print(astar_grid.get_id_path(Vector2i(0, 0), Vector2i(3, 4))) # prints (0, 0), (1, 1), (2, 2), (3, 3), (3, 4)
-		print(astar_grid.get_point_path(Vector2i(0, 0), Vector2i(3, 4))) # prints (0, 0), (16, 16), (32, 32), (48, 48), (48, 64)
+		print(astar_grid.get_id_path(Vector2i(0, 0), Vector2i(3, 4))) # Prints [(0, 0), (1, 1), (2, 2), (3, 3), (3, 4)]
+		print(astar_grid.get_point_path(Vector2i(0, 0), Vector2i(3, 4))) # Prints [(0, 0), (16, 16), (32, 32), (48, 48), (48, 64)]
 		[/gdscript]
 		[csharp]
 		AStarGrid2D astarGrid = new AStarGrid2D();

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -91,7 +91,7 @@
 				# Creates a Basis whose z axis points down.
 				var my_basis = Basis.from_euler(Vector3(TAU / 4, 0, 0))
 
-				print(my_basis.z) # Prints (0, -1, 0)
+				print(my_basis.z) # Prints (0.0, -1.0, 0.0)
 				[/gdscript]
 				[csharp]
 				// Creates a Basis whose z axis points down.
@@ -112,9 +112,9 @@
 				[gdscript]
 				var my_basis = Basis.from_scale(Vector3(2, 4, 8))
 
-				print(my_basis.x) # Prints (2, 0, 0)
-				print(my_basis.y) # Prints (0, 4, 0)
-				print(my_basis.z) # Prints (0, 0, 8)
+				print(my_basis.x) # Prints (2.0, 0.0, 0.0)
+				print(my_basis.y) # Prints (0.0, 4.0, 0.0)
+				print(my_basis.z) # Prints (0.0, 0.0, 8.0)
 				[/gdscript]
 				[csharp]
 				var myBasis = Basis.FromScale(new Vector3(2.0f, 4.0f, 8.0f));
@@ -163,7 +163,7 @@
 				my_basis = my_basis.rotated(Vector3.UP, TAU / 2)
 				my_basis = my_basis.rotated(Vector3.RIGHT, TAU / 4)
 
-				print(my_basis.get_scale()) # Prints (2, 4, 8)
+				print(my_basis.get_scale()) # Prints (2.0, 4.0, 8.0)
 				[/gdscript]
 				[csharp]
 				var myBasis = new Basis(
@@ -285,9 +285,9 @@
 				)
 				my_basis = my_basis.scaled(Vector3(0, 2, -2))
 
-				print(my_basis.x) # Prints (0, 2, -2)
-				print(my_basis.y) # Prints (0, 4, -4)
-				print(my_basis.z) # Prints (0, 6, -6)
+				print(my_basis.x) # Prints (0.0, 2.0, -2.0)
+				print(my_basis.y) # Prints (0.0, 4.0, -4.0)
+				print(my_basis.z) # Prints (0.0, 6.0, -6.0)
 				[/gdscript]
 				[csharp]
 				var myBasis = new Basis(
@@ -360,9 +360,9 @@
 				)
 				my_basis = my_basis.transposed()
 
-				print(my_basis.x) # Prints (1, 4, 7)
-				print(my_basis.y) # Prints (2, 5, 8)
-				print(my_basis.z) # Prints (3, 6, 9)
+				print(my_basis.x) # Prints (1.0, 4.0, 7.0)
+				print(my_basis.y) # Prints (2.0, 5.0, 8.0)
+				print(my_basis.z) # Prints (3.0, 6.0, 9.0)
 				[/gdscript]
 				[csharp]
 				var myBasis = new Basis(
@@ -454,7 +454,7 @@
 				[gdscript]
 				# Basis that swaps the X/Z axes and doubles the scale.
 				var my_basis = Basis(Vector3(0, 2, 0), Vector3(2, 0, 0), Vector3(0, 0, 2))
-				print(my_basis * Vector3(1, 2, 3)) # Prints (4, 2, 6)
+				print(my_basis * Vector3(1, 2, 3)) # Prints (4.0, 2.0, 6.0)
 				[/gdscript]
 				[csharp]
 				// Basis that swaps the X/Z axes and doubles the scale.

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -13,7 +13,7 @@
 		func test():
 		    var callable = Callable(self, "print_args")
 		    callable.call("hello", "world")  # Prints "hello world ".
-		    callable.call(Vector2.UP, 42, callable)  # Prints "(0, -1) 42 Node(node.gd)::print_args".
+		    callable.call(Vector2.UP, 42, callable)  # Prints "(0.0, -1.0) 42 Node(node.gd)::print_args".
 		    callable.call("invalid")  # Invalid call, should have at least 2 arguments.
 		[/gdscript]
 		[csharp]

--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -201,13 +201,13 @@
 				var polygon = PackedVector2Array([Vector2(0, 0), Vector2(100, 0), Vector2(100, 100), Vector2(0, 100)])
 				var offset = Vector2(50, 50)
 				polygon = Transform2D(0, offset) * polygon
-				print(polygon) # prints [(50, 50), (150, 50), (150, 150), (50, 150)]
+				print(polygon) # Prints [(50.0, 50.0), (150.0, 50.0), (150.0, 150.0), (50.0, 150.0)]
 				[/gdscript]
 				[csharp]
 				var polygon = new Vector2[] { new Vector2(0, 0), new Vector2(100, 0), new Vector2(100, 100), new Vector2(0, 100) };
 				var offset = new Vector2(50, 50);
 				polygon = new Transform2D(0, offset) * polygon;
-				GD.Print((Variant)polygon); // prints [(50, 50), (150, 50), (150, 150), (50, 150)]
+				GD.Print((Variant)polygon); // Prints [(50, 50), (150, 50), (150, 150), (50, 150)]
 				[/csharp]
 				[/codeblocks]
 			</description>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -987,12 +987,12 @@
 				[gdscript]
 				var node = Node2D.new()
 				node.set("global_scale", Vector2(8, 2.5))
-				print(node.global_scale) # Prints (8, 2.5)
+				print(node.global_scale) # Prints (8.0, 2.5)
 				[/gdscript]
 				[csharp]
 				var node = new Node2D();
-				node.Set(Node2D.PropertyName.GlobalScale, new Vector2(8, 2.5));
-				GD.Print(node.GlobalScale); // Prints Vector2(8, 2.5)
+				node.Set(Node2D.PropertyName.GlobalScale, new Vector2(8, 2.5f));
+				GD.Print(node.GlobalScale); // Prints (8, 2.5)
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] In C#, [param property] must be in snake_case when referring to built-in Godot properties. Prefer using the names exposed in the [code]PropertyName[/code] class to avoid allocating a new [StringName] on each call.
@@ -1047,7 +1047,7 @@
 				var node = Node2D.new()
 				node.set_indexed("position", Vector2(42, 0))
 				node.set_indexed("position:y", -10)
-				print(node.position) # Prints (42, -10)
+				print(node.position) # Prints (42.0, -10.0)
 				[/gdscript]
 				[csharp]
 				var node = new Node2D();

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -116,7 +116,7 @@
 				# Rotating the Transform2D in any way preserves its scale.
 				my_transform = my_transform.rotated(TAU / 2)
 
-				print(my_transform.get_scale()) # Prints (2, 4)
+				print(my_transform.get_scale()) # Prints (2.0, 4.0)
 				[/gdscript]
 				[csharp]
 				var myTransform = new Transform2D(

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -213,9 +213,9 @@
 			<description>
 				Creates a unit [Vector2] rotated to the given [param angle] in radians. This is equivalent to doing [code]Vector2(cos(angle), sin(angle))[/code] or [code]Vector2.RIGHT.rotated(angle)[/code].
 				[codeblock]
-				print(Vector2.from_angle(0)) # Prints (1, 0).
-				print(Vector2(1, 0).angle()) # Prints 0, which is the angle used above.
-				print(Vector2.from_angle(PI / 2)) # Prints (0, 1).
+				print(Vector2.from_angle(0)) # Prints (1.0, 0.0).
+				print(Vector2(1, 0).angle()) # Prints 0.0, which is the angle used above.
+				print(Vector2.from_angle(PI / 2)) # Prints (0.0, 1.0).
 				[/codeblock]
 			</description>
 		</method>
@@ -477,7 +477,7 @@
 			<description>
 				Multiplies each component of the [Vector2] by the components of the given [Vector2].
 				[codeblock]
-				print(Vector2(10, 20) * Vector2(3, 4)) # Prints "(30, 80)"
+				print(Vector2(10, 20) * Vector2(3, 4)) # Prints (30.0, 80.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -501,7 +501,7 @@
 			<description>
 				Adds each component of the [Vector2] by the components of the given [Vector2].
 				[codeblock]
-				print(Vector2(10, 20) + Vector2(3, 4)) # Prints "(13, 24)"
+				print(Vector2(10, 20) + Vector2(3, 4)) # Prints (13.0, 24.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -511,7 +511,7 @@
 			<description>
 				Subtracts each component of the [Vector2] by the components of the given [Vector2].
 				[codeblock]
-				print(Vector2(10, 20) - Vector2(3, 4)) # Prints "(7, 16)"
+				print(Vector2(10, 20) - Vector2(3, 4)) # Prints (7.0, 16.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -521,7 +521,7 @@
 			<description>
 				Divides each component of the [Vector2] by the components of the given [Vector2].
 				[codeblock]
-				print(Vector2(10, 20) / Vector2(2, 5)) # Prints "(5, 4)"
+				print(Vector2(10, 20) / Vector2(2, 5)) # Prints (5.0, 4.0)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -215,7 +215,7 @@
 			<description>
 				Gets the remainder of each component of the [Vector2i] with the components of the given [Vector2i]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
-				print(Vector2i(10, -20) % Vector2i(7, 8)) # Prints "(3, -4)"
+				print(Vector2i(10, -20) % Vector2i(7, 8)) # Prints (3, -4)
 				[/codeblock]
 			</description>
 		</operator>
@@ -225,7 +225,7 @@
 			<description>
 				Gets the remainder of each component of the [Vector2i] with the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
-				print(Vector2i(10, -20) % 7) # Prints "(3, -6)"
+				print(Vector2i(10, -20) % 7) # Prints (3, -6)
 				[/codeblock]
 			</description>
 		</operator>
@@ -235,7 +235,7 @@
 			<description>
 				Multiplies each component of the [Vector2i] by the components of the given [Vector2i].
 				[codeblock]
-				print(Vector2i(10, 20) * Vector2i(3, 4)) # Prints "(30, 80)"
+				print(Vector2i(10, 20) * Vector2i(3, 4)) # Prints (30, 80)
 				[/codeblock]
 			</description>
 		</operator>
@@ -245,7 +245,7 @@
 			<description>
 				Multiplies each component of the [Vector2i] by the given [float]. Returns a [Vector2].
 				[codeblock]
-				print(Vector2i(10, 15) * 0.9) # Prints "(9, 13.5)"
+				print(Vector2i(10, 15) * 0.9) # Prints (9.0, 13.5)
 				[/codeblock]
 			</description>
 		</operator>
@@ -262,7 +262,7 @@
 			<description>
 				Adds each component of the [Vector2i] by the components of the given [Vector2i].
 				[codeblock]
-				print(Vector2i(10, 20) + Vector2i(3, 4)) # Prints "(13, 24)"
+				print(Vector2i(10, 20) + Vector2i(3, 4)) # Prints (13, 24)
 				[/codeblock]
 			</description>
 		</operator>
@@ -272,7 +272,7 @@
 			<description>
 				Subtracts each component of the [Vector2i] by the components of the given [Vector2i].
 				[codeblock]
-				print(Vector2i(10, 20) - Vector2i(3, 4)) # Prints "(7, 16)"
+				print(Vector2i(10, 20) - Vector2i(3, 4)) # Prints (7, 16)
 				[/codeblock]
 			</description>
 		</operator>
@@ -282,7 +282,7 @@
 			<description>
 				Divides each component of the [Vector2i] by the components of the given [Vector2i].
 				[codeblock]
-				print(Vector2i(10, 20) / Vector2i(2, 5)) # Prints "(5, 4)"
+				print(Vector2i(10, 20) / Vector2i(2, 5)) # Prints (5, 4)
 				[/codeblock]
 			</description>
 		</operator>
@@ -292,7 +292,7 @@
 			<description>
 				Divides each component of the [Vector2i] by the given [float]. Returns a [Vector2].
 				[codeblock]
-				print(Vector2i(10, 20) / 2.9) # Prints "(5, 10)"
+				print(Vector2i(10, 20) / 2.9) # Prints (5.0, 10.0)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -518,7 +518,7 @@
 			<description>
 				Multiplies each component of the [Vector3] by the components of the given [Vector3].
 				[codeblock]
-				print(Vector3(10, 20, 30) * Vector3(3, 4, 5)) # Prints "(30, 80, 150)"
+				print(Vector3(10, 20, 30) * Vector3(3, 4, 5)) # Prints (30.0, 80.0, 150.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -542,7 +542,7 @@
 			<description>
 				Adds each component of the [Vector3] by the components of the given [Vector3].
 				[codeblock]
-				print(Vector3(10, 20, 30) + Vector3(3, 4, 5)) # Prints "(13, 24, 35)"
+				print(Vector3(10, 20, 30) + Vector3(3, 4, 5)) # Prints (13.0, 24.0, 35.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -552,7 +552,7 @@
 			<description>
 				Subtracts each component of the [Vector3] by the components of the given [Vector3].
 				[codeblock]
-				print(Vector3(10, 20, 30) - Vector3(3, 4, 5)) # Prints "(7, 16, 25)"
+				print(Vector3(10, 20, 30) - Vector3(3, 4, 5)) # Prints (7.0, 16.0, 25.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -562,7 +562,7 @@
 			<description>
 				Divides each component of the [Vector3] by the components of the given [Vector3].
 				[codeblock]
-				print(Vector3(10, 20, 30) / Vector3(2, 5, 3)) # Prints "(5, 4, 10)"
+				print(Vector3(10, 20, 30) / Vector3(2, 5, 3)) # Prints (5.0, 4.0, 10.0)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -222,7 +222,7 @@
 			<description>
 				Gets the remainder of each component of the [Vector3i] with the components of the given [Vector3i]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
-				print(Vector3i(10, -20, 30) % Vector3i(7, 8, 9)) # Prints "(3, -4, 3)"
+				print(Vector3i(10, -20, 30) % Vector3i(7, 8, 9)) # Prints (3, -4, 3)
 				[/codeblock]
 			</description>
 		</operator>
@@ -232,7 +232,7 @@
 			<description>
 				Gets the remainder of each component of the [Vector3i] with the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
-				print(Vector3i(10, -20, 30) % 7) # Prints "(3, -6, 2)"
+				print(Vector3i(10, -20, 30) % 7) # Prints (3, -6, 2)
 				[/codeblock]
 			</description>
 		</operator>
@@ -242,7 +242,7 @@
 			<description>
 				Multiplies each component of the [Vector3i] by the components of the given [Vector3i].
 				[codeblock]
-				print(Vector3i(10, 20, 30) * Vector3i(3, 4, 5)) # Prints "(30, 80, 150)"
+				print(Vector3i(10, 20, 30) * Vector3i(3, 4, 5)) # Prints (30, 80, 150)
 				[/codeblock]
 			</description>
 		</operator>
@@ -252,7 +252,7 @@
 			<description>
 				Multiplies each component of the [Vector3i] by the given [float]. Returns a [Vector3].
 				[codeblock]
-				print(Vector3i(10, 15, 20) * 0.9) # Prints "(9, 13.5, 18)"
+				print(Vector3i(10, 15, 20) * 0.9) # Prints (9.0, 13.5, 18.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -269,7 +269,7 @@
 			<description>
 				Adds each component of the [Vector3i] by the components of the given [Vector3i].
 				[codeblock]
-				print(Vector3i(10, 20, 30) + Vector3i(3, 4, 5)) # Prints "(13, 24, 35)"
+				print(Vector3i(10, 20, 30) + Vector3i(3, 4, 5)) # Prints (13, 24, 35)
 				[/codeblock]
 			</description>
 		</operator>
@@ -279,7 +279,7 @@
 			<description>
 				Subtracts each component of the [Vector3i] by the components of the given [Vector3i].
 				[codeblock]
-				print(Vector3i(10, 20, 30) - Vector3i(3, 4, 5)) # Prints "(7, 16, 25)"
+				print(Vector3i(10, 20, 30) - Vector3i(3, 4, 5)) # Prints (7, 16, 25)
 				[/codeblock]
 			</description>
 		</operator>
@@ -289,7 +289,7 @@
 			<description>
 				Divides each component of the [Vector3i] by the components of the given [Vector3i].
 				[codeblock]
-				print(Vector3i(10, 20, 30) / Vector3i(2, 5, 3)) # Prints "(5, 4, 10)"
+				print(Vector3i(10, 20, 30) / Vector3i(2, 5, 3)) # Prints (5, 4, 10)
 				[/codeblock]
 			</description>
 		</operator>
@@ -299,7 +299,7 @@
 			<description>
 				Divides each component of the [Vector3i] by the given [float]. Returns a [Vector3].
 				[codeblock]
-				print(Vector3i(10, 20, 30) / 2.9) # Prints "(5, 10, 15)"
+				print(Vector3i(10, 20, 30) / 2.9) # Prints (5.0, 10.0, 15.0)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -333,7 +333,7 @@
 			<description>
 				Multiplies each component of the [Vector4] by the components of the given [Vector4].
 				[codeblock]
-				print(Vector4(10, 20, 30, 40) * Vector4(3, 4, 5, 6)) # Prints "(30, 80, 150, 240)"
+				print(Vector4(10, 20, 30, 40) * Vector4(3, 4, 5, 6)) # Prints (30.0, 80.0, 150.0, 240.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -343,7 +343,7 @@
 			<description>
 				Multiplies each component of the [Vector4] by the given [float].
 				[codeblock]
-				print(Vector4(10, 20, 30, 40) * 2) # Prints "(20, 40, 60, 80)"
+				print(Vector4(10, 20, 30, 40) * 2) # Prints (20.0, 40.0, 60.0, 80.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -360,7 +360,7 @@
 			<description>
 				Adds each component of the [Vector4] by the components of the given [Vector4].
 				[codeblock]
-				print(Vector4(10, 20, 30, 40) + Vector4(3, 4, 5, 6)) # Prints "(13, 24, 35, 46)"
+				print(Vector4(10, 20, 30, 40) + Vector4(3, 4, 5, 6)) # Prints (13.0, 24.0, 35.0, 46.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -370,7 +370,7 @@
 			<description>
 				Subtracts each component of the [Vector4] by the components of the given [Vector4].
 				[codeblock]
-				print(Vector4(10, 20, 30, 40) - Vector4(3, 4, 5, 6)) # Prints "(7, 16, 25, 34)"
+				print(Vector4(10, 20, 30, 40) - Vector4(3, 4, 5, 6)) # Prints (7.0, 16.0, 25.0, 34.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -380,7 +380,7 @@
 			<description>
 				Divides each component of the [Vector4] by the components of the given [Vector4].
 				[codeblock]
-				print(Vector4(10, 20, 30, 40) / Vector4(2, 5, 3, 4)) # Prints "(5, 4, 10, 10)"
+				print(Vector4(10, 20, 30, 40) / Vector4(2, 5, 3, 4)) # Prints (5.0, 4.0, 10.0, 10.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -390,7 +390,7 @@
 			<description>
 				Divides each component of the [Vector4] by the given [float].
 				[codeblock]
-				print(Vector4(10, 20, 30, 40) / 2 # Prints "(5, 10, 15, 20)"
+				print(Vector4(10, 20, 30, 40) / 2 # Prints (5.0, 10.0, 15.0, 20.0)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -208,7 +208,7 @@
 			<description>
 				Gets the remainder of each component of the [Vector4i] with the components of the given [Vector4i]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
-				print(Vector4i(10, -20, 30, -40) % Vector4i(7, 8, 9, 10))  # Prints "(3, -4, 3, 0)"
+				print(Vector4i(10, -20, 30, -40) % Vector4i(7, 8, 9, 10))  # Prints (3, -4, 3, 0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -218,7 +218,7 @@
 			<description>
 				Gets the remainder of each component of the [Vector4i] with the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
-				print(Vector4i(10, -20, 30, -40) % 7)  # Prints "(3, -6, 2, -5)"
+				print(Vector4i(10, -20, 30, -40) % 7)  # Prints (3, -6, 2, -5)
 				[/codeblock]
 			</description>
 		</operator>
@@ -228,7 +228,7 @@
 			<description>
 				Multiplies each component of the [Vector4i] by the components of the given [Vector4i].
 				[codeblock]
-				print(Vector4i(10, 20, 30, 40) * Vector4i(3, 4, 5, 6)) # Prints "(30, 80, 150, 240)"
+				print(Vector4i(10, 20, 30, 40) * Vector4i(3, 4, 5, 6)) # Prints (30, 80, 150, 240)
 				[/codeblock]
 			</description>
 		</operator>
@@ -239,7 +239,7 @@
 				Multiplies each component of the [Vector4i] by the given [float].
 				Returns a Vector4 value due to floating-point operations.
 				[codeblock]
-				print(Vector4i(10, 20, 30, 40) * 2) # Prints "(20, 40, 60, 80)"
+				print(Vector4i(10, 20, 30, 40) * 2) # Prints (20.0, 40.0, 60.0, 80.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -256,7 +256,7 @@
 			<description>
 				Adds each component of the [Vector4i] by the components of the given [Vector4i].
 				[codeblock]
-				print(Vector4i(10, 20, 30, 40) + Vector4i(3, 4, 5, 6)) # Prints "(13, 24, 35, 46)"
+				print(Vector4i(10, 20, 30, 40) + Vector4i(3, 4, 5, 6)) # Prints (13, 24, 35, 46)
 				[/codeblock]
 			</description>
 		</operator>
@@ -266,7 +266,7 @@
 			<description>
 				Subtracts each component of the [Vector4i] by the components of the given [Vector4i].
 				[codeblock]
-				print(Vector4i(10, 20, 30, 40) - Vector4i(3, 4, 5, 6)) # Prints "(7, 16, 25, 34)"
+				print(Vector4i(10, 20, 30, 40) - Vector4i(3, 4, 5, 6)) # Prints (7, 16, 25, 34)
 				[/codeblock]
 			</description>
 		</operator>
@@ -276,7 +276,7 @@
 			<description>
 				Divides each component of the [Vector4i] by the components of the given [Vector4i].
 				[codeblock]
-				print(Vector4i(10, 20, 30, 40) / Vector4i(2, 5, 3, 4)) # Prints "(5, 4, 10, 10)"
+				print(Vector4i(10, 20, 30, 40) / Vector4i(2, 5, 3, 4)) # Prints (5, 4, 10, 10)
 				[/codeblock]
 			</description>
 		</operator>
@@ -287,7 +287,7 @@
 				Divides each component of the [Vector4i] by the given [float].
 				Returns a Vector4 value due to floating-point operations.
 				[codeblock]
-				print(Vector4i(10, 20, 30, 40) / 2 # Prints "(5, 10, 15, 20)"
+				print(Vector4i(10, 20, 30, 40) / 2 # Prints (5.0, 10.0, 15.0, 20.0)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -97,7 +97,7 @@
 			<description>
 				Multiplies each component of the [Vector2i] by the given [float]. Returns a [Vector2].
 				[codeblock]
-				print(0.9 * Vector2i(10, 15)) # Prints "(9, 13.5)"
+				print(0.9 * Vector2i(10, 15)) # Prints (9.0, 13.5)
 				[/codeblock]
 			</description>
 		</operator>
@@ -114,7 +114,7 @@
 			<description>
 				Multiplies each component of the [Vector3i] by the given [float]. Returns a [Vector3].
 				[codeblock]
-				print(0.9 * Vector3i(10, 15, 20)) # Prints "(9, 13.5, 18)"
+				print(0.9 * Vector3i(10, 15, 20)) # Prints (9.0, 13.5, 18.0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -131,7 +131,7 @@
 			<description>
 				Multiplies each component of the [Vector4i] by the given [float]. Returns a [Vector4].
 				[codeblock]
-				print(0.9 * Vector4i(10, 15, 20, -10)) # Prints "(9, 13.5, 18, -9)"
+				print(0.9 * Vector4i(10, 15, 20, -10)) # Prints (9.0, 13.5, 18.0, -9.0)
 				[/codeblock]
 			</description>
 		</operator>


### PR DESCRIPTION
See:
- #47502

To make it brief, `print(a) # Prints {value}` is a very common way in the class reference to represent a result. What follows it needs to be _precisely_ what is printed in the console. This is not always the case, but it's a pretty consistent rule. 

For transparency, my own notes on these kinds of comments is as follows:
> - `# Prints {value}`: After a `print` call. (or similar).
> Suitable for beginner topics, where you want the user to see the result upon copying and pasting the code sample. `{value}` should be formatted **exactly** how it would be printed to the console. No periods, no quotes.

However, since #47502, whole floating-point numbers are always converted and printed with the trailing `.0`, making many of these comments inaccurate. 

Although this is technically an error, this PR is worth debating about, as it actually makes readability **worse** in a vast majority of cases.
Either these comments are mostly fine as they are, we make a special exception just for Vectors, or we go ahead and always favour pure accuracy to not confuse the user.

