### PR TITLE
Improve misleading `Unexpected "x" in class body.` GDScript parser error

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1060,8 +1060,8 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 			default:
 				// Display a completion with identifiers.
 				make_completion_context(COMPLETION_IDENTIFIER, nullptr);
-				push_error(vformat(R"(Unexpected "%s" in class body.)", current.get_name()));
 				advance();
+				push_error(vformat(R"(Unexpected %s in class body.)", previous.get_debug_name()));
 				break;
 		}
 		if (token.type != GDScriptTokenizer::Token::STATIC) {

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -164,6 +164,15 @@ const char *GDScriptTokenizer::Token::get_name() const {
 	return token_names[type];
 }
 
+String GDScriptTokenizer::Token::get_debug_name() const {
+	switch (type) {
+		case IDENTIFIER:
+			return vformat(R"(identifier "%s")", source);
+		default:
+			return vformat(R"("%s")", get_name());
+	}
+}
+
 bool GDScriptTokenizer::Token::can_precede_bin_op() const {
 	switch (type) {
 		case IDENTIFIER:

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -178,6 +178,7 @@ public:
 		String source;
 
 		const char *get_name() const;
+		String get_debug_name() const;
 		bool can_precede_bin_op() const;
 		bool is_identifier() const;
 		bool is_node_name() const;

--- a/modules/gdscript/tests/scripts/parser/errors/unexpected_token_in_class_body.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/unexpected_token_in_class_body.gd
@@ -1,0 +1,7 @@
+# GH-96792
+
+var error
+error = true
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/unexpected_token_in_class_body.out
+++ b/modules/gdscript/tests/scripts/parser/errors/unexpected_token_in_class_body.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Unexpected identifier "error" in class body.


### PR DESCRIPTION
This parser error was misleading.

Fixes:
1. Now points at correct line
2. Now prints out the raw token source for identifiers (e.g. "variable_name" instead of "Identifier")

====

**With Change:**

![image](https://github.com/user-attachments/assets/7ab9f182-51a0-4a2b-b796-345ab0bafcc9)

**Without Change (misleading):**

![image](https://github.com/user-attachments/assets/7c3b2338-30af-49b2-a31f-14a1a4191514)

* _Bugsquad edit:_ Fixes #96792.