### PR TITLE
Implement `RD::buffer_get_data_async()` and `RD::texture_get_data_async()`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1563,6 +1563,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/staging_buffer/block_size_kb", PROPERTY_HINT_RANGE, "4,2048,1,or_greater"), 256);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/staging_buffer/max_size_mb", PROPERTY_HINT_RANGE, "1,1024,1,or_greater"), 128);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/staging_buffer/texture_upload_region_size_px", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), 64);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/staging_buffer/texture_download_region_size_px", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), 64);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::BOOL, "rendering/rendering_device/pipeline_cache/enable"), true);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "rendering/rendering_device/pipeline_cache/save_chunk_size_mb", PROPERTY_HINT_RANGE, "0.000001,64.0,0.001,or_greater"), 3.0);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/rendering_device/vulkan/max_descriptors_per_pool", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), 64);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2841,10 +2841,22 @@
 			Determines at which interval pipeline cache is saved to disk. The lower the value, the more often it is saved.
 		</member>
 		<member name="rendering/rendering_device/staging_buffer/block_size_kb" type="int" setter="" getter="" default="256">
+			The size of a block allocated in the staging buffers. Staging buffers are the intermediate resources the engine uses to upload or download data to the GPU. This setting determines the max amount of data that can be transferred in a copy operation. Increasing this will result in faster data transfers at the cost of extra memory.
+			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this value at run-time.
 		</member>
 		<member name="rendering/rendering_device/staging_buffer/max_size_mb" type="int" setter="" getter="" default="128">
+			The maximum amount of memory allowed to be used by staging buffers. If the amount of data being uploaded or downloaded exceeds this amount, the GPU will stall and wait for previous frames to finish.
+			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this value at run-time.
+		</member>
+		<member name="rendering/rendering_device/staging_buffer/texture_download_region_size_px" type="int" setter="" getter="" default="64">
+			The region size in pixels used to download texture data from the GPU when using methods like [method RenderingDevice.texture_get_data_async].
+			[b]Note:[/b] This property's upper limit is controlled by [member rendering/rendering_device/staging_buffer/block_size_kb] and whether it's possible to allocate a single block of texture data with this region size in the format that is requested.
+			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this value at run-time.
 		</member>
 		<member name="rendering/rendering_device/staging_buffer/texture_upload_region_size_px" type="int" setter="" getter="" default="64">
+			The region size in pixels used to upload texture data from the GPU when using methods like [method RenderingDevice.texture_update].
+			[b]Note:[/b] This property's upper limit is controlled by [member rendering/rendering_device/staging_buffer/block_size_kb] and whether it's possible to allocate a single block of texture data with this region size in the format that is requested.
+			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this value at run-time.
 		</member>
 		<member name="rendering/rendering_device/vsync/frame_queue_size" type="int" setter="" getter="" default="2">
 			The number of frames to track on the CPU side before stalling to wait for the GPU.

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -58,6 +58,27 @@
 			<param index="2" name="size_bytes" type="int" default="0" />
 			<description>
 				Returns a copy of the data of the specified [param buffer], optionally [param offset_bytes] and [param size_bytes] can be set to copy only a portion of the buffer.
+				[b]Note:[/b] This method will block the GPU from working until the data is retrieved. Refer to [method buffer_get_data_async] for an alternative that returns the data in more performant way.
+			</description>
+		</method>
+		<method name="buffer_get_data_async">
+			<return type="int" enum="Error" />
+			<param index="0" name="buffer" type="RID" />
+			<param index="1" name="callback" type="Callable" />
+			<param index="2" name="offset_bytes" type="int" default="0" />
+			<param index="3" name="size_bytes" type="int" default="0" />
+			<description>
+				Asynchronous version of [method buffer_get_data]. RenderingDevice will call [param callback] in a certain amount of frames with the data the buffer had at the time of the request.
+				[b]Note:[/b] At the moment, the delay corresponds to the amount of frames specified by [member ProjectSettings.rendering/rendering_device/vsync/frame_queue_size].
+				[b]Note:[/b] Downloading large buffers can have a prohibitive cost for real-time even when using the asynchronous method due to hardware bandwidth limitations. When dealing with large resources, you can adjust settings such as [member ProjectSettings.rendering/rendering_device/staging_buffer/block_size_kb] to improve the transfer speed at the cost of extra memory.
+				[codeblock]
+				func _buffer_get_data_callback(array):
+				    value = array.decode_u32(0)
+
+				...
+
+				rd.buffer_get_data_async(buffer, _buffer_get_data_callback)
+				[/codeblock]
 			</description>
 		</method>
 		<method name="buffer_update">
@@ -928,6 +949,26 @@
 				Returns the [param texture] data for the specified [param layer] as raw binary data. For 2D textures (which only have one layer), [param layer] must be [code]0[/code].
 				[b]Note:[/b] [param texture] can't be retrieved while a draw list that uses it as part of a framebuffer is being created. Ensure the draw list is finalized (and that the color/depth texture using it is not set to [constant FINAL_ACTION_CONTINUE]) to retrieve this texture. Otherwise, an error is printed and a empty [PackedByteArray] is returned.
 				[b]Note:[/b] [param texture] requires the [constant TEXTURE_USAGE_CAN_COPY_FROM_BIT] to be retrieved. Otherwise, an error is printed and a empty [PackedByteArray] is returned.
