### PR TITLE
Document inverse aspect ratio convention of `Projection::get_fovy()`

### DIFF
--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -194,6 +194,7 @@
 			<param index="1" name="aspect" type="float" />
 			<description>
 				Returns the vertical field of view of the projection (in degrees) associated with the given horizontal field of view (in degrees) and aspect ratio.
+				[b]Note:[/b] Unlike most methods of [Projection], [param aspect] is expected to be 1 divided by the X:Y aspect ratio.
 			</description>
 		</method>
 		<method name="get_lod_multiplier" qualifiers="const">


### PR DESCRIPTION
`Projection::get_fovy()` takes the inverse of the "regular" X:Y aspect ratio as a argument.
I just lost 15mins today until I figured this out.

There is already an open discussion (#81394) on whether it should be harmonized or not.
This PR just documents the current status quo in the meantime as it is very misleading right now.

Test project : [get_fov.zip](https://github.com/user-attachments/files/17977162/get_fov.zip)

Script :
```GDScript
var proj = Projection.create_perspective(30, 0.8, 0.2, 10.0) # Y-fov 30 degrees, X:Y aspect 0.8
print("X fov : ", proj.get_fov())
print("X:Y aspect : ", proj.get_aspect())
print("Y:X aspect : ", 1.0 / proj.get_aspect())
print("Y fov : " , Projection.get_fovy(proj.get_fov(), 1.0 / proj.get_aspect()))
```

Output :
```
X fov : 24.1975421905518
X:Y aspect : 0.79999989271164
Y:X aspect : 1.25000016763809
Y fov : 29.9999542236328
```