### PR TITLE
Fix error when using add selection with new line in TextEdit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6636,6 +6636,14 @@ void TextEdit::add_selection_for_next_occurrence() {
 	const String &highlighted_text = get_selected_text(caret);
 	int column = get_selection_from_column(caret) + 1;
 	int line = get_selection_from_line(caret);
+	if (column >= text[line].size()) {
+		// Start search from the next line.
+		line++;
+		column = 0;
+		if (line >= get_line_count()) {
+			line = 0;
+		}
+	}
 
 	const Point2i next_occurrence = search(highlighted_text, SEARCH_MATCH_CASE, line, column);
 
@@ -6677,6 +6685,14 @@ void TextEdit::skip_selection_for_next_occurrence() {
 
 	int column = get_selection_from_column(caret) + 1;
 	int line = get_selection_from_line(caret);
+	if (column >= text[line].size()) {
+		// Start search from the next line.
+		line++;
+		column = 0;
+		if (line >= get_line_count()) {
+			line = 0;
+		}
+	}
 
 	const Point2i next_occurrence = search(searched_text, SEARCH_MATCH_CASE, line, column);
 

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -1363,40 +1363,35 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_selection_for_next_occurrence();
 			CHECK(text_edit->get_caret_count() == 1);
 			CHECK(text_edit->get_selected_text(0) == "test");
-			CHECK(text_edit->get_selection_from_line(0) == 1);
-			CHECK(text_edit->get_selection_from_column(0) == 0);
-			CHECK(text_edit->get_selection_to_line(0) == 1);
-			CHECK(text_edit->get_selection_to_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
 			CHECK(text_edit->get_caret_line(0) == 1);
 			CHECK(text_edit->get_caret_column(0) == 4);
 
+			// Select the next occurrence on the same line.
 			text_edit->add_selection_for_next_occurrence();
 			CHECK(text_edit->get_caret_count() == 2);
 			CHECK(text_edit->get_selected_text(1) == "test");
-			CHECK(text_edit->get_selection_from_line(1) == 1);
-			CHECK(text_edit->get_selection_from_column(1) == 13);
-			CHECK(text_edit->get_selection_to_line(1) == 1);
-			CHECK(text_edit->get_selection_to_column(1) == 17);
+			CHECK(text_edit->get_selection_origin_line(1) == 1);
+			CHECK(text_edit->get_selection_origin_column(1) == 13);
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 17);
 
+			// Select the next occurrence on the next line.
 			text_edit->add_selection_for_next_occurrence();
 			CHECK(text_edit->get_caret_count() == 3);
 			CHECK(text_edit->get_selected_text(2) == "test");
-			CHECK(text_edit->get_selection_from_line(2) == 2);
-			CHECK(text_edit->get_selection_from_column(2) == 9);
-			CHECK(text_edit->get_selection_to_line(2) == 2);
-			CHECK(text_edit->get_selection_to_column(2) == 13);
+			CHECK(text_edit->get_selection_origin_line(2) == 2);
+			CHECK(text_edit->get_selection_origin_column(2) == 9);
 			CHECK(text_edit->get_caret_line(2) == 2);
 			CHECK(text_edit->get_caret_column(2) == 13);
 
+			// Select the next occurrence on the next line.
 			text_edit->add_selection_for_next_occurrence();
 			CHECK(text_edit->get_caret_count() == 4);
 			CHECK(text_edit->get_selected_text(3) == "test");
-			CHECK(text_edit->get_selection_from_line(3) == 3);
-			CHECK(text_edit->get_selection_from_column(3) == 5);
-			CHECK(text_edit->get_selection_to_line(3) == 3);
-			CHECK(text_edit->get_selection_to_column(3) == 9);
+			CHECK(text_edit->get_selection_origin_line(3) == 3);
+			CHECK(text_edit->get_selection_origin_column(3) == 5);
 			CHECK(text_edit->get_caret_line(3) == 3);
 			CHECK(text_edit->get_caret_column(3) == 9);
 
@@ -1408,10 +1403,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->add_selection_for_next_occurrence();
 			CHECK(text_edit->get_caret_count() == 6);
 			CHECK(text_edit->get_selected_text(5) == "rand");
-			CHECK(text_edit->get_selection_from_line(5) == 3);
-			CHECK(text_edit->get_selection_from_column(5) == 18);
-			CHECK(text_edit->get_selection_to_line(5) == 3);
-			CHECK(text_edit->get_selection_to_column(5) == 22);
+			CHECK(text_edit->get_selection_origin_line(5) == 3);
+			CHECK(text_edit->get_selection_origin_column(5) == 18);
 			CHECK(text_edit->get_caret_line(5) == 3);
 			CHECK(text_edit->get_caret_column(5) == 22);
 
@@ -1420,6 +1413,16 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selected_text(1) == "test");
 			CHECK(text_edit->get_selected_text(2) == "test");
 			CHECK(text_edit->get_selected_text(3) == "test");
+
+			// Selecting from end of line does not error.
+			text_edit->remove_secondary_carets();
+			text_edit->select(1, 17, 3, 8, 0);
+			text_edit->add_selection_for_next_occurrence();
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 17);
+			CHECK(text_edit->get_caret_line(0) == 3);
+			CHECK(text_edit->get_caret_column(0) == 8);
 		}
 
 		SUBCASE("[TextEdit] skip selection for next occurrence") {
@@ -1460,10 +1463,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 1);
 			CHECK(text_edit->has_selection(0));
 			CHECK(text_edit->get_selected_text(0) == "test");
