### PR TITLE
Fix UID support in MultiplayerSpawner

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -145,7 +145,12 @@ String ResourceUID::uid_to_path(const String &p_uid) {
 }
 
 String ResourceUID::path_to_uid(const String &p_path) {
-	return singleton->id_to_text(ResourceLoader::get_resource_uid(p_path));
+	const ID id = ResourceLoader::get_resource_uid(p_path);
+	if (id == INVALID_ID) {
+		return p_path;
+	} else {
+		return singleton->id_to_text(id);
+	}
 }
 
 String ResourceUID::ensure_path(const String &p_uid_or_path) {

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -46,7 +46,7 @@ bool MultiplayerSpawner::_set(const StringName &p_name, const Variant &p_value) 
 		if (ns.begins_with("scenes/")) {
 			uint32_t index = ns.get_slicec('/', 1).to_int();
 			ERR_FAIL_UNSIGNED_INDEX_V(index, spawnable_scenes.size(), false);
-			spawnable_scenes[index].path = p_value;
+			spawnable_scenes[index].path = ResourceUID::ensure_path(p_value);
 			return true;
 		}
 	}
@@ -62,7 +62,7 @@ bool MultiplayerSpawner::_get(const StringName &p_name, Variant &r_ret) const {
 		if (ns.begins_with("scenes/")) {
 			uint32_t index = ns.get_slicec('/', 1).to_int();
 			ERR_FAIL_UNSIGNED_INDEX_V(index, spawnable_scenes.size(), false);
-			r_ret = spawnable_scenes[index].path;
+			r_ret = ResourceUID::path_to_uid(spawnable_scenes[index].path);
 			return true;
 		}
 	}
@@ -97,15 +97,9 @@ PackedStringArray MultiplayerSpawner::get_configuration_warnings() const {
 
 void MultiplayerSpawner::add_spawnable_scene(const String &p_path) {
 	SpawnableScene sc;
-	if (p_path.begins_with("uid://")) {
-		sc.uid = p_path;
-		sc.path = ResourceUID::uid_to_path(p_path);
-	} else {
-		sc.uid = ResourceUID::path_to_uid(p_path);
-		sc.path = p_path;
-	}
+	sc.path = ResourceUID::ensure_path(p_path);
 	if (Engine::get_singleton()->is_editor_hint()) {
-		ERR_FAIL_COND(!ResourceLoader::exists(p_path));
+		ERR_FAIL_COND(!ResourceLoader::exists(sc.path));
 	}
 	spawnable_scenes.push_back(sc);
 #ifdef TOOLS_ENABLED
@@ -145,7 +139,7 @@ Vector<String> MultiplayerSpawner::_get_spawnable_scenes() const {
 	Vector<String> ss;
 	ss.resize(spawnable_scenes.size());
 	for (int i = 0; i < ss.size(); i++) {
-		ss.write[i] = spawnable_scenes[i].uid;
+		ss.write[i] = ResourceUID::path_to_uid(spawnable_scenes[i].path);
 	}
 	return ss;
 }

--- a/modules/multiplayer/multiplayer_spawner.h
+++ b/modules/multiplayer/multiplayer_spawner.h
@@ -49,7 +49,6 @@ public:
 private:
 	struct SpawnableScene {
 		String path;
-		String uid;
 		Ref<PackedScene> cache;
 	};
 


### PR DESCRIPTION
Fixes #99706

The bug occurred because setting a path will use `_set()` on path index, instead of `_set_spawnable_scenes()`. idk how I missed it previously.

The main problem is that MultiplayerSpawner *must* operate on paths, but the editor wants it to store the paths as UID. I removed the uid field added in #99137. Now all paths are stored as paths internally, but saved as UID, with the conversion happening inside setters/getters. This might affect scene loading, but shouldn't impact performance of the spawner's operation.