### PR TITLE
SCons: Remove `env["ENV"]` overrides

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -111,9 +110,6 @@ def configure(env: "SConsEnvironment"):
         env["initial_memory"] = 64
 
     env.Append(LINKFLAGS=["-sINITIAL_MEMORY=%sMB" % env["initial_memory"]])
-
-    ## Copy env variables.
-    env["ENV"] = os.environ
 
     # LTO
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -908,10 +908,6 @@ def configure(env: "SConsEnvironment"):
     # At this point the env has been set up with basic tools/compilers.
     env.Prepend(CPPPATH=["#platform/windows"])
 
-    if os.name == "nt":
-        env["ENV"] = os.environ  # this makes build less repeatable, but simplifies some things
-        env["ENV"]["TMP"] = os.environ["TMP"]
-
     # First figure out which compiler, version, and target arch we're using
     if os.getenv("VCINSTALLDIR") and detect_build_env_arch() and not env["use_mingw"]:
         setup_msvc_manual(env)


### PR DESCRIPTION
There's two instances in the repo of outright overriding the `env["ENV"]` variable *itself* with `os.environ`. This strikes me as an entirely legacy practice, as not only is assigning values to `env["ENV"]` already explicitly handled and noted at the top of SConstruct, but the existance of these overrides make (relatively) recent additions like `import_env_vars` completely moot. I'm not positive how best to test these changes, though local builds & GHA continue to work like a charm so it might be entirely vestigial?