### PR TITLE
Add a new theme for the Android and XR editor

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -359,6 +359,10 @@ public:
 	// This is invoked by the GDExtensionManager after loading GDExtensions specified by the project.
 	virtual void load_platform_gdextensions() const {}
 
+	// Allows the platform to customize the editor theme.
+	// Should return a path to a theme resource that will be merged with the current editor theme.
+	virtual String get_editor_theme_override(const String &p_editor_theme_preset) { return String(); }
+
 	OS();
 	virtual ~OS();
 };

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1024,11 +1024,19 @@
 			The saturation to use for editor icons. Higher values result in more vibrant colors.
 			[b]Note:[/b] The default editor icon saturation was increased by 30% in Godot 4.0 and later. To get Godot 3.x's icon saturation back, set [member interface/theme/icon_saturation] to [code]0.77[/code].
 		</member>
+		<member name="interface/theme/increase_scrollbar_touch_area" type="bool" setter="" getter="">
+			If [code]true[/code], increases the scrollbar touch area to improve usability on touchscreen devices.
+			[b]Note:[/b] Defaults to [code]true[/code] on touchscreen devices.
+		</member>
 		<member name="interface/theme/preset" type="String" setter="" getter="">
 			The editor theme preset to use.
 		</member>
 		<member name="interface/theme/relationship_line_opacity" type="float" setter="" getter="">
 			The opacity to use when drawing relationship lines in the editor's [Tree]-based GUIs (such as the Scene tree dock).
+		</member>
+		<member name="interface/theme/scale_gizmo_handles" type="float" setter="" getter="">
+			Specify the multiplier to apply to the scale for the editor gizmo handles to improve usability on touchscreen devices.
+			[b]Note:[/b] Defaults to [code]1[/code] on non-touchscreen devices.
 		</member>
 		<member name="interface/theme/spacing_preset" type="String" setter="" getter="">
 			The editor theme spacing preset to use. See also [member interface/theme/base_spacing] and [member interface/theme/additional_spacing].
@@ -1044,14 +1052,6 @@
 		<member name="interface/touchscreen/enable_pan_and_scale_gestures" type="bool" setter="" getter="">
 			If [code]true[/code], enable two finger pan and scale gestures on touchscreen devices.
 			[b]Note:[/b] Defaults to [code]true[/code] on touchscreen devices.
-		</member>
-		<member name="interface/touchscreen/increase_scrollbar_touch_area" type="bool" setter="" getter="">
-			If [code]true[/code], increases the scrollbar touch area to improve usability on touchscreen devices.
-			[b]Note:[/b] Defaults to [code]true[/code] on touchscreen devices.
-		</member>
-		<member name="interface/touchscreen/scale_gizmo_handles" type="float" setter="" getter="">
-			Specify the multiplier to apply to the scale for the editor gizmo handles to improve usability on touchscreen devices.
-			[b]Note:[/b] Defaults to [code]1[/code] on non-touchscreen devices.
 		</member>
 		<member name="network/connection/engine_version_update_mode" type="int" setter="" getter="">
 			Specifies how the engine should check for updates.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -537,8 +537,16 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_OKHSL_CIRCLE, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle")
 
 	// Theme
