### PR TITLE
Destroy EditorFilesystem/EditorSettings on test shutdown

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -3556,5 +3556,9 @@ EditorFileSystem::EditorFileSystem() {
 }
 
 EditorFileSystem::~EditorFileSystem() {
+	if (filesystem) {
+		memdelete(filesystem);
+	}
+	filesystem = nullptr;
 	ResourceSaver::set_get_resource_id_for_path(nullptr);
 }

--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -105,6 +105,7 @@ void EditorPaths::create() {
 void EditorPaths::free() {
 	ERR_FAIL_NULL(singleton);
 	memdelete(singleton);
+	singleton = nullptr;
 }
 
 void EditorPaths::_bind_methods() {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -370,6 +370,9 @@ struct GodotTestCaseListener : public doctest::IReporter {
 		if (EditorSettings::get_singleton()) {
 			EditorSettings::destroy();
 		}
+		if (EditorPaths::get_singleton()) {
+			EditorPaths::free();
+		}
 #endif // TOOLS_ENABLED
 
 		Engine::get_singleton()->set_editor_hint(false);


### PR DESCRIPTION
Otherwise asan complains if a test tries to use these.

Split off from https://github.com/godotengine/godot/pull/98909