### PR TITLE
Fix orphan strings in `EditorHelpBit`

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3476,6 +3476,8 @@ EditorHelp::EditorHelp() {
 
 #define HANDLE_DOC(m_string) ((is_native ? DTR(m_string) : (m_string)).strip_edges())
 
+SafeNumeric<int> EditorHelpBit::instance_counter;
+
 EditorHelpBit::HelpData EditorHelpBit::_get_class_help_data(const StringName &p_class_name) {
 	if (doc_class_cache.has(p_class_name)) {
 		return doc_class_cache[p_class_name];
@@ -4514,6 +4516,7 @@ void EditorHelpBit::update_content_height() {
 }
 
 EditorHelpBit::EditorHelpBit(const String &p_symbol, const String &p_prologue, bool p_use_class_prefix, bool p_allow_selection) {
+	instance_counter.increment();
 	add_theme_constant_override("separation", 0);
 
 	title = memnew(RichTextLabel);
@@ -4545,6 +4548,21 @@ EditorHelpBit::EditorHelpBit(const String &p_symbol, const String &p_prologue, b
 		parse_symbol(p_symbol, p_prologue);
 	} else if (!p_prologue.is_empty()) {
 		set_custom_text(String(), String(), p_prologue);
+	}
+}
+
+EditorHelpBit::~EditorHelpBit() {
+	instance_counter.decrement();
+
+	if (instance_counter.get() == 0) {
+		doc_class_cache.clear();
+		doc_enum_cache.clear();
+		doc_constant_cache.clear();
+		doc_property_cache.clear();
+		doc_theme_item_cache.clear();
+		doc_method_cache.clear();
+		doc_signal_cache.clear();
+		doc_annotation_cache.clear();
 	}
 }
 

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/os/thread.h"
+#include "core/templates/safe_refcount.h"
 #include "editor/doc/doc_tools.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/dialogs.h"
@@ -316,6 +317,8 @@ class EditorHelpBit : public VBoxContainer {
 	inline static HashMap<StringName, HashMap<StringName, HelpData>> doc_signal_cache;
 	inline static HashMap<StringName, HashMap<StringName, HelpData>> doc_annotation_cache;
 
+	static SafeNumeric<int> instance_counter;
+
 	RichTextLabel *title = nullptr;
 	RichTextLabel *content = nullptr;
 
@@ -358,6 +361,7 @@ public:
 	void update_content_height();
 
 	EditorHelpBit(const String &p_symbol = String(), const String &p_prologue = String(), bool p_use_class_prefix = false, bool p_allow_selection = true);
+	~EditorHelpBit();
 };
 
 // Standard tooltips do not allow you to hover over them.


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/92726

Before:

![изображение](https://github.com/user-attachments/assets/1fa1b124-7c73-4a32-b398-0a7404fb866b)

After:

![изображение](https://github.com/user-attachments/assets/8be08773-c156-49a8-958c-062f62fcc60d)
