### PR TITLE
Clarify type-specific `lerp()` documentation

### DIFF
--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -306,7 +306,9 @@
 			<param index="0" name="to" type="Color" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the linear interpolation between this color's components and [param to]'s components. The interpolation factor [param weight] should be between 0.0 and 1.0 (inclusive). See also [method @GlobalScope.lerp].
+				Returns the linear interpolation between this color's components and [param to]'s components.
+				To perform interpolation, [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i]. If this is not desired, use [method @GlobalScope.clampf] to limit [param weight].
+				See also [method @GlobalScope.lerp].
 				[codeblocks]
 				[gdscript]
 				var red = Color(1.0, 0.0, 0.0)

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -145,7 +145,8 @@
 			<param index="1" name="weight" type="float" />
 			<description>
 				Returns the result of the linear interpolation between this transform and [param xform] by the given [param weight].
-				The [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). Values outside this range are allowed and can be used to perform [i]extrapolation[/i] instead.
+				To perform interpolation, [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i]. If this is not desired, use [method @GlobalScope.clampf] to limit [param weight].
+				See also [method @GlobalScope.lerp].
 			</description>
 		</method>
 		<method name="inverse" qualifiers="const">

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -72,7 +72,8 @@
 			<param index="1" name="weight" type="float" />
 			<description>
 				Returns the result of the linear interpolation between this transform and [param xform] by the given [param weight].
-				The [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). Values outside this range are allowed and can be used to perform [i]extrapolation[/i] instead.
+				To perform interpolation, [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i]. If this is not desired, use [method @GlobalScope.clampf] to limit [param weight].
+				See also [method @GlobalScope.lerp].
 			</description>
 		</method>
 		<method name="inverse" qualifiers="const">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -263,7 +263,9 @@
 			<param index="0" name="to" type="Vector2" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of [code]0.0[/code] to [code]1.0[/code], representing the amount of interpolation.
+				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight].
+				To perform interpolation, [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i]. If this is not desired, use [method @GlobalScope.clampf] to limit [param weight].
+				See also [method @GlobalScope.lerp].
 			</description>
 		</method>
 		<method name="limit_length" qualifiers="const" keywords="truncate">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -232,7 +232,9 @@
 			<param index="0" name="to" type="Vector3" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of [code]0.0[/code] to [code]1.0[/code], representing the amount of interpolation.
+				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight].
+				To perform interpolation, [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i]. If this is not desired, use [method @GlobalScope.clampf] to limit [param weight].
+				See also [method @GlobalScope.lerp].
 			</description>
 		</method>
 		<method name="limit_length" qualifiers="const" keywords="truncate">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -181,7 +181,9 @@
 			<param index="0" name="to" type="Vector4" />
 			<param index="1" name="weight" type="float" />
 			<description>
-				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight]. [param weight] is on the range of [code]0.0[/code] to [code]1.0[/code], representing the amount of interpolation.
+				Returns the result of the linear interpolation between this vector and [param to] by amount [param weight].
+				To perform interpolation, [param weight] should be between [code]0.0[/code] and [code]1.0[/code] (inclusive). However, values outside this range are allowed and can be used to perform [i]extrapolation[/i]. If this is not desired, use [method @GlobalScope.clampf] to limit [param weight].
+				See also [method @GlobalScope.lerp].
 			</description>
 		</method>
 		<method name="max" qualifiers="const">


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot-docs/issues/10362.

I'm not 100% sure about this one.

For each type-specific `lerp()` or `lerp()` equivalent, except for Basis and Quaternion, add a line mentioning that `weight` can be with the range `[0,1]` or not, to perform either extrapolation or interpolation. Some of these descriptions had similar information already, in which case I removed that information in favor of this new line.

Each description also links to the GlobalScope `lerp()`.

Because these are copypasta notes, I put them on a separate line and used generic phrasing so that it is a single string for translation (I think this works?).

The note is copied verbatim from the GlobalScope `lerp()`. Personally I think that the wording could be improved and made a bit more concise. If we do so, it should apply to all of these notes and also potentially to the GlobalScope `lerp()` as well.