### PR TITLE
Add formatting to errors printed due to invalid command line arguments

### DIFF
--- a/main/main.h
+++ b/main/main.h
@@ -46,6 +46,7 @@ class Main {
 		CLI_OPTION_AVAILABILITY_HIDDEN,
 	};
 
+	static void print_argument_error(const char *p_message);
 	static void print_header(bool p_rich);
 	static void print_help_copyright(const char *p_notice);
 	static void print_help_title(const char *p_title);


### PR DESCRIPTION
- Fix `--test` error message not being visible on Windows on builds with tests disabled (salvaged from https://github.com/godotengine/godot/pull/99294).

## Preview

![image](https://github.com/user-attachments/assets/1d45a264-545e-402f-b8eb-7bc46ce8fb8a)