### PR TITLE
Fix vertical alignment of the main menu bar

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7173,6 +7173,7 @@ EditorNode::EditorNode() {
 	main_menu = memnew(MenuBar);
 	main_menu->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 	title_bar->add_child(main_menu);
+	main_menu->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	main_menu->set_theme_type_variation("MainMenuBar");
 	main_menu->set_start_index(0); // Main menu, add to the start of global menu.
 	main_menu->set_prefer_global_menu(global_menu);


### PR DESCRIPTION
The menu bar wasn't centered vertically. This appears to be more noticeable on macOS because the buttons on the left give it away, but it should make it look a bit better on other OSes as well since they'll be aligned with the other stuff in the top bar

![g](https://github.com/user-attachments/assets/ba10d18d-2544-479c-84b9-f7a2235a4818)
