### PR TITLE
Add Depth Offset property to BaseMaterial3D and fix collision shape gizmo flicker

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -150,6 +150,13 @@
 		<member name="depth_draw_mode" type="int" setter="set_depth_draw_mode" getter="get_depth_draw_mode" enum="BaseMaterial3D.DepthDrawMode" default="0">
 			Determines when depth rendering takes place. See [enum DepthDrawMode]. See also [member transparency].
 		</member>
+		<member name="depth_offset" type="bool" setter="set_depth_offset_enabled" getter="is_depth_offset_enabled" default="false">
+			If [code]true[/code], offsets the per-pixel depth by the amount specified in [member depth_offset_amount]. This can be used to force the material to render in front of (or behind) other meshes that are at the exact same position, which can prevent Z-fighting artifacts. This can be useful for mesh-based decals, or when rendering meshes as overlays to other meshes.
+			[b]Note:[/b] Enabling depth offset forces the material to go through the transparent pipeline, which has a performance cost and can result in transparency sorting issues.
+		</member>
+		<member name="depth_offset_amount" type="float" setter="set_depth_offset" getter="get_depth_offset" default="0.0">
+			The depth offset to apply when [member depth_offset] is [code]true[/code]. Negative values will push the pixels towards the camera, while positive values will push the pixels away from the camera. Typical values are between [code]-0.01[/code] and [code]0.01[/code]. If you still notice Z-fighting after adjusting the depth offset, try using a lower value (if negative) or a higher value (if positive).
+		</member>
 		<member name="detail_albedo" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture that specifies the color of the detail overlay. [member detail_albedo]'s alpha channel is used as a mask, even when the material is opaque. To use a dedicated texture as a mask, see [member detail_mask].
 			[b]Note:[/b] [member detail_albedo] is [i]not[/i] modulated by [member albedo_color].

--- a/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
@@ -77,6 +77,12 @@ void CollisionShape3DGizmoPlugin::create_collision_material(const String &p_name
 		material->set_albedo(color);
 		material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 		material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+
+		// Prevent collision shape triangles that overlap with geometry from Z-fighting.
+		// by pushing the pixels towards the camera slightly.
+		material->set_depth_offset_enabled(true);
+		material->set_depth_offset(-0.005);
+
 		material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 1);
 		material->set_cull_mode(StandardMaterial3D::CULL_BACK);
 		material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -910,6 +910,12 @@ void EditorNode3DGizmoPlugin::create_material(const String &p_name, const Color 
 		material->set_albedo(color);
 		material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 		material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+
+		// Prevent collision shape triangles that overlap with geometry from Z-fighting
+		// by pushing the pixels towards the camera slightly.
+		material->set_depth_offset_enabled(true);
+		material->set_depth_offset(-0.005);
+
 		material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 1);
 		material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
 		material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -153,6 +153,12 @@ Ref<Material> Shape3D::get_debug_collision_material() {
 	material->set_albedo(Color(1.0, 1.0, 1.0));
 	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+
+	// Prevent collision shape triangles that overlap with geometry from Z-fighting.
+	// by pushing the pixels towards the camera slightly.
+	material->set_depth_offset_enabled(true);
+	material->set_depth_offset(-0.005);
+
 	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 1);
 	material->set_cull_mode(StandardMaterial3D::CULL_BACK);
 	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1369,8 +1369,8 @@ void vertex() {)";
 		code += R"(
 	// Depth Offset: Enabled
 	VERTEX = VERTEX;
-	POSITION = PROJECTION_MATRIX * VIEW_MATRIX * MODEL_MATRIX * vec4(VERTEX.xyz, 1.0);
-	POSITION.z = mix(POSITION.z, POSITION.w, 0.001);
+	POSITION = PROJECTION_MATRIX * (VIEW_MATRIX * MODEL_MATRIX * vec4(VERTEX.xyz, 1.0) - vec4(0.0, 0.0, depth_offset, 0.0));
+	//POSITION = PROJECTION_MATRIX * VIEW_MATRIX * MODEL_MATRIX * vec4(VERTEX.xyz, 1.0) - PROJECTION_MATRIX * vec4(0.0, 0.0, depth_offset, 0.0);
 )";
 	}
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1365,6 +1365,15 @@ void vertex() {)";
 )";
 	}
 
+	if (depth_offset_enabled) {
+		code += R"(
+	// Depth Offset: Enabled
+	VERTEX = VERTEX;
+	POSITION = PROJECTION_MATRIX * VIEW_MATRIX * MODEL_MATRIX * vec4(VERTEX.xyz, 1.0);
+	POSITION.z = mix(POSITION.z, POSITION.w, 0.001);
+)";
+	}
+
 	code += "}\n";
 
 	if (flags[FLAG_ALBEDO_TEXTURE_MSDF] && !flags[FLAG_UV1_USE_TRIPLANAR]) {
@@ -1404,21 +1413,6 @@ void fragment() {)";
 			code += "\n";
 		}
 		code += R"(	vec2 base_uv2 = UV2;
