### PR TITLE
Fix C# boolean "Prints" comments in documentation

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -183,17 +183,17 @@
 
 				public override void _Ready()
 				{
-				    // Prints true (3/3 elements evaluate to true).
+				    // Prints True (3/3 elements evaluate to true).
 				    GD.Print(new Godot.Collections.Array&gt;int&lt; { 6, 10, 6 }.All(GreaterThan5));
-				    // Prints false (1/3 elements evaluate to true).
+				    // Prints False (1/3 elements evaluate to true).
 				    GD.Print(new Godot.Collections.Array&gt;int&lt; { 4, 10, 4 }.All(GreaterThan5));
-				    // Prints false (0/3 elements evaluate to true).
+				    // Prints False (0/3 elements evaluate to true).
 				    GD.Print(new Godot.Collections.Array&gt;int&lt; { 4, 4, 4 }.All(GreaterThan5));
-				    // Prints true (0/0 elements evaluate to true).
+				    // Prints True (0/0 elements evaluate to true).
 				    GD.Print(new Godot.Collections.Array&gt;int&lt; { }.All(GreaterThan5));
 
 				    // Same as the first line above, but using a lambda function.
-				    GD.Print(new Godot.Collections.Array&gt;int&lt; { 6, 10, 6 }.All(element =&gt; element &gt; 5)); // Prints true
+				    GD.Print(new Godot.Collections.Array&gt;int&lt; { 6, 10, 6 }.All(element =&gt; element &gt; 5)); // Prints True
 				}
 				[/csharp]
 				[/codeblocks]
@@ -462,10 +462,10 @@
 				[csharp]
 				var arr = new Godot.Collections.Array { "inside", 7 };
 				// By C# convention, this method is renamed to `Contains`.
-				GD.Print(arr.Contains("inside"));  // Prints true
-				GD.Print(arr.Contains("outside")); // Prints false
-				GD.Print(arr.Contains(7));         // Prints true
-				GD.Print(arr.Contains("7"));       // Prints false
+				GD.Print(arr.Contains("inside"));  // Prints True
+				GD.Print(arr.Contains("outside")); // Prints False
+				GD.Print(arr.Contains(7));         // Prints True
+				GD.Print(arr.Contains("7"));       // Prints False
 				[/csharp]
 				[/codeblocks]
 				In GDScript, this is equivalent to the [code]in[/code] operator:

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -281,9 +281,9 @@
 				    { 210, default },
 				};
 
-				GD.Print(myDict.ContainsKey("Godot")); // Prints true
-				GD.Print(myDict.ContainsKey(210));     // Prints true
-				GD.Print(myDict.ContainsKey(4));       // Prints false
+				GD.Print(myDict.ContainsKey("Godot")); // Prints True
+				GD.Print(myDict.ContainsKey(210));     // Prints True
+				GD.Print(myDict.ContainsKey(4));       // Prints False
 				[/csharp]
 				[/codeblocks]
 				In GDScript, this is equivalent to the [code]in[/code] operator:
@@ -321,7 +321,7 @@
 				var dict2 = new Godot.Collections.Dictionary{{"A", 10}, {"B", 2}};
 
 				// Godot.Collections.Dictionary has no Hash() method. Use GD.Hash() instead.
-				GD.Print(GD.Hash(dict1) == GD.Hash(dict2)); // Prints true
+				GD.Print(GD.Hash(dict1) == GD.Hash(dict2)); // Prints True
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] Dictionaries with the same entries but in a different order will not have the same hash.

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -223,10 +223,10 @@
 				print(Engine.has_singleton("Unknown"))     # Prints false
 				[/gdscript]
 				[csharp]
-				GD.Print(Engine.HasSingleton("OS"));          // Prints true
-				GD.Print(Engine.HasSingleton("Engine"));      // Prints true
-				GD.Print(Engine.HasSingleton("AudioServer")); // Prints true
-				GD.Print(Engine.HasSingleton("Unknown"));     // Prints false
+				GD.Print(Engine.HasSingleton("OS"));          // Prints True
+				GD.Print(Engine.HasSingleton("Engine"));      // Prints True
+				GD.Print(Engine.HasSingleton("AudioServer")); // Prints True
+				GD.Print(Engine.HasSingleton("Unknown"));     // Prints False
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] Global singletons are not the same as autoloaded nodes, which are configurable in the project settings.

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -605,10 +605,10 @@
 				print(OS.is_keycode_unicode(KEY_ESCAPE)) # Prints false
 				[/gdscript]
 				[csharp]
-				GD.Print(OS.IsKeycodeUnicode((long)Key.G));      // Prints true
-				GD.Print(OS.IsKeycodeUnicode((long)Key.Kp4));    // Prints true
-				GD.Print(OS.IsKeycodeUnicode((long)Key.Tab));    // Prints false
-				GD.Print(OS.IsKeycodeUnicode((long)Key.Escape)); // Prints false
+				GD.Print(OS.IsKeycodeUnicode((long)Key.G));      // Prints True
+				GD.Print(OS.IsKeycodeUnicode((long)Key.Kp4));    // Prints True
+				GD.Print(OS.IsKeycodeUnicode((long)Key.Tab));    // Prints False
+				GD.Print(OS.IsKeycodeUnicode((long)Key.Escape)); // Prints False
 				[/csharp]
 				[/codeblocks]
 			</description>

--- a/doc/classes/PolygonPathFinder.xml
+++ b/doc/classes/PolygonPathFinder.xml
@@ -62,8 +62,8 @@
 				};
 				var connections = new int[] { 0, 1, 1, 2, 2, 0 };
 				polygonPathFinder.Setup(points, connections);
-				GD.Print(polygonPathFinder.IsPointInside(new Vector2(0.2f, 0.2f))); // Prints true
-				GD.Print(polygonPathFinder.IsPointInside(new Vector2(1.0f, 1.0f))); // Prints false
+				GD.Print(polygonPathFinder.IsPointInside(new Vector2(0.2f, 0.2f))); // Prints True
+				GD.Print(polygonPathFinder.IsPointInside(new Vector2(1.0f, 1.0f))); // Prints False
 				[/csharp]
 				[/codeblocks]
 			</description>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -139,8 +139,8 @@
 				print("I" in "team")         # Prints false
 				[/gdscript]
 				[csharp]
-				GD.Print("Node".Contains("de")); // Prints true
-				GD.Print("team".Contains("I"));  // Prints false
+				GD.Print("Node".Contains("de")); // Prints True
+				GD.Print("team".Contains("I"));  // Prints False
 				[/csharp]
 				[/codeblocks]
 				If you need to know where [param what] is within the string, use [method find]. See also [method containsn].

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -122,8 +122,8 @@
 				print("I" in "team")         # Prints false
 				[/gdscript]
 				[csharp]
-				GD.Print("Node".Contains("de")); // Prints true
-				GD.Print("team".Contains("I"));  // Prints false
+				GD.Print("Node".Contains("de")); // Prints True
+				GD.Print("team".Contains("I"));  // Prints False
 				[/csharp]
 				[/codeblocks]
 				If you need to know where [param what] is within the string, use [method find]. See also [method containsn].


### PR DESCRIPTION
See also https://github.com/godotengine/godot/pull/95762

In GDScript, `print()` prints "**true**" and "**false**".
In C#, `GD.Print()` prints "**True**" and "**False**".
So a lot of these comments in the class reference examples are _technically_ inaccurate.

Note that, in the grand scheme of things, this is an _extremely_ minor change. Approve and merge this PR only if you feel like this is worth the localization needing to be refreshed.