### PR TITLE
Add missing error prints to format-specific load/save functions

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2645,9 +2645,10 @@ Error Image::save_png(const String &p_path) const {
 }
 
 Error Image::save_jpg(const String &p_path, float p_quality) const {
-	if (save_jpg_func == nullptr) {
-		return ERR_UNAVAILABLE;
-	}
+	ERR_FAIL_NULL_V_MSG(
+			save_jpg_func,
+			ERR_UNAVAILABLE,
+			"The JPEG module isn't enabled. Recompile the Godot editor or export template binary with the `module_jpg_enabled=yes` SCons option.");
 
 	return save_jpg_func(p_path, Ref<Image>((Image *)this), p_quality);
 }
@@ -2669,9 +2670,16 @@ Vector<uint8_t> Image::save_jpg_to_buffer(float p_quality) const {
 }
 
 Error Image::save_exr(const String &p_path, bool p_grayscale) const {
-	if (save_exr_func == nullptr) {
-		return ERR_UNAVAILABLE;
-	}
+#ifdef TOOLS_ENABLED
+	ERR_FAIL_NULL_V_MSG(
+			save_exr_func,
+			ERR_UNAVAILABLE,
+			"The TinyEXR module isn't enabled. Recompile the Godot editor with the `module_tinyexr_enabled=yes` SCons option.");
+#else
+	ERR_FAIL_V_MSG(
+			ERR_UNAVAILABLE,
+			"The TinyEXR module is only available in editor builds. EXR images cannot be saved using an export template.");
+#endif
 
 	return save_exr_func(p_path, Ref<Image>((Image *)this), p_grayscale);
 }
@@ -2684,9 +2692,11 @@ Vector<uint8_t> Image::save_exr_to_buffer(bool p_grayscale) const {
 }
 
 Error Image::save_webp(const String &p_path, const bool p_lossy, const float p_quality) const {
-	if (save_webp_func == nullptr) {
-		return ERR_UNAVAILABLE;
-	}
+	ERR_FAIL_NULL_V_MSG(
+			save_webp_func,
+			ERR_UNAVAILABLE,
+			"The WebP module isn't enabled. Recompile the Godot editor or export template binary with the `module_webp_enabled=yes` SCons option.");
+
 	ERR_FAIL_COND_V_MSG(p_lossy && !(0.0f <= p_quality && p_quality <= 1.0f), ERR_INVALID_PARAMETER, vformat("The WebP lossy quality was set to %f, which is not valid. WebP lossy quality must be between 0.0 and 1.0 (inclusive).", p_quality));
 
 	return save_webp_func(p_path, Ref<Image>((Image *)this), p_lossy, p_quality);
@@ -4038,10 +4048,18 @@ Error Image::load_png_from_buffer(const Vector<uint8_t> &p_array) {
 }
 
 Error Image::load_jpg_from_buffer(const Vector<uint8_t> &p_array) {
+	ERR_FAIL_NULL_V_MSG(
+			_jpg_mem_loader_func,
+			ERR_UNAVAILABLE,
+			"The JPEG module isn't enabled. Recompile the Godot editor or export template binary with the `module_jpg_enabled=yes` SCons option.");
 	return _load_from_buffer(p_array, _jpg_mem_loader_func);
 }
 
 Error Image::load_webp_from_buffer(const Vector<uint8_t> &p_array) {
+	ERR_FAIL_NULL_V_MSG(
+			_webp_mem_loader_func,
+			ERR_UNAVAILABLE,
+			"The WebP module isn't enabled. Recompile the Godot editor or export template binary with the `module_webp_enabled=yes` SCons option.");
 	return _load_from_buffer(p_array, _webp_mem_loader_func);
 }
 

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -358,6 +358,7 @@
 			<param index="0" name="buffer" type="PackedByteArray" />
 			<description>
 				Loads an image from the binary contents of a JPEG file.
+				[b]Note:[/b] This method is only available in engine builds with the JPEG module enabled. By default, the JPEG module is enabled, but it can be disabled at build-time using the [code]module_jpg_enabled=no[/code] SCons option.
 			</description>
 		</method>
 		<method name="load_ktx_from_buffer">
@@ -408,6 +409,7 @@
 			<param index="0" name="buffer" type="PackedByteArray" />
 			<description>
 				Loads an image from the binary contents of a WebP file.
+				[b]Note:[/b] This method is only available in engine builds with the WebP module enabled. By default, the WebP module is enabled, but it can be disabled at build-time using the [code]module_webp_enabled=no[/code] SCons option.
 			</description>
 		</method>
 		<method name="normal_map_to_xy">
@@ -464,6 +466,7 @@
 			<param index="1" name="grayscale" type="bool" default="false" />
 			<description>
 				Saves the image as an EXR file to [param path]. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
+				[b]Note:[/b] This method is only available in engine builds with the TinyEXR module enabled. By default, the TinyEXR module is enabled, but it can be disabled at build-time using the [code]module_tinyexr_enabled=no[/code] SCons option.
 				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return [constant ERR_UNAVAILABLE] when it is called from an exported project.
 			</description>
 		</method>
@@ -472,7 +475,8 @@
 			<param index="0" name="grayscale" type="bool" default="false" />
 			<description>
 				Saves the image as an EXR file to a byte array. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return an empty byte array if Godot was compiled without the TinyEXR module.
-				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return an empty byte array when it is called from an exported project.
+				[b]Note:[/b] This method is only available in engine builds with the TinyEXR module enabled. By default, the TinyEXR module is enabled, but it can be disabled at build-time using the [code]module_tinyexr_enabled=no[/code] SCons option.
+				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr_to_buffer] will return an empty byte array when it is called from an exported project.
 			</description>
 		</method>
 		<method name="save_jpg" qualifiers="const">
