### PR TITLE
Fix discarded input event metadata in `xformed_by`

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -754,6 +754,8 @@ Ref<InputEvent> InputEventMouseButton::xformed_by(const Transform2D &p_xform, co
 	mb->set_factor(factor);
 	mb->set_button_index(button_index);
 
+	mb->merge_meta_from(this);
+
 	return mb;
 }
 
@@ -973,6 +975,8 @@ Ref<InputEvent> InputEventMouseMotion::xformed_by(const Transform2D &p_xform, co
 	mm->set_relative_screen_position(get_relative_screen_position());
 	mm->set_velocity(p_xform.basis_xform(get_velocity()));
 	mm->set_screen_velocity(get_screen_velocity());
+
+	mm->merge_meta_from(this);
 
 	return mm;
 }
@@ -1366,6 +1370,8 @@ Ref<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &p_xform, co
 	st->set_canceled(canceled);
 	st->set_double_tap(double_tap);
 
+	st->merge_meta_from(this);
+
 	return st;
 }
 
@@ -1493,6 +1499,8 @@ Ref<InputEvent> InputEventScreenDrag::xformed_by(const Transform2D &p_xform, con
 	sd->set_relative_screen_position(get_relative_screen_position());
 	sd->set_velocity(p_xform.basis_xform(velocity));
 	sd->set_screen_velocity(get_screen_velocity());
+
+	sd->merge_meta_from(this);
 
 	return sd;
 }
@@ -1705,6 +1713,8 @@ Ref<InputEvent> InputEventMagnifyGesture::xformed_by(const Transform2D &p_xform,
 	ev->set_position(p_xform.xform(get_position() + p_local_ofs));
 	ev->set_factor(get_factor());
 
+	ev->merge_meta_from(this);
+
 	return ev;
 }
 
@@ -1744,6 +1754,8 @@ Ref<InputEvent> InputEventPanGesture::xformed_by(const Transform2D &p_xform, con
 
 	ev->set_position(p_xform.xform(get_position() + p_local_ofs));
 	ev->set_delta(get_delta());
+
+	ev->merge_meta_from(this);
 
 	return ev;
 }


### PR DESCRIPTION
This pull request fixes an issue where event metadata is lost when events are passed through `Input.parse_input_event()` due to the way `xformed_by()` handles clones.

- Modified `input_event.cpp` and `input_event.h` to implement a function that copies metadata.
- Ensured that metadata is correctly copied when passed through the `xformed_by()` overrides.

The changes were tested by following the reproduction steps provided in the issue, ensuring that each `xformed_by()` override properly preserves the event metadata.

Fixes #95205