### PR TITLE
Deprecate `damping`, add `reflectivity` to match `AudioEffectReverb`'s documentation

### DIFF
--- a/doc/classes/AudioEffectReverb.xml
+++ b/doc/classes/AudioEffectReverb.xml
@@ -11,8 +11,7 @@
 		<link title="Third Person Shooter (TPS) Demo">https://godotengine.org/asset-library/asset/2710</link>
 	</tutorials>
 	<members>
-		<member name="damping" type="float" setter="set_damping" getter="get_damping" default="0.5">
-			Defines how reflective the imaginary room's walls are. Value can range from 0 to 1.
+		<member name="damping" type="float" setter="set_damping" getter="get_damping" default="0.5" deprecated="Use [member reflectivity] instead.">
 		</member>
 		<member name="dry" type="float" setter="set_dry" getter="get_dry" default="1.0">
 			Output percent of original sound. At 0, only modified sound is outputted. Value can range from 0 to 1.
@@ -25,6 +24,9 @@
 		</member>
 		<member name="predelay_msec" type="float" setter="set_predelay_msec" getter="get_predelay_msec" default="150.0">
 			Time between the original signal and the early reflections of the reverb signal, in milliseconds.
+		</member>
+		<member name="reflectivity" type="float" setter="set_reflectivity" getter="get_reflectivity" default="0.5">
+			Defines how reflective the imaginary room's walls are. Value can range from 0 to 1 with 1 being fully reflective and 0 being non-reflective.
 		</member>
 		<member name="room_size" type="float" setter="set_room_size" getter="get_room_size" default="0.8">
 			Dimensions of simulated room. Bigger means more echoes. Value can range from 0 to 1.

