### PR TITLE
ColorPicker: Add an intensity slider in raw mode for HDR

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -168,6 +168,9 @@
 		<theme_item name="color_hue" data_type="icon" type="Texture2D">
 			Custom texture for the hue selection slider on the right.
 		</theme_item>
+		<theme_item name="color_script" data_type="icon" type="Texture2D">
+			The icon for the button that switches color text to hexadecimal.
+		</theme_item>
 		<theme_item name="expanded_arrow" data_type="icon" type="Texture2D">
 			The icon for color preset drop down menu when expanded.
 		</theme_item>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1769,6 +1769,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_icon("bar_arrow", "ColorPicker", p_theme->get_icon(SNAME("ColorPickerBarArrow"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("picker_cursor", "ColorPicker", p_theme->get_icon(SNAME("PickerCursor"), EditorStringName(EditorIcons)));
 		p_theme->set_icon("picker_cursor_bg", "ColorPicker", p_theme->get_icon(SNAME("PickerCursorBg"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("color_script", "ColorPicker", p_theme->get_icon(SNAME("Script"), EditorStringName(EditorIcons)));
 
 		// ColorPickerButton.
 		p_theme->set_icon("bg", "ColorPickerButton", p_theme->get_icon(SNAME("GuiMiniCheckerboard"), EditorStringName(EditorIcons)));

--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -210,26 +210,36 @@ void ColorModeHSV::slider_draw(int p_which) {
 }
 
 String ColorModeRAW::get_slider_label(int idx) const {
-	ERR_FAIL_INDEX_V_MSG(idx, 3, String(), "Couldn't get slider label.");
+	ERR_FAIL_INDEX_V_MSG(idx, 4, String(), "Couldn't get slider label.");
 	return labels[idx];
 }
 
 float ColorModeRAW::get_slider_max(int idx) const {
-	ERR_FAIL_INDEX_V_MSG(idx, 4, 0, "Couldn't get slider max value.");
+	ERR_FAIL_INDEX_V_MSG(idx, 5, 0, "Couldn't get slider max value.");
 	return slider_max[idx];
 }
 
 float ColorModeRAW::get_slider_value(int idx) const {
-	ERR_FAIL_INDEX_V_MSG(idx, 4, 0, "Couldn't get slider value.");
-	return color_picker->get_pick_color().components[idx];
+	ERR_FAIL_INDEX_V_MSG(idx, 5, 0, "Couldn't get slider value.");
+	Color color = color_picker->get_pick_color();
+	float intensity = MAX(1, MAX(MAX(color.r, color.g), color.b));
+	if (idx == 3) {
+		return Math::log2(intensity);
+	} else if (idx == 4) {
+		return color.a;
+	} else {
+		return color.components[idx] / intensity;
+	}
 }
 
 Color ColorModeRAW::get_color() const {
 	Vector<float> values = color_picker->get_active_slider_values();
 	Color color;
-	for (int i = 0; i < 4; i++) {
-		color.components[i] = values[i];
+	float intensity = Math::pow(2, values[3]);
+	for (int i = 0; i < 3; i++) {
+		color.components[i] = values[i] * intensity;
 	}
+	color.a = values[4];
 	return color;
 }
 

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -105,11 +105,12 @@ public:
 
 class ColorModeRAW : public ColorMode {
 public:
-	String labels[3] = { "R", "G", "B" };
-	float slider_max[4] = { 100, 100, 100, 1 };
+	String labels[4] = { "R", "G", "B", "I" };
+	float slider_max[5] = { 1, 1, 1, 5, 1 };
 
 	virtual String get_name() const override { return "RAW"; }
 
+	virtual int get_slider_count() const override { return 4; }
 	virtual float get_slider_step() const override { return 0.001; }
 	virtual float get_spinbox_arrow_step() const override { return 0.01; }
 	virtual String get_slider_label(int idx) const override;

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -104,7 +104,7 @@ public:
 		SHAPE_MAX
 	};
 
-	static const int SLIDER_COUNT = 3;
+	static const int SLIDER_COUNT = 4;
 
 private:
 	enum class MenuOption {
@@ -268,6 +268,8 @@ private:
 		Ref<Texture2D> picker_cursor;
 		Ref<Texture2D> picker_cursor_bg;
 		Ref<Texture2D> color_hue;
+
+		Ref<Texture2D> color_script;
 
 		/* Mode buttons */
 		Ref<StyleBox> mode_button_normal;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1054,6 +1054,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("bar_arrow", "ColorPicker", icons["color_picker_bar_arrow"]);
 	theme->set_icon("picker_cursor", "ColorPicker", icons["color_picker_cursor"]);
 	theme->set_icon("picker_cursor_bg", "ColorPicker", icons["color_picker_cursor_bg"]);
+	theme->set_icon("color_script", "ColorPicker", icons["script"]);
 
 	{
 		const int precision = 7;

--- a/scene/theme/icons/script.svg
+++ b/scene/theme/icons/script.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#e0e0e0" d="M6 1a2 2 0 0 0-2 2v7H1v3a2 2 0 0 0 2 2h7a2 2 0 0 0 2-2V5h3V3a2 2 0 0 0-2-2z"/><path fill-opacity=".2" d="M6 1a2 2 0 0 0-2 2v7H1v3a2 2 0 1 0 4 0V3a1 1 0 0 1 2 0v3h5V5H8V3a2 2 0 0 0-2-2zM2 11h2v2a1 1 0 0 1-2 0z"/></svg>


### PR DESCRIPTION
This PR adopts a relatively simple approach, without storing intensity or modifying the Color class. Intensity is inferred from raw RGB, and will be 0 and not be retained if RGB does not exceed 1.

Add a intensity slider and reduce the max value of RGB to 1 in ColorPicker raw mode.
Keep the hex LineEdit always visiable and switch it to code if RGB exceeds the valid range.

<img src=https://github.com/user-attachments/assets/f60a5c49-95dc-4a8f-9aa8-3612b3c0b618 height=350>

Resolve: https://github.com/godotengine/godot-proposals/issues/1031