### PR TITLE
Fix missing focus outline for 2D and 3D editor viewports

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1823,8 +1823,6 @@ void EditorThemeManager::_populate_editor_styles(const Ref<EditorTheme> &p_theme
 		p_theme->set_stylebox("Focus", EditorStringName(EditorStyles), p_config.button_style_focus);
 
 		Ref<StyleBoxFlat> style_widget_focus_viewport = p_config.button_style_focus->duplicate();
-		// Make the focus outline appear to be flush with the buttons it's focusing, so not draw on top of the content.
-		style_widget_focus_viewport->set_expand_margin_all(2);
 		// Use a less opaque color to be less distracting for the 2D and 3D editor viewports.
 		style_widget_focus_viewport->set_border_color(p_config.accent_color * Color(1, 1, 1, 0.5));
 		p_theme->set_stylebox("FocusViewport", EditorStringName(EditorStyles), style_widget_focus_viewport);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/100170

Removed line was added in https://github.com/godotengine/godot/pull/97521.
Don't think this style is used anywhere else in the editor.
If the outline should be removed or to prevent overlapping (do people find this a problem?) in the viewport, it needs to be handled in another way.