### PR TITLE
[MP] Move OfflineMultiplayerPeer docs to the module

### DIFF
--- a/modules/multiplayer/config.py
+++ b/modules/multiplayer/config.py
@@ -12,6 +12,7 @@ def get_doc_classes():
         "SceneMultiplayer",
         "MultiplayerSpawner",
         "MultiplayerSynchronizer",
+        "OfflineMultiplayerPeer",
     ]
 
 

--- a/modules/multiplayer/doc_classes/OfflineMultiplayerPeer.xml
+++ b/modules/multiplayer/doc_classes/OfflineMultiplayerPeer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="OfflineMultiplayerPeer" inherits="MultiplayerPeer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="OfflineMultiplayerPeer" inherits="MultiplayerPeer" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		A [MultiplayerPeer] which is always connected and acts as a server.
 	</brief_description>


### PR DESCRIPTION
Was missing from the module config, causing the XML to be added to the main doc folder