### PR TITLE
Add `clear_task_if_completed` function to `WorkerThreadPool`

### DIFF
--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -238,6 +238,7 @@ public:
 	TaskID add_task(const Callable &p_action, bool p_high_priority = false, const String &p_description = String());
 
 	bool is_task_completed(TaskID p_task_id) const;
+	bool clear_task_if_completed(TaskID p_task_id);
 	Error wait_for_task_completion(TaskID p_task_id);
 
 	void yield();

--- a/doc/classes/WorkerThreadPool.xml
+++ b/doc/classes/WorkerThreadPool.xml
@@ -72,6 +72,14 @@
 				[b]Warning:[/b] Every task must be waited for completion using [method wait_for_task_completion] or [method wait_for_group_task_completion] at some point so that any allocated resources inside the task can be cleaned up.
 			</description>
 		</method>
+		<method name="clear_task_if_completed">
+			<return type="bool" />
+			<param index="0" name="task_id" type="int" />
+			<description>
+				Returns [code]true[/code] if the task with the given ID is completed, and then removes it from memory (if completed).
+				[b]Note:[/b] You should only call this method between adding the task and awaiting its completion.
+			</description>
+		</method>
 		<method name="get_group_processed_element_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="group_id" type="int" />


### PR DESCRIPTION
Currently every task must be waited on (wait_for_task_completion) for their resources to be removed from memory (https://github.com/godotengine/godot/issues/84888). This is addressed in the docs however said solution may not always be intuitive or ideal as the function known as "wait_for_task_completion" is used even in cases where no waiting is necessary as it does the double duty of waiting, and also clearing memory.

While it makes sense that if you wait for a task, and it finishes, it should be cleared from memory, it is not always intuitive that you HAVE to wait for a task that you know is completed (via is_task_completed) to prevent a memory leak.

This can currently be circumvented by using an if statement (if is_task_completed: wait_for_task_completion) however said usage is ugly and also unintuitive.

This commit adds a function which checks if the task is completed, and then returns true and clears resources if so. Essentially doing the same job as wait_for_task_completion if already completed, HOWEVER not binding the main thread (or the thread it is called from) in the case the task isn't.

This allows for resource clearing without accidentally pausing the entire thread if not completed, in the case of a non essential functions such as saving (which can be allowed to operate in the background without pausing the entire game/main thread)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
