### PR TITLE
SCons: Properly set SSE2 as baseline on x86_32

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -713,6 +713,12 @@ elif env.msvc:
         )
         Exit(255)
 
+# Default architecture flags.
+if env["arch"] == "x86_32":
+    if env.msvc:
+        env.Append(CCFLAGS=["/arch:SSE2"])
+    else:
+        env.Append(CCFLAGS=["-msse2"])
 
 # Set optimize and debug_symbols flags.
 # "custom" means do nothing and let users set their own optimization flags.

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -66,18 +66,12 @@ if env["builtin_embree"]:
     env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2", "EMBREE_LOWEST_ISA", "TASKING_INTERNAL"])
     env_raycast.AppendUnique(CPPDEFINES=["NDEBUG"])  # No assert() even in debug builds.
 
-    if not env.msvc:
-        if env["arch"] in ["x86_64", "x86_32"]:
-            env_raycast.Append(CCFLAGS=["-msse2", "-mxsave"])
-
-        if env["platform"] == "windows":
-            env_raycast.Append(CCFLAGS=["-mstackrealign"])
-
     if env["platform"] == "windows":
         if env.msvc:
             env.Append(LINKFLAGS=["psapi.lib"])
         else:
             env.Append(LIBS=["psapi"])
+            env_raycast.Append(CCFLAGS=["-mstackrealign"])
 
     if env.msvc:  # Disable bogus warning about intentional struct padding.
         env_raycast.Append(CCFLAGS=["/wd4324"])

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -70,14 +70,6 @@ def configure(env: "SConsEnvironment"):
     supported_arches = ["x86_64", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)
 
-    ## Build type
-
-    if env["target"] == "template_release":
-        if env["arch"] != "arm64":
-            env.Prepend(CCFLAGS=["-msse2"])
-    elif env.dev_build:
-        env.Prepend(LINKFLAGS=["-Xlinker", "-no_deduplicate"])
-
     ## Compiler configuration
 
     # Save this in environment for use by other modules
@@ -97,6 +89,7 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
+    env.Append(CCFLAGS=["-fobjc-arc"])
 
     cc_version = get_compiler_version(env)
     cc_version_major = cc_version["apple_major"]
@@ -106,7 +99,8 @@ def configure(env: "SConsEnvironment"):
     if is_apple_clang(env) and cc_version_major == 1500 and cc_version_minor == 0:
         env.Prepend(LINKFLAGS=["-ld_classic"])
 
-    env.Append(CCFLAGS=["-fobjc-arc"])
+    if env.dev_build:
+        env.Prepend(LINKFLAGS=["-Xlinker", "-no_deduplicate"])
 
     if "osxcross" not in env:  # regular native build
         if env["macports_clang"] != "no":

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -701,11 +701,7 @@ def configure_mingw(env: "SConsEnvironment"):
         print("Detected GCC to be a wrapper for Clang.")
         env["use_llvm"] = True
 
-    # TODO: Re-evaluate the need for this / streamline with common config.
-    if env["target"] == "template_release":
-        if env["arch"] != "arm64":
-            env.Append(CCFLAGS=["-msse2"])
-    elif env.dev_build:
+    if env.dev_build:
         # Allow big objects. It's supposed not to have drawbacks but seems to break
         # GCC LTO, so enabling for debug builds only (which are not built with LTO
         # and are the only ones with too big objects).


### PR DESCRIPTION
Setting it only for release templates on Windows and macOS was inconsistent, and Jolt requires it as a minimum.

Drop the `-mxsave` flag from the raycast module, this doesn't seem to be used explicitly by Embree, and unnecessarily makes our config and baseline muddy.

I'm aware of #59595, but this one requires more discussion as requiring SSE4.2 does cut off a significant amount of CPUs, and we need to evaluate whether we're willing to make that compromise.

SSE2 on the other hand should be a no brainer, it was already the default for MSVC, and for all other platforms indirectly by way of it being set for the raycast module, which would mean that our binaries can't run on i386 machines without SSE2 already.