### PR TITLE
mbedtls: Update to upstream 3.6.2

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -561,7 +561,7 @@ File extracted from upstream source:
 ## mbedtls
 
 - Upstream: https://github.com/Mbed-TLS/mbedtls
-- Version: 3.6.1 (71c569d44bf3a8bd53d874c81ee8ac644dd6e9e3, 2024)
+- Version: 3.6.2 (107ea89daaefb9867ea9121002fbbdf926780e98, 2024)
 - License: Apache 2.0
 
 File extracted from upstream release tarball:

--- a/thirdparty/mbedtls/include/mbedtls/build_info.h
+++ b/thirdparty/mbedtls/include/mbedtls/build_info.h
@@ -26,16 +26,16 @@
  */
 #define MBEDTLS_VERSION_MAJOR  3
 #define MBEDTLS_VERSION_MINOR  6
-#define MBEDTLS_VERSION_PATCH  1
+#define MBEDTLS_VERSION_PATCH  2
 
 /**
  * The single version number has the following structure:
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x03060100
-#define MBEDTLS_VERSION_STRING         "3.6.1"
-#define MBEDTLS_VERSION_STRING_FULL    "Mbed TLS 3.6.1"
+#define MBEDTLS_VERSION_NUMBER         0x03060200
+#define MBEDTLS_VERSION_STRING         "3.6.2"
+#define MBEDTLS_VERSION_STRING_FULL    "Mbed TLS 3.6.2"
 
 /* Macros for build-time platform detection */
 


### PR DESCRIPTION
Security fix: https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.2

For 4.2 and earlier, we should look if there's an update to mbedtls 2.28.x LTS.

*Edit:* This specific security issue doesn't seem to affect 2.28.x:

> The vulnerability is present in Mbed TLS 3.5.x, Mbed TLS 3.6.0 and Mbed TLS 3.6.1. Earlier versions had a different implementation of the problematic cases and are not affected.

But there is a 2.28.9 we missed in August that we should update 4.2 and earlier branches to.