### PR TITLE
Core: Consolidate index error macro logic

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -86,7 +86,7 @@ Input *Input::get_singleton() {
 }
 
 void Input::set_mouse_mode(MouseMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 5);
+	ERR_FAIL_INDEX(p_mode, 5);
 
 	if (p_mode == mouse_mode) {
 		return;
@@ -1223,7 +1223,7 @@ void Input::set_event_dispatch_function(EventDispatchFunc p_function) {
 void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 	_THREAD_SAFE_METHOD_;
 	Joypad &joy = joy_names[p_device];
-	ERR_FAIL_INDEX((int)p_button, (int)JoyButton::MAX);
+	ERR_FAIL_INDEX(p_button, JoyButton::MAX);
 
 	if (joy.last_buttons[(size_t)p_button] == p_pressed) {
 		return;
@@ -1250,7 +1250,7 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 	_THREAD_SAFE_METHOD_;
 
-	ERR_FAIL_INDEX((int)p_axis, (int)JoyAxis::MAX);
+	ERR_FAIL_INDEX(p_axis, JoyAxis::MAX);
 
 	Joypad &joy = joy_names[p_device];
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -403,7 +403,7 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 					String path;
 
 					if (using_named_scene_ids) { // New format.
-						ERR_FAIL_INDEX_V((int)index, internal_resources.size(), ERR_PARSE_ERROR);
+						ERR_FAIL_INDEX_V(index, internal_resources.size(), ERR_PARSE_ERROR);
 						path = internal_resources[index].path;
 					} else {
 						path += res_path + "::" + itos(index);

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -189,7 +189,7 @@ bool AStarGrid2D::is_jumping_enabled() const {
 }
 
 void AStarGrid2D::set_diagonal_mode(DiagonalMode p_diagonal_mode) {
-	ERR_FAIL_INDEX((int)p_diagonal_mode, (int)DIAGONAL_MODE_MAX);
+	ERR_FAIL_INDEX(p_diagonal_mode, DIAGONAL_MODE_MAX);
 	diagonal_mode = p_diagonal_mode;
 }
 
@@ -198,7 +198,7 @@ AStarGrid2D::DiagonalMode AStarGrid2D::get_diagonal_mode() const {
 }
 
 void AStarGrid2D::set_default_compute_heuristic(Heuristic p_heuristic) {
-	ERR_FAIL_INDEX((int)p_heuristic, (int)HEURISTIC_MAX);
+	ERR_FAIL_INDEX(p_heuristic, HEURISTIC_MAX);
 	default_compute_heuristic = p_heuristic;
 }
 
@@ -207,7 +207,7 @@ AStarGrid2D::Heuristic AStarGrid2D::get_default_compute_heuristic() const {
 }
 
 void AStarGrid2D::set_default_estimate_heuristic(Heuristic p_heuristic) {
-	ERR_FAIL_INDEX((int)p_heuristic, (int)HEURISTIC_MAX);
+	ERR_FAIL_INDEX(p_heuristic, HEURISTIC_MAX);
 	default_estimate_heuristic = p_heuristic;
 }
 

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -648,7 +648,7 @@ public:
 	}
 
 	KeyValue<TKey, TValue> &get_by_index(uint32_t p_index) {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, num_elements);
+		CRASH_BAD_INDEX(p_index, num_elements);
 		return elements[p_index];
 	}
 

--- a/core/templates/bin_sorted_array.h
+++ b/core/templates/bin_sorted_array.h
@@ -61,7 +61,7 @@ public:
 	}
 
 	uint64_t move(uint64_t p_idx, uint64_t p_bin) {
-		ERR_FAIL_UNSIGNED_INDEX_V(p_idx, array.size(), -1);
+		ERR_FAIL_INDEX_V(p_idx, array.size(), -1);
 
 		uint64_t current_bin = bin_limits.size() - 1;
 		while (p_idx > bin_limits[current_bin]) {
@@ -113,7 +113,7 @@ public:
 	}
 
 	void remove_at(uint64_t p_idx) {
-		ERR_FAIL_UNSIGNED_INDEX(p_idx, array.size());
+		ERR_FAIL_INDEX(p_idx, array.size());
 		uint64_t new_idx = move(p_idx, 0);
 		uint64_t swap_idx = array.size() - 1;
 

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -72,7 +72,7 @@ public:
 	}
 
 	void remove_at(U p_index) {
-		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
+		ERR_FAIL_INDEX(p_index, count);
 		count--;
 		for (U i = p_index; i < count; i++) {
 			data[i] = data[i + 1];
@@ -170,11 +170,11 @@ public:
 		}
 	}
 	_FORCE_INLINE_ const T &operator[](U p_index) const {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+		CRASH_BAD_INDEX(p_index, count);
 		return data[p_index];
 	}
 	_FORCE_INLINE_ T &operator[](U p_index) {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+		CRASH_BAD_INDEX(p_index, count);
 		return data[p_index];
 	}
 
@@ -243,7 +243,7 @@ public:
 	}
 
 	void insert(U p_pos, T p_val) {
-		ERR_FAIL_UNSIGNED_INDEX(p_pos, count + 1);
+		ERR_FAIL_INDEX(p_pos, count + 1);
 		if (p_pos == count) {
 			push_back(p_val);
 		} else {

--- a/core/templates/paged_array.h
+++ b/core/templates/paged_array.h
@@ -166,14 +166,14 @@ class PagedArray {
 
 public:
 	_FORCE_INLINE_ const T &operator[](uint64_t p_index) const {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+		CRASH_BAD_INDEX(p_index, count);
 		uint32_t page = p_index >> page_size_shift;
 		uint32_t offset = p_index & page_size_mask;
 
 		return page_data[page][offset];
 	}
 	_FORCE_INLINE_ T &operator[](uint64_t p_index) {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, count);
+		CRASH_BAD_INDEX(p_index, count);
 		uint32_t page = p_index >> page_size_shift;
 		uint32_t offset = p_index & page_size_mask;
 
@@ -230,7 +230,7 @@ public:
 	}
 
 	void remove_at_unordered(uint64_t p_index) {
-		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
+		ERR_FAIL_INDEX(p_index, count);
 		(*this)[p_index] = (*this)[count - 1];
 		pop_back();
 	}

--- a/core/templates/pooled_list.h
+++ b/core/templates/pooled_list.h
@@ -120,7 +120,7 @@ public:
 	}
 	void free(const U &p_id) {
 		// should not be on free list already
-		ERR_FAIL_UNSIGNED_INDEX(p_id, list.size());
+		ERR_FAIL_INDEX(p_id, list.size());
 		freelist.push_back(p_id);
 		ERR_FAIL_COND_MSG(!_used_size, "_used_size has become out of sync, have you double freed an item?");
 		_used_size--;

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -295,31 +295,31 @@ int Variant::get_constructor_count(Variant::Type p_type) {
 
 Variant::ValidatedConstructor Variant::get_validated_constructor(Variant::Type p_type, int p_constructor) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, nullptr);
-	ERR_FAIL_INDEX_V(p_constructor, (int)construct_data[p_type].size(), nullptr);
+	ERR_FAIL_INDEX_V(p_constructor, construct_data[p_type].size(), nullptr);
 	return construct_data[p_type][p_constructor].validated_construct;
 }
 
 Variant::PTRConstructor Variant::get_ptr_constructor(Variant::Type p_type, int p_constructor) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, nullptr);
-	ERR_FAIL_INDEX_V(p_constructor, (int)construct_data[p_type].size(), nullptr);
+	ERR_FAIL_INDEX_V(p_constructor, construct_data[p_type].size(), nullptr);
 	return construct_data[p_type][p_constructor].ptr_construct;
 }
 
 int Variant::get_constructor_argument_count(Variant::Type p_type, int p_constructor) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, -1);
-	ERR_FAIL_INDEX_V(p_constructor, (int)construct_data[p_type].size(), -1);
+	ERR_FAIL_INDEX_V(p_constructor, construct_data[p_type].size(), -1);
 	return construct_data[p_type][p_constructor].argument_count;
 }
 
 Variant::Type Variant::get_constructor_argument_type(Variant::Type p_type, int p_constructor, int p_argument) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, Variant::VARIANT_MAX);
-	ERR_FAIL_INDEX_V(p_constructor, (int)construct_data[p_type].size(), Variant::VARIANT_MAX);
+	ERR_FAIL_INDEX_V(p_constructor, construct_data[p_type].size(), Variant::VARIANT_MAX);
 	return construct_data[p_type][p_constructor].get_argument_type(p_argument);
 }
 
 String Variant::get_constructor_argument_name(Variant::Type p_type, int p_constructor, int p_argument) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, String());
-	ERR_FAIL_INDEX_V(p_constructor, (int)construct_data[p_type].size(), String());
+	ERR_FAIL_INDEX_V(p_constructor, construct_data[p_type].size(), String());
 	return construct_data[p_type][p_constructor].arg_names[p_argument];
 }
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -963,7 +963,7 @@ String VariantUtilityFunctions::error_string(Error error) {
 }
 
 String VariantUtilityFunctions::type_string(Variant::Type p_type) {
-	ERR_FAIL_INDEX_V_MSG((int)p_type, (int)Variant::VARIANT_MAX, "<invalid type>", "Invalid type argument to type_string(), use the TYPE_* constants.");
+	ERR_FAIL_INDEX_V_MSG(p_type, Variant::VARIANT_MAX, "<invalid type>", "Invalid type argument to type_string(), use the TYPE_* constants.");
 	return Variant::get_type_name(p_type);
 }
 

--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -315,7 +315,7 @@ Error EGLManager::window_create(DisplayServer::WindowID p_window_id, void *p_dis
 }
 
 void EGLManager::window_destroy(DisplayServer::WindowID p_window_id) {
-	ERR_FAIL_INDEX(p_window_id, (int)windows.size());
+	ERR_FAIL_INDEX(p_window_id, windows.size());
 
 	GLWindow &glwindow = windows[p_window_id];
 
@@ -325,7 +325,7 @@ void EGLManager::window_destroy(DisplayServer::WindowID p_window_id) {
 
 	glwindow.initialized = false;
 
-	ERR_FAIL_INDEX(glwindow.gldisplay_id, (int)displays.size());
+	ERR_FAIL_INDEX(glwindow.gldisplay_id, displays.size());
 	GLDisplay &gldisplay = displays[glwindow.gldisplay_id];
 
 	if (glwindow.egl_surface != EGL_NO_SURFACE) {

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2098,7 +2098,7 @@ void RasterizerSceneGLES3::_render_shadow_pass(RID p_light, RID p_shadow_atlas, 
 		uint32_t quadrant = (key >> GLES3::LightStorage::QUADRANT_SHIFT) & 0x3;
 		uint32_t shadow = key & GLES3::LightStorage::SHADOW_INDEX_MASK;
 
-		ERR_FAIL_INDEX((int)shadow, light_storage->shadow_atlas_get_quadrant_shadows_length(p_shadow_atlas, quadrant));
+		ERR_FAIL_INDEX(shadow, light_storage->shadow_atlas_get_quadrant_shadows_length(p_shadow_atlas, quadrant));
 
 		int shadow_size = light_storage->shadow_atlas_get_quadrant_shadow_size(p_shadow_atlas, quadrant);
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -232,10 +232,10 @@ protected:
 		ERR_FAIL_INDEX_V(p_which, uniform_count, -1);
 		Version *version = version_owner.get_or_null(p_version);
 		ERR_FAIL_NULL_V(version, -1);
-		ERR_FAIL_INDEX_V(p_variant, int(version->variants.size()), -1);
+		ERR_FAIL_INDEX_V(p_variant, version->variants.size(), -1);
 		Version::Specialization *spec = version->variants[p_variant].lookup_ptr(p_specialization);
 		ERR_FAIL_NULL_V(spec, -1);
-		ERR_FAIL_INDEX_V(p_which, int(spec->uniform_location.size()), -1);
+		ERR_FAIL_INDEX_V(p_which, spec->uniform_location.size(), -1);
 		return spec->uniform_location[p_which];
 	}
 

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -827,52 +827,52 @@ public:
 	_FORCE_INLINE_ int shadow_atlas_get_quadrant_shadows_length(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].shadows.size();
 	}
 
 	_FORCE_INLINE_ uint32_t shadow_atlas_get_quadrant_shadows_allocated(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].textures.size();
 	}
 
 	_FORCE_INLINE_ uint32_t shadow_atlas_get_quadrant_subdivision(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].subdivision;
 	}
 
 	_FORCE_INLINE_ GLuint shadow_atlas_get_quadrant_shadow_texture(RID p_atlas, uint32_t p_quadrant, uint32_t p_shadow) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_shadow, atlas->quadrants[p_quadrant].textures.size(), 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_shadow, atlas->quadrants[p_quadrant].textures.size(), 0);
 		return atlas->quadrants[p_quadrant].textures[p_shadow];
 	}
 
 	_FORCE_INLINE_ GLuint shadow_atlas_get_quadrant_shadow_fb(RID p_atlas, uint32_t p_quadrant, uint32_t p_shadow) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_shadow, atlas->quadrants[p_quadrant].fbos.size(), 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_shadow, atlas->quadrants[p_quadrant].fbos.size(), 0);
 		return atlas->quadrants[p_quadrant].fbos[p_shadow];
 	}
 
 	_FORCE_INLINE_ int shadow_atlas_get_quadrant_shadow_size(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return (atlas->size >> 1) / atlas->quadrants[p_quadrant].subdivision;
 	}
 
 	_FORCE_INLINE_ bool shadow_atlas_get_quadrant_shadow_is_omni(RID p_atlas, uint32_t p_quadrant, uint32_t p_shadow) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, false);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, false);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_shadow, (uint32_t)atlas->quadrants[p_quadrant].shadows.size(), false);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, false);
+		ERR_FAIL_INDEX_V(p_shadow, atlas->quadrants[p_quadrant].shadows.size(), false);
 		return atlas->quadrants[p_quadrant].shadows[p_shadow].owner_is_omni;
 	}
 

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -457,7 +457,7 @@ int MeshStorage::mesh_get_blend_shape_count(RID p_mesh) const {
 void MeshStorage::mesh_set_blend_shape_mode(RID p_mesh, RS::BlendShapeMode p_mode) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_INDEX((int)p_mode, 2);
+	ERR_FAIL_INDEX(p_mode, 2);
 
 	mesh->blend_shape_mode = p_mode;
 }
