### PR TITLE
CI: Format SCons input flags & build action

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -5,30 +5,26 @@ inputs:
   target:
     description: Build target (editor, template_release, template_debug).
     default: editor
-  tests:
-    description: Unit tests.
-    default: false
-    required: false
+    type: choice
+    options: [editor, template_debug, template_release]
   platform:
     description: Target platform.
-    required: false
-  sconsflags:
+    type: string
+  scons-flags:
     description: Additional SCons flags.
-    default: ""
-    required: false
+    type: string
   scons-cache:
     description: The SCons cache path.
     default: ${{ github.workspace }}/.scons_cache/
+    type: string
 
 runs:
   using: composite
   steps:
     - name: SCons Build
       shell: sh
-      env:
-        SCONSFLAGS: ${{ inputs.sconsflags }}
       run: |
-        echo "Building with flags:" platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }} "cache_path=${{ inputs.scons-cache }}" redirect_build_objects=no
+        echo "Building with flags:" platform=${{ inputs.platform }} target=${{ inputs.target }} ${{ inputs.scons-flags }} "cache_path=${{ inputs.scons-cache }}" redirect_build_objects=no
 
         if [ "${{ inputs.target }}" != "editor" ]; then
           # Ensure we don't include editor code in export template builds.
@@ -42,5 +38,5 @@ runs:
           export BUILD_NAME="gh"
         fi
 
-        scons platform=${{ inputs.platform }} target=${{ inputs.target }} tests=${{ inputs.tests }} ${{ env.SCONSFLAGS }} "cache_path=${{ inputs.scons-cache }}" redirect_build_objects=no
+        scons platform=${{ inputs.platform }} target=${{ inputs.target }} ${{ inputs.scons-flags }} "cache_path=${{ inputs.scons-cache }}" redirect_build_objects=no
         ls -l bin/

--- a/.github/actions/godot-cpp-build/action.yml
+++ b/.github/actions/godot-cpp-build/action.yml
@@ -35,6 +35,4 @@ runs:
 
     - name: SCons Build
       shell: sh
-      env:
-        SCONS_CACHE: ${{ inputs.scons-cache }}
       run: scons --directory=./godot-cpp/test "gdextension_dir=${{ github.workspace }}" ${{ inputs.scons-flags }}

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -4,7 +4,11 @@ on:
 
 # Global Settings
 env:
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
+  SCONS_FLAGS: >-
+    dev_mode=yes
+    module_text_server_fb_enabled=yes
+    tests=no
+    swappy=yes
 
 jobs:
   build-android:
@@ -18,20 +22,19 @@ jobs:
           - name: Editor (target=editor)
             cache-name: android-editor
             target: editor
-            tests: false
-            sconsflags: arch=arm64 production=yes swappy=yes
+            scons-flags: >-
+              arch=arm64
+              production=yes
 
           - name: Template arm32 (target=template_release, arch=arm32)
             cache-name: android-template-arm32
             target: template_release
-            tests: false
-            sconsflags: arch=arm32 swappy=yes
+            scons-flags: arch=arm32
 
           - name: Template arm64 (target=template_release, arch=arm64)
             cache-name: android-template-arm64
             target: template_release
-            tests: false
-            sconsflags: arch=arm64 swappy=yes
+            scons-flags: arch=arm64
 
     steps:
       - name: Checkout
@@ -68,10 +71,9 @@ jobs:
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }}
           platform: android
           target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -4,7 +4,11 @@ on:
 
 # Global Settings
 env:
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
+  SCONS_FLAGS: >-
+    dev_mode=yes
+    module_text_server_fb_enabled=yes
+    tests=no
+    debug_symbols=no
 
 jobs:
   ios-template:
@@ -28,10 +32,9 @@ jobs:
       - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }}
+          scons-flags: ${{ env.SCONS_FLAGS }}
           platform: ios
           target: template_release
-          tests: false
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,8 +4,11 @@ on:
 
 # Global Settings
 env:
