### PR TITLE
[Windows] Strip `(*)` from `All Files` filter name on Windows 10 and older.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -496,7 +496,11 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 				String str = String(";").join(exts);
 				filter_exts.push_back(str.utf16());
 				if (tokens.size() == 2) {
-					filter_names.push_back(tokens[1].strip_edges().utf16());
+					String name = tokens[1].strip_edges();
+					if (ds->os_ver.dwBuildNumber < 22000 && str == "*.*" && name.ends_with(" (*)")) {
+						name = name.rstrip(" (*)");
+					}
+					filter_names.push_back(name.utf16());
 				} else {
 					filter_names.push_back(str.utf16());
 				}
@@ -505,7 +509,11 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 	}
 	if (filter_names.is_empty()) {
 		filter_exts.push_back(String("*.*").utf16());
-		filter_names.push_back((RTR("All Files") + " (*)").utf16());
+		if (ds->os_ver.dwBuildNumber < 22000) {
+			filter_names.push_back((RTR("All Files")).utf16());
+		} else {
+			filter_names.push_back((RTR("All Files") + " (*)").utf16());
+		}
 	}
 
 	Vector<COMDLG_FILTERSPEC> filters;
@@ -6037,7 +6045,6 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
 
 	// Load Windows version info.
-	OSVERSIONINFOW os_ver;
 	ZeroMemory(&os_ver, sizeof(OSVERSIONINFOW));
 	os_ver.dwOSVersionInfoSize = sizeof(OSVERSIONINFOW);
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -454,6 +454,8 @@ class DisplayServerWindows : public DisplayServer {
 	TTS_Windows *tts = nullptr;
 	NativeMenuWindows *native_menu = nullptr;
 
+	OSVERSIONINFOW os_ver;
+
 	struct WindowData {
 		HWND hWnd;
 


### PR DESCRIPTION
Probably fixes https://github.com/godotengine/godot/issues/99596 (not tested).