### PR TITLE
Always render animation track name as RTL text

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2135,7 +2135,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				Vector2 string_pos = Point2(ofs, (get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size));
 				string_pos = string_pos.floor();
-				draw_string(font, string_pos, text, HORIZONTAL_ALIGNMENT_LEFT, limit - ofs - h_separation, font_size, text_color);
+				draw_string(font, string_pos, text, HORIZONTAL_ALIGNMENT_RIGHT, limit - ofs - h_separation, font_size, text_color, TextServer::JUSTIFICATION_WORD_BOUND, TextServer::DIRECTION_RTL);
 
 				draw_line(Point2(limit, 0), Point2(limit, get_size().height), h_line_color, Math::round(EDSCALE));
 			}


### PR DESCRIPTION
This is so the beginning of the track name gets clipped instead of the end.

Before:
![Screenshot From 2024-11-14 14-33-42](https://github.com/user-attachments/assets/ec3361c9-7ed3-499b-95e3-95739362177b)

After:
![Screenshot From 2024-11-14 15-08-22](https://github.com/user-attachments/assets/961254d8-7f00-479c-a485-a4a24ee89dac)

Another improvement that could be made is to render a text ellipsis to make it clear something got cut off, but, to my knowledge, there is currently no API for doing that with `draw_string`.

Fixes #99022.