### PR TITLE
Use processed filter list for native dialogs.

### DIFF
--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -145,6 +145,7 @@ private:
 	void _push_history();
 
 	Vector<String> filters;
+	Vector<String> processed_filters;
 
 	bool previews_enabled = true;
 	bool preview_waiting = false;

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -394,7 +394,7 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServer::WindowID p_windo
 				} else {
 					if (flt == "*.*") {
 						filter_exts.push_back("*");
-						filter_names.push_back(RTR("All Files"));
+						filter_names.push_back(RTR("All Files") + " (*)");
 					} else {
 						filter_exts.push_back(flt);
 						filter_names.push_back(flt);
@@ -405,7 +405,7 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServer::WindowID p_windo
 	}
 	if (filter_names.is_empty()) {
 		filter_exts.push_back("*");
-		filter_names.push_back(RTR("All Files"));
+		filter_names.push_back(RTR("All Files") + " (*)");
 	}
 
 	DBusError err;

--- a/platform/macos/godot_open_save_delegate.mm
+++ b/platform/macos/godot_open_save_delegate.mm
@@ -130,7 +130,7 @@
 					}
 
 					if ([type_filters count] > 0) {
-						NSString *name_str = [NSString stringWithUTF8String:((tokens.size() == 1) ? tokens[0] : vformat("%s (%s)", tokens[1].strip_edges(), tokens[0].strip_edges())).utf8().get_data()];
+						NSString *name_str = [NSString stringWithUTF8String:((tokens.size() == 1) ? tokens[0] : tokens[1].strip_edges()).utf8().get_data()];
 						[new_allowed_types addObject:type_filters];
 						[popup addItemWithTitle:name_str];
 					}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -505,7 +505,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 	}
 	if (filter_names.is_empty()) {
 		filter_exts.push_back(String("*.*").utf16());
-		filter_names.push_back(RTR("All Files").utf16());
+		filter_names.push_back((RTR("All Files") + " (*)").utf16());
 	}
 
 	Vector<COMDLG_FILTERSPEC> filters;

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -101,6 +101,7 @@ private:
 	Button *show_filename_filter_button = nullptr;
 
 	Vector<String> filters;
+	Vector<String> processed_filters;
 	String file_name_filter;
 	bool show_filename_filter = false;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/99250

Ensures native dialog filters are translated, have autogenerated filters included and use the same text on all platforms.