### PR TITLE
[3.x] Show `TextureProgress` radial center cross only when editing the scene

### DIFF
--- a/scene/gui/texture_progress.cpp
+++ b/scene/gui/texture_progress.cpp
@@ -510,7 +510,7 @@ void TextureProgress::_notification(int p_what) {
 							}
 
 							// Draw a reference cross.
-							if (Engine::get_singleton()->is_editor_hint()) {
+							if (Engine::get_singleton()->is_editor_hint() && is_inside_tree() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->get_parent()->is_a_parent_of(this)) {
 								Point2 p;
 
 								if (nine_patch_stretch) {


### PR DESCRIPTION
Backport https://github.com/godotengine/godot/pull/99685 to 3.x to make everyone happy.
Closes https://github.com/godotengine/godot/issues/46266 Closes https://github.com/godotengine/godot/issues/96859

![godot windows tools 64_sy7BmRR3eu](https://github.com/user-attachments/assets/aa008a4c-1d6f-4109-82b7-92c4397622d8)
