### PR TITLE
Add `layers` and `layers_cull_mode` properties to `BaseMaterial3D`

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -24,6 +24,13 @@
 				Returns [code]true[/code] if the specified [param flag] is enabled.
 			</description>
 		</method>
+		<method name="get_layer_mask_value" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_number" type="int" />
+			<description>
+				Returns whether or not the specified layer of the [member layers] is enabled, given a [param layer_number] between 1 and 20.
+			</description>
+		</method>
 		<method name="get_texture" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="param" type="int" enum="BaseMaterial3D.TextureParam" />
@@ -45,6 +52,14 @@
 			<param index="1" name="enable" type="bool" />
 			<description>
 				If [param enable] is [code]true[/code], enables the specified [param flag]. Flags are optional behavior that can be turned on and off. Only one flag can be enabled at a time with this function, the flag enumerators cannot be bit-masked together to enable or disable multiple flags at once. Flags can also be enabled by setting their corresponding property to [code]true[/code].
+			</description>
+		</method>
+		<method name="set_layer_mask_value">
+			<return type="void" />
+			<param index="0" name="layer_number" type="int" />
+			<param index="1" name="value" type="bool" />
+			<description>
+				Based on [param value], enables or disables the specified layer in the [member layers], given a [param layer_number] between 1 and 20.
 			</description>
 		</method>
 		<method name="set_texture">
@@ -277,6 +292,14 @@
 			The texture to use as a height map. See also [member heightmap_enabled].
 			For best results, the texture should be normalized (with [member heightmap_scale] reduced to compensate). In [url=https://gimp.org]GIMP[/url], this can be done using [b]Colors &gt; Auto &gt; Equalize[/b]. If the texture only uses a small part of its available range, the parallax effect may look strange, especially when the camera moves.
 			[b]Note:[/b] To reduce memory usage and improve loading times, you may be able to use a lower-resolution heightmap texture as most heightmaps are only comprised of low-frequency data.
+		</member>
+		<member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask" default="1">
+			The render layer(s) this [BaseMaterial3D] will render to. Only applies when [member layers_cull_mode] is not [constant LAYERS_CULL_DISABLED].
+			This material will only be visible for [Camera3D]s whose cull mask includes any of the render layers this [BaseMaterial3D] is set to.
+		</member>
+		<member name="layers_cull_mode" type="int" setter="set_layers_cull_mode" getter="get_layers_cull_mode" enum="BaseMaterial3D.LayersCullMode" default="0">
+			Controls how the material is culled when there are no shared layers between a [Camera3D] and this [BaseMaterial3D]. See [enum LayersCullMode].
+			[b]Note:[/b] Enabling this feature will incur some performance penalty. Only use it if you need to hide this [i]material[/i] on certain layers. If you are instead looking to hide an entire [i]object[/i] on certain layers, use [member VisualInstance3D.layers] instead.
 		</member>
 		<member name="metallic" type="float" setter="set_metallic" getter="get_metallic" default="0.0">
 			A high value makes the material appear more like a metal. Non-metals use their albedo as the diffuse color and add diffuse to the specular reflection. With non-metals, the reflection appears on top of the albedo color. Metals use their albedo as a multiplier to the specular reflection and set the diffuse color to black resulting in a tinted reflection. Materials work better when fully metal or fully non-metal, values between [code]0[/code] and [code]1[/code] should only be used for blending between metal and non-metal sections. To alter the amount of reflection use [member roughness].
@@ -890,6 +913,15 @@
 		</constant>
 		<constant name="STENCIL_COMPARE_GREATER_OR_EQUAL" value="6" enum="StencilCompare">
 			Passes the stencil test when the reference value is greater than or equal to the existing stencil value.
+		</constant>
+		<constant name="LAYERS_CULL_DISABLED" value="0" enum="LayersCullMode">
+			No layer-based culling will occur for this [BaseMaterial3D].
+		</constant>
+		<constant name="LAYERS_CULL_VERTEX" value="1" enum="LayersCullMode">
+			Layer-based culling for this [BaseMaterial3D] will occur in the vertex shader. This has the potential to be more performant than [constant LAYERS_CULL_FRAGMENT], but the method that is used is less well-defined and may not work on all systems.
+		</constant>
+		<constant name="LAYERS_CULL_FRAGMENT" value="2" enum="LayersCullMode">
+			Layer-based culling for this [BaseMaterial3D] will occur in the fragment shader. This should work on all systems but may not be as performant [constant LAYERS_CULL_VERTEX].
 		</constant>
 	</constants>
 </class>

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -670,6 +670,8 @@ void BaseMaterial3D::init_shaders() {
 	shader_names->albedo_texture_size = "albedo_texture_size";
 	shader_names->z_clip_scale = "z_clip_scale";
 	shader_names->fov_override = "fov_override";
+
+	shader_names->layers = "layers";
 }
 
 HashMap<uint64_t, Ref<StandardMaterial3D>> BaseMaterial3D::materials_for_2d;
@@ -1062,6 +1064,12 @@ uniform bool particles_anim_loop;
 )";
 	}
 
