### PR TITLE
Fix selecting and editing invisible items in SubViewports

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -260,6 +260,11 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 		return false;
 	}
 
+	Viewport *vp = _get_node()->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
+		return false;
+	}
+
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	Ref<InputEventMouseButton> mb = p_event;
 
@@ -498,6 +503,11 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 	}
 
 	if (!_get_node()->is_visible_in_tree()) {
+		return;
+	}
+
+	Viewport *vp = _get_node()->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
 		return;
 	}
 

--- a/editor/plugins/cast_2d_editor_plugin.cpp
+++ b/editor/plugins/cast_2d_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "scene/2d/physics/ray_cast_2d.h"
 #include "scene/2d/physics/shape_cast_2d.h"
+#include "scene/main/viewport.h"
 
 void Cast2DEditor::_notification(int p_what) {
 	switch (p_what) {
@@ -56,6 +57,11 @@ void Cast2DEditor::_node_removed(Node *p_node) {
 
 bool Cast2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 	if (!node || !node->is_visible_in_tree()) {
+		return false;
+	}
+
+	Viewport *vp = node->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
 		return false;
 	}
 
@@ -111,6 +117,11 @@ bool Cast2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 
 void Cast2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 	if (!node || !node->is_visible_in_tree()) {
+		return;
+	}
+
+	Viewport *vp = node->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
 		return;
 	}
 

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -300,6 +300,11 @@ bool CollisionShape2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 		return false;
 	}
 
+	Viewport *vp = node->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
+		return false;
+	}
+
 	if (shape_type == -1) {
 		return false;
 	}
@@ -430,6 +435,11 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 	}
 
 	if (!node->is_visible_in_tree()) {
+		return;
+	}
+
+	Viewport *vp = node->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
 		return;
 	}
 

--- a/editor/plugins/navigation_link_2d_editor_plugin.cpp
+++ b/editor/plugins/navigation_link_2d_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "scene/main/viewport.h"
 #include "servers/navigation_server_3d.h"
 
 void NavigationLink2DEditor::_notification(int p_what) {
@@ -56,6 +57,11 @@ void NavigationLink2DEditor::_node_removed(Node *p_node) {
 
 bool NavigationLink2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 	if (!node || !node->is_visible_in_tree()) {
+		return false;
+	}
+
+	Viewport *vp = node->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
 		return false;
 	}
 
@@ -139,6 +145,11 @@ bool NavigationLink2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 
 void NavigationLink2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 	if (!node || !node->is_visible_in_tree()) {
+		return;
+	}
+
+	Viewport *vp = node->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
 		return;
 	}
 

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -71,6 +71,11 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 		return false;
 	}
 
+	Viewport *vp = node->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
+		return false;
+	}
+
 	if (node->get_curve().is_null()) {
 		return false;
 	}
@@ -390,6 +395,11 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 
 void Path2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 	if (!node || !node->is_visible_in_tree() || node->get_curve().is_null()) {
+		return;
+	}
+
+	Viewport *vp = node->get_viewport();
+	if (vp && !vp->is_visible_subviewport()) {
 		return;
 	}
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3893,6 +3893,16 @@ bool Viewport::get_canvas_cull_mask_bit(uint32_t p_layer) const {
 	return (canvas_cull_mask & (1 << p_layer));
 }
 
+#ifdef TOOLS_ENABLED
+bool Viewport::is_visible_subviewport() const {
+	if (!is_sub_viewport()) {
+		return true;
+	}
+	SubViewportContainer *container = Object::cast_to<SubViewportContainer>(get_parent());
+	return container && container->is_visible_in_tree();
+}
+#endif // TOOLS_ENABLED
+
 void Viewport::_update_audio_listener_2d() {
 	if (AudioServer::get_singleton()) {
 		AudioServer::get_singleton()->notify_listener_changed();

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -672,6 +672,10 @@ public:
 	void set_canvas_cull_mask_bit(uint32_t p_layer, bool p_enable);
 	bool get_canvas_cull_mask_bit(uint32_t p_layer) const;
 
+#ifdef TOOLS_ENABLED
+	bool is_visible_subviewport() const;
+#endif // TOOLS_ENABLED
+
 	virtual bool is_size_2d_override_stretch_enabled() const { return true; }
 
 	Transform2D get_screen_transform() const;


### PR DESCRIPTION
- See https://github.com/godotengine/godot/pull/99401#pullrequestreview-2468904067

In the 2D editor:

Fixes selecting and editing nodes in SubViewports without a parent SubViewportContainer.

Fixes selecting and editing nodes in SubViewports with a parent SubViewportContainer that is not visible.

Fixes locks and groups position in Viewports. (Note currently cannot be toggled when in Viewport, but can be toggled and then moved into one. See https://github.com/godotengine/godot/issues/30910)
