### PR TITLE
Make LookAtModifier3D adopt the bone name method

### DIFF
--- a/doc/classes/LookAtModifier3D.xml
+++ b/doc/classes/LookAtModifier3D.xml
@@ -32,8 +32,11 @@
 		</method>
 	</methods>
 	<members>
-		<member name="bone" type="int" setter="set_bone" getter="get_bone" default="0">
-			The bone index of the [Skeleton3D] that the modification will operate on.
+		<member name="bone" type="int" setter="set_bone" getter="get_bone" default="-1">
+			Index of the [member bone_name] in the parent [Skeleton3D].
+		</member>
+		<member name="bone_name" type="String" setter="set_bone_name" getter="get_bone_name" default="&quot;&quot;">
+			The bone name of the [Skeleton3D] that the modification will operate on.
 		</member>
 		<member name="duration" type="float" setter="set_duration" getter="get_duration" default="0.0">
 			The duration of the time-based interpolation. Interpolation is triggered at the following cases:
@@ -48,6 +51,9 @@
 			The forward axis of the bone. This [SkeletonModifier3D] modifies the bone so that this axis points toward the [member target_node].
 		</member>
 		<member name="origin_bone" type="int" setter="set_origin_bone" getter="get_origin_bone">
+			Index of the [member origin_bone_name] in the parent [Skeleton3D].
+		</member>
+		<member name="origin_bone_name" type="String" setter="set_origin_bone_name" getter="get_origin_bone_name">
 			If [member origin_from] is [constant ORIGIN_FROM_SPECIFIC_BONE], the bone global pose position specified for this is used as origin.
 		</member>
 		<member name="origin_external_node" type="NodePath" setter="set_origin_external_node" getter="get_origin_external_node">

--- a/scene/3d/look_at_modifier_3d.h
+++ b/scene/3d/look_at_modifier_3d.h
@@ -54,7 +54,8 @@ public:
 	};
 
 private:
-	int bone = 0;
+	String bone_name;
+	int bone = -1;
 
 	Vector3 forward_vector;
 	Vector3 forward_vector_nrm;
@@ -64,6 +65,7 @@ private:
 	bool use_secondary_rotation = true;
 
 	OriginFrom origin_from = ORIGIN_FROM_SELF;
+	String origin_bone_name;
 	int origin_bone = -1;
 	NodePath origin_external_node;
 
@@ -123,6 +125,8 @@ protected:
 	virtual void _process_modification() override;
 
 public:
+	void set_bone_name(const String &p_bone_name);
+	String get_bone_name() const;
 	void set_bone(int p_bone);
 	int get_bone() const;
 
@@ -135,6 +139,8 @@ public:
 
 	void set_origin_from(OriginFrom p_origin_from);
 	OriginFrom get_origin_from() const;
+	void set_origin_bone_name(const String &p_bone_name);
+	String get_origin_bone_name() const;
 	void set_origin_bone(int p_bone);
 	int get_origin_bone() const;
 	void set_origin_external_node(const NodePath &p_external_node);


### PR DESCRIPTION
- Alternative of the #99610
- Fixes https://github.com/godotengine/godot/issues/99510

It is redundant but consistent with BoneAttachment3D.