### PR TITLE
Fix regression in SSS with reverse-z

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/subsurface_scattering.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/subsurface_scattering.glsl
@@ -152,10 +152,10 @@ void main() {
 		float depth_scale;
 
 		if (params.orthogonal) {
-			depth = ((depth + (params.camera_z_far + params.camera_z_near) / (params.camera_z_far - params.camera_z_near)) * (params.camera_z_far - params.camera_z_near)) / 2.0;
+			depth = -(depth * (params.camera_z_far - params.camera_z_near) - (params.camera_z_far + params.camera_z_near)) / 2.0;
 			depth_scale = params.unit_size; //remember depth is negative by default in OpenGL
 		} else {
-			depth = 2.0 * params.camera_z_near * params.camera_z_far / (params.camera_z_far + params.camera_z_near - depth * (params.camera_z_far - params.camera_z_near));
+			depth = 2.0 * params.camera_z_near * params.camera_z_far / (params.camera_z_far + params.camera_z_near + depth * (params.camera_z_far - params.camera_z_near));
 			depth_scale = params.unit_size / depth; //remember depth is negative by default in OpenGL
 		}
 


### PR DESCRIPTION
This PR fixes how the Subsurface Scattering shader fetches depth from the now reverse-z buffer.
It seems like SSS was missed in the original reverse-z implementation #88328.

The change is very subtle, so I had to set the depth scale to `1.0` in the settings to make it obvious in the screenshots below (`rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale`).

Note that the depth value is not used in orthographic mode, hence no difference.

~I also took this opportunity to rewrite the depth reconstruction code in a less convoluted way. It should allow easier maintenance in the future.~

| | 4.2.1 (before reverse-z) | 4.3 (after reverse-z) | With this PR |
| - |---|---|---|
| Perspective | ![Capture d’écran du 2024-11-14 10-13-32](https://github.com/user-attachments/assets/0d9405da-2e3e-4050-89cd-03f610ce9864) | ![Capture d’écran du 2024-11-14 10-16-48](https://github.com/user-attachments/assets/d4d5f674-de81-46d3-8a85-a7b60de8138a) | ![Capture d’écran du 2024-11-14 10-14-37](https://github.com/user-attachments/assets/535e5eb0-cd53-4e2e-b4f5-333e19079861) |
| Orthographic | ![Capture d’écran du 2024-11-14 10-22-15](https://github.com/user-attachments/assets/e120663d-fcb8-4216-a79d-f1da294c7dfb) |![Capture d’écran du 2024-11-14 10-22-15](https://github.com/user-attachments/assets/ef7ce51e-6aba-418f-ae73-ee32b9a173aa)  |![Capture d’écran du 2024-11-14 10-20-51](https://github.com/user-attachments/assets/5c70d549-8bfd-4429-bba4-7ff4ea6a4d28) |


