### PR TITLE
[RTL] Improve `hint` and `url` tags interaction.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1014,11 +1014,13 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 
 			Vector2 ul_start;
 			bool ul_started = false;
+			bool off_ul = false;
 			Color ul_color_prev;
 			Color ul_color;
 
 			Vector2 dot_ul_start;
 			bool dot_ul_started = false;
+			bool off_dot = false;
 			Color dot_ul_color_prev;
 			Color dot_ul_color;
 
@@ -1066,6 +1068,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 						if (ul_started && font_color != ul_color_prev) {
 							float y_off = upos;
 							float underline_width = MAX(1.0, uth * theme_cache.base_scale);
+							if (off_ul) {
+								y_off += underline_width * 3;
+							}
 							draw_line(ul_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), ul_color, underline_width);
 							ul_start = p_ofs + Vector2(off_step.x, off_step.y);
 							ul_color_prev = font_color;
@@ -1073,6 +1078,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 							ul_color.a *= 0.5;
 						} else if (!ul_started) {
 							ul_started = true;
+							if (dot_ul_started) {
+								off_ul = true;
+							}
 							ul_start = p_ofs + Vector2(off_step.x, off_step.y);
 							ul_color_prev = font_color;
 							ul_color = font_color;
@@ -1082,12 +1090,19 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 						ul_started = false;
 						float y_off = upos;
 						float underline_width = MAX(1.0, uth * theme_cache.base_scale);
+						if (off_ul) {
+							y_off += underline_width * 3;
+						}
+						off_ul = false;
 						draw_line(ul_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), ul_color, underline_width);
 					}
 					if (_find_hint(it, nullptr) && underline_hint) {
 						if (dot_ul_started && font_color != dot_ul_color_prev) {
 							float y_off = upos;
 							float underline_width = MAX(1.0, uth * theme_cache.base_scale);
+							if (off_dot) {
+								y_off += underline_width * 3;
+							}
 							draw_dashed_line(dot_ul_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), dot_ul_color, underline_width, MAX(2.0, underline_width * 2));
 							dot_ul_start = p_ofs + Vector2(off_step.x, off_step.y);
 							dot_ul_color_prev = font_color;
@@ -1095,6 +1110,9 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 							dot_ul_color.a *= 0.5;
 						} else if (!dot_ul_started) {
 							dot_ul_started = true;
+							if (ul_started) {
+								off_dot = true;
+							}
 							dot_ul_start = p_ofs + Vector2(off_step.x, off_step.y);
 							dot_ul_color_prev = font_color;
 							dot_ul_color = font_color;
@@ -1104,6 +1122,10 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 						dot_ul_started = false;
 						float y_off = upos;
 						float underline_width = MAX(1.0, uth * theme_cache.base_scale);
+						if (off_dot) {
+							y_off += underline_width * 3;
+						}
+						off_dot = false;
 						draw_dashed_line(dot_ul_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), dot_ul_color, underline_width, MAX(2.0, underline_width * 2));
 					}
 					if (_find_strikethrough(it)) {
@@ -1311,12 +1333,20 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 								ul_started = false;
 								float y_off = upos;
 								float underline_width = MAX(1.0, uth * theme_cache.base_scale);
+								if (off_ul) {
+									y_off += underline_width * 3;
+								}
+								off_ul = false;
 								draw_line(ul_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), ul_color, underline_width);
 							}
 							if (dot_ul_started) {
 								dot_ul_started = false;
 								float y_off = upos;
 								float underline_width = MAX(1.0, uth * theme_cache.base_scale);
+								if (off_dot) {
+									y_off += underline_width * 3;
+								}
+								off_dot = false;
 								draw_dashed_line(dot_ul_start + Vector2(0, y_off), p_ofs + Vector2(off_step.x, off_step.y + y_off), dot_ul_color, underline_width, MAX(2.0, underline_width * 2));
 							}
 							if (st_started) {


### PR DESCRIPTION
Improves `hint` and `url` tags interaction by adding offset to nested outline (only one level deep, since RTL currently support only one underline of the same time at a time).

<img width="703" alt="Screenshot 2024-11-21 at 11 49 50" src="https://github.com/user-attachments/assets/97b5e7c9-0656-41b4-bc1b-29c13797107d">

```
test [hint="tooltip"]hello[/hint] test [url="https://example.com"]hello[/url] test 
test [hint="tooltip"][url="https://example.com"]hello[/url][/hint] test 
test [hint=" tooltip"]world[url="https://example.com"]hello[/url]world[/hint] test
test [url="https://example.com"]world[hint="tooltip"]hello[/hint]world[/url] test
```