### PR TITLE
Allow to select multiple remote nodes at runtime

### DIFF
--- a/core/math/math_fieldwise.cpp
+++ b/core/math/math_fieldwise.cpp
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifdef TOOLS_ENABLED
+#ifdef DEBUG_ENABLED
 
 #include "math_fieldwise.h"
 
@@ -242,4 +242,4 @@ Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const
 	/* clang-format on */
 }
 
-#endif // TOOLS_ENABLED
+#endif // DEBUG_ENABLED

--- a/core/math/math_fieldwise.h
+++ b/core/math/math_fieldwise.h
@@ -30,10 +30,10 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
+#ifdef DEBUG_ENABLED
 
 #include "core/variant/variant.h"
 
 Variant fieldwise_assign(const Variant &p_target, const Variant &p_source, const String &p_field);
 
-#endif // TOOLS_ENABLED
+#endif // DEBUG_ENABLED

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -191,6 +191,10 @@
 		<member name="debugger/auto_switch_to_stack_trace" type="bool" setter="" getter="">
 			If [code]true[/code], automatically switches to the [b]Stack Trace[/b] panel when the debugger hits a breakpoint or steps.
 		</member>
+		<member name="debugger/max_node_selection" type="int" setter="" getter="">
+			The limit of how many remote nodes can be selected at once.
+			[b]Warning:[/b] Increasing this value is not recommended, as selecting too many can make the editing and inspection of remote properties unreliable.
+		</member>
 		<member name="debugger/profile_native_calls" type="bool" setter="" getter="">
 			If [code]true[/code], enables collection of profiling data from non-GDScript Godot functions, such as engine class methods. Enabling this slows execution while profiling further.
 		</member>

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -843,7 +843,9 @@ bool DebugAdapterProtocol::request_remote_object(const ObjectID &p_object_id) {
 		return false;
 	}
 
-	EditorDebuggerNode::get_singleton()->get_default_debugger()->request_remote_object(p_object_id);
+	TypedArray<uint64_t> arr;
+	arr.append(p_object_id);
+	EditorDebuggerNode::get_singleton()->get_default_debugger()->request_remote_objects(arr);
 	object_pending_set.insert(p_object_id);
 
 	return true;

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -33,29 +33,57 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/io/marshalls.h"
 #include "editor/editor_node.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/inspector_dock.h"
 #include "scene/debugger/scene_debugger.h"
 
-bool EditorDebuggerRemoteObject::_set(const StringName &p_name, const Variant &p_value) {
-	if (!prop_values.has(p_name) || String(p_name).begins_with("Constants/")) {
+bool EditorDebuggerRemoteObjects::_set(const StringName &p_name, const Variant &p_value) {
+	return _set_impl(p_name, p_value, "");
+}
+
+bool EditorDebuggerRemoteObjects::_set_impl(const StringName &p_name, const Variant &p_value, const String &p_field) {
+	String name = p_name;
+
+	if (name.begins_with("Metadata/")) {
+		name = name.replace_first("Metadata/", "metadata/");
+	}
+	if (!prop_values.has(name) || String(name).begins_with("Constants/")) {
 		return false;
 	}
 
-	prop_values[p_name] = p_value;
-	emit_signal(SNAME("value_edited"), remote_object_id, p_name, p_value);
+	Dictionary &values = prop_values[p_name];
+	Dictionary old_values = values.duplicate();
+	for (const uint64_t key : values.keys()) {
+		values.set(key, p_value);
+	}
+
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	const int size = remote_object_ids.size();
+	ur->create_action(size == 1 ? vformat(TTR("Set %s"), name) : vformat(TTR("Set %s on %d objects"), name, size), UndoRedo::MERGE_ENDS);
+
+	ur->add_do_method(this, SNAME("emit_signal"), SNAME("values_edited"), name, values, p_field);
+	ur->add_undo_method(this, SNAME("emit_signal"), SNAME("values_edited"), name, old_values, p_field);
+	ur->commit_action();
+
 	return true;
 }
 
-bool EditorDebuggerRemoteObject::_get(const StringName &p_name, Variant &r_ret) const {
-	if (!prop_values.has(p_name)) {
+bool EditorDebuggerRemoteObjects::_get(const StringName &p_name, Variant &r_ret) const {
+	String name = p_name;
+
+	if (name.begins_with("Metadata/")) {
+		name = name.replace_first("Metadata/", "metadata/");
+	}
+	if (!prop_values.has(name)) {
 		return false;
 	}
 
-	r_ret = prop_values[p_name];
+	r_ret = prop_values[p_name][remote_object_ids[0]];
 	return true;
 }
 
-void EditorDebuggerRemoteObject::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->clear(); // Sorry, no want category.
+void EditorDebuggerRemoteObjects::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->clear(); // Sorry, don't want any categories.
 	for (const PropertyInfo &prop : prop_list) {
 		if (prop.name == "script") {
 			// Skip the script property, it's always added by the non-virtual method.
@@ -66,31 +94,35 @@ void EditorDebuggerRemoteObject::_get_property_list(List<PropertyInfo> *p_list) 
 	}
 }
 
-String EditorDebuggerRemoteObject::get_title() {
-	if (remote_object_id.is_valid()) {
-		return vformat(TTR("Remote %s:"), String(type_name)) + " " + itos(remote_object_id);
-	} else {
-		return "<null>";
-	}
+void EditorDebuggerRemoteObjects::set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field) {
+	_set_impl(p_property, p_value, p_field);
 }
 
-Variant EditorDebuggerRemoteObject::get_variant(const StringName &p_name) {
+String EditorDebuggerRemoteObjects::get_title() {
+	if (!remote_object_ids.is_empty() && ObjectID(remote_object_ids[0].operator uint64_t()).is_valid()) {
+		const int size = remote_object_ids.size();
+		return size == 1 ? vformat(TTR("Remote %s: %d"), type_name, remote_object_ids[0]) : vformat(TTR("Remote %s (%d Selected)"), type_name, size);
+	}
+
+	return "<null>";
+}
+
+Variant EditorDebuggerRemoteObjects::get_variant(const StringName &p_name) {
 	Variant var;
 	_get(p_name, var);
 	return var;
 }
 
-void EditorDebuggerRemoteObject::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_title"), &EditorDebuggerRemoteObject::get_title);
-	ClassDB::bind_method(D_METHOD("get_variant"), &EditorDebuggerRemoteObject::get_variant);
-	ClassDB::bind_method(D_METHOD("clear"), &EditorDebuggerRemoteObject::clear);
-	ClassDB::bind_method(D_METHOD("get_remote_object_id"), &EditorDebuggerRemoteObject::get_remote_object_id);
+void EditorDebuggerRemoteObjects::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_title"), &EditorDebuggerRemoteObjects::get_title);
 
-	ADD_SIGNAL(MethodInfo("value_edited", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "property"), PropertyInfo("value")));
+	ADD_SIGNAL(MethodInfo("values_edited", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::DICTIONARY, "values", PROPERTY_HINT_DICTIONARY_TYPE, "uint64_t:Variant"), PropertyInfo(Variant::STRING, "field")));
 }
 
+/// EditorDebuggerInspector
+
 EditorDebuggerInspector::EditorDebuggerInspector() {
-	variables = memnew(EditorDebuggerRemoteObject);
+	variables = memnew(EditorDebuggerRemoteObjects);
 }
 
 EditorDebuggerInspector::~EditorDebuggerInspector() {
@@ -100,7 +132,7 @@ EditorDebuggerInspector::~EditorDebuggerInspector() {
 
 void EditorDebuggerInspector::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("object_selected", PropertyInfo(Variant::INT, "id")));
-	ADD_SIGNAL(MethodInfo("object_edited", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "property"), PropertyInfo("value")));
+	ADD_SIGNAL(MethodInfo("objects_edited", PropertyInfo(Variant::ARRAY, "ids"), PropertyInfo(Variant::STRING, "property"), PropertyInfo("value"), PropertyInfo(Variant::STRING, "field")));
 	ADD_SIGNAL(MethodInfo("object_property_updated", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "property")));
 }
 
@@ -111,50 +143,143 @@ void EditorDebuggerInspector::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
+			variables->remote_object_ids.append(0);
 			edit(variables);
 		} break;
 	}
 }
 
