### PR TITLE
Add area tree to bvh for fixing "inmonitorable area VS static body" detection.

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -181,6 +181,11 @@ public:
 		h.set(p_handle);
 		return item_get_tree_id(h);
 	}
+	uint32_t get_tree_collision_mask(uint32_t p_handle) const {
+		BVHHandle h;
+		h.set(p_handle);
+		return item_get_tree_collision_mask(h);
+	}
 	int get_subindex(uint32_t p_handle) const {
 		BVHHandle h;
 		h.set(p_handle);
@@ -451,6 +456,9 @@ private:
 			abb.from(expanded_aabb);
 
 			tree.item_fill_cullparams(h, params);
+			if (params.tree_collision_mask == 0) {
+				continue;
+			}
 
 			// find all the existing paired aabbs that are no longer
 			// paired, and send callbacks
@@ -491,6 +499,7 @@ public:
 private:
 	// supplemental funcs
 	uint32_t item_get_tree_id(BVHHandle p_handle) const { return _get_extra(p_handle).tree_id; }
+	uint32_t item_get_tree_collision_mask(BVHHandle p_handle) const { return _get_extra(p_handle).tree_collision_mask; }
 	T *item_get_userdata(BVHHandle p_handle) const { return _get_extra(p_handle).userdata; }
 	int item_get_subindex(BVHHandle p_handle) const { return _get_extra(p_handle).subindex; }
 

--- a/modules/godot_physics_2d/godot_area_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_2d.cpp
@@ -80,6 +80,8 @@ void GodotArea2D::set_space(GodotSpace2D *p_space) {
 void GodotArea2D::set_monitor_callback(const Callable &p_callback) {
 	_unregister_shapes();
 
+	bool prev_monitoring = is_monitoring();
+
 	monitor_callback = p_callback;
 
 	monitored_bodies.clear();
@@ -90,10 +92,17 @@ void GodotArea2D::set_monitor_callback(const Callable &p_callback) {
 	if (!moved_list.in_list() && get_space()) {
 		get_space()->area_add_to_moved_list(&moved_list);
 	}
+
+	if (prev_monitoring != is_monitoring()) {
+		_set_type(!monitorable, is_monitoring(), false);
+		_shapes_changed();
+	}
 }
 
 void GodotArea2D::set_area_monitor_callback(const Callable &p_callback) {
 	_unregister_shapes();
+
+	bool prev_monitoring = is_monitoring();
 
 	area_monitor_callback = p_callback;
 
@@ -104,6 +113,11 @@ void GodotArea2D::set_area_monitor_callback(const Callable &p_callback) {
 
 	if (!moved_list.in_list() && get_space()) {
 		get_space()->area_add_to_moved_list(&moved_list);
+	}
+
+	if (prev_monitoring != is_monitoring()) {
+		_set_type(!monitorable, is_monitoring(), false);
+		_shapes_changed();
 	}
 }
 
@@ -193,7 +207,7 @@ void GodotArea2D::set_monitorable(bool p_monitorable) {
 	}
 
 	monitorable = p_monitorable;
-	_set_static(!monitorable);
+	_set_type(!p_monitorable, is_monitoring(), false);
 	_shapes_changed();
 }
 
@@ -307,7 +321,7 @@ GodotArea2D::GodotArea2D() :
 		GodotCollisionObject2D(TYPE_AREA),
 		monitor_query_list(this),
 		moved_list(this) {
-	_set_static(true); //areas are not active by default
+	_set_type(false, false, false); //areas are not active by default
 }
 
 GodotArea2D::~GodotArea2D() {

--- a/modules/godot_physics_2d/godot_area_2d.h
+++ b/modules/godot_physics_2d/godot_area_2d.h
@@ -144,6 +144,8 @@ public:
 	void set_monitorable(bool p_monitorable);
 	_FORCE_INLINE_ bool is_monitorable() const { return monitorable; }
 
+	_FORCE_INLINE_ bool is_monitoring() const { return monitor_callback.is_valid() || area_monitor_callback.is_valid(); }
+
 	void set_transform(const Transform2D &p_transform);
 
 	void set_space(GodotSpace2D *p_space) override;

--- a/modules/godot_physics_2d/godot_broad_phase_2d.h
+++ b/modules/godot_physics_2d/godot_broad_phase_2d.h
@@ -48,13 +48,16 @@ public:
 	typedef void (*UnpairCallback)(GodotCollisionObject2D *A, int p_subindex_A, GodotCollisionObject2D *B, int p_subindex_B, void *p_data, void *p_userdata);
 
 	// 0 is an invalid ID
-	virtual ID create(GodotCollisionObject2D *p_object_, int p_subindex = 0, const Rect2 &p_aabb = Rect2(), bool p_static = false) = 0;
+	virtual ID create(GodotCollisionObject2D *p_object_, int p_subindex = 0, const Rect2 &p_aabb = Rect2(), bool p_static = false, bool p_area = false, bool p_dynamic = true) = 0;
 	virtual void move(ID p_id, const Rect2 &p_aabb) = 0;
 	virtual void set_static(ID p_id, bool p_static) = 0;
+	virtual void set_type(ID p_id, bool p_static, bool p_area, bool p_dynamic) = 0;
 	virtual void remove(ID p_id) = 0;
 
 	virtual GodotCollisionObject2D *get_object(ID p_id) const = 0;
 	virtual bool is_static(ID p_id) const = 0;
+	virtual bool is_area(ID p_id) const = 0;
+	virtual bool is_dynamic(ID p_id) const = 0;
 	virtual int get_subindex(ID p_id) const = 0;
 
 	virtual int cull_segment(const Vector2 &p_from, const Vector2 &p_to, GodotCollisionObject2D **p_results, int p_max_results, int *p_result_indices = nullptr) = 0;

--- a/modules/godot_physics_2d/godot_broad_phase_2d_bvh.h
+++ b/modules/godot_physics_2d/godot_broad_phase_2d_bvh.h
@@ -57,15 +57,20 @@ class GodotBroadPhase2DBVH : public GodotBroadPhase2D {
 
 	enum Tree {
 		TREE_STATIC = 0,
-		TREE_DYNAMIC = 1,
+		TREE_AREA = 1,
+		TREE_DYNAMIC = 2,
+		TREE_MAX = 3,
 	};
 
 	enum TreeFlag {
 		TREE_FLAG_STATIC = 1 << TREE_STATIC,
+		TREE_FLAG_AREA = 1 << TREE_AREA,
 		TREE_FLAG_DYNAMIC = 1 << TREE_DYNAMIC,
 	};
 
-	BVH_Manager<GodotCollisionObject2D, 2, true, 128, UserPairTestFunction<GodotCollisionObject2D>, UserCullTestFunction<GodotCollisionObject2D>, Rect2, Vector2> bvh;
+	BVH_Manager<GodotCollisionObject2D, TREE_MAX, true, 128, UserPairTestFunction<GodotCollisionObject2D>, UserCullTestFunction<GodotCollisionObject2D>, Rect2, Vector2> bvh;
+
+	void get_tree_and_collition_mask(bool p_static, bool p_area, bool p_dynamic, uint32_t &r_tree_id, uint32_t &p_tree_collision_mask);
 
 	static void *_pair_callback(void *, uint32_t, GodotCollisionObject2D *, int, uint32_t, GodotCollisionObject2D *, int);
 	static void _unpair_callback(void *, uint32_t, GodotCollisionObject2D *, int, uint32_t, GodotCollisionObject2D *, int, void *);
@@ -77,13 +82,16 @@ class GodotBroadPhase2DBVH : public GodotBroadPhase2D {
 
 public:
 	// 0 is an invalid ID
-	virtual ID create(GodotCollisionObject2D *p_object, int p_subindex = 0, const Rect2 &p_aabb = Rect2(), bool p_static = false) override;
+	virtual ID create(GodotCollisionObject2D *p_object, int p_subindex = 0, const Rect2 &p_aabb = Rect2(), bool p_static = false, bool p_area = false, bool p_dynamic = true) override;
 	virtual void move(ID p_id, const Rect2 &p_aabb) override;
 	virtual void set_static(ID p_id, bool p_static) override;
+	virtual void set_type(ID p_id, bool p_static, bool p_area, bool p_dynamic) override;
 	virtual void remove(ID p_id) override;
 
 	virtual GodotCollisionObject2D *get_object(ID p_id) const override;
 	virtual bool is_static(ID p_id) const override;
+	virtual bool is_area(ID p_id) const override;
+	virtual bool is_dynamic(ID p_id) const override;
 	virtual int get_subindex(ID p_id) const override;
 
 	virtual int cull_segment(const Vector2 &p_from, const Vector2 &p_to, GodotCollisionObject2D **p_results, int p_max_results, int *p_result_indices = nullptr) override;

--- a/modules/godot_physics_2d/godot_collision_object_2d.cpp
+++ b/modules/godot_physics_2d/godot_collision_object_2d.cpp
@@ -131,10 +131,12 @@ void GodotCollisionObject2D::remove_shape(int p_index) {
 }
 
 void GodotCollisionObject2D::_set_static(bool p_static) {
-	if (_static == p_static) {
+	if (_static == p_static && _area == false && _dynamic == !_static) {
 		return;
 	}
 	_static = p_static;
+	_area = false;
+	_dynamic = !_static;
 
 	if (!space) {
 		return;
@@ -142,7 +144,29 @@ void GodotCollisionObject2D::_set_static(bool p_static) {
 	for (int i = 0; i < get_shape_count(); i++) {
 		const Shape &s = shapes[i];
 		if (s.bpid > 0) {
-			space->get_broadphase()->set_static(s.bpid, _static);
+			space->get_broadphase()->set_type(s.bpid, _static, _area, _dynamic);
+		}
+	}
+}
+
+void GodotCollisionObject2D::_set_type(bool p_static, bool p_area, bool p_dynamic) {
+	if (_static == p_static && _area == p_area && _dynamic == p_dynamic) {
+		return;
+	}
+#ifdef DEV_ENABLED
+	ERR_FAIL_COND(p_static && p_dynamic);
+#endif // DEV_ENABLED
+	_static = p_static;
+	_area = p_area;
+	_dynamic = p_dynamic;
+
+	if (!space) {
+		return;
+	}
+	for (int i = 0; i < get_shape_count(); i++) {
+		const Shape &s = shapes[i];
+		if (s.bpid > 0) {
+			space->get_broadphase()->set_type(s.bpid, _static, _area, _dynamic);
 		}
 	}
 }
@@ -176,8 +200,8 @@ void GodotCollisionObject2D::_update_shapes() {
 		s.aabb_cache = shape_aabb;
 
 		if (s.bpid == 0) {
-			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static);
-			space->get_broadphase()->set_static(s.bpid, _static);
+			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static, _dynamic);
+			space->get_broadphase()->set_type(s.bpid, _static, _area, _dynamic);
 		}
 
 		space->get_broadphase()->move(s.bpid, shape_aabb);
@@ -203,8 +227,8 @@ void GodotCollisionObject2D::_update_shapes_with_motion(const Vector2 &p_motion)
 		s.aabb_cache = shape_aabb;
 
 		if (s.bpid == 0) {
-			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static);
-			space->get_broadphase()->set_static(s.bpid, _static);
+			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static, _dynamic);
+			space->get_broadphase()->set_type(s.bpid, _static, _area, _dynamic);
 		}
 
 		space->get_broadphase()->move(s.bpid, shape_aabb);

--- a/modules/godot_physics_2d/godot_collision_object_2d.h
+++ b/modules/godot_physics_2d/godot_collision_object_2d.h
@@ -72,6 +72,8 @@ private:
 	uint32_t collision_layer = 1;
 	real_t collision_priority = 1.0;
 	bool _static = true;
+	bool _area = false;
+	bool _dynamic = false;
 
 	SelfList<GodotCollisionObject2D> pending_shape_update_list;
 
@@ -89,6 +91,7 @@ protected:
 	}
 	_FORCE_INLINE_ void _set_inv_transform(const Transform2D &p_transform) { inv_transform = p_transform; }
 	void _set_static(bool p_static);
+	void _set_type(bool p_static, bool p_area, bool p_dynamic);
 
 	virtual void _shapes_changed() = 0;
 	void _set_space(GodotSpace2D *p_space);

--- a/modules/godot_physics_3d/godot_area_3d.cpp
+++ b/modules/godot_physics_3d/godot_area_3d.cpp
@@ -89,6 +89,8 @@ void GodotArea3D::set_space(GodotSpace3D *p_space) {
 void GodotArea3D::set_monitor_callback(const Callable &p_callback) {
 	_unregister_shapes();
 
+	bool prev_monitoring = is_monitoring();
+
 	monitor_callback = p_callback;
 
 	monitored_bodies.clear();
@@ -99,10 +101,17 @@ void GodotArea3D::set_monitor_callback(const Callable &p_callback) {
 	if (!moved_list.in_list() && get_space()) {
 		get_space()->area_add_to_moved_list(&moved_list);
 	}
+
+	if (prev_monitoring != is_monitoring()) {
+		_set_type(!monitorable, is_monitoring(), false);
+		_shapes_changed();
+	}
 }
 
 void GodotArea3D::set_area_monitor_callback(const Callable &p_callback) {
 	_unregister_shapes();
+
+	bool prev_monitoring = is_monitoring();
 
 	area_monitor_callback = p_callback;
 
@@ -113,6 +122,11 @@ void GodotArea3D::set_area_monitor_callback(const Callable &p_callback) {
 
 	if (!moved_list.in_list() && get_space()) {
 		get_space()->area_add_to_moved_list(&moved_list);
+	}
+
+	if (prev_monitoring != is_monitoring()) {
+		_set_type(!monitorable, is_monitoring(), false);
+		_shapes_changed();
 	}
 }
 
@@ -224,7 +238,7 @@ void GodotArea3D::set_monitorable(bool p_monitorable) {
 	}
 
 	monitorable = p_monitorable;
-	_set_static(!monitorable);
+	_set_type(!p_monitorable, is_monitoring(), false);
 	_shapes_changed();
 }
 
@@ -338,7 +352,7 @@ GodotArea3D::GodotArea3D() :
 		GodotCollisionObject3D(TYPE_AREA),
 		monitor_query_list(this),
 		moved_list(this) {
-	_set_static(true); //areas are never active
+	_set_type(false, false, false); //areas are never active
 	set_ray_pickable(false);
 }
 

--- a/modules/godot_physics_3d/godot_area_3d.h
+++ b/modules/godot_physics_3d/godot_area_3d.h
@@ -165,6 +165,8 @@ public:
 	void set_monitorable(bool p_monitorable);
 	_FORCE_INLINE_ bool is_monitorable() const { return monitorable; }
 
+	_FORCE_INLINE_ bool is_monitoring() const { return monitor_callback.is_valid() || area_monitor_callback.is_valid(); }
+
 	void set_transform(const Transform3D &p_transform);
 
 	void set_space(GodotSpace3D *p_space) override;

--- a/modules/godot_physics_3d/godot_broad_phase_3d.h
+++ b/modules/godot_physics_3d/godot_broad_phase_3d.h
@@ -48,13 +48,16 @@ public:
 	typedef void (*UnpairCallback)(GodotCollisionObject3D *A, int p_subindex_A, GodotCollisionObject3D *B, int p_subindex_B, void *p_data, void *p_userdata);
 
 	// 0 is an invalid ID
-	virtual ID create(GodotCollisionObject3D *p_object_, int p_subindex = 0, const AABB &p_aabb = AABB(), bool p_static = false) = 0;
+	virtual ID create(GodotCollisionObject3D *p_object_, int p_subindex = 0, const AABB &p_aabb = AABB(), bool p_static = false, bool p_area = false, bool p_dynamic = true) = 0;
 	virtual void move(ID p_id, const AABB &p_aabb) = 0;
 	virtual void set_static(ID p_id, bool p_static) = 0;
+	virtual void set_type(ID p_id, bool p_static, bool p_area, bool p_dynamic) = 0;
 	virtual void remove(ID p_id) = 0;
 
 	virtual GodotCollisionObject3D *get_object(ID p_id) const = 0;
 	virtual bool is_static(ID p_id) const = 0;
+	virtual bool is_area(ID p_id) const = 0;
+	virtual bool is_dynamic(ID p_id) const = 0;
 	virtual int get_subindex(ID p_id) const = 0;
 
 	virtual int cull_point(const Vector3 &p_point, GodotCollisionObject3D **p_results, int p_max_results, int *p_result_indices = nullptr) = 0;

--- a/modules/godot_physics_3d/godot_broad_phase_3d_bvh.h
+++ b/modules/godot_physics_3d/godot_broad_phase_3d_bvh.h
@@ -55,15 +55,20 @@ class GodotBroadPhase3DBVH : public GodotBroadPhase3D {
 
 	enum Tree {
 		TREE_STATIC = 0,
-		TREE_DYNAMIC = 1,
+		TREE_AREA = 1,
+		TREE_DYNAMIC = 2,
+		TREE_MAX = 3,
 	};
 
 	enum TreeFlag {
 		TREE_FLAG_STATIC = 1 << TREE_STATIC,
+		TREE_FLAG_AREA = 1 << TREE_AREA,
 		TREE_FLAG_DYNAMIC = 1 << TREE_DYNAMIC,
 	};
 
-	BVH_Manager<GodotCollisionObject3D, 2, true, 128, UserPairTestFunction<GodotCollisionObject3D>, UserCullTestFunction<GodotCollisionObject3D>> bvh;
+	BVH_Manager<GodotCollisionObject3D, TREE_MAX, true, 128, UserPairTestFunction<GodotCollisionObject3D>, UserCullTestFunction<GodotCollisionObject3D>> bvh;
+
+	void get_tree_and_collition_mask(bool p_static, bool p_area, bool p_dynamic, uint32_t &r_tree_id, uint32_t &p_tree_collision_mask);
 
 	static void *_pair_callback(void *, uint32_t, GodotCollisionObject3D *, int, uint32_t, GodotCollisionObject3D *, int);
 	static void _unpair_callback(void *, uint32_t, GodotCollisionObject3D *, int, uint32_t, GodotCollisionObject3D *, int, void *);
@@ -75,13 +80,16 @@ class GodotBroadPhase3DBVH : public GodotBroadPhase3D {
 
 public:
 	// 0 is an invalid ID
-	virtual ID create(GodotCollisionObject3D *p_object, int p_subindex = 0, const AABB &p_aabb = AABB(), bool p_static = false) override;
+	virtual ID create(GodotCollisionObject3D *p_object, int p_subindex = 0, const AABB &p_aabb = AABB(), bool p_static = false, bool p_area = false, bool p_dynamic = true) override;
 	virtual void move(ID p_id, const AABB &p_aabb) override;
 	virtual void set_static(ID p_id, bool p_static) override;
+	virtual void set_type(ID p_id, bool p_static, bool p_area, bool p_dynamic) override;
 	virtual void remove(ID p_id) override;
 
 	virtual GodotCollisionObject3D *get_object(ID p_id) const override;
 	virtual bool is_static(ID p_id) const override;
+	virtual bool is_area(ID p_id) const override;
+	virtual bool is_dynamic(ID p_id) const override;
 	virtual int get_subindex(ID p_id) const override;
 
 	virtual int cull_point(const Vector3 &p_point, GodotCollisionObject3D **p_results, int p_max_results, int *p_result_indices = nullptr) override;

--- a/modules/godot_physics_3d/godot_collision_object_3d.h
+++ b/modules/godot_physics_3d/godot_collision_object_3d.h
@@ -76,6 +76,8 @@ private:
 	Transform3D transform;
 	Transform3D inv_transform;
 	bool _static = true;
+	bool _area = false;
+	bool _dynamic = false;
 
 	SelfList<GodotCollisionObject3D> pending_shape_update_list;
 
@@ -98,6 +100,7 @@ protected:
 	}
 	_FORCE_INLINE_ void _set_inv_transform(const Transform3D &p_transform) { inv_transform = p_transform; }
 	void _set_static(bool p_static);
+	void _set_type(bool p_static, bool p_area, bool p_dynamic);
 
 	virtual void _shapes_changed() = 0;
 	void _set_space(GodotSpace3D *p_space);


### PR DESCRIPTION
Fix [#17238](https://github.com/godotengine/godot/issues/17238).

The implementation similar to [#58505](https://github.com/godotengine/godot/pull/58505), but have some difference, and for 4.x.

-------------------------

https://github.com/user-attachments/assets/bd6598c6-2701-4556-abc7-5830de7c4aed


https://github.com/user-attachments/assets/178e3f2f-f99a-4bf1-8ef1-8ed10ef5e5e7

------------------------
Test project here:
[Test.zip](https://github.com/user-attachments/files/18107920/Test.zip)
