### PR TITLE
Fix use of non-existent `Vector3.Axis` enum type in built-in methods and members

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -739,7 +739,7 @@ Vector<Plane> Geometry3D::build_box_planes(const Vector3 &p_extents) {
 	return planes;
 }
 
-Vector<Plane> Geometry3D::build_cylinder_planes(real_t p_radius, real_t p_height, int p_sides, Vector3::Axis p_axis) {
+Vector<Plane> Geometry3D::build_cylinder_planes(real_t p_radius, real_t p_height, int p_sides, int p_axis) {
 	ERR_FAIL_INDEX_V(p_axis, 3, Vector<Plane>());
 
 	Vector<Plane> planes;
@@ -793,7 +793,7 @@ Vector<Plane> Geometry3D::build_sphere_planes(real_t p_radius, int p_lats, int p
 	return planes;
 }
 
-Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height, int p_sides, int p_lats, Vector3::Axis p_axis) {
+Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height, int p_sides, int p_lats, int p_axis) {
 	ERR_FAIL_INDEX_V(p_axis, 3, Vector<Plane>());
 
 	Vector<Plane> planes;

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -574,8 +574,8 @@ public:
 	static MeshData build_convex_mesh(const Vector<Plane> &p_planes);
 	static Vector<Plane> build_sphere_planes(real_t p_radius, int p_lats, int p_lons, Vector3::Axis p_axis = Vector3::AXIS_Z);
 	static Vector<Plane> build_box_planes(const Vector3 &p_extents);
-	static Vector<Plane> build_cylinder_planes(real_t p_radius, real_t p_height, int p_sides, Vector3::Axis p_axis = Vector3::AXIS_Z);
-	static Vector<Plane> build_capsule_planes(real_t p_radius, real_t p_height, int p_sides, int p_lats, Vector3::Axis p_axis = Vector3::AXIS_Z);
+	static Vector<Plane> build_cylinder_planes(real_t p_radius, real_t p_height, int p_sides, int p_axis = Vector3::AXIS_Z);
+	static Vector<Plane> build_capsule_planes(real_t p_radius, real_t p_height, int p_sides, int p_lats, int p_axis = Vector3::AXIS_Z);
 
 	static Vector<Vector3> compute_convex_mesh_points(const Plane *p_planes, int p_plane_count);
 

--- a/doc/classes/Geometry3D.xml
+++ b/doc/classes/Geometry3D.xml
@@ -24,7 +24,7 @@
 			<param index="3" name="lats" type="int" />
 			<param index="4" name="axis" type="int" enum="Vector3.Axis" default="2" />
 			<description>
-				Returns an array of [Plane]s closely bounding a faceted capsule centered at the origin with radius [param radius] and height [param height]. The parameter [param sides] defines how many planes will be generated for the side part of the capsule, whereas [param lats] gives the number of latitudinal steps at the bottom and top of the capsule. The parameter [param axis] describes the axis along which the capsule is oriented (0 for X, 1 for Y, 2 for Z).
+				Returns an array of [Plane]s closely bounding a faceted capsule centered at the origin with radius [param radius] and height [param height]. The parameter [param sides] defines how many planes will be generated for the side part of the capsule, whereas [param lats] gives the number of latitudinal steps at the bottom and top of the capsule. The parameter [param axis] describes the index of the axis along which the capsule is oriented (see [constant Vector3.AXIS_X], [constant Vector3.AXIS_Y], and [constant Vector3.AXIS_Z]).
 			</description>
 		</method>
 		<method name="build_cylinder_planes">
@@ -34,7 +34,7 @@
 			<param index="2" name="sides" type="int" />
 			<param index="3" name="axis" type="int" enum="Vector3.Axis" default="2" />
 			<description>
-				Returns an array of [Plane]s closely bounding a faceted cylinder centered at the origin with radius [param radius] and height [param height]. The parameter [param sides] defines how many planes will be generated for the round part of the cylinder. The parameter [param axis] describes the axis along which the cylinder is oriented (0 for X, 1 for Y, 2 for Z).
+				Returns an array of [Plane]s closely bounding a faceted cylinder centered at the origin with radius [param radius] and height [param height]. The parameter [param sides] defines how many planes will be generated for the round part of the cylinder. The parameter [param axis] describes the index of the axis along which the cylinder is oriented (see [constant Vector3.AXIS_X], [constant Vector3.AXIS_Y], and [constant Vector3.AXIS_Z]).
 			</description>
 		</method>
 		<method name="clip_polygon">

--- a/doc/classes/LookAtModifier3D.xml
+++ b/doc/classes/LookAtModifier3D.xml
@@ -82,8 +82,8 @@
 		<member name="primary_positive_limit_angle" type="float" setter="set_primary_positive_limit_angle" getter="get_primary_positive_limit_angle">
 			The limit angle of positive side of the primary rotation when [member symmetry_limitation] is [code]false[/code].
 		</member>
-		<member name="primary_rotation_axis" type="int" setter="set_primary_rotation_axis" getter="get_primary_rotation_axis" enum="Vector3.Axis" default="1">
-			The axis of the first rotation. This [SkeletonModifier3D] works by compositing the rotation by Euler angles to prevent to rotate the [member forward_axis].
+		<member name="primary_rotation_axis" type="int" setter="set_primary_rotation_axis" getter="get_primary_rotation_axis" default="1">
+			The index of the axis of the first rotation. This [SkeletonModifier3D] works by compositing the rotation by Euler angles to prevent to rotate the [member forward_axis] (see [constant Vector3.AXIS_X], [constant Vector3.AXIS_Y], and [constant Vector3.AXIS_Z]).
 		</member>
 		<member name="secondary_damp_threshold" type="float" setter="set_secondary_damp_threshold" getter="get_secondary_damp_threshold">
 			The threshold to start damping for [member secondary_limit_angle].

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -755,7 +755,7 @@
 		<method name="generic_6dof_joint_get_flag" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
-			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<param index="1" name="axis" type="int" />
 			<param index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
 			<description>
 				Returns the value of a generic 6DOF joint flag. See [enum G6DOFJointAxisFlag] for the list of available flags.
@@ -764,7 +764,7 @@
 		<method name="generic_6dof_joint_get_param" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
-			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<param index="1" name="axis" type="int" />
 			<param index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
 			<description>
 				Returns the value of a generic 6DOF joint parameter. See [enum G6DOFJointAxisParam] for the list of available parameters.
@@ -773,7 +773,7 @@
 		<method name="generic_6dof_joint_set_flag">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
-			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<param index="1" name="axis" type="int" />
 			<param index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
 			<param index="3" name="enable" type="bool" />
 			<description>
@@ -783,7 +783,7 @@
 		<method name="generic_6dof_joint_set_param">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
-			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<param index="1" name="axis" type="int" />
 			<param index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
 			<param index="3" name="value" type="float" />
 			<description>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -683,7 +683,7 @@
 		<method name="_generic_6dof_joint_get_flag" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
-			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<param index="1" name="axis" type="int" />
 			<param index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
 			<description>
 			</description>
@@ -691,7 +691,7 @@
 		<method name="_generic_6dof_joint_get_param" qualifiers="virtual const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
-			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<param index="1" name="axis" type="int" />
 			<param index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
 			<description>
 			</description>
@@ -699,7 +699,7 @@
 		<method name="_generic_6dof_joint_set_flag" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
-			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<param index="1" name="axis" type="int" />
 			<param index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
 			<param index="3" name="enable" type="bool" />
 			<description>
@@ -708,7 +708,7 @@
 		<method name="_generic_6dof_joint_set_param" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
-			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<param index="1" name="axis" type="int" />
 			<param index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
 			<param index="3" name="value" type="float" />
 			<description>

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -53,8 +53,8 @@
 		<member name="alpha_scissor_threshold" type="float" setter="set_alpha_scissor_threshold" getter="get_alpha_scissor_threshold" default="0.5">
 			Threshold at which the alpha scissor will discard values.
 		</member>
-		<member name="axis" type="int" setter="set_axis" getter="get_axis" enum="Vector3.Axis" default="2">
-			The direction in which the front of the texture faces.
+		<member name="axis" type="int" setter="set_axis" getter="get_axis" default="2">
+			The index of the axis in which the front of the texture faces (see [constant Vector3.AXIS_X], [constant Vector3.AXIS_Y], and [constant Vector3.AXIS_Z]).
 		</member>
 		<member name="billboard" type="int" setter="set_billboard_mode" getter="get_billboard_mode" enum="BaseMaterial3D.BillboardMode" default="0">
 			The billboard mode to use for the sprite. See [enum BaseMaterial3D.BillboardMode] for possible values.

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -122,3 +122,19 @@ GH-98918
 Validate extension JSON: Error: Field 'classes/FileAccess/methods/open_encrypted/arguments': size changed value in new API, from 3 to 4.
 
 Optional argument added to allow setting initialization vector. Compatibility method registered.
+
+
+GH-99341
+--------
+Validate extension JSON: Error: Field 'classes/PhysicsServer3D/methods/generic_6dof_joint_set_param/arguments/1': type changed value in new API, from "enum::Vector3.Axis" to "int".
+Validate extension JSON: Error: Field 'classes/PhysicsServer3D/methods/generic_6dof_joint_get_param/arguments/1': type changed value in new API, from "enum::Vector3.Axis" to "int".
+Validate extension JSON: Error: Field 'classes/PhysicsServer3D/methods/generic_6dof_joint_set_flag/arguments/1': type changed value in new API, from "enum::Vector3.Axis" to "int".
+Validate extension JSON: Error: Field 'classes/PhysicsServer3D/methods/generic_6dof_joint_get_flag/arguments/1': type changed value in new API, from "enum::Vector3.Axis" to "int".
+Validate extension JSON: Error: Field 'classes/PhysicsServer3DExtension/methods/_generic_6dof_joint_set_param/arguments/1': type changed value in new API, from "enum::Vector3.Axis" to "int".
+Validate extension JSON: Error: Field 'classes/PhysicsServer3DExtension/methods/_generic_6dof_joint_get_param/arguments/1': type changed value in new API, from "enum::Vector3.Axis" to "int".
+Validate extension JSON: Error: Field 'classes/PhysicsServer3DExtension/methods/_generic_6dof_joint_set_flag/arguments/1': type changed value in new API, from "enum::Vector3.Axis" to "int".
+Validate extension JSON: Error: Field 'classes/PhysicsServer3DExtension/methods/_generic_6dof_joint_get_flag/arguments/1': type changed value in new API, from "enum::Vector3.Axis" to "int".
+Validate extension JSON: Error: Field 'classes/SpriteBase3D/methods/set_axis/arguments/0': type changed value in new API, from "enum::Vector3.Axis" to "int".
+Validate extension JSON: Error: Field 'classes/SpriteBase3D/methods/get_axis/return_value': type changed value in new API, from "enum::Vector3.Axis" to "int".
+
+Fix use of non-existent Vector3.Axis enum type in built-in methods and members

--- a/modules/godot_physics_3d/godot_physics_server_3d.compat.inc
+++ b/modules/godot_physics_3d/godot_physics_server_3d.compat.inc
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  godot_physics_server_3d.compat.inc                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+#include "godot_physics_server_3d.h"
+
+void GodotPhysicsServer3D::_generic_6dof_joint_set_param_bind_compat_99341(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisParam p_param, real_t p_value) {
+	GodotPhysicsServer3D::generic_6dof_joint_set_param(p_joint, (int)p_axis, p_param, p_value);
+}
+
+real_t GodotPhysicsServer3D::_generic_6dof_joint_get_param_bind_compat_99341(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisParam p_param) const {
+	return GodotPhysicsServer3D::generic_6dof_joint_get_param(p_joint, (int)p_axis, p_param);
+}
+
+void GodotPhysicsServer3D::_generic_6dof_joint_set_flag_bind_compat_99341(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag, bool p_enable) {
+	GodotPhysicsServer3D::generic_6dof_joint_set_flag(p_joint, (int)p_axis, p_flag, p_enable);
+}
+
+bool GodotPhysicsServer3D::_generic_6dof_joint_get_flag_bind_compat_99341(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag) const {
+	return GodotPhysicsServer3D::generic_6dof_joint_get_flag(p_joint, (int)p_axis, p_flag);
+}
+
+#endif //DISABLE_DEPRECATED

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "godot_physics_server_3d.h"
+#include "godot_physics_server_3d.compat.inc"
 
 #include "godot_body_direct_state_3d.h"
 #include "godot_broad_phase_3d_bvh.h"
@@ -1521,7 +1522,7 @@ void GodotPhysicsServer3D::joint_make_generic_6dof(RID p_joint, RID p_body_A, co
 	memdelete(prev_joint);
 }
 
-void GodotPhysicsServer3D::generic_6dof_joint_set_param(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisParam p_param, real_t p_value) {
+void GodotPhysicsServer3D::generic_6dof_joint_set_param(RID p_joint, int p_axis, G6DOFJointAxisParam p_param, real_t p_value) {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF);
@@ -1529,7 +1530,7 @@ void GodotPhysicsServer3D::generic_6dof_joint_set_param(RID p_joint, Vector3::Ax
 	generic_6dof_joint->set_param(p_axis, p_param, p_value);
 }
 
-real_t GodotPhysicsServer3D::generic_6dof_joint_get_param(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisParam p_param) const {
+real_t GodotPhysicsServer3D::generic_6dof_joint_get_param(RID p_joint, int p_axis, G6DOFJointAxisParam p_param) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, 0);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_6DOF, 0);
@@ -1537,7 +1538,7 @@ real_t GodotPhysicsServer3D::generic_6dof_joint_get_param(RID p_joint, Vector3::
 	return generic_6dof_joint->get_param(p_axis, p_param);
 }
 
-void GodotPhysicsServer3D::generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag, bool p_enable) {
+void GodotPhysicsServer3D::generic_6dof_joint_set_flag(RID p_joint, int p_axis, G6DOFJointAxisFlag p_flag, bool p_enable) {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);
 	ERR_FAIL_COND(joint->get_type() != JOINT_TYPE_6DOF);
@@ -1545,7 +1546,7 @@ void GodotPhysicsServer3D::generic_6dof_joint_set_flag(RID p_joint, Vector3::Axi
 	generic_6dof_joint->set_flag(p_axis, p_flag, p_enable);
 }
 
-bool GodotPhysicsServer3D::generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis p_axis, G6DOFJointAxisFlag p_flag) const {
+bool GodotPhysicsServer3D::generic_6dof_joint_get_flag(RID p_joint, int p_axis, G6DOFJointAxisFlag p_flag) const {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL_V(joint, false);
 	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_6DOF, false);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -348,11 +348,20 @@ public:
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override; //reference frame is A
 
-	virtual void generic_6dof_joint_set_param(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param, real_t p_value) override;
-	virtual real_t generic_6dof_joint_get_param(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param) const override;
+	virtual void generic_6dof_joint_set_param(RID p_joint, int, G6DOFJointAxisParam p_param, real_t p_value) override;
+	virtual real_t generic_6dof_joint_get_param(RID p_joint, int, G6DOFJointAxisParam p_param) const override;
 
-	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override;
-	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override;
+	virtual void generic_6dof_joint_set_flag(RID p_joint, int, G6DOFJointAxisFlag p_flag, bool p_enable) override;
+	virtual bool generic_6dof_joint_get_flag(RID p_joint, int, G6DOFJointAxisFlag p_flag) const override;
+
+#ifndef DISABLE_DEPRECATED
+	virtual void _generic_6dof_joint_set_param_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param, real_t p_value) override;
+	virtual real_t _generic_6dof_joint_get_param_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param) const override;
+
+	virtual void _generic_6dof_joint_set_flag_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override;
+	virtual bool _generic_6dof_joint_get_flag_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override;
+
+#endif //DISABLE_DEPRECATED
 
 	virtual JointType joint_get_type(RID p_joint) const override;
 

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
@@ -444,7 +444,7 @@ void GodotGeneric6DOFJoint3D::calcAnchorPos() {
 	m_AnchorPos = pA * weight + pB * (real_t(1.0) - weight);
 }
 
