### PR TITLE
Fix bottom panel sizing with multiple options

### DIFF
--- a/editor/gui/editor_bottom_panel.h
+++ b/editor/gui/editor_bottom_panel.h
@@ -37,6 +37,10 @@ class Button;
 class ConfigFile;
 class EditorToaster;
 class HBoxContainer;
+class PopupMenu;
+class ScrollContainer;
+class StyleBoxEmpty;
+class StyleBoxFlat;
 class VBoxContainer;
 
 class EditorBottomPanel : public PanelContainer {
@@ -51,18 +55,34 @@ class EditorBottomPanel : public PanelContainer {
 	Vector<BottomPanelItem> items;
 	bool lock_panel_switching = false;
 
+	Control *shadow_spacer = nullptr;
 	VBoxContainer *item_vbox = nullptr;
 	HBoxContainer *bottom_hbox = nullptr;
+	HBoxContainer *button_tab_bar_hbox = nullptr;
+	Panel *shadow_panel_left = nullptr;
+	Panel *shadow_panel_right = nullptr;
+	ScrollContainer *button_sc = nullptr;
+	Button *button_menu = nullptr;
+	PopupMenu *button_popup_menu = nullptr;
 	HBoxContainer *button_hbox = nullptr;
 	EditorToaster *editor_toaster = nullptr;
 	Button *pin_button = nullptr;
 	Button *expand_button = nullptr;
 	Control *last_opened_control = nullptr;
+	Ref<StyleBoxFlat> stylebox_shadow_left;
+	Ref<StyleBoxFlat> stylebox_shadow_right;
+	Ref<StyleBoxEmpty> stylebox_shadow_empty;
 
 	void _switch_by_control(bool p_visible, Control *p_control, bool p_ignore_lock = false);
 	void _switch_to_item(bool p_visible, int p_idx, bool p_ignore_lock = false);
 	void _pin_button_toggled(bool p_pressed);
 	void _expand_button_toggled(bool p_pressed);
+	void _focus_pressed_button(ObjectID btn_id);
+	void _add_item_to_popup();
+	void _popup_item_pressed(int p_idx);
+	void _set_button_sc_controls();
+	void _sc_input(const Ref<InputEvent> &p_gui_input);
+	void _popup_position();
 
 	bool _button_drag_hover(const Vector2 &, const Variant &, Button *p_button, Control *p_control);
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/95681

Did see this issue a while ago and thought it looked interesting, as I needed to create something similar in gdscript and if a version could be made for the editor.

I did now see there is PR for this already. Haven't looked how it is implemented or tested it. 
If not used in its entirety maybe something here can be useful or combined in to a PR.

## Features:

I first made a version with < prev and next > buttons. But decided to remove them to save space in the bottom panel, as the popup menu gives you a good overview of all the options.

Before:
![Screenshot_20241123_085708](https://github.com/user-attachments/assets/872e9d0d-2f02-4c00-96ee-10d9cfee6bfa)


After (looks the same):
![Screenshot_20241123_085542](https://github.com/user-attachments/assets/9a953d42-0789-48e9-bcb7-0dc73f3389b4)

### Compact
Default:
![Screenshot_20241123_090050](https://github.com/user-attachments/assets/d43579b9-e474-4c27-a1be-65d8069c794f)

Light:
![Screenshot_20241123_090116](https://github.com/user-attachments/assets/9df109df-b1f7-49d6-972a-2f929d8c2267)

Oled:
![Screenshot_20241123_090141](https://github.com/user-attachments/assets/6f715a16-31b3-4919-ab19-57d80cd7c7cf)

### Resizing and scrolling between options:
You can speed up scroll by holding alt key.

[Screencast_20241123_091418.webm](https://github.com/user-attachments/assets/ea0eba11-a9fe-4d6d-9472-8d6590a4552c)

### Scrolls to clicked option:
[Screencast_20241123_091707.webm](https://github.com/user-attachments/assets/21e4ce08-f643-432f-9526-24b6bb466526)


### Scrolls to popup menu selection:
Popup only shows buttons visible in the bottom panel.

[Screencast_20241123_092159.webm](https://github.com/user-attachments/assets/dc70ea58-c631-4c4f-a42d-df69090159b7)

### Scrolls to the editor opened by events such as clicking on a node in the tree:

[Screencast_20241123_092408.webm](https://github.com/user-attachments/assets/edb4208a-4d91-4f4b-a881-0e7f1f1b52b5)

