### PR TITLE
Optimize PointLight2D shadow rendering by reducing draw calls and RD state changes

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1636,7 +1636,7 @@ void RasterizerCanvasGLES3::light_set_use_shadow(RID p_rid, bool p_enable) {
 	cl->shadow.enabled = p_enable;
 }
 
-void RasterizerCanvasGLES3::light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders) {
+void RasterizerCanvasGLES3::light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders, const Rect2 &p_light_rect) {
 	GLES3::Config *config = GLES3::Config::get_singleton();
 
 	CanvasLight *cl = canvas_light_owner.get_or_null(p_rid);

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -343,7 +343,7 @@ public:
 	RID light_create() override;
 	void light_set_texture(RID p_rid, RID p_texture) override;
 	void light_set_use_shadow(RID p_rid, bool p_enable) override;
-	void light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders) override;
+	void light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders, const Rect2 &p_light_rect) override;
 	void light_update_directional_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_cull_distance, const Rect2 &p_clip_rect, LightOccluderInstance *p_occluders) override;
 
 	void render_sdf(RID p_render_target, LightOccluderInstance *p_occluders) override;

--- a/servers/rendering/dummy/rasterizer_canvas_dummy.h
+++ b/servers/rendering/dummy/rasterizer_canvas_dummy.h
@@ -43,7 +43,7 @@ public:
 	RID light_create() override { return RID(); }
 	void light_set_texture(RID p_rid, RID p_texture) override {}
 	void light_set_use_shadow(RID p_rid, bool p_enable) override {}
-	void light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders) override {}
+	void light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders, const Rect2 &p_light_rect) override {}
 	void light_update_directional_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_cull_distance, const Rect2 &p_clip_rect, LightOccluderInstance *p_occluders) override {}
 
 	void render_sdf(RID p_render_target, LightOccluderInstance *p_occluders) override {}

--- a/servers/rendering/renderer_canvas_render.h
+++ b/servers/rendering/renderer_canvas_render.h
@@ -531,7 +531,7 @@ public:
 	virtual RID light_create() = 0;
 	virtual void light_set_texture(RID p_rid, RID p_texture) = 0;
 	virtual void light_set_use_shadow(RID p_rid, bool p_enable) = 0;
-	virtual void light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders) = 0;
+	virtual void light_update_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_near, float p_far, LightOccluderInstance *p_occluders, const Rect2 &p_light_rect) = 0;
 	virtual void light_update_directional_shadow(RID p_rid, int p_shadow_index, const Transform2D &p_light_xform, int p_light_mask, float p_cull_distance, const Rect2 &p_clip_rect, LightOccluderInstance *p_occluders) = 0;
 
 	virtual void render_sdf(RID p_render_target, LightOccluderInstance *p_occluders) = 0;

--- a/servers/rendering/renderer_rd/shaders/canvas_occlusion.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_occlusion.glsl
@@ -6,26 +6,69 @@
 
 layout(location = 0) in highp vec3 vertex;
 
+#ifdef POSITIONAL_SHADOW
+layout(push_constant, std430) uniform Constants {
+	mat2x4 modelview;
+	vec4 rotation;
+	vec2 direction;
+	float z_far;
+	uint pad;
+	float z_near;
+	uint cull_mode;
+	float pad3;
+	float pad4;
+}
+constants;
+
+layout(set = 0, binding = 0, std430) restrict readonly buffer OccluderTransforms {
+	mat2x4 transforms[];
+}
+occluder_transforms;
+
+#else
+
 layout(push_constant, std430) uniform Constants {
 	mat4 projection;
 	mat2x4 modelview;
 	vec2 direction;
 	float z_far;
-	float pad;
+	uint cull_mode;
 }
 constants;
