### PR TITLE
Revert "basis_universal: Make tinyexr dependency explicit"

### DIFF
--- a/modules/basis_universal/config.py
+++ b/modules/basis_universal/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    env.module_add_dependencies("basis_universal", ["jpg", "tinyexr"])
+    env.module_add_dependencies("basis_universal", ["jpg"])
     return True
 
 


### PR DESCRIPTION
- Reverts #99825.

basis_universal is compiled for all targets (editor, templates), while tinyexr is an editor-only dependency.
So marking it as a mandatory dependency is breaking the dependency check and prevents building export templates.