### PR TITLE
Style: Rework `*.compat.inc` to handle headers

### DIFF
--- a/core/core_bind.compat.inc
+++ b/core/core_bind.compat.inc
@@ -28,35 +28,36 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef DISABLE_DEPRECATED
-
-namespace core_bind {
-
 // Semaphore
 
-void Semaphore::_post_bind_compat_93605() {
-	post(1);
-}
+#define _COMPAT_HEADER_Semaphore \
+	void _post_bind_compat_93605();
 
-void Semaphore::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("post"), &Semaphore::_post_bind_compat_93605);
-}
+#define _COMPAT_SOURCE_Semaphore                                                                   \
+	void Semaphore::_post_bind_compat_93605() {                                                    \
+		post(1);                                                                                   \
+	}                                                                                              \
+                                                                                                   \
+	void Semaphore::_bind_compatibility_methods() {                                                \
+		ClassDB::bind_compatibility_method(D_METHOD("post"), &Semaphore::_post_bind_compat_93605); \
+	}
 
 // OS
 
-String OS::_read_string_from_stdin_bind_compat_91201() {
-	return read_string_from_stdin(1024);
-}
+#define _COMPAT_HEADER_OS                               \
+	String _read_string_from_stdin_bind_compat_91201(); \
+	Dictionary _execute_with_pipe_bind_compat_94434(const String &p_path, const Vector<String> &p_arguments);
 
-Dictionary OS::_execute_with_pipe_bind_compat_94434(const String &p_path, const Vector<String> &p_arguments) {
-	return execute_with_pipe(p_path, p_arguments, true);
-}
-
-void OS::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("read_string_from_stdin"), &OS::_read_string_from_stdin_bind_compat_91201);
-	ClassDB::bind_compatibility_method(D_METHOD("execute_with_pipe", "path", "arguments"), &OS::_execute_with_pipe_bind_compat_94434);
-}
-
-} // namespace core_bind
-
-#endif // DISABLE_DEPRECATED
+#define _COMPAT_SOURCE_OS                                                                                                                  \
+	String OS::_read_string_from_stdin_bind_compat_91201() {                                                                               \
+		return read_string_from_stdin(1024);                                                                                               \
+	}                                                                                                                                      \
+                                                                                                                                           \
+	Dictionary OS::_execute_with_pipe_bind_compat_94434(const String &p_path, const Vector<String> &p_arguments) {                         \
+		return execute_with_pipe(p_path, p_arguments, true);                                                                               \
+	}                                                                                                                                      \
+                                                                                                                                           \
+	void OS::_bind_compatibility_methods() {                                                                                               \
+		ClassDB::bind_compatibility_method(D_METHOD("read_string_from_stdin"), &OS::_read_string_from_stdin_bind_compat_91201);            \
+		ClassDB::bind_compatibility_method(D_METHOD("execute_with_pipe", "path", "arguments"), &OS::_execute_with_pipe_bind_compat_94434); \
+	}

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -29,7 +29,6 @@
 /**************************************************************************/
 
 #include "core_bind.h"
-#include "core_bind.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
@@ -213,6 +212,8 @@ void ResourceSaver::_bind_methods() {
 }
 
 ////// OS //////
