### PR TITLE
Show `TextureProgressBar` radial center cross only when editing the scene

### DIFF
--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -536,7 +536,7 @@ void TextureProgressBar::_notification(int p_what) {
 							}
 
 							// Draw a reference cross.
-							if (Engine::get_singleton()->is_editor_hint()) {
+							if (is_part_of_edited_scene()) {
 								Point2 p;
 
 								if (nine_patch_stretch) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/46266 Closes https://github.com/godotengine/godot/issues/96859 for real. Nothing more.
Special thanks to @Mickeon 
![godot windows editor dev x86_64_frtvhxH0pr](https://github.com/user-attachments/assets/aef6afa7-8d3f-4d46-8af5-aa167b854bb6)