-void GodotGeneric6DOFJoint3D::set_param(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param, real_t p_value) {
+void GodotGeneric6DOFJoint3D::set_param(int p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param, real_t p_value) {
 	ERR_FAIL_INDEX(p_axis, 3);
 	switch (p_param) {
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_LOWER_LIMIT: {
@@ -531,7 +531,7 @@ void GodotGeneric6DOFJoint3D::set_param(Vector3::Axis p_axis, PhysicsServer3D::G
 	}
 }
 
-real_t GodotGeneric6DOFJoint3D::get_param(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param) const {
+real_t GodotGeneric6DOFJoint3D::get_param(int p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param) const {
 	ERR_FAIL_INDEX_V(p_axis, 3, 0);
 	switch (p_param) {
 		case PhysicsServer3D::G6DOF_JOINT_LINEAR_LOWER_LIMIT: {
@@ -619,7 +619,7 @@ real_t GodotGeneric6DOFJoint3D::get_param(Vector3::Axis p_axis, PhysicsServer3D:
 	return 0;
 }
 
-void GodotGeneric6DOFJoint3D::set_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_value) {
+void GodotGeneric6DOFJoint3D::set_flag(int p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_value) {
 	ERR_FAIL_INDEX(p_axis, 3);
 
 	switch (p_flag) {
@@ -646,7 +646,7 @@ void GodotGeneric6DOFJoint3D::set_flag(Vector3::Axis p_axis, PhysicsServer3D::G6
 	}
 }
 
-bool GodotGeneric6DOFJoint3D::get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const {
+bool GodotGeneric6DOFJoint3D::get_flag(int p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const {
 	ERR_FAIL_INDEX_V(p_axis, 3, false);
 	switch (p_flag) {
 		case PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT: {

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.h
@@ -312,11 +312,11 @@ public:
 
 	virtual void calcAnchorPos(); // overridable
 
-	void set_param(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param, real_t p_value);
-	real_t get_param(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param) const;
+	void set_param(int p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param, real_t p_value);
+	real_t get_param(int p_axis, PhysicsServer3D::G6DOFJointAxisParam p_param) const;
 
-	void set_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_value);
-	bool get_flag(Vector3::Axis p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const;
+	void set_flag(int p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag, bool p_value);
+	bool get_flag(int p_axis, PhysicsServer3D::G6DOFJointAxisFlag p_flag) const;
 };
 
 #endif // GODOT_GENERIC_6DOF_JOINT_3D_H

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -92,12 +92,12 @@ LookAtModifier3D::BoneAxis LookAtModifier3D::get_forward_axis() const {
 	return forward_axis;
 }
 
-void LookAtModifier3D::set_primary_rotation_axis(Vector3::Axis p_axis) {
+void LookAtModifier3D::set_primary_rotation_axis(int p_axis) {
 	primary_rotation_axis = p_axis;
 	update_configuration_warnings();
 }
 
-Vector3::Axis LookAtModifier3D::get_primary_rotation_axis() const {
+int LookAtModifier3D::get_primary_rotation_axis() const {
 	return primary_rotation_axis;
 }
 
@@ -542,7 +542,7 @@ void LookAtModifier3D::_process_modification() {
 	prev_q = destination;
 }
 
-bool LookAtModifier3D::is_intersecting_axis(const Vector3 &p_prev, const Vector3 &p_current, Vector3::Axis p_flipping_axis, Vector3::Axis p_check_axis, bool p_check_plane) const {
+bool LookAtModifier3D::is_intersecting_axis(const Vector3 &p_prev, const Vector3 &p_current, int p_flipping_axis, int p_check_axis, bool p_check_plane) const {
 	// Prevent that the angular velocity does not become too large.
 	// Check that is p_flipping_axis flipped nearby p_check_axis (close than origin_safe_margin) or not. If p_check_plane is true, check two axes of crossed plane.
 	if (p_check_plane) {
@@ -606,7 +606,7 @@ Vector3 LookAtModifier3D::get_vector_from_bone_axis(const LookAtModifier3D::Bone
 	return ret;
 }
 
-Vector3 LookAtModifier3D::get_vector_from_axis(const Vector3::Axis &p_axis) const {
+Vector3 LookAtModifier3D::get_vector_from_axis(const int &p_axis) const {
 	Vector3 ret;
 	switch (p_axis) {
 		case Vector3::AXIS_X: {
@@ -641,7 +641,7 @@ Vector3::Axis LookAtModifier3D::get_axis_from_bone_axis(BoneAxis p_axis) const {
 	return ret;
 }
 
-Vector2 LookAtModifier3D::get_projection_vector(const Vector3 &p_vector, Vector3::Axis p_axis) const {
+Vector2 LookAtModifier3D::get_projection_vector(const Vector3 &p_vector, int p_axis) const {
 	// NOTE: axis is swapped between 2D and 3D.
 	Vector2 ret;
 	switch (p_axis) {

--- a/scene/3d/look_at_modifier_3d.h
+++ b/scene/3d/look_at_modifier_3d.h
@@ -59,7 +59,7 @@ private:
 	Vector3 forward_vector;
 	Vector3 forward_vector_nrm;
 	BoneAxis forward_axis = BONE_AXIS_PLUS_Z;
-	Vector3::Axis primary_rotation_axis = Vector3::AXIS_Y;
+	int primary_rotation_axis = Vector3::AXIS_Y;
 	Vector3::Axis secondary_rotation_axis = Vector3::AXIS_X;
 	bool use_secondary_rotation = true;
 
@@ -104,12 +104,12 @@ private:
 
 	Vector3 get_basis_vector_from_bone_axis(const Basis &p_basis, BoneAxis p_axis) const;
 	Vector3 get_vector_from_bone_axis(const BoneAxis &p_axis) const;
-	Vector3 get_vector_from_axis(const Vector3::Axis &p_axis) const;
+	Vector3 get_vector_from_axis(const int &p_axis) const;
 	Vector3::Axis get_axis_from_bone_axis(BoneAxis p_axis) const;
-	Vector2 get_projection_vector(const Vector3 &p_vector, Vector3::Axis p_axis) const;
+	Vector2 get_projection_vector(const Vector3 &p_vector, int p_axis) const;
 	float remap_damped(float p_from, float p_to, float p_damp_threshold, float p_value) const;
 	double get_bspline_y(const Vector2 &p_from, const Vector2 &p_control, const Vector2 &p_to, double p_x) const;
-	bool is_intersecting_axis(const Vector3 &p_prev, const Vector3 &p_current, Vector3::Axis p_flipping_axis, Vector3::Axis p_check_axis, bool p_check_plane = false) const;
+	bool is_intersecting_axis(const Vector3 &p_prev, const Vector3 &p_current, int p_flipping_axis, int p_check_axis, bool p_check_plane = false) const;
 
 	Transform3D look_at_with_axes(const Transform3D &p_rest);
 	void init_transition();
@@ -128,8 +128,8 @@ public:
 
 	void set_forward_axis(BoneAxis p_axis);
 	BoneAxis get_forward_axis() const;
-	void set_primary_rotation_axis(Vector3::Axis p_axis);
-	Vector3::Axis get_primary_rotation_axis() const;
+	void set_primary_rotation_axis(int p_axis);
+	int get_primary_rotation_axis() const;
 	void set_use_secondary_rotation(bool p_enabled);
 	bool is_using_secondary_rotation() const;
 

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -998,27 +998,27 @@ void PhysicalBone3D::_reload_joint() {
 			PhysicsServer3D::get_singleton()->joint_make_generic_6dof(joint, body_a->get_rid(), local_a, get_rid(), joint_offset);
 			const SixDOFJointData *g6dofjd(static_cast<const SixDOFJointData *>(joint_data));
 			for (int axis = 0; axis < 3; ++axis) {
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT, g6dofjd->axis_data[axis].linear_limit_enabled);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_LINEAR_UPPER_LIMIT, g6dofjd->axis_data[axis].linear_limit_upper);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_LINEAR_LOWER_LIMIT, g6dofjd->axis_data[axis].linear_limit_lower);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SOFTNESS, g6dofjd->axis_data[axis].linear_limit_softness);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING, g6dofjd->axis_data[axis].linear_spring_enabled);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_STIFFNESS, g6dofjd->axis_data[axis].linear_spring_stiffness);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_DAMPING, g6dofjd->axis_data[axis].linear_spring_damping);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT, g6dofjd->axis_data[axis].linear_equilibrium_point);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_LINEAR_RESTITUTION, g6dofjd->axis_data[axis].linear_restitution);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_LINEAR_DAMPING, g6dofjd->axis_data[axis].linear_damping);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_LIMIT, g6dofjd->axis_data[axis].angular_limit_enabled);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_ANGULAR_UPPER_LIMIT, g6dofjd->axis_data[axis].angular_limit_upper);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_ANGULAR_LOWER_LIMIT, g6dofjd->axis_data[axis].angular_limit_lower);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_ANGULAR_LIMIT_SOFTNESS, g6dofjd->axis_data[axis].angular_limit_softness);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_ANGULAR_RESTITUTION, g6dofjd->axis_data[axis].angular_restitution);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_ANGULAR_DAMPING, g6dofjd->axis_data[axis].angular_damping);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_ANGULAR_ERP, g6dofjd->axis_data[axis].erp);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING, g6dofjd->axis_data[axis].angular_spring_enabled);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS, g6dofjd->axis_data[axis].angular_spring_stiffness);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_DAMPING, g6dofjd->axis_data[axis].angular_spring_damping);
-				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, static_cast<Vector3::Axis>(axis), PhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT, g6dofjd->axis_data[axis].angular_equilibrium_point);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(joint, axis, PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT, g6dofjd->axis_data[axis].linear_limit_enabled);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_LINEAR_UPPER_LIMIT, g6dofjd->axis_data[axis].linear_limit_upper);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_LINEAR_LOWER_LIMIT, g6dofjd->axis_data[axis].linear_limit_lower);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_LINEAR_LIMIT_SOFTNESS, g6dofjd->axis_data[axis].linear_limit_softness);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(joint, axis, PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_LINEAR_SPRING, g6dofjd->axis_data[axis].linear_spring_enabled);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_STIFFNESS, g6dofjd->axis_data[axis].linear_spring_stiffness);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_DAMPING, g6dofjd->axis_data[axis].linear_spring_damping);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_LINEAR_SPRING_EQUILIBRIUM_POINT, g6dofjd->axis_data[axis].linear_equilibrium_point);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_LINEAR_RESTITUTION, g6dofjd->axis_data[axis].linear_restitution);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_LINEAR_DAMPING, g6dofjd->axis_data[axis].linear_damping);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(joint, axis, PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_LIMIT, g6dofjd->axis_data[axis].angular_limit_enabled);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_UPPER_LIMIT, g6dofjd->axis_data[axis].angular_limit_upper);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_LOWER_LIMIT, g6dofjd->axis_data[axis].angular_limit_lower);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_LIMIT_SOFTNESS, g6dofjd->axis_data[axis].angular_limit_softness);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_RESTITUTION, g6dofjd->axis_data[axis].angular_restitution);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_DAMPING, g6dofjd->axis_data[axis].angular_damping);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_ERP, g6dofjd->axis_data[axis].erp);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_flag(joint, axis, PhysicsServer3D::G6DOF_JOINT_FLAG_ENABLE_ANGULAR_SPRING, g6dofjd->axis_data[axis].angular_spring_enabled);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_STIFFNESS, g6dofjd->axis_data[axis].angular_spring_stiffness);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_DAMPING, g6dofjd->axis_data[axis].angular_spring_damping);
+				PhysicsServer3D::get_singleton()->generic_6dof_joint_set_param(joint, axis, PhysicsServer3D::G6DOF_JOINT_ANGULAR_SPRING_EQUILIBRIUM_POINT, g6dofjd->axis_data[axis].angular_equilibrium_point);
 			}
 
 		} break;

