### PR TITLE
[FileAccess] Replace `get_/store_` methods with separate signed and unsigned variants.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -740,10 +740,10 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 	f->get_buffer(hdr, 4);
 	ERR_FAIL_COND_V_MSG((hdr[0] != 'E' || hdr[1] != 'C' || hdr[2] != 'F' || hdr[3] != 'G'), ERR_FILE_CORRUPT, "Corrupted header in binary project.binary (not ECFG).");
 
-	uint32_t count = f->get_32();
+	uint32_t count = f->get_u32();
 
 	for (uint32_t i = 0; i < count; i++) {
-		uint32_t slen = f->get_32();
+		uint32_t slen = f->get_u32();
 		CharString cs;
 		cs.resize(slen + 1);
 		cs[slen] = 0;
@@ -751,7 +751,7 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 		String key;
 		key.parse_utf8(cs.ptr(), slen);
 
-		uint32_t vlen = f->get_32();
+		uint32_t vlen = f->get_u32();
 		Vector<uint8_t> d;
 		d.resize(vlen);
 		f->get_buffer(d.ptrw(), vlen);
@@ -898,7 +898,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const RBMap<S
 
 	if (!p_custom_features.is_empty()) {
 		// Store how many properties are saved, add one for custom features, which must always go first.
-		file->store_32(count + 1);
+		file->store_u32(count + 1);
 		String key = CoreStringName(_custom_features);
 		file->store_pascal_string(key);
 
@@ -911,12 +911,12 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const RBMap<S
 
 		err = encode_variant(p_custom_features, buff.ptrw(), len, false);
 		ERR_FAIL_COND_V(err != OK, err);
-		file->store_32(len);
+		file->store_u32(len);
 		file->store_buffer(buff.ptr(), buff.size());
 
 	} else {
 		// Store how many properties are saved.
-		file->store_32(count);
+		file->store_u32(count);
 	}
 
 	for (const KeyValue<String, List<String>> &E : p_props) {
@@ -943,7 +943,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const RBMap<S
 
 			err = encode_variant(value, buff.ptrw(), len, true);
 			ERR_FAIL_COND_V_MSG(err != OK, ERR_INVALID_DATA, "Error when trying to encode Variant.");
-			file->store_32(len);
+			file->store_u32(len);
 			file->store_buffer(buff.ptr(), buff.size());
 		}
 	}

