### PR TITLE
[Windows] Fix handling of paths in console wrapper

### DIFF
--- a/platform/windows/console_wrapper_windows.cpp
+++ b/platform/windows/console_wrapper_windows.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[]) {
 	si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
 
 	WCHAR new_command_line[32767];
-	_snwprintf_s(new_command_line, 32767, _TRUNCATE, L"%ls %ls", exe_name, PathGetArgsW(GetCommandLineW()));
+	_snwprintf_s(new_command_line, 32767, _TRUNCATE, L"\"%ls\" %ls", exe_name, PathGetArgsW(GetCommandLineW()));
 
 	if (!CreateProcessW(nullptr, new_command_line, nullptr, nullptr, true, CREATE_SUSPENDED, nullptr, nullptr, &si, &pi)) {
 		wprintf(L"CreateProcess failed, error %d\n", GetLastError());


### PR DESCRIPTION
Wrapper does not handle paths with spaces

There might be an alternative way to add this or format this, but this solves the problem, I'm surprised this hasn't popped up before (it only did for me now because my new laptop was configured in the store and had "First-name Last-name" as my account, triggering this)

Additionally we might want to make the error message a bit more descriptive (I had to hack in printing the command line string to discover what was even wrong for this), but not touching that right now

Edit: It seems to be in very specific paths, see the report

* Fixes: https://github.com/godotengine/godot/issues/101303

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
