### PR TITLE
Editor: Add named `EditorScript`s to the command palette

### DIFF
--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Scripts extending this class and implementing its [method _run] method can be executed from the Script Editor's [b]File &gt; Run[/b] menu option (or by pressing [kbd]Ctrl + Shift + X[/kbd]) while the editor is running. This is useful for adding custom in-editor functionality to Godot. For more complex additions, consider using [EditorPlugin]s instead.
+		If a script extending this class also has a global class name, it will be included in the editor's command palette.
 		[b]Note:[/b] Extending scripts need to have [code]tool[/code] mode enabled.
 		[b]Example:[/b] Running the following script prints "Hello from the Godot Editor!":
 		[codeblocks]

--- a/editor/plugins/editor_script_plugin.cpp
+++ b/editor/plugins/editor_script_plugin.cpp
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  editor_script_plugin.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_script_plugin.h"
+
+#include "editor/editor_command_palette.h"
+#include "editor/editor_interface.h"
+#include "editor/editor_script.h"
+
+Ref<EditorScript> create_instance(const StringName &p_name) {
+	Ref<EditorScript> es;
+	es.instantiate();
+	Ref<Script> scr = ResourceLoader::load(ScriptServer::get_global_class_path(p_name), "Script", ResourceFormatLoader::CACHE_MODE_REUSE);
+	if (scr.is_valid()) {
+		es->set_script(scr);
+	}
+	return es;
+}
+
+void EditorScriptPlugin::run_command(const StringName &p_name) {
+	create_instance(p_name)->run();
+}
+
+void EditorScriptPlugin::command_palette_about_to_popup() {
+	for (const StringName &command : commands) {
+		EditorInterface::get_singleton()->get_command_palette()->remove_command("editor_scripts/" + command);
+	}
+	commands.clear();
+	ScriptServer::get_inheriters_list(SNAME("EditorScript"), &commands);
+	for (const StringName &command : commands) {
+		EditorInterface::get_singleton()->get_command_palette()->add_command(String(command).capitalize(), "editor_scripts/" + command, callable_mp(this, &EditorScriptPlugin::run_command), varray(command), nullptr);
+	}
+}
+
+EditorScriptPlugin::EditorScriptPlugin() {
+	EditorInterface::get_singleton()->get_command_palette()->connect("about_to_popup", callable_mp(this, &EditorScriptPlugin::command_palette_about_to_popup));
+}

--- a/editor/plugins/editor_script_plugin.h
+++ b/editor/plugins/editor_script_plugin.h
@@ -1,0 +1,48 @@
+/**************************************************************************/
+/*  editor_script_plugin.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/plugins/editor_plugin.h"
+
+class EditorScriptPlugin : public EditorPlugin {
+	GDCLASS(EditorScriptPlugin, EditorPlugin);
+
+private:
+	List<StringName> commands;
+
+	void run_command(const StringName &p_name);
+	void command_palette_about_to_popup();
+
+public:
+	EditorScriptPlugin();
+
+	virtual String get_plugin_name() const override { return "EditorScript"; }
+};

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -83,6 +83,7 @@
 #include "editor/plugins/editor_context_menu_plugin.h"
 #include "editor/plugins/editor_debugger_plugin.h"
 #include "editor/plugins/editor_resource_tooltip_plugins.h"
+#include "editor/plugins/editor_script_plugin.h"
 #include "editor/plugins/font_config_plugin.h"
 #include "editor/plugins/gpu_particles_collision_sdf_editor_plugin.h"
 #include "editor/plugins/gradient_editor_plugin.h"
@@ -218,6 +219,7 @@ void register_editor_types() {
 	if (!Engine::get_singleton()->is_recovery_mode_hint()) {
 		EditorPlugins::add_by_type<DebugAdapterServer>();
 	}
+	EditorPlugins::add_by_type<EditorScriptPlugin>();
 	EditorPlugins::add_by_type<FontEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticles3DEditorPlugin>();
 	EditorPlugins::add_by_type<GPUParticlesCollisionSDF3DEditorPlugin>();


### PR DESCRIPTION
Tries to solve the problem from godotengine/godot-proposals#8923. I agree with https://github.com/godotengine/godot-proposals/issues/8923#issuecomment-1986829877 that this would best be solved through the command palette.

This PR makes it possible to execute `EditorScript`s through the command palette, which makes them a bit more suitable for project specific commands. For practical reasons only named scripts will be added. This is done to always have a display name, and since only named scripts are easily searchable through the `ScriptServer`.

~It also introduces an `_get_name` virtual method to customize the display name (if not overridden the class name is used).~ (Removed due to performance concerns)
