### PR TITLE
Fix crash within header_guards when a file is too short

### DIFF
--- a/misc/scripts/header_guards.py
+++ b/misc/scripts/header_guards.py
@@ -36,10 +36,15 @@ for file in sys.argv[1:]:
                 break
 
     if HEADER_CHECK_OFFSET < 0:
+        invalid.append(file)
         continue
 
     HEADER_BEGIN_OFFSET = HEADER_CHECK_OFFSET + 1
     HEADER_END_OFFSET = len(lines) - 1
+
+    if HEADER_BEGIN_OFFSET >= HEADER_END_OFFSET:
+        invalid.append(file)
+        continue
 
     split = file.split("/")  # Already in posix-format.
 


### PR DESCRIPTION
Fixes #98813

When header_guards.py is run, if a file is empty or is too short, the file is included in the files that needs manual changes. header_guards.py no longer crashes when ran on a file that is too short.
