### PR TITLE
Fix `RandomPCG::random(int, int)` overflow bug

### DIFF
--- a/core/math/random_pcg.cpp
+++ b/core/math/random_pcg.cpp
@@ -80,5 +80,15 @@ int RandomPCG::random(int p_from, int p_to) {
 	if (p_from == p_to) {
 		return p_from;
 	}
-	return int(rand(uint32_t(Math::abs(p_from - p_to)) + 1U)) + MIN(p_from, p_to);
+
+	int64_t min = MIN(p_from, p_to);
+	int64_t max = MAX(p_from, p_to);
+	uint32_t diff = static_cast<uint32_t>(max - min);
+
+	if (diff == UINT32_MAX) {
+		// Can't add 1 to max uint32_t value for inclusive range, so call rand without passing bounds.
+		return static_cast<int64_t>(rand()) + min;
+	}
+
+	return static_cast<int64_t>(rand(diff + 1U)) + min;
 }


### PR DESCRIPTION
- Use int64_t for subtraction before converting to uint32_t
- Don't add one to uint32_t max value for rand() bounds

Fixes #94578

Tested with gdscript below (and similar C# code).  Results will vary from run to run, but old code seemed to consistently use very narrow ranges:

```gdscript
extends Node

func _ready() -> void:
	test_rand_range(-2147483648, 2147483647)
	print("-----")
	test_rand_range(-2147483640, 2147483640)
	print("-----")
	test_rand_range(0, 1)

func test_rand_range(min : int, max : int):
	for i in 5:
		print(randi_range(min, max))

```

old:
```
-2147483647
-2147483647
-2147483647
-2147483647
-2147483647
-----
-2147483629
-2147483639
-2147483639
-2147483632
-2147483631
-----
0
0
1
0
1
```

new:
```
-293104615
-1349897285
51334271
1668222099
762702258
-----
415601630
-584587391
62246720
-877669916
287709698
-----
1
1
1
0
0

```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
