### PR TITLE
RID Max Allocation Project Setting

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1584,6 +1584,8 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translations_pot_files", PackedStringArray());
 	GLOBAL_DEF_INTERNAL("internationalization/locale/translation_add_builtin_strings_to_pot", false);
 
+	GLOBAL_DEF_RST("memory/limits/rid/max_rid_allocate", 262144);
+
 	ProjectSettings::get_singleton()->add_hidden_prefix("input/");
 }
 

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -31,6 +31,7 @@
 #ifndef RID_OWNER_H
 #define RID_OWNER_H
 
+#include "core/config/project_settings.h"
 #include "core/os/memory.h"
 #include "core/os/mutex.h"
 #include "core/string/print_string.h"
@@ -323,9 +324,12 @@ public:
 		description = p_descrption;
 	}
 
-	RID_Alloc(uint32_t p_target_chunk_byte_size = 65536, uint32_t p_maximum_number_of_elements = 262144) {
+	RID_Alloc(uint32_t p_target_chunk_byte_size = 65536, uint32_t p_maximum_number_of_elements = 0) {
 		elements_in_chunk = sizeof(T) > p_target_chunk_byte_size ? 1 : (p_target_chunk_byte_size / sizeof(T));
 		if constexpr (THREAD_SAFE) {
+			if (p_maximum_number_of_elements == 0) {
+				p_maximum_number_of_elements = GLOBAL_GET("memory/limits/rid/max_rid_allocate");
+			}
 			chunk_limit = (p_maximum_number_of_elements / elements_in_chunk) + 1;
 			chunks = (Chunk **)memalloc(sizeof(Chunk *) * chunk_limit);
 			free_list_chunks = (uint32_t **)memalloc(sizeof(uint32_t *) * chunk_limit);
@@ -416,7 +420,7 @@ public:
 		alloc.set_description(p_descrption);
 	}
 
-	RID_PtrOwner(uint32_t p_target_chunk_byte_size = 65536, uint32_t p_maximum_number_of_elements = 262144) :
+	RID_PtrOwner(uint32_t p_target_chunk_byte_size = 65536, uint32_t p_maximum_number_of_elements = 0) :
 			alloc(p_target_chunk_byte_size, p_maximum_number_of_elements) {}
 };
 
@@ -470,7 +474,7 @@ public:
 	void set_description(const char *p_descrption) {
 		alloc.set_description(p_descrption);
 	}
-	RID_Owner(uint32_t p_target_chunk_byte_size = 65536, uint32_t p_maximum_number_of_elements = 262144) :
+	RID_Owner(uint32_t p_target_chunk_byte_size = 65536, uint32_t p_maximum_number_of_elements = 0) :
 			alloc(p_target_chunk_byte_size, p_maximum_number_of_elements) {}
 };
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2114,6 +2114,10 @@
 		<member name="memory/limits/message_queue/max_size_mb" type="int" setter="" getter="" default="32">
 			Godot uses a message queue to defer some function calls. If you run out of space on it (you will see an error), you can increase the size here.
 		</member>
+		<member name="memory/limits/rid/max_rid_allocate" type="int" setter="" getter="" default="262144">
+			Maximum number of RIDs per allocator. Generally there is one allocator for each type of resource.
+			[b]Note:[/b] If you find yourself needing more than the default value, consider using other methods of batching work.
+		</member>
 		<member name="navigation/2d/default_cell_size" type="float" setter="" getter="" default="1.0">
 			Default cell size for 2D navigation maps. See [method NavigationServer2D.map_set_cell_size].
 		</member>


### PR DESCRIPTION
Fixes #99162

Not fully confident about the name of this setting. Also basically my first PR so would love feedback of any kind.

Add a project setting for the maximum allocations per `RID_Alloc`.

When `p_maximum_number_of_elements` is 0 the project setting will be used. The default value is now 0.