### PR TITLE
Style: Incorporate `pyupgrade` ruleset

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -173,7 +173,7 @@ env["x86_libtheora_opt_gcc"] = False
 env["x86_libtheora_opt_vc"] = False
 
 # avoid issues when building with different versions of python out of the same directory
-env.SConsignFile(File("#.sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL)).abspath)
+env.SConsignFile(File(f"#.sconsign{pickle.HIGHEST_PROTOCOL}.dblite").abspath)
 
 # Build options
 
@@ -190,9 +190,9 @@ opts = Variables(customs, ARGUMENTS)
 
 # Target build options
 if env.scons_version >= (4, 3):
-    opts.Add(["platform", "p"], "Target platform (%s)" % "|".join(platform_list), "")
+    opts.Add(["platform", "p"], "Target platform ({})".format("|".join(platform_list)), "")
 else:
-    opts.Add("platform", "Target platform (%s)" % "|".join(platform_list), "")
+    opts.Add("platform", "Target platform ({})".format("|".join(platform_list)), "")
     opts.Add("p", "Alias for 'platform'", "")
 opts.Add(EnumVariable("target", "Compilation target", "editor", ("editor", "template_release", "template_debug")))
 opts.Add(EnumVariable("arch", "CPU architecture", "auto", ["auto"] + architectures, architecture_aliases))
@@ -444,7 +444,7 @@ for name, path in modules_detected.items():
     else:
         enabled = False
 
-    opts.Add(BoolVariable("module_" + name + "_enabled", "Enable module '%s'" % (name,), enabled))
+    opts.Add(BoolVariable("module_" + name + "_enabled", f"Enable module '{name}'", enabled))
 
     # Add module-specific options.
     try:
@@ -588,7 +588,7 @@ if env["build_profile"] != "":
     import json
 
     try:
-        ft = json.load(open(env["build_profile"], "r", encoding="utf-8"))
+        ft = json.load(open(env["build_profile"], encoding="utf-8"))
         if "disabled_classes" in ft:
             env.disabled_classes = ft["disabled_classes"]
         if "disabled_build_options" in ft:
@@ -1062,9 +1062,7 @@ if env["vsproj"]:
 if env["compiledb"]:
     if env.scons_version < (4, 0, 0):
         # Generating the compilation DB (`compile_commands.json`) requires SCons 4.0.0 or later.
-        print_error(
-            "The `compiledb=yes` option requires SCons 4.0 or later, but your version is %s." % scons_raw_version
-        )
+        print_error(f"The `compiledb=yes` option requires SCons 4.0 or later, but your version is {scons_raw_version}.")
         Exit(255)
 
     env.Tool("compilation_db")
@@ -1072,7 +1070,7 @@ if env["compiledb"]:
 
 if env["ninja"]:
     if env.scons_version < (4, 2, 0):
-        print_error("The `ninja=yes` option requires SCons 4.2 or later, but your version is %s." % scons_raw_version)
+        print_error(f"The `ninja=yes` option requires SCons 4.2 or later, but your version is {scons_raw_version}.")
         Exit(255)
 
     SetOption("experimental", "ninja")

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -8,8 +8,8 @@ def escape_string(s):
         rev_result = []
         while c >= 256:
             c, low = (c // 256, c % 256)
-            rev_result.append("\\%03o" % low)
-        rev_result.append("\\%03o" % c)
+            rev_result.append(f"\\{low:03o}")
+        rev_result.append(f"\\{c:03o}")
         return "".join(reversed(rev_result))
 
     result = ""
@@ -40,7 +40,7 @@ def make_certs_header(target, source, env):
 
         # System certs path. Editor will use them if defined. (for package maintainers)
         path = env["system_certs_path"]
-        g.write('#define _SYSTEM_CERTS_PATH "%s"\n' % str(path))
+        g.write(f'#define _SYSTEM_CERTS_PATH "{path}"\n')
         if env["builtin_certs"]:
             # Defined here and not in env so changing it does not trigger a full rebuild.
             g.write("#define BUILTIN_CERTS_ENABLED\n")
@@ -69,7 +69,7 @@ def make_authors_header(target, source, env):
 
     src = str(source[0])
     dst = str(target[0])
-    with open(src, "r", encoding="utf-8") as f, open(dst, "w", encoding="utf-8", newline="\n") as g:
+    with open(src, encoding="utf-8") as f, open(dst, "w", encoding="utf-8", newline="\n") as g:
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef AUTHORS_GEN_H\n")
         g.write("#define AUTHORS_GEN_H\n")
@@ -126,7 +126,7 @@ def make_donors_header(target, source, env):
 
     src = str(source[0])
     dst = str(target[0])
-    with open(src, "r", encoding="utf-8") as f, open(dst, "w", encoding="utf-8", newline="\n") as g:
+    with open(src, encoding="utf-8") as f, open(dst, "w", encoding="utf-8", newline="\n") as g:
         g.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         g.write("#ifndef DONORS_GEN_H\n")
         g.write("#define DONORS_GEN_H\n")
@@ -193,7 +193,7 @@ def make_license_header(target, source, env):
     projects: dict = OrderedDict()
     license_list = []
 
-    with open(src_copyright, "r", encoding="utf-8") as copyright_file:
+    with open(src_copyright, encoding="utf-8") as copyright_file:
         reader = LicenseReader(copyright_file)
         part = {}
         while reader.current:
@@ -226,7 +226,7 @@ def make_license_header(target, source, env):
         f.write("#define LICENSE_GEN_H\n")
         f.write("const char *const GODOT_LICENSE_TEXT =")
 
-        with open(src_license, "r", encoding="utf-8") as license_file:
+        with open(src_license, encoding="utf-8") as license_file:
             for line in license_file:
                 escaped_string = escape_string(line.strip())
                 f.write('\n\t\t"' + escaped_string + '\\n"')

--- a/core/input/input_builders.py
+++ b/core/input/input_builders.py
@@ -13,7 +13,7 @@ def make_default_controller_mappings(target, source, env):
         # ensure mappings have a consistent order
         platform_mappings: dict = OrderedDict()
         for src_path in source:
-            with open(str(src_path), "r", encoding="utf-8") as f:
+            with open(str(src_path), encoding="utf-8") as f:
                 # read mapping file and skip header
                 mapping_file_lines = f.readlines()[2:]
 
@@ -33,9 +33,7 @@ def make_default_controller_mappings(target, source, env):
                     guid = line_parts[0]
                     if guid in platform_mappings[current_platform]:
                         g.write(
-                            "// WARNING: DATABASE {} OVERWROTE PRIOR MAPPING: {} {}\n".format(
-                                src_path, current_platform, platform_mappings[current_platform][guid]
-                            )
+                            f"// WARNING: DATABASE {src_path} OVERWROTE PRIOR MAPPING: {current_platform} {platform_mappings[current_platform][guid]}\n"
                         )
                     platform_mappings[current_platform][guid] = line
 
@@ -51,9 +49,9 @@ def make_default_controller_mappings(target, source, env):
         g.write("const char* DefaultControllerMappings::mappings[] = {\n")
         for platform, mappings in platform_mappings.items():
             variable = platform_variables[platform]
-            g.write("{}\n".format(variable))
+            g.write(f"{variable}\n")
             for mapping in mappings.values():
-                g.write('\t"{}",\n'.format(mapping))
+                g.write(f'\t"{mapping}",\n')
             g.write("#endif\n")
 
         g.write("\tnullptr\n};\n")

--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -255,7 +255,7 @@ class ClassStatus:
                 output["comment"] = color("part_good", "ALL OK")
         else:
             output["url"] = color(
-                "url", "https://docs.godotengine.org/en/latest/classes/class_{name}.html".format(name=self.name.lower())
+                "url", f"https://docs.godotengine.org/en/latest/classes/class_{self.name.lower()}.html"
             )
 
             if flags["s"] and not flags["g"] and self.is_ok():
@@ -450,7 +450,7 @@ if len(table) == 1 and flags["a"]:
     sys.exit(0)
 
 if len(table) > 2 or not flags["a"]:
-    total_status.name = "Total = {0}".format(len(table) - 1)
+    total_status.name = f"Total = {len(table) - 1}"
     out = total_status.make_output()
     row = []
     for column in table_columns:

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -393,7 +393,7 @@ class State:
 
                 theme_item_name = theme_item.attrib["name"]
                 theme_item_data_name = theme_item.attrib["data_type"]
-                theme_item_id = "{}_{}".format(theme_item_data_name, theme_item_name)
+                theme_item_id = f"{theme_item_data_name}_{theme_item_name}"
                 if theme_item_id in class_def.theme_items:
                     print_error(
                         f'{class_name}.xml: Duplicate theme property "{theme_item_name}" of type "{theme_item_data_name}".',
@@ -727,9 +727,7 @@ def main() -> None:
 
     # Retrieve heading translations for the given language.
     if not args.dry_run and args.lang != "en":
-        lang_file = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "..", "translations", "{}.po".format(args.lang)
-        )
+        lang_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "translations", f"{args.lang}.po")
         if os.path.exists(lang_file):
             try:
                 import polib  # type: ignore
@@ -2167,7 +2165,7 @@ def format_text_block(
 
                         # Default to the tag command name. This works by default for most tags,
                         # but method, member, and theme_item have special cases.
-                        ref_type = "_{}".format(tag_state.name)
+                        ref_type = f"_{tag_state.name}"
 
                         if target_class_name in state.classes:
                             class_def = state.classes[target_class_name]

--- a/editor/icons/editor_icons_builders.py
+++ b/editor/icons/editor_icons_builders.py
@@ -13,13 +13,13 @@ def make_editor_icons_action(target, source, env):
 
     with StringIO() as icons_string, StringIO() as s:
         for svg in svg_icons:
-            with open(str(svg), "r") as svgf:
-                icons_string.write("\t%s,\n" % to_raw_cstring(svgf.read()))
+            with open(str(svg)) as svgf:
+                icons_string.write(f"\t{to_raw_cstring(svgf.read())},\n")
 
         s.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
         s.write("#ifndef _EDITOR_ICONS_H\n")
         s.write("#define _EDITOR_ICONS_H\n")
-        s.write("static const int editor_icons_count = {};\n".format(len(svg_icons)))
+        s.write(f"static const int editor_icons_count = {len(svg_icons)};\n")
         s.write("static const char *editor_icons_sources[] = {\n")
         s.write(icons_string.getvalue())
         s.write("};\n\n")
@@ -42,7 +42,7 @@ def make_editor_icons_action(target, source, env):
             if icon_name.endswith("GodotFile"):  # don't know a better way to handle this
                 thumb_big_indices.append(str(index))
 
-            s.write('\t"{0}"'.format(icon_name))
+            s.write(f'\t"{icon_name}"')
 
             if fname != svg_icons[-1]:
                 s.write(",")
@@ -54,13 +54,13 @@ def make_editor_icons_action(target, source, env):
 
         if thumb_medium_indices:
             s.write("\n\n")
-            s.write("static const int editor_md_thumbs_count = {};\n".format(len(thumb_medium_indices)))
+            s.write(f"static const int editor_md_thumbs_count = {len(thumb_medium_indices)};\n")
             s.write("static const int editor_md_thumbs_indices[] = {")
             s.write(", ".join(thumb_medium_indices))
             s.write("};\n")
         if thumb_big_indices:
             s.write("\n\n")
-            s.write("static const int editor_bg_thumbs_count = {};\n".format(len(thumb_big_indices)))
+            s.write(f"static const int editor_bg_thumbs_count = {len(thumb_big_indices)};\n")
             s.write("static const int editor_bg_thumbs_indices[] = {")
             s.write(", ".join(thumb_big_indices))
             s.write("};\n")

--- a/editor/template_builders.py
+++ b/editor/template_builders.py
@@ -16,7 +16,7 @@ def parse_template(inherits, source, delimiter):
     meta_prefix = delimiter + " meta-"
     meta = ["name", "description", "version", "space-indent"]
 
-    with open(source, "r", encoding="utf-8") as f:
+    with open(source, encoding="utf-8") as f:
         lines = f.readlines()
         for line in lines:
             if line.startswith(meta_prefix):

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -32,7 +32,7 @@ class GLES3HeaderStruct:
 
 
 def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, depth: int):
-    with open(filename, "r", encoding="utf-8") as fs:
+    with open(filename, encoding="utf-8") as fs:
         line = fs.readline()
 
         while line:

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -24,7 +24,7 @@ class RDHeaderStruct:
 
 
 def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth: int) -> RDHeaderStruct:
-    with open(filename, "r", encoding="utf-8") as fs:
+    with open(filename, encoding="utf-8") as fs:
         line = fs.readline()
 
         while line:
@@ -111,13 +111,13 @@ def build_rd_header(
 
     if header_data.compute_lines:
         body_parts = [
-            "static const char _compute_code[] = {\n%s\n\t\t};" % to_raw_cstring(header_data.compute_lines),
+            f"static const char _compute_code[] = {{\n{to_raw_cstring(header_data.compute_lines)}\n\t\t}};",
             f'setup(nullptr, nullptr, _compute_code, "{out_file_class}");',
         ]
     else:
         body_parts = [
-            "static const char _vertex_code[] = {\n%s\n\t\t};" % to_raw_cstring(header_data.vertex_lines),
-            "static const char _fragment_code[] = {\n%s\n\t\t};" % to_raw_cstring(header_data.fragment_lines),
+            f"static const char _vertex_code[] = {{\n{to_raw_cstring(header_data.vertex_lines)}\n\t\t}};",
+            f"static const char _fragment_code[] = {{\n{to_raw_cstring(header_data.fragment_lines)}\n\t\t}};",
             f'setup(_vertex_code, _fragment_code, nullptr, "{out_file_class}");',
         ]
 
@@ -158,7 +158,7 @@ class RAWHeaderStruct:
 
 
 def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, depth: int) -> None:
-    with open(filename, "r", encoding="utf-8") as fs:
+    with open(filename, encoding="utf-8") as fs:
         line = fs.readline()
 
         while line:

--- a/methods.py
+++ b/methods.py
@@ -85,7 +85,7 @@ def add_source_files_orig(self, sources, files, allow_gen=False):
     for path in files:
         obj = self.Object(path)
         if obj in sources:
-            print_warning('Object "{}" already included in environment sources.'.format(obj))
+            print_warning(f'Object "{obj}" already included in environment sources.')
             continue
         sources.append(obj)
 
@@ -189,13 +189,13 @@ def get_version_info(module_version_string="", silent=False):
     gitfolder = ".git"
 
     if os.path.isfile(".git"):
-        with open(".git", "r", encoding="utf-8") as file:
+        with open(".git", encoding="utf-8") as file:
             module_folder = file.readline().strip()
         if module_folder.startswith("gitdir: "):
             gitfolder = module_folder[8:]
 
     if os.path.isfile(os.path.join(gitfolder, "HEAD")):
-        with open(os.path.join(gitfolder, "HEAD"), "r", encoding="utf8") as file:
+        with open(os.path.join(gitfolder, "HEAD"), encoding="utf8") as file:
             head = file.readline().strip()
         if head.startswith("ref: "):
             ref = head[5:]
@@ -206,12 +206,12 @@ def get_version_info(module_version_string="", silent=False):
             head = os.path.join(gitfolder, ref)
             packedrefs = os.path.join(gitfolder, "packed-refs")
             if os.path.isfile(head):
-                with open(head, "r", encoding="utf-8") as file:
+                with open(head, encoding="utf-8") as file:
                     githash = file.readline().strip()
             elif os.path.isfile(packedrefs):
                 # Git may pack refs into a single file. This code searches .git/packed-refs file for the current ref's hash.
                 # https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-pack-refs.html
-                for line in open(packedrefs, "r", encoding="utf-8").read().splitlines():
+                for line in open(packedrefs, encoding="utf-8").read().splitlines():
                     if line.startswith("#"):
                         continue
                     (line_hash, line_ref) = line.split(" ")
@@ -280,7 +280,7 @@ def detect_modules(search_path, recursive=False):
         # Godot sources when using `custom_modules` build option.
         version_path = os.path.join(path, "version.py")
         if os.path.exists(version_path):
-            with open(version_path, "r", encoding="utf-8") as f:
+            with open(version_path, encoding="utf-8") as f:
                 if 'short_name = "godot"' in f.read():
                     return True
         return False
@@ -360,7 +360,7 @@ def module_check_dependencies(self, module):
     missing_deps = set()
     required_deps = self.module_dependencies[module][0] if module in self.module_dependencies else []
     for dep in required_deps:
-        opt = "module_{}_enabled".format(dep)
+        opt = f"module_{dep}_enabled"
         if opt not in self or not self[opt] or not module_check_dependencies(self, dep):
             missing_deps.add(dep)
 
@@ -409,8 +409,7 @@ def use_windows_spawn_fix(self, platform=None):
             "shell": False,
             "env": env,
         }
