### PR TITLE
Fix changing scene during `_init` causing the first scene to not unload

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1537,6 +1537,8 @@ Error SceneTree::change_scene_to_packed(const Ref<PackedScene> &p_scene) {
 		// Let as many side effects as possible happen or be queued now,
 		// so they are run before the scene is actually deleted.
 		root->remove_child(current_scene);
+	} else {
+		possible_uninitialized_scene = true;
 	}
 	DEV_ASSERT(!current_scene);
 
@@ -1562,7 +1564,12 @@ void SceneTree::unload_current_scene() {
 void SceneTree::add_current_scene(Node *p_current) {
 	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "Adding a current scene can only be done from the main thread.");
 	current_scene = p_current;
-	root->add_child(p_current);
+	if (!possible_uninitialized_scene) {
+		root->add_child(p_current);
+	} else {
+		WARN_PRINT("Avoid changing scene before the current scene is ready. Try putting the change in the _ready function instead.");
+		possible_uninitialized_scene = false;
+	}
 }
 
 Ref<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, bool p_process_always, bool p_process_in_physics, bool p_ignore_time_scale) {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -190,6 +190,7 @@ private:
 	Node *current_scene = nullptr;
 	Node *prev_scene = nullptr;
 	Node *pending_new_scene = nullptr;
+	bool possible_uninitialized_scene = false;
 
 	Color debug_collisions_color;
 	Color debug_collision_contact_color;


### PR DESCRIPTION
Fixes #99651
