### PR TITLE
Fix error emitting when passing custom callable to `UndoRedo`

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -159,10 +159,11 @@ void UndoRedo::add_do_method(const Callable &p_callable) {
 		do_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(object));
 	}
 	do_op.type = Operation::TYPE_METHOD;
-	do_op.name = p_callable.get_method();
-	if (do_op.name == StringName()) {
+	if (p_callable.is_custom()) {
 		// There's no `get_method()` for custom callables, so use `operator String()` instead.
 		do_op.name = static_cast<String>(p_callable);
+	} else {
+		do_op.name = p_callable.get_method();
 	}
 
 	actions.write[current_action + 1].do_ops.push_back(do_op);
@@ -190,10 +191,11 @@ void UndoRedo::add_undo_method(const Callable &p_callable) {
 	}
 	undo_op.type = Operation::TYPE_METHOD;
 	undo_op.force_keep_in_merge_ends = force_keep_in_merge_ends;
-	undo_op.name = p_callable.get_method();
-	if (undo_op.name == StringName()) {
+	if (p_callable.is_custom()) {
 		// There's no `get_method()` for custom callables, so use `operator String()` instead.
 		undo_op.name = static_cast<String>(p_callable);
+	} else {
+		undo_op.name = p_callable.get_method();
 	}
 
 	actions.write[current_action + 1].undo_ops.push_back(undo_op);


### PR DESCRIPTION
To prevent emitting 
```
ERROR: Can't get method on CallableCustom "Delegate::Invoke".
   at: (core/variant/callable.cpp:443)
```
Which emitting every time user pass a custom callable to it (for example using `Callable.From` in C#).