### PR TITLE
Expose ResourceLoader::get_resource_script_class

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -132,6 +132,14 @@ ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {
 	return ::ResourceLoader::get_resource_uid(p_path);
 }
 
+String ResourceLoader::get_resource_type(const String &p_path) {
+	return ::ResourceLoader::get_resource_type(p_path);
+}
+
+String ResourceLoader::get_resource_script_class(const String &p_path) {
+	return ::ResourceLoader::get_resource_script_class(p_path);
+}
+
 Vector<String> ResourceLoader::list_directory(const String &p_directory) {
 	return ::ResourceLoader::list_directory(p_directory);
 }
@@ -151,6 +159,8 @@ void ResourceLoader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_cached_ref", "path"), &ResourceLoader::get_cached_ref);
 	ClassDB::bind_method(D_METHOD("exists", "path", "type_hint"), &ResourceLoader::exists, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_resource_uid", "path"), &ResourceLoader::get_resource_uid);
+	ClassDB::bind_method(D_METHOD("get_resource_type", "path"), &ResourceLoader::get_resource_type);
+	ClassDB::bind_method(D_METHOD("get_resource_script_class", "path"), &ResourceLoader::get_resource_script_class);
 	ClassDB::bind_method(D_METHOD("list_directory", "directory_path"), &ResourceLoader::list_directory);
 
 	BIND_ENUM_CONSTANT(THREAD_LOAD_INVALID_RESOURCE);

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -142,6 +142,10 @@ String ResourceLoader::get_resource_type(const String &p_path) {
 	return ::ResourceLoader::get_resource_type(p_path);
 }
 
+String ResourceLoader::get_resource_script_class(const String &p_path) {
+	return ::ResourceLoader::get_resource_script_class(p_path);
+}
+
 Vector<String> ResourceLoader::list_directory(const String &p_directory) {
 	return ::ResourceLoader::list_directory(p_directory);
 }
@@ -162,6 +166,7 @@ void ResourceLoader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("exists", "path", "type_hint"), &ResourceLoader::exists, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_resource_uid", "path"), &ResourceLoader::get_resource_uid);
 	ClassDB::bind_method(D_METHOD("get_resource_type", "path"), &ResourceLoader::get_resource_type);
+	ClassDB::bind_method(D_METHOD("get_resource_script_class", "path"), &ResourceLoader::get_resource_script_class);
 	ClassDB::bind_method(D_METHOD("list_directory", "directory_path"), &ResourceLoader::list_directory);
 
 	BIND_ENUM_CONSTANT(THREAD_LOAD_INVALID_RESOURCE);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -85,6 +85,8 @@ public:
 	Ref<Resource> get_cached_ref(const String &p_path);
 	bool exists(const String &p_path, const String &p_type_hint = "");
 	ResourceUID::ID get_resource_uid(const String &p_path);
+	String get_resource_type(const String &p_path);
+	String get_resource_script_class(const String &p_path);
 
 	Vector<String> list_directory(const String &p_directory);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -85,6 +85,7 @@ public:
 	bool exists(const String &p_path, const String &p_type_hint = "");
 	ResourceUID::ID get_resource_uid(const String &p_path);
 	String get_resource_type(const String &p_path);
+	String get_resource_script_class(const String &p_path);
 
 	Vector<String> list_directory(const String &p_directory);
 

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -60,6 +60,21 @@
 				Returns the list of recognized extensions for a resource type.
 			</description>
 		</method>
+		<method name="get_resource_script_class">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns the global script class name a given [param path], as set by the [code]class_name[/code] keyword in GDScript or the [code][GlobalClass][/code] attribute in C#.
+				If there is none, it returns an empty string.
+			</description>
+		</method>
+		<method name="get_resource_type">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns the type of the resource at the given [param path].
+			</description>
+		</method>
 		<method name="get_resource_uid">
 			<return type="int" />
 			<param index="0" name="path" type="String" />

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -64,6 +64,14 @@
 				Returns the list of recognized extensions for a resource type.
 			</description>
 		</method>
+		<method name="get_resource_script_class">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Returns the global script class name a given [param path], as set by the [code]class_name[/code] keyword in GDScript or the [code][GlobalClass][/code] attribute in C#.
+				If there is none, it returns an empty string.
+			</description>
+		</method>
 		<method name="get_resource_type">
 			<return type="String" />
 			<param index="0" name="path" type="String" />


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This PR exposes ResourceLoader::get_resource_script_class and get_resource_type, allowing retrieval of a resource's global class name and type without having to load it (which can be expensive) or do hacky workarounds (that only work in text serialization). 

Relevant https://github.com/godotengine/godot-proposals/issues/11216