### PR TITLE
Disable the debugger thread selector when there's nothing to select

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1062,6 +1062,7 @@ void ScriptEditorDebugger::_update_buttons_state() {
 	for (KeyValue<uint64_t, ThreadDebugged> &I : threads_debugged) {
 		threadss.push_back(&I.value);
 	}
+	threads->set_disabled(threadss.is_empty());
 
 	threadss.sort_custom<ThreadSort>();
 	threads->clear();


### PR DESCRIPTION
A small UI fix. Empty lists just have this tiny rectangle appear when there's nothing in them and it looks broken

| Old | New |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/24330523-76f9-4431-bcb2-7a745699fa0c) | ![2](https://github.com/user-attachments/assets/0abcdff7-7cee-474b-9eba-475ebf7c8ed9) |


