### PR TITLE
Add `flipped_horizontally` and `flipped_vertically` signals for `Sprite2D`, `AnimatedSprite2D` and `SpriteBase3D`

### DIFF
--- a/doc/classes/AnimatedSprite2D.xml
+++ b/doc/classes/AnimatedSprite2D.xml
@@ -124,6 +124,20 @@
 				Emitted when the animation loops.
 			</description>
 		</signal>
+		<signal name="flipped_horizontally">
+			<param index="0" name="flipped" type="bool" />
+			<description>
+				Emitted when the [member flip_h] changes.
+				This is useful for flipping a group of (animated) sprites horizontally, and reflecting their [member Node2D.position][code].x[/code] as if their X scales were negative.
+			</description>
+		</signal>
+		<signal name="flipped_vertically">
+			<param index="0" name="flipped" type="bool" />
+			<description>
+				Emitted when the [member flip_v] changes.
+				This is useful for flipping a group of (animated) sprites vertically, and reflecting their [member Node2D.position][code].y[/code] as if their Y scales were negative.
+			</description>
+		</signal>
 		<signal name="frame_changed">
 			<description>
 				Emitted when [member frame] changes.

--- a/doc/classes/Sprite2D.xml
+++ b/doc/classes/Sprite2D.xml
@@ -89,6 +89,20 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="flipped_horizontally">
+			<param index="0" name="flipped" type="bool" />
+			<description>
+				Emitted when the [member flip_h] changes.
+				This is useful for flipping a group of (animated) sprites horizontally, and reflecting their [member Node2D.position][code].x[/code] as if their X scales were negative.
+			</description>
+		</signal>
+		<signal name="flipped_vertically">
+			<param index="0" name="flipped" type="bool" />
+			<description>
+				Emitted when the [member flip_v] changes.
+				This is useful for flipping a group of (animated) sprites vertically, and reflecting their [member Node2D.position][code].y[/code] as if their Y scales were negative.
+			</description>
+		</signal>
 		<signal name="frame_changed">
 			<description>
 				Emitted when the [member frame] changes.

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -105,6 +105,22 @@
 			If [code]true[/code], the texture's transparency and the opacity are used to make those parts of the sprite invisible.
 		</member>
 	</members>
+	<signals>
+		<signal name="flipped_horizontally">
+			<param index="0" name="flipped" type="bool" />
+			<description>
+				Emitted when the [member flip_h] changes.
+				This is useful for flipping a group of (animated) sprites horizontally, and reflecting their "X position" in a plane as if their "X scales in 2D" were negative.
+			</description>
+		</signal>
+		<signal name="flipped_vertically">
+			<param index="0" name="flipped" type="bool" />
+			<description>
+				Emitted when the [member flip_v] changes.
+				This is useful for flipping a group of (animated) sprites vertically, and reflecting their "Y position" in a plane as if their "Y scales in 2D" were negative.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="FLAG_TRANSPARENT" value="0" enum="DrawFlags">
 			If set, the texture's transparency and the opacity are used to make those parts of the sprite invisible.
@@ -137,20 +153,4 @@
 			This mode draws cuts off all values below a spatially-deterministic threshold, the rest will remain opaque.
 		</constant>
 	</constants>
-	<signals>
-		<signal name="flipped_horizontally">
-			<param index="0" name="flipped" type="bool" />
-			<description>
-				Emitted when the [member flip_h] changes.
-				This is useful for flipping a group of (animated) sprites horizontally, and reflecting their "X position" in a plane as if their "X scales in 2D" were negative.
-			</description>
-		</signal>
-		<signal name="flipped_vertically">
-			<param index="0" name="flipped" type="bool" />
-			<description>
-				Emitted when the [member flip_v] changes.
-				This is useful for flipping a group of (animated) sprites vertically, and reflecting their "Y position" in a plane as if their "Y scales in 2D" were negative.
-			</description>
-		</signal>
-	</signals>
 </class>

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -137,4 +137,20 @@
 			This mode draws cuts off all values below a spatially-deterministic threshold, the rest will remain opaque.
 		</constant>
 	</constants>
+	<signals>
+		<signal name="flipped_horizontally">
+			<param index="0" name="flipped" type="bool" />
+			<description>
+				Emitted when the [member flip_h] changes.
+				This is useful for flipping a group of (animated) sprites horizontally, and reflecting their "X position" in a plane as if their "X scales in 2D" were negative.
+			</description>
+		</signal>
+		<signal name="flipped_vertically">
+			<param index="0" name="flipped" type="bool" />
+			<description>
+				Emitted when the [member flip_v] changes.
+				This is useful for flipping a group of (animated) sprites vertically, and reflecting their "Y position" in a plane as if their "Y scales in 2D" were negative.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -416,6 +416,7 @@ void AnimatedSprite2D::set_flip_h(bool p_flip) {
 	}
 
 	hflip = p_flip;
+	emit_signal("flipped_horizontally", hflip);
 	queue_redraw();
 }
 
@@ -429,6 +430,7 @@ void AnimatedSprite2D::set_flip_v(bool p_flip) {
 	}
 
 	vflip = p_flip;
+	emit_signal("flipped_vertically", vflip);
 	queue_redraw();
 }
 
@@ -652,6 +654,8 @@ void AnimatedSprite2D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 	ADD_SIGNAL(MethodInfo("animation_looped"));
 	ADD_SIGNAL(MethodInfo("animation_finished"));
