### PR TITLE
Add OnReady attribute source generator

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/CSharpSourceGeneratorVerifier.cs
@@ -18,7 +18,7 @@ where TSourceGenerator : ISourceGenerator, new()
     {
         public Test()
         {
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net60;
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net90;
 
             SolutionTransforms.Add((Solution solution, ProjectId projectId) =>
             {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/Godot.SourceGenerators.Tests.csproj
@@ -15,13 +15,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0-3.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/OnReadyGeneratorTests.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/OnReadyGeneratorTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace Godot.SourceGenerators.Tests;
+
+public class OnReadyGeneratorTests
+{
+    [Fact]
+    public async void OneOnReadyProperties()
+    {
+        await CSharpSourceGeneratorVerifier<OnReadyGenerator>.Verify(
+            "OnReadyPropertiesOne.cs",
+            "OnReadyPropertiesOne_OnReady.generated.cs"
+        );
+    }
+
+    [Fact]
+    public async void TwoOnReadyProperties()
+    {
+        await CSharpSourceGeneratorVerifier<OnReadyGenerator>.Verify(
+            "OnReadyPropertiesTwo.cs",
+            "OnReadyPropertiesTwo_OnReady.generated.cs"
+        );
+    }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OnReadyPropertiesOne_OnReady.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OnReadyPropertiesOne_OnReady.generated.cs
@@ -1,0 +1,15 @@
+using Godot;
+
+#nullable enable
+
+partial class OnReadyPropertiesOne
+{
+    private global::Godot.Node? _myNode;
+    private global::Godot.Node MyNodeReady => _myNode ??= MyNode();
+    private partial global::Godot.Node MyNode()
+    {
+        return GetNode<global::Godot.Node>("/Gamemanager");
+    }
+
+}
+#nullable restore

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OnReadyPropertiesTwo_OnReady.generated.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/GeneratedSources/OnReadyPropertiesTwo_OnReady.generated.cs
@@ -1,0 +1,28 @@
+using Godot;
+
+#nullable enable
+
+partial class OnReadyPropertiesTwo
+{
+    private global::Godot.Node? _myNode;
+    private global::Godot.Node MyNodeReady => _myNode ??= MyNode();
+    private partial global::Godot.Node MyNode()
+    {
+        return GetNode<global::Godot.Node>("/Gamemanager");
+    }
+
+    private global::Godot.Node? _myNode2;
+    private global::Godot.Node? MyNode2Ready => _myNode2 ??= MyNode2();
+    private partial global::Godot.Node? MyNode2()
+    {
+        return GetNodeOrNull<global::Godot.Node>("/Gamemanager2");
+    }
+
+    private global::Godot.Node? _myNode3;
+    private partial global::Godot.Node MyNode3 => _myNode3 ??= GetNode<global::Godot.Node>("/Gamemanager3");
+
+    private global::Godot.Node? _myNode4;
+    private partial global::Godot.Node? MyNode4 => _myNode4 ??= GetNodeOrNull<global::Godot.Node>("/Gamemanager4");
+
+}
+#nullable restore

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/OnReadyPropertiesOne.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/OnReadyPropertiesOne.cs
@@ -1,0 +1,7 @@
+using Godot;
+
+public partial class OnReadyPropertiesOne : Node
+{
+    [OnReady("/Gamemanager")]
+    private partial Node MyNode();
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/OnReadyPropertiesTwo.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Tests/TestData/Sources/OnReadyPropertiesTwo.cs
@@ -1,0 +1,16 @@
+using Godot;
+
+public partial class OnReadyPropertiesTwo : Node
+{
+    [OnReady("/Gamemanager")]
+    private partial Node MyNode();
+
+    [OnReady("/Gamemanager2")]
+    private partial Node? MyNode2();
+
+    [OnReady("/Gamemanager3")]
+    private partial Node MyNode3 { get; }
+
+    [OnReady("/Gamemanager4")]
+    private partial Node? MyNode4 { get; }
+}

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -3,3 +3,6 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
 GD0003  |  Usage   |  Error   | ScriptPathAttributeGenerator, [Documentation](https://docs.godotengine.org/en/latest/tutorials/scripting/c_sharp/diagnostics/GD0003.html)
+GD0501 | Usage | Error | OnReadyGenerator
+GD0502 | Usage | Error | OnReadyGenerator
+GD0503 | Usage | Error | OnReadyGenerator

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Common.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Godot.SourceGenerators
 {
@@ -186,5 +185,35 @@ namespace Godot.SourceGenerators
                 isEnabledByDefault: true,
                 "The class must not be generic. Make the class non-generic, or remove the '[GlobalClass]' attribute.",
                 helpLinkUri: string.Format(_helpLinkFormat, "GD0402"));
+
+        public static readonly DiagnosticDescriptor OnReadyMemberReturnMustDeriveFromNode =
+            new(id: "GD0501",
+                title: $"On ready member type must derive from {GodotClasses.Node}",
+                messageFormat: $"The [OnReady] member '{0}' type must derive from {GodotClasses.Node}",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                $"The [OnReady] member type must derive from {GodotClasses.Node}. Change the type to a type which derives from Node.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0501"));
+
+        public static readonly DiagnosticDescriptor OnReadyMemberMustBeEmptyPartial =
+            new(id: "GD0502",
+                title: "On ready member must be partial and must not be implemented",
+                messageFormat: "The [OnReady] member '{0}' must be partial without an implementation",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The [OnReady] member must be partial and must not have a body. Make the member partial and remove the body.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0502"));
+
+        public static readonly DiagnosticDescriptor OnReadyMemberCannotBeStatic =
+            new(id: "GD0503",
+                title: "On ready member cannot be static",
+                messageFormat: "The [OnReady] member '{0}' cannot be static",
+                category: "Usage",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                "The [OnReady] member cannot be static. Remove the static keyword from the member.",
+                helpLinkUri: string.Format(_helpLinkFormat, "GD0503"));
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -290,6 +290,14 @@ namespace Godot.SourceGenerators
         public static bool IsSystemFlagsAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.SystemFlagsAttr;
 
+        public static bool HasAttribute(this ISymbol symbol, string attribute)
+            => symbol.GetAttributes()
+                    .Any(a => a.AttributeClass?.FullQualifiedNameOmitGlobal() == attribute);
+
+        public static AttributeData GetAttribute(this ISymbol symbol, string attribute)
+            => symbol.GetAttributes()
+                .First(a => a.AttributeClass?.FullQualifiedNameOmitGlobal() == attribute);
+
         public static GodotMethodData? HasGodotCompatibleSignature(
             this IMethodSymbol method,
             MarshalUtils.TypeCache typeCache

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/Godot.SourceGenerators.csproj
@@ -20,6 +20,7 @@
     <!-- Do not include the generator as a lib dependency -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
   <!-- Analyzer release tracking -->
   <ItemGroup>
@@ -27,7 +28,7 @@
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <!-- Package the generator in the analyzer directory of the nuget package -->

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
@@ -10,6 +10,7 @@ namespace Godot.SourceGenerators
         public const string ExportGroupAttr = "Godot.ExportGroupAttribute";
         public const string ExportSubgroupAttr = "Godot.ExportSubgroupAttribute";
         public const string SignalAttr = "Godot.SignalAttribute";
+        public const string OnReadyAttr = "Godot.OnReadyAttribute";
         public const string MustBeVariantAttr = "Godot.MustBeVariantAttribute";
         public const string GodotClassNameAttr = "Godot.GodotClassNameAttribute";
         public const string GlobalClassAttr = "Godot.GlobalClassAttribute";

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/OnReadyGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/OnReadyGenerator.cs
@@ -1,0 +1,219 @@
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Godot.SourceGenerators;
+
+[Generator]
+public class OnReadyGenerator : ISourceGenerator
+{
+    private const string GetNodeMethod = "GetNode";
+    private const string GetNodeOrNullMethod = "GetNodeOrNull";
+
+    public void Initialize(GeneratorInitializationContext context)
+    {
+
+    }
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        if (context.IsGodotSourceGeneratorDisabled("OnReady"))
+            return;
+
+        INamedTypeSymbol[] godotClasses = context
+            .Compilation.SyntaxTrees
+            .SelectMany(tree =>
+                tree.GetRoot().DescendantNodes()
+                    .OfType<ClassDeclarationSyntax>()
+                    .SelectGodotScriptClasses(context.Compilation)
+                    // Report and skip non-partial classes
+                    .Where(x =>
+                    {
+                        if (!x.cds.IsPartial()) return false;
+
+                        if (x.cds.IsNested() && !x.cds.AreAllOuterTypesPartial(out _)) return false;
+
+                        if (!x.symbol.GetMembers().Any(m => m.HasAttribute(GodotClasses.OnReadyAttr))) return false;
+
+                        return true;
+                    })
+                    .Select(x => x.symbol)
+            )
+            .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)
+            .ToArray();
+        foreach (var godotClass in godotClasses)
+        {
+            VisitGodotScriptClass(context, godotClass);
+        }
+    }
+
+    private static void VisitGodotScriptClass(
+        GeneratorExecutionContext context,
+        INamedTypeSymbol typeSymbol
+    )
+    {
+        INamespaceSymbol namespaceSymbol = typeSymbol.ContainingNamespace;
+        string classNs = namespaceSymbol is { IsGlobalNamespace: false }
+            ? namespaceSymbol.FullQualifiedNameOmitGlobal()
+            : string.Empty;
+
+        bool hasNamespace = classNs.Length != 0;
+
+        bool isInnerClass = typeSymbol.ContainingType != null;
+
+        string uniqueHint = typeSymbol.FullQualifiedNameOmitGlobal().SanitizeQualifiedNameForUniqueHint()
+                            + "_OnReady.generated";
+
+        var source = new StringBuilder();
+
+        source.Append("using Godot;\n");
+        source.Append("\n#nullable enable");
+        source.Append("\n\n");
+
+        if (hasNamespace)
+        {
+            source.Append("namespace ");
+            source.Append(classNs);
+            source.Append(" {\n\n");
+        }
+
+        if (isInnerClass)
+        {
+            var rootContainingType = typeSymbol.ContainingType;
+            AppendPartialContainingTypeDeclarations(rootContainingType);
+
+            void AppendPartialContainingTypeDeclarations(INamedTypeSymbol? containingType)
+            {
+                if (containingType == null)
+                    return;
+
+                AppendPartialContainingTypeDeclarations(containingType.ContainingType);
+
+                source.Append("partial ");
+                source.Append(containingType.GetDeclarationKeyword());
+                source.Append(" ");
+                source.Append(containingType.NameWithTypeParameters());
+                source.Append("\n{\n");
+            }
+        }
+
+        source.Append("partial class ");
+        source.Append(typeSymbol.NameWithTypeParameters());
+        source.Append("\n{\n");
+
+        var members = typeSymbol.GetMembers();
+
+        var onReadySymbols = members
+            .Where(s => s.HasAttribute(GodotClasses.OnReadyAttr));
+
+        foreach (var symbol in onReadySymbols)
+        {
+            switch (symbol)
+            {
+                case IMethodSymbol method when Valid(context, method):
+                    CreateOnReadyMethod(method, source);
+                    break;
+                case IPropertySymbol property when Valid(context, property):
+                    CreateOnReadyProperty(property, source);
+                    break;
+            }
+        }
+
+        source.Append("}\n"); // partial class
+
+        if (isInnerClass)
+        {
+            var containingType = typeSymbol.ContainingType;
+
+            while (containingType != null)
+            {
+                source.Append("}\n"); // outer class
+
+                containingType = containingType.ContainingType;
+            }
+        }
+
+        if (hasNamespace)
+        {
+            source.Append("\n}\n");
+        }
+
+        source.Append("#nullable restore\n");
+        context.AddSource(uniqueHint, SourceText.From(source.ToString(), Encoding.UTF8));
+    }
+
+    private static void CreateOnReadyMethod(IMethodSymbol method, StringBuilder source)
+    {
+        var nodePath = method.GetAttribute(GodotClasses.OnReadyAttr).ConstructorArguments[0].Value;
+        var nullable = method.ReturnType.NullableAnnotation == NullableAnnotation.Annotated;
+        var returnType = method.ReturnType.FullQualifiedNameIncludeGlobal();
+        var returnTypeWithNullable = nullable ? returnType + '?' : returnType;
+        var getNodeMethod = nullable ? GetNodeOrNullMethod : GetNodeMethod;
+        var modifiers = SyntaxFacts.GetText(method.DeclaredAccessibility);
+        var backingField = string.Concat("_", method.Name[0].ToString().ToLower(), method.Name.Substring(1));
+
+        source.Append($"    private {returnType}? {backingField};\n"); // backing field
+        source.Append($"    {modifiers} {returnTypeWithNullable} {method.Name}Ready => {backingField} ??= {method.Name}();\n"); // property
+        source.Append($"    {modifiers} partial {returnTypeWithNullable} {method.Name}()\n"); // implementing the method
+        source.Append($"    {{\n");
+        source.Append($"        return {getNodeMethod}<{returnType}>(\"{nodePath}\");\n");
+        source.Append($"    }}\n\n");
+    }
+    private static void CreateOnReadyProperty(IPropertySymbol property, StringBuilder source)
+    {
+        var nodePath = property.GetAttribute(GodotClasses.OnReadyAttr).ConstructorArguments[0].Value?.ToString() ?? string.Empty;
+        var nullable = property.Type.NullableAnnotation == NullableAnnotation.Annotated;
+        var type = property.Type.FullQualifiedNameIncludeGlobal();
+        var typeWithNullable = nullable ? type + '?' : type;
+        var getNodeMethod = nullable ? GetNodeOrNullMethod : GetNodeMethod;
+        var modifiers = SyntaxFacts.GetText(property.DeclaredAccessibility);
+        var backingField = string.Concat("_", property.Name[0].ToString().ToLower(), property.Name.Substring(1));
+
+        source.Append($"    private {type}? {backingField};\n"); // backing field
+        source.Append($"    {modifiers} partial {typeWithNullable} {property.Name} => {backingField} ??= {getNodeMethod}<{type}>(\"{nodePath}\");\n\n"); // property impl
+    }
+
+    private static bool Valid(GeneratorExecutionContext context, IPropertySymbol property) =>
+        Valid(context, property, property.IsPartialDefinition, property.Type);
+
+    private static bool Valid(GeneratorExecutionContext context, IMethodSymbol property) =>
+        Valid(context, property, property.IsPartialDefinition, property.ReturnType);
+
+    private static bool Valid(GeneratorExecutionContext context, ISymbol symbol, bool isPartial, ITypeSymbol type)
+    {
+        if (symbol.IsStatic)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Common.OnReadyMemberCannotBeStatic,
+                symbol.Locations.FirstLocationWithSourceTreeOrDefault(),
+                symbol.ToDisplayString()
+            ));
+            return false;
+        }
+
+        if (!isPartial)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Common.OnReadyMemberMustBeEmptyPartial,
+                symbol.Locations.FirstLocationWithSourceTreeOrDefault(),
+                symbol.ToDisplayString()
+            ));
+            return false;
+        }
+
+        if (!type.InheritsFrom("GodotSharp", GodotClasses.Node))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                Common.OnReadyMemberReturnMustDeriveFromNode,
+                symbol.Locations.FirstLocationWithSourceTreeOrDefault(),
+                symbol.ToDisplayString()
+            ));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/OnReadyAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/OnReadyAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Godot;
+
+/// <summary>
+/// Attribute that automatically defers initialization of a member until _Ready() is called.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+public class OnReadyAttribute : Attribute
+{
+    /// <summary>
+    /// Relative or absolute path in a scene tree like <see cref="Godot.NodePath"/>
+    /// </summary>
+    public string NodePath { get; }
+
+    /// <summary>
+    /// Constructs a new OnReadyAttribute instance.
+    /// </summary>
+    /// <param name="nodePath">Relative or absolute path in a scene tree like <see cref="Godot.NodePath"/></param>
+    public OnReadyAttribute(string nodePath)
+    {
+        NodePath = nodePath;
+    }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Core\Attributes\MustBeVariantAttribute.cs" />
     <Compile Include="Core\Attributes\RpcAttribute.cs" />
     <Compile Include="Core\Attributes\ScriptPathAttribute.cs" />
+    <Compile Include="Core\Attributes\OnReadyAttribute.cs" />
     <Compile Include="Core\Attributes\SignalAttribute.cs" />
     <Compile Include="Core\Attributes\ToolAttribute.cs" />
     <Compile Include="Core\Basis.cs" />


### PR DESCRIPTION
### Alternative implementation for proposal: [Proposal#2425](https://github.com/godotengine/godot-proposals/issues/2425)

### Reason for this alternative implementation
In this implementation, only the nuget packages are updated. The bindings generator was not edited to make this work.

### Usage
It contains 2 implementations.
One for methods:
```csharp
[OnReady("Player/Sprite")] 
partial Sprite2D PlayerSprite();
```
And one for Properties(Only compatible with dotnet 9):
```csharp
[OnReady("Player/Sprite")] 
partial Sprite2D PlayerSprite { get; }
```
### Generated code
They both use a source generator to generate a partial class containing the following implementation.

For methods:
```csharp
Sprite2D? _playerSprite; //Backing field
Sprite2D PlayerSpriteReady => _playerSprite ??= PlayerSprite(); // Property
Sprite2D PlayerSprite() // Method implementation
{
    return GetNode<Sprite2D>("Player/Sprite");
}
```

For properties:
```csharp
  Sprite2D? _playerSprite; //Backing field
  partial Sprite2D PlayerSprite => _sprite ??= GetNode<Sprite2D>("Player/Sprite"); // Property implementation
```

When you use a nullable type, it generates the following property instead:
```csharp
  partial Sprite2D PlayerSprite? => _sprite ??= GetNodeOrNull<Sprite2D>("Player/Sprite"); 
```
This uses GetNodeOrNull so it doesnt throw an exception and you can handle nulls yourself.

### Compatibility

The property version uses partial properties which is only supported with dotnet9.
The generator wont generate this when the property is not partial, so it wont generate incompatible code when having a godot project with dotnet version lower than dotnet9.

### Analyzers

There are 3 new analyzer coming with this source generator:
- GD0501: On ready member type must derive from Godot.Node
- GD0502: On ready member must be partial and must not be implemented
- GD0503: On ready member cannot be static

I'll have to add these to the documentation as well.

### Alternative PR

There is a similar PR for this proposal: [PR#92886](https://github.com/godotengine/godot/pull/92886)
There was a comment regarding the name of the attribute being too similar to a concept in gdscript(@onready) without it being exactly the same. I personally don't understand this point as it is supposed to be the same functionality as you get in GDscript(Getting a node from the tree without explicitly calling getnode in the _ready method).

I also believe this implementation is more elegant and concise. You can use the onready members in the _onready without any problems. There are no extra methods to be called by the engine. In essence this generator rather generates pure boilerplate code instead of modifying how flow of the ready methods get called.
As this doesnt add any methods, stacktraces remain the same and easy to debug. The property is the same as if the user had a field filled with getnode in the ready method.

I remember when i started in godot and immediatly got confused as to why there was no OnReady annotation like in GDscript. Having it the same name in C# makes this for newcomers alot more intuitive to use and follow GDscript tutorials online.
Ofcourse this name can easily be changed if deemed too confusing.

### Extra

I've added 2 tests.
Documentation still needs to be made.



* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/2425*




