### PR TITLE
Display CPU and GPU model name in the editor visual profiler

### DIFF
--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -37,6 +37,12 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/resources/image_texture.h"
 
+void EditorVisualProfiler::set_hardware_info(const String &p_cpu_name, const String &p_gpu_name) {
+	cpu_name = p_cpu_name;
+	gpu_name = p_gpu_name;
+	queue_redraw();
+}
+
 void EditorVisualProfiler::add_frame_metric(const Metric &p_metric) {
 	++last_metric;
 	if (last_metric >= frame_metrics.size()) {
@@ -489,8 +495,8 @@ void EditorVisualProfiler::_graph_tex_draw() {
 		graph->draw_string(font, Vector2(half_width * 2 - font->get_string_size(limit_str, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x - 2, frame_y - 2), limit_str, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color * Color(1, 1, 1, 0.75));
 	}
 
-	graph->draw_string(font, Vector2(font->get_string_size("X", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x, font->get_ascent(font_size) + 2), "CPU:", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color * Color(1, 1, 1));
-	graph->draw_string(font, Vector2(font->get_string_size("X", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + graph->get_size().width / 2, font->get_ascent(font_size) + 2), "GPU:", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color * Color(1, 1, 1));
+	graph->draw_string(font, Vector2(font->get_string_size("X", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x, font->get_ascent(font_size) + 2), "CPU: " + cpu_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color * Color(1, 1, 1, 0.75));
+	graph->draw_string(font, Vector2(font->get_string_size("X", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + graph->get_size().width / 2, font->get_ascent(font_size) + 2), "GPU: " + gpu_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color * Color(1, 1, 1, 0.75));
 }
 
 void EditorVisualProfiler::_graph_tex_mouse_exit() {

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -98,6 +98,9 @@ private:
 
 	float graph_limit = 1000.0f / 60;
 
+	String cpu_name;
+	String gpu_name;
+
 	bool seeking = false;
 
 	Timer *frame_delay = nullptr;
@@ -136,6 +139,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	void set_hardware_info(const String &p_cpu_name, const String &p_gpu_name);
 	void add_frame_metric(const Metric &p_metric);
 	void set_enabled(bool p_enable);
 	void set_profiling(bool p_profiling);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -513,6 +513,10 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 			frame_data.write[i] = p_data[i];
 		}
 		performance_profiler->add_profile_frame(frame_data);
+	} else if (p_msg == "visual:hardware_info") {
+		const String cpu_name = p_data[0];
+		const String gpu_name = p_data[1];
+		visual_profiler->set_hardware_info(cpu_name, gpu_name);
 	} else if (p_msg == "visual:profile_frame") {
 		ServersDebugger::VisualProfilerFrame frame;
 		frame.deserialize(p_data);

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -370,6 +370,12 @@ class ServersDebugger::VisualProfiler : public EngineProfiler {
 public:
 	void toggle(bool p_enable, const Array &p_opts) {
 		RS::get_singleton()->set_frame_profiling_enabled(p_enable);
+
+		// Send hardware information from the remote device so that it's accurate for remote debugging.
+		Array hardware_info;
+		hardware_info.push_back(OS::get_singleton()->get_processor_name());
+		hardware_info.push_back(RenderingServer::get_singleton()->get_video_adapter_name());
+		EngineDebugger::get_singleton()->send_message("visual:hardware_info", hardware_info);
 	}
 
 	void add(const Array &p_data) {}


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/99084
(can be merged independently, I'll rebase).

This shows the information from the remote device, which will typically differ from the local device in remote debugging scenarios.

## Preview

![image](https://github.com/user-attachments/assets/3a09fb5f-be0c-40fe-abc6-3542aeeecefe)
