### PR TITLE
[OS] Add support for script based logger.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -226,6 +226,14 @@ String OS::get_system_ca_certificates() {
 	return ::OS::get_singleton()->get_system_ca_certificates();
 }
 
+void OS::add_logger(const Callable &p_callback) {
+	::OS::get_singleton()->_add_logger(p_callback);
+}
+
+void OS::remove_logger(const Callable &p_callback) {
+	::OS::get_singleton()->_remove_logger(p_callback);
+}
+
 PackedStringArray OS::get_connected_midi_inputs() {
 	return ::OS::get_singleton()->get_connected_midi_inputs();
 }
@@ -624,6 +632,9 @@ String OS::get_unique_id() const {
 OS *OS::singleton = nullptr;
 
 void OS::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_logger", "callback"), &OS::add_logger);
+	ClassDB::bind_method(D_METHOD("remove_logger", "callback"), &OS::remove_logger);
+
 	ClassDB::bind_method(D_METHOD("get_entropy", "size"), &OS::get_entropy);
 	ClassDB::bind_method(D_METHOD("get_system_ca_certificates"), &OS::get_system_ca_certificates);
 	ClassDB::bind_method(D_METHOD("get_connected_midi_inputs"), &OS::get_connected_midi_inputs);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -157,6 +157,9 @@ public:
 		STD_HANDLE_UNKNOWN,
 	};
 
+	void add_logger(const Callable &p_callback);
+	void remove_logger(const Callable &p_callback);
+
 	virtual PackedStringArray get_connected_midi_inputs();
 	virtual void open_midi_inputs();
 	virtual void close_midi_inputs();

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -34,6 +34,7 @@
 #include "core/io/file_access.h"
 #include "core/string/ustring.h"
 #include "core/templates/vector.h"
+#include "core/variant/callable.h"
 #include "modules/modules_enabled.gen.h" // For regex.
 #ifdef MODULE_REGEX_ENABLED
 #include "modules/regex/regex.h"
@@ -112,6 +113,18 @@ public:
 	void add_logger(Logger *p_logger);
 
 	virtual ~CompositeLogger();
+};
+
+class ScriptCallbackLogger : public Logger {
+	Vector<Callable> cbs;
+
+public:
+	explicit ScriptCallbackLogger() {}
+
+	void add_callback(const Callable &p_cb);
+	void remove_callback(const Callable &p_cb);
+
+	virtual void logv(const char *p_format, va_list p_list, bool p_err) override _PRINTF_FORMAT_ATTRIBUTE_2_0;
 };
 
 #endif // LOGGER_H

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -71,6 +71,20 @@ void OS::_set_logger(CompositeLogger *p_logger) {
 	_logger = p_logger;
 }
 
+void OS::_add_logger(const Callable &p_callback) {
+	if (!_cb_logger) {
+		_cb_logger = memnew(ScriptCallbackLogger);
+		add_logger(_cb_logger);
+	}
+	_cb_logger->add_callback(p_callback);
+}
+
+void OS::_remove_logger(const Callable &p_callback) {
+	if (_cb_logger) {
+		_cb_logger->remove_callback(p_callback);
+	}
+}
+
 void OS::add_logger(Logger *p_logger) {
 	if (!_logger) {
 		Vector<Logger *> loggers;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -65,6 +65,7 @@ class OS {
 	bool _in_editor = false;
 
 	CompositeLogger *_logger = nullptr;
+	ScriptCallbackLogger *_cb_logger = nullptr;
 
 	bool restart_on_exit = false;
 	List<String> restart_commandline;
@@ -135,6 +136,9 @@ public:
 	typedef int64_t ProcessID;
 
 	static OS *get_singleton();
+
+	void _add_logger(const Callable &p_callback);
+	void _remove_logger(const Callable &p_callback);
 
 	void set_current_rendering_driver_name(const String &p_driver_name) { _current_rendering_driver_name = p_driver_name; }
 	void set_current_rendering_method(const String &p_name) { _current_rendering_method = p_name; }

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -11,6 +11,13 @@
 		<link title="Operating System Testing Demo">https://godotengine.org/asset-library/asset/2789</link>
 	</tutorials>
 	<methods>
+		<method name="add_logger">
+			<return type="void" />
+			<param index="0" name="callback" type="Callable" />
+			<description>
+				Adds a callback function, which is called when a log message is printed. The callback function takes two arguments: [code]message: String[/code] and [code]error: bool[/code].
+			</description>
+		</method>
 		<method name="alert">
 			<return type="void" />
 			<param index="0" name="text" type="String" />
@@ -724,6 +731,13 @@
 				[b]Note:[/b] This method automatically replaces [code]\r\n[/code] line breaks with [code]\n[/code] and removes them from the end of the string. Use [method read_buffer_from_stdin] to read the unprocessed data.
 				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
 				[b]Note:[/b] On exported Windows builds, run the console wrapper executable to access the terminal. If standard input is console, calling this method without console wrapped will freeze permanently. If standard input is pipe or file, it can be used without console wrapper. If you need a single executable with full console support, use a custom build compiled with the [code]windows_subsystem=console[/code] flag.
+			</description>
+		</method>
+		<method name="remove_logger">
+			<return type="void" />
+			<param index="0" name="callback" type="Callable" />
+			<description>
+				Removes the given callback function if it was previously added with [method add_logger].
 			</description>
 		</method>
 		<method name="request_permission">


### PR DESCRIPTION
Adds method to register script callback as a custom `Logger` (receives all messages printed by the engine).

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/5937
and closes https://github.com/godotengine/godot-proposals/issues/8964.*