### PR TITLE
Add DirAccess interface to file_access_memory

### DIFF
--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -31,17 +31,17 @@
 #ifndef FILE_ACCESS_MEMORY_H
 #define FILE_ACCESS_MEMORY_H
 
+#include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 
 class FileAccessMemory : public FileAccess {
-	uint8_t *data = nullptr;
-	uint64_t length = 0;
+	String current_file;
 	mutable uint64_t pos = 0;
 
 	static Ref<FileAccess> create();
 
 public:
-	static void register_file(const String &p_name, const Vector<uint8_t> &p_data);
+	static void initialize();
 	static void cleanup();
 
 	virtual Error open_custom(const uint8_t *p_data, uint64_t p_len); ///< open a file
@@ -77,6 +77,45 @@ public:
 	virtual void close() override {}
 
 	FileAccessMemory() {}
+};
+
+class DirAccessMemory : public DirAccess {
+	String current_dir;
+	List<String> list_items;
+	String current_item;
+
+	String _localize(const String &p_name) const;
+
+public:
+	virtual Error list_dir_begin() override;
+	virtual String get_next() override;
+	virtual bool current_is_dir() const override;
+	virtual bool current_is_hidden() const override;
+	virtual void list_dir_end() override;
+
+	virtual int get_drive_count() override;
+	virtual String get_drive(int p_drive) override;
+
+	virtual Error change_dir(String p_dir) override;
+	virtual String get_current_dir(bool p_include_drive = true) const override;
+
+	virtual bool file_exists(String p_file) override;
+	virtual bool dir_exists(String p_dir) override;
+
+	virtual Error make_dir(String p_dir) override;
+
+	virtual Error rename(String p_from, String p_to) override;
+	virtual Error remove(String p_name) override;
+
+	uint64_t get_space_left() override;
+
+	virtual bool is_link(String p_file) override { return false; }
+	virtual String read_link(String p_file) override { return p_file; }
+	virtual Error create_link(String p_source, String p_target) override { return FAILED; }
+
+	virtual String get_filesystem_type() const override;
+
+	DirAccessMemory() {}
 };
 
 #endif // FILE_ACCESS_MEMORY_H

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -104,6 +104,8 @@ public:
 
 protected:
 	friend class Main;
+	// Needed to reset default fs access on test start.
+	friend struct GodotTestCaseListener;
 	// Needed by tests to setup command-line args.
 	friend int test_main(int argc, char *argv[]);
 
@@ -115,6 +117,7 @@ protected:
 
 	virtual void initialize() = 0;
 	virtual void initialize_joypads() = 0;
+	virtual void initialize_default_fs_access() {}
 
 	virtual void set_main_loop(MainLoop *p_main_loop) = 0;
 	virtual void delete_main_loop() = 0;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -154,11 +154,7 @@ int OS_Unix::unix_initialize_audio(int p_audio_driver) {
 	return 0;
 }
 
-void OS_Unix::initialize_core() {
-#ifdef THREADS_ENABLED
-	init_thread_posix();
-#endif
-
+void OS_Unix::initialize_default_fs_access() {
 	FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_RESOURCES);
 	FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_USERDATA);
 	FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_FILESYSTEM);
