### PR TITLE
Ensure `parse_utf8` has length of string passed in when available

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -749,7 +749,7 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 		cs[slen] = 0;
 		f->get_buffer((uint8_t *)cs.ptr(), slen);
 		String key;
-		key.parse_utf8(cs.ptr());
+		key.parse_utf8(cs.ptr(), slen);
 
 		uint32_t vlen = f->get_32();
 		Vector<uint8_t> d;

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -491,7 +491,7 @@ String FileAccess::get_as_utf8_string(bool p_skip_cr) const {
 	w[len] = 0;
 
 	String s;
-	s.parse_utf8((const char *)w, -1, p_skip_cr);
+	s.parse_utf8((const char *)w, len, p_skip_cr);
 	return s;
 }
 
@@ -651,7 +651,7 @@ String FileAccess::get_pascal_string() {
 	cs[sl] = 0;
 
 	String ret;
-	ret.parse_utf8(cs.ptr());
+	ret.parse_utf8(cs.ptr(), sl);
 	return ret;
 }
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -309,7 +309,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		cs[sl] = 0;
 
 		String path;
-		path.parse_utf8(cs.ptr());
+		path.parse_utf8(cs.ptr(), sl);
 
 		uint64_t ofs = f->get_64();
 		uint64_t size = f->get_64();

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -484,7 +484,7 @@ Error HTTPClientTCP::poll() {
 					// End of response, parse.
 					response_str.push_back(0);
 					String response;
-					response.parse_utf8((const char *)response_str.ptr());
+					response.parse_utf8((const char *)response_str.ptr(), response_str.size());
 					Vector<String> responses = response.split("\n");
 					body_size = -1;
 					chunked = false;

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -165,7 +165,7 @@ StringName ResourceLoaderBinary::_get_string() {
 		}
 		f->get_buffer((uint8_t *)&str_buf[0], len);
 		String s;
-		s.parse_utf8(&str_buf[0]);
+		s.parse_utf8(&str_buf[0], len);
 		return s;
 	}
 
@@ -921,7 +921,7 @@ static String get_ustring(Ref<FileAccess> f) {
 	str_buf.resize(len);
 	f->get_buffer((uint8_t *)&str_buf[0], len);
 	String s;
-	s.parse_utf8(&str_buf[0]);
+	s.parse_utf8(&str_buf[0], len);
 	return s;
 }
 
@@ -935,7 +935,7 @@ String ResourceLoaderBinary::get_unicode_string() {
 	}
 	f->get_buffer((uint8_t *)&str_buf[0], len);
 	String s;
-	s.parse_utf8(&str_buf[0]);
+	s.parse_utf8(&str_buf[0], len);
 	return s;
 }
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1143,7 +1143,7 @@ Error GDScript::load_source_code(const String &p_path) {
 	w[len] = 0;
 
 	String s;
-	if (s.parse_utf8((const char *)w) != OK) {
+	if (s.parse_utf8((const char *)w, len) != OK) {
 		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Script '" + p_path + "' contains invalid unicode (UTF-8), so it was not loaded. Please ensure that scripts are saved in valid UTF-8 unicode.");
 	}
 

--- a/modules/gdscript/gdscript_cache.cpp
+++ b/modules/gdscript/gdscript_cache.cpp
@@ -275,7 +275,7 @@ String GDScriptCache::get_source_code(const String &p_path) {
 	source_file.write[len] = 0;
 
 	String source;
-	if (source.parse_utf8((const char *)source_file.ptr()) != OK) {
+	if (source.parse_utf8((const char *)source_file.ptr(), len) != OK) {
 		ERR_FAIL_V_MSG("", "Script '" + p_path + "' contains invalid unicode (UTF-8), so it was not loaded. Please ensure that scripts are saved in valid UTF-8 unicode.");
 	}
 	return source;

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -159,7 +159,7 @@ Error read_all_file_utf8(const String &p_path, String &r_content) {
 	w[len] = 0;
 
 	String source;
-	if (source.parse_utf8((const char *)w) != OK) {
+	if (source.parse_utf8((const char *)w, len) != OK) {
 		ERR_FAIL_V(ERR_INVALID_DATA);
 	}
 

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1525,7 +1525,7 @@ String EditorExportPlatformAndroid::_parse_string(const uint8_t *p_bytes, bool p
 		}
 		str8.write[len] = 0;
 		String str;
-		str.parse_utf8((const char *)str8.ptr());
+		str.parse_utf8((const char *)str8.ptr(), len);
 		return str;
 	} else {
 		String str;

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -179,9 +179,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 		if (new_expected_buffer_size > original_path_size) {
 			ERR_FAIL_COND_V_MSG(original_path_size < min_base_size + suffix_size, FAILED, vformat("The original PDB path size in bytes is too small: '%s'. Expected size: %d or more bytes, but available %d.", pdb_info.path, min_base_size + suffix_size, original_path_size));
 
-			utf8_name.resize(original_path_size - suffix_size + 1); // +1 for the \0
-			utf8_name[utf8_name.size() - 1] = '\0';
-			new_pdb_base_name.parse_utf8(utf8_name);
+			new_pdb_base_name.parse_utf8(utf8_name, original_path_size - suffix_size);
 			new_pdb_base_name[new_pdb_base_name.length() - 1] = '_'; // Restore the last '_'
 			WARN_PRINT(vformat("The original path size of '%s' in bytes was too small to fit the new name, so it was shortened to '%s%d.pdb'.", pdb_info.path, new_pdb_base_name, max_pdb_names - 1));
 		}


### PR DESCRIPTION
As seen in https://github.com/godotengine/godot/pull/99826, parse utf_8 is faster when it doesn't have to find the size of the string first.
So if calling code has it, make sure to pass it along.
