### PR TITLE
Resource UID fixes and improvements

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2611,23 +2611,25 @@ Image::AlphaMode Image::detect_alpha() const {
 }
 
 Error Image::load(const String &p_path) {
+	String path = ResourceUID::ensure_path(p_path);
 #ifdef DEBUG_ENABLED
-	if (p_path.begins_with("res://") && ResourceLoader::exists(p_path)) {
-		WARN_PRINT(vformat("Loaded resource as image file, this will not work on export: '%s'. Instead, import the image file as an Image resource and load it normally as a resource.", p_path));
+	if (path.begins_with("res://") && ResourceLoader::exists(path)) {
+		WARN_PRINT(vformat("Loaded resource as image file, this will not work on export: '%s'. Instead, import the image file as an Image resource and load it normally as a resource.", path));
 	}
 #endif
-	return ImageLoader::load_image(p_path, this);
+	return ImageLoader::load_image(ResourceUID::ensure_path(p_path), this);
 }
 
 Ref<Image> Image::load_from_file(const String &p_path) {
+	String path = ResourceUID::ensure_path(p_path);
 #ifdef DEBUG_ENABLED
-	if (p_path.begins_with("res://") && ResourceLoader::exists(p_path)) {
-		WARN_PRINT(vformat("Loaded resource as image file, this will not work on export: '%s'. Instead, import the image file as an Image resource and load it normally as a resource.", p_path));
+	if (path.begins_with("res://") && ResourceLoader::exists(path)) {
+		WARN_PRINT(vformat("Loaded resource as image file, this will not work on export: '%s'. Instead, import the image file as an Image resource and load it normally as a resource.", path));
 	}
 #endif
 	Ref<Image> image;
 	image.instantiate();
-	Error err = ImageLoader::load_image(p_path, image);
+	Error err = ImageLoader::load_image(path, image);
 	if (err != OK) {
 		ERR_FAIL_V_MSG(Ref<Image>(), vformat("Failed to load image. Error %d", err));
 	}

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -34,6 +34,7 @@
 #include "core/crypto/crypto_core.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
 
 // These constants are off by 1, causing the 'z' and '9' characters never to be used.
 // This cannot be fixed without breaking compatibility; see GH-83843.
@@ -137,6 +138,21 @@ void ResourceUID::remove_id(ID p_id) {
 	MutexLock l(mutex);
 	ERR_FAIL_COND(!unique_ids.has(p_id));
 	unique_ids.erase(p_id);
+}
+
+String ResourceUID::uid_to_path(const String &p_uid) {
+	return singleton->get_id_path(singleton->text_to_id(p_uid));
+}
+
+String ResourceUID::path_to_uid(const String &p_path) {
+	return singleton->id_to_text(ResourceLoader::get_resource_uid(p_path));
+}
+
+String ResourceUID::ensure_path(const String &p_uid_or_path) {
+	if (p_uid_or_path.begins_with("uid://")) {
+		return uid_to_path(p_uid_or_path);
+	}
+	return p_uid_or_path;
 }
 
 Error ResourceUID::save_to_cache() {

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -73,6 +73,10 @@ public:
 	String get_id_path(ID p_id) const;
 	void remove_id(ID p_id);
 
+	static String uid_to_path(const String &p_uid);
+	static String path_to_uid(const String &p_path);
+	static String ensure_path(const String &p_uid_or_path);
+
 	Error load_from_cache(bool p_reset);
 	Error save_to_cache();
 	Error update_cache();


### PR DESCRIPTION
- Added new static helper methods to ResourceUID
  - `uid_to_path(uid)` - converts `uid://` to `res://`
  - `path_to_uid(path)` - opposite of the above
  - `ensure_path(uid_or_path)` - returns a path, converts UID when necessary
- Fixed #99221

In a follow-up I plan to make use of the helper methods where applicable.