### PR TITLE
Add `Toggle` selection mode to `ItemList`

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -473,6 +473,9 @@
 		<constant name="SELECT_MULTI" value="1" enum="SelectMode">
 			Allows selecting multiple items by holding [kbd]Ctrl[/kbd] or [kbd]Shift[/kbd].
 		</constant>
+		<constant name="SELECT_TOGGLE" value="2" enum="SelectMode">
+			Allows selecting multiple items by toggling them on and off.
+		</constant>
 	</constants>
 	<theme_items>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.65, 0.65, 0.65, 1)">

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -47,7 +47,8 @@ public:
 
 	enum SelectMode {
 		SELECT_SINGLE,
-		SELECT_MULTI
+		SELECT_MULTI,
+		SELECT_TOGGLE,
 	};
 
 private:


### PR DESCRIPTION
I have added a `Toggle` selection to the `ItemList` node. Now you can select an item and deselect it by clicking on it again. 
Closes https://github.com/godotengine/godot-proposals/issues/6371

It emits the signal `multi_selected` when a value changes. I think it would be clearer if it would be renamed to `selection_changed`, for example, but that would be a breaking change. Of course it would be possible to add a new signal, but that would duplicate the functionality.  

What do you think? 
Should I just change the description of `multi_selected` to add the toggle mode?