### PR TITLE
Export: Propagate `save_zip` error to callers.

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -2234,6 +2234,8 @@ Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, bo
 	Error err = export_project_files(p_preset, p_debug, p_save_func, nullptr, &zd, _zip_add_shared_object);
 	if (err != OK && err != ERR_SKIP) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Save ZIP"), TTR("Failed to export project files."));
+		zipClose(zip, nullptr);
+		return err;
 	}
 
 	zipClose(zip, nullptr);
@@ -2250,6 +2252,7 @@ Error EditorExportPlatform::save_zip(const Ref<EditorExportPreset> &p_preset, bo
 	if (err != OK) {
 		da->remove(tmppath);
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Save ZIP"), vformat(TTR("Failed to move temporary file \"%s\" to \"%s\"."), tmppath, p_path));
+		return err;
 	}
 
 	return OK;


### PR DESCRIPTION
Currently the save_zip method in editor_export_platform.cpp will silently swallow any errors produced during the zip exporting process, and just report that everything is fine to the callers, while leaving messages on the error log.   But the higher levels can not react to this.

This makes it report the error to the callers, similar to what the the `save_pack` method does in the same class.

It does look like this is just a historical artifact left from the day it was first stubbed out.