### PR TITLE
Standardize all "Prints" comments in documentation

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -388,9 +388,9 @@
 				Returns a human-readable name for the given [enum Error] code.
 				[codeblock]
 				print(OK)                              # Prints 0
-				print(error_string(OK))                # Prints OK
-				print(error_string(ERR_BUSY))          # Prints Busy
-				print(error_string(ERR_OUT_OF_MEMORY)) # Prints Out of memory
+				print(error_string(OK))                # Prints "OK"
+				print(error_string(ERR_BUSY))          # Prints "Busy"
+				print(error_string(ERR_OUT_OF_MEMORY)) # Prints "Out of memory"
 				[/codeblock]
 			</description>
 		</method>
@@ -495,23 +495,23 @@
 				Returns the [Object] that corresponds to [param instance_id]. All Objects have a unique instance ID. See also [method Object.get_instance_id].
 				[codeblocks]
 				[gdscript]
-				var foo = "bar"
+				var drink = "water"
 
 				func _ready():
 				    var id = get_instance_id()
-				    var inst = instance_from_id(id)
-				    print(inst.foo) # Prints bar
+				    var instance = instance_from_id(id)
+				    print(instance.foo) # Prints "water"
 				[/gdscript]
 				[csharp]
 				public partial class MyNode : Node
 				{
-				    public string Foo { get; set; } = "bar";
+				    public string Drink { get; set; } = "water";
 
 				    public override void _Ready()
 				    {
 				        ulong id = GetInstanceId();
-				        var inst = (MyNode)InstanceFromId(Id);
-				        GD.Print(inst.Foo); // Prints bar
+				        var instance = (MyNode)InstanceFromId(Id);
+				        GD.Print(instance.Drink); // Prints "water"
 				    }
 				}
 				[/csharp]
@@ -850,11 +850,11 @@
 				[codeblocks]
 				[gdscript]
 				var a = [1, 2, 3]
-				print("a", "b", a) # Prints ab[1, 2, 3]
+				print("a", "b", a) # Prints "ab[1, 2, 3]"
 				[/gdscript]
 				[csharp]
 				Godot.Collections.Array a = [1, 2, 3];
-				GD.Print("a", "b", a); // Prints ab[1, 2, 3]
+				GD.Print("a", "b", a); // Prints "ab[1, 2, 3]"
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] Consider using [method push_error] and [method push_warning] to print error and warning messages instead of [method print] or [method print_rich]. This distinguishes them from print messages used for debugging purposes, while also displaying a stack trace when an error or warning is printed. See also [member Engine.print_to_stdout] and [member ProjectSettings.application/run/disable_stdout].
@@ -869,10 +869,10 @@
 				When printing to standard output, the supported subset of BBCode is converted to ANSI escape codes for the terminal emulator to display. Support for ANSI escape codes varies across terminal emulators, especially for italic and strikethrough. In standard output, [code]code[/code] is represented with faint text but without any font change. Unsupported tags are left as-is in standard output.
 				[codeblocks]
 				[gdscript skip-lint]
-				print_rich("[color=green][b]Hello world![/b][/color]") # Prints out "Hello world!" in green with a bold font
+				print_rich("[color=green][b]Hello world![/b][/color]") # Prints "Hello world!", in green with a bold font.
 				[/gdscript]
 				[csharp skip-lint]
-				GD.PrintRich("[color=green][b]Hello world![/b][/color]"); // Prints out "Hello world!" in green with a bold font
+				GD.PrintRich("[color=green][b]Hello world![/b][/color]"); // Prints "Hello world!", in green with a bold font.
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] Consider using [method push_error] and [method push_warning] to print error and warning messages instead of [method print] or [method print_rich]. This distinguishes them from print messages used for debugging purposes, while also displaying a stack trace when an error or warning is printed.
@@ -907,16 +907,16 @@
 				[b]Note:[/b] The OS terminal is [i]not[/i] the same as the editor's Output dock. The output sent to the OS terminal can be seen when running Godot from a terminal. On Windows, this requires using the [code]console.exe[/code] executable.
 				[codeblocks]
 				[gdscript]
+				# Prints "ABC" to terminal.
 				printraw("A")
 				printraw("B")
 				printraw("C")
