### PR TITLE
Show editor toaster when copying `[codeblock]` in class reference

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -45,6 +45,7 @@
 #include "editor/editor_property_name_processor.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
+#include "editor/gui/editor_toaster.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/line_edit.h"
@@ -329,6 +330,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		OS::get_singleton()->shell_open(p_select);
 	} else if (p_select.begins_with("^")) { // Copy button.
 		DisplayServer::get_singleton()->clipboard_set(p_select.substr(1));
+		EditorToaster::get_singleton()->popup_str(TTR("Code snippet copied to clipboard."), EditorToaster::SEVERITY_INFO);
 	}
 }
 


### PR DESCRIPTION
A bit of visual feedback doesn't hurt.
![image](https://github.com/user-attachments/assets/b60b0b80-f14a-48dd-b455-c1cddc82ccac)
Feel free to suggest something more meaningful, if necessary(?)