### PR TITLE
Docs: Update example from Window signal `files_dropped`

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -727,7 +727,7 @@
 				Emitted when files are dragged from the OS file manager and dropped in the game window. The argument is a list of file paths.
 				[codeblock]
 				func _ready():
-				    get_viewport().files_dropped.connect(on_files_dropped)
+				    get_window().files_dropped.connect(on_files_dropped)
 
 				func on_files_dropped(files):
 				    print(files)


### PR DESCRIPTION
As mentioned in [godot-docs/issues/10318](https://github.com/godotengine/godot-docs/issues/10318), switching to `get_window()` may be more appropriated as we are talking about a signal that only exist in `Window`.  

Note: I think that this PR is so small that could be done together with another docs update.  

_Bugsquad edit: closes https://github.com/godotengine/godot-docs/issues/10318_

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
