### PR TITLE
Free debug mesh when `NavigationRegion2D`'s `navigation_polygon` is set to null.

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -208,6 +208,13 @@ void NavigationRegion2D::set_navigation_polygon(const Ref<NavigationPolygon> &p_
 	if (navigation_polygon.is_valid()) {
 		navigation_polygon->connect_changed(callable_mp(this, &NavigationRegion2D::_navigation_polygon_changed));
 	}
+
+#ifdef DEBUG_ENABLED
+	if (navigation_polygon.is_null()) {
+		_free_debug();
+	}
+#endif // DEBUG_ENABLED
+
 	_navigation_polygon_changed();
 
 	update_configuration_warnings();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Make `NavigationRegion2D`(free debug elements) similar to `NavigationRegion3D`(make debug elements invisible).