### PR TITLE
Clarify `limit_length()` for infinite vectors

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -270,7 +270,7 @@
 			<return type="Vector2" />
 			<param index="0" name="length" type="float" default="1.0" />
 			<description>
-				Returns the vector with a maximum length by limiting its length to [param length].
+				Returns the vector with a maximum length by limiting its length to [param length]. If the vector is non-finite, the result is undefined.
 			</description>
 		</method>
 		<method name="max" qualifiers="const">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -239,7 +239,7 @@
 			<return type="Vector3" />
 			<param index="0" name="length" type="float" default="1.0" />
 			<description>
-				Returns the vector with a maximum length by limiting its length to [param length].
+				Returns the vector with a maximum length by limiting its length to [param length]. If the vector is non-finite, the result is undefined.
 			</description>
 		</method>
 		<method name="max" qualifiers="const">


### PR DESCRIPTION
Closes #29714

The issue also mentions problems with multiplying, but you can't multiply infinity and 0, so the result makes sense. For `limit_length()` it's not obvious if you don't know the implementation.