### PR TITLE
Avoid duplicated `utf8()` calls

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -198,11 +198,12 @@ Error PCKPacker::flush(bool p_verbose) {
 	}
 
 	for (int i = 0; i < files.size(); i++) {
-		int string_len = files[i].path.utf8().length();
+		CharString utf8_string = files[i].path.utf8();
+		int string_len = utf8_string.length();
 		int pad = _get_pad(4, string_len);
 
 		fhead->store_32(uint32_t(string_len + pad));
-		fhead->store_buffer((const uint8_t *)files[i].path.utf8().get_data(), string_len);
+		fhead->store_buffer((const uint8_t *)utf8_string.get_data(), string_len);
 		for (int j = 0; j < pad; j++) {
 			fhead->store_8(0);
 		}

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -8235,11 +8235,10 @@ PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Erro
 	const int32_t header_size = 12;
 	const int32_t chunk_header_size = 8;
 
-	int32_t padding = (chunk_header_size + json.utf8().length()) % 4;
-	json += String(" ").repeat(padding);
-
 	CharString cs = json.utf8();
-	const uint32_t text_chunk_length = cs.length();
+	int32_t padding = (chunk_header_size + cs.length()) % 4;
+
+	const uint32_t text_chunk_length = cs.length() + padding;
 
 	const uint32_t text_chunk_type = 0x4E4F534A; //JSON
 	int32_t binary_data_length = 0;
@@ -8257,6 +8256,9 @@ PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Erro
 	buffer->put_32(text_chunk_length);
 	buffer->put_32(text_chunk_type);
 	buffer->put_data((uint8_t *)&cs[0], cs.length());
+	for (int i = 0; i < padding; i++) {
+		buffer->put_8(' ');
+	}
 	if (binary_chunk_length) {
 		buffer->put_32(binary_chunk_length);
 		buffer->put_32(binary_chunk_type);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1939,7 +1939,8 @@ void DisplayServerX11::window_set_title(const String &p_title, WindowID p_window
 	Atom _net_wm_name = XInternAtom(x11_display, "_NET_WM_NAME", false);
 	Atom utf8_string = XInternAtom(x11_display, "UTF8_STRING", false);
 	if (_net_wm_name != None && utf8_string != None) {
-		XChangeProperty(x11_display, wd.x11_window, _net_wm_name, utf8_string, 8, PropModeReplace, (unsigned char *)p_title.utf8().get_data(), p_title.utf8().length());
+		CharString utf8_title = p_title.utf8();
+		XChangeProperty(x11_display, wd.x11_window, _net_wm_name, utf8_string, 8, PropModeReplace, (unsigned char *)utf8_title.get_data(), utf8_title.length());
 	}
 }
 


### PR DESCRIPTION
Added `utf8_length` in String class to avoid creating a temporary generating memory allocations, when all we need is the length.

Updated code that had such a pattern to use the new function.

Came from a discussion in [99834](https://github.com/godotengine/godot/pull/99834)