### PR TITLE
PhysicalBone3D: expose sleeping state

### DIFF
--- a/doc/classes/PhysicalBone3D.xml
+++ b/doc/classes/PhysicalBone3D.xml
@@ -108,7 +108,18 @@
 		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="1.0">
 			The body's mass.
 		</member>
+		<member name="sleeping" type="bool" setter="set_sleeping" getter="is_sleeping" default="false">
+			If [code]true[/code], the body will not move and will not calculate forces until woken up by another body through, for example, a collision, or by using the [method apply_impulse] or [method apply_force] methods.
+		</member>
 	</members>
+	<signals>
+		<signal name="sleeping_state_changed">
+			<description>
+				Emitted when the physics engine changes the body's sleeping state.
+				[b]Note:[/b] Changing the value [member sleeping] will not trigger this signal. It is only emitted if the sleeping state is changed by the physics engine or [code]emit_signal("sleeping_state_changed")[/code] is used.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="DAMP_MODE_COMBINE" value="0" enum="DampMode">
 			In this mode, the body's damping value is added to any value set in areas or the default value.

--- a/doc/classes/PhysicalBone3D.xml
+++ b/doc/classes/PhysicalBone3D.xml
@@ -109,7 +109,7 @@
 			The body's mass.
 		</member>
 		<member name="sleeping" type="bool" setter="set_sleeping" getter="is_sleeping" default="false">
-			If [code]true[/code], the body will not move and will not calculate forces until woken up by another body through, for example, a collision, or by using the [method apply_impulse] or [method apply_force] methods.
+			If [code]true[/code], the body will not move and will not calculate forces until woken up by another body through, for example, a collision.
 		</member>
 	</members>
 	<signals>

--- a/scene/3d/physics/physical_bone_3d.h
+++ b/scene/3d/physics/physical_bone_3d.h
@@ -195,6 +195,8 @@ private:
 	real_t linear_damp = 0.0;
 	real_t angular_damp = 0.0;
 
+	bool sleeping = false;
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
@@ -284,6 +286,9 @@ public:
 
 	void set_angular_damp(real_t p_angular_damp);
 	real_t get_angular_damp() const;
+
+	void set_sleeping(bool p_sleeping);
+	bool is_sleeping() const;
 
 	void set_can_sleep(bool p_active);
 	bool is_able_to_sleep() const;


### PR DESCRIPTION
It seems like PhysicalBone3D nodes support sleeping, but it wasn't possible to access this state unless going through the PhysicsServer3D directly, and even then it would miss the convenient "sleeping_state_changed" signal.

This commit exposes the sleeping state and adds the "sleeping_state_changed" by copying what's done for RigidBody3D.

Example project using the new APIs: [ragdoll-sleep.zip](https://github.com/user-attachments/files/17996674/ragdoll-sleep.zip) (hit spacebar to reset the bones)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
