### PR TITLE
Ensure primitive meshes are created before connected to `changed` signal.

### DIFF
--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -65,6 +65,9 @@ void MeshInstance2D::set_mesh(const Ref<Mesh> &p_mesh) {
 	mesh = p_mesh;
 
 	if (mesh.is_valid()) {
+		// If mesh is a PrimitiveMesh, calling get_rid on it can trigger a changed callback
+		// so do this before connecting to the change signal.
+		mesh->get_rid();
 		mesh->connect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
 	}
 


### PR DESCRIPTION
Primitive meshes are special in that they aren't created until calling one of their methods which cause it to actually create the mesh resources.  If this is not done early enough, a changed signal can be triggered from an unexpected thread resulting in a threading warning.

This follows the pattern of [mesh_instance_3d](https://github.com/godotengine/godot/blob/d09d82d433b03bb3773fd2a8cc8d6ccc2f8739ce/scene/3d/mesh_instance_3d.cpp#L112) which also does this before connecting to the change signal.  Future cleanup could provide a better means to populate the meshes.

Closes #99661. 


