### PR TITLE
Enable `SubViewportContainer` as a potential candidate for dropping in Drag&Drop

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3062,6 +3062,13 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 			}
 			v->_update_mouse_over(v->get_final_transform().affine_inverse().xform(pos));
 		}
+
+		Viewport *section_root = get_section_root_viewport();
+		if (section_root && !section_root->gui.target_control) {
+			// In the case that no control nodes were found within SubViewports at the position of the mouse cursor,
+			// ensure, that the current SubViewportContainer is considered for the Control node, that the mouse is over.
+			section_root->gui.target_control = over;
+		}
 	}
 }
 


### PR DESCRIPTION
When no Control node inside of a `SubViewport` is currently hovered, then the `SubViewportContainer` should be available as a potential Drop-target.

- partially resolve #99155

As explained in https://github.com/godotengine/godot/issues/99155#issuecomment-2475088279, I believe, that instead of merging this PR, the documentation of `SubViewportContainer` should be extended to indicate better the intended use of `SubViewportContainer`.
That being said, with this PR I want to provide a reasonable, but based on circumstances a bit unpredictable approach to the problem at hand as an extension of the current functionality.

Superseded by: #99270