### PR TITLE
Improve the material preview in the inspector

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -37,6 +37,7 @@
 #include "core/io/file_access.h"
 #include "core/io/file_access_pack.h"
 #include "core/io/marshalls.h"
+#include "core/io/resource_loader.h"
 #include "core/io/resource_uid.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
@@ -1843,6 +1844,27 @@ ProjectSettings::ProjectSettings() {
 
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Linear Mipmap,Nearest Mipmap"), 1);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/textures/canvas_textures/default_texture_repeat", PROPERTY_HINT_ENUM, "Disable,Enable,Mirror"), 0);
+
+	List<String> exts;
+	ResourceLoader::get_recognized_extensions_for_type("Environment", &exts);
+	String ext_hint;
+	for (const String &E : exts) {
+		if (!ext_hint.is_empty()) {
+			ext_hint += ",";
+		}
+		ext_hint += "*." + E;
+	}
+	GLOBAL_DEF(PropertyInfo(Variant::STRING, "editor/3d/preview_environment", PROPERTY_HINT_FILE, ext_hint), "");
+	List<String> mat_exts;
+	ResourceLoader::get_recognized_extensions_for_type("BaseMaterial3D", &mat_exts);
+	String mat_ext_hint;
+	for (const String &E : mat_exts) {
+		if (!mat_ext_hint.is_empty()) {
+			mat_ext_hint += ",";
+		}
+		mat_ext_hint += "*." + E;
+	}
+	GLOBAL_DEF(PropertyInfo(Variant::STRING, "editor/3d/preview_floor_material", PROPERTY_HINT_FILE, mat_ext_hint), "");
 
 	GLOBAL_DEF("collada/use_ambient", false);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1119,6 +1119,12 @@
 			Directory that contains the [code].sln[/code] file. By default, the [code].sln[/code] files is in the root of the project directory, next to the [code]project.godot[/code] and [code].csproj[/code] files.
 			Changing this value allows setting up a multi-project scenario where there are multiple [code].csproj[/code]. Keep in mind that the Godot project is considered one of the C# projects in the workspace and it's root directory should contain the [code]project.godot[/code] and [code].csproj[/code] next to each other.
 		</member>
