### PR TITLE
Strip any trailing slashes when reading the default project path

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -758,6 +758,7 @@ void ProjectDialog::show_dialog(bool p_reset_name) {
 		project_path->set_editable(true);
 
 		String fav_dir = EDITOR_GET("filesystem/directories/default_project_path");
+		fav_dir = fav_dir.simplify_path();
 		if (!fav_dir.is_empty()) {
 			project_path->set_text(fav_dir);
 			install_path->set_text(fav_dir);


### PR DESCRIPTION
Fixes #99689. Any trailing slashes in default project path will now be removed.

![image](https://github.com/user-attachments/assets/a404f2e0-94eb-4af2-9609-ea7658c74a29)

![image](https://github.com/user-attachments/assets/47203047-1312-4157-8290-98130a255ab4)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
