### PR TITLE
Fix multiple scene changes that may cause the `SceneTree::current_scene` to be lost

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1516,8 +1516,8 @@ void SceneTree::_flush_scene_change() {
 		prev_scene = nullptr;
 	}
 	current_scene = pending_new_scene;
-	root->add_child(pending_new_scene);
 	pending_new_scene = nullptr;
+	root->add_child(current_scene);
 	// Update display for cursor instantly.
 	root->update_mouse_cursor_state();
 }


### PR DESCRIPTION
Fix #99896.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
