### PR TITLE
Augment unit tests for `OptionButton`

### DIFF
--- a/tests/scene/test_option_button.h
+++ b/tests/scene/test_option_button.h
@@ -83,7 +83,7 @@ TEST_CASE("[SceneTree][OptionButton] Single item") {
 	memdelete(test_opt);
 }
 
-TEST_CASE("[SceneTree][OptionButton] Complex structure") {
+TEST_CASE("[SceneTree][OptionButton] Many items") {
 	OptionButton *test_opt = memnew(OptionButton);
 
 	SUBCASE("Creating a complex structure and checking getters") {
@@ -126,6 +126,31 @@ TEST_CASE("[SceneTree][OptionButton] Complex structure") {
 
 		CHECK_FALSE(test_opt->has_selectable_items());
 		CHECK(test_opt->get_item_count() == 1);
+	}
+
+	SUBCASE("Getters and setters not related to structure") {
+		test_opt->add_item("regular", 2019);
+
+		Ref<Texture2D> test_icon = memnew(Texture2D);
+		test_opt->add_icon_item(test_icon, "icon", 3092);
+
+		// item_text.
+		test_opt->set_item_text(0, "example text");
+		CHECK(test_opt->get_item_text(0) == "example text");
+
+		// item_metadata.
+		Dictionary m;
+		m["bool"] = true;
+		m["String"] = "yes";
+		test_opt->set_item_metadata(1, m);
+		CHECK(test_opt->get_item_metadata(1) == m);
+
+		// item_tooltip.
+		test_opt->set_item_tooltip(0, "tooltip guide");
+		CHECK(test_opt->get_item_tooltip(0) == "tooltip guide");
+
+		test_opt->remove_item(1);
+		test_opt->remove_item(0);
 	}
 
 	memdelete(test_opt);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Further to [this comment](https://github.com/godotengine/godot/pull/93824#discussion_r1675661312) on my previous PR #93824, this new PR implements the (optional) improvements that were suggested by @Geometror .

A new `SUBCASE` has been provided, that verifies the getters and setters for:
1. `item_text`
2. `item_tooltop`
3. `item_metadata`

Hope it was worth the wait! 😅 