### PR TITLE
Fix `Variant` modulo operation 

### DIFF
--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -317,7 +317,7 @@ public:
 		*VariantGetInternalPtr<Vector2i>::get_ptr(r_ret) = *VariantGetInternalPtr<Vector2i>::get_ptr(left) % *VariantGetInternalPtr<Vector2i>::get_ptr(right);
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {
-		PtrToArg<Vector2i>::encode(PtrToArg<Vector2i>::convert(left) / PtrToArg<Vector2i>::convert(right), r_ret);
+		PtrToArg<Vector2i>::encode(PtrToArg<Vector2i>::convert(left) % PtrToArg<Vector2i>::convert(right), r_ret);
 	}
 	static Variant::Type get_return_type() { return GetTypeInfo<Vector2i>::VARIANT_TYPE; }
 };


### PR DESCRIPTION
Replace erroneous use of `/` with `%`.

<i>Bugsquad edit:</i>
- Fix https://github.com/godotengine/godot/issues/99518