### PR TITLE
[3.x] CanvasItemEditor: Fix snapping grid misalignment

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -129,7 +129,7 @@ public:
 		label->set_h_size_flags(SIZE_EXPAND_FILL);
 
 		grid_step_x = memnew(SpinBox);
-		grid_step_x->set_min(0.01);
+		grid_step_x->set_min(1);
 		grid_step_x->set_max(SPIN_BOX_GRID_RANGE);
 		grid_step_x->set_allow_greater(true);
 		grid_step_x->set_suffix("px");
@@ -137,7 +137,7 @@ public:
 		child_container->add_child(grid_step_x);
 
 		grid_step_y = memnew(SpinBox);
-		grid_step_y->set_min(0.01);
+		grid_step_y->set_min(1);
 		grid_step_y->set_max(SPIN_BOX_GRID_RANGE);
 		grid_step_y->set_allow_greater(true);
 		grid_step_y->set_suffix("px");


### PR DESCRIPTION
Cherry-picks changes from #70428 to Godot 3.X.

_Bugsquad edit_
Fixes #98466

Grid alignment is horrible broken in Godot 3.X and needs to be fixed asap, especially for pixelart games in which grid alignment is crucial.
