### PR TITLE
Revert "ResourceLoader: Report error if resource type unrecognized"

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -295,13 +295,13 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 	load_paths_stack.push_back(original_path);
 
 	// Try all loaders and pick the first match for the type hint
-	bool loader_found = false;
+	bool found = false;
 	Ref<Resource> res;
 	for (int i = 0; i < loader_count; i++) {
 		if (!loader[i]->recognize_path(p_path, p_type_hint)) {
 			continue;
 		}
-		loader_found = true;
+		found = true;
 		res = loader[i]->load(p_path, original_path, r_error, p_use_sub_threads, r_progress, p_cache_mode);
 		if (!res.is_null()) {
 			break;
@@ -316,24 +316,15 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 		return res;
 	}
 
-	if (!loader_found) {
-		if (r_error) {
-			*r_error = ERR_FILE_UNRECOGNIZED;
-		}
-		ERR_FAIL_V_MSG(Ref<Resource>(), vformat("No loader found for resource: %s (expected type: %s)", p_path, p_type_hint));
-	}
+	ERR_FAIL_COND_V_MSG(found, Ref<Resource>(),
+			vformat("Failed loading resource: %s. Make sure resources have been imported by opening the project in the editor at least once.", p_path));
 
 #ifdef TOOLS_ENABLED
 	Ref<FileAccess> file_check = FileAccess::create(FileAccess::ACCESS_RESOURCES);
-	if (!file_check->file_exists(p_path)) {
-		if (r_error) {
-			*r_error = ERR_FILE_NOT_FOUND;
-		}
-		ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Resource file not found: %s (expected type: %s)", p_path, p_type_hint));
-	}
+	ERR_FAIL_COND_V_MSG(!file_check->file_exists(p_path), Ref<Resource>(), vformat("Resource file not found: %s (expected type: %s)", p_path, p_type_hint));
 #endif
 
-	ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Failed loading resource: %s. Make sure resources have been imported by opening the project in the editor at least once.", p_path));
+	ERR_FAIL_V_MSG(Ref<Resource>(), vformat("No loader found for resource: %s (expected type: %s)", p_path, p_type_hint));
 }
 
 // This implementation must allow re-entrancy for a task that started awaiting in a deeper stack frame.


### PR DESCRIPTION
- This reverts commit fe21913ee82c9e3fd660b511f618fce40cf43e49 / PR #97370.
- Fixes #99467.
- Reopens #95490.

PR #97370 actually seems benign and correct, but it seems to be exposing a pre-existing issue when the `r_error` code is now set and bubbles up. Ideally we'd just give this a bit of time to find a fixup, but we're about to build 4.4-dev5 right now and would prefer not to have a known regression on refactoring in an update that's centered around refactoring (UIDs).

So we're doing a quick revert for now, to re-try that PR (third time's the charm!) later on. CC @RandomShaper 