+	ADD_SIGNAL(MethodInfo("flipped_horizontally", PropertyInfo(Variant::BOOL, "flipped", PROPERTY_HINT_NONE)));
+	ADD_SIGNAL(MethodInfo("flipped_vertically", PropertyInfo(Variant::BOOL, "flipped", PROPERTY_HINT_NONE)));
 
 	ADD_GROUP("Animation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sprite_frames", PROPERTY_HINT_RESOURCE_TYPE, "SpriteFrames"), "set_sprite_frames", "get_sprite_frames");
@@ -663,6 +667,7 @@ void AnimatedSprite2D::_bind_methods() {
 	ADD_GROUP("Offset", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
+	ADD_GROUP("Flip", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 }

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -189,6 +189,7 @@ void Sprite2D::set_flip_h(bool p_flip) {
 	}
 
 	hflip = p_flip;
+	emit_signal("flipped_horizontally", hflip);
 	queue_redraw();
 }
 
@@ -202,6 +203,7 @@ void Sprite2D::set_flip_v(bool p_flip) {
 	}
 
 	vflip = p_flip;
+	emit_signal("flipped_vertically", vflip);
 	queue_redraw();
 }
 
@@ -479,11 +481,14 @@ void Sprite2D::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 	ADD_SIGNAL(MethodInfo("texture_changed"));
+	ADD_SIGNAL(MethodInfo("flipped_horizontally", PropertyInfo(Variant::BOOL, "flipped", PROPERTY_HINT_NONE)));
+	ADD_SIGNAL(MethodInfo("flipped_vertically", PropertyInfo(Variant::BOOL, "flipped", PROPERTY_HINT_NONE)));
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture");
 	ADD_GROUP("Offset", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
+	ADD_GROUP("Flip", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 	ADD_GROUP("Animation", "");

--- a/scene/2d/sprite_2d.h
+++ b/scene/2d/sprite_2d.h
@@ -100,6 +100,18 @@ public:
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
 
+	void set_flip_h_as_parent(const bool p_flip_as_parent);
+	bool is_flip_h_as_parent() const;
+
+	void set_flip_v_as_parent(const bool p_flip_as_parent);
+	bool is_flip_v_as_parent() const;
+
+	void set_flip_h_is_reflection(const bool p_flip_is_reflection);
+	bool is_flip_h_reflection() const;
+
+	void set_flip_v_is_reflection(const bool p_flip_is_reflection);
+	bool is_flip_v_reflection() const;
+
 	void set_region_enabled(bool p_enabled);
 	bool is_region_enabled() const;
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -316,6 +316,7 @@ void SpriteBase3D::set_flip_h(bool p_flip) {
 	}
 
 	hflip = p_flip;
+	emit_signal("flipped_horizontally", hflip);
 	_queue_redraw();
 }
 
@@ -329,6 +330,7 @@ void SpriteBase3D::set_flip_v(bool p_flip) {
 	}
 
 	vflip = p_flip;
+	emit_signal("flipped_vertically", vflip);
 	_queue_redraw();
 }
 
@@ -639,10 +641,16 @@ void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_rect"), &SpriteBase3D::get_item_rect);
 	ClassDB::bind_method(D_METHOD("generate_triangle_mesh"), &SpriteBase3D::generate_triangle_mesh);
 
+	ADD_SIGNAL(MethodInfo("flipped_horizontally", PropertyInfo(Variant::BOOL, "flipped", PROPERTY_HINT_NONE)));
+	ADD_SIGNAL(MethodInfo("flipped_vertically", PropertyInfo(Variant::BOOL, "flipped", PROPERTY_HINT_NONE)));
+
+	ADD_GROUP("Offset", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "centered"), "set_centered", "is_centered");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), "set_offset", "get_offset");
+	ADD_GROUP("Flip", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
+	ADD_GROUP("", "");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pixel_size", PROPERTY_HINT_RANGE, "0.0001,128,0.0001,suffix:m"), "set_pixel_size", "get_pixel_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis", PROPERTY_HINT_ENUM, "X-Axis,Y-Axis,Z-Axis"), "set_axis", "get_axis");


### PR DESCRIPTION
Completes: https://github.com/godotengine/godot-proposals/issues/5146

In that proposal, the author noted mentioned the following:
> Implement a AnimatedSprite.frame_refreshed signal. Although the signal is reasonably self-explanatory, It will be emitted only once per frame, if one of the following happen:
>
>    The animation changes;
>    The frame changes;
>    flip_x and flip_y are toggled;
>    The SpriteFrames frames is changed;

According to the reference, the `frame_refreshed` will be emitted on the change of `flip_*`. But sadly, the signal was obsolescent.

Meanwhile, there has been a lot of discussions and proposal duplicates about complaining getting unexpected result from a scale like (-1, 1) and the users wanted to figure out a way to the solution and put their hope on `flip_*`. Because we don't have `property_changed` signal for `Object`, which could be costly for the  performance, I implemented a pair of signals for some nodes such as `Sprite2D`, `AnimatedSprite2D` and `SpriteBase3D` that have members beginning with `flip_`, which will be emitted on the change of these members.

By connecting this signal to other sprites, one can easily achieve the flipping synchronization and safe reflection on single axis (negative X/Y scale without polluting the global rotation):
```GDScript
# Taking a Sprite2D as an example
extends Sprite2D

func _ready() -> void:
    (get_parent() as Sprite2D).flipped_horizontally.connected(
        func _on_parent_flipped_horizontally(flipped: bool) -> void:
            if flip_h == flipped:
               return
            flip_h = flipped
            position.x *= -1.0
    )
```