### PR TITLE
Enable Godot reinstantiation on iOS for embedding in a single view

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1587,3 +1587,7 @@ ProjectSettings::~ProjectSettings() {
 		singleton = nullptr;
 	}
 }
+
+void ProjectSettings::reset() {
+	singleton = nullptr;
+}

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -222,6 +222,7 @@ public:
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 #endif
+	static void reset();
 
 	ProjectSettings();
 	ProjectSettings(const String &p_path);

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -301,4 +301,5 @@ GDExtensionManager::~GDExtensionManager() {
 #ifndef DISABLE_DEPRECATED
 	GDExtensionCompatHashes::finalize();
 #endif
+	singleton = nullptr;
 }

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -127,6 +127,8 @@ PackedData::~PackedData() {
 		memdelete(sources[i]);
 	}
 	_free_packed_dirs(root);
+
+	singleton = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -232,6 +232,7 @@ ZipArchive::~ZipArchive() {
 	}
 
 	packages.clear();
+	instance = nullptr;
 }
 
 Error FileAccessZip::open_internal(const String &p_path, int p_mode_flags) {

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -351,4 +351,5 @@ IP::~IP() {
 	resolver->thread.wait_to_finish();
 
 	memdelete(resolver);
+	singleton = nullptr;
 }

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -267,4 +267,5 @@ ResourceUID::ResourceUID() {
 }
 ResourceUID::~ResourceUID() {
 	memdelete((CryptoCore::RandomGenerator *)crypto);
+	singleton = nullptr;
 }

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2321,5 +2321,8 @@ void ObjectDB::cleanup() {
 		memfree(object_slots);
 	}
 
+	slot_count = 0;
+	slot_max = 0;
+	object_slots = nullptr;
 	spin_lock.unlock();
 }

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -42,6 +42,8 @@
 #include "core/templates/local_vector.h"
 #include "core/variant/typed_array.h"
 
