### PR TITLE
Convert line breaks to `\n` and strip line break from the end of string returned by `OS::read_string_from_stdin`/`OS::get_stdin_string`.

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -721,6 +721,7 @@
 				- If standard input is console, this method will block until the program receives a line break in standard input (usually by the user pressing [kbd]Enter[/kbd]).
 				- If standard input is pipe, this method will block until a specific amount of data is read or pipe is closed.
 				- If standard input is a file, this method will read a specific amount of data (or less if end-of-file is reached) and return immediately.
+				[b]Note:[/b] This method automatically replaces [code]\r\n[/code] line breaks with [code]\n[/code] and removes them from the end of the string. Use [method read_buffer_from_stdin] to read the unprocessed data.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 				[b]Note:[/b] On exported Windows builds, run the console wrapper executable to access the terminal. If standard input is console, calling this method without console wrapped will freeze permanently. If standard input is pipe or file, it can be used without console wrapper. If you need a single executable with full console support, use a custom build compiled with the [code]windows_subsystem=console[/code] flag.
 			</description>

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -191,7 +191,7 @@ String OS_Unix::get_stdin_string(int64_t p_buffer_size) {
 	Vector<uint8_t> data;
 	data.resize(p_buffer_size);
 	if (fgets((char *)data.ptrw(), data.size(), stdin)) {
-		return String::utf8((char *)data.ptr());
+		return String::utf8((char *)data.ptr()).replace("\r\n", "\n").rstrip("\n");
 	}
 	return String();
 }

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1751,7 +1751,7 @@ String OS_Windows::get_stdin_string(int64_t p_buffer_size) {
 	data.resize(p_buffer_size);
 	DWORD count = 0;
 	if (ReadFile(GetStdHandle(STD_INPUT_HANDLE), data.ptrw(), data.size(), &count, nullptr)) {
-		return String::utf8((const char *)data.ptr(), count);
+		return String::utf8((const char *)data.ptr(), count).replace("\r\n", "\n").rstrip("\n");
 	}
 
 	return String();


### PR DESCRIPTION
- Replaces `\r\n` with `\n` (can be in the middle of the string is pipe/redirection is used).
- Strips line breaks from the end of the string.

Fixes https://github.com/godotengine/godot/issues/80136