### PR TITLE
Buildsystem: Include icu4c into `ft_linked_deps` check

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -224,11 +224,12 @@ def configure(env: "SConsEnvironment"):
         env["builtin_zlib"],
         env["builtin_graphite"],
         env["builtin_harfbuzz"],
+        env["builtin_icu4c"],
     ]
     if (not all(ft_linked_deps)) and any(ft_linked_deps):  # All or nothing.
         print_error(
             "These libraries should be either all builtin, or all system provided:\n"
-            "freetype, libpng, zlib, graphite, harfbuzz.\n"
+            "freetype, libpng, zlib, graphite, harfbuzz, icu4c.\n"
             "Please specify `builtin_<name>=no` for all of them, or none."
         )
         sys.exit(255)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes #91401

Building `freetype, libpng, zlib, graphite, harfbuzz` as system-provided while leaving `icu4c` as built-in leads to editor crash when loading GDExtension libraries that uses `std::call_once` in static initialization. By including `builtin_icu4c` into `ft_linked_deps` check, these libraries as a whole, will be either built-in or system-provided.