### PR TITLE
Add `get_connection_list_from_port` function to `GraphEdit`

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -203,6 +203,14 @@
 				Returns an [Array] containing the list of connections. A connection consists in a structure of the form [code]{ from_port: 0, from_node: "GraphNode name 0", to_port: 1, to_node: "GraphNode name 1" }[/code].
 			</description>
 		</method>
+		<method name="get_connection_list_from_port">
+			<return type="Dictionary[]" />
+			<param index="0" name="node" type="StringName" />
+			<param index="1" name="port" type="int" />
+			<description>
+				Returns an [Array] containing a list of all connections for [param port]. A connection consists in a structure of the form [code]{ node: "GraphNode name 0", port: 0, type: "left" }[/code].
+			</description>
+		</method>
 		<method name="get_connections_intersecting_with_rect" qualifiers="const">
 			<return type="Dictionary[]" />
 			<param index="0" name="rect" type="Rect2" />

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -347,6 +347,27 @@ int GraphEdit::get_connection_count(const StringName &p_node, int p_port) {
 	return count;
 }
 
+TypedArray<Dictionary> GraphEdit::_get_connection_list_from_port(const StringName &p_node, int p_port) {
+	TypedArray<Dictionary> connections_from_port;
+	for (const Ref<Connection> &conn : connections) {
+		if (conn->from_node == p_node && conn->from_port == p_port) {
+			Dictionary d;
+			d["node"] = conn->to_node;
+			d["port"] = conn->to_port;
+			d["type"] = "right";
+			connections_from_port.push_back(d);
+
+		} else if (conn->to_node == p_node && conn->to_port == p_port) {
+			Dictionary d;
+			d["node"] = conn->from_node;
+			d["port"] = conn->from_port;
+			d["type"] = "left";
+			connections_from_port.push_back(d);
+		}
+	}
+	return connections_from_port;
+}
+
 void GraphEdit::set_scroll_offset(const Vector2 &p_offset) {
 	setting_scroll_offset = true;
 	h_scrollbar->set_value(p_offset.x);
@@ -2651,6 +2672,7 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_connection_activity", "from_node", "from_port", "to_node", "to_port", "amount"), &GraphEdit::set_connection_activity);
 	ClassDB::bind_method(D_METHOD("get_connection_list"), &GraphEdit::_get_connection_list);
 	ClassDB::bind_method(D_METHOD("get_connection_count", "from_node", "from_port"), &GraphEdit::get_connection_count);
+	ClassDB::bind_method(D_METHOD("get_connection_list_from_port", "node", "port"), &GraphEdit::_get_connection_list_from_port);
 	ClassDB::bind_method(D_METHOD("get_closest_connection_at_point", "point", "max_distance"), &GraphEdit::_get_closest_connection_at_point, DEFVAL(4.0));
 	ClassDB::bind_method(D_METHOD("get_connections_intersecting_with_rect", "rect"), &GraphEdit::_get_connections_intersecting_with_rect);
 	ClassDB::bind_method(D_METHOD("clear_connections"), &GraphEdit::clear_connections);

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -399,7 +399,6 @@ public:
 	// Connection related methods.
 	Error connect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	bool is_node_connected(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
-	int get_connection_count(const StringName &p_node, int p_port);
 	void disconnect_node(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 	void clear_connections();
 
@@ -408,6 +407,8 @@ public:
 	virtual PackedVector2Array get_connection_line(const Vector2 &p_from, const Vector2 &p_to) const;
 	Ref<Connection> get_closest_connection_at_point(const Vector2 &p_point, float p_max_distance = 4.0) const;
 	List<Ref<Connection>> get_connections_intersecting_with_rect(const Rect2 &p_rect) const;
+	TypedArray<Dictionary> _get_connection_list_from_port(const StringName &p_node, int p_port);
+	int get_connection_count(const StringName &p_node, int p_port);
 
 	virtual bool is_node_hover_valid(const StringName &p_from, int p_from_port, const StringName &p_to, int p_to_port);
 


### PR DESCRIPTION
Adds the `get_connection_list_from_port(node,port)` function to GraphEdit, with its help we can get a full list of connections in a specific port, as well as get the number of connections using the `size` array function.

Example of the resulting list:
`[{ "node": &"@GraphNode@35", "port": 0, "type": "left" }, { "node": &"@GraphNode@35", "port": 1, "type": "left" }, { "node": &"@GraphNode@49", "port": 0, "type": "left" }]`

Closes: [godot-proposals/issues/11287](https://github.com/godotengine/godot-proposals/issues/11287)
