### PR TITLE
Fix occlusion culling buffer getting overwritten in larger scenes

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -366,7 +366,7 @@ void RaycastOcclusionCull::Scenario::_transform_vertices_thread(uint32_t p_threa
 }
 
 void RaycastOcclusionCull::Scenario::_transform_vertices_range(const Vector3 *p_read, float *p_write, const Transform3D &p_xform, int p_from, int p_to) {
-	float *floats_w = p_write;
+	float *floats_w = p_write + 3 * p_from;
 	for (int i = p_from; i < p_to; i++) {
 		const Vector3 p = p_xform.xform(p_read[i]);
 		floats_w[0] = p.x;


### PR DESCRIPTION
Fixes #100032 

On subsequent calls to `_transform_vertices_range()` (where `p_from` would have been adjusted) it would still start writing to the same index in of `xformed_vertices` effectively overwriting and corrupting vertex data previously written.

The correct implementation is to offset `p_write` with 3*`p_from`.

I tested using [occlusion_culling_mesh_lod](https://github.com/godotengine/godot-demo-projects/tree/master/3d/occlusion_culling_mesh_lod) for both double and float builds. 

Before:
![image](https://github.com/user-attachments/assets/5609102a-a504-4d23-8aae-7cd1a04356fd)

After:
![image](https://github.com/user-attachments/assets/4ec52891-4930-4c12-b557-9201e79e63e4)
