### PR TITLE
Add builtin icons as a fallback option and as a way to use the editor's icons

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4846,13 +4846,15 @@ Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, cons
 		if (theme->has_icon(p_class, EditorStringName(EditorIcons))) {
 			return theme->get_icon(p_class, EditorStringName(EditorIcons));
 		}
-		
+
 		// If there is a path associated with the node but there was no icon there or it was invalid.
 		// Then it takes the basename of the file and, if it's the name of an icon in the theme, it uses that instead as a fallback.
 		// This enables using "Node2D" as a valid path to get the icon without having to copy it and have it inside the project folder.
 		if (GDExtensionManager::get_singleton()->class_has_icon_path(p_class)) {
 			String icon_name = GDExtensionManager::get_singleton()
-			->class_get_icon_path(p_class).get_file().get_basename();
+									   ->class_get_icon_path(p_class)
+									   .get_file()
+									   .get_basename();
 			if (theme->has_icon(icon_path, EditorStringName(EditorIcons))) {
 				return theme->get_icon(icon_path, EditorStringName(EditorIcons));
 			}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4846,6 +4846,17 @@ Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, cons
 		if (theme->has_icon(p_class, EditorStringName(EditorIcons))) {
 			return theme->get_icon(p_class, EditorStringName(EditorIcons));
 		}
+		
+		// If there is a path associated with the node but there was no icon there or it was invalid.
+		// Then it takes the basename of the file and, if it's the name of an icon in the theme, it uses that instead as a fallback.
+		// This enables using "Node2D" as a valid path to get the icon without having to copy it and have it inside the project folder.
+		if (GDExtensionManager::get_singleton()->class_has_icon_path(p_class)) {
+			String icon_name = GDExtensionManager::get_singleton()
+			->class_get_icon_path(p_class).get_file().get_basename();
+			if (theme->has_icon(icon_path, EditorStringName(EditorIcons))) {
+				return theme->get_icon(icon_path, EditorStringName(EditorIcons));
+			}
+		}
 
 		if (!p_fallback.is_empty() && theme->has_icon(p_fallback, EditorStringName(EditorIcons))) {
 			return theme->get_icon(p_fallback, EditorStringName(EditorIcons));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4855,8 +4855,8 @@ Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, cons
 									   ->class_get_icon_path(p_class)
 									   .get_file()
 									   .get_basename();
-			if (theme->has_icon(icon_path, EditorStringName(EditorIcons))) {
-				return theme->get_icon(icon_path, EditorStringName(EditorIcons));
+			if (theme->has_icon(icon_name, EditorStringName(EditorIcons))) {
+				return theme->get_icon(icon_name, EditorStringName(EditorIcons));
 			}
 		}
 


### PR DESCRIPTION
This check makes it so, in case any custom icon finding or opening were to fail, it fallbacks on a builtin icon in the theme with the same name. This way, we can specify an icon that's already in the engine instead of having to provide it. For example, if you wanted your CustomNode icon to be that of a CharacterBody2D, you could specify it as a path with "CharacterBody2D".

This would palliate the need to automatically find the base class to use as the icon. Not only that, but it also covers more use cases. Let's say you make a node that's akin to a person, but you use Node2D as the base instead. You could specify the icon to be that of CharacterBody2D instead.

This allows users not to have to provide the icon, saving space on the computer and also stopping them from bloating the project folders.

In this implementation though, worst case scenario the GDExtension::get_singleton()->class_get_icon_path(p_class) gets called twice, but this can easily be changed if that's what's wanted here, and I can change it myself.

Original proposal: https://github.com/godotengine/godot-proposals/issues/11336

(and already ran the pre-commit run)

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/11336*