### PR TITLE
`CompositorEffect` should use `GDVIRTUAL_CALL()` so it works with GDExtension

### DIFF
--- a/scene/resources/compositor.cpp
+++ b/scene/resources/compositor.cpp
@@ -85,6 +85,10 @@ void CompositorEffect::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
+void CompositorEffect::_call_render_callback(int p_effect_callback_type, const RenderData *p_render_data) {
+	GDVIRTUAL_CALL(_render_callback, p_effect_callback_type, p_render_data);
+}
+
 void CompositorEffect::set_enabled(bool p_enabled) {
 	enabled = p_enabled;
 	if (rid.is_valid()) {
@@ -105,7 +109,7 @@ void CompositorEffect::set_effect_callback_type(EffectCallbackType p_callback_ty
 	if (rid.is_valid()) {
 		RenderingServer *rs = RenderingServer::get_singleton();
 		ERR_FAIL_NULL(rs);
-		rs->compositor_effect_set_callback(rid, RenderingServer::CompositorEffectCallbackType(effect_callback_type), Callable(this, "_render_callback"));
+		rs->compositor_effect_set_callback(rid, RenderingServer::CompositorEffectCallbackType(effect_callback_type), callable_mp(this, &CompositorEffect::_call_render_callback));
 	}
 }
 

--- a/scene/resources/compositor.h
+++ b/scene/resources/compositor.h
@@ -65,6 +65,8 @@ protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;
 
+	void _call_render_callback(int p_effect_callback_type, const RenderData *p_render_data);
+
 	GDVIRTUAL2(_render_callback, int, const RenderData *)
 
 public:


### PR DESCRIPTION
Virtual methods defined with `GDVIRTUAL*()` should always use `GDVIRTUAL_CALL()` to call them, so that they work via both GDExtension and GDScript.

Presently, `CompositorEffect` is using a trick with `Callable()` that only works with GDScript, and this PR switches to using `GDVIRTUAL_CALL()`.

~~This is marked as DRAFT because I haven't actually tested it yet. I've never used compositor effects, so I need to get a test project going, but then I'll mark it as ready for review.~~

Fixes https://github.com/godotengine/godot/issues/99933