### PR TITLE
Implement `get_model_name` on macOS and Windows.

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -356,7 +356,7 @@
 			<return type="String" />
 			<description>
 				Returns the model name of the current device.
-				[b]Note:[/b] This method is implemented on Android and iOS. Returns [code]"GenericDevice"[/code] on unsupported platforms.
+				[b]Note:[/b] This method is implemented on Android, iOS, macOS, and Windows. Returns [code]"GenericDevice"[/code] on unsupported platforms.
 			</description>
 		</method>
 		<method name="get_name" qualifiers="const">

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -114,6 +114,8 @@ public:
 	virtual String get_unique_id() const override;
 	virtual String get_processor_name() const override;
 
+	virtual String get_model_name() const override;
+
 	virtual bool is_sandboxed() const override;
 	virtual Vector<String> get_granted_permissions() const override;
 	virtual void revoke_granted_permissions() override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -67,6 +67,15 @@ void OS_MacOS::initialize() {
 	initialize_core();
 }
 
+String OS_MacOS::get_model_name() const {
+	char buffer[256];
+	size_t buffer_len = 256;
+	if (sysctlbyname("hw.model", &buffer, &buffer_len, nullptr, 0) == 0 && buffer_len != 0) {
+		return String::utf8(buffer, buffer_len);
+	}
+	return OS_Unix::get_model_name();
+}
+
 String OS_MacOS::get_processor_name() const {
 	char buffer[256];
 	size_t buffer_len = 256;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1740,6 +1740,34 @@ String OS_Windows::get_locale() const {
 	return "en";
 }
 
+String OS_Windows::get_model_name() const {
+	HKEY hkey;
+	if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"Hardware\\Description\\System\\BIOS", 0, KEY_QUERY_VALUE, &hkey) != ERROR_SUCCESS) {
+		return OS::get_model_name();
+	}
+
+	String sys_name;
+	String board_name;
+	WCHAR buffer[256];
+	DWORD buffer_len = 256;
+	DWORD vtype = REG_SZ;
+	if (RegQueryValueExW(hkey, L"SystemProductName", nullptr, &vtype, (LPBYTE)buffer, &buffer_len) == ERROR_SUCCESS && buffer_len != 0) {
+		sys_name = String::utf16((const char16_t *)buffer, buffer_len).strip_edges();
+	}
+	buffer_len = 256;
+	if (RegQueryValueExW(hkey, L"BaseBoardProduct", nullptr, &vtype, (LPBYTE)buffer, &buffer_len) == ERROR_SUCCESS && buffer_len != 0) {
+		board_name = String::utf16((const char16_t *)buffer, buffer_len).strip_edges();
+	}
+	RegCloseKey(hkey);
+	if (!sys_name.is_empty() && sys_name.to_lower() != "system product name") {
+		return sys_name;
+	}
+	if (!board_name.is_empty() && board_name.to_lower() != "base board product") {
+		return board_name;
+	}
+	return OS::get_model_name();
+}
+
 String OS_Windows::get_processor_name() const {
 	const String id = "Hardware\\Description\\System\\CentralProcessor\\0";
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -210,6 +210,8 @@ public:
 
 	virtual String get_processor_name() const override;
 
+	virtual String get_model_name() const override;
+
 	virtual uint64_t get_embedded_pck_offset() const override;
 
 	virtual String get_config_path() const override;


### PR DESCRIPTION
I have noticed that it's used in #75025, but not implemented on any desktop OS.

- On macOS, it is a `MacX,Y` model identifier (similar to existing iOS code).
- On Windows, it's either manufacturer specific model ID (on laptops with OEM Windows install) or motherboard name (on custom desktop builds), probably less useful, but still better than `GenericDevice`.