### PR TITLE
Deprecate `PrimitiveMesh.custom_aabb` and `ArrayMesh.custom_aabb`

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -202,7 +202,7 @@
 		<member name="blend_shape_mode" type="int" setter="set_blend_shape_mode" getter="get_blend_shape_mode" enum="Mesh.BlendShapeMode" default="1">
 			Sets the blend shape mode to one of [enum Mesh.BlendShapeMode].
 		</member>
-		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
+		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)" deprecated="Use [member GeometryInstance3D.custom_aabb] instead.">
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
 		<member name="shadow_mesh" type="ArrayMesh" setter="set_shadow_mesh" getter="get_shadow_mesh">

--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -45,7 +45,7 @@
 		<member name="add_uv2" type="bool" setter="set_add_uv2" getter="get_add_uv2" default="false">
 			If set, generates UV2 UV coordinates applying a padding using the [member uv2_padding] setting. UV2 is needed for lightmapping.
 		</member>
-		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
+		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)" deprecated="Use [member GeometryInstance3D.custom_aabb] instead.">
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
 		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -406,7 +406,12 @@ void MeshInstance3D::_mesh_changed() {
 			RS::get_singleton()->instance_set_surface_override_material(get_instance(), surface_index, surface_override_materials[surface_index]->get_rid());
 		}
 	}
-
+#ifndef DISABLE_DEPRECATED
+	// Workaround for also setting the GeometryInstance3D.custom_aabb when setting the mesh resource custom_aabb
+	if (has_method("set_custom_aabb") && mesh->has_method("get_custom_aabb")) {
+		call("set_custom_aabb", mesh->call("get_custom_aabb"));
+	}
+#endif
 	update_gizmos();
 }
 

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -237,8 +237,10 @@ void PrimitiveMesh::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_mesh_arrays"), &PrimitiveMesh::get_mesh_arrays);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &PrimitiveMesh::set_custom_aabb);
 	ClassDB::bind_method(D_METHOD("get_custom_aabb"), &PrimitiveMesh::get_custom_aabb);
+#endif
 
 	ClassDB::bind_method(D_METHOD("set_flip_faces", "flip_faces"), &PrimitiveMesh::set_flip_faces);
 	ClassDB::bind_method(D_METHOD("get_flip_faces"), &PrimitiveMesh::get_flip_faces);
@@ -252,7 +254,9 @@ void PrimitiveMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("request_update"), &PrimitiveMesh::request_update);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial"), "set_material", "get_material");
+#ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::AABB, "custom_aabb", PROPERTY_HINT_NONE, "suffix:m"), "set_custom_aabb", "get_custom_aabb");
+#endif
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_faces"), "set_flip_faces", "get_flip_faces");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "add_uv2"), "set_add_uv2", "get_add_uv2");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "uv2_padding", PROPERTY_HINT_RANGE, "0,10,0.01,or_greater"), "set_uv2_padding", "get_uv2_padding");
@@ -278,15 +282,19 @@ Array PrimitiveMesh::get_mesh_arrays() const {
 	return surface_get_arrays(0);
 }
 
+#ifndef DISABLE_DEPRECATED
 void PrimitiveMesh::set_custom_aabb(const AABB &p_custom) {
 	custom_aabb = p_custom;
 	RS::get_singleton()->mesh_set_custom_aabb(mesh, custom_aabb);
+	WARN_DEPRECATED_MSG("Use GeometryInstance3D.set_custom_aabb instead.");
 	emit_changed();
 }
 
 AABB PrimitiveMesh::get_custom_aabb() const {
+	WARN_DEPRECATED_MSG("Use GeometryInstance3D.set_custom_aabb instead.");
 	return custom_aabb;
 }
