### PR TITLE
Make Camera2D smoothing more framerate independent

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -195,8 +195,7 @@ Transform2D Camera2D::get_camera_transform() {
 		if (position_smoothing_enabled && !_is_editing_in_editor()) {
 			bool physics_process = (process_callback == CAMERA2D_PROCESS_PHYSICS) || is_physics_interpolated_and_enabled();
 			real_t delta = physics_process ? get_physics_process_delta_time() : get_process_delta_time();
-			real_t c = position_smoothing_speed * delta;
-			smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
+			smoothed_camera_pos = camera_pos + (smoothed_camera_pos - camera_pos) * Math::exp(-position_smoothing_speed * delta); // Adapted from: https://www.youtube.com/watch?v=LSNQuFEDOyQ
 			ret_camera_pos = smoothed_camera_pos;
 			//camera_pos=camera_pos*(1.0-position_smoothing_speed)+new_camera_pos*position_smoothing_speed;
 		} else {
@@ -212,8 +211,8 @@ Transform2D Camera2D::get_camera_transform() {
 
 	if (!ignore_rotation) {
 		if (rotation_smoothing_enabled && !_is_editing_in_editor()) {
-			real_t step = rotation_smoothing_speed * (process_callback == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time());
-			camera_angle = Math::lerp_angle(camera_angle, get_global_rotation(), step);
+			real_t delta = process_callback == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time();
+			camera_angle = get_global_rotation() + Math::angle_difference(get_global_rotation(), camera_angle) * Math::exp(-rotation_smoothing_speed * delta);
 		} else {
 			camera_angle = get_global_rotation();
 		}


### PR DESCRIPTION
Currently Camera2D smoothing uses lerp smoothing multiplied by delta, this is an approximation that's not entirely framerate independent but is, probably, usually fine in most cases. However it's still not perfect and this aims to fix that, implementing the algorithm shown here https://www.youtube.com/watch?v=LSNQuFEDOyQ.

https://github.com/user-attachments/assets/a0c0b057-0edb-49b7-b41b-ee346565b436


Main issue I could find with the current implementation is, if under circumstances that allow it, delta happens to be more than 1 second, smoothing will break and overshoot it's destination.

https://github.com/user-attachments/assets/691aeaa0-f463-483a-a65f-6381d0756a7a

This fixes that.

https://github.com/user-attachments/assets/da9a6f27-f3fb-4199-a61d-5ee86100f34f

Notes:
- I applied this to both rotation and position smoothing.
- The general speed seems to be roughly the exact same so I don't believe this breaks compat.
- This is obviously slightly more expensive (didn't test by how much), so I imagine whether this PR lands or not will depend on if it's deemed worth it, especially since by default `delta` is capped at ~0.125.