### PR TITLE
Fix ReflectionProbe AABB

### DIFF
--- a/editor/plugins/gizmos/reflection_probe_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/reflection_probe_gizmo_plugin.cpp
@@ -165,13 +165,6 @@ void ReflectionProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		aabb.position = -size / 2;
 		aabb.size = size;
 
-		for (int i = 0; i < 12; i++) {
-			Vector3 a, b;
-			aabb.get_edge(i, a, b);
-			lines.push_back(a);
-			lines.push_back(b);
-		}
-
 		for (int i = 0; i < 8; i++) {
 			Vector3 ep = aabb.get_endpoint(i);
 			internal_lines.push_back(probe->get_origin_offset());

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -185,8 +185,8 @@ ReflectionProbe::UpdateMode ReflectionProbe::get_update_mode() const {
 
 AABB ReflectionProbe::get_aabb() const {
 	AABB aabb;
-	aabb.position = -origin_offset;
-	aabb.size = origin_offset + size / 2;
+	aabb.position = -size / 2;
+	aabb.size = size;
 	return aabb;
 }
 


### PR DESCRIPTION
This PR resolves some issues in the AABB calculation of the reflection probe:
- The AABB of ReflectionProbe is now calculated from corner to corner
- Removed the origin_offset from the AABB calculation. Origin_offset should not have any bearing on the bounding box.

Additionally I've also removed the green wire-frame, since the bounding box is displayed on top of it anyways.

| 4.3 | This PR |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/926b63dd-f0fd-449e-8ce1-7b477d256de8) | ![image](https://github.com/user-attachments/assets/e32e9d1e-e30b-47bc-b3f5-40e604ea2828) |
| ![image](https://github.com/user-attachments/assets/8247fd3c-aa61-4fe9-9f04-218d58409da2) | ![image](https://github.com/user-attachments/assets/4afb586e-de13-4781-ae76-cecadcda7b65) |
| ![24_11_28_17_27__Godot_v4 3-stable_win64_KaL9XxGQDx](https://github.com/user-attachments/assets/2e41b56c-82f4-447e-861b-4540aa6670ed) | ![24_11_28_17_26__godot windows editor x86_64_cVjwQTIUl8](https://github.com/user-attachments/assets/54266b9b-94c1-4115-a017-23611f16ab6a)
