### PR TITLE
Enable Deploy with Remote Debug by default in the editor

### DIFF
--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -181,7 +181,7 @@ void EditorRunNative::_bind_methods() {
 }
 
 bool EditorRunNative::is_deploy_debug_remote_enabled() const {
-	return EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", false);
+	return EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", true);
 }
 
 EditorRunNative::EditorRunNative() {

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -228,7 +228,7 @@ void DebuggerEditorPlugin::_notification(int p_what) {
 }
 
 void DebuggerEditorPlugin::_update_debug_options() {
-	bool check_deploy_remote = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", false);
+	bool check_deploy_remote = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_deploy_remote_debug", true);
 	bool check_file_server = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_file_server", false);
 	bool check_debug_collisions = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_collisions", false);
 	bool check_debug_paths = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_paths", false);


### PR DESCRIPTION
This makes one-click deploy make use of remote debugging, so that you can see output from the remote device, run the debugger and use the monitor and performance/network profilers.

- This closes https://github.com/godotengine/godot-proposals/issues/11191.
