### PR TITLE
Revert "Fix `InputEvent` device id clash" and add a compatibility function

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -514,16 +514,19 @@ void ProjectSettings::_convert_to_last_version(int p_from_version) {
 			}
 		}
 	}
-	if (p_from_version <= 5) {
-		// Converts the device in events from -1 (emulated events) to -3 (all events).
+	if (p_from_version == 5) {
+		// Converts the device in events from -3 to -1.
+		// -3 was introduced in GH-97707 as a way to prevent a clash in device IDs, but as reported in GH-99243, this leads to problems.
+		// -3 was used during dev-releases, so this conversion helps to revert such affected projects.
+		// This conversion doesn't affect any other projects, since -3 is not used otherwise.
 		for (KeyValue<StringName, ProjectSettings::VariantContainer> &E : props) {
 			if (String(E.key).begins_with("input/")) {
 				Dictionary action = E.value.variant;
 				Array events = action["events"];
 				for (int i = 0; i < events.size(); i++) {
 					Ref<InputEvent> ev = events[i];
-					if (ev.is_valid() && ev->get_device() == -1) { // -1 was the previous value (GH-97707).
-						ev->set_device(InputEvent::DEVICE_ID_ALL_DEVICES);
+					if (ev.is_valid() && ev->get_device() == -3) {
+						ev->set_device(-1);
 					}
 				}
 			}

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -35,6 +35,9 @@
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
 
+const int InputEvent::DEVICE_ID_EMULATION = -1;
+const int InputEvent::DEVICE_ID_INTERNAL = -2;
+
 void InputEvent::set_device(int p_device) {
 	device = p_device;
 	emit_changed();

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -62,9 +62,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	inline static constexpr int DEVICE_ID_EMULATION = -1;
-	inline static constexpr int DEVICE_ID_INTERNAL = -2;
-	inline static constexpr int DEVICE_ID_ALL_DEVICES = -3; // Signify that a given Action can be triggered by any device.
+	static const int DEVICE_ID_EMULATION;
+	static const int DEVICE_ID_INTERNAL;
 
 	void set_device(int p_device);
 	int get_device() const;

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -39,6 +39,8 @@
 
 InputMap *InputMap::singleton = nullptr;
 
+int InputMap::ALL_DEVICES = -1;
+
 void InputMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_action", "action"), &InputMap::has_action);
 	ClassDB::bind_method(D_METHOD("get_actions"), &InputMap::_get_actions);
@@ -161,7 +163,7 @@ List<Ref<InputEvent>>::Element *InputMap::_find_event(Action &p_action, const Re
 	int i = 0;
 	for (List<Ref<InputEvent>>::Element *E = p_action.inputs.front(); E; E = E->next()) {
 		int device = E->get()->get_device();
-		if (device == InputEvent::DEVICE_ID_ALL_DEVICES || device == p_event->get_device()) {
+		if (device == ALL_DEVICES || device == p_event->get_device()) {
 			if (E->get()->action_match(p_event, p_exact_match, p_action.deadzone, r_pressed, r_strength, r_raw_strength)) {
 				if (r_event_index) {
 					*r_event_index = i;

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -43,6 +43,11 @@ class InputMap : public Object {
 	GDCLASS(InputMap, Object);
 
 public:
+	/**
+	 * A special value used to signify that a given Action can be triggered by any device
+	 */
+	static int ALL_DEVICES;
+
 	struct Action {
 		int id;
 		float deadzone;

--- a/editor/event_listener_line_edit.cpp
+++ b/editor/event_listener_line_edit.cpp
@@ -121,7 +121,7 @@ String EventListenerLineEdit::get_event_text(const Ref<InputEvent> &p_event, boo
 }
 
 String EventListenerLineEdit::get_device_string(int p_device) {
-	if (p_device == InputEvent::DEVICE_ID_ALL_DEVICES) {
+	if (p_device == InputMap::ALL_DEVICES) {
 		return TTR("All Devices");
 	}
 	return TTR("Device") + " " + itos(p_device);

--- a/editor/input_event_configuration_dialog.cpp
+++ b/editor/input_event_configuration_dialog.cpp
@@ -551,18 +551,18 @@ void InputEventConfigurationDialog::_input_list_item_selected() {
 }
 
 void InputEventConfigurationDialog::_device_selection_changed(int p_option_button_index) {
-	// Option index 0 corresponds to "All Devices" (value of -3).
-	// Otherwise subtract 1 as option index 1 corresponds to device 0, etc...
-	event->set_device(p_option_button_index == 0 ? InputEvent::DEVICE_ID_ALL_DEVICES : p_option_button_index - 1);
+	// Subtract 1 as option index 0 corresponds to "All Devices" (value of -1)
+	// and option index 1 corresponds to device 0, etc...
+	event->set_device(p_option_button_index - 1);
 	event_as_text->set_text(EventListenerLineEdit::get_event_text(event, true));
 }
 
 void InputEventConfigurationDialog::_set_current_device(int p_device) {
-	device_id_option->select(p_device == InputEvent::DEVICE_ID_ALL_DEVICES ? 0 : p_device + 1);
+	device_id_option->select(p_device + 1);
 }
 
 int InputEventConfigurationDialog::_get_current_device() const {
-	return device_id_option->get_selected() == 0 ? InputEvent::DEVICE_ID_ALL_DEVICES : device_id_option->get_selected() - 1;
+	return device_id_option->get_selected() - 1;
 }
 
 void InputEventConfigurationDialog::_notification(int p_what) {
@@ -705,12 +705,11 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 
 	device_id_option = memnew(OptionButton);
 	device_id_option->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	device_id_option->add_item(EventListenerLineEdit::get_device_string(InputEvent::DEVICE_ID_ALL_DEVICES));
-	for (int i = 0; i < 8; i++) {
+	for (int i = -1; i < 8; i++) {
 		device_id_option->add_item(EventListenerLineEdit::get_device_string(i));
 	}
 	device_id_option->connect(SceneStringName(item_selected), callable_mp(this, &InputEventConfigurationDialog::_device_selection_changed));
-	_set_current_device(InputEvent::DEVICE_ID_ALL_DEVICES);
+	_set_current_device(InputMap::ALL_DEVICES);
 	device_container->add_child(device_id_option);
 
 	device_container->hide();


### PR DESCRIPTION
- resolve #99243
- revert #97707
- revert #98493

Since the reverted PR introduced changes in the project.godot file, it seems prudent to introduce a compatibility function for such affected projects.

Updated 2024-11-20: Squashed commits together.