### PR TITLE
Add a GitHub action to warn if the binary size is significantly larger than the reference binary size.

### DIFF
--- a/.github/actions/check-artifact-size/action.yml
+++ b/.github/actions/check-artifact-size/action.yml
@@ -1,0 +1,50 @@
+name: Check master and artifact binary sizes
+description: Check master and artifact binary sizes for Godot artifacts.
+inputs:
+  name:
+    description: The artifact name.
+    default: "${{ github.job }}"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download artifact
+      id: download-artifact
+      uses: dawidd6/action-download-artifact@v7
+      with:
+        commit: ${{github.event.pull_request.base.sha}}
+        name: ${{inputs.name}}
+        path: bin_ref/
+    - name: Compare binary size with the base build.
+      shell: bash
+      run: |
+        file_path_old="bin_ref/"
+        if [ ! -d "${file_path_old}" ]; then
+          echo "Directory ${file_path_old} does not exist, exiting..."
+          exit 0
+        fi
+        file_path_new="bin/"
+        if [ ! -d "${file_path_new}" ]; then
+          echo "Directory ${file_path_new} does not exist, exiting..."
+          exit 0
+        fi
+        # Excludes hidden files and folders, like the upload job.
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          actual_size_old=$(find "$file_path_old" -type d -name '.*' -prune -o -type f ! -name '.*' -exec stat -f%z {} + | awk '{total += $1} END {print total}')
+          actual_size_new=$(find "$file_path_new" -type d -name '.*' -prune -o -type f ! -name '.*' -exec stat -f%z {} + | awk '{total += $1} END {print total}')
+        else
+          actual_size_old=$(find "$file_path_old" -type d -name '.*' -prune -o -type f ! -name '.*' -exec stat --printf="%s\n" {} + | awk '{total += $1} END {print total}')
+          actual_size_new=$(find "$file_path_new" -type d -name '.*' -prune -o -type f ! -name '.*' -exec stat --printf="%s\n" {} + | awk '{total += $1} END {print total}')
+        fi
+        size_difference=$((actual_size_new - actual_size_old))
+        if [[ $size_difference -ge 1 ]]; then
+          if [[ $size_difference -gt 1048576 ]]; then
+            echo -e "::warning::\033[1mBinary size:\033[0m The binary is \033[1;91m$size_difference bytes larger\033[0m than the reference ($actual_size_old -> $actual_size_new bytes)."
+          else
+            echo -e "\033[1mBinary size:\033[0m The binary is \033[1;91m$size_difference bytes larger\033[0m than the reference ($actual_size_old -> $actual_size_new bytes)."
+          fi
+        elif [[ $size_difference -lt 0 ]]; then
+          echo -e "\033[1mBinary size:\033[0m The binary is \033[1;92m$((-size_difference)) bytes smaller\033[0m than the reference ($actual_size_old -> $actual_size_new bytes)."
+        else
+          echo -e "\033[1mBinary size:\033[0m The binary is \033[1;92mexactly as the reference ($actual_size_old -> $actual_size_new bytes).\033[0m"
+        fi

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -105,3 +105,9 @@ jobs:
         uses: ./.github/actions/upload-artifact
         with:
           name: ${{ matrix.cache-name }}
+
+      - name: Check artifact sizes
+        uses: ./.github/actions/check-artifact-size
+        if: github.event_name == 'pull_request'
+        with:
+          name: ${{ matrix.cache-name }}

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -44,3 +44,7 @@ jobs:
 
       - name: Upload artifact
         uses: ./.github/actions/upload-artifact
+
+      - name: Check artifact sizes
+        uses: ./.github/actions/check-artifact-size
+        if: github.event_name == 'pull_request'

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -8,51 +8,51 @@ concurrency:
 jobs:
   # First stage: Only static checks, fast and prevent expensive builds from running.
 
-  static-checks:
-    if: '!vars.DISABLE_GODOT_CI'
-    name: 📊 Static checks
-    uses: ./.github/workflows/static_checks.yml
+#  static-checks:
+#    if: '!vars.DISABLE_GODOT_CI'
+#    name: 📊 Static checks
+#    uses: ./.github/workflows/static_checks.yml
 
   # Second stage: Run all the builds and some of the tests.
 
-  android-build:
-    name: 🤖 Android
-    needs: static-checks
-    uses: ./.github/workflows/android_builds.yml
+#  android-build:
+#    name: 🤖 Android
+#    needs: static-checks
+#    uses: ./.github/workflows/android_builds.yml
 
   ios-build:
     name: 🍏 iOS
-    needs: static-checks
+#    needs: static-checks
     uses: ./.github/workflows/ios_builds.yml
 
-  linux-build:
-    name: 🐧 Linux
-    needs: static-checks
-    uses: ./.github/workflows/linux_builds.yml
-
-  macos-build:
-    name: 🍎 macOS
-    needs: static-checks
-    uses: ./.github/workflows/macos_builds.yml
-
-  windows-build:
-    name: 🏁 Windows
-    needs: static-checks
-    uses: ./.github/workflows/windows_builds.yml
-
+#  linux-build:
+#    name: 🐧 Linux
+#    needs: static-checks
+#    uses: ./.github/workflows/linux_builds.yml
+#
+#  macos-build:
+#    name: 🍎 macOS
+#    needs: static-checks
+#    uses: ./.github/workflows/macos_builds.yml
+#
+#  windows-build:
+#    name: 🏁 Windows
+#    needs: static-checks
+#    uses: ./.github/workflows/windows_builds.yml
+#
   web-build:
     name: 🌐 Web
-    needs: static-checks
+#    needs: static-checks
     uses: ./.github/workflows/web_builds.yml
-
-  # Third stage: Run auxiliary tests using build artifacts from previous jobs.
-
-  # Can be turned off for PRs that intentionally break compat with godot-cpp,
-  # until both the upstream PR and the matching godot-cpp changes are merged.
-  godot-cpp-test:
-    name: 🪲 Godot CPP
-    # This can be changed to depend on another platform, if we decide to use it for
-    # godot-cpp instead. Make sure to move the .github/actions/godot-api-dump step
-    # appropriately.
-    needs: linux-build
-    uses: ./.github/workflows/godot_cpp_test.yml
+#
+#  # Third stage: Run auxiliary tests using build artifacts from previous jobs.
+#
+#  # Can be turned off for PRs that intentionally break compat with godot-cpp,
+#  # until both the upstream PR and the matching godot-cpp changes are merged.
+#  godot-cpp-test:
+#    name: 🪲 Godot CPP
+#    # This can be changed to depend on another platform, if we decide to use it for
+#    # godot-cpp instead. Make sure to move the .github/actions/godot-api-dump step
+#    # appropriately.
+#    needs: linux-build
+#    uses: ./.github/workflows/godot_cpp_test.yml

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -79,3 +79,9 @@ jobs:
         if: matrix.artifact
         with:
           name: ${{ matrix.cache-name }}
+
+      - name: Check artifact sizes
+        uses: ./.github/actions/check-artifact-size
+        if: github.event_name == 'pull_request'
+        with:
+          name: ${{ matrix.cache-name }}


### PR DESCRIPTION
Follow-up of #91715.
The related proposal is https://github.com/godotengine/godot-proposals/issues/9705

Basically, we're adding a github action to the runner that warns PRs if the binary size is larger than the reference binary size. 

Unfortunately, there is no WARN output state for github actions, or at least [last time i tried](https://github.com/godotengine/godot/pull/99126) I didn't find a good way to do it. It's questionable whether anyone will check the action log, but it does work. Open to other approaches.