### PR TITLE
[Windows] Improve frame pacing by busy waiting as needed

### DIFF
--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -94,8 +94,10 @@ public:
 class JoypadWindows;
 
 class OS_Windows : public OS {
+	uint64_t target_ticks = 0;
 	uint64_t ticks_start = 0;
 	uint64_t ticks_per_second = 0;
+	uint64_t delay_resolution = 1000;
 
 	HINSTANCE hInstance;
 	MainLoop *main_loop = nullptr;
@@ -188,6 +190,7 @@ public:
 
 	virtual Error set_cwd(const String &p_cwd) override;
 
+	virtual void add_frame_delay(bool p_can_draw) override;
 	virtual void delay_usec(uint32_t p_usec) const override;
 	virtual uint64_t get_ticks_usec() const override;
 


### PR DESCRIPTION
Apply a solution similar to the one in https://github.com/godotengine/godot/pull/99178 to the frame delay function only.

Fixes #99728 (implemented for windows only as describe in https://github.com/godotengine/godot/issues/99728#issuecomment-2504866896 since other platform doesn't seem affected).