### PR TITLE
[Export] Write text server data from memory, instead of using temporary file.

### DIFF
--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -125,6 +125,12 @@
 				Returns array of core file names that always should be exported regardless of preset config.
 			</description>
 		</method>
+		<method name="get_internal_export_files" qualifiers="static">
+			<return type="Dictionary" />
+			<description>
+				Returns additional files that should always be exported regardless of preset configuration, and are not part of the project source. The returned [Dictionary] contains filename keys ([String]) and their corresponding raw data ([PackedByteArray]).
+			</description>
+		</method>
 		<method name="get_message_category" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="index" type="int" />

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1067,6 +1067,12 @@
 				Returns the name of the server interface.
 			</description>
 		</method>
+		<method name="get_support_data" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+				Returns default TextServer database (e.g. ICU break iterators and dictionaries).
+			</description>
+		</method>
 		<method name="get_support_data_filename" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -1170,6 +1170,13 @@
 				Returns the name of the server interface.
 			</description>
 		</method>
+		<method name="_get_support_data" qualifiers="virtual const">
+			<return type="PackedByteArray" />
+			<description>
+				[b]Optional.[/b]
+				Returns default TextServer database (e.g. ICU break iterators and dictionaries).
+			</description>
+		</method>
 		<method name="_get_support_data_filename" qualifiers="virtual const">
 			<return type="String" />
 			<description>

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -900,6 +900,26 @@ String EditorExportPlatform::_get_script_encryption_key(const Ref<EditorExportPr
 	return p_preset->get_script_encryption_key().to_lower();
 }
 
