### PR TITLE
Android: `OS.create_instance()` should return `-1` on failure

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -1123,7 +1123,7 @@ class Godot(private val context: Context) {
 
 	@Keep
 	private fun createNewGodotInstance(args: Array<String>): Int {
-		return primaryHost?.onNewGodotInstanceRequested(args) ?: 0
+		return primaryHost?.onNewGodotInstanceRequested(args) ?: -1
 	}
 
 	@Keep

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
@@ -474,7 +474,7 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 		if (parentHost != null) {
 			return parentHost.onNewGodotInstanceRequested(args);
 		}
-		return 0;
+		return -1;
 	}
 
 	@Override

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotHost.java
@@ -92,7 +92,7 @@ public interface GodotHost {
 	 * @return the id of the new instance. See {@code onGodotForceQuit}
 	 */
 	default int onNewGodotInstanceRequested(String[] args) {
-		return 0;
+		return -1;
 	}
 
 	/**

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -863,6 +863,9 @@ Error OS_Android::create_process(const String &p_path, const List<String> &p_arg
 
 Error OS_Android::create_instance(const List<String> &p_arguments, ProcessID *r_child_id) {
 	int instance_id = godot_java->create_new_godot_instance(p_arguments);
+	if (instance_id == -1) {
+		return FAILED;
+	}
 	if (r_child_id) {
 		*r_child_id = instance_id;
 	}


### PR DESCRIPTION
I was checking if `OS.create_instance()` worked in exported Android games (it does not - it's unimplemented) and found that it returns `0`, however, [according to the docs](https://docs.godotengine.org/en/latest/classes/class_os.html#class-os-method-create-instance) it should return `-1` on failure.

Also, within the engine itself, the `OS::get_singleton()->create_instance()` returns `Error` rather than the PID integer, and that would return `OK` in exported Android games, whereas it should probably return `FAILED`, because it doesn't actually work.

A super minor thing because it's unimplemented, but if someone wrote cross-platform code and expected `-1` in the case of failure, it could potentially create problems.