### PR TITLE
Use enums for requesting permissions

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -606,16 +606,16 @@ Key OS::find_keycode_from_string(const String &p_code) const {
 	return find_keycode(p_code);
 }
 
-bool OS::request_permission(const String &p_name) {
-	return ::OS::get_singleton()->request_permission(p_name);
+bool OS::request_permission(PermissionType p_type) {
+	return ::OS::get_singleton()->request_permission(p_type);
 }
 
 bool OS::request_permissions() {
 	return ::OS::get_singleton()->request_permissions();
 }
 
-Vector<String> OS::get_granted_permissions() const {
-	return ::OS::get_singleton()->get_granted_permissions();
+TypedArray<int> OS::get_granted_permissions() const {
+	return TypedArray<int>(::OS::get_singleton()->get_granted_permissions());
 }
 
 void OS::revoke_granted_permissions() {
@@ -726,7 +726,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_feature", "tag_name"), &OS::has_feature);
 	ClassDB::bind_method(D_METHOD("is_sandboxed"), &OS::is_sandboxed);
 
-	ClassDB::bind_method(D_METHOD("request_permission", "name"), &OS::request_permission);
+	ClassDB::bind_method(D_METHOD("request_permission", "type"), &OS::request_permission);
 	ClassDB::bind_method(D_METHOD("request_permissions"), &OS::request_permissions);
 	ClassDB::bind_method(D_METHOD("get_granted_permissions"), &OS::get_granted_permissions);
 	ClassDB::bind_method(D_METHOD("revoke_granted_permissions"), &OS::revoke_granted_permissions);
@@ -759,6 +759,10 @@ void OS::_bind_methods() {
 	BIND_ENUM_CONSTANT(STD_HANDLE_FILE);
 	BIND_ENUM_CONSTANT(STD_HANDLE_PIPE);
 	BIND_ENUM_CONSTANT(STD_HANDLE_UNKNOWN);
+
+	BIND_ENUM_CONSTANT(PERMISSION_CAMERA);
+	BIND_ENUM_CONSTANT(PERMISSION_RECORD_AUDIO);
+	BIND_ENUM_CONSTANT(PERMISSION_VIBRATE);
 }
 
 ////// Geometry2D //////

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -271,9 +271,15 @@ public:
 	bool has_feature(const String &p_feature) const;
 	bool is_sandboxed() const;
 
-	bool request_permission(const String &p_name);
+	enum PermissionType {
+		PERMISSION_CAMERA,
+		PERMISSION_RECORD_AUDIO,
+		PERMISSION_VIBRATE,
+	};
+
+	bool request_permission(PermissionType p_type);
 	bool request_permissions();
-	Vector<String> get_granted_permissions() const;
+	TypedArray<int> get_granted_permissions() const;
 	void revoke_granted_permissions();
 
 	static OS *get_singleton() { return singleton; }
@@ -661,6 +667,7 @@ VARIANT_BITFIELD_CAST(core_bind::ResourceSaver::SaverFlags);
 VARIANT_ENUM_CAST(core_bind::OS::RenderingDriver);
 VARIANT_ENUM_CAST(core_bind::OS::SystemDir);
 VARIANT_ENUM_CAST(core_bind::OS::StdHandleType);
+VARIANT_ENUM_CAST(core_bind::OS::PermissionType);
 
 VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyBooleanOperation);
 VARIANT_ENUM_CAST(core_bind::Geometry2D::PolyJoinType);

--- a/core/os/main_loop.cpp
+++ b/core/os/main_loop.cpp
@@ -44,7 +44,7 @@ void MainLoop::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_APPLICATION_FOCUS_OUT);
 	BIND_CONSTANT(NOTIFICATION_TEXT_SERVER_CHANGED);
 
-	ADD_SIGNAL(MethodInfo("on_request_permissions_result", PropertyInfo(Variant::STRING, "permission"), PropertyInfo(Variant::BOOL, "granted")));
+	ADD_SIGNAL(MethodInfo("on_request_permissions_result", PropertyInfo(Variant::INT, "permission"), PropertyInfo(Variant::BOOL, "granted")));
 
 	GDVIRTUAL_BIND(_initialize);
 	GDVIRTUAL_BIND(_physics_process, "delta");

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -331,9 +331,15 @@ public:
 	bool is_restart_on_exit_set() const;
 	List<String> get_restart_on_exit_arguments() const;
 
-	virtual bool request_permission(const String &p_name) { return true; }
+	enum PermissionType {
+		PERMISSION_CAMERA,
+		PERMISSION_RECORD_AUDIO,
+		PERMISSION_VIBRATE,
+	};
+
+	virtual bool request_permission(int p_type) { return true; }
 	virtual bool request_permissions() { return true; }
-	virtual Vector<String> get_granted_permissions() const { return Vector<String>(); }
+	virtual Vector<int> get_granted_permissions() const { return Vector<int>(); }
 	virtual void revoke_granted_permissions() {}
 
 	// For recording / measuring benchmark data. Only enabled with tools

--- a/doc/classes/MainLoop.xml
+++ b/doc/classes/MainLoop.xml
@@ -93,7 +93,7 @@
 	</methods>
 	<signals>
 		<signal name="on_request_permissions_result">
-			<param index="0" name="permission" type="String" />
+			<param index="0" name="permission" type="int" />
 			<param index="1" name="granted" type="bool" />
 			<description>
 				Emitted when a user responds to a permission request.

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -289,10 +289,9 @@
 			</description>
 		</method>
 		<method name="get_granted_permissions" qualifiers="const">
-			<return type="PackedStringArray" />
+			<return type="int[]" />
 			<description>
 				On Android devices: Returns the list of dangerous permissions that have been granted.
-				On macOS: Returns the list of user selected folders accessible to the application (sandboxed applications only). Use the native file dialog to request folder access permission.
 			</description>
 		</method>
 		<method name="get_keycode_string" qualifiers="const">
@@ -734,10 +733,10 @@
 		</method>
 		<method name="request_permission">
 			<return type="bool" />
-			<param index="0" name="name" type="String" />
+			<param index="0" name="type" type="int" enum="OS.PermissionType" />
 			<description>
-				Requests permission from the OS for the given [param name]. Returns [code]true[/code] if the permission has been successfully granted.
-				[b]Note:[/b] This method is currently only implemented on Android, to specifically request permission for [code]"RECORD_AUDIO"[/code] by [code]AudioDriverOpenSL[/code].
+				Requests permission from the OS for the given [param type]. See the [enum PermissionType] constants for available permissions. Returns [code]true[/code] if the permission has been successfully granted.
+				[b]Note:[/b] This method is currently only implemented on Android, to specifically request permission for [constant PERMISSION_RECORD_AUDIO] by [code]AudioDriverOpenSL[/code].
 			</description>
 		</method>
 		<method name="request_permissions">
@@ -886,6 +885,15 @@
 		</constant>
 		<constant name="STD_HANDLE_UNKNOWN" value="4" enum="StdHandleType">
 			Standard I/O device type is unknown.
+		</constant>
+		<constant name="PERMISSION_CAMERA" value="0" enum="PermissionType">
+			Permission for accessing the camera device.
+		</constant>
+		<constant name="PERMISSION_RECORD_AUDIO" value="1" enum="PermissionType">
+			Permission for recording audio.
+		</constant>
+		<constant name="PERMISSION_VIBRATE" value="2" enum="PermissionType">
+			Permission for accessing vibration.
 		</constant>
 	</constants>
 </class>

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -272,7 +272,7 @@ Error AudioDriverOpenSL::input_start() {
 		return ERR_ALREADY_IN_USE;
 	}
 
-	if (OS::get_singleton()->request_permission("RECORD_AUDIO")) {
+	if (OS::get_singleton()->request_permission(OS::PERMISSION_RECORD_AUDIO)) {
 		return init_input_device();
 	}
 

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -570,8 +570,19 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResu
 		AudioDriver::get_singleton()->input_start();
 	}
 
+	OS::PermissionType permission_enum;
+	if (permission == "android.permission.CAMERA") {
+		permission_enum = OS::PERMISSION_CAMERA;
+	} else if (permission == "android.permission.RECORD_AUDIO") {
+		permission_enum = OS::PERMISSION_RECORD_AUDIO;
+	} else if (permission == "android.permission.VIBRATE") {
+		permission_enum = OS::PERMISSION_VIBRATE;
+	} else {
+		return;
+	}
+
 	if (os_android->get_main_loop()) {
-		os_android->get_main_loop()->emit_signal(SNAME("on_request_permissions_result"), permission, p_result == JNI_TRUE);
+		os_android->get_main_loop()->emit_signal(SNAME("on_request_permissions_result"), permission_enum, p_result == JNI_TRUE);
 	}
 }
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -150,16 +150,35 @@ GodotIOJavaWrapper *OS_Android::get_godot_io_java() {
 	return godot_io_java;
 }
 
