### PR TITLE
Fix instance binding state tracking

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1949,8 +1949,8 @@ void Object::set_instance_binding(void *p_token, void *p_binding, const GDExtens
 	ERR_FAIL_COND(_instance_bindings != nullptr && _instance_bindings[0].binding != nullptr);
 	if (_instance_bindings == nullptr) {
 		_instance_bindings = (InstanceBinding *)memalloc(sizeof(InstanceBinding));
-		_instance_binding_count = 1;
 	}
+	_instance_binding_count = 1;
 	_instance_bindings[0].binding = p_binding;
 	_instance_bindings[0].free_callback = p_callbacks->free_callback;
 	_instance_bindings[0].reference_callback = p_callbacks->reference_callback;


### PR DESCRIPTION
If you call GDExtension's set_binding, followed later by a free_binding this keeps the _instance_bindings allocated, but with the first slot set to zeros.   If you call set_binding again, it will succeed and set the values on the first slot, but will not track the state correctly, so looking it up will incorrectly state that there are no bindings, but attempting to set it will fail due to the assertion that checks for the binding.

This makes _instance_binding_count reflect the reality that there is one item on the table.