### PR TITLE
OpenXR: Fix pose recenter signal to be omitted properly

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2036,8 +2036,9 @@ bool OpenXRAPI::poll_events() {
 				if (local_floor_emulation.enabled) {
 					local_floor_emulation.should_reset_floor_height = true;
 				}
-				if (event->poseValid && xr_interface) {
-					xr_interface->on_pose_recentered();
+
+				if (xr_interface) {
+					xr_interface->on_reference_space_change_pending();
 				}
 			} break;
 			case XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED: {

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -1134,6 +1134,12 @@ void OpenXRInterface::process() {
 	if (head.is_valid()) {
 		head->set_pose("default", head_transform, head_linear_velocity, head_angular_velocity, head_confidence);
 	}
+
+	if (reference_stage_changing) {
+		// Now that we have updated tracking information in our updated reference space, trigger our pose recentered signal.
+		emit_signal(SNAME("pose_recentered"));
+		reference_stage_changing = false;
+	}
 }
 
 void OpenXRInterface::pre_render() {
@@ -1315,8 +1321,8 @@ void OpenXRInterface::on_state_exiting() {
 	emit_signal(SNAME("instance_exiting"));
 }
 
-void OpenXRInterface::on_pose_recentered() {
-	emit_signal(SNAME("pose_recentered"));
+void OpenXRInterface::on_reference_space_change_pending() {
+	reference_stage_changing = true;
 }
 
 void OpenXRInterface::on_refresh_rate_changes(float p_new_rate) {

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -70,6 +70,7 @@ class OpenXRInterface : public XRInterface {
 private:
 	OpenXRAPI *openxr_api = nullptr;
 	bool initialized = false;
+	bool reference_stage_changing = false;
 	XRInterface::TrackingStatus tracking_state;
 
 	// At a minimum we need a tracker for our head
@@ -207,7 +208,7 @@ public:
 	void on_state_stopping();
 	void on_state_loss_pending();
 	void on_state_exiting();
-	void on_pose_recentered();
+	void on_reference_space_change_pending();
 	void on_refresh_rate_changes(float p_new_rate);
 	void tracker_profile_changed(RID p_tracker, RID p_interaction_profile);
 


### PR DESCRIPTION
This fixes the pose recenter logic in the OpenXR interface.

To test use: https://github.com/godotengine/godot-demo-projects/pull/1131

Fixes https://github.com/godotengine/godot/issues/99157