-        if sys.version_info >= (3, 7, 0):
-            popen_args["text"] = True
+        popen_args["text"] = True
         proc = subprocess.Popen(cmdline, **popen_args)
         _, err = proc.communicate()
         rv = proc.wait()
@@ -666,7 +665,7 @@ def detect_darwin_sdk_path(platform, env):
             if sdk_path:
                 env[var_name] = sdk_path
         except (subprocess.CalledProcessError, OSError):
-            print_error("Failed to find SDK path while running xcrun --sdk {} --show-sdk-path.".format(sdk_name))
+            print_error(f"Failed to find SDK path while running xcrun --sdk {sdk_name} --show-sdk-path.")
             raise
 
 
@@ -828,9 +827,7 @@ def show_progress(env):
             self.limit = limit
             if env["verbose"] and path is not None:
                 screen.write(
-                    "Current cache limit is {} (used: {})\n".format(
-                        self.convert_size(limit), self.convert_size(self.get_size(path))
-                    )
+                    f"Current cache limit is {self.convert_size(limit)} (used: {self.convert_size(self.get_size(path))})\n"
                 )
 
         def __call__(self, node, *args, **kw):
@@ -855,7 +852,7 @@ def show_progress(env):
             i = int(math.floor(math.log(size_bytes, 1024)))
             p = math.pow(1024, i)
             s = round(size_bytes / p, 2)