+	if (layers_cull_mode != LAYERS_CULL_DISABLED) {
+		code += R"(
+uniform uint layers = 1u;
+)";
+	}
+
 	if (features[FEATURE_EMISSION]) {
 		code += vformat(R"(
 uniform sampler2D texture_emission : source_color, hint_default_black, %s;
@@ -1215,6 +1223,14 @@ uniform vec3 uv2_offset;
 	// Generate vertex shader.
 	code += R"(
 void vertex() {)";
+
+	if (layers_cull_mode == LAYERS_CULL_VERTEX) {
+		code += R"(
+	if ((CAMERA_VISIBLE_LAYERS & layers) == 0u) { // Begin vertex cull mode
+		POSITION = vec4(vec3(2.0), 1.0);
+	} else {
+)";
+	}
 
 	if (flags[FLAG_SRGB_VERTEX_COLOR]) {
 		code += R"(
@@ -1481,6 +1497,13 @@ void vertex() {)";
 )";
 	}
 
+	if (layers_cull_mode == LAYERS_CULL_VERTEX) {
+		code += R"(
+	POSITION = PROJECTION_MATRIX * MODELVIEW_MATRIX * vec4(VERTEX, 1.0);
+	} // End vertex cull mode
+)";
+	}
+
 	// End of the vertex shader function.
 	code += "}\n";
 
@@ -1507,6 +1530,14 @@ vec4 triplanar_texture(sampler2D p_sampler, vec3 p_weights, vec3 p_triplanar_pos
 	// Generate fragment shader.
 	code += R"(
 void fragment() {)";
+
+	if (layers_cull_mode == LAYERS_CULL_FRAGMENT) {
+		code += R"(
+	if ((CAMERA_VISIBLE_LAYERS & layers) == 0u) {
+		discard;
+	}
+)";
+	}
 
 	if (!flags[FLAG_UV1_USE_TRIPLANAR]) {
 		code += R"(
@@ -2574,6 +2605,47 @@ BaseMaterial3D::TextureFilter BaseMaterial3D::get_texture_filter() const {
 	return texture_filter;
 }
 
+void BaseMaterial3D::set_layers_cull_mode(LayersCullMode p_mode) {
+	if (layers_cull_mode == p_mode) {
+		return;
+	}
+
+	layers_cull_mode = p_mode;
+	notify_property_list_changed();
+	_queue_shader_change();
+}
+
+BaseMaterial3D::LayersCullMode BaseMaterial3D::get_layers_cull_mode() const {
+	return layers_cull_mode;
+}
+
+void BaseMaterial3D::set_layer_mask(uint32_t p_mask) {
+	layers = p_mask;
+	_material_set_param(shader_names->layers, layers);
+}
+
+uint32_t BaseMaterial3D::get_layer_mask() const {
+	return layers;
+}
+
+void BaseMaterial3D::set_layer_mask_value(int p_layer_number, bool p_value) {
+	ERR_FAIL_COND_MSG(p_layer_number < 1, "Render layer number must be between 1 and 20 inclusive.");
+	ERR_FAIL_COND_MSG(p_layer_number > 20, "Render layer number must be between 1 and 20 inclusive.");
+	uint32_t mask = get_layer_mask();
+	if (p_value) {
+		mask |= 1 << (p_layer_number - 1);
+	} else {
+		mask &= ~(1 << (p_layer_number - 1));
+	}
+	set_layer_mask(mask);
+}
+
+bool BaseMaterial3D::get_layer_mask_value(int p_layer_number) const {
+	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Render layer number must be between 1 and 20 inclusive.");
+	ERR_FAIL_COND_V_MSG(p_layer_number > 20, false, "Render layer number must be between 1 and 20 inclusive.");
+	return layers & (1 << (p_layer_number - 1));
+}
+
 void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "emission_intensity" && !GLOBAL_GET_CACHED(bool, "rendering/lights_and_shadows/use_physical_light_units")) {
 		p_property.usage = PROPERTY_USAGE_NONE;
@@ -2752,6 +2824,10 @@ void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
 		if (p_property.name.begins_with("transmittance")) {
 			p_property.usage = PROPERTY_USAGE_NONE;
 		}
+	}
+
+	if (p_property.name == "layers" && layers_cull_mode == LAYERS_CULL_DISABLED) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
 