-				# Prints ABC to terminal
 				[/gdscript]
 				[csharp]
+				// Prints "ABC" to terminal.
 				GD.PrintRaw("A");
 				GD.PrintRaw("B");
 				GD.PrintRaw("C");
-				// Prints ABC to terminal
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -927,10 +927,10 @@
 				Prints one or more arguments to the console with a space between each argument.
 				[codeblocks]
 				[gdscript]
-				prints("A", "B", "C") # Prints A B C
+				prints("A", "B", "C") # Prints "A B C"
 				[/gdscript]
 				[csharp]
-				GD.PrintS("A", "B", "C"); // Prints A B C
+				GD.PrintS("A", "B", "C"); // Prints "A B C"
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -941,10 +941,10 @@
 				Prints one or more arguments to the console with a tab between each argument.
 				[codeblocks]
 				[gdscript]
-				printt("A", "B", "C") # Prints A       B       C
+				printt("A", "B", "C") # Prints "A       B       C"
 				[/gdscript]
 				[csharp]
-				GD.PrintT("A", "B", "C"); // Prints A       B       C
+				GD.PrintT("A", "B", "C"); // Prints "A       B       C"
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -955,10 +955,10 @@
 				Pushes an error message to Godot's built-in debugger and to the OS terminal.
 				[codeblocks]
 				[gdscript]
-				push_error("test error") # Prints "test error" to debugger and terminal as error call
+				push_error("test error") # Prints "test error" to debugger and terminal as an error.
 				[/gdscript]
 				[csharp]
-				GD.PushError("test error"); // Prints "test error" to debugger and terminal as error call
+				GD.PushError("test error"); // Prints "test error" to debugger and terminal as an error.
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] This function does not pause project execution. To print an error message and pause project execution in debug builds, use [code]assert(false, "test error")[/code] instead.
@@ -970,10 +970,10 @@
 				Pushes a warning message to Godot's built-in debugger and to the OS terminal.
 				[codeblocks]
 				[gdscript]
-				push_warning("test warning") # Prints "test warning" to debugger and terminal as warning call
+				push_warning("test warning") # Prints "test warning" to debugger and terminal as a warning.
 				[/gdscript]
 				[csharp]
-				GD.PushWarning("test warning"); // Prints "test warning" to debugger and terminal as warning call
+				GD.PushWarning("test warning"); // Prints "test warning" to debugger and terminal as a warning.
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -1413,9 +1413,9 @@
 			<description>
 				Returns a human-readable name of the given [param type], using the [enum Variant.Type] values.
 				[codeblock]
-				print(TYPE_INT) # Prints 2.
-				print(type_string(TYPE_INT)) # Prints "int".
-				print(type_string(TYPE_STRING)) # Prints "String".
+				print(TYPE_INT) # Prints 2
+				print(type_string(TYPE_INT)) # Prints "int"
+				print(type_string(TYPE_STRING)) # Prints "String"
 				[/codeblock]
 				See also [method typeof].
 			</description>
@@ -1429,10 +1429,10 @@
 				var json = JSON.new()
 				json.parse('["a", "b", "c"]')
 				var result = json.get_data()
-				if typeof(result) == TYPE_ARRAY:
-				    print(result[0]) # Prints a
+				if result is Array:
+				    print(result[0]) # Prints "a"
 				else:
-				    print("Unexpected result")
+				    print("Unexpected result!")
 				[/codeblock]
 				See also [method type_string].
 			</description>

--- a/doc/classes/AStarGrid2D.xml
+++ b/doc/classes/AStarGrid2D.xml
@@ -20,8 +20,8 @@
 		astarGrid.Region = new Rect2I(0, 0, 32, 32);
 		astarGrid.CellSize = new Vector2I(16, 16);
 		astarGrid.Update();
