### PR TITLE
Move StringName `!=` operator to the header file to make it inlineable.

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -191,12 +191,6 @@ bool StringName::operator!=(const char *p_name) const {
 	return !(operator==(p_name));
 }
 
-bool StringName::operator!=(const StringName &p_name) const {
-	// the real magic of all this mess happens here.
-	// this is why path comparisons are very fast
-	return _data != p_name._data;
-}
-
 char32_t StringName::operator[](int p_index) const {
 	if (_data) {
 		if (_data->cname) {

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -132,9 +132,12 @@ public:
 		return _data >= p_name._data;
 	}
 	_FORCE_INLINE_ bool operator==(const StringName &p_name) const {
-		// the real magic of all this mess happens here.
-		// this is why path comparisons are very fast
+		// The real magic of all this mess happens here.
+		// This is why path comparisons are very fast.
 		return _data == p_name._data;
+	}
+	_FORCE_INLINE_ bool operator!=(const StringName &p_name) const {
+		return _data != p_name._data;
 	}
 	_FORCE_INLINE_ uint32_t hash() const {
 		if (_data) {
@@ -146,7 +149,6 @@ public:
 	_FORCE_INLINE_ const void *data_unique_pointer() const {
 		return (void *)_data;
 	}
-	bool operator!=(const StringName &p_name) const;
 
 	_FORCE_INLINE_ operator String() const {
 		if (_data) {


### PR DESCRIPTION
Small inconsistency I came across in my string endeavours. Shouldn't make a big difference, but it will make a small one, probably even with LTO enabled.

By allowing the function to be inlined, the compiler is allowed to reason about the code instead of having to make a Blackbox call, and surrounding code unlocks a whole slew of possible optimizations. 

Notice how `operator==` is already in the header file right above the new `!=` entry, ready to be inlined.