### PR TITLE
String: Don't repeat calls to `strlen` in `split`, and make `splitter_length` const in `get_slice`.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1278,7 +1278,7 @@ String String::get_slice(const char *p_splitter, int p_slice) const {
 	}
 
 	int i = 0;
-	int splitter_length = strlen(p_splitter);
+	const int splitter_length = strlen(p_splitter);
 	while (true) {
 		pos = find(p_splitter, pos);
 		if (pos == -1) {
@@ -1429,6 +1429,7 @@ Vector<String> String::split(const char *p_splitter, bool p_allow_empty, int p_m
 
 	int from = 0;
 	int len = length();
+	const int splitter_length = strlen(p_splitter);
 
 	while (true) {
 		int end;
@@ -1459,7 +1460,7 @@ Vector<String> String::split(const char *p_splitter, bool p_allow_empty, int p_m
 			break;
 		}
 
-		from = end + strlen(p_splitter);
+		from = end + splitter_length;
 	}
 
 	return ret;


### PR DESCRIPTION
Small optimization that just irked me as I went over the code. 