### PR TITLE
Move reimport check to EditorImportPlugin

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -3205,7 +3205,6 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 }
 
 Error EditorFileSystem::reimport_append(const String &p_file, const HashMap<StringName, Variant> &p_custom_options, const String &p_custom_importer, Variant p_generator_parameters) {
-	ERR_FAIL_COND_V_MSG(!importing, ERR_INVALID_PARAMETER, "Can only append files to import during a current reimport process.");
 	Vector<String> reloads;
 	reloads.append(p_file);
 

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -214,6 +214,7 @@ Error EditorImportPlugin::_append_import_external_resource(const String &p_file,
 }
 
 Error EditorImportPlugin::append_import_external_resource(const String &p_file, const HashMap<StringName, Variant> &p_custom_options, const String &p_custom_importer, Variant p_generator_parameters) {
+	ERR_FAIL_COND_V_MSG(!EditorFileSystem::get_singleton()->is_importing(), ERR_INVALID_PARAMETER, "Can only append files to import during a current reimport process.");
 	return EditorFileSystem::get_singleton()->reimport_append(p_file, p_custom_options, p_custom_importer, p_generator_parameters);
 }
 


### PR DESCRIPTION
reimport_append is used by gltf_document, fbx_document and editor_import_plugin. The first two will never call it when importing == false. It's only the editor_import_plugin that should guard against that. https://docs.godotengine.org/en/stable/classes/class_editorimportplugin.html#class-editorimportplugin-method-append-import-external-resource

The motivation of removing the check from gltf_document call path is to be able to test nested imports (texture embedded in gltf).

Related to: https://github.com/godotengine/godot/pull/98909 which is trying to introduce editor import tests (as opposed to runtime import test).

I originally though of doing it by introducing a test hint (https://github.com/godotengine/godot/pull/99848), but it's probably better not to riddle the code with `if test` statements.

