### PR TITLE
Fix underscore input not working with jp106 keyboard on Wayland platform

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -193,10 +193,7 @@ bool WaylandThread::_seat_state_configure_key_event(SeatState &p_ss, Ref<InputEv
 	Key keycode = KeyMappingXKB::get_keycode(xkb_state_key_get_one_sym(p_ss.xkb_state, p_keycode));
 	Key physical_keycode = KeyMappingXKB::get_scancode(p_keycode);
 	KeyLocation key_location = KeyMappingXKB::get_location(p_keycode);
-
-	if (physical_keycode == Key::NONE) {
-		return false;
-	}
+	uint32_t unicode = xkb_state_key_get_utf32(p_ss.xkb_state, p_keycode);
 
 	if (keycode == Key::NONE) {
 		keycode = physical_keycode;
@@ -204,6 +201,10 @@ bool WaylandThread::_seat_state_configure_key_event(SeatState &p_ss, Ref<InputEv
 
 	if (keycode >= Key::A + 32 && keycode <= Key::Z + 32) {
 		keycode -= 'a' - 'A';
+	}
+
+	if (physical_keycode == Key::NONE && keycode == Key::NONE && unicode == 0) {
+		return false;
 	}
 
 	p_event->set_window_id(DisplayServer::MAIN_WINDOW_ID);
@@ -218,8 +219,6 @@ bool WaylandThread::_seat_state_configure_key_event(SeatState &p_ss, Ref<InputEv
 	p_event->set_keycode(keycode);
 	p_event->set_physical_keycode(physical_keycode);
 	p_event->set_location(key_location);
-
-	uint32_t unicode = xkb_state_key_get_utf32(p_ss.xkb_state, p_keycode);
 
 	if (unicode != 0) {
 		p_event->set_key_label(fix_key_label(unicode, keycode));


### PR DESCRIPTION
This PR fixes an issue where the underscore key can't be typed in the jp106 Japanese input environments on the wayland platform.

## Details
Godot's wayland platform correctly converts keysyms using xkb and godot's xkb_keycode_map table.
However, in jp106 environments, when retrieving the physical key, physical_key becomes Key::NONE and input fails because the scancode_map table doesn't have a value set corresponding to underscore (0x61: backslash).

## Solutions
1. Set Key::BACKSLASH to 0x61 in scancode_map
While this solution works correctly in jp106 keymap environments, it breaks the other environments where 0x61 is assigned to different keys.

2. Allow Key::NONE for physical_key
This seems valid as godot's windows implementation also allows Key::NONE for physical_key.

This PR implements solution 2.

## Additional Notes
Godot currently stores scancodes as its internal code, but converting to internal codes can result in loss of information when using keymapping.
In the future, it might be better to store platform native scancodes.
Looking at Qt's implementation, scancode is stored as uint32 type with platform native values.
https://doc.qt.io/qt-6/qkeyevent.html