### PR TITLE
[Web] Fix `DirAccess::unlink()` not updating the IDBFS

### DIFF
--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -52,6 +52,9 @@ protected:
 	virtual bool is_hidden(const String &p_name);
 
 public:
+	typedef void (*RemoveNotificationFunc)(const String &p_file);
+	static RemoveNotificationFunc remove_notification_func;
+
 	virtual Error list_dir_begin() override; ///< This starts dir listing
 	virtual String get_next() override;
 	virtual bool current_is_dir() const override;

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -443,7 +443,7 @@ void FileAccessUnix::close() {
 	_close();
 }
 
-CloseNotificationFunc FileAccessUnix::close_notification_func = nullptr;
+FileAccessUnix::CloseNotificationFunc FileAccessUnix::close_notification_func = nullptr;
 
 FileAccessUnix::~FileAccessUnix() {
 	_close();

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -38,8 +38,6 @@
 
 #if defined(UNIX_ENABLED)
 
-typedef void (*CloseNotificationFunc)(const String &p_file, int p_flags);
-
 class FileAccessUnix : public FileAccess {
 	FILE *f = nullptr;
 	int flags = 0;
@@ -56,6 +54,7 @@ class FileAccessUnix : public FileAccess {
 #endif
 
 public:
+	typedef void (*CloseNotificationFunc)(const String &p_file, int p_flags);
 	static CloseNotificationFunc close_notification_func;
 
 	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -224,6 +224,18 @@ void OS_Web::file_access_close_callback(const String &p_file, int p_flags) {
 	}
 }
 
+void OS_Web::dir_access_remove_callback(const String &p_file) {
+	OS_Web *os = OS_Web::get_singleton();
+	bool is_file_persistent = p_file.begins_with("/userfs");
+#ifdef TOOLS_ENABLED
+	// Hack for editor persistence (can we track).
+	is_file_persistent = is_file_persistent || p_file.begins_with("/home/web_user/");
+#endif
+	if (is_file_persistent) {
+		os->idb_needs_sync = true;
+	}
+}
+
 void OS_Web::update_pwa_state_callback() {
 	if (OS_Web::get_singleton()) {
 		OS_Web::get_singleton()->pwa_is_waiting = true;
@@ -287,4 +299,5 @@ OS_Web::OS_Web() {
 	_set_logger(memnew(CompositeLogger(loggers)));
 
 	FileAccessUnix::close_notification_func = file_access_close_callback;
+	DirAccessUnix::remove_notification_func = dir_access_remove_callback;
 }

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -53,6 +53,7 @@ class OS_Web : public OS_Unix {
 	WASM_EXPORT static void main_loop_callback();
 
 	WASM_EXPORT static void file_access_close_callback(const String &p_file, int p_flags);
+	WASM_EXPORT static void dir_access_remove_callback(const String &p_file);
 	WASM_EXPORT static void fs_sync_callback();
 	WASM_EXPORT static void update_pwa_state_callback();
 


### PR DESCRIPTION
This PR introduces to `DirAccess` the same concept used by `FileAccess` to update the IndexDB when a file was modified. Now, when unlinking files and removing directories, `DirAccess` notifies `WebOS` of it and the latter can update the DB of deleted files.

Fixes #100217.