### PR TITLE
Fix boot splash loading when path is UID

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2611,25 +2611,23 @@ Image::AlphaMode Image::detect_alpha() const {
 }
 
 Error Image::load(const String &p_path) {
-	String path = ResourceUID::ensure_path(p_path);
 #ifdef DEBUG_ENABLED
-	if (path.begins_with("res://") && ResourceLoader::exists(path)) {
-		WARN_PRINT(vformat("Loaded resource as image file, this will not work on export: '%s'. Instead, import the image file as an Image resource and load it normally as a resource.", path));
+	if (p_path.begins_with("res://") && ResourceLoader::exists(p_path)) {
+		WARN_PRINT(vformat("Loaded resource as image file, this will not work on export: '%s'. Instead, import the image file as an Image resource and load it normally as a resource.", p_path));
 	}
 #endif
-	return ImageLoader::load_image(ResourceUID::ensure_path(p_path), this);
+	return ImageLoader::load_image(p_path, this);
 }
 
 Ref<Image> Image::load_from_file(const String &p_path) {
-	String path = ResourceUID::ensure_path(p_path);
 #ifdef DEBUG_ENABLED
-	if (path.begins_with("res://") && ResourceLoader::exists(path)) {
-		WARN_PRINT(vformat("Loaded resource as image file, this will not work on export: '%s'. Instead, import the image file as an Image resource and load it normally as a resource.", path));
+	if (p_path.begins_with("res://") && ResourceLoader::exists(p_path)) {
+		WARN_PRINT(vformat("Loaded resource as image file, this will not work on export: '%s'. Instead, import the image file as an Image resource and load it normally as a resource.", p_path));
 	}
 #endif
 	Ref<Image> image;
 	image.instantiate();
-	Error err = ImageLoader::load_image(path, image);
+	Error err = ImageLoader::load_image(p_path, image);
 	if (err != OK) {
 		ERR_FAIL_V_MSG(Ref<Image>(), vformat("Failed to load image. Error %d", err));
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5428,7 +5428,7 @@ void EditorNode::redo() {
 
 bool EditorNode::ensure_main_scene(bool p_from_native) {
 	pick_main_scene->set_meta("from_native", p_from_native); // Whether from play button or native run.
-	String main_scene = GLOBAL_GET("application/run/main_scene");
+	String main_scene = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
 
 	if (main_scene.is_empty()) {
 		current_menu_option = -1;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3457,7 +3457,7 @@ void Main::setup_boot_logo() {
 
 	if (show_logo) { //boot logo!
 		const bool boot_logo_image = GLOBAL_DEF_BASIC("application/boot_splash/show_image", true);
-		const String boot_logo_path = String(GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/boot_splash/image", PROPERTY_HINT_FILE, "*.png"), String())).strip_edges();
+		const String boot_logo_path = ResourceUID::ensure_path(GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/boot_splash/image", PROPERTY_HINT_FILE, "*.png"), String())).strip_edges();
 		const bool boot_logo_scale = GLOBAL_DEF_BASIC("application/boot_splash/fullsize", true);
 		const bool boot_logo_filter = GLOBAL_DEF_BASIC("application/boot_splash/use_filter", true);
 
@@ -4221,7 +4221,7 @@ int Main::start() {
 				}
 #endif
 
-				String icon_path = GLOBAL_GET("application/config/icon");
+				const String icon_path = ResourceUID::ensure_path(GLOBAL_GET("application/config/icon"));
 				if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_ICON) && !icon_path.is_empty() && !has_icon) {
 					Ref<Image> icon;
 					icon.instantiate();

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1668,7 +1668,7 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	monochrome.instantiate();
 
 	// Regular icon: user selection -> project icon -> default.
-	String path = static_cast<String>(p_preset->get(launcher_icon_option)).strip_edges();
+	String path = ResourceUID::ensure_path(p_preset->get(launcher_icon_option)).strip_edges();
 	print_verbose("Loading regular icon from " + path);
 	if (path.is_empty() || ImageLoader::load_image(path, icon) != OK) {
 		print_verbose("- falling back to project icon: " + project_icon_path);
@@ -1680,7 +1680,7 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	}
 
 	// Adaptive foreground: user selection -> regular icon (user selection -> project icon -> default).
-	path = static_cast<String>(p_preset->get(launcher_adaptive_icon_foreground_option)).strip_edges();
+	path = ResourceUID::ensure_path(p_preset->get(launcher_adaptive_icon_foreground_option)).strip_edges();
 	print_verbose("Loading adaptive foreground icon from " + path);
 	if (path.is_empty() || ImageLoader::load_image(path, foreground) != OK) {
 		print_verbose("- falling back to using the regular icon");
@@ -1688,14 +1688,14 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	}
 
 	// Adaptive background: user selection -> default.
-	path = static_cast<String>(p_preset->get(launcher_adaptive_icon_background_option)).strip_edges();
+	path = ResourceUID::ensure_path(p_preset->get(launcher_adaptive_icon_background_option)).strip_edges();
 	if (!path.is_empty()) {
 		print_verbose("Loading adaptive background icon from " + path);
 		ImageLoader::load_image(path, background);
 	}
 
 	// Adaptive monochrome: user selection -> default.
-	path = static_cast<String>(p_preset->get(launcher_adaptive_icon_monochrome_option)).strip_edges();
+	path = ResourceUID::ensure_path(p_preset->get(launcher_adaptive_icon_monochrome_option)).strip_edges();
 	if (!path.is_empty()) {
 		print_verbose("Loading adaptive monochrome icon from " + path);
 		ImageLoader::load_image(path, monochrome);

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -915,7 +915,7 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 				exp_name += "_tinted";
 			}
 			exp_name += ".png";
-			String icon_path = p_preset->get(key);
+			String icon_path = ResourceUID::ensure_path(p_preset->get(key));
 			bool resize_waning = true;
 			if (icon_path.is_empty()) {
 				// Load and resize base icon.
@@ -925,7 +925,7 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 				} else if (color_mode == ICON_TINTED) {
 					key += "_tinted";
 				}
-				icon_path = p_preset->get(key);
+				icon_path = ResourceUID::ensure_path(p_preset->get(key));
 				resize_waning = false;
 			}
 			if (icon_path.is_empty()) {
@@ -933,7 +933,7 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 					continue;
 				}
 				// Resize main app icon.
-				icon_path = GLOBAL_GET("application/config/icon");
+				icon_path = ResourceUID::ensure_path(GLOBAL_GET("application/config/icon"));
 				Ref<Image> img = memnew(Image);
 				Error err = ImageLoader::load_image(icon_path, img);
 				if (err != OK) {
@@ -1037,8 +1037,8 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 }
 
 Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExportPreset> &p_preset, const String &p_dest_dir) {
-	const String custom_launch_image_2x = p_preset->get("storyboard/custom_image@2x");
-	const String custom_launch_image_3x = p_preset->get("storyboard/custom_image@3x");
+	const String custom_launch_image_2x = ResourceUID::ensure_path(p_preset->get("storyboard/custom_image@2x"));
+	const String custom_launch_image_3x = ResourceUID::ensure_path(p_preset->get("storyboard/custom_image@3x"));
 
 	if (custom_launch_image_2x.length() > 0 && custom_launch_image_3x.length() > 0) {
 		Ref<Image> image;
@@ -1071,7 +1071,7 @@ Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExpor
 	} else {
 		Ref<Image> splash;
 
-		const String splash_path = GLOBAL_GET("application/boot_splash/image");
+		const String splash_path = ResourceUID::ensure_path(GLOBAL_GET("application/boot_splash/image"));
 
 		if (!splash_path.is_empty()) {
 			splash.instantiate();

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1869,6 +1869,8 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			}
 
 			if (!icon_path.is_empty()) {
+				icon_path = ResourceUID::ensure_path(icon_path);
+
 				if (icon_path.get_extension() == "icns") {
 					Ref<FileAccess> icon = FileAccess::open(icon_path, FileAccess::READ);
 					if (icon.is_valid()) {

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -188,10 +188,12 @@ Error EditorExportPlatformWeb::_add_manifest_icon(const String &p_path, const St
 
 	Ref<Image> icon;
 	if (!p_icon.is_empty()) {
+		const String icon_path = ResourceUID::ensure_path(p_icon);
+
 		icon.instantiate();
-		const Error err = ImageLoader::load_image(p_icon, icon);
+		const Error err = ImageLoader::load_image(icon_path, icon);
 		if (err != OK) {
-			add_message(EXPORT_MESSAGE_ERROR, TTR("Icon Creation"), vformat(TTR("Could not read file: \"%s\"."), p_icon));
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Icon Creation"), vformat(TTR("Could not read file: \"%s\"."), icon_path));
 			return err;
 		}
 		if (icon->get_width() != p_size || icon->get_height() != p_size) {

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -492,6 +492,7 @@ Error EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset
 	} else {
 		icon_path = GLOBAL_GET("application/config/icon");
 	}
+	icon_path = ResourceUID::ensure_path(icon_path);
 	icon_path = ProjectSettings::get_singleton()->globalize_path(icon_path);
 
 	if (p_console_icon) {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1903,7 +1903,7 @@ SceneTree::SceneTree() {
 	// We setup VRS for the main viewport here, in the editor this will have little effect.
 	const int vrs_mode = GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/vrs/mode", PROPERTY_HINT_ENUM, String::utf8("Disabled,Texture,XR")), 0);
 	root->set_vrs_mode(Viewport::VRSMode(vrs_mode));
-	const String vrs_texture_path = String(GLOBAL_DEF(PropertyInfo(Variant::STRING, "rendering/vrs/texture", PROPERTY_HINT_FILE, "*.bmp,*.png,*.tga,*.webp"), String())).strip_edges();
+	const String vrs_texture_path = ResourceUID::ensure_path(GLOBAL_DEF(PropertyInfo(Variant::STRING, "rendering/vrs/texture", PROPERTY_HINT_FILE, "*.bmp,*.png,*.tga,*.webp"), String())).strip_edges();
 	if (vrs_mode == 1 && !vrs_texture_path.is_empty()) {
 		Ref<Image> vrs_image;
 		vrs_image.instantiate();


### PR DESCRIPTION
Fixes #99221 for real.
I somehow missed the issue is about boot splash 🤦‍♂️ Now it makes more sense.

Main uses ImageLoader's `load_image()` directly, so it was not fixed by my previous changes. I added `ensure_path()` calls in some places that can be affected too.

The Image changes from #99226 are technically not needed.