+	bool has_touchscreen_ui = DisplayServer::get_singleton()->is_touchscreen_available();
+	bool is_native_touchscreen = has_touchscreen_ui && !OS::get_singleton()->has_feature("xr_editor");
+
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_ENUM, "interface/theme/follow_system_theme", false, "")
-	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", "Default", "Default,Breeze Dark,Godot 2,Gray,Light,Solarized (Dark),Solarized (Light),Black (OLED),Custom")
+
+	String default_theme_preset = "Default";
+#ifdef ANDROID_ENABLED
+	default_theme_preset = "Android";
+#endif
+	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", default_theme_preset, "Default,Breeze Dark,Godot 2,Gray,Light,Solarized (Dark),Solarized (Light),Black (OLED),Custom,Android")
 	EDITOR_SETTING_BASIC(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/spacing_preset", "Default", "Compact,Default,Spacious,Custom")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/theme/icon_and_font_color", 0, "Auto,Dark,Light")
 	EDITOR_SETTING_BASIC(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/base_color", Color(0.2, 0.23, 0.31), "")
@@ -552,21 +560,19 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/corner_radius", 3, "0,6,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/base_spacing", 4, "0,8,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/additional_spacing", 0, "0,8,1")
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/theme/increase_scrollbar_touch_area", is_native_touchscreen, "")
+	set_restart_if_changed("interface/theme/increase_scrollbar_touch_area", true);
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/scale_gizmo_handles", has_touchscreen_ui ? 3 : 1, "1,5,1")
+	set_restart_if_changed("interface/theme/scale_gizmo_handles", true);
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "interface/theme/custom_theme", "", "*.res,*.tres,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	// Touchscreen
-	bool has_touchscreen_ui = DisplayServer::get_singleton()->is_touchscreen_available();
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_pan_and_scale_gestures", has_touchscreen_ui, "")
 	set_restart_if_changed("interface/touchscreen/enable_pan_and_scale_gestures", true);
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/touchscreen/scale_gizmo_handles", has_touchscreen_ui ? 3 : 1, "1,5,1")
-	set_restart_if_changed("interface/touchscreen/scale_gizmo_handles", true);
 
 	// Disable some touchscreen settings by default for the XR Editor.
-	bool is_native_touchscreen = has_touchscreen_ui && !OS::get_singleton()->has_feature("xr_editor");
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/enable_long_press_as_right_click", is_native_touchscreen, "")
 	set_restart_if_changed("interface/touchscreen/enable_long_press_as_right_click", true);
-	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/touchscreen/increase_scrollbar_touch_area", is_native_touchscreen, "")
-	set_restart_if_changed("interface/touchscreen/increase_scrollbar_touch_area", true);
 
 	// Scene tabs
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/scene_tabs/display_close_button", 1, "Never,If Tab Active,Always"); // TabBar::CloseButtonDisplayPolicy

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -121,7 +121,7 @@ void CurveEdit::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			float gizmo_scale = EDITOR_GET("interface/touchscreen/scale_gizmo_handles");
+			float gizmo_scale = EDITOR_GET("interface/theme/scale_gizmo_handles");
 			point_radius = Math::round(BASE_POINT_RADIUS * get_theme_default_base_scale() * gizmo_scale);
 			hover_radius = Math::round(BASE_HOVER_RADIUS * get_theme_default_base_scale() * gizmo_scale);
 			tangent_radius = Math::round(BASE_TANGENT_RADIUS * get_theme_default_base_scale() * gizmo_scale);

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -245,8 +245,8 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 	config.relationship_line_opacity = EDITOR_GET("interface/theme/relationship_line_opacity");
 	config.thumb_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
 	config.class_icon_size = 16 * EDSCALE;
-	config.increase_scrollbar_touch_area = EDITOR_GET("interface/touchscreen/increase_scrollbar_touch_area");
-	config.gizmo_handle_scale = EDITOR_GET("interface/touchscreen/scale_gizmo_handles");
+	config.increase_scrollbar_touch_area = EDITOR_GET("interface/theme/increase_scrollbar_touch_area");
+	config.gizmo_handle_scale = EDITOR_GET("interface/theme/scale_gizmo_handles");
 	config.color_picker_button_height = 28 * EDSCALE;
 	config.subresource_hue_tint = EDITOR_GET("docks/property_editor/subresource_hue_tint");
 
@@ -282,9 +282,15 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 			Color preset_base_color;
 			float preset_contrast = 0;
 			bool preset_draw_extra_borders = false;
+			float preset_icon_saturation = config.icon_saturation;
 
 			// Please use alphabetical order if you're adding a new theme here.
-			if (config.preset == "Breeze Dark") {
+			if (config.preset == "Android") {
+				preset_accent_color = Color(0.34, 0.62, 1.00);
+				preset_base_color = Color(0.15, 0.15, 0.15);
+				preset_contrast = 0.3;
+				preset_icon_saturation = 2;
+			} else if (config.preset == "Breeze Dark") {
 				preset_accent_color = Color(0.26, 0.76, 1.00);
 				preset_base_color = Color(0.24, 0.26, 0.28);
 				preset_contrast = config.default_contrast;
@@ -326,11 +332,13 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 			config.base_color = preset_base_color;
 			config.contrast = preset_contrast;
 			config.draw_extra_borders = preset_draw_extra_borders;
+			config.icon_saturation = preset_icon_saturation;
 
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/accent_color", config.accent_color);
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/base_color", config.base_color);
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/contrast", config.contrast);
 			EditorSettings::get_singleton()->set_initial_value("interface/theme/draw_extra_borders", config.draw_extra_borders);
+			EditorSettings::get_singleton()->set_initial_value("interface/theme/icon_saturation", config.icon_saturation);
 		}
 
 		if (follow_system_theme && system_base_color != Color(0, 0, 0, 0)) {
@@ -349,6 +357,7 @@ EditorThemeManager::ThemeConfiguration EditorThemeManager::_create_theme_config(
 		EditorSettings::get_singleton()->set_manually("interface/theme/base_color", config.base_color);
 		EditorSettings::get_singleton()->set_manually("interface/theme/contrast", config.contrast);
 		EditorSettings::get_singleton()->set_manually("interface/theme/draw_extra_borders", config.draw_extra_borders);
+		EditorSettings::get_singleton()->set_manually("interface/theme/icon_saturation", config.icon_saturation);
 	}
 
 	// Handle theme spacing preset.
@@ -2769,6 +2778,14 @@ Ref<EditorTheme> EditorThemeManager::generate_theme(const Ref<EditorTheme> &p_ol
 	Ref<EditorTheme> theme = _create_base_theme(p_old_theme);
 
 	OS::get_singleton()->benchmark_begin_measure(get_benchmark_key(), "Merge Custom Theme");
+
+	const String platform_theme_override_path = OS::get_singleton()->get_editor_theme_override(EDITOR_GET("interface/theme/preset"));
+	if (!platform_theme_override_path.is_empty()) {
+		Ref<Theme> platform_theme_override = ResourceLoader::load(platform_theme_override_path);
+		if (platform_theme_override.is_valid()) {
+			theme->merge_with(platform_theme_override);
+		}
+	}
 
 	const String custom_theme_path = EDITOR_GET("interface/theme/custom_theme");
 	if (!custom_theme_path.is_empty()) {

--- a/platform/android/java/editor/src/main/assets/themes/README.md
+++ b/platform/android/java/editor/src/main/assets/themes/README.md
@@ -1,0 +1,3 @@
+## Godot Minimal Theme
+- Source: https://github.com/passivestar/godot-minimal-theme
+- Version: https://github.com/passivestar/godot-minimal-theme/releases/tag/2.0.1

--- a/platform/android/java/editor/src/main/assets/themes/minimal_theme.tres
+++ b/platform/android/java/editor/src/main/assets/themes/minimal_theme.tres
@@ -1,0 +1,726 @@
+[gd_resource type="Theme" load_steps=2 format=3 uid="uid://bcibt73qths3g"]
+
+[sub_resource type="GDScript" id="GDScript_hhmc0"]
+script/source = "@tool
+extends Theme
+
+var base_color : Color
+var contrast : float
+var scale : float
+var dark_theme : bool
+
+func _init() -> void:
+	# Editor Settings
+
+	var settings := EditorInterface.get_editor_settings()
+
+	base_color = settings.get_setting('interface/theme/base_color') as Color
+	contrast = settings.get_setting('interface/theme/contrast') as float
+	scale = EditorInterface.get_editor_scale()
+
+	var accent_color := settings.get_setting('interface/theme/accent_color') as Color
+	var base_spacing := settings.get_setting('interface/theme/base_spacing') as int
+	var extra_spacing := settings.get_setting('interface/theme/additional_spacing') as int
+	var corner_radius := settings.get_setting('interface/theme/corner_radius') as int
+	var icon_and_font_color := settings.get_setting('interface/theme/icon_and_font_color') as int
+	var relationship_line_opacity := settings.get_setting('interface/theme/relationship_line_opacity') as float
+	var draw_extra_borders := settings.get_setting('interface/theme/draw_extra_borders') as bool
+
+	# Globals
+
+	var base_margin = base_spacing
+	var increased_margin = base_spacing + extra_spacing * 0.75
+	var popup_margin = base_margin * 2.4
+
+	dark_theme = base_color.get_luminance() < 0.5
+	if icon_and_font_color != 0: # ColorMode.AUTO_COLOR
+		dark_theme = icon_and_font_color == 1 # ColorMode.DARK
+
+	var mono_color = Color.WHITE if dark_theme else Color.BLACK
+
+	var extra_border_color_1 = Color(1, 1, 1, 0.4) if dark_theme else Color(0, 0, 0, 0.4)
+	var extra_border_color_2 = Color(1, 1, 1, 0.2) if dark_theme else Color(0, 0, 0, 0.2)
+
+	# Ensure minimum contrast with the light theme. The default
+	# contrast makes it hard to see the UI elements
+	if not dark_theme and contrast < 0 and contrast > -0.4:
+		contrast = -0.4
+
+	# Main stylebox that most styleboxes duplicate
+	var base_sb := StyleBoxFlat.new()
+	base_sb.bg_color = base_color
+	base_sb.set_content_margin_all(base_margin * scale)
+	base_sb.set_corner_radius_all(corner_radius * scale)
+
+	# Non-transparent buttons will potentially blend worse with background
+	# than transparent ones, however this is currently only noticeable on the Close
+	# button of editor settings, and it probably shouldn't even exist
+	var button_sb := base_sb.duplicate()
+	button_sb.bg_color = _get_base_color(0.3, 0.8)
+	if draw_extra_borders:
+		_set_border(button_sb, extra_border_color_1, floor(scale))
+	else:
+		_set_border(button_sb, _get_base_color(0.5, 0.7), 1, true)
+	_set_margin(button_sb, base_margin * 2, base_margin * 1.5, base_margin * 2, base_margin * 1.5)
+
+	var button_hover_sb := button_sb.duplicate()
+	button_hover_sb.bg_color = _get_base_color(0.5, 0.7)
+	if draw_extra_borders:
+		_set_border(button_hover_sb, extra_border_color_1, floor(scale))
+	else:
+		_set_border(button_hover_sb, _get_base_color(0.7, 0.7), 1, true)
+
+	var button_pressed_sb := button_sb.duplicate()
+	button_pressed_sb.bg_color = _get_base_color(0.7, 0.7)
+	if draw_extra_borders:
+		_set_border(button_pressed_sb, extra_border_color_1, floor(scale))
+	else:
+		_set_border(button_pressed_sb, _get_base_color(0.9, 0.7), 1, true)
+
+	var button_disabled_sb := button_sb.duplicate()
+	button_disabled_sb.set_border_width_all(0)
+	button_disabled_sb.bg_color = _get_base_color(0.2, 0.7)
+	if draw_extra_borders:
+		_set_border(button_disabled_sb, extra_border_color_2 * Color(1, 1, 1, 0.5), floor(scale))
+
+	var flat_button_hover_sb := base_sb.duplicate()
+	_set_margin(flat_button_hover_sb, base_margin * 1.5, base_margin, base_margin * 1.5, base_margin)
+	flat_button_hover_sb.bg_color = _get_base_color(0.3, 0.7)
+	if draw_extra_borders:
+		_set_border(flat_button_hover_sb, extra_border_color_1, floor(scale))
+
+	var flat_button_pressed_sb := flat_button_hover_sb.duplicate()
+	flat_button_pressed_sb.bg_color = _get_base_color(0.5, 0.7)
+
+	var empty_sb := StyleBoxEmpty.new()
+	var empty_margin_sb := StyleBoxEmpty.new()
+	empty_margin_sb.set_content_margin_all(base_margin * 2 * scale)
+	var empty_wide_sb := StyleBoxEmpty.new()
+	_set_margin(empty_wide_sb, base_margin * 1.5, base_margin, base_margin * 1.5, base_margin)
+
+	# Animation editor
+
+	set_color('focus_color', 'AnimationBezierTrackEdit', Color.TRANSPARENT)
+	set_color('h_line_color', 'AnimationBezierTrackEdit', mono_color * Color(1, 1, 1, 0.12))
+	set_color('track_focus_color', 'AnimationBezierTrackEdit', mono_color * Color(1, 1, 1, 0.1))
+	set_color('v_line_color', 'AnimationBezierTrackEdit', Color.TRANSPARENT)
+
+	set_color('font_primary_color', 'AnimationTimelineEdit', mono_color * Color(1, 1, 1, 0.7))
+	set_color('font_secondary_color', 'AnimationTimelineEdit', mono_color * Color(1, 1, 1, 0.4))
+	set_color('h_line_color', 'AnimationTimelineEdit', Color.TRANSPARENT)
+	set_color('v_line_primary_color', 'AnimationTimelineEdit', mono_color * Color(1, 1, 1, 0.4))
+	set_color('v_line_secondary_color', 'AnimationTimelineEdit', mono_color * Color(1, 1, 1, 0.08))
+
+	set_constant('text_primary_margin', 'AnimationTimelineEdit', base_margin * 0.75 * scale)
+	set_constant('text_secondary_margin', 'AnimationTimelineEdit', base_margin * 0.5 * scale)
+	set_constant('v_line_primary_margin', 'AnimationTimelineEdit', base_margin * scale)
+	set_constant('v_line_primary_width', 'AnimationTimelineEdit', ceil(2 * scale))
+	set_constant('v_line_secondary_margin', 'AnimationTimelineEdit', base_margin * 1.5 * scale)
+	set_constant('v_line_secondary_width', 'AnimationTimelineEdit', ceil(scale))
+
+	var sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(0.55, 0.7)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_1, floor(scale))
+	set_stylebox('time_available', 'AnimationTimelineEdit', sb)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(0.2, 0.8)
+	set_stylebox('time_unavailable', 'AnimationTimelineEdit', sb)
+
+	set_color('h_line_color', 'AnimationTrackEdit', Color.TRANSPARENT)
+	set_constant('h_separation', 'AnimationTrackEdit', base_margin * 1.5 * scale)
+
+	sb = base_sb.duplicate()
+	sb.draw_center = false
+	_set_border(sb, _get_base_color(0.3, 0.6), 2)
+	_set_margin(sb, base_margin * 1.5, base_margin, base_margin * 1.5, base_margin)
+	set_stylebox('focus', 'AnimationTrackEdit', sb)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(0.2, 0.9)
+	set_stylebox('hover', 'AnimationTrackEdit', sb)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.2)
+	set_stylebox('odd', 'AnimationTrackEdit', sb)
+
+	set_color('bg_color', 'AnimationTrackEditGroup', _get_base_color(-0.2))
+	set_color('h_line_color', 'AnimationTrackEditGroup', Color.TRANSPARENT)
+	set_color('v_line_color', 'AnimationTrackEditGroup', Color.TRANSPARENT)
+	set_constant('h_separation', 'AnimationTrackEditGroup', base_margin * 2 * scale)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.6)
+	_set_margin(sb, base_margin * 4, base_margin, 0, base_margin)
+	set_stylebox('header', 'AnimationTrackEditGroup', sb)
+
+	# Bottom panel
+
+	# Use bigger margin for buttons in bottom panel to make them easier to press
+	sb = empty_sb.duplicate()
+	_set_margin(sb, base_margin * 2, base_margin * 1.2, base_margin * 2, base_margin * 1.2)
+	set_stylebox('normal', 'BottomPanelButton', empty_wide_sb)
+
+	sb = flat_button_hover_sb.duplicate()
+	_set_margin(sb, base_margin * 2, base_margin * 1.2, base_margin * 2, base_margin * 1.2)
+	set_stylebox('hover', 'BottomPanelButton', sb)
+	set_stylebox('pressed', 'BottomPanelButton', sb)
+
+	sb = flat_button_pressed_sb.duplicate()
+	_set_margin(sb, base_margin * 2, base_margin * 1.2, base_margin * 2, base_margin * 1.2)
+	set_stylebox('hover_pressed', 'BottomPanelButton', sb)
+
+	# Button
+
+	set_color('font_color', 'Button', mono_color * Color(1, 1, 1, 0.7))
+	set_color('font_disabled_color', 'Button', mono_color * Color(1, 1, 1, 0.3))
+	set_color('font_focus_color', 'Button', mono_color)
+	set_color('font_hover_color', 'Button', mono_color)
+	set_color('font_hover_pressed_color', 'Button', mono_color)
+	set_color('font_pressed_color', 'Button', mono_color)
+	set_color('icon_disabled_color', 'Button', mono_color * Color(1, 1, 1, 0.3))
+	set_color('icon_normal_color', 'Button', mono_color * Color(1, 1, 1, 0.7))
+	set_constant('outline_size', 'Button', 0)
+	set_stylebox('disabled', 'Button', button_disabled_sb)
+	set_stylebox('disabled_mirrored', 'Button', button_disabled_sb)
+	set_stylebox('focus', 'Button', empty_sb)
+	set_stylebox('hover', 'Button', button_hover_sb)
+	set_stylebox('hover_mirrored', 'Button', button_hover_sb)
+	set_stylebox('hover_pressed', 'Button', button_pressed_sb)
+	set_stylebox('hover_pressed_mirrored', 'Button', button_pressed_sb)
+	set_stylebox('normal', 'Button', button_sb)
+	set_stylebox('normal_mirrored', 'Button', button_sb)
+	set_stylebox('pressed', 'Button', button_pressed_sb)
+	set_stylebox('pressed_mirrored', 'Button', button_pressed_sb)
+
+	# Checkbox
+
+	set_color('font_hover_pressed_color', 'CheckBox', mono_color)
+	set_color('font_pressed_color', 'CheckBox', mono_color * Color(1, 1, 1, 0.7))
+
+	sb = base_sb.duplicate()
+	sb.draw_center = false
+	_set_margin(sb, base_margin * 1.5, base_margin * 0.5, base_margin * 1.5, base_margin * 0.5)
+	set_stylebox('normal', 'CheckBox', sb)
+	set_stylebox('normal_mirrored', 'CheckBox', sb)
+
+	# CheckButton
+
+	set_color('font_focus_color', 'CheckButton', mono_color * Color(1, 1, 1, 0.7))
+	set_color('font_hover_pressed_color', 'CheckButton', mono_color)
+	set_color('font_pressed_color', 'CheckButton', mono_color * Color(1, 1, 1, 0.7))
+
+	# Editor
+
+	set_color('background', 'Editor', _get_base_color(-0.6))
+	set_color('box_selection_fill_color', 'Editor', mono_color * Color(1, 1, 1, 0.12))
+	set_color('box_selection_stroke_color', 'Editor', mono_color * Color(1, 1, 1, 0.4))
+	# Ruler in 2D view:
+	set_color('dark_color_2', 'Editor', Color(0, 0, 0, 0.3) if dark_theme else Color(1, 1, 1, 0.3))
+
+	set_color('forward_plus_color', 'Editor', Color(0.54902, 0.752941, 0.392157))
+	set_color('gl_compatibility_color', 'Editor', Color(0.447059, 0.698039, 0.890196))
+	set_color('mobile_color', 'Editor', Color(0.862745, 0.482353, 0.584314))
+	set_color('property_color_w', 'Editor', mono_color * Color(1, 1, 1, 0.8))
+	set_color('property_color_x', 'Editor', Color('#E16277') if dark_theme else Color('#670A18'))
+	set_color('property_color_y', 'Editor', Color('#C3EF65') if dark_theme else Color('#455E10'))
+	set_color('property_color_z', 'Editor', Color('#6AABF6') if dark_theme else Color('#143862'))
+	set_color('warning_color', 'Editor', Color(0.95, 0.855, 0.57) if dark_theme else Color(0.82, 0.56, 0.1))
+
+	set_color('prop_subsection', 'Editor', Color.TRANSPARENT)
+	set_constant('top_bar_separation', 'Editor', base_margin * scale)
+	set_constant('window_border_margin', 'Editor', base_margin * scale)
+
+	# EditorHelpBit
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.3 if dark_theme else -0.7)
+	_set_margin(sb, base_margin * 2, base_margin, base_margin * 2, base_margin)
+	sb.set_corner_radius_all(0)
+	sb.corner_radius_bottom_right = corner_radius * scale
+	sb.corner_radius_bottom_left = corner_radius * scale
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_2, floor(scale))
+	set_stylebox('normal', 'EditorHelpBitContent', sb)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.55 if dark_theme else -0.9) # Same as secondary tree
+	_set_margin(sb, base_margin * 2, base_margin, base_margin * 2, base_margin)
+	sb.set_corner_radius_all(0)
+	sb.corner_radius_top_right = corner_radius * scale
+	sb.corner_radius_top_left = corner_radius * scale
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_2, floor(scale))
+	set_stylebox('normal', 'EditorHelpBitTitle', sb)
+
+	# EditorInspector
+
+	set_constant('v_separation', 'EditorInspector', base_margin * 0.85 * scale)
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(0.2, 0.8)
+	_set_margin(sb, 0, base_margin * 1.2, 0, base_margin * 1.2)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_2, floor(scale))
+	set_stylebox('bg', 'EditorInspectorCategory', sb)
+	set_constant('h_separation', 'EditorInspectorSection', base_margin * scale)
+
+	# EditorLogFilterButton
+
+	# Hover and pressed styles are swapped for toggle buttons on purpose
+	set_stylebox('hover', 'EditorLogFilterButton', flat_button_pressed_sb)
+	set_stylebox('pressed', 'EditorLogFilterButton', flat_button_hover_sb)
+	set_stylebox('normal', 'EditorLogFilterButton', empty_sb)
+
+
+	# EditorProperty
+
+	set_color('property_color', 'EditorProperty', mono_color * Color(1, 1, 1, 0.6))
+	set_color('warning_color', 'EditorProperty', Color(0.95, 0.855, 0.57, 1) if dark_theme else Color(0.82, 0.56, 0.1))
+	set_stylebox('bg', 'EditorProperty', empty_sb)
+	set_stylebox('bg_selected', 'EditorProperty', empty_sb)
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.8) # Same as LineEdit normal
+	sb.set_content_margin_all(base_margin * scale)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_2, floor(scale))
+	set_stylebox('child_bg', 'EditorProperty', sb)
+
+	# EditorSpinSlider
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.8)
+	sb.set_content_margin_all(base_margin * scale)
+	set_stylebox('label_bg', 'EditorSpinSlider', sb)
+
+	# Viewport
+
+	sb = base_sb.duplicate()
+	sb.draw_center = false
+	sb.set_corner_radius_all(0)
+	_set_border(sb, mono_color * Color(1, 1, 1, 0.07), 2, false)
+	set_stylebox('FocusViewport', 'EditorStyles', sb)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = Color(0, 0, 0, 0.3) if dark_theme else Color(1, 1, 1, 0.3)
+	_set_margin(sb, base_margin * 2, base_margin * 1.5, base_margin * 2, base_margin * 1.5)
+	set_stylebox('Information3dViewport', 'EditorStyles', sb)
+
+	# LaunchPad
+
+	set_color('movie_writer_icon_hover', 'EditorStyles', Color(1, 1, 1, 0.8))
+	set_color('movie_writer_icon_hover_pressed', 'EditorStyles', Color(1, 1, 1, 0.8))
+	set_color('movie_writer_icon_normal', 'EditorStyles', Color(1, 1, 1, 0.7))
+	set_color('movie_writer_icon_pressed', 'EditorStyles', Color(1, 1, 1, 0.941176))
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.5)
+	_set_margin(sb, base_margin * 1.5, base_margin, base_margin * 1.5, base_margin)
+	sb.set_expand_margin_all(scale)
+	sb.set_border_width_all(0)
+	set_stylebox('LaunchPadMovieMode', 'EditorStyles', sb)
+
+	sb = sb.duplicate()
+	sb.draw_center = false
+	sb.border_color = Color.TRANSPARENT
+	set_stylebox('LaunchPadNormal', 'EditorStyles', sb)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(0.5)
+	sb.set_content_margin_all(0)
+	set_stylebox('MovieWriterButtonPressed', 'EditorStyles', sb)
+
+	# EditorValidationPanel
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.5)
+	_set_margin(sb, base_margin, base_margin * 0.5, base_margin, base_margin * 0.5)
+	set_stylebox('panel', 'EditorValidationPanel', sb)
+
+	# FlatButton
+
+	set_color('font_color', 'FlatButton', mono_color * Color(1, 1, 1, 0.7))
+	set_color('font_disabled_color', 'FlatButton', mono_color * Color(1, 1, 1, 0.3))
+	set_color('font_focus_color', 'FlatButton', mono_color)
+	set_color('font_hover_color', 'FlatButton', mono_color)
+	set_color('font_hover_pressed_color', 'FlatButton', mono_color)
+	set_color('font_pressed_color', 'FlatButton', mono_color)
+	set_color('icon_disabled_color', 'FlatButton', mono_color * Color(1, 1, 1, 0.3))
+	set_color('icon_normal_color', 'FlatButton', mono_color * Color(1, 1, 1, 0.7))
+
+	set_stylebox('disabled', 'FlatButton', empty_wide_sb)
+	set_stylebox('disabled_mirrored', 'FlatButton', empty_wide_sb)
+	set_stylebox('normal', 'FlatButton', empty_wide_sb)
+	set_stylebox('normal_mirrored', 'FlatButton', empty_wide_sb)
+	set_stylebox('hover', 'FlatButton', flat_button_hover_sb)
+	set_stylebox('hover_mirrored', 'FlatButton', flat_button_hover_sb)
+	set_stylebox('hover_pressed', 'FlatButton', flat_button_pressed_sb)
+	set_stylebox('hover_pressed_mirrored', 'FlatButton', flat_button_pressed_sb)
+	set_stylebox('pressed', 'FlatButton', flat_button_pressed_sb)
+	set_stylebox('pressed_mirrored', 'FlatButton', flat_button_pressed_sb)
+
+
+	# FlatMenuButton
+
+	set_color('font_color', 'FlatMenuButton', mono_color * Color(1, 1, 1, 0.7))
+	set_color('font_disabled_color', 'FlatMenuButton', mono_color * Color(1, 1, 1, 0.3))
+	set_color('font_focus_color', 'FlatMenuButton', mono_color)
+	set_color('font_hover_color', 'FlatMenuButton', mono_color)
+	set_color('font_hover_pressed_color', 'FlatMenuButton', mono_color)
+	set_color('font_pressed_color', 'FlatMenuButton', mono_color)
+	set_color('icon_disabled_color', 'FlatMenuButton', mono_color * Color(1, 1, 1, 0.3))
+	set_color('icon_normal_color', 'FlatMenuButton', mono_color * Color(1, 1, 1, 0.7))
+
+	set_stylebox('disabled', 'FlatMenuButton', empty_wide_sb)
+	set_stylebox('disabled_mirrored', 'FlatMenuButton', empty_wide_sb)
+	set_stylebox('focus', 'FlatMenuButton', empty_wide_sb)
+	set_stylebox('normal', 'FlatMenuButton', empty_wide_sb)
+	set_stylebox('normal_mirrored', 'FlatMenuButton', empty_wide_sb)
+	set_stylebox('hover', 'FlatMenuButton', flat_button_hover_sb)
+	set_stylebox('hover_mirrored', 'FlatMenuButton', flat_button_hover_sb)
+	set_stylebox('hover_pressed', 'FlatMenuButton', flat_button_pressed_sb)
+	set_stylebox('hover_pressed_mirrored', 'FlatMenuButton', flat_button_pressed_sb)
+	set_stylebox('pressed', 'FlatMenuButton', flat_button_pressed_sb)
+	set_stylebox('pressed_mirrored', 'FlatMenuButton', flat_button_pressed_sb)
+
+	# GraphStateMachine
+
+	set_color('focus_color', 'GraphStateMachine', Color.TRANSPARENT)
+
+	# Box Containers
+
+	set_constant('separation', 'HBoxContainer', 2 * scale)
+	set_constant('separation', 'VBoxContainer', 2 * scale)
+
+	# Split Containers
+
+	set_constant('autohide', 'HSplitContainer', 1)
+	set_constant('minimum_grab_thickness', 'HSplitContainer', base_margin * 1.5 * scale)
+	set_constant('separation', 'HSplitContainer', ceil(2 * scale))
+
+	set_constant('autohide', 'VSplitContainer', 1)
+	set_constant('minimum_grab_thickness', 'VSplitContainer', base_margin * 1.5 * scale)
+	set_constant('separation', 'VSplitContainer', ceil(2 * scale))
+
+	# InspectorActionButton
+
+	set_constant('h_separation', 'InspectorActionButton', base_margin * 2 * scale)
+	set_stylebox('disabled', 'InspectorActionButton', button_disabled_sb)
+	set_stylebox('disabled_mirrored', 'InspectorActionButton', button_disabled_sb)
+	set_stylebox('normal', 'InspectorActionButton', button_sb)
+	set_stylebox('normal_mirrored', 'InspectorActionButton', button_sb)
+	set_stylebox('hover', 'InspectorActionButton', button_hover_sb)
+	set_stylebox('hover_mirrored', 'InspectorActionButton', button_hover_sb)
+	set_stylebox('pressed', 'InspectorActionButton', button_pressed_sb)
+	set_stylebox('pressed_mirrored', 'InspectorActionButton', button_pressed_sb)
+
+	# ItemList
+
+	set_color('guide_color', 'ItemList', Color.TRANSPARENT)
+	set_constant('v_separation', 'ItemList', base_margin * 1.5 * scale)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = mono_color * Color(1, 1, 1, 0.04)
+	set_stylebox('cursor', 'ItemList', sb)
+	set_stylebox('cursor_unfocused', 'ItemList', sb)
+	set_stylebox('focus', 'ItemList', empty_sb)
+
+	set_stylebox('hovered', 'ItemList', flat_button_hover_sb)
+	set_stylebox('selected', 'ItemList', flat_button_hover_sb)
+	set_stylebox('selected_focus', 'ItemList', flat_button_hover_sb)
+	set_stylebox('hovered_selected', 'ItemList', flat_button_hover_sb)
+	set_stylebox('hovered_selected_focus', 'ItemList', flat_button_hover_sb)
+
+	set_stylebox('panel', 'ItemList', empty_margin_sb)
+
+	# Label
+
+	set_color('font_color', 'Label', mono_color * Color(1, 1, 1, 0.7))
+
+	sb = empty_sb.duplicate()
+	# Keeping vertical margin low otherwise quick open looks bad
+	_set_margin(sb, base_margin * 2, base_margin, base_margin * 2, base_margin)
+	set_stylebox('normal', 'Label', sb)
+
+	# LineEdit and TextEdit
+
+	set_color('font_placeholder_color', 'LineEdit', mono_color * Color(1, 1, 1, 0.4))
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-1.2 if dark_theme else -2)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_1, floor(scale))
+	_set_margin(sb, base_margin * 2, base_margin * 0.75, base_margin * 2, base_margin * 0.75)
+	set_stylebox('focus', 'LineEdit', sb)
+	set_stylebox('focus', 'TextEdit', sb)
+
+	sb = sb.duplicate()
+	sb.bg_color = _get_base_color(-0.8 if dark_theme else -1.6)
+	set_stylebox('normal', 'LineEdit', sb)
+	set_stylebox('normal', 'TextEdit', sb)
+
+	# Using transparent background for readonly otherwise it looks bad in the master audio bus
+	sb = sb.duplicate()
+	sb.bg_color = Color(0, 0, 0, 0.1) if dark_theme else Color(1, 1, 1, 0.1)
+	set_stylebox('read_only', 'LineEdit', sb)
+	set_stylebox('read_only', 'TextEdit', sb)
+
+	# MainMenuBar
+
+	set_stylebox('normal', 'MainMenuBar', empty_wide_sb)
+	set_stylebox('hover', 'MainMenuBar', flat_button_hover_sb)
+	set_stylebox('hover_pressed', 'MainMenuBar', flat_button_pressed_sb)
+	set_stylebox('pressed', 'MainMenuBar', flat_button_pressed_sb)
+
+	# MainScreenButton
+
+	set_stylebox('normal', 'MainScreenButton', empty_wide_sb)
+	set_stylebox('normal_mirrored', 'MainScreenButton', empty_wide_sb)
+	set_stylebox('hover', 'MainScreenButton', empty_wide_sb)
+	set_stylebox('hover_mirrored', 'MainScreenButton', empty_wide_sb)
+	set_stylebox('hover_pressed', 'MainScreenButton', empty_wide_sb)
+	set_stylebox('hover_pressed_mirrored', 'MainScreenButton', empty_wide_sb)
+	set_stylebox('pressed', 'MainScreenButton', empty_wide_sb)
+	set_stylebox('pressed_mirrored', 'MainScreenButton', empty_wide_sb)
+
+	# MenuButton
+
+	set_stylebox('disabled', 'MenuButton', empty_wide_sb)
+	set_stylebox('disabled_mirrored', 'MenuButton', empty_wide_sb)
+	set_stylebox('focus', 'MenuButton', empty_wide_sb)
+	set_stylebox('normal', 'MenuButton', empty_wide_sb)
+	set_stylebox('normal_mirrored', 'MenuButton', empty_wide_sb)
+	set_stylebox('pressed', 'MenuButton', flat_button_pressed_sb)
+	set_stylebox('pressed_mirrored', 'MenuButton', flat_button_pressed_sb)
+	set_stylebox('hover', 'MenuButton', flat_button_hover_sb)
+	set_stylebox('hover_mirrored', 'MenuButton', flat_button_hover_sb)
+	set_stylebox('hover_pressed', 'MenuButton', flat_button_hover_sb)
+	set_stylebox('hover_pressed_mirrored', 'MenuButton', flat_button_hover_sb)
+
+	# OptionButton
+
+	set_constant('arrow_margin', 'OptionButton', base_margin * 3.5)
+
+	set_color('font_color', 'OptionButton', mono_color * Color(1, 1, 1, 0.7))
+	set_color('font_disabled_color', 'OptionButton', mono_color * Color(1, 1, 1, 0.3))
+	set_color('font_focus_color', 'OptionButton', mono_color)
+	set_color('font_hover_color', 'OptionButton', mono_color)
+	set_color('font_hover_pressed_color', 'OptionButton', mono_color)
+	set_color('font_pressed_color', 'OptionButton', mono_color)
+	set_color('icon_disabled_color', 'OptionButton', mono_color * Color(1, 1, 1, 0.3))
+	set_color('icon_normal_color', 'OptionButton', mono_color * Color(1, 1, 1, 0.7))
+
+	set_stylebox('disabled', 'OptionButton', button_disabled_sb)
+	set_stylebox('disabled_mirrored', 'OptionButton', button_disabled_sb)
+	set_stylebox('focus', 'OptionButton', empty_sb)
+	set_stylebox('normal', 'OptionButton', button_sb)
+	set_stylebox('normal_mirrored', 'OptionButton', button_sb)
+	set_stylebox('pressed', 'OptionButton', button_pressed_sb)
+	set_stylebox('pressed_mirrored', 'OptionButton', button_pressed_sb)
+	set_stylebox('hover', 'OptionButton', button_hover_sb)
+	set_stylebox('hover_mirrored', 'OptionButton', button_hover_sb)
+	set_stylebox('hover_pressed', 'OptionButton', button_pressed_sb)
+	set_stylebox('hover_pressed_mirrored', 'OptionButton', button_pressed_sb)
+
+	# Popups
+
+	set_constant('item_start_padding', 'PopupMenu', popup_margin * scale)
+	set_constant('v_separation', 'PopupMenu', base_margin * 1.75 * scale)
+
+	set_stylebox('hover', 'PopupMenu', flat_button_hover_sb)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.8, 0.9)
+	sb.set_content_margin_all(popup_margin)
+	sb.set_corner_radius_all(0)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_2, floor(scale))
+	set_stylebox('panel', 'PopupMenu', sb)
+
+	var line_sb := StyleBoxLine.new()
+	line_sb.color = _get_base_color(0.1, 0.8)
+	line_sb.grow_begin = base_margin * -1.5 * scale
+	line_sb.grow_end = base_margin * -1.5 * scale
+	line_sb.thickness = ceil(scale)
+	set_stylebox('labeled_separator_left', 'PopupMenu', line_sb)
+	set_stylebox('labeled_separator_right', 'PopupMenu', line_sb)
+	set_stylebox('separator', 'PopupMenu', line_sb)
+
+	set_stylebox('panel', 'PanelContainer', empty_wide_sb)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.8, 0.9)
+	sb.shadow_color = Color(0, 0, 0, 0.3)
+	sb.shadow_size = base_margin * 0.75 * scale
+	sb.set_content_margin_all(popup_margin)
+	sb.set_corner_radius_all(0)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_2, floor(scale))
+	set_stylebox('panel', 'PopupPanel', sb)
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.8, 0.9)
+	sb.set_content_margin_all(0)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_2, floor(scale))
+	set_stylebox('panel', 'TooltipPanel', sb)
+
+	# ProgressBar
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-1.2, 0.9)
+	sb.expand_margin_top = base_margin * 0.5 * scale
+	sb.expand_margin_bottom = base_margin * 0.5 * scale
+	sb.set_content_margin_all(base_margin * scale)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_2, floor(scale))
+	set_stylebox('background', 'ProgressBar', sb)
+
+	sb = sb.duplicate()
+	sb.bg_color = _get_base_color(0.4, 0.8)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_1, floor(scale))
+	set_stylebox('fill', 'ProgressBar', sb)
+
+	# RichTextLabel
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.5)
+	sb.set_content_margin_all(base_margin * 1.5 * scale)
+	set_stylebox('normal', 'RichTextLabel', sb)
+
+	# ScrollContainer
+
+	set_stylebox('focus', 'ScrollContainer', empty_sb)
+
+	# SplitContainer
+
+	set_constant('minimum_grab_thickness', 'SplitContainer', base_margin * 1.5 * scale)
+	set_constant('separation', 'SplitContainer', base_margin * 0.75 * scale)
+
+	var empty_texture := PlaceholderTexture2D.new()
+	empty_texture.size = Vector2(0, 0)
+	set_icon('h_grabber', 'SplitContainer', empty_texture)
+	set_icon('v_grabber', 'SplitContainer', empty_texture)
+
+	# TabContainer
+
+	sb = base_sb.duplicate()
+	_set_margin(sb, base_margin * 3.5, base_margin * 2, base_margin * 3.5, base_margin * 1.5)
+	sb.set_corner_radius_all(0)
+	sb.border_width_top = 2 * scale
+	var col = accent_color
+	col.v = 0.5
+	col.s = 0.5
+	sb.border_color = col
+	set_stylebox('tab_selected', 'TabBar', sb)
+	set_stylebox('tab_selected', 'TabContainer', sb)
+
+	sb = sb.duplicate()
+	sb.bg_color = _get_base_color(-0.35)
+	set_stylebox('tab_selected', 'TabContainerOdd', sb)
+
+	sb = sb.duplicate()
+	sb.bg_color = base_color
+	sb.border_color = accent_color
+	set_stylebox('tab_focus', 'TabBar', sb)
+	set_stylebox('tab_focus', 'TabContainer', sb)
+
+	sb = sb.duplicate()
+	sb.bg_color = Color.TRANSPARENT
+	sb.set_border_width_all(0)
+	set_stylebox('tab_unselected', 'TabBar', sb)
+	set_stylebox('tab_unselected', 'TabContainer', sb)
+
+	sb = sb.duplicate()
+	sb.bg_color = _get_base_color(-0.5)
+	set_stylebox('tab_hovered', 'TabBar', sb)
+	set_stylebox('tab_hovered', 'TabContainer', sb)
+
+	sb = base_sb.duplicate()
+	sb.set_content_margin_all(increased_margin * 1.5 * scale)
+	sb.set_corner_radius_all(0)
+	set_stylebox('panel', 'TabContainer', sb)
+
+	# Tree
+
+	set_color('drop_position_color', 'Tree', mono_color * Color(1, 1, 1, 0.4))
+	set_color('font_color', 'Tree', mono_color * Color(1, 1, 1, 0.7))
+	set_color('guide_color', 'Tree', Color.TRANSPARENT)
+	set_color('parent_hl_line_color', 'Tree', mono_color * Color(1, 1, 1, relationship_line_opacity))
+	set_constant('children_hl_line_width', 'Tree', 0)
+	set_constant('draw_guides', 'Tree', 0)
+	set_constant('draw_relationship_lines', 'Tree', 1)
+	set_constant('inner_item_margin_left', 'Tree', base_margin * scale)
+	set_constant('inner_item_margin_right', 'Tree', base_margin * scale)
+	set_constant('parent_hl_line_width', 'Tree', ceil(scale))
+	set_constant('relationship_line_width', 'Tree', 0)
+	set_constant('v_separation', 'Tree', ceil(scale) + ceil(extra_spacing * scale))
+
+	set_stylebox('panel', 'Tree', empty_margin_sb)
+
+	# Leaving focus empty for trees and scroll containers because there's no way to
+	# make focus indication look not janky when only a part of a dock is highlighted
+	set_stylebox('focus', 'Tree', empty_sb)
+
+	# Rounded corners look a little janky in tree titles because there's no way to
+	# introduce gaps between columns, however not having rounded corners looks even worse
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-1.2 if dark_theme else -1.8)
+	set_stylebox('title_button_hover', 'Tree', sb)
+	set_stylebox('title_button_normal', 'Tree', sb)
+	set_stylebox('title_button_pressed', 'Tree', sb)
+
+	sb = flat_button_hover_sb.duplicate()
+	sb.set_content_margin_all(0)
+	set_stylebox('button_hover', 'Tree', sb)
+	set_stylebox('hover', 'Tree', sb)
+	set_stylebox('hovered_dimmed', 'Tree', sb)
+	set_stylebox('custom_button_hover', 'Tree', sb)
+	set_stylebox('hovered', 'Tree', sb)
+	set_stylebox('selected', 'Tree', sb)
+	set_stylebox('selected_focus', 'Tree', sb)
+
+	set_stylebox('button_pressed', 'Tree', flat_button_pressed_sb)
+	set_stylebox('custom_button_pressed', 'Tree', flat_button_pressed_sb)
+
+	# Cursor is drawn on top of the item so it needs to be transparent
+	sb = base_sb.duplicate()
+	sb.bg_color = mono_color * Color(1, 1, 1, 0.04)
+	set_stylebox('cursor', 'Tree', sb)
+	set_stylebox('cursor_unfocused', 'Tree', sb)
+
+	# Sidebars
+
+	sb = base_sb.duplicate()
+	sb.bg_color = _get_base_color(-0.55 if dark_theme else -0.9)
+	if draw_extra_borders:
+		_set_border(sb, extra_border_color_2, floor(scale))
+	set_stylebox('panel', 'TreeSecondary', sb)
+	set_stylebox('panel', 'ItemListSecondary', sb)
+
+# Lighten base color in dark theme, darken in light theme, clamp
+func _get_base_color(brightness_offset: float = 0, saturation_multiplier: float = 1) -> Color:
+	var dark = dark_theme if brightness_offset >= 0 else !dark_theme
+	var color = Color(base_color)
+	color.v = clampf(lerpf(color.v, 1 if dark else 0, abs(contrast * brightness_offset)), 0, 1)
+	color.s *= saturation_multiplier
+	return color
+
+# Shorthand content margin setter
+func _set_margin(sb: StyleBox, left: float, top: float, right: float = left, bottom: float = top) -> void:
+	sb.content_margin_left = left * scale
+	sb.content_margin_top = top * scale
+	sb.content_margin_right = right * scale
+	sb.content_margin_bottom = bottom * scale
+
+# Shorthand border setter
+func _set_border(sb: StyleBox, color: Color, width: float = 1, blend: bool = false) -> void:
+	sb.border_color = color
+	sb.border_blend = blend
+	sb.set_border_width_all(ceil(width * scale))
+"
+
+
+[resource]
+script = SubResource("GDScript_hhmc0")

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -830,6 +830,14 @@ bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 	return false;
 }
 
