### PR TITLE
Expose `CreateDialog` by adding `EditorCreateDialog` singleton (accessed via `EditorInterface`).

### DIFF
--- a/doc/classes/EditorCreateDialog.xml
+++ b/doc/classes/EditorCreateDialog.xml
@@ -32,7 +32,7 @@
 				Removes all custom suffixes for types with them.
 			</description>
 		</method>
-		<method name="get_dialog_window"  qualifiers="const">
+		<method name="get_dialog_window" qualifiers="const">
 			<return type="ConfirmationDialog" />
 			<description>
 				Returns the window of the create dialog.

--- a/doc/classes/EditorCreateDialog.xml
+++ b/doc/classes/EditorCreateDialog.xml
@@ -4,7 +4,8 @@
 		Help manage the create dialog.
 	</brief_description>
 	<description>
-		This object helps manage the create dialog selection in the editor.
+		This object helps manage the create dialog in the editor. You can manage the custom suffixes for types by calling [method set_type_custom_suffix] and [method remove_type_custom_suffix], or manage their visibility by calling [method add_type_to_blacklist] and [method remove_type_from_black_list].
+		This object also provides quick access to some key compoenents. You are allowed access the window of the create dialog and the search options tree, by calling [method get_dialog_window] and [method get_search_options]. As they are editor-owned, any operation on them should be careful; otherwise it would lead to unexpected behaviors, or irrevertible changes, or even crashes.
 		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_create_dialog].
 	</description>
 	<tutorials>

--- a/doc/classes/EditorCreateDialog.xml
+++ b/doc/classes/EditorCreateDialog.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorCreateDialog" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Help manage the create dialog.
+	</brief_description>
+	<description>
+		This object helps manage the create dialog selection in the editor.
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_create_dialog].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_type_to_blacklist">
+			<return type="void" />
+			<param index="0" name="type_name" type="StringName" />
+			<description>
+				Adds a type to the blacklist of the create dialog. If the type is already in the blacklist, nothing will happen. Types in the blacklist will not be shown in the create dialog.
+				[b]Note:[/b] Unlike [method EditorFeatureProfile.set_disable_class], this method allows you to hide custom types from the create dialog.
+				[b]Note:[/b] The built-in classes shouldn't be added to the blacklist, unless you know what you're doing.
+				[b]Note:[/b] For plugins that hides types from the create dialog, [method remove_type_from_blacklist] should be called for the hidden types when the plugin is unregistered. Otherwise, the type will never be displayed until the next start of the engine.
+			</description>
+		</method>
+		<method name="clear_type_blacklist">
+			<return type="void" />
+			<description>
+				Removes all blacklisted types from the blacklist of the create dialog.
+			</description>
+		</method>
+		<method name="clear_type_custom_suffixes">
+			<return type="void" />
+			<description>
+				Removes all custom suffixes for types with them.
+			</description>
+		</method>
+		<method name="get_dialog_window">
+			<return type="ConfirmationDialog" />
+			<description>
+				Returns the window of the create dialog.
+				[b]Warning:[/b] The window of the create dialog shouldn't be deleted. Trying removing and freeing this window will render a part of the editor useless and may cause a crash.
+			</description>
+		</method>
+		<method name="get_search_options">
+			<return type="Tree" />
+			<description>
+				Returns a tree of search options for the create dialog.
+				[b]Warning:[/b] The search options tree shouldn't be deleted. Trying removing and freeing this tree will render a part of the editor useless and may cause a crash.
+			</description>
+		</method>
+		<method name="get_type_custom_suffix">
+			<return type="String" />
+			<param index="0" name="type_name" type="StringName" />
+			<description>
+				Returns the custom suffix for the given type. If the type has no custom suffix, a [code]&ltsuffix not found&gt[/code] string will be returned. If the type is invalid, a [code]&ltinvalid suffix&gt[/code] string will be returned.
+			</description>
+		</method>
+		<method name="has_type_custom_suffix">
+			<return type="bool" />
+			<param index="0" name="type_name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the type has a custom suffix, [code]false[/code] otherwise.
+			</description>
+		</method>
+		<method name="is_type_in_blacklist">
+			<return type="bool" />
+			<param index="0" name="type_name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the type is in the blacklist, [code]false[/code] otherwise.
+			</description>
+		</method>
+		<method name="remove_type_custom_suffix">
+			<return type="void" />
+			<param index="0" name="type_name" type="StringName" />
+			<description>
+				Removes the custom suffix for the given type. If the type has no custom suffix, nothing will happen.
+				[b]Note:[/b] For plugins that adds custom suffixes to types, this method should be called in [method Node._exit_tree] of the addon script to guarantee the safe unregistration. Otherwise, the custom suffix will remain in the create dialog until the next start of the engine.
+			</description>
+		</method>
+		<method name="remove_type_from_blacklist">
+			<return type="void" />
+			<param index="0" name="type_name" type="StringName" />
+			<description>
+				Removes a type from the blacklist of the create dialog. If the type is already out of the blacklist, nothing will happen. A type removed from the blacklist will be shown in the create dialog again.
+				[b]Note:[/b] For plugins that hides types from the create dialog, this method should be called in [method Node._exit_tree] of the addon script to guarantee the safe unregistration. Otherwise, the type will never be displayed until the next start of the engine.
+				[b]Warning:[/b] Never try removing types beginning with "Editor" from the blacklist, even though this is allowed, as most of them are kernel to the editor and should keep hidden.
+			</description>
+		</method>
+		<method name="set_type_custom_suffix">
+			<return type="void" />
+			<param index="0" name="type_name" type="StringName" />
+			<param index="1" name="custom_suffix" type="String" />
+			<description>
+				Sets a custom suffix for the given type. This suffix will be appended to the type name within a pair of braces in the create dialog.
+				If the type is a global script type, the suffix will replace the file name of the script in the create dialog.
+				[b]Note:[/b] If the [param custom_suffix] is an empty string, the custom suffix for the type will be removed.
+				[b]Note:[/b] For plugins that adds custom suffixes to types, [method remove_type_custom_suffix] should be called for the types when the plugin is unregistered. Otherwise, the custom suffix will remain in the create dialog until the next start of the engine.
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="created">
+			<description>
+				Emitted when an object is created via the create dialog.
+			</description>
+		</signal>
+		<signal name="dialog_closed">
+			<description>
+				Emitted when the dialog is closed.
+			</description>
+		</signal>
+		<signal name="dialog_poped">
+			<description>
+				Emitted when the dialog is popped up.
+			</description>
+		</signal>
+		<signal name="favorites_updated">
+			<description>
+				Emitted when the favorites list is updated.
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/EditorCreateDialog.xml
+++ b/doc/classes/EditorCreateDialog.xml
@@ -4,7 +4,7 @@
 		An interface that helps manage the create dialog.
 	</brief_description>
 	<description>
