### PR TITLE
Disable Clear Guides menu item when no guides exist

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4423,6 +4423,14 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 	te->commit_insert_queue();
 }
 
+void CanvasItemEditor::_prepare_view_menu() {
+	PopupMenu *popup = view_menu->get_popup();
+
+	Node *root = EditorNode::get_singleton()->get_edited_scene();
+	bool has_guides = root && (root->has_meta("_edit_horizontal_guides_") || root->has_meta("_edit_vertical_guides_"));
+	popup->set_item_disabled(popup->get_item_index(CLEAR_GUIDES), !has_guides);
+}
+
 void CanvasItemEditor::_popup_callback(int p_op) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	last_option = MenuOption(p_op);
@@ -5536,9 +5544,10 @@ CanvasItemEditor::CanvasItemEditor() {
 	view_menu->set_switch_on_hover(true);
 	view_menu->set_shortcut_context(this);
 	main_menu_hbox->add_child(view_menu);
-	view_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &CanvasItemEditor::_popup_callback));
 
 	p = view_menu->get_popup();
+	p->connect(SceneStringName(id_pressed), callable_mp(this, &CanvasItemEditor::_popup_callback));
+	p->connect("about_to_popup", callable_mp(this, &CanvasItemEditor::_prepare_view_menu));
 	p->set_hide_on_checkable_item_selection(false);
 
 	grid_menu = memnew(PopupMenu);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -403,6 +403,7 @@ private:
 	Vector2 _anchor_to_position(const Control *p_control, Vector2 anchor);
 	Vector2 _position_to_anchor(const Control *p_control, Vector2 position);
 
+	void _prepare_view_menu();
 	void _popup_callback(int p_op);
 	bool updating_scroll = false;
 	void _update_scroll(real_t);


### PR DESCRIPTION
Clear Guides does nothing when there are no guides available.

![clear_guides](https://github.com/user-attachments/assets/f84a92f0-5204-4ca9-b97c-1d1b8e301ef0)
