### PR TITLE
Change Event Configuration dialog wider and its input list taller for better usability

### DIFF
--- a/editor/input_event_configuration_dialog.cpp
+++ b/editor/input_event_configuration_dialog.cpp
@@ -637,7 +637,7 @@ void InputEventConfigurationDialog::set_allowed_input_types(int p_type_masks) {
 InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	allowed_input_types = INPUT_KEY | INPUT_MOUSE_BUTTON | INPUT_JOY_BUTTON | INPUT_JOY_MOTION;
 
-	set_min_size(Size2i(550, 0) * EDSCALE);
+	set_min_size(Size2i(800, 0) * EDSCALE);
 
 	VBoxContainer *main_vbox = memnew(VBoxContainer);
 	add_child(main_vbox);
@@ -674,7 +674,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 
 	input_list_tree = memnew(Tree);
 	input_list_tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	input_list_tree->set_custom_minimum_size(Size2(0, 100 * EDSCALE)); // Min height for tree
+	input_list_tree->set_custom_minimum_size(Size2(0, 300 * EDSCALE)); // Min height for tree
 	input_list_tree->connect("item_activated", callable_mp(this, &InputEventConfigurationDialog::_input_list_item_activated));
 	input_list_tree->connect(SceneStringName(item_selected), callable_mp(this, &InputEventConfigurationDialog::_input_list_item_selected));
 	input_list_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);


### PR DESCRIPTION
Fixed some usability problems in Event Configuration dialog:
- If the event name, e.g. "Joypad Button 0 (Bottom Action, Sony Cross, Xbox A, Nintendo B) - All Devices" does not fit on one line, the name label wraps the name to second line, causing the listbox containing inputs changing its location. This happening when clicking an input is quite distracting.
- The vertical size of the action listbox is quite small. When action is selected, some additional information is displayed at the bottom, making the listbox even smaller. If at the same time the event name is wrapped, you can see only 4 lines of information in the listbox.

Changes:
- Event Configuration dialog is now wider. Event name wrapping should now be much more rare.
- Action Tree is now taller.

The Event Configuration dialog is still smaller than its parent dialog (Project Settings), so I don't think that making the dialog larger will cause any problems.

Master:
![master](https://github.com/user-attachments/assets/be6d78ee-be88-47ff-a0d8-9e3d3f1e3973)

This PR:
![this-pr](https://github.com/user-attachments/assets/b66fa342-fd32-483d-8ba4-4b680e15e9a0)
