### PR TITLE
Style: Remove `IgnoreArrays` member-init option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,6 @@ ImplementationFileExtensions: [c, cc, cpp, cxx, m, mm, java]
 HeaderFilterRegex: (core|doc|drivers|editor|main|modules|platform|scene|servers|tests)/
 FormatStyle: file
 CheckOptions:
-  cppcoreguidelines-pro-type-member-init.IgnoreArrays: true
   cppcoreguidelines-pro-type-member-init.UseAssignment: true
   modernize-use-bool-literals.IgnoreMacros: false
   modernize-use-default-member-init.IgnoreMacros: false


### PR DESCRIPTION
`cppcoreguidelines-pro-type-member-init` remains, by far, the most unimplemented ruleset for clang-tidy across the repo. While I do want to address this in batches, I'd rather simultaneously address it with one of its options altered: `IgnoreArrays`. The way the rules are currently setup means that an uninitialized array will *not* give a warning for a constructor/struct, which doesn't feel ideal for the majority of situations. I'd much rather have an array require initialization by default, and selectively *disable* the check via `// NOLINT(cppcoreguidelines-pro-type-member-init)` instead. This *will* create some extra noise in the short-term, though it'd only be for the areas that're already noisy so I don't think that's dealbreaking.

It's entirely possible I'm simply uninformed & the vast majority of arrays are better left well-enough alone, so that's a big reason why I wanted to isolate this change before making any adjustments. I'm likely going to applying this ruleset under the assumption that it will be off, as it'll make catching uninitialized cases significantly easier, but it won't necesarily *have* to be changed as an option as far as the repo itself is concerned.