### PR TITLE
Don't emit `text_changed` signal when clearing empty LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1853,8 +1853,12 @@ Array LineEdit::get_structured_text_bidi_override_options() const {
 }
 
 void LineEdit::clear() {
+	bool was_empty = text.is_empty();
 	clear_internal();
-	_text_changed();
+	_clear_redo();
+	if (!was_empty) {
+		_emit_text_change();
+	}
 
 	// This should reset virtual keyboard state if needed.
 	if (editing) {


### PR DESCRIPTION
Doing `clear()` in LineEdit was always emitting `text_changed` signal, even if the text was already empty and so didn't change.