### PR TITLE
Fix `GodotSpace3D::test_body_motion()` not setting `local_shape`

### DIFF
--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -970,6 +970,7 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 
 				rcd.object = col_obj;
 				rcd.shape = shape_idx;
+				rcd.local_shape = j;
 				bool sc = GodotCollisionSolver3D::solve_static(body_shape, body_shape_xform, col_obj->get_shape(shape_idx), col_obj->get_transform() * col_obj->get_shape_transform(shape_idx), _rest_cbk_result, &rcd, nullptr, margin);
 				if (!sc) {
 					continue;


### PR DESCRIPTION
After studying and much debugging...

I compared these lines...
https://github.com/godotengine/godot/blob/893bbdfde8ad1f94fb4e6db246ff7075569396ea/modules/godot_physics_2d/godot_space_2d.cpp#L967-L973

with those.
https://github.com/godotengine/godot/blob/893bbdfde8ad1f94fb4e6db246ff7075569396ea/modules/godot_physics_3d/godot_space_3d.cpp#L971-L976

Mmmm. `godot_space_3d.cpp` seems to have a line missing. 
So I added the line missing.

And it works. (!!?!?!)

Fixes #75069