### PR TITLE
Fix error when calling `Window::move_to_center` when window is invisible

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -385,7 +385,7 @@ void Window::move_to_center() {
 	if (is_embedded()) {
 		parent_rect = get_embedder()->get_visible_rect();
 	} else {
-		int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
+		int parent_screen = get_current_screen();
 		parent_rect.position = DisplayServer::get_singleton()->screen_get_position(parent_screen);
 		parent_rect.size = DisplayServer::get_singleton()->screen_get_size(parent_screen);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

When calling move_to_center tries to get the screen id of the native window, and get the screen size to compute the centeral window position. But the native window is not exists when window node invisible and will lead to an DisplayServer error. In fact, There is a screen id cache in window and can be get by Window::get_current_screen. This PR solve this.