### PR TITLE
Avoid error spam when shaders fail to compile by freeing shader_data version when compilation fails

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -4642,7 +4642,7 @@ void RenderForwardClustered::mesh_generate_pipelines(RID p_mesh, bool p_backgrou
 		void *mesh_surface = mesh_storage->mesh_get_surface(p_mesh, i);
 		void *mesh_surface_shadow = mesh_surface;
 		SceneShaderForwardClustered::MaterialData *material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(materials[i], RendererRD::MaterialStorage::SHADER_TYPE_3D));
-		if (material == nullptr) {
+		if (material == nullptr || !material->shader_data->is_valid()) {
 			continue;
 		}
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -143,7 +143,14 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	MutexLock lock(SceneShaderForwardClustered::singleton_mutex);
 	Error err = SceneShaderForwardClustered::singleton->compiler.compile(RS::SHADER_SPATIAL, code, &actions, path, gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+
+	if (err != OK) {
+		if (version.is_valid()) {
+			SceneShaderForwardClustered::singleton->shader.version_free(version);
+			version = RID();
+		}
+		ERR_FAIL_MSG("Shader compilation failed.");
+	}
 
 	if (version.is_null()) {
 		version = SceneShaderForwardClustered::singleton->shader.version_create();

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -294,7 +294,7 @@ void RenderForwardMobile::mesh_generate_pipelines(RID p_mesh, bool p_background_
 		void *mesh_surface = mesh_storage->mesh_get_surface(p_mesh, i);
 		void *mesh_surface_shadow = mesh_surface;
 		SceneShaderForwardMobile::MaterialData *material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(materials[i], RendererRD::MaterialStorage::SHADER_TYPE_3D));
-		if (material == nullptr) {
+		if (material == nullptr || !material->shader_data->is_valid()) {
 			continue;
 		}
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -143,7 +143,14 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 
 	MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
 	Error err = SceneShaderForwardMobile::singleton->compiler.compile(RS::SHADER_SPATIAL, code, &actions, path, gen_code);
-	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+
+	if (err != OK) {
+		if (version.is_valid()) {
+			SceneShaderForwardMobile::singleton->shader.version_free(version);
+			version = RID();
+		}
+		ERR_FAIL_MSG("Shader compilation failed.");
+	}
 
 	if (version.is_null()) {
 		version = SceneShaderForwardMobile::singleton->shader.version_create();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/99263

#99263 is a regression from https://github.com/godotengine/godot/pull/90400

Previously the ShaderData class would set its member valid to false when about to compile and then set it to true if compilation was successful (both shader compilation and setting up pipelines). IIRC we removed that since we needed to shift around how the shader was compiled run asynchronously.

Then, when setting up geometry for drawing we checked if the shader_data of a material was valid, if not, we could fall back to the default material.

Now instead of checking if !shader_data->valid, we check if the `shader_data->version.is_valid()`. The `version` is allocated the first time the shader succeeds at compiling. After that, `shader_data.is_valid()` will always return true. Accordingly, a way to fix this is to free the `version` if it exists already and the compilation fails. 