### PR TITLE
Add minimum size to some debugger elements

### DIFF
--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -393,10 +393,14 @@ EditorPerformanceProfiler::EditorPerformanceProfiler() {
 	set_split_offset(340 * EDSCALE);
 
 	monitor_tree = memnew(Tree);
+	monitor_tree->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
 	monitor_tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	monitor_tree->set_columns(2);
 	monitor_tree->set_column_title(0, TTR("Monitor"));
+	monitor_tree->set_column_expand(0, true);
 	monitor_tree->set_column_title(1, TTR("Value"));
+	monitor_tree->set_column_custom_minimum_width(1, 100 * EDSCALE);
+	monitor_tree->set_column_expand(1, false);
 	monitor_tree->set_column_titles_visible(true);
 	monitor_tree->connect("item_edited", callable_mp(this, &EditorPerformanceProfiler::_monitor_select));
 	monitor_tree->create_item();
@@ -404,6 +408,7 @@ EditorPerformanceProfiler::EditorPerformanceProfiler() {
 	add_child(monitor_tree);
 
 	monitor_draw = memnew(Control);
+	monitor_draw->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
 	monitor_draw->set_clip_contents(true);
 	monitor_draw->connect(SceneStringName(draw), callable_mp(this, &EditorPerformanceProfiler::_monitor_draw));
 	monitor_draw->connect(SceneStringName(gui_input), callable_mp(this, &EditorPerformanceProfiler::_marker_input));

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -715,6 +715,7 @@ EditorProfiler::EditorProfiler() {
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
 
 	graph = memnew(TextureRect);
+	graph->set_custom_minimum_size(Size2(250 * EDSCALE, 0));
 	graph->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
 	graph->connect(SceneStringName(draw), callable_mp(this, &EditorProfiler::_graph_tex_draw));

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -810,6 +810,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
 
 	graph = memnew(TextureRect);
+	graph->set_custom_minimum_size(Size2(250 * EDSCALE, 0));
 	graph->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
 	graph->connect(SceneStringName(draw), callable_mp(this, &EditorVisualProfiler::_graph_tex_draw));

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1915,6 +1915,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		threads->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditorDebugger::_select_thread));
 
 		stack_dump = memnew(Tree);
+		stack_dump->set_custom_minimum_size(Size2(150, 0) * EDSCALE);
 		stack_dump->set_allow_reselect(true);
 		stack_dump->set_columns(1);
 		stack_dump->set_column_titles_visible(true);
@@ -1925,6 +1926,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		stack_vb->add_child(stack_dump);
 
 		VBoxContainer *inspector_vbox = memnew(VBoxContainer);
+		inspector_vbox->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 		inspector_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
 		sc->add_child(inspector_vbox);
 
@@ -1950,6 +1952,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		inspector_vbox->add_child(inspector);
 
 		breakpoints_tree = memnew(Tree);
+		breakpoints_tree->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 		breakpoints_tree->set_h_size_flags(SIZE_EXPAND_FILL);
 		breakpoints_tree->set_column_titles_visible(true);
 		breakpoints_tree->set_column_title(0, TTR("Breakpoints"));


### PR DESCRIPTION
Fixes how certain parts of the debuggers can be shrunk down to disappear, to look really messed up, or to be drawn wrong. Fixes #97786

![image](https://github.com/user-attachments/assets/e2871acc-184e-4225-990d-b9ee46abdae1)

![image](https://github.com/user-attachments/assets/d91d96fd-86da-4aad-8ad7-5c68ab669f2f)

![image](https://github.com/user-attachments/assets/266edbc4-b65a-46e3-806c-06df244ced4d)
