### PR TITLE
Allow `apply_floor_snap` to preserve the horizontal position regardless of `stop_on_slopes`

### DIFF
--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -352,14 +352,14 @@ void CharacterBody2D::_apply_floor_snap(bool p_wall_as_floor) {
 			floor_normal = result.collision_normal;
 			_set_platform_data(result);
 
-			if (floor_stop_on_slope) {
-				// move and collide may stray the object a bit because of pre un-stucking,
-				// so only ensure that motion happens on floor direction in this case.
-				if (result.travel.length() > margin) {
-					result.travel = up_direction * up_direction.dot(result.travel);
-				} else {
-					result.travel = Vector2();
-				}
+			// Ensure that we only move the body along the up axis, because
+			// move_and_collide may stray the object a bit when getting it unstuck.
+			// Canceling this motion should not affect move_and_slide, as previous
+			// calls to move_and_collide already took care of freeing the body.
+			if (result.travel.length() > margin) {
+				result.travel = up_direction * up_direction.dot(result.travel);
+			} else {
+				result.travel = Vector2();
 			}
 
 			parameters.from.columns[2] += result.travel;

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -469,14 +469,14 @@ void CharacterBody3D::apply_floor_snap() {
 		_set_collision_direction(result, result_state, CollisionState(true, false, false));
 
 		if (result_state.floor) {
-			if (floor_stop_on_slope) {
-				// move and collide may stray the object a bit because of pre un-stucking,
-				// so only ensure that motion happens on floor direction in this case.
-				if (result.travel.length() > margin) {
-					result.travel = up_direction * up_direction.dot(result.travel);
-				} else {
-					result.travel = Vector3();
-				}
+			// Ensure that we only move the body along the up axis, because
+			// move_and_collide may stray the object a bit when getting it unstuck.
+			// Canceling this motion should not affect move_and_slide, as previous
+			// calls to move_and_collide already took care of freeing the body.
+			if (result.travel.length() > margin) {
+				result.travel = up_direction * up_direction.dot(result.travel);
+			} else {
+				result.travel = Vector3();
 			}
 
 			parameters.from.origin += result.travel;


### PR DESCRIPTION
Removes the `stop_on_slopes` check from `apply_floor_snap`, allowing the part of the code that preserves the horizontal position to work independently of the value of `stop_on_slopes`. This should provide a more consistent behavior and prevent the character from sliding along the horizontal axis as a result of what should be a pure vertical snapping.

Fixes https://github.com/godotengine/godot-proposals/issues/9255

It would be technically more correct to set `p_cancel_sliding` on the parameters too, but it seemed like something for another PR.

EDIT: 

@a0kami has made a test scene to make sure it is working as intended.

**Pre-PR:**  The non stop on slopes has non vertical motion on the snapping, more noticeable incrementing safe margin a bit. You can notice how snapping those bodies cause a wrong horizontal motion. Note how the bodies still snap even if the safe margin is large enough to touch the platform, contrary to the stop on slopes bodies that will not try to snap the body if the distance to the floor is less than the safe margin.

https://github.com/user-attachments/assets/56ba44c1-e935-4e19-b9cc-2a03fd53f9b5

**After-pr:** The snapping is now consistent between both types of bodies, the non stop on slopes bodies now snap correctly along the snapping vector, and the safe margin is being respected too.

https://github.com/user-attachments/assets/23d39036-516c-4846-946b-a2b0554eb736

As you can see the different is quite noticeable and we are gaining a lot of precision.

TEST PROJECT BY @a0kami:

[test.tar.gz](https://github.com/user-attachments/files/17829019/test.tar.gz)