--- a/core/io/file_access.compat.inc
+++ b/core/io/file_access.compat.inc
@@ -35,19 +35,19 @@ Ref<FileAccess> FileAccess::_open_encrypted_bind_compat_98918(const String &p_pa
 }
 
 void FileAccess::store_8_bind_compat_78289(uint8_t p_dest) {
-	store_8(p_dest);
+	store_u8(p_dest);
 }
 
 void FileAccess::store_16_bind_compat_78289(uint16_t p_dest) {
-	store_16(p_dest);
+	store_u16(p_dest);
 }
 
 void FileAccess::store_32_bind_compat_78289(uint32_t p_dest) {
-	store_32(p_dest);
+	store_u32(p_dest);
 }
 
 void FileAccess::store_64_bind_compat_78289(uint64_t p_dest) {
-	store_64(p_dest);
+	store_u64(p_dest);
 }
 
 void FileAccess::store_buffer_bind_compat_78289(const Vector<uint8_t> &p_buffer) {

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -301,15 +301,31 @@ String FileAccess::fix_path(const String &p_path) const {
 	return r_path;
 }
 
+int8_t FileAccess::get_s8() const {
+	return (int8_t)get_u8();
+}
+
+int16_t FileAccess::get_s16() const {
+	return (int16_t)get_u16();
+}
+
+int32_t FileAccess::get_s32() const {
+	return (int32_t)get_u32();
+}
+
+int64_t FileAccess::get_s64() const {
+	return (int64_t)get_u64();
+}
+
 /* these are all implemented for ease of porting, then can later be optimized */
-uint8_t FileAccess::get_8() const {
+uint8_t FileAccess::get_u8() const {
 	uint8_t data = 0;
 	get_buffer(&data, sizeof(uint8_t));
 
 	return data;
 }
 
-uint16_t FileAccess::get_16() const {
+uint16_t FileAccess::get_u16() const {
 	uint16_t data = 0;
 	get_buffer(reinterpret_cast<uint8_t *>(&data), sizeof(uint16_t));
 
@@ -320,7 +336,7 @@ uint16_t FileAccess::get_16() const {
 	return data;
 }
 
-uint32_t FileAccess::get_32() const {
+uint32_t FileAccess::get_u32() const {
 	uint32_t data = 0;
 	get_buffer(reinterpret_cast<uint8_t *>(&data), sizeof(uint32_t));
 
@@ -331,7 +347,7 @@ uint32_t FileAccess::get_32() const {
 	return data;
 }
 
-uint64_t FileAccess::get_64() const {
+uint64_t FileAccess::get_u64() const {
 	uint64_t data = 0;
 	get_buffer(reinterpret_cast<uint8_t *>(&data), sizeof(uint64_t));
 
@@ -343,12 +359,12 @@ uint64_t FileAccess::get_64() const {
 }
 
 float FileAccess::get_half() const {
-	return Math::half_to_float(get_16());
+	return Math::half_to_float(get_u16());
 }
 
 float FileAccess::get_float() const {
 	MarshallFloat m;
-	m.i = get_32();
+	m.i = get_u32();
 	return m.f;
 }
 
@@ -361,7 +377,7 @@ real_t FileAccess::get_real() const {
 }
 
 Variant FileAccess::get_var(bool p_allow_objects) const {
-	uint32_t len = get_32();
+	uint32_t len = get_u32();
 	Vector<uint8_t> buff = get_buffer(len);
 	ERR_FAIL_COND_V((uint32_t)buff.size() != len, Variant());
 
@@ -376,14 +392,14 @@ Variant FileAccess::get_var(bool p_allow_objects) const {
 
 double FileAccess::get_double() const {
 	MarshallDouble m;
-	m.l = get_64();
+	m.l = get_u64();
 	return m.d;
 }
 
 String FileAccess::get_token() const {
 	CharString token;
 
-	char32_t c = get_8();
+	char32_t c = get_u8();
 
 	while (!eof_reached()) {
 		if (c <= ' ') {
@@ -393,7 +409,7 @@ String FileAccess::get_token() const {
 		} else {
 			token += c;
 		}
-		c = get_8();
+		c = get_u8();
 	}
 
 	return String::utf8(token.get_data());
@@ -448,7 +464,7 @@ public:
 String FileAccess::get_line() const {
 	CharBuffer line;
 
-	char32_t c = get_8();
+	char32_t c = get_u8();
 
 	while (!eof_reached()) {
 		if (c == '\n' || c == '\0') {
@@ -458,7 +474,7 @@ String FileAccess::get_line() const {
 			line.push_back(c);
 		}
 
-		c = get_8();
+		c = get_u8();
 	}
 	line.push_back(0);
 	return String::utf8(line.get_data());
@@ -569,11 +585,27 @@ String FileAccess::get_as_utf8_string(bool p_skip_cr) const {
 	return s;
 }
 
-bool FileAccess::store_8(uint8_t p_dest) {
+bool FileAccess::store_s8(int8_t p_dest) {
+	return store_u8((uint8_t)p_dest);
+}
+
+bool FileAccess::store_s16(int16_t p_dest) {
+	return store_u16((uint16_t)p_dest);
+}
+
+bool FileAccess::store_s32(int32_t p_dest) {
+	return store_u32((uint32_t)p_dest);
+}
+
+bool FileAccess::store_s64(int64_t p_dest) {
+	return store_u64((uint64_t)p_dest);
+}
+
+bool FileAccess::store_u8(uint8_t p_dest) {
 	return store_buffer(&p_dest, sizeof(uint8_t));
 }
 
-bool FileAccess::store_16(uint16_t p_dest) {
+bool FileAccess::store_u16(uint16_t p_dest) {
 	if (big_endian) {
 		p_dest = BSWAP16(p_dest);
 	}
@@ -581,7 +613,7 @@ bool FileAccess::store_16(uint16_t p_dest) {
 	return store_buffer(reinterpret_cast<uint8_t *>(&p_dest), sizeof(uint16_t));
 }
 
-bool FileAccess::store_32(uint32_t p_dest) {
+bool FileAccess::store_u32(uint32_t p_dest) {
 	if (big_endian) {
 		p_dest = BSWAP32(p_dest);
 	}
@@ -589,7 +621,7 @@ bool FileAccess::store_32(uint32_t p_dest) {
 	return store_buffer(reinterpret_cast<uint8_t *>(&p_dest), sizeof(uint32_t));
 }
 
-bool FileAccess::store_64(uint64_t p_dest) {
+bool FileAccess::store_u64(uint64_t p_dest) {
 	if (big_endian) {
 		p_dest = BSWAP64(p_dest);
 	}
@@ -606,19 +638,19 @@ bool FileAccess::store_real(real_t p_real) {
 }
 
 bool FileAccess::store_half(float p_dest) {
-	return store_16(Math::make_half_float(p_dest));
+	return store_u16(Math::make_half_float(p_dest));
 }
 
 bool FileAccess::store_float(float p_dest) {
 	MarshallFloat m;
 	m.f = p_dest;
-	return store_32(m.i);
+	return store_u32(m.i);
 }
 
 bool FileAccess::store_double(double p_dest) {
 	MarshallDouble m;
 	m.d = p_dest;
-	return store_64(m.l);
+	return store_u64(m.l);
 }
 
 uint64_t FileAccess::get_modified_time(const String &p_file) {
@@ -713,11 +745,11 @@ bool FileAccess::store_string(const String &p_string) {
 
 bool FileAccess::store_pascal_string(const String &p_string) {
 	CharString cs = p_string.utf8();
-	return store_32(cs.length()) && store_buffer((uint8_t *)&cs[0], cs.length());
+	return store_u32(cs.length()) && store_buffer((uint8_t *)&cs[0], cs.length());
 }
 
 String FileAccess::get_pascal_string() {
-	uint32_t sl = get_32();
+	uint32_t sl = get_u32();
 	CharString cs;
 	cs.resize(sl + 1);
 	get_buffer((uint8_t *)cs.ptr(), sl);
@@ -729,7 +761,7 @@ String FileAccess::get_pascal_string() {
 }
 
 bool FileAccess::store_line(const String &p_line) {
-	return store_string(p_line) && store_8('\n');
+	return store_string(p_line) && store_u8('\n');
 }
 
 bool FileAccess::store_csv_line(const Vector<String> &p_values, const String &p_delim) {
@@ -767,7 +799,7 @@ bool FileAccess::store_buffer(const Vector<uint8_t> &p_buffer) {
 bool FileAccess::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 	ERR_FAIL_COND_V(!p_src && p_length > 0, false);
 	for (uint64_t i = 0; i < p_length; i++) {
-		if (unlikely(!store_8(p_src[i]))) {
+		if (unlikely(!store_u8(p_src[i]))) {
 			return false;
 		}
 	}
@@ -786,7 +818,7 @@ bool FileAccess::store_var(const Variant &p_var, bool p_full_objects) {
 	err = encode_variant(p_var, &w[0], len, p_full_objects);
 	ERR_FAIL_COND_V_MSG(err != OK, false, "Error when trying to encode Variant.");
 
-	return store_32(len) && store_buffer(buff);
+	return store_u32(len) && store_buffer(buff);
 }
 
 Vector<uint8_t> FileAccess::get_file_as_bytes(const String &p_path, Error *r_error) {
@@ -923,10 +955,24 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_position"), &FileAccess::get_position);
 	ClassDB::bind_method(D_METHOD("get_length"), &FileAccess::get_length);
 	ClassDB::bind_method(D_METHOD("eof_reached"), &FileAccess::eof_reached);
-	ClassDB::bind_method(D_METHOD("get_8"), &FileAccess::get_8);
-	ClassDB::bind_method(D_METHOD("get_16"), &FileAccess::get_16);
-	ClassDB::bind_method(D_METHOD("get_32"), &FileAccess::get_32);
-	ClassDB::bind_method(D_METHOD("get_64"), &FileAccess::get_64);
+
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("get_8"), &FileAccess::get_u8);
+	ClassDB::bind_method(D_METHOD("get_16"), &FileAccess::get_u16);
+	ClassDB::bind_method(D_METHOD("get_32"), &FileAccess::get_u32);
+	ClassDB::bind_method(D_METHOD("get_64"), &FileAccess::get_u64);
+#endif
+
+	ClassDB::bind_method(D_METHOD("get_u8"), &FileAccess::get_u8);
+	ClassDB::bind_method(D_METHOD("get_u16"), &FileAccess::get_u16);
+	ClassDB::bind_method(D_METHOD("get_u32"), &FileAccess::get_u32);
+	ClassDB::bind_method(D_METHOD("get_u64"), &FileAccess::get_u64);
+
+	ClassDB::bind_method(D_METHOD("get_s8"), &FileAccess::get_s8);
+	ClassDB::bind_method(D_METHOD("get_s16"), &FileAccess::get_s16);
+	ClassDB::bind_method(D_METHOD("get_s32"), &FileAccess::get_s32);
+	ClassDB::bind_method(D_METHOD("get_s64"), &FileAccess::get_s64);
+
 	ClassDB::bind_method(D_METHOD("get_half"), &FileAccess::get_half);
 	ClassDB::bind_method(D_METHOD("get_float"), &FileAccess::get_float);
 	ClassDB::bind_method(D_METHOD("get_double"), &FileAccess::get_double);
@@ -942,10 +988,23 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_error"), &FileAccess::get_error);
 	ClassDB::bind_method(D_METHOD("get_var", "allow_objects"), &FileAccess::get_var, DEFVAL(false));
 
-	ClassDB::bind_method(D_METHOD("store_8", "value"), &FileAccess::store_8);
-	ClassDB::bind_method(D_METHOD("store_16", "value"), &FileAccess::store_16);
-	ClassDB::bind_method(D_METHOD("store_32", "value"), &FileAccess::store_32);
-	ClassDB::bind_method(D_METHOD("store_64", "value"), &FileAccess::store_64);
+#ifndef DISABLE_DEPRECATED
+	ClassDB::bind_method(D_METHOD("store_8", "value"), &FileAccess::store_u8);
+	ClassDB::bind_method(D_METHOD("store_16", "value"), &FileAccess::store_u16);
+	ClassDB::bind_method(D_METHOD("store_32", "value"), &FileAccess::store_u32);
+	ClassDB::bind_method(D_METHOD("store_64", "value"), &FileAccess::store_u64);
+#endif
+
+	ClassDB::bind_method(D_METHOD("store_u8", "value"), &FileAccess::store_u8);
+	ClassDB::bind_method(D_METHOD("store_u16", "value"), &FileAccess::store_u16);
+	ClassDB::bind_method(D_METHOD("store_u32", "value"), &FileAccess::store_u32);
+	ClassDB::bind_method(D_METHOD("store_u64", "value"), &FileAccess::store_u64);
+
+	ClassDB::bind_method(D_METHOD("store_s8", "value"), &FileAccess::store_s8);
+	ClassDB::bind_method(D_METHOD("store_s16", "value"), &FileAccess::store_s16);
+	ClassDB::bind_method(D_METHOD("store_s32", "value"), &FileAccess::store_s32);
+	ClassDB::bind_method(D_METHOD("store_s64", "value"), &FileAccess::store_s64);
+
 	ClassDB::bind_method(D_METHOD("store_half", "value"), &FileAccess::store_half);
 	ClassDB::bind_method(D_METHOD("store_float", "value"), &FileAccess::store_float);
 	ClassDB::bind_method(D_METHOD("store_double", "value"), &FileAccess::store_double);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -165,10 +165,15 @@ public:
 
 	virtual bool eof_reached() const = 0; ///< reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
-	virtual uint16_t get_16() const; ///< get 16 bits uint
-	virtual uint32_t get_32() const; ///< get 32 bits uint
-	virtual uint64_t get_64() const; ///< get 64 bits uint
+	virtual uint8_t get_u8() const;
+	virtual uint16_t get_u16() const;
+	virtual uint32_t get_u32() const;
+	virtual uint64_t get_u64() const;
+
+	virtual int8_t get_s8() const;
+	virtual int16_t get_s16() const;
+	virtual int32_t get_s32() const;
+	virtual int64_t get_s64() const;
 
 	virtual float get_half() const;
 	virtual float get_float() const;
@@ -198,10 +203,16 @@ public:
 
 	virtual Error resize(int64_t p_length) = 0;
 	virtual void flush() = 0;
-	virtual bool store_8(uint8_t p_dest); ///< store a byte
-	virtual bool store_16(uint16_t p_dest); ///< store 16 bits uint
-	virtual bool store_32(uint32_t p_dest); ///< store 32 bits uint
-	virtual bool store_64(uint64_t p_dest); ///< store 64 bits uint
+
+	virtual bool store_u8(uint8_t p_dest);
+	virtual bool store_u16(uint16_t p_dest);
+	virtual bool store_u32(uint32_t p_dest);
+	virtual bool store_u64(uint64_t p_dest);
+
+	virtual bool store_s8(int8_t p_dest);
+	virtual bool store_s16(int16_t p_dest);
+	virtual bool store_s32(int32_t p_dest);
+	virtual bool store_s64(int64_t p_dest);
 
 	virtual bool store_half(float p_dest);
 	virtual bool store_float(float p_dest);

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -65,13 +65,13 @@ Error FileAccessEncrypted::open_and_parse(Ref<FileAccess> p_base, const Vector<u
 		key = p_key;
 
 		if (use_magic) {
-			uint32_t magic = p_base->get_32();
+			uint32_t magic = p_base->get_u32();
 			ERR_FAIL_COND_V(magic != ENCRYPTED_HEADER_MAGIC, ERR_FILE_UNRECOGNIZED);
 		}
 
 		unsigned char md5d[16];
 		p_base->get_buffer(md5d, 16);
-		length = p_base->get_64();
+		length = p_base->get_u64();
 
 		iv.resize(16);
 		p_base->get_buffer(iv.ptrw(), 16);
@@ -148,11 +148,11 @@ void FileAccessEncrypted::_close() {
 		ctx.set_encode_key(key.ptrw(), 256);
 
 		if (use_magic) {
-			file->store_32(ENCRYPTED_HEADER_MAGIC);
+			file->store_u32(ENCRYPTED_HEADER_MAGIC);
 		}
 
 		file->store_buffer(hash, 16);
-		file->store_64(data.size());
+		file->store_u64(data.size());
 		file->store_buffer(iv.ptr(), 16);
 
 		ctx.encrypt_cfb(len, iv.ptrw(), compressed.ptrw(), compressed.ptrw());

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -89,17 +89,17 @@ Error PCKPacker::pck_start(const String &p_pck_path, int p_alignment, const Stri
 
 	alignment = p_alignment;
 
-	file->store_32(PACK_HEADER_MAGIC);
-	file->store_32(PACK_FORMAT_VERSION);
-	file->store_32(VERSION_MAJOR);
-	file->store_32(VERSION_MINOR);
-	file->store_32(VERSION_PATCH);
+	file->store_u32(PACK_HEADER_MAGIC);
+	file->store_u32(PACK_FORMAT_VERSION);
+	file->store_u32(VERSION_MAJOR);
+	file->store_u32(VERSION_MINOR);
+	file->store_u32(VERSION_PATCH);
 
 	uint32_t pack_flags = 0;
 	if (enc_dir) {
 		pack_flags |= PACK_DIR_ENCRYPTED;
 	}
-	file->store_32(pack_flags); // flags
+	file->store_u32(pack_flags); // flags
 
 	files.clear();
 	ofs = 0;
@@ -175,14 +175,14 @@ Error PCKPacker::flush(bool p_verbose) {
 	ERR_FAIL_COND_V_MSG(file.is_null(), ERR_INVALID_PARAMETER, "File must be opened before use.");
 
 	int64_t file_base_ofs = file->get_position();
-	file->store_64(0); // files base
+	file->store_u64(0); // files base
 
 	for (int i = 0; i < 16; i++) {
-		file->store_32(0); // reserved
+		file->store_u32(0); // reserved
 	}
 
 	// write the index
-	file->store_32(files.size());
+	file->store_u32(files.size());
 
 	Ref<FileAccessEncrypted> fae;
 	Ref<FileAccess> fhead = file;
@@ -201,14 +201,14 @@ Error PCKPacker::flush(bool p_verbose) {
 		int string_len = files[i].path.utf8().length();
 		int pad = _get_pad(4, string_len);
 
-		fhead->store_32(string_len + pad);
+		fhead->store_u32(string_len + pad);
 		fhead->store_buffer((const uint8_t *)files[i].path.utf8().get_data(), string_len);
 		for (int j = 0; j < pad; j++) {
-			fhead->store_8(0);
+			fhead->store_u8(0);
 		}
 
-		fhead->store_64(files[i].ofs);
-		fhead->store_64(files[i].size); // pay attention here, this is where file is
+		fhead->store_u64(files[i].ofs);
+		fhead->store_u64(files[i].size); // pay attention here, this is where file is
 		fhead->store_buffer(files[i].md5.ptr(), 16); //also save md5 for file
 
 		uint32_t flags = 0;
@@ -218,7 +218,7 @@ Error PCKPacker::flush(bool p_verbose) {
 		if (files[i].removal) {
 			flags |= PACK_FILE_REMOVAL;
 		}
-		fhead->store_32(flags);
+		fhead->store_u32(flags);
 	}
 
 	if (fae.is_valid()) {
@@ -228,12 +228,12 @@ Error PCKPacker::flush(bool p_verbose) {
 
 	int header_padding = _get_pad(alignment, file->get_position());
 	for (int i = 0; i < header_padding; i++) {
-		file->store_8(0);
+		file->store_u8(0);
 	}
 
 	int64_t file_base = file->get_position();
 	file->seek(file_base_ofs);
-	file->store_64(file_base); // update files base
+	file->store_u64(file_base); // update files base
 	file->seek(file_base);
 
 	const uint32_t buf_max = 65536;
@@ -271,7 +271,7 @@ Error PCKPacker::flush(bool p_verbose) {
 
 		int pad = _get_pad(alignment, file->get_position());
 		for (int j = 0; j < pad; j++) {
-			file->store_8(0);
+			file->store_u8(0);
 		}
 
 		count += 1;

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -104,7 +104,7 @@ void ResourceLoaderBinary::_advance_padding(uint32_t p_len) {
 	uint32_t extra = 4 - (p_len % 4);
 	if (extra < 4) {
 		for (uint32_t i = 0; i < extra; i++) {
-			f->get_8(); //pad to 32
+			f->get_u8(); //pad to 32
 		}
 	}
 }
@@ -154,7 +154,7 @@ static Error read_reals(real_t *dst, Ref<FileAccess> &f, size_t count) {
 }
 
 StringName ResourceLoaderBinary::_get_string() {
-	uint32_t id = f->get_32();
+	uint32_t id = f->get_u32();
 	if (id & 0x80000000) {
 		uint32_t len = id & 0x7FFFFFFF;
 		if ((int)len > str_buf.size()) {
@@ -173,7 +173,7 @@ StringName ResourceLoaderBinary::_get_string() {
 }
 
 Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
-	uint32_t prop_type = f->get_32();
+	uint32_t prop_type = f->get_u32();
 	print_bl("find property of type: " + itos(prop_type));
 
 	switch (prop_type) {
@@ -181,13 +181,13 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			r_v = Variant();
 		} break;
 		case VARIANT_BOOL: {
-			r_v = bool(f->get_32());
+			r_v = bool(f->get_u32());
 		} break;
 		case VARIANT_INT: {
-			r_v = int(f->get_32());
+			r_v = int(f->get_u32());
 		} break;
 		case VARIANT_INT64: {
-			r_v = int64_t(f->get_64());
+			r_v = int64_t(f->get_u64());
 		} break;
 		case VARIANT_FLOAT: {
 			r_v = f->get_real();
@@ -207,8 +207,8 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 		} break;
 		case VARIANT_VECTOR2I: {
 			Vector2i v;
-			v.x = f->get_32();
-			v.y = f->get_32();
+			v.x = f->get_u32();
+			v.y = f->get_u32();
 			r_v = v;
 
 		} break;
@@ -223,10 +223,10 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 		} break;
 		case VARIANT_RECT2I: {
 			Rect2i v;
-			v.position.x = f->get_32();
-			v.position.y = f->get_32();
-			v.size.x = f->get_32();
-			v.size.y = f->get_32();
+			v.position.x = f->get_u32();
+			v.position.y = f->get_u32();
+			v.size.x = f->get_u32();
+			v.size.y = f->get_u32();
 			r_v = v;
 
 		} break;
@@ -239,9 +239,9 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 		} break;
 		case VARIANT_VECTOR3I: {
 			Vector3i v;
-			v.x = f->get_32();
-			v.y = f->get_32();
-			v.z = f->get_32();
+			v.x = f->get_u32();
+			v.y = f->get_u32();
+			v.z = f->get_u32();
 			r_v = v;
 		} break;
 		case VARIANT_VECTOR4: {
@@ -254,10 +254,10 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 		} break;
 		case VARIANT_VECTOR4I: {
 			Vector4i v;
-			v.x = f->get_32();
-			v.y = f->get_32();
-			v.z = f->get_32();
-			v.w = f->get_32();
+			v.x = f->get_u32();
+			v.y = f->get_u32();
+			v.z = f->get_u32();
+			v.w = f->get_u32();
 			r_v = v;
 		} break;
 		case VARIANT_PLANE: {
@@ -367,8 +367,8 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			Vector<StringName> subnames;
 			bool absolute;
 
-			int name_count = f->get_16();
-			uint32_t subname_count = f->get_16();
+			int name_count = f->get_u16();
+			uint32_t subname_count = f->get_u16();
 			absolute = subname_count & 0x8000;
 			subname_count &= 0x7FFF;
 			if (ver_format < FORMAT_VERSION_NO_NODEPATH_PROPERTY) {
@@ -388,10 +388,10 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 
 		} break;
 		case VARIANT_RID: {
-			r_v = f->get_32();
+			r_v = f->get_u32();
 		} break;
 		case VARIANT_OBJECT: {
-			uint32_t objtype = f->get_32();
+			uint32_t objtype = f->get_u32();
 
 			switch (objtype) {
 				case OBJECT_EMPTY: {
@@ -399,7 +399,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 
 				} break;
 				case OBJECT_INTERNAL_RESOURCE: {
-					uint32_t index = f->get_32();
+					uint32_t index = f->get_u32();
 					String path;
 
 					if (using_named_scene_ids) { // New format.
@@ -442,7 +442,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 				} break;
 				case OBJECT_EXTERNAL_RESOURCE_INDEX: {
 					//new file format, just refers to an index in the external list
-					int erindex = f->get_32();
+					int erindex = f->get_u32();
 
 					if (erindex < 0 || erindex >= external_resources.size()) {
 						WARN_PRINT("Broken external resource! (index out of size)");
@@ -480,7 +480,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 		} break;
 
 		case VARIANT_DICTIONARY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 			Dictionary d; //last bit means shared
 			len &= 0x7FFFFFFF;
 			for (uint32_t i = 0; i < len; i++) {
@@ -495,7 +495,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			r_v = d;
 		} break;
 		case VARIANT_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 			Array a; //last bit means shared
 			len &= 0x7FFFFFFF;
 			a.resize(len);
@@ -509,7 +509,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 
 		} break;
 		case VARIANT_PACKED_BYTE_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 
 			Vector<uint8_t> array;
 			array.resize(len);
@@ -521,7 +521,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 
 		} break;
 		case VARIANT_PACKED_INT32_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 
 			Vector<int32_t> array;
 			array.resize(len);
@@ -540,7 +540,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			r_v = array;
 		} break;
 		case VARIANT_PACKED_INT64_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 
 			Vector<int64_t> array;
 			array.resize(len);
@@ -559,7 +559,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			r_v = array;
 		} break;
 		case VARIANT_PACKED_FLOAT32_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 
 			Vector<float> array;
 			array.resize(len);
@@ -578,7 +578,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			r_v = array;
 		} break;
 		case VARIANT_PACKED_FLOAT64_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 
 			Vector<double> array;
 			array.resize(len);
@@ -597,7 +597,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			r_v = array;
 		} break;
 		case VARIANT_PACKED_STRING_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 			Vector<String> array;
 			array.resize(len);
 			String *w = array.ptrw();
@@ -609,7 +609,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 
 		} break;
 		case VARIANT_PACKED_VECTOR2_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 
 			Vector<Vector2> array;
 			array.resize(len);
@@ -622,7 +622,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 
 		} break;
 		case VARIANT_PACKED_VECTOR3_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 
 			Vector<Vector3> array;
 			array.resize(len);
@@ -635,7 +635,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 
 		} break;
 		case VARIANT_PACKED_COLOR_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 
 			Vector<Color> array;
 			array.resize(len);
@@ -656,7 +656,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 			r_v = array;
 		} break;
 		case VARIANT_PACKED_VECTOR4_ARRAY: {
-			uint32_t len = f->get_32();
+			uint32_t len = f->get_u32();
 
 			Vector<Vector4> array;
 			array.resize(len);
@@ -811,7 +811,7 @@ Error ResourceLoaderBinary::load() {
 			internal_index_cache[path] = res;
 		}
 
-		int pc = f->get_32();
+		int pc = f->get_u32();
 
 		//set properties
 
@@ -911,12 +911,12 @@ void ResourceLoaderBinary::set_translation_remapped(bool p_remapped) {
 
 static void save_ustring(Ref<FileAccess> f, const String &p_string) {
 	CharString utf8 = p_string.utf8();
-	f->store_32(utf8.length() + 1);
+	f->store_u32(utf8.length() + 1);
 	f->store_buffer((const uint8_t *)utf8.get_data(), utf8.length() + 1);
 }
 
 static String get_ustring(Ref<FileAccess> f) {
-	int len = f->get_32();
+	int len = f->get_u32();
 	Vector<char> str_buf;
 	str_buf.resize(len);
 	f->get_buffer((uint8_t *)&str_buf[0], len);
@@ -926,7 +926,7 @@ static String get_ustring(Ref<FileAccess> f) {
 }
 
 String ResourceLoaderBinary::get_unicode_string() {
-	int len = f->get_32();
+	int len = f->get_u32();
 	if (len > str_buf.size()) {
 		str_buf.resize(len);
 	}
@@ -1010,14 +1010,14 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 		ERR_FAIL_MSG(vformat("Unrecognized binary resource file: '%s'.", local_path));
 	}
 
-	bool big_endian = f->get_32();
-	bool use_real64 = f->get_32();
+	bool big_endian = f->get_u32();
+	bool use_real64 = f->get_u32();
 
 	f->set_big_endian(big_endian != 0); //read big endian if saved as big endian
 
-	uint32_t ver_major = f->get_32();
-	uint32_t ver_minor = f->get_32();
-	ver_format = f->get_32();
+	uint32_t ver_major = f->get_u32();
+	uint32_t ver_minor = f->get_u32();
+	ver_format = f->get_u32();
 
 	print_bl("big endian: " + itos(big_endian));
 #ifdef BIG_ENDIAN_ENABLED
@@ -1040,8 +1040,8 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 
 	print_bl("type: " + type);
 
-	importmd_ofs = f->get_64();
-	uint32_t flags = f->get_32();
+	importmd_ofs = f->get_u64();
+	uint32_t flags = f->get_u32();
 	if (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_NAMED_SCENE_IDS) {
 		using_named_scene_ids = true;
 	}
@@ -1051,9 +1051,9 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 	f->real_is_double = (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_REAL_T_IS_DOUBLE) != 0;
 
 	if (using_uids) {
-		uid = f->get_64();
+		uid = f->get_u64();
 	} else {
-		f->get_64(); // skip over uid field
+		f->get_u64(); // skip over uid field
 		uid = ResourceUID::INVALID_ID;
 	}
 
@@ -1062,14 +1062,14 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 	}
 
 	for (int i = 0; i < ResourceFormatSaverBinaryInstance::RESERVED_FIELDS; i++) {
-		f->get_32(); //skip a few reserved fields
+		f->get_u32(); //skip a few reserved fields
 	}
 
 	if (p_no_resources) {
 		return;
 	}
 
-	uint32_t string_table_size = f->get_32();
+	uint32_t string_table_size = f->get_u32();
 	string_map.resize(string_table_size);
 	for (uint32_t i = 0; i < string_table_size; i++) {
 		StringName s = get_unicode_string();
@@ -1078,13 +1078,13 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 
 	print_bl("strings: " + itos(string_table_size));
 
-	uint32_t ext_resources_size = f->get_32();
+	uint32_t ext_resources_size = f->get_u32();
 	for (uint32_t i = 0; i < ext_resources_size; i++) {
 		ExtResource er;
 		er.type = get_unicode_string();
 		er.path = get_unicode_string();
 		if (using_uids) {
-			er.uid = f->get_64();
+			er.uid = f->get_u64();
 			if (!p_keep_uuid_paths && er.uid != ResourceUID::INVALID_ID) {
 				if (ResourceUID::get_singleton()->has_id(er.uid)) {
 					// If a UID is found and the path is valid, it will be used, otherwise, it falls back to the path.
@@ -1106,12 +1106,12 @@ void ResourceLoaderBinary::open(Ref<FileAccess> p_f, bool p_no_resources, bool p
 	}
 
 	print_bl("ext resources: " + itos(ext_resources_size));
-	uint32_t int_resources_size = f->get_32();
+	uint32_t int_resources_size = f->get_u32();
 
 	for (uint32_t i = 0; i < int_resources_size; i++) {
 		IntResource ir;
 		ir.path = get_unicode_string();
-		ir.offset = f->get_64();
+		ir.offset = f->get_u64();
 		internal_resources.push_back(ir);
 	}
 
@@ -1148,14 +1148,14 @@ String ResourceLoaderBinary::recognize(Ref<FileAccess> p_f) {
 		return "";
 	}
 
-	bool big_endian = f->get_32();
-	f->get_32(); // use_real64
+	bool big_endian = f->get_u32();
+	f->get_u32(); // use_real64
 
 	f->set_big_endian(big_endian != 0); //read big endian if saved as big endian
 
-	uint32_t ver_major = f->get_32();
-	f->get_32(); // ver_minor
-	uint32_t ver_fmt = f->get_32();
+	uint32_t ver_major = f->get_u32();
+	f->get_u32(); // ver_minor
+	uint32_t ver_fmt = f->get_u32();
 
 	if (ver_fmt > FORMAT_VERSION || ver_major > VERSION_MAJOR) {
 		f.unref();
@@ -1189,14 +1189,14 @@ String ResourceLoaderBinary::recognize_script_class(Ref<FileAccess> p_f) {
 		return "";
 	}
 
-	bool big_endian = f->get_32();
-	f->get_32(); // use_real64
+	bool big_endian = f->get_u32();
+	f->get_u32(); // use_real64
 
 	f->set_big_endian(big_endian != 0); //read big endian if saved as big endian
 
-	uint32_t ver_major = f->get_32();
-	f->get_32(); // ver_minor
-	uint32_t ver_fmt = f->get_32();
+	uint32_t ver_major = f->get_u32();
+	f->get_u32(); // ver_minor
+	uint32_t ver_fmt = f->get_u32();
 
 	if (ver_fmt > FORMAT_VERSION || ver_major > VERSION_MAJOR) {
 		f.unref();
@@ -1205,9 +1205,9 @@ String ResourceLoaderBinary::recognize_script_class(Ref<FileAccess> p_f) {
 
 	get_unicode_string(); // type
 
-	f->get_64(); // Metadata offset
-	uint32_t flags = f->get_32();
-	f->get_64(); // UID
+	f->get_u64(); // Metadata offset
+	uint32_t flags = f->get_u32();
+	f->get_u64(); // UID
 
 	if (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_HAS_SCRIPT_CLASS) {
 		return get_unicode_string();
@@ -1346,21 +1346,21 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		fw->store_buffer(magic, 4);
 	}
 
-	bool big_endian = f->get_32();
-	bool use_real64 = f->get_32();
+	bool big_endian = f->get_u32();
+	bool use_real64 = f->get_u32();
 
 	f->set_big_endian(big_endian != 0); //read big endian if saved as big endian
 #ifdef BIG_ENDIAN_ENABLED
-	fw->store_32(!big_endian);
+	fw->store_u32(!big_endian);
 #else
-	fw->store_32(big_endian);
+	fw->store_u32(big_endian);
 #endif
 	fw->set_big_endian(big_endian != 0);
-	fw->store_32(use_real64); //use real64
+	fw->store_u32(use_real64); //use real64
 
-	uint32_t ver_major = f->get_32();
-	uint32_t ver_minor = f->get_32();
-	uint32_t ver_format = f->get_32();
+	uint32_t ver_major = f->get_u32();
+	uint32_t ver_minor = f->get_u32();
+	uint32_t ver_format = f->get_u32();
 
 	if (ver_format < FORMAT_VERSION_CAN_RENAME_DEPS) {
 		fw.unref();
@@ -1402,35 +1402,35 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 
 	// Since we're not actually converting the file contents, leave the version
 	// numbers in the file untouched.
-	fw->store_32(ver_major);
-	fw->store_32(ver_minor);
-	fw->store_32(ver_format);
+	fw->store_u32(ver_major);
+	fw->store_u32(ver_minor);
+	fw->store_u32(ver_format);
 
 	save_ustring(fw, get_ustring(f)); //type
 
 	uint64_t md_ofs = f->get_position();
-	uint64_t importmd_ofs = f->get_64();
-	fw->store_64(0); //metadata offset
+	uint64_t importmd_ofs = f->get_u64();
+	fw->store_u64(0); //metadata offset
 
-	uint32_t flags = f->get_32();
+	uint32_t flags = f->get_u32();
 	bool using_uids = (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_UIDS);
-	uint64_t uid_data = f->get_64();
+	uint64_t uid_data = f->get_u64();
 
-	fw->store_32(flags);
-	fw->store_64(uid_data);
+	fw->store_u32(flags);
+	fw->store_u64(uid_data);
 	if (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_HAS_SCRIPT_CLASS) {
 		save_ustring(fw, get_ustring(f));
 	}
 
 	for (int i = 0; i < ResourceFormatSaverBinaryInstance::RESERVED_FIELDS; i++) {
-		fw->store_32(0); // reserved
-		f->get_32();
+		fw->store_u32(0); // reserved
+		f->get_u32();
 	}
 
 	//string table
-	uint32_t string_table_size = f->get_32();
+	uint32_t string_table_size = f->get_u32();
 
-	fw->store_32(string_table_size);
+	fw->store_u32(string_table_size);
 
 	for (uint32_t i = 0; i < string_table_size; i++) {
 		String s = get_ustring(f);
@@ -1438,14 +1438,14 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	}
 
 	//external resources
-	uint32_t ext_resources_size = f->get_32();
-	fw->store_32(ext_resources_size);
+	uint32_t ext_resources_size = f->get_u32();
+	fw->store_u32(ext_resources_size);
 	for (uint32_t i = 0; i < ext_resources_size; i++) {
 		String type = get_ustring(f);
 		String path = get_ustring(f);
 
 		if (using_uids) {
-			ResourceUID::ID uid = f->get_64();
+			ResourceUID::ID uid = f->get_u64();
 			if (uid != ResourceUID::INVALID_ID) {
 				if (ResourceUID::get_singleton()->has_id(uid)) {
 					// If a UID is found and the path is valid, it will be used, otherwise, it falls back to the path.
@@ -1477,35 +1477,35 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 
 		if (using_uids) {
 			ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(full_path);
-			fw->store_64(uid);
+			fw->store_u64(uid);
 		}
 	}
 
 	int64_t size_diff = (int64_t)fw->get_position() - (int64_t)f->get_position();
 
 	//internal resources
-	uint32_t int_resources_size = f->get_32();
-	fw->store_32(int_resources_size);
+	uint32_t int_resources_size = f->get_u32();
+	fw->store_u32(int_resources_size);
 
 	for (uint32_t i = 0; i < int_resources_size; i++) {
 		String path = get_ustring(f);
-		uint64_t offset = f->get_64();
+		uint64_t offset = f->get_u64();
 		save_ustring(fw, path);
-		fw->store_64(offset + size_diff);
+		fw->store_u64(offset + size_diff);
 	}
 
 	//rest of file
-	uint8_t b = f->get_8();
+	uint8_t b = f->get_u8();
 	while (!f->eof_reached()) {
-		fw->store_8(b);
-		b = f->get_8();
+		fw->store_u8(b);
+		b = f->get_u8();
 	}
 	f.unref();
 
 	bool all_ok = fw->get_error() == OK;
 
 	fw->seek(md_ofs);
-	fw->store_64(importmd_ofs + size_diff);
+	fw->store_u64(importmd_ofs + size_diff);
 
 	if (!all_ok) {
 		return ERR_CANT_CREATE;
@@ -1589,7 +1589,7 @@ void ResourceFormatSaverBinaryInstance::_pad_buffer(Ref<FileAccess> f, int p_byt
 	int extra = 4 - (p_bytes % 4);
 	if (extra < 4) {
 		for (int i = 0; i < extra; i++) {
-			f->store_8(0); //pad to 32
+			f->store_u8(0); //pad to 32
 		}
 	}
 }
@@ -1597,23 +1597,23 @@ void ResourceFormatSaverBinaryInstance::_pad_buffer(Ref<FileAccess> f, int p_byt
 void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint) {
 	switch (p_property.get_type()) {
 		case Variant::NIL: {
-			f->store_32(VARIANT_NIL);
+			f->store_u32(VARIANT_NIL);
 			// don't store anything
 		} break;
 		case Variant::BOOL: {
-			f->store_32(VARIANT_BOOL);
+			f->store_u32(VARIANT_BOOL);
 			bool val = p_property;
-			f->store_32(val);
+			f->store_u32(val);
 		} break;
 		case Variant::INT: {
 			int64_t val = p_property;
 			if (val > 0x7FFFFFFF || val < -(int64_t)0x80000000) {
-				f->store_32(VARIANT_INT64);
-				f->store_64(val);
+				f->store_u32(VARIANT_INT64);
+				f->store_u64(val);
 
 			} else {
-				f->store_32(VARIANT_INT);
-				f->store_32(int32_t(p_property));
+				f->store_u32(VARIANT_INT);
+				f->store_u32(int32_t(p_property));
 			}
 
 		} break;
@@ -1621,36 +1621,36 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 			double d = p_property;
 			float fl = d;
 			if (double(fl) != d) {
-				f->store_32(VARIANT_DOUBLE);
+				f->store_u32(VARIANT_DOUBLE);
 				f->store_double(d);
 			} else {
-				f->store_32(VARIANT_FLOAT);
+				f->store_u32(VARIANT_FLOAT);
 				f->store_real(fl);
 			}
 
 		} break;
 		case Variant::STRING: {
-			f->store_32(VARIANT_STRING);
+			f->store_u32(VARIANT_STRING);
 			String val = p_property;
 			save_unicode_string(f, val);
 
 		} break;
 		case Variant::VECTOR2: {
-			f->store_32(VARIANT_VECTOR2);
+			f->store_u32(VARIANT_VECTOR2);
 			Vector2 val = p_property;
 			f->store_real(val.x);
 			f->store_real(val.y);
 
 		} break;
 		case Variant::VECTOR2I: {
-			f->store_32(VARIANT_VECTOR2I);
+			f->store_u32(VARIANT_VECTOR2I);
 			Vector2i val = p_property;
-			f->store_32(val.x);
-			f->store_32(val.y);
+			f->store_u32(val.x);
+			f->store_u32(val.y);
 
 		} break;
 		case Variant::RECT2: {
-			f->store_32(VARIANT_RECT2);
+			f->store_u32(VARIANT_RECT2);
 			Rect2 val = p_property;
 			f->store_real(val.position.x);
 			f->store_real(val.position.y);
@@ -1659,16 +1659,16 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::RECT2I: {
-			f->store_32(VARIANT_RECT2I);
+			f->store_u32(VARIANT_RECT2I);
 			Rect2i val = p_property;
-			f->store_32(val.position.x);
-			f->store_32(val.position.y);
-			f->store_32(val.size.x);
-			f->store_32(val.size.y);
+			f->store_u32(val.position.x);
+			f->store_u32(val.position.y);
+			f->store_u32(val.size.x);
+			f->store_u32(val.size.y);
 
 		} break;
 		case Variant::VECTOR3: {
-			f->store_32(VARIANT_VECTOR3);
+			f->store_u32(VARIANT_VECTOR3);
 			Vector3 val = p_property;
 			f->store_real(val.x);
 			f->store_real(val.y);
@@ -1676,15 +1676,15 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::VECTOR3I: {
-			f->store_32(VARIANT_VECTOR3I);
+			f->store_u32(VARIANT_VECTOR3I);
 			Vector3i val = p_property;
-			f->store_32(val.x);
-			f->store_32(val.y);
-			f->store_32(val.z);
+			f->store_u32(val.x);
+			f->store_u32(val.y);
+			f->store_u32(val.z);
 
 		} break;
 		case Variant::VECTOR4: {
-			f->store_32(VARIANT_VECTOR4);
+			f->store_u32(VARIANT_VECTOR4);
 			Vector4 val = p_property;
 			f->store_real(val.x);
 			f->store_real(val.y);
@@ -1693,16 +1693,16 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::VECTOR4I: {
-			f->store_32(VARIANT_VECTOR4I);
+			f->store_u32(VARIANT_VECTOR4I);
 			Vector4i val = p_property;
-			f->store_32(val.x);
-			f->store_32(val.y);
-			f->store_32(val.z);
-			f->store_32(val.w);
+			f->store_u32(val.x);
+			f->store_u32(val.y);
+			f->store_u32(val.z);
+			f->store_u32(val.w);
 
 		} break;
 		case Variant::PLANE: {
-			f->store_32(VARIANT_PLANE);
+			f->store_u32(VARIANT_PLANE);
 			Plane val = p_property;
 			f->store_real(val.normal.x);
 			f->store_real(val.normal.y);
@@ -1711,7 +1711,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::QUATERNION: {
-			f->store_32(VARIANT_QUATERNION);
+			f->store_u32(VARIANT_QUATERNION);
 			Quaternion val = p_property;
 			f->store_real(val.x);
 			f->store_real(val.y);
@@ -1720,7 +1720,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::AABB: {
-			f->store_32(VARIANT_AABB);
+			f->store_u32(VARIANT_AABB);
 			AABB val = p_property;
 			f->store_real(val.position.x);
 			f->store_real(val.position.y);
@@ -1731,7 +1731,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::TRANSFORM2D: {
-			f->store_32(VARIANT_TRANSFORM2D);
+			f->store_u32(VARIANT_TRANSFORM2D);
 			Transform2D val = p_property;
 			f->store_real(val.columns[0].x);
 			f->store_real(val.columns[0].y);
@@ -1742,7 +1742,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::BASIS: {
-			f->store_32(VARIANT_BASIS);
+			f->store_u32(VARIANT_BASIS);
 			Basis val = p_property;
 			f->store_real(val.rows[0].x);
 			f->store_real(val.rows[0].y);
@@ -1756,7 +1756,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::TRANSFORM3D: {
-			f->store_32(VARIANT_TRANSFORM3D);
+			f->store_u32(VARIANT_TRANSFORM3D);
 			Transform3D val = p_property;
 			f->store_real(val.basis.rows[0].x);
 			f->store_real(val.basis.rows[0].y);
@@ -1773,7 +1773,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::PROJECTION: {
-			f->store_32(VARIANT_PROJECTION);
+			f->store_u32(VARIANT_PROJECTION);
 			Projection val = p_property;
 			f->store_real(val.columns[0].x);
 			f->store_real(val.columns[0].y);
@@ -1794,7 +1794,7 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::COLOR: {
-			f->store_32(VARIANT_COLOR);
+			f->store_u32(VARIANT_COLOR);
 			Color val = p_property;
 			// Color are always floats
 			f->store_float(val.r);
@@ -1804,31 +1804,31 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::STRING_NAME: {
-			f->store_32(VARIANT_STRING_NAME);
+			f->store_u32(VARIANT_STRING_NAME);
 			String val = p_property;
 			save_unicode_string(f, val);
 
 		} break;
 
 		case Variant::NODE_PATH: {
-			f->store_32(VARIANT_NODE_PATH);
+			f->store_u32(VARIANT_NODE_PATH);
 			NodePath np = p_property;
-			f->store_16(np.get_name_count());
+			f->store_u16(np.get_name_count());
 			uint16_t snc = np.get_subname_count();
 			if (np.is_absolute()) {
 				snc |= 0x8000;
 			}
-			f->store_16(snc);
+			f->store_u16(snc);
 			for (int i = 0; i < np.get_name_count(); i++) {
 				if (string_map.has(np.get_name(i))) {
-					f->store_32(string_map[np.get_name(i)]);
+					f->store_u32(string_map[np.get_name(i)]);
 				} else {
 					save_unicode_string(f, np.get_name(i), true);
 				}
 			}
 			for (int i = 0; i < np.get_subname_count(); i++) {
 				if (string_map.has(np.get_subname(i))) {
-					f->store_32(string_map[np.get_subname(i)]);
+					f->store_u32(string_map[np.get_subname(i)]);
 				} else {
 					save_unicode_string(f, np.get_subname(i), true);
 				}
@@ -1836,47 +1836,47 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::RID: {
-			f->store_32(VARIANT_RID);
+			f->store_u32(VARIANT_RID);
 			WARN_PRINT("Can't save RIDs.");
 			RID val = p_property;
-			f->store_32(val.get_id());
+			f->store_u32(val.get_id());
 		} break;
 		case Variant::OBJECT: {
-			f->store_32(VARIANT_OBJECT);
+			f->store_u32(VARIANT_OBJECT);
 			Ref<Resource> res = p_property;
 			if (res.is_null() || res->get_meta(SNAME("_skip_save_"), false)) {
-				f->store_32(OBJECT_EMPTY);
+				f->store_u32(OBJECT_EMPTY);
 				return; // Don't save it.
 			}
 
 			if (!res->is_built_in()) {
-				f->store_32(OBJECT_EXTERNAL_RESOURCE_INDEX);
-				f->store_32(external_resources[res]);
+				f->store_u32(OBJECT_EXTERNAL_RESOURCE_INDEX);
+				f->store_u32(external_resources[res]);
 			} else {
 				if (!resource_map.has(res)) {
-					f->store_32(OBJECT_EMPTY);
+					f->store_u32(OBJECT_EMPTY);
 					ERR_FAIL_MSG("Resource was not pre cached for the resource section, most likely due to circular reference.");
 				}
 
-				f->store_32(OBJECT_INTERNAL_RESOURCE);
-				f->store_32(resource_map[res]);
+				f->store_u32(OBJECT_INTERNAL_RESOURCE);
+				f->store_u32(resource_map[res]);
 				//internal resource
 			}
 
 		} break;
 		case Variant::CALLABLE: {
-			f->store_32(VARIANT_CALLABLE);
+			f->store_u32(VARIANT_CALLABLE);
 			WARN_PRINT("Can't save Callables.");
 		} break;
 		case Variant::SIGNAL: {
-			f->store_32(VARIANT_SIGNAL);
+			f->store_u32(VARIANT_SIGNAL);
 			WARN_PRINT("Can't save Signals.");
 		} break;
 
 		case Variant::DICTIONARY: {
-			f->store_32(VARIANT_DICTIONARY);
+			f->store_u32(VARIANT_DICTIONARY);
 			Dictionary d = p_property;
-			f->store_32(uint32_t(d.size()));
+			f->store_u32(uint32_t(d.size()));
 
 			List<Variant> keys;
 			d.get_key_list(&keys);
@@ -1888,51 +1888,51 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::ARRAY: {
-			f->store_32(VARIANT_ARRAY);
+			f->store_u32(VARIANT_ARRAY);
 			Array a = p_property;
-			f->store_32(uint32_t(a.size()));
+			f->store_u32(uint32_t(a.size()));
 			for (const Variant &var : a) {
 				write_variant(f, var, resource_map, external_resources, string_map);
 			}
 
 		} break;
 		case Variant::PACKED_BYTE_ARRAY: {
-			f->store_32(VARIANT_PACKED_BYTE_ARRAY);
+			f->store_u32(VARIANT_PACKED_BYTE_ARRAY);
 			Vector<uint8_t> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const uint8_t *r = arr.ptr();
 			f->store_buffer(r, len);
 			_pad_buffer(f, len);
 
 		} break;
 		case Variant::PACKED_INT32_ARRAY: {
-			f->store_32(VARIANT_PACKED_INT32_ARRAY);
+			f->store_u32(VARIANT_PACKED_INT32_ARRAY);
 			Vector<int32_t> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const int32_t *r = arr.ptr();
 			for (int i = 0; i < len; i++) {
-				f->store_32(r[i]);
+				f->store_u32(r[i]);
 			}
 
 		} break;
 		case Variant::PACKED_INT64_ARRAY: {
-			f->store_32(VARIANT_PACKED_INT64_ARRAY);
+			f->store_u32(VARIANT_PACKED_INT64_ARRAY);
 			Vector<int64_t> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const int64_t *r = arr.ptr();
 			for (int i = 0; i < len; i++) {
-				f->store_64(r[i]);
+				f->store_u64(r[i]);
 			}
 
 		} break;
 		case Variant::PACKED_FLOAT32_ARRAY: {
-			f->store_32(VARIANT_PACKED_FLOAT32_ARRAY);
+			f->store_u32(VARIANT_PACKED_FLOAT32_ARRAY);
 			Vector<float> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const float *r = arr.ptr();
 			for (int i = 0; i < len; i++) {
 				f->store_float(r[i]);
@@ -1940,10 +1940,10 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::PACKED_FLOAT64_ARRAY: {
-			f->store_32(VARIANT_PACKED_FLOAT64_ARRAY);
+			f->store_u32(VARIANT_PACKED_FLOAT64_ARRAY);
 			Vector<double> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const double *r = arr.ptr();
 			for (int i = 0; i < len; i++) {
 				f->store_double(r[i]);
@@ -1951,10 +1951,10 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::PACKED_STRING_ARRAY: {
-			f->store_32(VARIANT_PACKED_STRING_ARRAY);
+			f->store_u32(VARIANT_PACKED_STRING_ARRAY);
 			Vector<String> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const String *r = arr.ptr();
 			for (int i = 0; i < len; i++) {
 				save_unicode_string(f, r[i]);
@@ -1962,10 +1962,10 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 		} break;
 
 		case Variant::PACKED_VECTOR2_ARRAY: {
-			f->store_32(VARIANT_PACKED_VECTOR2_ARRAY);
+			f->store_u32(VARIANT_PACKED_VECTOR2_ARRAY);
 			Vector<Vector2> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const Vector2 *r = arr.ptr();
 			for (int i = 0; i < len; i++) {
 				f->store_real(r[i].x);
@@ -1974,10 +1974,10 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 		} break;
 
 		case Variant::PACKED_VECTOR3_ARRAY: {
-			f->store_32(VARIANT_PACKED_VECTOR3_ARRAY);
+			f->store_u32(VARIANT_PACKED_VECTOR3_ARRAY);
 			Vector<Vector3> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const Vector3 *r = arr.ptr();
 			for (int i = 0; i < len; i++) {
 				f->store_real(r[i].x);
@@ -1987,10 +1987,10 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 		} break;
 
 		case Variant::PACKED_COLOR_ARRAY: {
-			f->store_32(VARIANT_PACKED_COLOR_ARRAY);
+			f->store_u32(VARIANT_PACKED_COLOR_ARRAY);
 			Vector<Color> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const Color *r = arr.ptr();
 			for (int i = 0; i < len; i++) {
 				f->store_float(r[i].r);
@@ -2001,10 +2001,10 @@ void ResourceFormatSaverBinaryInstance::write_variant(Ref<FileAccess> f, const V
 
 		} break;
 		case Variant::PACKED_VECTOR4_ARRAY: {
-			f->store_32(VARIANT_PACKED_VECTOR4_ARRAY);
+			f->store_u32(VARIANT_PACKED_VECTOR4_ARRAY);
 			Vector<Vector4> arr = p_property;
 			int len = arr.size();
-			f->store_32(len);
+			f->store_u32(len);
 			const Vector4 *r = arr.ptr();
 			for (int i = 0; i < len; i++) {
 				f->store_real(r[i].x);
@@ -2115,9 +2115,9 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 void ResourceFormatSaverBinaryInstance::save_unicode_string(Ref<FileAccess> p_f, const String &p_string, bool p_bit_on_len) {
 	CharString utf8 = p_string.utf8();
 	if (p_bit_on_len) {
-		p_f->store_32((utf8.length() + 1) | 0x80000000);
+		p_f->store_u32((utf8.length() + 1) | 0x80000000);
 	} else {
-		p_f->store_32(utf8.length() + 1);
+		p_f->store_u32(utf8.length() + 1);
 	}
 	p_f->store_buffer((const uint8_t *)utf8.get_data(), utf8.length() + 1);
 }
@@ -2181,23 +2181,23 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 	}
 
 	if (big_endian) {
-		f->store_32(1);
+		f->store_u32(1);
 		f->set_big_endian(true);
 	} else {
-		f->store_32(0);
+		f->store_u32(0);
 	}
 
-	f->store_32(0); //64 bits file, false for now
-	f->store_32(VERSION_MAJOR);
-	f->store_32(VERSION_MINOR);
-	f->store_32(FORMAT_VERSION);
+	f->store_u32(0); //64 bits file, false for now
+	f->store_u32(VERSION_MAJOR);
+	f->store_u32(VERSION_MINOR);
+	f->store_u32(FORMAT_VERSION);
 
 	if (f->get_error() != OK && f->get_error() != ERR_FILE_EOF) {
 		return ERR_CANT_CREATE;
 	}
 
 	save_unicode_string(f, _resource_get_class(p_resource));
-	f->store_64(0); //offset to import metadata
+	f->store_u64(0); //offset to import metadata
 
 	String script_class;
 	{
@@ -2215,16 +2215,16 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 			}
 		}
 
-		f->store_32(format_flags);
+		f->store_u32(format_flags);
 	}
 	ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(p_path, true);
-	f->store_64(uid);
+	f->store_u64(uid);
 	if (!script_class.is_empty()) {
 		save_unicode_string(f, script_class);
 	}
 
 	for (int i = 0; i < ResourceFormatSaverBinaryInstance::RESERVED_FIELDS; i++) {
-		f->store_32(0); // reserved
+		f->store_u32(0); // reserved
 	}
 
 	List<ResourceData> resources;
@@ -2284,13 +2284,13 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 		}
 	}
 
-	f->store_32(strings.size()); //string table size
+	f->store_u32(strings.size()); //string table size
 	for (int i = 0; i < strings.size(); i++) {
 		save_unicode_string(f, strings[i]);
 	}
 
 	// save external resource table
-	f->store_32(external_resources.size()); //amount of external resources
+	f->store_u32(external_resources.size()); //amount of external resources
 	Vector<Ref<Resource>> save_order;
 	save_order.resize(external_resources.size());
 
@@ -2304,10 +2304,10 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 		res_path = relative_paths ? local_path.path_to_file(res_path) : res_path;
 		save_unicode_string(f, res_path);
 		ResourceUID::ID ruid = ResourceSaver::get_resource_id_for_path(save_order[i]->get_path(), false);
-		f->store_64(ruid);
+		f->store_u64(ruid);
 	}
 	// save internal resource table
-	f->store_32(saved_resources.size()); //amount of internal resources
+	f->store_u32(saved_resources.size()); //amount of internal resources
 	Vector<uint64_t> ofs_pos;
 	HashSet<String> used_unique_ids;
 
@@ -2352,7 +2352,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 			save_unicode_string(f, r->get_path()); //actual external
 		}
 		ofs_pos.push_back(f->get_position());
-		f->store_64(0); //offset in 64 bits
+		f->store_u64(0); //offset in 64 bits
 		resource_map[r] = res_index++;
 	}
 
@@ -2362,17 +2362,17 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 	for (const ResourceData &rd : resources) {
 		ofs_table.push_back(f->get_position());
 		save_unicode_string(f, rd.type);
-		f->store_32(rd.properties.size());
+		f->store_u32(rd.properties.size());
 
 		for (const Property &p : rd.properties) {
-			f->store_32(p.name_idx);
+			f->store_u32(p.name_idx);
 			write_variant(f, p.value, resource_map, external_resources, string_map, p.pi);
 		}
 	}
 
 	for (int i = 0; i < ofs_table.size(); i++) {
 		f->seek(ofs_pos[i]);
-		f->store_64(ofs_table[i]);
+		f->store_u64(ofs_table[i]);
 	}
 
 	f->seek_end();
@@ -2423,20 +2423,20 @@ Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceU
 		fw->store_buffer(magich, 4);
 	}
 
-	big_endian = f->get_32();
-	bool use_real64 = f->get_32();
+	big_endian = f->get_u32();
+	bool use_real64 = f->get_u32();
 	f->set_big_endian(big_endian != 0); //read big endian if saved as big endian
 #ifdef BIG_ENDIAN_ENABLED
-	fw->store_32(!big_endian);
+	fw->store_u32(!big_endian);
 #else
-	fw->store_32(big_endian);
+	fw->store_u32(big_endian);
 #endif
 	fw->set_big_endian(big_endian != 0);
-	fw->store_32(use_real64); //use real64
+	fw->store_u32(use_real64); //use real64
 
-	uint32_t ver_major = f->get_32();
-	uint32_t ver_minor = f->get_32();
-	uint32_t ver_format = f->get_32();
+	uint32_t ver_major = f->get_u32();
+	uint32_t ver_minor = f->get_u32();
+	uint32_t ver_format = f->get_u32();
 
 	if (ver_format < FORMAT_VERSION_CAN_RENAME_DEPS) {
 		fw.unref();
@@ -2460,30 +2460,30 @@ Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceU
 
 	// Since we're not actually converting the file contents, leave the version
 	// numbers in the file untouched.
-	fw->store_32(ver_major);
-	fw->store_32(ver_minor);
-	fw->store_32(ver_format);
+	fw->store_u32(ver_major);
+	fw->store_u32(ver_minor);
+	fw->store_u32(ver_format);
 
 	save_ustring(fw, get_ustring(f)); //type
 
-	fw->store_64(f->get_64()); //metadata offset
+	fw->store_u64(f->get_u64()); //metadata offset
 
-	uint32_t flags = f->get_32();
+	uint32_t flags = f->get_u32();
 	flags |= ResourceFormatSaverBinaryInstance::FORMAT_FLAG_UIDS;
-	f->get_64(); // Skip previous UID
+	f->get_u64(); // Skip previous UID
 
-	fw->store_32(flags);
-	fw->store_64(p_uid);
+	fw->store_u32(flags);
+	fw->store_u64(p_uid);
 
 	if (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_HAS_SCRIPT_CLASS) {
 		save_ustring(fw, get_ustring(f));
 	}
 
 	//rest of file
-	uint8_t b = f->get_8();
+	uint8_t b = f->get_u8();
 	while (!f->eof_reached()) {
-		fw->store_8(b);
-		b = f->get_8();
+		fw->store_u8(b);
+		b = f->get_u8();
 	}
 
 	f.unref();

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -173,14 +173,14 @@ Error ResourceUID::save_to_cache() {
 	}
 
 	MutexLock l(mutex);
-	f->store_32(unique_ids.size());
+	f->store_u32(unique_ids.size());
 
 	cache_entries = 0;
 
 	for (KeyValue<ID, Cache> &E : unique_ids) {
-		f->store_64(E.key);
+		f->store_u64(E.key);
 		uint32_t s = E.value.cs.length();
-		f->store_32(s);
+		f->store_u32(s);
 		f->store_buffer((const uint8_t *)E.value.cs.ptr(), s);
 		E.value.saved_to_cache = true;
 		cache_entries++;
@@ -201,10 +201,10 @@ Error ResourceUID::load_from_cache(bool p_reset) {
 		unique_ids.clear();
 	}
 
-	uint32_t entry_count = f->get_32();
+	uint32_t entry_count = f->get_u32();
 	for (uint32_t i = 0; i < entry_count; i++) {
-		int64_t id = f->get_64();
-		int32_t len = f->get_32();
+		int64_t id = f->get_u64();
+		int32_t len = f->get_u32();
 		Cache c;
 		c.cs.resize(len + 1);
 		ERR_FAIL_COND_V(c.cs.size() != len + 1, ERR_FILE_CORRUPT); // out of memory
@@ -241,9 +241,9 @@ Error ResourceUID::update_cache() {
 				}
 				f->seek_end();
 			}
-			f->store_64(E.key);
+			f->store_u64(E.key);
 			uint32_t s = E.value.cs.length();
-			f->store_32(s);
+			f->store_u32(s);
 			f->store_buffer((const uint8_t *)E.value.cs.ptr(), s);
 			E.value.saved_to_cache = true;
 			cache_entries++;
@@ -252,7 +252,7 @@ Error ResourceUID::update_cache() {
 
 	if (f.is_valid()) {
 		f->seek(0);
-		f->store_32(cache_entries); //update amount of entries
+		f->store_u32(cache_entries); //update amount of entries
 	}
 
 	changed = false;

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -42,17 +42,17 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 	Ref<TranslationPO> translation = Ref<TranslationPO>(memnew(TranslationPO));
 	String config;
 
-	uint32_t magic = f->get_32();
+	uint32_t magic = f->get_u32();
 	if (magic == 0x950412de) {
 		// Load binary MO file.
 
-		uint16_t version_maj = f->get_16();
-		uint16_t version_min = f->get_16();
+		uint16_t version_maj = f->get_u16();
+		uint16_t version_min = f->get_u16();
 		ERR_FAIL_COND_V_MSG(version_maj > 1, Ref<Resource>(), vformat("Unsupported MO file %s, version %d.%d.", path, version_maj, version_min));
 
-		uint32_t num_strings = f->get_32();
-		uint32_t id_table_offset = f->get_32();
-		uint32_t trans_table_offset = f->get_32();
+		uint32_t num_strings = f->get_u32();
+		uint32_t id_table_offset = f->get_u32();
+		uint32_t trans_table_offset = f->get_u32();
 
 		// Read string tables.
 		for (uint32_t i = 0; i < num_strings; i++) {
@@ -65,8 +65,8 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 				Vector<uint8_t> data;
 				f->seek(id_table_offset + i * 8);
 				uint32_t str_start = 0;
-				uint32_t str_len = f->get_32();
-				uint32_t str_offset = f->get_32();
+				uint32_t str_len = f->get_u32();
+				uint32_t str_offset = f->get_u32();
 
 				data.resize(str_len + 1);
 				f->seek(str_offset);
@@ -95,8 +95,8 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 			{
 				Vector<uint8_t> data;
 				f->seek(trans_table_offset + i * 8);
-				uint32_t str_len = f->get_32();
-				uint32_t str_offset = f->get_32();
+				uint32_t str_len = f->get_u32();
+				uint32_t str_offset = f->get_u32();
 
 				data.resize(str_len + 1);
 				f->seek(str_offset);

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -99,25 +99,25 @@
 				[b]Note:[/b] Only call [method flush] when you actually need it. Otherwise, it will decrease performance due to constant disk writes.
 			</description>
 		</method>
-		<method name="get_8" qualifiers="const">
+		<method name="get_8" qualifiers="const" deprecated="Use [method get_u8] or [method get_s8] instead.">
 			<return type="int" />
 			<description>
 				Returns the next 8 bits from the file as an integer. See [method store_8] for details on what values can be stored and retrieved this way.
 			</description>
 		</method>
-		<method name="get_16" qualifiers="const">
+		<method name="get_16" qualifiers="const" deprecated="Use [method get_u16] or [method get_s16] instead.">
 			<return type="int" />
 			<description>
 				Returns the next 16 bits from the file as an integer. See [method store_16] for details on what values can be stored and retrieved this way.
 			</description>
 		</method>
-		<method name="get_32" qualifiers="const">
+		<method name="get_32" qualifiers="const" deprecated="Use [method get_u32] or [method get_s32] instead.">
 			<return type="int" />
 			<description>
 				Returns the next 32 bits from the file as an integer. See [method store_32] for details on what values can be stored and retrieved this way.
 			</description>
 		</method>
-		<method name="get_64" qualifiers="const">
+		<method name="get_64" qualifiers="const" deprecated="Use [method get_u64] or [method get_s64] instead.">
 			<return type="int" />
 			<description>
 				Returns the next 64 bits from the file as an integer. See [method store_64] for details on what values can be stored and retrieved this way.
@@ -273,11 +273,59 @@
 				Returns the next bits from the file as a floating-point number.
 			</description>
 		</method>
+		<method name="get_s8" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the next 8 bits from the file as a signed integer. See [method store_s8] for details on what values can be stored and retrieved this way.
+			</description>
+		</method>
+		<method name="get_s16" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the next 16 bits from the file as a signed integer. See [method store_s16] for details on what values can be stored and retrieved this way.
+			</description>
+		</method>
+		<method name="get_s32" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the next 32 bits from the file as a signed integer. See [method store_s32] for details on what values can be stored and retrieved this way.
+			</description>
+		</method>
+		<method name="get_s64" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the next 64 bits from the file as a signed integer. See [method store_s64] for details on what values can be stored and retrieved this way.
+			</description>
+		</method>
 		<method name="get_sha256" qualifiers="static">
 			<return type="String" />
 			<param index="0" name="path" type="String" />
 			<description>
 				Returns an SHA-256 [String] representing the file at the given path or an empty [String] on failure.
+			</description>
+		</method>
+		<method name="get_u8" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the next 8 bits from the file as an unsigned integer. See [method store_u8] for details on what values can be stored and retrieved this way.
+			</description>
+		</method>
+		<method name="get_u16" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the next 16 bits from the file as an unsigned integer. See [method store_u16] for details on what values can be stored and retrieved this way.
+			</description>
+		</method>
+		<method name="get_u32" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the next 32 bits from the file as an unsigned integer. See [method store_u32] for details on what values can be stored and retrieved this way.
+			</description>
+		</method>
+		<method name="get_u64" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the next 64 bits from the file as an unsigned integer. See [method store_u64] for details on what values can be stored and retrieved this way.
 			</description>
 		</method>
 		<method name="get_unix_permissions" qualifiers="static">
@@ -394,69 +442,37 @@
 				[b]Note:[/b] This method is implemented on iOS, Linux/BSD, and macOS.
 			</description>
 		</method>
-		<method name="store_8">
+		<method name="store_8" deprecated="Use [method store_u8] or [method store_s8] instead.">
 			<return type="bool" />
 			<param index="0" name="value" type="int" />
 			<description>
 				Stores an integer as 8 bits in the file.
 				[b]Note:[/b] The [param value] should lie in the interval [code][0, 255][/code]. Any other value will overflow and wrap around.
 				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
-				To store a signed integer, use [method store_64], or convert it manually (see [method store_16] for an example).
+				To store a signed integer, use [method store_s8].
 			</description>
 		</method>
-		<method name="store_16">
+		<method name="store_16" deprecated="Use [method store_u16] or [method store_s16] instead.">
 			<return type="bool" />
 			<param index="0" name="value" type="int" />
 			<description>
 				Stores an integer as 16 bits in the file.
 				[b]Note:[/b] The [param value] should lie in the interval [code][0, 2^16 - 1][/code]. Any other value will overflow and wrap around.
 				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
-				To store a signed integer, use [method store_64] or store a signed integer from the interval [code][-2^15, 2^15 - 1][/code] (i.e. keeping one bit for the signedness) and compute its sign manually when reading. For example:
-				[codeblocks]
-				[gdscript]
-				const MAX_15B = 1 &lt;&lt; 15
-				const MAX_16B = 1 &lt;&lt; 16
-
-				func unsigned16_to_signed(unsigned):
-				    return (unsigned + MAX_15B) % MAX_16B - MAX_15B
-
-				func _ready():
-				    var f = FileAccess.open("user://file.dat", FileAccess.WRITE_READ)
-				    f.store_16(-42) # This wraps around and stores 65494 (2^16 - 42).
-				    f.store_16(121) # In bounds, will store 121.
-				    f.seek(0) # Go back to start to read the stored value.
-				    var read1 = f.get_16() # 65494
-				    var read2 = f.get_16() # 121
-				    var converted1 = unsigned16_to_signed(read1) # -42
-				    var converted2 = unsigned16_to_signed(read2) # 121
-				[/gdscript]
-				[csharp]
-				public override void _Ready()
-				{
-				    using var f = FileAccess.Open("user://file.dat", FileAccess.ModeFlags.WriteRead);
-				    f.Store16(unchecked((ushort)-42)); // This wraps around and stores 65494 (2^16 - 42).
-				    f.Store16(121); // In bounds, will store 121.
-				    f.Seek(0); // Go back to start to read the stored value.
-				    ushort read1 = f.Get16(); // 65494
-				    ushort read2 = f.Get16(); // 121
-				    short converted1 = (short)read1; // -42
-				    short converted2 = (short)read2; // 121
-				}
-				[/csharp]
-				[/codeblocks]
+				To store a signed integer, use [method store_s16].
 			</description>
 		</method>
-		<method name="store_32">
+		<method name="store_32" deprecated="Use [method store_u32] or [method store_s32] instead.">
 			<return type="bool" />
 			<param index="0" name="value" type="int" />
 			<description>
 				Stores an integer as 32 bits in the file.
 				[b]Note:[/b] The [param value] should lie in the interval [code][0, 2^32 - 1][/code]. Any other value will overflow and wrap around.
 				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
-				To store a signed integer, use [method store_64], or convert it manually (see [method store_16] for an example).
+				To store a signed integer, use [method store_s32].
 			</description>
 		</method>
-		<method name="store_64">
+		<method name="store_64" deprecated="Use [method store_u64] or [method store_s64] instead.">
 			<return type="bool" />
 			<param index="0" name="value" type="int" />
 			<description>
@@ -531,12 +547,84 @@
 				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
 			</description>
 		</method>
+		<method name="store_s8">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Stores a signed integer as 8 bits in the file.
+				[b]Note:[/b] The [param value] should lie in the interval [code][-128, 127][/code]. Using any other value is undefined behavior.
+				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+			</description>
+		</method>
+		<method name="store_s16">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Stores a signed integer as 16 bits in the file.
+				[b]Note:[/b] The [param value] should lie in the interval [code][-32768, 32767][/code]. Using any other value is undefined behavior.
+				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+			</description>
+		</method>
+		<method name="store_s32">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Stores a signed integer as 32 bits in the file.
+				[b]Note:[/b] The [param value] should lie in the interval [code][-2147483648, 2147483647][/code]. Using any other value is undefined behavior.
+				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+			</description>
+		</method>
+		<method name="store_s64">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Stores an integer as 64 bits in the file.
+				[b]Note:[/b] The [param value] must lie in the interval [code][-9223372036854775808, 9223372036854775807][/code] (i.e. be a valid [int] value).
+				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+			</description>
+		</method>
 		<method name="store_string">
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
 			<description>
 				Stores [param string] in the file without a newline character ([code]\n[/code]), encoding the text as UTF-8.
 				[b]Note:[/b] This method is intended to be used to write text files. The string is stored as a UTF-8 encoded buffer without string length or terminating zero, which means that it can't be loaded back easily. If you want to store a retrievable string in a binary file, consider using [method store_pascal_string] instead. For retrieving strings from a text file, you can use [code]get_buffer(length).get_string_from_utf8()[/code] (if you know the length) or [method get_as_text].
+				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+			</description>
+		</method>
+		<method name="store_u8">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Stores an unsigned integer as 8 bits in the file.
+				[b]Note:[/b] The [param value] should lie in the interval [code][0, 255][/code]. Any other value will overflow and wrap around.
+				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+			</description>
+		</method>
+		<method name="store_u16">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Stores an unsigned integer as 16 bits in the file.
+				[b]Note:[/b] The [param value] should lie in the interval [code][0, 2^16 - 1][/code]. Any other value will overflow and wrap around.
+				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+			</description>
+		</method>
+		<method name="store_u32">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Stores an unsigned integer as 32 bits in the file.
+				[b]Note:[/b] The [param value] should lie in the interval [code][0, 2^32 - 1][/code]. Any other value will overflow and wrap around.
+				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+			</description>
+		</method>
+		<method name="store_u64">
+			<return type="bool" />
+			<param index="0" name="value" type="int" />
+			<description>
+				Stores an unsigned integer as 64 bits in the file.
+				[b]Note:[/b] The [param value] must lie in the interval [code][0, 2^63 - 1][/code] (i.e. be a valid [int] value).
 				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
 			</description>
 		</method>

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -152,14 +152,14 @@ void EditorFileServer::poll() {
 		tags.push_back(tag);
 	}
 
-	uint32_t file_buffer_decompressed_size = tcp_peer->get_32();
+	uint32_t file_buffer_decompressed_size = tcp_peer->get_u32();
 	HashMap<String, uint64_t> cached_files;
 
 	if (file_buffer_decompressed_size > 0) {
 		pr.step(TTR("Getting remote file system"), 1, true);
 
 		// Got files cached by client.
-		uint32_t file_buffer_size = tcp_peer->get_32();
+		uint32_t file_buffer_size = tcp_peer->get_u32();
 		print_verbose("EFS: Getting file buffer: compressed - " + String::humanize_size(file_buffer_size) + " decompressed: " + String::humanize_size(file_buffer_decompressed_size));
 
 		ERR_FAIL_COND(tcp_peer->get_status() != StreamPeerTCP::STATUS_CONNECTED);

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -1120,17 +1120,17 @@ void CodeSignSuperBlob::write_to_file(Ref<FileAccess> p_file) const {
 	uint32_t data_offset = 12 + blobs.size() * 8;
 
 	// Write header.
-	p_file->store_32(BSWAP32(0xfade0cc0));
-	p_file->store_32(BSWAP32(size));
-	p_file->store_32(BSWAP32(blobs.size()));
+	p_file->store_u32(BSWAP32(0xfade0cc0));
+	p_file->store_u32(BSWAP32(size));
+	p_file->store_u32(BSWAP32(blobs.size()));
 
 	// Write index.
 	for (int i = 0; i < blobs.size(); i++) {
 		if (blobs[i].is_null()) {
 			return;
 		}
-		p_file->store_32(BSWAP32(blobs[i]->get_index_type()));
-		p_file->store_32(BSWAP32(data_offset));
+		p_file->store_u32(BSWAP32(blobs[i]->get_index_type()));
+		p_file->store_u32(BSWAP32(data_offset));
 		data_offset += blobs[i]->get_size();
 	}
 

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -282,7 +282,7 @@ Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_pa
 
 	int pad = _get_pad(PCK_PADDING, pd->f->get_position());
 	for (int i = 0; i < pad; i++) {
-		pd->f->store_8(0);
+		pd->f->store_u8(0);
 	}
 
 	// Store MD5 of original file.
@@ -1596,7 +1596,7 @@ Error EditorExportPlatform::_remove_pack_file(void *p_userdata, const String &p_
 	// This padding will likely never be added, as we should already be aligned when removals are added.
 	int pad = _get_pad(PCK_PADDING, pd->f->get_position());
 	for (int i = 0; i < pad; i++) {
-		pd->f->store_8(0);
+		pd->f->store_u8(0);
 	}
 
 	sd.md5.resize(16);
@@ -1895,17 +1895,17 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 		// Ensure embedded PCK starts at a 64-bit multiple
 		int pad = f->get_position() % 8;
 		for (int i = 0; i < pad; i++) {
-			f->store_8(0);
+			f->store_u8(0);
 		}
 	}
 
 	int64_t pck_start_pos = f->get_position();
 
-	f->store_32(PACK_HEADER_MAGIC);
-	f->store_32(PACK_FORMAT_VERSION);
-	f->store_32(VERSION_MAJOR);
-	f->store_32(VERSION_MINOR);
-	f->store_32(VERSION_PATCH);
+	f->store_u32(PACK_HEADER_MAGIC);
+	f->store_u32(PACK_FORMAT_VERSION);
+	f->store_u32(VERSION_MAJOR);
+	f->store_u32(VERSION_MINOR);
+	f->store_u32(VERSION_PATCH);
 
 	uint32_t pack_flags = 0;
 	bool enc_pck = p_preset->get_enc_pck();
@@ -1916,17 +1916,17 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 	if (p_embed) {
 		pack_flags |= PACK_REL_FILEBASE;
 	}
-	f->store_32(pack_flags); // flags
+	f->store_u32(pack_flags); // flags
 
 	uint64_t file_base_ofs = f->get_position();
-	f->store_64(0); // files base
+	f->store_u64(0); // files base
 
 	for (int i = 0; i < 16; i++) {
 		//reserved
-		f->store_32(0);
+		f->store_u32(0);
 	}
 
-	f->store_32(pd.file_ofs.size()); //amount of files
+	f->store_u32(pd.file_ofs.size()); //amount of files
 
 	Ref<FileAccessEncrypted> fae;
 	Ref<FileAccess> fhead = f;
@@ -2000,14 +2000,14 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 		uint32_t string_len = pd.file_ofs[i].path_utf8.length();
 		uint32_t pad = _get_pad(4, string_len);
 
-		fhead->store_32(string_len + pad);
+		fhead->store_u32(string_len + pad);
 		fhead->store_buffer((const uint8_t *)pd.file_ofs[i].path_utf8.get_data(), string_len);
 		for (uint32_t j = 0; j < pad; j++) {
-			fhead->store_8(0);
+			fhead->store_u8(0);
 		}
 
-		fhead->store_64(pd.file_ofs[i].ofs);
-		fhead->store_64(pd.file_ofs[i].size); // pay attention here, this is where file is
+		fhead->store_u64(pd.file_ofs[i].ofs);
+		fhead->store_u64(pd.file_ofs[i].size); // pay attention here, this is where file is
 		fhead->store_buffer(pd.file_ofs[i].md5.ptr(), 16); //also save md5 for file
 		uint32_t flags = 0;
 		if (pd.file_ofs[i].encrypted) {
@@ -2016,7 +2016,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 		if (pd.file_ofs[i].removal) {
 			flags |= PACK_FILE_REMOVAL;
 		}
-		fhead->store_32(flags);
+		fhead->store_u32(flags);
 	}
 
 	if (fae.is_valid()) {
@@ -2026,7 +2026,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 
 	int header_padding = _get_pad(PCK_PADDING, f->get_position());
 	for (int i = 0; i < header_padding; i++) {
-		f->store_8(0);
+		f->store_u8(0);
 	}
 
 	uint64_t file_base = f->get_position();
@@ -2035,7 +2035,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 		file_base_store -= pck_start_pos;
 	}
 	f->seek(file_base_ofs);
-	f->store_64(file_base_store); // update files base
+	f->store_u64(file_base_store); // update files base
 	f->seek(file_base);
 
 	// Save the rest of the data.
@@ -2065,12 +2065,12 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 		uint64_t embed_end = f->get_position() - embed_pos + 12;
 		uint64_t pad = embed_end % 8;
 		for (uint64_t i = 0; i < pad; i++) {
-			f->store_8(0);
+			f->store_u8(0);
 		}
 
 		uint64_t pck_size = f->get_position() - pck_start_pos;
-		f->store_64(pck_size);
-		f->store_32(PACK_HEADER_MAGIC);
+		f->store_u64(pck_size);
+		f->store_u32(PACK_HEADER_MAGIC);
 
 		if (r_embedded_size) {
 			*r_embedded_size = f->get_position() - embed_pos;

--- a/editor/export/lipo.cpp
+++ b/editor/export/lipo.cpp
@@ -33,7 +33,7 @@
 bool LipO::is_lipo(const String &p_path) {
 	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_path));
-	uint32_t magic = fb->get_32();
+	uint32_t magic = fb->get_u32();
 	return (magic == 0xbebafeca || magic == 0xcafebabe || magic == 0xbfbafeca || magic == 0xcafebabf);
 }
 
@@ -72,27 +72,27 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 	// Write header.
 	bool is_64 = (max_size >= std::numeric_limits<uint32_t>::max());
 	if (is_64) {
-		fa->store_32(0xbfbafeca);
+		fa->store_u32(0xbfbafeca);
 	} else {
-		fa->store_32(0xbebafeca);
+		fa->store_u32(0xbebafeca);
 	}
-	fa->store_32(BSWAP32(archs.size()));
+	fa->store_u32(BSWAP32(archs.size()));
 	uint64_t offset = archs.size() * (is_64 ? 32 : 20) + 8;
 	for (int i = 0; i < archs.size(); i++) {
 		archs.write[i].offset = offset + PAD(offset, uint64_t(1) << archs[i].align);
 		if (is_64) {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_64(BSWAP64(archs[i].offset));
-			fa->store_64(BSWAP64(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
-			fa->store_32(0);
+			fa->store_u32(BSWAP32(archs[i].cputype));
+			fa->store_u32(BSWAP32(archs[i].cpusubtype));
+			fa->store_u64(BSWAP64(archs[i].offset));
+			fa->store_u64(BSWAP64(archs[i].size));
+			fa->store_u32(BSWAP32(archs[i].align));
+			fa->store_u32(0);
 		} else {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_32(BSWAP32(archs[i].offset));
-			fa->store_32(BSWAP32(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
+			fa->store_u32(BSWAP32(archs[i].cputype));
+			fa->store_u32(BSWAP32(archs[i].cpusubtype));
+			fa->store_u32(BSWAP32(archs[i].offset));
+			fa->store_u32(BSWAP32(archs[i].size));
+			fa->store_u32(BSWAP32(archs[i].align));
 		}
 		offset = archs[i].offset + archs[i].size;
 	}
@@ -106,7 +106,7 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 		}
 		uint64_t cur = fa->get_position();
 		for (uint64_t j = cur; j < archs[i].offset; j++) {
-			fa->store_8(0);
+			fa->store_u8(0);
 		}
 		int pages = archs[i].size / 4096;
 		int remain = archs[i].size % 4096;
@@ -166,27 +166,27 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 	// Write header.
 	bool is_64 = (max_size >= std::numeric_limits<uint32_t>::max());
 	if (is_64) {
-		fa->store_32(0xbfbafeca);
+		fa->store_u32(0xbfbafeca);
 	} else {
-		fa->store_32(0xbebafeca);
+		fa->store_u32(0xbebafeca);
 	}
-	fa->store_32(BSWAP32(archs.size()));
+	fa->store_u32(BSWAP32(archs.size()));
 	uint64_t offset = archs.size() * (is_64 ? 32 : 20) + 8;
 	for (int i = 0; i < archs.size(); i++) {
 		archs.write[i].offset = offset + PAD(offset, uint64_t(1) << archs[i].align);
 		if (is_64) {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_64(BSWAP64(archs[i].offset));
-			fa->store_64(BSWAP64(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
-			fa->store_32(0);
+			fa->store_u32(BSWAP32(archs[i].cputype));
+			fa->store_u32(BSWAP32(archs[i].cpusubtype));
+			fa->store_u64(BSWAP64(archs[i].offset));
+			fa->store_u64(BSWAP64(archs[i].size));
+			fa->store_u32(BSWAP32(archs[i].align));
+			fa->store_u32(0);
 		} else {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_32(BSWAP32(archs[i].offset));
-			fa->store_32(BSWAP32(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
+			fa->store_u32(BSWAP32(archs[i].cputype));
+			fa->store_u32(BSWAP32(archs[i].cpusubtype));
+			fa->store_u32(BSWAP32(archs[i].offset));
+			fa->store_u32(BSWAP32(archs[i].size));
+			fa->store_u32(BSWAP32(archs[i].align));
 		}
 		offset = archs[i].offset + archs[i].size;
 	}
@@ -200,7 +200,7 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 		}
 		uint64_t cur = fa->get_position();
 		for (uint64_t j = cur; j < archs[i].offset; j++) {
-			fa->store_8(0);
+			fa->store_u8(0);
 		}
 		int pages = archs[i].size / 4096;
 		int remain = archs[i].size % 4096;
@@ -225,58 +225,58 @@ bool LipO::open_file(const String &p_path) {
 	fa = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(fa.is_null(), false, vformat("LipO: Can't open file: \"%s\".", p_path));
 
-	uint32_t magic = fa->get_32();
+	uint32_t magic = fa->get_u32();
 	if (magic == 0xbebafeca) {
 		// 32-bit fat binary, bswap.
-		uint32_t nfat_arch = BSWAP32(fa->get_32());
+		uint32_t nfat_arch = BSWAP32(fa->get_u32());
 		for (uint32_t i = 0; i < nfat_arch; i++) {
 			FatArch arch;
-			arch.cputype = BSWAP32(fa->get_32());
-			arch.cpusubtype = BSWAP32(fa->get_32());
-			arch.offset = BSWAP32(fa->get_32());
-			arch.size = BSWAP32(fa->get_32());
-			arch.align = BSWAP32(fa->get_32());
+			arch.cputype = BSWAP32(fa->get_u32());
+			arch.cpusubtype = BSWAP32(fa->get_u32());
+			arch.offset = BSWAP32(fa->get_u32());
+			arch.size = BSWAP32(fa->get_u32());
+			arch.align = BSWAP32(fa->get_u32());
 
 			archs.push_back(arch);
 		}
 	} else if (magic == 0xcafebabe) {
 		// 32-bit fat binary.
-		uint32_t nfat_arch = fa->get_32();
+		uint32_t nfat_arch = fa->get_u32();
 		for (uint32_t i = 0; i < nfat_arch; i++) {
 			FatArch arch;
-			arch.cputype = fa->get_32();
-			arch.cpusubtype = fa->get_32();
-			arch.offset = fa->get_32();
-			arch.size = fa->get_32();
-			arch.align = fa->get_32();
+			arch.cputype = fa->get_u32();
+			arch.cpusubtype = fa->get_u32();
+			arch.offset = fa->get_u32();
+			arch.size = fa->get_u32();
+			arch.align = fa->get_u32();
 
 			archs.push_back(arch);
 		}
 	} else if (magic == 0xbfbafeca) {
 		// 64-bit fat binary, bswap.
-		uint32_t nfat_arch = BSWAP32(fa->get_32());
+		uint32_t nfat_arch = BSWAP32(fa->get_u32());
 		for (uint32_t i = 0; i < nfat_arch; i++) {
 			FatArch arch;
-			arch.cputype = BSWAP32(fa->get_32());
-			arch.cpusubtype = BSWAP32(fa->get_32());
-			arch.offset = BSWAP64(fa->get_64());
-			arch.size = BSWAP64(fa->get_64());
-			arch.align = BSWAP32(fa->get_32());
-			fa->get_32(); // Skip, reserved.
+			arch.cputype = BSWAP32(fa->get_u32());
+			arch.cpusubtype = BSWAP32(fa->get_u32());
+			arch.offset = BSWAP64(fa->get_u64());
+			arch.size = BSWAP64(fa->get_u64());
+			arch.align = BSWAP32(fa->get_u32());
+			fa->get_u32(); // Skip, reserved.
 
 			archs.push_back(arch);
 		}
 	} else if (magic == 0xcafebabf) {
 		// 64-bit fat binary.
-		uint32_t nfat_arch = fa->get_32();
+		uint32_t nfat_arch = fa->get_u32();
 		for (uint32_t i = 0; i < nfat_arch; i++) {
 			FatArch arch;
-			arch.cputype = fa->get_32();
-			arch.cpusubtype = fa->get_32();
-			arch.offset = fa->get_64();
-			arch.size = fa->get_64();
-			arch.align = fa->get_32();
-			fa->get_32(); // Skip, reserved.
+			arch.cputype = fa->get_u32();
+			arch.cpusubtype = fa->get_u32();
+			arch.offset = fa->get_u64();
+			arch.size = fa->get_u64();
+			arch.align = fa->get_u32();
+			fa->get_u32(); // Skip, reserved.
 
 			archs.push_back(arch);
 		}

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -912,7 +912,7 @@ public:
 	String get_line(Ref<FileAccess> f) {
 		_line_buffer.clear();
 
-		char32_t c = f->get_8();
+		char32_t c = f->get_u8();
 
 		while (!f->eof_reached()) {
 			if (c == '\n') {
@@ -928,7 +928,7 @@ public:
 				_line_buffer.push_back(c);
 			}
 
-			c = f->get_8();
+			c = f->get_u8();
 		}
 
 		_line_buffer.push_back(0);

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -209,7 +209,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 	// Avoid trying to load/interpret potential build artifacts from Visual Studio (e.g. when compiling native plugins inside the project tree).
 	// This should only match if it's indeed a COFF file header.
 	// https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#machine-types
-	const int first_bytes = f->get_16();
+	const int first_bytes = f->get_u16();
 	static const Vector<int> coff_header_machines{
 		0x0, // IMAGE_FILE_MACHINE_UNKNOWN
 		0x8664, // IMAGE_FILE_MACHINE_AMD64
@@ -665,7 +665,7 @@ Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_s
 	if (mesh_lightmap_caches.size()) {
 		Ref<FileAccess> f = FileAccess::open(p_source_file + ".unwrap_cache", FileAccess::WRITE);
 		if (f.is_valid()) {
-			f->store_32(mesh_lightmap_caches.size());
+			f->store_u32(mesh_lightmap_caches.size());
 			for (int i = 0; i < mesh_lightmap_caches.size(); i++) {
 				String md5 = String::md5(mesh_lightmap_caches[i].ptr());
 				f->store_buffer(mesh_lightmap_caches[i].ptr(), mesh_lightmap_caches[i].size());

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3080,7 +3080,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	if (mesh_lightmap_caches.size()) {
 		Ref<FileAccess> f = FileAccess::open(p_source_file + ".unwrap_cache", FileAccess::WRITE);
 		if (f.is_valid()) {
-			f->store_32(mesh_lightmap_caches.size());
+			f->store_u32(mesh_lightmap_caches.size());
 			for (int i = 0; i < mesh_lightmap_caches.size(); i++) {
 				String md5 = String::md5(mesh_lightmap_caches[i].ptr());
 				f->store_buffer(mesh_lightmap_caches[i].ptr(), mesh_lightmap_caches[i].size());

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -261,20 +261,20 @@ void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, cons
 	}
 
 	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
-	f->store_8('G');
-	f->store_8('S');
-	f->store_8('T');
-	f->store_8('L');
+	f->store_u8('G');
+	f->store_u8('S');
+	f->store_u8('T');
+	f->store_u8('L');
 
-	f->store_32(CompressedTextureLayered::FORMAT_VERSION);
-	f->store_32(p_images.size()); // For 2d layers or 3d depth.
-	f->store_32(mode);
-	f->store_32(0);
+	f->store_u32(CompressedTextureLayered::FORMAT_VERSION);
+	f->store_u32(p_images.size()); // For 2d layers or 3d depth.
+	f->store_u32(mode);
+	f->store_u32(0);
 
-	f->store_32(0);
-	f->store_32(mipmap_images.size()); // Adjust the amount of mipmaps.
-	f->store_32(0);
-	f->store_32(0);
+	f->store_u32(0);
+	f->store_u32(mipmap_images.size()); // Adjust the amount of mipmaps.
+	f->store_u32(0);
+	f->store_u32(0);
 
 	if ((p_compress_mode == COMPRESS_LOSSLESS || p_compress_mode == COMPRESS_LOSSY) && p_images[0]->get_format() >= Image::FORMAT_RF) {
 		p_compress_mode = COMPRESS_VRAM_UNCOMPRESSED; // These can't go as lossy.

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -263,11 +263,11 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 			bool lossless_force_png = GLOBAL_GET("rendering/textures/lossless_compression/force_png") ||
 					!Image::_webp_mem_loader_func; // WebP module disabled.
 			bool use_webp = !lossless_force_png && p_image->get_width() <= 16383 && p_image->get_height() <= 16383; // WebP has a size limit
-			f->store_32(use_webp ? CompressedTexture2D::DATA_FORMAT_WEBP : CompressedTexture2D::DATA_FORMAT_PNG);
-			f->store_16(p_image->get_width());
-			f->store_16(p_image->get_height());
-			f->store_32(p_image->get_mipmap_count());
-			f->store_32(p_image->get_format());
+			f->store_u32(use_webp ? CompressedTexture2D::DATA_FORMAT_WEBP : CompressedTexture2D::DATA_FORMAT_PNG);
+			f->store_u16(p_image->get_width());
+			f->store_u16(p_image->get_height());
+			f->store_u32(p_image->get_mipmap_count());
+			f->store_u32(p_image->get_format());
 
 			for (int i = 0; i < p_image->get_mipmap_count() + 1; i++) {
 				Vector<uint8_t> data;
@@ -277,7 +277,7 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 					data = Image::png_packer(i ? p_image->get_image_from_mipmap(i) : p_image);
 				}
 				int data_len = data.size();
-				f->store_32(data_len);
+				f->store_u32(data_len);
 
 				const uint8_t *r = data.ptr();
 				f->store_buffer(r, data_len);
@@ -285,16 +285,16 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 
 		} break;
 		case COMPRESS_LOSSY: {
-			f->store_32(CompressedTexture2D::DATA_FORMAT_WEBP);
-			f->store_16(p_image->get_width());
-			f->store_16(p_image->get_height());
-			f->store_32(p_image->get_mipmap_count());
-			f->store_32(p_image->get_format());
+			f->store_u32(CompressedTexture2D::DATA_FORMAT_WEBP);
+			f->store_u16(p_image->get_width());
+			f->store_u16(p_image->get_height());
+			f->store_u32(p_image->get_mipmap_count());
+			f->store_u32(p_image->get_format());
 
 			for (int i = 0; i < p_image->get_mipmap_count() + 1; i++) {
 				Vector<uint8_t> data = Image::webp_lossy_packer(i ? p_image->get_image_from_mipmap(i) : p_image, p_lossy_quality);
 				int data_len = data.size();
-				f->store_32(data_len);
+				f->store_u32(data_len);
 
 				const uint8_t *r = data.ptr();
 				f->store_buffer(r, data_len);
@@ -305,11 +305,11 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 
 			image->compress_from_channels(p_compress_format, p_channels);
 
-			f->store_32(CompressedTexture2D::DATA_FORMAT_IMAGE);
-			f->store_16(image->get_width());
-			f->store_16(image->get_height());
-			f->store_32(image->get_mipmap_count());
-			f->store_32(image->get_format());
+			f->store_u32(CompressedTexture2D::DATA_FORMAT_IMAGE);
+			f->store_u16(image->get_width());
+			f->store_u16(image->get_height());
+			f->store_u32(image->get_mipmap_count());
+			f->store_u32(image->get_format());
 
 			Vector<uint8_t> data = image->get_data();
 			int dl = data.size();
@@ -317,11 +317,11 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 			f->store_buffer(r, dl);
 		} break;
 		case COMPRESS_VRAM_UNCOMPRESSED: {
-			f->store_32(CompressedTexture2D::DATA_FORMAT_IMAGE);
-			f->store_16(p_image->get_width());
-			f->store_16(p_image->get_height());
-			f->store_32(p_image->get_mipmap_count());
-			f->store_32(p_image->get_format());
+			f->store_u32(CompressedTexture2D::DATA_FORMAT_IMAGE);
+			f->store_u16(p_image->get_width());
+			f->store_u16(p_image->get_height());
+			f->store_u32(p_image->get_mipmap_count());
+			f->store_u32(p_image->get_format());
 
 			Vector<uint8_t> data = p_image->get_data();
 			int dl = data.size();
@@ -331,14 +331,14 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 
 		} break;
 		case COMPRESS_BASIS_UNIVERSAL: {
-			f->store_32(CompressedTexture2D::DATA_FORMAT_BASIS_UNIVERSAL);
-			f->store_16(p_image->get_width());
-			f->store_16(p_image->get_height());
-			f->store_32(p_image->get_mipmap_count());
-			f->store_32(p_image->get_format());
+			f->store_u32(CompressedTexture2D::DATA_FORMAT_BASIS_UNIVERSAL);
+			f->store_u16(p_image->get_width());
+			f->store_u16(p_image->get_height());
+			f->store_u32(p_image->get_mipmap_count());
+			f->store_u32(p_image->get_format());
 			Vector<uint8_t> data = Image::basis_universal_packer(p_image, p_channels);
 			int data_len = data.size();
-			f->store_32(data_len);
+			f->store_u32(data_len);
 			const uint8_t *r = data.ptr();
 			f->store_buffer(r, data_len);
 		} break;
@@ -348,16 +348,16 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
 	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	ERR_FAIL_COND(f.is_null());
-	f->store_8('G');
-	f->store_8('S');
-	f->store_8('T');
-	f->store_8('2'); //godot streamable texture 2D
+	f->store_u8('G');
+	f->store_u8('S');
+	f->store_u8('T');
+	f->store_u8('2'); //godot streamable texture 2D
 
 	//format version
-	f->store_32(CompressedTexture2D::FORMAT_VERSION);
+	f->store_u32(CompressedTexture2D::FORMAT_VERSION);
 	//texture may be resized later, so original size must be saved first
-	f->store_32(p_image->get_width());
-	f->store_32(p_image->get_height());
+	f->store_u32(p_image->get_width());
+	f->store_u32(p_image->get_height());
 
 	uint32_t flags = 0;
 	if (p_streamable) {
@@ -376,12 +376,12 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 		flags |= CompressedTexture2D::FORMAT_BIT_DETECT_NORMAL;
 	}
 
-	f->store_32(flags);
-	f->store_32(p_limit_mipmap);
+	f->store_u32(flags);
+	f->store_u32(p_limit_mipmap);
 	//reserved for future use
-	f->store_32(0);
-	f->store_32(0);
-	f->store_32(0);
+	f->store_u32(0);
+	f->store_u32(0);
+	f->store_u32(0);
 
 	if ((p_compress_mode == COMPRESS_LOSSLESS || p_compress_mode == COMPRESS_LOSSY) && p_image->get_format() >= Image::FORMAT_RF) {
 		p_compress_mode = COMPRESS_VRAM_UNCOMPRESSED; //these can't go as lossy

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -820,7 +820,7 @@ void EditorAssetLibrary::_image_update(bool p_use_cache, bool p_final, const Pac
 		Ref<FileAccess> file = FileAccess::open(cache_filename_base + ".data", FileAccess::READ);
 		if (file.is_valid()) {
 			PackedByteArray cached_data;
-			int len = file->get_32();
+			int len = file->get_u32();
 			cached_data.resize(len);
 
 			uint8_t *w = cached_data.ptrw();
@@ -917,7 +917,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 					const uint8_t *r = p_data.ptr();
 					file = FileAccess::open(cache_filename_base + ".data", FileAccess::WRITE);
 					if (file.is_valid()) {
-						file->store_32(len);
+						file->store_u32(len);
 						file->store_buffer(r, len);
 					}
 

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -214,38 +214,38 @@ Error ImageLoaderBMP::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	// file header and a minimal info header
 	if (f->get_length() > BITMAP_FILE_HEADER_SIZE + BITMAP_INFO_HEADER_MIN_SIZE) {
 		// File Header
-		bmp_header.bmp_file_header.bmp_signature = f->get_16();
+		bmp_header.bmp_file_header.bmp_signature = f->get_u16();
 		if (bmp_header.bmp_file_header.bmp_signature == BITMAP_SIGNATURE) {
-			bmp_header.bmp_file_header.bmp_file_size = f->get_32();
-			bmp_header.bmp_file_header.bmp_file_padding = f->get_32();
-			bmp_header.bmp_file_header.bmp_file_offset = f->get_32();
+			bmp_header.bmp_file_header.bmp_file_size = f->get_u32();
+			bmp_header.bmp_file_header.bmp_file_padding = f->get_u32();
+			bmp_header.bmp_file_header.bmp_file_offset = f->get_u32();
 
 			// Info Header
-			bmp_header.bmp_info_header.bmp_header_size = f->get_32();
+			bmp_header.bmp_info_header.bmp_header_size = f->get_u32();
 			ERR_FAIL_COND_V_MSG(bmp_header.bmp_info_header.bmp_header_size < BITMAP_INFO_HEADER_MIN_SIZE, ERR_FILE_CORRUPT,
 					vformat("Couldn't parse the BMP info header. The file is likely corrupt: %s", f->get_path()));
 
-			bmp_header.bmp_info_header.bmp_width = f->get_32();
-			bmp_header.bmp_info_header.bmp_height = f->get_32();
+			bmp_header.bmp_info_header.bmp_width = f->get_u32();
+			bmp_header.bmp_info_header.bmp_height = f->get_u32();
 
-			bmp_header.bmp_info_header.bmp_planes = f->get_16();
+			bmp_header.bmp_info_header.bmp_planes = f->get_u16();
 			ERR_FAIL_COND_V_MSG(bmp_header.bmp_info_header.bmp_planes != 1, ERR_FILE_CORRUPT,
 					vformat("Couldn't parse the BMP planes. The file is likely corrupt: %s", f->get_path()));
 
-			bmp_header.bmp_info_header.bmp_bit_count = f->get_16();
-			bmp_header.bmp_info_header.bmp_compression = f->get_32();
-			bmp_header.bmp_info_header.bmp_size_image = f->get_32();
-			bmp_header.bmp_info_header.bmp_pixels_per_meter_x = f->get_32();
-			bmp_header.bmp_info_header.bmp_pixels_per_meter_y = f->get_32();
-			bmp_header.bmp_info_header.bmp_colors_used = f->get_32();
-			bmp_header.bmp_info_header.bmp_important_colors = f->get_32();
+			bmp_header.bmp_info_header.bmp_bit_count = f->get_u16();
+			bmp_header.bmp_info_header.bmp_compression = f->get_u32();
+			bmp_header.bmp_info_header.bmp_size_image = f->get_u32();
+			bmp_header.bmp_info_header.bmp_pixels_per_meter_x = f->get_u32();
+			bmp_header.bmp_info_header.bmp_pixels_per_meter_y = f->get_u32();
+			bmp_header.bmp_info_header.bmp_colors_used = f->get_u32();
+			bmp_header.bmp_info_header.bmp_important_colors = f->get_u32();
 
 			switch (bmp_header.bmp_info_header.bmp_compression) {
 				case BI_BITFIELDS: {
-					bmp_header.bmp_bitfield.red_mask = f->get_32();
-					bmp_header.bmp_bitfield.green_mask = f->get_32();
-					bmp_header.bmp_bitfield.blue_mask = f->get_32();
-					bmp_header.bmp_bitfield.alpha_mask = f->get_32();
+					bmp_header.bmp_bitfield.red_mask = f->get_u32();
+					bmp_header.bmp_bitfield.green_mask = f->get_u32();
+					bmp_header.bmp_bitfield.blue_mask = f->get_u32();
+					bmp_header.bmp_bitfield.alpha_mask = f->get_u32();
 
 					bmp_header.bmp_bitfield.red_mask_width = get_mask_width(bmp_header.bmp_bitfield.red_mask);
 					bmp_header.bmp_bitfield.green_mask_width = get_mask_width(bmp_header.bmp_bitfield.green_mask);

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -561,18 +561,18 @@ Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_orig
 
 	ERR_FAIL_COND_V_MSG(err != OK, Ref<Resource>(), vformat("Unable to open DDS texture file '%s'.", p_path));
 
-	uint32_t magic = f->get_32();
-	uint32_t hsize = f->get_32();
-	uint32_t flags = f->get_32();
-	uint32_t height = f->get_32();
-	uint32_t width = f->get_32();
-	uint32_t pitch = f->get_32();
-	uint32_t depth = f->get_32();
-	uint32_t mipmaps = f->get_32();
+	uint32_t magic = f->get_u32();
+	uint32_t hsize = f->get_u32();
+	uint32_t flags = f->get_u32();
+	uint32_t height = f->get_u32();
+	uint32_t width = f->get_u32();
+	uint32_t pitch = f->get_u32();
+	uint32_t depth = f->get_u32();
+	uint32_t mipmaps = f->get_u32();
 
 	// Skip reserved.
 	for (int i = 0; i < 11; i++) {
-		f->get_32();
+		f->get_u32();
 	}
 
 	// Validate.
@@ -582,22 +582,22 @@ Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_orig
 		ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Invalid or unsupported DDS texture file '%s'.", p_path));
 	}
 
-	/* uint32_t format_size = */ f->get_32();
-	uint32_t format_flags = f->get_32();
-	uint32_t format_fourcc = f->get_32();
-	uint32_t format_rgb_bits = f->get_32();
-	uint32_t format_red_mask = f->get_32();
-	uint32_t format_green_mask = f->get_32();
-	uint32_t format_blue_mask = f->get_32();
-	uint32_t format_alpha_mask = f->get_32();
+	/* uint32_t format_size = */ f->get_u32();
+	uint32_t format_flags = f->get_u32();
+	uint32_t format_fourcc = f->get_u32();
+	uint32_t format_rgb_bits = f->get_u32();
+	uint32_t format_red_mask = f->get_u32();
+	uint32_t format_green_mask = f->get_u32();
+	uint32_t format_blue_mask = f->get_u32();
+	uint32_t format_alpha_mask = f->get_u32();
 
-	/* uint32_t caps_1 = */ f->get_32();
-	uint32_t caps_2 = f->get_32();
-	/* uint32_t caps_3 = */ f->get_32();
-	/* uint32_t caps_4 = */ f->get_32();
+	/* uint32_t caps_1 = */ f->get_u32();
+	uint32_t caps_2 = f->get_u32();
+	/* uint32_t caps_3 = */ f->get_u32();
+	/* uint32_t caps_4 = */ f->get_u32();
 
 	// Skip reserved.
-	f->get_32();
+	f->get_u32();
 
 	if (f->get_position() < 128) {
 		f->seek(128);
@@ -659,11 +659,11 @@ Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_orig
 				dds_format = DDS_RGBA32F;
 			} break;
 			case DDFCC_DX10: {
-				uint32_t dxgi_format = f->get_32();
-				uint32_t dimension = f->get_32();
-				/* uint32_t misc_flags_1 = */ f->get_32();
-				uint32_t array_size = f->get_32();
-				/* uint32_t misc_flags_2 = */ f->get_32();
+				uint32_t dxgi_format = f->get_u32();
+				uint32_t dimension = f->get_u32();
+				/* uint32_t misc_flags_1 = */ f->get_u32();
+				uint32_t array_size = f->get_u32();
+				/* uint32_t misc_flags_2 = */ f->get_u32();
 
 				if (dimension == DX10D_3D) {
 					dds_type = DDST_3D;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -306,12 +306,12 @@ Error GLTFDocument::_parse_glb(Ref<FileAccess> p_file, Ref<GLTFState> p_state) {
 	ERR_FAIL_COND_V(p_file.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_file->get_position() != 0, ERR_FILE_CANT_READ);
-	uint32_t magic = p_file->get_32();
+	uint32_t magic = p_file->get_u32();
 	ERR_FAIL_COND_V(magic != 0x46546C67, ERR_FILE_UNRECOGNIZED); //glTF
-	p_file->get_32(); // version
-	p_file->get_32(); // length
-	uint32_t chunk_length = p_file->get_32();
-	uint32_t chunk_type = p_file->get_32();
+	p_file->get_u32(); // version
+	p_file->get_u32(); // length
+	uint32_t chunk_length = p_file->get_u32();
+	uint32_t chunk_type = p_file->get_u32();
 
 	ERR_FAIL_COND_V(chunk_type != 0x4E4F534A, ERR_PARSE_ERROR); //JSON
 	Vector<uint8_t> json_data;
@@ -333,8 +333,8 @@ Error GLTFDocument::_parse_glb(Ref<FileAccess> p_file, Ref<GLTFState> p_state) {
 
 	//data?
 
-	chunk_length = p_file->get_32();
-	chunk_type = p_file->get_32();
+	chunk_length = p_file->get_u32();
+	chunk_type = p_file->get_u32();
 
 	if (p_file->eof_reached()) {
 		return OK; //all good
@@ -7954,7 +7954,7 @@ Error GLTFDocument::_parse(Ref<GLTFState> p_state, String p_path, Ref<FileAccess
 		return FAILED;
 	}
 	p_file->seek(0);
-	uint32_t magic = p_file->get_32();
+	uint32_t magic = p_file->get_u32();
 	if (magic == 0x46546C67) {
 		//binary file
 		//text file
@@ -8076,29 +8076,29 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 		const uint32_t binary_chunk_type = 0x004E4942; //BIN
 
 		file->create(FileAccess::ACCESS_RESOURCES);
-		file->store_32(magic);
-		file->store_32(p_state->major_version); // version
+		file->store_u32(magic);
+		file->store_u32(p_state->major_version); // version
 		uint32_t total_length = header_size + chunk_header_size + text_chunk_length;
 		if (binary_chunk_length) {
 			total_length += chunk_header_size + binary_chunk_length;
 		}
-		file->store_32(total_length);
+		file->store_u32(total_length);
 
 		// Write the JSON text chunk.
-		file->store_32(text_chunk_length);
-		file->store_32(text_chunk_type);
+		file->store_u32(text_chunk_length);
+		file->store_u32(text_chunk_type);
 		file->store_buffer((uint8_t *)&cs[0], cs.length());
 		for (uint32_t pad_i = text_data_length; pad_i < text_chunk_length; pad_i++) {
-			file->store_8(' ');
+			file->store_u8(' ');
 		}
 
 		// Write a single binary chunk.
 		if (binary_chunk_length) {
-			file->store_32(binary_chunk_length);
-			file->store_32(binary_chunk_type);
+			file->store_u32(binary_chunk_length);
+			file->store_u32(binary_chunk_type);
 			file->store_buffer(p_state->buffers[0].ptr(), binary_data_length);
 			for (uint32_t pad_i = binary_data_length; pad_i < binary_chunk_length; pad_i++) {
-				file->store_8(0);
+				file->store_u8(0);
 			}
 		}
 	} else {

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -82,9 +82,9 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 			// Read RLE-encoded data
 
 			for (int j = 0; j < height; ++j) {
-				int c1 = f->get_8();
-				int c2 = f->get_8();
-				int len = f->get_8();
+				int c1 = f->get_u8();
+				int c2 = f->get_u8();
+				int len = f->get_u8();
 				if (c1 != 2 || c2 != 2 || (len & 0x80)) {
 					// not run-length encoded, so we have to actually use THIS data as a decoded
 					// pixel (note this can't be a valid pixel--one of RGB must be >= 128)
@@ -92,23 +92,23 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 					ptr[(j * width) * 4 + 0] = uint8_t(c1);
 					ptr[(j * width) * 4 + 1] = uint8_t(c2);
 					ptr[(j * width) * 4 + 2] = uint8_t(len);
-					ptr[(j * width) * 4 + 3] = f->get_8();
+					ptr[(j * width) * 4 + 3] = f->get_u8();
 
 					f->get_buffer(&ptr[(j * width + 1) * 4], (width - 1) * 4);
 					continue;
 				}
 				len <<= 8;
-				len |= f->get_8();
+				len |= f->get_u8();
 
 				ERR_FAIL_COND_V_MSG(len != width, ERR_FILE_CORRUPT, "Invalid decoded scanline length, corrupt HDR.");
 
 				for (int k = 0; k < 4; ++k) {
 					int i = 0;
 					while (i < width) {
-						int count = f->get_8();
+						int count = f->get_u8();
 						if (count > 128) {
 							// Run
-							int value = f->get_8();
+							int value = f->get_u8();
 							count -= 128;
 							for (int z = 0; z < count; ++z) {
 								ptr[(j * width + i++) * 4 + k] = uint8_t(value);

--- a/modules/ktx/texture_loader_ktx.cpp
+++ b/modules/ktx/texture_loader_ktx.cpp
@@ -46,7 +46,7 @@ KTX_error_code ktx_read(ktxStream *stream, void *dst, const ktx_size_t count) {
 KTX_error_code ktx_skip(ktxStream *stream, const ktx_size_t count) {
 	Ref<FileAccess> *f = reinterpret_cast<Ref<FileAccess> *>(stream->data.custom_ptr.address);
 	for (ktx_size_t i = 0; i < count; ++i) {
-		(*f)->get_8();
+		(*f)->get_u8();
 	}
 	return KTX_SUCCESS;
 }

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -262,20 +262,20 @@ Error ImageLoaderTGA::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	Error err = OK;
 
 	tga_header_s tga_header;
-	tga_header.id_length = f->get_8();
-	tga_header.color_map_type = f->get_8();
-	tga_header.image_type = static_cast<tga_type_e>(f->get_8());
+	tga_header.id_length = f->get_u8();
+	tga_header.color_map_type = f->get_u8();
+	tga_header.image_type = static_cast<tga_type_e>(f->get_u8());
 
-	tga_header.first_color_entry = f->get_16();
-	tga_header.color_map_length = f->get_16();
-	tga_header.color_map_depth = f->get_8();
+	tga_header.first_color_entry = f->get_u16();
+	tga_header.color_map_length = f->get_u16();
+	tga_header.color_map_depth = f->get_u8();
 
-	tga_header.x_origin = f->get_16();
-	tga_header.y_origin = f->get_16();
-	tga_header.image_width = f->get_16();
-	tga_header.image_height = f->get_16();
-	tga_header.pixel_depth = f->get_8();
-	tga_header.image_descriptor = f->get_8();
+	tga_header.x_origin = f->get_u16();
+	tga_header.y_origin = f->get_u16();
+	tga_header.image_width = f->get_u16();
+	tga_header.image_height = f->get_u16();
+	tga_header.pixel_depth = f->get_u8();
+	tga_header.image_descriptor = f->get_u8();
 
 	bool is_encoded = (tga_header.image_type == TGA_TYPE_RLE_INDEXED || tga_header.image_type == TGA_TYPE_RLE_RGB || tga_header.image_type == TGA_TYPE_RLE_MONOCHROME);
 	bool has_color_map = (tga_header.image_type == TGA_TYPE_RLE_INDEXED || tga_header.image_type == TGA_TYPE_INDEXED);

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -1309,12 +1309,12 @@ bool EditorExportPlatformIOS::_archive_has_arm64(const String &p_path, uint32_t 
 						}
 
 						// Read file content.
-						uint32_t obj_magic = sim_f->get_32();
+						uint32_t obj_magic = sim_f->get_u32();
 
 						bool swap = (obj_magic == 0xcffaedfe || obj_magic == 0xcefaedfe);
 						if (obj_magic == 0xcefaedfe || obj_magic == 0xfeedface || obj_magic == 0xcffaedfe || obj_magic == 0xfeedfacf) {
-							uint32_t cputype = sim_f->get_32();
-							uint32_t cpusubtype = sim_f->get_32();
+							uint32_t cputype = sim_f->get_u32();
+							uint32_t cpusubtype = sim_f->get_u32();
 							if (swap) {
 								cputype = BSWAP32(cputype);
 								cpusubtype = BSWAP32(cpusubtype);
@@ -1369,18 +1369,18 @@ int EditorExportPlatformIOS::_archive_convert_to_simulator(const String &p_path)
 				}
 
 				// Read file content.
-				uint32_t obj_magic = sim_f->get_32();
+				uint32_t obj_magic = sim_f->get_u32();
 
 				bool swap = (obj_magic == 0xcffaedfe || obj_magic == 0xcefaedfe);
 				if (obj_magic == 0xcefaedfe || obj_magic == 0xfeedface || obj_magic == 0xcffaedfe || obj_magic == 0xfeedfacf) {
-					uint32_t cputype = sim_f->get_32();
-					uint32_t cpusubtype = sim_f->get_32();
-					uint32_t filetype = sim_f->get_32();
-					uint32_t ncmds = sim_f->get_32();
-					sim_f->get_32(); // Commands total size.
-					sim_f->get_32(); // Commands flags.
+					uint32_t cputype = sim_f->get_u32();
+					uint32_t cpusubtype = sim_f->get_u32();
+					uint32_t filetype = sim_f->get_u32();
+					uint32_t ncmds = sim_f->get_u32();
+					sim_f->get_u32(); // Commands total size.
+					sim_f->get_u32(); // Commands flags.
 					if (obj_magic == 0xcffaedfe || obj_magic == 0xfeedfacf) {
-						sim_f->get_32(); // Reserved, 64-bit only.
+						sim_f->get_u32(); // Reserved, 64-bit only.
 					}
 					if (swap) {
 						ncmds = BSWAP32(ncmds);
@@ -1392,14 +1392,14 @@ int EditorExportPlatformIOS::_archive_convert_to_simulator(const String &p_path)
 						// ARM64, object file.
 						for (uint32_t i = 0; i < ncmds; i++) {
 							int64_t cmdofs = sim_f->get_position();
-							uint32_t cmdid = sim_f->get_32();
-							uint32_t cmdsize = sim_f->get_32();
+							uint32_t cmdid = sim_f->get_u32();
+							uint32_t cmdsize = sim_f->get_u32();
 							if (swap) {
 								cmdid = BSWAP32(cmdid);
 								cmdsize = BSWAP32(cmdsize);
 							}
 							if (cmdid == MachO::LoadCommandID::LC_BUILD_VERSION) {
-								int64_t platform = sim_f->get_32();
+								int64_t platform = sim_f->get_u32();
 								if (swap) {
 									platform = BSWAP32(platform);
 								}
@@ -1409,7 +1409,7 @@ int EditorExportPlatformIOS::_archive_convert_to_simulator(const String &p_path)
 									if (swap) {
 										new_id = BSWAP32(new_id);
 									}
-									sim_f->store_32(new_id);
+									sim_f->store_u32(new_id);
 									commands_patched++;
 								}
 							}

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -574,14 +574,14 @@ uint64_t OS_LinuxBSD::get_embedded_pck_offset() const {
 
 	// Read and check ELF magic number.
 	{
-		uint32_t magic = f->get_32();
+		uint32_t magic = f->get_u32();
 		if (magic != 0x464c457f) { // 0x7F + "ELF"
 			return 0;
 		}
 	}
 
 	// Read program architecture bits from class field.
-	int bits = f->get_8() * 32;
+	int bits = f->get_u8() * 32;
 
 	// Get info about the section header table.
 	int64_t section_table_pos;
@@ -589,16 +589,16 @@ uint64_t OS_LinuxBSD::get_embedded_pck_offset() const {
 	if (bits == 32) {
 		section_header_size = 40;
 		f->seek(0x20);
-		section_table_pos = f->get_32();
+		section_table_pos = f->get_u32();
 		f->seek(0x30);
 	} else { // 64
 		section_header_size = 64;
 		f->seek(0x28);
-		section_table_pos = f->get_64();
+		section_table_pos = f->get_u64();
 		f->seek(0x3c);
 	}
-	int num_sections = f->get_16();
-	int string_section_idx = f->get_16();
+	int num_sections = f->get_u16();
+	int string_section_idx = f->get_u16();
 
 	// Load the strings table.
 	uint8_t *strings;
@@ -611,12 +611,12 @@ uint64_t OS_LinuxBSD::get_embedded_pck_offset() const {
 		int64_t string_data_size;
 		if (bits == 32) {
 			f->seek(f->get_position() + 0x10);
-			string_data_pos = f->get_32();
-			string_data_size = f->get_32();
+			string_data_pos = f->get_u32();
+			string_data_size = f->get_u32();
 		} else { // 64
 			f->seek(f->get_position() + 0x18);
-			string_data_pos = f->get_64();
-			string_data_size = f->get_64();
+			string_data_pos = f->get_u64();
+			string_data_size = f->get_u64();
 		}
 
 		// Read strings data.
@@ -634,14 +634,14 @@ uint64_t OS_LinuxBSD::get_embedded_pck_offset() const {
 		int64_t section_header_pos = section_table_pos + i * section_header_size;
 		f->seek(section_header_pos);
 
-		uint32_t name_offset = f->get_32();
+		uint32_t name_offset = f->get_u32();
 		if (strcmp((char *)strings + name_offset, "pck") == 0) {
 			if (bits == 32) {
 				f->seek(section_header_pos + 0x10);
-				off = f->get_32();
+				off = f->get_u32();
 			} else { // 64
 				f->seek(section_header_pos + 0x18);
-				off = f->get_64();
+				off = f->get_u64();
 			}
 			break;
 		}

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1477,7 +1477,7 @@ Error EditorExportPlatformMacOS::_create_dmg(const String &p_dmg_path, const Str
 bool EditorExportPlatformMacOS::is_shebang(const String &p_path) const {
 	Ref<FileAccess> fb = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(fb.is_null(), false, vformat("Can't open file: \"%s\".", p_path));
-	uint16_t magic = fb->get_16();
+	uint16_t magic = fb->get_u16();
 	return (magic == 0x2123);
 }
 

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -103,10 +103,10 @@ int64_t get_image_base(const String &p_path) {
 	}
 	{
 		f->seek(0x3c);
-		uint32_t pe_pos = f->get_32();
+		uint32_t pe_pos = f->get_u32();
 
 		f->seek(pe_pos);
-		uint32_t magic = f->get_32();
+		uint32_t magic = f->get_u32();
 		if (magic != 0x00004550) {
 			return 0;
 		}
@@ -114,13 +114,13 @@ int64_t get_image_base(const String &p_path) {
 	int64_t opt_header_pos = f->get_position() + 0x14;
 	f->seek(opt_header_pos);
 
-	uint16_t opt_header_magic = f->get_16();
+	uint16_t opt_header_magic = f->get_u16();
 	if (opt_header_magic == 0x10B) {
 		f->seek(opt_header_pos + 0x1C);
-		return f->get_32();
+		return f->get_u32();
 	} else if (opt_header_magic == 0x20B) {
 		f->seek(opt_header_pos + 0x18);
-		return f->get_64();
+		return f->get_u64();
 	} else {
 		return 0;
 	}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3327,17 +3327,17 @@ void DisplayServerWindows::set_native_icon(const String &p_filename) {
 	ICONDIR *icon_dir = (ICONDIR *)memalloc(sizeof(ICONDIR));
 	int pos = 0;
 
-	icon_dir->idReserved = f->get_32();
+	icon_dir->idReserved = f->get_u32();
 	pos += sizeof(WORD);
 	f->seek(pos);
 
-	icon_dir->idType = f->get_32();
+	icon_dir->idType = f->get_u32();
 	pos += sizeof(WORD);
 	f->seek(pos);
 
 	ERR_FAIL_COND_MSG(icon_dir->idType != 1, "Invalid icon file format!");
 
-	icon_dir->idCount = f->get_32();
+	icon_dir->idCount = f->get_u32();
 	pos += sizeof(WORD);
 	f->seek(pos);
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2017,10 +2017,10 @@ uint64_t OS_Windows::get_embedded_pck_offset() const {
 	// Process header.
 	{
 		f->seek(0x3c);
-		uint32_t pe_pos = f->get_32();
+		uint32_t pe_pos = f->get_u32();
 
 		f->seek(pe_pos);
-		uint32_t magic = f->get_32();
+		uint32_t magic = f->get_u32();
 		if (magic != 0x00004550) {
 			return 0;
 		}
@@ -2031,9 +2031,9 @@ uint64_t OS_Windows::get_embedded_pck_offset() const {
 		int64_t header_pos = f->get_position();
 
 		f->seek(header_pos + 2);
-		num_sections = f->get_16();
+		num_sections = f->get_u16();
 		f->seek(header_pos + 16);
-		uint16_t opt_header_size = f->get_16();
+		uint16_t opt_header_size = f->get_u16();
 
 		// Skip rest of header + optional header to go to the section headers.
 		f->seek(f->get_position() + 2 + opt_header_size);
@@ -2052,7 +2052,7 @@ uint64_t OS_Windows::get_embedded_pck_offset() const {
 
 		if (strcmp((char *)section_name, "pck") == 0) {
 			f->seek(section_header_pos + 20);
-			off = f->get_32();
+			off = f->get_u32();
 			break;
 		}
 	}

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -229,7 +229,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 		file->store_buffer(u8);
 
 		// Terminate string and fill the remaining part of the original string with the '\0'.
-		// Can be replaced by file->store_8('\0');
+		// Can be replaced by file->store_u8('\0');
 		Vector<uint8_t> padding_buffer;
 		padding_buffer.resize((int64_t)original_path_size - u8.size());
 		padding_buffer.fill('\0');

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -46,21 +46,21 @@ Error CompressedTexture2D::_load_data(const String &p_path, int &r_width, int &r
 		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Compressed texture file is corrupt (Bad header).");
 	}
 
-	uint32_t version = f->get_32();
+	uint32_t version = f->get_u32();
 
 	if (version > FORMAT_VERSION) {
 		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Compressed texture file is too new.");
 	}
-	r_width = f->get_32();
-	r_height = f->get_32();
-	uint32_t df = f->get_32(); //data format
+	r_width = f->get_u32();
+	r_height = f->get_u32();
+	uint32_t df = f->get_u32(); //data format
 
 	//skip reserved
-	mipmap_limit = int(f->get_32());
+	mipmap_limit = int(f->get_u32());
 	//reserved
-	f->get_32();
-	f->get_32();
-	f->get_32();
+	f->get_u32();
+	f->get_u32();
+	f->get_u32();
 
 #ifdef TOOLS_ENABLED
 
@@ -297,11 +297,11 @@ void CompressedTexture2D::_validate_property(PropertyInfo &p_property) const {
 }
 
 Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_size_limit) {
-	uint32_t data_format = f->get_32();
-	uint32_t w = f->get_16();
-	uint32_t h = f->get_16();
-	uint32_t mipmaps = f->get_32();
-	Image::Format format = Image::Format(f->get_32());
+	uint32_t data_format = f->get_u32();
+	uint32_t w = f->get_u16();
+	uint32_t h = f->get_u16();
+	uint32_t mipmaps = f->get_u32();
+	Image::Format format = Image::Format(f->get_u32());
 
 	if (data_format == DATA_FORMAT_PNG || data_format == DATA_FORMAT_WEBP) {
 		//look for a PNG or WebP file inside
@@ -316,7 +316,7 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 		bool first = true;
 
 		for (uint32_t i = 0; i < mipmaps + 1; i++) {
-			uint32_t size = f->get_32();
+			uint32_t size = f->get_u32();
 
 			if (p_size_limit > 0 && i < (mipmaps - 1) && (sw > p_size_limit || sh > p_size_limit)) {
 				//can't load this due to size limit
@@ -396,7 +396,7 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 	} else if (data_format == DATA_FORMAT_BASIS_UNIVERSAL) {
 		int sw = w;
 		int sh = h;
-		uint32_t size = f->get_32();
+		uint32_t size = f->get_u32();
 		if (p_size_limit > 0 && (sw > p_size_limit || sh > p_size_limit)) {
 			//can't load this due to size limit
 			sw = MAX(sw >> 1, 1);
@@ -516,20 +516,20 @@ Error CompressedTexture3D::_load_data(const String &p_path, Vector<Ref<Image>> &
 	ERR_FAIL_COND_V(header[0] != 'G' || header[1] != 'S' || header[2] != 'T' || header[3] != 'L', ERR_FILE_UNRECOGNIZED);
 
 	//stored as compressed textures (used for lossless and lossy compression)
-	uint32_t version = f->get_32();
+	uint32_t version = f->get_u32();
 
 	if (version > FORMAT_VERSION) {
 		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Compressed texture file is too new.");
 	}
 
-	r_depth = f->get_32(); //depth
-	f->get_32(); //ignored (mode)
-	f->get_32(); // ignored (data format)
+	r_depth = f->get_u32(); //depth
+	f->get_u32(); //ignored (mode)
+	f->get_u32(); // ignored (data format)
 
-	f->get_32(); //ignored
-	int mipmap_count = f->get_32();
-	f->get_32(); //ignored
-	f->get_32(); //ignored
+	f->get_u32(); //ignored
+	int mipmap_count = f->get_u32();
+	f->get_u32(); //ignored
+	f->get_u32(); //ignored
 
 	r_mipmaps = mipmap_count != 0;
 
@@ -708,22 +708,22 @@ Error CompressedTextureLayered::_load_data(const String &p_path, Vector<Ref<Imag
 		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Compressed texture layered file is corrupt (Bad header).");
 	}
 
-	uint32_t version = f->get_32();
+	uint32_t version = f->get_u32();
 
 	if (version > FORMAT_VERSION) {
 		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Compressed texture file is too new.");
 	}
 
-	uint32_t layer_count = f->get_32(); //layer count
-	uint32_t type = f->get_32(); //layer count
+	uint32_t layer_count = f->get_u32(); //layer count
+	uint32_t type = f->get_u32(); //layer count
 	ERR_FAIL_COND_V((int)type != layered_type, ERR_INVALID_DATA);
 
-	uint32_t df = f->get_32(); //data format
-	mipmap_limit = int(f->get_32());
+	uint32_t df = f->get_u32(); //data format
+	mipmap_limit = int(f->get_u32());
 	//reserved
-	f->get_32();
-	f->get_32();
-	f->get_32();
+	f->get_u32();
+	f->get_u32();
+	f->get_u32();
 
 	if (!(df & FORMAT_BIT_STREAM)) {
 		p_size_limit = 0;

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1480,8 +1480,8 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 		// Binary BMFont file.
 		ERR_FAIL_COND_V_MSG(magic[3] != 3, ERR_CANT_CREATE, vformat("Version %d of BMFont is not supported (should be 3).", (int)magic[3]));
 
-		uint8_t block_type = f->get_8();
-		uint32_t block_size = f->get_32();
+		uint8_t block_type = f->get_u8();
+		uint32_t block_size = f->get_u32();
 		bool unicode = false;
 		uint8_t encoding = 9;
 		while (!f->eof_reached()) {
@@ -1489,11 +1489,11 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 			switch (block_type) {
 				case 1: /* info */ {
 					ERR_FAIL_COND_V_MSG(block_size < 15, ERR_CANT_CREATE, "Invalid BMFont info block size.");
-					base_size = ABS(static_cast<int16_t>(f->get_16()));
+					base_size = ABS(static_cast<int16_t>(f->get_u16()));
 					if (base_size == 0) {
 						base_size = 16;
 					}
-					uint8_t flags = f->get_8();
+					uint8_t flags = f->get_u8();
 					if (flags & (1 << 3)) {
 						st_flags.set_flag(TextServer::FONT_BOLD);
 					}
@@ -1501,7 +1501,7 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 						st_flags.set_flag(TextServer::FONT_ITALIC);
 					}
 					unicode = (flags & 0x02);
-					uint8_t encoding_id = f->get_8(); // non-unicode charset
+					uint8_t encoding_id = f->get_u8(); // non-unicode charset
 					if (!unicode) {
 						switch (encoding_id) {
 							case 0x00: {
@@ -1536,11 +1536,11 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 							} break;
 						};
 					}
-					f->get_16(); // stretch_h, skip
-					f->get_8(); // aa, skip
-					f->get_32(); // padding, skip
-					f->get_16(); // spacing, skip
-					outline = f->get_8();
+					f->get_u16(); // stretch_h, skip
+					f->get_u8(); // aa, skip
+					f->get_u32(); // padding, skip
+					f->get_u16(); // spacing, skip
+					outline = f->get_u8();
 					// font name
 					PackedByteArray name_data;
 					name_data.resize(block_size - 14);
@@ -1550,16 +1550,16 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 				} break;
 				case 2: /* common */ {
 					ERR_FAIL_COND_V_MSG(block_size != 15, ERR_CANT_CREATE, "Invalid BMFont common block size.");
-					height = f->get_16();
-					ascent = f->get_16();
-					f->get_32(); // scale, skip
-					f->get_16(); // pages, skip
-					uint8_t flags = f->get_8();
+					height = f->get_u16();
+					ascent = f->get_u16();
+					f->get_u32(); // scale, skip
+					f->get_u16(); // pages, skip
+					uint8_t flags = f->get_u8();
 					packed = (flags & 0x01);
-					ch[3] = f->get_8();
-					ch[0] = f->get_8();
-					ch[1] = f->get_8();
-					ch[2] = f->get_8();
+					ch[3] = f->get_u8();
+					ch[0] = f->get_u8();
+					ch[1] = f->get_u8();
+					ch[2] = f->get_u8();
 					for (int i = 0; i < 4; i++) {
 						if (ch[i] == 0 && first_gl_ch == -1) {
 							first_gl_ch = i;
@@ -1578,7 +1578,7 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 				case 3: /* pages */ {
 					int page = 0;
 					CharString cs;
-					char32_t c = f->get_8();
+					char32_t c = f->get_u8();
 					while (!f->eof_reached() && f->get_position() <= off + block_size) {
 						if (c == '\0') {
 							String base_dir = p_path.get_base_dir();
@@ -1632,7 +1632,7 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 						} else {
 							cs += c;
 						}
-						c = f->get_8();
+						c = f->get_u8();
 					}
 				} break;
 				case 4: /* chars */ {
@@ -1643,7 +1643,7 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 						Vector2 offset;
 						Rect2 uv_rect;
 
-						char32_t idx = f->get_32();
+						char32_t idx = f->get_u32();
 						if (!unicode && encoding < 9) {
 							if (idx >= 0x80 && idx <= 0xFF) {
 								idx = _oem_to_unicode[encoding][idx - 0x80];
@@ -1652,21 +1652,21 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 								idx = 0x00;
 							}
 						}
-						uv_rect.position.x = (int16_t)f->get_16();
-						uv_rect.position.y = (int16_t)f->get_16();
-						uv_rect.size.width = (int16_t)f->get_16();
+						uv_rect.position.x = (int16_t)f->get_u16();
+						uv_rect.position.y = (int16_t)f->get_u16();
+						uv_rect.size.width = (int16_t)f->get_u16();
 						size.width = uv_rect.size.width;
-						uv_rect.size.height = (int16_t)f->get_16();
+						uv_rect.size.height = (int16_t)f->get_u16();
 						size.height = uv_rect.size.height;
-						offset.x = (int16_t)f->get_16();
-						offset.y = (int16_t)f->get_16() - ascent;
-						advance.x = (int16_t)f->get_16();
+						offset.x = (int16_t)f->get_u16();
+						offset.y = (int16_t)f->get_u16() - ascent;
+						advance.x = (int16_t)f->get_u16();
 						if (advance.x < 0) {
 							advance.x = size.width + 1;
 						}
 
-						int texture_idx = f->get_8();
-						uint8_t channel = f->get_8();
+						int texture_idx = f->get_u8();
+						uint8_t channel = f->get_u8();
 
 						int ch_off = 0;
 						if (packed) {
@@ -1705,8 +1705,8 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 					int pair_count = block_size / 10;
 					for (int i = 0; i < pair_count; i++) {
 						Vector2i kpk;
-						kpk.x = f->get_32();
-						kpk.y = f->get_32();
+						kpk.x = f->get_u32();
+						kpk.y = f->get_u32();
 						if (!unicode && encoding < 9) {
 							if (kpk.x >= 0x80 && kpk.x <= 0xFF) {
 								kpk.x = _oem_to_unicode[encoding][kpk.x - 0x80];
@@ -1721,7 +1721,7 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 								kpk.y = 0x00;
 							}
 						}
-						set_kerning(0, base_size, kpk, Vector2((int16_t)f->get_16(), 0));
+						set_kerning(0, base_size, kpk, Vector2((int16_t)f->get_u16(), 0));
 					}
 				} break;
 				default: {
@@ -1729,8 +1729,8 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 				} break;
 			}
 			f->seek(off + block_size);
-			block_type = f->get_8();
-			block_size = f->get_32();
+			block_type = f->get_u8();
+			block_size = f->get_u32();
 		}
 
 	} else {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -2105,10 +2105,10 @@ Error ResourceLoaderText::set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid) {
 		fw->store_string("[gd_resource type=\"" + res_type + "\" " + script_res_text + "load_steps=" + itos(resources_total) + " format=" + itos(format_version) + " uid=\"" + ResourceUID::get_singleton()->id_to_text(p_uid) + "\"]");
 	}
 
-	uint8_t c = f->get_8();
+	uint8_t c = f->get_u8();
 	while (!f->eof_reached()) {
-		fw->store_8(c);
-		c = f->get_8();
+		fw->store_u8(c);
+		c = f->get_u8();
 	}
 
 	bool all_ok = fw->get_error() == OK;

--- a/servers/movie_writer/movie_writer_mjpeg.cpp
+++ b/servers/movie_writer/movie_writer_mjpeg.cpp
@@ -63,73 +63,73 @@ Error MovieWriterMJPEG::write_begin(const Size2i &p_movie_size, uint32_t p_fps, 
 	ERR_FAIL_COND_V(f.is_null(), ERR_CANT_OPEN);
 
 	f->store_buffer((const uint8_t *)"RIFF", 4);
-	f->store_32(0); // Total length (update later)
+	f->store_u32(0); // Total length (update later)
 	f->store_buffer((const uint8_t *)"AVI ", 4);
 	f->store_buffer((const uint8_t *)"LIST", 4);
-	f->store_32(300); // 4 + 4 + 4 + 56 + 4 + 4 + 132 + 4 + 4 + 84
+	f->store_u32(300); // 4 + 4 + 4 + 56 + 4 + 4 + 132 + 4 + 4 + 84
 	f->store_buffer((const uint8_t *)"hdrl", 4);
 	f->store_buffer((const uint8_t *)"avih", 4);
-	f->store_32(56);
+	f->store_u32(56);
 
-	f->store_32(1000000 / p_fps); // Microsecs per frame.
-	f->store_32(7000); // Max bytes per second
-	f->store_32(0); // Padding Granularity
-	f->store_32(16);
+	f->store_u32(1000000 / p_fps); // Microsecs per frame.
+	f->store_u32(7000); // Max bytes per second
+	f->store_u32(0); // Padding Granularity
+	f->store_u32(16);
 	total_frames_ofs = f->get_position();
-	f->store_32(0); // Total frames (update later)
-	f->store_32(0); // Initial frames
-	f->store_32(1); // Streams
-	f->store_32(0); // Suggested buffer size
-	f->store_32(p_movie_size.width); // Movie Width
-	f->store_32(p_movie_size.height); // Movie Height
+	f->store_u32(0); // Total frames (update later)
+	f->store_u32(0); // Initial frames
+	f->store_u32(1); // Streams
+	f->store_u32(0); // Suggested buffer size
+	f->store_u32(p_movie_size.width); // Movie Width
+	f->store_u32(p_movie_size.height); // Movie Height
 	for (uint32_t i = 0; i < 4; i++) {
-		f->store_32(0); // Reserved.
+		f->store_u32(0); // Reserved.
 	}
 	f->store_buffer((const uint8_t *)"LIST", 4);
-	f->store_32(132); // 4 + 4 + 4 + 48 + 4 + 4 + 40 + 4 + 4 + 16
+	f->store_u32(132); // 4 + 4 + 4 + 48 + 4 + 4 + 40 + 4 + 4 + 16
 	f->store_buffer((const uint8_t *)"strl", 4);
 	f->store_buffer((const uint8_t *)"strh", 4);
-	f->store_32(48);
+	f->store_u32(48);
 	f->store_buffer((const uint8_t *)"vids", 4);
 	f->store_buffer((const uint8_t *)"MJPG", 4);
-	f->store_32(0); // Flags
-	f->store_16(0); // Priority
-	f->store_16(0); // Language
-	f->store_32(0); // Initial Frames
-	f->store_32(1); // Scale
-	f->store_32(p_fps); // FPS
-	f->store_32(0); // Start
+	f->store_u32(0); // Flags
+	f->store_u16(0); // Priority
+	f->store_u16(0); // Language
+	f->store_u32(0); // Initial Frames
+	f->store_u32(1); // Scale
+	f->store_u32(p_fps); // FPS
+	f->store_u32(0); // Start
 	total_frames_ofs2 = f->get_position();
-	f->store_32(0); // Number of frames (to be updated later)
-	f->store_32(0); // Suggested Buffer Size
-	f->store_32(0); // Quality
-	f->store_32(0); // Sample Size
+	f->store_u32(0); // Number of frames (to be updated later)
+	f->store_u32(0); // Suggested Buffer Size
+	f->store_u32(0); // Quality
+	f->store_u32(0); // Sample Size
 
 	f->store_buffer((const uint8_t *)"strf", 4);
-	f->store_32(40); // Size.
-	f->store_32(40); // Size.
+	f->store_u32(40); // Size.
+	f->store_u32(40); // Size.
 
-	f->store_32(p_movie_size.width); // Width
-	f->store_32(p_movie_size.height); // Width
-	f->store_16(1); // Planes
-	f->store_16(24); // Bitcount
+	f->store_u32(p_movie_size.width); // Width
+	f->store_u32(p_movie_size.height); // Width
+	f->store_u16(1); // Planes
+	f->store_u16(24); // Bitcount
 	f->store_buffer((const uint8_t *)"MJPG", 4); // Compression
 
-	f->store_32(((p_movie_size.width * 24 / 8 + 3) & 0xFFFFFFFC) * p_movie_size.height); // SizeImage
-	f->store_32(0); // XPelsXMeter
-	f->store_32(0); // YPelsXMeter
-	f->store_32(0); // ClrUsed
-	f->store_32(0); // ClrImportant
+	f->store_u32(((p_movie_size.width * 24 / 8 + 3) & 0xFFFFFFFC) * p_movie_size.height); // SizeImage
+	f->store_u32(0); // XPelsXMeter
+	f->store_u32(0); // YPelsXMeter
+	f->store_u32(0); // ClrUsed
+	f->store_u32(0); // ClrImportant
 
 	f->store_buffer((const uint8_t *)"LIST", 4);
-	f->store_32(16);
+	f->store_u32(16);
 
 	f->store_buffer((const uint8_t *)"odml", 4);
 	f->store_buffer((const uint8_t *)"dmlh", 4);
-	f->store_32(4); // sizes
+	f->store_u32(4); // sizes
 
 	total_frames_ofs3 = f->get_position();
-	f->store_32(0); // Number of frames (to be updated later)
+	f->store_u32(0); // Number of frames (to be updated later)
 
 	// Audio //
 
@@ -152,39 +152,39 @@ Error MovieWriterMJPEG::write_begin(const Size2i &p_movie_size, uint32_t p_fps, 
 	uint32_t blockalign = bit_depth / 8 * channels;
 
 	f->store_buffer((const uint8_t *)"LIST", 4);
-	f->store_32(84); // 4 + 4 + 4 + 48 + 4 + 4 + 16
+	f->store_u32(84); // 4 + 4 + 4 + 48 + 4 + 4 + 16
 	f->store_buffer((const uint8_t *)"strl", 4);
 	f->store_buffer((const uint8_t *)"strh", 4);
-	f->store_32(48);
+	f->store_u32(48);
 	f->store_buffer((const uint8_t *)"auds", 4);
-	f->store_32(0); // Handler
-	f->store_32(0); // Flags
-	f->store_16(0); // Priority
-	f->store_16(0); // Language
-	f->store_32(0); // Initial Frames
-	f->store_32(blockalign); // Scale
-	f->store_32(mix_rate * blockalign); // mix rate
-	f->store_32(0); // Start
+	f->store_u32(0); // Handler
+	f->store_u32(0); // Flags
+	f->store_u16(0); // Priority
+	f->store_u16(0); // Language
+	f->store_u32(0); // Initial Frames
+	f->store_u32(blockalign); // Scale
+	f->store_u32(mix_rate * blockalign); // mix rate
+	f->store_u32(0); // Start
 	total_audio_frames_ofs4 = f->get_position();
-	f->store_32(0); // Number of frames (to be updated later)
-	f->store_32(12288); // Suggested Buffer Size
-	f->store_32(0xFFFFFFFF); // Quality
-	f->store_32(blockalign); // Block Align to 32 bits
+	f->store_u32(0); // Number of frames (to be updated later)
+	f->store_u32(12288); // Suggested Buffer Size
+	f->store_u32(0xFFFFFFFF); // Quality
+	f->store_u32(blockalign); // Block Align to 32 bits
 
 	audio_block_size = (mix_rate / fps) * blockalign;
 
 	f->store_buffer((const uint8_t *)"strf", 4);
-	f->store_32(16); // Standard format, no extra fields
-	f->store_16(1); // Compression code, standard PCM
-	f->store_16(channels);
-	f->store_32(mix_rate); // Samples (frames) / Sec
-	f->store_32(mix_rate * blockalign); // Bytes / sec
-	f->store_16(blockalign); // Bytes / sec
-	f->store_16(bit_depth); // Bytes / sec
+	f->store_u32(16); // Standard format, no extra fields
+	f->store_u16(1); // Compression code, standard PCM
+	f->store_u16(channels);
+	f->store_u32(mix_rate); // Samples (frames) / Sec
+	f->store_u32(mix_rate * blockalign); // Bytes / sec
+	f->store_u16(blockalign); // Bytes / sec
+	f->store_u16(bit_depth); // Bytes / sec
 
 	f->store_buffer((const uint8_t *)"LIST", 4);
 	movi_data_ofs = f->get_position();
-	f->store_32(0); // Number of frames (to be updated later)
+	f->store_u32(0); // Number of frames (to be updated later)
 	f->store_buffer((const uint8_t *)"movi", 4);
 
 	return OK;
@@ -197,16 +197,16 @@ Error MovieWriterMJPEG::write_frame(const Ref<Image> &p_image, const int32_t *p_
 	uint32_t s = jpg_buffer.size();
 
 	f->store_buffer((const uint8_t *)"00db", 4); // Stream 0, Video
-	f->store_32(jpg_buffer.size()); // sizes
+	f->store_u32(jpg_buffer.size()); // sizes
 	f->store_buffer(jpg_buffer.ptr(), jpg_buffer.size());
 	if (jpg_buffer.size() & 1) {
-		f->store_8(0);
+		f->store_u8(0);
 		s++;
 	}
 	jpg_frame_sizes.push_back(s);
 
 	f->store_buffer((const uint8_t *)"01wb", 4); // Stream 1, Audio.
-	f->store_32(audio_block_size);
+	f->store_u32(audio_block_size);
 	f->store_buffer((const uint8_t *)p_audio_data, audio_block_size);
 
 	frame_count++;
@@ -218,21 +218,21 @@ void MovieWriterMJPEG::write_end() {
 	if (f.is_valid()) {
 		// Finalize the file (frame indices)
 		f->store_buffer((const uint8_t *)"idx1", 4);
-		f->store_32(8 * 4 * frame_count);
+		f->store_u32(8 * 4 * frame_count);
 		uint32_t ofs = 4;
 		uint32_t all_data_size = 0;
 		for (uint32_t i = 0; i < frame_count; i++) {
 			f->store_buffer((const uint8_t *)"00db", 4);
-			f->store_32(16); // AVI_KEYFRAME
-			f->store_32(ofs);
-			f->store_32(jpg_frame_sizes[i]);
+			f->store_u32(16); // AVI_KEYFRAME
+			f->store_u32(ofs);
+			f->store_u32(jpg_frame_sizes[i]);
 
 			ofs += jpg_frame_sizes[i] + 8;
 
 			f->store_buffer((const uint8_t *)"01wb", 4);
-			f->store_32(16); // AVI_KEYFRAME
-			f->store_32(ofs);
-			f->store_32(audio_block_size);
+			f->store_u32(16); // AVI_KEYFRAME
+			f->store_u32(ofs);
+			f->store_u32(audio_block_size);
 
 			ofs += audio_block_size + 8;
 			all_data_size += jpg_frame_sizes[i] + audio_block_size;
@@ -240,17 +240,17 @@ void MovieWriterMJPEG::write_end() {
 
 		uint32_t file_size = f->get_position();
 		f->seek(4);
-		f->store_32(file_size - 78);
+		f->store_u32(file_size - 78);
 		f->seek(total_frames_ofs);
-		f->store_32(frame_count);
+		f->store_u32(frame_count);
 		f->seek(total_frames_ofs2);
-		f->store_32(frame_count);
+		f->store_u32(frame_count);
 		f->seek(total_frames_ofs3);
-		f->store_32(frame_count);
+		f->store_u32(frame_count);
 		f->seek(total_audio_frames_ofs4);
-		f->store_32(frame_count * mix_rate / fps);
+		f->store_u32(frame_count * mix_rate / fps);
 		f->seek(movi_data_ofs);
-		f->store_32(all_data_size + 4 + 16 * frame_count);
+		f->store_u32(all_data_size + 4 + 16 * frame_count);
 
 		f.unref();
 	}

--- a/servers/movie_writer/movie_writer_pngwav.cpp
+++ b/servers/movie_writer/movie_writer_pngwav.cpp
@@ -88,7 +88,7 @@ Error MovieWriterPNGWAV::write_begin(const Size2i &p_movie_size, uint32_t p_fps,
 
 	f_wav->store_buffer((const uint8_t *)"RIFF", 4);
 	int total_size = 4 /* WAVE */ + 8 /* fmt+size */ + 16 /* format */ + 8 /* data+size */;
-	f_wav->store_32(total_size); //will store final later
+	f_wav->store_u32(total_size); //will store final later
 	f_wav->store_buffer((const uint8_t *)"WAVE", 4);
 
 	/* FORMAT CHUNK */
@@ -111,11 +111,11 @@ Error MovieWriterPNGWAV::write_begin(const Size2i &p_movie_size, uint32_t p_fps,
 			break;
 	}
 
-	f_wav->store_32(16); //standard format, no extra fields
-	f_wav->store_16(1); // compression code, standard PCM
-	f_wav->store_16(channels); //CHANNELS: 2
+	f_wav->store_u32(16); //standard format, no extra fields
+	f_wav->store_u16(1); // compression code, standard PCM
+	f_wav->store_u16(channels); //CHANNELS: 2
 
-	f_wav->store_32(mix_rate);
+	f_wav->store_u32(mix_rate);
 
 	/* useless stuff the format asks for */
 
@@ -125,15 +125,15 @@ Error MovieWriterPNGWAV::write_begin(const Size2i &p_movie_size, uint32_t p_fps,
 
 	audio_block_size = (mix_rate / fps) * blockalign;
 
-	f_wav->store_32(bytes_per_sec);
-	f_wav->store_16(blockalign); // block align (unused)
-	f_wav->store_16(bits_per_sample);
+	f_wav->store_u32(bytes_per_sec);
+	f_wav->store_u16(blockalign); // block align (unused)
+	f_wav->store_u16(bits_per_sample);
 
 	/* DATA CHUNK */
 
 	f_wav->store_buffer((const uint8_t *)"data", 4);
 
-	f_wav->store_32(0); //data size... wooh
+	f_wav->store_u32(0); //data size... wooh
 	wav_data_size_pos = f_wav->get_position();
 
 	return OK;
@@ -158,9 +158,9 @@ void MovieWriterPNGWAV::write_end() {
 		uint32_t total_size = 4 /* WAVE */ + 8 /* fmt+size */ + 16 /* format */ + 8 /* data+size */;
 		uint32_t datasize = f_wav->get_position() - wav_data_size_pos;
 		f_wav->seek(4);
-		f_wav->store_32(total_size + datasize);
+		f_wav->store_u32(total_size + datasize);
 		f_wav->seek(0x28);
-		f_wav->store_32(datasize);
+		f_wav->store_u32(datasize);
 	}
 }
 

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -456,18 +456,18 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 	f->get_buffer((uint8_t *)header, 4);
 	ERR_FAIL_COND_V(header != String(shader_file_header), false);
 
-	uint32_t file_version = f->get_32();
+	uint32_t file_version = f->get_u32();
 	if (file_version != cache_file_version) {
 		return false; // wrong version
 	}
 
-	uint32_t variant_count = f->get_32();
+	uint32_t variant_count = f->get_u32();
 
 	ERR_FAIL_COND_V(variant_count != (uint32_t)group_to_variant_map[p_group].size(), false); //should not happen but check
 
 	for (uint32_t i = 0; i < variant_count; i++) {
 		int variant_id = group_to_variant_map[p_group][i];
-		uint32_t variant_size = f->get_32();
+		uint32_t variant_size = f->get_u32();
 		ERR_FAIL_COND_V(variant_size == 0 && variants_enabled[variant_id], false);
 		if (!variants_enabled[variant_id]) {
 			continue;
@@ -514,12 +514,12 @@ void ShaderRD::_save_to_cache(Version *p_version, int p_group) {
 	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
 	ERR_FAIL_COND(f.is_null());
 	f->store_buffer((const uint8_t *)shader_file_header, 4);
-	f->store_32(cache_file_version); // File version.
+	f->store_u32(cache_file_version); // File version.
 	uint32_t variant_count = group_to_variant_map[p_group].size();
-	f->store_32(variant_count); // Variant count.
+	f->store_u32(variant_count); // Variant count.
 	for (uint32_t i = 0; i < variant_count; i++) {
 		int variant_id = group_to_variant_map[p_group][i];
-		f->store_32(p_version->variant_data[variant_id].size()); // Stage count.
+		f->store_u32(p_version->variant_data[variant_id].size()); // Stage count.
 		f->store_buffer(p_version->variant_data[variant_id].ptr(), p_version->variant_data[variant_id].size());
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/11316

Note: since GDScript only operates with `int64_t` values, `get_u64` and all `store_` methods are redundant and only added for consistency, and to match existing [`PackedByteArray`](https://docs.godotengine.org/en/stable/classes/class_packedbytearray.html#methods) `encode_`/`decode_` methods.