-bool OS_Android::request_permission(const String &p_name) {
-	return godot_java->request_permission(p_name);
+bool OS_Android::request_permission(int p_type) {
+	switch (p_type) {
+		case PERMISSION_CAMERA:
+			return godot_java->request_permission("CAMERA");
+		case PERMISSION_RECORD_AUDIO:
+			return godot_java->request_permission("RECORD_AUDIO");
+		case PERMISSION_VIBRATE:
+			return godot_java->request_permission("VIBRATE");
+	}
+	return false;
 }
 
 bool OS_Android::request_permissions() {
 	return godot_java->request_permissions();
 }
 
-Vector<String> OS_Android::get_granted_permissions() const {
-	return godot_java->get_granted_permissions();
+Vector<int> OS_Android::get_granted_permissions() const {
+	Vector<int> granted_enum;
+	Vector<String> granted_string = godot_java->get_granted_permissions();
+	for (String string : granted_string) {
+		if (string == "CAMERA") {
+			granted_enum.append(PERMISSION_CAMERA);
+		} else if (string == "RECORD_AUDIO") {
+			granted_enum.append(PERMISSION_RECORD_AUDIO);
+		} else if (string == "VIBRATE") {
+			granted_enum.append(PERMISSION_RECORD_AUDIO);
+		}
+	}
+	return granted_enum;
 }
 
 bool OS_Android::copy_dynamic_library(const String &p_library_path, const String &p_target_dir, String *r_copy_path) {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -113,9 +113,9 @@ public:
 	GodotJavaWrapper *get_godot_java();
 	GodotIOJavaWrapper *get_godot_io_java();
 
-	virtual bool request_permission(const String &p_name) override;
+	virtual bool request_permission(int p_type) override;
 	virtual bool request_permissions() override;
-	virtual Vector<String> get_granted_permissions() const override;
+	virtual Vector<int> get_granted_permissions() const override;
 
 	virtual void alert(const String &p_alert, const String &p_title) override;
 

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -118,7 +118,7 @@ public:
 	virtual String get_model_name() const override;
 
 	virtual bool is_sandboxed() const override;
-	virtual Vector<String> get_granted_permissions() const override;
+	virtual Vector<int> get_granted_permissions() const override;
 	virtual void revoke_granted_permissions() override;
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -89,23 +89,8 @@ bool OS_MacOS::is_sandboxed() const {
 	return has_environment("APP_SANDBOX_CONTAINER_ID");
 }
 
-Vector<String> OS_MacOS::get_granted_permissions() const {
-	Vector<String> ret;
-
-	if (is_sandboxed()) {
-		NSArray *bookmarks = [[NSUserDefaults standardUserDefaults] arrayForKey:@"sec_bookmarks"];
-		for (id bookmark in bookmarks) {
-			NSError *error = nil;
-			BOOL isStale = NO;
-			NSURL *url = [NSURL URLByResolvingBookmarkData:bookmark options:NSURLBookmarkResolutionWithSecurityScope relativeToURL:nil bookmarkDataIsStale:&isStale error:&error];
-			if (!error && !isStale) {
-				String url_string;
-				url_string.parse_utf8([[url path] UTF8String]);
-				ret.push_back(url_string);
-			}
-		}
-	}
-
+Vector<int> OS_MacOS::get_granted_permissions() const {
+	Vector<int> ret;
 	return ret;
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Use enumeration for requesting permission instead of strings.

This is breaking changes, as the method signatures are different.

The default path of `requestPermission(String permissionName, Activity activity)` in `PermissionUtil.java` for Android will become unreachable.