### PR TITLE
Add horizontal center for ColorPicker buttons

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1850,6 +1850,7 @@ ColorPicker::ColorPicker() {
 	real_vbox->add_child(sample_hbc);
 
 	btn_pick = memnew(Button);
+	btn_pick->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	sample_hbc->add_child(btn_pick);
 
 	sample = memnew(TextureRect);
@@ -1863,6 +1864,7 @@ ColorPicker::ColorPicker() {
 	sample_hbc->add_child(btn_shape);
 	btn_shape->set_toggle_mode(true);
 	btn_shape->set_tooltip_text(ETR("Select a picker shape."));
+	btn_shape->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 
 	current_shape = SHAPE_HSV_RECTANGLE;
 


### PR DESCRIPTION
If we have some extend margins on custom theme, color picker buttons are left aligned, and cannot be centered unless we create our own buttons. Before:

![image](https://github.com/user-attachments/assets/f2e90b9e-fca2-484a-ac1c-71de4c76a139)

After:

![image](https://github.com/user-attachments/assets/2f2380e4-5980-464a-8801-129bc53a0599)


This centers them horizontally.