### PR TITLE
Core: Fix `JSON.{from,to}_native()` issues

### DIFF
--- a/core/io/json.h
+++ b/core/io/json.h
@@ -80,6 +80,9 @@ class JSON : public Resource {
 	static Error _parse_object(Dictionary &object, const char32_t *p_str, int &index, int p_len, int &line, int p_depth, String &r_err_str);
 	static Error _parse_string(const String &p_json, Variant &r_ret, String &r_err_str, int &r_err_line);
 
+	static Variant _from_native(const Variant &p_variant, bool p_full_objects, int p_depth);
+	static Variant _to_native(const Variant &p_json, bool p_allow_objects, int p_depth);
+
 protected:
 	static void _bind_methods();
 
@@ -90,13 +93,18 @@ public:
 	static String stringify(const Variant &p_var, const String &p_indent = "", bool p_sort_keys = true, bool p_full_precision = false);
 	static Variant parse_string(const String &p_json_string);
 
-	inline Variant get_data() const { return data; }
-	void set_data(const Variant &p_data);
-	inline int get_error_line() const { return err_line; }
-	inline String get_error_message() const { return err_str; }
+	_FORCE_INLINE_ static Variant from_native(const Variant &p_variant, bool p_full_objects = false) {
+		return _from_native(p_variant, p_full_objects, 0);
+	}
+	_FORCE_INLINE_ static Variant to_native(const Variant &p_json, bool p_allow_objects = false) {
+		return _to_native(p_json, p_allow_objects, 0);
+	}
 
-	static Variant from_native(const Variant &p_variant, bool p_allow_classes = false, bool p_allow_scripts = false);
-	static Variant to_native(const Variant &p_json, bool p_allow_classes = false, bool p_allow_scripts = false);
+	void set_data(const Variant &p_data);
+	_FORCE_INLINE_ Variant get_data() const { return data; }
+
+	_FORCE_INLINE_ int get_error_line() const { return err_line; }
+	_FORCE_INLINE_ String get_error_message() const { return err_str; }
 };
 
 class ResourceFormatLoaderJSON : public ResourceFormatLoader {

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -33,6 +33,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"
+#include "core/variant/container_type_validate.h"
 
 #include <limits.h>
 #include <stdio.h>
@@ -82,12 +83,6 @@ enum ContainerTypeKind {
 	CONTAINER_TYPE_KIND_BUILTIN = 0b01,
 	CONTAINER_TYPE_KIND_CLASS_NAME = 0b10,
 	CONTAINER_TYPE_KIND_SCRIPT = 0b11,
-};
-
-struct ContainerType {
-	Variant::Type builtin_type = Variant::NIL;
-	StringName class_name;
-	Ref<Script> script;
 };
 
 #define GET_CONTAINER_TYPE_KIND(m_header, m_field) \
@@ -844,7 +839,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			Dictionary dict;
 			if (key_type.builtin_type != Variant::NIL || value_type.builtin_type != Variant::NIL) {
-				dict.set_typed(key_type.builtin_type, key_type.class_name, key_type.script, value_type.builtin_type, value_type.class_name, value_type.script);
+				dict.set_typed(key_type, value_type);
 			}
 
 			for (int i = 0; i < count; i++) {
@@ -901,7 +896,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			Array array;
 			if (type.builtin_type != Variant::NIL) {
-				array.set_typed(type.builtin_type, type.class_name, type.script);
+				array.set_typed(type);
 			}
 
 			for (int i = 0; i < count; i++) {
@@ -1402,31 +1397,13 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			}
 		} break;
 		case Variant::DICTIONARY: {
-			Dictionary dict = p_variant;
-
-			ContainerType key_type;
-			key_type.builtin_type = (Variant::Type)dict.get_typed_key_builtin();
-			key_type.class_name = dict.get_typed_key_class_name();
-			key_type.script = dict.get_typed_key_script();
-
-			_encode_container_type_header(key_type, header, HEADER_DATA_FIELD_TYPED_DICTIONARY_KEY_SHIFT, p_full_objects);
-
-			ContainerType value_type;
-			value_type.builtin_type = (Variant::Type)dict.get_typed_value_builtin();
-			value_type.class_name = dict.get_typed_value_class_name();
-			value_type.script = dict.get_typed_value_script();
-
-			_encode_container_type_header(value_type, header, HEADER_DATA_FIELD_TYPED_DICTIONARY_VALUE_SHIFT, p_full_objects);
+			const Dictionary dict = p_variant;
+			_encode_container_type_header(dict.get_key_type(), header, HEADER_DATA_FIELD_TYPED_DICTIONARY_KEY_SHIFT, p_full_objects);
+			_encode_container_type_header(dict.get_value_type(), header, HEADER_DATA_FIELD_TYPED_DICTIONARY_VALUE_SHIFT, p_full_objects);
 		} break;
 		case Variant::ARRAY: {
-			Array array = p_variant;
-
-			ContainerType type;
-			type.builtin_type = (Variant::Type)array.get_typed_builtin();
-			type.class_name = array.get_typed_class_name();
-			type.script = array.get_typed_script();
-
-			_encode_container_type_header(type, header, HEADER_DATA_FIELD_TYPED_ARRAY_SHIFT, p_full_objects);
+			const Array array = p_variant;
+			_encode_container_type_header(array.get_element_type(), header, HEADER_DATA_FIELD_TYPED_ARRAY_SHIFT, p_full_objects);
 		} break;
 #ifdef REAL_T_IS_DOUBLE
 		case Variant::VECTOR2:
@@ -1850,27 +1827,17 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			r_len += 8;
 		} break;
 		case Variant::DICTIONARY: {
-			Dictionary dict = p_variant;
+			const Dictionary dict = p_variant;
 
 			{
-				ContainerType key_type;
-				key_type.builtin_type = (Variant::Type)dict.get_typed_key_builtin();
-				key_type.class_name = dict.get_typed_key_class_name();
-				key_type.script = dict.get_typed_key_script();
-
-				Error err = _encode_container_type(key_type, buf, r_len, p_full_objects);
+				Error err = _encode_container_type(dict.get_key_type(), buf, r_len, p_full_objects);
 				if (err) {
 					return err;
 				}
 			}
 
 			{
-				ContainerType value_type;
-				value_type.builtin_type = (Variant::Type)dict.get_typed_value_builtin();
-				value_type.class_name = dict.get_typed_value_class_name();
-				value_type.script = dict.get_typed_value_script();
-
-				Error err = _encode_container_type(value_type, buf, r_len, p_full_objects);
+				Error err = _encode_container_type(dict.get_value_type(), buf, r_len, p_full_objects);
 				if (err) {
 					return err;
 				}
@@ -1894,7 +1861,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				if (buf) {
 					buf += len;
 				}
-				Variant *value = dict.getptr(key);
+				const Variant *value = dict.getptr(key);
 				ERR_FAIL_NULL_V(value, ERR_BUG);
 				err = encode_variant(*value, buf, len, p_full_objects, p_depth + 1);
 				ERR_FAIL_COND_V(err, err);
@@ -1907,15 +1874,10 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 
 		} break;
 		case Variant::ARRAY: {
-			Array array = p_variant;
+			const Array array = p_variant;
 
 			{
-				ContainerType type;
-				type.builtin_type = (Variant::Type)array.get_typed_builtin();
-				type.class_name = array.get_typed_class_name();
-				type.script = array.get_typed_script();
-
-				Error err = _encode_container_type(type, buf, r_len, p_full_objects);
+				Error err = _encode_container_type(array.get_element_type(), buf, r_len, p_full_objects);
 				if (err) {
 					return err;
 				}

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -473,10 +473,11 @@ Error Expression::_get_token(Token &r_token) {
 					} else if (id == "self") {
 						r_token.type = TK_SELF;
 					} else {
-						for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-							if (id == Variant::get_type_name(Variant::Type(i))) {
+						{
+							const Variant::Type type = Variant::get_type_by_name(id);
+							if (type < Variant::VARIANT_MAX) {
 								r_token.type = TK_BASIC_TYPE;
-								r_token.value = i;
+								r_token.value = type;
 								return OK;
 							}
 						}

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -41,8 +41,7 @@
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 
-class ArrayPrivate {
-public:
+struct ArrayPrivate {
 	SafeRefCount refcount;
 	Vector<Variant> array;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
@@ -843,6 +842,10 @@ Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_nam
 	assign(p_from);
 }
 
+void Array::set_typed(const ContainerType &p_element_type) {
+	set_typed(p_element_type.builtin_type, p_element_type.class_name, p_element_type.script);
+}
+
 void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
 	ERR_FAIL_COND_MSG(_p->array.size() > 0, "Type can only be set when array is empty.");
@@ -868,6 +871,14 @@ bool Array::is_same_typed(const Array &p_other) const {
 
 bool Array::is_same_instance(const Array &p_other) const {
 	return _p == p_other._p;
+}
+
+ContainerType Array::get_element_type() const {
+	ContainerType type;
+	type.builtin_type = _p->typed.type;
+	type.class_name = _p->typed.class_name;
+	type.script = _p->typed.script;
+	return type;
 }
 
 uint32_t Array::get_typed_builtin() const {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -35,11 +35,13 @@
 
 #include <climits>
 
-class Variant;
-class ArrayPrivate;
+class Callable;
 class Object;
 class StringName;
-class Callable;
+class Variant;
+
+struct ArrayPrivate;
+struct ContainerType;
 
 class Array {
 	mutable ArrayPrivate *_p;
@@ -185,10 +187,14 @@ public:
 
 	const void *id() const;
 
+	void set_typed(const ContainerType &p_element_type);
 	void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
+
 	bool is_typed() const;
 	bool is_same_typed(const Array &p_other) const;
 	bool is_same_instance(const Array &p_other) const;
+
+	ContainerType get_element_type() const;
 	uint32_t get_typed_builtin() const;
 	StringName get_typed_class_name() const;
 	Variant get_typed_script() const;

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -34,6 +34,12 @@
 #include "core/object/script_language.h"
 #include "core/variant/variant.h"
 
+struct ContainerType {
+	Variant::Type builtin_type = Variant::NIL;
+	StringName class_name;
+	Ref<Script> script;
+};
+
 struct ContainerTypeValidate {
 	Variant::Type type = Variant::NIL;
 	StringName class_name;

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -595,6 +595,10 @@ Dictionary Dictionary::recursive_duplicate(bool p_deep, int recursion_count) con
 	return n;
 }
 
+void Dictionary::set_typed(const ContainerType &p_key_type, const ContainerType &p_value_type) {
+	set_typed(p_key_type.builtin_type, p_key_type.class_name, p_key_type.script, p_value_type.builtin_type, p_value_type.class_name, p_key_type.script);
+}
+
 void Dictionary::set_typed(uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Dictionary is in read-only state.");
 	ERR_FAIL_COND_MSG(_p->variant_map.size() > 0, "Type can only be set when dictionary is empty.");
@@ -639,6 +643,22 @@ bool Dictionary::is_same_typed_key(const Dictionary &p_other) const {
 
 bool Dictionary::is_same_typed_value(const Dictionary &p_other) const {
 	return _p->typed_value == p_other._p->typed_value;
+}
+
+ContainerType Dictionary::get_key_type() const {
+	ContainerType type;
+	type.builtin_type = _p->typed_key.type;
+	type.class_name = _p->typed_key.class_name;
+	type.script = _p->typed_key.script;
+	return type;
+}
+
+ContainerType Dictionary::get_value_type() const {
+	ContainerType type;
+	type.builtin_type = _p->typed_value.type;
+	type.class_name = _p->typed_value.class_name;
+	type.script = _p->typed_value.script;
+	return type;
 }
 
 uint32_t Dictionary::get_typed_key_builtin() const {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -37,6 +37,7 @@
 
 class Variant;
 
+struct ContainerType;
 struct DictionaryPrivate;
 
 class Dictionary {
@@ -91,13 +92,18 @@ public:
 	Dictionary duplicate(bool p_deep = false) const;
 	Dictionary recursive_duplicate(bool p_deep, int recursion_count) const;
 
+	void set_typed(const ContainerType &p_key_type, const ContainerType &p_value_type);
 	void set_typed(uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script);
+
 	bool is_typed() const;
 	bool is_typed_key() const;
 	bool is_typed_value() const;
 	bool is_same_typed(const Dictionary &p_other) const;
 	bool is_same_typed_key(const Dictionary &p_other) const;
 	bool is_same_typed_value(const Dictionary &p_other) const;
+
+	ContainerType get_key_type() const;
+	ContainerType get_value_type() const;
 	uint32_t get_typed_key_builtin() const;
 	uint32_t get_typed_value_builtin() const;
 	StringName get_typed_key_class_name() const;

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -176,6 +176,18 @@ String Variant::get_type_name(Variant::Type p_type) {
 	return "";
 }
 
+Variant::Type Variant::get_type_by_name(const String &p_type_name) {
+	static HashMap<String, Type> type_names;
+	if (unlikely(type_names.is_empty())) {
+		for (int i = 0; i < VARIANT_MAX; i++) {
+			type_names[get_type_name((Type)i)] = (Type)i;
+		}
+	}
+
+	const Type *ptr = type_names.getptr(p_type_name);
+	return (ptr == nullptr) ? VARIANT_MAX : *ptr;
+}
+
 bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 	if (p_type_from == p_type_to) {
 		return true;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -354,6 +354,7 @@ public:
 		return type;
 	}
 	static String get_type_name(Variant::Type p_type);
+	static Variant::Type get_type_by_name(const String &p_type_name);
 	static bool can_convert(Type p_type_from, Type p_type_to);
 	static bool can_convert_strict(Type p_type_from, Type p_type_to);
 	static bool is_type_shared(Variant::Type p_type);

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -40,11 +40,15 @@
 		<method name="from_native" qualifiers="static">
 			<return type="Variant" />
 			<param index="0" name="variant" type="Variant" />
-			<param index="1" name="allow_classes" type="bool" default="false" />
-			<param index="2" name="allow_scripts" type="bool" default="false" />
+			<param index="1" name="full_objects" type="bool" default="false" />
 			<description>
-				Converts a native engine type to a JSON-compliant dictionary.
-				By default, classes and scripts are ignored for security reasons, unless [param allow_classes] or [param allow_scripts] are specified.
+				Converts a native engine type to a JSON-compliant value.
+				By default, objects are ignored for security reasons, unless [param full_objects] is [code]true[/code].
+				You can convert a native value to a JSON string like this:
+				[codeblock]
+				func encode_data(value, full_objects = false):
+				    return JSON.stringify(JSON.from_native(value, full_objects))
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_error_line" qualifiers="const">
@@ -136,11 +140,15 @@
 		<method name="to_native" qualifiers="static">
 			<return type="Variant" />
 			<param index="0" name="json" type="Variant" />
-			<param index="1" name="allow_classes" type="bool" default="false" />
-			<param index="2" name="allow_scripts" type="bool" default="false" />
+			<param index="1" name="allow_objects" type="bool" default="false" />
 			<description>
-				Converts a JSON-compliant dictionary that was created with [method from_native] back to native engine types.
-				By default, classes and scripts are ignored for security reasons, unless [param allow_classes] or [param allow_scripts] are specified.
+				Converts a JSON-compliant value that was created with [method from_native] back to native engine types.
+				By default, objects are ignored for security reasons, unless [param allow_objects] is [code]true[/code].
+				You can convert a JSON string back to a native value like this:
+				[codeblock]
+				func decode_data(string, allow_objects = false):
+				    return JSON.to_native(JSON.parse_string(string), allow_objects)
+				[/codeblock]
 			</description>
 		</method>
 	</methods>

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -112,14 +112,12 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 		return false;
 	}
 
-	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-		if (Variant::get_type_name(Variant::Type(i)) == p_name) {
-			if (r_error) {
-				*r_error = TTR("Invalid name.") + " " + TTR("Must not collide with an existing built-in type name.");
-			}
-
-			return false;
+	if (Variant::get_type_by_name(p_name) < Variant::VARIANT_MAX) {
+		if (r_error) {
+			*r_error = TTR("Invalid name.") + " " + TTR("Must not collide with an existing built-in type name.");
 		}
+
+		return false;
 	}
 
 	for (int i = 0; i < CoreConstants::get_global_constant_count(); i++) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3858,13 +3858,10 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 		return OK;
 	}
 
-	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-		Variant::Type t = Variant::Type(i);
-		if (Variant::get_type_name(t) == p_symbol) {
-			r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
-			r_result.class_name = Variant::get_type_name(t);
-			return OK;
-		}
+	if (Variant::get_type_by_name(p_symbol) < Variant::VARIANT_MAX) {
+		r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS;
+		r_result.class_name = p_symbol;
+		return OK;
 	}
 
 	if ("Variant" == p_symbol) {


### PR DESCRIPTION
* Add support for typed arrays and dictionaries.
  * See also #78219.
  * See also #98120.
* Fix script handling to be consistent with binary and text serialization.
  * Scripts should not be serialized as objects, otherwise the deserialized object has a distinct type.
  * See also https://github.com/godotengine/godot/pull/78219#issuecomment-2009004890.
  * Fixes #96887.
* Add protection against infinite recursion.
* Fix serialization/deserialization returns value not _equal_ to original.
  * JSON does not distinguish between `int` and `float`.
  * Godot dictionaries preserve the insertion order, while JSON dictionaries do not.
  * Make sure that custom properties/keys do not conflict with syntactic ones, as was the case with `__gdtype` in the case of string-only key dictionaries.
* Fix a copy of the bug fixed in #90693 (premature free `RefCounted`).
* Use a more compact representation.
  * Use JSON literal `null` instead of `{"__gdtype":"Nil"}` (or it would be `{"type":"Nil"}`).
  * Use prefixed strings for `int`, `float`, `String`, `StringName`, and `NodePath`.
    * Example: `"i:1"`, `"f:1.0"`, `"s:abc"`, `"sn:abc"`, `"np:abc"`.
    * These types are used very often.
    * `Number` JSON type does not distinguish between `int` and `float`.
    * `StringName` and `NodePath` are used quite often.
      * Especially `StringName` in Lua-style dictionaries.
  * Do not use nested components for types like `Rect2`, `Transform2D`, and `Transform3D`.
    * All types except objects and a few simple types store data in the `args` key, as if it were a constructor or list initializer.
    * This doesn't hurt readability or potential parsing outside of Godot much, but it saves a lot of space.
* Do not use separate parameters `allow_classes` and `allow_scripts`, use a single `allow_objects`.
  * This is consistent with binary serialization.
* More comprehensive tests and other minor improvements to code style and consistency with binary serialization.

There were also a few minor "unrelated" improvements along the way:

* Add `Variant::get_type_by_name()`, which is the inverse of `Variant::get_type_name()`.
  * This improves performance slightly since it uses a hashmap instead of comparing strings in a loop.
  * Several similar uses have been replaced with the new method.
* More unified container type logic for typed arrays and dictionaries.
  * This was done because `marshalls.cpp` already had `ContainerType`, which was causing an SCU build error.

<details>
<summary>Test script</summary>

```gdscript
@tool
extends EditorScript

var _json_from_native: Callable
var _json_to_native: Callable

func is_equal(a: Variant, b: Variant) -> bool:
    if is_same(a, b):
        return true
    if typeof(a) != typeof(b):
        return false
    if typeof(a) == TYPE_OBJECT:
        if a.get_class() != b.get_class():
            return false
        if a.get_script() != b.get_script():
            return false
        # NOTE: Ideally we would want to compare properties recursively,
        # but for this test we don't need that.
        return true
    if typeof(a) == TYPE_DICTIONARY:
        if not a.is_same_typed(b):
            return false
        if a.size() != b.size():
            return false
        var a_keys = a.keys()
        var b_keys = b.keys()
        if a_keys != b_keys:
            return false
        for key in a_keys:
            if not is_equal(a[key], b[key]):
                return false
        return true
    if typeof(a) == TYPE_ARRAY:
        if not a.is_same_typed(b):
            return false
        if a.size() != b.size():
            return false
        for i in a.size():
            if not is_equal(a[i], b[i]):
                return false
        return true
    if typeof(a) >= TYPE_PACKED_BYTE_ARRAY:
        return a == b
    assert(false)
    return false

func stringify(value: Variant) -> String:
    if value is Object:
        return "%s(%s)" % [value.get_class(), value.get_script()]
    else:
        return var_to_str(value).replace("\n", " ")

func encode_data(value: Variant, sort_keys: bool = false) -> String:
    return JSON.stringify(_json_from_native.call(value), "", sort_keys)

func decode_data(string: String) -> Variant:
    return _json_to_native.call(JSON.parse_string(string))

func test(value: Variant) -> void:
    var encoded = encode_data(value)
    var decoded = decode_data(encoded)
    if not is_equal(value, decoded):
        prints(stringify(value), "->", stringify(decoded))

func _run() -> void:
    var json := JSON.new()
    if json.get_method_argument_count(&"from_native") == 3:
        _json_from_native = json.from_native.bind(true, true)
        _json_to_native = json.to_native.bind(true, true)
    else:
        _json_from_native = json.from_native.bind(true)
        _json_to_native = json.to_native.bind(true)

    print("Non-optimal representation")
    print("==========================")
    # Prints `{"__gdtype":"Nil"}`, but JSON has `null`.
    print(encode_data(null))
    # `StringName`s are used frequently, so a short notation is desirable.
    print(encode_data({a = 1}))
    print(encode_data({"a": 1}))
    # Nested components take up a lot of space
    print(encode_data(Rect2()))
    print(encode_data(Transform2D()))
    print(encode_data(Transform3D()))
    # Godot dictionaries preserve the insertion order, while JSON dictionaries do not.
    # Therefore, the short form for string-only dictionaries is inconsistent,
    # we must always use an array for key-value pairs.
    print(encode_data({a = "a", b = "b"}, true))
    print(encode_data({b = "b", a = "a"}, true))
    print(encode_data({"a": "a", "b": "b"}, true))
    print(encode_data({"b": "b", "a": "a"}, true))

    print()
    print("Bad serialize-deserialize result")
    print("================================")

    # JSON does not distinguish between `int` and `float`.
    test(1)
    test(1.0)
    test([1, 1.0])
    test({1: 2, 1.0: 2.0})
    # Typed collections are not supported
    test([] as Array[int])
    test({} as Dictionary[int, int])
    # The string-only short form cannot escape the special key `__gdtype`.
    test({"__gdtype": "test escape"})
    test({"type": "test escape"})
    # The script after deserialization should be the same.
    test(preload("res://test.gd").new())

    print()
    print("end")
```

</details>

<details>
<summary>Before</summary>

```
Non-optimal representation
==========================
{"__gdtype":"Nil"}
{"pairs":[{"key":{"name":"a","__gdtype":"StringName"},"value":1}],"__gdtype":"Dictionary"}
{"a":1}
{"position":{"values":[0.0,0.0],"__gdtype":"Vector2"},"size":{"values":[0.0,0.0],"__gdtype":"Vector2"},"__gdtype":"Rect2"}
{"x":{"values":[1.0,0.0],"__gdtype":"Vector2"},"y":{"values":[0.0,1.0],"__gdtype":"Vector2"},"origin":{"values":[0.0,0.0],"__gdtype":"Vector2"},"__gdtype":"Transform2D"}
{"basis":{"x":{"values":[1.0,0.0,0.0],"__gdtype":"Vector3"},"y":{"values":[0.0,1.0,0.0],"__gdtype":"Vector3"},"z":{"values":[0.0,0.0,1.0],"__gdtype":"Vector3"},"__gdtype":"Basis"},"origin":{"values":[0.0,0.0,0.0],"__gdtype":"Vector3"},"__gdtype":"Transform3D"}
{"__gdtype":"Dictionary","pairs":[{"key":{"__gdtype":"StringName","name":"a"},"value":"a"},{"key":{"__gdtype":"StringName","name":"b"},"value":"b"}]}
{"__gdtype":"Dictionary","pairs":[{"key":{"__gdtype":"StringName","name":"b"},"value":"b"},{"key":{"__gdtype":"StringName","name":"a"},"value":"a"}]}
{"a":"a","b":"b"}
{"a":"a","b":"b"}

Bad serialize-deserialize result
================================
1 -> 1.0
[1, 1.0] -> [1.0, 1.0]
{ 1: 2, 1.0: 2.0 } -> { 1.0: 2.0 }
Array[int]([]) -> []
Dictionary[int, int]({}) -> {}
{ "__gdtype": "test escape" } -> null
Resource(<GDScript#-9223370082409708004>) -> Resource(<GDScript#-9223342979152718982>)

end
```

If `test.gd` has a global name (`class_name`), then this also causes an error:

```
gdscript://-9223342907295902962.gd:2 - Parse Error: Class "Test" hides a global script class.
```

</details>

<details>
<summary>After</summary>

```
Non-optimal representation
==========================
null
{"type":"Dictionary","args":["sn:a","i:1"]}
{"type":"Dictionary","args":["s:a","i:1"]}
{"type":"Rect2","args":[0.0,0.0,0.0,0.0]}
{"type":"Transform2D","args":[1.0,0.0,0.0,1.0,0.0,0.0]}
{"type":"Transform3D","args":[1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0]}
{"args":["sn:a","s:a","sn:b","s:b"],"type":"Dictionary"}
{"args":["sn:b","s:b","sn:a","s:a"],"type":"Dictionary"}
{"args":["s:a","s:a","s:b","s:b"],"type":"Dictionary"}
{"args":["s:b","s:b","s:a","s:a"],"type":"Dictionary"}

Bad serialize-deserialize result
================================

end
```

</details>