### PR TITLE
Hide unused `exp_edit` from SpinBox's inspector

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -545,6 +545,12 @@ void SpinBox::_set_step_no_signal(double p_step) {
 	set_block_signals(false);
 }
 
+void SpinBox::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "exp_edit") {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+}
+
 void SpinBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_horizontal_alignment", "alignment"), &SpinBox::set_horizontal_alignment);
 	ClassDB::bind_method(D_METHOD("get_horizontal_alignment"), &SpinBox::get_horizontal_alignment);

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -139,6 +139,7 @@ class SpinBox : public Range {
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _value_changed(double p_value) override;
+	void _validate_property(PropertyInfo &p_property) const;
 
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
- Context: https://github.com/godotengine/godot/pull/97573#issuecomment-2464778277