### PR TITLE
Fix mesh surface upgrade tool error.

### DIFF
--- a/editor/surface_upgrade_tool.cpp
+++ b/editor/surface_upgrade_tool.cpp
@@ -105,7 +105,7 @@ void SurfaceUpgradeTool::prepare_upgrade() {
 	EditorSettings::get_singleton()->set_project_metadata("surface_upgrade_tool", "resave_paths", resave_paths);
 
 	// Delay to avoid deadlocks, since this dialog can be triggered by loading a scene.
-	callable_mp(EditorNode::get_singleton(), &EditorNode::restart_editor).call_deferred();
+	callable_mp(EditorNode::get_singleton(), &EditorNode::restart_editor).bind(false).call_deferred();
 }
 
 // Ensure that the warnings and popups are skipped.


### PR DESCRIPTION
Fixes #100232 

Passes false to the restart_editor method (we don't want to return to the project list).  This fixes this error:
```
ERROR: Error calling deferred method: 'EditorNode::EditorNode::restart_editor': Method expected 1 arguments, but called with 0.
   at: _call_function (core/object/message_queue.cpp:222)
```