### PR TITLE
Expose a way to set the color of Shape3D debug mesh

### DIFF
--- a/doc/classes/Shape3D.xml
+++ b/doc/classes/Shape3D.xml
@@ -11,10 +11,36 @@
 		<link title="Physics introduction">$DOCS_URL/tutorials/physics/physics_introduction.html</link>
 	</tutorials>
 	<methods>
+		<method name="get_debug_color" qualifiers="const">
+			<return type="Color" />
+			<description>
+				Gets the color that will be used in the mesh returned by [method get_debug_mesh].
+			</description>
+		</method>
+		<method name="get_debug_fill" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Gets whether the mesh returned by [method get_debug_mesh] will have filled faces.
+			</description>
+		</method>
 		<method name="get_debug_mesh">
 			<return type="ArrayMesh" />
 			<description>
 				Returns the [ArrayMesh] used to draw the debug collision for this [Shape3D].
+			</description>
+		</method>
+		<method name="set_debug_color">
+			<return type="void" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Sets the color that will be used in the mesh returned by [method get_debug_mesh].
+			</description>
+		</method>
+		<method name="set_debug_fill">
+			<return type="void" />
+			<param index="0" name="fill" type="bool" />
+			<description>
+				Sets whether the mesh returned by [method get_debug_mesh] will have filled faces.
 			</description>
 		</method>
 	</methods>

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -30,6 +30,7 @@
 
 #include "collision_shape_2d.h"
 
+#include "core/config/project_settings.h"
 #include "scene/2d/physics/area_2d.h"
 #include "scene/2d/physics/collision_object_2d.h"
 #include "scene/resources/2d/concave_polygon_shape_2d.h"
@@ -229,7 +230,7 @@ real_t CollisionShape2D::get_one_way_collision_margin() const {
 
 Color CollisionShape2D::_get_default_debug_color() const {
 	const SceneTree *st = SceneTree::get_singleton();
-	return st ? st->get_debug_collisions_color() : Color(0.0, 0.0, 0.0, 0.0);
+	return st ? st->get_debug_collisions_color() : Color(GLOBAL_GET("debug/shapes/collision/shape_color"));
 }
 
 void CollisionShape2D::set_debug_color(const Color &p_color) {

--- a/scene/3d/physics/collision_shape_3d.cpp
+++ b/scene/3d/physics/collision_shape_3d.cpp
@@ -30,6 +30,7 @@
 
 #include "collision_shape_3d.h"
 
+#include "core/config/project_settings.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/physics/character_body_3d.h"
 #include "scene/3d/physics/vehicle_body_3d.h"
@@ -246,7 +247,7 @@ bool CollisionShape3D::is_disabled() const {
 
 Color CollisionShape3D::_get_default_debug_color() const {
 	const SceneTree *st = SceneTree::get_singleton();
-	return st ? st->get_debug_collisions_color() : Color(0.0, 0.0, 0.0, 0.0);
+	return st ? st->get_debug_collisions_color() : Color(GLOBAL_GET("debug/shapes/collision/shape_color"));
 }
 
 void CollisionShape3D::set_debug_color(const Color &p_color) {

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -173,6 +173,12 @@ void Shape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_margin", "margin"), &Shape3D::set_margin);
 	ClassDB::bind_method(D_METHOD("get_margin"), &Shape3D::get_margin);
 
+	ClassDB::bind_method(D_METHOD("set_debug_color", "color"), &Shape3D::set_debug_color);
+	ClassDB::bind_method(D_METHOD("get_debug_color"), &Shape3D::get_debug_color);
+
+	ClassDB::bind_method(D_METHOD("set_debug_fill", "fill"), &Shape3D::set_debug_fill);
+	ClassDB::bind_method(D_METHOD("get_debug_fill"), &Shape3D::get_debug_fill);
+
 	ClassDB::bind_method(D_METHOD("get_debug_mesh"), &Shape3D::get_debug_mesh);
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_solver_bias", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_custom_solver_bias", "get_custom_solver_bias");


### PR DESCRIPTION
This allows scripts and extensions that don't use nodes to still obtain a colored mesh using [get_debug_mesh](https://docs.godotengine.org/en/stable/classes/class_shape3d.html#class-shape3d-method-get-debug-mesh), so they can keep drawing them when the debug option is enabled.

Since #90644, debug shapes of my voxel terrain plugin stopped showing. I found out it's because now `Shape3D` has customizable colors, but they default to [transparent black](https://github.com/godotengine/godot/blob/19e003bc08ac2fb14fc2434bde9530387afd994c/scene/resources/3d/shape_3d.h#L50), which is invisible (I assume it is exploited to mean "null" in some places). 
`Shape3D.get_debug_mesh` is where that color is used. So the only way to make it generate with the right color is to expose `set_debug_color`. This is also the way `CollisionShape3D` nodes are working.

An alternative would be to pass these options directly to `get_debug_mesh`, but that would break compatibility.
