### PR TITLE
Disable debug fill for trimesh collision shapes to prevent z-fighting

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -876,11 +876,14 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		if (mesh.is_valid()) {
 			Vector<Ref<Shape3D>> shapes;
 			String fixed_name;
+			bool debug_fill = true;
+
 			if (r_collision_map.has(mesh)) {
 				shapes = r_collision_map[mesh];
 			} else if (_teststr(name, "col")) {
 				_pre_gen_shape_list(mesh, shapes, false);
 				r_collision_map[mesh] = shapes;
+				debug_fill = false;
 			} else if (_teststr(name, "convcol")) {
 				_pre_gen_shape_list(mesh, shapes, true);
 				r_collision_map[mesh] = shapes;
@@ -903,7 +906,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				mi->add_child(col, true);
 				col->set_owner(mi->get_owner());
 
-				_add_shapes(col, shapes);
+				_add_shapes(col, shapes, debug_fill);
 			}
 		}
 
@@ -1001,12 +1004,15 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		Ref<ImporterMesh> mesh = mi->get_mesh();
 		if (!mesh.is_null()) {
 			Vector<Ref<Shape3D>> shapes;
+			bool debug_fill = true;
+
 			if (r_collision_map.has(mesh)) {
 				shapes = r_collision_map[mesh];
 			} else if (_teststr(mesh->get_name(), "col")) {
 				_pre_gen_shape_list(mesh, shapes, false);
 				r_collision_map[mesh] = shapes;
 				mesh->set_name(_fixstr(mesh->get_name(), "col"));
+				debug_fill = false;
 			} else if (_teststr(mesh->get_name(), "convcol")) {
 				_pre_gen_shape_list(mesh, shapes, true);
 				r_collision_map[mesh] = shapes;
@@ -1023,7 +1029,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 				p_node->add_child(col, true);
 				col->set_owner(p_node->get_owner());
 
-				_add_shapes(col, shapes);
+				_add_shapes(col, shapes, debug_fill);
 			}
 		}
 	}
@@ -2646,10 +2652,13 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 	return p_node;
 }
 
-void ResourceImporterScene::_add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes) {
+void ResourceImporterScene::_add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes, bool p_debug_fill) {
 	for (const Ref<Shape3D> &E : p_shapes) {
 		CollisionShape3D *cshape = memnew(CollisionShape3D);
 		cshape->set_shape(E);
+#ifdef DEBUG_ENABLED
+		cshape->set_debug_fill_enabled(p_debug_fill);
+#endif
 		p_node->add_child(cshape, true);
 
 		cshape->set_owner(p_node->get_owner());

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -219,7 +219,7 @@ class ResourceImporterScene : public ResourceImporter {
 	Array _get_skinned_pose_transforms(ImporterMeshInstance3D *p_src_mesh_node);
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
 	Node *_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches);
-	void _add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes);
+	void _add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes, bool p_debug_fill = true);
 	void _copy_meta(Object *p_src_object, Object *p_dst_object);
 
 	enum AnimationImportTracks {

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -177,6 +177,9 @@ void MeshInstance3DEditor::_create_collision_shape() {
 			for (Ref<Shape3D> shape : shapes) {
 				CollisionShape3D *cshape = memnew(CollisionShape3D);
 				cshape->set_shape(shape);
+#ifdef DEBUG_ENABLED
+				cshape->set_debug_fill_enabled(shape_type_option != SHAPE_TYPE_TRIMESH);
+#endif
 				body->add_child(cshape, true);
 				ur->add_do_method(cshape, "set_owner", owner);
 				ur->add_do_method(Node3DEditor::get_singleton(), SceneStringName(_request_gizmo), cshape);
@@ -189,6 +192,9 @@ void MeshInstance3DEditor::_create_collision_shape() {
 				cshape->set_shape(shape);
 				cshape->set_name("CollisionShape3D");
 				cshape->set_transform(node->get_transform());
+#ifdef DEBUG_ENABLED
+				cshape->set_debug_fill_enabled(shape_type_option != SHAPE_TYPE_TRIMESH);
+#endif
 				ur->add_do_method(E, "add_sibling", cshape, true);
 				ur->add_do_method(cshape, "set_owner", owner);
 				ur->add_do_method(Node3DEditor::get_singleton(), SceneStringName(_request_gizmo), cshape);

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -140,6 +140,9 @@ void CSGShapeEditor::_create_baked_collision_shape() {
 
 	CollisionShape3D *cshape = memnew(CollisionShape3D);
 	cshape->set_shape(shape);
+#ifdef DEBUG_ENABLED
+	cshape->set_debug_fill_enabled(false);
+#endif
 	cshape->set_name("CSGBakedCollisionShape3D");
 	cshape->set_transform(node->get_transform());
 	ur->add_do_method(node, "add_sibling", cshape, true);

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -236,6 +236,9 @@ Node *MeshInstance3D::create_trimesh_collision_node() {
 	StaticBody3D *static_body = memnew(StaticBody3D);
 	CollisionShape3D *cshape = memnew(CollisionShape3D);
 	cshape->set_shape(shape);
+#ifdef DEBUG_ENABLED
+	cshape->set_debug_fill_enabled(false);
+#endif
 	static_body->add_child(cshape, true);
 	return static_body;
 }


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/99814

| Old | New |
|--------|--------|
| ![1](https://github.com/user-attachments/assets/431d93ba-bcf6-4a07-ab9a-e26777fb186d) | ![2](https://github.com/user-attachments/assets/c5cea8f3-2544-4831-9acd-71d30bd72b70) |
