### PR TITLE
Fix collision shape debug color breaking GDExtension

### DIFF
--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -227,8 +227,6 @@ real_t CollisionShape2D::get_one_way_collision_margin() const {
 	return one_way_collision_margin;
 }
 
-#ifdef DEBUG_ENABLED
-
 Color CollisionShape2D::_get_default_debug_color() const {
 	const SceneTree *st = SceneTree::get_singleton();
 	return st ? st->get_debug_collisions_color() : Color(0.0, 0.0, 0.0, 0.0);
@@ -246,6 +244,8 @@ void CollisionShape2D::set_debug_color(const Color &p_color) {
 Color CollisionShape2D::get_debug_color() const {
 	return debug_color;
 }
+
+#ifdef DEBUG_ENABLED
 
 bool CollisionShape2D::_property_can_revert(const StringName &p_name) const {
 	if (p_name == "debug_color") {
@@ -289,20 +289,16 @@ void CollisionShape2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_way_collision"), "set_one_way_collision", "is_one_way_collision_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "one_way_collision_margin", PROPERTY_HINT_RANGE, "0,128,0.1,suffix:px"), "set_one_way_collision_margin", "get_one_way_collision_margin");
 
-#ifdef DEBUG_ENABLED
 	ClassDB::bind_method(D_METHOD("set_debug_color", "color"), &CollisionShape2D::set_debug_color);
 	ClassDB::bind_method(D_METHOD("get_debug_color"), &CollisionShape2D::get_debug_color);
 
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_color"), "set_debug_color", "get_debug_color");
 	// Default value depends on a project setting, override for doc generation purposes.
 	ADD_PROPERTY_DEFAULT("debug_color", Color(0.0, 0.0, 0.0, 0.0));
-#endif // DEBUG_ENABLED
 }
 
 CollisionShape2D::CollisionShape2D() {
 	set_notify_local_transform(true);
 	set_hide_clip_children(true);
-#ifdef DEBUG_ENABLED
 	debug_color = _get_default_debug_color();
-#endif // DEBUG_ENABLED
 }

--- a/scene/2d/physics/collision_shape_2d.h
+++ b/scene/2d/physics/collision_shape_2d.h
@@ -52,9 +52,7 @@ class CollisionShape2D : public Node2D {
 	// Not wrapped in `#ifdef DEBUG_ENABLED` as it is used for rendering.
 	Color debug_color = Color(0.0, 0.0, 0.0, 0.0);
 
-#ifdef DEBUG_ENABLED
 	Color _get_default_debug_color() const;
-#endif // DEBUG_ENABLED
 
 protected:
 	void _notification(int p_what);
@@ -86,10 +84,8 @@ public:
 	void set_one_way_collision_margin(real_t p_margin);
 	real_t get_one_way_collision_margin() const;
 
-#ifdef DEBUG_ENABLED
 	void set_debug_color(const Color &p_color);
 	Color get_debug_color() const;
-#endif // DEBUG_ENABLED
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/scene/3d/physics/collision_shape_3d.cpp
+++ b/scene/3d/physics/collision_shape_3d.cpp
@@ -174,7 +174,6 @@ void CollisionShape3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape3D"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
 
-#ifdef DEBUG_ENABLED
 	ClassDB::bind_method(D_METHOD("set_debug_color", "color"), &CollisionShape3D::set_debug_color);
 	ClassDB::bind_method(D_METHOD("get_debug_color"), &CollisionShape3D::get_debug_color);
 
@@ -186,7 +185,6 @@ void CollisionShape3D::_bind_methods() {
 	ADD_PROPERTY_DEFAULT("debug_color", Color(0.0, 0.0, 0.0, 0.0));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_fill"), "set_enable_debug_fill", "get_enable_debug_fill");
-#endif // DEBUG_ENABLED
 }
 
 void CollisionShape3D::set_shape(const Ref<Shape3D> &p_shape) {
@@ -247,8 +245,6 @@ bool CollisionShape3D::is_disabled() const {
 	return disabled;
 }
 
-#ifdef DEBUG_ENABLED
-
 Color CollisionShape3D::_get_default_debug_color() const {
 	const SceneTree *st = SceneTree::get_singleton();
 	return st ? st->get_debug_collisions_color() : Color(0.0, 0.0, 0.0, 0.0);
@@ -285,6 +281,8 @@ void CollisionShape3D::set_debug_fill_enabled(bool p_enable) {
 bool CollisionShape3D::get_debug_fill_enabled() const {
 	return debug_fill;
 }
+
+#ifdef DEBUG_ENABLED
 
 bool CollisionShape3D::_property_can_revert(const StringName &p_name) const {
 	if (p_name == "debug_color") {
@@ -325,9 +323,7 @@ void CollisionShape3D::_shape_changed() {
 CollisionShape3D::CollisionShape3D() {
 	//indicator = RenderingServer::get_singleton()->mesh_create();
 	set_notify_local_transform(true);
-#ifdef DEBUG_ENABLED
 	debug_color = _get_default_debug_color();
-#endif // DEBUG_ENABLED
 }
 
 CollisionShape3D::~CollisionShape3D() {

--- a/scene/3d/physics/collision_shape_3d.h
+++ b/scene/3d/physics/collision_shape_3d.h
@@ -43,11 +43,12 @@ class CollisionShape3D : public Node3D {
 	uint32_t owner_id = 0;
 	CollisionObject3D *collision_object = nullptr;
 
-#ifdef DEBUG_ENABLED
 	Color debug_color;
 	bool debug_fill = true;
 
 	Color _get_default_debug_color() const;
+
+#ifdef DEBUG_ENABLED
 	void _shape_changed();
 #endif // DEBUG_ENABLED
 
@@ -78,13 +79,11 @@ public:
 	void set_disabled(bool p_disabled);
 	bool is_disabled() const;
 
-#ifdef DEBUG_ENABLED
 	void set_debug_color(const Color &p_color);
 	Color get_debug_color() const;
 
 	void set_debug_fill_enabled(bool p_enable);
 	bool get_debug_fill_enabled() const;
-#endif // DEBUG_ENABLED
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -66,15 +66,15 @@ void Shape3D::set_margin(real_t p_margin) {
 	PhysicsServer3D::get_singleton()->shape_set_margin(shape, margin);
 }
 
-#ifdef DEBUG_ENABLED
-
 void Shape3D::set_debug_color(const Color &p_color) {
 	if (p_color == debug_color) {
 		return;
 	}
 
 	debug_color = p_color;
+#ifdef DEBUG_ENABLED
 	debug_properties_edited = true;
+#endif // DEBUG_ENABLED
 	_update_shape();
 }
 
@@ -88,15 +88,15 @@ void Shape3D::set_debug_fill(bool p_fill) {
 	}
 
 	debug_fill = p_fill;
+#ifdef DEBUG_ENABLED
 	debug_properties_edited = true;
+#endif // DEBUG_ENABLED
 	_update_shape();
 }
 
 bool Shape3D::get_debug_fill() const {
 	return debug_fill;
 }
-
-#endif // DEBUG_ENABLED
 
 Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 	if (debug_mesh_cache.is_valid()) {

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -81,13 +81,13 @@ public:
 	real_t get_margin() const;
 	void set_margin(real_t p_margin);
 
-#ifdef DEBUG_ENABLED
 	void set_debug_color(const Color &p_color);
 	Color get_debug_color() const;
 
 	void set_debug_fill(bool p_fill);
 	bool get_debug_fill() const;
 
+#ifdef DEBUG_ENABLED
 	_FORCE_INLINE_ bool are_debug_properties_edited() const { return debug_properties_edited; }
 #endif // DEBUG_ENABLED
 


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/100313.

Issue description copied in below:

### Tested versions

- Introduced in this commit: https://github.com/godotengine/godot/commit/0fc082e1ee3af5bb6a4b52f85756d24dc02b230f#diff-0e07df9f216af3d10743ca02b77e1da07d78cbfd736da3d75aaf90bfefa76bee

### System information

N/A

### Issue description

Discovered when using Rust gdext here: https://github.com/godot-rust/gdext

```
ERROR: [panic]
  Failed to load class method CollisionShape3D::set_debug_color (hash 2920490490).
  Make sure gdext and Godot are compatible: https://godot-rust.github.io/book/gdext/advanced/compatibility.html
```

I've found exactly what is causing the issue.  Its because Godot only binds these methods in debug and editor builds:

https://github.com/godotengine/godot/blob/38775731e8494a28deddc3febda895679f49fd6e/scene/3d/physics/collision_shape_3d.cpp#L183C1-L195C24

```cpp
#ifdef DEBUG_ENABLED
	ClassDB::bind_method(D_METHOD("set_debug_color", "color"), &CollisionShape3D::set_debug_color);
	ClassDB::bind_method(D_METHOD("get_debug_color"), &CollisionShape3D::get_debug_color);

	ClassDB::bind_method(D_METHOD("set_enable_debug_fill", "enable"), &CollisionShape3D::set_debug_fill_enabled);
	ClassDB::bind_method(D_METHOD("get_enable_debug_fill"), &CollisionShape3D::get_debug_fill_enabled);

	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_color"), "set_debug_color", "get_debug_color");
	// Default value depends on a project setting, override for doc generation purposes.
	ADD_PROPERTY_DEFAULT("debug_color", get_placeholder_default_color());

	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_fill"), "set_enable_debug_fill", "get_enable_debug_fill");
#endif // DEBUG_ENABLED
```

And don't let the ``DEBUG_ENABLED`` fool you like it did me.  That is not only indicating a debug build.  That is indicating it is an **editor or debug** build as can be seen in the ``SConstruct`` here: https://github.com/godotengine/godot/blob/38775731e8494a28deddc3febda895679f49fd6e/SConstruct#L475.  So even release editor builds have this.

```py
env.debug_features = env["target"] in ["editor", "template_debug"]
```

I'm thinking the proper solution is to support these debug colors even in release builds.  Especially since we do for collision_shape_2d: https://github.com/godotengine/godot/blob/38775731e8494a28deddc3febda895679f49fd6e/scene/2d/physics/collision_shape_2d.cpp#L269C1-L288C2

```cpp
void CollisionShape2D::_bind_methods() {
	ClassDB::bind_method(D_METHOD("set_shape", "shape"), &CollisionShape2D::set_shape);
	ClassDB::bind_method(D_METHOD("get_shape"), &CollisionShape2D::get_shape);
	ClassDB::bind_method(D_METHOD("set_disabled", "disabled"), &CollisionShape2D::set_disabled);
	ClassDB::bind_method(D_METHOD("is_disabled"), &CollisionShape2D::is_disabled);
	ClassDB::bind_method(D_METHOD("set_one_way_collision", "enabled"), &CollisionShape2D::set_one_way_collision);
	ClassDB::bind_method(D_METHOD("is_one_way_collision_enabled"), &CollisionShape2D::is_one_way_collision_enabled);
	ClassDB::bind_method(D_METHOD("set_one_way_collision_margin", "margin"), &CollisionShape2D::set_one_way_collision_margin);
	ClassDB::bind_method(D_METHOD("get_one_way_collision_margin"), &CollisionShape2D::get_one_way_collision_margin);
	ClassDB::bind_method(D_METHOD("set_debug_color", "color"), &CollisionShape2D::set_debug_color);
	ClassDB::bind_method(D_METHOD("get_debug_color"), &CollisionShape2D::get_debug_color);


	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");
	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_way_collision"), "set_one_way_collision", "is_one_way_collision_enabled");
	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "one_way_collision_margin", PROPERTY_HINT_RANGE, "0,128,0.1,suffix:px"), "set_one_way_collision_margin", "get_one_way_collision_margin");
	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "debug_color"), "set_debug_color", "get_debug_color");
	// Default value depends on a project setting, override for doc generation purposes.
	ADD_PROPERTY_DEFAULT("debug_color", Color());
}
```

### Steps to reproduce

Invoke the godot editor with the ``--dump-extension-api`` arg.  Then inspect the ``extension_api.json`` and see that ``set_debug_color``, ``get_debug_color``, and other related methods that are only available in debug and editor builds are dumped for CollisionShape3D.

# Proposed Solution:

Allow these methods in all builds the same way we do for ColisionShape2D.

### Minimal reproduction project (MRP)

N/A