-            return "%s %s" % (int(s) if i == 0 else s, size_name[i])
+            return f"{int(s) if i == 0 else s} {size_name[i]}"
 
         def get_size(self, start_path="."):
             total_size = 0
@@ -874,7 +871,7 @@ def show_progress(env):
             pass
 
     try:
-        with open(node_count_fname, "r", encoding="utf-8") as f:
+        with open(node_count_fname, encoding="utf-8") as f:
             node_count_max = int(f.readline())
     except Exception:
         pass
@@ -962,7 +959,7 @@ def dump(env):
     from json import dump
 
     def non_serializable(obj):
-        return "<<non-serializable: %s>>" % (type(obj).__qualname__)
+        return f"<<non-serializable: {type(obj).__qualname__}>>"
 
     with open(".scons_env.json", "w", encoding="utf-8", newline="\n") as f:
         dump(env.Dictionary(), f, indent=4, default=non_serializable)
@@ -1118,7 +1115,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
     ).hexdigest()
 
     if os.path.exists(f"{project_name}.vcxproj.filters"):
-        with open(f"{project_name}.vcxproj.filters", "r", encoding="utf-8") as file:
+        with open(f"{project_name}.vcxproj.filters", encoding="utf-8") as file:
             existing_filters = file.read()
         match = re.search(r"(?ms)^<!-- CHECKSUM$.([0-9a-f]{32})", existing_filters)
         if match is not None and md5 == match.group(1):
