### PR TITLE
Replace `List` with `LocalVector` if used as simple buffer

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -77,8 +77,8 @@ bool DirAccess::drives_are_shortcuts() {
 }
 
 static Error _erase_recursive(DirAccess *da) {
-	List<String> dirs;
-	List<String> files;
+	LocalVector<String> dirs;
+	LocalVector<String> files;
 
 	da->list_dir_begin();
 	String n = da->get_next();
@@ -484,7 +484,7 @@ public:
 };
 
 Error DirAccess::_copy_dir(Ref<DirAccess> &p_target_da, const String &p_to, int p_chmod_flags, bool p_copy_links) {
-	List<String> dirs;
+	LocalVector<String> dirs;
 
 	String curdir = get_current_dir();
 	list_dir_begin();

--- a/core/io/packed_data_container.cpp
+++ b/core/io/packed_data_container.cpp
@@ -270,7 +270,7 @@ uint32_t PackedDataContainer::_pack(const Variant &p_data, Vector<uint8_t> &tmpd
 
 			List<Variant> keys;
 			d.get_key_list(&keys);
-			List<DictKey> sortk;
+			LocalVector<DictKey> sortk;
 
 			for (const Variant &key : keys) {
 				DictKey dk;

--- a/core/io/packed_data_container.cpp
+++ b/core/io/packed_data_container.cpp
@@ -271,6 +271,7 @@ uint32_t PackedDataContainer::_pack(const Variant &p_data, Vector<uint8_t> &tmpd
 			List<Variant> keys;
 			d.get_key_list(&keys);
 			LocalVector<DictKey> sortk;
+			sortk.reserve(keys.size());
 
 			for (const Variant &key : keys) {
 				DictKey dk;

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -381,7 +381,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 	uint64_t hash = hash_murmur3_one_64(HashMapHasherDefault::hash(VERSION_FULL_CONFIG));
 
-	List<StringName> class_list;
+	LocalVector<StringName> class_list;
 	for (const KeyValue<StringName, ClassInfo> &E : classes) {
 		class_list.push_back(E.key);
 	}
@@ -399,7 +399,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 		{ //methods
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
 			for (const KeyValue<StringName, MethodBind *> &F : t->method_map) {
 				String name = F.key.operator String();
@@ -444,7 +444,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 		{ //constants
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
 			for (const KeyValue<StringName, int64_t> &F : t->constant_map) {
 				snames.push_back(F.key);
@@ -460,7 +460,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 		{ //signals
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
 			for (const KeyValue<StringName, MethodInfo> &F : t->signal_map) {
 				snames.push_back(F.key);
@@ -479,7 +479,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 		{ //properties
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
 			for (const KeyValue<StringName, PropertySetGet> &F : t->property_setget) {
 				snames.push_back(F.key);

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -382,6 +382,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 	uint64_t hash = hash_murmur3_one_64(HashMapHasherDefault::hash(VERSION_FULL_CONFIG));
 
 	LocalVector<StringName> class_list;
+	class_list.reserve(classes.size());
 	for (const KeyValue<StringName, ClassInfo> &E : classes) {
 		class_list.push_back(E.key);
 	}
@@ -445,6 +446,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 		{ //constants
 
 			LocalVector<StringName> snames;
+			snames.reserve(t->constant_map.size());
 
 			for (const KeyValue<StringName, int64_t> &F : t->constant_map) {
 				snames.push_back(F.key);
@@ -461,6 +463,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 		{ //signals
 
 			LocalVector<StringName> snames;
+			snames.reserve(t->signal_map.size());
 
 			for (const KeyValue<StringName, MethodInfo> &F : t->signal_map) {
 				snames.push_back(F.key);
@@ -480,6 +483,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 		{ //properties
 
 			LocalVector<StringName> snames;
+			snames.reserve(t->property_setget.size());
 
 			for (const KeyValue<StringName, PropertySetGet> &F : t->property_setget) {
 				snames.push_back(F.key);

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -483,7 +483,7 @@ StringName ScriptServer::get_global_class_native_base(const String &p_class) {
 }
 
 void ScriptServer::get_global_class_list(List<StringName> *r_global_classes) {
-	List<StringName> classes;
+	LocalVector<StringName> classes;
 	for (const KeyValue<StringName, GlobalScriptClass> &E : global_classes) {
 		classes.push_back(E.key);
 	}
@@ -764,7 +764,7 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 	}
 
 	properties = p_properties;
-	List<StringName> to_remove;
+	LocalVector<StringName> to_remove;
 
 	for (KeyValue<StringName, Variant> &E : values) {
 		if (!new_values.has(E.key)) {
@@ -780,9 +780,8 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 		}
 	}
 
-	while (to_remove.size()) {
-		values.erase(to_remove.front()->get());
-		to_remove.pop_front();
+	for (const StringName &E : to_remove) {
+		values.erase(E);
 	}
 
 	if (owner && owner->get_script_instance() == this) {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -484,6 +484,7 @@ StringName ScriptServer::get_global_class_native_base(const String &p_class) {
 
 void ScriptServer::get_global_class_list(List<StringName> *r_global_classes) {
 	LocalVector<StringName> classes;
+	classes.reserve(r_global_classes->size());
 	for (const KeyValue<StringName, GlobalScriptClass> &E : global_classes) {
 		classes.push_back(E.key);
 	}

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1019,7 +1019,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 	}
 	{
 		//for textures no longer used, unregister them
-		List<StringName> to_delete;
+		LocalVector<StringName> to_delete;
 		for (KeyValue<StringName, uint64_t> &E : used_global_textures) {
 			if (E.value != global_textures_pass) {
 				to_delete.push_back(E.key);
@@ -1031,10 +1031,10 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 			}
 		}
 
-		while (to_delete.front()) {
-			used_global_textures.erase(to_delete.front()->get());
-			to_delete.pop_front();
+		for (StringName &name : to_delete) {
+			used_global_textures.erase(name);
 		}
+
 		//handle registering/unregistering global textures
 		if (uses_global_textures != (global_texture_E != nullptr)) {
 			if (uses_global_textures) {

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1745,7 +1745,7 @@ void AnimationBezierTrackEdit::duplicate_selected_keys(real_t p_ofs, bool p_ofs_
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Animation Duplicate Keys"));
 
-	List<Pair<int, real_t>> new_selection_values;
+	LocalVector<Pair<int, real_t>> new_selection_values;
 
 	for (SelectionSet::Element *E = selection.back(); E; E = E->prev()) {
 		real_t t = animation->track_get_key_time(E->get().first, E->get().second);
@@ -1883,7 +1883,7 @@ void AnimationBezierTrackEdit::paste_keys(real_t p_ofs, bool p_ofs_valid) {
 			WARN_PRINT("Pasted animation keys from multiple tracks into single Bezier track");
 		}
 
-		List<Pair<int, float>> new_selection_values;
+		LocalVector<Pair<int, float>> new_selection_values;
 		for (int i = 0; i < editor->key_clipboard.keys.size(); i++) {
 			const AnimationTrackEditor::KeyClipboard::Key key = editor->key_clipboard.keys[i];
 

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -1746,6 +1746,7 @@ void AnimationBezierTrackEdit::duplicate_selected_keys(real_t p_ofs, bool p_ofs_
 	undo_redo->create_action(TTR("Animation Duplicate Keys"));
 
 	LocalVector<Pair<int, real_t>> new_selection_values;
+	new_selection_values.reserve(selection.size());
 
 	for (SelectionSet::Element *E = selection.back(); E; E = E->prev()) {
 		real_t t = animation->track_get_key_time(E->get().first, E->get().second);
@@ -1884,6 +1885,7 @@ void AnimationBezierTrackEdit::paste_keys(real_t p_ofs, bool p_ofs_valid) {
 		}
 
 		LocalVector<Pair<int, float>> new_selection_values;
+		new_selection_values.reserve(editor->key_clipboard.keys.size());
 		for (int i = 0; i < editor->key_clipboard.keys.size(); i++) {
 			const AnimationTrackEditor::KeyClipboard::Key key = editor->key_clipboard.keys[i];
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5837,7 +5837,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Animation Move Keys"));
 
-	List<_AnimMoveRestore> to_restore;
+	LocalVector<_AnimMoveRestore> to_restore;
 
 	float motion = moving_selection_offset;
 	// 1 - remove the keys.
@@ -6146,7 +6146,7 @@ void AnimationTrackEditor::_anim_duplicate_keys(float p_ofs, bool p_ofs_valid, i
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->create_action(TTR("Animation Duplicate Keys"));
 
-		List<Pair<int, float>> new_selection_values;
+		LocalVector<Pair<int, float>> new_selection_values;
 
 		for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 			const SelectedKey &sk = E->key();
@@ -6295,7 +6295,7 @@ void AnimationTrackEditor::_anim_paste_keys(float p_ofs, bool p_ofs_valid, int p
 
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->create_action(TTR("Animation Paste Keys"));
-		List<Pair<int, float>> new_selection_values;
+		LocalVector<Pair<int, float>> new_selection_values;
 
 		for (int i = 0; i < key_clipboard.keys.size(); i++) {
 			const KeyClipboard::Key key = key_clipboard.keys[i];
@@ -6678,7 +6678,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->create_action(TTR("Animation Scale Keys"));
 
-			List<_AnimMoveRestore> to_restore;
+			LocalVector<_AnimMoveRestore> to_restore;
 
 			// 1 - Remove the keys.
 			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6296,6 +6296,7 @@ void AnimationTrackEditor::_anim_paste_keys(float p_ofs, bool p_ofs_valid, int p
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->create_action(TTR("Animation Paste Keys"));
 		LocalVector<Pair<int, float>> new_selection_values;
+		new_selection_values.reserve(key_clipboard.keys.size());
 
 		for (int i = 0; i < key_clipboard.keys.size(); i++) {
 			const KeyClipboard::Key key = key_clipboard.keys[i];

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -226,7 +226,7 @@ AudioStreamPreviewGenerator *AudioStreamPreviewGenerator::singleton = nullptr;
 void AudioStreamPreviewGenerator::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_PROCESS: {
-			List<ObjectID> to_erase;
+			LocalVector<ObjectID> to_erase;
 			for (KeyValue<ObjectID, Preview> &E : previews) {
 				if (!E.value.generating.is_set()) {
 					if (E.value.thread) {
@@ -240,9 +240,8 @@ void AudioStreamPreviewGenerator::_notification(int p_what) {
 				}
 			}
 
-			while (to_erase.front()) {
-				previews.erase(to_erase.front()->get());
-				to_erase.pop_front();
+			for (ObjectID &E : to_erase) {
+				previews.erase(E);
 			}
 		} break;
 	}

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -340,7 +340,7 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 	const Metric &m = frame_metrics[cursor_metric];
 
 	List<TreeItem *> stack;
-	List<TreeItem *> categories;
+	LocalVector<TreeItem *> categories;
 
 	TreeItem *ensure_selected = nullptr;
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1740,7 +1740,7 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 			}
 
 			// Store first else we will be removing as we loop.
-			List<int> lines;
+			LocalVector<int> lines;
 			for (TreeItem *breakpoint_item = file_item->get_first_child(); breakpoint_item; breakpoint_item = breakpoint_item->get_next()) {
 				lines.push_back(breakpoint_item->get_meta("line"));
 			}

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1741,6 +1741,7 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 
 			// Store first else we will be removing as we loop.
 			LocalVector<int> lines;
+			lines.reserve(file_item->get_child_count());
 			for (TreeItem *breakpoint_item = file_item->get_first_child(); breakpoint_item; breakpoint_item = breakpoint_item->get_next()) {
 				lines.push_back(breakpoint_item->get_meta("line"));
 			}

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -1257,7 +1257,7 @@ Error DocTools::erase_classes(const String &p_dir) {
 		return err;
 	}
 
-	List<String> to_erase;
+	LocalVector<String> to_erase;
 
 	da->list_dir_begin();
 	String path;
@@ -1270,9 +1270,8 @@ Error DocTools::erase_classes(const String &p_dir) {
 	}
 	da->list_dir_end();
 
-	while (to_erase.size()) {
-		da->remove(to_erase.front()->get());
-		to_erase.pop_front();
+	for (String &E : to_erase) {
+		da->remove(E);
 	}
 
 	return OK;

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1034,7 +1034,7 @@ void EditorFileSystem::ScanProgress::increment() {
 }
 
 int EditorFileSystem::_scan_new_dir(ScannedDirectory *p_dir, Ref<DirAccess> &da) {
-	List<String> dirs;
+	LocalVector<String> dirs;
 	List<String> files;
 
 	String cd = da->get_current_dir();
@@ -1073,15 +1073,15 @@ int EditorFileSystem::_scan_new_dir(ScannedDirectory *p_dir, Ref<DirAccess> &da)
 
 	int nb_files_total_scan = 0;
 
-	for (List<String>::Element *E = dirs.front(); E; E = E->next()) {
-		if (da->change_dir(E->get()) == OK) {
+	for (String &dir : dirs) {
+		if (da->change_dir(dir) == OK) {
 			String d = da->get_current_dir();
 
 			if (d == cd || !d.begins_with(cd)) {
 				da->change_dir(cd); //avoid recursion
 			} else {
 				ScannedDirectory *sd = memnew(ScannedDirectory);
-				sd->name = E->get();
+				sd->name = dir;
 				sd->full_path = p_dir->full_path.path_join(sd->name);
 
 				nb_files_total_scan += _scan_new_dir(sd, da);
@@ -1091,7 +1091,7 @@ int EditorFileSystem::_scan_new_dir(ScannedDirectory *p_dir, Ref<DirAccess> &da)
 				da->change_dir("..");
 			}
 		} else {
-			ERR_PRINT("Cannot go into subdir '" + E->get() + "'.");
+			ERR_PRINT("Cannot go into subdir '" + dir + "'.");
 		}
 	}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -921,7 +921,7 @@ void EditorNode::_plugin_over_self_own(EditorPlugin *p_plugin) {
 }
 
 void EditorNode::_resources_changed(const Vector<String> &p_resources) {
-	List<Ref<Resource>> changed;
+	LocalVector<Ref<Resource>> changed;
 
 	int rc = p_resources.size();
 	for (int i = 0; i < rc; i++) {
@@ -2301,7 +2301,7 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 	// Remove editor plugins no longer used by this editing owner. Keep the ones that can
 	// still be reused by the new edited object.
 
-	List<EditorPlugin *> to_remove;
+	LocalVector<EditorPlugin *> to_remove;
 	for (EditorPlugin *plugin : active_plugins[owner_id]) {
 		if (!available_plugins.has(plugin)) {
 			to_remove.push_back(plugin);
@@ -2414,7 +2414,7 @@ void EditorNode::hide_unused_editors(const Object *p_editing_owner) {
 	} else {
 		// If no editing owner is provided, this method will go over all owners and check if they are valid.
 		// This is to sweep properties that were removed from the inspector.
-		List<ObjectID> to_remove;
+		LocalVector<ObjectID> to_remove;
 		for (KeyValue<ObjectID, HashSet<EditorPlugin *>> &kv : active_plugins) {
 			Object *context = ObjectDB::get_instance(kv.key);
 			if (context) {
@@ -6234,7 +6234,7 @@ void EditorNode::reload_instances_with_path_in_edited_scenes() {
 			}
 
 			// Store all the paths for any selected nodes which are ancestors of the node we're replacing.
-			List<NodePath> selected_node_paths;
+			LocalVector<NodePath> selected_node_paths;
 			for (Node *selected_node : editor_selection->get_selected_node_list()) {
 				if (selected_node == original_node || original_node->is_ancestor_of(selected_node)) {
 					selected_node_paths.push_back(original_node->get_path_to(selected_node));

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1609,7 +1609,7 @@ void EditorSettings::list_text_editor_themes() {
 
 	Ref<DirAccess> d = DirAccess::open(EditorPaths::get_singleton()->get_text_editor_themes_dir());
 	if (d.is_valid()) {
-		List<String> custom_themes;
+		LocalVector<String> custom_themes;
 		d->list_dir_begin();
 		String file = d->get_next();
 		while (!file.is_empty()) {

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1053,7 +1053,7 @@ void EditorFileDialog::update_file_list() {
 	}
 	sort_file_info_list(file_infos, file_sort);
 
-	List<String> patterns;
+	LocalVector<String> patterns;
 	// build filter
 	if (filter->get_selected() == filter->get_item_count() - 1) {
 		// match all

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1450,7 +1450,7 @@ void SceneTreeEditor::_edited() {
 	ERR_FAIL_NULL(edited);
 
 	if (is_scene_tree_dock && tree->get_next_selected(which)) {
-		List<Node *> nodes_to_rename;
+		LocalVector<Node *> nodes_to_rename;
 		for (TreeItem *item = which; item; item = tree->get_next_selected(item)) {
 			Node *n = get_node(item->get_metadata(0));
 			ERR_FAIL_NULL(n);
@@ -1459,7 +1459,7 @@ void SceneTreeEditor::_edited() {
 		ERR_FAIL_COND(nodes_to_rename.is_empty());
 
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-		undo_redo->create_action(TTR("Rename Nodes"), UndoRedo::MERGE_DISABLE, nodes_to_rename.front()->get(), true);
+		undo_redo->create_action(TTR("Rename Nodes"), UndoRedo::MERGE_DISABLE, nodes_to_rename[0], true);
 
 		TreeItem *item = which;
 		String new_name = edited->get_text(0);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -543,7 +543,7 @@ void AnimationNodeBlendTreeEditor::_delete_nodes_request(const TypedArray<String
 		return;
 	}
 
-	List<StringName> to_erase;
+	LocalVector<StringName> to_erase;
 
 	if (p_nodes.is_empty()) {
 		for (int i = 0; i < graph->get_child_count(); i++) {

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -948,7 +948,7 @@ void EditorAssetLibrary::_update_image_queue() {
 	const int max_images = 6;
 	int current_images = 0;
 
-	List<int> to_delete;
+	LocalVector<int> to_delete;
 	for (KeyValue<int, ImageQueue> &E : image_queue) {
 		if (!E.value.active && current_images < max_images) {
 			String cache_filename_base = EditorPaths::get_singleton()->get_cache_dir().path_join("assetimage_" + E.value.image_url.md5_text());
@@ -973,10 +973,9 @@ void EditorAssetLibrary::_update_image_queue() {
 		}
 	}
 
-	while (to_delete.size()) {
-		image_queue[to_delete.front()->get()].request->queue_free();
-		image_queue.erase(to_delete.front()->get());
-		to_delete.pop_front();
+	for (const int &key : to_delete) {
+		image_queue[key].request->queue_free();
+		image_queue.erase(key);
 	}
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -890,7 +890,7 @@ void CanvasItemEditor::_restore_canvas_item_state(const List<CanvasItem *> &p_ca
 }
 
 void CanvasItemEditor::_commit_canvas_item_state(const List<CanvasItem *> &p_canvas_items, const String &action_name, bool commit_bones) {
-	List<CanvasItem *> modified_canvas_items;
+	LocalVector<CanvasItem *> modified_canvas_items;
 	for (CanvasItem *ci : p_canvas_items) {
 		Dictionary old_state = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(ci)->undo_state;
 		Dictionary new_state = ci->_edit_get_state();
@@ -3854,7 +3854,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 }
 
 void CanvasItemEditor::_draw_hover() {
-	List<Rect2> previous_rects;
+	LocalVector<Rect2> previous_rects;
 	Vector2 icon_size = Vector2(1, 1) * get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 
 	for (int i = 0; i < hovering_results.size(); i++) {
@@ -4404,7 +4404,7 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 
 			if (n2d->has_meta("_edit_bone_") && n2d->get_parent_item()) {
 				//look for an IK chain
-				List<Node2D *> ik_chain;
+				LocalVector<Node2D *> ik_chain;
 
 				Node2D *n = Object::cast_to<Node2D>(n2d->get_parent_item());
 				bool has_chain = false;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3855,6 +3855,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 
 void CanvasItemEditor::_draw_hover() {
 	LocalVector<Rect2> previous_rects;
+	previous_rects.reserve(hovering_results.size());
 	Vector2 icon_size = Vector2(1, 1) * get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 
 	for (int i = 0; i < hovering_results.size(); i++) {

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -183,7 +183,7 @@ void ResourcePreloaderEditor::_update_library() {
 	List<StringName> rnames;
 	preloader->get_resource_list(&rnames);
 
-	List<String> names;
+	LocalVector<String> names;
 	for (const StringName &E : rnames) {
 		names.push_back(E);
 	}

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -184,6 +184,7 @@ void ResourcePreloaderEditor::_update_library() {
 	preloader->get_resource_list(&rnames);
 
 	LocalVector<String> names;
+	names.reserve(rnames.size());
 	for (const StringName &E : rnames) {
 		names.push_back(E);
 	}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -342,7 +342,7 @@ public:
 	uint32_t max_cache_size = 128;
 
 	void cleanup() {
-		List<String> to_clean;
+		LocalVector<String> to_clean;
 
 		HashMap<String, Cache>::Iterator I = cached.begin();
 		while (I) {
@@ -352,9 +352,8 @@ public:
 			++I;
 		}
 
-		while (to_clean.front()) {
-			cached.erase(to_clean.front()->get());
-			to_clean.pop_front();
+		for (String &E : to_clean) {
+			cached.erase(E);
 		}
 	}
 

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -68,7 +68,7 @@ void ThemeItemImportTree::_update_items_tree() {
 
 	List<StringName> types;
 	List<StringName> names;
-	List<StringName> filtered_names;
+	LocalVector<StringName> filtered_names;
 	base_theme->get_type_list(&types);
 	types.sort_custom<StringName::AlphCompare>();
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4420,13 +4420,13 @@ void VisualShaderEditor::_delete_nodes(int p_type, const List<int> &p_nodes) {
 		}
 	}
 
-	List<VisualShader::Connection> used_conns;
+	LocalVector<VisualShader::Connection> used_conns;
 	for (const int &F : p_nodes) {
 		for (const VisualShader::Connection &E : conns) {
 			if (E.from_node == F || E.to_node == F) {
 				bool cancel = false;
-				for (List<VisualShader::Connection>::Element *R = used_conns.front(); R; R = R->next()) {
-					if (R->get().from_node == E.from_node && R->get().from_port == E.from_port && R->get().to_node == E.to_node && R->get().to_port == E.to_port) {
+				for (VisualShader::Connection &R : used_conns) {
+					if (R.from_node == E.from_node && R.from_port == E.from_port && R.to_node == E.to_node && R.to_port == E.to_port) {
 						cancel = true; // to avoid ERR_ALREADY_EXISTS warning
 						break;
 					}
@@ -4812,8 +4812,8 @@ void VisualShaderEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 		selected_frame = -1;
 		selected_float_constant = -1;
 
-		List<int> selected_deletable_graph_elements;
-		List<GraphElement *> selected_graph_elements;
+		LocalVector<int> selected_deletable_graph_elements;
+		LocalVector<GraphElement *> selected_graph_elements;
 		for (int i = 0; i < graph->get_child_count(); i++) {
 			GraphElement *graph_element = Object::cast_to<GraphElement>(graph->get_child(i));
 			if (!graph_element) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2609,6 +2609,7 @@ void SceneTreeDock::_toggle_placeholder_from_selection() {
 
 void SceneTreeDock::_reparent_nodes_to_root(Node *p_root, const Array &p_nodes, Node *p_owner) {
 	LocalVector<Node *> nodes;
+	nodes.reserve(p_nodes.size());
 	for (int i = 0; i < p_nodes.size(); i++) {
 		Node *node = Object::cast_to<Node>(p_nodes[i]);
 		ERR_FAIL_NULL(node);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -676,7 +676,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				ERR_CONTINUE(!dup);
 
 				// Preserve ownership relations ready for pasting.
-				List<Node *> owned;
+				LocalVector<Node *> owned;
 				Node *owner = node;
 				while (owner) {
 					List<Node *> cur_owned;
@@ -906,7 +906,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			for (Node *node : selection) {
 				Node *parent = node->get_parent();
 
-				List<Node *> owned;
+				LocalVector<Node *> owned;
 				Node *owner = node;
 				while (owner) {
 					List<Node *> cur_owned;
@@ -2608,7 +2608,7 @@ void SceneTreeDock::_toggle_placeholder_from_selection() {
 }
 
 void SceneTreeDock::_reparent_nodes_to_root(Node *p_root, const Array &p_nodes, Node *p_owner) {
-	List<Node *> nodes;
+	LocalVector<Node *> nodes;
 	for (int i = 0; i < p_nodes.size(); i++) {
 		Node *node = Object::cast_to<Node>(p_nodes[i]);
 		ERR_FAIL_NULL(node);
@@ -3177,7 +3177,7 @@ void SceneTreeDock::_replace_node(Node *p_node, Node *p_by_node, bool p_keep_pro
 
 	String newname = oldnode->get_name();
 
-	List<Node *> to_erase;
+	LocalVector<Node *> to_erase;
 	for (int i = 0; i < oldnode->get_child_count(); i++) {
 		if (oldnode->get_child(i)->get_owner() == nullptr && oldnode->is_owned_by_parent()) {
 			to_erase.push_back(oldnode->get_child(i));
@@ -3211,9 +3211,8 @@ void SceneTreeDock::_replace_node(Node *p_node, Node *p_by_node, bool p_keep_pro
 	if (p_remove_old) {
 		memdelete(oldnode);
 
-		while (to_erase.front()) {
-			memdelete(to_erase.front()->get());
-			to_erase.pop_front();
+		for (Node *&oldnode_child : to_erase) {
+			memdelete(oldnode_child);
 		}
 	}
 }

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1283,7 +1283,7 @@ RBSet<GDScript *> GDScript::get_dependencies() {
 HashMap<GDScript *, RBSet<GDScript *>> GDScript::get_all_dependencies() {
 	HashMap<GDScript *, RBSet<GDScript *>> all_dependencies;
 
-	List<GDScript *> scripts;
+	LocalVector<GDScript *> scripts;
 	{
 		MutexLock lock(GDScriptLanguage::singleton->mutex);
 
@@ -2585,7 +2585,7 @@ void GDScriptLanguage::reload_all_scripts() {
 void GDScriptLanguage::reload_scripts(const Array &p_scripts, bool p_soft_reload) {
 #ifdef DEBUG_ENABLED
 
-	List<Ref<GDScript>> scripts;
+	LocalVector<Ref<GDScript>> scripts;
 	{
 		MutexLock lock(mutex);
 

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -85,7 +85,7 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 		}
 	}
 
-	List<_GDFKCS> stackpositions;
+	LocalVector<_GDFKCS> stackpositions;
 	for (const KeyValue<StringName, _GDFKC> &E : sdmap) {
 		_GDFKCS spp;
 		spp.id = E.key;

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -86,6 +86,7 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 	}
 
 	LocalVector<_GDFKCS> stackpositions;
+	stackpositions.reserve(sdmap.size());
 	for (const KeyValue<StringName, _GDFKC> &E : sdmap) {
 		_GDFKCS spp;
 		spp.id = E.key;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2244,7 +2244,7 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 	bool all_have_return = true;
 	bool have_wildcard = false;
 
-	List<AnnotationNode *> match_branch_annotation_stack;
+	LocalVector<AnnotationNode *> match_branch_annotation_stack;
 
 	while (!check(GDScriptTokenizer::Token::DEDENT) && !is_at_end()) {
 		if (match(GDScriptTokenizer::Token::PASS)) {

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -59,7 +59,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 		{ //methods
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
 			for (const KeyValue<StringName, MethodBind *> &F : t->method_map) {
 				String name = F.key.operator String();
@@ -122,7 +122,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 		{ //constants
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
 			for (const KeyValue<StringName, int64_t> &F : t->constant_map) {
 				snames.push_back(F.key);
@@ -147,7 +147,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 		{ //signals
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
 			for (const KeyValue<StringName, MethodInfo> &F : t->signal_map) {
 				snames.push_back(F.key);
@@ -180,7 +180,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 		{ //properties
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
 			for (const KeyValue<StringName, ClassDB::PropertySetGet> &F : t->property_setget) {
 				snames.push_back(F.key);

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -123,6 +123,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 		{ //constants
 
 			LocalVector<StringName> snames;
+			snames.reserve(t->constant_map.size());
 
 			for (const KeyValue<StringName, int64_t> &F : t->constant_map) {
 				snames.push_back(F.key);
@@ -148,6 +149,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 		{ //signals
 
 			LocalVector<StringName> snames;
+			snames.reserve(t->signal_map.size());
 
 			for (const KeyValue<StringName, MethodInfo> &F : t->signal_map) {
 				snames.push_back(F.key);
@@ -181,6 +183,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 		{ //properties
 
 			LocalVector<StringName> snames;
+			snames.reserve(t->property_setget.size());
 
 			for (const KeyValue<StringName, ClassDB::PropertySetGet> &F : t->property_setget) {
 				snames.push_back(F.key);

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -491,7 +491,7 @@ Error SceneReplicationInterface::_make_spawn_packet(Node *p_node, MultiplayerSpa
 
 	// Prepare spawn state.
 	List<NodePath> state_props;
-	List<uint32_t> sync_ids;
+	LocalVector<uint32_t> sync_ids;
 	const HashSet<ObjectID> synchronizers = tnode->synchronizers;
 	for (const ObjectID &sid : synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(sid);

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -71,8 +71,8 @@ void WebRTCMultiplayerPeer::poll() {
 		return;
 	}
 
-	List<int> remove;
-	List<int> add;
+	LocalVector<int> remove;
+	LocalVector<int> add;
 	for (KeyValue<int, Ref<ConnectedPeer>> &E : peer_map) {
 		Ref<ConnectedPeer> peer = E.value;
 		peer->connection->poll();

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -68,7 +68,7 @@ PackedStringArray ZIPReader::get_files() {
 	err = unzGoToFirstFile(uzf);
 	ERR_FAIL_COND_V(err != UNZ_OK, PackedStringArray());
 
-	List<String> s;
+	LocalVector<String> s;
 	do {
 		unz_file_info64 file_info;
 		String filepath;
@@ -82,8 +82,8 @@ PackedStringArray ZIPReader::get_files() {
 	PackedStringArray arr;
 	arr.resize(s.size());
 	int idx = 0;
-	for (const List<String>::Element *E = s.front(); E; E = E->next()) {
-		arr.set(idx++, E->get());
+	for (const String &E : s) {
+		arr.set(idx++, E);
 	}
 	return arr;
 }

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1744,7 +1744,7 @@ bool AnimationNodeBlendTree::_get(const StringName &p_name, Variant &r_ret) cons
 }
 
 void AnimationNodeBlendTree::_get_property_list(List<PropertyInfo> *p_list) const {
-	List<StringName> names;
+	LocalVector<StringName> names;
 	for (const KeyValue<StringName, Node> &E : nodes) {
 		names.push_back(E.key);
 	}

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1745,6 +1745,7 @@ bool AnimationNodeBlendTree::_get(const StringName &p_name, Variant &r_ret) cons
 
 void AnimationNodeBlendTree::_get_property_list(List<PropertyInfo> *p_list) const {
 	LocalVector<StringName> names;
+	names.reserve(nodes.size());
 	for (const KeyValue<StringName, Node> &E : nodes) {
 		names.push_back(E.key);
 	}

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -392,7 +392,7 @@ void AnimationMixer::rename_animation_library(const StringName &p_name, const St
 }
 
 void AnimationMixer::get_animation_list(List<StringName> *p_animations) const {
-	List<String> anims;
+	LocalVector<String> anims;
 	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 		anims.push_back(E.key);
 	}

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -393,6 +393,7 @@ void AnimationMixer::rename_animation_library(const StringName &p_name, const St
 
 void AnimationMixer::get_animation_list(List<StringName> *p_animations) const {
 	LocalVector<String> anims;
+	anims.reserve(animation_set.size());
 	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 		anims.push_back(E.key);
 	}

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1429,6 +1429,7 @@ void AnimationNodeStateMachine::_rename_transitions(const StringName &p_name, co
 
 void AnimationNodeStateMachine::get_node_list(List<StringName> *r_nodes) const {
 	LocalVector<StringName> nodes;
+	nodes.reserve(states.size());
 	for (const KeyValue<StringName, State> &E : states) {
 		nodes.push_back(E.key);
 	}
@@ -1697,6 +1698,7 @@ bool AnimationNodeStateMachine::_get(const StringName &p_name, Variant &r_ret) c
 
 void AnimationNodeStateMachine::_get_property_list(List<PropertyInfo> *p_list) const {
 	LocalVector<StringName> names;
+	names.reserve(states.size());
 	for (const KeyValue<StringName, State> &E : states) {
 		names.push_back(E.key);
 	}

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -1211,10 +1211,10 @@ AnimationNodeStateMachinePlayback::AnimationNodeStateMachinePlayback() {
 void AnimationNodeStateMachine::get_parameter_list(List<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::OBJECT, playback, PROPERTY_HINT_RESOURCE_TYPE, "AnimationNodeStateMachinePlayback", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ALWAYS_DUPLICATE)); // Don't store this object in .tres, it always needs to be made as unique object.
-	List<StringName> advance_conditions;
+	LocalVector<StringName> advance_conditions;
 	for (int i = 0; i < transitions.size(); i++) {
 		StringName ac = transitions[i].transition->get_advance_condition_name();
-		if (ac != StringName() && advance_conditions.find(ac) == nullptr) {
+		if (ac != StringName() && advance_conditions.find(ac) == -1) {
 			advance_conditions.push_back(ac);
 		}
 	}
@@ -1428,7 +1428,7 @@ void AnimationNodeStateMachine::_rename_transitions(const StringName &p_name, co
 }
 
 void AnimationNodeStateMachine::get_node_list(List<StringName> *r_nodes) const {
-	List<StringName> nodes;
+	LocalVector<StringName> nodes;
 	for (const KeyValue<StringName, State> &E : states) {
 		nodes.push_back(E.key);
 	}
@@ -1696,7 +1696,7 @@ bool AnimationNodeStateMachine::_get(const StringName &p_name, Variant &r_ret) c
 }
 
 void AnimationNodeStateMachine::_get_property_list(List<PropertyInfo> *p_list) const {
-	List<StringName> names;
+	LocalVector<StringName> names;
 	for (const KeyValue<StringName, State> &E : states) {
 		names.push_back(E.key);
 	}

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -130,7 +130,7 @@ void AnimationPlayer::_validate_property(PropertyInfo &p_property) const {
 }
 
 void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
-	List<PropertyInfo> anim_names;
+	LocalVector<PropertyInfo> anim_names;
 
 	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 		AHashMap<StringName, StringName>::ConstIterator F = animation_next_set.find(E.key);
@@ -282,7 +282,7 @@ void AnimationPlayer::_blend_playback_data(double p_delta, bool p_started) {
 		playback.blend.clear();
 		return;
 	}
-	List<List<Blend>::Element *> to_erase;
+	LocalVector<List<Blend>::Element *> to_erase;
 	for (List<Blend>::Element *E = c.blend.front(); E; E = E->next()) {
 		Blend &b = E->get();
 		b.blend_left = MAX(0, b.blend_left - Math::absf(speed_scale * p_delta) / b.blend_time);
@@ -896,7 +896,7 @@ void AnimationPlayer::_animation_removed(const StringName &p_name, const StringN
 	_animation_set_cache_update();
 
 	// Erase blends if needed
-	List<BlendKey> to_erase;
+	LocalVector<BlendKey> to_erase;
 	for (const KeyValue<BlendKey, double> &E : blend_times) {
 		BlendKey bk = E.key;
 		if (bk.from == name || bk.to == name) {
@@ -904,9 +904,8 @@ void AnimationPlayer::_animation_removed(const StringName &p_name, const StringN
 		}
 	}
 
-	while (to_erase.size()) {
-		blend_times.erase(to_erase.front()->get());
-		to_erase.pop_front();
+	for (const BlendKey &bk : to_erase) {
+		blend_times.erase(bk);
 	}
 }
 
@@ -914,7 +913,7 @@ void AnimationPlayer::_rename_animation(const StringName &p_from_name, const Str
 	AnimationMixer::_rename_animation(p_from_name, p_to_name);
 
 	// Rename autoplay or blends if needed.
-	List<BlendKey> to_erase;
+	LocalVector<BlendKey> to_erase;
 	HashMap<BlendKey, double, BlendKey> to_insert;
 	for (const KeyValue<BlendKey, double> &E : blend_times) {
 		BlendKey bk = E.key;
@@ -935,9 +934,8 @@ void AnimationPlayer::_rename_animation(const StringName &p_from_name, const Str
 		}
 	}
 
-	while (to_erase.size()) {
-		blend_times.erase(to_erase.front()->get());
-		to_erase.pop_front();
+	for (const BlendKey &bk : to_erase) {
+		blend_times.erase(bk);
 	}
 
 	while (to_insert.size()) {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3724,6 +3724,7 @@ void CodeEdit::_text_changed() {
 	_update_line_number_gutter_width();
 
 	LocalVector<int> breakpoints;
+	breakpoints.reserve(breakpointed_lines.size());
 	for (const KeyValue<int, bool> &E : breakpointed_lines) {
 		breakpoints.push_back(E.key);
 	}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3723,7 +3723,7 @@ void CodeEdit::_text_changed() {
 	line_number_digits = new_line_number_digits;
 	_update_line_number_gutter_width();
 
-	List<int> breakpoints;
+	LocalVector<int> breakpoints;
 	for (const KeyValue<int, bool> &E : breakpointed_lines) {
 		breakpoints.push_back(E.key);
 	}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -226,7 +226,7 @@ void Control::get_argument_options(const StringName &p_function, int p_idx, List
 			List<ThemeDB::ThemeItemBind> theme_items;
 			ThemeDB::get_singleton()->get_class_items(get_class_name(), &theme_items, true, type);
 
-			List<StringName> sn;
+			LocalVector<StringName> sn;
 			for (const ThemeDB::ThemeItemBind &E : theme_items) {
 				if (E.data_type == type) {
 					sn.push_back(E.item_name);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -806,7 +806,7 @@ void FileDialog::update_file_list() {
 
 	String filename_filter_lower = file_name_filter.to_lower();
 
-	List<String> patterns;
+	LocalVector<String> patterns;
 	// build filter
 	if (filter->get_selected() == filter->get_item_count() - 1) {
 		// match all

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2780,7 +2780,7 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 		node->data.editable_instance = data.editable_instance;
 	}
 
-	List<const Node *> hidden_roots;
+	LocalVector<const Node *> hidden_roots;
 	List<const Node *> node_tree;
 	node_tree.push_front(this);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3942,8 +3942,8 @@ void Viewport::_camera_2d_set(Camera2D *p_camera_2d) {
 }
 
 void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paused_only, uint64_t p_frame_reference) {
-	List<ObjectID> to_erase;
-	List<ObjectID> to_mouse_exit;
+	LocalVector<ObjectID> to_erase;
+	LocalVector<ObjectID> to_mouse_exit;
 
 	for (const KeyValue<ObjectID, uint64_t> &E : physics_2d_mouseover) {
 		if (!p_clean_all_frames && E.value == p_frame_reference) {
@@ -3963,14 +3963,13 @@ void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paus
 		to_erase.push_back(E.key);
 	}
 
-	while (to_erase.size()) {
-		physics_2d_mouseover.erase(to_erase.front()->get());
-		to_erase.pop_front();
+	for (ObjectID &E : to_erase) {
+		physics_2d_mouseover.erase(E);
 	}
 
 	// Per-shape.
-	List<Pair<ObjectID, int>> shapes_to_erase;
-	List<Pair<ObjectID, int>> shapes_to_mouse_exit;
+	LocalVector<Pair<ObjectID, int>> shapes_to_erase;
+	LocalVector<Pair<ObjectID, int>> shapes_to_mouse_exit;
 
 	for (KeyValue<Pair<ObjectID, int>, uint64_t> &E : physics_2d_shape_mouseover) {
 		if (!p_clean_all_frames && E.value == p_frame_reference) {
@@ -3990,24 +3989,20 @@ void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paus
 		shapes_to_erase.push_back(E.key);
 	}
 
-	while (shapes_to_erase.size()) {
-		physics_2d_shape_mouseover.erase(shapes_to_erase.front()->get());
-		shapes_to_erase.pop_front();
+	for (Pair<ObjectID, int> &E : shapes_to_erase) {
+		physics_2d_shape_mouseover.erase(E);
 	}
 
-	while (to_mouse_exit.size()) {
-		Object *o = ObjectDB::get_instance(to_mouse_exit.front()->get());
+	for (ObjectID &E : to_mouse_exit) {
+		Object *o = ObjectDB::get_instance(E);
 		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(o);
 		co->_mouse_exit();
-		to_mouse_exit.pop_front();
 	}
 
-	while (shapes_to_mouse_exit.size()) {
-		Pair<ObjectID, int> e = shapes_to_mouse_exit.front()->get();
-		Object *o = ObjectDB::get_instance(e.first);
+	for (Pair<ObjectID, int> &E : shapes_to_mouse_exit) {
+		Object *o = ObjectDB::get_instance(E.first);
 		CollisionObject2D *co = Object::cast_to<CollisionObject2D>(o);
-		co->_mouse_shape_exit(e.second);
-		shapes_to_mouse_exit.pop_front();
+		co->_mouse_shape_exit(E.second);
 	}
 }
 

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -112,7 +112,7 @@ void AnimationLibrary::_animation_changed(const StringName &p_name) {
 }
 
 void AnimationLibrary::get_animation_list(List<StringName> *p_animations) const {
-	List<StringName> anims;
+	LocalVector<StringName> anims;
 
 	for (const KeyValue<StringName, Ref<Animation>> &E : animations) {
 		anims.push_back(E.key);

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -113,6 +113,7 @@ void AnimationLibrary::_animation_changed(const StringName &p_name) {
 
 void AnimationLibrary::get_animation_list(List<StringName> *p_animations) const {
 	LocalVector<StringName> anims;
+	anims.reserve(animations.size());
 
 	for (const KeyValue<StringName, Ref<Animation>> &E : animations) {
 		anims.push_back(E.key);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -126,7 +126,7 @@ Ref<Resource> SceneState::get_remap_resource(const Ref<Resource> &p_resource, Ha
 
 Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	// Nodes where instantiation failed (because something is missing.)
-	List<Node *> stray_instances;
+	LocalVector<Node *> stray_instances;
 
 #define NODE_FROM_ID(p_name, p_id)                      \
 	Node *p_name;                                       \
@@ -612,9 +612,8 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 	//Node *s = ret_nodes[0];
 
 	//remove nodes that could not be added, likely as a result that
-	while (stray_instances.size()) {
-		memdelete(stray_instances.front()->get());
-		stray_instances.pop_front();
+	for (Node *&node : stray_instances) {
+		memdelete(node);
 	}
 
 	for (int i = 0; i < editable_instances.size(); i++) {

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1604,9 +1604,6 @@ String VisualShader::validate_port_name(const String &p_port_name, VisualShaderN
 		return String();
 	}
 
-	List<String> input_names;
-	List<String> output_names;
-
 	for (int i = 0; i < p_node->get_input_port_count(); i++) {
 		if (!p_output && i == p_port_id) {
 			continue;
@@ -2594,7 +2591,7 @@ void VisualShader::_update_shader() const {
 
 	String global_expressions;
 	HashSet<String> used_parameter_names;
-	List<VisualShaderNodeParameter *> parameters;
+	LocalVector<VisualShaderNodeParameter *> parameters;
 	HashMap<int, List<int>> emitters;
 	HashMap<int, List<int>> varying_setters;
 
@@ -2639,7 +2636,7 @@ void VisualShader::_update_shader() const {
 	}
 
 	int idx = 0;
-	for (List<VisualShaderNodeParameter *>::Iterator itr = parameters.begin(); itr != parameters.end(); ++itr, ++idx) {
+	for (LocalVector<VisualShaderNodeParameter *>::Iterator itr = parameters.begin(); itr != parameters.end(); ++itr, ++idx) {
 		VisualShaderNodeParameter *parameter = *itr;
 		if (used_parameter_names.has(parameter->get_parameter_name())) {
 			global_code += parameter->generate_global(get_mode(), Type(idx), -1);

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -1037,7 +1037,7 @@ void MaterialStorage::MaterialData::update_textures(const HashMap<StringName, Va
 	}
 	{
 		//for textures no longer used, unregister them
-		List<StringName> to_delete;
+		LocalVector<StringName> to_delete;
 		for (KeyValue<StringName, uint64_t> &E : used_global_textures) {
 			if (E.value != global_textures_pass) {
 				to_delete.push_back(E.key);
@@ -1049,10 +1049,10 @@ void MaterialStorage::MaterialData::update_textures(const HashMap<StringName, Va
 			}
 		}
 
-		while (to_delete.front()) {
-			used_global_textures.erase(to_delete.front()->get());
-			to_delete.pop_front();
+		for (StringName &name : to_delete) {
+			used_global_textures.erase(name);
 		}
+
 		//handle registering/unregistering global textures
 		if (uses_global_textures != (global_texture_E != nullptr)) {
 			if (uses_global_textures) {

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -660,7 +660,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 
 			uint32_t index = p_default_actions.base_varying_index;
 
-			List<Pair<StringName, SL::ShaderNode::Varying>> var_frag_to_light;
+			LocalVector<Pair<StringName, SL::ShaderNode::Varying>> var_frag_to_light;
 
 			Vector<StringName> varying_names;
 

--- a/thirdparty/enet/godot.cpp
+++ b/thirdparty/enet/godot.cpp
@@ -335,7 +335,7 @@ public:
 			}
 		}
 
-		List<String> remove;
+		LocalVector<String> remove;
 		Error err = ERR_BUSY;
 		// TODO this needs to be fair!
 


### PR DESCRIPTION
A byproduct when I go through `List`. These list are used as simple buffer to store value temporarily, which means:
- They are local variables.
- They get value by `push_back`.
- Values are consumed by iterating the `List`.

So I change them to `LocalVector`, as they do not depend on container implementation.

There are other kinds of usages which can be replaced, but need some prepare first:
- Same as above, but iterate from tail to head. Need a reverse iterator for `LocalVector`.
- Used as stack. Need a `pop_back()` method for `LocalVector`.
- Used as queue. Shall we implement a dedicated `Queue`?