### PR TITLE
Make visual shader editor create node window a popup

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2209,10 +2209,12 @@ String VisualShaderEditor::_get_description(int p_idx) {
 void VisualShaderEditor::_update_options_menu() {
 	node_desc->set_text("");
 	highend_label->set_visible(false);
-	members_dialog->get_ok_button()->set_disabled(true);
 
 	members->clear();
 	TreeItem *root = members->create_item();
+	if (members_dialog != nullptr) {
+		members_dialog->get_ok_button()->set_disabled(true);
+	}
 
 	String filter = node_filter->get_text().strip_edges();
 	bool use_filter = !filter.is_empty();
@@ -2374,7 +2376,9 @@ void VisualShaderEditor::_update_options_menu() {
 			node_desc->set_text(options[i].description);
 			is_first_item = false;
 
-			members_dialog->get_ok_button()->set_disabled(false);
+			if (members_dialog != nullptr) {
+				members_dialog->get_ok_button()->set_disabled(false);
+			}
 		}
 		switch (options[i].return_type) {
 			case VisualShaderNode::PORT_TYPE_SCALAR:
@@ -4206,7 +4210,7 @@ void VisualShaderEditor::_connection_to_empty(const String &p_from, int p_from_s
 	if (node.is_valid()) {
 		output_port_type = node->get_output_port_type(from_slot);
 	}
-	_show_members_dialog(true, input_port_type, output_port_type);
+	_show_members_box(true, input_port_type, output_port_type);
 }
 
 void VisualShaderEditor::_connection_from_empty(const String &p_to, int p_to_slot, const Vector2 &p_release_position) {
@@ -4218,7 +4222,7 @@ void VisualShaderEditor::_connection_from_empty(const String &p_to, int p_to_slo
 	if (node.is_valid()) {
 		input_port_type = node->get_input_port_type(to_slot);
 	}
-	_show_members_dialog(true, input_port_type, output_port_type);
+	_show_members_box(true, input_port_type, output_port_type);
 }
 
 bool VisualShaderEditor::_check_node_drop_on_connection(const Vector2 &p_position, Ref<GraphEdit::Connection> *r_closest_connection, int *r_from_port, int *r_to_port) {
@@ -4874,7 +4878,7 @@ void VisualShaderEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 			connection_popup_menu->reset_size();
 			connection_popup_menu->popup();
 		} else if (selected_graph_elements.is_empty() && copy_buffer_empty) {
-			_show_members_dialog(true);
+			_show_members_box(true);
 		} else {
 			popup_menu->set_item_disabled(NodeMenuOptions::CUT, selected_deletable_graph_elements.is_empty());
 			popup_menu->set_item_disabled(NodeMenuOptions::COPY, selected_deletable_graph_elements.is_empty());
@@ -4987,39 +4991,95 @@ void VisualShaderEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
-void VisualShaderEditor::_show_members_dialog(bool at_mouse_pos, VisualShaderNode::PortType p_input_port_type, VisualShaderNode::PortType p_output_port_type) {
+void VisualShaderEditor::_show_members_box(bool p_as_popup, VisualShaderNode::PortType p_input_port_type, VisualShaderNode::PortType p_output_port_type) {
+	if ((p_as_popup && members_dialog != nullptr) || (!p_as_popup && members_popup != nullptr)) {
+		_hide_members_box();
+	}
+
+	Window *created_window = nullptr;
+
+	if (p_as_popup) {
+		if (members_popup == nullptr) {
+			members_popup = memnew(PopupPanel);
+			members_box->reparent(members_popup, false);
+			members_popup->set_title(TTR("Create Shader Node"));
+			if (members_size.x < 1) {
+				members_size = Size2i(300, 360);
+			}
+			members_popup->set_min_size(members_size * EDSCALE);
+			add_child(members_popup);
+		}
+
+		saved_node_pos_dirty = true;
+		saved_node_pos = graph->get_local_mouse_position();
+
+		Point2 gpos = get_screen_position() + get_local_mouse_position();
+		members_popup->set_position(gpos);
+
+		created_window = members_popup;
+	} else {
+		if (members_dialog != nullptr) {
+			members_size = members_box->get_size() / EDSCALE;
+			members_dialog->grab_focus();
+			members_dialog->popup();
+		} else {
+			saved_node_pos_dirty = false;
+
+			members_dialog = memnew(ConfirmationDialog);
+			members_box->reparent(members_dialog, false);
+			members_dialog->set_title(TTR("Create Shader Node"));
+			members_dialog->set_ok_button_text(TTR("Create"));
+			members_dialog->connect(SceneStringName(confirmed), callable_mp(this, &VisualShaderEditor::_member_create));
+			members_dialog->get_ok_button()->set_disabled(true);
+			members_dialog->connect("canceled", callable_mp(this, &VisualShaderEditor::_member_cancel));
+			members_dialog->register_text_enter(node_filter);
+			if (members_size.x > 0) {
+				members_dialog->set_size(members_size * EDSCALE);
+			}
+			add_child(members_dialog);
+
+			members_dialog->set_position(graph->get_screen_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
+
+			created_window = members_dialog;
+		}
+	}
+
 	if (members_input_port_type != p_input_port_type || members_output_port_type != p_output_port_type) {
 		members_input_port_type = p_input_port_type;
 		members_output_port_type = p_output_port_type;
 		_update_options_menu();
 	}
 
-	if (at_mouse_pos) {
-		saved_node_pos_dirty = true;
-		saved_node_pos = graph->get_local_mouse_position();
+	members_box->show();
 
-		Point2 gpos = get_screen_position() + get_local_mouse_position();
-		members_dialog->set_position(gpos);
-	} else {
-		saved_node_pos_dirty = false;
-		members_dialog->set_position(graph->get_screen_position() + Point2(5 * EDSCALE, 65 * EDSCALE));
+	if (created_window != nullptr) {
+		created_window->popup();
+
+		// Keep dialog within window bounds.
+		Rect2 window_rect = Rect2(get_window()->get_position(), get_window()->get_size());
+		Rect2 dialog_rect = Rect2(created_window->get_position(), created_window->get_size());
+		Vector2 difference = (dialog_rect.get_end() - window_rect.get_end()).maxf(0);
+		created_window->set_position(created_window->get_position() - difference);
 	}
-
-	if (members_dialog->is_visible()) {
-		members_dialog->grab_focus();
-		return;
-	}
-
-	members_dialog->popup();
-
-	// Keep dialog within window bounds.
-	Rect2 window_rect = Rect2(get_window()->get_position(), get_window()->get_size());
-	Rect2 dialog_rect = Rect2(members_dialog->get_position(), members_dialog->get_size());
-	Vector2 difference = (dialog_rect.get_end() - window_rect.get_end()).maxf(0);
-	members_dialog->set_position(members_dialog->get_position() - difference);
 
 	node_filter->grab_focus();
 	node_filter->select_all();
+}
+
+void VisualShaderEditor::_hide_members_box() {
+	if (members_box->get_parent() != this) {
+		members_box->hide();
+		members_box->reparent(this);
+		if (members_popup != nullptr) {
+			members_popup->queue_free();
+			members_popup = nullptr;
+		}
+		if (members_dialog != nullptr) {
+			members_size = members_box->get_size() / EDSCALE;
+			members_dialog->queue_free();
+			members_dialog = nullptr;
+		}
+	}
 }
 
 void VisualShaderEditor::_varying_menu_id_pressed(int p_idx) {
@@ -5067,7 +5127,7 @@ void VisualShaderEditor::_sbox_input(const Ref<InputEvent> &p_event) {
 	// Redirect navigational key events to the tree.
 	Ref<InputEventKey> key = p_event;
 	if (key.is_valid()) {
-		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
+		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down") || key->is_action("ui_accept")) {
 			members->gui_input(key);
 			node_filter->accept_event();
 		}
@@ -5795,12 +5855,16 @@ void VisualShaderEditor::_member_selected() {
 	TreeItem *item = members->get_selected();
 
 	if (item != nullptr && item->has_meta("id")) {
-		members_dialog->get_ok_button()->set_disabled(false);
+		if (members_dialog != nullptr) {
+			members_dialog->get_ok_button()->set_disabled(false);
+		}
 		highend_label->set_visible(add_options[item->get_meta("id")].highend);
 		node_desc->set_text(_get_description(item->get_meta("id")));
 	} else {
 		highend_label->set_visible(false);
-		members_dialog->get_ok_button()->set_disabled(true);
+		if (members_dialog != nullptr) {
+			members_dialog->get_ok_button()->set_disabled(true);
+		}
 		node_desc->set_text("");
 	}
 }
@@ -5831,7 +5895,7 @@ void VisualShaderEditor::_member_create() {
 			saved_node_pos = 0.5 * (from_graph_element->get_position() + zoom * from_graph_element->get_output_port_position(from_slot) + to_graph_element->get_position() + zoom * to_graph_element->get_input_port_position(to_slot));
 		}
 		_add_node(idx, add_options[idx].ops);
-		members_dialog->hide();
+		_hide_members_box();
 	}
 }
 
@@ -5975,7 +6039,7 @@ void VisualShaderEditor::_tools_menu_option(int p_idx) {
 void VisualShaderEditor::_node_menu_id_pressed(int p_idx) {
 	switch (p_idx) {
 		case NodeMenuOptions::ADD:
-			_show_members_dialog(true);
+			_show_members_box(false);
 			break;
 		case NodeMenuOptions::CUT:
 			_copy_nodes(true);
@@ -6045,7 +6109,7 @@ void VisualShaderEditor::_connection_menu_id_pressed(int p_idx) {
 			}
 
 			connection_node_insert_requested = true;
-			_show_members_dialog(true, input_port_type, output_port_type);
+			_show_members_box(false, input_port_type, output_port_type);
 		} break;
 		case ConnectionMenuOptions::INSERT_NEW_REROUTE: {
 			from_node = String(clicked_connection->from_node).to_int();
@@ -6532,7 +6596,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	add_node->set_text(TTR("Add Node..."));
 	toolbar->add_child(add_node);
 	toolbar->move_child(add_node, 0);
-	add_node->connect(SceneStringName(pressed), callable_mp(this, &VisualShaderEditor::_show_members_dialog).bind(false, VisualShaderNode::PORT_TYPE_MAX, VisualShaderNode::PORT_TYPE_MAX));
+	add_node->connect(SceneStringName(pressed), callable_mp(this, &VisualShaderEditor::_show_members_box).bind(false, VisualShaderNode::PORT_TYPE_MAX, VisualShaderNode::PORT_TYPE_MAX));
 
 	graph->connect("graph_elements_linked_to_frame_request", callable_mp(this, &VisualShaderEditor::_nodes_linked_to_frame_request));
 	graph->connect("frame_rect_changed", callable_mp(this, &VisualShaderEditor::_frame_rect_changed));
@@ -6698,6 +6762,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	///////////////////////////////////////
 
 	VBoxContainer *members_vb = memnew(VBoxContainer);
+	members_vb->set_h_size_flags(SIZE_EXPAND_FILL);
 	members_vb->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	HBoxContainer *filter_hb = memnew(HBoxContainer);
@@ -6752,15 +6817,12 @@ VisualShaderEditor::VisualShaderEditor() {
 	node_desc->set_v_size_flags(SIZE_FILL);
 	node_desc->set_custom_minimum_size(Size2(0, 70 * EDSCALE));
 
-	members_dialog = memnew(ConfirmationDialog);
-	members_dialog->set_title(TTR("Create Shader Node"));
-	members_dialog->add_child(members_vb);
-	members_dialog->set_ok_button_text(TTR("Create"));
-	members_dialog->connect(SceneStringName(confirmed), callable_mp(this, &VisualShaderEditor::_member_create));
-	members_dialog->get_ok_button()->set_disabled(true);
-	members_dialog->connect("canceled", callable_mp(this, &VisualShaderEditor::_member_cancel));
-	members_dialog->register_text_enter(node_filter);
-	add_child(members_dialog);
+	members_box = memnew(VBoxContainer);
+	members_box->hide();
+	members_box->set_h_size_flags(SIZE_EXPAND_FILL);
+	members_box->set_v_size_flags(SIZE_EXPAND_FILL);
+	members_box->add_child(members_vb);
+	add_child(members_box);
 
 	// add varyings dialog
 	{

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -251,6 +251,9 @@ class VisualShaderEditor : public ShaderEditor {
 	Point2 saved_node_pos;
 	bool saved_node_pos_dirty = false;
 
+	Size2i members_size = Size2i(0, 0);
+	VBoxContainer *members_box = nullptr;
+	PopupPanel *members_popup = nullptr;
 	ConfirmationDialog *members_dialog = nullptr;
 	VisualShaderNode::PortType members_input_port_type = VisualShaderNode::PORT_TYPE_MAX;
 	VisualShaderNode::PortType members_output_port_type = VisualShaderNode::PORT_TYPE_MAX;
@@ -371,7 +374,8 @@ class VisualShaderEditor : public ShaderEditor {
 	Label *highend_label = nullptr;
 
 	void _tools_menu_option(int p_idx);
-	void _show_members_dialog(bool at_mouse_pos, VisualShaderNode::PortType p_input_port_type = VisualShaderNode::PORT_TYPE_MAX, VisualShaderNode::PortType p_output_port_type = VisualShaderNode::PORT_TYPE_MAX);
+	void _show_members_box(bool p_as_popup, VisualShaderNode::PortType p_input_port_type = VisualShaderNode::PORT_TYPE_MAX, VisualShaderNode::PortType p_output_port_type = VisualShaderNode::PORT_TYPE_MAX);
+	void _hide_members_box();
 
 	void _varying_menu_id_pressed(int p_idx);
 	void _show_add_varying_dialog();


### PR DESCRIPTION
This makes the Visual Shader editor's "Create Shader Node" window to be a popup instead of a dialog, thus being easily dismissed by clicking outside the window like in most other DCC applications that use a node editor. It addresses https://github.com/godotengine/godot-proposals/issues/11213. It also solves the issue where the window would appear outside the screen area.

Please note that i have only tested this on Linux and X11.

![add_node_popup](https://github.com/user-attachments/assets/fcd24652-91d8-44ad-bd6a-72fe97ccfff3)

The main negative with this patch is that unlike the window, the popup is not resizable and instead a 300px (scaled by `EDSCALE`) minimum width is used to ensure that the node names are visible. While it is possible to make the window resizable by setting the `Window::FLAG_RESIZE_DISABLED` to `false`, there is no visual indicator that the window is resizable and the window closes as soon as the resize finishes (seems a race condition between the window manager and the X11 mouse handling code for popups). Ideally there should be a control that can be placed on popups (like a small triangle at the bottom right corner, as that is common in various toolkits) to handle client-side resizing, but i can't find anything like that in Godot.

A potential alternative would be to use the popup-based approach in this PR for right clicking but use a dialog when "Add Node" is selected from the popup menu. This will most likely require a larger change though as from what i can tell a window can't switch "modes" between being a Popup and a Dialog.