### PR TITLE
Use `LocalVector` instead of `List` as arg of `Dictionary::get_key_list`

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -122,8 +122,7 @@ String JSON::_stringify(const Variant &p_var, const String &p_indent, int p_cur_
 			ERR_FAIL_COND_V_MSG(p_markers.has(d.id()), "\"{...}\"", "Converting circular structure to JSON.");
 			p_markers.insert(d.id());
 
-			List<Variant> keys;
-			d.get_key_list(&keys);
+			LocalVector<Variant> keys = d.get_key_list();
 
 			if (p_sort_keys) {
 				keys.sort_custom<StringLikeVariantOrder>();

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -272,9 +272,7 @@ void Resource::_dupe_sub_resources(Variant &r_variant, Node *p_for_scene, HashMa
 		} break;
 		case Variant::DICTIONARY: {
 			Dictionary d = r_variant;
-			List<Variant> keys;
-			d.get_key_list(&keys);
-			for (Variant &k : keys) {
+			for (Variant &k : d.get_key_list()) {
 				if (k.get_type() == Variant::OBJECT) {
 					// Replace in dictionary key.
 					Ref<Resource> sr = k;

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -57,14 +57,14 @@ Dictionary::ConstIterator Dictionary::end() const {
 	return _p->variant_map.end();
 }
 
-void Dictionary::get_key_list(List<Variant> *p_keys) const {
-	if (_p->variant_map.is_empty()) {
-		return;
-	}
+LocalVector<Variant> Dictionary::get_key_list() const {
+	LocalVector<Variant> keys;
 
+	keys.reserve(_p->variant_map.size());
 	for (const KeyValue<Variant, Variant> &E : _p->variant_map) {
-		p_keys->push_back(E.key);
+		keys.push_back(E.key);
 	}
+	return keys;
 }
 
 Variant Dictionary::get_key_at_index(int p_index) const {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -32,7 +32,7 @@
 
 #include "core/string/ustring.h"
 #include "core/templates/hash_map.h"
-#include "core/templates/list.h"
+#include "core/templates/local_vector.h"
 #include "core/templates/pair.h"
 #include "core/variant/array.h"
 
@@ -55,7 +55,7 @@ public:
 	ConstIterator begin() const;
 	ConstIterator end() const;
 
-	void get_key_list(List<Variant> *p_keys) const;
+	LocalVector<Variant> get_key_list() const;
 	Variant get_key_at_index(int p_index) const;
 	Variant get_value_at_index(int p_index) const;
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -54,6 +54,7 @@
 #include "core/os/keyboard.h"
 #include "core/string/node_path.h"
 #include "core/string/ustring.h"
+#include "core/templates/list.h"
 #include "core/templates/paged_allocator.h"
 #include "core/templates/rid.h"
 #include "core/variant/array.h"

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -2248,8 +2248,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				ERR_PRINT("Max recursion reached");
 				p_store_string_func(p_store_string_ud, "{}");
 			} else {
-				List<Variant> keys;
-				dict.get_key_list(&keys);
+				LocalVector<Variant> keys = dict.get_key_list();
 				keys.sort_custom<StringLikeVariantOrder>();
 
 				if (keys.is_empty()) {
@@ -2260,11 +2259,12 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 
 					p_store_string_func(p_store_string_ud, "{\n");
 
-					for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-						write(E->get(), p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+					for (uint32_t i = 0; i < keys.size(); i++) {
+						const Variant &key = keys[i];
+						write(key, p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
 						p_store_string_func(p_store_string_ud, ": ");
-						write(dict[E->get()], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
-						if (E->next()) {
+						write(dict[key], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, p_recursion_count, p_compat);
+						if (i + 1 < keys.size()) {
 							p_store_string_func(p_store_string_ud, ",\n");
 						} else {
 							p_store_string_func(p_store_string_ud, "\n");

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3702,10 +3702,8 @@ void EditorNode::replace_resources_in_object(Object *p_object, const Vector<Ref<
 			} break;
 			case Variant::DICTIONARY: {
 				Dictionary d = p_object->get(E.name);
-				List<Variant> keys;
 				bool dictionary_requires_updating = false;
-				d.get_key_list(&keys);
-				for (const Variant &F : keys) {
+				for (const Variant &F : d.get_key_list()) {
 					Variant v = d[F];
 					Ref<Resource> res = v;
 

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -638,9 +638,7 @@ EditorExportPlatform::ExportNotifier::~ExportNotifier() {
 bool EditorExportPlatform::_export_customize_dictionary(Dictionary &dict, LocalVector<Ref<EditorExportPlugin>> &customize_resources_plugins) {
 	bool changed = false;
 
-	List<Variant> keys;
-	dict.get_key_list(&keys);
-	for (const Variant &K : keys) {
+	for (const Variant &K : dict.get_key_list()) {
 		Variant v = dict[K];
 		switch (v.get_type()) {
 			case Variant::OBJECT: {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1732,9 +1732,7 @@ void FileSystemDock::_folder_removed(const String &p_folder) {
 
 	// Remove assigned folder color for all subfolders.
 	bool folder_colors_updated = false;
-	List<Variant> paths;
-	assigned_folder_colors.get_key_list(&paths);
-	for (const Variant &E : paths) {
+	for (const Variant &E : assigned_folder_colors.get_key_list()) {
 		const String &path = E;
 		// These folder paths are guaranteed to end with a "/".
 		if (path.begins_with(p_folder)) {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2199,8 +2199,7 @@ void VisualShaderEditor::_update_nodes() {
 		}
 	}
 
-	List<Variant> keys;
-	added.get_key_list(&keys);
+	LocalVector<Variant> keys = added.get_key_list();
 	keys.sort_custom<StringLikeVariantOrder>();
 
 	for (const Variant &key : keys) {

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -216,15 +216,15 @@ String GDScriptDocGen::_docvalue_from_variant(const Variant &p_variant, int p_re
 			} else {
 				result += "{";
 
-				List<Variant> keys;
-				dict.get_key_list(&keys);
+				LocalVector<Variant> keys = dict.get_key_list();
 				keys.sort_custom<StringLikeVariantOrder>();
 
-				for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-					if (E->prev()) {
+				for (uint32_t i = 0; i < keys.size(); i++) {
+					const Variant &key = keys[i];
+					if (i > 0) {
 						result += ", ";
 					}
-					result += _docvalue_from_variant(E->get(), p_recursion_level + 1) + ": " + _docvalue_from_variant(dict[E->get()], p_recursion_level + 1);
+					result += _docvalue_from_variant(key, p_recursion_level + 1) + ": " + _docvalue_from_variant(dict[key], p_recursion_level + 1);
 				}
 
 				result += "}";

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1317,8 +1317,7 @@ Error RenderingServer::mesh_create_surface_data_from_arrays(SurfaceData *r_surfa
 	}
 	Vector<SurfaceData::LOD> lods;
 	if (index_array_len) {
-		List<Variant> keys;
-		p_lods.get_key_list(&keys);
+		LocalVector<Variant> keys = p_lods.get_key_list();
 		keys.sort(); // otherwise lod levels may get skipped
 		for (const Variant &E : keys) {
 			float distance = E;

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -115,19 +115,18 @@ TEST_CASE("[Dictionary] List init") {
 	CHECK_EQ(tdict[5.0], Variant(2.0));
 }
 
-TEST_CASE("[Dictionary] get_key_lists()") {
+TEST_CASE("[Dictionary] get_key_list()") {
 	Dictionary map;
-	List<Variant> keys;
-	List<Variant> *ptr = &keys;
-	map.get_key_list(ptr);
+	LocalVector<Variant> keys;
+	keys = map.get_key_list();
 	CHECK(keys.is_empty());
 	map[1] = 3;
-	map.get_key_list(ptr);
+	keys = map.get_key_list();
 	CHECK(keys.size() == 1);
-	CHECK(int(keys.front()->get()) == 1);
+	CHECK(int(keys[0]) == 1);
 	map[2] = 4;
-	map.get_key_list(ptr);
-	CHECK(keys.size() == 3);
+	keys = map.get_key_list();
+	CHECK(keys.size() == 2);
 }
 
 TEST_CASE("[Dictionary] get_key_at_index()") {


### PR DESCRIPTION
An attempt to refactor old interface. It is done last month but I thought the changes are too widespread to be merged so I just leave it aside. Anyway, I decide to upload this to spark some discussion.

As a side effect, we can now reserve the key list which reduce calls to malloc.

~~The function name should definitely be changed, maybe `get_keys`? I don't know.~~

Edit: There are many other `xx_list` like API not returning lists, so the name should be ok.