### PR TITLE
Improve editor file dialog options

### DIFF
--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -39,6 +39,7 @@
 class DependencyRemoveDialog;
 class GridContainer;
 class HSplitContainer;
+class HFlowContainer;
 class ItemList;
 class MenuButton;
 class OptionButton;
@@ -94,7 +95,8 @@ private:
 	Button *makedir = nullptr;
 	Access access = ACCESS_RESOURCES;
 
-	GridContainer *grid_options = nullptr;
+	HFlowContainer *flow_checkbox_options = nullptr;
+	GridContainer *grid_select_options = nullptr;
 	VBoxContainer *vbox = nullptr;
 	FileMode mode = FILE_MODE_SAVE_FILE;
 	bool can_create_dir = false;


### PR DESCRIPTION
Fixes #95079.
While fixing the check boxes not being clickable, it improves the layout to be more space efficient and clean.


### Alternatives

- #97892
  This PR looks the same as that one for dialogs with Checkboxes only. That PR has the issue that labels for OptionButtons would be directly next to the labels of a previous Checkbox. This PR puts the OptionButtons separately to mitigate that issue.
- #95140
  That PR uses CheckButtons which do not fit semantically. Also does not show options next to each other, wasting space.
- #95304
  Does not handle OptionButton options well.


### Screenshots

Current:
![image](https://github.com/user-attachments/assets/856cb5e5-3554-4e34-9c5a-f284b0c2a45f)

New:
![image](https://github.com/user-attachments/assets/f55bd2eb-0083-41b7-beeb-d0c5b7f54b41)

New with Checkboxes and OptionButtons:
![image](https://github.com/user-attachments/assets/bc8ddfbf-49a8-484d-9c38-e162e521968f)

One notable change is that the checkboxes will always be displayed above the OptionButtons, which I think is fine here. I could not come up with a case where it's strictly necessary to retain the order between the options.