@@ -471,7 +471,7 @@ RS::BlendShapeMode MeshStorage::mesh_get_blend_shape_mode(RID p_mesh) const {
 void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 
 	uint64_t data_size = p_data.size();
@@ -486,7 +486,7 @@ void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, i
 void MeshStorage::mesh_surface_update_attribute_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 
 	uint64_t data_size = p_data.size();
@@ -501,7 +501,7 @@ void MeshStorage::mesh_surface_update_attribute_region(RID p_mesh, int p_surface
 void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 
 	uint64_t data_size = p_data.size();
@@ -516,7 +516,7 @@ void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int
 void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	mesh->surfaces[p_surface]->material = p_material;
 
 	mesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
@@ -526,7 +526,7 @@ void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_mat
 RID MeshStorage::mesh_surface_get_material(RID p_mesh, int p_surface) const {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL_V(mesh, RID());
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_surface, mesh->surface_count, RID());
+	ERR_FAIL_INDEX_V(p_surface, mesh->surface_count, RID());
 
 	return mesh->surfaces[p_surface]->material;
 }
@@ -534,7 +534,7 @@ RID MeshStorage::mesh_surface_get_material(RID p_mesh, int p_surface) const {
 RS::SurfaceData MeshStorage::mesh_get_surface(RID p_mesh, int p_surface) const {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL_V(mesh, RS::SurfaceData());
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_surface, mesh->surface_count, RS::SurfaceData());
+	ERR_FAIL_INDEX_V(p_surface, mesh->surface_count, RS::SurfaceData());
 
 	Mesh::Surface &s = *mesh->surfaces[p_surface];
 
@@ -1078,7 +1078,7 @@ void MeshStorage::mesh_instance_set_skeleton(RID p_mesh_instance, RID p_skeleton
 void MeshStorage::mesh_instance_set_blend_shape_weight(RID p_mesh_instance, int p_shape, float p_weight) {
 	MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
 	ERR_FAIL_NULL(mi);
-	ERR_FAIL_INDEX(p_shape, (int)mi->blend_weights.size());
+	ERR_FAIL_INDEX(p_shape, mi->blend_weights.size());
 	mi->blend_weights[p_shape] = p_weight;
 	mi->dirty = true;
 }
@@ -1569,7 +1569,7 @@ void MeshStorage::_multimesh_mark_dirty(MultiMesh *multimesh, int p_index, bool 
 	uint32_t region_index = p_index / MULTIMESH_DIRTY_REGION_SIZE;
 #ifdef DEBUG_ENABLED
 	uint32_t data_cache_dirty_region_count = Math::division_round_up(multimesh->instances, MULTIMESH_DIRTY_REGION_SIZE);
-	ERR_FAIL_UNSIGNED_INDEX(region_index, data_cache_dirty_region_count); //bug
+	ERR_FAIL_INDEX(region_index, data_cache_dirty_region_count); //bug
 #endif
 	if (!multimesh->data_cache_dirty_regions[region_index]) {
 		multimesh->data_cache_dirty_regions[region_index] = true;

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -337,7 +337,7 @@ public:
 	_FORCE_INLINE_ void *mesh_get_surface(RID p_mesh, uint32_t p_surface_index) {
 		Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 		ERR_FAIL_NULL_V(mesh, nullptr);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_surface_index, mesh->surface_count, nullptr);
+		ERR_FAIL_INDEX_V(p_surface_index, mesh->surface_count, nullptr);
 
 		return mesh->surfaces[p_surface_index];
 	}
@@ -460,7 +460,7 @@ public:
 		MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
 		ERR_FAIL_NULL(mi);
 		Mesh *mesh = mi->mesh;
-		ERR_FAIL_UNSIGNED_INDEX(p_surface_index, mesh->surface_count);
+		ERR_FAIL_INDEX(p_surface_index, mesh->surface_count);
 
 		MeshInstance::Surface *mis = &mi->surfaces[p_surface_index];
 		Mesh::Surface *s = mesh->surfaces[p_surface_index];

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -373,17 +373,17 @@ uint64_t Utilities::get_captured_timestamps_frame() const {
 }
 
 uint64_t Utilities::get_captured_timestamp_gpu_time(uint32_t p_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
 	return frames[frame].timestamp_result_values[p_index];
 }
 
 uint64_t Utilities::get_captured_timestamp_cpu_time(uint32_t p_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
 	return frames[frame].timestamp_cpu_result_values[p_index];
 }
 
 String Utilities::get_captured_timestamp_name(uint32_t p_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, String());
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, String());
 	return frames[frame].timestamp_result_names[p_index];
 }
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1855,7 +1855,7 @@ void EditorInspectorArray::_vbox_visibility_changed() {
 }
 
 void EditorInspectorArray::_panel_draw(int p_index) {
-	ERR_FAIL_INDEX(p_index, (int)array_elements.size());
+	ERR_FAIL_INDEX(p_index, array_elements.size());
 
 	Ref<StyleBox> style = get_theme_stylebox(SNAME("Focus"), EditorStringName(EditorStyles));
 	if (!style.is_valid()) {
@@ -1867,7 +1867,7 @@ void EditorInspectorArray::_panel_draw(int p_index) {
 }
 
 void EditorInspectorArray::_panel_gui_input(Ref<InputEvent> p_event, int p_index) {
-	ERR_FAIL_INDEX(p_index, (int)array_elements.size());
+	ERR_FAIL_INDEX(p_index, array_elements.size());
 
 	if (read_only) {
 		return;

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -541,7 +541,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 	Ref<InputEventMouseMotion> mm = p_event;
 	if (mm.is_valid()) {
 		if (drag_type == DRAG_TYPE_DRAG_POINT) {
-			ERR_FAIL_INDEX(drag_polygon_index, (int)polygons.size());
+			ERR_FAIL_INDEX(drag_polygon_index, polygons.size());
 			ERR_FAIL_INDEX(drag_point_index, polygons[drag_polygon_index].size());
 			Point2 point = xform.affine_inverse().xform(mm->get_position());
 			float distance = grab_threshold * 2.0;
@@ -831,7 +831,7 @@ int GenericTilePolygonEditor::add_polygon(const Vector<Point2> &p_polygon, int p
 }
 
 void GenericTilePolygonEditor::remove_polygon(int p_index) {
-	ERR_FAIL_INDEX(p_index, (int)polygons.size());
+	ERR_FAIL_INDEX(p_index, polygons.size());
 	polygons.remove_at(p_index);
 
 	if (polygons.size() == 0) {
@@ -846,7 +846,7 @@ void GenericTilePolygonEditor::clear_polygons() {
 }
 
 void GenericTilePolygonEditor::set_polygon(int p_polygon_index, const Vector<Point2> &p_polygon) {
-	ERR_FAIL_INDEX(p_polygon_index, (int)polygons.size());
+	ERR_FAIL_INDEX(p_polygon_index, polygons.size());
 	ERR_FAIL_COND(p_polygon.size() < 3);
 	polygons[p_polygon_index] = p_polygon;
 	button_edit->set_pressed(true);
@@ -854,7 +854,7 @@ void GenericTilePolygonEditor::set_polygon(int p_polygon_index, const Vector<Poi
 }
 
 Vector<Point2> GenericTilePolygonEditor::get_polygon(int p_polygon_index) {
-	ERR_FAIL_INDEX_V(p_polygon_index, (int)polygons.size(), Vector<Point2>());
+	ERR_FAIL_INDEX_V(p_polygon_index, polygons.size(), Vector<Point2>());
 	return polygons[p_polygon_index];
 }
 

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -3310,7 +3310,7 @@ void TileMapLayerEditorTerrainsPlugin::_update_terrains_cache() {
 					TileData *tile_data = atlas_source->get_tile_data(tile_id, alternative_id);
 					int terrain_set = tile_data->get_terrain_set();
 					if (terrain_set >= 0) {
-						ERR_FAIL_INDEX(terrain_set, (int)per_terrain_terrains_patterns.size());
+						ERR_FAIL_INDEX(terrain_set, per_terrain_terrains_patterns.size());
 
 						TileMapCell cell;
 						cell.source_id = source_id;

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -422,33 +422,33 @@ uint32_t GodotSoftBody3D::get_node_count() const {
 }
 
 real_t GodotSoftBody3D::get_node_inv_mass(uint32_t p_node_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), 0.0);
+	ERR_FAIL_INDEX_V(p_node_index, nodes.size(), 0.0);
 	return nodes[p_node_index].im;
 }
 
 Vector3 GodotSoftBody3D::get_node_position(uint32_t p_node_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), Vector3());
+	ERR_FAIL_INDEX_V(p_node_index, nodes.size(), Vector3());
 	return nodes[p_node_index].x;
 }
 
 Vector3 GodotSoftBody3D::get_node_velocity(uint32_t p_node_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), Vector3());
+	ERR_FAIL_INDEX_V(p_node_index, nodes.size(), Vector3());
 	return nodes[p_node_index].v;
 }
 
 Vector3 GodotSoftBody3D::get_node_biased_velocity(uint32_t p_node_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), Vector3());
+	ERR_FAIL_INDEX_V(p_node_index, nodes.size(), Vector3());
 	return nodes[p_node_index].bv;
 }
 
 void GodotSoftBody3D::apply_node_impulse(uint32_t p_node_index, const Vector3 &p_impulse) {
-	ERR_FAIL_UNSIGNED_INDEX(p_node_index, nodes.size());
+	ERR_FAIL_INDEX(p_node_index, nodes.size());
 	Node &node = nodes[p_node_index];
 	node.v += p_impulse * node.im;
 }
 
 void GodotSoftBody3D::apply_node_bias_impulse(uint32_t p_node_index, const Vector3 &p_impulse) {
-	ERR_FAIL_UNSIGNED_INDEX(p_node_index, nodes.size());
+	ERR_FAIL_INDEX(p_node_index, nodes.size());
 	Node &node = nodes[p_node_index];
 	node.bv += p_impulse * node.im;
 }
@@ -458,7 +458,7 @@ uint32_t GodotSoftBody3D::get_face_count() const {
 }
 
 void GodotSoftBody3D::get_face_points(uint32_t p_face_index, Vector3 &r_point_1, Vector3 &r_point_2, Vector3 &r_point_3) const {
-	ERR_FAIL_UNSIGNED_INDEX(p_face_index, faces.size());
+	ERR_FAIL_INDEX(p_face_index, faces.size());
 	const Face &face = faces[p_face_index];
 	r_point_1 = face.n[0]->x;
 	r_point_2 = face.n[1]->x;
@@ -466,7 +466,7 @@ void GodotSoftBody3D::get_face_points(uint32_t p_face_index, Vector3 &r_point_1,
 }
 
 Vector3 GodotSoftBody3D::get_face_normal(uint32_t p_face_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_face_index, faces.size(), Vector3());
+	ERR_FAIL_INDEX_V(p_face_index, faces.size(), Vector3());
 	return faces[p_face_index].normal;
 }
 

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -249,9 +249,9 @@ PackedInt32Array AudioStreamInteractive::get_transition_list() const {
 void AudioStreamInteractive::add_transition(int p_from_clip, int p_to_clip, TransitionFromTime p_from_time, TransitionToTime p_to_time, FadeMode p_fade_mode, float p_fade_beats, bool p_use_filler_flip, int p_filler_clip, bool p_hold_previous) {
 	ERR_FAIL_COND(p_from_clip < CLIP_ANY || p_from_clip >= clip_count);
 	ERR_FAIL_COND(p_to_clip < CLIP_ANY || p_to_clip >= clip_count);
-	ERR_FAIL_UNSIGNED_INDEX(p_from_time, TRANSITION_FROM_TIME_MAX);
-	ERR_FAIL_UNSIGNED_INDEX(p_to_time, TRANSITION_TO_TIME_MAX);
-	ERR_FAIL_UNSIGNED_INDEX(p_fade_mode, FADE_MAX);
+	ERR_FAIL_INDEX(p_from_time, TRANSITION_FROM_TIME_MAX);
+	ERR_FAIL_INDEX(p_to_time, TRANSITION_TO_TIME_MAX);
+	ERR_FAIL_INDEX(p_fade_mode, FADE_MAX);
 
 	Transition tr;
 	tr.from_time = p_from_time;
@@ -353,8 +353,8 @@ static void _test_and_swap(T &p_elem, uint32_t p_a, uint32_t p_b) {
 }
 
 void AudioStreamInteractive::_inspector_array_swap_clip(uint32_t p_item_a, uint32_t p_item_b) {
-	ERR_FAIL_UNSIGNED_INDEX(p_item_a, (uint32_t)clip_count);
-	ERR_FAIL_UNSIGNED_INDEX(p_item_b, (uint32_t)clip_count);
+	ERR_FAIL_INDEX(p_item_a, clip_count);
+	ERR_FAIL_INDEX(p_item_b, clip_count);
 
 	for (int i = 0; i < clip_count; i++) {
 		_test_and_swap(clips[i].auto_advance_next_clip, p_item_a, p_item_b);

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -45,7 +45,7 @@ bool MultiplayerSpawner::_set(const StringName &p_name, const Variant &p_value) 
 		String ns = p_name;
 		if (ns.begins_with("scenes/")) {
 			uint32_t index = ns.get_slicec('/', 1).to_int();
-			ERR_FAIL_UNSIGNED_INDEX_V(index, spawnable_scenes.size(), false);
+			ERR_FAIL_INDEX_V(index, spawnable_scenes.size(), false);
 			spawnable_scenes[index].path = ResourceUID::ensure_path(p_value);
 			return true;
 		}
@@ -61,7 +61,7 @@ bool MultiplayerSpawner::_get(const StringName &p_name, Variant &r_ret) const {
 		String ns = p_name;
 		if (ns.begins_with("scenes/")) {
 			uint32_t index = ns.get_slicec('/', 1).to_int();
-			ERR_FAIL_UNSIGNED_INDEX_V(index, spawnable_scenes.size(), false);
+			ERR_FAIL_INDEX_V(index, spawnable_scenes.size(), false);
 			r_ret = ResourceUID::path_to_uid(spawnable_scenes[index].path);
 			return true;
 		}
@@ -118,7 +118,7 @@ int MultiplayerSpawner::get_spawnable_scene_count() const {
 }
 
 String MultiplayerSpawner::get_spawnable_scene(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, (int)spawnable_scenes.size(), "");
+	ERR_FAIL_INDEX_V(p_idx, spawnable_scenes.size(), "");
 	return spawnable_scenes[p_idx].path;
 }
 
@@ -296,7 +296,7 @@ const Variant MultiplayerSpawner::get_spawn_argument(const ObjectID &p_id) const
 
 Node *MultiplayerSpawner::instantiate_scene(int p_id) {
 	ERR_FAIL_COND_V_MSG(spawn_limit && spawn_limit <= tracked_nodes.size(), nullptr, "Spawn limit reached!");
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_id, spawnable_scenes.size(), nullptr);
+	ERR_FAIL_INDEX_V(p_id, spawnable_scenes.size(), nullptr);
 	SpawnableScene &sc = spawnable_scenes[p_id];
 	if (sc.cache.is_null()) {
 		sc.cache = ResourceLoader::load(sc.path);

--- a/modules/navigation/3d/nav_mesh_queries_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_queries_3d.cpp
@@ -80,7 +80,7 @@ Vector3 NavMeshQueries3D::polygons_get_random_point(const LocalVector<gd::Polygo
 		RBMap<real_t, uint32_t>::Iterator region_E = region_area_map.find_closest(region_area_map_pos);
 		ERR_FAIL_COND_V(!region_E, Vector3());
 		uint32_t rrp_polygon_index = region_E->value;
-		ERR_FAIL_UNSIGNED_INDEX_V(rrp_polygon_index, region_polygons.size(), Vector3());
+		ERR_FAIL_INDEX_V(rrp_polygon_index, region_polygons.size(), Vector3());
 
 		const gd::Polygon &rr_polygon = region_polygons[rrp_polygon_index];
 
@@ -106,7 +106,7 @@ Vector3 NavMeshQueries3D::polygons_get_random_point(const LocalVector<gd::Polygo
 		RBMap<real_t, uint32_t>::Iterator polygon_E = polygon_area_map.find_closest(polygon_area_map_pos);
 		ERR_FAIL_COND_V(!polygon_E, Vector3());
 		uint32_t rrp_face_index = polygon_E->value;
-		ERR_FAIL_UNSIGNED_INDEX_V(rrp_face_index, rr_polygon.points.size(), Vector3());
+		ERR_FAIL_INDEX_V(rrp_face_index, rr_polygon.points.size(), Vector3());
 
 		const Face3 face(rr_polygon.points[0].pos, rr_polygon.points[rrp_face_index - 1].pos, rr_polygon.points[rrp_face_index].pos);
 

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -336,7 +336,7 @@ Vector3 NavMap::get_random_point(uint32_t p_navigation_layers, bool p_uniformly)
 		RBMap<real_t, uint32_t>::Iterator E = accessible_regions_area_map.find_closest(random_accessible_regions_area_map);
 		ERR_FAIL_COND_V(!E, Vector3());
 		uint32_t random_region_index = E->value;
-		ERR_FAIL_UNSIGNED_INDEX_V(random_region_index, accessible_regions.size(), Vector3());
+		ERR_FAIL_INDEX_V(random_region_index, accessible_regions.size(), Vector3());
 
 		const NavRegion *random_region = accessible_regions[random_region_index];
 		ERR_FAIL_NULL_V(random_region, Vector3());

--- a/modules/navigation/nav_utils.h
+++ b/modules/navigation/nav_utils.h
@@ -228,7 +228,7 @@ public:
 	 * Update the position of the element in the heap if necessary.
 	 */
 	void shift(uint32_t p_index) {
-		ERR_FAIL_UNSIGNED_INDEX_MSG(p_index, _buffer.size(), "Heap element index is out of range.");
+		ERR_FAIL_INDEX_MSG(p_index, _buffer.size(), "Heap element index is out of range.");
 		if (!_shift_up(p_index)) {
 			_shift_down(p_index);
 		}

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -359,19 +359,19 @@ bool OpenXRHandTrackingExtension::get_active() {
 }
 
 const OpenXRHandTrackingExtension::HandTracker *OpenXRHandTrackingExtension::get_hand_tracker(HandTrackedHands p_hand) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, nullptr);
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, nullptr);
 
 	return &hand_trackers[p_hand];
 }
 
 XrHandJointsMotionRangeEXT OpenXRHandTrackingExtension::get_motion_range(HandTrackedHands p_hand) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XR_HAND_JOINTS_MOTION_RANGE_MAX_ENUM_EXT);
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XR_HAND_JOINTS_MOTION_RANGE_MAX_ENUM_EXT);
 
 	return hand_trackers[p_hand].motion_range;
 }
 
 OpenXRHandTrackingExtension::HandTrackedSource OpenXRHandTrackingExtension::get_hand_tracking_source(HandTrackedHands p_hand) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, OPENXR_SOURCE_UNKNOWN);
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, OPENXR_SOURCE_UNKNOWN);
 
 	if (hand_tracking_source_ext) {
 		if (!hand_trackers[p_hand].data_source.isActive) {
@@ -391,13 +391,13 @@ OpenXRHandTrackingExtension::HandTrackedSource OpenXRHandTrackingExtension::get_
 }
 
 void OpenXRHandTrackingExtension::set_motion_range(HandTrackedHands p_hand, XrHandJointsMotionRangeEXT p_motion_range) {
-	ERR_FAIL_UNSIGNED_INDEX(p_hand, OPENXR_MAX_TRACKED_HANDS);
+	ERR_FAIL_INDEX(p_hand, OPENXR_MAX_TRACKED_HANDS);
 	hand_trackers[p_hand].motion_range = p_motion_range;
 }
 
 XrSpaceLocationFlags OpenXRHandTrackingExtension::get_hand_joint_location_flags(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceLocationFlags(0));
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceLocationFlags(0));
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceLocationFlags(0));
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceLocationFlags(0));
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return XrSpaceLocationFlags(0);
@@ -408,8 +408,8 @@ XrSpaceLocationFlags OpenXRHandTrackingExtension::get_hand_joint_location_flags(
 }
 
 Quaternion OpenXRHandTrackingExtension::get_hand_joint_rotation(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Quaternion());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Quaternion());
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Quaternion());
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Quaternion());
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return Quaternion();
@@ -420,8 +420,8 @@ Quaternion OpenXRHandTrackingExtension::get_hand_joint_rotation(HandTrackedHands
 }
 
 Vector3 OpenXRHandTrackingExtension::get_hand_joint_position(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return Vector3();
@@ -432,8 +432,8 @@ Vector3 OpenXRHandTrackingExtension::get_hand_joint_position(HandTrackedHands p_
 }
 
 float OpenXRHandTrackingExtension::get_hand_joint_radius(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, 0.0);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, 0.0);
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, 0.0);
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, 0.0);
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return 0.0;
@@ -443,8 +443,8 @@ float OpenXRHandTrackingExtension::get_hand_joint_radius(HandTrackedHands p_hand
 }
 
 XrSpaceVelocityFlags OpenXRHandTrackingExtension::get_hand_joint_velocity_flags(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceVelocityFlags(0));
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceVelocityFlags(0));
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, XrSpaceVelocityFlags(0));
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, XrSpaceVelocityFlags(0));
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return XrSpaceVelocityFlags(0);
@@ -455,8 +455,8 @@ XrSpaceVelocityFlags OpenXRHandTrackingExtension::get_hand_joint_velocity_flags(
 }
 
 Vector3 OpenXRHandTrackingExtension::get_hand_joint_linear_velocity(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return Vector3();
@@ -467,8 +467,8 @@ Vector3 OpenXRHandTrackingExtension::get_hand_joint_linear_velocity(HandTrackedH
 }
 
 Vector3 OpenXRHandTrackingExtension::get_hand_joint_angular_velocity(HandTrackedHands p_hand, XrHandJointEXT p_joint) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
+	ERR_FAIL_INDEX_V(p_hand, OPENXR_MAX_TRACKED_HANDS, Vector3());
+	ERR_FAIL_INDEX_V(p_joint, XR_HAND_JOINT_COUNT_EXT, Vector3());
 
 	if (!hand_trackers[p_hand].is_initialized) {
 		return Vector3();

--- a/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
+++ b/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
@@ -171,7 +171,7 @@ RID OpenXRVisibilityMaskExtension::get_mesh() {
 
 void OpenXRVisibilityMaskExtension::_update_mesh_data(uint32_t p_view) {
 	if (available) {
-		ERR_FAIL_UNSIGNED_INDEX(p_view, 4);
+		ERR_FAIL_INDEX(p_view, 4);
 
 		OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
 		ERR_FAIL_NULL(openxr_api);

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2536,7 +2536,7 @@ int OpenXRAPI::get_foveation_level() const {
 }
 
 void OpenXRAPI::set_foveation_level(int p_foveation_level) {
-	ERR_FAIL_UNSIGNED_INDEX(p_foveation_level, 4);
+	ERR_FAIL_INDEX(p_foveation_level, 4);
 	OpenXRFBFoveationExtension *fov_ext = OpenXRFBFoveationExtension::get_singleton();
 	if (fov_ext != nullptr && fov_ext->is_enabled()) {
 		XrFoveationLevelFB levels[] = { XR_FOVEATION_LEVEL_NONE_FB, XR_FOVEATION_LEVEL_LOW_FB, XR_FOVEATION_LEVEL_MEDIUM_FB, XR_FOVEATION_LEVEL_HIGH_FB };

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -1003,7 +1003,7 @@ Transform3D OpenXRInterface::get_camera_transform() {
 Transform3D OpenXRInterface::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, Transform3D());
-	ERR_FAIL_UNSIGNED_INDEX_V_MSG(p_view, get_view_count(), Transform3D(), "View index outside bounds.");
+	ERR_FAIL_INDEX_V_MSG(p_view, get_view_count(), Transform3D(), "View index outside bounds.");
 
 	Transform3D t;
 	if (openxr_api && openxr_api->get_view_transform(p_view, t)) {
@@ -1023,7 +1023,7 @@ Transform3D OpenXRInterface::get_transform_for_view(uint32_t p_view, const Trans
 
 Projection OpenXRInterface::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
 	Projection cm;
-	ERR_FAIL_UNSIGNED_INDEX_V_MSG(p_view, get_view_count(), cm, "View index outside bounds.");
+	ERR_FAIL_INDEX_V_MSG(p_view, get_view_count(), cm, "View index outside bounds.");
 
 	if (openxr_api) {
 		if (openxr_api->get_view_projection(p_view, p_z_near, p_z_far, cm)) {

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2517,7 +2517,7 @@ double TextServerAdvanced::_font_get_embolden(const RID &p_font_rid) const {
 }
 
 void TextServerAdvanced::_font_set_spacing(const RID &p_font_rid, SpacingType p_spacing, int64_t p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, 4);
+	ERR_FAIL_INDEX(p_spacing, SpacingType::SPACING_MAX);
 	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		if (fdv->extra_spacing[p_spacing] != p_value) {
@@ -2535,7 +2535,7 @@ void TextServerAdvanced::_font_set_spacing(const RID &p_font_rid, SpacingType p_
 }
 
 int64_t TextServerAdvanced::_font_get_spacing(const RID &p_font_rid, SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
+	ERR_FAIL_INDEX_V(p_spacing, SpacingType::SPACING_MAX, 0);
 	FontAdvancedLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		return fdv->extra_spacing[p_spacing];
@@ -4402,7 +4402,7 @@ bool TextServerAdvanced::_shaped_text_get_preserve_control(const RID &p_shaped) 
 }
 
 void TextServerAdvanced::_shaped_text_set_spacing(const RID &p_shaped, SpacingType p_spacing, int64_t p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, 4);
+	ERR_FAIL_INDEX(p_spacing, SpacingType::SPACING_MAX);
 	ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL(sd);
 
@@ -4417,7 +4417,7 @@ void TextServerAdvanced::_shaped_text_set_spacing(const RID &p_shaped, SpacingTy
 }
 
 int64_t TextServerAdvanced::_shaped_text_get_spacing(const RID &p_shaped, SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
+	ERR_FAIL_INDEX_V(p_spacing, SpacingType::SPACING_MAX, 0);
 
 	const ShapedTextDataAdvanced *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0);

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1508,7 +1508,7 @@ double TextServerFallback::_font_get_embolden(const RID &p_font_rid) const {
 }
 
 void TextServerFallback::_font_set_spacing(const RID &p_font_rid, SpacingType p_spacing, int64_t p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, 4);
+	ERR_FAIL_INDEX(p_spacing, SpacingType::SPACING_MAX);
 	FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		if (fdv->extra_spacing[p_spacing] != p_value) {
@@ -1527,7 +1527,7 @@ void TextServerFallback::_font_set_spacing(const RID &p_font_rid, SpacingType p_
 }
 
 int64_t TextServerFallback::_font_get_spacing(const RID &p_font_rid, SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
+	ERR_FAIL_INDEX_V(p_spacing, SpacingType::SPACING_MAX, 0);
 	FontFallbackLinkedVariation *fdv = font_var_owner.get_or_null(p_font_rid);
 	if (fdv) {
 		return fdv->extra_spacing[p_spacing];
@@ -3246,7 +3246,7 @@ bool TextServerFallback::_shaped_text_get_preserve_control(const RID &p_shaped) 
 }
 
 void TextServerFallback::_shaped_text_set_spacing(const RID &p_shaped, SpacingType p_spacing, int64_t p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, 4);
+	ERR_FAIL_INDEX(p_spacing, SpacingType::SPACING_MAX);
 	ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL(sd);
 
@@ -3261,7 +3261,7 @@ void TextServerFallback::_shaped_text_set_spacing(const RID &p_shaped, SpacingTy
 }
 
 int64_t TextServerFallback::_shaped_text_get_spacing(const RID &p_shaped, SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, 4, 0);
+	ERR_FAIL_INDEX_V(p_spacing, SpacingType::SPACING_MAX, 0);
 
 	const ShapedTextDataFallback *sd = shaped_owner.get_or_null(p_shaped);
 	ERR_FAIL_NULL_V(sd, 0);

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -378,8 +378,7 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServer::WindowID p_windo
 	if (unsupported) {
 		return FAILED;
 	}
-
-	ERR_FAIL_INDEX_V(int(p_mode), DisplayServer::FILE_DIALOG_MODE_SAVE_MAX, FAILED);
+	ERR_FAIL_INDEX_V(p_mode, DisplayServer::FILE_DIALOG_MODE_SAVE_MAX, FAILED);
 	ERR_FAIL_NULL_V(monitor_connection, FAILED);
 
 	Vector<String> filter_names;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -964,7 +964,7 @@ Error DisplayServerMacOS::file_dialog_with_options_show(const String &p_title, c
 Error DisplayServerMacOS::_file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb) {
 	_THREAD_SAFE_METHOD_
 
-	ERR_FAIL_INDEX_V(int(p_mode), FILE_DIALOG_MODE_SAVE_MAX, FAILED);
+	ERR_FAIL_INDEX_V(p_mode, FILE_DIALOG_MODE_SAVE_MAX, FAILED);
 
 	NSString *url = [NSString stringWithUTF8String:p_current_directory.utf8().get_data()];
 	WindowID prev_focus = last_focused_window;

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -222,7 +222,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 
 		int original_path_size = pdb_info.path.utf8().length();
 		// Double-check file bounds.
-		ERR_FAIL_UNSIGNED_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
+		ERR_FAIL_INDEX_V_MSG(pdb_info.address + original_path_size, file->get_length(), FAILED, vformat("Failed to write a new PDB path. Probably '%s' has been changed.", p_dll_path));
 
 		Vector<uint8_t> u8 = new_pdb_name.to_utf8_buffer();
 		file->seek(pdb_info.address);

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -582,7 +582,7 @@ bool Camera2D::is_current() const {
 }
 
 void Camera2D::set_limit(Side p_side, int p_limit) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	limit[p_side] = p_limit;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
@@ -590,7 +590,7 @@ void Camera2D::set_limit(Side p_side, int p_limit) {
 }
 
 int Camera2D::get_limit(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return limit[p_side];
 }
 
@@ -604,13 +604,13 @@ bool Camera2D::is_limit_smoothing_enabled() const {
 }
 
 void Camera2D::set_drag_margin(Side p_side, real_t p_drag_margin) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	drag_margin[p_side] = p_drag_margin;
 	queue_redraw();
 }
 
 real_t Camera2D::get_drag_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return drag_margin[p_side];
 }
 

--- a/scene/2d/physics/collision_polygon_2d.cpp
+++ b/scene/2d/physics/collision_polygon_2d.cpp
@@ -203,7 +203,7 @@ Vector<Point2> CollisionPolygon2D::get_polygon() const {
 }
 
 void CollisionPolygon2D::set_build_mode(BuildMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 2);
+	ERR_FAIL_INDEX(p_mode, 2);
 	build_mode = p_mode;
 	if (collision_object) {
 		_build_polygon();

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -38,14 +38,14 @@
 	if (layer < 0) {                                 \
 		layer = layers.size() + layer;               \
 	};                                               \
-	ERR_FAIL_INDEX(layer, (int)layers.size());       \
+	ERR_FAIL_INDEX(layer, layers.size());            \
 	layers[layer]->function(__VA_ARGS__);
 
 #define TILEMAP_CALL_FOR_LAYER_V(layer, err_value, function, ...) \
 	if (layer < 0) {                                              \
 		layer = layers.size() + layer;                            \
 	};                                                            \
-	ERR_FAIL_INDEX_V(layer, (int)layers.size(), err_value);       \
+	ERR_FAIL_INDEX_V(layer, layers.size(), err_value);            \
 	return layers[layer]->function(__VA_ARGS__);
 
 void TileMap::_tile_set_changed() {
@@ -263,7 +263,7 @@ void TileMap::add_layer(int p_to_pos) {
 		p_to_pos = layers.size() + p_to_pos + 1;
 	}
 
-	ERR_FAIL_INDEX(p_to_pos, (int)layers.size() + 1);
+	ERR_FAIL_INDEX(p_to_pos, layers.size() + 1);
 
 	// Must clear before adding the layer.
 	TileMapLayer *new_layer = memnew(TileMapLayer);
@@ -285,8 +285,8 @@ void TileMap::add_layer(int p_to_pos) {
 }
 
 void TileMap::move_layer(int p_layer, int p_to_pos) {
-	ERR_FAIL_INDEX(p_layer, (int)layers.size());
-	ERR_FAIL_INDEX(p_to_pos, (int)layers.size() + 1);
+	ERR_FAIL_INDEX(p_layer, layers.size());
+	ERR_FAIL_INDEX(p_to_pos, layers.size() + 1);
 
 	// Clear before shuffling layers.
 	TileMapLayer *layer = layers[p_layer];
@@ -304,7 +304,7 @@ void TileMap::move_layer(int p_layer, int p_to_pos) {
 }
 
 void TileMap::remove_layer(int p_layer) {
-	ERR_FAIL_INDEX(p_layer, (int)layers.size());
+	ERR_FAIL_INDEX(p_layer, layers.size());
 
 	// Clear before removing the layer.
 	TileMapLayer *removed = layers[p_layer];

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -671,7 +671,7 @@ float AudioStreamPlayer3D::get_attenuation_filter_db() const {
 }
 
 void AudioStreamPlayer3D::set_attenuation_model(AttenuationModel p_model) {
-	ERR_FAIL_INDEX((int)p_model, 4);
+	ERR_FAIL_INDEX(p_model, 4);
 	attenuation_model = p_model;
 	update_gizmos();
 }

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -571,7 +571,7 @@ Ref<Skin> GPUParticles3D::get_skin() const {
 }
 
 void GPUParticles3D::set_transform_align(TransformAlign p_align) {
-	ERR_FAIL_INDEX(uint32_t(p_align), 4);
+	ERR_FAIL_INDEX(p_align, 4);
 	transform_align = p_align;
 	RS::get_singleton()->particles_set_transform_align(particles, RS::ParticlesTransformAlign(transform_align));
 }

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -650,7 +650,7 @@ String Label3D::get_text() const {
 }
 
 void Label3D::set_horizontal_alignment(HorizontalAlignment p_alignment) {
-	ERR_FAIL_INDEX((int)p_alignment, 4);
+	ERR_FAIL_INDEX(p_alignment, 4);
 	if (horizontal_alignment != p_alignment) {
 		if (horizontal_alignment == HORIZONTAL_ALIGNMENT_FILL || p_alignment == HORIZONTAL_ALIGNMENT_FILL) {
 			dirty_lines = true; // Reshape lines.
@@ -665,7 +665,7 @@ HorizontalAlignment Label3D::get_horizontal_alignment() const {
 }
 
 void Label3D::set_vertical_alignment(VerticalAlignment p_alignment) {
-	ERR_FAIL_INDEX((int)p_alignment, 4);
+	ERR_FAIL_INDEX(p_alignment, 4);
 	if (vertical_alignment != p_alignment) {
 		vertical_alignment = p_alignment;
 		_queue_update();

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -149,13 +149,13 @@ int MeshInstance3D::find_blend_shape_by_name(const StringName &p_name) {
 
 float MeshInstance3D::get_blend_shape_value(int p_blend_shape) const {
 	ERR_FAIL_COND_V(mesh.is_null(), 0.0);
-	ERR_FAIL_INDEX_V(p_blend_shape, (int)blend_shape_tracks.size(), 0);
+	ERR_FAIL_INDEX_V(p_blend_shape, blend_shape_tracks.size(), 0);
 	return blend_shape_tracks[p_blend_shape];
 }
 
 void MeshInstance3D::set_blend_shape_value(int p_blend_shape, float p_value) {
 	ERR_FAIL_COND(mesh.is_null());
-	ERR_FAIL_INDEX(p_blend_shape, (int)blend_shape_tracks.size());
+	ERR_FAIL_INDEX(p_blend_shape, blend_shape_tracks.size());
 	blend_shape_tracks[p_blend_shape] = p_value;
 	RenderingServer::get_singleton()->instance_set_blend_shape_weight(get_instance(), p_blend_shape, p_value);
 }

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -89,7 +89,7 @@ bool Skeleton3D::_set(const StringName &p_path, const Variant &p_value) {
 		return true;
 	}
 
-	ERR_FAIL_UNSIGNED_INDEX_V(which, bones.size(), false);
+	ERR_FAIL_INDEX_V(which, bones.size(), false);
 
 	if (what == "parent") {
 		set_bone_parent(which, p_value);
@@ -156,7 +156,7 @@ bool Skeleton3D::_get(const StringName &p_path, Variant &r_ret) const {
 	uint32_t which = path.get_slicec('/', 1).to_int();
 	String what = path.get_slicec('/', 2);
 
-	ERR_FAIL_UNSIGNED_INDEX_V(which, bones.size(), false);
+	ERR_FAIL_INDEX_V(which, bones.size(), false);
 
 	if (what == "name") {
 		r_ret = get_bone_name(which);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -718,7 +718,7 @@ void Control::_set_anchor(Side p_side, real_t p_anchor) {
 
 void Control::set_anchor(Side p_side, real_t p_anchor, bool p_keep_offset, bool p_push_opposite_anchor) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 
 	Rect2 parent_rect = get_parent_anchorable_rect();
 	real_t parent_range = (p_side == SIDE_LEFT || p_side == SIDE_RIGHT) ? parent_rect.size.x : parent_rect.size.y;
@@ -751,14 +751,14 @@ void Control::set_anchor(Side p_side, real_t p_anchor, bool p_keep_offset, bool 
 
 real_t Control::get_anchor(Side p_side) const {
 	ERR_READ_THREAD_GUARD_V(0);
-	ERR_FAIL_INDEX_V(int(p_side), 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	return data.anchor[p_side];
 }
 
 void Control::set_offset(Side p_side, real_t p_value) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	if (data.offset[p_side] == p_value) {
 		return;
 	}
@@ -769,7 +769,7 @@ void Control::set_offset(Side p_side, real_t p_value) {
 
 real_t Control::get_offset(Side p_side) const {
 	ERR_READ_THREAD_GUARD_V(0);
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 
 	return data.offset[p_side];
 }
@@ -819,7 +819,7 @@ void Control::set_h_grow_direction(GrowDirection p_direction) {
 		return;
 	}
 
-	ERR_FAIL_INDEX((int)p_direction, 3);
+	ERR_FAIL_INDEX(p_direction, 3);
 
 	data.h_grow = p_direction;
 	_size_changed();
@@ -836,7 +836,7 @@ void Control::set_v_grow_direction(GrowDirection p_direction) {
 		return;
 	}
 
-	ERR_FAIL_INDEX((int)p_direction, 3);
+	ERR_FAIL_INDEX(p_direction, 3);
 
 	data.v_grow = p_direction;
 	_size_changed();
@@ -1069,7 +1069,7 @@ int Control::_get_anchors_layout_preset() const {
 
 void Control::set_anchors_preset(LayoutPreset p_preset, bool p_keep_offsets) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_INDEX((int)p_preset, 16);
+	ERR_FAIL_INDEX(p_preset, 16);
 
 	//Left
 	switch (p_preset) {
@@ -1186,8 +1186,8 @@ void Control::set_anchors_preset(LayoutPreset p_preset, bool p_keep_offsets) {
 
 void Control::set_offsets_preset(LayoutPreset p_preset, LayoutPresetMode p_resize_mode, int p_margin) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_INDEX((int)p_preset, 16);
-	ERR_FAIL_INDEX((int)p_resize_mode, 4);
+	ERR_FAIL_INDEX(p_preset, 16);
+	ERR_FAIL_INDEX(p_resize_mode, 4);
 
 	// Calculate the size if the node is not resized
 	Size2 min_size = get_minimum_size();
@@ -2000,7 +2000,7 @@ bool Control::is_drag_successful() const {
 
 void Control::set_focus_mode(FocusMode p_focus_mode) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_INDEX((int)p_focus_mode, 3);
+	ERR_FAIL_INDEX(p_focus_mode, 3);
 
 	if (is_inside_tree() && p_focus_mode == FOCUS_NONE && data.focus_mode != FOCUS_NONE && has_focus()) {
 		release_focus();
@@ -2223,13 +2223,13 @@ Control *Control::find_prev_valid_focus() const {
 
 void Control::set_focus_neighbor(Side p_side, const NodePath &p_neighbor) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	data.focus_neighbor[p_side] = p_neighbor;
 }
 
 NodePath Control::get_focus_neighbor(Side p_side) const {
 	ERR_READ_THREAD_GUARD_V(NodePath());
-	ERR_FAIL_INDEX_V((int)p_side, 4, NodePath());
+	ERR_FAIL_INDEX_V(p_side, 4, NodePath());
 	return data.focus_neighbor[p_side];
 }
 
@@ -2256,7 +2256,7 @@ NodePath Control::get_focus_previous() const {
 #define MAX_NEIGHBOR_SEARCH_COUNT 512
 
 Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
-	ERR_FAIL_INDEX_V((int)p_side, 4, nullptr);
+	ERR_FAIL_INDEX_V(p_side, 4, nullptr);
 
 	if (p_count >= MAX_NEIGHBOR_SEARCH_COUNT) {
 		return nullptr;
@@ -2420,7 +2420,7 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 
 void Control::set_default_cursor_shape(CursorShape p_shape) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_INDEX(int(p_shape), CURSOR_MAX);
+	ERR_FAIL_INDEX(p_shape, CURSOR_MAX);
 
 	if (data.default_cursor == p_shape) {
 		return;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1136,7 +1136,7 @@ bool FileDialog::is_mode_overriding_title() const {
 }
 
 void FileDialog::set_file_mode(FileMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 5);
+	ERR_FAIL_INDEX(p_mode, 5);
 	if (mode == p_mode) {
 		return;
 	}

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -603,7 +603,7 @@ ItemList::SelectMode ItemList::get_select_mode() const {
 }
 
 void ItemList::set_icon_mode(IconMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 2);
+	ERR_FAIL_INDEX(p_mode, 2);
 	if (icon_mode != p_mode) {
 		icon_mode = p_mode;
 		for (int i = 0; i < items.size(); i++) {

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -968,7 +968,7 @@ int Label::get_visible_line_count() const {
 }
 
 void Label::set_horizontal_alignment(HorizontalAlignment p_alignment) {
-	ERR_FAIL_INDEX((int)p_alignment, 4);
+	ERR_FAIL_INDEX(p_alignment, 4);
 	if (horizontal_alignment == p_alignment) {
 		return;
 	}
@@ -988,7 +988,7 @@ HorizontalAlignment Label::get_horizontal_alignment() const {
 }
 
 void Label::set_vertical_alignment(VerticalAlignment p_alignment) {
-	ERR_FAIL_INDEX((int)p_alignment, 4);
+	ERR_FAIL_INDEX(p_alignment, 4);
 
 	if (vertical_alignment == p_alignment) {
 		return;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -920,7 +920,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void LineEdit::set_horizontal_alignment(HorizontalAlignment p_alignment) {
-	ERR_FAIL_INDEX((int)p_alignment, 4);
+	ERR_FAIL_INDEX(p_alignment, 4);
 	if (alignment == p_alignment) {
 		return;
 	}

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -75,7 +75,7 @@ Vector<int> MarginContainer::get_allowed_size_flags_vertical() const {
 }
 
 int MarginContainer::get_margin_size(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 
 	switch (p_side) {
 		case SIDE_LEFT:

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -118,7 +118,7 @@ Ref<Texture2D> NinePatchRect::get_texture() const {
 }
 
 void NinePatchRect::set_patch_margin(Side p_side, int p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 
 	if (margin[p_side] == p_size) {
 		return;
@@ -130,7 +130,7 @@ void NinePatchRect::set_patch_margin(Side p_side, int p_size) {
 }
 
 int NinePatchRect::get_patch_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return margin[p_side];
 }
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3990,7 +3990,7 @@ void RichTextLabel::set_table_column_expand(int p_column, bool p_expand, int p_r
 	ERR_FAIL_COND(current->type != ITEM_TABLE);
 
 	ItemTable *table = static_cast<ItemTable *>(current);
-	ERR_FAIL_INDEX(p_column, (int)table->columns.size());
+	ERR_FAIL_INDEX(p_column, table->columns.size());
 	table->columns[p_column].expand = p_expand;
 	table->columns[p_column].expand_ratio = p_ratio;
 }

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -49,7 +49,7 @@ Ref<Texture2D> TextureProgressBar::get_over_texture() const {
 }
 
 void TextureProgressBar::set_stretch_margin(Side p_side, int p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 
 	if (stretch_margin[p_side] == p_size) {
 		return;
@@ -61,7 +61,7 @@ void TextureProgressBar::set_stretch_margin(Side p_side, int p_size) {
 }
 
 int TextureProgressBar::get_stretch_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return stretch_margin[p_side];
 }
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1412,7 +1412,7 @@ uint32_t CanvasItem::get_visibility_layer() const {
 
 void CanvasItem::set_visibility_layer_bit(uint32_t p_visibility_layer, bool p_enable) {
 	ERR_THREAD_GUARD;
-	ERR_FAIL_UNSIGNED_INDEX(p_visibility_layer, 32);
+	ERR_FAIL_INDEX(p_visibility_layer, 32);
 	if (p_enable) {
 		set_visibility_layer(visibility_layer | (1 << p_visibility_layer));
 	} else {
@@ -1422,7 +1422,7 @@ void CanvasItem::set_visibility_layer_bit(uint32_t p_visibility_layer, bool p_en
 
 bool CanvasItem::get_visibility_layer_bit(uint32_t p_visibility_layer) const {
 	ERR_READ_THREAD_GUARD_V(false);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_visibility_layer, 32, false);
+	ERR_FAIL_INDEX_V(p_visibility_layer, 32, false);
 	return (visibility_layer & (1 << p_visibility_layer));
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -482,7 +482,7 @@ void Node::move_child(Node *p_child, int p_index) {
 		if (p_index < 0) {
 			p_index += get_child_count(false);
 		}
-		ERR_FAIL_INDEX_MSG(p_index, (int)data.children_cache.size() + 1 - data.internal_children_front_count_cache - data.internal_children_back_count_cache, vformat("Invalid new child index: %d.", p_index));
+		ERR_FAIL_INDEX_MSG(p_index, data.children_cache.size() + 1 - data.internal_children_front_count_cache - data.internal_children_back_count_cache, vformat("Invalid new child index: %d.", p_index));
 		_move_child(p_child, p_index + data.internal_children_front_count_cache);
 	}
 }
@@ -1768,13 +1768,13 @@ Node *Node::get_child(int p_index, bool p_include_internal) const {
 		if (p_index < 0) {
 			p_index += data.children_cache.size();
 		}
-		ERR_FAIL_INDEX_V(p_index, (int)data.children_cache.size(), nullptr);
+		ERR_FAIL_INDEX_V(p_index, data.children_cache.size(), nullptr);
 		return data.children_cache[p_index];
 	} else {
 		if (p_index < 0) {
 			p_index += (int)data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache;
 		}
-		ERR_FAIL_INDEX_V(p_index, (int)data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache, nullptr);
+		ERR_FAIL_INDEX_V(p_index, data.children_cache.size() - data.internal_children_front_count_cache - data.internal_children_back_count_cache, nullptr);
 		p_index += data.internal_children_front_count_cache;
 		return data.children_cache[p_index];
 	}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3880,7 +3880,7 @@ uint32_t Viewport::get_canvas_cull_mask() const {
 
 void Viewport::set_canvas_cull_mask_bit(uint32_t p_layer, bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_UNSIGNED_INDEX(p_layer, 32);
+	ERR_FAIL_INDEX(p_layer, 32);
 	if (p_enable) {
 		set_canvas_cull_mask(canvas_cull_mask | (1 << p_layer));
 	} else {
@@ -3890,7 +3890,7 @@ void Viewport::set_canvas_cull_mask_bit(uint32_t p_layer, bool p_enable) {
 
 bool Viewport::get_canvas_cull_mask_bit(uint32_t p_layer) const {
 	ERR_READ_THREAD_GUARD_V(false);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_layer, 32, false);
+	ERR_FAIL_INDEX_V(p_layer, 32, false);
 	return (canvas_cull_mask & (1 << p_layer));
 }
 

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -1407,12 +1407,12 @@ int TileSet::add_pattern(Ref<TileMapPattern> p_pattern, int p_index) {
 }
 
 Ref<TileMapPattern> TileSet::get_pattern(int p_index) {
-	ERR_FAIL_INDEX_V(p_index, (int)patterns.size(), Ref<TileMapPattern>());
+	ERR_FAIL_INDEX_V(p_index, patterns.size(), Ref<TileMapPattern>());
 	return patterns[p_index];
 }
 
 void TileSet::remove_pattern(int p_index) {
-	ERR_FAIL_INDEX(p_index, (int)patterns.size());
+	ERR_FAIL_INDEX(p_index, patterns.size());
 	patterns.remove_at(p_index);
 	emit_changed();
 }
@@ -5162,7 +5162,7 @@ int TileSetAtlasSource::get_tile_animation_frames_count(const Vector2i p_atlas_c
 
 void TileSetAtlasSource::set_tile_animation_frame_duration(const Vector2i p_atlas_coords, int p_frame_index, real_t p_duration) {
 	ERR_FAIL_COND_MSG(!tiles.has(p_atlas_coords), vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
-	ERR_FAIL_INDEX(p_frame_index, (int)tiles[p_atlas_coords].animation_frames_durations.size());
+	ERR_FAIL_INDEX(p_frame_index, tiles[p_atlas_coords].animation_frames_durations.size());
 	ERR_FAIL_COND(p_duration <= 0.0);
 
 	tiles[p_atlas_coords].animation_frames_durations[p_frame_index] = p_duration;
@@ -5172,7 +5172,7 @@ void TileSetAtlasSource::set_tile_animation_frame_duration(const Vector2i p_atla
 
 real_t TileSetAtlasSource::get_tile_animation_frame_duration(const Vector2i p_atlas_coords, int p_frame_index) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), 1, vformat("TileSetAtlasSource has no tile at %s.", Vector2i(p_atlas_coords)));
-	ERR_FAIL_INDEX_V(p_frame_index, (int)tiles[p_atlas_coords].animation_frames_durations.size(), 0.0);
+	ERR_FAIL_INDEX_V(p_frame_index, tiles[p_atlas_coords].animation_frames_durations.size(), 0.0);
 	return tiles[p_atlas_coords].animation_frames_durations[p_frame_index];
 }
 
@@ -5296,7 +5296,7 @@ PackedVector2Array TileSetAtlasSource::get_tiles_to_be_removed_on_change(Ref<Tex
 
 Rect2i TileSetAtlasSource::get_tile_texture_region(Vector2i p_atlas_coords, int p_frame) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), Rect2i(), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
-	ERR_FAIL_INDEX_V(p_frame, (int)tiles[p_atlas_coords].animation_frames_durations.size(), Rect2i());
+	ERR_FAIL_INDEX_V(p_frame, tiles[p_atlas_coords].animation_frames_durations.size(), Rect2i());
 
 	const TileAlternativesData &tad = tiles[p_atlas_coords];
 
@@ -5346,7 +5346,7 @@ Ref<Texture2D> TileSetAtlasSource::get_runtime_texture() const {
 
 Rect2i TileSetAtlasSource::get_runtime_tile_texture_region(Vector2i p_atlas_coords, int p_frame) const {
 	ERR_FAIL_COND_V_MSG(!tiles.has(p_atlas_coords), Rect2i(), vformat("TileSetAtlasSource has no tile at %s.", String(p_atlas_coords)));
-	ERR_FAIL_INDEX_V(p_frame, (int)tiles[p_atlas_coords].animation_frames_durations.size(), Rect2i());
+	ERR_FAIL_INDEX_V(p_frame, tiles[p_atlas_coords].animation_frames_durations.size(), Rect2i());
 
 	Rect2i src_rect = get_tile_texture_region(p_atlas_coords, p_frame);
 	if (use_texture_padding) {
@@ -6462,7 +6462,7 @@ int TileData::get_collision_polygon_shapes_count(int p_layer_id, int p_polygon_i
 Ref<ConvexPolygonShape2D> TileData::get_collision_polygon_shape(int p_layer_id, int p_polygon_index, int shape_index, bool p_flip_h, bool p_flip_v, bool p_transpose) const {
 	ERR_FAIL_INDEX_V(p_layer_id, physics.size(), Ref<ConvexPolygonShape2D>());
 	ERR_FAIL_INDEX_V(p_polygon_index, physics[p_layer_id].polygons.size(), Ref<ConvexPolygonShape2D>());
-	ERR_FAIL_INDEX_V(shape_index, (int)physics[p_layer_id].polygons[p_polygon_index].shapes.size(), Ref<ConvexPolygonShape2D>());
+	ERR_FAIL_INDEX_V(shape_index, physics[p_layer_id].polygons[p_polygon_index].shapes.size(), Ref<ConvexPolygonShape2D>());
 
 	const PhysicsLayerTileData &layer_tile_data = physics[p_layer_id];
 	const PhysicsLayerTileData::PolygonShapeTileData &shapes_data = layer_tile_data.polygons[p_polygon_index];

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -1089,9 +1089,9 @@ Error ImporterMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, 
 
 	//go through all indices
 	for (int i = 0; i < gen_index_count; i += 3) {
-		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 0]], (int)uv_indices.size(), ERR_BUG);
-		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 1]], (int)uv_indices.size(), ERR_BUG);
-		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 2]], (int)uv_indices.size(), ERR_BUG);
+		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 0]], uv_indices.size(), ERR_BUG);
+		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 1]], uv_indices.size(), ERR_BUG);
+		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 2]], uv_indices.size(), ERR_BUG);
 
 		ERR_FAIL_COND_V(uv_indices[gen_vertices[gen_indices[i + 0]]].first != uv_indices[gen_vertices[gen_indices[i + 1]]].first || uv_indices[gen_vertices[gen_indices[i + 0]]].first != uv_indices[gen_vertices[gen_indices[i + 2]]].first, ERR_BUG);
 

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -3632,7 +3632,7 @@ TextMesh::~TextMesh() {
 }
 
 void TextMesh::set_horizontal_alignment(HorizontalAlignment p_alignment) {
-	ERR_FAIL_INDEX((int)p_alignment, 4);
+	ERR_FAIL_INDEX(p_alignment, 4);
 	if (horizontal_alignment != p_alignment) {
 		if (horizontal_alignment == HORIZONTAL_ALIGNMENT_FILL || p_alignment == HORIZONTAL_ALIGNMENT_FILL) {
 			dirty_lines = true;
@@ -3647,7 +3647,7 @@ HorizontalAlignment TextMesh::get_horizontal_alignment() const {
 }
 
 void TextMesh::set_vertical_alignment(VerticalAlignment p_alignment) {
-	ERR_FAIL_INDEX((int)p_alignment, 4);
+	ERR_FAIL_INDEX(p_alignment, 4);
 	if (vertical_alignment != p_alignment) {
 		vertical_alignment = p_alignment;
 		request_update();

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -119,7 +119,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (what == "compressed_track") {
 			int index = p_value;
 			ERR_FAIL_COND_V(!compression.enabled, false);
-			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)index, compression.bounds.size(), false);
+			ERR_FAIL_INDEX_V(index, compression.bounds.size(), false);
 			Track *t = tracks[track];
 			t->interpolation = INTERPOLATION_LINEAR; //only linear supported
 			switch (t->type) {
@@ -2750,7 +2750,7 @@ void Animation::value_track_set_update_mode(int p_track, UpdateMode p_mode) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_VALUE);
-	ERR_FAIL_INDEX((int)p_mode, 3);
+	ERR_FAIL_INDEX(p_mode, 3);
 
 	ValueTrack *vt = static_cast<ValueTrack *>(t);
 	vt->update_mode = p_mode;
@@ -5290,7 +5290,7 @@ bool Animation::_blend_shape_interpolate_compressed(uint32_t p_compressed_track,
 template <uint32_t COMPONENTS>
 bool Animation::_fetch_compressed(uint32_t p_compressed_track, double p_time, Vector3i &r_current_value, double &r_current_time, Vector3i &r_next_value, double &r_next_time, uint32_t *key_index) const {
 	ERR_FAIL_COND_V(!compression.enabled, false);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_compressed_track, compression.bounds.size(), false);
+	ERR_FAIL_INDEX_V(p_compressed_track, compression.bounds.size(), false);
 	p_time = CLAMP(p_time, 0, length);
 	if (key_index) {
 		*key_index = 0;
@@ -5436,7 +5436,7 @@ bool Animation::_fetch_compressed(uint32_t p_compressed_track, double p_time, Ve
 template <uint32_t COMPONENTS>
 void Animation::_get_compressed_key_indices_in_range(uint32_t p_compressed_track, double p_time, double p_delta, List<int> *r_indices) const {
 	ERR_FAIL_COND(!compression.enabled);
-	ERR_FAIL_UNSIGNED_INDEX(p_compressed_track, compression.bounds.size());
+	ERR_FAIL_INDEX(p_compressed_track, compression.bounds.size());
 
 	double frame_to_sec = 1.0 / double(compression.fps);
 	uint32_t key_index = 0;
@@ -5517,7 +5517,7 @@ void Animation::_get_compressed_key_indices_in_range(uint32_t p_compressed_track
 
 int Animation::_get_compressed_key_count(uint32_t p_compressed_track) const {
 	ERR_FAIL_COND_V(!compression.enabled, -1);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_compressed_track, compression.bounds.size(), -1);
+	ERR_FAIL_INDEX_V(p_compressed_track, compression.bounds.size(), -1);
 
 	int key_count = 0;
 
@@ -5553,7 +5553,7 @@ float Animation::_uncompress_blend_shape(const Vector3i &p_value) const {
 template <uint32_t COMPONENTS>
 bool Animation::_fetch_compressed_by_index(uint32_t p_compressed_track, int p_index, Vector3i &r_value, double &r_time) const {
 	ERR_FAIL_COND_V(!compression.enabled, false);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_compressed_track, compression.bounds.size(), false);
+	ERR_FAIL_INDEX_V(p_compressed_track, compression.bounds.size(), false);
 
 	for (const Compression::Page &page : compression.pages) {
 		const uint8_t *page_data = page.data.ptr();

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -3033,7 +3033,7 @@ Dictionary FontVariation::get_opentype_features() const {
 }
 
 void FontVariation::set_spacing(TextServer::SpacingType p_spacing, int p_value) {
-	ERR_FAIL_INDEX((int)p_spacing, TextServer::SPACING_MAX);
+	ERR_FAIL_INDEX(p_spacing, TextServer::SPACING_MAX);
 	if (extra_spacing[p_spacing] != p_value) {
 		extra_spacing[p_spacing] = p_value;
 		_invalidate_rids();
@@ -3041,7 +3041,7 @@ void FontVariation::set_spacing(TextServer::SpacingType p_spacing, int p_value) 
 }
 
 int FontVariation::get_spacing(TextServer::SpacingType p_spacing) const {
-	ERR_FAIL_INDEX_V((int)p_spacing, TextServer::SPACING_MAX, 0);
+	ERR_FAIL_INDEX_V(p_spacing, TextServer::SPACING_MAX, 0);
 	return extra_spacing[p_spacing];
 }
 

--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -339,14 +339,14 @@ int ImmediateMesh::get_surface_count() const {
 	return surfaces.size();
 }
 int ImmediateMesh::surface_get_array_len(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, int(surfaces.size()), -1);
+	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), -1);
 	return surfaces[p_idx].array_len;
 }
 int ImmediateMesh::surface_get_array_index_len(int p_idx) const {
 	return 0;
 }
 Array ImmediateMesh::surface_get_arrays(int p_surface) const {
-	ERR_FAIL_INDEX_V(p_surface, int(surfaces.size()), Array());
+	ERR_FAIL_INDEX_V(p_surface, surfaces.size(), Array());
 	return RS::get_singleton()->mesh_surface_get_arrays(mesh, p_surface);
 }
 TypedArray<Array> ImmediateMesh::surface_get_blend_shape_arrays(int p_surface) const {
@@ -356,15 +356,15 @@ Dictionary ImmediateMesh::surface_get_lods(int p_surface) const {
 	return Dictionary();
 }
 BitField<Mesh::ArrayFormat> ImmediateMesh::surface_get_format(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, int(surfaces.size()), 0);
+	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), 0);
 	return surfaces[p_idx].format;
 }
 Mesh::PrimitiveType ImmediateMesh::surface_get_primitive_type(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, int(surfaces.size()), PRIMITIVE_MAX);
+	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), PRIMITIVE_MAX);
 	return surfaces[p_idx].primitive;
 }
 void ImmediateMesh::surface_set_material(int p_idx, const Ref<Material> &p_material) {
-	ERR_FAIL_INDEX(p_idx, int(surfaces.size()));
+	ERR_FAIL_INDEX(p_idx, surfaces.size());
 	surfaces[p_idx].material = p_material;
 	RID mat;
 	if (p_material.is_valid()) {
@@ -373,7 +373,7 @@ void ImmediateMesh::surface_set_material(int p_idx, const Ref<Material> &p_mater
 	RS::get_singleton()->mesh_surface_set_material(mesh, p_idx, mat);
 }
 Ref<Material> ImmediateMesh::surface_get_material(int p_idx) const {
-	ERR_FAIL_INDEX_V(p_idx, int(surfaces.size()), Ref<Material>());
+	ERR_FAIL_INDEX_V(p_idx, surfaces.size(), Ref<Material>());
 	return surfaces[p_idx].material;
 }
 int ImmediateMesh::get_blend_shape_count() const {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2186,9 +2186,9 @@ Error ArrayMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, flo
 
 	//go through all indices
 	for (int i = 0; i < gen_index_count; i += 3) {
-		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 0]], (int)uv_indices.size(), ERR_BUG);
-		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 1]], (int)uv_indices.size(), ERR_BUG);
-		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 2]], (int)uv_indices.size(), ERR_BUG);
+		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 0]], uv_indices.size(), ERR_BUG);
+		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 1]], uv_indices.size(), ERR_BUG);
+		ERR_FAIL_INDEX_V(gen_vertices[gen_indices[i + 2]], uv_indices.size(), ERR_BUG);
 
 		ERR_FAIL_COND_V(uv_indices[gen_vertices[gen_indices[i + 0]]].first != uv_indices[gen_vertices[gen_indices[i + 1]]].first || uv_indices[gen_vertices[gen_indices[i + 0]]].first != uv_indices[gen_vertices[gen_indices[i + 2]]].first, ERR_BUG);
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -318,14 +318,14 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 							// We cannot know if the referenced nodes exist yet, so instead of deferring, we write the NodePaths directly.
 
 							uint32_t name_idx = nprops[j].name & (FLAG_PATH_PROPERTY_IS_NODE - 1);
-							ERR_FAIL_UNSIGNED_INDEX_V(name_idx, (uint32_t)sname_count, nullptr);
+							ERR_FAIL_INDEX_V(name_idx, (uint32_t)sname_count, nullptr);
 
 							node->set(snames[name_idx], props[nprops[j].value], &valid);
 							continue;
 						}
 
 						uint32_t name_idx = nprops[j].name & (FLAG_PATH_PROPERTY_IS_NODE - 1);
-						ERR_FAIL_UNSIGNED_INDEX_V(name_idx, (uint32_t)sname_count, nullptr);
+						ERR_FAIL_INDEX_V(name_idx, sname_count, nullptr);
 
 						DeferredNodePathProperties dnp;
 						dnp.value = props[nprops[j].value];

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -48,7 +48,7 @@ Size2 StyleBox::get_minimum_size() const {
 }
 
 void StyleBox::set_content_margin(Side p_side, float p_value) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 
 	content_margin[p_side] = p_value;
 	emit_changed();
@@ -70,13 +70,13 @@ void StyleBox::set_content_margin_individual(float p_left, float p_top, float p_
 }
 
 float StyleBox::get_content_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	return content_margin[p_side];
 }
 
 float StyleBox::get_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	if (content_margin[p_side] < 0) {
 		return get_style_margin(p_side);

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -33,7 +33,7 @@
 #include "servers/rendering_server.h"
 
 float StyleBoxFlat::get_style_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 	return border_width[p_side];
 }
 
@@ -74,13 +74,13 @@ int StyleBoxFlat::get_border_width_min() const {
 }
 
 void StyleBoxFlat::set_border_width(Side p_side, int p_width) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	border_width[p_side] = p_width;
 	emit_changed();
 }
 
 int StyleBoxFlat::get_border_width(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return border_width[p_side];
 }
 
@@ -94,7 +94,7 @@ bool StyleBoxFlat::get_border_blend() const {
 }
 
 void StyleBoxFlat::set_corner_radius(const Corner p_corner, const int radius) {
-	ERR_FAIL_INDEX((int)p_corner, 4);
+	ERR_FAIL_INDEX(p_corner, 4);
 	corner_radius[p_corner] = radius;
 	emit_changed();
 }
@@ -117,7 +117,7 @@ void StyleBoxFlat::set_corner_radius_individual(const int radius_top_left, const
 }
 
 int StyleBoxFlat::get_corner_radius(const Corner p_corner) const {
-	ERR_FAIL_INDEX_V((int)p_corner, 4, 0);
+	ERR_FAIL_INDEX_V(p_corner, 4, 0);
 	return corner_radius[p_corner];
 }
 
@@ -131,7 +131,7 @@ int StyleBoxFlat::get_corner_detail() const {
 }
 
 void StyleBoxFlat::set_expand_margin(Side p_side, float p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	expand_margin[p_side] = p_size;
 	emit_changed();
 }
@@ -152,7 +152,7 @@ void StyleBoxFlat::set_expand_margin_individual(float p_left, float p_top, float
 }
 
 float StyleBoxFlat::get_expand_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 	return expand_margin[p_side];
 }
 

--- a/scene/resources/style_box_line.cpp
+++ b/scene/resources/style_box_line.cpp
@@ -33,7 +33,7 @@
 #include "servers/rendering_server.h"
 
 float StyleBoxLine::get_style_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 
 	if (vertical) {
 		if (p_side == SIDE_LEFT || p_side == SIDE_RIGHT) {

--- a/scene/resources/style_box_texture.cpp
+++ b/scene/resources/style_box_texture.cpp
@@ -31,7 +31,7 @@
 #include "style_box_texture.h"
 
 float StyleBoxTexture::get_style_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	return texture_margin[p_side];
 }
@@ -49,7 +49,7 @@ Ref<Texture2D> StyleBoxTexture::get_texture() const {
 }
 
 void StyleBoxTexture::set_texture_margin(Side p_side, float p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 
 	texture_margin[p_side] = p_size;
 	emit_changed();
@@ -71,13 +71,13 @@ void StyleBoxTexture::set_texture_margin_individual(float p_left, float p_top, f
 }
 
 float StyleBoxTexture::get_texture_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0.0);
 
 	return texture_margin[p_side];
 }
 
 void StyleBoxTexture::set_expand_margin(Side p_side, float p_size) {
-	ERR_FAIL_INDEX((int)p_side, 4);
+	ERR_FAIL_INDEX(p_side, 4);
 	expand_margin[p_side] = p_size;
 	emit_changed();
 }
@@ -98,7 +98,7 @@ void StyleBoxTexture::set_expand_margin_individual(float p_left, float p_top, fl
 }
 
 float StyleBoxTexture::get_expand_margin(Side p_side) const {
-	ERR_FAIL_INDEX_V((int)p_side, 4, 0);
+	ERR_FAIL_INDEX_V(p_side, 4, 0);
 	return expand_margin[p_side];
 }
 
@@ -125,7 +125,7 @@ bool StyleBoxTexture::is_draw_center_enabled() const {
 }
 
 void StyleBoxTexture::set_h_axis_stretch_mode(AxisStretchMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 3);
+	ERR_FAIL_INDEX(p_mode, 3);
 	axis_h = p_mode;
 	emit_changed();
 }
@@ -135,7 +135,7 @@ StyleBoxTexture::AxisStretchMode StyleBoxTexture::get_h_axis_stretch_mode() cons
 }
 
 void StyleBoxTexture::set_v_axis_stretch_mode(AxisStretchMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, 3);
+	ERR_FAIL_INDEX(p_mode, 3);
 	axis_v = p_mode;
 	emit_changed();
 }

--- a/scene/resources/texture_rd.cpp
+++ b/scene/resources/texture_rd.cpp
@@ -169,7 +169,7 @@ RID TextureLayeredRD::get_rid() const {
 }
 
 Ref<Image> TextureLayeredRD::get_layer_data(int p_layer) const {
-	ERR_FAIL_INDEX_V(p_layer, (int)layers, Ref<Image>());
+	ERR_FAIL_INDEX_V(p_layer, layers, Ref<Image>());
 	return RS::get_singleton()->texture_2d_layer_get(texture_rid, p_layer);
 }
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -834,8 +834,8 @@ VisualShader::Type VisualShader::get_shader_type() const {
 
 void VisualShader::add_varying(const String &p_name, VaryingMode p_mode, VaryingType p_type) {
 	ERR_FAIL_COND(!p_name.is_valid_ascii_identifier());
-	ERR_FAIL_INDEX((int)p_mode, (int)VARYING_MODE_MAX);
-	ERR_FAIL_INDEX((int)p_type, (int)VARYING_TYPE_MAX);
+	ERR_FAIL_INDEX(p_mode, VARYING_MODE_MAX);
+	ERR_FAIL_INDEX(p_type, VARYING_TYPE_MAX);
 	ERR_FAIL_COND(varyings.has(p_name));
 	Varying var = Varying(p_name, p_mode, p_type);
 	varyings[p_name] = var;
@@ -869,7 +869,7 @@ const VisualShader::Varying *VisualShader::get_varying_by_index(int p_idx) const
 }
 
 void VisualShader::set_varying_mode(const String &p_name, VaryingMode p_mode) {
-	ERR_FAIL_INDEX((int)p_mode, (int)VARYING_MODE_MAX);
+	ERR_FAIL_INDEX(p_mode, VARYING_MODE_MAX);
 	ERR_FAIL_COND(!varyings.has(p_name));
 	if (varyings[p_name].mode == p_mode) {
 		return;
@@ -884,7 +884,7 @@ VisualShader::VaryingMode VisualShader::get_varying_mode(const String &p_name) {
 }
 
 void VisualShader::set_varying_type(const String &p_name, VaryingType p_type) {
-	ERR_FAIL_INDEX((int)p_type, (int)VARYING_TYPE_MAX);
+	ERR_FAIL_INDEX(p_type, VARYING_TYPE_MAX);
 	ERR_FAIL_COND(!varyings.has(p_name));
 	if (varyings[p_name].type == p_type) {
 		return;
@@ -4177,7 +4177,7 @@ String VisualShaderNodeParameter::get_parameter_name() const {
 }
 
 void VisualShaderNodeParameter::set_qualifier(VisualShaderNodeParameter::Qualifier p_qual) {
-	ERR_FAIL_INDEX(int(p_qual), int(QUAL_MAX));
+	ERR_FAIL_INDEX(p_qual, QUAL_MAX);
 	if (qualifier == p_qual) {
 		return;
 	}
@@ -4592,7 +4592,7 @@ bool VisualShaderNodeGroupBase::is_valid_port_name(const String &p_name) const {
 }
 
 void VisualShaderNodeGroupBase::add_input_port(int p_id, int p_type, const String &p_name) {
-	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
+	ERR_FAIL_INDEX(p_type, PORT_TYPE_MAX);
 	ERR_FAIL_COND(!is_valid_port_name(p_name));
 
 	String str = itos(p_id) + "," + itos(p_type) + "," + p_name + ";";
@@ -4667,7 +4667,7 @@ bool VisualShaderNodeGroupBase::has_input_port(int p_id) const {
 }
 
 void VisualShaderNodeGroupBase::add_output_port(int p_id, int p_type, const String &p_name) {
-	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
+	ERR_FAIL_INDEX(p_type, PORT_TYPE_MAX);
 	ERR_FAIL_COND(!is_valid_port_name(p_name));
 
 	String str = itos(p_id) + "," + itos(p_type) + "," + p_name + ";";
@@ -4751,7 +4751,7 @@ void VisualShaderNodeGroupBase::clear_output_ports() {
 
 void VisualShaderNodeGroupBase::set_input_port_type(int p_id, int p_type) {
 	ERR_FAIL_COND(!has_input_port(p_id));
-	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
+	ERR_FAIL_INDEX(p_type, PORT_TYPE_MAX);
 
 	if (input_ports[p_id].type == p_type) {
 		return;
@@ -4821,7 +4821,7 @@ String VisualShaderNodeGroupBase::get_input_port_name(int p_id) const {
 
 void VisualShaderNodeGroupBase::set_output_port_type(int p_id, int p_type) {
 	ERR_FAIL_COND(!has_output_port(p_id));
-	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
+	ERR_FAIL_INDEX(p_type, PORT_TYPE_MAX);
 
 	if (output_ports[p_id].type == p_type) {
 		return;

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -64,7 +64,7 @@ VisualShaderNodeVectorBase::PortType VisualShaderNodeVectorBase::get_output_port
 }
 
 void VisualShaderNodeVectorBase::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -898,7 +898,7 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeTexture::set_source(Source p_source) {
-	ERR_FAIL_INDEX(int(p_source), int(SOURCE_MAX));
+	ERR_FAIL_INDEX(p_source, SOURCE_MAX);
 	if (source == p_source) {
 		return;
 	}
@@ -948,7 +948,7 @@ Ref<Texture2D> VisualShaderNodeTexture::get_texture() const {
 }
 
 void VisualShaderNodeTexture::set_texture_type(TextureType p_texture_type) {
-	ERR_FAIL_INDEX(int(p_texture_type), int(TYPE_MAX));
+	ERR_FAIL_INDEX(p_texture_type, TYPE_MAX);
 	if (texture_type == p_texture_type) {
 		return;
 	}
@@ -1291,7 +1291,7 @@ String VisualShaderNodeSample3D::generate_code(Shader::Mode p_mode, VisualShader
 }
 
 void VisualShaderNodeSample3D::set_source(Source p_source) {
-	ERR_FAIL_INDEX(int(p_source), int(SOURCE_MAX));
+	ERR_FAIL_INDEX(p_source, SOURCE_MAX);
 	if (source == p_source) {
 		return;
 	}
@@ -1557,7 +1557,7 @@ bool VisualShaderNodeCubemap::is_input_port_default(int p_port, Shader::Mode p_m
 }
 
 void VisualShaderNodeCubemap::set_source(Source p_source) {
-	ERR_FAIL_INDEX(int(p_source), int(SOURCE_MAX));
+	ERR_FAIL_INDEX(p_source, SOURCE_MAX);
 	if (source == p_source) {
 		return;
 	}
@@ -1579,7 +1579,7 @@ Ref<TextureLayered> VisualShaderNodeCubemap::get_cube_map() const {
 }
 
 void VisualShaderNodeCubemap::set_texture_type(TextureType p_texture_type) {
-	ERR_FAIL_INDEX(int(p_texture_type), int(TYPE_MAX));
+	ERR_FAIL_INDEX(p_texture_type, TYPE_MAX);
 	if (texture_type == p_texture_type) {
 		return;
 	}
@@ -1894,7 +1894,7 @@ String VisualShaderNodeFloatOp::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeFloatOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_ENUM_SIZE));
+	ERR_FAIL_INDEX(p_op, OP_ENUM_SIZE);
 	if (op == p_op) {
 		return;
 	}
@@ -2013,7 +2013,7 @@ String VisualShaderNodeIntOp::generate_code(Shader::Mode p_mode, VisualShader::T
 }
 
 void VisualShaderNodeIntOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), OP_ENUM_SIZE);
+	ERR_FAIL_INDEX(p_op, OP_ENUM_SIZE);
 	if (op == p_op) {
 		return;
 	}
@@ -2134,7 +2134,7 @@ String VisualShaderNodeUIntOp::generate_code(Shader::Mode p_mode, VisualShader::
 }
 
 void VisualShaderNodeUIntOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), OP_ENUM_SIZE);
+	ERR_FAIL_INDEX(p_op, OP_ENUM_SIZE);
 	if (op == p_op) {
 		return;
 	}
@@ -2253,7 +2253,7 @@ String VisualShaderNodeVectorOp::generate_code(Shader::Mode p_mode, VisualShader
 }
 
 void VisualShaderNodeVectorOp::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -2278,7 +2278,7 @@ void VisualShaderNodeVectorOp::set_op_type(OpType p_op_type) {
 }
 
 void VisualShaderNodeVectorOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_ENUM_SIZE));
+	ERR_FAIL_INDEX(p_op, OP_ENUM_SIZE);
 	if (op == p_op) {
 		return;
 	}
@@ -2456,7 +2456,7 @@ String VisualShaderNodeColorOp::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeColorOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_MAX));
+	ERR_FAIL_INDEX(p_op, OP_MAX);
 	if (op == p_op) {
 		return;
 	}
@@ -2584,7 +2584,7 @@ String VisualShaderNodeTransformOp::generate_code(Shader::Mode p_mode, VisualSha
 }
 
 void VisualShaderNodeTransformOp::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_MAX));
+	ERR_FAIL_INDEX(p_op, OP_MAX);
 	if (op == p_op) {
 		return;
 	}
@@ -2668,7 +2668,7 @@ String VisualShaderNodeTransformVecMult::generate_code(Shader::Mode p_mode, Visu
 }
 
 void VisualShaderNodeTransformVecMult::set_operator(Operator p_op) {
-	ERR_FAIL_INDEX(int(p_op), int(OP_MAX));
+	ERR_FAIL_INDEX(p_op, OP_MAX);
 	if (op == p_op) {
 		return;
 	}
@@ -2773,7 +2773,7 @@ String VisualShaderNodeFloatFunc::generate_code(Shader::Mode p_mode, VisualShade
 }
 
 void VisualShaderNodeFloatFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -2878,7 +2878,7 @@ String VisualShaderNodeIntFunc::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeIntFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -2953,7 +2953,7 @@ String VisualShaderNodeUIntFunc::generate_code(Shader::Mode p_mode, VisualShader
 }
 
 void VisualShaderNodeUIntFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -3075,7 +3075,7 @@ String VisualShaderNodeVectorFunc::generate_code(Shader::Mode p_mode, VisualShad
 }
 
 void VisualShaderNodeVectorFunc::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -3097,7 +3097,7 @@ void VisualShaderNodeVectorFunc::set_op_type(OpType p_op_type) {
 }
 
 void VisualShaderNodeVectorFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -3274,7 +3274,7 @@ String VisualShaderNodeColorFunc::generate_code(Shader::Mode p_mode, VisualShade
 }
 
 void VisualShaderNodeColorFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -3354,7 +3354,7 @@ String VisualShaderNodeTransformFunc::generate_code(Shader::Mode p_mode, VisualS
 }
 
 void VisualShaderNodeTransformFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -3488,7 +3488,7 @@ String VisualShaderNodeUVFunc::generate_code(Shader::Mode p_mode, VisualShader::
 }
 
 void VisualShaderNodeUVFunc::set_function(VisualShaderNodeUVFunc::Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -3698,7 +3698,7 @@ String VisualShaderNodeVectorLen::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeVectorLen::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -3859,7 +3859,7 @@ String VisualShaderNodeDerivativeFunc::get_warning(Shader::Mode p_mode, VisualSh
 }
 
 void VisualShaderNodeDerivativeFunc::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX((int)p_op_type, int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -3888,7 +3888,7 @@ VisualShaderNodeDerivativeFunc::OpType VisualShaderNodeDerivativeFunc::get_op_ty
 }
 
 void VisualShaderNodeDerivativeFunc::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -3901,7 +3901,7 @@ VisualShaderNodeDerivativeFunc::Function VisualShaderNodeDerivativeFunc::get_fun
 }
 
 void VisualShaderNodeDerivativeFunc::set_precision(Precision p_precision) {
-	ERR_FAIL_INDEX(int(p_precision), int(PRECISION_MAX));
+	ERR_FAIL_INDEX(p_precision, PRECISION_MAX);
 	if (precision == p_precision) {
 		return;
 	}
@@ -4026,7 +4026,7 @@ String VisualShaderNodeClamp::generate_code(Shader::Mode p_mode, VisualShader::T
 }
 
 void VisualShaderNodeClamp::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX((int)p_op_type, int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -4127,7 +4127,7 @@ String VisualShaderNodeFaceForward::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeFaceForward::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -4289,7 +4289,7 @@ String VisualShaderNodeStep::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeStep::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -4445,7 +4445,7 @@ String VisualShaderNodeSmoothStep::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeSmoothStep::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -4561,7 +4561,7 @@ String VisualShaderNodeVectorDistance::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeVectorDistance::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -4629,7 +4629,7 @@ String VisualShaderNodeVectorRefract::generate_code(Shader::Mode p_mode, VisualS
 }
 
 void VisualShaderNodeVectorRefract::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -4734,7 +4734,7 @@ String VisualShaderNodeMix::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeMix::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -4888,7 +4888,7 @@ String VisualShaderNodeVectorCompose::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeVectorCompose::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -5070,7 +5070,7 @@ String VisualShaderNodeVectorDecompose::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeVectorDecompose::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -5229,7 +5229,7 @@ bool VisualShaderNodeFloatParameter::is_use_prop_slots() const {
 }
 
 void VisualShaderNodeFloatParameter::set_hint(Hint p_hint) {
-	ERR_FAIL_INDEX(int(p_hint), int(HINT_MAX));
+	ERR_FAIL_INDEX(p_hint, HINT_MAX);
 	if (hint == p_hint) {
 		return;
 	}
@@ -5434,7 +5434,7 @@ bool VisualShaderNodeIntParameter::is_use_prop_slots() const {
 }
 
 void VisualShaderNodeIntParameter::set_hint(Hint p_hint) {
-	ERR_FAIL_INDEX(int(p_hint), int(HINT_MAX));
+	ERR_FAIL_INDEX(p_hint, HINT_MAX);
 	if (hint == p_hint) {
 		return;
 	}
@@ -6480,7 +6480,7 @@ String VisualShaderNodeTextureParameter::generate_code(Shader::Mode p_mode, Visu
 }
 
 void VisualShaderNodeTextureParameter::set_texture_type(TextureType p_texture_type) {
-	ERR_FAIL_INDEX(int(p_texture_type), int(TYPE_MAX));
+	ERR_FAIL_INDEX(p_texture_type, TYPE_MAX);
 	if (texture_type == p_texture_type) {
 		return;
 	}
@@ -6493,7 +6493,7 @@ VisualShaderNodeTextureParameter::TextureType VisualShaderNodeTextureParameter::
 }
 
 void VisualShaderNodeTextureParameter::set_color_default(ColorDefault p_color_default) {
-	ERR_FAIL_INDEX(int(p_color_default), int(COLOR_DEFAULT_MAX));
+	ERR_FAIL_INDEX(p_color_default, COLOR_DEFAULT_MAX);
 	if (color_default == p_color_default) {
 		return;
 	}
@@ -6506,7 +6506,7 @@ VisualShaderNodeTextureParameter::ColorDefault VisualShaderNodeTextureParameter:
 }
 
 void VisualShaderNodeTextureParameter::set_texture_filter(TextureFilter p_filter) {
-	ERR_FAIL_INDEX(int(p_filter), int(FILTER_MAX));
+	ERR_FAIL_INDEX(p_filter, FILTER_MAX);
 	if (texture_filter == p_filter) {
 		return;
 	}
@@ -6519,7 +6519,7 @@ VisualShaderNodeTextureParameter::TextureFilter VisualShaderNodeTextureParameter
 }
 
 void VisualShaderNodeTextureParameter::set_texture_repeat(TextureRepeat p_repeat) {
-	ERR_FAIL_INDEX(int(p_repeat), int(REPEAT_MAX));
+	ERR_FAIL_INDEX(p_repeat, REPEAT_MAX);
 	if (texture_repeat == p_repeat) {
 		return;
 	}
@@ -6532,7 +6532,7 @@ VisualShaderNodeTextureParameter::TextureRepeat VisualShaderNodeTextureParameter
 }
 
 void VisualShaderNodeTextureParameter::set_texture_source(TextureSource p_source) {
-	ERR_FAIL_INDEX(int(p_source), int(SOURCE_MAX));
+	ERR_FAIL_INDEX(p_source, SOURCE_MAX);
 	if (texture_source == p_source) {
 		return;
 	}
@@ -7072,7 +7072,7 @@ String VisualShaderNodeSwitch::get_output_port_name(int p_port) const {
 }
 
 void VisualShaderNodeSwitch::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -7331,7 +7331,7 @@ String VisualShaderNodeIs::generate_code(Shader::Mode p_mode, VisualShader::Type
 }
 
 void VisualShaderNodeIs::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -7511,7 +7511,7 @@ String VisualShaderNodeCompare::generate_code(Shader::Mode p_mode, VisualShader:
 }
 
 void VisualShaderNodeCompare::set_comparison_type(ComparisonType p_comparison_type) {
-	ERR_FAIL_INDEX(int(p_comparison_type), int(CTYPE_MAX));
+	ERR_FAIL_INDEX(p_comparison_type, CTYPE_MAX);
 	if (comparison_type == p_comparison_type) {
 		return;
 	}
@@ -7564,7 +7564,7 @@ VisualShaderNodeCompare::ComparisonType VisualShaderNodeCompare::get_comparison_
 }
 
 void VisualShaderNodeCompare::set_function(Function p_func) {
-	ERR_FAIL_INDEX(int(p_func), int(FUNC_MAX));
+	ERR_FAIL_INDEX(p_func, FUNC_MAX);
 	if (func == p_func) {
 		return;
 	}
@@ -7577,7 +7577,7 @@ VisualShaderNodeCompare::Function VisualShaderNodeCompare::get_function() const 
 }
 
 void VisualShaderNodeCompare::set_condition(Condition p_condition) {
-	ERR_FAIL_INDEX(int(p_condition), int(COND_MAX));
+	ERR_FAIL_INDEX(p_condition, COND_MAX);
 	if (condition == p_condition) {
 		return;
 	}
@@ -7707,7 +7707,7 @@ String VisualShaderNodeMultiplyAdd::generate_code(Shader::Mode p_mode, VisualSha
 }
 
 void VisualShaderNodeMultiplyAdd::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX((int)p_op_type, int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -7845,7 +7845,7 @@ bool VisualShaderNodeBillboard::is_show_prop_names() const {
 }
 
 void VisualShaderNodeBillboard::set_billboard_type(BillboardType p_billboard_type) {
-	ERR_FAIL_INDEX(int(p_billboard_type), int(BILLBOARD_TYPE_MAX));
+	ERR_FAIL_INDEX(p_billboard_type, BILLBOARD_TYPE_MAX);
 	if (billboard_type == p_billboard_type) {
 		return;
 	}

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -1009,7 +1009,7 @@ String VisualShaderNodeParticleRandomness::generate_code(Shader::Mode p_mode, Vi
 }
 
 void VisualShaderNodeParticleRandomness::set_op_type(OpType p_op_type) {
-	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	ERR_FAIL_INDEX(p_op_type, OP_TYPE_MAX);
 	if (op_type == p_op_type) {
 		return;
 	}
@@ -1138,7 +1138,7 @@ String VisualShaderNodeParticleAccelerator::generate_code(Shader::Mode p_mode, V
 }
 
 void VisualShaderNodeParticleAccelerator::set_mode(Mode p_mode) {
-	ERR_FAIL_INDEX(int(p_mode), int(MODE_MAX));
+	ERR_FAIL_INDEX(p_mode, MODE_MAX);
 	if (mode == p_mode) {
 		return;
 	}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2539,7 +2539,7 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 		uint32_t shadow = key & RendererRD::LightStorage::SHADOW_INDEX_MASK;
 		uint32_t subdivision = light_storage->shadow_atlas_get_quadrant_subdivision(p_shadow_atlas, quadrant);
 
-		ERR_FAIL_INDEX((int)shadow, light_storage->shadow_atlas_get_quadrant_shadow_size(p_shadow_atlas, quadrant));
+		ERR_FAIL_INDEX(shadow, light_storage->shadow_atlas_get_quadrant_shadow_size(p_shadow_atlas, quadrant));
 
 		uint32_t shadow_atlas_size = light_storage->shadow_atlas_get_size(p_shadow_atlas);
 		uint32_t quadrant_size = shadow_atlas_size >> 1;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -376,7 +376,7 @@ RID RenderForwardMobile::_setup_render_pass_uniform_set(RenderListType p_render_
 	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
 
 	//there should always be enough uniform buffers for render passes, otherwise bugs
-	ERR_FAIL_INDEX_V(p_index, (int)scene_state.uniform_buffers.size(), RID());
+	ERR_FAIL_INDEX_V(p_index, scene_state.uniform_buffers.size(), RID());
 
 	bool is_multiview = false;
 
@@ -1292,7 +1292,7 @@ void RenderForwardMobile::_render_shadow_pass(RID p_light, RID p_shadow_atlas, i
 		uint32_t shadow = key & RendererRD::LightStorage::SHADOW_INDEX_MASK;
 		uint32_t subdivision = light_storage->shadow_atlas_get_quadrant_subdivision(p_shadow_atlas, quadrant);
 
-		ERR_FAIL_INDEX((int)shadow, light_storage->shadow_atlas_get_quadrant_shadow_size(p_shadow_atlas, quadrant));
+		ERR_FAIL_INDEX(shadow, light_storage->shadow_atlas_get_quadrant_shadow_size(p_shadow_atlas, quadrant));
 
 		uint32_t shadow_atlas_size = light_storage->shadow_atlas_get_size(p_shadow_atlas);
 		uint32_t quadrant_size = shadow_atlas_size >> 1;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -1083,14 +1083,14 @@ public:
 	_FORCE_INLINE_ int shadow_atlas_get_quadrant_shadow_size(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].shadows.size();
 	}
 
 	_FORCE_INLINE_ uint32_t shadow_atlas_get_quadrant_subdivision(RID p_atlas, uint32_t p_quadrant) {
 		ShadowAtlas *atlas = shadow_atlas_owner.get_or_null(p_atlas);
 		ERR_FAIL_NULL_V(atlas, 0);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_quadrant, 4, 0);
+		ERR_FAIL_INDEX_V(p_quadrant, 4, 0);
 		return atlas->quadrants[p_quadrant].subdivision;
 	}
 

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -514,7 +514,7 @@ int MeshStorage::mesh_get_blend_shape_count(RID p_mesh) const {
 void MeshStorage::mesh_set_blend_shape_mode(RID p_mesh, RS::BlendShapeMode p_mode) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_INDEX((int)p_mode, 2);
+	ERR_FAIL_INDEX(p_mode, 2);
 
 	mesh->blend_shape_mode = p_mode;
 }
@@ -528,7 +528,7 @@ RS::BlendShapeMode MeshStorage::mesh_get_blend_shape_mode(RID p_mesh) const {
 void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->vertex_buffer.is_null());
 	uint64_t data_size = p_data.size();
@@ -540,7 +540,7 @@ void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, i
 void MeshStorage::mesh_surface_update_attribute_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->attribute_buffer.is_null());
 	uint64_t data_size = p_data.size();
@@ -552,7 +552,7 @@ void MeshStorage::mesh_surface_update_attribute_region(RID p_mesh, int p_surface
 void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	ERR_FAIL_COND(p_data.is_empty());
 	ERR_FAIL_COND(mesh->surfaces[p_surface]->skin_buffer.is_null());
 	uint64_t data_size = p_data.size();
@@ -564,7 +564,7 @@ void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int
 void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL(mesh);
-	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	ERR_FAIL_INDEX(p_surface, mesh->surface_count);
 	mesh->surfaces[p_surface]->material = p_material;
 
 	mesh->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_MATERIAL);
@@ -574,7 +574,7 @@ void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_mat
 RID MeshStorage::mesh_surface_get_material(RID p_mesh, int p_surface) const {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL_V(mesh, RID());
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_surface, mesh->surface_count, RID());
+	ERR_FAIL_INDEX_V(p_surface, mesh->surface_count, RID());
 
 	return mesh->surfaces[p_surface]->material;
 }
@@ -582,7 +582,7 @@ RID MeshStorage::mesh_surface_get_material(RID p_mesh, int p_surface) const {
 RS::SurfaceData MeshStorage::mesh_get_surface(RID p_mesh, int p_surface) const {
 	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 	ERR_FAIL_NULL_V(mesh, RS::SurfaceData());
-	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_surface, mesh->surface_count, RS::SurfaceData());
+	ERR_FAIL_INDEX_V(p_surface, mesh->surface_count, RS::SurfaceData());
 
 	Mesh::Surface &s = *mesh->surfaces[p_surface];
 
@@ -919,7 +919,7 @@ void MeshStorage::mesh_instance_set_skeleton(RID p_mesh_instance, RID p_skeleton
 void MeshStorage::mesh_instance_set_blend_shape_weight(RID p_mesh_instance, int p_shape, float p_weight) {
 	MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
 	ERR_FAIL_NULL(mi);
-	ERR_FAIL_INDEX(p_shape, (int)mi->blend_weights.size());
+	ERR_FAIL_INDEX(p_shape, mi->blend_weights.size());
 	mi->blend_weights[p_shape] = p_weight;
 	mi->weights_dirty = true;
 	//will be eventually updated
@@ -1639,7 +1639,7 @@ void MeshStorage::_multimesh_mark_dirty(MultiMesh *multimesh, int p_index, bool 
 	uint32_t region_index = p_index / MULTIMESH_DIRTY_REGION_SIZE;
 #ifdef DEBUG_ENABLED
 	uint32_t data_cache_dirty_region_count = Math::division_round_up(multimesh->instances, MULTIMESH_DIRTY_REGION_SIZE);
-	ERR_FAIL_UNSIGNED_INDEX(region_index, data_cache_dirty_region_count); //bug
+	ERR_FAIL_INDEX(region_index, data_cache_dirty_region_count); //bug
 #endif
 	if (!multimesh->data_cache_dirty_regions[region_index]) {
 		multimesh->data_cache_dirty_regions[region_index] = true;

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.h
@@ -411,7 +411,7 @@ public:
 	_FORCE_INLINE_ void *mesh_get_surface(RID p_mesh, uint32_t p_surface_index) {
 		Mesh *mesh = mesh_owner.get_or_null(p_mesh);
 		ERR_FAIL_NULL_V(mesh, nullptr);
-		ERR_FAIL_UNSIGNED_INDEX_V(p_surface_index, mesh->surface_count, nullptr);
+		ERR_FAIL_INDEX_V(p_surface_index, mesh->surface_count, nullptr);
 
 		return mesh->surfaces[p_surface_index];
 	}
@@ -519,7 +519,7 @@ public:
 		MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
 		ERR_FAIL_NULL(mi);
 		Mesh *mesh = mi->mesh;
-		ERR_FAIL_UNSIGNED_INDEX(p_surface_index, mesh->surface_count);
+		ERR_FAIL_INDEX(p_surface_index, mesh->surface_count);
 
 		MeshInstance::Surface *mis = &mi->surfaces[p_surface_index];
 		Mesh::Surface *s = mesh->surfaces[p_surface_index];

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -395,10 +395,10 @@ RID RenderSceneBuffersRD::get_texture_slice_view(const StringName &p_context, co
 	ERR_FAIL_COND_V(named_texture.texture.is_null(), RID());
 
 	// check if we're in bounds
-	ERR_FAIL_UNSIGNED_INDEX_V(p_layer, named_texture.format.array_layers, RID());
+	ERR_FAIL_INDEX_V(p_layer, named_texture.format.array_layers, RID());
 	ERR_FAIL_COND_V(p_layers == 0, RID());
 	ERR_FAIL_COND_V(p_layer + p_layers > named_texture.format.array_layers, RID());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_mipmap, named_texture.format.mipmaps, RID());
+	ERR_FAIL_INDEX_V(p_mipmap, named_texture.format.mipmaps, RID());
 	ERR_FAIL_COND_V(p_mipmaps == 0, RID());
 	ERR_FAIL_COND_V(p_mipmap + p_mipmaps > named_texture.format.mipmaps, RID());
 
@@ -445,7 +445,7 @@ Size2i RenderSceneBuffersRD::get_texture_slice_size(const StringName &p_context,
 	ERR_FAIL_COND_V(named_texture.texture.is_null(), Size2i());
 
 	// check if we're in bounds
-	ERR_FAIL_UNSIGNED_INDEX_V(p_mipmap, named_texture.format.mipmaps, Size2i());
+	ERR_FAIL_INDEX_V(p_mipmap, named_texture.format.mipmaps, Size2i());
 
 	// return our size
 	return named_texture.sizes[p_mipmap];

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.cpp
@@ -51,13 +51,13 @@ uint32_t RenderSceneDataRD::get_view_count() const {
 }
 
 Vector3 RenderSceneDataRD::get_view_eye_offset(uint32_t p_view) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_view, view_count, Vector3());
+	ERR_FAIL_INDEX_V(p_view, view_count, Vector3());
 
 	return view_eye_offset[p_view];
 }
 
 Projection RenderSceneDataRD::get_view_projection(uint32_t p_view) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_view, view_count, Projection());
+	ERR_FAIL_INDEX_V(p_view, view_count, Projection());
 
 	Projection correction;
 	correction.set_depth_correction(flip_y);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3624,7 +3624,7 @@ RID TextureStorage::render_target_get_rd_texture_slice(RID p_render_target, uint
 	if (rt->view_count == 1) {
 		return rt->color;
 	} else {
-		ERR_FAIL_UNSIGNED_INDEX_V(p_layer, rt->view_count, RID());
+		ERR_FAIL_INDEX_V(p_layer, rt->view_count, RID());
 		if (rt->color_slices.size() == 0) {
 			for (uint32_t v = 0; v < rt->view_count; v++) {
 				RID slice = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rt->color, v, 0);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1073,9 +1073,9 @@ RID RenderingDevice::texture_create_shared_from_slice(const TextureView &p_view,
 
 	// Create view.
 
-	ERR_FAIL_UNSIGNED_INDEX_V(p_mipmap, src_texture->mipmaps, RID());
+	ERR_FAIL_INDEX_V(p_mipmap, src_texture->mipmaps, RID());
 	ERR_FAIL_COND_V(p_mipmap + p_mipmaps > src_texture->mipmaps, RID());
-	ERR_FAIL_UNSIGNED_INDEX_V(p_layer, src_texture->layers, RID());
+	ERR_FAIL_INDEX_V(p_layer, src_texture->layers, RID());
 
 	int slice_layers = 1;
 	if (p_layers != 0) {
@@ -6675,18 +6675,18 @@ uint64_t RenderingDevice::get_captured_timestamps_frame() const {
 
 uint64_t RenderingDevice::get_captured_timestamp_gpu_time(uint32_t p_index) const {
 	ERR_RENDER_THREAD_GUARD_V(0);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
 	return driver->timestamp_query_result_to_time(frames[frame].timestamp_result_values[p_index]);
 }
 
 uint64_t RenderingDevice::get_captured_timestamp_cpu_time(uint32_t p_index) const {
 	ERR_RENDER_THREAD_GUARD_V(0);
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, 0);
 	return frames[frame].timestamp_cpu_result_values[p_index];
 }
 
 String RenderingDevice::get_captured_timestamp_name(uint32_t p_index) const {
-	ERR_FAIL_UNSIGNED_INDEX_V(p_index, frames[frame].timestamp_result_count, String());
+	ERR_FAIL_INDEX_V(p_index, frames[frame].timestamp_result_count, String());
 	return frames[frame].timestamp_result_names[p_index];
 }
 

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -127,7 +127,7 @@ bool RenderingLightCuller::cull_directional_light(const RendererSceneCull::Insta
 		return true;
 	}
 
-	ERR_FAIL_INDEX_V(p_directional_light_id, (int32_t)data.directional_cull_planes.size(), true);
+	ERR_FAIL_INDEX_V(p_directional_light_id, data.directional_cull_planes.size(), true);
 
 	LightCullPlanes &cull_planes = data.directional_cull_planes[p_directional_light_id];
 


### PR DESCRIPTION
- Alternative to #96356

Setup this PR months ago but completely forgot about it until @adamscott's above PR reminded me of it. This opts for a constexpr template function instead of a lambda macro; the biggest functional difference between the two is that this implementation accounts for enums as well, both legacy and class. I haven't actually tested this PR in ages, but the core logic *should* be sound after all this time.

This PR also removes the `UNSIGNED_INDEX` macros because they're no longer necessary & updates certain macro instances to not need conversion casts where unnecessary.