+		<member name="editor/3d/preview_environment" type="String" setter="" getter="" default="&quot;&quot;">
+			Path to the [Environment] resource that will be used in the Inspector's material preview. If this is not set, a default environment will be used instead.
+		</member>
+		<member name="editor/3d/preview_floor_material" type="String" setter="" getter="" default="&quot;&quot;">
+			Path to the [BaseMaterial3D] resource that will be assigned to the floor of the Inspector's material preview. If this is not set, a default material will be used instead.
+		</member>
 		<member name="editor/export/convert_text_resources_to_binary" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], text resource ([code]tres[/code]) and text scene ([code]tscn[/code]) files are converted to their corresponding binary format on export. This decreases file sizes and speeds up loading slightly.
 			[b]Note:[/b] Because a resource's file extension may change in an exported project, it is heavily recommended to use [method @GDScript.load] or [ResourceLoader] instead of [FileAccess] to load resources dynamically.

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
+#include "core/object/class_db.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
@@ -53,6 +54,8 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/reflection_probe.h"
+#include "scene/resources/3d/sky_material.h"
 
 Ref<ShaderMaterial> MaterialEditor::make_shader_material(const Ref<Material> &p_from, bool p_copy_params) {
 	ERR_FAIL_COND_V(p_from.is_null(), Ref<ShaderMaterial>());
@@ -90,15 +93,15 @@ void MaterialEditor::gui_input(const Ref<InputEvent> &p_event) {
 	if (mm.is_valid() && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 		rot.x -= mm->get_relative().y * 0.01;
 		rot.y -= mm->get_relative().x * 0.01;
-		if (quad_instance->is_visible()) {
-			// Clamp rotation so the quad is always visible.
-			const real_t limit = Math::deg_to_rad(80.0);
-			rot = rot.clampf(-limit, limit);
-		} else {
-			rot.x = CLAMP(rot.x, -Math::PI / 2, Math::PI / 2);
-		}
-		_update_rotation();
-		_store_rotation_metadata();
+		rot.x = CLAMP(rot.x, -Math::PI / 2, Math::PI / 2);
+		_update_camera();
+		return;
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_released()) {
+		Vector2 rotation_degrees = Vector2(Math::rad_to_deg(rot.x), Math::rad_to_deg(rot.y));
+		EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_rotation", rotation_degrees);
 	}
 }
 
@@ -107,6 +110,7 @@ void MaterialEditor::_update_theme_item_cache() {
 
 	theme_cache.light_1_icon = get_editor_theme_icon(SNAME("MaterialPreviewLight1"));
 	theme_cache.light_2_icon = get_editor_theme_icon(SNAME("MaterialPreviewLight2"));
+	theme_cache.floor_icon = get_editor_theme_icon(SNAME("GuiMiniCheckerboard"));
 
 	theme_cache.sphere_icon = get_editor_theme_icon(SNAME("MaterialPreviewSphere"));
 	theme_cache.box_icon = get_editor_theme_icon(SNAME("MaterialPreviewCube"));
@@ -117,15 +121,24 @@ void MaterialEditor::_update_theme_item_cache() {
 
 void MaterialEditor::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_READY: {
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &MaterialEditor::_update_environment));
+			_update_environment();
+			_update_camera();
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			light_1_switch->set_button_icon(theme_cache.light_1_icon);
 			light_2_switch->set_button_icon(theme_cache.light_2_icon);
+			floor_switch->set_button_icon(theme_cache.floor_icon);
 
 			sphere_switch->set_button_icon(theme_cache.sphere_icon);
 			box_switch->set_button_icon(theme_cache.box_icon);
 			quad_switch->set_button_icon(theme_cache.quad_icon);
 
 			error_label->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+
+			default_floor_material->set_texture(BaseMaterial3D::TEXTURE_ALBEDO, get_editor_theme_icon(SNAME("GuiMiniCheckerboard")));
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -137,28 +150,18 @@ void MaterialEditor::_notification(int p_what) {
 	}
 }
 
-void MaterialEditor::_set_rotation(real_t p_x_degrees, real_t p_y_degrees) {
-	rot.x = Math::deg_to_rad(p_x_degrees);
-	rot.y = Math::deg_to_rad(p_y_degrees);
-	_update_rotation();
-}
-
-// Store the rotation so it can persist when switching between materials.
-void MaterialEditor::_store_rotation_metadata() {
-	Vector2 rotation_degrees = Vector2(Math::rad_to_deg(rot.x), Math::rad_to_deg(rot.y));
-	EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_rotation", rotation_degrees);
-}
-
-void MaterialEditor::_update_rotation() {
-	Transform3D t;
-	t.basis.rotate(Vector3(0, 1, 0), -rot.y);
-	t.basis.rotate(Vector3(1, 0, 0), -rot.x);
-	rotation->set_transform(t);
+void MaterialEditor::_update_camera() {
+	Transform3D xf;
+	Vector3 center = contents_aabb.get_center();
+	xf.basis = Basis(Vector3(0, 1, 0), rot.y) * Basis(Vector3(1, 0, 0), rot.x);
+	xf.origin = center;
+	xf.translate_local(0, 0, cam_zoom);
+	camera->set_transform(xf);
 }
 
 void MaterialEditor::edit(Ref<Material> p_material, const Ref<Environment> &p_env) {
 	material = p_material;
-	camera->set_environment(p_env);
+	viewport->get_world_3d()->set_fallback_environment(p_env);
 
 	is_unsupported_shader_mode = false;
 	if (material.is_valid()) {
@@ -193,45 +196,64 @@ void MaterialEditor::edit(Ref<Material> p_material, const Ref<Environment> &p_en
 	}
 }
 
-void MaterialEditor::_on_light_1_switch_pressed() {
-	light1->set_visible(light_1_switch->is_pressed());
+void MaterialEditor::_on_visibility_switch_pressed(int p_shape) {
+	switch ((Switch)p_shape) {
+		case Switch::LIGHT_1: {
+			light1->set_visible(light_1_switch->is_pressed());
+			EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_light1", light1->is_visible());
+		} break;
+
+		case Switch::LIGHT_2: {
+			light2->set_visible(light_2_switch->is_pressed());
+			EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_light2", light2->is_visible());
+		} break;
+
+		case Switch::FLOOR: {
+			bool is_visible = !floor_instance->is_visible();
+			floor_instance->set_visible(is_visible);
+			floor_switch->set_pressed(is_visible);
+			EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_floor", is_visible);
+		} break;
+	}
 }
 
-void MaterialEditor::_on_light_2_switch_pressed() {
-	light2->set_visible(light_2_switch->is_pressed());
-}
+void MaterialEditor::_on_shape_switch_pressed(int p_shape) {
+	Shape shape_switch = (Shape)p_shape;
+	sphere_instance->set_visible(shape_switch == Shape::SPHERE);
+	box_instance->set_visible(shape_switch == Shape::BOX);
+	quad_instance->set_visible(shape_switch == Shape::QUAD);
+	sphere_switch->set_pressed_no_signal(shape_switch == Shape::SPHERE);
+	box_switch->set_pressed_no_signal(shape_switch == Shape::BOX);
+	quad_switch->set_pressed_no_signal(shape_switch == Shape::QUAD);
 
-void MaterialEditor::_on_sphere_switch_pressed() {
-	sphere_instance->show();
-	box_instance->hide();
-	quad_instance->hide();
-	box_switch->set_pressed(false);
-	quad_switch->set_pressed(false);
-	_set_rotation(-15.0, 30.0);
-	_store_rotation_metadata();
-	EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_mesh", "sphere");
-}
+	// Reset the camera if pressing the current shape switch.
+	float visible_height = 1.2;
+	switch (shape_switch) {
+		case Shape::SPHERE: {
+			if (shape == Shape::SPHERE) {
+				rot = Vector2(Math::deg_to_rad(-30.0), Math::deg_to_rad(0.0));
+			}
+		} break;
 
-void MaterialEditor::_on_box_switch_pressed() {
-	sphere_instance->hide();
-	box_instance->show();
-	quad_instance->hide();
-	sphere_switch->set_pressed(false);
-	quad_switch->set_pressed(false);
-	_set_rotation(-15.0, 30.0);
-	_store_rotation_metadata();
-	EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_mesh", "box");
-}
+		case Shape::BOX: {
+			if (shape == Shape::BOX) {
+				rot = Vector2(Math::deg_to_rad(-30.0), Math::deg_to_rad(20.0));
+			}
+			visible_height = 1.55;
+		} break;
 
-void MaterialEditor::_on_quad_switch_pressed() {
-	sphere_instance->hide();
-	box_instance->hide();
-	quad_instance->show();
-	sphere_switch->set_pressed(false);
-	box_switch->set_pressed(false);
-	_set_rotation(0.0, 0.0);
-	_store_rotation_metadata();
-	EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_mesh", "quad");
+		case Shape::QUAD: {
+			if (shape == Shape::QUAD) {
+				rot = Vector2(0.0, 0.0);
+			}
+		}
+	}
+
+	shape = shape_switch;
+	// FOV independent camera framing based on view height.
+	cam_zoom = visible_height / Math::sin(Math::deg_to_rad(camera->get_fov()));
+	_update_camera();
+	EditorSettings::get_singleton()->set_project_metadata("inspector_options", "material_preview_mesh", shape);
 }
 
 MaterialEditor::MaterialEditor() {
@@ -285,13 +307,15 @@ MaterialEditor::MaterialEditor() {
 	Ref<World3D> world_3d;
 	world_3d.instantiate();
 	viewport->set_world_3d(world_3d); // Use own world.
-	vc->add_child(viewport);
 	viewport->set_disable_input(true);
-	viewport->set_transparent_background(true);
+	viewport->set_transparent_background(false);
 	viewport->set_msaa_3d(Viewport::MSAA_4X);
+	// Use supersampling to further reduce aliasing.
+	viewport->set_scaling_3d_scale(2.0);
+	vc->add_child(viewport);
 
 	camera = memnew(Camera3D);
-	camera->set_transform(Transform3D(Basis(), Vector3(0, 0, 1.1)));
+	camera->set_transform(Transform3D(Basis(), Vector3(0, 0.5, cam_zoom)));
 	// Use low field of view so the sphere/box/quad is fully encompassed within the preview,
 	// without much distortion.
 	camera->set_perspective(20, 0.1, 10);
@@ -303,10 +327,15 @@ MaterialEditor::MaterialEditor() {
 	viewport->add_child(camera);
 
 	light1 = memnew(DirectionalLight3D);
-	light1->set_transform(Transform3D().looking_at(Vector3(-1, -1, -1), Vector3(0, 1, 0)));
+	light1->set_transform(Transform3D().looking_at(Vector3(1, -1, -1), Vector3(0, 1, 0)));
+	light1->set_shadow(true);
+	light1->set_shadow_mode(DirectionalLight3D::SHADOW_ORTHOGONAL);
 	viewport->add_child(light1);
 
 	light2 = memnew(DirectionalLight3D);
+	// Prevent the fill light from creating a specular lobe on the object,
+	// as seeing two specular lobes at once (one coming from below) looks strange.
+	light2->set_param(Light3D::PARAM_SPECULAR, 0.0);
 	light2->set_transform(Transform3D().looking_at(Vector3(0, 1, 0), Vector3(0, 0, 1)));
 	light2->set_color(Color(0.7, 0.7, 0.7));
 	viewport->add_child(light2);
@@ -323,9 +352,14 @@ MaterialEditor::MaterialEditor() {
 	quad_instance = memnew(MeshInstance3D);
 	rotation->add_child(quad_instance);
 
-	sphere_instance->set_transform(Transform3D() * 0.375);
-	box_instance->set_transform(Transform3D() * 0.25);
-	quad_instance->set_transform(Transform3D() * 0.375);
+	floor_instance = memnew(MeshInstance3D);
+	rotation->add_child(floor_instance);
+
+	Transform3D transform;
+	transform.origin = Vector3(0, 0.5, 0);
+	sphere_instance->set_transform(transform);
+	box_instance->set_transform(transform);
+	quad_instance->set_transform(transform);
 
 	sphere_mesh.instantiate();
 	sphere_instance->set_mesh(sphere_mesh);
@@ -333,6 +367,26 @@ MaterialEditor::MaterialEditor() {
 	box_instance->set_mesh(box_mesh);
 	quad_mesh.instantiate();
 	quad_instance->set_mesh(quad_mesh);
+	floor_mesh.instantiate();
+	floor_mesh->set_size(Size2(5, 5));
+	floor_instance->set_mesh(floor_mesh);
+
+	contents_aabb = sphere_instance->get_transform().xform(sphere_mesh->get_aabb());
+
+	default_floor_material = memnew(StandardMaterial3D);
+	default_floor_material->set_uv1_scale(Vector3(20, 20, 20));
+	default_floor_material->set_texture_filter(StandardMaterial3D::TEXTURE_FILTER_NEAREST);
+	default_floor_material->set_albedo(Color::hex(0x454545ff));
+	floor_mesh->set_material(default_floor_material);
+
+	probe = memnew(ReflectionProbe);
+	probe->set_size(Vector3(5, 1.5, 5));
+	// Disable blending as the probe fully covers the entire preview scene.
+	probe->set_blend_distance(0.0);
+	rotation->add_child(probe);
+	probe->set_position(Vector3(0, 0.5, 0));
+
+	set_custom_minimum_size(Size2(1, 165) * EDSCALE);
 
 	layout_3d = memnew(HBoxContainer);
 	add_child(layout_3d);
@@ -346,21 +400,21 @@ MaterialEditor::MaterialEditor() {
 	sphere_switch->set_toggle_mode(true);
 	sphere_switch->set_accessibility_name(TTRC("Sphere"));
 	vb_shape->add_child(sphere_switch);
-	sphere_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_sphere_switch_pressed));
+	sphere_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_shape_switch_pressed).bind((int)Shape::SPHERE));
 
 	box_switch = memnew(Button);
 	box_switch->set_theme_type_variation("PreviewLightButton");
 	box_switch->set_toggle_mode(true);
 	box_switch->set_accessibility_name(TTRC("Box"));
 	vb_shape->add_child(box_switch);
-	box_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_box_switch_pressed));
+	box_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_shape_switch_pressed).bind((int)Shape::BOX));
 
 	quad_switch = memnew(Button);
 	quad_switch->set_theme_type_variation("PreviewLightButton");
 	quad_switch->set_toggle_mode(true);
 	quad_switch->set_accessibility_name(TTRC("Quad"));
 	vb_shape->add_child(quad_switch);
-	quad_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_quad_switch_pressed));
+	quad_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_shape_switch_pressed).bind((int)Shape::QUAD));
 
 	layout_3d->add_spacer();
 
