### PR TITLE
Fix `String.num_scientific()`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1979,14 +1979,14 @@ String String::num_scientific(double p_num) {
 	// MinGW requires _set_output_format() to conform to C99 output for printf
 	unsigned int old_exponent_format = _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
-	snprintf(buf, 256, "%lg", p_num);
+	snprintf(buf, 256, "%lE", p_num);
 
 #if defined(__MINGW32__) && defined(_TWO_DIGIT_EXPONENT) && !defined(_UCRT)
 	_set_output_format(old_exponent_format);
 #endif
 
 #else
-	sprintf(buf, "%.16lg", p_num);
+	sprintf(buf, "%.16lE", p_num);
 #endif
 
 	buf[255] = 0;


### PR DESCRIPTION
Fixes #99763

New results:
```
-1.234500E+01
-1.234500E+05
-1.234500E+06
-1.234568E+08
```
Tested the same numbers in C# and the results are consistent.

EDIT:
Looks like the method was used incorrectly so simply fixing it won't work.
![image](https://github.com/user-attachments/assets/ca0e9069-796c-46d4-9326-0f8a5db385f3)