--- a/servers/audio/effects/audio_effect_reverb.cpp
+++ b/servers/audio/effects/audio_effect_reverb.cpp
@@ -38,7 +38,7 @@ void AudioEffectReverbInstance::process(const AudioFrame *p_src_frames, AudioFra
 		r.set_predelay_feedback(base->predelay_fb);
 		r.set_highpass(base->hpf);
 		r.set_room_size(base->room_size);
-		r.set_damp(base->damping);
+		r.set_reflection(base->reflectivity);
 		r.set_extra_spread(base->spread);
 		r.set_wet(base->wet);
 		r.set_dry(base->dry);
@@ -98,9 +98,16 @@ void AudioEffectReverb::set_room_size(float p_size) {
 	room_size = p_size;
 }
 
-void AudioEffectReverb::set_damping(float p_damping) {
-	damping = p_damping;
+void AudioEffectReverb::set_reflectivity(float p_reflectivity) {
+	reflectivity = p_reflectivity;
 }
+
+#ifndef DISABLE_DEPRECATED
+void AudioEffectReverb::set_damping(float p_damping) {
+	WARN_DEPRECATED_MSG("Use set_reflectivity instead.");
+	set_reflectivity(p_damping);
+}
+#endif
 
 void AudioEffectReverb::set_spread(float p_spread) {
 	spread = p_spread;
@@ -130,9 +137,16 @@ float AudioEffectReverb::get_room_size() const {
 	return room_size;
 }
 
-float AudioEffectReverb::get_damping() const {
-	return damping;
+float AudioEffectReverb::get_reflectivity() const {
+	return reflectivity;
 }
+
+#ifndef DISABLE_DEPRECATED
+float AudioEffectReverb::get_damping() const {
+	WARN_DEPRECATED_MSG("Use get_reflectivity instead.");
+	return get_reflectivity();
+}
+#endif
 
 float AudioEffectReverb::get_spread() const {
 	return spread;
@@ -160,8 +174,13 @@ void AudioEffectReverb::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_room_size", "size"), &AudioEffectReverb::set_room_size);
 	ClassDB::bind_method(D_METHOD("get_room_size"), &AudioEffectReverb::get_room_size);
 
+	ClassDB::bind_method(D_METHOD("set_reflectivity", "amount"), &AudioEffectReverb::set_reflectivity);
+	ClassDB::bind_method(D_METHOD("get_reflectivity"), &AudioEffectReverb::get_reflectivity);
+
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_damping", "amount"), &AudioEffectReverb::set_damping);
 	ClassDB::bind_method(D_METHOD("get_damping"), &AudioEffectReverb::get_damping);
+#endif
 
 	ClassDB::bind_method(D_METHOD("set_spread", "amount"), &AudioEffectReverb::set_spread);
 	ClassDB::bind_method(D_METHOD("get_spread"), &AudioEffectReverb::get_spread);
@@ -180,7 +199,10 @@ void AudioEffectReverb::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "predelay_feedback", PROPERTY_HINT_RANGE, "0,0.98,0.01"), "set_predelay_feedback", "get_predelay_feedback");
 	ADD_GROUP("", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "room_size", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_room_size", "get_room_size");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "damping", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_damping", "get_damping");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "reflectivity", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_reflectivity", "get_reflectivity");
+#ifndef DISABLE_DEPRECATED
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "damping", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_damping", "get_damping");
+#endif
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "spread", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_spread", "get_spread");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "hipass", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_hpf", "get_hpf");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "dry", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_dry", "get_dry");
@@ -192,7 +214,7 @@ AudioEffectReverb::AudioEffectReverb() {
 	predelay_fb = 0.4;
 	hpf = 0;
 	room_size = 0.8;
-	damping = 0.5;
+	reflectivity = 0.5;
 	spread = 1.0;
 	dry = 1.0;
 	wet = 0.5;

--- a/servers/audio/effects/audio_effect_reverb.h
+++ b/servers/audio/effects/audio_effect_reverb.h
@@ -62,7 +62,7 @@ class AudioEffectReverb : public AudioEffect {
 	float predelay_fb;
 	float hpf;
 	float room_size;
-	float damping;
+	float reflectivity;
 	float spread;
 	float dry;
 	float wet;
@@ -74,7 +74,10 @@ public:
 	void set_predelay_msec(float p_msec);
 	void set_predelay_feedback(float p_feedback);
 	void set_room_size(float p_size);
+	void set_reflectivity(float p_reflectivity);
+#ifndef DISABLE_DEPRECATED
 	void set_damping(float p_damping);
+#endif
 	void set_spread(float p_spread);
 	void set_dry(float p_dry);
 	void set_wet(float p_wet);
@@ -83,7 +86,10 @@ public:
 	float get_predelay_msec() const;
 	float get_predelay_feedback() const;
 	float get_room_size() const;
+	float get_reflectivity() const;
+#ifndef DISABLE_DEPRECATED
 	float get_damping() const;
+#endif
 	float get_spread() const;
 	float get_dry() const;
 	float get_wet() const;

--- a/servers/audio/effects/reverb_filter.cpp
+++ b/servers/audio/effects/reverb_filter.cpp
@@ -112,8 +112,8 @@ void Reverb::process(float *p_src, float *p_dst, int p_frames) {
 			}
 
 			float out = undenormalize(c.buffer[c.pos] * c.feedback);
-			out = out * (1.0 - c.damp) + c.damp_h * c.damp; //lowpass
-			c.damp_h = out;
+			out = out * (1.0 - c.reflection) + c.reflection_h * c.reflection; //lowpass
+			c.reflection_h = out;
 			c.buffer[c.pos] = input_buffer[j] + out;
 			p_dst[j] += out;
 			c.pos++;
@@ -181,10 +181,18 @@ void Reverb::set_room_size(float p_size) {
 	update_parameters();
 }
 
-void Reverb::set_damp(float p_damp) {
-	params.damp = p_damp;
+void Reverb::set_reflection(float p_reflection) {
+	params.reflection = p_reflection;
 	update_parameters();
 }
+
+#ifndef DISABLE_DEPRECATED
+void Reverb::set_damp(float p_damp) {
+	WARN_DEPRECATED_MSG("Use set_reflection instead.");
+	set_reflection(p_damp);
+}
+
+#endif
 
 void Reverb::set_wet(float p_wet) {
 	params.wet = p_wet;
@@ -288,10 +296,10 @@ void Reverb::update_parameters() {
 			c.feedback = (room_offset + room_scale);
 		}
 
-		float auxdmp = params.damp / 2.0 + 0.5; //only half the range (0.5 .. 1.0 is enough)
+		float auxdmp = params.reflection / 2.0 + 0.5; //only half the range (0.5 .. 1.0 is enough)
 		auxdmp *= auxdmp;
 
-		c.damp = expf(-Math_TAU * auxdmp * 10000 / params.mix_rate); // 0 .. 10khz
+		c.reflection = expf(-Math_TAU * auxdmp * 10000 / params.mix_rate); // 0 .. 10khz
 	}
 }
 
@@ -319,7 +327,7 @@ void Reverb::clear_buffers() {
 
 Reverb::Reverb() {
 	params.room_size = 0.8;
-	params.damp = 0.5;
+	params.reflection = 0.5;
 	params.dry = 1.0;
 	params.wet = 0.0;
 	params.mix_rate = 44100;

--- a/servers/audio/effects/reverb_filter.h
+++ b/servers/audio/effects/reverb_filter.h
@@ -57,8 +57,8 @@ private:
 		int size = 0;
 		float *buffer = nullptr;
 		float feedback = 0;
-		float damp = 0; //lowpass
-		float damp_h = 0; //history
+		float reflection = 0; //lowpass
+		float reflection_h = 0; //history
 		int pos = 0;
 		int extra_spread_frames = 0;
 
@@ -85,7 +85,7 @@ private:
 
 	struct Parameters {
 		float room_size;
-		float damp;
+		float reflection;
 		float wet;
 		float dry;
 		float mix_rate;
@@ -102,7 +102,10 @@ private:
 
 public:
 	void set_room_size(float p_size);
+	void set_reflection(float p_reflection);
+#ifndef DISABLE_DEPRECATED
 	void set_damp(float p_damp);
+#endif
 	void set_wet(float p_wet);
 	void set_dry(float p_dry);
 	void set_predelay(float p_predelay); // in ms


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes #98945.
Renamed `damping` to `reflectivity` in the documentation and class of `AudioEffectReverb`. And tested it.