### PR TITLE
Fix calculation of inercia and centre of mass to account for shapes not centered.

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -67,8 +67,8 @@ void GodotBody2D::update_mass_properties() {
 
 						real_t mass_new = area * mass / total_area;
 
-						// NOTE: we assume that the shape origin is also its center of mass.
-						center_of_mass_local += mass_new * get_shape_transform(i).get_origin();
+						// NOTE: we assume that the shape aabb center is also its center of mass.
+						center_of_mass_local += mass_new * (get_shape_transform(i).get_origin() + get_shape(i)->get_aabb().get_center());
 					}
 
 					center_of_mass_local /= mass;
@@ -94,7 +94,7 @@ void GodotBody2D::update_mass_properties() {
 
 					Transform2D mtx = get_shape_transform(i);
 					Vector2 scale = mtx.get_scale();
-					Vector2 shape_origin = mtx.get_origin() - center_of_mass_local;
+					Vector2 shape_origin = mtx.get_origin() + shape->get_aabb().get_center() - center_of_mass_local;
 					inertia += shape->get_moment_of_inertia(mass_new, scale) + mass_new * shape_origin.length_squared();
 				}
 			}


### PR DESCRIPTION
When calculating the center of mass and the inertia of 2D bodies, it was assumed that all shapes are centered, and the origin of the shape is used as it's center of mass.
This leads to visually incoherent behavior like in issue #74305.
Since the calculation for these quantities is based on the aabb of the shape, this commit fixes the formulas by considering the center of the shape's aabb to be the center of mass.
This is accomplished by summing get_shape(i)->get_aabb().get_center() accordingly.
It can be checked, for example, in the minimal reproduction project of issue #74305 that the issue is fixed.