### PR TITLE
Add `get_connection_count` function to `GraphEdit`

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -181,6 +181,14 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="get_connection_count">
+			<return type="int" />
+			<param index="0" name="from_node" type="StringName" />
+			<param index="1" name="from_port" type="int" />
+			<description>
+				Returns the number of connections from [param from_port] of [param from_node].
+			</description>
+		</method>
 		<method name="get_connection_line" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<param index="0" name="from_node" type="Vector2" />

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -337,6 +337,16 @@ const List<Ref<GraphEdit::Connection>> &GraphEdit::get_connection_list() const {
 	return connections;
 }
 
+int GraphEdit::get_connection_count(const StringName &p_node, int p_port) {
+	int count = 0;
+	for (const Ref<Connection> &conn : connections) {
+		if ((conn->from_node == p_node && conn->from_port == p_port) || (conn->to_node == p_node && conn->to_port == p_port)) {
+			count += 1;
+		}
+	}
+	return count;
+}
+
 void GraphEdit::set_scroll_offset(const Vector2 &p_offset) {
 	setting_scroll_offset = true;
 	h_scrollbar->set_value(p_offset.x);
@@ -2640,6 +2650,7 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("disconnect_node", "from_node", "from_port", "to_node", "to_port"), &GraphEdit::disconnect_node);
 	ClassDB::bind_method(D_METHOD("set_connection_activity", "from_node", "from_port", "to_node", "to_port", "amount"), &GraphEdit::set_connection_activity);
 	ClassDB::bind_method(D_METHOD("get_connection_list"), &GraphEdit::_get_connection_list);
+	ClassDB::bind_method(D_METHOD("get_connection_count", "from_node", "from_port"), &GraphEdit::get_connection_count);
 	ClassDB::bind_method(D_METHOD("get_closest_connection_at_point", "point", "max_distance"), &GraphEdit::_get_closest_connection_at_point, DEFVAL(4.0));
 	ClassDB::bind_method(D_METHOD("get_connections_intersecting_with_rect", "rect"), &GraphEdit::_get_connections_intersecting_with_rect);
 	ClassDB::bind_method(D_METHOD("clear_connections"), &GraphEdit::clear_connections);

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -399,6 +399,7 @@ public:
 	// Connection related methods.
 	Error connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	bool is_node_connected(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
+	int get_connection_count(const StringName &p_node, int p_port);
 	void disconnect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	void clear_connections();
 


### PR DESCRIPTION
_This is my second attempt at this PR, the first one had problems with Git._

Closes: [https://github.com/godotengine/godot-proposals/issues/10942](https://github.com/godotengine/godot-proposals/issues/10942)

Adds a method to GraphEdit to get the number of connections to a given node and port `get_connection_count(to_node,to_port)`.
With this we can easily limit the number of connections using the condition:
```
if get_connection_count(to_node,to_port)<1:
	connect_node(from_node,from_port,to_node,to_port)
```

Test project:
[graphedit_test_func.zip](https://github.com/user-attachments/files/17877358/graphedit_test_func.zip)
