### PR TITLE
Fix Inspector tooltips blinking on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4815,7 +4815,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			}
 
 			DisplayServer::WindowID receiving_window_id = window_id;
-			if (mouse_mode == MOUSE_MODE_CAPTURED || mouse_mode == MOUSE_MODE_CONFINED || mouse_mode == MOUSE_MODE_CONFINED_HIDDEN) {
+			if (!windows[window_id].no_focus) {
 				receiving_window_id = _get_focused_window_or_popup();
 				if (receiving_window_id == INVALID_WINDOW_ID) {
 					receiving_window_id = window_id;


### PR DESCRIPTION
- Fixes #99287

I changed the condition to skip the call to `_get_focused_window_or_popup`. The original problem was that the mouse move was not sent to the proper window if the window is not focusable. That seems to fix the blinking issue while still fix the original issue: #95754