### PR TITLE
Add `_enable`/`_disable_plugin` to plugin script template

### DIFF
--- a/modules/gdscript/editor/script_templates/EditorPlugin/plugin.gd
+++ b/modules/gdscript/editor/script_templates/EditorPlugin/plugin.gd
@@ -4,6 +4,16 @@
 extends _BASE_
 
 
+func _enable_plugin() -> void:
+	# Add autoloads here.
+	pass
+
+
+func _disable_plugin() -> void:
+	# Remove autoloads here.
+	pass
+
+
 func _enter_tree() -> void:
 	# Initialization of the plugin goes here.
 	pass


### PR DESCRIPTION
In godotengine/godot-docs#9979 the documentation was adjusted to use `_enable`/`_disable_plugin` for autoloads. This PR adjusts the script template to reflect that.