-		GD.Print(astarGrid.GetIdPath(Vector2I.Zero, new Vector2I(3, 4))); // prints (0, 0), (1, 1), (2, 2), (3, 3), (3, 4)
-		GD.Print(astarGrid.GetPointPath(Vector2I.Zero, new Vector2I(3, 4))); // prints (0, 0), (16, 16), (32, 32), (48, 48), (48, 64)
+		GD.Print(astarGrid.GetIdPath(Vector2I.Zero, new Vector2I(3, 4))); // Prints [(0, 0), (1, 1), (2, 2), (3, 3), (3, 4)]
+		GD.Print(astarGrid.GetPointPath(Vector2I.Zero, new Vector2I(3, 4))); // Prints [(0, 0), (16, 16), (32, 32), (48, 48), (48, 64)]
 		[/csharp]
 		[/codeblocks]
 		To remove a point from the pathfinding grid, it must be set as "solid" with [method set_point_solid].

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -410,7 +410,7 @@
 				    return number % 2 == 0
 
 				func _ready():
-				    print([1, 3, 4, 7].find_custom(is_even.bind())) # prints 2
+				    print([1, 3, 4, 7].find_custom(is_even.bind())) # Prints 2
 				[/gdscript]
 				[/codeblocks]
 			</description>
@@ -637,10 +637,10 @@
 				If [method max] is not desirable, this method may also be used to implement a custom comparator:
 				[codeblock]
 				func _ready():
-				    var arr = [Vector2(5, 0), Vector2(3, 4), Vector2(1, 2)]
+				    var arr = [Vector2i(5, 0), Vector2i(3, 4), Vector2i(1, 2)]
 
 				    var longest_vec = arr.reduce(func(max, vec): return vec if is_length_greater(vec, max) else max)
-				    print(longest_vec) # Prints Vector2(3, 4).
+				    print(longest_vec) # Prints (3, 4)
 
 				func is_length_greater(a, b):
 				    return a.length() &gt; b.length()
@@ -652,11 +652,11 @@
 
 				func _ready():
 				    var arr = [1, 2, 3, 4, 5]
-				    # Increment count if it's even, else leaves count the same.
+				    # If the current element is even, increment count, otherwise leave count the same.
 				    var even_count = arr.reduce(func(count, next): return count + 1 if is_even(next) else count, 0)
 				    print(even_count) # Prints 2
 				[/codeblock]
-				See also [method map], [method filter], [method any] and [method all].
+				See also [method map], [method filter], [method any], and [method all].
 			</description>
 		</method>
 		<method name="remove_at">

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -13,7 +13,7 @@
 		func test():
 		    var callable = Callable(self, "print_args")
 		    callable.call("hello", "world")  # Prints "hello world ".
-		    callable.call(Vector2.UP, 42, callable)  # Prints "(0.0, -1.0) 42 Node(node.gd)::print_args".
+		    callable.call(Vector2.UP, 42, callable)  # Prints "(0.0, -1.0) 42 Node(node.gd)::print_args"
 		    callable.call("invalid")  # Invalid call, should have at least 2 arguments.
 		[/gdscript]
 		[csharp]
@@ -28,7 +28,7 @@
 		    // Invalid calls fail silently.
 		    Callable callable = new Callable(this, MethodName.PrintArgs);
 		    callable.Call("hello", "world"); // Default parameter values are not supported, should have 3 arguments.
-		    callable.Call(Vector2.Up, 42, callable); // Prints "(0, -1) 42 Node(Node.cs)::PrintArgs".
+		    callable.Call(Vector2.Up, 42, callable); // Prints "(0, -1) 42 Node(Node.cs)::PrintArgs"
 		    callable.Call("invalid"); // Invalid call, should have 3 arguments.
 		}
 		[/csharp]
@@ -39,7 +39,7 @@
 		    var my_lambda = func (message):
 		        print(message)
 
-		    # Prints Hello everyone!
+		    # Prints "Hello everyone!"
 		    my_lambda.call("Hello everyone!")
 
 		    # Prints "Attack!", when the button_pressed signal is emitted.

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -18,7 +18,7 @@
 		if error == OK:
 		    var data_received = json.data
 		    if typeof(data_received) == TYPE_ARRAY:
-		        print(data_received) # Prints array
+		        print(data_received) # Prints the array.
 		    else:
 		        print("Unexpected data")
 		else:

--- a/doc/classes/JavaScriptObject.xml
+++ b/doc/classes/JavaScriptObject.xml
@@ -13,11 +13,13 @@
 
 		func _init():
 		    var buf = JavaScriptBridge.create_object("ArrayBuffer", 10) # new ArrayBuffer(10)
-		    print(buf) # prints [JavaScriptObject:OBJECT_ID]
+		    print(buf) # Prints [JavaScriptObject:OBJECT_ID]
 		    var uint8arr = JavaScriptBridge.create_object("Uint8Array", buf) # new Uint8Array(buf)
 		    uint8arr[1] = 255
-		    prints(uint8arr[1], uint8arr.byteLength) # prints 255 10
-		    console.log(uint8arr) # prints in browser console "Uint8Array(10) [ 0, 255, 0, 0, 0, 0, 0, 0, 0, 0 ]"
+		    prints(uint8arr[1], uint8arr.byteLength) # Prints "255 10"
+
+		    # Prints "Uint8Array(10) [ 0, 255, 0, 0, 0, 0, 0, 0, 0, 0 ]" in the browser's console.
+		    console.log(uint8arr)
 
 		    # Equivalent of JavaScriptBridge: Array.from(uint8arr).forEach(myCallback)
 		    JavaScriptBridge.get_interface("Array").from(uint8arr).forEach(_my_js_callback)

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -100,7 +100,7 @@
 
 				// propertyPath points to the "position" in the "x" axis of this node.
 				NodePath propertyPath = nodePath.GetAsPropertyPath();
-				GD.Print(propertyPath); // Prints ":position:x".
+				GD.Print(propertyPath); // Prints ":position:x"
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -118,11 +118,11 @@
 				[codeblocks]
 				[gdscript]
 				var node_path = ^"Sprite2D:texture:resource_name"
-				print(node_path.get_concatenated_subnames()) # Prints "texture:resource_name".
+				print(node_path.get_concatenated_subnames()) # Prints "texture:resource_name"
 				[/gdscript]
 				[csharp]
 				var nodePath = new NodePath("Sprite2D:texture:resource_name");
-				GD.Print(nodePath.GetConcatenatedSubnames()); // Prints "texture:resource_name".
+				GD.Print(nodePath.GetConcatenatedSubnames()); // Prints "texture:resource_name"
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -135,15 +135,15 @@
 				[codeblocks]
 				[gdscript]
 				var sprite_path = NodePath("../RigidBody2D/Sprite2D")
-				print(sprite_path.get_name(0)) # Prints "..".
-				print(sprite_path.get_name(1)) # Prints "RigidBody2D".
-				print(sprite_path.get_name(2)) # Prints "Sprite".
+				print(sprite_path.get_name(0)) # Prints ".."
+				print(sprite_path.get_name(1)) # Prints "RigidBody2D"
+				print(sprite_path.get_name(2)) # Prints "Sprite"
 				[/gdscript]
 				[csharp]
 				var spritePath = new NodePath("../RigidBody2D/Sprite2D");
-				GD.Print(spritePath.GetName(0)); // Prints "..".
-				GD.Print(spritePath.GetName(1)); // Prints "PathFollow2D".
-				GD.Print(spritePath.GetName(2)); // Prints "Sprite".
+				GD.Print(spritePath.GetName(0)); // Prints ".."
+				GD.Print(spritePath.GetName(1)); // Prints "PathFollow2D"
+				GD.Print(spritePath.GetName(2)); // Prints "Sprite"
 				[/csharp]
 				[/codeblocks]
 			</description>
@@ -163,13 +163,13 @@
 				[codeblocks]
 				[gdscript]
 				var path_to_name = NodePath("Sprite2D:texture:resource_name")
-				print(path_to_name.get_subname(0)) # Prints "texture".
-				print(path_to_name.get_subname(1)) # Prints "resource_name".
+				print(path_to_name.get_subname(0)) # Prints "texture"
+				print(path_to_name.get_subname(1)) # Prints "resource_name"
 				[/gdscript]
 				[csharp]
 				var pathToName = new NodePath("Sprite2D:texture:resource_name");
-				GD.Print(pathToName.GetSubname(0)); // Prints "texture".
-				GD.Print(pathToName.GetSubname(1)); // Prints "resource_name".
+				GD.Print(pathToName.GetSubname(0)); // Prints "texture"
+				GD.Print(pathToName.GetSubname(1)); // Prints "resource_name"
 				[/csharp]
 				[/codeblocks]
 			</description>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -366,11 +366,11 @@
 				[codeblocks]
 				[gdscript]
 				var array = PackedByteArray([11, 46, 255])
