### PR TITLE
Rename `SubViewportContainer` option `consume_drag_and_drop` to `mouse_target`

### DIFF
--- a/doc/classes/SubViewportContainer.xml
+++ b/doc/classes/SubViewportContainer.xml
@@ -20,11 +20,12 @@
 		</method>
 	</methods>
 	<members>
-		<member name="consume_drag_and_drop" type="bool" setter="set_consume_drag_and_drop" getter="is_consume_drag_and_drop_enabled" default="false">
-			If [code]false[/code], the [SubViewportContainer] is not available as a drop target in drag-and-drop operations, and instead the [Control] nodes inside its [Viewport] children are potential drop targets.
-			If [code]true[/code], the [SubViewportContainer] itself will be considered as a drop target in drag-and-drop operations, preventing the [Control] nodes inside its [Viewport] children from becoming drop targets.
-		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="1" />
+		<member name="mouse_target" type="bool" setter="set_mouse_target" getter="is_mouse_target_enabled" default="false">
+			Configure, if either the [SubViewportContainer] or alternatively the [Control] nodes of its [SubViewport] children should be available as targets of mouse-related functionalities, like identifying the drop target in drag-and-drop operations or cursor shape of hovered [Control] node.
+			If [code]false[/code], the [Control] nodes inside its [SubViewport] children are considered as targets.
+			If [code]true[/code], the [SubViewportContainer] itself will be considered as a target.
+		</member>
 		<member name="stretch" type="bool" setter="set_stretch" getter="is_stretch_enabled" default="false">
 			If [code]true[/code], the sub-viewport will be automatically resized to the control's size.
 			[b]Note:[/b] If [code]true[/code], this will prohibit changing [member SubViewport.size] of its children manually.

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -246,12 +246,12 @@ bool SubViewportContainer::_is_propagated_in_gui_input(const Ref<InputEvent> &p_
 	return false;
 }
 
-void SubViewportContainer::set_consume_drag_and_drop(bool p_enable) {
-	consume_drag_and_drop = p_enable;
+void SubViewportContainer::set_mouse_target(bool p_enable) {
+	mouse_target = p_enable;
 }
 
-bool SubViewportContainer::is_consume_drag_and_drop_enabled() {
-	return consume_drag_and_drop;
+bool SubViewportContainer::is_mouse_target_enabled() {
+	return mouse_target;
 }
 
 void SubViewportContainer::add_child_notify(Node *p_child) {
@@ -294,12 +294,12 @@ void SubViewportContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stretch_shrink", "amount"), &SubViewportContainer::set_stretch_shrink);
 	ClassDB::bind_method(D_METHOD("get_stretch_shrink"), &SubViewportContainer::get_stretch_shrink);
 
-	ClassDB::bind_method(D_METHOD("set_consume_drag_and_drop", "amount"), &SubViewportContainer::set_consume_drag_and_drop);
-	ClassDB::bind_method(D_METHOD("is_consume_drag_and_drop_enabled"), &SubViewportContainer::is_consume_drag_and_drop_enabled);
+	ClassDB::bind_method(D_METHOD("set_mouse_target", "amount"), &SubViewportContainer::set_mouse_target);
+	ClassDB::bind_method(D_METHOD("is_mouse_target_enabled"), &SubViewportContainer::is_mouse_target_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stretch"), "set_stretch", "is_stretch_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_shrink", PROPERTY_HINT_RANGE, "1,32,1,or_greater"), "set_stretch_shrink", "get_stretch_shrink");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "consume_drag_and_drop"), "set_consume_drag_and_drop", "is_consume_drag_and_drop_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mouse_target"), "set_mouse_target", "is_mouse_target_enabled");
 
 	GDVIRTUAL_BIND(_propagate_input_event, "event");
 }

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -38,7 +38,7 @@ class SubViewportContainer : public Container {
 
 	bool stretch = false;
 	int shrink = 1;
-	bool consume_drag_and_drop = false;
+	bool mouse_target = false;
 
 	void _notify_viewports(int p_notification);
 	bool _is_propagated_in_gui_input(const Ref<InputEvent> &p_event);
@@ -65,8 +65,8 @@ public:
 	int get_stretch_shrink() const;
 	void recalc_force_viewport_sizes();
 
-	void set_consume_drag_and_drop(bool p_enable);
-	bool is_consume_drag_and_drop_enabled();
+	void set_mouse_target(bool p_enable);
+	bool is_mouse_target_enabled();
 
 	virtual Size2 get_minimum_size() const override;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3062,8 +3062,8 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 		}
 
 		Viewport *section_root = get_section_root_viewport();
-		if (section_root && c->is_consume_drag_and_drop_enabled()) {
-			// Evaluating `consume_drag_and_drop` and adjusting target_control needs to happen
+		if (section_root && c->is_mouse_target_enabled()) {
+			// Evaluating `mouse_target` and adjusting target_control needs to happen
 			// after `_update_mouse_over` in the SubViewports, because otherwise physics picking
 			// would not work inside SubViewports.
 			section_root->gui.target_control = over;


### PR DESCRIPTION
The functionality of the parameter is not limited to drag-and-drop operations, but it has also other uses.
So its name should not be tied to drag-and-drop.

The API was created in the not yet released Godot 4.4-dev6, so this change should not be considered compatibility breaking.

- follow-up to #99270