### PR TITLE
[RTL] Fix clearing text with `set_text("")`.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -5828,7 +5828,11 @@ void RichTextLabel::set_text(const String &p_bbcode) {
 	stack_externally_modified = false;
 
 	text = p_bbcode;
-	_apply_translation();
+	if (text.is_empty()) {
+		clear();
+	} else {
+		_apply_translation();
+	}
 }
 
 void RichTextLabel::_apply_translation() {


### PR DESCRIPTION
Fixes `set_text("")`, likely regressions from https://github.com/godotengine/godot/pull/97061

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/99891*