### PR TITLE
Revert "Avoid duplicating signals from scene instances into packed scenes"

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -572,7 +572,7 @@ public:
 		CONNECT_PERSIST = 2, // hint for scene to save this connection
 		CONNECT_ONE_SHOT = 4,
 		CONNECT_REFERENCE_COUNTED = 8,
-		CONNECT_INHERITED = 16, // Whether or not the connection is in an instance of a scene.
+		CONNECT_INHERITED = 16, // Used in editor builds.
 	};
 
 	struct Connection {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1060,12 +1060,6 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 				continue;
 			}
 
-			// Don't include signals that are from scene instances
-			// (they are already saved in the scenes themselves).
-			if (c.flags & CONNECT_INHERITED) {
-				continue;
-			}
-
 			// only connections that originate or end into main saved scene are saved
 			// everything else is discarded
 

--- a/tests/scene/test_packed_scene.h
+++ b/tests/scene/test_packed_scene.h
@@ -96,6 +96,8 @@ TEST_CASE("[PackedScene] Signals Preserved when Packing Scene") {
 		CHECK_EQ(state->get_connection_count(), 3);
 	}
 
+	/*
+	// FIXME: This subcase requires GH-48064 to be fixed.
 	SUBCASE("Signals that should not be saved") {
 		int subscene_flags = Object::CONNECT_PERSIST | Object::CONNECT_INHERITED;
 		// subscene node to itself
@@ -115,6 +117,7 @@ TEST_CASE("[PackedScene] Signals Preserved when Packing Scene") {
 		Ref<SceneState> state = packed_scene->get_state();
 		CHECK_EQ(state->get_connection_count(), 0);
 	}
+	*/
 
 	memdelete(main_scene_root);
 }


### PR DESCRIPTION
This partially reverts #97303 i.e. commit 8a42e3d3eff8f8ef44d663cbe735c2bb05170cba.
Comment improvements and the test case were kept, with one part commented out.

That change sadly introduced a critical regression (#100097), and given how core the changes are, we prefer to be conservative and go back to the previous working state, before trying to tack on significant complexity to fix the regression (see #100160).

- Fixes #100097
- Supersedes #100160
- Reopens #48064

#48064 is still worth fixing so we should try again, e.g. with a draft PR including #97303 + #100160 and then proper review of the combined changes by more core experts.