### PR TITLE
Fix Minimap Margin and Bounds for Increased Scrollbar Touch Area

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1081,6 +1081,9 @@ void CodeTextEditor::update_editor_settings() {
 	text_editor->set_draw_line_numbers(EDITOR_GET("text_editor/appearance/gutters/show_line_numbers"));
 	text_editor->set_line_numbers_zero_padded(EDITOR_GET("text_editor/appearance/gutters/line_numbers_zero_padded"));
 
+	// Appearance: Scrollbar
+	text_editor->set_scrollbar_touch_area_enabled(EDITOR_GET("interface/touchscreen/increase_scrollbar_touch_area"));
+
 	// Appearance: Minimap
 	text_editor->set_draw_minimap(EDITOR_GET("text_editor/appearance/minimap/show_minimap"));
 	text_editor->set_minimap_width((int)EDITOR_GET("text_editor/appearance/minimap/minimap_width") * EDSCALE);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -634,6 +634,12 @@ void TextEdit::_notification(int p_what) {
 			if (draw_minimap) {
 				xmargin_end -= minimap_width;
 			}
+
+			// Use the local variable to adjust for increased scrollbar touch area.
+			if (increase_scrollbar_touch_area) {
+				xmargin_end -= 50; // Hardcoded value matching the increased touch area size.
+			}
+
 			// Let's do it easy for now.
 			theme_cache.style_normal->draw(ci, Rect2(Point2(), size));
 			if (!editable) {
@@ -5913,6 +5919,18 @@ double TextEdit::get_scroll_pos_for_line(int p_line, int p_wrap_index) const {
 	return new_line_scroll_pos;
 }
 
+void TextEdit::set_scrollbar_touch_area_enabled(bool p_enabled) {
+	if (increase_scrollbar_touch_area == p_enabled) {
+		return; // No need to update if the value is unchanged.
+	}
+
+	increase_scrollbar_touch_area = p_enabled;
+
+	// Update layout to reflect the new scrollbar configuration.
+	_update_scrollbars();
+	queue_redraw(); // Requests a redraw of the viewport to reflect changes.
+}
+
 // Visible lines.
 void TextEdit::set_line_as_first_visible(int p_line, int p_wrap_index) {
 	ERR_FAIL_INDEX(p_line, text.size());
@@ -8204,7 +8222,8 @@ void TextEdit::_scroll_lines_down() {
 
 void TextEdit::_update_minimap_hover() {
 	const Point2 mp = get_local_mouse_pos();
-	const int xmargin_end = get_size().width - theme_cache.style_normal->get_margin(SIDE_RIGHT);
+	int scrollbar_offset = increase_scrollbar_touch_area ? 50 : 0;
+	const int xmargin_end = get_size().width - theme_cache.style_normal->get_margin(SIDE_RIGHT) - scrollbar_offset;
 
 	bool hovering_sidebar = mp.x > xmargin_end - minimap_width && mp.x < xmargin_end;
 	if (!hovering_sidebar) {
@@ -8231,7 +8250,9 @@ void TextEdit::_update_minimap_hover() {
 void TextEdit::_update_minimap_click() {
 	Point2 mp = get_local_mouse_pos();
 
-	int xmargin_end = get_size().width - theme_cache.style_normal->get_margin(SIDE_RIGHT);
+	int scrollbar_offset = increase_scrollbar_touch_area ? 50 : 0;
+	int xmargin_end = get_size().width - theme_cache.style_normal->get_margin(SIDE_RIGHT) - scrollbar_offset;
+
 	if (!dragging_minimap && (mp.x < xmargin_end - minimap_width || mp.x > xmargin_end)) {
 		minimap_clicked = false;
 		return;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -521,6 +521,8 @@ private:
 	bool scrolling = false;
 	bool updating_scrolls = false;
 
+	bool increase_scrollbar_touch_area = false;
+
 	void _update_scrollbars();
 	int _get_control_height() const;
 
@@ -994,6 +996,8 @@ public:
 	bool is_fit_content_width_enabled() const;
 
 	double get_scroll_pos_for_line(int p_line, int p_wrap_index = 0) const;
+
+	void set_scrollbar_touch_area_enabled(bool p_enabled);
 
 	// Visible lines.
 	void set_line_as_first_visible(int p_line, int p_wrap_index = 0);


### PR DESCRIPTION
This pull request resolves [Issue #100186](https://github.com/godotengine/godot/issues/100186), where the script editor minimap overlaps the vertical scrollbar when "Increase scrollbar touch area" is enabled in the editor settings.

The changes ensure that the minimap adjusts its position dynamically to avoid overlapping with the scrollbar, and the hover, click, and drag functionalities respect the minimap's new position.

![Minimap](https://github.com/user-attachments/assets/ce338658-1143-4efa-9d2f-d8a78dc6cfe5)

Changes Made
Updated the rendering logic to shift the minimap left by the increased scrollbar offset (50px), ensuring proper alignment.
Modified hover, click, and drag detection logic to align with the new minimap position.
Added a new method set_scrollbar_touch_area_enabled in TextEdit to handle the dynamic adjustment of the scrollbar touch area.

The hardcoded offset (50px) matches the touch area size defined in editor_theme_manager.cpp.