### PR TITLE
Add a github runner check for single commits. 

### DIFF
--- a/.github/workflows/check-single-commit.yml
+++ b/.github/workflows/check-single-commit.yml
@@ -1,0 +1,21 @@
+name: ⓵ Is single-commit PR
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-single-commit
+  cancel-in-progress: true
+
+jobs:
+  static-checks:
+    name: Is single-commit PR
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 'Is single-commit PR'
+        env:
+          COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+        run: |
+          if [ "$COMMIT_COUNT" -ne 1 ]; then
+            echo "Please squash your PR into a single commit. See: https://docs.godotengine.org/en/stable/contributing/workflow/pr_workflow.html"
+            exit 1
+          fi

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -13,6 +13,11 @@ jobs:
     name: 📊 Static checks
     uses: ./.github/workflows/static_checks.yml
 
+  single-commit:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: ⓵ Is single-commit PR
+    uses: ./.github/workflows/check-single-commit.yml
+
   # Second stage: Run all the builds and some of the tests.
 
   android-build:


### PR DESCRIPTION
Pull requests that are composed of more than one commit will now fail tests, and the error message will link to the PR workflow.

Related to https://github.com/godotengine/godot-proposals/issues/11030 - since there seems to be no desire to change workflows, we might as well embrace it and automate the workflow a bit.