### PR TITLE
[FileAccess] Set `last_error` on file read/write errors.

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -46,10 +46,18 @@
 #include <stdlib.h>
 #endif
 
-void FileAccessUnix::check_errors() const {
+void FileAccessUnix::check_errors(bool p_write) const {
 	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
 
-	if (feof(f)) {
+	last_error = OK;
+	if (ferror(f)) {
+		if (p_write) {
+			last_error = ERR_FILE_CANT_WRITE;
+		} else {
+			last_error = ERR_FILE_CANT_READ;
+		}
+	}
+	if (!p_write && feof(f)) {
 		last_error = ERR_FILE_EOF;
 	}
 }
@@ -217,7 +225,6 @@ String FileAccessUnix::get_real_path() const {
 void FileAccessUnix::seek(uint64_t p_position) {
 	ERR_FAIL_NULL_MSG(f, "File must be opened before use.");
 
-	last_error = OK;
 	if (fseeko(f, p_position, SEEK_SET)) {
 		check_errors();
 	}
@@ -256,7 +263,7 @@ uint64_t FileAccessUnix::get_length() const {
 }
 
 bool FileAccessUnix::eof_reached() const {
-	return last_error == ERR_FILE_EOF;
+	return feof(f);
 }
 
 uint64_t FileAccessUnix::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
@@ -298,7 +305,9 @@ void FileAccessUnix::flush() {
 bool FileAccessUnix::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_NULL_V_MSG(f, false, "File must be opened before use.");
 	ERR_FAIL_COND_V(!p_src && p_length > 0, false);
-	return fwrite(p_src, 1, p_length, f) == p_length;
+	bool res = fwrite(p_src, 1, p_length, f) == p_length;
+	check_errors(true);
+	return res;
 }
 
 bool FileAccessUnix::file_exists(const String &p_path) {

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -43,7 +43,7 @@ typedef void (*CloseNotificationFunc)(const String &p_file, int p_flags);
 class FileAccessUnix : public FileAccess {
 	FILE *f = nullptr;
 	int flags = 0;
-	void check_errors() const;
+	void check_errors(bool p_write = false) const;
 	mutable Error last_error = OK;
 	String save_path;
 	String path;

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -52,10 +52,18 @@
 #define S_ISREG(m) ((m) & _S_IFREG)
 #endif
 
-void FileAccessWindows::check_errors() const {
+void FileAccessWindows::check_errors(bool p_write) const {
 	ERR_FAIL_NULL(f);
 
-	if (feof(f)) {
+	last_error = OK;
+	if (ferror(f)) {
+		if (p_write) {
+			last_error = ERR_FILE_CANT_WRITE;
+		} else {
+			last_error = ERR_FILE_CANT_READ;
+		}
+	}
+	if (!p_write && feof(f)) {
 		last_error = ERR_FILE_EOF;
 	}
 }
@@ -284,7 +292,6 @@ bool FileAccessWindows::is_open() const {
 void FileAccessWindows::seek(uint64_t p_position) {
 	ERR_FAIL_NULL(f);
 
-	last_error = OK;
 	if (_fseeki64(f, p_position, SEEK_SET)) {
 		check_errors();
 	}
@@ -320,8 +327,7 @@ uint64_t FileAccessWindows::get_length() const {
 }
 
 bool FileAccessWindows::eof_reached() const {
-	check_errors();
-	return last_error == ERR_FILE_EOF;
+	return feof(f);
 }
 
 uint64_t FileAccessWindows::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
@@ -385,7 +391,9 @@ bool FileAccessWindows::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 		prev_op = WRITE;
 	}
 
-	return fwrite(p_src, 1, p_length, f) == (size_t)p_length;
+	bool res = fwrite(p_src, 1, p_length, f) == (size_t)p_length;
+	check_errors(true);
+	return res;
 }
 
 bool FileAccessWindows::file_exists(const String &p_name) {

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -41,7 +41,7 @@
 class FileAccessWindows : public FileAccess {
 	FILE *f = nullptr;
 	int flags = 0;
-	void check_errors() const;
+	void check_errors(bool p_write = false) const;
 	mutable int prev_op = 0;
 	mutable Error last_error = OK;
 	String path;


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/78289 comments.

Also changes `eof_reached()` to use `feof` directly, since write operations do not unset EOF flag, but do unset last error.