### PR TITLE
ColorPicker: Allow other color wheels in okhsl mode

### DIFF
--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -54,7 +54,6 @@ public:
 
 	virtual void slider_draw(int p_which) = 0;
 	virtual bool apply_theme() const { return false; }
-	virtual ColorPicker::PickerShapeType get_shape_override() const { return ColorPicker::SHAPE_MAX; }
 
 	ColorMode(ColorPicker *p_color_picker);
 	virtual ~ColorMode() {}
@@ -145,7 +144,6 @@ public:
 	virtual void _value_changed() override;
 
 	virtual void slider_draw(int p_which) override;
-	virtual ColorPicker::PickerShapeType get_shape_override() const override { return ColorPicker::SHAPE_OKHSL_CIRCLE; }
 
 	ColorModeOKHSL(ColorPicker *p_color_picker) :
 			ColorMode(p_color_picker) {}

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -309,7 +309,7 @@ void ColorPicker::_update_controls() {
 		alpha_label->hide();
 	}
 
-	switch (_get_actual_shape()) {
+	switch (current_shape) {
 		case SHAPE_HSV_RECTANGLE:
 			wheel_edit->hide();
 			w_edit->show();
@@ -562,7 +562,7 @@ void ColorPicker::_copy_color_to_hsv() {
 }
 
 void ColorPicker::_copy_hsv_to_color() {
-	if (_get_actual_shape() == SHAPE_OKHSL_CIRCLE) {
+	if (current_shape == SHAPE_OKHSL_CIRCLE) {
 		color.set_ok_hsl(ok_hsl_h, ok_hsl_s, ok_hsl_l, color.a);
 	} else {
 		color.set_hsv(h, s, v, color.a);
@@ -592,10 +592,6 @@ bool ColorPicker::_select_from_recent_preset_hbc(const Color &p_color) {
 		}
 	}
 	return false;
-}
-
-ColorPicker::PickerShapeType ColorPicker::_get_actual_shape() const {
-	return modes[current_mode]->get_shape_override() != SHAPE_MAX ? modes[current_mode]->get_shape_override() : current_shape;
 }
 
 void ColorPicker::_reset_sliders_theme() {
@@ -1323,19 +1319,18 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 		return;
 	}
 
-	PickerShapeType actual_shape = _get_actual_shape();
 	if (p_which == 0) {
 		Color col = color;
 		Vector2 center = c->get_size() / 2.0;
 
-		if (actual_shape == SHAPE_HSV_RECTANGLE || actual_shape == SHAPE_HSV_WHEEL) {
+		if (current_shape == SHAPE_HSV_RECTANGLE || current_shape == SHAPE_HSV_WHEEL) {
 			Vector<Point2> points;
 			Vector<Color> colors;
 			Vector<Color> colors2;
 			points.resize(4);
 			colors.resize(4);
 			colors2.resize(4);
-			if (actual_shape == SHAPE_HSV_RECTANGLE) {
+			if (current_shape == SHAPE_HSV_RECTANGLE) {
 				points.set(0, Vector2());
 				points.set(1, Vector2(c->get_size().x, 0));
 				points.set(2, c->get_size());
@@ -1369,9 +1364,9 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 
 		int x;
 		int y;
-		if (actual_shape == SHAPE_VHS_CIRCLE || actual_shape == SHAPE_OKHSL_CIRCLE) {
+		if (current_shape == SHAPE_VHS_CIRCLE || current_shape == SHAPE_OKHSL_CIRCLE) {
 			Vector2 hue_offset;
-			if (actual_shape == SHAPE_OKHSL_CIRCLE) {
+			if (current_shape == SHAPE_OKHSL_CIRCLE) {
 				hue_offset = center * Vector2(Math::cos(ok_hsl_h * Math_TAU), Math::sin(ok_hsl_h * Math_TAU)) * ok_hsl_s;
 			} else {
 				hue_offset = center * Vector2(Math::cos(h * Math_TAU), Math::sin(h * Math_TAU)) * s;
@@ -1391,7 +1386,7 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 		c->draw_texture(theme_cache.picker_cursor_bg, Point2(x, y), _col);
 		c->draw_texture(theme_cache.picker_cursor, Point2(x, y));
 
-		if (actual_shape == SHAPE_HSV_WHEEL) {
+		if (current_shape == SHAPE_HSV_WHEEL) {
 			float _radius = WHEEL_RADIUS * 2.0;
 			_radius += (1.0 - _radius) * 0.5;
 			Point2 pos = center - (theme_cache.picker_cursor->get_size() * 0.5) + Point2(center.x * Math::cos(h * Math_TAU) * _radius, center.y * Math::sin(h * Math_TAU) * _radius);
@@ -1399,7 +1394,7 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 		}
 
 	} else if (p_which == 1) {
-		if (actual_shape == SHAPE_HSV_RECTANGLE) {
+		if (current_shape == SHAPE_HSV_RECTANGLE) {
 			c->draw_set_transform(Point2(), -Math_PI / 2, Size2(c->get_size().x, -c->get_size().y));
 			c->draw_texture_rect(theme_cache.color_hue, Rect2(Point2(), Size2(1, 1)));
 			c->draw_set_transform(Point2(), 0, Size2(1, 1));
@@ -1407,7 +1402,7 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 			Color col;
 			col.set_hsv(h, 1, 1);
 			c->draw_line(Point2(0, y), Point2(c->get_size().x, y), col.inverted());
-		} else if (actual_shape == SHAPE_OKHSL_CIRCLE) {
+		} else if (current_shape == SHAPE_OKHSL_CIRCLE) {
 			Vector<Point2> points;
 			Vector<Color> colors;
 			Color col;
@@ -1434,7 +1429,7 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 			int y = c->get_size().y - c->get_size().y * CLAMP(ok_hsl_l, 0, 1);
 			col.set_ok_hsl(ok_hsl_h, 1, ok_hsl_l);
 			c->draw_line(Point2(0, y), Point2(c->get_size().x, y), col.inverted());
-		} else if (actual_shape == SHAPE_VHS_CIRCLE) {
+		} else if (current_shape == SHAPE_VHS_CIRCLE) {
 			Vector<Point2> points;
 			Vector<Color> colors;
 			Color col;
@@ -1456,9 +1451,9 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 		}
 	} else if (p_which == 2) {
 		c->draw_rect(Rect2(Point2(), c->get_size()), Color(1, 1, 1));
-		if (actual_shape == SHAPE_VHS_CIRCLE) {
+		if (current_shape == SHAPE_VHS_CIRCLE) {
 			circle_mat->set_shader_parameter("v", v);
-		} else if (actual_shape == SHAPE_OKHSL_CIRCLE) {
+		} else if (current_shape == SHAPE_OKHSL_CIRCLE) {
 			circle_mat->set_shader_parameter("ok_hsl_l", ok_hsl_l);
 		}
 	}
@@ -1472,12 +1467,11 @@ void ColorPicker::_slider_draw(int p_which) {
 
 void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 	Ref<InputEventMouseButton> bev = p_event;
-	PickerShapeType actual_shape = _get_actual_shape();
 
 	if (bev.is_valid()) {
 		if (bev->is_pressed() && bev->get_button_index() == MouseButton::LEFT) {
 			Vector2 center = c->get_size() / 2.0;
-			if (actual_shape == SHAPE_VHS_CIRCLE || actual_shape == SHAPE_OKHSL_CIRCLE) {
+			if (current_shape == SHAPE_VHS_CIRCLE || current_shape == SHAPE_OKHSL_CIRCLE) {
 				real_t dist = center.distance_to(bev->get_position());
 				if (dist <= center.x) {
 					real_t rad = center.angle_to_point(bev->get_position());
@@ -1547,7 +1541,7 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 		}
 
 		Vector2 center = c->get_size() / 2.0;
-		if (actual_shape == SHAPE_VHS_CIRCLE || actual_shape == SHAPE_OKHSL_CIRCLE) {
+		if (current_shape == SHAPE_VHS_CIRCLE || current_shape == SHAPE_OKHSL_CIRCLE) {
 			real_t dist = center.distance_to(mev->get_position());
 			real_t rad = center.angle_to_point(mev->get_position());
 			h = ((rad >= 0) ? rad : (Math_TAU + rad)) / Math_TAU;
@@ -1583,13 +1577,12 @@ void ColorPicker::_uv_input(const Ref<InputEvent> &p_event, Control *c) {
 
 void ColorPicker::_w_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> bev = p_event;
-	PickerShapeType actual_shape = _get_actual_shape();
 
 	if (bev.is_valid()) {
 		if (bev->is_pressed() && bev->get_button_index() == MouseButton::LEFT) {
 			changing_color = true;
 			float y = CLAMP((float)bev->get_position().y, 0, w_edit->get_size().height);
-			if (actual_shape == SHAPE_VHS_CIRCLE || actual_shape == SHAPE_OKHSL_CIRCLE) {
+			if (current_shape == SHAPE_VHS_CIRCLE || current_shape == SHAPE_OKHSL_CIRCLE) {
 				v = 1.0 - (y / w_edit->get_size().height);
 				ok_hsl_l = v;
 			} else {
@@ -1618,7 +1611,7 @@ void ColorPicker::_w_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 		float y = CLAMP((float)mev->get_position().y, 0, w_edit->get_size().height);
-		if (actual_shape == SHAPE_VHS_CIRCLE || actual_shape == SHAPE_OKHSL_CIRCLE) {
+		if (current_shape == SHAPE_VHS_CIRCLE || current_shape == SHAPE_OKHSL_CIRCLE) {
 			v = 1.0 - (y / w_edit->get_size().height);
 			ok_hsl_l = v;
 		} else {

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -277,7 +277,6 @@ private:
 	void _copy_color_to_hsv();
 	void _copy_hsv_to_color();
 
-	PickerShapeType _get_actual_shape() const;
 	void create_slider(GridContainer *gc, int idx);
 	void _reset_sliders_theme();
 	void _html_submitted(const String &p_html);


### PR DESCRIPTION
Remove `get_shape_override` method in ColorMode.
Since #99461, there is no reason to disable other color wheels in okhsl mode. This makes the use of color wheels more flexible.

Closes #102598
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
