### PR TITLE
Core: Do not generate `*.uid` files for JSON, certificates, and translations

### DIFF
--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -155,6 +155,10 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
+
+	// Treat certificates as text files, do not generate a `*.{crt,key,pub}.uid` file.
+	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override { return ResourceUID::INVALID_ID; }
+	virtual bool has_custom_uid_support() const override { return true; }
 };
 
 class ResourceFormatSaverCrypto : public ResourceFormatSaver {

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -105,6 +105,10 @@ public:
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
+
+	// Treat JSON as a text file, do not generate a `*.json.uid` file.
+	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override { return ResourceUID::INVALID_ID; }
+	virtual bool has_custom_uid_support() const override { return true; }
 };
 
 class ResourceFormatSaverJSON : public ResourceFormatSaver {

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -43,6 +43,10 @@ public:
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 
+	// Treat translations as text/binary files, do not generate a `*.{po,mo}.uid` file.
+	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override { return ResourceUID::INVALID_ID; }
+	virtual bool has_custom_uid_support() const override { return true; }
+
 	TranslationLoaderPO() {}
 };
 


### PR DESCRIPTION
* Fixes #99514.