### PR TITLE
Add paths filter to github runner builds, to skip CI when appropriate.

### DIFF
--- a/.github/path_filters.yaml
+++ b/.github/path_filters.yaml
@@ -1,0 +1,21 @@
+shared: &shared
+  - '**'
+  - '!platform/*/**'
+android:
+  - *shared
+  - 'platform/android/**'
+ios:
+  - *shared
+  - 'platform/ios/**'
+linux:
+  - *shared
+  - 'platform/linuxbsd/**'
+macos:
+  - *shared
+  - 'platform/macos/**'
+windows:
+  - *shared
+  - 'platform/windows/**'
+web:
+  - *shared
+  - 'platform/web/**'

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -6,6 +6,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  dispatch:
+    name: 🐝 Dispatch
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      android: ${{ steps.path_filters.outputs.android }}
+      ios: ${{ steps.path_filters.outputs.ios }}
+      linux: ${{ steps.path_filters.outputs.linux }}
+      macos: ${{ steps.path_filters.outputs.macos }}
+      windows: ${{ steps.path_filters.outputs.windows }}
+      web: ${{ steps.path_filters.outputs.web }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      if: github.event_name == 'pull_request'
+    - uses: AurorNZ/paths-filter@298e00d16954592b06fe237dbf749947c3dd4a98
+      if: github.event_name == 'pull_request'
+      id: path_filters
+      with:
+        filters: .github/path_filters.yaml
+
   # First stage: Only static checks, fast and prevent expensive builds from running.
 
   static-checks:
@@ -17,32 +40,38 @@ jobs:
 
   android-build:
     name: 🤖 Android
-    needs: static-checks
+    needs: [static-checks, dispatch]
+    if: github.event_name != 'pull_request' || needs.dispatch.outputs.android == 'true'
     uses: ./.github/workflows/android_builds.yml
 
   ios-build:
     name: 🍏 iOS
-    needs: static-checks
+    needs: [static-checks, dispatch]
+    if: github.event_name != 'pull_request' || needs.dispatch.outputs.ios == 'true'
     uses: ./.github/workflows/ios_builds.yml
 
   linux-build:
     name: 🐧 Linux
-    needs: static-checks
+    needs: [static-checks, dispatch]
+    if: github.event_name != 'pull_request' || needs.dispatch.outputs.linux == 'true'
     uses: ./.github/workflows/linux_builds.yml
 
   macos-build:
     name: 🍎 macOS
-    needs: static-checks
+    needs: [static-checks, dispatch]
+    if: github.event_name != 'pull_request' || needs.dispatch.outputs.macos == 'true'
     uses: ./.github/workflows/macos_builds.yml
 
   windows-build:
     name: 🏁 Windows
-    needs: static-checks
+    needs: [static-checks, dispatch]
+    if: github.event_name != 'pull_request' || needs.dispatch.outputs.windows == 'true'
     uses: ./.github/workflows/windows_builds.yml
 
   web-build:
     name: 🌐 Web
-    needs: static-checks
+    needs: [static-checks, dispatch]
+    if: github.event_name != 'pull_request' || needs.dispatch.outputs.web == 'true'
     uses: ./.github/workflows/web_builds.yml
 
   # Third stage: Run auxiliary tests using build artifacts from previous jobs.


### PR DESCRIPTION
This PR lets the CI / GitHub Runner skip some of the jobs when running them would be unnecessary, because just from looking at the files it can be understood that no rebuild is needed. The CI will still pass even if some jobs are skipped.

**Example: https://github.com/Ivorforce/godot/actions/runs/12241380885**
_(only Linux build is run for a change to the linux platform)_
_((to make the example work, i had to modify the base ref for the branch only, but it _should_ work out of the box for PRs))_

### Discussion

Theoretically, GitHub has support for path filters builtin through the [paths parameter](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore).

However, it can only be used to skip the CI as a whole, not parts of it, making it unsuitable for our purposes. (And besides, if the CI is skipped, it is well-known that the PR is not mergable - it is only mergable on an OK result).

A solution is provided by https://github.com/dorny/paths-filter. The action uses `git` to check against a git ref. By default, the ref is the latest shared commit of the base branch (`master`). 

Unfortunately, path filters are not applied sequentially, but evaluated in a `some` or `all` pattern. This prohibits `.gitignore`-like filters like:
```
**
!platform/*/**
platform/android/**
```

Fortunately, [this has been addressed](https://github.com/dorny/paths-filter/issues/106#issuecomment-1055848325) in [a fork](https://github.com/AurorNZ/paths-filter). Therefore, I am using the fork. I have not extensively tested the stability of either the fork or the original repository. I cannot guarantee it won't introduce problems with CI, for example, by incorrectly skipping CI.

### Addendum

For now, only `platforms` contributions are filtered, which can skip CI for contributions like https://github.com/godotengine/godot/pull/100205, which only affect one particular platform's python files. Follow-up PRs should expand the filters to better pinpoint what other parts can be skipped, for example, on changes to the readme file.

Also, the filters can be defined in a dedicated file like `.github/filters.yaml`. This would probably be advisable to avoid cluttering the workflow itself.