### PR TITLE
Synchronize `NavigationRegion2D`'s modulate to its debug elements.

### DIFF
--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -55,6 +55,7 @@ private:
 	RID debug_mesh_rid;
 	RID debug_instance_rid;
 
+	Color debug_modulate = Color(1.0, 1.0, 1.0, 1.0);
 	bool debug_mesh_dirty = true;
 
 	void _free_debug();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

The main purpose is to adjust the display of `NavigationRegion2D`'s debug mesh, to distinguish or reduce its visibility, and to avoid it being cluttered in the editor.