### PR TITLE
Add a code sample that extracts all files to ZIPReader documentation

### DIFF
--- a/doc/classes/PCKPacker.xml
+++ b/doc/classes/PCKPacker.xml
@@ -20,6 +20,7 @@
 		[/csharp]
 		[/codeblocks]
 		The above [PCKPacker] creates package [code]test.pck[/code], then adds a file named [code]text.txt[/code] at the root of the package.
+		[b]Note:[/b] PCK is Godot's own pack file format. To create ZIP archives that can be read by any program, use [ZIPPacker] instead.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/zip/doc_classes/ZIPPacker.xml
+++ b/modules/zip/doc_classes/ZIPPacker.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ZIPPacker" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
-		Allows the creation of zip files.
+		Allows the creation of ZIP files.
 	</brief_description>
 	<description>
-		This class implements a writer that allows storing the multiple blobs in a zip archive.
+		This class implements a writer that allows storing the multiple blobs in a ZIP archive. See also [ZIPReader] and [PCKPacker].
 		[codeblock]
+		# Create a ZIP archive with a single file at its root.
 		func write_zip_file():
 		    var writer = ZIPPacker.new()
 		    var err = writer.open("user://archive.zip")

--- a/modules/zip/doc_classes/ZIPReader.xml
+++ b/modules/zip/doc_classes/ZIPReader.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ZIPReader" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
-		Allows reading the content of a zip file.
+		Allows reading the content of a ZIP file.
 	</brief_description>
 	<description>
-		This class implements a reader that can extract the content of individual files inside a zip archive.
+		This class implements a reader that can extract the content of individual files inside a ZIP archive. See also [ZIPPacker].
 		[codeblock]
+		# Read a single file from a ZIP archive.
 		func read_zip_file():
 		    var reader = ZIPReader.new()
 		    var err = reader.open("user://archive.zip")
@@ -14,6 +15,32 @@
 		    var res = reader.read_file("hello.txt")
 		    reader.close()
 		    return res
+
+		# Extract all files from a ZIP archive, preserving the directories within.
+		# This acts like the "Extract all" functionality from most archive managers.
+		func extract_all_from_zip():
+		    var reader = ZIPReader.new()
+		    reader.open("res://archive.zip")
+
+		    # Destination directory for the extracted files (this folder must exist before extraction).
+		    # Not all ZIP archives put everything in a single root folder,
+		    # which means several files/folders may be created in `root_dir` after extraction.
+		    var root_dir = DirAccess.open("user://")
+
+		    var files = reader.get_files()
+		    for file_path in files:
+		        # If the current entry is a directory.
+		        if file_path.ends_with("/"):
+		            root_dir.make_dir_recursive(file_path)
+		            continue
+
+		        # Write file contents, creating folders automatically when needed.
+		        # Not all ZIP archives are strictly ordered, so we need to do this in case
+		        # the file entry comes before the folder entry.
+		        root_dir.make_dir_recursive(root_dir.get_current_dir().path_join(file_path).get_base_dir())
+		        var file = FileAccess.open(root_dir.get_current_dir().path_join(file_path), FileAccess.WRITE)
+		        var buffer = reader.read_file(file_path)
+		        file.store_buffer(buffer)
 		[/codeblock]
 	</description>
 	<tutorials>


### PR DESCRIPTION
Tested with various ZIP files found on the web (e.g. from [this page](https://sourceforge.net/projects/nexuiz/files/)), with a single root folder or multiple files at its root.

Thanks @raulsntos for the [original code sample](https://github.com/godotengine/godot-proposals/issues/11083#issuecomment-2480362303), which I've modified to better handle various ZIP files I've tested.


