### PR TITLE
Fix key is deselected by changing key time in KeyEdit in FPS mode

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -7364,7 +7364,6 @@ void AnimationTrackEditor::_update_snap_unit() {
 	}
 
 	if (timeline->is_using_fps()) {
-		_clear_selection(true); // Needs to recreate a spinbox of the KeyEdit.
 		snap_unit = 1.0 / step->get_value();
 	} else {
 		if (fps_compat->is_pressed()) {


### PR DESCRIPTION
- Follow up / Context https://github.com/godotengine/godot/pull/99013#discussion_r1844990997

KeyEdit in FPS mode is unstable (like https://github.com/godotengine/godot/issues/99320), but this fix does not particularly help that fix, and we are partially revert because of the problem.