### PR TITLE
Fix `switch_on_hover` for `MenuButton`

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -138,7 +138,7 @@ void MenuButton::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			MenuButton *menu_btn_other = Object::cast_to<MenuButton>(get_viewport()->gui_find_control(get_viewport()->get_mouse_position()));
+			MenuButton *menu_btn_other = Object::cast_to<MenuButton>(get_viewport()->gui_get_hovered_control());
 
 			if (menu_btn_other && menu_btn_other != this && menu_btn_other->is_switch_on_hover() && !menu_btn_other->is_disabled() &&
 					(get_parent()->is_ancestor_of(menu_btn_other) || menu_btn_other->get_parent()->is_ancestor_of(popup))) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1630,9 +1630,11 @@ void Viewport::_gui_call_notification(Control *p_control, int p_what) {
 	}
 }
 
+// `gui_find_control` doesn't take embedded windows into account. So the caller of this function
+// needs to make sure, that there is no embedded window at the specified position.
 Control *Viewport::gui_find_control(const Point2 &p_global) {
 	ERR_MAIN_THREAD_GUARD_V(nullptr);
-	// Handle subwindows.
+
 	_gui_sort_roots();
 
 	for (List<Control *>::Element *E = gui.roots.back(); E; E = E->prev()) {


### PR DESCRIPTION
Previously, embedded Windows (the opened menu) were not accounted for when checking for `switch_on_hover`.

 `gui_get_hovered_control()` is more appropriate to check for the hover status of other `MenuButton` nodes at the mouse position.

Explain the usage of the incorrectly used function in a comment.

- resolve #99842