### PR TITLE
Fix code consistency between AudioStreamPlayer2D and AudioStreamPlayer3D

### DIFF
--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -553,7 +553,7 @@ void AudioStreamPlayer3D::play(float p_from_pos) {
 	setplay.set(p_from_pos);
 
 	// Sample handling.
-	if (stream_playback->get_is_sample()) {
+	if (stream_playback->get_is_sample() && stream_playback->get_sample_playback().is_valid()) {
 		Ref<AudioSamplePlayback> sample_playback = stream_playback->get_sample_playback();
 		sample_playback->offset = p_from_pos;
 		sample_playback->bus = _get_actual_bus();
@@ -563,10 +563,7 @@ void AudioStreamPlayer3D::play(float p_from_pos) {
 }
 
 void AudioStreamPlayer3D::seek(float p_seconds) {
-	if (is_playing()) {
-		stop();
-		play(p_seconds);
-	}
+	internal->seek(p_seconds);
 }
 
 void AudioStreamPlayer3D::stop() {


### PR DESCRIPTION
This started with the intention to fix\ https://github.com/godotengine/godot/issues/99699 but it doesn't work that way.

I saw some very noticeable difference between 2D and 3D, in both `play()` and `seek()`. These came from https://github.com/godotengine/godot/pull/91382