### PR TITLE
Core: Avoid including `modules/modules_enabled.gen.h` in headers

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -4410,7 +4410,6 @@ EditorHelpBitTooltip::EditorHelpBitTooltip(Control *p_target) {
 	set_process_internal(true);
 }
 
-#if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
 /// EditorHelpHighlighter ///
 
 EditorHelpHighlighter *EditorHelpHighlighter::singleton = nullptr;
@@ -4575,8 +4574,6 @@ EditorHelpHighlighter::~EditorHelpHighlighter() {
 	memdelete(text_edits[LANGUAGE_CSHARP]);
 #endif
 }
-
-#endif // defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
 
 /// FindBar ///
 

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -40,8 +40,6 @@
 #include "scene/gui/text_edit.h"
 #include "scene/main/timer.h"
 
-#include "modules/modules_enabled.gen.h" // For gdscript, mono.
-
 class FindBar : public HBoxContainer {
 	GDCLASS(FindBar, HBoxContainer);
 
@@ -360,7 +358,6 @@ public:
 	EditorHelpBitTooltip(Control *p_target);
 };
 
-#if defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)
 class EditorSyntaxHighlighter;
 
 class EditorHelpHighlighter {
@@ -395,4 +392,3 @@ public:
 	EditorHelpHighlighter();
 	virtual ~EditorHelpHighlighter();
 };
-#endif // defined(MODULE_GDSCRIPT_ENABLED) || defined(MODULE_MONO_ENABLED)

--- a/modules/gdscript/language_server/gdscript_language_protocol.h
+++ b/modules/gdscript/language_server/gdscript_language_protocol.h
@@ -36,12 +36,7 @@
 #include "core/io/stream_peer_tcp.h"
 #include "core/io/tcp_server.h"
 
-#include "modules/modules_enabled.gen.h" // For jsonrpc.
-#ifdef MODULE_JSONRPC_ENABLED
 #include "modules/jsonrpc/jsonrpc.h"
-#else
-#error "Can't build GDScript LSP without JSONRPC module."
-#endif
 
 #define LSP_MAX_BUFFER_SIZE 4194304
 #define LSP_MAX_CLIENTS 8

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -32,6 +32,10 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "modules/modules_enabled.gen.h" // For jsonrpc.
+
+#ifdef MODULE_JSONRPC_ENABLED
+
 #include "tests/test_macros.h"
 
 #include "../language_server/gdscript_extend_parser.h"
@@ -505,5 +509,7 @@ func f():
 }
 
 } // namespace GDScriptTests
+
+#endif // MODULE_JSONRPC_ENABLED
 
 #endif // TOOLS_ENABLED

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -62,6 +62,15 @@
 #include "editor/editor_file_system.h"
 #endif
 
+#include "modules/modules_enabled.gen.h" // For csg, gridmap.
+
+#ifdef MODULE_CSG_ENABLED
+#include "modules/csg/csg_shape.h"
+#endif
+#ifdef MODULE_GRIDMAP_ENABLED
+#include "modules/gridmap/grid_map.h"
+#endif
+
 // FIXME: Hardcoded to avoid editor dependency.
 #define GLTF_IMPORT_GENERATE_TANGENT_ARRAYS 8
 #define GLTF_IMPORT_USE_NAMED_SKIN_BINDS 16
@@ -5912,8 +5921,10 @@ void GLTFDocument::_convert_scene_node(Ref<GLTFState> p_state, Node *p_current, 
 	}
 }
 
-#ifdef MODULE_CSG_ENABLED
 void GLTFDocument::_convert_csg_shape_to_gltf(CSGShape3D *p_current, GLTFNodeIndex p_gltf_parent, Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state) {
+#ifndef MODULE_CSG_ENABLED
+	ERR_FAIL_MSG("csg module is disabled.");
+#else
 	CSGShape3D *csg = p_current;
 	csg->call("_update_shape");
 	Array meshes = csg->get_meshes();
@@ -5964,8 +5975,8 @@ void GLTFDocument::_convert_csg_shape_to_gltf(CSGShape3D *p_current, GLTFNodeInd
 	p_gltf_node->transform = csg->get_transform();
 	p_gltf_node->set_original_name(csg->get_name());
 	p_gltf_node->set_name(_gen_unique_name(p_state, csg->get_name()));
-}
 #endif // MODULE_CSG_ENABLED
+}
 
 void GLTFDocument::_check_visibility(Node *p_node, bool &r_retflag) {
 	r_retflag = true;
@@ -5996,8 +6007,10 @@ void GLTFDocument::_convert_light_to_gltf(Light3D *light, Ref<GLTFState> p_state
 	}
 }
 
