### PR TITLE
Style skeleton button on import screen

### DIFF
--- a/editor/icons/SkeletonPreview.svg
+++ b/editor/icons/SkeletonPreview.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#eee" d="M6 2a4 4 0 0 0-2 7.453V13a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V9.453A4 4 0 0 0 10 2zM5 5a1 1 0 0 1 0 2 1 1 0 0 1 0-2zm6 0a1 1 0 0 1 0 2 1 1 0 0 1 0-2zM7 7h2v1H7zM5 9h1v1h1V9h2v1h1V9h1v4h-1v-1H9v1H7v-1H6v1H5V8z"/></svg>

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1329,7 +1329,7 @@ void SceneImportSettingsDialog::_notification(int p_what) {
 			light_2_switch->set_button_icon(theme_cache.light_2_icon);
 			light_rotate_switch->set_button_icon(theme_cache.rotate_icon);
 
-			animation_toggle_skeleton_visibility->set_button_icon(get_editor_theme_icon(SNAME("Skeleton3D")));
+			animation_toggle_skeleton_visibility->set_button_icon(get_editor_theme_icon(SNAME("SkeletonPreview")));
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -1725,7 +1725,7 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	animation_toggle_skeleton_visibility = memnew(Button);
 	animation_hbox->add_child(animation_toggle_skeleton_visibility);
 	animation_toggle_skeleton_visibility->set_toggle_mode(true);
-	animation_toggle_skeleton_visibility->set_flat(true);
+	animation_toggle_skeleton_visibility->set_theme_type_variation("FlatButton");
 	animation_toggle_skeleton_visibility->set_focus_mode(Control::FOCUS_NONE);
 	animation_toggle_skeleton_visibility->set_tooltip_text(TTR("Toggle Animation Skeleton Visibility"));
 


### PR DESCRIPTION
Fixes #98723

There is no white skeleton svg available currently, so I kept the red one, which is consistent with the Skeleton3D node, so it kinda make sense.
But now, when it's enabled, you get the square backdrop, similar to other toggle buttons in the editor, like the `Snap to grid` button.

![Screenshot_20241128_221511](https://github.com/user-attachments/assets/9a99cb8e-4c6c-4671-ac3c-0582ffa5361e)
