### PR TITLE
Document `AudioStreamPlayer.get_playback_position()` intentionally always returning `0.0` when using `AudioStreamInteractive`

### DIFF
--- a/doc/classes/AudioStreamPlayer.xml
+++ b/doc/classes/AudioStreamPlayer.xml
@@ -22,6 +22,7 @@
 			<description>
 				Returns the position in the [AudioStream] of the latest sound, in seconds. Returns [code]0.0[/code] if no sounds are playing.
 				[b]Note:[/b] The position is not always accurate, as the [AudioServer] does not mix audio every processed frame. To get more accurate results, add [method AudioServer.get_time_since_last_mix] to the returned position.
+				[b]Note:[/b] This method always returns [code]0.0[/code] if the [member stream] is an [AudioStreamInteractive], since it can have multiple clips playing at once.
 			</description>
 		</method>
 		<method name="get_stream_playback">


### PR DESCRIPTION
Fix #97791 
`AudioStreamPlayer.get_playback_position()` always returns `0.0` if the `AudioStream` for the `AudioStreamPlayer` is `AudioStreamInteractive`. This is intended behaviour that lacks documentation, as confirmed by https://github.com/godotengine/godot/pull/97806#issuecomment-2471132992 and https://github.com/godotengine/godot/issues/97791#issuecomment-2429830156. This pull requests adds documentation for the behaviour to the class reference.