### PR TITLE
Fix script button press in connections dialog

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -719,6 +719,16 @@ void ConnectDialog::_advanced_pressed() {
 	popup_centered();
 }
 
+void ConnectDialog::_tree_gui_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_double_click() && mb->is_pressed()) {
+		Tree *scene_tree = tree->get_scene_tree();
+		if (scene_tree->get_pressed_button() != -1) {
+			scene_tree->emit_signal(SNAME("item_activated"));
+		}
+	}
+}
+
 ConnectDialog::ConnectDialog() {
 	set_min_size(Size2(0, 500) * EDSCALE);
 
@@ -740,6 +750,7 @@ ConnectDialog::ConnectDialog() {
 	tree->set_show_enabled_subscene(true);
 	tree->set_v_size_flags(Control::SIZE_FILL | Control::SIZE_EXPAND);
 	tree->get_scene_tree()->connect("item_activated", callable_mp(this, &ConnectDialog::_item_activated));
+	tree->get_scene_tree()->connect("gui_input", callable_mp(this, &ConnectDialog::_tree_gui_input));
 	tree->connect("node_selected", callable_mp(this, &ConnectDialog::_tree_node_selected));
 	tree->set_connect_to_script_mode(true);
 

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -157,6 +157,8 @@ private:
 	void _update_ok_enabled();
 	void _update_warning_label();
 
+	void _tree_gui_input(const Ref<InputEvent> &p_event);
+
 protected:
 	virtual void _post_popup() override;
 	void _notification(int p_what);

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -82,12 +82,13 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		return;
 	}
 
-	if (connect_to_script_mode) {
-		return; // Don't do anything in this mode.
-	}
-
 	TreeItem *item = Object::cast_to<TreeItem>(p_item);
 	ERR_FAIL_NULL(item);
+
+	if (connect_to_script_mode || connecting_signal) {
+		tree->set_selected(item);
+		return;
+	}
 
 	NodePath np = item->get_metadata(0);
 
@@ -421,7 +422,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 			p_item->add_button(0, get_editor_theme_icon(SNAME("Script")), BUTTON_SCRIPT);
 			if (EditorNode::get_singleton()->get_object_custom_type_base(p_node) == scr) {
 				// Disable button on custom scripts (pure visual cue).
-				p_item->set_button_disabled(0, p_item->get_button_count(0) - 1, true);
+				p_item->set_button_color(0, 0, get_theme_color(SNAME("icon_disabled_color"), EditorStringName(Editor)));
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/99854

Script button will now connect the signal to the script when clicked.

When script button is pressed in the Scene tree dock it opens the script so I thought it would be nice if it  opened/connected the script here too.


[Screencast_20241129_230919.webm](https://github.com/user-attachments/assets/1ed14c7d-c741-4d69-a93e-30ed3b96d29e)
