### PR TITLE
Debounce inspector search to make it more responsive

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -34,6 +34,7 @@
 #include "editor/add_metadata_dialog.h"
 #include "editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/scroll_container.h"
 
 class AcceptDialog;
@@ -42,7 +43,6 @@ class ConfirmationDialog;
 class EditorInspector;
 class EditorValidationPanel;
 class HSeparator;
-class LineEdit;
 class MarginContainer;
 class OptionButton;
 class PanelContainer;
@@ -599,7 +599,6 @@ class EditorInspector : public ScrollContainer {
 
 	void _keying_changed();
 
-	void _filter_changed(const String &p_text);
 	void _parse_added_editors(VBoxContainer *current_vbox, EditorInspectorSection *p_section, Ref<EditorInspectorPlugin> ped);
 
 	void _vscroll_changed(double);
@@ -689,6 +688,21 @@ public:
 	Variant get_property_clipboard() const;
 
 	EditorInspector();
+};
+
+class DebouncedLineEdit : public LineEdit {
+	GDCLASS(DebouncedLineEdit, LineEdit);
+
+	Timer *debounce_timer = nullptr;
+
+	void _start_timer();
+
+protected:
+	static void _bind_methods();
+	void _notification(int p_what);
+
+public:
+	DebouncedLineEdit();
 };
 
 #endif // EDITOR_INSPECTOR_H

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -303,10 +303,10 @@ void SectionedInspector::update_category_list() {
 	inspector->update_tree();
 }
 
