### PR TITLE
Jolt: Fix multiple definition LTO linking issue with mingw-gcc

### DIFF
--- a/modules/jolt_physics/spaces/jolt_layers.cpp
+++ b/modules/jolt_physics/spaces/jolt_layers.cpp
@@ -191,6 +191,10 @@ JoltLayers::JoltLayers() {
 	_allocate_object_layer(0);
 }
 
+// MinGW GCC using LTO will emit errors during linking if this is defined in the header file, implicitly or otherwise.
+// Likely caused by this GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94156
+JoltLayers::~JoltLayers() = default;
+
 JPH::ObjectLayer JoltLayers::to_object_layer(JPH::BroadPhaseLayer p_broad_phase_layer, uint32_t p_collision_layer, uint32_t p_collision_mask) {
 	const uint64_t collision = encode_collision(p_collision_layer, p_collision_mask);
 

--- a/modules/jolt_physics/spaces/jolt_layers.h
+++ b/modules/jolt_physics/spaces/jolt_layers.h
@@ -63,6 +63,7 @@ class JoltLayers final
 
 public:
 	JoltLayers();
+	virtual ~JoltLayers();
 
 	JPH::ObjectLayer to_object_layer(JPH::BroadPhaseLayer p_broad_phase_layer, uint32_t p_collision_layer, uint32_t p_collision_mask);
 	void from_object_layer(JPH::ObjectLayer p_encoded_layer, JPH::BroadPhaseLayer &r_broad_phase_layer, uint32_t &r_collision_layer, uint32_t &r_collision_mask) const;


### PR DESCRIPTION
This fixes the following errors when building with mingw-gcc for Windows with `scons p=windows lto=full`:
```
/usr/lib/gcc/x86_64-w64-mingw32/14.1.1/../../../../x86_64-w64-mingw32/bin/ld: modules/jolt_physics/spaces/jolt_layers.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD1Ev[_ZThn16_N10JoltLayersD1Ev]+0x0): multiple definition of `JoltLayers::~JoltLayers()'; modules/jolt_physics/spaces/jolt_space_3d.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD1Ev[_ZThn8_N10JoltLayersD1Ev]+0x0): first defined here
/usr/lib/gcc/x86_64-w64-mingw32/14.1.1/../../../../x86_64-w64-mingw32/bin/ld: modules/jolt_physics/spaces/jolt_layers.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD1Ev[_ZThn16_N10JoltLayersD1Ev]+0x0): multiple definition of `non-virtual thunk to JoltLayers::~JoltLayers()'; modules/jolt_physics/spaces/jolt_space_3d.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD1Ev[_ZThn8_N10JoltLayersD1Ev]+0x0): first defined here
/usr/lib/gcc/x86_64-w64-mingw32/14.1.1/../../../../x86_64-w64-mingw32/bin/ld: modules/jolt_physics/spaces/jolt_layers.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD1Ev[_ZThn16_N10JoltLayersD1Ev]+0x0): multiple definition of `non-virtual thunk to JoltLayers::~JoltLayers()'; modules/jolt_physics/spaces/jolt_space_3d.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD1Ev[_ZThn8_N10JoltLayersD1Ev]+0x0): first defined here
/usr/lib/gcc/x86_64-w64-mingw32/14.1.1/../../../../x86_64-w64-mingw32/bin/ld: modules/jolt_physics/spaces/jolt_layers.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD0Ev[_ZThn16_N10JoltLayersD0Ev]+0x0): multiple definition of `JoltLayers::~JoltLayers()'; modules/jolt_physics/spaces/jolt_space_3d.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD0Ev[_ZThn8_N10JoltLayersD0Ev]+0x0): first defined here
/usr/lib/gcc/x86_64-w64-mingw32/14.1.1/../../../../x86_64-w64-mingw32/bin/ld: modules/jolt_physics/spaces/jolt_layers.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD0Ev[_ZThn16_N10JoltLayersD0Ev]+0x0): multiple definition of `non-virtual thunk to JoltLayers::~JoltLayers()'; modules/jolt_physics/spaces/jolt_space_3d.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD0Ev[_ZThn8_N10JoltLayersD0Ev]+0x0): first defined here
/usr/lib/gcc/x86_64-w64-mingw32/14.1.1/../../../../x86_64-w64-mingw32/bin/ld: modules/jolt_physics/spaces/jolt_layers.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD0Ev[_ZThn16_N10JoltLayersD0Ev]+0x0): multiple definition of `non-virtual thunk to JoltLayers::~JoltLayers()'; modules/jolt_physics/spaces/jolt_space_3d.windows.editor.x86_64.o (symbol from plugin):(.gnu.linkonce.t._ZN10JoltLayersD0Ev[_ZThn8_N10JoltLayersD0Ev]+0x0): first defined here
```

@hpvb gave me this advice:

> This means that during the LTO step we end up with multiple symbols of the same name, probably means something has to be moved out of a header to a .cpp file

And indeed defining the empty destructor in the .cpp file solved it. Previous attempts at adding `~JoltLayers();` or `~JoltLayers = default;` in the header wouldn't work.

For the record, this sounds related to this GCC bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94156
But it's unconfirmed upstream so I don't know if it's indeed a GCC bug or just a spec caveat.