### PR TITLE
Fix physics picking when hovering an embedded window

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -682,8 +682,9 @@ void Viewport::_process_picking() {
 	if (Object::cast_to<Window>(this) && Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
 		return;
 	}
-	if (!gui.mouse_in_viewport) {
-		// Clear picking events if mouse has left viewport.
+	if (!gui.mouse_in_viewport || gui.subwindow_over) {
+		// Clear picking events if the mouse has left the viewport or is over an embedded window.
+		// These are locations, that are expected to not trigger physics picking.
 		physics_picking_events.clear();
 		return;
 	}


### PR DESCRIPTION
When the mouse is hovering an embedded window, it is still considered within the main viewport.
Previously in this case physics picking was executed, as if no embedded window was there. (Regression from #78017)

This PR introduces an additional check to exclude these cases.

- Resolve #99735