### PR TITLE
Allow non-tres text resources (for GDScript and C# currently) to store metadata

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -182,10 +182,14 @@ Ref<Resource> ResourceFormatLoader::load(const String &p_path, const String &p_o
 void ResourceFormatLoader::load_meta(const Ref<Resource> &p_resource, const String &p_path) {
 	// FIXME
 	// Don't have acquaintance with multi-thread programming sorry :(
+	if (!FileAccess::exists(p_path + ".gdmeta")) {
+		return;
+	}
+
 	Ref<ConfigFile> cfg = memnew(ConfigFile);
 	Error err = cfg->load(p_path + ".gdmeta");
 
-	ERR_FAIL_COND_MSG(err, "Could not load the metadata of the file '" + p_path + "'.");
+	ERR_FAIL_COND_MSG(err != OK, "Could not load the metadata of the file '" + p_path + "'.");
 
 	// To prevent from throwing the error of not having section "".
 	// Also, remove the empty gdmeta file to save more spaces.

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -32,9 +32,9 @@
 
 #include "core/config/project_settings.h"
 #include "core/core_bind.h"
+#include "core/io/config_file.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
-#include "core/io/config_file.h"
 #include "core/io/resource_importer.h"
 #include "core/object/script_language.h"
 #include "core/os/condition_variable.h"

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -72,6 +72,7 @@ protected:
 
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual void load_meta(const Ref<Resource> &p_resource, const String &p_path);
 	virtual bool exists(const String &p_path) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -30,9 +30,9 @@
 
 #include "resource_saver.h"
 #include "core/config/project_settings.h"
-#include "core/io/file_access.h"
-#include "core/io/dir_access.h"
 #include "core/io/config_file.h"
+#include "core/io/dir_access.h"
+#include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
 #include "core/object/script_language.h"
 

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -48,6 +48,7 @@ protected:
 
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
+	virtual Error save_meta(const Ref<Resource> &p_resource, const String &p_path);
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1519,6 +1519,9 @@ void EditorFileSystem::_delete_internal_files(const String &p_file) {
 	if (FileAccess::exists(p_file + ".uid")) {
 		DirAccess::remove_absolute(p_file + ".uid");
 	}
+	if (FileAccess::exists(p_file + ".gdmeta")) {
+		DirAccess::remove_absolute(p_file + ".uid");
+	}
 }
 
 int EditorFileSystem::_insert_actions_delete_files_directory(EditorFileSystemDirectory *p_dir) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1453,6 +1453,13 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 			}
 		}
 
+		if (p_item.is_file && FileAccess::exists(old_path + ".gdmeta")) {
+			err = da->rename(old_path + ".gdmeta", new_path + ".gdmeta");
+			if (err != OK) {
+				EditorNode::get_singleton()->add_io_error(TTR("Error moving:") + "\n" + old_path + ".gdmeta\n");
+			}
+		}
+
 		// Update scene if it is open.
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			String new_item_path = p_item.is_file ? new_path : file_changed_paths[i].replace_first(old_path, new_path);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -3103,7 +3103,7 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 	}
 
 	if (save_meta(p_resource, p_path) != OK) {
-		ERR_PRINT("Could not save the metadata of the file '" + p_path + "' successfully.");
+		ERR_PRINT("Could not save the metadata of GDScript file '" + p_path + "' successfully.");
 	}
 
 	if (ScriptServer::is_reload_scripts_on_save_enabled()) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -3043,6 +3043,8 @@ Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const Str
 		*r_error = scr.is_valid() ? OK : err;
 	}
 
+	load_meta(scr, p_original_path);
+
 	return scr;
 }
 
@@ -3098,6 +3100,10 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
 			return ERR_CANT_CREATE;
 		}
+	}
+
+	if (save_meta(p_resource, p_path) != OK) {
+		ERR_PRINT("Could not save the metadata of the file '" + p_path + "' successfully.");
 	}
 
 	if (ScriptServer::is_reload_scripts_on_save_enabled()) {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2862,6 +2862,8 @@ Ref<Resource> ResourceFormatLoaderCSharpScript::load(const String &p_path, const
 		*r_error = OK;
 	}
 
+	load_meta(scr, p_original_path);
+
 	return scr;
 }
 
@@ -2903,6 +2905,10 @@ Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, con
 		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
 			return ERR_CANT_CREATE;
 		}
+	}
+
+	if (save_meta(p_resource, p_path) != OK) {
+		ERR_PRINT("Could not save the metadata of C# script file '" + p_path + "' successfully.");
 	}
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
The problem comes from https://github.com/godotengine/godot/pull/99748#issuecomment-2504004205
After days of work, I finally figured out a solution.

# `.gdmeta` file
Like `.uid` files, `.gdmeta` files are actually resuffixed config files (sorry but I don't know how to parse a format data file in a better way...), which is placed in the same directory as the resource files. When a text resource (referring to a resource that is stored directly with its texts) contains metadata and is going to store its data, a `.gdmeta` file will be created in the same directory of the resource file. When a resource has no metadata while its metadata file exists, the metadata file will be removed.

# Metadata files for `GDScript` and `C#`
Currently, this PR only supports GDScript and C# to store metadata files, and the other types of text resources will be allowed soon by future PRs of mine or other contributors.
In their definitions of formatters' `save()` and `load()`, there will be `save_meta()` and `load_meta()` respectively in the middle-bottom of the method body, which are defined in `ResourceFormatSaver` and `ResourceFormatLoader` correspondingly.

# Limitations
Currently, I'm not sure whether the method `load_meta()` should be written like that, or should be written with the background of multi-thread programming (i.e. `Mutex` or something else for multi-thread work). If you have better solution, feel free to share yours in this pr. :)

# WIPs
- [x] Add `.gdmeta` file for storing metadatas of text resources, and add meta `save_meta()` and `load_meta()` for operations of the file.
- [x] Allow `GDScript` and `C#` script resources to store metadata.
- [ ] Local test and feedback solution.