### PR TITLE
[Web] Implement dummy IP and NetSocket

### DIFF
--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#if defined(UNIX_ENABLED)
+#if defined(UNIX_ENABLED) && !defined(UNIX_SOCKET_UNAVAILABLE)
 
 #include "ip_unix.h"
 

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -169,8 +169,8 @@ void OS_Unix::initialize_core() {
 
 #ifndef UNIX_SOCKET_UNAVAILABLE
 	NetSocketUnix::make_default();
-#endif
 	IPUnix::make_default();
+#endif
 	process_map = memnew((HashMap<ProcessID, ProcessInfo>));
 
 	_setup_clock();

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -26,6 +26,7 @@ web_files = [
     "http_client_web.cpp",
     "javascript_bridge_singleton.cpp",
     "web_main.cpp",
+    "ip_web.cpp",
     "os_web.cpp",
 ]
 

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -27,6 +27,7 @@ web_files = [
     "javascript_bridge_singleton.cpp",
     "web_main.cpp",
     "ip_web.cpp",
+    "net_socket_web.cpp",
     "os_web.cpp",
 ]
 

--- a/platform/web/ip_web.cpp
+++ b/platform/web/ip_web.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  ip_unix.h                                                             */
+/*  ip_web.cpp                                                            */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,27 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef IP_UNIX_H
-#define IP_UNIX_H
+#include "ip_web.h"
 
-#if defined(UNIX_ENABLED) && !defined(UNIX_SOCKET_UNAVAILABLE)
+void IPWeb::_resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type) const {
+}
 
-#include "core/io/ip.h"
+void IPWeb::get_local_interfaces(HashMap<String, Interface_Info> *r_interfaces) const {
+}
 
-class IPUnix : public IP {
-	GDCLASS(IPUnix, IP);
+void IPWeb::make_default() {
+	_create = _create_web;
+}
 
-	virtual void _resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const override;
+IP *IPWeb::_create_web() {
+	return memnew(IPWeb);
+}
 
-	static IP *_create_unix();
-
-public:
-	virtual void get_local_interfaces(HashMap<String, Interface_Info> *r_interfaces) const override;
-
-	static void make_default();
-	IPUnix();
-};
-
-#endif // UNIX_ENABLED
-
-#endif // IP_UNIX_H
+IPWeb::IPWeb() {
+}

--- a/platform/web/ip_web.h
+++ b/platform/web/ip_web.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  ip_unix.h                                                             */
+/*  ip_web.h                                                              */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,27 +28,24 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef IP_UNIX_H
-#define IP_UNIX_H
-
-#if defined(UNIX_ENABLED) && !defined(UNIX_SOCKET_UNAVAILABLE)
+#ifndef IP_WEB_H
+#define IP_WEB_H
 
 #include "core/io/ip.h"
 
