### PR TITLE
[4.3] Normalize normal tangent and binormal before interpolating in the mobile renderer to avoid precision errors on heavily scaled meshes

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -439,12 +439,12 @@ void main() {
 
 	vertex_interp = vertex;
 #ifdef NORMAL_USED
-	normal_interp = normal;
+	normal_interp = normalize(normal);
 #endif
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-	tangent_interp = tangent;
-	binormal_interp = binormal;
+	tangent_interp = normalize(tangent);
+	binormal_interp = normalize(binormal);
 #endif
 
 #ifdef MODE_RENDER_DEPTH


### PR DESCRIPTION
Backport of https://github.com/godotengine/godot/pull/99163 because it can't be cherry-picked cleanly

