### PR TITLE
Fix TileMapLayer emitting changed() signal after get_tree().quit()

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1648,7 +1648,9 @@ RBSet<TerrainConstraint> TileMapLayer::_get_terrain_constraints_from_painted_cel
 void TileMapLayer::_tile_set_changed() {
 	dirty.flags[DIRTY_FLAGS_TILE_SET] = true;
 	_queue_internal_update();
-	emit_signal(CoreStringName(changed));
+	if (is_inside_tree()) {
+		emit_signal(CoreStringName(changed));
+	}
 }
 
 void TileMapLayer::_renamed() {


### PR DESCRIPTION
If changed() callback of TileMapLayer accesses a tile_set property, game
hangs on close since changed() is emitted after the TileSet has been removed
from the scene tree.

This new check prevents changed() from being emitted when closing the
game.

Fixes #96898.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
