### PR TITLE
Expose GridMapEditorPlugin to scripts and add methods to manipulate to the selection and selected palette item

### DIFF
--- a/modules/gridmap/config.py
+++ b/modules/gridmap/config.py
@@ -7,9 +7,7 @@ def configure(env):
 
 
 def get_doc_classes():
-    return [
-        "GridMap",
-    ]
+    return ["GridMap", "GridMapEditorPlugin"]
 
 
 def get_doc_path():

--- a/modules/gridmap/doc_classes/GridMapEditorPlugin.xml
+++ b/modules/gridmap/doc_classes/GridMapEditorPlugin.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GridMapEditorPlugin" inherits="EditorPlugin" keywords="tilemap" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Editor for [GridMap] nodes.
+	</brief_description>
+	<description>
+		GridMapEditorPlugin provides access to the [GridMap] editor functionality.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="clear_selection">
+			<return type="void" />
+			<description>
+				Deselects any currently selected cells.
+			</description>
+		</method>
+		<method name="get_current_grid_map" qualifiers="const">
+			<return type="GridMap" />
+			<description>
+				Returns the [GridMap] node currently edited by the grid map editor.
+			</description>
+		</method>
+		<method name="get_selected_cells" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns an array of [Vector3i]s with the selected cells' coordinates.
+			</description>
+		</method>
+		<method name="get_selected_palette_item" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the index of the selected [MeshLibrary] item in the grid map editor's palette or [code]-1[/code] if no item is selected.
+				[b]Note:[/b] The indices might not be in the same order as they appear in the editor's interface.
+			</description>
+		</method>
+		<method name="get_selection" qualifiers="const">
+			<return type="AABB" />
+			<description>
+				Returns the cell coordinate bounds of the current selection. Use [method has_selection] to check if there is an active selection.
+			</description>
+		</method>
+		<method name="has_selection" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if there are selected cells.
+			</description>
+		</method>
+		<method name="set_selected_palette_item" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="item" type="int" />
+			<description>
+				Selects the [MeshLibrary] item with the given index in the grid map editor's palette. If a negative index is given, no item will be selected. If a value greater than the last index is given, the last item will be selected.
+				[b]Note:[/b] The indices might not be in the same order as they appear in the editor's interface.
+			</description>
+		</method>
+		<method name="set_selection">
+			<return type="void" />
+			<param index="0" name="begin" type="Vector3i" />
+			<param index="1" name="end" type="Vector3i" />
+			<description>
+				Selects the cells inside the given bounds from [param begin] to [param end].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -243,6 +243,9 @@ class GridMapEditor : public VBoxContainer {
 	void _update_selection_transform();
 	void _validate_selection();
 	void _set_selection(bool p_active, const Vector3 &p_begin = Vector3(), const Vector3 &p_end = Vector3());
+	AABB _get_selection() const;
+	bool _has_selection() const;
+	Array _get_selected_cells() const;
 
 	void _floor_changed(float p_value);
 	void _floor_mouse_exited();
@@ -272,6 +275,10 @@ class GridMapEditorPlugin : public EditorPlugin {
 	GridMapEditor *grid_map_editor = nullptr;
 	Button *panel_button = nullptr;
 
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
 public:
 	virtual EditorPlugin::AfterGUIInput forward_3d_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return grid_map_editor->forward_spatial_input_event(p_camera, p_event); }
 	virtual String get_plugin_name() const override { return "GridMap"; }
@@ -279,6 +286,15 @@ public:
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
+
+	GridMap *get_current_grid_map() const;
+	void set_selection(const Vector3i &p_begin, const Vector3i &p_end);
+	void clear_selection();
+	AABB get_selection() const;
+	bool has_selection() const;
+	Array get_selected_cells() const;
+	void set_selected_palette_item(int p_item) const;
+	int get_selected_palette_item() const;
 
 	GridMapEditorPlugin();
 	~GridMapEditorPlugin();

--- a/modules/gridmap/register_types.cpp
+++ b/modules/gridmap/register_types.cpp
@@ -46,6 +46,7 @@ void initialize_gridmap_module(ModuleInitializationLevel p_level) {
 	}
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		GDREGISTER_CLASS(GridMapEditorPlugin);
 		EditorPlugins::add_by_type<GridMapEditorPlugin>();
 	}
 #endif


### PR DESCRIPTION
This PR allows editor scripts and plugins to access `GridMapEditorPlugin` and adds methods for extending the editor's functionality by allowing manipulation of the selection and selected palette item.

This addresses and closes https://github.com/godotengine/godot-proposals/issues/11161. It can also help with custom grid map tools that could be added later by scripts as i wrote in https://github.com/godotengine/godot-proposals/issues/11206#issuecomment-2491437914.

The video below shows how it could be used to implement a script that replaces tiles in the selection:

[Godot Gridmap Selection Plugin.webm](https://github.com/user-attachments/assets/668388f4-5001-4217-998f-fb6a2dd7795c)

(obviously this is just an example -and probably the replace functionality should be core part of the editor- to show how the API can be used but it could also be used for making game-specific tools like assigning data -to be stored elsewhere, like in a node- to cells, or to pre-fill a gridmap with some procedural code that can be then manually edited, or to quickly set data and/or colors -especially useful for data as they can be something different than color- if https://github.com/godotengine/godot/pull/94282 is merged, etc)

EDIT:

Attached MRP with the script in the screenshot (though different map). To test it open the "node_3d.tscn" scene, select the "Floor" gridmap, pick "Floor3" from the available tiles (the cracked one), activate the "Replace Tile" dock (should be at bottom left), click the "Pick original tile" button (the label should change to "Select an item to replace 4 with"), make a rectangular selection in the viewport with some cracked tiles inside, pick "Floor2" from the available tiles (the one with the dark smudge) and click the "Replace in selection" button (note: if some tiles at the selection edges do not change that is because the tiles have their origin at the corner and thus the selection can be misleading a bit - that is an issue with the assets, not this PR).

The MRP: 
[gridmap-editor-scripting-test.zip](https://github.com/user-attachments/files/17967444/gridmap-editor-scripting-test.zip)
