### PR TITLE
Fix native `FileDialog` crash on Android

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -17,6 +17,7 @@
 				Adds a comma-delimited file name [param filter] option to the [FileDialog] with an optional [param description], which restricts what files can be picked.
 				A [param filter] should be of the form [code]"filename.extension"[/code], where filename and extension can be [code]*[/code] to match any string. Filters starting with [code].[/code] (i.e. empty filenames) are not allowed.
 				For example, a [param filter] of [code]"*.png, *.jpg"[/code] and a [param description] of [code]"Images"[/code] results in filter text "Images (*.png, *.jpg)".
+				[b]Note:[/b] For android native dialog, MIME types are used. For example, [code]image/*, application/pdf[/code].
 			</description>
 		</method>
 		<method name="add_option">
@@ -146,7 +147,7 @@
 		</member>
 		<member name="filters" type="PackedStringArray" setter="set_filters" getter="get_filters" default="PackedStringArray()">
 			The available file type filters. Each filter string in the array should be formatted like this: [code]*.txt,*.doc;Text Files[/code]. The description text of the filter is optional and can be omitted.
-			[b]Note:[/b] For android native dialog, MIME types are used like this: [code]image/*, application/pdf[/code].
+			[b]Note:[/b] For android native dialog, MIME types are used. For example, [code]image/*, application/pdf[/code].
 		</member>
 		<member name="mode_overrides_title" type="bool" setter="set_mode_overrides_title" getter="is_mode_overriding_title" default="true">
 			If [code]true[/code], changing the [member file_mode] property will set the window title accordingly (e.g. setting [member file_mode] to [constant FILE_MODE_OPEN_FILE] will change the window title to "Open a File").

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -70,7 +70,8 @@ void FileDialog::_native_popup() {
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE_EXTRA)) {
 		DisplayServer::get_singleton()->file_dialog_with_options_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(dir->get_text()), root, file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &FileDialog::_native_dialog_cb_with_options));
 	} else {
-		DisplayServer::get_singleton()->file_dialog_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(dir->get_text()), file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, callable_mp(this, &FileDialog::_native_dialog_cb));
+		// Using [filters] instead of [processed_filters] as the latter is unsupported on Android; file_dialog_show is currently Android-only in this case.
+		DisplayServer::get_singleton()->file_dialog_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(dir->get_text()), file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), filters, callable_mp(this, &FileDialog::_native_dialog_cb));
 	}
 }
 


### PR DESCRIPTION
- Fixes #99326 

The issue occurred after merging PR #99266, causing a crash due to the use of `processed_filters`, which is not supported on Android. To resolve this, `processed_filters` has been replaced with `filters` in _file_dialog_show_, as this function is only called for Android. Other platforms use _file_dialog_with_options_show._  

This means that only platforms with the FEATURE_NATIVE_DIALOG_FILE_EXTRA will use `processed_filters`.

Also, updated FileDialog documentation for better clarity.
