### PR TITLE
Improve `ContainerTypeValidate` performance for object types

### DIFF
--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -124,9 +124,9 @@ struct ContainerTypeValidate {
 			return true; // All good, no class type requested.
 		}
 
-		StringName obj_class = object->get_class_name();
+		const StringName &obj_class = object->get_class_name();
 		if (obj_class != class_name) {
-			ERR_FAIL_COND_V_MSG(!ClassDB::is_parent_class(object->get_class_name(), class_name), false, vformat("Attempted to %s an object of type '%s' into a %s, which does not inherit from '%s'.", String(p_operation), object->get_class(), where, String(class_name)));
+			ERR_FAIL_COND_V_MSG(!ClassDB::is_parent_class(obj_class, class_name), false, vformat("Attempted to %s an object of type '%s' into a %s, which does not inherit from '%s'.", String(p_operation), object->get_class(), where, String(class_name)));
 		}
 
 		if (script.is_null()) {


### PR DESCRIPTION
Use const reference for class name instead of copying, to avoid some extra reference counting overhead

Reduces time to add items to object typed containers by around 10%:

```gdscript
extends Node

func _ready() -> void:
	test_node_array()
	test_subclass_array()
	test_dictionary()
	test_untyped()

func test_node_array():
	var a : Array[Node] = []
	var node := Node.new()
	var start := Time.get_ticks_msec()
	for i in 1000000:
		a.push_back(node)
	var end := Time.get_ticks_msec()
	print("Node Array: %sms" % (end - start))

func test_subclass_array():
	var a : Array[Node] = []
	var node := Node2D.new()
	var start := Time.get_ticks_msec()
	for i in 1000000:
		a.push_back(node)
	var end := Time.get_ticks_msec()
	print("Subclass Array: %sms" % (end - start))
	
func test_dictionary():
	var d : Dictionary[int, Node] = {}
	var node := Node2D.new()
	var start := Time.get_ticks_msec()
	for i in 1000000:
		d[i] = node
	var end := Time.get_ticks_msec()
	print("Dictionary: %sms" % (end - start))

func test_untyped():
	var a := []
	var node := Node2D.new()
	var start := Time.get_ticks_msec()
	for i in 1000000:
		a.push_back(node)
	var end := Time.get_ticks_msec()
	print("Untyped Array: %sms" % (end - start))

```

old:
```
Node Array: 111ms
Subclass Array: 150ms
Dictionary: 258ms
Untyped Array: 92ms
```

new:
```
Node Array: 99ms
Subclass Array: 132ms
Dictionary: 236ms
Untyped Array: 92ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
