### PR TITLE
Fix `OS::has_feature()` skipping custom features

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -536,14 +536,9 @@ bool OS::has_feature(const String &p_feature) {
 		return true;
 	}
 
-	if (has_server_feature_callback) {
-		return has_server_feature_callback(p_feature);
+	if (has_server_feature_callback && has_server_feature_callback(p_feature)) {
+		return true;
 	}
-#ifdef DEBUG_ENABLED
-	else if (is_stdout_verbose()) {
-		WARN_PRINT_ONCE("Server features cannot be checked before RenderingServer has been created. If you are checking a server feature, consider moving your OS::has_feature call after INITIALIZATION_LEVEL_SERVERS.");
-	}
-#endif
 
 	if (ProjectSettings::get_singleton()->has_custom_feature(p_feature)) {
 		return true;


### PR DESCRIPTION
Resolves #99850 

Previously, #98862 introduced a regression where `OS::has_feature()` would always skip `ProjectSettings::get_singleton()->has_custom_feature(p_feature)` once `OS::has_server_feature_callback` was set. This PR reverts the code-change to `OS::has_feature()`, restoring the original functionality.

Also due to #98862, `OS::has_feature()` printed a warning when called before `OS::has_server_feature_callback` was set. Unfortunately, this always printed in debug builds run with verbose logging due to OS-specific features that were always checked (e.g., "macos"). On platforms without those features, the check "fell-through" until they hit the warning before the final `return false`. Since this is a reasonable use-case for `OS::has_feature()` and it is not possible to differentiate between general feature checks and server feature checks, this PR removes the warning.