### PR TITLE
[Buildsystem] Fix path format for SCU builds on Windows

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -102,6 +102,7 @@ def add_source_files_scu(self, sources, files, allow_gen=False):
         subdir = os.path.dirname(files)
         subdir = subdir if subdir == "" else subdir + "/"
         section_name = self.Dir(subdir).tpath
+        section_name = section_name.replace("\\", "/")  # win32
         # if the section name is in the hash table?
         # i.e. is it part of the SCU build?
         global _scu_folders


### PR DESCRIPTION
Regression from:
* https://github.com/godotengine/godot/pull/98888

Keeping the other changes for now unless it's better to just revert that, I think the cleanup otherwise is an improvement. Don't know if there might be better ways to achieve this particular fix but the method to just replace `\\` with `/` is used elsewhere in this file so I think it's appropriate.

Any additional ideas on how to solve this is very welcome, but does solve the problem for me

* Fixes: https://github.com/godotengine/godot/issues/99607
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
