### PR TITLE
Clean up UI of ReflectionProbe

### DIFF
--- a/editor/plugins/gizmos/reflection_probe_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/reflection_probe_gizmo_plugin.cpp
@@ -47,7 +47,7 @@ ReflectionProbeGizmoPlugin::ReflectionProbeGizmoPlugin() {
 	gizmo_color.a = 0.5;
 	create_material("reflection_internal_material", gizmo_color);
 
-	gizmo_color.a = 0.1;
+	gizmo_color.a = 0.025;
 	create_material("reflection_probe_solid_material", gizmo_color);
 
 	create_icon_material("reflection_probe_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoReflectionProbe"), EditorStringName(EditorIcons)));
@@ -165,22 +165,17 @@ void ReflectionProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		aabb.position = -size / 2;
 		aabb.size = size;
 
-		for (int i = 0; i < 8; i++) {
-			Vector3 ep = aabb.get_endpoint(i);
-			internal_lines.push_back(probe->get_origin_offset());
-			internal_lines.push_back(ep);
-		}
-
 		Vector<Vector3> handles = helper->box_get_handles(probe->get_size());
 
-		for (int i = 0; i < 3; i++) {
-			Vector3 orig_handle = probe->get_origin_offset();
-			orig_handle[i] -= 0.25;
-			lines.push_back(orig_handle);
-			handles.push_back(orig_handle);
+		if (probe->get_origin_offset() != Vector3(0.0, 0.0, 0.0)) {
+			for (int i = 0; i < 3; i++) {
+				Vector3 orig_handle = probe->get_origin_offset();
+				orig_handle[i] -= 0.25;
+				lines.push_back(orig_handle);
 
-			orig_handle[i] += 0.5;
-			lines.push_back(orig_handle);
+				orig_handle[i] += 0.5;
+				lines.push_back(orig_handle);
+			}
 		}
 
 		Ref<Material> material = get_material("reflection_probe_material", p_gizmo);


### PR DESCRIPTION
This PR cleans up some of the UI of ReflectionProbes.
Proposal: https://github.com/godotengine/godot-proposals/issues/11269
- Removed corner to center-offset lines
- Only show center-offset representation cross when center-offset actually has an offset
  - I would prefer to use an icon that shows up when the probe is selected, instead of the cross, but it doesn't look like `add_unscaled_billboard` supports offsets.
- Removed handles for the center-offset
- Significantly reduced opacity on solid box

Still missing from that proposal:
Improved bounding box handles feedback and depth, however that should be an improvement for all objects using handles, for which a separate PR makes more sense. (https://github.com/godotengine/godot/pull/60474)


| Master | this PR |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/a403c28e-0edf-4395-b7f2-96cf58d6b138) | ![image](https://github.com/user-attachments/assets/fcff7e7b-f971-4419-9031-caaeff1601af) |
| ![image](https://github.com/user-attachments/assets/e085c517-f9de-4866-8822-69954c523b43) | ![image](https://github.com/user-attachments/assets/d08d7f17-cf35-4234-a24e-9fb2abf359bd) |
