### PR TITLE
Fix button text and dependency list not updating after resolving dependencies

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -219,7 +219,7 @@ void DependencyEditor::_update_list() {
 
 		item->add_button(1, folder, 0);
 	}
-
+	on_update(missing);
 	fixdeps->set_disabled(!broken);
 }
 
@@ -757,7 +757,20 @@ void DependencyErrorDialog::ok_pressed() {
 }
 
 void DependencyErrorDialog::custom_action(const String &) {
-	EditorNode::get_singleton()->fix_dependencies(for_file);
+	EditorNode::get_singleton()->fix_dependencies( for_file, std::bind(&DependencyErrorDialog::on_update_callback, this, std::placeholders::_1) );
+}
+
+void DependencyErrorDialog::on_update_callback(Vector<String> report) {
+	if (report.is_empty()) {
+		files->clear();
+		set_ok_button_text(TTR("Open"));
+	}
+	auto len = files->get_size().length();
+	printf("%f", len);
+	// for (auto &r : report) {
+		
+	// 	if ()
+	// }
 }
 
 DependencyErrorDialog::DependencyErrorDialog() {

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -765,12 +765,25 @@ void DependencyErrorDialog::on_update_callback(Vector<String> report) {
 		files->clear();
 		set_ok_button_text(TTR("Open"));
 	}
-	auto len = files->get_size().length();
-	printf("%f", len);
-	// for (auto &r : report) {
-		
-	// 	if ()
-	// }
+
+	// recreating files to update the popup list
+	files->clear();
+
+	TreeItem *root = files->create_item(nullptr);
+	for (int i = 0; i < report.size(); i++) {
+		String dep;
+		String type = "Object";
+		dep = report[i].get_slice("::", 0);
+		if (report[i].get_slice_count("::") > 0) {
+			type = report[i].get_slice("::", 1);
+		}
+
+		Ref<Texture2D> icon = EditorNode::get_singleton()->get_class_icon(type);
+
+		TreeItem *ti = files->create_item(root);
+		ti->set_text(0, dep);
+		ti->set_icon(0, icon);
+	}
 }
 
 DependencyErrorDialog::DependencyErrorDialog() {

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -31,6 +31,7 @@
 #ifndef DEPENDENCY_EDITOR_H
 #define DEPENDENCY_EDITOR_H
 
+#include <functional>
 #include "scene/gui/box_container.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
@@ -50,7 +51,9 @@ class DependencyEditor : public AcceptDialog {
 
 	String replacing;
 	String editing;
-	List<String> missing;
+	Vector<String> missing;
+
+	std::function<void(Vector<String>)> on_update = [](Vector<String>){};
 
 	void _fix_and_find(EditorFileSystemDirectory *efsd, HashMap<String, HashMap<String, String>> &candidates);
 
@@ -63,6 +66,7 @@ class DependencyEditor : public AcceptDialog {
 
 public:
 	void edit(const String &p_path);
+	void register_onupdate_callback(std::function<void(Vector<String>)> p_on_update) { on_update = p_on_update; };
 	DependencyEditor();
 };
 
@@ -153,6 +157,7 @@ private:
 	Tree *files = nullptr;
 	void ok_pressed() override;
 	void custom_action(const String &) override;
+	void on_update_callback(Vector<String>);
 
 public:
 	void show(Mode p_mode, const String &p_for_file, const Vector<String> &report);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3919,7 +3919,8 @@ bool EditorNode::is_multi_window_enabled() const {
 	return !SceneTree::get_singleton()->get_root()->is_embedding_subwindows() && !EDITOR_GET("interface/editor/single_window_mode") && EDITOR_GET("interface/multi_window/enable");
 }
 
-void EditorNode::fix_dependencies(const String &p_for_file) {
+void EditorNode::fix_dependencies(const String &p_for_file, std::function<void(Vector<String>)> p_on_update) {
+	dependency_fixer->register_onupdate_callback(p_on_update);
 	dependency_fixer->edit(p_for_file);
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -31,6 +31,7 @@
 #ifndef EDITOR_NODE_H
 #define EDITOR_NODE_H
 
+#include <functional>
 #include "core/object/script_language.h"
 #include "core/templates/safe_refcount.h"
 #include "editor/editor_data.h"
@@ -780,7 +781,7 @@ public:
 	void set_edited_scene_root(Node *p_scene, bool p_auto_add);
 	Node *get_edited_scene() { return editor_data.get_edited_scene_root(); }
 
-	void fix_dependencies(const String &p_for_file);
+	void fix_dependencies(const String &p_for_file, std::function<void(Vector<String>)> p_on_update);
 	int new_scene();
 	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false, bool p_silent_change_tab = false);
 	Error load_resource(const String &p_resource, bool p_ignore_broken_deps = false);


### PR DESCRIPTION
Fix #56397
This PR still needs work to do and is therefore marked as draft.
For now the implementation has resolved the button and list updating issues but is using the STL library which is not permitted in Godot. The correct usage of the "Callable" class is the remaining work.