-			CHECK(text_edit->get_selection_from_line(0) == 1);
-			CHECK(text_edit->get_selection_from_column(0) == 0);
-			CHECK(text_edit->get_selection_to_line(0) == 1);
-			CHECK(text_edit->get_selection_to_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
 			CHECK(text_edit->get_caret_line(0) == 1);
 			CHECK(text_edit->get_caret_column(0) == 4);
 
@@ -1472,10 +1473,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 1);
 			CHECK(text_edit->has_selection(0));
 			CHECK(text_edit->get_selected_text(0) == "test");
-			CHECK(text_edit->get_selection_from_line(0) == 1);
-			CHECK(text_edit->get_selection_from_column(0) == 13);
-			CHECK(text_edit->get_selection_to_line(0) == 1);
-			CHECK(text_edit->get_selection_to_column(0) == 17);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 13);
 			CHECK(text_edit->get_caret_line(0) == 1);
 			CHECK(text_edit->get_caret_column(0) == 17);
 
@@ -1483,10 +1482,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 1);
 			CHECK(text_edit->has_selection(0));
 			CHECK(text_edit->get_selected_text(0) == "test");
-			CHECK(text_edit->get_selection_from_line(0) == 2);
-			CHECK(text_edit->get_selection_from_column(0) == 9);
-			CHECK(text_edit->get_selection_to_line(0) == 2);
-			CHECK(text_edit->get_selection_to_column(0) == 13);
+			CHECK(text_edit->get_selection_origin_line(0) == 2);
+			CHECK(text_edit->get_selection_origin_column(0) == 9);
 			CHECK(text_edit->get_caret_line(0) == 2);
 			CHECK(text_edit->get_caret_column(0) == 13);
 
@@ -1494,10 +1491,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 1);
 			CHECK(text_edit->has_selection(0));
 			CHECK(text_edit->get_selected_text(0) == "test");
-			CHECK(text_edit->get_selection_from_line(0) == 3);
-			CHECK(text_edit->get_selection_from_column(0) == 5);
-			CHECK(text_edit->get_selection_to_line(0) == 3);
-			CHECK(text_edit->get_selection_to_column(0) == 9);
+			CHECK(text_edit->get_selection_origin_line(0) == 3);
+			CHECK(text_edit->get_selection_origin_column(0) == 5);
 			CHECK(text_edit->get_caret_line(0) == 3);
 			CHECK(text_edit->get_caret_column(0) == 9);
 
@@ -1505,10 +1500,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->skip_selection_for_next_occurrence();
 			CHECK(text_edit->has_selection(0));
 			CHECK(text_edit->get_selected_text(0) == "test");
