### PR TITLE
[Windows] Fix TTS events arriving out of order.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3244,6 +3244,10 @@ void DisplayServerWindows::process_events() {
 	}
 	_THREAD_SAFE_UNLOCK_
 
+	if (tts) {
+		tts->process_events();
+	}
+
 	if (!drop_events) {
 		_process_key_events();
 		Input::get_singleton()->flush_buffered_events();

--- a/platform/windows/tts_windows.cpp
+++ b/platform/windows/tts_windows.cpp
@@ -43,7 +43,7 @@ void __stdcall TTS_Windows::speech_event_callback(WPARAM wParam, LPARAM lParam) 
 			} else if (event.eEventId == SPEI_END_INPUT_STREAM) {
 				DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_ENDED, tts->ids[stream_num].id);
 				tts->ids.erase(stream_num);
-				tts->_update_tts();
+				tts->update_requested = true;
 			} else if (event.eEventId == SPEI_WORD_BOUNDARY) {
 				const Char16String &string = tts->ids[stream_num].string;
 				int pos = 0;
@@ -60,8 +60,8 @@ void __stdcall TTS_Windows::speech_event_callback(WPARAM wParam, LPARAM lParam) 
 	}
 }
 
-void TTS_Windows::_update_tts() {
-	if (!is_speaking() && !paused && queue.size() > 0) {
+void TTS_Windows::process_events() {
+	if (update_requested && !paused && queue.size() > 0 && !is_speaking()) {
 		DisplayServer::TTSUtterance &message = queue.front()->get();
 
 		String text;
@@ -110,6 +110,8 @@ void TTS_Windows::_update_tts() {
 		ids[(uint32_t)stream_number] = ut;
 
 		queue.pop_front();
+
+		update_requested = false;
 	}
 }
 
@@ -207,7 +209,7 @@ void TTS_Windows::speak(const String &p_text, const String &p_voice, int p_volum
 	if (is_paused()) {
 		resume();
 	} else {
-		_update_tts();
+		update_requested = true;
 	}
 }
 

--- a/platform/windows/tts_windows.h
+++ b/platform/windows/tts_windows.h
@@ -55,9 +55,9 @@ class TTS_Windows {
 		int id;
 	};
 	HashMap<uint32_t, UTData> ids;
+	bool update_requested = false;
 
 	static void __stdcall speech_event_callback(WPARAM wParam, LPARAM lParam);
-	void _update_tts();
 
 	static TTS_Windows *singleton;
 
@@ -72,6 +72,8 @@ public:
 	void pause();
 	void resume();
 	void stop();
+
+	void process_events();
 
 	TTS_Windows();
 	~TTS_Windows();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/99166

Ensures TTS query is updated only after processing pending TTS events (processed by hidden window message loop).
