### PR TITLE
GDScript: Display deprecated symbols in editor and language server

### DIFF
--- a/core/object/editor_language.h
+++ b/core/object/editor_language.h
@@ -96,6 +96,7 @@ public:
 		Variant default_value;
 		int location = CompletionLocation::OTHER;
 		String theme_color_name;
+		bool deprecated = false;
 
 		CompletionOption() = default;
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -344,6 +344,7 @@ public:
 		 */
 		TextEdit text_edit;
 		Color font_color;
+		bool deprecated = false;
 		Ref<Resource> icon;
 		Variant default_value;
 		Vector<Pair<int, int>> matches;

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -50,9 +50,11 @@
 			<param index="4" name="icon" type="Resource" default="null" />
 			<param index="5" name="value" type="Variant" default="null" />
 			<param index="6" name="location" type="int" default="1024" />
+			<param index="7" name="deprecated" type="bool" default="false" />
 			<description>
 				Submits an item to the queue of potential candidates for the autocomplete menu. Call [method update_code_completion_options] to update the list.
 				[param location] indicates location of the option relative to the location of the code completion query. See [enum CodeEdit.CodeCompletionLocation] for how to set this value.
+				If [param deprecated] is [code]true[/code], then the item will be indicated to the user as being unwise to use (such as with a strikethrough effect).
 				[b]Note:[/b] This list will replace all current candidates.
 			</description>
 		</method>

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -51,9 +51,11 @@
 			<param index="4" name="icon" type="Resource" default="null" />
 			<param index="5" name="value" type="Variant" default="null" />
 			<param index="6" name="location" type="int" default="1024" />
+			<param index="7" name="deprecated" type="bool" default="false" />
 			<description>
 				Submits an item to the queue of potential candidates for the autocomplete menu. Call [method update_code_completion_options] to update the list.
 				[param location] indicates location of the option relative to the location of the code completion query. See [enum CodeEdit.CodeCompletionLocation] for how to set this value.
+				If [param deprecated] is [code]true[/code], then the item will be indicated to the user as being unwise to use (such as with a strikethrough effect).
 				[b]Note:[/b] This list will replace all current candidates.
 			</description>
 		</method>

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1052,7 +1052,7 @@ void CodeTextEditor::_complete_request() {
 		} else if (e.insert_text.begins_with("#") || e.insert_text.begins_with("//")) {
 			font_color = completion_comment_color;
 		}
-		text_editor->add_code_completion_option((CodeEdit::CodeCompletionKind)e.kind, e.display, e.insert_text, font_color, _get_completion_icon(e), e.default_value, e.location);
+		text_editor->add_code_completion_option((CodeEdit::CodeCompletionKind)e.kind, e.display, e.insert_text, font_color, _get_completion_icon(e), e.default_value, e.location, e.deprecated);
 	}
 	text_editor->update_code_completion_options(forced);
 }

--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1051,7 +1051,7 @@ void CodeTextEditor::_complete_request() {
 		} else if (e.insert_text.begins_with("#") || e.insert_text.begins_with("//")) {
 			font_color = completion_comment_color;
 		}
-		text_editor->add_code_completion_option((CodeEdit::CodeCompletionKind)e.kind, e.display, e.insert_text, font_color, _get_completion_icon(e), e.default_value, e.location);
+		text_editor->add_code_completion_option((CodeEdit::CodeCompletionKind)e.kind, e.display, e.insert_text, font_color, _get_completion_icon(e), e.default_value, e.location, e.deprecated);
 	}
 	text_editor->update_code_completion_options(forced);
 }

--- a/misc/extension_api_validation/4.7-stable/GH-100019.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-100019.txt
@@ -1,0 +1,6 @@
+GH-100019
+---------
+Validate extension JSON: Error: Field 'classes/CodeEdit/methods/add_code_completion_option/arguments': size changed value in new API, from 6 to 8.
+Validate extension JSON: Error: Field 'classes/CodeEdit/methods/add_code_completion_option/arguments': size changed value in new API, from 7 to 8.
+
+New argument `deprecated` added to `add_code_completion_option`. Compatibility method registered.

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -35,6 +35,7 @@
 #include "gdscript_utility_functions.h"
 
 #ifdef TOOLS_ENABLED
+#include "editor/doc/editor_help.h"
 #include "editor/gdscript_docgen.h"
 #include "editor/gdscript_editor_language.h"
 #include "editor/script_templates/templates.gen.h"
@@ -1117,11 +1118,18 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 		r_result.insert(variant_option.display, variant_option);
 	}
 
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
 	LocalVector<StringName> native_types;
 	ClassDB::get_class_list(native_types);
 	for (const StringName &type : native_types) {
 		if (ClassDB::is_class_exposed(type) && !Engine::get_singleton()->has_singleton(type)) {
+			// Native class, when used as a type.
+			// 		var my_var: No...  # <-- will suggest `Node2D`
 			ScriptLanguage::CodeCompletionOption option(type, ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
+			if (class_doc_map && class_doc_map->has(type)) {
+				option.deprecated = class_doc_map->get(type).is_deprecated;
+			}
 			r_result.insert(option.display, option);
 		}
 	}
@@ -1129,11 +1137,18 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 	// TODO: Unify with _find_identifiers_in_class.
 	if (p_context.current_class) {
 		if (!p_inherit_only && p_context.current_class->base_type.is_set()) {
-			// Native enums from base class
+			// Native enum from parent class, when used as a type.
+			//		extends AnimationPlayer
+			//		...
+			// 		var i: Anim...  # <-- Will suggest `AnimationProcessCallback`
 			List<StringName> enums;
-			ClassDB::get_enum_list(p_context.current_class->base_type.native_type, &enums);
+			const String base_native_type = p_context.current_class->base_type.native_type;
+			ClassDB::get_enum_list(base_native_type, &enums);
 			for (const StringName &E : enums) {
 				ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_ENUM);
+				if (class_doc_map && class_doc_map->has(base_native_type) && class_doc_map->get(base_native_type).enums.has(E)) {
+					option.deprecated = class_doc_map->get(base_native_type).enums.get(E).is_deprecated;
+				}
 				r_result.insert(option.display, option);
 			}
 		}
@@ -1146,18 +1161,36 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 				const GDScriptParser::ClassNode::Member &member = current->members[i];
 				switch (member.type) {
 					case GDScriptParser::ClassNode::Member::CLASS: {
+						// Inner class (that is, class within this class file defined
+						// with `class`), when used to define a variable's type.
+						// 		var inner_inst: InnerCl...  # <-- will suggest `InnerClass`
 						ScriptLanguage::CodeCompletionOption option(member.m_class->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_CLASS, ScriptLanguage::LOCATION_LOCAL + location_offset);
+						option.deprecated = member.m_class->doc_data.is_deprecated;
 						r_result.insert(option.display, option);
 					} break;
 					case GDScriptParser::ClassNode::Member::ENUM: {
 						if (!p_inherit_only) {
+							// Named enum within this class, when used to define
+							// a variable's type.
+							// e.g.,
+							// 		var current_state: MyEn...  # <-- will suggest `MyEnum`
 							ScriptLanguage::CodeCompletionOption option(member.m_enum->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_ENUM, ScriptLanguage::LOCATION_LOCAL + location_offset);
+							option.deprecated = member.m_enum->doc_data.is_deprecated;
 							r_result.insert(option.display, option);
 						}
 					} break;
 					case GDScriptParser::ClassNode::Member::CONSTANT: {
 						if (member.constant->type_constraint.is_meta_type) {
+							// Preloaded type within this script.
+							// const MyType = preload("res://my_type.gd")
+							// var m: MyT... # <-- will suggest MyType
 							ScriptLanguage::CodeCompletionOption option(member.constant->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_CLASS, ScriptLanguage::LOCATION_LOCAL + location_offset);
+
+							bool held_class_is_deprecated = false;
+							if (member.constant->type_constraint.class_type) {
+								held_class_is_deprecated = member.constant->type_constraint.class_type->doc_data.is_deprecated;
+							}
+							option.deprecated = held_class_is_deprecated || member.constant->doc_data.is_deprecated;
 							r_result.insert(option.display, option);
 						}
 					} break;
@@ -1174,7 +1207,13 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 	LocalVector<StringName> global_classes;
 	ScriptServer::get_global_class_list(global_classes);
 	for (const StringName &class_name : global_classes) {
+		// Global classes (that is, classes defined with `class_name`), when used
+		// as a type declaration.
+		// 		var my_var: SomeCl...  # <-- will suggest `SomeClass`
 		ScriptLanguage::CodeCompletionOption option(class_name, ScriptLanguage::CODE_COMPLETION_KIND_CLASS, ScriptLanguage::LOCATION_OTHER_USER_CODE);
+		if (class_doc_map && class_doc_map->has(class_name)) {
+			option.deprecated = class_doc_map->get(class_name).is_deprecated;
+		}
 		r_result.insert(option.display, option);
 	}
 
@@ -1189,7 +1228,12 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 		if (!info.is_singleton || !info.path.has_extension("gd")) {
 			continue;
 		}
+		// Autoload global variable names, when used as a type declaration.
+		// 		var my_autoload: GameAu...  # <-- will suggest `GameAutoload`
 		ScriptLanguage::CodeCompletionOption option(info.name, ScriptLanguage::CODE_COMPLETION_KIND_CLASS, ScriptLanguage::LOCATION_OTHER_USER_CODE);
+		if (class_doc_map && class_doc_map->has(info.name)) {
+			option.deprecated = class_doc_map->get(info.name).is_deprecated;
+		}
 		r_result.insert(option.display, option);
 	}
 }
