### PR TITLE
Hide `NavigationRegion2D`'s debug instance instead of freeing it, and hide it when `navigation_polygon` is set to null.

### DIFF
--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -57,7 +57,7 @@ private:
 
 	bool debug_mesh_dirty = true;
 
-	void _free_debug();
+	void _set_debug_visibile(bool p_visible);
 	void _update_debug_mesh();
 	void _update_debug_edge_connections_mesh();
 	void _update_debug_baking_rect();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

An alternative of [#99948](https://github.com/godotengine/godot/pull/99948).



------------------------------
> I guess we could remove the `navigation_polygon.is_valid()` check in the notification draw function instead as that should clear the debug canvas item instance and the debug mesh without freeing the entire rendering RIDs. Although there are likely some missing checks then in the later functions.
> 
@smix8 I can't find the " `navigation_polygon.is_valid()` check" that can be removed. Could your point it out? 
            