### PR TITLE
Make Inspector search inside sub-resources

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -496,6 +496,7 @@ class EditorInspector : public ScrollContainer {
 	GDCLASS(EditorInspector, ScrollContainer);
 
 	friend class EditorInspectorCategory;
+	friend class EditorPropertyResource;
 
 	enum {
 		MAX_PLUGINS = 1024
@@ -585,6 +586,7 @@ class EditorInspector : public ScrollContainer {
 	void _property_checked(const String &p_path, bool p_checked);
 	void _property_pinned(const String &p_path, bool p_pinned);
 	bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style);
+	bool _resource_properties_matches(const Ref<Resource> &p_resource, const String &p_filter);
 
 	void _resource_selected(const String &p_path, Ref<Resource> p_resource);
 	void _property_selected(const String &p_path, int p_focusable);
@@ -604,7 +606,6 @@ class EditorInspector : public ScrollContainer {
 
 	void _keying_changed();
 
-	void _filter_changed(const String &p_text);
 	void _parse_added_editors(VBoxContainer *current_vbox, EditorInspectorSection *p_section, Ref<EditorInspectorPlugin> ped);
 
 	void _vscroll_changed(double);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3292,6 +3292,9 @@ void EditorPropertyResource::update_property() {
 
 				sub_inspector->set_draw_focus_border(false);
 
+				sub_inspector->set_use_filter(use_filter);
+				sub_inspector->register_text_enter(parent_inspector->search_box);
+
 				sub_inspector->set_mouse_filter(MOUSE_FILTER_STOP);
 				add_child(sub_inspector);
 				set_bottom_editor(sub_inspector);
@@ -3318,16 +3321,14 @@ void EditorPropertyResource::update_property() {
 				_update_property_bg();
 			}
 
-		} else {
-			if (sub_inspector) {
-				set_bottom_editor(nullptr);
-				memdelete(sub_inspector);
-				sub_inspector = nullptr;
+		} else if (sub_inspector) {
+			set_bottom_editor(nullptr);
+			memdelete(sub_inspector);
+			sub_inspector = nullptr;
 
-				if (opened_editor) {
-					EditorNode::get_singleton()->hide_unused_editors();
-					opened_editor = false;
-				}
+			if (opened_editor) {
+				EditorNode::get_singleton()->hide_unused_editors();
+				opened_editor = false;
 			}
 		}
 	}
@@ -3355,6 +3356,13 @@ void EditorPropertyResource::expand_revertable() {
 
 void EditorPropertyResource::set_use_sub_inspector(bool p_enable) {
 	use_sub_inspector = p_enable;
+}
+
+void EditorPropertyResource::set_use_filter(bool p_use) {
+	use_filter = p_use;
+	if (sub_inspector) {
+		update_property();
+	}
 }
 
 void EditorPropertyResource::fold_resource() {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -673,6 +673,7 @@ class EditorPropertyResource : public EditorProperty {
 	bool use_sub_inspector = false;
 	EditorInspector *sub_inspector = nullptr;
 	bool opened_editor = false;
+	bool use_filter = false;
 
 	void _resource_selected(const Ref<Resource> &p_resource, bool p_inspect);
 	void _resource_changed(const Ref<Resource> &p_resource);
@@ -701,6 +702,7 @@ public:
 	void expand_revertable() override;
 
 	void set_use_sub_inspector(bool p_enable);
+	void set_use_filter(bool p_use);
 	void fold_resource();
 
 	virtual bool is_colored(ColorationMode p_mode) override;


### PR DESCRIPTION
This allows the inspector to search the properties of sub-resources (and the sub-resources of those as well), and keep them visible if they match the filter.

[Screencast_20241203_124025.webm](https://github.com/user-attachments/assets/7f263b19-7855-4b80-9fd0-4ce08131a1f9)

Closes https://github.com/godotengine/godot-proposals/issues/5502.

**Sponsored By:** 🐺 Lone Wolf Technology / 🍀 W4 Games.