### PR TITLE
Add support for disabling per-filetype `ImageFormatLoader` import

### DIFF
--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -56,6 +56,12 @@ Error ImageFormatLoaderExtension::load_image(Ref<Image> p_image, Ref<FileAccess>
 	return err;
 }
 
+bool ImageFormatLoaderExtension::should_import() const {
+	bool import = true;
+	GDVIRTUAL_CALL(_should_import, import);
+	return import;
+}
+
 void ImageFormatLoaderExtension::get_recognized_extensions(List<String> *p_extension) const {
 	PackedStringArray ext;
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, ext)) {
@@ -76,6 +82,7 @@ void ImageFormatLoaderExtension::remove_format_loader() {
 void ImageFormatLoaderExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_recognized_extensions);
 	GDVIRTUAL_BIND(_load_image, "image", "fileaccess", "flags", "scale");
+	GDVIRTUAL_BIND(_should_import);
 	ClassDB::bind_method(D_METHOD("add_format_loader"), &ImageFormatLoaderExtension::add_format_loader);
 	ClassDB::bind_method(D_METHOD("remove_format_loader"), &ImageFormatLoaderExtension::remove_format_loader);
 }
@@ -110,8 +117,11 @@ Error ImageLoader::load_image(const String &p_file, Ref<Image> p_image, Ref<File
 	return ERR_FILE_UNRECOGNIZED;
 }
 
-void ImageLoader::get_recognized_extensions(List<String> *p_extensions) {
+void ImageLoader::get_recognized_extensions(List<String> *p_extensions, bool p_is_import) {
 	for (int i = 0; i < loader.size(); i++) {
+		if (p_is_import && !loader[i]->should_import()) {
+			continue;
+		}
 		loader[i]->get_recognized_extensions(p_extensions);
 	}
 }

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -60,6 +60,7 @@ protected:
 
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) = 0;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	virtual bool should_import() const { return true; }
 	bool recognize(const String &p_extension) const;
 
 public:
@@ -76,6 +77,7 @@ protected:
 
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) override;
+	virtual bool should_import() const override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
 
 	void add_format_loader();
@@ -83,6 +85,7 @@ public:
 
 	GDVIRTUAL0RC(PackedStringArray, _get_recognized_extensions);
 	GDVIRTUAL4R(Error, _load_image, Ref<Image>, Ref<FileAccess>, BitField<ImageFormatLoader::LoaderFlags>, float);
+	GDVIRTUAL0RC(bool, _should_import);
 };
 
 class ImageLoader {
@@ -92,7 +95,7 @@ class ImageLoader {
 protected:
 public:
 	static Error load_image(const String &p_file, Ref<Image> p_image, Ref<FileAccess> p_custom = Ref<FileAccess>(), BitField<ImageFormatLoader::LoaderFlags> p_flags = ImageFormatLoader::FLAG_NONE, float p_scale = 1.0);
-	static void get_recognized_extensions(List<String> *p_extensions);
+	static void get_recognized_extensions(List<String> *p_extensions, bool p_is_import = true);
 	static Ref<ImageFormatLoader> recognize(const String &p_extension);
 
 	static void add_image_format_loader(Ref<ImageFormatLoader> p_loader);

--- a/doc/classes/ImageFormatLoaderExtension.xml
+++ b/doc/classes/ImageFormatLoaderExtension.xml
@@ -26,6 +26,12 @@
 				Loads the content of [param fileaccess] into the provided [param image].
 			</description>
 		</method>
+		<method name="_should_import" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if image file importing should be performed for this image format's extensions, else returns [code]false[/code].
+			</description>
+		</method>
 		<method name="add_format_loader">
 			<return type="void" />
 			<description>

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -258,7 +258,7 @@ Particles2DEditorPlugin::Particles2DEditorPlugin() {
 	file = memnew(EditorFileDialog);
 
 	List<String> ext;
-	ImageLoader::get_recognized_extensions(&ext);
+	ImageLoader::get_recognized_extensions(&ext, false);
 	for (const String &E : ext) {
 		file->add_filter("*." + E, E.to_upper());
 	}


### PR DESCRIPTION
This was the simplest way I could conceive of to address https://github.com/godotengine/godot/pull/69085#issuecomment-1697342131, this would pave the way to restore functional DDS runtime image loading without the import process messing them up. If `should_import()` returns false then it'll be skipped for `ImageLoader::get_recognized_extensions()` when `p_import` is true. (which is every case that function is called except for `Particles2DEditorPlugin`'s constructor from what I can see)