### PR TITLE
Trim long variable names in animation editor

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2152,7 +2152,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				if (text.contains("/")) {
 					float text_width = font->get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
 					if (text_width > (limit - ofs - h_separation)) {
-						Vector<String> parts = text.split("/");
+						Vector<String> parts = text.rsplit("/", true, 1);
 						if (parts.size() > 0) {
 							text = ".../" + parts[parts.size() - 1];
 						}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2149,6 +2149,15 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				Vector2 string_pos = Point2(ofs, (get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size));
 				string_pos = string_pos.floor();
+				if (text.contains("/")) {
+					float text_width = font->get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
+					if (text_width > (limit - ofs - h_separation)) {
+						Vector<String> parts = text.split("/");
+						if (parts.size() > 0) {
+							text = ".../" + parts[parts.size() - 1];
+						}
+					}
+				}
 				draw_string(font, string_pos, text, HORIZONTAL_ALIGNMENT_LEFT, limit - ofs - h_separation, font_size, text_color);
 
 				draw_line(Point2(limit, 0), Point2(limit, get_size().height), h_line_color, Math::round(EDSCALE));

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2149,13 +2149,11 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 				Vector2 string_pos = Point2(ofs, (get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size));
 				string_pos = string_pos.floor();
-				if (text.contains("/")) {
+				int pos = text.rfind_char('/');
+				if (pos != -1) {
 					float text_width = font->get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
 					if (text_width > (limit - ofs - h_separation)) {
-						Vector<String> parts = text.rsplit("/", true, 1);
-						if (parts.size() > 0) {
-							text = ".../" + parts[parts.size() - 1];
-						}
+						text = ".../" + text.substr(pos + 1);
 					}
 				}
 				draw_string(font, string_pos, text, HORIZONTAL_ALIGNMENT_LEFT, limit - ofs - h_separation, font_size, text_color);


### PR DESCRIPTION
Changes logic of how track names are displayed when dragging the name limit handle (the vertical line you can drag left/right to adjust how much space is given to track names vs the timeline)
Closes: https://github.com/godotengine/godot/issues/99022

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
