### PR TITLE
Introduce `Viewport` functions for keeping the mouse over state consistent

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -188,6 +188,20 @@
 				If [member handle_input_locally] is set to [code]false[/code], this method will try finding the first parent viewport that is set to handle input locally, and return its value for [method is_input_handled] instead.
 			</description>
 		</method>
+		<method name="notify_mouse_entered">
+			<return type="void" />
+			<description>
+				Inform the Viewport that the mouse has entered its area. Use this function before sending an [InputEventMouseButton] or [InputEventMouseMotion] to the [Viewport] with [method Viewport.push_input]. See also [method notify_mouse_exited].
+				[b]Note:[/b] In most cases, it is not necessary to call this function because [SubViewport] nodes that are children of [SubViewportContainer] are notified automatically. This is only necessary when interacting with viewports in non-default ways, for example as textures in [TextureRect] or with an [Area3D] that forwards input events.
+			</description>
+		</method>
+		<method name="notify_mouse_exited">
+			<return type="void" />
+			<description>
+				Inform the Viewport that the mouse has left its area. Use this function when the node that displays the viewport notices the mouse has left the area of the displayed viewport. See also [method notify_mouse_entered].
+				[b]Note:[/b] In most cases, it is not necessary to call this function because [SubViewport] nodes that are children of [SubViewportContainer] are notified automatically. This is only necessary when interacting with viewports in non-default ways, for example as textures in [TextureRect] or with an [Area3D] that forwards input events.
+			</description>
+		</method>
 		<method name="push_input">
 			<return type="void" />
 			<param index="0" name="event" type="InputEvent" />

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3257,6 +3257,22 @@ void Viewport::_push_unhandled_input_internal(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void Viewport::notify_mouse_entered() {
+	if (gui.mouse_in_viewport) {
+		WARN_PRINT_ED("The Viewport was previously notified that the mouse is in its area. There is no need to notify it at this time.");
+		return;
+	}
+	notification(NOTIFICATION_VP_MOUSE_ENTER);
+}
+
+void Viewport::notify_mouse_exited() {
+	if (!gui.mouse_in_viewport) {
+		WARN_PRINT_ED("The Viewport was previously notified that the mouse has left its area. There is no need to notify it at this time.");
+		return;
+	}
+	_mouse_leave_viewport();
+}
+
 void Viewport::set_physics_object_picking(bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
 	physics_object_picking = p_enable;
@@ -4679,6 +4695,8 @@ void Viewport::_bind_methods() {
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("push_unhandled_input", "event", "in_local_coords"), &Viewport::push_unhandled_input, DEFVAL(false));
 #endif // DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("notify_mouse_entered"), &Viewport::notify_mouse_entered);
+	ClassDB::bind_method(D_METHOD("notify_mouse_exited"), &Viewport::notify_mouse_exited);
 
 	ClassDB::bind_method(D_METHOD("get_mouse_position"), &Viewport::get_mouse_position);
 	ClassDB::bind_method(D_METHOD("warp_mouse", "position"), &Viewport::warp_mouse);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -578,6 +578,8 @@ public:
 #ifndef DISABLE_DEPRECATED
 	void push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
 #endif // DISABLE_DEPRECATED
+	void notify_mouse_entered();
+	void notify_mouse_exited();
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;


### PR DESCRIPTION
- resolve #89757
- resolve #98003
- resolve parts of #97267
- resolve duplicate #90413
- supersedes #89868
- supersedes #90444
- usage demo https://github.com/godotengine/godot-demo-projects/pull/1142

Some users had problems with forwarding input events to `SubViewport` since #88992, which adjusted a default value and in effect prevented calling `gui_input` when used without changes.
I still believe, that this change makes mouse-handling more consistent. But this change makes it necessary to give users tools and instructions about how to deal with this new situation.
Previously I did believe, that sending `NOTIFICATION_VP_MOUSE_ENTER` and `NOTIFICATION_VP_MOUSE_EXIT` was sufficient (see https://github.com/godotengine/godot-demo-projects/pull/1139), but the MRP of #98003 demonstrates, that this approach still leaves some situations unresolved.

So I want to introduce with this PR two functions, that allow users to notify viewports about the mouse-over state. These two functions take care of all internal state-adjustments.

I discarded #90444 as a solution, because while it automatically handles the mouse-enter-part, users still have no solution for the mouse-exit-part.
I discarded #89868 as a solution, because it is restricted to `TextureRect` and doesn't provide a generic solution for all potential relevant nodes.

The introduction of these two function with their descriptions could be seen as either a partial or a total fix of issue #97267. 
