### PR TITLE
Optimize `String::chr` to avoid calling `strlen`. Use `String::chr` instead of `String(&chr, 1)` where appropriate.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1626,11 +1626,6 @@ String String::to_lower() const {
 	return lower;
 }
 
-String String::chr(char32_t p_char) {
-	char32_t c[2] = { p_char, 0 };
-	return String(c);
-}
-
 String String::num(double p_num, int p_decimals) {
 	if (Math::is_nan(p_num)) {
 		return "nan";

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -452,7 +452,11 @@ public:
 	static String num_real(float p_num, bool p_trailing = true);
 	static String num_int64(int64_t p_num, int base = 10, bool capitalize_hex = false);
 	static String num_uint64(uint64_t p_num, int base = 10, bool capitalize_hex = false);
-	static String chr(char32_t p_char);
+	static String chr(char32_t p_char) {
+		String string;
+		string.parse_utf32(p_char);
+		return string;
+	}
 	static String md5(const uint8_t *p_md5);
 	static String hex_encode_buffer(const uint8_t *p_buffer, int p_len);
 	Vector<uint8_t> hex_decode() const;

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -768,8 +768,7 @@ struct VariantIndexedSetGet_String {
 			*oob = true;
 			return;
 		}
-		char32_t result = (*VariantGetInternalPtr<String>::get_ptr(base))[index];
-		*value = String(&result, 1);
+		*value = String::chr((*VariantGetInternalPtr<String>::get_ptr(base))[index]);
 		*oob = false;
 	}
 	static void ptr_get(const void *base, int64_t index, void *member) {
@@ -779,8 +778,7 @@ struct VariantIndexedSetGet_String {
 			index += v.length();
 		}
 		OOB_TEST(index, v.length());
-		char32_t c = v[index];
-		PtrToArg<String>::encode(String(&c, 1), member);
+		PtrToArg<String>::encode(String::chr(v[index]), member);
 	}
 	static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {
 		if (value->get_type() != Variant::STRING) {

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -1337,7 +1337,7 @@ void GDScriptTokenizerText::check_indent() {
 }
 
 String GDScriptTokenizerText::_get_indent_char_name(char32_t ch) {
-	ERR_FAIL_COND_V(ch != ' ' && ch != '\t', String(&ch, 1).c_escape());
+	ERR_FAIL_COND_V(ch != ' ' && ch != '\t', String::chr(ch).c_escape());
 
 	return ch == ' ' ? "space" : "tab";
 }


### PR DESCRIPTION
This is a small refactor to get rid of 3 uses of `String(ptr, len)` (which I'm planning to delete entirely, because it's inefficient). I also make `String::chr` inlineable because the function is trivial, and having it in the `cpp` file is unnecessary.

It's technically a tiny improvement too since the resulting code is faster and can be better optimized by the compiler. But it should be considered a refactor.