### PR TITLE
Add priority-based blending to reflection probes.

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -529,6 +529,14 @@ protected:
 		return forward_id_storage_mobile;
 	}
 
+	struct ForwardIDByMapSort {
+		uint8_t map;
+		RendererRD::ForwardID forward_id;
+		bool operator<(const ForwardIDByMapSort &p_sort) const {
+			return map > p_sort.map;
+		}
+	};
+
 public:
 	static RenderForwardMobile *get_singleton() { return singleton; }
 

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -1897,17 +1897,29 @@ void fragment_shader(in SceneData scene_data) {
 					continue; //not masked
 				}
 
+				if (reflection_accum.a >= 1.0 && ambient_accum.a >= 1.0) {
+					break;
+				}
+
 				reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
 			}
 		}
 
+		if (ambient_accum.a < 1.0) {
+			ambient_accum.rgb = mix(ambient_light, ambient_accum.rgb, ambient_accum.a);
+		}
+
+		if (reflection_accum.a < 1.0) {
+			reflection_accum.rgb = mix(specular_light, reflection_accum.rgb, reflection_accum.a);
+		}
+
 		if (reflection_accum.a > 0.0) {
-			specular_light = reflection_accum.rgb / reflection_accum.a;
+			specular_light = reflection_accum.rgb;
 		}
 
 #if !defined(USE_LIGHTMAP)
 		if (ambient_accum.a > 0.0) {
-			ambient_light = ambient_accum.rgb / ambient_accum.a;
+			ambient_light = ambient_accum.rgb;
 		}
 #endif
 	}

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1364,16 +1364,29 @@ void main() {
 		uvec2 reflection_indices = instances.data[draw_call.instance_index].reflection_probes;
 		for (uint i = 0; i < sc_reflection_probes(); i++) {
 			uint reflection_index = (i > 3) ? ((reflection_indices.y >> ((i - 4) * 8)) & 0xFF) : ((reflection_indices.x >> (i * 8)) & 0xFF);
-			reflection_process(reflection_index, vertex, ref_vec, bent_normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
+
+			if (reflection_accum.a >= 1.0 && ambient_accum.a >= 1.0) {
+				break;
+			}
+
+			reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
+		}
+
+		if (ambient_accum.a < 1.0) {
+			ambient_accum.rgb = mix(ambient_light, ambient_accum.rgb, ambient_accum.a);
+		}
+
+		if (reflection_accum.a < 1.0) {
+			reflection_accum.rgb = mix(specular_light, reflection_accum.rgb, reflection_accum.a);
 		}
 
 		if (reflection_accum.a > 0.0) {
-			specular_light = reflection_accum.rgb / reflection_accum.a;
+			specular_light = reflection_accum.rgb;
 		}
 
 #if !defined(USE_LIGHTMAP)
 		if (ambient_accum.a > 0.0) {
-			ambient_light = ambient_accum.rgb / ambient_accum.a;
+			ambient_light = ambient_accum.rgb;
 		}
 #endif
 	} //Reflection probes

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1732,11 +1732,12 @@ void LightStorage::update_reflection_probe_buffer(RenderDataRD *p_render_data, c
 		if (!rpi) {
 			continue;
 		}
-
-		Transform3D transform = rpi->transform;
+		ReflectionProbe *probe = reflection_probe_owner.get_or_null(rpi->probe);
+		Vector3 extents = probe->size / 2;
+		float probe_size = extents.length();
 
 		reflection_sort[reflection_count].probe_instance = rpi;
-		reflection_sort[reflection_count].depth = -p_camera_inverse_transform.xform(transform.origin).z;
+		reflection_sort[reflection_count].size = -probe_size;
 		reflection_count++;
 	}
 

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -316,10 +316,10 @@ private:
 	};
 
 	struct ReflectionProbeInstanceSort {
-		float depth;
+		float size;
 		ReflectionProbeInstance *probe_instance;
 		bool operator<(const ReflectionProbeInstanceSort &p_sort) const {
-			return depth < p_sort.depth;
+			return size < p_sort.size;
 		}
 	};
 


### PR DESCRIPTION
Supersedes #89408
Closes https://github.com/godotengine/godot-proposals/issues/8167
Fixes: https://github.com/godotengine/godot/issues/101074

This PR implements size-based priority blending by sorting reflection indexes based on the extents size before their contribution is computed in reflection_process. This sorting step is necessary to allow for correct blending between probes, where the correct priorities are respected in the blending areas. It also allows us to do an early-out for consecutive probes if the accum alpha channels > 1, skipping reflection/ambient calculations. Sorting is supported for up to 32 probes overlapping on a pixel.

The behavior is following the UX of Unreal Engines reflection captures because:
- A manual priority int introduces a significant extra workload on artists, especially when using a nested-probe workflow which is standard practice.
- Fully blending reflection probes is not favorable, since it introduces duplicate reflections.
- This UX is fast and effective.

The reasoning for blending based on size, as opposed to exposing a manual priority int, is outlined in more detail here: https://github.com/godotengine/godot/pull/89408#issuecomment-2505587939

This PR is only relevant for forward+ and mobile, since compatibility has strong limitations on reflection probes. I don't think it makes sense to implement these changes there.

It makes sense to merge #99958 before this pr, since the current blending logic on master doesn't allow probes to have 100% opacity, so it doesn't work great with these changes since you always still blend with lower priority probes. It also makes sense to have control over blending distances for this PR.

For the screenshots of this pr I increased the blending strength temporarily since it makes it more representative of how these changes work with #99958.
Sorting behavior:
![24_12_10_12_11__godot windows editor x86_64_1KE84ngh7y](https://github.com/user-attachments/assets/fd29a6c0-92b4-43e7-b2ff-2adeaac50b56)

| This PR | 4.3 |
| -- | -- |
| ![24_12_12_22_03__godot windows editor x86_64_CKxtThuEp9](https://github.com/user-attachments/assets/7d508a95-f0b2-459d-a1d1-40356c7d3885) | ![24_12_10_12_50__4zDuFovebk](https://github.com/user-attachments/assets/617d1a81-072a-4208-b5e9-4cc6f42b5c3e) |
| Smaller probes take priority. | All probes blend together. |

**_4.3:_**

https://github.com/user-attachments/assets/1b91a22b-dd4a-4956-8be9-864657240d59

**_This PR:_**

https://github.com/user-attachments/assets/4919dedf-ab00-4e12-89f6-c0b04d65557f



**_Interior probe behavior_**
| With other probe (This PR) | With other probe (4.3) |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/8563ce50-1051-43cc-9407-b24274c64311) | ![image](https://github.com/user-attachments/assets/1973d52e-2d40-4cc9-9846-17a8b1eb8d78) |

| With sky (This PR) | With sky (4.3) |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/4f191315-5144-4431-b929-c477a5bcecbe) | ![image](https://github.com/user-attachments/assets/515d328b-9b4e-425e-96ed-c06a8c716ad7) |
