### PR TITLE
[DRAFT] WebXR: Add support for Space Warp

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2495,7 +2495,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 
 	scene_state.reset_gl_state();
 
-	GLuint motion_vectors_fbo = rt->overridden.velocity_fbo;
+	GLuint motion_vectors_fbo = rt->velocity_fbo;
 	if (motion_vectors_fbo != 0 && GLES3::Config::get_singleton()->max_vertex_attribs >= 22) {
 		RENDER_TIMESTAMP("Motion Vectors Pass");
 		glBindFramebuffer(GL_FRAMEBUFFER, motion_vectors_fbo);

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -357,6 +357,9 @@ struct RenderTarget {
 	GLuint backbuffer_fbo = 0;
 	GLuint backbuffer = 0;
 	GLuint backbuffer_depth = 0;
+	GLuint velocity_fbo = 0;
+	GLuint velocity_texture = 0;
+	GLuint velocity_depth_texture = 0;
 	bool depth_has_stencil = true;
 
 	Size2i velocity_target_size;
@@ -403,9 +406,7 @@ struct RenderTarget {
 			bool depth_has_stencil;
 		};
 		RBMap<uint32_t, FBOCacheEntry> fbo_cache;
-
-		GLuint velocity_fbo = 0;
-		RBMap<uint32_t, GLuint> velocity_fbo_cache;
+		RBMap<uint32_t, FBOCacheEntry> velocity_fbo_cache;
 	} overridden;
 
 	RID texture;

--- a/modules/webxr/godot_webxr.h
+++ b/modules/webxr/godot_webxr.h
@@ -70,6 +70,9 @@ extern bool godot_webxr_get_projection_for_view(int p_view, float *r_transform);
 extern unsigned int godot_webxr_get_color_texture();
 extern unsigned int godot_webxr_get_depth_texture();
 extern unsigned int godot_webxr_get_velocity_texture();
+extern unsigned int godot_webxr_get_velocity_depth_texture();
+extern bool godot_webxr_get_motion_vector_target_size(int *r_size);
+extern void godot_webxr_set_delta_pose(float *p_transform);
 
 extern bool godot_webxr_update_input_source(
 		int p_input_source_id,

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -62,6 +62,8 @@ private:
 	XRInterface::EnvironmentBlendMode environment_blend_mode = XRInterface::XR_ENV_BLEND_MODE_OPAQUE;
 
 	Size2 render_targetsize;
+	Size2i motion_vector_targetsize;
+	Transform3D previous_world_transform;
 	RBMap<unsigned int, RID> texture_cache;
 	struct Touch {
 		bool is_touching = false;
@@ -83,11 +85,18 @@ private:
 
 	RID color_texture;
 	RID depth_texture;
+	RID velocity_texture;
+	RID velocity_depth_texture;
 
 	RID _get_color_texture();
 	RID _get_depth_texture();
+	RID _get_velocity_texture();
+	RID _get_velocity_depth_texture();
+
+	static Transform3D _js_matrix_to_transform(float *p_js_matrix);
+	static void _transform_to_js_matrix(const Transform3D &p_transform, float *r_js_matrix);
+
 	RID _get_texture(unsigned int p_texture_id);
-	Transform3D _js_matrix_to_transform(float *p_js_matrix);
 	void _update_input_source(int p_input_source_id);
 
 	Vector2 _get_screen_position_from_joy_vector(const Vector2 &p_joy_vector);
@@ -136,8 +145,11 @@ public:
 	virtual RID get_color_texture() override;
 	virtual RID get_depth_texture() override;
 	virtual RID get_velocity_texture() override;
+	virtual RID get_velocity_depth_texture() override;
+	virtual Size2i get_velocity_target_size() override;
 
 	virtual void process() override;
+	virtual void pre_render() override;
 
 	void _on_input_event(int p_event_type, int p_input_source_id);
 


### PR DESCRIPTION
Depends on https://github.com/godotengine/godot/pull/97151

This implements [WebXR Space Warp](https://immersive-web.github.io/layers/#spacewarp), which is supported on the Meta Quest browser.

In order to test, you'll need to:

1. Go to `chrome://flags` in the browser, search for “WebXR Space Warp” and change it from "Default" to "Enabled"
2. In your WebXR app, add both `"layers"` and `"space-warp"` to either `WebXRInterface.required_features` or `WebXRInterface.optional_features`
3. Check the FPS somehow (perhaps using the overlay from the OVR Metrics app?) and see that it is 45 fps (rather than the expected 90 fps -- unless you purposefully changed it to something else, in which case it should be half of whatever you set it to)
4. You can also enable "space warp debug mode" on the Quest using the `adb` commands shown in PR https://github.com/GodotVR/godot_openxr_vendors/pull/222, which will show a transparent overlay of the motion vectors. Non-transparent objects that are moving should light up!

TODO:

- ~~Set [deltaPose](https://immersive-web.github.io/layers/#dom-xrprojectionlayer-deltapose) for changes to the world origin in the same way as PR https://github.com/GodotVR/godot_openxr_vendors/pull/222~~

Marking as a DRAFT until PR https://github.com/godotengine/godot/pull/97151 is merged