-)";
-	}
-
-	if (depth_offset_enabled) {
-		code += R"(
-	// Depth Offset: Enabled
-	// Force transparency on the material (required for depth offset).
-	ALPHA = 1.0;
-	vec4 view_position = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2. - 1.0, FRAGCOORD.z, 1.0);
-	vec3 view_direction = normalize(VIEW);
-	view_position.xyz /= view_position.w;
-	view_position.xyz -= depth_offset * view_direction;
-	vec4 ndc_position = PROJECTION_MATRIX * vec4(view_position.xyz, 1.0);
-	ndc_position.xyz /= ndc_position.w;
-	DEPTH = ndc_position.z;
 )";
 	}
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -339,6 +339,7 @@ private:
 		uint64_t invalid_key : 1;
 		uint64_t deep_parallax : 1;
 		uint64_t grow : 1;
+		uint64_t depth_offset : 1;
 		uint64_t proximity_fade : 1;
 		uint64_t orm : 1;
 
@@ -389,6 +390,7 @@ private:
 		mk.billboard_mode = billboard_mode;
 		mk.deep_parallax = deep_parallax;
 		mk.grow = grow_enabled;
+		mk.depth_offset = depth_offset_enabled;
 		mk.proximity_fade = proximity_fade_enabled;
 		mk.distance_fade = distance_fade;
 		mk.emission_op = emission_op;
@@ -444,6 +446,7 @@ private:
 		StringName uv1_blend_sharpness;
 		StringName uv2_blend_sharpness;
 		StringName grow;
+		StringName depth_offset;
 		StringName proximity_fade_distance;
 		StringName msdf_pixel_range;
 		StringName msdf_outline_size;
@@ -508,6 +511,8 @@ private:
 	float alpha_scissor_threshold = 0.0f;
 	float alpha_hash_scale = 0.0f;
 	float alpha_antialiasing_edge = 0.0f;
+	bool depth_offset_enabled = false;
+	float depth_offset = 0.0f;
 	bool grow_enabled = false;
 	float ao_light_affect = 0.0f;
 	float grow = 0.0f;
@@ -666,6 +671,12 @@ public:
 
 	void set_alpha_antialiasing_edge(float p_edge);
 	float get_alpha_antialiasing_edge() const;
+
+	void set_depth_offset_enabled(bool p_enabled);
+	bool is_depth_offset_enabled() const;
+
+	void set_depth_offset(float p_offset);
+	float get_depth_offset() const;
 
 	void set_shading_mode(ShadingMode p_shading_mode);
 	ShadingMode get_shading_mode() const;


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/90644.

This has several use cases:

- Prevent collision shape gizmos that overlap with geometry from Z-fighting, which causes flickering in motion.
- Draw meshes that overlap other meshes without Z-fighting, which is useful for mesh-based decals (without needing to offset them from the surface manually).
- In general, allow meshes to draw in front of other meshes even if they're actually slightly behind, which can be useful for some VFX.
- This paves the way for implementing https://github.com/godotengine/godot-proposals/issues/1000.
- This closes https://github.com/godotengine/godot/issues/99184.

**Testing project:** [test_depth_offset.zip](https://github.com/user-attachments/files/18065679/test_depth_offset.zip)

## Preview

### Debug collisions

#### Without depth offset

![Screenshot_20241209_182031](https://github.com/user-attachments/assets/2393266b-bbb3-4fe1-b74a-24a4dd0cfd81)

#### With depth offset

![Screenshot_20241209_181943](https://github.com/user-attachments/assets/f6a84542-c4a5-48ce-933e-0b7a3eb4efd0)

### Debug collisions (supersampled)

*2.0 render scale + 8x MSAA 3D.*

#### Without depth offset

![Screenshot_20241209_182121](https://github.com/user-attachments/assets/8f85e8fd-1aae-4620-b6c5-dd6bd7ea4cae)

#### With depth offset

![Screenshot_20241209_182143](https://github.com/user-attachments/assets/32bd19b0-96f2-4d2f-af6a-ba9d603efa7e)

### Debug collisions in motion

### Without depth offset

https://github.com/user-attachments/assets/47b6d731-592c-4108-85b4-20f49b20844c

#### With depth offset

https://github.com/user-attachments/assets/815a81ec-3cb8-4c53-8055-9c3536d19afa

### CSG node gizmos

#### Without depth offset

![Screenshot_20241209_184914](https://github.com/user-attachments/assets/6906c537-41e4-48c7-8ae4-f731c008bee4)

#### With depth offset

![Screenshot_20241209_184954](https://github.com/user-attachments/assets/c7914267-7e30-4153-bb11-c7fb680d7c89)

### Mesh-based decal

*Both planes are at the same height as the box they're resting on (no offset is applied to the mesh's vertices).*

#### Without depth offset

*Z-fighting occurs and is most visible when the camera moves or rotates.*

![Screenshot_20241209_183330](https://github.com/user-attachments/assets/799e573c-7ede-4e29-9bb4-ee3d29846d68)

#### With depth offset

*No more Z-fighting.*

![Screenshot_20241209_183336](https://github.com/user-attachments/assets/2e569512-eb98-401d-baab-51438e176a25)