@@ -373,7 +427,7 @@ MaterialEditor::MaterialEditor() {
 	light_1_switch->set_pressed(true);
 	light_1_switch->set_accessibility_name(TTRC("First Light"));
 	vb_light->add_child(light_1_switch);
-	light_1_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_light_1_switch_pressed));
+	light_1_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_visibility_switch_pressed).bind((int)Switch::LIGHT_1));
 
 	light_2_switch = memnew(Button);
 	light_2_switch->set_theme_type_variation("PreviewLightButton");
@@ -381,25 +435,30 @@ MaterialEditor::MaterialEditor() {
 	light_2_switch->set_pressed(true);
 	light_2_switch->set_accessibility_name(TTRC("Second Light"));
 	vb_light->add_child(light_2_switch);
-	light_2_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_light_2_switch_pressed));
+	light_2_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_visibility_switch_pressed).bind((int)Switch::LIGHT_2));
 
-	String shape = EditorSettings::get_singleton()->get_project_metadata("inspector_options", "material_preview_mesh", "sphere");
-	if (shape == "sphere") {
-		box_instance->hide();
-		quad_instance->hide();
-		sphere_switch->set_pressed_no_signal(true);
-	} else if (shape == "box") {
-		sphere_instance->hide();
-		quad_instance->hide();
-		box_switch->set_pressed_no_signal(true);
-	} else {
-		sphere_instance->hide();
-		box_instance->hide();
-		quad_switch->set_pressed_no_signal(true);
-	}
+	floor_switch = memnew(Button);
+	floor_switch->set_theme_type_variation("PreviewLightButton");
+	floor_switch->set_toggle_mode(true);
+	floor_switch->set_pressed(false);
+	vb_light->add_child(floor_switch);
+	floor_switch->connect(SceneStringName(pressed), callable_mp(this, &MaterialEditor::_on_visibility_switch_pressed).bind((int)Switch::FLOOR));
 
