### PR TITLE
Fix crash when inserting keyframes with empty properties array

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2724,7 +2724,7 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, EditorIn
 	for (const EditorInspectorPlugin::AddedEditor &F : ped->added_editors) {
 		EditorProperty *ep = Object::cast_to<EditorProperty>(F.property_editor);
 
-		if (ep && current_favorites.has(F.properties[0])) {
+		if (ep && !F.properties.is_empty() && current_favorites.has(F.properties[0])) {
 			ep->favorited = true;
 			favorites_vbox->add_child(F.property_editor);
 		} else {


### PR DESCRIPTION
# Fix crash when inserting keyframes with empty properties array

*Bugsquad edit:*
- ~Fixes (for 4.4) #98751 (Crash when inserting rotation keyframe)~
  Doesn't seem to be the case, the issue just sounds related.
- Fixes #99249.

## Description

When inserting rotation keyframes in the animation editor, clicking on the keyframe would cause the editor to crash due to an Array out-of-bound error. Upon further inspection using coredumpctl it seems to be crashing from a out-of-bounds index on editor_inspector.cpp:2727, with accessing `F.properties[0]` without checking if the properties array is empty could cause a crash. This is accessed to see if the property is in the favorites list. However, if an element such as AnimationTrackKeyEdit does not have any properties that can be favorited. This PR adds a safety check to prevent accessing an empty array.

## Modified Files

- `editor/editor_inspector.cpp`

## Changes

The following changes prevent the crash by adding an empty check before accessing the properties array:

```cpp
EditorProperty ***ep = Object::cast_to<EditorProperty>(F.property_editor);
- if (ep && current_favorites.has(F.properties[0])) {
+ if (ep && !F.properties.is_empty() && current_favorites.has(F.properties[0])) {
    ep->favorited = true;
    favorites_vbox->add_child(F.property_editor);
} else {
    current_vbox->add_child(F.property_editor);
}
```

## Testing

Tested with the provided reproduction case:
1. Imported the FBX model from the reproduction case
2. Created a new inherited scene
3. Added animation track as child to Skeleton3D
4. Created new animation
5. Added upper_arm.L and upper_arm.R rotation to track
6. Successfully inserted keyframe without crash

Tested on:
- Godot v4.4.dev
- Arch Linux x86_64 GNOME 47.1 Kernel: 6.11.6-arch1-1
- CPU: 12th Gen Intel i7-1260P (16) @ 4.700GHz 
- GPU: Intel Alder Lake-P GT2 [Iris Xe Graphics]

## Notes

The crash occurred because the properties array could be empty when attempting to insert certain types of keyframes in the animation editor. This fix ensures we check for empty arrays before accessing their elements, following proper array bounds checking practices.