### PR TITLE
Editor: Fix default preview environment sky's horizon and brightness.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8534,8 +8534,10 @@ void Node3DEditor::_preview_settings_changed() {
 	}
 
 	{ //preview env
-		sky_material->set_sky_energy_multiplier(environ_energy->get_value());
-		Color hz_color = environ_sky_color->get_pick_color().lerp(environ_ground_color->get_pick_color(), 0.5).lerp(Color(1, 1, 1), 0.5);
+		sky_material->set_energy_multiplier(environ_energy->get_value());
+		Color hz_color = environ_sky_color->get_pick_color().lerp(environ_ground_color->get_pick_color(), 0.5);
+		float hz_lum = hz_color.get_luminance() * 3.333;
+		hz_color = hz_color.lerp(Color(hz_lum, hz_lum, hz_lum), 0.5);
 		sky_material->set_sky_top_color(environ_sky_color->get_pick_color());
 		sky_material->set_sky_horizon_color(hz_color);
 		sky_material->set_ground_bottom_color(environ_ground_color->get_pick_color());


### PR DESCRIPTION
Closes #99701 

This addresses two issues with the default preview environment's sky. First is the horizon always appearing grey, even when both the sky and ground colors are set to black. Second is the fact that the "Sky Energy" slider only affects the top hemisphere of the sky, while the lower hemisphere's brightness cannot be modified.

The first issue occurs because the horizon color is generated automatically from the sky and ground colors, rather than being exposed to the user. This is desirably convenient of course, except that the horizon color is generated as first a 50/50 blend between the sky and ground colors, and then a 50/50 blend between the result and pure white. This second blend is why the horizon remains grey even when the user would reasonably expect it to be pitch black.
To fix this, the second blend has been replaced by a 50/50 blend with the first blend result's luminance multiplied by 3.333 (an arbitrary value, chosen to maintain roughly the same horizon brightness that the original method produced with the default sky and ground colors).

The second issue is similarly perplexing from a user's perspective; the "**Sky Energy**" slider modifies the preview sky's `sky_energy_multiplier` rather than its `energy_multiplier`, meaning that only the upper half of the sky is affected, while the user has no way of modifying the `ground_energy_multiplier` for the lower half. For the sake of keeping the preview environment's interface simple and quick to use, I've opted to make the slider alter the sky's `energy_multiplier` property, rather than add a second slider for the ground, as I believe the more convenient use of such a slider is to quickly modify the sky's overall brightness, as well as its associated ambient light. I also frankly wouldn't be surprised if the use of `sky_energy_multiplier` instead of `energy_multiplier` was a mistake from the start, given that its name doesn't necessarily indicate it's specifically for the *top* of the sky.

With sky and ground colors set to pure black:
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0d65cf45-7974-4978-a3ee-841ff67146b4) | ![image](https://github.com/user-attachments/assets/ca17e6b3-c3e3-4394-bff5-35edf918bbb5) |

With "**Sky Energy**" slider set to `0.25`:
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f6de0a36-1547-496a-b347-44034cf055c7) | ![image](https://github.com/user-attachments/assets/3d92e40a-efc6-4411-953c-d96fa03e0853) |

With default sky and ground colors:
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5fe6d316-b76d-42d9-aa98-1e8f418eb3f7) | ![image](https://github.com/user-attachments/assets/9610fc76-7bf4-4a24-ab9e-5f6abcb7ba35) | 