### PR TITLE
Replace hardcoded radial center cross marker for `TextureProgressBar` with internal `Marker2D` child node

### DIFF
--- a/doc/classes/TextureProgressBar.xml
+++ b/doc/classes/TextureProgressBar.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		TextureProgressBar works like [ProgressBar], but uses up to 3 textures instead of Godot's [Theme] resource. It can be used to create horizontal, vertical and radial progress bars.
+		[b]Note:[/b] When added in the editor, the internal [Marker2D] child node is added as the radial center cross marker. This [Marker2D] node is visible only if the [member texture_progress] is valid and the [member fill_mode] is [constant FILL_CLOCKWISE], [constant FILL_COUNTER_CLOCKWISE], or [constant FILL_CLOCKWISE_AND_COUNTER_CLOCKWISE]. To remove the radial center cross marker (for example, in a plugin or in a tool script) this [Marker2D] node could be accessed as the first internal child node and then freed.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/gui/texture_progress_bar.h
+++ b/scene/gui/texture_progress_bar.h
@@ -33,6 +33,10 @@
 
 #include "scene/gui/range.h"
 
+#ifdef TOOLS_ENABLED
+#include "scene/2d/marker_2d.h"
+#endif
+
 class TextureProgressBar : public Range {
 	GDCLASS(TextureProgressBar, Range);
 
@@ -113,6 +117,10 @@ private:
 	Color tint_under = Color(1, 1, 1);
 	Color tint_progress = Color(1, 1, 1);
 	Color tint_over = Color(1, 1, 1);
+
+#ifdef TOOLS_ENABLED
+	Marker2D *reference_cross_marker = nullptr;
+#endif
 
 	void _set_texture(Ref<Texture2D> *p_destination, const Ref<Texture2D> &p_texture);
 	void _texture_changed();


### PR DESCRIPTION
*Updated after separating 1) replacing hardcoded marker and 2) issues with its visibility in plugins.*

This is proof of concept showing how https://github.com/godotengine/godot-proposals/issues/11225 may be implemented, nothing more.

How it looks:
![godot windows editor dev x86_64_RiIircpkeu](https://github.com/user-attachments/assets/75059456-c963-4ce9-b28d-9f4be26f11f2)
| | Current | PR |
|--|---------|-----------|
| 1024x1024 | ![Godot_v4 4-dev2_win64_Lksr6p93Qr](https://github.com/user-attachments/assets/51b1d132-2e93-4f1a-89de-e1ba477ccf66)        |   ![godot windows editor dev x86_64_PLyyQBxnf3](https://github.com/user-attachments/assets/77ccf894-967c-4c6d-a2be-80b2b90420d3)        | 
| 48x48 | ![Godot_v4 4-dev2_win64_duNiAhNCOF](https://github.com/user-attachments/assets/86ae8c4d-e6eb-4d44-84bb-1e83209637c9) |  ![godot windows editor dev x86_64_6ZL3ie810C](https://github.com/user-attachments/assets/11742d34-8510-45f3-8a55-b3d8ef9cb811)



Pros:
1) Crosshair now doesn't look unnatural compared to other stuff in editor.
2) Reusing existing functionality of `Marker2D` node.
3) Allows seeing actual center more precisely - may be good for low-res art.

Cons:
1) Additional overhead in editor as additional node is created.
2) Less code readability, too overcomplicated.


Implementation details:
- If the code is executed in the editor, an additional internal `Marker2D` child node will be added when `TextureProgressBar` is created.
- When setting `fill_mode`, `Marker2D` node visibility changes. It becomes visible if mode is radial and `texture_progress` is valid. ~Also these is check if `Marker2D` node is valid as it could be freed (to cover issues https://github.com/godotengine/godot/issues/46266 and https://github.com/godotengine/godot/issues/96859).~ <- Not applicable anymore, now this PR is targeting to show only visual changes. 
- When drawing, position of `Marker2D` node is updated.
- Visibility of `Marker2D` is also changed inside `set_progress_texture()`.
- Changes are reflected in `TextureProgressBar` node description in docs. UPD: All mechanism around removing reference cross in plugins could be ignored, now this is not targeting to fix this issue.
- **Previously position of hardcoded radial center marker was rounded to the largest whole number. Now this rounding is removed and position of `Marker2D` is real radial center position.** - This one could be moved into any other alternative of current PR.