### PR TITLE
Mention `DUPLICATE_SIGNALS` only affects `CONNECT_PERSIST` signals

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1307,7 +1307,7 @@
 			Disables physics interpolation for this node and for children set to [constant PHYSICS_INTERPOLATION_MODE_INHERIT].
 		</constant>
 		<constant name="DUPLICATE_SIGNALS" value="1" enum="DuplicateFlags">
-			Duplicate the node's signal connections.
+			Duplicate the node's signal connections that are connected with the [constant Object.CONNECT_PERSIST] flag.
 		</constant>
 		<constant name="DUPLICATE_GROUPS" value="2" enum="DuplicateFlags">
 			Duplicate the node's groups.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/65618