### PR TITLE
[3.x] Backport  "[Editor] Add `EditorPlugin::scene_saved` signal"

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -518,6 +518,7 @@
 		<signal name="resource_saved">
 			<argument index="0" name="resource" type="Resource" />
 			<description>
+				Emitted when the given [code]resource[/code] was saved on disc. See also [signal scene_saved], which is used for edited scenes instead of this signal. The [PackedScene] does not count as a saved resource.
 			</description>
 		</signal>
 		<signal name="scene_changed">
@@ -529,7 +530,13 @@
 		<signal name="scene_closed">
 			<argument index="0" name="filepath" type="String" />
 			<description>
-				Emitted when user closes a scene. The argument is file path to a closed scene.
+				Emitted when user closes a scene. The argument is a file path to the closed scene.
+			</description>
+		</signal>
+		<signal name="scene_saved">
+			<argument index="0" name="filepath" type="String" />
+			<description>
+				Emitted when a scene was saved on disc. The argument is a file path to the saved scene. See also [signal resource_saved], used for other resources.
 			</description>
 		</signal>
 	</signals>

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -376,6 +376,12 @@ void EditorData::notify_resource_saved(const Ref<Resource> &p_resource) {
 	}
 }
 
+void EditorData::notify_scene_saved(const String &p_path) {
+	for (int i = 0; i < editor_plugins.size(); i++) {
+		editor_plugins[i]->notify_scene_saved(p_path);
+	}
+}
+
 void EditorData::clear_editor_states() {
 	for (int i = 0; i < editor_plugins.size(); i++) {
 		editor_plugins[i]->clear();

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -208,6 +208,7 @@ public:
 	Dictionary restore_edited_scene_state(EditorSelection *p_selection, EditorHistory *p_history);
 	void notify_edited_scene_changed();
 	void notify_resource_saved(const Ref<Resource> &p_resource);
+	void notify_scene_saved(const String &p_path);
 
 	bool script_class_is_parent(const String &p_class, const String &p_inherits);
 	StringName script_class_get_base(const String &p_class) const;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1577,6 +1577,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 
 	// This needs to be emitted before saving external resources.
 	emit_signal("scene_saved", p_file);
+	editor_data.notify_scene_saved(p_file);
 
 	_save_external_resources();
 	editor_data.save_editor_external_data();

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -547,6 +547,10 @@ void EditorPlugin::notify_resource_saved(const Ref<Resource> &p_resource) {
 	emit_signal("resource_saved", p_resource);
 }
 
+void EditorPlugin::notify_scene_saved(const String &p_scene_filepath) {
+	emit_signal("scene_saved", p_scene_filepath);
+}
+
 bool EditorPlugin::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 	if (get_script_instance() && get_script_instance()->has_method("forward_canvas_gui_input")) {
 		return get_script_instance()->call("forward_canvas_gui_input", p_event);
@@ -884,6 +888,7 @@ void EditorPlugin::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("scene_closed", PropertyInfo(Variant::STRING, "filepath")));
 	ADD_SIGNAL(MethodInfo("main_screen_changed", PropertyInfo(Variant::STRING, "screen_name")));
 	ADD_SIGNAL(MethodInfo("resource_saved", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
+	ADD_SIGNAL(MethodInfo("scene_saved", PropertyInfo(Variant::STRING, "filepath")));
 
 	BIND_ENUM_CONSTANT(CONTAINER_TOOLBAR);
 	BIND_ENUM_CONSTANT(CONTAINER_SPATIAL_EDITOR_MENU);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -190,6 +190,7 @@ public:
 	void notify_scene_changed(const Node *scn_root);
 	void notify_scene_closed(const String &scene_filepath);
 	void notify_resource_saved(const Ref<Resource> &p_resource);
+	void notify_scene_saved(const String &p_scene_filepath);
 
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
 	virtual void forward_canvas_draw_over_viewport(Control *p_overlay);


### PR DESCRIPTION
`3.x` backport of 97b469c46d8a3225cc26b22952e408451192794e

I have also attempted to better-clarify the documentation in regards to the behaviour as testing revealed (at least on `3.x`); this is why the co-authored-by tag was attached to the commit.

The main usecase I foresee in 3.x, particularly with GLES2, is for automating the generation of various kinds of impostors, atlases, and generally performance-enhancing proxies.