### PR TITLE
Set correct position of node with `Align Transform with View` in orthographic view

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3584,12 +3584,11 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 					continue;
 				}
 
-				Transform3D xform;
+				Transform3D xform = camera_transform;
 				if (orthogonal) {
-					xform = sp->get_global_transform();
-					xform.basis = Basis::from_euler(camera_transform.basis.get_euler());
+					Vector3 offset = camera_transform.basis.xform(Vector3(0, 0, cursor.distance));
+					xform.origin = cursor.pos + offset;
 				} else {
-					xform = camera_transform;
 					xform.scale_basis(sp->get_scale());
 				}
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/99074

`3D View Menu > Align Transform with View` changes only the node's rotation when the view is in orthogonal mode.
This PR calculates the equivalent position in orthogonal mode too so the behavior is consistent with the perspective mode.

Result:

https://github.com/user-attachments/assets/0d04fd8d-f29f-455f-84bc-763a1293c740

