### PR TITLE
Add back `AnimationPlayer.get_argument_options`

### DIFF
--- a/modules/gdscript/tests/scripts/completion/argument_options/argument_options.tscn
+++ b/modules/gdscript/tests/scripts/completion/argument_options/argument_options.tscn
@@ -1,3 +1,16 @@
 [gd_scene load_steps=1 format=3 uid="uid://dl28pdkxcjvym"]
 
+[sub_resource type="Animation" id="Animation_d1pub"]
+resource_name = "bounce"
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_gs7mj"]
+_data = {
+"bounce": SubResource("Animation_d1pub")
+}
+
 [node name="GetNode" type="Node"]
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_gs7mj")
+}

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_inferred.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_inferred.cfg
@@ -1,0 +1,6 @@
+[input]
+scene="res://completion/argument_options/argument_options.tscn"
+[output]
+include=[
+    {"display": "\"bounce\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_inferred.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_inferred.gd
@@ -1,0 +1,5 @@
+@onready var anim := $AnimationPlayer
+
+func test():
+	anim.play(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_typed.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_typed.cfg
@@ -1,0 +1,6 @@
+[input]
+scene="res://completion/argument_options/argument_options.tscn"
+[output]
+include=[
+    {"display": "\"bounce\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_typed.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_typed.gd
@@ -1,0 +1,5 @@
+@onready var anim: AnimationPlayer = $AnimationPlayer
+
+func test():
+	anim.play(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_untyped.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_untyped.cfg
@@ -1,0 +1,6 @@
+[input]
+scene="res://completion/argument_options/argument_options.tscn"
+[output]
+include=[
+    {"display": "\"bounce\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_untyped.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_untyped.gd
@@ -1,0 +1,5 @@
+@onready var anim = $AnimationPlayer
+
+func test():
+	anim.play(➡)
+    pass

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -876,6 +876,20 @@ Tween::EaseType AnimationPlayer::get_auto_capture_ease_type() const {
 	return auto_capture_ease_type;
 }
 
+#ifdef TOOLS_ENABLED
+void AnimationPlayer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
+	const String pf = p_function;
+	if (p_idx == 0 && (pf == "play" || pf == "play_backwards" || pf == "has_animation" || pf == "queue")) {
+		List<StringName> al;
+		get_animation_list(&al);
+		for (const StringName &name : al) {
+			r_options->push_back(String(name).quote());
+		}
+	}
+	AnimationMixer::get_argument_options(p_function, p_idx, r_options);
+}
+#endif
+
 void AnimationPlayer::_animation_removed(const StringName &p_name, const StringName &p_library) {
 	AnimationMixer::_animation_removed(p_name, p_library);
 

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -178,6 +178,10 @@ public:
 	void set_auto_capture_ease_type(Tween::EaseType p_auto_capture_ease_type);
 	Tween::EaseType get_auto_capture_ease_type() const;
 
+#ifdef TOOLS_ENABLED
+	void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
+#endif
+
 	void play(const StringName &p_name = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
 	void play_section_with_markers(const StringName &p_name = StringName(), const StringName &p_start_marker = StringName(), const StringName &p_end_marker = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
 	void play_section(const StringName &p_name = StringName(), double p_start_time = -1, double p_end_time = -1, double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);


### PR DESCRIPTION
Closes #99211 (First and last example. The second one is intended, when casting a value to a certain type, additional information is lost.)

For some reason #91765 removed this method, I assume it was an oversight.
