### PR TITLE
[Buildsystem] Tweak cache sizes for CI

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -25,18 +25,21 @@ jobs:
             target: editor
             tests: false
             sconsflags: arch=arm64 production=yes swappy=yes
+            cache-limit: 1
 
           - name: Template arm32 (target=template_release, arch=arm32)
             cache-name: android-template-arm32
             target: template_release
             tests: false
             sconsflags: arch=arm32 swappy=yes
+            cache-limit: 1
 
           - name: Template arm64 (target=template_release, arch=arm64)
             cache-name: android-template-arm64
             target: template_release
             tests: false
             sconsflags: arch=arm64 swappy=yes
+            cache-limit: 1
 
     steps:
       - name: Checkout
@@ -77,6 +80,7 @@ jobs:
           platform: android
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+          scons-cache-limit: ${{ matrix.cache-limit }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -37,6 +37,7 @@ jobs:
           platform: ios
           target: template_release
           tests: false
+          scons-cache-limit: 1
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -35,6 +35,7 @@ jobs:
             proj-conv: true
             api-compat: true
             artifact: true
+            cache-limit: 1
 
           - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=gold)
             cache-name: linux-editor-double-sanitizers
@@ -49,6 +50,7 @@ jobs:
             api-dump: true
             # Skip 2GiB artifact speeding up action.
             artifact: false
+            cache-limit: 7
 
           - name: Editor with clang sanitizers (target=editor, tests=yes, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-llvm-sanitizers
@@ -61,6 +63,7 @@ jobs:
             artifact: false
             # Test our oldest supported SCons/Python versions on one arbitrary editor build.
             legacy-scons: true
+            cache-limit: 7
 
           - name: Editor with ThreadSanitizer (target=editor, tests=yes, dev_build=yes, use_tsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-thread-sanitizer
@@ -71,6 +74,7 @@ jobs:
             build-mono: false
             # Skip 2GiB artifact speeding up action.
             artifact: false
+            cache-limit: 5
 
           - name: Template w/ Mono (target=template_release, tests=yes)
             cache-name: linux-template-mono
@@ -80,6 +84,7 @@ jobs:
             build-mono: false
             tests: true
             artifact: true
+            cache-limit: 1
 
           - name: Minimal template (target=template_release, tests=yes, everything disabled)
             cache-name: linux-template-minimal
@@ -88,6 +93,7 @@ jobs:
             bin: ./bin/godot.linuxbsd.template_release.x86_64
             tests: true
             artifact: true
+            cache-limit: 1
 
     steps:
       - name: Checkout
@@ -143,6 +149,7 @@ jobs:
           platform: linuxbsd
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+          scons-cache-limit: ${{ matrix.cache-limit }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -25,6 +25,7 @@ jobs:
             target: editor
             tests: true
             bin: ./bin/godot.macos.editor.universal
+            cache-limit: 1
 
           - name: Template (target=template_release, tests=yes)
             cache-name: macos-template
@@ -32,6 +33,7 @@ jobs:
             tests: true
             sconsflags: debug_symbols=no
             bin: ./bin/godot.macos.template_release.universal
+            cache-limit: 1
 
     steps:
       - name: Checkout
@@ -59,6 +61,7 @@ jobs:
           platform: macos
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+          scons-cache-limit: 0 # Only cap on second run to avoid purging unnecessarily
 
       - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
@@ -67,6 +70,7 @@ jobs:
           platform: macos
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+          scons-cache-limit: ${{ matrix.cache-limit }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -67,6 +67,7 @@ jobs:
           platform: web
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+          scons-cache-limit: 0.5
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -31,6 +31,7 @@ jobs:
             sconsflags: debug_symbols=no vsproj=yes vsproj_gen_only=no windows_subsystem=console
             bin: ./bin/godot.windows.editor.x86_64.exe
             compiler: msvc
+            cache-limit: 2
 
           - name: Editor w/ clang-cl (target=editor, tests=yes, use_llvm=yes)
             cache-name: windows-editor-clang
@@ -39,6 +40,7 @@ jobs:
             sconsflags: debug_symbols=no windows_subsystem=console use_llvm=yes
             bin: ./bin/godot.windows.editor.x86_64.llvm.exe
             compiler: clang
+            cache-limit: 1
 
           - name: Template (target=template_release, tests=yes)
             cache-name: windows-template
@@ -47,6 +49,7 @@ jobs:
             sconsflags: debug_symbols=no
             bin: ./bin/godot.windows.template_release.x86_64.console.exe
             compiler: msvc
+            cache-limit: 2
 
           - name: Template w/ GCC (target=template_release, tests=yes, use_mingw=yes)
             cache-name: windows-template-gcc
@@ -56,6 +59,7 @@ jobs:
             sconsflags: debug_symbols=no use_mingw=yes
             bin: ./bin/godot.windows.template_release.x86_64.console.exe
             compiler: gcc
+            cache-limit: 1
 
     steps:
       - name: Checkout
@@ -101,6 +105,7 @@ jobs:
           platform: windows
           target: ${{ matrix.target }}
           tests: ${{ matrix.tests }}
+          scons-cache-limit: ${{ matrix.cache-limit }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save


### PR DESCRIPTION
The default cache limit of 7 GiB gives a lot of space for caching but is significantly larger than needed for most targets for CI

With successive builds changes build up, unnecessarily increasing cache use for each entry. This is especially true with major changes to core headers etc.

This was the cause of the issues resolved by:
* https://github.com/godotengine/godot/pull/96752

The limits were chosen from a complete rebuild with an empty cache going in, then doubling the needed space (and generally rounding up), for a few cases the limit was left at 7 GiB as the cache space required was already more than half of that, or around that limit. This should give us space for growth, and allow using the cache for back-and-forth changes, while still trying to save space. Things add up and with 18 artifacts per PR and run (all but two of which now reduced in size) something as small as a few tens of MiB per artifact is a lot of saved space.

The specific cache sizes are fully up for tweaking, picked these as a mix between giving room for growth and clamping at a reasonable limit.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
