### PR TITLE
Make `SpinBox` tell parent container to sort children on `SpinBox` size change when inner LineEdit has `expand_to_text_length=true`

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -65,6 +65,10 @@ void SpinBox::_update_text(bool p_keep_line_edit) {
 
 	line_edit->set_text_with_selection(value);
 	last_updated_text = value;
+
+	if (line_edit->is_expand_to_text_length_enabled()) {
+		emit_signal(SNAME("minimum_size_changed"));
+	}
 }
 
 void SpinBox::_text_submitted(const String &p_string) {
@@ -116,6 +120,9 @@ LineEdit *SpinBox::get_line_edit() {
 }
 
 void SpinBox::_line_edit_input(const Ref<InputEvent> &p_event) {
+	if (line_edit->is_expand_to_text_length_enabled()) {
+		emit_signal(SNAME("minimum_size_changed"));
+	}
 }
 
 void SpinBox::_range_click_timeout() {


### PR DESCRIPTION
Fix #98761 

When a `LineEdit` has `expand_to_text_length=true` and is in a container, the container will sort its children when the `LineEdit` changes size the text length changing. This behaviour was previously not present for `SpinBox` which relies on a `LineEdit`. Setting `expand_to_text_length=true` on the `LineEdit` of the `SpinBox` in GDScript would make the `SpinBox` change size on large input without the container sorting the children. This resulted in the `SpinBox` overlapping with other children of the container. This can be seen in the following video before this fix:

https://github.com/user-attachments/assets/2773acc0-5e87-410b-9441-0e62780f9333

With this fix, the `SpinBox` behaves like a `LineEdit` when the inner `LineEdit` of the `SpinBox` is modified to have `expand_to_text_length=true`.

https://github.com/user-attachments/assets/e924f383-e460-4e22-9a9c-33c0c339513c

I have tested to make sure that the behaviour of `SpinBox` is consistent with that of `LineEdit` when `expand_to_text_length=false`.

Before the fix with `expand_to_text_length=false`:

https://github.com/user-attachments/assets/1d4e105a-4bb8-4b8f-852d-c1c868893100

After the fix with `expand_to_text_length=false`:

https://github.com/user-attachments/assets/b0ba4a8a-e434-4a49-bc5d-abe903c03c1c

