### PR TITLE
Rewrite some `@GlobalScope` keys in documentation to use `[code]` tags

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2143,49 +2143,49 @@
 			Space key.
 		</constant>
 		<constant name="KEY_EXCLAM" value="33" enum="Key">
-			! key.
+			Exclamation mark ([code]![/code]) key.
 		</constant>
 		<constant name="KEY_QUOTEDBL" value="34" enum="Key">
-			" key.
+			Double quotation mark ([code]"[/code]) key.
 		</constant>
-		<constant name="KEY_NUMBERSIGN" value="35" enum="Key">
-			# key.
+		<constant name="KEY_NUMBERSIGN" value="35" enum="Key" keywords="pound, hash">
+			Number sign or [i]hash[/i] ([code]#[/code]) key.
 		</constant>
 		<constant name="KEY_DOLLAR" value="36" enum="Key">
-			$ key.
+			Dollar sign ([code]$[/code]) key.
 		</constant>
 		<constant name="KEY_PERCENT" value="37" enum="Key">
-			% key.
+			Percent sign ([code]%[/code]) key.
 		</constant>
 		<constant name="KEY_AMPERSAND" value="38" enum="Key">
-			&amp; key.
+			Ampersand ([code]&amp;[/code]) key.
 		</constant>
 		<constant name="KEY_APOSTROPHE" value="39" enum="Key">
-			' key.
+			Apostrophe ([code]'[/code]) key.
 		</constant>
-		<constant name="KEY_PARENLEFT" value="40" enum="Key">
-			( key.
+		<constant name="KEY_PARENLEFT" value="40" enum="Key" keywords="open round bracket">
+			Left parenthesis ([code]([/code]) key.
 		</constant>
-		<constant name="KEY_PARENRIGHT" value="41" enum="Key">
-			) key.
+		<constant name="KEY_PARENRIGHT" value="41" enum="Key" keywords="close round bracket">
+			Right parenthesis ([code])[/code]) key.
 		</constant>
 		<constant name="KEY_ASTERISK" value="42" enum="Key">
-			* key.
+			Asterisk ([code]*[/code]) key.
 		</constant>
 		<constant name="KEY_PLUS" value="43" enum="Key">
-			+ key.
+			Plus ([code]+[/code]) key.
 		</constant>
 		<constant name="KEY_COMMA" value="44" enum="Key">
-			, key.
+			Comma ([code],[/code]) key.
 		</constant>
-		<constant name="KEY_MINUS" value="45" enum="Key">
-			- key.
+		<constant name="KEY_MINUS" value="45" enum="Key" keywords="hyphen">
+			Minus ([code]-[/code]) key.
 		</constant>
-		<constant name="KEY_PERIOD" value="46" enum="Key">
-			. key.
+		<constant name="KEY_PERIOD" value="46" enum="Key" keywords="dot">
+			Period ([code].[/code]) key.
 		</constant>
 		<constant name="KEY_SLASH" value="47" enum="Key">
-			/ key.
+			Slash ([code]/[/code]) key.
 		</constant>
 		<constant name="KEY_0" value="48" enum="Key">
 			Number 0 key.
@@ -2218,25 +2218,25 @@
 			Number 9 key.
 		</constant>
 		<constant name="KEY_COLON" value="58" enum="Key">
-			: key.
+			Colon ([code]:[/code]) key.
 		</constant>
 		<constant name="KEY_SEMICOLON" value="59" enum="Key">
-			; key.
+			Semicolon ([code];[/code]) key.
 		</constant>
 		<constant name="KEY_LESS" value="60" enum="Key">
-			&lt; key.
+			Less-than sign ([code]&lt;[/code]) key.
 		</constant>
 		<constant name="KEY_EQUAL" value="61" enum="Key">
-			= key.
+			Equal sign ([code]=[/code]) key.
 		</constant>
 		<constant name="KEY_GREATER" value="62" enum="Key">
-			&gt; key.
+			Greater-than sign ([code]&gt;[/code]) key.
 		</constant>
 		<constant name="KEY_QUESTION" value="63" enum="Key">
-			? key.
+			Question mark ([code]?[/code]) key.
 		</constant>
-		<constant name="KEY_AT" value="64" enum="Key">
-			@ key.
+		<constant name="KEY_AT" value="64" enum="Key" keywords="commercial at">
+			At sign ([code]@[/code]) key.
 		</constant>
 		<constant name="KEY_A" value="65" enum="Key">
 			A key.
@@ -2316,41 +2316,41 @@
 		<constant name="KEY_Z" value="90" enum="Key">
 			Z key.
 		</constant>
-		<constant name="KEY_BRACKETLEFT" value="91" enum="Key">
-			[ key.
+		<constant name="KEY_BRACKETLEFT" value="91" enum="Key" keywords="open square bracket">
+			Left bracket ([code][lb][/code]) key.
 		</constant>
 		<constant name="KEY_BACKSLASH" value="92" enum="Key">
-			\ key.
+			Backslash ([code]\[/code]) key.
 		</constant>
-		<constant name="KEY_BRACKETRIGHT" value="93" enum="Key">
-			] key.
+		<constant name="KEY_BRACKETRIGHT" value="93" enum="Key" keywords="close square bracket">
+			Right bracket ([code][rb][/code]) key.
 		</constant>
-		<constant name="KEY_ASCIICIRCUM" value="94" enum="Key">
-			^ key.
+		<constant name="KEY_ASCIICIRCUM" value="94" enum="Key" keywords="caret">
+			Caret ([code]^[/code]) key.
 		</constant>
-		<constant name="KEY_UNDERSCORE" value="95" enum="Key">
-			_ key.
+		<constant name="KEY_UNDERSCORE" value="95" enum="Key" keywords="underline">
+			Underscore ([code]_[/code]) key.
 		</constant>
-		<constant name="KEY_QUOTELEFT" value="96" enum="Key">
-			` key.
+		<constant name="KEY_QUOTELEFT" value="96" enum="Key" keywords="backtick, backquote">
+			Backtick ([code]`[/code]) key.
 		</constant>
-		<constant name="KEY_BRACELEFT" value="123" enum="Key">
-			{ key.
+		<constant name="KEY_BRACELEFT" value="123" enum="Key" keywords="open curly bracket">
+			Left brace ([code]{[/code]) key.
 		</constant>
-		<constant name="KEY_BAR" value="124" enum="Key">
-			| key.
+		<constant name="KEY_BAR" value="124" enum="Key" keywords="pipe">
+			Vertical bar or [i]pipe[/i] ([code]|[/code]) key.
 		</constant>
-		<constant name="KEY_BRACERIGHT" value="125" enum="Key">
-			} key.
+		<constant name="KEY_BRACERIGHT" value="125" enum="Key" keywords="close curly bracket">
+			Right brace ([code]}[/code]) key.
 		</constant>
 		<constant name="KEY_ASCIITILDE" value="126" enum="Key">
-			~ key.
+			Tilde ([code]~[/code]) key.
 		</constant>
 		<constant name="KEY_YEN" value="165" enum="Key">
-			¥ key.
+			Yen symbol ([code]¥[/code]) key.
 		</constant>
-		<constant name="KEY_SECTION" value="167" enum="Key">
-			§ key.
+		<constant name="KEY_SECTION" value="167" enum="Key" keywords="silcrow">
+			Section sign ([code]§[/code]) key.
 		</constant>
 		<constant name="KEY_CODE_MASK" value="8388607" enum="KeyModifierMask" is_bitfield="true">
 			Key Code mask.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/8127

This PR changes the descriptions of some `@GlobalScope` **Key** constants to be a bit more elaborate and use `[code]` tags, instead of beginning with the symbol. This not only prevents the symbols from [accidentally being used for formatting](https://github.com/godotengine/godot-docs/issues/8127), but allows the descriptions to be localized a lot better.
In the meantime, keywords are also added to the affected keys.


----

This PR originally was going to use `[kbd]` tags across ALL Keys. However, the idea fell through.
Content in `[kbd]` tags is assumed to be untranslatable, as the engine does not localize keycode text. It also oftentimes made readability worse (for the sake of accuracy), and would've been a massive change for a somewhat cosmetic change. This can be reconsidered another time.