### PR TITLE
Additional fixes and improvements to JavaClassWrapper

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -28,6 +28,7 @@ android_files = [
     "display_server_android.cpp",
     "plugin/godot_plugin_jni.cpp",
     "rendering_context_driver_vulkan_android.cpp",
+    "variant/callable_jni.cpp",
 ]
 
 env_android = env.Clone()

--- a/platform/android/api/api.cpp
+++ b/platform/android/api/api.cpp
@@ -73,6 +73,9 @@ void JavaClassWrapper::_bind_methods() {
 }
 
 #if !defined(ANDROID_ENABLED)
+bool JavaClass::_get(const StringName &p_name, Variant &r_ret) const {
+	return false;
+}
 
 Variant JavaClass::callp(const StringName &, const Variant **, int, Callable::CallError &) {
 	return Variant();

--- a/platform/android/api/java_class_wrapper.h
+++ b/platform/android/api/java_class_wrapper.h
@@ -58,6 +58,8 @@ class JavaClass : public RefCounted {
 		ARG_TYPE_FLOAT,
 		ARG_TYPE_DOUBLE,
 		ARG_TYPE_STRING, //special case
+		ARG_TYPE_CHARSEQUENCE,
+		ARG_TYPE_CALLABLE,
 		ARG_TYPE_CLASS,
 		ARG_ARRAY_BIT = 1 << 16,
 		ARG_NUMBER_CLASS_BIT = 1 << 17,
@@ -123,7 +125,11 @@ class JavaClass : public RefCounted {
 				likelihood = 0.5;
 				break;
 			case ARG_TYPE_STRING:
+			case ARG_TYPE_CHARSEQUENCE:
 				r_type = Variant::STRING;
+				break;
+			case ARG_TYPE_CALLABLE:
+				r_type = Variant::CALLABLE;
 				break;
 			case ARG_TYPE_CLASS:
 				r_type = Variant::OBJECT;
@@ -163,9 +169,11 @@ class JavaClass : public RefCounted {
 				likelihood = 0.5;
 				break;
 			case ARG_ARRAY_BIT | ARG_TYPE_STRING:
+			case ARG_ARRAY_BIT | ARG_TYPE_CHARSEQUENCE:
 				r_type = Variant::PACKED_STRING_ARRAY;
 				break;
 			case ARG_ARRAY_BIT | ARG_TYPE_CLASS:
+			case ARG_ARRAY_BIT | ARG_TYPE_CALLABLE:
 				r_type = Variant::ARRAY;
 				break;
 		}
@@ -185,6 +193,7 @@ class JavaClass : public RefCounted {
 
 protected:
 	static void _bind_methods();
+	bool _get(const StringName &p_name, Variant &r_ret) const;
 
 public:
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -30,7 +30,7 @@
 
 #include "dir_access_jandroid.h"
 
-#include "string_android.h"
+#include "jni_utils.h"
 #include "thread_jandroid.h"
 
 #include "core/string/print_string.h"

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
@@ -35,6 +35,7 @@ import org.godotengine.godot.io.directory.DirectoryAccessHandler;
 import org.godotengine.godot.io.file.FileAccessHandler;
 import org.godotengine.godot.tts.GodotTTS;
 import org.godotengine.godot.utils.GodotNetUtils;
+import org.godotengine.godot.variant.Callable;
 
 import android.app.Activity;
 import android.content.res.AssetManager;
@@ -200,16 +201,26 @@ public class GodotLib {
 	 * @param p_id Id of the Godot object to invoke
 	 * @param p_method Name of the method to invoke
 	 * @param p_params Parameters to use for method invocation
+	 *
+	 * @deprecated Use {@link Callable#call(long, String, Object...)} instead.
 	 */
-	public static native void callobject(long p_id, String p_method, Object[] p_params);
+	@Deprecated
+	public static void callobject(long p_id, String p_method, Object[] p_params) {
+		Callable.call(p_id, p_method, p_params);
+	}
 
 	/**
 	 * Invoke method |p_method| on the Godot object specified by |p_id| during idle time.
 	 * @param p_id Id of the Godot object to invoke
 	 * @param p_method Name of the method to invoke
 	 * @param p_params Parameters to use for method invocation
+	 *
+	 * @deprecated Use {@link Callable#callDeferred(long, String, Object...)} instead.
 	 */
-	public static native void calldeferred(long p_id, String p_method, Object[] p_params);
+	@Deprecated
+	public static void calldeferred(long p_id, String p_method, Object[] p_params) {
+		Callable.callDeferred(p_id, p_method, p_params);
+	}
 
 	/**
 	 * Forward the results from a permission request.

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/AndroidRuntimePlugin.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/AndroidRuntimePlugin.kt
@@ -31,6 +31,7 @@
 package org.godotengine.godot.plugin
 
 import org.godotengine.godot.Godot
+import org.godotengine.godot.variant.Callable
 
 /**
  * Provides access to the Android runtime capabilities.
@@ -38,7 +39,7 @@ import org.godotengine.godot.Godot
  * For example, from gdscript, developers can use [getApplicationContext] to access system services
  * and check if the device supports vibration.
  *
- * var android_runtime = Engine.get_singleton("AndroidRuntime")
+ * 	var android_runtime = Engine.get_singleton("AndroidRuntime")
  * 	if android_runtime:
  * 		print("Checking if the device supports vibration")
  * 		var vibrator_service = android_runtime.getApplicationContext().getSystemService("vibrator")
@@ -51,13 +52,50 @@ import org.godotengine.godot.Godot
  * 			printerr("Unable to retrieve the vibrator service")
  * 	else:
  * 		printerr("Couldn't find AndroidRuntime singleton")
+ *
+ *
+ * Or it can be used to display an Android native toast from gdscript
+ *
+ * 	var android_runtime = Engine.get_singleton("AndroidRuntime")
+ * 	if android_runtime:
+ * 		var activity = android_runtime.getActivity()
+ *
+ * 		var toastCallable = func ():
+ * 			var ToastClass = JavaClassWrapper.wrap("android.widget.Toast")
+ * 			ToastClass.makeText(activity, "This is a test", ToastClass.LENGTH_LONG).show()
+ *
+ * 		activity.runOnUiThread(android_runtime.createRunnableFromGodotCallable(toastCallable))
+ * 	else:
+ * 		printerr("Unable to access android runtime")
  */
 class AndroidRuntimePlugin(godot: Godot) : GodotPlugin(godot) {
 	override fun getPluginName() = "AndroidRuntime"
 
+	/**
+	 * Provides access to the application context to GDScript
+	 */
 	@UsedByGodot
 	fun getApplicationContext() = activity?.applicationContext
 
+	/**
+	 * Provides access to the host activity to GDScript
+	 */
 	@UsedByGodot
 	override fun getActivity() = super.getActivity()
+
+	/**
+	 * Utility method used to create [Runnable] from Godot [Callable].
+	 */
+	@UsedByGodot
+	fun createRunnableFromGodotCallable(godotCallable: Callable): Runnable {
+		return Runnable { godotCallable.call() }
+	}
+
+	/**
+	 * Utility method used to create [java.util.concurrent.Callable] from Godot [Callable].
+	 */
+	@UsedByGodot
+	fun createCallableFromGodotCallable(godotCallable: Callable): java.util.concurrent.Callable<Any> {
+		return java.util.concurrent.Callable { godotCallable.call() }
+	}
 }

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -42,7 +42,6 @@
 #include "net_socket_android.h"
 #include "os_android.h"
 #include "plugin/godot_plugin_jni.h"
-#include "string_android.h"
 #include "thread_jandroid.h"
 #include "tts_android.h"
 
@@ -486,51 +485,6 @@ JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getEditorSetting(J
 #endif
 
 	return env->NewStringUTF(editor_setting_value.utf8().get_data());
-}
-
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *env, jclass clazz, jlong ID, jstring method, jobjectArray params) {
-	Object *obj = ObjectDB::get_instance(ObjectID(ID));
-	ERR_FAIL_NULL(obj);
-
-	String str_method = jstring_to_string(method, env);
-
-	int count = env->GetArrayLength(params);
-
-	Variant *vlist = (Variant *)alloca(sizeof(Variant) * count);
-	const Variant **vptr = (const Variant **)alloca(sizeof(Variant *) * count);
-
-	for (int i = 0; i < count; i++) {
-		jobject jobj = env->GetObjectArrayElement(params, i);
-		ERR_FAIL_NULL(jobj);
-		memnew_placement(&vlist[i], Variant(_jobject_to_variant(env, jobj)));
-		vptr[i] = &vlist[i];
-		env->DeleteLocalRef(jobj);
-	}
-
-	Callable::CallError err;
-	obj->callp(str_method, vptr, count, err);
-}
-
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *env, jclass clazz, jlong ID, jstring method, jobjectArray params) {
-	Object *obj = ObjectDB::get_instance(ObjectID(ID));
-	ERR_FAIL_NULL(obj);
-
-	String str_method = jstring_to_string(method, env);
-
-	int count = env->GetArrayLength(params);
-
-	Variant *args = (Variant *)alloca(sizeof(Variant) * count);
-	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * count);
-
-	for (int i = 0; i < count; i++) {
-		jobject jobj = env->GetObjectArrayElement(params, i);
-		ERR_FAIL_NULL(jobj);
-		memnew_placement(&args[i], Variant(_jobject_to_variant(env, jobj)));
-		argptrs[i] = &args[i];
-		env->DeleteLocalRef(jobj);
-	}
-
-	Callable(obj, str_method).call_deferredp(argptrs, count);
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onNightModeChanged(JNIEnv *env, jclass clazz) {

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -62,8 +62,6 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusin(JNIEnv *env, 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_focusout(JNIEnv *env, jclass clazz);
 JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getGlobal(JNIEnv *env, jclass clazz, jstring path);
 JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getEditorSetting(JNIEnv *env, jclass clazz, jstring p_setting_key);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *env, jclass clazz, jlong ID, jstring method, jobjectArray params);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *env, jclass clazz, jlong ID, jstring method, jobjectArray params);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setVirtualKeyboardHeight(JNIEnv *env, jclass clazz, jint p_height);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResult(JNIEnv *env, jclass clazz, jstring p_permission, jboolean p_result);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onNightModeChanged(JNIEnv *env, jclass clazz);

--- a/platform/android/java_godot_view_wrapper.h
+++ b/platform/android/java_godot_view_wrapper.h
@@ -31,7 +31,7 @@
 #ifndef JAVA_GODOT_VIEW_WRAPPER_H
 #define JAVA_GODOT_VIEW_WRAPPER_H
 
-#include "string_android.h"
+#include "jni_utils.h"
 
 #include "core/math/vector2.h"
 

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -32,7 +32,6 @@
 #define JAVA_GODOT_WRAPPER_H
 
 #include "java_godot_view_wrapper.h"
-#include "string_android.h"
 
 #include "core/math/color.h"
 #include "core/templates/list.h"

--- a/platform/android/jni_utils.h
+++ b/platform/android/jni_utils.h
@@ -31,9 +31,10 @@
 #ifndef JNI_UTILS_H
 #define JNI_UTILS_H
 
-#include "string_android.h"
+#include "thread_jandroid.h"
 
 #include "core/config/engine.h"
+#include "core/string/ustring.h"
 #include "core/variant/variant.h"
 
 #include <jni.h>
@@ -52,6 +53,49 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj);
 
 Variant::Type get_jni_type(const String &p_type);
 
-String get_jni_sig(const String &p_type);
+/**
+ * Convert a Godot Callable to a org.godotengine.godot.variant.Callable java object.
+ * @param p_env JNI environment instance
+ * @param p_callable Callable parameter to convert. If null or invalid type, a null jobject is returned.
+ * @return org.godotengine.godot.variant.Callable jobject or null
+ */
+jobject callable_to_jcallable(JNIEnv *p_env, const Variant &p_callable);
+
+/**
+ * Convert a org.godotengine.godot.variant.Callable java object to a Godot Callable variant.
+ * @param p_env JNI environment instance
+ * @param p_jcallable_obj org.godotengine.godot.variant.Callable java object to convert.
+ * @return Callable variant
+ */
+Callable jcallable_to_callable(JNIEnv *p_env, jobject p_jcallable_obj);
+
+/**
+ * Converts a java.lang.CharSequence object to a Godot String.
+ * @param p_env  JNI environment instance
+ * @param p_charsequence java.lang.CharSequence object to convert
+ * @return Godot String instance.
+ */
+String charsequence_to_string(JNIEnv *p_env, jobject p_charsequence);
+
+/**
+ * Converts JNI jstring to Godot String.
+ * @param source Source JNI string. If null an empty string is returned.
+ * @param env JNI environment instance. If null obtained by get_jni_env().
+ * @return Godot string instance.
+ */
+static inline String jstring_to_string(jstring source, JNIEnv *env = nullptr) {
+	String result;
+	if (source) {
+		if (!env) {
+			env = get_jni_env();
+		}
+		const char *const source_utf8 = env->GetStringUTFChars(source, nullptr);
+		if (source_utf8) {
+			result.parse_utf8(source_utf8);
+			env->ReleaseStringUTFChars(source, source_utf8);
+		}
+	}
+	return result;
+}
 
 #endif // JNI_UTILS_H

--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -33,7 +33,6 @@
 #include "api/java_class_wrapper.h"
 #include "api/jni_singleton.h"
 #include "jni_utils.h"
-#include "string_android.h"
 
 #include "core/config/engine.h"
 #include "core/error/error_macros.h"
@@ -136,5 +135,10 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitS
 	}
 
 	singleton->emit_signalp(StringName(signal_name), args, count);
+
+	// Manually invoke the destructor to decrease the reference counts for the variant arguments.
+	for (int i = 0; i < count; i++) {
+		variant_params[i].~Variant();
+	}
 }
 }