+bool Object::initialized = false;
+
 #ifdef DEBUG_ENABLED
 
 struct _ObjectDebugLock {
@@ -1504,7 +1506,6 @@ Variant Object::_get_indexed_bind(const NodePath &p_name) const {
 }
 
 void Object::initialize_class() {
-	static bool initialized = false;
 	if (initialized) {
 		return;
 	}
@@ -2319,6 +2320,7 @@ void ObjectDB::cleanup() {
 
 	if (object_slots) {
 		memfree(object_slots);
+		object_slots = nullptr;
 	}
 
 	slot_count = 0;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1506,13 +1506,15 @@ Variant Object::_get_indexed_bind(const NodePath &p_name) const {
 }
 
 void Object::initialize_class() {
-	if (initialized) {
+	static int local_version = -1;
+	if (Main::version == local_version) {
 		return;
 	}
 	ClassDB::_add_class<Object>();
 	_bind_methods();
 	_bind_compatibility_methods();
 	initialized = true;
+	local_version++;
 }
 
 String Object::tr(const StringName &p_message, const StringName &p_context) const {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -43,6 +43,7 @@
 #include "core/templates/safe_refcount.h"
 #include "core/variant/callable_bind.h"
 #include "core/variant/variant.h"
+#include "main/main.h"
 
 template <typename T>
 class TypedArray;
@@ -457,8 +458,8 @@ protected:                                                                      
                                                                                                                                                  \
 public:                                                                                                                                          \
 	static void initialize_class() {                                                                                                             \
-		static bool initialized = false;                                                                                                         \
-		if (initialized) {                                                                                                                       \
+		static int local_version = -1;                                                                                                    	     \
+		if (Main::version == local_version) {                                                                                         			 \
 			return;                                                                                                                              \
 		}                                                                                                                                        \
 		m_inherits::initialize_class();                                                                                                          \
@@ -469,7 +470,7 @@ public:                                                                         
 		if (m_class::_get_bind_compatibility_methods() != m_inherits::_get_bind_compatibility_methods()) {                                       \
 			_bind_compatibility_methods();                                                                                                       \
 		}                                                                                                                                        \
-		initialized = true;                                                                                                                      \
+		local_version++;                                                                                                                  		 \
 	}                                                                                                                                            \
                                                                                                                                                  \
 protected:                                                                                                                                       \
@@ -600,6 +601,8 @@ public:
 		Connection() {}
 		Connection(const Variant &p_variant);
 	};
+
+	static bool initialized;
 
 private:
 #ifdef DEBUG_ENABLED

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -766,11 +766,20 @@ protected:
 	Variant _call_deferred_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	virtual const StringName *_get_class_namev() const {
-		static StringName _class_name_static;
-		if (unlikely(!_class_name_static)) {
-			StringName::assign_static_unique_class_name(&_class_name_static, "Object");
+		static std::queue<StringName> _class_name_statics;
+		static int local_version = -1;
+		if (unlikely(Main::version != local_version)) {
+			local_version = Main::version;
+			if (_class_name_statics.size() > 0) {
+				/* TODO: pop unused references */
+				/*_class_name_statics.pop();*/
+			}
+			_class_name_statics.push(StringName());
+		}     
+		if (unlikely(!_class_name_statics.back())) {
+			StringName::assign_static_unique_class_name(&_class_name_statics.back(), "Object");
 		}
-		return &_class_name_static;
+		return &_class_name_statics.back();
 	}
 
 	TypedArray<StringName> _get_meta_list_bind() const;

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -169,16 +169,11 @@ bool StringName::operator!=(const StringName &p_name) const {
 }
 
 void StringName::operator=(const StringName &p_name) {
-	static int local_version = 0;
 	if (this == &p_name) {
 		return;
 	}
 
-	if (Main::version != local_version) {
-		local_version = Main::version;
-	} else {
-		unref();
-	}
+	unref();
 
 	if (p_name._data && p_name._data->refcount.ref()) {
 		_data = p_name._data;

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -169,11 +169,16 @@ bool StringName::operator!=(const StringName &p_name) const {
 }
 
 void StringName::operator=(const StringName &p_name) {
+	static int local_version = 0;
 	if (this == &p_name) {
 		return;
 	}
 
-	unref();
+	if (Main::version != local_version) {
+		local_version = Main::version;
+	} else {
+		unref();
+	}
 
 	if (p_name._data && p_name._data->refcount.ref()) {
 		_data = p_name._data;

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -213,6 +213,15 @@ StringName _scs_create(const char *p_chr, bool p_static = false);
  * Use in places that can be called hundreds of times per frame (or more) is recommended, but this situation is very rare. If in doubt, do not use.
  */
 
-#define SNAME(m_arg) ([]() -> const StringName & { static StringName sname = _scs_create(m_arg, true); return sname; })()
+// TODO: reinstate caching
+#define SNAME(m_arg) ([]() -> const StringName & {         \
+	static std::queue<StringName> snames;                  \
+	static int local_version = -1;                         \
+	if (unlikely(Main::version != local_version)) {        \
+		local_version = Main::version;                     \
+		snames.push(_scs_create(m_arg, true));             \
+	}                                                      \
+	return snames.back();                                  \
+})()
 
 #endif // STRING_NAME_H

--- a/core/templates/paged_allocator.h
+++ b/core/templates/paged_allocator.h
@@ -115,6 +115,10 @@ private:
 			available_pool = nullptr;
 			pages_allocated = 0;
 			allocs_available = 0;
+
+			page_shift = 0;
+			page_mask = 0;
+			page_size = 0;
 		}
 	}
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4530,4 +4530,5 @@ void Main::cleanup(bool p_force) {
 	FramebufferCacheRD::reset();
 	Object::initialized = false; // TODO: create a proper Object::finalize() method
 	Main::version++;
+	AudioDriverManager::reset();
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -85,6 +85,7 @@
 #include "servers/physics_server_3d.h"
 #include "servers/xr_server.h"
 #endif // _3D_DISABLED
+#include "servers/rendering/renderer_rd/framebuffer_cache_rd.h"
 
 #ifdef TESTS_ENABLED
 #include "tests/test_main.h"
@@ -4509,6 +4510,7 @@ void Main::cleanup(bool p_force) {
 		memdelete(steam_tracker);
 	}
 #endif
+	ProjectSettings::reset();
 
 	unregister_core_driver_types();
 	unregister_core_extensions();
@@ -4524,6 +4526,8 @@ void Main::cleanup(bool p_force) {
 	OS::get_singleton()->benchmark_dump();
 
 	OS::get_singleton()->finalize_core();
+
+	FramebufferCacheRD::reset();
 	Object::initialized = false; // TODO: create a proper Object::finalize() method
 	Main::version++;
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -259,6 +259,7 @@ static const String NULL_AUDIO_DRIVER("Dummy");
 // (excluding the 2-space left and right margins).
 // Currently, this is `--export-release <preset> <path>`.
 static const int OPTION_COLUMN_LENGTH = 32;
+int Main::version = 0;
 
 /* Helper methods */
 
@@ -4523,4 +4524,6 @@ void Main::cleanup(bool p_force) {
 	OS::get_singleton()->benchmark_dump();
 
 	OS::get_singleton()->finalize_core();
+	Object::initialized = false; // TODO: create a proper Object::finalize() method
+	Main::version++;
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4528,7 +4528,7 @@ void Main::cleanup(bool p_force) {
 	OS::get_singleton()->finalize_core();
 
 	FramebufferCacheRD::reset();
-	Object::initialized = false; // TODO: create a proper Object::finalize() method
+	Object::initialized = false;
 	Main::version++;
 	AudioDriverManager::reset();
 }

--- a/main/main.h
+++ b/main/main.h
@@ -61,6 +61,7 @@ class Main {
 
 public:
 	static bool is_cmdline_tool();
+	static int version;
 #ifdef TOOLS_ENABLED
 	enum CLIScope {
 		CLI_SCOPE_TOOL, // Editor and project manager.

--- a/modules/navigation/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/2d/nav_mesh_generator_2d.cpp
@@ -80,6 +80,7 @@ NavMeshGenerator2D::NavMeshGenerator2D() {
 
 NavMeshGenerator2D::~NavMeshGenerator2D() {
 	cleanup();
+	singleton = nullptr;
 }
 
 void NavMeshGenerator2D::sync() {

--- a/modules/navigation/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_generator_3d.cpp
@@ -93,6 +93,7 @@ NavMeshGenerator3D::NavMeshGenerator3D() {
 
 NavMeshGenerator3D::~NavMeshGenerator3D() {
 	cleanup();
+	singleton = nullptr;
 }
 
 void NavMeshGenerator3D::sync() {

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -59,6 +59,7 @@ def generate_bundle(target, source, env):
 
 
 ios_lib = [
+    "godot_ios_wrapper.mm",
     "godot_ios.mm",
     "os_ios.mm",
     "main.m",

--- a/platform/ios/app_delegate.h
+++ b/platform/ios/app_delegate.h
@@ -42,6 +42,8 @@
 //#endif
 
 @property(strong, nonatomic) UIWindow *window;
-@property(strong, class, readonly, nonatomic) ViewController *viewController;
+@property(strong, class, nonatomic) ViewController *viewController;
++ (void)focusIn;
++ (void)focusOut;
 
 @end

--- a/platform/ios/app_delegate.mm
+++ b/platform/ios/app_delegate.mm
@@ -66,6 +66,10 @@ static ViewController *mainViewController = nil;
 	return mainViewController;
 }
 
++ (void)setViewController:(ViewController *)newVC {
+	mainViewController = newVC;
+}
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 	// TODO: might be required to make an early return, so app wouldn't crash because of timeout.
 	// TODO: logo screen is not displayed while shaders are compiling
@@ -181,6 +185,14 @@ static ViewController *mainViewController = nil;
 
 - (void)dealloc {
 	self.window = nil;
+}
+
++ (void)focusIn {
+    OS_IOS::get_singleton()->on_focus_in();
+}
+
++ (void)focusOut {
+    OS_IOS::get_singleton()->on_focus_out();
 }
 
 @end

--- a/platform/ios/godot_ios_wrapper.h
+++ b/platform/ios/godot_ios_wrapper.h
@@ -1,0 +1,10 @@
+// godot_ios_wrapper.h
+
+#import <Foundation/Foundation.h>
+
+@interface GodotIosWrapper : NSObject
+
++ (void)ios_finish_wrapper;
++ (int)ios_main_wrapper:(int)argc argv:(char **)argv;
+
+@end

--- a/platform/ios/godot_ios_wrapper.mm
+++ b/platform/ios/godot_ios_wrapper.mm
@@ -1,0 +1,18 @@
+// godot_ios_wrapper.mm
+
+#import "godot_ios_wrapper.h"
+
+@implementation GodotIosWrapper
+
+extern int ios_main(int, char **);
+extern void ios_finish();
+
++ (void)ios_finish_wrapper {
+    ios_finish();
+}
+
++ (int)ios_main_wrapper:(int)argc argv:(char **)argv {
+    return ios_main(argc, argv);
+}
+
+@end

--- a/platform/web/api/api.cpp
+++ b/platform/web/api/api.cpp
@@ -60,7 +60,9 @@ JavaScriptBridge::JavaScriptBridge() {
 	singleton = this;
 }
 
-JavaScriptBridge::~JavaScriptBridge() {}
+JavaScriptBridge::~JavaScriptBridge() {
+	singleton = nullptr;
+}
 
 void JavaScriptBridge::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("eval", "code", "use_global_execution_context"), &JavaScriptBridge::eval, DEFVAL(false));

--- a/scene/main/multiplayer_api.h
+++ b/scene/main/multiplayer_api.h
@@ -76,7 +76,9 @@ public:
 	bool is_server() { return get_unique_id() == MultiplayerPeer::TARGET_PEER_SERVER; }
 
 	MultiplayerAPI() {}
-	virtual ~MultiplayerAPI() {}
+	virtual ~MultiplayerAPI() {
+		default_interface = StringName();
+	}
 };
 
 VARIANT_ENUM_CAST(MultiplayerAPI::RPCMode);

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -213,6 +213,16 @@ int AudioDriverManager::get_driver_count() {
 	return driver_count;
 }
 
+void AudioDriverManager::reset() {
+	AudioDriverManager::driver_count = 1;
+
+	for (int i = 0; i < driver_count; i++) {
+		drivers[i] = nullptr;
+	}
+
+	drivers[0] = &AudioDriverManager::dummy_driver;
+}
+
 void AudioDriverManager::initialize(int p_driver) {
 	GLOBAL_DEF_RST("audio/driver/enable_input", false);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "audio/driver/mix_rate", PROPERTY_HINT_RANGE, "11025,192000,1,or_greater,suffix:Hz"), DEFAULT_MIX_RATE);

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -175,6 +175,7 @@ public:
 	static void initialize(int p_driver);
 	static int get_driver_count();
 	static AudioDriver *get_driver(int p_driver);
+	static void reset();
 };
 
 class AudioBusLayout;

--- a/servers/rendering/renderer_compositor.cpp
+++ b/servers/rendering/renderer_compositor.cpp
@@ -39,6 +39,7 @@ RendererCompositor *(*RendererCompositor::_create_func)() = nullptr;
 bool RendererCompositor::low_end = false;
 
 RendererCompositor *RendererCompositor::create() {
+	RendererCompositor::singleton = nullptr;
 	return _create_func();
 }
 

--- a/servers/rendering/renderer_rd/framebuffer_cache_rd.h
+++ b/servers/rendering/renderer_rd/framebuffer_cache_rd.h
@@ -308,6 +308,7 @@ public:
 	static RID get_cache_multipass_array(const TypedArray<RID> &p_textures, const TypedArray<RDFramebufferPass> &p_passes, uint32_t p_views = 1);
 
 	static FramebufferCacheRD *get_singleton() { return singleton; }
+	static void reset() { singleton = nullptr; }
 
 	FramebufferCacheRD();
 	~FramebufferCacheRD();


### PR DESCRIPTION
Partially adresses : https://github.com/godotengine/godot-proposals/issues/1473.

The goal is to be able to run Godot from within a classically-made mobile app (think Snapchat Games). As underlined in the umbrella issue, several things will still be missing after this PR is merged :
1. **boot splashscreen management** : a way to enable / disable the boot splashscreen at will
2. **export configuration** : supporting project export as either an embeddable or a full-fledged standalone app

We faced many issues related to instanciating Godot several times. We fixed all of them, but are unsure for some fixes ; specificially, we came up using a queue to store `StringName` references. We are iOS developers and we're humble about our C++ knowledge, but we're committed to make this work ; any feedback is therefore much appreciated.

While the ability to embed Godot is functional with this PR, some manual adjustments are still required. An example implementation demonstrating how to embed Godot in a basic mobile app is available in our repository: [here](https://github.com/bamlab/EmbeddableGodot).