### PR TITLE
Remove uses of static typing from the documentation

### DIFF
--- a/doc/classes/CompositorEffect.xml
+++ b/doc/classes/CompositorEffect.xml
@@ -24,7 +24,7 @@
 			If [code]true[/code] and MSAA is enabled, this will trigger a color buffer resolve before the effect is run.
 			[b]Note:[/b] In [method _render_callback], to access the resolved buffer use:
 			[codeblock]
-			var render_scene_buffers : RenderSceneBuffersRD = render_data.get_render_scene_buffers()
+			var render_scene_buffers = render_data.get_render_scene_buffers()
 			var color_buffer = render_scene_buffers.get_texture("render_buffers", "color")
 			[/codeblock]
 		</member>
@@ -32,7 +32,7 @@
 			If [code]true[/code] and MSAA is enabled, this will trigger a depth buffer resolve before the effect is run.
 			[b]Note:[/b] In [method _render_callback], to access the resolved buffer use:
 			[codeblock]
-			var render_scene_buffers : RenderSceneBuffersRD = render_data.get_render_scene_buffers()
+			var render_scene_buffers = render_data.get_render_scene_buffers()
 			var depth_buffer = render_scene_buffers.get_texture("render_buffers", "depth")
 			[/codeblock]
 		</member>
@@ -46,7 +46,7 @@
 			If [code]true[/code] this triggers motion vectors being calculated during the opaque render state.
 			[b]Note:[/b] In [method _render_callback], to access the motion vector buffer use:
 			[codeblock]
-			var render_scene_buffers : RenderSceneBuffersRD = render_data.get_render_scene_buffers()
+			var render_scene_buffers = render_data.get_render_scene_buffers()
 			var motion_buffer = render_scene_buffers.get_velocity_texture()
 			[/codeblock]
 		</member>
@@ -54,7 +54,7 @@
 			If [code]true[/code] this triggers normal and roughness data to be output during our depth pre-pass, only applicable for the Forward+ renderer.
 			[b]Note:[/b] In [method _render_callback], to access the roughness buffer use:
 			[codeblock]
