### PR TITLE
Implement `AudioStreamSynchronized::get_bar_beats()`, fix division by zero

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -691,9 +691,14 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 				src_fade_wait = beat_sec - remainder;
 			} break;
 			case AudioStreamInteractive::TRANSITION_FROM_TIME_NEXT_BAR: {
-				float bar_sec = beat_sec * from_state.stream->get_bar_beats();
-				float remainder = Math::fmod(current_pos, bar_sec);
-				src_fade_wait = bar_sec - remainder;
+				if (from_state.stream->get_bar_beats() > 0) {
+					float bar_sec = beat_sec * from_state.stream->get_bar_beats();
+					float remainder = Math::fmod(current_pos, bar_sec);
+					src_fade_wait = bar_sec - remainder;
+				} else {
+					// Stream does not have a number of beats per bar - avoid NaN, and play immediately.
+					src_fade_wait = 0;
+				}
 			} break;
 			case AudioStreamInteractive::TRANSITION_FROM_TIME_END: {
 				float end = from_state.stream->get_beat_count() > 0 ? float(from_state.stream->get_beat_count() * beat_sec) : from_state.stream->get_length();

--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -99,6 +99,18 @@ int AudioStreamSynchronized::get_beat_count() const {
 	return max_beats;
 }
 
+int AudioStreamSynchronized::get_bar_beats() const {
+	for (int i = 0; i < stream_count; i++) {
+		if (audio_streams[i].is_valid()) {
+			int bar_beats = audio_streams[i]->get_bar_beats();
+			if (bar_beats != 0) {
+				return bar_beats;
+			}
+		}
+	}
+	return 0;
+}
+
 bool AudioStreamSynchronized::has_loop() const {
 	for (int i = 0; i < stream_count; i++) {
 		if (audio_streams[i].is_valid()) {

--- a/modules/interactive_music/audio_stream_synchronized.h
+++ b/modules/interactive_music/audio_stream_synchronized.h
@@ -54,6 +54,7 @@ private:
 public:
 	virtual double get_bpm() const override;
 	virtual int get_beat_count() const override;
+	virtual int get_bar_beats() const override;
 	virtual bool has_loop() const override;
 	void set_stream_count(int p_count);
 	int get_stream_count() const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92453, and tested using its MRP. `get_bar_beats()` was unimplemented on `AudioStreamSynchronized`, so this implements it similarly to other methods like `get_bpm()`. It could also be implemented more similarly to `get_beat_count()`, which gets the maximum beat count (not just the first), although it's a bit unclear what the intended behavior would be if there are different bar beats for each sub-stream.

The underlying issue is that `get_bar_beats()` is used to calculate the end time of the current bar (in `AudioStreamInteractive`), and without an implementation, it returns zero. This leads to a division by zero, resulting in NaN, which completely breaks timings. Thus, this PR also adds a guard which will check if bar beats is > 0 (if not, the transition will instead occur immediately), since this can probably occur with other stream types that still do not implement `get_bar_beats()`.

(As a side note, this division by zero guard may also need to be implemented in the new code introduced in https://github.com/godotengine/godot/pull/99188.)