@@ -482,6 +486,7 @@
 			<description>
 				Saves the image as a JPEG file to [param path] with the specified [param quality] between [code]0.01[/code] and [code]1.0[/code] (inclusive). Higher [param quality] values result in better-looking output at the cost of larger file sizes. Recommended [param quality] values are between [code]0.75[/code] and [code]0.90[/code]. Even at quality [code]1.00[/code], JPEG compression remains lossy.
 				[b]Note:[/b] JPEG does not save an alpha channel. If the [Image] contains an alpha channel, the image will still be saved, but the resulting JPEG file won't contain the alpha channel.
+				[b]Note:[/b] This method is only available in engine builds with the JPEG module enabled. By default, the JPEG module is enabled, but it can be disabled at build-time using the [code]module_jpg_enabled=no[/code] SCons option.
 			</description>
 		</method>
 		<method name="save_jpg_to_buffer" qualifiers="const">
@@ -490,6 +495,7 @@
 			<description>
 				Saves the image as a JPEG file to a byte array with the specified [param quality] between [code]0.01[/code] and [code]1.0[/code] (inclusive). Higher [param quality] values result in better-looking output at the cost of larger byte array sizes (and therefore memory usage). Recommended [param quality] values are between [code]0.75[/code] and [code]0.90[/code]. Even at quality [code]1.00[/code], JPEG compression remains lossy.
 				[b]Note:[/b] JPEG does not save an alpha channel. If the [Image] contains an alpha channel, the image will still be saved, but the resulting byte array won't contain the alpha channel.
+				[b]Note:[/b] This method is only available in engine builds with the JPEG module enabled. By default, the JPEG module is enabled, but it can be disabled at build-time using the [code]module_jpg_enabled=no[/code] SCons option.
 			</description>
 		</method>
 		<method name="save_png" qualifiers="const">
@@ -513,6 +519,7 @@
 			<description>
 				Saves the image as a WebP (Web Picture) file to the file at [param path]. By default it will save lossless. If [param lossy] is [code]true[/code], the image will be saved lossy, using the [param quality] setting between [code]0.0[/code] and [code]1.0[/code] (inclusive). Lossless WebP offers more efficient compression than PNG.
 				[b]Note:[/b] The WebP format is limited to a size of 16383×16383 pixels, while PNG can save larger images.
+				[b]Note:[/b] This method is only available in engine builds with the WebP module enabled. By default, the WebP module is enabled, but it can be disabled at build-time using the [code]module_webp_enabled=no[/code] SCons option.
 			</description>
 		</method>
 		<method name="save_webp_to_buffer" qualifiers="const">
@@ -522,6 +529,7 @@
 			<description>
 				Saves the image as a WebP (Web Picture) file to a byte array. By default it will save lossless. If [param lossy] is [code]true[/code], the image will be saved lossy, using the [param quality] setting between [code]0.0[/code] and [code]1.0[/code] (inclusive). Lossless WebP offers more efficient compression than PNG.
 				[b]Note:[/b] The WebP format is limited to a size of 16383×16383 pixels, while PNG can save larger images.
+				[b]Note:[/b] This method is only available in engine builds with the WebP module enabled. By default, the WebP module is enabled, but it can be disabled at build-time using the [code]module_webp_enabled=no[/code] SCons option.
 			</description>
 		</method>
 		<method name="set_data">


### PR DESCRIPTION
This also updates the documentation.

Note that this doesn't affect `load_from_file()` because it uses dynamic loaders, while these functions are wrappers around direct calls to functions defined inside modules without using the RresourceLoader API.

- This salvages https://github.com/godotengine/godot/pull/97780. Thanks @dustfg for the original implementation :slightly_smiling_face:
