### PR TITLE
Reserve space for LocalVector if size is known

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -848,6 +848,7 @@ Ref<Resource> ResourceLoader::_load_complete_inner(LoadToken &p_load_token, Erro
 		if (curr_load_task) {
 			// A task awaiting another => Let the awaiter accumulate the resource changed connections.
 			DEV_ASSERT(curr_load_task != load_task_ptr);
+			curr_load_task->resource_changed_connections.reserve(curr_load_task->resource_changed_connections.size() + load_task_ptr->resource_changed_connections.size());
 			for (const ThreadLoadTask::ResourceChangedConnection &rcc : load_task_ptr->resource_changed_connections) {
 				curr_load_task->resource_changed_connections.push_back(rcc);
 			}

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -132,12 +132,19 @@ void AStarGrid2D::update() {
 	const int32_t end_x = region.get_end().x;
 	const int32_t end_y = region.get_end().y;
 	const Vector2 half_cell_size = cell_size / 2;
+
+	points.reserve(MAX(end_y - region.position.y, 0));
+	solid_mask.reserve(MAX(end_x - region.position.x + 2, 0) * MAX(end_y - region.position.y + 2, 0));
+
 	for (int32_t x = region.position.x; x < end_x + 2; x++) {
 		solid_mask.push_back(true);
 	}
 
+	LocalVector<Point> line;
+	line.reserve(MAX(end_x - region.position.x, 0));
+
 	for (int32_t y = region.position.y; y < end_y; y++) {
-		LocalVector<Point> line;
+		line.clear();
 		solid_mask.push_back(true);
 		for (int32_t x = region.position.x; x < end_x; x++) {
 			Vector2 v = offset;

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -2176,6 +2176,7 @@ real_t ConvexHullComputer::compute(const Vector3 *p_coords, int32_t p_count, rea
 
 	LocalVector<ConvexHullInternal::Vertex *> old_vertices;
 	get_vertex_copy(hull.vertex_list, old_vertices);
+	vertices.reserve(old_vertices.size());
 	int32_t copied = 0;
 	while (copied < (int32_t)old_vertices.size()) {
 		ConvexHullInternal::Vertex *v = old_vertices[copied];

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -248,6 +248,7 @@ public:
 			Simplex *root = memnew(Simplex(point_count + 0, point_count + 1, point_count + 2, point_count + 3));
 			root->SE = simplex_list.push_back(root);
 
+			root->grid_positions.reserve(ACCEL_GRID_SIZE * ACCEL_GRID_SIZE * ACCEL_GRID_SIZE);
 			for (uint32_t i = 0; i < ACCEL_GRID_SIZE; i++) {
 				for (uint32_t j = 0; j < ACCEL_GRID_SIZE; j++) {
 					for (uint32_t k = 0; k < ACCEL_GRID_SIZE; k++) {
@@ -338,6 +339,7 @@ public:
 					from = from.clampi(0, ACCEL_GRID_SIZE - 1);
 					to = to.clampi(0, ACCEL_GRID_SIZE - 1);
 
+					new_simplex->grid_positions.reserve(MAX(to.x - from.x + 1, 0) * MAX(to.y - from.y + 1, 0) * MAX(to.z - from.z + 1, 0));
 					for (int32_t x = from.x; x <= to.x; x++) {
 						for (int32_t y = from.y; y <= to.y; y++) {
 							for (int32_t z = from.z; z <= to.z; z++) {

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -387,6 +387,7 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E, bool p_execu
 						method_callback(method_callback_ud, obj, op.name, nullptr, 0);
 					} else {
 						args.clear();
+						args.reserve(binds.size());
 
 						for (int i = 0; i < binds.size(); i++) {
 							args.push_back(&binds[i]);


### PR DESCRIPTION
As stated in [99936(comment)](https://github.com/godotengine/godot/pull/99936#issuecomment-2515610193), use `LocalVector::reserve()` if we can.

This covers the `core` directory. All these cases are trival and should be riskless.

Some length are wrapped with `MAX(length, 0)` to avoid negative value. Please tell me if these check can be removed.
