### PR TITLE
Make Godot compile on `FreeBSD`

### DIFF
--- a/modules/camera/config.py
+++ b/modules/camera/config.py
@@ -1,4 +1,8 @@
 def can_build(env, platform):
+    import sys
+
+    if sys.platform.startswith("freebsd"):
+        return False
     return platform == "macos" or platform == "windows" or platform == "linuxbsd"
 
 

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
+import sys
+
 Import("env")
 Import("env_modules")
 
@@ -29,7 +31,9 @@ elif env["platform"] == "linuxbsd":
         env_openxr.AppendUnique(CPPDEFINES=["XR_USE_PLATFORM_EGL"])
 
     # FIXME: Review what needs to be set for Android and macOS.
-    env_openxr.AppendUnique(CPPDEFINES=["HAVE_SECURE_GETENV"])
+    # FreeBSD uses non-standard getenv functions.
+    if not sys.platform.startswith("freebsd"):
+        env_openxr.AppendUnique(CPPDEFINES=["HAVE_SECURE_GETENV"])
 elif env["platform"] == "windows":
     env_openxr.AppendUnique(CPPDEFINES=["XR_OS_WINDOWS", "NOMINMAX", "XR_USE_PLATFORM_WIN32"])
 elif env["platform"] == "macos":

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -32,8 +32,12 @@
 
 #ifdef WAYLAND_ENABLED
 
-// FIXME: Does this cause issues with *BSDs?
+#ifdef __FreeBSD__
+#include <dev/evdev/input-event-codes.h>
+#else
+// Assume Linux.
 #include <linux/input-event-codes.h>
+#endif
 
 // For the actual polling thread.
 #include <poll.h>

--- a/thirdparty/linuxbsd_headers/alsa/asoundlib.h
+++ b/thirdparty/linuxbsd_headers/alsa/asoundlib.h
@@ -38,7 +38,11 @@
 #include <poll.h>
 #include <errno.h>
 #include <stdarg.h>
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif // __FreeBSD__
 
 #ifndef __GNUC__
 #define __inline__ inline

--- a/thirdparty/linuxbsd_headers/alsa/patches/freebsd_endian.diff
+++ b/thirdparty/linuxbsd_headers/alsa/patches/freebsd_endian.diff
@@ -1,0 +1,16 @@
+diff --git a/thirdparty/linuxbsd_headers/alsa/asoundlib.h b/thirdparty/linuxbsd_headers/alsa/asoundlib.h
+index a546194382..598175403c 100644
+--- a/thirdparty/linuxbsd_headers/alsa/asoundlib.h
++++ b/thirdparty/linuxbsd_headers/alsa/asoundlib.h
+@@ -38,7 +38,11 @@
+ #include <poll.h>
+ #include <errno.h>
+ #include <stdarg.h>
++#ifdef __FreeBSD__
++#include <sys/endian.h>
++#else
+ #include <endian.h>
++#endif // __FreeBSD__
+ 
+ #ifndef __GNUC__
+ #define __inline__ inline


### PR DESCRIPTION
Fixes #67838, well, at least it does build on my dedicated FreeBSD 12.4 VM.

Some issues however:

1. ~~There are minor thirdparty code modifications, hopefully its acceptable.~~ Committed the changed and also documented them in a diff file.
2. ~~Not a fan of having to `import sys` directly to _specifically_ detect FreeBSD. Any other solution would be appreciated.~~ Seems like the simplest solution for now.

I'll tackle OpenBSD on a separate PR once I have that set-up.