### PR TITLE
[Web] Restore ScriptProcessorNode audio driver fallback

### DIFF
--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -479,6 +479,8 @@ void AudioDriverWorklet::_capture_callback(int p_pos, int p_samples) {
 	driver->_audio_driver_capture(p_pos, p_samples);
 }
 
+#endif // THREADS_ENABLED
+
 /// ScriptProcessorNode implementation
 AudioDriverScriptProcessor *AudioDriverScriptProcessor::singleton = nullptr;
 
@@ -497,5 +499,3 @@ Error AudioDriverScriptProcessor::create(int &p_buffer_samples, int p_channels) 
 void AudioDriverScriptProcessor::start(float *p_out_buf, int p_out_buf_size, float *p_in_buf, int p_in_buf_size) {
 	godot_audio_script_start(p_in_buf, p_in_buf_size, p_out_buf, p_out_buf_size, &_process_callback);
 }
-
-#endif // THREADS_ENABLED

--- a/platform/web/audio_driver_web.h
+++ b/platform/web/audio_driver_web.h
@@ -169,6 +169,8 @@ public:
 	AudioDriverWorklet() { singleton = this; }
 };
 
+#endif // THREADS_ENABLED
+
 class AudioDriverScriptProcessor : public AudioDriverWeb {
 private:
 	static void _process_callback();
@@ -178,7 +180,6 @@ private:
 protected:
 	virtual Error create(int &p_buffer_size, int p_output_channels) override;
 	virtual void start(float *p_out_buf, int p_out_buf_size, float *p_in_buf, int p_in_buf_size) override;
-	virtual void finish_driver() override;
 
 public:
 	virtual const char *get_name() const override { return "ScriptProcessor"; }
@@ -190,7 +191,5 @@ public:
 
 	AudioDriverScriptProcessor() { singleton = this; }
 };
-
-#endif // THREADS_ENABLED
 
 #endif // AUDIO_DRIVER_WEB_H

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -2160,7 +2160,7 @@ autoAddDeps(GodotAudioWorklet, '$GodotAudioWorklet');
 mergeInto(LibraryManager.library, GodotAudioWorklet);
 
 /*
- * The ScriptProcessorNode API, used when threads are disabled.
+ * The ScriptProcessorNode API, used as a fallback if AudioWorklet is not available.
  */
 const GodotAudioScript = {
 	$GodotAudioScript__deps: ['$GodotAudio'],

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -275,6 +275,7 @@ OS_Web::OS_Web() {
 
 	if (AudioDriverWeb::is_available()) {
 		audio_drivers.push_back(memnew(AudioDriverWorklet));
+		audio_drivers.push_back(memnew(AudioDriverScriptProcessor));
 	}
 	for (AudioDriverWeb *audio_driver : audio_drivers) {
 		AudioDriverManager::add_driver(audio_driver);


### PR DESCRIPTION
Godot has a ScriptProcessorNode audio driver implementation for the (deprecated) Web API.

As reported by some users, this fallback was not properly re-added during the Godot 4 transition, and was left as "dead code".

While the API is deprecated, it is still supported by most browsers, and some WebView may not implement AudioWorklet correctly (the new recommended API).

This commit re-adds the ScriptProcessorNode implementation as a fallback if the AudioWorklet driver fails to initialized (and can be forced if desired via project settings as usual).