--- a/platform/android/tts_android.cpp
+++ b/platform/android/tts_android.cpp
@@ -32,7 +32,6 @@
 
 #include "java_godot_wrapper.h"
 #include "os_android.h"
-#include "string_android.h"
 #include "thread_jandroid.h"
 
 bool TTS_Android::initialized = false;

--- a/platform/android/variant/callable_jni.cpp
+++ b/platform/android/variant/callable_jni.cpp
@@ -1,0 +1,130 @@
+/**************************************************************************/
+/*  callable_jni.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "callable_jni.h"
+
+#include "jni_utils.h"
+
+#include "core/error/error_macros.h"
+#include "core/object/object.h"
+
+static Callable _generate_callable(JNIEnv *p_env, jlong p_object_id, jstring p_method_name, jobjectArray p_parameters) {
+	Object *obj = ObjectDB::get_instance(ObjectID(p_object_id));
+	ERR_FAIL_NULL_V(obj, Callable());
+
+	String str_method = jstring_to_string(p_method_name, p_env);
+
+	int count = p_env->GetArrayLength(p_parameters);
+
+	Variant *args = (Variant *)alloca(sizeof(Variant) * count);
+	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * count);
+
+	for (int i = 0; i < count; i++) {
+		jobject jobj = p_env->GetObjectArrayElement(p_parameters, i);
+		ERR_FAIL_NULL_V(jobj, Callable());
+		memnew_placement(&args[i], Variant(_jobject_to_variant(p_env, jobj)));
+		argptrs[i] = &args[i];
+		p_env->DeleteLocalRef(jobj);
+	}
+
+	Callable ret = Callable(obj, str_method).bindp(argptrs, count);
+
+	// Manually invoke the destructor to decrease the reference counts for the variant arguments.
+	for (int i = 0; i < count; i++) {
+		args[i].~Variant();
+	}
+
+	return ret;
+}
+
+extern "C" {
+JNIEXPORT jobject JNICALL Java_org_godotengine_godot_variant_Callable_nativeCall(JNIEnv *p_env, jclass p_clazz, jlong p_native_callable, jobjectArray p_parameters) {
+	const Variant *callable_variant = reinterpret_cast<const Variant *>(p_native_callable);
+	ERR_FAIL_NULL_V(callable_variant, nullptr);
+	if (callable_variant->get_type() != Variant::CALLABLE) {
+		return nullptr;
+	}
+
+	int count = p_env->GetArrayLength(p_parameters);
+
+	Variant *args = (Variant *)alloca(sizeof(Variant) * count);
+	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * count);
+
+	for (int i = 0; i < count; i++) {
+		jobject jobj = p_env->GetObjectArrayElement(p_parameters, i);
+		ERR_FAIL_NULL_V(jobj, nullptr);
+		memnew_placement(&args[i], Variant(_jobject_to_variant(p_env, jobj)));
+		argptrs[i] = &args[i];
+		p_env->DeleteLocalRef(jobj);
+	}
+
+	Callable callable = *callable_variant;
+	jobject ret = nullptr;
+	if (callable.is_valid()) {
+		Callable::CallError err;
+		Variant result;
+		callable.callp(argptrs, count, result, err);
+		jvalret jresult = _variant_to_jvalue(p_env, result.get_type(), &result, true);
+		ret = jresult.obj;
+	}
+
+	// Manually invoke the destructor to decrease the reference counts for the variant arguments.
+	for (int i = 0; i < count; i++) {
+		args[i].~Variant();
+	}
+
+	return ret;
+}
+
+JNIEXPORT jobject JNICALL Java_org_godotengine_godot_variant_Callable_nativeCallObject(JNIEnv *p_env, jclass p_clazz, jlong p_object_id, jstring p_method_name, jobjectArray p_parameters) {
+	Callable callable = _generate_callable(p_env, p_object_id, p_method_name, p_parameters);
+	if (callable.is_valid()) {
+		Variant result = callable.call();
+		jvalret jresult = _variant_to_jvalue(p_env, result.get_type(), &result, true);
+		return jresult.obj;
+	} else {
+		return nullptr;
+	}
+}
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_variant_Callable_nativeCallObjectDeferred(JNIEnv *p_env, jclass p_clazz, jlong p_object_id, jstring p_method_name, jobjectArray p_parameters) {
+	Callable callable = _generate_callable(p_env, p_object_id, p_method_name, p_parameters);
+	if (callable.is_valid()) {
+		callable.call_deferred();
+	}
+}
+
+JNIEXPORT void JNICALL
+Java_org_godotengine_godot_variant_Callable_releaseNativePointer(JNIEnv *p_env, jclass clazz, jlong p_native_pointer) {
+	Variant *variant = reinterpret_cast<Variant *>(p_native_pointer);
+	ERR_FAIL_NULL(variant);
+	memdelete(variant);
+}
+}

--- a/platform/android/variant/callable_jni.h
+++ b/platform/android/variant/callable_jni.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  string_android.h                                                      */
+/*  callable_jni.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,34 +28,16 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef STRING_ANDROID_H
-#define STRING_ANDROID_H
-
-#include "thread_jandroid.h"
-
-#include "core/string/ustring.h"
+#ifndef CALLABLE_JNI_H
+#define CALLABLE_JNI_H
 
 #include <jni.h>
 
-/**
- * Converts JNI jstring to Godot String.
- * @param source Source JNI string. If null an empty string is returned.
- * @param env JNI environment instance. If null obtained by get_jni_env().
- * @return Godot string instance.
- */
-static inline String jstring_to_string(jstring source, JNIEnv *env = nullptr) {
-	String result;
-	if (source) {
-		if (!env) {
-			env = get_jni_env();
-		}
-		const char *const source_utf8 = env->GetStringUTFChars(source, nullptr);
-		if (source_utf8) {
-			result.parse_utf8(source_utf8);
-			env->ReleaseStringUTFChars(source, source_utf8);
-		}
-	}
-	return result;
+extern "C" {
+JNIEXPORT jobject JNICALL Java_org_godotengine_godot_variant_Callable_nativeCall(JNIEnv *p_env, jclass p_clazz, jlong p_native_callable, jobjectArray p_parameters);
+JNIEXPORT jobject JNICALL Java_org_godotengine_godot_variant_Callable_nativeCallObject(JNIEnv *p_env, jclass p_clazz, jlong p_object_id, jstring p_method_name, jobjectArray p_parameters);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_variant_Callable_nativeCallObjectDeferred(JNIEnv *p_env, jclass p_clazz, jlong p_object_id, jstring p_method_name, jobjectArray p_parameters);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_variant_Callable_releaseNativePointer(JNIEnv *p_env, jclass clazz, jlong p_native_pointer);
 }
 
-#endif // STRING_ANDROID_H
+#endif // CALLABLE_JNI_H


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/96182

- Fix crashing bug when invoking Java class constructor with parameters
- Add support for accessing class constants
- Add support for Godot `Callable` arguments. A Godot `Callable` can be wrapped by a Java `Runnable` to allow Java logic to run arbitrary Godot lambdas
- Automatically convert `java.lang.CharSequence` to Godot `String` as needed
- Code cleanup

Those fixes make https://github.com/godotengine/godot-proposals/issues/11189 feasible out of the box.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
