### PR TITLE
Add `double` to the version full build string when using a double-precision build

### DIFF
--- a/core/version.h
+++ b/core/version.h
@@ -62,17 +62,22 @@
 #define GODOT_VERSION_HEX 0x10000 * GODOT_VERSION_MAJOR + 0x100 * GODOT_VERSION_MINOR + GODOT_VERSION_PATCH
 
 // Describes the full configuration of that Godot version, including the version number,
-// the status (beta, stable, etc.) and potential module-specific features (e.g. mono).
-// Example: "3.1.4.stable.mono"
+// the status (beta, stable, etc.), potential module-specific features (e.g. mono)
+// and double-precision status.
+// Example: "3.1.4.stable.mono.double"
+#ifdef REAL_T_IS_DOUBLE
+#define GODOT_VERSION_FULL_CONFIG GODOT_VERSION_NUMBER "." GODOT_VERSION_STATUS GODOT_VERSION_MODULE_CONFIG ".double"
+#else
 #define GODOT_VERSION_FULL_CONFIG GODOT_VERSION_NUMBER "." GODOT_VERSION_STATUS GODOT_VERSION_MODULE_CONFIG
+#endif
 
 // Similar to GODOT_VERSION_FULL_CONFIG, but also includes the (potentially custom) GODOT_VERSION_BUILD
 // description (e.g. official, custom_build, etc.).
-// Example: "3.1.4.stable.mono.official"
+// Example: "3.1.4.stable.mono.double.official"
 #define GODOT_VERSION_FULL_BUILD GODOT_VERSION_FULL_CONFIG "." GODOT_VERSION_BUILD
 
 // Same as above, but prepended with Godot's name and a cosmetic "v" for "version".
-// Example: "Godot v3.1.4.stable.official.mono"
+// Example: "Godot v3.1.4.stable.official.mono.double"
 #define GODOT_VERSION_FULL_NAME GODOT_VERSION_NAME " v" GODOT_VERSION_FULL_BUILD
 
 // Git commit hash, generated at build time in `core/version_hash.gen.cpp`.

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -53,6 +53,7 @@ enum DownloadsAvailability {
 	DOWNLOADS_AVAILABLE,
 	DOWNLOADS_NOT_AVAILABLE_IN_OFFLINE_MODE,
 	DOWNLOADS_NOT_AVAILABLE_FOR_DEV_BUILDS,
+	DOWNLOADS_NOT_AVAILABLE_FOR_DOUBLE_BUILDS,
 };
 
 static DownloadsAvailability _get_downloads_availability() {
@@ -68,6 +69,10 @@ static DownloadsAvailability _get_downloads_availability() {
 			String(GODOT_VERSION_STATUS) == String("rc")) {
 		return DOWNLOADS_NOT_AVAILABLE_FOR_DEV_BUILDS;
 	}
+
+#ifdef REAL_T_IS_DOUBLE
+	return DOWNLOADS_NOT_AVAILABLE_FOR_DOUBLE_BUILDS;
+#endif
 
 	if (network_mode == EditorSettings::NETWORK_OFFLINE) {
 		return DOWNLOADS_NOT_AVAILABLE_IN_OFFLINE_MODE;
@@ -739,6 +744,20 @@ void ExportTemplateManager::popup_manager() {
 
 			enable_online_hb->hide();
 		} break;
+
+		case DOWNLOADS_NOT_AVAILABLE_FOR_DOUBLE_BUILDS: {
+			current_missing_label->set_text(TTR("Export templates are missing. Install them from a file."));
+
+			mirrors_list->clear();
+			mirrors_list->add_item(TTR("No templates for double-precision builds"), 0);
+			mirrors_list->set_disabled(true);
+			mirrors_list->set_tooltip_text(TTR("Official export templates aren't available for double-precision builds."));
+
+			mirror_options_button->set_disabled(true);
+
+			download_current_button->set_disabled(true);
+			download_current_button->set_tooltip_text(TTR("Official export templates aren't available for double-precision builds."));
+		}
 	}
 
 	popup_centered(Size2(720, 280) * EDSCALE);


### PR DESCRIPTION
This means that `double` is now visible in the command line startup version, project manager, editor About dialog and at the bottom of the editor. This is because double-precision mode has a significant impact on how the editor and projects run.

Similar to `mono` for C# builds, this affects which export templates the editor looks for, since it needs a different set of export templates.

The export templates manager now indicates that no official double-precision export template downloads are currently available (although the `dev` status message takes priority over it).

## Preview

*With the version string rolled back to 4.3.stable for preview purposes:*

![Export templates manager with double-precision build](https://github.com/user-attachments/assets/6a774ed6-faa5-4a2a-a8f9-8dd94cfdeb6a)