### PR TITLE
Fix Window clamping to embedder on resize

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1190,6 +1190,14 @@ bool Viewport::_set_size(const Size2i &p_size, const int p_view_count, const Siz
 	Rect2i limit = get_visible_rect();
 	for (int i = 0; i < gui.sub_windows.size(); ++i) {
 		Window *sw = gui.sub_windows[i].window;
+#ifdef TOOLS_ENABLED
+		if (!is_part_of_edited_scene() && sw->is_part_of_edited_scene()) {
+			continue;
+		}
+#endif
+		if (!sw->is_clamped_to_embedder()) {
+			continue;
+		}
 		Rect2i rect = Rect2i(sw->position, sw->size);
 		Rect2i new_rect = sw->fit_rect_in_parent(rect, limit);
 		if (new_rect != rect) {

--- a/tests/scene/test_viewport.cpp
+++ b/tests/scene/test_viewport.cpp
@@ -1972,6 +1972,29 @@ TEST_CASE("[SceneTree][Viewport] Embedded Windows") {
 		CHECK_EQ(root->subwindow_get_popup_safe_rect(w), Rect2i());
 	}
 
+	SUBCASE("[Viewport] Clamp to embedder on resize") {
+		root->set_size(Size2i(200, 200));
+		root->set_embedding_subwindows(true);
+		root->add_child(w);
+		w->set_size(Size2i(100, 100));
+		w->set_position(Point2i(150, 0));
+		const int title_height = root->get_theme_constant("title_height");
+
+		// Do not clamp to embedder on resize.
+		w->set_clamp_to_embedder(false);
+		CHECK_FALSE(w->is_clamped_to_embedder());
+		root->set_size(Size2i(200, 201));
+		CHECK(w->get_size() == Size2i(100, 100));
+		CHECK(w->get_position() == Point2i(150, 0));
+
+		// Clamp to embedder on resize.
+		w->set_clamp_to_embedder(true);
+		CHECK(w->is_clamped_to_embedder());
+		root->set_size(Size2i(200, 202));
+		CHECK(w->get_size() == Size2i(100, 100));
+		CHECK(w->get_position() == Point2i(100, title_height));
+	}
+
 	memdelete(w);
 }
 


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/89644
- Fixes https://github.com/godotengine/godot/issues/119180
- Related https://github.com/godotengine/godot/pull/75141

Fixes non-clamped windows clamping when embedder changes size.
`set_clamp_to_embedder` isn't exposed, but AcceptDialog uses it. We should probably expose it in the future.
Added a simple test for it.
