### PR TITLE
Fix Occlusion culling jitter

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -536,8 +536,6 @@ Projection RaycastOcclusionCull::_jitter_projection(const Projection &p_cam_proj
 		return p_cam_projection;
 	}
 
-	Projection p = p_cam_projection;
-
 	int32_t frame = Engine::get_singleton()->get_frames_drawn();
 	frame %= 9;
 
@@ -577,11 +575,11 @@ Projection RaycastOcclusionCull::_jitter_projection(const Projection &p_cam_proj
 	// Higher divergence gives fewer false hidden, but more false shown.
 	// False hidden is obvious to viewer, false shown is not.
 	// False shown can lower percentage that are occluded, and therefore performance.
-	jitter *= Vector2(1 / (float)p_viewport_size.x, 1 / (float)p_viewport_size.y) * 0.05f;
+	jitter *= Vector2(1 / (float)p_viewport_size.x, 1 / (float)p_viewport_size.y) * 0.9f;
 
-	p.add_jitter_offset(jitter);
-
-	return p;
+	Projection correction;
+	correction.add_jitter_offset(jitter);
+	return correction * p_cam_projection;
 }
 
 void RaycastOcclusionCull::buffer_update(RID p_buffer, const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal) {


### PR DESCRIPTION
Jitter is applied the wrong way to the projection matrix, with 2 noticeable impacts :
- the jitter magnitude depends on znear (more jitter when smaller)
- no noticeable jitter with orthographic projection

This PR applies the jitter correction in clip space (left side matrix product) instead of adding the offset to the matrix' 4th column (which is not even a linear transformation, but vaguely resembles a translation in view space with scaling screwed up). This new implementation is aligned with the way jitter is applied for TAA in [scene rendering](https://github.com/godotengine/godot/blob/6960b33cbbbd372a7bce482f35c9136acee710a0/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp#L83-L86) and [sky](https://github.com/godotengine/godot/blob/6960b33cbbbd372a7bce482f35c9136acee710a0/servers/rendering/renderer_rd/environment/sky.cpp#L1177-L1187).

The new jitter magnitude is tuned to roughly match the former behavior with the default znear (0.05).


Test project : [occlusion_jitter.zip](https://github.com/user-attachments/files/17983531/occlusion_jitter.zip)

Captures below are from the Editor, in Display debug mode Occlusion Culling Buffer :

|   | Before | After |
|---|---|---|
| znear 0.5 | ![before_05](https://github.com/user-attachments/assets/b33ee40b-22d2-42c1-b8ee-473b923c2e89) | ![after](https://github.com/user-attachments/assets/16bc66a6-280f-47ab-b8a8-194bb5256af3)
| znear 0.05 (default) | ![before](https://github.com/user-attachments/assets/21a1c69b-d8dd-4b60-a63b-3a56cba51c75) | ![after](https://github.com/user-attachments/assets/b5ee252d-38ba-4d0e-904b-fb8b7ee9ea80) |
| znear 0.01 | ![before_001](https://github.com/user-attachments/assets/cc6c7e46-3026-42a4-acf5-b54988bb7748) | ![after](https://github.com/user-attachments/assets/a00a38dd-442f-46c4-8c5a-993a4778acce) |
| ortho | ![before_ortho](https://github.com/user-attachments/assets/486e51a1-3d60-4813-9ba3-669abbeaae85) | ![after_ortho](https://github.com/user-attachments/assets/1fe5a942-a492-489d-95f8-d707f5a13f3a) |