+  SCONS_FLAGS: >-
+    dev_mode=yes
+    module_text_server_fb_enabled=yes
+    "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.15.1/"
   GODOT_CPP_BRANCH: 4.4
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes strict_checks=yes "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.15.1/"
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   TSAN_OPTIONS: suppressions=${{ github.workspace }}/misc/error_suppressions/tsan.txt
@@ -24,10 +27,9 @@ jobs:
           - name: Editor w/ Mono (target=editor)
             cache-name: linux-editor-mono
             target: editor
-            sconsflags: module_mono_enabled=yes
+            scons-flags: module_mono_enabled=yes
             bin: ./bin/godot.linuxbsd.editor.x86_64.mono
             build-mono: true
-            tests: false # Disabled due freeze caused by mix Mono build and CI
             doc-test: true
             proj-conv: true
             api-compat: true
@@ -35,64 +37,72 @@ jobs:
             # Validate godot-cpp compatibility on one arbitrary editor build.
             godot-cpp: true
 
-          - name: Editor with doubles and GCC sanitizers (target=editor, tests=yes, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=mold)
+          - name: Editor with doubles and GCC sanitizers (target=editor, dev_build=yes, scu_build=yes, precision=double, use_asan=yes, use_ubsan=yes, linker=mold)
             cache-name: linux-editor-double-sanitizers
             target: editor
             # Debug symbols disabled as they're huge on this build and we hit the 14 GB limit for runners.
-            sconsflags: dev_build=yes scu_build=yes debug_symbols=no precision=double use_asan=yes use_ubsan=yes linker=mold
+            scons-flags: >-
+              dev_build=yes
+              scu_build=yes
+              debug_symbols=no
+              precision=double
+              use_asan=yes
+              use_ubsan=yes
+              linker=mold
             bin: ./bin/godot.linuxbsd.editor.dev.double.x86_64.san
-            build-mono: false
-            tests: true
             proj-test: true
-            # Skip 2GiB artifact speeding up action.
-            artifact: false
 
-          - name: Editor with clang sanitizers (target=editor, tests=yes, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
+          - name: Editor with clang sanitizers (target=editor, dev_build=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-llvm-sanitizers
             target: editor
-            sconsflags: dev_build=yes use_asan=yes use_ubsan=yes use_llvm=yes linker=lld
+            scons-flags: >-
+              dev_build=yes
+              use_asan=yes
+              use_ubsan=yes
+              use_llvm=yes
+              linker=lld
             bin: ./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san
-            build-mono: false
-            tests: true
-            # Skip 2GiB artifact speeding up action.
-            artifact: false
             # Test our oldest supported SCons/Python versions on one arbitrary editor build.
             legacy-scons: true
 
-          - name: Editor with ThreadSanitizer (target=editor, tests=yes, dev_build=yes, use_tsan=yes, use_llvm=yes, linker=lld)
+          - name: Editor with ThreadSanitizer (target=editor, dev_build=yes, use_tsan=yes, use_llvm=yes, linker=lld)
             cache-name: linux-editor-thread-sanitizer
             target: editor
-            tests: true
-            sconsflags: dev_build=yes use_tsan=yes use_llvm=yes linker=lld
+            scons-flags: >-
+              dev_build=yes
+              use_tsan=yes
+              use_llvm=yes
+              linker=lld
             bin: ./bin/godot.linuxbsd.editor.dev.x86_64.llvm.san
-            build-mono: false
-            # Skip 2GiB artifact speeding up action.
-            artifact: false
 
-          - name: Template w/ Mono, release (target=template_release, tests=yes)
+          - name: Template w/ Mono, release (target=template_release)
             cache-name: linux-template-mono
             target: template_release
-            sconsflags: module_mono_enabled=yes
+            scons-flags: module_mono_enabled=yes
             bin: ./bin/godot.linuxbsd.template_release.x86_64.mono
-            build-mono: false
-            tests: true
             artifact: true
 
-          - name: Template w/ Mono, debug (target=template_debug, tests=yes)
+          - name: Template w/ Mono, debug (target=template_debug)
             cache-name: linux-template-mono-debug
             target: template_debug
-            sconsflags: module_mono_enabled=yes
+            scons-flags: module_mono_enabled=yes
             bin: ./bin/godot.linuxbsd.template_debug.x86_64.mono
-            build-mono: false
-            tests: true
             artifact: true
 
-          - name: Minimal template (target=template_release, tests=yes, everything disabled)
+          - name: Minimal template (target=template_release, everything disabled)
             cache-name: linux-template-minimal
             target: template_release
-            sconsflags: modules_enabled_by_default=no disable_3d=yes disable_advanced_gui=yes disable_physics_2d=yes disable_physics_3d=yes deprecated=no minizip=no
+            scons-flags: >-
+              modules_enabled_by_default=no
+              module_text_server_fb_enabled=no
+              disable_3d=yes
+              disable_advanced_gui=yes
+              disable_physics_2d=yes
+              disable_physics_3d=yes
+              deprecated=no
+              minizip=no
+              brotli=no
             bin: ./bin/godot.linuxbsd.template_release.x86_64
-            tests: true
             artifact: true
 
     steps:
@@ -166,10 +176,9 @@ jobs:
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }}
           platform: linuxbsd
           target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
 
       - name: Compilation (godot-cpp)
         uses: ./.github/actions/godot-cpp-build