-		This object helps manage the create dialog in the editor. You can manage the custom suffixes for types by calling [method set_type_custom_suffix] and [method remove_type_custom_suffix], or manage their visibility by calling [method add_type_to_blacklist] and [method remove_type_from_black_list].
+		This object helps manage the create dialog in the editor. You can manage the custom suffixes for types by calling [method set_type_custom_suffix] and [method remove_type_custom_suffix], or manage their visibility by calling [method add_type_to_blacklist] and [method remove_type_from_blacklist].
 		This object also provides quick access to some key compoenents. You are allowed access the window of the create dialog and the search options tree, by calling [method get_dialog_window] and [method get_search_options]. As they are editor-owned, any operation on them should be careful; otherwise it would lead to unexpected behaviors, or irrevertible changes, or even crashes.
 		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_create_dialog].
 	</description>

--- a/doc/classes/EditorCreateDialog.xml
+++ b/doc/classes/EditorCreateDialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="EditorCreateDialog" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Help manage the create dialog.
+		An interface that helps manage the create dialog.
 	</brief_description>
 	<description>
 		This object helps manage the create dialog in the editor. You can manage the custom suffixes for types by calling [method set_type_custom_suffix] and [method remove_type_custom_suffix], or manage their visibility by calling [method add_type_to_blacklist] and [method remove_type_from_black_list].
@@ -18,7 +18,7 @@
 				Adds a type to the blacklist of the create dialog. If the type is already in the blacklist, nothing will happen. Types in the blacklist will not be shown in the create dialog.
 				[b]Note:[/b] Unlike [method EditorFeatureProfile.set_disable_class], this method allows you to hide custom types from the create dialog.
 				[b]Note:[/b] The built-in classes shouldn't be added to the blacklist, unless you know what you're doing.
-				[b]Note:[/b] For plugins that hides types from the create dialog, [method remove_type_from_blacklist] should be called for the hidden types when the plugin is unregistered. Otherwise, the type will never be displayed until the next start of the engine.
+				[b]Note:[/b] For plugins that hides custom types from the create dialog, [method remove_type_from_blacklist] should be called for the hidden types when the plugin is unregistered. Otherwise, the type will never be displayed until the next start of the engine.
 			</description>
 		</method>
 		<method name="clear_type_blacklist">
@@ -36,14 +36,16 @@
 		<method name="get_dialog_window" qualifiers="const">
 			<return type="ConfirmationDialog" />
 			<description>
-				Returns the window of the create dialog.
-				[b]Warning:[/b] The window of the create dialog shouldn't be deleted. Trying removing and freeing this window will render a part of the editor useless and may cause a crash.
+				Returns the create dialog window.
+				[b]Note:[/b] The create dialog window is accessible only when it is visible. Otherwise, the method will return [code]null[/code] with an error.
+				[b]Warning:[/b] The create dialog window shouldn't be deleted. Trying removing and freeing this window will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
 		<method name="get_search_options" qualifiers="const">
 			<return type="Tree" />
 			<description>
 				Returns a tree of search options for the create dialog.
+				[b]Note:[/b] The search options are accessible only when the create dialog visible. Otherwise, the method will return [code]null[/code] with an error.
 				[b]Warning:[/b] The search options tree shouldn't be deleted. Trying removing and freeing this tree will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
@@ -81,8 +83,8 @@
 			<param index="0" name="type_name" type="StringName" />
 			<description>
 				Removes a type from the blacklist of the create dialog. If the type is already out of the blacklist, nothing will happen. A type removed from the blacklist will be shown in the create dialog again.
+				[b]Note:[/b] This method cannot enables the visibility of built-in types hidden by the engine.
 				[b]Note:[/b] For plugins that hides types from the create dialog, this method should be called in [method Node._exit_tree] of the addon script to guarantee the safe unregistration. Otherwise, the type will never be displayed until the next start of the engine.
-				[b]Warning:[/b] Never try removing types beginning with "Editor" from the blacklist, even though this is allowed, as most of them are kernel to the editor and should keep hidden.
 			</description>
 		</method>
 		<method name="set_type_custom_suffix">

--- a/doc/classes/EditorCreateDialog.xml
+++ b/doc/classes/EditorCreateDialog.xml
@@ -32,35 +32,35 @@
 				Removes all custom suffixes for types with them.
 			</description>
 		</method>
-		<method name="get_dialog_window">
+		<method name="get_dialog_window"  qualifiers="const">
 			<return type="ConfirmationDialog" />
 			<description>
 				Returns the window of the create dialog.
 				[b]Warning:[/b] The window of the create dialog shouldn't be deleted. Trying removing and freeing this window will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
-		<method name="get_search_options">
+		<method name="get_search_options" qualifiers="const">
 			<return type="Tree" />
 			<description>
 				Returns a tree of search options for the create dialog.
 				[b]Warning:[/b] The search options tree shouldn't be deleted. Trying removing and freeing this tree will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
-		<method name="get_type_custom_suffix">
+		<method name="get_type_custom_suffix" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="type_name" type="StringName" />
 			<description>
 				Returns the custom suffix for the given type. If the type has no custom suffix, a [code]suffix not found[/code] string will be returned. If the type is invalid, a [code]invalid suffix[/code] string will be returned.
 			</description>
 		</method>
-		<method name="has_type_custom_suffix">
+		<method name="has_type_custom_suffix" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="type_name" type="StringName" />
 			<description>
 				Returns [code]true[/code] if the type has a custom suffix, [code]false[/code] otherwise.
 			</description>
 		</method>
-		<method name="is_type_in_blacklist">
+		<method name="is_type_in_blacklist" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="type_name" type="StringName" />
 			<description>

--- a/doc/classes/EditorCreateDialog.xml
+++ b/doc/classes/EditorCreateDialog.xml
@@ -50,7 +50,7 @@
 			<return type="String" />
 			<param index="0" name="type_name" type="StringName" />
 			<description>
-				Returns the custom suffix for the given type. If the type has no custom suffix, a [code]&ltsuffix not found&gt[/code] string will be returned. If the type is invalid, a [code]&ltinvalid suffix&gt[/code] string will be returned.
+				Returns the custom suffix for the given type. If the type has no custom suffix, a [code]suffix not found[/code] string will be returned. If the type is invalid, a [code]invalid suffix[/code] string will be returned.
 			</description>
 		</method>
 		<method name="has_type_custom_suffix">

--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -57,6 +57,13 @@
 				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
