### PR TITLE
`EditorUndoRedoManager`: Use fixed history when a custom context is provided

### DIFF
--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -332,7 +332,7 @@ void EditorSettingsDialog::_update_shortcut_events(const String &p_path, const A
 	Ref<Shortcut> current_sc = EditorSettings::get_singleton()->get_shortcut(p_path);
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(vformat(TTR("Edit Shortcut: %s"), p_path));
+	undo_redo->create_action(vformat(TTR("Edit Shortcut: %s"), p_path), UndoRedo::MERGE_DISABLE, EditorSettings::get_singleton());
 	undo_redo->add_do_method(current_sc.ptr(), "set_events", p_events);
 	undo_redo->add_undo_method(current_sc.ptr(), "set_events", current_sc->get_events());
 	undo_redo->add_do_method(EditorSettings::get_singleton(), "mark_setting_changed", "shortcuts");

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -150,6 +150,7 @@ void EditorUndoRedoManager::create_action(const String &p_name, UndoRedo::MergeM
 	if (p_custom_context) {
 		// This assigns history to pending action.
 		get_history_for_object(p_custom_context);
+		force_fixed_history();
 	}
 }
 


### PR DESCRIPTION
This makes the custom context feature of the `EditorUndoRedoManager` behave consistently with the [current documentation](https://docs.godotengine.org/en/stable/classes/class_editorundoredomanager.html#class-editorundoredomanager-method-create-action).

Fixes #100108. Also fixes #76851 by providing a custom context when creating the "Edit Shortcut" action.