@@ -166,6 +162,14 @@ void OS_Unix::initialize_core() {
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_RESOURCES);
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_USERDATA);
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_FILESYSTEM);
+}
+
+void OS_Unix::initialize_core() {
+#ifdef THREADS_ENABLED
+	init_thread_posix();
+#endif
+
+	initialize_default_fs_access();
 
 #ifndef UNIX_SOCKET_UNAVAILABLE
 	NetSocketUnix::make_default();

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -49,6 +49,7 @@ protected:
 	// inheriting platforms under unix (eg. X11) should handle the rest
 
 	virtual void initialize_core();
+	virtual void initialize_default_fs_access() override;
 	virtual int unix_initialize_audio(int p_audio_driver);
 
 	virtual void finalize_core() override;

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -83,9 +83,7 @@ void OS_Android::alert(const String &p_alert, const String &p_title) {
 	godot_java->alert(p_alert, p_title);
 }
 
-void OS_Android::initialize_core() {
-	OS_Unix::initialize_core();
-
+void OS_Android::initialize_default_fs_access() {
 #ifdef TOOLS_ENABLED
 	FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_RESOURCES);
 #else
@@ -109,7 +107,11 @@ void OS_Android::initialize_core() {
 #endif
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_USERDATA);
 	DirAccess::make_default<DirAccessJAndroid>(DirAccess::ACCESS_FILESYSTEM);
+}
 
+void OS_Android::initialize_core() {
+	OS_Unix::initialize_core();
+	initialize_default_fs_access();
 	NetSocketAndroid::make_default();
 }
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -99,6 +99,7 @@ public:
 
 	virtual void initialize_core() override;
 	virtual void initialize() override;
+	virtual void initialize_default_fs_access() override;
 
 	virtual void initialize_joypads() override;
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -241,6 +241,16 @@ static void _error_handler(void *p_self, const char *p_func, const char *p_file,
 }
 #endif
 
+void OS_Windows::initialize_default_fs_access() {
+	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_RESOURCES);
+	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_USERDATA);
+	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_FILESYSTEM);
+	FileAccess::make_default<FileAccessWindowsPipe>(FileAccess::ACCESS_PIPE);
+	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_RESOURCES);
+	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_USERDATA);
+	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_FILESYSTEM);
+}
+
 void OS_Windows::initialize() {
 	crash_handler.initialize();
 
@@ -254,13 +264,7 @@ void OS_Windows::initialize() {
 	init_thread_win();
 #endif
 
-	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_RESOURCES);
-	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_USERDATA);
-	FileAccess::make_default<FileAccessWindows>(FileAccess::ACCESS_FILESYSTEM);
-	FileAccess::make_default<FileAccessWindowsPipe>(FileAccess::ACCESS_PIPE);
-	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_RESOURCES);
-	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_USERDATA);
-	DirAccess::make_default<DirAccessWindows>(DirAccess::ACCESS_FILESYSTEM);
+	initialize_default_fs_access();
 
 	NetSocketWinSock::make_default();
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -140,6 +140,7 @@ class OS_Windows : public OS {
 	// functions used by main to initialize/deinitialize the OS
 protected:
 	virtual void initialize() override;
+	virtual void initialize_default_fs_access() override;
 
 	virtual void set_main_loop(MainLoop *p_main_loop) override;
 	virtual void delete_main_loop() override;

--- a/tests/core/io/test_file_access_memory.h
+++ b/tests/core/io/test_file_access_memory.h
@@ -1,0 +1,113 @@
+/**************************************************************************/
+/*  test_file_access_memory.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_FILE_ACCESS_MEMORY_H
+#define TEST_FILE_ACCESS_MEMORY_H
+
+#include "core/io/file_access.h"
+#include "core/io/file_access_memory.h"
+#include "tests/test_macros.h"
+#include "tests/test_utils.h"
+
+namespace TestFileAccessMemory {
+
+TEST_CASE("[Editor][FileAccessMemory] Read/write string") {
+	Ref<FileAccessMemory> f = FileAccessMemory::open("res://string_test", FileAccessMemory::READ_WRITE);
+	REQUIRE(!f.is_null());
+
+	f->store_string("test");
+	f->store_string(" ");
+	f->store_string("string");
+
+	f->seek(0);
+	CHECK(f->get_as_text() == "test string");
+}
+
+TEST_CASE("[Editor][FileAccessMemory] Read/write buffer") {
+	Ref<FileAccessMemory> f = FileAccessMemory::open("res://buffer_test", FileAccessMemory::READ_WRITE);
+	REQUIRE(!f.is_null());
+
+	f->seek(0);
+	f->store_64(123456);
+	f->store_32(654321);
+	f->store_16(65000);
+	f->store_8(123);
+	f->seek(0);
+
+	// Read forwards
+	CHECK(f->get_64() == 123456);
+	CHECK(f->get_32() == 654321);
+	CHECK(f->get_16() == 65000);
+	CHECK(f->get_8() == 123);
+
+	// Seek backwards
+	f->seek_end(-1);
+	CHECK(f->get_8() == 123);
+	f->seek_end(-1 - 2);
+	CHECK(f->get_16() == 65000);
+	f->seek_end(-1 - 2 - 4);
+	CHECK(f->get_32() == 654321);
+	f->seek_end(-1 - 2 - 4 - 8);
+	CHECK(f->get_64() == 123456);
+}
+
+TEST_CASE("[Editor][FileAccessMemory] Testing in memory dirs") {
+	Ref<DirAccessMemory> da = DirAccessMemory::create(DirAccess::ACCESS_RESOURCES);
+
+	// Creating subfolder to non-existent folders shouldn't work.
+	CHECK(da->make_dir("test/subfolder") == ERR_CANT_CREATE);
+
+	CHECK(da->make_dir("test") == OK);
+	CHECK(da->dir_exists("test"));
+	CHECK(da->dir_exists("res://test"));
+	CHECK_FALSE(da->dir_exists("non_existing"));
+	CHECK_FALSE(da->dir_exists("res://non_existing"));
+
+	CHECK(da->make_dir_recursive("test/subfolder\\subsub") == OK);
+	CHECK(da->dir_exists("res://test"));
+	CHECK(da->dir_exists("res://test/"));
+	CHECK(da->dir_exists("res://test/subfolder"));
+	CHECK(da->dir_exists("res://test/subfolder/"));
+	CHECK(da->dir_exists("res://test/subfolder/subsub"));
+	CHECK(da->dir_exists("res://test/subfolder/subsub/"));
+	CHECK(da->change_dir("test") == OK);
+	CHECK(da->change_dir("..") == OK);
+	CHECK(da->get_current_dir() == "res://");
+	CHECK(da->change_dir("test/subfolder//") == OK);
+
+	da->list_dir_begin();
+	CHECK(da->get_next() == "subsub");
+	CHECK(da->get_next().is_empty());
+	da->list_dir_end();
+}
+
+} // namespace TestFileAccessMemory
+
+#endif // TEST_FILE_ACCESS_MEMORY_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -44,6 +44,7 @@
 #include "tests/core/input/test_shortcut.h"
 #include "tests/core/io/test_config_file.h"
 #include "tests/core/io/test_file_access.h"
+#include "tests/core/io/test_file_access_memory.h"
 #include "tests/core/io/test_http_client.h"
 #include "tests/core/io/test_image.h"
 #include "tests/core/io/test_ip.h"
@@ -283,6 +284,8 @@ struct GodotTestCaseListener : public doctest::IReporter {
 		String name = String(p_in.m_name);
 		String suite_name = String(p_in.m_test_suite);
 
+		OS::get_singleton()->initialize_default_fs_access();
+
 		if (name.contains("[SceneTree]") || name.contains("[Editor]")) {
 			memnew(MessageQueue);
 
@@ -306,6 +309,12 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			// no residual theme from something else.
 			ThemeDB::get_singleton()->finalize_theme();
 			ThemeDB::get_singleton()->initialize_theme_noproject();
+
+			if (name.contains("[FileAccessMemory]")) {
+				FileAccessMemory::initialize();
+				DirAccess::make_default<DirAccessMemory>(DirAccess::ACCESS_RESOURCES);
+				FileAccess::make_default<FileAccessMemory>(FileAccess::ACCESS_RESOURCES);
+			}
 
 #ifndef _3D_DISABLED
 			physics_server_3d = PhysicsServer3DManager::get_singleton()->new_default_server();
@@ -382,6 +391,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 #endif // TOOLS_ENABLED
 
 		Engine::get_singleton()->set_editor_hint(false);
+		FileAccessMemory::cleanup();
 
 		if (SceneTree::get_singleton()) {
 			SceneTree::get_singleton()->finalize();


### PR DESCRIPTION
Having memory backed res:// folder is useful for hermetic tests that need to mutate contents of the resource directory.

For example in https://github.com/godotengine/godot/pull/98909 we want the res:// folder not to contain a texture imported on previous run to always test the same code path.

It requires changes to core/os/os.h so that we can re-initialize the file/dir handlers during test setup.