### PR TITLE
Fix loading layout with floating dock in single window mode and fix `restore_windows_on_load`

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -520,12 +520,12 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 	FileSystemDock::get_singleton()->save_layout_to_config(p_layout, p_section);
 }
 
-void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
+void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section, bool p_first_load) {
 	Dictionary floating_docks_dump = p_layout->get_value(p_section, "dock_floating", Dictionary());
 	Array dock_bottom = p_layout->get_value(p_section, "dock_bottom", Array());
 	Array closed_docks = p_layout->get_value(p_section, "dock_closed", Array());
 
-	bool restore_window_on_load = EDITOR_GET("interface/multi_window/restore_windows_on_load");
+	bool allow_floating_docks = EditorNode::get_singleton()->is_multi_window_enabled() && (!p_first_load || EDITOR_GET("interface/multi_window/restore_windows_on_load"));
 
 	// Store the docks by name for easy lookup.
 	HashMap<String, Control *> dock_map;
@@ -554,7 +554,7 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 				continue;
 			}
 			bool at_bottom = false;
-			if (restore_window_on_load && floating_docks_dump.has(name)) {
+			if (allow_floating_docks && floating_docks_dump.has(name)) {
 				all_docks[dock].previous_at_bottom = dock_bottom.has(name);
 				_restore_dock_to_saved_window(dock, floating_docks_dump[name]);
 			} else if (dock_bottom.has(name)) {

--- a/editor/editor_dock_manager.h
+++ b/editor/editor_dock_manager.h
@@ -143,7 +143,7 @@ public:
 	PopupMenu *get_docks_menu();
 
 	void save_docks_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
-	void load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section);
+	void load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section, bool p_first_load = false);
 
 	void set_dock_enabled(Control *p_dock, bool p_enabled);
 	void close_dock(Control *p_dock);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5282,7 +5282,7 @@ void EditorNode::_load_editor_layout() {
 		}
 	} else {
 		ep.step(TTR("Loading docks..."), 1, true);
-		editor_dock_manager->load_docks_from_config(config, "docks");
+		editor_dock_manager->load_docks_from_config(config, "docks", true);
 
 		ep.step(TTR("Reopening scenes..."), 2, true);
 		_load_open_scenes_from_config(config);


### PR DESCRIPTION
In single window mode, the dock will instead be docked and not floating.

To reproduce:
1. In multi-window mode, save a layout with a floating dock.
2. Change to single window mode.
3. Load that layout.

It causes the UI to be messed up:

![image](https://github.com/user-attachments/assets/7a7a7f43-dddb-416e-bcec-1310e89fcadd)

It also prints errors like: `editor/window_wrapper.cpp:222 - Condition "!is_window_available()" is true.`


Also fixes `restore_windows_on_load` preventing loading floating docks in a layout when false.
This setting should only affect the behavior when the editor is opened, and should not prevent floating windows when loading a layout (in multi-window mode).
To reproduce, disable the setting and load a layout with a floating dock.
