### PR TITLE
Fix non-empty project folder confirmation dialog

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -488,12 +488,14 @@ void ProjectDialog::ok_pressed() {
 	// Before we create a project, check that the target folder is empty.
 	// If not, we need to ask the user if they're sure they want to do this.
 	if (!is_folder_empty) {
-		ConfirmationDialog *cd = memnew(ConfirmationDialog);
-		cd->set_title(TTR("Warning: This folder is not empty"));
-		cd->set_text(TTR("You are about to create a Godot project in a non-empty folder.\nThe entire contents of this folder will be imported as project resources!\n\nAre you sure you wish to continue?"));
-		cd->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &ProjectDialog::_nonempty_confirmation_ok_pressed));
-		get_parent()->add_child(cd);
-		cd->popup_centered();
+		if (!nonempty_confirmation) {
+			nonempty_confirmation = memnew(ConfirmationDialog);
+			nonempty_confirmation->set_title(TTR("Warning: This folder is not empty"));
+			nonempty_confirmation->set_text(TTR("You are about to create a Godot project in a non-empty folder.\nThe entire contents of this folder will be imported as project resources!\n\nAre you sure you wish to continue?"));
+			nonempty_confirmation->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &ProjectDialog::_nonempty_confirmation_ok_pressed));
+			add_child(nonempty_confirmation);
+		}
+		nonempty_confirmation->popup_centered();
 		return;
 	}
 

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -65,6 +65,7 @@ private:
 
 	Mode mode = MODE_NEW;
 	bool is_folder_empty = true;
+	ConfirmationDialog *nonempty_confirmation = nullptr;
 
 	CheckButton *create_dir = nullptr;
 	Button *project_browse = nullptr;


### PR DESCRIPTION
A special dialog opens when you try to create a project in non-empty folder. It will also print
```
ERROR: Attempting to make child window exclusive, but the parent window already has another exclusive child. This window: /root/@ProjectManager@1100/@ConfirmationDialog@1264, parent window: /root, current exclusive child window: /root/@ProjectManager@1100/@ProjectDialog@737
   at: Window::_set_transient_exclusive_child (C:\godot_source\scene/main/window.cpp:951)
```
The PR fixes it and also makes the dialog reused, instead of created every time.