### PR TITLE
Update gridmap editor nodes when the gridmap node transform changes

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1199,6 +1199,8 @@ void GridMapEditor::_notification(int p_what) {
 					RS::get_singleton()->instance_set_transform(grid_instance[i], xf * edit_grid_xform);
 				}
 				grid_xform = xf;
+				_update_cursor_transform();
+				_update_selection_transform();
 			}
 		} break;
 


### PR DESCRIPTION
A minor fix for a gridmap editor glitch - when the gridmap node's transform changes the editor nodes for cursor and selection are now updated to reflect the new transformation.
