### PR TITLE
Android: Support for DisplayServer base color retrieval

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -199,7 +199,7 @@
 			<return type="Color" />
 			<description>
 				Returns the OS theme base color (default control background). Returns [code]Color(0, 0, 0, 0)[/code] if the base color is unknown.
-				[b]Note:[/b] This method is implemented on macOS and Windows.
+				[b]Note:[/b] This method is implemented on macOS, Windows, and Android.
 			</description>
 		</method>
 		<method name="get_display_cutouts" qualifiers="const">

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -209,6 +209,12 @@ Color DisplayServerAndroid::get_accent_color() const {
 	return godot_java->get_accent_color();
 }
 
+Color DisplayServerAndroid::get_base_color() const {
+	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
+	ERR_FAIL_NULL_V(godot_java, Color(0, 0, 0, 0));
+	return godot_java->get_base_color();
+}
+
 TypedArray<Rect2> DisplayServerAndroid::get_display_cutouts() const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	ERR_FAIL_NULL_V(godot_io_java, Array());

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -126,6 +126,7 @@ public:
 	void emit_file_picker_callback(bool p_ok, const Vector<String> &p_selected_paths);
 
 	virtual Color get_accent_color() const override;
+	virtual Color get_base_color() const override;
 
 	virtual TypedArray<Rect2> get_display_cutouts() const override;
 	virtual Rect2i get_display_safe_area() const override;

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -933,6 +933,13 @@ class Godot(private val context: Context) {
 		return value.data
 	}
 
+	@Keep
+	private fun getBaseColor(): Int {
+		val value = TypedValue()
+		context.theme.resolveAttribute(android.R.attr.colorBackground, value, true)
+		return value.data
+	}
+
 	/**
 	 * Destroys the Godot Engine and kill the process it's running in.
 	 */

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -65,6 +65,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_is_dark_mode_supported = p_env->GetMethodID(godot_class, "isDarkModeSupported", "()Z");
 	_is_dark_mode = p_env->GetMethodID(godot_class, "isDarkMode", "()Z");
 	_get_accent_color = p_env->GetMethodID(godot_class, "getAccentColor", "()I");
+	_get_base_color = p_env->GetMethodID(godot_class, "getBaseColor", "()I");
 	_get_clipboard = p_env->GetMethodID(godot_class, "getClipboard", "()Ljava/lang/String;");
 	_set_clipboard = p_env->GetMethodID(godot_class, "setClipboard", "(Ljava/lang/String;)V");
 	_has_clipboard = p_env->GetMethodID(godot_class, "hasClipboard", "()Z");
@@ -215,18 +216,32 @@ bool GodotJavaWrapper::is_dark_mode() {
 	}
 }
 
+// Convert ARGB to RGBA.
+static Color _argb_to_rgba(int p_color) {
+	int alpha = (p_color >> 24) & 0xFF;
+	int red = (p_color >> 16) & 0xFF;
+	int green = (p_color >> 8) & 0xFF;
+	int blue = p_color & 0xFF;
+	return Color(red / 255.0f, green / 255.0f, blue / 255.0f, alpha / 255.0f);
+}
+
 Color GodotJavaWrapper::get_accent_color() {
 	if (_get_accent_color) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_NULL_V(env, Color(0, 0, 0, 0));
 		int accent_color = env->CallIntMethod(godot_instance, _get_accent_color);
+		return _argb_to_rgba(accent_color);
+	} else {
+		return Color(0, 0, 0, 0);
+	}
+}
 
-		// Convert ARGB to RGBA.
-		int alpha = (accent_color >> 24) & 0xFF;
-		int red = (accent_color >> 16) & 0xFF;
-		int green = (accent_color >> 8) & 0xFF;
-		int blue = accent_color & 0xFF;
-		return Color(red / 255.0f, green / 255.0f, blue / 255.0f, alpha / 255.0f);
+Color GodotJavaWrapper::get_base_color() {
+	if (_get_base_color) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, Color(0, 0, 0, 0));
+		int base_color = env->CallIntMethod(godot_instance, _get_base_color);
+		return _argb_to_rgba(base_color);
 	} else {
 		return Color(0, 0, 0, 0);
 	}

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -57,6 +57,7 @@ private:
 	jmethodID _is_dark_mode_supported = nullptr;
 	jmethodID _is_dark_mode = nullptr;
 	jmethodID _get_accent_color = nullptr;
+	jmethodID _get_base_color = nullptr;
 	jmethodID _get_clipboard = nullptr;
 	jmethodID _set_clipboard = nullptr;
 	jmethodID _has_clipboard = nullptr;
@@ -102,6 +103,7 @@ public:
 	bool is_dark_mode_supported();
 	bool is_dark_mode();
 	Color get_accent_color();
+	Color get_base_color();
 	bool has_get_clipboard();
 	String get_clipboard();
 	bool has_set_clipboard();


### PR DESCRIPTION
This PR brings `get_base_color()` support to Android, aligning with existing functionality currently available only on macOS and Windows.

This enables the support for the setting `Follow System Theme` on **Android Editor**.