### PR TITLE
Check if EditorNode exists before trying to generate preview

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -233,6 +233,7 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 	ERR_FAIL_NULL_MSG(p_scene, "The provided scene is null.");
 	ERR_FAIL_COND_MSG(p_scene->is_inside_tree(), "The scene must not be inside the tree.");
 	ERR_FAIL_COND_MSG(!Engine::get_singleton()->is_editor_hint(), "This function can only be called from the editor.");
+	ERR_FAIL_NULL_MSG(EditorNode::get_singleton(), "EditorNode doesn't exist.");
 
 	SubViewport *sub_viewport_node = memnew(SubViewport);
 	AABB scene_aabb;


### PR DESCRIPTION
EditorNode is a very heavy object that current test harness cannot create, so after https://github.com/godotengine/godot/pull/96544 editor import cannot be tested as the new code path will try to create a screenshot.

Split off from https://github.com/godotengine/godot/pull/98909