+
+COMPAT_SOURCE(OS)
 
 PackedByteArray OS::get_entropy(int p_bytes) {
 	PackedByteArray pba;
@@ -1273,6 +1274,8 @@ void Marshalls::_bind_methods() {
 }
 
 ////// Semaphore //////
+
+COMPAT_SOURCE(Semaphore)
 
 void Semaphore::wait() {
 	semaphore.wait();

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -39,6 +39,7 @@
 #include "core/os/semaphore.h"
 #include "core/os/thread.h"
 #include "core/templates/safe_refcount.h"
+#include "core_bind.compat.inc"
 
 class MainLoop;
 template <typename T>
@@ -131,12 +132,7 @@ protected:
 	static void _bind_methods();
 	static OS *singleton;
 
-#ifndef DISABLE_DEPRECATED
-	Dictionary _execute_with_pipe_bind_compat_94434(const String &p_path, const Vector<String> &p_arguments);
-
-	String _read_string_from_stdin_bind_compat_91201();
-	static void _bind_compatibility_methods();
-#endif
+	COMPAT_HEADER(OS)
 
 public:
 	enum RenderingDriver {
@@ -420,10 +416,8 @@ class Semaphore : public RefCounted {
 
 protected:
 	static void _bind_methods();
-#ifndef DISABLE_DEPRECATED
-	void _post_bind_compat_93605();
-	static void _bind_compatibility_methods();
-#endif // DISABLE_DEPRECATED
+
+	COMPAT_HEADER(Semaphore)
 
 public:
 	void wait();

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -561,6 +561,16 @@ public:                                                                 \
                                                                         \
 private:
 
+/* clang-format off */
+#ifndef DISABLE_DEPRECATED
+#define COMPAT_HEADER(m_class) protected: static void _bind_compatibility_methods(); _COMPAT_HEADER_##m_class private:
+#define COMPAT_SOURCE(m_class) _COMPAT_SOURCE_##m_class
+#else
+#define COMPAT_HEADER(m_class)
+#define COMPAT_SOURCE(m_class)
+#endif
+/* clang-format on */
+
 class ScriptInstance;
 
 class Object {

--- a/servers/text_server.compat.inc
+++ b/servers/text_server.compat.inc
@@ -28,14 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef DISABLE_DEPRECATED
+#define _COMPAT_HEADER_TextServer \
+	PackedInt32Array _shaped_text_get_word_breaks_bind_compat_90732(const RID &p_shaped, BitField<TextServer::GraphemeFlag> p_grapheme_flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION) const;
 
-PackedInt32Array TextServer::_shaped_text_get_word_breaks_bind_compat_90732(const RID &p_shaped, BitField<TextServer::GraphemeFlag> p_grapheme_flags) const {
-	return shaped_text_get_word_breaks(p_shaped, p_grapheme_flags, 0);
-}
-
-void TextServer::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("shaped_text_get_word_breaks", "shaped", "grapheme_flags"), &TextServer::_shaped_text_get_word_breaks_bind_compat_90732, DEFVAL(GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION));
-}
-
-#endif
+#define _COMPAT_SOURCE_TextServer                                                                                                                                                                                                  \
+	PackedInt32Array TextServer::_shaped_text_get_word_breaks_bind_compat_90732(const RID &p_shaped, BitField<TextServer::GraphemeFlag> p_grapheme_flags) const {                                                                  \
+		return shaped_text_get_word_breaks(p_shaped, p_grapheme_flags, 0);                                                                                                                                                         \
+	}                                                                                                                                                                                                                              \
+                                                                                                                                                                                                                                   \
+	void TextServer::_bind_compatibility_methods() {                                                                                                                                                                               \
+		ClassDB::bind_compatibility_method(D_METHOD("shaped_text_get_word_breaks", "shaped", "grapheme_flags"), &TextServer::_shaped_text_get_word_breaks_bind_compat_90732, DEFVAL(GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION)); \
+	}

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -29,10 +29,11 @@
 /**************************************************************************/
 
 #include "servers/text_server.h"
-#include "text_server.compat.inc"
 
 #include "core/variant/typed_array.h"
 #include "servers/rendering_server.h"
+
+COMPAT_SOURCE(TextServer)
 
 TextServerManager *TextServerManager::singleton = nullptr;
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -37,6 +37,7 @@
 #include "core/templates/rid.h"
 #include "core/variant/native_ptr.h"
 #include "core/variant/variant.h"
+#include "text_server.compat.inc"
 
 template <typename T>
 class TypedArray;
@@ -227,10 +228,7 @@ protected:
 
 	static void _bind_methods();
 
-#ifndef DISABLE_DEPRECATED
-	PackedInt32Array _shaped_text_get_word_breaks_bind_compat_90732(const RID &p_shaped, BitField<TextServer::GraphemeFlag> p_grapheme_flags = GRAPHEME_IS_SPACE | GRAPHEME_IS_PUNCTUATION) const;
-	static void _bind_compatibility_methods();
-#endif
+	COMPAT_HEADER(TextServer)
 
 public:
 	virtual bool has_feature(Feature p_feature) const = 0;

--- a/servers/xr_server.compat.inc
+++ b/servers/xr_server.compat.inc
@@ -28,24 +28,26 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef DISABLE_DEPRECATED
+#define _COMPAT_HEADER_XRServer                                                        \
+	void _add_tracker_bind_compat_90645(const Ref<XRPositionalTracker> &p_tracker);    \
+	void _remove_tracker_bind_compat_90645(const Ref<XRPositionalTracker> &p_tracker); \
+	Ref<XRPositionalTracker> _get_tracker_bind_compat_90645(const StringName &p_name) const;
 
-void XRServer::_add_tracker_bind_compat_90645(const Ref<XRPositionalTracker> &p_tracker) {
-	add_tracker(p_tracker);
-}
-
-void XRServer::_remove_tracker_bind_compat_90645(const Ref<XRPositionalTracker> &p_tracker) {
-	remove_tracker(p_tracker);
-}
-
-Ref<XRPositionalTracker> XRServer::_get_tracker_bind_compat_90645(const StringName &p_name) const {
-	return get_tracker(p_name);
-}
-
-void XRServer::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_method(D_METHOD("add_tracker", "tracker"), &XRServer::_add_tracker_bind_compat_90645);
-	ClassDB::bind_compatibility_method(D_METHOD("remove_tracker", "tracker"), &XRServer::_remove_tracker_bind_compat_90645);
-	ClassDB::bind_compatibility_method(D_METHOD("get_tracker", "name"), &XRServer::_get_tracker_bind_compat_90645);
-}
-
-#endif // DISABLE_DEPRECATED
+#define _COMPAT_SOURCE_XRServer                                                                                                  \
+	void XRServer::_add_tracker_bind_compat_90645(const Ref<XRPositionalTracker> &p_tracker) {                                   \
+		add_tracker(p_tracker);                                                                                                  \
+	}                                                                                                                            \
+                                                                                                                                 \
+	void XRServer::_remove_tracker_bind_compat_90645(const Ref<XRPositionalTracker> &p_tracker) {                                \
+		remove_tracker(p_tracker);                                                                                               \
+	}                                                                                                                            \
+                                                                                                                                 \
+	Ref<XRPositionalTracker> XRServer::_get_tracker_bind_compat_90645(const StringName &p_name) const {                          \
+		return get_tracker(p_name);                                                                                              \
+	}                                                                                                                            \
+                                                                                                                                 \
+	void XRServer::_bind_compatibility_methods() {                                                                               \
+		ClassDB::bind_compatibility_method(D_METHOD("add_tracker", "tracker"), &XRServer::_add_tracker_bind_compat_90645);       \
+		ClassDB::bind_compatibility_method(D_METHOD("remove_tracker", "tracker"), &XRServer::_remove_tracker_bind_compat_90645); \
+		ClassDB::bind_compatibility_method(D_METHOD("get_tracker", "name"), &XRServer::_get_tracker_bind_compat_90645);          \
+	}

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -35,7 +35,8 @@
 #include "xr/xr_hand_tracker.h"
 #include "xr/xr_interface.h"
 #include "xr/xr_positional_tracker.h"
-#include "xr_server.compat.inc"
+
+COMPAT_SOURCE(XRServer)
 
 XRServer::XRMode XRServer::xr_mode = XRMODE_DEFAULT;
 

--- a/servers/xr_server.h
+++ b/servers/xr_server.h
@@ -37,6 +37,7 @@
 #include "core/templates/rid.h"
 #include "core/variant/variant.h"
 #include "rendering_server.h"
+#include "xr_server.compat.inc"
 
 class XRInterface;
 class XRTracker;
@@ -138,12 +139,7 @@ protected:
 
 	static void _bind_methods();
 
-#ifndef DISABLE_DEPRECATED
-	static void _bind_compatibility_methods();
-	void _add_tracker_bind_compat_90645(const Ref<XRPositionalTracker> &p_tracker);
-	void _remove_tracker_bind_compat_90645(const Ref<XRPositionalTracker> &p_tracker);
-	Ref<XRPositionalTracker> _get_tracker_bind_compat_90645(const StringName &p_name) const;
-#endif
+	COMPAT_HEADER(XRServer)
 
 public:
 	static XRMode get_xr_mode();


### PR DESCRIPTION
- Alternative to #99517

While I'm no longer interested in removing the `*.compat.inc` files from the repo, I am still not satisfied with their implementation, particularly regarding this point KoBeWi made[^1] in the previous PR:

> They are in the headers only because it's the only way.

Brainstorming a followup was explicitly *not* a priority, so this has been on the backburner for a fair bit. With that said, I'm pretty sure I've come up with a system which would solve that problem, so I'm showcasing it in a reduced scope via draft to see what people think.

The idea is to constrain compatibility changes to specially-named defines, while including the `*.compat.inc` file in the relevant script's **header**. Calling to these specialized defines will be handled by passing the class name through new `object.h` wrapper macros. These adjustments provide the following benefits:
- With the sole exception of the wrapper defines & `*.compat.inc` include, there is *absolutely zero* compatibility code anywhere in header/definition files.
- Constraining logic to defines plays much nicer with IDEs and intellisense, as their logic is properly evaluated in the relevant locations.
- Significantly reduces boilerplate via `object.h` wrapper macros, which automatically handle the logic for deprecation & scope.

[^1]: https://github.com/godotengine/godot/pull/99517#issuecomment-2492675926