### PR TITLE
Improve how Project & Editor Settings look in online docs

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -2241,6 +2241,15 @@ def format_text_block(
                             repl_text = f"{target_class_name}.{target_name}"
                         if tag_state.name == "method":
                             repl_text = f"{repl_text}()"
+
+                        if tag_state.name == "member" and (
+                            target_class_name == "ProjectSettings" or target_class_name == "EditorSettings"
+                        ):
+                            repl_text = "(Editor)" if target_class_name == "EditorSettings" else ""
+                            for section in target_name.split("/"):
+                                repl_text += section.title() + " > "
+                            return repl_text
+
                         tag_text = f":ref:`{repl_text}<class_{sanitize_class_name(target_class_name)}{ref_type}_{target_name}>`"
                         escape_pre = True
                         escape_post = True


### PR DESCRIPTION

This is the equivalent of https://github.com/godotengine/godot/pull/89086 but for the online documentation.

I... have not tested this. I have yet to figure out how.