### PR TITLE
Project Dialog: Allow editing the Create Folder suffix

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -245,8 +245,10 @@ String ProjectDialog::_get_target_path() {
 	} else if (mode == MODE_IMPORT) {
 		path = install_path->get_text();
 	}
-	if (project_name_suffix->is_visible() || install_name_suffix->is_visible()) {
-		path = path.path_join(auto_dir);
+	if (project_name_suffix->is_visible()) {
+		path = path.path_join(project_name_suffix->get_text());
+	} else if (install_name_suffix->is_visible()) {
+		path = path.path_join(install_name_suffix->get_text());
 	}
 	return path;
 }
@@ -288,9 +290,11 @@ void ProjectDialog::_update_target_auto_dir() {
 
 void ProjectDialog::_create_dir_toggled(bool p_pressed) {
 	if (p_pressed) {
-		project_name_suffix->set_text("/" + auto_dir);
-		install_name_suffix->set_text("/" + auto_dir);
+		project_name_suffix->set_text(auto_dir);
+		install_name_suffix->set_text(auto_dir);
 	}
+	project_name_joining_slash->set_visible(p_pressed && mode == MODE_NEW);
+	install_name_joining_slash->set_visible(p_pressed && mode == MODE_IMPORT);
 	project_name_suffix->set_visible(p_pressed && mode == MODE_NEW);
 	install_name_suffix->set_visible(p_pressed && mode == MODE_IMPORT);
 	_validate_path();
@@ -816,12 +820,24 @@ ProjectDialog::ProjectDialog() {
 	install_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	install_path->set_structured_text_bidi_override(TextServer::STRUCTURED_TEXT_FILE);
 	iphb->add_child(install_path);
+	
+	project_name_joining_slash = memnew(Label);
+	project_name_joining_slash->set_text("/");
+	project_name_joining_slash->hide();
+	pphb->add_child(project_name_joining_slash);
+	
+	install_name_joining_slash = memnew(Label);
+	install_name_joining_slash->set_text("/");
+	install_name_joining_slash->hide();
+	iphb->add_child(install_name_joining_slash);
 
-	project_name_suffix = memnew(Label);
+	project_name_suffix = memnew(LineEdit);
+	project_name_suffix->set_expand_to_text_length_enabled(true);
 	project_name_suffix->hide();
 	pphb->add_child(project_name_suffix);
 
-	install_name_suffix = memnew(Label);
+	install_name_suffix = memnew(LineEdit);
+	install_name_suffix->set_expand_to_text_length_enabled(true);
 	install_name_suffix->hide();
 	iphb->add_child(install_name_suffix);
 
@@ -950,6 +966,8 @@ ProjectDialog::ProjectDialog() {
 	project_name->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_project_name_changed).unbind(1));
 	project_path->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_project_path_changed).unbind(1));
 	install_path->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_install_path_changed).unbind(1));
+	project_name_suffix->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_project_path_changed).unbind(1));
+	install_name_suffix->connect(SceneStringName(text_changed), callable_mp(this, &ProjectDialog::_install_path_changed).unbind(1));
 	fdialog_install->connect("dir_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
 	fdialog_install->connect("file_selected", callable_mp(this, &ProjectDialog::_install_path_selected));
 

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -79,6 +79,8 @@ private:
 	Ref<ButtonGroup> renderer_button_group;
 
 	Label *msg = nullptr;
+	Label *project_name_suffix = nullptr;
+	Label *install_name_suffix = nullptr;
 	LineEdit *project_name = nullptr;
 	LineEdit *project_path = nullptr;
 	LineEdit *install_path = nullptr;
@@ -100,16 +102,12 @@ private:
 	// Project path for MODE_NEW and MODE_INSTALL. Install path for MODE_IMPORT.
 	// Install path is only visible when importing a ZIP.
 	String _get_target_path();
-	void _set_target_path(const String &p_text);
 
 	// Calculated from project name / ZIP name.
 	String auto_dir;
 
 	// Updates `auto_dir`. If the target path dir name is equal to `auto_dir` (the default state), the target path is also updated.
 	void _update_target_auto_dir();
-
-	// While `create_dir` is disabled, stores the last target path dir name, or an empty string if equal to `auto_dir`.
-	String last_custom_target_dir;
 	void _create_dir_toggled(bool p_pressed);
 
 	void _project_name_changed();

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -79,8 +79,10 @@ private:
 	Ref<ButtonGroup> renderer_button_group;
 
 	Label *msg = nullptr;
-	Label *project_name_suffix = nullptr;
-	Label *install_name_suffix = nullptr;
+	Label *project_name_joining_slash = nullptr;
+	Label *install_name_joining_slash = nullptr;
+	LineEdit *project_name_suffix = nullptr;
+	LineEdit *install_name_suffix = nullptr;
 	LineEdit *project_name = nullptr;
 	LineEdit *project_path = nullptr;
 	LineEdit *install_path = nullptr;


### PR DESCRIPTION
Depends on #95262
(Let me know if the request is set up incorrectly, this is my first time making a PR that depends on an unmerged commit)

Follows up on #93973

Using Label for the suffix does not allow for editing the created folder's name.
To prevent this regression, it now uses LineEdit instead.
The joining slash is also represented separately as its own Label for clarity.