### PR TITLE
SCons: Fix MSVC bypassing disabled warnings

### DIFF
--- a/drivers/d3d12/d3d12ma.cpp
+++ b/drivers/d3d12/d3d12ma.cpp
@@ -58,7 +58,7 @@
 #endif
 
 #if defined(_MSC_VER)
-#pragma warning(disable : 4189 4324 4505)
+#pragma warning(disable : 4189 4505)
 #endif
 
 #include "thirdparty/d3d12ma/D3D12MemAlloc.cpp"

--- a/methods.py
+++ b/methods.py
@@ -130,9 +130,10 @@ def disable_warnings(self):
     if self.msvc and not using_clang(self):
         # We have to remove existing warning level defines before appending /w,
         # otherwise we get: "warning D9025 : overriding '/W3' with '/w'"
-        self["CCFLAGS"] = [x for x in self["CCFLAGS"] if not (x.startswith("/W") or x.startswith("/w"))]
-        self["CFLAGS"] = [x for x in self["CFLAGS"] if not (x.startswith("/W") or x.startswith("/w"))]
-        self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if not (x.startswith("/W") or x.startswith("/w"))]
+        WARN_FLAGS = ["/Wall", "/W4", "/W3", "/W2", "/W1", "/W0"]
+        self["CCFLAGS"] = [x for x in self["CCFLAGS"] if x not in WARN_FLAGS]
+        self["CFLAGS"] = [x for x in self["CFLAGS"] if x not in WARN_FLAGS]
+        self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if x not in WARN_FLAGS]
         self.AppendUnique(CCFLAGS=["/w"])
     else:
         self.AppendUnique(CCFLAGS=["-w"])

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -31,17 +31,22 @@ thirdparty_sources = [
 ]
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-env_csg.Prepend(
-    CPPPATH=[
-        thirdparty_dir + "include",
-    ]
-)
+env_csg.Prepend(CPPPATH=[thirdparty_dir + "include"])
 env_thirdparty = env_csg.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 env.modules_sources += thirdparty_obj
 
-# Godot's own source files
-env_csg.add_source_files(env.modules_sources, "*.cpp")
+# Godot source files
+
+module_obj = []
+
+env_csg.add_source_files(module_obj, "*.cpp")
+
 if env.editor_build:
-    env_csg.add_source_files(env.modules_sources, "editor/*.cpp")
+    env_csg.add_source_files(module_obj, "editor/*.cpp")
+
+env.modules_sources += module_obj
+
+# Needed to force rebuilding the module files when the thirdparty library is updated.
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/text_server_adv/gdextension_build/methods.py
+++ b/modules/text_server_adv/gdextension_build/methods.py
@@ -77,17 +77,13 @@ def disable_warnings(self):
     if self["platform"] == "windows" and not self["use_mingw"]:
         # We have to remove existing warning level defines before appending /w,
         # otherwise we get: "warning D9025 : overriding '/W3' with '/w'"
-        warn_flags = ["/Wall", "/W4", "/W3", "/W2", "/W1", "/WX"]
-        self.Append(CCFLAGS=["/w"])
-        self.Append(CFLAGS=["/w"])
-        self.Append(CXXFLAGS=["/w"])
-        self["CCFLAGS"] = [x for x in self["CCFLAGS"] if x not in warn_flags]
-        self["CFLAGS"] = [x for x in self["CFLAGS"] if x not in warn_flags]
-        self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if x not in warn_flags]
+        WARN_FLAGS = ["/Wall", "/W4", "/W3", "/W2", "/W1", "/W0"]
+        self["CCFLAGS"] = [x for x in self["CCFLAGS"] if x not in WARN_FLAGS]
+        self["CFLAGS"] = [x for x in self["CFLAGS"] if x not in WARN_FLAGS]
+        self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if x not in WARN_FLAGS]
+        self.AppendUnique(CCFLAGS=["/w"])
     else:
-        self.Append(CCFLAGS=["-w"])
-        self.Append(CFLAGS=["-w"])
-        self.Append(CXXFLAGS=["-w"])
+        self.AppendUnique(CCFLAGS=["-w"])
 
 
 def make_icu_data(target, source, env):

--- a/modules/text_server_fb/gdextension_build/methods.py
+++ b/modules/text_server_fb/gdextension_build/methods.py
@@ -77,17 +77,13 @@ def disable_warnings(self):
     if self["platform"] == "windows" and not self["use_mingw"]:
         # We have to remove existing warning level defines before appending /w,
         # otherwise we get: "warning D9025 : overriding '/W3' with '/w'"
-        warn_flags = ["/Wall", "/W4", "/W3", "/W2", "/W1", "/WX"]
-        self.Append(CCFLAGS=["/w"])
-        self.Append(CFLAGS=["/w"])
-        self.Append(CXXFLAGS=["/w"])
-        self["CCFLAGS"] = [x for x in self["CCFLAGS"] if x not in warn_flags]
-        self["CFLAGS"] = [x for x in self["CFLAGS"] if x not in warn_flags]
-        self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if x not in warn_flags]
+        WARN_FLAGS = ["/Wall", "/W4", "/W3", "/W2", "/W1", "/W0"]
+        self["CCFLAGS"] = [x for x in self["CCFLAGS"] if x not in WARN_FLAGS]
+        self["CFLAGS"] = [x for x in self["CFLAGS"] if x not in WARN_FLAGS]
+        self["CXXFLAGS"] = [x for x in self["CXXFLAGS"] if x not in WARN_FLAGS]
+        self.AppendUnique(CCFLAGS=["/w"])
     else:
-        self.Append(CCFLAGS=["-w"])
-        self.Append(CFLAGS=["-w"])
-        self.Append(CXXFLAGS=["-w"])
+        self.AppendUnique(CCFLAGS=["-w"])
 
 
 def make_icu_data(target, source, env):

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -35,16 +35,7 @@
 #include "core/os/os.h"
 #include "scene/resources/image_texture.h"
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4127)
-#endif
-
 #include "thirdparty/misc/yuv2rgb.h"
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 int VideoStreamPlaybackTheora::buffer_data() {
 	char *buffer = ogg_sync_buffer(&oy, 4096);


### PR DESCRIPTION
Merging #94321 exposed a bug in our SCons setup on MSVC: some warnings persist even when they should've been disabled via `/w`. Technically, this is more of an MSVC bug, but this was fixed by implementing these two changes:
1. Ensuring that the *only* flags removed in `disable_warnings` are the flags that change the overall warning scope
2. When `warning=no` is passed, ensure that `/wd4267` is explicitly appended alongside `/w`

This includes a few other changes that were integrated while getting to the bottom of this, as they were tangentally related:
- `csg` module now correctly rebuilds itself if third-party libraries change
- Removed redundant MSVC pragma warning suppressions
- Update GDExtension `disable_warnings` functions to their main equivalent