### PR TITLE
Docs: Update Control class to properly reflect behavior of Themes on Control Children

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -12,7 +12,7 @@
 		Call [method accept_event] so no other node receives the event. Once you accept an input, it becomes handled so [method Node._unhandled_input] will not process it.
 		Only one [Control] node can be in focus. Only the node in focus will receive events. To get the focus, call [method grab_focus]. [Control] nodes lose focus when another node grabs it, or if you hide the node in focus.
 		Sets [member mouse_filter] to [constant MOUSE_FILTER_IGNORE] to tell a [Control] node to ignore mouse or touch events. You'll need it if you place an icon on top of a button.
-		[Theme] resources change the Control's appearance. If you change the [Theme] on a [Control] node, it affects all of its children. To override some of the theme's parameters, call one of the [code]add_theme_*_override[/code] methods, like [method add_theme_font_override]. You can override the theme with the Inspector.
+		[Theme] resources change the control's appearance. The [member theme] of a [Control] node affects all of its direct and indirect children (as long as a chain of controls is uninterrupted). To override some of the theme items, call one of the [code]add_theme_*_override[/code] methods, like [method add_theme_font_override]. You can also override theme items in the Inspector.
 		[b]Note:[/b] Theme items are [i]not[/i] [Object] properties. This means you can't access their values using [method Object.get] and [method Object.set]. Instead, use the [code]get_theme_*[/code] and [code]add_theme_*_override[/code] methods provided by this class.
 	</description>
 	<tutorials>


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/90289. Apologies if this kind of salvage is frowned upon in the main repo; I've been doing this to clear the backlog in the docs repo recently.

Closes https://github.com/godotengine/godot/issues/88534.

The wording "as long as a chain of [Control]s is uninterrupted" is copied from the Theme docs.

I made some additional changes:
- Don't call theme items "parameters" - I believe either "items" or "properties" is correct here.
- Don't mention that you can override the theme with the inspector, since this is implicit from the fact that this is a class with a `theme` property.
- Link to the `[member theme]`.
