### PR TITLE
Use Vector4 for texture mask in BaseMaterial to avoid converting to and from Plane

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2737,13 +2737,13 @@ float BaseMaterial3D::get_grow() const {
 	return grow;
 }
 
-static Plane _get_texture_mask(BaseMaterial3D::TextureChannel p_channel) {
-	static const Plane masks[5] = {
-		Plane(1, 0, 0, 0),
-		Plane(0, 1, 0, 0),
-		Plane(0, 0, 1, 0),
-		Plane(0, 0, 0, 1),
-		Plane(0.3333333, 0.3333333, 0.3333333, 0),
+static Vector4 _get_texture_mask(BaseMaterial3D::TextureChannel p_channel) {
+	static const Vector4 masks[5] = {
+		Vector4(1, 0, 0, 0),
+		Vector4(0, 1, 0, 0),
+		Vector4(0, 0, 1, 0),
+		Vector4(0, 0, 0, 1),
+		Vector4(0.3333333, 0.3333333, 0.3333333, 0),
 	};
 
 	return masks[p_channel];


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/84633
Fixes: https://github.com/godotengine/godot/issues/99663
Supersedes: https://github.com/godotengine/godot/pull/84650

It seems like ShaderMaterial doesn't serialize Plane properly (or it doesn't handle converting back and forth between Plane and Vector4 gracefully). #84650 fixes the issue by forcing the plane to become a Vector4 during conversion, but the solution can be even cleaner by just never using a Plane. 

The fact that this change fixes the issue hints at a deeper issue with how we serialize shader params as both Plane and Vector should work fine. But we should go ahead with this small fix for now and investigate deeper later if necessary. 
