### PR TITLE
Add clarification on `WorkerThreadPool` threadcount

### DIFF
--- a/doc/classes/WorkerThreadPool.xml
+++ b/doc/classes/WorkerThreadPool.xml
@@ -6,6 +6,7 @@
 	<description>
 		The [WorkerThreadPool] singleton allocates a set of [Thread]s (called worker threads) on project startup and provides methods for offloading tasks to them. This can be used for simple multithreading without having to create [Thread]s.
 		Tasks hold the [Callable] to be run by the threads. [WorkerThreadPool] can be used to create regular tasks, which will be taken by one worker thread, or group tasks, which can be distributed between multiple worker threads. Group tasks execute the [Callable] multiple times, which makes them useful for iterating over a lot of elements, such as the enemies in an arena.
+		[b]Note:[/b] The amount of threads created is given by the [OS] as the amount of processors on the system-1 unless it is on a browser in which case it will be 0
 		Here's a sample on how to offload an expensive function to worker threads:
 		[codeblocks]
 		[gdscript]


### PR DESCRIPTION
https://github.com/godotengine/godot/blob/master/core/os/os.h https://github.com/godotengine/godot/blob/master/platform/web/os_web.h

Sources here 
https://github.com/godotengine/godot/blob/master/core/os/os.h#L91 https://github.com/godotengine/godot/blob/master/platform/web/os_web.h#319 https://github.com/godotengine/godot/blob/master/core/object/worker_thread_pool.cpp#L752

Note that although web returns 1, the max threads is the returned processors - 1 so no multithreading on web

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
