### PR TITLE
Add support for trimming text from the beginning instead of end, use it for right aligned text.

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -49,6 +49,9 @@
 		<member name="clip_text" type="bool" setter="set_clip_text" getter="get_clip_text" default="false">
 			If [code]true[/code], text that is too large to fit the button is clipped horizontally. If [code]false[/code], the button will always be wide enough to hold the text. The text is not vertically clipped, and the button's height is not affected by this property.
 		</member>
+		<member name="ellipsis_direction" type="int" setter="set_ellipsis_direction" getter="get_ellipsis_direction" enum="TextServer.TextOverrunDirection" default="2">
+			Ellipsis/text clipping direction.
+		</member>
 		<member name="expand_icon" type="bool" setter="set_expand_icon" getter="is_expand_icon" default="false">
 			When enabled, the button's icon will expand/shrink to fit the button's size while keeping its aspect. See also [theme_item icon_max_width].
 		</member>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -55,6 +55,9 @@
 		<member name="ellipsis_char" type="String" setter="set_ellipsis_char" getter="get_ellipsis_char" default="&quot;…&quot;">
 			Ellipsis character used for text clipping.
 		</member>
+		<member name="ellipsis_direction" type="int" setter="set_ellipsis_direction" getter="get_ellipsis_direction" enum="TextServer.TextOverrunDirection" default="2">
+			Ellipsis/text clipping direction.
+		</member>
 		<member name="horizontal_alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
 			Controls the text's horizontal alignment. Supports left, center, right, and fill, or justify. Set it to one of the [enum HorizontalAlignment] constants.
 		</member>

--- a/doc/classes/TextLine.xml
+++ b/doc/classes/TextLine.xml
@@ -154,6 +154,9 @@
 		<member name="ellipsis_char" type="String" setter="set_ellipsis_char" getter="get_ellipsis_char" default="&quot;…&quot;">
 			Ellipsis character used for text clipping.
 		</member>
+		<member name="ellipsis_direction" type="int" setter="set_ellipsis_direction" getter="get_ellipsis_direction" enum="TextServer.TextOverrunDirection" default="2">
+			Ellipsis/text clipping direction.
+		</member>
 		<member name="flags" type="int" setter="set_flags" getter="get_flags" enum="TextServer.JustificationFlag" is_bitfield="true" default="3">
 			Line alignment rules. For more info see [TextServer].
 		</member>

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -277,6 +277,9 @@
 		<member name="ellipsis_char" type="String" setter="set_ellipsis_char" getter="get_ellipsis_char" default="&quot;…&quot;">
 			Ellipsis character used for text clipping.
 		</member>
+		<member name="ellipsis_direction" type="int" setter="set_ellipsis_direction" getter="get_ellipsis_direction" enum="TextServer.TextOverrunDirection" default="2">
+			Ellipsis/text clipping direction.
+		</member>
 		<member name="justification_flags" type="int" setter="set_justification_flags" getter="get_justification_flags" enum="TextServer.JustificationFlag" is_bitfield="true" default="163">
 			Line fill alignment rules. See [enum TextServer.JustificationFlag] for more information.
 		</member>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1369,6 +1369,13 @@
 				Returns dominant direction of in the range of text.
 			</description>
 		</method>
+		<method name="shaped_text_get_ellipsis_direction" qualifiers="const">
+			<return type="int" enum="TextServer.TextOverrunDirection" />
+			<param index="0" name="shaped" type="RID" />
+			<description>
+				Returns ellipsis/text clipping direction.
+			</description>
+		</method>
 		<method name="shaped_text_get_ellipsis_glyph_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
@@ -1386,6 +1393,7 @@
 		<method name="shaped_text_get_ellipsis_pos" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="left" type="bool" default="false" />
 			<description>
 				Returns position of the ellipsis.
 			</description>
@@ -1534,6 +1542,7 @@
 		<method name="shaped_text_get_trim_pos" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="left" type="bool" default="false" />
 			<description>
 				Returns the position of the overrun trim.
 			</description>
@@ -1619,6 +1628,7 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="width" type="float" default="0" />
 			<param index="2" name="overrun_trim_flags" type="int" enum="TextServer.TextOverrunFlag" is_bitfield="true" default="0" />
+			<param index="3" name="direction" type="int" enum="TextServer.TextOverrunDirection" default="2" />
 			<description>
 				Trims text if it exceeds the given width.
 			</description>
@@ -1992,6 +2002,15 @@
 		</constant>
 		<constant name="OVERRUN_JUSTIFICATION_AWARE" value="16" enum="TextOverrunFlag" is_bitfield="true">
 			Accounts for the text being justified before attempting to trim it (see [enum JustificationFlag]).
+		</constant>
+		<constant name="OVERRUN_TRIM_START" value="0" enum="TextOverrunDirection">
+			Is set, text is trimmed from the beginning of the string.
+		</constant>
+		<constant name="OVERRUN_TRIM_BOTH" value="1" enum="TextOverrunDirection">
+			Is set, text is trimmed from both the beginning and the end of the string.
+		</constant>
+		<constant name="OVERRUN_TRIM_END" value="2" enum="TextOverrunDirection">
+			Is set, text is trimmed from the end of the string.
 		</constant>
 		<constant name="GRAPHEME_IS_VALID" value="1" enum="GraphemeFlag" is_bitfield="true">
 			Grapheme is supported by the font, and can be drawn.

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -1493,6 +1493,14 @@
 				Returns dominant direction of in the range of text.
 			</description>
 		</method>
+		<method name="_shaped_text_get_ellipsis_direction" qualifiers="virtual const">
+			<return type="int" enum="TextServer.TextOverrunDirection" />
+			<param index="0" name="shaped" type="RID" />
+			<description>
+				[b]Optional.[/b]
+				Returns ellipsis/text clipping direction.
+			</description>
+		</method>
 		<method name="_shaped_text_get_ellipsis_glyph_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
@@ -1512,6 +1520,7 @@
 		<method name="_shaped_text_get_ellipsis_pos" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="left" type="bool" />
 			<description>
 				[b]Required.[/b]
 				Returns position of the ellipsis.
@@ -1678,6 +1687,7 @@
 		<method name="_shaped_text_get_trim_pos" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="left" type="bool" />
 			<description>
 				[b]Required.[/b]
 				Returns the position of the overrun trim.
@@ -1766,6 +1776,7 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="width" type="float" />
 			<param index="2" name="trim_flags" type="int" enum="TextServer.TextOverrunFlag" is_bitfield="true" />
+			<param index="3" name="direction" type="int" enum="TextServer.TextOverrunDirection" />
 			<description>
 				[b]Optional.[/b]
 				Trims text if it exceeds the given width.

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -202,6 +202,13 @@
 				Returns custom font size used to draw text in the column [param column].
 			</description>
 		</method>
