### PR TITLE
Use `CONNECT_INHERITED` only in edited scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4136,7 +4136,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		sdata->set_path(lpath, true); // Take over path.
 	}
 
-	Node *new_scene = sdata->instantiate(p_set_inherited ? PackedScene::GEN_EDIT_STATE_MAIN_INHERITED : PackedScene::GEN_EDIT_STATE_MAIN);
+	Node *new_scene = sdata->instantiate_edited_scene(p_set_inherited ? PackedScene::GEN_EDIT_STATE_MAIN_INHERITED : PackedScene::GEN_EDIT_STATE_MAIN);
 	if (!new_scene) {
 		sdata.unref();
 		_dialog_display_load_error(lpath, ERR_FILE_CORRUPT);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -123,7 +123,7 @@ Ref<Resource> SceneState::get_remap_resource(const Ref<Resource> &p_resource, Ha
 	return remap_resource;
 }
 
-Node *SceneState::instantiate(GenEditState p_edit_state) const {
+Node *SceneState::instantiate(GenEditState p_edit_state, bool p_is_edited_scene) const {
 	// Nodes where instantiation failed (because something is missing.)
 	List<Node *> stray_instances;
 
@@ -195,7 +195,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			// Scene inheritance on root node.
 			Ref<PackedScene> sdata = props[base_scene_idx];
 			ERR_FAIL_COND_V(sdata.is_null(), nullptr);
-			node = sdata->instantiate(p_edit_state == GEN_EDIT_STATE_DISABLED ? PackedScene::GEN_EDIT_STATE_DISABLED : PackedScene::GEN_EDIT_STATE_INSTANCE); //only main gets main edit state
+			node = _instantiate_sub_scene(sdata, p_edit_state == GEN_EDIT_STATE_DISABLED ? GEN_EDIT_STATE_DISABLED : GEN_EDIT_STATE_INSTANCE, p_is_edited_scene); // Only main gets main edit state.
 			ERR_FAIL_NULL_V(node, nullptr);
 			if (p_edit_state != GEN_EDIT_STATE_DISABLED) {
 				node->set_scene_inherited_state(sdata->get_state());
@@ -208,7 +208,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				if (disable_placeholders) {
 					Ref<PackedScene> sdata = ResourceLoader::load(scene_path, "PackedScene");
 					if (sdata.is_valid()) {
-						node = sdata->instantiate(p_edit_state == GEN_EDIT_STATE_DISABLED ? PackedScene::GEN_EDIT_STATE_DISABLED : PackedScene::GEN_EDIT_STATE_INSTANCE);
+						node = _instantiate_sub_scene(sdata, p_edit_state == GEN_EDIT_STATE_DISABLED ? GEN_EDIT_STATE_DISABLED : GEN_EDIT_STATE_INSTANCE, p_is_edited_scene);
 						ERR_FAIL_NULL_V(node, nullptr);
 					} else if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
 						missing_node = memnew(MissingNode);
@@ -228,7 +228,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				Ref<Resource> res = props[n.instance & FLAG_MASK];
 				Ref<PackedScene> sdata = res;
 				if (sdata.is_valid()) {
-					node = sdata->instantiate(p_edit_state == GEN_EDIT_STATE_DISABLED ? PackedScene::GEN_EDIT_STATE_DISABLED : PackedScene::GEN_EDIT_STATE_INSTANCE);
+					node = _instantiate_sub_scene(sdata, p_edit_state == GEN_EDIT_STATE_DISABLED ? GEN_EDIT_STATE_DISABLED : GEN_EDIT_STATE_INSTANCE, p_is_edited_scene);
 					ERR_FAIL_NULL_V_MSG(node, nullptr, vformat("Failed to load scene dependency: \"%s\". Make sure the required scene is valid.", sdata->get_path()));
 				} else if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
 					missing_node = memnew(MissingNode);
@@ -607,7 +607,13 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 			callable = callable.bindp(argptrs, binds.size());
 		}
 
-		cfrom->connect(snames[c.signal], callable, CONNECT_PERSIST | c.flags | (p_edit_state == GEN_EDIT_STATE_MAIN ? 0 : CONNECT_INHERITED));
+		int flags = CONNECT_PERSIST | c.flags;
+#ifdef TOOLS_ENABLED
+		if (p_is_edited_scene && p_edit_state != GEN_EDIT_STATE_MAIN) {
+			flags |= CONNECT_INHERITED;
+		}
+#endif
+		cfrom->connect(snames[c.signal], callable, flags);
 	}
 
 	//Node *s = ret_nodes[0];
@@ -1061,6 +1067,12 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 				continue;
 			}
 
+			// Don't include signals that are from scene instances
+			// (they are already saved in the scenes themselves).
+			if (c.flags & CONNECT_INHERITED) {
+				continue;
+			}
+
 			// only connections that originate or end into main saved scene are saved
 			// everything else is discarded
 
@@ -1233,6 +1245,18 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 	}
 
 	return OK;
+}
+
+Node *SceneState::_instantiate_sub_scene(const Ref<PackedScene> &p_scene, GenEditState p_edit_state, bool p_is_edited_scene) const {
+#ifdef TOOLS_ENABLED
+	if (p_edit_state) {
+		return p_scene->instantiate_edited_scene((PackedScene::GenEditState)p_edit_state);
+	} else {
+		return p_scene->instantiate((PackedScene::GenEditState)p_edit_state);
+	}
+#else
+	return p_scene->instantiate(PackedScene::GEN_EDIT_STATE_DISABLED);
+#endif
 }
 
 Error SceneState::pack(Node *p_scene) {
@@ -2172,7 +2196,11 @@ Node *PackedScene::instantiate(GenEditState p_edit_state) const {
 	ERR_FAIL_COND_V_MSG(p_edit_state != GEN_EDIT_STATE_DISABLED, nullptr, "Edit state is only for editors, does not work without tools compiled.");
 #endif
 
+#ifdef TOOLS_ENABLED
+	Node *s = state->instantiate((SceneState::GenEditState)p_edit_state, is_edited_scene);
+#else
 	Node *s = state->instantiate((SceneState::GenEditState)p_edit_state);
+#endif
 	if (!s) {
 		return nullptr;
 	}
@@ -2189,6 +2217,15 @@ Node *PackedScene::instantiate(GenEditState p_edit_state) const {
 
 	return s;
 }
+
+#ifdef TOOLS_ENABLED
+Node *PackedScene::instantiate_edited_scene(GenEditState p_edit_state) {
+	is_edited_scene = true;
+	Node *instance = instantiate(p_edit_state);
+	is_edited_scene = false;
+	return instance;
+}
+#endif
 
 void PackedScene::replace_state(Ref<SceneState> p_by) {
 	state = p_by;

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -134,6 +134,10 @@ public:
 		int node = -1;
 	};
 
+private:
+	Node *_instantiate_sub_scene(const Ref<PackedScene> &p_scene, GenEditState p_edit_state, bool p_is_edited_scene) const;
+
+public:
 	static void set_disable_placeholders(bool p_disable);
 	static Ref<Resource> get_remap_resource(const Ref<Resource> &p_resource, HashMap<Ref<Resource>, Ref<Resource>> &remap_cache, const Ref<Resource> &p_fallback, Node *p_for_scene);
 
@@ -154,7 +158,7 @@ public:
 	Error copy_from(const Ref<SceneState> &p_scene_state);
 
 	bool can_instantiate() const;
-	Node *instantiate(GenEditState p_edit_state) const;
+	Node *instantiate(GenEditState p_edit_state, bool p_is_edited_scene = false) const;
 
 	Array setup_resources_in_array(Array &array_to_scan, const SceneState::NodeData &n, HashMap<Ref<Resource>, Ref<Resource>> &resources_local_to_sub_scene, Node *node, const StringName sname, HashMap<Ref<Resource>, Ref<Resource>> &resources_local_to_scene, int i, Node **ret_nodes, SceneState::GenEditState p_edit_state) const;
 	Dictionary setup_resources_in_dictionary(Dictionary &p_dictionary_to_scan, const SceneState::NodeData &p_n, HashMap<Ref<Resource>, Ref<Resource>> &p_resources_local_to_sub_scene, Node *p_node, const StringName p_sname, HashMap<Ref<Resource>, Ref<Resource>> &p_resources_local_to_scene, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
@@ -256,6 +260,10 @@ public:
 
 	bool can_instantiate() const;
 	Node *instantiate(GenEditState p_edit_state = GEN_EDIT_STATE_DISABLED) const;
+#ifdef TOOLS_ENABLED
+	bool is_edited_scene = false;
+	Node *instantiate_edited_scene(GenEditState p_edit_state = GEN_EDIT_STATE_DISABLED);
+#endif
 
 	void recreate_state();
 	void replace_state(Ref<SceneState> p_by);


### PR DESCRIPTION
Fixes #48064

The fix assumes that CONNECT_INHERITED is only relevant in the edited scene, it's not applied anywhere else. Let me know if it's incorrect.