### PR TITLE
Fix example code snippets in AudioStreamGenerator.xml

### DIFF
--- a/doc/classes/AudioStreamGenerator.xml
+++ b/doc/classes/AudioStreamGenerator.xml
@@ -11,6 +11,7 @@
 		var playback # Will hold the AudioStreamGeneratorPlayback.
 		@onready var sample_hz = $AudioStreamPlayer.stream.mix_rate
 		var pulse_hz = 440.0 # The frequency of the sound wave.
+		var phase = 0.0
 
 		func _ready():
 		    $AudioStreamPlayer.play()
@@ -18,7 +19,6 @@
 		    fill_buffer()
 
 		func fill_buffer():
-		    var phase = 0.0
 		    var increment = pulse_hz / sample_hz
 		    var frames_available = playback.get_frames_available()
 
@@ -32,6 +32,7 @@
 		private AudioStreamGeneratorPlayback _playback; // Will hold the AudioStreamGeneratorPlayback.
 		private float _sampleHz;
 		private float _pulseHz = 440.0f; // The frequency of the sound wave.
+		private double phase = 0.0;
 
 		public override void _Ready()
 		{
@@ -46,7 +47,6 @@
 
 		public void FillBuffer()
 		{
-		    double phase = 0.0;
 		    float increment = _pulseHz / _sampleHz;
 		    int framesAvailable = _playback.GetFramesAvailable();
 


### PR DESCRIPTION
I was playing around with C# code snippet but I kept hearing a clipping sound. I think this is because the phase variable is being set to 0 in the wrong spot.

The phase at the end of the FillBuffer() method is some non zero number. When FillBuffer is called again, the phase is suddenly changed back to zero. This causes the end of one sin wave segment to be out of sync with the next sin wave segment. The sin wave needs to be continuous between FillBuffer calls so no clipping sound occurs.

Moving the phase variable out of FillBuffer and putting it in a scope above makes it retain its value between FillBuffer calls, making the sin wave continuous, and the clipping sound is gone.

For further proof, the demo project "Audio Generator Demo" (https://github.com/godotengine/godot-demo-projects/blob/4.2-31d1c0c/audio/generator/generator_demo.gd) has the phase variable be one scope above FillBuffer and it does not set phase=0 inside of FillBuffer. If anything, I'm fixing this documentation to match the working demo

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
