### PR TITLE
Use a vec4 instead of an array in canvas shader instance buffer

### DIFF
--- a/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
@@ -37,7 +37,7 @@ struct InstanceData {
 
 #endif
 	vec2 color_texture_pixel_size;
-	uint lights[4];
+	uvec4 lights;
 };
 
 //1 means enabled, 2+ means trails in use


### PR DESCRIPTION
This avoids a pathological performance cliff on Adreno devices

I noticed a regression between dev2 and dev3 in 2D rendering performance. I finally took the time to investigate it last night. I found that on my Pixel 4 (Adreno 640) frame time roughly tripled (from 15 FPS down to 5 FPS) in the [isometric 2D](https://github.com/godotengine/godot-demo-projects/tree/master/2d/isometric) demo.

The regression was most likely caused by the move to batching which is very weird as batching barely affects the shader code. 

I ran a profiler over the demo and found something very odd. The profiler showed shader processor memory bandwidth use go from 16mb/s to 6.5GB/s. I expected that this scene would be ALU bound due to the high number of lights. 

After a lot of investigation, I accidentally stumbled on the cause. Adreno doesn't like having an array inside a struct inside of an array. We can easily fix that since vectors can be indexed like arrays. Simply by changing the `lights` member into a `uvec4` we reclaim all the performance we lost. Non-Adreno devices don't care one way or the other, so this ends up being a very safe fix. 