### PR TITLE
Remove temporary project conversion

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -514,24 +514,6 @@ void ProjectSettings::_convert_to_last_version(int p_from_version) {
 			}
 		}
 	}
-	if (p_from_version == 5) {
-		// Converts the device in events from -3 to -1.
-		// -3 was introduced in GH-97707 as a way to prevent a clash in device IDs, but as reported in GH-99243, this leads to problems.
-		// -3 was used during dev-releases, so this conversion helps to revert such affected projects.
-		// This conversion doesn't affect any other projects, since -3 is not used otherwise.
-		for (KeyValue<StringName, ProjectSettings::VariantContainer> &E : props) {
-			if (String(E.key).begins_with("input/")) {
-				Dictionary action = E.value.variant;
-				Array events = action["events"];
-				for (int i = 0; i < events.size(); i++) {
-					Ref<InputEvent> ev = events[i];
-					if (ev.is_valid() && ev->get_device() == -3) {
-						ev->set_device(-1);
-					}
-				}
-			}
-		}
-	}
 #endif // DISABLE_DEPRECATED
 }
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -103,14 +103,6 @@ bool EditorSettings::_set_only(const StringName &p_name, const Variant &p_value)
 
 			builtin_action_overrides[action_name].clear();
 			for (int ev_idx = 0; ev_idx < events.size(); ev_idx++) {
-#ifndef DISABLE_DEPRECATED
-				// -3 was introduced in GH-97707 as a way to prevent a clash in device IDs, but as reported in GH-99243, this leads to problems.
-				// -3 was used during dev-releases, so this conversion helps to revert such affected editor shortcuts.
-				Ref<InputEvent> x = events[ev_idx];
-				if (x.is_valid() && x->get_device() == -3) {
-					x->set_device(-1);
-				}
-#endif // DISABLE_DEPRECATED
 				im->action_add_event(action_name, events[ev_idx]);
 				builtin_action_overrides[action_name].push_back(events[ev_idx]);
 			}


### PR DESCRIPTION
This project conversion affects only projects, that were edited after #97707 (v4.4-dev4) and provides an easy way to upgrade these projects.

It seems reasonable to assume, that at that time of the next stable Godot-release all affected projects have been converted.
So I would like to suggest to merge this PR and remove the project conversion shortly before the next stable release,

For projects, that haven't been converted, we can provide an upgrade-strategy, that that consists of opening the project once with v4.4-dev5.

Follow-up to/Implements https://github.com/godotengine/godot/pull/99449#pullrequestreview-2449032498
