### PR TITLE
LSP: Fix spec violations that break the VSCode outline

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -57,6 +57,12 @@ lsp::Position GodotPosition::to_lsp(const Vector<String> &p_lines) const {
 		return res;
 	}
 	res.line = line - 1;
+
+	// Special case: `column = 0` -> Starts at beginning of line.
+	if (column <= 0) {
+		return res;
+	}
+
 	// Note: character outside of `pos_line.length()-1` is valid.
 	res.character = column - 1;
 
@@ -238,9 +244,12 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 	r_symbol.kind = lsp::SymbolKind::Class;
 	r_symbol.deprecated = false;
 	r_symbol.range = range_of_node(p_class);
-	r_symbol.range.start.line = MAX(r_symbol.range.start.line, 0);
 	if (p_class->identifier) {
 		r_symbol.selectionRange = range_of_node(p_class->identifier);
+	} else {
+		// No meaningful `selectionRange`, but we must ensure that it is inside of `range`.
+		r_symbol.selectionRange.start = r_symbol.range.start;
+		r_symbol.selectionRange.end = r_symbol.range.start;
 	}
 	r_symbol.detail = "class " + r_symbol.name;
 	{

--- a/modules/gdscript/tests/scripts/lsp/first_line_comment.gd
+++ b/modules/gdscript/tests/scripts/lsp/first_line_comment.gd
@@ -1,0 +1,2 @@
+# Some comment
+extends Node


### PR DESCRIPTION
Fixes #98164

This contains fixes to two situations that would break the vscode outline:

1. The one described in #98164:
As noticed in the issue: with the comment on the first line, the range of the root symbol shifts, which is fine. However, the spec for `selectionRange` requires the selection range to be inside of the range. When the class has no `class_name` we would just leave the selection range on its default of the start of the first line. With the root symbol shift this means, that the selection range is outside the range which is a spec violation and breaks the VSCode outline.

> Figuring this out was so much more work than the three line fix would make it seem TwT

2. The conversion between GDScript positions and LSP positions did not take a special case into account where the GDScript column is set to `0` but the line is set `1`, for this case it would output an invalid lsp column value of `-1` which would break the VSCode outline as well. This case can happen in scripts without `extends` and `class_name` statements.


