### PR TITLE
Normalize normal, tangent, and binormal before interpolating in the mobile renderer to avoid precision errors on heavily scaled meshes

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -434,12 +434,12 @@ void main() {
 
 	vertex_interp = vertex;
 #ifdef NORMAL_USED
-	normal_interp = normal;
+	normal_interp = normalize(normal);
 #endif
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-	tangent_interp = tangent;
-	binormal_interp = binormal;
+	tangent_interp = normalize(tangent);
+	binormal_interp = normalize(binormal);
 #endif
 
 // VERTEX LIGHTING
@@ -456,13 +456,13 @@ void main() {
 	uvec2 omni_light_indices = instances.data[draw_call.instance_index].omni_lights;
 	for (uint i = 0; i < sc_omni_lights(); i++) {
 		uint light_index = (i > 3) ? ((omni_light_indices.y >> ((i - 4) * 8)) & 0xFF) : ((omni_light_indices.x >> (i * 8)) & 0xFF);
-		light_process_omni_vertex(light_index, vertex, view, normal, roughness, diffuse_light_interp.rgb, specular_light_interp.rgb);
+		light_process_omni_vertex(light_index, vertex, view, normal_interp, roughness, diffuse_light_interp.rgb, specular_light_interp.rgb);
 	}
 
 	uvec2 spot_light_indices = instances.data[draw_call.instance_index].spot_lights;
 	for (uint i = 0; i < sc_spot_lights(); i++) {
 		uint light_index = (i > 3) ? ((spot_light_indices.y >> ((i - 4) * 8)) & 0xFF) : ((spot_light_indices.x >> (i * 8)) & 0xFF);
-		light_process_spot_vertex(light_index, vertex, view, normal, roughness, diffuse_light_interp.rgb, specular_light_interp.rgb);
+		light_process_spot_vertex(light_index, vertex, view, normal_interp, roughness, diffuse_light_interp.rgb, specular_light_interp.rgb);
 	}
 
 	if (sc_directional_lights() > 0) {
@@ -479,13 +479,13 @@ void main() {
 				continue; // Statically baked light and object uses lightmap, skip.
 			}
 			if (i == 0) {
-				light_compute_vertex(normal, directional_lights.data[0].direction, view,
+				light_compute_vertex(normal_interp, directional_lights.data[0].direction, view,
 						directional_lights.data[0].color * directional_lights.data[0].energy,
 						true, roughness,
 						directional_diffuse,
 						directional_specular);
 			} else {
-				light_compute_vertex(normal, directional_lights.data[i].direction, view,
+				light_compute_vertex(normal_interp, directional_lights.data[i].direction, view,
 						directional_lights.data[i].color * directional_lights.data[i].energy,
 						true, roughness,
 						diffuse_light_interp.rgb,


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/89101
Fixes: https://github.com/godotengine/godot/issues/86275
Fixes: https://github.com/godotengine/godot/issues/86707

We interpolate normals using half precision in the Mobile renderer. As a result, very small normals can become corrupted. We can end up with very small normals when using a small scale in a MeshInstance's transform. In all three bug reports large meshes are used with a tiny scale (0.01 or smaller), the tiny scale transforms the normals to also be tiny, then the conversion to half float breaks them.

There are two options to solve that problem:
1. Interpolate with full precision (this is what we do in the Forward+ renderer which is why it doesn't have issues)
2. Normalize the normal before interpolating so it is in a good range

I chose the second option since a single normalize in the vertex shader will be relatively cheap and we need to minimize the amount of varying data that we use as it can easily be a bottleneck on Mobile devices. 