### PR TITLE
[Input] Add comments, and elaborate on unmapped joypads in class documentations

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -89,7 +89,7 @@ private:
 	RBSet<Key> key_label_pressed;
 	RBSet<Key> physical_keys_pressed;
 	RBSet<Key> keys_pressed;
-	RBSet<JoyButton> joy_buttons_pressed;
+	RBSet<JoyButton> joy_buttons_pressed; // Holds pseudo joy buttons, which requresents the actual button + device index.
 	RBMap<JoyAxis, float> _joy_axis;
 	//RBMap<StringName,int> custom_action_press;
 	bool gravity_enabled = false;
@@ -210,7 +210,7 @@ private:
 	struct JoyBinding {
 		JoyType inputType;
 		union {
-			JoyButton button;
+			JoyButton button; // The raw button index, which usually does not match the named JoyButton value.
 
 			struct {
 				JoyAxis axis;
@@ -227,7 +227,7 @@ private:
 
 		JoyType outputType;
 		union {
-			JoyButton button;
+			JoyButton button; // The JoyButton value `JoyBinding.input` maps to.
 
 			struct {
 				JoyAxis axis;
@@ -359,8 +359,8 @@ public:
 	void set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape = Input::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
 
 	void parse_mapping(const String &p_mapping);
-	void joy_button(int p_device, JoyButton p_button, bool p_pressed);
-	void joy_axis(int p_device, JoyAxis p_axis, float p_value);
+	void joy_button(int p_device, JoyButton p_input_button, bool p_pressed);
+	void joy_axis(int p_device, JoyAxis p_input_axis, float p_value);
 	void joy_hat(int p_device, BitField<HatMask> p_val);
 
 	void add_joy_mapping(const String &p_mapping, bool p_update_existing = false);

--- a/core/input/input_enums.h
+++ b/core/input/input_enums.h
@@ -83,7 +83,7 @@ enum class JoyButton {
 	PADDLE4 = 19,
 	TOUCHPAD = 20,
 	SDL_MAX = 21,
-	MAX = 128, // Android supports up to 36 buttons. DirectInput supports up to 128 buttons.
+	MAX = 128, // DirectX supports up to 14 buttons. Android supports up to 36 buttons. DirectInput supports up to 128 buttons. Linux is clamped to 128 buttons.
 };
 
 enum class MIDIMessage {

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1085,7 +1085,7 @@ void InputEventMouseMotion::_bind_methods() {
 ///////////////////////////////////
 
 void InputEventJoypadMotion::set_axis(JoyAxis p_axis) {
-	ERR_FAIL_COND(p_axis < JoyAxis::INVALID || p_axis > JoyAxis::MAX);
+	ERR_FAIL_COND(p_axis < JoyAxis::INVALID || p_axis >= JoyAxis::MAX);
 
 	axis = p_axis;
 	emit_changed();
@@ -1201,6 +1201,8 @@ void InputEventJoypadMotion::_bind_methods() {
 ///////////////////////////////////
 
 void InputEventJoypadButton::set_button_index(JoyButton p_index) {
+	ERR_FAIL_COND(p_index < JoyButton::INVALID || p_index >= JoyButton::MAX);
+
 	button_index = p_index;
 	emit_changed();
 }

--- a/doc/classes/InputEventJoypadButton.xml
+++ b/doc/classes/InputEventJoypadButton.xml
@@ -12,6 +12,7 @@
 	<members>
 		<member name="button_index" type="int" setter="set_button_index" getter="get_button_index" enum="JoyButton" default="0">
 			Button identifier. One of the [enum JoyButton] button constants.
+			For unmapped joypads, this identifier does not necessarily match the [enum JoyButton] button constants. To check if your device is mapped, use [method Input.is_joy_known].
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the button's state is pressed. If [code]false[/code], the button's state is released.

--- a/doc/classes/InputEventJoypadMotion.xml
+++ b/doc/classes/InputEventJoypadMotion.xml
@@ -12,6 +12,7 @@
 	<members>
 		<member name="axis" type="int" setter="set_axis" getter="get_axis" enum="JoyAxis" default="0">
 			Axis identifier. Use one of the [enum JoyAxis] axis constants.
+			For unmapped joypads, this identifier does not necessarily match the [enum JoyAxis] axis constants. To check if your device is mapped, use [method Input.is_joy_known].
 		</member>
 		<member name="axis_value" type="float" setter="set_axis_value" getter="get_axis_value" default="0.0">
 			Current position of the joystick on the given axis. The value ranges from [code]-1.0[/code] to [code]1.0[/code]. A value of [code]0[/code] means the axis is in its resting position.


### PR DESCRIPTION
* I also renamed some parameters, as they are raw input button IDs, and the code attempts to map them to output button IDs. It helps to know when you're dealing with which (especially for first-time readers of that stuff).
* Added one `ERR_CONTINUE_MSG` for an error, that was silently dropped. I also have no problem removing the error print and leaving a comment such as `Silently ignoring this error on purpose.`
* The PR is a draft, for now, until I've actually tested the behavior described in the classes. It should be accurate, judging from the code