### PR TITLE
Ignore `__MACOSX` directory for export template and project ZIPs

### DIFF
--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -437,6 +437,13 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 		}
 
 		String file = String::utf8(fname);
+
+		// Skip the __MACOSX directory created by macOS's built-in file zipper.
+		if (file.begins_with("__MACOSX")) {
+			ret = unzGoToNextFile(pkg);
+			continue;
+		}
+
 		if (file.ends_with("version.txt")) {
 			Vector<uint8_t> uncomp_data;
 			uncomp_data.resize(info.uncompressed_size);
@@ -512,7 +519,8 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 
 		String file = file_path.get_file();
 
-		if (file.size() == 0) {
+		// Skip the __MACOSX directory created by macOS's built-in file zipper.
+		if (file.is_empty() || file.begins_with("__MACOSX")) {
 			ret = unzGoToNextFile(pkg);
 			continue;
 		}

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -132,6 +132,13 @@ void ProjectDialog::_validate_path() {
 				ERR_FAIL_COND_MSG(ret != UNZ_OK, "Failed to get current file info.");
 
 				String name = String::utf8(fname);
+
+				// Skip the __MACOSX directory created by macOS's built-in file zipper.
+				if (name.begins_with("__MACOSX")) {
+					ret = unzGoToNextFile(pkg);
+					continue;
+				}
+
 				if (name.get_file() == "project.godot") {
 					break; // ret == UNZ_OK.
 				}
@@ -604,6 +611,13 @@ void ProjectDialog::ok_pressed() {
 				ERR_FAIL_COND_MSG(ret != UNZ_OK, "Failed to get current file info.");
 
 				String name = String::utf8(fname);
+
+				// Skip the __MACOSX directory created by macOS's built-in file zipper.
+				if (name.begins_with("__MACOSX")) {
+					ret = unzGoToNextFile(pkg);
+					continue;
+				}
+
 				if (name.get_file() == "project.godot") {
 					zip_root = name.get_base_dir();
 					break;
@@ -636,7 +650,15 @@ void ProjectDialog::ok_pressed() {
 				ret = unzGetCurrentFileInfo(pkg, &info, fname, 16384, nullptr, 0, nullptr, 0);
 				ERR_FAIL_COND_MSG(ret != UNZ_OK, "Failed to get current file info.");
 
-				String rel_path = String::utf8(fname).trim_prefix(zip_root);
+				String name = String::utf8(fname);
+
+				// Skip the __MACOSX directory created by macOS's built-in file zipper.
+				if (name.begins_with("__MACOSX")) {
+					ret = unzGoToNextFile(pkg);
+					continue;
+				}
+
+				String rel_path = name.trim_prefix(zip_root);
 				if (rel_path.is_empty()) { // Root.
 				} else if (rel_path.ends_with("/")) { // Directory.
 					Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);


### PR DESCRIPTION
macOS's Archive Utility (built-in ZIP file creator) apparently adds a secret `__MACOSX` directory to the files it zips. When Godot is unzipping archives it expects to have a specific structure, the presence of the `__MACOSX` directory and its subfiles can confuse it. For example, a macOS-zipped export templates file could not be imported because Godot was finding a dummy version of `version.txt` within `__MACOSX`.

This PR causes the export template importer and the project importer to skip any files in a zipped archive whose paths begin with `__MACOSX`. I've tested this with both a macOS-zipped export template file and a macOS-zipped project.