-				print(array.hex_encode()) # Prints: 0b2eff
+				print(array.hex_encode()) # Prints "0b2eff"
 				[/gdscript]
 				[csharp]
 				byte[] array = [11, 46, 255];
-				GD.Print(array.HexEncode()); // Prints: 0b2eff
+				GD.Print(array.HexEncode()); // Prints "0b2eff"
 				[/csharp]
 				[/codeblocks]
 			</description>

--- a/doc/classes/PackedDataContainer.xml
+++ b/doc/classes/PackedDataContainer.xml
@@ -16,11 +16,12 @@
 		var container = load("packed_data.res")
 		for key in container:
 		    prints(key, container[key])
-
-		# Prints:
-		# key value
-		# lock (0, 0)
-		# another_key 123
+		[/codeblock]
+		Prints:
+		[codeblock lang=text]
+		key value
+		lock (0, 0)
+		another_key 123
 		[/codeblock]
 		Nested containers will be packed recursively. While iterating, they will be returned as [PackedDataContainerRef].
 	</description>

--- a/doc/classes/PackedDataContainerRef.xml
+++ b/doc/classes/PackedDataContainerRef.xml
@@ -7,7 +7,7 @@
 		When packing nested containers using [PackedDataContainer], they are recursively packed into [PackedDataContainerRef] (only applies to [Array] and [Dictionary]). Their data can be retrieved the same way as from [PackedDataContainer].
 		[codeblock]
 		var packed = PackedDataContainer.new()
-		packed.pack([1, 2, 3, ["abc", "def"], 4, 5, 6])
+		packed.pack([1, 2, 3, ["nested1", "nested2"], 4, 5, 6])
 
 		for element in packed:
 		    if element is PackedDataContainerRef:
@@ -15,16 +15,17 @@
 		            print("::", subelement)
 		    else:
 		        print(element)
-
-		# Prints:
-		# 1
-		# 2
-		# 3
-		# ::abc
-		# ::def
-		# 4
-		# 5
-		# 6
+		[/codeblock]
+		Prints:
+		[codeblock lang=text]
+		1
+		2
+		3
+		::nested1
+		::nested2
+		4
+		5
+		6
 		[/codeblock]
 	</description>
 	<tutorials>

--- a/doc/classes/RandomNumberGenerator.xml
+++ b/doc/classes/RandomNumberGenerator.xml
@@ -100,7 +100,7 @@
 			var saved_state = rng.state # Store current state.
 			print(rng.randf()) # Advance internal state.
 			rng.state = saved_state # Restore the state.
-			print(rng.randf()) # Prints the same value as in previous.
+			print(rng.randf()) # Prints the same value as previously.
 			[/codeblock]
 			[b]Note:[/b] Do not set state to arbitrary values, since the random number generator requires the state to have certain qualities to behave properly. It should only be set to values that came from the state property itself. To initialize the random number generator with arbitrary input, use [member seed] instead.
 			[b]Note:[/b] The default value of this property is pseudo-random, and changes when calling [method randomize]. The [code]0[/code] value documented here is a placeholder, and not the actual default seed.

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -47,9 +47,9 @@
 				Returns the dependencies for the resource at the given [param path].
 				[b]Note:[/b] The dependencies are returned with slices separated by [code]::[/code]. You can use [method String.get_slice] to get their components.
 				[codeblock]
-				for dep in ResourceLoader.get_dependencies(path):
-				    print(dep.get_slice("::", 0)) # Prints UID.
-				    print(dep.get_slice("::", 2)) # Prints path.
+				for dependency in ResourceLoader.get_dependencies(path):
+				    print(dependency.get_slice("::", 0)) # Prints the UID.
+				    print(dependency.get_slice("::", 2)) # Prints the path.
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -272,10 +272,10 @@
 				See also the [url=$DOCS_URL/tutorials/scripting/gdscript/gdscript_format_string.html]GDScript format string[/url] tutorial.
 				[b]Note:[/b] Each replacement is done sequentially for each element of [param values], [b]not[/b] all at once. This means that if any element is inserted and it contains another placeholder, it may be changed by the next replacement. While this can be very useful, it often causes unexpected results. If not necessary, make sure [param values]'s elements do not contain placeholders.
 				[codeblock]
