### PR TITLE
Make loading translations from threads safe

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -80,8 +80,10 @@ void Translation::set_locale(const String &p_locale) {
 	if (Thread::is_main_thread()) {
 		_notify_translation_changed_if_applies();
 	} else {
-		// Avoid calling non-thread-safe functions here.
-		callable_mp(this, &Translation::_notify_translation_changed_if_applies).call_deferred();
+		// This has to happen on the main thread (bypassing the ResourceLoader per-thread call queue)
+		// because it interacts with the generally non-thread-safe window management, leading to
+		// different issues across platforms otherwise.
+		MessageQueue::get_main_singleton()->push_callable(callable_mp(this, &Translation::_notify_translation_changed_if_applies));
 	}
 }
 


### PR DESCRIPTION
Fixes #98577.

Note that when loading a translation from a thread, by the time the load is reported to be complete, the `NOTIFICATION_TRANSLATION_CHANGED` may have not been delivered yet. That will happen the next time the message queue is flushed, so no later than one frame. However, if that's an issue, I can add some extra logic so resource classes have a way to communicate the `ResourceLoader` it shouldn't call the load complete until some condition has been met. That's what happens with the resource changed mechanism, for instance.