### PR TITLE
Adjust VoxelGI gizmo opacity

### DIFF
--- a/editor/plugins/gizmos/voxel_gi_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/voxel_gi_gizmo_plugin.cpp
@@ -46,10 +46,10 @@ VoxelGIGizmoPlugin::VoxelGIGizmoPlugin() {
 	create_material("voxel_gi_material", gizmo_color);
 
 	// This gizmo draws a lot of lines. Use a low opacity to make it not too intrusive.
-	gizmo_color.a = 0.1;
+	gizmo_color.a = 0.03;
 	create_material("voxel_gi_internal_material", gizmo_color);
 
-	gizmo_color.a = 0.05;
+	gizmo_color.a = 0.025;
 	create_material("voxel_gi_solid_material", gizmo_color);
 
 	create_icon_material("voxel_gi_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoVoxelGI"), EditorStringName(EditorIcons)));


### PR DESCRIPTION
Adjust opacity of VoxelGI for improved visibility inside the bounds. In line with ReflectionProbes UI improvements #99920.

| This PR | 4.3 |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/4ea6bc41-1459-49fd-ac49-63a05acd6111) | ![image](https://github.com/user-attachments/assets/2aae733e-98cb-4957-b0df-d3940f63cffd) |