### PR TITLE
Fix Monitors tab incorrectly reporting integers as floats

### DIFF
--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -88,7 +88,11 @@ String EditorPerformanceProfiler::_create_label(float p_value, Performance::Moni
 			return TS->format_number(rtos(p_value * 1000).pad_decimals(2)) + " " + TTR("ms");
 		}
 		default: {
-			return TS->format_number(rtos(p_value));
+			String ret = TS->format_number(rtos(p_value));
+			if (ret.ends_with(".0")) {
+				ret = ret.pad_decimals(0);
+			}
+			return ret;
 		}
 	}
 }


### PR DESCRIPTION
This is a very small change that causes values in the monitor tab to be shown as integers if they are integers. Fixes #99577 

Before change:
![image](https://github.com/user-attachments/assets/1bc947fd-cd8b-4eed-a887-9332424690fc)

After change:
![image](https://github.com/user-attachments/assets/54206181-c80b-4f05-81ce-21d4a34a712c)

Floating point numbers are unaffected. 

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/99000*