-	Vector2 stored_rot = EditorSettings::get_singleton()->get_project_metadata("inspector_options", "material_preview_rotation", Vector2());
-	_set_rotation(stored_rot.x, stored_rot.y);
+	shape = (Shape)EditorSettings::get_singleton()->get_project_metadata("inspector_options", "material_preview_mesh", (int)Shape::SPHERE);
+	_on_shape_switch_pressed((int)shape);
+
+	Vector2 stored_rot = EditorSettings::get_singleton()->get_project_metadata("inspector_options", "material_preview_rotation", Vector2(-30, 0));
+	rot.x = Math::deg_to_rad(stored_rot.x);
+	rot.y = Math::deg_to_rad(stored_rot.y);
+
+	light1->set_visible(EditorSettings::get_singleton()->get_project_metadata("inspector_options", "material_preview_light1", true));
+	light_1_switch->set_pressed_no_signal(light1->is_visible());
+	light2->set_visible(EditorSettings::get_singleton()->get_project_metadata("inspector_options", "material_preview_light2", false));
+	light_2_switch->set_pressed_no_signal(light2->is_visible());
+
+	bool floor_visible = EditorSettings::get_singleton()->get_project_metadata("inspector_options", "material_preview_floor", false);
+	floor_instance->set_visible(floor_visible);
+	floor_switch->set_pressed(floor_visible);
 
 	EditorNode::get_singleton()->register_hdr_viewport(viewport);
 	EditorNode::get_singleton()->register_hdr_viewport(viewport_2d);
