### PR TITLE
Reserve space for LocalVector if size is known

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3741,6 +3741,7 @@ void RasterizerSceneGLES3::_render_uv2(const PagedArray<RenderGeometryInstance *
 		glDepthFunc(GL_GREATER);
 
 		TightLocalVector<GLenum> draw_buffers;
+		draw_buffers.reserve(4);
 		draw_buffers.push_back(GL_COLOR_ATTACHMENT0);
 		draw_buffers.push_back(GL_COLOR_ATTACHMENT1);
 		draw_buffers.push_back(GL_COLOR_ATTACHMENT2);

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -578,6 +578,7 @@ bool ShaderGLES3::_load_from_cache(Version *p_version) {
 	ERR_FAIL_COND_V_MSG(cache_variant_count != variant_count, false, "shader cache variant count mismatch, expected " + itos(variant_count) + " got " + itos(cache_variant_count)); //should not happen but check
 
 	LocalVector<OAHashMap<uint64_t, Version::Specialization>> variants;
+	variants.reserve(cache_variant_count);
 	for (int i = 0; i < cache_variant_count; i++) {
 		uint32_t cache_specialization_count = f->get_32();
 		OAHashMap<uint64_t, Version::Specialization> variant;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2863,6 +2863,7 @@ Error DisplayServerWindows::dialog_show(String p_title, String p_description, Ve
 	Char16String title = p_title.utf16();
 	Char16String message = p_description.utf16();
 	LocalVector<Char16String> buttons;
+	buttons.reserve(p_buttons.size());
 	for (String s : p_buttons) {
 		buttons.push_back(s.utf16());
 	}
@@ -6677,6 +6678,7 @@ void DisplayServerWindows::register_windows_driver() {
 
 DisplayServerWindows::~DisplayServerWindows() {
 	LocalVector<List<FileDialogData *>::Element *> to_remove;
+	to_remove.reserve(file_dialogs.size());
 	for (List<FileDialogData *>::Element *E = file_dialogs.front(); E; E = E->next()) {
 		FileDialogData *fd = E->get();
 		if (fd->listener_thread.is_started()) {

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1115,6 +1115,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 
 		LocalVector<Vector3> new_probe_positions;
 		HashMap<Vector3i, bool> positions_used;
+		new_probe_positions.reserve(8);
 		for (uint32_t i = 0; i < 8; i++) { //insert bounding endpoints
 			Vector3i pos;
 			if (i & 1) {
@@ -1346,6 +1347,8 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		LocalVector<Plane> bsp_planes;
 		LocalVector<int32_t> bsp_simplex_indices;
 		PackedInt32Array tetrahedrons;
+		bsp_simplices.reserve(solved_simplices.size());
+		bsp_simplex_indices.reserve(solved_simplices.size());
 
 		for (int i = 0; i < solved_simplices.size(); i++) {
 			//Prepare a special representation of the simplex, which uses a BSP Tree

--- a/scene/3d/retarget_modifier_3d.cpp
+++ b/scene/3d/retarget_modifier_3d.cpp
@@ -274,6 +274,7 @@ void RetargetModifier3D::_retarget_global_pose() {
 	}
 
 	LocalVector<Transform3D> source_poses;
+	source_poses.reserve(source_bone_ids.size());
 	if (influence < 1.0) {
 		for (int source_bone_id : source_bone_ids) {
 			source_poses.push_back(source_bone_id < 0 ? Transform3D() : source_skeleton->get_bone_global_rest(source_bone_id).interpolate_with(source_skeleton->get_bone_global_pose(source_bone_id), influence));
@@ -308,6 +309,7 @@ void RetargetModifier3D::_retarget_pose() {
 	}
 
 	LocalVector<Transform3D> source_poses;
+	source_poses.reserve(source_bone_ids.size());
 	if (influence < 1.0) {
 		for (int source_bone_id : source_bone_ids) {
 			source_poses.push_back(source_bone_id < 0 ? Transform3D() : source_skeleton->get_bone_rest(source_bone_id).interpolate_with(source_skeleton->get_bone_pose(source_bone_id), influence));

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -1163,11 +1163,13 @@ void Skeleton3D::_process_modifiers() {
 		real_t influence = mod->get_influence();
 		if (influence < 1.0) {
 			LocalVector<Transform3D> old_poses;
+			old_poses.reserve(get_bone_count());
 			for (int i = 0; i < get_bone_count(); i++) {
 				old_poses.push_back(get_bone_pose(i));
 			}
 			mod->process_modification();
 			LocalVector<Transform3D> new_poses;
+			new_poses.reserve(get_bone_count());
 			for (int i = 0; i < get_bone_count(); i++) {
 				new_poses.push_back(get_bone_pose(i));
 			}

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -226,6 +226,7 @@ static bool _collect_inheritance_chain(const Ref<SceneState> &p_state, const Nod
 	}
 
 	if (inheritance_states.size() > 0) {
+		r_states_stack.reserve(r_states_stack.size() + inheritance_states.size());
 		for (int i = inheritance_states.size() - 1; i >= 0; --i) {
 			r_states_stack.push_back(inheritance_states[i]);
 		}

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2173,6 +2173,7 @@ Error ArrayMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, flo
 
 	//create surfacetools for each surface..
 	LocalVector<Ref<SurfaceTool>> surfaces_tools;
+	surfaces_tools.reserve(lightmap_surfaces.size());
 
 	for (int i = 0; i < lightmap_surfaces.size(); i++) {
 		Ref<SurfaceTool> st;

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -1057,6 +1057,7 @@ void SurfaceTool::append_from(const Ref<Mesh> &p_existing, int p_surface, const 
 		vertex_array.push_back(v);
 	}
 
+	index_array.reserve(index_array.size() + nindices.size());
 	for (const int &index : nindices) {
 		int dst_index = index + vfrom;
 		index_array.push_back(dst_index);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -2372,6 +2372,7 @@ RDD::RenderPassID RenderingDevice::_render_pass_create(RenderingDeviceDriver *p_
 
 	LocalVector<RDD::Attachment> attachments;
 	LocalVector<uint32_t> attachment_remap;
+	attachment_remap.reserve(p_attachments.size());
 
 	for (int i = 0; i < p_attachments.size(); i++) {
 		if (p_attachments[i].usage_flags == AttachmentFormat::UNUSED_ATTACHMENT) {
@@ -2437,6 +2438,9 @@ RDD::RenderPassID RenderingDevice::_render_pass_create(RenderingDeviceDriver *p_
 	for (int i = 0; i < p_passes.size(); i++) {
 		const FramebufferPass *pass = &p_passes[i];
 		RDD::Subpass &subpass = subpasses[i];
+		subpass.color_references.reserve(pass->color_attachments.size());
+		subpass.input_references.reserve(pass->input_attachments.size());
+		subpass.resolve_references.reserve(pass->resolve_attachments.size());
 
 		TextureSamples texture_samples = TEXTURE_SAMPLES_1;
 		bool is_multisample_first = true;
@@ -2623,6 +2627,8 @@ RenderingDevice::FramebufferFormatID RenderingDevice::framebuffer_format_create_
 	Vector<TextureSamples> samples;
 	LocalVector<RDD::AttachmentLoadOp> load_ops;
 	LocalVector<RDD::AttachmentStoreOp> store_ops;
+	load_ops.reserve(p_attachments.size());
+	store_ops.reserve(p_attachments.size());
 	for (int64_t i = 0; i < p_attachments.size(); i++) {
 		load_ops.push_back(RDD::ATTACHMENT_LOAD_OP_CLEAR);
 		store_ops.push_back(RDD::ATTACHMENT_STORE_OP_STORE);
@@ -2762,6 +2768,7 @@ RID RenderingDevice::framebuffer_create_multipass(const Vector<RID> &p_texture_a
 	Vector<AttachmentFormat> attachments;
 	LocalVector<RDD::TextureID> textures;
 	LocalVector<RDG::ResourceTracker *> trackers;
+	trackers.reserve(p_texture_attachments.size());
 	attachments.resize(p_texture_attachments.size());
 	Size2i size;
 	bool size_set = false;
@@ -3389,6 +3396,7 @@ RID RenderingDevice::uniform_set_create(const Collection &p_uniforms, RID p_shad
 		RDD::BoundUniform &driver_uniform = driver_uniforms[i];
 		driver_uniform.type = uniform.uniform_type;
 		driver_uniform.binding = uniform.binding;
+		driver_uniform.ids.reserve(uniform.get_id_count());
 
 		// Mark immutable samplers to be skipped when creating uniform set.
 		driver_uniform.immutable_sampler = uniform.immutable_sampler;

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -368,6 +368,7 @@ String ShaderPreprocessor::vector_to_string(const LocalVector<char32_t> &p_v, in
 
 String ShaderPreprocessor::tokens_to_string(const LocalVector<Token> &p_tokens) {
 	LocalVector<char32_t> result;
+	result.reserve(p_tokens.size());
 	for (const Token &token : p_tokens) {
 		result.push_back(token.text);
 	}


### PR DESCRIPTION
Follow up #100251, covers other part of the engine.

Change in `scene/property_utils.cpp` is special, all caller passes in a newly constructed `LocalVector` so reserve helps.