### PR TITLE
Make `AudioStreamRandomizer` not bias towards higher pitch

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -791,7 +791,7 @@ void AudioStreamPlaybackRandomizer::start(double p_from_pos) {
 		float range_from = 1.0 / randomizer->random_pitch_scale;
 		float range_to = randomizer->random_pitch_scale;
 
-		pitch_scale = range_from + Math::randf() * (range_to - range_from);
+		pitch_scale = range_from * Math::exp(Math::randf() * Math::log(range_to / range_from)); // Makes it not bias towards higher pitch.
 	}
 	{
 		float range_from = -randomizer->random_volume_offset_db;


### PR DESCRIPTION
https://github.com/godotengine/godot-proposals/discussions/10238
`AudioStreamRandomizer` randomizes between `1.0 / random_pitch_scale` and `random_pitch_scale`, so for example when random_pitch_scale is set to 16.0, it will randomize between 0.0625 and 16.0, this will obviously have a heavy bias towards higher pitch. 
This fixes that (running ~10000 iterations of the function gave me a median of ~1.0 so I think I did it right), at the cost of making it a bit more expensive.