+		<method name="get_ellipsis_direction" qualifiers="const">
+			<return type="int" enum="TextServer.TextOverrunDirection" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns ellipsis/text clipping direction.
+			</description>
+		</method>
 		<method name="get_expand_right" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="column" type="int" />
@@ -657,6 +664,14 @@
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				If [param enabled] is [code]true[/code], the given [param column] is editable.
+			</description>
+		</method>
+		<method name="set_ellipsis_direction">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="ellipsis_direction" type="int" enum="TextServer.TextOverrunDirection" />
+			<description>
+				Sets ellipsis/text clipping direction.
 			</description>
 		</method>
 		<method name="set_expand_right">

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -285,3 +285,15 @@ GH-101482
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/set_table_column_expand/arguments': size changed value in new API, from 3 to 4.
 
 Added optional "shrink" argument. Compatibility method registered.
+
+
+GH-99236
+--------
+Validate extension JSON: Error: Field 'classes/TextServer/methods/shaped_text_get_ellipsis_pos/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/TextServer/methods/shaped_text_get_trim_pos/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/TextServer/methods/shaped_text_overrun_trim_to_width/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shaped_text_get_ellipsis_pos/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shaped_text_get_trim_pos/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shaped_text_overrun_trim_to_width/arguments': size changed value in new API, from 3 to 4.
+
+Added optional parameters. Compatibility methods registered.

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -4957,12 +4957,13 @@ double TextServerAdvanced::_shaped_text_fit_to_width(const RID &p_shaped, double
 
 	double justification_width;
 	if (p_jst_flags.has_flag(JUSTIFICATION_CONSTRAIN_ELLIPSIS)) {
-		if (sd->overrun_trim_data.trim_pos >= 0) {
-			if (sd->para_direction == DIRECTION_RTL) {
-				start_pos = sd->overrun_trim_data.trim_pos;
-			} else {
-				end_pos = sd->overrun_trim_data.trim_pos;
-			}
+		if (sd->overrun_trim_data.left_trim_pos >= 0) {
+			start_pos = sd->overrun_trim_data.left_trim_pos;
+		}
+		if (sd->overrun_trim_data.right_trim_pos >= 0) {
+			end_pos = sd->overrun_trim_data.right_trim_pos;
+		}
+		if (sd->overrun_trim_data.left_trim_pos >= 0 || sd->overrun_trim_data.right_trim_pos >= 0) {
 			justification_width = sd->width_trimmed;
 		} else {
 			return Math::ceil(sd->width);
@@ -5293,7 +5294,7 @@ RID TextServerAdvanced::_find_sys_font_for_text(const RID &p_fdef, const String 
 	return f;
 }
 
-void TextServerAdvanced::_shaped_text_overrun_trim_to_width(const RID &p_shaped_line, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) {
+void TextServerAdvanced::_shaped_text_overrun_trim_to_width(const RID &p_shaped_line, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags, TextOverrunDirection p_direction) {
 	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped_line);
 	ERR_FAIL_NULL_MSG(sd, "ShapedTextDataAdvanced invalid.");
 
@@ -5313,8 +5314,10 @@ void TextServerAdvanced::_shaped_text_overrun_trim_to_width(const RID &p_shaped_
 	Glyph *sd_glyphs = sd->glyphs.ptrw();
 
 	if ((p_trim_flags & OVERRUN_TRIM) == OVERRUN_NO_TRIM || sd_glyphs == nullptr || p_width <= 0 || !(sd->width > p_width || enforce_ellipsis)) {
-		sd->overrun_trim_data.trim_pos = -1;
-		sd->overrun_trim_data.ellipsis_pos = -1;
+		sd->overrun_trim_data.left_trim_pos = -1;
+		sd->overrun_trim_data.left_ellipsis_pos = -1;
+		sd->overrun_trim_data.right_trim_pos = -1;
+		sd->overrun_trim_data.right_ellipsis_pos = -1;
 		return;
 	}
 
@@ -5408,63 +5411,124 @@ void TextServerAdvanced::_shaped_text_overrun_trim_to_width(const RID &p_shaped_
 
 	bool is_rtl = sd->para_direction == DIRECTION_RTL;
 
-	int trim_pos = (is_rtl) ? sd_size : 0;
-	int ellipsis_pos = (enforce_ellipsis) ? 0 : -1;
-
-	int last_valid_cut = 0;
-	bool found = false;
-
-	int glyphs_from = (is_rtl) ? 0 : sd_size - 1;
-	int glyphs_to = (is_rtl) ? sd_size - 1 : -1;
-	int glyphs_delta = (is_rtl) ? +1 : -1;
+	int left_trim_pos = -1;
+	int right_trim_pos = -1;
+	int left_ellipsis_pos = (enforce_ellipsis) ? 0 : -1;
+	int right_ellipsis_pos = (enforce_ellipsis) ? 0 : -1;
 
 	if (enforce_ellipsis && (width + ellipsis_width <= p_width)) {
-		trim_pos = -1;
-		ellipsis_pos = (is_rtl) ? 0 : sd_size;
+		left_trim_pos = -1;
+		left_ellipsis_pos = 0;
+		right_trim_pos = -1;
+		right_ellipsis_pos = sd_size;
 	} else {
-		for (int i = glyphs_from; i != glyphs_to; i += glyphs_delta) {
-			if (!is_rtl) {
-				width -= sd_glyphs[i].advance * sd_glyphs[i].repeat;
-			}
-			if (sd_glyphs[i].count > 0) {
-				bool above_min_char_threshold = ((is_rtl) ? sd_size - 1 - i : i) >= ell_min_characters;
+		int left_ptr = sd_size - 1;
+		int right_ptr = 0;
 
-				if (width + (((above_min_char_threshold && add_ellipsis) || enforce_ellipsis) ? ellipsis_width : 0) <= p_width) {
-					if (cut_per_word && above_min_char_threshold) {
-						if ((sd_glyphs[i].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT) {
-							last_valid_cut = i;
-							found = true;
-						}
-					} else {
-						last_valid_cut = i;
-						found = true;
-					}
-					if (found) {
-						trim_pos = last_valid_cut;
+		float min_pos = 0.0;
+		float max_pos = p_width;
 
-						if (add_ellipsis && (above_min_char_threshold || enforce_ellipsis) && width - ellipsis_width <= p_width) {
-							ellipsis_pos = trim_pos;
+		float left_pos = p_width;
+		float right_pos = 0.0;
+
+		if ((p_direction == OVERRUN_TRIM_START && !is_rtl) || (p_direction == OVERRUN_TRIM_END && is_rtl)) { // Left.
+			left_ptr = sd_size - 1;
+			right_ptr = sd_size;
+		} else if ((p_direction == OVERRUN_TRIM_START && is_rtl) || (p_direction == OVERRUN_TRIM_END && !is_rtl)) { // Right.
+			left_ptr = 0;
+			right_ptr = 0;
+		} else if (p_direction == OVERRUN_TRIM_BOTH) {
+			left_ptr = sd_size / 2;
+			right_ptr = sd_size / 2;
+			min_pos = -p_width / 2.0;
+			max_pos = p_width / 2.0;
+			left_pos = 0.0;
+			right_pos = 0.0;
+		}
+
+		int left_count = 0;
+		int right_count = 0;
+
+		int left_last_valid_cut = 0;
+		int right_last_valid_cut = 0;
+		bool left_found = false;
+		bool right_found = false;
+
+		while (left_ptr > 0 || right_ptr < sd_size - 1) {
+			if (left_ptr > 0) {
+				if (sd_glyphs[left_ptr].count > 0) {
+					bool above_min_char_threshold = left_count >= ell_min_characters;
+					left_pos -= sd_glyphs[left_ptr].advance * sd_glyphs[left_ptr].repeat;
+					if (left_pos - (((above_min_char_threshold && add_ellipsis) || enforce_ellipsis) ? ellipsis_width : 0) <= min_pos) {
+						if (cut_per_word && above_min_char_threshold) {
+							if ((sd_glyphs[left_ptr].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT) {
+								left_last_valid_cut = left_ptr;
+								left_found = true;
+							}
+						} else {
+							left_last_valid_cut = left_ptr;
+							left_found = true;
 						}
-						break;
+						if (left_found) {
+							left_trim_pos = left_last_valid_cut;
+
+							if (add_ellipsis && (above_min_char_threshold || enforce_ellipsis) && left_pos - ellipsis_width <= min_pos) {
+								left_ellipsis_pos = left_trim_pos;
+							}
+							left_ptr = 0;
+						}
 					}
+					left_count++;
+					left_ptr--;
 				}
 			}
-			if (is_rtl) {
-				width -= sd_glyphs[i].advance * sd_glyphs[i].repeat;
+			if (right_ptr < sd_size - 1) {
+				if (sd_glyphs[right_ptr].count > 0) {
+					bool above_min_char_threshold = right_count >= ell_min_characters;
+					right_pos += sd_glyphs[right_ptr].advance * sd_glyphs[right_ptr].repeat;
+					if (right_pos + (((above_min_char_threshold && add_ellipsis) || enforce_ellipsis) ? ellipsis_width : 0) >= max_pos) {
+						if (cut_per_word && above_min_char_threshold) {
+							if ((sd_glyphs[right_ptr].flags & GRAPHEME_IS_BREAK_SOFT) == GRAPHEME_IS_BREAK_SOFT) {
+								right_last_valid_cut = right_ptr;
+								right_found = true;
+							}
+						} else {
+							right_last_valid_cut = right_ptr;
+							right_found = true;
+						}
+						if (right_found) {
+							right_trim_pos = right_last_valid_cut;
+
+							if (add_ellipsis && (above_min_char_threshold || enforce_ellipsis) && right_pos + ellipsis_width >= max_pos) {
+								right_ellipsis_pos = right_trim_pos;
+							}
+							right_ptr = sd_size - 1;
+						}
+					}
+					right_count++;
+					right_ptr++;
+				}
 			}
 		}
 	}
 
-	sd->overrun_trim_data.trim_pos = trim_pos;
-	sd->overrun_trim_data.ellipsis_pos = ellipsis_pos;
-	if (trim_pos == 0 && enforce_ellipsis && add_ellipsis) {
-		sd->overrun_trim_data.ellipsis_pos = 0;
+	sd->overrun_trim_data.el_dir = p_direction;
+
+	sd->overrun_trim_data.left_trim_pos = left_trim_pos;
+	sd->overrun_trim_data.left_ellipsis_pos = left_ellipsis_pos;
+	if (left_trim_pos == 0 && enforce_ellipsis && add_ellipsis) {
+		sd->overrun_trim_data.left_ellipsis_pos = 0;
+	}
+	sd->overrun_trim_data.right_trim_pos = right_trim_pos;
+	sd->overrun_trim_data.right_ellipsis_pos = right_ellipsis_pos;
+	if (right_trim_pos == 0 && enforce_ellipsis && add_ellipsis) {
+		sd->overrun_trim_data.right_ellipsis_pos = 0;
 	}
 
-	if ((trim_pos >= 0 && sd->width > p_width) || enforce_ellipsis) {
-		if (add_ellipsis && (ellipsis_pos > 0 || enforce_ellipsis)) {
+	if (((left_trim_pos >= 0 || right_trim_pos >= 0) && sd->width > p_width) || enforce_ellipsis) {
+		if (add_ellipsis && ((left_ellipsis_pos > 0 || right_ellipsis_pos > 0) || enforce_ellipsis)) {
 			// Insert an additional space when cutting word bound for aesthetics.
-			if (cut_per_word && (ellipsis_pos > 0)) {
+			if (cut_per_word && (left_ellipsis_pos > 0 || right_ellipsis_pos > 0)) {
 				Glyph gl;
 				gl.count = 1;
 				gl.advance = whitespace_adv.x;
@@ -5491,24 +5555,32 @@ void TextServerAdvanced::_shaped_text_overrun_trim_to_width(const RID &p_shaped_
 		}
 
 		sd->text_trimmed = true;
-		sd->width_trimmed = width + ((ellipsis_pos != -1) ? ellipsis_width : 0);
+		sd->width_trimmed = width + (left_trim_pos >= 0 ? ellipsis_width : 0) + (right_trim_pos >= 0 ? ellipsis_width : 0);
 	}
 }
 
-int64_t TextServerAdvanced::_shaped_text_get_trim_pos(const RID &p_shaped) const {
+int64_t TextServerAdvanced::_shaped_text_get_trim_pos(const RID &p_shaped, bool p_left) const {
 	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL_V_MSG(sd, -1, "ShapedTextDataAdvanced invalid.");
 
 	MutexLock lock(sd->mutex);
-	return sd->overrun_trim_data.trim_pos;
+	if (p_left) {
+		return sd->overrun_trim_data.left_trim_pos;
+	} else {
+		return sd->overrun_trim_data.right_trim_pos;
+	}
 }
 
-int64_t TextServerAdvanced::_shaped_text_get_ellipsis_pos(const RID &p_shaped) const {
+int64_t TextServerAdvanced::_shaped_text_get_ellipsis_pos(const RID &p_shaped, bool p_left) const {
 	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL_V_MSG(sd, -1, "ShapedTextDataAdvanced invalid.");
 
 	MutexLock lock(sd->mutex);
-	return sd->overrun_trim_data.ellipsis_pos;
+	if (p_left) {
+		return sd->overrun_trim_data.left_ellipsis_pos;
+	} else {
+		return sd->overrun_trim_data.right_ellipsis_pos;
+	}
 }
 
 const Glyph *TextServerAdvanced::_shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const {
@@ -5525,6 +5597,14 @@ int64_t TextServerAdvanced::_shaped_text_get_ellipsis_glyph_count(const RID &p_s
 
 	MutexLock lock(sd->mutex);
 	return sd->overrun_trim_data.ellipsis_glyph_buf.size();
+}
+
+TextServer::TextOverrunDirection TextServerAdvanced::_shaped_text_get_ellipsis_direction(const RID &p_shaped) const {
+	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
+	ERR_FAIL_NULL_V_MSG(sd, OVERRUN_TRIM_END, "ShapedTextDataAdvanced invalid.");
+
+	MutexLock lock(sd->mutex);
+	return sd->overrun_trim_data.el_dir;
 }
 
 void TextServerAdvanced::_update_chars(ShapedTextDataAdvanced *p_sd) const {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -456,8 +456,11 @@ class TextServerAdvanced : public TextServerExtension {
 
 	// Shaped text cache data.
 	struct TrimData {
-		int trim_pos = -1;
-		int ellipsis_pos = -1;
+		TextServer::TextOverrunDirection el_dir = OVERRUN_TRIM_END;
+		int left_trim_pos = -1;
+		int left_ellipsis_pos = -1;
+		int right_trim_pos = -1;
+		int right_ellipsis_pos = -1;
 		Vector<Glyph> ellipsis_glyph_buf;
 	};
 
@@ -972,12 +975,13 @@ public:
 	MODBIND1R(bool, shaped_text_update_breaks, const RID &);
 	MODBIND1R(bool, shaped_text_update_justification_ops, const RID &);
 
-	MODBIND1RC(int64_t, shaped_text_get_trim_pos, const RID &);
-	MODBIND1RC(int64_t, shaped_text_get_ellipsis_pos, const RID &);
+	MODBIND2RC(int64_t, shaped_text_get_trim_pos, const RID &, bool);
+	MODBIND2RC(int64_t, shaped_text_get_ellipsis_pos, const RID &, bool);
 	MODBIND1RC(const Glyph *, shaped_text_get_ellipsis_glyphs, const RID &);
 	MODBIND1RC(int64_t, shaped_text_get_ellipsis_glyph_count, const RID &);
+	MODBIND1RC(TextServer::TextOverrunDirection, shaped_text_get_ellipsis_direction, const RID &);
 
-	MODBIND3(shaped_text_overrun_trim_to_width, const RID &, double, BitField<TextServer::TextOverrunFlag>);
+	MODBIND4(shaped_text_overrun_trim_to_width, const RID &, double, BitField<TextServer::TextOverrunFlag>, TextServer::TextOverrunDirection);
 
 	MODBIND1RC(bool, shaped_text_is_ready, const RID &);
 

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -394,8 +394,11 @@ class TextServerFallback : public TextServerExtension {
 
 	// Shaped text cache data.
 	struct TrimData {
-		int trim_pos = -1;
-		int ellipsis_pos = -1;
+		TextServer::TextOverrunDirection el_dir = OVERRUN_TRIM_END;
+		int left_trim_pos = -1;
+		int left_ellipsis_pos = -1;
+		int right_trim_pos = -1;
+		int right_ellipsis_pos = -1;
 		Vector<Glyph> ellipsis_glyph_buf;
 	};
 
@@ -832,12 +835,13 @@ public:
 	MODBIND1R(bool, shaped_text_update_breaks, const RID &);
 	MODBIND1R(bool, shaped_text_update_justification_ops, const RID &);
 
-	MODBIND1RC(int64_t, shaped_text_get_trim_pos, const RID &);
-	MODBIND1RC(int64_t, shaped_text_get_ellipsis_pos, const RID &);
+	MODBIND2RC(int64_t, shaped_text_get_trim_pos, const RID &, bool);
+	MODBIND2RC(int64_t, shaped_text_get_ellipsis_pos, const RID &, bool);
 	MODBIND1RC(const Glyph *, shaped_text_get_ellipsis_glyphs, const RID &);
 	MODBIND1RC(int64_t, shaped_text_get_ellipsis_glyph_count, const RID &);
+	MODBIND1RC(TextServer::TextOverrunDirection, shaped_text_get_ellipsis_direction, const RID &);
 
-	MODBIND3(shaped_text_overrun_trim_to_width, const RID &, double, BitField<TextServer::TextOverrunFlag>);
+	MODBIND4(shaped_text_overrun_trim_to_width, const RID &, double, BitField<TextServer::TextOverrunFlag>, TextServer::TextOverrunDirection);
 
 	MODBIND1RC(bool, shaped_text_is_ready, const RID &);
 

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -577,6 +577,21 @@ void Button::_shape(Ref<TextParagraph> p_paragraph, String p_text) const {
 	}
 	p_paragraph->add_string(p_text, font, font_size, language);
 	p_paragraph->set_text_overrun_behavior(overrun_behavior);
+	p_paragraph->set_ellipsis_direction(ellipsis_direction);
+}
+
+void Button::set_ellipsis_direction(TextServer::TextOverrunDirection p_ellipsis_direction) {
+	if (ellipsis_direction != p_ellipsis_direction) {
+		ellipsis_direction = p_ellipsis_direction;
+		_shape();
+
+		queue_redraw();
+		update_minimum_size();
+	}
+}
+
+TextServer::TextOverrunDirection Button::get_ellipsis_direction() const {
+	return ellipsis_direction;
 }
 
 void Button::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
@@ -784,6 +799,8 @@ void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vertical_icon_alignment"), &Button::get_vertical_icon_alignment);
 	ClassDB::bind_method(D_METHOD("set_expand_icon", "enabled"), &Button::set_expand_icon);
 	ClassDB::bind_method(D_METHOD("is_expand_icon"), &Button::is_expand_icon);
+	ClassDB::bind_method(D_METHOD("set_ellipsis_direction", "ellipsis_direction"), &Button::set_ellipsis_direction);
+	ClassDB::bind_method(D_METHOD("get_ellipsis_direction"), &Button::get_ellipsis_direction);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_button_icon", "get_button_icon");
@@ -792,6 +809,7 @@ void Button::_bind_methods() {
 	ADD_GROUP("Text Behavior", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_text_alignment", "get_text_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim Nothing,Trim Characters,Trim Words,Ellipsis,Word Ellipsis"), "set_text_overrun_behavior", "get_text_overrun_behavior");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "ellipsis_direction", PROPERTY_HINT_ENUM, "Start,Both,End"), "set_ellipsis_direction", "get_ellipsis_direction");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "autowrap_mode", PROPERTY_HINT_ENUM, "Off,Arbitrary,Word,Word (Smart)"), "set_autowrap_mode", "get_autowrap_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_text"), "set_clip_text", "get_clip_text");
 

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -51,6 +51,7 @@ private:
 	Ref<Texture2D> icon;
 	bool expand_icon = false;
 	bool clip_text = false;
+	TextServer::TextOverrunDirection ellipsis_direction = TextServer::OVERRUN_TRIM_END;
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_CENTER;
 	HorizontalAlignment horizontal_icon_alignment = HORIZONTAL_ALIGNMENT_LEFT;
 	VerticalAlignment vertical_icon_alignment = VERTICAL_ALIGNMENT_CENTER;
@@ -125,6 +126,9 @@ public:
 
 	void set_text(const String &p_text);
 	String get_text() const;
+
+	void set_ellipsis_direction(TextServer::TextOverrunDirection p_ellipsis_direction);
+	TextServer::TextOverrunDirection get_ellipsis_direction() const;
 
 	void set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior);
 	TextServer::OverrunBehavior get_text_overrun_behavior() const;

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -52,6 +52,7 @@ private:
 	TextServer::AutowrapMode autowrap_mode = TextServer::AUTOWRAP_OFF;
 	BitField<TextServer::JustificationFlag> jst_flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_SKIP_LAST_LINE | TextServer::JUSTIFICATION_DO_NOT_SKIP_SINGLE_LINE;
 	bool clip = false;
+	TextServer::TextOverrunDirection ellipsis_direction = TextServer::OVERRUN_TRIM_END;
 	String el_char = U"…";
 	TextServer::OverrunBehavior overrun_behavior = TextServer::OVERRUN_NO_TRIMMING;
 	mutable Size2 minsize;
@@ -155,6 +156,9 @@ public:
 
 	void set_justification_flags(BitField<TextServer::JustificationFlag> p_flags);
 	BitField<TextServer::JustificationFlag> get_justification_flags() const;
+
+	void set_ellipsis_direction(TextServer::TextOverrunDirection p_ellipsis_direction);
+	TextServer::TextOverrunDirection get_ellipsis_direction() const;
 
 	void set_uppercase(bool p_uppercase);
 	bool is_uppercase() const;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -433,6 +433,24 @@ TextServer::OverrunBehavior TreeItem::get_text_overrun_behavior(int p_column) co
 	return cells[p_column].text_buf->get_text_overrun_behavior();
 }
 
+void TreeItem::set_ellipsis_direction(int p_column, TextServer::TextOverrunDirection p_ellipsis_direction) {
+	ERR_FAIL_INDEX(p_column, cells.size());
+
+	if (cells[p_column].text_buf->get_ellipsis_direction() == p_ellipsis_direction) {
+		return;
+	}
+
+	cells.write[p_column].text_buf->set_ellipsis_direction(p_ellipsis_direction);
+	cells.write[p_column].dirty = true;
+	cells.write[p_column].cached_minimum_size_dirty = true;
+	_changed_notify(p_column);
+}
+
+TextServer::TextOverrunDirection TreeItem::get_ellipsis_direction(int p_column) const {
+	ERR_FAIL_INDEX_V(p_column, cells.size(), TextServer::OVERRUN_TRIM_END);
+	return cells[p_column].text_buf->get_ellipsis_direction();
+}
+
 void TreeItem::set_structured_text_bidi_override(int p_column, TextServer::StructuredTextParser p_parser) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 
@@ -1696,6 +1714,9 @@ void TreeItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_text_overrun_behavior", "column", "overrun_behavior"), &TreeItem::set_text_overrun_behavior);
 	ClassDB::bind_method(D_METHOD("get_text_overrun_behavior", "column"), &TreeItem::get_text_overrun_behavior);
+
+	ClassDB::bind_method(D_METHOD("set_ellipsis_direction", "column", "ellipsis_direction"), &TreeItem::set_ellipsis_direction);
+	ClassDB::bind_method(D_METHOD("get_ellipsis_direction", "column"), &TreeItem::get_ellipsis_direction);
 
 	ClassDB::bind_method(D_METHOD("set_structured_text_bidi_override", "column", "parser"), &TreeItem::set_structured_text_bidi_override);
 	ClassDB::bind_method(D_METHOD("get_structured_text_bidi_override", "column"), &TreeItem::get_structured_text_bidi_override);

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -250,6 +250,9 @@ public:
 	void set_text_overrun_behavior(int p_column, TextServer::OverrunBehavior p_behavior);
 	TextServer::OverrunBehavior get_text_overrun_behavior(int p_column) const;
 
+	void set_ellipsis_direction(int p_column, TextServer::TextOverrunDirection p_ellipsis_direction);
+	TextServer::TextOverrunDirection get_ellipsis_direction(int p_column) const;
+
 	void set_structured_text_bidi_override(int p_column, TextServer::StructuredTextParser p_parser);
 	TextServer::StructuredTextParser get_structured_text_bidi_override(int p_column) const;
 

--- a/scene/resources/text_line.cpp
+++ b/scene/resources/text_line.cpp
@@ -33,6 +33,11 @@
 void TextLine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &TextLine::clear);
 
+	ClassDB::bind_method(D_METHOD("set_ellipsis_direction", "ellipsis_direction"), &TextLine::set_ellipsis_direction);
+	ClassDB::bind_method(D_METHOD("get_ellipsis_direction"), &TextLine::get_ellipsis_direction);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "ellipsis_direction", PROPERTY_HINT_ENUM, "Start,Both,End"), "set_ellipsis_direction", "get_ellipsis_direction");
+
 	ClassDB::bind_method(D_METHOD("set_direction", "direction"), &TextLine::set_direction);
 	ClassDB::bind_method(D_METHOD("get_direction"), &TextLine::get_direction);
 
@@ -142,10 +147,10 @@ void TextLine::_shape() const {
 				TS->shaped_text_fit_to_width(rid, width, flags);
 				overrun_flags.set_flag(TextServer::OVERRUN_JUSTIFICATION_AWARE);
 				TS->shaped_text_set_custom_ellipsis(rid, (el_char.length() > 0) ? el_char[0] : 0x2026);
-				TS->shaped_text_overrun_trim_to_width(rid, width, overrun_flags);
+				TS->shaped_text_overrun_trim_to_width(rid, width, overrun_flags, ellipsis_direction);
 			} else {
 				TS->shaped_text_set_custom_ellipsis(rid, (el_char.length() > 0) ? el_char[0] : 0x2026);
-				TS->shaped_text_overrun_trim_to_width(rid, width, overrun_flags);
+				TS->shaped_text_overrun_trim_to_width(rid, width, overrun_flags, ellipsis_direction);
 			}
 		} else if (alignment == HORIZONTAL_ALIGNMENT_FILL) {
 			TS->shaped_text_fit_to_width(rid, width, flags);
@@ -160,6 +165,19 @@ RID TextLine::get_rid() const {
 
 void TextLine::clear() {
 	TS->shaped_text_clear(rid);
+}
+
+void TextLine::set_ellipsis_direction(TextServer::TextOverrunDirection p_ellipsis_direction) {
+	if (ellipsis_direction == p_ellipsis_direction) {
+		return;
+	}
+
+	ellipsis_direction = p_ellipsis_direction;
+	dirty = true;
+}
+
+TextServer::TextOverrunDirection TextLine::get_ellipsis_direction() const {
+	return ellipsis_direction;
 }
 
 void TextLine::set_preserve_invalid(bool p_enabled) {

--- a/scene/resources/text_line.h
+++ b/scene/resources/text_line.h
@@ -44,6 +44,7 @@ private:
 
 	mutable bool dirty = true;
 
+	TextServer::TextOverrunDirection ellipsis_direction = TextServer::OVERRUN_TRIM_END;
 	float width = -1.0;
 	BitField<TextServer::JustificationFlag> flags = TextServer::JUSTIFICATION_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA;
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_LEFT;
@@ -69,6 +70,9 @@ public:
 
 	void set_orientation(TextServer::Orientation p_orientation);
 	TextServer::Orientation get_orientation() const;
+
+	void set_ellipsis_direction(TextServer::TextOverrunDirection p_ellipsis_direction);
+	TextServer::TextOverrunDirection get_ellipsis_direction() const;
 
 	void set_preserve_invalid(bool p_enabled);
 	bool get_preserve_invalid() const;

--- a/scene/resources/text_paragraph.cpp
+++ b/scene/resources/text_paragraph.cpp
@@ -33,6 +33,11 @@
 void TextParagraph::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &TextParagraph::clear);
 
+	ClassDB::bind_method(D_METHOD("set_ellipsis_direction", "ellipsis_direction"), &TextParagraph::set_ellipsis_direction);
+	ClassDB::bind_method(D_METHOD("get_ellipsis_direction"), &TextParagraph::get_ellipsis_direction);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "ellipsis_direction", PROPERTY_HINT_ENUM, "Start,Both,End"), "set_ellipsis_direction", "get_ellipsis_direction");
+
 	ClassDB::bind_method(D_METHOD("set_direction", "direction"), &TextParagraph::set_direction);
 	ClassDB::bind_method(D_METHOD("get_direction"), &TextParagraph::get_direction);
 
@@ -266,12 +271,12 @@ void TextParagraph::_shape_lines() const {
 						TS->shaped_text_fit_to_width(lines_rid[i], line_w, jst_flags);
 					} else if (i == (visible_lines - 1)) {
 						TS->shaped_text_set_custom_ellipsis(lines_rid[visible_lines - 1], (el_char.length() > 0) ? el_char[0] : 0x2026);
-						TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], line_w, overrun_flags);
+						TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], line_w, overrun_flags, ellipsis_direction);
 					}
 				}
 			} else if (lines_hidden) {
 				TS->shaped_text_set_custom_ellipsis(lines_rid[visible_lines - 1], (el_char.length() > 0) ? el_char[0] : 0x2026);
-				TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], (visible_lines - 1 <= dropcap_lines) ? (width - h_offset) : width, overrun_flags);
+				TS->shaped_text_overrun_trim_to_width(lines_rid[visible_lines - 1], (visible_lines - 1 <= dropcap_lines) ? (width - h_offset) : width, overrun_flags, ellipsis_direction);
 			}
 		} else {
 			// Autowrap disabled.
@@ -297,11 +302,11 @@ void TextParagraph::_shape_lines() const {
 					TS->shaped_text_fit_to_width(lines_rid[i], line_w, jst_flags);
 					overrun_flags.set_flag(TextServer::OVERRUN_JUSTIFICATION_AWARE);
 					TS->shaped_text_set_custom_ellipsis(lines_rid[i], (el_char.length() > 0) ? el_char[0] : 0x2026);
-					TS->shaped_text_overrun_trim_to_width(lines_rid[i], line_w, overrun_flags);
+					TS->shaped_text_overrun_trim_to_width(lines_rid[i], line_w, overrun_flags, ellipsis_direction);
 					TS->shaped_text_fit_to_width(lines_rid[i], line_w, jst_flags | TextServer::JUSTIFICATION_CONSTRAIN_ELLIPSIS);
 				} else {
 					TS->shaped_text_set_custom_ellipsis(lines_rid[i], (el_char.length() > 0) ? el_char[0] : 0x2026);
-					TS->shaped_text_overrun_trim_to_width(lines_rid[i], line_w, overrun_flags);
+					TS->shaped_text_overrun_trim_to_width(lines_rid[i], line_w, overrun_flags, ellipsis_direction);
 				}
 			}
 		}
@@ -334,6 +339,19 @@ void TextParagraph::clear() {
 	lines_rid.clear();
 	TS->shaped_text_clear(rid);
 	TS->shaped_text_clear(dropcap_rid);
+}
+
+void TextParagraph::set_ellipsis_direction(TextServer::TextOverrunDirection p_ellipsis_direction) {
+	if (ellipsis_direction == p_ellipsis_direction) {
+		return;
+	}
+
+	ellipsis_direction = p_ellipsis_direction;
+	lines_dirty = true;
+}
+
+TextServer::TextOverrunDirection TextParagraph::get_ellipsis_direction() const {
+	return ellipsis_direction;
 }
 
 void TextParagraph::set_preserve_invalid(bool p_enabled) {

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -51,6 +51,7 @@ private:
 
 	mutable bool lines_dirty = true;
 
+	TextServer::TextOverrunDirection ellipsis_direction = TextServer::OVERRUN_TRIM_END;
 	float line_spacing = 0.0;
 	float width = -1.0;
 	int max_lines_visible = -1;
@@ -75,6 +76,9 @@ public:
 	RID get_dropcap_rid() const;
 
 	void clear();
+
+	void set_ellipsis_direction(TextServer::TextOverrunDirection p_ellipsis_direction);
+	TextServer::TextOverrunDirection get_ellipsis_direction() const;
 
 	void set_direction(TextServer::Direction p_direction);
 	TextServer::Direction get_direction() const;

--- a/servers/text/text_server_dummy.h
+++ b/servers/text/text_server_dummy.h
@@ -109,10 +109,11 @@ public:
 	virtual const Glyph *shaped_text_sort_logical(const RID &p_shaped) override { return nullptr; }
 	virtual int64_t shaped_text_get_glyph_count(const RID &p_shaped) const override { return 0; }
 	virtual Vector2i shaped_text_get_range(const RID &p_shaped) const override { return Vector2i(); }
-	virtual int64_t shaped_text_get_trim_pos(const RID &p_shaped) const override { return -1; }
-	virtual int64_t shaped_text_get_ellipsis_pos(const RID &p_shaped) const override { return -1; }
+	virtual int64_t shaped_text_get_trim_pos(const RID &p_shaped, bool p_left = false) const override { return -1; }
+	virtual int64_t shaped_text_get_ellipsis_pos(const RID &p_shaped, bool p_left = false) const override { return -1; }
 	virtual const Glyph *shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const override { return nullptr; }
 	virtual int64_t shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const override { return -1; }
+	virtual TextOverrunDirection shaped_text_get_ellipsis_direction(const RID &p_shaped) const override { return OVERRUN_TRIM_END; }
 	virtual Array shaped_text_get_objects(const RID &p_shaped) const override { return Array(); }
 	virtual Rect2 shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const override { return Rect2(); }
 	virtual Vector2i shaped_text_get_object_range(const RID &p_shaped, const Variant &p_key) const override { return Vector2i(); }

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -293,12 +293,13 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_shaped_text_get_line_breaks, "shaped", "width", "start", "break_flags");
 	GDVIRTUAL_BIND(_shaped_text_get_word_breaks, "shaped", "grapheme_flags", "skip_grapheme_flags");
 
-	GDVIRTUAL_BIND(_shaped_text_get_trim_pos, "shaped");
-	GDVIRTUAL_BIND(_shaped_text_get_ellipsis_pos, "shaped");
+	GDVIRTUAL_BIND(_shaped_text_get_trim_pos, "shaped", "left");
+	GDVIRTUAL_BIND(_shaped_text_get_ellipsis_pos, "shaped", "left");
 	GDVIRTUAL_BIND(_shaped_text_get_ellipsis_glyph_count, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_ellipsis_glyphs, "shaped");
+	GDVIRTUAL_BIND(_shaped_text_get_ellipsis_direction, "shaped");
 
-	GDVIRTUAL_BIND(_shaped_text_overrun_trim_to_width, "shaped", "width", "trim_flags");
+	GDVIRTUAL_BIND(_shaped_text_overrun_trim_to_width, "shaped", "width", "trim_flags", "direction");
 
 	GDVIRTUAL_BIND(_shaped_text_get_objects, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_object_rect, "shaped", "key");
@@ -1299,15 +1300,15 @@ PackedInt32Array TextServerExtension::shaped_text_get_word_breaks(const RID &p_s
 	return TextServer::shaped_text_get_word_breaks(p_shaped, p_grapheme_flags, p_skip_grapheme_flags);
 }
 
-int64_t TextServerExtension::shaped_text_get_trim_pos(const RID &p_shaped) const {
+int64_t TextServerExtension::shaped_text_get_trim_pos(const RID &p_shaped, bool p_left) const {
 	int64_t ret = -1;
-	GDVIRTUAL_CALL(_shaped_text_get_trim_pos, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_trim_pos, p_shaped, p_left, ret);
 	return ret;
 }
 
-int64_t TextServerExtension::shaped_text_get_ellipsis_pos(const RID &p_shaped) const {
+int64_t TextServerExtension::shaped_text_get_ellipsis_pos(const RID &p_shaped, bool p_left) const {
 	int64_t ret = -1;
-	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_pos, p_shaped, ret);
+	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_pos, p_shaped, p_left, ret);
 	return ret;
 }
 
@@ -1323,8 +1324,14 @@ int64_t TextServerExtension::shaped_text_get_ellipsis_glyph_count(const RID &p_s
 	return ret;
 }
 
-void TextServerExtension::shaped_text_overrun_trim_to_width(const RID &p_shaped_line, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) {
-	GDVIRTUAL_CALL(_shaped_text_overrun_trim_to_width, p_shaped_line, p_width, p_trim_flags);
+TextServer::TextOverrunDirection TextServerExtension::shaped_text_get_ellipsis_direction(const RID &p_shaped) const {
+	TextOverrunDirection ret = OVERRUN_TRIM_END;
+	GDVIRTUAL_CALL(_shaped_text_get_ellipsis_direction, p_shaped, ret);
+	return ret;
+}
+
+void TextServerExtension::shaped_text_overrun_trim_to_width(const RID &p_shaped_line, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags, TextOverrunDirection p_direction) {
+	GDVIRTUAL_CALL(_shaped_text_overrun_trim_to_width, p_shaped_line, p_width, p_trim_flags, p_direction);
 }
 
 Array TextServerExtension::shaped_text_get_objects(const RID &p_shaped) const {

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -488,17 +488,19 @@ public:
 	GDVIRTUAL4RC(PackedInt32Array, _shaped_text_get_line_breaks, RID, double, int64_t, BitField<TextServer::LineBreakFlag>);
 	GDVIRTUAL3RC(PackedInt32Array, _shaped_text_get_word_breaks, RID, BitField<TextServer::GraphemeFlag>, BitField<TextServer::GraphemeFlag>);
 
-	virtual int64_t shaped_text_get_trim_pos(const RID &p_shaped) const override;
-	virtual int64_t shaped_text_get_ellipsis_pos(const RID &p_shaped) const override;
+	virtual int64_t shaped_text_get_trim_pos(const RID &p_shaped, bool p_left = false) const override;
+	virtual int64_t shaped_text_get_ellipsis_pos(const RID &p_shaped, bool p_left = false) const override;
 	virtual const Glyph *shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const override;
 	virtual int64_t shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const override;
-	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_trim_pos, RID);
-	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_ellipsis_pos, RID);
+	virtual TextServer::TextOverrunDirection shaped_text_get_ellipsis_direction(const RID &p_shaped) const override;
+	GDVIRTUAL2RC_REQUIRED(int64_t, _shaped_text_get_trim_pos, RID, bool);
+	GDVIRTUAL2RC_REQUIRED(int64_t, _shaped_text_get_ellipsis_pos, RID, bool);
 	GDVIRTUAL1RC_REQUIRED(GDExtensionConstPtr<const Glyph>, _shaped_text_get_ellipsis_glyphs, RID);
 	GDVIRTUAL1RC_REQUIRED(int64_t, _shaped_text_get_ellipsis_glyph_count, RID);
+	GDVIRTUAL1RC_REQUIRED(TextServer::TextOverrunDirection, _shaped_text_get_ellipsis_direction, RID);
 
-	virtual void shaped_text_overrun_trim_to_width(const RID &p_shaped, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) override;
-	GDVIRTUAL3(_shaped_text_overrun_trim_to_width, RID, double, BitField<TextServer::TextOverrunFlag>);
+	virtual void shaped_text_overrun_trim_to_width(const RID &p_shaped, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags, TextServer::TextOverrunDirection p_direction) override;
+	GDVIRTUAL4(_shaped_text_overrun_trim_to_width, RID, double, BitField<TextServer::TextOverrunFlag>, TextServer::TextOverrunDirection);
 
 	virtual Array shaped_text_get_objects(const RID &p_shaped) const override;
 	virtual Rect2 shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const override;

--- a/servers/text_server.compat.inc
+++ b/servers/text_server.compat.inc
@@ -34,8 +34,27 @@ PackedInt32Array TextServer::_shaped_text_get_word_breaks_bind_compat_90732(cons
 	return shaped_text_get_word_breaks(p_shaped, p_grapheme_flags, 0);
 }
 
+int64_t TextServer::_shaped_text_get_trim_pos_bind_compat_99236(const RID &p_shaped) const {
+	bool is_rtl = shaped_text_get_inferred_direction(p_shaped) == DIRECTION_RTL;
+
+	return shaped_text_get_trim_pos(p_shaped, is_rtl);
+}
+
+int64_t TextServer::_shaped_text_get_ellipsis_pos_bind_compat_99236(const RID &p_shaped) const {
+	bool is_rtl = shaped_text_get_inferred_direction(p_shaped) == DIRECTION_RTL;
+
+	return shaped_text_get_ellipsis_pos(p_shaped, is_rtl);
+}
+
+void TextServer::_shaped_text_overrun_trim_to_width_bind_compat_99236(const RID &p_shaped, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) {
+	shaped_text_overrun_trim_to_width(p_shaped, p_width, p_trim_flags, OVERRUN_TRIM_END);
+}
+
 void TextServer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("shaped_text_get_word_breaks", "shaped", "grapheme_flags"), &TextServer::_shaped_text_get_word_breaks_bind_compat_90732, DEFVAL(GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION));
+	ClassDB::bind_compatibility_method(D_METHOD("shaped_text_get_trim_pos", "shaped"), &TextServer::_shaped_text_get_trim_pos_bind_compat_99236);
+	ClassDB::bind_compatibility_method(D_METHOD("shaped_text_get_ellipsis_pos", "shaped"), &TextServer::_shaped_text_get_ellipsis_pos_bind_compat_99236);
+	ClassDB::bind_compatibility_method(D_METHOD("shaped_text_overrun_trim_to_width", "shaped", "width", "overrun_trim_flags"), &TextServer::_shaped_text_overrun_trim_to_width_bind_compat_99236, DEFVAL(0), DEFVAL(OVERRUN_NO_TRIM));
 }
 
 #endif

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -130,6 +130,12 @@ public:
 		OVERRUN_JUSTIFICATION_AWARE = 1 << 4,
 	};
 
+	enum TextOverrunDirection {
+		OVERRUN_TRIM_START,
+		OVERRUN_TRIM_BOTH,
+		OVERRUN_TRIM_END,
+	};
+
 	enum GraphemeFlag {
 		GRAPHEME_IS_VALID = 1 << 0, // Grapheme is valid.
 		GRAPHEME_IS_RTL = 1 << 1, // Grapheme is right-to-left.
@@ -228,6 +234,11 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	PackedInt32Array _shaped_text_get_word_breaks_bind_compat_90732(const RID &p_shaped, BitField<TextServer::GraphemeFlag> p_grapheme_flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION) const;
+
+	int64_t _shaped_text_get_trim_pos_bind_compat_99236(const RID &p_shaped) const;
+	int64_t _shaped_text_get_ellipsis_pos_bind_compat_99236(const RID &p_shaped) const;
+	void _shaped_text_overrun_trim_to_width_bind_compat_99236(const RID &p_shaped, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags);
+
 	static void _bind_compatibility_methods();
 #endif
 
@@ -496,13 +507,14 @@ public:
 	virtual PackedInt32Array shaped_text_get_line_breaks(const RID &p_shaped, double p_width, int64_t p_start = 0, BitField<TextServer::LineBreakFlag> p_break_flags = BREAK_MANDATORY | BREAK_WORD_BOUND) const;
 	virtual PackedInt32Array shaped_text_get_word_breaks(const RID &p_shaped, BitField<TextServer::GraphemeFlag> p_grapheme_flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION, BitField<TextServer::GraphemeFlag> p_skip_grapheme_flags = GRAPHEME_IS_VIRTUAL) const;
 
-	virtual int64_t shaped_text_get_trim_pos(const RID &p_shaped) const = 0;
-	virtual int64_t shaped_text_get_ellipsis_pos(const RID &p_shaped) const = 0;
+	virtual int64_t shaped_text_get_trim_pos(const RID &p_shaped, bool p_left = false) const = 0;
+	virtual int64_t shaped_text_get_ellipsis_pos(const RID &p_shaped, bool p_left = false) const = 0;
 	virtual const Glyph *shaped_text_get_ellipsis_glyphs(const RID &p_shaped) const = 0;
 	TypedArray<Dictionary> _shaped_text_get_ellipsis_glyphs_wrapper(const RID &p_shaped) const;
 	virtual int64_t shaped_text_get_ellipsis_glyph_count(const RID &p_shaped) const = 0;
+	virtual TextOverrunDirection shaped_text_get_ellipsis_direction(const RID &p_shaped) const = 0;
 
-	virtual void shaped_text_overrun_trim_to_width(const RID &p_shaped, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags) = 0;
+	virtual void shaped_text_overrun_trim_to_width(const RID &p_shaped, double p_width, BitField<TextServer::TextOverrunFlag> p_trim_flags, TextOverrunDirection p_direction = OVERRUN_TRIM_END) = 0;
 
 	virtual Array shaped_text_get_objects(const RID &p_shaped) const = 0;
 	virtual Rect2 shaped_text_get_object_rect(const RID &p_shaped, const Variant &p_key) const = 0;
@@ -654,6 +666,7 @@ VARIANT_ENUM_CAST(TextServer::Orientation);
 VARIANT_BITFIELD_CAST(TextServer::JustificationFlag);
 VARIANT_BITFIELD_CAST(TextServer::LineBreakFlag);
 VARIANT_BITFIELD_CAST(TextServer::TextOverrunFlag);
+VARIANT_ENUM_CAST(TextServer::TextOverrunDirection);
 VARIANT_BITFIELD_CAST(TextServer::GraphemeFlag);
 VARIANT_ENUM_CAST(TextServer::Hinting);
 VARIANT_ENUM_CAST(TextServer::SubpixelPositioning);


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/99234#issuecomment-2476493765