@@ -209,7 +218,6 @@ jobs:
           name: ${{ matrix.cache-name }}
 
       - name: Unit tests
-        if: matrix.tests
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -4,7 +4,10 @@ on:
 
 # Global Settings
 env:
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes strict_checks=yes "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.15.1/"
+  SCONS_FLAGS: >-
+    dev_mode=yes
+    module_text_server_fb_enabled=yes
+    "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.15.1/"
 
 jobs:
   build-macos:
@@ -15,17 +18,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=editor, tests=yes)
+          - name: Editor (target=editor)
             cache-name: macos-editor
             target: editor
-            tests: true
             bin: ./bin/godot.macos.editor.universal
 
-          - name: Template (target=template_release, tests=yes)
+          - name: Template (target=template_release)
             cache-name: macos-template
             target: template_release
-            tests: true
-            sconsflags: debug_symbols=no
+            scons-flags: debug_symbols=no
             bin: ./bin/godot.macos.template_release.universal
 
     steps:
@@ -68,18 +69,16 @@ jobs:
       - name: Compilation (x86_64)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }} arch=x86_64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=x86_64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
           platform: macos
           target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
 
       - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }} arch=arm64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=arm64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }}
           platform: macos
           target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save
@@ -100,7 +99,6 @@ jobs:
           name: ${{ matrix.cache-name }}
 
       - name: Unit tests
-        if: matrix.tests
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -4,7 +4,11 @@ on:
 
 # Global Settings
 env:
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no use_closure_compiler=yes strict_checks=yes
+  SCONS_FLAGS: >-
+    dev_mode=yes
+    tests=no
+    debug_symbols=no
+    use_closure_compiler=yes
   EM_VERSION: 3.1.64
 
 jobs:
@@ -19,15 +23,13 @@ jobs:
           - name: Template w/ threads (target=template_release, threads=yes)
             cache-name: web-template
             target: template_release
-            sconsflags: threads=yes
-            tests: false
+            scons-flags: threads=yes
             artifact: true
 
           - name: Template w/o threads (target=template_release, threads=no)
             cache-name: web-nothreads-template
             target: template_release
-            sconsflags: threads=no
-            tests: false
+            scons-flags: threads=no
             artifact: true
 
     steps:
@@ -58,10 +60,9 @@ jobs:
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }}
           platform: web
           target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -3,9 +3,14 @@ on:
   workflow_call:
 
 # Global Settings
