### PR TITLE
Use colors and formatting for printing shader errors to console

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1521,12 +1521,12 @@ Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, Ident
 		for (const KeyValue<String, Vector<String>> &E : includes) {
 			if (E.key.is_empty()) {
 				if (p_path == "") {
-					print_line("--Main Shader--");
+					print_line_rich("[b]== Main Shader ==[/b]");
 				} else {
-					print_line("--" + p_path + "--");
+					print_line_rich("[b]-- " + p_path + " --[/b]");
 				}
 			} else {
-				print_line("--" + E.key + "--");
+				print_line_rich("[b]-- " + E.key + " --[/b]");
 			}
 			int err_line = -1;
 			for (int i = 0; i < include_positions.size(); i++) {
@@ -1539,7 +1539,7 @@ Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, Ident
 				if (i == err_line - 1) {
 					// Mark the error line to be visible without having to look at
 					// the trace at the end.
-					print_line(vformat("E%4d-> %s", i + 1, V[i]));
+					print_line_rich(vformat("[color=red][b]E%4d->[/b] %s[/color]", i + 1, V[i]));
 				} else {
 					print_line(vformat("%5d | %s", i + 1, V[i]));
 				}


### PR DESCRIPTION
This only affects errors in user-made shaders, not errors in core shaders which are handled differently.

- Related to https://github.com/godotengine/godot/pull/95495.

## Preview

> [!NOTE]
>
> Colors could be improved using https://github.com/godotengine/godot/pull/77114.

### Before

![Shader error in Output panel without colors](https://github.com/user-attachments/assets/eb12ad26-0c41-49ed-bf44-4cc043aec2bd)

### After

![Shader error in Output panel with colors](https://github.com/user-attachments/assets/99ccdaf1-e826-48a5-8a30-e4f312e32c76)