### PR TITLE
Introduce a `SubViewportContainer` config for drag-and-drop target locations

### DIFF
--- a/doc/classes/SubViewportContainer.xml
+++ b/doc/classes/SubViewportContainer.xml
@@ -20,6 +20,10 @@
 		</method>
 	</methods>
 	<members>
+		<member name="consume_drag_and_drop" type="bool" setter="set_consume_drag_and_drop" getter="is_consume_drag_and_drop_enabled" default="false">
+			If [code]false[/code], the [SubViewportContainer] is not available as a drop target in drag-and-drop operations, and instead the [Control] nodes inside its [Viewport] children are potential drop targets.
+			If [code]true[/code], the [SubViewportContainer] itself will be considered as a drop target in drag-and-drop operations, preventing the [Control] nodes inside its [Viewport] children from becoming drop targets.
+		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="1" />
 		<member name="stretch" type="bool" setter="set_stretch" getter="is_stretch_enabled" default="false">
 			If [code]true[/code], the sub-viewport will be automatically resized to the control's size.

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -246,6 +246,14 @@ bool SubViewportContainer::_is_propagated_in_gui_input(const Ref<InputEvent> &p_
 	return false;
 }
 
+void SubViewportContainer::set_consume_drag_and_drop(bool p_enable) {
+	consume_drag_and_drop = p_enable;
+}
+
+bool SubViewportContainer::is_consume_drag_and_drop_enabled() {
+	return consume_drag_and_drop;
+}
+
 void SubViewportContainer::add_child_notify(Node *p_child) {
 	if (Object::cast_to<SubViewport>(p_child)) {
 		queue_redraw();
@@ -286,8 +294,12 @@ void SubViewportContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stretch_shrink", "amount"), &SubViewportContainer::set_stretch_shrink);
 	ClassDB::bind_method(D_METHOD("get_stretch_shrink"), &SubViewportContainer::get_stretch_shrink);
 
+	ClassDB::bind_method(D_METHOD("set_consume_drag_and_drop", "amount"), &SubViewportContainer::set_consume_drag_and_drop);
+	ClassDB::bind_method(D_METHOD("is_consume_drag_and_drop_enabled"), &SubViewportContainer::is_consume_drag_and_drop_enabled);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stretch"), "set_stretch", "is_stretch_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_shrink", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), "set_stretch_shrink", "get_stretch_shrink");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "consume_drag_and_drop"), "set_consume_drag_and_drop", "is_consume_drag_and_drop_enabled");
 
 	GDVIRTUAL_BIND(_propagate_input_event, "event");
 }

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -38,6 +38,8 @@ class SubViewportContainer : public Container {
 
 	bool stretch = false;
 	int shrink = 1;
+	bool consume_drag_and_drop = false;
+
 	void _notify_viewports(int p_notification);
 	bool _is_propagated_in_gui_input(const Ref<InputEvent> &p_event);
 	void _send_event_to_viewports(const Ref<InputEvent> &p_event);
@@ -62,6 +64,9 @@ public:
 	void set_stretch_shrink(int p_shrink);
 	int get_stretch_shrink() const;
 	void recalc_force_viewport_sizes();
+
+	void set_consume_drag_and_drop(bool p_enable);
+	bool is_consume_drag_and_drop_enabled();
 
 	virtual Size2 get_minimum_size() const override;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3062,6 +3062,14 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 			}
 			v->_update_mouse_over(v->get_final_transform().affine_inverse().xform(pos));
 		}
+
+		Viewport *section_root = get_section_root_viewport();
+		if (section_root && c->is_consume_drag_and_drop_enabled()) {
+			// Evaluating `consume_drag_and_drop` and adjusting target_control needs to happen
+			// after `_update_mouse_over` in the SubViewports, because otherwise physics picking
+			// would not work inside SubViewports.
+			section_root->gui.target_control = over;
+		}
 	}
 }
 


### PR DESCRIPTION
With the drag-and-drop rewrite #67531, `SubViewportContainer` nodes were no longer available as drop-locations.
A detailed explanation of this situation is available in https://github.com/godotengine/godot/issues/99155#issuecomment-2475088279.

This PR introduces a configuration option, that allows `SubViewportContainer` to be considered as drop-location, but disables the `Control` nodes inside its `SubViewport` children as drop-locations. The reasoning for this either-or-approach is also explained in https://github.com/godotengine/godot/issues/99155#issuecomment-2475088279.

With this setup, it is possible to use the `SubViewportContainer` as drop-location, while at the same time use physics-picking inside the `SubViewports` of the `SubViewportContainer`.

- resolve #99155
- alternative to/supersedes #99209