### PR TITLE
Fix project tag theme changing

### DIFF
--- a/editor/project_manager/project_tag.cpp
+++ b/editor/project_manager/project_tag.cpp
@@ -35,8 +35,13 @@
 #include "scene/gui/color_rect.h"
 
 void ProjectTag::_notification(int p_what) {
-	if (display_close && p_what == NOTIFICATION_THEME_CHANGED) {
-		button->set_button_icon(get_theme_icon(SNAME("close"), SNAME("TabBar")));
+	if (p_what == NOTIFICATION_THEME_CHANGED) {
+		if (display_close) {
+			button->set_button_icon(get_theme_icon(SNAME("close"), SNAME("TabBar")));
+		}
+		button->add_theme_style_override(CoreStringName(normal), get_theme_stylebox(CoreStringName(normal), SNAME("ProjectTag")));
+		button->add_theme_style_override("hover", get_theme_stylebox("hover", SNAME("ProjectTag")));
+		button->add_theme_style_override(SceneStringName(pressed), get_theme_stylebox(SceneStringName(pressed), SNAME("ProjectTag")));
 	}
 }
 


### PR DESCRIPTION
Fix theme changing for project tag buttons.

<details>
<summary>Before</summary>

![bugfix_none](https://github.com/user-attachments/assets/23c8197c-bb16-4989-a41c-63c18d763c48)

</details>

<details>
<summary>After</summary>

![bugfix](https://github.com/user-attachments/assets/f6a9394d-fe79-425b-82fa-5beb942cb3ae)

</details>
