### PR TITLE
SCons: Bump minimum version of SCons to 4.0 & Python to 3.8

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -27,6 +27,5 @@ runs:
       shell: bash
       run: |
         python -c "import sys; print(sys.version)"
-        python -m pip install wheel
         python -m pip install scons==${{ inputs.scons-version }}
         scons --version

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -17,8 +17,8 @@ concurrency:
 
 jobs:
   build-linux:
-    # If unspecified, stay one LTS before latest to increase portability of Linux artifacts.
-    runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
+    # Stay one LTS before latest to increase portability of Linux artifacts.
+    runs-on: ubuntu-22.04
     name: ${{ matrix.name }}
     strategy:
       fail-fast: false
@@ -61,8 +61,6 @@ jobs:
             artifact: false
             # Test our oldest supported SCons/Python versions on one arbitrary editor build.
             legacy-scons: true
-            # Python 3.6 unavailable on 22.04.
-            os: ubuntu-20.04
 
           - name: Editor with ThreadSanitizer (target=editor, tests=yes, dev_build=yes, use_tsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-thread-sanitizer
@@ -132,8 +130,8 @@ jobs:
         uses: ./.github/actions/godot-deps
         with:
           # Sync with Ensure*Version in SConstruct.
-          python-version: 3.6
-          scons-version: 3.1.2
+          python-version: 3.8
+          scons-version: 4.0
 
       - name: Setup GCC problem matcher
         uses: ammaraskar/gcc-problem-matcher@master

--- a/SConstruct
+++ b/SConstruct
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
-EnsureSConsVersion(3, 1, 2)
-EnsurePythonVersion(3, 6)
+EnsureSConsVersion(4, 0)
+EnsurePythonVersion(3, 8)
 
 # System
 import atexit
@@ -1060,13 +1060,6 @@ if env["vsproj"]:
     env.vs_srcs = []
 
 if env["compiledb"]:
-    if env.scons_version < (4, 0, 0):
-        # Generating the compilation DB (`compile_commands.json`) requires SCons 4.0.0 or later.
-        print_error(
-            "The `compiledb=yes` option requires SCons 4.0 or later, but your version is %s." % scons_raw_version
-        )
-        Exit(255)
-
     env.Tool("compilation_db")
     env.Alias("compiledb", env.CompilationDatabase())
 

--- a/methods.py
+++ b/methods.py
@@ -409,8 +409,7 @@ def use_windows_spawn_fix(self, platform=None):
             "shell": False,
             "env": env,
         }
-        if sys.version_info >= (3, 7, 0):
-            popen_args["text"] = True
+        popen_args["text"] = True
         proc = subprocess.Popen(cmdline, **popen_args)
         _, err = proc.communicate()
         rv = proc.wait()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python_version = "3.8"
 extend-exclude = ["thirdparty"]
 extend-include = ["SConstruct", "SCsub"]
 line-length = 120
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
- Supersedes #85968
- Supersedes #98907

As discussed in this RocketChat thread[^1], the bump to Ubuntu 22.04 for our GitHub Actions have raised the lower bounds of support for both Python and SCons. As our current minimum versions for both (3.1.2 for SCons & 3.6 for Python) are *well* into EOL as-is, it feels ideal to bump the versions in tandem. In contrast to previous PRs trying to have other changes in tandem, this is *strictly* focused on bumping the minimum versions

Immediate benefits include:
- Having a minimum Python version that matches the minimum supported version for mypy.
- Bumping Ruff's minimum version to 3.8 as well, now matching versions
- Single baseline OS for Linux builds

[^1]:https://chat.godotengine.org/channel/buildsystem?msg=Wuq39TCvaHTSiSAuL