### PR TITLE
Simplify some UID conversions

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -476,7 +476,7 @@ void EditorPropertyPath::_path_selected(const String &p_path) {
 String EditorPropertyPath::_get_path_text() {
 	String full_path = get_edited_property_value();
 	if (full_path.begins_with("uid://")) {
-		full_path = ResourceUID::get_singleton()->get_id_path(ResourceUID::get_singleton()->text_to_id(full_path));
+		full_path = ResourceUID::uid_to_path(full_path);
 	}
 
 	return full_path;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -951,7 +951,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 	} else if (p_symbol.is_resource_file() || p_symbol.begins_with("uid://")) {
 		String symbol = p_symbol;
 		if (symbol.begins_with("uid://")) {
-			symbol = ResourceUID::get_singleton()->get_id_path(ResourceUID::get_singleton()->text_to_id(symbol));
+			symbol = ResourceUID::uid_to_path(symbol);
 		}
 
 		List<String> scene_extensions;


### PR DESCRIPTION
Micro-follow-up to #99226
Replaces long conversions between UID and paths with the new methods. Turns out most of the code check for invalid UID first, so direct conversion is rarely used.

Still, the methods might be used more in the future, e.g. in #99137