### PR TITLE
Add `String::concat` and `string.extend` functions to core for efficient String concatenation.

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -449,5 +449,8 @@ Variant AABB::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) c
 }
 
 AABB::operator String() const {
-	return "[P: " + position.operator String() + ", S: " + size + "]";
+	return String::concat(
+			"[P: ", position.operator String(),
+			", S: ", size,
+			"]");
 }

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -724,9 +724,11 @@ bool Basis::operator!=(const Basis &p_matrix) const {
 }
 
 Basis::operator String() const {
-	return "[X: " + get_column(0).operator String() +
-			", Y: " + get_column(1).operator String() +
-			", Z: " + get_column(2).operator String() + "]";
+	return String::concat(
+			"[X: ", get_column(0).operator String(),
+			", Y: ", get_column(1).operator String(),
+			", Z: ", get_column(2).operator String(),
+			"]");
 }
 
 Quaternion Basis::get_quaternion() const {

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -487,7 +487,13 @@ Color Color::from_rgba8(int64_t p_r8, int64_t p_g8, int64_t p_b8, int64_t p_a8) 
 }
 
 Color::operator String() const {
-	return "(" + String::num(r, 4) + ", " + String::num(g, 4) + ", " + String::num(b, 4) + ", " + String::num(a, 4) + ")";
+	return String::concat(
+			"(",
+			String::num(r, 4), ", ",
+			String::num(g, 4), ", ",
+			String::num(b, 4), ", ",
+			String::num(a, 4),
+			")");
 }
 
 Color Color::operator+(const Color &p_color) const {

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -201,7 +201,10 @@ bool Face3::intersects_aabb(const AABB &p_aabb) const {
 }
 
 Face3::operator String() const {
-	return String() + vertex[0] + ", " + vertex[1] + ", " + vertex[2];
+	return String::concat(
+			vertex[0], ", ",
+			vertex[1], ", ",
+			vertex[2]);
 }
 
 void Face3::project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const {

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -181,5 +181,8 @@ bool Plane::is_finite() const {
 }
 
 Plane::operator String() const {
-	return "[N: " + normal.operator String() + ", D: " + String::num_real(d, false) + "]";
+	return String::concat(
+			"[N: ", normal.operator String(),
+			", D: ", String::num_real(d, false),
+			"]");
 }

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -869,10 +869,12 @@ void Projection::set_light_atlas_rect(const Rect2 &p_rect) {
 }
 
 Projection::operator String() const {
-	return "[X: " + columns[0].operator String() +
-			", Y: " + columns[1].operator String() +
-			", Z: " + columns[2].operator String() +
-			", W: " + columns[3].operator String() + "]";
+	return String::concat(
+			"[X: ", columns[0].operator String(),
+			", Y: ", columns[1].operator String(),
+			", Z: ", columns[2].operator String(),
+			", W: ", columns[3].operator String(),
+			"]");
 }
 
 real_t Projection::get_aspect() const {

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -281,7 +281,13 @@ Quaternion Quaternion::spherical_cubic_interpolate_in_time(const Quaternion &p_b
 }
 
 Quaternion::operator String() const {
-	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ", " + String::num_real(z, false) + ", " + String::num_real(w, false) + ")";
+	return String::concat(
+			"(",
+			String::num_real(x, false), ", ",
+			String::num_real(y, false), ", ",
+			String::num_real(z, false), ", ",
+			String::num_real(w, false),
+			")");
 }
 
 Vector3 Quaternion::get_axis() const {
@@ -298,7 +304,7 @@ real_t Quaternion::get_angle() const {
 
 Quaternion::Quaternion(const Vector3 &p_axis, real_t p_angle) {
 #ifdef MATH_CHECKS
-	ERR_FAIL_COND_MSG(!p_axis.is_normalized(), "The axis Vector3 " + p_axis.operator String() + " must be normalized.");
+	ERR_FAIL_COND_MSG(!p_axis.is_normalized(), String::concat("The axis Vector3 ", p_axis.operator String(), " must be normalized."));
 #endif
 	real_t d = p_axis.length();
 	if (d == 0) {

--- a/core/math/rect2.cpp
+++ b/core/math/rect2.cpp
@@ -287,7 +287,10 @@ next4:
 }
 
 Rect2::operator String() const {
-	return "[P: " + position.operator String() + ", S: " + size.operator String() + "]";
+	return String::concat(
+			"[P: ", position.operator String(),
+			", S: ", size.operator String(),
+			"]");
 }
 
 Rect2::operator Rect2i() const {

--- a/core/math/rect2i.cpp
+++ b/core/math/rect2i.cpp
@@ -34,7 +34,10 @@
 #include "core/string/ustring.h"
 
 Rect2i::operator String() const {
-	return "[P: " + position.operator String() + ", S: " + size + "]";
+	return String::concat(
+			"[P: ", position.operator String(),
+			", S: ", size,
+			"]");
 }
 
 Rect2i::operator Rect2() const {

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -312,7 +312,9 @@ Transform2D Transform2D::operator/(real_t p_val) const {
 }
 
 Transform2D::operator String() const {
-	return "[X: " + columns[0].operator String() +
-			", Y: " + columns[1].operator String() +
-			", O: " + columns[2].operator String() + "]";
+	return String::concat(
+			"[X: ", columns[0].operator String(),
+			", Y: ", columns[1].operator String(),
+			", O: ", columns[2].operator String(),
+			"]");
 }

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -223,10 +223,12 @@ Transform3D Transform3D::operator/(real_t p_val) const {
 }
 
 Transform3D::operator String() const {
-	return "[X: " + basis.get_column(0).operator String() +
-			", Y: " + basis.get_column(1).operator String() +
-			", Z: " + basis.get_column(2).operator String() +
-			", O: " + origin.operator String() + "]";
+	return String::concat(
+			"[X: ", basis.get_column(0).operator String(),
+			", Y: ", basis.get_column(1).operator String(),
+			", Z: ", basis.get_column(2).operator String(),
+			", O: ", origin.operator String(),
+			"]");
 }
 
 Transform3D::Transform3D(const Basis &p_basis, const Vector3 &p_origin) :

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -207,7 +207,11 @@ bool Vector2::is_finite() const {
 }
 
 Vector2::operator String() const {
-	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ")";
+	return String::concat(
+			"(",
+			String::num_real(x, true), ", ",
+			String::num_real(y, true),
+			")");
 }
 
 Vector2::operator Vector2i() const {

--- a/core/math/vector2i.cpp
+++ b/core/math/vector2i.cpp
@@ -135,7 +135,11 @@ bool Vector2i::operator!=(const Vector2i &p_vec2) const {
 }
 
 Vector2i::operator String() const {
-	return "(" + itos(x) + ", " + itos(y) + ")";
+	return String::concat(
+			"(",
+			itos(x), ", ",
+			itos(y),
+			")");
 }
 
 Vector2i::operator Vector2() const {

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -169,7 +169,12 @@ bool Vector3::is_finite() const {
 }
 
 Vector3::operator String() const {
-	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ", " + String::num_real(z, true) + ")";
+	return String::concat(
+			"(",
+			String::num_real(x, true), ", ",
+			String::num_real(y, true), ", ",
+			String::num_real(z, true),
+			")");
 }
 
 Vector3::operator Vector3i() const {

--- a/core/math/vector3i.cpp
+++ b/core/math/vector3i.cpp
@@ -70,7 +70,12 @@ Vector3i Vector3i::snappedi(int32_t p_step) const {
 }
 
 Vector3i::operator String() const {
-	return "(" + itos(x) + ", " + itos(y) + ", " + itos(z) + ")";
+	return String::concat(
+			"(",
+			itos(x), ", ",
+			itos(y), ", ",
+			itos(z),
+			")");
 }
 
 Vector3i::operator Vector3() const {

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -217,7 +217,13 @@ Vector4 Vector4::clampf(real_t p_min, real_t p_max) const {
 }
 
 Vector4::operator String() const {
-	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ", " + String::num_real(z, true) + ", " + String::num_real(w, true) + ")";
+	return String::concat(
+			"(",
+			String::num_real(x, true), ", ",
+			String::num_real(y, true), ", ",
+			String::num_real(z, true), ", ",
+			String::num_real(w, true),
+			")");
 }
 
 static_assert(sizeof(Vector4) == 4 * sizeof(real_t));

--- a/core/math/vector4i.cpp
+++ b/core/math/vector4i.cpp
@@ -90,7 +90,13 @@ Vector4i Vector4i::snappedi(int32_t p_step) const {
 }
 
 Vector4i::operator String() const {
-	return "(" + itos(x) + ", " + itos(y) + ", " + itos(z) + ", " + itos(w) + ")";
+	return String::concat(
+			"(",
+			itos(x), ", ",
+			itos(y), ", ",
+			itos(z), ", ",
+			itos(w),
+			")");
 }
 
 Vector4i::operator Vector4() const {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -607,6 +607,23 @@ public:
 	// Use `is_valid_ascii_identifier()` instead. Kept for compatibility.
 	bool is_valid_identifier() const { return is_valid_ascii_identifier(); }
 
+	template <typename... Args>
+	void extend(Args... args);
+
+	template <typename... Args>
+	static String concat(Args... args) {
+		String string;
+		string.extend(args...);
+		return string;
+	}
+
+	template <typename... Args>
+	static String concat(String &&string, Args... args) {
+		// Optimized case of the concat call, where we can consume the first argument to avoid re-allocation.
+		string.extend(args...);
+		return std::move(string);
+	}
+
 	/**
 	 * The constructors must not depend on other overloads
 	 */
@@ -668,6 +685,50 @@ bool operator!=(const wchar_t *p_chr, const String &p_str);
 String operator+(const char *p_chr, const String &p_str);
 String operator+(const wchar_t *p_chr, const String &p_str);
 String operator+(char32_t p_chr, const String &p_str);
+
+_FORCE_INLINE_ char32_t *_insert_string(const Span<char> &string, char32_t *dst) {
+	const char32_t *src = dst;
+	for (const char32_t *end = dst + string.size(); src < end; ++src, ++dst) {
+		*dst = *src;
+	}
+	return dst;
+}
+
+_FORCE_INLINE_ char32_t *_insert_string(const Span<char32_t> &string, char32_t *dst) {
+	memcpy(dst, string.ptr(), string.size() * sizeof(char32_t));
+	dst += string.size();
+	return dst;
+}
+
+inline Span<char32_t> _to_str_range(const String &string) {
+	return Span<char32_t>(string);
+}
+template <typename Char, typename = std::enable_if_t<std::is_fundamental_v<Char>>>
+Span<Char> _to_str_range(const Span<Char> &string) {
+	return string;
+}
+template <typename Char, size_t len, typename = std::enable_if_t<std::is_fundamental_v<Char>>>
+Span<Char> _to_str_range(const Char (&string)[len]) {
+	return Span(string, strlen(string));
+}
+template <typename Char, typename = std::enable_if_t<std::is_fundamental_v<Char>>>
+Span<Char> _to_str_range(const Char &chr) {
+	return Span<Char>(&chr, 1);
+}
+
+template <typename... Args>
+void _extend_string_ranges(String &string, Args... args) {
+	const int length_before = string.length();
+	string.resize(length_before + (args.len + ...) + 1);
+	char32_t *dst = string.ptrw() + length_before;
+	((dst = _insert_string(args, dst)), ...);
+	*dst = 0;
+}
+
+template <typename... Args>
+void String::extend(Args... args) {
+	_extend_string_ranges(*this, _to_str_range(args)...);
+}
 
 String itos(int64_t p_val);
 String uitos(uint64_t p_val);

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1733,10 +1733,10 @@ String Variant::stringify(int recursion_count) const {
 		}
 		case RID: {
 			const ::RID &s = *reinterpret_cast<const ::RID *>(_data._mem);
-			return "RID(" + itos(s.get_id()) + ")";
+			return String::concat("RID(", itos(s.get_id()), ")");
 		}
 		default: {
-			return "<" + get_type_name(type) + ">";
+			return String::concat("<", get_type_name(type), ">");
 		}
 	}
 }


### PR DESCRIPTION
Small optimization and readability improvement.

`String::concat` and `string.extend` enter the arena to join strings, and are the fastest method among `operator+`, `StringBuilder` and `StringBuffer` for known-count string concatenations. They use compile-time logic to avoid needing RAM allocations for bookkeeping (like `StringBuilder` or multiple `reallocs` (like `StringBuffer`) and is thus _always_ faster than either.

I have also changed all `Variant` conversions to `String` to use the `String::concat ` function. This is not because of an urgent need to optimize these functions, but they serve as exemplary cases about how to use the function, and how this improves performance (1.6x in the case of `Projection`). Future PRs should address the various uses of repeated `A + B + C + D + E...`  throughout the codebase where appropriate for optimization.

I am open to renaming or moving the function.

Imo #100293 should be merged before this one, to avoid unnecessary additional renames.

## Explanation

Take the example case `Vector4`. This has previously compiled like:

```c++
// Actual Code
	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ", " + String::num_real(z, true) + ", " + String::num_real(w, true) + ")";

// Compiled like
// Technically even each addition is hidden behind a function, but that's not that relevant to performance.
String s1 = "(";
s1 += String::num_real(x, true);  // resize

String s2 = s1;  // Cow copy
s2 += String::num_real(y, true);  // resize

String s3 = s2;  // Cow copy
s3 += String::num_real(z, true);  // resize

String s4 = s3;  // Cow copy
s4 += String::num_real(w, true);  // resize

String s5 = s4;  // Cow copy
s5 += ")";  // resize

return s5;
```

This will now compile like:

```c++
// Actual code
	return String::concat(
		"(",
		String::num_real(x, true), ", ",
		String::num_real(y, true), ", ",
		String::num_real(z, true), ", ",
		String::num_real(w, true),
		")"
	);

// Compiled like
String s1 = String::num_real(x, true);
String s2 = String::num_real(y, true);
String s3 = String::num_real(z, true);
String s4 = String::num_real(w, true);

String string;
string.resize(1 + s1.length() + 2 + s2.length() + 2 + s3.length() + 2 + s4.length() + 1);  // resize
const char32_t *ptr;

*(ptr++) = '(';

memcpy(ptr, s1.ptr(), s1.length() * sizeof(char32_t));
ptr += s1.length();

// Technically these loops are likely unrolled by the optimizing compiler, but you get the gist.
for (int i = 0; i < 2; i++) (*ptr++) = ", "[i];

memcpy(ptr, s2.ptr(), s2.length() * sizeof(char32_t));
ptr += s2.length();

for (int i = 0; i < 2; i++) (*ptr++) = ", "[i];

memcpy(ptr, s3.ptr(), s3.length() * sizeof(char32_t));
ptr += s3.length();

for (int i = 0; i < 2; i++) (*ptr++) = ", "[i];

memcpy(ptr, s4.ptr(), s4.length() * sizeof(char32_t));
ptr += s4.length();

*(ptr++) = ')';

*ptr = '\n';

return string;
```

## Benchmark

I ran the following benchmark:

```c++
	Projection p;

	auto t0 = std::chrono::high_resolution_clock::now();
	for (int i = 0; i < 1000000; i ++) {
		// Test
		String s = p.operator String();
	}
	auto t1 = std::chrono::high_resolution_clock::now();
	std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
```

This prints:
- `4141ms` on master (a40fc2354a1639f283c7c46ba8dc321b7ff15960)
- `2540ms` on this PR (b7f85fec53d9fc539f270fdde06563fe920bacef)

Which showcases an improvement of `1.6x` in this particular case.

