### PR TITLE
Prevent SubViewports Update Mode from resetting on visibility changes

### DIFF
--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -121,12 +121,9 @@ void SubViewportContainer::_notification(int p_what) {
 					continue;
 				}
 
-				if (is_visible_in_tree()) {
-					c->set_update_mode(SubViewport::UPDATE_ALWAYS);
-				} else {
+				if (!is_visible_in_tree()) {
 					c->set_update_mode(SubViewport::UPDATE_DISABLED);
 				}
-
 				c->set_handle_input_locally(false); //do not handle input locally here
 			}
 		} break;


### PR DESCRIPTION
Removes potentially undesired resets of render_target_update_mode on visibility changes.

see #23729 and #71227

First commit btw so I assume I didn't do something correct or informaly, please let me know how...

I think this line has either been an oversight or is simply a leftover from before other render_target_update_modes were implemented or planned.