### PR TITLE
[Debugger] Fully disable debugger in release builds by default

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -259,6 +259,7 @@ opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and be
 opts.Add("build_profile", "Path to a file containing a feature build profile", "")
 opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules except ones explicitly enabled", True))
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
+opts.Add(BoolVariable("enable_engine_debugger", "Enable engine-specific debugging features", True))
 opts.Add(
     "system_certs_path",
     "Use this path as TLS certificates default for editor and Linux/BSD export templates (for package maintainers)",
@@ -500,6 +501,14 @@ if env.dev_build:
 else:
     # Disable assert() for production targets (only used in thirdparty code).
     env.Append(CPPDEFINES=["NDEBUG"])
+
+env["enable_engine_debugger"] = methods.get_cmdline_bool("enable_engine_debugger", env.debug_features)
+
+if env["enable_engine_debugger"]:
+    env.Append(CPPDEFINES=["DEBUGGER_ENABLED"])
+elif env.editor_build:
+    print_error(f'Engine debugger is required for editor builds.')
+    Exit(255)
 
 # SCons speed optimization controlled by the `fast_unsafe` option, which provide
 # more than 10 s speed up for incremental rebuilds.

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -45,6 +45,16 @@ HashMap<String, EngineDebugger::CreatePeerFunc> EngineDebugger::protocols;
 
 void (*EngineDebugger::allow_focus_steal_fn)();
 
+#ifdef DEBUGGER_ENABLED
+
+void EngineDebugger::line_poll() {
+	// The purpose of this is just processing events every now and then when the script might get too busy otherwise bugs like infinite loops can't be caught.
+	if (unlikely(poll_every % 2048) == 0) {
+		poll_events(false);
+	}
+	poll_every++;
+}
+
 void EngineDebugger::register_profiler(const StringName &p_name, const Profiler &p_func) {
 	ERR_FAIL_COND_MSG(profilers.has(p_name), vformat("Profiler already registered: '%s'.", p_name));
 	profilers.insert(p_name, p_func);
@@ -193,6 +203,60 @@ void EngineDebugger::deinitialize() {
 	captures.clear();
 	protocols.clear();
 }
+
+#else
+
+void EngineDebugger::line_poll() {
+}
+
+void EngineDebugger::register_profiler(const StringName &p_name, const Profiler &p_func) {
+}
+
+void EngineDebugger::unregister_profiler(const StringName &p_name) {
+}
+
+void EngineDebugger::register_message_capture(const StringName &p_name, Capture p_func) {
+}
+
+void EngineDebugger::unregister_message_capture(const StringName &p_name) {
+}
+
+void EngineDebugger::register_uri_handler(const String &p_protocol, CreatePeerFunc p_func) {
+}
+
+void EngineDebugger::profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts) {
+}
+
+void EngineDebugger::profiler_add_frame_data(const StringName &p_name, const Array &p_data) {
+}
+
+bool EngineDebugger::is_profiling(const StringName &p_name) {
+	return false;
+}
+
+bool EngineDebugger::has_profiler(const StringName &p_name) {
+	return false;
+}
+
+bool EngineDebugger::has_capture(const StringName &p_name) {
+	return false;
+}
+
+Error EngineDebugger::capture_parse(const StringName &p_name, const String &p_msg, const Array &p_args, bool &r_captured) {
+	r_captured = false;
+	return ERR_UNAVAILABLE;
+}
+
+void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, double p_physics_frame_time) {
+}
+
+void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, const Vector<String> &p_breakpoints, void (*p_allow_focus_steal_fn)()) {
+}
+
+void EngineDebugger::deinitialize() {
+}
+
+#endif
 
 EngineDebugger::~EngineDebugger() {
 	if (script_debugger) {

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -58,7 +58,9 @@ public:
 		ProfilingAdd add = nullptr;
 		ProfilingTick tick = nullptr;
 		void *data = nullptr;
+#ifdef DEBUGGER_ENABLED
 		bool active = false;
+#endif
 
 	public:
 		Profiler() {}
@@ -85,12 +87,14 @@ public:
 	};
 
 private:
+#ifdef DEBUGGER_ENABLED
 	double frame_time = 0.0;
 	double process_time = 0.0;
 	double physics_time = 0.0;
 	double physics_frame_time = 0.0;
 
 	uint32_t poll_every = 0;
+#endif
 
 protected:
 	static EngineDebugger *singleton;
@@ -126,13 +130,7 @@ public:
 	void profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts = Array());
 	Error capture_parse(const StringName &p_name, const String &p_msg, const Array &p_args, bool &r_captured);
 
