### PR TITLE
ColorPicker: Fix OKHSL circle in HSV mode

### DIFF
--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -211,6 +211,11 @@ private:
 	float h = 0.0;
 	float s = 0.0;
 	float v = 0.0;
+
+	float ok_hsl_h = 0.0;
+	float ok_hsl_s = 0.0;
+	float ok_hsl_l = 0.0;
+
 	Color last_color;
 
 	struct ThemeCache {


### PR DESCRIPTION
Fixes #68286.
OKHSL and HSV are different things, they should be stored separately in different fields.