### PR TITLE
Tweak unknown annotation GDScript error for `@deprecated`/`@experimental`/`@tutorial`

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1624,7 +1624,15 @@ GDScriptParser::AnnotationNode *GDScriptParser::parse_annotation(uint32_t p_vali
 	bool valid = true;
 
 	if (!valid_annotations.has(annotation->name)) {
-		push_error(vformat(R"(Unrecognized annotation: "%s".)", annotation->name));
+		if (annotation->name == "@deprecated") {
+			push_error(R"("@deprecated" annotation does not exist. Use "## @deprecated: Reason here." instead.)");
+		} else if (annotation->name == "@experimental") {
+			push_error(R"("@experimental" annotation does not exist. Use "## @experimental: Reason here." instead.)");
+		} else if (annotation->name == "@tutorial") {
+			push_error(R"("@tutorial" annotation does not exist. Use "## @tutorial(Title): https://example.com" instead.)");
+		} else {
+			push_error(vformat(R"(Unrecognized annotation: "%s".)", annotation->name));
+		}
 		valid = false;
 	}
 

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_deprecated.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_deprecated.gd
@@ -1,0 +1,5 @@
+# This annotation should be used within a documentation comment instead:
+# ## @deprecated: Reason here.
+
+@deprecated
+var some_variable = "value"

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_deprecated.out
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_deprecated.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+"@deprecated" annotation does not exist. Use "## @deprecated: Reason here." instead.

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_experimental.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_experimental.gd
@@ -1,0 +1,6 @@
+# This annotation should be used within a documentation comment instead:
+# ## @experimental: Reason here.
+
+@experimental("This function isn't implemented yet.")
+func say_hello():
+    pass

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_experimental.out
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_experimental.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+"@experimental" annotation does not exist. Use "## @experimental: Reason here." instead.

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_tutorial.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_tutorial.gd
@@ -1,0 +1,5 @@
+# This annotation should be used within a documentation comment instead:
+# ## @tutorial(Title): https://example.com
+
+@tutorial("https://example.com")
+const SOME_CONSTANT = "value"

--- a/modules/gdscript/tests/scripts/parser/errors/annotation_tutorial.out
+++ b/modules/gdscript/tests/scripts/parser/errors/annotation_tutorial.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+"@tutorial" annotation does not exist. Use "## @tutorial(Title): https://example.com" instead.


### PR DESCRIPTION
These annotations don't exist at a source level, so the error messages point to the documentation comment syntax.

- This closes https://github.com/godotengine/godot-proposals/issues/7622.

**Testing project:** [test_gdscript_deprecated_experimental.zip](https://github.com/user-attachments/files/18052631/test_gdscript_deprecated_experimental.zip)

## Preview

![Annotation errors](https://github.com/user-attachments/assets/f01773ea-c6b9-4c94-bd0d-489f8fff395e)