### PR TITLE
Make `delay_usec` more precise on Windows to fix framepacing (reverted)

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -769,10 +769,22 @@ double OS_Windows::get_unix_time() const {
 }
 
 void OS_Windows::delay_usec(uint32_t p_usec) const {
-	if (p_usec < 1000) {
-		Sleep(1);
-	} else {
-		Sleep(p_usec / 1000);
+	constexpr uint32_t tolerance = 1000 + 20;
+
+	uint64_t t0 = get_ticks_usec();
+	uint64_t target_time = t0 + p_usec;
+
+	// Calculate sleep duration with a tolerance for fine-tuning.
+	if (p_usec > tolerance) {
+		uint32_t coarse_sleep_usec = p_usec - tolerance;
+		if (coarse_sleep_usec >= 1000) {
+			Sleep(coarse_sleep_usec / 1000);
+		}
+	}
+
+	// Spin-wait until we reach the precise target time.
+	while (get_ticks_usec() < target_time) {
+		YieldProcessor();
 	}
 }
 


### PR DESCRIPTION
- *Production edit: Follow-up to https://github.com/godotengine/godot/pull/99041.*

Addresses inaccurate framepacing issues on Windows.
Based on these articles:

https://blog.bearcats.nl/accurate-sleep-function/
https://blog.bearcats.nl/perfect-sleep-function/