### PR TITLE
Add test hint

### DIFF
--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -85,6 +85,7 @@ private:
 	HashMap<StringName, Object *> singleton_ptrs;
 
 	bool editor_hint = false;
+	bool tests_hint = false;
 	bool project_manager_hint = false;
 	bool extension_reloading = false;
 
@@ -157,6 +158,9 @@ public:
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) { editor_hint = p_enabled; }
 	_FORCE_INLINE_ bool is_editor_hint() const { return editor_hint; }
 
+	_FORCE_INLINE_ void set_tests_hint(bool p_enabled) { tests_hint = p_enabled; }
+	_FORCE_INLINE_ bool is_tests_hint() const { return tests_hint; }
+
 	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) { project_manager_hint = p_enabled; }
 	_FORCE_INLINE_ bool is_project_manager_hint() const { return project_manager_hint; }
 
@@ -165,6 +169,9 @@ public:
 #else
 	_FORCE_INLINE_ void set_editor_hint(bool p_enabled) {}
 	_FORCE_INLINE_ bool is_editor_hint() const { return false; }
+
+	_FORCE_INLINE_ void set_tests_hint(bool p_enabled) {}
+	_FORCE_INLINE_ bool is_tests_hint() const { return false; }
 
 	_FORCE_INLINE_ void set_project_manager_hint(bool p_enabled) {}
 	_FORCE_INLINE_ bool is_project_manager_hint() const { return false; }

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2722,7 +2722,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		importer = ResourceFormatImporter::get_singleton()->get_importer_by_extension(p_file.get_extension());
 		load_default = true;
 		if (importer.is_null()) {
-			ERR_FAIL_V_MSG(ERR_FILE_CANT_OPEN, "BUG: File queued for import, but can't be imported, importer for type '" + importer_name + "' not found.");
+			ERR_FAIL_V_MSG(ERR_FILE_CANT_OPEN, "BUG: File '" + p_file + "' queued for import, but can't be imported, importer for type '" + importer_name + "' not found.");
 		}
 	}
 
@@ -3205,7 +3205,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 }
 
 Error EditorFileSystem::reimport_append(const String &p_file, const HashMap<StringName, Variant> &p_custom_options, const String &p_custom_importer, Variant p_generator_parameters) {
-	ERR_FAIL_COND_V_MSG(!importing, ERR_INVALID_PARAMETER, "Can only append files to import during a current reimport process.");
+	ERR_FAIL_COND_V_MSG(!Engine::get_singleton()->is_tests_hint() && !importing, ERR_INVALID_PARAMETER, "Can only append files to import during a current reimport process.");
 	Vector<String> reloads;
 	reloads.append(p_file);
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -336,6 +336,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 #ifdef TOOLS_ENABLED
 			if (name.contains("[Editor]")) {
 				Engine::get_singleton()->set_editor_hint(true);
+				Engine::get_singleton()->set_tests_hint(true);
 				EditorPaths::create();
 				EditorSettings::create();
 			}
@@ -372,6 +373,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 #endif // TOOLS_ENABLED
 
 		Engine::get_singleton()->set_editor_hint(false);
+		Engine::get_singleton()->set_tests_hint(false);
 
 		if (SceneTree::get_singleton()) {
 			SceneTree::get_singleton()->finalize();


### PR DESCRIPTION
Similar to editor_hint, this introduces a hint if the current execution is under test. It's very hard to setup the import process the same in tests - especially with nested imports - i.e. blend imports gltf which imports a texture.

Split off from https://github.com/godotengine/godot/pull/98909