### PR TITLE
servers/rendering: add new GLSL file format that is compatible with standard GLSL

### DIFF
--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -180,8 +180,8 @@ Error RDShaderFile::_parse_sectioned_text(const Vector<String> &p_lines, const S
 const char *RDShaderFile::_stage_str[RD::SHADER_STAGE_MAX] = {
 	"vertex",
 	"fragment",
-	"tesselation_control",
-	"tesselation_evaluation",
+	"tessellation_control",
+	"tessellation_evaluation",
 	"compute",
 };
 
@@ -190,6 +190,13 @@ RD::ShaderStage RDShaderFile::_str_to_stage(const String &s) {
 		if (s == _stage_str[i]) {
 			return RD::ShaderStage(i);
 		}
+	}
+	// Compatibility names (only one L in "tessellation" instead of two)
+	// for historical typo, so that older shaders keep working.
+	if (s == "tesselation_control") {
+		return RD::SHADER_STAGE_TESSELATION_CONTROL;
+	} else if (s == "tesselation_evaluation") {
+		return RD::SHADER_STAGE_TESSELATION_EVALUATION;
 	}
 	return RD::SHADER_STAGE_MAX;
 }

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -141,7 +141,8 @@ Error RDShaderFile::_parse_sectioned_text(const Vector<String> &p_lines, const S
 
 	if (base_error.is_empty()) {
 		if (stage_found[RD::SHADER_STAGE_COMPUTE] && stages_found > 1) {
-			ERR_FAIL_V_MSG(ERR_PARSE_ERROR, "When writing compute shaders, [compute] mustbe the only stage present.");
+			base_error = "When writing compute shaders, [compute] must be the only stage present.";
+			return ERR_PARSE_ERROR;
 		}
 
 		if (version_texts.is_empty()) {

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -70,7 +70,8 @@ Error RDShaderFile::_parse_sectioned_text(const Vector<String> &p_lines, const S
 				} else {
 					stage = _str_to_stage(section);
 					if (stage == RD::SHADER_STAGE_MAX) {
-						continue;
+						base_error = "Unknown shader section type: " + section;
+						break;
 					}
 					if (stage_found[stage]) {
 						base_error = "Invalid shader file, stage appears twice: " + section;

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -39,7 +39,13 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 			"Cannot import custom .glsl shaders when running without a RenderingDevice. This can happen if you are using the headless more or the Compatibility backend.");
 
 	Vector<String> lines = p_text.split("\n");
+	versions.clear();
+	base_error = "";
 
+	return _parse_sectioned_text(lines, p_defines, p_include_func, p_include_func_userdata);
+}
+
+Error RDShaderFile::_parse_sectioned_text(const Vector<String> &p_lines, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata) {
 	bool reading_versions = false;
 	bool stage_found[RD::SHADER_STAGE_MAX] = { false, false, false, false, false };
 	RD::ShaderStage stage = RD::SHADER_STAGE_MAX;
@@ -54,11 +60,8 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 	int stages_found = 0;
 	HashMap<StringName, String> version_texts;
 
-	versions.clear();
-	base_error = "";
-
-	for (int lidx = 0; lidx < lines.size(); lidx++) {
-		String line = lines[lidx];
+	for (int lidx = 0; lidx < p_lines.size(); lidx++) {
+		String line = p_lines[lidx];
 
 		{
 			String ls = line.strip_edges();

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -408,6 +408,8 @@ public:
 	Error parse_versions_from_text(const String &p_text, const String p_defines = String(), OpenIncludeFunction p_include_func = nullptr, void *p_include_func_userdata = nullptr);
 
 protected:
+	Error _parse_sectioned_text(const Vector<String> &p_lines, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata);
+
 	Dictionary _get_versions() const {
 		TypedArray<StringName> vnames = get_version_list();
 		Dictionary ret;

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -410,10 +410,12 @@ public:
 protected:
 	static const char *_stage_str[RD::SHADER_STAGE_MAX];
 	Error _parse_sectioned_text(const Vector<String> &p_lines, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata);
+	Error _parse_pragma_text(const Vector<String> &p_lines, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata);
 	RD::ShaderStage _str_to_stage(const String &s);
 	String _stage_to_str(const RD::ShaderStage s);
 	bool _compile_shader(const RD::ShaderStage p_stage, const String &p_code, Ref<RDShaderSPIRV> p_bytecode);
 	String _expand_include(const String &p_line, OpenIncludeFunction p_include_func, void *p_include_func_userdata);
+	Error _parse_godot_pragma(const String &p_line, String *r_pragma_name, Vector<String> *r_pragma_vals);
 
 	Dictionary _get_versions() const {
 		TypedArray<StringName> vnames = get_version_list();

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -412,6 +412,7 @@ protected:
 	Error _parse_sectioned_text(const Vector<String> &p_lines, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata);
 	RD::ShaderStage _str_to_stage(const String &s);
 	String _stage_to_str(const RD::ShaderStage s);
+	bool _compile_shader(const RD::ShaderStage p_stage, const String &p_code, Ref<RDShaderSPIRV> p_bytecode);
 	String _expand_include(const String &p_line, OpenIncludeFunction p_include_func, void *p_include_func_userdata);
 
 	Dictionary _get_versions() const {

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -408,7 +408,10 @@ public:
 	Error parse_versions_from_text(const String &p_text, const String p_defines = String(), OpenIncludeFunction p_include_func = nullptr, void *p_include_func_userdata = nullptr);
 
 protected:
+	static const char *_stage_str[RD::SHADER_STAGE_MAX];
 	Error _parse_sectioned_text(const Vector<String> &p_lines, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata);
+	RD::ShaderStage _str_to_stage(const String &s);
+	String _stage_to_str(const RD::ShaderStage s);
 
 	Dictionary _get_versions() const {
 		TypedArray<StringName> vnames = get_version_list();

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -412,6 +412,7 @@ protected:
 	Error _parse_sectioned_text(const Vector<String> &p_lines, const String p_defines, OpenIncludeFunction p_include_func, void *p_include_func_userdata);
 	RD::ShaderStage _str_to_stage(const String &s);
 	String _stage_to_str(const RD::ShaderStage s);
+	String _expand_include(const String &p_line, OpenIncludeFunction p_include_func, void *p_include_func_userdata);
 
 	Dictionary _get_versions() const {
 		TypedArray<StringName> vnames = get_version_list();


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/11274

The proposal has detailed justifications for the design, but TLDR: this change lets you write GLSL shaders where the Godot-specific hints are encoded as `#pragmas`, so that standard GLSL tools (IDE language servers, linters, glslang etc.) can parse the files and give a better development experience. The code supports both the new and existing file formats, so existing shaders keep working exactly as before.

Detailed syntax and examples with more complex shaders is in the proposal, For a simple compute shader, the only change is the first 2 lines:

```glsl
#[compute]
#version 450
```

becomes:

```glsl
#version 450
#pragma godot_shader_stages(compute)
```

I brought this to the rendering meeting earlier today and got :+1: on the concept, so here I am with code :)

For ease of reviewing, I split the change into multiple standalone commits. You can review each one separately, if you'd like smaller diffs with a single logical change in each. Godot compiles cleanly at every commit, so they can be merged as-is or I can squash them after review, your decision.

Assuming this gets merged, I will send followup PRs to godot-docs and godot-example-projects to update the compute shader documentation to this format. I can also send followups to convert the internal shaders the renderers use, but I plan to check with the rendering folks again before I do that, to make sure I don't mess with other WIPs. It's not urgent to do, since the existing format will keep working.