### PR TITLE
SCons: Add optional `detect.py` `get_tools` method to let platforms register custom tools

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -19,6 +19,10 @@ def can_build():
     return os.path.exists(get_env_android_sdk_root())
 
 
+def get_tools():
+    return ["clang", "clang++", "as", "ar", "link"]
+
+
 def get_opts():
     from SCons.Variables import BoolVariable
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -28,6 +28,11 @@ def can_build():
     return WhereIs("emcc") is not None
 
 
+def get_tools():
+    # Use generic POSIX build toolchain for Emscripten.
+    return ["cc", "c++", "ar", "link", "textfile", "zip"]
+
+
 def get_opts():
     from SCons.Variables import BoolVariable
 

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -155,6 +155,13 @@ def detect_build_env_arch():
     return ""
 
 
+def get_tools():
+    if os.name != "nt" or methods.get_cmdline_bool("use_mingw", False):
+        return ["mingw"]
+    else:
+        return ["default"]
+
+
 def get_opts():
     from SCons.Variables import BoolVariable, EnumVariable
 


### PR DESCRIPTION
This helps move this logic out of SConstruct, keeping platforms more self contained, and helping thirdparty platforms define their own custom tools.

This logic was also unreliable (the `use_mingw` one would only work if passed manually on the command line, not in e.g. `get_flags` or `custom.py`).

Draft for now as this requires some testing on affected platforms, and validation of the use case I have in W4 for thirdparty platforms setting their own tools.

Our overall set of custom tools registered for first-party platforms is something that might be worth reviewing over time. The Windows `mingw` stuff is still pretty hacky, and there's a stray `env.Tools("msvc")` for Windows which we might want to do differently. And some platforms override `CC`, `CXX`, etc. manually when we might be able to rely on pre-existing SCons tools to do it properly. As always, such changes have a high risk of regression though so we'd need to be careful with testing.