+String OS_Android::get_editor_theme_override(const String &p_editor_theme_preset) {
+	if (p_editor_theme_preset == "Android") {
+		return "assets://themes/minimal_theme.tres";
+	}
+
+	return String();
+}
+
 OS_Android::OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion) {
 	display_size.width = DEFAULT_WINDOW_WIDTH;
 	display_size.height = DEFAULT_WINDOW_HEIGHT;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -179,6 +179,9 @@ public:
 	virtual void load_platform_gdextensions() const override;
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
+
+	virtual String get_editor_theme_override(const String &p_editor_theme_preset) override;
+
 	OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_godot_io_java, bool p_use_apk_expansion);
 	~OS_Android();
 


### PR DESCRIPTION
- Add support for platform's customization of the editor theme
- Adds a new theme for the Android and XR editor based off @passivestar  [minimal theme](https://github.com/passivestar/godot-minimal-theme)

![Screenshot_20241114_114901](https://github.com/user-attachments/assets/967ce29f-5286-4d2f-9cae-dc3e0199180e)


**Note** that I'm still iterating on the look and feel for the new theme, so feedback and contributions are welcomed!
To contribute, feel free to grab [minimal_theme_high_ppi](https://github.com/m4gr3d/godot/blob/create_android_editor_theme/platform/android/java/editor/src/main/assets/themes/minimal_theme_high_ppi.tres), make edits to it and submit back!

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
