### PR TITLE
Increase the size of the uniform set cache to 4096 to avoid cache thrashing from projects with high numbers of unique textures

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2367,7 +2367,7 @@
 		<member name="rendering/2d/batching/item_buffer_size" type="int" setter="" getter="" default="16384">
 			Maximum number of canvas item commands that can be batched into a single draw call.
 		</member>
-		<member name="rendering/2d/batching/uniform_set_cache_size" type="int" setter="" getter="" default="256">
+		<member name="rendering/2d/batching/uniform_set_cache_size" type="int" setter="" getter="" default="4096">
 			Maximum number of uniform sets that will be cached by the 2D renderer when batching draw calls.
 			[b]Note:[/b] A project that uses a large number of unique sprite textures per frame may benefit from increasing this value.
 		</member>

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3584,7 +3584,7 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/2d/shadow_atlas/size", PROPERTY_HINT_RANGE, "128,16384"), 2048);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/2d/batching/item_buffer_size", PROPERTY_HINT_RANGE, "128,1048576,1"), 16384);
-	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/2d/batching/uniform_set_cache_size", PROPERTY_HINT_RANGE, "256,1048576,1"), 256);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/2d/batching/uniform_set_cache_size", PROPERTY_HINT_RANGE, "256,1048576,1"), 4096);
 
 	// Number of commands that can be drawn per frame.
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "rendering/gl_compatibility/item_buffer_size", PROPERTY_HINT_RANGE, "128,1048576,1"), 16384);


### PR DESCRIPTION
Fixes the part of the performance regression that I was able to reproduce in https://github.com/godotengine/godot/issues/99420. More investigation is needed to find out why the OP is still seeing a performance regression. 

CC @stuartcarnie 