### PR TITLE
Optimize `StringBuilder.as_string` by constructing the string in-place and skipping unnecessary checks.

### DIFF
--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -61,7 +61,9 @@ String StringBuilder::as_string() const {
 		return "";
 	}
 
-	char32_t *buffer = memnew_arr(char32_t, string_length);
+	String string;
+	string.resize(string_length + 1);
+	char32_t *buffer = string.ptrw();
 
 	int current_position = 0;
 
@@ -92,10 +94,7 @@ String StringBuilder::as_string() const {
 			c_string_elem++;
 		}
 	}
+	buffer[current_position] = 0;
 
-	String final_string = String(buffer, string_length);
-
-	memdelete_arr(buffer);
-
-	return final_string;
+	return string;
 }


### PR DESCRIPTION
Originally authored by @YYF233333 in #97777.

I'm extracting the `StringBuilder` part as it's semantically different from the rest of the PR.

## Benchmark
I have benchmarked the following code:
```c++
	String s1 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";

	auto t0 = std::chrono::high_resolution_clock::now();
	for (int i = 0; i < 10000; i ++) {
		StringBuilder builder;
		for (int j = 0; j < 100; j ++) {
			builder.append(s1);
		}
		String s1 = builder.as_string();
	}
	auto t1 = std::chrono::high_resolution_clock::now();
	std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
```

This yields:
- `487ms` on master (a40fc2354a1639f283c7c46ba8dc321b7ff15960)
- `68ms` on this PR (26ac632e364e504b34821674b102a0f7a21112c0)

Therefore, this PR can be expected to speed up uses of `StringBuilder` by `7x` in extreme cases.

## Discussion

The reason for this speed up can be separated as follows:
- The needed space was allocated twice.
- `StringBuilder` was calling `String(const char *ptr, int clip_to)`
    - This function calls the inefficient function `_strlen_clipped`, to find the length of the string even though it was known.
    - This function copies the string.
    - During the copy, the string checks the input for integrity, even though all inputs are known to be correct (`char *` is always a correct string, and `char32_t *` were taken from `String` where they are known to be correct). Therefore, the check can be skipped.