### PR TITLE
ufbx: Update to 0.15.0

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -928,7 +928,7 @@ number and run the script.
 ## ufbx
 
 - Upstream: https://github.com/ufbx/ufbx
-- Version: 0.14.3 (19bdb7e7ef02eb914d5e7211a3685f50ee6d27e3, 2024)
+- Version: 0.15.0 (24eea6f40929fe0f679b7950def378edb003afdb, 2024)
 - License: MIT
 
 Files extracted from upstream source:


### PR DESCRIPTION
https://github.com/ufbx/ufbx/releases/tag/v0.15.0

**Changes from version 0.14.3 to version 0.14.4:**

- Support building on Arm64EC

**Changes from version 0.14.4 to version 0.15.0:**

- Support building without libc
- Allow overriding malloc/stdio
- Add extra/ufbx_math.c
- Add extra/ufbx_libc.c
- Remove <string.h> from header
- Add ufbx_open_memory_ctx() and ufbx_open_file_ctx()

---

In other news, happy [**100000**](https://github.com/godotengine/godot/issues/100000)th issue/pull request/~discussion~ to Godot!! ^^

I was going to snipe it, but sleepiness took over 😅

In retrospect, I'm glad Rémi's writeup holds that number, much more fitting :)