@@ -424,7 +483,7 @@ void EditorInspectorPluginMaterial::parse_begin(Object *p_object) {
 	Ref<Material> m(material);
 
 	MaterialEditor *editor = memnew(MaterialEditor);
-	editor->edit(m, env);
+	editor->edit(m, default_environment);
 	add_custom_control(editor);
 }
 
@@ -464,14 +523,85 @@ void EditorInspectorPluginMaterial::_undo_redo_inspector_callback(Object *p_undo
 }
 
 EditorInspectorPluginMaterial::EditorInspectorPluginMaterial() {
-	env.instantiate();
+	default_environment.instantiate();
 	Ref<Sky> sky = memnew(Sky());
-	env->set_sky(sky);
-	env->set_background(Environment::BG_COLOR);
-	env->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
-	env->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
+	Ref<ProceduralSkyMaterial> sky_material;
+	sky_material.instantiate();
+	sky->set_material(sky_material);
+
+	default_environment->set_sky(sky);
+	default_environment->set_background(Environment::BG_SKY);
+	default_environment->set_ambient_source(Environment::AMBIENT_SOURCE_SKY);
+	default_environment->set_reflection_source(Environment::REFLECTION_SOURCE_SKY);
+	default_environment->set_glow_enabled(true);
 
 	EditorNode::get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &EditorInspectorPluginMaterial::_undo_redo_inspector_callback));
