### PR TITLE
ResourceLoader: Report appropriate error code when no suitable loader is found

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -316,14 +316,34 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 		return res;
 	}
 
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		if (ResourceFormatImporter::get_singleton()->get_importer_by_extension(p_path.get_extension()).is_valid()) {
+			// The format is known to the editor, but the file hasn't been imported
+			// (otherwise, ResourceFormatImporter would have been found as a suitable loader).
+			found = true;
+			if (r_error) {
+				*r_error = ERR_FILE_NOT_FOUND;
+			}
+		}
+	}
+#endif
 	ERR_FAIL_COND_V_MSG(found, Ref<Resource>(),
 			vformat("Failed loading resource: %s. Make sure resources have been imported by opening the project in the editor at least once.", p_path));
 
 #ifdef TOOLS_ENABLED
 	Ref<FileAccess> file_check = FileAccess::create(FileAccess::ACCESS_RESOURCES);
-	ERR_FAIL_COND_V_MSG(!file_check->file_exists(p_path), Ref<Resource>(), vformat("Resource file not found: %s (expected type: %s)", p_path, p_type_hint));
+	if (!file_check->file_exists(p_path)) {
+		if (r_error) {
+			*r_error = ERR_FILE_NOT_FOUND;
+		}
+		ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Resource file not found: %s (expected type: %s)", p_path, p_type_hint));
+	}
 #endif
 
+	if (r_error) {
+		*r_error = ERR_FILE_UNRECOGNIZED;
+	}
 	ERR_FAIL_V_MSG(Ref<Resource>(), vformat("No loader found for resource: %s (expected type: %s)", p_path, p_type_hint));
 }
 


### PR DESCRIPTION
New version of the reverted #97370.

One difference worth mentioning compared to the reverted PR is that, in order to make a simpler diff, reporting the file doesn't 
exist is more prioritary than telling the extension is unknown. I don't think we have reasons to prefer one over the other.

E.g., loading `thing.aaa`, which doesn't exist:
- Old PR: `ERR_FILE_UNRECOGNIZED`.
- This PR: `ERR_FILE_NOT_FOUND`.

If the file exists, then this PR will then do report `ERR_FILE_UNRECOGNIZED`.

Fixes #95490.