### PR TITLE
Add console logger for web to log warnings to console

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -22,6 +22,7 @@ if "serve" in COMMAND_LINE_TARGETS or "run" in COMMAND_LINE_TARGETS:
 
 web_files = [
     "audio_driver_web.cpp",
+    "console_logger_web.cpp",
     "display_server_web.cpp",
     "http_client_web.cpp",
     "javascript_bridge_singleton.cpp",

--- a/platform/web/console_logger_web.cpp
+++ b/platform/web/console_logger_web.cpp
@@ -1,0 +1,108 @@
+/**************************************************************************/
+/*  console_logger_web.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "console_logger_web.h"
+
+#include "godot_js.h"
+
+void ConsoleLoggerWeb::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type) {
+	if (!should_log(true)) {
+		return;
+	}
+
+	const char *err_details;
+	if (p_rationale && *p_rationale) {
+		err_details = p_rationale;
+	} else {
+		err_details = p_code;
+	}
+
+	const char *err_type = "ERROR";
+	switch (p_type) {
+		case ERR_ERROR:
+			err_type = "ERROR";
+			break;
+		case ERR_WARNING:
+			logf_warn("WARNING: %s\n   at: %s (%s:%i)\n", err_details, p_function, p_file, p_line);
+			return;
+		case ERR_SCRIPT:
+			err_type = "SCRIPT ERROR";
+			break;
+		case ERR_SHADER:
+			err_type = "SHADER ERROR";
+			break;
+		default:
+			ERR_PRINT("Unknown error type");
+			break;
+	}
+
+	logf_error("%s: %s\n   at: %s (%s:%i)\n", err_type, err_details, p_function, p_file, p_line);
+}
+
+void ConsoleLoggerWeb::logf_warn(const char *p_format, ...) {
+	if (!should_log(false)) {
+		return;
+	}
+
+	va_list argp;
+	va_start(argp, p_format);
+
+	logv(p_format, argp, PrintType::WARN);
+
+	va_end(argp);
+}
+
+void ConsoleLoggerWeb::logv(const char *p_format, va_list p_list, bool p_err) {
+	logv(p_format, p_list, p_err ? PrintType::ERROR : PrintType::LOG);
+}
+
+void ConsoleLoggerWeb::logv(const char *p_format, va_list p_list, PrintType p_type) {
+	if (!should_log(p_type == PrintType::ERROR || p_type == PrintType::WARN)) {
+		return;
+	}
+
+	int str_size = vsnprintf(nullptr, 0, p_format, p_list) + 1;
+	char *str = new char[str_size];
+	vsnprintf(str, str_size, p_format, p_list);
+
+	switch (p_type) {
+		case PrintType::ERROR:
+			godot_js_os_print_error(str);
+			break;
+		case PrintType::LOG:
+			godot_js_os_print(str);
+			break;
+		case PrintType::WARN:
+			godot_js_os_print_warning(str);
+			break;
+	}
+
+	delete[] str;
+}

--- a/platform/web/console_logger_web.h
+++ b/platform/web/console_logger_web.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  console_logger_web.h                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef CONSOLE_LOGGER_WEB_H
+#define CONSOLE_LOGGER_WEB_H
+
+#include "core/io/logger.h"
+
+class ConsoleLoggerWeb : public Logger {
+	enum class PrintType { LOG,
+		ERROR,
+		WARN };
+	virtual void logv(const char *p_format, va_list p_list, PrintType p_type);
+
+public:
+	virtual void logv(const char *p_format, va_list p_list, bool p_err) override;
+	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify = false, ErrorType p_type = ERR_ERROR) override;
+	virtual ~ConsoleLoggerWeb() {}
+
+	void logf_warn(const char *p_format, ...) _PRINTF_FORMAT_ATTRIBUTE_2_3;
+};
+
+#endif // CONSOLE_LOGGER_WEB_H

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -45,6 +45,9 @@ extern void godot_js_config_locale_get(char *p_ptr, int p_ptr_max);
 extern void godot_js_config_canvas_id_get(char *p_ptr, int p_ptr_max);
 
 // OS
+extern void godot_js_os_print(const char *p_str);
+extern void godot_js_os_print_error(const char *p_str);
+extern void godot_js_os_print_warning(const char *p_str);
 extern void godot_js_os_finish_async(void (*p_callback)());
 extern void godot_js_os_request_quit_cb(void (*p_callback)());
 extern int godot_js_os_fs_is_persistent();

--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -183,34 +183,49 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		 */
 		onProgress: null,
 		/**
-		 * A callback function for handling the standard output stream. This method should usually only be used in debug pages.
+		 * A callback function for handling prints. This method should usually only be used in debug pages.
 		 *
 		 * By default, ``console.log()`` is used.
 		 *
 		 * @callback EngineConfig.onPrint
-		 * @param {...*} [var_args] A variadic number of arguments to be printed.
+		 * @param {string} text The text to be printed.
 		 */
 		/**
 		 * @ignore
-		 * @type {?function(...*)}
+		 * @type {?function(string)}
 		 */
-		onPrint: function () {
-			console.log.apply(console, Array.from(arguments)); // eslint-disable-line no-console
+		onPrint: function (text) {
+			console.log(text); // eslint-disable-line no-console
 		},
 		/**
-		 * A callback function for handling the standard error stream. This method should usually only be used in debug pages.
+		 * A callback function for handling pushed errors. This method should usually only be used in debug pages.
 		 *
 		 * By default, ``console.error()`` is used.
 		 *
 		 * @callback EngineConfig.onPrintError
-		 * @param {...*} [var_args] A variadic number of arguments to be printed as errors.
+		 * @param {string} text The text to be printed as an error.
 		*/
 		/**
 		 * @ignore
-		 * @type {?function(...*)}
+		 * @type {?function(string)}
 		 */
-		onPrintError: function (var_args) {
-			console.error.apply(console, Array.from(arguments)); // eslint-disable-line no-console
+		onPrintError: function (text) {
+			console.error(text); // eslint-disable-line no-console
+		},
+		/**
+		 * A callback function for handling pushed warnings. This method should usually only be used in debug pages.
+		 *
+		 * By default, ``console.warn()`` is used.
+		 *
+		 * @callback EngineConfig.onPrintWarn
+		 * @param {string} text The text to be printed as a warning.
+		 */
+		/**
+		 * @ignore
+		 * @type {?function(string)}
+		 */
+		onPrintWarn: function (text) {
+			console.warn(text); // eslint-disable-line no-console
 		},
 	};
 
@@ -242,8 +257,6 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		}
 		// Module config
 		this.unloadAfterInit = parse('unloadAfterInit', this.unloadAfterInit);
-		this.onPrintError = parse('onPrintError', this.onPrintError);
-		this.onPrint = parse('onPrint', this.onPrint);
 		this.onProgress = parse('onProgress', this.onProgress);
 
 		// Godot config
@@ -262,6 +275,9 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		this.args = parse('args', this.args);
 		this.onExecute = parse('onExecute', this.onExecute);
 		this.onExit = parse('onExit', this.onExit);
+		this.onPrintError = parse('onPrintError', this.onPrintError);
+		this.onPrintWarn = parse('onPrintWarn', this.onPrintWarn);
+		this.onPrint = parse('onPrint', this.onPrint);
 	};
 
 	/**
@@ -273,8 +289,6 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		let r = response;
 		const gdext = this.gdextensionLibs;
 		return {
-			'print': this.onPrint,
-			'printErr': this.onPrintError,
 			'thisProgram': this.executable,
 			'noExitRuntime': false,
 			'dynamicLibraries': [`${loadPath}.side.wasm`].concat(this.gdextensionLibs),
@@ -360,6 +374,9 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 					onExit(p_code);
 				}
 			},
+			'onPrint': this.onPrint,
+			'onPrintError': this.onPrintError,
+			'onPrintWarn': this.onPrintWarn,
 		};
 	};
 	return new Config(initConfig);

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -72,6 +72,9 @@ const GodotConfig = {
 			GodotConfig.persistent_drops = !!p_opts['persistentDrops'];
 			GodotConfig.on_execute = p_opts['onExecute'];
 			GodotConfig.on_exit = p_opts['onExit'];
+			GodotConfig.on_print = p_opts['onPrint'];
+			GodotConfig.on_print_error = p_opts['onPrintError'];
+			GodotConfig.on_print_warn = p_opts['onPrintWarn'];
 			if (p_opts['focusCanvas']) {
 				GodotConfig.canvas.focus();
 			}
@@ -88,6 +91,9 @@ const GodotConfig = {
 			GodotConfig.persistent_drops = false;
 			GodotConfig.on_execute = null;
 			GodotConfig.on_exit = null;
+			GodotConfig.on_print = null;
+			GodotConfig.on_print_error = null;
+			GodotConfig.on_print_warn = null;
 		},
 	},
 
@@ -266,6 +272,27 @@ const GodotOS = {
 				}, 0);
 			});
 		},
+	},
+
+	godot_js_os_print__proxy: 'sync',
+	godot_js_os_print__sig: 'vi',
+	godot_js_os_print: function (p_str) {
+		const str = GodotRuntime.parseString(p_str);
+		GodotConfig.on_print(str);
+	},
+
+	godot_js_os_print_error__proxy: 'sync',
+	godot_js_os_print_error__sig: 'vi',
+	godot_js_os_print_error: function (p_str) {
+		const str = GodotRuntime.parseString(p_str);
+		GodotConfig.on_print_error(str);
+	},
+
+	godot_js_os_print_warning__proxy: 'sync',
+	godot_js_os_print_warning__sig: 'vi',
+	godot_js_os_print_warning: function (p_str) {
+		const str = GodotRuntime.parseString(p_str);
+		GodotConfig.on_print_warn(str);
 	},
 
 	godot_js_os_finish_async__proxy: 'sync',

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -31,6 +31,7 @@
 #include "os_web.h"
 
 #include "api/javascript_bridge_singleton.h"
+#include "console_logger_web.h"
 #include "display_server_web.h"
 #include "godot_js.h"
 
@@ -283,7 +284,7 @@ OS_Web::OS_Web() {
 	idb_available = godot_js_os_fs_is_persistent();
 
 	Vector<Logger *> loggers;
-	loggers.push_back(memnew(StdLogger));
+	loggers.push_back(memnew(ConsoleLoggerWeb));
 	_set_logger(memnew(CompositeLogger(loggers)));
 
 	FileAccessUnix::close_notification_func = file_access_close_callback;


### PR DESCRIPTION
Resolves #98952. Adds a platform specific logger to the web which allows to print through `console.warn` in the browser and which links to the JS `EngineConfig` API.

This also seemed like an appropriate time to change the docstring to reflect the implementation more accurately. See comment on the docstring for a further explanation.

This PR is in draft because this needs discussion:
- Do we need the ability to log warnings as warnings in the console instead of errors?
- Consecutive `printraw` functions now log on seperate lines instead of the same line. This behaviour is similar to calling consecutive `console.log` functions. What is desired?
- Prints containing newlines used to be seperated but now they are grouped into one log. What is desired?