### PR TITLE
[3.x] Ameliorate performance regression due to directional shadow `fade_start`

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2799,7 +2799,10 @@ void RasterizerSceneGLES3::_setup_directional_light(int p_index, const Transform
 		const float fade_start = li->light_ptr->param[VS::LIGHT_PARAM_SHADOW_FADE_START];
 		// Using 1.0 would break `smoothstep()` in the shader.
 		ubo_data.fade_from = -ubo_data.shadow_split_offsets[shadow_count - 1] * MIN(fade_start, 0.999);
-		ubo_data.fade_to = -ubo_data.shadow_split_offsets[shadow_count - 1];
+
+		// To prevent the need for a fade to, store the fade to in the final split offset.
+		// It will either be the same as before, or the maximum split offset.
+		ubo_data.shadow_split_offsets[3] = ubo_data.shadow_split_offsets[shadow_count - 1];
 	}
 
 	glBindBuffer(GL_UNIFORM_BUFFER, state.directional_ubo);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -592,8 +592,7 @@ public:
 		float shadow_split_offsets[4];
 
 		float fade_from;
-		float fade_to;
-		float pad[2];
+		float pad[3];
 	};
 
 	struct LightInstance : public RID_Data {

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -148,8 +148,7 @@ layout(std140) uniform DirectionalLightData { //ubo:3
 	mediump vec4 shadow_split_offsets;
 
 	mediump float fade_from;
-	mediump float fade_to;
-	mediump vec2 pad;
+	mediump vec3 pad;
 };
 
 #endif //ubershader-skip
@@ -848,8 +847,7 @@ layout(std140) uniform DirectionalLightData {
 	mediump vec4 shadow_split_offsets;
 
 	mediump float fade_from;
-	mediump float fade_to;
-	mediump vec2 pad;
+	mediump vec3 pad;
 };
 
 uniform highp sampler2DShadow directional_shadow; // texunit:-5
@@ -2292,7 +2290,7 @@ FRAGMENT_SHADER_CODE
 			shadow = min(shadow, contact_shadow);
 		}
 #endif //ubershader-runtime
-		float pssm_fade = smoothstep(fade_from, fade_to, vertex.z);
+		float pssm_fade = smoothstep(fade_from, -shadow_split_offsets.w, vertex.z);
 		light_attenuation = mix(mix(shadow_color_contact.rgb, vec3(1.0), shadow), vec3(1.0), pssm_fade);
 	}
 


### PR DESCRIPTION
Stores `fade_to` by reusing `shadow_split_offsets.w`.

Draft as it may be worth discussing the best approach here, this PR seems to work, but it may be GPU / driver dependent.

Helps address #99468
Performance regression introduced by #60246

## Notes
* As I mentioned on the original PR, the `fade_to` is duplicating information already sent in `shadow_split_offsets`.
* This seems to fix the major performance regression in `GLES3`, increasing FPS from 260 to 312 in "3D platformer" for me.
* Possibly similar could be applied to `GLES2`, although that suffers less.
* Also may apply to 4.x.
* It is possible we can bandit another uniform to send the `fade_from`, at present it is using 4 floats with padding.

## Discussion
Due to the change in graphics, and the performance regression, I'm now of the opinion we should consider again a `define` in the shader to enable / disable this behaviour for full backward compatibility and to ensure no performance regressions for users that do not wish to use the feature.

In particular I'm concerned there was insufficient performance testing on the original PR, especially on mobile / low end. This shows it really is essential to do performance testing on PRs changing shaders, as the performance drop here is quite pronounced (20% reported).

This is really a note to myself - as I did approve the original PR, so my bad, should be stricter before approval. :grinning: 


#### Register pressure?

I'm also not entirely sure why this works so well versus the old approach (I'm really no expert in this area). We may be hitting a hard limit on number of variables on the GPU (thus could be GPU dependent), or it could be able to shift some work to a constant, or better optimize etc.

I've noted that we may be able to store `fade_in` inside e.g. `spot_attenuation` in `light_params[]`. However I'm not at all sure this will improve performance now, as it may be the uniform register storage is being blown rather than the absolute size of the uniform buffer (we are using the exact same uniform buffer size before and after this PR, despite the difference in performance, which is suggestive that it is not the uniform buffer size that is directly critical here).

https://community.arm.com/support-forums/f/graphics-gaming-and-vr-forum/55072/why-uniform-buffer-is-limit-to-so-small-in-arm-gpu-best-practices-developer-guide

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