+
+#endif
 
 #ifdef MODE_SHADOW
 layout(location = 0) out highp float depth;
 #endif
 
 void main() {
-	highp vec4 vtx = vec4(vertex, 1.0) * mat4(constants.modelview[0], constants.modelview[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
+#ifdef POSITIONAL_SHADOW
+	float c = -(constants.z_far + constants.z_near) / (constants.z_far - constants.z_near);
+	float d = -2.0 * constants.z_far * constants.z_near / (constants.z_far - constants.z_near);
+
+	mat4 projection = mat4(vec4(1.0, 0.0, 0.0, 0.0),
+			vec4(0.0, 1.0, 0.0, 0.0),
+			vec4(0.0, 0.0, c, -1.0),
+			vec4(0.0, 0.0, d, 0.0));
+
+	// Precomputed:
+	// Vector3 cam_target = Basis::from_euler(Vector3(0, 0, Math_TAU * ((i + 3) / 4.0))).xform(Vector3(0, 1, 0));
+	// projection = projection * Projection(Transform3D().looking_at(cam_targets[i], Vector3(0, 0, -1)).affine_inverse());
+	projection *= mat4(vec4(constants.rotation.x, 0.0, constants.rotation.y, 0.0), vec4(constants.rotation.z, 0.0, constants.rotation.w, 0.0), vec4(0.0, -1.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
+	mat4 modelview = mat4(occluder_transforms.transforms[constants.pad]) * mat4(constants.modelview);
+#else
+	mat4 projection = constants.projection;
+	mat4 modelview = mat4(constants.modelview[0], constants.modelview[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0));
+#endif
+
+	highp vec4 vtx = vec4(vertex, 1.0) * modelview;
 
 #ifdef MODE_SHADOW
 	depth = dot(constants.direction, vtx.xy);
 #endif
-	gl_Position = constants.projection * vtx;
+
+	gl_Position = projection * vtx;
 }
 
 #[fragment]
@@ -34,14 +77,32 @@ void main() {
 
 #VERSION_DEFINES
 
+#ifdef POSITIONAL_SHADOW
+layout(push_constant, std430) uniform Constants {
+	mat2x4 modelview;
+	vec4 rotation;
+	vec2 direction;
+	float z_far;
+	uint pad;
+	float z_near;
+	uint cull_mode;
+	float pad3;
+	float pad4;
+}
+constants;
+
+#else
+
 layout(push_constant, std430) uniform Constants {
 	mat4 projection;
 	mat2x4 modelview;
 	vec2 direction;
 	float z_far;
-	float pad;
+	uint cull_mode;
 }
 constants;
+
+#endif
 
 #ifdef MODE_SHADOW
 layout(location = 0) in highp float depth;
@@ -50,8 +111,18 @@ layout(location = 0) out highp float distance_buf;
 layout(location = 0) out highp float sdf_buf;
 #endif
 
+#define POLYGON_CULL_DISABLED 0
+#define POLYGON_CULL_FRONT 1
+#define POLYGON_CULL_BACK 2
+
 void main() {
 #ifdef MODE_SHADOW
+	bool front_facing = gl_FrontFacing;
+	if (constants.cull_mode == POLYGON_CULL_BACK && !front_facing) {
+		discard;
+	} else if (constants.cull_mode == POLYGON_CULL_FRONT && front_facing) {
+		discard;
+	}
 	distance_buf = depth / constants.z_far;
 #else
 	sdf_buf = 1.0;

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -498,7 +498,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			while (light) {
 				RENDER_TIMESTAMP("Render PointLight2D Shadow");
 
-				RSG::canvas_render->light_update_shadow(light->light_internal, shadow_count++, light->xform_cache.affine_inverse(), light->item_shadow_mask, light->radius_cache / 1000.0, light->radius_cache * 1.1, occluders);
+				RSG::canvas_render->light_update_shadow(light->light_internal, shadow_count++, light->xform_cache.affine_inverse(), light->item_shadow_mask, light->radius_cache / 1000.0, light->radius_cache * 1.1, occluders, light->rect_cache);
 				light = light->shadows_next_ptr;
 			}
 


### PR DESCRIPTION
This dramatically reduces the CPU time spent on rendering shadows for PointLight2Ds

I think this fixes the remaining regression in https://github.com/godotengine/godot/issues/99420
Fixes: https://github.com/godotengine/godot/issues/73805

Basically the problem is that certain changes in 4.4 have increased the cost of:
1. Most RD API calls (this is the Thread Guard change)
2. Ending a draw list (this is the command intersection checks)

Rendering PointLight2D Shadows creates 4 draw lists per light on screen and `4 * lights_on_screen * occluders_on_screen` draw calls. And each draw call comes with 4 other API calls. 

Therefore, we are checking the thread guard `5 * 4 * lights_on_screen * occluders_on_screen` In #99420 this means we check the thread guard over 100,000 times. So, despite it being a very cheap operation, it ends up reducing performance in a measurable way. 

Eventually we will reduce the cost of Thread guards by disabling them in release builds and maybe by disabling them when RD functions are called internally. But for now, the best option is just to drastically reduce the algorithmic complexity and other costs of rendering shadows. I did that with a number of things:

1. Cull occluders against each light, so we only render occluders that matter
2. Move the projection creation to the GPU so we transfer less data (binding the push constant is one of the more expensive operations simply because of the memory copies)
3. Use viewport culling instead of creating a render pass for each direction
4. Save the occluder transforms in an SSBO and reuse for all lights so we only pay the upload cost once
5. Move culling into the fragment shader so we don't have to constantly switch pipelines

Most of these changes increase the cost on the GPU. However, this shader is still so simple that the GPU spends way more time waiting for commands than it does actually drawing things. So these changes have no measurable impact on GPU time. 

Finally, I left one optimization on the table. We can reduce the entire draw loop to 4 draw calls per light by using one giant shared vertex buffer and using vertex pulling in the shader to read the vertex positions. I didn't implement this since:
1. It would add a significant amount of complexity and make the whole process harder to understand
2. It would require a lot of bookeeping
3. It would be much riskier than the current changes

Overall, since I got the performance gain I needed and the current code is not much more complex than it was before, I decided to leave it here. 

**Performance**

In my test scene Performance goes from 330 FPS in master to 430 FPS (Windows, RX 3600, release builds)
For comparison, 4.4 dev3 was about 380 FPS. So I am confident that this already fully restores the performance from 4.3 and then some. 

On a M2 MBP it goes from 160 FPS (dev3) to 400 FPS (debug build) (which makes sense since it is a tiling architecture)

On a Pixel 4 it goes from 17 FPS to 60 FPS (vsync locked)

This test project is intended to be a worst case scenario since it has so many lights and occluders on screen at once
[light2dopt.zip](https://github.com/user-attachments/files/18117316/light2dopt.zip)
