### PR TITLE
Replace default deadzone magic number with named constant and fix `InputEventJoypadMotion::set_axis_value` unresponsiveness

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1408,7 +1408,7 @@ void ProjectSettings::_add_builtin_input_map() {
 			}
 
 			Dictionary action;
-			action["deadzone"] = Variant(0.2f);
+			action["deadzone"] = Variant(InputMap::DEFAULT_DEADZONE);
 			action["events"] = events;
 
 			String action_name = "input/" + E.key;

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1097,7 +1097,7 @@ JoyAxis InputEventJoypadMotion::get_axis() const {
 
 void InputEventJoypadMotion::set_axis_value(float p_value) {
 	axis_value = p_value;
-	pressed = Math::abs(axis_value) >= 0.5f;
+	pressed = Math::abs(axis_value) >= InputMap::DEFAULT_DEADZONE;
 	emit_changed();
 }
 

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -42,7 +42,7 @@ InputMap *InputMap::singleton = nullptr;
 void InputMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_action", "action"), &InputMap::has_action);
 	ClassDB::bind_method(D_METHOD("get_actions"), &InputMap::_get_actions);
-	ClassDB::bind_method(D_METHOD("add_action", "action", "deadzone"), &InputMap::add_action, DEFVAL(0.2f));
+	ClassDB::bind_method(D_METHOD("add_action", "action", "deadzone"), &InputMap::add_action, DEFVAL(DEFAULT_DEADZONE));
 	ClassDB::bind_method(D_METHOD("erase_action", "action"), &InputMap::erase_action);
 
 	ClassDB::bind_method(D_METHOD("action_set_deadzone", "action", "deadzone"), &InputMap::action_set_deadzone);
@@ -305,7 +305,7 @@ void InputMap::load_from_project_settings() {
 		String name = pi.name.substr(pi.name.find("/") + 1, pi.name.length());
 
 		Dictionary action = GLOBAL_GET(pi.name);
-		float deadzone = action.has("deadzone") ? (float)action["deadzone"] : 0.2f;
+		float deadzone = action.has("deadzone") ? (float)action["deadzone"] : DEFAULT_DEADZONE;
 		Array events = action["events"];
 
 		add_action(name, deadzone);

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -49,6 +49,8 @@ public:
 		List<Ref<InputEvent>> inputs;
 	};
 
+	static constexpr float DEFAULT_DEADZONE = 0.2f;
+
 private:
 	static InputMap *singleton;
 
@@ -74,7 +76,7 @@ public:
 
 	bool has_action(const StringName &p_action) const;
 	List<StringName> get_actions() const;
-	void add_action(const StringName &p_action, float p_deadzone = 0.2);
+	void add_action(const StringName &p_action, float p_deadzone = DEFAULT_DEADZONE);
 	void erase_action(const StringName &p_action);
 
 	float action_get_deadzone(const StringName &p_action);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -31,6 +31,7 @@
 #include "project_settings_editor.h"
 
 #include "core/config/project_settings.h"
+#include "core/input/input_map.h"
 #include "editor/editor_inspector.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
@@ -390,7 +391,7 @@ void ProjectSettingsEditor::_action_added(const String &p_name) {
 
 	Dictionary action;
 	action["events"] = Array();
-	action["deadzone"] = 0.2f;
+	action["deadzone"] = InputMap::DEFAULT_DEADZONE;
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add Input Action"));


### PR DESCRIPTION
Closes #98982.

In #97281, the default deadzone for input actions was changed from 0.5 to 0.2. Apparently this instance of 0.5 slipped through the cracks, so controller sticks were often not surpassing the threshold for their action to be considered "pressed".

The PR now replaces all instances of the 0.2 default deadzone magic number (that I know of) with a constant, `InputMap::DEFAULT_DEADZONE`. This way, if something necessitates changing the value again, it only has to be changed in one spot, and additionally we know what the value means when looking through the code.

~~Currently, the PR fixes this instance of the deadzone value. In the long run, I think it might be best to replace this magic number and all of the instances of 0.2 with a deadzone constant, but I'm not sure where exactly in the Godot code such a constant would go, so that it can be accessed from everywhere it needs to be. If that sounds like a good idea, I would appreciate advice on where to put it 😄~~
