### PR TITLE
[3.x] Hide last DirectionalLight shadow split distance property when using PSSM 3 Splits

### DIFF
--- a/scene/3d/light.cpp
+++ b/scene/3d/light.cpp
@@ -365,12 +365,17 @@ bool DirectionalLight::is_blend_splits_enabled() const {
 
 void DirectionalLight::_validate_property(PropertyInfo &property) const {
 	if (shadow_mode == SHADOW_ORTHOGONAL && (property.name == "directional_shadow_split_1" || property.name == "directional_shadow_blend_splits" || property.name == "directional_shadow_bias_split_scale")) {
-		// Split 2, split blending and bias split scale are only used with the PSSM 2 Splits and PSSM 4 Splits shadow modes.
+		// Splits 2/3/4, split blending and bias split scale are only used with the PSSM 2 Splits, PSSM 3 Splits and PSSM 4 Splits shadow modes.
 		property.usage = PROPERTY_USAGE_NOEDITOR;
 	}
 
-	if ((shadow_mode == SHADOW_ORTHOGONAL || shadow_mode == SHADOW_PARALLEL_2_SPLITS) && (property.name == "directional_shadow_split_2" || property.name == "directional_shadow_split_3")) {
-		// Splits 3 and 4 are only used with the PSSM 4 Splits shadow mode.
+	if ((shadow_mode == SHADOW_ORTHOGONAL || shadow_mode == SHADOW_PARALLEL_2_SPLITS) && (property.name == "directional_shadow_split_2")) {
+		// Splits 3/4 are only used with the PSSM 3 Splits and PSSM 4 Splits shadow modes.
+		property.usage = PROPERTY_USAGE_NOEDITOR;
+	}
+
+	if ((shadow_mode == SHADOW_ORTHOGONAL || shadow_mode == SHADOW_PARALLEL_2_SPLITS || shadow_mode == SHADOW_PARALLEL_3_SPLITS) && (property.name == "directional_shadow_split_3")) {
+		// Split 4 is only used with the PSSM 4 Splits shadow mode.
 		property.usage = PROPERTY_USAGE_NOEDITOR;
 	}
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/75468.

The last shadow split property only has an effect when using PSSM 4 Splits.

I noticed this while testing https://github.com/godotengine/godot/pull/99536 :slightly_smiling_face:

## Preview

https://github.com/user-attachments/assets/a6d1905c-7bc9-4e51-be11-423e3fe6bddc

