### PR TITLE
Add `samplerExternalOES` type to shader globals

### DIFF
--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -65,6 +65,7 @@ static const char *global_var_type_names[RS::GLOBAL_VAR_TYPE_MAX] = {
 	"sampler2DArray",
 	"sampler3D",
 	"samplerCube",
+	"samplerExternalOES",
 };
 
 class ShaderGlobalsEditorInterface : public Object {
@@ -232,6 +233,11 @@ protected:
 					pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
 					pinfo.hint_string = "Cubemap,CompressedCubemap";
 				} break;
+				case RS::GLOBAL_VAR_TYPE_SAMPLEREXT: {
+					pinfo.type = Variant::OBJECT;
+					pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+					pinfo.hint_string = "ExternalTexture";
+				} break;
 				default: {
 				} break;
 			}
@@ -337,6 +343,9 @@ static Variant create_var(RS::GlobalShaderParameterType p_type) {
 			return "";
 		}
 		case RS::GLOBAL_VAR_TYPE_SAMPLERCUBE: {
+			return "";
+		}
+		case RS::GLOBAL_VAR_TYPE_SAMPLEREXT: {
 			return "";
 		}
 		default: {

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -197,6 +197,11 @@ void ShaderGlobalsOverride::_get_property_list(List<PropertyInfo> *p_list) const
 				pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
 				pinfo.hint_string = "Cubemap";
 			} break;
+			case RS::GLOBAL_VAR_TYPE_SAMPLEREXT: {
+				pinfo.type = Variant::OBJECT;
+				pinfo.hint = PROPERTY_HINT_RESOURCE_TYPE;
+				pinfo.hint_string = "ExternalTexture";
+			} break;
 			default: {
 			} break;
 		}

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1868,6 +1868,8 @@ int RenderingServer::global_shader_uniform_type_get_shader_datatype(GlobalShader
 			return ShaderLanguage::TYPE_SAMPLER3D;
 		case RS::GLOBAL_VAR_TYPE_SAMPLERCUBE:
 			return ShaderLanguage::TYPE_SAMPLERCUBE;
+		case RS::GLOBAL_VAR_TYPE_SAMPLEREXT:
+			return ShaderLanguage::TYPE_SAMPLEREXT;
 		default:
 			return ShaderLanguage::TYPE_MAX; // Invalid or not found.
 	}


### PR DESCRIPTION
- Fix https://github.com/godotengine/godot/issues/99233