-void SectionedInspector::register_search_box(LineEdit *p_box) {
+void SectionedInspector::register_search_box(DebouncedLineEdit *p_box) {
 	search_box = p_box;
 	inspector->register_text_enter(p_box);
-	search_box->connect(SceneStringName(text_changed), callable_mp(this, &SectionedInspector::_search_changed));
+	p_box->connect("debounce_timeout", callable_mp(this, &SectionedInspector::_search_changed));
 }
 
 void SectionedInspector::register_advanced_toggle(CheckButton *p_toggle) {
@@ -315,9 +315,9 @@ void SectionedInspector::register_advanced_toggle(CheckButton *p_toggle) {
 	_advanced_toggled(advanced_toggle->is_pressed());
 }
 
-void SectionedInspector::_search_changed(const String &p_what) {
+void SectionedInspector::_search_changed() {
 	if (advanced_toggle) {
-		if (p_what.is_empty()) {
+		if (search_box->get_text().is_empty()) {
 			advanced_toggle->set_pressed_no_signal(!restrict_to_basic);
 			advanced_toggle->set_disabled(false);
 			advanced_toggle->set_tooltip_text(String());

--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -35,7 +35,7 @@
 
 class CheckButton;
 class EditorInspector;
-class LineEdit;
+class DebouncedLineEdit;
 class SectionedInspectorFilter;
 class Tree;
 class TreeItem;
@@ -50,7 +50,7 @@ class SectionedInspector : public HSplitContainer {
 
 	HashMap<String, TreeItem *> section_map;
 	EditorInspector *inspector = nullptr;
-	LineEdit *search_box = nullptr;
+	DebouncedLineEdit *search_box = nullptr;
 	CheckButton *advanced_toggle = nullptr;
 
 	String selected_category;
@@ -60,11 +60,11 @@ class SectionedInspector : public HSplitContainer {
 	static void _bind_methods();
 	void _section_selected();
 
-	void _search_changed(const String &p_what);
+	void _search_changed();
 	void _advanced_toggled(bool p_toggled_on);
 
 public:
-	void register_search_box(LineEdit *p_box);
+	void register_search_box(DebouncedLineEdit *p_box);
 	void register_advanced_toggle(CheckButton *p_toggle);
 
 	EditorInspector *get_inspector();

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -846,7 +846,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	tab_general->add_child(hbc);
 
-	search_box = memnew(LineEdit);
+	search_box = memnew(DebouncedLineEdit);
 	search_box->set_placeholder(TTR("Filter Settings"));
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(search_box);

--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -35,6 +35,7 @@
 #include "scene/gui/dialogs.h"
 
 class CheckButton;
+class DebouncedLineEdit;
 class PanelContainer;
 class SectionedInspector;
 class TabContainer;
@@ -51,7 +52,7 @@ class EditorSettingsDialog : public AcceptDialog {
 	Control *tab_general = nullptr;
 	Control *tab_shortcuts = nullptr;
 
-	LineEdit *search_box = nullptr;
+	DebouncedLineEdit *search_box = nullptr;
 	CheckButton *advanced_switch = nullptr;
 	LineEdit *shortcut_search_box = nullptr;
 	EventListenerLineEdit *shortcut_search_by_event = nullptr;

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -736,7 +736,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	HBoxContainer *property_tools_hb = memnew(HBoxContainer);
 	add_child(property_tools_hb);
 
-	search = memnew(LineEdit);
+	search = memnew(DebouncedLineEdit);
 	search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search->set_placeholder(TTR("Filter Properties"));
 	search->set_clear_button_enabled(true);

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -37,10 +37,10 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
-#include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/tree.h"
 
+class DebouncedLineEdit;
 class EditorFileDialog;
 class EditorObjectSelector;
 
@@ -88,7 +88,7 @@ class InspectorDock : public VBoxContainer {
 	MenuButton *resource_save_button = nullptr;
 	MenuButton *resource_extra_button = nullptr;
 	MenuButton *history_menu = nullptr;
-	LineEdit *search = nullptr;
+	DebouncedLineEdit *search = nullptr;
 
 	Button *open_docs_button = nullptr;
 	MenuButton *object_menu = nullptr;

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -37,7 +37,6 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/grid_container.h"
-#include "scene/gui/line_edit.h"
 #include "scene/gui/link_button.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/option_button.h"
@@ -50,6 +49,7 @@
 #include "scene/gui/texture_button.h"
 #include "scene/main/http_request.h"
 
+class DebouncedLineEdit;
 class EditorFileDialog;
 class MenuButton;
 
@@ -200,8 +200,7 @@ class EditorAssetLibrary : public PanelContainer {
 	void _set_library_message(const String &p_message);
 	void _set_library_message_with_action(const String &p_message, const String &p_action_text, const Callable &p_action);
 
-	LineEdit *filter = nullptr;
-	Timer *filter_debounce_timer = nullptr;
+	DebouncedLineEdit *filter = nullptr;
 	OptionButton *categories = nullptr;
 	OptionButton *repository = nullptr;
 	OptionButton *sort = nullptr;
@@ -303,11 +302,9 @@ class EditorAssetLibrary : public PanelContainer {
 
 	void _search(int p_page = 0);
 	void _rerun_search(int p_ignore);
-	void _search_text_changed(const String &p_text = "");
 	void _search_text_submitted(const String &p_text = "");
 	void _api_request(const String &p_request, RequestType p_request_type, const String &p_arguments = "");
 	void _http_request_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data);
-	void _filter_debounce_timer_timeout();
 	void _request_current_config();
 	EditorAssetLibraryItemDownload *_get_asset_in_progress(int p_asset_id) const;
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -645,7 +645,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	HBoxContainer *search_bar = memnew(HBoxContainer);
 	general_editor->add_child(search_bar);
 
-	search_box = memnew(LineEdit);
+	search_box = memnew(DebouncedLineEdit);
 	search_box->set_placeholder(TTR("Filter Settings"));
 	search_box->set_clear_button_enabled(true);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -43,6 +43,7 @@
 #include "editor/shader_globals_editor.h"
 #include "scene/gui/tab_container.h"
 
+class DebouncedLineEdit;
 class FileSystemDock;
 
 class ProjectSettingsEditor : public AcceptDialog {
@@ -62,7 +63,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	GroupSettingsEditor *group_settings = nullptr;
 	EditorPluginSettings *plugin_settings = nullptr;
 
-	LineEdit *search_box = nullptr;
+	DebouncedLineEdit *search_box = nullptr;
 	CheckButton *advanced = nullptr;
 
 	HBoxContainer *custom_properties = nullptr;


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/e718970c-6684-4df5-a3fc-29154b3e1ab0

I'm writing text, but the editor is frozen as I'm writing, because the inspector updates with every letter. The text just appears in the end.

After

https://github.com/user-attachments/assets/c01177e5-fbac-427c-98c7-8447866eeb37

You can actually see that I'm typing something.

The issue is a bit exaggerated, because it's a dev build, but it's still noticeable problem in official release. The PR adds a debounce timer, so the inspector won't search (and destroy/rebuild whole tree) every time you add a letter.