@@ -3585,6 +3661,14 @@ void BaseMaterial3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stencil_effect_outline_thickness", "stencil_outline_thickness"), &BaseMaterial3D::set_stencil_effect_outline_thickness);
 	ClassDB::bind_method(D_METHOD("get_stencil_effect_outline_thickness"), &BaseMaterial3D::get_stencil_effect_outline_thickness);
 
+	ClassDB::bind_method(D_METHOD("set_layers_cull_mode", "mode"), &BaseMaterial3D::set_layers_cull_mode);
+	ClassDB::bind_method(D_METHOD("get_layers_cull_mode"), &BaseMaterial3D::get_layers_cull_mode);
+
+	ClassDB::bind_method(D_METHOD("set_layer_mask", "mask"), &BaseMaterial3D::set_layer_mask);
+	ClassDB::bind_method(D_METHOD("get_layer_mask"), &BaseMaterial3D::get_layer_mask);
+	ClassDB::bind_method(D_METHOD("set_layer_mask_value", "layer_number", "value"), &BaseMaterial3D::set_layer_mask_value);
+	ClassDB::bind_method(D_METHOD("get_layer_mask_value", "layer_number"), &BaseMaterial3D::get_layer_mask_value);
+
 	ADD_GROUP("Transparency", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transparency", PROPERTY_HINT_ENUM, "Disabled,Alpha,Alpha Scissor,Alpha Hash,Depth Pre-Pass"), "set_transparency", "get_transparency");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_scissor_threshold", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_alpha_scissor_threshold", "get_alpha_scissor_threshold");
@@ -3781,6 +3865,10 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "stencil_color", PROPERTY_HINT_NONE), "set_stencil_effect_color", "get_stencil_effect_color");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "stencil_outline_thickness", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,suffix:m"), "set_stencil_effect_outline_thickness", "get_stencil_effect_outline_thickness");
 
+	ADD_GROUP("Layers", "");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "layers_cull_mode", PROPERTY_HINT_ENUM, "Disabled,Vertex,Fragment"), "set_layers_cull_mode", "get_layers_cull_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "layers", PROPERTY_HINT_LAYERS_3D_RENDER), "set_layer_mask", "get_layer_mask");
+
 	BIND_ENUM_CONSTANT(TEXTURE_ALBEDO);
 	BIND_ENUM_CONSTANT(TEXTURE_METALLIC);
 	BIND_ENUM_CONSTANT(TEXTURE_ROUGHNESS);
@@ -3932,6 +4020,10 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(STENCIL_COMPARE_GREATER);
 	BIND_ENUM_CONSTANT(STENCIL_COMPARE_NOT_EQUAL);
 	BIND_ENUM_CONSTANT(STENCIL_COMPARE_GREATER_OR_EQUAL);
+
+	BIND_ENUM_CONSTANT(LAYERS_CULL_DISABLED);
+	BIND_ENUM_CONSTANT(LAYERS_CULL_VERTEX);
+	BIND_ENUM_CONSTANT(LAYERS_CULL_FRAGMENT);
 }
 
 BaseMaterial3D::BaseMaterial3D(bool p_orm) :
@@ -4001,6 +4093,8 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 	set_fov_override(75.0);
 
 	set_stencil_mode(STENCIL_MODE_DISABLED);
+
+	set_layers_cull_mode(LAYERS_CULL_DISABLED);
 
 	flags[FLAG_ALBEDO_TEXTURE_MSDF] = false;
 	flags[FLAG_USE_TEXTURE_REPEAT] = true;

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -354,6 +354,13 @@ public:
 		STENCIL_COMPARE_MAX // Not an actual operator, just the amount of operators.
 	};
 
+	enum LayersCullMode {
+		LAYERS_CULL_DISABLED,
+		LAYERS_CULL_VERTEX,
+		LAYERS_CULL_FRAGMENT,
+		LAYERS_CULL_MAX
+	};
+
 private:
 	struct MaterialKey {
 		// enum values
@@ -373,6 +380,7 @@ private:
 		uint64_t roughness_channel : Math::get_num_bits(TEXTURE_CHANNEL_MAX - 1);
 		uint64_t emission_op : Math::get_num_bits(EMISSION_OP_MAX - 1);
 		uint64_t distance_fade : Math::get_num_bits(DISTANCE_FADE_MAX - 1);
+		uint64_t layers_cull_mode : Math::get_num_bits(LAYERS_CULL_MAX - 1);
 
 		// stencil
 		uint64_t stencil_mode : Math::get_num_bits(STENCIL_MODE_MAX - 1);
@@ -440,6 +448,7 @@ private:
 		mk.emission_op = emission_op;
 		mk.alpha_antialiasing_mode = alpha_antialiasing_mode;
 		mk.orm = orm;
+		mk.layers_cull_mode = layers_cull_mode;
 
 		mk.stencil_mode = stencil_mode;
 		mk.stencil_flags = stencil_flags;
@@ -518,6 +527,8 @@ private:
 		StringName albedo_texture_size;
 		StringName z_clip_scale;
 		StringName fov_override;
+
+		StringName layers;
 	};
 
 	static Mutex material_mutex;
