### PR TITLE
[Windows] Fix root and current folder in native file dialog.

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -117,6 +117,12 @@ void EditorFileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_file
 	selected_options = p_selected_options;
 
 	String f = files[0];
+
+	filter->select(p_filter);
+	dir->set_text(f.get_base_dir());
+	file->set_text(f.get_file());
+	_dir_submitted(f.get_base_dir());
+
 	if (mode == FILE_MODE_OPEN_FILES) {
 		emit_signal(SNAME("files_selected"), files);
 	} else {
@@ -145,9 +151,6 @@ void EditorFileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_file
 			emit_signal(SNAME("dir_selected"), f);
 		}
 	}
-	file->set_text(f);
-	dir->set_text(f.get_base_dir());
-	filter->select(p_filter);
 }
 
 void EditorFileDialog::popup_file_dialog() {
@@ -363,6 +366,7 @@ Vector<String> EditorFileDialog::get_selected_files() const {
 }
 
 void EditorFileDialog::update_dir() {
+	full_dir = dir_access->get_current_dir();
 	if (drives->is_visible()) {
 		if (dir_access->get_current_dir().is_network_share_path()) {
 			_update_drives(false);

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -203,6 +203,7 @@ private:
 	Vector<Option> options;
 	Dictionary selected_options;
 	bool options_dirty = false;
+	String full_dir;
 
 	void update_dir();
 	void update_file_name();

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -572,10 +572,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 			}
 		}
 		dir = dir.simplify_path();
-		dir = dir.replace("/", "\\");
-		if (!dir.is_network_share_path() && !dir.begins_with(R"(\\?\)")) {
-			dir = R"(\\?\)" + dir;
-		}
+		dir = dir.trim_prefix(R"(\\?\)").replace("/", "\\");
 
 		IShellItem *shellitem = nullptr;
 		hr = SHCreateItemFromParsingName((LPCWSTR)dir.utf16().ptr(), nullptr, IID_IShellItem, (void **)&shellitem);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -62,15 +62,17 @@ void FileDialog::_focus_file_text() {
 void FileDialog::_native_popup() {
 	// Show native dialog directly.
 	String root;
-	if (access == ACCESS_RESOURCES) {
+	if (!root_prefix.is_empty()) {
+		root = ProjectSettings::get_singleton()->globalize_path(root_prefix);
+	} else if (access == ACCESS_RESOURCES) {
 		root = ProjectSettings::get_singleton()->get_resource_path();
 	} else if (access == ACCESS_USERDATA) {
 		root = OS::get_singleton()->get_user_data_dir();
 	}
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE_EXTRA)) {
-		DisplayServer::get_singleton()->file_dialog_with_options_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(dir->get_text()), root, file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &FileDialog::_native_dialog_cb_with_options));
+		DisplayServer::get_singleton()->file_dialog_with_options_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), root, file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &FileDialog::_native_dialog_cb_with_options));
 	} else {
-		DisplayServer::get_singleton()->file_dialog_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(dir->get_text()), file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, callable_mp(this, &FileDialog::_native_dialog_cb));
+		DisplayServer::get_singleton()->file_dialog_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, callable_mp(this, &FileDialog::_native_dialog_cb));
 	}
 }
 
@@ -143,6 +145,11 @@ void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> 
 	selected_options = p_selected_options;
 
 	String f = files[0];
+	filter->select(p_filter);
+	dir->set_text(f.get_base_dir());
+	file->set_text(f.get_file());
+	_change_dir(f.get_base_dir());
+
 	if (mode == FILE_MODE_OPEN_FILES) {
 		emit_signal(SNAME("files_selected"), files);
 	} else {
@@ -171,9 +178,6 @@ void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> 
 			emit_signal(SNAME("dir_selected"), f);
 		}
 	}
-	file->set_text(f);
-	dir->set_text(f.get_base_dir());
-	filter->select(p_filter);
 }
 
 VBoxContainer *FileDialog::get_vbox() {
@@ -365,6 +369,7 @@ Vector<String> FileDialog::get_selected_files() const {
 }
 
 void FileDialog::update_dir() {
+	full_dir = dir_access->get_current_dir();
 	if (root_prefix.is_empty()) {
 		dir->set_text(dir_access->get_current_dir(false));
 	} else {
@@ -970,7 +975,7 @@ String FileDialog::get_filename_filter() const {
 }
 
 String FileDialog::get_current_dir() const {
-	return dir->get_text();
+	return full_dir;
 }
 
 String FileDialog::get_current_file() const {
@@ -978,7 +983,7 @@ String FileDialog::get_current_file() const {
 }
 
 String FileDialog::get_current_path() const {
-	return dir->get_text().path_join(file->get_text());
+	return full_dir.path_join(file->get_text());
 }
 
 void FileDialog::set_current_dir(const String &p_dir) {

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -152,6 +152,7 @@ private:
 	Vector<Option> options;
 	Dictionary selected_options;
 	bool options_dirty = false;
+	String full_dir;
 
 	void update_dir();
 	void update_file_name();


### PR DESCRIPTION
Supersede https://github.com/godotengine/godot/pull/98839

Fixes https://github.com/godotengine/godot/issues/98832
Fixes https://github.com/godotengine/godot/issues/99598