### PR TITLE
Linux: Relax interdependency between freetype, libpng, and zlib for unvendored builds

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -99,6 +99,8 @@ if env["builtin_zlib"]:
     env.Prepend(CPPPATH=[thirdparty_zlib_dir])
     if env.dev_build:
         env_thirdparty.Append(CPPDEFINES=["ZLIB_DEBUG"])
+        # Affects headers so it should also be defined for Godot code
+        env.Append(CPPDEFINES=["ZLIB_DEBUG"])
 
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_zlib_sources)
 

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -67,8 +67,6 @@ if env["builtin_freetype"]:
     env.Prepend(CPPPATH=[thirdparty_dir + "/include"])
 
     env_freetype.Append(CPPDEFINES=["FT2_BUILD_LIBRARY", "FT_CONFIG_OPTION_USE_PNG", "FT_CONFIG_OPTION_SYSTEM_ZLIB"])
-    if env.dev_build:
-        env_freetype.Append(CPPDEFINES=["ZLIB_DEBUG"])
 
     # Also requires libpng headers
     if env["builtin_libpng"]:

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -222,23 +222,6 @@ def configure(env: "SConsEnvironment"):
 
     # FIXME: Check for existence of the libs before parsing their flags with pkg-config
 
-    # freetype depends on libpng and zlib, so bundling one of them while keeping others
-    # as shared libraries leads to weird issues. And graphite and harfbuzz need freetype.
-    ft_linked_deps = [
-        env["builtin_freetype"],
-        env["builtin_libpng"],
-        env["builtin_zlib"],
-        env["builtin_graphite"],
-        env["builtin_harfbuzz"],
-    ]
-    if (not all(ft_linked_deps)) and any(ft_linked_deps):  # All or nothing.
-        print_error(
-            "These libraries should be either all builtin, or all system provided:\n"
-            "freetype, libpng, zlib, graphite, harfbuzz.\n"
-            "Please specify `builtin_<name>=no` for all of them, or none."
-        )
-        sys.exit(255)
-
     if not env["builtin_freetype"]:
         env.ParseConfig("pkg-config freetype2 --cflags --libs")
 
@@ -250,6 +233,11 @@ def configure(env: "SConsEnvironment"):
 
     if not env["builtin_harfbuzz"]:
         env.ParseConfig("pkg-config harfbuzz harfbuzz-icu --cflags --libs")
+
+    if not env["builtin_icu4c"] or not env["builtin_harfbuzz"]:
+        print_warning(
+            "System-provided icu4c or harfbuzz cause known issues for GDExtension (see GH-91401 and GH-100301)."
+        )
 
     if not env["builtin_libpng"]:
         env.ParseConfig("pkg-config libpng16 --cflags --libs")


### PR DESCRIPTION
This restriction was added to fix #7373 back then, which was a symbol conflict between FreeType's bundled copy of gzip/zlib, and distro packages.

But we also unbundled FreeType's zlib in #69395 so this is no longer an issue.

Builds successfully with `scons builtin_zlib=no builtin_libpng=no`, didn't test much more than that.