@@ -1201,8 +1245,12 @@ static void _find_identifiers_in_suite(const GDScriptParser::SuiteNode *p_suite,
 		if (p_suite->locals[i].type == GDScriptParser::SuiteNode::Local::CONSTANT) {
 			option = ScriptLanguage::CodeCompletionOption(p_suite->locals[i].name, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
 			option.default_value = p_suite->locals[i].constant->initializer->reduced_value;
+			option.deprecated = p_suite->locals[i].constant->doc_data.is_deprecated;
 		} else {
 			option = ScriptLanguage::CodeCompletionOption(p_suite->locals[i].name, ScriptLanguage::CODE_COMPLETION_KIND_VARIABLE, location);
+			if (p_suite->locals[i].type == GDScriptParser::SuiteNode::Local::VARIABLE) {
+				option.deprecated = p_suite->locals[i].variable->doc_data.is_deprecated;
+			}
 		}
 		r_result.insert(option.display, option);
 	}
@@ -1230,43 +1278,83 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 						if (p_types_only || p_only_functions || outer || (p_static && !member.variable->is_static)) {
 							continue;
 						}
+						// Property of a class.
+						// 		var my_var = 3
+						//		func _ready():
+						// 			print(my_v...  # <-- will suggest `my_var`.
 						option = ScriptLanguage::CodeCompletionOption(member.variable->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_MEMBER, location);
+						option.deprecated = member.variable->doc_data.is_deprecated;
 						break;
-					case GDScriptParser::ClassNode::Member::CONSTANT:
+					case GDScriptParser::ClassNode::Member::CONSTANT: {
 						if ((p_types_only && !member.constant->type_constraint.is_meta_type) || p_only_functions) {
 							continue;
 						}
 						if (r_result.has(member.constant->identifier->name)) {
 							continue;
 						}
+						// Constant in a class.
+						// 		const MY_CONST = 3
+						//		func _ready():
+						// 			print(MY_CON...  # <-- will suggest `MY_CONST`
 						option = ScriptLanguage::CodeCompletionOption(member.constant->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
+
+						// This constant holds a script class, so we should check
+						// if the script class is itself deprecated.
+						bool held_class_is_deprecated = false;
+						if (member.constant->type_constraint.is_meta_type && member.constant->type_constraint.class_type) {
+							held_class_is_deprecated = member.constant->type_constraint.class_type->doc_data.is_deprecated;
+						}
+						option.deprecated = held_class_is_deprecated || member.constant->doc_data.is_deprecated;
 						if (member.constant->initializer) {
 							option.default_value = member.constant->initializer->reduced_value;
 						}
 						break;
+					}
 					case GDScriptParser::ClassNode::Member::CLASS:
 						if (p_only_functions) {
 							continue;
 						}
+						// Inner class in a class.
+						// 		class MyInnerClass:
+						//			pass
+						//		func _ready():
+						// 			print(MyInn...  # <-- will suggest `MyInnerClass`
 						option = ScriptLanguage::CodeCompletionOption(member.m_class->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_CLASS, location);
+						option.deprecated = member.m_class->doc_data.is_deprecated;
 						break;
 					case GDScriptParser::ClassNode::Member::ENUM_VALUE:
 						if (p_types_only || p_only_functions) {
 							continue;
 						}
+						// Value from an anonymous enum in a class.
+						// 		enum { ONE, TWO }
+						//		func _ready():
+						// 			print(ON...  # <-- will suggest `ONE`
 						option = ScriptLanguage::CodeCompletionOption(member.enum_value.identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
+						option.deprecated = member.enum_value.doc_data.is_deprecated;
 						break;
 					case GDScriptParser::ClassNode::Member::ENUM:
 						if (p_only_functions) {
 							continue;
 						}
+						// Name of an enum in a class.
+						// 		enum MyEnum { ONE, TWO }
+						//		func _ready():
+						// 			print(MyEn...  # <-- will suggest `MyEnum`
 						option = ScriptLanguage::CodeCompletionOption(member.m_enum->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_ENUM, location);
+						option.deprecated = member.m_enum->doc_data.is_deprecated;
 						break;
 					case GDScriptParser::ClassNode::Member::FUNCTION:
 						if (p_types_only || outer || (p_static && !member.function->is_static) || member.function->identifier->name.string().begins_with("@")) {
 							continue;
 						}
+						// Method in a class.
+						// 		func say_hello():
+						//			print("Hello!")
+						//		func _ready():
+						// 			print(say_he...  # <-- will suggest `say_hello()`
 						option = ScriptLanguage::CodeCompletionOption(member.function->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
+						option.deprecated = member.function->doc_data.is_deprecated;
 						if (p_add_braces) {
 							if (member.function->parameters.size() > 0 || (member.function->info.flags & METHOD_FLAG_VARARG)) {
 								option.insert_text += "(";
@@ -1281,7 +1369,12 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 						if (p_types_only || p_only_functions || outer || p_static) {
 							continue;
 						}
+						// Signal in a class.
+						// 		signal something_happened
+						//		func _ready():
+						// 			something_hap...  # <-- will suggest `something_happened`
 						option = ScriptLanguage::CodeCompletionOption(member.signal->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_SIGNAL, location);
+						option.deprecated = member.signal->doc_data.is_deprecated;
 						break;
 					case GDScriptParser::ClassNode::Member::GROUP:
 						break; // No-op, but silences warnings.
@@ -1313,7 +1406,11 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 	GDScriptParser::DataType base_type = p_base.type;
 
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
 	if (!p_types_only && base_type.is_meta_type && base_type.kind != GDScriptParser::DataType::BUILTIN && base_type.kind != GDScriptParser::DataType::ENUM) {
+		// Constructor for a class.
+		// 		var i = AnimatedSprite2D.n...  # <-- will suggest `new(...)`
 		ScriptLanguage::CodeCompletionOption option("new", ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, ScriptLanguage::LOCATION_LOCAL);
 		if (p_add_braces) {
 			option.insert_text += "(";
@@ -1323,6 +1420,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 	}
 
 	while (!base_type.has_no_type()) {
+		// This HashSet is declared up here because it works across both
+		// the ENUM and BUILTIN cases.
+		HashSet<String> deprecated_values;
 		switch (base_type.kind) {
 			case GDScriptParser::DataType::CLASS: {
 				_find_identifiers_in_class(base_type.class_type, p_only_functions, p_types_only, base_type.is_meta_type, false, p_add_braces, r_result, p_recursion_depth);
@@ -1338,6 +1438,17 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						if (!base_type.is_meta_type) {
 							List<PropertyInfo> members;
 							scr->get_script_property_list(&members);
+
+							HashSet<StringName> deprecated_properties;
+
+							if (class_doc_map && class_doc_map->has(scr->get_doc_class_name())) {
+								for (const DocData::PropertyDoc &property : class_doc_map->get(scr->get_doc_class_name()).properties) {
+									if (property.is_deprecated) {
+										deprecated_properties.insert(property.name);
+									}
+								}
+							}
+
 							for (const PropertyInfo &E : members) {
 								if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 									continue;
@@ -1346,26 +1457,55 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 									continue;
 								}
 								int location = p_recursion_depth + _get_property_location(scr, E.name);
+
+								// Property in a Script type (such as a C# script).
 								ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_MEMBER, location);
+								option.deprecated = deprecated_properties.has(E.name);
 								r_result.insert(option.display, option);
 							}
 
 							List<MethodInfo> signals;
 							scr->get_script_signal_list(&signals);
+
+							HashSet<StringName> deprecated_signals;
+							if (class_doc_map && class_doc_map->has(scr->get_doc_class_name())) {
+								for (const DocData::MethodDoc &signal_doc : class_doc_map->get(scr->get_doc_class_name()).signals) {
+									if (signal_doc.is_deprecated) {
+										deprecated_signals.insert(signal_doc.name);
+									}
+								}
+							}
+
 							for (const MethodInfo &E : signals) {
 								if (E.name.begins_with("_")) {
 									continue;
 								}
 								int location = p_recursion_depth + _get_signal_location(scr, E.name);
+
+								// Signal in a Script type (such as a C# script).
 								ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_SIGNAL, location);
+								option.deprecated = deprecated_signals.has(E.name);
 								r_result.insert(option.display, option);
 							}
 						}
 						HashMap<StringName, Variant> constants;
 						scr->get_constants(&constants);
+
+						HashSet<StringName> deprecated_consts;
+						if (class_doc_map && class_doc_map->has(scr->get_doc_class_name())) {
+							for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(scr->get_doc_class_name()).constants) {
+								if (constant_doc.is_deprecated) {
+									deprecated_consts.insert(constant_doc.name);
+								}
+							}
+						}
+
 						for (const KeyValue<StringName, Variant> &E : constants) {
 							int location = p_recursion_depth + _get_constant_location(scr, E.key);
+
+							// Constant in a Script type (such as a C# script).
 							ScriptLanguage::CodeCompletionOption option(E.key.string(), ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
+							option.deprecated = deprecated_consts.has(E.key.string());
 							r_result.insert(option.display, option);
 						}
 					}
@@ -1378,6 +1518,8 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 								continue;
 							}
 							int location = p_recursion_depth + _get_method_location(scr->get_class_name(), E.name);
+
+							// Method in a Script type (such as a C# script).
 							ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
 							if (p_add_braces) {
 								if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
@@ -1414,6 +1556,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 				ClassDB::get_enum_list(type, &enums);
 				for (const StringName &E : enums) {
 					int location = p_recursion_depth + _get_enum_location(type, E);
+					// Enum names for a native class.
+					//		TextureRe...  # <-- will suggest `TextureRepeat`
+					// 		AnimationPlayer.AnimationPro...  # <-- will suggest `AnimationProcessCallback`
 					ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_ENUM, location);
 					r_result.insert(option.display, option);
 				}
@@ -1424,16 +1569,47 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				if (!p_only_functions) {
 					List<String> constants;
+
+					HashSet<String> deprecated_consts;
+					if (class_doc_map) {
+						if (!class_doc_map->has(type)) {
+							print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+						} else {
+							for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(type).constants) {
+								if (constant_doc.is_deprecated) {
+									deprecated_consts.insert(constant_doc.name);
+								}
+							}
+						}
+					}
+
 					ClassDB::get_integer_constant_list(type, &constants);
 					for (const String &E : constants) {
 						int location = p_recursion_depth + _get_constant_location(type, StringName(E));
+						// Constant in a native class.
+						// 		NOTIFICATION_DR...  # <-- Will suggest `NOTIFICATION_DRAW`
 						ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
+						option.deprecated = deprecated_consts.has(E);
 						r_result.insert(option.display, option);
 					}
 
 					if (!base_type.is_meta_type || Engine::get_singleton()->has_singleton(type)) {
 						List<PropertyInfo> pinfo;
 						ClassDB::get_property_list(type, &pinfo);
+
+						HashSet<String> deprecated_properties;
+						if (class_doc_map) {
+							if (!class_doc_map->has(type)) {
+								print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+							} else {
+								for (const DocData::PropertyDoc &property_doc : class_doc_map->get(type).properties) {
+									if (property_doc.is_deprecated) {
+										deprecated_properties.insert(property_doc.name);
+									}
+								}
+							}
+						}
+
 						for (const PropertyInfo &E : pinfo) {
 							if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 								continue;
@@ -1442,18 +1618,42 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 								continue;
 							}
 							int location = p_recursion_depth + _get_property_location(type, E.name);
+
+							// Property in a native class.
+							// 		var my_node = Node2D.new()
+							// 		my_node.pos...  # <-- will suggest `position`
 							ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_MEMBER, location);
+							option.deprecated = deprecated_properties.has(E.name);
 							r_result.insert(option.display, option);
 						}
 
 						List<MethodInfo> signals;
 						ClassDB::get_signal_list(type, &signals);
+
+						HashSet<String> deprecated_signals;
+						if (class_doc_map) {
+							if (!class_doc_map->has(type)) {
+								print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+							} else {
+								for (const DocData::MethodDoc &signal_doc : class_doc_map->get(type).signals) {
+									if (signal_doc.is_deprecated) {
+										deprecated_signals.insert(signal_doc.name);
+									}
+								}
+							}
+						}
+
 						for (const MethodInfo &E : signals) {
 							if (E.name.begins_with("_")) {
 								continue;
 							}
 							int location = p_recursion_depth + _get_signal_location(type, StringName(E.name));
+
+							// Signal in a native class.
+							// 		var my_node = AnimatedSprite2D.new()
+							// 		my_node.anim...  # <-- will suggest `animation_changed`
 							ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_SIGNAL, location);
+							option.deprecated = deprecated_signals.has(E.name);
 							r_result.insert(option.display, option);
 						}
 					}
@@ -1463,6 +1663,21 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				List<MethodInfo> methods;
 				ClassDB::get_method_list(type, &methods, false, true);
+
+				// Assemble a set of deprecated method names.
+				HashSet<String> deprecated_methods;
+				if (class_doc_map) {
+					if (!class_doc_map->has(type)) {
+						print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+					} else {
+						for (const DocData::MethodDoc &method_doc : class_doc_map->get(type).methods) {
+							if (method_doc.is_deprecated) {
+								deprecated_methods.insert(method_doc.name);
+							}
+						}
+					}
+				}
+
 				for (const MethodInfo &E : methods) {
 					if (only_static && (E.flags & METHOD_FLAG_STATIC) == 0) {
 						continue;
@@ -1471,7 +1686,12 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						continue;
 					}
 					int location = p_recursion_depth + _get_method_location(type, E.name);
+
+					// Method name in a native class.
+					// 		var my_node = AnimatedSprite2D.new()
+					// 		my_node.get_pl...  # <-- will suggest `get_playing_speed`
 					ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
+					option.deprecated = deprecated_methods.has(E.name);
 					if (p_add_braces) {
 						if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
 							option.insert_text += "(";
@@ -1503,9 +1723,34 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						ClassDB::get_enum_constants(type, type_enum, &enum_values);
 					}
 
+					if (base_type.class_type && base_type.kind == GDScriptParser::DataType::ENUM) {
+						const GDScriptParser::EnumNode *_enum = base_type.class_type->get_member(type_enum).m_enum;
+						for (const GDScriptParser::EnumNode::Value &enum_value : _enum->values) {
+							if (enum_value.doc_data.is_deprecated) {
+								deprecated_values.insert(enum_value.identifier->name);
+							}
+						}
+					} else {
+						if (class_doc_map) {
+							if (!class_doc_map->has(type)) {
+								print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+							} else {
+								for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(type).constants) {
+									if (constant_doc.is_deprecated) {
+										deprecated_values.insert(constant_doc.name);
+									}
+								}
+							}
+						}
+					}
+
 					for (const StringName &E : enum_values) {
 						int location = p_recursion_depth + _get_enum_constant_location(type, E);
+
+						// Enum value from a named enum in another class.
+						// 		CanvasItem.ClipChildrenMode.CLI...  # <-- will suggest `CLIP_CHILDREN_DISABLED`
 						ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT, location);
+						option.deprecated = deprecated_values.has(E);
 						r_result.insert(option.display, option);
 					}
 				} else if (CoreConstants::is_global_enum(base_type.enum_type)) {
@@ -1542,6 +1787,8 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						tmp.get_property_list(&members);
 					}
 
