### PR TITLE
Fix misleading error on missing export template

### DIFF
--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -146,7 +146,7 @@ Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_
 		template_path = find_export_template(get_template_file_name(p_debug ? "debug" : "release", p_preset->get("binary_format/architecture")));
 	}
 
-	if (!template_path.is_empty() && !FileAccess::exists(template_path)) {
+	if (template_path.is_empty() || !FileAccess::exists(template_path)) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Template"), vformat(TTR("Template file not found: \"%s\"."), template_path));
 		return ERR_FILE_NOT_FOUND;
 	}


### PR DESCRIPTION
The `template_path` check on line 149 passes silently if the path is empty, which leads to only the generic error being shown and a plain `Failed to open` error in console. See #99225 for more details.

This PR shows the more informative message, `Template file not found`