### PR TITLE
Fix 3D ruler theme overrides

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3254,6 +3254,12 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 			cinema_label->add_theme_style_override(CoreStringName(normal), information_3d_stylebox);
 			locked_label->add_theme_style_override(CoreStringName(normal), information_3d_stylebox);
+
+			ruler_label->add_theme_color_override(SceneStringName(font_color), Color(1.0, 0.9, 0.0, 1.0));
+			ruler_label->add_theme_color_override("font_outline_color", Color(0.0, 0.0, 0.0, 1.0));
+			ruler_label->add_theme_constant_override("outline_size", 4 * EDSCALE);
+			ruler_label->add_theme_font_size_override(SceneStringName(font_size), 15 * EDSCALE);
+			ruler_label->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
 		} break;
 
 		case NOTIFICATION_DRAG_END: {
@@ -5827,11 +5833,6 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	ruler_line_xray->set_material_override(ruler_material_xray);
 
 	ruler_label = memnew(Label);
-	ruler_label->add_theme_color_override(SceneStringName(font_color), Color(1.0, 0.9, 0.0, 1.0));
-	ruler_label->add_theme_color_override("font_outline_color", Color(0.0, 0.0, 0.0, 1.0));
-	ruler_label->add_theme_constant_override("outline_size", 4 * EDSCALE);
-	ruler_label->add_theme_font_size_override(SceneStringName(font_size), 15 * EDSCALE);
-	ruler_label->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
 	ruler_label->set_visible(false);
 
 	ruler->add_child(ruler_start_point);


### PR DESCRIPTION
Fixes warning introduced in #100162
```
WARNING: Attempting to access theme items too early in Node3DEditorViewport; prefer NOTIFICATION_POSTINITIALIZE and NOTIFICATION_THEME_CHANGED
     at: get_theme_font (./scene/gui/control.cpp:2632)
```