### PR TITLE
Simplify depth reprojection code

### DIFF
--- a/servers/rendering/renderer_rd/effects/bokeh_dof.cpp
+++ b/servers/rendering/renderer_rd/effects/bokeh_dof.cpp
@@ -88,7 +88,7 @@ BokehDOF::~BokehDOF() {
 	}
 }
 
-void BokehDOF::bokeh_dof_compute(const BokehBuffers &p_buffers, RID p_camera_attributes, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal) {
+void BokehDOF::bokeh_dof_compute(const BokehBuffers &p_buffers, RID p_camera_attributes, const Projection &p_camera) {
 	ERR_FAIL_COND_MSG(prefer_raster_effects, "Can't use compute version of bokeh depth of field with the mobile renderer.");
 
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
@@ -125,9 +125,14 @@ void BokehDOF::bokeh_dof_compute(const BokehBuffers &p_buffers, RID p_camera_att
 	bokeh.push_constant.use_jitter = use_jitter;
 	bokeh.push_constant.jitter_seed = Math::randf() * 1000.0;
 
-	bokeh.push_constant.z_near = p_cam_znear;
-	bokeh.push_constant.z_far = p_cam_zfar;
-	bokeh.push_constant.orthogonal = p_cam_orthogonal;
+	Projection correction;
+	correction.set_depth_correction(false);
+	Projection corrected = correction * p_camera;
+
+	bokeh.push_constant.proj_zw[0][0] = corrected[2][2];
+	bokeh.push_constant.proj_zw[0][1] = corrected[2][3];
+	bokeh.push_constant.proj_zw[1][0] = corrected[3][2];
+	bokeh.push_constant.proj_zw[1][1] = corrected[3][3];
 	bokeh.push_constant.blur_size = (dof_near_size < 0.0 && dof_far_size < 0.0) ? 32 : bokeh_size; // Cap with physically-based to keep performance reasonable.
 
 	bokeh.push_constant.second_pass = false;
@@ -294,7 +299,7 @@ void BokehDOF::bokeh_dof_compute(const BokehBuffers &p_buffers, RID p_camera_att
 	RD::get_singleton()->compute_list_end();
 }
 
-void BokehDOF::bokeh_dof_raster(const BokehBuffers &p_buffers, RID p_camera_attributes, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal) {
+void BokehDOF::bokeh_dof_raster(const BokehBuffers &p_buffers, RID p_camera_attributes, const Projection &p_camera) {
 	ERR_FAIL_COND_MSG(!prefer_raster_effects, "Can't blur-based depth of field with the clustered renderer.");
 
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
@@ -316,11 +321,17 @@ void BokehDOF::bokeh_dof_raster(const BokehBuffers &p_buffers, RID p_camera_attr
 	// setup our base push constant
 	memset(&bokeh.push_constant, 0, sizeof(BokehPushConstant));
 
-	bokeh.push_constant.orthogonal = p_cam_orthogonal;
 	bokeh.push_constant.size[0] = p_buffers.base_texture_size.width;
 	bokeh.push_constant.size[1] = p_buffers.base_texture_size.height;
-	bokeh.push_constant.z_far = p_cam_zfar;
-	bokeh.push_constant.z_near = p_cam_znear;
+
+	Projection correction;
+	correction.set_depth_correction(false);
+	Projection corrected = correction * p_camera;
+
+	bokeh.push_constant.proj_zw[0][0] = corrected[2][2];
+	bokeh.push_constant.proj_zw[0][1] = corrected[2][3];
+	bokeh.push_constant.proj_zw[1][0] = corrected[3][2];
+	bokeh.push_constant.proj_zw[1][1] = corrected[3][3];
 
 	bokeh.push_constant.second_pass = false;
 	bokeh.push_constant.half_size = false;

--- a/servers/rendering/renderer_rd/effects/bokeh_dof.h
+++ b/servers/rendering/renderer_rd/effects/bokeh_dof.h
@@ -43,32 +43,30 @@ private:
 
 	struct BokehPushConstant {
 		uint32_t size[2];
-		float z_far;
-		float z_near;
-
-		uint32_t orthogonal;
 		float blur_size;
 		float blur_scale;
-		uint32_t steps;
 
+		float proj_zw[2][2]; // Bottom-right 2x2 corner of the projection matrix with reverse-z and z-remap applied
+
+		uint32_t steps;
 		uint32_t blur_near_active;
 		float blur_near_begin;
 		float blur_near_end;
-		uint32_t blur_far_active;
 
+		uint32_t blur_far_active;
 		float blur_far_begin;
 		float blur_far_end;
 		uint32_t second_pass;
-		uint32_t half_size;
 
+		uint32_t half_size;
 		uint32_t use_jitter;
 		float jitter_seed;
 		uint32_t use_physical_near;
-		uint32_t use_physical_far;
 
+		uint32_t use_physical_far;
 		float blur_size_near;
 		float blur_size_far;
-		uint32_t pad[2];
+		uint32_t pad[1];
 	};
 
 	enum BokehMode {
@@ -113,8 +111,8 @@ public:
 	BokehDOF(bool p_prefer_raster_effects);
 	~BokehDOF();
 
-	void bokeh_dof_compute(const BokehBuffers &p_buffers, RID p_camera_attributes, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
-	void bokeh_dof_raster(const BokehBuffers &p_buffers, RID p_camera_attributes, float p_cam_znear, float p_cam_zfar, bool p_cam_orthogonal);
+	void bokeh_dof_compute(const BokehBuffers &p_buffers, RID p_camera_attributes, const Projection &p_camera);
+	void bokeh_dof_raster(const BokehBuffers &p_buffers, RID p_camera_attributes, const Projection &p_camera);
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -466,7 +466,7 @@ void CopyEffects::copy_octmap_to_panorama(RID p_source_octmap, RID p_dest_panora
 	copy.push_constant.section[3] = p_panorama_size.height;
 	copy.push_constant.target[0] = 0;
 	copy.push_constant.target[1] = 0;
-	copy.push_constant.camera_z_far = p_lod;
+	copy.push_constant.lod = p_lod;
 	copy.push_constant.octmap_border_size[0] = p_source_octmap_border_size.x;
 	copy.push_constant.octmap_border_size[1] = p_source_octmap_border_size.y;
 
@@ -529,7 +529,7 @@ void CopyEffects::copy_depth_to_rect(RID p_source_rd_texture, RID p_dest_texture
 	RD::get_singleton()->compute_list_end();
 }
 
-void CopyEffects::copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y, float p_z_near, float p_z_far) {
+void CopyEffects::copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y, const Projection &p_projection) {
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -546,8 +546,10 @@ void CopyEffects::copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID 
 	copy.push_constant.section[3] = p_rect.size.height;
 	copy.push_constant.target[0] = p_rect.position.x;
 	copy.push_constant.target[1] = p_rect.position.y;
-	copy.push_constant.camera_z_far = p_z_far;
-	copy.push_constant.camera_z_near = p_z_near;
+	copy.push_constant.proj_zw[0][0] = p_projection[2][2];
+	copy.push_constant.proj_zw[0][1] = p_projection[2][3];
+	copy.push_constant.proj_zw[1][0] = p_projection[3][2];
+	copy.push_constant.proj_zw[1][1] = p_projection[3][3];
 
 	// setup our uniforms
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
@@ -1079,7 +1081,7 @@ void CopyEffects::set_color_raster(RID p_dest_texture, const Color &p_color, con
 	RD::get_singleton()->draw_list_end();
 }
 
-void CopyEffects::copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, float p_z_near, float p_z_far, bool p_dp_flip) {
+void CopyEffects::copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, const Projection &p_projection, float p_z_far, bool p_dp_flip) {
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
 	ERR_FAIL_NULL(uniform_set_cache);
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -1094,8 +1096,11 @@ void CopyEffects::copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuf
 	screen_rect.size.height = (int32_t)(Math::round(p_dst_size.height));
 
 	CopyToDPPushConstant push_constant;
+	push_constant.proj_zw[0][0] = p_projection[2][2];
+	push_constant.proj_zw[0][1] = p_projection[2][3];
+	push_constant.proj_zw[1][0] = p_projection[3][2];
+	push_constant.proj_zw[1][1] = p_projection[3][3];
 	push_constant.z_far = p_z_far;
-	push_constant.z_near = p_z_near;
 	push_constant.texel_size[0] = 1.0f / p_dst_size.width;
 	push_constant.texel_size[1] = 1.0f / p_dst_size.height;
 	push_constant.texel_size[0] *= p_dp_flip ? -1.0f : 1.0f; // Encode dp flip as x size sign

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -147,21 +147,24 @@ private:
 		int32_t target[2];
 		uint32_t flags;
 		float luminance_multiplier;
+
+		float lod;
 		// Glow.
 		float glow_strength;
 		float glow_bloom;
 		float glow_hdr_threshold;
-		float glow_hdr_scale;
 
+		float glow_hdr_scale;
 		float glow_exposure;
 		float glow_white;
 		float glow_luminance_cap;
+
 		float glow_auto_exposure_scale;
-		// DOF.
-		float camera_z_far;
-		float camera_z_near;
+		float padding;
 		// Octmap.
 		float octmap_border_size[2];
+		// DOF.
+		float proj_zw[2][2]; // Bottom-right 2x2 corner of the projection matrix
 		//SET color
 		float set_color[4];
 	};
@@ -222,8 +225,9 @@ private:
 	// Copy to DP
 
 	struct CopyToDPPushConstant {
+		float proj_zw[2][2]; // Bottom-right 2x2 corner of the projection matrix in OpenGL format (no reverse-z, no Y-flip, no z-remap)
 		float z_far;
-		float z_near;
+		uint32_t pad;
 		float texel_size[2];
 	};
 
@@ -372,7 +376,7 @@ public:
 	void copy_to_rect(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_all_source = false, bool p_8_bit_dst = false, bool p_alpha_to_one = false, bool p_sanitize_inf_nan = false);
 	void copy_octmap_to_panorama(RID p_source_octmap, RID p_dest_panorama, const Size2i &p_panorama_size, float p_lod, bool p_is_array, const Size2 &p_source_octmap_border_size);
 	void copy_depth_to_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false);
-	void copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y, float p_z_near, float p_z_far);
+	void copy_depth_to_rect_and_linearize(RID p_source_rd_texture, RID p_dest_texture, const Rect2i &p_rect, bool p_flip_y, const Projection &p_projection);
 	void copy_to_fb_rect(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2i &p_rect, bool p_flip_y = false, bool p_force_luminance = false, bool p_alpha_to_zero = false, bool p_srgb = false, RID p_secondary = RID(), bool p_multiview = false, bool alpha_to_one = false, bool p_linear = false, bool p_normal = false, const Rect2 &p_src_rect = Rect2(), float p_linear_luminance_multiplier = 1.0);
 	void copy_to_atlas_fb(RID p_source_rd_texture, RID p_dest_framebuffer, const Rect2 &p_uv_rect, RD::DrawListID p_draw_list, bool p_flip_y = false, bool p_panorama = false);
 	void copy_to_drawlist(RD::DrawListID p_draw_list, RD::FramebufferFormatID p_fb_format, RID p_source_rd_texture, bool p_linear = false, float p_linear_luminance_multiplier = 1.0);
@@ -390,7 +394,7 @@ public:
 	void set_color(RID p_dest_texture, const Color &p_color, const Rect2i &p_region, bool p_8bit_dst = false);
 	void set_color_raster(RID p_dest_texture, const Color &p_color, const Rect2i &p_region);
 
-	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, float p_z_near, float p_z_far, bool p_dp_flip);
+	void copy_cubemap_to_dp(RID p_source_rd_texture, RID p_dst_framebuffer, const Rect2 &p_rect, const Vector2 &p_dst_size, const Projection &p_projection, float p_z_far, bool p_dp_flip);
 	void copy_cubemap_to_octmap(RID p_source_rd_texture, RID p_dst_framebuffer, float p_border_size);
 	void octmap_downsample(RID p_source_octmap, RID p_dest_octmap, const Size2i &p_size, float p_border_size);
 	void octmap_downsample_raster(RID p_source_octmap, RID p_dest_framebuffer, const Size2i &p_size, float p_border_size);

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -577,19 +577,10 @@ void SSEffects::downsample_depth(Ref<RenderSceneBuffersRD> p_render_buffers, uin
 	correction.set_depth_correction(false);
 	Projection temp = correction * p_projection;
 
-	float depth_linearize_mul = -temp.columns[3][2];
-	float depth_linearize_add = temp.columns[2][2];
-	if (depth_linearize_mul * depth_linearize_add < 0) {
-		depth_linearize_add = -depth_linearize_add;
-	}
-
-	ss_effects.downsample_push_constant.orthogonal = p_projection.is_orthogonal();
-	ss_effects.downsample_push_constant.z_near = depth_linearize_mul;
-	ss_effects.downsample_push_constant.z_far = depth_linearize_add;
-	if (ss_effects.downsample_push_constant.orthogonal) {
-		ss_effects.downsample_push_constant.z_near = p_projection.get_z_near();
-		ss_effects.downsample_push_constant.z_far = p_projection.get_z_far();
-	}
+	ss_effects.downsample_push_constant.proj_zw[0][0] = temp[2][2];
+	ss_effects.downsample_push_constant.proj_zw[0][1] = temp[2][3];
+	ss_effects.downsample_push_constant.proj_zw[1][0] = temp[3][2];
+	ss_effects.downsample_push_constant.proj_zw[1][1] = temp[3][3];
 	ss_effects.downsample_push_constant.pixel_size[0] = 1.0 / full_screen_size.x;
 	ss_effects.downsample_push_constant.pixel_size[1] = 1.0 / full_screen_size.y;
 	ss_effects.downsample_push_constant.radius_sq = 1.0;
@@ -777,8 +768,10 @@ void SSEffects::screen_space_indirect_lighting(Ref<RenderSceneBuffersRD> p_rende
 		ssil.gather_push_constant.NDC_to_view_mul[1] = tan_half_fov_y * -2.0;
 		ssil.gather_push_constant.NDC_to_view_add[0] = tan_half_fov_x * -1.0;
 		ssil.gather_push_constant.NDC_to_view_add[1] = tan_half_fov_y;
-		ssil.gather_push_constant.z_near = p_projection.get_z_near();
-		ssil.gather_push_constant.z_far = p_projection.get_z_far();
+		ssil.gather_push_constant.proj_zw[0][0] = p_projection[2][2];
+		ssil.gather_push_constant.proj_zw[0][1] = p_projection[2][3];
+		ssil.gather_push_constant.proj_zw[1][0] = p_projection[3][2];
+		ssil.gather_push_constant.proj_zw[1][1] = p_projection[3][3];
 		ssil.gather_push_constant.is_orthogonal = p_projection.is_orthogonal();
 
 		ssil.gather_push_constant.radius = p_settings.radius;
@@ -1765,12 +1758,17 @@ void SSEffects::sub_surface_scattering(Ref<RenderSceneBuffersRD> p_render_buffer
 	p.normal /= p.d;
 	float unit_size = p.normal.x;
 
+	Projection correction;
+	correction.set_depth_correction(false);
+	Projection temp = correction * p_camera;
+
 	{ //scale color and depth to half
 		RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 
-		sss.push_constant.camera_z_far = p_camera.get_z_far();
-		sss.push_constant.camera_z_near = p_camera.get_z_near();
-		sss.push_constant.orthogonal = p_camera.is_orthogonal();
+		sss.push_constant.proj_zw[0][0] = temp[2][2];
+		sss.push_constant.proj_zw[0][1] = temp[2][3];
+		sss.push_constant.proj_zw[1][0] = temp[3][2];
+		sss.push_constant.proj_zw[1][1] = temp[3][3];
 		sss.push_constant.unit_size = unit_size;
 		sss.push_constant.screen_size[0] = p_screen_size.x;
 		sss.push_constant.screen_size[1] = p_screen_size.y;

--- a/servers/rendering/renderer_rd/effects/ss_effects.h
+++ b/servers/rendering/renderer_rd/effects/ss_effects.h
@@ -187,11 +187,9 @@ private:
 
 	struct SSEffectsDownsamplePushConstant {
 		float pixel_size[2];
-		float z_far;
-		float z_near;
-		uint32_t orthogonal;
 		float radius_sq;
-		uint32_t pad[2];
+		uint32_t pad[1];
+		float proj_zw[2][2]; // Bottom-right 2x2 corner of the projection matrix with reverse-z and z-remap applied
 	};
 
 	enum SSEffectsMode {
@@ -253,9 +251,7 @@ private:
 		float NDC_to_view_mul[2];
 		float NDC_to_view_add[2];
 
-		float pad2[2];
-		float z_near;
-		float z_far;
+		float proj_zw[2][2]; // Bottom-right 2x2 corner of the projection matrix in OpenGL standard form (no reverse-z, no z-remap)
 
 		float radius;
 		float intensity;
@@ -509,16 +505,14 @@ private:
 
 	struct SubSurfaceScatteringPushConstant {
 		int32_t screen_size[2];
-		float camera_z_far;
-		float camera_z_near;
-
 		uint32_t vertical;
-		uint32_t orthogonal;
 		float unit_size;
-		float scale;
 
+		float proj_zw[2][2]; // Bottom-right 2x2 corner of the projection matrix with reverse-z and z-remap applied
+
+		float scale;
 		float depth_scale;
-		uint32_t pad[3];
+		uint32_t pad[2];
 	};
 
 	struct SubSurfaceScattering {

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3903,9 +3903,14 @@ void GI::process_gi(Ref<RenderSceneBuffersRD> p_render_buffers, const RID *p_nor
 	push_constant.high_quality_vct = voxel_gi_quality == RS::VOXEL_GI_QUALITY_HIGH;
 
 	// these should be the same for all views
-	push_constant.orthogonal = p_projections[0].is_orthogonal();
-	push_constant.z_near = p_projections[0].get_z_near();
-	push_constant.z_far = p_projections[0].get_z_far();
+	Projection correction;
+	correction.set_depth_correction(false);
+	Projection corrected = correction * p_projections[0];
+
+	push_constant.proj_zw[0][0] = corrected[2][2];
+	push_constant.proj_zw[0][1] = corrected[2][3];
+	push_constant.proj_zw[1][0] = corrected[3][2];
+	push_constant.proj_zw[1][1] = corrected[3][3];
 
 	// these are only used if we have 1 view, else we use the projections in our scene data
 	push_constant.proj_info[0] = -2.0f / (internal_size.x * p_projections[0].columns[0][0]);

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -783,10 +783,7 @@ public:
 
 		float proj_info[4];
 
-		float z_near;
-		float z_far;
-		float pad2;
-		float pad3;
+		float proj_zw[2][2]; // Bottom-right 2x2 corner of the projection matrix with reverse-z and z-remap applied
 	};
 
 	RID sdfgi_ubo;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2736,9 +2736,9 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 			Rect2 atlas_rect_norm = atlas_rect;
 			atlas_rect_norm.position /= float(atlas_size);
 			atlas_rect_norm.size /= float(atlas_size);
-			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection.get_z_near(), zfar, false);
+			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection, zfar, false);
 			atlas_rect_norm.position += Vector2(dual_paraboloid_offset) * atlas_rect_norm.size;
-			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection.get_z_near(), zfar, true);
+			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection, zfar, true);
 
 			//restore transform so it can be properly used
 			light_storage->light_instance_set_shadow_transform(p_light, Projection(), light_storage->light_instance_get_base_transform(p_light), zfar, 0, 0, 0);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1527,9 +1527,9 @@ void RenderForwardMobile::_render_shadow_pass(RID p_light, RID p_shadow_atlas, i
 			Rect2 atlas_rect_norm = atlas_rect;
 			atlas_rect_norm.position /= float(atlas_size);
 			atlas_rect_norm.size /= float(atlas_size);
-			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection.get_z_near(), zfar, false);
+			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection, zfar, false);
 			atlas_rect_norm.position += Vector2(dual_paraboloid_offset) * atlas_rect_norm.size;
-			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection.get_z_near(), zfar, true);
+			copy_effects->copy_cubemap_to_dp(render_texture, atlas_fb, atlas_rect_norm, atlas_rect.size, light_projection, zfar, true);
 
 			//restore transform so it can be properly used
 			light_storage->light_instance_set_shadow_transform(p_light, Projection(), light_storage->light_instance_get_base_transform(p_light), zfar, 0, 0, 0);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -514,10 +514,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 				buffers.base_texture = use_upscaled_texture ? rb->get_upscaled_texture(i) : rb->get_internal_texture(i);
 				buffers.depth_texture = rb->get_depth_texture(i);
 
-				// In stereo p_render_data->z_near and p_render_data->z_far can be offset for our combined frustum.
-				float z_near = p_render_data->scene_data->view_projection[i].get_z_near();
-				float z_far = p_render_data->scene_data->view_projection[i].get_z_far();
-				bokeh_dof->bokeh_dof_compute(buffers, p_render_data->camera_attributes, z_near, z_far, p_render_data->scene_data->cam_orthogonal);
+				bokeh_dof->bokeh_dof_compute(buffers, p_render_data->camera_attributes, p_render_data->scene_data->view_projection[i]);
 			};
 		} else {
 			// Set framebuffers.
@@ -537,10 +534,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 				buffers.depth_texture = p_use_msaa ? rb->get_texture_slice(RB_SCOPE_BUFFERS, RB_TEX_BACK_DEPTH, i, 0) : rb->get_depth_texture(i);
 				buffers.base_fb = FramebufferCacheRD::get_singleton()->get_cache(buffers.base_texture); // TODO move this into bokeh_dof_raster, we can do this internally
 
-				// In stereo p_render_data->z_near and p_render_data->z_far can be offset for our combined frustum.
-				float z_near = p_render_data->scene_data->view_projection[i].get_z_near();
-				float z_far = p_render_data->scene_data->view_projection[i].get_z_far();
-				bokeh_dof->bokeh_dof_raster(buffers, p_render_data->camera_attributes, z_near, z_far, p_render_data->scene_data->cam_orthogonal);
+				bokeh_dof->bokeh_dof_raster(buffers, p_render_data->camera_attributes, p_render_data->scene_data->view_projection[i]);
 			}
 		}
 		RD::get_singleton()->draw_command_end_label();

--- a/servers/rendering/renderer_rd/shaders/effects/bokeh_dof.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/bokeh_dof.glsl
@@ -30,13 +30,8 @@ layout(set = 1, binding = 0) uniform sampler2D source_bokeh;
 #ifdef MODE_GEN_BLUR_SIZE
 
 float get_depth_at_pos(vec2 uv) {
-	float depth = textureLod(source_depth, uv, 0.0).x * 2.0 - 1.0;
-	if (params.orthogonal) {
-		depth = -(depth * (params.z_far - params.z_near) - (params.z_far + params.z_near)) / 2.0;
-	} else {
-		depth = 2.0 * params.z_near * params.z_far / (params.z_far + params.z_near + depth * (params.z_far - params.z_near));
-	}
-	return depth;
+	float depth = textureLod(source_depth, uv, 0.0).x;
+	return -(params.proj_zw[1][0] - params.proj_zw[1][1] * depth) / (params.proj_zw[0][1] * depth - params.proj_zw[0][0]);
 }
 
 float get_blur_size(float depth) {

--- a/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_inc.glsl
@@ -1,31 +1,29 @@
 layout(push_constant, std430) uniform Params {
 	ivec2 size;
-	float z_far;
-	float z_near;
-
-	bool orthogonal;
 	float blur_size;
 	float blur_scale;
-	int blur_steps;
 
+	mat2 proj_zw; // Bottom-right 2x2 corner of the projection matrix with reverse-z and z-remap applied
+
+	int blur_steps;
 	bool blur_near_active;
 	float blur_near_begin;
 	float blur_near_end;
-	bool blur_far_active;
 
+	bool blur_far_active;
 	float blur_far_begin;
 	float blur_far_end;
 	bool second_pass;
-	bool half_size;
 
+	bool half_size;
 	bool use_jitter;
 	float jitter_seed;
 	bool use_physical_near;
-	bool use_physical_far;
 
+	bool use_physical_far;
 	float blur_size_near;
 	float blur_size_far;
-	uint pad[2];
+	uint pad[1];
 }
 params;
 

--- a/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/bokeh_dof_raster.glsl
@@ -65,12 +65,7 @@ layout(set = 2, binding = 0) uniform sampler2D original_weight;
 
 float get_depth_at_pos(vec2 uv) {
 	float depth = textureLod(source_depth, uv, 0.0).x * 2.0 - 1.0;
-	if (params.orthogonal) {
-		depth = -(depth * (params.z_far - params.z_near) - (params.z_far + params.z_near)) / 2.0;
-	} else {
-		depth = 2.0 * params.z_near * params.z_far / (params.z_far + params.z_near + depth * (params.z_far - params.z_near));
-	}
-	return depth;
+	return -(params.proj_zw[1][0] - params.proj_zw[1][1] * depth) / (params.proj_zw[0][1] * depth - params.proj_zw[0][0]);
 }
 
 float get_blur_size(float depth) {

--- a/servers/rendering/renderer_rd/shaders/effects/copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/copy.glsl
@@ -24,21 +24,24 @@ layout(push_constant, std430) uniform Params {
 	ivec2 target;
 	uint flags;
 	float luminance_multiplier;
+
+	uint lod;
 	// Glow.
 	float glow_strength;
 	float glow_bloom;
 	float glow_hdr_threshold;
-	float glow_hdr_scale;
 
+	float glow_hdr_scale;
 	float glow_exposure;
 	float glow_white;
 	float glow_luminance_cap;
+
 	float glow_auto_exposure_scale;
-	// DOF.
-	float camera_z_far;
-	float camera_z_near;
+	float padding;
 	// Octmap.
 	vec2 octmap_border_size;
+	// DOF.
+	mat2 proj_zw; // Bottom-right 2x2 corner of the projection matrix
 
 	vec4 set_color;
 }
@@ -254,15 +257,13 @@ void main() {
 #ifdef MODE_LINEARIZE_DEPTH_COPY
 
 	float depth = texelFetch(source_color, pos + params.section.xy, 0).r;
-	depth = depth * 2.0 - 1.0;
-	depth = 2.0 * params.camera_z_near * params.camera_z_far / (params.camera_z_far + params.camera_z_near - depth * (params.camera_z_far - params.camera_z_near));
-	vec4 color = vec4(depth / params.camera_z_far);
+	depth = (params.proj_zw[1][0] - params.proj_zw[1][1] * depth) / (params.proj_zw[0][1] * depth - params.proj_zw[0][0]);
 
 	if (bool(params.flags & FLAG_FLIP_Y)) {
 		pos.y = params.section.w - pos.y - 1;
 	}
 
-	imageStore(dest_buffer, pos + params.target, color);
+	imageStore(dest_buffer, pos + params.target, vec4(depth));
 #endif // MODE_LINEARIZE_DEPTH_COPY
 
 #if defined(MODE_OCTMAP_TO_PANORAMA) || defined(MODE_OCTMAP_ARRAY_TO_PANORAMA)
@@ -281,9 +282,9 @@ void main() {
 	normal.z = cos(phi) * sin(theta) * -1.0;
 
 #ifdef MODE_OCTMAP_TO_PANORAMA
-	vec4 color = textureLod(source_color, vec3_to_oct_with_border(normal, params.octmap_border_size), params.camera_z_far); //the biggest the lod the least the acne
+	vec4 color = textureLod(source_color, vec3_to_oct_with_border(normal, params.octmap_border_size), params.lod); //the biggest the lod the least the acne
 #else
-	vec4 color = textureLod(source_color, vec3(vec3_to_oct_with_border(normal, params.octmap_border_size), params.camera_z_far), 0.0); //the biggest the lod the least the acne
+	vec4 color = textureLod(source_color, vec3(vec3_to_oct_with_border(normal, params.octmap_border_size), params.lod), 0.0); //the biggest the lod the least the acne
 #endif
 	imageStore(dest_buffer, pos + params.target, color * params.luminance_multiplier);
 #endif // defined(MODE_OCTMAP_TO_PANORAMA) || defined(MODE_OCTMAP_ARRAY_TO_PANORAMA)

--- a/servers/rendering/renderer_rd/shaders/effects/cube_to_dp.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/cube_to_dp.glsl
@@ -5,8 +5,9 @@
 #VERSION_DEFINES
 
 layout(push_constant, std430) uniform Params {
+	float[2][2] proj_zw; // Bottom-right 2x2 corner of the projection matrix in OpenGL format (no reverse-z, no Y-flip, no z-remap)
 	float z_far;
-	float z_near;
+	uint pad;
 	vec2 texel_size;
 }
 params;
@@ -30,8 +31,9 @@ layout(location = 0) in vec2 uv_interp;
 layout(set = 0, binding = 0) uniform samplerCube source_cube;
 
 layout(push_constant, std430) uniform Params {
+	float[2][2] proj_zw; // Bottom-right 2x2 corner of the projection matrix in OpenGL format (no reverse-z, no Y-flip, no z-remap)
 	float z_far;
-	float z_near;
+	uint pad;
 	vec2 texel_size;
 }
 params;
@@ -74,7 +76,7 @@ void main() {
 	float depth_fix = 1.0 / dot(normal, unorm);
 
 	depth = 2.0 * depth - 1.0;
-	float linear_depth = 2.0 * params.z_near * params.z_far / (params.z_far + params.z_near + depth * (params.z_far - params.z_near));
+	float linear_depth = (params.proj_zw[1][1] * depth + params.proj_zw[1][0]) / (params.proj_zw[0][1] * depth + params.proj_zw[0][0]);
 	// linear_depth equal to view space depth
 	depth = (params.z_far - linear_depth * depth_fix) / params.z_far;
 	gl_FragDepth = depth;

--- a/servers/rendering/renderer_rd/shaders/effects/ssil.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/ssil.glsl
@@ -99,9 +99,7 @@ layout(push_constant, std430) uniform Params {
 	vec2 NDC_to_view_mul;
 	vec2 NDC_to_view_add;
 
-	vec2 pad2;
-	float z_near;
-	float z_far;
+	float proj_zw[2][2]; // Bottom-right 2x2 corner of the projection matrix in OpenGL standard form (no reverse-z, no z-remap)
 
 	float radius;
 	float intensity;
@@ -201,7 +199,7 @@ void SSIL_tap_inner(const int p_quality_level, inout vec3 r_color_sum, inout flo
 	}
 
 	// Translate sampling_uv to last screen's coordinates
-	const vec4 sample_pos = projection_constants.reprojection * vec4(p_sampling_uv * 2.0 - 1.0, (viewspace_sample_z - params.z_near) / (params.z_far - params.z_near) * 2.0 - 1.0, 1.0);
+	const vec4 sample_pos = projection_constants.reprojection * vec4(p_sampling_uv * 2.0 - 1.0, (params.proj_zw[1][0] - params.proj_zw[0][0] * viewspace_sample_z) / (params.proj_zw[1][1] - params.proj_zw[0][1] * viewspace_sample_z), 1.0);
 	vec2 reprojected_sampling_uv = (sample_pos.xy / sample_pos.w) * 0.5 + 0.5;
 
 	weight *= p_weight_mod;


### PR DESCRIPTION
This PR **rewrites ndc-to-view space depth reprojection code in all effects and environment shaders** : GI, SSS, SSR, SSIL, SSAO, SS downsampler, Bokeh, Copy effects and Cubemap to DP

The new code typically looks like this :
```glsl
float depth = texture(source_depth, uv).r;
depth = (proj_zw[1][0] - proj_zw[1][1] * depth) / (proj_zw[0][1] * depth - proj_zw[0][0]);
// with `proj_zw` a `mat2` that is the bottom-right 2x2 corner of the projection matrix.
```

It replaces old reprojection code which typically looks like that :
```glsl
float depth = texture(source_depth, uv).r;
depth = depth * 2.0 - 1.0;
if (is_orthogonal) {
	depth = ((depth + (z_far + z_near) / (z_far - z_near)) * (z_far - z_near)) / 2.0;
} else {
	depth = 2.0 * z_near * z_far / (z_far + z_near - depth * (z_far - z_near));
}
```

There are some slight variations depending on whether the shader expects negative or positive depth, and whether the ndc depth is reversed.

### Benefits
**1. The new code doesn't break with infinite projection matrices anymore**.

Camera attributes are typically retrieved from the projection matrix (with `Projection::is_orthogonal()`, `Projection::get_z_far()`, ...) then passed to the shaders.
Some of the above functions can break when zfar is much bigger than znear : the perspective matrix becomes infinite and zfar cannot be retrieved back from it anymore.

This change is part of the groundwork I'm carrying out to **support wider ranges of zfar / znear ratios in single precision** (today limited to ~1e6, typically zfar = 10km with znear = 0.01) which is important in open worlds and space games.

**2. It prepares the support of custom projection matrices** where it cannot be determined whether the projection is orthographic (for example with blended perspective and orthographic projections)

### Non-regression tests
Test project : [reprojection.zip](https://github.com/user-attachments/files/17936117/reprojection.zip)

**There shouldn't be any visual change after this PR** ~except for SSS, which is broken in master (see #99220 - this PR fixes it too). The screen captures for SSS below are made with 4.2.~ [**edit** : #99220 was merged]

Visual reference **before** this PR (all visuals do match after the PR - see test project) :
|   | GI | SSS | SSR | SSIL | SSAO |Bokeh | Sky | Shadows |
|---|---|---|---|---|---|---|---|---|
| Persp | ![Capture d’écran du 2024-11-27 10-33-09](https://github.com/user-attachments/assets/cb7af2d8-9b5f-4571-afbd-68fada65c350) | ![Capture d’écran du 2024-11-27 11-18-55](https://github.com/user-attachments/assets/49453c71-8e6b-4df7-a050-cfe017914903) | ![Capture d’écran du 2024-11-27 12-00-22](https://github.com/user-attachments/assets/30127c74-9d36-4125-a81d-986e345886a7) | ![Capture d’écran du 2024-11-27 10-27-06](https://github.com/user-attachments/assets/9b2b31fd-d4b7-4dcc-9846-b13a15d7003c) | ![Capture d’écran du 2024-11-27 11-31-48](https://github.com/user-attachments/assets/6a3b80b6-cedb-40fd-8228-2f194dce0923) | ![Capture d’écran du 2024-11-27 10-27-15](https://github.com/user-attachments/assets/02e13e8d-f0d4-4199-b9a2-e16239b0729b) | ![Capture d’écran du 2024-11-27 13-24-04](https://github.com/user-attachments/assets/42850345-7be5-4351-9ff5-60da6f059dad) | ![Capture d’écran du 2024-11-27 11-53-22](https://github.com/user-attachments/assets/cee80287-a8c6-48c9-bd9e-3fb9f1215f42) |
| Ortho | ![Capture d’écran du 2024-11-27 15-55-06](https://github.com/user-attachments/assets/df69e8cd-1d8e-4e96-b3f9-551f8e89f0e5) | ![Capture d’écran du 2024-11-27 15-56-05](https://github.com/user-attachments/assets/aca64750-16de-43b7-b5ea-13927845be28) | ![Capture d’écran du 2024-11-27 15-53-15](https://github.com/user-attachments/assets/831232dc-21e3-4da6-a213-dd50ec716444) | ![Capture d’écran du 2024-11-27 15-53-39](https://github.com/user-attachments/assets/216b7dd7-8a96-4bb7-bf55-c605a415cdd1) | ![Capture d’écran du 2024-11-27 15-59-03](https://github.com/user-attachments/assets/10f47e12-28ad-4775-90a0-81bb5bfc8505) | ![Capture d’écran du 2024-11-27 15-55-20](https://github.com/user-attachments/assets/069b9f32-ca6a-41ce-8327-9e7d17895d73) | ![Capture d’écran du 2024-11-27 15-54-20](https://github.com/user-attachments/assets/d9dea19a-b9a0-4a66-966e-dff8730c7506) | ![Capture d’écran du 2024-11-27 15-54-37](https://github.com/user-attachments/assets/bc8ce184-3766-4069-ab9c-e0a3477729b9) |