### PR TITLE
Fix animation compression method for Non-zero blend shape weights and rounding & Add unit tests

### DIFF
--- a/tests/scene/test_animation.h
+++ b/tests/scene/test_animation.h
@@ -31,6 +31,7 @@
 #ifndef TEST_ANIMATION_H
 #define TEST_ANIMATION_H
 
+#include "core/math/random_pcg.h"
 #include "scene/resources/animation.h"
 
 #include "tests/test_macros.h"
@@ -307,6 +308,269 @@ TEST_CASE("[Animation] Create Bezier track") {
 	CHECK(animation->try_scale_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	CHECK(animation->try_blend_shape_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	ERR_PRINT_ON;
+}
+
+// Number of random keys to create when testing compression.
+//
+// Ideally this value would be higher. But if it's too high then the compression starts to use multiple pages,
+// which means that keys get duplicated at page boundaries - that breaks the test, which relies on key indices
+// being stable so that original and compressed key values can be compared. So, this value has been chosen to
+// be reasonably high while only using a single page.
+static const int COMPRESSION_RANDOM_KEY_COUNT = 200;
+
+// Helper for printing the result of a Unorm16Check.
+struct Unorm16CheckResult {
+	real_t original;
+	real_t decompressed;
+	real_t difference;
+	real_t threshold;
+
+	Unorm16CheckResult(real_t p_original, real_t p_decompressed, real_t p_difference, real_t p_threshold) {
+		original = p_original;
+		decompressed = p_decompressed;
+		difference = p_difference;
+		threshold = p_threshold;
+	}
+
+	operator bool() const {
+		return difference < threshold;
+	}
+};
+
+doctest::String toString(const Unorm16CheckResult &r) {
+	return vformat("original: %f, decompressed: %f, difference: %f, threshold: %f", r.original, r.decompressed, r.difference, r.threshold).utf8().get_data();
+}
+
+// Given a value that has been linearly remapped to unorm16 and back again, check if the decompressed value is within an expected error threshold.
+struct Unorm16Check {
+	real_t threshold;
+
+	Unorm16Check(real_t range_min, real_t range_max) {
+		threshold = 0.6 * (Math::abs(range_max - range_min) / 65535.0);
+	}
+
+	Unorm16CheckResult operator()(real_t original, real_t decompressed) const {
+		real_t difference = Math::abs(original - decompressed);
+
+		return Unorm16CheckResult(original, decompressed, difference, threshold);
+	}
+};
+
+TEST_CASE("[Animation] Create compressed 3D position and scale tracks") {
+	RandomPCG random;
+
+	// Create tracks of random keys within a variety of ranges.
+
+	Vector<Vector3> range_min_array;
+	Vector<Vector3> range_max_array;
+
+	range_min_array.push_back(Vector3(1.0, -4.0, -4.0));
+	range_max_array.push_back(Vector3(4.0, 1.0, -1.0));
+
+	range_min_array.push_back(Vector3(1.0, -10000.0, 10000.0));
+	range_max_array.push_back(Vector3(10000.0, 20000.0, 10004.0));
+
+	REQUIRE(range_min_array.size() == range_max_array.size());
+
+	const int track_count = range_min_array.size();
+
+	Vector<Vector<Vector3>> track_array;
+
+	for (int track_index = 0; track_index < track_count; track_index++) {
+		Vector<Vector3> key_array;
+
+		Vector3 range_min = range_min_array[track_index];
+		Vector3 range_max = range_max_array[track_index];
+		Vector3 range_span = range_max - range_min;
+
+		key_array.push_back(range_min);
+		key_array.push_back(range_max);
+
+		for (int random_key_index = 0; random_key_index < COMPRESSION_RANDOM_KEY_COUNT; random_key_index++) {
+			key_array.push_back(range_min + (random.randf() * range_span));
+		}
+
+		track_array.push_back(key_array);
+	}
+
+	Ref<Animation> animation_position = memnew(Animation);
+	Ref<Animation> animation_scale = memnew(Animation);
+
+	for (int track_index = 0; track_index < track_count; track_index++) {
+		REQUIRE(animation_position->add_track(Animation::TYPE_POSITION_3D, track_index) == track_index);
+		REQUIRE(animation_scale->add_track(Animation::TYPE_SCALE_3D, track_index) == track_index);
+
+		animation_position->track_set_path(track_index, NodePath(vformat("Enemy:position%d", track_index)));
+		animation_scale->track_set_path(track_index, NodePath(vformat("Enemy:scale%d", track_index)));
+
+		Vector<Vector3> key_array = track_array[track_index];
+
+		for (int key_index = 0; key_index < key_array.size(); key_index++) {
+			Vector3 key = key_array[key_index];
+			double time = (double)key_index;
+
+			REQUIRE(animation_position->position_track_insert_key(track_index, time, key) == key_index);
+			REQUIRE(animation_scale->scale_track_insert_key(track_index, time, key) == key_index);
+		}
+	}
+
+	animation_position->compress();
+	animation_scale->compress();
+
+	REQUIRE(track_array.size() == track_count);
+	REQUIRE(animation_position->get_track_count() == track_count);
+	REQUIRE(animation_scale->get_track_count() == track_count);
+
+	for (int track_index = 0; track_index < track_count; track_index++) {
+		REQUIRE(animation_position->track_is_compressed(track_index));
+		REQUIRE(animation_scale->track_is_compressed(track_index));
+
+		Vector3 range_min = range_min_array[track_index];
+		Vector3 range_max = range_max_array[track_index];
+
+		const Vector<Vector3> &key_array = track_array[track_index];
+
+		REQUIRE(animation_position->track_get_key_count(track_index) == key_array.size());
+		REQUIRE(animation_scale->track_get_key_count(track_index) == key_array.size());
+
+		for (int key_index = 0; key_index < key_array.size(); key_index++) {
+			Vector3 key = key_array[key_index];
+
+			Vector3 decompressed_position, decompressed_scale;
+			REQUIRE(animation_position->position_track_get_key(track_index, key_index, &decompressed_position) == OK);
+			REQUIRE(animation_scale->scale_track_get_key(track_index, key_index, &decompressed_scale) == OK);
+
+			for (int axis_index = 0; axis_index < 3; axis_index++) {
+				Unorm16Check check(range_min[axis_index], range_max[axis_index]);
+
+				CHECK(check(key[axis_index], decompressed_position[axis_index]));
+				CHECK(check(key[axis_index], decompressed_scale[axis_index]));
+			}
+		}
+	}
+}
+
+TEST_CASE("[Animation] Create compressed 3D rotation track") {
+	RandomPCG random;
+
+	// Start with various extremes.
+
+	Vector<Quaternion> keys = {
+		Quaternion(1.0, 0.0, 0.0, 0.0),
+		Quaternion(0.0, 1.0, 0.0, 0.0),
+		Quaternion(0.0, 0.0, 1.0, 0.0),
+		Quaternion(0.0, 0.0, 0.0, 1.0),
+
+		Quaternion(-1.0, 0.0, 0.0, 0.0),
+		Quaternion(0.0, -1.0, 0.0, 0.0),
+		Quaternion(0.0, 0.0, -1.0, 0.0),
+		Quaternion(0.0, 0.0, 0.0, -1.0),
+	};
+
+	// Also add some random keys.
+
+	for (int random_key_index = 0; random_key_index < COMPRESSION_RANDOM_KEY_COUNT; random_key_index++) {
+		Quaternion q;
+
+		do {
+			q = Quaternion(random.randf(), random.randf(), random.randf(), random.randf());
+		} while (q.length() < 0.001);
+
+		q.normalize();
+
+		keys.push_back(q);
+	}
+
+	Ref<Animation> animation = memnew(Animation);
+
+	REQUIRE(animation->add_track(Animation::TYPE_ROTATION_3D, 0) == 0);
+	animation->track_set_path(0, NodePath("Enemy:rotation"));
+
+	for (int key_index = 0; key_index < keys.size(); key_index++) {
+		double time = (double)key_index;
+		Quaternion key = keys[key_index];
+
+		REQUIRE(animation->rotation_track_insert_key(0, time, key) == key_index);
+	}
+
+	animation->compress();
+
+	REQUIRE(animation->get_track_count() == 1);
+	REQUIRE(animation->track_is_compressed(0));
+
+	// The exact error threshold is hard to work out because the quaternion compression has some non-linear transforms.
+	// This value is the maximum difference observed from 100,000,000 random keys plus a small fudge factor.
+
+	real_t threshold = 0.000068393776 * 1.2;
+
+	for (int key_index = 0; key_index < keys.size(); key_index++) {
+		Quaternion key = keys[key_index];
+
+		Quaternion decompressed;
+		REQUIRE(animation->rotation_track_get_key(0, key_index, &decompressed) == OK);
+
+		// Treat q and (q * -1.0) as the same. This is necessary because a quaternion with an angle close to 360 degrees
+		// (w = -1.0) can be decompressed to a quaternion with an angle close to zero (w = 1.0).
+
+		real_t difference = MIN((key - decompressed).length(), (key + decompressed).length());
+
+		CHECK(difference < threshold);
+	}
+}
+
+TEST_CASE("[Animation] Create compressed blend shape track") {
+	RandomPCG random;
+
+	// Hard code Animation::Compression::BLEND_SHAPE_RANGE since it's private.
+
+	const float range_min = -8.0;
+	const float range_max = 8.0;
+	const float range_span = range_max - range_min;
+
+	// Start with some extremes. Use zero for the first key as there's a special check for it later.
+
+	Vector<float> keys = { 0.0, range_min, range_max };
+
+	int zero_key_index = 0;
+
+	// Also add some random keys.
+
+	for (int random_key_index = 0; random_key_index < COMPRESSION_RANDOM_KEY_COUNT; random_key_index++) {
+		keys.push_back(range_min + (random.randf() * range_span));
+	}
+
+	Ref<Animation> animation = memnew(Animation);
+
+	REQUIRE(animation->add_track(Animation::TYPE_BLEND_SHAPE, 0) == 0);
+	animation->track_set_path(0, NodePath("Enemy:blendshape"));
+
+	for (int key_index = 0; key_index < keys.size(); key_index++) {
+		double time = (double)key_index;
+		float key = keys[key_index];
+
+		REQUIRE(animation->blend_shape_track_insert_key(0, time, key) == key_index);
+	}
+
+	animation->compress();
+
+	REQUIRE(animation->get_track_count() == 1);
+	REQUIRE(animation->track_is_compressed(0));
+
+	float zero_key_decompressed;
+	REQUIRE(animation->blend_shape_track_get_key(0, zero_key_index, &zero_key_decompressed) == OK);
+
+	CHECK_MESSAGE(zero_key_decompressed == 0.0f, "An original value of zero is expected to decompress to exactly zero");
+
+	Unorm16Check check(range_min, range_max);
+
+	for (int key_index = 0; key_index < keys.size(); key_index++) {
+		float key = keys[key_index];
+
+		float decompressed;
+		REQUIRE(animation->blend_shape_track_get_key(0, key_index, &decompressed) == OK);
+
+		CHECK(check(key, decompressed));
+	}
 }
 
 } // namespace TestAnimation


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/99794 and fixes https://github.com/godotengine/godot/issues/99796.

I don't have any evidence that these issues are noticeably affecting Godot users, but the changes are small so hopefully worth considering. Also includes a defensive change and unit tests. I've rolled them into one PR as the fixes touch the same code, and the new unit tests validate the fixes.

- Changed blend shape unorm encoding to scale by 65534 instead of 65535.
  - Fixes potential performance issues from zero weights getting compressed to non-zero and triggering unnecessary vertex shader work.
  - Details in https://github.com/godotengine/godot/issues/99794.
- Changed unorm conversion for all tracks to include a `+ 0.5`. 
  - This makes it round towards nearest instead of towards zero, which doubles the accuracy.
  - Details in https://github.com/godotengine/godot/issues/99796.
- Added unit tests.
  - These generate anims and then check that the compressed keys are within expected tolerances.
  - The tests would have failed without the above fixes.
- Changed quaternion compression to skip the octahedron encode if the axis is zero.
  - Previously, the octahedron encode would return NaNs if the axis was zero.
  - The NaNs were later set to zero by conversions and clamps, so arguably it wasn't a bug.
  - But I figure that avoiding NaNs entirely is a good defensive change.

Impact on users:

 - The blend shape zero weight change will affect existing assets. It might fix a performance issue if a user has an animation with a lot of zero weight blend shapes.
 - The rounding changes will take effect on asset reimport. They will give a small quality increase.

Things I wasn't sure about:

- The blend shape unit test hard codes `Animation::Compression::BLEND_SHAPE_RANGE` since it's private. Maybe better to move it somewhere public.
- The blend shape unit test requires that an original value of zero decompresses to exactly zero. I think this is reasonable as it avoids having to agree on a threshold with other code, but is arguably too strict.
