### PR TITLE
Fix scroll to symbol's documentation

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -712,6 +712,7 @@
 		<signal name="finished">
 			<description>
 				Triggered when the document is fully loaded.
+				[b]Note:[/b] This can happen before the text is processed for drawing. Scrolling values may not be valid until the document is drawn for the first time after this signal.
 			</description>
 		</signal>
 		<signal name="meta_clicked">

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -270,7 +270,7 @@ void EditorHelp::_search(bool p_search_previous) {
 
 void EditorHelp::_class_desc_finished() {
 	if (scroll_to >= 0) {
-		class_desc->scroll_to_paragraph(scroll_to);
+		class_desc->connect(SceneStringName(draw), callable_mp(class_desc, &RichTextLabel::scroll_to_paragraph).bind(scroll_to), CONNECT_ONE_SHOT | CONNECT_DEFERRED);
 	}
 	scroll_to = -1;
 }


### PR DESCRIPTION
- Fix: https://github.com/godotengine/godot/issues/100087

Same fix as https://github.com/godotengine/godot/pull/90035 but for a different code path.
A doc page goes through this code path the first time it opens but depending on the device it will execute too early so the correct offsets weren't calculated yet.