### PR TITLE
Add tooltips to dock menu and remove disabled items

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -174,6 +174,9 @@ void EditorDockManager::_update_docks_menu() {
 	docks_menu_docks.clear();
 	int id = 0;
 	for (const KeyValue<Control *, DockInfo> &dock : all_docks) {
+		if (!dock.value.enabled) {
+			continue;
+		}
 		if (dock.value.shortcut.is_valid()) {
 			docks_menu->add_shortcut(dock.value.shortcut, id);
 			docks_menu->set_item_text(id, dock.value.title);
@@ -184,8 +187,10 @@ void EditorDockManager::_update_docks_menu() {
 		docks_menu->set_item_icon(id, icon.is_valid() ? icon : default_icon);
 		if (!dock.value.open) {
 			docks_menu->set_item_icon_modulate(id, closed_icon_color_mod);
+			docks_menu->set_item_tooltip(id, vformat(TTR("Open the %s dock."), dock.value.title));
+		} else {
+			docks_menu->set_item_tooltip(id, vformat(TTR("Focus on the %s dock."), dock.value.title));
 		}
-		docks_menu->set_item_disabled(id, !dock.value.enabled);
 		docks_menu_docks.push_back(dock.key);
 		id++;
 	}


### PR DESCRIPTION
- since https://github.com/godotengine/godot/issues/73926 is fixed
- related #89017

Removed docks disabled in EditorFeatures from menu, instead of having them disabled (https://github.com/godotengine/godot/pull/89017#discussion_r1589401628)
I could alternatively keep them and add a tooltip if we want.

![image](https://github.com/user-attachments/assets/4cad61b8-2f4b-462e-a780-c9690e77b67a)

It will say 'Open the %s dock' if it is closed and 'Focus on the %s dock' if it is already open.
~It's a little weird since they use the same text, the tooltip doesn't get moved when hovering over different items.~