### PR TITLE
Windows: Avoid child processes inheriting all file handles

### DIFF
--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -148,7 +148,7 @@ protected:
 	String _quote_command_line_argument(const String &p_text) const;
 
 	struct ProcessInfo {
-		STARTUPINFO si;
+		STARTUPINFOEX si;
 		PROCESS_INFORMATION pi;
 		mutable bool is_running = true;
 		mutable int exit_code = -1;


### PR DESCRIPTION
Before this PR, child processes would inherit all the open handles. Handle inheritance is needed so both parent and child can communicate via pipes. However, full inheritance could lead to hard to diagnose file-in-use (sharing violation) issues in cases either the editor or the running project has to run external commands.

This PR adds use of the extended API to condition the spawning of a child process, that gives fine-grained control on the set of inheritable handles. Now only the pipes are inherited.

Version for 4.3 submitted as #99108.