### PR TITLE
Style: Add 19.1.0 LLVM options to `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 # Commented out parameters are those with the same value as base LLVM style.
 # We can uncomment them if we want to change their value, or enforce the
-# chosen value in case the base style changes (last sync: Clang 18.1.8).
+# chosen value in case the base style changes (last sync: Clang 19.1.0).
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
@@ -37,7 +37,29 @@ AlignAfterOpenBracket: DontAlign
 #   Enabled: false
 #   AcrossEmptyLines: false
 #   AcrossComments: false
+#   AlignCaseArrows: false
 #   AlignCaseColons: false
+# AlignConsecutiveTableGenBreakingDAGArgColons:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignConsecutiveTableGenCondOperatorColons:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
+# AlignConsecutiveTableGenDefinitionColons:
+#   Enabled: false
+#   AcrossEmptyLines: false
+#   AcrossComments: false
+#   AlignCompound: false
+#   AlignFunctionPointers: false
+#   PadOperators: false
 # AlignEscapedNewlines: Right
 AlignOperands: DontAlign
 AlignTrailingComments:
@@ -47,6 +69,7 @@ AlignTrailingComments:
 AllowAllParametersOfDeclarationOnNextLine: false
 # AllowBreakBeforeNoexceptSpecifier: Never
 # AllowShortBlocksOnASingleLine: Never
+# AllowShortCaseExpressionOnASingleLine: true
 # AllowShortCaseLabelsOnASingleLine: false
 # AllowShortCompoundRequirementOnASingleLine: true
 # AllowShortEnumsOnASingleLine: true
@@ -54,9 +77,7 @@ AllowAllParametersOfDeclarationOnNextLine: false
 # AllowShortIfStatementsOnASingleLine: Never
 # AllowShortLambdasOnASingleLine: All
 # AllowShortLoopsOnASingleLine: false
-# AlwaysBreakAfterReturnType: None
 # AlwaysBreakBeforeMultilineStrings: false
-# AlwaysBreakTemplateDeclarations: MultiLine
 # AttributeMacros:
 #   - __capability
 # BinPackArguments: true
@@ -84,6 +105,7 @@ AllowAllParametersOfDeclarationOnNextLine: false
 # BreakAdjacentStringLiterals: true
 # BreakAfterAttributes: Leave
 # BreakAfterJavaFieldAnnotations: false
+# BreakAfterReturnType: None
 # BreakArrays: true
 # BreakBeforeBinaryOperators: None
 # BreakBeforeBraces: Attach
@@ -91,8 +113,10 @@ AllowAllParametersOfDeclarationOnNextLine: false
 # BreakBeforeInlineASMColon: OnlyMultiline
 # BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: AfterColon
+# BreakFunctionDefinitionParameters: false
 # BreakInheritanceList: BeforeColon
 # BreakStringLiterals: true
+# BreakTemplateDeclarations: MultiLine
 ColumnLimit: 0
 # CommentPragmas: '^ IWYU pragma:'
 # CompactNamespaces: false
@@ -150,13 +174,16 @@ JavaImportGroups:
   - javax
 # JavaScriptQuotes: Leave
 # JavaScriptWrapImports: true
-# KeepEmptyLinesAtEOF: false
-KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLines:
+  AtEndOfFile: false
+  AtStartOfBlock: false
+  AtStartOfFile: false
 # LambdaBodyIndentation: Signature
 # Language: Cpp
 # LineEnding: DeriveLF
 # MacroBlockBegin: ''
 # MacroBlockEnd: ''
+# MainIncludeChar: Quote
 # MaxEmptyLinesToKeep: 1
 # NamespaceIndentation: None
 # ObjCBinPackProtocolList: Auto
@@ -219,13 +246,12 @@ RemoveSemicolon: true
 # SpacesBeforeTrailingComments: 1
 # SpacesInAngles: Never
 # SpacesInContainerLiterals: true
-## Godot TODO: We'll want to use a min of 1, but we need to see how to fix
-## our comment capitalization at the same time.
 SpacesInLineCommentPrefix:
-  Minimum: 0
+  Minimum: 0 # We want a minimum of 1 for comments, but allow 0 for disabled code.
   Maximum: -1
 # SpacesInParens: Never
 # SpacesInParensOptions:
+#   ExceptDoubleParentheses: false
 #   InConditionalStatements: false
 #   InCStyleCasts: false
 #   InEmptyParentheses: false
@@ -238,6 +264,7 @@ Standard: c++20
 #   - Q_UNUSED
 #   - QT_REQUIRE_VERSION
 TabWidth: 4
+# TableGenBreakInsideDAGArg: DontBreak
 UseTab: Always
 # VerilogBreakBetweenInstancePorts: true
 # WhitespaceSensitiveMacros:

--- a/core/math/bvh_logic.inc
+++ b/core/math/bvh_logic.inc
@@ -1,4 +1,3 @@
-
 // for slow incremental optimization, we will periodically remove each
 // item from the tree and reinsert, to give it a chance to find a better position
 void _logic_item_remove_and_reinsert(uint32_t p_ref_id) {

--- a/core/math/bvh_misc.inc
+++ b/core/math/bvh_misc.inc
@@ -1,4 +1,3 @@
-
 int _handle_get_tree_id(BVHHandle p_handle) const {
 	if (USE_PAIRS) {
 		return _extra[p_handle.id()].tree_id;

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -1,4 +1,3 @@
-
 public:
 struct ItemRef {
 	uint32_t tnode_id; // -1 is invalid

--- a/drivers/gles3/shaders/canvas_uniforms_inc.glsl
+++ b/drivers/gles3/shaders/canvas_uniforms_inc.glsl
@@ -1,4 +1,3 @@
-
 #define MAX_LIGHTS_PER_ITEM uint(16)
 
 #define M_PI 3.14159265359

--- a/misc/utility/.clang-format-glsl
+++ b/misc/utility/.clang-format-glsl
@@ -30,7 +30,10 @@ JavaImportGroups:
   - com.google
   - java
   - javax
-KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLines:
+  AtEndOfFile: false
+  AtStartOfBlock: false
+  AtStartOfFile: false
 ObjCBlockIndentWidth: 4
 PackConstructorInitializers: NextLine
 RemoveSemicolon: false # Differs from base .clang-format

--- a/modules/betsy/CrossPlatformSettings_piece_all.glsl
+++ b/modules/betsy/CrossPlatformSettings_piece_all.glsl
@@ -1,4 +1,3 @@
-
 #define min3(a, b, c) min(a, min(b, c))
 #define max3(a, b, c) max(a, max(b, c))
 

--- a/modules/betsy/UavCrossPlatform_piece_all.glsl
+++ b/modules/betsy/UavCrossPlatform_piece_all.glsl
@@ -1,4 +1,3 @@
-
 #define OGRE_imageLoad2D(inImage, iuv) imageLoad(inImage, int2(iuv))
 #define OGRE_imageLoad2DArray(inImage, iuvw) imageLoad(inImage, int3(iuvw))
 

--- a/modules/lightmapper_rd/lm_common_inc.glsl
+++ b/modules/lightmapper_rd/lm_common_inc.glsl
@@ -1,4 +1,3 @@
-
 /* SET 0, static data that does not change between any call */
 
 layout(set = 0, binding = 0) uniform BakeParameters {

--- a/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
@@ -1,4 +1,3 @@
-
 #define MAX_LIGHTS_PER_ITEM 16
 
 #define M_PI 3.14159265359

--- a/servers/rendering/renderer_rd/shaders/decal_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/decal_data_inc.glsl
@@ -1,4 +1,3 @@
-
 struct DecalData {
 	highp mat4 xform; //to decal transform
 	highp vec3 inv_extents;

--- a/servers/rendering/renderer_rd/shaders/effects/luminance_reduce_raster_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/luminance_reduce_raster_inc.glsl
@@ -1,4 +1,3 @@
-
 layout(push_constant, std430) uniform PushConstant {
 	ivec2 source_size;
 	ivec2 dest_size;


### PR DESCRIPTION
Given `pre-commit-config.yaml` has already bumped clang-format from 18.1.8 to 19.1.0, it was only fair to give the same treatment to our `.clang-format` file. Not *too* much new was added, seemed to mostly be renames & features for other languages, but one option stood out that made sense to apply right away: `KeepEmptyLines.AtStartOfFile: false`. `KeepEmptyLines` is now a container for all options of that type, with the two options migrating to it (`KeepEmptyLinesAtEOF`→`KeepEmptyLines.AtEndOfFile`, `KeepEmptyLinesAtTheStartOfBlocks`→`KeepEmptyLines.AtStartOfBlock`) being ones we already disable, so this simply makes the new option match our expected behavior. Only a handful of files were affected, none of which were depending on that behavior, so it's an entirely safe conversion.