--- a/scene/3d/sprite_3d.compat.inc
+++ b/scene/3d/sprite_3d.compat.inc
@@ -1,0 +1,47 @@
+/**************************************************************************/
+/*  sprite_3d.compat.inc                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+#include "sprite_3d.h"
+
+void SpriteBase3D::_set_axis_bind_compat_99341(Vector3::Axis p_axis) {
+	set_axis((int)p_axis);
+}
+
+Vector3::Axis SpriteBase3D::_get_axis_bind_compat_99341() const {
+	return (Vector3::Axis)get_axis();
+}
+
+void SpriteBase3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_axis", "axis"), &SpriteBase3D::_set_axis_bind_compat_99341);
+	ClassDB::bind_compatibility_method(D_METHOD("get_axis"), &SpriteBase3D::_get_axis_bind_compat_99341);
+}
+
+#endif //DISABLE_DEPRECATED

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "sprite_3d.h"
+#include "sprite_3d.compat.inc"
 
 #include "scene/resources/atlas_texture.h"
 
@@ -378,7 +379,7 @@ real_t SpriteBase3D::get_pixel_size() const {
 	return pixel_size;
 }
 
-void SpriteBase3D::set_axis(Vector3::Axis p_axis) {
+void SpriteBase3D::set_axis(int p_axis) {
 	ERR_FAIL_INDEX(p_axis, 3);
 
 	if (axis == p_axis) {
@@ -389,7 +390,7 @@ void SpriteBase3D::set_axis(Vector3::Axis p_axis) {
 	_queue_redraw();
 }
 
-Vector3::Axis SpriteBase3D::get_axis() const {
+int SpriteBase3D::get_axis() const {
 	return axis;
 }
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -75,7 +75,7 @@ private:
 	Color modulate = Color(1, 1, 1, 1);
 	int render_priority = 0;
 
-	Vector3::Axis axis = Vector3::AXIS_Z;
+	int axis = Vector3::AXIS_Z;
 	real_t pixel_size = 0.01;
 	AABB aabb;
 
@@ -102,6 +102,9 @@ protected:
 	Color _get_color_accum();
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+#endif //DISABLE_DEPRECATED
 	virtual void _draw() = 0;
 	void draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect, Rect2 p_src_rect);
 	_FORCE_INLINE_ void set_aabb(const AABB &p_aabb) { aabb = p_aabb; }
@@ -141,8 +144,13 @@ public:
 	void set_pixel_size(real_t p_amount);
 	real_t get_pixel_size() const;
 
-	void set_axis(Vector3::Axis p_axis);
-	Vector3::Axis get_axis() const;
+	void set_axis(int p_axis);
+	int get_axis() const;
+
+#ifndef DISABLE_DEPRECATED
+	void _set_axis_bind_compat_99341(Vector3::Axis p_axis);
+	Vector3::Axis _get_axis_bind_compat_99341() const;
+#endif //DISABLE_DEPRECATED
 
 	void set_draw_flag(DrawFlags p_flag, bool p_enable);
 	bool get_draw_flag(DrawFlags p_flag) const;

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -504,11 +504,19 @@ public:
 
 	EXBIND5(joint_make_generic_6dof, RID, RID, const Transform3D &, RID, const Transform3D &)
 
-	EXBIND4(generic_6dof_joint_set_param, RID, Vector3::Axis, G6DOFJointAxisParam, real_t)
-	EXBIND3RC(real_t, generic_6dof_joint_get_param, RID, Vector3::Axis, G6DOFJointAxisParam)
+	EXBIND4(generic_6dof_joint_set_param, RID, int, G6DOFJointAxisParam, real_t)
+	EXBIND3RC(real_t, generic_6dof_joint_get_param, RID, int, G6DOFJointAxisParam)
 
-	EXBIND4(generic_6dof_joint_set_flag, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
-	EXBIND3RC(bool, generic_6dof_joint_get_flag, RID, Vector3::Axis, G6DOFJointAxisFlag)
+	EXBIND4(generic_6dof_joint_set_flag, RID, int, G6DOFJointAxisFlag, bool)
+	EXBIND3RC(bool, generic_6dof_joint_get_flag, RID, int, G6DOFJointAxisFlag)
+
+#ifndef DISABLE_DEPRECATED
+	EXBIND4(_generic_6dof_joint_set_param_bind_compat_99341, RID, Vector3::Axis, G6DOFJointAxisParam, real_t)
+	EXBIND3RC(real_t, _generic_6dof_joint_get_param_bind_compat_99341, RID, Vector3::Axis, G6DOFJointAxisParam)
+
+	EXBIND4(_generic_6dof_joint_set_flag_bind_compat_99341, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
+	EXBIND3RC(bool, _generic_6dof_joint_get_flag_bind_compat_99341, RID, Vector3::Axis, G6DOFJointAxisFlag)
+#endif //DISABLE_DEPRECATED
 
 	EXBIND1RC(JointType, joint_get_type, RID)
 

--- a/servers/physics_server_3d.compat.inc
+++ b/servers/physics_server_3d.compat.inc
@@ -1,0 +1,42 @@
+/**************************************************************************/
+/*  physics_server_3d.compat.inc                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "physics_server_3d.h"
+
+void PhysicsServer3D::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("generic_6dof_joint_set_param", "joint", "axis", "param", "value"), &PhysicsServer3D::_generic_6dof_joint_set_param_bind_compat_99341);
+	ClassDB::bind_compatibility_method(D_METHOD("generic_6dof_joint_get_param", "joint", "axis", "param"), &PhysicsServer3D::_generic_6dof_joint_get_param_bind_compat_99341);
+	ClassDB::bind_compatibility_method(D_METHOD("generic_6dof_joint_set_flag", "joint", "axis", "flag", "enable"), &PhysicsServer3D::_generic_6dof_joint_set_flag_bind_compat_99341);
+	ClassDB::bind_compatibility_method(D_METHOD("generic_6dof_joint_get_flag", "joint", "axis", "flag"), &PhysicsServer3D::_generic_6dof_joint_get_flag_bind_compat_99341);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -31,6 +31,7 @@
 #ifndef _3D_DISABLED
 
 #include "physics_server_3d.h"
+#include "physics_server_3d.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/string/print_string.h"

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -240,6 +240,9 @@ class PhysicsServer3D : public Object {
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	static void _bind_compatibility_methods();
+#endif //DISABLE_DEPRECATED
 public:
 	static PhysicsServer3D *get_singleton();
 
@@ -777,11 +780,20 @@ public:
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) = 0; //reference frame is A
 
-	virtual void generic_6dof_joint_set_param(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param, real_t p_value) = 0;
-	virtual real_t generic_6dof_joint_get_param(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param) const = 0;
+	virtual void generic_6dof_joint_set_param(RID p_joint, int, G6DOFJointAxisParam p_param, real_t p_value) = 0;
+	virtual real_t generic_6dof_joint_get_param(RID p_joint, int, G6DOFJointAxisParam p_param) const = 0;
 
-	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) = 0;
-	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const = 0;
+	virtual void generic_6dof_joint_set_flag(RID p_joint, int, G6DOFJointAxisFlag p_flag, bool p_enable) = 0;
+	virtual bool generic_6dof_joint_get_flag(RID p_joint, int, G6DOFJointAxisFlag p_flag) const = 0;
+
+#ifndef DISABLE_DEPRECATED
+	virtual void _generic_6dof_joint_set_param_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param, real_t p_value) = 0;
+	virtual real_t _generic_6dof_joint_get_param_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param) const = 0;
+
+	virtual void _generic_6dof_joint_set_flag_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) = 0;
+	virtual bool _generic_6dof_joint_get_flag_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const = 0;
+
+#endif //DISABLE_DEPRECATED
 
 	/* QUERY API */
 

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -404,11 +404,20 @@ public:
 
 	virtual void joint_make_generic_6dof(RID p_joint, RID p_body_A, const Transform3D &p_local_frame_A, RID p_body_B, const Transform3D &p_local_frame_B) override {}
 
