### PR TITLE
Add OS::get_launch_path function

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -428,6 +428,10 @@ Vector<String> OS::get_video_adapter_driver_info() const {
 	return ::OS::get_singleton()->get_video_adapter_driver_info();
 }
 
+String OS::get_launch_path() const {
+	return ::OS::get_singleton()->get_launch_path();
+}
+
 Vector<String> OS::get_cmdline_args() {
 	List<String> cmdline = ::OS::get_singleton()->get_cmdline_args();
 	Vector<String> cmdlinev;
@@ -675,6 +679,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_name"), &OS::get_name);
 	ClassDB::bind_method(D_METHOD("get_distribution_name"), &OS::get_distribution_name);
 	ClassDB::bind_method(D_METHOD("get_version"), &OS::get_version);
+	ClassDB::bind_method(D_METHOD("get_launch_path"), &OS::get_launch_path);
 	ClassDB::bind_method(D_METHOD("get_cmdline_args"), &OS::get_cmdline_args);
 	ClassDB::bind_method(D_METHOD("get_cmdline_user_args"), &OS::get_cmdline_user_args);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -208,6 +208,7 @@ public:
 	String get_name() const;
 	String get_distribution_name() const;
 	String get_version() const;
+	String get_launch_path() const;
 	Vector<String> get_cmdline_args();
 	Vector<String> get_cmdline_user_args();
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -49,6 +49,13 @@
 #define THREADING_NAMESPACE std
 #endif
 
+#ifdef _WIN32
+#include <direct.h>
+#define getcwd _getcwd
+#else
+#include <unistd.h>
+#endif
+
 OS *OS::singleton = nullptr;
 uint64_t OS::target_ticks = 0;
 
@@ -78,6 +85,15 @@ void OS::add_logger(Logger *p_logger) {
 		_logger = memnew(CompositeLogger(loggers));
 	} else {
 		_logger->add_logger(p_logger);
+	}
+}
+
+void OS::initialize_launchpath() {
+	char launchpath_buffer[FILENAME_MAX];
+	if (getcwd(launchpath_buffer, sizeof(launchpath_buffer))) {
+		_launchpath = String::utf8(launchpath_buffer);
+	} else {
+		ERR_PRINT_ED("Could not initialize the launch path / current working directory.");
 	}
 }
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -46,6 +46,7 @@ class OS {
 	static OS *singleton;
 	static uint64_t target_ticks;
 	String _execpath;
+	String _launchpath;
 	List<String> _cmdline;
 	List<String> _user_args;
 	bool _keep_screen_on = true; // set default value to true, because this had been true before godot 2.0.
@@ -118,6 +119,7 @@ protected:
 
 	virtual void initialize() = 0;
 	virtual void initialize_joypads() = 0;
+	virtual void initialize_launchpath();
 
 	void set_display_driver_id(int p_display_driver_id) { _display_driver_id = p_display_driver_id; }
 
@@ -216,6 +218,7 @@ public:
 	virtual String get_identifier() const;
 	virtual String get_distribution_name() const = 0;
 	virtual String get_version() const = 0;
+	virtual String get_launch_path() const { return _launchpath; }
 	virtual List<String> get_cmdline_args() const { return _cmdline; }
 	virtual List<String> get_cmdline_user_args() const { return _user_args; }
 	virtual List<String> get_cmdline_platform_args() const { return List<String>(); }

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -315,6 +315,12 @@
 				See also [method find_keycode_from_string], [member InputEventKey.keycode], and [method InputEventKey.get_keycode_with_modifiers].
 			</description>
 		</method>
+		<method name="get_launch_path" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the working directory from which the engine or game executable was launched.
+			</description>
+		</method>
 		<method name="get_locale" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -946,6 +946,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// platforms, it's used to set up the time utilities.
 	OS::get_singleton()->benchmark_begin_measure("Startup", "Main::Setup");
 
+	OS::get_singleton()->initialize_launchpath();
+
 	engine = memnew(Engine);
 
 	MAIN_PRINT("Main: Initialize CORE");
@@ -4586,6 +4588,7 @@ void Main::cleanup(bool p_force) {
 	OS::get_singleton()->_cmdline.clear();
 	OS::get_singleton()->_user_args.clear();
 	OS::get_singleton()->_execpath = "";
+	OS::get_singleton()->_launchpath = "";
 	OS::get_singleton()->_local_clipboard = "";
 
 	ResourceLoader::clear_translation_remaps();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

**Scenario:**
I have a Godot project in `/myProjects/App`
I'm currently in the terminal at this directory: `/myTestSpace`

I want to run App in the current working directory `/myTestSpace`
The App project has a function that's supposed to save files in the current working directory

**Problem:**
when I run `godot --path /myProjects/App`:
I expected the file to be saved in `/myTestSpace` because that is the current working directory
Instead the file gets saved to the root of the project `/myProjects/App`

**Cause:**
When godot is run with the `--path` argument, the process will change working directory to the project root in order for the project to start but this also mean we lose the context of the initial launch / working directory.

**Proposed Solution:** 
Initialize a string value in the OS singleton to keep track of what the original launch path was. Then the user can call `OS.get_launch_path` to access that directory