### PR TITLE
Use `get_slicec` instead of `get_slice` for single character splitters

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -289,7 +289,7 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 				remove_autoload(node_name);
 			}
 		} else if (p_name.operator String().begins_with("global_group/")) {
-			String group_name = p_name.operator String().get_slice("/", 1);
+			String group_name = p_name.operator String().get_slicec('/', 1);
 			if (global_groups.has(group_name)) {
 				remove_global_group(group_name);
 			}
@@ -340,7 +340,7 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 			}
 			add_autoload(autoload);
 		} else if (p_name.operator String().begins_with("global_group/")) {
-			String group_name = p_name.operator String().get_slice("/", 1);
+			String group_name = p_name.operator String().get_slicec('/', 1);
 			add_global_group(group_name, p_value);
 		}
 	}

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1594,8 +1594,8 @@ void Input::parse_mapping(const String &p_mapping) {
 			continue;
 		}
 
-		String output = entry[idx].get_slice(":", 0).replace(" ", "");
-		String input = entry[idx].get_slice(":", 1).replace(" ", "");
+		String output = entry[idx].get_slicec(':', 0).replace(" ", "");
+		String input = entry[idx].get_slicec(':', 1).replace(" ", "");
 		if (output.length() < 1 || input.length() < 2) {
 			continue;
 		}

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -138,7 +138,7 @@ TranslationServer::Locale::Locale(const TranslationServer &p_server, const Strin
 	String univ_locale = p_locale.replace("-", "_");
 
 	// Extract locale elements.
-	Vector<String> locale_elements = univ_locale.get_slice("@", 0).split("_");
+	Vector<String> locale_elements = univ_locale.get_slicec('@', 0).split("_");
 	language = locale_elements[0];
 	if (locale_elements.size() >= 2) {
 		if (locale_elements[1].length() == 4 && is_ascii_upper_case(locale_elements[1][0]) && is_ascii_lower_case(locale_elements[1][1]) && is_ascii_lower_case(locale_elements[1][2]) && is_ascii_lower_case(locale_elements[1][3])) {
@@ -162,7 +162,7 @@ TranslationServer::Locale::Locale(const TranslationServer &p_server, const Strin
 	}
 
 	// Try extract script and variant from the extra part.
-	Vector<String> script_extra = univ_locale.get_slice("@", 1).split(";");
+	Vector<String> script_extra = univ_locale.get_slicec('@', 1).split(";");
 	for (int i = 0; i < script_extra.size(); i++) {
 		if (script_extra[i].to_lower() == "cyrillic") {
 			script = "Cyrl";

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -226,7 +226,7 @@ Config::Config() {
 		// OpenGL ES 3.0 V@331.0 (GIT@35e467f, Ice9844a736) (Date:04/15/19)
 		// OpenGL ES 3.0 V@415.0 (GIT@d39f783, I79de86aa2c, 1591296226) (Date:06/04/20)
 		// OpenGL ES 3.0 V@0502.0 (GIT@09fef447e8, I1fe547a144, 1661493934) (Date:08/25/22)
-		String driver_version = gl_version.get_slice("V@", 1).get_slice(" ", 0);
+		String driver_version = gl_version.get_slice("V@", 1).get_slicec(' ', 0);
 		if (driver_version.is_valid_float() && driver_version.to_float() >= 331.0) {
 			flip_xy_workaround = false;
 

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1925,7 +1925,7 @@ void MaterialStorage::global_shader_parameters_load_settings(bool p_load_texture
 
 	for (const PropertyInfo &E : settings) {
 		if (E.name.begins_with("shader_globals/")) {
-			StringName name = E.name.get_slice("/", 1);
+			StringName name = E.name.get_slicec('/', 1);
 			Dictionary d = GLOBAL_GET(E.name);
 
 			ERR_CONTINUE(!d.has("type"));

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -221,10 +221,10 @@ bool AnimationTrackKeyEdit::_set(const StringName &p_name, const Variant &p_valu
 				change_notify_deserved = true;
 			} else if (name.begins_with("args/")) {
 				Vector<Variant> args = d_old["args"];
-				int idx = name.get_slice("/", 1).to_int();
+				int idx = name.get_slicec('/', 1).to_int();
 				ERR_FAIL_INDEX_V(idx, args.size(), false);
 
-				String what = name.get_slice("/", 2);
+				String what = name.get_slicec('/', 2);
 				if (what == "type") {
 					Variant::Type t = Variant::Type(int(p_value));
 
@@ -478,10 +478,10 @@ bool AnimationTrackKeyEdit::_get(const StringName &p_name, Variant &r_ret) const
 			}
 
 			if (name.begins_with("args/")) {
-				int idx = name.get_slice("/", 1).to_int();
+				int idx = name.get_slicec('/', 1).to_int();
 				ERR_FAIL_INDEX_V(idx, args.size(), false);
 
-				String what = name.get_slice("/", 2);
+				String what = name.get_slicec('/', 2);
 				if (what == "type") {
 					r_ret = args[idx].get_type();
 					return true;
@@ -833,10 +833,10 @@ bool AnimationMultiTrackKeyEdit::_set(const StringName &p_name, const Variant &p
 						change_notify_deserved = true;
 					} else if (name.begins_with("args/")) {
 						Vector<Variant> args = d_old["args"];
-						int idx = name.get_slice("/", 1).to_int();
+						int idx = name.get_slicec('/', 1).to_int();
 						ERR_FAIL_INDEX_V(idx, args.size(), false);
 
-						String what = name.get_slice("/", 2);
+						String what = name.get_slicec('/', 2);
 						if (what == "type") {
 							Variant::Type t = Variant::Type(int(p_value));
 
@@ -1055,10 +1055,10 @@ bool AnimationMultiTrackKeyEdit::_get(const StringName &p_name, Variant &r_ret) 
 					}
 
 					if (name.begins_with("args/")) {
-						int idx = name.get_slice("/", 1).to_int();
+						int idx = name.get_slicec('/', 1).to_int();
 						ERR_FAIL_INDEX_V(idx, args.size(), false);
 
-						String what = name.get_slice("/", 2);
+						String what = name.get_slicec('/', 2);
 						if (what == "type") {
 							r_ret = args[idx].get_type();
 							return true;
@@ -3324,7 +3324,7 @@ Variant AnimationTrackEdit::get_drag_data(const Point2 &p_point) {
 	Dictionary drag_data;
 	drag_data["type"] = "animation_track";
 	String base_path = animation->track_get_path(track);
-	base_path = base_path.get_slice(":", 0); // Remove sub-path.
+	base_path = base_path.get_slicec(':', 0); // Remove sub-path.
 	drag_data["group"] = base_path;
 	drag_data["index"] = track;
 
@@ -3355,7 +3355,7 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 	// Don't allow moving tracks outside their groups.
 	if (get_editor()->is_grouping_tracks()) {
 		String base_path = animation->track_get_path(track);
-		base_path = base_path.get_slice(":", 0); // Remove sub-path.
+		base_path = base_path.get_slicec(':', 0); // Remove sub-path.
 		if (d["group"] != base_path) {
 			return false;
 		}
@@ -3386,7 +3386,7 @@ void AnimationTrackEdit::drop_data(const Point2 &p_point, const Variant &p_data)
 	// Don't allow moving tracks outside their groups.
 	if (get_editor()->is_grouping_tracks()) {
 		String base_path = animation->track_get_path(track);
-		base_path = base_path.get_slice(":", 0); // Remove sub-path.
+		base_path = base_path.get_slicec(':', 0); // Remove sub-path.
 		if (d["group"] != base_path) {
 			return;
 		}
@@ -4935,7 +4935,7 @@ void AnimationTrackEditor::_update_tracks() {
 
 		if (use_grouping) {
 			String base_path = animation->track_get_path(i);
-			base_path = base_path.get_slice(":", 0); // Remove sub-path.
+			base_path = base_path.get_slicec(':', 0); // Remove sub-path.
 
 			if (!group_sort.has(base_path)) {
 				AnimationTrackEditGroup *g = memnew(AnimationTrackEditGroup);

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -81,7 +81,7 @@ public:
 		String name = p_name;
 
 		if (name.begins_with("bind/argument_")) {
-			int which = name.get_slice("_", 1).to_int() - 1;
+			int which = name.get_slicec('_', 1).to_int() - 1;
 			ERR_FAIL_INDEX_V(which, params.size(), false);
 			params.write[which] = p_value;
 		} else {
@@ -95,7 +95,7 @@ public:
 		String name = p_name;
 
 		if (name.begins_with("bind/argument_")) {
-			int which = name.get_slice("_", 1).to_int() - 1;
+			int which = name.get_slicec('_', 1).to_int() - 1;
 			ERR_FAIL_INDEX_V(which, params.size(), false);
 			r_ret = params[which];
 		} else {
@@ -224,7 +224,7 @@ void ConnectDialog::_remove_bind() {
 	if (st.is_empty()) {
 		return;
 	}
-	int idx = st.get_slice("/", 1).to_int() - 1;
+	int idx = st.get_slicec('/', 1).to_int() - 1;
 
 	ERR_FAIL_INDEX(idx, cdbinds->params.size());
 	cdbinds->params.remove_at(idx);
@@ -575,8 +575,8 @@ String ConnectDialog::get_signature(const MethodInfo &p_method, PackedStringArra
 			case Variant::DICTIONARY:
 				type_name = "Dictionary";
 				if (pi.hint == PROPERTY_HINT_DICTIONARY_TYPE && !pi.hint_string.is_empty()) {
-					String key_hint = pi.hint_string.get_slice(";", 0);
-					String value_hint = pi.hint_string.get_slice(";", 1);
+					String key_hint = pi.hint_string.get_slicec(';', 0);
+					String value_hint = pi.hint_string.get_slicec(';', 1);
 					if (key_hint.is_empty() || key_hint.begins_with("res://")) {
 						key_hint = "Variant";
 					}

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -290,7 +290,7 @@ void EditorDebuggerInspector::clear_stack_variables() {
 String EditorDebuggerInspector::get_stack_variable(const String &p_var) {
 	for (KeyValue<StringName, Variant> &E : variables->prop_values) {
 		String v = E.key.operator String();
-		if (v.get_slice("/", 1) == p_var) {
+		if (v.get_slicec('/', 1) == p_var) {
 			return variables->get_variant(v);
 		}
 	}

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -78,7 +78,7 @@ void EditorFileServer::_scan_files_changed(EditorFileSystemDirectory *efd, const
 					uint64_t mt = FileAccess::get_modified_time(remapped_path);
 					_add_file(remapped_path, mt, files_to_send, cached_files);
 				} else if (remap.begins_with("path.")) {
-					String feature = remap.get_slice(".", 1);
+					String feature = remap.get_slicec('.', 1);
 					if (p_tags.has(feature)) {
 						String remapped_path = cf->get_value("remap", remap);
 						uint64_t mt = FileAccess::get_modified_time(remapped_path);

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -133,8 +133,8 @@ ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<St
 
 				while (*names_ptr) {
 					const String name = String::utf8(*names_ptr++);
-					const String identifier = name.get_slice("<", 0);
-					const String website = name.get_slice_count("<") == 1 ? "" : name.get_slice("<", 1).trim_suffix(">");
+					const String identifier = name.get_slicec('<', 0);
+					const String website = name.get_slice_count("<") == 1 ? "" : name.get_slicec('<', 1).trim_suffix(">");
 
 					const int name_item_id = il->add_item(identifier, nullptr, false);
 					il->set_item_tooltip_enabled(name_item_id, false);

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -187,7 +187,7 @@ void EditorAutoloadSettings::_autoload_edited() {
 
 	if (column == 0) {
 		String name = ti->get_text(0);
-		String old_name = selected_autoload.get_slice("/", 1);
+		String old_name = selected_autoload.get_slicec('/', 1);
 
 		if (name == old_name) {
 			return;
@@ -483,7 +483,7 @@ void EditorAutoloadSettings::update_autoload() {
 			continue;
 		}
 
-		String name = pi.name.get_slice("/", 1);
+		String name = pi.name.get_slicec('/', 1);
 		String scr_path = GLOBAL_GET(pi.name);
 
 		if (name.is_empty()) {
@@ -862,7 +862,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 			continue;
 		}
 
-		String name = pi.name.get_slice("/", 1);
+		String name = pi.name.get_slicec('/', 1);
 		String scr_path = GLOBAL_GET(pi.name);
 
 		if (name.is_empty()) {

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -112,7 +112,7 @@ void EditorCommandPalette::_update_command_search(const String &search_text) {
 
 	const int entry_limit = MIN(entries.size(), 300);
 	for (int i = 0; i < entry_limit; i++) {
-		String section_name = entries[i].key_name.get_slice("/", 0);
+		String section_name = entries[i].key_name.get_slicec('/', 0);
 		TreeItem *section;
 
 		if (sections.has(section_name)) {

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -261,7 +261,7 @@ Error EditorFeatureProfile::load_from_file(const String &p_path) {
 		Array disabled_properties_arr = data["disabled_properties"];
 		for (int i = 0; i < disabled_properties_arr.size(); i++) {
 			String s = disabled_properties_arr[i];
-			set_disable_class_property(s.get_slice(":", 0), s.get_slice(":", 1), true);
+			set_disable_class_property(s.get_slicec(':', 0), s.get_slicec(':', 1), true);
 		}
 	}
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -447,8 +447,8 @@ void EditorFileSystem::_scan_filesystem() {
 					name = cpath.path_join(name);
 
 					FileCache fc;
-					fc.type = split[1].get_slice("/", 0);
-					fc.resource_script_class = split[1].get_slice("/", 1);
+					fc.type = split[1].get_slicec('/', 0);
+					fc.resource_script_class = split[1].get_slicec('/', 1);
 					fc.uid = split[2].to_int();
 					fc.modification_time = split[3].to_int();
 					fc.import_modification_time = split[4].to_int();

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1704,8 +1704,8 @@ void EditorHelp::_update_doc() {
 
 			for (KeyValue<String, Vector<DocData::ConstantDoc>> &E : enums) {
 				String key = E.key;
-				if ((key.get_slice_count(".") > 1) && (key.get_slice(".", 0) == edited_class)) {
-					key = key.get_slice(".", 1);
+				if ((key.get_slice_count(".") > 1) && (key.get_slicec('.', 0) == edited_class)) {
+					key = key.get_slicec('.', 1);
 				}
 				if (cd.enums.has(key)) {
 					const bool is_documented = cd.enums[key].is_deprecated || cd.enums[key].is_experimental || !cd.enums[key].description.strip_edges().is_empty();
@@ -2334,11 +2334,11 @@ void EditorHelp::_request_help(const String &p_string) {
 }
 
 void EditorHelp::_help_callback(const String &p_topic) {
-	String what = p_topic.get_slice(":", 0);
-	String clss = p_topic.get_slice(":", 1);
+	String what = p_topic.get_slicec(':', 0);
+	String clss = p_topic.get_slicec(':', 1);
 	String name;
 	if (p_topic.get_slice_count(":") == 3) {
-		name = p_topic.get_slice(":", 2);
+		name = p_topic.get_slicec(':', 2);
 	}
 
 	_request_help(clss); // First go to class.

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3546,9 +3546,9 @@ void EditorInspector::update_tree() {
 			String swap_method;
 			for (int i = (p.type == Variant::NIL ? 1 : 2); i < class_name_components.size(); i++) {
 				if (class_name_components[i].begins_with("page_size") && class_name_components[i].get_slice_count("=") == 2) {
-					page_size = class_name_components[i].get_slice("=", 1).to_int();
+					page_size = class_name_components[i].get_slicec('=', 1).to_int();
 				} else if (class_name_components[i].begins_with("add_button_text") && class_name_components[i].get_slice_count("=") == 2) {
-					add_button_text = class_name_components[i].get_slice("=", 1).strip_edges();
+					add_button_text = class_name_components[i].get_slicec('=', 1).strip_edges();
 				} else if (class_name_components[i] == "static") {
 					movable = false;
 				} else if (class_name_components[i] == "const") {
@@ -3558,7 +3558,7 @@ void EditorInspector::update_tree() {
 				} else if (class_name_components[i] == "unfoldable") {
 					foldable = false;
 				} else if (class_name_components[i].begins_with("swap_method") && class_name_components[i].get_slice_count("=") == 2) {
-					swap_method = class_name_components[i].get_slice("=", 1).strip_edges();
+					swap_method = class_name_components[i].get_slicec('=', 1).strip_edges();
 				}
 			}
 
@@ -4611,7 +4611,7 @@ void EditorInspector::_set_property_favorited(const String &p_path, bool p_favor
 
 	String theme_property;
 	if (p_path.begins_with("theme_override_")) {
-		theme_property = p_path.get_slice("/", 1);
+		theme_property = p_path.get_slicec('/', 1);
 	}
 
 	while (!validate_name.is_empty()) {

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -52,9 +52,9 @@ bool EditorPropertyArrayObject::_set(const StringName &p_name, const Variant &p_
 
 	int index;
 	if (name.begins_with("metadata/")) {
-		index = name.get_slice("/", 2).to_int();
+		index = name.get_slicec('/', 2).to_int();
 	} else {
-		index = name.get_slice("/", 1).to_int();
+		index = name.get_slicec('/', 1).to_int();
 	}
 
 	array.set(index, p_value);
@@ -70,9 +70,9 @@ bool EditorPropertyArrayObject::_get(const StringName &p_name, Variant &r_ret) c
 
 	int index;
 	if (name.begins_with("metadata/")) {
-		index = name.get_slice("/", 2).to_int();
+		index = name.get_slicec('/', 2).to_int();
 	} else {
-		index = name.get_slice("/", 1).to_int();
+		index = name.get_slicec('/', 1).to_int();
 	}
 
 	bool valid;
@@ -263,7 +263,7 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 		p_value = Variant(); // `EditorResourcePicker` resets to `Ref<Resource>()`. See GH-82716.
 	}
 
-	int index = p_property.get_slice("/", 1).to_int();
+	int index = p_property.get_slicec('/', 1).to_int();
 
 	Variant array = object->get_array().duplicate();
 	array.set(index, p_value);
@@ -1456,7 +1456,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 
 void EditorPropertyLocalizableString::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("indices")) {
-		int index = p_property.get_slice("/", 1).to_int();
+		int index = p_property.get_slicec('/', 1).to_int();
 
 		Dictionary dict = object->get_dict().duplicate();
 		Variant key = dict.get_key_at_index(index);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -156,7 +156,7 @@ void EditorResourcePicker::_file_selected(const String &p_path) {
 		}
 
 		for (int i = 0; i < base_type.get_slice_count(","); i++) {
-			String base = base_type.get_slice(",", i);
+			String base = base_type.get_slicec(',', i);
 
 			any_type_matches = is_global_class ? EditorNode::get_editor_data().script_class_is_parent(res_type, base) : loaded_resource->is_class(base);
 
@@ -263,7 +263,7 @@ void EditorResourcePicker::_update_menu_items() {
 			String res_type = _get_resource_type(cb);
 
 			for (int i = 0; i < base_type.get_slice_count(","); i++) {
-				String base = base_type.get_slice(",", i);
+				String base = base_type.get_slicec(',', i);
 
 				paste_valid = ClassDB::is_parent_class(res_type, base) || EditorNode::get_editor_data().script_class_is_parent(res_type, base);
 
@@ -313,7 +313,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 		case OBJ_MENU_LOAD: {
 			List<String> extensions;
 			for (int i = 0; i < base_type.get_slice_count(","); i++) {
-				String base = base_type.get_slice(",", i);
+				String base = base_type.get_slicec(',', i);
 				ResourceLoader::get_recognized_extensions_for_type(base, &extensions);
 				if (ScriptServer::is_global_class(base)) {
 					ResourceLoader::get_recognized_extensions_for_type(ScriptServer::get_global_class_native_base(base), &extensions);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -389,7 +389,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 		for (const String &locale : get_editor_locales()) {
 			// Skip locales which we can't render properly (see above comment).
 			// Test against language code without regional variants (e.g. ur_PK).
-			String lang_code = locale.get_slice("_", 0);
+			String lang_code = locale.get_slicec('_', 0);
 			if (locales_to_skip.has(lang_code)) {
 				continue;
 			}

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -572,7 +572,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 	// Create all sections first.
 	for (const String &E : slist) {
 		Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(E);
-		String section_name = E.get_slice("/", 0);
+		String section_name = E.get_slicec('/', 0);
 
 		if (sections.has(section_name)) {
 			continue;
@@ -605,7 +605,7 @@ void EditorSettingsDialog::_update_shortcuts() {
 			continue;
 		}
 
-		String section_name = E.get_slice("/", 0);
+		String section_name = E.get_slicec('/', 0);
 		TreeItem *section = sections[section_name];
 
 		if (!_should_display_shortcut(sc->get_name(), sc->get_events(), true)) {

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1404,7 +1404,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 
 				for (const String &F : remaps) {
 					String remap = F;
-					String feature = remap.get_slice(".", 1);
+					String feature = remap.get_slicec('.', 1);
 					if (features.has(feature)) {
 						remap_features.insert(feature);
 					}
@@ -1423,7 +1423,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 						Vector<uint8_t> array = FileAccess::get_file_as_bytes(remapped_path);
 						err = save_proxy.save_file(p_udata, remapped_path, array, idx, total, enc_in_filters, enc_ex_filters, key, seed);
 					} else if (remap.begins_with("path.")) {
-						String feature = remap.get_slice(".", 1);
+						String feature = remap.get_slicec('.', 1);
 
 						if (remap_features.has(feature)) {
 							String remapped_path = config->get_value("remap", remap);
@@ -2344,7 +2344,7 @@ Error EditorExportPlatform::ssh_run_on_remote(const String &p_host, const String
 		print_verbose(vformat("Exit code: %d, Output: %s", exit_code, out.replace("\r\n", "\n")));
 	}
 	if (r_out) {
-		*r_out = out.replace("\r\n", "\n").get_slice("\n", 0);
+		*r_out = out.replace("\r\n", "\n").get_slicec('\n', 0);
 	}
 	if (err != OK) {
 		return err;

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -142,9 +142,9 @@ void EditorFileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_file
 			} else if (filters.size() > 1 && p_filter == 0) {
 				// Match all filters.
 				for (int i = 0; i < filters.size(); i++) {
-					String flt = filters[i].get_slice(";", 0);
+					String flt = filters[i].get_slicec(';', 0);
 					for (int j = 0; j < flt.get_slice_count(","); j++) {
-						String str = flt.get_slice(",", j).strip_edges();
+						String str = flt.get_slicec(',', j).strip_edges();
 						if (f.matchn(str)) {
 							valid = true;
 							break;
@@ -160,10 +160,10 @@ void EditorFileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_file
 					idx--;
 				}
 				if (idx >= 0 && idx < filters.size()) {
-					String flt = filters[idx].get_slice(";", 0);
+					String flt = filters[idx].get_slicec(';', 0);
 					int filter_slice_count = flt.get_slice_count(",");
 					for (int j = 0; j < filter_slice_count; j++) {
-						String str = (flt.get_slice(",", j).strip_edges());
+						String str = flt.get_slicec(',', j).strip_edges();
 						if (f.matchn(str)) {
 							valid = true;
 							break;
@@ -171,7 +171,7 @@ void EditorFileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_file
 					}
 
 					if (!valid && filter_slice_count > 0) {
-						String str = (flt.get_slice(",", 0).strip_edges());
+						String str = flt.get_slicec(',', 0).strip_edges();
 						f += str.substr(1);
 						file->set_text(f.get_file());
 						valid = true;
@@ -184,8 +184,8 @@ void EditorFileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_file
 			// Add first extension of filter if no valid extension is found.
 			if (!valid) {
 				int idx = p_filter;
-				String flt = filters[idx].get_slice(";", 0);
-				String ext = flt.get_slice(",", 0).strip_edges().get_extension();
+				String flt = filters[idx].get_slicec(';', 0);
+				String ext = flt.get_slicec(',', 0).strip_edges().get_extension();
 				f += "." + ext;
 			}
 			emit_signal(SNAME("file_selected"), f);
@@ -620,9 +620,9 @@ void EditorFileDialog::_action_pressed() {
 		} else if (filters.size() > 1 && filter->get_selected() == 0) {
 			// Match all filters.
 			for (int i = 0; i < filters.size(); i++) {
-				String flt = filters[i].get_slice(";", 0);
+				String flt = filters[i].get_slicec(';', 0);
 				for (int j = 0; j < flt.get_slice_count(","); j++) {
-					String str = flt.get_slice(",", j).strip_edges();
+					String str = flt.get_slicec(',', j).strip_edges();
 					if (f.matchn(str)) {
 						valid = true;
 						break;
@@ -638,10 +638,10 @@ void EditorFileDialog::_action_pressed() {
 				idx--;
 			}
 			if (idx >= 0 && idx < filters.size()) {
-				String flt = filters[idx].get_slice(";", 0);
+				String flt = filters[idx].get_slicec(';', 0);
 				int filter_slice_count = flt.get_slice_count(",");
 				for (int j = 0; j < filter_slice_count; j++) {
-					String str = (flt.get_slice(",", j).strip_edges());
+					String str = (flt.get_slicec(',', j).strip_edges());
 					if (f.matchn(str)) {
 						valid = true;
 						break;
@@ -649,7 +649,7 @@ void EditorFileDialog::_action_pressed() {
 				}
 
 				if (!valid && filter_slice_count > 0) {
-					String str = (flt.get_slice(",", 0).strip_edges());
+					String str = flt.get_slicec(',', 0).strip_edges();
 					f += str.substr(1);
 					_request_single_thumbnail(get_current_dir().path_join(f.get_file()));
 					file->set_text(f.get_file());
@@ -671,8 +671,8 @@ void EditorFileDialog::_action_pressed() {
 		// Add first extension of filter if no valid extension is found.
 		if (!valid) {
 			int idx = filter->get_selected();
-			String flt = filters[idx].get_slice(";", 0);
-			String ext = flt.get_slice(",", 0).strip_edges().get_extension();
+			String flt = filters[idx].get_slicec(';', 0);
+			String ext = flt.get_slicec(',', 0).strip_edges().get_extension();
 			f += "." + ext;
 		}
 
@@ -1105,9 +1105,9 @@ void EditorFileDialog::update_file_list() {
 	} else if (filters.size() > 1 && filter->get_selected() == 0) {
 		// match all filters
 		for (int i = 0; i < filters.size(); i++) {
-			String f = filters[i].get_slice(";", 0);
+			String f = filters[i].get_slicec(';', 0);
 			for (int j = 0; j < f.get_slice_count(","); j++) {
-				patterns.push_back(f.get_slice(",", j).strip_edges());
+				patterns.push_back(f.get_slicec(',', j).strip_edges());
 			}
 		}
 	} else {
@@ -1117,9 +1117,9 @@ void EditorFileDialog::update_file_list() {
 		}
 
 		if (idx >= 0 && idx < filters.size()) {
-			String f = filters[idx].get_slice(";", 0);
+			String f = filters[idx].get_slicec(';', 0);
 			for (int j = 0; j < f.get_slice_count(","); j++) {
-				patterns.push_back(f.get_slice(",", j).strip_edges());
+				patterns.push_back(f.get_slicec(',', j).strip_edges());
 			}
 		}
 	}

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -1812,9 +1812,9 @@ void Collada::_parse_animation(XMLParser &p_parser) {
 				track.target = target.get_slicec('/', 0);
 				track.param = target.get_slicec('/', 1);
 				if (track.param.contains_char('.')) {
-					track.component = track.param.get_slice(".", 1).to_upper();
+					track.component = track.param.get_slicec('.', 1).to_upper();
 				}
-				track.param = track.param.get_slice(".", 0);
+				track.param = track.param.get_slicec('.', 0);
 				if (names.size() > 1 && track.component.is_empty()) {
 					//this is a guess because the collada spec is ambiguous here...
 					//i suppose if you have many names (outputs) you can't use a component and i should abide to that.
@@ -2347,9 +2347,9 @@ Error Collada::load(const String &p_path, int p_flags) {
 	{
 		//version
 		String version = parser.get_named_attribute_value("version");
-		state.version.major = version.get_slice(".", 0).to_int();
-		state.version.minor = version.get_slice(".", 1).to_int();
-		state.version.rev = version.get_slice(".", 2).to_int();
+		state.version.major = version.get_slicec('.', 0).to_int();
+		state.version.minor = version.get_slicec('.', 1).to_int();
+		state.version.rev = version.get_slicec('.', 2).to_int();
 		COLLADA_PRINT("Collada VERSION: " + version);
 	}
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2211,7 +2211,7 @@ bool ResourceImporterScene::get_internal_option_visibility(InternalImportCategor
 			}
 			if (p_option.begins_with("slice_")) {
 				int max_slice = p_options["slices/amount"];
-				int slice = p_option.get_slice("_", 1).to_int() - 1;
+				int slice = p_option.get_slicec('_', 1).to_int() - 1;
 				if (slice >= max_slice) {
 					return false;
 				}

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -503,7 +503,7 @@ void AnimationPlayerEditor::_animation_rename() {
 
 	// Remove library prefix if present.
 	if (selected_name.contains_char('/')) {
-		selected_name = selected_name.get_slice("/", 1);
+		selected_name = selected_name.get_slicec('/', 1);
 	}
 
 	name_dialog->set_title(TTR("Rename Animation"));
@@ -536,7 +536,7 @@ void AnimationPlayerEditor::_animation_remove_confirmed() {
 
 	// For names of form lib_name/anim_name, remove library name prefix.
 	if (current.contains_char('/')) {
-		current = current.get_slice("/", 1);
+		current = current.get_slicec('/', 1);
 	}
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Remove Animation"));
@@ -625,8 +625,8 @@ void AnimationPlayerEditor::_animation_name_edited() {
 			// Extract library prefix if present.
 			String new_library_prefix = "";
 			if (current.contains_char('/')) {
-				new_library_prefix = current.get_slice("/", 0) + "/";
-				current = current.get_slice("/", 1);
+				new_library_prefix = current.get_slicec('/', 0) + "/";
+				current = current.get_slicec('/', 1);
 			}
 
 			undo_redo->create_action(TTR("Rename Animation"));
@@ -1340,7 +1340,7 @@ void AnimationPlayerEditor::_animation_duplicate() {
 
 	if (new_name.contains_char('/')) {
 		// Discard library prefix.
-		new_name = new_name.get_slice("/", 1);
+		new_name = new_name.get_slicec('/', 1);
 	}
 
 	_update_name_dialog_library_dropdown();

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -158,7 +158,7 @@ void EditorPropertyFontMetaOverride::_notification(int p_what) {
 void EditorPropertyFontMetaOverride::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("keys")) {
 		Dictionary dict = object->get_dict();
-		String key = p_property.get_slice("/", 1);
+		String key = p_property.get_slicec('/', 1);
 		dict[key] = (bool)p_value;
 
 		emit_changed(get_edited_property(), dict, "", true);
@@ -378,7 +378,7 @@ EditorPropertyFontMetaOverride::EditorPropertyFontMetaOverride(bool p_script) {
 void EditorPropertyOTVariation::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("keys")) {
 		Dictionary dict = object->get_dict();
-		int key = p_property.get_slice("/", 1).to_int();
+		int key = p_property.get_slicec('/', 1).to_int();
 		dict[key] = (int)p_value;
 
 		emit_changed(get_edited_property(), dict, "", true);
@@ -561,7 +561,7 @@ void EditorPropertyOTFeatures::_notification(int p_what) {
 void EditorPropertyOTFeatures::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("keys")) {
 		Dictionary dict = object->get_dict();
-		int key = p_property.get_slice("/", 1).to_int();
+		int key = p_property.get_slicec('/', 1).to_int();
 		dict[key] = (int)p_value;
 
 		emit_changed(get_edited_property(), dict, "", true);

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -239,7 +239,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 		case MENU_OPTION_REMOVE_ITEM: {
 			String p = InspectorDock::get_inspector_singleton()->get_selected_path();
 			if (p.begins_with("item") && p.get_slice_count("/") >= 2) {
-				to_erase = p.get_slice("/", 1).to_int();
+				to_erase = p.get_slicec('/', 1).to_int();
 				cd_remove->set_text(vformat(TTR("Remove item %d?"), to_erase));
 				cd_remove->popup_centered(Size2(300, 60));
 			}

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -156,7 +156,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 				// Extract FileDialog's filters property with values in format "*.png ; PNG Images","*.gd ; GDScript Files".
 				Vector<String> str_values = property_value;
 				for (int k = 0; k < str_values.size(); k++) {
-					String desc = str_values[k].get_slice(";", 1).strip_edges();
+					String desc = str_values[k].get_slicec(';', 1).strip_edges();
 					if (!desc.is_empty()) {
 						r_translations->push_back({ desc });
 					}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -202,8 +202,8 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		List<String> comments;
 		scr_lang->get_comment_delimiters(&comments);
 		for (const String &comment : comments) {
-			String beg = comment.get_slice(" ", 0);
-			String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
+			String beg = comment.get_slicec(' ', 0);
+			String end = comment.get_slice_count(" ") > 1 ? comment.get_slicec(' ', 1) : String();
 			highlighter->add_color_region(beg, end, comment_color, end.is_empty());
 		}
 
@@ -212,8 +212,8 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		List<String> doc_comments;
 		scr_lang->get_doc_comment_delimiters(&doc_comments);
 		for (const String &doc_comment : doc_comments) {
-			String beg = doc_comment.get_slice(" ", 0);
-			String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slice(" ", 1) : String();
+			String beg = doc_comment.get_slicec(' ', 0);
+			String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slicec(' ', 1) : String();
 			highlighter->add_color_region(beg, end, doc_comment_color, end.is_empty());
 		}
 
@@ -222,8 +222,8 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		List<String> strings;
 		scr_lang->get_string_delimiters(&strings);
 		for (const String &string : strings) {
-			String beg = string.get_slice(" ", 0);
-			String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
+			String beg = string.get_slicec(' ', 0);
+			String end = string.get_slice_count(" ") > 1 ? string.get_slicec(' ', 1) : String();
 			highlighter->add_color_region(beg, end, string_color, end.is_empty());
 		}
 	}
@@ -443,7 +443,7 @@ void ScriptEditorQuickOpen::_confirmed() {
 	if (!ti) {
 		return;
 	}
-	int line = ti->get_text(0).get_slice(":", 1).to_int();
+	int line = ti->get_text(0).get_slicec(':', 1).to_int();
 
 	emit_signal(SNAME("goto_line"), line - 1);
 	hide();
@@ -2111,10 +2111,10 @@ void ScriptEditor::_update_members_overview() {
 
 	for (int i = 0; i < functions.size(); i++) {
 		String filter = filter_methods->get_text();
-		String name = functions[i].get_slice(":", 0);
+		String name = functions[i].get_slicec(':', 0);
 		if (filter.is_empty() || filter.is_subsequence_ofn(name)) {
 			members_overview->add_item(name);
-			members_overview->set_item_metadata(-1, functions[i].get_slice(":", 1).to_int() - 1);
+			members_overview->set_item_metadata(-1, functions[i].get_slicec(':', 1).to_int() - 1);
 		}
 	}
 
@@ -3681,7 +3681,7 @@ void ScriptEditor::_help_class_open(const String &p_class) {
 }
 
 void ScriptEditor::_help_class_goto(const String &p_desc) {
-	String cname = p_desc.get_slice(":", 1);
+	String cname = p_desc.get_slicec(':', 1);
 
 	if (_help_tab_goto(cname, p_desc)) {
 		return;
@@ -3988,7 +3988,7 @@ void ScriptEditor::_on_find_in_files_result_selected(const String &fpath, int li
 
 				// Found the end of the script.
 				scr_id = line.get_slice(scr_header, 1);
-				scr_id = scr_id.get_slice("\"", 0);
+				scr_id = scr_id.get_slicec('"', 0);
 
 				scr_start_line = l + 1;
 				int scr_line_count = 0;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -228,8 +228,8 @@ void ScriptTextEditor::_set_theme_for_script() {
 	script->get_language()->get_string_delimiters(&strings);
 	text_edit->clear_string_delimiters();
 	for (const String &string : strings) {
-		String beg = string.get_slice(" ", 0);
-		String end = string.get_slice_count(" ") > 1 ? string.get_slice(" ", 1) : String();
+		String beg = string.get_slicec(' ', 0);
+		String end = string.get_slice_count(" ") > 1 ? string.get_slicec(' ', 1) : String();
 		if (!text_edit->has_string_delimiter(beg)) {
 			text_edit->add_string_delimiter(beg, end, end.is_empty());
 		}
@@ -244,8 +244,8 @@ void ScriptTextEditor::_set_theme_for_script() {
 	List<String> comments;
 	script->get_language()->get_comment_delimiters(&comments);
 	for (const String &comment : comments) {
-		String beg = comment.get_slice(" ", 0);
-		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
+		String beg = comment.get_slicec(' ', 0);
+		String end = comment.get_slice_count(" ") > 1 ? comment.get_slicec(' ', 1) : String();
 		text_edit->add_comment_delimiter(beg, end, end.is_empty());
 
 		if (!end.is_empty() && !text_edit->has_auto_brace_completion_open_key(beg)) {
@@ -256,8 +256,8 @@ void ScriptTextEditor::_set_theme_for_script() {
 	List<String> doc_comments;
 	script->get_language()->get_doc_comment_delimiters(&doc_comments);
 	for (const String &doc_comment : doc_comments) {
-		String beg = doc_comment.get_slice(" ", 0);
-		String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slice(" ", 1) : String();
+		String beg = doc_comment.get_slicec(' ', 0);
+		String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slicec(' ', 1) : String();
 		text_edit->add_comment_delimiter(beg, end, end.is_empty());
 
 		if (!end.is_empty() && !text_edit->has_auto_brace_completion_open_key(beg)) {
@@ -1278,12 +1278,12 @@ void ScriptTextEditor::_update_connected_methods() {
 				int line = -1;
 
 				for (int j = 0; j < functions.size(); j++) {
-					String name = functions[j].get_slice(":", 0);
+					String name = functions[j].get_slicec(':', 0);
 					if (name == method) {
 						Dictionary line_meta;
 						line_meta["type"] = "connection";
 						line_meta["method"] = method;
-						line = functions[j].get_slice(":", 1).to_int() - 1;
+						line = functions[j].get_slicec(':', 1).to_int() - 1;
 						text_edit->set_line_gutter_metadata(line, connection_gutter, line_meta);
 						text_edit->set_line_gutter_icon(line, connection_gutter, get_parent_control()->get_editor_theme_icon(SNAME("Slot")));
 						text_edit->set_line_gutter_clickable(line, connection_gutter, true);
@@ -1318,7 +1318,7 @@ void ScriptTextEditor::_update_connected_methods() {
 	// Add override icons to methods.
 	methods_found.clear();
 	for (int i = 0; i < functions.size(); i++) {
-		String raw_name = functions[i].get_slice(":", 0);
+		String raw_name = functions[i].get_slicec(':', 0);
 		StringName name = StringName(raw_name);
 		if (methods_found.has(name)) {
 			continue;
@@ -1364,7 +1364,7 @@ void ScriptTextEditor::_update_connected_methods() {
 		}
 
 		if (!found_base_class.is_empty()) {
-			int line = functions[i].get_slice(":", 1).to_int() - 1;
+			int line = functions[i].get_slicec(':', 1).to_int() - 1;
 
 			Dictionary line_meta = text_edit->get_line_gutter_metadata(line, connection_gutter);
 			if (line_meta.is_empty()) {

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -444,7 +444,7 @@ void ProjectList::_migrate_config() {
 		String path = EDITOR_GET(property_key);
 		print_line("Migrating legacy project '" + path + "'.");
 
-		String favoriteKey = "favorite_projects/" + property_key.get_slice("/", 1);
+		String favoriteKey = "favorite_projects/" + property_key.get_slicec('/', 1);
 		bool favorite = EditorSettings::get_singleton()->has_setting(favoriteKey);
 		add_project(path, favorite);
 		if (favorite) {
@@ -651,7 +651,7 @@ void ProjectList::sort_projects() {
 			PackedStringArray remaining;
 			for (const String &part : search_parts) {
 				if (part.begins_with("tag:")) {
-					tags.push_back(part.get_slice(":", 1));
+					tags.push_back(part.get_slicec(':', 1));
 				} else {
 					remaining.append(part);
 				}

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -139,7 +139,7 @@ void ProjectSettingsEditor::_add_setting() {
 	undo_redo->add_undo_method(this, "queue_save");
 	undo_redo->commit_action();
 
-	general_settings_inspector->set_current_section(setting.get_slice("/", 1));
+	general_settings_inspector->set_current_section(setting.get_slicec('/', 1));
 	add_button->release_focus();
 }
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -238,7 +238,7 @@ void PropertySelector::_update_search() {
 				continue;
 			}
 
-			String name = mi.name.get_slice(":", 0);
+			String name = mi.name.get_slicec(':', 0);
 			if (!script_methods && name.begins_with("_") && !(mi.flags & METHOD_FLAG_VIRTUAL)) {
 				continue;
 			}
@@ -259,8 +259,8 @@ void PropertySelector::_update_search() {
 
 			String desc;
 			if (mi.name.contains_char(':')) {
-				desc = mi.name.get_slice(":", 1) + " ";
-				mi.name = mi.name.get_slice(":", 0);
+				desc = mi.name.get_slicec(':', 1) + " ";
+				mi.name = mi.name.get_slicec(':', 0);
 			} else if (mi.return_val.type != Variant::NIL) {
 				desc = Variant::get_type_name(mi.return_val.type);
 			} else {
@@ -279,8 +279,8 @@ void PropertySelector::_update_search() {
 				if (arg_itr->type == Variant::NIL) {
 					desc += ": Variant";
 				} else if (arg_itr->name.contains_char(':')) {
-					desc += vformat(": %s", arg_itr->name.get_slice(":", 1));
-					arg_itr->name = arg_itr->name.get_slice(":", 0);
+					desc += vformat(": %s", arg_itr->name.get_slicec(':', 1));
+					arg_itr->name = arg_itr->name.get_slicec(':', 0);
 				} else {
 					desc += vformat(": %s", Variant::get_type_name(arg_itr->type));
 				}

--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -83,7 +83,7 @@ void SceneCreateDialog::browse_types() {
 }
 
 void SceneCreateDialog::on_type_picked() {
-	other_type_display->set_text(select_node_dialog->get_selected_type().get_slice(" ", 0));
+	other_type_display->set_text(select_node_dialog->get_selected_type().get_slicec(' ', 0));
 	if (node_type_other->is_pressed()) {
 		validation_panel->update();
 	} else {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3277,7 +3277,7 @@ bool SceneTreeDock::_check_node_recursive(Variant &r_variant, Node *p_node, Node
 			bool updated = false;
 			for (int i = 0; i < a.size(); i++) {
 				Variant value = a[i];
-				if (_check_node_recursive(value, p_node, p_by_node, type_hint.get_slice(":", 1), r_warn_message)) {
+				if (_check_node_recursive(value, p_node, p_by_node, type_hint.get_slicec(':', 1), r_warn_message)) {
 					if (!updated) {
 						a = a.duplicate(); // Need to duplicate for undo-redo to work.
 						updated = true;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1274,8 +1274,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					goto error;
 				}
 
-				int w = vm.get_slice("x", 0).to_int();
-				int h = vm.get_slice("x", 1).to_int();
+				int w = vm.get_slicec('x', 0).to_int();
+				int h = vm.get_slicec('x', 1).to_int();
 
 				if (w <= 0 || h <= 0) {
 					OS::get_singleton()->print("Invalid resolution '%s', width and height must be above 0.\n",
@@ -1317,8 +1317,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					goto error;
 				}
 
-				int x = vm.get_slice(",", 0).to_int();
-				int y = vm.get_slice(",", 1).to_int();
+				int x = vm.get_slicec(',', 0).to_int();
+				int y = vm.get_slicec(',', 1).to_int();
 
 				init_custom_pos = Point2(x, y);
 				init_use_custom_pos = true;
@@ -2405,7 +2405,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 	}
 
-	default_renderer = renderer_hints.get_slice(",", 0);
+	default_renderer = renderer_hints.get_slicec(',', 0);
 	GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::STRING, "rendering/renderer/rendering_method", PROPERTY_HINT_ENUM, renderer_hints), default_renderer);
 	GLOBAL_DEF_RST_BASIC("rendering/renderer/rendering_method.mobile", default_renderer_mobile);
 	GLOBAL_DEF_RST_BASIC("rendering/renderer/rendering_method.web", "gl_compatibility"); // This is a bit of a hack until we have WebGPU support.

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -783,8 +783,8 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	List<String> comments;
 	gdscript->get_comment_delimiters(&comments);
 	for (const String &comment : comments) {
-		String beg = comment.get_slice(" ", 0);
-		String end = comment.get_slice_count(" ") > 1 ? comment.get_slice(" ", 1) : String();
+		String beg = comment.get_slicec(' ', 0);
+		String end = comment.get_slice_count(" ") > 1 ? comment.get_slicec(' ', 1) : String();
 		add_color_region(ColorRegion::TYPE_COMMENT, beg, end, comment_color, end.is_empty());
 	}
 
@@ -793,8 +793,8 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	List<String> doc_comments;
 	gdscript->get_doc_comment_delimiters(&doc_comments);
 	for (const String &doc_comment : doc_comments) {
-		String beg = doc_comment.get_slice(" ", 0);
-		String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slice(" ", 1) : String();
+		String beg = doc_comment.get_slicec(' ', 0);
+		String end = doc_comment.get_slice_count(" ") > 1 ? doc_comment.get_slicec(' ', 1) : String();
 		add_color_region(ColorRegion::TYPE_COMMENT, beg, end, doc_comment_color, end.is_empty());
 	}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5574,7 +5574,7 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_property(const PropertyInfo
 			result.set_container_element_type(0, elem_type);
 		} else if (p_property.type == Variant::DICTIONARY && p_property.hint == PROPERTY_HINT_DICTIONARY_TYPE) {
 			// Check element type.
-			StringName key_elem_type_name = p_property.hint_string.get_slice(";", 0);
+			StringName key_elem_type_name = p_property.hint_string.get_slicec(';', 0);
 			GDScriptParser::DataType key_elem_type;
 			key_elem_type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
 
@@ -5599,7 +5599,7 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_property(const PropertyInfo
 			}
 			key_elem_type.is_constant = false;
 
-			StringName value_elem_type_name = p_property.hint_string.get_slice(";", 1);
+			StringName value_elem_type_name = p_property.hint_string.get_slicec(';', 1);
 			GDScriptParser::DataType value_elem_type;
 			value_elem_type.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -530,9 +530,9 @@ String GDScriptLanguage::make_function(const String &p_class, const String &p_na
 			if (i > 0) {
 				s += ", ";
 			}
-			s += p_args[i].get_slice(":", 0);
+			s += p_args[i].get_slicec(':', 0);
 			if (th) {
-				String type = p_args[i].get_slice(":", 1);
+				String type = p_args[i].get_slicec(':', 1);
 				if (!type.is_empty()) {
 					s += ": " + type;
 				}
@@ -722,8 +722,8 @@ static String _get_visual_datatype(const PropertyInfo &p_info, bool p_is_arg, co
 	} else if (p_info.type == Variant::ARRAY && p_info.hint == PROPERTY_HINT_ARRAY_TYPE && !p_info.hint_string.is_empty()) {
 		return "Array[" + _trim_parent_class(p_info.hint_string, p_base_class) + "]";
 	} else if (p_info.type == Variant::DICTIONARY && p_info.hint == PROPERTY_HINT_DICTIONARY_TYPE && !p_info.hint_string.is_empty()) {
-		const String key = p_info.hint_string.get_slice(";", 0);
-		const String value = p_info.hint_string.get_slice(";", 1);
+		const String key = p_info.hint_string.get_slicec(';', 0);
+		const String value = p_info.hint_string.get_slicec(';', 1);
 		return "Dictionary[" + _trim_parent_class(key, p_base_class) + ", " + _trim_parent_class(value, p_base_class) + "]";
 	} else if (p_info.type == Variant::NIL) {
 		if (p_is_arg || (p_info.usage & PROPERTY_USAGE_NIL_IS_VARIANT)) {
@@ -1866,7 +1866,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 								if (all_is_const && call->function_name == SNAME("get_node") && ClassDB::is_parent_class(native_type.native_type, SNAME("Node")) && args.size()) {
 									String arg1 = args[0];
 									if (arg1.begins_with("/root/")) {
-										String which = arg1.get_slice("/", 2);
+										String which = arg1.get_slicec('/', 2);
 										if (!which.is_empty()) {
 											// Try singletons first
 											if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(which)) {
@@ -2745,8 +2745,8 @@ static void _find_enumeration_candidates(GDScriptParser::CompletionContext &p_co
 			}
 		}
 	} else {
-		String class_name = p_enum_hint.get_slice(".", 0);
-		String enum_name = p_enum_hint.get_slice(".", 1);
+		String class_name = p_enum_hint.get_slicec('.', 0);
+		String enum_name = p_enum_hint.get_slicec('.', 1);
 
 		if (!ClassDB::class_exists(class_name)) {
 			return;
@@ -2949,7 +2949,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						if (!s.begins_with("autoload/")) {
 							continue;
 						}
-						String name = s.get_slice("/", 1);
+						String name = s.get_slicec('/', 1);
 						String path = ("/root/" + name).quote(quote_style);
 						if (use_node_paths) {
 							path = "^" + path;
@@ -2968,7 +2968,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						if (!s.begins_with("input/")) {
 							continue;
 						}
-						String name = s.get_slice("/", 1).quote(quote_style);
+						String name = s.get_slicec('/', 1).quote(quote_style);
 						if (use_string_names) {
 							name = "&" + name;
 						}
@@ -3491,7 +3491,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			for (const MethodInfo &mi : virtual_methods) {
 				String method_hint = mi.name;
 				if (method_hint.contains_char(':')) {
-					method_hint = method_hint.get_slice(":", 0);
+					method_hint = method_hint.get_slicec(':', 0);
 				}
 				method_hint += "(";
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -8067,8 +8067,8 @@ Dictionary GLTFDocument::_serialize_texture_transform_uv2(Ref<BaseMaterial3D> p_
 
 Error GLTFDocument::_serialize_asset_header(Ref<GLTFState> p_state) {
 	const String version = "2.0";
-	p_state->major_version = version.get_slice(".", 0).to_int();
-	p_state->minor_version = version.get_slice(".", 1).to_int();
+	p_state->major_version = version.get_slicec('.', 0).to_int();
+	p_state->minor_version = version.get_slicec('.', 1).to_int();
 	Dictionary asset;
 	asset["version"] = version;
 	if (!p_state->copyright.is_empty()) {
@@ -8349,8 +8349,8 @@ Error GLTFDocument::_parse_asset_header(Ref<GLTFState> p_state) {
 		return ERR_PARSE_ERROR;
 	}
 	String version = asset["version"];
-	p_state->major_version = version.get_slice(".", 0).to_int();
-	p_state->minor_version = version.get_slice(".", 1).to_int();
+	p_state->major_version = version.get_slicec('.', 0).to_int();
+	p_state->minor_version = version.get_slicec('.', 1).to_int();
 	if (asset.has("copyright")) {
 		p_state->copyright = asset["copyright"];
 	}

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -400,24 +400,24 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 							p = p.replace("]", "");
 
 							if (p.begins_with("ro.product.model=")) {
-								device = p.get_slice("=", 1).strip_edges();
+								device = p.get_slicec('=', 1).strip_edges();
 							} else if (p.begins_with("ro.product.brand=")) {
-								vendor = p.get_slice("=", 1).strip_edges().capitalize();
+								vendor = p.get_slicec('=', 1).strip_edges().capitalize();
 							} else if (p.begins_with("ro.build.display.id=")) {
-								d.description += "Build: " + p.get_slice("=", 1).strip_edges() + "\n";
+								d.description += "Build: " + p.get_slicec('=', 1).strip_edges() + "\n";
 							} else if (p.begins_with("ro.build.version.release=")) {
-								d.description += "Release: " + p.get_slice("=", 1).strip_edges() + "\n";
+								d.description += "Release: " + p.get_slicec('=', 1).strip_edges() + "\n";
 							} else if (p.begins_with("ro.build.version.sdk=")) {
-								d.api_level = p.get_slice("=", 1).to_int();
+								d.api_level = p.get_slicec('=', 1).to_int();
 							} else if (p.begins_with("ro.product.cpu.abi=")) {
-								d.architecture = p.get_slice("=", 1).strip_edges();
+								d.architecture = p.get_slicec('=', 1).strip_edges();
 								d.description += "CPU: " + d.architecture + "\n";
 							} else if (p.begins_with("ro.product.manufacturer=")) {
-								d.description += "Manufacturer: " + p.get_slice("=", 1).strip_edges() + "\n";
+								d.description += "Manufacturer: " + p.get_slicec('=', 1).strip_edges() + "\n";
 							} else if (p.begins_with("ro.board.platform=")) {
-								d.description += "Chipset: " + p.get_slice("=", 1).strip_edges() + "\n";
+								d.description += "Chipset: " + p.get_slicec('=', 1).strip_edges() + "\n";
 							} else if (p.begins_with("ro.opengles.version=")) {
-								uint32_t opengl = p.get_slice("=", 1).to_int();
+								uint32_t opengl = p.get_slicec('=', 1).to_int();
 								d.description += "OpenGL: " + itos(opengl >> 16) + "." + itos((opengl >> 8) & 0xFF) + "." + itos((opengl) & 0xFF) + "\n";
 							}
 						}

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -226,7 +226,7 @@ void FreeDesktopPortalDesktop::append_dbus_dict_filters(DBusMessageIter *p_iter,
 		int filter_slice_count = flt.get_slice_count(",");
 		for (int j = 0; j < filter_slice_count; j++) {
 			dbus_message_iter_open_container(&array_iter, DBUS_TYPE_STRUCT, nullptr, &array_struct_iter);
-			String str = (flt.get_slice(",", j).strip_edges());
+			String str = (flt.get_slicec(',', j).strip_edges());
 			{
 				const unsigned flt_type = 0;
 				dbus_message_iter_append_basic(&array_struct_iter, DBUS_TYPE_UINT32, &flt_type);

--- a/platform/macos/godot_open_save_delegate.mm
+++ b/platform/macos/godot_open_save_delegate.mm
@@ -124,7 +124,7 @@
 
 					NSMutableArray *type_filters = [[NSMutableArray alloc] init];
 					for (int j = 0; j < filter_slice_count; j++) {
-						String str = (flt.get_slice(",", j).strip_edges());
+						String str = (flt.get_slicec(',', j).strip_edges());
 						if (!str.is_empty()) {
 							if (@available(macOS 11, *)) {
 								UTType *ut = nullptr;
@@ -178,7 +178,7 @@
 
 				NSMutableArray *type_filters = [[NSMutableArray alloc] init];
 				for (int j = 0; j < filter_slice_count; j++) {
-					String str = (flt.get_slice(",", j).strip_edges());
+					String str = (flt.get_slicec(',', j).strip_edges());
 					if (!str.is_empty()) {
 						if (@available(macOS 11, *)) {
 							UTType *ut = nullptr;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -489,7 +489,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 			int filter_slice_count = flt.get_slice_count(",");
 			Vector<String> exts;
 			for (int j = 0; j < filter_slice_count; j++) {
-				String str = (flt.get_slice(",", j).strip_edges());
+				String str = (flt.get_slicec(',', j).strip_edges());
 				if (!str.is_empty()) {
 					exts.push_back(str);
 				}
@@ -6486,8 +6486,8 @@ Vector2i _get_device_ids(const String &p_device_name) {
 			SysFreeString(object_name);
 			if (hr == S_OK) {
 				String device_id = String(V_BSTR(&did));
-				ids.x = device_id.get_slice("&", 0).lstrip("PCI\\VEN_").hex_to_int();
-				ids.y = device_id.get_slice("&", 1).lstrip("DEV_").hex_to_int();
+				ids.x = device_id.get_slicec('&', 0).lstrip("PCI\\VEN_").hex_to_int();
+				ids.y = device_id.get_slicec('&', 1).lstrip("DEV_").hex_to_int();
 			}
 
 			for (ULONG i = 0; i < resultCount; i++) {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3350,8 +3350,8 @@ void CodeEdit::_set_delimiters(const TypedArray<String> &p_delimiters, Delimiter
 			continue;
 		}
 
-		const String start_key = key.get_slice(" ", 0);
-		const String end_key = key.get_slice_count(" ") > 1 ? key.get_slice(" ", 1) : String();
+		const String start_key = key.get_slicec(' ', 0);
+		const String end_key = key.get_slice_count(" ") > 1 ? key.get_slicec(' ', 1) : String();
 
 		_add_delimiter(start_key, end_key, end_key.is_empty(), p_type);
 	}

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -168,9 +168,9 @@ void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> 
 			} else if (filters.size() > 1 && p_filter == 0) {
 				// Match all filters.
 				for (int i = 0; i < filters.size(); i++) {
-					String flt = filters[i].get_slice(";", 0);
+					String flt = filters[i].get_slicec(';', 0);
 					for (int j = 0; j < flt.get_slice_count(","); j++) {
-						String str = flt.get_slice(",", j).strip_edges();
+						String str = flt.get_slicec(',', j).strip_edges();
 						if (f.matchn(str)) {
 							valid = true;
 							break;
@@ -186,10 +186,10 @@ void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> 
 					idx--;
 				}
 				if (idx >= 0 && idx < filters.size()) {
-					String flt = filters[idx].get_slice(";", 0);
+					String flt = filters[idx].get_slicec(';', 0);
 					int filter_slice_count = flt.get_slice_count(",");
 					for (int j = 0; j < filter_slice_count; j++) {
-						String str = (flt.get_slice(",", j).strip_edges());
+						String str = flt.get_slicec(',', j).strip_edges();
 						if (f.matchn(str)) {
 							valid = true;
 							break;
@@ -197,7 +197,7 @@ void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> 
 					}
 
 					if (!valid && filter_slice_count > 0) {
-						String str = (flt.get_slice(",", 0).strip_edges());
+						String str = flt.get_slicec(',', 0).strip_edges();
 						f += str.substr(1);
 						file->set_text(f.get_file());
 						valid = true;
@@ -210,8 +210,8 @@ void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> 
 			// Add first extension of filter if no valid extension is found.
 			if (!valid) {
 				int idx = p_filter;
-				String flt = filters[idx].get_slice(";", 0);
-				String ext = flt.get_slice(",", 0).strip_edges().get_extension();
+				String flt = filters[idx].get_slicec(';', 0);
+				String ext = flt.get_slicec(',', 0).strip_edges().get_extension();
 				f += "." + ext;
 			}
 			emit_signal(SNAME("file_selected"), f);
@@ -543,9 +543,9 @@ void FileDialog::_action_pressed() {
 		} else if (filters.size() > 1 && filter->get_selected() == 0) {
 			// Match all filters.
 			for (int i = 0; i < filters.size(); i++) {
-				String flt = filters[i].get_slice(";", 0);
+				String flt = filters[i].get_slicec(';', 0);
 				for (int j = 0; j < flt.get_slice_count(","); j++) {
-					String str = flt.get_slice(",", j).strip_edges();
+					String str = flt.get_slicec(',', j).strip_edges();
 					if (f.matchn(str)) {
 						valid = true;
 						break;
@@ -561,10 +561,10 @@ void FileDialog::_action_pressed() {
 				idx--;
 			}
 			if (idx >= 0 && idx < filters.size()) {
-				String flt = filters[idx].get_slice(";", 0);
+				String flt = filters[idx].get_slicec(';', 0);
 				int filter_slice_count = flt.get_slice_count(",");
 				for (int j = 0; j < filter_slice_count; j++) {
-					String str = (flt.get_slice(",", j).strip_edges());
+					String str = (flt.get_slicec(',', j).strip_edges());
 					if (f.matchn(str)) {
 						valid = true;
 						break;
@@ -572,7 +572,7 @@ void FileDialog::_action_pressed() {
 				}
 
 				if (!valid && filter_slice_count > 0) {
-					String str = (flt.get_slice(",", 0).strip_edges());
+					String str = flt.get_slicec(',', 0).strip_edges();
 					f += str.substr(1);
 					file->set_text(f.get_file());
 					valid = true;
@@ -870,9 +870,9 @@ void FileDialog::update_file_list() {
 	} else if (filters.size() > 1 && filter->get_selected() == 0) {
 		// match all filters
 		for (int i = 0; i < filters.size(); i++) {
-			String f = filters[i].get_slice(";", 0);
+			String f = filters[i].get_slicec(';', 0);
 			for (int j = 0; j < f.get_slice_count(","); j++) {
-				patterns.push_back(f.get_slice(",", j).strip_edges());
+				patterns.push_back(f.get_slicec(',', j).strip_edges());
 			}
 		}
 	} else {
@@ -882,9 +882,9 @@ void FileDialog::update_file_list() {
 		}
 
 		if (idx >= 0 && idx < filters.size()) {
-			String f = filters[idx].get_slice(";", 0);
+			String f = filters[idx].get_slicec(';', 0);
 			for (int j = 0; j < f.get_slice_count(","); j++) {
-				patterns.push_back(f.get_slice(",", j).strip_edges());
+				patterns.push_back(f.get_slicec(',', j).strip_edges());
 			}
 		}
 	}

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -41,8 +41,8 @@ bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 		return false;
 	}
 
-	int idx = str.get_slice("/", 1).to_int();
-	String slot_property_name = str.get_slice("/", 2);
+	int idx = str.get_slicec('/', 1).to_int();
+	String slot_property_name = str.get_slicec('/', 2);
 
 	Slot slot;
 	if (slot_table.has(idx)) {
@@ -93,8 +93,8 @@ bool GraphNode::_get(const StringName &p_name, Variant &r_ret) const {
 		return false;
 	}
 
-	int idx = str.get_slice("/", 1).to_int();
-	StringName slot_property_name = str.get_slice("/", 2);
+	int idx = str.get_slicec('/', 1).to_int();
+	StringName slot_property_name = str.get_slicec('/', 2);
 
 	Slot slot;
 	if (slot_table.has(idx)) {

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -219,7 +219,7 @@ void MenuBar::bind_global_menu() {
 	String prev_tag;
 	if (start_index >= 0) {
 		for (int i = 0; i < count; i++) {
-			String tag = nmenu->get_item_tag(main_menu, i).operator String().get_slice("#", 1);
+			String tag = nmenu->get_item_tag(main_menu, i).operator String().get_slicec('#', 1);
 			if (!tag.is_empty() && tag != prev_tag) {
 				MenuBar *mb = Object::cast_to<MenuBar>(ObjectDB::get_instance(ObjectID(static_cast<uint64_t>(tag.to_int()))));
 				if (mb && mb->get_start_index() >= start_index) {

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -165,7 +165,7 @@ bool OptionButton::_set(const StringName &p_name, const Variant &p_value) {
 			_select(index, false);
 		}
 
-		const String property = sname.get_slice("/", 2);
+		const String property = sname.get_slicec('/', 2);
 		if (property == "text" || property == "icon") {
 			_queue_update_size_cache();
 		}

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -829,7 +829,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				int slash_pos = subtype_string.find_char('/');
 				PropertyHint subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
 				if (slash_pos >= 0) {
-					subtype_hint = PropertyHint(subtype_string.get_slice("/", 1).to_int());
+					subtype_hint = PropertyHint(subtype_string.get_slicec('/', 1).to_int());
 					subtype_string = subtype_string.substr(0, slash_pos);
 				}
 				Variant::Type subtype = Variant::Type(subtype_string.to_int());
@@ -859,7 +859,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				int key_slash_pos = key_subtype_string.find_char('/');
 				PropertyHint key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
 				if (key_slash_pos >= 0) {
-					key_subtype_hint = PropertyHint(key_subtype_string.get_slice("/", 1).to_int());
+					key_subtype_hint = PropertyHint(key_subtype_string.get_slicec('/', 1).to_int());
 					key_subtype_string = key_subtype_string.substr(0, key_slash_pos);
 				}
 				Variant::Type key_subtype = Variant::Type(key_subtype_string.to_int());
@@ -870,7 +870,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				int value_slash_pos = value_subtype_string.find_char('/');
 				PropertyHint value_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
 				if (value_slash_pos >= 0) {
-					value_subtype_hint = PropertyHint(value_subtype_string.get_slice("/", 1).to_int());
+					value_subtype_hint = PropertyHint(value_subtype_string.get_slicec('/', 1).to_int());
 					value_subtype_string = value_subtype_string.substr(0, value_slash_pos);
 				}
 				Variant::Type value_subtype = Variant::Type(value_subtype_string.to_int());

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -543,8 +543,8 @@ void CodeHighlighter::set_color_regions(const Dictionary &p_color_regions) {
 	for (const Variant &E : keys) {
 		String key = E;
 
-		String start_key = key.get_slice(" ", 0);
-		String end_key = key.get_slice_count(" ") > 1 ? key.get_slice(" ", 1) : String();
+		String start_key = key.get_slicec(' ', 0);
+		String end_key = key.get_slice_count(" ") > 1 ? key.get_slicec(' ', 1) : String();
 
 		add_color_region(start_key, end_key, p_color_regions[key], end_key.is_empty());
 	}

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -164,7 +164,7 @@ void Theme::_get_property_list(List<PropertyInfo> *p_list) const {
 	String prev_type;
 	for (const PropertyInfo &E : list) {
 		// Add groups for types so that their names are left unchanged in the inspector.
-		String current_type = E.name.get_slice("/", 0);
+		String current_type = E.name.get_slicec('/', 0);
 		if (prev_type != current_type) {
 			p_list->push_back(PropertyInfo(Variant::NIL, current_type, PROPERTY_HINT_NONE, current_type + "/", PROPERTY_USAGE_GROUP));
 			prev_type = current_type;

--- a/servers/audio/effects/audio_effect_chorus.cpp
+++ b/servers/audio/effects/audio_effect_chorus.cpp
@@ -274,7 +274,7 @@ float AudioEffectChorus::get_dry() const {
 
 void AudioEffectChorus::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name.begins_with("voice/")) {
-		int voice_idx = p_property.name.get_slice("/", 1).to_int();
+		int voice_idx = p_property.name.get_slicec('/', 1).to_int();
 		if (voice_idx > voice_count) {
 			p_property.usage = PROPERTY_USAGE_NONE;
 		}

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -2044,14 +2044,14 @@ AudioServer::~AudioServer() {
 bool AudioBusLayout::_set(const StringName &p_name, const Variant &p_value) {
 	String s = p_name;
 	if (s.begins_with("bus/")) {
-		int index = s.get_slice("/", 1).to_int();
+		int index = s.get_slicec('/', 1).to_int();
 		if (buses.size() <= index) {
 			buses.resize(index + 1);
 		}
 
 		Bus &bus = buses.write[index];
 
-		String what = s.get_slice("/", 2);
+		String what = s.get_slicec('/', 2);
 
 		if (what == "name") {
 			bus.name = p_value;
@@ -2066,14 +2066,14 @@ bool AudioBusLayout::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (what == "send") {
 			bus.send = p_value;
 		} else if (what == "effect") {
-			int which = s.get_slice("/", 3).to_int();
+			int which = s.get_slicec('/', 3).to_int();
 			if (bus.effects.size() <= which) {
 				bus.effects.resize(which + 1);
 			}
 
 			Bus::Effect &fx = bus.effects.write[which];
 
-			String fxwhat = s.get_slice("/", 4);
+			String fxwhat = s.get_slicec('/', 4);
 			if (fxwhat == "effect") {
 				fx.effect = p_value;
 			} else if (fxwhat == "enabled") {
@@ -2096,14 +2096,14 @@ bool AudioBusLayout::_set(const StringName &p_name, const Variant &p_value) {
 bool AudioBusLayout::_get(const StringName &p_name, Variant &r_ret) const {
 	String s = p_name;
 	if (s.begins_with("bus/")) {
-		int index = s.get_slice("/", 1).to_int();
+		int index = s.get_slicec('/', 1).to_int();
 		if (index < 0 || index >= buses.size()) {
 			return false;
 		}
 
 		const Bus &bus = buses[index];
 
-		String what = s.get_slice("/", 2);
+		String what = s.get_slicec('/', 2);
 
 		if (what == "name") {
 			r_ret = bus.name;
@@ -2118,14 +2118,14 @@ bool AudioBusLayout::_get(const StringName &p_name, Variant &r_ret) const {
 		} else if (what == "send") {
 			r_ret = bus.send;
 		} else if (what == "effect") {
-			int which = s.get_slice("/", 3).to_int();
+			int which = s.get_slicec('/', 3).to_int();
 			if (which < 0 || which >= bus.effects.size()) {
 				return false;
 			}
 
 			const Bus::Effect &fx = bus.effects[which];
 
-			String fxwhat = s.get_slice("/", 4);
+			String fxwhat = s.get_slicec('/', 4);
 			if (fxwhat == "effect") {
 				r_ret = fx.effect;
 			} else if (fxwhat == "enabled") {

--- a/servers/rendering/dummy/storage/material_storage.cpp
+++ b/servers/rendering/dummy/storage/material_storage.cpp
@@ -85,7 +85,7 @@ void MaterialStorage::global_shader_parameters_load_settings(bool p_load_texture
 
 	for (const PropertyInfo &E : settings) {
 		if (E.name.begins_with("shader_globals/")) {
-			StringName name = E.name.get_slice("/", 1);
+			StringName name = E.name.get_slicec('/', 1);
 			Dictionary d = GLOBAL_GET(E.name);
 
 			ERR_CONTINUE(!d.has("type"));

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -1705,7 +1705,7 @@ void MaterialStorage::global_shader_parameters_load_settings(bool p_load_texture
 
 	for (const PropertyInfo &E : settings) {
 		if (E.name.begins_with("shader_globals/")) {
-			StringName name = E.name.get_slice("/", 1);
+			StringName name = E.name.get_slicec('/', 1);
 			Dictionary d = GLOBAL_GET(E.name);
 
 			ERR_CONTINUE(!d.has("type"));

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -115,7 +115,7 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 					base_error = "Missing `;` in '" + l + "'. Version syntax is `version = \"<defines with C escaping>\";`.";
 					break;
 				}
-				Vector<String> slices = l.get_slice(";", 0).split("=");
+				Vector<String> slices = l.get_slicec(';', 0).split("=");
 				String version = slices[0].strip_edges();
 				if (!version.is_valid_ascii_identifier()) {
 					base_error = "Version names must be valid identifiers, found '" + version + "' instead.";

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -165,8 +165,8 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 	SUBCASE("Basic valid escape sequences") {
 		for (int i = 0; i < valid_escapes.size(); i++) {
 			String valid_escape = valid_escapes[i];
-			String valid_escape_string = valid_escape.get_slice(";", 0);
-			String valid_escape_value = valid_escape.get_slice(";", 1);
+			String valid_escape_string = valid_escape.get_slicec(';', 0);
+			String valid_escape_value = valid_escape.get_slicec(';', 1);
 
 			String json_string = "\"\\";
 			json_string += valid_escape_string;
@@ -204,7 +204,7 @@ TEST_CASE("[JSON] Parsing escape sequences") {
 			bool skip = false;
 			for (int j = 0; j < valid_escapes.size(); j++) {
 				String valid_escape = valid_escapes[j];
-				String valid_escape_string = valid_escape.get_slice(";", 0);
+				String valid_escape_string = valid_escape.get_slicec(';', 0);
 				if (valid_escape_string[0] == i) {
 					skip = true;
 					break;


### PR DESCRIPTION
This method exists for this dedicated purpose and is faster for these kinds of input
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
