### PR TITLE
Introduce a conversion for editor shortcuts

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -103,6 +103,14 @@ bool EditorSettings::_set_only(const StringName &p_name, const Variant &p_value)
 
 			builtin_action_overrides[action_name].clear();
 			for (int ev_idx = 0; ev_idx < events.size(); ev_idx++) {
+#ifndef DISABLE_DEPRECATED
+				// -3 was introduced in GH-97707 as a way to prevent a clash in device IDs, but as reported in GH-99243, this leads to problems.
+				// -3 was used during dev-releases, so this conversion helps to revert such affected editor shortcuts.
+				Ref<InputEvent> x = events[ev_idx];
+				if (x.is_valid() && x->get_device() == -3) {
+					x->set_device(-1);
+				}
+#endif // DISABLE_DEPRECATED
 				im->action_add_event(action_name, events[ev_idx]);
 				builtin_action_overrides[action_name].push_back(events[ev_idx]);
 			}


### PR DESCRIPTION
This is temporary code for reverting effects in editor settings, that were caused by the reverted #97707.

Follow-up to #99449 which solved the problem only for project settings, but not for editor settings.

In the case that this PR get merged, it should be reverted in #99479 before 4.4-stable.

This PR addresses part of https://github.com/godotengine/godot/issues/100182#issuecomment-2529352039