### PR TITLE
Fix file order issue with base and enumerated file-names

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1022,6 +1022,15 @@ static _FORCE_INLINE_ signed char naturalnocasecmp_to_base(const char32_t *p_thi
 		while (*p_this_str) {
 			if (!*p_that_str) {
 				return 1;
+			} else if (*p_this_str == '.' || *p_that_str == '.') {
+				if (*p_this_str != '.') {
+					return 1;
+				}
+				if (*p_that_str != '.') {
+					return -1;
+				}
+				p_this_str++;
+				p_that_str++;
 			} else if (is_digit(*p_this_str)) {
 				if (!is_digit(*p_that_str)) {
 					return -1;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1023,14 +1023,12 @@ static _FORCE_INLINE_ signed char naturalnocasecmp_to_base(const char32_t *p_thi
 			if (!*p_that_str) {
 				return 1;
 			} else if (*p_this_str == '.' || *p_that_str == '.') {
-				if (*p_this_str != '.') {
+				if (*p_this_str++ != '.') {
 					return 1;
 				}
-				if (*p_that_str != '.') {
+				if (*p_that_str++ != '.') {
 					return -1;
 				}
-				p_this_str++;
-				p_that_str++;
 			} else if (is_digit(*p_this_str)) {
 				if (!is_digit(*p_that_str)) {
 					return -1;


### PR DESCRIPTION
fix #99235

Added a `.` check before digits' check makes file name sporting put base name before enumerated ones (`name.ext` before `name1.ext`).
