### PR TITLE
[macOS] Print full source paths in the trace.

### DIFF
--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -149,6 +149,7 @@ static void handle_crash(int sig) {
 				args.push_back("-arch");
 				args.push_back("arm64");
 #endif
+				args.push_back("--fullPath");
 				args.push_back("-l");
 				snprintf(str, 1024, "%p", load_addr);
 				args.push_back(str);


### PR DESCRIPTION
Adds full (or relative) paths to the trace, for consistency with other platforms.

## Before:
```
[17] SceneTree::initialize() (in godot.macos.editor.dev.arm64) (scene_tree.cpp:572)
[18] OS_MacOS::run() (in godot.macos.editor.dev.arm64) (os_macos.mm:800)
[19] main (in godot.macos.editor.dev.arm64) (godot_main_macos.mm:84)
```

## After, with `debug_paths_relative=false`:
```
[17] SceneTree::initialize() (in godot.macos.editor.dev.arm64) (/Volumes/Backup/Projects/godot/scene/main/scene_tree.cpp:572)
[18] OS_MacOS::run() (in godot.macos.editor.dev.arm64) (/Volumes/Backup/Projects/godot/platform/macos/os_macos.mm:800)
[19] main (in godot.macos.editor.dev.arm64) (/Volumes/Backup/Projects/godot/platform/macos/godot_main_macos.mm:84)
```

## After, with `debug_paths_relative=true`:
```
[17] SceneTree::initialize() (in godot.macos.editor.dev.arm64) (./scene/main/scene_tree.cpp:572)
[18] OS_MacOS::run() (in godot.macos.editor.dev.arm64) (./platform/macos/os_macos.mm:800)
[19] main (in godot.macos.editor.dev.arm64) (./platform/macos/godot_main_macos.mm:84)
```