### PR TITLE
GridMap: Fix hidden gizmo at start-up

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1351,7 +1351,6 @@ GridMapEditor::GridMapEditor() {
 			callable_mp(this, &GridMapEditor::_on_tool_mode_changed).unbind(1));
 	mode_buttons->add_child(select_mode_button);
 	viewport_shortcut_buttons.push_back(select_mode_button);
-	select_mode_button->set_pressed(true);
 
 	erase_mode_button = memnew(Button);
 	erase_mode_button->set_theme_type_variation("FlatButton");
@@ -1724,6 +1723,10 @@ bool GridMapEditorPlugin::handles(Object *p_object) const {
 
 void GridMapEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
+		BaseButton *button = grid_map_editor->mode_buttons_group->get_pressed_button();
+		if (button == nullptr) {
+			grid_map_editor->select_mode_button->set_pressed(true);
+		}
 		grid_map_editor->_on_tool_mode_changed();
 		panel_button->show();
 		EditorNode::get_bottom_panel()->make_item_visible(grid_map_editor);


### PR DESCRIPTION
fix https://github.com/godotengine/godot/issues/99305

I moved the `set_pressed(true)` in the `make_visible()` function. Sorry for the inconvinience, I did not realise that GridmapEditor's constructor was on Godot's start-up.

Also, I don't know if this is ok to test againt `nullptr`? if not we can loop through each button and check `is_pressed`. 