### PR TITLE
Add missing `GDVIRTUAL_BIND()` for `AudioStream::_has_loop()` and `::_get_bar_beats()`

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -13,6 +13,12 @@
 		<link title="Audio Spectrum Visualizer Demo">https://godotengine.org/asset-library/asset/2762</link>
 	</tutorials>
 	<methods>
+		<method name="_get_bar_beats" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+				Override this method to return the bar beats of this stream.
+			</description>
+		</method>
 		<method name="_get_beat_count" qualifiers="virtual const">
 			<return type="int" />
 			<description>
@@ -43,6 +49,12 @@
 			<return type="String" />
 			<description>
 				Override this method to customize the name assigned to this audio stream. Unused by the engine.
+			</description>
+		</method>
+		<method name="_has_loop" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+				Override this method to return [code]true[/code] if this stream has a loop.
 			</description>
 		</method>
 		<method name="_instantiate_playback" qualifiers="virtual const">

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -352,6 +352,8 @@ void AudioStream::_bind_methods() {
 	GDVIRTUAL_BIND(_get_bpm)
 	GDVIRTUAL_BIND(_get_beat_count)
 	GDVIRTUAL_BIND(_get_parameter_list)
+	GDVIRTUAL_BIND(_has_loop);
+	GDVIRTUAL_BIND(_get_bar_beats);
 
 	ADD_SIGNAL(MethodInfo("parameter_list_changed"));
 }


### PR DESCRIPTION
On https://github.com/godotengine/godot/issues/99933, @Bromeon noticed that there were some `GDVIRTUAL_CALL()`'s that didn't have corresponding `GDVIRTUAL_BIND()`'s registering the virtual methods.

This PR adds them!

I'm at a little bit of a loss with regard to the documentation, because I don't really know what the data returned from these virtual methods means, so if anyone knows, please let me know and I'll update it! Otherwise, having something in the docs is better than having the methods missing entirely :-)