### PR TITLE
Small fixups for the new reflection probe blending

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1619,21 +1619,15 @@ void reflection_process(samplerCube reflection_map,
 		return;
 	}
 
-	vec3 inner_pos = abs(local_pos / box_extents);
-	vec3 blend_axes = vec3(0.0, 0.0, 0.0);
-	float blend = 0.0;
-	if (blend_distance != 0) {
-		for (int i = 0; i < 3; i++) {
-			float axis_blend_distance = min(blend_distance, box_extents[i]);
-			blend_axes[i] = (inner_pos[i] * box_extents[i]) - box_extents[i] + axis_blend_distance;
-			blend_axes[i] = blend_axes[i] / axis_blend_distance;
-			blend_axes[i] = clamp(blend_axes[i], 0.0, 1.0);
-		}
-		blend = pow((1.0 - blend_axes.x) * (1.0 - blend_axes.y) * (1.0 - blend_axes.z), 2);
-		blend = 1 - blend;
+	float blend = 1.0;
+	if (blend_distance != 0.0) {
+		vec3 axis_blend_distance = min(vec3(blend_distance), box_extents);
+		vec3 blend_axes = abs(local_pos) - box_extents + axis_blend_distance;
+		blend_axes /= axis_blend_distance;
+		blend_axes = clamp(1.0 - blend_axes, vec3(0.0), vec3(1.0));
+
+		blend = pow(blend_axes.x * blend_axes.y * blend_axes.z, 2.0);
 	}
-	blend = max(0.0, 1.0 - blend);
-	blend = clamp(blend, 0.0, 1.0);
 
 	//reflect and make local
 	vec3 ref_normal = normalize(reflect(vertex, normal));

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -875,21 +875,15 @@ void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, 
 		return;
 	}
 
-	vec3 inner_pos = abs(local_pos / box_extents);
-	vec3 blend_axes = vec3(0.0, 0.0, 0.0);
-	float blend = 0.0;
-	if (reflections.data[ref_index].blend_distance != 0) {
-		for (int i = 0; i < 3; i++) {
-			float axis_blend_distance = min(reflections.data[ref_index].blend_distance, box_extents[i]);
-			blend_axes[i] = (inner_pos[i] * box_extents[i]) - box_extents[i] + axis_blend_distance;
-			blend_axes[i] = blend_axes[i] / axis_blend_distance;
-			blend_axes[i] = clamp(blend_axes[i], 0.0, 1.0);
-		}
-		blend = pow((1.0 - blend_axes.x) * (1.0 - blend_axes.y) * (1.0 - blend_axes.z), 2);
-		blend = 1 - blend;
+	float blend = 1.0;
+	if (reflections.data[ref_index].blend_distance != 0.0) {
+		vec3 axis_blend_distance = min(vec3(reflections.data[ref_index].blend_distance), box_extents);
+		vec3 blend_axes = abs(local_pos) - box_extents + axis_blend_distance;
+		blend_axes /= axis_blend_distance;
+		blend_axes = clamp(1.0 - blend_axes, vec3(0.0), vec3(1.0));
+
+		blend = pow(blend_axes.x * blend_axes.y * blend_axes.z, 2.0);
 	}
-	blend = max(0.0, 1.0 - blend);
-	blend = clamp(blend, 0.0, 1.0);
 
 	if (reflections.data[ref_index].intensity > 0.0) { // compute reflection
 


### PR DESCRIPTION
Fixes some small issues from https://github.com/godotengine/godot/pull/99958

The biggest issue is that ANGLE doesn't allow mixing ints and floats so this shader will fail to compile on the web or when using the ANGLE backend. 

Second, the way the shader is written it does a lot of unnecessary instructions. Running a quick comparison in shader playground shows that it was allocating 2 more VGPRs than necessary and was roughly doing double the number of instructions it needed to. https://shader-playground.timjones.io/0a125912ec8d14f234b4a9c287f0f2e6

I rewrote the code to do vector operations throughout (the compiler mostly did this, but not fully) and avoid doing work that would get immediately undone. This makes the code easier to understand, faster to compile, and faster to run. 