+}
+
+void MaterialEditor::_update_environment() {
+	{
+		Ref<Environment> env = camera->get_environment();
+		String env_path = GLOBAL_GET("editor/3d/preview_environment");
+		env_path = ResourceUID::get_singleton()->ensure_path(env_path.strip_edges());
+
+		if (!env_path.is_empty()) {
+			String type = ResourceLoader::get_resource_type(env_path);
+			if (!ClassDB::is_parent_class(type, "Environment")) {
+				// Wrong type, set as empty.
+				ProjectSettings::get_singleton()->set("editor/3d/preview_environment", "");
+			}
+		}
+
+		String cpath;
+		Ref<Environment> fallback = viewport->get_world_3d()->get_fallback_environment();
+		if (fallback.is_valid()) {
+			cpath = fallback->get_path();
+		}
+		if (cpath != env_path) {
+			if (!env_path.is_empty()) {
+				fallback = ResourceLoader::load(env_path);
+				if (fallback.is_null()) {
+					// Could not load fallback, set as empty.
+					ProjectSettings::get_singleton()->set("editor/3d/preview_environment", "");
+				}
+			} else {
+				fallback.unref();
+			}
+		}
+		viewport->get_world_3d()->set_environment(fallback);
+	}
+
+	{
+		String mat_path = GLOBAL_GET("editor/3d/preview_floor_material");
+		mat_path = ResourceUID::get_singleton()->ensure_path(mat_path.strip_edges());
+
+		if (!mat_path.is_empty()) {
+			String type = ResourceLoader::get_resource_type(mat_path);
+			if (!ClassDB::is_parent_class(type, "BaseMaterial3D")) {
+				// Wrong type, set as empty.
+				ProjectSettings::get_singleton()->set("editor/3d/preview_floor_material", "");
+			}
+		}
+
+		String cpath;
+		Ref<BaseMaterial3D> fallback_mat = floor_mesh->get_material();
+		if (fallback_mat.is_valid()) {
+			cpath = fallback_mat->get_path();
+		}
+		if (cpath != mat_path) {
+			if (!mat_path.is_empty()) {
+				fallback_mat = ResourceLoader::load(mat_path);
+				if (fallback_mat.is_null()) {
+					// Could not load fallback, set as empty.
+					ProjectSettings::get_singleton()->set("editor/3d/preview_floor_material", "");
+					fallback_mat = default_floor_material;
+				}
+			} else {
+				fallback_mat = default_floor_material;
+			}
+		}
+		floor_mesh->set_material(fallback_mat);
+	}
 }
 
 MaterialEditorPlugin::MaterialEditorPlugin() {

--- a/editor/scene/material_editor_plugin.h
+++ b/editor/scene/material_editor_plugin.h
@@ -41,6 +41,7 @@ class ColorRect;
 class DirectionalLight3D;
 class HBoxContainer;
 class MeshInstance3D;
+class ReflectionProbe;
 class SubViewport;
 class SubViewportContainer;
 class Button;
@@ -49,42 +50,47 @@ class Label;
 class MaterialEditor : public Control {
 	GDCLASS(MaterialEditor, Control);
 
-	// Both 2D and 3D materials.
-	Ref<Material> material;
-	SubViewportContainer *vc = nullptr;
-	SubViewport *viewport = nullptr;
-	VBoxContainer *layout_error = nullptr;
-	Label *error_label = nullptr;
-	bool is_unsupported_shader_mode = false;
+	enum class Shape {
+		SPHERE,
+		BOX,
+		QUAD,
+	};
 
-	struct ThemeCache {
-		Ref<Texture2D> light_1_icon;
-		Ref<Texture2D> light_2_icon;
-		Ref<Texture2D> sphere_icon;
-		Ref<Texture2D> box_icon;
-		Ref<Texture2D> quad_icon;
-		Ref<Texture2D> checkerboard;
-	} theme_cache;
+	enum class Switch {
+		LIGHT_1,
+		LIGHT_2,
+		FLOOR,
+	};
 
-	// 2D canvas materials.
 	SubViewportContainer *vc_2d = nullptr;
 	SubViewport *viewport_2d = nullptr;
 	HBoxContainer *layout_2d = nullptr;
 	ColorRect *rect_instance = nullptr;
 
-	// 3D spatial materials.
-	Vector2 rot;
+	// Both 2D and 3D materials.
+	Ref<Material> material;
+	SubViewportContainer *vc = nullptr;
+	SubViewport *viewport = nullptr;
 	Node3D *rotation = nullptr;
 	MeshInstance3D *sphere_instance = nullptr;
 	MeshInstance3D *box_instance = nullptr;
 	MeshInstance3D *quad_instance = nullptr;
+	MeshInstance3D *floor_instance = nullptr;
 	DirectionalLight3D *light1 = nullptr;
 	DirectionalLight3D *light2 = nullptr;
+	ReflectionProbe *probe = nullptr;
 	Camera3D *camera = nullptr;
 	Ref<CameraAttributesPractical> camera_attributes;
+
 	Ref<SphereMesh> sphere_mesh;
 	Ref<BoxMesh> box_mesh;
 	Ref<QuadMesh> quad_mesh;
+	Ref<PlaneMesh> floor_mesh;
+
+	VBoxContainer *layout_error = nullptr;
+	Label *error_label = nullptr;
+	bool is_unsupported_shader_mode = false;
+
 	HBoxContainer *layout_3d = nullptr;
 
 	Button *sphere_switch = nullptr;
@@ -92,21 +98,36 @@ class MaterialEditor : public Control {
 	Button *quad_switch = nullptr;
 	Button *light_1_switch = nullptr;
 	Button *light_2_switch = nullptr;
+	Button *floor_switch = nullptr;
 
-	void _on_light_1_switch_pressed();
-	void _on_light_2_switch_pressed();
-	void _on_sphere_switch_pressed();
-	void _on_box_switch_pressed();
-	void _on_quad_switch_pressed();
+	Shape shape = Shape::SPHERE;
 
-	void _set_rotation(real_t p_x_degrees, real_t p_y_degrees);
-	void _store_rotation_metadata();
-	void _update_rotation();
+	Vector2 rot;
+	float cam_zoom = 3.0f;
+	AABB contents_aabb;
+
+	Ref<BaseMaterial3D> default_floor_material;
+
+	struct ThemeCache {
+		Ref<Texture2D> light_1_icon;
+		Ref<Texture2D> light_2_icon;
+		Ref<Texture2D> floor_icon;
+		Ref<Texture2D> sphere_icon;
+		Ref<Texture2D> box_icon;
+		Ref<Texture2D> quad_icon;
+		Ref<Texture2D> checkerboard;
+	} theme_cache;
+
+	void _on_visibility_switch_pressed(int p_shape);
+	void _on_shape_switch_pressed(int p_shape);
+
+	void _update_environment();
 
 protected:
 	virtual void _update_theme_item_cache() override;
 	void _notification(int p_what);
 	void gui_input(const Ref<InputEvent> &p_event) override;
+	void _update_camera();
 
 public:
 	static Ref<ShaderMaterial> make_shader_material(const Ref<Material> &p_from, bool p_copy_params = true);
@@ -116,7 +137,7 @@ public:
 
 class EditorInspectorPluginMaterial : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorPluginMaterial, EditorInspectorPlugin);
-	Ref<Environment> env;
+	Ref<Environment> default_environment;
 
 public:
 	virtual bool can_handle(Object *p_object) override;


### PR DESCRIPTION
- Closes: https://github.com/godotengine/godot-proposals/issues/11259

The current preview setup is a solid color with no sky so PBR effects can't be visualized correctly and the material looks very different from what it would look in a scene.

I made the default preview use an `Environment` similar to the default 3D view's environment with a procedural sky. A floor can be toggled to preview reflections too using a reflection probe. The environment and floor material can be configured in the settings.

| Before | After |
| -------|------|
|![image](https://github.com/user-attachments/assets/b2e843f9-d65e-4a84-8595-b48fd361b1a8)|![image](https://github.com/user-attachments/assets/a6a45536-1a92-472f-8983-63b2bcedd6c9)
|![image](https://github.com/user-attachments/assets/0640ba55-2d00-469b-830a-68d33c15f3d2)|![image](https://github.com/user-attachments/assets/c7d9c202-35ae-417c-a960-31a27bb82ce8)