### PR TITLE
On bad array access error, bubble up the error

### DIFF
--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -537,7 +537,9 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 
 	if (p_generate_lods) {
 		// Use normal merge/split angles that match the defaults used for 3D scene importing.
-		mesh->generate_lods(60.0f, {});
+		Error err;
+		mesh->generate_lods(60.0f, {}, &err);
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Error while generating lods. The imported object may be corrupt.");
 	}
 
 	if (p_generate_shadow_mesh) {

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2457,7 +2457,7 @@ Array ResourceImporterScene::_get_skinned_pose_transforms(ImporterMeshInstance3D
 	return skin_pose_transform_array;
 }
 
-Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches) {
+Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches, Error *r_error) {
 	ImporterMeshInstance3D *src_mesh_node = Object::cast_to<ImporterMeshInstance3D>(p_node);
 	if (src_mesh_node) {
 		//is mesh
@@ -2571,7 +2571,17 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 
 				if (generate_lods) {
 					Array skin_pose_transform_array = _get_skinned_pose_transforms(src_mesh_node);
-					src_mesh_node->get_mesh()->generate_lods(merge_angle, skin_pose_transform_array);
+					Error err;
+					src_mesh_node->get_mesh()->generate_lods(merge_angle, skin_pose_transform_array, &err);
+					if (r_error) {
+						*r_error = err;
+					}
+					if (err != OK) {
+						if (r_error) {
+							return nullptr;
+						}
+						ERR_FAIL_V_MSG(nullptr, "Error while generating lods. The imported scene may be corrupt.");
+					}
 				}
 
 				if (create_shadow_meshes) {
@@ -2640,7 +2650,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
-		_generate_meshes(p_node->get_child(i), p_mesh_data, p_generate_lods, p_create_shadow_meshes, p_light_bake_mode, p_lightmap_texel_size, p_src_lightmap_cache, r_lightmap_caches);
+		_generate_meshes(p_node->get_child(i), p_mesh_data, p_generate_lods, p_create_shadow_meshes, p_light_bake_mode, p_lightmap_texel_size, p_src_lightmap_cache, r_lightmap_caches, r_error);
 	}
 
 	return p_node;
@@ -3075,7 +3085,8 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		}
 	}
 
-	scene = _generate_meshes(scene, mesh_data, gen_lods, create_shadow_meshes, LightBakeMode(light_bake_mode), lightmap_texel_size, src_lightmap_cache, mesh_lightmap_caches);
+	scene = _generate_meshes(scene, mesh_data, gen_lods, create_shadow_meshes, LightBakeMode(light_bake_mode), lightmap_texel_size, src_lightmap_cache, mesh_lightmap_caches, &err);
+	ERR_FAIL_COND_V_MSG(err != OK, err, "Error while generating meshes. The imported scene may be corrupt.");
 
 	if (mesh_lightmap_caches.size()) {
 		Ref<FileAccess> f = FileAccess::open(p_source_file + ".unwrap_cache", FileAccess::WRITE);

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -218,7 +218,7 @@ class ResourceImporterScene : public ResourceImporter {
 	static Error _check_resource_save_paths(const Dictionary &p_data);
 	Array _get_skinned_pose_transforms(ImporterMeshInstance3D *p_src_mesh_node);
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
-	Node *_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches);
+	Node *_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches, Error *r_error);
 	void _add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes);
 	void _copy_meta(Object *p_src_object, Object *p_dst_object);
 

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -292,7 +292,7 @@ void ImporterMesh::optimize_indices() {
 	}                                                                                                              \
 	write_array[vert_idx] = transformed_vert;
 
-void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transform_array) {
+void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transform_array, Error *r_error) {
 	if (!SurfaceTool::simplify_scale_func) {
 		return;
 	}
@@ -421,6 +421,10 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 			}
 		}
 
+		if (r_error) {
+			return;
+		}
+		ERR_FAIL_COND_MSG(index_count >= indices.size(), "Bad array access while generating lods.");
 		LocalVector<int> merged_indices;
 		merged_indices.resize(index_count);
 		for (unsigned int j = 0; j < index_count; j++) {
@@ -517,7 +521,8 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 
 void ImporterMesh::_generate_lods_bind(float p_normal_merge_angle, float p_normal_split_angle, Array p_skin_pose_transform_array) {
 	// p_normal_split_angle is unused, but kept for compatibility
-	generate_lods(p_normal_merge_angle, p_skin_pose_transform_array);
+	// _generate_lods_bind() doesn't carry an Error object or reference, so nullptr is passed down as a parameter
+	generate_lods(p_normal_merge_angle, p_skin_pose_transform_array, nullptr);
 }
 
 bool ImporterMesh::has_mesh() const {

--- a/scene/resources/3d/importer_mesh.h
+++ b/scene/resources/3d/importer_mesh.h
@@ -115,7 +115,7 @@ public:
 
 	void optimize_indices();
 
-	void generate_lods(float p_normal_merge_angle, Array p_skin_pose_transform_array);
+	void generate_lods(float p_normal_merge_angle, Array p_skin_pose_transform_array, Error *r_error);
 
 	void create_shadow_mesh();
 	Ref<ImporterMesh> get_shadow_mesh() const;


### PR DESCRIPTION
Addresses issue #98519 "Importing a large 400mb gltf/glb file crashes at 99%"

I would like to correct something incorrect that I said in a previous comment. I erroneously said before that upon importing the corrupt glb file to a new Godot project for the first time, it would remain unresponsive indefinitely. This was not actually the case. In truth, Godot only remains responsive for a very long time (about 10 minutes on my machine) but it will eventually arrive at the bad unsigned integer square brackets operation that I described, whether on the first try or any succeeding tries.

My fix does resolve the crashing for this case. It eventually returns Godot to a responsive state (as opposed to being unresponsive indefinitely), and communicates the error via notifications and on the console. It notably does NOT revert the state of the project to prior to the corrupt import.

After the exception is caught:
![image](https://github.com/user-attachments/assets/bc7c2232-59a0-47f2-aa45-d2da83013391)
![image](https://github.com/user-attachments/assets/d6c7791e-1c8b-4df4-a8db-3efb2f15ef76)
![image](https://github.com/user-attachments/assets/f644a55e-92a0-4412-b38b-bbdde01eec63)

I believe the red X icon in the FileSystem correctly indicates that the file is corrupt, which is nice.
Additionally, I am under the impression that throwing an exception from the STD library is unconventional in the codebase but I am not familiar with the desirable standard.

I would be very pleased to make whatever modifications are seen fit.