### PR TITLE
Implement multi-pass shader directive and custom variants in Material.

### DIFF
--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -409,7 +409,7 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 	if (!complete_from_path.ends_with("/")) {
 		complete_from_path += "/";
 	}
-	preprocessor.preprocess(p_code, resource_path, code, nullptr, nullptr, nullptr, nullptr, &pp_options, &pp_defines, _complete_include_paths);
+	preprocessor.preprocess(p_code, resource_path, code, nullptr, nullptr, nullptr, nullptr, nullptr, &pp_options, &pp_defines, _complete_include_paths);
 	complete_from_path = String();
 	if (pp_options.size()) {
 		for (const ScriptLanguage::CodeCompletionOption &E : pp_options) {
@@ -465,7 +465,7 @@ void ShaderTextEditor::_validate_script() {
 	} else if (shader_inc.is_valid()) {
 		filename = shader_inc->get_path();
 	}
-	last_compile_result = preprocessor.preprocess(code, filename, code_pp, &error_pp, &err_positions, &regions);
+	last_compile_result = preprocessor.preprocess(code, filename, code_pp, nullptr, &error_pp, &err_positions, &regions);
 
 	for (int i = 0; i < get_text_editor()->get_line_count(); i++) {
 		get_text_editor()->set_line_background_color(i, Color(0, 0, 0, 0));

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6247,7 +6247,7 @@ void VisualShaderEditor::_update_preview() {
 		String error_pp;
 		List<ShaderPreprocessor::FilePosition> err_positions;
 		ShaderPreprocessor preprocessor;
-		Error err = preprocessor.preprocess(code, path, preprocessed_code, &error_pp, &err_positions);
+		Error err = preprocessor.preprocess(code, path, preprocessed_code, nullptr, &error_pp, &err_positions);
 		if (err != OK) {
 			ERR_FAIL_COND(err_positions.is_empty());
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -100,7 +100,7 @@ void Shader::set_code(const String &p_code) {
 		// 2) Server does not do interaction with Resource filetypes, this is a scene level feature.
 		HashSet<Ref<ShaderInclude>> new_include_dependencies;
 		ShaderPreprocessor preprocessor;
-		Error result = preprocessor.preprocess(p_code, path, preprocessed_code, nullptr, nullptr, nullptr, &new_include_dependencies);
+		Error result = preprocessor.preprocess(p_code, path, preprocessed_code, nullptr, nullptr, nullptr, nullptr, &new_include_dependencies);
 		if (result == OK) {
 			// This ensures previous include resources are not freed and then re-loaded during parse (which would make compiling slower)
 			include_dependencies = new_include_dependencies;

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -52,7 +52,7 @@ void ShaderInclude::set_code(const String &p_code) {
 		String pp_code;
 		HashSet<Ref<ShaderInclude>> new_dependencies;
 		ShaderPreprocessor preprocessor;
-		Error result = preprocessor.preprocess(p_code, path, pp_code, nullptr, nullptr, nullptr, &new_dependencies);
+		Error result = preprocessor.preprocess(p_code, path, pp_code, nullptr, nullptr, nullptr, nullptr, &new_dependencies);
 		if (result == OK) {
 			// This ensures previous include resources are not freed and then re-loaded during parse (which would make compiling slower)
 			dependencies = new_dependencies;

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -826,6 +826,20 @@ void ShaderPreprocessor::process_undef(Tokenizer *p_tokenizer) {
 	}
 }
 
+void ShaderPreprocessor::process_pass(Tokenizer *p_tokenizer) {
+	const int line = p_tokenizer->get_line();
+	const String label = p_tokenizer->get_identifier();
+	if (label.is_empty() || !p_tokenizer->consume_empty_line()) {
+		set_error(vformat(RTR("Invalid '%s' directive."), "pass"), line);
+		return;
+	}
+
+	if (state->defines.has(label)) {
+		set_error(vformat(RTR("Cannot use pass directive '%s' if it's been already defined previously."), label), line);
+		return;
+	}
+}
+
 void ShaderPreprocessor::add_region(int p_line, bool p_enabled, Region *p_parent_region) {
 	Region region;
 	region.file = state->current_filename;
@@ -1330,7 +1344,7 @@ Error ShaderPreprocessor::preprocess(State *p_state, const String &p_code, Strin
 	return OK;
 }
 
-Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filename, String &r_result, String *r_error_text, List<FilePosition> *r_error_position, List<Region> *r_regions, HashSet<Ref<ShaderInclude>> *r_includes, List<ScriptLanguage::CodeCompletionOption> *r_completion_options, List<ScriptLanguage::CodeCompletionOption> *r_completion_defines, IncludeCompletionFunction p_include_completion_func) {
+Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filename, String &r_result, String *p_pass, String *r_error_text, List<FilePosition> *r_error_position, List<Region> *r_regions, HashSet<Ref<ShaderInclude>> *r_includes, List<ScriptLanguage::CodeCompletionOption> *r_completion_options, List<ScriptLanguage::CodeCompletionOption> *r_completion_defines, IncludeCompletionFunction p_include_completion_func, Vector<String> *r_passes) {
 	State pp_state;
 	if (!p_filename.is_empty()) {
 		pp_state.current_filename = p_filename;
@@ -1352,6 +1366,10 @@ Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filen
 		insert_builtin_define("RENDERER_COMPATIBILITY", _MKSTR(0), pp_state);
 		insert_builtin_define("RENDERER_MOBILE", _MKSTR(1), pp_state);
 		insert_builtin_define("RENDERER_FORWARD_PLUS", _MKSTR(2), pp_state);
+
+		if (p_pass) {
+			insert_builtin_define(*p_pass, "", pp_state);
+		}
 	}
 
 	Error err = preprocess(&pp_state, p_code, r_result);
@@ -1362,6 +1380,9 @@ Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filen
 		if (r_error_position) {
 			*r_error_position = pp_state.include_positions;
 		}
+	}
+	if (r_passes) {
+		*r_passes = pp_state.passes;
 	}
 	if (r_regions) {
 		*r_regions = pp_state.regions[p_filename];

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -166,6 +166,7 @@ private:
 		bool disabled = false;
 		CompletionType completion_type = COMPLETION_TYPE_NONE;
 		HashSet<Ref<ShaderInclude>> shader_includes;
+		Vector<String> passes;
 	};
 
 private:
@@ -199,6 +200,7 @@ private:
 	void process_include(Tokenizer *p_tokenizer);
 	void process_pragma(Tokenizer *p_tokenizer);
 	void process_undef(Tokenizer *p_tokenizer);
+	void process_pass(Tokenizer *p_tokenizer);
 
 	void add_region(int p_line, bool p_enabled, Region *p_parent_region);
 	void start_branch_condition(Tokenizer *p_tokenizer, bool p_success, bool p_continue = false);
@@ -224,7 +226,7 @@ private:
 public:
 	typedef void (*IncludeCompletionFunction)(List<ScriptLanguage::CodeCompletionOption> *);
 
-	Error preprocess(const String &p_code, const String &p_filename, String &r_result, String *r_error_text = nullptr, List<FilePosition> *r_error_position = nullptr, List<Region> *r_regions = nullptr, HashSet<Ref<ShaderInclude>> *r_includes = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_options = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_defines = nullptr, IncludeCompletionFunction p_include_completion_func = nullptr);
+	Error preprocess(const String &p_code, const String &p_filename, String &r_result, String *p_pass = nullptr, String *r_error_text = nullptr, List<FilePosition> *r_error_position = nullptr, List<Region> *r_regions = nullptr, HashSet<Ref<ShaderInclude>> *r_includes = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_options = nullptr, List<ScriptLanguage::CodeCompletionOption> *r_completion_defines = nullptr, IncludeCompletionFunction p_include_completion_func = nullptr, Vector<String> *r_passes = nullptr);
 
 	static void get_keyword_list(List<String> *r_keywords, bool p_include_shader_keywords, bool p_ignore_context_keywords = false);
 	static void get_pragma_list(List<String> *r_pragmas);


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/7870
closes https://github.com/godotengine/godot-proposals/issues/8076

Implements the `#pass` directive to be used by multi-pass shaders without copying the code or having to put it inside of a include file.

Implements a define list, a typed dictionary with string keys and values to be able to pass custom defines into the code. This is done thru `#variant <variant_name> <DEFINE LIST>`, which allows the programmer to choose a shader "variant" 

- [x] Implement the preprocessor directives
- [x] Implement custom define list for ShaderPreprocessor.
- [ ] Implement multi-pass system.
- [ ] Write tests
- [ ] Write documentation

TODO after:
- [x] Fix bug where files cant be properly included in any branch that includes files without them being the base pass by marking all include statements as possible dependencies.