### PR TITLE
Automatically expand a resource after creating it in the inspector

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3396,6 +3396,14 @@ void EditorPropertyResource::_set_read_only(bool p_read_only) {
 }
 
 void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource, bool p_inspect) {
+	_select_resource(p_resource, p_inspect, false);
+}
+
+void EditorPropertyResource::_resource_expand_requested(const Ref<Resource> &p_resource, bool p_inspect) {
+	_select_resource(p_resource, p_inspect, true);
+}
+
+void EditorPropertyResource::_select_resource(const Ref<Resource> &p_resource, bool p_inspect, bool p_force_open) {
 	if (p_resource->is_built_in() && !p_resource->get_path().is_empty()) {
 		String parent = p_resource->get_path().get_slice("::", 0);
 		List<String> extensions;
@@ -3413,7 +3421,10 @@ void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource,
 	}
 
 	if (!p_inspect && use_sub_inspector) {
-		bool unfold = !get_edited_object()->editor_is_section_unfolded(get_edited_property());
+		bool unfold = p_force_open;
+		if (!unfold) {
+			unfold = !get_edited_object()->editor_is_section_unfolded(get_edited_property());
+		}
 		get_edited_object()->editor_set_section_unfold(get_edited_property(), unfold);
 		user_opened_editor = unfold;
 		update_property();
@@ -3649,6 +3660,7 @@ void EditorPropertyResource::setup(Object *p_object, const String &p_path, const
 
 	resource_picker->connect("resource_selected", callable_mp(this, &EditorPropertyResource::_resource_selected));
 	resource_picker->connect("resource_changed", callable_mp(this, &EditorPropertyResource::_resource_changed));
+	resource_picker->connect("_resource_expand_requested", callable_mp(this, &EditorPropertyResource::_resource_expand_requested));
 
 	for (int i = 0; i < resource_picker->get_child_count(); i++) {
 		Button *b = Object::cast_to<Button>(resource_picker->get_child(i));

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -751,6 +751,8 @@ class EditorPropertyResource : public EditorProperty {
 	bool user_opened_editor = false;
 
 	void _resource_selected(const Ref<Resource> &p_resource, bool p_inspect);
+	void _resource_expand_requested(const Ref<Resource> &p_resource, bool p_inspect);
+	void _select_resource(const Ref<Resource> &p_resource, bool p_inspect, bool p_force_open);
 	void _resource_changed(const Ref<Resource> &p_resource);
 
 	Node *_get_base_node();

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -640,6 +640,12 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			Ref<Resource> old_edited_resource = edited_resource;
 			edited_resource = resp;
 			_resource_changed();
+
+			if (edited_resource.is_valid() && bool(EDITOR_GET("interface/inspector/open_resources_in_current_inspector"))) {
+				// Expand newly created resources, as the user will most likely want to change at least one property within the resource.
+				// This is disabled when resources are forcibly opened in a new inspector, as it would be too intrusive.
+				emit_signal(SNAME("_resource_expand_requested"), edited_resource, false);
+			}
 		} break;
 	}
 }
@@ -1058,6 +1064,7 @@ void EditorResourcePicker::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, Resource::get_class_static()), PropertyInfo(Variant::BOOL, "inspect")));
 	ADD_SIGNAL(MethodInfo("resource_changed", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, Resource::get_class_static())));
+	ADD_SIGNAL(MethodInfo("_resource_expand_requested", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, Resource::get_class_static()), PropertyInfo(Variant::BOOL, "inspect")));
 }
 
 void EditorResourcePicker::_notification(int p_what) {


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/88647 (can be merged independently).

This reduces the number of mouse clicks needed to set up various nodes, such as MeshInstance3D and GPUParticles3D.

This is only effective if Open Resources in Current Inspector is enabled in the editor settings (which is the default).

- This closes https://github.com/godotengine/godot-proposals/issues/6278.

## Preview

https://github.com/user-attachments/assets/6918c24b-57d7-487b-a3a9-8c70a20a0b73


