### PR TITLE
[C#] Fix thread deadlock when using a worker thread to load a script with a generic base class

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -493,6 +493,8 @@ namespace Godot.Bridge
             {
                 _scriptTypeBiMap.ReadWriteLock.ExitUpgradeableReadLock();
             }
+
+            NativeFuncs.godotsharp_internal_reload_registered_script(outScript->Reference);
         }
 
         internal static unsafe void GetOrLoadOrCreateScriptForType(Type scriptType, godot_ref* outScript)
@@ -527,12 +529,14 @@ namespace Godot.Bridge
 
                     CreateScriptBridgeForType(scriptType, outScript);
                     scriptPath = null;
-                    return false;
                 }
                 finally
                 {
                     _scriptTypeBiMap.ReadWriteLock.ExitUpgradeableReadLock();
                 }
+
+                NativeFuncs.godotsharp_internal_reload_registered_script(outScript->Reference);
+                return false;
             }
 
             static string GetVirtualConstructedGenericTypeScriptPath(Type scriptType, string scriptPath)
@@ -597,6 +601,9 @@ namespace Godot.Bridge
             }
         }
 
+        /// <summary>
+        /// WARNING: We need to make sure that after unlocking the bimap, we call godotsharp_internal_reload_registered_script
+        /// </summary>
         private static unsafe void CreateScriptBridgeForType(Type scriptType, godot_ref* outScript)
         {
             Debug.Assert(!scriptType.IsGenericTypeDefinition, $"Script type must be a constructed generic type or not generic at all. Type: {scriptType}.");
@@ -613,8 +620,6 @@ namespace Godot.Bridge
             {
                 _scriptTypeBiMap.ReadWriteLock.ExitWriteLock();
             }
-
-            NativeFuncs.godotsharp_internal_reload_registered_script(outScript->Reference);
         }
 
         [UnmanagedCallersOnly]


### PR DESCRIPTION
Fix for #99839 and #99128

Currently, if we use either a worker thread with `ResourceLoader::load()` or use `ResourceLoader::load_threaded_request()`, and try to load any resource with a dependency on a script that inherits a generic C# class, we run into a `_scriptTypeBiMap.ReadWriteLock` deadlock. 

This happens in a very specific circumstance:
1. The script and its base hasn't been loaded before, so it's not populated into the BiMap
2. Calling the load from a worker thread will make the `ResourceLoader::load()` call from inside `godot_sharp_internal_script_load` to spin up a separate worker thread to load the dependency base script
3. This secondary worker thread will try to get the script from the BiMap unsuccessfully, since it hasn't been populated yet, and will then fall back to creating the script bridge. While doing so, it will try to lock the already locked BiMap `ReadWriteLock` from when we were loading it's child script

This PR addresses this by moving the call to `godot_sharp_internal_reload_registered_script` after we've unlocked the lock on the BiMap. This method doesn't need, and in fact shouldn't be run while we're locked. This has made it necessary to always call this method after we call `CreateScriptBridgeForType` from inside the lock, however that method has only two callsites at the moment, so it wasn't a difficult change to make.

To make sure the method is called by anyone making further changes to the code in the future, I've added a doc comment to the `CreateScriptBridgeForType` method noting that the registration needs to be done manually.

---

Detailed callstack of the problem with explanations:

Managed code is italics to make it easier to read when we switch between managed and unmanaged

> 01. ResourceFormatLoaderCSharpScript::load(**derived_script_path**)
> 02. *ScriptManagerBridge_GetOrCreateScriptBridgeForPath*
> 03. *GetOrCreateScriptBridgeForType*
> 04. ***lock(_scriptTypeBiMap.ReadWriteLock)***
> 05. *CreateScriptBridgeForType*
> 06. godot_sharp_internal_reload_registered_script(**derived_script_path**)
> 07. reload_registered_script
> 08. update_script_class_info
> 09. *ScriptManagerBridge_UpdateScriptClassInfo* -- **As part of populating the class info, this will try to load the base script**
> 10. *GetOrLoadOrCreateScriptForType(**generic_base_type**)
> 11. godot_sharp_internal_script_load
> 12. ResourceLoader::load -- **Because we're calling this whole callstack from a worker thread, the resource loader will automatically start the loading of this resource in a different worker thread, with LOAD_THREAD_SPAWN_SINGLE**
> 13. wait -- **The thread will now wait for the worker thread to resolve before it continues execution**

Then we call the following on the new worker thread:
> 01. ResourceFormatLoaderCSharpScript::load(**generic_base_type**)
> 02. *ScriptManagerBridge_GetOrCreateScriptBridgeForPath*
> 03. *GetOrCreateScriptBridgeForType*
> 04. ***lock(_scriptTypeBiMap.ReadWriteLock)*** -- Second lock of the already locked BiMap

