### PR TITLE
SCons: Unconditionally use `env.Decider("MD5-timestamp")`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -501,14 +501,19 @@ else:
     # Disable assert() for production targets (only used in thirdparty code).
     env.Append(CPPDEFINES=["NDEBUG"])
 
+# This is not part of fast_unsafe because the only downside it has compared to
+# the default is that SCons won't mark files that were changed in the last second
+# as different. This is unlikely to be a problem in any real situation as just booting
+# up scons takes more than that time.
+# Renamed to `content-timestamp` in SCons >= 4.2, keeping MD5 for compat.
+env.Decider("MD5-timestamp")
+
 # SCons speed optimization controlled by the `fast_unsafe` option, which provide
 # more than 10 s speed up for incremental rebuilds.
 # Unsafe as they reduce the certainty of rebuilding all changed files, so it's
 # enabled by default for `debug` builds, and can be overridden from command line.
 # Ref: https://github.com/SCons/scons/wiki/GoFastButton
 if methods.get_cmdline_bool("fast_unsafe", env.dev_build):
-    # Renamed to `content-timestamp` in SCons >= 4.2, keeping MD5 for compat.
-    env.Decider("MD5-timestamp")
     env.SetOption("implicit_cache", 1)
     env.SetOption("max_drift", 60)
 


### PR DESCRIPTION
It seems that we are only enabling this option together with unsafe build determinators. However it seems that MD5-timestamp by itself is not unsafe.

MD5-Timestamp works by first checking the timestamp of a file, comparing it to the scons database and if it does not match it will do an md5sum to determine if the file needs rebuilding.

Without this option SCons will always create md5sums of every file. In the case of a null build this is 50% of the time.

Performance improvements are massive:

```
$ scons p=linuxbsd debug_symbols=yes verbose=yes compiledb=yes optimize=speed linker=mold -j64 fast_unsafe=yes
[Time elapsed: 00:00:07.48]

$ scons p=linuxbsd debug_symbols=yes verbose=yes compiledb=yes optimize=speed linker=mold -j64 # with MD5-Timestamp forced
[Time elapsed: 00:00:11.02]

$ scons p=linuxbsd debug_symbols=yes verbose=yes compiledb=yes optimize=speed linker=mold -j64 # vanilla godot
[Time elapsed: 00:00:25.73]
```

I suspect this will also help with CI times.