### PR TITLE
CI: Add module dependencies to mypy hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,7 @@ repos:
       - id: mypy
         files: \.py$
         types_or: [text]
+        additional_dependencies: [scons==4.8.1, pytest==7.1.2]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -2,13 +2,11 @@ import os
 import platform
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+
+from SCons.Script.SConscript import SConsEnvironment
 
 from methods import print_error, print_warning
 from platform_methods import validate_arch
-
-if TYPE_CHECKING:
-    from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_name():
@@ -54,7 +52,7 @@ def get_min_sdk_version(platform):
     return int(platform.split("-")[1])
 
 
-def get_android_ndk_root(env: "SConsEnvironment"):
+def get_android_ndk_root(env: SConsEnvironment):
     return env["ANDROID_HOME"] + "/ndk/" + get_ndk_version()
 
 
@@ -78,7 +76,7 @@ def get_flags():
 
 # Check if Android NDK version is installed
 # If not, install it.
-def install_ndk_if_needed(env: "SConsEnvironment"):
+def install_ndk_if_needed(env: SConsEnvironment):
     sdk_root = env["ANDROID_HOME"]
     if not os.path.exists(get_android_ndk_root(env)):
         extension = ".bat" if os.name == "nt" else ""
@@ -106,7 +104,7 @@ def detect_swappy():
     return has_swappy
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -1,12 +1,10 @@
 import os
 import sys
-from typing import TYPE_CHECKING
+
+from SCons.Script.SConscript import SConsEnvironment
 
 from methods import detect_darwin_sdk_path, print_error, print_warning
 from platform_methods import validate_arch
-
-if TYPE_CHECKING:
-    from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_name():
@@ -58,7 +56,7 @@ def get_flags():
     }
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -1,13 +1,11 @@
 import os
 import platform
 import sys
-from typing import TYPE_CHECKING
+
+from SCons.Script.SConscript import SConsEnvironment
 
 from methods import get_compiler_version, print_error, print_warning, using_gcc
 from platform_methods import detect_arch, validate_arch
-
-if TYPE_CHECKING:
-    from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_name():
@@ -71,7 +69,7 @@ def get_flags():
     }
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -1,12 +1,10 @@
 import os
 import sys
-from typing import TYPE_CHECKING
+
+from SCons.Script.SConscript import SConsEnvironment
 
 from methods import detect_darwin_sdk_path, get_compiler_version, is_apple_clang, print_error, print_warning
 from platform_methods import detect_arch, detect_mvk, validate_arch
-
-if TYPE_CHECKING:
-    from SCons.Script.SConscript import SConsEnvironment
 
 # To match other platforms
 STACK_SIZE = 8388608
@@ -65,7 +63,7 @@ def get_flags():
     }
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_64", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from typing import TYPE_CHECKING
 
 from emscripten_helpers import (
     add_js_externs,
@@ -11,13 +10,11 @@ from emscripten_helpers import (
     get_template_zip_path,
     run_closure_compiler,
 )
+from SCons.Script.SConscript import SConsEnvironment
 from SCons.Util import WhereIs
 
 from methods import get_compiler_version, print_error, print_warning
 from platform_methods import validate_arch
-
-if TYPE_CHECKING:
-    from SCons.Script.SConscript import SConsEnvironment
 
 
 def get_name():
@@ -84,7 +81,7 @@ def get_flags():
     }
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["wasm32"]
     validate_arch(env["arch"], get_name(), supported_arches)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -2,14 +2,12 @@ import os
 import re
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+
+from SCons.Script.SConscript import SConsEnvironment
 
 import methods
 from methods import print_error, print_warning
 from platform_methods import detect_arch, validate_arch
-
-if TYPE_CHECKING:
-    from SCons.Script.SConscript import SConsEnvironment
 
 # To match other platforms
 STACK_SIZE = 8388608
@@ -79,7 +77,7 @@ def get_mingw_bin_prefix(prefix, arch):
     return bin_prefix + arch_prefix
 
 
-def get_detected(env: "SConsEnvironment", tool: str) -> str:
+def get_detected(env: SConsEnvironment, tool: str) -> str:
     checks = [
         get_mingw_bin_prefix(env["mingw_prefix"], env["arch"]) + tool,
         get_mingw_bin_prefix(env["mingw_prefix"], "") + tool,
@@ -245,7 +243,7 @@ def get_flags():
     }
 
 
-def setup_msvc_manual(env: "SConsEnvironment"):
+def setup_msvc_manual(env: SConsEnvironment):
     """Running from VCVARS environment"""
 
     env_arch = detect_build_env_arch()
@@ -260,7 +258,7 @@ def setup_msvc_manual(env: "SConsEnvironment"):
     print("Using VCVARS-determined MSVC, arch %s" % (env_arch))
 
 
-def setup_msvc_auto(env: "SConsEnvironment"):
+def setup_msvc_auto(env: SConsEnvironment):
     """Set up MSVC using SCons's auto-detection logic"""
 
     # If MSVC_VERSION is set by SCons, we know MSVC is installed.
@@ -302,7 +300,7 @@ def setup_msvc_auto(env: "SConsEnvironment"):
     print("Using SCons-detected MSVC version %s, arch %s" % (env["MSVC_VERSION"], env["arch"]))
 
 
-def setup_mingw(env: "SConsEnvironment"):
+def setup_mingw(env: SConsEnvironment):
     """Set up env for use with mingw"""
 
     env_arch = detect_build_env_arch()
@@ -333,7 +331,7 @@ def setup_mingw(env: "SConsEnvironment"):
     print("Using MinGW, arch %s" % (env["arch"]))
 
 
-def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
+def configure_msvc(env: SConsEnvironment, vcvars_msvc_config):
     """Configure env to work with MSVC"""
 
     ## Build type
@@ -670,7 +668,7 @@ def tempfile_arg_esc_func(arg):
     return WINPATHSEP_RE.sub(r"/\1", arg)
 
 
-def configure_mingw(env: "SConsEnvironment"):
+def configure_mingw(env: SConsEnvironment):
     # Workaround for MinGW. See:
     # https://www.scons.org/wiki/LongCmdLinesOnWin32
     env.use_windows_spawn_fix()
@@ -900,7 +898,7 @@ def configure_mingw(env: "SConsEnvironment"):
     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])
 
 
-def configure(env: "SConsEnvironment"):
+def configure(env: SConsEnvironment):
     # Validate arch.
     supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)


### PR DESCRIPTION
Turns out the `detect.py` files don't actually need `TYPE_CHECKING` boilerplate. They were initially added for a mypy validation script, but that's since been replaced by pre-commit hooks; those hooks support additional dependencies, meaning more type info for mypy checks. This PR takes advantage of that by passing modules used anywhere in the repo (SCons & pytest), allowing us to remove some excess boilerplate