+		<method name="get_create_dialog" qualifiers="const">
+			<return type="EditorCreateDialog" />
+			<description>
+				Returns the editor's [EditorCreateDialog] instance.
+				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
+			</description>
+		</method>
 		<method name="get_current_directory" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -33,6 +33,7 @@
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_feature_profile.h"
+#include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
@@ -124,7 +125,7 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 	}
 
 	if (is_base_type_node && p_type.operator String().begins_with("Editor")) {
-		return true; // Do not show editor nodes.
+		return true; // Do not show editor nodes or create dialog.
 	}
 
 	if (ClassDB::class_exists(p_type)) {
@@ -289,9 +290,15 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		r_item->set_metadata(0, p_type);
 		r_item->set_text(0, p_type);
 		String script_path = ScriptServer::get_global_class_path(p_type);
-		r_item->set_suffix(0, "(" + script_path.get_file() + ")");
-
 		Ref<Script> scr = ResourceLoader::load(script_path, "Script");
+		String suffix = script_path.get_file();
+		if (scr.is_valid() && custom_type_suffixes.has(p_type)) {
+			suffix = custom_type_suffixes[p_type];
+		}
+		if (!suffix.is_empty()) {
+			r_item->set_suffix(0, "(" + suffix + ")");
+		}
+		
 		ERR_FAIL_COND(!scr.is_valid());
 		is_abstract = scr->is_abstract();
 	} else {
@@ -817,4 +824,7 @@ CreateDialog::CreateDialog() {
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
 	set_clamp_to_embedder(true);
+
+	editor_create_dialog = memnew(EditorCreateDialog(this));
+	add_child(editor_create_dialog);
 }

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -129,7 +129,7 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 		return true; // Do not show editor nodes or create dialog.
 	}
 
