### PR TITLE
Optimize Callable's stringify text.

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -361,8 +361,12 @@ Callable::operator String() const {
 		if (base) {
 			String class_name = base->get_class();
 			Ref<Script> script = base->get_script();
-			if (script.is_valid() && script->get_path().is_resource_file()) {
-				class_name += "(" + script->get_path().get_file() + ")";
+			if (script.is_valid()) {
+				if (!script->get_global_name().is_empty()) {
+					class_name += "(" + script->get_global_name() + ")";
+				} else if (script->get_path().is_resource_file()) {
+					class_name += "(" + script->get_path().get_file() + ")";
+				}
 			}
 			return class_name + "::" + String(method);
 		} else {

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -178,12 +178,12 @@ uint32_t GDScriptLambdaSelfCallable::hash() const {
 
 String GDScriptLambdaSelfCallable::get_as_text() const {
 	if (function == nullptr) {
-		return "<invalid lambda>";
+		return "<invalid self lambda>";
 	}
 	if (function->get_name() != StringName()) {
-		return function->get_name().operator String() + "(lambda)";
+		return function->get_name().operator String() + "(self lambda)";
 	}
-	return "(anonymous lambda)";
+	return "(anonymous self lambda)";
 }
 
 CallableCustom::CompareEqualFunc GDScriptLambdaSelfCallable::get_compare_equal_func() const {

--- a/modules/gdscript/gdscript_rpc_callable.cpp
+++ b/modules/gdscript/gdscript_rpc_callable.cpp
@@ -49,7 +49,14 @@ uint32_t GDScriptRPCCallable::hash() const {
 String GDScriptRPCCallable::get_as_text() const {
 	String class_name = object->get_class();
 	Ref<Script> script = object->get_script();
-	return class_name + "(" + script->get_path().get_file() + ")::" + String(method) + " (rpc)";
+	if (script.is_valid()) {
+		if (!script->get_global_name().is_empty()) {
+			class_name += "(" + script->get_global_name() + ")";
+		} else if (script->get_path().is_resource_file()) {
+			class_name += "(" + script->get_path().get_file() + ")";
+		}
+	}
+	return class_name + "::" + String(method) + " (rpc)";
 }
 
 CallableCustom::CompareEqualFunc GDScriptRPCCallable::get_compare_equal_func() const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

`GDScriptLambdaSelfCallable` and `GDScriptLambdaCallable` are used similarly, but `GDScriptLambdaSelfCallable` will become invalid when its member `object` is freed.
The mainly purpose of this pr is to distinguish between `GDScriptLambdaSelfCallable` and `GDScriptLambdaCallable`, provides more information to help debugging (maybe we should discussion about the naming of "self lambda").

And I make callable try to use its script instance's global name instead of use script file path directly by passing.