### PR TITLE
Enable rendering with unbounded far distance

### DIFF
--- a/core/math/frustum.cpp
+++ b/core/math/frustum.cpp
@@ -1,0 +1,260 @@
+/**************************************************************************/
+/*  frustum.cpp                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "frustum.h"
+
+#include "core/math/projection.h"
+#include "core/math/rect2.h"
+#include "core/math/transform_3d.h"
+#include "core/math/vector2.h"
+
+void Frustum::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov) {
+	if (p_flip_fov) {
+		p_fovy_degrees = Projection::get_fovy(p_fovy_degrees, 1.0 / p_aspect);
+	}
+
+	// Inspired by https://iquilezles.org/articles/frustum/
+	real_t an = Math::deg_to_rad(p_fovy_degrees / 2);
+	real_t si = Math::sin(an);
+	real_t co = Math::cos(an);
+	real_t mag = Math::sqrt(co * co + si * si * p_aspect * p_aspect);
+
+	planes[Projection::PLANE_NEAR] = Plane(Vector3(0, 0, 1), -p_z_near);
+	planes[Projection::PLANE_FAR] = Plane(Vector3(0, 0, -1), p_z_far);
+	planes[Projection::PLANE_LEFT] = Plane(Vector3(-co, 0, si * p_aspect) / mag, 0);
+	planes[Projection::PLANE_TOP] = Plane(Vector3(0, co, si), 0);
+	planes[Projection::PLANE_RIGHT] = Plane(Vector3(co, 0, si * p_aspect) / mag, 0);
+	planes[Projection::PLANE_BOTTOM] = Plane(Vector3(0, -co, si), 0);
+}
+
+void Frustum::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov, int p_eye, real_t p_intraocular_dist, real_t p_convergence_dist) {
+	if (p_flip_fov) {
+		p_fovy_degrees = Projection::get_fovy(p_fovy_degrees, 1.0 / p_aspect);
+	}
+
+	real_t left, right, model_translation, y_max, x_max, frustum_shift;
+
+	y_max = p_z_near * Math::tan(Math::deg_to_rad(p_fovy_degrees / 2.0));
+	x_max = y_max * p_aspect;
+	frustum_shift = (p_intraocular_dist / 2.0) * p_z_near / p_convergence_dist;
+
+	switch (p_eye) {
+		case 1: { // Left eye.
+			left = -x_max + frustum_shift;
+			right = x_max + frustum_shift;
+			model_translation = p_intraocular_dist / 2.0;
+		} break;
+		case 2: { // Right eye.
+			left = -x_max - frustum_shift;
+			right = x_max - frustum_shift;
+			model_translation = -p_intraocular_dist / 2.0;
+		} break;
+		default: { // Mono, should give the same result as set_perspective(p_fovy_degrees,p_aspect,p_z_near,p_z_far,p_flip_fov).
+			left = -x_max;
+			right = x_max;
+			model_translation = 0.0;
+		} break;
+	}
+
+	set_frustum(left, right, -y_max, y_max, p_z_near, p_z_far);
+
+	// Translate frustum by (model_translation, 0.0, 0.0).
+	planes[Projection::PLANE_LEFT].d = -model_translation * Math::cos(Math::atan2(left, p_z_near));
+	planes[Projection::PLANE_RIGHT].d = model_translation * Math::cos(Math::atan2(right, p_z_near));
+}
+
+void Frustum::set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample, real_t p_z_near, real_t p_z_far) {
+	// We first calculate our base frustum on our values without taking our lens magnification into account.
+	real_t f1 = (p_intraocular_dist * 0.5) / p_display_to_lens;
+	real_t f2 = ((p_display_width - p_intraocular_dist) * 0.5) / p_display_to_lens;
+	real_t f3 = (p_display_width / 4.0) / p_display_to_lens;
+
+	// Now we apply our oversample factor to increase our FOV. how much we oversample is always a balance we strike between performance and how much
+	// we're willing to sacrifice in FOV.
+	real_t add = ((f1 + f2) * (p_oversample - 1.0)) / 2.0;
+	f1 += add;
+	f2 += add;
+	f3 *= p_oversample;
+
+	// Always apply KEEP_WIDTH aspect ratio.
+	f3 /= p_aspect;
+
+	switch (p_eye) {
+		case 1: { // Left eye.
+			set_frustum(-f2 * p_z_near, f1 * p_z_near, -f3 * p_z_near, f3 * p_z_near, p_z_near, p_z_far);
+		} break;
+		case 2: { // Right eye.
+			set_frustum(-f1 * p_z_near, f2 * p_z_near, -f3 * p_z_near, f3 * p_z_near, p_z_near, p_z_far);
+		} break;
+		default: { // Mono, does not apply here.
+		} break;
+	}
+}
+
+void Frustum::set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar) {
+	planes[Projection::PLANE_NEAR] = Plane(Vector3(0, 0, 1), -p_znear);
+	planes[Projection::PLANE_FAR] = Plane(Vector3(0, 0, -1), p_zfar);
+	planes[Projection::PLANE_LEFT] = Plane(Vector3(-1, 0, 0), -p_left);
+	planes[Projection::PLANE_TOP] = Plane(Vector3(0, 1, 0), p_top);
+	planes[Projection::PLANE_RIGHT] = Plane(Vector3(1, 0, 0), p_right);
+	planes[Projection::PLANE_BOTTOM] = Plane(Vector3(0, -1, 0), -p_bottom);
+}
+
+void Frustum::set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov) {
+	if (!p_flip_fov) {
+		p_size *= p_aspect;
+	}
+
+	set_orthogonal(-p_size / 2, +p_size / 2, -p_size / p_aspect / 2, +p_size / p_aspect / 2, p_znear, p_zfar);
+}
+
+void Frustum::set_frustum(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov) {
+	if (!p_flip_fov) {
+		p_size *= p_aspect;
+	}
+
+	set_frustum(-p_size / 2 + p_offset.x, +p_size / 2 + p_offset.x, -p_size / p_aspect / 2 + p_offset.y, +p_size / p_aspect / 2 + p_offset.y, p_near, p_far);
+}
+
+void Frustum::set_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far) {
+	ERR_FAIL_COND(p_right <= p_left);
+	ERR_FAIL_COND(p_top <= p_bottom);
+	ERR_FAIL_COND(p_far <= p_near);
+
+	real_t left = Math::atan2(p_left, p_near);
+	real_t top = Math::atan2(p_top, p_near);
+	real_t right = Math::atan2(p_right, p_near);
+	real_t bottom = Math::atan2(p_bottom, p_near);
+
+	planes[Projection::PLANE_NEAR] = Plane(Vector3(0, 0, 1), -p_near);
+	planes[Projection::PLANE_FAR] = Plane(Vector3(0, 0, -1), p_far);
+	planes[Projection::PLANE_LEFT] = Plane(Vector3(-Math::cos(left), 0, -Math::sin(left)), 0);
+	planes[Projection::PLANE_TOP] = Plane(Vector3(0, Math::cos(top), Math::sin(top)), 0);
+	planes[Projection::PLANE_RIGHT] = Plane(Vector3(Math::cos(right), 0, Math::sin(right)), 0);
+	planes[Projection::PLANE_BOTTOM] = Plane(Vector3(0, -Math::cos(bottom), -Math::sin(bottom)), 0);
+}
+
+Vector<Plane> Frustum::get_projection_planes(const Transform3D &p_transform) const {
+	Vector<Plane> result;
+	result.resize(6);
+	Basis tr_inverse = p_transform.basis.inverse().transposed();
+	for (int i = 0; i < 6; i++) {
+		result.write[i] = p_transform.xform_fast(planes[i], tr_inverse);
+	}
+	return result;
+}
+
+Vector2 Frustum::get_viewport_half_extents() const {
+	// NOTE: This assumes a symmetrical frustum, i.e. that :
+	// - the frustum is a projection across z-axis
+	// - the projection plane is rectangular
+	// - there is no offset / skew
+	Vector3 res;
+	planes[Projection::PLANE_NEAR].normalized().intersect_3(planes[Projection::PLANE_RIGHT].normalized(), planes[Projection::PLANE_TOP].normalized(), &res);
+	return Vector2(res.x, res.y);
+}
+
+Rect2 Frustum::get_viewport_rect() const {
+	// NOTE: This assumes a rectangular projection plane, i.e. that :
+	// - the matrix is a projection across z-axis
+	// - the projection plane is rectangular
+	Vector3 bottom_left;
+	Vector3 top_right;
+	planes[Projection::PLANE_NEAR].normalized().intersect_3(planes[Projection::PLANE_LEFT].normalized(), planes[Projection::PLANE_BOTTOM].normalized(), &bottom_left);
+	planes[Projection::PLANE_NEAR].normalized().intersect_3(planes[Projection::PLANE_RIGHT].normalized(), planes[Projection::PLANE_TOP].normalized(), &top_right);
+	return Rect2(Point2{ bottom_left.x, bottom_left.y }, Size2{ top_right.x - bottom_left.x, top_right.y - bottom_left.y });
+}
+
+Vector2 Frustum::get_far_plane_half_extents() const {
+	// NOTE: This assumes a symmetrical frustum, i.e. that :
+	// - the frustum is a projection across z-axis
+	// - the projection plane is rectangular
+	// - there is no offset / skew
+	Vector3 res;
+	planes[Projection::PLANE_FAR].normalized().intersect_3(planes[Projection::PLANE_RIGHT].normalized(), planes[Projection::PLANE_TOP].normalized(), &res);
+	return Vector2(res.x, res.y);
+}
+
+Rect2 Frustum::get_far_plane_rect() const {
+	// NOTE: This assumes a rectangular projection plane, i.e. that :
+	// - the matrix is a projection across z-axis
+	// - the projection plane is rectangular
+	Vector3 bottom_left;
+	Vector3 top_right;
+	planes[Projection::PLANE_FAR].normalized().intersect_3(planes[Projection::PLANE_LEFT].normalized(), planes[Projection::PLANE_BOTTOM].normalized(), &bottom_left);
+	planes[Projection::PLANE_FAR].normalized().intersect_3(planes[Projection::PLANE_RIGHT].normalized(), planes[Projection::PLANE_TOP].normalized(), &top_right);
+	return Rect2(Point2{ bottom_left.x, bottom_left.y }, Size2{ top_right.x - bottom_left.x, top_right.y - bottom_left.y });
+}
+
+bool Frustum::get_endpoints(const Transform3D &p_transform, Vector3 *p_8points) const {
+	const Projection::Planes intersections[8][3] = {
+		{ Projection::PLANE_FAR, Projection::PLANE_LEFT, Projection::PLANE_TOP },
+		{ Projection::PLANE_FAR, Projection::PLANE_LEFT, Projection::PLANE_BOTTOM },
+		{ Projection::PLANE_FAR, Projection::PLANE_RIGHT, Projection::PLANE_TOP },
+		{ Projection::PLANE_FAR, Projection::PLANE_RIGHT, Projection::PLANE_BOTTOM },
+		{ Projection::PLANE_NEAR, Projection::PLANE_LEFT, Projection::PLANE_TOP },
+		{ Projection::PLANE_NEAR, Projection::PLANE_LEFT, Projection::PLANE_BOTTOM },
+		{ Projection::PLANE_NEAR, Projection::PLANE_RIGHT, Projection::PLANE_TOP },
+		{ Projection::PLANE_NEAR, Projection::PLANE_RIGHT, Projection::PLANE_BOTTOM },
+	};
+
+	for (int i = 0; i < 8; i++) {
+		Vector3 point;
+		Plane a = planes[intersections[i][0]];
+		Plane b = planes[intersections[i][1]];
+		Plane c = planes[intersections[i][2]];
+		bool res = a.intersect_3(b, c, &point);
+		ERR_FAIL_COND_V(!res, false);
+		p_8points[i] = p_transform.xform(point);
+	}
+
+	return true;
+}
+
+real_t Frustum::get_z_near() const {
+	// NOTE: This assumes z-facing near and far planes, i.e. that :
+	// - the frustum is a projection across z-axis
+	// - near and far planes are z-facing
+	return -planes[Projection::PLANE_NEAR].normalized().d;
+}
+
+real_t Frustum::get_z_far() const {
+	// NOTE: This assumes z-facing near and far planes, i.e. that :
+	// - the frustum is a projection across z-axis
+	// - near and far planes are z-facing
+	return planes[Projection::PLANE_FAR].normalized().d;
+}
+
+Frustum::Frustum(const Vector<Plane> &p_planes) {
+	int nb_planes = MIN(p_planes.size(), 6);
+	for (int i = 0; i < nb_planes; i++) {
+		planes[i] = p_planes[i];
+	}
+}

--- a/core/math/frustum.h
+++ b/core/math/frustum.h
@@ -1,0 +1,90 @@
+/**************************************************************************/
+/*  frustum.h                                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/math/plane.h"
+
+struct Transform3D;
+struct Rect2;
+
+struct Frustum {
+	/*
+	Frustum stands for the 6 planes that define a frustum in 3D space.
+	It is an alternative way to struct Projection to represent a projection matrix.
+
+	Unlike Projection though, it does not suffer from hard numerical precision
+	issues when retrieving near/far planes and distances, as well as boundary points.
+
+	It must be preferred over Projection when the frustum is to be used for culling
+	or other geometric operations, in contrast to (un)projecting points. This ensures
+	a reliable behavior with near and far distances across the whole range of floating
+	point values.
+
+	Planes are stored in the same order defined in struct Projection :
+
+		enum Projection::Planes {
+			PLANE_NEAR,
+			PLANE_FAR,
+			PLANE_LEFT,
+			PLANE_TOP,
+			PLANE_RIGHT,
+			PLANE_BOTTOM
+		};
+	*/
+
+	Plane planes[6];
+
+	_FORCE_INLINE_ Plane &operator[](int p_index) { return planes[p_index]; }
+	_FORCE_INLINE_ const Plane &operator[](int p_index) const { return planes[p_index]; }
+
+	void set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov = false);
+	void set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov, int p_eye, real_t p_intraocular_dist, real_t p_convergence_dist);
+	void set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample, real_t p_z_near, real_t p_z_far);
+	void set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar);
+	void set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov = false);
+	void set_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far);
+	void set_frustum(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
+
+	Vector<Plane> get_projection_planes(const Transform3D &p_transform) const;
+
+	bool get_endpoints(const Transform3D &p_transform, Vector3 *p_8points) const;
+	Vector2 get_viewport_half_extents() const;
+	Rect2 get_viewport_rect() const;
+	Vector2 get_far_plane_half_extents() const;
+	Rect2 get_far_plane_rect() const;
+	real_t get_z_near() const;
+	real_t get_z_far() const;
+
+	Frustum() = default;
+	Frustum(const Vector<Plane> &p_planes);
+	Frustum(const Frustum &p_frustum) = default;
+	Frustum &operator=(const Frustum &p_frustum) = default;
+};

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -83,7 +83,8 @@ struct [[nodiscard]] Projection {
 	void set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov = false);
 	void set_frustum(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_near, real_t p_far);
 	void set_frustum(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
-	void adjust_perspective_znear(real_t p_new_znear);
+	void adjust_perspective_znear_zfar(real_t p_new_znear, real_t p_new_zfar);
+	void adjust_perspective_fov(real_t p_new_fovy_degrees);
 
 	static Projection create_depth_correction(bool p_flip_y);
 	static Projection create_light_atlas_rect(const Rect2 &p_rect);
@@ -96,6 +97,7 @@ struct [[nodiscard]] Projection {
 	static Projection create_frustum_aspect(real_t p_size, real_t p_aspect, Vector2 p_offset, real_t p_near, real_t p_far, bool p_flip_fov = false);
 	static Projection create_fit_aabb(const AABB &p_aabb);
 	Projection perspective_znear_adjusted(real_t p_new_znear) const;
+	Projection perspective_fov_adjusted(real_t p_new_fovy_degrees) const;
 	Plane get_projection_plane(Planes p_plane) const;
 	Projection flipped_y() const;
 	Projection jitter_offseted(const Vector2 &p_offset) const;

--- a/doc/classes/RenderSceneData.xml
+++ b/doc/classes/RenderSceneData.xml
@@ -10,6 +10,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_cam_frustum_plane" qualifiers="const">
+			<return type="Plane" />
+			<param index="0" name="plane" type="int" enum="Projection.Planes" />
+			<description>
+				Returns the plane whose index is given by [param plane] from the frustum used to cull this frame.
+				[param plane] should be equal to one of [constant Projection.PLANE_NEAR], [constant Projection.PLANE_FAR], [constant Projection.PLANE_LEFT], [constant Projection.PLANE_TOP], [constant Projection.PLANE_RIGHT], or [constant Projection.PLANE_BOTTOM].
+			</description>
+		</method>
 		<method name="get_cam_projection" qualifiers="const">
 			<return type="Projection" />
 			<description>

--- a/doc/classes/RenderSceneDataExtension.xml
+++ b/doc/classes/RenderSceneDataExtension.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_get_cam_frustum_plane" qualifiers="virtual const">
+			<return type="Plane" />
+			<param index="0" name="plane" type="int" />
+			<description>
+				Implement this in GDExtension to return the given frustum [param plane] of the camera.
+			</description>
+		</method>
 		<method name="_get_cam_projection" qualifiers="virtual const">
 			<return type="Projection" />
 			<description>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -684,7 +684,7 @@ GLES3::SkyMaterialData *RasterizerSceneGLES3::_get_sky_material_data(RID p_env) 
 	return material_data;
 }
 
-void RasterizerSceneGLES3::_setup_sky(const RenderDataGLES3 *p_render_data, const PagedArray<RID> &p_lights, const Projection &p_projection, const Transform3D &p_transform, const Size2i p_screen_size) {
+void RasterizerSceneGLES3::_setup_sky(const RenderDataGLES3 *p_render_data, const PagedArray<RID> &p_lights, const Transform3D &p_transform, const Size2i &p_screen_size) {
 	GLES3::LightStorage *light_storage = GLES3::LightStorage::get_singleton();
 	ERR_FAIL_COND(p_render_data->environment.is_null());
 
@@ -898,16 +898,11 @@ void RasterizerSceneGLES3::_draw_sky(RID p_env, const Projection &p_projection, 
 	}
 
 	// Camera
-	Projection camera;
+	Projection camera = p_projection;
 
-	if (environment_get_sky_custom_fov(p_env)) {
-		float near_plane = p_projection.get_z_near();
-		float far_plane = p_projection.get_z_far();
-		float aspect = p_projection.get_aspect();
-
-		camera.set_perspective(environment_get_sky_custom_fov(p_env), aspect, near_plane, far_plane);
-	} else {
-		camera = p_projection;
+	float custom_fov = environment_get_sky_custom_fov(p_env);
+	if (custom_fov > 0) {
+		camera.adjust_perspective_fov(custom_fov);
 	}
 
 	Projection correction;
@@ -949,7 +944,7 @@ void RasterizerSceneGLES3::_draw_sky(RID p_env, const Projection &p_projection, 
 	glDrawArrays(GL_TRIANGLES, 0, 3);
 }
 
-void RasterizerSceneGLES3::_update_sky_radiance(RID p_env, const Projection &p_projection, const Transform3D &p_transform, float p_sky_energy_multiplier) {
+void RasterizerSceneGLES3::_update_sky_radiance(RID p_env, const Transform3D &p_transform, float p_sky_energy_multiplier) {
 	GLES3::CubemapFilter *cubemap_filter = GLES3::CubemapFilter::get_singleton();
 	ERR_FAIL_COND(p_env.is_null());
 
@@ -1293,11 +1288,11 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 	}
 
 	Plane near_plane;
-	if (p_render_data->cam_orthogonal) {
+	if (p_render_data->cam_is_orthogonal) {
 		near_plane = Plane(-p_render_data->cam_transform.basis.get_column(Vector3::AXIS_Z), p_render_data->cam_transform.origin);
-		near_plane.d += p_render_data->cam_projection.get_z_near();
+		near_plane.d += p_render_data->z_near;
 	}
-	float z_max = p_render_data->cam_projection.get_z_far() - p_render_data->cam_projection.get_z_near();
+	float z_max = p_render_data->z_far - p_render_data->z_near;
 
 	RenderList *rl = &render_list[p_render_list];
 
@@ -1317,7 +1312,7 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 		GeometryInstanceGLES3 *inst = static_cast<GeometryInstanceGLES3 *>((*p_render_data->instances)[i]);
 
 		Vector3 center = inst->transform.origin;
-		if (p_render_data->cam_orthogonal) {
+		if (p_render_data->cam_is_orthogonal) {
 			if (inst->use_aabb_center) {
 				center = inst->transformed_aabb.get_support(-near_plane.normal);
 			}
@@ -1435,7 +1430,7 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 
 		float lod_distance = 0.0;
 
-		if (p_render_data->cam_orthogonal) {
+		if (p_render_data->cam_is_orthogonal) {
 			lod_distance = 1.0;
 		} else {
 			Vector3 aabb_min = inst->transformed_aabb.position;
@@ -2327,6 +2322,7 @@ void RasterizerSceneGLES3::_render_shadow_pass(RID p_light, RID p_shadow_atlas, 
 
 	RenderDataGLES3 render_data;
 	render_data.cam_projection = light_projection;
+	render_data.cam_frustum = light_projection.get_projection_planes(Transform3D());
 	render_data.cam_transform = light_transform;
 	render_data.inv_cam_transform = light_transform.affine_inverse();
 	render_data.z_far = zfar; // Only used by OmniLights.
@@ -2444,7 +2440,8 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		render_data.cam_transform = p_camera_data->main_transform;
 		render_data.inv_cam_transform = render_data.cam_transform.affine_inverse();
 		render_data.cam_projection = p_camera_data->main_projection;
-		render_data.cam_orthogonal = p_camera_data->is_orthogonal;
+		render_data.cam_frustum = p_camera_data->main_frustum;
+		render_data.cam_is_orthogonal = p_camera_data->is_orthogonal;
 		render_data.camera_visible_layers = p_camera_data->visible_layers;
 		render_data.main_cam_transform = p_camera_data->main_transform;
 
@@ -2454,8 +2451,8 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 			render_data.view_projection[v] = p_camera_data->view_projection[v];
 		}
 
-		render_data.z_near = p_camera_data->main_projection.get_z_near();
-		render_data.z_far = p_camera_data->main_projection.get_z_far();
+		render_data.z_near = p_camera_data->main_frustum.get_z_near();
+		render_data.z_far = p_camera_data->main_frustum.get_z_far();
 
 		render_data.instances = &p_instances;
 		render_data.lights = &p_lights;
@@ -2641,15 +2638,13 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 		// setup sky if used for ambient, reflections, or background
 		if (draw_sky || draw_sky_fog_only || sky_reflections || sky_ambient) {
 			RENDER_TIMESTAMP("Setup Sky");
-			Projection projection = render_data.cam_projection;
-
 			sky_energy_multiplier *= bg_energy_multiplier;
 
-			_setup_sky(&render_data, *render_data.lights, projection, render_data.cam_transform, screen_size);
+			_setup_sky(&render_data, *render_data.lights, render_data.cam_transform, screen_size);
 
 			if (environment_get_sky(render_data.environment).is_valid()) {
 				if (sky_reflections || sky_ambient) {
-					_update_sky_radiance(render_data.environment, projection, render_data.cam_transform, sky_energy_multiplier);
+					_update_sky_radiance(render_data.environment, render_data.cam_transform, sky_energy_multiplier);
 				}
 			} else {
 				// do not try to draw sky if invalid
@@ -4033,7 +4028,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 	}
 }
 
-void RasterizerSceneGLES3::render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) {
+void RasterizerSceneGLES3::render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) {
 }
 
 void RasterizerSceneGLES3::render_particle_collider_heightfield(RID p_collider, const Transform3D &p_transform, const PagedArray<RenderGeometryInstance *> &p_instances) {
@@ -4058,10 +4053,11 @@ void RasterizerSceneGLES3::render_particle_collider_heightfield(RID p_collider, 
 	RenderDataGLES3 render_data;
 
 	render_data.cam_projection = cm;
+	render_data.cam_frustum = cm.get_projection_planes(Transform3D());
 	render_data.cam_transform = cam_xform;
 	render_data.view_projection[0] = cm;
 	render_data.inv_cam_transform = render_data.cam_transform.affine_inverse();
-	render_data.cam_orthogonal = true;
+	render_data.cam_is_orthogonal = true;
 	render_data.z_near = 0.0;
 	render_data.z_far = cm.get_z_far();
 	render_data.main_cam_transform = cam_xform;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -105,7 +105,8 @@ struct RenderDataGLES3 {
 	Transform3D cam_transform;
 	Transform3D inv_cam_transform;
 	Projection cam_projection;
-	bool cam_orthogonal = false;
+	Frustum cam_frustum;
+	bool cam_is_orthogonal = false;
 	uint32_t camera_visible_layers = 0xFFFFFFFF;
 
 	// For billboards to cast correct shadows.
@@ -859,10 +860,10 @@ protected:
 	mutable RID_Owner<Sky, true> sky_owner;
 
 	GLES3::SkyMaterialData *_get_sky_material_data(RID p_env);
-	void _setup_sky(const RenderDataGLES3 *p_render_data, const PagedArray<RID> &p_lights, const Projection &p_projection, const Transform3D &p_transform, const Size2i p_screen_size);
+	void _setup_sky(const RenderDataGLES3 *p_render_data, const PagedArray<RID> &p_lights, const Transform3D &p_transform, const Size2i &p_screen_size);
 	void _invalidate_sky(Sky *p_sky);
 	void _update_dirty_skys();
-	void _update_sky_radiance(RID p_env, const Projection &p_projection, const Transform3D &p_transform, float p_sky_energy_multiplier);
+	void _update_sky_radiance(RID p_env, const Transform3D &p_transform, float p_sky_energy_multiplier);
 	void _draw_sky(RID p_env, const Projection &p_projection, const Transform3D &p_transform, float p_sky_energy_multiplier, float p_luminance_multiplier, bool p_use_multiview, bool p_flip_y, bool p_apply_color_adjustments_in_post);
 	void _free_sky_data(Sky *p_sky);
 
@@ -949,7 +950,7 @@ public:
 	void voxel_gi_set_quality(RSE::VoxelGIQuality) override;
 
 	void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, float p_window_output_max_value, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingServerTypes::RenderInfo *r_render_info = nullptr) override;
-	void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override;
+	void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override;
 	void render_particle_collider_heightfield(RID p_collider, const Transform3D &p_transform, const PagedArray<RenderGeometryInstance *> &p_instances) override;
 
 	void set_scene_pass(uint64_t p_pass) override {

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -34,7 +34,6 @@
 #include "core/input/input.h"
 #include "core/math/geometry_3d.h"
 #include "core/math/math_funcs.h"
-#include "core/math/projection.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"

--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -34,9 +34,9 @@
 #include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/io/resource_loader.h"
+#include "core/math/frustum.h"
 #include "core/math/geometry_3d.h"
 #include "core/math/math_funcs.h"
-#include "core/math/projection.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
@@ -1182,13 +1182,13 @@ void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, Vector<_RayRe
 }
 
 Vector3 Node3DEditorViewport::_get_screen_to_space(const Vector3 &p_vector3) {
-	Projection cm;
+	Frustum fm;
 	if (view_3d_controller->is_orthogonal()) {
-		cm.set_orthogonal(camera->get_size(), get_size().aspect(), get_znear() + p_vector3.z, get_zfar());
+		fm.set_orthogonal(camera->get_size(), get_size().aspect(), get_znear() + p_vector3.z, get_zfar());
 	} else {
-		cm.set_perspective(get_fov(), get_size().aspect(), get_znear() + p_vector3.z, get_zfar());
+		fm.set_perspective(get_fov(), get_size().aspect(), get_znear() + p_vector3.z, get_zfar());
 	}
-	Vector2 screen_he = cm.get_viewport_half_extents();
+	Vector2 screen_he = fm.get_viewport_half_extents();
 
 	Transform3D camera_transform;
 	camera_transform.translate_local(Vector3(view_3d_controller->cursor.pos_x, view_3d_controller->cursor.pos_y, view_3d_controller->cursor.pos_z));

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -584,16 +584,7 @@ Vector2 RaycastOcclusionCull::_get_jitter(const Rect2 &p_viewport_rect, const Si
 	return jitter;
 }
 
-Rect2 _get_viewport_rect(const Projection &p_cam_projection) {
-	// NOTE: This assumes a rectangular projection plane, i.e. that:
-	// - the matrix is a projection across z-axis (i.e. is invertible and columns[0][1], [0][3], [1][0] and [1][3] == 0)
-	// - the projection plane is rectangular (i.e. columns[0][2] and [1][2] == 0 if columns[2][3] != 0)
-	Size2 half_extents = p_cam_projection.get_viewport_half_extents();
-	Point2 bottom_left = -half_extents * Vector2(p_cam_projection.columns[3][0] * p_cam_projection.columns[3][3] + p_cam_projection.columns[2][0] * p_cam_projection.columns[2][3] + 1, p_cam_projection.columns[3][1] * p_cam_projection.columns[3][3] + p_cam_projection.columns[2][1] * p_cam_projection.columns[2][3] + 1);
-	return Rect2(bottom_left, 2 * half_extents);
-}
-
-void RaycastOcclusionCull::buffer_update(RID p_buffer, const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal) {
+void RaycastOcclusionCull::buffer_update(RID p_buffer, const Transform3D &p_cam_transform, const Frustum &p_cam_frustum, bool p_cam_orthogonal) {
 	if (!buffers.has(p_buffer)) {
 		return;
 	}
@@ -607,12 +598,12 @@ void RaycastOcclusionCull::buffer_update(RID p_buffer, const Transform3D &p_cam_
 	Scenario &scenario = scenarios[buffer.scenario_rid];
 	scenario.update();
 
-	Rect2 vp_rect = _get_viewport_rect(p_cam_projection);
+	Rect2 vp_rect = p_cam_frustum.get_viewport_rect();
 	Vector2 bottom_left = vp_rect.position;
 	bottom_left += _get_jitter(vp_rect, buffer.get_occlusion_buffer_size());
-	Vector3 near_bottom_left = Vector3(bottom_left.x, bottom_left.y, -p_cam_projection.get_z_near());
+	Vector3 near_bottom_left = Vector3(bottom_left.x, bottom_left.y, -p_cam_frustum.get_z_near());
 
-	buffer.update_camera_rays(p_cam_transform, near_bottom_left, vp_rect.get_size(), p_cam_projection.get_z_far(), p_cam_orthogonal);
+	buffer.update_camera_rays(p_cam_transform, near_bottom_left, vp_rect.get_size(), p_cam_frustum.get_z_far(), p_cam_orthogonal);
 
 	scenario.raycast(buffer.camera_rays, buffer.camera_ray_masks.ptr(), buffer.camera_rays_tile_count);
 	buffer.sort_rays(-p_cam_transform.basis.get_column(2), p_cam_orthogonal);

--- a/modules/raycast/raycast_occlusion_cull.h
+++ b/modules/raycast/raycast_occlusion_cull.h
@@ -182,7 +182,7 @@ public:
 	virtual HZBuffer *buffer_get_ptr(RID p_buffer) override;
 	virtual void buffer_set_scenario(RID p_buffer, RID p_scenario) override;
 	virtual void buffer_set_size(RID p_buffer, const Vector2i &p_size) override;
-	virtual void buffer_update(RID p_buffer, const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal) override;
+	virtual void buffer_update(RID p_buffer, const Transform3D &p_cam_transform, const Frustum &p_cam_frustum, bool p_cam_orthogonal) override;
 
 	virtual RID buffer_get_debug_texture(RID p_buffer) override;
 

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -31,6 +31,7 @@
 #include "camera_3d.h"
 
 #include "core/config/engine.h"
+#include "core/math/frustum.h"
 #include "core/math/projection.h"
 #include "core/math/transform_interpolator.h"
 #include "core/object/callable_mp.h"
@@ -301,6 +302,25 @@ Projection Camera3D::_get_camera_projection(real_t p_near) const {
 	return cm;
 }
 
+Frustum Camera3D::_get_camera_frustum() const {
+	Size2 viewport_size = get_viewport()->get_visible_rect().size;
+	Frustum fm;
+
+	switch (mode) {
+		case PROJECTION_PERSPECTIVE: {
+			fm.set_perspective(fov, viewport_size.aspect(), _near, _far, keep_aspect == KEEP_WIDTH);
+		} break;
+		case PROJECTION_ORTHOGONAL: {
+			fm.set_orthogonal(size, viewport_size.aspect(), _near, _far, keep_aspect == KEEP_WIDTH);
+		} break;
+		case PROJECTION_FRUSTUM: {
+			fm.set_frustum(size, viewport_size.aspect(), frustum_offset, _near, _far);
+		} break;
+	}
+
+	return fm;
+}
+
 Projection Camera3D::get_camera_projection() const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Projection(), "Camera is not inside the scene tree.");
 	return _get_camera_projection(_near);
@@ -422,8 +442,8 @@ Vector3 Camera3D::project_local_ray_normal(const Point2 &p_pos) const {
 	if (mode == PROJECTION_ORTHOGONAL) {
 		ray = Vector3(0, 0, -1);
 	} else {
-		Projection cm = _get_camera_projection(_near);
-		Vector2 screen_he = cm.get_viewport_half_extents();
+		Frustum fm = _get_camera_frustum();
+		Vector2 screen_he = fm.get_viewport_half_extents();
 		ray = Vector3(((cpos.x / viewport_size.width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (cpos.y / viewport_size.height)) * 2.0 - 1.0) * screen_he.y, -_near).normalized();
 	}
 
@@ -468,10 +488,10 @@ bool Camera3D::is_position_behind(const Vector3 &p_pos) const {
 Vector<Vector3> Camera3D::get_near_plane_points() const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector<Vector3>(), "Camera is not inside scene.");
 
-	Projection cm = _get_camera_projection(_near);
+	Frustum fm = _get_camera_frustum();
 
 	Vector3 endpoints[8];
-	cm.get_endpoints(Transform3D(), endpoints);
+	fm.get_endpoints(Transform3D(), endpoints);
 
 	Vector<Vector3> points = {
 		Vector3(),
@@ -515,11 +535,11 @@ Vector3 Camera3D::project_position(const Point2 &p_point, real_t p_z_depth) cons
 	}
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
-	Projection cm = _get_camera_projection(_near);
+	Frustum fm = _get_camera_frustum();
 
 	Plane z_slice(Vector3(0, 0, 1), -p_z_depth);
 	Vector3 res;
-	z_slice.intersect_3(cm.get_projection_plane(Projection::Planes::PLANE_RIGHT), cm.get_projection_plane(Projection::Planes::PLANE_TOP), &res);
+	z_slice.intersect_3(fm.planes[Projection::Planes::PLANE_RIGHT], fm.planes[Projection::Planes::PLANE_TOP], &res);
 	Vector2 vp_he(res.x, res.y);
 
 	Vector2 point;
@@ -795,10 +815,8 @@ bool Camera3D::get_cull_mask_value(int p_layer_number) const {
 
 Vector<Plane> Camera3D::get_frustum() const {
 	ERR_FAIL_COND_V(!is_inside_world(), Vector<Plane>());
-
-	Projection cm = _get_camera_projection(_near);
-
-	return cm.get_projection_planes(get_camera_transform());
+	Frustum fm = _get_camera_frustum();
+	return fm.get_projection_planes(get_camera_transform());
 }
 
 TypedArray<Plane> Camera3D::_get_frustum() const {

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -37,6 +37,8 @@
 #include "scene/resources/compositor.h"
 #include "scene/resources/environment.h"
 
+struct Frustum;
+
 class Camera3D : public Node3D {
 	GDCLASS(Camera3D, Node3D);
 
@@ -129,6 +131,7 @@ protected:
 	static void _bind_methods();
 
 	Projection _get_camera_projection(real_t p_near) const;
+	Frustum _get_camera_frustum() const;
 
 public:
 	enum {

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -161,7 +161,7 @@ public:
 	void voxel_gi_set_quality(RSE::VoxelGIQuality) override {}
 
 	void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, float p_window_output_max_value, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingServerTypes::RenderInfo *r_info = nullptr) override {}
-	void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override {}
+	void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override {}
 	void render_particle_collider_heightfield(RID p_collider, const Transform3D &p_transform, const PagedArray<RenderGeometryInstance *> &p_instances) override {}
 
 	void set_scene_pass(uint64_t p_pass) override {}

--- a/servers/rendering/renderer_rd/cluster_builder_rd.cpp
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.cpp
@@ -30,6 +30,7 @@
 
 #include "cluster_builder_rd.h"
 
+#include "core/math/frustum.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server_globals.h" // IWYU pragma: keep. RENDER_TIMESTAMP macro uses RSG.
 
@@ -412,20 +413,18 @@ void ClusterBuilderRD::setup(Size2i p_screen_size, uint32_t p_max_elements, RID 
 	}
 }
 
-void ClusterBuilderRD::begin(const Transform3D &p_view_transform, const Projection &p_cam_projection, bool p_flip_y) {
+void ClusterBuilderRD::begin(const Transform3D &p_view_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_flip_y) {
 	view_xform = p_view_transform.affine_inverse();
-	projection = p_cam_projection;
-	z_near = projection.get_z_near();
-	z_far = projection.get_z_far();
+	z_near = p_cam_frustum.get_z_near();
+	z_far = p_cam_frustum.get_z_far();
 	camera_orthogonal = p_cam_projection.is_orthogonal();
-	adjusted_projection = projection;
+	adjusted_projection = p_cam_projection;
 	if (!camera_orthogonal) {
-		adjusted_projection.adjust_perspective_znear(0.0001);
+		adjusted_projection.adjust_perspective_znear_zfar(0.0001, z_far);
 	}
 
 	Projection correction;
 	correction.set_depth_correction(p_flip_y);
-	projection = correction * projection;
 	adjusted_projection = correction * adjusted_projection;
 
 	// Reset counts.

--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -35,6 +35,8 @@
 #include "servers/rendering/renderer_rd/shaders/cluster_store.glsl.gen.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 
+struct Frustum;
+
 class ClusterBuilderSharedDataRD {
 	friend class ClusterBuilderRD;
 
@@ -179,7 +181,6 @@ private:
 
 	Transform3D view_xform;
 	Projection adjusted_projection;
-	Projection projection;
 	float z_far = 0;
 	float z_near = 0;
 	bool camera_orthogonal = false;
@@ -231,7 +232,7 @@ private:
 public:
 	void setup(Size2i p_screen_size, uint32_t p_max_elements, RID p_depth_buffer, RID p_depth_buffer_sampler, RID p_color_buffer);
 
-	void begin(const Transform3D &p_view_transform, const Projection &p_cam_projection, bool p_flip_y);
+	void begin(const Transform3D &p_view_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_flip_y);
 
 	_FORCE_INLINE_ void add_light(LightType p_type, const Transform3D &p_transform, float p_radius, float p_spot_aperture, const Vector2 &p_area_size) {
 		if (p_type == LIGHT_TYPE_OMNI && cluster_count_by_type[ELEMENT_TYPE_OMNI_LIGHT] == max_elements_by_type) {

--- a/servers/rendering/renderer_rd/effects/debug_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/debug_effects.cpp
@@ -30,6 +30,7 @@
 
 #include "debug_effects.h"
 
+#include "core/math/frustum.h"
 #include "servers/rendering/renderer_rd/storage_rd/light_storage.h"
 #include "servers/rendering/renderer_rd/storage_rd/material_storage.h"
 #include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"
@@ -179,7 +180,7 @@ DebugEffects::~DebugEffects() {
 	motion_vectors.shader.version_free(motion_vectors.shader_version);
 }
 
-void DebugEffects::draw_shadow_frustum(RID p_light, const Projection &p_cam_projection, const Transform3D &p_cam_transform, RID p_dest_fb, const Rect2 p_rect) {
+void DebugEffects::draw_shadow_frustum(RID p_light, const Frustum &p_cam_frustum, bool p_cam_is_orthogonal, const Transform3D &p_cam_transform, RID p_dest_fb, const Rect2 p_rect) {
 	RendererRD::LightStorage *light_storage = RendererRD::LightStorage::get_singleton();
 
 	RID base = light_storage->light_instance_get_base_light(p_light);
@@ -203,17 +204,9 @@ void DebugEffects::draw_shadow_frustum(RID p_light, const Projection &p_cam_proj
 	}
 
 	// Setup our camera info (this is mostly a duplicate of the logic found in RendererSceneCull::_light_instance_setup_directional_shadow).
-	bool is_orthogonal = p_cam_projection.is_orthogonal();
-	real_t aspect = p_cam_projection.get_aspect();
-	real_t fov = 0.0;
-	Vector2 vp_he;
-	if (is_orthogonal) {
-		vp_he = p_cam_projection.get_viewport_half_extents();
-	} else {
-		fov = p_cam_projection.get_fov(); //this is actually yfov, because set aspect tries to keep it
-	}
-	real_t min_distance = p_cam_projection.get_z_near();
-	real_t max_distance = p_cam_projection.get_z_far();
+	bool is_orthogonal = p_cam_is_orthogonal;
+	real_t min_distance = p_cam_frustum.get_z_near();
+	real_t max_distance = p_cam_frustum.get_z_far();
 	real_t shadow_max = RSG::light_storage->light_get_param(base, RSE::LIGHT_PARAM_SHADOW_MAX_DISTANCE);
 	if (shadow_max > 0 && !is_orthogonal) {
 		max_distance = MIN(shadow_max, max_distance);
@@ -243,15 +236,11 @@ void DebugEffects::draw_shadow_frustum(RID p_light, const Projection &p_cam_proj
 		uint8_t *w = points.ptrw();
 		Vector3 *vw = (Vector3 *)w;
 
-		Projection projection;
+		Frustum camera_frustum = p_cam_frustum;
+		camera_frustum.planes[Projection::PLANE_NEAR].d = -distances[(split == 0 || !overlap) ? split : split - 1];
+		camera_frustum.planes[Projection::PLANE_FAR].d = distances[split + 1];
 
-		if (is_orthogonal) {
-			projection.set_orthogonal(vp_he.y * 2.0, aspect, distances[(split == 0 || !overlap) ? split : split - 1], distances[split + 1], false);
-		} else {
-			projection.set_perspective(fov, aspect, distances[(split == 0 || !overlap) ? split : split - 1], distances[split + 1], true);
-		}
-
-		bool res = projection.get_endpoints(p_cam_transform, vw);
+		bool res = camera_frustum.get_endpoints(p_cam_transform, vw);
 		ERR_CONTINUE(!res);
 
 		RD::get_singleton()->buffer_update(frustum.vertex_buffer, 0, 8 * sizeof(float) * 3, w);

--- a/servers/rendering/renderer_rd/effects/debug_effects.h
+++ b/servers/rendering/renderer_rd/effects/debug_effects.h
@@ -34,6 +34,8 @@
 #include "servers/rendering/renderer_rd/shaders/effects/motion_vectors.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/effects/shadow_frustum.glsl.gen.h"
 
+struct Frustum;
+
 namespace RendererRD {
 
 class DebugEffects {
@@ -88,7 +90,7 @@ public:
 	DebugEffects();
 	~DebugEffects();
 
-	void draw_shadow_frustum(RID p_light, const Projection &p_cam_projection, const Transform3D &p_cam_transform, RID p_dest_fb, const Rect2 p_rect);
+	void draw_shadow_frustum(RID p_light, const Frustum &p_cam_frustum, bool p_cam_is_orthogonal, const Transform3D &p_cam_transform, RID p_dest_fb, const Rect2 p_rect);
 	void draw_motion_vectors(RID p_velocity, RID p_depth, RID p_dest_fb, const Projection &p_current_projection, const Transform3D &p_current_transform, const Projection &p_previous_projection, const Transform3D &p_previous_transform, Size2i p_resolution);
 };
 

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -565,7 +565,7 @@ Vector3i Fog::_point_get_position_in_froxel_volume(const Vector3 &p_point, float
 	return Vector3i(fog_position);
 }
 
-void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes) {
+void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const Frustum &p_cam_frustum, bool p_cam_is_orthogonal, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes) {
 	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
@@ -581,15 +581,15 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 
 		VolumetricFogShader::VolumeUBO params;
 
-		Vector2 frustum_near_size = p_cam_projection.get_viewport_half_extents();
-		Vector2 frustum_far_size = p_cam_projection.get_far_plane_half_extents();
-		float z_near = p_cam_projection.get_z_near();
-		float z_far = p_cam_projection.get_z_far();
+		Vector2 frustum_near_size = p_cam_frustum.get_viewport_half_extents();
+		Vector2 frustum_far_size = p_cam_frustum.get_far_plane_half_extents();
+		float z_near = p_cam_frustum.get_z_near();
+		float z_far = p_cam_frustum.get_z_far();
 		float fog_end = RendererSceneRenderRD::get_singleton()->environment_get_volumetric_fog_length(p_settings.env);
 
 		Vector2 fog_far_size = frustum_near_size.lerp(frustum_far_size, (fog_end - z_near) / (z_far - z_near));
 		Vector2 fog_near_size;
-		if (p_cam_projection.is_orthogonal()) {
+		if (p_cam_is_orthogonal) {
 			fog_near_size = fog_far_size;
 		} else {
 			fog_near_size = frustum_near_size.maxf(0.001);
@@ -1067,15 +1067,15 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 
 	VolumetricFogShader::ParamsUBO params;
 
-	Vector2 frustum_near_size = p_cam_projection.get_viewport_half_extents();
-	Vector2 frustum_far_size = p_cam_projection.get_far_plane_half_extents();
-	float z_near = p_cam_projection.get_z_near();
-	float z_far = p_cam_projection.get_z_far();
+	Vector2 frustum_near_size = p_cam_frustum.get_viewport_half_extents();
+	Vector2 frustum_far_size = p_cam_frustum.get_far_plane_half_extents();
+	float z_near = p_cam_frustum.get_z_near();
+	float z_far = p_cam_frustum.get_z_far();
 	float fog_end = RendererSceneRenderRD::get_singleton()->environment_get_volumetric_fog_length(p_settings.env);
 
 	Vector2 fog_far_size = frustum_near_size.lerp(frustum_far_size, (fog_end - z_near) / (z_far - z_near));
 	Vector2 fog_near_size;
-	if (p_cam_projection.is_orthogonal()) {
+	if (p_cam_is_orthogonal) {
 		fog_near_size = fog_far_size;
 	} else {
 		fog_near_size = frustum_near_size.maxf(0.001);

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -371,7 +371,7 @@ public:
 		RID env;
 		SkyRD *sky;
 	};
-	void volumetric_fog_update(const VolumetricFogSettings &p_settings, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes);
+	void volumetric_fog_update(const VolumetricFogSettings &p_settings, const Frustum &p_cam_frustum, bool p_cam_is_orthogonal, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes);
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3264,7 +3264,9 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 				bool z_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_column(2)) > 0);
 
 				Projection cm;
+				Frustum fm;
 				cm.set_orthogonal(-rect.size.width / 2, rect.size.width / 2, -rect.size.height / 2, rect.size.height / 2, 0.0001, aabb.size[z_axis]);
+				fm.set_orthogonal(-rect.size.width / 2, rect.size.width / 2, -rect.size.height / 2, rect.size.height / 2, 0.0001, aabb.size[z_axis]);
 
 				if (RendererSceneRenderRD::get_singleton()->cull_argument.size() == 0) {
 					RendererSceneRenderRD::get_singleton()->cull_argument.push_back(nullptr);
@@ -3276,7 +3278,7 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 					exposure_normalization = gi->voxel_gi_get_baked_exposure_normalization(probe);
 				}
 
-				RendererSceneRenderRD::get_singleton()->_render_material(to_world_xform * xform, cm, true, RendererSceneRenderRD::get_singleton()->cull_argument, dynamic_maps[0].fb, Rect2i(Vector2i(), rect.size), exposure_normalization);
+				RendererSceneRenderRD::get_singleton()->_render_material(to_world_xform * xform, cm, fm, true, RendererSceneRenderRD::get_singleton()->cull_argument, dynamic_maps[0].fb, Rect2i(Vector2i(), rect.size), exposure_normalization);
 
 				Vector3 ps = octree_size / gi->voxel_gi_get_bounds(probe).size;
 				float cell_size = (1.0 / MAX(MAX(ps.x, ps.y), ps.z)); // probe size relative to 1 unit in world space

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1261,7 +1261,7 @@ void SkyRD::setup_sky(const RenderDataRD *p_render_data, const Size2i p_screen_s
 		sky_scene_state.ubo.view_eye_offsets[i][3] = 0.0;
 	}
 
-	sky_scene_state.ubo.z_far = p_render_data->scene_data->view_projection[0].get_z_far(); // Should be the same for all projection.
+	sky_scene_state.ubo.z_far = p_render_data->scene_data->z_far;
 	sky_scene_state.ubo.fog_enabled = RendererSceneRenderRD::get_singleton()->environment_get_fog_enabled(p_render_data->environment);
 	sky_scene_state.ubo.fog_density = RendererSceneRenderRD::get_singleton()->environment_get_fog_density(p_render_data->environment);
 	sky_scene_state.ubo.fog_aerial_perspective = RendererSceneRenderRD::get_singleton()->environment_get_fog_aerial_perspective(p_render_data->environment);

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -934,8 +934,8 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 	uint32_t lightmap_captures_used = 0;
 
 	Plane near_plane = Plane(-p_render_data->scene_data->cam_transform.basis.get_column(Vector3::AXIS_Z), p_render_data->scene_data->cam_transform.origin);
-	near_plane.d += p_render_data->scene_data->cam_projection.get_z_near();
-	float z_max = p_render_data->scene_data->cam_projection.get_z_far() - p_render_data->scene_data->cam_projection.get_z_near();
+	near_plane.d += p_render_data->scene_data->z_near;
+	float z_max = p_render_data->scene_data->z_far - p_render_data->scene_data->z_near;
 
 	RenderList *rl = &render_list[p_render_list];
 	_update_dirty_geometry_instances();
@@ -955,7 +955,7 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 		GeometryInstanceForwardClustered *inst = static_cast<GeometryInstanceForwardClustered *>((*p_render_data->instances)[i]);
 
 		Vector3 center = inst->transform.origin;
-		if (p_render_data->scene_data->cam_orthogonal) {
+		if (p_render_data->scene_data->cam_is_orthogonal) {
 			if (inst->use_aabb_center) {
 				center = inst->transformed_aabb.get_support(-near_plane.normal);
 			}
@@ -1083,7 +1083,7 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 
 		float lod_distance = 0.0;
 
-		if (p_render_data->scene_data->cam_orthogonal) {
+		if (p_render_data->scene_data->cam_is_orthogonal) {
 			lod_distance = 1.0;
 		} else {
 			Vector3 aabb_min = inst->transformed_aabb.position;
@@ -1315,7 +1315,7 @@ void RenderForwardClustered::_debug_draw_cluster(Ref<RenderSceneBuffersRD> p_ren
 ////////////////////////////////////////////////////////////////////////////////
 // FOG SHADER
 
-void RenderForwardClustered::_update_volumetric_fog(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_environment, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes) {
+void RenderForwardClustered::_update_volumetric_fog(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_environment, const Frustum &p_cam_frustum, bool p_cam_is_orthogonal, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes) {
 	ERR_FAIL_COND(p_render_buffers.is_null());
 
 	Ref<RenderBufferDataForwardClustered> rb_data = p_render_buffers->get_custom_data(RB_SCOPE_FORWARD_CLUSTERED);
@@ -1385,7 +1385,7 @@ void RenderForwardClustered::_update_volumetric_fog(Ref<RenderSceneBuffersRD> p_
 		settings.sky = &sky;
 		settings.gi = &gi;
 
-		RendererRD::Fog::get_singleton()->volumetric_fog_update(settings, p_cam_projection, p_cam_transform, p_prev_cam_inv_transform, p_shadow_atlas, p_directional_light_count, p_use_directional_shadows, p_positional_light_count, p_voxel_gi_count, p_fog_volumes);
+		RendererRD::Fog::get_singleton()->volumetric_fog_update(settings, p_cam_frustum, p_cam_is_orthogonal, p_cam_transform, p_prev_cam_inv_transform, p_shadow_atlas, p_directional_light_count, p_use_directional_shadows, p_positional_light_count, p_voxel_gi_count, p_fog_volumes);
 	}
 }
 
@@ -1650,7 +1650,7 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 		// This only works as we don't filter our cluster by depth buffer.
 		// If we ever make this optimization we should make it optional and only use it in mono.
 		// What we win by filtering out a few lights, we loose by having to do the work double for stereo.
-		current_cluster_builder->begin(p_render_data->scene_data->cam_transform, p_render_data->scene_data->cam_projection, !p_render_data->reflection_probe.is_valid());
+		current_cluster_builder->begin(p_render_data->scene_data->cam_transform, p_render_data->scene_data->cam_projection, p_render_data->scene_data->cam_frustum, !p_render_data->reflection_probe.is_valid());
 	}
 
 	bool using_shadows = true;
@@ -1678,7 +1678,7 @@ void RenderForwardClustered::_pre_opaque_render(RenderDataRD *p_render_data, boo
 	if (rb_data.is_valid()) {
 		RENDER_TIMESTAMP("Update Volumetric Fog");
 		bool directional_shadows = RendererRD::LightStorage::get_singleton()->has_directional_shadows(directional_light_count);
-		_update_volumetric_fog(rb, p_render_data->environment, p_render_data->scene_data->cam_projection, p_render_data->scene_data->cam_transform, p_render_data->scene_data->prev_cam_transform.affine_inverse(), p_render_data->shadow_atlas, directional_light_count, directional_shadows, positional_light_count, p_render_data->voxel_gi_count, *p_render_data->fog_volumes);
+		_update_volumetric_fog(rb, p_render_data->environment, p_render_data->scene_data->cam_frustum, p_render_data->scene_data->cam_is_orthogonal, p_render_data->scene_data->cam_transform, p_render_data->scene_data->prev_cam_transform.affine_inverse(), p_render_data->shadow_atlas, directional_light_count, directional_shadows, positional_light_count, p_render_data->voxel_gi_count, *p_render_data->fog_volumes);
 	}
 }
 
@@ -2810,6 +2810,7 @@ void RenderForwardClustered::_render_shadow_append(RID p_framebuffer, const Page
 	RenderSceneDataRD scene_data;
 	scene_data.flip_y = !p_flip_y; // Q: Why is this inverted? Do we assume flip in shadow logic?
 	scene_data.cam_projection = p_projection;
+	scene_data.cam_frustum = p_projection.get_projection_planes(Transform3D());
 	scene_data.cam_transform = p_transform;
 	scene_data.view_projection[0] = p_projection;
 	scene_data.z_far = p_zfar;
@@ -2915,6 +2916,7 @@ void RenderForwardClustered::_render_particle_collider_heightfield(RID p_fb, con
 	RenderSceneDataRD scene_data;
 	scene_data.flip_y = true;
 	scene_data.cam_projection = p_cam_projection;
+	scene_data.cam_frustum = p_cam_projection.get_projection_planes(Transform3D());
 	scene_data.cam_transform = p_cam_transform;
 	scene_data.view_projection[0] = p_cam_projection;
 	scene_data.z_near = 0.0;
@@ -2955,13 +2957,14 @@ void RenderForwardClustered::_render_particle_collider_heightfield(RID p_fb, con
 	RD::get_singleton()->draw_command_end_label();
 }
 
-void RenderForwardClustered::_render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) {
+void RenderForwardClustered::_render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) {
 	RENDER_TIMESTAMP("Setup Rendering 3D Material");
 
 	RD::get_singleton()->draw_command_begin_label("Render 3D Material");
 
 	RenderSceneDataRD scene_data;
 	scene_data.cam_projection = p_cam_projection;
+	scene_data.cam_frustum = p_cam_frustum;
 	scene_data.cam_transform = p_cam_transform;
 	scene_data.view_projection[0] = p_cam_projection;
 	scene_data.dual_paraboloid_side = 0;
@@ -3153,6 +3156,7 @@ void RenderForwardClustered::_render_sdfgi(Ref<RenderSceneBuffersRD> p_render_bu
 		float v_size = half_size[up_axis];
 		float d_size = half_size[i] * 2.0;
 		scene_data.cam_projection.set_orthogonal(-h_size, h_size, -v_size, v_size, 0, d_size);
+		scene_data.cam_frustum.set_orthogonal(-h_size, h_size, -v_size, v_size, 0, d_size);
 		//print_line("pass: " + itos(i) + " cam hsize: " + rtos(h_size) + " vsize: " + rtos(v_size) + " dsize " + rtos(d_size));
 
 		Transform3D to_bounds;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -762,7 +762,7 @@ private:
 	/* Volumetric fog */
 	RID shadow_sampler;
 
-	void _update_volumetric_fog(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_environment, const Projection &p_cam_projection, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes);
+	void _update_volumetric_fog(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_environment, const Frustum &p_cam_frustum, bool p_cam_is_orthogonal, const Transform3D &p_cam_transform, const Transform3D &p_prev_cam_inv_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes);
 
 	/* Render shadows */
 
@@ -802,7 +802,7 @@ protected:
 	virtual void _render_scene(RenderDataRD *p_render_data, const Color &p_default_bg_color) override;
 	virtual void _render_buffers_debug_draw(const RenderDataRD *p_render_data) override;
 
-	virtual void _render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) override;
+	virtual void _render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) override;
 	virtual void _render_uv2(const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override;
 	virtual void _render_sdfgi(Ref<RenderSceneBuffersRD> p_render_buffers, const Vector3i &p_from, const Vector3i &p_size, const AABB &p_bounds, const PagedArray<RenderGeometryInstance *> &p_instances, const RID &p_albedo_texture, const RID &p_emission_texture, const RID &p_emission_aniso_texture, const RID &p_geom_facing_texture, float p_exposure_normalization) override;
 	virtual void _render_particle_collider_heightfield(RID p_fb, const Transform3D &p_cam_transform, const Projection &p_cam_projection, const PagedArray<RenderGeometryInstance *> &p_instances) override;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1609,6 +1609,7 @@ void RenderForwardMobile::_render_shadow_append(RID p_framebuffer, const PagedAr
 	RenderSceneDataRD scene_data;
 	scene_data.flip_y = !p_flip_y; // Q: Why is this inverted? Do we assume flip in shadow logic?
 	scene_data.cam_projection = p_projection;
+	scene_data.cam_frustum = p_projection.get_projection_planes(Transform3D());
 	scene_data.cam_transform = p_transform;
 	scene_data.view_projection[0] = p_projection;
 	scene_data.z_near = 0.0;
@@ -1700,7 +1701,7 @@ void RenderForwardMobile::_render_shadow_end() {
 
 /* */
 
-void RenderForwardMobile::_render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) {
+void RenderForwardMobile::_render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) {
 	RENDER_TIMESTAMP("Setup Rendering 3D Material");
 
 	RD::get_singleton()->draw_command_begin_label("Render 3D Material");
@@ -1709,6 +1710,7 @@ void RenderForwardMobile::_render_material(const Transform3D &p_cam_transform, c
 
 	RenderSceneDataRD scene_data;
 	scene_data.cam_projection = p_cam_projection;
+	scene_data.cam_frustum = p_cam_frustum;
 	scene_data.cam_transform = p_cam_transform;
 	scene_data.view_projection[0] = p_cam_projection;
 	scene_data.dual_paraboloid_side = 0;
@@ -1846,6 +1848,7 @@ void RenderForwardMobile::_render_particle_collider_heightfield(RID p_fb, const 
 	RenderSceneDataRD scene_data;
 	scene_data.flip_y = true;
 	scene_data.cam_projection = p_cam_projection;
+	scene_data.cam_frustum = p_cam_projection.get_projection_planes(Transform3D());
 	scene_data.cam_transform = p_cam_transform;
 	scene_data.view_projection[0] = p_cam_projection;
 	scene_data.z_near = 0.0;
@@ -2181,8 +2184,8 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 	uint32_t lightmap_captures_used = 0;
 
 	Plane near_plane(-p_render_data->scene_data->cam_transform.basis.get_column(Vector3::AXIS_Z), p_render_data->scene_data->cam_transform.origin);
-	near_plane.d += p_render_data->scene_data->cam_projection.get_z_near();
-	float z_max = p_render_data->scene_data->cam_projection.get_z_far() - p_render_data->scene_data->cam_projection.get_z_near();
+	near_plane.d += p_render_data->scene_data->z_near;
+	float z_max = p_render_data->scene_data->z_far - p_render_data->scene_data->z_near;
 
 	RenderList *rl = &render_list[p_render_list];
 
@@ -2202,7 +2205,7 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 		GeometryInstanceForwardMobile *inst = static_cast<GeometryInstanceForwardMobile *>((*p_render_data->instances)[i]);
 
 		Vector3 center = inst->transform.origin;
-		if (p_render_data->scene_data->cam_orthogonal) {
+		if (p_render_data->scene_data->cam_is_orthogonal) {
 			if (inst->use_aabb_center) {
 				center = inst->transformed_aabb.get_support(-near_plane.normal);
 			}
@@ -2268,7 +2271,7 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 
 		float lod_distance = 0.0;
 
-		if (p_render_data->scene_data->cam_orthogonal) {
+		if (p_render_data->scene_data->cam_is_orthogonal) {
 			lod_distance = 1.0;
 		} else {
 			Vector3 aabb_min = inst->transformed_aabb.position;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -592,7 +592,7 @@ protected:
 
 	virtual void _render_scene(RenderDataRD *p_render_data, const Color &p_default_bg_color) override;
 
-	virtual void _render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) override;
+	virtual void _render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) override;
 	virtual void _render_uv2(const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override;
 	virtual void _render_sdfgi(Ref<RenderSceneBuffersRD> p_render_buffers, const Vector3i &p_from, const Vector3i &p_size, const AABB &p_bounds, const PagedArray<RenderGeometryInstance *> &p_instances, const RID &p_albedo_texture, const RID &p_emission_texture, const RID &p_emission_aniso_texture, const RID &p_geom_facing_texture, float p_exposure_normalization) override;
 	virtual void _render_particle_collider_heightfield(RID p_fb, const Transform3D &p_cam_transform, const Projection &p_cam_projection, const PagedArray<RenderGeometryInstance *> &p_instances) override;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -522,7 +522,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 				// In stereo p_render_data->z_near and p_render_data->z_far can be offset for our combined frustum.
 				float z_near = p_render_data->scene_data->view_projection[i].get_z_near();
 				float z_far = p_render_data->scene_data->view_projection[i].get_z_far();
-				bokeh_dof->bokeh_dof_compute(buffers, p_render_data->camera_attributes, z_near, z_far, p_render_data->scene_data->cam_orthogonal);
+				bokeh_dof->bokeh_dof_compute(buffers, p_render_data->camera_attributes, z_near, z_far, p_render_data->scene_data->cam_is_orthogonal);
 			};
 		} else {
 			// Set framebuffers.
@@ -545,7 +545,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 				// In stereo p_render_data->z_near and p_render_data->z_far can be offset for our combined frustum.
 				float z_near = p_render_data->scene_data->view_projection[i].get_z_near();
 				float z_far = p_render_data->scene_data->view_projection[i].get_z_far();
-				bokeh_dof->bokeh_dof_raster(buffers, p_render_data->camera_attributes, z_near, z_far, p_render_data->scene_data->cam_orthogonal);
+				bokeh_dof->bokeh_dof_raster(buffers, p_render_data->camera_attributes, z_near, z_far, p_render_data->scene_data->cam_is_orthogonal);
 			}
 		}
 		RD::get_singleton()->draw_command_end_label();
@@ -1096,7 +1096,7 @@ void RendererSceneRenderRD::_render_buffers_debug_draw(const RenderDataRD *p_ren
 				RID base = light_storage->light_instance_get_base_light(light);
 
 				if (light_storage->light_get_type(base) == RSE::LIGHT_DIRECTIONAL) {
-					debug_effects->draw_shadow_frustum(light, p_render_data->scene_data->cam_projection, p_render_data->scene_data->cam_transform, dest_fb, Rect2(Size2(), size));
+					debug_effects->draw_shadow_frustum(light, p_render_data->scene_data->cam_frustum, p_render_data->scene_data->cam_is_orthogonal, p_render_data->scene_data->cam_transform, dest_fb, Rect2(Size2(), size));
 				}
 			}
 		}
@@ -1376,7 +1376,8 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 		// Our first camera is used by default
 		scene_data.cam_transform = p_camera_data->main_transform;
 		scene_data.cam_projection = p_camera_data->main_projection;
-		scene_data.cam_orthogonal = p_camera_data->is_orthogonal;
+		scene_data.cam_frustum = p_camera_data->main_frustum;
+		scene_data.cam_is_orthogonal = p_camera_data->is_orthogonal;
 		scene_data.camera_visible_layers = p_camera_data->visible_layers;
 		scene_data.taa_jitter = p_camera_data->taa_jitter;
 		scene_data.taa_frame_count = p_camera_data->taa_frame_count;
@@ -1397,8 +1398,8 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 			scene_data.prev_view_projection[v] = p_prev_camera_data->view_projection[v];
 		}
 
-		scene_data.z_near = p_camera_data->main_projection.get_z_near();
-		scene_data.z_far = p_camera_data->main_projection.get_z_far();
+		scene_data.z_near = p_camera_data->main_frustum.get_z_near();
+		scene_data.z_far = p_camera_data->main_frustum.get_z_far();
 
 		// this should be the same for all cameras..
 		const float lod_distance_multiplier = p_camera_data->main_projection.get_lod_multiplier();
@@ -1509,8 +1510,8 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 	_render_scene(&render_data, clear_color);
 }
 
-void RendererSceneRenderRD::render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) {
-	_render_material(p_cam_transform, p_cam_projection, p_cam_orthogonal, p_instances, p_framebuffer, p_region, 1.0);
+void RendererSceneRenderRD::render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) {
+	_render_material(p_cam_transform, p_cam_projection, p_cam_frustum, p_cam_orthogonal, p_instances, p_framebuffer, p_region, 1.0);
 }
 
 void RendererSceneRenderRD::render_particle_collider_heightfield(RID p_collider, const Transform3D &p_transform, const PagedArray<RenderGeometryInstance *> &p_instances) {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -92,7 +92,7 @@ protected:
 	virtual void _render_scene(RenderDataRD *p_render_data, const Color &p_default_color) = 0;
 	virtual void _render_buffers_debug_draw(const RenderDataRD *p_render_data);
 
-	virtual void _render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) = 0;
+	virtual void _render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region, float p_exposure_normalization) = 0;
 	virtual void _render_uv2(const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) = 0;
 	virtual void _render_sdfgi(Ref<RenderSceneBuffersRD> p_render_buffers, const Vector3i &p_from, const Vector3i &p_size, const AABB &p_bounds, const PagedArray<RenderGeometryInstance *> &p_instances, const RID &p_albedo_texture, const RID &p_emission_texture, const RID &p_emission_aniso_texture, const RID &p_geom_facing_texture, float p_exposure_normalization) = 0;
 	virtual void _render_particle_collider_heightfield(RID p_fb, const Transform3D &p_cam_transform, const Projection &p_cam_projection, const PagedArray<RenderGeometryInstance *> &p_instances) = 0;
@@ -251,7 +251,7 @@ public:
 
 	virtual void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, float p_window_output_max_value, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingServerTypes::RenderInfo *r_render_info = nullptr) override;
 
-	virtual void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override;
+	virtual void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override;
 
 	virtual void render_particle_collider_heightfield(RID p_collider, const Transform3D &p_transform, const PagedArray<RenderGeometryInstance *> &p_instances) override;
 

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -35,6 +35,10 @@
 #include "servers/rendering/renderer_rd/storage_rd/texture_storage.h"
 #include "servers/rendering/rendering_server_globals.h"
 
+Plane RenderSceneDataRD::get_cam_frustum_plane(Projection::Planes p_plane) const {
+	return cam_frustum[p_plane];
+}
+
 Transform3D RenderSceneDataRD::get_cam_transform() const {
 	return cam_transform;
 }

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -44,10 +44,11 @@ public:
 
 	Transform3D cam_transform;
 	Projection cam_projection;
+	Frustum cam_frustum;
 	Vector2 taa_jitter;
 	float taa_frame_count = 0.0f;
 	uint32_t camera_visible_layers;
-	bool cam_orthogonal = false;
+	bool cam_is_orthogonal = false;
 	bool flip_y = false;
 
 	// For billboards to cast correct shadows.
@@ -86,6 +87,7 @@ public:
 	float time;
 	float time_step;
 
+	virtual Plane get_cam_frustum_plane(Projection::Planes p_plane) const override;
 	virtual Transform3D get_cam_transform() const override;
 	virtual Projection get_cam_projection() const override;
 

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2143,7 +2143,7 @@ void RendererSceneCull::_update_instance_lightmap_captures(Instance *p_instance)
 	geom->geometry_instance->set_lightmap_capture(p_instance->lightmap_sh.ptr());
 }
 
-void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_index, Instance *p_instance, const Transform3D p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, bool p_cam_vaspect) {
+void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_index, Instance *p_instance, const Transform3D p_cam_transform, const Frustum &p_cam_frustum, bool p_cam_orthogonal, bool p_cam_vaspect) {
 	// For later tight culling, the light culler needs to know the details of the directional light.
 	light_culler->prepare_directional_light_begin(p_instance, p_shadow_index);
 
@@ -2152,13 +2152,13 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 	Transform3D light_transform = p_instance->transform;
 	light_transform.orthonormalize(); //scale does not count on lights
 
-	real_t max_distance = p_cam_projection.get_z_far();
+	real_t max_distance = p_cam_frustum.get_z_far();
 	real_t shadow_max = RSG::light_storage->light_get_param(p_instance->base, RSE::LIGHT_PARAM_SHADOW_MAX_DISTANCE);
 	if (shadow_max > 0 && !p_cam_orthogonal) { //its impractical (and leads to unwanted behaviors) to set max distance in orthogonal camera
 		max_distance = MIN(shadow_max, max_distance);
 	}
-	max_distance = MAX(max_distance, p_cam_projection.get_z_near() + 0.001);
-	real_t min_distance = MIN(p_cam_projection.get_z_near(), max_distance);
+	max_distance = MAX(max_distance, p_cam_frustum.get_z_near() + 0.001);
+	real_t min_distance = MIN(p_cam_frustum.get_z_near(), max_distance);
 
 	real_t pancake_size = RSG::light_storage->light_get_param(p_instance->base, RSE::LIGHT_PARAM_SHADOW_PANCAKE_SIZE);
 
@@ -2198,25 +2198,16 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 	for (int i = 0; i < splits; i++) {
 		RENDER_TIMESTAMP("Cull DirectionalLight3D, Split " + itos(i));
 
-		// setup a camera matrix for that range!
-		Projection camera_matrix;
+		// Setup a camera frustum for that range!
+		Frustum camera_frustum = p_cam_frustum;
+		camera_frustum.planes[Projection::PLANE_NEAR].d = -distances[(i == 0 || !overlap) ? i : i - 1];
+		camera_frustum.planes[Projection::PLANE_FAR].d = distances[i + 1];
 
-		real_t aspect = p_cam_projection.get_aspect();
+		Vector<Plane> receiver_frustum_planes = camera_frustum.get_projection_planes(p_cam_transform);
 
-		if (p_cam_orthogonal) {
-			Vector2 vp_he = p_cam_projection.get_viewport_half_extents();
-
-			camera_matrix.set_orthogonal(vp_he.y * 2.0, aspect, distances[(i == 0 || !overlap) ? i : i - 1], distances[i + 1], false);
-		} else {
-			real_t fov = p_cam_projection.get_fov(); //this is actually yfov, because set aspect tries to keep it
-			camera_matrix.set_perspective(fov, aspect, distances[(i == 0 || !overlap) ? i : i - 1], distances[i + 1], true);
-		}
-
-		Vector<Plane> receiver_frustum_planes = camera_matrix.get_projection_planes(p_cam_transform);
-
-		//obtain the frustum endpoints
+		// Obtain the frustum endpoints.
 		Vector3 endpoints[8]; // frustum plane endpoints
-		bool res = camera_matrix.get_endpoints(p_cam_transform, endpoints);
+		bool res = camera_frustum.get_endpoints(p_cam_transform, endpoints);
 		ERR_CONTINUE(!res);
 
 		light_culler->prepare_directional_light_cascade(p_shadow_index, i, receiver_frustum_planes, endpoints);
@@ -2354,7 +2345,7 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 			ortho_transform.basis = transform.basis;
 			ortho_transform.origin = x_vec * (x_min_cam + half_x) + y_vec * (y_min_cam + half_y) + z_vec * z_max;
 
-			cull.shadows[p_shadow_index].cascades[i].frustum = Frustum(light_frustum_planes);
+			cull.shadows[p_shadow_index].cascades[i].frustum = light_frustum_planes;
 			cull.shadows[p_shadow_index].cascades[i].projection = ortho_camera;
 			cull.shadows[p_shadow_index].cascades[i].transform = ortho_transform;
 			cull.shadows[p_shadow_index].cascades[i].zfar = z_max - z_min_cam;
@@ -2367,7 +2358,7 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 	}
 }
 
-bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, const Transform3D p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, bool p_cam_vaspect, RID p_shadow_atlas, Scenario *p_scenario, float p_screen_mesh_lod_threshold, uint32_t p_visible_layers) {
+bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, const Transform3D p_cam_transform, bool p_cam_orthogonal, bool p_cam_vaspect, RID p_shadow_atlas, Scenario *p_scenario, float p_screen_mesh_lod_threshold, uint32_t p_visible_layers) {
 	InstanceLightData *light = static_cast<InstanceLightData *>(p_instance->base_data);
 
 	Transform3D light_transform = p_instance->transform;
@@ -2458,7 +2449,9 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 				real_t radius = RSG::light_storage->light_get_param(p_instance->base, RSE::LIGHT_PARAM_RANGE);
 				real_t z_near = MIN(0.025f, radius);
 				Projection cm;
+				Frustum fm;
 				cm.set_perspective(90, 1, z_near, radius);
+				fm.set_perspective(90, 1, z_near, radius);
 
 				for (int i = 0; i < 6; i++) {
 					RENDER_TIMESTAMP("Cull OmniLight3D Shadow Cube, Side " + itos(i));
@@ -2483,7 +2476,7 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 
 					Transform3D xform = light_transform * Transform3D().looking_at(view_normals[i], view_up[i]);
 
-					Vector<Plane> planes = cm.get_projection_planes(xform);
+					Vector<Plane> planes = fm.get_projection_planes(xform);
 
 					instance_shadow_cull_result.clear();
 
@@ -2550,9 +2543,11 @@ bool RendererSceneCull::_light_instance_update_shadow(Instance *p_instance, cons
 			real_t z_near = MIN(0.025f, radius);
 
 			Projection cm;
+			Frustum fm;
 			cm.set_perspective(angle * 2.0, 1.0, z_near, radius);
+			fm.set_perspective(angle * 2.0, 1.0, z_near, radius);
 
-			Vector<Plane> planes = cm.get_projection_planes(light_transform);
+			Vector<Plane> planes = fm.get_projection_planes(light_transform);
 
 			instance_shadow_cull_result.clear();
 
@@ -2705,12 +2700,22 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 		// Normal camera
 		Transform3D transform = camera->transform;
 		Projection projection;
+		Frustum frustum;
 		bool vaspect = camera->vaspect;
 		bool is_orthogonal = false;
 
 		switch (camera->type) {
 			case Camera::ORTHOGONAL: {
 				projection.set_orthogonal(
+						camera->size,
+						p_viewport_size.width / (float)p_viewport_size.height,
+						camera->znear,
+						camera->zfar,
+						camera->vaspect);
+
+				// The frustum must be initialized from the camera settings too (not from planes extracted
+				// from the projection matrix) to avoid numerical precision issues with large zfar.
+				frustum.set_orthogonal(
 						camera->size,
 						p_viewport_size.width / (float)p_viewport_size.height,
 						camera->znear,
@@ -2726,6 +2731,15 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 						camera->zfar,
 						camera->vaspect);
 
+				// The frustum must be initialized from the camera settings too (not from planes extracted
+				// from the projection matrix) to avoid numerical precision issues with large zfar.
+				frustum.set_perspective(
+						camera->fov,
+						p_viewport_size.width / (float)p_viewport_size.height,
+						camera->znear,
+						camera->zfar,
+						camera->vaspect);
+
 			} break;
 			case Camera::FRUSTUM: {
 				projection.set_frustum(
@@ -2735,10 +2749,20 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 						camera->znear,
 						camera->zfar,
 						camera->vaspect);
+
+				// The frustum must be initialized from the camera settings too (not from planes extracted
+				// from the projection matrix) to avoid numerical precision issues with large zfar.
+				frustum.set_frustum(
+						camera->size,
+						p_viewport_size.width / (float)p_viewport_size.height,
+						camera->offset,
+						camera->znear,
+						camera->zfar,
+						camera->vaspect);
 			} break;
 		}
 
-		camera_data.set_camera(transform, projection, is_orthogonal, vaspect, jitter, taa_frame_count, camera->visible_layers);
+		camera_data.set_camera(transform, projection, frustum, is_orthogonal, vaspect, jitter, taa_frame_count, camera->visible_layers);
 #ifndef XR_DISABLED
 	} else {
 		XRServer *xr_server = XRServer::get_singleton();
@@ -2771,7 +2795,7 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 		}
 
 		if (view_count == 1) {
-			camera_data.set_camera(transforms[0], projections[0], false, camera->vaspect, jitter, p_jitter_phase_count, camera->visible_layers);
+			camera_data.set_camera(transforms[0], projections[0], projections[0].get_projection_planes(Transform3D()), false, camera->vaspect, jitter, p_jitter_phase_count, camera->visible_layers);
 		} else if (view_count == 2) {
 			camera_data.set_multiview_camera(view_count, transforms, projections, false, camera->vaspect, camera->visible_layers);
 		} else {
@@ -2785,7 +2809,7 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 
 	RENDER_TIMESTAMP("Update Occlusion Buffer")
 	// For now just cull on the first camera
-	RendererSceneOcclusionCull::get_singleton()->buffer_update(p_viewport, camera_data.main_transform, camera_data.main_projection, camera_data.is_orthogonal);
+	RendererSceneOcclusionCull::get_singleton()->buffer_update(p_viewport, camera_data.main_transform, camera_data.main_frustum, camera_data.is_orthogonal);
 
 	_render_scene(&camera_data, p_render_buffers, environment, camera->attributes, compositor, camera->visible_layers, p_scenario, p_viewport, p_shadow_atlas, RID(), -1, p_screen_mesh_lod_threshold, p_window_output_max_value, true, r_render_info);
 #endif
@@ -3306,7 +3330,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 	Instance *render_reflection_probe = instance_owner.get_or_null(p_reflection_probe); //if null, not rendering to it
 
 	// Prepare the light - camera volume culling system.
-	light_culler->prepare_camera(p_camera_data->main_transform, p_camera_data->main_projection);
+	light_culler->prepare_camera(p_camera_data->main_transform, p_camera_data->main_frustum, p_camera_data->is_orthogonal);
 
 	Scenario *scenario = scenario_owner.get_or_null(p_scenario);
 	Vector3 camera_position = p_camera_data->main_transform.origin;
@@ -3357,8 +3381,8 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 	/* STEP 2 - CULL */
 
-	Vector<Plane> planes = p_camera_data->main_projection.get_projection_planes(p_camera_data->main_transform);
-	cull.frustum = Frustum(planes);
+	Vector<Plane> planes = p_camera_data->main_frustum.get_projection_planes(p_camera_data->main_transform);
+	cull.frustum = FrustumSign(planes);
 
 	Vector<RID> directional_lights;
 	// directional lights
@@ -3392,7 +3416,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 		RSG::light_storage->set_directional_shadow_count(lights_with_shadow.size());
 
 		for (int i = 0; i < lights_with_shadow.size(); i++) {
-			_light_instance_setup_directional_shadow(i, lights_with_shadow[i], p_camera_data->main_transform, p_camera_data->main_projection, p_camera_data->is_orthogonal, p_camera_data->vaspect);
+			_light_instance_setup_directional_shadow(i, lights_with_shadow[i], p_camera_data->main_transform, p_camera_data->main_frustum, p_camera_data->is_orthogonal, p_camera_data->vaspect);
 		}
 	}
 
@@ -3519,11 +3543,11 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 			{ //compute coverage
 
 				Transform3D cam_xf = p_camera_data->main_transform;
-				float zn = p_camera_data->main_projection.get_z_near();
+				float zn = p_camera_data->main_frustum.get_z_near();
 				Plane p(-cam_xf.basis.get_column(2), cam_xf.origin + cam_xf.basis.get_column(2) * -zn); //camera near plane
 
 				// near plane half width and height
-				Vector2 vp_half_extents = p_camera_data->main_projection.get_viewport_half_extents();
+				Vector2 vp_half_extents = p_camera_data->main_frustum.get_viewport_half_extents();
 
 				switch (RSG::light_storage->light_get_type(ins->base)) {
 					case RSE::LIGHT_OMNI: {
@@ -3640,7 +3664,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 			if (redraw && max_shadows_used < MAX_UPDATE_SHADOWS) {
 				//must redraw!
 				RENDER_TIMESTAMP("> Render Light3D " + itos(i));
-				if (_light_instance_update_shadow(ins, p_camera_data->main_transform, p_camera_data->main_projection, p_camera_data->is_orthogonal, p_camera_data->vaspect, p_shadow_atlas, scenario, p_screen_mesh_lod_threshold, p_visible_layers)) {
+				if (_light_instance_update_shadow(ins, p_camera_data->main_transform, p_camera_data->is_orthogonal, p_camera_data->vaspect, p_shadow_atlas, scenario, p_screen_mesh_lod_threshold, p_visible_layers)) {
 					light->make_shadow_dirty();
 				}
 				RENDER_TIMESTAMP("< Render Light3D " + itos(i));
@@ -3776,7 +3800,7 @@ void RendererSceneCull::render_empty_scene(const Ref<RenderSceneBuffers> &p_rend
 	RENDER_TIMESTAMP("Render Empty 3D Scene");
 
 	RendererSceneRender::CameraData camera_data;
-	camera_data.set_camera(Transform3D(), Projection(), true, false);
+	camera_data.set_camera(Transform3D(), Projection(), Frustum(), true, false);
 
 	scene_render->render_scene(p_render_buffers, &camera_data, &camera_data, PagedArray<RenderGeometryInstance *>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), PagedArray<RID>(), environment, RID(), compositor, p_shadow_atlas, RID(), scenario->reflection_atlas, RID(), 0, 0, nullptr, 0, nullptr, 0, p_window_output_max_value, nullptr);
 #endif
@@ -3835,14 +3859,16 @@ bool RendererSceneCull::_render_reflection_probe_step(Instance *p_instance, int 
 
 			// Render cubemap side.
 			Projection cm;
+			Frustum fm;
 			cm.set_perspective(90, 1, 0.01, max_distance);
+			fm.set_perspective(90, 1, 0.01, max_distance);
 
 			Transform3D local_view;
 			local_view.set_look_at(origin_offset, origin_offset + view_normals[face], view_up[face]);
 
 			RendererSceneRender::CameraData camera_data;
 			Transform3D xform = p_instance->transform * local_view;
-			camera_data.set_camera(xform, cm, false, false);
+			camera_data.set_camera(xform, cm, fm, false, false);
 
 			RENDER_TIMESTAMP("Render ReflectionProbe, Face " + itos(face));
 			_render_scene(&camera_data, render_buffers, environment, RID(), RID(), RSG::light_storage->reflection_probe_get_cull_mask(p_instance->base), p_instance->scenario->self, RID(), shadow_atlas, reflection_probe->instance, face, mesh_lod_threshold, use_shadows);

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/math/dynamic_bvh.h"
+#include "core/math/frustum.h"
 #include "core/math/transform_interpolator.h"
 #include "core/templates/bin_sorted_array.h"
 #include "core/templates/local_vector.h"
@@ -155,15 +156,15 @@ public:
 		uint32_t signs[3];
 	};
 
-	struct Frustum {
+	struct FrustumSign {
 		Vector<Plane> planes;
 		Vector<PlaneSign> plane_signs;
 		const Plane *planes_ptr;
 		const PlaneSign *plane_signs_ptr;
 		uint32_t plane_count;
 
-		_ALWAYS_INLINE_ Frustum() {}
-		_ALWAYS_INLINE_ Frustum(const Frustum &p_frustum) {
+		_ALWAYS_INLINE_ FrustumSign() {}
+		_ALWAYS_INLINE_ FrustumSign(const FrustumSign &p_frustum) {
 			planes = p_frustum.planes;
 			plane_signs = p_frustum.plane_signs;
 
@@ -171,7 +172,7 @@ public:
 			plane_signs_ptr = plane_signs.ptr();
 			plane_count = p_frustum.plane_count;
 		}
-		_ALWAYS_INLINE_ void operator=(const Frustum &p_frustum) {
+		_ALWAYS_INLINE_ void operator=(const FrustumSign &p_frustum) {
 			planes = p_frustum.planes;
 			plane_signs = p_frustum.plane_signs;
 
@@ -179,7 +180,7 @@ public:
 			plane_signs_ptr = plane_signs.ptr();
 			plane_count = p_frustum.plane_count;
 		}
-		_ALWAYS_INLINE_ Frustum(const Vector<Plane> &p_planes) {
+		_ALWAYS_INLINE_ FrustumSign(const Vector<Plane> &p_planes) {
 			planes = p_planes;
 			planes_ptr = planes.ptrw();
 			plane_count = planes.size();
@@ -188,6 +189,17 @@ public:
 				plane_signs.push_back(ps);
 			}
 
+			plane_signs_ptr = plane_signs.ptr();
+		}
+		_ALWAYS_INLINE_ FrustumSign(const Frustum &p_frustum) {
+			plane_count = 6;
+			for (int i = 0; i < 6; i++) {
+				planes.push_back(p_frustum[i]);
+				PlaneSign ps(p_frustum[i]);
+				plane_signs.push_back(ps);
+			}
+
+			planes_ptr = planes.ptrw();
 			plane_signs_ptr = plane_signs.ptr();
 		}
 	};
@@ -208,7 +220,7 @@ public:
 			bounds[4] = p_aabb.position.y + p_aabb.size.y;
 			bounds[5] = p_aabb.position.z + p_aabb.size.z;
 		}
-		_ALWAYS_INLINE_ bool in_frustum(const Frustum &p_frustum) const {
+		_ALWAYS_INLINE_ bool in_frustum(const FrustumSign &p_frustum) const {
 			// This is not a full SAT check and the possibility of false positives exist,
 			// but the tradeoff vs performance is still very good.
 
@@ -1075,9 +1087,9 @@ public:
 	_FORCE_INLINE_ void _update_instance_lightmap_captures(Instance *p_instance) const;
 	void _unpair_instance(Instance *p_instance);
 
-	void _light_instance_setup_directional_shadow(int p_shadow_index, Instance *p_instance, const Transform3D p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, bool p_cam_vaspect);
+	void _light_instance_setup_directional_shadow(int p_shadow_index, Instance *p_instance, const Transform3D p_cam_transform, const Frustum &p_cam_frustum, bool p_cam_orthogonal, bool p_cam_vaspect);
 
-	_FORCE_INLINE_ bool _light_instance_update_shadow(Instance *p_instance, const Transform3D p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, bool p_cam_vaspect, RID p_shadow_atlas, Scenario *p_scenario, float p_screen_mesh_lod_threshold, uint32_t p_visible_layers = 0xFFFFFF);
+	_FORCE_INLINE_ bool _light_instance_update_shadow(Instance *p_instance, const Transform3D p_cam_transform, bool p_cam_orthogonal, bool p_cam_vaspect, RID p_shadow_atlas, Scenario *p_scenario, float p_screen_mesh_lod_threshold, uint32_t p_visible_layers = 0xFFFFFF);
 
 	RID _render_get_environment(RID p_camera, RID p_scenario);
 	RID _render_get_compositor(RID p_camera, RID p_scenario);
@@ -1087,7 +1099,7 @@ public:
 			RID light_instance;
 			uint32_t caster_mask;
 			struct Cascade {
-				Frustum frustum;
+				FrustumSign frustum;
 
 				Projection projection;
 				Transform3D transform;
@@ -1118,7 +1130,7 @@ public:
 
 		SpinLock lock;
 
-		Frustum frustum;
+		FrustumSign frustum;
 	} cull;
 
 	struct VisibilityCullData {

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/io/image.h"
+#include "core/math/frustum.h"
 #include "core/math/projection.h"
 #include "core/templates/local_vector.h"
 #include "servers/rendering/rendering_server_enums.h"
@@ -229,7 +230,7 @@ public:
 	}
 	virtual void buffer_set_scenario(RID p_buffer, RID p_scenario) { _print_warning(); }
 	virtual void buffer_set_size(RID p_buffer, const Vector2i &p_size) { _print_warning(); }
-	virtual void buffer_update(RID p_buffer, const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal) {}
+	virtual void buffer_update(RID p_buffer, const Transform3D &p_cam_transform, const Frustum &p_cam_frustum, bool p_cam_orthogonal) {}
 
 	virtual RID buffer_get_debug_texture(RID p_buffer) {
 		_print_warning();

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -35,13 +35,14 @@
 /////////////////////////////////////////////////////////////////////////////
 // CameraData
 
-void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter, float p_taa_frame_count, uint32_t p_visible_layers) {
+void RendererSceneRender::CameraData::set_camera(const Transform3D &p_transform, const Projection &p_projection, const Frustum &p_frustum, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter, float p_taa_frame_count, const uint32_t p_visible_layers) {
 	view_count = 1;
 	is_orthogonal = p_is_orthogonal;
 	vaspect = p_vaspect;
 
 	main_transform = p_transform;
 	main_projection = p_projection;
+	main_frustum = p_frustum;
 
 	visible_layers = p_visible_layers;
 	view_offset[0] = Transform3D();
@@ -180,6 +181,7 @@ void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count
 
 	// 16. Use this to build the combined camera matrix.
 	main_projection.set_frustum(local_min_vec.x, local_max_vec.x, local_min_vec.y, local_max_vec.y, z_near, z_far);
+	main_frustum.set_frustum(local_min_vec.x, local_max_vec.x, local_min_vec.y, local_max_vec.y, z_near, z_far);
 
 	/////////////////////////////////////////////////////////////////////////////
 	// 3. Copy our view data

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/math/frustum.h"
 #include "core/math/projection.h"
 #include "core/templates/paged_array.h"
 #include "servers/rendering/renderer_geometry_instance.h"
@@ -312,19 +313,20 @@ public:
 		// Main/center projection
 		Transform3D main_transform;
 		Projection main_projection;
+		Frustum main_frustum;
 
 		Transform3D view_offset[RendererSceneRender::MAX_RENDER_VIEWS];
 		Projection view_projection[RendererSceneRender::MAX_RENDER_VIEWS];
 		Vector2 taa_jitter;
 		float taa_frame_count = 0.0f;
 
-		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), float p_taa_frame_count = 0.0f, uint32_t p_visible_layers = 0xFFFFFFFF);
+		void set_camera(const Transform3D &p_transform, const Projection &p_projection, const Frustum &p_frustum, bool p_is_orthogonal, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), float p_taa_frame_count = 0.0f, uint32_t p_visible_layers = 0xFFFFFFFF);
 		void set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_vaspect, uint32_t p_visible_layers = 0xFFFFFFFF);
 	};
 
 	virtual void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, float p_window_output_max_value, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingServerTypes::RenderInfo *r_render_info = nullptr) = 0;
 
-	virtual void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) = 0;
+	virtual void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, const Frustum &p_cam_frustum, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) = 0;
 	virtual void render_particle_collider_heightfield(RID p_collider, const Transform3D &p_transform, const PagedArray<RenderGeometryInstance *> &p_instances) = 0;
 
 	virtual void set_scene_pass(uint64_t p_pass) = 0;

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -516,7 +516,7 @@ bool RenderingLightCuller::_add_light_camera_planes(LightCullPlanes &r_cull_plan
 	return true;
 }
 
-bool RenderingLightCuller::prepare_camera(const Transform3D &p_cam_transform, const Projection &p_cam_matrix) {
+bool RenderingLightCuller::prepare_camera(const Transform3D &p_cam_transform, const Frustum &p_cam_frustum, bool p_camera_is_orthogonal) {
 	data.debug_count++;
 	if (data.debug_count >= 120) {
 		data.debug_count = 0;
@@ -541,10 +541,11 @@ bool RenderingLightCuller::prepare_camera(const Transform3D &p_cam_transform, co
 	}
 	// These are needed later to build per-cascade cull frustums for directional lights.
 	data.camera_transform = p_cam_transform;
-	data.camera_projection = p_cam_matrix;
+	data.camera_frustum = p_cam_frustum;
+	data.camera_is_orthogonal = p_camera_is_orthogonal;
 
 	// Get the camera frustum planes in world space.
-	data.frustum_planes = p_cam_matrix.get_projection_planes(p_cam_transform);
+	data.frustum_planes = p_cam_frustum.get_projection_planes(p_cam_transform);
 	DEV_CHECK_ONCE(data.frustum_planes.size() == 6);
 
 	data.regular_cull_planes.num_cull_planes = 0;

--- a/servers/rendering/rendering_light_culler.h
+++ b/servers/rendering/rendering_light_culler.h
@@ -141,7 +141,7 @@ private:
 public:
 	// Before each pass with a different camera, you must call this so the culler can pre-create
 	// the camera frustum planes and corner points in world space which are used for the culling.
-	bool prepare_camera(const Transform3D &p_cam_transform, const Projection &p_cam_matrix);
+	bool prepare_camera(const Transform3D &p_cam_transform, const Frustum &p_cam_frustum, bool p_camera_is_orthogonal);
 
 	// REGULAR LIGHTS (SPOT, OMNI).
 	// These are prepared then used for culling one by one, single threaded.
@@ -257,7 +257,8 @@ private:
 		LocalVector<DirectionalLightCullData> directional_cull_planes;
 
 		Transform3D camera_transform;
-		Projection camera_projection;
+		Frustum camera_frustum;
+		bool camera_is_orthogonal;
 
 		// Single threaded cull planes for regular lights
 		// (OMNI, SPOT). These lights reuse the same set of cull plane data.

--- a/servers/rendering/storage/render_data_extension.cpp
+++ b/servers/rendering/storage/render_data_extension.cpp
@@ -66,6 +66,7 @@ void RenderSceneBuffersExtension::set_use_debanding(bool p_use_debanding) {
 // RenderSceneDataExtension
 
 void RenderSceneDataExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_get_cam_frustum_plane, "plane");
 	GDVIRTUAL_BIND(_get_cam_transform);
 	GDVIRTUAL_BIND(_get_cam_projection);
 	GDVIRTUAL_BIND(_get_view_count);
@@ -73,6 +74,12 @@ void RenderSceneDataExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_view_projection, "view");
 
 	GDVIRTUAL_BIND(_get_uniform_buffer);
+}
+
+Plane RenderSceneDataExtension::get_cam_frustum_plane(Projection::Planes p_plane) const {
+	Plane ret;
+	GDVIRTUAL_CALL(_get_cam_frustum_plane, p_plane, ret);
+	return ret;
 }
 
 Transform3D RenderSceneDataExtension::get_cam_transform() const {

--- a/servers/rendering/storage/render_data_extension.h
+++ b/servers/rendering/storage/render_data_extension.h
@@ -65,6 +65,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual Plane get_cam_frustum_plane(Projection::Planes p_plane) const override;
 	virtual Transform3D get_cam_transform() const override;
 	virtual Projection get_cam_projection() const override;
 
@@ -74,6 +75,7 @@ public:
 
 	virtual RID get_uniform_buffer() const override;
 
+	GDVIRTUAL1RC(Plane, _get_cam_frustum_plane, uint32_t)
 	GDVIRTUAL0RC(Transform3D, _get_cam_transform)
 	GDVIRTUAL0RC(Projection, _get_cam_projection)
 

--- a/servers/rendering/storage/render_scene_data.cpp
+++ b/servers/rendering/storage/render_scene_data.cpp
@@ -33,6 +33,7 @@
 #include "core/object/class_db.h"
 
 void RenderSceneData::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_cam_frustum_plane", "plane"), &RenderSceneData::get_cam_frustum_plane);
 	ClassDB::bind_method(D_METHOD("get_cam_transform"), &RenderSceneData::get_cam_transform);
 	ClassDB::bind_method(D_METHOD("get_cam_projection"), &RenderSceneData::get_cam_projection);
 

--- a/servers/rendering/storage/render_scene_data.h
+++ b/servers/rendering/storage/render_scene_data.h
@@ -39,6 +39,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	virtual Plane get_cam_frustum_plane(Projection::Planes p_plane) const = 0;
 	virtual Transform3D get_cam_transform() const = 0;
 	virtual Projection get_cam_projection() const = 0;
 

--- a/tests/core/math/test_frustum.cpp
+++ b/tests/core/math/test_frustum.cpp
@@ -1,0 +1,315 @@
+/**************************************************************************/
+/*  test_frustum.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_frustum)
+
+#include "core/math/frustum.h"
+
+namespace TestFrustum {
+
+TEST_CASE("[Frustum] Construction from planes") {
+	constexpr real_t sqrt_2_half = 1.41421356237309504880 / 2;
+
+	Vector<Plane> planes;
+	planes.push_back(Plane(0, 0, 1, -0.02)); // NEAR with znear = 0.02
+	planes.push_back(Plane(0, 0, -1, 50)); // FAR with zfar = 50
+	planes.push_back(Plane(-sqrt_2_half, 0, sqrt_2_half, 0)); // LEFT with fov 90° and aspect 1.0
+	planes.push_back(Plane(0, sqrt_2_half, sqrt_2_half, 0)); // TOP with fov 90° and aspect 1.0
+	planes.push_back(Plane(sqrt_2_half, 0, sqrt_2_half, 0)); // RIGHT with fov 90° and aspect 1.0
+	planes.push_back(Plane(0, -sqrt_2_half, sqrt_2_half, 0)); // BOTTOM with fov 90° and aspect 1.0
+
+	Frustum frustum(planes);
+
+	CHECK_EQ(frustum.planes[0], planes[0]);
+	CHECK_EQ(frustum.planes[1], planes[1]);
+	CHECK_EQ(frustum.planes[2], planes[2]);
+	CHECK_EQ(frustum.planes[3], planes[3]);
+	CHECK_EQ(frustum.planes[4], planes[4]);
+	CHECK_EQ(frustum.planes[5], planes[5]);
+}
+
+TEST_CASE("[Frustum] Orthographic construction") {
+	Frustum frustum;
+	Projection ref;
+
+	frustum.set_orthogonal(-4, 5, -6, 7, 0.2, 9);
+	ref.set_orthogonal(-4, 5, -6, 7, 0.2, 9);
+
+	Vector<Plane> truth = ref.get_projection_planes(Transform3D());
+
+	CHECK(frustum.planes[0].is_equal_approx(truth[0].normalized()));
+	CHECK(frustum.planes[1].is_equal_approx(truth[1].normalized()));
+	CHECK(frustum.planes[2].is_equal_approx(truth[2].normalized()));
+	CHECK(frustum.planes[3].is_equal_approx(truth[3].normalized()));
+	CHECK(frustum.planes[4].is_equal_approx(truth[4].normalized()));
+	CHECK(frustum.planes[5].is_equal_approx(truth[5].normalized()));
+}
+
+TEST_CASE("[Frustum] Perspective construction") {
+	Frustum frustum;
+	Projection ref;
+
+	frustum.set_perspective(50, 0.8, 0.2, 10.0);
+	ref.set_perspective(50, 0.8, 0.2, 10.0);
+
+	Vector<Plane> truth = ref.get_projection_planes(Transform3D());
+
+	CHECK(frustum.planes[0].is_equal_approx(truth[0].normalized()));
+	CHECK(frustum.planes[1].is_equal_approx(truth[1].normalized()));
+	CHECK(frustum.planes[2].is_equal_approx(truth[2].normalized()));
+	CHECK(frustum.planes[3].is_equal_approx(truth[3].normalized()));
+	CHECK(frustum.planes[4].is_equal_approx(truth[4].normalized()));
+	CHECK(frustum.planes[5].is_equal_approx(truth[5].normalized()));
+}
+
+TEST_CASE("[Frustum] Frustum construction") {
+	Frustum frustum;
+	Projection ref;
+
+	frustum.set_frustum(-4, 5, -6, 7, 0.2, 9);
+	ref.set_frustum(-4, 5, -6, 7, 0.2, 9);
+
+	Vector<Plane> truth = ref.get_projection_planes(Transform3D());
+
+	CHECK(frustum.planes[0].is_equal_approx(truth[0].normalized()));
+	CHECK(frustum.planes[1].is_equal_approx(truth[1].normalized()));
+	CHECK(frustum.planes[2].is_equal_approx(truth[2].normalized()));
+	CHECK(frustum.planes[3].is_equal_approx(truth[3].normalized()));
+	CHECK(frustum.planes[4].is_equal_approx(truth[4].normalized()));
+	CHECK(frustum.planes[5].is_equal_approx(truth[5].normalized()));
+
+	frustum.set_frustum(1.0, 4.0 / 3.0, Vector2(0.5, -0.25), 0.5, 50, true);
+	ref.set_frustum(1.0, 4.0 / 3.0, Vector2(0.5, -0.25), 0.5, 50, true);
+
+	truth = ref.get_projection_planes(Transform3D());
+
+	CHECK(frustum.planes[0].is_equal_approx(truth[0].normalized()));
+	CHECK(frustum.planes[1].is_equal_approx(truth[1].normalized()));
+	CHECK(frustum.planes[2].is_equal_approx(truth[2].normalized()));
+	CHECK(frustum.planes[3].is_equal_approx(truth[3].normalized()));
+	CHECK(frustum.planes[4].is_equal_approx(truth[4].normalized()));
+	CHECK(frustum.planes[5].is_equal_approx(truth[5].normalized()));
+}
+
+TEST_CASE("[Frustum] Perspective values extraction") {
+	Frustum persp;
+	persp.set_perspective(90, 0.5, 1, 50, true);
+
+	double znear = persp.get_z_near();
+	double zfar = persp.get_z_far();
+
+	CHECK_EQ(znear, doctest::Approx(1));
+	CHECK_EQ(zfar, doctest::Approx(50));
+
+	persp.set_perspective(38, 1.3, 0.2, 8, false);
+
+	znear = persp.get_z_near();
+	zfar = persp.get_z_far();
+
+	CHECK_EQ(znear, doctest::Approx(0.2));
+	CHECK_EQ(zfar, doctest::Approx(8));
+
+	persp.set_perspective(47, 2.5, 0.9, 14, true);
+
+	znear = persp.get_z_near();
+	zfar = persp.get_z_far();
+
+	CHECK_EQ(znear, doctest::Approx(0.9));
+	CHECK_EQ(zfar, doctest::Approx(14));
+}
+
+TEST_CASE("[Frustum] Frustum values extraction") {
+	Frustum frustum;
+	frustum.set_frustum(1.0, 4.0 / 3.0, Vector2(0.5, -0.25), 0.5, 50, true);
+
+	double znear = frustum.get_z_near();
+	double zfar = frustum.get_z_far();
+
+	CHECK_EQ(znear, doctest::Approx(0.5));
+	CHECK_EQ(zfar, doctest::Approx(50));
+
+	frustum.set_frustum(2.0, 1.5, Vector2(-0.5, 2), 2, 12, false);
+
+	znear = frustum.get_z_near();
+	zfar = frustum.get_z_far();
+
+	CHECK_EQ(znear, doctest::Approx(2));
+	CHECK_EQ(zfar, doctest::Approx(12));
+}
+
+TEST_CASE("[Frustum] Orthographic values extraction") {
+	Frustum ortho;
+	ortho.set_orthogonal(-2, 3, -0.5, 1.5, 1.2, 15);
+
+	double znear = ortho.get_z_near();
+	double zfar = ortho.get_z_far();
+
+	CHECK_EQ(znear, doctest::Approx(1.2));
+	CHECK_EQ(zfar, doctest::Approx(15));
+
+	ortho.set_orthogonal(-7, 2, 2.5, 5.5, 0.5, 6);
+
+	znear = ortho.get_z_near();
+	zfar = ortho.get_z_far();
+
+	CHECK_EQ(znear, doctest::Approx(0.5));
+	CHECK_EQ(zfar, doctest::Approx(6));
+}
+
+TEST_CASE("[Frustum] Perspective extents") {
+	constexpr real_t sqrt3 = 1.7320508;
+	Frustum persp;
+	persp.set_perspective(90, 1, 1, 40, false);
+	Vector2 ne = persp.get_viewport_half_extents();
+	Vector2 fe = persp.get_far_plane_half_extents();
+	Rect2 nr = persp.get_viewport_rect();
+	Rect2 fr = persp.get_far_plane_rect();
+
+	CHECK(ne.is_equal_approx(Vector2(1, 1) * 1));
+	CHECK(fe.is_equal_approx(Vector2(1, 1) * 40));
+	CHECK(nr.is_equal_approx(Rect2(-Vector2(1, 1), 2 * Vector2(1, 1))));
+	CHECK(fr.is_equal_approx(Rect2(-Vector2(1, 1) * 40, 2 * Vector2(1, 1) * 40)));
+
+	persp.set_perspective(120, sqrt3, 0.8, 10, true);
+	ne = persp.get_viewport_half_extents();
+	fe = persp.get_far_plane_half_extents();
+	nr = persp.get_viewport_rect();
+	fr = persp.get_far_plane_rect();
+
+	CHECK(ne.is_equal_approx(Vector2(sqrt3, 1.0) * 0.8));
+	CHECK(fe.is_equal_approx(Vector2(sqrt3, 1.0) * 10));
+	CHECK(nr.is_equal_approx(Rect2(-Vector2(sqrt3, 1.0) * 0.8, 2 * Vector2(sqrt3, 1.0) * 0.8)));
+	CHECK(fr.is_equal_approx(Rect2(-Vector2(sqrt3, 1.0) * 10, 2 * Vector2(sqrt3, 1.0) * 10)));
+
+	persp.set_perspective(60, 1.2, 0.5, 15, false);
+	ne = persp.get_viewport_half_extents();
+	fe = persp.get_far_plane_half_extents();
+	nr = persp.get_viewport_rect();
+	fr = persp.get_far_plane_rect();
+
+	CHECK(ne.is_equal_approx(Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 0.5));
+	CHECK(fe.is_equal_approx(Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 15));
+	CHECK(nr.is_equal_approx(Rect2(-Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 0.5, 2 * Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 0.5)));
+	CHECK(fr.is_equal_approx(Rect2(-Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 15, 2 * Vector2(sqrt3 / 3 * 1.2, sqrt3 / 3) * 15)));
+}
+
+TEST_CASE("[Frustum] Orthographic extents") {
+	Frustum ortho;
+	ortho.set_orthogonal(-3, 3, -1.5, 1.5, 1.2, 15);
+	Vector2 ne = ortho.get_viewport_half_extents();
+	Vector2 fe = ortho.get_far_plane_half_extents();
+	Rect2 nr = ortho.get_viewport_rect();
+	Rect2 fr = ortho.get_far_plane_rect();
+
+	CHECK(ne.is_equal_approx(Vector2(3, 1.5)));
+	CHECK(fe.is_equal_approx(Vector2(3, 1.5)));
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-3, -1.5), 2 * Vector2(3, 1.5))));
+	CHECK(fr.is_equal_approx(Rect2(Vector2(-3, -1.5), 2 * Vector2(3, 1.5))));
+
+	ortho.set_orthogonal(-7, 7, -2.5, 2.5, 0.5, 6);
+	ne = ortho.get_viewport_half_extents();
+	fe = ortho.get_far_plane_half_extents();
+	nr = ortho.get_viewport_rect();
+	fr = ortho.get_far_plane_rect();
+
+	CHECK(ne.is_equal_approx(Vector2(7, 2.5)));
+	CHECK(fe.is_equal_approx(Vector2(7, 2.5)));
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-7, -2.5), 2 * Vector2(7, 2.5))));
+	CHECK(fr.is_equal_approx(Rect2(Vector2(-7, -2.5), 2 * Vector2(7, 2.5))));
+
+	ortho.set_orthogonal(-2, 6, -3.5, 0.5, 1.5, 5.5);
+	nr = ortho.get_viewport_rect();
+	fr = ortho.get_far_plane_rect();
+
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-2, -3.5), Vector2(8, 4))));
+	CHECK(fr.is_equal_approx(Rect2(Vector2(-2, -3.5), Vector2(8, 4))));
+}
+
+TEST_CASE("[Frustum] Frustum extents") {
+	Frustum frustum;
+	frustum.set_frustum(-3, 3, -1.5, 1.5, 1.2, 15);
+	Rect2 nr = frustum.get_viewport_rect();
+	Rect2 fr = frustum.get_far_plane_rect();
+
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-3, -1.5), 2 * Vector2(3, 1.5))));
+	CHECK(fr.is_equal_approx(Rect2(12.5 * Vector2(-3, -1.5), 25 * Vector2(3, 1.5))));
+
+	frustum.set_frustum(-2, 6, -3.5, 0.5, 2, 6);
+	nr = frustum.get_viewport_rect();
+	fr = frustum.get_far_plane_rect();
+
+	CHECK(nr.is_equal_approx(Rect2(Vector2(-2, -3.5), Vector2(8, 4))));
+	CHECK(fr.is_equal_approx(Rect2(3 * Vector2(-2, -3.5), 3 * Vector2(8, 4))));
+}
+
+TEST_CASE("[Frustum] Endpoints") {
+	constexpr real_t sqrt3 = 1.7320508;
+	Frustum persp;
+	persp.set_perspective(90, 1, 1, 40, false);
+	Vector3 ep[8];
+	persp.get_endpoints(Transform3D(), ep);
+
+	CHECK(ep[0].is_equal_approx(Vector3(-1, 1, -1) * 40));
+	CHECK(ep[1].is_equal_approx(Vector3(-1, -1, -1) * 40));
+	CHECK(ep[2].is_equal_approx(Vector3(1, 1, -1) * 40));
+	CHECK(ep[3].is_equal_approx(Vector3(1, -1, -1) * 40));
+	CHECK(ep[4].is_equal_approx(Vector3(-1, 1, -1) * 1));
+	CHECK(ep[5].is_equal_approx(Vector3(-1, -1, -1) * 1));
+	CHECK(ep[6].is_equal_approx(Vector3(1, 1, -1) * 1));
+	CHECK(ep[7].is_equal_approx(Vector3(1, -1, -1) * 1));
+
+	persp.set_perspective(120, sqrt3, 0.8, 10, true);
+	persp.get_endpoints(Transform3D(), ep);
+
+	CHECK(ep[0].is_equal_approx(Vector3(-sqrt3, 1, -1) * 10));
+	CHECK(ep[1].is_equal_approx(Vector3(-sqrt3, -1, -1) * 10));
+	CHECK(ep[2].is_equal_approx(Vector3(sqrt3, 1, -1) * 10));
+	CHECK(ep[3].is_equal_approx(Vector3(sqrt3, -1, -1) * 10));
+	CHECK(ep[4].is_equal_approx(Vector3(-sqrt3, 1, -1) * 0.8));
+	CHECK(ep[5].is_equal_approx(Vector3(-sqrt3, -1, -1) * 0.8));
+	CHECK(ep[6].is_equal_approx(Vector3(sqrt3, 1, -1) * 0.8));
+	CHECK(ep[7].is_equal_approx(Vector3(sqrt3, -1, -1) * 0.8));
+
+	persp.set_perspective(60, 1.2, 0.5, 15, false);
+	persp.get_endpoints(Transform3D(), ep);
+
+	CHECK(ep[0].is_equal_approx(Vector3(-sqrt3 / 3 * 1.2, sqrt3 / 3, -1) * 15));
+	CHECK(ep[1].is_equal_approx(Vector3(-sqrt3 / 3 * 1.2, -sqrt3 / 3, -1) * 15));
+	CHECK(ep[2].is_equal_approx(Vector3(sqrt3 / 3 * 1.2, sqrt3 / 3, -1) * 15));
+	CHECK(ep[3].is_equal_approx(Vector3(sqrt3 / 3 * 1.2, -sqrt3 / 3, -1) * 15));
+	CHECK(ep[4].is_equal_approx(Vector3(-sqrt3 / 3 * 1.2, sqrt3 / 3, -1) * 0.5));
+	CHECK(ep[5].is_equal_approx(Vector3(-sqrt3 / 3 * 1.2, -sqrt3 / 3, -1) * 0.5));
+	CHECK(ep[6].is_equal_approx(Vector3(sqrt3 / 3 * 1.2, sqrt3 / 3, -1) * 0.5));
+	CHECK(ep[7].is_equal_approx(Vector3(sqrt3 / 3 * 1.2, -sqrt3 / 3, -1) * 0.5));
+}
+
+} //namespace TestFrustum

--- a/tests/core/math/test_projection.cpp
+++ b/tests/core/math/test_projection.cpp
@@ -258,7 +258,7 @@ TEST_CASE("[Projection] Jitter offset") {
 	CHECK(proj[3] == offsetted[3]);
 }
 
-TEST_CASE("[Projection] Adjust znear") {
+TEST_CASE("[Projection] Adjust znear zfar") {
 	Projection persp = Projection::create_perspective(90, 0.5, 1, 50, false);
 	Projection adjusted = persp.perspective_znear_adjusted(2);
 
@@ -267,12 +267,12 @@ TEST_CASE("[Projection] Adjust znear") {
 	CHECK(adjusted[2].is_equal_approx(Vector4(persp[2][0], persp[2][1], -1.083333, persp[2][3])));
 	CHECK(adjusted[3].is_equal_approx(Vector4(persp[3][0], persp[3][1], -4.166666, persp[3][3])));
 
-	persp.adjust_perspective_znear(2);
+	persp.adjust_perspective_znear_zfar(2, 60);
 
 	CHECK(persp[0] == adjusted[0]);
 	CHECK(persp[1] == adjusted[1]);
-	CHECK(persp[2] == adjusted[2]);
-	CHECK(persp[3] == adjusted[3]);
+	CHECK(persp[2].is_equal_approx(Vector4(adjusted[2][0], adjusted[2][1], -1.068965, adjusted[2][3])));
+	CHECK(persp[3].is_equal_approx(Vector4(adjusted[3][0], adjusted[3][1], -4.137931, adjusted[3][3])));
 }
 
 TEST_CASE("[Projection] Set light bias") {
@@ -283,6 +283,23 @@ TEST_CASE("[Projection] Set light bias") {
 	CHECK(proj[1] == Vector4(0, 0.5, 0, 0));
 	CHECK(proj[2] == Vector4(0, 0, 0.5, 0));
 	CHECK(proj[3] == Vector4(0.5, 0.5, 0.5, 1));
+}
+
+TEST_CASE("[Projection] Adjust fov") {
+	Projection persp = Projection::create_perspective(90, 0.5, 1, 50, false);
+	Projection adjusted = persp.perspective_fov_adjusted(45);
+
+	CHECK(adjusted[0].is_equal_approx(Vector4(2.0 / 0.414214, persp[0][1], persp[0][2], persp[0][3])));
+	CHECK(adjusted[1].is_equal_approx(Vector4(persp[1][0], 1.0 / 0.414214, persp[1][2], persp[1][3])));
+	CHECK(adjusted[2] == persp[2]);
+	CHECK(adjusted[3] == persp[3]);
+
+	persp.adjust_perspective_fov(45);
+
+	CHECK(persp[0] == adjusted[0]);
+	CHECK(persp[1] == adjusted[1]);
+	CHECK(persp[2] == adjusted[2]);
+	CHECK(persp[3] == adjusted[3]);
 }
 
 TEST_CASE("[Projection] Depth correction") {


### PR DESCRIPTION
**This PR allows rendering with unlimited camera zfar** - or rather limited by the sole floating point range i.e. ~3.4e+38 in single precision and ~1.8e+308 with doubles.

This effectively untaps the potential of reverse-z depth buffer especially with single precision build.

## Outline
Currently zfar cannot be pushed further than barely ~1e6 times znear (with single precision floats) because of numerical precision limitations with some methods of struct `Projection`.
With the default znear = 0.05 this sets the maximum view distance to ~50 km.
While it's enough in most cases, it can be a hard limitation for open worlds, space games, and any very large scene.
Beyond this limit, scene rendering currently breaks and Godot starts spaming errors.

This PR removes this limitation with 3 key changes :
- **Stores the 6 frustum planes** alongside the projection matrix in the rendering server's internals. Both are equivalent representations except that the former allows retrieving near/far distances and boundary points with much more accurate numerical precision
- **Restricts the use of the matrix representation to the sole cases where projections / un-projections are performed**. Use the 6 planes in any other situation (typically to retrieve znear / zfar, get boundary points, etc...)
- **Bundles the 6 planes representation into a new struct `Frustum`** with a few helper methods for convenience. This avoids relying of `Vector<Plane>` everywhere and improves readability

This PR focuses on in-game rendering and camera preview in Editor.
On top of it, PR #100896 allows *editing* very distant objects right in Godot's editor

## TODOs (now complete)
 - [x] Z-fighting with very far away opaque objects (incl. Sky) in Compatibility and Mobile : **Intended behavior** (see caveats)
 - [x] Objects farther than 1e20 disappear when Occlusion culling is on : **Solved by #103798** (see https://github.com/godotengine/godot/pull/99986#issuecomment-2688194684)

## Demo : full-scale scene
[large_zfar.zip](https://github.com/user-attachments/files/17999322/large_zfar.zip)

Vegetation is ~1m tall and ~10m from the observer
The terrain is 10 km large
The moon's radius is 1,700 km and is 400,000 km from the observer
The Andromeda galaxy is 152,000 light-years wide and is 2.5 million light years from the observer

![image](https://github.com/user-attachments/assets/0049f142-d68c-4f2b-bf6f-d3f8972eab98)

## Performance

This PR improves very slightly the frame process time of an empty scene by ~ 0.5%.
This is likely due to the significant number of planes retrieval operations avoided by the fact the 6 planes are already made available.

| Before | After |
|---|---|
|![Capture d’écran du 2024-12-06 13-16-21](https://github.com/user-attachments/assets/9ba95422-b40e-4fb8-b809-44717a678d01) |![Capture d’écran du 2024-12-06 12-56-13](https://github.com/user-attachments/assets/7b01471b-324f-455f-9953-30cec5443d31)|

## Effects compatibility

I spent a considerable amount of time making sure all effects work with large zfar.
Some require additional PRs to be merged.
**Test project for effects** : [effects.zip](https://github.com/user-attachments/files/18006334/effects.zip) (make sure to preview the large zfar camera in each scene)

| Effects | Works with large zfar |
|---|---|
| Bokeh DOF | :heavy_check_mark:  with #99755| 
| SSR | :heavy_check_mark: |
| SSIL | :heavy_check_mark: |
| SSAO | :heavy_check_mark:  |
| Sky | :heavy_check_mark: |
| Shadows | :heavy_check_mark:  |
| SDFGI | :heavy_check_mark: with #104120 |
| SSS | :heavy_check_mark: with #99755 | 
| Fog | :heavy_check_mark: |

## Caveats
- XR is left unchanged for now because this would require the XR APIs to return frustum planes in addition to the projection matrix. This may be the subject of another PR
- Unlike Forward+, Mobile and Compatibility renderers use 24bit UNORM depth buffers which don't get any benefit from reverse-z, so z-fighting will happen near the far plane when zfar is very large. This can notably cause the sky to occlude very distant objects.

## Optional dependencies
#99961 ~and #99962~ may help ensuring non-regression on `Viewport` and `Camera3D`.

----

Documentation twin PR : https://github.com/godotengine/godot-docs/pull/11776
Closes https://github.com/godotengine/godot-proposals/issues/10515
Closes #55070
Supersedes #95944 