### PR TITLE
Use `atr` for FileDialog filters

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -875,7 +875,7 @@ void FileDialog::update_filters() {
 		String flt = filters[i].get_slice(";", 0).strip_edges();
 		String desc = filters[i].get_slice(";", 1).strip_edges();
 		if (desc.length()) {
-			filter->add_item(String(tr(desc)) + " (" + flt + ")");
+			filter->add_item(atr(desc) + " (" + flt + ")");
 		} else {
 			filter->add_item("(" + flt + ")");
 		}


### PR DESCRIPTION
- Descriptions of filter strings should respect auto translate mode.
- The `String()` cast is redundant because both `tr` and `atr` return strings already.