### PR TITLE
Fix tutorial links after documentation reorganization

### DIFF
--- a/doc/classes/DirAccess.xml
+++ b/doc/classes/DirAccess.xml
@@ -63,7 +63,7 @@
 		Keep in mind that file names may change or be remapped after export. If you want to see the actual resource file list as it appears in the editor, use [method ResourceLoader.list_directory] instead.
 	</description>
 	<tutorials>
-		<link title="File system">$DOCS_URL/tutorials/scripting/filesystem.html</link>
+		<link title="File system">$DOCS_URL/tutorials/core/filesystem.html</link>
 	</tutorials>
 	<methods>
 		<method name="change_dir">

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -38,7 +38,7 @@
 		[b]Note:[/b] Files are automatically closed only if the process exits "normally" (such as by clicking the window manager's close button or pressing [b]Alt + F4[/b]). If you stop the project execution by pressing [b]F8[/b] while the project is running, the file won't be closed as the game process will be killed. You can work around this by calling [method flush] at regular intervals.
 	</description>
 	<tutorials>
-		<link title="File system">$DOCS_URL/tutorials/scripting/filesystem.html</link>
+		<link title="File system">$DOCS_URL/tutorials/core/filesystem.html</link>
 		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/2755</link>
 	</tutorials>

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -10,7 +10,7 @@
 		[b]Note:[/b] In C#, resources will not be freed instantly after they are no longer in use. Instead, garbage collection will run periodically and will free resources that are no longer in use. This means that unused resources will remain in memory for a while before being removed.
 	</description>
 	<tutorials>
-		<link title="Resources">$DOCS_URL/tutorials/scripting/resources.html</link>
+		<link title="Resources">$DOCS_URL/tutorials/core/resources.html</link>
 		<link title="When and how to avoid using nodes for everything">$DOCS_URL/tutorials/best_practices/node_alternatives.html</link>
 	</tutorials>
 	<methods>

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -9,7 +9,7 @@
 		[SceneTree] is the default [MainLoop] implementation used by the engine, and is thus in charge of the game loop.
 	</description>
 	<tutorials>
-		<link title="SceneTree">$DOCS_URL/tutorials/scripting/scene_tree.html</link>
+		<link title="SceneTree">$DOCS_URL/tutorials/core/scenes/scene_tree.html</link>
 		<link title="Multiple resolutions">$DOCS_URL/tutorials/rendering/multiple_resolutions.html</link>
 	</tutorials>
 	<methods>
@@ -273,7 +273,7 @@
 			To handle 'Go Back' button when this option is disabled, use [constant DisplayServer.WINDOW_EVENT_GO_BACK_REQUEST].
 		</member>
 		<member name="root" type="Window" setter="" getter="get_root">
-			The tree's root [Window]. This is top-most [Node] of the scene tree, and is always present. An absolute [NodePath] always starts from this node. Children of the root node may include the loaded [member current_scene], as well as any [url=$DOCS_URL/tutorials/scripting/singletons_autoload.html]AutoLoad[/url] configured in the Project Settings.
+			The tree's root [Window]. This is top-most [Node] of the scene tree, and is always present. An absolute [NodePath] always starts from this node. Children of the root node may include the loaded [member current_scene], as well as any [url=$DOCS_URL/tutorials/core/singletons_autoload.html]AutoLoad[/url] configured in the Project Settings.
 			[b]Warning:[/b] Do not delete this node. This will result in unstable behavior, followed by a crash.
 		</member>
 	</members>


### PR DESCRIPTION
Required if https://github.com/godotengine/godot-docs/pull/10384 is approved.

Marked as draft until that PR is finalized and approved.