### PR TITLE
Do not transform Node3D gizmos if the node is not visible in tree

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -254,8 +254,10 @@ void Node3D::_notification(int p_what) {
 			ERR_THREAD_GUARD;
 
 #ifdef TOOLS_ENABLED
-			for (int i = 0; i < data.gizmos.size(); i++) {
-				data.gizmos.write[i]->transform();
+			if (is_visible_in_tree()) {
+				for (int i = 0; i < data.gizmos.size(); i++) {
+					data.gizmos.write[i]->transform();
+				}
 			}
 #endif
 		} break;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related: https://github.com/godotengine/godot/pull/98590

Updating the transform of gizmos of hidden nodes is a waste of resources. This PR improves editor performance when manipulating scenes with many hidden nodes. 