### PR TITLE
Fix avoidance dirty flag regression

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -948,14 +948,18 @@ void NavMap::_sync_dirty_map_update_requests() {
 
 void NavMap::_sync_dirty_avoidance_update_requests() {
 	// Sync NavAgents.
-	agents_dirty = sync_dirty_requests.agents.first();
+	if (!agents_dirty) {
+		agents_dirty = sync_dirty_requests.agents.first();
+	}
 	for (SelfList<NavAgent> *element = sync_dirty_requests.agents.first(); element; element = element->next()) {
 		element->self()->sync();
 	}
 	sync_dirty_requests.agents.clear();
 
 	// Sync NavObstacles.
-	obstacles_dirty = sync_dirty_requests.obstacles.first();
+	if (!obstacles_dirty) {
+		obstacles_dirty = sync_dirty_requests.obstacles.first();
+	}
 	for (SelfList<NavObstacle> *element = sync_dirty_requests.obstacles.first(); element; element = element->next()) {
 		element->self()->sync();
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/100085

The dirty flag can also still be set by some legacy functions triggered by the agents and obstacles.

So what happened is that those would set the dirty flag to `true` at random moments expecting that the next sync would pick it up at some point. Meanwhile the actual agent or obstacle sync queue was empty turning it back to `false`, and without the dirty sync the arrays for the avoidance would be broken causing the crash.



<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
