### PR TITLE
Add `back()` and `pop_back()` to `LocalVector`

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -57,6 +57,16 @@ public:
 		return data;
 	}
 
+	T &back() {
+		CRASH_BAD_UNSIGNED_INDEX(0, count);
+		return data[count - 1];
+	}
+
+	const T &back() const {
+		CRASH_BAD_UNSIGNED_INDEX(0, count);
+		return data[count - 1];
+	}
+
 	// Must take a copy instead of a reference (see GH-31736).
 	_FORCE_INLINE_ void push_back(T p_elem) {
 		if (unlikely(count == capacity)) {
@@ -69,6 +79,14 @@ public:
 			memnew_placement(&data[count++], T(p_elem));
 		} else {
 			data[count++] = std::move(p_elem);
+		}
+	}
+
+	void pop_back() {
+		ERR_FAIL_COND(count == 0);
+		count--;
+		if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
+			data[count].~T();
 		}
 	}
 


### PR DESCRIPTION
~~Follow up #99936.~~

~~Having some difficulties so I upload this as draft for discussion.~~

~~Which type should `LocalVector::back()` return?~~
- ~~Return `T&`.~~
    ~~Simplify caller's code, but not that compitable with the semantic of reference, since one can get a `nullptr` if container is empty. What should be returned if empty? (We do have bound check so this is unlikely to happen)~~
- ~~Return `T *`.~~
    ~~Shift the responsibility of checking `nullptr` to caller, resulting in a lot of explicit dereference. Also not sure if deref a pointer has the same effect as deref a reference for complex types.~~
- ~~Return `Option<T>`.~~
    ~~Too rusty I think :)~~

~~What's your opinion?~~

Split the `LocalVector` change and `List` change to keep PR small and easy to review.

This one add `back()` and `pop_back()` method for `LocalVector` so it's capable as a stack. It will be used to replace `List` based stack in following PR.