-class IPUnix : public IP {
-	GDCLASS(IPUnix, IP);
+class IPWeb : public IP {
+	GDCLASS(IPWeb, IP);
 
 	virtual void _resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const override;
 
-	static IP *_create_unix();
+private:
+	static IP *_create_web();
 
 public:
 	virtual void get_local_interfaces(HashMap<String, Interface_Info> *r_interfaces) const override;
 
 	static void make_default();
-	IPUnix();
+	IPWeb();
 };
 
-#endif // UNIX_ENABLED
-
-#endif // IP_UNIX_H
+#endif // IP_WEB_H

--- a/platform/web/net_socket_web.cpp
+++ b/platform/web/net_socket_web.cpp
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  net_socket_web.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "net_socket_web.h"
+
+NetSocket *NetSocketWeb::_create_func() {
+	return memnew(NetSocketWeb);
+}
+
+void NetSocketWeb::make_default() {
+	_create = _create_func;
+}

--- a/platform/web/net_socket_web.h
+++ b/platform/web/net_socket_web.h
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  net_socket_web.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef NET_SOCKET_WEB_H
+#define NET_SOCKET_WEB_H
+
+#include "core/io/net_socket.h"
+
+#include <sys/socket.h>
+
+class NetSocketWeb : public NetSocket {
+protected:
+	static NetSocket *_create_func();
+
+public:
+	static void make_default();
+
+	virtual Error open(Type p_sock_type, IP::Type &ip_type) override { return ERR_UNAVAILABLE; }
+	virtual void close() override {}
+	virtual Error bind(IPAddress p_addr, uint16_t p_port) override { return ERR_UNAVAILABLE; }
+	virtual Error listen(int p_max_pending) override { return ERR_UNAVAILABLE; }
+	virtual Error connect_to_host(IPAddress p_host, uint16_t p_port) override { return ERR_UNAVAILABLE; }
+	virtual Error poll(PollType p_type, int timeout) const override { return ERR_UNAVAILABLE; }
+	virtual Error recv(uint8_t *p_buffer, int p_len, int &r_read) override { return ERR_UNAVAILABLE; }
+	virtual Error recvfrom(uint8_t *p_buffer, int p_len, int &r_read, IPAddress &r_ip, uint16_t &r_port, bool p_peek = false) override { return ERR_UNAVAILABLE; }
+	virtual Error send(const uint8_t *p_buffer, int p_len, int &r_sent) override { return ERR_UNAVAILABLE; }
+	virtual Error sendto(const uint8_t *p_buffer, int p_len, int &r_sent, IPAddress p_ip, uint16_t p_port) override { return ERR_UNAVAILABLE; }
+	virtual Ref<NetSocket> accept(IPAddress &r_ip, uint16_t &r_port) override { return Ref<NetSocket>(); }
+
+	virtual bool is_open() const override { return false; }
+	virtual int get_available_bytes() const override { return -1; }
+	virtual Error get_socket_address(IPAddress *r_ip, uint16_t *r_port) const override { return ERR_UNAVAILABLE; }
+
+	virtual Error set_broadcasting_enabled(bool p_enabled) override { return ERR_UNAVAILABLE; }
+	virtual void set_blocking_enabled(bool p_enabled) override {}
+	virtual void set_ipv6_only_enabled(bool p_enabled) override {}
+	virtual void set_tcp_no_delay_enabled(bool p_enabled) override {}
+	virtual void set_reuse_address_enabled(bool p_enabled) override {}
+	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override { return ERR_UNAVAILABLE; }
+	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override { return ERR_UNAVAILABLE; }
+
+	NetSocketWeb() {}
+};
+
+#endif // NET_SOCKET_WEB_H

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -34,6 +34,7 @@
 #include "display_server_web.h"
 #include "godot_js.h"
 #include "ip_web.h"
+#include "net_socket_web.h"
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
@@ -55,6 +56,7 @@ void OS_Web::alert(const String &p_alert, const String &p_title) {
 void OS_Web::initialize() {
 	OS_Unix::initialize_core();
 	IPWeb::make_default();
+	NetSocketWeb::make_default();
 	DisplayServerWeb::register_web_driver();
 }
 

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -33,6 +33,7 @@
 #include "api/javascript_bridge_singleton.h"
 #include "display_server_web.h"
 #include "godot_js.h"
+#include "ip_web.h"
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
@@ -53,6 +54,7 @@ void OS_Web::alert(const String &p_alert, const String &p_title) {
 // Lifecycle
 void OS_Web::initialize() {
 	OS_Unix::initialize_core();
+	IPWeb::make_default();
 	DisplayServerWeb::register_web_driver();
 }
 


### PR DESCRIPTION
In this PR:
- Replace IPUnix with dummy IPWeb.

Note: This commit ties the IPUnix to the UNIX_SOCKET_UNAVAILABLE define, disabling it when set. It is maybe not semantically correct (getifaddrs) is not part of the "socket" API, but it's reasonable to expect that a platform not supporting Unix-style sockets, would also not support other Unix network functions.

- Implement dummy NetSocketWeb to prevent error spams when using UDP/TCP classes.

This makes the class available to avoid spam from classes using it, even if without any actual implementation (since raw sockets are not available on the web).