### PR TITLE
Capitalize `PRINT_VERBOSE` macro to match other macros

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -177,12 +177,12 @@ Error RemoteDebuggerPeerTCP::_try_connect(Ref<StreamPeerSocket> p_tcp_client) {
 	for (int i = 0; i < tries; i++) {
 		p_tcp_client->poll();
 		if (p_tcp_client->get_status() == StreamPeerTCP::STATUS_CONNECTED) {
-			print_verbose("Remote Debugger: Connected!");
+			PRINT_VERBOSE("Remote Debugger: Connected!");
 			break;
 		} else {
 			const int ms = waits[i];
 			OS::get_singleton()->delay_usec(ms * 1000);
-			print_verbose("Remote Debugger: Connection failed with status: '" + String::num_int64(p_tcp_client->get_status()) + "', retrying in " + String::num_int64(ms) + " msec.");
+			PRINT_VERBOSE("Remote Debugger: Connection failed with status: '" + String::num_int64(p_tcp_client->get_status()) + "', retrying in " + String::num_int64(ms) + " msec.");
 		}
 	}
 

--- a/core/extension/godot_instance.cpp
+++ b/core/extension/godot_instance.cpp
@@ -54,7 +54,7 @@ GodotInstance::~GodotInstance() {
 }
 
 bool GodotInstance::initialize(GDExtensionInitializationFunction p_init_func) {
-	print_verbose("Godot Instance initialization");
+	PRINT_VERBOSE("Godot Instance initialization");
 	GDExtensionManager *gdextension_manager = GDExtensionManager::get_singleton();
 	GDExtensionPtr<const GDExtensionInitializationFunction> ptr((const GDExtensionInitializationFunction *)&p_init_func);
 	GDExtensionManager::LoadStatus status = gdextension_manager->load_extension_from_function("libgodot://main", ptr);
@@ -62,7 +62,7 @@ bool GodotInstance::initialize(GDExtensionInitializationFunction p_init_func) {
 }
 
 bool GodotInstance::start() {
-	print_verbose("GodotInstance::start()");
+	PRINT_VERBOSE("GodotInstance::start()");
 	Error err = Main::setup2();
 	if (err != OK) {
 		return false;
@@ -84,7 +84,7 @@ bool GodotInstance::iteration() {
 }
 
 void GodotInstance::stop() {
-	print_verbose("GodotInstance::stop()");
+	PRINT_VERBOSE("GodotInstance::stop()");
 	if (started) {
 		OS::get_singleton()->get_main_loop()->finalize();
 	}
@@ -92,7 +92,7 @@ void GodotInstance::stop() {
 }
 
 void GodotInstance::focus_out() {
-	print_verbose("GodotInstance::focus_out()");
+	PRINT_VERBOSE("GodotInstance::focus_out()");
 	if (started) {
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_OUT);
@@ -101,7 +101,7 @@ void GodotInstance::focus_out() {
 }
 
 void GodotInstance::focus_in() {
-	print_verbose("GodotInstance::focus_in()");
+	PRINT_VERBOSE("GodotInstance::focus_in()");
 	if (started) {
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_FOCUS_IN);
@@ -110,7 +110,7 @@ void GodotInstance::focus_in() {
 }
 
 void GodotInstance::pause() {
-	print_verbose("GodotInstance::pause()");
+	PRINT_VERBOSE("GodotInstance::pause()");
 	if (started) {
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_PAUSED);
@@ -119,7 +119,7 @@ void GodotInstance::pause() {
 }
 
 void GodotInstance::resume() {
-	print_verbose("GodotInstance::resume()");
+	PRINT_VERBOSE("GodotInstance::resume()");
 	if (started) {
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_RESUMED);

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -2204,7 +2204,7 @@ void Input::parse_mapping(const String &p_mapping) {
 		JoyButton output_button = _get_output_button(output);
 		JoyAxis output_axis = _get_output_axis(output);
 		if (output_button == JoyButton::INVALID && output_axis == JoyAxis::INVALID) {
-			print_verbose(vformat("Unrecognized output string \"%s\" in mapping:\n%s", output, p_mapping));
+			PRINT_VERBOSE(vformat("Unrecognized output string \"%s\" in mapping:\n%s", output, p_mapping));
 			continue;
 		}
 		ERR_CONTINUE_MSG(output_button != JoyButton::INVALID && output_axis != JoyAxis::INVALID,
@@ -2434,7 +2434,7 @@ Input::Input() {
 				continue;
 			}
 
-			print_verbose(vformat("Device Ignored -- Vendor: %s Product: %s", vid_pid[0], vid_pid[1]));
+			PRINT_VERBOSE(vformat("Device Ignored -- Vendor: %s Product: %s", vid_pid[0], vid_pid[1]));
 			const uint16_t vid_unswapped = vid_pid[0].hex_to_int();
 			const uint16_t pid_unswapped = vid_pid[1].hex_to_int();
 			const uint16_t vid = BSWAP16(vid_unswapped);

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -2231,7 +2231,7 @@ void Input::parse_mapping(const String &p_mapping) {
 		JoyButton output_button = _get_output_button(output);
 		JoyAxis output_axis = _get_output_axis(output);
 		if (output_button == JoyButton::INVALID && output_axis == JoyAxis::INVALID) {
-			print_verbose(vformat("Unrecognized output string \"%s\" in mapping:\n%s", output, p_mapping));
+			PRINT_VERBOSE(vformat("Unrecognized output string \"%s\" in mapping:\n%s", output, p_mapping));
 			continue;
 		}
 		ERR_CONTINUE_MSG(output_button != JoyButton::INVALID && output_axis != JoyAxis::INVALID,
@@ -2461,7 +2461,7 @@ Input::Input() {
 				continue;
 			}
 
-			print_verbose(vformat("Device Ignored -- Vendor: %s Product: %s", vid_pid[0], vid_pid[1]));
+			PRINT_VERBOSE(vformat("Device Ignored -- Vendor: %s Product: %s", vid_pid[0], vid_pid[1]));
 			const uint16_t vid_unswapped = vid_pid[0].hex_to_int();
 			const uint16_t pid_unswapped = vid_pid[1].hex_to_int();
 			const uint16_t vid = BSWAP16(vid_unswapped);

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -245,7 +245,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 				magic = f->get_32();
 				if (magic == PACK_HEADER_MAGIC) {
 #ifdef DEBUG_ENABLED
-					print_verbose("PCK header found in executable pck section, loading from offset 0x" + String::num_int64(pck_off - 4, 16));
+					PRINT_VERBOSE("PCK header found in executable pck section, loading from offset 0x" + String::num_int64(pck_off - 4, 16));
 #endif
 					pck_header_found = true;
 					break;
@@ -273,7 +273,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 			magic = f->get_32();
 			if (magic == PACK_HEADER_MAGIC) {
 #ifdef DEBUG_ENABLED
-				print_verbose("PCK header found at the end of executable, loading from offset 0x" + String::num_int64(f->get_position() - 4, 16));
+				PRINT_VERBOSE("PCK header found at the end of executable, loading from offset 0x" + String::num_int64(f->get_position() - 4, 16));
 #endif
 				pck_header_found = true;
 			}

--- a/core/io/file_access_patched.cpp
+++ b/core/io/file_access_patched.cpp
@@ -72,7 +72,7 @@ Error FileAccessPatched::_apply_patch() const {
 
 		uint64_t total_usec_end = OS::get_singleton()->get_ticks_usec();
 
-		print_verbose(vformat(U"Applied delta patch to \"%s\" from \"%s\" in %d μs (%d μs I/O, %d μs decoding).", path, delta_patch.pack.get_file(), total_usec_end - total_usec_start, io_usec_end - io_usec_start, decode_usec_end - decode_usec_start));
+		PRINT_VERBOSE(vformat(U"Applied delta patch to \"%s\" from \"%s\" in %d μs (%d μs I/O, %d μs decoding).", path, delta_patch.pack.get_file(), total_usec_end - total_usec_start, io_usec_end - io_usec_start, decode_usec_end - decode_usec_start));
 	}
 
 	patched_file_data = old_file_data;

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -153,7 +153,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 
 	IPAddress ip = p_host.is_valid_ip_address() ? IPAddress(p_host) : IP::get_singleton()->resolve_hostname(p_host);
 	ERR_FAIL_COND_V_MSG(!ip.is_valid(), ERR_INVALID_PARAMETER, vformat("Unable to resolve remote filesystem server hostname: '%s'.", p_host));
-	print_verbose(vformat("Remote Filesystem: Connecting to host %s, port %d.", ip, p_port));
+	PRINT_VERBOSE(vformat("Remote Filesystem: Connecting to host %s, port %d.", ip, p_port));
 	Error err = tcp_client->connect_to_host(ip, p_port);
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Unable to open connection to remote file server (%s, port %d) failed.", String(p_host), p_port));
 
@@ -167,17 +167,17 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 	}
 
 	// Connection OK, now send the current file state.
-	print_verbose("Remote Filesystem: Connection OK.");
+	PRINT_VERBOSE("Remote Filesystem: Connection OK.");
 
 	// Header (GRFS) - Godot Remote File System
-	print_verbose("Remote Filesystem: Sending header");
+	PRINT_VERBOSE("Remote Filesystem: Sending header");
 	tcp_client->put_u8('G');
 	tcp_client->put_u8('R');
 	tcp_client->put_u8('F');
 	tcp_client->put_u8('S');
 	// Protocol version
 	tcp_client->put_32(FILESYSTEM_PROTOCOL_VERSION);
-	print_verbose("Remote Filesystem: Sending password");
+	PRINT_VERBOSE("Remote Filesystem: Sending password");
 	uint8_t password[PASSWORD_LENGTH]; // Send fixed size password, since it's easier and safe to validate.
 	for (int i = 0; i < PASSWORD_LENGTH; i++) {
 		if (i < p_password.length()) {
@@ -187,7 +187,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 		}
 	}
 	tcp_client->put_data(password, PASSWORD_LENGTH);
-	print_verbose("Remote Filesystem: Tags.");
+	PRINT_VERBOSE("Remote Filesystem: Tags.");
 	Vector<String> tags;
 	{
 		tags.push_back(OS::get_singleton()->get_identifier());
@@ -208,7 +208,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 		tcp_client->put_utf8_string(tags[i]);
 	}
 	// Size of compressed list of files
-	print_verbose("Remote Filesystem: Sending file list");
+	PRINT_VERBOSE("Remote Filesystem: Sending file list");
 
 	Vector<FileCache> file_cache = _load_cache_file();
 
@@ -307,7 +307,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 		new_file_cache.push_back(fc);
 	}
 
-	print_verbose("Remote Filesystem: Updating the cache file.");
+	PRINT_VERBOSE("Remote Filesystem: Updating the cache file.");
 
 	// Go through the list of local files read initially (file_cache) and see which ones are
 	// unchanged (not sent again from the server).
@@ -323,7 +323,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 	err = _store_cache_file(new_file_cache);
 	ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_CANT_OPEN, "Error writing the remote filesystem file cache.");
 
-	print_verbose("Remote Filesystem: Update success.");
+	PRINT_VERBOSE("Remote Filesystem: Update success.");
 
 	_update_cache_path(r_cache_path);
 	return OK;

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -150,7 +150,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 
 	IPAddress ip = p_host.is_valid_ip_address() ? IPAddress(p_host) : IP::get_singleton()->resolve_hostname(p_host);
 	ERR_FAIL_COND_V_MSG(!ip.is_valid(), ERR_INVALID_PARAMETER, vformat("Unable to resolve remote filesystem server hostname: '%s'.", p_host));
-	print_verbose(vformat("Remote Filesystem: Connecting to host %s, port %d.", ip, p_port));
+	PRINT_VERBOSE(vformat("Remote Filesystem: Connecting to host %s, port %d.", ip, p_port));
 	Error err = tcp_client->connect_to_host(ip, p_port);
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Unable to open connection to remote file server (%s, port %d) failed.", String(p_host), p_port));
 
@@ -164,17 +164,17 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 	}
 
 	// Connection OK, now send the current file state.
-	print_verbose("Remote Filesystem: Connection OK.");
+	PRINT_VERBOSE("Remote Filesystem: Connection OK.");
 
 	// Header (GRFS) - Godot Remote File System
-	print_verbose("Remote Filesystem: Sending header");
+	PRINT_VERBOSE("Remote Filesystem: Sending header");
 	tcp_client->put_u8('G');
 	tcp_client->put_u8('R');
 	tcp_client->put_u8('F');
 	tcp_client->put_u8('S');
 	// Protocol version
 	tcp_client->put_32(FILESYSTEM_PROTOCOL_VERSION);
-	print_verbose("Remote Filesystem: Sending password");
+	PRINT_VERBOSE("Remote Filesystem: Sending password");
 	uint8_t password[PASSWORD_LENGTH]; // Send fixed size password, since it's easier and safe to validate.
 	for (int i = 0; i < PASSWORD_LENGTH; i++) {
 		if (i < p_password.length()) {
@@ -184,7 +184,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 		}
 	}
 	tcp_client->put_data(password, PASSWORD_LENGTH);
-	print_verbose("Remote Filesystem: Tags.");
+	PRINT_VERBOSE("Remote Filesystem: Tags.");
 	Vector<String> tags;
 	{
 		tags.push_back(OS::get_singleton()->get_identifier());
@@ -205,7 +205,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 		tcp_client->put_utf8_string(tags[i]);
 	}
 	// Size of compressed list of files
-	print_verbose("Remote Filesystem: Sending file list");
+	PRINT_VERBOSE("Remote Filesystem: Sending file list");
 
 	Vector<FileCache> file_cache = _load_cache_file();
 
@@ -304,7 +304,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 		new_file_cache.push_back(fc);
 	}
 
-	print_verbose("Remote Filesystem: Updating the cache file.");
+	PRINT_VERBOSE("Remote Filesystem: Updating the cache file.");
 
 	// Go through the list of local files read initially (file_cache) and see which ones are
 	// unchanged (not sent again from the server).
@@ -320,7 +320,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 	err = _store_cache_file(new_file_cache);
 	ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_CANT_OPEN, "Error writing the remote filesystem file cache.");
 
-	print_verbose("Remote Filesystem: Update success.");
+	PRINT_VERBOSE("Remote Filesystem: Update success.");
 
 	_update_cache_path(r_cache_path);
 	return OK;

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -77,7 +77,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 		err = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, nullptr, true);
 		if (err == ERR_FILE_EOF) {
 			if (p_load && !path_found && decomp_path_found) {
-				print_verbose(vformat("No natively supported texture format found for %s, using decompressable format %s.", p_path, decomp_path));
+				PRINT_VERBOSE(vformat("No natively supported texture format found for %s, using decompressable format %s.", p_path, decomp_path));
 				r_path_and_type.path = decomp_path;
 			}
 
@@ -123,7 +123,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 	}
 
 	if (p_load && !path_found && decomp_path_found) {
-		print_verbose(vformat("No natively supported texture format found for %s, using decompressable format %s.", p_path, decomp_path));
+		PRINT_VERBOSE(vformat("No natively supported texture format found for %s, using decompressable format %s.", p_path, decomp_path));
 		r_path_and_type.path = decomp_path;
 		return OK;
 	}

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -276,7 +276,7 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 	const String &original_path = p_original_path.is_empty() ? p_path : p_original_path;
 	load_nesting++;
 
-	print_verbose(vformat("Loading resource: %s remapped: %s", p_path, _path_remap(p_path)));
+	PRINT_VERBOSE(vformat("Loading resource: %s remapped: %s", p_path, _path_remap(p_path)));
 
 	// Try all loaders and pick the first match for the type hint
 	bool found = false;
@@ -298,7 +298,7 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 	if (res.is_valid()) {
 		return res;
 	} else {
-		print_verbose(vformat("Failed loading resource: %s", p_path));
+		PRINT_VERBOSE(vformat("Failed loading resource: %s", p_path));
 	}
 
 #ifdef TOOLS_ENABLED
@@ -443,7 +443,7 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 					}
 
 					if (lowest_waiting == thread_index) {
-						print_verbose(
+						PRINT_VERBOSE(
 								vformat("CYCLE: Stealing on thread %d for resource '%s' originally on thread %d",
 										thread_index, load_task.local_path, waiting_on_task->thread_index));
 						// Take over the task. The original thread was definitely
@@ -683,7 +683,7 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 
 	curr_load_task = curr_load_task_backup;
 
-	print_verbose(vformat("Completed load for: '%s' remapped '%s' at thread %d", load_task.local_path, remapped_path, thread_index));
+	PRINT_VERBOSE(vformat("Completed load for: '%s' remapped '%s' at thread %d", load_task.local_path, remapped_path, thread_index));
 }
 
 String ResourceLoader::_validate_local_path(const String &p_path) {
@@ -705,7 +705,7 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 ResourceLoader::LoadToken *ResourceLoader::_load_threaded_request_reuse_user_token(const String &p_path) {
 	HashMap<String, LoadToken *>::Iterator E = user_load_tokens.find(p_path);
 	if (E) {
-		print_verbose("load_threaded_request(): Another threaded load for resource path '" + p_path + "' has been initiated. Not an error.");
+		PRINT_VERBOSE("load_threaded_request(): Another threaded load for resource path '" + p_path + "' has been initiated. Not an error.");
 		LoadToken *token = E->value;
 		token->user_rc++;
 		return token;
@@ -891,7 +891,7 @@ ResourceLoader::ThreadLoadStatus ResourceLoader::load_threaded_get_status(const 
 		MutexLock thread_load_lock(thread_load_mutex);
 
 		if (!user_load_tokens.has(p_path)) {
-			print_verbose("load_threaded_get_status(): No threaded load for resource path '" + p_path + "' has been initiated or its result has already been collected.");
+			PRINT_VERBOSE("load_threaded_get_status(): No threaded load for resource path '" + p_path + "' has been initiated or its result has already been collected.");
 			return THREAD_LOAD_INVALID_RESOURCE;
 		}
 
@@ -939,7 +939,7 @@ Ref<Resource> ResourceLoader::load_threaded_get(const String &p_path, Error *r_e
 		MutexLock thread_load_lock(thread_load_mutex);
 
 		if (!user_load_tokens.has(p_path)) {
-			print_verbose("load_threaded_get(): No threaded load for resource path '" + p_path + "' has been initiated or its result has already been collected.");
+			PRINT_VERBOSE("load_threaded_get(): No threaded load for resource path '" + p_path + "' has been initiated or its result has already been collected.");
 			if (r_error) {
 				*r_error = ERR_INVALID_PARAMETER;
 			}

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -364,7 +364,7 @@ WorkerThreadPool::TaskID WorkerThreadPool::_add_task(const Callable &p_callable,
 		pump_task_count++;
 		int thread_count = get_thread_count();
 		if (pump_task_count >= thread_count) {
-			print_verbose(vformat("A greater number of dedicated threads were requested (%d) than threads available (%d). Please increase the number of available worker task threads. Recovering this session by spawning more worker task threads.", pump_task_count + 1, thread_count)); // +1 because we want to keep a Thread without any pump tasks free.
+			PRINT_VERBOSE(vformat("A greater number of dedicated threads were requested (%d) than threads available (%d). Please increase the number of available worker task threads. Recovering this session by spawning more worker task threads.", pump_task_count + 1, thread_count)); // +1 because we want to keep a Thread without any pump tasks free.
 
 			// Re-sizing implies relocation, which is not supported for this array.
 			CRASH_COND_MSG(thread_count + 1 > (int)threads.get_capacity(), "Reserve trick for worker thread pool failed. Crashing.");
@@ -817,7 +817,7 @@ void WorkerThreadPool::init(int p_thread_count, float p_low_priority_task_ratio)
 
 	max_low_priority_threads = CLAMP(p_thread_count * p_low_priority_task_ratio, 1, p_thread_count - 1);
 
-	print_verbose(vformat("WorkerThreadPool: %d threads, %d max low-priority.", p_thread_count, max_low_priority_threads));
+	PRINT_VERBOSE(vformat("WorkerThreadPool: %d threads, %d max low-priority.", p_thread_count, max_low_priority_threads));
 
 #ifdef THREADS_ENABLED
 	// Reserve 5 threads in case we need separate threads for 1) 2D physics 2) 3D physics 3) rendering 4) GPU texture compression, 5) all other tasks.

--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -58,12 +58,15 @@ extern void print_error(const String &p_string);
 extern bool is_print_verbose_enabled();
 
 // This version avoids processing the text to be printed until it actually has to be printed, saving some CPU usage.
-#define print_verbose(m_text) \
+#define PRINT_VERBOSE(m_text) \
 	{ \
 		if (is_print_verbose_enabled()) { \
 			print_line(m_text); \
 		} \
 	}
+
+// For compatibility, and for parity with the print_line() function, also provide as lowercase.
+#define print_verbose PRINT_VERBOSE
 
 template <typename... Args>
 void print_line(Args... p_args) {

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -103,7 +103,7 @@ void StringName::cleanup() {
 		}
 	}
 	if (lost_strings) {
-		print_verbose(vformat("StringName: %d unclaimed string names at exit.", lost_strings));
+		PRINT_VERBOSE(vformat("StringName: %d unclaimed string names at exit.", lost_strings));
 	}
 	configured = false;
 }

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -970,7 +970,7 @@ void VariantUtilityFunctions::print_rich(const Variant **p_args, int p_arg_count
 
 void VariantUtilityFunctions::_print_verbose(const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 	if (OS::get_singleton()->is_stdout_verbose()) {
-		// No need p_to use `print_verbose()` as this call already only happens
+		// No need to use `PRINT_VERBOSE()` as this call already only happens
 		// when verbose mode is enabled. This avoids performing string argument concatenation
 		// when not needed.
 		print_line(join_string(p_args, p_arg_count));

--- a/drivers/accesskit/accessibility_server_accesskit.cpp
+++ b/drivers/accesskit/accessibility_server_accesskit.cpp
@@ -67,7 +67,7 @@ bool AccessibilityServerAccessKit::window_create(DisplayServerEnums::WindowID p_
 #ifdef LINUXBSD_ENABLED
 	wd.adapter = accesskit_unix_adapter_new(&_accessibility_initial_tree_update_callback, (void *)(size_t)p_window_id, &_accessibility_action_callback, (void *)(size_t)p_window_id, &_accessibility_deactivation_callback, (void *)(size_t)p_window_id);
 #endif
-	print_verbose(vformat("Accessibility: window %d adapter created.", p_window_id));
+	PRINT_VERBOSE(vformat("Accessibility: window %d adapter created.", p_window_id));
 
 	if (wd.adapter == nullptr) {
 		memdelete(ae);
@@ -84,7 +84,7 @@ void AccessibilityServerAccessKit::window_destroy(DisplayServerEnums::WindowID p
 	WindowData *wd = windows.getptr(p_window_id);
 	ERR_FAIL_NULL(wd);
 
-	print_verbose(vformat("Accessibility: window %d adapter destroyed.", p_window_id));
+	PRINT_VERBOSE(vformat("Accessibility: window %d adapter destroyed.", p_window_id));
 
 #ifdef WINDOWS_ENABLED
 	accesskit_windows_subclassing_adapter_free(wd->adapter);
@@ -105,7 +105,7 @@ void AccessibilityServerAccessKit::_accessibility_deactivation_callback(void *p_
 	WindowData *wd = static_cast<AccessibilityServerAccessKit *>(get_singleton())->windows.getptr(window_id);
 	ERR_FAIL_NULL(wd);
 
-	print_verbose(vformat("Accessibility: window %d adapter deactivated.", window_id));
+	PRINT_VERBOSE(vformat("Accessibility: window %d adapter deactivated.", window_id));
 
 	if (static_cast<AccessibilityServerAccessKit *>(get_singleton())->focus.is_valid()) {
 		AccessibilityElement *ae = static_cast<AccessibilityServerAccessKit *>(get_singleton())->rid_owner.get_or_null(static_cast<AccessibilityServerAccessKit *>(get_singleton())->focus);
@@ -229,7 +229,7 @@ accesskit_tree_update *AccessibilityServerAccessKit::_accessibility_initial_tree
 	accesskit_tree_update_set_tree(tree_update, accesskit_tree_new(win_id));
 	accesskit_tree_update_push_node(tree_update, win_id, win_node);
 
-	print_verbose(vformat("Accessibility: window %d adapter activated.", window_id));
+	PRINT_VERBOSE(vformat("Accessibility: window %d adapter activated.", window_id));
 
 	if (wd->activate.is_valid()) {
 		wd->activate.call_deferred(); // Should be called on main thread only.
@@ -253,7 +253,7 @@ void AccessibilityServerAccessKit::window_activation_completed(DisplayServerEnum
 		return;
 	}
 
-	print_verbose(vformat("Accessibility: window %d adapter initial update completed.", p_window_id));
+	PRINT_VERBOSE(vformat("Accessibility: window %d adapter initial update completed.", p_window_id));
 
 	wd->initial_update_completed = true;
 }
@@ -264,7 +264,7 @@ void AccessibilityServerAccessKit::window_deactivation_completed(DisplayServerEn
 		return;
 	}
 
-	print_verbose(vformat("Accessibility: window %d adapter deactivation completed.", p_window_id));
+	PRINT_VERBOSE(vformat("Accessibility: window %d adapter deactivation completed.", p_window_id));
 
 #ifdef DEV_ENABLED
 	LocalVector<RID> to_delete;
@@ -1701,7 +1701,7 @@ void AccessibilityServerAccessKit::update_set_foreground_color(const RID &p_id, 
 }
 
 AccessibilityServer *AccessibilityServerAccessKit::create_func(Error &r_error) {
-	print_verbose("Accessibility: AccessKit driver loaded.");
+	PRINT_VERBOSE("Accessibility: AccessKit driver loaded.");
 	r_error = OK;
 	return memnew(AccessibilityServerAccessKit);
 }

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -130,7 +130,7 @@ Error AudioDriverALSA::init_output_device() {
 	status = snd_pcm_hw_params_set_period_size_near(pcm_handle, hwparams, &period_size, nullptr);
 	CHECK_FAIL(status < 0);
 
-	print_verbose("Audio buffer frames: " + itos(period_size) + " calculated latency: " + itos(period_size * 1000 / mix_rate) + "ms");
+	PRINT_VERBOSE("Audio buffer frames: " + itos(period_size) + " calculated latency: " + itos(period_size * 1000 / mix_rate) + "ms");
 
 	status = snd_pcm_hw_params_set_periods_near(pcm_handle, hwparams, &periods, nullptr);
 	CHECK_FAIL(status < 0);
@@ -183,9 +183,9 @@ Error AudioDriverALSA::init() {
 	if (ver_parts.size() >= 2) {
 		ver_ok = ((ver_parts[0].to_int() == 1 && ver_parts[1].to_int() >= 1)) || (ver_parts[0].to_int() > 1); // 1.1.0
 	}
-	print_verbose(vformat("ALSA %s detected.", version));
+	PRINT_VERBOSE(vformat("ALSA %s detected.", version));
 	if (!ver_ok) {
-		print_verbose("Unsupported ALSA library version!");
+		PRINT_VERBOSE("Unsupported ALSA library version!");
 		return ERR_CANT_OPEN;
 	}
 

--- a/drivers/apple_embedded/apple_embedded.mm
+++ b/drivers/apple_embedded/apple_embedded.mm
@@ -194,7 +194,7 @@ String AppleEmbedded::get_rate_url(int p_app_id) const {
 
 	String ret = app_url_path.replace("APP_ID", String::num_int64(p_app_id));
 
-	print_verbose(vformat("Returning rate url %s", ret));
+	PRINT_VERBOSE(vformat("Returning rate url %s", ret));
 	return ret;
 }
 

--- a/drivers/apple_embedded/apple_embedded.mm
+++ b/drivers/apple_embedded/apple_embedded.mm
@@ -204,7 +204,7 @@ String AppleEmbedded::get_rate_url(int p_app_id) const {
 
 	String ret = app_url_path.replace("APP_ID", String::num_int64(p_app_id));
 
-	print_verbose(vformat("Returning rate url %s", ret));
+	PRINT_VERBOSE(vformat("Returning rate url %s", ret));
 	return ret;
 }
 

--- a/drivers/apple_embedded/godot_view_apple_embedded.mm
+++ b/drivers/apple_embedded/godot_view_apple_embedded.mm
@@ -179,7 +179,7 @@ static const float earth_gravity = 9.80665;
 
 	self.isActive = NO;
 
-	print_verbose("Stop animation!");
+	PRINT_VERBOSE("Stop animation!");
 
 	if (self.useCADisplayLink) {
 		[self.displayLink invalidate];
@@ -199,7 +199,7 @@ static const float earth_gravity = 9.80665;
 
 	self.isActive = YES;
 
-	print_verbose("Start animation!");
+	PRINT_VERBOSE("Start animation!");
 
 	if (self.useCADisplayLink) {
 		self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(drawView)];
@@ -214,7 +214,7 @@ static const float earth_gravity = 9.80665;
 
 - (void)drawView {
 	if (!self.isActive) {
-		print_verbose("Draw view not active!");
+		PRINT_VERBOSE("Draw view not active!");
 		return;
 	}
 

--- a/drivers/apple_embedded/godot_view_apple_embedded.mm
+++ b/drivers/apple_embedded/godot_view_apple_embedded.mm
@@ -179,7 +179,7 @@ static const float earth_gravity = 9.80665;
 
 	self.isActive = NO;
 
-	print_verbose("Stop rendering");
+	PRINT_VERBOSE("Stop rendering");
 
 	if (self.useCADisplayLink) {
 		[self.displayLink invalidate];
@@ -199,7 +199,7 @@ static const float earth_gravity = 9.80665;
 
 	self.isActive = YES;
 
-	print_verbose("Start rendering");
+	PRINT_VERBOSE("Start rendering");
 
 	if (self.useCADisplayLink) {
 		self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(drawView)];
@@ -214,7 +214,7 @@ static const float earth_gravity = 9.80665;
 
 - (void)drawView {
 	if (!self.isActive) {
-		print_verbose("Draw view not active!");
+		PRINT_VERBOSE("Draw view not active!");
 		return;
 	}
 

--- a/drivers/apple_embedded/godot_view_controller.mm
+++ b/drivers/apple_embedded/godot_view_controller.mm
@@ -157,7 +157,7 @@
 
 - (void)didReceiveMemoryWarning {
 	[super didReceiveMemoryWarning];
-	print_verbose("Did receive memory warning!");
+	PRINT_VERBOSE("Did receive memory warning!");
 }
 
 - (void)viewDidLoad {
@@ -183,11 +183,11 @@
 }
 
 - (void)observeKeyboard {
-	print_verbose("Setting up keyboard input view.");
+	PRINT_VERBOSE("Setting up keyboard input view.");
 	self.keyboardView = [GDTKeyboardInputView new];
 	[self.view addSubview:self.keyboardView];
 
-	print_verbose("Adding observer for keyboard show/hide.");
+	PRINT_VERBOSE("Adding observer for keyboard show/hide.");
 	[[NSNotificationCenter defaultCenter]
 			addObserver:self
 			   selector:@selector(keyboardOnScreen:)

--- a/drivers/apple_embedded/os_apple_embedded.mm
+++ b/drivers/apple_embedded/os_apple_embedded.mm
@@ -386,7 +386,7 @@ Error OS_AppleEmbedded::shell_open(const String &p_uri) {
 		return ERR_CANT_OPEN;
 	}
 
-	print_verbose(vformat("Opening URL %s", p_uri));
+	PRINT_VERBOSE(vformat("Opening URL %s", p_uri));
 
 	[[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 

--- a/drivers/apple_embedded/tts_apple_embedded.mm
+++ b/drivers/apple_embedded/tts_apple_embedded.mm
@@ -39,7 +39,7 @@
 	self->speaking = false;
 	self->av_synth = [[AVSpeechSynthesizer alloc] init];
 	[self->av_synth setDelegate:self];
-	print_verbose("Text-to-Speech: AVSpeechSynthesizer initialized.");
+	PRINT_VERBOSE("Text-to-Speech: AVSpeechSynthesizer initialized.");
 	return self;
 }
 

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -167,9 +167,9 @@ Error AudioDriverCoreAudio::init() {
 	unsigned int buffer_size = buffer_frames * channels;
 	samples_in.resize(buffer_size);
 
-	print_verbose("CoreAudio: detected " + itos(channels) + " channels");
-	print_verbose("CoreAudio: output sampling rate: " + itos(mix_rate) + " Hz");
-	print_verbose("CoreAudio: output audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
+	PRINT_VERBOSE("CoreAudio: detected " + itos(channels) + " channels");
+	PRINT_VERBOSE("CoreAudio: output sampling rate: " + itos(mix_rate) + " Hz");
+	PRINT_VERBOSE("CoreAudio: output audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	AURenderCallbackStruct callback;
 	memset(&callback, 0, sizeof(AURenderCallbackStruct));
@@ -477,8 +477,8 @@ Error AudioDriverCoreAudio::init_input_device() {
 	result = AudioUnitInitialize(input_unit);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 
-	print_verbose("CoreAudio: input sampling rate: " + itos(capture_mix_rate) + " Hz");
-	print_verbose("CoreAudio: input audio buffer frames: " + itos(capture_buffer_frames) + " calculated latency: " + itos(capture_buffer_frames * 1000 / capture_mix_rate) + "ms");
+	PRINT_VERBOSE("CoreAudio: input sampling rate: " + itos(capture_mix_rate) + " Hz");
+	PRINT_VERBOSE("CoreAudio: input audio buffer frames: " + itos(capture_buffer_frames) + " calculated latency: " + itos(capture_buffer_frames * 1000 / capture_mix_rate) + "ms");
 
 	return OK;
 }

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -167,9 +167,9 @@ Error AudioDriverCoreAudio::init() {
 	unsigned int buffer_size = buffer_frames * channels;
 	samples_in.resize(buffer_size);
 
-	print_verbose("CoreAudio: detected " + itos(channels) + " channels");
-	print_verbose("CoreAudio: output sampling rate: " + itos(mix_rate) + " Hz");
-	print_verbose("CoreAudio: output audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
+	PRINT_VERBOSE("CoreAudio: detected " + itos(channels) + " channels");
+	PRINT_VERBOSE("CoreAudio: output sampling rate: " + itos(mix_rate) + " Hz");
+	PRINT_VERBOSE("CoreAudio: output audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	AURenderCallbackStruct callback;
 	memset(&callback, 0, sizeof(AURenderCallbackStruct));
@@ -487,8 +487,8 @@ Error AudioDriverCoreAudio::init_input_device() {
 	result = AudioUnitInitialize(input_unit);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 
-	print_verbose("CoreAudio: input sampling rate: " + itos(capture_mix_rate) + " Hz");
-	print_verbose("CoreAudio: input audio buffer frames: " + itos(capture_buffer_frames) + " calculated latency: " + itos(capture_buffer_frames * 1000 / capture_mix_rate) + "ms");
+	PRINT_VERBOSE("CoreAudio: input sampling rate: " + itos(capture_mix_rate) + " Hz");
+	PRINT_VERBOSE("CoreAudio: input audio buffer frames: " + itos(capture_buffer_frames) + " calculated latency: " + itos(capture_buffer_frames * 1000 / capture_mix_rate) + "ms");
 
 	return OK;
 }

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -521,7 +521,7 @@ void RenderingDeviceDriverD3D12::_debug_message_func(D3D12_MESSAGE_CATEGORY p_ca
 	// Convert D3D12 severity to our own log macros.
 	switch (p_severity) {
 		case D3D12_MESSAGE_SEVERITY_MESSAGE:
-			print_verbose(error_message);
+			PRINT_VERBOSE(error_message);
 			break;
 		case D3D12_MESSAGE_SEVERITY_INFO:
 			print_line(error_message);
@@ -2504,7 +2504,7 @@ Error RenderingDeviceDriverD3D12::command_queue_execute_and_present(CommandQueue
 		SwapChain *swap_chain = (SwapChain *)(p_swap_chains[i].id);
 		res = swap_chain->d3d_swap_chain->Present(swap_chain->sync_interval, swap_chain->present_flags);
 		if (!SUCCEEDED(res)) {
-			print_verbose(vformat("D3D12: Presenting swapchain failed with error 0x%08ux.", (uint64_t)res));
+			PRINT_VERBOSE(vformat("D3D12: Presenting swapchain failed with error 0x%08ux.", (uint64_t)res));
 			any_present_failed = true;
 		}
 	}
@@ -6152,8 +6152,8 @@ Error RenderingDeviceDriverD3D12::_check_capabilities() {
 		ERR_FAIL_COND_V_MSG(shader_capabilities.shader_model < SMS_TO_CHECK[ARRAY_SIZE(SMS_TO_CHECK) - 1], ERR_UNAVAILABLE,
 				vformat("No support for any of the suitable shader models (%s-%s) has been found.", D3D_SHADER_MODEL_TO_STRING(SMS_TO_CHECK[ARRAY_SIZE(SMS_TO_CHECK) - 1]), D3D_SHADER_MODEL_TO_STRING(SMS_TO_CHECK[0])));
 
-		print_verbose("- Shader:");
-		print_verbose("  model: " + D3D_SHADER_MODEL_TO_STRING(shader_capabilities.shader_model));
+		PRINT_VERBOSE("- Shader:");
+		PRINT_VERBOSE("  model: " + D3D_SHADER_MODEL_TO_STRING(shader_capabilities.shader_model));
 	}
 
 	shader_container_format.set_lib_d3d12(context_driver->lib_d3d12);
@@ -6224,48 +6224,48 @@ Error RenderingDeviceDriverD3D12::_check_capabilities() {
 	}
 
 	if (fsr_capabilities.pipeline_supported || fsr_capabilities.primitive_supported || fsr_capabilities.attachment_supported) {
-		print_verbose("- D3D12 Variable Rate Shading supported:");
+		PRINT_VERBOSE("- D3D12 Variable Rate Shading supported:");
 		if (fsr_capabilities.pipeline_supported) {
-			print_verbose("  Draw call");
+			PRINT_VERBOSE("  Draw call");
 		}
 		if (fsr_capabilities.primitive_supported) {
-			print_verbose("  Primitive");
+			PRINT_VERBOSE("  Primitive");
 		}
 		if (fsr_capabilities.attachment_supported) {
-			print_verbose(String("  Screen-space image (tile size: ") + itos(fsr_capabilities.min_texel_size.x) + ")");
+			PRINT_VERBOSE(String("  Screen-space image (tile size: ") + itos(fsr_capabilities.min_texel_size.x) + ")");
 		}
 	} else {
-		print_verbose("- D3D12 Variable Rate Shading not supported");
+		PRINT_VERBOSE("- D3D12 Variable Rate Shading not supported");
 	}
 
 	if (multiview_capabilities.is_supported) {
-		print_verbose("- D3D12 multiview supported:");
-		print_verbose("  max view count: " + itos(multiview_capabilities.max_view_count));
-		//print_verbose("  max instances: " + itos(multiview_capabilities.max_instance_count)); // Hardcoded; not very useful at the moment.
+		PRINT_VERBOSE("- D3D12 multiview supported:");
+		PRINT_VERBOSE("  max view count: " + itos(multiview_capabilities.max_view_count));
+		//PRINT_VERBOSE("  max instances: " + itos(multiview_capabilities.max_instance_count)); // Hardcoded; not very useful at the moment.
 	} else {
-		print_verbose("- D3D12 multiview not supported");
+		PRINT_VERBOSE("- D3D12 multiview not supported");
 	}
 
 	if (format_capabilities.relaxed_casting_supported) {
 #if 0
-		print_verbose("- Relaxed casting supported");
+		PRINT_VERBOSE("- Relaxed casting supported");
 #else
 		// Certain configurations (Windows 11 with an updated NVIDIA driver) crash when using relaxed casting.
 		// Therefore, we disable it temporarily until we can assure that it's reliable.
 		// There are fallbacks in place that work in every case, if less efficient.
 		format_capabilities.relaxed_casting_supported = false;
-		print_verbose("- Relaxed casting supported (but disabled for now)");
+		PRINT_VERBOSE("- Relaxed casting supported (but disabled for now)");
 #endif
 	} else {
-		print_verbose("- Relaxed casting not supported");
+		PRINT_VERBOSE("- Relaxed casting not supported");
 	}
 
-	print_verbose(String("- D3D12 16-bit ops supported: ") + (shader_capabilities.native_16bit_ops ? "yes" : "no"));
+	PRINT_VERBOSE(String("- D3D12 16-bit ops supported: ") + (shader_capabilities.native_16bit_ops ? "yes" : "no"));
 
 	if (misc_features_support.depth_bounds_supported) {
-		print_verbose("- Depth bounds test supported");
+		PRINT_VERBOSE("- Depth bounds test supported");
 	} else {
-		print_verbose("- Depth bounds test not supported");
+		PRINT_VERBOSE("- Depth bounds test not supported");
 	}
 
 	return OK;
@@ -6297,7 +6297,7 @@ Error RenderingDeviceDriverD3D12::_get_device_limits() {
 
 	res = unused_command_queue->GetTimestampFrequency(&device_limits.timestamp_frequency);
 	if (!SUCCEEDED(res)) {
-		print_verbose("D3D12: GetTimestampFrequency failed with error " + vformat("0x%08ux", (uint64_t)res) + ". Timestamps will be inaccurate.");
+		PRINT_VERBOSE("D3D12: GetTimestampFrequency failed with error " + vformat("0x%08ux", (uint64_t)res) + ". Timestamps will be inaccurate.");
 	}
 
 	return OK;
@@ -6314,12 +6314,12 @@ Error RenderingDeviceDriverD3D12::_initialize_allocator() {
 
 	if (allocator->IsGPUUploadHeapSupported()) {
 		dynamic_persistent_upload_heap = D3D12_HEAP_TYPE_GPU_UPLOAD;
-		print_verbose("D3D12: Device supports GPU UPLOAD heap.");
+		PRINT_VERBOSE("D3D12: Device supports GPU UPLOAD heap.");
 	} else {
 		dynamic_persistent_upload_heap = D3D12_HEAP_TYPE_UPLOAD;
 		// Print it as a warning (instead of verbose) because in the rare chance this lesser-used code path
 		// causes bugs, we get an inkling of what's going on (i.e. in order to repro bugs locally).
-		print_verbose("D3D12: Device does NOT support GPU UPLOAD heap. ReBAR must be enabled for this feature. Regular UPLOAD heaps will be used as fallback.");
+		PRINT_VERBOSE("D3D12: Device does NOT support GPU UPLOAD heap. ReBAR must be enabled for this feature. Regular UPLOAD heaps will be used as fallback.");
 	}
 
 	return OK;

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -522,7 +522,7 @@ void RenderingDeviceDriverD3D12::_debug_message_func(D3D12_MESSAGE_CATEGORY p_ca
 	// Convert D3D12 severity to our own log macros.
 	switch (p_severity) {
 		case D3D12_MESSAGE_SEVERITY_MESSAGE:
-			print_verbose(error_message);
+			PRINT_VERBOSE(error_message);
 			break;
 		case D3D12_MESSAGE_SEVERITY_INFO:
 			print_line(error_message);
@@ -2656,7 +2656,7 @@ Error RenderingDeviceDriverD3D12::command_queue_execute_and_present(CommandQueue
 		SwapChain *swap_chain = (SwapChain *)(p_swap_chains[i].id);
 		res = swap_chain->d3d_swap_chain->Present(swap_chain->sync_interval, swap_chain->present_flags);
 		if (!SUCCEEDED(res)) {
-			print_verbose(vformat("D3D12: Presenting swapchain failed with error 0x%08ux.", (uint64_t)res));
+			PRINT_VERBOSE(vformat("D3D12: Presenting swapchain failed with error 0x%08ux.", (uint64_t)res));
 			any_present_failed = true;
 		}
 	}
@@ -6371,8 +6371,8 @@ Error RenderingDeviceDriverD3D12::_check_capabilities() {
 		ERR_FAIL_COND_V_MSG(shader_capabilities.shader_model < SMS_TO_CHECK[ARRAY_SIZE(SMS_TO_CHECK) - 1], ERR_UNAVAILABLE,
 				vformat("No support for any of the suitable shader models (%s-%s) has been found.", D3D_SHADER_MODEL_TO_STRING(SMS_TO_CHECK[ARRAY_SIZE(SMS_TO_CHECK) - 1]), D3D_SHADER_MODEL_TO_STRING(SMS_TO_CHECK[0])));
 
-		print_verbose("- Shader:");
-		print_verbose("  model: " + D3D_SHADER_MODEL_TO_STRING(shader_capabilities.shader_model));
+		PRINT_VERBOSE("- Shader:");
+		PRINT_VERBOSE("  model: " + D3D_SHADER_MODEL_TO_STRING(shader_capabilities.shader_model));
 	}
 
 	shader_container_format.set_lib_d3d12(context_driver->lib_d3d12);
@@ -6443,48 +6443,48 @@ Error RenderingDeviceDriverD3D12::_check_capabilities() {
 	}
 
 	if (fsr_capabilities.pipeline_supported || fsr_capabilities.primitive_supported || fsr_capabilities.attachment_supported) {
-		print_verbose("- D3D12 Variable Rate Shading supported:");
+		PRINT_VERBOSE("- D3D12 Variable Rate Shading supported:");
 		if (fsr_capabilities.pipeline_supported) {
-			print_verbose("  Draw call");
+			PRINT_VERBOSE("  Draw call");
 		}
 		if (fsr_capabilities.primitive_supported) {
-			print_verbose("  Primitive");
+			PRINT_VERBOSE("  Primitive");
 		}
 		if (fsr_capabilities.attachment_supported) {
-			print_verbose(String("  Screen-space image (tile size: ") + itos(fsr_capabilities.min_texel_size.x) + ")");
+			PRINT_VERBOSE(String("  Screen-space image (tile size: ") + itos(fsr_capabilities.min_texel_size.x) + ")");
 		}
 	} else {
-		print_verbose("- D3D12 Variable Rate Shading not supported");
+		PRINT_VERBOSE("- D3D12 Variable Rate Shading not supported");
 	}
 
 	if (multiview_capabilities.is_supported) {
-		print_verbose("- D3D12 multiview supported:");
-		print_verbose("  max view count: " + itos(multiview_capabilities.max_view_count));
-		//print_verbose("  max instances: " + itos(multiview_capabilities.max_instance_count)); // Hardcoded; not very useful at the moment.
+		PRINT_VERBOSE("- D3D12 multiview supported:");
+		PRINT_VERBOSE("  max view count: " + itos(multiview_capabilities.max_view_count));
+		//PRINT_VERBOSE("  max instances: " + itos(multiview_capabilities.max_instance_count)); // Hardcoded; not very useful at the moment.
 	} else {
-		print_verbose("- D3D12 multiview not supported");
+		PRINT_VERBOSE("- D3D12 multiview not supported");
 	}
 
 	if (format_capabilities.relaxed_casting_supported) {
 #if 0
-		print_verbose("- Relaxed casting supported");
+		PRINT_VERBOSE("- Relaxed casting supported");
 #else
 		// Certain configurations (Windows 11 with an updated NVIDIA driver) crash when using relaxed casting.
 		// Therefore, we disable it temporarily until we can assure that it's reliable.
 		// There are fallbacks in place that work in every case, if less efficient.
 		format_capabilities.relaxed_casting_supported = false;
-		print_verbose("- Relaxed casting supported (but disabled for now)");
+		PRINT_VERBOSE("- Relaxed casting supported (but disabled for now)");
 #endif
 	} else {
-		print_verbose("- Relaxed casting not supported");
+		PRINT_VERBOSE("- Relaxed casting not supported");
 	}
 
-	print_verbose(String("- D3D12 16-bit ops supported: ") + (shader_capabilities.native_16bit_ops ? "yes" : "no"));
+	PRINT_VERBOSE(String("- D3D12 16-bit ops supported: ") + (shader_capabilities.native_16bit_ops ? "yes" : "no"));
 
 	if (misc_features_support.depth_bounds_supported) {
-		print_verbose("- Depth bounds test supported");
+		PRINT_VERBOSE("- Depth bounds test supported");
 	} else {
-		print_verbose("- Depth bounds test not supported");
+		PRINT_VERBOSE("- Depth bounds test not supported");
 	}
 
 	return OK;
@@ -6516,7 +6516,7 @@ Error RenderingDeviceDriverD3D12::_get_device_limits() {
 
 	res = unused_command_queue->GetTimestampFrequency(&device_limits.timestamp_frequency);
 	if (!SUCCEEDED(res)) {
-		print_verbose("D3D12: GetTimestampFrequency failed with error " + vformat("0x%08ux", (uint64_t)res) + ". Timestamps will be inaccurate.");
+		PRINT_VERBOSE("D3D12: GetTimestampFrequency failed with error " + vformat("0x%08ux", (uint64_t)res) + ". Timestamps will be inaccurate.");
 	}
 
 	return OK;
@@ -6533,12 +6533,12 @@ Error RenderingDeviceDriverD3D12::_initialize_allocator() {
 
 	if (allocator->IsGPUUploadHeapSupported()) {
 		dynamic_persistent_upload_heap = D3D12_HEAP_TYPE_GPU_UPLOAD;
-		print_verbose("D3D12: Device supports GPU UPLOAD heap.");
+		PRINT_VERBOSE("D3D12: Device supports GPU UPLOAD heap.");
 	} else {
 		dynamic_persistent_upload_heap = D3D12_HEAP_TYPE_UPLOAD;
 		// Print it as a warning (instead of verbose) because in the rare chance this lesser-used code path
 		// causes bugs, we get an inkling of what's going on (i.e. in order to repro bugs locally).
-		print_verbose("D3D12: Device does NOT support GPU UPLOAD heap. ReBAR must be enabled for this feature. Regular UPLOAD heaps will be used as fallback.");
+		PRINT_VERBOSE("D3D12: Device does NOT support GPU UPLOAD heap. ReBAR must be enabled for this feature. Regular UPLOAD heaps will be used as fallback.");
 	}
 
 	misc_features_support.uma_supported = allocator->IsUMA();

--- a/drivers/d3d12/rendering_shader_container_d3d12.cpp
+++ b/drivers/d3d12/rendering_shader_container_d3d12.cpp
@@ -472,7 +472,7 @@ bool RenderingShaderContainerD3D12::_convert_nir_to_dxil(const HashMap<int, nir_
 		dxil_logger logger = {};
 		logger.log = [](void *p_priv, const char *p_msg) {
 #ifdef DEBUG_ENABLED
-			print_verbose(p_msg);
+			PRINT_VERBOSE(p_msg);
 #endif
 		};
 

--- a/drivers/d3d12/rendering_shader_container_d3d12.cpp
+++ b/drivers/d3d12/rendering_shader_container_d3d12.cpp
@@ -477,7 +477,7 @@ bool RenderingShaderContainerD3D12::_convert_nir_to_dxil(const HashMap<int, nir_
 		dxil_logger logger = {};
 		logger.log = [](void *p_priv, const char *p_msg) {
 #ifdef DEBUG_ENABLED
-			print_verbose(p_msg);
+			PRINT_VERBOSE(p_msg);
 #endif
 		};
 

--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -142,7 +142,7 @@ int EGLManager::_get_gldisplay_id(void *p_display) {
 
 		if (egl_extensions.has("EGL_ANGLE_surface_orientation")) {
 			new_gldisplay.has_EGL_ANGLE_surface_orientation = true;
-			print_verbose("EGL: EGL_ANGLE_surface_orientation is supported.");
+			PRINT_VERBOSE("EGL: EGL_ANGLE_surface_orientation is supported.");
 		}
 	}
 #endif
@@ -309,7 +309,7 @@ Error EGLManager::window_create(DisplayServerEnums::WindowID p_window_id, void *
 		if (eglQuerySurface(gldisplay.egl_display, glwindow.egl_surface, EGL_SURFACE_ORIENTATION_ANGLE, &orientation)) {
 			if (orientation & EGL_SURFACE_ORIENTATION_INVERT_Y_ANGLE && !(orientation & EGL_SURFACE_ORIENTATION_INVERT_X_ANGLE)) {
 				glwindow.flipped_y = true;
-				print_verbose("EGL: Using optimal surface orientation: Invert Y");
+				PRINT_VERBOSE("EGL: Using optimal surface orientation: Invert Y");
 			}
 		} else {
 			ERR_PRINT(vformat("Failed to get EGL_SURFACE_ORIENTATION_ANGLE, error: 0x%08X", eglGetError()));
@@ -488,7 +488,7 @@ Error EGLManager::initialize(void *p_native_display) {
 	int major = GLAD_VERSION_MAJOR(version);
 	int minor = GLAD_VERSION_MINOR(version);
 
-	print_verbose(vformat("Loaded EGL %d.%d", major, minor));
+	PRINT_VERBOSE(vformat("Loaded EGL %d.%d", major, minor));
 
 	ERR_FAIL_COND_V_MSG(!GLAD_EGL_VERSION_1_4, ERR_UNAVAILABLE, vformat("EGL version is too old! %d.%d < 1.4", major, minor));
 

--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -142,7 +142,7 @@ int EGLManager::_get_gldisplay_id(void *p_display) {
 
 		if (egl_extensions.has("EGL_ANGLE_surface_orientation")) {
 			new_gldisplay.has_EGL_ANGLE_surface_orientation = true;
-			print_verbose("EGL: EGL_ANGLE_surface_orientation is supported.");
+			PRINT_VERBOSE("EGL: EGL_ANGLE_surface_orientation is supported.");
 		}
 	}
 #endif
@@ -309,7 +309,7 @@ Error EGLManager::window_create(DisplayServerEnums::WindowID p_window_id, void *
 		if (eglQuerySurface(gldisplay.egl_display, glwindow.egl_surface, EGL_SURFACE_ORIENTATION_ANGLE, &orientation)) {
 			if (orientation & EGL_SURFACE_ORIENTATION_INVERT_Y_ANGLE && !(orientation & EGL_SURFACE_ORIENTATION_INVERT_X_ANGLE)) {
 				glwindow.flipped_y = true;
-				print_verbose("EGL: Using optimal surface orientation: Invert Y");
+				PRINT_VERBOSE("EGL: Using optimal surface orientation: Invert Y");
 			}
 		} else {
 			ERR_PRINT(vformat("Failed to get EGL_SURFACE_ORIENTATION_ANGLE, error: 0x%08X", eglGetError()));
@@ -489,7 +489,7 @@ Error EGLManager::initialize(void *p_native_display) {
 	int major = GLAD_VERSION_MAJOR(version);
 	int minor = GLAD_VERSION_MINOR(version);
 
-	print_verbose(vformat("Loaded EGL %d.%d", major, minor));
+	PRINT_VERBOSE(vformat("Loaded EGL %d.%d", major, minor));
 
 	ERR_FAIL_COND_V_MSG(!GLAD_EGL_VERSION_1_4, ERR_UNAVAILABLE, vformat("EGL version is too old! %d.%d < 1.4", major, minor));
 

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -803,7 +803,7 @@ void ShaderGLES3::initialize(const String &p_general_defines, int p_base_texture
 		}
 		shader_cache_dir_valid = true;
 
-		print_verbose("Shader '" + name + "' SHA256: " + base_sha256);
+		PRINT_VERBOSE("Shader '" + name + "' SHA256: " + base_sha256);
 	}
 
 	GLES3::Config *config = GLES3::Config::get_singleton();

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2895,11 +2895,11 @@ Error RenderingDeviceDriverMetal::_initialize(uint32_t p_device_index, uint32_t 
 		// NOTE: I'm not sure what the limit is as I don't see it referenced anywhere
 		multiview_capabilities.max_instance_count = UINT32_MAX;
 
-		print_verbose("- Metal multiview supported:");
-		print_verbose("  max view count: " + itos(multiview_capabilities.max_view_count));
-		print_verbose("  max instances: " + itos(multiview_capabilities.max_instance_count));
+		PRINT_VERBOSE("- Metal multiview supported:");
+		PRINT_VERBOSE("  max view count: " + itos(multiview_capabilities.max_view_count));
+		PRINT_VERBOSE("  max instances: " + itos(multiview_capabilities.max_instance_count));
 	} else {
-		print_verbose("- Metal multiview not supported");
+		PRINT_VERBOSE("- Metal multiview not supported");
 	}
 
 	// The Metal renderer requires Apple4 family. This is 2017 era A11 chips and newer.

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -2885,7 +2885,7 @@ RenderingDeviceDriverMetal::~RenderingDeviceDriverMetal() {
 			const char *pool_names[3] = { "private", "shared", "shared_wc" };
 			for (uint32_t i = 0; i < 3; i++) {
 				const MetalAllocatorStats::Pool &p = stats.pools[i];
-				print_verbose(vformat("Metal allocator pool %s: %d blocks, %s reserved, %s used, %d live allocations, %d dedicated (%s).",
+				PRINT_VERBOSE(vformat("Metal allocator pool %s: %d blocks, %s reserved, %s used, %d live allocations, %d dedicated (%s).",
 						pool_names[i], p.block_count, String::humanize_size(p.reserved_bytes), String::humanize_size(p.used_bytes),
 						p.allocation_count, p.dedicated_count, String::humanize_size(p.dedicated_bytes)));
 			}
@@ -3014,11 +3014,11 @@ Error RenderingDeviceDriverMetal::_initialize(uint32_t p_device_index, uint32_t 
 		// NOTE: I'm not sure what the limit is as I don't see it referenced anywhere
 		multiview_capabilities.max_instance_count = UINT32_MAX;
 
-		print_verbose("- Metal multiview supported:");
-		print_verbose("  max view count: " + itos(multiview_capabilities.max_view_count));
-		print_verbose("  max instances: " + itos(multiview_capabilities.max_instance_count));
+		PRINT_VERBOSE("- Metal multiview supported:");
+		PRINT_VERBOSE("  max view count: " + itos(multiview_capabilities.max_view_count));
+		PRINT_VERBOSE("  max instances: " + itos(multiview_capabilities.max_instance_count));
 	} else {
-		print_verbose("- Metal multiview not supported");
+		PRINT_VERBOSE("- Metal multiview not supported");
 	}
 
 	// The Metal renderer requires Apple4 family. This is 2017 era A11 chips and newer.

--- a/drivers/metal/rendering_device_driver_metal3.cpp
+++ b/drivers/metal/rendering_device_driver_metal3.cpp
@@ -130,7 +130,7 @@ Error RenderingDeviceDriverMetal::initialize(uint32_t p_device_index, uint32_t p
 	} else {
 		if (barriers_enabled) {
 			// Application or user has requested barriers, but the OS doesn't support them.
-			print_verbose("Metal 3: Resource barriers are not supported on this OS version.");
+			PRINT_VERBOSE("Metal 3: Resource barriers are not supported on this OS version.");
 			barriers_enabled = false;
 		}
 	}

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -51,19 +51,19 @@ void AudioDriverPulseAudio::pa_state_cb(pa_context *c, void *userdata) {
 
 	switch (pa_context_get_state(c)) {
 		case PA_CONTEXT_TERMINATED:
-			print_verbose("PulseAudio: context terminated");
+			PRINT_VERBOSE("PulseAudio: context terminated");
 			ad->pa_ready = -1;
 			break;
 		case PA_CONTEXT_FAILED:
-			print_verbose("PulseAudio: context failed");
+			PRINT_VERBOSE("PulseAudio: context failed");
 			ad->pa_ready = -1;
 			break;
 		case PA_CONTEXT_READY:
-			print_verbose("PulseAudio: context ready");
+			PRINT_VERBOSE("PulseAudio: context ready");
 			ad->pa_ready = 1;
 			break;
 		default:
-			print_verbose("PulseAudio: context other");
+			PRINT_VERBOSE("PulseAudio: context other");
 			// TODO: Check if we want to handle some of the other
 			// PA context states like PA_CONTEXT_UNCONNECTED.
 			break;
@@ -143,7 +143,7 @@ Error AudioDriverPulseAudio::detect_channels(bool input) {
 	if (device == "Default") {
 		device = input ? default_input_device : default_output_device;
 	}
-	print_verbose("PulseAudio: Detecting channels for device: " + device);
+	PRINT_VERBOSE("PulseAudio: Detecting channels for device: " + device);
 
 	CharString device_utf8 = device.utf8();
 
@@ -227,8 +227,8 @@ Error AudioDriverPulseAudio::init_output_device() {
 	buffer_frames = Math::closest_power_of_2(tmp_latency * mix_rate / 1000);
 	pa_buffer_size = buffer_frames * pa_map.channels;
 
-	print_verbose("PulseAudio: detected " + itos(pa_map.channels) + " output channels");
-	print_verbose("PulseAudio: audio buffer frames: " + itos(buffer_frames) + " calculated output latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
+	PRINT_VERBOSE("PulseAudio: detected " + itos(pa_map.channels) + " output channels");
+	PRINT_VERBOSE("PulseAudio: audio buffer frames: " + itos(buffer_frames) + " calculated output latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	pa_sample_spec spec;
 	spec.format = PA_SAMPLE_S16LE;
@@ -299,9 +299,9 @@ Error AudioDriverPulseAudio::init() {
 	if (ver_parts.size() >= 2) {
 		ver_ok = (ver_parts[0].to_int() >= 8); // 8.0.0
 	}
-	print_verbose(vformat("PulseAudio %s detected.", version));
+	PRINT_VERBOSE(vformat("PulseAudio %s detected.", version));
 	if (!ver_ok) {
-		print_verbose("Unsupported PulseAudio library version!");
+		PRINT_VERBOSE("Unsupported PulseAudio library version!");
 		return ERR_CANT_OPEN;
 	}
 
@@ -732,7 +732,7 @@ Error AudioDriverPulseAudio::init_input_device() {
 			break;
 	}
 
-	print_verbose("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
+	PRINT_VERBOSE("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
 
 	pa_sample_spec spec;
 
@@ -766,8 +766,8 @@ Error AudioDriverPulseAudio::init_input_device() {
 
 	input_buffer_init(input_buffer_frames);
 
-	print_verbose("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
-	print_verbose("PulseAudio: input buffer frames: " + itos(input_buffer_frames) + " calculated latency: " + itos(input_buffer_frames * 1000 / mix_rate) + "ms");
+	PRINT_VERBOSE("PulseAudio: detected " + itos(pa_rec_map.channels) + " input channels");
+	PRINT_VERBOSE("PulseAudio: input buffer frames: " + itos(input_buffer_frames) + " calculated latency: " + itos(input_buffer_frames * 1000 / mix_rate) + "ms");
 
 	return OK;
 }

--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -77,7 +77,7 @@ Error JoypadSDL::initialize() {
 	// Make sure that we handle already connected joypads when the driver is initialized.
 	process_events();
 
-	print_verbose("SDL: Init OK!");
+	PRINT_VERBOSE("SDL: Init OK!");
 	return OK;
 }
 
@@ -144,7 +144,7 @@ void JoypadSDL::process_events() {
 					device_name = SDL_GetGamepadName(gamepad);
 					joy = SDL_GetGamepadJoystick(gamepad);
 
-					print_verbose(vformat("SDL: Gamepad %s connected", SDL_GetGamepadName(gamepad)));
+					PRINT_VERBOSE(vformat("SDL: Gamepad %s connected", SDL_GetGamepadName(gamepad)));
 				} else {
 					joy = SDL_OpenJoystick(sdl_event.jdevice.which);
 					ERR_CONTINUE_MSG(!joy,
@@ -152,7 +152,7 @@ void JoypadSDL::process_events() {
 
 					device_name = SDL_GetJoystickName(joy);
 
-					print_verbose(vformat("SDL: Joystick %s connected", SDL_GetJoystickName(joy)));
+					PRINT_VERBOSE(vformat("SDL: Joystick %s connected", SDL_GetJoystickName(joy)));
 				}
 
 				const int MAX_GUID_SIZE = 64;

--- a/drivers/unix/ip_unix.cpp
+++ b/drivers/unix/ip_unix.cpp
@@ -86,12 +86,12 @@ void IPUnix::_resolve_hostname(List<IPAddress> &r_addresses, const String &p_hos
 
 	int s = getaddrinfo(p_hostname.utf8().get_data(), nullptr, &hints, &result);
 	if (s != 0) {
-		print_verbose("getaddrinfo failed! Cannot resolve hostname.");
+		PRINT_VERBOSE("getaddrinfo failed! Cannot resolve hostname.");
 		return;
 	}
 
 	if (result == nullptr || result->ai_addr == nullptr) {
-		print_verbose("Invalid response from getaddrinfo.");
+		PRINT_VERBOSE("Invalid response from getaddrinfo.");
 		if (result) {
 			freeaddrinfo(result);
 		}

--- a/drivers/unix/net_socket_unix.cpp
+++ b/drivers/unix/net_socket_unix.cpp
@@ -171,7 +171,7 @@ NetSocketUnix::NetError NetSocketUnix::_get_socket_error() const {
 	if (errno == ENOBUFS) {
 		return ERR_NET_BUFFER_TOO_SMALL;
 	}
-	print_verbose("Socket error: " + itos(errno) + ".");
+	PRINT_VERBOSE("Socket error: " + itos(errno) + ".");
 	return ERR_NET_OTHER;
 }
 
@@ -309,7 +309,7 @@ Error NetSocketUnix::_inet_open(Type p_sock_type, IP::Type &r_ip_type) {
 	// Disable SIGPIPE (should only be relevant to stream sockets, but seems to affect UDP too on iOS).
 	int par = 1;
 	if (setsockopt(_sock, SOL_SOCKET, SO_NOSIGPIPE, &par, sizeof(int)) != 0) {
-		print_verbose("Unable to turn off SIGPIPE on socket.");
+		PRINT_VERBOSE("Unable to turn off SIGPIPE on socket.");
 	}
 #endif
 	return OK;
@@ -327,7 +327,7 @@ Error NetSocketUnix::_unix_open() {
 	// Disable SIGPIPE (should only be relevant to stream sockets, but seems to affect UDP too on iOS).
 	int par = 1;
 	if (setsockopt(_sock, SOL_SOCKET, SO_NOSIGPIPE, &par, sizeof(int)) != 0) {
-		print_verbose("Unable to turn off SIGPIPE on socket.");
+		PRINT_VERBOSE("Unable to turn off SIGPIPE on socket.");
 	}
 #endif
 
@@ -375,7 +375,7 @@ Error NetSocketUnix::_inet_bind(IPAddress p_addr, uint16_t p_port) {
 
 	if (::bind(_sock, (struct sockaddr *)&addr, addr_size) != 0) {
 		NetError err = _get_socket_error();
-		print_verbose("Failed to bind socket. Error: " + itos(err) + ".");
+		PRINT_VERBOSE("Failed to bind socket. Error: " + itos(err) + ".");
 		close();
 		return ERR_UNAVAILABLE;
 	}
@@ -412,7 +412,7 @@ Error NetSocketUnix::_unix_bind(const CharString &p_path) {
 
 	if (::bind(_sock, (struct sockaddr *)&addr, addr_size) != 0) {
 		NetError err = _get_socket_error();
-		print_verbose("Failed to bind socket. Error: " + itos(err) + ".");
+		PRINT_VERBOSE("Failed to bind socket. Error: " + itos(err) + ".");
 		close();
 		switch (err) {
 			case ERR_NET_UNAUTHORIZED:
@@ -447,7 +447,7 @@ Error NetSocketUnix::listen(int p_max_pending) {
 
 	if (::listen(_sock, p_max_pending) != 0) {
 		_get_socket_error();
-		print_verbose("Failed to listen from socket.");
+		PRINT_VERBOSE("Failed to listen from socket.");
 		close();
 		return FAILED;
 	}
@@ -473,7 +473,7 @@ Error NetSocketUnix::_inet_connect_to_host(IPAddress p_host, uint16_t p_port) {
 			case ERR_NET_IN_PROGRESS:
 				return ERR_BUSY;
 			default:
-				print_verbose("Connection to remote host failed.");
+				PRINT_VERBOSE("Connection to remote host failed.");
 				close();
 				return FAILED;
 		}
@@ -501,7 +501,7 @@ Error NetSocketUnix::_unix_connect_to_host(const CharString &p_path) {
 			case ERR_NET_UNAUTHORIZED:
 				return ERR_UNAUTHORIZED;
 			default:
-				print_verbose("Connection to host failed.");
+				PRINT_VERBOSE("Connection to host failed.");
 				close();
 				return FAILED;
 		}
@@ -548,7 +548,7 @@ Error NetSocketUnix::poll(PollType p_type, int p_timeout) const {
 
 	if (ret < 0 || pfd.revents & POLLERR) {
 		_get_socket_error();
-		print_verbose("Error when polling socket.");
+		PRINT_VERBOSE("Error when polling socket.");
 		return FAILED;
 	}
 
@@ -740,7 +740,7 @@ int NetSocketUnix::get_available_bytes() const {
 	int ret = ioctl(_sock, FIONREAD, &len);
 	if (ret == -1) {
 		_get_socket_error();
-		print_verbose("Error when checking available bytes on socket.");
+		PRINT_VERBOSE("Error when checking available bytes on socket.");
 		return -1;
 	}
 	return len;
@@ -751,7 +751,7 @@ Error NetSocketUnix::_inet_get_socket_address(IPAddress *r_ip, uint16_t *r_port)
 	socklen_t len = sizeof(saddr);
 	if (getsockname(_sock, (struct sockaddr *)&saddr, &len) != 0) {
 		_get_socket_error();
-		print_verbose("Error when reading local socket address.");
+		PRINT_VERBOSE("Error when reading local socket address.");
 		return FAILED;
 	}
 	_set_ip_port(&saddr, r_ip, r_port);
@@ -790,7 +790,7 @@ Ref<NetSocket> NetSocketUnix::_inet_accept(IPAddress &r_ip, uint16_t &r_port) {
 	int fd = ::accept(_sock, (struct sockaddr *)&their_addr, &size);
 	if (fd == -1) {
 		_get_socket_error();
-		print_verbose("Error when accepting socket connection.");
+		PRINT_VERBOSE("Error when accepting socket connection.");
 		return Ref<NetSocket>();
 	}
 
@@ -810,7 +810,7 @@ Ref<NetSocket> NetSocketUnix::_unix_accept() {
 	int fd = ::accept(_sock, (struct sockaddr *)&addr, &addr_len);
 	if (fd == -1) {
 		_get_socket_error();
-		print_verbose("Error when accepting socket connection.");
+		PRINT_VERBOSE("Error when accepting socket connection.");
 		return Ref<NetSocket>();
 	}
 

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -475,7 +475,7 @@ Error RenderingContextDriverVulkan::_initialize_instance_extensions() {
 
 #ifdef DEV_ENABLED
 	for (uint32_t i = 0; i < instance_extension_count; i++) {
-		print_verbose(String("Vulkan: Found instance extension ") + String::utf8(instance_extensions[i].extensionName) + String("."));
+		PRINT_VERBOSE(String("Vulkan: Found instance extension ") + String::utf8(instance_extensions[i].extensionName) + String("."));
 	}
 #endif
 
@@ -493,7 +493,7 @@ Error RenderingContextDriverVulkan::_initialize_instance_extensions() {
 			if (requested_extension.value) {
 				ERR_FAIL_V_MSG(ERR_BUG, String("Required Vulkan instance extension ") + String::utf8(requested_extension.key) + String(" not found."));
 			} else {
-				print_verbose(String("Optional Vulkan instance extension ") + String::utf8(requested_extension.key) + String(" not found."));
+				PRINT_VERBOSE(String("Optional Vulkan instance extension ") + String::utf8(requested_extension.key) + String(" not found."));
 			}
 		}
 	}
@@ -645,7 +645,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL RenderingContextDriverVulkan::_debug_messenger_ca
 	// we don't enable everything by default.
 	switch (p_message_severity) {
 		case VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT:
-			print_verbose(error_message);
+			PRINT_VERBOSE(error_message);
 			break;
 		case VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT:
 			print_line(error_message);

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -661,7 +661,7 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 
 #ifdef DEV_ENABLED
 	for (uint32_t i = 0; i < device_extension_count; i++) {
-		print_verbose(String("Vulkan: Found device extension ") + String::utf8(device_extensions[i].extensionName));
+		PRINT_VERBOSE(String("Vulkan: Found device extension ") + String::utf8(device_extensions[i].extensionName));
 	}
 #endif
 
@@ -679,7 +679,7 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 			if (requested_extension.value) {
 				ERR_FAIL_V_MSG(ERR_BUG, String("Required Vulkan device extension ") + String::utf8(requested_extension.key) + String(" not found."));
 			} else {
-				print_verbose(String("Optional Vulkan device extension ") + String::utf8(requested_extension.key) + String(" not found"));
+				PRINT_VERBOSE(String("Optional Vulkan device extension ") + String::utf8(requested_extension.key) + String(" not found"));
 			}
 		}
 	}
@@ -1194,12 +1194,12 @@ Error RenderingDeviceDriverVulkan::_check_device_capabilities() {
 		}
 
 		if (fsr_capabilities.pipeline_supported || fsr_capabilities.primitive_supported || fsr_capabilities.attachment_supported) {
-			print_verbose("- Vulkan Fragment Shading Rate supported:");
+			PRINT_VERBOSE("- Vulkan Fragment Shading Rate supported:");
 			if (fsr_capabilities.pipeline_supported) {
-				print_verbose("  Pipeline fragment shading rate");
+				PRINT_VERBOSE("  Pipeline fragment shading rate");
 			}
 			if (fsr_capabilities.primitive_supported) {
-				print_verbose("  Primitive fragment shading rate");
+				PRINT_VERBOSE("  Primitive fragment shading rate");
 			}
 			if (fsr_capabilities.attachment_supported) {
 				// TODO: Expose these somehow to the end user.
@@ -1210,14 +1210,14 @@ Error RenderingDeviceDriverVulkan::_check_device_capabilities() {
 				fsr_capabilities.max_fragment_size.x = fsr_properties.maxFragmentSize.width; // either 4 or 8
 				fsr_capabilities.max_fragment_size.y = fsr_properties.maxFragmentSize.height; // generally the same as width
 
-				print_verbose(String("  Attachment fragment shading rate") +
+				PRINT_VERBOSE(String("  Attachment fragment shading rate") +
 						String(", min texel size: (") + itos(fsr_capabilities.min_texel_size.x) + String(", ") + itos(fsr_capabilities.min_texel_size.y) + String(")") +
 						String(", max texel size: (") + itos(fsr_capabilities.max_texel_size.x) + String(", ") + itos(fsr_capabilities.max_texel_size.y) + String(")") +
 						String(", max fragment size: (") + itos(fsr_capabilities.max_fragment_size.x) + String(", ") + itos(fsr_capabilities.max_fragment_size.y) + String(")"));
 			}
 
 		} else {
-			print_verbose("- Vulkan Variable Rate Shading not supported");
+			PRINT_VERBOSE("- Vulkan Variable Rate Shading not supported");
 		}
 
 		if (fdm_capabilities.attachment_supported || fdm_capabilities.dynamic_attachment_supported || fdm_capabilities.non_subsampled_images_supported) {
@@ -1227,59 +1227,59 @@ Error RenderingDeviceDriverVulkan::_check_device_capabilities() {
 			fdm_capabilities.max_texel_size.y = fdm_properties.maxFragmentDensityTexelSize.height;
 			fdm_capabilities.invocations_supported = fdm_properties.fragmentDensityInvocations;
 
-			print_verbose(String("- Vulkan Fragment Density Map supported") +
+			PRINT_VERBOSE(String("- Vulkan Fragment Density Map supported") +
 					String(", min texel size: (") + itos(fdm_capabilities.min_texel_size.x) + String(", ") + itos(fdm_capabilities.min_texel_size.y) + String(")") +
 					String(", max texel size: (") + itos(fdm_capabilities.max_texel_size.x) + String(", ") + itos(fdm_capabilities.max_texel_size.y) + String(")"));
 
 			if (fdm_capabilities.dynamic_attachment_supported) {
-				print_verbose("  - dynamic fragment density map supported");
+				PRINT_VERBOSE("  - dynamic fragment density map supported");
 			}
 
 			if (fdm_capabilities.non_subsampled_images_supported) {
-				print_verbose("  - non-subsampled images supported");
+				PRINT_VERBOSE("  - non-subsampled images supported");
 			}
 		} else {
-			print_verbose("- Vulkan Fragment Density Map not supported");
+			PRINT_VERBOSE("- Vulkan Fragment Density Map not supported");
 		}
 
 		if (fdm_capabilities.offset_supported) {
-			print_verbose("- Vulkan Fragment Density Map Offset supported");
+			PRINT_VERBOSE("- Vulkan Fragment Density Map Offset supported");
 
 			fdm_capabilities.offset_granularity.x = fdmo_properties.fragmentDensityOffsetGranularity.width;
 			fdm_capabilities.offset_granularity.y = fdmo_properties.fragmentDensityOffsetGranularity.height;
 
-			print_verbose(vformat("  Offset granularity: (%d, %d)", fdm_capabilities.offset_granularity.x, fdm_capabilities.offset_granularity.y));
+			PRINT_VERBOSE(vformat("  Offset granularity: (%d, %d)", fdm_capabilities.offset_granularity.x, fdm_capabilities.offset_granularity.y));
 		} else if (use_fdm_offsets) {
-			print_verbose("- Vulkan Fragment Density Map Offset not supported");
+			PRINT_VERBOSE("- Vulkan Fragment Density Map Offset not supported");
 		}
 
 		if (multiview_capabilities.is_supported) {
 			multiview_capabilities.max_view_count = multiview_properties.maxMultiviewViewCount;
 			multiview_capabilities.max_instance_count = multiview_properties.maxMultiviewInstanceIndex;
 
-			print_verbose("- Vulkan multiview supported:");
-			print_verbose("  max view count: " + itos(multiview_capabilities.max_view_count));
-			print_verbose("  max instances: " + itos(multiview_capabilities.max_instance_count));
+			PRINT_VERBOSE("- Vulkan multiview supported:");
+			PRINT_VERBOSE("  max view count: " + itos(multiview_capabilities.max_view_count));
+			PRINT_VERBOSE("  max instances: " + itos(multiview_capabilities.max_instance_count));
 		} else {
-			print_verbose("- Vulkan multiview not supported");
+			PRINT_VERBOSE("- Vulkan multiview not supported");
 		}
 
-		print_verbose("- Vulkan subgroup:");
-		print_verbose("  size: " + itos(subgroup_capabilities.size));
-		print_verbose("  min size: " + itos(subgroup_capabilities.min_size));
-		print_verbose("  max size: " + itos(subgroup_capabilities.max_size));
-		print_verbose("  stages: " + subgroup_capabilities.supported_stages_desc());
-		print_verbose("  supported ops: " + subgroup_capabilities.supported_operations_desc());
+		PRINT_VERBOSE("- Vulkan subgroup:");
+		PRINT_VERBOSE("  size: " + itos(subgroup_capabilities.size));
+		PRINT_VERBOSE("  min size: " + itos(subgroup_capabilities.min_size));
+		PRINT_VERBOSE("  max size: " + itos(subgroup_capabilities.max_size));
+		PRINT_VERBOSE("  stages: " + subgroup_capabilities.supported_stages_desc());
+		PRINT_VERBOSE("  supported ops: " + subgroup_capabilities.supported_operations_desc());
 		if (subgroup_capabilities.quad_operations_in_all_stages) {
-			print_verbose("  quad operations in all stages");
+			PRINT_VERBOSE("  quad operations in all stages");
 		}
 
 		if (acceleration_structure_capabilities.acceleration_structure_support) {
-			print_verbose("- Vulkan Acceleration Structure supported");
+			PRINT_VERBOSE("- Vulkan Acceleration Structure supported");
 			acceleration_structure_capabilities.min_acceleration_structure_scratch_offset_alignment = acceleration_structure_properties.minAccelerationStructureScratchOffsetAlignment;
-			print_verbose("  min acceleration structure scratch offset alignment: " + itos(acceleration_structure_capabilities.min_acceleration_structure_scratch_offset_alignment));
+			PRINT_VERBOSE("  min acceleration structure scratch offset alignment: " + itos(acceleration_structure_capabilities.min_acceleration_structure_scratch_offset_alignment));
 		} else {
-			print_verbose("- Vulkan Acceleration Structure not supported");
+			PRINT_VERBOSE("- Vulkan Acceleration Structure not supported");
 		}
 
 		if (raytracing_capabilities.raytracing_pipeline_support) {
@@ -1288,13 +1288,13 @@ Error RenderingDeviceDriverVulkan::_check_device_capabilities() {
 			raytracing_capabilities.shader_group_handle_size_aligned = _align_up(raytracing_capabilities.shader_group_handle_size, raytracing_capabilities.shader_group_handle_alignment);
 			raytracing_capabilities.shader_group_base_alignment = raytracing_properties.shaderGroupBaseAlignment;
 
-			print_verbose("- Vulkan Raytracing supported");
-			print_verbose("  shader group handle size: " + itos(raytracing_capabilities.shader_group_handle_size));
-			print_verbose("  shader group handle alignment: " + itos(raytracing_capabilities.shader_group_handle_alignment));
-			print_verbose("  shader group handle size aligned: " + itos(raytracing_capabilities.shader_group_handle_size_aligned));
-			print_verbose("  shader group base alignment: " + itos(raytracing_capabilities.shader_group_base_alignment));
+			PRINT_VERBOSE("- Vulkan Raytracing supported");
+			PRINT_VERBOSE("  shader group handle size: " + itos(raytracing_capabilities.shader_group_handle_size));
+			PRINT_VERBOSE("  shader group handle alignment: " + itos(raytracing_capabilities.shader_group_handle_alignment));
+			PRINT_VERBOSE("  shader group handle size aligned: " + itos(raytracing_capabilities.shader_group_handle_size_aligned));
+			PRINT_VERBOSE("  shader group base alignment: " + itos(raytracing_capabilities.shader_group_base_alignment));
 		} else {
-			print_verbose("- Vulkan Raytracing not supported");
+			PRINT_VERBOSE("- Vulkan Raytracing not supported");
 		}
 	}
 
@@ -1947,7 +1947,7 @@ VmaPool RenderingDeviceDriverVulkan::_find_or_create_small_allocs_pool(uint32_t 
 		return small_allocs_pools[p_mem_type_index];
 	}
 
-	print_verbose("Creating VMA small objects pool for memory type index " + itos(p_mem_type_index));
+	PRINT_VERBOSE("Creating VMA small objects pool for memory type index " + itos(p_mem_type_index));
 
 	VmaPoolCreateInfo pci = {};
 	pci.memoryTypeIndex = p_mem_type_index;
@@ -5330,11 +5330,11 @@ bool RenderingDeviceDriverVulkan::pipeline_cache_create(const Vector<uint8_t> &p
 		if (p_data.is_empty()) {
 			// No pre-existing cache, just create it.
 		} else if (p_data.size() <= (int)sizeof(PipelineCacheHeader)) {
-			print_verbose("Invalid/corrupt Vulkan pipelines cache. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
+			PRINT_VERBOSE("Invalid/corrupt Vulkan pipelines cache. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
 		} else {
 			const PipelineCacheHeader *loaded_header = reinterpret_cast<const PipelineCacheHeader *>(p_data.ptr());
 			if (loaded_header->magic != 868 + VK_PIPELINE_CACHE_HEADER_VERSION_ONE) {
-				print_verbose("Invalid Vulkan pipelines cache magic number. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
+				PRINT_VERBOSE("Invalid Vulkan pipelines cache magic number. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
 			} else {
 				const uint8_t *loaded_buffer_start = p_data.ptr() + sizeof(PipelineCacheHeader);
 				uint32_t loaded_buffer_size = p_data.size() - sizeof(PipelineCacheHeader);
@@ -5346,7 +5346,7 @@ bool RenderingDeviceDriverVulkan::pipeline_cache_create(const Vector<uint8_t> &p
 						loaded_header->driver_version != current_header->driver_version ||
 						memcmp(loaded_header->uuid, current_header->uuid, VK_UUID_SIZE) != 0 ||
 						loaded_header->driver_abi != current_header->driver_abi) {
-					print_verbose("Invalid Vulkan pipelines cache header. This may be due to an engine change, GPU change or graphics driver version change. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
+					PRINT_VERBOSE("Invalid Vulkan pipelines cache header. This may be due to an engine change, GPU change or graphics driver version change. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
 				} else {
 					pipelines_cache.current_size = loaded_buffer_size;
 					pipelines_cache.buffer = p_data;

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -660,7 +660,7 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 
 #ifdef DEV_ENABLED
 	for (uint32_t i = 0; i < device_extension_count; i++) {
-		print_verbose(String("Vulkan: Found device extension ") + String::utf8(device_extensions[i].extensionName));
+		PRINT_VERBOSE(String("Vulkan: Found device extension ") + String::utf8(device_extensions[i].extensionName));
 	}
 #endif
 
@@ -678,7 +678,7 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 			if (requested_extension.value) {
 				ERR_FAIL_V_MSG(ERR_BUG, String("Required Vulkan device extension ") + String::utf8(requested_extension.key) + String(" not found."));
 			} else {
-				print_verbose(String("Optional Vulkan device extension ") + String::utf8(requested_extension.key) + String(" not found"));
+				PRINT_VERBOSE(String("Optional Vulkan device extension ") + String::utf8(requested_extension.key) + String(" not found"));
 			}
 		}
 	}
@@ -1182,12 +1182,12 @@ Error RenderingDeviceDriverVulkan::_check_device_capabilities() {
 		}
 
 		if (fsr_capabilities.pipeline_supported || fsr_capabilities.primitive_supported || fsr_capabilities.attachment_supported) {
-			print_verbose("- Vulkan Fragment Shading Rate supported:");
+			PRINT_VERBOSE("- Vulkan Fragment Shading Rate supported:");
 			if (fsr_capabilities.pipeline_supported) {
-				print_verbose("  Pipeline fragment shading rate");
+				PRINT_VERBOSE("  Pipeline fragment shading rate");
 			}
 			if (fsr_capabilities.primitive_supported) {
-				print_verbose("  Primitive fragment shading rate");
+				PRINT_VERBOSE("  Primitive fragment shading rate");
 			}
 			if (fsr_capabilities.attachment_supported) {
 				// TODO: Expose these somehow to the end user.
@@ -1198,14 +1198,14 @@ Error RenderingDeviceDriverVulkan::_check_device_capabilities() {
 				fsr_capabilities.max_fragment_size.x = fsr_properties.maxFragmentSize.width; // either 4 or 8
 				fsr_capabilities.max_fragment_size.y = fsr_properties.maxFragmentSize.height; // generally the same as width
 
-				print_verbose(String("  Attachment fragment shading rate") +
+				PRINT_VERBOSE(String("  Attachment fragment shading rate") +
 						String(", min texel size: (") + itos(fsr_capabilities.min_texel_size.x) + String(", ") + itos(fsr_capabilities.min_texel_size.y) + String(")") +
 						String(", max texel size: (") + itos(fsr_capabilities.max_texel_size.x) + String(", ") + itos(fsr_capabilities.max_texel_size.y) + String(")") +
 						String(", max fragment size: (") + itos(fsr_capabilities.max_fragment_size.x) + String(", ") + itos(fsr_capabilities.max_fragment_size.y) + String(")"));
 			}
 
 		} else {
-			print_verbose("- Vulkan Variable Rate Shading not supported");
+			PRINT_VERBOSE("- Vulkan Variable Rate Shading not supported");
 		}
 
 		if (fdm_capabilities.attachment_supported || fdm_capabilities.dynamic_attachment_supported || fdm_capabilities.non_subsampled_images_supported) {
@@ -1215,59 +1215,59 @@ Error RenderingDeviceDriverVulkan::_check_device_capabilities() {
 			fdm_capabilities.max_texel_size.y = fdm_properties.maxFragmentDensityTexelSize.height;
 			fdm_capabilities.invocations_supported = fdm_properties.fragmentDensityInvocations;
 
-			print_verbose(String("- Vulkan Fragment Density Map supported") +
+			PRINT_VERBOSE(String("- Vulkan Fragment Density Map supported") +
 					String(", min texel size: (") + itos(fdm_capabilities.min_texel_size.x) + String(", ") + itos(fdm_capabilities.min_texel_size.y) + String(")") +
 					String(", max texel size: (") + itos(fdm_capabilities.max_texel_size.x) + String(", ") + itos(fdm_capabilities.max_texel_size.y) + String(")"));
 
 			if (fdm_capabilities.dynamic_attachment_supported) {
-				print_verbose("  - dynamic fragment density map supported");
+				PRINT_VERBOSE("  - dynamic fragment density map supported");
 			}
 
 			if (fdm_capabilities.non_subsampled_images_supported) {
-				print_verbose("  - non-subsampled images supported");
+				PRINT_VERBOSE("  - non-subsampled images supported");
 			}
 		} else {
-			print_verbose("- Vulkan Fragment Density Map not supported");
+			PRINT_VERBOSE("- Vulkan Fragment Density Map not supported");
 		}
 
 		if (fdm_capabilities.offset_supported) {
-			print_verbose("- Vulkan Fragment Density Map Offset supported");
+			PRINT_VERBOSE("- Vulkan Fragment Density Map Offset supported");
 
 			fdm_capabilities.offset_granularity.x = fdmo_properties.fragmentDensityOffsetGranularity.width;
 			fdm_capabilities.offset_granularity.y = fdmo_properties.fragmentDensityOffsetGranularity.height;
 
-			print_verbose(vformat("  Offset granularity: (%d, %d)", fdm_capabilities.offset_granularity.x, fdm_capabilities.offset_granularity.y));
+			PRINT_VERBOSE(vformat("  Offset granularity: (%d, %d)", fdm_capabilities.offset_granularity.x, fdm_capabilities.offset_granularity.y));
 		} else if (use_fdm_offsets) {
-			print_verbose("- Vulkan Fragment Density Map Offset not supported");
+			PRINT_VERBOSE("- Vulkan Fragment Density Map Offset not supported");
 		}
 
 		if (multiview_capabilities.is_supported) {
 			multiview_capabilities.max_view_count = multiview_properties.maxMultiviewViewCount;
 			multiview_capabilities.max_instance_count = multiview_properties.maxMultiviewInstanceIndex;
 
-			print_verbose("- Vulkan multiview supported:");
-			print_verbose("  max view count: " + itos(multiview_capabilities.max_view_count));
-			print_verbose("  max instances: " + itos(multiview_capabilities.max_instance_count));
+			PRINT_VERBOSE("- Vulkan multiview supported:");
+			PRINT_VERBOSE("  max view count: " + itos(multiview_capabilities.max_view_count));
+			PRINT_VERBOSE("  max instances: " + itos(multiview_capabilities.max_instance_count));
 		} else {
-			print_verbose("- Vulkan multiview not supported");
+			PRINT_VERBOSE("- Vulkan multiview not supported");
 		}
 
-		print_verbose("- Vulkan subgroup:");
-		print_verbose("  size: " + itos(subgroup_capabilities.size));
-		print_verbose("  min size: " + itos(subgroup_capabilities.min_size));
-		print_verbose("  max size: " + itos(subgroup_capabilities.max_size));
-		print_verbose("  stages: " + subgroup_capabilities.supported_stages_desc());
-		print_verbose("  supported ops: " + subgroup_capabilities.supported_operations_desc());
+		PRINT_VERBOSE("- Vulkan subgroup:");
+		PRINT_VERBOSE("  size: " + itos(subgroup_capabilities.size));
+		PRINT_VERBOSE("  min size: " + itos(subgroup_capabilities.min_size));
+		PRINT_VERBOSE("  max size: " + itos(subgroup_capabilities.max_size));
+		PRINT_VERBOSE("  stages: " + subgroup_capabilities.supported_stages_desc());
+		PRINT_VERBOSE("  supported ops: " + subgroup_capabilities.supported_operations_desc());
 		if (subgroup_capabilities.quad_operations_in_all_stages) {
-			print_verbose("  quad operations in all stages");
+			PRINT_VERBOSE("  quad operations in all stages");
 		}
 
 		if (acceleration_structure_capabilities.acceleration_structure_support) {
-			print_verbose("- Vulkan Acceleration Structure supported");
+			PRINT_VERBOSE("- Vulkan Acceleration Structure supported");
 			acceleration_structure_capabilities.min_acceleration_structure_scratch_offset_alignment = acceleration_structure_properties.minAccelerationStructureScratchOffsetAlignment;
-			print_verbose("  min acceleration structure scratch offset alignment: " + itos(acceleration_structure_capabilities.min_acceleration_structure_scratch_offset_alignment));
+			PRINT_VERBOSE("  min acceleration structure scratch offset alignment: " + itos(acceleration_structure_capabilities.min_acceleration_structure_scratch_offset_alignment));
 		} else {
-			print_verbose("- Vulkan Acceleration Structure not supported");
+			PRINT_VERBOSE("- Vulkan Acceleration Structure not supported");
 		}
 
 		if (raytracing_capabilities.raytracing_pipeline_support) {
@@ -1276,13 +1276,13 @@ Error RenderingDeviceDriverVulkan::_check_device_capabilities() {
 			raytracing_capabilities.shader_group_handle_size_aligned = _align_up(raytracing_capabilities.shader_group_handle_size, raytracing_capabilities.shader_group_handle_alignment);
 			raytracing_capabilities.shader_group_base_alignment = raytracing_properties.shaderGroupBaseAlignment;
 
-			print_verbose("- Vulkan Raytracing supported");
-			print_verbose("  shader group handle size: " + itos(raytracing_capabilities.shader_group_handle_size));
-			print_verbose("  shader group handle alignment: " + itos(raytracing_capabilities.shader_group_handle_alignment));
-			print_verbose("  shader group handle size aligned: " + itos(raytracing_capabilities.shader_group_handle_size_aligned));
-			print_verbose("  shader group base alignment: " + itos(raytracing_capabilities.shader_group_base_alignment));
+			PRINT_VERBOSE("- Vulkan Raytracing supported");
+			PRINT_VERBOSE("  shader group handle size: " + itos(raytracing_capabilities.shader_group_handle_size));
+			PRINT_VERBOSE("  shader group handle alignment: " + itos(raytracing_capabilities.shader_group_handle_alignment));
+			PRINT_VERBOSE("  shader group handle size aligned: " + itos(raytracing_capabilities.shader_group_handle_size_aligned));
+			PRINT_VERBOSE("  shader group base alignment: " + itos(raytracing_capabilities.shader_group_base_alignment));
 		} else {
-			print_verbose("- Vulkan Raytracing not supported");
+			PRINT_VERBOSE("- Vulkan Raytracing not supported");
 		}
 	}
 
@@ -1909,7 +1909,7 @@ VmaPool RenderingDeviceDriverVulkan::_find_or_create_small_allocs_pool(uint32_t 
 		return small_allocs_pools[p_mem_type_index];
 	}
 
-	print_verbose("Creating VMA small objects pool for memory type index " + itos(p_mem_type_index));
+	PRINT_VERBOSE("Creating VMA small objects pool for memory type index " + itos(p_mem_type_index));
 
 	VmaPoolCreateInfo pci = {};
 	pci.memoryTypeIndex = p_mem_type_index;
@@ -5283,11 +5283,11 @@ bool RenderingDeviceDriverVulkan::pipeline_cache_create(const Vector<uint8_t> &p
 		if (p_data.is_empty()) {
 			// No pre-existing cache, just create it.
 		} else if (p_data.size() <= (int)sizeof(PipelineCacheHeader)) {
-			print_verbose("Invalid/corrupt Vulkan pipelines cache. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
+			PRINT_VERBOSE("Invalid/corrupt Vulkan pipelines cache. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
 		} else {
 			const PipelineCacheHeader *loaded_header = reinterpret_cast<const PipelineCacheHeader *>(p_data.ptr());
 			if (loaded_header->magic != 868 + VK_PIPELINE_CACHE_HEADER_VERSION_ONE) {
-				print_verbose("Invalid Vulkan pipelines cache magic number. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
+				PRINT_VERBOSE("Invalid Vulkan pipelines cache magic number. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
 			} else {
 				const uint8_t *loaded_buffer_start = p_data.ptr() + sizeof(PipelineCacheHeader);
 				uint32_t loaded_buffer_size = p_data.size() - sizeof(PipelineCacheHeader);
@@ -5299,7 +5299,7 @@ bool RenderingDeviceDriverVulkan::pipeline_cache_create(const Vector<uint8_t> &p
 						loaded_header->driver_version != current_header->driver_version ||
 						memcmp(loaded_header->uuid, current_header->uuid, VK_UUID_SIZE) != 0 ||
 						loaded_header->driver_abi != current_header->driver_abi) {
-					print_verbose("Invalid Vulkan pipelines cache header. This may be due to an engine change, GPU change or graphics driver version change. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
+					PRINT_VERBOSE("Invalid Vulkan pipelines cache header. This may be due to an engine change, GPU change or graphics driver version change. Existing shader pipeline cache will be ignored, which may result in stuttering during gameplay.");
 				} else {
 					pipelines_cache.current_size = loaded_buffer_size;
 					pipelines_cache.buffer = p_data;

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -298,9 +298,9 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 			// IID_IAudioClient3 will never activate on OS versions before Windows 10.
 			// Older Windows versions should fall back gracefully.
 			using_audio_client_3 = false;
-			print_verbose("WASAPI: Couldn't activate output_device with IAudioClient3 interface, falling back to IAudioClient interface");
+			PRINT_VERBOSE("WASAPI: Couldn't activate output_device with IAudioClient3 interface, falling back to IAudioClient interface");
 		} else {
-			print_verbose("WASAPI: Activated output_device using IAudioClient3 interface");
+			PRINT_VERBOSE("WASAPI: Activated output_device using IAudioClient3 interface");
 		}
 	}
 	if (!using_audio_client_3) {
@@ -329,26 +329,26 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 	ERR_FAIL_COND_V(hr != S_OK, ERR_CANT_OPEN);
 	// From this point onward, CoTaskMemFree(pwfex) must be called before returning or pwfex will leak!
 
-	print_verbose("WASAPI: wFormatTag = " + itos(pwfex->wFormatTag));
-	print_verbose("WASAPI: nChannels = " + itos(pwfex->nChannels));
-	print_verbose("WASAPI: nSamplesPerSec = " + itos(pwfex->nSamplesPerSec));
-	print_verbose("WASAPI: nAvgBytesPerSec = " + itos(pwfex->nAvgBytesPerSec));
-	print_verbose("WASAPI: nBlockAlign = " + itos(pwfex->nBlockAlign));
-	print_verbose("WASAPI: wBitsPerSample = " + itos(pwfex->wBitsPerSample));
-	print_verbose("WASAPI: cbSize = " + itos(pwfex->cbSize));
+	PRINT_VERBOSE("WASAPI: wFormatTag = " + itos(pwfex->wFormatTag));
+	PRINT_VERBOSE("WASAPI: nChannels = " + itos(pwfex->nChannels));
+	PRINT_VERBOSE("WASAPI: nSamplesPerSec = " + itos(pwfex->nSamplesPerSec));
+	PRINT_VERBOSE("WASAPI: nAvgBytesPerSec = " + itos(pwfex->nAvgBytesPerSec));
+	PRINT_VERBOSE("WASAPI: nBlockAlign = " + itos(pwfex->nBlockAlign));
+	PRINT_VERBOSE("WASAPI: wBitsPerSample = " + itos(pwfex->wBitsPerSample));
+	PRINT_VERBOSE("WASAPI: cbSize = " + itos(pwfex->cbSize));
 
 	WAVEFORMATEX *closest = nullptr;
 	hr = p_device->audio_client->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, pwfex, &closest);
 	if (hr == S_FALSE) {
 		WARN_PRINT("WASAPI: Mix format is not supported by the output_device");
 		if (closest) {
-			print_verbose("WASAPI: closest->wFormatTag = " + itos(closest->wFormatTag));
-			print_verbose("WASAPI: closest->nChannels = " + itos(closest->nChannels));
-			print_verbose("WASAPI: closest->nSamplesPerSec = " + itos(closest->nSamplesPerSec));
-			print_verbose("WASAPI: closest->nAvgBytesPerSec = " + itos(closest->nAvgBytesPerSec));
-			print_verbose("WASAPI: closest->nBlockAlign = " + itos(closest->nBlockAlign));
-			print_verbose("WASAPI: closest->wBitsPerSample = " + itos(closest->wBitsPerSample));
-			print_verbose("WASAPI: closest->cbSize = " + itos(closest->cbSize));
+			PRINT_VERBOSE("WASAPI: closest->wFormatTag = " + itos(closest->wFormatTag));
+			PRINT_VERBOSE("WASAPI: closest->nChannels = " + itos(closest->nChannels));
+			PRINT_VERBOSE("WASAPI: closest->nSamplesPerSec = " + itos(closest->nSamplesPerSec));
+			PRINT_VERBOSE("WASAPI: closest->nAvgBytesPerSec = " + itos(closest->nAvgBytesPerSec));
+			PRINT_VERBOSE("WASAPI: closest->nBlockAlign = " + itos(closest->nBlockAlign));
+			PRINT_VERBOSE("WASAPI: closest->wBitsPerSample = " + itos(closest->wBitsPerSample));
+			PRINT_VERBOSE("WASAPI: closest->cbSize = " + itos(closest->cbSize));
 
 			WARN_PRINT("WASAPI: Using closest match instead");
 			CoTaskMemFree(pwfex);
@@ -395,7 +395,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 			// In case we're trying to re-initialize the device, prevent throwing this error on the console,
 			// otherwise if there is currently no device available this will spam the console.
 			if (hr != S_OK) {
-				print_verbose("WASAPI: Initialize failed with error 0x" + String::num_uint64(hr, 16) + ".");
+				PRINT_VERBOSE("WASAPI: Initialize failed with error 0x" + String::num_uint64(hr, 16) + ".");
 				CoTaskMemFree(pwfex);
 				return ERR_CANT_OPEN;
 			}
@@ -431,7 +431,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 		// AUDCLNT_STREAMFLAGS_RATEADJUST is an invalid flag with IAudioClient3, therefore we have to use
 		// the closest supported mix rate supported by the audio driver.
 		mix_rate = pwfex->nSamplesPerSec;
-		print_verbose("WASAPI: mix_rate = " + itos(mix_rate));
+		PRINT_VERBOSE("WASAPI: mix_rate = " + itos(mix_rate));
 
 		UINT32 default_period_frames, fundamental_period_frames, min_period_frames, max_period_frames;
 		hr = device_audio_client_3->GetSharedModeEnginePeriod(
@@ -441,7 +441,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 				&min_period_frames,
 				&max_period_frames);
 		if (hr != S_OK) {
-			print_verbose("WASAPI: GetSharedModeEnginePeriod failed with error 0x" + String::num_uint64(hr, 16) + ", falling back to IAudioClient.");
+			PRINT_VERBOSE("WASAPI: GetSharedModeEnginePeriod failed with error 0x" + String::num_uint64(hr, 16) + ", falling back to IAudioClient.");
 			CoTaskMemFree(pwfex);
 			return audio_device_init(p_device, p_input, p_reinit, true);
 		}
@@ -454,15 +454,15 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 			period_frames = period_frames + fundamental_period_frames;
 		}
 		period_frames = CLAMP(period_frames, min_period_frames, max_period_frames);
-		print_verbose("WASAPI: fundamental_period_frames = " + itos(fundamental_period_frames));
-		print_verbose("WASAPI: min_period_frames = " + itos(min_period_frames));
-		print_verbose("WASAPI: max_period_frames = " + itos(max_period_frames));
-		print_verbose("WASAPI: selected a period frame size of " + itos(period_frames));
+		PRINT_VERBOSE("WASAPI: fundamental_period_frames = " + itos(fundamental_period_frames));
+		PRINT_VERBOSE("WASAPI: min_period_frames = " + itos(min_period_frames));
+		PRINT_VERBOSE("WASAPI: max_period_frames = " + itos(max_period_frames));
+		PRINT_VERBOSE("WASAPI: selected a period frame size of " + itos(period_frames));
 		buffer_frames = period_frames;
 
 		hr = device_audio_client_3->InitializeSharedAudioStream(0, period_frames, pwfex, nullptr);
 		if (hr != S_OK) {
-			print_verbose("WASAPI: InitializeSharedAudioStream failed with error 0x" + String::num_uint64(hr, 16) + ", falling back to IAudioClient.");
+			PRINT_VERBOSE("WASAPI: InitializeSharedAudioStream failed with error 0x" + String::num_uint64(hr, 16) + ", falling back to IAudioClient.");
 			CoTaskMemFree(pwfex);
 			return audio_device_init(p_device, p_input, p_reinit, true);
 		} else {
@@ -473,7 +473,7 @@ Error AudioDriverWASAPI::audio_device_init(AudioDeviceWASAPI *p_device, bool p_i
 				real_latency = (float)output_latency_in_frames / (float)current_pwfex->nSamplesPerSec;
 				CoTaskMemFree(current_pwfex);
 			} else {
-				print_verbose("WASAPI: GetCurrentSharedModeEnginePeriod failed with error 0x" + String::num_uint64(hr, 16) + ", falling back to IAudioClient.");
+				PRINT_VERBOSE("WASAPI: GetCurrentSharedModeEnginePeriod failed with error 0x" + String::num_uint64(hr, 16) + ", falling back to IAudioClient.");
 				CoTaskMemFree(pwfex);
 				return audio_device_init(p_device, p_input, p_reinit, true);
 			}
@@ -535,8 +535,8 @@ Error AudioDriverWASAPI::init_output_device(bool p_reinit) {
 	input_position = 0;
 	input_size = 0;
 
-	print_verbose("WASAPI: detected " + itos(audio_output.channels) + " channels");
-	print_verbose("WASAPI: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
+	PRINT_VERBOSE("WASAPI: detected " + itos(audio_output.channels) + " channels");
+	PRINT_VERBOSE("WASAPI: audio buffer frames: " + itos(buffer_frames) + " calculated latency: " + itos(buffer_frames * 1000 / mix_rate) + "ms");
 
 	return OK;
 }

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -702,7 +702,7 @@ void FileAccessWindows::initialize() {
 	}
 
 	_setmaxstdio(8192);
-	print_verbose(vformat("Maximum number of file handles: %d", _getmaxstdio()));
+	PRINT_VERBOSE(vformat("Maximum number of file handles: %d", _getmaxstdio()));
 }
 
 void FileAccessWindows::finalize() {

--- a/drivers/windows/ip_windows.cpp
+++ b/drivers/windows/ip_windows.cpp
@@ -69,12 +69,12 @@ void IPWindows::_resolve_hostname(List<IPAddress> &r_addresses, const String &p_
 
 	int s = getaddrinfo(p_hostname.utf8().get_data(), nullptr, &hints, &result);
 	if (s != 0) {
-		print_verbose("getaddrinfo failed! Cannot resolve hostname.");
+		PRINT_VERBOSE("getaddrinfo failed! Cannot resolve hostname.");
 		return;
 	}
 
 	if (result == nullptr || result->ai_addr == nullptr) {
-		print_verbose("Invalid response from getaddrinfo.");
+		PRINT_VERBOSE("Invalid response from getaddrinfo.");
 		if (result) {
 			freeaddrinfo(result);
 		}

--- a/drivers/windows/net_socket_winsock.cpp
+++ b/drivers/windows/net_socket_winsock.cpp
@@ -142,7 +142,7 @@ NetSocketWinSock::NetError NetSocketWinSock::_get_socket_error() const {
 	if (err == WSAEMSGSIZE || err == WSAENOBUFS) {
 		return ERR_NET_BUFFER_TOO_SMALL;
 	}
-	print_verbose("Socket error: " + itos(err) + ".");
+	PRINT_VERBOSE("Socket error: " + itos(err) + ".");
 	return ERR_NET_OTHER;
 }
 
@@ -256,11 +256,11 @@ Error NetSocketWinSock::open(Family p_family, Type p_sock_type, IP::Type &ip_typ
 		// recv/recvfrom and an ICMP reply was received from a previous send/sendto.
 		unsigned long disable = 0;
 		if (ioctlsocket(_sock, SIO_UDP_CONNRESET, &disable) == SOCKET_ERROR) {
-			print_verbose("Unable to turn off UDP WSAECONNRESET behavior on Windows.");
+			PRINT_VERBOSE("Unable to turn off UDP WSAECONNRESET behavior on Windows.");
 		}
 		if (ioctlsocket(_sock, SIO_UDP_NETRESET, &disable) == SOCKET_ERROR) {
 			// This feature seems not to be supported on wine.
-			print_verbose("Unable to turn off UDP WSAENETRESET behavior on Windows.");
+			PRINT_VERBOSE("Unable to turn off UDP WSAENETRESET behavior on Windows.");
 		}
 	}
 	return OK;
@@ -286,7 +286,7 @@ Error NetSocketWinSock::bind(Address p_addr) {
 
 	if (::bind(_sock, (struct sockaddr *)&addr, addr_size) != 0) {
 		NetError err = _get_socket_error();
-		print_verbose("Failed to bind socket. Error: " + itos(err) + ".");
+		PRINT_VERBOSE("Failed to bind socket. Error: " + itos(err) + ".");
 		close();
 		return ERR_UNAVAILABLE;
 	}
@@ -299,7 +299,7 @@ Error NetSocketWinSock::listen(int p_max_pending) {
 
 	if (::listen(_sock, p_max_pending) != 0) {
 		_get_socket_error();
-		print_verbose("Failed to listen from socket.");
+		PRINT_VERBOSE("Failed to listen from socket.");
 		close();
 		return FAILED;
 	}
@@ -327,7 +327,7 @@ Error NetSocketWinSock::connect_to_host(Address p_addr) {
 			case ERR_NET_IN_PROGRESS:
 				return ERR_BUSY;
 			default:
-				print_verbose("Connection to remote host failed.");
+				PRINT_VERBOSE("Connection to remote host failed.");
 				close();
 				return FAILED;
 		}
@@ -383,7 +383,7 @@ Error NetSocketWinSock::poll(PollType p_type, int p_timeout) const {
 
 	if (FD_ISSET(_sock, &ex)) {
 		_get_socket_error();
-		print_verbose("Exception when polling socket.");
+		PRINT_VERBOSE("Exception when polling socket.");
 		return FAILED;
 	}
 
@@ -564,7 +564,7 @@ int NetSocketWinSock::get_available_bytes() const {
 	int ret = ioctlsocket(_sock, FIONREAD, &len);
 	if (ret == -1) {
 		_get_socket_error();
-		print_verbose("Error when checking available bytes on socket.");
+		PRINT_VERBOSE("Error when checking available bytes on socket.");
 		return -1;
 	}
 	return len;
@@ -577,7 +577,7 @@ Error NetSocketWinSock::get_socket_address(Address *r_addr) const {
 	socklen_t len = sizeof(saddr);
 	if (getsockname(_sock, (struct sockaddr *)&saddr, &len) != 0) {
 		_get_socket_error();
-		print_verbose("Error when reading local socket address.");
+		PRINT_VERBOSE("Error when reading local socket address.");
 		return FAILED;
 	}
 	IPAddress ip;
@@ -598,7 +598,7 @@ Ref<NetSocket> NetSocketWinSock::accept(Address &r_addr) {
 	SOCKET fd = ::accept(_sock, (struct sockaddr *)&their_addr, &size);
 	if (fd == INVALID_SOCKET) {
 		_get_socket_error();
-		print_verbose("Error when accepting socket connection.");
+		PRINT_VERBOSE("Error when accepting socket connection.");
 		return out;
 	}
 

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -119,7 +119,7 @@ void EditorFileServer::poll() {
 	EditorProgress pr("updating_remote_file_system", TTR("Updating assets on target device:"), 105);
 
 	pr.step(TTR("Syncing headers"), 0, true);
-	print_verbose("EFS: Connecting taken!");
+	PRINT_VERBOSE("EFS: Connecting taken!");
 	char header[4];
 	Error err = tcp_peer->get_data((uint8_t *)&header, 4);
 	ERR_FAIL_COND(err != OK);
@@ -135,17 +135,17 @@ void EditorFileServer::poll() {
 	err = tcp_peer->get_data((uint8_t *)cpassword, PASSWORD_LENGTH);
 	cpassword[PASSWORD_LENGTH] = 0;
 	ERR_FAIL_COND(err != OK);
-	print_verbose("EFS: Got password: " + String(cpassword));
+	PRINT_VERBOSE("EFS: Got password: " + String(cpassword));
 	ERR_FAIL_COND_MSG(password != cpassword, "Client disconnected because password mismatch.");
 
 	uint32_t tag_count = tcp_peer->get_u32();
-	print_verbose("EFS: Getting tags: " + itos(tag_count));
+	PRINT_VERBOSE("EFS: Getting tags: " + itos(tag_count));
 
 	ERR_FAIL_COND(tcp_peer->get_status() != StreamPeerTCP::STATUS_CONNECTED);
 	Vector<String> tags;
 	for (uint32_t i = 0; i < tag_count; i++) {
 		String tag = tcp_peer->get_utf8_string();
-		print_verbose("EFS: tag #" + itos(i) + ": " + tag);
+		PRINT_VERBOSE("EFS: tag #" + itos(i) + ": " + tag);
 		ERR_FAIL_COND(tcp_peer->get_status() != StreamPeerTCP::STATUS_CONNECTED);
 		tags.push_back(tag);
 	}
@@ -158,7 +158,7 @@ void EditorFileServer::poll() {
 
 		// Got files cached by client.
 		uint32_t file_buffer_size = tcp_peer->get_32();
-		print_verbose("EFS: Getting file buffer: compressed - " + String::humanize_size(file_buffer_size) + " decompressed: " + String::humanize_size(file_buffer_decompressed_size));
+		PRINT_VERBOSE("EFS: Getting file buffer: compressed - " + String::humanize_size(file_buffer_size) + " decompressed: " + String::humanize_size(file_buffer_decompressed_size));
 
 		ERR_FAIL_COND(tcp_peer->get_status() != StreamPeerTCP::STATUS_CONNECTED);
 		ERR_FAIL_COND(file_buffer_size > MAX_FILE_BUFFER_SIZE);
@@ -178,7 +178,7 @@ void EditorFileServer::poll() {
 		String files_text = String::utf8((const char *)file_buffer_decompressed.ptr(), file_buffer_decompressed.size());
 		Vector<String> files = files_text.split("\n");
 
-		print_verbose("EFS: Total cached files received: " + itos(files.size()));
+		PRINT_VERBOSE("EFS: Total cached files received: " + itos(files.size()));
 		for (int i = 0; i < files.size(); i++) {
 			if (files[i].get_slice_count("::") != 2) {
 				continue;
@@ -194,7 +194,7 @@ void EditorFileServer::poll() {
 
 	pr.step(TTR("Scanning for local changes"), 3, true);
 
-	print_verbose("EFS: Scanning changes:");
+	PRINT_VERBOSE("EFS: Scanning changes:");
 
 	HashMap<String, uint64_t> files_to_send;
 	// Scan files to send.
@@ -215,7 +215,7 @@ void EditorFileServer::poll() {
 
 	tcp_peer->put_32(files_to_send.size());
 
-	print_verbose("EFS: Sending list of changed files.");
+	PRINT_VERBOSE("EFS: Sending list of changed files.");
 	pr.step(TTR("Sending list of changed files:"), 4, true);
 
 	// Send list of changed files first, to ensure that if connecting breaks, the client is not found in a broken state.
@@ -224,7 +224,7 @@ void EditorFileServer::poll() {
 		tcp_peer->put_64(K.value);
 	}
 
-	print_verbose("EFS: Sending " + itos(files_to_send.size()) + " files.");
+	PRINT_VERBOSE("EFS: Sending " + itos(files_to_send.size()) + " files.");
 
 	int idx = 0;
 	for (KeyValue<String, uint64_t> K : files_to_send) {
@@ -243,7 +243,7 @@ void EditorFileServer::poll() {
 
 	tcp_peer->put_data((const uint8_t *)"GEND", 4); // End marker.
 
-	print_verbose("EFS: Done.");
+	PRINT_VERBOSE("EFS: Done.");
 }
 
 void EditorFileServer::start() {

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -442,7 +442,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 		for (uint32_t classes_idx = 0; classes_idx < classes.size(); classes_idx++) {
 			const String &name = classes[classes_idx];
 			if (!ClassDB::is_class_exposed(name)) {
-				print_verbose(vformat("Class '%s' is not exposed, skipping.", name));
+				PRINT_VERBOSE(vformat("Class '%s' is not exposed, skipping.", name));
 				continue;
 			}
 

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3165,7 +3165,7 @@ static void _load_script_doc_cache(bool p_changes) {
 
 void EditorHelp::load_script_doc_cache() {
 	if (!ProjectSettings::get_singleton()->is_project_loaded()) {
-		print_verbose("Skipping loading script doc cache since no project is open.");
+		PRINT_VERBOSE("Skipping loading script doc cache since no project is open.");
 		return;
 	}
 
@@ -3176,7 +3176,7 @@ void EditorHelp::load_script_doc_cache() {
 	_wait_for_thread();
 
 	if (!ResourceLoader::exists(get_script_doc_cache_full_path())) {
-		print_verbose("Script documentation cache not found. Regenerating it may take a while for projects with many scripts.");
+		PRINT_VERBOSE("Script documentation cache not found. Regenerating it may take a while for projects with many scripts.");
 		regenerate_script_doc_cache();
 		return;
 	}
@@ -3211,7 +3211,7 @@ void EditorHelp::_load_script_doc_cache_thread(void *p_udata) {
 
 	Ref<Resource> script_doc_cache_res = ResourceLoader::load(get_script_doc_cache_full_path(), "", ResourceFormatLoader::CACHE_MODE_IGNORE);
 	if (script_doc_cache_res.is_null()) {
-		print_verbose("Script doc cache is corrupted. Regenerating it instead.");
+		PRINT_VERBOSE("Script doc cache is corrupted. Regenerating it instead.");
 		_delete_script_doc_cache();
 		callable_mp_static(EditorHelp::regenerate_script_doc_cache).call_deferred();
 		return;
@@ -3304,7 +3304,7 @@ void EditorHelp::_delete_script_doc_cache() {
 
 void EditorHelp::save_script_doc_cache() {
 	if (!_script_docs_loaded.is_set()) {
-		print_verbose("Script docs haven't been properly loaded or regenerated, so don't save them to disk.");
+		PRINT_VERBOSE("Script docs haven't been properly loaded or regenerated, so don't save them to disk.");
 		return;
 	}
 
@@ -3340,7 +3340,7 @@ void EditorHelp::generate_doc(bool p_use_cache, bool p_use_script_cache) {
 	if (p_use_cache && FileAccess::exists(get_cache_full_path())) {
 		worker_thread.start(_load_doc_thread, (void *)p_use_script_cache);
 	} else {
-		print_verbose("Regenerating editor help cache");
+		PRINT_VERBOSE("Regenerating editor help cache");
 		doc->generate();
 		worker_thread.start(_gen_doc_thread, (void *)p_use_script_cache);
 	}

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3126,7 +3126,7 @@ static void _load_script_doc_cache(bool p_changes) {
 
 void EditorHelp::load_script_doc_cache() {
 	if (!ProjectSettings::get_singleton()->is_project_loaded()) {
-		print_verbose("Skipping loading script doc cache since no project is open.");
+		PRINT_VERBOSE("Skipping loading script doc cache since no project is open.");
 		return;
 	}
 
@@ -3137,7 +3137,7 @@ void EditorHelp::load_script_doc_cache() {
 	_wait_for_thread();
 
 	if (!ResourceLoader::exists(get_script_doc_cache_full_path())) {
-		print_verbose("Script documentation cache not found. Regenerating it may take a while for projects with many scripts.");
+		PRINT_VERBOSE("Script documentation cache not found. Regenerating it may take a while for projects with many scripts.");
 		regenerate_script_doc_cache();
 		return;
 	}
@@ -3172,7 +3172,7 @@ void EditorHelp::_load_script_doc_cache_thread(void *p_udata) {
 
 	Ref<Resource> script_doc_cache_res = ResourceLoader::load(get_script_doc_cache_full_path(), "", ResourceFormatLoader::CACHE_MODE_IGNORE);
 	if (script_doc_cache_res.is_null()) {
-		print_verbose("Script doc cache is corrupted. Regenerating it instead.");
+		PRINT_VERBOSE("Script doc cache is corrupted. Regenerating it instead.");
 		_delete_script_doc_cache();
 		callable_mp_static(EditorHelp::regenerate_script_doc_cache).call_deferred();
 		return;
@@ -3265,7 +3265,7 @@ void EditorHelp::_delete_script_doc_cache() {
 
 void EditorHelp::save_script_doc_cache() {
 	if (!_script_docs_loaded.is_set()) {
-		print_verbose("Script docs haven't been properly loaded or regenerated, so don't save them to disk.");
+		PRINT_VERBOSE("Script docs haven't been properly loaded or regenerated, so don't save them to disk.");
 		return;
 	}
 
@@ -3301,7 +3301,7 @@ void EditorHelp::generate_doc(bool p_use_cache, bool p_use_script_cache) {
 	if (p_use_cache && FileAccess::exists(get_cache_full_path())) {
 		worker_thread.start(_load_doc_thread, (void *)p_use_script_cache);
 	} else {
-		print_verbose("Regenerating editor help cache");
+		PRINT_VERBOSE("Regenerating editor help cache");
 		doc->generate();
 		worker_thread.start(_gen_doc_thread, (void *)p_use_script_cache);
 	}

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1565,7 +1565,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 	}
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	print_verbose("Moving " + old_path + " -> " + new_path);
+	PRINT_VERBOSE("Moving " + old_path + " -> " + new_path);
 	Error err = da->rename(old_path, new_path);
 	if (err == OK) {
 		// Move/Rename any corresponding import settings too.
@@ -1601,7 +1601,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		// Only treat as a changed dependency if it was successfully moved.
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			p_file_renames[file_changed_paths[i]] = file_changed_paths[i].replace_first(old_path, new_path);
-			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
+			PRINT_VERBOSE("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
 			emit_signal(SNAME("files_moved"), file_changed_paths[i], p_file_renames[file_changed_paths[i]]);
 		}
 		for (int i = 0; i < folder_changed_paths.size(); ++i) {
@@ -1630,7 +1630,7 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 	}
 
 	if (p_item.is_file) {
-		print_verbose("Duplicating " + old_path + " -> " + new_path);
+		PRINT_VERBOSE("Duplicating " + old_path + " -> " + new_path);
 
 		// Create the directory structure.
 		EditorFileSystem::get_singleton()->make_dir_recursive(p_new_path.get_base_dir());
@@ -1676,7 +1676,7 @@ void FileSystemDock::_update_resource_paths_after_move(const HashMap<String, Str
 			files_to_update.push_back(E.value);
 		}
 	}
-	print_verbose("FileSystem: updating file infos.");
+	PRINT_VERBOSE("FileSystem: updating file infos.");
 	EditorFileSystem::get_singleton()->update_files(files_to_update);
 }
 
@@ -1692,7 +1692,7 @@ void FileSystemDock::_update_dependencies_after_move(const HashMap<String, Strin
 		// Because we haven't called a rescan yet the found remap might still be an old path itself.
 		const HashMap<String, String>::ConstIterator I = p_renames.find(E);
 		const String file = I ? I->value : E;
-		print_verbose("Remapping dependencies for: " + file);
+		PRINT_VERBOSE("Remapping dependencies for: " + file);
 		const Error err = ResourceLoader::rename_dependencies(file, p_renames);
 		if (err == OK) {
 			if (ResourceLoader::get_resource_type(file) == "PackedScene" && EditorNode::get_editor_data().get_edited_scene_from_path(file) != -1) {
@@ -1946,7 +1946,7 @@ void FileSystemDock::_rename_operation_confirm() {
 		current_path_line_edit->set_text(current_path);
 	}
 
-	print_verbose("FileSystem: calling rescan.");
+	PRINT_VERBOSE("FileSystem: calling rescan.");
 	_rescan();
 }
 
@@ -2107,7 +2107,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 
 			EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
 
-			print_verbose("FileSystem: calling rescan.");
+			PRINT_VERBOSE("FileSystem: calling rescan.");
 			_rescan();
 
 			current_path = p_to_path;

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1571,7 +1571,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 	}
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	print_verbose("Moving " + old_path + " -> " + new_path);
+	PRINT_VERBOSE("Moving " + old_path + " -> " + new_path);
 	Error err = da->rename(old_path, new_path);
 	if (err == OK) {
 		// Move/Rename any corresponding import settings too.
@@ -1607,7 +1607,7 @@ void FileSystemDock::_try_move_item(const FileOrFolder &p_item, const String &p_
 		// Only treat as a changed dependency if it was successfully moved.
 		for (int i = 0; i < file_changed_paths.size(); ++i) {
 			p_file_renames[file_changed_paths[i]] = file_changed_paths[i].replace_first(old_path, new_path);
-			print_verbose("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
+			PRINT_VERBOSE("  Remap: " + file_changed_paths[i] + " -> " + p_file_renames[file_changed_paths[i]]);
 			emit_signal(SNAME("files_moved"), file_changed_paths[i], p_file_renames[file_changed_paths[i]]);
 		}
 		for (int i = 0; i < folder_changed_paths.size(); ++i) {
@@ -1636,7 +1636,7 @@ void FileSystemDock::_try_duplicate_item(const FileOrFolder &p_item, const Strin
 	}
 
 	if (p_item.is_file) {
-		print_verbose("Duplicating " + old_path + " -> " + new_path);
+		PRINT_VERBOSE("Duplicating " + old_path + " -> " + new_path);
 
 		// Create the directory structure.
 		EditorFileSystem::get_singleton()->make_dir_recursive(p_new_path.get_base_dir());
@@ -1682,7 +1682,7 @@ void FileSystemDock::_update_resource_paths_after_move(const HashMap<String, Str
 			files_to_update.push_back(E.value);
 		}
 	}
-	print_verbose("FileSystem: updating file infos.");
+	PRINT_VERBOSE("FileSystem: updating file infos.");
 	EditorFileSystem::get_singleton()->update_files(files_to_update);
 }
 
@@ -1698,7 +1698,7 @@ void FileSystemDock::_update_dependencies_after_move(const HashMap<String, Strin
 		// Because we haven't called a rescan yet the found remap might still be an old path itself.
 		const HashMap<String, String>::ConstIterator I = p_renames.find(E);
 		const String file = I ? I->value : E;
-		print_verbose("Remapping dependencies for: " + file);
+		PRINT_VERBOSE("Remapping dependencies for: " + file);
 		const Error err = ResourceLoader::rename_dependencies(file, p_renames);
 		if (err == OK) {
 			if (ResourceLoader::get_resource_type(file) == "PackedScene" && EditorNode::get_editor_data().get_edited_scene_from_path(file) != -1) {
@@ -1952,7 +1952,7 @@ void FileSystemDock::_rename_operation_confirm() {
 		current_path_line_edit->set_text(current_path);
 	}
 
-	print_verbose("FileSystem: calling rescan.");
+	PRINT_VERBOSE("FileSystem: calling rescan.");
 	_rescan();
 }
 
@@ -2113,7 +2113,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_cop
 
 			EditorSceneTabs::get_singleton()->set_current_tab(current_tab);
 
-			print_verbose("FileSystem: calling rescan.");
+			PRINT_VERBOSE("FileSystem: calling rescan.");
 			_rescan();
 
 			current_path = p_to_path;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1136,7 +1136,7 @@ void EditorNode::_notification(int p_what) {
 					tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(0);
 				}
 				DisplayServer::get_singleton()->tablet_set_current_driver(tablet_driver);
-				print_verbose("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
+				PRINT_VERBOSE("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
 			}
 
 			if (EDITOR_GET("interface/editor/behavior/import_resources_when_unfocused")) {
@@ -4266,7 +4266,7 @@ void EditorNode::_exit_editor(int p_exit_code) {
 
 void EditorNode::unload_editor_addons() {
 	for (const KeyValue<String, EditorPlugin *> &E : addon_name_to_plugin) {
-		print_verbose(vformat("Unloading addon: %s", E.key));
+		PRINT_VERBOSE(vformat("Unloading addon: %s", E.key));
 		remove_editor_plugin(E.value, false);
 		memdelete(E.value);
 	}
@@ -8011,7 +8011,7 @@ void EditorNode::_print_handler_impl(const String &p_string, bool p_error, bool 
 static void _execute_thread(void *p_ud) {
 	EditorNode::ExecuteThreadArgs *eta = (EditorNode::ExecuteThreadArgs *)p_ud;
 	Error err = OS::get_singleton()->execute(eta->path, eta->args, &eta->output, &eta->exitcode, true, &eta->execute_output_mutex);
-	print_verbose("Thread exit status: " + itos(eta->exitcode));
+	PRINT_VERBOSE("Thread exit status: " + itos(eta->exitcode));
 	if (err != OK) {
 		eta->exitcode = err;
 	}
@@ -9494,7 +9494,7 @@ EditorNode::EditorNode() {
 	if (AssetLibraryEditorPlugin::is_available()) {
 		add_editor_plugin(memnew(AssetLibraryEditorPlugin));
 	} else {
-		print_verbose("Asset Store not available (due to using Web editor, or SSL support disabled).");
+		PRINT_VERBOSE("Asset Store not available (due to using Web editor, or SSL support disabled).");
 	}
 
 	// More visually meaningful to have this later.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1138,7 +1138,7 @@ void EditorNode::_notification(int p_what) {
 					tablet_driver = DisplayServer::get_singleton()->tablet_get_driver_name(0);
 				}
 				DisplayServer::get_singleton()->tablet_set_current_driver(tablet_driver);
-				print_verbose("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
+				PRINT_VERBOSE("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
 			}
 
 			if (EDITOR_GET("interface/editor/behavior/import_resources_when_unfocused")) {
@@ -4247,7 +4247,7 @@ void EditorNode::_exit_editor(int p_exit_code) {
 
 void EditorNode::unload_editor_addons() {
 	for (const KeyValue<String, EditorPlugin *> &E : addon_name_to_plugin) {
-		print_verbose(vformat("Unloading addon: %s", E.key));
+		PRINT_VERBOSE(vformat("Unloading addon: %s", E.key));
 		remove_editor_plugin(E.value, false);
 		memdelete(E.value);
 	}
@@ -7970,7 +7970,7 @@ void EditorNode::_print_handler_impl(const String &p_string, bool p_error, bool 
 static void _execute_thread(void *p_ud) {
 	EditorNode::ExecuteThreadArgs *eta = (EditorNode::ExecuteThreadArgs *)p_ud;
 	Error err = OS::get_singleton()->execute(eta->path, eta->args, &eta->output, &eta->exitcode, true, &eta->execute_output_mutex);
-	print_verbose("Thread exit status: " + itos(eta->exitcode));
+	PRINT_VERBOSE("Thread exit status: " + itos(eta->exitcode));
 	if (err != OK) {
 		eta->exitcode = err;
 	}
@@ -9470,7 +9470,7 @@ EditorNode::EditorNode() {
 	if (AssetLibraryEditorPlugin::is_available()) {
 		add_editor_plugin(memnew(AssetLibraryEditorPlugin));
 	} else {
-		print_verbose("Asset Store not available (due to using Web editor, or SSL support disabled).");
+		PRINT_VERBOSE("Asset Store not available (due to using Web editor, or SSL support disabled).");
 	}
 
 	// More visually meaningful to have this later.

--- a/editor/export/android_sdk_manager.cpp
+++ b/editor/export/android_sdk_manager.cpp
@@ -110,18 +110,18 @@ void AndroidSDKManager::_notification(int p_what) {
 								err_output.append_utf8((const char *)buf.ptr(), buf_size);
 
 								if (!output.is_empty()) {
-									print_verbose(output);
+									PRINT_VERBOSE(output);
 									execute_outputs->add_text(output);
 								}
 
 								if (!err_output.is_empty()) {
-									print_verbose(err_output);
+									PRINT_VERBOSE(err_output);
 									execute_outputs->add_text(err_output);
 								}
 							}
 						} else {
 							int exit_code = OS::get_singleton()->get_process_exit_code(setup_android_pid);
-							print_verbose("Exit code: " + itos(exit_code));
+							PRINT_VERBOSE("Exit code: " + itos(exit_code));
 							execute_outputs->add_text("\nExit code: " + itos(exit_code));
 							_android_sdk_installed(exit_code);
 						}
@@ -141,33 +141,33 @@ void AndroidSDKManager::_cancel_setup() {
 		} break;
 
 		case PROMPTING_ANDROID_ONLINE_ACCESS: {
-			print_verbose("Canceling online mode request prompt for Android SDK setup.");
+			PRINT_VERBOSE("Canceling online mode request prompt for Android SDK setup.");
 		} break;
 
 		case PROMPTING_ANDROID_SDK_SETUP: {
-			print_verbose("Canceling Android SDK setup prompt.");
+			PRINT_VERBOSE("Canceling Android SDK setup prompt.");
 		} break;
 
 		case PROMPTING_JAVA_ONLINE_ACCESS: {
-			print_verbose("Canceling online mode request prompt for Java SDK setup.");
+			PRINT_VERBOSE("Canceling online mode request prompt for Java SDK setup.");
 		} break;
 
 		case PROMPTING_JAVA_SDK_SETUP: {
-			print_verbose("Canceling Java SDK setup prompt.");
+			PRINT_VERBOSE("Canceling Java SDK setup prompt.");
 		} break;
 
 		case DOWNLOADING_ANDROID_SDK: {
-			print_verbose("Canceling Android SDK download.");
+			PRINT_VERBOSE("Canceling Android SDK download.");
 			downloader->cancel_request();
 		} break;
 
 		case DOWNLOADING_JAVA_SDK: {
-			print_verbose("Canceling Java SDK download.");
+			PRINT_VERBOSE("Canceling Java SDK download.");
 			downloader->cancel_request();
 		} break;
 
 		case INSTALLING_ANDROID_SDK: {
-			print_verbose("Canceling Android SDK installation.");
+			PRINT_VERBOSE("Canceling Android SDK installation.");
 			int setup_android_pid = setup_process_data["pid"];
 			if (setup_android_pid > 0 && OS::get_singleton()->is_process_running(setup_android_pid)) {
 				OS::get_singleton()->kill(setup_android_pid);
@@ -175,7 +175,7 @@ void AndroidSDKManager::_cancel_setup() {
 		} break;
 
 		case INSTALLING_JAVA_SDK: {
-			print_verbose("Canceling Java SDK installation.");
+			PRINT_VERBOSE("Canceling Java SDK installation.");
 		} break;
 	}
 
@@ -323,12 +323,12 @@ void AndroidSDKManager::_install_android_sdk_packages() {
 	const char **packages = ANDROID_SDK_PACKAGES;
 	while (*packages) {
 		String package = String(*packages);
-		print_verbose("Requesting Android SDK package " + package);
+		PRINT_VERBOSE("Requesting Android SDK package " + package);
 		cli_args.push_back(package);
 		packages++;
 	}
 
-	print_verbose("Installing Android SDK packages to " + default_android_sdk_path);
+	PRINT_VERBOSE("Installing Android SDK packages to " + default_android_sdk_path);
 	setup_process_data = OS::get_singleton()->execute_with_pipe(cli_bin, cli_args, false);
 	if (!setup_process_data.has("pid") || setup_process_data["pid"].operator int() <= 0) {
 		ERR_PRINT("Installation of Android SDK packages failed.");
@@ -360,7 +360,7 @@ void AndroidSDKManager::_android_sdk_installed(int p_exit_code) {
 
 void AndroidSDKManager::_setup_android_sdk() {
 	if (is_android_sdk_setup()) {
-		print_verbose("Android SDK is already setup!");
+		PRINT_VERBOSE("Android SDK is already setup!");
 		return;
 	}
 
@@ -384,7 +384,7 @@ void AndroidSDKManager::_setup_android_sdk() {
 
 void AndroidSDKManager::_setup_java_sdk() {
 	if (is_java_sdk_setup()) {
-		print_verbose("Java SDK is already setup!");
+		PRINT_VERBOSE("Java SDK is already setup!");
 		return;
 	}
 
@@ -428,7 +428,7 @@ void AndroidSDKManager::_download_java_sdk() {
 		ERR_PRINT("Failed to start Java SDK download.");
 		_cancel_setup();
 	} else {
-		print_verbose("Downloading Java SDK from " + url);
+		PRINT_VERBOSE("Downloading Java SDK from " + url);
 		_show_setup_dialog(DOWNLOADING_JAVA_SDK);
 	}
 }
@@ -461,7 +461,7 @@ void AndroidSDKManager::_java_sdk_downloaded(const PackedByteArray &p_body) {
 		ERR_PRINT("Failed to save Java SDK archive.");
 		return;
 	}
-	print_verbose("Storing Java SDK archive to " + archive_path);
+	PRINT_VERBOSE("Storing Java SDK archive to " + archive_path);
 	f->store_buffer(p_body.ptr(), p_body.size());
 	f.unref();
 
@@ -474,7 +474,7 @@ void AndroidSDKManager::_java_sdk_downloaded(const PackedByteArray &p_body) {
 	}
 
 	// Remove temporary archive.
-	print_verbose("Deleting Java SDK archive...");
+	PRINT_VERBOSE("Deleting Java SDK archive...");
 	DirAccess::remove_file_or_error(archive_path);
 
 	_java_sdk_installed();
@@ -495,7 +495,7 @@ void AndroidSDKManager::_java_sdk_installed() {
 }
 
 Error AndroidSDKManager::_extract_java_sdk(const String &p_file, const String &p_target_path) {
-	print_verbose(vformat("Extracting Java SDK from %s to %s", p_file, p_target_path));
+	PRINT_VERBOSE(vformat("Extracting Java SDK from %s to %s", p_file, p_target_path));
 	if (OS::get_singleton()->has_feature("windows")) {
 		Ref<ZIPReader> reader;
 		reader.instantiate();
@@ -594,7 +594,7 @@ void AndroidSDKManager::_download_android_cli() {
 		ERR_PRINT("Failed to start android-cli download.");
 		_cancel_setup();
 	} else {
-		print_verbose("Downloading android-cli from " + url);
+		PRINT_VERBOSE("Downloading android-cli from " + url);
 		_show_setup_dialog(DOWNLOADING_ANDROID_SDK);
 	}
 }
@@ -616,7 +616,7 @@ void AndroidSDKManager::_android_cli_downloaded(const PackedByteArray &p_body) {
 	if (f.is_null()) {
 		ERR_PRINT("Failed to save android-cli binary.");
 	} else {
-		print_verbose("Storing android-cli to " + cli_bin);
+		PRINT_VERBOSE("Storing android-cli to " + cli_bin);
 		f->store_buffer(p_body.ptr(), p_body.size());
 		f.unref();
 

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -169,7 +169,7 @@ bool CodeSignCodeResources::add_file1(const String &p_root, const String &p_path
 	f.optional = (found == CRMatch::CR_MATCH_OPTIONAL);
 	f.nested = false;
 	f.hash = hash_sha1_base64(p_root.path_join(p_path));
-	print_verbose(vformat("CodeSign/CodeResources: File(V1) %s hash1:%s", f.name, f.hash));
+	PRINT_VERBOSE(vformat("CodeSign/CodeResources: File(V1) %s hash1:%s", f.name, f.hash));
 
 	files1.push_back(f);
 	return true;
@@ -191,7 +191,7 @@ bool CodeSignCodeResources::add_file2(const String &p_root, const String &p_path
 	f.hash = hash_sha1_base64(p_root.path_join(p_path));
 	f.hash2 = hash_sha256_base64(p_root.path_join(p_path));
 
-	print_verbose(vformat("CodeSign/CodeResources: File(V2) %s hash1:%s hash2:%s", f.name, f.hash, f.hash2));
+	PRINT_VERBOSE(vformat("CodeSign/CodeResources: File(V2) %s hash1:%s hash2:%s", f.name, f.hash, f.hash2));
 
 	files2.push_back(f);
 	return true;
@@ -262,7 +262,7 @@ bool CodeSignCodeResources::add_nested_file(const String &p_root, const String &
 		if (req_string.is_empty()) {
 			req_string = "cdhash H\"" + String::hex_encode_buffer(hash.ptr(), hash.size()) + "\"";
 		}
-		print_verbose(vformat("CodeSign/CodeResources: Nested object %s (cputype: %d) cdhash:%s designated rq:%s", f.name, mh.get_cputype(), f.hash, req_string));
+		PRINT_VERBOSE(vformat("CodeSign/CodeResources: Nested object %s (cputype: %d) cdhash:%s designated rq:%s", f.name, mh.get_cputype(), f.hash, req_string));
 		if (f.requirements != req_string) {
 			if (i != 0) {
 				f.requirements += " or ";
@@ -349,7 +349,7 @@ bool CodeSignCodeResources::add_folder_recursive(const String &p_root, const Str
 bool CodeSignCodeResources::save_to_file(const String &p_path) {
 	PList pl;
 
-	print_verbose(vformat("CodeSign/CodeResources: Writing to file: %s", p_path));
+	PRINT_VERBOSE(vformat("CodeSign/CodeResources: Writing to file: %s", p_path));
 
 	// Write version 1 hashes.
 	Ref<PListNode> files1_dict = PListNode::new_dict();
@@ -1187,7 +1187,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 		} \
 	}
 
-	print_verbose(vformat("CodeSign: Signing executable: %s, bundle: %s with entitlements %s", p_exe_path, p_bundle_path, p_ent_path));
+	PRINT_VERBOSE(vformat("CodeSign: Signing executable: %s, bundle: %s with entitlements %s", p_exe_path, p_bundle_path, p_ent_path));
 
 	PackedByteArray info_hash1, info_hash2;
 	PackedByteArray res_hash1, res_hash2;
@@ -1202,7 +1202,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 
 	// Read Info.plist.
 	if (!p_info.is_empty()) {
-		print_verbose("CodeSign: Reading bundle info...");
+		PRINT_VERBOSE("CodeSign: Reading bundle info...");
 		PList info_plist;
 		if (info_plist.load_file(p_info)) {
 			info_hash1 = file_hash_sha1(p_info);
@@ -1234,7 +1234,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 	// Extract fat binary.
 	Vector<String> files_to_sign;
 	if (LipO::is_lipo(main_exe)) {
-		print_verbose(vformat("CodeSign: Executable is fat, extracting..."));
+		PRINT_VERBOSE(vformat("CodeSign: Executable is fat, extracting..."));
 		String tmp_path_name = EditorPaths::get_singleton()->get_temp_dir().path_join("_lipo");
 		Error err = da->make_dir_recursive(tmp_path_name);
 		if (err != OK) {
@@ -1253,7 +1253,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 			}
 		}
 	} else if (MachO::is_macho(main_exe)) {
-		print_verbose("CodeSign: Executable is thin...");
+		PRINT_VERBOSE("CodeSign: Executable is thin...");
 		files_to_sign.push_back(main_exe);
 	} else {
 		r_error_msg = TTR("Invalid binary format.");
@@ -1275,7 +1275,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 
 	// Generate core resources.
 	if (!p_bundle_path.is_empty()) {
-		print_verbose("CodeSign: Generating bundle CodeResources...");
+		PRINT_VERBOSE("CodeSign: Generating bundle CodeResources...");
 		CodeSignCodeResources cr;
 
 		if (p_ios_bundle) {
@@ -1353,9 +1353,9 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 		id = (String("a-55554944") /*a-UUID*/ + String::hex_encode_buffer(uuid, 16));
 	}
 	CharString uuid_str = id.utf8();
-	print_verbose(vformat("CodeSign: Used bundle ID: %s", id));
+	PRINT_VERBOSE(vformat("CodeSign: Used bundle ID: %s", id));
 
-	print_verbose("CodeSign: Processing entitlements...");
+	PRINT_VERBOSE("CodeSign: Processing entitlements...");
 
 	Ref<CodeSignEntitlementsText> cet;
 	Ref<CodeSignEntitlementsBinary> ceb;
@@ -1370,7 +1370,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 		ceb.instantiate(entitlements);
 	}
 
-	print_verbose("CodeSign: Generating requirements...");
+	PRINT_VERBOSE("CodeSign: Generating requirements...");
 	Ref<CodeSignRequirements> rq;
 	String team_id = "";
 	rq.instantiate();
@@ -1383,12 +1383,12 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 			r_error_msg = TTR("Invalid executable file.");
 			ERR_FAIL_V_MSG(FAILED, "CodeSign: Invalid executable file.");
 		}
-		print_verbose(vformat("CodeSign: Signing executable for cputype: %d ...", mh.get_cputype()));
+		PRINT_VERBOSE(vformat("CodeSign: Signing executable for cputype: %d ...", mh.get_cputype()));
 
-		print_verbose("CodeSign: Generating CodeDirectory...");
+		PRINT_VERBOSE("CodeSign: Generating CodeDirectory...");
 		Ref<CodeSignCodeDirectory> cd1 = memnew(CodeSignCodeDirectory(0x14, 0x01, true, uuid_str, team_id.utf8(), 12, mh.get_exe_limit(), mh.get_code_limit()));
 		Ref<CodeSignCodeDirectory> cd2 = memnew(CodeSignCodeDirectory(0x20, 0x02, true, uuid_str, team_id.utf8(), 12, mh.get_exe_limit(), mh.get_code_limit()));
-		print_verbose("CodeSign: Calculating special slot hashes...");
+		PRINT_VERBOSE("CodeSign: Calculating special slot hashes...");
 		if (info_hash2.size() == 0x20) {
 			cd2->set_hash_in_slot(info_hash2, CodeSignCodeDirectory::SLOT_INFO_PLIST);
 		}
@@ -1426,14 +1426,14 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 		sign_size += 16; // Empty signature size.
 
 		// Alloc/resize signature load command.
-		print_verbose(vformat("CodeSign: Reallocating space for the signature superblob (%d)...", sign_size));
+		PRINT_VERBOSE(vformat("CodeSign: Reallocating space for the signature superblob (%d)...", sign_size));
 		if (!mh.set_signature_size(sign_size)) {
 			CLEANUP();
 			r_error_msg = TTR("Can't resize signature load command.");
 			ERR_FAIL_V_MSG(FAILED, "CodeSign: Can't resize signature load command.");
 		}
 
-		print_verbose("CodeSign: Calculating executable code hashes...");
+		PRINT_VERBOSE("CodeSign: Calculating executable code hashes...");
 		// Calculate executable code hashes.
 		PackedByteArray buffer;
 		PackedByteArray hash1, hash2;
@@ -1470,11 +1470,11 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 			cd1->set_hash_in_slot(hash1, cd1->get_page_count());
 		}
 
-		print_verbose("CodeSign: Generating signature...");
+		PRINT_VERBOSE("CodeSign: Generating signature...");
 		Ref<CodeSignSignature> cs;
 		cs.instantiate();
 
-		print_verbose("CodeSign: Writing signature superblob...");
+		PRINT_VERBOSE("CodeSign: Writing signature superblob...");
 		// Write signature data to the executable.
 		CodeSignSuperBlob sb = CodeSignSuperBlob();
 		sb.add_blob(cd2);
@@ -1491,7 +1491,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 		sb.write_to_file(mh.get_file());
 	}
 	if (files_to_sign.size() > 1) {
-		print_verbose("CodeSign: Rebuilding fat executable...");
+		PRINT_VERBOSE("CodeSign: Rebuilding fat executable...");
 		LipO lip;
 		if (!lip.create_file(main_exe, files_to_sign)) {
 			CLEANUP();

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -529,14 +529,14 @@ Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> 
 		double reduction_ratio = reduction_bytes / (double)p_data.size();
 
 		if (reduction_ratio >= p_preset->get_patch_delta_min_reduction()) {
-			print_verbose(vformat("Used delta encoding for patch of \"%s\", resulting in a patch of %d bytes, which reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+			PRINT_VERBOSE(vformat("Used delta encoding for patch of \"%s\", resulting in a patch of %d bytes, which reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
 		} else {
-			print_verbose(vformat("Skipped delta encoding for patch of \"%s\", as it resulted in a patch of %d bytes, which only reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+			PRINT_VERBOSE(vformat("Skipped delta encoding for patch of \"%s\", as it resulted in a patch of %d bytes, which only reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
 			patch_data = p_data;
 			delta = false;
 		}
 	} else {
-		print_verbose(vformat("Skipped delta encoding for patch of \"%s\", due to include/exclude filters.", p_path));
+		PRINT_VERBOSE(vformat("Skipped delta encoding for patch of \"%s\", due to include/exclude filters.", p_path));
 	}
 
 	return _save_pack_file(p_preset, p_userdata, p_path, patch_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed, delta);
@@ -2624,9 +2624,9 @@ Error EditorExportPlatform::ssh_run_on_remote(const String &p_host, const String
 
 	Error err = OS::get_singleton()->execute(ssh_path, args, &out, &exit_code, true);
 	if (out.is_empty()) {
-		print_verbose(vformat("Exit code: %d", exit_code));
+		PRINT_VERBOSE(vformat("Exit code: %d", exit_code));
 	} else {
-		print_verbose(vformat("Exit code: %d, Output: %s", exit_code, out.replace("\r\n", "\n")));
+		PRINT_VERBOSE(vformat("Exit code: %d, Output: %s", exit_code, out.replace("\r\n", "\n")));
 	}
 	if (r_out) {
 		*r_out = out.replace("\r\n", "\n").get_slicec('\n', 0);
@@ -2738,7 +2738,7 @@ Array EditorExportPlatform::get_current_presets() const {
 String EditorExportPlatform::simplify_path(const String &p_path) {
 	if (p_path.begins_with("uid://")) {
 		const String path = ResourceUID::uid_to_path(p_path);
-		print_verbose(vformat(R"(UID-referenced exported file name "%s" was replaced with "%s".)", p_path, path));
+		PRINT_VERBOSE(vformat(R"(UID-referenced exported file name "%s" was replaced with "%s".)", p_path, path));
 		return path.simplify_path();
 	} else {
 		return p_path.simplify_path();

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -526,14 +526,14 @@ Error EditorExportPlatform::_save_pack_patch_file(const Ref<EditorExportPreset> 
 		double reduction_ratio = reduction_bytes / (double)p_data.size();
 
 		if (reduction_ratio >= p_preset->get_patch_delta_min_reduction()) {
-			print_verbose(vformat("Used delta encoding for patch of \"%s\", resulting in a patch of %d bytes, which reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_info.path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+			PRINT_VERBOSE(vformat("Used delta encoding for patch of \"%s\", resulting in a patch of %d bytes, which reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_info.path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
 		} else {
-			print_verbose(vformat("Skipped delta encoding for patch of \"%s\", as it resulted in a patch of %d bytes, which only reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_info.path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
+			PRINT_VERBOSE(vformat("Skipped delta encoding for patch of \"%s\", as it resulted in a patch of %d bytes, which only reduced the size by %.1f%% (%d bytes) compared to the actual file.", p_info.path, patch_data.size(), reduction_ratio * 100, reduction_bytes));
 			patch_data = p_data;
 			delta = false;
 		}
 	} else {
-		print_verbose(vformat("Skipped delta encoding for patch of \"%s\", due to include/exclude filters.", p_info.path));
+		PRINT_VERBOSE(vformat("Skipped delta encoding for patch of \"%s\", due to include/exclude filters.", p_info.path));
 	}
 
 	SaveFileInfo new_file_info = p_info;
@@ -2585,9 +2585,9 @@ Error EditorExportPlatform::ssh_run_on_remote(const String &p_host, const String
 
 	Error err = OS::get_singleton()->execute(ssh_path, args, &out, &exit_code, true);
 	if (out.is_empty()) {
-		print_verbose(vformat("Exit code: %d", exit_code));
+		PRINT_VERBOSE(vformat("Exit code: %d", exit_code));
 	} else {
-		print_verbose(vformat("Exit code: %d, Output: %s", exit_code, out.replace("\r\n", "\n")));
+		PRINT_VERBOSE(vformat("Exit code: %d, Output: %s", exit_code, out.replace("\r\n", "\n")));
 	}
 	if (r_out) {
 		*r_out = out.replace("\r\n", "\n").get_slicec('\n', 0);
@@ -2697,7 +2697,7 @@ Array EditorExportPlatform::get_current_presets() const {
 String EditorExportPlatform::simplify_path(const String &p_path) {
 	if (p_path.begins_with("uid://")) {
 		const String path = ResourceUID::uid_to_path(p_path);
-		print_verbose(vformat(R"(UID-referenced exported file name "%s" was replaced with "%s".)", p_path, path));
+		PRINT_VERBOSE(vformat(R"(UID-referenced exported file name "%s" was replaced with "%s".)", p_path, path));
 		return path.simplify_path();
 	} else {
 		return p_path.simplify_path();

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -881,7 +881,7 @@ Error EditorExportPlatformAppleEmbedded::_codesign(String p_file, void *p_userda
 		codesign_args.push_back(p_file);
 		String str;
 		Error err = OS::get_singleton()->execute("codesign", codesign_args, &str, nullptr, true);
-		print_verbose("codesign (" + p_file + "):\n" + str);
+		PRINT_VERBOSE("codesign (" + p_file + "):\n" + str);
 
 		return err;
 	}

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -889,7 +889,7 @@ Error EditorExportPlatformAppleEmbedded::_codesign(String p_file, void *p_userda
 		codesign_args.push_back(p_file);
 		String str;
 		Error err = OS::get_singleton()->execute("codesign", codesign_args, &str, nullptr, true);
-		print_verbose("codesign (" + p_file + "):\n" + str);
+		PRINT_VERBOSE("codesign (" + p_file + "):\n" + str);
 
 		return err;
 	}

--- a/editor/export/export_template_manager.cpp
+++ b/editor/export/export_template_manager.cpp
@@ -1464,7 +1464,7 @@ Error ExportTemplateManager::delete_android_build_directory(const Ref<EditorExpo
 
 	String build_dir = get_android_build_directory(p_preset);
 	String parent_dir = build_dir.get_base_dir();
-	print_verbose("Deleting android build directory " + build_dir);
+	PRINT_VERBOSE("Deleting android build directory " + build_dir);
 
 	ProgressDialog::get_singleton()->add_task("deleting_android_build_dir", TTR("Deleting Android Build Directory"), 1);
 
@@ -1494,7 +1494,7 @@ Error ExportTemplateManager::install_android_template_from_file(const String &p_
 
 	String build_dir = get_android_build_directory(p_preset);
 	String parent_dir = build_dir.get_base_dir();
-	print_verbose("Installing android build directory " + build_dir);
+	PRINT_VERBOSE("Installing android build directory " + build_dir);
 
 	// Make parent of the build dir (if it does not exist).
 	da->make_dir_recursive(parent_dir);

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -799,7 +799,7 @@ void DependencyRemoveDialog::ok_pressed() {
 
 	for (const String &file : files_to_delete) {
 		const String path = OS::get_singleton()->get_resource_dir() + file.replace_first("res://", "/");
-		print_verbose("Moving to trash: " + path);
+		PRINT_VERBOSE("Moving to trash: " + path);
 		Error err = OS::get_singleton()->move_to_trash(path);
 		if (err != OK) {
 			EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:") + "\n" + file + "\n");
@@ -819,7 +819,7 @@ void DependencyRemoveDialog::ok_pressed() {
 	} else {
 		for (int i = 0; i < dirs_to_delete.size(); ++i) {
 			String path = OS::get_singleton()->get_resource_dir() + dirs_to_delete[i].replace_first("res://", "/");
-			print_verbose("Moving to trash: " + path);
+			PRINT_VERBOSE("Moving to trash: " + path);
 			Error err = OS::get_singleton()->move_to_trash(path);
 			if (err != OK) {
 				EditorNode::get_singleton()->add_io_error(TTR("Cannot remove:") + "\n" + dirs_to_delete[i] + "\n");

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2797,7 +2797,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 }
 
 Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<StringName, Variant> &p_custom_options, const String &p_custom_importer, Variant *p_generator_parameters, bool p_update_file_system) {
-	print_verbose(vformat("EditorFileSystem: Importing file: %s", p_file));
+	PRINT_VERBOSE(vformat("EditorFileSystem: Importing file: %s", p_file));
 	uint64_t start_time = OS::get_singleton()->get_ticks_msec();
 
 	EditorFileSystemDirectory *fs = nullptr;
@@ -3078,7 +3078,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
 
-	print_verbose(vformat("EditorFileSystem: \"%s\" import took %d ms.", p_file, OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("EditorFileSystem: \"%s\" import took %d ms.", p_file, OS::get_singleton()->get_ticks_msec() - start_time));
 
 	ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_UNRECOGNIZED, "Error importing '" + p_file + "'.");
 	return OK;

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2796,7 +2796,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 }
 
 Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<StringName, Variant> &p_custom_options, const String &p_custom_importer, Variant *p_generator_parameters, bool p_update_file_system) {
-	print_verbose(vformat("EditorFileSystem: Importing file: %s", p_file));
+	PRINT_VERBOSE(vformat("EditorFileSystem: Importing file: %s", p_file));
 	uint64_t start_time = OS::get_singleton()->get_ticks_msec();
 
 	EditorFileSystemDirectory *fs = nullptr;
@@ -3077,7 +3077,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
 
-	print_verbose(vformat("EditorFileSystem: \"%s\" import took %d ms.", p_file, OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("EditorFileSystem: \"%s\" import took %d ms.", p_file, OS::get_singleton()->get_ticks_msec() - start_time));
 
 	ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_UNRECOGNIZED, "Error importing '" + p_file + "'.");
 	return OK;

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -436,8 +436,8 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 
 				surf_tool->index();
 
-				print_verbose("OBJ: Current material library " + current_material_library + " has " + itos(material_map.has(current_material_library)));
-				print_verbose("OBJ: Current material " + current_material + " has " + itos(material_map.has(current_material_library) && material_map[current_material_library].has(current_material)));
+				PRINT_VERBOSE("OBJ: Current material library " + current_material_library + " has " + itos(material_map.has(current_material_library)));
+				PRINT_VERBOSE("OBJ: Current material " + current_material + " has " + itos(material_map.has(current_material_library) && material_map[current_material_library].has(current_material)));
 				Ref<StandardMaterial3D> material;
 				if (material_map.has(current_material_library) && material_map[current_material_library].has(current_material)) {
 					material = material_map[current_material_library][current_material];
@@ -465,7 +465,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 
 				mesh->add_surface(Mesh::PRIMITIVE_TRIANGLES, array, TypedArray<Array>(), Dictionary(), material, name, mesh_flags);
 
-				print_verbose("OBJ: Added surface :" + mesh->get_surface_name(mesh->get_surface_count() - 1));
+				PRINT_VERBOSE("OBJ: Added surface :" + mesh->get_surface_name(mesh->get_surface_count() - 1));
 
 				if (!current_material.is_empty()) {
 					if (mesh->get_surface_count() >= 1) {

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -442,8 +442,8 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 
 				surf_tool->index();
 
-				print_verbose("OBJ: Current material library " + current_material_library + " has " + itos(material_map.has(current_material_library)));
-				print_verbose("OBJ: Current material " + current_material + " has " + itos(material_map.has(current_material_library) && material_map[current_material_library].has(current_material)));
+				PRINT_VERBOSE("OBJ: Current material library " + current_material_library + " has " + itos(material_map.has(current_material_library)));
+				PRINT_VERBOSE("OBJ: Current material " + current_material + " has " + itos(material_map.has(current_material_library) && material_map[current_material_library].has(current_material)));
 				Ref<StandardMaterial3D> material;
 				if (material_map.has(current_material_library) && material_map[current_material_library].has(current_material)) {
 					material = material_map[current_material_library][current_material];
@@ -471,7 +471,7 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 
 				mesh->add_surface(Mesh::PRIMITIVE_TRIANGLES, array, TypedArray<Array>(), Dictionary(), material, name, mesh_flags);
 
-				print_verbose("OBJ: Added surface :" + mesh->get_surface_name(mesh->get_surface_count() - 1));
+				PRINT_VERBOSE("OBJ: Added surface :" + mesh->get_surface_name(mesh->get_surface_count() - 1));
 
 				if (!current_material.is_empty()) {
 					if (mesh->get_surface_count() >= 1) {

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -760,7 +760,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 					for (const Pair<NodePath, Node *> &F : r_node_renames) {
 						if (F.first == absolute_path) {
 							NodePath new_path(ap_root->get_path_to(F.second).get_names(), path.get_subnames(), false);
-							print_verbose(vformat("Fix: Correcting node path in animation track: %s should be %s", path, new_path));
+							PRINT_VERBOSE(vformat("Fix: Correcting node path in animation track: %s should be %s", path, new_path));
 							anim->track_set_path(i, new_path);
 							break; // Only one match is possible.
 						}
@@ -1068,7 +1068,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 	if (p_node) {
 		NodePath new_path = p_root->get_path_to(p_node);
 		if (new_path != original_path) {
-			print_verbose(vformat("Fix: Renamed %s to %s", original_path, new_path));
+			PRINT_VERBOSE(vformat("Fix: Renamed %s to %s", original_path, new_path));
 			r_node_renames.push_back({ original_path, p_node });
 		}
 		// If we created new node instead, merge meta values from the original node.
@@ -3487,13 +3487,13 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 			library.instantiate(); // Will be empty
 		}
 
-		print_verbose("Saving animation to: " + p_save_path + ".res");
+		PRINT_VERBOSE("Saving animation to: " + p_save_path + ".res");
 		err = ResourceSaver::save(library, p_save_path + ".res", flags); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save animation to file '" + p_save_path + ".res'.");
 	} else if (_scene_import_type == "PackedScene") {
 		Ref<PackedScene> packer = memnew(PackedScene);
 		packer->pack(scene);
-		print_verbose("Saving scene to: " + p_save_path + ".scn");
+		PRINT_VERBOSE("Saving scene to: " + p_save_path + ".scn");
 		err = ResourceSaver::save(packer, p_save_path + ".scn", flags); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
 		EditorInterface::get_singleton()->make_scene_preview(p_source_file, scene, 1024);

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -760,7 +760,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 					for (const Pair<NodePath, Node *> &F : r_node_renames) {
 						if (F.first == absolute_path) {
 							NodePath new_path(ap_root->get_path_to(F.second).get_names(), path.get_subnames(), false);
-							print_verbose(vformat("Fix: Correcting node path in animation track: %s should be %s", path, new_path));
+							PRINT_VERBOSE(vformat("Fix: Correcting node path in animation track: %s should be %s", path, new_path));
 							anim->track_set_path(i, new_path);
 							break; // Only one match is possible.
 						}
@@ -1068,7 +1068,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 	if (p_node) {
 		NodePath new_path = p_root->get_path_to(p_node);
 		if (new_path != original_path) {
-			print_verbose(vformat("Fix: Renamed %s to %s", original_path, new_path));
+			PRINT_VERBOSE(vformat("Fix: Renamed %s to %s", original_path, new_path));
 			r_node_renames.push_back({ original_path, p_node });
 		}
 		// If we created new node instead, merge meta values from the original node.
@@ -3497,13 +3497,13 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 			library.instantiate(); // Will be empty
 		}
 
-		print_verbose("Saving animation to: " + p_save_path + ".res");
+		PRINT_VERBOSE("Saving animation to: " + p_save_path + ".res");
 		err = ResourceSaver::save(library, p_save_path + ".res", flags); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save animation to file '" + p_save_path + ".res'.");
 	} else if (_scene_import_type == "PackedScene") {
 		Ref<PackedScene> packer = memnew(PackedScene);
 		packer->pack(scene);
-		print_verbose("Saving scene to: " + p_save_path + ".scn");
+		PRINT_VERBOSE("Saving scene to: " + p_save_path + ".scn");
 		err = ResourceSaver::save(packer, p_save_path + ".scn", flags); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
 		EditorInterface::get_singleton()->make_scene_preview(p_source_file, scene, 1024);

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -872,11 +872,11 @@ void DynamicFontImportSettingsDialog::open_settings(const String &p_path) {
 	ERR_FAIL_COND(config.is_null());
 
 	Error err = config->load(p_path + ".import");
-	print_verbose("Loading import settings:");
+	PRINT_VERBOSE("Loading import settings:");
 	if (err == OK) {
 		Vector<String> keys = config->get_section_keys("params");
 		for (const String &key : keys) {
-			print_verbose(String("    ") + key + " == " + String(config->get_value("params", key)));
+			PRINT_VERBOSE(String("    ") + key + " == " + String(config->get_value("params", key)));
 			if (key == "preload") {
 				Array preload_configurations = config->get_value("params", key);
 				for (int i = 0; i < preload_configurations.size(); i++) {

--- a/editor/import/resource_importer_bmfont.cpp
+++ b/editor/import/resource_importer_bmfont.cpp
@@ -70,7 +70,7 @@ void ResourceImporterBMFont::get_import_options(const String &p_path, List<Impor
 }
 
 Error ResourceImporterBMFont::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
-	print_verbose("Importing BMFont font from: " + p_source_file);
+	PRINT_VERBOSE("Importing BMFont font from: " + p_source_file);
 
 	Array fallbacks = p_options["fallbacks"];
 	TextServer::FixedSizeScaleMode smode = (TextServer::FixedSizeScaleMode)p_options["scaling_mode"].operator int();
@@ -105,9 +105,9 @@ Error ResourceImporterBMFont::import(ResourceUID::ID p_source_id, const String &
 		flg |= ResourceSaver::SaverFlags::FLAG_COMPRESS;
 	}
 
-	print_verbose("Saving to: " + p_save_path + ".fontdata");
+	PRINT_VERBOSE("Saving to: " + p_save_path + ".fontdata");
 	err = ResourceSaver::save(font, p_save_path + ".fontdata", flg);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save font to file \"" + p_save_path + ".res\".");
-	print_verbose("Done saving to: " + p_save_path + ".fontdata");
+	PRINT_VERBOSE("Done saving to: " + p_save_path + ".fontdata");
 	return OK;
 }

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -151,7 +151,7 @@ void ResourceImporterDynamicFont::show_advanced_options(const String &p_path) {
 }
 
 Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
-	print_verbose("Importing dynamic font from: " + p_source_file);
+	PRINT_VERBOSE("Importing dynamic font from: " + p_source_file);
 
 	int antialiasing = p_options["antialiasing"];
 	bool generate_mipmaps = p_options["generate_mipmaps"];
@@ -292,9 +292,9 @@ Error ResourceImporterDynamicFont::import(ResourceUID::ID p_source_id, const Str
 		flg |= ResourceSaver::SaverFlags::FLAG_COMPRESS;
 	}
 
-	print_verbose("Saving to: " + p_save_path + ".fontdata");
+	PRINT_VERBOSE("Saving to: " + p_save_path + ".fontdata");
 	Error err = ResourceSaver::save(font, p_save_path + ".fontdata", flg);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save font to file \"" + p_save_path + ".res\".");
-	print_verbose("Done saving to: " + p_save_path + ".fontdata");
+	PRINT_VERBOSE("Done saving to: " + p_save_path + ".fontdata");
 	return OK;
 }

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -78,7 +78,7 @@ void ResourceImporterImageFont::get_import_options(const String &p_path, List<Im
 }
 
 Error ResourceImporterImageFont::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
-	print_verbose("Importing image font from: " + p_source_file);
+	PRINT_VERBOSE("Importing image font from: " + p_source_file);
 
 	int columns = p_options["columns"];
 	int rows = p_options["rows"];
@@ -375,9 +375,9 @@ Error ResourceImporterImageFont::import(ResourceUID::ID p_source_id, const Strin
 		flg |= ResourceSaver::SaverFlags::FLAG_COMPRESS;
 	}
 
-	print_verbose("Saving to: " + p_save_path + ".fontdata");
+	PRINT_VERBOSE("Saving to: " + p_save_path + ".fontdata");
 	err = ResourceSaver::save(font, p_save_path + ".fontdata", flg);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save font to file \"" + p_save_path + ".res\".");
-	print_verbose("Done saving to: " + p_save_path + ".fontdata");
+	PRINT_VERBOSE("Done saving to: " + p_save_path + ".fontdata");
 	return OK;
 }

--- a/editor/import/resource_importer_svg.cpp
+++ b/editor/import/resource_importer_svg.cpp
@@ -102,10 +102,10 @@ Error ResourceImporterSVG::import(ResourceUID::ID p_source_id, const String &p_s
 		flg |= ResourceSaver::SaverFlags::FLAG_COMPRESS;
 	}
 
-	print_verbose("Saving to: " + p_save_path + ".dpitex");
+	PRINT_VERBOSE("Saving to: " + p_save_path + ".dpitex");
 	Error err = ResourceSaver::save(dpi_tex, p_save_path + ".dpitex", flg);
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot save DPI texture to file \"%s.dpitex\".", p_save_path));
-	print_verbose("Done saving to: " + p_save_path + ".dpitex");
+	PRINT_VERBOSE("Done saving to: " + p_save_path + ".dpitex");
 
 	return OK;
 }

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -713,15 +713,15 @@ void ProjectList::_scan_thread(void *p_scan_data) {
 	ScanData *scan_data = static_cast<ScanData *>(p_scan_data);
 
 	for (const String &base_path : scan_data->paths_to_scan) {
-		print_verbose(vformat("Scanning for projects in \"%s\".", base_path));
+		PRINT_VERBOSE(vformat("Scanning for projects in \"%s\".", base_path));
 		_scan_folder_recursive(base_path, &scan_data->found_projects, scan_data->scan_in_progress);
 
 		if (!scan_data->scan_in_progress.is_set()) {
-			print_verbose("Scan aborted.");
+			PRINT_VERBOSE("Scan aborted.");
 			break;
 		}
 	}
-	print_verbose(vformat("Found %d project(s).", scan_data->found_projects.size()));
+	PRINT_VERBOSE(vformat("Found %d project(s).", scan_data->found_projects.size()));
 	scan_data->scan_in_progress.clear();
 }
 

--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -681,7 +681,7 @@ Vector<String> ProjectConverter3To4::check_for_files() {
 				file_name = dir->_get_next();
 			}
 		} else {
-			print_verbose("Failed to open " + path);
+			PRINT_VERBOSE("Failed to open " + path);
 		}
 	}
 	return collected_files;

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -130,12 +130,12 @@ void FindInFilesSearch::_notification(int p_what) {
 
 void FindInFilesSearch::start() {
 	if (pattern.is_empty()) {
-		print_verbose("Nothing to search, pattern is empty");
+		PRINT_VERBOSE("Nothing to search, pattern is empty");
 		emit_signal(SceneStringName(finished));
 		return;
 	}
 	if (extension_filter.is_empty()) {
-		print_verbose("Nothing to search, filter matches no files");
+		PRINT_VERBOSE("Nothing to search, filter matches no files");
 		emit_signal(SceneStringName(finished));
 		return;
 	}
@@ -214,7 +214,7 @@ void FindInFilesSearch::_iterate() {
 		_scan_file(fpath);
 
 	} else {
-		print_verbose("Search complete");
+		PRINT_VERBOSE("Search complete");
 		set_process(false);
 		current_dir = "";
 		searching = false;
@@ -232,7 +232,7 @@ float FindInFilesSearch::get_progress() const {
 void FindInFilesSearch::_scan_dir(const String &p_path, PackedStringArray &r_out_folders, PackedStringArray &r_out_files_to_scan) {
 	Ref<DirAccess> dir = DirAccess::open(p_path);
 	if (dir.is_null()) {
-		print_verbose("Cannot open directory! " + p_path);
+		PRINT_VERBOSE("Cannot open directory! " + p_path);
 		return;
 	}
 
@@ -1115,7 +1115,7 @@ void FindInFilesPanel::_apply_replaces_in_file(const String &p_fpath, const Vect
 			if (find_next(line, search_text, location.begin, finder->is_match_case(), finder->is_whole_words(), placeholder, placeholder)) {
 				line = line.left(location.begin) + p_new_text + line.substr(location.end);
 			} else {
-				print_verbose(vformat(R"(Occurrence no longer matches, replace will be ignored in "%s": line %d, col %d.)", p_fpath, repl_line_number, location.begin));
+				PRINT_VERBOSE(vformat(R"(Occurrence no longer matches, replace will be ignored in "%s": line %d, col %d.)", p_fpath, repl_line_number, location.begin));
 			}
 		}
 	}

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -148,14 +148,14 @@ void FindInFilesSearch::_notification(int p_what) {
 
 void FindInFilesSearch::start() {
 	if (pattern.is_empty()) {
-		print_verbose("Nothing to search, pattern is empty");
+		PRINT_VERBOSE("Nothing to search, pattern is empty");
 		emit_signal(SceneStringName(finished));
 		return;
 	}
 	_calculate_wildcard(include_string, &include_wildcards);
 	_calculate_wildcard(exclude_string, &exclude_wildcards);
 	if (extension_filter.is_empty()) {
-		print_verbose("Nothing to search, filter matches no files");
+		PRINT_VERBOSE("Nothing to search, filter matches no files");
 		emit_signal(SceneStringName(finished));
 		return;
 	}
@@ -235,7 +235,7 @@ void FindInFilesSearch::_iterate() {
 		_scan_file(fpath);
 
 	} else {
-		print_verbose("Search complete");
+		PRINT_VERBOSE("Search complete");
 		set_process(false);
 		current_dir = "";
 		searching = false;
@@ -253,7 +253,7 @@ float FindInFilesSearch::get_progress() const {
 void FindInFilesSearch::_scan_dir(const String &p_path, PackedStringArray &r_out_folders, PackedStringArray &r_out_files_to_scan) {
 	Ref<DirAccess> dir = DirAccess::open(p_path);
 	if (dir.is_null()) {
-		print_verbose("Cannot open directory! " + p_path);
+		PRINT_VERBOSE("Cannot open directory! " + p_path);
 		return;
 	}
 
@@ -1171,7 +1171,7 @@ void FindInFilesResultsPanel::_apply_replaces_in_file(const String &p_fpath, con
 			if (find_next(line, search_text, location.begin, finder->is_match_case(), finder->is_whole_words(), placeholder, placeholder)) {
 				line = line.left(location.begin) + p_new_text + line.substr(location.end);
 			} else {
-				print_verbose(vformat(R"(Occurrence no longer matches, replace will be ignored in "%s": line %d, col %d.)", p_fpath, repl_line_number, location.begin));
+				PRINT_VERBOSE(vformat(R"(Occurrence no longer matches, replace will be ignored in "%s": line %d, col %d.)", p_fpath, repl_line_number, location.begin));
 			}
 		}
 	}

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1456,7 +1456,7 @@ void EditorSettings::create() {
 		singleton->set_path(get_newest_settings_path()); // Settings can be loaded from older version file, so make sure it's newest.
 		singleton->save_changed_setting = true;
 
-		print_verbose("EditorSettings: Load OK!");
+		PRINT_VERBOSE("EditorSettings: Load OK!");
 
 		singleton->init_shortcuts();
 		singleton->setup_language(true);
@@ -1566,7 +1566,7 @@ void EditorSettings::save() {
 		ERR_PRINT("Error saving editor settings to " + singleton->get_path());
 	} else {
 		singleton->changed_settings.clear();
-		print_verbose("EditorSettings: Save OK!");
+		PRINT_VERBOSE("EditorSettings: Save OK!");
 	}
 }
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1459,7 +1459,7 @@ void EditorSettings::create() {
 		singleton->set_path(get_newest_settings_path()); // Settings can be loaded from older version file, so make sure it's newest.
 		singleton->save_changed_setting = true;
 
-		print_verbose("EditorSettings: Load OK!");
+		PRINT_VERBOSE("EditorSettings: Load OK!");
 
 		singleton->init_shortcuts();
 		singleton->setup_language(true);
@@ -1579,7 +1579,7 @@ void EditorSettings::save() {
 		ERR_PRINT("Error saving editor settings to " + singleton->get_path());
 	} else {
 		singleton->changed_settings.clear();
-		print_verbose("EditorSettings: Save OK!");
+		PRINT_VERBOSE("EditorSettings: Save OK!");
 	}
 }
 

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -175,7 +175,7 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 	theme->set_generated_fonts_hash(config.hash_fonts());
 	theme->set_generated_icons_hash(config.hash_icons());
 
-	print_verbose(vformat("EditorTheme: Generating new theme for the config '%d'.", theme->get_generated_hash()));
+	PRINT_VERBOSE(vformat("EditorTheme: Generating new theme for the config '%d'.", theme->get_generated_hash()));
 
 	bool is_default_style = config.style == "Modern";
 	if (is_default_style) {
@@ -195,10 +195,10 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 		// Otherwise, regenerate them.
 		bool keep_old_icons = (p_old_theme.is_valid() && theme->get_generated_icons_hash() == p_old_theme->get_generated_icons_hash());
 		if (keep_old_icons) {
-			print_verbose("EditorTheme: Can keep old icons, copying.");
+			PRINT_VERBOSE("EditorTheme: Can keep old icons, copying.");
 			editor_copy_icons(theme, p_old_theme);
 		} else {
-			print_verbose("EditorTheme: Generating new icons.");
+			PRINT_VERBOSE("EditorTheme: Generating new icons.");
 			editor_register_icons(theme, config.dark_icon_and_font, config.icon_saturation, config.thumb_size, config.gizmo_handle_scale);
 		}
 
@@ -212,7 +212,7 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 		// TODO: Check if existing font definitions from the old theme are usable and copy them.
 
 		// External function, see editor_fonts.cpp.
-		print_verbose("EditorTheme: Generating new fonts.");
+		PRINT_VERBOSE("EditorTheme: Generating new fonts.");
 		editor_register_fonts(theme);
 
 		OS::get_singleton()->benchmark_end_measure(get_benchmark_key(), "Register Fonts");
@@ -220,7 +220,7 @@ Ref<EditorTheme> EditorThemeManager::_create_base_theme(const Ref<EditorTheme> &
 
 	// TODO: Check if existing style definitions from the old theme are usable and copy them.
 
-	print_verbose("EditorTheme: Generating new styles.");
+	PRINT_VERBOSE("EditorTheme: Generating new styles.");
 
 	if (is_default_style) {
 		ThemeModern::populate_standard_styles(theme, config);

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -469,7 +469,7 @@ void LocalizationEditor::_filesystem_files_moved(const String &p_old_file, const
 		remaps.erase(p_old_file);
 		remaps[p_new_file] = remapped_files;
 		remaps_changed = true;
-		print_verbose(vformat("Changed remap key \"%s\" to \"%s\" due to a moved file.", p_old_file, p_new_file));
+		PRINT_VERBOSE(vformat("Changed remap key \"%s\" to \"%s\" due to a moved file.", p_old_file, p_new_file));
 	}
 
 	// Check for the Array elements of the values.
@@ -489,7 +489,7 @@ void LocalizationEditor::_filesystem_files_moved(const String &p_old_file, const
 				remapped_files.remove_at(j + 1);
 				remaps_changed = true;
 				remapped_files_updated = true;
-				print_verbose(vformat("Changed remap value \"%s\" to \"%s\" of key \"%s\" due to a moved file.", res_path + ":" + locale_name, remapped_files[j], remap_key));
+				PRINT_VERBOSE(vformat("Changed remap value \"%s\" to \"%s\" of key \"%s\" due to a moved file.", res_path + ":" + locale_name, remapped_files[j], remap_key));
 			}
 		}
 
@@ -531,12 +531,12 @@ void LocalizationEditor::_filesystem_file_removed(const String &p_file) {
 				String res_path = remapped_files[j].substr(0, splitter_pos);
 				remaps_changed = p_file == res_path;
 				if (remaps_changed) {
-					print_verbose(vformat("Remap value \"%s\" of key \"%s\" has been removed from the file system.", remapped_files[j], remap_keys[i]));
+					PRINT_VERBOSE(vformat("Remap value \"%s\" of key \"%s\" has been removed from the file system.", remapped_files[j], remap_keys[i]));
 				}
 			}
 		}
 	} else {
-		print_verbose(vformat("Remap key \"%s\" has been removed from the file system.", p_file));
+		PRINT_VERBOSE(vformat("Remap key \"%s\" has been removed from the file system.", p_file));
 	}
 
 	if (remaps_changed) {

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -475,7 +475,7 @@ void LocalizationEditor::_filesystem_files_moved(const String &p_old_file, const
 		remaps.erase(p_old_file);
 		remaps[p_new_file] = remapped_files;
 		remaps_changed = true;
-		print_verbose(vformat("Changed remap key \"%s\" to \"%s\" due to a moved file.", p_old_file, p_new_file));
+		PRINT_VERBOSE(vformat("Changed remap key \"%s\" to \"%s\" due to a moved file.", p_old_file, p_new_file));
 	}
 
 	// Check for the Array elements of the values.
@@ -495,7 +495,7 @@ void LocalizationEditor::_filesystem_files_moved(const String &p_old_file, const
 				remapped_files.remove_at(j + 1);
 				remaps_changed = true;
 				remapped_files_updated = true;
-				print_verbose(vformat("Changed remap value \"%s\" to \"%s\" of key \"%s\" due to a moved file.", res_path + ":" + locale_name, remapped_files[j], remap_key));
+				PRINT_VERBOSE(vformat("Changed remap value \"%s\" to \"%s\" of key \"%s\" due to a moved file.", res_path + ":" + locale_name, remapped_files[j], remap_key));
 			}
 		}
 
@@ -537,12 +537,12 @@ void LocalizationEditor::_filesystem_file_removed(const String &p_file) {
 				String res_path = remapped_files[j].substr(0, splitter_pos);
 				remaps_changed = p_file == res_path;
 				if (remaps_changed) {
-					print_verbose(vformat("Remap value \"%s\" of key \"%s\" has been removed from the file system.", remapped_files[j], remap_keys[i]));
+					PRINT_VERBOSE(vformat("Remap value \"%s\" of key \"%s\" has been removed from the file system.", remapped_files[j], remap_keys[i]));
 				}
 			}
 		}
 	} else {
-		print_verbose(vformat("Remap key \"%s\" has been removed from the file system.", p_file));
+		PRINT_VERBOSE(vformat("Remap key \"%s\" has been removed from the file system.", p_file));
 	}
 
 	if (remaps_changed) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3454,7 +3454,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 			DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(0));
 		}
 
-		print_verbose("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
+		PRINT_VERBOSE("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
 
 		OS::get_singleton()->benchmark_end_measure("Servers", "Tablet Driver");
 	}
@@ -3807,8 +3807,8 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 	ClassDB::set_current_api(ClassDB::API_NONE); //no more APIs are registered at this point
 
-	print_verbose("CORE API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_CORE)));
-	print_verbose("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
+	PRINT_VERBOSE("CORE API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_CORE)));
+	PRINT_VERBOSE("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
 	MAIN_PRINT("Main: Done");
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Setup2");

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3523,7 +3523,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 			DisplayServer::get_singleton()->tablet_set_current_driver(DisplayServer::get_singleton()->tablet_get_driver_name(0));
 		}
 
-		print_verbose("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
+		PRINT_VERBOSE("Using \"" + DisplayServer::get_singleton()->tablet_get_current_driver() + "\" pen tablet driver...");
 
 		OS::get_singleton()->benchmark_end_measure("Servers", "Tablet Driver");
 	}
@@ -3878,8 +3878,8 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 	ClassDB::set_current_api(ClassDB::API_NONE); //no more APIs are registered at this point
 
-	print_verbose("CORE API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_CORE)));
-	print_verbose("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
+	PRINT_VERBOSE("CORE API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_CORE)));
+	PRINT_VERBOSE("EDITOR API HASH: " + uitos(ClassDB::get_api_hash(ClassDB::API_EDITOR)));
 	MAIN_PRINT("Main: Done");
 
 	OS::get_singleton()->benchmark_end_measure("Startup", "Main::Setup2");

--- a/main/steam_tracker.cpp
+++ b/main/steam_tracker.cpp
@@ -73,7 +73,7 @@ SteamTracker::SteamTracker() {
 		steam_library_handle = nullptr;
 		return;
 	}
-	print_verbose("Loaded SteamAPI library");
+	PRINT_VERBOSE("Loaded SteamAPI library");
 
 	void *symbol_handle = nullptr;
 	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_InitFlat", symbol_handle, true); // Try new API, 1.59+.

--- a/modules/astcenc/image_compress_astcenc.cpp
+++ b/modules/astcenc/image_compress_astcenc.cpp
@@ -110,7 +110,7 @@ void _compress_astc(Image *r_img, Image::UsedChannels p_channels, Image::Compres
 		height = required_height;
 	}
 
-	print_verbose(vformat("astcenc: Encoding image size %dx%d to format %s%s.", width, height, Image::get_format_name(target_format), has_mipmaps ? ", with mipmaps" : ""));
+	PRINT_VERBOSE(vformat("astcenc: Encoding image size %dx%d to format %s%s.", width, height, Image::get_format_name(target_format), has_mipmaps ? ", with mipmaps" : ""));
 
 	// Initialize astcenc.
 	const int64_t dest_size = Image::get_image_data_size(width, height, target_format, has_mipmaps);
@@ -189,7 +189,7 @@ void _compress_astc(Image *r_img, Image::UsedChannels p_channels, Image::Compres
 	// Replace original image with compressed one.
 	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
 
-	print_verbose(vformat("astcenc: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("astcenc: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
 #endif // TOOLS_ENABLED
 
@@ -315,5 +315,5 @@ void _decompress_astc(Image *r_img) {
 	// Replace original image with compressed one.
 	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
 
-	print_verbose(vformat("astcenc: Decompression took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("astcenc: Decompression took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }

--- a/modules/astcenc/image_compress_astcenc.cpp
+++ b/modules/astcenc/image_compress_astcenc.cpp
@@ -109,7 +109,7 @@ void _compress_astc(Image *r_img, Image::UsedChannels p_channels, Image::Compres
 		r_img->resize(width, height, Image::INTERPOLATE_NEAREST);
 	}
 
-	print_verbose(vformat("astcenc: Encoding image size %dx%d to format %s%s.", width, height, Image::get_format_name(target_format), has_mipmaps ? ", with mipmaps" : ""));
+	PRINT_VERBOSE(vformat("astcenc: Encoding image size %dx%d to format %s%s.", width, height, Image::get_format_name(target_format), has_mipmaps ? ", with mipmaps" : ""));
 
 	// Initialize astcenc.
 	const int64_t dest_size = Image::get_image_data_size(width, height, target_format, has_mipmaps);
@@ -188,7 +188,7 @@ void _compress_astc(Image *r_img, Image::UsedChannels p_channels, Image::Compres
 	// Replace original image with compressed one.
 	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
 
-	print_verbose(vformat("astcenc: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("astcenc: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
 #endif // TOOLS_ENABLED
 
@@ -310,5 +310,5 @@ void _decompress_astc(Image *r_img) {
 	// Replace original image with compressed one.
 	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
 
-	print_verbose(vformat("astcenc: Decompression took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("astcenc: Decompression took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -266,7 +266,7 @@ Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedCha
 	*(uint32_t *)basisu_data_ptr = decompress_format | BASIS_DECOMPRESS_FLAG_KTX2;
 	memcpy(basisu_data_ptr + 4, basisu_encoded.get_ptr(), basisu_encoded.size());
 
-	print_verbose(vformat("BasisU: Encoding a %dx%d image with %d mipmaps took %d ms.", p_image->get_width(), p_image->get_height(), p_image->get_mipmap_count(), OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("BasisU: Encoding a %dx%d image with %d mipmaps took %d ms.", p_image->get_width(), p_image->get_height(), p_image->get_mipmap_count(), OS::get_singleton()->get_ticks_msec() - start_time));
 
 	return basisu_data;
 }
@@ -477,7 +477,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 		}
 	}
 
-	print_verbose(vformat("BasisU: Transcoding a %dx%d image with %d mipmaps into %s took %d ms.",
+	PRINT_VERBOSE(vformat("BasisU: Transcoding a %dx%d image with %d mipmaps into %s took %d ms.",
 			image->get_width(), image->get_height(), image->get_mipmap_count(), Image::get_format_name(image_format), OS::get_singleton()->get_ticks_msec() - start_time));
 
 	return image;

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -211,7 +211,7 @@ Vector<uint8_t> basis_universal_packer(const Ref<Image> &p_image, Image::UsedCha
 	*(uint32_t *)basisu_data_ptr = decompress_format | BASIS_DECOMPRESS_FLAG_KTX2;
 	memcpy(basisu_data_ptr + 4, basisu_encoded.get_ptr(), basisu_encoded.size());
 
-	print_verbose(vformat("BasisU: Encoding a %dx%d image with %d mipmaps took %d ms.", p_image->get_width(), p_image->get_height(), p_image->get_mipmap_count(), OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("BasisU: Encoding a %dx%d image with %d mipmaps took %d ms.", p_image->get_width(), p_image->get_height(), p_image->get_mipmap_count(), OS::get_singleton()->get_ticks_msec() - start_time));
 
 	return basisu_data;
 }
@@ -422,7 +422,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 		}
 	}
 
-	print_verbose(vformat("BasisU: Transcoding a %dx%d image with %d mipmaps into %s took %d ms.",
+	PRINT_VERBOSE(vformat("BasisU: Transcoding a %dx%d image with %d mipmaps into %s took %d ms.",
 			image->get_width(), image->get_height(), image->get_mipmap_count(), Image::get_format_name(image_format), OS::get_singleton()->get_ticks_msec() - start_time));
 
 	return image;

--- a/modules/bcdec/image_decompress_bcdec.cpp
+++ b/modules/bcdec/image_decompress_bcdec.cpp
@@ -298,6 +298,6 @@ void image_decompress_bcdec(Image *p_image) {
 		p_image->convert_ra_rgba8_to_rg();
 	}
 
-	print_verbose(vformat("bcdec: Decompression of a %dx%d %s image with %d mipmaps took %d ms.",
+	PRINT_VERBOSE(vformat("bcdec: Decompression of a %dx%d %s image with %d mipmaps took %d ms.",
 			p_image->get_width(), p_image->get_height(), Image::get_format_name(source_format), p_image->get_mipmap_count(), OS::get_singleton()->get_ticks_msec() - start_time));
 }

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -832,7 +832,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 	// Set the compressed data to the image.
 	r_img->set_data(img_width, img_height, r_img->has_mipmaps(), dest_format, dst_data);
 
-	print_verbose(
+	PRINT_VERBOSE(
 			vformat("Betsy: Encoding a %dx%d image with %d mipmaps as %s took %d ms.",
 					img_width,
 					img_height,

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -844,7 +844,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 	// Set the compressed data to the image.
 	r_img->set_data(img_width, img_height, r_img->has_mipmaps(), dest_format, dst_data);
 
-	print_verbose(
+	PRINT_VERBOSE(
 			vformat("Betsy: Encoding a %dx%d image with %d mipmaps as %s took %d ms.",
 					img_width,
 					img_height,

--- a/modules/camera/camera_android.cpp
+++ b/modules/camera/camera_android.cpp
@@ -141,7 +141,7 @@ void CameraFeedAndroid::refresh_camera_metadata() {
 	status = ACameraMetadata_getConstEntry(metadata, ACAMERA_SENSOR_ORIENTATION, &orientation_entry);
 	if (status == ACAMERA_OK) {
 		orientation = orientation_entry.data.i32[0];
-		print_verbose(vformat("Camera %s: Orientation updated to %d.", camera_id, orientation));
+		PRINT_VERBOSE(vformat("Camera %s: Orientation updated to %d.", camera_id, orientation));
 	} else {
 		ERR_PRINT(vformat("Camera %s: Failed to get sensor orientation after refresh (status: %d).", camera_id, status));
 	}
@@ -149,12 +149,12 @@ void CameraFeedAndroid::refresh_camera_metadata() {
 	formats.clear();
 	_add_formats();
 
-	print_verbose(vformat("Camera %s: Metadata refreshed successfully.", camera_id));
+	PRINT_VERBOSE(vformat("Camera %s: Metadata refreshed successfully.", camera_id));
 }
 
 void CameraFeedAndroid::_set_rotation() {
 	if (!metadata) {
-		print_verbose(vformat("Camera %s: Metadata is null in _set_rotation, attempting refresh.", camera_id));
+		PRINT_VERBOSE(vformat("Camera %s: Metadata is null in _set_rotation, attempting refresh.", camera_id));
 		refresh_camera_metadata();
 	}
 
@@ -390,7 +390,7 @@ CameraFeed::FeedFormat CameraFeedAndroid::get_format() const {
 void CameraFeedAndroid::handle_pause() {
 	if (is_active()) {
 		was_active_before_pause = true;
-		print_verbose(vformat("Camera %s: Pausing (was active).", camera_id));
+		PRINT_VERBOSE(vformat("Camera %s: Pausing (was active).", camera_id));
 		deactivate_feed();
 	} else {
 		was_active_before_pause = false;
@@ -399,7 +399,7 @@ void CameraFeedAndroid::handle_pause() {
 
 void CameraFeedAndroid::handle_resume() {
 	if (was_active_before_pause) {
-		print_verbose(vformat("Camera %s: Resuming.", camera_id));
+		PRINT_VERBOSE(vformat("Camera %s: Resuming.", camera_id));
 		activate_feed();
 		was_active_before_pause = false;
 	}
@@ -410,7 +410,7 @@ void CameraFeedAndroid::handle_rotation_change() {
 		return;
 	}
 
-	print_verbose(vformat("Camera %s: Handling rotation change.", camera_id));
+	PRINT_VERBOSE(vformat("Camera %s: Handling rotation change.", camera_id));
 	refresh_camera_metadata();
 	_set_rotation();
 }
@@ -630,7 +630,7 @@ void CameraFeedAndroid::onImage(void *context, AImageReader *p_reader) {
 		if (feed->metadata != nullptr) {
 			feed->_set_rotation();
 		} else {
-			print_verbose(vformat("Camera %s: Metadata invalidated in onImage, attempting refresh.", feed->camera_id));
+			PRINT_VERBOSE(vformat("Camera %s: Metadata invalidated in onImage, attempting refresh.", feed->camera_id));
 			feed->refresh_camera_metadata();
 			if (feed->metadata != nullptr && !feed->formats.is_empty()) {
 				feed->_set_rotation();
@@ -642,11 +642,11 @@ void CameraFeedAndroid::onImage(void *context, AImageReader *p_reader) {
 }
 
 void CameraFeedAndroid::onSessionReady(void *context, ACameraCaptureSession *session) {
-	print_verbose("Capture session ready");
+	PRINT_VERBOSE("Capture session ready");
 }
 
 void CameraFeedAndroid::onSessionActive(void *context, ACameraCaptureSession *session) {
-	print_verbose("Capture session active");
+	PRINT_VERBOSE("Capture session active");
 }
 
 void CameraFeedAndroid::onSessionClosed(void *context, ACameraCaptureSession *p_session) {

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -112,7 +112,7 @@ void CameraFeedLinux::_add_format(v4l2_fmtdesc p_description, v4l2_frmsize_discr
 	feed_format.frame_numerator = p_frame_numerator;
 	feed_format.frame_denominator = p_frame_denominator;
 	feed_format.pixel_format = p_description.pixelformat;
-	print_verbose(vformat("%s %dx%d@%d/%dfps", (char *)p_description.description, p_size.width, p_size.height, p_frame_denominator, p_frame_numerator));
+	PRINT_VERBOSE(vformat("%s %dx%d@%d/%dfps", (char *)p_description.description, p_size.width, p_size.height, p_frame_denominator, p_frame_numerator));
 	formats.push_back(feed_format);
 }
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -460,7 +460,7 @@ static void _pack_manifold(
 	ERR_FAIL_COND_MSG(mesh.vertProperties.size() % mesh.numProp != 0, "Invalid vertex properties size.");
 	mesh.Merge();
 #ifdef DEV_ENABLED
-	print_verbose(_export_meshgl_as_json(mesh));
+	PRINT_VERBOSE(_export_meshgl_as_json(mesh));
 #endif // DEV_ENABLED
 	r_manifold = manifold::Manifold(mesh);
 }

--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -293,7 +293,7 @@ void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels, Image::
 
 	p_image->set_data(w, h, p_image->has_mipmaps(), target_format, data);
 
-	print_verbose(vformat("CVTT: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("CVTT: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
 
 void image_decompress_cvtt(Image *p_image) {

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -303,6 +303,6 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 	// Replace original image with compressed one.
 	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
 
-	print_verbose(vformat("etcpak: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("etcpak: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
 #endif // TOOLS_ENABLED

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -304,6 +304,6 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 	// Replace original image with compressed one.
 	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
 
-	print_verbose(vformat("etcpak: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
+	PRINT_VERBOSE(vformat("etcpak: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
 #endif // ETCPAK_COMPRESS_ENABLED

--- a/modules/etcpak/image_decompress_etcpak.cpp
+++ b/modules/etcpak/image_decompress_etcpak.cpp
@@ -240,6 +240,6 @@ void _decompress_etc(Image *p_image) {
 		p_image->convert_ra_rgba8_to_rg();
 	}
 
-	print_verbose(vformat("etcpak: Decompression of %dx%d %s image %s with %d mipmaps took %d ms.",
+	PRINT_VERBOSE(vformat("etcpak: Decompression of %dx%d %s image %s with %d mipmaps took %d ms.",
 			p_image->get_width(), p_image->get_height(), Image::get_format_name(source_format), p_image->get_path(), p_image->get_mipmap_count(), OS::get_singleton()->get_ticks_msec() - start_time));
 }

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -83,8 +83,8 @@ Node *EditorSceneFormatImporterFBX2GLTF::import_scene(const String &p_path, uint
 	String standard_out;
 	int ret;
 	OS::get_singleton()->execute(fbx2gltf_path, args, &standard_out, &ret, true);
-	print_verbose(fbx2gltf_path);
-	print_verbose(standard_out);
+	PRINT_VERBOSE(fbx2gltf_path);
+	PRINT_VERBOSE(standard_out);
 
 	if (ret != 0) {
 		if (r_err) {
@@ -108,7 +108,7 @@ Node *EditorSceneFormatImporterFBX2GLTF::import_scene(const String &p_path, uint
 	if (p_options.has(SNAME("nodes/import_as_skeleton_bones")) ? (bool)p_options[SNAME("nodes/import_as_skeleton_bones")] : false) {
 		state->set_import_as_skeleton_bones(true);
 	}
-	print_verbose(vformat("glTF path: %s", sink));
+	PRINT_VERBOSE(vformat("glTF path: %s", sink));
 	Error err = gltf->append_from_file(sink, state, p_flags, p_path.get_base_dir());
 	if (err != OK) {
 		if (r_err) {

--- a/modules/fbx/editor/editor_scene_importer_ufbx.cpp
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.cpp
@@ -58,7 +58,7 @@ Node *EditorSceneFormatImporterUFBX::import_scene(const String &p_path, uint32_t
 	fbx.instantiate();
 	Ref<FBXState> state;
 	state.instantiate();
-	print_verbose(vformat("FBX path: %s", p_path));
+	PRINT_VERBOSE(vformat("FBX path: %s", p_path));
 	String path = ProjectSettings::get_singleton()->globalize_path(p_path);
 	if (p_options.has("fbx/naming_version")) {
 		int naming_version = p_options["fbx/naming_version"];

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -458,7 +458,7 @@ Error FBXDocument::_parse_meshes(Ref<FBXState> p_state) {
 	}
 
 	for (const ufbx_mesh *fbx_mesh : fbx_scene->meshes) {
-		print_verbose("FBX: Parsing mesh: " + itos(int64_t(fbx_mesh->typed_id)));
+		PRINT_VERBOSE("FBX: Parsing mesh: " + itos(int64_t(fbx_mesh->typed_id)));
 
 		static const Mesh::PrimitiveType primitive_types[] = {
 			Mesh::PRIMITIVE_TRIANGLES,
@@ -488,7 +488,7 @@ Error FBXDocument::_parse_meshes(Ref<FBXState> p_state) {
 		Vector<float> blend_weights;
 		Vector<int> blend_channels;
 		if (use_blend_shapes) {
-			print_verbose("FBX: Mesh has targets");
+			PRINT_VERBOSE("FBX: Mesh has targets");
 
 			import_mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
 
@@ -765,7 +765,7 @@ Error FBXDocument::_parse_meshes(Ref<FBXState> p_state) {
 				Array morphs;
 				//blend shapes
 				if (use_blend_shapes) {
-					print_verbose("FBX: Mesh has targets");
+					PRINT_VERBOSE("FBX: Mesh has targets");
 
 					import_mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
 
@@ -903,7 +903,7 @@ Error FBXDocument::_parse_meshes(Ref<FBXState> p_state) {
 		p_state->meshes.push_back(mesh);
 	}
 
-	print_verbose("FBX: Total meshes: " + itos(p_state->meshes.size()));
+	PRINT_VERBOSE("FBX: Total meshes: " + itos(p_state->meshes.size()));
 
 	return OK;
 }
@@ -1098,7 +1098,7 @@ Error FBXDocument::_parse_images(Ref<FBXState> p_state, const String &p_base_pat
 		p_state->textures.push_back(texture);
 	}
 
-	print_verbose("FBX: Total images: " + itos(p_state->images.size()));
+	PRINT_VERBOSE("FBX: Total images: " + itos(p_state->images.size()));
 
 	return OK;
 }
@@ -1315,7 +1315,7 @@ Error FBXDocument::_parse_materials(Ref<FBXState> p_state) {
 		p_state->materials.push_back(material);
 	}
 
-	print_verbose("Total materials: " + itos(p_state->materials.size()));
+	PRINT_VERBOSE("Total materials: " + itos(p_state->materials.size()));
 
 	return OK;
 }
@@ -1343,7 +1343,7 @@ Error FBXDocument::_parse_cameras(Ref<FBXState> p_state) {
 		p_state->cameras.push_back(camera);
 	}
 
-	print_verbose("FBX: Total cameras: " + itos(p_state->cameras.size()));
+	PRINT_VERBOSE("FBX: Total cameras: " + itos(p_state->cameras.size()));
 
 	return OK;
 }
@@ -1436,7 +1436,7 @@ Error FBXDocument::_parse_animations(Ref<FBXState> p_state) {
 		p_state->animations.push_back(animation);
 	}
 
-	print_verbose("FBX: Total animations '" + itos(p_state->animations.size()) + "'.");
+	PRINT_VERBOSE("FBX: Total animations '" + itos(p_state->animations.size()) + "'.");
 
 	return OK;
 }
@@ -1468,7 +1468,7 @@ BoneAttachment3D *FBXDocument::_generate_bone_attachment(Ref<FBXState> p_state, 
 	Ref<GLTFNode> fbx_node = p_state->nodes[p_node_index];
 	Ref<GLTFNode> bone_node = p_state->nodes[p_bone_index];
 	BoneAttachment3D *bone_attachment = memnew(BoneAttachment3D);
-	print_verbose("FBX: Creating bone attachment for: " + fbx_node->get_name());
+	PRINT_VERBOSE("FBX: Creating bone attachment for: " + fbx_node->get_name());
 
 	ERR_FAIL_COND_V(!bone_node->joint, nullptr);
 
@@ -1483,7 +1483,7 @@ ImporterMeshInstance3D *FBXDocument::_generate_mesh_instance(Ref<FBXState> p_sta
 	ERR_FAIL_INDEX_V(fbx_node->mesh, p_state->meshes.size(), nullptr);
 
 	ImporterMeshInstance3D *mi = memnew(ImporterMeshInstance3D);
-	print_verbose("FBX: Creating mesh for: " + fbx_node->get_name());
+	PRINT_VERBOSE("FBX: Creating mesh for: " + fbx_node->get_name());
 
 	p_state->scene_mesh_instances.insert(p_node_index, mi);
 	Ref<GLTFMesh> mesh = p_state->meshes.write[fbx_node->mesh];
@@ -1503,7 +1503,7 @@ Camera3D *FBXDocument::_generate_camera(Ref<FBXState> p_state, const GLTFNodeInd
 
 	ERR_FAIL_INDEX_V(fbx_node->camera, p_state->cameras.size(), nullptr);
 
-	print_verbose("FBX: Creating camera for: " + fbx_node->get_name());
+	PRINT_VERBOSE("FBX: Creating camera for: " + fbx_node->get_name());
 
 	Ref<GLTFCamera> c = p_state->cameras[fbx_node->camera];
 	return c->to_node();
@@ -1514,7 +1514,7 @@ Light3D *FBXDocument::_generate_light(Ref<FBXState> p_state, const GLTFNodeIndex
 
 	ERR_FAIL_INDEX_V(fbx_node->light, p_state->lights.size(), nullptr);
 
-	print_verbose("FBX: Creating light for: " + fbx_node->get_name());
+	PRINT_VERBOSE("FBX: Creating light for: " + fbx_node->get_name());
 
 	Ref<GLTFLight> l = p_state->lights[fbx_node->light];
 	Light3D *light = nullptr;
@@ -1592,7 +1592,7 @@ Node3D *FBXDocument::_generate_spatial(Ref<FBXState> p_state, const GLTFNodeInde
 	Ref<GLTFNode> fbx_node = p_state->nodes[p_node_index];
 
 	Node3D *spatial = memnew(Node3D);
-	print_verbose("FBX: Converting spatial: " + fbx_node->get_name());
+	PRINT_VERBOSE("FBX: Converting spatial: " + fbx_node->get_name());
 
 	return spatial;
 }
@@ -2358,7 +2358,7 @@ Error FBXDocument::_parse_lights(Ref<FBXState> p_state) {
 		light->set_additional_data("GODOT_fbx_light", additional_data);
 		p_state->lights.push_back(light);
 	}
-	print_verbose("FBX: Total lights: " + itos(p_state->lights.size()));
+	PRINT_VERBOSE("FBX: Total lights: " + itos(p_state->lights.size()));
 	return OK;
 }
 
@@ -2461,7 +2461,7 @@ Error FBXDocument::_parse_skins(Ref<FBXState> p_state) {
 		ERR_FAIL_COND_V(SkinTool::_verify_skin(p_state->nodes, skin), ERR_PARSE_ERROR);
 	}
 
-	print_verbose("FBX: Total skins: " + itos(p_state->skins.size()));
+	PRINT_VERBOSE("FBX: Total skins: " + itos(p_state->skins.size()));
 
 	for (HashMap<GLTFNodeIndex, bool>::Iterator it = joint_mapping.begin(); it != joint_mapping.end(); ++it) {
 		GLTFNodeIndex node_index = it->key;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2458,7 +2458,7 @@ struct GDScriptDepSort {
 
 void GDScriptLanguage::reload_all_scripts() {
 #ifdef DEBUG_ENABLED
-	print_verbose("GDScript: Reloading all scripts");
+	PRINT_VERBOSE("GDScript: Reloading all scripts");
 	Array scripts;
 	{
 		MutexLock lock(mutex);
@@ -2466,7 +2466,7 @@ void GDScriptLanguage::reload_all_scripts() {
 		SelfList<GDScript> *elem = script_list.first();
 		while (elem) {
 			if (elem->self()->get_path().is_resource_file()) {
-				print_verbose("GDScript: Found: " + elem->self()->get_path());
+				PRINT_VERBOSE("GDScript: Found: " + elem->self()->get_path());
 				scripts.push_back(Ref<GDScript>(elem->self())); //cast to gdscript to avoid being erased by accident
 			}
 			elem = elem->next();
@@ -2527,7 +2527,7 @@ void GDScriptLanguage::reload_scripts(const Array &p_scripts) {
 
 	for (KeyValue<Ref<GDScript>, HashMap<ObjectID, List<Pair<StringName, Variant>>>> &E : to_reload) {
 		Ref<GDScript> scr = E.key;
-		print_verbose("GDScript: Reloading: " + scr->get_path());
+		PRINT_VERBOSE("GDScript: Reloading: " + scr->get_path());
 		if (scr->is_built_in()) {
 			// TODO: It would be nice to do it more efficiently than loading the whole scene again.
 			Ref<PackedScene> scene = ResourceLoader::load(scr->get_path().get_slice("::", 0), "", ResourceFormatLoader::CACHE_MODE_IGNORE_DEEP);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2480,7 +2480,7 @@ struct GDScriptDepSort {
 
 void GDScriptLanguage::reload_all_scripts() {
 #ifdef DEBUG_ENABLED
-	print_verbose("GDScript: Reloading all scripts");
+	PRINT_VERBOSE("GDScript: Reloading all scripts");
 	Array scripts;
 	{
 		MutexLock lock(mutex);
@@ -2488,7 +2488,7 @@ void GDScriptLanguage::reload_all_scripts() {
 		SelfList<GDScript> *elem = script_list.first();
 		while (elem) {
 			if (elem->self()->get_path().is_resource_file()) {
-				print_verbose("GDScript: Found: " + elem->self()->get_path());
+				PRINT_VERBOSE("GDScript: Found: " + elem->self()->get_path());
 				scripts.push_back(Ref<GDScript>(elem->self())); //cast to gdscript to avoid being erased by accident
 			}
 			elem = elem->next();
@@ -2549,7 +2549,7 @@ void GDScriptLanguage::reload_scripts(const Array &p_scripts) {
 
 	for (KeyValue<Ref<GDScript>, HashMap<ObjectID, List<Pair<StringName, Variant>>>> &E : to_reload) {
 		Ref<GDScript> scr = E.key;
-		print_verbose("GDScript: Reloading: " + scr->get_path());
+		PRINT_VERBOSE("GDScript: Reloading: " + scr->get_path());
 		if (scr->is_built_in()) {
 			// TODO: It would be nice to do it more efficiently than loading the whole scene again.
 			Ref<PackedScene> scene = ResourceLoader::load(scr->get_path().get_slice("::", 0), "", ResourceFormatLoader::CACHE_MODE_IGNORE_DEEP);

--- a/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
+++ b/modules/gltf/extensions/physics/gltf_document_extension_physics.cpp
@@ -306,7 +306,7 @@ void _setup_shape_mesh_resource_from_index_if_needed(const Ref<GLTFState> &p_sta
 
 #ifndef DISABLE_DEPRECATED
 CollisionObject3D *_generate_shape_with_body(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Ref<GLTFPhysicsShape> p_physics_shape, Ref<GLTFPhysicsBody> p_physics_body) {
-	print_verbose("glTF: Creating shape with body for: " + p_gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Creating shape with body for: " + p_gltf_node->get_name());
 	bool is_trigger = p_physics_shape->get_is_trigger();
 	// This method is used for the case where we must generate a parent body.
 	// This is can happen for multiple reasons. One possibility is that this

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -702,7 +702,7 @@ static inline bool _all_buffers_empty(const Vector<Vector<uint8_t>> &p_buffers, 
 }
 
 Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_path) {
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
+	PRINT_VERBOSE("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
 		ERR_FAIL_COND_V_MSG(!p_state->buffer_views.is_empty(), ERR_INVALID_DATA, "glTF: Buffer views are present, but buffers are empty.");
@@ -745,7 +745,7 @@ Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_p
 }
 
 Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_path) {
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
+	PRINT_VERBOSE("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
 		ERR_FAIL_COND_V_MSG(!p_state->buffer_views.is_empty(), ERR_INVALID_DATA, "glTF: Buffer views are present, but buffers are empty.");
@@ -823,7 +823,7 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state, const String &p_base_
 		p_state->buffers.push_back(buffer_data);
 	}
 
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
+	PRINT_VERBOSE("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	return OK;
 }
@@ -834,7 +834,7 @@ Error GLTFDocument::_encode_buffer_views(Ref<GLTFState> p_state) {
 		const Ref<GLTFBufferView> buffer_view = p_state->buffer_views[i];
 		buffers.push_back(buffer_view->to_dictionary());
 	}
-	print_verbose("glTF: Total buffer views: " + itos(p_state->buffer_views.size()));
+	PRINT_VERBOSE("glTF: Total buffer views: " + itos(p_state->buffer_views.size()));
 	if (!buffers.size()) {
 		return OK;
 	}
@@ -856,7 +856,7 @@ Error GLTFDocument::_parse_buffer_views(Ref<GLTFState> p_state) {
 		p_state->buffer_views.push_back(buffer_view);
 	}
 
-	print_verbose("glTF: Total buffer views: " + itos(p_state->buffer_views.size()));
+	PRINT_VERBOSE("glTF: Total buffer views: " + itos(p_state->buffer_views.size()));
 
 	return OK;
 }
@@ -873,7 +873,7 @@ Error GLTFDocument::_encode_accessors(Ref<GLTFState> p_state) {
 	}
 	p_state->json["accessors"] = accessors;
 	ERR_FAIL_COND_V(!p_state->json.has("accessors"), ERR_FILE_CORRUPT);
-	print_verbose("glTF: Total accessors: " + itos(p_state->accessors.size()));
+	PRINT_VERBOSE("glTF: Total accessors: " + itos(p_state->accessors.size()));
 
 	return OK;
 }
@@ -893,7 +893,7 @@ Error GLTFDocument::_parse_accessors(Ref<GLTFState> p_state) {
 		p_state->accessors.push_back(accessor);
 	}
 
-	print_verbose("glTF: Total accessors: " + itos(p_state->accessors.size()));
+	PRINT_VERBOSE("glTF: Total accessors: " + itos(p_state->accessors.size()));
 
 	return OK;
 }
@@ -1001,7 +1001,7 @@ Array GLTFDocument::_decode_accessor_as_variants(const Ref<GLTFState> p_gltf_sta
 Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 	Array meshes;
 	for (GLTFMeshIndex gltf_mesh_i = 0; gltf_mesh_i < p_state->meshes.size(); gltf_mesh_i++) {
-		print_verbose("glTF: Serializing mesh: " + itos(gltf_mesh_i));
+		PRINT_VERBOSE("glTF: Serializing mesh: " + itos(gltf_mesh_i));
 		Ref<GLTFMesh> &gltf_mesh = p_state->meshes.write[gltf_mesh_i];
 		Ref<ImporterMesh> import_mesh = gltf_mesh->get_mesh();
 		if (import_mesh.is_null()) {
@@ -1287,7 +1287,7 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 			primitive["attributes"] = attributes;
 
 			// Blend shapes
-			print_verbose("glTF: Mesh has targets");
+			PRINT_VERBOSE("glTF: Mesh has targets");
 			if (import_mesh->get_blend_shape_count()) {
 				ArrayMesh::BlendShapeMode shape_mode = import_mesh->get_blend_shape_mode();
 				const float normal_tangent_sparse_rounding = 0.001;
@@ -1415,7 +1415,7 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 		return OK;
 	}
 	p_state->json["meshes"] = meshes;
-	print_verbose("glTF: Total meshes: " + itos(meshes.size()));
+	PRINT_VERBOSE("glTF: Total meshes: " + itos(meshes.size()));
 
 	return OK;
 }
@@ -1427,7 +1427,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 
 	Array meshes = p_state->json["meshes"];
 	for (GLTFMeshIndex i = 0; i < meshes.size(); i++) {
-		print_verbose("glTF: Parsing mesh: " + itos(i));
+		PRINT_VERBOSE("glTF: Parsing mesh: " + itos(i));
 		Dictionary mesh_dict = meshes[i];
 
 		Ref<GLTFMesh> mesh;
@@ -1847,7 +1847,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 			Array morphs;
 			// Blend shapes
 			if (mesh_prim.has("targets")) {
-				print_verbose("glTF: Mesh has targets");
+				PRINT_VERBOSE("glTF: Mesh has targets");
 				const Array &targets = mesh_prim["targets"];
 
 				import_mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
@@ -2001,7 +2001,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 		p_state->meshes.push_back(mesh);
 	}
 
-	print_verbose("glTF: Total meshes: " + itos(p_state->meshes.size()));
+	PRINT_VERBOSE("glTF: Total meshes: " + itos(p_state->meshes.size()));
 
 	return OK;
 }
@@ -2080,7 +2080,7 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> p_state) {
 		images.push_back(image_dict);
 	}
 
-	print_verbose("Total images: " + itos(p_state->images.size()));
+	PRINT_VERBOSE("Total images: " + itos(p_state->images.size()));
 
 	if (!images.size()) {
 		return OK;
@@ -2445,7 +2445,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_p
 		_parse_image_save_image(p_state, data, resource_uri, file_extension, i, img);
 	}
 
-	print_verbose("glTF: Total images: " + itos(p_state->images.size()));
+	PRINT_VERBOSE("glTF: Total images: " + itos(p_state->images.size()));
 
 	return OK;
 }
@@ -2965,7 +2965,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 		return OK;
 	}
 	p_state->json["materials"] = materials;
-	print_verbose("Total materials: " + itos(p_state->materials.size()));
+	PRINT_VERBOSE("Total materials: " + itos(p_state->materials.size()));
 
 	return OK;
 }
@@ -3241,7 +3241,7 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 		p_state->materials.push_back(material);
 	}
 
-	print_verbose("Total materials: " + itos(p_state->materials.size()));
+	PRINT_VERBOSE("Total materials: " + itos(p_state->materials.size()));
 
 	return OK;
 }
@@ -3412,7 +3412,7 @@ Error GLTFDocument::_parse_skins(Ref<GLTFState> p_state) {
 		ERR_FAIL_COND_V(SkinTool::_verify_skin(p_state->nodes, skin), ERR_PARSE_ERROR);
 	}
 
-	print_verbose("glTF: Total skins: " + itos(p_state->skins.size()));
+	PRINT_VERBOSE("glTF: Total skins: " + itos(p_state->skins.size()));
 
 	return OK;
 }
@@ -3538,7 +3538,7 @@ Error GLTFDocument::_serialize_lights(Ref<GLTFState> p_state) {
 	extensions["KHR_lights_punctual"] = lights_punctual;
 	lights_punctual["lights"] = lights;
 
-	print_verbose("glTF: Total lights: " + itos(p_state->lights.size()));
+	PRINT_VERBOSE("glTF: Total lights: " + itos(p_state->lights.size()));
 
 	return OK;
 }
@@ -3556,7 +3556,7 @@ Error GLTFDocument::_serialize_cameras(Ref<GLTFState> p_state) {
 
 	p_state->json["cameras"] = cameras;
 
-	print_verbose("glTF: Total cameras: " + itos(p_state->cameras.size()));
+	PRINT_VERBOSE("glTF: Total cameras: " + itos(p_state->cameras.size()));
 
 	return OK;
 }
@@ -3584,7 +3584,7 @@ Error GLTFDocument::_parse_lights(Ref<GLTFState> p_state) {
 		p_state->lights.push_back(light);
 	}
 
-	print_verbose("glTF: Total lights: " + itos(p_state->lights.size()));
+	PRINT_VERBOSE("glTF: Total lights: " + itos(p_state->lights.size()));
 
 	return OK;
 }
@@ -3600,7 +3600,7 @@ Error GLTFDocument::_parse_cameras(Ref<GLTFState> p_state) {
 		p_state->cameras.push_back(GLTFCamera::from_dictionary(cameras[i]));
 	}
 
-	print_verbose("glTF: Total cameras: " + itos(p_state->cameras.size()));
+	PRINT_VERBOSE("glTF: Total cameras: " + itos(p_state->cameras.size()));
 
 	return OK;
 }
@@ -3828,7 +3828,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> p_state) {
 	}
 	p_state->json["animations"] = animations;
 
-	print_verbose("glTF: Total animations '" + itos(p_state->animations.size()) + "'.");
+	PRINT_VERBOSE("glTF: Total animations '" + itos(p_state->animations.size()) + "'.");
 
 	return OK;
 }
@@ -3974,7 +3974,7 @@ Error GLTFDocument::_parse_animations(Ref<GLTFState> p_state) {
 		p_state->animations.push_back(animation);
 	}
 
-	print_verbose("glTF: Total animations '" + itos(p_state->animations.size()) + "'.");
+	PRINT_VERBOSE("glTF: Total animations '" + itos(p_state->animations.size()) + "'.");
 
 	return OK;
 }
@@ -4105,7 +4105,7 @@ void GLTFDocument::_assign_node_names(Ref<GLTFState> p_state) {
 
 BoneAttachment3D *GLTFDocument::_generate_bone_attachment(Skeleton3D *p_godot_skeleton, const Ref<GLTFNode> &p_bone_node) {
 	BoneAttachment3D *bone_attachment = memnew(BoneAttachment3D);
-	print_verbose("glTF: Creating bone attachment for: " + p_bone_node->get_name());
+	PRINT_VERBOSE("glTF: Creating bone attachment for: " + p_bone_node->get_name());
 	bone_attachment->set_name(p_bone_node->get_name());
 	p_godot_skeleton->add_child(bone_attachment, true);
 	bone_attachment->set_bone_name(p_bone_node->get_name());
@@ -4116,7 +4116,7 @@ BoneAttachment3D *GLTFDocument::_generate_bone_attachment_compat_4pt4(Ref<GLTFSt
 	Ref<GLTFNode> gltf_node = p_state->nodes[p_node_index];
 	Ref<GLTFNode> bone_node = p_state->nodes[p_bone_index];
 	BoneAttachment3D *bone_attachment = memnew(BoneAttachment3D);
-	print_verbose("glTF: Creating bone attachment for: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Creating bone attachment for: " + gltf_node->get_name());
 
 	ERR_FAIL_COND_V(!bone_node->joint, nullptr);
 
@@ -4162,7 +4162,7 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 	ERR_FAIL_INDEX_V(gltf_node->mesh, p_state->meshes.size(), nullptr);
 
 	ImporterMeshInstance3D *mi = memnew(ImporterMeshInstance3D);
-	print_verbose("glTF: Creating mesh for: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Creating mesh for: " + gltf_node->get_name());
 
 	p_state->scene_mesh_instances.insert(p_node_index, mi);
 	Ref<GLTFMesh> mesh = p_state->meshes.write[gltf_node->mesh];
@@ -4183,7 +4183,7 @@ Light3D *GLTFDocument::_generate_light(Ref<GLTFState> p_state, const GLTFNodeInd
 
 	ERR_FAIL_INDEX_V(gltf_node->light, p_state->lights.size(), nullptr);
 
-	print_verbose("glTF: Creating light for: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Creating light for: " + gltf_node->get_name());
 
 	Ref<GLTFLight> l = p_state->lights[gltf_node->light];
 	return l->to_node();
@@ -4194,14 +4194,14 @@ Camera3D *GLTFDocument::_generate_camera(Ref<GLTFState> p_state, const GLTFNodeI
 
 	ERR_FAIL_INDEX_V(gltf_node->camera, p_state->cameras.size(), nullptr);
 
-	print_verbose("glTF: Creating camera for: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Creating camera for: " + gltf_node->get_name());
 
 	Ref<GLTFCamera> c = p_state->cameras[gltf_node->camera];
 	return c->to_node();
 }
 
 GLTFCameraIndex GLTFDocument::_convert_camera(Ref<GLTFState> p_state, Camera3D *p_camera) {
-	print_verbose("glTF: Converting camera: " + p_camera->get_name());
+	PRINT_VERBOSE("glTF: Converting camera: " + p_camera->get_name());
 
 	Ref<GLTFCamera> c = GLTFCamera::from_node(p_camera);
 	GLTFCameraIndex camera_index = p_state->cameras.size();
@@ -4210,7 +4210,7 @@ GLTFCameraIndex GLTFDocument::_convert_camera(Ref<GLTFState> p_state, Camera3D *
 }
 
 GLTFLightIndex GLTFDocument::_convert_light(Ref<GLTFState> p_state, Light3D *p_light) {
-	print_verbose("glTF: Converting light: " + p_light->get_name());
+	PRINT_VERBOSE("glTF: Converting light: " + p_light->get_name());
 
 	Ref<GLTFLight> l = GLTFLight::from_node(p_light);
 
@@ -4227,7 +4227,7 @@ Node3D *GLTFDocument::_generate_spatial(Ref<GLTFState> p_state, const GLTFNodeIn
 	Ref<GLTFNode> gltf_node = p_state->nodes[p_node_index];
 
 	Node3D *spatial = memnew(Node3D);
-	print_verbose("glTF: Converting spatial: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Converting spatial: " + gltf_node->get_name());
 
 	return spatial;
 }

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -702,7 +702,7 @@ static inline bool _all_buffers_empty(const Vector<Vector<uint8_t>> &p_buffers, 
 }
 
 Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_path) {
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
+	PRINT_VERBOSE("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
 		ERR_FAIL_COND_V_MSG(!p_state->buffer_views.is_empty(), ERR_INVALID_DATA, "glTF: Buffer views are present, but buffers are empty.");
@@ -745,7 +745,7 @@ Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_p
 }
 
 Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_path) {
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
+	PRINT_VERBOSE("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
 		ERR_FAIL_COND_V_MSG(!p_state->buffer_views.is_empty(), ERR_INVALID_DATA, "glTF: Buffer views are present, but buffers are empty.");
@@ -823,7 +823,7 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state, const String &p_base_
 		p_state->buffers.push_back(buffer_data);
 	}
 
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
+	PRINT_VERBOSE("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	return OK;
 }
@@ -834,7 +834,7 @@ Error GLTFDocument::_encode_buffer_views(Ref<GLTFState> p_state) {
 		const Ref<GLTFBufferView> buffer_view = p_state->buffer_views[i];
 		buffers.push_back(buffer_view->to_dictionary());
 	}
-	print_verbose("glTF: Total buffer views: " + itos(p_state->buffer_views.size()));
+	PRINT_VERBOSE("glTF: Total buffer views: " + itos(p_state->buffer_views.size()));
 	if (!buffers.size()) {
 		return OK;
 	}
@@ -856,7 +856,7 @@ Error GLTFDocument::_parse_buffer_views(Ref<GLTFState> p_state) {
 		p_state->buffer_views.push_back(buffer_view);
 	}
 
-	print_verbose("glTF: Total buffer views: " + itos(p_state->buffer_views.size()));
+	PRINT_VERBOSE("glTF: Total buffer views: " + itos(p_state->buffer_views.size()));
 
 	return OK;
 }
@@ -873,7 +873,7 @@ Error GLTFDocument::_encode_accessors(Ref<GLTFState> p_state) {
 	}
 	p_state->json["accessors"] = accessors;
 	ERR_FAIL_COND_V(!p_state->json.has("accessors"), ERR_FILE_CORRUPT);
-	print_verbose("glTF: Total accessors: " + itos(p_state->accessors.size()));
+	PRINT_VERBOSE("glTF: Total accessors: " + itos(p_state->accessors.size()));
 
 	return OK;
 }
@@ -893,7 +893,7 @@ Error GLTFDocument::_parse_accessors(Ref<GLTFState> p_state) {
 		p_state->accessors.push_back(accessor);
 	}
 
-	print_verbose("glTF: Total accessors: " + itos(p_state->accessors.size()));
+	PRINT_VERBOSE("glTF: Total accessors: " + itos(p_state->accessors.size()));
 
 	return OK;
 }
@@ -1001,7 +1001,7 @@ Array GLTFDocument::_decode_accessor_as_variants(const Ref<GLTFState> p_gltf_sta
 Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 	Array meshes;
 	for (GLTFMeshIndex gltf_mesh_i = 0; gltf_mesh_i < p_state->meshes.size(); gltf_mesh_i++) {
-		print_verbose("glTF: Serializing mesh: " + itos(gltf_mesh_i));
+		PRINT_VERBOSE("glTF: Serializing mesh: " + itos(gltf_mesh_i));
 		Ref<GLTFMesh> &gltf_mesh = p_state->meshes.write[gltf_mesh_i];
 		Ref<ImporterMesh> import_mesh = gltf_mesh->get_mesh();
 		if (import_mesh.is_null()) {
@@ -1287,7 +1287,7 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 			primitive["attributes"] = attributes;
 
 			// Blend shapes
-			print_verbose("glTF: Mesh has targets");
+			PRINT_VERBOSE("glTF: Mesh has targets");
 			if (import_mesh->get_blend_shape_count()) {
 				ArrayMesh::BlendShapeMode shape_mode = import_mesh->get_blend_shape_mode();
 				const float normal_tangent_sparse_rounding = 0.001;
@@ -1415,7 +1415,7 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 		return OK;
 	}
 	p_state->json["meshes"] = meshes;
-	print_verbose("glTF: Total meshes: " + itos(meshes.size()));
+	PRINT_VERBOSE("glTF: Total meshes: " + itos(meshes.size()));
 
 	return OK;
 }
@@ -1427,7 +1427,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 
 	Array meshes = p_state->json["meshes"];
 	for (GLTFMeshIndex i = 0; i < meshes.size(); i++) {
-		print_verbose("glTF: Parsing mesh: " + itos(i));
+		PRINT_VERBOSE("glTF: Parsing mesh: " + itos(i));
 		Dictionary mesh_dict = meshes[i];
 
 		Ref<GLTFMesh> mesh;
@@ -1846,7 +1846,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 			Array morphs;
 			// Blend shapes
 			if (mesh_prim.has("targets")) {
-				print_verbose("glTF: Mesh has targets");
+				PRINT_VERBOSE("glTF: Mesh has targets");
 				const Array &targets = mesh_prim["targets"];
 
 				import_mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
@@ -2000,7 +2000,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 		p_state->meshes.push_back(mesh);
 	}
 
-	print_verbose("glTF: Total meshes: " + itos(p_state->meshes.size()));
+	PRINT_VERBOSE("glTF: Total meshes: " + itos(p_state->meshes.size()));
 
 	return OK;
 }
@@ -2079,7 +2079,7 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> p_state) {
 		images.push_back(image_dict);
 	}
 
-	print_verbose("Total images: " + itos(p_state->images.size()));
+	PRINT_VERBOSE("Total images: " + itos(p_state->images.size()));
 
 	if (!images.size()) {
 		return OK;
@@ -2444,7 +2444,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_p
 		_parse_image_save_image(p_state, data, resource_uri, file_extension, i, img);
 	}
 
-	print_verbose("glTF: Total images: " + itos(p_state->images.size()));
+	PRINT_VERBOSE("glTF: Total images: " + itos(p_state->images.size()));
 
 	return OK;
 }
@@ -2964,7 +2964,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> p_state) {
 		return OK;
 	}
 	p_state->json["materials"] = materials;
-	print_verbose("Total materials: " + itos(p_state->materials.size()));
+	PRINT_VERBOSE("Total materials: " + itos(p_state->materials.size()));
 
 	return OK;
 }
@@ -3240,7 +3240,7 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 		p_state->materials.push_back(material);
 	}
 
-	print_verbose("Total materials: " + itos(p_state->materials.size()));
+	PRINT_VERBOSE("Total materials: " + itos(p_state->materials.size()));
 
 	return OK;
 }
@@ -3411,7 +3411,7 @@ Error GLTFDocument::_parse_skins(Ref<GLTFState> p_state) {
 		ERR_FAIL_COND_V(SkinTool::_verify_skin(p_state->nodes, skin), ERR_PARSE_ERROR);
 	}
 
-	print_verbose("glTF: Total skins: " + itos(p_state->skins.size()));
+	PRINT_VERBOSE("glTF: Total skins: " + itos(p_state->skins.size()));
 
 	return OK;
 }
@@ -3537,7 +3537,7 @@ Error GLTFDocument::_serialize_lights(Ref<GLTFState> p_state) {
 	extensions["KHR_lights_punctual"] = lights_punctual;
 	lights_punctual["lights"] = lights;
 
-	print_verbose("glTF: Total lights: " + itos(p_state->lights.size()));
+	PRINT_VERBOSE("glTF: Total lights: " + itos(p_state->lights.size()));
 
 	return OK;
 }
@@ -3555,7 +3555,7 @@ Error GLTFDocument::_serialize_cameras(Ref<GLTFState> p_state) {
 
 	p_state->json["cameras"] = cameras;
 
-	print_verbose("glTF: Total cameras: " + itos(p_state->cameras.size()));
+	PRINT_VERBOSE("glTF: Total cameras: " + itos(p_state->cameras.size()));
 
 	return OK;
 }
@@ -3583,7 +3583,7 @@ Error GLTFDocument::_parse_lights(Ref<GLTFState> p_state) {
 		p_state->lights.push_back(light);
 	}
 
-	print_verbose("glTF: Total lights: " + itos(p_state->lights.size()));
+	PRINT_VERBOSE("glTF: Total lights: " + itos(p_state->lights.size()));
 
 	return OK;
 }
@@ -3599,7 +3599,7 @@ Error GLTFDocument::_parse_cameras(Ref<GLTFState> p_state) {
 		p_state->cameras.push_back(GLTFCamera::from_dictionary(cameras[i]));
 	}
 
-	print_verbose("glTF: Total cameras: " + itos(p_state->cameras.size()));
+	PRINT_VERBOSE("glTF: Total cameras: " + itos(p_state->cameras.size()));
 
 	return OK;
 }
@@ -3827,7 +3827,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> p_state) {
 	}
 	p_state->json["animations"] = animations;
 
-	print_verbose("glTF: Total animations '" + itos(p_state->animations.size()) + "'.");
+	PRINT_VERBOSE("glTF: Total animations '" + itos(p_state->animations.size()) + "'.");
 
 	return OK;
 }
@@ -3973,7 +3973,7 @@ Error GLTFDocument::_parse_animations(Ref<GLTFState> p_state) {
 		p_state->animations.push_back(animation);
 	}
 
-	print_verbose("glTF: Total animations '" + itos(p_state->animations.size()) + "'.");
+	PRINT_VERBOSE("glTF: Total animations '" + itos(p_state->animations.size()) + "'.");
 
 	return OK;
 }
@@ -4104,7 +4104,7 @@ void GLTFDocument::_assign_node_names(Ref<GLTFState> p_state) {
 
 BoneAttachment3D *GLTFDocument::_generate_bone_attachment(Skeleton3D *p_godot_skeleton, const Ref<GLTFNode> &p_bone_node) {
 	BoneAttachment3D *bone_attachment = memnew(BoneAttachment3D);
-	print_verbose("glTF: Creating bone attachment for: " + p_bone_node->get_name());
+	PRINT_VERBOSE("glTF: Creating bone attachment for: " + p_bone_node->get_name());
 	bone_attachment->set_name(p_bone_node->get_name());
 	p_godot_skeleton->add_child(bone_attachment, true);
 	bone_attachment->set_bone_name(p_bone_node->get_name());
@@ -4115,7 +4115,7 @@ BoneAttachment3D *GLTFDocument::_generate_bone_attachment_compat_4pt4(Ref<GLTFSt
 	Ref<GLTFNode> gltf_node = p_state->nodes[p_node_index];
 	Ref<GLTFNode> bone_node = p_state->nodes[p_bone_index];
 	BoneAttachment3D *bone_attachment = memnew(BoneAttachment3D);
-	print_verbose("glTF: Creating bone attachment for: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Creating bone attachment for: " + gltf_node->get_name());
 
 	ERR_FAIL_COND_V(!bone_node->joint, nullptr);
 
@@ -4161,7 +4161,7 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 	ERR_FAIL_INDEX_V(gltf_node->mesh, p_state->meshes.size(), nullptr);
 
 	ImporterMeshInstance3D *mi = memnew(ImporterMeshInstance3D);
-	print_verbose("glTF: Creating mesh for: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Creating mesh for: " + gltf_node->get_name());
 
 	p_state->scene_mesh_instances.insert(p_node_index, mi);
 	Ref<GLTFMesh> mesh = p_state->meshes.write[gltf_node->mesh];
@@ -4182,7 +4182,7 @@ Light3D *GLTFDocument::_generate_light(Ref<GLTFState> p_state, const GLTFNodeInd
 
 	ERR_FAIL_INDEX_V(gltf_node->light, p_state->lights.size(), nullptr);
 
-	print_verbose("glTF: Creating light for: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Creating light for: " + gltf_node->get_name());
 
 	Ref<GLTFLight> l = p_state->lights[gltf_node->light];
 	return l->to_node();
@@ -4193,14 +4193,14 @@ Camera3D *GLTFDocument::_generate_camera(Ref<GLTFState> p_state, const GLTFNodeI
 
 	ERR_FAIL_INDEX_V(gltf_node->camera, p_state->cameras.size(), nullptr);
 
-	print_verbose("glTF: Creating camera for: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Creating camera for: " + gltf_node->get_name());
 
 	Ref<GLTFCamera> c = p_state->cameras[gltf_node->camera];
 	return c->to_node();
 }
 
 GLTFCameraIndex GLTFDocument::_convert_camera(Ref<GLTFState> p_state, Camera3D *p_camera) {
-	print_verbose("glTF: Converting camera: " + p_camera->get_name());
+	PRINT_VERBOSE("glTF: Converting camera: " + p_camera->get_name());
 
 	Ref<GLTFCamera> c = GLTFCamera::from_node(p_camera);
 	GLTFCameraIndex camera_index = p_state->cameras.size();
@@ -4209,7 +4209,7 @@ GLTFCameraIndex GLTFDocument::_convert_camera(Ref<GLTFState> p_state, Camera3D *
 }
 
 GLTFLightIndex GLTFDocument::_convert_light(Ref<GLTFState> p_state, Light3D *p_light) {
-	print_verbose("glTF: Converting light: " + p_light->get_name());
+	PRINT_VERBOSE("glTF: Converting light: " + p_light->get_name());
 
 	Ref<GLTFLight> l = GLTFLight::from_node(p_light);
 
@@ -4226,7 +4226,7 @@ Node3D *GLTFDocument::_generate_spatial(Ref<GLTFState> p_state, const GLTFNodeIn
 	Ref<GLTFNode> gltf_node = p_state->nodes[p_node_index];
 
 	Node3D *spatial = memnew(Node3D);
-	print_verbose("glTF: Converting spatial: " + gltf_node->get_name());
+	PRINT_VERBOSE("glTF: Converting spatial: " + gltf_node->get_name());
 
 	return spatial;
 }

--- a/modules/gltf/structures/gltf_accessor.cpp
+++ b/modules/gltf/structures/gltf_accessor.cpp
@@ -640,7 +640,7 @@ Vector<T> GLTFAccessor::_decode_raw_numbers(const Ref<GLTFState> &p_gltf_state, 
 			stride_skip_bytes = declared_byte_stride - bytes_per_vector;
 		}
 	} else if (raw_buffer_view->get_vertex_attributes()) {
-		print_verbose("WARNING: glTF import: Buffer view byte stride should be declared for vertex attributes. Assuming packed data and reading anyway.");
+		PRINT_VERBOSE("WARNING: glTF import: Buffer view byte stride should be declared for vertex attributes. Assuming packed data and reading anyway.");
 	}
 	const int64_t min_raw_byte_size = actual_byte_stride * (raw_vector_count - 1) + bytes_per_vector + raw_read_offset_start;
 	const PackedByteArray raw_bytes = raw_buffer_view->load_buffer_view_data(p_gltf_state);

--- a/modules/jolt_physics/jolt_globals.cpp
+++ b/modules/jolt_physics/jolt_globals.cpp
@@ -82,7 +82,7 @@ void jolt_trace(const char *p_format, ...) {
 	char buffer[1024] = { '\0' };
 	vsnprintf(buffer, sizeof(buffer), p_format, args);
 	va_end(args);
-	print_verbose(buffer);
+	PRINT_VERBOSE(buffer);
 }
 
 bool jolt_assert(const char *p_expr, const char *p_msg, const char *p_file, uint32_t p_line) {

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -987,7 +987,7 @@ LightmapperRD::BakeError LightmapperRD::_denoise_oidn(RenderingDevice *p_rd, RID
 
 			if (err != OK || exitcode != 0) {
 				da->remove(fname_out);
-				print_verbose(str);
+				PRINT_VERBOSE(str);
 				ERR_FAIL_V_MSG(BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES, vformat("OIDN denoiser failed, return code: %d", exitcode));
 			}
 

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -262,7 +262,7 @@ Error X509CertificateMbedTLS::load(const String &p_path) {
 	int ret = mbedtls_x509_crt_parse(&cert, out.ptr(), out.size());
 	ERR_FAIL_COND_V_MSG(ret < 0, FAILED, vformat("Error parsing X509 certificates from file '%s': %d.", p_path, ret));
 	if (ret > 0) { // Some certs parsed fine, don't error.
-		print_verbose(vformat("MbedTLS: Some X509 certificates could not be parsed from file '%s' (%d certificates skipped).", p_path, ret));
+		PRINT_VERBOSE(vformat("MbedTLS: Some X509 certificates could not be parsed from file '%s' (%d certificates skipped).", p_path, ret));
 	}
 
 	return OK;
@@ -274,7 +274,7 @@ Error X509CertificateMbedTLS::load_from_memory(const uint8_t *p_buffer, int p_le
 	int ret = mbedtls_x509_crt_parse(&cert, p_buffer, p_len);
 	ERR_FAIL_COND_V_MSG(ret < 0, FAILED, vformat("Error parsing X509 certificates: %d.", ret));
 	if (ret > 0) { // Some certs parsed fine, don't error.
-		print_verbose(vformat("MbedTLS: Some X509 certificates could not be parsed (%d certificates skipped).", ret));
+		PRINT_VERBOSE(vformat("MbedTLS: Some X509 certificates could not be parsed (%d certificates skipped).", ret));
 	}
 	return OK;
 }
@@ -325,7 +325,7 @@ Error X509CertificateMbedTLS::load_from_string(const String &p_string_key) {
 	int ret = mbedtls_x509_crt_parse(&cert, (const unsigned char *)cs.get_data(), cs.size());
 	ERR_FAIL_COND_V_MSG(ret < 0, FAILED, vformat("Error parsing X509 certificates: %d.", ret));
 	if (ret > 0) { // Some certs parsed fine, don't error.
-		print_verbose(vformat("MbedTLS: Some X509 certificates could not be parsed (%d certificates skipped).", ret));
+		PRINT_VERBOSE(vformat("MbedTLS: Some X509 certificates could not be parsed (%d certificates skipped).", ret));
 	}
 
 	return OK;
@@ -457,7 +457,7 @@ void CryptoMbedTLS::load_default_certificates(const String &p_path) {
 		if (!system_certs.is_empty()) {
 			CharString cs = system_certs.utf8();
 			default_certs->load_from_memory((const uint8_t *)cs.get_data(), cs.size());
-			print_verbose("Loaded system CA certificates");
+			PRINT_VERBOSE("Loaded system CA certificates");
 		}
 #ifdef BUILTIN_CERTS_ENABLED
 		else {
@@ -468,7 +468,7 @@ void CryptoMbedTLS::load_default_certificates(const String &p_path) {
 			ERR_FAIL_COND_MSG(decompressed_size != _certs_uncompressed_size, "Error decompressing builtin CA certificates. Decompressed size did not match expected size.");
 			certs.write[_certs_uncompressed_size] = 0; // Make sure it ends with string terminator
 			default_certs->load_from_memory(certs.ptr(), certs.size());
-			print_verbose("Loaded builtin CA certificates");
+			PRINT_VERBOSE("Loaded builtin CA certificates");
 		}
 #endif
 	}

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -102,7 +102,7 @@ String CSharpLanguage::get_extension() const {
 void CSharpLanguage::init() {
 #ifdef TOOLS_ENABLED
 	if (OS::get_singleton()->get_cmdline_args().find("--generate-mono-glue")) {
-		print_verbose(".NET: Skipping runtime initialization because glue generation is enabled.");
+		PRINT_VERBOSE(".NET: Skipping runtime initialization because glue generation is enabled.");
 		return;
 	}
 #endif
@@ -634,7 +634,7 @@ void CSharpLanguage::reload_assemblies() {
 		return;
 	}
 
-	print_verbose(".NET: Reloading assemblies...");
+	PRINT_VERBOSE(".NET: Reloading assemblies...");
 
 	// There is no soft reloading with Mono. It's always hard reloading.
 
@@ -2602,7 +2602,7 @@ Error CSharpScript::reload(bool p_keep_state) {
 
 	if (valid) {
 #ifdef DEBUG_ENABLED
-		print_verbose("Found class for script " + get_path());
+		PRINT_VERBOSE("Found class for script " + get_path());
 #endif // DEBUG_ENABLED
 
 		update_script_class_info(this);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -102,7 +102,7 @@ String CSharpLanguage::get_extension() const {
 void CSharpLanguage::init() {
 #ifdef TOOLS_ENABLED
 	if (OS::get_singleton()->get_cmdline_args().find("--generate-mono-glue")) {
-		print_verbose(".NET: Skipping runtime initialization because glue generation is enabled.");
+		PRINT_VERBOSE(".NET: Skipping runtime initialization because glue generation is enabled.");
 		return;
 	}
 #endif
@@ -634,7 +634,7 @@ void CSharpLanguage::reload_assemblies() {
 		return;
 	}
 
-	print_verbose(".NET: Reloading assemblies...");
+	PRINT_VERBOSE(".NET: Reloading assemblies...");
 
 	// There is no soft reloading with Mono. It's always hard reloading.
 
@@ -2606,7 +2606,7 @@ Error CSharpScript::reload(bool p_keep_state) {
 
 	if (valid) {
 #ifdef DEBUG_ENABLED
-		print_verbose("Found class for script " + get_path());
+		PRINT_VERBOSE("Found class for script " + get_path());
 #endif // DEBUG_ENABLED
 
 		update_script_class_info(this);

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -177,7 +177,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			}
 		} break;
 		case CompletionKind::SHADER_PARAMS: {
-			print_verbose("Shader uniforms completion for C# is not implemented yet.");
+			PRINT_VERBOSE("Shader uniforms completion for C# is not implemented yet.");
 		} break;
 		case CompletionKind::SIGNALS: {
 			Ref<Script> script = ResourceLoader::load(p_script_file.simplify_path());

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -182,7 +182,7 @@ private:
 		String packed_path = "res://.godot/mono/publish/" + arch;
 #ifdef ANDROID_ENABLED
 		api_assemblies_dir = packed_path;
-		print_verbose(".NET: Android platform detected. Setting api_assemblies_dir directly to pck path: " + api_assemblies_dir);
+		PRINT_VERBOSE(".NET: Android platform detected. Setting api_assemblies_dir directly to pck path: " + api_assemblies_dir);
 #else
 		if (DirAccess::exists(packed_path)) {
 			// The dotnet publish data is packed in the pck/zip.

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -153,7 +153,7 @@ bool try_get_dotnet_root_from_command_line(String &r_dotnet_root) {
 	}
 
 	if (!latest_sdk_path.is_empty()) {
-		print_verbose("Found .NET SDK at " + latest_sdk_path);
+		PRINT_VERBOSE("Found .NET SDK at " + latest_sdk_path);
 		// The `dotnet_root` is the parent directory.
 		r_dotnet_root = latest_sdk_path.path_join("..").simplify_path();
 		return true;
@@ -265,7 +265,7 @@ bool load_hostfxr(void *&r_hostfxr_dll_handle) {
 		return false;
 	}
 
-	print_verbose("Found hostfxr: " + hostfxr_path);
+	PRINT_VERBOSE("Found hostfxr: " + hostfxr_path);
 
 	Error err = OS::get_singleton()->open_dynamic_library(hostfxr_path, r_hostfxr_dll_handle);
 
@@ -314,7 +314,7 @@ bool load_coreclr(void *&r_coreclr_dll_handle) {
 	}
 
 	const String coreclr_name = is_monovm ? "monosgen" : "coreclr";
-	print_verbose("Found " + coreclr_name + ": " + coreclr_path);
+	PRINT_VERBOSE("Found " + coreclr_name + ": " + coreclr_path);
 
 	Error err = OS::get_singleton()->open_dynamic_library(coreclr_path, r_coreclr_dll_handle);
 
@@ -449,7 +449,7 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 
 	r_runtime_initialized = true;
 
-	print_verbose(".NET: hostfxr initialized");
+	PRINT_VERBOSE(".NET: hostfxr initialized");
 
 	int rc = load_assembly_and_get_function_pointer(get_data(godot_plugins_path),
 			HOSTFXR_STR("GodotPlugins.Main, GodotPlugins"),
@@ -476,7 +476,7 @@ godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime
 
 	r_runtime_initialized = true;
 
-	print_verbose(".NET: hostfxr initialized");
+	PRINT_VERBOSE(".NET: hostfxr initialized");
 
 	int rc = load_assembly_and_get_function_pointer(get_data(assembly_path),
 			get_data(str_to_hostfxr("GodotPlugins.Game.Main, " + assembly_name)),
@@ -541,7 +541,7 @@ MonoAssembly *load_assembly_from_pck(MonoAssemblyName *p_assembly_name, char **p
 	String path = GodotSharpDirs::get_api_assemblies_dir();
 	path = path.path_join(assembly_name);
 
-	print_verbose(".NET: Loading assembly '" + assembly_name + "' from '" + path + "'.");
+	PRINT_VERBOSE(".NET: Loading assembly '" + assembly_name + "' from '" + path + "'.");
 
 	if (!FileAccess::exists(path)) {
 		// We could not find the assembly, return null so another hook may find it.
@@ -595,7 +595,7 @@ godot_plugins_initialize_fn initialize_coreclr_and_godot_plugins(bool &r_runtime
 
 	r_runtime_initialized = true;
 
-	print_verbose(".NET: CoreCLR initialized");
+	PRINT_VERBOSE(".NET: CoreCLR initialized");
 
 	coreclr_create_delegate(coreclr_handle, domain_id,
 			assembly_name.utf8().get_data(),
@@ -637,7 +637,7 @@ static bool _on_core_api_assembly_loaded() {
 }
 
 void GDMono::initialize() {
-	print_verbose(".NET: Initializing module...");
+	PRINT_VERBOSE(".NET: Initializing module...");
 
 	_init_godot_api_hashes();
 
@@ -706,7 +706,7 @@ void GDMono::initialize() {
 
 	GDMonoCache::update_godot_api_cache(managed_callbacks);
 
-	print_verbose(".NET: GodotPlugins initialized");
+	PRINT_VERBOSE(".NET: GodotPlugins initialized");
 
 	_on_core_api_assembly_loaded();
 

--- a/modules/objectdb_profiler/editor/snapshot_data.cpp
+++ b/modules/objectdb_profiler/editor/snapshot_data.cpp
@@ -355,7 +355,7 @@ Ref<GameStateSnapshot> GameStateSnapshot::create_ref(const String &p_snapshot_na
 	}
 
 	snapshot->recompute_references();
-	print_verbose("Resource cache hits: " + String::num(resource_cache.hits) + ". Resource cache misses: " + String::num(resource_cache.misses));
+	PRINT_VERBOSE("Resource cache hits: " + String::num(resource_cache.hits) + ". Resource cache misses: " + String::num(resource_cache.misses));
 	return snapshot;
 }
 

--- a/modules/objectdb_profiler/snapshot_collector.cpp
+++ b/modules/objectdb_profiler/snapshot_collector.cpp
@@ -50,7 +50,7 @@ void SnapshotCollector::deinitialize() {
 }
 
 void SnapshotCollector::snapshot_objects(Array *p_arr, Dictionary &p_snapshot_context) {
-	print_verbose("Starting to snapshot");
+	PRINT_VERBOSE("Starting to snapshot");
 	p_arr->clear();
 
 	// Gather all ObjectIDs first. The ObjectDB will be locked in debug_objects, so we can't serialize until it exits.
@@ -73,7 +73,7 @@ void SnapshotCollector::snapshot_objects(Array *p_arr, Dictionary &p_snapshot_co
 		ObjectID oid = ids.first;
 		Object *obj = ObjectDB::get_instance(oid);
 		if (unlikely(obj == nullptr)) {
-			print_verbose(vformat("Object of class '%s' with ID %ud was found to be deleted after ObjectDB was snapshotted.", ids.second, (uint64_t)oid));
+			PRINT_VERBOSE(vformat("Object of class '%s' with ID %ud was found to be deleted after ObjectDB was snapshotted.", ids.second, (uint64_t)oid));
 			continue;
 		}
 
@@ -123,7 +123,7 @@ void SnapshotCollector::snapshot_objects(Array *p_arr, Dictionary &p_snapshot_co
 		p_arr->push_back(debug_data.extra_debug_data);
 	}
 
-	print_verbose("Snapshot size: " + String::num_uint64(p_arr->size()));
+	PRINT_VERBOSE("Snapshot size: " + String::num_uint64(p_arr->size()));
 }
 
 Error SnapshotCollector::parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured) {

--- a/modules/openxr/extensions/openxr_debug_utils_extension.cpp
+++ b/modules/openxr/extensions/openxr_debug_utils_extension.cpp
@@ -281,7 +281,7 @@ XrBool32 OpenXRDebugUtilsExtension::debug_callback(XrDebugUtilsMessageSeverityFl
 		print_line("OpenXR: Severity: Info" + msg);
 	} else if (p_message_severity == XR_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) {
 		// This is a bit double because we won't output this unless verbose messaging in Godot is on.
-		print_verbose("OpenXR: Severity: Verbose" + msg);
+		PRINT_VERBOSE("OpenXR: Severity: Verbose" + msg);
 	}
 
 	return XR_FALSE;

--- a/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
+++ b/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
@@ -137,7 +137,7 @@ bool OpenXRHTCViveTrackerExtension::on_event_polled(const XrEventDataBuffer &eve
 	switch (event.type) {
 		case XR_TYPE_EVENT_DATA_VIVE_TRACKER_CONNECTED_HTCX: {
 			// Investigate if we need to do more here
-			print_verbose("OpenXR EVENT: VIVE tracker connected");
+			PRINT_VERBOSE("OpenXR EVENT: VIVE tracker connected");
 
 			return true;
 		} break;

--- a/modules/openxr/extensions/openxr_render_model_extension.cpp
+++ b/modules/openxr/extensions/openxr_render_model_extension.cpp
@@ -235,7 +235,7 @@ void OpenXRRenderModelExtension::on_sync_actions() {
 			if (XR_FAILED(result)) {
 				ERR_PRINT("OpenXR: Failed to update the top level path for render models [" + openxr_api->get_error_string(result) + "]");
 			} else if (new_path != render_model->top_level_path) {
-				print_verbose("OpenXR: Render model top level path changed to " + openxr_api->get_xr_path_name(new_path));
+				PRINT_VERBOSE("OpenXR: Render model top level path changed to " + openxr_api->get_xr_path_name(new_path));
 
 				// Set the new path
 				render_model->top_level_path = new_path;

--- a/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
+++ b/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
@@ -147,7 +147,7 @@ bool OpenXRVisibilityMaskExtension::on_event_polled(const XrEventDataBuffer &eve
 	if (event.type == XR_TYPE_EVENT_DATA_VISIBILITY_MASK_CHANGED_KHR) {
 		XrEventDataVisibilityMaskChangedKHR *vismask_event = (XrEventDataVisibilityMaskChangedKHR *)&event;
 
-		print_verbose("OpenXR EVENT: Visibility mask changed for view " + String::num_uint64(vismask_event->viewIndex));
+		PRINT_VERBOSE("OpenXR EVENT: Visibility mask changed for view " + String::num_uint64(vismask_event->viewIndex));
 
 		if (available) { // This event won't be called if this extension is not available but better safe than sorry.
 			_update_mesh_data(vismask_event->viewIndex);

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
@@ -384,7 +384,7 @@ void OpenXRSpatialAnchorCapability::on_instance_created(const XrInstance p_insta
 		if (xr_result != XR_SUCCESS) {
 			// Check for stores for compatibility with beta runtimes.
 			// Lucky for us, related structs and enums are compatible.
-			print_verbose("OpenXR: xrEnumerateSpatialPersistenceScopesEXT is not supported, falling back to xrEnumerateSpatialPersistenceStoresEXT!");
+			PRINT_VERBOSE("OpenXR: xrEnumerateSpatialPersistenceScopesEXT is not supported, falling back to xrEnumerateSpatialPersistenceStoresEXT!");
 			xr_result = openxr_api->get_instance_proc_addr("xrEnumerateSpatialPersistenceStoresEXT", (PFN_xrVoidFunction *)&xrEnumerateSpatialPersistenceScopesEXT_ptr);
 		}
 		ERR_FAIL_COND(XR_FAILED(xr_result));
@@ -590,9 +590,9 @@ bool OpenXRSpatialAnchorCapability::_load_supported_persistence_scopes() {
 
 		if (is_print_verbose_enabled()) {
 			if (!supported_persistence_scopes.is_empty()) {
-				print_verbose("OpenXR: Supported spatial persistence scopes:");
+				PRINT_VERBOSE("OpenXR: Supported spatial persistence scopes:");
 				for (const XrSpatialPersistenceScopeEXT &scope : supported_persistence_scopes) {
-					print_verbose(" - " + get_spatial_persistence_scope_name(scope));
+					PRINT_VERBOSE(" - " + get_spatial_persistence_scope_name(scope));
 				}
 			} else {
 				WARN_PRINT("OpenXR: No persistence scopes found!");
@@ -635,7 +635,7 @@ Ref<OpenXRFutureResult> OpenXRSpatialAnchorCapability::create_default_persistenc
 	}
 
 	// Output what we're using:
-	print_verbose("OpenXR: Using persistence scope " + get_spatial_persistence_scope_name(scope));
+	PRINT_VERBOSE("OpenXR: Using persistence scope " + get_spatial_persistence_scope_name(scope));
 
 	// Start by creating our persistence context.
 	return create_persistence_context(scope, p_user_callback);

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
@@ -195,7 +195,7 @@ void OpenXRSpatialEntityExtension::on_session_destroyed() {
 	// Cleanup remaining snapshot RIDs.
 	LocalVector<RID> spatial_snapshot_rids = spatial_snapshot_owner.get_owned_list();
 	if (!spatial_snapshot_rids.is_empty()) {
-		print_verbose("OpenXR: Found " + String::num_int64(spatial_snapshot_rids.size()) + " orphaned spatial snapshots"); // Don't have useful data to report here so just report count.
+		PRINT_VERBOSE("OpenXR: Found " + String::num_int64(spatial_snapshot_rids.size()) + " orphaned spatial snapshots"); // Don't have useful data to report here so just report count.
 		for (const RID &rid : spatial_snapshot_rids) {
 			free_spatial_snapshot(rid);
 		}
@@ -204,7 +204,7 @@ void OpenXRSpatialEntityExtension::on_session_destroyed() {
 	// Clean up all remaining spatial context RIDs.
 	LocalVector<RID> spatial_context_rids = spatial_context_owner.get_owned_list();
 	if (!spatial_context_rids.is_empty()) {
-		print_verbose("OpenXR: Found " + String::num_int64(spatial_context_rids.size()) + " orphaned spatial contexts"); // Don't have useful data to report here so just report count.
+		PRINT_VERBOSE("OpenXR: Found " + String::num_int64(spatial_context_rids.size()) + " orphaned spatial contexts"); // Don't have useful data to report here so just report count.
 		for (const RID &rid : spatial_context_rids) {
 			free_spatial_context(rid);
 		}
@@ -252,7 +252,7 @@ bool OpenXRSpatialEntityExtension::_load_capabilities() {
 
 			// Loop through capabilities
 			for (const XrSpatialCapabilityEXT &capability : capabilities) {
-				print_verbose("OpenXR: Found spatial entity capability " + get_spatial_capability_name(capability) + ".");
+				PRINT_VERBOSE("OpenXR: Found spatial entity capability " + get_spatial_capability_name(capability) + ".");
 
 				SpatialEntityCapabality &spatial_entity_capability = supported_capabilities[capability];
 
@@ -279,7 +279,7 @@ bool OpenXRSpatialEntityExtension::_load_capabilities() {
 						ERR_PRINT("OpenXR: Failed to get spatial entity component types [" + openxr_api->get_error_string(result) + "]");
 					} else if (is_print_verbose_enabled()) {
 						for (const XrSpatialComponentTypeEXT &component_type : spatial_entity_capability.component_types) {
-							print_verbose("- component type " + get_spatial_component_type_name(component_type));
+							PRINT_VERBOSE("- component type " + get_spatial_component_type_name(component_type));
 						}
 					}
 				}
@@ -297,7 +297,7 @@ bool OpenXRSpatialEntityExtension::_load_capabilities() {
 						ERR_PRINT("OpenXR: Failed to get spatial entity features [" + openxr_api->get_error_string(result) + "]");
 					} else if (is_print_verbose_enabled()) {
 						for (const XrSpatialCapabilityFeatureEXT &feature : spatial_entity_capability.features) {
-							print_verbose("- feature " + get_spatial_feature_name(feature));
+							PRINT_VERBOSE("- feature " + get_spatial_feature_name(feature));
 						}
 					}
 				}

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
@@ -203,7 +203,7 @@ void OpenXRSpatialEntityExtension::on_session_destroyed() {
 	// Cleanup remaining snapshot RIDs.
 	LocalVector<RID> spatial_snapshot_rids = spatial_snapshot_owner.get_owned_list();
 	if (!spatial_snapshot_rids.is_empty()) {
-		print_verbose("OpenXR: Found " + String::num_int64(spatial_snapshot_rids.size()) + " orphaned spatial snapshots"); // Don't have useful data to report here so just report count.
+		PRINT_VERBOSE("OpenXR: Found " + String::num_int64(spatial_snapshot_rids.size()) + " orphaned spatial snapshots"); // Don't have useful data to report here so just report count.
 		for (const RID &rid : spatial_snapshot_rids) {
 			free_spatial_snapshot(rid);
 		}
@@ -212,7 +212,7 @@ void OpenXRSpatialEntityExtension::on_session_destroyed() {
 	// Clean up all remaining spatial context RIDs.
 	LocalVector<RID> spatial_context_rids = spatial_context_owner.get_owned_list();
 	if (!spatial_context_rids.is_empty()) {
-		print_verbose("OpenXR: Found " + String::num_int64(spatial_context_rids.size()) + " orphaned spatial contexts"); // Don't have useful data to report here so just report count.
+		PRINT_VERBOSE("OpenXR: Found " + String::num_int64(spatial_context_rids.size()) + " orphaned spatial contexts"); // Don't have useful data to report here so just report count.
 		for (const RID &rid : spatial_context_rids) {
 			free_spatial_context(rid);
 		}
@@ -260,7 +260,7 @@ bool OpenXRSpatialEntityExtension::_load_capabilities() {
 
 			// Loop through capabilities
 			for (const XrSpatialCapabilityEXT &capability : capabilities) {
-				print_verbose("OpenXR: Found spatial entity capability " + get_spatial_capability_name(capability) + ".");
+				PRINT_VERBOSE("OpenXR: Found spatial entity capability " + get_spatial_capability_name(capability) + ".");
 
 				SpatialEntityCapabality &spatial_entity_capability = supported_capabilities[capability];
 
@@ -287,7 +287,7 @@ bool OpenXRSpatialEntityExtension::_load_capabilities() {
 						ERR_PRINT("OpenXR: Failed to get spatial entity component types [" + openxr_api->get_error_string(result) + "]");
 					} else if (is_print_verbose_enabled()) {
 						for (const XrSpatialComponentTypeEXT &component_type : spatial_entity_capability.component_types) {
-							print_verbose("- component type " + get_spatial_component_type_name(component_type));
+							PRINT_VERBOSE("- component type " + get_spatial_component_type_name(component_type));
 						}
 					}
 				}
@@ -305,7 +305,7 @@ bool OpenXRSpatialEntityExtension::_load_capabilities() {
 						ERR_PRINT("OpenXR: Failed to get spatial entity features [" + openxr_api->get_error_string(result) + "]");
 					} else if (is_print_verbose_enabled()) {
 						for (const XrSpatialCapabilityFeatureEXT &feature : spatial_entity_capability.features) {
-							print_verbose("- feature " + get_spatial_feature_name(feature));
+							PRINT_VERBOSE("- feature " + get_spatial_feature_name(feature));
 						}
 					}
 				}

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -675,7 +675,7 @@ Ref<OpenXRFutureResult> OpenXRSpatialMarkerTrackingCapability::_create_spatial_c
 	}
 
 	if (capability_configurations.is_empty()) {
-		print_verbose("OpenXR: There are no supported marker types. Marker tracking is not enabled.");
+		PRINT_VERBOSE("OpenXR: There are no supported marker types. Marker tracking is not enabled.");
 		return nullptr;
 	}
 

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -752,7 +752,7 @@ Ref<OpenXRFutureResult> OpenXRSpatialMarkerTrackingCapability::_create_spatial_c
 	}
 
 	if (capability_configurations.is_empty()) {
-		print_verbose("OpenXR: There are no supported marker types. Marker tracking is not enabled.");
+		PRINT_VERBOSE("OpenXR: There are no supported marker types. Marker tracking is not enabled.");
 		return nullptr;
 	}
 

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -483,7 +483,7 @@ Ref<Mesh> OpenXRPlaneTracker::get_mesh() {
 		// Cache this.
 		mesh.mesh = plane_mesh;
 	} else {
-		print_verbose("OpenXR: Can't create mesh for plane, no data.");
+		PRINT_VERBOSE("OpenXR: Can't create mesh for plane, no data.");
 	}
 	return mesh.mesh;
 }

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -505,7 +505,7 @@ Ref<Mesh> OpenXRPlaneTracker::get_mesh() {
 		// Cache this.
 		mesh.mesh = plane_mesh;
 	} else {
-		print_verbose("OpenXR: Can't create mesh for plane, no data.");
+		PRINT_VERBOSE("OpenXR: Can't create mesh for plane, no data.");
 	}
 	return mesh.mesh;
 }

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -409,7 +409,7 @@ bool OpenXRAPI::load_layer_properties() {
 	ERR_FAIL_COND_V_MSG(XR_FAILED(result), false, "OpenXR: Failed to enumerate api layer properties");
 
 	for (const XrApiLayerProperties &layer : layer_properties) {
-		print_verbose(vformat("OpenXR: Found OpenXR layer %s.", layer.layerName));
+		PRINT_VERBOSE(vformat("OpenXR: Found OpenXR layer %s.", layer.layerName));
 	}
 
 	return true;
@@ -439,7 +439,7 @@ bool OpenXRAPI::load_supported_extensions() {
 	ERR_FAIL_COND_V_MSG(XR_FAILED(result), false, "OpenXR: Failed to enumerate extension properties");
 
 	for (const XrExtensionProperties &extension : supported_extensions) {
-		print_verbose(vformat("OpenXR: Found OpenXR extension %s.", extension.extensionName));
+		PRINT_VERBOSE(vformat("OpenXR: Found OpenXR extension %s.", extension.extensionName));
 	}
 
 	return true;
@@ -483,7 +483,7 @@ bool OpenXRAPI::is_top_level_path_supported(const String &p_toplevel_path) {
 
 	if (!is_any_extension_enabled(required_extensions)) {
 		// It is very likely we have top level paths for which the extension is not available so don't flood the logs with unnecessary spam.
-		print_verbose("OpenXR: Top level path " + p_toplevel_path + " requires extension " + required_extensions.replace(",", " or "));
+		PRINT_VERBOSE("OpenXR: Top level path " + p_toplevel_path + " requires extension " + required_extensions.replace(",", " or "));
 		return false;
 	}
 
@@ -503,7 +503,7 @@ bool OpenXRAPI::is_interaction_profile_supported(const String &p_ip_path) {
 
 	if (!is_any_extension_enabled(required_extensions)) {
 		// It is very likely we have interaction profiles for which the extension is not available so don't flood the logs with unnecessary spam.
-		print_verbose("OpenXR: Interaction profile " + p_ip_path + " requires extension " + required_extensions.replace(",", " or "));
+		PRINT_VERBOSE("OpenXR: Interaction profile " + p_ip_path + " requires extension " + required_extensions.replace(",", " or "));
 		return false;
 	}
 
@@ -527,7 +527,7 @@ bool OpenXRAPI::interaction_profile_supports_io_path(const String &p_ip_path, co
 
 	if (!is_any_extension_enabled(io_path->openxr_extension_names)) {
 		// It is very likely we have io paths for which the extension is not available so don't flood the logs with unnecessary spam.
-		print_verbose("OpenXR: IO path " + String(p_ip_path) + String(p_io_path) + " requires extension " + io_path->openxr_extension_names.replace(",", " or "));
+		PRINT_VERBOSE("OpenXR: IO path " + String(p_ip_path) + String(p_io_path) + " requires extension " + io_path->openxr_extension_names.replace(",", " or "));
 		return false;
 	}
 
@@ -680,7 +680,7 @@ bool OpenXRAPI::create_instance() {
 
 	XrResult result = attempt_create_instance(init_version);
 	if (result == XR_ERROR_API_VERSION_UNSUPPORTED && init_version == XR_API_VERSION_1_1) {
-		print_verbose("OpenXR: Falling back to OpenXR 1.0");
+		PRINT_VERBOSE("OpenXR: Falling back to OpenXR 1.0");
 
 		init_version = XR_API_VERSION_1_0;
 		result = attempt_create_instance(init_version);
@@ -800,12 +800,12 @@ bool OpenXRAPI::load_supported_view_configuration_types() {
 	ERR_FAIL_COND_V_MSG(num_view_configuration_types == 0, false, "OpenXR: Failed to enumerateview configurations"); // JIC there should be at least 1!
 
 	for (const XrViewConfigurationType &view_configuration_type : supported_view_configuration_types) {
-		print_verbose(vformat("OpenXR: Found supported view configuration %s.", OpenXRUtil::get_view_configuration_name(view_configuration_type)));
+		PRINT_VERBOSE(vformat("OpenXR: Found supported view configuration %s.", OpenXRUtil::get_view_configuration_name(view_configuration_type)));
 	}
 
 	// Check value we loaded at startup...
 	if (!is_view_configuration_supported(view_configuration)) {
-		print_verbose(vformat("OpenXR: %s isn't supported, defaulting to %s.", OpenXRUtil::get_view_configuration_name(view_configuration), OpenXRUtil::get_view_configuration_name(supported_view_configuration_types[0])));
+		PRINT_VERBOSE(vformat("OpenXR: %s isn't supported, defaulting to %s.", OpenXRUtil::get_view_configuration_name(view_configuration), OpenXRUtil::get_view_configuration_name(supported_view_configuration_types[0])));
 
 		view_configuration = supported_view_configuration_types[0];
 	}
@@ -834,7 +834,7 @@ bool OpenXRAPI::load_supported_environmental_blend_modes() {
 	ERR_FAIL_COND_V_MSG(num_supported_environment_blend_modes == 0, false, "OpenXR: Failed to enumerate environmental blend modes"); // JIC there should be at least 1!
 
 	for (const XrEnvironmentBlendMode &supported_environment_blend_mode : supported_environment_blend_modes) {
-		print_verbose(vformat("OpenXR: Found environmental blend mode %s.", OpenXRUtil::get_environment_blend_mode_name(supported_environment_blend_mode)));
+		PRINT_VERBOSE(vformat("OpenXR: Found environmental blend mode %s.", OpenXRUtil::get_environment_blend_mode_name(supported_environment_blend_mode)));
 	}
 
 	return true;
@@ -968,7 +968,7 @@ bool OpenXRAPI::create_session() {
 	// Check our environment blend mode. This needs to happen after we call `on_session_created()`
 	// on the extension wrappers, so they can emulate alpha blend mode.
 	if (!set_environment_blend_mode(environment_blend_mode)) {
-		print_verbose(String("OpenXR: ") + OpenXRUtil::get_environment_blend_mode_name(environment_blend_mode) + String(" isn't supported, defaulting to ") + OpenXRUtil::get_environment_blend_mode_name(supported_environment_blend_modes[0]));
+		PRINT_VERBOSE(String("OpenXR: ") + OpenXRUtil::get_environment_blend_mode_name(environment_blend_mode) + String(" isn't supported, defaulting to ") + OpenXRUtil::get_environment_blend_mode_name(supported_environment_blend_modes[0]));
 		set_environment_blend_mode(supported_environment_blend_modes[0]);
 	}
 
@@ -996,7 +996,7 @@ bool OpenXRAPI::load_supported_reference_spaces() {
 	ERR_FAIL_COND_V_MSG(num_reference_spaces == 0, false, "OpenXR: Failed to enumerate reference spaces");
 
 	for (const XrReferenceSpaceType &supported_reference_space : supported_reference_spaces) {
-		print_verbose(vformat("OpenXR: Found supported reference space %s.", OpenXRUtil::get_reference_space_name(supported_reference_space)));
+		PRINT_VERBOSE(vformat("OpenXR: Found supported reference space %s.", OpenXRUtil::get_reference_space_name(supported_reference_space)));
 	}
 
 	return true;
@@ -1027,7 +1027,7 @@ bool OpenXRAPI::setup_play_space() {
 	} else if (requested_reference_space == XR_REFERENCE_SPACE_TYPE_LOCAL_FLOOR_EXT && is_reference_space_supported(XR_REFERENCE_SPACE_TYPE_STAGE)) {
 		// Note, in OpenXR 1.0 XR_EXT_LOCAL_FLOOR_EXTENSION_NAME needs to be enabled
 		// but from OpenXR 1.1 onwards this should always be available.
-		print_verbose("OpenXR: LOCAL_FLOOR space isn't supported, emulating using STAGE and LOCAL spaces.");
+		PRINT_VERBOSE("OpenXR: LOCAL_FLOOR space isn't supported, emulating using STAGE and LOCAL spaces.");
 
 		new_reference_space = XR_REFERENCE_SPACE_TYPE_LOCAL;
 		will_emulate_local_floor = true;
@@ -1078,7 +1078,7 @@ bool OpenXRAPI::setup_play_space() {
 		}
 	} else {
 		// Fallback on LOCAL, which all OpenXR runtimes are required to support.
-		print_verbose(String("OpenXR: ") + OpenXRUtil::get_reference_space_name(requested_reference_space) + String(" isn't supported, defaulting to LOCAL space."));
+		PRINT_VERBOSE(String("OpenXR: ") + OpenXRUtil::get_reference_space_name(requested_reference_space) + String(" isn't supported, defaulting to LOCAL space."));
 		new_reference_space = XR_REFERENCE_SPACE_TYPE_LOCAL;
 	}
 
@@ -1250,7 +1250,7 @@ bool OpenXRAPI::load_supported_swapchain_formats() {
 	ERR_FAIL_COND_V_MSG(XR_FAILED(result), false, "OpenXR: Failed to enumerate swapchain formats");
 
 	for (int64_t swapchain_format : supported_swapchain_formats) {
-		print_verbose(String("OpenXR: Found supported swapchain format ") + get_swapchain_format_name(swapchain_format));
+		PRINT_VERBOSE(String("OpenXR: Found supported swapchain format ") + get_swapchain_format_name(swapchain_format));
 	}
 
 	return true;
@@ -1280,7 +1280,7 @@ bool OpenXRAPI::obtain_swapchain_formats() {
 
 		ERR_FAIL_COND_V_MSG(color_swapchain_format == 0, false, "OpenXR: No usable color swap chain format available!");
 
-		print_verbose(String("Using color swap chain format:") + get_swapchain_format_name(color_swapchain_format));
+		PRINT_VERBOSE(String("Using color swap chain format:") + get_swapchain_format_name(color_swapchain_format));
 	}
 
 	if (submit_depth_buffer) {
@@ -1300,7 +1300,7 @@ bool OpenXRAPI::obtain_swapchain_formats() {
 		if (depth_swapchain_format == 0) {
 			WARN_PRINT("OpenXR: No usable depth swap chain format available!");
 		} else {
-			print_verbose(String("Using depth swap chain format:") + get_swapchain_format_name(depth_swapchain_format));
+			PRINT_VERBOSE(String("Using depth swap chain format:") + get_swapchain_format_name(depth_swapchain_format));
 		}
 	}
 
@@ -1430,7 +1430,7 @@ void OpenXRAPI::destroy_session() {
 }
 
 bool OpenXRAPI::on_state_idle() {
-	print_verbose("On state idle");
+	PRINT_VERBOSE("On state idle");
 
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_idle();
@@ -1440,7 +1440,7 @@ bool OpenXRAPI::on_state_idle() {
 }
 
 bool OpenXRAPI::on_state_ready() {
-	print_verbose("On state ready");
+	PRINT_VERBOSE("On state ready");
 
 	// begin session
 	XrSessionBeginInfo session_begin_info = {
@@ -1471,7 +1471,7 @@ bool OpenXRAPI::on_state_ready() {
 }
 
 bool OpenXRAPI::on_state_synchronized() {
-	print_verbose("On state synchronized");
+	PRINT_VERBOSE("On state synchronized");
 
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_synchronized();
@@ -1485,7 +1485,7 @@ bool OpenXRAPI::on_state_synchronized() {
 }
 
 bool OpenXRAPI::on_state_visible() {
-	print_verbose("On state visible");
+	PRINT_VERBOSE("On state visible");
 
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_visible();
@@ -1499,7 +1499,7 @@ bool OpenXRAPI::on_state_visible() {
 }
 
 bool OpenXRAPI::on_state_focused() {
-	print_verbose("On state focused");
+	PRINT_VERBOSE("On state focused");
 
 	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
 		wrapper->on_state_focused();
@@ -1513,7 +1513,7 @@ bool OpenXRAPI::on_state_focused() {
 }
 
 bool OpenXRAPI::on_state_stopping() {
-	print_verbose("On state stopping");
+	PRINT_VERBOSE("On state stopping");
 
 	if (xr_interface) {
 		xr_interface->on_state_stopping();
@@ -1538,7 +1538,7 @@ bool OpenXRAPI::on_state_stopping() {
 }
 
 bool OpenXRAPI::on_state_loss_pending() {
-	print_verbose("On state loss pending");
+	PRINT_VERBOSE("On state loss pending");
 
 	if (xr_interface) {
 		xr_interface->on_state_loss_pending();
@@ -1552,7 +1552,7 @@ bool OpenXRAPI::on_state_loss_pending() {
 }
 
 bool OpenXRAPI::on_state_exiting() {
-	print_verbose("On state existing");
+	PRINT_VERBOSE("On state existing");
 
 	if (xr_interface) {
 		xr_interface->on_state_exiting();
@@ -1948,9 +1948,9 @@ XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, 
 		if (head_pose_confidence == XRPose::XR_TRACKING_CONFIDENCE_NONE) {
 			print_line("OpenXR head space location not valid (check tracking?)");
 		} else if (head_pose_confidence == XRPose::XR_TRACKING_CONFIDENCE_LOW) {
-			print_verbose("OpenVR Head pose now tracking with low confidence");
+			PRINT_VERBOSE("OpenVR Head pose now tracking with low confidence");
 		} else {
-			print_verbose("OpenVR Head pose now tracking with high confidence");
+			PRINT_VERBOSE("OpenVR Head pose now tracking with high confidence");
 		}
 	}
 
@@ -2071,7 +2071,7 @@ bool OpenXRAPI::poll_events() {
 				// TODO We get this event if we're about to loose our OpenXR instance.
 				// We should queue exiting Godot at this point.
 
-				print_verbose(String("OpenXR EVENT: instance loss pending at ") + itos(event->lossTime));
+				PRINT_VERBOSE(String("OpenXR EVENT: instance loss pending at ") + itos(event->lossTime));
 				return false;
 			} break;
 			case XR_TYPE_EVENT_DATA_SESSION_STATE_CHANGED: {
@@ -2079,9 +2079,9 @@ bool OpenXRAPI::poll_events() {
 
 				session_state = event->state;
 				if (session_state >= XR_SESSION_STATE_MAX_ENUM) {
-					print_verbose(String("OpenXR EVENT: session state changed to UNKNOWN - ") + itos(session_state));
+					PRINT_VERBOSE(String("OpenXR EVENT: session state changed to UNKNOWN - ") + itos(session_state));
 				} else {
-					print_verbose(String("OpenXR EVENT: session state changed to ") + OpenXRUtil::get_session_state_name(session_state));
+					PRINT_VERBOSE(String("OpenXR EVENT: session state changed to ") + OpenXRUtil::get_session_state_name(session_state));
 
 					switch (session_state) {
 						case XR_SESSION_STATE_IDLE:
@@ -2116,7 +2116,7 @@ bool OpenXRAPI::poll_events() {
 			case XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING: {
 				XrEventDataReferenceSpaceChangePending *event = (XrEventDataReferenceSpaceChangePending *)&runtimeEvent;
 
-				print_verbose(String("OpenXR EVENT: reference space type ") + OpenXRUtil::get_reference_space_name(event->referenceSpaceType) + " change pending!");
+				PRINT_VERBOSE(String("OpenXR EVENT: reference space type ") + OpenXRUtil::get_reference_space_name(event->referenceSpaceType) + " change pending!");
 				if (local_floor_emulation.enabled) {
 					local_floor_emulation.should_reset_floor_height = true;
 				}
@@ -2126,7 +2126,7 @@ bool OpenXRAPI::poll_events() {
 				}
 			} break;
 			case XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED: {
-				print_verbose("OpenXR EVENT: interaction profile changed!");
+				PRINT_VERBOSE("OpenXR EVENT: interaction profile changed!");
 
 				XrEventDataInteractionProfileChanged *event = (XrEventDataInteractionProfileChanged *)&runtimeEvent;
 				if (event->session == session) {
@@ -2136,7 +2136,7 @@ bool OpenXRAPI::poll_events() {
 			} break;
 			default:
 				if (!handled) {
-					print_verbose(String("OpenXR Unhandled event type ") + OpenXRUtil::get_structure_type_name(runtimeEvent.type));
+					PRINT_VERBOSE(String("OpenXR Unhandled event type ") + OpenXRUtil::get_structure_type_name(runtimeEvent.type));
 				}
 				break;
 		}
@@ -2267,9 +2267,9 @@ void OpenXRAPI::_update_main_swapchain_size_rt() {
 
 #ifdef DEBUG_ENABLED
 	for (uint32_t i = 0; i < view_count_output; i++) {
-		print_verbose("OpenXR: Recommended resolution changed");
-		print_verbose(String(" - recommended render width: ") + itos(openxr_api->view_configuration_views[i].recommendedImageRectWidth));
-		print_verbose(String(" - recommended render height: ") + itos(openxr_api->view_configuration_views[i].recommendedImageRectHeight));
+		PRINT_VERBOSE("OpenXR: Recommended resolution changed");
+		PRINT_VERBOSE(String(" - recommended render width: ") + itos(openxr_api->view_configuration_views[i].recommendedImageRectWidth));
+		PRINT_VERBOSE(String(" - recommended render height: ") + itos(openxr_api->view_configuration_views[i].recommendedImageRectHeight));
 	}
 #endif
 }
@@ -2385,7 +2385,7 @@ bool OpenXRAPI::process() {
 
 	if (frame_state.predictedDisplayPeriod > 500000000) {
 		// display period more then 0.5 seconds? must be wrong data
-		print_verbose(String("OpenXR resetting invalid display period ") + rtos(frame_state.predictedDisplayPeriod));
+		PRINT_VERBOSE(String("OpenXR resetting invalid display period ") + rtos(frame_state.predictedDisplayPeriod));
 		frame_state.predictedDisplayPeriod = 0;
 	}
 
@@ -2481,9 +2481,9 @@ void OpenXRAPI::pre_render() {
 	if (render_state.view_pose_valid != pose_valid) {
 		render_state.view_pose_valid = pose_valid;
 		if (!render_state.view_pose_valid) {
-			print_verbose("OpenXR View pose became invalid");
+			PRINT_VERBOSE("OpenXR View pose became invalid");
 		} else {
-			print_verbose("OpenXR View pose became valid");
+			PRINT_VERBOSE("OpenXR View pose became valid");
 		}
 	}
 
@@ -3361,17 +3361,17 @@ bool OpenXRAPI::attach_action_sets(const Vector<RID> &p_action_sets) {
 	}
 
 	/* For debugging:
-	print_verbose("Attached set " + action_set->name);
+	PRINT_VERBOSE("Attached set " + action_set->name);
 	List<RID> action_rids;
 	action_owner.get_owned_list(&action_rids);
 	for (int i = 0; i < action_rids.size(); i++) {
 		Action * action = action_owner.get_or_null(action_rids[i]);
 		if (action && action->action_set_rid == p_action_set) {
-			print_verbose(" - Action " + action->name + ": " + OpenXRUtil::get_action_type_name(action->action_type));
+			PRINT_VERBOSE(" - Action " + action->name + ": " + OpenXRUtil::get_action_type_name(action->action_type));
 			for (int j = 0; j < action->trackers.size(); j++) {
 				Tracker * tracker = tracker_owner.get_or_null(action->trackers[j].tracker_rid);
 				if (tracker) {
-					print_verbose("    - " + tracker->name);
+					PRINT_VERBOSE("    - " + tracker->name);
 				}
 			}
 		}
@@ -3743,14 +3743,14 @@ bool OpenXRAPI::interaction_profile_suggest_bindings(RID p_interaction_profile) 
 	XrResult result = xrSuggestInteractionProfileBindings(instance, &suggested_bindings);
 	if (result == XR_ERROR_PATH_UNSUPPORTED) {
 		// this is fine, not all runtimes support all devices.
-		print_verbose("OpenXR Interaction profile " + ip->name + " is not supported on this runtime");
+		PRINT_VERBOSE("OpenXR Interaction profile " + ip->name + " is not supported on this runtime");
 	} else if (XR_FAILED(result)) {
 		print_line("OpenXR: failed to suggest bindings for ", ip->name, "! [", get_error_string(result), "]");
 		// reporting is enough...
 	}
 
 	/* For debugging:
-	print_verbose("Suggested bindings for " + ip->name);
+	PRINT_VERBOSE("Suggested bindings for " + ip->name);
 	for (int i = 0; i < ip->bindings.size(); i++) {
 		uint32_t strlen;
 		char path[XR_MAX_PATH_LENGTH];
@@ -3761,7 +3761,7 @@ bool OpenXRAPI::interaction_profile_suggest_bindings(RID p_interaction_profile) 
 		if (XR_FAILED(result)) {
 			print_line("OpenXR: failed to retrieve bindings for ", action_name, "! [", get_error_string(result), "]");
 		}
-		print_verbose(" - " + action_name + " => " + String(path));
+		PRINT_VERBOSE(" - " + action_name + " => " + String(path));
 	}
 	*/
 
@@ -3935,7 +3935,7 @@ XRPose::TrackingConfidence OpenXRAPI::get_action_pose(RID p_action, RID p_tracke
 
 	ERR_FAIL_COND_V(action->action_type != XR_ACTION_TYPE_POSE_INPUT, XRPose::XR_TRACKING_CONFIDENCE_NONE);
 
-	// print_verbose("Checking " + action->name + " => " + tracker->name + " (" + itos(tracker->toplevel_path) + ")");
+	// PRINT_VERBOSE("Checking " + action->name + " => " + tracker->name + " (" + itos(tracker->toplevel_path) + ")");
 
 	uint64_t index = 0xFFFFFFFF;
 	uint64_t size = uint64_t(action->trackers.size());

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -559,11 +559,11 @@ void OpenXRInterface::tracker_profile_changed(RID p_tracker, RID p_interaction_p
 	tracker->interaction_profile = p_interaction_profile;
 
 	if (p_interaction_profile.is_null()) {
-		print_verbose("OpenXR: Interaction profile for " + tracker->tracker_name + " changed to " + INTERACTION_PROFILE_NONE);
+		PRINT_VERBOSE("OpenXR: Interaction profile for " + tracker->tracker_name + " changed to " + INTERACTION_PROFILE_NONE);
 		tracker->controller_tracker->set_tracker_profile(INTERACTION_PROFILE_NONE);
 	} else {
 		String name = openxr_api->interaction_profile_get_name(p_interaction_profile);
-		print_verbose("OpenXR: Interaction profile for " + tracker->tracker_name + " changed to " + name);
+		PRINT_VERBOSE("OpenXR: Interaction profile for " + tracker->tracker_name + " changed to " + name);
 		tracker->controller_tracker->set_tracker_profile(name);
 	}
 }
@@ -1463,7 +1463,7 @@ void OpenXRInterface::on_reference_space_change_pending(XrReferenceSpaceType p_t
 			break;
 	}
 
-	print_verbose("OpenXR Interface: Play area changed, emitting signal.");
+	PRINT_VERBOSE("OpenXR Interface: Play area changed, emitting signal.");
 	emit_signal(SNAME("play_area_changed"), mode);
 }
 

--- a/modules/texture_streaming/texture_streaming.cpp
+++ b/modules/texture_streaming/texture_streaming.cpp
@@ -139,7 +139,7 @@ RID TextureStreaming::texture_configure_streaming(RID p_texture, Image::Format p
 }
 
 void TextureStreaming::_texture_configure_streaming_impl(Completion<RID> *p_completion, RID p_texture, Image::Format p_format, int p_width, int p_height, int p_min_lod, int p_max_lod, const Callable &p_reload_callable) {
-	print_verbose(vformat("TextureStreaming: Configuring streaming for texture RID(%d) size(%dx%d) format(%d) min_lod(%d) max_lod(%d)",
+	PRINT_VERBOSE(vformat("TextureStreaming: Configuring streaming for texture RID(%d) size(%dx%d) format(%d) min_lod(%d) max_lod(%d)",
 			p_texture.get_id(), p_width, p_height, int(p_format), p_min_lod, p_max_lod));
 
 	RID rid = streaming_info_owner.allocate_rid();
@@ -249,7 +249,7 @@ TextureStreaming::TextureStreaming() {
 
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextureStreaming::_on_settings_changed));
 
-	print_verbose(vformat("TextureStreaming settings: enabled=%d, budget_mb=%d, min_lod=%d, max_lod=%d",
+	PRINT_VERBOSE(vformat("TextureStreaming settings: enabled=%d, budget_mb=%d, min_lod=%d, max_lod=%d",
 			(int)setting_streaming_is_enabled,
 			(int)setting_budget_mb,
 			setting_min_lod,
@@ -340,7 +340,7 @@ void TextureStreaming::_stop_streaming() {
 		buffer_pool.clear();
 	}
 
-	print_verbose("TextureStreaming: Streaming stopped.");
+	PRINT_VERBOSE("TextureStreaming: Streaming stopped.");
 }
 
 void TextureStreaming::_render_thread_specific_initialization() {
@@ -395,7 +395,7 @@ void TextureStreaming::_feedback_frame_done_callback_render_thread() {
 	// Try to get a new buffer for the next frame
 	RID next_buffer = _feedback_buffer_get_next();
 	if (next_buffer.is_null()) {
-		print_verbose("TextureStreaming _feedback_frame_done_callback called but no feedback buffers are available.");
+		PRINT_VERBOSE("TextureStreaming _feedback_frame_done_callback called but no feedback buffers are available.");
 		feedback_buffer_last_submit_ticks = current_ticks; //
 		return;
 	}
@@ -564,7 +564,7 @@ void TextureStreaming::_feedback_buffer_thread_func(void *p_udata) {
 
 	TextureStreaming *texture_streaming = static_cast<TextureStreaming *>(p_udata);
 
-	print_verbose("Texture Streaming process thread starting...");
+	PRINT_VERBOSE("Texture Streaming process thread starting...");
 
 	texture_streaming->_feedback_buffer_thread_main();
 }
@@ -768,7 +768,7 @@ void TextureStreaming::_texture_reload_thread_func(void *p_udata) {
 
 	TextureStreaming *tss = static_cast<TextureStreaming *>(p_udata);
 
-	print_verbose("Texture Streaming i/o thread starting...");
+	PRINT_VERBOSE("Texture Streaming i/o thread starting...");
 
 	tss->_texture_reload_thread_main();
 }
@@ -857,7 +857,7 @@ void TextureStreaming::_texture_remove_finalize(RID p_state_rid) {
 }
 
 void TextureStreaming::flush_texture_streaming() {
-	print_verbose("Texture Streaming flush requested.");
+	PRINT_VERBOSE("Texture Streaming flush requested.");
 	if (!feedback_buffer_thread.is_started()) {
 		// Not running — nothing to flush, signal immediately.
 		callable_mp(this, &TextureStreaming::_emit_flush_completed).call_deferred();
@@ -884,6 +884,6 @@ void TextureStreaming::_flush_fence() {
 }
 
 void TextureStreaming::_emit_flush_completed() {
-	print_verbose("Texture Streaming flush completed.");
+	PRINT_VERBOSE("Texture Streaming flush completed.");
 	emit_signal(SNAME("flush_completed"));
 }

--- a/modules/visionos_xr/visionos_xr_interface.mm
+++ b/modules/visionos_xr/visionos_xr_interface.mm
@@ -192,7 +192,7 @@ bool VisionOSXRInterface::initialize() {
 
 	initialized = true;
 
-	print_verbose(String("VisionOSXRInterface initialized with:") + " compositorservices=" + (cs.enabled ? "yes" : "no") + " hands=" + (hands.enabled ? "yes" : "no") + " controllers=" + (controllers.enabled ? "yes" : "no"));
+	PRINT_VERBOSE(String("VisionOSXRInterface initialized with:") + " compositorservices=" + (cs.enabled ? "yes" : "no") + " hands=" + (hands.enabled ? "yes" : "no") + " controllers=" + (controllers.enabled ? "yes" : "no"));
 
 	return initialized;
 }

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -650,7 +650,7 @@ Ref<AudioStreamOggVorbis> AudioStreamOggVorbis::load_from_buffer(const Vector<ui
 				break;
 			}
 			if (packet_count == 0 && vorbis_synthesis_idheader(&packet) == 0) {
-				print_verbose("Found a non-vorbis-header packet in a header position");
+				PRINT_VERBOSE("Found a non-vorbis-header packet in a header position");
 				// Clearly this logical stream is not a vorbis stream, so destroy it and try again with the next page.
 				if (initialized_stream) {
 					ogg_stream_clear(&stream_state);

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -269,7 +269,7 @@ void WebSocketMultiplayerPeer::_poll_client() {
 		// Still connecting
 		ERR_FAIL_COND(!pending_peers.has(1)); // Bug.
 		if (OS::get_singleton()->get_ticks_msec() - pending_peers[1].time > handshake_timeout) {
-			print_verbose(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
+			PRINT_VERBOSE(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
 			_clear();
 			return;
 		}
@@ -296,7 +296,7 @@ void WebSocketMultiplayerPeer::_poll_server() {
 		int id = E.key;
 
 		if (OS::get_singleton()->get_ticks_msec() - peer.time > handshake_timeout) {
-			print_verbose(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
+			PRINT_VERBOSE(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
 			to_remove.insert(id);
 			continue;
 		}

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -266,7 +266,7 @@ void WebSocketMultiplayerPeer::_poll_client() {
 		// Still connecting
 		ERR_FAIL_COND(!pending_peers.has(1)); // Bug.
 		if (OS::get_singleton()->get_ticks_msec() - pending_peers[1].time > handshake_timeout) {
-			print_verbose(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
+			PRINT_VERBOSE(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
 			_clear();
 			return;
 		}
@@ -293,7 +293,7 @@ void WebSocketMultiplayerPeer::_poll_server() {
 		int id = E.key;
 
 		if (OS::get_singleton()->get_ticks_msec() - peer.time > handshake_timeout) {
-			print_verbose(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
+			PRINT_VERBOSE(vformat("WebSocket handshake timed out after %.3f seconds.", handshake_timeout * 0.001));
 			to_remove.insert(id);
 			continue;
 		}

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -220,7 +220,7 @@ Error WSLPeer::_do_server_handshake() {
 		if (tls->get_status() == StreamPeerTLS::STATUS_HANDSHAKING) {
 			return OK; // Pending handshake
 		} else if (tls->get_status() != StreamPeerTLS::STATUS_CONNECTED) {
-			print_verbose(vformat("WebSocket SSL connection error during handshake (StreamPeerTLS status code %d).", tls->get_status()));
+			PRINT_VERBOSE(vformat("WebSocket SSL connection error during handshake (StreamPeerTLS status code %d).", tls->get_status()));
 			close(-1);
 			return FAILED;
 		}
@@ -234,7 +234,7 @@ Error WSLPeer::_do_server_handshake() {
 			uint8_t byte;
 			Error err = connection->get_partial_data(&byte, 1, read);
 			if (err != OK) { // Got an error
-				print_verbose(vformat("WebSocket error while getting partial data (StreamPeer error code %d).", err));
+				PRINT_VERBOSE(vformat("WebSocket error while getting partial data (StreamPeer error code %d).", err));
 				close(-1);
 				return FAILED;
 			} else if (read != 1) { // Busy, wait next poll
@@ -280,7 +280,7 @@ Error WSLPeer::_do_server_handshake() {
 		int sent = 0;
 		Error err = connection->put_partial_data(data.ptr() + pos, left, sent);
 		if (err != OK) {
-			print_verbose(vformat("WebSocket error while putting partial data (StreamPeer error code %d).", err));
+			PRINT_VERBOSE(vformat("WebSocket error while putting partial data (StreamPeer error code %d).", err));
 			close(-1);
 			return err;
 		}
@@ -575,7 +575,7 @@ ssize_t WSLPeer::_wsl_recv_callback(wslay_event_context_ptr ctx, uint8_t *data, 
 	int read = 0;
 	Error err = conn->get_partial_data(data, to_read, read);
 	if (err != OK) {
-		print_verbose("Websocket get data error: " + itos(err) + ", read (should be 0!): " + itos(read));
+		PRINT_VERBOSE("Websocket get data error: " + itos(err) + ", read (should be 0!): " + itos(read));
 		wslay_event_set_error(ctx, WSLAY_ERR_CALLBACK_FAILURE);
 		return -1;
 	}
@@ -722,7 +722,7 @@ void WSLPeer::poll() {
 			if (err == 0) {
 				last_heartbeat = ticks;
 			} else {
-				print_verbose("Websocket (wslay) failed to send ping: " + itos(err));
+				PRINT_VERBOSE("Websocket (wslay) failed to send ping: " + itos(err));
 				wslay_event_context_free(wsl_ctx);
 				wsl_ctx = nullptr;
 				close(-1);
@@ -731,7 +731,7 @@ void WSLPeer::poll() {
 		}
 		if ((err = wslay_event_recv(wsl_ctx)) != 0 || (err = wslay_event_send(wsl_ctx)) != 0) {
 			// Error close.
-			print_verbose("Websocket (wslay) poll error: " + itos(err));
+			PRINT_VERBOSE("Websocket (wslay) poll error: " + itos(err));
 			wslay_event_context_free(wsl_ctx);
 			wsl_ctx = nullptr;
 			close(-1);

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -848,7 +848,7 @@ Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &
 	} else {
 		dst_path = String("assets/") + simplified_path.trim_prefix("res://");
 	}
-	print_verbose("Saving project files from " + simplified_path + " into " + dst_path);
+	PRINT_VERBOSE("Saving project files from " + simplified_path + " into " + dst_path);
 	store_in_apk(ed, dst_path, enc_data, _should_compress_asset(simplified_path, enc_data) ? Z_DEFLATED : 0);
 
 	ed->pd.file_ofs.push_back(sd);
@@ -881,7 +881,7 @@ Error EditorExportPlatformAndroid::copy_gradle_so(const Ref<EditorExportPreset> 
 			String filename = p_so.path.get_file();
 			String dst_path = export_data->libs_directory.path_join(type).path_join(abi).path_join(filename);
 			Vector<uint8_t> data = FileAccess::get_file_as_bytes(p_so.path);
-			print_verbose("Copying .so file from " + p_so.path + " to " + dst_path);
+			PRINT_VERBOSE("Copying .so file from " + p_so.path + " to " + dst_path);
 			Error err = store_file_at_path(dst_path, data);
 			ERR_FAIL_COND_V_MSG(err, err, "Failed to copy .so file from " + p_so.path + " to " + dst_path);
 			export_data->libs.push_back(dst_path);
@@ -970,7 +970,7 @@ void EditorExportPlatformAndroid::_create_editor_debug_keystore_if_needed() {
 		args.push_back("-dname");
 		args.push_back("cn=Godot, ou=Godot Engine, o=Stichting Godot, c=NL");
 		Error error = OS::get_singleton()->execute(keytool_path, args, &output, nullptr, true);
-		print_verbose(output);
+		PRINT_VERBOSE(output);
 		if (error != OK) {
 			WARN_PRINT("Error: Unable to create debug keystore");
 			return;
@@ -981,7 +981,7 @@ void EditorExportPlatformAndroid::_create_editor_debug_keystore_if_needed() {
 	EditorSettings::get_singleton()->set("export/android/debug_keystore", keystore_path);
 	EditorSettings::get_singleton()->set("export/android/debug_keystore_user", DEFAULT_ANDROID_KEYSTORE_DEBUG_USER);
 	EditorSettings::get_singleton()->set("export/android/debug_keystore_pass", DEFAULT_ANDROID_KEYSTORE_DEBUG_PASSWORD);
-	print_verbose("Updated editor debug keystore to " + keystore_path);
+	PRINT_VERBOSE("Updated editor debug keystore to " + keystore_path);
 }
 
 void EditorExportPlatformAndroid::_get_manifest_info(const Ref<EditorExportPreset> &p_preset, bool p_give_internet, Vector<String> &r_permissions, Vector<FeatureInfo> &r_features, Vector<MetadataInfo> &r_metadata) {
@@ -1039,7 +1039,7 @@ void EditorExportPlatformAndroid::_get_manifest_info(const Ref<EditorExportPrese
 }
 
 void EditorExportPlatformAndroid::_write_tmp_manifest(const Ref<EditorExportPreset> &p_preset, bool p_give_internet, bool p_debug) {
-	print_verbose("Building temporary manifest...");
+	PRINT_VERBOSE("Building temporary manifest...");
 	String manifest_text =
 			"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 			"<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
@@ -1083,7 +1083,7 @@ void EditorExportPlatformAndroid::_write_tmp_manifest(const Ref<EditorExportPres
 	manifest_text += "</manifest>\n";
 	String manifest_path = ExportTemplateManager::get_android_build_directory(p_preset).path_join(vformat("src/%s/AndroidManifest.xml", (p_debug ? "debug" : "release")));
 
-	print_verbose("Storing manifest into " + manifest_path + ": " + "\n" + manifest_text);
+	PRINT_VERBOSE("Storing manifest into " + manifest_path + ": " + "\n" + manifest_text);
 	store_string_at_path(manifest_path, manifest_text);
 }
 
@@ -1215,7 +1215,7 @@ void EditorExportPlatformAndroid::_fix_themes_xml(const Ref<EditorExportPreset> 
 	// Reconstruct the XML content from the modified lines.
 	String xml_content = String("\n").join(new_lines);
 	store_string_at_path(themes_xml_path, xml_content);
-	print_verbose("Successfully modified " + themes_xml_path + ": " + "\n" + xml_content);
+	PRINT_VERBOSE("Successfully modified " + themes_xml_path + ": " + "\n" + xml_content);
 }
 
 void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &p_manifest, bool p_give_internet) {
@@ -1929,12 +1929,12 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 
 	// Regular icon: user selection -> project icon -> default.
 	String path = static_cast<String>(p_preset->get(LAUNCHER_ICON_OPTION)).strip_edges();
-	print_verbose("Loading regular icon from " + path);
+	PRINT_VERBOSE("Loading regular icon from " + path);
 	if (!path.is_empty()) {
 		icon = _load_icon_or_splash_image(path, &err);
 	}
 	if (path.is_empty() || err != OK || icon.is_null() || icon->is_empty()) {
-		print_verbose("- falling back to project icon: " + project_icon_path);
+		PRINT_VERBOSE("- falling back to project icon: " + project_icon_path);
 		if (!project_icon_path.is_empty()) {
 			icon = _load_icon_or_splash_image(project_icon_path, &err);
 		} else {
@@ -1944,26 +1944,26 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 
 	// Adaptive foreground: user selection -> regular icon (user selection -> project icon -> default).
 	path = static_cast<String>(p_preset->get(LAUNCHER_ADAPTIVE_ICON_FOREGROUND_OPTION)).strip_edges();
-	print_verbose("Loading adaptive foreground icon from " + path);
+	PRINT_VERBOSE("Loading adaptive foreground icon from " + path);
 	if (!path.is_empty()) {
 		foreground = _load_icon_or_splash_image(path, &err);
 	}
 	if (path.is_empty() || err != OK || foreground.is_null() || foreground->is_empty()) {
-		print_verbose("- falling back to using the regular icon");
+		PRINT_VERBOSE("- falling back to using the regular icon");
 		foreground = icon;
 	}
 
 	// Adaptive background: user selection -> default.
 	path = static_cast<String>(p_preset->get(LAUNCHER_ADAPTIVE_ICON_BACKGROUND_OPTION)).strip_edges();
 	if (!path.is_empty()) {
-		print_verbose("Loading adaptive background icon from " + path);
+		PRINT_VERBOSE("Loading adaptive background icon from " + path);
 		background = _load_icon_or_splash_image(path, &err);
 	}
 
 	// Adaptive monochrome: user selection -> default.
 	path = static_cast<String>(p_preset->get(LAUNCHER_ADAPTIVE_ICON_MONOCHROME_OPTION)).strip_edges();
 	if (!path.is_empty()) {
-		print_verbose("Loading adaptive monochrome icon from " + path);
+		PRINT_VERBOSE("Loading adaptive monochrome icon from " + path);
 		monochrome = _load_icon_or_splash_image(path, &err);
 	}
 
@@ -1971,14 +1971,14 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	path = static_cast<String>(p_preset->get(ANDROID_SPLASH_ICON_OPTION)).strip_edges();
 	if (path.get_extension() != "xml") {
 		// XML file is handled in _fix_themes_xml().
-		print_verbose("Loading splash screen icon from " + path);
+		PRINT_VERBOSE("Loading splash screen icon from " + path);
 		bool loaded_ok = false;
 		if (!path.is_empty()) {
 			splash_icon = _load_icon_or_splash_image(path, &err);
 			loaded_ok = (err == OK && splash_icon.is_valid() && !splash_icon->is_empty());
 		}
 		if (!loaded_ok) {
-			print_verbose("- falling back to using the adaptive foreground icon");
+			PRINT_VERBOSE("- falling back to using the adaptive foreground icon");
 			splash_icon = foreground;
 		}
 	}
@@ -1988,7 +1988,7 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	// - Legacy build: If the path is empty, a transparent image is used.
 	path = static_cast<String>(p_preset->get(ANDROID_SPLASH_BRANDING_IMAGE_OPTION)).strip_edges();
 	if (!path.is_empty()) {
-		print_verbose("Loading splash screen branding image from " + path);
+		PRINT_VERBOSE("Loading splash screen branding image from " + path);
 		splash_branding_image = _load_icon_or_splash_image(path, &err);
 	}
 }
@@ -2005,13 +2005,13 @@ void EditorExportPlatformAndroid::_copy_icons_to_gradle_project(const Ref<Editor
 	// Copy splash screen icon to the drawable directory.
 	// This is only for png/webp/svg file; XML file is handled in _fix_themes_xml().
 	if (p_splash_icon.is_valid() && !p_splash_icon->is_empty()) {
-		print_verbose("Copying splash screen icon into " + ANDROID_SPLASH_ICON_PATH);
+		PRINT_VERBOSE("Copying splash screen icon into " + ANDROID_SPLASH_ICON_PATH);
 		Vector<uint8_t> buffer = p_splash_icon->save_webp_to_buffer();
 		store_file_at_path(gradle_build_dir.path_join(ANDROID_SPLASH_ICON_PATH), buffer);
 	}
 
 	if (p_splash_branding_image.is_valid() && !p_splash_branding_image->is_empty()) {
-		print_verbose("Copying splash screen branding image into " + ANDROID_SPLASH_BRANDING_IMAGE_PATH);
+		PRINT_VERBOSE("Copying splash screen branding image into " + ANDROID_SPLASH_BRANDING_IMAGE_PATH);
 		Vector<uint8_t> buffer = p_splash_branding_image->save_webp_to_buffer();
 		store_file_at_path(gradle_build_dir.path_join(ANDROID_SPLASH_BRANDING_IMAGE_PATH), buffer);
 	}
@@ -2023,14 +2023,14 @@ void EditorExportPlatformAndroid::_copy_icons_to_gradle_project(const Ref<Editor
 
 	for (int i = 0; i < ICON_DENSITIES_COUNT; ++i) {
 		if (p_main_image.is_valid() && !p_main_image->is_empty()) {
-			print_verbose("Processing launcher icon for dimension " + itos(LAUNCHER_ICONS[i].dimensions) + " into " + LAUNCHER_ICONS[i].export_path);
+			PRINT_VERBOSE("Processing launcher icon for dimension " + itos(LAUNCHER_ICONS[i].dimensions) + " into " + LAUNCHER_ICONS[i].export_path);
 			Vector<uint8_t> data;
 			_process_launcher_icons(LAUNCHER_ICONS[i].export_path, p_main_image, LAUNCHER_ICONS[i].dimensions, data);
 			store_file_at_path(gradle_build_dir.path_join(LAUNCHER_ICONS[i].export_path), data);
 		}
 
 		if (p_foreground.is_valid() && !p_foreground->is_empty()) {
-			print_verbose("Processing launcher adaptive icon p_foreground for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].export_path);
+			PRINT_VERBOSE("Processing launcher adaptive icon p_foreground for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].export_path);
 			Vector<uint8_t> data;
 			_process_launcher_icons(LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].export_path, p_foreground,
 					LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].dimensions, data);
@@ -2038,7 +2038,7 @@ void EditorExportPlatformAndroid::_copy_icons_to_gradle_project(const Ref<Editor
 		}
 
 		if (p_background.is_valid() && !p_background->is_empty()) {
-			print_verbose("Processing launcher adaptive icon p_background for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].export_path);
+			PRINT_VERBOSE("Processing launcher adaptive icon p_background for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].export_path);
 			Vector<uint8_t> data;
 			_process_launcher_icons(LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].export_path, p_background,
 					LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].dimensions, data);
@@ -2046,7 +2046,7 @@ void EditorExportPlatformAndroid::_copy_icons_to_gradle_project(const Ref<Editor
 		}
 
 		if (p_monochrome.is_valid() && !p_monochrome->is_empty()) {
-			print_verbose("Processing launcher adaptive icon p_monochrome for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].export_path);
+			PRINT_VERBOSE("Processing launcher adaptive icon p_monochrome for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].export_path);
 			Vector<uint8_t> data;
 			_process_launcher_icons(LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].export_path, p_monochrome,
 					LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].dimensions, data);
@@ -2207,7 +2207,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 #ifndef DISABLE_DEPRECATED
 	Vector<PluginConfigAndroid> plugins_configs = get_plugins();
 	for (int i = 0; i < plugins_configs.size(); i++) {
-		print_verbose("Found Android plugin " + plugins_configs[i].name);
+		PRINT_VERBOSE("Found Android plugin " + plugins_configs[i].name);
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("%s/%s", PNAME("plugins"), plugins_configs[i].name)), false));
 	}
 	android_plugins_changed.clear();
@@ -2492,7 +2492,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 		output.clear();
 		err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-		print_verbose(output);
+		PRINT_VERBOSE(output);
 	}
 
 	print_line("Installing to device (please wait...): " + devices[p_device - 1].name);
@@ -2513,7 +2513,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 	output.clear();
 	err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-	print_verbose(output);
+	PRINT_VERBOSE(output);
 	if (err || rv != 0) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Run"), vformat(TTR("Could not install to device: %s"), output));
 		CLEANUP_AND_RETURN(ERR_CANT_CREATE);
@@ -2532,7 +2532,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 			args.push_back("--remove-all");
 			output.clear();
 			OS::get_singleton()->execute(adb, args, &output, &rv, true);
-			print_verbose(output);
+			PRINT_VERBOSE(output);
 
 			if (p_debug_flags.has_flag(DEBUG_FLAG_REMOTE_DEBUG)) {
 				int dbg_port = EDITOR_GET("network/debug/remote_port");
@@ -2545,7 +2545,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 				output.clear();
 				OS::get_singleton()->execute(adb, args, &output, &rv, true);
-				print_verbose(output);
+				PRINT_VERBOSE(output);
 				print_line("Reverse result: " + itos(rv));
 			}
 
@@ -2561,7 +2561,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 				output.clear();
 				err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-				print_verbose(output);
+				PRINT_VERBOSE(output);
 				print_line("Reverse result2: " + itos(rv));
 			}
 		} else {
@@ -2626,8 +2626,8 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 				break;
 			}
 		}
-		print_verbose(output);
-		print_verbose(err_output);
+		PRINT_VERBOSE(output);
+		PRINT_VERBOSE(err_output);
 		if (!connected) {
 			OS::get_singleton()->kill(data["pid"].operator int());
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Run"), TTR("Could not execute on device, scrcpy failed with the following error:\n" + err_output));
@@ -2653,7 +2653,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 		output.clear();
 		err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-		print_verbose(output);
+		PRINT_VERBOSE(output);
 		if (err || rv != 0 || output.contains("Error: Activity not started")) {
 			// The implicit launch failed, let's try an explicit launch by specifying the component name before giving up.
 			const String component_name = get_package_name(p_preset, package_name) + "/com.godot.game.GodotAppLauncher";
@@ -2664,7 +2664,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 			output.clear();
 			err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-			print_verbose(output);
+			PRINT_VERBOSE(output);
 
 			if (err || rv != 0 || output.begins_with("Error: Activity not started")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Run"), TTR("Could not execute on device."));
@@ -3368,7 +3368,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 	}
 
 	String apksigner = get_apksigner_path(target_sdk_version.to_int(), true);
-	print_verbose("Starting signing of the APK binary using " + apksigner);
+	PRINT_VERBOSE("Starting signing of the APK binary using " + apksigner);
 	if (apksigner == "<FAILED>") {
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), TTR("All 'apksigner' tools located in Android SDK 'build-tools' directory failed to execute. Please check that you have the correct version installed for your target sdk version. The resulting APK is unsigned."));
 		return OK;
@@ -3391,7 +3391,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 	args.push_back(apk_path);
 	if (OS::get_singleton()->is_stdout_verbose() && p_debug) {
 		// We only print verbose logs with credentials for debug builds to avoid leaking release keystore credentials.
-		print_verbose("Signing debug binary using: " + String("\n") + apksigner + " " + join_list(args, String(" ")));
+		PRINT_VERBOSE("Signing debug binary using: " + String("\n") + apksigner + " " + join_list(args, String(" ")));
 	} else {
 		List<String> redacted_args = List<String>(args);
 		redacted_args.find(keystore)->set("<REDACTED>");
@@ -3430,7 +3430,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 	args.push_back("--verbose");
 	args.push_back(apk_path);
 	if (p_debug) {
-		print_verbose("Verifying signed build using: " + String("\n") + apksigner + " " + join_list(args, String(" ")));
+		PRINT_VERBOSE("Verifying signed build using: " + String("\n") + apksigner + " " + join_list(args, String(" ")));
 	}
 
 	output.clear();
@@ -3439,7 +3439,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), TTR("Could not start apksigner executable."));
 		return err;
 	}
-	print_verbose(output);
+	PRINT_VERBOSE(output);
 	if (retval) {
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), TTR("'apksigner' verification of APK failed."));
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), vformat(TTR("output: \n%s"), output));
@@ -3447,7 +3447,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 	}
 #endif
 
-	print_verbose("Successfully completed signing build.");
+	PRINT_VERBOSE("Successfully completed signing build.");
 
 #ifdef ANDROID_ENABLED
 	bool prompt_apk_install = EDITOR_GET("export/android/install_exported_apk");
@@ -3466,7 +3466,7 @@ void EditorExportPlatformAndroid::_clear_assets_directory(const Ref<EditorExport
 	// Clear the APK assets directory
 	String apk_assets_directory = gradle_build_directory.path_join(APK_ASSETS_DIRECTORY);
 	if (da_res->dir_exists(apk_assets_directory)) {
-		print_verbose("Clearing APK assets directory...");
+		PRINT_VERBOSE("Clearing APK assets directory...");
 		Ref<DirAccess> da_assets = DirAccess::open(apk_assets_directory);
 		ERR_FAIL_COND(da_assets.is_null());
 
@@ -3477,7 +3477,7 @@ void EditorExportPlatformAndroid::_clear_assets_directory(const Ref<EditorExport
 	// Clear the AAB assets directory
 	String aab_assets_directory = gradle_build_directory.path_join(AAB_ASSETS_DIRECTORY);
 	if (da_res->dir_exists(aab_assets_directory)) {
-		print_verbose("Clearing AAB assets directory...");
+		PRINT_VERBOSE("Clearing AAB assets directory...");
 		Ref<DirAccess> da_assets = DirAccess::open(aab_assets_directory);
 		ERR_FAIL_COND(da_assets.is_null());
 
@@ -3487,11 +3487,11 @@ void EditorExportPlatformAndroid::_clear_assets_directory(const Ref<EditorExport
 }
 
 void EditorExportPlatformAndroid::_remove_copied_libs(String p_gdextension_libs_path) {
-	print_verbose("Removing previously installed libraries...");
+	PRINT_VERBOSE("Removing previously installed libraries...");
 	Error error;
 	String libs_json = FileAccess::get_file_as_string(p_gdextension_libs_path, &error);
 	if (error || libs_json.is_empty()) {
-		print_verbose("No previously installed libraries found");
+		PRINT_VERBOSE("No previously installed libraries found");
 		return;
 	}
 
@@ -3502,7 +3502,7 @@ void EditorExportPlatformAndroid::_remove_copied_libs(String p_gdextension_libs_
 	Vector<String> libs = json.get_data();
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	for (int i = 0; i < libs.size(); i++) {
-		print_verbose("Removing previously installed library " + libs[i]);
+		PRINT_VERBOSE("Removing previously installed library " + libs[i]);
 		da->remove(libs[i]);
 	}
 	da->remove(p_gdextension_libs_path);
@@ -3713,16 +3713,16 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	bool p_give_internet = p_flags.has_flag(DEBUG_FLAG_DUMB_CLIENT) || p_flags.has_flag(DEBUG_FLAG_REMOTE_DEBUG);
 	Vector<ABI> enabled_abis = get_enabled_abis(p_preset);
 
-	print_verbose("Exporting for Android...");
-	print_verbose("- debug build: " + bool_to_string(p_debug));
-	print_verbose("- export path: " + p_path);
-	print_verbose("- export format: " + itos(export_format));
-	print_verbose("- sign build: " + bool_to_string(should_sign));
-	print_verbose("- gradle build enabled: " + bool_to_string(use_gradle_build));
-	print_verbose("- enabled abis: " + join_abis(enabled_abis, ",", false));
-	print_verbose("- export filter: " + itos(p_preset->get_export_filter()));
-	print_verbose("- include filter: " + p_preset->get_include_filter());
-	print_verbose("- exclude filter: " + p_preset->get_exclude_filter());
+	PRINT_VERBOSE("Exporting for Android...");
+	PRINT_VERBOSE("- debug build: " + bool_to_string(p_debug));
+	PRINT_VERBOSE("- export path: " + p_path);
+	PRINT_VERBOSE("- export format: " + itos(export_format));
+	PRINT_VERBOSE("- sign build: " + bool_to_string(should_sign));
+	PRINT_VERBOSE("- gradle build enabled: " + bool_to_string(use_gradle_build));
+	PRINT_VERBOSE("- enabled abis: " + join_abis(enabled_abis, ",", false));
+	PRINT_VERBOSE("- export filter: " + itos(p_preset->get_export_filter()));
+	PRINT_VERBOSE("- include filter: " + p_preset->get_include_filter());
+	PRINT_VERBOSE("- exclude filter: " + p_preset->get_exclude_filter());
 
 	Ref<Image> main_image;
 	Ref<Image> foreground;
@@ -3758,10 +3758,10 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	}
 
 	if (use_gradle_build) {
-		print_verbose("Starting gradle build...");
+		PRINT_VERBOSE("Starting gradle build...");
 		//test that installed build version is alright
 		{
-			print_verbose("Checking build version...");
+			PRINT_VERBOSE("Checking build version...");
 			String gradle_base_directory = gradle_build_directory.get_base_dir();
 			Ref<FileAccess> f = FileAccess::open(gradle_base_directory.path_join(".build_version"), FileAccess::READ);
 			if (f.is_null()) {
@@ -3770,7 +3770,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			}
 			String current_version = ExportTemplateManager::get_android_template_identifier(p_preset);
 			String installed_version = f->get_line().strip_edges();
-			print_verbose("- build version: " + installed_version);
+			PRINT_VERBOSE("- build version: " + installed_version);
 			if (installed_version != current_version) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR(MISMATCHED_VERSIONS_MESSAGE), installed_version, current_version));
 				return ERR_UNCONFIGURED;
@@ -3783,14 +3783,14 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), TTR("Java SDK path must be configured in Editor Settings at 'export/android/java_sdk_path'."));
 			return ERR_UNCONFIGURED;
 		}
-		print_verbose("Java sdk path: " + java_sdk_path);
+		PRINT_VERBOSE("Java sdk path: " + java_sdk_path);
 
 		String sdk_path = EDITOR_GET("export/android/android_sdk_path");
 		if (sdk_path.is_empty()) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), TTR("Android SDK path must be configured in Editor Settings at 'export/android/android_sdk_path'."));
 			return ERR_UNCONFIGURED;
 		}
-		print_verbose("Android sdk path: " + sdk_path);
+		PRINT_VERBOSE("Android sdk path: " + sdk_path);
 #endif
 
 		// TODO: should we use "package/name" or "application/config/name"?
@@ -3810,7 +3810,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		_clear_assets_directory(p_preset);
 		String gdextension_libs_path = gradle_build_directory.path_join(GDEXTENSION_LIBS_PATH);
 		_remove_copied_libs(gdextension_libs_path);
-		print_verbose("Exporting project files...");
+		PRINT_VERBOSE("Exporting project files...");
 		CustomExportData user_data;
 		user_data.assets_directory = assets_directory;
 		user_data.libs_directory = gradle_build_directory.path_join("libs");
@@ -3850,14 +3850,14 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			fa->store_string(JSON::stringify(user_data.libs, "\t"));
 		}
 
-		print_verbose("Storing command line flags...");
+		PRINT_VERBOSE("Storing command line flags...");
 		store_file_at_path(assets_directory + "/_cl_", command_line_flags);
 
 #ifndef ANDROID_ENABLED
-		print_verbose("Updating JAVA_HOME environment to " + java_sdk_path);
+		PRINT_VERBOSE("Updating JAVA_HOME environment to " + java_sdk_path);
 		OS::get_singleton()->set_environment("JAVA_HOME", java_sdk_path);
 
-		print_verbose("Updating ANDROID_HOME environment to " + sdk_path);
+		PRINT_VERBOSE("Updating ANDROID_HOME environment to " + sdk_path);
 		OS::get_singleton()->set_environment("ANDROID_HOME", sdk_path);
 #endif
 		String build_command;
@@ -3968,7 +3968,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		// to avoid accidentally leaking sensitive information when sharing verbose logs for troubleshooting.
 		// Any non-sensitive additions to the command line arguments must be done above this section.
 		// Sensitive additions must be done below the logging statement.
-		print_verbose("Build Android project using gradle command: " + String("\n") + build_command + " " + join_list(cmdline, String(" ")));
+		PRINT_VERBOSE("Build Android project using gradle command: " + String("\n") + build_command + " " + join_list(cmdline, String(" ")));
 
 		if (should_sign) {
 			if (p_debug) {
@@ -4073,25 +4073,25 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), TTR("Building of Android project failed, check output for the error:") + "\n\n" + build_project_output);
 			return ERR_CANT_CREATE;
 		} else {
-			print_verbose(build_project_output);
+			PRINT_VERBOSE(build_project_output);
 		}
 
-		print_verbose("Copying Android binary using gradle command: " + String("\n") + build_command + " " + join_list(copy_args, String(" ")));
+		PRINT_VERBOSE("Copying Android binary using gradle command: " + String("\n") + build_command + " " + join_list(copy_args, String(" ")));
 		String copy_binary_output;
 		int copy_result = EditorNode::get_singleton()->execute_and_show_output(TTR("Moving output"), build_command, copy_args, true, false, &copy_binary_output);
 		if (copy_result != 0) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), TTR("Unable to copy and rename export file:") + "\n\n" + copy_binary_output);
 			return ERR_CANT_CREATE;
 		} else {
-			print_verbose(copy_binary_output);
+			PRINT_VERBOSE(copy_binary_output);
 		}
 
-		print_verbose("Successfully completed Android gradle build.");
+		PRINT_VERBOSE("Successfully completed Android gradle build.");
 #endif
 		return OK;
 	}
 	// This is the start of the Legacy build system
-	print_verbose("Starting legacy build system...");
+	PRINT_VERBOSE("Starting legacy build system...");
 	if (p_debug) {
 		src_apk = p_preset->get("custom_template/debug");
 	} else {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -841,7 +841,7 @@ Error EditorExportPlatformAndroid::save_apk_file(const Ref<EditorExportPreset> &
 	} else {
 		dst_path = String("assets/") + simplified_path.trim_prefix("res://");
 	}
-	print_verbose("Saving project files from " + simplified_path + " into " + dst_path);
+	PRINT_VERBOSE("Saving project files from " + simplified_path + " into " + dst_path);
 	store_in_apk(ed, dst_path, enc_data, _should_compress_asset(simplified_path, enc_data) ? Z_DEFLATED : 0);
 
 	ed->pd.file_ofs.push_back(sd);
@@ -874,7 +874,7 @@ Error EditorExportPlatformAndroid::copy_gradle_so(const Ref<EditorExportPreset> 
 			String filename = p_so.path.get_file();
 			String dst_path = export_data->libs_directory.path_join(type).path_join(abi).path_join(filename);
 			Vector<uint8_t> data = FileAccess::get_file_as_bytes(p_so.path);
-			print_verbose("Copying .so file from " + p_so.path + " to " + dst_path);
+			PRINT_VERBOSE("Copying .so file from " + p_so.path + " to " + dst_path);
 			Error err = store_file_at_path(dst_path, data);
 			ERR_FAIL_COND_V_MSG(err, err, "Failed to copy .so file from " + p_so.path + " to " + dst_path);
 			export_data->libs.push_back(dst_path);
@@ -963,7 +963,7 @@ void EditorExportPlatformAndroid::_create_editor_debug_keystore_if_needed() {
 		args.push_back("-dname");
 		args.push_back("cn=Godot, ou=Godot Engine, o=Stichting Godot, c=NL");
 		Error error = OS::get_singleton()->execute(keytool_path, args, &output, nullptr, true);
-		print_verbose(output);
+		PRINT_VERBOSE(output);
 		if (error != OK) {
 			WARN_PRINT("Error: Unable to create debug keystore");
 			return;
@@ -974,7 +974,7 @@ void EditorExportPlatformAndroid::_create_editor_debug_keystore_if_needed() {
 	EditorSettings::get_singleton()->set("export/android/debug_keystore", keystore_path);
 	EditorSettings::get_singleton()->set("export/android/debug_keystore_user", DEFAULT_ANDROID_KEYSTORE_DEBUG_USER);
 	EditorSettings::get_singleton()->set("export/android/debug_keystore_pass", DEFAULT_ANDROID_KEYSTORE_DEBUG_PASSWORD);
-	print_verbose("Updated editor debug keystore to " + keystore_path);
+	PRINT_VERBOSE("Updated editor debug keystore to " + keystore_path);
 }
 
 void EditorExportPlatformAndroid::_get_manifest_info(const Ref<EditorExportPreset> &p_preset, bool p_give_internet, Vector<String> &r_permissions, Vector<FeatureInfo> &r_features, Vector<MetadataInfo> &r_metadata) {
@@ -1032,7 +1032,7 @@ void EditorExportPlatformAndroid::_get_manifest_info(const Ref<EditorExportPrese
 }
 
 void EditorExportPlatformAndroid::_write_tmp_manifest(const Ref<EditorExportPreset> &p_preset, bool p_give_internet, bool p_debug) {
-	print_verbose("Building temporary manifest...");
+	PRINT_VERBOSE("Building temporary manifest...");
 	String manifest_text =
 			"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
 			"<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
@@ -1076,7 +1076,7 @@ void EditorExportPlatformAndroid::_write_tmp_manifest(const Ref<EditorExportPres
 	manifest_text += "</manifest>\n";
 	String manifest_path = ExportTemplateManager::get_android_build_directory(p_preset).path_join(vformat("src/%s/AndroidManifest.xml", (p_debug ? "debug" : "release")));
 
-	print_verbose("Storing manifest into " + manifest_path + ": " + "\n" + manifest_text);
+	PRINT_VERBOSE("Storing manifest into " + manifest_path + ": " + "\n" + manifest_text);
 	store_string_at_path(manifest_path, manifest_text);
 }
 
@@ -1208,7 +1208,7 @@ void EditorExportPlatformAndroid::_fix_themes_xml(const Ref<EditorExportPreset> 
 	// Reconstruct the XML content from the modified lines.
 	String xml_content = String("\n").join(new_lines);
 	store_string_at_path(themes_xml_path, xml_content);
-	print_verbose("Successfully modified " + themes_xml_path + ": " + "\n" + xml_content);
+	PRINT_VERBOSE("Successfully modified " + themes_xml_path + ": " + "\n" + xml_content);
 }
 
 void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &p_manifest, bool p_give_internet) {
@@ -1922,12 +1922,12 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 
 	// Regular icon: user selection -> project icon -> default.
 	String path = static_cast<String>(p_preset->get(LAUNCHER_ICON_OPTION)).strip_edges();
-	print_verbose("Loading regular icon from " + path);
+	PRINT_VERBOSE("Loading regular icon from " + path);
 	if (!path.is_empty()) {
 		icon = _load_icon_or_splash_image(path, &err);
 	}
 	if (path.is_empty() || err != OK || icon.is_null() || icon->is_empty()) {
-		print_verbose("- falling back to project icon: " + project_icon_path);
+		PRINT_VERBOSE("- falling back to project icon: " + project_icon_path);
 		if (!project_icon_path.is_empty()) {
 			icon = _load_icon_or_splash_image(project_icon_path, &err);
 		} else {
@@ -1937,26 +1937,26 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 
 	// Adaptive foreground: user selection -> regular icon (user selection -> project icon -> default).
 	path = static_cast<String>(p_preset->get(LAUNCHER_ADAPTIVE_ICON_FOREGROUND_OPTION)).strip_edges();
-	print_verbose("Loading adaptive foreground icon from " + path);
+	PRINT_VERBOSE("Loading adaptive foreground icon from " + path);
 	if (!path.is_empty()) {
 		foreground = _load_icon_or_splash_image(path, &err);
 	}
 	if (path.is_empty() || err != OK || foreground.is_null() || foreground->is_empty()) {
-		print_verbose("- falling back to using the regular icon");
+		PRINT_VERBOSE("- falling back to using the regular icon");
 		foreground = icon;
 	}
 
 	// Adaptive background: user selection -> default.
 	path = static_cast<String>(p_preset->get(LAUNCHER_ADAPTIVE_ICON_BACKGROUND_OPTION)).strip_edges();
 	if (!path.is_empty()) {
-		print_verbose("Loading adaptive background icon from " + path);
+		PRINT_VERBOSE("Loading adaptive background icon from " + path);
 		background = _load_icon_or_splash_image(path, &err);
 	}
 
 	// Adaptive monochrome: user selection -> default.
 	path = static_cast<String>(p_preset->get(LAUNCHER_ADAPTIVE_ICON_MONOCHROME_OPTION)).strip_edges();
 	if (!path.is_empty()) {
-		print_verbose("Loading adaptive monochrome icon from " + path);
+		PRINT_VERBOSE("Loading adaptive monochrome icon from " + path);
 		monochrome = _load_icon_or_splash_image(path, &err);
 	}
 
@@ -1964,14 +1964,14 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	path = static_cast<String>(p_preset->get(ANDROID_SPLASH_ICON_OPTION)).strip_edges();
 	if (path.get_extension() != "xml") {
 		// XML file is handled in _fix_themes_xml().
-		print_verbose("Loading splash screen icon from " + path);
+		PRINT_VERBOSE("Loading splash screen icon from " + path);
 		bool loaded_ok = false;
 		if (!path.is_empty()) {
 			splash_icon = _load_icon_or_splash_image(path, &err);
 			loaded_ok = (err == OK && splash_icon.is_valid() && !splash_icon->is_empty());
 		}
 		if (!loaded_ok) {
-			print_verbose("- falling back to using the adaptive foreground icon");
+			PRINT_VERBOSE("- falling back to using the adaptive foreground icon");
 			splash_icon = foreground;
 		}
 	}
@@ -1981,7 +1981,7 @@ void EditorExportPlatformAndroid::load_icon_refs(const Ref<EditorExportPreset> &
 	// - Legacy build: If the path is empty, a transparent image is used.
 	path = static_cast<String>(p_preset->get(ANDROID_SPLASH_BRANDING_IMAGE_OPTION)).strip_edges();
 	if (!path.is_empty()) {
-		print_verbose("Loading splash screen branding image from " + path);
+		PRINT_VERBOSE("Loading splash screen branding image from " + path);
 		splash_branding_image = _load_icon_or_splash_image(path, &err);
 	}
 }
@@ -1998,13 +1998,13 @@ void EditorExportPlatformAndroid::_copy_icons_to_gradle_project(const Ref<Editor
 	// Copy splash screen icon to the drawable directory.
 	// This is only for png/webp/svg file; XML file is handled in _fix_themes_xml().
 	if (p_splash_icon.is_valid() && !p_splash_icon->is_empty()) {
-		print_verbose("Copying splash screen icon into " + ANDROID_SPLASH_ICON_PATH);
+		PRINT_VERBOSE("Copying splash screen icon into " + ANDROID_SPLASH_ICON_PATH);
 		Vector<uint8_t> buffer = p_splash_icon->save_webp_to_buffer();
 		store_file_at_path(gradle_build_dir.path_join(ANDROID_SPLASH_ICON_PATH), buffer);
 	}
 
 	if (p_splash_branding_image.is_valid() && !p_splash_branding_image->is_empty()) {
-		print_verbose("Copying splash screen branding image into " + ANDROID_SPLASH_BRANDING_IMAGE_PATH);
+		PRINT_VERBOSE("Copying splash screen branding image into " + ANDROID_SPLASH_BRANDING_IMAGE_PATH);
 		Vector<uint8_t> buffer = p_splash_branding_image->save_webp_to_buffer();
 		store_file_at_path(gradle_build_dir.path_join(ANDROID_SPLASH_BRANDING_IMAGE_PATH), buffer);
 	}
@@ -2016,14 +2016,14 @@ void EditorExportPlatformAndroid::_copy_icons_to_gradle_project(const Ref<Editor
 
 	for (int i = 0; i < ICON_DENSITIES_COUNT; ++i) {
 		if (p_main_image.is_valid() && !p_main_image->is_empty()) {
-			print_verbose("Processing launcher icon for dimension " + itos(LAUNCHER_ICONS[i].dimensions) + " into " + LAUNCHER_ICONS[i].export_path);
+			PRINT_VERBOSE("Processing launcher icon for dimension " + itos(LAUNCHER_ICONS[i].dimensions) + " into " + LAUNCHER_ICONS[i].export_path);
 			Vector<uint8_t> data;
 			_process_launcher_icons(LAUNCHER_ICONS[i].export_path, p_main_image, LAUNCHER_ICONS[i].dimensions, data);
 			store_file_at_path(gradle_build_dir.path_join(LAUNCHER_ICONS[i].export_path), data);
 		}
 
 		if (p_foreground.is_valid() && !p_foreground->is_empty()) {
-			print_verbose("Processing launcher adaptive icon p_foreground for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].export_path);
+			PRINT_VERBOSE("Processing launcher adaptive icon p_foreground for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].export_path);
 			Vector<uint8_t> data;
 			_process_launcher_icons(LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].export_path, p_foreground,
 					LAUNCHER_ADAPTIVE_ICON_FOREGROUNDS[i].dimensions, data);
@@ -2031,7 +2031,7 @@ void EditorExportPlatformAndroid::_copy_icons_to_gradle_project(const Ref<Editor
 		}
 
 		if (p_background.is_valid() && !p_background->is_empty()) {
-			print_verbose("Processing launcher adaptive icon p_background for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].export_path);
+			PRINT_VERBOSE("Processing launcher adaptive icon p_background for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].export_path);
 			Vector<uint8_t> data;
 			_process_launcher_icons(LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].export_path, p_background,
 					LAUNCHER_ADAPTIVE_ICON_BACKGROUNDS[i].dimensions, data);
@@ -2039,7 +2039,7 @@ void EditorExportPlatformAndroid::_copy_icons_to_gradle_project(const Ref<Editor
 		}
 
 		if (p_monochrome.is_valid() && !p_monochrome->is_empty()) {
-			print_verbose("Processing launcher adaptive icon p_monochrome for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].export_path);
+			PRINT_VERBOSE("Processing launcher adaptive icon p_monochrome for dimension " + itos(LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].dimensions) + " into " + LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].export_path);
 			Vector<uint8_t> data;
 			_process_launcher_icons(LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].export_path, p_monochrome,
 					LAUNCHER_ADAPTIVE_ICON_MONOCHROMES[i].dimensions, data);
@@ -2200,7 +2200,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 #ifndef DISABLE_DEPRECATED
 	Vector<PluginConfigAndroid> plugins_configs = get_plugins();
 	for (int i = 0; i < plugins_configs.size(); i++) {
-		print_verbose("Found Android plugin " + plugins_configs[i].name);
+		PRINT_VERBOSE("Found Android plugin " + plugins_configs[i].name);
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("%s/%s", PNAME("plugins"), plugins_configs[i].name)), false));
 	}
 	android_plugins_changed.clear();
@@ -2485,7 +2485,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 		output.clear();
 		err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-		print_verbose(output);
+		PRINT_VERBOSE(output);
 	}
 
 	print_line("Installing to device (please wait...): " + devices[p_device - 1].name);
@@ -2506,7 +2506,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 	output.clear();
 	err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-	print_verbose(output);
+	PRINT_VERBOSE(output);
 	if (err || rv != 0) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Run"), vformat(TTR("Could not install to device: %s"), output));
 		CLEANUP_AND_RETURN(ERR_CANT_CREATE);
@@ -2525,7 +2525,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 			args.push_back("--remove-all");
 			output.clear();
 			OS::get_singleton()->execute(adb, args, &output, &rv, true);
-			print_verbose(output);
+			PRINT_VERBOSE(output);
 
 			if (p_debug_flags.has_flag(DEBUG_FLAG_REMOTE_DEBUG)) {
 				int dbg_port = EDITOR_GET("network/debug/remote_port");
@@ -2538,7 +2538,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 				output.clear();
 				OS::get_singleton()->execute(adb, args, &output, &rv, true);
-				print_verbose(output);
+				PRINT_VERBOSE(output);
 				print_line("Reverse result: " + itos(rv));
 			}
 
@@ -2554,7 +2554,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 				output.clear();
 				err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-				print_verbose(output);
+				PRINT_VERBOSE(output);
 				print_line("Reverse result2: " + itos(rv));
 			}
 		} else {
@@ -2619,8 +2619,8 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 				break;
 			}
 		}
-		print_verbose(output);
-		print_verbose(err_output);
+		PRINT_VERBOSE(output);
+		PRINT_VERBOSE(err_output);
 		if (!connected) {
 			OS::get_singleton()->kill(data["pid"].operator int());
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Run"), TTR("Could not execute on device, scrcpy failed with the following error:\n" + err_output));
@@ -2646,7 +2646,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 		output.clear();
 		err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-		print_verbose(output);
+		PRINT_VERBOSE(output);
 		if (err || rv != 0 || output.contains("Error: Activity not started")) {
 			// The implicit launch failed, let's try an explicit launch by specifying the component name before giving up.
 			const String component_name = get_package_name(p_preset, package_name) + "/com.godot.game.GodotAppLauncher";
@@ -2657,7 +2657,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 
 			output.clear();
 			err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
-			print_verbose(output);
+			PRINT_VERBOSE(output);
 
 			if (err || rv != 0 || output.begins_with("Error: Activity not started")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Run"), TTR("Could not execute on device."));
@@ -3169,7 +3169,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 	}
 
 	String apksigner = AndroidSDKManager::get_apksigner_path(target_sdk_version.to_int(), true);
-	print_verbose("Starting signing of the APK binary using " + apksigner);
+	PRINT_VERBOSE("Starting signing of the APK binary using " + apksigner);
 	if (apksigner == "<FAILED>") {
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), TTR("All 'apksigner' tools located in Android SDK 'build-tools' directory failed to execute. Please check that you have the correct version installed for your target sdk version. The resulting APK is unsigned."));
 		return OK;
@@ -3192,7 +3192,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 	args.push_back(apk_path);
 	if (OS::get_singleton()->is_stdout_verbose() && p_debug) {
 		// We only print verbose logs with credentials for debug builds to avoid leaking release keystore credentials.
-		print_verbose("Signing debug binary using: " + String("\n") + apksigner + " " + join_list(args, String(" ")));
+		PRINT_VERBOSE("Signing debug binary using: " + String("\n") + apksigner + " " + join_list(args, String(" ")));
 	} else {
 		List<String> redacted_args = List<String>(args);
 		redacted_args.find(keystore)->set("<REDACTED>");
@@ -3231,7 +3231,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 	args.push_back("--verbose");
 	args.push_back(apk_path);
 	if (p_debug) {
-		print_verbose("Verifying signed build using: " + String("\n") + apksigner + " " + join_list(args, String(" ")));
+		PRINT_VERBOSE("Verifying signed build using: " + String("\n") + apksigner + " " + join_list(args, String(" ")));
 	}
 
 	output.clear();
@@ -3240,7 +3240,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), TTR("Could not start apksigner executable."));
 		return err;
 	}
-	print_verbose(output);
+	PRINT_VERBOSE(output);
 	if (retval) {
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), TTR("'apksigner' verification of APK failed."));
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), vformat(TTR("output: \n%s"), output));
@@ -3248,7 +3248,7 @@ Error EditorExportPlatformAndroid::sign_apk(const Ref<EditorExportPreset> &p_pre
 	}
 #endif
 
-	print_verbose("Successfully completed signing build.");
+	PRINT_VERBOSE("Successfully completed signing build.");
 
 #ifdef ANDROID_ENABLED
 	bool prompt_apk_install = EDITOR_GET("export/android/install_exported_apk");
@@ -3267,7 +3267,7 @@ void EditorExportPlatformAndroid::_clear_assets_directory(const Ref<EditorExport
 	// Clear the APK assets directory
 	String apk_assets_directory = gradle_build_directory.path_join(APK_ASSETS_DIRECTORY);
 	if (da_res->dir_exists(apk_assets_directory)) {
-		print_verbose("Clearing APK assets directory...");
+		PRINT_VERBOSE("Clearing APK assets directory...");
 		Ref<DirAccess> da_assets = DirAccess::open(apk_assets_directory);
 		ERR_FAIL_COND(da_assets.is_null());
 
@@ -3278,7 +3278,7 @@ void EditorExportPlatformAndroid::_clear_assets_directory(const Ref<EditorExport
 	// Clear the AAB assets directory
 	String aab_assets_directory = gradle_build_directory.path_join(AAB_ASSETS_DIRECTORY);
 	if (da_res->dir_exists(aab_assets_directory)) {
-		print_verbose("Clearing AAB assets directory...");
+		PRINT_VERBOSE("Clearing AAB assets directory...");
 		Ref<DirAccess> da_assets = DirAccess::open(aab_assets_directory);
 		ERR_FAIL_COND(da_assets.is_null());
 
@@ -3288,11 +3288,11 @@ void EditorExportPlatformAndroid::_clear_assets_directory(const Ref<EditorExport
 }
 
 void EditorExportPlatformAndroid::_remove_copied_libs(String p_gdextension_libs_path) {
-	print_verbose("Removing previously installed libraries...");
+	PRINT_VERBOSE("Removing previously installed libraries...");
 	Error error;
 	String libs_json = FileAccess::get_file_as_string(p_gdextension_libs_path, &error);
 	if (error || libs_json.is_empty()) {
-		print_verbose("No previously installed libraries found");
+		PRINT_VERBOSE("No previously installed libraries found");
 		return;
 	}
 
@@ -3303,7 +3303,7 @@ void EditorExportPlatformAndroid::_remove_copied_libs(String p_gdextension_libs_
 	Vector<String> libs = json.get_data();
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	for (int i = 0; i < libs.size(); i++) {
-		print_verbose("Removing previously installed library " + libs[i]);
+		PRINT_VERBOSE("Removing previously installed library " + libs[i]);
 		da->remove(libs[i]);
 	}
 	da->remove(p_gdextension_libs_path);
@@ -3488,16 +3488,16 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	bool p_give_internet = p_flags.has_flag(DEBUG_FLAG_DUMB_CLIENT) || p_flags.has_flag(DEBUG_FLAG_REMOTE_DEBUG);
 	Vector<ABI> enabled_abis = get_enabled_abis(p_preset);
 
-	print_verbose("Exporting for Android...");
-	print_verbose("- debug build: " + bool_to_string(p_debug));
-	print_verbose("- export path: " + p_path);
-	print_verbose("- export format: " + itos(export_format));
-	print_verbose("- sign build: " + bool_to_string(should_sign));
-	print_verbose("- gradle build enabled: " + bool_to_string(use_gradle_build));
-	print_verbose("- enabled abis: " + join_abis(enabled_abis, ",", false));
-	print_verbose("- export filter: " + itos(p_preset->get_export_filter()));
-	print_verbose("- include filter: " + p_preset->get_include_filter());
-	print_verbose("- exclude filter: " + p_preset->get_exclude_filter());
+	PRINT_VERBOSE("Exporting for Android...");
+	PRINT_VERBOSE("- debug build: " + bool_to_string(p_debug));
+	PRINT_VERBOSE("- export path: " + p_path);
+	PRINT_VERBOSE("- export format: " + itos(export_format));
+	PRINT_VERBOSE("- sign build: " + bool_to_string(should_sign));
+	PRINT_VERBOSE("- gradle build enabled: " + bool_to_string(use_gradle_build));
+	PRINT_VERBOSE("- enabled abis: " + join_abis(enabled_abis, ",", false));
+	PRINT_VERBOSE("- export filter: " + itos(p_preset->get_export_filter()));
+	PRINT_VERBOSE("- include filter: " + p_preset->get_include_filter());
+	PRINT_VERBOSE("- exclude filter: " + p_preset->get_exclude_filter());
 
 	Ref<Image> main_image;
 	Ref<Image> foreground;
@@ -3536,13 +3536,13 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		if (ep.step(TTR("Starting gradle build..."), 0)) {
 			return ERR_SKIP;
 		}
-		print_verbose("Starting gradle build...");
+		PRINT_VERBOSE("Starting gradle build...");
 		//test that installed build version is alright
 		{
 			if (ep.step(TTR("Checking build directory..."), 10)) {
 				return ERR_SKIP;
 			}
-			print_verbose("Checking build directory...");
+			PRINT_VERBOSE("Checking build directory...");
 			err = EditorNode::get_singleton()->setup_android_build_template(p_preset, true);
 			if (err != OK) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Unable to set up Android build directory. Please fix by manually deleting the \"%s\" directory and try again. Or enable automatic deletion in the Editor Settings (Export > Android > Build > Automatically Delete Build Directory)."), gradle_build_directory));
@@ -3556,14 +3556,14 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), TTR("Java SDK path must be configured in Editor Settings at 'export/android/java_sdk_path'."));
 			return ERR_UNCONFIGURED;
 		}
-		print_verbose("Java sdk path: " + java_sdk_path);
+		PRINT_VERBOSE("Java sdk path: " + java_sdk_path);
 
 		String sdk_path = EDITOR_GET("export/android/android_sdk_path");
 		if (sdk_path.is_empty()) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), TTR("Android SDK path must be configured in Editor Settings at 'export/android/android_sdk_path'."));
 			return ERR_UNCONFIGURED;
 		}
-		print_verbose("Android sdk path: " + sdk_path);
+		PRINT_VERBOSE("Android sdk path: " + sdk_path);
 #endif
 
 		// TODO: should we use "package/name" or "application/config/name"?
@@ -3587,7 +3587,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		if (ep.step(TTR("Exporting project files..."), 20)) {
 			return ERR_SKIP;
 		}
-		print_verbose("Exporting project files...");
+		PRINT_VERBOSE("Exporting project files...");
 		CustomExportData user_data;
 		user_data.assets_directory = assets_directory;
 		user_data.libs_directory = gradle_build_directory.path_join("libs");
@@ -3630,14 +3630,14 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		if (ep.step(TTR("Storing command line flags..."), 30)) {
 			return ERR_SKIP;
 		}
-		print_verbose("Storing command line flags...");
+		PRINT_VERBOSE("Storing command line flags...");
 		store_file_at_path(assets_directory + "/_cl_", command_line_flags);
 
 #ifndef ANDROID_ENABLED
-		print_verbose("Updating JAVA_HOME environment to " + java_sdk_path);
+		PRINT_VERBOSE("Updating JAVA_HOME environment to " + java_sdk_path);
 		OS::get_singleton()->set_environment("JAVA_HOME", java_sdk_path);
 
-		print_verbose("Updating ANDROID_HOME environment to " + sdk_path);
+		PRINT_VERBOSE("Updating ANDROID_HOME environment to " + sdk_path);
 		OS::get_singleton()->set_environment("ANDROID_HOME", sdk_path);
 #endif
 		String build_command;
@@ -3751,7 +3751,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		if (ep.step(TTR("Build Android project..."), 40)) {
 			return ERR_SKIP;
 		}
-		print_verbose("Build Android project using gradle command: " + String("\n") + build_command + " " + join_list(cmdline, String(" ")));
+		PRINT_VERBOSE("Build Android project using gradle command: " + String("\n") + build_command + " " + join_list(cmdline, String(" ")));
 
 		if (should_sign) {
 			if (p_debug) {
@@ -3856,20 +3856,20 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), TTR("Building of Android project failed, check output for the error:") + "\n\n" + build_project_output);
 			return ERR_CANT_CREATE;
 		} else {
-			print_verbose(build_project_output);
+			PRINT_VERBOSE(build_project_output);
 		}
 
-		print_verbose("Copying Android binary using gradle command: " + String("\n") + build_command + " " + join_list(copy_args, String(" ")));
+		PRINT_VERBOSE("Copying Android binary using gradle command: " + String("\n") + build_command + " " + join_list(copy_args, String(" ")));
 		String copy_binary_output;
 		int copy_result = EditorNode::get_singleton()->execute_and_show_output(TTR("Moving output"), build_command, copy_args, true, false, &copy_binary_output);
 		if (copy_result != 0) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), TTR("Unable to copy and rename export file:") + "\n\n" + copy_binary_output);
 			return ERR_CANT_CREATE;
 		} else {
-			print_verbose(copy_binary_output);
+			PRINT_VERBOSE(copy_binary_output);
 		}
 
-		print_verbose("Successfully completed Android gradle build.");
+		PRINT_VERBOSE("Successfully completed Android gradle build.");
 #endif
 		if (ep.step(TTR("Build complete."), 105)) {
 			return ERR_SKIP;
@@ -3877,7 +3877,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		return OK;
 	}
 	// This is the start of the Legacy build system
-	print_verbose("Starting legacy build system...");
+	PRINT_VERBOSE("Starting legacy build system...");
 	if (p_debug) {
 		src_apk = p_preset->get("custom_template/debug");
 	} else {

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -187,7 +187,7 @@ Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_p
 	} else {
 		dst_path = export_data->assets_directory + String("/") + simplified_path.trim_prefix("res://");
 	}
-	print_verbose("Saving project files from " + simplified_path + " into " + dst_path);
+	PRINT_VERBOSE("Saving project files from " + simplified_path + " into " + dst_path);
 	Error err = store_file_at_path(dst_path, enc_data);
 
 	export_data->pd.file_ofs.push_back(sd);
@@ -211,7 +211,7 @@ String _android_xml_escape(const String &p_string) {
 
 // Creates strings.xml files inside the gradle project for different locales.
 Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &p_project_name, const String &p_gradle_build_dir, const Dictionary &p_appnames) {
-	print_verbose("Creating strings resources for supported locales for project " + p_project_name);
+	PRINT_VERBOSE("Creating strings resources for supported locales for project " + p_project_name);
 	// Stores the string into the default values directory.
 	String processed_default_xml_string = vformat(GODOT_PROJECT_NAME_XML_STRING, _android_xml_escape(p_project_name));
 	store_string_at_path(p_gradle_build_dir.path_join("res/values/godot_project_name_string.xml"), processed_default_xml_string);
@@ -252,7 +252,7 @@ Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset
 		}
 		if (locale_project_name != p_project_name) {
 			String processed_xml_string = vformat(GODOT_PROJECT_NAME_XML_STRING, _android_xml_escape(locale_project_name));
-			print_verbose("Storing project name for locale " + locale + " under " + locale_directory);
+			PRINT_VERBOSE("Storing project name for locale " + locale + " under " + locale_directory);
 			store_string_at_path(locale_directory, processed_xml_string);
 		} else {
 			// TODO: Once the legacy build system is deprecated we don't need to have xml files for this else branch

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -193,7 +193,7 @@ Error rename_and_store_file_in_gradle_project(const Ref<EditorExportPreset> &p_p
 	} else {
 		dst_path = export_data->assets_directory + String("/") + simplified_path.trim_prefix("res://");
 	}
-	print_verbose("Saving project files from " + simplified_path + " into " + dst_path);
+	PRINT_VERBOSE("Saving project files from " + simplified_path + " into " + dst_path);
 	err = store_file_at_path(dst_path, enc_data);
 
 	export_data->pd.file_ofs.push_back(sd);
@@ -217,7 +217,7 @@ String _android_xml_escape(const String &p_string) {
 
 // Creates strings.xml files inside the gradle project for different locales.
 Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset, const String &p_project_name, const String &p_gradle_build_dir, const Dictionary &p_appnames) {
-	print_verbose("Creating strings resources for supported locales for project " + p_project_name);
+	PRINT_VERBOSE("Creating strings resources for supported locales for project " + p_project_name);
 	// Stores the string into the default values directory.
 	String processed_default_xml_string = vformat(GODOT_PROJECT_NAME_XML_STRING, _android_xml_escape(p_project_name));
 	store_string_at_path(p_gradle_build_dir.path_join("res/values/godot_project_name_string.xml"), processed_default_xml_string);
@@ -258,7 +258,7 @@ Error _create_project_name_strings_files(const Ref<EditorExportPreset> &p_preset
 		}
 		if (locale_project_name != p_project_name) {
 			String processed_xml_string = vformat(GODOT_PROJECT_NAME_XML_STRING, _android_xml_escape(locale_project_name));
-			print_verbose("Storing project name for locale " + locale + " under " + locale_directory);
+			PRINT_VERBOSE("Storing project name for locale " + locale + " under " + locale_directory);
 			store_string_at_path(locale_directory, processed_xml_string);
 		} else {
 			// TODO: Once the legacy build system is deprecated we don't need to have xml files for this else branch

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -199,13 +199,13 @@ bool OS_Android::copy_dynamic_library(const String &p_library_path, const String
 	String copy_path = p_target_dir.path_join(p_library_path.get_file());
 	bool copy_exists = FileAccess::exists(copy_path);
 	if (copy_exists) {
-		print_verbose("Deleting existing library copy " + copy_path);
+		PRINT_VERBOSE("Deleting existing library copy " + copy_path);
 		if (da_ref->remove(copy_path) != OK) {
-			print_verbose("Unable to delete " + copy_path);
+			PRINT_VERBOSE("Unable to delete " + copy_path);
 		}
 	}
 
-	print_verbose("Copying " + p_library_path + " to " + p_target_dir);
+	PRINT_VERBOSE("Copying " + p_library_path + " to " + p_target_dir);
 	Error create_dir_result = da_ref->make_dir_recursive(p_target_dir);
 	if (create_dir_result == OK || create_dir_result == ERR_ALREADY_EXISTS) {
 		copy_exists = da_ref->copy(p_library_path, copy_path) == OK;
@@ -234,7 +234,7 @@ Error OS_Android::open_dynamic_library(const String &p_path, void *&p_library_ha
 
 		if (p_data != nullptr && p_data->library_dependencies != nullptr && !p_data->library_dependencies->is_empty()) {
 			// Copy the library dependencies
-			print_verbose("Copying library dependencies..");
+			PRINT_VERBOSE("Copying library dependencies..");
 			for (const String &library_dependency_path : *p_data->library_dependencies) {
 				String internal_library_dependency_path;
 				if (!copy_dynamic_library(library_dependency_path, dynamic_library_path.path_join(library_dependency_path.get_base_dir()), &internal_library_dependency_path)) {
@@ -249,11 +249,11 @@ Error OS_Android::open_dynamic_library(const String &p_path, void *&p_library_ha
 		}
 
 		String internal_path;
-		print_verbose("Copying library " + p_path);
+		PRINT_VERBOSE("Copying library " + p_path);
 		const bool internal_so_file_exists = copy_dynamic_library(p_path, dynamic_library_path.path_join(p_path.get_base_dir()), &internal_path);
 
 		if (internal_so_file_exists) {
-			print_verbose("Opening library " + internal_path);
+			PRINT_VERBOSE("Opening library " + internal_path);
 			p_library_handle = dlopen(internal_path.utf8().get_data(), RTLD_NOW);
 			if (p_library_handle) {
 				path = internal_path;

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -577,7 +577,7 @@ bool FreeDesktopPortalDesktop::_is_interface_supported(const char *p_iface, uint
 					dbus_message_iter_recurse(&iter, &iter_ver);
 					dbus_uint32_t ver_code;
 					dbus_message_iter_get_basic(&iter_ver, &ver_code);
-					print_verbose(vformat("PortalDesktop: %s version %d detected, version %d required.", p_iface, ver_code, p_minimum_version));
+					PRINT_VERBOSE(vformat("PortalDesktop: %s version %d detected, version %d required.", p_iface, ver_code, p_minimum_version));
 					supported = ver_code >= p_minimum_version;
 				}
 				dbus_message_unref(reply);

--- a/platform/linuxbsd/freedesktop_screensaver.cpp
+++ b/platform/linuxbsd/freedesktop_screensaver.cpp
@@ -86,7 +86,7 @@ void FreeDesktopScreenSaver::inhibit() {
 	DBusMessageIter reply_iter;
 	dbus_message_iter_init(reply, &reply_iter);
 	dbus_message_iter_get_basic(&reply_iter, &cookie);
-	print_verbose("FreeDesktopScreenSaver: Acquired screensaver inhibition cookie: " + uitos(cookie));
+	PRINT_VERBOSE("FreeDesktopScreenSaver: Acquired screensaver inhibition cookie: " + uitos(cookie));
 
 	dbus_message_unref(reply);
 	dbus_connection_unref(bus);
@@ -124,7 +124,7 @@ void FreeDesktopScreenSaver::uninhibit() {
 		return;
 	}
 
-	print_verbose("FreeDesktopScreenSaver: Released screensaver inhibition cookie: " + uitos(cookie));
+	PRINT_VERBOSE("FreeDesktopScreenSaver: Released screensaver inhibition cookie: " + uitos(cookie));
 
 	dbus_message_unref(reply);
 	dbus_connection_unref(bus);

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -1347,7 +1347,7 @@ OS_LinuxBSD::OS_LinuxBSD() {
 		bool ver_ok = false;
 		int version = FcGetVersion();
 		ver_ok = ((version / 100 / 100) == 2 && (version / 100 % 100) >= 11) || ((version / 100 / 100) > 2); // 2.11.0
-		print_verbose(vformat("FontConfig %d.%d.%d detected.", version / 100 / 100, version / 100 % 100, version % 100));
+		PRINT_VERBOSE(vformat("FontConfig %d.%d.%d detected.", version / 100 / 100, version / 100 % 100, version % 100));
 		if (!ver_ok) {
 			font_config_initialized = false;
 		}

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -1004,12 +1004,12 @@ void OS_LinuxBSD::run() {
 		if (use_gamemode) {
 			gamemode_status = GameMode::gamemode_request_start_for(OS::get_singleton()->get_process_id());
 			if (gamemode_status >= 0) {
-				print_verbose("GameMode: Enabled successfully.");
+				PRINT_VERBOSE("GameMode: Enabled successfully.");
 			} else {
 				WARN_VERBOSE("GameMode: Failed to enable (check if the daemon is installed and running).");
 			}
 		} else {
-			print_verbose("GameMode: Not enabling, as the project has it disabled.");
+			PRINT_VERBOSE("GameMode: Not enabling, as the project has it disabled.");
 		}
 	}
 #endif
@@ -1378,7 +1378,7 @@ OS_LinuxBSD::OS_LinuxBSD() {
 		bool ver_ok = false;
 		int version = FcGetVersion();
 		ver_ok = ((version / 100 / 100) == 2 && (version / 100 % 100) >= 11) || ((version / 100 / 100) > 2); // 2.11.0
-		print_verbose(vformat("FontConfig %d.%d.%d detected.", version / 100 / 100, version / 100 % 100, version % 100));
+		PRINT_VERBOSE(vformat("FontConfig %d.%d.%d detected.", version / 100 / 100, version / 100 % 100, version % 100));
 		if (!ver_ok) {
 			font_config_initialized = false;
 		}

--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -48,11 +48,11 @@ void TTS_Linux::speech_init_thread_func(void *p_userdata) {
 		int dylibloader_verbose = 0;
 #endif
 		if (initialize_speechd(dylibloader_verbose) != 0) {
-			print_verbose("Text-to-Speech: Cannot load Speech Dispatcher library!");
+			PRINT_VERBOSE("Text-to-Speech: Cannot load Speech Dispatcher library!");
 		} else {
 			if (!spd_open || !spd_set_notification_on || !spd_list_synthesis_voices || !free_spd_voices || !spd_set_synthesis_voice || !spd_set_volume || !spd_set_voice_pitch || !spd_set_voice_rate || !spd_set_data_mode || !spd_say || !spd_pause || !spd_resume || !spd_cancel) {
 				// There's no API to check version, check if functions are available instead.
-				print_verbose("Text-to-Speech: Unsupported Speech Dispatcher library version!");
+				PRINT_VERBOSE("Text-to-Speech: Unsupported Speech Dispatcher library version!");
 				return;
 			}
 #else
@@ -73,9 +73,9 @@ void TTS_Linux::speech_init_thread_func(void *p_userdata) {
 				spd_set_notification_on(tts->synth, SPD_END);
 				spd_set_notification_on(tts->synth, SPD_CANCEL);
 
-				print_verbose("Text-to-Speech: Speech Dispatcher initialized.");
+				PRINT_VERBOSE("Text-to-Speech: Speech Dispatcher initialized.");
 			} else {
-				print_verbose("Text-to-Speech: Cannot initialize Speech Dispatcher synthesizer!");
+				PRINT_VERBOSE("Text-to-Speech: Cannot initialize Speech Dispatcher synthesizer!");
 			}
 		}
 	}

--- a/platform/linuxbsd/wayland/detect_prime_egl.cpp
+++ b/platform/linuxbsd/wayland/detect_prime_egl.cpp
@@ -36,7 +36,7 @@
 #include "core/core_globals.h"
 #include "core/string/print_string.h"
 #include "core/string/ustring.h"
-#include "core/variant/variant.h" // IWYU pragma: keep. Needed for print_verbose.
+#include "core/variant/variant.h" // IWYU pragma: keep. Needed for PRINT_VERBOSE.
 
 #ifdef GLAD_ENABLED
 #include <platform_gl.h>
@@ -57,7 +57,7 @@
 void DetectPrimeEGL::create_context(EGLenum p_platform_enum) {
 #if defined(GLAD_ENABLED)
 	if (!gladLoaderLoadEGL(nullptr)) {
-		print_verbose("Unable to load EGL, GPU detection skipped.");
+		PRINT_VERBOSE("Unable to load EGL, GPU detection skipped.");
 		quick_exit(1);
 	}
 #endif
@@ -81,7 +81,7 @@ void DetectPrimeEGL::create_context(EGLenum p_platform_enum) {
 
 #if defined(GLAD_ENABLED)
 	if (!gladLoaderLoadEGL(egl_display)) {
-		print_verbose("Unable to load EGL, GPU detection skipped.");
+		PRINT_VERBOSE("Unable to load EGL, GPU detection skipped.");
 		quick_exit(1);
 	}
 #endif
@@ -111,7 +111,7 @@ void DetectPrimeEGL::create_context(EGLenum p_platform_enum) {
 
 	egl_context = eglCreateContext(egl_display, egl_config, EGL_NO_CONTEXT, context_attribs);
 	if (egl_context == EGL_NO_CONTEXT) {
-		print_verbose("Unable to create an EGL context, GPU detection skipped.");
+		PRINT_VERBOSE("Unable to create an EGL context, GPU detection skipped.");
 		quick_exit(1);
 	}
 
@@ -133,7 +133,7 @@ int DetectPrimeEGL::detect_prime(EGLenum p_platform_enum) {
 		int fdset[2];
 
 		if (pipe(fdset) == -1) {
-			print_verbose("Failed to pipe(), using default GPU");
+			PRINT_VERBOSE("Failed to pipe(), using default GPU");
 			return 0;
 		}
 
@@ -193,7 +193,7 @@ int DetectPrimeEGL::detect_prime(EGLenum p_platform_enum) {
 			memcpy(&string[vendor_len], renderer, renderer_len);
 
 			if (write(fdset[1], string, vendor_len + renderer_len) == -1) {
-				print_verbose("Couldn't write vendor/renderer string.");
+				PRINT_VERBOSE("Couldn't write vendor/renderer string.");
 			}
 			close(fdset[1]);
 
@@ -207,7 +207,7 @@ int DetectPrimeEGL::detect_prime(EGLenum p_platform_enum) {
 	int priority = 0;
 
 	if (vendors[0] == vendors[1]) {
-		print_verbose("Only one GPU found, using default.");
+		PRINT_VERBOSE("Only one GPU found, using default.");
 		return 0;
 	}
 
@@ -226,12 +226,12 @@ int DetectPrimeEGL::detect_prime(EGLenum p_platform_enum) {
 		}
 	}
 
-	print_verbose("Found renderers:");
+	PRINT_VERBOSE("Found renderers:");
 	for (int i = 0; i < 4; ++i) {
-		print_verbose("Renderer " + itos(i) + ": " + renderers[i] + " with priority: " + itos(priorities[i]));
+		PRINT_VERBOSE("Renderer " + itos(i) + ": " + renderers[i] + " with priority: " + itos(priorities[i]));
 	}
 
-	print_verbose("Using renderer: " + renderers[preferred]);
+	PRINT_VERBOSE("Using renderer: " + renderers[preferred]);
 	return preferred;
 }
 

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -34,7 +34,7 @@
 
 #define WAYLAND_DISPLAY_SERVER_DEBUG_LOGS_ENABLED
 #ifdef WAYLAND_DISPLAY_SERVER_DEBUG_LOGS_ENABLED
-#define DEBUG_LOG_WAYLAND(...) print_verbose(__VA_ARGS__)
+#define DEBUG_LOG_WAYLAND(...) PRINT_VERBOSE(__VA_ARGS__)
 #else
 #define DEBUG_LOG_WAYLAND(...)
 #endif
@@ -593,7 +593,7 @@ String DisplayServerWayland::clipboard_get() const {
 
 	for (String mime : text_mimes) {
 		if (wayland_thread.selection_has_mime(mime)) {
-			print_verbose(vformat("Selecting media type \"%s\" from offered types.", mime));
+			PRINT_VERBOSE(vformat("Selecting media type \"%s\" from offered types.", mime));
 			data = wayland_thread.selection_get_mime(mime);
 			break;
 		}
@@ -668,7 +668,7 @@ String DisplayServerWayland::clipboard_get_primary() const {
 
 	for (String mime : text_mimes) {
 		if (wayland_thread.primary_has_mime(mime)) {
-			print_verbose(vformat("Selecting media type \"%s\" from offered types.", mime));
+			PRINT_VERBOSE(vformat("Selecting media type \"%s\" from offered types.", mime));
 			data = wayland_thread.primary_get_mime(mime);
 			break;
 		}
@@ -1473,7 +1473,7 @@ void DisplayServerWayland::window_set_vsync_mode(DisplayServerEnums::VSyncMode p
 		wd.emulate_vsync = (!wayland_thread.is_fifo_available() && rendering_context->window_get_vsync_mode(p_window_id) == DisplayServerEnums::VSYNC_ENABLED);
 
 		if (wd.emulate_vsync) {
-			print_verbose("VSYNC: manually throttling frames using MAILBOX.");
+			PRINT_VERBOSE("VSYNC: manually throttling frames using MAILBOX.");
 			rendering_context->window_set_vsync_mode(p_window_id, DisplayServerEnums::VSYNC_MAILBOX);
 		}
 	}
@@ -1488,7 +1488,7 @@ void DisplayServerWayland::window_set_vsync_mode(DisplayServerEnums::VSyncMode p
 		wd.emulate_vsync = egl_manager->is_using_vsync();
 
 		if (wd.emulate_vsync) {
-			print_verbose("VSYNC: manually throttling frames with swap delay 0.");
+			PRINT_VERBOSE("VSYNC: manually throttling frames with swap delay 0.");
 			egl_manager->set_use_vsync(false);
 		}
 	}
@@ -1799,7 +1799,7 @@ Error DisplayServerWayland::embed_process(DisplayServerEnums::WindowID p_window,
 		scaled_rect.position = WaylandThread::scale_vector2i(scaled_rect.position, 1 / window_scale);
 		scaled_rect.size = WaylandThread::scale_vector2i(scaled_rect.size, 1 / window_scale);
 
-		print_verbose(vformat("Scaling embedded rect down by %f from %s to %s.", window_scale, p_rect, scaled_rect));
+		PRINT_VERBOSE(vformat("Scaling embedded rect down by %f from %s to %s.", window_scale, p_rect, scaled_rect));
 
 		godot_embedded_client_set_embedded_window_rect(embedded_client, scaled_rect.position.x, scaled_rect.position.y, scaled_rect.size.width, scaled_rect.size.height);
 	} else {
@@ -2394,7 +2394,7 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 					getenv("PRIMUS_LOAD_GLOBAL") ||
 					getenv("BUMBLEBEE_SOCKET") ||
 					getenv("__NV_PRIME_RENDER_OFFLOAD")) {
-				print_verbose("Optirun/primusrun detected. Skipping GPU detection");
+				PRINT_VERBOSE("Optirun/primusrun detected. Skipping GPU detection");
 				prime_idx = 0;
 			}
 
@@ -2408,14 +2408,14 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 				for (int i = 0; i < libraries.size(); ++i) {
 					if (FileAccess::exists(libraries[i] + "/libGL.so.1") ||
 							FileAccess::exists(libraries[i] + "/libGL.so")) {
-						print_verbose("Custom libGL override detected. Skipping GPU detection");
+						PRINT_VERBOSE("Custom libGL override detected. Skipping GPU detection");
 						prime_idx = 0;
 					}
 				}
 			}
 
 			if (prime_idx == -1) {
-				print_verbose("Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.");
+				PRINT_VERBOSE("Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.");
 				prime_idx = DetectPrimeEGL::detect_prime(EGL_PLATFORM_WAYLAND_KHR);
 			}
 
@@ -2535,7 +2535,7 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 	bool dbus_ok = true;
 #ifdef SOWRAP_ENABLED
 	if (initialize_dbus(dylibloader_verbose) != 0) {
-		print_verbose("Failed to load DBus library!");
+		PRINT_VERBOSE("Failed to load DBus library!");
 		dbus_ok = false;
 	}
 #endif
@@ -2546,9 +2546,9 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 		int version_rev = 0;
 		dbus_get_version(&version_major, &version_minor, &version_rev);
 		ver_ok = (version_major == 1 && version_minor >= 10) || (version_major > 1); // 1.10.0
-		print_verbose(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
+		PRINT_VERBOSE(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
 		if (!ver_ok) {
-			print_verbose("Unsupported DBus library version!");
+			PRINT_VERBOSE("Unsupported DBus library version!");
 			dbus_ok = false;
 		}
 	}

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -34,7 +34,7 @@
 
 #define WAYLAND_DISPLAY_SERVER_DEBUG_LOGS_ENABLED
 #ifdef WAYLAND_DISPLAY_SERVER_DEBUG_LOGS_ENABLED
-#define DEBUG_LOG_WAYLAND(...) print_verbose(__VA_ARGS__)
+#define DEBUG_LOG_WAYLAND(...) PRINT_VERBOSE(__VA_ARGS__)
 #else
 #define DEBUG_LOG_WAYLAND(...)
 #endif
@@ -593,7 +593,7 @@ String DisplayServerWayland::clipboard_get() const {
 
 	for (String mime : text_mimes) {
 		if (wayland_thread.selection_has_mime(mime)) {
-			print_verbose(vformat("Selecting media type \"%s\" from offered types.", mime));
+			PRINT_VERBOSE(vformat("Selecting media type \"%s\" from offered types.", mime));
 			data = wayland_thread.selection_get_mime(mime);
 			break;
 		}
@@ -668,7 +668,7 @@ String DisplayServerWayland::clipboard_get_primary() const {
 
 	for (String mime : text_mimes) {
 		if (wayland_thread.primary_has_mime(mime)) {
-			print_verbose(vformat("Selecting media type \"%s\" from offered types.", mime));
+			PRINT_VERBOSE(vformat("Selecting media type \"%s\" from offered types.", mime));
 			data = wayland_thread.primary_get_mime(mime);
 			break;
 		}
@@ -1473,7 +1473,7 @@ void DisplayServerWayland::window_set_vsync_mode(DisplayServerEnums::VSyncMode p
 		wd.emulate_vsync = (!wayland_thread.is_fifo_available() && rendering_context->window_get_vsync_mode(p_window_id) == DisplayServerEnums::VSYNC_ENABLED);
 
 		if (wd.emulate_vsync) {
-			print_verbose("VSYNC: manually throttling frames using MAILBOX.");
+			PRINT_VERBOSE("VSYNC: manually throttling frames using MAILBOX.");
 			rendering_context->window_set_vsync_mode(p_window_id, DisplayServerEnums::VSYNC_MAILBOX);
 		}
 	}
@@ -1488,7 +1488,7 @@ void DisplayServerWayland::window_set_vsync_mode(DisplayServerEnums::VSyncMode p
 		wd.emulate_vsync = egl_manager->is_using_vsync();
 
 		if (wd.emulate_vsync) {
-			print_verbose("VSYNC: manually throttling frames with swap delay 0.");
+			PRINT_VERBOSE("VSYNC: manually throttling frames with swap delay 0.");
 			egl_manager->set_use_vsync(false);
 		}
 	}
@@ -1798,7 +1798,7 @@ Error DisplayServerWayland::embed_process(DisplayServerEnums::WindowID p_window,
 		scaled_rect.position = WaylandThread::scale_vector2i(scaled_rect.position, 1 / window_scale);
 		scaled_rect.size = WaylandThread::scale_vector2i(scaled_rect.size, 1 / window_scale);
 
-		print_verbose(vformat("Scaling embedded rect down by %f from %s to %s.", window_scale, p_rect, scaled_rect));
+		PRINT_VERBOSE(vformat("Scaling embedded rect down by %f from %s to %s.", window_scale, p_rect, scaled_rect));
 
 		godot_embedded_client_set_embedded_window_rect(embedded_client, scaled_rect.position.x, scaled_rect.position.y, scaled_rect.size.width, scaled_rect.size.height);
 	} else {
@@ -2393,7 +2393,7 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 					getenv("PRIMUS_LOAD_GLOBAL") ||
 					getenv("BUMBLEBEE_SOCKET") ||
 					getenv("__NV_PRIME_RENDER_OFFLOAD")) {
-				print_verbose("Optirun/primusrun detected. Skipping GPU detection");
+				PRINT_VERBOSE("Optirun/primusrun detected. Skipping GPU detection");
 				prime_idx = 0;
 			}
 
@@ -2407,14 +2407,14 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 				for (int i = 0; i < libraries.size(); ++i) {
 					if (FileAccess::exists(libraries[i] + "/libGL.so.1") ||
 							FileAccess::exists(libraries[i] + "/libGL.so")) {
-						print_verbose("Custom libGL override detected. Skipping GPU detection");
+						PRINT_VERBOSE("Custom libGL override detected. Skipping GPU detection");
 						prime_idx = 0;
 					}
 				}
 			}
 
 			if (prime_idx == -1) {
-				print_verbose("Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.");
+				PRINT_VERBOSE("Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.");
 				prime_idx = DetectPrimeEGL::detect_prime(EGL_PLATFORM_WAYLAND_KHR);
 			}
 
@@ -2534,7 +2534,7 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 	bool dbus_ok = true;
 #ifdef SOWRAP_ENABLED
 	if (initialize_dbus(dylibloader_verbose) != 0) {
-		print_verbose("Failed to load DBus library!");
+		PRINT_VERBOSE("Failed to load DBus library!");
 		dbus_ok = false;
 	}
 #endif
@@ -2545,9 +2545,9 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 		int version_rev = 0;
 		dbus_get_version(&version_major, &version_minor, &version_rev);
 		ver_ok = (version_major == 1 && version_minor >= 10) || (version_major > 1); // 1.10.0
-		print_verbose(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
+		PRINT_VERBOSE(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
 		if (!ver_ok) {
-			print_verbose("Unsupported DBus library version!");
+			PRINT_VERBOSE("Unsupported DBus library version!");
 			dbus_ok = false;
 		}
 	}

--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -3212,12 +3212,12 @@ Error WaylandEmbedder::init(bool debug) {
 		String test_socket_path = runtime_dir_path + "/godot-wayland-" + itos(socket_id);
 		String test_socket_lock_path = test_socket_path + ".lock";
 
-		print_verbose(vformat("Trying to get socket %s", test_socket_path));
-		print_verbose(vformat("Opening lock %s", test_socket_lock_path));
+		PRINT_VERBOSE(vformat("Trying to get socket %s", test_socket_path));
+		PRINT_VERBOSE(vformat("Opening lock %s", test_socket_lock_path));
 		int test_lock_fd = open(test_socket_lock_path.utf8().get_data(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
 
 		if (flock(test_lock_fd, LOCK_EX | LOCK_NB) == -1) {
-			print_verbose(vformat("Can't lock %s", test_socket_lock_path));
+			PRINT_VERBOSE(vformat("Can't lock %s", test_socket_lock_path));
 			close(test_lock_fd);
 			++socket_id;
 			continue;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -59,7 +59,7 @@
 
 #define WAYLAND_THREAD_DEBUG_LOGS_ENABLED
 #ifdef WAYLAND_THREAD_DEBUG_LOGS_ENABLED
-#define DEBUG_LOG_WAYLAND_THREAD(...) print_verbose(__VA_ARGS__)
+#define DEBUG_LOG_WAYLAND_THREAD(...) PRINT_VERBOSE(__VA_ARGS__)
 #else
 #define DEBUG_LOG_WAYLAND_THREAD(...)
 #endif
@@ -305,7 +305,7 @@ Ref<InputEventKey> WaylandThread::_seat_state_get_unstuck_key_event(SeatState *p
 	if (p_pressed) {
 		Key *old_key = p_ss->pressed_keycodes.getptr(p_keycode);
 		if (old_key != nullptr && *old_key != p_key) {
-			print_verbose(vformat("%s and %s have same keycode. Generating release event for %s", keycode_get_string(*old_key), keycode_get_string(p_key), keycode_get_string(*old_key)));
+			PRINT_VERBOSE(vformat("%s and %s have same keycode. Generating release event for %s", keycode_get_string(*old_key), keycode_get_string(p_key), keycode_get_string(*old_key)));
 			event = _seat_state_get_key_event(p_ss, p_keycode, false);
 			if (event.is_valid()) {
 				event->set_keycode(*old_key);
@@ -439,7 +439,7 @@ bool WaylandThread::_load_cursor_theme(int p_cursor_size) {
 		cursor_theme_name = "default";
 	}
 
-	print_verbose(vformat("Loading cursor theme \"%s\" size %d.", cursor_theme_name, p_cursor_size));
+	PRINT_VERBOSE(vformat("Loading cursor theme \"%s\" size %d.", cursor_theme_name, p_cursor_size));
 
 	wl_cursor_theme = wl_cursor_theme_load(cursor_theme_name.utf8().get_data(), p_cursor_size, registry.wl_shm);
 
@@ -496,7 +496,7 @@ bool WaylandThread::_load_cursor_theme(int p_cursor_size) {
 			wl_cursors[i] = cursor;
 		} else {
 			wl_cursors[i] = nullptr;
-			print_verbose("Failed loading cursor: " + String(cursor_names[i]));
+			PRINT_VERBOSE("Failed loading cursor: " + String(cursor_names[i]));
 		}
 	}
 
@@ -508,7 +508,7 @@ void WaylandThread::_update_scale(int p_scale) {
 		return;
 	}
 
-	print_verbose(vformat("Bumping cursor scale to %d", p_scale));
+	PRINT_VERBOSE(vformat("Bumping cursor scale to %d", p_scale));
 
 	// There's some display that's bigger than the cache, let's update it.
 	cursor_scale = p_scale;
@@ -5021,7 +5021,7 @@ void WaylandThread::window_set_borderless(DisplayServerEnums::WindowID p_window_
 		// possible to destroy the frame more than once, by setting the visibility
 		// to false multiple times and thus crashing.
 		if (visible_current != visible_target) {
-			print_verbose(vformat("Setting libdecor frame visibility to %s", visible_target));
+			PRINT_VERBOSE(vformat("Setting libdecor frame visibility to %s", visible_target));
 			libdecor_frame_set_visibility(ws.libdecor_frame, visible_target);
 		}
 	}
@@ -5545,12 +5545,12 @@ Error WaylandThread::init() {
 	bool embedder_enabled = true;
 
 	if (OS::get_singleton()->get_environment("GODOT_WAYLAND_DISABLE_EMBEDDER") == "1") {
-		print_verbose("Disabling Wayland embedder as per GODOT_WAYLAND_DISABLE_EMBEDDER.");
+		PRINT_VERBOSE("Disabling Wayland embedder as per GODOT_WAYLAND_DISABLE_EMBEDDER.");
 		embedder_enabled = false;
 	}
 
 	if (embedder_enabled && Engine::get_singleton()->is_editor_hint() && !Engine::get_singleton()->is_project_manager_hint()) {
-		print_verbose("Initializing Wayland embedder.");
+		PRINT_VERBOSE("Initializing Wayland embedder.");
 		bool embedder_debug = OS::get_singleton()->get_environment("GODOT_WAYLAND_EMBEDDER_DEBUG") == "1";
 		Error embedder_status = embedder.init(embedder_debug);
 		ERR_FAIL_COND_V_MSG(embedder_status != OK, ERR_CANT_CREATE, "Can't initialize Wayland embedder.");
@@ -5574,10 +5574,10 @@ Error WaylandThread::init() {
 	}
 
 	if (embedder_socket_path.is_empty()) {
-		print_verbose("Connecting to the default Wayland display.");
+		PRINT_VERBOSE("Connecting to the default Wayland display.");
 		wl_display = wl_display_connect(nullptr);
 	} else {
-		print_verbose("Connecting to the Wayland embedder display.");
+		PRINT_VERBOSE("Connecting to the Wayland embedder display.");
 		wl_display = wl_display_connect(embedder_socket_path.utf8().get_data());
 	}
 
@@ -5597,12 +5597,12 @@ Error WaylandThread::init() {
 #endif // SOWRAP_ENABLED
 
 	if (skip_libdecor) {
-		print_verbose("Skipping libdecor check because GODOT_WAYLAND_DISABLE_LIBDECOR is set to 1.");
+		PRINT_VERBOSE("Skipping libdecor check because GODOT_WAYLAND_DISABLE_LIBDECOR is set to 1.");
 	} else {
 		if (libdecor_found) {
 			libdecor_context = libdecor_new(wl_display, (struct libdecor_interface *)&libdecor_interface);
 		} else {
-			print_verbose("libdecor not found. Client-side decorations disabled.");
+			PRINT_VERBOSE("libdecor not found. Client-side decorations disabled.");
 		}
 	}
 #endif // LIBDECOR_ENABLED
@@ -5660,7 +5660,7 @@ Error WaylandThread::init() {
 
 	unscaled_cursor_size = OS::get_singleton()->get_environment("XCURSOR_SIZE").to_int();
 	if (unscaled_cursor_size <= 0) {
-		print_verbose("Detected invalid cursor size preference, defaulting to 24.");
+		PRINT_VERBOSE("Detected invalid cursor size preference, defaulting to 24.");
 		unscaled_cursor_size = 24;
 	}
 
@@ -6290,7 +6290,7 @@ void WaylandThread::destroy() {
 		// for cleanup.
 		LocalVector<DisplayServerEnums::WindowID> window_ids;
 		for (KeyValue<DisplayServerEnums::WindowID, WindowState> &pair : windows) {
-			print_verbose(vformat("Window %d still allocated", pair.key));
+			PRINT_VERBOSE(vformat("Window %d still allocated", pair.key));
 			window_ids.push_back(pair.key);
 		}
 

--- a/platform/linuxbsd/x11/detect_prime_x11.cpp
+++ b/platform/linuxbsd/x11/detect_prime_x11.cpp
@@ -65,7 +65,7 @@ typedef GLXContext (*GLXCREATECONTEXTATTRIBSARBPROC)(Display *, GLXFBConfig, GLX
 int silent_error_handler(Display *display, XErrorEvent *error) {
 	static char message[1024];
 	XGetErrorText(display, error->error_code, message, sizeof(message));
-	print_verbose(vformat("XServer error: %s"
+	PRINT_VERBOSE(vformat("XServer error: %s"
 						  "\n   Major opcode of failed request: %d"
 						  "\n   Serial number of failed request: %d"
 						  "\n   Current serial number in output stream: %d",
@@ -95,7 +95,7 @@ void DetectPrimeX11::create_context() {
 	};
 
 	if (gladLoaderLoadGLX(x11_display, XScreenNumberOfScreen(XDefaultScreenOfDisplay(x11_display))) == 0) {
-		print_verbose("Unable to load GLX, GPU detection skipped.");
+		PRINT_VERBOSE("Unable to load GLX, GPU detection skipped.");
 		quick_exit(1);
 	}
 	int fbcount;
@@ -152,7 +152,7 @@ int DetectPrimeX11::detect_prime() {
 		int fdset[2];
 
 		if (pipe(fdset) == -1) {
-			print_verbose("Failed to pipe(), using default GPU");
+			PRINT_VERBOSE("Failed to pipe(), using default GPU");
 			return 0;
 		}
 
@@ -202,7 +202,7 @@ int DetectPrimeX11::detect_prime() {
 
 			PFNGLGETSTRINGPROC glGetString = (PFNGLGETSTRINGPROC)glXGetProcAddressARB((GLubyte *)"glGetString");
 			if (!glGetString) {
-				print_verbose("Unable to get glGetString, GPU detection skipped.");
+				PRINT_VERBOSE("Unable to get glGetString, GPU detection skipped.");
 				quick_exit(1);
 			}
 
@@ -220,7 +220,7 @@ int DetectPrimeX11::detect_prime() {
 			memcpy(&string[vendor_len], renderer, renderer_len);
 
 			if (write(fdset[1], string, vendor_len + renderer_len) == -1) {
-				print_verbose("Couldn't write vendor/renderer string.");
+				PRINT_VERBOSE("Couldn't write vendor/renderer string.");
 			}
 			close(fdset[1]);
 
@@ -234,7 +234,7 @@ int DetectPrimeX11::detect_prime() {
 	int priority = 0;
 
 	if (vendors[0] == vendors[1]) {
-		print_verbose("Only one GPU found, using default.");
+		PRINT_VERBOSE("Only one GPU found, using default.");
 		return 0;
 	}
 
@@ -253,12 +253,12 @@ int DetectPrimeX11::detect_prime() {
 		}
 	}
 
-	print_verbose("Found renderers:");
+	PRINT_VERBOSE("Found renderers:");
 	for (int i = 0; i < 2; ++i) {
-		print_verbose("Renderer " + itos(i) + ": " + renderers[i] + " with priority: " + itos(priorities[i]));
+		PRINT_VERBOSE("Renderer " + itos(i) + ": " + renderers[i] + " with priority: " + itos(priorities[i]));
 	}
 
-	print_verbose("Using renderer: " + renderers[preferred]);
+	PRINT_VERBOSE("Using renderer: " + renderers[preferred]);
 	return preferred;
 }
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -266,10 +266,10 @@ void DisplayServerX11::_update_real_mouse_position(const WindowData &wd) {
 bool DisplayServerX11::_refresh_device_info() {
 	int event_base, error_base;
 
-	print_verbose("XInput: Refreshing devices.");
+	PRINT_VERBOSE("XInput: Refreshing devices.");
 
 	if (!XQueryExtension(x11_display, "XInputExtension", &xi.opcode, &event_base, &error_base)) {
-		print_verbose("XInput extension not available. Please upgrade your distribution.");
+		PRINT_VERBOSE("XInput extension not available. Please upgrade your distribution.");
 		return false;
 	}
 
@@ -277,13 +277,13 @@ bool DisplayServerX11::_refresh_device_info() {
 	int xi_minor_query = XINPUT_CLIENT_VERSION_MINOR;
 
 	if (XIQueryVersion(x11_display, &xi_major_query, &xi_minor_query) != Success) {
-		print_verbose(vformat("XInput 2 not available (server supports %d.%d).", xi_major_query, xi_minor_query));
+		PRINT_VERBOSE(vformat("XInput 2 not available (server supports %d.%d).", xi_major_query, xi_minor_query));
 		xi.opcode = 0;
 		return false;
 	}
 
 	if (xi_major_query < XINPUT_CLIENT_VERSION_MAJOR || (xi_major_query == XINPUT_CLIENT_VERSION_MAJOR && xi_minor_query < XINPUT_CLIENT_VERSION_MINOR)) {
-		print_verbose(vformat("XInput %d.%d not available (server supports %d.%d). Touch input unavailable.",
+		PRINT_VERBOSE(vformat("XInput %d.%d not available (server supports %d.%d). Touch input unavailable.",
 				XINPUT_CLIENT_VERSION_MAJOR, XINPUT_CLIENT_VERSION_MINOR, xi_major_query, xi_minor_query));
 	}
 
@@ -351,7 +351,7 @@ bool DisplayServerX11::_refresh_device_info() {
 		}
 		if (direct_touch) {
 			xi.touch_devices.push_back(dev->deviceid);
-			print_verbose("XInput: Using touch device: " + String(dev->name));
+			PRINT_VERBOSE("XInput: Using touch device: " + String(dev->name));
 		}
 		if (absolute_mode) {
 			// If no resolution was reported, use the min/max ranges.
@@ -362,7 +362,7 @@ bool DisplayServerX11::_refresh_device_info() {
 				resolution_y = (abs_y_max - abs_y_min) * abs_resolution_range_mult;
 			}
 			xi.absolute_devices[dev->deviceid] = Vector2(abs_resolution_mult / resolution_x, abs_resolution_mult / resolution_y);
-			print_verbose("XInput: Absolute pointing device: " + String(dev->name));
+			PRINT_VERBOSE("XInput: Absolute pointing device: " + String(dev->name));
 		}
 
 		xi.pressure = 0;
@@ -375,7 +375,7 @@ bool DisplayServerX11::_refresh_device_info() {
 	XIFreeDeviceInfo(info);
 #ifdef TOUCH_ENABLED
 	if (!xi.touch_devices.size()) {
-		print_verbose("XInput: No touch devices found.");
+		PRINT_VERBOSE("XInput: No touch devices found.");
 	}
 #endif
 
@@ -847,7 +847,7 @@ String DisplayServerX11::_clipboard_get_impl(Atom p_source, Window x11_window, A
 							success = true;
 						}
 					} else {
-						print_verbose("Failed to get selection data chunk.");
+						PRINT_VERBOSE("Failed to get selection data chunk.");
 						done = true;
 					}
 
@@ -874,7 +874,7 @@ String DisplayServerX11::_clipboard_get_impl(Atom p_source, Window x11_window, A
 			if (result == Success) {
 				ret.append_utf8((const char *)data);
 			} else {
-				print_verbose("Failed to get selection data.");
+				PRINT_VERBOSE("Failed to get selection data.");
 			}
 
 			if (data) {
@@ -933,7 +933,7 @@ Atom DisplayServerX11::_clipboard_get_image_target(Atom p_source, Window x11_win
 			if (result == Success) {
 				atom_count = len;
 			} else {
-				print_verbose("Failed to get selection data.");
+				PRINT_VERBOSE("Failed to get selection data.");
 				return None;
 			}
 		} else {
@@ -1092,7 +1092,7 @@ Ref<Image> DisplayServerX11::clipboard_get_image() const {
 							success = true;
 						}
 					} else {
-						print_verbose("Failed to get selection data chunk.");
+						PRINT_VERBOSE("Failed to get selection data chunk.");
 						done = true;
 					}
 
@@ -1125,7 +1125,7 @@ Ref<Image> DisplayServerX11::clipboard_get_image() const {
 				ret.instantiate();
 				PNGDriverCommon::png_to_image((uint8_t *)data, bytes_left, false, ret);
 			} else {
-				print_verbose("Failed to get selection data.");
+				PRINT_VERBOSE("Failed to get selection data.");
 			}
 
 			if (data) {
@@ -4214,7 +4214,7 @@ void DisplayServerX11::_handle_key_event(DisplayServerEnums::WindowID p_window, 
 	// know Mod1 was ALT and Mod4 was META (applekey/winkey)
 	// just tried Mods until i found them.
 
-	//print_verbose("mod1: "+itos(xkeyevent->state&Mod1Mask)+" mod 5: "+itos(xkeyevent->state&Mod5Mask));
+	//PRINT_VERBOSE("mod1: "+itos(xkeyevent->state&Mod1Mask)+" mod 5: "+itos(xkeyevent->state&Mod5Mask));
 
 	Ref<InputEventKey> k;
 	k.instantiate();
@@ -4377,7 +4377,7 @@ Atom DisplayServerX11::_process_selection_request_target(Atom p_target, Window p
 		return p_property;
 	} else {
 		char *target_name = XGetAtomName(x11_display, p_target);
-		print_verbose(vformat("Target '%s' not supported.", target_name));
+		PRINT_VERBOSE(vformat("Target '%s' not supported.", target_name));
 		if (target_name) {
 			XFree(target_name);
 		}
@@ -4512,7 +4512,7 @@ void DisplayServerX11::_xim_preedit_caret_callback(::XIM xim, ::XPointer client_
 
 void DisplayServerX11::_xim_destroy_callback(::XIM im, ::XPointer client_data,
 		::XPointer call_data) {
-	print_verbose("Input method stopped.");
+	PRINT_VERBOSE("Input method stopped.");
 
 	DisplayServerX11 *ds = reinterpret_cast<DisplayServerX11 *>(client_data);
 	ds->xim = nullptr;
@@ -6774,7 +6774,7 @@ static ::XIMStyle _get_best_xim_style(const ::XIMStyle &p_style_a, const ::XIMSt
 
 void DisplayServerX11::_xim_instantiate_callback(::Display *display, ::XPointer client_data,
 		::XPointer call_data) {
-	print_verbose("Input method started.");
+	PRINT_VERBOSE("Input method started.");
 
 	DisplayServerX11 *ds = reinterpret_cast<DisplayServerX11 *>(client_data);
 
@@ -6857,12 +6857,12 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 	xkb_loaded_v05p = xkb_loaded;
 	if (!xkb_context_new || !xkb_compose_table_new_from_locale || !xkb_compose_table_unref || !xkb_context_unref || !xkb_compose_state_feed || !xkb_compose_state_unref || !xkb_compose_state_new || !xkb_compose_state_get_status || !xkb_compose_state_get_utf8) {
 		xkb_loaded_v05p = false;
-		print_verbose("Detected XKBcommon library version older than 0.5, dead key composition and Unicode key labels disabled.");
+		PRINT_VERBOSE("Detected XKBcommon library version older than 0.5, dead key composition and Unicode key labels disabled.");
 	}
 	xkb_loaded_v08p = xkb_loaded;
 	if (!xkb_keysym_to_utf32 || !xkb_keysym_to_upper) {
 		xkb_loaded_v08p = false;
-		print_verbose("Detected XKBcommon library version older than 0.8, Unicode key labels disabled.");
+		PRINT_VERBOSE("Detected XKBcommon library version older than 0.8, Unicode key labels disabled.");
 	}
 #endif
 	if (initialize_xext(dylibloader_verbose) != 0) {
@@ -6949,10 +6949,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 0;
 		int version_minor = 0;
 		int rc = XShapeQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xshape %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xshape %d.%d detected.", version_major, version_minor));
 		if (rc != 1 || version_major < 1) {
 			xshaped_ext_ok = false;
-			print_verbose("Unsupported Xshape library version.");
+			PRINT_VERBOSE("Unsupported Xshape library version.");
 		}
 	}
 
@@ -6960,10 +6960,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 0;
 		int version_minor = 0;
 		int rc = XineramaQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xinerama %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xinerama %d.%d detected.", version_major, version_minor));
 		if (rc != 1 || version_major < 1) {
 			xinerama_ext_ok = false;
-			print_verbose("Unsupported Xinerama library version.");
+			PRINT_VERBOSE("Unsupported Xinerama library version.");
 		}
 	}
 
@@ -6971,10 +6971,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 0;
 		int version_minor = 0;
 		int rc = XRRQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xrandr %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xrandr %d.%d detected.", version_major, version_minor));
 		if (rc != 1 || (version_major == 1 && version_minor < 3) || (version_major < 1)) {
 			xrandr_ext_ok = false;
-			print_verbose("Unsupported Xrandr library version.");
+			PRINT_VERBOSE("Unsupported Xrandr library version.");
 		}
 	}
 
@@ -6982,7 +6982,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 0;
 		int version_minor = 0;
 		int rc = XRenderQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xrender %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xrender %d.%d detected.", version_major, version_minor));
 		if (rc != 1 || (version_major == 0 && version_minor < 11)) {
 			ERR_PRINT("Unsupported Xrender library version.");
 			r_error = ERR_UNAVAILABLE;
@@ -6995,7 +6995,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 2; // Report 2.2 as supported by engine, but should work with 2.1 or 2.0 library as well.
 		int version_minor = 2;
 		int rc = XIQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xinput %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xinput %d.%d detected.", version_major, version_minor));
 		if (rc != Success || (version_major < 2)) {
 			ERR_PRINT("Unsupported Xinput2 library version.");
 			r_error = ERR_UNAVAILABLE;
@@ -7159,7 +7159,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 					getenv("PRIMUS_libGL") ||
 					getenv("PRIMUS_LOAD_GLOBAL") ||
 					getenv("BUMBLEBEE_SOCKET")) {
-				print_verbose("Optirun/primusrun detected. Skipping GPU detection");
+				PRINT_VERBOSE("Optirun/primusrun detected. Skipping GPU detection");
 				use_prime = 0;
 			}
 
@@ -7173,14 +7173,14 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 				for (int i = 0; i < libraries.size(); ++i) {
 					if (FileAccess::exists(libraries[i] + "/libGL.so.1") ||
 							FileAccess::exists(libraries[i] + "/libGL.so")) {
-						print_verbose("Custom libGL override detected. Skipping GPU detection");
+						PRINT_VERBOSE("Custom libGL override detected. Skipping GPU detection");
 						use_prime = 0;
 					}
 				}
 			}
 
 			if (use_prime == -1) {
-				print_verbose("Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.");
+				PRINT_VERBOSE("Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.");
 				use_prime = DetectPrimeX11::detect_prime();
 			}
 
@@ -7302,7 +7302,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 	cursor_theme = XcursorGetTheme(x11_display);
 
 	if (!cursor_theme) {
-		print_verbose("XcursorGetTheme could not get cursor theme");
+		PRINT_VERBOSE("XcursorGetTheme could not get cursor theme");
 		cursor_theme = "default";
 	}
 
@@ -7385,7 +7385,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		if (cursor_img[i]) {
 			cursors[i] = XcursorImageLoadCursor(x11_display, cursor_img[i]);
 		} else {
-			print_verbose("Failed loading custom cursor: " + String(cursor_file[i]));
+			PRINT_VERBOSE("Failed loading custom cursor: " + String(cursor_file[i]));
 		}
 	}
 
@@ -7436,7 +7436,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 	bool dbus_ok = true;
 #ifdef SOWRAP_ENABLED
 	if (initialize_dbus(dylibloader_verbose) != 0) {
-		print_verbose("Failed to load DBus library!");
+		PRINT_VERBOSE("Failed to load DBus library!");
 		dbus_ok = false;
 	}
 #endif
@@ -7447,9 +7447,9 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_rev = 0;
 		dbus_get_version(&version_major, &version_minor, &version_rev);
 		ver_ok = (version_major == 1 && version_minor >= 10) || (version_major > 1); // 1.10.0
-		print_verbose(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
+		PRINT_VERBOSE(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
 		if (!ver_ok) {
-			print_verbose("Unsupported DBus library version!");
+			PRINT_VERBOSE("Unsupported DBus library version!");
 			dbus_ok = false;
 		}
 	}

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -266,10 +266,10 @@ void DisplayServerX11::_update_real_mouse_position(const WindowData &wd) {
 bool DisplayServerX11::_refresh_device_info() {
 	int event_base, error_base;
 
-	print_verbose("XInput: Refreshing devices.");
+	PRINT_VERBOSE("XInput: Refreshing devices.");
 
 	if (!XQueryExtension(x11_display, "XInputExtension", &xi.opcode, &event_base, &error_base)) {
-		print_verbose("XInput extension not available. Please upgrade your distribution.");
+		PRINT_VERBOSE("XInput extension not available. Please upgrade your distribution.");
 		return false;
 	}
 
@@ -277,13 +277,13 @@ bool DisplayServerX11::_refresh_device_info() {
 	int xi_minor_query = XINPUT_CLIENT_VERSION_MINOR;
 
 	if (XIQueryVersion(x11_display, &xi_major_query, &xi_minor_query) != Success) {
-		print_verbose(vformat("XInput 2 not available (server supports %d.%d).", xi_major_query, xi_minor_query));
+		PRINT_VERBOSE(vformat("XInput 2 not available (server supports %d.%d).", xi_major_query, xi_minor_query));
 		xi.opcode = 0;
 		return false;
 	}
 
 	if (xi_major_query < XINPUT_CLIENT_VERSION_MAJOR || (xi_major_query == XINPUT_CLIENT_VERSION_MAJOR && xi_minor_query < XINPUT_CLIENT_VERSION_MINOR)) {
-		print_verbose(vformat("XInput %d.%d not available (server supports %d.%d). Touch input unavailable.",
+		PRINT_VERBOSE(vformat("XInput %d.%d not available (server supports %d.%d). Touch input unavailable.",
 				XINPUT_CLIENT_VERSION_MAJOR, XINPUT_CLIENT_VERSION_MINOR, xi_major_query, xi_minor_query));
 	}
 
@@ -351,7 +351,7 @@ bool DisplayServerX11::_refresh_device_info() {
 		}
 		if (direct_touch) {
 			xi.touch_devices.push_back(dev->deviceid);
-			print_verbose("XInput: Using touch device: " + String(dev->name));
+			PRINT_VERBOSE("XInput: Using touch device: " + String(dev->name));
 		}
 		if (absolute_mode) {
 			// If no resolution was reported, use the min/max ranges.
@@ -362,7 +362,7 @@ bool DisplayServerX11::_refresh_device_info() {
 				resolution_y = (abs_y_max - abs_y_min) * abs_resolution_range_mult;
 			}
 			xi.absolute_devices[dev->deviceid] = Vector2(abs_resolution_mult / resolution_x, abs_resolution_mult / resolution_y);
-			print_verbose("XInput: Absolute pointing device: " + String(dev->name));
+			PRINT_VERBOSE("XInput: Absolute pointing device: " + String(dev->name));
 		}
 
 		xi.pressure = 0;
@@ -375,7 +375,7 @@ bool DisplayServerX11::_refresh_device_info() {
 	XIFreeDeviceInfo(info);
 #ifdef TOUCH_ENABLED
 	if (!xi.touch_devices.size()) {
-		print_verbose("XInput: No touch devices found.");
+		PRINT_VERBOSE("XInput: No touch devices found.");
 	}
 #endif
 
@@ -847,7 +847,7 @@ String DisplayServerX11::_clipboard_get_impl(Atom p_source, Window x11_window, A
 							success = true;
 						}
 					} else {
-						print_verbose("Failed to get selection data chunk.");
+						PRINT_VERBOSE("Failed to get selection data chunk.");
 						done = true;
 					}
 
@@ -874,7 +874,7 @@ String DisplayServerX11::_clipboard_get_impl(Atom p_source, Window x11_window, A
 			if (result == Success) {
 				ret.append_utf8((const char *)data);
 			} else {
-				print_verbose("Failed to get selection data.");
+				PRINT_VERBOSE("Failed to get selection data.");
 			}
 
 			if (data) {
@@ -933,7 +933,7 @@ Atom DisplayServerX11::_clipboard_get_image_target(Atom p_source, Window x11_win
 			if (result == Success) {
 				atom_count = len;
 			} else {
-				print_verbose("Failed to get selection data.");
+				PRINT_VERBOSE("Failed to get selection data.");
 				return None;
 			}
 		} else {
@@ -1092,7 +1092,7 @@ Ref<Image> DisplayServerX11::clipboard_get_image() const {
 							success = true;
 						}
 					} else {
-						print_verbose("Failed to get selection data chunk.");
+						PRINT_VERBOSE("Failed to get selection data chunk.");
 						done = true;
 					}
 
@@ -1125,7 +1125,7 @@ Ref<Image> DisplayServerX11::clipboard_get_image() const {
 				ret.instantiate();
 				PNGDriverCommon::png_to_image((uint8_t *)data, bytes_left, false, ret);
 			} else {
-				print_verbose("Failed to get selection data.");
+				PRINT_VERBOSE("Failed to get selection data.");
 			}
 
 			if (data) {
@@ -4262,7 +4262,7 @@ void DisplayServerX11::_handle_key_event(DisplayServerEnums::WindowID p_window, 
 	// know Mod1 was ALT and Mod4 was META (applekey/winkey)
 	// just tried Mods until i found them.
 
-	//print_verbose("mod1: "+itos(xkeyevent->state&Mod1Mask)+" mod 5: "+itos(xkeyevent->state&Mod5Mask));
+	//PRINT_VERBOSE("mod1: "+itos(xkeyevent->state&Mod1Mask)+" mod 5: "+itos(xkeyevent->state&Mod5Mask));
 
 	Ref<InputEventKey> k;
 	k.instantiate();
@@ -4425,7 +4425,7 @@ Atom DisplayServerX11::_process_selection_request_target(Atom p_target, Window p
 		return p_property;
 	} else {
 		char *target_name = XGetAtomName(x11_display, p_target);
-		print_verbose(vformat("Target '%s' not supported.", target_name));
+		PRINT_VERBOSE(vformat("Target '%s' not supported.", target_name));
 		if (target_name) {
 			XFree(target_name);
 		}
@@ -4560,7 +4560,7 @@ void DisplayServerX11::_xim_preedit_caret_callback(::XIM xim, ::XPointer client_
 
 void DisplayServerX11::_xim_destroy_callback(::XIM im, ::XPointer client_data,
 		::XPointer call_data) {
-	print_verbose("Input method stopped.");
+	PRINT_VERBOSE("Input method stopped.");
 
 	DisplayServerX11 *ds = reinterpret_cast<DisplayServerX11 *>(client_data);
 	ds->xim = nullptr;
@@ -6822,7 +6822,7 @@ static ::XIMStyle _get_best_xim_style(const ::XIMStyle &p_style_a, const ::XIMSt
 
 void DisplayServerX11::_xim_instantiate_callback(::Display *display, ::XPointer client_data,
 		::XPointer call_data) {
-	print_verbose("Input method started.");
+	PRINT_VERBOSE("Input method started.");
 
 	DisplayServerX11 *ds = reinterpret_cast<DisplayServerX11 *>(client_data);
 
@@ -6905,12 +6905,12 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 	xkb_loaded_v05p = xkb_loaded;
 	if (!xkb_context_new || !xkb_compose_table_new_from_locale || !xkb_compose_table_unref || !xkb_context_unref || !xkb_compose_state_feed || !xkb_compose_state_unref || !xkb_compose_state_new || !xkb_compose_state_get_status || !xkb_compose_state_get_utf8) {
 		xkb_loaded_v05p = false;
-		print_verbose("Detected XKBcommon library version older than 0.5, dead key composition and Unicode key labels disabled.");
+		PRINT_VERBOSE("Detected XKBcommon library version older than 0.5, dead key composition and Unicode key labels disabled.");
 	}
 	xkb_loaded_v08p = xkb_loaded;
 	if (!xkb_keysym_to_utf32 || !xkb_keysym_to_upper) {
 		xkb_loaded_v08p = false;
-		print_verbose("Detected XKBcommon library version older than 0.8, Unicode key labels disabled.");
+		PRINT_VERBOSE("Detected XKBcommon library version older than 0.8, Unicode key labels disabled.");
 	}
 #endif
 	if (initialize_xext(dylibloader_verbose) != 0) {
@@ -6997,10 +6997,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 0;
 		int version_minor = 0;
 		int rc = XShapeQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xshape %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xshape %d.%d detected.", version_major, version_minor));
 		if (rc != 1 || version_major < 1) {
 			xshaped_ext_ok = false;
-			print_verbose("Unsupported Xshape library version.");
+			PRINT_VERBOSE("Unsupported Xshape library version.");
 		}
 	}
 
@@ -7008,10 +7008,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 0;
 		int version_minor = 0;
 		int rc = XineramaQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xinerama %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xinerama %d.%d detected.", version_major, version_minor));
 		if (rc != 1 || version_major < 1) {
 			xinerama_ext_ok = false;
-			print_verbose("Unsupported Xinerama library version.");
+			PRINT_VERBOSE("Unsupported Xinerama library version.");
 		}
 	}
 
@@ -7019,10 +7019,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 0;
 		int version_minor = 0;
 		int rc = XRRQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xrandr %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xrandr %d.%d detected.", version_major, version_minor));
 		if (rc != 1 || (version_major == 1 && version_minor < 3) || (version_major < 1)) {
 			xrandr_ext_ok = false;
-			print_verbose("Unsupported Xrandr library version.");
+			PRINT_VERBOSE("Unsupported Xrandr library version.");
 		}
 	}
 
@@ -7030,7 +7030,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 0;
 		int version_minor = 0;
 		int rc = XRenderQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xrender %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xrender %d.%d detected.", version_major, version_minor));
 		if (rc != 1 || (version_major == 0 && version_minor < 11)) {
 			ERR_PRINT("Unsupported Xrender library version.");
 			r_error = ERR_UNAVAILABLE;
@@ -7043,7 +7043,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_major = 2; // Report 2.2 as supported by engine, but should work with 2.1 or 2.0 library as well.
 		int version_minor = 2;
 		int rc = XIQueryVersion(x11_display, &version_major, &version_minor);
-		print_verbose(vformat("Xinput %d.%d detected.", version_major, version_minor));
+		PRINT_VERBOSE(vformat("Xinput %d.%d detected.", version_major, version_minor));
 		if (rc != Success || (version_major < 2)) {
 			ERR_PRINT("Unsupported Xinput2 library version.");
 			r_error = ERR_UNAVAILABLE;
@@ -7207,7 +7207,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 					getenv("PRIMUS_libGL") ||
 					getenv("PRIMUS_LOAD_GLOBAL") ||
 					getenv("BUMBLEBEE_SOCKET")) {
-				print_verbose("Optirun/primusrun detected. Skipping GPU detection");
+				PRINT_VERBOSE("Optirun/primusrun detected. Skipping GPU detection");
 				use_prime = 0;
 			}
 
@@ -7221,14 +7221,14 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 				for (int i = 0; i < libraries.size(); ++i) {
 					if (FileAccess::exists(libraries[i] + "/libGL.so.1") ||
 							FileAccess::exists(libraries[i] + "/libGL.so")) {
-						print_verbose("Custom libGL override detected. Skipping GPU detection");
+						PRINT_VERBOSE("Custom libGL override detected. Skipping GPU detection");
 						use_prime = 0;
 					}
 				}
 			}
 
 			if (use_prime == -1) {
-				print_verbose("Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.");
+				PRINT_VERBOSE("Detecting GPUs, set DRI_PRIME in the environment to override GPU detection logic.");
 				use_prime = DetectPrimeX11::detect_prime();
 			}
 
@@ -7350,7 +7350,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 	cursor_theme = XcursorGetTheme(x11_display);
 
 	if (!cursor_theme) {
-		print_verbose("XcursorGetTheme could not get cursor theme");
+		PRINT_VERBOSE("XcursorGetTheme could not get cursor theme");
 		cursor_theme = "default";
 	}
 
@@ -7433,7 +7433,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		if (cursor_img[i]) {
 			cursors[i] = XcursorImageLoadCursor(x11_display, cursor_img[i]);
 		} else {
-			print_verbose("Failed loading custom cursor: " + String(cursor_file[i]));
+			PRINT_VERBOSE("Failed loading custom cursor: " + String(cursor_file[i]));
 		}
 	}
 
@@ -7484,7 +7484,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 	bool dbus_ok = true;
 #ifdef SOWRAP_ENABLED
 	if (initialize_dbus(dylibloader_verbose) != 0) {
-		print_verbose("Failed to load DBus library!");
+		PRINT_VERBOSE("Failed to load DBus library!");
 		dbus_ok = false;
 	}
 #endif
@@ -7495,9 +7495,9 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 		int version_rev = 0;
 		dbus_get_version(&version_major, &version_minor, &version_rev);
 		ver_ok = (version_major == 1 && version_minor >= 10) || (version_major > 1); // 1.10.0
-		print_verbose(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
+		PRINT_VERBOSE(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
 		if (!ver_ok) {
-			print_verbose("Unsupported DBus library version!");
+			PRINT_VERBOSE("Unsupported DBus library version!");
 			dbus_ok = false;
 		}
 	}

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -972,7 +972,7 @@ Error EditorExportPlatformMacOS::_export_liquid_glass_icon(const Ref<EditorExpor
 	}
 	PList info_plist;
 	if (!info_plist.load_string(str, err_str)) {
-		print_verbose(str);
+		PRINT_VERBOSE(str);
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Liquid Glass Icons"), TTR("Could not read 'actool' version."));
 		return err;
 	}
@@ -1015,7 +1015,7 @@ Error EditorExportPlatformMacOS::_export_liquid_glass_icon(const Ref<EditorExpor
 
 	err = OS::get_singleton()->execute(actool, args, &str, &exitcode, true);
 	if (err != OK || str.contains("error:") || !FileAccess::exists(p_app_path + "/Contents/Resources/Assets.car") || !FileAccess::exists(plist)) {
-		print_verbose(str);
+		PRINT_VERBOSE(str);
 		add_message(EXPORT_MESSAGE_WARNING, TTR("Liquid Glass Icons"), TTR("Could not export liquid glass icon:") + "\n" + str);
 		return err;
 	}
@@ -1034,7 +1034,7 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 	int notary_tool = p_preset->get("notarization/notarization");
 	switch (notary_tool) {
 		case 1: { // "rcodesign"
-			print_verbose("using rcodesign notarization...");
+			PRINT_VERBOSE("using rcodesign notarization...");
 
 			String rcodesign = EDITOR_GET("export/macos/rcodesign").operator String();
 			if (rcodesign.is_empty()) {
@@ -1083,7 +1083,7 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 				add_message(EXPORT_MESSAGE_WARNING, TTR("Notarization"), TTR("Notarization failed, see editor log for details."));
 				return Error::FAILED;
 			} else {
-				print_verbose("rcodesign (" + p_path + "):\n" + str);
+				PRINT_VERBOSE("rcodesign (" + p_path + "):\n" + str);
 				int next_nl = str.find_char('\n', rq_offset);
 				String request_uuid = (next_nl == -1) ? str.substr(rq_offset + 23) : str.substr(rq_offset + 23, next_nl - rq_offset - 23);
 				add_message(EXPORT_MESSAGE_INFO, TTR("Notarization"), vformat(TTR("Notarization request UUID: \"%s\""), request_uuid));
@@ -1096,7 +1096,7 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 		} break;
 #ifdef MACOS_ENABLED
 		case 2: { // "notarytool"
-			print_verbose("using notarytool notarization...");
+			PRINT_VERBOSE("using notarytool notarization...");
 
 			if (!FileAccess::exists("/usr/bin/xcrun") && !FileAccess::exists("/bin/xcrun")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Notarization"), TTR("Xcode command line tools are not installed."));
@@ -1167,7 +1167,7 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 				add_message(EXPORT_MESSAGE_WARNING, TTR("Notarization"), TTR("Notarization failed, see editor log for details."));
 				return Error::FAILED;
 			} else {
-				print_verbose("notarytool (" + p_path + "):\n" + str);
+				PRINT_VERBOSE("notarytool (" + p_path + "):\n" + str);
 				int next_nl = str.find_char('\n', rq_offset);
 				String request_uuid = (next_nl == -1) ? str.substr(rq_offset + 4) : str.substr(rq_offset + 4, next_nl - rq_offset - 4);
 				add_message(EXPORT_MESSAGE_INFO, TTR("Notarization"), vformat(TTR("Notarization request UUID: \"%s\""), request_uuid));
@@ -1191,7 +1191,7 @@ void EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pres
 	int codesign_tool = p_preset->get("codesign/codesign");
 	switch (codesign_tool) {
 		case 1: { // built-in ad-hoc
-			print_verbose("using built-in codesign...");
+			PRINT_VERBOSE("using built-in codesign...");
 			String error_msg;
 			Error err = CodeSign::codesign(false, true, p_path, p_ent_path, error_msg);
 			if (err != OK) {
@@ -1200,7 +1200,7 @@ void EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pres
 			}
 		} break;
 		case 2: { // "rcodesign"
-			print_verbose("using rcodesign codesign...");
+			PRINT_VERBOSE("using rcodesign codesign...");
 
 			String rcodesign = EDITOR_GET("export/macos/rcodesign").operator String();
 			if (rcodesign.is_empty()) {
@@ -1251,12 +1251,12 @@ void EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pres
 				add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), TTR("Code signing failed, see editor log for details."));
 				return;
 			} else {
-				print_verbose("rcodesign (" + p_path + "):\n" + str);
+				PRINT_VERBOSE("rcodesign (" + p_path + "):\n" + str);
 			}
 		} break;
 #ifdef MACOS_ENABLED
 		case 3: { // "codesign"
-			print_verbose("using xcode codesign...");
+			PRINT_VERBOSE("using xcode codesign...");
 
 			if (!FileAccess::exists("/usr/bin/codesign") && !FileAccess::exists("/bin/codesign")) {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Code Signing"), TTR("Xcode command line tools are not installed."));
@@ -1317,7 +1317,7 @@ void EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pres
 				add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), TTR("Code signing failed, see editor log for details."));
 				return;
 			} else {
-				print_verbose("codesign (" + p_path + "):\n" + str);
+				PRINT_VERBOSE("codesign (" + p_path + "):\n" + str);
 			}
 		} break;
 #endif
@@ -1398,7 +1398,7 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 #ifndef UNIX_ENABLED
 		add_message(EXPORT_MESSAGE_INFO, TTR("Export"), vformat(TTR("Relative symlinks are not supported, exported \"%s\" might be broken!"), p_src_path.get_file()));
 #endif
-		print_verbose("export framework: " + p_src_path + " -> " + p_in_app_path);
+		PRINT_VERBOSE("export framework: " + p_src_path + " -> " + p_in_app_path);
 
 		bool plist_missing = false;
 		Ref<PList> plist;
@@ -1467,7 +1467,7 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 			}
 		}
 	} else {
-		print_verbose("export dylib: " + p_src_path + " -> " + p_in_app_path);
+		PRINT_VERBOSE("export dylib: " + p_src_path + " -> " + p_in_app_path);
 		err = dir_access->copy(p_src_path, p_in_app_path);
 	}
 	if (err == OK && p_sign_enabled) {
@@ -1540,7 +1540,7 @@ Error EditorExportPlatformMacOS::_create_pkg(const Ref<EditorExportPreset> &p_pr
 		return err;
 	}
 
-	print_verbose("productbuild returned: " + str);
+	PRINT_VERBOSE("productbuild returned: " + str);
 	if (str.contains("productbuild: error:")) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("PKG Creation"), TTR("`productbuild` failed."));
 		return FAILED;
@@ -1572,7 +1572,7 @@ Error EditorExportPlatformMacOS::_create_dmg(const String &p_dmg_path, const Str
 		return err;
 	}
 
-	print_verbose("hdiutil returned: " + str);
+	PRINT_VERBOSE("hdiutil returned: " + str);
 	if (str.contains("create failed")) {
 		if (str.contains("File exists")) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("DMG Creation"), TTR("`hdiutil create` failed - file exists."));
@@ -1708,7 +1708,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		scr_path = tmp_base_path_name.path_join(pkg_name + ".command");
 	}
 
-	print_verbose("Exporting to " + tmp_app_path_name);
+	PRINT_VERBOSE("Exporting to " + tmp_app_path_name);
 
 	Error err = OK;
 
@@ -1733,7 +1733,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 	// Create our folder structure.
 	if (err == OK) {
-		print_verbose("Creating " + tmp_app_path_name + "/Contents/MacOS");
+		PRINT_VERBOSE("Creating " + tmp_app_path_name + "/Contents/MacOS");
 		err = tmp_app_dir->make_dir_recursive(tmp_app_path_name + "/Contents/MacOS");
 		if (err != OK) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not create directory \"%s\"."), tmp_app_path_name + "/Contents/MacOS"));
@@ -1741,7 +1741,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 	}
 
 	if (err == OK) {
-		print_verbose("Creating " + tmp_app_path_name + "/Contents/Frameworks");
+		PRINT_VERBOSE("Creating " + tmp_app_path_name + "/Contents/Frameworks");
 		err = tmp_app_dir->make_dir_recursive(tmp_app_path_name + "/Contents/Frameworks");
 		if (err != OK) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not create directory \"%s\"."), tmp_app_path_name + "/Contents/Frameworks"));
@@ -1757,7 +1757,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 	}
 
 	if (err == OK) {
-		print_verbose("Creating " + tmp_app_path_name + "/Contents/Resources");
+		PRINT_VERBOSE("Creating " + tmp_app_path_name + "/Contents/Resources");
 		err = tmp_app_dir->make_dir_recursive(tmp_app_path_name + "/Contents/Resources");
 		if (err != OK) {
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not create directory \"%s\"."), tmp_app_path_name + "/Contents/Resources"));
@@ -1941,7 +1941,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 				if (err != OK) {
 					add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not created symlink \"%s\" -> \"%s\"."), lnk_data, file));
 				}
-				print_verbose(vformat("ADDING SYMLINK %s => %s\n", file, lnk_data));
+				PRINT_VERBOSE(vformat("ADDING SYMLINK %s => %s\n", file, lnk_data));
 			}
 
 			ret = unzGoToNextFile(src_pkg_zip);
@@ -2016,7 +2016,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		if (data.size() > 0) {
-			print_verbose("ADDING: " + file + " size: " + itos(data.size()));
+			PRINT_VERBOSE("ADDING: " + file + " size: " + itos(data.size()));
 
 			// Write it into our application bundle.
 			file = tmp_app_path_name.path_join(file);
@@ -2429,11 +2429,11 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 		}
 
 		if (FileAccess::exists(ent_path)) {
-			print_verbose("entitlements:\n" + FileAccess::get_file_as_string(ent_path));
+			PRINT_VERBOSE("entitlements:\n" + FileAccess::get_file_as_string(ent_path));
 		}
 
 		if (FileAccess::exists(hlp_ent_path)) {
-			print_verbose("helper entitlements:\n" + FileAccess::get_file_as_string(hlp_ent_path));
+			PRINT_VERBOSE("helper entitlements:\n" + FileAccess::get_file_as_string(hlp_ent_path));
 		}
 
 		// Clean up temporary entitlements files.

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -112,7 +112,7 @@ __attribute__((visibility("default"))) int main(int argc, char **argv) {
 #ifdef TOOLS_ENABLED
 	if (wait_for_debugger > 0) {
 		os->wait_for_debugger(wait_for_debugger);
-		print_verbose("Continuing execution.");
+		PRINT_VERBOSE("Continuing execution.");
 	}
 #else
 	if (wait_for_debugger > 0) {

--- a/platform/macos/tts_macos.mm
+++ b/platform/macos/tts_macos.mm
@@ -39,7 +39,7 @@
 	self->speaking = false;
 	self->synth = [[AVSpeechSynthesizer alloc] init];
 	[self->synth setDelegate:self];
-	print_verbose("Text-to-Speech: AVSpeechSynthesizer initialized.");
+	PRINT_VERBOSE("Text-to-Speech: AVSpeechSynthesizer initialized.");
 	return self;
 }
 

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -1146,7 +1146,7 @@ DisplayServerWeb::DisplayServerWeb(const String &p_rendering_driver, DisplayServ
 	}
 	if (webgl2_inited) {
 		if (!emscripten_webgl_enable_extension(webgl_ctx, "OVR_multiview2")) {
-			print_verbose("Failed to enable WebXR extension.");
+			PRINT_VERBOSE("Failed to enable WebXR extension.");
 		}
 		RasterizerGLES3::make_current(false);
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7268,7 +7268,7 @@ void DisplayServerWindows::_update_tablet_ctx(const String &p_old_driver, const 
 				}
 				wintab_WTEnable(wd.wtctx, true);
 			} else {
-				print_verbose("WinTab context creation failed.");
+				PRINT_VERBOSE("WinTab context creation failed.");
 			}
 		}
 	}
@@ -7455,7 +7455,7 @@ Error DisplayServerWindows::_create_window(DisplayServerEnums::WindowID p_window
 					wd.tilt_supported = orientation[0].axResolution && orientation[1].axResolution;
 				}
 			} else {
-				print_verbose("WinTab context creation failed.");
+				PRINT_VERBOSE("WinTab context creation failed.");
 			}
 		} else {
 			wd.wtctx = nullptr;
@@ -8001,7 +8001,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 					parser->read();
 					if (parser->get_node_type() == XMLParser::NODE_TEXT) {
 						winink_disabled = (parser->get_node_data().to_lower().strip_edges() != "true");
-						print_verbose(vformat("Wacom tablet config found at \"%s\", Windows Ink support is %s.", wacom_cfg, winink_disabled ? "disabled" : "enabled"));
+						PRINT_VERBOSE(vformat("Wacom tablet config found at \"%s\", Windows Ink support is %s.", wacom_cfg, winink_disabled ? "disabled" : "enabled"));
 						break;
 					}
 				}

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7166,7 +7166,7 @@ void DisplayServerWindows::_update_tablet_ctx(const String &p_old_driver, const 
 				}
 				wintab_WTEnable(wd.wtctx, true);
 			} else {
-				print_verbose("WinTab context creation failed.");
+				PRINT_VERBOSE("WinTab context creation failed.");
 			}
 		}
 	}
@@ -7353,7 +7353,7 @@ Error DisplayServerWindows::_create_window(DisplayServerEnums::WindowID p_window
 					wd.tilt_supported = orientation[0].axResolution && orientation[1].axResolution;
 				}
 			} else {
-				print_verbose("WinTab context creation failed.");
+				PRINT_VERBOSE("WinTab context creation failed.");
 			}
 		} else {
 			wd.wtctx = nullptr;
@@ -7913,7 +7913,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 					parser->read();
 					if (parser->get_node_type() == XMLParser::NODE_TEXT) {
 						winink_disabled = (parser->get_node_data().to_lower().strip_edges() != "true");
-						print_verbose(vformat("Wacom tablet config found at \"%s\", Windows Ink support is %s.", wacom_cfg, winink_disabled ? "disabled" : "enabled"));
+						PRINT_VERBOSE(vformat("Wacom tablet config found at \"%s\", Windows Ink support is %s.", wacom_cfg, winink_disabled ? "disabled" : "enabled"));
 						break;
 					}
 				}

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -96,7 +96,7 @@ static bool nvapi_err_check(const char *msg, int status) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			NvAPI_ShortString err_desc = { 0 };
 			NvAPI_GetErrorMessage__(status, err_desc);
-			print_verbose(vformat("%s: %s(code %d)", msg, err_desc, status));
+			PRINT_VERBOSE(vformat("%s: %s(code %d)", msg, err_desc, status));
 		}
 		return false;
 	}
@@ -125,7 +125,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 	NvAPI_QueryInterface = (void *(__cdecl *)(unsigned int))(void *)GetProcAddress(nvapi, "nvapi_QueryInterface");
 
 	if (NvAPI_QueryInterface == nullptr) {
-		print_verbose("Error getting NVAPI NvAPI_QueryInterface");
+		PRINT_VERBOSE("Error getting NVAPI NvAPI_QueryInterface");
 		return;
 	}
 
@@ -148,7 +148,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 		return;
 	}
 
-	print_verbose("NVAPI: Init OK!");
+	PRINT_VERBOSE("NVAPI: Init OK!");
 
 	NvDRSSessionHandle session_handle;
 
@@ -186,7 +186,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 	int old_status = NvAPI_DRS_FindProfileByName(session_handle, (NvU16 *)(old_profile_name_u16.ptrw()), &old_profile_handle);
 
 	if (old_status == 0) {
-		print_verbose("NVAPI: Deleting old profile...");
+		PRINT_VERBOSE("NVAPI: Deleting old profile...");
 
 		if (!nvapi_err_check("NVAPI: Error deleting old profile", NvAPI_DRS_DeleteProfile(session_handle, old_profile_handle))) {
 			NvAPI_DRS_DestroySession(session_handle);
@@ -206,7 +206,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 	int profile_status = NvAPI_DRS_FindProfileByName(session_handle, (NvU16 *)(app_profile_name_u16.ptrw()), &profile_handle);
 
 	if (profile_status != 0) {
-		print_verbose("NVAPI: Profile not found, creating...");
+		PRINT_VERBOSE("NVAPI: Profile not found, creating...");
 
 		NVDRS_PROFILE profile_info;
 		profile_info.version = NVDRS_PROFILE_VER;
@@ -226,7 +226,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 	int app_status = NvAPI_DRS_GetApplicationInfo(session_handle, profile_handle, (NvU16 *)(app_executable_name_u16.ptrw()), &app);
 
 	if (app_status != 0) {
-		print_verbose("NVAPI: Application not found in profile, creating...");
+		PRINT_VERBOSE("NVAPI: Application not found in profile, creating...");
 
 		app.isPredefined = 0;
 		memcpy(app.appName, app_executable_name_u16.get_data(), sizeof(char16_t) * app_executable_name_u16.size());
@@ -275,11 +275,11 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 	}
 
 	if (thread_control_val == OGL_THREAD_CONTROL_DISABLE) {
-		print_verbose("NVAPI: Disabled OpenGL threaded optimization successfully");
+		PRINT_VERBOSE("NVAPI: Disabled OpenGL threaded optimization successfully");
 	} else {
-		print_verbose("NVAPI: Enabled OpenGL threaded optimization successfully");
+		PRINT_VERBOSE("NVAPI: Enabled OpenGL threaded optimization successfully");
 	}
-	print_verbose("NVAPI: Disabled G-SYNC for windowed mode successfully");
+	PRINT_VERBOSE("NVAPI: Disabled G-SYNC for windowed mode successfully");
 
 	NvAPI_DRS_DestroySession(session_handle);
 }

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -337,9 +337,9 @@ void OS_Windows::initialize() {
 		}
 	}
 	if (!dwrite_init) {
-		print_verbose("Unable to load IDWriteFactory, system font support is disabled.");
+		PRINT_VERBOSE("Unable to load IDWriteFactory, system font support is disabled.");
 	} else if (!dwrite2_init) {
-		print_verbose("Unable to load IDWriteFactory2, automatic system font fallback is disabled.");
+		PRINT_VERBOSE("Unable to load IDWriteFactory2, automatic system font fallback is disabled.");
 	}
 
 	FileAccessWindows::initialize();
@@ -2956,7 +2956,7 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	outMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 	if (!SetConsoleMode(stdoutHandle, outMode)) {
 		// Windows 10 prior to Anniversary Update.
-		print_verbose("Can't set the ENABLE_VIRTUAL_TERMINAL_PROCESSING Windows console mode. `print_rich()` will not work as expected.");
+		PRINT_VERBOSE("Can't set the ENABLE_VIRTUAL_TERMINAL_PROCESSING Windows console mode. `print_rich()` will not work as expected.");
 	}
 
 	Vector<Logger *> loggers;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -337,9 +337,9 @@ void OS_Windows::initialize() {
 		}
 	}
 	if (!dwrite_init) {
-		print_verbose("Unable to load IDWriteFactory, system font support is disabled.");
+		PRINT_VERBOSE("Unable to load IDWriteFactory, system font support is disabled.");
 	} else if (!dwrite2_init) {
-		print_verbose("Unable to load IDWriteFactory2, automatic system font fallback is disabled.");
+		PRINT_VERBOSE("Unable to load IDWriteFactory2, automatic system font fallback is disabled.");
 	}
 
 	FileAccessWindows::initialize();
@@ -2958,7 +2958,7 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	outMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 	if (!SetConsoleMode(stdoutHandle, outMode)) {
 		// Windows 10 prior to Anniversary Update.
-		print_verbose("Can't set the ENABLE_VIRTUAL_TERMINAL_PROCESSING Windows console mode. `print_rich()` will not work as expected.");
+		PRINT_VERBOSE("Can't set the ENABLE_VIRTUAL_TERMINAL_PROCESSING Windows console mode. `print_rich()` will not work as expected.");
 	}
 
 	Vector<Logger *> loggers;

--- a/platform/windows/tts_driver_onecore.cpp
+++ b/platform/windows/tts_driver_onecore.cpp
@@ -246,14 +246,14 @@ void TTSDriverOneCore::stop() {
 
 bool TTSDriverOneCore::init() {
 	if (!ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", 1)) {
-		print_verbose("Text-to-Speech: Cannot initialize OneCore driver, API contract not present!");
+		PRINT_VERBOSE("Text-to-Speech: Cannot initialize OneCore driver, API contract not present!");
 		return false;
 	}
 	if (SpeechSynthesizer::AllVoices().Size() == 0) {
-		print_verbose("Text-to-Speech: Cannot initialize OneCore driver, no voices found!");
+		PRINT_VERBOSE("Text-to-Speech: Cannot initialize OneCore driver, no voices found!");
 		return false;
 	}
-	print_verbose("Text-to-Speech: OneCore initialized.");
+	PRINT_VERBOSE("Text-to-Speech: OneCore initialized.");
 	return true;
 }
 

--- a/platform/windows/tts_driver_onecore.cpp
+++ b/platform/windows/tts_driver_onecore.cpp
@@ -449,15 +449,15 @@ void TTSDriverOneCore::stop() {
 
 bool TTSDriverOneCore::init() {
 	if (!WinRTUtils::is_initialized()) {
-		print_verbose("Text-to-Speech: Cannot initialize OneCore driver, WinRT API not supported!");
+		PRINT_VERBOSE("Text-to-Speech: Cannot initialize OneCore driver, WinRT API not supported!");
 		return false;
 	}
 	if (!WinRTUtils::is_api_contract_present(L"Windows.Foundation.UniversalApiContract", 1) || !WinRTUtils::is_type_present(ROSpeechSynthesizerName) || !WinRTUtils::is_type_present(ROSpeechSynthesisStreamName) || !WinRTUtils::is_type_present(ROMediaPlayerName)) {
-		print_verbose("Text-to-Speech: Cannot initialize OneCore driver, API contract or type not present!");
+		PRINT_VERBOSE("Text-to-Speech: Cannot initialize OneCore driver, API contract or type not present!");
 	}
 	ComPtr<ROInstalledVoicesStatic> synth_static;
 	if (FAILED(WinRTUtils::activation_factory(ROSpeechSynthesizerName, IID_PPV_ARGS(&synth_static)))) {
-		print_verbose("Text-to-Speech: Cannot initialize OneCore driver, interface not supported!");
+		PRINT_VERBOSE("Text-to-Speech: Cannot initialize OneCore driver, interface not supported!");
 		return false;
 	}
 
@@ -467,11 +467,11 @@ bool TTSDriverOneCore::init() {
 	uint32_t size = 0;
 	ERR_FAIL_COND_V(FAILED(voices->get_Size(&size)), false);
 	if (size == 0) {
-		print_verbose("Text-to-Speech: Cannot initialize OneCore driver, no voices found!");
+		PRINT_VERBOSE("Text-to-Speech: Cannot initialize OneCore driver, no voices found!");
 		return false;
 	}
 
-	print_verbose("Text-to-Speech: OneCore initialized.");
+	PRINT_VERBOSE("Text-to-Speech: OneCore initialized.");
 	return true;
 }
 

--- a/platform/windows/tts_driver_sapi.cpp
+++ b/platform/windows/tts_driver_sapi.cpp
@@ -254,10 +254,10 @@ bool TTSDriverSAPI::init() {
 		ULONGLONG event_mask = SPFEI(SPEI_END_INPUT_STREAM) | SPFEI(SPEI_START_INPUT_STREAM) | SPFEI(SPEI_WORD_BOUNDARY);
 		synth->SetInterest(event_mask, event_mask);
 		synth->SetNotifyCallbackFunction(&speech_event_callback, (WPARAM)(this), 0);
-		print_verbose("Text-to-Speech: SAPI initialized.");
+		PRINT_VERBOSE("Text-to-Speech: SAPI initialized.");
 		return true;
 	} else {
-		print_verbose("Text-to-Speech: Cannot initialize SAPI driver!");
+		PRINT_VERBOSE("Text-to-Speech: Cannot initialize SAPI driver!");
 		return false;
 	}
 }

--- a/platform/windows/wgl_detect_version.cpp
+++ b/platform/windows/wgl_detect_version.cpp
@@ -168,7 +168,7 @@ Dictionary detect_wgl() {
 #else
 										sscanf(version, "%d.%d", &major, &minor);
 #endif
-										print_verbose(vformat("Native OpenGL API detected: %d.%d: %s - %s", major, minor, device_vendor, device_name));
+										PRINT_VERBOSE(vformat("Native OpenGL API detected: %d.%d: %s - %s", major, minor, device_vendor, device_name));
 										gl_info["vendor"] = device_vendor;
 										gl_info["name"] = device_name;
 										gl_info["version"] = major * 10000 + minor;

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -258,7 +258,7 @@ void WindowsUtils::remove_temp_pdbs(const String &p_dll_path) {
 				} else {
 					failed++;
 					if (failed <= failed_limit) {
-						print_verbose("Failed to remove temp PDB: " + pdb);
+						PRINT_VERBOSE("Failed to remove temp PDB: " + pdb);
 					}
 				}
 			} else {
@@ -267,7 +267,7 @@ void WindowsUtils::remove_temp_pdbs(const String &p_dll_path) {
 		}
 
 		if (failed > failed_limit) {
-			print_verbose(vformat("And %d more PDB files could not be removed....", failed - failed_limit));
+			PRINT_VERBOSE(vformat("And %d more PDB files could not be removed....", failed - failed_limit));
 		}
 
 		for (const String &pdb : removed) {

--- a/platform/windows/winrt_utils.cpp
+++ b/platform/windows/winrt_utils.cpp
@@ -279,7 +279,7 @@ HRESULT WinRTUtils::activation_factory(const String &p_class_name, REFIID p_iid,
 		res = GD_RoGetActivationFactory(name->get_ptr(), p_iid, p_factory);
 	}
 	if (res == (HRESULT)0x80004001 || res == (HRESULT)0x80004002) {
-		print_verbose(vformat("RoGetActivationFactory(%s) not supported.", p_class_name));
+		PRINT_VERBOSE(vformat("RoGetActivationFactory(%s) not supported.", p_class_name));
 		return res;
 	}
 	ERR_FAIL_COND_V_MSG(FAILED(res), res, vformat("RoGetActivationFactory(%s) failed with error 0x%08ux.", p_class_name, (uint64_t)res));
@@ -334,7 +334,7 @@ bool WinRTUtils::create_queue(const String &p_appid) {
 	ComPtr<ROToastNotificationManagerStatics> toastman_fact;
 	if (SUCCEEDED(activation_factory(ROToastNotificationManagerName, IID_PPV_ARGS(&toastman_fact)))) {
 		res = toastman_fact->CreateToastNotifierWithId(appid->get_ptr(), (void **)notifier.GetAddressOf());
-		print_verbose(vformat("Windows.UI.Notifications.ToastNotificationManager initialized for AppID '%s'.", p_appid));
+		PRINT_VERBOSE(vformat("Windows.UI.Notifications.ToastNotificationManager initialized for AppID '%s'.", p_appid));
 	}
 
 	return true;

--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -781,13 +781,13 @@ SceneTreeFTI::SceneTreeFTI() {
 
 	switch (data.traversal_mode) {
 		default: {
-			print_verbose("SceneTreeFTI: traversal method DEFAULT");
+			PRINT_VERBOSE("SceneTreeFTI: traversal method DEFAULT");
 		} break;
 		case TM_LEGACY: {
-			print_verbose("SceneTreeFTI: traversal method Legacy");
+			PRINT_VERBOSE("SceneTreeFTI: traversal method Legacy");
 		} break;
 		case TM_DEBUG: {
-			print_verbose("SceneTreeFTI: traversal method Debug");
+			PRINT_VERBOSE("SceneTreeFTI: traversal method Debug");
 		} break;
 	}
 

--- a/scene/resources/2d/polygon_path_finder.cpp
+++ b/scene/resources/2d/polygon_path_finder.cpp
@@ -298,7 +298,7 @@ Vector<Vector2> PolygonPathFinder::find_path(const Vector2 &p_from, const Vector
 
 	while (true) {
 		if (open_list.is_empty()) {
-			print_verbose("Open list empty.");
+			PRINT_VERBOSE("Open list empty.");
 			break;
 		}
 		//check open list

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -754,7 +754,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 			}
 		}
 
-		print_verbose("LOD Generation: Triangles " + itos(index_count / 3) + ", vertices " + itos(vertex_count) + " (merged " + itos(merged_vertex_count) + ")" + (deformable ? ", deformable" : ""));
+		PRINT_VERBOSE("LOD Generation: Triangles " + itos(index_count / 3) + ", vertices " + itos(vertex_count) + " (merged " + itos(merged_vertex_count) + ")" + (deformable ? ", deformable" : ""));
 
 		const float max_mesh_error = 1.0f; // We only need LODs that can be selected by error threshold.
 		const unsigned min_target_indices = 12;
@@ -818,12 +818,12 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 			current_indices = new_indices;
 
 			if (new_index_count == 0 || (new_index_count >= current_index_count * 0.75f)) {
-				print_verbose("  LOD stop: got " + itos(new_index_count / 3) + " triangles when asking for " + itos(target_index_count / 3));
+				PRINT_VERBOSE("  LOD stop: got " + itos(new_index_count / 3) + " triangles when asking for " + itos(target_index_count / 3));
 				break;
 			}
 
 			if (current_error > max_mesh_error) {
-				print_verbose("  LOD stop: reached " + rtos(current_error) + " cumulative error (step error " + rtos(step_error) + ")");
+				PRINT_VERBOSE("  LOD stop: reached " + rtos(current_error) + " cumulative error (step error " + rtos(step_error) + ")");
 				break;
 			}
 
@@ -840,7 +840,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 			lod.indices = new_indices;
 			surfaces.write[i].lods.push_back(lod);
 
-			print_verbose("  LOD " + itos(surfaces.write[i].lods.size()) + ": " + itos(new_index_count / 3) + " triangles, error " + rtos(current_error) + " (step error " + rtos(step_error) + ")");
+			PRINT_VERBOSE("  LOD " + itos(surfaces.write[i].lods.size()) + ": " + itos(new_index_count / 3) + " triangles, error " + rtos(current_error) + " (step error " + rtos(step_error) + ")");
 		}
 
 		surfaces.write[i].lods.sort_custom<Surface::LODComparator>();
@@ -1456,7 +1456,7 @@ Error ImporterMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, 
 	//remove surfaces
 	clear();
 
-	print_verbose("Mesh: Gen indices: " + itos(gen_index_count));
+	PRINT_VERBOSE("Mesh: Gen indices: " + itos(gen_index_count));
 
 	//go through all indices
 	for (int i = 0; i < gen_index_count; i += 3) {

--- a/scene/resources/audio/audio_stream_microphone.cpp
+++ b/scene/resources/audio/audio_stream_microphone.cpp
@@ -92,7 +92,7 @@ int AudioStreamPlaybackMicrophone::_mix_internal(AudioFrame *p_buffer, int p_fra
 
 #ifdef DEBUG_ENABLED
 	if (input_ofs > input_position && (int)(input_ofs - input_position) < (p_frames * 2)) {
-		print_verbose(String(get_class_name()) + " buffer underrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
+		PRINT_VERBOSE(String(get_class_name()) + " buffer underrun: input_position=" + itos(input_position) + " input_ofs=" + itos(input_ofs) + " input_size=" + itos(input_size));
 	}
 #endif
 

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -538,7 +538,7 @@ Vector<Vector<Vector2>> BitMap::clip_opaque_to_polygons(const Rect2i &p_rect, fl
 					polygon = reduce(polygon, r, p_epsilon);
 
 					if (polygon.size() < 3) {
-						print_verbose("Invalid polygon, skipped");
+						PRINT_VERBOSE("Invalid polygon, skipped");
 						continue;
 					}
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1450,9 +1450,9 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 			}
 
 			//clear unused flags
-			print_verbose("Mesh format pre-conversion: " + itos(old_format));
+			PRINT_VERBOSE("Mesh format pre-conversion: " + itos(old_format));
 
-			print_verbose("Mesh format post-conversion: " + itos(new_format));
+			PRINT_VERBOSE("Mesh format post-conversion: " + itos(new_format));
 
 			ERR_FAIL_COND_V(!d.has("aabb"), false);
 			AABB aabb_new = d["aabb"];
@@ -2209,7 +2209,7 @@ Error ArrayMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, flo
 		surfaces_tools.push_back(st); //stay there
 	}
 
-	print_verbose("Mesh: Gen indices: " + itos(gen_index_count));
+	PRINT_VERBOSE("Mesh: Gen indices: " + itos(gen_index_count));
 
 	//go through all indices
 	for (int i = 0; i < gen_index_count; i += 3) {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1460,9 +1460,9 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 			}
 
 			//clear unused flags
-			print_verbose("Mesh format pre-conversion: " + itos(old_format));
+			PRINT_VERBOSE("Mesh format pre-conversion: " + itos(old_format));
 
-			print_verbose("Mesh format post-conversion: " + itos(new_format));
+			PRINT_VERBOSE("Mesh format post-conversion: " + itos(new_format));
 
 			ERR_FAIL_COND_V(!d.has("aabb"), false);
 			AABB aabb_new = d["aabb"];
@@ -2219,7 +2219,7 @@ Error ArrayMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, flo
 		surfaces_tools.push_back(st); //stay there
 	}
 
-	print_verbose("Mesh: Gen indices: " + itos(gen_index_count));
+	PRINT_VERBOSE("Mesh: Gen indices: " + itos(gen_index_count));
 
 	//go through all indices
 	for (int i = 0; i < gen_index_count; i += 3) {

--- a/scene/resources/streamed_texture.cpp
+++ b/scene/resources/streamed_texture.cpp
@@ -121,7 +121,7 @@ void StreamedTexture2D::texture_reload(uint8_t p_mip_level) {
 
 	if (verbose_logging) {
 		const uint64_t end_time = OS::get_singleton()->get_ticks_msec();
-		print_verbose(vformat("Streamed texture %s reloaded (%dx%d) in %d ms (start=%d, end=%d)", path_to_file, w, h, end_time - start_time, start_time, end_time));
+		PRINT_VERBOSE(vformat("Streamed texture %s reloaded (%dx%d) in %d ms (start=%d, end=%d)", path_to_file, w, h, end_time - start_time, start_time, end_time));
 	}
 }
 

--- a/servers/camera/camera_server.cpp
+++ b/servers/camera/camera_server.cpp
@@ -120,7 +120,7 @@ void CameraServer::add_feed(const Ref<CameraFeed> &p_feed) {
 	// add our feed
 	feeds.push_back(p_feed);
 
-	print_verbose("CameraServer: Registered camera " + p_feed->get_name() + " with ID " + itos(p_feed->get_id()) + " and position " + itos(p_feed->get_position()) + " at index " + itos(feeds.size() - 1));
+	PRINT_VERBOSE("CameraServer: Registered camera " + p_feed->get_name() + " with ID " + itos(p_feed->get_id()) + " and position " + itos(p_feed->get_position()) + " at index " + itos(feeds.size() - 1));
 
 	// let whomever is interested know
 	emit_signal(SNAME("camera_feed_added"), p_feed->get_id());
@@ -131,7 +131,7 @@ void CameraServer::remove_feed(const Ref<CameraFeed> &p_feed) {
 		if (feeds[i] == p_feed) {
 			int feed_id = p_feed->get_id();
 
-			print_verbose("CameraServer: Removed camera " + p_feed->get_name() + " with ID " + itos(feed_id) + " and position " + itos(p_feed->get_position()));
+			PRINT_VERBOSE("CameraServer: Removed camera " + p_feed->get_name() + " with ID " + itos(feed_id) + " and position " + itos(p_feed->get_position()));
 
 			// remove it from our array, if this results in our feed being unreferenced it will be destroyed
 			feeds.remove_at(i);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -3559,9 +3559,9 @@ RenderForwardMobile::RenderForwardMobile() {
 
 	disable_ubershaders = RD::get_singleton()->get_driver_workarounds().disable_ubershaders;
 	if (disable_ubershaders) {
-		print_verbose("Ubershaders: Disabled");
+		PRINT_VERBOSE("Ubershaders: Disabled");
 	} else {
-		print_verbose("Ubershaders: Enabled");
+		PRINT_VERBOSE("Ubershaders: Enabled");
 	}
 
 	sky.set_texture_format(_render_buffers_get_preferred_color_format());

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -3599,9 +3599,9 @@ RenderForwardMobile::RenderForwardMobile() {
 
 	disable_ubershaders = RD::get_singleton()->get_driver_workarounds().disable_ubershaders;
 	if (disable_ubershaders) {
-		print_verbose("Ubershaders: Disabled");
+		PRINT_VERBOSE("Ubershaders: Disabled");
 	} else {
-		print_verbose("Ubershaders: Enabled");
+		PRINT_VERBOSE("Ubershaders: Enabled");
 	}
 
 	sky.set_texture_format(_render_buffers_get_preferred_color_format());

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -635,7 +635,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 
 	if (f.is_null()) {
 		const String &sha1 = _version_get_sha1(p_version);
-		print_verbose(vformat("Shader cache miss for %s", name.path_join(group_sha256[p_group]).path_join(sha1)));
+		PRINT_VERBOSE(vformat("Shader cache miss for %s", name.path_join(group_sha256[p_group]).path_join(sha1)));
 		return false;
 	}
 
@@ -661,7 +661,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 		}
 		if (variant_size == 0) {
 			// A new variant has been requested, failing the entire load will generate it
-			print_verbose(vformat("Shader cache miss for %s due to missing variant %d", name.path_join(group_sha256[p_group]).path_join(_version_get_sha1(p_version)), variant_id));
+			PRINT_VERBOSE(vformat("Shader cache miss for %s due to missing variant %d", name.path_join(group_sha256[p_group]).path_join(_version_get_sha1(p_version)), variant_id));
 			return false;
 		}
 		Vector<uint8_t> variant_bytes;
@@ -1063,7 +1063,7 @@ void ShaderRD::_initialize_cache() {
 			}
 		}
 
-		print_verbose("Shader '" + name + "' (group " + itos(E.key) + ") SHA256: " + group_sha256[E.key]);
+		PRINT_VERBOSE("Shader '" + name + "' (group " + itos(E.key) + ") SHA256: " + group_sha256[E.key]);
 	}
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -772,7 +772,7 @@ void TextureStorage::_tex_blit_shader_free() {
 	if (tex_blit_shader.initialized) {
 		MaterialStorage *material_storage = MaterialStorage::get_singleton();
 
-		print_verbose("Freeing Default Tex_Blit Shader");
+		PRINT_VERBOSE("Freeing Default Tex_Blit Shader");
 		material_storage->material_free(tex_blit_shader.default_material);
 		material_storage->shader_free(tex_blit_shader.default_shader);
 	}

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -4552,7 +4552,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 							"Image (binding: " + itos(uniform.binding) + ", index " + itos(j) + ") needs to have the same texture type as the uniform.");
 
 					if (likely(set_uniform.texture_format != RD::DATA_FORMAT_MAX) && unlikely(texture->format != set_uniform.texture_format)) {
-						print_verbose("Image (binding: " + itos(uniform.binding) + ", index " + itos(j) + ") needs to have the same texture format as the uniform (expected: " + String(FORMAT_NAMES[set_uniform.texture_format]) + ", actual: " + String(FORMAT_NAMES[texture->format]) + ").");
+						PRINT_VERBOSE("Image (binding: " + itos(uniform.binding) + ", index " + itos(j) + ") needs to have the same texture format as the uniform (expected: " + String(FORMAT_NAMES[set_uniform.texture_format]) + ", actual: " + String(FORMAT_NAMES[texture->format]) + ").");
 					}
 
 					ERR_FAIL_COND_V_MSG(!(texture->usage_flags & TEXTURE_USAGE_STORAGE_BIT), RID(),
@@ -8331,7 +8331,7 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 	context = p_context;
 	driver = context->driver_create();
 
-	print_verbose("Devices:");
+	PRINT_VERBOSE("Devices:");
 	int32_t device_index = Engine::get_singleton()->get_gpu_index();
 	const uint32_t device_count = context->device_get_count();
 	const bool device_index_out_of_range = (device_index >= int32_t(device_count));
@@ -8348,7 +8348,7 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 		String vendor = _get_device_vendor_name(device_option);
 		String type = _get_device_type_name(device_option);
 		bool present_supported = main_surface != 0 ? context->device_supports_present(i, main_surface) : false;
-		print_verbose("  #" + itos(i) + ": " + vendor + " " + name + " - " + (present_supported ? "Supported" : "Unsupported") + ", " + type);
+		PRINT_VERBOSE("  #" + itos(i) + ": " + vendor + " " + name + " - " + (present_supported ? "Supported" : "Unsupported") + ", " + type);
 		if (detect_device && (present_supported || main_surface == 0)) {
 			// If a window was specified, present must be supported by the device to be available as an option.
 			// Assign a score for each type of device and prefer the device with the higher score.
@@ -8591,7 +8591,7 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 		pipeline_cache_enabled = driver->pipeline_cache_create(cache_data);
 		if (pipeline_cache_enabled) {
 			pipeline_cache_size = driver->pipeline_cache_query_size();
-			print_verbose(vformat("Startup PSO cache (%.1f MiB)", pipeline_cache_size / (1024.0f * 1024.0f)));
+			PRINT_VERBOSE(vformat("Startup PSO cache (%.1f MiB)", pipeline_cache_size / (1024.0f * 1024.0f)));
 		}
 	}
 
@@ -8667,7 +8667,7 @@ void RenderingDevice::_save_pipeline_cache(void *p_data) {
 	if (cache_blob.is_empty()) {
 		return;
 	}
-	print_verbose(vformat("Updated PSO cache (%.1f MiB)", cache_blob.size() / (1024.0f * 1024.0f)));
+	PRINT_VERBOSE(vformat("Updated PSO cache (%.1f MiB)", cache_blob.size() / (1024.0f * 1024.0f)));
 
 	Ref<FileAccess> f = FileAccess::open(self->pipeline_cache_file_path, FileAccess::WRITE, nullptr);
 	if (f.is_valid()) {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -4638,7 +4638,7 @@ RID RenderingDevice::uniform_set_create(const VectorView<RD::Uniform> &p_uniform
 							"Image (binding: " + itos(uniform.binding) + ", index " + itos(j) + ") needs to have the same texture type as the uniform.");
 
 					if (likely(set_uniform.texture_format != RD::DATA_FORMAT_MAX) && unlikely(texture->format != set_uniform.texture_format)) {
-						print_verbose("Image (binding: " + itos(uniform.binding) + ", index " + itos(j) + ") needs to have the same texture format as the uniform (expected: " + String(FORMAT_NAMES[set_uniform.texture_format]) + ", actual: " + String(FORMAT_NAMES[texture->format]) + ").");
+						PRINT_VERBOSE("Image (binding: " + itos(uniform.binding) + ", index " + itos(j) + ") needs to have the same texture format as the uniform (expected: " + String(FORMAT_NAMES[set_uniform.texture_format]) + ", actual: " + String(FORMAT_NAMES[texture->format]) + ").");
 					}
 
 					ERR_FAIL_COND_V_MSG(!(texture->usage_flags & TEXTURE_USAGE_STORAGE_BIT), RID(),
@@ -8546,7 +8546,7 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 	context = p_context;
 	driver = context->driver_create();
 
-	print_verbose("Devices:");
+	PRINT_VERBOSE("Devices:");
 	int32_t device_index = Engine::get_singleton()->get_gpu_index();
 	const uint32_t device_count = context->device_get_count();
 	const bool device_index_out_of_range = (device_index >= int32_t(device_count));
@@ -8563,7 +8563,7 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 		String vendor = _get_device_vendor_name(device_option);
 		String type = _get_device_type_name(device_option);
 		bool present_supported = main_surface != 0 ? context->device_supports_present(i, main_surface) : false;
-		print_verbose("  #" + itos(i) + ": " + vendor + " " + name + " - " + (present_supported ? "Supported" : "Unsupported") + ", " + type);
+		PRINT_VERBOSE("  #" + itos(i) + ": " + vendor + " " + name + " - " + (present_supported ? "Supported" : "Unsupported") + ", " + type);
 		if (detect_device && (present_supported || main_surface == 0)) {
 			// If a window was specified, present must be supported by the device to be available as an option.
 			// Assign a score for each type of device and prefer the device with the higher score.
@@ -8806,7 +8806,7 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 		pipeline_cache_enabled = driver->pipeline_cache_create(cache_data);
 		if (pipeline_cache_enabled) {
 			pipeline_cache_size = driver->pipeline_cache_query_size();
-			print_verbose(vformat("Startup PSO cache (%.1f MiB)", pipeline_cache_size / (1024.0f * 1024.0f)));
+			PRINT_VERBOSE(vformat("Startup PSO cache (%.1f MiB)", pipeline_cache_size / (1024.0f * 1024.0f)));
 		}
 	}
 
@@ -8882,7 +8882,7 @@ void RenderingDevice::_save_pipeline_cache(void *p_data) {
 	if (cache_blob.is_empty()) {
 		return;
 	}
-	print_verbose(vformat("Updated PSO cache (%.1f MiB)", cache_blob.size() / (1024.0f * 1024.0f)));
+	PRINT_VERBOSE(vformat("Updated PSO cache (%.1f MiB)", cache_blob.size() / (1024.0f * 1024.0f)));
 
 	Ref<FileAccess> f = FileAccess::open(self->pipeline_cache_file_path, FileAccess::WRITE, nullptr);
 	if (f.is_valid()) {

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -275,7 +275,7 @@ void RenderingServerDefault::_finish() {
 
 void RenderingServerDefault::init() {
 	if (create_thread) {
-		print_verbose("RenderingServerWrapMT: Starting render thread");
+		PRINT_VERBOSE("RenderingServerWrapMT: Starting render thread");
 		DisplayServer::get_singleton()->release_rendering_thread();
 		WorkerThreadPool::TaskID tid = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &RenderingServerDefault::_thread_loop), true, "Rendering Server pump task", true);
 		command_queue.set_pump_task_id(tid);

--- a/servers/text/text_server.cpp
+++ b/servers/text/text_server.cpp
@@ -70,7 +70,7 @@ void TextServerManager::add_interface(const Ref<TextServer> &p_interface) {
 	};
 
 	interfaces.push_back(p_interface);
-	print_verbose("TextServer: Added interface \"" + p_interface->get_name() + "\" (" + p_interface->get_short_name() + ")");
+	PRINT_VERBOSE("TextServer: Added interface \"" + p_interface->get_name() + "\" (" + p_interface->get_short_name() + ")");
 	emit_signal(SNAME("interface_added"), p_interface->get_name());
 }
 
@@ -87,7 +87,7 @@ void TextServerManager::remove_interface(const Ref<TextServer> &p_interface) {
 	};
 
 	ERR_FAIL_COND_MSG(idx == -1, "Interface not found.");
-	print_verbose("TextServer: Removed interface \"" + p_interface->get_name() + "\" (" + p_interface->get_short_name() + ")");
+	PRINT_VERBOSE("TextServer: Removed interface \"" + p_interface->get_name() + "\" (" + p_interface->get_short_name() + ")");
 	emit_signal(SNAME("interface_removed"), p_interface->get_name());
 	interfaces.remove_at(idx);
 }
@@ -132,11 +132,11 @@ TypedArray<Dictionary> TextServerManager::get_interfaces() const {
 
 void TextServerManager::set_primary_interface(const Ref<TextServer> &p_primary_interface) {
 	if (p_primary_interface.is_null()) {
-		print_verbose("TextServer: Clearing primary interface");
+		PRINT_VERBOSE("TextServer: Clearing primary interface");
 		primary_interface.unref();
 	} else {
 		primary_interface = p_primary_interface;
-		print_verbose("TextServer: Primary interface set to: \"" + primary_interface->get_name() + "\" (" + primary_interface->get_short_name() + ").");
+		PRINT_VERBOSE("TextServer: Primary interface set to: \"" + primary_interface->get_name() + "\" (" + primary_interface->get_short_name() + ").");
 
 		if (OS::get_singleton()->get_main_loop()) {
 			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TEXT_SERVER_CHANGED);

--- a/servers/xr/xr_server.cpp
+++ b/servers/xr/xr_server.cpp
@@ -293,7 +293,7 @@ void XRServer::remove_interface(const Ref<XRInterface> &p_interface) {
 
 	int idx = interfaces.find(p_interface);
 	ERR_FAIL_COND_MSG(idx == -1, "Interface not found.");
-	print_verbose("XR: Removed interface \"" + p_interface->get_name() + "\"");
+	PRINT_VERBOSE("XR: Removed interface \"" + p_interface->get_name() + "\"");
 	emit_signal(SNAME("interface_removed"), p_interface->get_name());
 	interfaces.remove_at(idx);
 }
@@ -338,12 +338,12 @@ Ref<XRInterface> XRServer::get_primary_interface() const {
 
 void XRServer::set_primary_interface(const Ref<XRInterface> &p_primary_interface) {
 	if (p_primary_interface.is_null()) {
-		print_verbose("XR: Clearing primary interface");
+		PRINT_VERBOSE("XR: Clearing primary interface");
 		primary_interface.unref();
 	} else {
 		primary_interface = p_primary_interface;
 
-		print_verbose("XR: Primary interface set to: " + primary_interface->get_name());
+		PRINT_VERBOSE("XR: Primary interface set to: " + primary_interface->get_name());
 	}
 }
 


### PR DESCRIPTION
EDIT: https://github.com/godotengine/godot/pull/106147 should be merged first, so I have marked this as draft.

This PR changes the `print_verbose` macro to `PRINT_VERBOSE`, for 3 reasons:

1. Fixes a name conflict with GDExtension `UtilityFunctions`: https://github.com/godotengine/godot-cpp/pull/1668
2. Fixes a name conflict with the engine's internal `VariantUtilityFunctions`, avoiding this awkwardness:
<img width="387" alt="Screenshot 2024-12-09 at 2 35 36 PM" src="https://github.com/user-attachments/assets/0d5adc13-ad4d-4ebd-83c8-b768a20a6064">

3. Capitalizing the macro is consistent with the style used for all other macros in Godot.

This PR may minorly affect compatibility with third-party modules, but does not change the exposed scripting API. However, it is trivial for third-party modules to either update their code or add `print_verbose` as an alias.