### PR TITLE
Allow changing the Gradle build type for Android Gradle exports

### DIFF
--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -51,6 +51,10 @@
 			If [code]true[/code], native libraries are compressed when performing a Gradle build.
 			[b]Note:[/b] Although your binary may be smaller, your application may load slower because the native libraries are not loaded directly from the binary at runtime.
 		</member>
+		<member name="gradle_build/debug_build_type" type="int" setter="" getter="">
+			Gradle build type to use for debug exports.
+			[b]Note:[/b] This is only used if [member EditorExportPlatformAndroid.gradle_build/use_gradle_build] is enabled.
+		</member>
 		<member name="gradle_build/export_format" type="int" setter="" getter="">
 			Application export format (*.apk or *.aab).
 		</member>
@@ -59,6 +63,10 @@
 		</member>
 		<member name="gradle_build/min_sdk" type="String" setter="" getter="">
 			Minimum Android API level required for the application to run (used during Gradle build). See [url=https://developer.android.com/guide/topics/manifest/uses-sdk-element#uses]android:minSdkVersion[/url].
+		</member>
+		<member name="gradle_build/release_build_type" type="int" setter="" getter="">
+			Gradle build type to use for release exports.
+			[b]Note:[/b] This is only used if [member EditorExportPlatformAndroid.gradle_build/use_gradle_build] is enabled.
 		</member>
 		<member name="gradle_build/target_sdk" type="String" setter="" getter="">
 			The Android API level on which the application is designed to run (used during Gradle build). See [url=https://developer.android.com/guide/topics/manifest/uses-sdk-element#uses]android:targetSdkVersion[/url].


### PR DESCRIPTION
Closes godotengine/godot-proposals#11163.

This adds two new export settings for Android exports, called `gradle_build/debug_build_type` and `gradle_build/release_build_type`, which can be used to control which of Gradle's `buildTypes` is used when building a Gradle export.

This lets you distribute a debug template export on Google Play, by enabling `gradle_build/use_gradle_build` and setting `gradle_build/debug_build_type` to `Release`, which omits the [`debuggable`](https://developer.android.com/privacy-and-security/risks/android-debuggable) attribute and thus allows it to be uploaded for distribution.

![Screenshot](https://github.com/user-attachments/assets/61e3120c-d2bd-4b87-aaea-76f3cd5fb67a)