### PR TITLE
Optimize StringBuilder by using `LocalVector` instead of `Vector`.

### DIFF
--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -68,8 +68,10 @@ String StringBuilder::as_string() const {
 	int godot_string_elem = 0;
 	int c_string_elem = 0;
 
-	for (int i = 0; i < appended_strings.size(); i++) {
-		if (appended_strings[i] == -1) {
+	for (uint32_t i = 0; i < appended_strings.size(); i++) {
+		const int32_t str_len = appended_strings[i];
+
+		if (str_len == -1) {
 			// Godot string
 			const String &s = strings[godot_string_elem];
 
@@ -81,11 +83,11 @@ String StringBuilder::as_string() const {
 		} else {
 			const char *s = c_strings[c_string_elem];
 
-			for (int32_t j = 0; j < appended_strings[i]; j++) {
+			for (int32_t j = 0; j < str_len; j++) {
 				buffer[current_position + j] = s[j];
 			}
 
-			current_position += appended_strings[i];
+			current_position += str_len;
 
 			c_string_elem++;
 		}

--- a/core/string/string_builder.h
+++ b/core/string/string_builder.h
@@ -32,17 +32,17 @@
 #define STRING_BUILDER_H
 
 #include "core/string/ustring.h"
-#include "core/templates/vector.h"
+#include "core/templates/local_vector.h"
 
 class StringBuilder {
 	uint32_t string_length = 0;
 
-	Vector<String> strings;
-	Vector<const char *> c_strings;
+	LocalVector<String> strings;
+	LocalVector<const char *> c_strings;
 
 	// -1 means it's a Godot String
 	// a natural number means C string.
-	Vector<int32_t> appended_strings;
+	LocalVector<int32_t> appended_strings;
 
 public:
 	StringBuilder &append(const String &p_string);


### PR DESCRIPTION
Simple, unopinionated optimization of `StringBuilder` that's invisible to its callers.
This PR optimizes:
- calls like `builder.append("test")`, which no longer call `strlen()` because the size is known statically.
- `as_string` is now better optimized, regarding the iteration.
- `LocalVector` instead of `Vector` foregoes COW overhead (lifted from #97777).

This should slightly improve performance already, and should be easier to merge than #77158 because it does not modify any other parts of the code, and #97777 because it does not change assumptions about the strings.
I especially opted not to remove the explicit call to `String(buffer, string_length)` in the end because it does some error checking that should arguably stay - or at least, it should be the task of another PR to remove it.

I do think we should try optimizing strings further - especially with regards to large strings being checked for `strlen` quite repeatedly because of NULL termination - but this will be done in follow-up PRs. Especially, follow-up PRs will be able to call `append(ptr, len)` due to this PR if they already know the size.