### PR TITLE
Fix `forward_vector` scale to handle `safe_margin` correctly in LookAtModifier

### DIFF
--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -486,7 +486,7 @@ void LookAtModifier3D::_process_modification() {
 		} else {
 			origin_tr = bone_rest_space;
 		}
-		forward_vector = bone_rest_space.basis.xform_inv((target->get_global_position() - origin_tr.translated_local(origin_offset).origin));
+		forward_vector = bone_rest_space.orthonormalized().basis.xform_inv((target->get_global_position() - origin_tr.translated_local(origin_offset).origin));
 		forward_vector_nrm = forward_vector.normalized();
 		if (forward_vector_nrm.abs().is_equal_approx(get_vector_from_axis(primary_rotation_axis))) {
 			destination = skeleton->get_bone_pose_rotation(bone);


### PR DESCRIPTION
- Follow up #98446

In MRP of #99510, the parent is scaled to 0.01, so you can see that the safe margin value has been multiplied by 100 in the process. The space to get the forward vector should be orthonormalized because it affects the threshold of the safe margin when scaled.

It is possible that the calculation results could be undesirable in the presence of shear, but I believe this is a niche case, so I would prefer to prevent the problem in the general case.