### PR TITLE
Update Dotnet iOS Export Process

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/iOSNativeAOT.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/iOSNativeAOT.targets
@@ -15,7 +15,12 @@
   <Target Name="PrepareBeforeIlcCompile"
           BeforeTargets="IlcCompile">
 
-    <Copy SourceFiles="%(ResolvedRuntimePack.PackageDirectory)/runtimes/$(RuntimeIdentifier)/native/icudt.dat" DestinationFolder="$(PublishDir)"/>
+    <PropertyGroup>
+      <IcuTargetDir>%(ResolvedRuntimePack.PackageDirectory)/runtimes/$(RuntimeIdentifier)/native/icudt.dat</IcuTargetDir>
+      <IcuEnabled Condition="Exists('$(IcuTargetDir)')">true</IcuEnabled>
+    </PropertyGroup>
+
+    <Copy SourceFiles="$(IcuTargetDir)" DestinationFolder="$(PublishDir)" Condition=" '$(IcuEnabled)' == 'true' "/>
 
     <!-- We need to find the path to Xcode so we can set manual linker args to the correct SDKs
         Once https://github.com/dotnet/runtime/issues/88737 is released, we can take this out


### PR DESCRIPTION
Resolves #100123

~~This updates the iOS export build process to allow for hybrid globalization introduced in .NET 9 while preserving .NET 8 settings. Also allows for custom ICU or no ICU.~~

UPDATE:

After reading more about how future versions of .NET will handle globalization APIs it's unnecessary to support hybrid globalization so this updates the iOS export build process to check if the ICU file is needed (such as with .NET 8) and if not (such as with .NET 9+) the ICU file is simply omitted. 