### PR TITLE
Add `--fail-on-error` option and fail exports on errors

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -84,6 +84,12 @@ class OS {
 	HashMap<Pair<String, String>, uint64_t, PairHash<String, String>> benchmark_marks_from;
 	HashMap<Pair<String, String>, double, PairHash<String, String>> benchmark_marks_final;
 
+	// Error handling.
+	bool _error_occurred = false;
+	bool _fail_on_error = false;
+
+	ErrorHandlerList eh;
+
 protected:
 	void _set_logger(CompositeLogger *p_logger);
 
@@ -313,6 +319,11 @@ public:
 	// level, e.g. from the `Main::start` if leaving without creating a `SceneTree`).
 	// For other components, `SceneTree.quit()` should be used instead.
 	virtual void set_exit_code(int p_code);
+
+	bool is_error_occurred() const;
+	void set_error_occurred(bool p_occurred);
+	bool is_fail_on_error() const;
+	void set_fail_on_error(bool p_enabled);
 
 	virtual int get_processor_count() const;
 	virtual String get_processor_name() const;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -621,6 +621,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_title("Debug options");
 	print_help_option("-d, --debug", "Debug (local stdout debugger).\n");
 	print_help_option("-b, --breakpoints", "Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
+	print_help_option("--fail-on-error", "Set the exit code to 1 if any errors are encountered.\n");
 	print_help_option("--profiling", "Enable profiling in the script debugger.\n");
 	print_help_option("--gpu-profile", "Show a GPU profile of the tasks that took the most time during frame rendering.\n");
 	print_help_option("--gpu-validation", "Enable graphics API validation layers for debugging.\n");
@@ -998,6 +999,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String audio_driver = "";
 	String project_path = ".";
 	bool upwards = false;
+	bool fail_on_error = false;
 	String debug_uri = "";
 	bool skip_breakpoints = false;
 	String main_pack;
@@ -1623,6 +1625,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 
+		} else if (arg == "--fail-on-error") {
+			fail_on_error = true;
 		} else if (arg == "--max-fps") { // set maximum rendered FPS
 
 			if (N) {
@@ -1821,6 +1825,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		goto error;
 	}
 #endif
+
+	// Enable failing on errors as early as possible so that errors that
+	// aren't returned fail the process.
+	OS::get_singleton()->set_fail_on_error(fail_on_error);
 
 	// Network file system needs to be configured before globals, since globals are based on the
 	// 'project.godot' file which will only be available through the network if this is enabled

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1499,6 +1499,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			editor = true;
 			cmdline_tool = true;
 			wait_for_import = true;
+			fail_on_error = true;
 			main_args.push_back(arg);
 		} else if (arg == "--patches") {
 			if (N) {

--- a/misc/dist/linux/godot.6
+++ b/misc/dist/linux/godot.6
@@ -99,6 +99,9 @@ Breakpoint list as source::line comma\-separated pairs, no spaces (use %20 inste
 \fB\-\-profiling\fR
 Enable profiling in the script debugger.
 .TP
+\fB\-\-fail\-on\-error\fR
+Set the exit code to 1 if any errors are encountered.
+.TP
 \fB\-\-remote\-debug\fR <address>
 Remote debug (<host/IP>:<port> address).
 .TP

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -63,6 +63,7 @@ _arguments \
   '--xr-mode[select Extended Reality (XR) mode]:Extended Reality (XR) mode:(default off on)' \
   '(-d --debug)'{-d,--debug}'[debug (local stdout debugger)]' \
   '(-b --breakpoints)'{-b,--breakpoints}'[specify the breakpoint list as source::line comma-separated pairs, no spaces (use %20 instead)]:breakpoint list' \
+  '--fail-on-error[set the exit code to 1 if any errors are encountered]' \
   '--profiling[enable profiling in the script debugger]' \
   '--gpu-profile[show a GPU profile of the tasks that took the most time during frame rendering]' \
   '--gpu-validation[enable graphics API validation layers for debugging]' \

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -66,6 +66,7 @@ _complete_godot_options() {
 --xr-mode
 --debug
 --breakpoints
+--fail-on-error
 --profiling
 --gpu-profile
 --gpu-validation

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -83,6 +83,7 @@ complete -c godot -l xr-mode -d "Select Extended Reality (XR) mode" -a "default 
 # Debug options:
 complete -c godot -s d -l debug -d "Debug (local stdout debugger)"
 complete -c godot -s b -l breakpoints -d "Specify the breakpoint list as source::line comma-separated pairs, no spaces (use %20 instead)" -x
+complete -c godot -l fail-on-error -d "Set the exit code to 1 if any errors are encountered"
 complete -c godot -l profiling -d "Enable profiling in the script debugger"
 complete -c godot -l gpu-profile -d "Show a GPU profile of the tasks that took the most time during frame rendering"
 complete -c godot -l gpu-validation -d "Enable graphics API validation layers for debugging"


### PR DESCRIPTION
This adds an OS error handler that optionally sets the exit code to `EXIT_FAILURE`. The option can be enabled with the `--fail-on-error` CLI flag, but it's also set when exporting a project. The error handling is a little funky to make sure that a script calling `get_tree().quit()` doesn't inadvertently set the exit code back to `EXIT_SUCCESS`. I'm also not really sure about the public  `is_error_occurred`/`set_error_occurred` handlers, but they were necessary for testing.

Fixes: #94957

- *Bugsquad edit: This closes https://github.com/godotengine/godot/issues/122169.*