@@ -1130,7 +1127,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
     if not skip_filters:
         print(f"Regenerating {project_name}.vcxproj.filters")
 
-        with open("misc/msvs/vcxproj.filters.template", "r", encoding="utf-8") as file:
+        with open("misc/msvs/vcxproj.filters.template", encoding="utf-8") as file:
             filters_template = file.read()
         for i in range(1, 10):
             filters_template = filters_template.replace(f"%%UUID{i}%%", str(uuid.uuid4()))
@@ -1280,11 +1277,11 @@ def generate_vs_project(env, original_args, project_name="godot"):
 
         for x in itemlist.keys():
             properties.append(
-                "<ActiveProjectItemList_%s>;%s;</ActiveProjectItemList_%s>" % (x, ";".join(itemlist[x]), x)
+                "<ActiveProjectItemList_{}>;{};</ActiveProjectItemList_{}>".format(x, ";".join(itemlist[x]), x)
             )
         output = f'bin\\godot{env["PROGSUFFIX"]}'
 
-        with open("misc/msvs/props.template", "r", encoding="utf-8") as file:
+        with open("misc/msvs/props.template", encoding="utf-8") as file:
             props_template = file.read()
 
         props_template = props_template.replace("%%VSCONF%%", vsconf)
@@ -1357,7 +1354,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
     sln_uuid = str(uuid.uuid4())
 
     if os.path.exists(f"{project_name}.sln"):
