### PR TITLE
Allow dragging to specific folders in filesystem dock

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5828,7 +5828,11 @@ PopupMenu *EditorNode::get_export_as_menu() {
 }
 
 void EditorNode::_dropped_files(const Vector<String> &p_files) {
-	String to_path = ProjectSettings::get_singleton()->globalize_path(FileSystemDock::get_singleton()->get_current_directory());
+	String to_path = FileSystemDock::get_singleton()->get_folder_path_at_mouse_position();
+	if (to_path.is_empty()) {
+		to_path = FileSystemDock::get_singleton()->get_current_directory();
+	}
+	to_path = ProjectSettings::get_singleton()->globalize_path(to_path);
 
 	_add_dropped_files_recursive(p_files, to_path);
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2749,6 +2749,15 @@ void FileSystemDock::remove_resource_tooltip_plugin(const Ref<EditorResourceTool
 	tooltip_plugins.remove_at(index);
 }
 
+String FileSystemDock::get_folder_path_at_mouse_position() const {
+	TreeItem *item = tree->get_item_at_position(tree->get_local_mouse_position());
+	if (!item) {
+		return String();
+	}
+	String fpath = item->get_metadata(0);
+	return fpath.get_base_dir();
+}
+
 Control *FileSystemDock::create_tooltip_for_path(const String &p_path) const {
 	if (p_path == "Favorites") {
 		// No tooltip for the "Favorites" group.

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -380,6 +380,7 @@ public:
 
 	String get_current_path() const;
 	String get_current_directory() const;
+	String get_folder_path_at_mouse_position() const;
 
 	void navigate_to_path(const String &p_path);
 	void focus_on_path();


### PR DESCRIPTION
from https://github.com/godotengine/godot/issues/99445
Before, any file dragged into the filesystem dock just went into the currently selected folder instead.

Behaviour is:
If dragged to folder: places into folder.
If dragged into another file: places into same folder as file.
If dragged into empty space: places into currently selected folder (or to base res:// folder if none are selected).

*Bugsquad edit:* Closes #80667