### PR TITLE
Align CowData data with its actual data instead of `max_align_t`.

### DIFF
--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -41,8 +41,13 @@
 template <size_t previous_offset, typename PreviousType, typename NextType>
 constexpr size_t memory_get_offset() {
 	size_t free_addr = previous_offset + sizeof(PreviousType);
-	size_t n_bytes_unaligned = free_addr % alignof(NextType);
-	return (n_bytes_unaligned == 0) ? free_addr : (free_addr + alignof(NextType) - n_bytes_unaligned);
+	size_t alignment = alignof(NextType);
+
+	if (alignment == 0) {
+		return free_addr;
+	}
+	size_t n_bytes_unaligned = free_addr % alignment;
+	return (n_bytes_unaligned == 0) ? free_addr : (free_addr + alignment - n_bytes_unaligned);
 }
 
 class Memory {

--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -68,12 +68,18 @@ void remove_print_handler(const PrintHandlerList *p_handler) {
 	ERR_FAIL_NULL(l);
 }
 
+SafeNumeric<uint64_t> _MEM_ADDED;
+
 void __print_line(const String &p_string) {
 	if (!CoreGlobals::print_line_enabled) {
 		return;
 	}
 
+	static auto start = std::chrono::high_resolution_clock::now();
 	OS::get_singleton()->print("%s\n", p_string.utf8().get_data());
+	OS::get_singleton()->print("%llu\n", _MEM_ADDED.get());
+	auto diff = std::chrono::high_resolution_clock::now() - start;
+	OS::get_singleton()->print("%llu\n", std::chrono::duration_cast<std::chrono::microseconds>(diff).count());
 
 	_global_lock();
 	PrintHandlerList *l = print_handler_list;

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -89,7 +89,7 @@ private:
 		return ++x;
 	}
 
-	// Alignment:  ↓ max_align_t           ↓ USize          ↓ max_align_t
+	// Alignment:  ↓ max_align_t           ↓ USize          ↓ T
 	//             ┌────────────────────┬──┬─────────────┬──┬───────────...
 	//             │ SafeNumeric<USize> │░░│ USize       │░░│ T[]
 	//             │ ref. count         │░░│ data size   │░░│ data
@@ -98,7 +98,7 @@ private:
 
 	static constexpr size_t REF_COUNT_OFFSET = 0;
 	static constexpr size_t SIZE_OFFSET = memory_get_offset<REF_COUNT_OFFSET, SafeNumeric<USize>, USize>();
-	static constexpr size_t DATA_OFFSET = memory_get_offset<SIZE_OFFSET, USize, max_align_t>();
+	static constexpr size_t DATA_OFFSET = memory_get_offset<SIZE_OFFSET, USize, T>();
 
 	mutable T *_ptr = nullptr;
 

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -97,8 +97,8 @@ private:
 	// Offset:     ↑ REF_COUNT_OFFSET      ↑ SIZE_OFFSET    ↑ DATA_OFFSET
 
 	static constexpr size_t REF_COUNT_OFFSET = 0;
-	static constexpr size_t SIZE_OFFSET = ((REF_COUNT_OFFSET + sizeof(SafeNumeric<USize>)) % alignof(USize) == 0) ? (REF_COUNT_OFFSET + sizeof(SafeNumeric<USize>)) : ((REF_COUNT_OFFSET + sizeof(SafeNumeric<USize>)) + alignof(USize) - ((REF_COUNT_OFFSET + sizeof(SafeNumeric<USize>)) % alignof(USize)));
-	static constexpr size_t DATA_OFFSET = ((SIZE_OFFSET + sizeof(USize)) % alignof(max_align_t) == 0) ? (SIZE_OFFSET + sizeof(USize)) : ((SIZE_OFFSET + sizeof(USize)) + alignof(max_align_t) - ((SIZE_OFFSET + sizeof(USize)) % alignof(max_align_t)));
+	static constexpr size_t SIZE_OFFSET = memory_get_offset<REF_COUNT_OFFSET, SafeNumeric<USize>, USize>();
+	static constexpr size_t DATA_OFFSET = memory_get_offset<SIZE_OFFSET, USize, max_align_t>();
 
 	mutable T *_ptr = nullptr;
 


### PR DESCRIPTION
This decreases alignment of all CowData on some systems from 16 bytes down to 8, decreasing memory use slightly.

For example, `alignof(max_align_t)` is 16 on macOS. The starting offset is guaranteed to be in alignment to `uint64_t`, due to the previous struct entry, which is 8. Since we don't use `long long` or `long double`, this means we can save 8 bytes for every `CowData` instance without breaking alignment.

Includes #100145.