### PR TITLE
Change file dialog all files filter name from `All Files (*)` to `All Files (*.*)`.

### DIFF
--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -40,7 +40,7 @@
 		<method name="clear_filters">
 			<return type="void" />
 			<description>
-				Removes all filters except for "All Files (*)".
+				Removes all filters except for "All Files (*.*)".
 			</description>
 		</method>
 		<method name="get_line_edit">

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1193,7 +1193,7 @@ void EditorFileDialog::update_filters() {
 		}
 	}
 
-	String f = TTR("All Files (*)");
+	String f = TTR("All Files") + " (*.*)";
 	filter->add_item(f);
 	processed_filters.push_back("*.*;" + f);
 }

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -394,7 +394,7 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServer::WindowID p_windo
 				} else {
 					if (flt == "*.*") {
 						filter_exts.push_back("*");
-						filter_names.push_back(RTR("All Files") + " (*)");
+						filter_names.push_back(RTR("All Files") + " (*.*)");
 					} else {
 						filter_exts.push_back(flt);
 						filter_names.push_back(flt);
@@ -405,7 +405,7 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServer::WindowID p_windo
 	}
 	if (filter_names.is_empty()) {
 		filter_exts.push_back("*");
-		filter_names.push_back(RTR("All Files") + " (*)");
+		filter_names.push_back(RTR("All Files") + " (*.*)");
 	}
 
 	DBusError err;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -505,7 +505,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 	}
 	if (filter_names.is_empty()) {
 		filter_exts.push_back(String("*.*").utf16());
-		filter_names.push_back((RTR("All Files") + " (*)").utf16());
+		filter_names.push_back((RTR("All Files") + " (*.*)").utf16());
 	}
 
 	Vector<COMDLG_FILTERSPEC> filters;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -896,7 +896,7 @@ void FileDialog::update_filters() {
 		}
 	}
 
-	String f = atr(ETR("All Files")) + " (*)";
+	String f = atr(ETR("All Files")) + " (*.*)";
 	filter->add_item(f);
 	processed_filters.push_back("*.*;" + f);
 }


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/99599, see https://github.com/godotengine/godot/pull/99599#issuecomment-2495640753

Should fix https://github.com/godotengine/godot/issues/99596

Note: only changes displayed name, Linux native dialogs still use `*` as actual filter to allow selecting files without extension.