### PR TITLE
Fix volumetric fog artifacts when outside the fog

### DIFF
--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -691,9 +691,9 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 				// when the camera's near plane is inside the fog, we must always consider the entire screen
 				Vector3 near_plane_corner(frustum_near_size.x, frustum_near_size.y, z_near);
 				float expand = near_plane_corner.length();
-				if (cam_position.x > (corner_min.x - expand) && cam_position.x < (corner_max.x + expand) &&
-						cam_position.y > (corner_min.y - expand) && cam_position.y < (corner_max.y + expand) &&
-						cam_position.z > (corner_min.z - expand) && cam_position.z < (corner_max.z + expand)) {
+				if ((cam_position.x > (corner_min.x - expand) && cam_position.x < (corner_max.x + expand)) ||
+						(cam_position.y > (corner_min.y - expand) && cam_position.y < (corner_max.y + expand)) ||
+						(cam_position.z > (corner_min.z - expand) && cam_position.z < (corner_max.z + expand))) {
 					froxel_min.x = 0;
 					froxel_min.y = 0;
 					froxel_min.z = 0;


### PR DESCRIPTION
PR #86103 fixed some weird culling issues that caused fog to artifact but it assumed that this was only happening when the camera near plane was inside the fog. Other testers (including myself) found it was also happening when the camera was outside the fog volume. This change fixes that issue.