### PR TITLE
Remove double `is_editor_hint()` check inside `NOTIFICATION_READY` for `Camera2D` node

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -277,7 +277,7 @@ void Camera2D::_notification(int p_what) {
 	switch (p_what) {
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_READY: {
-			if (Engine::get_singleton()->is_editor_hint() && is_part_of_edited_scene()) {
+			if (is_part_of_edited_scene()) {
 				ProjectSettings::get_singleton()->connect(SNAME("settings_changed"), callable_mp(this, &Camera2D::_project_settings_changed));
 			}
 		} break;


### PR DESCRIPTION
`Engine::get_singleton()->is_editor_hint()` is already a part of `is_part_of_edited_scene()` function, no need to call it twice. 