### PR TITLE
Fix obstacle avoidance and 3D editor ignoring transform

### DIFF
--- a/scene/2d/navigation_obstacle_2d.h
+++ b/scene/2d/navigation_obstacle_2d.h
@@ -111,6 +111,7 @@ public:
 private:
 	void _update_map(RID p_map);
 	void _update_position(const Vector2 p_position);
+	void _update_transform();
 };
 
 #endif // NAVIGATION_OBSTACLE_2D_H

--- a/scene/3d/navigation_obstacle_3d.h
+++ b/scene/3d/navigation_obstacle_3d.h
@@ -121,6 +121,7 @@ public:
 private:
 	void _update_map(RID p_map);
 	void _update_position(const Vector3 p_position);
+	void _update_transform();
 	void _update_use_3d_avoidance(bool p_use_3d_avoidance);
 };
 


### PR DESCRIPTION
Follow up PR to #96730, #93059, and #99030

- [X] Update the new NavigationObstacle3D editor plugin debug visuals to respect the node transform
- [X] Fix oversight of my previous PRs where the obstacle's node transform is ignored when registering its vertices on the NavigationServer
- [X] Clean up, optimize, and comment code (done, but could probably be improved further)