### PR TITLE
GDScript: Fix `Callable` call error text

### DIFF
--- a/core/variant/variant_callable.cpp
+++ b/core/variant/variant_callable.cpp
@@ -45,7 +45,7 @@ uint32_t VariantCallable::hash() const {
 }
 
 String VariantCallable::get_as_text() const {
-	return vformat("%s::%s (Callable)", Variant::get_type_name(variant.get_type()), method);
+	return vformat("%s::%s", Variant::get_type_name(variant.get_type()), method);
 }
 
 CallableCustom::CompareEqualFunc VariantCallable::get_compare_equal_func() const {

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -551,7 +551,8 @@ private:
 	} profile;
 #endif
 
-	_FORCE_INLINE_ String _get_call_error(const String &p_where, const Variant **p_argptrs, const Variant &p_ret, const Callable::CallError &p_err) const;
+	String _get_call_error(const String &p_where, const Variant **p_argptrs, int p_argcount, const Variant &p_ret, const Callable::CallError &p_err) const;
+	String _get_callable_call_error(const String &p_where, const Callable &p_callable, const Variant **p_argptrs, int p_argcount, const Variant &p_ret, const Callable::CallError &p_err) const;
 	Variant _get_default_variant_for_data_type(const GDScriptDataType &p_data_type);
 
 public:

--- a/modules/gdscript/gdscript_utility_callable.cpp
+++ b/modules/gdscript/gdscript_utility_callable.cpp
@@ -55,7 +55,7 @@ String GDScriptUtilityCallable::get_as_text() const {
 			scope = "@GDScript";
 			break;
 	}
-	return vformat("%s::%s (Callable)", scope, function_name);
+	return vformat("%s::%s", scope, function_name);
 }
 
 CallableCustom::CompareEqualFunc GDScriptUtilityCallable::get_compare_equal_func() const {

--- a/modules/gdscript/tests/scripts/runtime/errors/callable_call_invalid_arg_type.gd
+++ b/modules/gdscript/tests/scripts/runtime/errors/callable_call_invalid_arg_type.gd
@@ -1,0 +1,3 @@
+#debug-only
+func test():
+	print(load.bind([]).call())

--- a/modules/gdscript/tests/scripts/runtime/errors/callable_call_invalid_arg_type.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/callable_call_invalid_arg_type.out
@@ -1,0 +1,2 @@
+GDTEST_RUNTIME_ERROR
+>> SCRIPT ERROR at runtime/errors/callable_call_invalid_arg_type.gd:3 on test(): Invalid type in function '@GDScript::load (Callable)'. Cannot convert argument 1 from Array to String.

--- a/modules/gdscript/tests/scripts/runtime/features/utility_func_as_callable.out
+++ b/modules/gdscript/tests/scripts/runtime/features/utility_func_as_callable.out
@@ -1,6 +1,6 @@
 GDTEST_OK
-@GlobalScope::print (Callable)
-@GDScript::len (Callable)
+@GlobalScope::print
+@GDScript::len
 1 2 3
 1
 3


### PR DESCRIPTION
```gdscript
extends Node

func _ready() -> void:
    print(load.bind([]).call())
```

Before:

```
Invalid type in function '@GDScript::load (Callable) (Callable)'. Cannot convert argument 1 from Callable to String.
```

After:

```
Invalid type in function '@GDScript::load (Callable)'. Cannot convert argument 1 from Array to String.
```

`GDScriptFunction::_get_call_error()` is an extension of `Variant::get_call_error_text()`, so a `Callable` version is needed for GDScript, just like `Variant::get_callable_error_text()`. Perhaps in the future we should refactor this.

https://github.com/godotengine/godot/blob/cb411fa960f0b7fdbd97dcdb4c90f9346360ee0e/core/variant/variant.cpp#L3629-L3684