### PR TITLE
Optimize `String::copy_from` and `String::copy_from_unchecked` implementations, improving String allocation speed.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -329,21 +329,14 @@ void String::copy_from(const char *p_cstr) {
 
 	resize(len + 1); // include 0
 
+	const char *end = p_cstr + len;
 	char32_t *dst = ptrw();
 
-	for (size_t i = 0; i <= len; i++) {
-#if CHAR_MIN == 0
-		uint8_t c = p_cstr[i];
-#else
-		uint8_t c = p_cstr[i] >= 0 ? p_cstr[i] : uint8_t(256 + p_cstr[i]);
-#endif
-		if (c == 0 && i < len) {
-			print_unicode_error("NUL character", true);
-			dst[i] = _replacement_char;
-		} else {
-			dst[i] = c;
-		}
+	for (; p_cstr < end; ++p_cstr, ++dst) {
+		// If char is int8_t, a set sign bit will be reinterpreted as 256 - val implicitly.
+		*dst = static_cast<uint8_t>(*p_cstr);
 	}
+	*dst = 0;
 }
 
 void String::copy_from(const char *p_cstr, const int p_clip_to) {
@@ -366,22 +359,14 @@ void String::copy_from(const char *p_cstr, const int p_clip_to) {
 
 	resize(len + 1); // include 0
 
+	const char *end = p_cstr + len;
 	char32_t *dst = ptrw();
 
-	for (int i = 0; i < len; i++) {
-#if CHAR_MIN == 0
-		uint8_t c = p_cstr[i];
-#else
-		uint8_t c = p_cstr[i] >= 0 ? p_cstr[i] : uint8_t(256 + p_cstr[i]);
-#endif
-		if (c == 0) {
-			print_unicode_error("NUL character", true);
-			dst[i] = _replacement_char;
-		} else {
-			dst[i] = c;
-		}
+	for (; p_cstr < end; ++p_cstr, ++dst) {
+		// If char is int8_t, a set sign bit will be reinterpreted as 256 - val implicitly.
+		*dst = static_cast<uint8_t>(*p_cstr);
 	}
-	dst[len] = 0;
+	*dst = 0;
 }
 
 void String::copy_from(const wchar_t *p_cstr) {
@@ -469,27 +454,25 @@ void String::copy_from(const char32_t *p_cstr, const int p_clip_to) {
 // p_length <= p_char strlen
 void String::copy_from_unchecked(const char32_t *p_char, const int p_length) {
 	resize(p_length + 1);
-	char32_t *dst = ptrw();
-	dst[p_length] = 0;
 
-	for (int i = 0; i < p_length; i++) {
-		if (p_char[i] == 0) {
-			print_unicode_error("NUL character", true);
-			dst[i] = _replacement_char;
+	const char32_t *end = p_char + p_length;
+	char32_t *dst = ptrw();
+
+	for (; p_char < end; ++p_char, ++dst) {
+		const char32_t chr = *p_char;
+		if ((chr & 0xfffff800) == 0xd800) {
+			print_unicode_error(vformat("Unpaired surrogate (%x)", (uint32_t)chr));
+			*dst = _replacement_char;
 			continue;
 		}
-		if ((p_char[i] & 0xfffff800) == 0xd800) {
-			print_unicode_error(vformat("Unpaired surrogate (%x)", (uint32_t)p_char[i]));
-			dst[i] = _replacement_char;
+		if (chr > 0x10ffff) {
+			print_unicode_error(vformat("Invalid unicode codepoint (%x)", (uint32_t)chr));
+			*dst = _replacement_char;
 			continue;
 		}
-		if (p_char[i] > 0x10ffff) {
-			print_unicode_error(vformat("Invalid unicode codepoint (%x)", (uint32_t)p_char[i]));
-			dst[i] = _replacement_char;
-			continue;
-		}
-		dst[i] = p_char[i];
+		*dst = chr;
 	}
+	*dst = 0;
 }
 
 void String::operator=(const char *p_str) {


### PR DESCRIPTION
Summarizing my notes from https://github.com/godotengine/godot/pull/99775#issuecomment-2505762287:

1) At the time of the loop in `copy_from`, `strlen()` has already established that no `NULL` is contained in the string range. We can make use of this assumption by simply deleting the check for it.
2) This is also true for `copy_from_unchecked`, where this assumption has already been documented above the function. It is a module-local function that's otherwise only used on substrings, where the contract of no-null is equally true (if dubious).
3) Casting rules of the C++ spec ensure us that a cast from `char` to `uint8_t` will always reinterpret the bits in the same way that the manual check did in the current code ([example](https://onlinegdb.com/EGWnFbsxF)). Clang is able to optimize this manual conversion away, but [MSVC cannot](https://godbolt.org/z/PY8xW9EWa). It is therefor optimizable.
4) Running pointers reduce the amount of unnecessary addition operations. 

Everything put together, the `copy_from` loop is very likely to be SMID vectorized by the compiler now, improving its throughput by up to an estimated 8x.