+				[b]Note:[/b] This method will block the GPU from working until the data is retrieved. Refer to [method texture_get_data_async] for an alternative that returns the data in more performant way.
+			</description>
+		</method>
+		<method name="texture_get_data_async">
+			<return type="int" enum="Error" />
+			<param index="0" name="texture" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="callback" type="Callable" />
+			<description>
+				Asynchronous version of [method texture_get_data]. RenderingDevice will call [param callback] in a certain amount of frames with the data the texture had at the time of the request.
+				[b]Note:[/b] At the moment, the delay corresponds to the amount of frames specified by [member ProjectSettings.rendering/rendering_device/vsync/frame_queue_size].
+				[b]Note:[/b] Downloading large textures can have a prohibitive cost for real-time even when using the asynchronous method due to hardware bandwidth limitations. When dealing with large resources, you can adjust settings such as [member ProjectSettings.rendering/rendering_device/staging_buffer/texture_download_region_size_px] and [member ProjectSettings.rendering/rendering_device/staging_buffer/block_size_kb] to improve the transfer speed at the cost of extra memory.
+				[codeblock]
+				func _texture_get_data_callback(array):
+				    value = array.decode_u32(0)
+
+				...
+
+				rd.texture_get_data_async(texture, 0, _texture_get_data_callback)
+				[/codeblock]
 			</description>
 		</method>
 		<method name="texture_get_format">


### PR DESCRIPTION
### Background

This implements the feature proposed in the discussion originated by https://github.com/godotengine/godot/issues/99750.

As proposed by Clay [here](https://github.com/godotengine/godot/issues/99750#issuecomment-2504553147).

> Instead we can add texture_get_data_async(RID, callback) which returns immediately, but calls the callback once the data is ready. The callback would always be a function with the structure func some_name(PackedByteArray) where the user can then do what they will with that array, the same as if they had called texture_get_data().

This PR does exactly that for `buffer_get_data` and `texture_get_data`. These now have asynchronous variants which will trigger the callback when the frame the data retrieval was requested is flushed. This opens a way for users to request data downloads back to the CPU without introducing heavy stalls on their game that affect performance.

As seen on the issue, this also fixes a perceived regression caused by the introduction of thread guards for `RenderingDevice` in https://github.com/godotengine/godot/pull/90400, where users were allowed to previously access these functions from another thread and request the data without blocking the main thread, but being unaware they were causing the entire device to flush the frames out and reduce performance in the process.

Here's an example script that showcases how to use these functions.
```gdscript
extends Node2D

var rd
var in_counter
var out_counter
var buffer
var in_array
var out_array
var data
var format
var view
var texture
var texture_values

func _init():
	rd = RenderingServer.get_rendering_device()
	buffer = rd.storage_buffer_create(4)
	in_counter = 0;
	in_array = PackedByteArray()
	in_array.resize(4)
	
	data = [ PackedByteArray() ]
	format = RDTextureFormat.new()
	format.width = 4
	format.height = 4
	format.format = RenderingDevice.DATA_FORMAT_R8_UINT
	format.usage_bits = RenderingDevice.TEXTURE_USAGE_SAMPLING_BIT | RenderingDevice.TEXTURE_USAGE_CAN_COPY_FROM_BIT
	
	view = RDTextureView.new()
	data[0].resize(16)
	data[0].encode_u32(0, 0xFF0000FF)
	data[0].encode_u32(4, 0xFF0000FF)
	data[0].encode_u32(8, 0x00FF00FF)
	data[0].encode_u32(12, 0x0000FFFF)
	texture = rd.texture_create(format, view, data)
	texture_values = [0, 0, 0, 0]
	pass

func _buffer_get_data_callback(array):
	out_counter = array.decode_u32(0)
	pass
	
func _texture_get_data_callback(array):
	texture_values[0] = array.decode_u32(0)
	texture_values[1] = array.decode_u32(4)
	texture_values[2] = array.decode_u32(8)
	texture_values[3] = array.decode_u32(12)
	pass

func _process(_delta):
	in_counter += 1
	in_array.encode_u32(0, in_counter)
	rd.buffer_update(buffer, 0, in_array.size(), in_array)
	rd.buffer_get_data_async(buffer, _buffer_get_data_callback, 0, in_array.size())
	rd.texture_get_data_async(texture, 0, _texture_get_data_callback)
	
	$Label.text = "Counter: %X Buffer Value: %X\n(these shouldn't match if it's async)\nTexture Values: %X %X %X %X" % [in_counter, out_counter, texture_values[0], texture_values[1], texture_values[2], texture_values[3]]
	
	pass
```

CC @RPicster who brought up the issue originally and may wish to test this out.

### Notes

This implementation piggybacks off the fact we already have a structure for staging buffers for uploading data from the CPU to the GPU. This duplicates that concept for the exact opposite purpose, but there's no separate configuration setting for it.

~~There's also an implied restriction, which will currently error out, if the staging buffer's block size is too small to handle one image mipmap. This was mostly done to reduce the complexity of the implementation, but it's not impossible to fix it to allow the function to do it in image chunks instead that can fit inside of the staging buffer's block size. Handling it like this might be implemented at a later point if it's deemed necessary.~~ This restriction has been lifted, but performance can degrade if the block size or region size is too small for the large downloads.

### TODO:
- [x] Documentation.
- [x] Test for validation errors or edge cases.

---

Contributed by [W4 Games](https://w4games.com/). 🍀