-			CHECK(text_edit->get_selection_from_line(0) == 1);
-			CHECK(text_edit->get_selection_from_column(0) == 0);
-			CHECK(text_edit->get_selection_to_line(0) == 1);
-			CHECK(text_edit->get_selection_to_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
 			CHECK(text_edit->get_caret_line(0) == 1);
 			CHECK(text_edit->get_caret_column(0) == 4);
 
@@ -1521,10 +1514,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			CHECK(text_edit->has_selection(1));
 			CHECK(text_edit->get_selected_text(1) == "test");
-			CHECK(text_edit->get_selection_from_line(1) == 1);
-			CHECK(text_edit->get_selection_from_column(1) == 13);
-			CHECK(text_edit->get_selection_to_line(1) == 1);
-			CHECK(text_edit->get_selection_to_column(1) == 17);
+			CHECK(text_edit->get_selection_origin_line(1) == 1);
+			CHECK(text_edit->get_selection_origin_column(1) == 13);
 			CHECK(text_edit->get_caret_line(1) == 1);
 			CHECK(text_edit->get_caret_column(1) == 17);
 
@@ -1536,10 +1527,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selected_text(0) == "test");
 
 			CHECK(text_edit->get_selected_text(1) == "test");
-			CHECK(text_edit->get_selection_from_line(1) == 2);
-			CHECK(text_edit->get_selection_from_column(1) == 9);
-			CHECK(text_edit->get_selection_to_line(1) == 2);
-			CHECK(text_edit->get_selection_to_column(1) == 13);
+			CHECK(text_edit->get_selection_origin_line(1) == 2);
+			CHECK(text_edit->get_selection_origin_column(1) == 9);
 			CHECK(text_edit->get_caret_line(1) == 2);
 			CHECK(text_edit->get_caret_column(1) == 13);
 
@@ -1549,10 +1538,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_selected_text(0) == "test");
 
 			CHECK(text_edit->get_selected_text(1) == "test");
-			CHECK(text_edit->get_selection_from_line(1) == 3);
-			CHECK(text_edit->get_selection_from_column(1) == 5);
-			CHECK(text_edit->get_selection_to_line(1) == 3);
-			CHECK(text_edit->get_selection_to_column(1) == 9);
+			CHECK(text_edit->get_selection_origin_line(1) == 3);
+			CHECK(text_edit->get_selection_origin_column(1) == 5);
 			CHECK(text_edit->get_caret_line(1) == 3);
 			CHECK(text_edit->get_caret_column(1) == 9);
 
@@ -1561,12 +1548,20 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_count() == 1);
 			CHECK(text_edit->has_selection(0));
 			CHECK(text_edit->get_selected_text(0) == "test");
-			CHECK(text_edit->get_selection_from_line(0) == 1);
-			CHECK(text_edit->get_selection_from_column(0) == 0);
-			CHECK(text_edit->get_selection_to_line(0) == 1);
-			CHECK(text_edit->get_selection_to_column(0) == 4);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 0);
 			CHECK(text_edit->get_caret_line(0) == 1);
 			CHECK(text_edit->get_caret_column(0) == 4);
+
+			// Selecting from end of line does not error.
+			text_edit->remove_secondary_carets();
+			text_edit->select(1, 17, 3, 8, 0);
+			text_edit->skip_selection_for_next_occurrence();
+			CHECK(text_edit->get_caret_count() == 1);
+			CHECK(text_edit->get_selection_origin_line(0) == 1);
+			CHECK(text_edit->get_selection_origin_column(0) == 17);
+			CHECK(text_edit->get_caret_line(0) == 3);
+			CHECK(text_edit->get_caret_column(0) == 8);
 		}
 
 		SUBCASE("[TextEdit] deselect on focus loss") {


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/99358

In both add selection (ctrl + d) and skip selection (ctrl + alt + d).
I thought I already fixed this issue, but I guess not completely.
There is no multi-line search, so it won't find any other occurrences.

The column adds 1 so search doesn't find the same match, but when it was at the end of the line it caused an error. Now it goes to the start of the next line. It shouldn't be possible for the from line to reach the end of the text here, but I wrapped it around just in case. 

Added basic tests to make sure it doesn't error.
Updated those test cases to use `get_selection_origin` instead of the from/to line.