### PR TITLE
Fix for `RuntimeNodeSelect` `selection_list` showing up as an orphaned node when editor is open during runtime

### DIFF
--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -295,6 +295,9 @@ private:
 	void _clear_selection();
 	void _set_selection_visible(bool p_visible);
 
+	void _open_selection_list(const Vector<SelectResult> &p_items, const Point2 &p_pos);
+	void _close_selection_list();
+
 	void _find_canvas_items_at_pos(const Point2 &p_pos, Node *p_node, Vector<SelectResult> &r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
 	void _pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event);
 	void _zoom_callback(float p_zoom_factor, Vector2 p_origin, Ref<InputEvent> p_event);


### PR DESCRIPTION
- fixes https://github.com/godotengine/godot/issues/98999

The issue appears because the `selection_list` https://github.com/godotengine/godot/commit/194ddfd0c469bf1d554caf62f45a9736333d2c44 exists and is not a part of the tree, this solution destroys and recreates the selection list popup as needed instead of keeping it around.


[MRP from 98999](https://github.com/user-attachments/files/17688863/control_orphans.zip)