### PR TITLE
Change default index of the LookAtModifier3D's origin bone

### DIFF
--- a/scene/3d/look_at_modifier_3d.h
+++ b/scene/3d/look_at_modifier_3d.h
@@ -64,7 +64,7 @@ private:
 	bool use_secondary_rotation = true;
 
 	OriginFrom origin_from = ORIGIN_FROM_SELF;
-	int origin_bone = -1;
+	int origin_bone = 0;
 	NodePath origin_external_node;
 
 	Vector3 origin_offset;


### PR DESCRIPTION
- Fixes #99510

However, I am not sure if this is a good way.

BoneAttachment has both a bone name and a bone idx, which I remember was for the case when the bone idx was changed by import. Maybe it was for 3.x->4.0 compatibility, I don't remember. Is there any idea @fire @lyuma?

If we adopt the same method as BoneAttachment, I think we should change not only the `origin_bone` but also the `bone` property as well, but I think it is too redundant.

On the other hand, it is not good for performance to always have a string in a property like ENUM SUGGESTION. Caching is possible, but it is impractical to recommend caching to users when they do similar implementations.

Perhaps in the future we should consider an additional enum hint that allows `-1` as an invalid value?