### PR TITLE
Add web support for all missing splash screen properties

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -52,6 +52,20 @@ body {
 	margin: auto;
 }
 
+#status-splash.show-image--false {
+	display: none;
+}
+
+#status-splash.fullsize--true {
+	height: 100%;
+	width: 100%;
+	object-fit: contain;
+}
+
+#status-splash.use-filter--false {
+	image-rendering: pixelated;
+}
+
 #status-progress, #status-notice {
 	display: none;
 }
@@ -88,7 +102,7 @@ body {
 		</noscript>
 
 		<div id="status">
-			<img id="status-splash" src="$GODOT_SPLASH" alt="">
+			<img id="status-splash" class="$GODOT_SPLASH_CLASSES" src="$GODOT_SPLASH" alt="">
 			<progress id="status-progress"></progress>
 			<div id="status-notice"></div>
 		</div>

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -170,6 +170,12 @@ void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<Edito
 	replaces["$GODOT_HEAD_INCLUDE"] = head_include + custom_head_include;
 	replaces["$GODOT_CONFIG"] = str_config;
 	replaces["$GODOT_SPLASH_COLOR"] = "#" + Color(GLOBAL_GET("application/boot_splash/bg_color")).to_html(false);
+
+	LocalVector<String> godot_splash_classes;
+	godot_splash_classes.push_back("show-image--" + String(GLOBAL_GET("application/boot_splash/show_image")));
+	godot_splash_classes.push_back("fullsize--" + String(GLOBAL_GET("application/boot_splash/fullsize")));
+	godot_splash_classes.push_back("use-filter--" + String(GLOBAL_GET("application/boot_splash/use_filter")));
+	replaces["$GODOT_SPLASH_CLASSES"] = String(" ").join(godot_splash_classes);
 	replaces["$GODOT_SPLASH"] = p_name + ".png";
 
 	if (p_preset->get("variant/thread_support")) {


### PR DESCRIPTION
This is another small PR with improvements to the current web splash screen. It adds support for `application/boot_splash/show_image`, `application/boot_splash/fullsize` and `application/boot_splash/use_filter` through CSS classes, which means that all current boot splash project settings are supported now. Tested on Firefox 132.0.2, Chrome 131.0.6778.70, Safari 18.0.1.

<details>
<summary> Screenshots </summary>

Demonstrated on this cute 25x25px-sized fella as a splash image:
![godot_pixel](https://github.com/user-attachments/assets/a7dcc418-5e12-4f42-9fe2-6c4771a93990)

**Current behaviour (no matter the settings)**
<img width="1511" alt="current" src="https://github.com/user-attachments/assets/8b4c7c6c-f921-4716-86f3-3b768c5019b0">

**fullsize = true, use_filter = true**
<img width="1511" alt="fullsize" src="https://github.com/user-attachments/assets/cc681339-5591-4f6b-a57e-6edd89dd1846">

**fullsize = true, use_filter = false**
<img width="1511" alt="no-filter" src="https://github.com/user-attachments/assets/8b1b9bf7-c509-4af0-9745-afce874f2344">

**show_image = false**
<img width="1511" alt="no-show" src="https://github.com/user-attachments/assets/2a18880e-a09d-4a9c-b64e-f9f8eefd7521">
</details>