-#ifdef MODULE_GRIDMAP_ENABLED
 void GLTFDocument::_convert_grid_map_to_gltf(GridMap *p_grid_map, GLTFNodeIndex p_parent_node_index, GLTFNodeIndex p_root_node_index, Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state) {
+#ifndef MODULE_GRIDMAP_ENABLED
+	ERR_FAIL_MSG("gridmap module is disabled.");
+#else
 	Array cells = p_grid_map->get_used_cells();
 	for (int32_t k = 0; k < cells.size(); k++) {
 		GLTFNode *new_gltf_node = memnew(GLTFNode);
@@ -6025,8 +6038,8 @@ void GLTFDocument::_convert_grid_map_to_gltf(GridMap *p_grid_map, GLTFNodeIndex 
 		new_gltf_node->set_original_name(p_grid_map->get_mesh_library()->get_item_name(cell));
 		new_gltf_node->set_name(_gen_unique_name(p_state, p_grid_map->get_mesh_library()->get_item_name(cell)));
 	}
-}
 #endif // MODULE_GRIDMAP_ENABLED
+}
 
 void GLTFDocument::_convert_multi_mesh_instance_to_gltf(
 		MultiMeshInstance3D *p_multi_mesh_instance,

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -38,13 +38,8 @@
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/multimesh_instance_3d.h"
 
-#include "modules/modules_enabled.gen.h" // For csg, gridmap.
-#ifdef MODULE_CSG_ENABLED
-#include "modules/csg/csg_shape.h"
-#endif // MODULE_CSG_ENABLED
-#ifdef MODULE_GRIDMAP_ENABLED
-#include "modules/gridmap/grid_map.h"
-#endif // MODULE_GRIDMAP_ENABLED
+class CSGShape3D;
+class GridMap;
 
 class GLTFDocument : public Resource {
 	GDCLASS(GLTFDocument, Resource);
@@ -339,20 +334,16 @@ public:
 			const GLTFNodeIndex p_gltf_current,
 			const GLTFNodeIndex p_gltf_root);
 
-#ifdef MODULE_CSG_ENABLED
 	void _convert_csg_shape_to_gltf(CSGShape3D *p_current, GLTFNodeIndex p_gltf_parent, Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state);
-#endif // MODULE_CSG_ENABLED
 
 	void _check_visibility(Node *p_node, bool &r_retflag);
 	void _convert_camera_to_gltf(Camera3D *p_camera, Ref<GLTFState> p_state,
 			Ref<GLTFNode> p_gltf_node);
-#ifdef MODULE_GRIDMAP_ENABLED
 	void _convert_grid_map_to_gltf(
 			GridMap *p_grid_map,
 			GLTFNodeIndex p_parent_node_index,
 			GLTFNodeIndex p_root_node_index,
 			Ref<GLTFNode> p_gltf_node, Ref<GLTFState> p_state);
-#endif // MODULE_GRIDMAP_ENABLED
 	void _convert_multi_mesh_instance_to_gltf(
 			MultiMeshInstance3D *p_multi_mesh_instance,
 			GLTFNodeIndex p_parent_node_index,

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include "thorvg_svg_in_ot.h"
+
 #ifdef GDEXTENSION
 // Headers for building as GDExtension plug-in.
 
@@ -54,8 +56,6 @@ using namespace godot;
 
 #ifdef MODULE_SVG_ENABLED
 #ifdef MODULE_FREETYPE_ENABLED
-
-#include "thorvg_svg_in_ot.h"
 
 #include <freetype/otsvg.h>
 #include <ft2build.h>

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include "thorvg_svg_in_ot.h"
+
 #ifdef GDEXTENSION
 // Headers for building as GDExtension plug-in.
 
@@ -54,8 +56,6 @@ using namespace godot;
 
 #ifdef MODULE_SVG_ENABLED
 #ifdef MODULE_FREETYPE_ENABLED
-
-#include "thorvg_svg_in_ot.h"
 
 #include <freetype/otsvg.h>
 #include <ft2build.h>


### PR DESCRIPTION
- Alternative to #99302

Because `modules/modules_enabled.gen.h` regenerates anytime a module is changed, this causes **all** files with this header to necessitate a rebuild. For definition files this is generally fine, but header files can cause cascading recompilations across dozens, if not hundreds, of unnecessary files. Taking the test format from #99302, the refactors from this PR resulted in:

<details>
<summary>Results</summary>

```
scons: Building targets ...
[  4%] Generating modules\modules_enabled.gen.h ...
[ 79%] Compiling editor\editor_node.cpp ...
[ 79%] Generating modules\register_module_types.gen.cpp ...
[ 79%] Generating modules\modules_tests.gen.h ...
[ 79%] Compiling modules\register_module_types.gen.cpp ...
[ 79%] Compiling tests\test_main.cpp ...
[ 79%] Compiling modules\navigation\3d\nav_mesh_generator_3d.cpp ...
[ 79%] Compiling editor\scene_tree_dock.cpp ...
[ 79%] Compiling modules\gdscript\language_server\gdscript_workspace.cpp ...
[ 79%] Compiling editor\themes\editor_icons.cpp ...
[ 79%] Compiling platform\windows\export\export_plugin.cpp ...
[ 79%] Compiling modules\gdscript\language_server\gdscript_language_protocol.cpp ...
[ 79%] Compiling scene\theme\default_theme.cpp ...
[ 79%] Compiling platform\macos\export\export_plugin.cpp ...
[ 79%] Compiling scene\gui\rich_text_label.cpp ...
[ 79%] Compiling platform\web\export\export_plugin.cpp ...
[ 79%] Compiling modules\text_server_fb\register_types.cpp ...
[ 79%] Compiling modules\text_server_adv\thorvg_svg_in_ot.cpp ...
[ 79%] Compiling editor\export\codesign.cpp ...
[ 79%] Compiling editor\plugins\bone_map_editor_plugin.cpp ...
[ 79%] Compiling modules\gdscript\language_server\gdscript_language_server.cpp ...
[ 79%] Compiling platform\ios\export\export_plugin.cpp ...
[ 79%] Compiling modules\gdscript\language_server\gdscript_extend_parser.cpp ...
[ 79%] Compiling modules\navigation\3d\godot_navigation_server_3d.cpp ...
[ 79%] Compiling editor\project_converter_3_to_4.cpp ...
[ 79%] Compiling main\main.cpp ...
[ 79%] Compiling scene\resources\shader.cpp ...
[ 79%] Compiling platform\android\export\export_plugin.cpp ...
[ 79%] Compiling editor\rename_dialog.cpp ...
[ 79%] Compiling editor\editor_help.cpp ...
[ 79%] Compiling modules\gdscript\language_server\gdscript_text_document.cpp ...
[ 79%] Compiling editor\doc_tools.cpp ...
[ 80%] Compiling platform\linuxbsd\export\export_plugin.cpp ...
[ 80%] Compiling modules\gltf\gltf_document.cpp ...
[ 80%] Linking Static Library modules\modules.windows.editor.dev.x86_64.lib ...
[ 80%] Compiling modules\text_server_adv\register_types.cpp ...
[ 80%] Compiling editor\import\resource_importer_dynamic_font.cpp ...
[ 80%] Compiling modules\text_server_adv\text_server_adv.cpp ...
[ 80%] Compiling editor\register_editor_types.cpp ...
[ 80%] Compiling core\io\logger.cpp ...
[ 80%] Compiling modules\text_server_fb\text_server_fb.cpp ...
[ 80%] Compiling modules\gdscript\register_types.cpp ...
[ 80%] Compiling core\config\project_settings.cpp ...
[ 80%] Compiling modules\text_server_fb\thorvg_svg_in_ot.cpp ...
[ 80%] Linking Static Library modules\module_navigation.windows.editor.dev.x86_64.lib ...
[ 81%] Linking Static Library scene\scene.windows.editor.dev.x86_64.lib ...
[ 85%] Linking Static Library core\core.windows.editor.dev.x86_64.lib ...
[ 85%] Linking Static Library modules\module_gltf.windows.editor.dev.x86_64.lib ...
[ 88%] Linking Static Library main\main.windows.editor.dev.x86_64.lib ...
[ 88%] Linking Static Library modules\module_text_server_fb.windows.editor.dev.x86_64.lib ...
[ 89%] Linking Static Library modules\module_gdscript.windows.editor.dev.x86_64.lib ...
[ 92%] Linking Static Library modules\module_text_server_adv.windows.editor.dev.x86_64.lib ...
[ 97%] Building compilation database compile_commands.json
[ 99%] Linking Static Library editor\editor.windows.editor.dev.x86_64.lib ...
[100%] Building node count database .scons_node_count
[100%] Linking Static Library tests\tests.windows.editor.dev.x86_64.lib ...
[100%] Linking Program bin\godot.windows.editor.dev.x86_64.exe ...
[100%] Linking Program bin\godot.windows.editor.dev.x86_64.console.exe ...
[100%] scons: done building targets.
[Time elapsed: 00:01:00.56]
```
</details>
So while this doesn't reach the peak speed of #99302's implementation, those speeds were only possible by fundamentally changing how modules were parsed. Not only does this PR leave the module logic itself entirely untouched, but it does so while improving compile time threefold!