### PR TITLE
Make `backward` be parameter of the `AnimationTree` in the `AnimationNodeAnimation`

### DIFF
--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -36,6 +36,8 @@
 class AnimationNodeAnimation : public AnimationRootNode {
 	GDCLASS(AnimationNodeAnimation, AnimationRootNode);
 
+	StringName backward = "backward"; // Only used by pingpong animation.
+
 	StringName animation;
 
 	bool advance_on_start = false;
@@ -56,6 +58,7 @@ public:
 	};
 
 	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual NodeTimeInfo get_node_time_info() const override; // Wrapper of get_parameter().
 
@@ -100,7 +103,6 @@ protected:
 
 private:
 	PlayMode play_mode = PLAY_MODE_FORWARD;
-	bool backward = false; // Only used by pingpong animation.
 };
 
 VARIANT_ENUM_CAST(AnimationNodeAnimation::PlayMode)


### PR DESCRIPTION
- Fixes #100018

Properties that need to be managed for each AnimationTree should be parameterized for the same reason as https://github.com/godotengine/godot/issues/22887.