### PR TITLE
Add `Span` struct (replacing `StrRange`). Spans represent read-only access to a contiguous array, resembling `std::span`.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -299,16 +299,16 @@ Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r
 	return OK;
 }
 
-void String::parse_latin1(const StrRange<char> &p_cstr) {
-	if (p_cstr.len == 0) {
+void String::parse_latin1(const Span<char> &p_cstr) {
+	if (p_cstr.size() == 0) {
 		resize(0);
 		return;
 	}
 
-	resize(p_cstr.len + 1); // include 0
+	resize(p_cstr.size() + 1); // include 0
 
-	const char *src = p_cstr.c_str;
-	const char *end = src + p_cstr.len;
+	const char *src = p_cstr.ptr();
+	const char *end = src + p_cstr.size();
 	char32_t *dst = ptrw();
 
 	for (; src < end; ++src, ++dst) {
@@ -318,13 +318,13 @@ void String::parse_latin1(const StrRange<char> &p_cstr) {
 	*dst = 0;
 }
 
-void String::parse_utf32(const StrRange<char32_t> &p_cstr) {
-	if (p_cstr.len == 0) {
+void String::parse_utf32(const Span<char32_t> &p_cstr) {
+	if (p_cstr.size() == 0) {
 		resize(0);
 		return;
 	}
 
-	copy_from_unchecked(p_cstr.c_str, p_cstr.len);
+	copy_from_unchecked(p_cstr.ptr(), p_cstr.size());
 }
 
 void String::parse_utf32(const char32_t &p_char) {
@@ -564,8 +564,8 @@ bool String::operator==(const String &p_str) const {
 	return memcmp(ptr(), p_str.ptr(), length() * sizeof(char32_t)) == 0;
 }
 
-bool String::operator==(const StrRange<char32_t> &p_str_range) const {
-	const int len = p_str_range.len;
+bool String::operator==(const Span<char32_t> &p_str_range) const {
+	const int len = p_str_range.size();
 
 	if (length() != len) {
 		return false;
@@ -574,7 +574,7 @@ bool String::operator==(const StrRange<char32_t> &p_str_range) const {
 		return true;
 	}
 
-	return memcmp(ptr(), p_str_range.c_str, len * sizeof(char32_t)) == 0;
+	return memcmp(ptr(), p_str_range.ptr(), len * sizeof(char32_t)) == 0;
 }
 
 bool operator==(const char *p_chr, const String &p_str) {
@@ -1921,16 +1921,16 @@ CharString String::ascii(bool p_allow_extended) const {
 	return cs;
 }
 
-Error String::parse_ascii(const StrRange<char> &p_range) {
-	if (p_range.len == 0) {
+Error String::parse_ascii(const Span<char> &p_range) {
+	if (p_range.size() == 0) {
 		resize(0);
 		return OK;
 	}
 
-	resize(p_range.len + 1); // Include \0
+	resize(p_range.size() + 1); // Include \0
 
-	const char *src = p_range.c_str;
-	const char *end = src + p_range.len;
+	const char *src = p_range.ptr();
+	const char *end = src + p_range.size();
 	char32_t *dst = ptrw();
 	bool decode_failed = false;
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -98,30 +98,6 @@ constexpr size_t _strlen_clipped(const char32_t *p_str, int p_clip_to_len) {
 }
 
 /*************************************************************************/
-/*  StrRange                                                             */
-/*************************************************************************/
-
-template <typename Element>
-struct StrRange {
-	const Element *c_str;
-	size_t len;
-
-	explicit StrRange(const std::nullptr_t p_cstring) :
-			c_str(nullptr), len(0) {}
-
-	explicit StrRange(const Element *p_cstring, const size_t p_len) :
-			c_str(p_cstring), len(p_len) {}
-
-	template <size_t len>
-	explicit StrRange(const Element (&p_cstring)[len]) :
-			c_str(p_cstring), len(strlen(p_cstring)) {}
-
-	static StrRange from_c_str(const Element *p_cstring) {
-		return StrRange(p_cstring, p_cstring ? strlen(p_cstring) : 0);
-	}
-};
-
-/*************************************************************************/
 /*  CharProxy                                                            */
 /*************************************************************************/
 
@@ -177,6 +153,10 @@ public:
 	_FORCE_INLINE_ char16_t *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const char16_t *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+
+	_FORCE_INLINE_ operator Span<char16_t>() const { return Span(ptr(), length()); }
+	_FORCE_INLINE_ Span<char16_t> span() const { return Span(ptr(), length()); }
+
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
 
 	_FORCE_INLINE_ char16_t get(int p_index) const { return _cowdata.get(p_index); }
@@ -203,7 +183,6 @@ public:
 	Char16String &operator+=(char16_t p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char16_t *get_data() const;
-	operator StrRange<char16_t>() const { return StrRange(get_data(), length()); }
 
 protected:
 	void copy_from(const char16_t *p_cstr);
@@ -221,6 +200,10 @@ public:
 	_FORCE_INLINE_ char *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const char *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+
+	_FORCE_INLINE_ operator Span<char>() const { return Span(ptr(), length()); }
+	_FORCE_INLINE_ Span<char> span() const { return Span(ptr(), length()); }
+
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
 
 	_FORCE_INLINE_ char get(int p_index) const { return _cowdata.get(p_index); }
@@ -248,7 +231,6 @@ public:
 	CharString &operator+=(char p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char *get_data() const;
-	operator StrRange<char>() const { return StrRange(get_data(), length()); }
 
 protected:
 	void copy_from(const char *p_cstr);
@@ -264,33 +246,33 @@ class String {
 	static const char32_t _replacement_char;
 
 	// Known-length copy.
-	void parse_latin1(const StrRange<char> &p_cstr);
-	void parse_utf32(const StrRange<char32_t> &p_cstr);
+	void parse_latin1(const Span<char> &p_cstr);
+	void parse_utf32(const Span<char32_t> &p_cstr);
 	void parse_utf32(const char32_t &p_char);
 	void copy_from_unchecked(const char32_t *p_char, int p_length);
 
 	// NULL-terminated c string copy - automatically parse the string to find the length.
 	void parse_latin1(const char *p_cstr) {
-		parse_latin1(StrRange<char>::from_c_str(p_cstr));
+		parse_latin1(Span(p_cstr, p_cstr ? strlen(p_cstr) : 0));
 	}
 	void parse_latin1(const char *p_cstr, int p_clip_to) {
-		parse_latin1(StrRange(p_cstr, p_cstr ? _strlen_clipped(p_cstr, p_clip_to) : 0));
+		parse_latin1(Span(p_cstr, p_cstr ? _strlen_clipped(p_cstr, p_clip_to) : 0));
 	}
 	void parse_utf32(const char32_t *p_cstr) {
-		parse_utf32(StrRange<char32_t>::from_c_str(p_cstr));
+		parse_utf32(Span(p_cstr, p_cstr ? strlen(p_cstr) : 0));
 	}
 	void parse_utf32(const char32_t *p_cstr, int p_clip_to) {
-		parse_utf32(StrRange(p_cstr, p_cstr ? _strlen_clipped(p_cstr, p_clip_to) : 0));
+		parse_utf32(Span(p_cstr, p_cstr ? _strlen_clipped(p_cstr, p_clip_to) : 0));
 	}
 
 	// wchar_t copy_from depends on the platform.
-	void parse_wstring(const StrRange<wchar_t> &p_cstr) {
+	void parse_wstring(const Span<wchar_t> &p_cstr) {
 #ifdef WINDOWS_ENABLED
 		// wchar_t is 16-bit, parse as UTF-16
-		parse_utf16((const char16_t *)p_cstr.c_str, p_cstr.len);
+		parse_utf16((const char16_t *)p_cstr.ptr(), p_cstr.size());
 #else
 		// wchar_t is 32-bit, copy directly
-		parse_utf32((StrRange<char32_t> &)p_cstr);
+		parse_utf32((Span<char32_t> &)p_cstr);
 #endif
 	}
 	void parse_wstring(const wchar_t *p_cstr) {
@@ -324,6 +306,10 @@ public:
 
 	_FORCE_INLINE_ char32_t *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const char32_t *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+
+	_FORCE_INLINE_ operator Span<char32_t>() const { return Span(ptr(), length()); }
+	_FORCE_INLINE_ Span<char32_t> span() const { return Span(ptr(), length()); }
 
 	void remove_at(int p_index) { _cowdata.remove_at(p_index); }
 
@@ -331,7 +317,6 @@ public:
 
 	_FORCE_INLINE_ char32_t get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const char32_t &p_elem) { _cowdata.set(p_index, p_elem); }
-	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
 
 	_FORCE_INLINE_ const char32_t &operator[](int p_index) const {
@@ -359,7 +344,7 @@ public:
 	bool operator==(const char *p_str) const;
 	bool operator==(const wchar_t *p_str) const;
 	bool operator==(const char32_t *p_str) const;
-	bool operator==(const StrRange<char32_t> &p_str_range) const;
+	bool operator==(const Span<char32_t> &p_str_range) const;
 
 	bool operator!=(const char *p_str) const;
 	bool operator!=(const wchar_t *p_str) const;
@@ -520,8 +505,8 @@ public:
 	CharString ascii(bool p_allow_extended = false) const;
 	// Parse an ascii string.
 	// If any character is > 127, an error will be logged, and 0xfffd will be inserted.
-	Error parse_ascii(const StrRange<char> &p_range);
-	static String ascii(const StrRange<char> &p_range) {
+	Error parse_ascii(const Span<char> &p_range);
+	static String ascii(const Span<char> &p_range) {
 		String s;
 		s.parse_ascii(p_range);
 		return s;
@@ -529,19 +514,19 @@ public:
 
 	CharString utf8() const;
 	Error parse_utf8(const char *p_utf8, int p_len = -1, bool p_skip_cr = false);
-	Error parse_utf8(const StrRange<char> &p_range, bool p_skip_cr = false) {
-		return parse_utf8(p_range.c_str, p_range.len, p_skip_cr);
+	Error parse_utf8(const Span<char> &p_range, bool p_skip_cr = false) {
+		return parse_utf8(p_range.ptr(), p_range.size(), p_skip_cr);
 	}
 	static String utf8(const char *p_utf8, int p_len = -1);
-	static String utf8(const StrRange<char> &p_range) { return utf8(p_range.c_str, p_range.len); }
+	static String utf8(const Span<char> &p_range) { return utf8(p_range.ptr(), p_range.size()); }
 
 	Char16String utf16() const;
 	Error parse_utf16(const char16_t *p_utf16, int p_len = -1, bool p_default_little_endian = true);
-	Error parse_utf16(const StrRange<char16_t> p_range, bool p_skip_cr = false) {
-		return parse_utf16(p_range.c_str, p_range.len, p_skip_cr);
+	Error parse_utf16(const Span<char16_t> p_range, bool p_skip_cr = false) {
+		return parse_utf16(p_range.ptr(), p_range.size(), p_skip_cr);
 	}
 	static String utf16(const char16_t *p_utf16, int p_len = -1);
-	static String utf16(const StrRange<char16_t> &p_range) { return utf16(p_range.c_str, p_range.len); }
+	static String utf16(const Span<char16_t> &p_range) { return utf16(p_range.ptr(), p_range.size()); }
 
 	static uint32_t hash(const char32_t *p_cstr, int p_len); /* hash the string */
 	static uint32_t hash(const char32_t *p_cstr); /* hash the string */
@@ -655,8 +640,6 @@ public:
 	void operator=(const char32_t *p_cstr) {
 		parse_utf32(p_cstr);
 	}
-
-	operator StrRange<char32_t>() const { return StrRange(get_data(), length()); }
 };
 
 bool operator==(const char *p_chr, const String &p_str);

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -33,6 +33,7 @@
 #include "core/error/error_macros.h"
 #include "core/os/memory.h"
 #include "core/templates/safe_refcount.h"
+#include "core/templates/span.h"
 
 #include <string.h>
 #include <initializer_list>
@@ -247,6 +248,9 @@ public:
 
 		return OK;
 	}
+
+	_FORCE_INLINE_ operator Span<T>() const { return Span<T>(ptr(), size()); }
+	_FORCE_INLINE_ Span<T> span() const { return operator Span<T>(); }
 
 	Size find(const T &p_val, Size p_from = 0) const;
 	Size rfind(const T &p_val, Size p_from = -1) const;

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -89,13 +89,17 @@ public:
 
 	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
+	_FORCE_INLINE_ Size size() const { return _cowdata.size(); }
+
+	_FORCE_INLINE_ operator Span<T>() const { return _cowdata.span(); }
+	_FORCE_INLINE_ Span<T> span() const { return _cowdata.span(); }
+
 	_FORCE_INLINE_ void clear() { resize(0); }
 	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
 
 	_FORCE_INLINE_ T get(Size p_index) { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ const T &get(Size p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(Size p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
-	_FORCE_INLINE_ Size size() const { return _cowdata.size(); }
 	Error resize(Size p_size) { return _cowdata.resize(p_size); }
 	Error resize_zeroed(Size p_size) { return _cowdata.template resize<true>(p_size); }
 	_FORCE_INLINE_ const T &operator[](Size p_index) const { return _cowdata.get(p_index); }

--- a/tests/core/templates/test_span.h
+++ b/tests/core/templates/test_span.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  sort_effects.h                                                        */
+/*  test_span.h                                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,36 +30,31 @@
 
 #pragma once
 
-#include "servers/rendering/renderer_rd/shader_rd.h"
-#include "servers/rendering/renderer_rd/shaders/effects/sort.glsl.gen.h"
+#include "core/templates/span.h"
 
-namespace RendererRD {
+#include "tests/test_macros.h"
 
-class SortEffects {
-private:
-	enum SortMode {
-		SORT_MODE_BLOCK,
-		SORT_MODE_STEP,
-		SORT_MODE_INNER,
-		SORT_MODE_MAX
-	};
+namespace TestSpan {
 
-	struct PushConstant {
-		uint32_t total_elements;
-		uint32_t pad[3];
-		int32_t job_params[4];
-	};
+TEST_CASE("[Span] Constexpr Validators") {
+	constexpr Span<uint16_t> span_empty;
+	static_assert(span_empty.ptr() == nullptr);
+	static_assert(span_empty.size() == 0);
+	static_assert(span_empty.is_empty());
 
-	SortShaderRD shader;
-	RID shader_version;
-	RID pipelines[SORT_MODE_MAX];
+	constexpr static uint16_t value = 5;
+	constexpr Span<uint16_t> span_value(&value, 1);
+	static_assert(span_value.ptr() == &value);
+	static_assert(span_value.size() == 1);
+	static_assert(!span_value.is_empty());
 
-protected:
-public:
-	SortEffects();
-	~SortEffects();
+	constexpr static char32_t array[] = U"122345";
+	constexpr Span<char32_t> span_array(array, strlen(array));
+	static_assert(span_array.ptr() == &array[0]);
+	static_assert(span_array.size() == 6);
+	static_assert(!span_array.is_empty());
+	static_assert(span_array[0] == U'1');
+	static_assert(span_array[span_array.size() - 1] == U'5');
+}
 
-	void sort_buffer(RID p_uniform_set, int p_size);
-};
-
-} // namespace RendererRD
+} // namespace TestSpan

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -102,6 +102,7 @@
 #include "tests/core/templates/test_oa_hash_map.h"
 #include "tests/core/templates/test_paged_array.h"
 #include "tests/core/templates/test_rid.h"
+#include "tests/core/templates/test_span.h"
 #include "tests/core/templates/test_vector.h"
 #include "tests/core/test_crypto.h"
 #include "tests/core/test_hashing_context.h"


### PR DESCRIPTION
It is currently difficult to run algorithms on `String`, `Vector`, `LocalVector`  data ranges or plain C arrays without copying the data first. This leads to inefficiencies.

This PR adds the `Span` class. A span represents a view into an array (it's a `pointer` and `size`). 
With `Span`, it will be easier to implement functions with more agnosticism as to the memory storage, helping to reduce unnecessary copies. Additionally, `Span` will help bridge the gap between `LocalVector` and `Vector`, helping to address https://github.com/godotengine/godot-proposals/issues/5144.

`Span` is similar to `StrView` which it replaces, but meant for more than just strings. It is furthermore similar to `VectorView` which will be replaced in a future PR.

## Example
The `String.path_to` implementation currently has the following lines of code:

https://github.com/godotengine/godot/blob/c2e4ae782a399adf42c664d3d21d8defe49ba8e5/core/string/ustring.cpp#L5108-L5109

Here, the String is first subselected through `substr`, causing a copy to be made.
Then, it is split through a `split` call, through which multiple copies of regions of the string are made.
None of the regions are modified in the process - the copies are made merely because it is not possible to avoid them.

An optimized implementation could look like this:
```c++
LocalVector<Span<char32_t>> src_dirs = spans::split(src.span().subspan(1, src.length() - 2), U'/'); 
LocalVector<Span<char32_t>> dst_dirs = spans::split(dst.span().subspan(1, dst.length() - 2), U'/'); 
```

In this implementation, no copies of the string need to be made, because all `Span`s used here are views into the original string (`spans::split` and `subspan` would need to be added as functions).

## Discussion
`Span` is named after `std::span` of C++20 [std::span](https://en.cppreference.com/w/cpp/container/span).
`Span` is const-only because a need for mutable spans is not obvious yet. It is easier to use if it is const by default. If mutable spans are needed in the future, it can be proposed then.
