### PR TITLE
Remove apparent contradiction in vector.h header

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -33,7 +33,10 @@
 
 /**
  * @class Vector
- * Vector container. Regular Vector Container. Use with care and for smaller arrays when possible. Use Vector for large arrays.
+ * Vector container. Simple copy-on-write container.
+ *
+ * LocalVector is an alternative available for internal use when COW is not
+ * required.
  */
 
 #include "core/error/error_macros.h"


### PR DESCRIPTION
3205a92ad8 was a major commit which removed `PoolVector`, and replaced most references to `PoolVector` with `Vector` instead. In most cases, this was appropriate, given that `PoolVector` was being replaced with `Vector`, as an effective generalist in 64-bit address space layouts.

However, vector.h itself was left with an artifact advising the reader to use `Vector` instead of `Vector` for large arrays. While this led to a fascinating deep dive, and hopefully improved some of the documentation along the way, it's probably best to clean this up for the next person.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