-        for line in open(f"{project_name}.sln", "r", encoding="utf-8").read().splitlines():
+        for line in open(f"{project_name}.sln", encoding="utf-8").read().splitlines():
             if line.startswith('Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}")'):
                 proj_uuid = re.search(
                     r"\"{(\b[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-\b[0-9a-fA-F]{12}\b)}\"$",
@@ -1446,7 +1443,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
     section2 = sorted(section2)
 
     if not get_bool(original_args, "vsproj_props_only", False):
-        with open("misc/msvs/vcxproj.template", "r", encoding="utf-8") as file:
+        with open("misc/msvs/vcxproj.template", encoding="utf-8") as file:
             proj_template = file.read()
         proj_template = proj_template.replace("%%UUID%%", proj_uuid)
         proj_template = proj_template.replace("%%CONFS%%", "\n    ".join(configurations))
@@ -1458,7 +1455,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
             f.write(proj_template)
 
     if not get_bool(original_args, "vsproj_props_only", False):
-        with open("misc/msvs/sln.template", "r", encoding="utf-8") as file:
+        with open("misc/msvs/sln.template", encoding="utf-8") as file:
             sln_template = file.read()
         sln_template = sln_template.replace("%%NAME%%", project_name)
         sln_template = sln_template.replace("%%UUID%%", proj_uuid)
@@ -1564,7 +1561,7 @@ def generated_wrapper(
         header_guard = (f"{prefix}{split[0]}{suffix}.{'.'.join(split[1:])}".upper()
                 .replace(".", "_").replace("-", "_").replace(" ", "_").replace("__", "_"))  # fmt: skip
 
-    with open(path, "wt", encoding="utf-8", newline="\n") as file:
+    with open(path, "w", encoding="utf-8", newline="\n") as file:
         file.write(generate_copyright_header(path))
         file.write("\n/* THIS FILE IS GENERATED. EDITS WILL BE LOST. */\n\n")
 

--- a/misc/scripts/check_ci_log.py
+++ b/misc/scripts/check_ci_log.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import sys
 
@@ -9,7 +8,7 @@ if len(sys.argv) < 2:
 
 fname = sys.argv[1]
 
-with open(fname.strip(), "r", encoding="utf-8") as fileread:
+with open(fname.strip(), encoding="utf-8") as fileread:
     file_contents = fileread.read()
 
 # If find "ERROR: AddressSanitizer:", then happens invalid read or write

--- a/misc/scripts/copyright_headers.py
+++ b/misc/scripts/copyright_headers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import os
 import sys
@@ -69,7 +68,7 @@ for f in sys.argv[1:]:
     # In a second pass, we skip all consecutive comment lines starting with "/*",
     # then we can append the rest (step 2).
 
-    with open(fname.strip(), "r", encoding="utf-8") as fileread:
+    with open(fname.strip(), encoding="utf-8") as fileread:
         line = fileread.readline()
         header_done = False
 

--- a/misc/scripts/dotnet_format.py
+++ b/misc/scripts/dotnet_format.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import glob
 import os

--- a/misc/scripts/file_format.py
+++ b/misc/scripts/file_format.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import sys
 
@@ -14,7 +13,7 @@ invalid = []
 
 for file in sys.argv[1:]:
     try:
-        with open(file, "rt", encoding="utf-8") as f:
+        with open(file, encoding="utf-8") as f:
             original = f.read()
     except UnicodeDecodeError:
         invalid.append(file)

--- a/misc/scripts/header_guards.py
+++ b/misc/scripts/header_guards.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import sys
 from pathlib import Path
@@ -15,7 +14,7 @@ for file in sys.argv[1:]:
     header_start = -1
     HEADER_CHECK_OFFSET = -1
 
-    with open(file.strip(), "rt", encoding="utf-8", newline="\n") as f:
+    with open(file.strip(), encoding="utf-8", newline="\n") as f:
         lines = f.readlines()
 
     for idx, line in enumerate(lines):
@@ -86,7 +85,7 @@ for file in sys.argv[1:]:
         lines[HEADER_CHECK_OFFSET] = HEADER_CHECK
         lines[HEADER_BEGIN_OFFSET] = HEADER_BEGIN
         lines[HEADER_END_OFFSET] = HEADER_END
-        with open(file, "wt", encoding="utf-8", newline="\n") as f:
+        with open(file, "w", encoding="utf-8", newline="\n") as f:
             f.writelines(lines)
         changed.append(file)
         continue
@@ -125,7 +124,7 @@ for file in sys.argv[1:]:
         lines.insert(HEADER_BEGIN_OFFSET, HEADER_BEGIN)
         lines.append("\n")
         lines.append(HEADER_END)
-        with open(file, "wt", encoding="utf-8", newline="\n") as f:
+        with open(file, "w", encoding="utf-8", newline="\n") as f:
             f.writelines(lines)
         changed.append(file)
         continue
@@ -136,7 +135,7 @@ for file in sys.argv[1:]:
         lines.insert(HEADER_BEGIN_OFFSET, HEADER_BEGIN)
         lines.append("\n")
         lines.append(HEADER_END)
-        with open(file, "wt", encoding="utf-8", newline="\n") as f:
+        with open(file, "w", encoding="utf-8", newline="\n") as f:
             f.writelines(lines)
         changed.append(file)
         continue
@@ -153,7 +152,7 @@ for file in sys.argv[1:]:
             lines.insert(HEADER_BEGIN_OFFSET, HEADER_BEGIN)
             lines.append("\n")
             lines.append(HEADER_END)
-            with open(file, "wt", encoding="utf-8", newline="\n") as f:
+            with open(file, "w", encoding="utf-8", newline="\n") as f:
                 f.writelines(lines)
             changed.append(file)
             continue

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -73,7 +73,7 @@ for name, path in env.module_list.items():
     base_path = path if os.path.isabs(path) else name
     SConscript(base_path + "/SCsub")
 
-    lib = env_modules.add_library("module_%s" % name, env.modules_sources)
+    lib = env_modules.add_library(f"module_{name}", env.modules_sources)
     env.Prepend(LIBS=[lib])
     if env["vsproj"]:
         vs_sources += env.modules_sources

--- a/modules/raycast/godot_update_embree.py
+++ b/modules/raycast/godot_update_embree.py
@@ -148,7 +148,7 @@ with open(os.path.join(dest_dir, "kernels/hash.h"), "w", encoding="utf-8", newli
 for config_file in config_files:
     os.rename(os.path.join(dest_dir, config_file), os.path.join(dest_dir, config_file[:-3]))
 
-with open("CMakeLists.txt", "r", encoding="utf-8") as cmake_file:
+with open("CMakeLists.txt", encoding="utf-8") as cmake_file:
     cmake_content = cmake_file.read()
     major_version = int(re.compile(r"EMBREE_VERSION_MAJOR\s(\d+)").findall(cmake_content)[0])
     minor_version = int(re.compile(r"EMBREE_VERSION_MINOR\s(\d+)").findall(cmake_content)[0])

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -16,7 +16,7 @@ def export_icon_builder(target, source, env):
     src_path = Path(str(source[0]))
     src_name = src_path.stem
     platform = src_path.parent.parent.stem
-    with open(str(source[0]), "r") as file:
+    with open(str(source[0])) as file:
         svg = file.read()
     with methods.generated_wrapper(target, prefix=platform) as file:
         file.write(

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -130,7 +130,7 @@ def configure(env: "SConsEnvironment"):
             else:
                 env.Append(LINKFLAGS=["-fuse-ld=mold"])
         else:
-            env.Append(LINKFLAGS=["-fuse-ld=%s" % env["linker"]])
+            env.Append(LINKFLAGS=["-fuse-ld={}".format(env["linker"])])
 
     if env["use_coverage"]:
         env.Append(CCFLAGS=["-ftest-coverage", "-fprofile-arcs"])

--- a/platform/linuxbsd/platform_linuxbsd_builders.py
+++ b/platform/linuxbsd/platform_linuxbsd_builders.py
@@ -5,6 +5,6 @@ import os
 
 def make_debug_linuxbsd(target, source, env):
     dst = str(target[0])
-    os.system("objcopy --only-keep-debug {0} {0}.debugsymbols".format(dst))
-    os.system("strip --strip-debug --strip-unneeded {0}".format(dst))
-    os.system("objcopy --add-gnu-debuglink={0}.debugsymbols {0}".format(dst))
+    os.system(f"objcopy --only-keep-debug {dst} {dst}.debugsymbols")
+    os.system(f"strip --strip-debug --strip-unneeded {dst}")
+    os.system(f"objcopy --add-gnu-debuglink={dst}.debugsymbols {dst}")

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -27,7 +27,9 @@ def generate_bundle(target, source, env):
         target_bin = lipo(bin_dir + "/" + prefix, env.extra_suffix + env.module_version_string)
 
         # Assemble .app bundle and update version info.
-        app_dir = Dir("#bin/" + (prefix + env.extra_suffix + env.module_version_string).replace(".", "_") + ".app").abspath
+        app_dir = Dir(
+            "#bin/" + (prefix + env.extra_suffix + env.module_version_string).replace(".", "_") + ".app"
+        ).abspath
         templ = Dir("#misc/dist/macos_tools.app").abspath
         if os.path.exists(app_dir):
             shutil.rmtree(app_dir)
@@ -40,8 +42,8 @@ def generate_bundle(target, source, env):
             shutil.copytree(Dir("#bin/GodotSharp").abspath, app_dir + "/Contents/Resources/GodotSharp")
         version = get_build_version(False)
         short_version = get_build_version(True)
-        with open(Dir("#misc/dist/macos").abspath + "/editor_info_plist.template", "rt", encoding="utf-8") as fin:
-            with open(app_dir + "/Contents/Info.plist", "wt", encoding="utf-8", newline="\n") as fout:
+        with open(Dir("#misc/dist/macos").abspath + "/editor_info_plist.template", encoding="utf-8") as fin:
+            with open(app_dir + "/Contents/Info.plist", "w", encoding="utf-8", newline="\n") as fout:
                 for line in fin:
                     line = line.replace("$version", version)
                     line = line.replace("$short_version", short_version)

--- a/platform/macos/platform_macos_builders.py
+++ b/platform/macos/platform_macos_builders.py
@@ -8,7 +8,7 @@ def make_debug_macos(target, source, env):
     if env["macports_clang"] != "no":
         mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
         mpclangver = env["macports_clang"]
-        os.system(mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-dsymutil {0} -o {0}.dSYM".format(dst))
+        os.system(mpprefix + "/libexec/llvm-" + mpclangver + f"/bin/llvm-dsymutil {dst} -o {dst}.dSYM")
     else:
-        os.system("dsymutil {0} -o {0}.dSYM".format(dst))
-    os.system("strip -u -r {0}".format(dst))
+        os.system(f"dsymutil {dst} -o {dst}.dSYM")
+    os.system(f"strip -u -r {dst}")

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -110,7 +110,7 @@ def configure(env: "SConsEnvironment"):
         print("Note: Forcing `initial_memory=64` as it is required for the web editor.")
         env["initial_memory"] = 64
 
-    env.Append(LINKFLAGS=["-sINITIAL_MEMORY=%sMB" % env["initial_memory"]])
+    env.Append(LINKFLAGS=["-sINITIAL_MEMORY={}MB".format(env["initial_memory"])])
 
     ## Copy env variables.
     env["ENV"] = os.environ
@@ -197,7 +197,7 @@ def configure(env: "SConsEnvironment"):
 
     # Minimum emscripten requirements.
     if cc_semver < (3, 1, 62):
-        print_error("The minimum emscripten version to build Godot is 3.1.62, detected: %s.%s.%s" % cc_semver)
+        print_error("The minimum emscripten version to build Godot is 3.1.62, detected: {}.{}.{}".format(*cc_semver))
         sys.exit(255)
 
     env.Prepend(CPPPATH=["#platform/web"])
@@ -216,14 +216,14 @@ def configure(env: "SConsEnvironment"):
     if env["javascript_eval"]:
         env.Append(CPPDEFINES=["JAVASCRIPT_EVAL_ENABLED"])
 
-    env.Append(LINKFLAGS=["-s%s=%sKB" % ("STACK_SIZE", env["stack_size"])])
+    env.Append(LINKFLAGS=["-s{}={}KB".format("STACK_SIZE", env["stack_size"])])
 
     if env["threads"]:
         # Thread support (via SharedArrayBuffer).
         env.Append(CPPDEFINES=["PTHREAD_NO_RENAME"])
         env.Append(CCFLAGS=["-sUSE_PTHREADS=1"])
         env.Append(LINKFLAGS=["-sUSE_PTHREADS=1"])
-        env.Append(LINKFLAGS=["-sDEFAULT_PTHREAD_STACK_SIZE=%sKB" % env["default_pthread_stack_size"]])
+        env.Append(LINKFLAGS=["-sDEFAULT_PTHREAD_STACK_SIZE={}KB".format(env["default_pthread_stack_size"])])
         env.Append(LINKFLAGS=["-sPTHREAD_POOL_SIZE=8"])
         env.Append(LINKFLAGS=["-sWASM_MEM_MAX=2048MB"])
         if not env["dlink_enabled"]:

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -251,13 +251,14 @@ def setup_msvc_manual(env: "SConsEnvironment"):
     env_arch = detect_build_env_arch()
     if env["arch"] != env_arch:
         print_error(
-            "Arch argument (%s) is not matching Native/Cross Compile Tools Prompt/Developer Console (or Visual Studio settings) that is being used to run SCons (%s).\n"
-            "Run SCons again without arch argument (example: scons p=windows) and SCons will attempt to detect what MSVC compiler will be executed and inform you."
-            % (env["arch"], env_arch)
+            "Arch argument ({}) is not matching Native/Cross Compile Tools Prompt/Developer Console (or Visual Studio settings) that is being used to run SCons ({}).\n"
+            "Run SCons again without arch argument (example: scons p=windows) and SCons will attempt to detect what MSVC compiler will be executed and inform you.".format(
+                env["arch"], env_arch
+            )
         )
         sys.exit(255)
 
-    print("Using VCVARS-determined MSVC, arch %s" % (env_arch))
+    print(f"Using VCVARS-determined MSVC, arch {env_arch}")
 
 
 def setup_msvc_auto(env: "SConsEnvironment"):
@@ -299,7 +300,7 @@ def setup_msvc_auto(env: "SConsEnvironment"):
     env.AppendUnique(RCFLAGS=env.get("rcflags", "").split())
 
     # Note: actual compiler version can be found in env['MSVC_VERSION'], e.g. "14.1" for VS2015
-    print("Using SCons-detected MSVC version %s, arch %s" % (env["MSVC_VERSION"], env["arch"]))
+    print("Using SCons-detected MSVC version {}, arch {}".format(env["MSVC_VERSION"], env["arch"]))
 
 
 def setup_mingw(env: "SConsEnvironment"):
@@ -314,9 +315,10 @@ def setup_mingw(env: "SConsEnvironment"):
 
     if env_arch != "" and env["arch"] != env_arch:
         print_error(
-            "Arch argument (%s) is not matching MSYS2 console/environment that is being used to run SCons (%s).\n"
-            "Run SCons again without arch argument (example: scons p=windows) and SCons will attempt to detect what MSYS2 compiler will be executed and inform you."
-            % (env["arch"], env_arch)
+            "Arch argument ({}) is not matching MSYS2 console/environment that is being used to run SCons ({}).\n"
+            "Run SCons again without arch argument (example: scons p=windows) and SCons will attempt to detect what MSYS2 compiler will be executed and inform you.".format(
+                env["arch"], env_arch
+            )
         )
         sys.exit(255)
 
@@ -330,7 +332,7 @@ def setup_mingw(env: "SConsEnvironment"):
     env.AppendUnique(CCFLAGS=env.get("ccflags", "").split())
     env.AppendUnique(RCFLAGS=env.get("rcflags", "").split())
 
-    print("Using MinGW, arch %s" % (env["arch"]))
+    print("Using MinGW, arch {}".format(env["arch"]))
 
 
 def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
@@ -364,7 +366,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
 
         # Ensure we have a location to write captured output to, in case of false positives.
         capture_path = methods.base_folder_path + "platform/windows/msvc_capture.log"
-        with open(capture_path, "wt", encoding="utf-8"):
+        with open(capture_path, "w", encoding="utf-8"):
             pass
 
         old_spawn = env["SPAWN"]
@@ -388,7 +390,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
             ret = old_spawn(sh, escape, cmd, args, env)
 
             try:
-                with open(tmp_stdout_name, "r", encoding=sys.stdout.encoding, errors="replace") as tmp_stdout:
+                with open(tmp_stdout_name, encoding=sys.stdout.encoding, errors="replace") as tmp_stdout:
                     lines = tmp_stdout.read().splitlines()
                 os.remove(tmp_stdout_name)
             except OSError:
@@ -461,8 +463,8 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
             "WINMIDI_ENABLED",
             "TYPED_METHOD_BIND",
             "WIN32",
-            "WINVER=%s" % env["target_win_version"],
-            "_WIN32_WINNT=%s" % env["target_win_version"],
+            "WINVER={}".format(env["target_win_version"]),
+            "_WIN32_WINNT={}".format(env["target_win_version"]),
         ]
     )
     env.AppendUnique(CPPDEFINES=["NOMINMAX"])  # disable bogus min/max WinDef.h macros

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -8,5 +8,5 @@ def make_debug_mingw(target, source, env):
     # Force separate debug symbols if executable size is larger than 1.9 GB.
     if env["separate_debug_symbols"] or os.stat(dst).st_size >= 2040109465:
         os.system("{0} --only-keep-debug {1} {1}.debugsymbols".format(env["OBJCOPY"], dst))
-        os.system("{0} --strip-debug --strip-unneeded {1}".format(env["STRIP"], dst))
+        os.system("{} --strip-debug --strip-unneeded {}".format(env["STRIP"], dst))
         os.system("{0} --add-gnu-debuglink={1}.debugsymbols {1}".format(env["OBJCOPY"], dst))

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -44,8 +44,9 @@ def detect_arch():
 def validate_arch(arch, platform_name, supported_arches):
     if arch not in supported_arches:
         methods.print_error(
-            'Unsupported CPU architecture "%s" for %s. Supported architectures are: %s.'
-            % (arch, platform_name, ", ".join(supported_arches))
+            'Unsupported CPU architecture "{}" for {}. Supported architectures are: {}.'.format(
+                arch, platform_name, ", ".join(supported_arches)
+            )
         )
         sys.exit(255)
 
@@ -63,7 +64,7 @@ def get_build_version(short):
     if not short:
         if os.getenv("GODOT_VERSION_STATUS") is not None:
             status = str(os.getenv("GODOT_VERSION_STATUS"))
-        v += ".%s.%s" % (status, name)
+        v += f".{status}.{name}"
     return v
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,10 @@ target-version = "py37"
 
 [tool.ruff.lint]
 extend-select = [
-	"I", # isort
+	"I",  # isort
+	"UP", # pyupgrade
 ]
+extend-safe-fixes = ["UP"]
 
 [tool.ruff.lint.per-file-ignores]
 "{SConstruct,SCsub}" = [

--- a/scene/theme/icons/default_theme_icons_builders.py
+++ b/scene/theme/icons/default_theme_icons_builders.py
@@ -13,14 +13,14 @@ def make_default_theme_icons_action(target, source, env):
 
     with StringIO() as icons_string, StringIO() as s:
         for svg in svg_icons:
-            with open(svg, "r") as svgf:
-                icons_string.write("\t%s,\n" % to_raw_cstring(svgf.read()))
+            with open(svg) as svgf:
+                icons_string.write(f"\t{to_raw_cstring(svgf.read())},\n")
 
         s.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n\n")
         s.write('#include "modules/modules_enabled.gen.h"\n\n')
         s.write("#ifndef _DEFAULT_THEME_ICONS_H\n")
         s.write("#define _DEFAULT_THEME_ICONS_H\n")
-        s.write("static const int default_theme_icons_count = {};\n\n".format(len(svg_icons)))
+        s.write(f"static const int default_theme_icons_count = {len(svg_icons)};\n\n")
         s.write("#ifdef MODULE_SVG_ENABLED\n")
         s.write("static const char *default_theme_icons_sources[] = {\n")
         s.write(icons_string.getvalue())
@@ -35,7 +35,7 @@ def make_default_theme_icons_action(target, source, env):
             # Trim the `.svg` extension from the string.
             icon_name = os.path.basename(fname)[:-4]
 
-            s.write('\t"{0}"'.format(icon_name))
+            s.write(f'\t"{icon_name}"')
 
             if fname != svg_icons[-1]:
                 s.write(",")

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -74,7 +74,7 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
             print_error(f'SCU: "{output_folder}" could not be created.')
             return
         if _verbose:
-            print("SCU: Creating folder: %s" % output_folder)
+            print(f"SCU: Creating folder: {output_folder}")
 
     file_text = ""
 
@@ -94,7 +94,7 @@ def write_output_file(file_count, include_list, start_line, end_line, output_fol
 
     if not output_path.exists() or output_path.read_text() != file_text:
         if _verbose:
-            print("SCU: Generating: %s" % short_filename)
+            print(f"SCU: Generating: {short_filename}")
         output_path.write_text(file_text, encoding="utf8")
     elif _verbose:
         print("SCU: Generation not needed for: " + short_filename)
@@ -371,6 +371,6 @@ def generate_scu_files(max_includes_per_scu):
     os.chdir(curr_folder)
 
     if _verbose:
-        print("SCU: Processed folders: %s" % sorted(_scu_folders))
+        print(f"SCU: Processed folders: {sorted(_scu_folders)}")
 
     return _scu_folders

--- a/tests/create_test.py
+++ b/tests/create_test.py
@@ -106,7 +106,7 @@ TEST_CASE("[{name_pascal_case}] Example test case") {{
 
     if args.invasive:
         print("Trying to insert include directive in test_main.cpp...")
-        with open("test_main.cpp", "r", encoding="utf-8") as file:
+        with open("test_main.cpp", encoding="utf-8") as file:
             contents = file.read()
         match = re.search(r'#include "tests.*\n', contents)
 

--- a/tests/python_build/test_gles3_builder.py
+++ b/tests/python_build/test_gles3_builder.py
@@ -17,15 +17,15 @@ def test_gles3_builder(shader_files, builder, header_struct):
 
     builder(shader_files["path_input"], "drivers/gles3/shader_gles3.h", "GLES3", header_data=header)
 
-    with open(shader_files["path_expected_parts"], "r", encoding="utf-8") as f:
+    with open(shader_files["path_expected_parts"], encoding="utf-8") as f:
         expected_parts = json.load(f)
         assert expected_parts == header.__dict__
 
-    with open(shader_files["path_output"], "r", encoding="utf-8") as f:
+    with open(shader_files["path_output"], encoding="utf-8") as f:
         actual_output = f.read()
         assert actual_output
 
-    with open(shader_files["path_expected_full"], "r", encoding="utf-8") as f:
+    with open(shader_files["path_expected_full"], encoding="utf-8") as f:
         expected_output = f.read()
 
     assert actual_output == expected_output

--- a/tests/python_build/test_glsl_builder.py
+++ b/tests/python_build/test_glsl_builder.py
@@ -23,15 +23,15 @@ def test_glsl_builder(shader_files, builder, header_struct):
     header = header_struct()
     builder(shader_files["path_input"], header_data=header)
 
-    with open(shader_files["path_expected_parts"], "r", encoding="utf-8") as f:
+    with open(shader_files["path_expected_parts"], encoding="utf-8") as f:
         expected_parts = json.load(f)
         assert expected_parts == header.__dict__
 
-    with open(shader_files["path_output"], "r", encoding="utf-8") as f:
+    with open(shader_files["path_output"], encoding="utf-8") as f:
         actual_output = f.read()
         assert actual_output
 
-    with open(shader_files["path_expected_full"], "r", encoding="utf-8") as f:
+    with open(shader_files["path_expected_full"], encoding="utf-8") as f:
         expected_output = f.read()
 
     assert actual_output == expected_output


### PR DESCRIPTION
Extends ruff's linter to include the pyupgrade[^1] ruleset. Enabling this allows ruff to seek out outdated syntax, applying modern equivalents where possible. Ran the new settings across the repo; it mostly incorporated f-strings & removed redundant `open` arguments

[^1]: https://docs.astral.sh/ruff/rules/#pyupgrade-up