### PR TITLE
Make start/end can be retrieved from each PlaybackData on AnimationPlayer

### DIFF
--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -70,6 +70,18 @@ private:
 		float speed_scale = 1.0;
 		double start_time = 0.0;
 		double end_time = 0.0;
+		double get_start_time() const {
+			if (from && (Animation::is_less_approx(start_time, 0) || Animation::is_greater_approx(start_time, from->animation->get_length()))) {
+				return 0;
+			}
+			return start_time;
+		}
+		double get_end_time() const {
+			if (from && (Animation::is_less_approx(end_time, 0) || Animation::is_greater_approx(end_time, from->animation->get_length()))) {
+				return from->animation->get_length();
+			}
+			return end_time;
+		}
 	};
 
 	struct Blend {


### PR DESCRIPTION
- Follow up #91765
- Fixes #99486

On AnimationPlayer, when multiple animations were being processed, the end time was only being retrieved from the current animation, so this PR will allow them to be retrieved individually. Also, to make the code explicit, internally only use retrieval from PlaybackData, not from bound methods.

cc @chocola-mint 