-	HashSet<String> custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
+	const HashSet<String> custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
 	if (ClassDB::class_exists(p_type)) {
 		if (!ClassDB::can_instantiate(p_type) || ClassDB::is_virtual(p_type)) {
 			return true; // Can't create abstract or virtual class.

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -182,7 +182,7 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 			return true;
 		}
 		for (const StringName &E : custom_type_blacklist) {
-			if (E == ScriptServer::get_global_class_base(p_type)|| ScriptServer::get_global_class_native_base(p_type) == E) {
+			if (E == ScriptServer::get_global_class_base(p_type) || ScriptServer::get_global_class_native_base(p_type) == E) {
 				return true; // Parent type is listed in the custom blacklist.
 			}
 		}
@@ -315,7 +315,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		if (!suffix.is_empty()) {
 			r_item->set_suffix(0, "(" + suffix + ")");
 		}
-		
+
 		ERR_FAIL_COND(!scr.is_valid());
 		is_abstract = scr->is_abstract();
 	} else {

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -129,7 +129,7 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 		return true; // Do not show editor nodes or create dialog.
 	}
 
-	const HashSet<StringName> custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
+	const HashSet<StringName> &custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
 	if (ClassDB::class_exists(p_type)) {
 		if (!ClassDB::can_instantiate(p_type) || ClassDB::is_virtual(p_type)) {
 			return true; // Can't create abstract or virtual class.

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -129,7 +129,7 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 		return true; // Do not show editor nodes or create dialog.
 	}
 
-	const HashSet<String> custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
+	const HashSet<String> &custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
 	if (ClassDB::class_exists(p_type)) {
 		if (!ClassDB::can_instantiate(p_type) || ClassDB::is_virtual(p_type)) {
 			return true; // Can't create abstract or virtual class.

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -129,7 +129,7 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 		return true; // Do not show editor nodes or create dialog.
 	}
 
-	const HashSet<String> custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
+	const HashSet<StringName> custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
 	if (ClassDB::class_exists(p_type)) {
 		if (!ClassDB::can_instantiate(p_type) || ClassDB::is_virtual(p_type)) {
 			return true; // Can't create abstract or virtual class.

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -129,7 +129,7 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 		return true; // Do not show editor nodes or create dialog.
 	}
 
-	const HashSet<String> &custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
+	const HashSet<String> custom_type_blacklist = EditorInterface::get_singleton()->get_create_dialog()->get_type_blacklist();
 	if (ClassDB::class_exists(p_type)) {
 		if (!ClassDB::can_instantiate(p_type) || ClassDB::is_virtual(p_type)) {
 			return true; // Can't create abstract or virtual class.
@@ -148,8 +148,8 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 				return true; // Parent type is blacklisted.
 			}
 		}
-		for (const StringName &E : custom_type_blacklist) {
-			if (ClassDB::is_parent_class(p_type, E)) {
+		for (const StringName &F : custom_type_blacklist) {
+			if (ClassDB::is_parent_class(p_type, F)) {
 				return true; // Parent type is listed in the custom blacklist.
 			}
 		}

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -31,12 +31,15 @@
 #ifndef CREATE_DIALOG_H
 #define CREATE_DIALOG_H
 
+#include "editor/editor_create_dialog.h"
 #include "editor/editor_help.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/tree.h"
+
+class EditorCreateDialog;
 
 class CreateDialog : public ConfirmationDialog {
 	GDCLASS(CreateDialog, ConfirmationDialog);
@@ -47,6 +50,7 @@ class CreateDialog : public ConfirmationDialog {
 		OTHER_TYPE
 	};
 
+	EditorCreateDialog *editor_create_dialog = nullptr;
 	LineEdit *search_box = nullptr;
 	Tree *search_options = nullptr;
 
@@ -64,6 +68,7 @@ class CreateDialog : public ConfirmationDialog {
 	HashMap<String, TreeItem *> search_options_types;
 	HashMap<String, String> custom_type_parents;
 	HashMap<String, int> custom_type_indices;
+	HashMap<StringName, String> custom_type_suffixes;
 	List<StringName> type_list;
 	HashSet<StringName> type_blacklist;
 
@@ -108,6 +113,10 @@ protected:
 	void _save_and_update_favorite_list();
 
 public:
+	// Allow EditorCreateDialog, the helper of CreateDialog,
+	// to get access to private members for fast access and less declarations of setters and getters.
+	friend class EditorCreateDialog;
+
 	Variant instantiate_selected();
 	String get_selected_type();
 

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -31,7 +31,6 @@
 #ifndef CREATE_DIALOG_H
 #define CREATE_DIALOG_H
 
-#include "editor/editor_create_dialog.h"
 #include "editor/editor_help.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
@@ -50,7 +49,6 @@ class CreateDialog : public ConfirmationDialog {
 		OTHER_TYPE
 	};
 
-	EditorCreateDialog *editor_create_dialog = nullptr;
 	LineEdit *search_box = nullptr;
 	Tree *search_options = nullptr;
 
@@ -68,7 +66,6 @@ class CreateDialog : public ConfirmationDialog {
 	HashMap<String, TreeItem *> search_options_types;
 	HashMap<String, String> custom_type_parents;
 	HashMap<String, int> custom_type_indices;
-	HashMap<StringName, String> custom_type_suffixes;
 	List<StringName> type_list;
 	HashSet<StringName> type_blacklist;
 

--- a/editor/editor_create_dialog.cpp
+++ b/editor/editor_create_dialog.cpp
@@ -1,0 +1,129 @@
+/**************************************************************************/
+/*  editor_create_dialog.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_create_dialog.h"
+
+#include "editor/editor_interface.h"
+
+void EditorCreateDialog::_notify_visibility_changed() {
+	CHECK_IF_NO_BOUND_CREATE_DIALOG;
+	EditorInterface::get_singleton()->emit_signal(create_dialog->is_visible() ? "create_dialog_showed" : "create_dialog_hid", this);
+}
+
+void EditorCreateDialog::_notify_favourites_updated() {
+	emit_signal("favorites_updated");
+}
+
+void EditorCreateDialog::_notify_created() {
+	emit_signal("created");
+}
+
+void EditorCreateDialog::add_type_to_blacklist(const StringName &p_type_name) {
+	CHECK_IF_NO_BOUND_CREATE_DIALOG;
+	ERR_FAIL_COND_MSG(!ClassDB::is_parent_class(p_type_name, "Object"), vformat("Inexist type %s.", p_type_name));
+
+	if (create_dialog->type_blacklist.has(p_type_name)) {
+		return;
+	}
+
+	create_dialog->type_blacklist.insert(p_type_name);
+	create_dialog->_update_search();
+}
+
+void EditorCreateDialog::remove_type_from_blacklist(const StringName &p_type_name) {
+	CHECK_IF_NO_BOUND_CREATE_DIALOG;
+	ERR_FAIL_COND_MSG(!ClassDB::is_parent_class(p_type_name, "Object"), vformat("Inexist type %s.", p_type_name));
+
+	if (!create_dialog->type_blacklist.has(p_type_name)) {
+		return;
+	}
+
+	create_dialog->type_blacklist.erase(p_type_name);
+	create_dialog->_update_search();
+}
+
+void EditorCreateDialog::set_type_custom_suffix(const StringName &p_type_name, const String &p_custom_suffix) {
+	CHECK_IF_NO_BOUND_CREATE_DIALOG;
+	ERR_FAIL_COND_MSG(!ClassDB::is_parent_class(p_type_name, "Object"), vformat("Inexist type %s.", p_type_name));
+
+	if (create_dialog->custom_type_suffixes.has(p_type_name)) {
+		create_dialog->custom_type_suffixes[p_type_name] = p_custom_suffix;
+	} else {
+		create_dialog->custom_type_suffixes.insert(p_type_name, p_custom_suffix);
+	}
+	create_dialog->_update_search();
+}
+
+String EditorCreateDialog::get_type_custom_suffix(const StringName &p_type_name) const {
+	CHECK_IF_NO_BOUND_CREATE_DIALOG_V("");
+	ERR_FAIL_COND_V_MSG(!ClassDB::is_parent_class(p_type_name, "Object"), "", vformat("Inexist type %s.", p_type_name));
+	return create_dialog->custom_type_suffixes.has(p_type_name) ? create_dialog->custom_type_suffixes.get(p_type_name) : "";
+}
+
+void EditorCreateDialog::clear_all_type_custom_suffixes() {
+	CHECK_IF_NO_BOUND_CREATE_DIALOG;
+	create_dialog->custom_type_suffixes.clear();
+	create_dialog->_update_search();
+}
+
+Tree *EditorCreateDialog::get_search_options() const {
+	CHECK_IF_NO_BOUND_CREATE_DIALOG_V(nullptr);
+	return create_dialog->search_options;
+}
+
+void EditorCreateDialog::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_type_to_blacklist", "type_name"), &EditorCreateDialog::add_type_to_blacklist);
+	ClassDB::bind_method(D_METHOD("remove_type_from_blacklist", "type_name"), &EditorCreateDialog::remove_type_from_blacklist);
+	ClassDB::bind_method(D_METHOD("set_type_custom_suffix", "type_name", "custom_suffix"), &EditorCreateDialog::set_type_custom_suffix);
+	ClassDB::bind_method(D_METHOD("get_type_custom_suffix", "type_name"), &EditorCreateDialog::get_type_custom_suffix);
+	ClassDB::bind_method(D_METHOD("clear_all_type_custom_suffixes"), &EditorCreateDialog::clear_all_type_custom_suffixes);
+	ClassDB::bind_method(D_METHOD("get_search_options"), &EditorCreateDialog::get_search_options);
+
+	ADD_SIGNAL(MethodInfo("create"));
+	ADD_SIGNAL(MethodInfo("favorites_updated"));
+}
+
+EditorCreateDialog::EditorCreateDialog() {
+	ERR_PRINT("Cannot instantiate an editor create dialog without binding create dialog. The editor create dialog was deleted.");
+	memdelete(this);
+}
+
+EditorCreateDialog::EditorCreateDialog(CreateDialog *p_create_dialog) {
+	create_dialog = p_create_dialog;
+	if (create_dialog != nullptr) {
+		print_line(vformat(R"(Connecting signals from %s to %s)", create_dialog->get_name(), get_name()));
+		create_dialog->connect("visibility_changed", callable_mp(this, &EditorCreateDialog::_notify_visibility_changed));
+		create_dialog->connect("create", callable_mp(this, &EditorCreateDialog::_notify_created));
+		create_dialog->connect("favorites_updated", callable_mp(this, &EditorCreateDialog::_notify_favourites_updated));
+	} else {
+		ERR_PRINT("Cannot instantiate an editor create dialog without binding create dialog. The editor create dialog was deleted.");
+		memdelete(this);
+	}
+}

--- a/editor/editor_create_dialog.cpp
+++ b/editor/editor_create_dialog.cpp
@@ -30,67 +30,72 @@
 
 #include "editor_create_dialog.h"
 
-#include "editor/editor_interface.h"
+EditorCreateDialog *EditorCreateDialog::singleton = nullptr;
 
-void EditorCreateDialog::_notify_visibility_changed() {
-	CHECK_IF_NO_BOUND_CREATE_DIALOG;
-	EditorInterface::get_singleton()->emit_signal(create_dialog->is_visible() ? "create_dialog_showed" : "create_dialog_hid", this);
+bool EditorCreateDialog::_is_type_valid(const StringName &p_type_name) const {
+	return ClassDB::class_exists(p_type_name) || ScriptServer::is_global_class(p_type_name);
 }
 
-void EditorCreateDialog::_notify_favourites_updated() {
-	emit_signal("favorites_updated");
+void EditorCreateDialog::set_create_dialog(CreateDialog *p_create_dialog) {
+	create_dialog = p_create_dialog;
 }
 
-void EditorCreateDialog::_notify_created() {
-	emit_signal("created");
+CreateDialog *EditorCreateDialog::get_create_dialog() const {
+	return create_dialog;
+}
+
+ConfirmationDialog *EditorCreateDialog::get_dialog_window() const {
+	return Object::cast_to<ConfirmationDialog>(create_dialog);
 }
 
 void EditorCreateDialog::add_type_to_blacklist(const StringName &p_type_name) {
-	CHECK_IF_NO_BOUND_CREATE_DIALOG;
-	ERR_FAIL_COND_MSG(!ClassDB::is_parent_class(p_type_name, "Object"), vformat("Inexist type %s.", p_type_name));
-
-	if (create_dialog->type_blacklist.has(p_type_name)) {
+	CHECK_IF_TYPE_IS_VALID(p_type_name);
+	if (custom_type_blacklist.has(p_type_name)) {
 		return;
 	}
+	custom_type_blacklist.insert(p_type_name);
+}
 
-	create_dialog->type_blacklist.insert(p_type_name);
-	create_dialog->_update_search();
+HashSet<String> &EditorCreateDialog::get_type_blacklist() {
+	return custom_type_blacklist;
+}
+
+bool EditorCreateDialog::is_type_in_blacklist(const StringName &p_type_name) const {
+	return custom_type_blacklist.has(p_type_name);
 }
 
 void EditorCreateDialog::remove_type_from_blacklist(const StringName &p_type_name) {
-	CHECK_IF_NO_BOUND_CREATE_DIALOG;
-	ERR_FAIL_COND_MSG(!ClassDB::is_parent_class(p_type_name, "Object"), vformat("Inexist type %s.", p_type_name));
-
-	if (!create_dialog->type_blacklist.has(p_type_name)) {
+	CHECK_IF_TYPE_IS_VALID(p_type_name);
+	if (!custom_type_blacklist.has(p_type_name)) {
 		return;
 	}
+	custom_type_blacklist.erase(p_type_name);
+}
 
-	create_dialog->type_blacklist.erase(p_type_name);
-	create_dialog->_update_search();
+void EditorCreateDialog::clear_type_blacklist() {
+	custom_type_blacklist.clear();
 }
 
 void EditorCreateDialog::set_type_custom_suffix(const StringName &p_type_name, const String &p_custom_suffix) {
-	CHECK_IF_NO_BOUND_CREATE_DIALOG;
-	ERR_FAIL_COND_MSG(!ClassDB::is_parent_class(p_type_name, "Object"), vformat("Inexist type %s.", p_type_name));
-
-	if (create_dialog->custom_type_suffixes.has(p_type_name)) {
-		create_dialog->custom_type_suffixes[p_type_name] = p_custom_suffix;
+	CHECK_IF_TYPE_IS_VALID(p_type_name);
+	if (custom_type_suffixes.has(p_type_name)) {
+		custom_type_suffixes[p_type_name] = p_custom_suffix;
 	} else {
-		create_dialog->custom_type_suffixes.insert(p_type_name, p_custom_suffix);
+		custom_type_suffixes.insert(p_type_name, p_custom_suffix);
 	}
-	create_dialog->_update_search();
+}
+
+bool EditorCreateDialog::has_type_custom_suffix(const StringName &p_type_name) const {
+	return custom_type_suffixes.has(p_type_name);
 }
 
 String EditorCreateDialog::get_type_custom_suffix(const StringName &p_type_name) const {
-	CHECK_IF_NO_BOUND_CREATE_DIALOG_V("");
-	ERR_FAIL_COND_V_MSG(!ClassDB::is_parent_class(p_type_name, "Object"), "", vformat("Inexist type %s.", p_type_name));
-	return create_dialog->custom_type_suffixes.has(p_type_name) ? create_dialog->custom_type_suffixes.get(p_type_name) : "";
+	CHECK_IF_TYPE_IS_VALID_V(p_type_name, "<invalid suffix>");
+	return custom_type_suffixes.has(p_type_name) ? custom_type_suffixes.get(p_type_name) : "<suffix not found>";
 }
 
-void EditorCreateDialog::clear_all_type_custom_suffixes() {
-	CHECK_IF_NO_BOUND_CREATE_DIALOG;
-	create_dialog->custom_type_suffixes.clear();
-	create_dialog->_update_search();
+void EditorCreateDialog::clear_type_custom_suffixes() {
+	custom_type_suffixes.clear();
 }
 
 Tree *EditorCreateDialog::get_search_options() const {
@@ -98,32 +103,29 @@ Tree *EditorCreateDialog::get_search_options() const {
 	return create_dialog->search_options;
 }
 
+EditorCreateDialog *EditorCreateDialog::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(EditorCreateDialog);
+	}
+	return singleton;
+}
+
 void EditorCreateDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_type_to_blacklist", "type_name"), &EditorCreateDialog::add_type_to_blacklist);
+	ClassDB::bind_method(D_METHOD("is_type_in_blacklist", "type_name"), &EditorCreateDialog::is_type_in_blacklist);
 	ClassDB::bind_method(D_METHOD("remove_type_from_blacklist", "type_name"), &EditorCreateDialog::remove_type_from_blacklist);
+	ClassDB::bind_method(D_METHOD("clear_type_blacklist"), &EditorCreateDialog::clear_type_blacklist);
 	ClassDB::bind_method(D_METHOD("set_type_custom_suffix", "type_name", "custom_suffix"), &EditorCreateDialog::set_type_custom_suffix);
+	ClassDB::bind_method(D_METHOD("has_type_custom_suffix", "type_name"), &EditorCreateDialog::has_type_custom_suffix);
 	ClassDB::bind_method(D_METHOD("get_type_custom_suffix", "type_name"), &EditorCreateDialog::get_type_custom_suffix);
-	ClassDB::bind_method(D_METHOD("clear_all_type_custom_suffixes"), &EditorCreateDialog::clear_all_type_custom_suffixes);
+	ClassDB::bind_method(D_METHOD("clear_type_custom_suffixes"), &EditorCreateDialog::clear_type_custom_suffixes);
 	ClassDB::bind_method(D_METHOD("get_search_options"), &EditorCreateDialog::get_search_options);
 
-	ADD_SIGNAL(MethodInfo("create"));
+	ADD_SIGNAL(MethodInfo("dialog_poped"));
+	ADD_SIGNAL(MethodInfo("dialog_closed"));
+	ADD_SIGNAL(MethodInfo("created"));
 	ADD_SIGNAL(MethodInfo("favorites_updated"));
 }
 
 EditorCreateDialog::EditorCreateDialog() {
-	ERR_PRINT("Cannot instantiate an editor create dialog without binding create dialog. The editor create dialog was deleted.");
-	memdelete(this);
-}
-
-EditorCreateDialog::EditorCreateDialog(CreateDialog *p_create_dialog) {
-	create_dialog = p_create_dialog;
-	if (create_dialog != nullptr) {
-		print_line(vformat(R"(Connecting signals from %s to %s)", create_dialog->get_name(), get_name()));
-		create_dialog->connect("visibility_changed", callable_mp(this, &EditorCreateDialog::_notify_visibility_changed));
-		create_dialog->connect("create", callable_mp(this, &EditorCreateDialog::_notify_created));
-		create_dialog->connect("favorites_updated", callable_mp(this, &EditorCreateDialog::_notify_favourites_updated));
-	} else {
-		ERR_PRINT("Cannot instantiate an editor create dialog without binding create dialog. The editor create dialog was deleted.");
-		memdelete(this);
-	}
 }

--- a/editor/editor_create_dialog.cpp
+++ b/editor/editor_create_dialog.cpp
@@ -56,7 +56,7 @@ void EditorCreateDialog::add_type_to_blacklist(const StringName &p_type_name) {
 	custom_type_blacklist.insert(p_type_name);
 }
 
-HashSet<String> &EditorCreateDialog::get_type_blacklist() {
+HashSet<String> EditorCreateDialog::get_type_blacklist() {
 	return custom_type_blacklist;
 }
 

--- a/editor/editor_create_dialog.cpp
+++ b/editor/editor_create_dialog.cpp
@@ -56,7 +56,7 @@ void EditorCreateDialog::add_type_to_blacklist(const StringName &p_type_name) {
 	custom_type_blacklist.insert(p_type_name);
 }
 
-HashSet<String> EditorCreateDialog::get_type_blacklist() {
+const HashSet<String> &EditorCreateDialog::get_type_blacklist() const {
 	return custom_type_blacklist;
 }
 

--- a/editor/editor_create_dialog.cpp
+++ b/editor/editor_create_dialog.cpp
@@ -45,7 +45,19 @@ CreateDialog *EditorCreateDialog::get_create_dialog() const {
 }
 
 ConfirmationDialog *EditorCreateDialog::get_dialog_window() const {
+	if (create_dialog == nullptr) {
+		ERR_PRINT("Got null create dialog reference. Please call this when the dialog is visible.");
+		return nullptr;
+	}
 	return Object::cast_to<ConfirmationDialog>(create_dialog);
+}
+
+Tree *EditorCreateDialog::get_search_options() const {
+	if (create_dialog == nullptr) {
+		ERR_PRINT("Got null search options reference. Please call this when the dialog is visible.");
+		return nullptr;
+	}
+	return create_dialog->search_options;
 }
 
 void EditorCreateDialog::add_type_to_blacklist(const StringName &p_type_name) {
@@ -104,11 +116,6 @@ void EditorCreateDialog::remove_type_custom_suffix(const StringName &p_type_name
 
 void EditorCreateDialog::clear_type_custom_suffixes() {
 	custom_type_suffixes.clear();
-}
-
-Tree *EditorCreateDialog::get_search_options() const {
-	CHECK_IF_NO_BOUND_CREATE_DIALOG_V(nullptr);
-	return create_dialog->search_options;
 }
 
 EditorCreateDialog *EditorCreateDialog::get_singleton() {

--- a/editor/editor_create_dialog.cpp
+++ b/editor/editor_create_dialog.cpp
@@ -56,7 +56,7 @@ void EditorCreateDialog::add_type_to_blacklist(const StringName &p_type_name) {
 	custom_type_blacklist.insert(p_type_name);
 }
 
-const HashSet<String> &EditorCreateDialog::get_type_blacklist() const {
+const HashSet<StringName> &EditorCreateDialog::get_type_blacklist() const {
 	return custom_type_blacklist;
 }
 

--- a/editor/editor_create_dialog.cpp
+++ b/editor/editor_create_dialog.cpp
@@ -94,6 +94,14 @@ String EditorCreateDialog::get_type_custom_suffix(const StringName &p_type_name)
 	return custom_type_suffixes.has(p_type_name) ? custom_type_suffixes.get(p_type_name) : "<suffix not found>";
 }
 
+void EditorCreateDialog::remove_type_custom_suffix(const StringName &p_type_name) {
+	CHECK_IF_TYPE_IS_VALID(p_type_name);
+	if (!custom_type_suffixes.has(p_type_name)) {
+		return;
+	}
+	custom_type_suffixes.erase(p_type_name);
+}
+
 void EditorCreateDialog::clear_type_custom_suffixes() {
 	custom_type_suffixes.clear();
 }
@@ -118,8 +126,10 @@ void EditorCreateDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_type_custom_suffix", "type_name", "custom_suffix"), &EditorCreateDialog::set_type_custom_suffix);
 	ClassDB::bind_method(D_METHOD("has_type_custom_suffix", "type_name"), &EditorCreateDialog::has_type_custom_suffix);
 	ClassDB::bind_method(D_METHOD("get_type_custom_suffix", "type_name"), &EditorCreateDialog::get_type_custom_suffix);
+	ClassDB::bind_method(D_METHOD("remove_type_custom_suffix", "type_name"), &EditorCreateDialog::remove_type_custom_suffix);
 	ClassDB::bind_method(D_METHOD("clear_type_custom_suffixes"), &EditorCreateDialog::clear_type_custom_suffixes);
 	ClassDB::bind_method(D_METHOD("get_search_options"), &EditorCreateDialog::get_search_options);
+	ClassDB::bind_method(D_METHOD("get_dialog_window"), &EditorCreateDialog::get_dialog_window);
 
 	ADD_SIGNAL(MethodInfo("dialog_poped"));
 	ADD_SIGNAL(MethodInfo("dialog_closed"));

--- a/editor/editor_create_dialog.h
+++ b/editor/editor_create_dialog.h
@@ -1,0 +1,70 @@
+/**************************************************************************/
+/*  editor_create_dialog.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef EDITOR_CREATE_DIALOG_H
+#define EDITOR_CREATE_DIALOG_H
+
+#include "editor/create_dialog.h"
+#include "editor/editor_node.h"
+
+class CreateDialog;
+
+class EditorCreateDialog : public Node {
+	GDCLASS(EditorCreateDialog, Node);
+
+	CreateDialog *create_dialog = nullptr;
+
+#define CHECK_IF_NO_BOUND_CREATE_DIALOG \
+	ERR_FAIL_COND_MSG(create_dialog == nullptr, "Null create dialog is bound. It's a bug and please report it.")
+#define CHECK_IF_NO_BOUND_CREATE_DIALOG_V(m_retval) \
+	ERR_FAIL_COND_V_MSG(create_dialog == nullptr, (m_retval), "Null create dialog is bound. It's a bug and please report it.")
+
+	void _notify_visibility_changed();
+	void _notify_created();
+	void _notify_favourites_updated();
+
+protected:
+	static void _bind_methods();
+
+public:
+	void add_type_to_blacklist(const StringName &p_type_name);
+	void remove_type_from_blacklist(const StringName &p_type_name);
+
+	void set_type_custom_suffix(const StringName &p_type_name, const String &p_custom_suffix);
+	String get_type_custom_suffix(const StringName &p_type_name) const;
+	void clear_all_type_custom_suffixes();
+
+	Tree *get_search_options() const;
+
+	EditorCreateDialog();
+	EditorCreateDialog(CreateDialog *p_create_dialog);
+};
+
+#endif EDITOR_CREATE_DIALOG_H

--- a/editor/editor_create_dialog.h
+++ b/editor/editor_create_dialog.h
@@ -31,40 +31,56 @@
 #ifndef EDITOR_CREATE_DIALOG_H
 #define EDITOR_CREATE_DIALOG_H
 
+#include "core/object/object.h"
 #include "editor/create_dialog.h"
-#include "editor/editor_node.h"
+#include "scene/gui/tree.h"
 
-class CreateDialog;
+class EditorCreateDialog : public Object {
+	GDCLASS(EditorCreateDialog, Object);
 
-class EditorCreateDialog : public Node {
-	GDCLASS(EditorCreateDialog, Node);
-
+	static EditorCreateDialog *singleton;
 	CreateDialog *create_dialog = nullptr;
+
+	HashSet<String> custom_type_blacklist;
+	HashMap<StringName, String> custom_type_suffixes;
 
 #define CHECK_IF_NO_BOUND_CREATE_DIALOG \
 	ERR_FAIL_COND_MSG(create_dialog == nullptr, "Null create dialog is bound. It's a bug and please report it.")
 #define CHECK_IF_NO_BOUND_CREATE_DIALOG_V(m_retval) \
 	ERR_FAIL_COND_V_MSG(create_dialog == nullptr, (m_retval), "Null create dialog is bound. It's a bug and please report it.")
 
-	void _notify_visibility_changed();
-	void _notify_created();
-	void _notify_favourites_updated();
+	bool _is_type_valid(const StringName &p_type_name) const;
+
+#define CHECK_IF_TYPE_IS_VALID(m_type) \
+	ERR_FAIL_COND_MSG(!_is_type_valid((m_type)), vformat("Inexist type %s.", (m_type)));
+#define CHECK_IF_TYPE_IS_VALID_V(m_type, m_retval) \
+	ERR_FAIL_COND_V_MSG(!_is_type_valid((m_type)), (m_retval), vformat("Inexist type %s.", (m_type)));
 
 protected:
 	static void _bind_methods();
 
 public:
+	void set_create_dialog(CreateDialog *p_create_dialog);
+	CreateDialog *get_create_dialog() const;
+
+	ConfirmationDialog *get_dialog_window() const;
+
 	void add_type_to_blacklist(const StringName &p_type_name);
+	bool is_type_in_blacklist(const StringName &p_type_name) const;
+	HashSet<String> &get_type_blacklist();
 	void remove_type_from_blacklist(const StringName &p_type_name);
+	void clear_type_blacklist();
 
 	void set_type_custom_suffix(const StringName &p_type_name, const String &p_custom_suffix);
+	bool has_type_custom_suffix(const StringName &p_type_name) const;
 	String get_type_custom_suffix(const StringName &p_type_name) const;
-	void clear_all_type_custom_suffixes();
+	void clear_type_custom_suffixes();
 
 	Tree *get_search_options() const;
 
+	static EditorCreateDialog *get_singleton();
+
 	EditorCreateDialog();
-	EditorCreateDialog(CreateDialog *p_create_dialog);
 };
 
-#endif EDITOR_CREATE_DIALOG_H
+#endif // EDITOR_CREATE_DIALOG_H

--- a/editor/editor_create_dialog.h
+++ b/editor/editor_create_dialog.h
@@ -74,6 +74,7 @@ public:
 	void set_type_custom_suffix(const StringName &p_type_name, const String &p_custom_suffix);
 	bool has_type_custom_suffix(const StringName &p_type_name) const;
 	String get_type_custom_suffix(const StringName &p_type_name) const;
+	void remove_type_custom_suffix(const StringName &p_type_name);
 	void clear_type_custom_suffixes();
 
 	Tree *get_search_options() const;

--- a/editor/editor_create_dialog.h
+++ b/editor/editor_create_dialog.h
@@ -67,7 +67,7 @@ public:
 
 	void add_type_to_blacklist(const StringName &p_type_name);
 	bool is_type_in_blacklist(const StringName &p_type_name) const;
-	HashSet<String> get_type_blacklist();
+	const HashSet<String> &get_type_blacklist() const;
 	void remove_type_from_blacklist(const StringName &p_type_name);
 	void clear_type_blacklist();
 

--- a/editor/editor_create_dialog.h
+++ b/editor/editor_create_dialog.h
@@ -41,7 +41,7 @@ class EditorCreateDialog : public Object {
 	static EditorCreateDialog *singleton;
 	CreateDialog *create_dialog = nullptr;
 
-	HashSet<String> custom_type_blacklist;
+	HashSet<StringName> custom_type_blacklist;
 	HashMap<StringName, String> custom_type_suffixes;
 
 #define CHECK_IF_NO_BOUND_CREATE_DIALOG \
@@ -67,7 +67,7 @@ public:
 
 	void add_type_to_blacklist(const StringName &p_type_name);
 	bool is_type_in_blacklist(const StringName &p_type_name) const;
-	const HashSet<String> &get_type_blacklist() const;
+	const HashSet<StringName> &get_type_blacklist() const;
 	void remove_type_from_blacklist(const StringName &p_type_name);
 	void clear_type_blacklist();
 

--- a/editor/editor_create_dialog.h
+++ b/editor/editor_create_dialog.h
@@ -64,6 +64,7 @@ public:
 	CreateDialog *get_create_dialog() const;
 
 	ConfirmationDialog *get_dialog_window() const;
+	Tree *get_search_options() const;
 
 	void add_type_to_blacklist(const StringName &p_type_name);
 	bool is_type_in_blacklist(const StringName &p_type_name) const;
@@ -76,8 +77,6 @@ public:
 	String get_type_custom_suffix(const StringName &p_type_name) const;
 	void remove_type_custom_suffix(const StringName &p_type_name);
 	void clear_type_custom_suffixes();
-
-	Tree *get_search_options() const;
 
 	static EditorCreateDialog *get_singleton();
 

--- a/editor/editor_create_dialog.h
+++ b/editor/editor_create_dialog.h
@@ -67,7 +67,7 @@ public:
 
 	void add_type_to_blacklist(const StringName &p_type_name);
 	bool is_type_in_blacklist(const StringName &p_type_name) const;
-	HashSet<String> &get_type_blacklist();
+	HashSet<String> get_type_blacklist();
 	void remove_type_from_blacklist(const StringName &p_type_name);
 	void clear_type_blacklist();
 

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -774,6 +774,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("popup_method_selector", "object", "callback", "current_value"), &EditorInterface::popup_method_selector, DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("popup_quick_open", "callback", "base_types"), &EditorInterface::popup_quick_open, DEFVAL(TypedArray<StringName>()));
 
+	ADD_SIGNAL(MethodInfo("create_dialog_showed", PropertyInfo(Variant::OBJECT, "editor_create_dialog", PROPERTY_HINT_RESOURCE_TYPE, "EditorCreateDialog")));
+	ADD_SIGNAL(MethodInfo("create_dialog_hid", PropertyInfo(Variant::OBJECT, "editor_create_dialog", PROPERTY_HINT_RESOURCE_TYPE, "EditorCreateDialog")));
+
 	// Editor docks.
 
 	ClassDB::bind_method(D_METHOD("get_file_system_dock"), &EditorInterface::get_file_system_dock);

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -33,6 +33,7 @@
 
 #include "core/config/project_settings.h"
 #include "editor/editor_command_palette.h"
+#include "editor/editor_create_dialog.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
@@ -73,6 +74,10 @@ void EditorInterface::restart_editor(bool p_save) {
 
 EditorCommandPalette *EditorInterface::get_command_palette() const {
 	return EditorCommandPalette::get_singleton();
+}
+
+EditorCreateDialog *EditorInterface::get_create_dialog() const {
+	return EditorCreateDialog::get_singleton();
 }
 
 EditorFileSystem *EditorInterface::get_resource_file_system() const {
@@ -728,6 +733,7 @@ void EditorInterface::_bind_methods() {
 	// Editor tools.
 
 	ClassDB::bind_method(D_METHOD("get_command_palette"), &EditorInterface::get_command_palette);
+	ClassDB::bind_method(D_METHOD("get_create_dialog"), &EditorInterface::get_create_dialog);
 	ClassDB::bind_method(D_METHOD("get_resource_filesystem"), &EditorInterface::get_resource_file_system);
 	ClassDB::bind_method(D_METHOD("get_editor_paths"), &EditorInterface::get_editor_paths);
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
@@ -773,9 +779,6 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("popup_property_selector", "object", "callback", "type_filter", "current_value"), &EditorInterface::popup_property_selector, DEFVAL(PackedInt32Array()), DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("popup_method_selector", "object", "callback", "current_value"), &EditorInterface::popup_method_selector, DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("popup_quick_open", "callback", "base_types"), &EditorInterface::popup_quick_open, DEFVAL(TypedArray<StringName>()));
-
-	ADD_SIGNAL(MethodInfo("create_dialog_showed", PropertyInfo(Variant::OBJECT, "editor_create_dialog", PROPERTY_HINT_RESOURCE_TYPE, "EditorCreateDialog")));
-	ADD_SIGNAL(MethodInfo("create_dialog_hid", PropertyInfo(Variant::OBJECT, "editor_create_dialog", PROPERTY_HINT_RESOURCE_TYPE, "EditorCreateDialog")));
 
 	// Editor docks.
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -38,6 +38,7 @@
 
 class Control;
 class EditorCommandPalette;
+class EditorCreateDialog;
 class EditorFileSystem;
 class EditorInspector;
 class EditorPaths;
@@ -99,6 +100,7 @@ public:
 	// Editor tools.
 
 	EditorCommandPalette *get_command_palette() const;
+	EditorCreateDialog *get_create_dialog() const;
 	EditorFileSystem *get_resource_file_system() const;
 	EditorPaths *get_editor_paths() const;
 	EditorResourcePreview *get_resource_previewer() const;

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/script_language.h"
 #include "editor/debugger/debug_adapter/debug_adapter_server.h"
+#include "editor/editor_create_dialog.h"
 #include "editor/editor_command_palette.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_file_system.h"
@@ -174,6 +175,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorInspector);
 	GDREGISTER_CLASS(EditorInspectorPlugin);
 	GDREGISTER_CLASS(EditorProperty);
+	GDREGISTER_CLASS(EditorCreateDialog);
 	GDREGISTER_CLASS(ScriptCreateDialog);
 	GDREGISTER_CLASS(EditorFeatureProfile);
 	GDREGISTER_CLASS(EditorSpinSlider);

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -32,8 +32,8 @@
 
 #include "core/object/script_language.h"
 #include "editor/debugger/debug_adapter/debug_adapter_server.h"
-#include "editor/editor_create_dialog.h"
 #include "editor/editor_command_palette.h"
+#include "editor/editor_create_dialog.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_interface.h"


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/11238 (Will be done via an addon if this gets merged)

Exposes `CreateDialog` in another way: By adding a new class `EditorCreateDialog` as a singleton that can only be accessed via `EditorInterface`, with some singals and methods.

# Signals
`created`: Emitted when an objects is created from the create dialog.
`favourites_updated`: Emitted when the content of "favourites" slot gets updated.

# Methods
`add_type_to_blacklist(type_name: StringName)`: Adds a type to the blacklist and update the search result of the create dialog. The type in the blacklist will not be displayed in the create dialog.
`remove_type_from_blacklist(type_name: StringName)`: Removes a type from the blacklist. The type removed from the blacklist will get recovery of being displayed in the create dialog.
`set_type_custom_suffix(type_name: StringName, custom_suffix: String)`: Sets the custom suffix of the type in the create dialog. The item will display its suffix with higher priority. If the custom suffix is an empty string, the suffix will be hidden. This is useful for labeling the node by someone, or from some addon, or being used as a "namespace".
`get_type_custom_suffix(type_name: StringName)`: Returns the custom suffix of the type in the create dialog.
`clear_all_type_custom_suffixes()`: Removes all custom suffixes in the create dialog from all types (If the type is a script type, then it will fall back to showing the file name of the script).
`get_search_options`: Returns the "result list" (`Tree`) that is used in the create dialog.
`get_dialog_window`: Returns the create dialog window. (`ConfirmationDialog`)

# Why not exposing `CreateDialog`
Exposing `CreateDialog` seems to be a much more easier and direct way. However, when a user is trying instantiating it with `new()` by mistake, the whole engine will crash. To make users' engines safe, `EditorCreateDialog` provides a safer box where users will receive an error if they are trying to instantiate an `EditorCreateDialog` without passing in a `CreateDialog` instance, which is not exposed to the engine, and the instance create by mistake will be deleted immediately. A user should never try instantiating  `EditorCreateDialog`, even though it's safe for them.

# Getting the instance of `EditorCreateDialog`
A user can get access to it by calling `EditorInterface.get_create_dialog()`.
# WIPs
- [x] Adding basic interfaces.
- [x] Basic bug fixes and docs, (done 50%)
- [ ] Further fixes, local and inter-member tests.