-			var render_scene_buffers : RenderSceneBuffersRD = render_data.get_render_scene_buffers()
+			var render_scene_buffers = render_data.get_render_scene_buffers()
 			var roughness_buffer = render_scene_buffers.get_texture("forward_clustered", "normal_roughness")
 			[/codeblock]
 			The raw normal and roughness buffer is stored in an optimized format, different than the one available in Spatial shaders. When sampling the buffer, a conversion function must be applied. Use this function, copied from [url=https://github.com/godotengine/godot/blob/da5f39889f155658cef7f7ec3cc1abb94e17d815/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl#L334-L341]here[/url]:

--- a/doc/classes/DTLSServer.xml
+++ b/doc/classes/DTLSServer.xml
@@ -23,8 +23,8 @@
 
 		func _process(delta):
 		    while server.is_connection_available():
-		        var peer: PacketPeerUDP = server.take_connection()
-		        var dtls_peer: PacketPeerDTLS = dtls.take_connection(peer)
+		        var peer = server.take_connection()
+		        var dtls_peer = dtls.take_connection(peer)
 		        if dtls_peer.get_status() != PacketPeerDTLS.STATUS_HANDSHAKING:
 		            continue # It is normal that 50% of the connections fails due to cookie exchange.
 		        print("Peer connected!")

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -31,8 +31,8 @@
 				Below is a sample code to help get started:
 				[codeblock]
 				func _is_in_input_hotzone(in_node, in_port, mouse_position):
-				    var port_size: Vector2 = Vector2(get_theme_constant("port_grab_distance_horizontal"), get_theme_constant("port_grab_distance_vertical"))
-				    var port_pos: Vector2 = in_node.get_position() + in_node.get_input_port_position(in_port) - port_size / 2
+				    var port_size = Vector2(get_theme_constant("port_grab_distance_horizontal"), get_theme_constant("port_grab_distance_vertical"))
+				    var port_pos = in_node.get_position() + in_node.get_input_port_position(in_port) - port_size / 2
 				    var rect = Rect2(port_pos, port_size)
 
 				    return rect.has_point(mouse_position)
@@ -49,8 +49,8 @@
 				Below is a sample code to help get started:
 				[codeblock]
 				func _is_in_output_hotzone(in_node, in_port, mouse_position):
-				    var port_size: Vector2 = Vector2(get_theme_constant("port_grab_distance_horizontal"), get_theme_constant("port_grab_distance_vertical"))
-				    var port_pos: Vector2 = in_node.get_position() + in_node.get_output_port_position(in_port) - port_size / 2
+				    var port_size = Vector2(get_theme_constant("port_grab_distance_horizontal"), get_theme_constant("port_grab_distance_vertical"))
+				    var port_pos = in_node.get_position() + in_node.get_output_port_position(in_port) - port_size / 2
 				    var rect = Rect2(port_pos, port_size)
 
 				    return rect.has_point(mouse_position)

--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -9,12 +9,12 @@
 		A heightmap collision shape can also be build by using an [Image] reference:
 		[codeblocks]
 		[gdscript]
-		var heightmap_texture: Texture = ResourceLoader.load("res://heightmap_image.exr")
-		var heightmap_image: Image = heightmap_texture.get_image()
+		var heightmap_texture = ResourceLoader.load("res://heightmap_image.exr")
+		var heightmap_image = heightmap_texture.get_image()
 		heightmap_image.convert(Image.FORMAT_RF)
 
-		var height_min: float = 0.0
-		var height_max: float = 10.0
+		var height_min = 0.0
+		var height_max = 10.0
 
 		update_map_data_from_image(heightmap_image, height_min, height_max)
 		[/gdscript]

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -20,7 +20,7 @@
 		[b]Note:[/b] The image can be retrieved from an imported texture using the [method Texture2D.get_image] method, which returns a copy of the image:
 		[codeblock]
 		var texture = load("res://icon.svg")
-		var image: Image = texture.get_image()
+		var image = texture.get_image()
 		[/codeblock]
 		An [ImageTexture] is not meant to be operated from within the editor interface directly, and is mostly useful for rendering images on screen dynamically via code. If you need to generate images procedurally from within the editor, consider saving and importing images as custom texture resources implementing a new [EditorImportPlugin].
 		[b]Note:[/b] The maximum texture size is 16384×16384 pixels due to graphics hardware limitations.

--- a/doc/classes/UDPServer.xml
+++ b/doc/classes/UDPServer.xml
@@ -22,7 +22,7 @@
 		func _process(delta):
 		    server.poll() # Important!
 		    if server.is_connection_available():
-		        var peer: PacketPeerUDP = server.take_connection()
+		        var peer = server.take_connection()
 		        var packet = peer.get_packet()
 		        print("Accepted peer: %s:%s" % [peer.get_packet_ip(), peer.get_packet_port()])
 		        print("Received data: %s" % [packet.get_string_from_utf8()])

--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -123,9 +123,9 @@
 				[b]Note:[/b] Not all runtimes support all environment blend modes, so it is important to check this at startup. For example:
 				[codeblock]
 				func _ready():
-				    var xr_interface: XRInterface = XRServer.find_interface("OpenXR")
+				    var xr_interface = XRServer.find_interface("OpenXR")
 				    if xr_interface and xr_interface.is_initialized():
-				        var vp: Viewport = get_viewport()
+				        var vp = get_viewport()
 				        vp.use_xr = true
 				        var acceptable_modes = [XRInterface.XR_ENV_BLEND_MODE_OPAQUE, XRInterface.XR_ENV_BLEND_MODE_ADDITIVE]
 				        var modes = xr_interface.get_supported_environment_blend_modes()

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -734,7 +734,7 @@
 			<description>
 				Mark the following property as assigned when the [Node] is ready. Values for these properties are not assigned immediately when the node is initialized ([method Object._init]), and instead are computed and stored right before [method Node._ready].
 				[codeblock]
-				@onready var character_name: Label = $Label
+				@onready var character_name = $Label
 				[/codeblock]
 			</description>
 		</annotation>


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/99924
See https://github.com/godotengine/godot/pull/99325#discussion_r1865820604 and prior comments

TL:DR: We shouldn't use static typing in the documentation (unless it's relevant to the code example). At least _not yet_.

This is not the same PR as https://github.com/godotengine/godot/pull/99924.
The reason I decided to split the two is because the choice is not as clear-cut. Removing some of these static types may actually make the code examples worse, as I'll comment below.