### PR TITLE
Defer initializing BasisU encoder until it is needed

### DIFF
--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -38,13 +38,12 @@
 #include <transcoder/basisu_transcoder.h>
 #ifdef TOOLS_ENABLED
 #include <encoder/basisu_comp.h>
+
+static Mutex init_mutex;
+static bool initialized = false;
 #endif
 
 void basis_universal_init() {
-#ifdef TOOLS_ENABLED
-	basisu::basisu_encoder_init();
-#endif
-
 	basist::basisu_transcoder_init();
 }
 
@@ -80,6 +79,13 @@ inline void _basisu_pad_mipmap(const uint8_t *p_image_mip_data, Vector<uint8_t> 
 }
 
 Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedChannels p_channels) {
+	init_mutex.lock();
+	if (!initialized) {
+		basisu::basisu_encoder_init();
+		initialized = true;
+	}
+	init_mutex.unlock();
+
 	uint64_t start_time = OS::get_singleton()->get_ticks_msec();
 
 	Ref<Image> image = p_image->duplicate();


### PR DESCRIPTION
This is something I noticed while playing around with XCode's CPU profiler. On my M2 Macbook, initial startup of a near empty project with a debug build takes about 2.5 seconds. 1.3 seconds of that is from generating a LUT while initializing the BasisU encoder. This initialization is only needed in the editor and only when importing textures set to use BasisU. In other words, most projects will never need this LUT. 

Since this runs at startup, the cost is payed every time a user hits the "play" button. Despite the fact that the functionality will only ever be used inside the editor. 

This PR defers the initialization of the basisu encoder functions (the transcoder is initialized at startup as before) until the pack function is called. We use a mutex to cover the initialization since this function can be called from multiple threads. 

_Startup Time On M2 Macbook_
|         | Before      | After       |
|---------|-------------|-------------|
| Debug   | 2.5 seconds | 1.2 seconds |
| Release | 650 ms      | 325 ms      |

_Startup time on my Windows (Ryzen 5 3600)_
|         | Before      | After       |
|---------|-------------|-------------|
| Release |  1.9 seconds      | 650 ms      |

_Startup time on my Linux laptop (i7-1165G7)_
|         | Before      | After       |
|---------|-------------|-------------|
| Debug   | 2.2 seconds | 950 ms |
| Release |  1.0 seconds      | 600 ms      |

The test used is just hitting play in the editor with an empty scene containing a single script that prints `Time.get_ticks_msec()` in the `_ready()` function