### PR TITLE
Add missing cleanup of editor history & set appropriate class icon for object in it

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4886,11 +4886,29 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 	ERR_FAIL_NULL_V_MSG(p_object, nullptr, "Object cannot be null.");
 
 	Ref<Script> scr = p_object->get_script();
+
+	if (Object::cast_to<EditorDebuggerRemoteObject>(p_object)) {
+		String class_name;
+		if (scr.is_valid()) {
+			class_name = scr->get_global_name();
+
+			if (class_name.is_empty()) {
+				// If there is no class_name in this script we just take the script path.
+				class_name = scr->get_path();
+			}
+		}
+		return get_class_icon(class_name.is_empty() ? Object::cast_to<EditorDebuggerRemoteObject>(p_object)->type_name : class_name, p_fallback);
+	}
+
 	if (scr.is_null() && p_object->is_class("Script")) {
 		scr = p_object;
 	}
 
-	return _get_class_or_script_icon(p_object->get_class(), scr, p_fallback);
+	if (Object::cast_to<MultiNodeEdit>(p_object)) {
+		return get_class_icon(Object::cast_to<MultiNodeEdit>(p_object)->get_edited_class_name(), p_fallback);
+	} else {
+		return _get_class_or_script_icon(p_object->get_class(), scr, p_fallback);
+	}
 }
 
 Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p_fallback) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -832,8 +832,8 @@ public:
 	};
 
 	struct SceneEditorDataEntry {
-		bool is_editable;
-		bool is_display_folded;
+		bool is_editable = false;
+		bool is_display_folded = false;
 	};
 
 	HashMap<int, SceneModificationsEntry> scenes_modification_table;

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -30,11 +30,9 @@
 
 #include "editor_object_selector.h"
 
-#include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/editor_data.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
-#include "editor/multi_node_edit.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/margin_container.h"
 
@@ -129,25 +127,7 @@ void EditorObjectSelector::update_path() {
 			continue;
 		}
 
-		Ref<Texture2D> obj_icon;
-		if (Object::cast_to<MultiNodeEdit>(obj)) {
-			obj_icon = EditorNode::get_singleton()->get_class_icon(Object::cast_to<MultiNodeEdit>(obj)->get_edited_class_name());
-		} else if (Object::cast_to<EditorDebuggerRemoteObject>(obj)) {
-			String class_name;
-			Ref<Script> base_script = obj->get_script();
-			if (base_script.is_valid()) {
-				class_name = base_script->get_global_name();
-
-				if (class_name.is_empty()) {
-					// If there is no class_name in this script we just take the script path.
-					class_name = base_script->get_path();
-				}
-			}
-
-			obj_icon = EditorNode::get_singleton()->get_class_icon(class_name.is_empty() ? Object::cast_to<EditorDebuggerRemoteObject>(obj)->type_name : class_name);
-		} else {
-			obj_icon = EditorNode::get_singleton()->get_object_icon(obj);
-		}
+		Ref<Texture2D> obj_icon = EditorNode::get_singleton()->get_object_icon(obj);
 
 		if (obj_icon.is_valid()) {
 			current_object_icon->set_texture(obj_icon);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -316,6 +316,7 @@ Ref<Resource> InspectorDock::_get_current_resource() const {
 
 void InspectorDock::_prepare_history() {
 	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
+	editor_history->cleanup_history();
 
 	int history_to = MAX(0, editor_history->get_history_len() - 25);
 
@@ -505,6 +506,7 @@ void InspectorDock::clear() {
 
 void InspectorDock::update(Object *p_object) {
 	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
+
 	backward_button->set_disabled(editor_history->is_at_beginning());
 	forward_button->set_disabled(editor_history->is_at_end());
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2308,7 +2308,6 @@ void SceneTreeDock::_node_reparent(NodePath p_path, bool p_keep_global_xform) {
 	ERR_FAIL_NULL(new_parent);
 
 	List<Node *> selection = editor_selection->get_selected_node_list();
-	List<Node *> full_selection = editor_selection->get_full_selected_node_list();
 
 	if (selection.is_empty()) {
 		return; // Nothing to reparent.
@@ -2321,10 +2320,6 @@ void SceneTreeDock::_node_reparent(NodePath p_path, bool p_keep_global_xform) {
 	}
 
 	_do_reparent(new_parent, -1, nodes, p_keep_global_xform);
-
-	for (Node *E : full_selection) {
-		editor_selection->add_node(E);
-	}
 }
 
 void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, Vector<Node *> p_nodes, bool p_keep_global_xform) {
@@ -2517,12 +2512,20 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 
 	perform_node_renames(nullptr, &path_renames);
 
-	undo_redo->commit_action();
+	undo_redo->add_do_method(editor_selection, "clear");
+	undo_redo->add_undo_method(editor_selection, "clear");
+	List<Node *> full_selection = editor_selection->get_full_selected_node_list();
+	for (Node *E : full_selection) {
+		undo_redo->add_do_method(editor_selection, "add_node", E);
+		undo_redo->add_undo_method(editor_selection, "add_node", E);
+	}
 
 	if (need_edit) {
 		EditorNode::get_singleton()->edit_current();
 		editor_selection->clear();
 	}
+
+	undo_redo->commit_action();
 }
 
 void SceneTreeDock::_script_created(Ref<Script> p_script) {
@@ -3661,7 +3664,6 @@ void SceneTreeDock::_nodes_dragged(const Array &p_nodes, NodePath p_to, int p_ty
 	}
 
 	List<Node *> selection = editor_selection->get_selected_node_list();
-	List<Node *> full_selection = editor_selection->get_full_selected_node_list();
 
 	if (selection.is_empty()) {
 		return; //nothing to reparent
@@ -3681,10 +3683,6 @@ void SceneTreeDock::_nodes_dragged(const Array &p_nodes, NodePath p_to, int p_ty
 
 	_normalize_drop(to_node, to_pos, p_type);
 	_do_reparent(to_node, to_pos, nodes, !Input::get_singleton()->is_key_pressed(Key::SHIFT));
-
-	for (Node *E : full_selection) {
-		editor_selection->add_node(E);
-	}
 }
 
 void SceneTreeDock::_add_children_to_popup(Object *p_obj, int p_depth) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/91447
Also set the corresponding class icon in the editor history, same when selecting a node in the remote tree; before it was using the fallback Object icon.
Reselecting the reparented nodes support do&undo now.