### PR TITLE
Fix language server causing random crashes when `use_threads` is enabled

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -112,10 +112,19 @@ void GDScriptTextDocument::didSave(const Variant &p_param) {
 		}
 
 		scr->update_exports();
-		ScriptEditor::get_singleton()->reload_scripts(true);
-		ScriptEditor::get_singleton()->update_docs_from_script(scr);
-		ScriptEditor::get_singleton()->trigger_live_script_reload(scr->get_path());
+
+		if (!Thread::is_main_thread()) {
+			callable_mp(this, &GDScriptTextDocument::reload_script).call_deferred(scr);
+		} else {
+			reload_script(scr);
+		}
 	}
+}
+
+void GDScriptTextDocument::reload_script(Ref<GDScript> p_to_reload_script) {
+	ScriptEditor::get_singleton()->reload_scripts(true);
+	ScriptEditor::get_singleton()->update_docs_from_script(p_to_reload_script);
+	ScriptEditor::get_singleton()->trigger_live_script_reload(p_to_reload_script->get_path());
 }
 
 lsp::TextDocumentItem GDScriptTextDocument::load_document_item(const Variant &p_param) {

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -36,6 +36,8 @@
 #include "core/io/file_access.h"
 #include "core/object/ref_counted.h"
 
+class GDScript;
+
 class GDScriptTextDocument : public RefCounted {
 	GDCLASS(GDScriptTextDocument, RefCounted)
 protected:
@@ -49,6 +51,7 @@ protected:
 	void willSaveWaitUntil(const Variant &p_param);
 	void didSave(const Variant &p_param);
 
+	void reload_script(Ref<GDScript> p_to_reload_script);
 	void sync_script_content(const String &p_path, const String &p_content);
 	void show_native_symbol_in_editor(const String &p_symbol_id);
 


### PR DESCRIPTION
For a few years, I’ve been experiencing random crashes in VS Code when saving GDScript files, and after a long time troubleshooting, I finally found the root cause. 

The issue was that `ScriptEditor::reload_scripts` was being called directly on the language server thread when `network/language_server/use_thread` was enabled. This led to race conditions that would eventually cause the crashes.