### PR TITLE
Do not check for command intersections when not using the write list.

### DIFF
--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -527,7 +527,7 @@ void RenderingDeviceGraph::_add_command_to_graph(ResourceTracker **p_resource_tr
 				// The index is just the latest command index that wrote to the resource.
 				if (search_tracker->write_command_or_list_index == p_command_index) {
 					ERR_FAIL_MSG("Command can't have itself as a dependency.");
-				} else if (_check_command_intersection(resource_tracker, search_tracker->write_command_or_list_index, p_command_index)) {
+				} else {
 					_add_adjacent_command(search_tracker->write_command_or_list_index, p_command_index, r_command);
 				}
 			}


### PR DESCRIPTION
Fixes the follow up issue brought up [here](https://github.com/godotengine/godot/issues/99228#issuecomment-2487938922).

Just a small modification after the partial coverage rewrite. Now that partial coverage guarantees the write list will be used instead, there's no reason to actually check for intersections _when not using write lists_ as it'll just cause issues.

*Bugsquad edit:*
- Fixes #99228.