### PR TITLE
Add optional GDScript UID comments

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1026,6 +1026,10 @@
 		</member>
 		<member name="editor/version_control/plugin_name" type="String" setter="" getter="" default="&quot;&quot;">
 		</member>
+		<member name="filesystem/gdscript/inline_script_uids" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the UIDs of [GDScript] resources will be stored inside the scripts themselves, inside a comment on their first line. UID comments will be automatically created when the scripts are saved. If [code]false[/code], the UIDs are stored in dedicated files. See also [ResourceUID].
+			Note that if some scripts already have associated UID files, you will need to manually delete them after enabling this setting. The files take priority in determining the script's UID.
+		</member>
 		<member name="filesystem/import/blender/enabled" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], Blender 3D scene files with the [code].blend[/code] extension will be imported by converting them to glTF 2.0.
 			This requires configuring a path to a Blender executable in the editor settings at [code]filesystem/import/blender/blender_path[/code]. Blender 3.0 or later is required.

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -147,6 +147,7 @@ void ScriptTextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 	ERR_FAIL_COND(p_res.is_null());
 
 	script = p_res;
+	script->connect_changed(callable_mp((ScriptEditorBase *)this, &ScriptEditorBase::reload_text));
 
 	code_editor->get_text_editor()->set_text(script->get_source_code());
 	code_editor->get_text_editor()->clear_undo_history();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -270,6 +270,9 @@ public:
 	bool is_tool() const override { return tool; }
 	Ref<GDScript> get_base() const;
 
+	static String get_raw_source_code(const String &p_path, bool *r_error);
+	static String insert_uid_into_source(const String &p_source, const ResourceUID::ID p_uid);
+
 	const HashMap<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }
 	const HashMap<StringName, GDScriptFunction *> &debug_get_member_functions() const; //this is debug only
 	StringName debug_get_member_by_index(int p_idx) const;
@@ -648,6 +651,8 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
+	virtual bool has_custom_uid_support() const override;
+	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
 };
 
@@ -656,6 +661,7 @@ public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
+	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 };
 
 #endif // GDSCRIPT_H


### PR DESCRIPTION
Somewhat a revival of #67132 and a follow-up to #97352
Closes https://github.com/godotengine/godot-proposals/issues/11579

This implements the original idea of UID comments in scripts (before they were changed to annotation and then reverted anyway), with a difference that it uses the new `has_custom_uid_support()` method to make them optional based on a new project setting called `filesystem/gdscript/inline_script_uids`. The setting is disabled by default. If you enable it, GDScript will create UID comments in scripts instead of using `.uid` files. The comment looks like this:
```GDScript
# uid://s0m3rand0mu1d # Auto-generated, do not modify or remove.
```

Note that
- I don't expect it to be merged
- I'm not going to change the implementation to use annotation/parser

I opened this, because I already had the code and some people were interested in the previous solution. The new setting allows to get rid of additional files, but it's for advanced users.