### PR TITLE
Fix 3D CSG not reacting to child node order changes

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -848,6 +848,10 @@ void CSGShape3D::_notification(int p_what) {
 			parent_shape = nullptr;
 		} break;
 
+		case NOTIFICATION_CHILD_ORDER_CHANGED: {
+			_make_dirty();
+		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_root_shape() && last_visible != is_visible()) {
 				// Update this node's parent only if its own visibility has changed, not the visibility of parent nodes


### PR DESCRIPTION
Fixes 3D CSG not reacting to child node order changes.

While working on the 2D CSG https://github.com/godotengine/godot/pull/99911 I noticed that when I just moved csg child nodes up and down in the SceneTree order it would not update the CSG shapes.

This was because the `_notifcation()` code was missing the `NOTIFICATION_CHILD_ORDER_CHANGED` to set the dirty flags. The csg nodes only reacted to the `NOTIFICATION_PARENTED` and `NOTIFICATION_UNPARENTED` notifcations. Without a full (re)parent event it would not update. The child order is critical for the result as the CSG operations are applied in child order.

Fast forward knowing that I had copied that entire update and notification code from the 3D version here is the same fix for 3D.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
