### PR TITLE
Add option to toggle always showing collision shapes

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -599,6 +599,9 @@
 		<member name="editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size" type="float" setter="" getter="">
 			Size of the disk gizmo displayed when editing [Path3D]'s tilt handles.
 		</member>
+		<member name="editors/3d_gizmos/gizmo_settings/show_collision_shapes_only_when_selected" type="bool" setter="" getter="">
+			If [code]true[/code], collision shapes in the 3D editor are visible only when selected. If [code]false[/code], collision shapes are always visible.
+		</member>
 		<member name="editors/animation/autorename_animation_tracks" type="bool" setter="" getter="">
 			If [code]true[/code], automatically updates animation tracks' target paths when renaming or reparenting nodes in the Scene tree dock.
 		</member>

--- a/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/3d/gizmos/gizmo_3d_helper.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "editor/settings/editor_settings.h"
 #include "scene/3d/physics/collision_shape_3d.h"
 #include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/capsule_shape_3d.h"
@@ -48,6 +49,8 @@
 
 CollisionShape3DGizmoPlugin::CollisionShape3DGizmoPlugin() {
 	helper.instantiate();
+
+	show_only_when_selected = EDITOR_GET("editors/3d_gizmos/gizmo_settings/show_collision_shapes_only_when_selected");
 
 	create_collision_material("shape_material", 2.0);
 	create_collision_material("shape_material_arraymesh", 0.0625);
@@ -304,6 +307,10 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	Ref<Shape3D> s = cs->get_shape();
 	if (s.is_null()) {
+		return;
+	}
+
+	if (show_only_when_selected && !p_gizmo->is_selected()) {
 		return;
 	}
 
@@ -666,4 +673,8 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		Vector<Vector3> lines = hms->get_debug_mesh_lines();
 		p_gizmo->add_lines(lines, material, false, collision_color);
 	}
+}
+
+void CollisionShape3DGizmoPlugin::set_show_only_when_selected(bool p_enabled) {
+	show_only_when_selected = p_enabled;
 }

--- a/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.h
@@ -41,11 +41,14 @@ class CollisionShape3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 
 	Ref<Gizmo3DHelper> helper;
 
+	inline static bool show_only_when_selected = false;
+
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
 	String get_gizmo_name() const override;
 	int get_priority() const override;
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
+	static void set_show_only_when_selected(bool p_enabled);
 
 	String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
 	Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -9022,6 +9022,10 @@ void Node3DEditor::_notification(int p_what) {
 				}
 				update_gizmo_opacity();
 			}
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("editors/3d_gizmos/gizmo_settings")) {
+				CollisionShape3DGizmoPlugin::set_show_only_when_selected(EDITOR_GET("editors/3d_gizmos/gizmo_settings/show_collision_shapes_only_when_selected"));
+				update_all_gizmos();
+			}
 		} break;
 
 		case NOTIFICATION_PHYSICS_PROCESS: {

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -907,6 +907,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d_gizmos/gizmo_settings/bone_shape", 1, "Wire,Octahedron");
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size", 0.8, "0.01,4.0,0.001,or_greater", PROPERTY_USAGE_DEFAULT)
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d_gizmos/gizmo_settings/lightmap_gi_probe_size", 0.4, "0.0,1.0,0.001,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	_initial_set("editors/3d_gizmos/gizmo_settings/show_collision_shapes_only_when_selected", false);
 
 	// If a line is a multiple of this, it uses the primary grid color.
 	// Use a power of 2 value by default as it's more common to use powers of 2 in level design.


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/11220

Currently even a simple scene can be visually distracting with a few collision shapes:

This PR adds a setting to only show collision shapes when the node is selected vs all the time.

This is with no object selected
<img src="https://github.com/user-attachments/assets/18ab4ddf-a200-426c-b173-6e2af7608db9" width="512">

With this PR:
<img src="https://github.com/user-attachments/assets/620b5cd0-7370-4550-8144-5e30cb2bcc77" width="512">
<img src="https://github.com/user-attachments/assets/5fedd258-78e6-43fb-b2c4-147587811d3f" width="512">


<img src="https://github.com/user-attachments/assets/a8ff0b42-1c16-4b6b-95f7-9be999eee085" width="512">

<img src="https://github.com/user-attachments/assets/507fc175-dbf4-471b-8e67-c8be1e92016e" width="512">


