### PR TITLE
Fix AudioStreamPlaybackInteractive::get_playback_position() always returning 0

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -1023,7 +1023,11 @@ int AudioStreamPlaybackInteractive::get_loop_count() const {
 }
 
 double AudioStreamPlaybackInteractive::get_playback_position() const {
-	return 0.0;
+	if (playback_current < 0 || !states[playback_current].playback.is_valid()) {
+		return 0.0;
+	}
+
+	return states[playback_current].playback->get_playback_position();
 }
 
 bool AudioStreamPlaybackInteractive::is_playing() const {


### PR DESCRIPTION
_get_playback_position_ method from **AudioStreamPlaybackInteractive** is currently returning always 0.

[Minimum Reproduction Project](https://github.com/adriano-sudario/godot_streams_issues_mrp) under scene [bugs/interactive_stream_get_playback_position_returns_always_zero.tscn](https://github.com/adriano-sudario/godot_streams_issues_mrp/blob/main/bugs/interactive_stream_get_playback_position_returns_always_zero.tscn)