+Dictionary EditorExportPlatform::get_internal_export_files() {
+	Dictionary files;
+
+	// Text server support data.
+	if (TS->has_feature(TextServer::FEATURE_USE_SUPPORT_DATA) && (bool)GLOBAL_GET("internationalization/locale/include_text_server_data")) {
+		String ts_name = TS->get_support_data_filename();
+		if (!ts_name.is_empty()) {
+			ts_name = "res://" + ts_name;
+			if (!FileAccess::exists(ts_name)) { // Do not include if user supplied data file exist.
+				const PackedByteArray &ts_data = TS->get_support_data();
+				if (!ts_data.is_empty()) {
+					files[ts_name] = ts_data;
+				}
+			}
+		}
+	}
+
+	return files;
+}
+
 Vector<String> EditorExportPlatform::get_forced_export_files() {
 	Vector<String> files;
 
@@ -923,25 +943,13 @@ Vector<String> EditorExportPlatform::get_forced_export_files() {
 		files.push_back(extension_list_config_file);
 	}
 
-	// Store text server data if it is supported.
-	if (TS->has_feature(TextServer::FEATURE_USE_SUPPORT_DATA)) {
-		bool use_data = GLOBAL_GET("internationalization/locale/include_text_server_data");
-		if (use_data) {
-			// Try using user provided data file.
-			if (!TS->get_support_data_filename().is_empty()) {
-				String ts_data = "res://" + TS->get_support_data_filename();
-				if (FileAccess::exists(ts_data)) {
-					files.push_back(ts_data);
-				} else {
-					// Use default text server data.
-					String abs_path = ProjectSettings::get_singleton()->globalize_path(ts_data);
-					ERR_FAIL_COND_V(!TS->save_support_data(abs_path), files);
-					if (FileAccess::exists(abs_path)) {
-						files.push_back(ts_data);
-						// Remove the file later.
-						callable_mp_static(DirAccess::remove_absolute).call_deferred(abs_path);
-					}
-				}
+	// Text server support data.
+	if (TS->has_feature(TextServer::FEATURE_USE_SUPPORT_DATA) && (bool)GLOBAL_GET("internationalization/locale/include_text_server_data")) {
+		String ts_name = TS->get_support_data_filename();
+		if (!ts_name.is_empty()) {
+			ts_name = "res://" + ts_name;
+			if (FileAccess::exists(ts_name)) { // Include user supplied data file.
+				files.push_back(ts_name);
 			}
 		}
 	}
@@ -1505,6 +1513,15 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			array = FileAccess::get_file_as_bytes(forced_export[i]);
 		}
 		err = p_save_func(p_udata, forced_export[i], array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
+		if (err != OK) {
+			return err;
+		}
+	}
+
+	Dictionary int_export = get_internal_export_files();
+	for (const Variant &int_name : int_export.keys()) {
+		const PackedByteArray &array = int_export[int_name];
+		err = p_save_func(p_udata, int_name, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
 		if (err != OK) {
 			return err;
 		}
@@ -2427,6 +2444,7 @@ void EditorExportPlatform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("ssh_push_to_remote", "host", "port", "scp_args", "src_file", "dst_file"), &EditorExportPlatform::ssh_push_to_remote);
 
 	ClassDB::bind_static_method("EditorExportPlatform", D_METHOD("get_forced_export_files"), &EditorExportPlatform::get_forced_export_files);
+	ClassDB::bind_static_method("EditorExportPlatform", D_METHOD("get_internal_export_files"), &EditorExportPlatform::get_internal_export_files);
 
 	BIND_ENUM_CONSTANT(EXPORT_MESSAGE_NONE);
 	BIND_ENUM_CONSTANT(EXPORT_MESSAGE_INFO);

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -277,6 +277,7 @@ public:
 		return worst_type;
 	}
 
+	static Dictionary get_internal_export_files();
 	static Vector<String> get_forced_export_files();
 
 	virtual bool fill_log_messages(RichTextLabel *p_log, Error p_err);

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -500,6 +500,20 @@ bool TextServerAdvanced::_save_support_data(const String &p_filename) const {
 #endif
 }
 
+PackedByteArray TextServerAdvanced::_get_support_data() const {
+	_THREAD_SAFE_METHOD_
+#ifdef ICU_STATIC_DATA
+
+	PackedByteArray icu_data_static;
+	icu_data_static.resize(U_ICUDATA_SIZE);
+	memcpy(icu_data_static.ptrw(), U_ICUDATA_ENTRY_POINT, U_ICUDATA_SIZE);
+
+	return icu_data_static;
+#else
+	return icu_data;
+#endif
+}
+
 bool TextServerAdvanced::_is_locale_right_to_left(const String &p_locale) const {
 	String l = p_locale.get_slicec('_', 0);
 	if ((l == "ar") || (l == "dv") || (l == "he") || (l == "fa") || (l == "ff") || (l == "ku") || (l == "ur")) {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -732,6 +732,7 @@ public:
 	MODBIND0RC(String, get_support_data_filename);
 	MODBIND0RC(String, get_support_data_info);
 	MODBIND1RC(bool, save_support_data, const String &);
+	MODBIND0RC(PackedByteArray, get_support_data);
 
 	MODBIND1RC(bool, is_locale_right_to_left, const String &);
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -170,6 +170,10 @@ bool TextServerFallback::_save_support_data(const String &p_filename) const {
 	return false; // No extra data used.
 }
 
+PackedByteArray TextServerFallback::_get_support_data() const {
+	return PackedByteArray(); // No extra data used.
+}
+
 bool TextServerFallback::_is_locale_right_to_left(const String &p_locale) const {
 	return false; // No RTL support.
 }

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -592,6 +592,7 @@ public:
 	MODBIND0RC(String, get_support_data_filename);
 	MODBIND0RC(String, get_support_data_info);
 	MODBIND1RC(bool, save_support_data, const String &);
+	MODBIND0RC(PackedByteArray, get_support_data);
 
 	MODBIND1RC(bool, is_locale_right_to_left, const String &);
 

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -42,6 +42,7 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_support_data_filename);
 	GDVIRTUAL_BIND(_get_support_data_info);
 	GDVIRTUAL_BIND(_save_support_data, "filename");
+	GDVIRTUAL_BIND(_get_support_data);
 
 	GDVIRTUAL_BIND(_is_locale_right_to_left, "locale");
 
@@ -399,6 +400,12 @@ String TextServerExtension::get_support_data_info() const {
 bool TextServerExtension::save_support_data(const String &p_filename) const {
 	bool ret = false;
 	GDVIRTUAL_CALL(_save_support_data, p_filename, ret);
+	return ret;
+}
+
+PackedByteArray TextServerExtension::get_support_data() const {
+	PackedByteArray ret;
+	GDVIRTUAL_CALL(_get_support_data, ret);
 	return ret;
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -63,9 +63,11 @@ public:
 	virtual String get_support_data_filename() const override;
 	virtual String get_support_data_info() const override;
 	virtual bool save_support_data(const String &p_filename) const override;
+	virtual PackedByteArray get_support_data() const override;
 	GDVIRTUAL0RC(String, _get_support_data_filename);
 	GDVIRTUAL0RC(String, _get_support_data_info);
 	GDVIRTUAL1RC(bool, _save_support_data, const String &);
+	GDVIRTUAL0RC(PackedByteArray, _get_support_data);
 
 	virtual bool is_locale_right_to_left(const String &p_locale) const override;
 	GDVIRTUAL1RC(bool, _is_locale_right_to_left, const String &);

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -196,6 +196,7 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_support_data_filename"), &TextServer::get_support_data_filename);
 	ClassDB::bind_method(D_METHOD("get_support_data_info"), &TextServer::get_support_data_info);
 	ClassDB::bind_method(D_METHOD("save_support_data", "filename"), &TextServer::save_support_data);
+	ClassDB::bind_method(D_METHOD("get_support_data"), &TextServer::get_support_data);
 
 	ClassDB::bind_method(D_METHOD("is_locale_right_to_left", "locale"), &TextServer::is_locale_right_to_left);
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -244,6 +244,7 @@ public:
 	virtual String get_support_data_filename() const = 0;
 	virtual String get_support_data_info() const = 0;
 	virtual bool save_support_data(const String &p_filename) const = 0;
+	virtual PackedByteArray get_support_data() const = 0;
 
 	virtual bool is_locale_right_to_left(const String &p_locale) const = 0;
 


### PR DESCRIPTION
Write text server (ICU) data directly to PCK/ZIP, using `PackedByteArray` instead of saving it to disk and reading back (removes unnecessary disk operations, ensures temporary file is not prematurely deleted).