-# SCONS_CACHE for windows must be set in the build environment
 env:
-  SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes d3d12=yes strict_checks=yes "angle_libs=${{ github.workspace }}/" "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.15.1/"
+  SCONS_FLAGS: >-
+    dev_mode=yes
+    module_text_server_fb_enabled=yes
+    debug_symbols=no
+    d3d12=yes
+    "angle_libs=${{ github.workspace }}/"
+    "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.15.1/"
   SCONS_CACHE_MSVC_CONFIG: true
   PYTHONIOENCODING: utf8
 
@@ -19,37 +24,36 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=editor, tests=yes)
+          - name: Editor (target=editor)
             cache-name: windows-editor
             target: editor
-            tests: true
-            # Skip debug symbols, they're way too big with MSVC.
-            sconsflags: debug_symbols=no vsproj=yes vsproj_gen_only=no windows_subsystem=console
+            scons-flags: >-
+              windows_subsystem=console
+              vsproj=yes
+              vsproj_gen_only=no
             bin: ./bin/godot.windows.editor.x86_64.exe
             compiler: msvc
 
-          - name: Editor w/ clang-cl (target=editor, tests=yes, use_llvm=yes)
+          - name: Editor w/ clang-cl (target=editor, use_llvm=yes)
             cache-name: windows-editor-clang
             target: editor
-            tests: true
-            sconsflags: debug_symbols=no windows_subsystem=console use_llvm=yes
+            scons-flags: >-
+              windows_subsystem=console
+              use_llvm=yes
             bin: ./bin/godot.windows.editor.x86_64.llvm.exe
             compiler: clang
 
-          - name: Template (target=template_release, tests=yes)
+          - name: Template (target=template_release)
             cache-name: windows-template
             target: template_release
-            tests: true
-            sconsflags: debug_symbols=no
             bin: ./bin/godot.windows.template_release.x86_64.console.exe
             compiler: msvc
 
-          - name: Template w/ GCC (target=template_release, tests=yes, use_mingw=yes)
+          - name: Template w/ GCC (target=template_release, use_mingw=yes)
             cache-name: windows-template-gcc
             # MinGW takes MUCH longer to compile; save time by only targeting Template.
             target: template_release
-            tests: true
-            sconsflags: debug_symbols=no use_mingw=yes
+            scons-flags: use_mingw=yes
             bin: ./bin/godot.windows.template_release.x86_64.console.exe
             compiler: gcc
 
@@ -96,10 +100,9 @@ jobs:
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} ${{ matrix.sconsflags }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }}
           platform: windows
           target: ${{ matrix.target }}
-          tests: ${{ matrix.tests }}
 
       - name: Save Godot build cache
         uses: ./.github/actions/godot-cache-save
@@ -119,7 +122,6 @@ jobs:
           name: ${{ matrix.cache-name }}
 
       - name: Unit tests
-        if: matrix.tests
         run: |
           ${{ matrix.bin }} --version
           ${{ matrix.bin }} --help


### PR DESCRIPTION
Gives the GHA workflows a bit of a facelift:
- `godot-build` actions now expect specific types; no change in practice, but ensures valid defaults
- `godot-build` no longer has a `tests` section, as its no longer relevant as a standalone variable
- `SCONSFLAGS` renamed to `SCONS_FLAGS` to prevent SCons from parsing it directly
- `sconsflags` renamed to `scons-flags` for uniformity
- `SCONS_FLAGS` and `scons-flags` variables with multiple arguments are now multiline strings; will make tracking future changes on version control much easier
- `dev_mode=yes` added as first argument for all `SCONSFLAGS` environment variables, removing the need to specify the original elements individually & rendering the `tests` matrix variable moot. If a workflow explicitly doesn't want tests, they now pass `tests=no` after to override the alias
- Superfluous matrix arguments were removed where applicable; mostly applies to booleans whose negation is implicit when absent
- Added `brotli=no` to minimal template