### PR TITLE
Fix typo in `editor_log.h`

### DIFF
--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -145,8 +145,7 @@ private:
 	Button *show_search_button = nullptr;
 	LineEdit *search_box = nullptr;
 
-	// Reference to the "Output" button on the toolbar so we can update it's icon when
-	// Warnings or Errors are encounetered.
+	// Reference to the "Output" button on the toolbar so we can update its icon when warnings or errors are encountered.
 	Button *tool_button = nullptr;
 
 	bool is_loading_state = false; // Used to disable saving requests while loading (some signals from buttons will try trigger a save, which happens during loading).


### PR DESCRIPTION
I had this in a branch made 2 years ago and it still holds up, so yeah, sure, why not.