### PR TITLE
Add move constructor and move assignment to `CowData`, `String`, `Char16String`, `CharString`, and `Vector`.

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -39,6 +39,8 @@
 #include "core/typedefs.h"
 #include "core/variant/array.h"
 
+#include <utility>
+
 /*************************************************************************/
 /*  Utility Functions                                                    */
 /*************************************************************************/
@@ -193,7 +195,10 @@ public:
 
 	_FORCE_INLINE_ Char16String() {}
 	_FORCE_INLINE_ Char16String(const Char16String &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ Char16String(Char16String &&p_str) :
+			_cowdata(std::move(p_str._cowdata)) {}
 	_FORCE_INLINE_ void operator=(const Char16String &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ void operator=(Char16String &&p_str) { _cowdata = std::move(p_str._cowdata); }
 	_FORCE_INLINE_ Char16String(const char16_t *p_cstr) { copy_from(p_cstr); }
 
 	void operator=(const char16_t *p_cstr);
@@ -235,7 +240,10 @@ public:
 
 	_FORCE_INLINE_ CharString() {}
 	_FORCE_INLINE_ CharString(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ CharString(CharString &&p_str) :
+			_cowdata(std::move(p_str._cowdata)) {}
 	_FORCE_INLINE_ void operator=(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ void operator=(CharString &&p_str) { _cowdata = std::move(p_str._cowdata); }
 	_FORCE_INLINE_ CharString(const char *p_cstr) { copy_from(p_cstr); }
 
 	void operator=(const char *p_cstr);
@@ -594,7 +602,10 @@ public:
 
 	_FORCE_INLINE_ String() {}
 	_FORCE_INLINE_ String(const String &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ String(String &&p_str) :
+			_cowdata(std::move(p_str._cowdata)) {}
 	_FORCE_INLINE_ void operator=(const String &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ void operator=(String &&p_str) { _cowdata = std::move(p_str._cowdata); }
 
 	Vector<uint8_t> to_ascii_buffer() const;
 	Vector<uint8_t> to_utf8_buffer() const;

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -167,6 +167,15 @@ private:
 
 public:
 	void operator=(const CowData<T> &p_from) { _ref(p_from); }
+	void operator=(CowData<T> &&p_from) {
+		if (_ptr == p_from._ptr) {
+			return;
+		}
+
+		_unref();
+		_ptr = p_from._ptr;
+		p_from._ptr = nullptr;
+	}
 
 	_FORCE_INLINE_ T *ptrw() {
 		_copy_on_write();
@@ -241,7 +250,11 @@ public:
 
 	_FORCE_INLINE_ CowData() {}
 	_FORCE_INLINE_ ~CowData();
-	_FORCE_INLINE_ CowData(CowData<T> &p_from) { _ref(p_from); }
+	_FORCE_INLINE_ CowData(const CowData<T> &p_from) { _ref(p_from); }
+	_FORCE_INLINE_ CowData(CowData<T> &&p_from) {
+		_ptr = p_from._ptr;
+		p_from._ptr = nullptr;
+	}
 };
 
 template <typename T>

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -47,6 +47,7 @@
 
 #include <climits>
 #include <initializer_list>
+#include <utility>
 
 template <typename T>
 class VectorWriteProxy {
@@ -147,9 +148,8 @@ public:
 		insert(i, p_val);
 	}
 
-	inline void operator=(const Vector &p_from) {
-		_cowdata._ref(p_from._cowdata);
-	}
+	void operator=(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
+	void operator=(Vector &&p_from) { _cowdata = std::move(p_from._cowdata); }
 
 	Vector<uint8_t> to_byte_array() const {
 		Vector<uint8_t> ret;
@@ -290,6 +290,8 @@ public:
 		}
 	}
 	_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
+	_FORCE_INLINE_ Vector(Vector &&p_from) :
+			_cowdata(std::move(p_from._cowdata)) {}
 
 	_FORCE_INLINE_ ~Vector() {}
 };


### PR DESCRIPTION
This will allow the compiler to optimize transfer of data better. Previously, a transfer would necessitate incrementing and decrementing the `refcount` unnecessarily. Now, it is possible to simply transfer the data by swapping pointer ownership.

The new constructor and assignment operators are selected automatically, instead of the copy versions, for compatible callers, without any explicit adjustments required.

This should grease the gears and make some parts of Godot faster and / or smaller and / or compile faster by a nebulous small factor.