-	void line_poll() {
-		// The purpose of this is just processing events every now and then when the script might get too busy otherwise bugs like infinite loops can't be caught.
-		if (unlikely(poll_every % 2048) == 0) {
-			poll_events(false);
-		}
-		poll_every++;
-	}
+	void line_poll();
 
 	virtual void poll_events(bool p_is_idle) {}
 	virtual void send_message(const String &p_msg, const Array &p_data) = 0;

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUGGER_ENABLED
+
 #include "local_debugger.h"
 
 #include "core/debugger/script_debugger.h"
@@ -388,3 +390,5 @@ LocalDebugger::~LocalDebugger() {
 		memdelete(scripts_profiler);
 	}
 }
+
+#endif // DEBUGGER_ENABLED

--- a/core/debugger/local_debugger.h
+++ b/core/debugger/local_debugger.h
@@ -31,6 +31,8 @@
 #ifndef LOCAL_DEBUGGER_H
 #define LOCAL_DEBUGGER_H
 
+#ifdef DEBUGGER_ENABLED
+
 #include "core/debugger/engine_debugger.h"
 #include "core/object/script_language.h"
 #include "core/templates/list.h"
@@ -55,5 +57,7 @@ public:
 	LocalDebugger();
 	~LocalDebugger();
 };
+
+#endif // DEBUGGER_ENABLED
 
 #endif // LOCAL_DEBUGGER_H

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUGGER_ENABLED
+
 #include "remote_debugger.h"
 
 #include "core/config/project_settings.h"
@@ -734,3 +736,5 @@ RemoteDebugger::~RemoteDebugger() {
 	remove_print_handler(&phl);
 	remove_error_handler(&eh);
 }
+
+#endif // DEBUGGER_ENABLED

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -31,6 +31,8 @@
 #ifndef REMOTE_DEBUGGER_H
 #define REMOTE_DEBUGGER_H
 
+#ifdef DEBUGGER_ENABLED
+
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/remote_debugger_peer.h"
@@ -122,5 +124,7 @@ public:
 	explicit RemoteDebugger(Ref<RemoteDebuggerPeer> p_peer);
 	~RemoteDebugger();
 };
+
+#endif // DEBUGGER_ENABLED
 
 #endif // REMOTE_DEBUGGER_H

--- a/modules/websocket/register_types.cpp
+++ b/modules/websocket/register_types.cpp
@@ -70,8 +70,10 @@ void initialize_websocket_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(WebSocketMultiplayerPeer);
 		ClassDB::register_custom_instance_class<WebSocketPeer>();
 
+#ifdef DEBUGGER_ENABLED
 		EngineDebugger::register_uri_handler("ws://", RemoteDebuggerPeerWebSocket::create);
 		EngineDebugger::register_uri_handler("wss://", RemoteDebuggerPeerWebSocket::create);
+#endif
 	}
 
 #ifdef TOOLS_ENABLED

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUGGER_ENABLED
+
 #include "remote_debugger_peer_websocket.h"
 
 #include "core/config/project_settings.h"
@@ -139,3 +141,5 @@ RemoteDebuggerPeer *RemoteDebuggerPeerWebSocket::create(const String &p_uri) {
 	}
 	return peer;
 }
+
+#endif // DEBUGGER_ENABLED

--- a/modules/websocket/remote_debugger_peer_websocket.h
+++ b/modules/websocket/remote_debugger_peer_websocket.h
@@ -31,6 +31,8 @@
 #ifndef REMOTE_DEBUGGER_PEER_WEBSOCKET_H
 #define REMOTE_DEBUGGER_PEER_WEBSOCKET_H
 
+#ifdef DEBUGGER_ENABLED
+
 #include "websocket_peer.h"
 
 #include "core/debugger/remote_debugger_peer.h"
@@ -58,5 +60,7 @@ public:
 
 	RemoteDebuggerPeerWebSocket(Ref<WebSocketPeer> p_peer = Ref<WebSocketPeer>());
 };
+
+#endif // DEBUGGER_ENABLED
 
 #endif // REMOTE_DEBUGGER_PEER_WEBSOCKET_H

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -17,7 +17,8 @@ SConscript("2d/SCsub")
 SConscript("animation/SCsub")
 SConscript("audio/SCsub")
 SConscript("resources/SCsub")
