### PR TITLE
Remove uses of implicit static typing from the documentation

### DIFF
--- a/doc/classes/DTLSServer.xml
+++ b/doc/classes/DTLSServer.xml
@@ -11,8 +11,8 @@
 		# server_node.gd
 		extends Node
 
-		var dtls := DTLSServer.new()
-		var server := UDPServer.new()
+		var dtls = DTLSServer.new()
+		var server = UDPServer.new()
 		var peers = []
 
 		func _ready():
@@ -90,8 +90,8 @@
 		# client_node.gd
 		extends Node
 
-		var dtls := PacketPeerDTLS.new()
-		var udp := PacketPeerUDP.new()
+		var dtls = PacketPeerDTLS.new()
+		var udp = PacketPeerUDP.new()
 		var connected = false
 
 		func _ready():

--- a/doc/classes/UDPServer.xml
+++ b/doc/classes/UDPServer.xml
@@ -13,7 +13,7 @@
 		class_name ServerNode
 		extends Node
 
-		var server := UDPServer.new()
+		var server = UDPServer.new()
 		var peers = []
 
 		func _ready():
@@ -22,7 +22,7 @@
 		func _process(delta):
 		    server.poll() # Important!
 		    if server.is_connection_available():
-		        var peer: PacketPeerUDP = server.take_connection()
+		        var peer = server.take_connection()
 		        var packet = peer.get_packet()
 		        print("Accepted peer: %s:%s" % [peer.get_packet_ip(), peer.get_packet_port()])
 		        print("Received data: %s" % [packet.get_string_from_utf8()])
@@ -77,7 +77,7 @@
 		class_name ClientNode
 		extends Node
 
-		var udp := PacketPeerUDP.new()
+		var udp = PacketPeerUDP.new()
 		var connected = false
 
 		func _ready():

--- a/modules/zip/doc_classes/ZIPPacker.xml
+++ b/modules/zip/doc_classes/ZIPPacker.xml
@@ -7,8 +7,8 @@
 		This class implements a writer that allows storing the multiple blobs in a zip archive.
 		[codeblock]
 		func write_zip_file():
-		    var writer := ZIPPacker.new()
-		    var err := writer.open("user://archive.zip")
+		    var writer = ZIPPacker.new()
+		    var err = writer.open("user://archive.zip")
 		    if err != OK:
 		        return err
 		    writer.start_file("hello.txt")

--- a/modules/zip/doc_classes/ZIPReader.xml
+++ b/modules/zip/doc_classes/ZIPReader.xml
@@ -7,11 +7,11 @@
 		This class implements a reader that can extract the content of individual files inside a zip archive.
 		[codeblock]
 		func read_zip_file():
-		    var reader := ZIPReader.new()
-		    var err := reader.open("user://archive.zip")
+		    var reader = ZIPReader.new()
+		    var err = reader.open("user://archive.zip")
 		    if err != OK:
 		        return PackedByteArray()
-		    var res := reader.read_file("hello.txt")
+		    var res = reader.read_file("hello.txt")
 		    reader.close()
 		    return res
 		[/codeblock]


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/99325#discussion_r1865820604 and prior comments

TL:DR: We shouldn't use static typing in the documentation (unless it's relevant to the code example). At least _not yet_.

Use this opportunity to point out oddities within the affected descriptions. There always are.