### PR TITLE
Add async build support for the Web platform (asyncify)

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -34,7 +34,7 @@ def get_tools(env: "SConsEnvironment"):
 
 
 def get_opts():
-    from SCons.Variables import BoolVariable
+    from SCons.Variables import BoolVariable, EnumVariable
 
     return [
         ("initial_memory", "Initial WASM memory (in MiB)", 32),
@@ -56,6 +56,14 @@ def get_opts():
             "proxy_to_pthread",
             "Use Emscripten PROXY_TO_PTHREAD option to run the main application code to a separate thread",
             False,
+        ),
+        EnumVariable(
+            "async",
+            "Enable synchronous C++ interaction with asynchronous JavaScript",
+            "no",
+            ["no", "asyncify", "jspi"],
+            {"yes": "asyncify"},
+            ignorecase=2,
         ),
     ]
 
@@ -282,10 +290,6 @@ def configure(env: "SConsEnvironment"):
     # Wrap the JavaScript support code around a closure named Godot.
     env.Append(LINKFLAGS=["-sMODULARIZE=1", "-sEXPORT_NAME='Godot'"])
 
-    # Force long jump mode to 'wasm'
-    env.Append(CCFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
-    env.Append(LINKFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
-
     # Allow increasing memory buffer size during runtime. This is efficient
     # when using WebAssembly (in comparison to asm.js) and works well for
     # us since we don't know requirements at compile-time.
@@ -303,3 +307,18 @@ def configure(env: "SConsEnvironment"):
     # This workaround creates a closure that prevents the garbage collector from freeing the WebGL context.
     # We also only use WebGL2, and changing context version is not widely supported anyway.
     env.Append(LINKFLAGS=["-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0"])
+
+    # Async support.
+    if env["async"] != "no":
+        env.Append(CPPDEFINES=["ASYNC_ENABLED"])
+
+        if env["async"] == "asyncify":
+            env.Append(LINKFLAGS=["-sASYNCIFY"])
+        elif env["async"] == "jspi":
+            env.Append(LINKFLAGS=["-sJSPI"])
+
+        env.Append(CCFLAGS=["-sSUPPORT_LONGJMP='emscripten'"])
+        env.Append(LINKFLAGS=["-sSUPPORT_LONGJMP='emscripten'"])
+    else:
+        env.Append(CCFLAGS=["-sSUPPORT_LONGJMP='wasm'"])
+        env.Append(LINKFLAGS=["-sSUPPORT_LONGJMP='wasm'"])


### PR DESCRIPTION
> [!WARNING]
> **May 2, 2025:** I discovered that async is currently broken on Godot. This is because browser events are triggered, and they callback directly the engine. That makes it so that the WASM is run again, even when it "sleeps". I'll investigate this issue.

> [!NOTE]
> This PR is not needed _per se_ now, but it will prove useful for integrating features that require deep asynchronicity when the codebase expects an immediate response. I think [integrating WebGPU](https://github.com/godotengine/godot-proposals/issues/6646) is such a case.

> [!NOTE]
> Edit: I realized that we could support the `DisplayServer.clipboard_*` API on the web, but it requires async support.

This PR adds asynchronous build support to the Web platform by introducing a new build variable:

| Build variable | Description | Default value | Values |
| :---: | :---: | :---: | :---: |
| `async` | Enable synchronous C++ interaction with asynchronous JavaScript. | no | no, asyncify (yes), jspi |

See [Asynchronous Code](https://emscripten.org/docs/porting/asyncify.html) from the emscripten docs for more details about `asyncify` and `jspi`.

> [!WARNING]
> `asyncify` introduces a **huge** overhead. A _template_debug_ build can go from 41.6MiB to 82.3MiB. But with Brotli compression, the size can be reduced to 10.3MiB, which is less than the current non-compressed build. (note: without 

> [!NOTE]
> `jspi` is currently behind flags for Firefox and Chromium (see the [Feature Extensions table](https://webassembly.org/features/#table-row-jspi) for more info). It removes completely the overhead introduced by `asyncify`.

Ultimately, when supported, we could release a template combining two builds: one with `asyncify` and the other with `jspi`. Could be interesting to switch the build based on compatibility.