-SConscript("debugger/SCsub")
+if env["enable_engine_debugger"]:
+    SConscript("debugger/SCsub")
 SConscript("theme/SCsub")
 
 # Build it all as a library

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -56,16 +56,13 @@
 SceneDebugger::SceneDebugger() {
 	singleton = this;
 
-#ifdef DEBUG_ENABLED
 	LiveEditor::singleton = memnew(LiveEditor);
 	RuntimeNodeSelect::singleton = memnew(RuntimeNodeSelect);
 
 	EngineDebugger::register_message_capture("scene", EngineDebugger::Capture(nullptr, SceneDebugger::parse_message));
-#endif
 }
 
 SceneDebugger::~SceneDebugger() {
-#ifdef DEBUG_ENABLED
 	if (LiveEditor::singleton) {
 		EngineDebugger::unregister_message_capture("scene");
 		memdelete(LiveEditor::singleton);
@@ -76,7 +73,6 @@ SceneDebugger::~SceneDebugger() {
 		memdelete(RuntimeNodeSelect::singleton);
 		RuntimeNodeSelect::singleton = nullptr;
 	}
-#endif
 
 	singleton = nullptr;
 }
@@ -93,7 +89,6 @@ void SceneDebugger::deinitialize() {
 	}
 }
 
-#ifdef DEBUG_ENABLED
 void SceneDebugger::_handle_input(const Ref<InputEvent> &p_event, const Ref<Shortcut> &p_shortcut) {
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed() && !k->is_echo() && p_shortcut->matches_event(k)) {
@@ -2156,4 +2151,3 @@ void RuntimeNodeSelect::_reset_camera_3d() {
 	SceneTree::get_singleton()->get_root()->set_camera_3d_override_perspective(CAMERA_BASE_FOV * cursor.fov_scale, CAMERA_ZNEAR, CAMERA_ZFAR);
 }
 #endif // _3D_DISABLED
-#endif

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -55,7 +55,6 @@ public:
 
 	~SceneDebugger();
 
-#ifdef DEBUG_ENABLED
 private:
 	static void _handle_input(const Ref<InputEvent> &p_event, const Ref<Shortcut> &p_shortcut);
 
@@ -70,10 +69,8 @@ public:
 	static void add_to_cache(const String &p_filename, Node *p_node);
 	static void remove_from_cache(const String &p_filename, Node *p_node);
 	static void reload_cached_files(const PackedStringArray &p_files);
-#endif
 };
 
-#ifdef DEBUG_ENABLED
 class SceneDebuggerObject {
 private:
 	void _parse_script_properties(Script *p_script, ScriptInstance *p_instance);
@@ -322,6 +319,5 @@ public:
 
 	~RuntimeNodeSelect();
 };
-#endif
 
 #endif // SCENE_DEBUGGER_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1239,7 +1239,9 @@ void register_scene_types() {
 		GraphEdit::init_shaders();
 	}
 
+#ifdef DEBUGGER_ENABLED
 	SceneDebugger::initialize();
+#endif
 
 	OS::get_singleton()->benchmark_end_measure("Scene", "Register Types");
 }
@@ -1247,7 +1249,9 @@ void register_scene_types() {
 void unregister_scene_types() {
 	OS::get_singleton()->benchmark_begin_measure("Scene", "Unregister Types");
 
+#ifdef DEBUGGER_ENABLED
 	SceneDebugger::deinitialize();
+#endif
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);
 	resource_loader_texture_layered.unref();

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -18,7 +18,8 @@ env.add_source_files(env.servers_sources, "text_server.cpp")
 
 SConscript("audio/SCsub")
 SConscript("camera/SCsub")
-SConscript("debugger/SCsub")
+if env["enable_engine_debugger"]:
+    SConscript("debugger/SCsub")
 SConscript("display/SCsub")
 SConscript("extensions/SCsub")
 SConscript("movie_writer/SCsub")

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -247,7 +247,9 @@ void register_server_types() {
 
 	GDREGISTER_VIRTUAL_CLASS(MovieWriter);
 
+#ifdef DEBUGGER_ENABLED
 	ServersDebugger::initialize();
+#endif
 
 	// Physics 2D
 	GDREGISTER_CLASS(PhysicsServer2DManager);
@@ -337,7 +339,9 @@ void register_server_types() {
 void unregister_server_types() {
 	OS::get_singleton()->benchmark_begin_measure("Servers", "Unregister Extensions");
 
+#ifdef DEBUGGER_ENABLED
 	ServersDebugger::deinitialize();
+#endif
 	memdelete(shader_types);
 	memdelete(writer_mjpeg);
 	memdelete(writer_pngwav);


### PR DESCRIPTION
The debugger can still be manually enabled by forcing the `enable_engine_debugger` build flag, enabling all debugger features in that case (including e.g. scene live edit).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
