### PR TITLE
Fix vsync on macOS getting disabled when using `afterMinimumDuration`

### DIFF
--- a/drivers/metal/rendering_context_driver_metal.mm
+++ b/drivers/metal/rendering_context_driver_metal.mm
@@ -172,7 +172,11 @@ public:
 		count--;
 		front = (front + 1) % frame_buffers.size();
 
-		[p_cmd_buffer->get_command_buffer() presentDrawable:drawable afterMinimumDuration:present_minimum_duration];
+		if (vsync_mode != DisplayServer::VSYNC_DISABLED) {
+			[p_cmd_buffer->get_command_buffer() presentDrawable:drawable afterMinimumDuration:present_minimum_duration];
+		} else {
+			[p_cmd_buffer->get_command_buffer() presentDrawable:drawable];
+		}
 	}
 };
 


### PR DESCRIPTION
Calling afterMinimumDuration with 0.0 will implicitly enable vsync so need to work around that.

Fixes https://github.com/godotengine/godot/issues/99657#issuecomment-2501743024