### PR TITLE
Force `get_thread_count()` to `1` if single threaded

### DIFF
--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -258,7 +258,13 @@ public:
 	bool is_group_task_completed(GroupID p_group) const;
 	void wait_for_group_task_completion(GroupID p_group);
 
-	_FORCE_INLINE_ int get_thread_count() const { return threads.size(); }
+	_FORCE_INLINE_ int get_thread_count() const {
+#ifdef THREADS_ENABLED
+		return threads.size();
+#else
+		return 1;
+#endif
+	}
 
 	static WorkerThreadPool *get_singleton() { return singleton; }
 	static int get_thread_index();


### PR DESCRIPTION
This PR makes sure that `WorkerThreadPool::get_singleton()->get_thread_count()` returns `1` when `threads=no`. Otherwise, a lot of `WorkerThreadPool` calls will not run as `threads.size()` would return `0` in single-thread builds, as jobs are set as done if no elements/threads are available.

Alternative to #98121
Fixes #88192