### PR TITLE
basis_universal: Make tinyexr dependency explicit (reverted)

### DIFF
--- a/modules/basis_universal/config.py
+++ b/modules/basis_universal/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    env.module_add_dependencies("basis_universal", ["jpg"])
+    env.module_add_dependencies("basis_universal", ["jpg", "tinyexr"])
     return True
 
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Disabling only tinyexr (`module_tinyexr_enabled = "no"`) and trying to build will cause linking errors because basis_universal relies on it

This makes tinyexr a requirement to build basis_universal