### PR TITLE
Re-organize UI in the shader editor

### DIFF
--- a/editor/plugins/shader/shader_editor.h
+++ b/editor/plugins/shader/shader_editor.h
@@ -44,4 +44,5 @@ public:
 	virtual bool is_unsaved() const = 0;
 	virtual void save_external_data(const String &p_str = "") = 0;
 	virtual void validate_script() = 0;
+	virtual Control *get_top_bar() = 0;
 };

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -40,6 +40,7 @@ class ShaderEditor;
 class TabContainer;
 class TextShaderEditor;
 class VBoxContainer;
+class HBoxContainer;
 class VisualShaderEditor;
 class WindowWrapper;
 
@@ -74,6 +75,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 		CLOSE_OTHER_TABS,
 		SHOW_IN_FILE_SYSTEM,
 		COPY_PATH,
+		TOGGLE_SHADERS_PANEL,
 	};
 
 	enum PopupMenuType {
@@ -84,6 +86,8 @@ class ShaderEditorPlugin : public EditorPlugin {
 
 	HSplitContainer *main_split = nullptr;
 	VBoxContainer *left_panel = nullptr;
+	HBoxContainer *menu_hb = nullptr;
+
 	ItemList *shader_list = nullptr;
 	TabContainer *shader_tabs = nullptr;
 
@@ -124,6 +128,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 	void _window_changed(bool p_visible);
 
 	void _set_text_shader_zoom_factor(float p_zoom_factor);
+	void _switch_to_editor(ShaderEditor *p_editor);
 
 protected:
 	void _notification(int p_what);

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -38,6 +38,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
+#include "scene/gui/separator.h"
 #include "scene/gui/split_container.h"
 #include "servers/rendering/shader_preprocessor.h"
 #include "servers/rendering/shader_types.h"
@@ -749,8 +750,7 @@ void TextShaderEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			PopupMenu *popup = help_menu->get_popup();
-			popup->set_item_icon(popup->get_item_index(HELP_DOCS), get_editor_theme_icon(SNAME("ExternalLink")));
+			site_search->set_button_icon(get_editor_theme_icon(SNAME("ExternalLink")));
 		} break;
 
 		case NOTIFICATION_APPLICATION_FOCUS_IN: {
@@ -976,6 +976,10 @@ void TextShaderEditor::validate_script() {
 	code_editor->_validate_script();
 }
 
+Control *TextShaderEditor::get_top_bar() {
+	return hbc;
+}
+
 bool TextShaderEditor::is_unsaved() const {
 	return code_editor->get_text_editor()->get_saved_version() != code_editor->get_text_editor()->get_version();
 }
@@ -1149,7 +1153,7 @@ TextShaderEditor::TextShaderEditor() {
 
 	VBoxContainer *main_container = memnew(VBoxContainer);
 	main_container->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
-	HBoxContainer *hbc = memnew(HBoxContainer);
+	hbc = memnew(HBoxContainer);
 
 	edit_menu = memnew(MenuButton);
 	edit_menu->set_shortcut_context(this);
@@ -1205,18 +1209,21 @@ TextShaderEditor::TextShaderEditor() {
 	bookmarks_menu->connect("about_to_popup", callable_mp(this, &TextShaderEditor::_update_bookmark_list));
 	bookmarks_menu->connect("index_pressed", callable_mp(this, &TextShaderEditor::_bookmark_item_pressed));
 
-	help_menu = memnew(MenuButton);
-	help_menu->set_text(TTR("Help"));
-	help_menu->set_switch_on_hover(true);
-	help_menu->get_popup()->add_item(TTR("Online Docs"), HELP_DOCS);
-	help_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &TextShaderEditor::_menu_option));
-
 	add_child(main_container);
 	main_container->add_child(hbc);
-	hbc->add_child(search_menu);
 	hbc->add_child(edit_menu);
+	hbc->add_child(search_menu);
 	hbc->add_child(goto_menu);
-	hbc->add_child(help_menu);
+	hbc->add_spacer();
+
+	site_search = memnew(Button);
+	site_search->set_flat(true);
+	site_search->connect(SceneStringName(pressed), callable_mp(this, &TextShaderEditor::_menu_option).bind(HELP_DOCS));
+	site_search->set_text(TTR("Online Docs"));
+	site_search->set_tooltip_text(TTR("Open Godot online documentation."));
+	hbc->add_child(site_search);
+	hbc->add_child(memnew(VSeparator));
+
 	hbc->add_theme_style_override(SceneStringName(panel), EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SNAME("ScriptEditorPanel"), EditorStringName(EditorStyles)));
 
 	VSplitContainer *editor_box = memnew(VSplitContainer);

--- a/editor/plugins/text_shader_editor.h
+++ b/editor/plugins/text_shader_editor.h
@@ -136,10 +136,11 @@ class TextShaderEditor : public ShaderEditor {
 		EDIT_EMOJI_AND_SYMBOL,
 	};
 
+	HBoxContainer *hbc = nullptr;
 	MenuButton *edit_menu = nullptr;
 	MenuButton *search_menu = nullptr;
 	PopupMenu *bookmarks_menu = nullptr;
-	MenuButton *help_menu = nullptr;
+	Button *site_search = nullptr;
 	PopupMenu *context_menu = nullptr;
 	RichTextLabel *warnings_panel = nullptr;
 	uint64_t idle = 0;
@@ -195,6 +196,7 @@ public:
 	virtual bool is_unsaved() const override;
 	virtual void save_external_data(const String &p_str = "") override;
 	virtual void validate_script() override;
+	virtual Control *get_top_bar() override;
 
 	bool was_compilation_successful() const { return compilation_success; }
 	bool get_trim_trailing_whitespace_on_save() const { return trim_trailing_whitespace_on_save; }

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -211,11 +211,15 @@ class VisualShaderEditor : public ShaderEditor {
 	String param_filter_name;
 	EditorProperty *current_prop = nullptr;
 	VBoxContainer *shader_preview_vbox = nullptr;
+	Button *site_search = nullptr;
+	Button *toggle_scripts_button = nullptr;
+	Control *toggle_scripts_list = nullptr;
 	GraphEdit *graph = nullptr;
 	Button *add_node = nullptr;
 	MenuButton *varying_button = nullptr;
 	Button *code_preview_button = nullptr;
 	Button *shader_preview_button = nullptr;
+	Control *toolbar = nullptr;
 
 	int last_to_node = -1;
 	int last_to_port = -1;
@@ -446,6 +450,8 @@ class VisualShaderEditor : public ShaderEditor {
 
 	void _show_shader_preview();
 
+	void _toggle_scripts_pressed();
+
 	Vector<int> nodes_link_to_frame_buffer; // Contains the nodes that are requested to be linked to a frame. This is used to perform one Undo/Redo operation for dragging nodes.
 	int frame_node_id_to_link_to = -1;
 
@@ -633,6 +639,8 @@ class VisualShaderEditor : public ShaderEditor {
 	void _param_selected();
 	void _param_unselected();
 
+	void _help_open();
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -643,6 +651,7 @@ public:
 	virtual bool is_unsaved() const override;
 	virtual void save_external_data(const String &p_str = "") override;
 	virtual void validate_script() override;
+	virtual Control *get_top_bar() override;
 
 	void add_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
 	void remove_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
@@ -651,11 +660,13 @@ public:
 
 	void clear_custom_types();
 	void add_custom_type(const String &p_name, const String &p_type, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, bool p_highend);
+	void set_toggle_list_control(Control *p_control);
 
 	Dictionary get_custom_node_data(Ref<VisualShaderNodeCustom> &p_custom_node);
 	void update_custom_type(const Ref<Resource> &p_resource);
 
 	virtual Size2 get_minimum_size() const override;
+	void update_toggle_scripts_button();
 
 	Ref<VisualShader> get_visual_shader() const { return visual_shader; }
 


### PR DESCRIPTION
This PR updates UI for shader and visual shader editor.

Changes:

- Menu bar added to the visual shader editor
- `File` menu button will always be visible regardless of left panel visibility, as well as `Make The Shader Editor Floating` button.
- `Help` menu removed - added `Online Docs` button to the right corner of the menu bar instead (to conform with a script editor UI).
- Added `Online Docs` button to visual shader editor
- `Edit` and `Search` menu buttons swapped in the shader editor (to conform with a script editor UI).
- `Added Toggle Script Panel` button to File menu, now user may use a hotkey for the Toggle Scripts Panel (when shader editor focused).

![изображение](https://github.com/user-attachments/assets/3d1ead76-721e-4c4b-8d5f-be0835e4f844)

- Closes https://github.com/godotengine/godot-proposals/issues/11026
- Closes https://github.com/godotengine/godot-proposals/issues/11311