### PR TITLE
Improve SSR raymarching performance

### DIFF
--- a/servers/rendering/renderer_rd/effects/ss_effects.h
+++ b/servers/rendering/renderer_rd/effects/ss_effects.h
@@ -422,14 +422,11 @@ private:
 	// SSR Scale
 
 	struct ScreenSpaceReflectionScalePushConstant {
-		int32_t screen_size[2];
-		float camera_z_near;
-		float camera_z_far;
+		float inv_projection[16];
 
-		uint32_t orthogonal;
+		int32_t screen_size[2];
 		uint32_t filter;
-		uint32_t view_index;
-		uint32_t pad1;
+		uint32_t pad;
 	};
 
 	struct ScreenSpaceReflectionScale {
@@ -447,23 +444,14 @@ private:
 	};
 
 	struct ScreenSpaceReflectionPushConstant {
-		float proj_info[4]; // 16 - 16
+		int32_t screen_size[2];
+		int32_t num_steps;
+		float depth_tolerance;
 
-		int32_t screen_size[2]; //  8 - 24
-		float camera_z_near; //  4 - 28
-		float camera_z_far; //  4 - 32
-
-		int32_t num_steps; //  4 - 36
-		float depth_tolerance; //  4 - 40
-		float distance_fade; //  4 - 44
-		float curve_fade_in; //  4 - 48
-
-		uint32_t orthogonal; //  4 - 52
-		float filter_mipmap_levels; //  4 - 56
-		uint32_t use_half_res; //  4 - 60
-		uint32_t view_index; //  4 - 64
-
-		// float projection[16];			// this is in our ScreenSpaceReflectionSceneData now
+		float distance_fade;
+		float curve_fade_in;
+		uint32_t view_index;
+		uint32_t pad;
 	};
 
 	struct ScreenSpaceReflection {
@@ -477,16 +465,16 @@ private:
 	// SSR Filter
 
 	struct ScreenSpaceReflectionFilterPushConstant {
-		float proj_info[4]; // 16 - 16
+		float proj_info[4];
 
-		uint32_t orthogonal; //  4 - 20
-		float edge_tolerance; //  4 - 24
-		int32_t increment; //  4 - 28
-		uint32_t view_index; //  4 - 32
+		uint32_t pad;
+		float edge_tolerance;
+		int32_t increment;
+		uint32_t view_index;
 
-		int32_t screen_size[2]; //  8 - 40
-		uint32_t vertical; //  4 - 44
-		uint32_t steps; //  4 - 48
+		int32_t screen_size[2];
+		uint32_t vertical;
+		uint32_t steps;
 	};
 
 	enum SSRReflectionMode {

--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection_inc.glsl
@@ -1,28 +1,12 @@
 layout(constant_id = 0) const bool sc_multiview = false;
 
 layout(set = 4, binding = 0, std140) uniform SceneData {
-	mat4x4 projection[2];
-	mat4x4 inv_projection[2];
+	mat4x4 projection[2]; // With reverse-z and remap-z applied
+	mat4x4 inv_projection[2]; // With reverse-z and remap-z applied
 	vec4 eye_offset[2];
 }
 scene_data;
 
-vec3 reconstructCSPosition(vec2 screen_pos, float z) {
-	if (sc_multiview) {
-		vec4 pos;
-		pos.xy = (2.0 * vec2(screen_pos) / vec2(params.screen_size)) - 1.0;
-		pos.z = z * 2.0 - 1.0;
-		pos.w = 1.0;
-
-		pos = scene_data.inv_projection[params.view_index] * pos;
-		pos.xyz /= pos.w;
-
-		return pos.xyz;
-	} else {
-		if (params.orthogonal) {
-			return vec3(-(screen_pos.xy * params.proj_info.xy + params.proj_info.zw), z);
-		} else {
-			return vec3((screen_pos.xy * params.proj_info.xy + params.proj_info.zw) * z, z);
-		}
-	}
+float z_ndc_from_view(vec2 ndc, float view_z) {
+	return (ndc.x * (view_z * scene_data.inv_projection[params.view_index][0][3] - scene_data.inv_projection[params.view_index][0][2]) + ndc.y * (view_z * scene_data.inv_projection[params.view_index][1][3] - scene_data.inv_projection[params.view_index][1][2]) + (view_z * scene_data.inv_projection[params.view_index][3][3] - scene_data.inv_projection[params.view_index][3][2])) / (-view_z * scene_data.inv_projection[params.view_index][2][3] + scene_data.inv_projection[params.view_index][2][2]);
 }


### PR DESCRIPTION
This PR brings a major rewrite of the **Screen Space Reflection raymarching code**, targetting performance optimization :

- Implements a **DDA algorithm** that marches the ray simultaneously in ndc and homogeneous view space, as described in "[Efficient GPU Screen-Space Ray Tracing](https://jcgt.org/published/0003/04/04/paper.pdf)" (Morgan McGuire and al.).
- Produces a **linear depth buffer during the scale pre-pass** (this was actually already the case for the single-eye setup, but not for VR). In conjunction with homogeneous view space marching, this removes the need for any reprojection in the ray marching loop.
- ~Removes **normal-roughness buffer fetches** during marching, utilized to perform backface culling~. Backface culling is now performed by comparing the current and previous samples' depth and rejecting hits when the ray exits the volume, instead of fetching the normal-roughness buffer.
- **[Edit] normal-roughness buffer fetches** are repurposed to perform holes filling at sharp angles and/or long distances.
- **Solves 2 issues** :
  - rays didn't pass behind objects resulting in long hollow trails (see captures below). These are now gone and in the worst case replaced by smaller holes corresponding to the object footprint on the surface behind
  - SSR code doesn't depend anymore on any camera attributes reconstruction method (like `Projection::get_z_far()` or `Projection::is_orthogonal()`). These can break under certain circumstances, typically when the zfar / znear ratio is very large, the projection matrix becomes infinite and it's not possible to extract zfar anymore from it

- Hopefully improves **code readability** and establishes a good foundation for further improvements. A few ideas I leave to further PRs :
  - Ray striding and jittering, as described in the above paper. This allows marching farther with the same number of samples without deteriorating image quality too much
  - Add a binary search pass to refine the hit points [as suggested here](https://zznewclear13.github.io/posts/screen-space-reflection-en/#binary-search)
  - Hierarchical-Z approaches involving pre-computed z-buffer mip-maps to speed up marching even further

## Visual differences
Cube roughness is 0.2, floor roughness is 0.0.
Depth threshold is 0.1.
Raymarching 512 steps.

This is the single-eye case. **Any help to test it in VR is welcome.**
Also, any test with more complex scenes would be appreciated.

| Before | With this PR |
|---|---|
| ![Capture d’écran du 2024-11-25 15-14-25](https://github.com/user-attachments/assets/302a2ed8-358f-4240-af15-c12be5829088) | ![image](https://github.com/user-attachments/assets/eed36084-ba69-4443-88bc-9f4473b54560) |

## Performance improvements

> [!WARNING]
> **These benchmaks needs an update**. This PR has evolved since its inception. The performance improvements should now be less aggressive than what's described below, but visual quality is now on-par with master.

These should be material for **both single-eye and VR setups**. Although I couldn't get it statistically measured (I couldn't sort out yet the render graph messing up debug markers, despite active support from @clayjohn @Ansraer and @DarioSamo), the GPU traces below show clues of a ~20% compute time reduction.

In this context, please take the below with a grain of salt as it is my interpretation (also please ignore the markers) :
 1. might be the scale pass, left pretty much unchanged in single-eye setup
 2. is likely the core ray marching logic, optimized by ~50% after this PR
 3. looks like the filter pass, although it's pretty much left untouched by this PR and I don't get why it would be longer

**Any help on making this analysis stronger is welcome.**

**Top chart** : before
**Bottom chart** : with this PR

![image](https://github.com/user-attachments/assets/3d424b21-62db-44f8-b8f2-50b1ec581142)
