### PR TITLE
Add tmpexport.*.apk.idsig file to cleanup

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2087,11 +2087,14 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 	String tmp_export_path = EditorPaths::get_singleton()->get_cache_dir().path_join("tmpexport." + uitos(OS::get_singleton()->get_unix_time()) + ".apk");
 
-#define CLEANUP_AND_RETURN(m_err)                         \
-	{                                                     \
-		DirAccess::remove_file_or_error(tmp_export_path); \
-		return m_err;                                     \
-	}                                                     \
+#define CLEANUP_AND_RETURN(m_err)                                       \
+	{                                                                   \
+		DirAccess::remove_file_or_error(tmp_export_path);               \
+		if (FileAccess::exists(tmp_export_path + ".idsig")) {           \
+			DirAccess::remove_file_or_error(tmp_export_path + ".idsig") \
+		}                                                               \
+		return m_err;                                                   \
+	}                                                                   \
 	((void)0)
 
 	// Export to temporary APK before sending to device.
@@ -3447,11 +3450,14 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 
 	String tmp_unaligned_path = EditorPaths::get_singleton()->get_cache_dir().path_join("tmpexport-unaligned." + uitos(OS::get_singleton()->get_unix_time()) + ".apk");
 
-#define CLEANUP_AND_RETURN(m_err)                            \
-	{                                                        \
-		DirAccess::remove_file_or_error(tmp_unaligned_path); \
-		return m_err;                                        \
-	}                                                        \
+#define CLEANUP_AND_RETURN(m_err)                                           \
+	{                                                                       \
+		DirAccess::remove_file_or_error(tmp_unaligned_path);                \
+		if (FileAccess::exists(tmp_unaligned_path + ".idsig")) {            \
+			DirAccess::remove_file_or_error(tmp_unaligned_path + ".idsig"); \
+		}                                                                   \
+		return m_err;                                                       \
+	}                                                                       \
 	((void)0)
 
 	zipFile unaligned_apk = zipOpen2(tmp_unaligned_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io2);


### PR DESCRIPTION
> [!WARNING]
> Not tested yet.

This PR adds `.idsig` files to the Android cleanup phases.

Fixes #100101