### PR TITLE
Fix `PackedData::has_path()` using wrong path format.

### DIFF
--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -205,7 +205,7 @@ Ref<FileAccess> PackedData::try_open_path(const String &p_path) {
 }
 
 bool PackedData::has_path(const String &p_path) {
-	return files.has(PathMD5(p_path.simplify_path().md5_buffer()));
+	return files.has(PathMD5(p_path.simplify_path().trim_prefix("res://").md5_buffer()));
 }
 
 bool PackedData::has_directory(const String &p_path) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/99151 (regression from https://github.com/godotengine/godot/pull/97356, one of the places using path hash was not updated).
