### PR TITLE
GDExtension: Fix method binds not saying if they are varargs

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -154,7 +154,7 @@ public:
 	}
 
 	virtual bool is_vararg() const override {
-		return false;
+		return vararg;
 	}
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-cpp/issues/1641

For whatever reason, `GDExtensionMethodBind::is_vararg()` was hard-coded to return `false` - possibly we didn't originally support varargs, added support later, and then didn't update that?

Anyway, this PR updates it to return the correct value, which will prevent GDScript from trying to do a validated call for vararg functions (which isn't supported), fixing the bug.