+					// Handles members from Variant types. Since named enums are
+					// internally the Dictionary type, they are also handled here.
 					for (const PropertyInfo &E : members) {
 						if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 							continue;
@@ -1551,6 +1798,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 							if (base_type.kind == GDScriptParser::DataType::ENUM) {
 								// Sort enum members in their declaration order.
 								location += 1;
+								option.deprecated = deprecated_values.has(E.name);
 							}
 							if (GDScriptParser::theme_color_names.has(E.name)) {
 								option.theme_color_name = GDScriptParser::theme_color_names[E.name];
@@ -1562,12 +1810,29 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				List<MethodInfo> methods;
 				tmp.get_method_list(&methods);
+
+				HashSet<String> deprecated_methods;
+				if (class_doc_map) {
+					if (!class_doc_map->has(Variant::get_type_name(base_type.builtin_type))) {
+						print_error(vformat(R"(Variant "%s" couldn't be found in doc data.)", Variant::get_type_name(base_type.builtin_type)));
+					} else {
+						for (const DocData::MethodDoc &method_doc : class_doc_map->get(Variant::get_type_name(base_type.builtin_type)).methods) {
+							if (method_doc.is_deprecated) {
+								deprecated_methods.insert(method_doc.name);
+							}
+						}
+					}
+				}
+
 				for (const MethodInfo &E : methods) {
 					if (base_type.kind == GDScriptParser::DataType::ENUM && base_type.is_meta_type && !(E.flags & METHOD_FLAG_CONST)) {
 						// Enum types are static and cannot change, therefore we skip non-const dictionary methods.
 						continue;
 					}
+					// Method for a built-in type.
+					// 		"Hello".beg...  # <-- will suggest `begins_with(...)`
 					ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
+					option.deprecated = deprecated_methods.has(E.name);
 					if (p_add_braces) {
 						if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
 							option.insert_text += "(";
@@ -1602,9 +1867,28 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	List<StringName> functions;
 	GDScriptUtilityFunctions::get_function_list(&functions);
 
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
+	HashSet<String> deprecated_methods;
+	if (class_doc_map) {
+		if (!class_doc_map->has("@GDScript")) {
+			print_error(R"(Class "@GDScript" couldn't be found in doc data.)");
+		} else {
+			for (const DocData::MethodDoc &method_doc : class_doc_map->get("@GDScript").methods) {
+				if (method_doc.is_deprecated) {
+					deprecated_methods.insert(method_doc.name);
+				}
+			}
+		}
+	}
+
 	for (const StringName &E : functions) {
 		MethodInfo function = GDScriptUtilityFunctions::get_function_info(E);
+		// Method in the `@GDScript` namespace/class.
+		// 		Col...  # <-- will suggest `Color8(...)`
+
 		ScriptLanguage::CodeCompletionOption option(String(E), ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
+		option.deprecated = deprecated_methods.has(String(E));
 		if (p_add_braces) {
 			if (function.arguments.size() || (function.flags & METHOD_FLAG_VARARG)) {
 				option.insert_text += "(";
@@ -1631,6 +1915,8 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	const char **kw = _keywords;
 	while (*kw) {
+		// Keyword with no arguments or operands.
+		// 		tr...  # <-- will suggest `true`
 		ScriptLanguage::CodeCompletionOption option(*kw, ScriptLanguage::CODE_COMPLETION_KIND_KEYWORD);
 		r_result.insert(option.display, option);
 		kw++;
@@ -1644,6 +1930,8 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	const char **kws = _keywords_with_space;
 	while (*kws) {
+		// Keyword separated from its arguments/operands by spaces.
+		// 		class_n...  # <-- will suggest `class_name`
 		ScriptLanguage::CodeCompletionOption option(*kws, ScriptLanguage::CODE_COMPLETION_KIND_KEYWORD);
 		option.insert_text += " ";
 		r_result.insert(option.display, option);
@@ -1657,6 +1945,8 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	const char **kwa = _keywords_with_args;
 	while (*kwa) {
+		// Keyword that takes its arguments inside parentheses, similarly to functions.
+		// 		prel...  # <-- will suggest `preload(...)`
 		ScriptLanguage::CodeCompletionOption option(*kwa, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 		if (p_add_braces) {
 			option.insert_text += "(";
@@ -1670,6 +1960,8 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	Variant::get_utility_function_list(&utility_func_names);
 
 	for (const StringName &util_func_name : utility_func_names) {
+		// Function in the global scope.
+		// 		pri...  # <-- will suggest `print(...)`
 		ScriptLanguage::CodeCompletionOption option(util_func_name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 		if (p_add_braces) {
 			option.insert_text += "(";
@@ -1682,17 +1974,44 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 		if (!E.value.is_singleton) {
 			continue;
 		}
+
+		// Autoload with a global variable name.
+		// 		MyAu...  # <-- will suggest `MyAutoload` (if the user has set that in Project Settings > Globals).
 		ScriptLanguage::CodeCompletionOption option(E.key, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
+		if (class_doc_map && class_doc_map->has(E.key)) {
+			option.deprecated = class_doc_map->get(E.key).is_deprecated;
+		}
 		r_result.insert(option.display, option);
 	}
 
 	// Native classes and global constants.
 	for (const KeyValue<StringName, int> &E : GDScriptLanguage::get_singleton()->get_global_map()) {
 		ScriptLanguage::CodeCompletionOption option;
+		String name = E.key.string();
 		if (GDScriptAnalyzer::class_exists(E.key) || Engine::get_singleton()->has_singleton(E.key)) {
-			option = ScriptLanguage::CodeCompletionOption(E.key.string(), ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
+			// Native class name.
+			// 		Ani...  # <-- will suggest `AnimationPlayer`
+			option = ScriptLanguage::CodeCompletionOption(name, ScriptLanguage::CODE_COMPLETION_KIND_CLASS);
+			if (class_doc_map && class_doc_map->has(name)) {
+				option.deprecated = class_doc_map->get(name).is_deprecated;
+			}
 		} else {
-			option = ScriptLanguage::CodeCompletionOption(E.key.string(), ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
+			// Global constants.
+			// 		SIDE_LE...  # <-- will suggest `SIDE_LEFT`
+			option = ScriptLanguage::CodeCompletionOption(name, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
+
+			if (class_doc_map) {
+				if (!class_doc_map->has("@GlobalScope")) {
+					print_error(R"(Class "@GlobalScope" couldn't be found in doc data.)");
+				} else {
+					for (const DocData::ConstantDoc &constant_doc : class_doc_map->get("@GlobalScope").constants) {
+						if (constant_doc.name == name) {
+							option.deprecated = constant_doc.is_deprecated;
+							break;
+						}
+					}
+				}
+			}
 		}
 		r_result.insert(option.display, option);
 	}
@@ -1704,7 +2023,12 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	LocalVector<StringName> global_classes;
 	ScriptServer::get_global_class_list(global_classes);
 	for (const StringName &class_name : global_classes) {
+		// Classes registered using `class_name`.
+		// 		MyCl...  # <-- will suggest `MyClass`, if the user has written `class_name MyClass` in a script
 		ScriptLanguage::CodeCompletionOption option(class_name, ScriptLanguage::CODE_COMPLETION_KIND_CLASS, ScriptLanguage::LOCATION_OTHER_USER_CODE);
+		if (class_doc_map && class_doc_map->has(class_name)) {
+			option.deprecated = class_doc_map->get(class_name).is_deprecated;
+		}
 		r_result.insert(option.display, option);
 	}
 }
@@ -2966,19 +3290,33 @@ static bool _guess_expecting_callable(GDScriptParser::CompletionContext &p_conte
 }
 
 static void _find_enumeration_candidates(GDScriptParser::CompletionContext &p_context, const String &p_enum_hint, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_result) {
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
 	if (!p_enum_hint.contains_char('.')) {
 		// Global constant or in the current class.
 		StringName current_enum = p_enum_hint;
 		if (p_context.current_class && p_context.current_class->has_member(current_enum) && p_context.current_class->get_member(current_enum).type == GDScriptParser::ClassNode::Member::ENUM) {
 			const GDScriptParser::EnumNode *_enum = p_context.current_class->get_member(current_enum).m_enum;
 			for (int i = 0; i < _enum->values.size(); i++) {
+				// Enum value when the enum belongs to the current class.
+				// 		class_name MyClass
+				//		enum MyEnum { ONE, TWO }
+				//		func print_enum(v: MyEnum): print(v)
+				//		func _ready():
+				//			print_enum(...  # <-- should suggest `ONE`, `TWO`
 				ScriptLanguage::CodeCompletionOption option(_enum->values[i].identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_ENUM);
+				option.deprecated = _enum->doc_data.is_deprecated;
 				r_result.insert(option.display, option);
 			}
 		} else {
 			for (int i = 0; i < CoreConstants::get_global_constant_count(); i++) {
 				if (CoreConstants::get_global_constant_enum(i) == current_enum) {
+					// Global constant enum value for a native class's method.
+					// 		my_control.set_anchor(...  # <-- will suggest `SIDE_BOTTOM` and others from `@GlobalScope.Side`
 					ScriptLanguage::CodeCompletionOption option(CoreConstants::get_global_constant_name(i), ScriptLanguage::CODE_COMPLETION_KIND_ENUM);
+					if (class_doc_map && class_doc_map->has("@GlobalScope") && class_doc_map->get("@GlobalScope").enums.has(CoreConstants::get_global_constant_name(i))) {
+						option.deprecated = class_doc_map->get("@GlobalScope").enums.get(CoreConstants::get_global_constant_name(i)).is_deprecated;
+					}
 					r_result.insert(option.display, option);
 				}
 			}
@@ -2993,10 +3331,30 @@ static void _find_enumeration_candidates(GDScriptParser::CompletionContext &p_co
 
 		List<StringName> enum_constants;
 		ClassDB::get_enum_constants(class_name, enum_name, &enum_constants);
+
+		// Build set of deprecated enum constants.
+		HashSet<String> deprecated_consts;
+		if (class_doc_map) {
+			if (!class_doc_map->has(class_name)) {
+				print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", class_name));
+			} else {
+				for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(class_name).constants) {
+					if (constant_doc.is_deprecated) {
+						deprecated_consts.insert(constant_doc.name);
+					}
+				}
+			}
+		}
+
 		for (const StringName &E : enum_constants) {
 			String candidate = class_name + "." + E;
 			int location = _get_enum_constant_location(class_name, E);
+			// Native enum value for a context with a native enum type.
+			// 		extends Control
+			//		func _ready():
+			//			set_anchors_and_offsets_preset(...  # <-- will suggest `Control.PRESET_TOP_LEFT` and others from `Control.LayoutPreset`
 			ScriptLanguage::CodeCompletionOption option(candidate, ScriptLanguage::CODE_COMPLETION_KIND_ENUM, location);
+			option.deprecated = deprecated_consts.has(E);
 			r_result.insert(option.display, option);
 		}
 	}
@@ -3454,6 +3812,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	}
 	bool is_function = false;
 
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
 	switch (completion_context.type) {
 		case GDScriptParser::COMPLETION_NONE:
 		case GDScriptParser::COMPLETION_DECLARATION:
@@ -3483,6 +3843,18 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			{
 				List<StringName> constants;
 				Variant::get_constants_for_type(completion_context.builtin_type, &constants);
+				const String variant_name = Variant::get_type_name(completion_context.builtin_type);
+
+				// Create set of deprecated constants within this Variant.
+				HashSet<String> deprecated_consts;
+				if (class_doc_map) {
+					for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(variant_name).constants) {
+						if (constant_doc.is_deprecated) {
+							deprecated_consts.insert(constant_doc.name);
+						}
+					}
+				}
+
 				for (const StringName &E : constants) {
 					ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_CONSTANT);
 					bool valid = false;
@@ -3490,6 +3862,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					if (valid) {
 						option.default_value = default_value;
 					}
+					option.deprecated = deprecated_consts.has(E);
 					options.insert(option.display, option);
 				}
 			}
@@ -3497,6 +3870,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			{
 				List<StringName> methods;
 				Variant::get_builtin_method_list(completion_context.builtin_type, &methods);
+
 				for (const StringName &E : methods) {
 					if (Variant::is_builtin_method_static(completion_context.builtin_type, E)) {
 						ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -35,6 +35,7 @@
 #include "gdscript_utility_functions.h"
 
 #ifdef TOOLS_ENABLED
+#include "editor/doc/editor_help.h"
 #include "editor/gdscript_docgen.h"
 #include "editor/gdscript_editor_language.h"
 #include "editor/script_templates/templates.gen.h"
@@ -1138,11 +1139,18 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 		r_result.insert(variant_option.display, variant_option);
 	}
 
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
 	LocalVector<StringName> native_types;
 	ClassDB::get_class_list(native_types);
 	for (const StringName &type : native_types) {
 		if (ClassDB::is_class_exposed(type) && !Engine::get_singleton()->has_singleton(type)) {
+			// Native class, when used as a type.
+			// 		var my_var: No...  # <-- will suggest `Node2D`
 			EditorLanguage::CompletionOption option(type, EditorLanguage::CompletionKind::CLASS);
+			if (class_doc_map && class_doc_map->has(type)) {
+				option.deprecated = class_doc_map->get(type).is_deprecated;
+			}
 			r_result.insert(option.display, option);
 		}
 	}
@@ -1150,11 +1158,18 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 	// TODO: Unify with _find_identifiers_in_class.
 	if (p_context.current_class) {
 		if (!p_inherit_only && p_context.current_class->base_type.is_set()) {
-			// Native enums from base class
+			// Native enum from parent class, when used as a type.
+			//		extends AnimationPlayer
+			//		...
+			// 		var i: Anim...  # <-- Will suggest `AnimationProcessCallback`
 			List<StringName> enums;
-			ClassDB::get_enum_list(p_context.current_class->base_type.native_type, &enums);
+			const String base_native_type = p_context.current_class->base_type.native_type;
+			ClassDB::get_enum_list(base_native_type, &enums);
 			for (const StringName &E : enums) {
 				EditorLanguage::CompletionOption option(E, EditorLanguage::CompletionKind::ENUM);
+				if (class_doc_map && class_doc_map->has(base_native_type) && class_doc_map->get(base_native_type).enums.has(E)) {
+					option.deprecated = class_doc_map->get(base_native_type).enums.get(E).is_deprecated;
+				}
 				r_result.insert(option.display, option);
 			}
 		}
@@ -1166,18 +1181,36 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 			for (const GDScriptParser::ClassNode::Member &member : current->members) {
 				switch (member.type) {
 					case GDScriptParser::ClassNode::Member::CLASS: {
+						// Inner class (that is, class within this class file defined
+						// with `class`), when used to define a variable's type.
+						// 		var inner_inst: InnerCl...  # <-- will suggest `InnerClass`
 						EditorLanguage::CompletionOption option(member.m_class->identifier->name, EditorLanguage::CompletionKind::CLASS, EditorLanguage::CompletionLocation::LOCAL + location_offset);
+						option.deprecated = member.m_class->doc_data.is_deprecated;
 						r_result.insert(option.display, option);
 					} break;
 					case GDScriptParser::ClassNode::Member::ENUM: {
 						if (!p_inherit_only) {
+							// Named enum within this class, when used to define
+							// a variable's type.
+							// e.g.,
+							// 		var current_state: MyEn...  # <-- will suggest `MyEnum`
 							EditorLanguage::CompletionOption option(member.m_enum->identifier->name, EditorLanguage::CompletionKind::ENUM, EditorLanguage::CompletionLocation::LOCAL + location_offset);
+							option.deprecated = member.m_enum->doc_data.is_deprecated;
 							r_result.insert(option.display, option);
 						}
 					} break;
 					case GDScriptParser::ClassNode::Member::CONSTANT: {
 						if (member.constant->type_constraint.is_meta_type) {
+							// Preloaded type within this script.
+							// const MyType = preload("res://my_type.gd")
+							// var m: MyT... # <-- will suggest MyType
 							EditorLanguage::CompletionOption option(member.constant->identifier->name, EditorLanguage::CompletionKind::CLASS, EditorLanguage::CompletionLocation::LOCAL + location_offset);
+
+							bool held_class_is_deprecated = false;
+							if (member.constant->type_constraint.class_type) {
+								held_class_is_deprecated = member.constant->type_constraint.class_type->doc_data.is_deprecated;
+							}
+							option.deprecated = held_class_is_deprecated || member.constant->doc_data.is_deprecated;
 							r_result.insert(option.display, option);
 						}
 					} break;
@@ -1194,7 +1227,13 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 	LocalVector<StringName> global_classes;
 	ScriptServer::get_global_class_list(global_classes);
 	for (const StringName &class_name : global_classes) {
+		// Global classes (that is, classes defined with `class_name`), when used
+		// as a type declaration.
+		// 		var my_var: SomeCl...  # <-- will suggest `SomeClass`
 		EditorLanguage::CompletionOption option(class_name, EditorLanguage::CompletionKind::CLASS, EditorLanguage::CompletionLocation::OTHER_USER_CODE);
+		if (class_doc_map && class_doc_map->has(class_name)) {
+			option.deprecated = class_doc_map->get(class_name).is_deprecated;
+		}
 		r_result.insert(option.display, option);
 	}
 
@@ -1209,7 +1248,12 @@ static void _list_available_types(bool p_inherit_only, GDScriptParser::Completio
 		if (!info.is_singleton || !info.path.has_extension("gd")) {
 			continue;
 		}
+		// Autoload global variable names, when used as a type declaration.
+		// 		var my_autoload: GameAu...  # <-- will suggest `GameAutoload`
 		EditorLanguage::CompletionOption option(info.name, EditorLanguage::CompletionKind::CLASS, EditorLanguage::CompletionLocation::OTHER_USER_CODE);
+		if (class_doc_map && class_doc_map->has(info.name)) {
+			option.deprecated = class_doc_map->get(info.name).is_deprecated;
+		}
 		r_result.insert(option.display, option);
 	}
 }
@@ -1221,8 +1265,12 @@ static void _find_identifiers_in_suite(const GDScriptParser::SuiteNode *p_suite,
 		if (local.type == GDScriptParser::SuiteNode::Local::CONSTANT) {
 			option = EditorLanguage::CompletionOption(local.name, EditorLanguage::CompletionKind::CONSTANT, location);
 			option.default_value = local.constant->initializer->reduced_value;
+			option.deprecated = local.constant->doc_data.is_deprecated;
 		} else {
 			option = EditorLanguage::CompletionOption(local.name, EditorLanguage::CompletionKind::VARIABLE, location);
+			if (local.type == GDScriptParser::SuiteNode::Local::VARIABLE) {
+				option.deprecated = local.variable->doc_data.is_deprecated;
+			}
 		}
 		r_result.insert(option.display, option);
 	}
@@ -1249,43 +1297,83 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 						if (p_types_only || p_only_functions || outer || (p_static && !member.variable->is_static)) {
 							continue;
 						}
+						// Property of a class.
+						// 		var my_var = 3
+						//		func _ready():
+						// 			print(my_v...  # <-- will suggest `my_var`.
 						option = EditorLanguage::CompletionOption(member.variable->identifier->name, EditorLanguage::CompletionKind::MEMBER_VARIABLE, location);
+						option.deprecated = member.variable->doc_data.is_deprecated;
 						break;
-					case GDScriptParser::ClassNode::Member::CONSTANT:
+					case GDScriptParser::ClassNode::Member::CONSTANT: {
 						if ((p_types_only && !member.constant->type_constraint.is_meta_type) || p_only_functions) {
 							continue;
 						}
 						if (r_result.has(member.constant->identifier->name)) {
 							continue;
 						}
+						// Constant in a class.
+						// 		const MY_CONST = 3
+						//		func _ready():
+						// 			print(MY_CON...  # <-- will suggest `MY_CONST`
 						option = EditorLanguage::CompletionOption(member.constant->identifier->name, EditorLanguage::CompletionKind::CONSTANT, location);
+
+						// This constant holds a script class, so we should check
+						// if the script class is itself deprecated.
+						bool held_class_is_deprecated = false;
+						if (member.constant->type_constraint.is_meta_type && member.constant->type_constraint.class_type) {
+							held_class_is_deprecated = member.constant->type_constraint.class_type->doc_data.is_deprecated;
+						}
+						option.deprecated = held_class_is_deprecated || member.constant->doc_data.is_deprecated;
 						if (member.constant->initializer) {
 							option.default_value = member.constant->initializer->reduced_value;
 						}
 						break;
+					}
 					case GDScriptParser::ClassNode::Member::CLASS:
 						if (p_only_functions) {
 							continue;
 						}
+						// Inner class in a class.
+						// 		class MyInnerClass:
+						//			pass
+						//		func _ready():
+						// 			print(MyInn...  # <-- will suggest `MyInnerClass`
 						option = EditorLanguage::CompletionOption(member.m_class->identifier->name, EditorLanguage::CompletionKind::CLASS, location);
+						option.deprecated = member.m_class->doc_data.is_deprecated;
 						break;
 					case GDScriptParser::ClassNode::Member::ENUM_VALUE:
 						if (p_types_only || p_only_functions) {
 							continue;
 						}
+						// Value from an anonymous enum in a class.
+						// 		enum { ONE, TWO }
+						//		func _ready():
+						// 			print(ON...  # <-- will suggest `ONE`
 						option = EditorLanguage::CompletionOption(member.enum_value.identifier->name, EditorLanguage::CompletionKind::CONSTANT, location);
+						option.deprecated = member.enum_value.doc_data.is_deprecated;
 						break;
 					case GDScriptParser::ClassNode::Member::ENUM:
 						if (p_only_functions) {
 							continue;
 						}
+						// Name of an enum in a class.
+						// 		enum MyEnum { ONE, TWO }
+						//		func _ready():
+						// 			print(MyEn...  # <-- will suggest `MyEnum`
 						option = EditorLanguage::CompletionOption(member.m_enum->identifier->name, EditorLanguage::CompletionKind::ENUM, location);
+						option.deprecated = member.m_enum->doc_data.is_deprecated;
 						break;
 					case GDScriptParser::ClassNode::Member::FUNCTION:
 						if (p_types_only || outer || (p_static && !member.function->is_static) || member.function->identifier->name.string().begins_with("@")) {
 							continue;
 						}
+						// Method in a class.
+						// 		func say_hello():
+						//			print("Hello!")
+						//		func _ready():
+						// 			print(say_he...  # <-- will suggest `say_hello()`
 						option = EditorLanguage::CompletionOption(member.function->identifier->name, EditorLanguage::CompletionKind::FUNCTION, location);
+						option.deprecated = member.function->doc_data.is_deprecated;
 						if (p_add_braces) {
 							if (member.function->parameters.size() > 0 || (member.function->info.flags & METHOD_FLAG_VARARG)) {
 								option.insert_text += "(";
@@ -1300,7 +1388,12 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 						if (p_types_only || p_only_functions || outer || p_static) {
 							continue;
 						}
+						// Signal in a class.
+						// 		signal something_happened
+						//		func _ready():
+						// 			something_hap...  # <-- will suggest `something_happened`
 						option = EditorLanguage::CompletionOption(member.signal->identifier->name, EditorLanguage::CompletionKind::SIGNAL, location);
+						option.deprecated = member.signal->doc_data.is_deprecated;
 						break;
 					case GDScriptParser::ClassNode::Member::GROUP:
 						break; // No-op, but silences warnings.
@@ -1332,7 +1425,11 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 	GDScriptParser::DataType base_type = p_base.type;
 
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
 	if (!p_types_only && base_type.is_meta_type && base_type.kind != GDScriptParser::DataType::BUILTIN && base_type.kind != GDScriptParser::DataType::ENUM) {
+		// Constructor for a class.
+		// 		var i = AnimatedSprite2D.n...  # <-- will suggest `new(...)`
 		EditorLanguage::CompletionOption option("new", EditorLanguage::CompletionKind::FUNCTION, EditorLanguage::CompletionLocation::LOCAL);
 		if (p_add_braces) {
 			option.insert_text += "(";
@@ -1342,6 +1439,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 	}
 
 	while (!base_type.has_no_type()) {
+		// This HashSet is declared up here because it works across both
+		// the ENUM and BUILTIN cases.
+		HashSet<String> deprecated_values;
 		switch (base_type.kind) {
 			case GDScriptParser::DataType::CLASS: {
 				_find_identifiers_in_class(base_type.class_type, p_only_functions, p_types_only, base_type.is_meta_type, false, p_add_braces, r_result, p_recursion_depth);
@@ -1357,6 +1457,17 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						if (!base_type.is_meta_type) {
 							List<PropertyInfo> members;
 							scr->get_script_property_list(&members);
+
+							HashSet<StringName> deprecated_properties;
+
+							if (class_doc_map && class_doc_map->has(scr->get_doc_class_name())) {
+								for (const DocData::PropertyDoc &property : class_doc_map->get(scr->get_doc_class_name()).properties) {
+									if (property.is_deprecated) {
+										deprecated_properties.insert(property.name);
+									}
+								}
+							}
+
 							for (const PropertyInfo &E : members) {
 								if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 									continue;
@@ -1365,26 +1476,55 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 									continue;
 								}
 								int location = p_recursion_depth + _get_property_location(scr, E.name);
+
+								// Property in a Script type (such as a C# script).
 								EditorLanguage::CompletionOption option(E.name, EditorLanguage::CompletionKind::MEMBER_VARIABLE, location);
+								option.deprecated = deprecated_properties.has(E.name);
 								r_result.insert(option.display, option);
 							}
 
 							List<MethodInfo> signals;
 							scr->get_script_signal_list(&signals);
+
+							HashSet<StringName> deprecated_signals;
+							if (class_doc_map && class_doc_map->has(scr->get_doc_class_name())) {
+								for (const DocData::MethodDoc &signal_doc : class_doc_map->get(scr->get_doc_class_name()).signals) {
+									if (signal_doc.is_deprecated) {
+										deprecated_signals.insert(signal_doc.name);
+									}
+								}
+							}
+
 							for (const MethodInfo &E : signals) {
 								if (E.name.begins_with("_")) {
 									continue;
 								}
 								int location = p_recursion_depth + _get_signal_location(scr, E.name);
+
+								// Signal in a Script type (such as a C# script).
 								EditorLanguage::CompletionOption option(E.name, EditorLanguage::CompletionKind::SIGNAL, location);
+								option.deprecated = deprecated_signals.has(E.name);
 								r_result.insert(option.display, option);
 							}
 						}
 						HashMap<StringName, Variant> constants;
 						scr->get_constants(&constants);
+
+						HashSet<StringName> deprecated_consts;
+						if (class_doc_map && class_doc_map->has(scr->get_doc_class_name())) {
+							for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(scr->get_doc_class_name()).constants) {
+								if (constant_doc.is_deprecated) {
+									deprecated_consts.insert(constant_doc.name);
+								}
+							}
+						}
+
 						for (const KeyValue<StringName, Variant> &E : constants) {
 							int location = p_recursion_depth + _get_constant_location(scr, E.key);
+
+							// Constant in a Script type (such as a C# script).
 							EditorLanguage::CompletionOption option(E.key.string(), EditorLanguage::CompletionKind::CONSTANT, location);
+							option.deprecated = deprecated_consts.has(E.key.string());
 							r_result.insert(option.display, option);
 						}
 					}
@@ -1397,6 +1537,8 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 								continue;
 							}
 							int location = p_recursion_depth + _get_method_location(scr->get_class_name(), E.name);
+
+							// Method in a Script type (such as a C# script).
 							EditorLanguage::CompletionOption option(E.name, EditorLanguage::CompletionKind::FUNCTION, location);
 							if (p_add_braces) {
 								if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
@@ -1433,6 +1575,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 				ClassDB::get_enum_list(type, &enums);
 				for (const StringName &E : enums) {
 					int location = p_recursion_depth + _get_enum_location(type, E);
+					// Enum names for a native class.
+					//		TextureRe...  # <-- will suggest `TextureRepeat`
+					// 		AnimationPlayer.AnimationPro...  # <-- will suggest `AnimationProcessCallback`
 					EditorLanguage::CompletionOption option(E, EditorLanguage::CompletionKind::ENUM, location);
 					r_result.insert(option.display, option);
 				}
@@ -1443,16 +1588,47 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				if (!p_only_functions) {
 					List<String> constants;
+
+					HashSet<String> deprecated_consts;
+					if (class_doc_map) {
+						if (!class_doc_map->has(type)) {
+							print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+						} else {
+							for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(type).constants) {
+								if (constant_doc.is_deprecated) {
+									deprecated_consts.insert(constant_doc.name);
+								}
+							}
+						}
+					}
+
 					ClassDB::get_integer_constant_list(type, &constants);
 					for (const String &E : constants) {
 						int location = p_recursion_depth + _get_constant_location(type, StringName(E));
+						// Constant in a native class.
+						// 		NOTIFICATION_DR...  # <-- Will suggest `NOTIFICATION_DRAW`
 						EditorLanguage::CompletionOption option(E, EditorLanguage::CompletionKind::CONSTANT, location);
+						option.deprecated = deprecated_consts.has(E);
 						r_result.insert(option.display, option);
 					}
 
 					if (!base_type.is_meta_type || Engine::get_singleton()->has_singleton(type)) {
 						List<PropertyInfo> pinfo;
 						ClassDB::get_property_list(type, &pinfo);
+
+						HashSet<String> deprecated_properties;
+						if (class_doc_map) {
+							if (!class_doc_map->has(type)) {
+								print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+							} else {
+								for (const DocData::PropertyDoc &property_doc : class_doc_map->get(type).properties) {
+									if (property_doc.is_deprecated) {
+										deprecated_properties.insert(property_doc.name);
+									}
+								}
+							}
+						}
+
 						for (const PropertyInfo &E : pinfo) {
 							if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 								continue;
@@ -1461,18 +1637,42 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 								continue;
 							}
 							int location = p_recursion_depth + _get_property_location(type, E.name);
+
+							// Property in a native class.
+							// 		var my_node = Node2D.new()
+							// 		my_node.pos...  # <-- will suggest `position`
 							EditorLanguage::CompletionOption option(E.name, EditorLanguage::CompletionKind::MEMBER_VARIABLE, location);
+							option.deprecated = deprecated_properties.has(E.name);
 							r_result.insert(option.display, option);
 						}
 
 						List<MethodInfo> signals;
 						ClassDB::get_signal_list(type, &signals);
+
+						HashSet<String> deprecated_signals;
+						if (class_doc_map) {
+							if (!class_doc_map->has(type)) {
+								print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+							} else {
+								for (const DocData::MethodDoc &signal_doc : class_doc_map->get(type).signals) {
+									if (signal_doc.is_deprecated) {
+										deprecated_signals.insert(signal_doc.name);
+									}
+								}
+							}
+						}
+
 						for (const MethodInfo &E : signals) {
 							if (E.name.begins_with("_")) {
 								continue;
 							}
 							int location = p_recursion_depth + _get_signal_location(type, StringName(E.name));
+
+							// Signal in a native class.
+							// 		var my_node = AnimatedSprite2D.new()
+							// 		my_node.anim...  # <-- will suggest `animation_changed`
 							EditorLanguage::CompletionOption option(E.name, EditorLanguage::CompletionKind::SIGNAL, location);
+							option.deprecated = deprecated_signals.has(E.name);
 							r_result.insert(option.display, option);
 						}
 					}
@@ -1500,6 +1700,21 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				List<MethodInfo> methods;
 				ClassDB::get_method_list(type, &methods, false);
+
+				// Assemble a set of deprecated method names.
+				HashSet<String> deprecated_methods;
+				if (class_doc_map) {
+					if (!class_doc_map->has(type)) {
+						print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+					} else {
+						for (const DocData::MethodDoc &method_doc : class_doc_map->get(type).methods) {
+							if (method_doc.is_deprecated) {
+								deprecated_methods.insert(method_doc.name);
+							}
+						}
+					}
+				}
+
 				for (const MethodInfo &E : methods) {
 					if (only_static && (E.flags & METHOD_FLAG_STATIC) == 0) {
 						continue;
@@ -1511,7 +1726,12 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						continue;
 					}
 					int location = p_recursion_depth + _get_method_location(type, E.name);
+
+					// Method name in a native class.
+					// 		var my_node = AnimatedSprite2D.new()
+					// 		my_node.get_pl...  # <-- will suggest `get_playing_speed`
 					EditorLanguage::CompletionOption option(E.name, EditorLanguage::CompletionKind::FUNCTION, location);
+					option.deprecated = deprecated_methods.has(E.name);
 					if (p_add_braces) {
 						if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
 							option.insert_text += "(";
@@ -1543,9 +1763,34 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						ClassDB::get_enum_constants(type, type_enum, &enum_values);
 					}
 
+					if (base_type.class_type && base_type.kind == GDScriptParser::DataType::ENUM) {
+						const GDScriptParser::EnumNode *_enum = base_type.class_type->get_member(type_enum).m_enum;
+						for (const GDScriptParser::EnumNode::Value &enum_value : _enum->values) {
+							if (enum_value.doc_data.is_deprecated) {
+								deprecated_values.insert(enum_value.identifier->name);
+							}
+						}
+					} else {
+						if (class_doc_map) {
+							if (!class_doc_map->has(type)) {
+								print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", type));
+							} else {
+								for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(type).constants) {
+									if (constant_doc.is_deprecated) {
+										deprecated_values.insert(constant_doc.name);
+									}
+								}
+							}
+						}
+					}
+
 					for (const StringName &E : enum_values) {
 						int location = p_recursion_depth + _get_enum_constant_location(type, E);
+
+						// Enum value from a named enum in another class.
+						// 		CanvasItem.ClipChildrenMode.CLI...  # <-- will suggest `CLIP_CHILDREN_DISABLED`
 						EditorLanguage::CompletionOption option(E, EditorLanguage::CompletionKind::CONSTANT, location);
+						option.deprecated = deprecated_values.has(E);
 						r_result.insert(option.display, option);
 					}
 				} else if (CoreConstants::is_global_enum(base_type.enum_type)) {
@@ -1582,6 +1827,8 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						tmp.get_property_list(&members);
 					}
 
+					// Handles members from Variant types. Since named enums are
+					// internally the Dictionary type, they are also handled here.
 					for (const PropertyInfo &E : members) {
 						if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 							continue;
@@ -1591,6 +1838,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 							if (base_type.kind == GDScriptParser::DataType::ENUM) {
 								// Sort enum members in their declaration order.
 								location += 1;
+								option.deprecated = deprecated_values.has(E.name);
 							}
 							if (GDScriptParser::theme_color_names.has(E.name)) {
 								option.theme_color_name = GDScriptParser::theme_color_names[E.name];
@@ -1602,12 +1850,29 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				List<MethodInfo> methods;
 				tmp.get_method_list(&methods);
+
+				HashSet<String> deprecated_methods;
+				if (class_doc_map) {
+					if (!class_doc_map->has(Variant::get_type_name(base_type.builtin_type))) {
+						print_error(vformat(R"(Variant "%s" couldn't be found in doc data.)", Variant::get_type_name(base_type.builtin_type)));
+					} else {
+						for (const DocData::MethodDoc &method_doc : class_doc_map->get(Variant::get_type_name(base_type.builtin_type)).methods) {
+							if (method_doc.is_deprecated) {
+								deprecated_methods.insert(method_doc.name);
+							}
+						}
+					}
+				}
+
 				for (const MethodInfo &E : methods) {
 					if (base_type.kind == GDScriptParser::DataType::ENUM && base_type.is_meta_type && !(E.flags & METHOD_FLAG_CONST)) {
 						// Enum types are static and cannot change, therefore we skip non-const dictionary methods.
 						continue;
 					}
+					// Method for a built-in type.
+					// 		"Hello".beg...  # <-- will suggest `begins_with(...)`
 					EditorLanguage::CompletionOption option(E.name, EditorLanguage::CompletionKind::FUNCTION, location);
+					option.deprecated = deprecated_methods.has(E.name);
 					if (p_add_braces) {
 						if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
 							option.insert_text += "(";
@@ -1642,9 +1907,28 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	List<StringName> functions;
 	GDScriptUtilityFunctions::get_function_list(&functions);
 
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
+	HashSet<String> deprecated_methods;
+	if (class_doc_map) {
+		if (!class_doc_map->has("@GDScript")) {
+			print_error(R"(Class "@GDScript" couldn't be found in doc data.)");
+		} else {
+			for (const DocData::MethodDoc &method_doc : class_doc_map->get("@GDScript").methods) {
+				if (method_doc.is_deprecated) {
+					deprecated_methods.insert(method_doc.name);
+				}
+			}
+		}
+	}
+
 	for (const StringName &E : functions) {
 		MethodInfo function = GDScriptUtilityFunctions::get_function_info(E);
+		// Method in the `@GDScript` namespace/class.
+		// 		Col...  # <-- will suggest `Color8(...)`
+
 		EditorLanguage::CompletionOption option(String(E), EditorLanguage::CompletionKind::FUNCTION);
+		option.deprecated = deprecated_methods.has(String(E));
 		if (p_add_braces) {
 			if (function.arguments.size() || (function.flags & METHOD_FLAG_VARARG)) {
 				option.insert_text += "(";
@@ -1671,6 +1955,8 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	const char **kw = _keywords;
 	while (*kw) {
+		// Keyword with no arguments or operands.
+		// 		tr...  # <-- will suggest `true`
 		EditorLanguage::CompletionOption option(*kw, EditorLanguage::CompletionKind::KEYWORD);
 		r_result.insert(option.display, option);
 		kw++;
@@ -1684,6 +1970,8 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	const char **kws = _keywords_with_space;
 	while (*kws) {
+		// Keyword separated from its arguments/operands by spaces.
+		// 		class_n...  # <-- will suggest `class_name`
 		EditorLanguage::CompletionOption option(*kws, EditorLanguage::CompletionKind::KEYWORD);
 		option.insert_text += " ";
 		r_result.insert(option.display, option);
@@ -1697,6 +1985,8 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	const char **kwa = _keywords_with_args;
 	while (*kwa) {
+		// Keyword that takes its arguments inside parentheses, similarly to functions.
+		// 		prel...  # <-- will suggest `preload(...)`
 		EditorLanguage::CompletionOption option(*kwa, EditorLanguage::CompletionKind::FUNCTION);
 		if (p_add_braces) {
 			option.insert_text += "(";
@@ -1710,6 +2000,8 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	Variant::get_utility_function_list(&utility_func_names);
 
 	for (const StringName &util_func_name : utility_func_names) {
+		// Function in the global scope.
+		// 		pri...  # <-- will suggest `print(...)`
 		EditorLanguage::CompletionOption option(util_func_name, EditorLanguage::CompletionKind::FUNCTION);
 		if (p_add_braces) {
 			option.insert_text += "(";
@@ -1722,17 +2014,44 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 		if (!E.value.is_singleton) {
 			continue;
 		}
+
+		// Autoload with a global variable name.
+		// 		MyAu...  # <-- will suggest `MyAutoload` (if the user has set that in Project Settings > Globals).
 		EditorLanguage::CompletionOption option(E.key, EditorLanguage::CompletionKind::CONSTANT);
+		if (class_doc_map && class_doc_map->has(E.key)) {
+			option.deprecated = class_doc_map->get(E.key).is_deprecated;
+		}
 		r_result.insert(option.display, option);
 	}
 
 	// Native classes and global constants.
 	for (const KeyValue<StringName, int> &E : GDScriptLanguage::get_singleton()->get_global_map()) {
 		EditorLanguage::CompletionOption option;
+		String name = E.key.string();
 		if (GDScriptAnalyzer::class_exists(E.key) || Engine::get_singleton()->has_singleton(E.key)) {
-			option = EditorLanguage::CompletionOption(E.key.string(), EditorLanguage::CompletionKind::CLASS);
+			// Native class name.
+			// 		Ani...  # <-- will suggest `AnimationPlayer`
+			option = EditorLanguage::CompletionOption(name, EditorLanguage::CompletionKind::CLASS);
+			if (class_doc_map && class_doc_map->has(name)) {
+				option.deprecated = class_doc_map->get(name).is_deprecated;
+			}
 		} else {
-			option = EditorLanguage::CompletionOption(E.key.string(), EditorLanguage::CompletionKind::CONSTANT);
+			// Global constants.
+			// 		SIDE_LE...  # <-- will suggest `SIDE_LEFT`
+			option = EditorLanguage::CompletionOption(name, EditorLanguage::CompletionKind::CONSTANT);
+
+			if (class_doc_map) {
+				if (!class_doc_map->has("@GlobalScope")) {
+					print_error(R"(Class "@GlobalScope" couldn't be found in doc data.)");
+				} else {
+					for (const DocData::ConstantDoc &constant_doc : class_doc_map->get("@GlobalScope").constants) {
+						if (constant_doc.name == name) {
+							option.deprecated = constant_doc.is_deprecated;
+							break;
+						}
+					}
+				}
+			}
 		}
 		r_result.insert(option.display, option);
 	}
@@ -1744,7 +2063,12 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	LocalVector<StringName> global_classes;
 	ScriptServer::get_global_class_list(global_classes);
 	for (const StringName &class_name : global_classes) {
+		// Classes registered using `class_name`.
+		// 		MyCl...  # <-- will suggest `MyClass`, if the user has written `class_name MyClass` in a script
 		EditorLanguage::CompletionOption option(class_name, EditorLanguage::CompletionKind::CLASS, EditorLanguage::CompletionLocation::OTHER_USER_CODE);
+		if (class_doc_map && class_doc_map->has(class_name)) {
+			option.deprecated = class_doc_map->get(class_name).is_deprecated;
+		}
 		r_result.insert(option.display, option);
 	}
 }
@@ -3006,19 +3330,33 @@ static bool _guess_expecting_callable(GDScriptParser::CompletionContext &p_conte
 }
 
 static void _find_enumeration_candidates(GDScriptParser::CompletionContext &p_context, const String &p_enum_hint, HashMap<String, EditorLanguage::CompletionOption> &r_result) {
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
 	if (!p_enum_hint.contains_char('.')) {
 		// Global constant or in the current class.
 		StringName current_enum = p_enum_hint;
 		if (p_context.current_class && p_context.current_class->has_member(current_enum) && p_context.current_class->get_member(current_enum).type == GDScriptParser::ClassNode::Member::ENUM) {
 			const GDScriptParser::EnumNode *_enum = p_context.current_class->get_member(current_enum).m_enum;
 			for (const GDScriptParser::EnumNode::Value &value : _enum->values) {
+				// Enum value when the enum belongs to the current class.
+				// 		class_name MyClass
+				//		enum MyEnum { ONE, TWO }
+				//		func print_enum(v: MyEnum): print(v)
+				//		func _ready():
+				//			print_enum(...  # <-- should suggest `ONE`, `TWO`
 				EditorLanguage::CompletionOption option(value.identifier->name, EditorLanguage::CompletionKind::ENUM);
+				option.deprecated = _enum->doc_data.is_deprecated;
 				r_result.insert(option.display, option);
 			}
 		} else {
 			for (int i = 0; i < CoreConstants::get_global_constant_count(); i++) {
 				if (CoreConstants::get_global_constant_enum(i) == current_enum) {
+					// Global constant enum value for a native class's method.
+					// 		my_control.set_anchor(...  # <-- will suggest `SIDE_BOTTOM` and others from `@GlobalScope.Side`
 					EditorLanguage::CompletionOption option(CoreConstants::get_global_constant_name(i), EditorLanguage::CompletionKind::ENUM);
+					if (class_doc_map && class_doc_map->has("@GlobalScope") && class_doc_map->get("@GlobalScope").enums.has(CoreConstants::get_global_constant_name(i))) {
+						option.deprecated = class_doc_map->get("@GlobalScope").enums.get(CoreConstants::get_global_constant_name(i)).is_deprecated;
+					}
 					r_result.insert(option.display, option);
 				}
 			}
@@ -3033,10 +3371,30 @@ static void _find_enumeration_candidates(GDScriptParser::CompletionContext &p_co
 
 		List<StringName> enum_constants;
 		ClassDB::get_enum_constants(class_name, enum_name, &enum_constants);
+
+		// Build set of deprecated enum constants.
+		HashSet<String> deprecated_consts;
+		if (class_doc_map) {
+			if (!class_doc_map->has(class_name)) {
+				print_error(vformat(R"(Class "%s" couldn't be found in doc data.)", class_name));
+			} else {
+				for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(class_name).constants) {
+					if (constant_doc.is_deprecated) {
+						deprecated_consts.insert(constant_doc.name);
+					}
+				}
+			}
+		}
+
 		for (const StringName &E : enum_constants) {
 			String candidate = class_name + "." + E;
 			int location = _get_enum_constant_location(class_name, E);
+			// Native enum value for a context with a native enum type.
+			// 		extends Control
+			//		func _ready():
+			//			set_anchors_and_offsets_preset(...  # <-- will suggest `Control.PRESET_TOP_LEFT` and others from `Control.LayoutPreset`
 			EditorLanguage::CompletionOption option(candidate, EditorLanguage::CompletionKind::ENUM, location);
+			option.deprecated = deprecated_consts.has(E);
 			r_result.insert(option.display, option);
 		}
 	}
@@ -3494,6 +3852,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 	}
 	bool is_function = false;
 
+	const HashMap<String, DocData::ClassDoc> *class_doc_map = EditorHelp::get_doc_data() ? &EditorHelp::get_doc_data()->class_list : nullptr;
+
 	switch (completion_context.type) {
 		case GDScriptParser::COMPLETION_NONE:
 		case GDScriptParser::COMPLETION_DECLARATION:
@@ -3523,6 +3883,18 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			{
 				List<StringName> constants;
 				Variant::get_constants_for_type(completion_context.builtin_type, &constants);
+				const String variant_name = Variant::get_type_name(completion_context.builtin_type);
+
+				// Create set of deprecated constants within this Variant.
+				HashSet<String> deprecated_consts;
+				if (class_doc_map) {
+					for (const DocData::ConstantDoc &constant_doc : class_doc_map->get(variant_name).constants) {
+						if (constant_doc.is_deprecated) {
+							deprecated_consts.insert(constant_doc.name);
+						}
+					}
+				}
+
 				for (const StringName &E : constants) {
 					EditorLanguage::CompletionOption option(E, EditorLanguage::CompletionKind::CONSTANT);
 					bool valid = false;
@@ -3530,6 +3902,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					if (valid) {
 						option.default_value = default_value;
 					}
+					option.deprecated = deprecated_consts.has(E);
 					options.insert(option.display, option);
 				}
 			}
@@ -3537,6 +3910,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			{
 				List<StringName> methods;
 				Variant::get_builtin_method_list(completion_context.builtin_type, &methods);
+
 				for (const StringName &E : methods) {
 					if (Variant::is_builtin_method_static(completion_context.builtin_type, E)) {
 						EditorLanguage::CompletionOption option(E, EditorLanguage::CompletionKind::FUNCTION);

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -163,7 +163,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 		r_symbol.name = path.get_file();
 	}
 	r_symbol.kind = LSP::SymbolKind::Class;
-	r_symbol.deprecated = false;
+	r_symbol.deprecated = p_class->doc_data.is_deprecated;
 	r_symbol.range = range_of_node(p_class);
 	if (p_class->identifier) {
 		r_symbol.selectionRange = range_of_node(p_class->identifier);
@@ -200,7 +200,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				LSP::DocumentSymbol symbol;
 				symbol.name = m.variable->identifier->name;
 				symbol.kind = m.variable->property == VariableNode::PROP_NONE ? LSP::SymbolKind::Variable : LSP::SymbolKind::Property;
-				symbol.deprecated = false;
+				symbol.deprecated = m.variable->doc_data.is_deprecated;
 				symbol.range = range_of_node(m.variable);
 				symbol.selectionRange = range_of_node(m.variable->identifier);
 				if (m.variable->exported) {
@@ -246,7 +246,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 
 				symbol.name = m.constant->identifier->name;
 				symbol.kind = LSP::SymbolKind::Constant;
-				symbol.deprecated = false;
+				symbol.deprecated = m.constant->doc_data.is_deprecated;
 				symbol.range = range_of_node(m.constant);
 				symbol.selectionRange = range_of_node(m.constant->identifier);
 				symbol.documentation = m.constant->doc_data.description;
@@ -286,7 +286,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				LSP::DocumentSymbol symbol;
 				symbol.name = m.signal->identifier->name;
 				symbol.kind = LSP::SymbolKind::Event;
-				symbol.deprecated = false;
+				symbol.deprecated = m.signal->doc_data.is_deprecated;
 				symbol.range = range_of_node(m.signal);
 				symbol.selectionRange = range_of_node(m.signal->identifier);
 				symbol.documentation = m.signal->doc_data.description;
@@ -305,7 +305,6 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 					LSP::DocumentSymbol param_symbol;
 					param_symbol.name = param->identifier->name;
 					param_symbol.kind = LSP::SymbolKind::Variable;
-					param_symbol.deprecated = false;
 					param_symbol.local = true;
 					param_symbol.range = range_of_node(param);
 					param_symbol.selectionRange = range_of_node(param->identifier);
@@ -324,7 +323,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 
 				symbol.name = m.enum_value.identifier->name;
 				symbol.kind = LSP::SymbolKind::EnumMember;
-				symbol.deprecated = false;
+				symbol.deprecated = m.enum_value.doc_data.is_deprecated;
 				symbol.range.start = GodotPosition(m.enum_value.line, m.enum_value.start_column).to_lsp();
 				symbol.range.end = GodotPosition(m.enum_value.line, m.enum_value.end_column).to_lsp();
 				symbol.selectionRange = range_of_node(m.enum_value.identifier);
@@ -360,7 +359,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 
 					child.name = value.identifier->name;
 					child.kind = LSP::SymbolKind::EnumMember;
-					child.deprecated = false;
+					child.deprecated = value.doc_data.is_deprecated;
 					child.range.start = GodotPosition(value.line, value.start_column).to_lsp();
 					child.range.end = GodotPosition(value.line, value.end_column).to_lsp();
 					child.selectionRange = range_of_node(value.identifier);
@@ -405,7 +404,7 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 		r_symbol.detail += " " + String(p_func->identifier->name);
 	}
 	r_symbol.detail += "(";
-	r_symbol.deprecated = false;
+	r_symbol.deprecated = p_func->doc_data.is_deprecated;
 	r_symbol.range = range_of_node(p_func);
 	if (is_named) {
 		r_symbol.selectionRange = range_of_node(p_func->identifier);

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -164,7 +164,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 		r_symbol.name = path.get_file();
 	}
 	r_symbol.kind = LSP::SymbolKind::Class;
-	r_symbol.deprecated = false;
+	r_symbol.deprecated = p_class->doc_data.is_deprecated;
 	r_symbol.range = range_of_node(p_class);
 	if (p_class->identifier) {
 		r_symbol.selectionRange = range_of_node(p_class->identifier);
@@ -199,7 +199,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				LSP::DocumentSymbol symbol;
 				symbol.name = m.variable->identifier->name;
 				symbol.kind = m.variable->property == VariableNode::PROP_NONE ? LSP::SymbolKind::Variable : LSP::SymbolKind::Property;
-				symbol.deprecated = false;
+				symbol.deprecated = m.variable->doc_data.is_deprecated;
 				symbol.range = range_of_node(m.variable);
 				symbol.selectionRange = range_of_node(m.variable->identifier);
 				if (m.variable->exported) {
@@ -245,7 +245,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 
 				symbol.name = m.constant->identifier->name;
 				symbol.kind = LSP::SymbolKind::Constant;
-				symbol.deprecated = false;
+				symbol.deprecated = m.constant->doc_data.is_deprecated;
 				symbol.range = range_of_node(m.constant);
 				symbol.selectionRange = range_of_node(m.constant->identifier);
 				symbol.documentation = m.constant->doc_data.description;
@@ -285,7 +285,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				LSP::DocumentSymbol symbol;
 				symbol.name = m.signal->identifier->name;
 				symbol.kind = LSP::SymbolKind::Event;
-				symbol.deprecated = false;
+				symbol.deprecated = m.signal->doc_data.is_deprecated;
 				symbol.range = range_of_node(m.signal);
 				symbol.selectionRange = range_of_node(m.signal->identifier);
 				symbol.documentation = m.signal->doc_data.description;
@@ -304,7 +304,6 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 					LSP::DocumentSymbol param_symbol;
 					param_symbol.name = param->identifier->name;
 					param_symbol.kind = LSP::SymbolKind::Variable;
-					param_symbol.deprecated = false;
 					param_symbol.local = true;
 					param_symbol.range = range_of_node(param);
 					param_symbol.selectionRange = range_of_node(param->identifier);
@@ -323,7 +322,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 
 				symbol.name = m.enum_value.identifier->name;
 				symbol.kind = LSP::SymbolKind::EnumMember;
-				symbol.deprecated = false;
+				symbol.deprecated = m.enum_value.doc_data.is_deprecated;
 				symbol.range.start = GodotPosition(m.enum_value.line, m.enum_value.start_column).to_lsp();
 				symbol.range.end = GodotPosition(m.enum_value.line, m.enum_value.end_column).to_lsp();
 				symbol.selectionRange = range_of_node(m.enum_value.identifier);
@@ -359,7 +358,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 
 					child.name = value.identifier->name;
 					child.kind = LSP::SymbolKind::EnumMember;
-					child.deprecated = false;
+					child.deprecated = value.doc_data.is_deprecated;
 					child.range.start = GodotPosition(value.line, value.start_column).to_lsp();
 					child.range.end = GodotPosition(value.line, value.end_column).to_lsp();
 					child.selectionRange = range_of_node(value.identifier);
@@ -404,7 +403,7 @@ void ExtendGDScriptParser::parse_function_symbol(const GDScriptParser::FunctionN
 		r_symbol.detail += " " + String(p_func->identifier->name);
 	}
 	r_symbol.detail += "(";
-	r_symbol.deprecated = false;
+	r_symbol.deprecated = p_func->doc_data.is_deprecated;
 	r_symbol.range = range_of_node(p_func);
 	if (is_named) {
 		r_symbol.selectionRange = range_of_node(p_func->identifier);

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -543,6 +543,7 @@ Array GDScriptLanguageProtocol::lsp_completion(const Dictionary &p_params) {
 			item.label = option.display;
 			item.data = request_data;
 			item.insertText = option.insert_text;
+			item.deprecated = option.deprecated;
 
 			// LSP clients won't autoclose brackets.
 			if (client->behavior.use_snippets_for_brace_completion) {

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -541,6 +541,7 @@ Array GDScriptLanguageProtocol::lsp_completion(const Dictionary &p_params) {
 			item.label = option.display;
 			item.data = request_data;
 			item.insertText = option.insert_text;
+			item.deprecated = option.deprecated;
 
 			// LSP clients won't autoclose brackets.
 			if (client->behavior.use_snippets_for_brace_completion) {

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1053,6 +1053,7 @@ struct CompletionItem {
 		dict["label"] = label;
 		dict["kind"] = kind;
 		dict["data"] = data;
+		dict["deprecated"] = deprecated;
 		if (!insertText.is_empty()) {
 			dict["insertText"] = insertText;
 		}

--- a/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Compat.cs
@@ -68,7 +68,7 @@ partial class AnimationTree
 
 partial class CodeEdit
 {
-    /// <inheritdoc cref="AddCodeCompletionOption(CodeCompletionKind, string, string, Nullable{Color}, Resource, Variant, int)"/>
+    /// <inheritdoc cref="AddCodeCompletionOption(CodeCompletionKind, string, string, Nullable{Color}, Resource, Variant, int, bool)"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public void AddCodeCompletionOption(CodeCompletionKind type, string displayText, string insertText, Nullable<Color> textColor, Resource icon, Nullable<Variant> value)
     {

--- a/scene/gui/code_edit.compat.inc
+++ b/scene/gui/code_edit.compat.inc
@@ -42,9 +42,15 @@ void CodeEdit::_add_code_completion_option_bind_compat_84906(CodeCompletionKind 
 	add_code_completion_option(p_type, p_display_text, p_insert_text, p_text_color, p_icon, p_value, p_location);
 }
 
+void CodeEdit::_add_code_completion_option_bind_compat_100019(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location) {
+	add_code_completion_option(p_type, p_display_text, p_insert_text, p_text_color, p_icon, p_value, p_location, false);
+}
+
 void CodeEdit::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_text_for_symbol_lookup"), &CodeEdit::_get_text_for_symbol_lookup_bind_compat_73196);
+
 	ClassDB::bind_compatibility_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location"), &CodeEdit::_add_code_completion_option_bind_compat_84906, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant::NIL), DEFVAL(LOCATION_OTHER));
+	ClassDB::bind_compatibility_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location"), &CodeEdit::_add_code_completion_option_bind_compat_100019, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant()), DEFVAL(LOCATION_OTHER));
 }
 
 #endif // DISABLE_DEPRECATED

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -404,6 +404,19 @@ void CodeEdit::_notification(int p_what) {
 							tl->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 						}
 
+						if (code_completion_options[i].deprecated) {
+							RID rid = tl->get_rid();
+							double l_ascent = TS->shaped_text_get_ascent(rid);
+							float st_width = MAX(1.0, TS->shaped_text_get_underline_thickness(rid) * get_theme_default_base_scale());
+
+							RS::get_singleton()->canvas_item_add_line(
+									ci,
+									Vector2(title_pos.x, title_pos.y + l_ascent / 2 + st_width / 2),
+									Vector2(title_pos.x + tl->get_line_width(), title_pos.y + l_ascent / 2 + st_width / 2),
+									code_completion_options[l].font_color,
+									st_width);
+						}
+
 						Point2 match_pos = Point2(code_completion_rect.position.x + icon_area_size.x + theme_cache.code_completion_icon_separation, code_completion_rect.position.y + i * row_height);
 
 						for (int j = 0; j < code_completion_options[l].matches.size(); j++) {
@@ -2513,7 +2526,7 @@ void CodeEdit::request_code_completion(bool p_force) {
 	queue_accessibility_update();
 }
 
-void CodeEdit::add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location) {
+void CodeEdit::add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location, bool p_deprecated) {
 	ScriptLanguage::CodeCompletionOption completion_option;
 	completion_option.kind = (ScriptLanguage::CodeCompletionKind)p_type;
 	completion_option.display = p_display_text;
@@ -2522,6 +2535,7 @@ void CodeEdit::add_code_completion_option(CodeCompletionKind p_type, const Strin
 	completion_option.icon = p_icon;
 	completion_option.default_value = p_value;
 	completion_option.location = p_location;
+	completion_option.deprecated = p_deprecated;
 	code_completion_option_submitted.push_back(completion_option);
 }
 
@@ -2548,6 +2562,7 @@ TypedArray<Dictionary> CodeEdit::get_code_completion_options() const {
 		option["icon"] = code_completion_options[i].icon;
 		option["location"] = code_completion_options[i].location;
 		option["default_value"] = code_completion_options[i].default_value;
+		option["deprecated"] = code_completion_options[i].deprecated;
 		completion_options[i] = option;
 	}
 	return completion_options;
@@ -2567,6 +2582,7 @@ Dictionary CodeEdit::get_code_completion_option(int p_index) const {
 	option["icon"] = code_completion_options[p_index].icon;
 	option["location"] = code_completion_options[p_index].location;
 	option["default_value"] = code_completion_options[p_index].default_value;
+	option["deprecated"] = code_completion_options[p_index].deprecated;
 	return option;
 }
 
@@ -3189,7 +3205,7 @@ void CodeEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_text_for_code_completion"), &CodeEdit::get_text_for_code_completion);
 	ClassDB::bind_method(D_METHOD("request_code_completion", "force"), &CodeEdit::request_code_completion, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location"), &CodeEdit::add_code_completion_option, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant()), DEFVAL(LOCATION_OTHER));
+	ClassDB::bind_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location", "deprecated"), &CodeEdit::add_code_completion_option, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant()), DEFVAL(LOCATION_OTHER), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("update_code_completion_options", "force"), &CodeEdit::update_code_completion_options);
 	ClassDB::bind_method(D_METHOD("get_code_completion_options"), &CodeEdit::get_code_completion_options);
 	ClassDB::bind_method(D_METHOD("get_code_completion_option", "index"), &CodeEdit::get_code_completion_option);
@@ -3826,6 +3842,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 			option["icon"] = E.icon;
 			option["default_value"] = E.default_value;
 			option["location"] = E.location;
+			option["deprecated"] = E.deprecated;
 			completion_options_sources[i] = option;
 			i++;
 		}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -406,6 +406,19 @@ void CodeEdit::_notification(int p_what) {
 							tl->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 						}
 
+						if (code_completion_options[i].deprecated) {
+							RID rid = tl->get_rid();
+							double l_ascent = TS->shaped_text_get_ascent(rid);
+							float st_width = MAX(1.0, TS->shaped_text_get_underline_thickness(rid) * get_theme_default_base_scale());
+
+							RS::get_singleton()->canvas_item_add_line(
+									ci,
+									Vector2(title_pos.x, title_pos.y + l_ascent / 2 + st_width / 2),
+									Vector2(title_pos.x + tl->get_line_width(), title_pos.y + l_ascent / 2 + st_width / 2),
+									code_completion_options[l].font_color,
+									st_width);
+						}
+
 						Point2 match_pos = Point2(code_completion_rect.position.x + icon_area_size.x + theme_cache.code_completion_icon_separation, code_completion_rect.position.y + i * row_height);
 
 						for (int j = 0; j < code_completion_options[l].matches.size(); j++) {
@@ -2519,7 +2532,7 @@ void CodeEdit::request_code_completion(bool p_force) {
 	queue_accessibility_update();
 }
 
-void CodeEdit::add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location) {
+void CodeEdit::add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location, bool p_deprecated) {
 	CodeCompletionOption completion_option;
 	completion_option.kind = (CodeCompletionKind)p_type;
 	completion_option.display = p_display_text;
@@ -2528,6 +2541,7 @@ void CodeEdit::add_code_completion_option(CodeCompletionKind p_type, const Strin
 	completion_option.icon = p_icon;
 	completion_option.default_value = p_value;
 	completion_option.location = p_location;
+	completion_option.deprecated = p_deprecated;
 	code_completion_option_submitted.push_back(completion_option);
 }
 
@@ -2555,6 +2569,7 @@ TypedArray<Dictionary> CodeEdit::get_code_completion_options() const {
 		option["icon"] = code_completion_options[i].icon;
 		option["location"] = code_completion_options[i].location;
 		option["default_value"] = code_completion_options[i].default_value;
+		option["deprecated"] = code_completion_options[i].deprecated;
 		completion_options[i] = option;
 	}
 	return completion_options;
@@ -2574,6 +2589,7 @@ Dictionary CodeEdit::get_code_completion_option(int p_index) const {
 	option["icon"] = code_completion_options[p_index].icon;
 	option["location"] = code_completion_options[p_index].location;
 	option["default_value"] = code_completion_options[p_index].default_value;
+	option["deprecated"] = code_completion_options[p_index].deprecated;
 	return option;
 }
 
@@ -3197,7 +3213,7 @@ void CodeEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_text_for_code_completion"), &CodeEdit::get_text_for_code_completion);
 	ClassDB::bind_method(D_METHOD("request_code_completion", "force"), &CodeEdit::request_code_completion, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location"), &CodeEdit::add_code_completion_option, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant()), DEFVAL(LOCATION_OTHER));
+	ClassDB::bind_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location", "deprecated"), &CodeEdit::add_code_completion_option, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant()), DEFVAL(LOCATION_OTHER), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("update_code_completion_options", "force"), &CodeEdit::update_code_completion_options);
 	ClassDB::bind_method(D_METHOD("get_code_completion_options"), &CodeEdit::get_code_completion_options);
 	ClassDB::bind_method(D_METHOD("get_code_completion_option", "index"), &CodeEdit::get_code_completion_option);
@@ -3885,6 +3901,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 			option["icon"] = E.icon;
 			option["default_value"] = E.default_value;
 			option["location"] = E.location;
+			option["deprecated"] = E.deprecated;
 			completion_options_sources[i] = option;
 			i++;
 		}

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -328,6 +328,7 @@ protected:
 #ifndef DISABLE_DEPRECATED
 	String _get_text_for_symbol_lookup_bind_compat_73196();
 	void _add_code_completion_option_bind_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant::NIL, int p_location = LOCATION_OTHER);
+	void _add_code_completion_option_bind_compat_100019(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant(), int p_location = LOCATION_OTHER);
 	static void _bind_compatibility_methods();
 #endif
 
@@ -497,7 +498,7 @@ public:
 
 	void request_code_completion(bool p_force = false);
 
-	void add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant(), int p_location = LOCATION_OTHER);
+	void add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant(), int p_location = LOCATION_OTHER, bool p_deprecated = false);
 	void update_code_completion_options(bool p_forced = false);
 
 	TypedArray<Dictionary> get_code_completion_options() const;

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -217,6 +217,7 @@ private:
 		Vector<Pair<int, int>> matches;
 		bool matches_dirty = true; // Must be set when mutating `matches`, so that sorting characteristics are recalculated.
 		int location = LOCATION_OTHER;
+		bool deprecated = false;
 
 		TypedArray<int> get_option_characteristics(const String &p_base);
 		void clear_characteristics();
@@ -356,6 +357,7 @@ protected:
 #ifndef DISABLE_DEPRECATED
 	String _get_text_for_symbol_lookup_bind_compat_73196();
 	void _add_code_completion_option_bind_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant::NIL, int p_location = LOCATION_OTHER);
+	void _add_code_completion_option_bind_compat_100019(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant(), int p_location = LOCATION_OTHER);
 	static void _bind_compatibility_methods();
 #endif
 
@@ -525,7 +527,7 @@ public:
 
 	void request_code_completion(bool p_force = false);
 
-	void add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant(), int p_location = LOCATION_OTHER);
+	void add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant(), int p_location = LOCATION_OTHER, bool p_deprecated = false);
 	void update_code_completion_options(bool p_forced = false);
 
 	TypedArray<Dictionary> get_code_completion_options() const;

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -4071,7 +4071,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			code_edit->set_code_completion_selected_index(1);
 			ERR_PRINT_ON;
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
-			CHECK(code_edit->get_code_completion_option(0).size() == 7);
+			CHECK(code_edit->get_code_completion_option(0).size() == 8);
 			CHECK(code_edit->get_code_completion_options().size() == 1);
 
 			/* Check cancel closes completion. */
@@ -4082,7 +4082,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			CHECK(code_edit->get_code_completion_selected_index() == 0);
 			code_edit->set_code_completion_selected_index(1);
 			CHECK(code_edit->get_code_completion_selected_index() == 1);
-			CHECK(code_edit->get_code_completion_option(0).size() == 7);
+			CHECK(code_edit->get_code_completion_option(0).size() == 8);
 			CHECK(code_edit->get_code_completion_options().size() == 3);
 
 			/* Check data. */
@@ -4093,6 +4093,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			CHECK(option["font_color"] == Color(1, 0, 0));
 			CHECK(option["icon"] == Ref<Resource>());
 			CHECK(option["default_value"] == Color(1, 0, 0));
+			CHECK(option["deprecated"] == Variant(false));
 
 			/* Set size for mouse input. */
 			code_edit->set_size(Size2(100, 100));


### PR DESCRIPTION
Related to https://github.com/godotengine/godot-proposals/issues/11079 !

This PR adds the ability for code completions from the language server to be marked as deprecated, according to the class documentation, so that they can be displayed as such in a code editor. It also implements this display for the built-in script editor:

In Godot's built-in script editor:
![CleanShot 2024-12-04 at 09 58 12@2x](https://github.com/user-attachments/assets/a74334b8-3c06-42a0-b03f-71f9f726d920)

In VS Code:
![CleanShot 2024-12-04 at 09 59 08@2x](https://github.com/user-attachments/assets/1d4f197f-48bd-43a6-b9a1-02f81fa567d0)

## Tested cases
### Methods
<details>

<summary>A user-defined method marked with `@deprecated`</summary>

```gdscript
## This method is deprecated.
## @deprecated
func do_something():
    print("Hello world")

func _ready():
	# do_something will show as deprecated
	do_som... 
```

</details>

<details>

<summary>A class built-in to Godot and marked as deprecated in the documentation</summary>

```gdscript
func _ready():
	var player = AnimationPlayer.new()
	# get_method_call_mode will show as deprecated
	player.get_method_c... 
```

</details>

### Classes

<details>

<summary>Main class of a file marked with `@deprecated`</summary>

```gdscript
class_name MyOldClass
extends Node

## This class is deprecated.
## @deprecated
```

```gdscript
# main.gd
extends Node

func _ready():
	# MyOldClass will show as deprecated
    var i = MyOl... 

```

</details>

<details>

<summary>Inner class marked with `@deprecated`</summary>

```gdscript
## This inner class is deprecated.
## @deprecated
class InnerDeprecatedClass:
	pass

func _ready():
	# InnerDeprecatedClass will show as deprecated
	var i = InnerDep...
```

</details>

<details>

<summary>A class built-in to Godot and marked as deprecated in the documentation</summary>

```gdscript
func _ready():
	# AnimatedTexture will show as deprecated
	var i = AnimatedTex...
```

</details>

<details>

<summary>A class built-in to Godot and marked as deprecated in the documentation, used as a type</summary>

```gdscript
func _ready():
	# AnimatedTexture will show as deprecated
	var i: AnimatedTex...
```

</details>

<details>

<summary>An autoload with a global variable name</summary>

```gdscript
# deprecated_autoload.gd
extends Node

## This autoload is registered with the name DeprecatedAutoload,
## and is marked as deprecated.
## @deprecated

func do_thing():
   print("a thing has been done")
```

```gdscript
# main.gd
func _ready():
    # DeprecatedAutoload will show as deprecated
    DeprecatedAu...
```

> [!WARNING]
> I've found this doesn't always work. It seems to involve something with the `.godot` folder preventing the doc data from being fully parsed, so I think it's outside the scope of this PR to try to fix.


</details>

### Enums and constants

<details>

<summary>
A user-defined constant, marked with `@deprecated`
</summary>

```gdscript
## This is a deprecated constant.
## @deprecated
const DEPRECATED_CONST = "hello"

func _ready():
	# DEPRECATED_CONST will show as deprecated
	print(DEPRECATED_CON...
```

</details>

<details>

<summary>A user-defined named enum, marked with `@deprecated`</summary>

```gdscript
## This is a deprecated enum.
## @deprecated
enum DeprecatedEnum { ONE, TWO, THREE }

func _ready():
	# DeprecatedEnum will show as deprecated
	print(Depre...
```

</details>

<details>

<summary>Individual values in a user-defined anonymous enum, marked with `@deprecated`</summary>

```gdscript
enum {
    ANONYMOUS_ONE,
    ## This one is deprecated
    ## @deprecated
    ANONYMOUS_TWO
}

func _ready():
	# ANONYMOUS_TWO will show as deprecated
	print(ANONYMOUS_T...
```

</details>

<details>

<summary>Individual values in a user-defined named enum, marked with `@deprecated`</summary>

```gdscript
enum NamedEnum {
	ONE,
	## This is a deprecated constant in an enum.
	## @deprecated
	TWO
}

func _ready():
	# NamedEnum.TWO will show as deprecated
	print(NamedEnum.TW... 
```

</details>

<details>

<summary>Individual values in an enum from a class built-in to Godot and marked as deprecated in the documentation</summary>

```gdscript
func _ready():
	# ANIMATION_PROCESS_PHYSICS will show as deprecated
	var i = AnimationPlayer.ANIMATION_PROCESS_PH...

	# Will also show as deprecated
	i = AnimationPlayer.AnimationProcessCallback.ANIMATION_PROCESS_PH...
```

</details>

<details>

<summary>Constants in `@GlobalScope`</summary>

```gdscript
func _ready():
	# PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE will show as deprecated
	print(PROPERTY_HINT_NODE_PATH_T...
```

</details>

### Properties

<details>

<summary>A user-defined property marked with `@deprecated`</summary>

```gdscript
## This is a deprecated property.
## @deprecated
var deprecated_property: float = 1.0

## This is a deprecated property with a getter and setter.
## @deprecated
var deprecated_property_2: float = 2.0:
    get:
        return sqrt(5)
    set(value):
        deprecated_property_2 = value

func _ready():
	# deprecated_property and deprecated_property_2 will show as deprecated
	print(deprecated_prop...
```

</details>

<details>

<summary>A class built-in to Godot and marked as deprecated in the documentation</summary>

```gdscript
func _ready():
	# auto_translate will show as deprecated
    var i = Control.new().auto_tr...
```

</details>

### Signals

<details>

<summary>A user-defined signal marked with `@deprecated`</summary>

```gdscript
## This is a deprecated signal.
## @deprecated
signal deprecated_signal

func _ready():
	# deprecated_signal will show as deprecated
	depreca...
```

</details>

<details>

<summary>A class built-in to Godot and marked as deprecated in the documentation</summary>

```gdscript
func _ready():
	# setup_local_to_scene_requested will show as deprecated
	Resource.new().setup_local_t...
```

</details>

## To-Do
### Language server
- [x] Fix behavior with autoloads (determine how to retrieve their class's `DocData`)
- [x] General clean-up of code structure - it's messy right now! (Maybe add some static methods for getting is-deprecated hashmaps?)
   - I've tried to standardize the variable names used so I think it's better now, but would still appreciate suggestions if you have them!
### Godot Script editor
- [x] Ensure the strikethrough scales correctly as the editor scale is changed