-				print("{0} {1}".format(["{1}", "x"]))           # Prints "x x".
-				print("{0} {1}".format(["x", "{0}"]))           # Prints "x {0}".
-				print("{a} {b}".format({"a": "{b}", "b": "c"})) # Prints "c c".
-				print("{a} {b}".format({"b": "c", "a": "{b}"})) # Prints "{b} c".
+				print("{0} {1}".format(["{1}", "x"]))           # Prints "x x"
+				print("{0} {1}".format(["x", "{0}"]))           # Prints "x {0}"
+				print("{a} {b}".format({"a": "{b}", "b": "c"})) # Prints "c c"
+				print("{a} {b}".format({"b": "c", "a": "{b}"})) # Prints "{b} c"
 				[/codeblock]
 				[b]Note:[/b] In C#, it's recommended to [url=https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated]interpolate strings with "$"[/url], instead.
 			</description>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -255,10 +255,10 @@
 				See also the [url=$DOCS_URL/tutorials/scripting/gdscript/gdscript_format_string.html]GDScript format string[/url] tutorial.
 				[b]Note:[/b] Each replacement is done sequentially for each element of [param values], [b]not[/b] all at once. This means that if any element is inserted and it contains another placeholder, it may be changed by the next replacement. While this can be very useful, it often causes unexpected results. If not necessary, make sure [param values]'s elements do not contain placeholders.
 				[codeblock]
-				print("{0} {1}".format(["{1}", "x"]))           # Prints "x x".
-				print("{0} {1}".format(["x", "{0}"]))           # Prints "x {0}".
-				print("{a} {b}".format({"a": "{b}", "b": "c"})) # Prints "c c".
-				print("{a} {b}".format({"b": "c", "a": "{b}"})) # Prints "{b} c".
+				print("{0} {1}".format(["{1}", "x"]))           # Prints "x x"
+				print("{0} {1}".format(["x", "{0}"]))           # Prints "x {0}"
+				print("{a} {b}".format({"a": "{b}", "b": "c"})) # Prints "c c"
+				print("{a} {b}".format({"b": "c", "a": "{b}"})) # Prints "{b} c"
 				[/codeblock]
 				[b]Note:[/b] In C#, it's recommended to [url=https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated]interpolate strings with "$"[/url], instead.
 			</description>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1772,9 +1772,12 @@
 				When [param chars_per_line] is greater than zero, line break boundaries are returned instead.
 				[codeblock]
 				var ts = TextServerManager.get_primary_interface()
-				print(ts.string_get_word_breaks("The Godot Engine, 4")) # Prints [0, 3, 4, 9, 10, 16, 18, 19], which corresponds to the following substrings: "The", "Godot", "Engine", "4"
-				print(ts.string_get_word_breaks("The Godot Engine, 4", "en", 5)) # Prints [0, 3, 4, 9, 10, 15, 15, 19], which corresponds to the following substrings: "The", "Godot", "Engin", "e, 4"
-				print(ts.string_get_word_breaks("The Godot Engine, 4", "en", 10)) # Prints [0, 9, 10, 19], which corresponds to the following substrings: "The Godot", "Engine, 4"
+				# Corresponds to the substrings "The", "Godot", "Engine", and "4".
+				print(ts.string_get_word_breaks("The Godot Engine, 4")) # Prints [0, 3, 4, 9, 10, 16, 18, 19]
+				# Corresponds to the substrings "The", "Godot", "Engin", and "e, 4".
+				print(ts.string_get_word_breaks("The Godot Engine, 4", "en", 5)) # Prints [0, 3, 4, 9, 10, 15, 15, 19]
+				# Corresponds to the substrings "The Godot" and "Engine, 4".
+				print(ts.string_get_word_breaks("The Godot Engine, 4", "en", 10)) # Prints [0, 9, 10, 19]
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -213,9 +213,9 @@
 			<description>
 				Creates a unit [Vector2] rotated to the given [param angle] in radians. This is equivalent to doing [code]Vector2(cos(angle), sin(angle))[/code] or [code]Vector2.RIGHT.rotated(angle)[/code].
 				[codeblock]
