### PR TITLE
Make bottom panel switch when pinned and removed

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -712,7 +712,7 @@ void EditorDockManager::focus_dock(Control *p_dock) {
 	}
 
 	if (all_docks[p_dock].at_bottom) {
-		EditorNode::get_bottom_panel()->make_item_visible(p_dock);
+		EditorNode::get_bottom_panel()->make_item_visible(p_dock, true, true);
 		return;
 	}
 

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -209,7 +209,7 @@ void EditorBottomPanel::remove_item(Control *p_item) {
 	if (was_visible) {
 		// Open the first panel to ensure that if the removed dock was visible, the bottom
 		// panel will not collapse.
-		_switch_to_item(true, 0);
+		_switch_to_item(true, 0, true);
 	} else if (last_opened_control == p_item) {
 		// When a dock is removed by plugins, it might not have been visible, and it
 		// might have been the last_opened_control. We need to make sure to reset the last opened control.
@@ -217,8 +217,8 @@ void EditorBottomPanel::remove_item(Control *p_item) {
 	}
 }
 
-void EditorBottomPanel::make_item_visible(Control *p_item, bool p_visible) {
-	_switch_by_control(p_visible, p_item);
+void EditorBottomPanel::make_item_visible(Control *p_item, bool p_visible, bool p_ignore_lock) {
+	_switch_by_control(p_visible, p_item, p_ignore_lock);
 }
 
 void EditorBottomPanel::move_item_to_end(Control *p_item) {

--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -75,7 +75,7 @@ public:
 
 	Button *add_item(String p_text, Control *p_item, const Ref<Shortcut> &p_shortcut = nullptr, bool p_at_front = false);
 	void remove_item(Control *p_item);
-	void make_item_visible(Control *p_item, bool p_visible = true);
+	void make_item_visible(Control *p_item, bool p_visible = true, bool p_ignore_lock = false);
 	void move_item_to_end(Control *p_item);
 	void hide_bottom_panel();
 	void toggle_last_opened_bottom_panel();


### PR DESCRIPTION
- related https://github.com/godotengine/godot/pull/98074

When a bottom panel is opened, pinned, then removed, it doesn't properly change the bottom panel:

This can be seen by moving the Filesystem dock to the bottom panel, pinning it, then moving it out of the bottom panel, or when disabling a custom bottom panel plugin.

![Screenshot 2024-11-11 171115](https://github.com/user-attachments/assets/4793d8ed-9625-4e6f-a69e-8a9c16429c5b)

Also the `Filesystem` Editor Docks menu option and the `Show in Filesystem` action should still switch when the filesystem is at the bottom.
