### PR TITLE
GDExtension: Add method to set the class icon

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -245,6 +245,7 @@ void GDExtension::_register_extension_class(GDExtensionClassLibraryPtr p_library
 		p_extension_funcs->is_abstract, // GDExtensionBool is_abstract;
 		true, // GDExtensionBool is_exposed;
 		false, // GDExtensionBool is_runtime;
+		nullptr, // GDExtensionConstStringPtr icon_path;
 		p_extension_funcs->set_func, // GDExtensionClassSet set_func;
 		p_extension_funcs->get_func, // GDExtensionClassGet get_func;
 		p_extension_funcs->get_property_list_func, // GDExtensionClassGetPropertyList get_property_list_func;
@@ -280,6 +281,7 @@ void GDExtension::_register_extension_class2(GDExtensionClassLibraryPtr p_librar
 		p_extension_funcs->is_abstract, // GDExtensionBool is_abstract;
 		p_extension_funcs->is_exposed, // GDExtensionBool is_exposed;
 		false, // GDExtensionBool is_runtime;
+		nullptr, // GDExtensionConstStringPtr icon_path;
 		p_extension_funcs->set_func, // GDExtensionClassSet set_func;
 		p_extension_funcs->get_func, // GDExtensionClassGet get_func;
 		p_extension_funcs->get_property_list_func, // GDExtensionClassGetPropertyList get_property_list_func;
@@ -315,6 +317,7 @@ void GDExtension::_register_extension_class3(GDExtensionClassLibraryPtr p_librar
 		p_extension_funcs->is_abstract, // GDExtensionBool is_abstract;
 		p_extension_funcs->is_exposed, // GDExtensionBool is_exposed;
 		p_extension_funcs->is_runtime, // GDExtensionBool is_runtime;
+		nullptr, // GDExtensionConstStringPtr icon_path;
 		p_extension_funcs->set_func, // GDExtensionClassSet set_func;
 		p_extension_funcs->get_func, // GDExtensionClassGet get_func;
 		p_extension_funcs->get_property_list_func, // GDExtensionClassGetPropertyList get_property_list_func;
@@ -456,6 +459,13 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 #endif
 
 	ClassDB::register_extension_class(&extension->gdextension);
+
+	if (p_extension_funcs->icon_path != nullptr) {
+		const String icon_path = *reinterpret_cast<const String *>(p_extension_funcs->icon_path);
+		if (!icon_path.is_empty()) {
+			self->class_icon_paths[class_name] = icon_path;
+		}
+	}
 }
 
 void GDExtension::_register_extension_class_method(GDExtensionClassLibraryPtr p_library, GDExtensionConstStringNamePtr p_class_name, const GDExtensionClassMethodInfo *p_method_info) {

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -368,6 +368,7 @@ typedef struct {
 	GDExtensionBool is_abstract;
 	GDExtensionBool is_exposed;
 	GDExtensionBool is_runtime;
+	GDExtensionConstStringPtr icon_path;
 	GDExtensionClassSet set_func;
 	GDExtensionClassGet get_func;
 	GDExtensionClassGetPropertyList get_property_list_func;

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -210,6 +210,12 @@ void GDExtensionManager::initialize_extensions(GDExtension::InitializationLevel 
 	ERR_FAIL_COND(int32_t(p_level) - 1 != level);
 	for (KeyValue<String, Ref<GDExtension>> &E : gdextension_map) {
 		E.value->initialize_library(p_level);
+
+		if (p_level == GDExtension::INITIALIZATION_LEVEL_EDITOR) {
+			for (const KeyValue<String, String> &kv : E.value->class_icon_paths) {
+				gdextension_class_icon_paths[kv.key] = kv.value;
+			}
+		}
 	}
 	level = p_level;
 }


### PR DESCRIPTION
Allows GDExtensions to set the icon of a class programmatically, which is useful for extensions that don't use a `.gdextension` file.

- Matching PR in `godot-cpp` repo: https://github.com/godotengine/godot-cpp/pull/1666
- Example project for testing: https://github.com/raulsntos/threen/tree/set_class_icon