### PR TITLE
Fix `format` description being different between String and StringName

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -248,7 +248,7 @@
 			<param index="1" name="placeholder" type="String" default="&quot;{_}&quot;" />
 			<description>
 				Formats the string by replacing all occurrences of [param placeholder] with the elements of [param values].
-				[param values] can be a [Dictionary], an [Array] or an [Object]. Any underscores in [param placeholder] will be replaced with the corresponding keys in advance. Array elements use their index as keys.
+				[param values] can be a [Dictionary], an [Array], or an [Object]. Any underscores in [param placeholder] will be replaced with the corresponding keys in advance. Array elements use their index as keys.
 				[codeblock]
 				# Prints "Waiting for Godot is a play by Samuel Beckett, and Godot Engine is named after it."
 				var use_array_values = "Waiting for {0} is a play by {1}, and {0} Engine is named after it."
@@ -265,7 +265,7 @@
 				[/codeblock]
 				When passing an [Object], the property names from [method Object.get_property_list] are used as keys.
 				[codeblock]
-				# Prints: Visible true, position (0, 0).
+				# Prints "Visible true, position (0, 0)"
 				var node = Node2D.new()
 				print("Visible {visible}, position {position}".format(node))
 				[/codeblock]

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -231,7 +231,7 @@
 			<param index="1" name="placeholder" type="String" default="&quot;{_}&quot;" />
 			<description>
 				Formats the string by replacing all occurrences of [param placeholder] with the elements of [param values].
-				[param values] can be a [Dictionary] or an [Array]. Any underscores in [param placeholder] will be replaced with the corresponding keys in advance. Array elements use their index as keys.
+				[param values] can be a [Dictionary], an [Array], or an [Object]. Any underscores in [param placeholder] will be replaced with the corresponding keys in advance. Array elements use their index as keys.
 				[codeblock]
 				# Prints "Waiting for Godot is a play by Samuel Beckett, and Godot Engine is named after it."
 				var use_array_values = "Waiting for {0} is a play by {1}, and {0} Engine is named after it."
@@ -245,6 +245,12 @@
 				# Prints "User 42 is Godot."
 				print("User {} is {}.".format([42, "Godot"], "{}"))
 				print("User {id} is {name}.".format([["id", 42], ["name", "Godot"]]))
+				[/codeblock]
+				When passing an [Object], the property names from [method Object.get_property_list] are used as keys.
+				[codeblock]
+				# Prints "Visible true, position (0, 0)"
+				var node = Node2D.new()
+				print("Visible {visible}, position {position}".format(node))
 				[/codeblock]
 				See also the [url=$DOCS_URL/tutorials/scripting/gdscript/gdscript_format_string.html]GDScript format string[/url] tutorial.
 				[b]Note:[/b] Each replacement is done sequentially for each element of [param values], [b]not[/b] all at once. This means that if any element is inserted and it contains another placeholder, it may be changed by the next replacement. While this can be very useful, it often causes unexpected results. If not necessary, make sure [param values]'s elements do not contain placeholders.


### PR DESCRIPTION
While https://github.com/godotengine/godot/pull/95758 was waiting to be merged https://github.com/godotengine/godot/pull/65962 was merged in the meantime that caused these two to be different _again_.

It would be awesome to automate this, but..