+#endif
 
 void PrimitiveMesh::set_flip_faces(bool p_enable) {
 	flip_faces = p_enable;

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -48,7 +48,9 @@ class PrimitiveMesh : public Mesh {
 private:
 	RID mesh;
 	mutable AABB aabb;
+#ifndef DISABLE_DEPRECATED
 	AABB custom_aabb;
+#endif
 
 	mutable int array_len = 0;
 	mutable int index_array_len = 0;
@@ -103,8 +105,10 @@ public:
 
 	Array get_mesh_arrays() const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_custom_aabb(const AABB &p_custom);
 	AABB get_custom_aabb() const;
+#endif
 
 	void set_flip_faces(bool p_enable);
 	bool get_flip_faces() const;

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1731,7 +1731,9 @@ void ArrayMesh::reset_state() {
 
 	aabb = AABB();
 	blend_shape_mode = BLEND_SHAPE_MODE_RELATIVE;
+#ifndef DISABLE_DEPRECATED
 	custom_aabb = AABB();
+#endif
 }
 
 void ArrayMesh::_get_property_list(List<PropertyInfo> *p_list) const {
@@ -1977,13 +1979,6 @@ void ArrayMesh::surface_update_skin_region(int p_surface, int p_offset, const Ve
 	emit_changed();
 }
 
-void ArrayMesh::surface_set_custom_aabb(int p_idx, const AABB &p_aabb) {
-	ERR_FAIL_INDEX(p_idx, surfaces.size());
-	surfaces.write[p_idx].aabb = p_aabb;
-	// set custom aabb too?
-	emit_changed();
-}
-
 Ref<Material> ArrayMesh::surface_get_material(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), Ref<Material>());
 	return surfaces[p_idx].material;
@@ -2007,16 +2002,20 @@ void ArrayMesh::clear_surfaces() {
 	aabb = AABB();
 }
 
+#ifndef DISABLE_DEPRECATED
 void ArrayMesh::set_custom_aabb(const AABB &p_custom) {
 	_create_if_empty();
 	custom_aabb = p_custom;
 	RS::get_singleton()->mesh_set_custom_aabb(mesh, custom_aabb);
+	WARN_DEPRECATED_MSG("Use GeometryInstance3D.set_custom_aabb instead.");
 	emit_changed();
 }
 
 AABB ArrayMesh::get_custom_aabb() const {
+	WARN_DEPRECATED_MSG("Use GeometryInstance3D.get_custom_aabb instead.");
 	return custom_aabb;
 }
+#endif
 
 void ArrayMesh::regen_normal_maps() {
 	if (surfaces.size() == 0) {
@@ -2295,9 +2294,10 @@ void ArrayMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("lightmap_unwrap", "transform", "texel_size"), &ArrayMesh::lightmap_unwrap);
 	ClassDB::set_method_flags(get_class_static(), _scs_create("lightmap_unwrap"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &ArrayMesh::generate_triangle_mesh);
-
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &ArrayMesh::set_custom_aabb);
 	ClassDB::bind_method(D_METHOD("get_custom_aabb"), &ArrayMesh::get_custom_aabb);
+#endif
 
 	ClassDB::bind_method(D_METHOD("set_shadow_mesh", "mesh"), &ArrayMesh::set_shadow_mesh);
 	ClassDB::bind_method(D_METHOD("get_shadow_mesh"), &ArrayMesh::get_shadow_mesh);
@@ -2311,7 +2311,9 @@ void ArrayMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "_blend_shape_names", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_blend_shape_names", "_get_blend_shape_names");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "_surfaces", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_surfaces", "_get_surfaces");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "blend_shape_mode", PROPERTY_HINT_ENUM, "Normalized,Relative"), "set_blend_shape_mode", "get_blend_shape_mode");
+#ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::AABB, "custom_aabb", PROPERTY_HINT_NONE, "suffix:m"), "set_custom_aabb", "get_custom_aabb");
+#endif
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shadow_mesh", PROPERTY_HINT_RESOURCE_TYPE, "ArrayMesh"), "set_shadow_mesh", "get_shadow_mesh");
 }
 

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -321,7 +321,9 @@ private:
 	AABB aabb;
 	BlendShapeMode blend_shape_mode = BLEND_SHAPE_MODE_RELATIVE;
 	Vector<StringName> blend_shapes;
+#ifndef DISABLE_DEPRECATED
 	AABB custom_aabb;
+#endif
 
 	_FORCE_INLINE_ void _create_if_empty() const;
 	void _recompute_aabb();
@@ -364,8 +366,6 @@ public:
 
 	void clear_surfaces();
 
-	void surface_set_custom_aabb(int p_idx, const AABB &p_aabb); //only recognized by driver
-
 	int surface_get_array_len(int p_idx) const override;
 	int surface_get_array_index_len(int p_idx) const override;
 	BitField<ArrayFormat> surface_get_format(int p_idx) const override;
@@ -377,9 +377,10 @@ public:
 	int surface_find_by_name(const String &p_name) const;
 	void surface_set_name(int p_idx, const String &p_name);
 	String surface_get_name(int p_idx) const;
-
+#ifndef DISABLE_DEPRECATED
 	void set_custom_aabb(const AABB &p_custom);
 	AABB get_custom_aabb() const;
+#endif
 
 	AABB get_aabb() const override;
 	virtual RID get_rid() const override;


### PR DESCRIPTION
There is a redundancy in the `custom_aabb` property shared by the `PrimitiveMesh, ArrayMesh` resources, and `GeometryInstance3D`.
I don't see the point of having 2 separate properties that do the same thing.
Also, `GeometryInstance3D.custom_aabb` can be visible because of this https://github.com/godotengine/godot/pull/89538. 
![image](https://github.com/user-attachments/assets/52cadcfc-4a2b-4ab3-a7db-00bbef37308e)

Note: I also did a workaround for the `PrimitiveMesh.custom_aabb` and `ArrayMesh.custom_aabb`: when setting those properties now the `GeometryInstance3D.custom_aabb` will also update (making the `custom_abb` visible)