@@ -625,6 +636,9 @@ private:
 
 	Color stencil_effect_color;
 	float stencil_effect_outline_thickness = 0.01f;
+
+	LayersCullMode layers_cull_mode;
+	uint32_t layers = 1;
 
 	bool features[FEATURE_MAX] = {};
 
@@ -872,6 +886,13 @@ public:
 	void set_fov_override(float p_fov_override);
 	float get_fov_override() const;
 
+	void set_layers_cull_mode(LayersCullMode p_mode);
+	LayersCullMode get_layers_cull_mode() const;
+	void set_layer_mask(uint32_t p_mask);
+	uint32_t get_layer_mask() const;
+	void set_layer_mask_value(int p_layer_number, bool p_value);
+	bool get_layer_mask_value(int p_layer_number) const;
+
 	static void init_shaders();
 	static void finish_shaders();
 	static void flush_changes();
@@ -908,6 +929,7 @@ VARIANT_ENUM_CAST(BaseMaterial3D::DistanceFadeMode)
 VARIANT_ENUM_CAST(BaseMaterial3D::StencilMode)
 VARIANT_ENUM_CAST(BaseMaterial3D::StencilFlags)
 VARIANT_ENUM_CAST(BaseMaterial3D::StencilCompare)
+VARIANT_ENUM_CAST(BaseMaterial3D::LayersCullMode)
 
 class StandardMaterial3D : public BaseMaterial3D {
 	GDCLASS(StandardMaterial3D, BaseMaterial3D)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This PR adds two new properties to `BaseMaterial3D` which allow it to render only on selected layers:
* `layers` - Determines which layers this material will be rendered on.
* `layers_cull_mode` - Determines how to cull the material on the layers where it is not rendered. Has three options:
   * `LAYERS_CULL_DISABLED` - No layer-based culling will occur. (Exactly the same as current `BaseMaterial3D`.)
   * `LAYERS_CULL_VERTEX` - Layer-based culling will occur via code generated in the `vertex()` function.
   * `LAYERS_CULL_FRAGMENT` - Layer-based culling will occur via code generated in the `fragment()` function.

## Motivation

The purpose of this is to allow users to apply `StandardMaterial3D` or `ORMMaterial3D` to an object only on certain render layers. Godot shaders can already accomplish this, and other effects, through use of `CAMERA_VISIBLE_LAYERS` (see https://github.com/godotengine/godot/pull/67387). This PR exposes some of that same functionality to users of `StandardMaterial3D` and `ORMMaterial3D`. Combined with the ability to add more materials via `next_pass`, this will allow users a greater level of control over how their objects render on different layers.

## Implementation

If either `LAYERS_CULL_VERTEX` or `LAYERS_CULL_FRAGMENT` are selected, a uniform will be added to the generated Godot shader code. It will be controlled by the new `layers` property.
```glsl
uniform uint layers = 1u;
```

If the mode `LAYERS_CULL_VERTEX` is selected, the following will be added inside the `vertex()` function in the generated Godot shader code:
```glsl
if ((CAMERA_VISIBLE_LAYERS & layers) == 0u) { // Begin vertex cull mode
	VERTEX = vec3(1.0 / 0.0);
} else {
	// other generated vertex shader code...
} // End vertex cull mode
```

> **Note:** Assuming this PR is considered, I could definitely use some input on the vertex cull mode. I know this works on my own machine. However, I'm not familiar enough with shaders and rendering to know whether this will work on all machines. (Or whether there is a more performant way to do it.)

If the mode `LAYERS_CULL_FRAGMENT` is selected, the following will be added at the beginning of the `fragment()` function in the generated Godot shader code:
```glsl
if ((CAMERA_VISIBLE_LAYERS & layers) == 0u) {
	discard;
}
```

---

_Bugsquad edit: Implements and closes https://github.com/godotengine/godot-proposals/issues/11210_