### PR TITLE
Fix proximity fade in Compatibility renderer

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1716,7 +1716,11 @@ void fragment() {)";
 		code += R"(
 	// Proximity Fade: Enabled
 	float proximity_depth_tex = textureLod(depth_texture, SCREEN_UV, 0.0).r;
+	#if CURRENT_RENDERER == RENDERER_COMPATIBILITY
+	vec4 proximity_view_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, proximity_depth_tex * 2.0 - 1.0, 1.0);
+	#else
 	vec4 proximity_view_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, proximity_depth_tex, 1.0);
+	#endif
 	proximity_view_pos.xyz /= proximity_view_pos.w;
 	ALPHA *= clamp(1.0 - smoothstep(proximity_view_pos.z + proximity_fade_distance, proximity_view_pos.z, VERTEX.z), 0.0, 1.0);
 )";


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/89942.
Supersedes https://github.com/godotengine/godot/pull/89966.

Uses the correct NDC for the Compatibility renderer.

Uses the preprocessor [defines for the current renderer](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shader_preprocessor.html#current-renderer) introduced in 4.4 in https://github.com/godotengine/godot/pull/98549. We also document a nearly identical reconstruction of world space using NDC in [this tutorial](https://docs.godotengine.org/en/latest/tutorials/shaders/advanced_postprocessing.html#depth-texture), which now uses the preprocessor defines to be renderer-independent.