-				print(Vector2.from_angle(0)) # Prints (1.0, 0.0).
+				print(Vector2.from_angle(0)) # Prints (1.0, 0.0)
 				print(Vector2(1, 0).angle()) # Prints 0.0, which is the angle used above.
-				print(Vector2.from_angle(PI / 2)) # Prints (0.0, 1.0).
+				print(Vector2.from_angle(PI / 2)) # Prints (0.0, 1.0)
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -390,7 +390,7 @@
 			<description>
 				Divides each component of the [Vector4] by the given [float].
 				[codeblock]
-				print(Vector4(10, 20, 30, 40) / 2 # Prints (5.0, 10.0, 15.0, 20.0)
+				print(Vector4(10, 20, 30, 40) / 2) # Prints (5.0, 10.0, 15.0, 20.0)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -208,7 +208,7 @@
 			<description>
 				Gets the remainder of each component of the [Vector4i] with the components of the given [Vector4i]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
-				print(Vector4i(10, -20, 30, -40) % Vector4i(7, 8, 9, 10))  # Prints (3, -4, 3, 0)
+				print(Vector4i(10, -20, 30, -40) % Vector4i(7, 8, 9, 10)) # Prints (3, -4, 3, 0)
 				[/codeblock]
 			</description>
 		</operator>
@@ -218,7 +218,7 @@
 			<description>
 				Gets the remainder of each component of the [Vector4i] with the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
-				print(Vector4i(10, -20, 30, -40) % 7)  # Prints (3, -6, 2, -5)
+				print(Vector4i(10, -20, 30, -40) % 7) # Prints (3, -6, 2, -5)
 				[/codeblock]
 			</description>
 		</operator>
@@ -287,7 +287,7 @@
 				Divides each component of the [Vector4i] by the given [float].
 				Returns a Vector4 value due to floating-point operations.
 				[codeblock]
-				print(Vector4i(10, 20, 30, 40) / 2 # Prints (5.0, 10.0, 15.0, 20.0)
+				print(Vector4i(10, 20, 30, 40) / 2) # Prints (5.0, 10.0, 15.0, 20.0)
 				[/codeblock]
 			</description>
 		</operator>

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -70,7 +70,7 @@
 			<description>
 				Multiplies each component of the [Color], including the alpha, by the given [float].
 				[codeblock]
-				print(1.5 * Color(0.5, 0.5, 0.5)) # Prints "(0.75, 0.75, 0.75, 1.5)"
+				print(1.5 * Color(0.5, 0.5, 0.5)) # Prints (0.75, 0.75, 0.75, 1.5)
 				[/codeblock]
 			</description>
 		</operator>
@@ -87,7 +87,7 @@
 			<description>
 				Multiplies each component of the [Vector2] by the given [float].
 				[codeblock]
-				print(2.5 * Vector2(1, 3)) # Prints "(2.5, 7.5)"
+				print(2.5 * Vector2(1, 3)) # Prints (2.5, 7.5)
 				[/codeblock]
 			</description>
 		</operator>


### PR DESCRIPTION
Related to
- https://github.com/godotengine/godot/pull/99089
- https://github.com/godotengine/godot/pull/99081

This PR tries to standardize the common `# Prints` comment present in a lot of the class reference. This is based off of a few rules, which are taken from my own written attempt to "explain myself":

>- Where appropriate, use the following common inline comments:
>	- `# Prints {value}`: After a `print` call. (or similar).
>	Suitable for beginner topics, where you want the user to see the result upon copying and pasting the code sample. `{value}` should be formatted **exactly** how it would be printed to the console. No trailing period.
>		- Do not encompass in quotes, unless a single String/StringName is the argument for `print`.
>		- Encompass everything in quotes, when multiple arguments in the same `print` are used.
>		- Beware of C# differences. `GD.Print()` outputs "True" and "False", trims the trailing `.0`, and outputs enum constants' names instead of their value.

~~This PR is still a draft because these rules are still not consistent.~~

-------------------------------------

As of writing this, not many additional changes are done to the affected descriptions.
Note that, in the grand scheme of things, this is an extremely minor change. Approve and merge this PR only if you feel like this is worth the localization needing to be refreshed.