### PR TITLE
Fix removing last digit in spinbox while `update_on_text_changed` is true

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -68,6 +68,10 @@ void SpinBox::_update_text(bool p_keep_line_edit) {
 }
 
 void SpinBox::_text_submitted(const String &p_string) {
+	if (p_string.is_empty()) {
+		return;
+	}
+
 	Ref<Expression> expr;
 	expr.instantiate();
 
@@ -284,8 +288,8 @@ void SpinBox::_line_edit_editing_toggled(bool p_toggled_on) {
 			line_edit->select_all();
 		}
 	} else {
-		// Discontinue because the focus_exit was caused by canceling.
-		if (Input::get_singleton()->is_action_pressed("ui_cancel")) {
+		// Discontinue because the focus_exit was caused by canceling or the text is empty.
+		if (Input::get_singleton()->is_action_pressed("ui_cancel") || line_edit->get_text().is_empty()) {
 			_update_text();
 			return;
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: https://github.com/godotengine/godot/issues/99281

As the issue explains currently if you have update_on_text_changed set to true, you are unable to delete the last digit which is janky since it gets appended to any subsequent digits that you type. This PR fixes it by ignoring submittals of empty text and if empty texted is accepted via enter/escape the previous value is used.

https://github.com/user-attachments/assets/3fc03f73-d58c-4511-8e20-8108947504d5

