### PR TITLE
Resolve some popping and mistiming in AudioStreamInteractive

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -912,6 +912,17 @@ void AudioStreamPlaybackInteractive::_mix_internal(int p_frames) {
 		state.queue_active = false;
 		_mix_internal_state(i, p_frames);
 	}
+
+	// Only go one level deep when immediately processing queued states,
+	// so mark any remaining queued states as active for next time.
+	for (int i = 0; i < stream->clip_count; i++) {
+		if (!states[i].queue_active) {
+			continue;
+		}
+		State &state = states[i];
+		state.active = true;
+		state.queue_active = false;
+	}
 }
 
 void AudioStreamPlaybackInteractive::_mix_internal_state(int p_state_idx, int p_frames) {

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -675,7 +675,7 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 	}
 
 	// Prepare the fadeout
-	double current_pos;
+	float current_pos;
 	if (p_is_auto_advance) {
 		// Use position from before mixing from_state, otherwise a small desync can occur.
 		current_pos = from_state.before_mix_position;
@@ -683,29 +683,29 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 		current_pos = from_state.playback->get_playback_position();
 	}
 
-	double src_fade_wait = 0;
-	double dst_seek_to = 0;
+	float src_fade_wait = 0;
+	float dst_seek_to = 0;
 	float fade_speed = 0;
 	bool src_no_loop = false;
 
 	if (from_state.stream->get_bpm()) {
 		// Check if source speed has BPM, if so, transition syncs to BPM
-		double beat_sec = 60 / double(from_state.stream->get_bpm());
+		float beat_sec = 60 / float(from_state.stream->get_bpm());
 		switch (transition.from_time) {
 			case AudioStreamInteractive::TRANSITION_FROM_TIME_IMMEDIATE: {
 				src_fade_wait = 0;
 			} break;
 			case AudioStreamInteractive::TRANSITION_FROM_TIME_NEXT_BEAT: {
-				double remainder = Math::fmod(current_pos, beat_sec);
+				float remainder = Math::fmod(current_pos, beat_sec);
 				src_fade_wait = beat_sec - remainder;
 			} break;
 			case AudioStreamInteractive::TRANSITION_FROM_TIME_NEXT_BAR: {
-				double bar_sec = beat_sec * from_state.stream->get_bar_beats();
-				double remainder = Math::fmod(current_pos, bar_sec);
+				float bar_sec = beat_sec * from_state.stream->get_bar_beats();
+				float remainder = Math::fmod(current_pos, bar_sec);
 				src_fade_wait = bar_sec - remainder;
 			} break;
 			case AudioStreamInteractive::TRANSITION_FROM_TIME_END: {
-				double end = from_state.stream->get_beat_count() > 0 ? double(from_state.stream->get_beat_count() * beat_sec) : from_state.stream->get_length();
+				float end = from_state.stream->get_beat_count() > 0 ? float(from_state.stream->get_beat_count() * beat_sec) : from_state.stream->get_length();
 				if (end == 0) {
 					// Stream does not have a length.
 					src_fade_wait = 0;
@@ -726,7 +726,7 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 	} else {
 		// Source has no BPM, so just simple transition.
 		if (transition.from_time == AudioStreamInteractive::TRANSITION_FROM_TIME_END && from_state.stream->get_length() > 0) {
-			double end = from_state.stream->get_length();
+			float end = from_state.stream->get_length();
 			src_fade_wait = end - current_pos;
 			if (!from_state.stream->has_loop()) {
 				src_no_loop = true;
@@ -742,9 +742,9 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 	} else if (transition.to_time == AudioStreamInteractive::TRANSITION_TO_TIME_SAME_POSITION && transition.from_time != AudioStreamInteractive::TRANSITION_FROM_TIME_END && to_state.stream->get_length() > 0.0) {
 		// Seeking to basically same position as when we start fading.
 		dst_seek_to = current_pos + src_fade_wait;
-		double end;
+		float end;
 		if (to_state.stream->get_bpm() > 0 && to_state.stream->get_beat_count()) {
-			double beat_sec = 60 / double(to_state.stream->get_bpm());
+			float beat_sec = 60 / float(to_state.stream->get_bpm());
 			end = to_state.stream->get_beat_count() * beat_sec;
 		} else {
 			end = to_state.stream->get_length();
@@ -817,9 +817,9 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 		filler_state.fade_wait = src_fade_wait;
 		filler_state.first_mix = true;
 
-		double filler_end;
+		float filler_end;
 		if (filler_state.stream->get_bpm() > 0 && filler_state.stream->get_beat_count() > 0) {
-			double filler_beat_sec = 60 / double(filler_state.stream->get_bpm());
+			float filler_beat_sec = 60 / float(filler_state.stream->get_bpm());
 			filler_end = filler_beat_sec * filler_state.stream->get_beat_count();
 		} else {
 			filler_end = filler_state.stream->get_length();

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -779,7 +779,8 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 
 	to_state.playback->start(dst_seek_to);
 	to_state.before_mix_position = dst_seek_to;
-	to_state.queue_active = true;
+	to_state.active = !p_is_auto_advance;
+	to_state.queue_active = p_is_auto_advance;
 	to_state.fade_volume = 0.0;
 	to_state.first_mix = true;
 
@@ -806,7 +807,8 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 
 		filler_state.playback->start(0);
 		filler_state.before_mix_position = 0;
-		filler_state.queue_active = true;
+		filler_state.active = !p_is_auto_advance;
+		filler_state.queue_active = p_is_auto_advance;
 
 		// Filler state does not fade (bake fade in the audio clip if you want fading).
 		filler_state.fade_volume = 1.0;

--- a/modules/interactive_music/audio_stream_interactive.h
+++ b/modules/interactive_music/audio_stream_interactive.h
@@ -216,12 +216,14 @@ private:
 		Ref<AudioStream> stream;
 		Ref<AudioStreamPlayback> playback;
 		bool active = false;
+		bool queue_active = false; // Whether the state has just been queued to become active
 		double fade_wait = 0; // Time to wait until fade kicks-in
 		double fade_volume = 1.0;
 		double fade_speed = 0; // Fade speed, negative or positive
 		int auto_advance = -1;
 		bool first_mix = true;
-		double previous_position = 0;
+		double previous_position = 0; // Position used for "Hold Previous"
+		double before_mix_position = 0; // Position of playback before the current/latest mix began
 
 		void reset_fade() {
 			fade_wait = 0;

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -197,6 +197,8 @@ int AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale, 
 
 	uint64_t mix_increment = uint64_t(((get_stream_sampling_rate() * p_rate_scale * playback_speed_scale) / double(target_rate)) * double(FP_LEN));
 
+	int mixed_frames_total = -1;
+
 	int i;
 	for (i = 0; i < p_frames; i++) {
 		uint32_t idx = CUBIC_INTERP_HISTORY + uint32_t(mix_offset >> FP_BITS);
@@ -207,6 +209,11 @@ int AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale, 
 		AudioFrame y1 = internal_buffer[idx - 2];
 		AudioFrame y2 = internal_buffer[idx - 1];
 		AudioFrame y3 = internal_buffer[idx - 0];
+
+		if (idx >= internal_buffer_end && mixed_frames_total == -1) {
+			// The internal buffer ends somewhere in this range, and we haven't yet recorded the number of good frames we have.
+			mixed_frames_total = i;
+		}
 
 		float mu2 = mu * mu;
 		float h11 = mu2 * (mu - 1);
@@ -225,15 +232,24 @@ int AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale, 
 			internal_buffer[3] = internal_buffer[INTERNAL_BUFFER_LEN + 3];
 			int mixed_frames = _mix_internal(internal_buffer + 4, INTERNAL_BUFFER_LEN);
 			if (mixed_frames != INTERNAL_BUFFER_LEN) {
-				// Ran out of data, fill the rest (old garbage data) with silence.
+				// internal_buffer[mixed_frames + 4] is the first frame of silence.
+				internal_buffer_end = mixed_frames + 4;
+
+				// Fill old (garbage) data with silence.
 				for (int j = mixed_frames + 4; j < INTERNAL_BUFFER_LEN + 4; j++) {
 					internal_buffer[j] = AudioFrame(0, 0);
 				}
+			} else {
+				// The internal buffer does not contain the first frame of silence.
+				internal_buffer_end = -1;
 			}
 			mix_offset -= (INTERNAL_BUFFER_LEN << FP_BITS);
 		}
 	}
-	return p_frames;
+	if (mixed_frames_total == -1 && i == p_frames) {
+		mixed_frames_total = p_frames;
+	}
+	return mixed_frames_total;
 }
 
 ////////////////////////////////


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/94538. Tested using that issue's MRP, as well as with small modifications to it (e.g. converting to WAV and checking for pops/mistiming there as well). Also tested using the original interactive music project from https://github.com/godotengine/godot/pull/64488 to ensure no issues appeared there.

In all, from what I could identify, there are several issues at play here, which produce different popping and mistimings:
- When queuing for auto-advance, the order of clips/states directly alters the timing of the sound output, due to the single-pass loop to mix all the states. This PR addresses this by adding a `queue_active` field to each state, which queues a state to be activated after all currently-active states have finished mixing (and potentially queuing). This is only used for auto-advance, as it is irrelevant otherwise.
- The time used to queue for auto-advance gets the playback position from the `from_state`'s playback position, which is from after mixing the current buffer. This erroneously offsets the queue timing by the duration of the mixing buffer. This PR solves this by tracking the playback position of the state *before* the current mixing started, and using that for auto-advance queuing, which is the only place that is affected. This also sidesteps issues from `AudioStreamPlaybackResampled` causing *another* time offset with the duration of its internal buffer, because it immediately begins mixing when `start()` is called.
- When one clip stops to transition into the next clip, some old audio data was being erroneously repeated, which led to an additional pop sound. It seems that `AudioStreamPlaybackResampled::mix` was the culprit (which is used for OGGs). When it runs out of data to mix, it seems like it reuses old data that happens to be in the internal buffer, repeating it. While `mix()` did originally return a lower number of mixed frames to signal this, AudioStreamInteractive did not account for it, and I'm sure other locations do not as well. I modified `mix()` to ~~always return `p_frames`, and to~~ sample silence when it runs out of data. This seems to work well, but I would like verification that this is a good solution - I tried some others beforehand, with limited success.
- While testing, I encountered an additional bug with filler clips, where with fading disabled, the transition from the filler clip to the next clip causes a fade-in for 1 second, due to what looks like a typo. I made a MRP for this, which tests for both this bug and the popping/mistiming that the overall PR addresses: [Audio Testing Filler Bug.zip](https://github.com/user-attachments/files/17768554/Audio.Testing.Filler.Bug.zip). It is intended to play a consistent tone while switching between three clips. In case the fade is somehow intended behavior, this can be undone.
- ~~This is more of a future-proofing thing (and feel free to undo these changes for this PR if desired), but I changed instances of `float` to `double` when calculating queue times/offsets. This is to prevent floating point inaccuracy drifting a few samples in edge cases where music can last very long (probably at least 10-20 minutes), and the cost is negligible due to how infrequently `_queue()` is called. It's also consistent with all the other values using `double`.~~ This has been undone for now and will be reintroduced in a future PR, see https://github.com/godotengine/godot/pull/99264#issuecomment-2479980593.
