### PR TITLE
Move uniform variables up in the `gles3/scene.glsl` template so that they are available within the `#GLOBALS` scope

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -974,6 +974,10 @@ layout(std140) uniform MultiviewData { // ubo:8
 multiview_data;
 #endif
 
+uniform highp mat4 world_transform;
+uniform highp uint instance_offset;
+uniform highp uint model_flags;
+
 /* clang-format off */
 
 #GLOBALS
@@ -1199,10 +1203,7 @@ ivec2 multiview_uv(ivec2 uv) {
 }
 #endif
 
-uniform highp mat4 world_transform;
 uniform mediump float opaque_prepass_threshold;
-uniform highp uint model_flags;
-uniform highp uint instance_offset;
 
 #if defined(RENDER_MATERIAL)
 layout(location = 0) out vec4 albedo_output_buffer;


### PR DESCRIPTION
This PR should:
Resolve #100080 

As well as prevent future issues in which the following uniform variables are needed (yet not defined) within '#GLOBALS'.

The following 3 uniform variables were previously defined after '#GLOBALS' within the fragment shader of 'drivers/gles3/shaders/scene.glsl':
```
uniform highp mat4 world_transform;
uniform highp uint instance_offset; 
uniform highp uint model_flags;
```
But there may be instances in which these variables are needed within '#GLOBALS'. To keep consistency with the vertex shader in the same file, I have moved these definitions to just below the
```
#ifdef USE_MULTIVIEW
...
#endif
```
Preprocessor directive.
