### PR TITLE
GitHub Actions: Use quiet xmllint output to only print error lines

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Class reference schema checks
         run: |
-          xmllint --noout --schema doc/class.xsd doc/classes/*.xml modules/*/doc_classes/*.xml platform/*/doc_classes/*.xml
+          xmllint --quiet --noout --schema doc/class.xsd doc/classes/*.xml modules/*/doc_classes/*.xml platform/*/doc_classes/*.xml
 
       - name: Run C compiler on `gdextension_interface.h`
         run: |


### PR DESCRIPTION
Success lines are no longer printed, making the CI log shorter and faster to read.

[This was originally not done because of the Ubuntu version used on CI](https://github.com/godotengine/godot/pull/35679#issuecomment-1039660482), but it can safely be done now.
