### PR TITLE
CI: Add explicit problem matchers

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -29,3 +29,7 @@ runs:
         python -c "import sys; print(sys.version)"
         python -m pip install scons==${{ inputs.scons-version }}
         scons --version
+
+    - name: Setup problem matchers
+      shell: bash
+      run: echo ::add-matcher::misc/utility/problem-matchers.json

--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          sparse-checkout: .github
+          sparse-checkout: |
+            .github
+            misc/utility/problem-matchers.json
 
       - name: Checkout godot-cpp
         uses: actions/checkout@v4
@@ -33,9 +35,6 @@ jobs:
 
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
-
-      - name: Setup GCC problem matcher
-        uses: ammaraskar/gcc-problem-matcher@master
 
       - name: Download GDExtension interface and API dump
         uses: ./.github/actions/download-artifact

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -133,9 +133,6 @@ jobs:
           python-version: 3.8
           scons-version: 4.0
 
-      - name: Setup GCC problem matcher
-        uses: ammaraskar/gcc-problem-matcher@master
-
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
@@ -158,6 +155,9 @@ jobs:
       - name: Build .NET solutions
         if: matrix.build-mono
         run: |
+          # FIXME: C# warnings should be properly handled eventually, but we don't want to clutter
+          # the GitHub Actions annotations, so remove the associated problem matcher for now.
+          echo "::remove-matcher owner=msvc::"
           ./modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --godot-platform=linuxbsd
 
       - name: Prepare artifact

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -86,14 +86,6 @@ jobs:
       - name: Extract pre-built ANGLE static libraries
         run: Expand-Archive -Force angle/angle.zip ${{ github.workspace }}/
 
-      - name: Setup MSVC problem matcher
-        if: matrix.compiler == 'msvc'
-        uses: ammaraskar/msvc-problem-matcher@master
-
-      - name: Setup GCC problem matcher
-        if: matrix.compiler != 'msvc'
-        uses: ammaraskar/gcc-problem-matcher@master
-
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:

--- a/misc/utility/problem-matchers.json
+++ b/misc/utility/problem-matchers.json
@@ -1,0 +1,32 @@
+{
+	"problemMatcher": [
+		{
+			"owner": "gcc",
+			"pattern": [
+				{
+					"regexp": "^(?:\\s+\\d+\\>)?(\\S.*?)[\\(:](\\d+)[,:]?(\\d*)(?::{\\d+:\\d+\\-\\d+:\\d+})?\\)?:\\s+(?:fatal\\s+)?(error|warning|info):\\s+(.*?)(?:\\s*\\[(.*)\\])?$",
+					"file": 1,
+					"line": 2,
+					"column": 3,
+					"severity": 4,
+					"message": 5,
+					"code": 6
+				}
+			]
+		},
+		{
+			"owner": "msvc",
+			"pattern": [
+				{
+					"regexp": "^(?:\\s+\\d+\\>)?(\\S.*)\\((\\d+),?(\\d*)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(?:fatal\\s+)?(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+					"file": 1,
+					"line": 2,
+					"column": 3,
+					"severity": 4,
+					"code": 5,
+					"message": 6
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This PR took the GCC/MSVC problem matchers we were using in a handful of jobs & integrated them locally. In doing so, they've been updated with more effective regexes & were assigned to the dependency action so every workflow can take advantage of them. Here's the action output from two sample commits with a single change: commenting out `typedef Vector<uint8_t> PackedByteArray;` in `variant.h`. The new implementation catches warnings/errors in twice as many files. Images below sampled from the Windows `clang-cl` build, one of the actions that necessitated updated regex

## Before[^1]
![kSrfaMC](https://github.com/user-attachments/assets/81ea17e9-3cb0-407e-bd3f-97fc99441f47)

## After[^2]
![image](https://github.com/user-attachments/assets/864a1e74-f5fd-4a9e-bfeb-4c402860118b)

[^1]: https://github.com/Repiteo/godot/actions/runs/12057936131
[^2]: https://github.com/Repiteo/godot/actions/runs/12057997968