### PR TITLE
Add `AudioStreamGeneratorPlayback::get_frames_buffered()` and `AudioStreamGeneratorPlayback::get_frames_buffer_length()` methods

### DIFF
--- a/doc/classes/AudioStreamGeneratorPlayback.xml
+++ b/doc/classes/AudioStreamGeneratorPlayback.xml
@@ -30,6 +30,18 @@
 				Returns the number of frames that can be pushed to the audio sample data buffer without overflowing it. If the result is [code]0[/code], the buffer is full.
 			</description>
 		</method>
+		<method name="get_frames_buffered" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of frames that are currently queued in the audio sample data buffer. If the result is [code]0[/code], the buffer is empty.
+			</description>
+		</method>
+		<method name="get_frames_buffer_length" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total size of the internal audio sample data buffer in frames.
+			</description>
+		</method>
 		<method name="get_skips" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/doc/classes/AudioStreamGeneratorPlayback.xml
+++ b/doc/classes/AudioStreamGeneratorPlayback.xml
@@ -30,16 +30,16 @@
 				Returns the number of frames that can be pushed to the audio sample data buffer without overflowing it. If the result is [code]0[/code], the buffer is full.
 			</description>
 		</method>
-		<method name="get_frames_buffered" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the number of frames that are currently queued in the audio sample data buffer. If the result is [code]0[/code], the buffer is empty.
-			</description>
-		</method>
 		<method name="get_frames_buffer_length" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the total size of the internal audio sample data buffer in frames.
+			</description>
+		</method>
+		<method name="get_frames_buffered" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of frames that are currently queued in the audio sample data buffer. If the result is [code]0[/code], the buffer is empty.
 			</description>
 		</method>
 		<method name="get_skips" qualifiers="const">

--- a/servers/audio/effects/audio_stream_generator.cpp
+++ b/servers/audio/effects/audio_stream_generator.cpp
@@ -132,6 +132,14 @@ int AudioStreamGeneratorPlayback::get_frames_available() const {
 	return buffer.space_left();
 }
 
+int AudioStreamGeneratorPlayback::get_frames_buffered() const {
+	return buffer.data_left();
+}
+
+int AudioStreamGeneratorPlayback::get_frames_buffer_length() const {
+	return buffer.size();
+}
+
 int AudioStreamGeneratorPlayback::get_skips() const {
 	return skips;
 }
@@ -208,6 +216,8 @@ void AudioStreamGeneratorPlayback::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("can_push_buffer", "amount"), &AudioStreamGeneratorPlayback::can_push_buffer);
 	ClassDB::bind_method(D_METHOD("push_buffer", "frames"), &AudioStreamGeneratorPlayback::push_buffer);
 	ClassDB::bind_method(D_METHOD("get_frames_available"), &AudioStreamGeneratorPlayback::get_frames_available);
+	ClassDB::bind_method(D_METHOD("get_frames_buffered"), &AudioStreamGeneratorPlayback::get_frames_buffered);
+	ClassDB::bind_method(D_METHOD("get_frames_buffer_length"), &AudioStreamGeneratorPlayback::get_frames_buffer_length);
 	ClassDB::bind_method(D_METHOD("get_skips"), &AudioStreamGeneratorPlayback::get_skips);
 	ClassDB::bind_method(D_METHOD("clear_buffer"), &AudioStreamGeneratorPlayback::clear_buffer);
 }

--- a/servers/audio/effects/audio_stream_generator.h
+++ b/servers/audio/effects/audio_stream_generator.h
@@ -87,6 +87,8 @@ public:
 	bool can_push_buffer(int p_frames) const;
 	bool push_buffer(const PackedVector2Array &p_frames);
 	int get_frames_available() const;
+	int get_frames_buffered() const;
+	int get_frames_buffer_length() const;
 	int get_skips() const;
 
 	virtual void tag_used_streams() override;


### PR DESCRIPTION
Implement `AudioStreamGeneratorPlayback::get_frames_buffered()` and `AudioStreamGeneratorPlayback::get_frames_buffer_length()` methods in order to streamline using `AudioStreamGenerator` as a queue for procedurally/externally generated audio frames.

Implements  [godotengine/godot-proposals#11180](https://github.com/godotengine/godot-proposals/issues/11180).

I would like to point out that `AudioEffectCapture` has equivalent methods to the ones added in this PR (`AudioEffectCapture::get_frames_available()` and `AudioEffectCapture::get_buffer_length_frames()`).