### PR TITLE
Fix `fade_beats` defined as `int` in `audio_stream_interactive.h`

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.h
+++ b/modules/interactive_music/audio_stream_interactive.h
@@ -100,7 +100,7 @@ private:
 		TransitionFromTime from_time = TRANSITION_FROM_TIME_NEXT_BEAT;
 		TransitionToTime to_time = TRANSITION_TO_TIME_START;
 		FadeMode fade_mode = FADE_AUTOMATIC;
-		int fade_beats = 1;
+		float fade_beats = 1;
 		bool use_filler_clip = false;
 		int filler_clip = 0;
 		bool hold_previous = false;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fixes #99172 
changed type in [audio_stream_interactive.h line 103](https://github.com/godotengine/godot/blob/master/modules/interactive_music/audio_stream_interactive.h#L103)