### PR TITLE
Revert "Warn on unknown command line arguments"

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1801,13 +1801,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "--" || arg == "++") {
 			adding_user_args = true;
 		} else {
-			if (!FileAccess::exists(arg) && !DirAccess::exists(arg)) {
-				// Warn if the argument isn't recognized by Godot *and* the file/folder
-				// specified by a positional argument doesn't exist.
-				// This allows projects to read file or folder paths as a positional argument
-				// without printing a warning, as this scenario can't make use of user command line arguments.
-				WARN_PRINT(vformat("Unknown command line argument \"%s\". User arguments should be passed after a -- or ++ separator, e.g. \"-- %s\".", arg, arg));
-			}
 			main_args.push_back(arg);
 		}
 


### PR DESCRIPTION
This reverts commit 8379cc85aad36c6224a7eb163773fe25ca3c811b.

This caused some regressions, as this approach doesn't properly handle all possible arguments.

- Reverts #98895.
- Fixes #99224.
- Fixes #99069.
- Supersedes #99294.

I still think #98895 is a desirable change but it needs more work to handle things without false positives. We've tried several times in the past and it's not easy. I prefer we revert for now instead of adding hacks to work around the regressions.