-	virtual void generic_6dof_joint_set_param(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param, real_t p_value) override {}
-	virtual real_t generic_6dof_joint_get_param(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param) const override { return 0; }
+	virtual void generic_6dof_joint_set_param(RID p_joint, int, G6DOFJointAxisParam p_param, real_t p_value) override {}
+	virtual real_t generic_6dof_joint_get_param(RID p_joint, int, G6DOFJointAxisParam p_param) const override { return 0; }
 
-	virtual void generic_6dof_joint_set_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override {}
-	virtual bool generic_6dof_joint_get_flag(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override { return false; }
+	virtual void generic_6dof_joint_set_flag(RID p_joint, int, G6DOFJointAxisFlag p_flag, bool p_enable) override {}
+	virtual bool generic_6dof_joint_get_flag(RID p_joint, int, G6DOFJointAxisFlag p_flag) const override { return false; }
+
+#ifndef DISABLE_DEPRECATED
+	virtual void _generic_6dof_joint_set_param_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param, real_t p_value) override {}
+	virtual real_t _generic_6dof_joint_get_param_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisParam p_param) const override { return 0; }
+
+	virtual void _generic_6dof_joint_set_flag_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag, bool p_enable) override {}
+	virtual bool _generic_6dof_joint_get_flag_bind_compat_99341(RID p_joint, Vector3::Axis, G6DOFJointAxisFlag p_flag) const override { return false; }
+
+#endif //DISABLE_DEPRECATED
 
 	/* MISC */
 

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -363,11 +363,20 @@ public:
 
 	FUNC5(joint_make_generic_6dof, RID, RID, const Transform3D &, RID, const Transform3D &)
 
