### PR TITLE
[3.x] Update the `Thirdparty` section of `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,13 +215,13 @@ See the [release announcement](https://godotengine.org/article/godot-3-6-finally
 
 - bullet updated to 3.25.
 - Embree updated to version 3.13.5.
-- libpng updated to version 1.6.39.
-- libwebp updated to version 1.2.4.
-- MbedTLS updated to version 2.28.2.
-- miniupnpc updated to version 2.2.3.
-- zlib/minizip updated to version 1.2.13.
-- zstd updated to version 1.5.2.
-- CA root certificates updated to 2022.10 bundle from Mozilla.
+- libpng updated to version 1.6.43.
+- libwebp updated to version 1.3.2.
+- MbedTLS updated to version 2.28.8.
+- miniupnpc updated to version 2.2.7.
+- zlib/minizip updated to version 1.3.1.
+- zstd updated to version 1.5.5.
+- CA root certificates updated to 2024.03 bundle from Mozilla.
 - SDL GameControllerDB updated to 2023-02-27 git snapshot.
 
 #### XR


### PR DESCRIPTION
While reading the `3.6`'s changelog some months ago I noticed that the thirdparty lib updates don't list the most recent versions (i.e., they say those libraries were updated to version `x` when an update to a more recent version `y` took place afterwards in the dev cycle).

Inaccuracies I found in the order they appear:

- libpng: `1.6.39` vs `1.6.43` - https://github.com/godotengine/godot/commit/c37bbbfbdcef565dc7f8051aa489a471b0c8ee97
- libwebp: `1.2.4` vs `1.3.2` - https://github.com/godotengine/godot/commit/a7c5e3134a8bb631bb6b97210ef8540f80858799
- mbedtls: `2.28.2` vs `2.28.8` - https://github.com/godotengine/godot/commit/c1615e766d39cecdb8ec1b874d89651b5184791b
- miniupnpc: `2.2.3` vs `2.2.7` - https://github.com/godotengine/godot/commit/f59c244a4a9f6668b4284edc075b730105b802a1
- zlib/minizip: `1.2.13` vs `1.3.1` - https://github.com/godotengine/godot/commit/7885b5814cafe6cbc68ef4e4c7c0e5ee6addfcc2
- zstd: `1.5.2` vs `1.5.5` - https://github.com/godotengine/godot/commit/c1a84c685b3aecd1f8fb6cc31fde6cb6328548d0
- certs: `2022.10` vs `2024.03` - https://github.com/godotengine/godot/commit/9a2e88aa01cfce46cb33943486773fd735041bd8

There may be more thirdparty updates that were missed in https://github.com/godotengine/godot/pull/96594, but I haven't done a side-by-side comparison of `3.5` and `3.6`; I have only checked libraries that were written down as updated.