-void EditorDebuggerInspector::_object_edited(ObjectID p_id, const String &p_prop, const Variant &p_value) {
-	emit_signal(SNAME("object_edited"), p_id, p_prop, p_value);
+void EditorDebuggerInspector::_objects_edited(const String &p_prop, const TypedDictionary<uint64_t, Variant> &p_values, const String &p_field) {
+	emit_signal(SNAME("objects_edited"), p_prop, p_values, p_field);
 }
 
 void EditorDebuggerInspector::_object_selected(ObjectID p_object) {
 	emit_signal(SNAME("object_selected"), p_object);
 }
 
-ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
-	EditorDebuggerRemoteObject *debug_obj = nullptr;
+EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p_arr) {
+	ERR_FAIL_COND_V(p_arr.is_empty(), nullptr);
 
-	SceneDebuggerObject obj;
-	obj.deserialize(p_arr);
-	ERR_FAIL_COND_V(obj.id.is_null(), ObjectID());
+	TypedArray<uint64_t> ids;
+	LocalVector<SceneDebuggerObject> objects;
+	for (const Array arr : p_arr) {
+		SceneDebuggerObject obj;
+		obj.deserialize(arr);
+		if (obj.id.is_valid()) {
+			ids.push_back((uint64_t)obj.id);
+			objects.push_back(obj);
+		}
+	}
+	ERR_FAIL_COND_V(ids.is_empty(), nullptr);
 
-	if (remote_objects.has(obj.id)) {
-		debug_obj = remote_objects[obj.id];
-	} else {
-		debug_obj = memnew(EditorDebuggerRemoteObject);
-		debug_obj->remote_object_id = obj.id;
-		debug_obj->type_name = obj.class_name;
-		remote_objects[obj.id] = debug_obj;
-		debug_obj->connect("value_edited", callable_mp(this, &EditorDebuggerInspector::_object_edited));
+	// Sorting is necessary, as selected nodes in the remote tree are ordered by index.
+	ids.sort();
+
+	EditorDebuggerRemoteObjects *remote_objects = nullptr;
+	for (EditorDebuggerRemoteObjects *robjs : remote_objects_list) {
+		if (robjs->remote_object_ids == ids) {
+			remote_objects = robjs;
+			break;
+		}
 	}
 
-	int old_prop_size = debug_obj->prop_list.size();
+	if (!remote_objects) {
+		remote_objects = memnew(EditorDebuggerRemoteObjects);
+		remote_objects->remote_object_ids = ids;
+		remote_objects->remote_object_ids.make_read_only();
+		remote_objects->connect("values_edited", callable_mp(this, &EditorDebuggerInspector::_objects_edited));
+		remote_objects_list.push_back(remote_objects);
+	}
 
-	debug_obj->prop_list.clear();
+	StringName class_name = objects[0].class_name;
+	if (class_name != SNAME("Object")) {
+		// Search for the common class between all selected objects.
+		bool check_type_again = true;
+		while (check_type_again) {
+			check_type_again = false;
+
+			if (class_name == SNAME("Object") || class_name == StringName()) {
+				// All objects inherit from Object, so no need to continue checking.
+				class_name = SNAME("Object");
+				break;
+			}
+
+			// Check that all objects inherit from type_name.
+			for (const SceneDebuggerObject &obj : objects) {
+				if (obj.class_name == class_name || ClassDB::is_parent_class(obj.class_name, class_name)) {
+					continue; // class_name is the same or a parent of the object's class.
+				}
+
+				// class_name is not a parent of the node's class, so check again with the parent class.
+				class_name = ClassDB::get_parent_class(class_name);
+				check_type_again = true;
+				break;
+			}
+		}
+	}
+	remote_objects->type_name = class_name;
+
+	// Search for properties that are present in all selected objects.
+	struct UsageData {
+		int qty = 0;
+		SceneDebuggerObject::SceneDebuggerProperty prop;
+		TypedDictionary<uint64_t, Variant> values;
+	};
+	HashMap<String, UsageData> usage;
+	int nc = 0;
+	for (const SceneDebuggerObject &obj : objects) {
+		for (const SceneDebuggerObject::SceneDebuggerProperty &prop : obj.properties) {
+			PropertyInfo pinfo = prop.first;
+			if (pinfo.name == "script") {
+				continue; // Added later manually, since this is intercepted before being set (check Variant Object::get()).
+			} else if (pinfo.name.begins_with("metadata/")) {
+				pinfo.name = pinfo.name.replace_first("metadata/", "Metadata/"); // Trick to not get actual metadata edited from EditorDebuggerRemoteObjects.
+			}
+
+			if (!usage.has(pinfo.name)) {
+				UsageData usage_dt;
+				usage_dt.prop = prop;
+				usage_dt.prop.first.name = pinfo.name;
+				usage_dt.values[obj.id] = prop.second;
+				usage[pinfo.name] = usage_dt;
+			}
+
+			// Make sure only properties with the same exact PropertyInfo data will appear.
+			if (usage[pinfo.name].prop.first == pinfo) {
+				usage[pinfo.name].qty++;
+				usage[pinfo.name].values[obj.id] = prop.second;
+			}
+		}
+
+		nc++;
+	}
+	for (HashMap<String, UsageData>::Iterator E = usage.begin(); E;) {
+		HashMap<String, UsageData>::Iterator next = E;
+		++next;
+
+		UsageData usage_dt = E->value;
+		if (nc != usage_dt.qty) {
+			// Doesn't appear on all of them, remove it.
+			usage.erase(E->key);
+		}
+
+		E = next;
+	}
+
+	int old_prop_size = remote_objects->prop_list.size();
+
+	remote_objects->prop_list.clear();
 	int new_props_added = 0;
 	HashSet<String> changed;
-	for (SceneDebuggerObject::SceneDebuggerProperty &property : obj.properties) {
-		PropertyInfo &pinfo = property.first;
-		Variant &var = property.second;
+	for (const KeyValue<String, UsageData> &KV : usage) {
+		const PropertyInfo &pinfo = KV.value.prop.first;
+		Variant var = KV.value.values[remote_objects->remote_object_ids[0]];
 
 		if (pinfo.type == Variant::OBJECT) {
 			if (var.is_string()) {
 				String path = var;
 				if (path.contains("::")) {
-					// built-in resource
+					// Built-in resource.
 					String base_path = path.get_slice("::", 0);
 					Ref<Resource> dependency = ResourceLoader::load(base_path);
 					if (dependency.is_valid()) {
@@ -164,13 +289,13 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 				var = ResourceLoader::load(path);
 
 				if (pinfo.hint_string == "Script") {
-					if (debug_obj->get_script() != var) {
-						debug_obj->set_script(Ref<RefCounted>());
+					if (remote_objects->get_script() != var) {
+						remote_objects->set_script(Ref<RefCounted>());
 						Ref<Script> scr(var);
 						if (scr.is_valid()) {
-							ScriptInstance *scr_instance = scr->placeholder_instance_create(debug_obj);
+							ScriptInstance *scr_instance = scr->placeholder_instance_create(remote_objects);
 							if (scr_instance) {
-								debug_obj->set_script_and_instance(var, scr_instance);
+								remote_objects->set_script_and_instance(var, scr_instance);
 							}
 						}
 					}
@@ -178,49 +303,67 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 			}
 		}
 
-		//always add the property, since props may have been added or removed
-		debug_obj->prop_list.push_back(pinfo);
+		// Always add the property, since props may have been added or removed.
+		remote_objects->prop_list.push_back(pinfo);
 
-		if (!debug_obj->prop_values.has(pinfo.name)) {
+		if (!remote_objects->prop_values.has(pinfo.name)) {
 			new_props_added++;
-			debug_obj->prop_values[pinfo.name] = var;
-		} else {
-			if (bool(Variant::evaluate(Variant::OP_NOT_EQUAL, debug_obj->prop_values[pinfo.name], var))) {
-				debug_obj->prop_values[pinfo.name] = var;
-				changed.insert(pinfo.name);
-			}
+		} else if (bool(Variant::evaluate(Variant::OP_NOT_EQUAL, remote_objects->prop_values[pinfo.name], var))) {
+			changed.insert(pinfo.name);
 		}
+
+		remote_objects->prop_values[pinfo.name] = KV.value.values;
 	}
 
-	if (old_prop_size == debug_obj->prop_list.size() && new_props_added == 0) {
-		//only some may have changed, if so, then update those, if exist
+	if (old_prop_size == remote_objects->prop_list.size() && new_props_added == 0) {
+		// Only some may have changed, if so, then update those, if they exist.
 		for (const String &E : changed) {
-			emit_signal(SNAME("object_property_updated"), debug_obj->remote_object_id, E);
+			emit_signal(SNAME("object_property_updated"), remote_objects->get_instance_id(), E);
 		}
 	} else {
-		//full update, because props were added or removed
-		debug_obj->update();
+		// Full update, because props were added or removed.
+		remote_objects->update();
 	}
-	return obj.id;
+
+	return remote_objects;
+}
+
+void EditorDebuggerInspector::clear_remote_inspector() {
+	if (remote_objects_list.is_empty()) {
+		return;
+	}
+
+	const Object *obj = InspectorDock::get_inspector_singleton()->get_edited_object();
+	// Check if the inspector holds remote items, and take it out if so.
+	if (Object::cast_to<EditorDebuggerRemoteObjects>(obj)) {
+		EditorNode::get_singleton()->push_item(nullptr);
+	}
 }
 
 void EditorDebuggerInspector::clear_cache() {
-	for (const KeyValue<ObjectID, EditorDebuggerRemoteObject *> &E : remote_objects) {
-		EditorNode *editor = EditorNode::get_singleton();
-		if (editor->get_editor_selection_history()->get_current() == E.value->get_instance_id()) {
-			editor->push_item(nullptr);
-		}
-		memdelete(E.value);
+	clear_remote_inspector();
+
+	for (EditorDebuggerRemoteObjects *robjs : remote_objects_list) {
+		memdelete(robjs);
 	}
-	remote_objects.clear();
+	remote_objects_list.clear();
+
 	remote_dependencies.clear();
 }
 
-Object *EditorDebuggerInspector::get_object(ObjectID p_id) {
-	if (remote_objects.has(p_id)) {
-		return remote_objects[p_id];
+void EditorDebuggerInspector::invalidate_selection_from_cache(const TypedArray<uint64_t> &p_ids) {
+	for (EditorDebuggerRemoteObjects *robjs : remote_objects_list) {
+		if (robjs->remote_object_ids == p_ids) {
+			const Object *obj = InspectorDock::get_inspector_singleton()->get_edited_object();
+			if (obj == robjs) {
+				EditorNode::get_singleton()->push_item(nullptr);
+			}
+
+			remote_objects_list.erase(robjs);
+			memdelete(robjs);
+			break;
+		}
 	}
-	return nullptr;
 }
 
 void EditorDebuggerInspector::add_stack_variable(const Array &p_array, int p_offset) {
@@ -270,7 +413,7 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array, int p_off
 		}
 		variables->prop_list.insert_before(current, pinfo);
 	}
-	variables->prop_values[type + n] = v;
+	variables->prop_values[type + n][0] = v;
 	variables->update();
 	edit(variables);
 
@@ -288,7 +431,7 @@ void EditorDebuggerInspector::clear_stack_variables() {
 }
 
 String EditorDebuggerInspector::get_stack_variable(const String &p_var) {
-	for (KeyValue<StringName, Variant> &E : variables->prop_values) {
+	for (KeyValue<StringName, TypedDictionary<uint64_t, Variant>> &E : variables->prop_values) {
 		String v = E.key.operator String();
 		if (v.get_slicec('/', 1) == p_var) {
 			return variables->get_variant(v);

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -30,10 +30,16 @@
 
 #pragma once
 
+#include "core/variant/typed_dictionary.h"
 #include "editor/editor_inspector.h"
 
-class EditorDebuggerRemoteObject : public Object {
-	GDCLASS(EditorDebuggerRemoteObject, Object);
+class SceneDebuggerObject;
+
+class EditorDebuggerRemoteObjects : public Object {
+	GDCLASS(EditorDebuggerRemoteObjects, Object);
+
+private:
+	bool _set_impl(const StringName &p_name, const Variant &p_value, const String &p_field);
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -42,14 +48,13 @@ protected:
 	static void _bind_methods();
 
 public:
-	ObjectID remote_object_id;
+	TypedArray<uint64_t> remote_object_ids;
 	String type_name;
 	List<PropertyInfo> prop_list;
-	HashMap<StringName, Variant> prop_values;
+	HashMap<StringName, TypedDictionary<uint64_t, Variant>> prop_values;
 
-	ObjectID get_remote_object_id() { return remote_object_id; }
+	void set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field);
 	String get_title();
-
 	Variant get_variant(const StringName &p_name);
 
 	void clear() {
@@ -59,20 +64,19 @@ public:
 
 	void update() { notify_property_list_changed(); }
 
-	EditorDebuggerRemoteObject() {}
+	EditorDebuggerRemoteObjects() {}
 };
 
 class EditorDebuggerInspector : public EditorInspector {
 	GDCLASS(EditorDebuggerInspector, EditorInspector);
 
 private:
-	ObjectID inspected_object_id;
-	HashMap<ObjectID, EditorDebuggerRemoteObject *> remote_objects;
+	LocalVector<EditorDebuggerRemoteObjects *> remote_objects_list;
 	HashSet<Ref<Resource>> remote_dependencies;
-	EditorDebuggerRemoteObject *variables = nullptr;
+	EditorDebuggerRemoteObjects *variables = nullptr;
 
 	void _object_selected(ObjectID p_object);
-	void _object_edited(ObjectID p_id, const String &p_prop, const Variant &p_value);
+	void _objects_edited(const String &p_prop, const TypedDictionary<uint64_t, Variant> &p_values, const String &p_field);
 
 protected:
 	void _notification(int p_what);
@@ -83,9 +87,10 @@ public:
 	~EditorDebuggerInspector();
 
 	// Remote Object cache
-	ObjectID add_object(const Array &p_arr);
-	Object *get_object(ObjectID p_id);
+	EditorDebuggerRemoteObjects *set_objects(const Array &p_array);
+	void clear_remote_inspector();
 	void clear_cache();
+	void invalidate_selection_from_cache(const TypedArray<uint64_t> &p_ids);
 
 	// Stack Dump variables
 	String get_stack_variable(const String &p_var);

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -38,7 +38,7 @@ class Button;
 class DebugAdapterParser;
 class EditorDebuggerPlugin;
 class EditorDebuggerTree;
-class EditorDebuggerRemoteObject;
+class EditorDebuggerRemoteObjects;
 class MenuButton;
 class ScriptEditorDebugger;
 class TabContainer;
@@ -102,9 +102,12 @@ private:
 	int last_error_count = 0;
 	int last_warning_count = 0;
 
+	bool inspect_edited_object_wait = false;
 	float inspect_edited_object_timeout = 0;
 	EditorDebuggerTree *remote_scene_tree = nullptr;
+	bool remote_scene_tree_wait = false;
 	float remote_scene_tree_timeout = 0.0;
+	bool remote_scene_tree_clear_msg = true;
 	bool auto_switch_remote_scene_tree = false;
 	bool debug_with_external_editor = false;
 	bool keep_open = false;
@@ -116,7 +119,6 @@ private:
 	HashSet<Ref<EditorDebuggerPlugin>> debugger_plugins;
 
 	ScriptEditorDebugger *_add_debugger();
-	EditorDebuggerRemoteObject *get_inspected_remote_object();
 	void _update_errors();
 
 	friend class DebuggerEditorPlugin;
@@ -128,12 +130,15 @@ protected:
 	void _debugger_stopped(int p_id);
 	void _debugger_wants_stop(int p_id);
 	void _debugger_changed(int p_tab);
-	void _remote_tree_select_requested(ObjectID p_id, int p_debugger);
+	void _debug_data(const String &p_msg, const Array &p_data, int p_debugger);
+	void _remote_tree_select_requested(const TypedArray<int64_t> &p_ids, int p_debugger);
+	void _remote_tree_clear_selection_requested(int p_debugger);
 	void _remote_tree_updated(int p_debugger);
 	void _remote_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
-	void _remote_object_updated(ObjectID p_id, int p_debugger);
+	void _remote_objects_updated(EditorDebuggerRemoteObjects *p_objs, int p_debugger);
 	void _remote_object_property_updated(ObjectID p_id, const String &p_property, int p_debugger);
-	void _remote_object_requested(ObjectID p_id, int p_debugger);
+	void _remote_objects_requested(const TypedArray<uint64_t> &p_ids, int p_debugger);
+	void _remote_selection_cleared(int p_debugger);
 	void _save_node_requested(ObjectID p_id, const String &p_file, int p_debugger);
 
 	void _breakpoint_set_in_tree(Ref<RefCounted> p_script, int p_line, bool p_enabled, int p_debugger);
@@ -190,6 +195,10 @@ public:
 
 	// Remote inspector/edit.
 	void request_remote_tree();
+	void set_remote_selection(const TypedArray<int64_t> &p_ids);
+	void clear_remote_tree_selection();
+	void stop_waiting_inspection();
+	bool match_remote_selection(const TypedArray<uint64_t> &p_ids) const;
 	static void _methods_changed(void *p_ud, Object *p_base, const StringName &p_name, const Variant **p_args, int p_argcount);
 	static void _properties_changed(void *p_ud, Object *p_base, const StringName &p_property, const Variant &p_value);
 

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_toaster.h"
 #include "editor/scene_tree_dock.h"
 #include "scene/debugger/scene_debugger.h"
 #include "scene/gui/texture_rect.h"
@@ -44,6 +45,7 @@
 EditorDebuggerTree::EditorDebuggerTree() {
 	set_v_size_flags(SIZE_EXPAND_FILL);
 	set_allow_rmb_select(true);
+	set_select_mode(SELECT_MULTI);
 
 	// Popup
 	item_menu = memnew(PopupMenu);
@@ -54,6 +56,9 @@ EditorDebuggerTree::EditorDebuggerTree() {
 	file_dialog = memnew(EditorFileDialog);
 	file_dialog->connect("file_selected", callable_mp(this, &EditorDebuggerTree::_file_selected));
 	add_child(file_dialog);
+
+	accept = memnew(AcceptDialog);
+	add_child(accept);
 }
 
 void EditorDebuggerTree::_notification(int p_what) {
@@ -61,7 +66,8 @@ void EditorDebuggerTree::_notification(int p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
 			set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 
-			connect("cell_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_selected));
+			connect("multi_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_selection_changed));
+			connect("nothing_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_nothing_selected));
 			connect("item_collapsed", callable_mp(this, &EditorDebuggerTree::_scene_tree_folded));
 			connect("item_mouse_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_rmb_selected));
 		} break;
@@ -73,24 +79,57 @@ void EditorDebuggerTree::_notification(int p_what) {
 }
 
 void EditorDebuggerTree::_bind_methods() {
-	ADD_SIGNAL(MethodInfo("object_selected", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::INT, "debugger")));
+	ADD_SIGNAL(MethodInfo("objects_selected", PropertyInfo(Variant::ARRAY, "object_ids"), PropertyInfo(Variant::INT, "debugger")));
+	ADD_SIGNAL(MethodInfo("selection_cleared", PropertyInfo(Variant::INT, "debugger")));
 	ADD_SIGNAL(MethodInfo("save_node", PropertyInfo(Variant::INT, "object_id"), PropertyInfo(Variant::STRING, "filename"), PropertyInfo(Variant::INT, "debugger")));
 	ADD_SIGNAL(MethodInfo("open"));
 }
 
-void EditorDebuggerTree::_scene_tree_selected() {
-	if (updating_scene_tree) {
+void EditorDebuggerTree::_scene_tree_selection_changed(TreeItem *p_item, int p_column, bool p_selected) {
+	if (updating_scene_tree || !p_item) {
 		return;
 	}
 
-	TreeItem *item = get_selected();
-	if (!item) {
-		return;
+	uint64_t id = uint64_t(p_item->get_metadata(0));
+	if (p_selected) {
+		if (inspected_object_ids.size() == (int)EDITOR_GET("debugger/max_node_selection")) {
+			selection_surpassed_limit = true;
+			p_item->deselect(0);
+			return;
+		}
+
+		if (!inspected_object_ids.has(id)) {
+			inspected_object_ids.append(id);
+		}
+	} else if (inspected_object_ids.has(id)) {
+		inspected_object_ids.erase(id);
 	}
 
-	inspected_object_id = uint64_t(item->get_metadata(0));
+	if (!notify_selection_queued) {
+		callable_mp(this, &EditorDebuggerTree::_notify_selection_changed).call_deferred();
+		notify_selection_queued = true;
+	}
+}
 
-	emit_signal(SNAME("object_selected"), inspected_object_id, debugger_id);
+void EditorDebuggerTree::_scene_tree_nothing_selected() {
+	deselect_all();
+	inspected_object_ids.clear();
+	emit_signal(SNAME("selection_cleared"), debugger_id);
+}
+
+void EditorDebuggerTree::_notify_selection_changed() {
+	notify_selection_queued = false;
+
+	if (inspected_object_ids.is_empty()) {
+		emit_signal(SNAME("selection_cleared"), debugger_id);
+	} else {
+		emit_signal(SNAME("objects_selected"), inspected_object_ids.duplicate(), debugger_id);
+	}
+
+	if (selection_surpassed_limit) {
+		selection_surpassed_limit = false;
+		EditorToaster::get_singleton()->popup_str(vformat(TTR("Some remote nodes were not selected, as the configured maximum selection is %d. This can be changed at \"debugger/max_node_selection\" in the Editor Settings."), EDITOR_GET("debugger/max_node_selection")), EditorToaster::SEVERITY_WARNING);
+	}
 }
 
 void EditorDebuggerTree::_scene_tree_folded(Object *p_obj) {
@@ -124,7 +163,7 @@ void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position, Mou
 	item->select(0);
 
 	item_menu->clear();
-	item_menu->add_icon_item(get_editor_theme_icon(SNAME("CreateNewSceneFrom")), TTR("Save Branch as Scene"), ITEM_MENU_SAVE_REMOTE_NODE);
+	item_menu->add_icon_item(get_editor_theme_icon(SNAME("CreateNewSceneFrom")), TTR("Save Branch as Scene..."), ITEM_MENU_SAVE_REMOTE_NODE);
 	item_menu->add_icon_item(get_editor_theme_icon(SNAME("CopyNodePath")), TTR("Copy Node Path"), ITEM_MENU_COPY_NODE_PATH);
 	item_menu->add_icon_item(get_editor_theme_icon(SNAME("Collapse")), TTR("Expand/Collapse Branch"), ITEM_MENU_EXPAND_COLLAPSE);
 	item_menu->set_position(get_screen_position() + get_local_mouse_position());
@@ -152,12 +191,13 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 	updating_scene_tree = true;
 	const String last_path = get_selected_path();
 	const String filter = SceneTreeDock::get_singleton()->get_filter();
-	TreeItem *select_item = nullptr;
+	LocalVector<TreeItem *> select_items;
 	bool hide_filtered_out_parents = EDITOR_GET("docks/scene_tree/hide_filtered_out_parents");
 
 	bool should_scroll = scrolling_to_item || filter != last_filter;
 	scrolling_to_item = false;
 	TreeItem *scroll_item = nullptr;
+	TypedArray<uint64_t> ids_present;
 
 	// Nodes are in a flatten list, depth first. Use a stack of parents, avoid recursion.
 	List<ParentItem> parents;
@@ -216,9 +256,11 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		}
 		item->set_meta("node_path", current_path + "/" + item->get_text(0));
 
-		// Select previously selected node.
+		// Select previously selected nodes.
 		if (debugger_id == p_debugger) { // Can use remote id.
-			if (node.id == inspected_object_id) {
+			if (inspected_object_ids.has(uint64_t(node.id))) {
+				ids_present.append(node.id);
+
 				if (selection_uncollapse_all) {
 					selection_uncollapse_all = false;
 
@@ -228,14 +270,14 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 					updating_scene_tree = true;
 				}
 
-				select_item = item;
+				select_items.push_back(item);
 				if (should_scroll) {
 					scroll_item = item;
 				}
 			}
 		} else if (last_path == (String)item->get_meta("node_path")) { // Must use path.
-			updating_scene_tree = false; // Force emission of new selection.
-			select_item = item;
+			updating_scene_tree = false; // Force emission of new selections.
+			select_items.push_back(item);
 			if (should_scroll) {
 				scroll_item = item;
 			}
@@ -280,12 +322,12 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 					break; // Filter matches, must survive.
 				}
 
-				parent->remove_child(item);
-				memdelete(item);
-				if (select_item == item || scroll_item == item) {
-					select_item = nullptr;
+				if (select_items.has(item) || scroll_item == item) {
+					select_items.resize(select_items.size() - 1);
 					scroll_item = nullptr;
 				}
+				parent->remove_child(item);
+				memdelete(item);
 
 				if (had_siblings) {
 					break; // Parent must survive.
@@ -316,18 +358,20 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 
 				from->get_parent()->remove_child(from);
 				memdelete(from);
-				if (select_item == from || scroll_item == from) {
-					select_item = nullptr;
+				if (select_items.has(from) || scroll_item == from) {
+					select_items.erase(from);
 					scroll_item = nullptr;
 				}
 			}
 		}
 	}
 
+	inspected_object_ids = ids_present;
+
 	debugger_id = p_debugger; // Needed by hook, could be avoided if every debugger had its own tree.
 
-	if (select_item) {
-		select_item->select(0);
+	for (TreeItem *item : select_items) {
+		item->select(0);
 	}
 	if (scroll_item) {
 		scroll_to_item(scroll_item, false);
@@ -337,12 +381,22 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 	updating_scene_tree = false;
 }
 
-void EditorDebuggerTree::select_node(ObjectID p_id) {
+void EditorDebuggerTree::select_nodes(const TypedArray<int64_t> &p_ids) {
 	// Manually select, as the tree control may be out-of-date for some reason (e.g. not shown yet).
 	selection_uncollapse_all = true;
-	inspected_object_id = uint64_t(p_id);
+	inspected_object_ids = p_ids;
 	scrolling_to_item = true;
-	emit_signal(SNAME("object_selected"), inspected_object_id, debugger_id);
+
+	if (!updating_scene_tree) {
+		// Request a tree refresh.
+		EditorDebuggerNode::get_singleton()->request_remote_tree();
+	}
+	// Set the value immediately, so no update flooding happens and causes a crash.
+	updating_scene_tree = true;
+}
+
+void EditorDebuggerTree::clear_selection() {
+	inspected_object_ids.clear();
 
 	if (!updating_scene_tree) {
 		// Request a tree refresh.
@@ -453,8 +507,11 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 }
 
 void EditorDebuggerTree::_file_selected(const String &p_file) {
-	if (inspected_object_id.is_null()) {
+	if (inspected_object_ids.size() != 1) {
+		accept->set_text(vformat(TTR("Saving the branch as a scene requires selecting only one node, but you have selected %d nodes."), inspected_object_ids.size()));
+		accept->popup_centered();
 		return;
 	}
-	emit_signal(SNAME("save_node"), inspected_object_id, p_file, debugger_id);
+
+	emit_signal(SNAME("save_node"), inspected_object_ids[0], p_file, debugger_id);
 }

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -32,6 +32,7 @@
 
 #include "scene/gui/tree.h"
 
+class AcceptDialog;
 class SceneDebuggerTree;
 class EditorFileDialog;
 
@@ -57,18 +58,23 @@ private:
 		ITEM_MENU_EXPAND_COLLAPSE,
 	};
 
-	ObjectID inspected_object_id;
+	TypedArray<uint64_t> inspected_object_ids;
 	int debugger_id = 0;
 	bool updating_scene_tree = false;
 	bool scrolling_to_item = false;
+	bool notify_selection_queued = false;
+	bool selection_surpassed_limit = false;
 	bool selection_uncollapse_all = false;
 	HashSet<ObjectID> unfold_cache;
 	PopupMenu *item_menu = nullptr;
 	EditorFileDialog *file_dialog = nullptr;
+	AcceptDialog *accept = nullptr;
 	String last_filter;
 
 	void _scene_tree_folded(Object *p_obj);
-	void _scene_tree_selected();
+	void _scene_tree_selection_changed(TreeItem *p_item, int p_column, bool p_selected);
+	void _scene_tree_nothing_selected();
+	void _notify_selection_changed();
 	void _scene_tree_rmb_selected(const Vector2 &p_position, MouseButton p_button);
 	void _item_menu_id_pressed(int p_option);
 	void _file_selected(const String &p_file);
@@ -89,7 +95,10 @@ public:
 	String get_selected_path();
 	ObjectID get_selected_object();
 	int get_current_debugger(); // Would love to have one tree for every debugger.
+	inline TypedArray<uint64_t> get_selection() const { return inspected_object_ids.duplicate(); }
 	void update_scene_tree(const SceneDebuggerTree *p_tree, int p_debugger);
-	void select_node(ObjectID p_id);
+	void select_nodes(const TypedArray<int64_t> &p_ids);
+	void clear_selection();
+
 	EditorDebuggerTree();
 };

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -34,7 +34,6 @@
 #include "core/os/os.h"
 #include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/debugger/editor_debugger_node.h"
-#include "editor/debugger/editor_debugger_server.h"
 #include "scene/gui/button.h"
 #include "scene/gui/margin_container.h"
 
@@ -146,7 +145,7 @@ private:
 	Ref<RemoteDebuggerPeer> peer;
 
 	HashMap<NodePath, int> node_path_cache;
-	int last_path_id;
+	int last_path_id = 0;
 	HashMap<String, int> res_path_cache;
 
 	EditorProfiler *profiler = nullptr;
@@ -158,7 +157,7 @@ private:
 	bool move_to_foreground = true;
 	bool can_request_idle_draw = false;
 
-	bool live_debug;
+	bool live_debug = true;
 
 	uint64_t debugging_thread_id = Thread::UNASSIGNED_ID;
 
@@ -191,7 +190,7 @@ private:
 	void _set_reason_text(const String &p_reason, MessageType p_type);
 	void _update_buttons_state();
 	void _remote_object_selected(ObjectID p_object);
-	void _remote_object_edited(ObjectID, const String &p_prop, const Variant &p_value);
+	void _remote_objects_edited(const String &p_prop, const TypedDictionary<uint64_t, Variant> &p_values, const String &p_field);
 	void _remote_object_property_updated(ObjectID p_id, const String &p_property);
 
 	void _video_mem_request();
@@ -245,9 +244,10 @@ protected:
 	static void _bind_methods();
 
 public:
-	void request_remote_object(ObjectID p_obj_id);
-	void update_remote_object(ObjectID p_obj_id, const String &p_prop, const Variant &p_value);
-	Object *get_remote_object(ObjectID p_id);
+	void request_remote_objects(const TypedArray<uint64_t> &p_obj_ids, bool p_update_selection = true);
+	void update_remote_object(ObjectID p_obj_id, const String &p_prop, const Variant &p_value, const String &p_field = "");
+
+	void clear_inspector(bool p_send_msg = true);
 
 	// Needed by _live_edit_set, buttons state.
 	void set_editor_remote_tree(const Tree *p_tree) { editor_remote_tree = p_tree; }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -33,6 +33,7 @@
 
 #include "core/os/keyboard.h"
 #include "editor/add_metadata_dialog.h"
+#include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/doc_tools.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_main_screen.h"
@@ -4280,6 +4281,10 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		emit_signal(_prop_edited, p_name);
 	} else if (Object::cast_to<MultiNodeEdit>(object)) {
 		Object::cast_to<MultiNodeEdit>(object)->set_property_field(p_name, p_value, p_changed_field);
+		_edit_request_change(object, p_name);
+		emit_signal(_prop_edited, p_name);
+	} else if (Object::cast_to<EditorDebuggerRemoteObjects>(object)) {
+		Object::cast_to<EditorDebuggerRemoteObjects>(object)->set_property_field(p_name, p_value, p_changed_field);
 		_edit_request_change(object, p_name);
 		emit_signal(_prop_edited, p_name);
 	} else {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2533,12 +2533,13 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		InspectorDock::get_inspector_singleton()->edit(nullptr);
 		NodeDock::get_singleton()->set_node(nullptr);
 		InspectorDock::get_singleton()->update(nullptr);
+		EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 		hide_unused_editors();
 		return;
 	}
 
 	// Update the use folding setting and state.
-	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding")) || current_obj->is_class("EditorDebuggerRemoteObject");
+	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding")) || current_obj->is_class("EditorDebuggerRemoteObjects");
 	if (InspectorDock::get_inspector_singleton()->is_using_folding() == disable_folding) {
 		InspectorDock::get_inspector_singleton()->set_use_folding(!disable_folding, false);
 	}
@@ -2566,6 +2567,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 			SceneTreeDock::get_singleton()->set_selected(nullptr);
 			NodeDock::get_singleton()->set_node(nullptr);
 			InspectorDock::get_singleton()->update(nullptr);
+			EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 			ImportDock::get_singleton()->set_edit_path(current_res->get_path());
 		}
 
@@ -2605,6 +2607,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 			SceneTreeDock::get_singleton()->set_selected(nullptr);
 			InspectorDock::get_singleton()->update(nullptr);
 		}
+		EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 
 		if (get_edited_scene() && !get_edited_scene()->get_scene_file_path().is_empty()) {
 			String source_scene = get_edited_scene()->get_scene_file_path();
@@ -2613,7 +2616,6 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 				info_is_warning = true;
 			}
 		}
-
 	} else {
 		Node *selected_node = nullptr;
 
@@ -2637,6 +2639,10 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 					}
 				}
 			}
+		}
+
+		if (!current_obj->is_class("EditorDebuggerRemoteObjects")) {
+			EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 		}
 
 		InspectorDock::get_inspector_singleton()->edit(current_obj);
@@ -4932,7 +4938,8 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 
 	Ref<Script> scr = p_object->get_script();
 
-	if (Object::cast_to<EditorDebuggerRemoteObject>(p_object)) {
+	const EditorDebuggerRemoteObjects *robjs = Object::cast_to<EditorDebuggerRemoteObjects>(p_object);
+	if (robjs) {
 		String class_name;
 		if (scr.is_valid()) {
 			class_name = scr->get_global_name();
@@ -4942,7 +4949,12 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 				class_name = scr->get_path();
 			}
 		}
-		return get_class_icon(class_name.is_empty() ? Object::cast_to<EditorDebuggerRemoteObject>(p_object)->type_name : class_name, p_fallback);
+
+		if (class_name.is_empty()) {
+			return get_class_icon(robjs->type_name, p_fallback);
+		}
+
+		return get_class_icon(class_name, p_fallback);
 	}
 
 	if (scr.is_null() && p_object->is_class("Script")) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -993,6 +993,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "debugger/auto_switch_to_remote_scene_tree", false, "")
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "debugger/auto_switch_to_stack_trace", true, "")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "debugger/max_node_selection", 20, "1,100,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "debugger/profiler_frame_history_size", 3600, "60,10000,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "debugger/profiler_frame_max_functions", 64, "16,512,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "debugger/profiler_target_fps", 60, "1,1000,1")

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -61,7 +61,7 @@ UndoRedo *EditorUndoRedoManager::get_history_undo_redo(int p_idx) const {
 int EditorUndoRedoManager::get_history_id_for_object(Object *p_object) const {
 	int history_id = INVALID_HISTORY;
 
-	if (Object::cast_to<EditorDebuggerRemoteObject>(p_object)) {
+	if (Object::cast_to<EditorDebuggerRemoteObjects>(p_object)) {
 		return REMOTE_HISTORY;
 	}
 

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -128,7 +128,6 @@ void EditorObjectSelector::update_path() {
 		}
 
 		Ref<Texture2D> obj_icon = EditorNode::get_singleton()->get_object_icon(obj);
-
 		if (obj_icon.is_valid()) {
 			current_object_icon->set_texture(obj_icon);
 		}
@@ -148,7 +147,7 @@ void EditorObjectSelector::update_path() {
 				if (name.is_empty()) {
 					name = r->get_class();
 				}
-			} else if (obj->is_class("EditorDebuggerRemoteObject")) {
+			} else if (obj->is_class("EditorDebuggerRemoteObjects")) {
 				name = obj->call("get_title");
 			} else if (Object::cast_to<Node>(obj)) {
 				name = Object::cast_to<Node>(obj)->get_name();

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -30,6 +30,8 @@
 
 #include "inspector_dock.h"
 
+#include "editor/debugger/editor_debugger_inspector.h"
+#include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
@@ -351,7 +353,7 @@ void InspectorDock::_prepare_history() {
 			}
 		} else if (Object::cast_to<Node>(obj)) {
 			text = Object::cast_to<Node>(obj)->get_name();
-		} else if (obj->is_class("EditorDebuggerRemoteObject")) {
+		} else if (obj->is_class("EditorDebuggerRemoteObjects")) {
 			text = obj->call("get_title");
 		} else {
 			text = obj->get_class();
@@ -372,6 +374,10 @@ void InspectorDock::_select_history(int p_idx) {
 		return;
 	}
 	EditorNode::get_singleton()->push_item(obj);
+
+	if (const EditorDebuggerRemoteObjects *robjs = Object::cast_to<EditorDebuggerRemoteObjects>(obj)) {
+		EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids.duplicate());
+	}
 }
 
 void InspectorDock::_resource_created() {
@@ -396,6 +402,10 @@ void InspectorDock::_resource_selected(const Ref<Resource> &p_res, const String 
 void InspectorDock::_edit_forward() {
 	if (EditorNode::get_singleton()->get_editor_selection_history()->next()) {
 		EditorNode::get_singleton()->edit_current();
+
+		if (const EditorDebuggerRemoteObjects *robjs = Object::cast_to<EditorDebuggerRemoteObjects>(current)) {
+			EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids.duplicate());
+		}
 	}
 }
 
@@ -403,6 +413,10 @@ void InspectorDock::_edit_back() {
 	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	if ((current && editor_history->previous()) || editor_history->get_path_size() == 1) {
 		EditorNode::get_singleton()->edit_current();
+
+		if (const EditorDebuggerRemoteObjects *robjs = Object::cast_to<EditorDebuggerRemoteObjects>(current)) {
+			EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids.duplicate());
+		}
 	}
 }
 

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -212,7 +212,7 @@ class GameViewPlugin : public EditorPlugin {
 #ifndef ANDROID_ENABLED
 	GameView *game_view = nullptr;
 	WindowWrapper *window_wrapper = nullptr;
-#endif
+#endif // ANDROID_ENABLED
 
 	Ref<GameViewDebugger> debugger;
 
@@ -221,7 +221,7 @@ class GameViewPlugin : public EditorPlugin {
 	void _feature_profile_changed();
 #ifndef ANDROID_ENABLED
 	void _window_visibility_changed(bool p_visible);
-#endif
+#endif // ANDROID_ENABLED
 	void _save_last_editor(const String &p_editor);
 	void _focus_another_editor();
 	bool _is_window_wrapper_enabled() const;
@@ -243,10 +243,7 @@ public:
 
 	virtual void set_window_layout(Ref<ConfigFile> p_layout) override;
 	virtual void get_window_layout(Ref<ConfigFile> p_layout) override;
-
-	virtual void set_state(const Dictionary &p_state) override;
-	virtual Dictionary get_state() const override;
-#endif
+#endif // ANDROID_ENABLED
 
 	GameViewPlugin();
 	~GameViewPlugin();

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -33,6 +33,7 @@
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/io/marshalls.h"
+#include "core/math/math_fieldwise.h"
 #include "core/object/script_language.h"
 #include "core/templates/local_vector.h"
 #include "scene/2d/physics/collision_object_2d.h"
@@ -42,6 +43,7 @@
 #include "scene/3d/physics/collision_object_3d.h"
 #include "scene/3d/physics/collision_shape_3d.h"
 #include "scene/3d/visual_instance_3d.h"
+#include "scene/resources/3d/convex_polygon_shape_3d.h"
 #include "scene/resources/surface_tool.h"
 #endif // _3D_DISABLED
 #include "scene/gui/popup_menu.h"
@@ -59,7 +61,7 @@ SceneDebugger::SceneDebugger() {
 	RuntimeNodeSelect::singleton = memnew(RuntimeNodeSelect);
 
 	EngineDebugger::register_message_capture("scene", EngineDebugger::Capture(nullptr, SceneDebugger::parse_message));
-#endif
+#endif // DEBUG_ENABLED
 }
 
 SceneDebugger::~SceneDebugger() {
@@ -74,7 +76,7 @@ SceneDebugger::~SceneDebugger() {
 		memdelete(RuntimeNodeSelect::singleton);
 		RuntimeNodeSelect::singleton = nullptr;
 	}
-#endif
+#endif // DEBUG_ENABLED
 
 	singleton = nullptr;
 }
@@ -118,20 +120,26 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 	if (p_msg == "setup_scene") {
 		SceneTree::get_singleton()->get_root()->connect(SceneStringName(window_input), callable_mp_static(SceneDebugger::_handle_input).bind(DebuggerMarshalls::deserialize_key_shortcut(p_args)));
 
-	} else if (p_msg == "request_scene_tree") { // Scene tree
+	} else if (p_msg == "request_scene_tree") { /// Scene Tree
 		live_editor->_send_tree();
 
-	} else if (p_msg == "save_node") { // Save node.
+	} else if (p_msg == "save_node") {
 		ERR_FAIL_COND_V(p_args.size() < 2, ERR_INVALID_DATA);
 		_save_node(p_args[0], p_args[1]);
 		Array arr;
 		arr.append(p_args[1]);
 		EngineDebugger::get_singleton()->send_message("filesystem:update_file", { arr });
 
-	} else if (p_msg == "inspect_object") { // Object Inspect
-		ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
-		ObjectID id = p_args[0];
-		_send_object_id(id);
+	} else if (p_msg == "inspect_objects") { /// Object Inspect
+		ERR_FAIL_COND_V(p_args.size() < 2, ERR_INVALID_DATA);
+		Vector<ObjectID> ids;
+		for (const Variant &id : (Array)p_args[0]) {
+			ids.append(ObjectID(id.operator uint64_t()));
+		}
+		_send_object_ids(ids, p_args[1]);
+
+	} else if (p_msg == "clear_selection") {
+		runtime_node_select->_clear_selection();
 
 	} else if (p_msg == "suspend_changed") {
 		ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
@@ -142,7 +150,7 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 	} else if (p_msg == "next_frame") {
 		_next_frame();
 
-	} else if (p_msg == "override_cameras") { // Camera
+	} else if (p_msg == "override_cameras") { /// Camera
 		ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
 		bool enable = p_args[0];
 		bool from_editor = p_args[1];
@@ -178,6 +186,11 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 	} else if (p_msg == "set_object_property") {
 		ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);
 		_set_object_property(p_args[0], p_args[1], p_args[2]);
+		runtime_node_select->_queue_selection_update();
+
+	} else if (p_msg == "set_object_property_field") {
+		ERR_FAIL_COND_V(p_args.size() < 4, ERR_INVALID_DATA);
+		_set_object_property(p_args[0], p_args[1], p_args[2], p_args[3]);
 		runtime_node_select->_queue_selection_update();
 
 	} else if (p_msg == "reload_cached_files") {
@@ -249,18 +262,12 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 		} else if (p_msg == "live_remove_node") {
 			ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
 			live_editor->_remove_node_func(p_args[0]);
-
-			if (!runtime_node_select->has_selection) {
-				runtime_node_select->_clear_selection();
-			}
+			runtime_node_select->_queue_selection_update();
 
 		} else if (p_msg == "live_remove_and_keep_node") {
 			ERR_FAIL_COND_V(p_args.size() < 2, ERR_INVALID_DATA);
 			live_editor->_remove_and_keep_node_func(p_args[0], p_args[1]);
-
-			if (!runtime_node_select->has_selection) {
-				runtime_node_select->_clear_selection();
-			}
+			runtime_node_select->_queue_selection_update();
 
 		} else if (p_msg == "live_restore_node") {
 			ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);
@@ -326,7 +333,7 @@ void SceneDebugger::_save_node(ObjectID id, const String &p_path) {
 	Node *copy = node->duplicate_from_editor(duplimap);
 #else
 	Node *copy = node->duplicate();
-#endif
+#endif // TOOLS_ENABLED
 
 	// Handle Unique Nodes.
 	for (int i = 0; i < copy->get_child_count(false); i++) {
@@ -352,21 +359,55 @@ void SceneDebugger::_set_node_owner_recursive(Node *p_node, Node *p_owner) {
 	}
 }
 
-void SceneDebugger::_send_object_id(ObjectID p_id, int p_max_size) {
-	SceneDebuggerObject obj(p_id);
-	if (obj.id.is_null()) {
-		return;
+void SceneDebugger::_send_object_ids(const Vector<ObjectID> &p_ids, bool p_update_selection) {
+	Vector<ObjectID> ids = p_ids;
+	if (ids.size() > RuntimeNodeSelect::get_singleton()->max_selection) {
+		ids.resize(RuntimeNodeSelect::get_singleton()->max_selection);
+		EngineDebugger::get_singleton()->send_message("show_selection_limit_warning", Array());
 	}
 
-	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(p_id));
-	RuntimeNodeSelect::get_singleton()->_select_node(node);
+	LocalVector<Node *> nodes;
+	Array objs;
+	bool objs_missing = false;
+	for (const ObjectID &id : ids) {
+		SceneDebuggerObject obj(id);
+		if (obj.id.is_null()) {
+			objs_missing = true;
+			continue;
+		}
 
-	Array arr;
-	obj.serialize(arr);
-	EngineDebugger::get_singleton()->send_message("scene:inspect_object", arr);
+		if (p_update_selection) {
+			if (Node *node = Object::cast_to<Node>(ObjectDB::get_instance(id))) {
+				nodes.push_back(node);
+			}
+		}
+
+		Array arr;
+		obj.serialize(arr);
+		objs.append(arr);
+	}
+
+	if (p_update_selection) {
+		RuntimeNodeSelect::get_singleton()->_set_selected_nodes(nodes);
+	}
+
+	if (objs_missing) {
+		Array invalid_selection;
+		for (const ObjectID &id : ids) {
+			invalid_selection.append(id);
+		}
+
+		Array arr;
+		arr.append(invalid_selection);
+		EngineDebugger::get_singleton()->send_message("remote_selection_invalidated", arr);
+
+		EngineDebugger::get_singleton()->send_message(objs.is_empty() ? "remote_nothing_clicked" : "remote_nodes_clicked", objs);
+	} else {
+		EngineDebugger::get_singleton()->send_message("scene:inspect_objects", objs);
+	}
 }
 
-void SceneDebugger::_set_object_property(ObjectID p_id, const String &p_property, const Variant &p_value) {
+void SceneDebugger::_set_object_property(ObjectID p_id, const String &p_property, const Variant &p_value, const String &p_field) {
 	Object *obj = ObjectDB::get_instance(p_id);
 	if (!obj) {
 		return;
@@ -378,7 +419,16 @@ void SceneDebugger::_set_object_property(ObjectID p_id, const String &p_property
 		prop_name = ss[ss.size() - 1];
 	}
 
-	obj->set(prop_name, p_value);
+	Variant value;
+	if (p_field.is_empty()) {
+		// Whole value.
+		value = p_value;
+	} else {
+		// Only one field.
+		value = fieldwise_assign(obj->get(prop_name), p_value, p_field);
+	}
+
+	obj->set(prop_name, value);
 }
 
 void SceneDebugger::_next_frame() {
@@ -1218,19 +1268,11 @@ RuntimeNodeSelect::~RuntimeNodeSelect() {
 		memdelete(selection_list);
 	}
 
-	if (sbox_2d_canvas.is_valid()) {
-		RS::get_singleton()->free(sbox_2d_canvas);
+	if (draw_canvas.is_valid()) {
+		RS::get_singleton()->free(sel_drag_ci);
 		RS::get_singleton()->free(sbox_2d_ci);
+		RS::get_singleton()->free(draw_canvas);
 	}
-
-#ifndef _3D_DISABLED
-	if (sbox_3d_instance.is_valid()) {
-		RS::get_singleton()->free(sbox_3d_instance);
-		RS::get_singleton()->free(sbox_3d_instance_ofs);
-		RS::get_singleton()->free(sbox_3d_instance_xray);
-		RS::get_singleton()->free(sbox_3d_instance_xray_ofs);
-	}
-#endif // _3D_DISABLED
 }
 
 void RuntimeNodeSelect::_setup(const Dictionary &p_settings) {
@@ -1239,6 +1281,8 @@ void RuntimeNodeSelect::_setup(const Dictionary &p_settings) {
 
 	root->connect(SceneStringName(window_input), callable_mp(this, &RuntimeNodeSelect::_root_window_input));
 	root->connect("size_changed", callable_mp(this, &RuntimeNodeSelect::_queue_selection_update), CONNECT_DEFERRED);
+
+	max_selection = p_settings.get("debugger/max_node_selection", 1);
 
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &RuntimeNodeSelect::_pan_callback), callable_mp(this, &RuntimeNodeSelect::_zoom_callback));
@@ -1251,12 +1295,20 @@ void RuntimeNodeSelect::_setup(const Dictionary &p_settings) {
 	panner->setup_warped_panning(root, p_settings.get("editors/panning/warped_mouse_panning", true));
 	panner->set_scroll_speed(pan_speed);
 
+	sel_2d_grab_dist = p_settings.get("editors/polygon_editor/point_grab_radius", 0);
+
+	selection_area_fill = p_settings.get("box_selection_fill_color", Color());
+	selection_area_outline = p_settings.get("box_selection_stroke_color", Color());
+
+	draw_canvas = RS::get_singleton()->canvas_create();
+	sel_drag_ci = RS::get_singleton()->canvas_item_create();
+
 	/// 2D Selection Box Generation
 
-	sbox_2d_canvas = RS::get_singleton()->canvas_create();
 	sbox_2d_ci = RS::get_singleton()->canvas_item_create();
-	RS::get_singleton()->viewport_attach_canvas(root->get_viewport_rid(), sbox_2d_canvas);
-	RS::get_singleton()->canvas_item_set_parent(sbox_2d_ci, sbox_2d_canvas);
+	RS::get_singleton()->viewport_attach_canvas(root->get_viewport_rid(), draw_canvas);
+	RS::get_singleton()->canvas_item_set_parent(sel_drag_ci, draw_canvas);
+	RS::get_singleton()->canvas_item_set_parent(sbox_2d_ci, draw_canvas);
 
 #ifndef _3D_DISABLED
 	cursor = Cursor();
@@ -1276,6 +1328,8 @@ void RuntimeNodeSelect::_setup(const Dictionary &p_settings) {
 
 	/// 3D Selection Box Generation
 	// Copied from the Node3DEditor implementation.
+
+	sbox_3d_color = p_settings.get("editors/3d/selection_box_color", Color());
 
 	// Use two AABBs to create the illusion of a slightly thicker line.
 	AABB aabb(Vector3(), Vector3(1, 1, 1));
@@ -1301,10 +1355,7 @@ void RuntimeNodeSelect::_setup(const Dictionary &p_settings) {
 	Ref<StandardMaterial3D> mat = memnew(StandardMaterial3D);
 	mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	// In the original Node3DEditor, this value would be fetched from the "editors/3d/selection_box_color" editor property,
-	// but since this is not accessible from here, we will just use the default value.
-	const Color selection_color_3d = Color(1, 0.5, 0);
-	mat->set_albedo(selection_color_3d);
+	mat->set_albedo(sbox_3d_color);
 	mat->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	st->set_material(mat);
 	sbox_3d_mesh = st->commit();
@@ -1313,7 +1364,7 @@ void RuntimeNodeSelect::_setup(const Dictionary &p_settings) {
 	mat_xray->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	mat_xray->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
 	mat_xray->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-	mat_xray->set_albedo(selection_color_3d * Color(1, 1, 1, 0.15));
+	mat_xray->set_albedo(sbox_3d_color * Color(1, 1, 1, 0.15));
 	mat_xray->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	st_xray->set_material(mat_xray);
 	sbox_3d_mesh_xray = st_xray->commit();
@@ -1371,12 +1422,11 @@ void RuntimeNodeSelect::_root_window_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
+	bool is_dragging_camera = false;
 	if (camera_override) {
 		if (node_select_type == NODE_TYPE_2D) {
-			if (panner->gui_input(p_event, Rect2(Vector2(), root->get_size()))) {
-				return;
-			}
-		} else if (node_select_type == NODE_TYPE_3D) {
+			is_dragging_camera = panner->gui_input(p_event, Rect2(Vector2(), root->get_size()));
+		} else if (node_select_type == NODE_TYPE_3D && selection_drag_state == SELECTION_DRAG_NONE) {
 #ifndef _3D_DISABLED
 			if (_handle_3d_input(p_event)) {
 				return;
@@ -1386,25 +1436,54 @@ void RuntimeNodeSelect::_root_window_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventMouseButton> b = p_event;
-	if (b.is_null() || !b->is_pressed()) {
+
+	if (selection_drag_state == SELECTION_DRAG_MOVE) {
+		Ref<InputEventMouseMotion> m = p_event;
+		if (m.is_valid()) {
+			_update_selection_drag(root->get_screen_transform().affine_inverse().xform(m->get_position()));
+			return;
+		} else if (b.is_valid()) {
+			// Account for actions like zooming.
+			_update_selection_drag(root->get_screen_transform().affine_inverse().xform(b->get_position()));
+		}
+	}
+
+	if (b.is_null()) {
 		return;
 	}
 
-	list_shortcut_pressed = node_select_mode == SELECT_MODE_SINGLE && b->get_button_index() == MouseButton::RIGHT && b->is_alt_pressed();
-	if (list_shortcut_pressed || b->get_button_index() == MouseButton::LEFT) {
-		selection_position = b->get_position();
+	// Ignore mouse wheel inputs.
+	if (b->get_button_index() != MouseButton::LEFT && b->get_button_index() != MouseButton::RIGHT) {
+		return;
+	}
+
+	if (selection_drag_state == SELECTION_DRAG_MOVE && !b->is_pressed() && b->get_button_index() == MouseButton::LEFT) {
+		selection_drag_state = SELECTION_DRAG_END;
+		selection_drag_area = selection_drag_area.abs();
+		_update_selection_drag();
+
+		// Trigger a selection in the position on release.
+		if (multi_shortcut_pressed) {
+			selection_position = root->get_screen_transform().affine_inverse().xform(b->get_position());
+		}
+	}
+
+	if (!is_dragging_camera && b->is_pressed()) {
+		multi_shortcut_pressed = b->is_shift_pressed();
+		list_shortcut_pressed = node_select_mode == SELECT_MODE_SINGLE && b->get_button_index() == MouseButton::RIGHT && b->is_alt_pressed();
+		if (list_shortcut_pressed || b->get_button_index() == MouseButton::LEFT) {
+			selection_position = root->get_screen_transform().affine_inverse().xform(b->get_position());
+		}
 	}
 }
 
 void RuntimeNodeSelect::_items_popup_index_pressed(int p_index, PopupMenu *p_popup) {
 	Object *obj = p_popup->get_item_metadata(p_index).get_validated_object();
-	if (!obj) {
-		return;
+	if (obj) {
+		Vector<Node *> node;
+		node.append(Object::cast_to<Node>(obj));
+		_send_ids(node);
 	}
-
-	Array message;
-	message.append(obj->get_instance_id());
-	EngineDebugger::get_singleton()->send_message("remote_node_clicked", message);
 }
 
 void RuntimeNodeSelect::_update_input_state() {
@@ -1489,20 +1568,23 @@ void RuntimeNodeSelect::_process_frame() {
 }
 
 void RuntimeNodeSelect::_physics_frame() {
-	if (!Math::is_inf(selection_position.x) || !Math::is_inf(selection_position.y)) {
-		_click_point();
-		selection_position = Point2(INFINITY, INFINITY);
+	if (selection_drag_state != SELECTION_DRAG_END && (selection_drag_state == SELECTION_DRAG_MOVE || Math::is_inf(selection_position.x))) {
+		return;
 	}
-}
 
-void RuntimeNodeSelect::_click_point() {
 	Window *root = SceneTree::get_singleton()->get_root();
-	Point2 pos = root->get_screen_transform().affine_inverse().xform(selection_position);
+	bool selection_drag_valid = selection_drag_state == SELECTION_DRAG_END && selection_drag_area.get_area() > SELECTION_MIN_AREA;
 	Vector<SelectResult> items;
 
 	if (node_select_type == NODE_TYPE_2D) {
-		for (int i = 0; i < root->get_child_count(); i++) {
-			_find_canvas_items_at_pos(pos, root->get_child(i), items);
+		if (selection_drag_valid) {
+			for (int i = 0; i < root->get_child_count(); i++) {
+				_find_canvas_items_at_rect(selection_drag_area, root->get_child(i), items);
+			}
+		} else if (!Math::is_inf(selection_position.x)) {
+			for (int i = 0; i < root->get_child_count(); i++) {
+				_find_canvas_items_at_pos(selection_position, root->get_child(i), items);
+			}
 		}
 
 		// Remove possible duplicates.
@@ -1519,73 +1601,268 @@ void RuntimeNodeSelect::_click_point() {
 		}
 	} else if (node_select_type == NODE_TYPE_3D) {
 #ifndef _3D_DISABLED
-		_find_3d_items_at_pos(pos, items);
+		if (selection_drag_valid) {
+			_find_3d_items_at_rect(selection_drag_area, items);
+		} else {
+			_find_3d_items_at_pos(selection_position, items);
+		}
 #endif // _3D_DISABLED
-	}
-
-	if (items.is_empty()) {
-		return;
 	}
 
 	items.sort();
 
-	if ((!list_shortcut_pressed && node_select_mode == SELECT_MODE_SINGLE) || items.size() == 1) {
-		Array message;
-		message.append(items[0].item->get_instance_id());
-		EngineDebugger::get_singleton()->send_message("remote_node_clicked", message);
-	} else if (list_shortcut_pressed || node_select_mode == SELECT_MODE_LIST) {
-		if (!selection_list) {
-			_open_selection_list(items, pos);
+	switch (selection_drag_state) {
+		case SELECTION_DRAG_END: {
+			selection_position = Point2(INFINITY, INFINITY);
+			selection_drag_state = SELECTION_DRAG_NONE;
+
+			if (selection_drag_area.get_area() > SELECTION_MIN_AREA) {
+				if (!items.is_empty()) {
+					Vector<Node *> nodes;
+					for (const SelectResult item : items) {
+						nodes.append(item.item);
+					}
+					_send_ids(nodes, false);
+				}
+
+				_update_selection_drag();
+				return;
+			}
+
+			_update_selection_drag();
+		} break;
+
+		case SELECTION_DRAG_NONE: {
+			if (node_select_mode == SELECT_MODE_LIST) {
+				break;
+			}
+
+			if (multi_shortcut_pressed) {
+				// Allow forcing box selection when an item was clicked.
+				selection_drag_state = SELECTION_DRAG_MOVE;
+			} else if (items.is_empty()) {
+				if (!selected_ci_nodes.is_empty() || !selected_3d_nodes.is_empty()) {
+					EngineDebugger::get_singleton()->send_message("remote_nothing_clicked", Array());
+					_clear_selection();
+				}
+
+				selection_drag_state = SELECTION_DRAG_MOVE;
+			} else {
+				break;
+			}
+
+			[[fallthrough]];
+		}
+
+		case SELECTION_DRAG_MOVE: {
+			selection_drag_area.position = selection_position;
+
+			// Stop selection on click, so it can happen on release if the selection area doesn't pass the threshold.
+			if (multi_shortcut_pressed) {
+				return;
+			}
 		}
 	}
+
+	if (items.is_empty()) {
+		selection_position = Point2(INFINITY, INFINITY);
+		return;
+	}
+	if ((!list_shortcut_pressed && node_select_mode == SELECT_MODE_SINGLE) || items.size() == 1) {
+		selection_position = Point2(INFINITY, INFINITY);
+
+		Vector<Node *> node;
+		node.append(items[0].item);
+		_send_ids(node);
+
+		return;
+	}
+
+	if (!selection_list && (list_shortcut_pressed || node_select_mode == SELECT_MODE_LIST)) {
+		_open_selection_list(items, selection_position);
+	}
+
+	selection_position = Point2(INFINITY, INFINITY);
 }
 
-void RuntimeNodeSelect::_select_node(Node *p_node) {
-	if (p_node == selected_node) {
+void RuntimeNodeSelect::_send_ids(const Vector<Node *> &p_picked_nodes, bool p_invert_new_selections) {
+	ERR_FAIL_COND(p_picked_nodes.is_empty());
+
+	Vector<Node *> picked_nodes = p_picked_nodes;
+	Array message;
+
+	if (!multi_shortcut_pressed) {
+		if (picked_nodes.size() > max_selection) {
+			picked_nodes.resize(max_selection);
+			EngineDebugger::get_singleton()->send_message("show_selection_limit_warning", Array());
+		}
+
+		for (const Node *node : picked_nodes) {
+			SceneDebuggerObject obj(node->get_instance_id());
+			Array arr;
+			obj.serialize(arr);
+			message.append(arr);
+		}
+
+		EngineDebugger::get_singleton()->send_message("remote_nodes_clicked", message);
+		_set_selected_nodes(picked_nodes);
+
+		return;
+	}
+
+	const int limit = max_selection - (selected_ci_nodes.size() + selected_3d_nodes.size());
+	if (limit <= 0) {
+		return;
+	}
+	if (picked_nodes.size() > limit) {
+		picked_nodes.resize(limit);
+		EngineDebugger::get_singleton()->send_message("show_selection_limit_warning", Array());
+	}
+
+	LocalVector<Node *> nodes;
+	LocalVector<ObjectID> ids;
+	for (Node *node : picked_nodes) {
+		ObjectID id = node->get_instance_id();
+		if (CanvasItem *ci = Object::cast_to<CanvasItem>(node)) {
+			if (selected_ci_nodes.has(id)) {
+				if (p_invert_new_selections) {
+					selected_ci_nodes.erase(id);
+				}
+			} else {
+				ids.push_back(id);
+				nodes.push_back(ci);
+			}
+		} else {
+#ifndef _3D_DISABLED
+			if (Node3D *node3d = Object::cast_to<Node3D>(node)) {
+				if (selected_3d_nodes.has(id)) {
+					if (p_invert_new_selections) {
+						selected_3d_nodes.erase(id);
+					}
+				} else {
+					ids.push_back(id);
+					nodes.push_back(node3d);
+				}
+			}
+#endif // _3D_DISABLED
+		}
+	}
+
+	for (ObjectID id : selected_ci_nodes) {
+		ids.push_back(id);
+		nodes.push_back(Object::cast_to<Node>(ObjectDB::get_instance(id)));
+	}
+#ifndef _3D_DISABLED
+	for (const KeyValue<ObjectID, Ref<SelectionBox3D>> &KV : selected_3d_nodes) {
+		ids.push_back(KV.key);
+		nodes.push_back(Object::cast_to<Node>(ObjectDB::get_instance(KV.key)));
+	}
+#endif // _3D_DISABLED
+
+	if (ids.size() > (unsigned)max_selection) {
+		ids.resize(max_selection);
+		EngineDebugger::get_singleton()->send_message("show_selection_limit_warning", Array());
+	}
+
+	if (ids.is_empty()) {
+		EngineDebugger::get_singleton()->send_message("remote_nothing_clicked", message);
+	} else {
+		for (const ObjectID &id : ids) {
+			SceneDebuggerObject obj(id);
+			Array arr;
+			obj.serialize(arr);
+			message.append(arr);
+		}
+
+		EngineDebugger::get_singleton()->send_message("remote_nodes_clicked", message);
+	}
+
+	_set_selected_nodes(nodes);
+}
+
+void RuntimeNodeSelect::_set_selected_nodes(const Vector<Node *> &p_nodes) {
+	if (p_nodes.is_empty()) {
+		_clear_selection();
+		return;
+	}
+
+	bool changed = false;
+	LocalVector<ObjectID> nodes_ci;
+#ifndef _3D_DISABLED
+	HashMap<ObjectID, Ref<SelectionBox3D>> nodes_3d;
+#endif // _3D_DISABLED
+
+	for (Node *node : p_nodes) {
+		ObjectID id = node->get_instance_id();
+		if (Object::cast_to<CanvasItem>(node)) {
+			if (!changed || !selected_ci_nodes.has(id)) {
+				changed = true;
+			}
+
+			nodes_ci.push_back(id);
+		} else {
+#ifndef _3D_DISABLED
+			Node3D *node_3d = Object::cast_to<Node3D>(node);
+			if (!node_3d || !node_3d->is_inside_world()) {
+				continue;
+			}
+
+			if (!changed || !selected_3d_nodes.has(id)) {
+				changed = true;
+			}
+
+			if (selected_3d_nodes.has(id)) {
+				// Assign an already available visual instance.
+				nodes_3d[id] = selected_3d_nodes.get(id);
+				continue;
+			}
+
+			if (sbox_3d_mesh.is_null() || sbox_3d_mesh_xray.is_null()) {
+				continue;
+			}
+
+			Ref<SelectionBox3D> sb;
+			sb.instantiate();
+			nodes_3d[id] = sb;
+
+			RID scenario = node_3d->get_world_3d()->get_scenario();
+
+			sb->instance = RS::get_singleton()->instance_create2(sbox_3d_mesh->get_rid(), scenario);
+			sb->instance_ofs = RS::get_singleton()->instance_create2(sbox_3d_mesh->get_rid(), scenario);
+			RS::get_singleton()->instance_geometry_set_cast_shadows_setting(sb->instance, RS::SHADOW_CASTING_SETTING_OFF);
+			RS::get_singleton()->instance_geometry_set_cast_shadows_setting(sb->instance_ofs, RS::SHADOW_CASTING_SETTING_OFF);
+			RS::get_singleton()->instance_geometry_set_flag(sb->instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+			RS::get_singleton()->instance_geometry_set_flag(sb->instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+			RS::get_singleton()->instance_geometry_set_flag(sb->instance_ofs, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+			RS::get_singleton()->instance_geometry_set_flag(sb->instance_ofs, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+
+			sb->instance_xray = RS::get_singleton()->instance_create2(sbox_3d_mesh_xray->get_rid(), scenario);
+			sb->instance_xray_ofs = RS::get_singleton()->instance_create2(sbox_3d_mesh_xray->get_rid(), scenario);
+			RS::get_singleton()->instance_geometry_set_cast_shadows_setting(sb->instance_xray, RS::SHADOW_CASTING_SETTING_OFF);
+			RS::get_singleton()->instance_geometry_set_cast_shadows_setting(sb->instance_xray_ofs, RS::SHADOW_CASTING_SETTING_OFF);
+			RS::get_singleton()->instance_geometry_set_flag(sb->instance_xray, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+			RS::get_singleton()->instance_geometry_set_flag(sb->instance_xray, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+			RS::get_singleton()->instance_geometry_set_flag(sb->instance_xray_ofs, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
+			RS::get_singleton()->instance_geometry_set_flag(sb->instance_xray_ofs, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
+#endif // _3D_DISABLED
+		}
+	}
+
+	if (!changed && nodes_ci.size() == selected_ci_nodes.size() && nodes_3d.size() == selected_3d_nodes.size()) {
 		return;
 	}
 
 	_clear_selection();
+	selected_ci_nodes = nodes_ci;
+	has_selection = !nodes_ci.is_empty();
 
-	CanvasItem *ci = Object::cast_to<CanvasItem>(p_node);
-	if (ci) {
-		selected_node = p_node;
-	} else {
 #ifndef _3D_DISABLED
-		Node3D *node_3d = Object::cast_to<Node3D>(p_node);
-		if (node_3d) {
-			if (!node_3d->is_inside_world()) {
-				return;
-			}
-
-			selected_node = p_node;
-
-			if (sbox_3d_mesh.is_valid()) {
-				sbox_3d_instance = RS::get_singleton()->instance_create2(sbox_3d_mesh->get_rid(), node_3d->get_world_3d()->get_scenario());
-				sbox_3d_instance_ofs = RS::get_singleton()->instance_create2(sbox_3d_mesh->get_rid(), node_3d->get_world_3d()->get_scenario());
-				RS::get_singleton()->instance_geometry_set_cast_shadows_setting(sbox_3d_instance, RS::SHADOW_CASTING_SETTING_OFF);
-				RS::get_singleton()->instance_geometry_set_cast_shadows_setting(sbox_3d_instance_ofs, RS::SHADOW_CASTING_SETTING_OFF);
-				RS::get_singleton()->instance_geometry_set_flag(sbox_3d_instance, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-				RS::get_singleton()->instance_geometry_set_flag(sbox_3d_instance, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-				RS::get_singleton()->instance_geometry_set_flag(sbox_3d_instance_ofs, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-				RS::get_singleton()->instance_geometry_set_flag(sbox_3d_instance_ofs, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-			}
-
-			if (sbox_3d_mesh_xray.is_valid()) {
-				sbox_3d_instance_xray = RS::get_singleton()->instance_create2(sbox_3d_mesh_xray->get_rid(), node_3d->get_world_3d()->get_scenario());
-				sbox_3d_instance_xray_ofs = RS::get_singleton()->instance_create2(sbox_3d_mesh_xray->get_rid(), node_3d->get_world_3d()->get_scenario());
-				RS::get_singleton()->instance_geometry_set_cast_shadows_setting(sbox_3d_instance_xray, RS::SHADOW_CASTING_SETTING_OFF);
-				RS::get_singleton()->instance_geometry_set_cast_shadows_setting(sbox_3d_instance_xray_ofs, RS::SHADOW_CASTING_SETTING_OFF);
-				RS::get_singleton()->instance_geometry_set_flag(sbox_3d_instance_xray, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-				RS::get_singleton()->instance_geometry_set_flag(sbox_3d_instance_xray, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-				RS::get_singleton()->instance_geometry_set_flag(sbox_3d_instance_xray_ofs, RS::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
-				RS::get_singleton()->instance_geometry_set_flag(sbox_3d_instance_xray_ofs, RS::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
-			}
-		}
-#endif // _3D_DISABLED
+	if (!nodes_3d.is_empty()) {
+		selected_3d_nodes = nodes_3d;
+		has_selection = true;
 	}
+#endif // _3D_DISABLED
 
-	has_selection = selected_node;
 	_queue_selection_update();
 }
 
@@ -1600,20 +1877,25 @@ void RuntimeNodeSelect::_queue_selection_update() {
 }
 
 void RuntimeNodeSelect::_update_selection() {
-	if (has_selection && (!selected_node || !selected_node->is_inside_tree())) {
-		_clear_selection();
-		return;
-	}
+	Window *root = SceneTree::get_singleton()->get_root();
 
-	CanvasItem *ci = Object::cast_to<CanvasItem>(selected_node);
-	if (ci) {
-		Window *root = SceneTree::get_singleton()->get_root();
+	RS::get_singleton()->canvas_item_clear(sbox_2d_ci);
+	RS::get_singleton()->canvas_item_set_visible(sbox_2d_ci, selection_visible);
+
+	for (LocalVector<ObjectID>::Iterator E = selected_ci_nodes.begin(); E != selected_ci_nodes.end(); ++E) {
+		ObjectID id = *E;
+		CanvasItem *ci = Object::cast_to<CanvasItem>(ObjectDB::get_instance(id));
+		if (!ci) {
+			selected_ci_nodes.erase(id);
+			--E;
+			continue;
+		}
+
 		Transform2D xform;
-		if (root->is_canvas_transform_override_enabled() && !ci->get_canvas_layer_node()) {
-			RS::get_singleton()->canvas_item_set_transform(sbox_2d_ci, (root->get_canvas_transform_override()));
-			xform = ci->get_global_transform();
+		// Cameras (overridden or not) don't affect `CanvasLayer`s.
+		if (root->is_canvas_transform_override_enabled() && !(ci->get_canvas_layer_node() && !ci->get_canvas_layer_node()->is_following_viewport())) {
+			xform = root->get_canvas_transform_override() * ci->get_global_transform();
 		} else {
-			RS::get_singleton()->canvas_item_set_transform(sbox_2d_ci, Transform2D());
 			xform = ci->get_global_transform_with_canvas();
 		}
 
@@ -1632,30 +1914,28 @@ void RuntimeNodeSelect::_update_selection() {
 			}
 		}
 
-		RS::get_singleton()->canvas_item_set_visible(sbox_2d_ci, selection_visible);
-
-		if (xform == sbox_2d_xform && rect == sbox_2d_rect) {
-			return; // Nothing changed.
-		}
-		sbox_2d_xform = xform;
-		sbox_2d_rect = rect;
-
-		RS::get_singleton()->canvas_item_clear(sbox_2d_ci);
-
 		const Vector2 endpoints[4] = {
 			xform.xform(rect.position),
-			xform.xform(rect.position + Vector2(rect.size.x, 0)),
+			xform.xform(rect.position + Point2(rect.size.x, 0)),
 			xform.xform(rect.position + rect.size),
-			xform.xform(rect.position + Vector2(0, rect.size.y))
+			xform.xform(rect.position + Point2(0, rect.size.y))
 		};
 
 		const Color selection_color_2d = Color(1, 0.6, 0.4, 0.7);
 		for (int i = 0; i < 4; i++) {
-			RS::get_singleton()->canvas_item_add_line(sbox_2d_ci, endpoints[i], endpoints[(i + 1) % 4], selection_color_2d, Math::round(2.f));
+			RS::get_singleton()->canvas_item_add_line(sbox_2d_ci, endpoints[i], endpoints[(i + 1) % 4], selection_color_2d, 2);
 		}
-	} else {
+	}
+
 #ifndef _3D_DISABLED
-		Node3D *node_3d = Object::cast_to<Node3D>(selected_node);
+	for (HashMap<ObjectID, Ref<SelectionBox3D>>::ConstIterator KV = selected_3d_nodes.begin(); KV != selected_3d_nodes.end(); ++KV) {
+		ObjectID id = KV->key;
+		Node3D *node_3d = Object::cast_to<Node3D>(ObjectDB::get_instance(id));
+		if (!node_3d) {
+			selected_3d_nodes.erase(id);
+			--KV;
+			continue;
+		}
 
 		// Fallback.
 		AABB bounds(Vector3(-0.5, -0.5, -0.5), Vector3(1, 1, 1));
@@ -1673,20 +1953,16 @@ void RuntimeNodeSelect::_update_selection() {
 			}
 		}
 
-		RS::get_singleton()->instance_set_visible(sbox_3d_instance, selection_visible);
-		RS::get_singleton()->instance_set_visible(sbox_3d_instance_ofs, selection_visible);
-		RS::get_singleton()->instance_set_visible(sbox_3d_instance_xray, selection_visible);
-		RS::get_singleton()->instance_set_visible(sbox_3d_instance_xray_ofs, selection_visible);
-
 		Transform3D xform_to_top_level_parent_space = node_3d->get_global_transform().affine_inverse() * node_3d->get_global_transform();
 		bounds = xform_to_top_level_parent_space.xform(bounds);
 		Transform3D t = node_3d->get_global_transform();
 
-		if (t == sbox_3d_xform && bounds == sbox_3d_bounds) {
-			return; // Nothing changed.
+		Ref<SelectionBox3D> sb = KV->value;
+		if (t == sb->transform && bounds == sb->bounds) {
+			continue; // Nothing changed.
 		}
-		sbox_3d_xform = t;
-		sbox_3d_bounds = bounds;
+		sb->transform = t;
+		sb->bounds = bounds;
 
 		Transform3D t_offset = t;
 
@@ -1706,30 +1982,78 @@ void RuntimeNodeSelect::_update_selection() {
 			t_offset.basis = t_offset.basis * aabb_s;
 		}
 
-		RS::get_singleton()->instance_set_transform(sbox_3d_instance, t);
-		RS::get_singleton()->instance_set_transform(sbox_3d_instance_ofs, t_offset);
-		RS::get_singleton()->instance_set_transform(sbox_3d_instance_xray, t);
-		RS::get_singleton()->instance_set_transform(sbox_3d_instance_xray_ofs, t_offset);
-#endif // _3D_DISABLED
+		RS::get_singleton()->instance_set_visible(sb->instance, selection_visible);
+		RS::get_singleton()->instance_set_visible(sb->instance_ofs, selection_visible);
+		RS::get_singleton()->instance_set_visible(sb->instance_xray, selection_visible);
+		RS::get_singleton()->instance_set_visible(sb->instance_xray_ofs, selection_visible);
+
+		RS::get_singleton()->instance_set_transform(sb->instance, t);
+		RS::get_singleton()->instance_set_transform(sb->instance_ofs, t_offset);
+		RS::get_singleton()->instance_set_transform(sb->instance_xray, t);
+		RS::get_singleton()->instance_set_transform(sb->instance_xray_ofs, t_offset);
 	}
+#endif // _3D_DISABLED
 }
 
 void RuntimeNodeSelect::_clear_selection() {
-	selected_node = nullptr;
-	has_selection = false;
-
-	if (sbox_2d_canvas.is_valid()) {
+	selected_ci_nodes.clear();
+	if (draw_canvas.is_valid()) {
 		RS::get_singleton()->canvas_item_clear(sbox_2d_ci);
 	}
 
 #ifndef _3D_DISABLED
-	if (sbox_3d_instance.is_valid()) {
-		RS::get_singleton()->free(sbox_3d_instance);
-		RS::get_singleton()->free(sbox_3d_instance_ofs);
-		RS::get_singleton()->free(sbox_3d_instance_xray);
-		RS::get_singleton()->free(sbox_3d_instance_xray_ofs);
-	}
+	selected_3d_nodes.clear();
 #endif // _3D_DISABLED
+
+	has_selection = false;
+}
+
+void RuntimeNodeSelect::_update_selection_drag(const Point2 &p_end_pos) {
+	RS::get_singleton()->canvas_item_clear(sel_drag_ci);
+
+	if (selection_drag_state != SELECTION_DRAG_MOVE) {
+		return;
+	}
+
+	selection_drag_area.size = p_end_pos - selection_drag_area.position;
+
+	if (selection_drag_state == SELECTION_DRAG_END) {
+		return;
+	}
+
+	Window *root = SceneTree::get_singleton()->get_root();
+	Rect2 selection_drawing;
+	int thickness;
+	if (root->is_canvas_transform_override_enabled()) {
+		Transform2D xform = root->get_canvas_transform_override();
+		RS::get_singleton()->canvas_item_set_transform(sel_drag_ci, xform);
+
+		selection_drawing.position = xform.affine_inverse().xform(selection_drag_area.position);
+		selection_drawing.size = xform.affine_inverse().xform(p_end_pos);
+		thickness = MAX(1, Math::ceil(1 / view_2d_zoom));
+	} else {
+		RS::get_singleton()->canvas_item_set_transform(sel_drag_ci, Transform2D());
+
+		selection_drawing.position = selection_drag_area.position;
+		selection_drawing.size = p_end_pos;
+		thickness = 1;
+	}
+	selection_drawing.size -= selection_drawing.position;
+	selection_drawing = selection_drawing.abs();
+
+	const Vector2 endpoints[4] = {
+		selection_drawing.position,
+		selection_drawing.position + Point2(selection_drawing.size.x, 0),
+		selection_drawing.position + selection_drawing.size,
+		selection_drawing.position + Point2(0, selection_drawing.size.y)
+	};
+
+	// Draw fill.
+	RS::get_singleton()->canvas_item_add_rect(sel_drag_ci, selection_drawing, selection_area_fill);
+	// Draw outline.
+	for (int i = 0; i < 4; i++) {
+		RS::get_singleton()->canvas_item_add_line(sel_drag_ci, endpoints[i], endpoints[(i + 1) % 4], selection_area_outline, thickness);
+	}
 }
 
 void RuntimeNodeSelect::_open_selection_list(const Vector<SelectResult> &p_items, const Point2 &p_pos) {
@@ -1749,7 +2073,7 @@ void RuntimeNodeSelect::_open_selection_list(const Vector<SelectResult> &p_items
 		selection_list->set_item_metadata(-1, I.item);
 	}
 
-	selection_list->set_position(selection_list->is_embedded() ? p_pos : selection_position + root->get_position());
+	selection_list->set_position(selection_list->is_embedded() ? p_pos : (Input::get_singleton()->get_mouse_position() + root->get_position()));
 	selection_list->reset_size();
 	selection_list->popup();
 	// FIXME: Ugly hack that stops the popup from hiding when the button is released.
@@ -1775,11 +2099,7 @@ void RuntimeNodeSelect::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_n
 		return;
 	}
 
-	// In the original CanvasItemEditor, this value would be fetched from the "editors/polygon_editor/point_grab_radius" editor property,
-	// but since this is not accessible from here, we will just use the default value.
-	const real_t grab_distance = 8;
 	CanvasItem *ci = Object::cast_to<CanvasItem>(p_node);
-
 	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
 		if (ci) {
 			if (!ci->is_set_as_top_level()) {
@@ -1793,41 +2113,103 @@ void RuntimeNodeSelect::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_n
 		}
 	}
 
-	if (ci && ci->is_visible_in_tree()) {
-		Transform2D xform = p_canvas_xform;
-		if (!ci->is_set_as_top_level()) {
-			xform *= p_parent_xform;
-		}
+	if (!ci || !ci->is_visible_in_tree()) {
+		return;
+	}
 
-		Vector2 pos;
-		// Cameras (overridden or not) don't affect `CanvasLayer`s.
-		if (!ci->get_canvas_layer_node()) {
-			Window *root = SceneTree::get_singleton()->get_root();
-			pos = (root->is_canvas_transform_override_enabled() ? root->get_canvas_transform_override() : root->get_canvas_transform()).affine_inverse().xform(p_pos);
-		} else {
-			pos = p_pos;
-		}
+	Transform2D xform = p_canvas_xform;
+	if (!ci->is_set_as_top_level()) {
+		xform *= p_parent_xform;
+	}
 
-		xform = (xform * ci->get_transform()).affine_inverse();
-		const real_t local_grab_distance = xform.basis_xform(Vector2(grab_distance, 0)).length() / view_2d_zoom;
-		if (ci->_edit_is_selected_on_click(xform.xform(pos), local_grab_distance)) {
-			SelectResult res;
-			res.item = ci;
-			res.order = ci->get_effective_z_index() + ci->get_canvas_layer();
-			r_items.push_back(res);
+	Window *root = SceneTree::get_singleton()->get_root();
+	Point2 pos;
+	// Cameras (overridden or not) don't affect `CanvasLayer`s.
+	if (!ci->get_canvas_layer_node() || ci->get_canvas_layer_node()->is_following_viewport()) {
+		pos = (root->is_canvas_transform_override_enabled() ? root->get_canvas_transform_override() : root->get_canvas_transform()).affine_inverse().xform(p_pos);
+	} else {
+		pos = p_pos;
+	}
 
-			// If it's a shape, get the collision object it's from.
-			// FIXME: If the collision object has multiple shapes, only the topmost will be above it in the list.
-			if (Object::cast_to<CollisionShape2D>(ci) || Object::cast_to<CollisionPolygon2D>(ci)) {
-				CollisionObject2D *collision_object = Object::cast_to<CollisionObject2D>(ci->get_parent());
-				if (collision_object) {
-					SelectResult res_col;
-					res_col.item = ci->get_parent();
-					res_col.order = collision_object->get_z_index() + ci->get_canvas_layer();
-					r_items.push_back(res_col);
-				}
+	xform = (xform * ci->get_transform()).affine_inverse();
+	const real_t local_grab_distance = xform.basis_xform(Vector2(sel_2d_grab_dist, 0)).length() / view_2d_zoom;
+	if (ci->_edit_is_selected_on_click(xform.xform(pos), local_grab_distance)) {
+		SelectResult res;
+		res.item = ci;
+		res.order = ci->get_effective_z_index() + ci->get_canvas_layer();
+		r_items.push_back(res);
+
+		// If it's a shape, get the collision object it's from.
+		// FIXME: If the collision object has multiple shapes, only the topmost will be above it in the list.
+		if (Object::cast_to<CollisionShape2D>(ci) || Object::cast_to<CollisionPolygon2D>(ci)) {
+			CollisionObject2D *collision_object = Object::cast_to<CollisionObject2D>(ci->get_parent());
+			if (collision_object) {
+				SelectResult res_col;
+				res_col.item = ci->get_parent();
+				res_col.order = collision_object->get_z_index() + ci->get_canvas_layer();
+				r_items.push_back(res_col);
 			}
 		}
+	}
+}
+
+// Copied and trimmed from the CanvasItemEditor implementation.
+void RuntimeNodeSelect::_find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_node, Vector<SelectResult> &r_items, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform) {
+	if (!p_node || Object::cast_to<Viewport>(p_node)) {
+		return;
+	}
+
+	CanvasItem *ci = Object::cast_to<CanvasItem>(p_node);
+	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {
+		if (ci) {
+			if (!ci->is_set_as_top_level()) {
+				_find_canvas_items_at_rect(p_rect, p_node->get_child(i), r_items, p_parent_xform * ci->get_transform(), p_canvas_xform);
+			} else {
+				_find_canvas_items_at_rect(p_rect, p_node->get_child(i), r_items, ci->get_transform(), p_canvas_xform);
+			}
+		} else {
+			CanvasLayer *cl = Object::cast_to<CanvasLayer>(p_node);
+			_find_canvas_items_at_rect(p_rect, p_node->get_child(i), r_items, Transform2D(), cl ? cl->get_transform() : p_canvas_xform);
+		}
+	}
+
+	if (!ci || !ci->is_visible_in_tree()) {
+		return;
+	}
+
+	Transform2D xform = p_canvas_xform;
+	if (!ci->is_set_as_top_level()) {
+		xform *= p_parent_xform;
+	}
+
+	Window *root = SceneTree::get_singleton()->get_root();
+	Rect2 rect;
+	// Cameras (overridden or not) don't affect `CanvasLayer`s.
+	if (!ci->get_canvas_layer_node() || ci->get_canvas_layer_node()->is_following_viewport()) {
+		rect = (root->is_canvas_transform_override_enabled() ? root->get_canvas_transform_override() : root->get_canvas_transform()).affine_inverse().xform(p_rect);
+	} else {
+		rect = p_rect;
+	}
+	rect = (xform * ci->get_transform()).affine_inverse().xform(rect);
+
+	bool selected = false;
+	if (ci->_edit_use_rect()) {
+		Rect2 ci_rect = ci->_edit_get_rect();
+		if (rect.has_point(ci_rect.position) &&
+				rect.has_point(ci_rect.position + Vector2(ci_rect.size.x, 0)) &&
+				rect.has_point(ci_rect.position + Vector2(ci_rect.size.x, ci_rect.size.y)) &&
+				rect.has_point(ci_rect.position + Vector2(0, ci_rect.size.y))) {
+			selected = true;
+		}
+	} else if (rect.has_point(Point2())) {
+		selected = true;
+	}
+
+	if (selected) {
+		SelectResult res;
+		res.item = ci;
+		res.order = ci->get_effective_z_index() + ci->get_canvas_layer();
+		r_items.push_back(res);
 	}
 }
 
@@ -1881,14 +2263,14 @@ void RuntimeNodeSelect::_update_view_2d() {
 #ifndef _3D_DISABLED
 void RuntimeNodeSelect::_find_3d_items_at_pos(const Point2 &p_pos, Vector<SelectResult> &r_items) {
 	Window *root = SceneTree::get_singleton()->get_root();
+
 	Vector3 ray, pos, to;
-	if (root->get_viewport()->is_camera_3d_override_enabled()) {
-		Viewport *vp = root->get_viewport();
-		ray = vp->camera_3d_override_project_ray_normal(p_pos);
-		pos = vp->camera_3d_override_project_ray_origin(p_pos);
-		to = pos + ray * vp->get_camera_3d_override_properties()["z_far"];
+	if (root->is_camera_3d_override_enabled()) {
+		ray = root->camera_3d_override_project_ray_normal(p_pos);
+		pos = root->camera_3d_override_project_ray_origin(p_pos);
+		to = pos + ray * root->get_camera_3d_override_properties()["z_far"];
 	} else {
-		Camera3D *camera = root->get_viewport()->get_camera_3d();
+		Camera3D *camera = root->get_camera_3d();
 		if (!camera) {
 			return;
 		}
@@ -1918,7 +2300,7 @@ void RuntimeNodeSelect::_find_3d_items_at_pos(const Point2 &p_pos, Vector<Select
 			if (collision) {
 				List<uint32_t> owners;
 				collision->get_shape_owners(&owners);
-				for (const uint32_t &I : owners) {
+				for (uint32_t &I : owners) {
 					SelectResult res_shape;
 					res_shape.item = Object::cast_to<Node>(collision->shape_owner_get_owner(I));
 					res_shape.order = res.order;
@@ -1963,9 +2345,181 @@ void RuntimeNodeSelect::_find_3d_items_at_pos(const Point2 &p_pos, Vector<Select
 	}
 }
 
+void RuntimeNodeSelect::_find_3d_items_at_rect(const Rect2 &p_rect, Vector<SelectResult> &r_items) {
+	Window *root = SceneTree::get_singleton()->get_root();
+	Camera3D *camera = root->get_camera_3d();
+	if (!camera) {
+		return;
+	}
+
+	bool cam_override = root->is_camera_3d_override_enabled();
+	Vector3 cam_pos;
+	Vector3 dist_pos;
+	if (cam_override) {
+		cam_pos = root->get_camera_3d_override_transform().origin;
+		dist_pos = root->camera_3d_override_project_ray_origin(p_rect.position + p_rect.size / 2);
+	} else {
+		cam_pos = camera->get_global_position();
+		dist_pos = camera->project_ray_origin(p_rect.position + p_rect.size / 2);
+	}
+
+	real_t znear, zfar = 0;
+	real_t zofs = 5.0;
+	if (cam_override) {
+		HashMap<StringName, real_t> override_props = root->get_camera_3d_override_properties();
+		znear = override_props["z_near"];
+		zfar = override_props["z_far"];
+		zofs -= znear;
+	} else {
+		znear = camera->get_near();
+		zfar = camera->get_far();
+		zofs -= znear;
+	}
+	zofs = MAX(0.0, zofs);
+
+	const Point2 pos_end = p_rect.position + p_rect.size;
+	Vector3 box[4] = {
+		Vector3(
+				MIN(p_rect.position.x, pos_end.x),
+				MIN(p_rect.position.y, pos_end.y),
+				zofs),
+		Vector3(
+				MAX(p_rect.position.x, pos_end.x),
+				MIN(p_rect.position.y, pos_end.y),
+				zofs),
+		Vector3(
+				MAX(p_rect.position.x, pos_end.x),
+				MAX(p_rect.position.y, pos_end.y),
+				zofs),
+		Vector3(
+				MIN(p_rect.position.x, pos_end.x),
+				MAX(p_rect.position.y, pos_end.y),
+				zofs)
+	};
+
+	Vector<Plane> frustum;
+	for (int i = 0; i < 4; i++) {
+		Vector3 a = _get_screen_to_space(box[i]);
+		Vector3 b = _get_screen_to_space(box[(i + 1) % 4]);
+		frustum.push_back(Plane(a, b, cam_pos));
+	}
+
+	Plane near_plane;
+	// Get the camera normal.
+	if (cam_override) {
+		near_plane = Plane(root->get_camera_3d_override_transform().basis.get_column(2), cam_pos);
+	} else {
+		near_plane = Plane(camera->get_global_transform().basis.get_column(2), cam_pos);
+	}
+	near_plane.d -= znear;
+	frustum.push_back(near_plane);
+
+	Plane far_plane = -near_plane;
+	far_plane.d += zfar;
+	frustum.push_back(far_plane);
+
+	Vector<Vector3> points = Geometry3D::compute_convex_mesh_points(&frustum[0], frustum.size());
+	Ref<ConvexPolygonShape3D> shape;
+	shape.instantiate();
+	shape->set_points(points);
+
+	// Start with physical objects.
+	PhysicsDirectSpaceState3D *ss = root->get_world_3d()->get_direct_space_state();
+	PhysicsDirectSpaceState3D::ShapeResult result;
+	PhysicsDirectSpaceState3D::ShapeParameters shape_params;
+	shape_params.shape_rid = shape->get_rid();
+	shape_params.collide_with_areas = true;
+	if (ss->intersect_shape(shape_params, &result, 32)) {
+		SelectResult res;
+		res.item = Object::cast_to<Node>(result.collider);
+		res.order = -dist_pos.distance_to(Object::cast_to<Node3D>(res.item)->get_global_transform().origin);
+
+		// Fetch collision shapes.
+		CollisionObject3D *collision = Object::cast_to<CollisionObject3D>(result.collider);
+		if (collision) {
+			List<uint32_t> owners;
+			collision->get_shape_owners(&owners);
+			for (uint32_t &I : owners) {
+				SelectResult res_shape;
+				res_shape.item = Object::cast_to<Node>(collision->shape_owner_get_owner(I));
+				res_shape.order = res.order;
+				r_items.push_back(res_shape);
+			}
+		}
+
+		r_items.push_back(res);
+	}
+
+	// Then go for the meshes.
+	Vector<ObjectID> items = RS::get_singleton()->instances_cull_convex(frustum, root->get_world_3d()->get_scenario());
+	for (int i = 0; i < items.size(); i++) {
+		Object *obj = ObjectDB::get_instance(items[i]);
+		GeometryInstance3D *geo_instance = Object::cast_to<GeometryInstance3D>(obj);
+		if (geo_instance) {
+			Ref<TriangleMesh> mesh_collision = geo_instance->generate_triangle_mesh();
+
+			if (mesh_collision.is_valid()) {
+				Transform3D gt = geo_instance->get_global_transform();
+				Vector3 mesh_scale = gt.get_basis().get_scale();
+				gt.orthonormalize();
+
+				Transform3D it = gt.affine_inverse();
+
+				Vector<Plane> transformed_frustum;
+				int plane_count = frustum.size();
+				transformed_frustum.resize(plane_count);
+
+				for (int j = 0; j < plane_count; j++) {
+					transformed_frustum.write[j] = it.xform(frustum[j]);
+				}
+				Vector<Vector3> convex_points = Geometry3D::compute_convex_mesh_points(transformed_frustum.ptr(), plane_count);
+				if (mesh_collision->inside_convex_shape(transformed_frustum.ptr(), transformed_frustum.size(), convex_points.ptr(), convex_points.size(), mesh_scale)) {
+					SelectResult res;
+					res.item = Object::cast_to<Node>(obj);
+					res.order = -dist_pos.distance_to(gt.origin);
+					r_items.push_back(res);
+
+					continue;
+				}
+			}
+		}
+
+		items.remove_at(i);
+		i--;
+	}
+}
+
+Vector3 RuntimeNodeSelect::_get_screen_to_space(const Vector3 &p_vector3) {
+	Window *root = SceneTree::get_singleton()->get_root();
+	Camera3D *camera = root->get_camera_3d();
+
+	Size2 size = root->get_size();
+	real_t znear = 0;
+
+	Projection cm;
+	Transform3D camera_transform;
+	if (root->is_camera_3d_override_enabled()) {
+		HashMap<StringName, real_t> override_props = root->get_camera_3d_override_properties();
+		znear = override_props["z_near"];
+		cm.set_perspective(override_props["fov"], size.aspect(), znear + p_vector3.z, override_props["z_far"]);
+
+		camera_transform.translate_local(cursor.pos);
+		camera_transform.basis.rotate(Vector3(1, 0, 0), -cursor.x_rot);
+		camera_transform.basis.rotate(Vector3(0, 1, 0), -cursor.y_rot);
+		camera_transform.translate_local(0, 0, cursor.distance);
+	} else {
+		znear = camera->get_near();
+		cm.set_perspective(camera->get_fov(), size.aspect(), znear + p_vector3.z, camera->get_far());
+
+		camera_transform = camera->get_camera_transform();
+	}
+
+	Vector2 screen_he = cm.get_viewport_half_extents();
+	return camera_transform.xform(Vector3(((p_vector3.x / size.width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (p_vector3.y / size.height)) * 2.0 - 1.0) * screen_he.y, -(znear + p_vector3.z)));
+}
+
 bool RuntimeNodeSelect::_handle_3d_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> b = p_event;
-
 	if (b.is_valid()) {
 		const real_t zoom_factor = 1.08 * b->get_factor();
 		switch (b->get_button_index()) {
@@ -1997,7 +2551,6 @@ bool RuntimeNodeSelect::_handle_3d_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventMouseMotion> m = p_event;
-
 	if (m.is_valid()) {
 		if (camera_freelook) {
 			_cursor_look(m);
@@ -2013,7 +2566,6 @@ bool RuntimeNodeSelect::_handle_3d_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventKey> k = p_event;
-
 	if (k.is_valid()) {
 		if (k->get_physical_keycode() == Key::ESCAPE) {
 			_set_camera_freelook_enabled(false);
@@ -2200,4 +2752,5 @@ void RuntimeNodeSelect::_reset_camera_3d() {
 	SceneTree::get_singleton()->get_root()->set_camera_3d_override_perspective(camera_fov * cursor.fov_scale, camera_znear, camera_zfar);
 }
 #endif // _3D_DISABLED
-#endif
+
+#endif // DEBUG_ENABLED


### PR DESCRIPTION
Closes #93628.

[Screencast_20241125_111648.webm](https://github.com/user-attachments/assets/7018978a-ca5f-42c3-b70f-96a4c63a397d)

### Features Implemented

- Multi selection of multiple nodes, even if from different types. The properties shown in the inspector will be the ones shared by all the ones selected, like how `MultiNodeEdit` works.
- Region selection for `Node2D`/`Control` and `Node3D` nodes.
- Additive selection: holding <kbd>Shift</kbd> will add/remove items to the selection group instead of overriding it.

**Sponsored By:** 🐺 Lone Wolf Technology / 🍀 W4 Games.