### PR TITLE
Describe edge cases for `DisplayServer.get_screen_from_rect()`

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -237,7 +237,7 @@
 			<return type="int" />
 			<param index="0" name="rect" type="Rect2" />
 			<description>
-				Returns index of the screen which contains specified rectangle.
+				Returns index of screen that overlaps the most with the given rectangle. Returns [code]-1[/code] if the rectangle doesn't overlap any screen or has zero area.
 			</description>
 		</method>
 		<method name="get_swap_cancel_ok">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -237,7 +237,7 @@
 			<return type="int" />
 			<param index="0" name="rect" type="Rect2" />
 			<description>
-				Returns index of screen that overlaps the most with the given rectangle. Returns [code]-1[/code] if the rectangle doesn't overlap any screen or has zero area.
+				Returns the index of the screen that overlaps the most with the given rectangle. Returns [code]-1[/code] if the rectangle doesn't overlap with any screen or has no area.
 			</description>
 		</method>
 		<method name="get_swap_cancel_ok">


### PR DESCRIPTION
Describes output for `get_screen_from_rect()` when multiple screens intersect with rectangle or rectangle has no area.
