### PR TITLE
Clarify effect of setting "page" parameter in ScrollBar nodes

### DIFF
--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -54,7 +54,7 @@
 			Minimum value. Range is clamped if [member value] is less than [member min_value].
 		</member>
 		<member name="page" type="float" setter="set_page" getter="get_page" default="0.0">
-			Page size. Used mainly for [ScrollBar]. ScrollBar's length is its size multiplied by [member page] over the difference between [member min_value] and [member max_value].
+			Page size. Used mainly for [ScrollBar]. ScrollBar's grabber length is ScrollBar's size multiplied by [member page] over the difference between [member min_value] and [member max_value].
 		</member>
 		<member name="ratio" type="float" setter="set_as_ratio" getter="get_as_ratio">
 			The value mapped between 0 and 1.

--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -54,7 +54,7 @@
 			Minimum value. Range is clamped if [member value] is less than [member min_value].
 		</member>
 		<member name="page" type="float" setter="set_page" getter="get_page" default="0.0">
-			Page size. Used mainly for [ScrollBar]. ScrollBar's grabber length is ScrollBar's size multiplied by [member page] over the difference between [member min_value] and [member max_value].
+			Page size. Used mainly for [ScrollBar]. A [ScrollBar]'s grabber length is the [ScrollBar]'s size multiplied by [member page] over the difference between [member min_value] and [member max_value].
 		</member>
 		<member name="ratio" type="float" setter="set_as_ratio" getter="get_as_ratio">
 			The value mapped between 0 and 1.


### PR DESCRIPTION
Setting `page` affects the ScrollBar's _grabber_ length, not the ScrollBar node itself. 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
