### PR TITLE
Correctly check time since shadow was allocated in atlas to avoid unnecessary re-allocations

### DIFF
--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -1405,7 +1405,7 @@ bool LightStorage::shadow_atlas_update_light(RID p_atlas, RID p_light_instance, 
 		old_shadow = old_key & SHADOW_INDEX_MASK;
 
 		// Only re-allocate if a better option is available, and enough time has passed.
-		should_realloc = shadow_atlas->quadrants[old_quadrant].subdivision != (uint32_t)best_subdiv && (shadow_atlas->quadrants[old_quadrant].shadows[old_shadow].alloc_tick - tick > shadow_atlas_realloc_tolerance_msec);
+		should_realloc = shadow_atlas->quadrants[old_quadrant].subdivision != (uint32_t)best_subdiv && (tick - shadow_atlas->quadrants[old_quadrant].shadows[old_shadow].alloc_tick > shadow_atlas_realloc_tolerance_msec);
 		should_redraw = shadow_atlas->quadrants[old_quadrant].shadows[old_shadow].version != p_light_version;
 
 		if (!should_realloc) {

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -2328,7 +2328,7 @@ bool LightStorage::shadow_atlas_update_light(RID p_atlas, RID p_light_instance, 
 		old_quadrant = (old_key >> QUADRANT_SHIFT) & 0x3;
 		old_shadow = old_key & SHADOW_INDEX_MASK;
 
-		should_realloc = shadow_atlas->quadrants[old_quadrant].subdivision != (uint32_t)best_subdiv && (shadow_atlas->quadrants[old_quadrant].shadows[old_shadow].alloc_tick - tick > shadow_atlas_realloc_tolerance_msec);
+		should_realloc = shadow_atlas->quadrants[old_quadrant].subdivision != (uint32_t)best_subdiv && (tick - shadow_atlas->quadrants[old_quadrant].shadows[old_shadow].alloc_tick > shadow_atlas_realloc_tolerance_msec);
 		should_redraw = shadow_atlas->quadrants[old_quadrant].shadows[old_shadow].version != p_light_version;
 
 		if (!should_realloc) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/97472

The bug is simple, `tick` is the current time `alloc_tick` is the time when we allocated the slot in the atlas and `shadow_atlas_realloc_tolerance_msec` is the minimum time we want a shadow to live in the atlas before trying to move up to a higher resolution slot. When the difference between `tick` and `alloc_tick` is less than the tolerance, we shouldn't allow it to move. All of these variables are unsigned ints. `tick` is always bigger than `alloc_tick` so the left side of the comparison always overflows to some large number and the condition always passed. 

The regression is more complicated. This condition is only checked when the current subdivision doesn't equal the best subdivision. In the MRP, that happens a lot because there are more shadows than can fit without the atlas. So there are always shadows asking to be moved onto the atlas (and thus evicting other shadows). In 4.2, we had a bug where some shadows would think they got a spot on the atlas, this led to us later attempting to read from non-existent memory which led to crashes. _But_ when it didn't crash it had the side effect of causing that first check to fail, so this bug wasn't exposed. I explain the regression in more detail here: https://github.com/godotengine/godot/issues/97472#issuecomment-2375997747

For maintainers, this is a very safe change and should be merged for 4.4 and 4.3 ASAP. 