### PR TITLE
Fix stream sync play and seek setting wrong position on certain cases

### DIFF
--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -203,7 +203,9 @@ void AudioStreamPlaybackSynchronized::seek(double p_time) {
 }
 
 void AudioStreamPlaybackSynchronized::_seek_or_start(double p_from_pos, bool is_start) {
-	p_from_pos = CLAMP(p_from_pos, 0, stream->get_length());
+	if (p_from_pos < 0 || p_from_pos > stream->get_length()) {
+		p_from_pos = 0;
+	}
 
 	if (is_start && active) {
 		stop();

--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -203,20 +203,18 @@ void AudioStreamPlaybackSynchronized::seek(double p_time) {
 }
 
 void AudioStreamPlaybackSynchronized::_seek_or_start(double p_from_pos, bool is_start) {
-	if (p_from_pos < 0 || p_from_pos > stream->get_length()) {
-		p_from_pos = 0;
-	}
-
 	if (is_start && active) {
 		stop();
 	}
+
+	bool is_pos_within_range = p_from_pos >= 0 && p_from_pos < stream->get_length();
 
 	for (int i = 0; i < stream->stream_count; i++) {
 		if (playback[i].is_valid() && stream->audio_streams[i].is_valid()) {
 			double audio_stream_length = stream->audio_streams[i]->get_length();
 			double playback_pos = p_from_pos;
 
-			if (audio_stream_length < playback_pos) {
+			if (is_pos_within_range && audio_stream_length < playback_pos) {
 				if (!stream->audio_streams[i]->has_loop()) {
 					continue;
 				}

--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -226,8 +226,7 @@ void AudioStreamPlaybackSynchronized::_seek_or_start(double p_from_pos, bool is_
 
 			if (is_start) {
 				playback[i]->start(playback_pos);
-			}
-			else {
+			} else {
 				playback[i]->seek(playback_pos);
 			}
 

--- a/modules/interactive_music/audio_stream_synchronized.h
+++ b/modules/interactive_music/audio_stream_synchronized.h
@@ -101,6 +101,7 @@ private:
 	bool active = false;
 
 	void _update_playback_instances();
+	void _seek_or_start(double p_from_pos, bool is_start);
 
 public:
 	virtual void start(double p_from_pos = 0.0) override;


### PR DESCRIPTION
If you have multiple streams on AudioStreamSynchronized with different lengths, start and seek methods will unsync the sound when position set is higher than one of the stream's length.

Example: if AudioStreamSynchronized has two streams, one with a beat sound with a length of 16s and the other with a base sound with a length of 32s and you call audio_player.play(20) or audio_player.seek(20), the first one will start at position 0, while the other one will start at 20.

You can reproduce this issue [here](https://github.com/adriano-sudario/godot_streams_issues_mrp) with detailed informations running the scene [stream_sync_play_and_seek_not_setting_position_right_sometimes](bugs/stream_sync_play_and_seek_not_setting_position_right_sometimes.tscn)

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/100570*