-	FUNC4(generic_6dof_joint_set_param, RID, Vector3::Axis, G6DOFJointAxisParam, real_t)
-	FUNC3RC(real_t, generic_6dof_joint_get_param, RID, Vector3::Axis, G6DOFJointAxisParam)
+	FUNC4(generic_6dof_joint_set_param, RID, int, G6DOFJointAxisParam, real_t)
+	FUNC3RC(real_t, generic_6dof_joint_get_param, RID, int, G6DOFJointAxisParam)
 
-	FUNC4(generic_6dof_joint_set_flag, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
-	FUNC3RC(bool, generic_6dof_joint_get_flag, RID, Vector3::Axis, G6DOFJointAxisFlag)
+	FUNC4(generic_6dof_joint_set_flag, RID, int, G6DOFJointAxisFlag, bool)
+	FUNC3RC(bool, generic_6dof_joint_get_flag, RID, int, G6DOFJointAxisFlag)
+
+#ifndef DISABLE_DEPRECATED
+	FUNC4(_generic_6dof_joint_set_param_bind_compat_99341, RID, Vector3::Axis, G6DOFJointAxisParam, real_t)
+	FUNC3RC(real_t, _generic_6dof_joint_get_param_bind_compat_99341, RID, Vector3::Axis, G6DOFJointAxisParam)
+
+	FUNC4(_generic_6dof_joint_set_flag_bind_compat_99341, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
+	FUNC3RC(bool, _generic_6dof_joint_get_flag_bind_compat_99341, RID, Vector3::Axis, G6DOFJointAxisFlag)
+
+#endif //DISABLE_DEPRECATED
 
 	FUNC1RC(JointType, joint_get_type, RID);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fixes #99309