### PR TITLE
Wayland: Only set selection when there is not already a source.

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3988,10 +3988,10 @@ void WaylandThread::selection_set_text(const String &p_text) {
 		wl_data_source_add_listener(ss->wl_data_source_selection, &wl_data_source_listener, ss);
 		wl_data_source_offer(ss->wl_data_source_selection, "text/plain;charset=utf-8");
 		wl_data_source_offer(ss->wl_data_source_selection, "text/plain");
-	}
 
-	// TODO: Implement a good way of getting the latest serial from the user.
-	wl_data_device_set_selection(ss->wl_data_device, ss->wl_data_source_selection, MAX(ss->pointer_data.button_serial, ss->last_key_pressed_serial));
+		// TODO: Implement a good way of getting the latest serial from the user.
+		wl_data_device_set_selection(ss->wl_data_device, ss->wl_data_source_selection, MAX(ss->pointer_data.button_serial, ss->last_key_pressed_serial));
+	}
 
 	// Wait for the message to get to the server before continuing, otherwise the
 	// clipboard update might come with a delay.


### PR DESCRIPTION
Might fix https://github.com/godotengine/godot/issues/95649.

While trying to use the editor I got really frustrated with inconsistent clipboard behavior when using wayland.  Often, when text has been selected and then copied, the paste afterwards results in nothing.  Trying to copy again usually succeeds.

The best way I have found to reproduce is to copy/paste once, scroll with mouse wheel, try copy/paste again.

When the source selection was reused, wayland seems to send a cancel event for the old(see `_wl_data_source_on_cancelled`), which causes us to destroy the source (which obviously means we didn't send anything to the clipboard now).  Since the selection is now cleared, the second attempt works.

Setting the selection only when there is not already a source seems to work.