### PR TITLE
Fix crash due to collision reposition functionality

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3097,6 +3097,11 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 				if (selection.size() == 1) {
 					Node3D *first_selected_node = Object::cast_to<Node3D>(selection.front()->get());
+					if (!first_selected_node) {
+						_edit.mode = TRANSFORM_NONE;
+						collision_reposition = false;
+						return;
+					}
 					double snap = EDITOR_GET("interface/inspector/default_float_step");
 					int snap_step_decimals = Math::range_step_decimals(snap);
 					set_message(TTR("Translating:") + " (" + String::num(first_selected_node->get_global_position().x, snap_step_decimals) + ", " +


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Regression from: https://github.com/godotengine/godot/pull/96740

Crash if trying to reposition a node not derived from Node3D. 

Added check to fix. 