### PR TITLE
Use correct coefficients to get luminance from a color in linear space

### DIFF
--- a/drivers/gles3/shaders/effect_blur.glsl
+++ b/drivers/gles3/shaders/effect_blur.glsl
@@ -282,7 +282,7 @@ void main() {
 
 #ifdef GLOW_FIRST_PASS
 
-	float luminance = max(frag_color.r, max(frag_color.g, frag_color.b));
+	float luminance = dot(frag_color.rgb, vec3(0.2126, 0.7152, 0.0722));
 	float feedback = max(smoothstep(glow_hdr_threshold, glow_hdr_threshold + glow_hdr_scale, luminance), glow_bloom);
 
 	frag_color = min(frag_color * feedback, vec4(luminance_cap));

--- a/drivers/gles3/shaders/effects/glow.glsl
+++ b/drivers/gles3/shaders/effects/glow.glsl
@@ -78,7 +78,7 @@ void main() {
 #endif // USE_MULTIVIEW
 	color /= luminance_multiplier * 8.0;
 
-	float feedback_factor = max(color.r, max(color.g, color.b));
+	float feedback_factor = dot(color, vec3(0.2126, 0.7152, 0.0722));
 	float feedback = max(smoothstep(glow_hdr_threshold, glow_hdr_threshold + glow_hdr_scale, feedback_factor), glow_bloom);
 
 	color = min(color * feedback, vec3(glow_luminance_cap));

--- a/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
@@ -133,7 +133,7 @@ void main() {
 #endif
 		frag_color *= blur.glow_exposure;
 
-		float luminance = max(frag_color.r, max(frag_color.g, frag_color.b));
+		float luminance = dot(frag_color.rgb, vec3(0.2126, 0.7152, 0.0722));
 		float feedback = max(smoothstep(blur.glow_hdr_threshold, blur.glow_hdr_threshold + blur.glow_hdr_scale, luminance), blur.glow_bloom);
 
 		frag_color = min(frag_color * feedback, vec4(blur.glow_luminance_cap)) / blur.luminance_multiplier;

--- a/servers/rendering/renderer_rd/shaders/effects/copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy.glsl
@@ -103,7 +103,7 @@ void main() {
 #ifdef MODE_GLOW
 	if (bool(params.flags & FLAG_GLOW_FIRST_PASS)) {
 		// Tonemap initial samples to reduce weight of fireflies: https://graphicrants.blogspot.com/2013/12/tone-mapping.html
-		vec3 tonemap_col = vec3(0.299, 0.587, 0.114) / max(params.glow_luminance_cap, 6.0);
+		vec3 tonemap_col = vec3(0.2126, 0.7152, 0.0722) / max(params.glow_luminance_cap, 6.0);
 		local_cache[dest_index] /= 1.0 + dot(local_cache[dest_index].rgb, tonemap_col);
 		local_cache[dest_index + 1] /= 1.0 + dot(local_cache[dest_index + 1].rgb, tonemap_col);
 		local_cache[dest_index + 16] /= 1.0 + dot(local_cache[dest_index + 16].rgb, tonemap_col);
@@ -178,7 +178,7 @@ void main() {
 #ifdef MODE_GLOW
 	if (bool(params.flags & FLAG_GLOW_FIRST_PASS)) {
 		// Undo tonemap to restore range: https://graphicrants.blogspot.com/2013/12/tone-mapping.html
-		color /= 1.0 - dot(color.rgb, vec3(0.299, 0.587, 0.114) / max(params.glow_luminance_cap, 6.0));
+		color /= 1.0 - dot(color.rgb, vec3(0.2126, 0.7152, 0.0722) / max(params.glow_luminance_cap, 6.0));
 	}
 
 	color *= params.glow_strength;
@@ -190,7 +190,7 @@ void main() {
 #endif
 		color *= params.glow_exposure;
 
-		float luminance = max(color.r, max(color.g, color.b));
+		float luminance = dot(color.rgb, vec3(0.2126, 0.7152, 0.0722));
 		float feedback = max(smoothstep(params.glow_hdr_threshold, params.glow_hdr_threshold + params.glow_hdr_scale, luminance), params.glow_bloom);
 
 		color = min(color * feedback, vec4(params.glow_luminance_cap));

--- a/servers/rendering/renderer_rd/shaders/effects/luminance_reduce.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/luminance_reduce.glsl
@@ -44,7 +44,7 @@ void main() {
 	if (any(lessThan(pos, params.source_size))) {
 #ifdef READ_TEXTURE
 		vec3 v = texelFetch(source_texture, pos, 0).rgb;
-		tmp_data[t] = max(v.r, max(v.g, v.b));
+		tmp_data[t] = dot(v, vec3(0.2126, 0.7152, 0.0722));
 #else
 		tmp_data[t] = imageLoad(source_luminance, pos).r;
 #endif

--- a/servers/rendering/renderer_rd/shaders/effects/luminance_reduce_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/luminance_reduce_raster.glsl
@@ -53,11 +53,7 @@ void main() {
 	source_color /= float((next_pos.x - src_pos.x) * (next_pos.y - src_pos.y));
 
 #ifdef FIRST_PASS
-	luminance = max(source_color.r, max(source_color.g, source_color.b));
-
-	// This formula should be more "accurate" but gave an overexposed result when testing.
-	// Leaving it here so we can revisit it if we want.
-	// luminance = source_color.r * 0.21 + source_color.g * 0.71 + source_color.b * 0.07;
+	luminance = dot(source_color, vec3(0.2126, 0.7152, 0.0722));
 #else
 	luminance = source_color.r;
 #endif

--- a/servers/rendering/renderer_rd/shaders/effects/ssil.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssil.glsl
@@ -210,7 +210,7 @@ void SSIL_tap_inner(const int p_quality_level, inout vec3 r_color_sum, inout flo
 
 	vec3 sample_color = textureLod(last_frame, reprojected_sampling_uv, 5.0).rgb;
 	// Reduce impact of fireflies by tonemapping before averaging: http://graphicrants.blogspot.com/2013/12/tone-mapping.html
-	sample_color /= (1.0 + dot(sample_color, vec3(0.299, 0.587, 0.114)));
+	sample_color /= (1.0 + dot(sample_color, vec3(0.2126, 0.7152, 0.0722)));
 	r_color_sum += sample_color * obscurance * weight * mix(1.0, smoothstep(0.0, 0.1, -dot(sample_normal, normalize(hit_delta))), params.normal_rejection_amount);
 	r_weight_sum += weight;
 }
@@ -391,7 +391,7 @@ void generate_SSIL(out vec3 r_color, out vec4 r_edges, out float r_obscurance, o
 
 	// Calculate weighted average
 	vec3 color = color_sum / weight_sum;
-	color /= 1.0 - dot(color, vec3(0.299, 0.587, 0.114));
+	color /= 1.0 - dot(color, vec3(0.2126, 0.7152, 0.0722));
 
 	// Calculate fadeout (1 close, gradient, 0 far)
 	float fade_out = clamp(pix_center_pos.z * params.fade_out_mul + params.fade_out_add, 0.0, 1.0);

--- a/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
@@ -301,7 +301,7 @@ vec3 clip_history_3x3(uvec2 group_pos, vec3 color_history, vec2 velocity_closest
 									TAA
 ------------------------------------------------------------------------------*/
 
-const vec3 lumCoeff = vec3(0.299f, 0.587f, 0.114f);
+const vec3 lumCoeff = vec3(0.2126f, 0.7152f, 0.0722f);
 
 float luminance(vec3 color) {
 	return max(dot(color, lumCoeff), 0.0001f);

--- a/servers/rendering/renderer_rd/shaders/environment/gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/gi.glsl
@@ -543,7 +543,7 @@ void voxel_gi_compute(uint index, vec3 position, vec3 normal, vec3 ref_vec, mat3
 	mat3 dir_xform = mat3(voxel_gi_instances.data[index].xform) * normal_xform;
 
 	vec3 blendv = abs(position / voxel_gi_instances.data[index].bounds * 2.0 - 1.0);
-	float blend = clamp(1.0 - max(blendv.x, max(blendv.y, blendv.z)), 0.0, 1.0);
+	float blend = clamp(1.0 - dot(blendv, vec3(0.2126, 0.7152, 0.0722)), 0.0, 1.0);
 	//float blend=1.0;
 
 	float max_distance = length(voxel_gi_instances.data[index].bounds);

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_direct_light.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_direct_light.glsl
@@ -383,10 +383,10 @@ void main() {
 
 	for (int i = 0; i < 6; i++) {
 		light_total += light_accum[i];
-		lumas[i] = max(light_accum[i].r, max(light_accum[i].g, light_accum[i].b));
+		lumas[i] = dot(light_accum[i], vec3(0.2126, 0.7152, 0.0722));
 	}
 
-	float luma_total = max(light_total.r, max(light_total.g, light_total.b));
+	float luma_total = dot(light_total, vec3(0.2126, 0.7152, 0.0722));
 
 	uint light_total_rgbe;
 

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2535,10 +2535,10 @@ void fragment_shader(in SceneData scene_data) {
 				float strength = max(0.0, dot(cam_normal, aniso_dir[i]));
 				vec3 light = emission * strength;
 				light_total += light;
-				lumas[i] = max(light.r, max(light.g, light.b));
+				lumas[i] = dot(light, vec3(0.2126, 0.7152, 0.0722));
 			}
 
-			float luma_total = max(light_total.r, max(light_total.g, light_total.b));
+			float luma_total = dot(light_total, vec3(0.2126, 0.7152, 0.0722));
 
 			uint light_aniso = 0;
 


### PR DESCRIPTION
vec3(0.299, 0.587, 0.114) should be used with gamma corrected SRGB colors, not with linear colors.

fixes https://github.com/godotengine/godot/issues/57015

https://stackoverflow.com/a/56678483

```
TO FIND LUMINANCE:

...Because apparently it was lost somewhere...

Step One:

Convert all sRGB 8 bit integer values to decimal 0.0-1.0

  vR = sR / 255;
  vG = sG / 255;
  vB = sB / 255;
Step Two:

Convert a gamma encoded RGB to a linear value. sRGB (computer standard) for instance requires a power curve of approximately V^2.2, though the "accurate" transform is:

sRGB to Linear

Where V´ is the gamma-encoded R, G, or B channel of sRGB.
Pseudocode:

function sRGBtoLin(colorChannel) {
        // Send this function a decimal sRGB gamma encoded color value
        // between 0.0 and 1.0, and it returns a linearized value.

    if ( colorChannel <= 0.04045 ) {
            return colorChannel / 12.92;
        } else {
            return pow((( colorChannel + 0.055)/1.055),2.4);
        }
    }
Step Three:

To find Luminance (Y) apply the standard coefficients for sRGB:

Apply coefficients Y = R * 0.2126 + G * 0.7152 + B *  0.0722 

Pseudocode using above functions:

Y = (0.2126 * sRGBtoLin(vR) + 0.7152 * sRGBtoLin(vG) + 0.0722 * sRGBtoLin(vB))
```