### PR TITLE
Vulkan validation error fixes

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -298,6 +298,7 @@ static VkPipelineStageFlags _rd_to_vk_pipeline_stages(BitField<RDD::PipelineStag
 	if (p_stages.has_flag(RDD::PIPELINE_STAGE_COPY_BIT) || p_stages.has_flag(RDD::PIPELINE_STAGE_RESOLVE_BIT)) {
 		// Transfer has been split into copy and resolve bits. Clear them and merge them into one bit.
 		vk_flags |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+		vk_flags |= VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
 		p_stages.clear_flag(RDD::PIPELINE_STAGE_COPY_BIT);
 		p_stages.clear_flag(RDD::PIPELINE_STAGE_RESOLVE_BIT);
 	}

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2344,6 +2344,7 @@ MaterialStorage::Samplers MaterialStorage::samplers_rd_allocate(float p_mipmap_b
 					sampler_state.mag_filter = RD::SAMPLER_FILTER_LINEAR;
 					sampler_state.min_filter = RD::SAMPLER_FILTER_LINEAR;
 					sampler_state.max_lod = 0;
+					sampler_state.enable_compare = true;
 				} break;
 				case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS: {
 					sampler_state.mag_filter = RD::SAMPLER_FILTER_NEAREST;


### PR DESCRIPTION
A bunch of vulkan validation issues were discovered on android here: https://github.com/godotengine/godot/issues/89101#issuecomment-2467105943.  While debugging this issue: https://github.com/godotengine/godot/issues/89101.

MRPs that reproduce it can be found here:

https://github.com/godotengine/godot/issues/89101#issuecomment-2471007113

Note that the mrps only reproduce this error:

```
11-10 21:21:10.343 21965 22006 E godot   : Validation Error: [ VUID-vkCmdDrawIndexed-magFilter-04553 ] Object 0: handle = 0x70b64e0000001bab, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; Object 1: handle = 0x3255d500000014aa, type = VK_OBJECT_TYPE_SAMPLER; Object 2: handle = 0x4295ab0000000035, type = VK_OBJECT_TYPE_IMAGE_VIEW; | MessageID = 0x9c7248ee | vkCmdDrawIndexed: Descriptor set VkDescriptorSet 0x70b64e0000001bab[] Sampler (VkSampler 0x3255d500000014aa[]) is set to use VK_FILTER_LINEAR with compareEnable is set to VK_FALSE, but image view's (VkImageView 0x4295ab0000000035[]) format (VK_FORMAT_D16_UNORM) VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features. The Vulkan spec states: If a VkSampler created with magFilter or minFilter equal to VK_FILTER_LINEAR and compareEnable equal to VK_FALSE is used to sample a VkImageView as a result of this command, then the image view's format features must contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT (https:
11-10 21:21:10.343 21965 22006 E godot   :    at: _debug_report_callback (drivers/vulkan/rendering_context_driver_vulkan.cpp:665)
```

I was unable to create an MRP that reproduces this error:

```
11-10 21:21:10.386 21965 22006 E godot   : Validation Error: [ VUID-vkCmdPipelineBarrier-srcAccessMask-02815 ] Object 0: handle = 0xb400007acecffb50, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x24d88c2b | vkCmdPipelineBarrier(): .pImageMemoryBarriers[0].srcAccessMask bit VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT is not supported by stage mask (VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT|VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT|VK_PIPELINE_STAGE_TRANSFER_BIT). The Vulkan spec states: The srcAccessMask member of each element of pMemoryBarriers must only include access flags that are supported by one or more of the pipeline stages in srcStageMask, as specified in the table of supported access types (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdPipelineBarrier-srcAccessMask-02815)
11-10 21:21:10.386 21965 22006 E godot   :    at: _debug_report_callback (drivers/vulkan/rendering_context_driver_vulkan.cpp:665)
11-10 21:21:10.387 21965 22006 E godot   : ERROR: Vulkan Debug Report: object - -5476376619426776240
```

But I did manage to track down the godot source code that was causing it while debugging our main project.  And here are the details on what fixes what:

The ``sampler_state.enable_compare = true;`` in ``material_storage.cpp`` fixes the " VK_FILTER_LINEAR and compareEnable equal to VK_FALSE..." error.

The ``vk_flags |= VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;`` fixes the "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT is not supported by stage mask..." error.

For the "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT" error, as far as I can tell, it is something related to SubViewports.  When I have a SubViewport in my main project's scene, the error occurs.  However, adding it to an mrp doesn't cause the error to occur.  So it must be some other combination of elements in my main project that makes it difficult to reproduce in an mrp.

~~I did not bisect to confirm which commit introduced this error.  But I can confirm that it is a regression.  Reason is I was using vulkan validation to debug this issue when we were deploying 4.3: https://github.com/godotengine/godot/issues/90459.~~

~~And this error was not present then.~~

I lied, this error was present then.  See this comment: https://github.com/godotengine/godot/issues/90459#issuecomment-2048585112.

Please let me know if you would like me to change anything and / or if this is the correct solution.  I'm not familiar with rendering.  I was just reading the error logs, debugging the code, and trying to make sense of what was going wrong.  Through trial and error, I found these changes to fix it.