### PR TITLE
Create `precise_delay_usec()` to avoid excessive CPU penalty when not intended

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -251,6 +251,7 @@ public:
 	virtual double get_unix_time() const;
 
 	virtual void delay_usec(uint32_t p_usec) const = 0;
+	void precise_delay_usec(uint32_t p_usec) const;
 	virtual void add_frame_delay(bool p_can_draw);
 
 	virtual uint64_t get_ticks_usec() const = 0;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -117,7 +117,7 @@ static void _setup_clock() {
 	kern_return_t ret = mach_timebase_info(&info);
 	ERR_FAIL_COND_MSG(ret != 0, "OS CLOCK IS NOT WORKING!");
 	_clock_scale = ((double)info.numer / (double)info.denom) / 1000.0;
-	_clock_start = mach_absolute_time() * _clock_scale;
+	_clock_start = mach_absolute_time();
 }
 #else
 #if defined(CLOCK_MONOTONIC_RAW) && !defined(WEB_ENABLED) // This is a better clock on Linux.
@@ -377,17 +377,17 @@ void OS_Unix::delay_usec(uint32_t p_usec) const {
 
 uint64_t OS_Unix::get_ticks_usec() const {
 #if defined(__APPLE__)
-	uint64_t longtime = mach_absolute_time() * _clock_scale;
+	uint64_t elapsed_ticks = mach_absolute_time() - _clock_start;
+	return elapsed_ticks * _clock_scale;
 #else
 	// Unchecked return. Static analyzers might complain.
 	// If _setup_clock() succeeded, we assume clock_gettime() works.
 	struct timespec tv_now = { 0, 0 };
 	clock_gettime(GODOT_CLOCK, &tv_now);
 	uint64_t longtime = ((uint64_t)tv_now.tv_nsec / 1000L) + (uint64_t)tv_now.tv_sec * 1000000L;
-#endif
 	longtime -= _clock_start;
-
 	return longtime;
+#endif
 }
 
 Dictionary OS_Unix::get_memory_info() const {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -265,7 +265,12 @@ void OS_Windows::initialize() {
 
 	// set minimum resolution for periodic timers, otherwise Sleep(n) may wait at least as
 	//  long as the windows scheduler resolution (~16-30ms) even for calls like Sleep(1)
-	timeBeginPeriod(1);
+	TIMECAPS time_caps;
+	if (timeGetDevCaps(&time_caps, sizeof(time_caps)) == MMSYSERR_NOERROR) {
+		timeBeginPeriod(time_caps.wPeriodMin);
+	} else {
+		timeBeginPeriod(1);
+	}
 
 	process_map = memnew((HashMap<ProcessID, ProcessInfo>));
 


### PR DESCRIPTION
Avoids the excess CPU penalty for non-frame pacing related sleeps as mentioned here:

https://github.com/godotengine/godot/issues/99593

The original PR aimed to fix inconsistent frame limiting on Windows due to the inaccuracy of the Sleep function.

@Calinou did some testing with the previous PR, and found it greatly helped with frame pacing and getting the timing right.

This PR aims to fix the unintended CPU time increase, while adding the improved frame limiting logic. Since sleep is based on hardware/OS, the method needs to be adaptive to both. On Windows, the sleep granularity is guaranteed, but on Unix we need to dynamically compute the upper bound to sleep.