### PR TITLE
Fix ProjectManager import dialog error

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -830,7 +830,10 @@ void ProjectDialog::ask_for_path_and_show() {
 	_browse_project_path();
 }
 
-void ProjectDialog::show_dialog(bool p_reset_name) {
+void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
+	if (mode == MODE_IMPORT && !p_is_confirmed) {
+		return;
+	}
 	if (mode == MODE_RENAME) {
 		// Name and path are set in `ProjectManager::_rename_project`.
 		project_path->set_editable(false);
@@ -978,7 +981,8 @@ void ProjectDialog::_notification(int p_what) {
 			fdialog_project->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 			fdialog_project->connect("dir_selected", callable_mp(this, &ProjectDialog::_project_path_selected));
 			fdialog_project->connect("file_selected", callable_mp(this, &ProjectDialog::_project_path_selected));
-			fdialog_project->connect("canceled", callable_mp(this, &ProjectDialog::show_dialog).bind(false), CONNECT_DEFERRED);
+			fdialog_project->connect(SceneStringName(confirmed), callable_mp(this, &ProjectDialog::show_dialog).bind(false, true), CONNECT_DEFERRED);
+			fdialog_project->connect("canceled", callable_mp(this, &ProjectDialog::show_dialog).bind(false, false), CONNECT_DEFERRED);
 			callable_mp((Node *)this, &Node::add_sibling).call_deferred(fdialog_project, false);
 		} break;
 	}

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -152,7 +152,7 @@ public:
 	void set_duplicate_can_edit(bool p_duplicate_can_edit);
 
 	void ask_for_path_and_show();
-	void show_dialog(bool p_reset_name = true);
+	void show_dialog(bool p_reset_name = true, bool p_is_confirmed = true);
 
 	ProjectDialog();
 };


### PR DESCRIPTION
When Cancel is selected in the import dialog, no subsequent operations should be performed.

The signal in the original code was incorrectly connected to `canceled` instead of `confirmed`. This results in that after canceling the import dialog, subsequent operations are still performed and the default path is used as the path for the imported project.

![7a5c3111fcfa7c1c7700bd8385848366](https://github.com/user-attachments/assets/d3fed62e-2038-4fd3-a8b4-83affe4e21a9)
