### PR TITLE
[3.x] Improve `TextureProgress.set_radial_initial_angle()` by removing loops

### DIFF
--- a/doc/classes/TextureProgress.xml
+++ b/doc/classes/TextureProgress.xml
@@ -40,6 +40,7 @@
 		</member>
 		<member name="radial_initial_angle" type="float" setter="set_radial_initial_angle" getter="get_radial_initial_angle" default="0.0">
 			Starting angle for the fill of [member texture_progress] if [member fill_mode] is [constant FILL_CLOCKWISE] or [constant FILL_COUNTER_CLOCKWISE]. When the node's [code]value[/code] is equal to its [code]min_value[/code], the texture doesn't show up at all. When the [code]value[/code] increases, the texture fills and tends towards [member radial_fill_degrees].
+			[b]Note:[/b] [member radial_initial_angle] is wrapped between [code]0[/code] and [code]360[/code] degrees (inclusive).
 		</member>
 		<member name="stretch_margin_bottom" type="int" setter="set_stretch_margin" getter="get_stretch_margin" default="0">
 			The height of the 9-patch's bottom row. A margin of 16 means the 9-slice's bottom corners and side will have a height of 16 pixels. You can set all 4 margin values individually to create panels with non-uniform borders.

--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -31,6 +31,7 @@
 #include "texture_progress.h"
 
 #include "core/engine.h"
+#include "math.h"
 
 void TextureProgress::set_under_texture(const Ref<Texture> &p_texture) {
 	under = p_texture;
@@ -577,12 +578,12 @@ int TextureProgress::get_fill_mode() {
 }
 
 void TextureProgress::set_radial_initial_angle(float p_angle) {
-	while (p_angle > 360) {
-		p_angle -= 360;
+	ERR_FAIL_COND_MSG(!isfinite(p_angle), "Angle is non-finite.");
+
+	if (p_angle < 0.0 || p_angle > 360.0) {
+		p_angle = Math::fposmod(p_angle, 360.0f);
 	}
-	while (p_angle < 0) {
-		p_angle += 360;
-	}
+
 	rad_init_angle = p_angle;
 	update();
 }


### PR DESCRIPTION
Backport https://github.com/godotengine/godot/pull/98816 to 3.x
Fixes https://github.com/godotengine/godot/issues/60338

Some notes:
- There are not `Math::is_finite()` and `Math::fposmodp()` in 3.x, so `Math::is_finite()` replaced with `isfinite()` from `math.h` stdlib (just expanding function `Math::is_finite()` from 4.x branch - feel free to suggest how it could be done differently), and `Math::fposmodp()` replaced with `Math::fposmod()` (same as `Math::fposmodp()` but with more checks).
- No unit tests added (as they are 4.x privilege), but in editor it works as expected.