### PR TITLE
Track script property favorites by UID instead of path

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4278,7 +4278,8 @@ void EditorInspector::_update_current_favorites() {
 
 		for (PropertyInfo &p : plist) {
 			if (p.usage & PROPERTY_USAGE_CATEGORY) {
-				path = favorites.has(p.hint_string) ? p.hint_string : String();
+				path = ResourceUID::path_to_uid(p.hint_string);
+				path = favorites.has(path) ? path : String();
 			} else if (p.usage & PROPERTY_USAGE_SCRIPT_VARIABLE && !path.is_empty()) {
 				props[path].push_back(p.name);
 			}
@@ -4288,18 +4289,20 @@ void EditorInspector::_update_current_favorites() {
 		bool invalid_props = false;
 		for (const KeyValue<String, LocalVector<String>> &KV : props) {
 			path = KV.key;
-			for (int i = 0; i < favorites[path].size(); i++) {
-				String prop = favorites[path][i];
+			PackedStringArray &favors = favorites[path];
+
+			for (int i = 0; i < favors.size(); i++) {
+				String prop = favors[i];
 				if (KV.value.has(prop)) {
 					current_favorites.append(prop);
 				} else {
 					invalid_props = true;
-					favorites[path].erase(prop);
+					favors.erase(prop);
 					i--;
 				}
 			}
 
-			if (favorites[path].is_empty()) {
+			if (favors.is_empty()) {
 				favorites.erase(path);
 			}
 		}
@@ -4344,7 +4347,7 @@ void EditorInspector::_set_property_favorited(const String &p_path, bool p_favor
 				if (p.usage & PROPERTY_USAGE_CATEGORY) {
 					path = p.hint_string;
 				} else if (p.usage & PROPERTY_USAGE_SCRIPT_VARIABLE && p.name == p_path) {
-					class_name = path;
+					class_name = ResourceUID::path_to_uid(path);
 					break;
 				}
 			}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1661,14 +1661,6 @@ void FileSystemDock::_update_favorites_after_move(const HashMap<String, String> 
 		}
 	}
 	EditorSettings::get_singleton()->set_favorites(new_favorite_files);
-
-	HashMap<String, PackedStringArray> favorite_properties = EditorSettings::get_singleton()->get_favorite_properties();
-	for (const KeyValue<String, String> &KV : p_files_renames) {
-		if (favorite_properties.has(KV.key)) {
-			favorite_properties.replace_key(KV.key, KV.value);
-		}
-	}
-	EditorSettings::get_singleton()->set_favorite_properties(favorite_properties);
 }
 
 void FileSystemDock::_make_scene_confirm() {


### PR DESCRIPTION
Follow up to #97415 and #97352
Makes favorites of script properties stored as UID instead of script path, allowing to remove the code that updates paths.