### PR TITLE
GDExtension: Check if class without recreate callback is creatable, before marking whole extension as unreloadable

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -410,8 +410,16 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 	}
 
 	if (self->reloadable && p_extension_funcs->recreate_instance_func == nullptr) {
-		ERR_PRINT(vformat("Extension marked as reloadable, but attempted to register class '%s' which doesn't support reloading. Perhaps your language binding don't support it? Reloading disabled for this extension.", class_name));
-		self->reloadable = false;
+		bool can_create_class = (bool)p_extension_funcs->create_instance_func;
+#ifndef DISABLE_DEPRECATED
+		if (!can_create_class && p_deprecated_funcs) {
+			can_create_class = (bool)p_deprecated_funcs->create_instance_func;
+		}
+#endif
+		if (can_create_class) {
+			ERR_PRINT(vformat("Extension marked as reloadable, but attempted to register class '%s' which doesn't support reloading. Perhaps your language binding don't support it? Reloading disabled for this extension.", class_name));
+			self->reloadable = false;
+		}
 	}
 
 	extension->gdextension.library = self;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96823

~~Marking as a draft for now, because I haven't had a chance to do any testing with it yet (and this isn't something covered in our automated tests).~~

If anyone else has time to test before I get to it, it'd be appreciated!

**UPDATE (2025-06-09):** @Bromeon tested it with the Rust bindings, so no longer draft