### PR TITLE
Don't tint icons of bottom panel and log filter buttons

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1901,6 +1901,8 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		p_theme->set_stylebox(SceneStringName(pressed), "BottomPanelButton", menu_transparent_style);
 		p_theme->set_stylebox("hover_pressed", "BottomPanelButton", main_screen_button_hover);
 		p_theme->set_stylebox("hover", "BottomPanelButton", main_screen_button_hover);
+		p_theme->set_color("icon_pressed_color", "BottomPanelButton", p_config.icon_normal_color);
+		p_theme->set_color("icon_hover_pressed_color", "BottomPanelButton", p_config.icon_normal_color);
 	}
 
 	// Editor GUI widgets.
@@ -1998,6 +2000,7 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 			Color icon_hover_color = p_config.icon_normal_color * (p_config.dark_theme ? 1.15 : 1.0);
 			icon_hover_color.a = 1.0;
 			p_theme->set_color("icon_hover_color", "EditorLogFilterButton", icon_hover_color);
+			p_theme->set_color("icon_hover_pressed_color", "EditorLogFilterButton", icon_hover_color);
 
 			// When pressed, add a small bottom border to the buttons to better show their active state,
 			// similar to active tabs.


### PR DESCRIPTION
| Old | New |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/1505439b-b3cf-46d5-a81d-50b8a6250baf) | ![2](https://github.com/user-attachments/assets/be5ea9c2-97ae-474f-a091-223aeb98505d) |

Both already have type variations, they were just missing overrides. Closes https://github.com/godotengine/godot/issues/98540