### PR TITLE
Support uid:// in more places

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -262,6 +262,12 @@ String ProjectSettings::globalize_path(const String &p_path) const {
 			return p_path.replace("res:/", resource_path);
 		}
 		return p_path.replace("res://", "");
+	} else if (p_path.begins_with("uid://")) {
+		const String path = ResourceUID::uid_to_path(p_path);
+		if (!resource_path.is_empty()) {
+			return path.replace("res:/", resource_path);
+		}
+		return path.replace("res://", "");
 	} else if (p_path.begins_with("user://")) {
 		String data_dir = OS::get_singleton()->get_user_data_dir();
 		if (!data_dir.is_empty()) {

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -71,7 +71,7 @@ void FileAccess::_set_access_type(AccessType p_access) {
 
 Ref<FileAccess> FileAccess::create_for_path(const String &p_path) {
 	Ref<FileAccess> ret;
-	if (p_path.begins_with("res://")) {
+	if (p_path.begins_with("res://") || p_path.begins_with("uid://")) {
 		ret = create(ACCESS_RESOURCES);
 	} else if (p_path.begins_with("user://")) {
 		ret = create(ACCESS_USERDATA);
@@ -183,13 +183,17 @@ FileAccess::AccessType FileAccess::get_access_type() const {
 }
 
 String FileAccess::fix_path(const String &p_path) const {
-	//helper used by file accesses that use a single filesystem
+	// Helper used by file accesses that use a single filesystem.
 
 	String r_path = p_path.replace("\\", "/");
 
 	switch (_access_type) {
 		case ACCESS_RESOURCES: {
 			if (ProjectSettings::get_singleton()) {
+				if (r_path.begins_with("uid://")) {
+					r_path = ResourceUID::uid_to_path(r_path);
+				}
+
 				if (r_path.begins_with("res://")) {
 					String resource_path = ProjectSettings::get_singleton()->get_resource_path();
 					if (!resource_path.is_empty()) {

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2617,7 +2617,7 @@ Error Image::load(const String &p_path) {
 		WARN_PRINT(vformat("Loaded resource as image file, this will not work on export: '%s'. Instead, import the image file as an Image resource and load it normally as a resource.", path));
 	}
 #endif
-	return ImageLoader::load_image(ResourceUID::ensure_path(p_path), this);
+	return ImageLoader::load_image(path, this);
 }
 
 Ref<Image> Image::load_from_file(const String &p_path) {

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -82,15 +82,16 @@ void ImageFormatLoaderExtension::_bind_methods() {
 
 Error ImageLoader::load_image(const String &p_file, Ref<Image> p_image, Ref<FileAccess> p_custom, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	ERR_FAIL_COND_V_MSG(p_image.is_null(), ERR_INVALID_PARAMETER, "Can't load an image: invalid Image object.");
+	const String file = ResourceUID::ensure_path(p_file);
 
 	Ref<FileAccess> f = p_custom;
 	if (f.is_null()) {
 		Error err;
-		f = FileAccess::open(p_file, FileAccess::READ, &err);
-		ERR_FAIL_COND_V_MSG(f.is_null(), err, vformat("Error opening file '%s'.", p_file));
+		f = FileAccess::open(file, FileAccess::READ, &err);
+		ERR_FAIL_COND_V_MSG(f.is_null(), err, vformat("Error opening file '%s'.", file));
 	}
 
-	String extension = p_file.get_extension();
+	String extension = file.get_extension();
 
 	for (int i = 0; i < loader.size(); i++) {
 		if (!loader[i]->recognize(extension)) {
@@ -98,7 +99,7 @@ Error ImageLoader::load_image(const String &p_file, Ref<Image> p_image, Ref<File
 		}
 		Error err = loader.write[i]->load_image(p_image, f, p_flags, p_scale);
 		if (err != OK) {
-			ERR_PRINT(vformat("Error loading image: '%s'.", p_file));
+			ERR_PRINT(vformat("Error loading image: '%s'.", file));
 		}
 
 		if (err != ERR_FILE_UNRECOGNIZED) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3450,7 +3450,7 @@ void Main::setup_boot_logo() {
 
 	if (show_logo) { //boot logo!
 		const bool boot_logo_image = GLOBAL_DEF_BASIC("application/boot_splash/show_image", true);
-		const String boot_logo_path = String(GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/boot_splash/image", PROPERTY_HINT_FILE, "*.png"), String())).strip_edges();
+		const String boot_logo_path = ResourceUID::ensure_path(GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/boot_splash/image", PROPERTY_HINT_FILE, "*.png"), String())).strip_edges();
 		const bool boot_logo_scale = GLOBAL_DEF_BASIC("application/boot_splash/fullsize", true);
 		const bool boot_logo_filter = GLOBAL_DEF_BASIC("application/boot_splash/use_filter", true);
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8df7e04c-b81c-4006-9314-3056736006eb)
Adds `uid://` support for Image, FileAccess and ProjectSettings.

Fixes #99221
Supersedes #99278