### PR TITLE
GDScript: Add C#-style property setter/getter shorthand

### DIFF
--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -488,9 +488,13 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 							prop_doc.getter = m_var->getter_pointer->name;
 						}
 						break;
+					case GDP::VariableNode::PROP_SHORT:
+						prop_doc.setter = "@" + m_var->identifier->name + "_setter";
+						prop_doc.getter = "@" + m_var->identifier->name + "_getter";
+						break;
 				}
 
-				if (m_var->initializer != nullptr) {
+				if (m_var->initializer != nullptr && m_var->property != GDP::VariableNode::PROP_SHORT) {
 					prop_doc.default_value = _docvalue_from_expression(m_var->initializer);
 				}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1373,7 +1373,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 				E->apply(parser, member.function, p_class);
 			}
 			resolve_function_body(member.function);
-		} else if (member.type == GDScriptParser::ClassNode::Member::VARIABLE && member.variable->property != GDScriptParser::VariableNode::PROP_NONE) {
+		} else if (member.type == GDScriptParser::ClassNode::Member::VARIABLE) {
 			if (member.variable->property == GDScriptParser::VariableNode::PROP_INLINE) {
 				if (member.variable->getter != nullptr) {
 					member.variable->getter->return_type = member.variable->datatype_specifier;
@@ -2961,7 +2961,7 @@ void GDScriptAnalyzer::reduce_assignment(GDScriptParser::AssignmentNode *p_assig
 	if (p_assignment->operation != GDScriptParser::AssignmentNode::OP_NONE && p_assignment->assignee->type == GDScriptParser::Node::IDENTIFIER) {
 		GDScriptParser::IdentifierNode *id = static_cast<GDScriptParser::IdentifierNode *>(p_assignment->assignee);
 		// Use == 1 here because this assignment was already counted in the beginning of the function.
-		if (id->source == GDScriptParser::IdentifierNode::LOCAL_VARIABLE && id->variable_source && id->variable_source->assignments == 1) {
+		if (id->source == GDScriptParser::IdentifierNode::LOCAL_VARIABLE && id->variable_source && id->variable_source->assignments == 1 && !id->variable_source->has_getter()) {
 			parser->push_warning(p_assignment, GDScriptWarning::UNASSIGNED_VARIABLE_OP_ASSIGN, id->name);
 		}
 	}
@@ -4310,7 +4310,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 			p_identifier->set_datatype(p_identifier->variable_source->get_datatype());
 			found_source = true;
 #ifdef DEBUG_ENABLED
-			if (p_identifier->variable_source && p_identifier->variable_source->assignments == 0 && !(p_identifier->get_datatype().is_hard_type() && p_identifier->get_datatype().kind == GDScriptParser::DataType::BUILTIN)) {
+			if (p_identifier->variable_source && p_identifier->variable_source->assignments == 0 && !p_identifier->variable_source->has_getter() && !(p_identifier->get_datatype().is_hard_type() && p_identifier->get_datatype().kind == GDScriptParser::DataType::BUILTIN)) {
 				parser->push_warning(p_identifier, GDScriptWarning::UNASSIGNED_VARIABLE, p_identifier->name);
 			}
 #endif

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2240,20 +2240,15 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Sui
 
 GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready, bool p_for_lambda) {
 	r_error = OK;
-	CodeGen codegen;
-	codegen.generator = memnew(GDScriptByteCodeGenerator);
-
-	codegen.class_node = p_class;
-	codegen.script = p_script;
-	codegen.function_node = p_func;
 
 	StringName func_name;
 	bool is_static = false;
 	Variant rpc_config;
-	GDScriptDataType return_type;
-	return_type.has_type = true;
-	return_type.kind = GDScriptDataType::BUILTIN;
-	return_type.builtin_type = Variant::NIL;
+
+	GDScriptParser::DataType parser_return_type;
+	parser_return_type.kind = GDScriptParser::DataType::BUILTIN;
+	parser_return_type.builtin_type = Variant::NIL;
+	parser_return_type.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
 
 	if (p_func) {
 		if (p_func->identifier) {
@@ -2263,23 +2258,35 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		}
 		is_static = p_func->is_static;
 		rpc_config = p_func->rpc_config;
-		return_type = _gdtype_from_datatype(p_func->get_datatype(), p_script);
+		// If no `return` statement, then return type is `void`, not `Variant`.
+		if (p_func->body->has_return) {
+			parser_return_type = p_func->get_datatype();
+		}
 	} else {
 		if (p_for_ready) {
-			func_name = SceneStringName(_ready);
+			func_name = "@implicit_ready";
 		} else {
 			func_name = "@implicit_new";
 		}
 	}
 
-	MethodInfo method_info;
+	const GDScriptDataType return_type = _gdtype_from_datatype(parser_return_type, p_script);
 
+	CodeGen codegen;
+	codegen.generator = memnew(GDScriptByteCodeGenerator);
+	codegen.script = p_script;
+	codegen.class_node = p_class;
+	codegen.function_node = p_func;
 	codegen.function_name = func_name;
-	method_info.name = func_name;
 	codegen.is_static = is_static;
+
+	MethodInfo method_info;
+	method_info.name = func_name;
+	method_info.return_val = parser_return_type.to_property_info(String());
 	if (is_static) {
 		method_info.flags |= METHOD_FLAG_STATIC;
 	}
+
 	codegen.generator->write_start(p_script, func_name, is_static, rpc_config, return_type);
 
 	int optional_parameters = 0;
@@ -2320,6 +2327,10 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 				continue;
 			}
 
+			if (field->property == GDScriptParser::VariableNode::PROP_SHORT) {
+				continue; // The field is effectively inaccessible.
+			}
+
 			GDScriptDataType field_type = _gdtype_from_datatype(field->get_datatype(), codegen.script);
 			if (field_type.has_type) {
 				codegen.generator->write_newline(field->start_line);
@@ -2345,9 +2356,14 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 			if (p_class->members[i].type != GDScriptParser::ClassNode::Member::VARIABLE) {
 				continue;
 			}
+
 			const GDScriptParser::VariableNode *field = p_class->members[i].variable;
 			if (field->is_static) {
 				continue;
+			}
+
+			if (field->property == GDScriptParser::VariableNode::PROP_SHORT) {
+				continue; // The field is effectively inaccessible.
 			}
 
 			if (field->onready != is_implicit_ready) {
@@ -2445,6 +2461,8 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	}
 
 	GDScriptFunction *gd_function = codegen.generator->write_end();
+	gd_function->return_type = return_type;
+	gd_function->method_info = method_info;
 
 	if (is_initializer) {
 		p_script->initializer = gd_function;
@@ -2453,21 +2471,6 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	} else if (is_implicit_ready) {
 		p_script->implicit_ready = gd_function;
 	}
-
-	if (p_func) {
-		// If no `return` statement, then return type is `void`, not `Variant`.
-		if (p_func->body->has_return) {
-			gd_function->return_type = _gdtype_from_datatype(p_func->get_datatype(), p_script);
-			method_info.return_val = p_func->get_datatype().to_property_info(String());
-		} else {
-			gd_function->return_type = GDScriptDataType();
-			gd_function->return_type.has_type = true;
-			gd_function->return_type.kind = GDScriptDataType::BUILTIN;
-			gd_function->return_type.builtin_type = Variant::NIL;
-		}
-	}
-
-	gd_function->method_info = method_info;
 
 	if (!is_implicit_initializer && !is_implicit_ready && !p_for_lambda) {
 		p_script->member_functions[func_name] = gd_function;
@@ -2478,24 +2481,25 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	return gd_function;
 }
 
-GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class) {
+void GDScriptCompiler::_make_static_initializer(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class) {
 	r_error = OK;
-	CodeGen codegen;
-	codegen.generator = memnew(GDScriptByteCodeGenerator);
-
-	codegen.class_node = p_class;
-	codegen.script = p_script;
 
 	StringName func_name = SNAME("@static_initializer");
 	bool is_static = true;
 	Variant rpc_config;
+
 	GDScriptDataType return_type;
 	return_type.has_type = true;
 	return_type.kind = GDScriptDataType::BUILTIN;
 	return_type.builtin_type = Variant::NIL;
 
+	CodeGen codegen;
+	codegen.generator = memnew(GDScriptByteCodeGenerator);
+	codegen.script = p_script;
+	codegen.class_node = p_class;
 	codegen.function_name = func_name;
 	codegen.is_static = is_static;
+
 	codegen.generator->write_start(p_script, func_name, is_static, rpc_config, return_type);
 
 	// The static initializer is always called on the same class where the static variables are defined,
@@ -2513,6 +2517,10 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 		const GDScriptParser::VariableNode *field = member.variable;
 		if (!field->is_static) {
 			continue;
+		}
+
+		if (field->property == GDScriptParser::VariableNode::PROP_SHORT) {
+			continue; // The field is effectively inaccessible.
 		}
 
 		GDScriptDataType field_type = _gdtype_from_datatype(field->get_datatype(), codegen.script);
@@ -2545,9 +2553,14 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 		if (p_class->members[i].type != GDScriptParser::ClassNode::Member::VARIABLE) {
 			continue;
 		}
+
 		const GDScriptParser::VariableNode *field = p_class->members[i].variable;
 		if (!field->is_static) {
 			continue;
+		}
+
+		if (field->property == GDScriptParser::VariableNode::PROP_SHORT) {
+			continue; // The field is effectively inaccessible.
 		}
 
 		if (field->initializer) {
@@ -2557,7 +2570,7 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 			GDScriptCodeGenerator::Address src_address = _parse_expression(codegen, r_error, field->initializer, false, true);
 			if (r_error) {
 				memdelete(codegen.generator);
-				return nullptr;
+				return;
 			}
 
 			GDScriptDataType field_type = _gdtype_from_datatype(field->get_datatype(), codegen.script);
@@ -2607,26 +2620,137 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 	codegen.generator->set_initial_line(p_class->start_line);
 
 	GDScriptFunction *gd_function = codegen.generator->write_end();
+	gd_function->return_type = return_type;
+
+	p_script->static_initializer = gd_function;
 
 	memdelete(codegen.generator);
+}
 
-	return gd_function;
+void GDScriptCompiler::_make_property_short_setter_getter(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter) {
+	r_error = OK;
+
+	StringName func_name = "@" + p_variable->identifier->name + (p_is_setter ? "_setter" : "_getter");
+	bool is_static = p_variable->is_static;
+	Variant rpc_config;
+
+	GDScriptParser::DataType parser_return_type;
+	if (p_is_setter) {
+		parser_return_type.kind = GDScriptParser::DataType::BUILTIN;
+		parser_return_type.builtin_type = Variant::NIL;
+		parser_return_type.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
+	} else {
+		parser_return_type = p_variable->get_datatype();
+	}
+
+	const GDScriptDataType return_type = _gdtype_from_datatype(parser_return_type, p_script);
+
+	CodeGen codegen;
+	codegen.generator = memnew(GDScriptByteCodeGenerator);
+	codegen.script = p_script;
+	codegen.class_node = p_class;
+	codegen.function_name = func_name;
+	codegen.is_static = is_static;
+
+	MethodInfo method_info;
+	method_info.name = func_name;
+	method_info.return_val = parser_return_type.to_property_info(String());
+	if (is_static) {
+		method_info.flags |= METHOD_FLAG_STATIC;
+	}
+
+	codegen.generator->write_start(p_script, func_name, is_static, rpc_config, return_type);
+
+	if (p_is_setter) {
+		const GDScriptParser::DataType parser_param_type = p_variable->get_datatype();
+		const GDScriptDataType param_type = _gdtype_from_datatype(parser_param_type, p_script);
+		const uint32_t param_addr = codegen.generator->add_parameter("@value", false, param_type);
+
+		codegen.parameters["@value"] = GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::FUNCTION_PARAMETER, param_addr, param_type);
+		method_info.arguments.push_back(parser_param_type.to_property_info("@value"));
+
+		if (p_variable->initializer->type == GDScriptParser::Node::IDENTIFIER || p_variable->initializer->type == GDScriptParser::Node::SUBSCRIPT) {
+			GDScriptParser::IdentifierNode param_identifier;
+			param_identifier.name = "@value";
+			param_identifier.source = GDScriptParser::IdentifierNode::FUNCTION_PARAMETER;
+
+			GDScriptParser::AssignmentNode assignment;
+			assignment.assignee = p_variable->initializer;
+			assignment.assigned_value = &param_identifier;
+			assignment.use_conversion_assign = true; // TODO: Optimize when possible.
+
+			_parse_expression(codegen, r_error, &assignment); // NOTE: Assignment does not return a value.
+			if (r_error) {
+				memdelete(codegen.generator);
+				return;
+			}
+		} else {
+			const String error_message = vformat(R"(Cannot assign a value to property "%s".)", p_variable->identifier->name);
+			codegen.generator->write_assert(codegen.add_constant(false), codegen.add_constant(error_message));
+		}
+	} else {
+		GDScriptCodeGenerator::Address result = _parse_expression(codegen, r_error, p_variable->initializer);
+		if (r_error) {
+			memdelete(codegen.generator);
+			return;
+		}
+		codegen.generator->write_return(result);
+		if (result.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
+			codegen.generator->pop_temporary();
+		}
+	}
+
+#ifdef DEBUG_ENABLED
+	if (EngineDebugger::is_active()) {
+		String signature;
+		// Path.
+		if (!p_script->get_script_path().is_empty()) {
+			signature += p_script->get_script_path();
+		}
+		// Location.
+		signature += "::" + itos(p_variable->initializer->start_line);
+
+		// Function and class.
+
+		if (p_class->identifier) {
+			signature += "::" + String(p_class->identifier->name) + "." + String(func_name);
+		} else {
+			signature += "::" + String(func_name);
+		}
+
+		codegen.generator->set_signature(signature);
+	}
+#endif
+
+	codegen.generator->set_initial_line(p_variable->initializer->start_line);
+
+	GDScriptFunction *gd_function = codegen.generator->write_end();
+	gd_function->return_type = return_type;
+	gd_function->method_info = method_info;
+
+	p_script->member_functions[func_name] = gd_function;
+
+	memdelete(codegen.generator);
 }
 
 Error GDScriptCompiler::_parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter) {
-	Error err = OK;
-
-	GDScriptParser::FunctionNode *function;
-
-	if (p_is_setter) {
-		function = p_variable->setter;
-	} else {
-		function = p_variable->getter;
+	switch (p_variable->property) {
+		case GDScriptParser::VariableNode::PROP_INLINE: {
+			Error err = OK;
+			_parse_function(err, p_script, p_class, p_is_setter ? p_variable->setter : p_variable->getter);
+			return err;
+		} break;
+		case GDScriptParser::VariableNode::PROP_SHORT: {
+			Error err = OK;
+			_make_property_short_setter_getter(err, p_script, p_class, p_variable, p_is_setter);
+			return err;
+		} break;
+		case GDScriptParser::VariableNode::PROP_NONE:
+		case GDScriptParser::VariableNode::PROP_SETGET: {
+			return ERR_BUG;
+		} break;
 	}
-
-	_parse_function(err, p_script, p_class, function);
-
-	return err;
+	return ERR_BUG;
 }
 
 // Prepares given script, and inner class scripts, for compilation. It populates class members and
@@ -2795,6 +2919,10 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 							minfo.getter = "@" + variable->identifier->name + "_getter";
 						}
 						break;
+					case GDScriptParser::VariableNode::PROP_SHORT:
+						minfo.setter = "@" + variable->identifier->name + "_setter";
+						minfo.getter = "@" + variable->identifier->name + "_getter";
+						break;
 				}
 				minfo.data_type = _gdtype_from_datatype(variable->get_datatype(), p_script);
 
@@ -2935,19 +3063,39 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 			}
 		} else if (member.type == member.VARIABLE) {
 			const GDScriptParser::VariableNode *variable = member.variable;
-			if (variable->property == GDScriptParser::VariableNode::PROP_INLINE) {
-				if (variable->setter != nullptr) {
-					Error err = _parse_setter_getter(p_script, p_class, variable, true);
-					if (err) {
-						return err;
+			switch (variable->property) {
+				case GDScriptParser::VariableNode::PROP_INLINE: {
+					if (variable->setter != nullptr) {
+						Error err = _parse_setter_getter(p_script, p_class, variable, true);
+						if (err) {
+							return err;
+						}
 					}
-				}
-				if (variable->getter != nullptr) {
-					Error err = _parse_setter_getter(p_script, p_class, variable, false);
-					if (err) {
-						return err;
+					if (variable->getter != nullptr) {
+						Error err = _parse_setter_getter(p_script, p_class, variable, false);
+						if (err) {
+							return err;
+						}
 					}
-				}
+				} break;
+				case GDScriptParser::VariableNode::PROP_SHORT: {
+					{
+						Error err = _parse_setter_getter(p_script, p_class, variable, true);
+						if (err) {
+							return err;
+						}
+					}
+					{
+						Error err = _parse_setter_getter(p_script, p_class, variable, false);
+						if (err) {
+							return err;
+						}
+					}
+				} break;
+				case GDScriptParser::VariableNode::PROP_NONE:
+				case GDScriptParser::VariableNode::PROP_SETGET: {
+					// Nothing to do.
+				} break;
 			}
 		}
 	}
@@ -2972,8 +3120,7 @@ Error GDScriptCompiler::_compile_class(GDScript *p_script, const GDScriptParser:
 
 	if (p_class->has_static_data) {
 		Error err = OK;
-		GDScriptFunction *func = _make_static_initializer(err, p_script, p_class);
-		p_script->static_initializer = func;
+		_make_static_initializer(err, p_script, p_class);
 		if (err) {
 			return err;
 		}

--- a/modules/gdscript/gdscript_compiler.h
+++ b/modules/gdscript/gdscript_compiler.h
@@ -157,7 +157,8 @@ class GDScriptCompiler {
 	void _clear_block_locals(CodeGen &codegen, const List<GDScriptCodeGenerator::Address> &p_locals);
 	Error _parse_block(CodeGen &codegen, const GDScriptParser::SuiteNode *p_block, bool p_add_locals = true, bool p_clear_locals = true);
 	GDScriptFunction *_parse_function(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::FunctionNode *p_func, bool p_for_ready = false, bool p_for_lambda = false);
-	GDScriptFunction *_make_static_initializer(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class);
+	void _make_static_initializer(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class);
+	void _make_property_short_setter_getter(Error &r_error, GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter);
 	Error _parse_setter_getter(GDScript *p_script, const GDScriptParser::ClassNode *p_class, const GDScriptParser::VariableNode *p_variable, bool p_is_setter);
 	Error _prepare_compilation(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);
 	Error _compile_class(GDScript *p_script, const GDScriptParser::ClassNode *p_class, bool p_keep_state);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1098,14 +1098,14 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 				complete_extents(variable);
 				return nullptr;
 			}
-		} else if (check((GDScriptTokenizer::Token::EQUAL))) {
+		} else if (check(GDScriptTokenizer::Token::EQUAL) || check(GDScriptTokenizer::Token::EQUAL_GREATER)) {
 			// Infer type.
 			variable->infer_datatype = true;
 		} else {
 			if (p_allow_property) {
 				make_completion_context(COMPLETION_PROPERTY_DECLARATION_OR_TYPE, variable);
 				if (check(GDScriptTokenizer::Token::IDENTIFIER)) {
-					// Check if get or set.
+					// Check if `get` or `set`.
 					if (current.get_identifier() == "get" || current.get_identifier() == "set") {
 						return parse_property(variable, false);
 					}
@@ -1117,16 +1117,39 @@ GDScriptParser::VariableNode *GDScriptParser::parse_variable(bool p_is_static, b
 		}
 	}
 
+	enum InitType {
+		INIT_TYPE_NONE,
+		INIT_TYPE_NORMAL,
+		INIT_TYPE_SHORT,
+	};
+
+	InitType init_type = INIT_TYPE_NONE;
+
 	if (match(GDScriptTokenizer::Token::EQUAL)) {
+		init_type = INIT_TYPE_NORMAL;
+		variable->assignments++;
+	} else if (match(GDScriptTokenizer::Token::EQUAL_GREATER)) {
+		init_type = INIT_TYPE_SHORT;
+		if (p_allow_property) {
+			variable->property = VariableNode::PROP_SHORT;
+		} else {
+			push_error(R"(Setters/getters are not allowed for local variables.)");
+		}
+	}
+
+	if (init_type != INIT_TYPE_NONE) {
 		// Initializer.
 		variable->initializer = parse_expression(false);
 		if (variable->initializer == nullptr) {
-			push_error(R"(Expected expression for variable initial value after "=".)");
+			if (init_type == INIT_TYPE_NORMAL) {
+				push_error(R"(Expected expression for variable initial value after "=".)");
+			} else { // init_type == INIT_TYPE_SHORT
+				push_error(R"(Expected expression for variable setter/getter shorthand after "=>".)");
+			}
 		}
-		variable->assignments++;
 	}
 
-	if (p_allow_property && match(GDScriptTokenizer::Token::COLON)) {
+	if (p_allow_property && variable->property == VariableNode::PROP_NONE && match(GDScriptTokenizer::Token::COLON)) {
 		if (match(GDScriptTokenizer::Token::NEWLINE)) {
 			return parse_property(variable, true);
 		} else {
@@ -1267,6 +1290,7 @@ void GDScriptParser::parse_property_setter(VariableNode *p_variable) {
 			}
 			break;
 		case VariableNode::PROP_NONE:
+		case VariableNode::PROP_SHORT:
 			break; // Unreachable.
 	}
 }
@@ -1308,6 +1332,7 @@ void GDScriptParser::parse_property_getter(VariableNode *p_variable) {
 			}
 			break;
 		case VariableNode::PROP_NONE:
+		case VariableNode::PROP_SHORT:
 			break; // Unreachable.
 	}
 }
@@ -1556,7 +1581,7 @@ void GDScriptParser::parse_function_signature(FunctionNode *p_function, SuiteNod
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, vformat(R"*(Expected closing ")" after %s parameters.)*", p_type));
 
-	if (match(GDScriptTokenizer::Token::FORWARD_ARROW)) {
+	if (match(GDScriptTokenizer::Token::MINUS_GREATER)) {
 		make_completion_context(COMPLETION_TYPE_NAME_OR_VOID, p_function);
 		p_function->return_type = parse_type(true);
 		if (p_function->return_type == nullptr) {
@@ -4018,7 +4043,8 @@ GDScriptParser::ParseRule *GDScriptParser::get_rule(GDScriptTokenizer::Token::Ty
 		{ nullptr,                                          nullptr,                                        PREC_NONE }, // PERIOD_PERIOD,
 		{ nullptr,                                          nullptr,                                        PREC_NONE }, // COLON,
 		{ &GDScriptParser::parse_get_node,               	nullptr,                                        PREC_NONE }, // DOLLAR,
-		{ nullptr,                                          nullptr,                                        PREC_NONE }, // FORWARD_ARROW,
+		{ nullptr,                                          nullptr,                                        PREC_NONE }, // MINUS_GREATER,
+		{ nullptr,                                          nullptr,                                        PREC_NONE }, // EQUAL_GREATER,
 		{ nullptr,                                          nullptr,                                        PREC_NONE }, // UNDERSCORE,
 		// Whitespace
 		{ nullptr,                                          nullptr,                                        PREC_NONE }, // NEWLINE,
@@ -6065,15 +6091,15 @@ void GDScriptParser::TreePrinter::print_variable(VariableNode *p_variable) {
 	increase_indent();
 
 	push_line();
-	push_text("= ");
+	push_text(p_variable->property == VariableNode::PROP_SHORT ? "=> " : "= ");
 	if (p_variable->initializer == nullptr) {
-		push_text("<default value>");
+		push_text("<empty expression>");
 	} else {
 		print_expression(p_variable->initializer);
 	}
 	push_line();
 
-	if (p_variable->property != VariableNode::PROP_NONE) {
+	if (p_variable->property != VariableNode::PROP_NONE && p_variable->property != VariableNode::PROP_SHORT) {
 		if (p_variable->getter != nullptr) {
 			push_text("Get");
 			if (p_variable->property == VariableNode::PROP_INLINE) {
@@ -6081,7 +6107,7 @@ void GDScriptParser::TreePrinter::print_variable(VariableNode *p_variable) {
 				increase_indent();
 				print_suite(p_variable->getter->body);
 				decrease_indent();
-			} else {
+			} else { // VariableNode::PROP_SETGET
 				push_line(" =");
 				increase_indent();
 				print_identifier(p_variable->getter_pointer);
@@ -6101,7 +6127,7 @@ void GDScriptParser::TreePrinter::print_variable(VariableNode *p_variable) {
 				increase_indent();
 				print_suite(p_variable->setter->body);
 				decrease_indent();
-			} else {
+			} else { // VariableNode::PROP_SETGET
 				push_line(" =");
 				increase_indent();
 				print_identifier(p_variable->setter_pointer);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1246,19 +1246,20 @@ public:
 	struct VariableNode : public AssignableNode {
 		enum PropertyStyle {
 			PROP_NONE,
-			PROP_INLINE,
-			PROP_SETGET,
+			PROP_INLINE, // `var a: set(value): <block> get: <block>`
+			PROP_SETGET, // `var a: set = set_a, get = get_a`
+			PROP_SHORT, // `var a => _a`
 		};
 
 		PropertyStyle property = PROP_NONE;
 		union {
-			FunctionNode *setter = nullptr;
-			IdentifierNode *setter_pointer;
+			FunctionNode *setter = nullptr; // For `PROP_INLINE`.
+			IdentifierNode *setter_pointer; // For `PROP_SETGET.
 		};
-		IdentifierNode *setter_parameter = nullptr;
+		IdentifierNode *setter_parameter = nullptr; // For `PROP_INLINE`.
 		union {
-			FunctionNode *getter = nullptr;
-			IdentifierNode *getter_pointer;
+			FunctionNode *getter = nullptr; // For `PROP_INLINE`.
+			IdentifierNode *getter_pointer; // For `PROP_SETGET`.
 		};
 
 		bool exported = false;
@@ -1269,6 +1270,20 @@ public:
 #ifdef TOOLS_ENABLED
 		MemberDocData doc_data;
 #endif // TOOLS_ENABLED
+
+		bool has_getter() const {
+			switch (property) {
+				case PROP_NONE:
+					return false;
+				case PROP_INLINE:
+					return getter != nullptr;
+				case PROP_SETGET:
+					return getter_pointer != nullptr;
+				case PROP_SHORT:
+					return true; // Even if `initializer == nullptr`.
+			}
+			return false; // Unreachable.
+		}
 
 		VariableNode() {
 			type = VARIABLE;

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -136,7 +136,8 @@ static const char *token_names[] = {
 	"..", // PERIOD_PERIOD,
 	":", // COLON,
 	"$", // DOLLAR,
-	"->", // FORWARD_ARROW,
+	"->", // MINUS_GREATER,
+	"=>", // EQUAL_GREATER,
 	"_", // UNDERSCORE,
 	// Whitespace
 	"Newline", // NEWLINE,
@@ -1565,7 +1566,7 @@ GDScriptTokenizer::Token GDScriptTokenizerText::scan() {
 				return number();
 			} else if (_peek() == '>') {
 				_advance();
-				return make_token(Token::FORWARD_ARROW);
+				return make_token(Token::MINUS_GREATER);
 			} else {
 				return make_token(Token::MINUS);
 			}
@@ -1636,6 +1637,9 @@ GDScriptTokenizer::Token GDScriptTokenizerText::scan() {
 		case '=':
 			if (_peek() == '=') {
 				return check_vcs_marker('=', Token::EQUAL_EQUAL);
+			} else if (_peek() == '>') {
+				_advance();
+				return make_token(Token::EQUAL_GREATER);
 			} else {
 				return make_token(Token::EQUAL);
 			}

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -148,7 +148,8 @@ public:
 			PERIOD_PERIOD,
 			COLON,
 			DOLLAR,
-			FORWARD_ARROW,
+			MINUS_GREATER,
+			EQUAL_GREATER,
 			UNDERSCORE,
 			// Whitespace
 			NEWLINE,


### PR DESCRIPTION
* Closes https://github.com/godotengine/godot-proposals/discussions/10360.
* See also a [thread](https://chat.godotengine.org/channel/gdscript?msg=JgzkG7bpDRbob2Smr) on `#gdscript`.

The following:

```gdscript
var position = Vector2()
var x => position.x
var y => position.y
var length => position.length()
```

is a shorthand for:

```gdscript
var position = Vector2()

var x:
    set(value):
        position.x = value
    get:
        return position.x

var y:
    set(value):
        position.y = value
    get:
        return position.y

var length:
    set(_value):
        assert(false, 'Cannot assign a value to property "length".')
    get:
        return position.length()
```

A valid setter is generated for "lvalue" expressions (identifiers and subscripts), for non-"lvalue" expressions the setter has an `assert`. It is also planned to add an analyzer error when assigning a "readonly" property (not yet implemented).

Type specifiers, type inference, and static variables are supported:

```gdscript
var a: int => _a
var b :=> _b
static var c => _c
```

This might be useful together with the new `@export_tool_button` annotation, as there are issues with `self` referenced lambdas _stored_ in properties of `RefCounted`-based objects. See https://github.com/godotengine/godot-proposals/issues/11147 and #97834.

### Q&A

- **Are local variables supported?**
  - No, like other setter/getter styles, it only supports member variables. This would require a completely different implementation for local variables and is actually quite controversial if we want to add control flow optimizations in the future.
- **Is it possible to have granular control for setter and getter? For example, public getter and private setter?**
  - No, GDScript does not support private variables, and you can't do this with other setter/getter styles.
- **Is it possible to customize the setter behavior (e.g. emit a signal)?**
  - No, customizability makes language design and implementation difficult. Use the full form if the default behavior doesn't suit you. See also https://github.com/godotengine/godot/pull/78991.
- **Is it possible to exclude the setter generation even if the expression is an "lvalue"?**
  - No. See https://github.com/godotengine/godot-proposals/issues/820 instead.
- **Are setters/getters with the shorthand notation inlined?**
  - No, although this form has special qualities that are convenient for potential inlining, it is not currently implemented. Also, removing a frame from the call stack can be inconvenient in debug versions.

### TODO

- [ ] Open a proposal.
- [ ] Check non-"lvalue" identifiers/subscripts (like constants).
- [ ] Add static analysis when assigning a "readonly" property.
- [ ] Add annotation validation (e.g. `@onready` doesn't make sense).
- [ ] Add tests.
