### PR TITLE
Add "Follow Selection" in the 3D editor by using Center Selection twice

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2694,6 +2694,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/focus_selection", event_mod)) {
 			_menu_option(VIEW_CENTER_TO_SELECTION);
+			times_focused_consecutively += 1;
 		}
 		if (ED_IS_SHORTCUT("spatial_editor/align_transform_with_view", event_mod)) {
 			_menu_option(VIEW_ALIGN_TRANSFORM_WITH_VIEW);
@@ -2875,6 +2876,8 @@ void Node3DEditorViewport::_nav_pan(Ref<InputEventWithModifiers> p_event, const 
 	translation *= cursor.distance / DISTANCE_DEFAULT;
 	camera_transform.translate_local(translation);
 	cursor.pos = camera_transform.origin;
+
+	_disable_follow_mode();
 }
 
 void Node3DEditorViewport::_nav_zoom(Ref<InputEventWithModifiers> p_event, const Vector2 &p_relative) {
@@ -3183,6 +3186,8 @@ void Node3DEditorViewport::_update_freelook(real_t delta) {
 	const Vector3 motion = direction * speed * delta;
 	cursor.pos += motion;
 	cursor.eye_pos += motion;
+
+	_disable_follow_mode();
 }
 
 void Node3DEditorViewport::set_message(const String &p_message, float p_time) {
@@ -3381,6 +3386,20 @@ void Node3DEditorViewport::_notification(int p_what) {
 			}
 
 			_update_freelook(delta);
+
+			if (focused_node_id.is_valid() && get_selected_count() > 0 && times_focused_consecutively >= 2 && times_focused_consecutively % 2 == 0) {
+				Node *focused_node = ObjectDB::get_instance<Node>(focused_node_id);
+				if (focused_node) {
+					follow_mode->set_text(vformat(TTR("Following %s"), focused_node->get_name()));
+					follow_mode->set_button_icon(get_editor_theme_icon(focused_node->get_class()));
+					follow_mode->show();
+					focus_selection();
+				} else {
+					_disable_follow_mode();
+				}
+			} else {
+				follow_mode->hide();
+			}
 
 			Node *scene_root = SceneTreeDock::get_singleton()->get_editor_data()->get_edited_scene_root();
 			if (previewing_cinema && scene_root != nullptr) {
@@ -3677,6 +3696,8 @@ void Node3DEditorViewport::_notification(int p_what) {
 			override_label_colors(view_display_menu);
 			override_button_stylebox(translation_preview_button, information_3d_stylebox);
 			override_label_colors(translation_preview_button);
+			override_button_stylebox(follow_mode, information_3d_stylebox);
+			override_label_colors(follow_mode);
 			override_button_stylebox(preview_camera, information_3d_stylebox);
 			override_label_colors(preview_camera);
 
@@ -4085,6 +4106,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 		} break;
 		case VIEW_CENTER_TO_ORIGIN: {
 			cursor.pos = Vector3(0, 0, 0);
+			_disable_follow_mode();
 
 		} break;
 		case VIEW_CENTER_TO_SELECTION: {
@@ -4541,6 +4563,11 @@ void Node3DEditorViewport::_finish_gizmo_instances() {
 	RS::get_singleton()->free_rid(trackball_sphere_instance);
 }
 
+void Node3DEditorViewport::_disable_follow_mode() {
+	// Exit follow mode by resetting the number of times the follow shortcut was used consecutively.
+	times_focused_consecutively = 0;
+}
+
 void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
 	ERR_FAIL_COND(p_activate && !preview);
 	ERR_FAIL_COND(!p_activate && !previewing);
@@ -4965,6 +4992,10 @@ void Node3DEditorViewport::focus_selection() {
 	int count = 0;
 
 	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+	focused_node_id = ObjectID();
+	if (!selection.is_empty()) {
+		focused_node_id = selection.front()->get()->get_instance_id();
+	}
 
 	for (Node *node : selection) {
 		Node3D *node_3d = Object::cast_to<Node3D>(node);
@@ -6392,6 +6423,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_display_menu->get_popup()->add_separator();
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
+	view_display_menu->get_popup()->set_item_tooltip(-1, TTR("Press Focus Selection twice to start following the selection as it moves. Press it yet another time to stop following the selection."));
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);
 	view_display_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &Node3DEditorViewport::_menu_option));
@@ -6418,6 +6450,12 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	translation_preview_button = memnew(EditorTranslationPreviewButton);
 	hbox->add_child(translation_preview_button);
+
+	follow_mode = memnew(Button);
+	follow_mode->set_tooltip_text(TTR("Click to stop following this node as it moves."));
+	follow_mode->hide();
+	vbox->add_child(follow_mode);
+	follow_mode->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditorViewport::_disable_follow_mode));
 
 	preview_camera = memnew(CheckBox);
 	preview_camera->set_text(TTRC("Preview"));

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -244,9 +244,12 @@ private:
 	Node *target_node = nullptr;
 	Point2 drop_pos;
 
+	ObjectID focused_node_id;
+
 	EditorSelection *editor_selection = nullptr;
 
 	Button *translation_preview_button = nullptr;
+	Button *follow_mode = nullptr;
 	CheckBox *preview_camera = nullptr;
 	SubViewportContainer *subviewport_container = nullptr;
 
@@ -502,10 +505,12 @@ private:
 
 	bool previewing_camera = false;
 	bool previewing_cinema = false;
+	int times_focused_consecutively = 0;
 	bool _is_node_locked(const Node *p_node) const;
 	void _preview_exited_scene();
 	void _preview_camera_property_changed();
 	void _update_centered_labels();
+	void _disable_follow_mode();
 	void _toggle_camera_preview(bool);
 	void _toggle_cinema_preview(bool);
 	void _init_gizmo_instance(int p_idx);


### PR DESCRIPTION
When pressing the Focus Selection shortcut twice, you will begin following the current selection. This also applies to selection changes.

The effect is undone by pressing the Focus Selection shortcut another time, using the Focus Origin shortcut, or by panning/using freelook on the 3D editor camera. (Orbiting or switching between perspective and orthogonal does not undo the effect.)

Some use cases include:

- Previewing lighting on a dynamic object as it moves across the scene.
- More generally, previewing something moving through a scene using an AnimationPlayer, which comes handy when paired with PathFollow3D.
- Jumping quickly from an object to another, while keeping your hand free of having to press <kbd>F</kbd> constantly.

___

- This closes https://github.com/godotengine/godot-proposals/issues/3164.

**Testing project:** [test_follow_selection.zip](https://github.com/user-attachments/files/17848437/test_follow_selection.zip)

## Preview

Following the selection will also follow other selected nodes, so you can iterate quickly on different nodes that may be spread far away from each other:

https://github.com/user-attachments/assets/78efa041-24ae-4bb7-ad57-617dc501f486

While following the selection, you can manipulate it as usual, e.g. with Blender-style manipulation shortcuts:

https://github.com/user-attachments/assets/d91ce577-3666-480e-8b08-d515db6deee3

This also pairs well with grid snapping and Blender-style manipulation by entering units on the keyboard:

https://github.com/user-attachments/assets/0478f64d-2f59-49ce-adea-2b8aff002698

Lastly, it works with keyboard-based camera manipulation too:

https://github.com/user-attachments/assets/2bb9b05d-c7a5-4440-acf1-9d47b840c126