### PR TITLE
[DRAFT] A Collection of Scene Shader Fixes

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -4,6 +4,7 @@
 
 #VERSION_DEFINES
 
+/* Include our Forward+ UBOs, definitions, etc. */
 #include "scene_forward_clustered_inc.glsl"
 
 #define SHADER_IS_SRGB false
@@ -14,58 +15,57 @@
 // Always contains vertex position in XYZ, can contain tangent angle in W.
 layout(location = 0) in vec4 vertex_angle_attrib;
 
-//only for pure render depth when normal is not used
+// Only for pure render depth when normal is not used.
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 // Contains Normal/Axis in RG, can contain tangent in BA.
 layout(location = 1) in vec4 axis_tangent_attrib;
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 
 // Location 2 is unused.
 
 #if defined(COLOR_USED)
 layout(location = 3) in vec4 color_attrib;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 4) in vec2 uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP) || defined(MODE_RENDER_MATERIAL)
 layout(location = 5) in vec2 uv2_attrib;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP || MODE_RENDER_MATERIAL
 
 #if defined(CUSTOM0_USED)
 layout(location = 6) in vec4 custom0_attrib;
-#endif
+#endif // CUSTOM0_USED
 
 #if defined(CUSTOM1_USED)
 layout(location = 7) in vec4 custom1_attrib;
-#endif
+#endif // CUSTOM1_USED
 
 #if defined(CUSTOM2_USED)
 layout(location = 8) in vec4 custom2_attrib;
-#endif
+#endif // CUSTOM2_USED
 
 #if defined(CUSTOM3_USED)
 layout(location = 9) in vec4 custom3_attrib;
-#endif
+#endif // CUSTOM3_USED
 
 #if defined(BONES_USED) || defined(USE_PARTICLE_TRAILS)
 layout(location = 10) in uvec4 bone_attrib;
-#endif
+#endif // BONES_USED || USE_PARTICLE_TRAILS
 
 #if defined(WEIGHTS_USED) || defined(USE_PARTICLE_TRAILS)
 layout(location = 11) in vec4 weight_attrib;
-#endif
+#endif // WEIGHTS_USED || USE_PARTICLE_TRAILS
 
 #ifdef MOTION_VECTORS
 layout(location = 12) in vec4 previous_vertex_attrib;
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 layout(location = 13) in vec4 previous_normal_attrib;
-#endif
-
+#endif // NORMAL_USED || TANGENT_USED
 #endif // MOTION_VECTORS
 
 vec3 oct_to_vec3(vec2 e) {
@@ -91,29 +91,29 @@ layout(location = 0) out vec3 vertex_interp;
 
 #ifdef NORMAL_USED
 layout(location = 1) out vec3 normal_interp;
-#endif
+#endif // NORMAL_USED
 
 #if defined(COLOR_USED)
 layout(location = 2) out vec4 color_interp;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 3) out vec2 uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 layout(location = 4) out vec2 uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #ifdef TANGENT_USED
 layout(location = 5) out vec3 tangent_interp;
 layout(location = 6) out vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED
 
 #ifdef MOTION_VECTORS
 layout(location = 7) out vec4 screen_position;
 layout(location = 8) out vec4 prev_screen_position;
-#endif
+#endif // MOTION_VECTORS
 
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
@@ -121,19 +121,18 @@ layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms
 #MATERIAL_UNIFORMS
 } material;
 /* clang-format on */
-#endif
+#endif // MATERIAL_UNIFORMS_USED
 
 float global_time;
 
 #ifdef MODE_DUAL_PARABOLOID
-
 layout(location = 9) out float dp_clip;
-
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 layout(location = 10) out flat uint instance_index_interp;
 
 #ifdef USE_MULTIVIEW
+
 #ifdef has_VK_KHR_multiview
 #define ViewIndex gl_ViewIndex
 #else // has_VK_KHR_multiview
@@ -147,8 +146,10 @@ ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
 layout(location = 11) out vec4 combined_projected;
+
 #else // USE_MULTIVIEW
-// Set to zero, not supported in non stereo
+
+// Set to zero, not supported in non-stereo.
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
@@ -157,9 +158,10 @@ ivec2 multiview_uv(ivec2 uv) {
 	return uv;
 }
 
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+
 layout(location = 12) highp out vec4 diffuse_light_interp;
 layout(location = 13) highp out vec4 specular_light_interp;
 
@@ -171,7 +173,7 @@ void cluster_get_item_range(uint p_offset, out uint item_min, out uint item_max,
 	item_max = item_min_max >> 16;
 
 	item_from = item_min >> 5;
-	item_to = (item_max == 0) ? 0 : ((item_max - 1) >> 5) + 1; //side effect of how it is stored, as item_max 0 means no elements
+	item_to = (item_max == 0) ? 0 : ((item_max - 1) >> 5) + 1; // Side effect of how it is stored, as item_max 0 means no elements.
 }
 
 uint cluster_get_range_clip_mask(uint i, uint z_min, uint z_max) {
@@ -179,11 +181,14 @@ uint cluster_get_range_clip_mask(uint i, uint z_min, uint z_max) {
 	int mask_width = min(int(z_max) - int(z_min), 32 - local_min);
 	return bitfieldInsert(uint(0), uint(0xFFFFFFFF), local_min, mask_width);
 }
-#endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
+
 invariant gl_Position;
+/* clang-format off */
 
 #GLOBALS
 
+/* clang-format on */
 #ifdef USE_DOUBLE_PRECISION
 // Helper functions for emulating double precision when adding floats.
 vec3 quick_two_sum(vec3 a, vec3 b, out vec3 out_p) {
@@ -209,7 +214,7 @@ vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec
 	s = quick_two_sum(s, se, out_precision);
 	return s;
 }
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 uint multimesh_stride() {
 	uint stride = sc_multimesh_format_2d() ? 2 : 3;
@@ -221,16 +226,16 @@ uint multimesh_stride() {
 void vertex_shader(vec3 vertex_input,
 #ifdef NORMAL_USED
 		in vec3 normal_input,
-#endif
+#endif // NORMAL_USED
 #ifdef TANGENT_USED
 		in vec3 tangent_input,
 		in vec3 binormal_input,
-#endif
+#endif // TANGENT_USED
 		in uint instance_index, in uint multimesh_offset, in SceneData scene_data, in mat4 model_matrix, out vec4 screen_pos) {
 	vec4 instance_custom = vec4(0.0);
 #if defined(COLOR_USED)
 	color_interp = color_attrib;
-#endif
+#endif // COLOR_USED
 
 	mat4 inv_view_matrix = scene_data.inv_view_matrix;
 
@@ -243,7 +248,7 @@ void vertex_shader(vec3 vertex_input,
 	inv_view_matrix[0][3] = 0.0;
 	inv_view_matrix[1][3] = 0.0;
 	inv_view_matrix[2][3] = 0.0;
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 	mat3 model_normal_matrix;
 	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
@@ -255,54 +260,52 @@ void vertex_shader(vec3 vertex_input,
 	mat4 matrix;
 	mat4 read_model_matrix = model_matrix;
 
-	if (sc_multimesh()) {
-		//multimesh, instances are for it
-
+	if (sc_multimesh()) { // Multimesh, instances are for it.
 #ifdef USE_PARTICLE_TRAILS
 		uint trail_size = (instances.data[instance_index].flags >> INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT) & INSTANCE_FLAGS_PARTICLE_TRAIL_MASK;
-		uint stride = 3 + 1 + 1; //particles always uses this format
+		uint stride = 3 + 1 + 1; // Particles always use this format.
 
 		uint offset = trail_size * stride * gl_InstanceIndex;
 
 #ifdef COLOR_USED
 		vec4 pcolor;
-#endif
+#endif // COLOR_USED
 		{
 			uint boffset = offset + bone_attrib.x * stride;
 			matrix = mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.x;
 #ifdef COLOR_USED
 			pcolor = transforms.data[boffset + 3] * weight_attrib.x;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.y > 0.001) {
 			uint boffset = offset + bone_attrib.y * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.y;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.y;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.z > 0.001) {
 			uint boffset = offset + bone_attrib.z * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.z;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.z;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.w > 0.001) {
 			uint boffset = offset + bone_attrib.w * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.w;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.w;
-#endif
+#endif // COLOR_USED
 		}
 
 		instance_custom = transforms.data[offset + 4];
 
 #ifdef COLOR_USED
 		color_interp *= pcolor;
-#endif
+#endif // COLOR_USED
 
-#else
+#else // USE_PARTICLE_TRAILS
 		uint stride = multimesh_stride();
 		uint offset = stride * (gl_InstanceIndex + multimesh_offset);
 
@@ -317,16 +320,15 @@ void vertex_shader(vec3 vertex_input,
 		if (sc_multimesh_has_color()) {
 #ifdef COLOR_USED
 			color_interp *= transforms.data[offset];
-#endif
+#endif // COLOR_USED
 			offset += 1;
 		}
 
 		if (sc_multimesh_has_custom_data()) {
 			instance_custom = transforms.data[offset];
 		}
+#endif // USE_PARTICLE_TRAILS
 
-#endif
-		//transpose
 		matrix = transpose(matrix);
 #if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
 		// Normally we can bake the multimesh transform into the model matrix, but when using double precision
@@ -334,71 +336,70 @@ void vertex_shader(vec3 vertex_input,
 		read_model_matrix = model_matrix * matrix;
 #if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
 		model_matrix = read_model_matrix;
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
+#endif // !USE_DOUBLE_PRECISION || SKIP_TRANSFORM_USED || VERTEX_WORLD_COORDS_USED
+#endif // !USE_DOUBLE_PRECISION || SKIP_TRANSFORM_USED || VERTEX_WORLD_COORDS_USED || MODEL_MATRIX_USED
 		model_normal_matrix = model_normal_matrix * mat3(matrix);
 	}
 
 	vec3 vertex = vertex_input;
 #ifdef NORMAL_USED
 	vec3 normal = normal_input;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
 	vec3 tangent = tangent_input;
 	vec3 binormal = binormal_input;
-#endif
+#endif // TANGENT_USED
 
 #ifdef UV_USED
 	uv_interp = uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	uv2_interp = uv2_attrib;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 	vec4 uv_scale = instances.data[instance_index].uv_scale;
 
-	if (uv_scale != vec4(0.0)) { // Compression enabled
+	if (uv_scale != vec4(0.0)) { // Compression enabled.
 #ifdef UV_USED
 		uv_interp = (uv_interp - 0.5) * uv_scale.xy;
-#endif
+#endif // UV_USED
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 		uv2_interp = (uv2_interp - 0.5) * uv_scale.zw;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 	}
 
 #ifdef OVERRIDE_POSITION
 	vec4 position = vec4(1.0);
-#endif
+#endif // OVERRIDE_POSITION
 
 #ifdef USE_MULTIVIEW
 	mat4 combined_projection = scene_data.projection_matrix;
 	mat4 projection_matrix = scene_data.projection_matrix_view[ViewIndex];
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix_view[ViewIndex];
 	vec3 eye_offset = scene_data.eye_offset[ViewIndex].xyz;
-#else
+#else // USE_MULTIVIEW
 	mat4 projection_matrix = scene_data.projection_matrix;
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix;
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
 
-//using world coordinates
+// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (model_matrix * vec4(vertex, 1.0)).xyz;
 
 #ifdef NORMAL_USED
 	normal = model_normal_matrix * normal;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
-
 	tangent = model_normal_matrix * tangent;
 	binormal = model_normal_matrix * binormal;
+#endif // TANGENT_USED
 
-#endif
-#endif
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	float roughness = 1.0;
 
@@ -407,11 +408,12 @@ void vertex_shader(vec3 vertex_input,
 	mat4 read_view_matrix = scene_data.view_matrix;
 	vec2 read_viewport_size = scene_data.viewport_size;
 
+	// GDShader VERTEX function gets inserted here.
 	{
 #CODE : VERTEX
 	}
 
-// using local coordinates (default)
+// Using local coordinates (default).
 #if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
 #ifdef USE_DOUBLE_PRECISION
@@ -427,44 +429,46 @@ void vertex_shader(vec3 vertex_input,
 	vec3 temp_precision; // Will be ignored.
 	vertex += double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
 	vertex = mat3(scene_data.view_matrix) * vertex;
-#else
+#else // USE_DOUBLE_PRECISION
 	vertex = (modelview * vec4(vertex, 1.0)).xyz;
-#endif
+#endif // USE_DOUBLE_PRECISION
+
 #ifdef NORMAL_USED
 	normal = modelview_normal * normal;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
-
 	binormal = modelview_normal * binormal;
 	tangent = modelview_normal * tangent;
-#endif
-#endif // !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
+#endif // TANGENT_USED
 
-//using world coordinates
+#endif // !SKIP_TRANSFORM_USED && !VERTEX_WORLD_COORDS_USED
+
+// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (scene_data.view_matrix * vec4(vertex, 1.0)).xyz;
 #ifdef NORMAL_USED
 	normal = (scene_data.view_matrix * vec4(normal, 0.0)).xyz;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
 	binormal = (scene_data.view_matrix * vec4(binormal, 0.0)).xyz;
 	tangent = (scene_data.view_matrix * vec4(tangent, 0.0)).xyz;
-#endif
-#endif
+#endif // TANGENT_USED
+
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	vertex_interp = vertex;
 
 #ifdef NORMAL_USED
 	normal_interp = normal;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
 	tangent_interp = tangent;
 	binormal_interp = binormal;
-#endif
+#endif // TANGENT_USED
 
 #ifdef MODE_RENDER_DEPTH
 
@@ -472,10 +476,9 @@ void vertex_shader(vec3 vertex_input,
 
 	vertex_interp.z *= scene_data.dual_paraboloid_side;
 
-	dp_clip = vertex_interp.z; //this attempts to avoid noise caused by objects sent to the other parabolloid side due to bias
+	dp_clip = vertex_interp.z; // This attempts to avoid noise caused by objects sent to the other paraboloid side due to bias.
 
-	//for dual paraboloid shadow mapping, this is the fastest but least correct way, as it curves straight edges
-
+	// For dual paraboloid shadow mapping, this is the fastest but least correct way, as it curves straight edges.
 	vec3 vtx = vertex_interp;
 	float distance = length(vtx);
 	vtx = normalize(vtx);
@@ -484,24 +487,25 @@ void vertex_shader(vec3 vertex_input,
 	vtx.z = vtx.z * 2.0 - 1.0;
 	vertex_interp = vtx;
 
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
-#endif //MODE_RENDER_DEPTH
+#endif // MODE_RENDER_DEPTH
 
 #ifdef OVERRIDE_POSITION
 	gl_Position = position;
-#else
+#else // OVERRIDE_POSITION
 	gl_Position = projection_matrix * vec4(vertex_interp, 1.0);
-#endif
+#endif // OVERRIDE_POSITION
 
 #ifdef USE_MULTIVIEW
 	combined_projected = combined_projection * vec4(vertex_interp, 1.0);
-#endif
+#endif // USE_MULTIVIEW
 
 #ifdef MOTION_VECTORS
 	screen_pos = gl_Position;
-#endif
+#endif // MOTION_VECTORS
 
+	// VERTEX LIGHTING //
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 	diffuse_light_interp = vec4(0.0);
 	specular_light_interp = vec4(0.0);
@@ -509,24 +513,19 @@ void vertex_shader(vec3 vertex_input,
 #ifdef USE_MULTIVIEW
 	vec3 view = -normalize(vertex_interp - eye_offset);
 	vec2 clip_pos = clamp((combined_projected.xy / combined_projected.w) * 0.5 + 0.5, 0.0, 1.0);
-#else
+#else // USE_MULTIVIEW
 	vec3 view = -normalize(vertex_interp);
 	vec2 clip_pos = clamp((gl_Position.xy / gl_Position.w) * 0.5 + 0.5, 0.0, 1.0);
-#endif
+#endif // USE_MULTIVIEW
 
 	uvec2 cluster_pos = uvec2(clip_pos / scene_data.screen_pixel_size) >> implementation_data.cluster_shift;
 	uint cluster_offset = (implementation_data.cluster_width * cluster_pos.y + cluster_pos.x) * (implementation_data.max_cluster_element_count_div_32 + 32);
 	uint cluster_z = uint(clamp((-vertex_interp.z / scene_data.z_far) * 32.0, 0.0, 31.0));
 
-	{ //omni lights
-
+	{ // Omni Lights //
 		uint cluster_omni_offset = cluster_offset;
 
-		uint item_min;
-		uint item_max;
-		uint item_from;
-		uint item_to;
-
+		uint item_min, item_max, item_from, item_to;
 		cluster_get_item_range(cluster_omni_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 		for (uint i = item_from; i < item_to; i++) {
@@ -540,11 +539,11 @@ void vertex_shader(vec3 vertex_input,
 				uint light_index = 32 * i + bit;
 
 				if (!bool(omni_lights.data[light_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (omni_lights.data[light_index].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				light_process_omni_vertex(light_index, vertex, view, normal, roughness,
@@ -553,14 +552,10 @@ void vertex_shader(vec3 vertex_input,
 		}
 	}
 
-	{ //spot lights
+	{ // Spot Lights //
 		uint cluster_spot_offset = cluster_offset + implementation_data.cluster_type_size;
 
-		uint item_min;
-		uint item_max;
-		uint item_from;
-		uint item_to;
-
+		uint item_min, item_max, item_from, item_to;
 		cluster_get_item_range(cluster_spot_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 		for (uint i = item_from; i < item_to; i++) {
@@ -575,11 +570,11 @@ void vertex_shader(vec3 vertex_input,
 				uint light_index = 32 * i + bit;
 
 				if (!bool(spot_lights.data[light_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (spot_lights.data[light_index].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				light_process_spot_vertex(light_index, vertex, view, normal, roughness,
@@ -588,7 +583,7 @@ void vertex_shader(vec3 vertex_input,
 		}
 	}
 
-	{ // Directional light.
+	{ // Directional Lights //
 
 		// We process the first directional light separately as it may have shadows.
 		vec3 directional_diffuse = vec3(0.0);
@@ -639,7 +634,7 @@ void vertex_shader(vec3 vertex_input,
 		specular_light_interp.rgb += directional_specular;
 	}
 
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
 
 #ifdef MODE_RENDER_DEPTH
 	if (scene_data.pancake_shadows) {
@@ -647,7 +642,7 @@ void vertex_shader(vec3 vertex_input,
 			gl_Position.z = 0.9999;
 		}
 	}
-#endif
+#endif // MODE_RENDER_DEPTH
 #ifdef MODE_RENDER_MATERIAL
 	if (scene_data.material_uv2_mode) {
 		vec2 uv_offset = unpackHalf2x16(draw_call.uv_offset);
@@ -655,7 +650,7 @@ void vertex_shader(vec3 vertex_input,
 		gl_Position.z = 0.00001;
 		gl_Position.w = 1.0;
 	}
-#endif
+#endif // MODE_RENDER_MATERIAL
 }
 
 void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position, vec3 p_compressed_aabb_size,
@@ -663,16 +658,16 @@ void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position
 		vec4 p_normal_in,
 #ifdef NORMAL_USED
 		out vec3 r_normal,
-#endif
+#endif // NORMAL_USED
 		out vec3 r_tangent,
 		out vec3 r_binormal,
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 		out vec3 r_vertex) {
 
 	r_vertex = p_vertex_in.xyz * p_compressed_aabb_size + p_compressed_aabb_position;
 #ifdef NORMAL_USED
 	r_normal = oct_to_vec3(p_normal_in.xy * 2.0 - 1.0);
-#endif
+#endif // NORMAL_USED
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 
@@ -695,7 +690,7 @@ void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position
 		axis_angle_to_tbn(axis, angle, r_tangent, r_binormal, r_normal);
 		r_binormal *= binormal_sign;
 	}
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 }
 
 void main() {
@@ -709,54 +704,52 @@ void main() {
 	mat4 model_matrix = instances.data[instance_index].transform;
 
 #ifdef MOTION_VECTORS
-	// Previous vertex.
-	vec3 prev_vertex;
+	vec3 prev_vertex; // Previous vertex position.
 #ifdef NORMAL_USED
 	vec3 prev_normal;
-#endif
+#endif // NORMAL_USED
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 	vec3 prev_tangent;
 	vec3 prev_binormal;
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 
 	_unpack_vertex_attributes(
 			previous_vertex_attrib,
 			instances.data[instance_index].compressed_aabb_position_pad.xyz,
 			instances.data[instance_index].compressed_aabb_size_pad.xyz,
-
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 			previous_normal_attrib,
 #ifdef NORMAL_USED
 			prev_normal,
-#endif
+#endif // NORMAL_USED
 			prev_tangent,
 			prev_binormal,
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 			prev_vertex);
 
 	global_time = scene_data_block.prev_data.time;
 	vertex_shader(prev_vertex,
 #ifdef NORMAL_USED
 			prev_normal,
-#endif
+#endif // NORMAL_USED
 #ifdef TANGENT_USED
 			prev_tangent,
 			prev_binormal,
-#endif
+#endif // TANGENT_USED
 			instance_index, draw_call.multimesh_motion_vectors_previous_offset, scene_data_block.prev_data, instances.data[instance_index].prev_transform, prev_screen_position);
-#else
+#else // MOTION_VECTORS
 	// Unused output.
 	vec4 screen_position;
-#endif
+#endif // MOTION_VECTORS
 
 	vec3 vertex;
 #ifdef NORMAL_USED
 	vec3 normal;
-#endif
+#endif // NORMAL_USED
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 	vec3 tangent;
 	vec3 binormal;
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 
 	_unpack_vertex_attributes(
 			vertex_angle_attrib,
@@ -766,10 +759,10 @@ void main() {
 			axis_tangent_attrib,
 #ifdef NORMAL_USED
 			normal,
-#endif
+#endif // NORMAL_USED
 			tangent,
 			binormal,
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 			vertex);
 
 	// Current vertex.
@@ -777,11 +770,11 @@ void main() {
 	vertex_shader(vertex,
 #ifdef NORMAL_USED
 			normal,
-#endif
+#endif // NORMAL_USED
 #ifdef TANGENT_USED
 			tangent,
 			binormal,
-#endif
+#endif // TANGENT_USED
 			instance_index, draw_call.multimesh_motion_vectors_current_offset, scene_data_block.data, model_matrix, screen_position);
 }
 
@@ -794,6 +787,7 @@ void main() {
 #define SHADER_IS_SRGB false
 #define SHADER_SPACE_FAR 0.0
 
+/* Include our Forward+ UBOs, definitions, etc. */
 #include "scene_forward_clustered_inc.glsl"
 
 /* Varyings */
@@ -802,40 +796,38 @@ layout(location = 0) in vec3 vertex_interp;
 
 #ifdef NORMAL_USED
 layout(location = 1) in vec3 normal_interp;
-#endif
+#endif // NORMAL_USED
 
 #if defined(COLOR_USED)
 layout(location = 2) in vec4 color_interp;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 3) in vec2 uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 layout(location = 4) in vec2 uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #ifdef TANGENT_USED
 layout(location = 5) in vec3 tangent_interp;
 layout(location = 6) in vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED
 
 #ifdef MOTION_VECTORS
 layout(location = 7) in vec4 screen_position;
 layout(location = 8) in vec4 prev_screen_position;
-#endif
+#endif // MOTION_VECTORS
 
 #ifdef MODE_DUAL_PARABOLOID
-
 layout(location = 9) in float dp_clip;
-
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 layout(location = 10) in flat uint instance_index_interp;
 
 #ifdef USE_LIGHTMAP
-// w0, w1, w2, and w3 are the four cubic B-spline basis functions
+// w0, w1, w2, and w3 are the four cubic B-spline basis functions.
 float w0(float a) {
 	return (1.0 / 6.0) * (a * (a * (-a + 3.0) - 3.0) + 1.0);
 }
@@ -852,7 +844,7 @@ float w3(float a) {
 	return (1.0 / 6.0) * (a * a * a);
 }
 
-// g0 and g1 are the two amplitude functions
+// g0 and g1 are the two amplitude functions.
 float g0(float a) {
 	return w0(a) + w1(a);
 }
@@ -861,7 +853,7 @@ float g1(float a) {
 	return w2(a) + w3(a);
 }
 
-// h0 and h1 are the two offset functions
+// h0 and h1 are the two offset functions.
 float h0(float a) {
 	return -1.0 + w1(a) / (w0(a) + w1(a));
 }
@@ -893,15 +885,17 @@ vec4 textureArray_bicubic(texture2DArray tex, vec3 uv, vec2 texture_size) {
 	return (g0(fuv.y) * (g0x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p0, uv.z)) + g1x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p1, uv.z)))) +
 			(g1(fuv.y) * (g0x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p2, uv.z)) + g1x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p3, uv.z))));
 }
-#endif //USE_LIGHTMAP
+#endif // USE_LIGHTMAP
 
 #ifdef USE_MULTIVIEW
+
 #ifdef has_VK_KHR_multiview
 #define ViewIndex gl_ViewIndex
 #else // has_VK_KHR_multiview
 // !BAS! This needs to become an input once we implement our fallback!
 #define ViewIndex 0
 #endif // has_VK_KHR_multiview
+
 vec3 multiview_uv(vec2 uv) {
 	return vec3(uv, ViewIndex);
 }
@@ -909,8 +903,10 @@ ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
 layout(location = 11) in vec4 combined_projected;
+
 #else // USE_MULTIVIEW
-// Set to zero, not supported in non stereo
+
+// Set to zero, not supported in non-stereo.
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
@@ -918,27 +914,28 @@ vec2 multiview_uv(vec2 uv) {
 ivec2 multiview_uv(ivec2 uv) {
 	return uv;
 }
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
+
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 layout(location = 12) highp in vec4 diffuse_light_interp;
 layout(location = 13) highp in vec4 specular_light_interp;
-#endif
-//defines to keep compatibility with vertex
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
+// Defines to keep compatibility with vertex.
 
 #ifdef USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix_view[ViewIndex]
 #define inv_projection_matrix scene_data.inv_projection_matrix_view[ViewIndex]
-#else
+#else // USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix
 #define inv_projection_matrix scene_data.inv_projection_matrix
-#endif
+#endif // USE_MULTIVIEW
 
 #define global_time scene_data_block.data.time
 
 #if defined(ENABLE_SSS) && defined(ENABLE_TRANSMITTANCE)
-//both required for transmittance to be enabled
+// Both required for transmittance to be enabled.
 #define LIGHT_TRANSMITTANCE_USED
-#endif
+#endif // ENABLE_SSS && ENABLE_TRANSMITTANCE
 
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
@@ -946,20 +943,20 @@ layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms
 #MATERIAL_UNIFORMS
 } material;
 /* clang-format on */
-#endif
+#endif // MATERIAL_UNIFORMS_USED
+/* clang-format off */
 
 #GLOBALS
 
+/* clang-format on */
 #ifdef MODE_RENDER_DEPTH
 
 #ifdef MODE_RENDER_MATERIAL
-
 layout(location = 0) out vec4 albedo_output_buffer;
 layout(location = 1) out vec4 normal_output_buffer;
 layout(location = 2) out vec4 orm_output_buffer;
 layout(location = 3) out vec4 emission_output_buffer;
 layout(location = 4) out float depth_output_buffer;
-
 #endif // MODE_RENDER_MATERIAL
 
 #ifdef MODE_RENDER_NORMAL_ROUGHNESS
@@ -967,25 +964,24 @@ layout(location = 0) out vec4 normal_roughness_output_buffer;
 
 #ifdef MODE_RENDER_VOXEL_GI
 layout(location = 1) out uvec2 voxel_gi_buffer;
-#endif
+#endif // MODE_RENDER_VOXEL_GI
 
-#endif //MODE_RENDER_NORMAL
-#else // RENDER DEPTH
+#endif // MODE_RENDER_NORMAL_ROUGHNESS
+
+#else // MODE_RENDER_DEPTH
 
 #ifdef MODE_SEPARATE_SPECULAR
-
-layout(location = 0) out vec4 diffuse_buffer; //diffuse (rgb) and roughness
-layout(location = 1) out vec4 specular_buffer; //specular and SSS (subsurface scatter)
-#else
-
+layout(location = 0) out vec4 diffuse_buffer; // Diffuse (RGB), subsurface scattering strength (A).
+layout(location = 1) out vec4 specular_buffer; // Specular (RGB), metalness (A).
+#else // MODE_SEPARATE_SPECULAR
 layout(location = 0) out vec4 frag_color;
 #endif // MODE_SEPARATE_SPECULAR
 
-#endif // RENDER DEPTH
+#endif // MODE_RENDER_DEPTH
 
 #ifdef MOTION_VECTORS
 layout(location = 2) out vec2 motion_vector;
-#endif
+#endif // MOTION_VECTORS
 
 #include "../scene_forward_aa_inc.glsl"
 
@@ -994,13 +990,13 @@ layout(location = 2) out vec2 motion_vector;
 // Default to SPECULAR_SCHLICK_GGX.
 #if !defined(SPECULAR_DISABLED) && !defined(SPECULAR_SCHLICK_GGX) && !defined(SPECULAR_TOON)
 #define SPECULAR_SCHLICK_GGX
-#endif
+#endif // !SPECULAR_DISABLED && !SPECULAR_SCHLICK_GGX && !SPECULAR_TOON
 
 #include "../scene_forward_lights_inc.glsl"
 
 #include "../scene_forward_gi_inc.glsl"
 
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
 #ifndef MODE_RENDER_DEPTH
 
@@ -1021,16 +1017,16 @@ vec4 fog_process(vec3 vertex) {
 	if (scene_data_block.data.fog_aerial_perspective > 0.0) {
 		vec3 sky_fog_color = vec3(0.0);
 		vec3 cube_view = scene_data_block.data.radiance_inverse_xform * vertex;
-		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred
+		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred.
 		float mip_level = mix(1.0 / MAX_ROUGHNESS_LOD, 1.0, 1.0 - (abs(vertex.z) - scene_data_block.data.z_near) / (scene_data_block.data.z_far - scene_data_block.data.z_near));
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(mip_level * MAX_ROUGHNESS_LOD, lod);
 		sky_fog_color = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod)).rgb;
 		sky_fog_color = mix(sky_fog_color, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod + 1)).rgb, blend);
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		sky_fog_color = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), cube_view, mip_level * MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 		fog_color = mix(fog_color, sky_fog_color, scene_data_block.data.fog_aerial_perspective);
 	}
 
@@ -1053,7 +1049,7 @@ vec4 fog_process(vec3 vertex) {
 		float fog_quad_amount = pow(fog_z, scene_data_block.data.fog_depth_curve) * scene_data_block.data.fog_density;
 		fog_amount = fog_quad_amount;
 	} else {
-		fog_amount = 1 - exp(min(0.0, -length(vertex) * scene_data_block.data.fog_density));
+		fog_amount = 1.0 - exp(min(0.0, -length(vertex) * scene_data_block.data.fog_density));
 	}
 
 	if (abs(scene_data_block.data.fog_height_density) >= 0.0001) {
@@ -1075,7 +1071,7 @@ void cluster_get_item_range(uint p_offset, out uint item_min, out uint item_max,
 	item_max = item_min_max >> 16;
 
 	item_from = item_min >> 5;
-	item_to = (item_max == 0) ? 0 : ((item_max - 1) >> 5) + 1; //side effect of how it is stored, as item_max 0 means no elements
+	item_to = (item_max == 0) ? 0 : ((item_max - 1) >> 5) + 1; // Side effect of how it is stored, as item_max 0 means no elements.
 }
 
 uint cluster_get_range_clip_mask(uint i, uint z_min, uint z_max) {
@@ -1084,29 +1080,29 @@ uint cluster_get_range_clip_mask(uint i, uint z_min, uint z_max) {
 	return bitfieldInsert(uint(0), uint(0xFFFFFFFF), local_min, mask_width);
 }
 
-#endif //!MODE_RENDER DEPTH
+#endif // !MODE_RENDER_DEPTH
 
 #if defined(MODE_RENDER_NORMAL_ROUGHNESS) || defined(MODE_RENDER_MATERIAL)
 // https://advances.realtimerendering.com/s2010/Kaplanyan-CryEngine3(SIGGRAPH%202010%20Advanced%20RealTime%20Rendering%20Course).pdf
 vec3 encode24(vec3 v) {
-	// Unsigned normal (handles most symmetry)
+	// Unsigned normal (handles most symmetry).
 	vec3 vNormalUns = abs(v);
-	// Get the major axis for our collapsed cubemap lookup
+	// Get the major axis for our collapsed cubemap lookup.
 	float maxNAbs = max(vNormalUns.z, max(vNormalUns.x, vNormalUns.y));
-	// Get the collapsed cubemap texture coordinates
+	// Get the collapsed cubemap texture coordinates.
 	vec2 vTexCoord = vNormalUns.z < maxNAbs ? (vNormalUns.y < maxNAbs ? vNormalUns.yz : vNormalUns.xz) : vNormalUns.xy;
 	vTexCoord /= maxNAbs;
 	vTexCoord = vTexCoord.x < vTexCoord.y ? vTexCoord.yx : vTexCoord.xy;
 	// Stretch:
 	vTexCoord.y /= vTexCoord.x;
 	float fFittingScale = texture(sampler2D(best_fit_normal_texture, SAMPLER_NEAREST_CLAMP), vTexCoord).r;
-	// Make vector touch unit cube
+	// Make vector touch unit cube.
 	vec3 result = v / maxNAbs;
-	// scale the normal to get the best fit
+	// Scale the normal to get the best fit.
 	result *= fFittingScale;
 	return result;
 }
-#endif // MODE_RENDER_NORMAL_ROUGHNESS
+#endif // MODE_RENDER_NORMAL_ROUGHNESS || MODE_RENDER_MATERIAL
 
 void fragment_shader(in SceneData scene_data) {
 	uint instance_index = instance_index_interp;
@@ -1114,19 +1110,19 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef PREMUL_ALPHA_USED
 	float premul_alpha = 1.0;
 #endif // PREMUL_ALPHA_USED
-	//lay out everything, whatever is unused is optimized away anyway
+	// Lay out everything, whatever is unused is optimized away anyway.
 	vec3 vertex = vertex_interp;
 #ifdef USE_MULTIVIEW
 	vec3 eye_offset = scene_data.eye_offset[ViewIndex].xyz;
 	vec3 view = -normalize(vertex_interp - eye_offset);
 
 	// UV in our combined frustum space is used for certain screen uv processes where it's
-	// overkill to render separate left and right eye views
+	// overkill to render separate left and right eye views.
 	vec2 combined_uv = (combined_projected.xy / combined_projected.w) * 0.5 + 0.5;
-#else
+#else // USE_MULTIVIEW
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
 	vec3 view = -normalize(vertex_interp);
-#endif
+#endif // USE_MULTIVIEW
 	vec3 albedo = vec3(1.0);
 	vec3 backlight = vec3(0.0);
 	vec4 transmittance_color = vec4(0.0, 0.0, 0.0, 1.0);
@@ -1145,12 +1141,14 @@ void fragment_shader(in SceneData scene_data) {
 #ifndef FOG_DISABLED
 	vec4 fog = vec4(0.0);
 #endif // !FOG_DISABLED
+
 #if defined(CUSTOM_RADIANCE_USED)
 	vec4 custom_radiance = vec4(0.0);
-#endif
+#endif // CUSTOM_RADIANCE_USED
+
 #if defined(CUSTOM_IRRADIANCE_USED)
 	vec4 custom_irradiance = vec4(0.0);
-#endif
+#endif // CUSTOM_IRRADIANCE_USED
 
 	float ao = 1.0;
 	float ao_light_affect = 0.0;
@@ -1160,38 +1158,35 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef TANGENT_USED
 	vec3 binormal = normalize(binormal_interp);
 	vec3 tangent = normalize(tangent_interp);
-#else
+#else // TANGENT_USED
 	vec3 binormal = vec3(0.0);
 	vec3 tangent = vec3(0.0);
-#endif
+#endif // TANGENT_USED
 
 #ifdef NORMAL_USED
 	vec3 normal = normalize(normal_interp);
-
 #if defined(DO_SIDE_CHECK)
 	if (!gl_FrontFacing) {
 		normal = -normal;
 	}
-#endif
-
-#endif //NORMAL_USED
+#endif // DO_SIDE_CHECK
+#endif // NORMAL_USED
 
 #ifdef UV_USED
 	vec2 uv = uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	vec2 uv2 = uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(COLOR_USED)
 	vec4 color = color_interp;
-#endif
+#endif // COLOR_USED
 
 #if defined(NORMAL_MAP_USED)
-
 	vec3 normal_map = vec3(0.5);
-#endif
+#endif // NORMAL_MAP_USED
 
 	float normal_map_depth = 1.0;
 
@@ -1221,11 +1216,11 @@ void fragment_shader(in SceneData scene_data) {
 	inv_view_matrix[0][3] = 0.0;
 	inv_view_matrix[1][3] = 0.0;
 	inv_view_matrix[2][3] = 0.0;
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 #ifdef LIGHT_VERTEX_USED
 	vec3 light_vertex = vertex;
-#endif //LIGHT_VERTEX_USED
+#endif // LIGHT_VERTEX_USED
 
 	mat3 model_normal_matrix;
 	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
@@ -1236,22 +1231,24 @@ void fragment_shader(in SceneData scene_data) {
 
 	mat4 read_view_matrix = scene_data.view_matrix;
 	vec2 read_viewport_size = scene_data.viewport_size;
+
+	// GDShader FRAGMENT function gets inserted here.
 	{
 #CODE : FRAGMENT
 	}
-
-#ifdef LIGHT_TRANSMITTANCE_USED
-	transmittance_color.a *= sss_strength;
-#endif
 
 #ifdef LIGHT_VERTEX_USED
 	vertex = light_vertex;
 #ifdef USE_MULTIVIEW
 	view = -normalize(vertex - eye_offset);
-#else
+#else // USE_MULTIVIEW
 	view = -normalize(vertex);
-#endif //USE_MULTIVIEW
-#endif //LIGHT_VERTEX_USED
+#endif // USE_MULTIVIEW
+#endif // LIGHT_VERTEX_USED
+
+#ifdef LIGHT_TRANSMITTANCE_USED
+	transmittance_color.a *= sss_strength;
+#endif // LIGHT_TRANSMITTANCE_USED
 
 #ifndef USE_SHADOW_TO_OPACITY
 
@@ -1261,7 +1258,7 @@ void fragment_shader(in SceneData scene_data) {
 	}
 #endif // ALPHA_SCISSOR_USED
 
-// alpha hash can be used in unison with alpha antialiasing
+// Alpha hash can be used in unison with alpha antialiasing.
 #ifdef ALPHA_HASH_USED
 	vec3 object_pos = (inverse(read_model_matrix) * inv_view_matrix * vec4(vertex, 1.0)).xyz;
 	if (alpha < compute_alpha_hash_threshold(object_pos, alpha_hash_scale)) {
@@ -1269,16 +1266,16 @@ void fragment_shader(in SceneData scene_data) {
 	}
 #endif // ALPHA_HASH_USED
 
-// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash
+// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash.
 #if (defined(ALPHA_SCISSOR_USED) || defined(ALPHA_HASH_USED)) && !defined(ALPHA_ANTIALIASING_EDGE_USED)
 	alpha = 1.0;
-#endif
+#endif // (ALPHA_SCISSOR_USED || ALPHA_HASH_USED) && !ALPHA_ANTIALIASING_EDGE_USED
 
 #ifdef ALPHA_ANTIALIASING_EDGE_USED
-// If alpha scissor is used, we must further the edge threshold, otherwise we won't get any edge feather
+// If alpha scissor is used, we must further the edge threshold, otherwise we won't get any edge feather.
 #ifdef ALPHA_SCISSOR_USED
 	alpha_antialiasing_edge = clamp(alpha_scissor_threshold + alpha_antialiasing_edge, 0.0, 1.0);
-#endif
+#endif // ALPHA_SCISSOR_USED
 	alpha = compute_alpha_antialiasing_edge(alpha, alpha_texture_coordinate, alpha_antialiasing_edge);
 #endif // ALPHA_ANTIALIASING_EDGE_USED
 
@@ -1293,42 +1290,35 @@ void fragment_shader(in SceneData scene_data) {
 #endif // !USE_SHADOW_TO_OPACITY
 
 #ifdef NORMAL_MAP_USED
-
 	normal_map.xy = normal_map.xy * 2.0 - 1.0;
-	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); //always ignore Z, as it can be RG packed, Z may be pos/neg, etc.
+	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); // Always reconstruct Z, as it can be RG packed, Z may be pos/neg, etc.
 
 	normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
-
-#endif
+#endif // NORMAL_MAP_USED
 
 #ifdef LIGHT_ANISOTROPY_USED
-
 	if (anisotropy > 0.01) {
-		//rotation matrix
 		mat3 rot = mat3(tangent, binormal, normal);
-		//make local to space
+		// Make local to space.
 		tangent = normalize(rot * vec3(anisotropy_flow.x, anisotropy_flow.y, 0.0));
 		binormal = normalize(rot * vec3(-anisotropy_flow.y, anisotropy_flow.x, 0.0));
 	}
-
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 
 #ifdef ENABLE_CLIP_ALPHA
 	if (albedo.a < 0.99) {
-		//used for doublepass and shadowmapping
+		// Used for doublepass and shadowmapping.
 		discard;
 	}
-#endif
+#endif // ENABLE_CLIP_ALPHA
 
 	/////////////////////// FOG //////////////////////
 #ifndef MODE_RENDER_DEPTH
 
 #ifndef FOG_DISABLED
 #ifndef CUSTOM_FOG_USED
-	// fog must be processed as early as possible and then packed.
-	// to maximize VGPR usage
+	// Fog must be processed as early as possible and then packed to maximize VGPR usage.
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
-
 	if (scene_data.fog_enabled) {
 		fog = fog_process(vertex);
 	}
@@ -1336,11 +1326,11 @@ void fragment_shader(in SceneData scene_data) {
 	if (implementation_data.volumetric_fog_enabled) {
 #ifdef USE_MULTIVIEW
 		vec4 volumetric_fog = volumetric_fog_process(combined_uv, -vertex.z);
-#else
+#else // USE_MULTIVIEW
 		vec4 volumetric_fog = volumetric_fog_process(screen_uv, -vertex.z);
-#endif
+#endif // USE_MULTIVIEW
 		if (scene_data.fog_enabled) {
-			//must use the full blending equation here to blend fogs
+			// Must use the full blending equation here to blend fogs.
 			vec4 res;
 			float sa = 1.0 - volumetric_fog.a;
 			res.a = fog.a * sa + volumetric_fog.a;
@@ -1354,13 +1344,13 @@ void fragment_shader(in SceneData scene_data) {
 			fog = volumetric_fog;
 		}
 	}
-#endif //!CUSTOM_FOG_USED
+#endif // !CUSTOM_FOG_USED
 
 	uint fog_rg = packHalf2x16(fog.rg);
 	uint fog_ba = packHalf2x16(fog.ba);
 
-#endif //!FOG_DISABLED
-#endif //!MODE_RENDER_DEPTH
+#endif // !FOG_DISABLED
+#endif // !MODE_RENDER_DEPTH
 
 	/////////////////////// DECALS ////////////////////////////////
 
@@ -1368,59 +1358,55 @@ void fragment_shader(in SceneData scene_data) {
 
 #ifdef USE_MULTIVIEW
 	uvec2 cluster_pos = uvec2(combined_uv.xy / scene_data.screen_pixel_size) >> implementation_data.cluster_shift;
-#else
+#else // USE_MULTIVIEW
 	uvec2 cluster_pos = uvec2(gl_FragCoord.xy) >> implementation_data.cluster_shift;
-#endif
+#endif // USE_MULTIVIEW
 	uint cluster_offset = (implementation_data.cluster_width * cluster_pos.y + cluster_pos.x) * (implementation_data.max_cluster_element_count_div_32 + 32);
 
 	uint cluster_z = uint(clamp((-vertex.z / scene_data.z_far) * 32.0, 0.0, 31.0));
 
-	//used for interpolating anything cluster related
+	// Used for interpolating anything cluster related.
 	vec3 vertex_ddx = dFdx(vertex);
 	vec3 vertex_ddy = dFdy(vertex);
 
-	{ // process decals
+	{ // Process Decals //
 
 		uint cluster_decal_offset = cluster_offset + implementation_data.cluster_type_size * 2;
 
-		uint item_min;
-		uint item_max;
-		uint item_from;
-		uint item_to;
-
+		uint item_min, item_max, item_from, item_to;
 		cluster_get_item_range(cluster_decal_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 #ifdef USE_SUBGROUPS
 		item_from = subgroupBroadcastFirst(subgroupMin(item_from));
 		item_to = subgroupBroadcastFirst(subgroupMax(item_to));
-#endif
+#endif // USE_SUBGROUPS
 
 		for (uint i = item_from; i < item_to; i++) {
 			uint mask = cluster_buffer.data[cluster_decal_offset + i];
 			mask &= cluster_get_range_clip_mask(i, item_min, item_max);
 #ifdef USE_SUBGROUPS
 			uint merged_mask = subgroupBroadcastFirst(subgroupOr(mask));
-#else
+#else // USE_SUBGROUPS
 			uint merged_mask = mask;
-#endif
+#endif // USE_SUBGROUPS
 
 			while (merged_mask != 0) {
 				uint bit = findMSB(merged_mask);
 				merged_mask &= ~(1u << bit);
 #ifdef USE_SUBGROUPS
-				if (((1u << bit) & mask) == 0) { //do not process if not originally here
-					continue;
+				if (((1u << bit) & mask) == 0) {
+					continue; // Do not process if not originally here.
 				}
-#endif
+#endif // USE_SUBGROUPS
 				uint decal_index = 32 * i + bit;
 
 				if (!bool(decals.data[decal_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				vec3 uv_local = (decals.data[decal_index].xform * vec4(vertex, 1.0)).xyz;
 				if (any(lessThan(uv_local, vec3(0.0, -1.0, 0.0))) || any(greaterThan(uv_local, vec3(1.0)))) {
-					continue; //out of decal
+					continue; // Out of decal.
 				}
 
 				float fade = pow(1.0 - (uv_local.y > 0.0 ? uv_local.y : -uv_local.y), uv_local.y > 0.0 ? decals.data[decal_index].upper_fade : decals.data[decal_index].lower_fade);
@@ -1429,12 +1415,12 @@ void fragment_shader(in SceneData scene_data) {
 					fade *= smoothstep(decals.data[decal_index].normal_fade, 1.0, dot(normal_interp, decals.data[decal_index].normal) * 0.5 + 0.5);
 				}
 
-				//we need ddx/ddy for mipmaps, so simulate them
+				// We need ddx/ddy for mipmaps, so simulate them.
 				vec2 ddx = (decals.data[decal_index].xform * vec4(vertex_ddx, 0.0)).xz;
 				vec2 ddy = (decals.data[decal_index].xform * vec4(vertex_ddy, 0.0)).xz;
 
 				if (decals.data[decal_index].albedo_rect != vec4(0.0)) {
-					//has albedo
+					// Has albedo.
 					vec4 decal_albedo;
 					if (sc_decal_use_mipmaps()) {
 						decal_albedo = textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].albedo_rect.zw + decals.data[decal_index].albedo_rect.xy, ddx * decals.data[decal_index].albedo_rect.zw, ddy * decals.data[decal_index].albedo_rect.zw);
@@ -1452,9 +1438,9 @@ void fragment_shader(in SceneData scene_data) {
 						} else {
 							decal_normal = textureLod(sampler2D(decal_atlas, decal_sampler), uv_local.xz * decals.data[decal_index].normal_rect.zw + decals.data[decal_index].normal_rect.xy, 0.0).xyz;
 						}
-						decal_normal.xy = decal_normal.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0); //users prefer flipped y normal maps in most authoring software
+						decal_normal.xy = decal_normal.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0); // Users prefer flipped Y normal maps in most authoring software.
 						decal_normal.z = sqrt(max(0.0, 1.0 - dot(decal_normal.xy, decal_normal.xy)));
-						//convert to view space, use xzy because y is up
+						// Convert to view space, use XZY because Y is up.
 						decal_normal = (decals.data[decal_index].normal_xform * decal_normal.xzy).xyz;
 
 						normal = normalize(mix(normal, decal_normal, decal_albedo.a));
@@ -1474,7 +1460,7 @@ void fragment_shader(in SceneData scene_data) {
 				}
 
 				if (decals.data[decal_index].emission_rect != vec4(0.0)) {
-					//emission is additive, so its independent from albedo
+					// Emission is additive, so it's independent from albedo.
 					if (sc_decal_use_mipmaps()) {
 						emission += textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].emission_rect.zw + decals.data[decal_index].emission_rect.xy, ddx * decals.data[decal_index].emission_rect.zw, ddy * decals.data[decal_index].emission_rect.zw).xyz * decals.data[decal_index].modulate.rgb * decals.data[decal_index].emission_energy * fade;
 					} else {
@@ -1484,37 +1470,35 @@ void fragment_shader(in SceneData scene_data) {
 			}
 		}
 	}
+#endif // !MODE_RENDER_DEPTH
 
-	//pack albedo until needed again, saves 2 VGPRs in the meantime
-
-#endif //not render depth
 	/////////////////////// LIGHTING //////////////////////////////
 
 #ifdef NORMAL_USED
 	if (scene_data.roughness_limiter_enabled) {
-		//https://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
+		// https://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
 		float roughness2 = roughness * roughness;
 		vec3 dndu = dFdx(normal), dndv = dFdy(normal);
 		float variance = scene_data.roughness_limiter_amount * (dot(dndu, dndu) + dot(dndv, dndv));
-		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit); //limit effect
+		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit);
 		float filteredRoughness2 = min(1.0, roughness2 + kernelRoughness2);
 		roughness = sqrt(filteredRoughness2);
 	}
-#endif
-	//apply energy conservation
+#endif // NORMAL_USED
 
-	vec3 specular_light = vec3(0.0, 0.0, 0.0);
-	vec3 diffuse_light = vec3(0.0, 0.0, 0.0);
-	vec3 ambient_light = vec3(0.0, 0.0, 0.0);
+	vec3 specular_light = vec3(0.0);
+	vec3 diffuse_light = vec3(0.0);
+	vec3 ambient_light = vec3(0.0);
 #ifndef MODE_UNSHADED
 	// Used in regular draw pass and when drawing SDFs for SDFGI and materials for VoxelGI.
 	emission *= scene_data.emissive_exposure_normalization;
-#endif
+#endif // !MODE_UNSHADED
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #ifndef AMBIENT_LIGHT_DISABLED
 
+	// Global Radiance //
 	if (scene_data.use_reflection_cubemap) {
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1524,25 +1508,23 @@ void fragment_shader(in SceneData scene_data) {
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
 		vec3 ref_vec = reflect(-view, bent_normal);
 		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
-#else
+#else // LIGHT_ANISOTROPY_USED
 		vec3 ref_vec = reflect(-view, normal);
 		ref_vec = mix(ref_vec, normal, roughness * roughness);
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
+
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
-
 		float lod, blend;
-
 		blend = modf(sqrt(roughness) * MAX_ROUGHNESS_LOD, lod);
 		specular_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
 		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
-
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light *= scene_data.IBL_exposure_normalization;
 		specular_light *= horizon * horizon;
 		specular_light *= scene_data.ambient_light_color_energy.a;
@@ -1550,10 +1532,10 @@ void fragment_shader(in SceneData scene_data) {
 
 #if defined(CUSTOM_RADIANCE_USED)
 	specular_light = mix(specular_light, custom_radiance.rgb, custom_radiance.a);
-#endif
+#endif // CUSTOM_RADIANCE_USED
 
 #ifndef USE_LIGHTMAP
-	//lightmap overrides everything
+	// Lightmap overrides everything.
 	if (scene_data.use_ambient_light) {
 		ambient_light = scene_data.ambient_light_color_energy.rgb;
 
@@ -1561,60 +1543,59 @@ void fragment_shader(in SceneData scene_data) {
 			vec3 ambient_dir = scene_data.radiance_inverse_xform * normal;
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 			vec3 cubemap_ambient = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ambient_dir, MAX_ROUGHNESS_LOD)).rgb;
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 			vec3 cubemap_ambient = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ambient_dir, MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 			cubemap_ambient *= scene_data.IBL_exposure_normalization;
 			ambient_light = mix(ambient_light, cubemap_ambient * scene_data.ambient_light_color_energy.a, scene_data.ambient_color_sky_mix);
 		}
 	}
-#endif // USE_LIGHTMAP
+#endif // !USE_LIGHTMAP
+
 #if defined(CUSTOM_IRRADIANCE_USED)
 	ambient_light = mix(ambient_light, custom_irradiance.rgb, custom_irradiance.a);
-#endif
+#endif // CUSTOM_IRRADIANCE_USED
 
 #ifdef LIGHT_CLEARCOAT_USED
 
+	// Note: We want to use geometric normal for clearcoat reflections/BRDF, ie. we ignore the normal map.
 	if (scene_data.use_reflection_cubemap) {
-		vec3 n = normalize(normal_interp); // We want to use geometric normal, not normal_map
+		vec3 n = normalize(normal_interp);
 		float NoV = max(dot(n, view), 0.0001);
 		vec3 ref_vec = reflect(-view, n);
-		// The clear coat layer assumes an IOR of 1.5 (4% reflectance)
+		ref_vec = mix(ref_vec, n, clearcoat_roughness * clearcoat_roughness);
+		// The clear coat layer assumes an IOR of 1.5 (4% reflectance).
 		float Fc = clearcoat * (0.04 + 0.96 * SchlickFresnel(NoV));
 		float attenuation = 1.0 - Fc;
 		ambient_light *= attenuation;
 		specular_light *= attenuation;
 
-		ref_vec = mix(ref_vec, n, clearcoat_roughness * clearcoat_roughness);
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
 		float roughness_lod = mix(0.001, 0.1, sqrt(clearcoat_roughness)) * MAX_ROUGHNESS_LOD;
-#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
+#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(roughness_lod, lod);
 		vec3 clearcoat_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
 		clearcoat_light = mix(clearcoat_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
-
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		vec3 clearcoat_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, roughness_lod).rgb;
-
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light += clearcoat_light * horizon * horizon * Fc * scene_data.ambient_light_color_energy.a;
 	}
 #endif // LIGHT_CLEARCOAT_USED
 #endif // !AMBIENT_LIGHT_DISABLED
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
-	//radiance
 
-/// GI ///
+	/// GI ///
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 #ifndef AMBIENT_LIGHT_DISABLED
 #ifdef USE_LIGHTMAP
 
-	//lightmap
-	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { //has lightmap capture
+	// Lightmapping //
+	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { // Process lightmap capture (L2 SH).
 		uint index = instances.data[instance_index].gi_offset;
 
 		vec3 wnormal = mat3(scene_data.inv_view_matrix) * normal;
@@ -1635,7 +1616,7 @@ void fragment_shader(in SceneData scene_data) {
 								 2.0 * c2 * lightmap_captures.data[index].sh[2].rgb * wnormal.z) *
 				scene_data.emissive_exposure_normalization;
 
-	} else if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // has actual lightmap
+	} else if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // Process lightmap texture.
 		bool uses_sh = bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_SH_LIGHTMAP);
 		uint ofs = instances.data[instance_index].gi_offset & 0xFFFF;
 		uint slice = instances.data[instance_index].gi_offset >> 16;
@@ -1644,12 +1625,9 @@ void fragment_shader(in SceneData scene_data) {
 		uvw.z = float(slice);
 
 		if (uses_sh) {
-			uvw.z *= 4.0; //SH textures use 4 times more data
-			vec3 lm_light_l0;
-			vec3 lm_light_l1n1;
-			vec3 lm_light_l1_0;
-			vec3 lm_light_l1p1;
+			uvw.z *= 4.0; // SH textures use 4 times more data.
 
+			vec3 lm_light_l0, lm_light_l1n1, lm_light_l1_0, lm_light_l1p1;
 			if (sc_use_lightmap_bicubic_filter()) {
 				lm_light_l0 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 0.0), lightmaps.data[ofs].light_texture_size).rgb;
 				lm_light_l1n1 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 1.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
@@ -1678,16 +1656,16 @@ void fragment_shader(in SceneData scene_data) {
 			}
 		}
 	}
-#else
+#else // USE_LIGHTMAP
 
-	if (sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_SDFGI)) { //has lightmap capture
+	if (sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_SDFGI)) { // Process SDFGI.
 
-		//make vertex orientation the world one, but still align to camera
+		// Make vertex orientation the world one, but still align to camera.
 		vec3 cam_pos = mat3(scene_data.inv_view_matrix) * vertex;
 		vec3 cam_normal = mat3(scene_data.inv_view_matrix) * normal;
 		vec3 cam_reflection = mat3(scene_data.inv_view_matrix) * reflect(-view, normal);
 
-		//apply y-mult
+		// Apply y-mult.
 		cam_pos.y *= sdfgi.y_mult;
 		cam_normal.y *= sdfgi.y_mult;
 		cam_normal = normalize(cam_normal);
@@ -1703,7 +1681,7 @@ void fragment_shader(in SceneData scene_data) {
 
 		float blend = -1.0;
 
-		// helper constants, compute once
+		// Helper constants, compute once.
 
 		uint cascade = 0xFFFFFFFF;
 		vec3 cascade_pos;
@@ -1713,7 +1691,7 @@ void fragment_shader(in SceneData scene_data) {
 			cascade_pos = (cam_pos - sdfgi.cascades[i].position) * sdfgi.cascades[i].to_probe;
 
 			if (any(lessThan(cascade_pos, vec3(0.0))) || any(greaterThanEqual(cascade_pos, sdfgi.cascade_probe_size))) {
-				continue; //skip cascade
+				continue; // Skip cascade.
 			}
 
 			cascade = i;
@@ -1727,7 +1705,7 @@ void fragment_shader(in SceneData scene_data) {
 			sdfgi_process(cascade, cascade_pos, cam_pos, cam_normal, cam_reflection, use_specular, roughness, diffuse, specular, blend);
 
 			if (blend > 0.0) {
-				//blend
+				// Blend cascades.
 				if (cascade == sdfgi.max_cascades - 1) {
 					diffuse = mix(diffuse, ambient_light, blend);
 					if (use_specular) {
@@ -1752,14 +1730,14 @@ void fragment_shader(in SceneData scene_data) {
 		}
 	}
 
-	if (sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_VOXEL_GI)) { // process voxel_gi_instances
+	if (sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_VOXEL_GI)) { // Process VoxelGI instances.
 		uint index1 = instances.data[instance_index].gi_offset & 0xFFFF;
 		// Make vertex orientation the world one, but still align to camera.
 		vec3 cam_pos = mat3(scene_data.inv_view_matrix) * vertex;
 		vec3 cam_normal = mat3(scene_data.inv_view_matrix) * normal;
 		vec3 ref_vec = mat3(scene_data.inv_view_matrix) * normalize(reflect(-view, normal));
 
-		//find arbitrary tangent and bitangent, then build a matrix
+		// Find arbitrary tangent and bitangent, then build a matrix.
 		vec3 v0 = abs(cam_normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(0.0, 1.0, 0.0);
 		vec3 tangent = normalize(cross(v0, cam_normal));
 		vec3 bitangent = normalize(cross(tangent, cam_normal));
@@ -1787,10 +1765,9 @@ void fragment_shader(in SceneData scene_data) {
 		ambient_light = amb_accum.rgb;
 	}
 
-	if (!sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_GI_BUFFERS)) { //use GI buffers
+	if (!sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_GI_BUFFERS)) { // Get deferred GI buffers.
 
-		vec2 coord;
-
+		vec2 coord = screen_uv;
 		if (implementation_data.gi_upscale_for_msaa) {
 			vec2 base_coord = screen_uv;
 			vec2 closest_coord = base_coord;
@@ -1815,9 +1792,6 @@ void fragment_shader(in SceneData scene_data) {
 			}
 
 			coord = closest_coord;
-
-		} else {
-			coord = screen_uv;
 		}
 
 #ifdef USE_MULTIVIEW
@@ -1831,36 +1805,32 @@ void fragment_shader(in SceneData scene_data) {
 		ambient_light = mix(ambient_light, buffer_ambient.rgb, buffer_ambient.a);
 		specular_light = mix(specular_light, buffer_reflection.rgb, buffer_reflection.a);
 	}
-#endif // !USE_LIGHTMAP
+#endif // USE_LIGHTMAP
 
 	if (bool(implementation_data.ss_effects_flags & SCREEN_SPACE_EFFECTS_FLAGS_USE_SSAO)) {
 #ifdef USE_MULTIVIEW
 		float ssao = texture(sampler2DArray(ao_buffer, SAMPLER_LINEAR_CLAMP), vec3(screen_uv, ViewIndex)).r;
-#else
+#else // USE_MULTIVIEW
 		float ssao = texture(sampler2D(ao_buffer, SAMPLER_LINEAR_CLAMP), screen_uv).r;
-#endif
+#endif // USE_MULTIVIEW
 		ao = min(ao, ssao);
 		ao_light_affect = mix(ao_light_affect, max(ao_light_affect, implementation_data.ssao_light_affect), implementation_data.ssao_ao_affect);
 	}
 
-	{ // process reflections
+	{ // Reflection Probes //
 
-		vec4 reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
-		vec4 ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
+		vec4 reflection_accum = vec4(0.0);
+		vec4 ambient_accum = vec4(0.0);
 
 		uint cluster_reflection_offset = cluster_offset + implementation_data.cluster_type_size * 3;
 
-		uint item_min;
-		uint item_max;
-		uint item_from;
-		uint item_to;
-
+		uint item_min, item_max, item_from, item_to;
 		cluster_get_item_range(cluster_reflection_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 #ifdef USE_SUBGROUPS
 		item_from = subgroupBroadcastFirst(subgroupMin(item_from));
 		item_to = subgroupBroadcastFirst(subgroupMax(item_to));
-#endif
+#endif // USE_SUBGROUPS
 
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1868,9 +1838,9 @@ void fragment_shader(in SceneData scene_data) {
 		vec3 anisotropic_tangent = cross(anisotropic_direction, view);
 		vec3 anisotropic_normal = cross(anisotropic_tangent, anisotropic_direction);
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
-#else
+#else // LIGHT_ANISOTROPY_USED
 		vec3 bent_normal = normal;
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 		vec3 ref_vec = normalize(reflect(-view, bent_normal));
 		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
 
@@ -1879,22 +1849,22 @@ void fragment_shader(in SceneData scene_data) {
 			mask &= cluster_get_range_clip_mask(i, item_min, item_max);
 #ifdef USE_SUBGROUPS
 			uint merged_mask = subgroupBroadcastFirst(subgroupOr(mask));
-#else
+#else // USE_SUBGROUPS
 			uint merged_mask = mask;
-#endif
+#endif // USE_SUBGROUPS
 
 			while (merged_mask != 0) {
 				uint bit = findMSB(merged_mask);
 				merged_mask &= ~(1u << bit);
 #ifdef USE_SUBGROUPS
-				if (((1u << bit) & mask) == 0) { //do not process if not originally here
-					continue;
+				if (((1u << bit) & mask) == 0) {
+					continue; // Do not process if not originally here.
 				}
-#endif
+#endif // USE_SUBGROUPS
 				uint reflection_index = 32 * i + bit;
 
 				if (!bool(reflections.data[reflection_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
@@ -1909,10 +1879,10 @@ void fragment_shader(in SceneData scene_data) {
 		if (ambient_accum.a > 0.0) {
 			ambient_light = ambient_accum.rgb / ambient_accum.a;
 		}
-#endif
+#endif // !USE_LIGHTMAP
 	}
 
-	//finalize ambient light here
+	// Finalize ambient light.
 	{
 		ambient_light *= albedo.rgb;
 		ambient_light *= ao;
@@ -1920,30 +1890,30 @@ void fragment_shader(in SceneData scene_data) {
 		if (bool(implementation_data.ss_effects_flags & SCREEN_SPACE_EFFECTS_FLAGS_USE_SSIL)) {
 #ifdef USE_MULTIVIEW
 			vec4 ssil = textureLod(sampler2DArray(ssil_buffer, SAMPLER_LINEAR_CLAMP), vec3(screen_uv, ViewIndex), 0.0);
-#else
+#else // USE_MULTIVIEW
 			vec4 ssil = textureLod(sampler2D(ssil_buffer, SAMPLER_LINEAR_CLAMP), screen_uv, 0.0);
 #endif // USE_MULTIVIEW
 			ambient_light *= 1.0 - ssil.a;
 			ambient_light += ssil.rgb * albedo.rgb;
 		}
 	}
-#endif // AMBIENT_LIGHT_DISABLED
-	// convert ao to direct light ao
+#endif // !AMBIENT_LIGHT_DISABLED
+
+	// Convert AO to direct light AO.
 	ao = mix(1.0, ao, ao_light_affect);
 
-	//this saves some VGPRs
+	// This saves some VGPRs.
 	vec3 f0 = F0(metallic, specular, albedo);
+
 #ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
-		//simplify for toon, as
+		// Simplified toon BRDF.
 		specular_light *= specular * metallic * albedo * 2.0;
-#else
-
-		// scales the specular reflections, needs to be computed before lighting happens,
-		// but after environment, GI, and reflection probes are added
-		// Environment brdf approximation (Lazarov 2013)
-		// see https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
+#else // DIFFUSE_TOON
+		// Environment BRDF Approximation (Lazarov 2013)
+		// Scales only indirect reflections, hence is computed before direct lighting happens.
+		// See: https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
 		const vec4 c0 = vec4(-1.0, -0.0275, -0.572, 0.022);
 		const vec4 c1 = vec4(1.0, 0.0425, 1.04, -0.04);
 		vec4 r = roughness * c0 + c1;
@@ -1952,38 +1922,37 @@ void fragment_shader(in SceneData scene_data) {
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 
 		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
-#endif
+#endif // DIFFUSE_TOON
 	}
 
 #endif // !AMBIENT_LIGHT_DISABLED
-#endif //GI !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
+	// End of GI //
 
 #if !defined(MODE_RENDER_DEPTH)
-	//this saves some VGPRs
+	// This saves some VGPRs.
 	uint orms = packUnorm4x8(vec4(ao, roughness, metallic, specular));
-#endif
+#endif // !MODE_RENDER_DEPTH
 
-// LIGHTING
+	// LIGHTING //
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #ifdef USE_VERTEX_LIGHTING
 	diffuse_light += diffuse_light_interp.rgb;
 	specular_light += specular_light_interp.rgb * f0;
-#endif
+#endif // USE_VERTEX_LIGHTING
 
-	{ // Directional light.
-
-		// Do shadow and lighting in two passes to reduce register pressure.
+	{ // Directional Lights //
 #ifndef SHADOWS_DISABLED
+		// Do shadows and lighting in two passes to reduce register pressure.
 		uint shadow0 = 0;
 		uint shadow1 = 0;
 
 		float shadowmask = 1.0;
-
 #ifdef USE_LIGHTMAP
 		uint shadowmask_mode = LIGHTMAP_SHADOWMASK_MODE_NONE;
 
-		if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
+		if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // Get shadowmask texture.
 			const uint ofs = instances.data[instance_index].gi_offset & 0xFFFF;
 			shadowmask_mode = lightmaps.data[ofs].flags;
 
@@ -2006,24 +1975,23 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef USE_VERTEX_LIGHTING
 			// Only process the first light's shadow for vertex lighting.
 			for (uint i = 0; i < 1; i++) {
-#else
-		for (uint i = 0; i < 8; i++) {
-			if (i >= scene_data.directional_light_count) {
-				break;
-			}
-#endif
+#else // USE_VERTEX_LIGHTING
+			for (uint i = 0; i < 8; i++) {
+				if (i >= scene_data.directional_light_count) {
+					break;
+				}
+#endif // USE_VERTEX_LIGHTING
 
 				if (!bool(directional_lights.data[i].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (directional_lights.data[i].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				float shadow = 1.0;
-
-				if (directional_lights.data[i].shadow_opacity > 0.001) {
+				if (directional_lights.data[i].shadow_opacity > 0.001) { // Compute Shadows //
 					float depth_z = -vertex.z;
 					vec3 light_dir = directional_lights.data[i].direction;
 					vec3 base_normal_bias = normalize(normal_interp) * (1.0 - max(0.0, dot(light_dir, -normalize(normal_interp))));
@@ -2034,12 +2002,11 @@ void fragment_shader(in SceneData scene_data) {
 	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
 	m_var.xyz += normal_bias;
 
-					//version with soft shadows, more expensive
-					if (sc_use_directional_soft_shadows() && directional_lights.data[i].softshadow_angle > 0) {
+					if (sc_use_directional_soft_shadows() && directional_lights.data[i].softshadow_angle > 0) { // Soft Shadows //
 						uint blend_count = 0;
 						const uint blend_max = directional_lights.data[i].blend_splits ? 2 : 1;
 
-						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 0)
@@ -2055,7 +2022,7 @@ void fragment_shader(in SceneData scene_data) {
 							blend_count++;
 						}
 
-						if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+						if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 1)
@@ -2071,8 +2038,7 @@ void fragment_shader(in SceneData scene_data) {
 
 							if (blend_count == 0) {
 								shadow = s;
-							} else {
-								//blend
+							} else { // Blend cascades.
 								float blend = smoothstep(0.0, directional_lights.data[i].shadow_split_offsets.x, depth_z);
 								shadow = mix(shadow, s, blend);
 							}
@@ -2080,7 +2046,7 @@ void fragment_shader(in SceneData scene_data) {
 							blend_count++;
 						}
 
-						if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+						if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 2)
@@ -2096,8 +2062,7 @@ void fragment_shader(in SceneData scene_data) {
 
 							if (blend_count == 0) {
 								shadow = s;
-							} else {
-								//blend
+							} else { // Blend cascades.
 								float blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x, directional_lights.data[i].shadow_split_offsets.y, depth_z);
 								shadow = mix(shadow, s, blend);
 							}
@@ -2105,7 +2070,7 @@ void fragment_shader(in SceneData scene_data) {
 							blend_count++;
 						}
 
-						if (blend_count < blend_max) {
+						if (blend_count < blend_max) { // Fourth cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 3)
@@ -2121,26 +2086,25 @@ void fragment_shader(in SceneData scene_data) {
 
 							if (blend_count == 0) {
 								shadow = s;
-							} else {
-								//blend
+							} else { // Blend cascades.
 								float blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y, directional_lights.data[i].shadow_split_offsets.z, depth_z);
 								shadow = mix(shadow, s, blend);
 							}
 						}
 
-					} else { //no soft shadows
+					} else { // Hard Shadows //
 
 						vec4 pssm_coord;
 						float blur_factor;
 
-						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 0)
 
 							pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
 							blur_factor = 1.0;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 1)
@@ -2148,7 +2112,7 @@ void fragment_shader(in SceneData scene_data) {
 							pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 2)
@@ -2156,7 +2120,7 @@ void fragment_shader(in SceneData scene_data) {
 							pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-						} else {
+						} else { // Fourth cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 3)
@@ -2174,21 +2138,21 @@ void fragment_shader(in SceneData scene_data) {
 							float pssm_blend;
 							float blur_factor2;
 
-							if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+							if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First-to-second blend.
 								vec4 v = vec4(vertex, 1.0);
 								BIAS_FUNC(v, 1)
 								pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 								pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x - directional_lights.data[i].shadow_split_offsets.x * 0.1, directional_lights.data[i].shadow_split_offsets.x, depth_z);
 								// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 								blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-							} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+							} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second-to-third blend.
 								vec4 v = vec4(vertex, 1.0);
 								BIAS_FUNC(v, 2)
 								pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 								pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y - directional_lights.data[i].shadow_split_offsets.y * 0.1, directional_lights.data[i].shadow_split_offsets.y, depth_z);
 								// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 								blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-							} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+							} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third-to-fourth blend.
 								vec4 v = vec4(vertex, 1.0);
 								BIAS_FUNC(v, 3)
 								pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
@@ -2196,7 +2160,7 @@ void fragment_shader(in SceneData scene_data) {
 								// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 								blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
 							} else {
-								pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
+								pssm_blend = 0.0; // If no blend, same coord will be used (divide by z will result in same value, and already cached).
 								blur_factor2 = 1.0;
 							}
 
@@ -2209,23 +2173,23 @@ void fragment_shader(in SceneData scene_data) {
 
 #ifdef USE_LIGHTMAP
 					if (shadowmask_mode == LIGHTMAP_SHADOWMASK_MODE_REPLACE) {
-						shadow = mix(shadow, shadowmask, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+						shadow = mix(shadow, shadowmask, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 					} else if (shadowmask_mode == LIGHTMAP_SHADOWMASK_MODE_OVERLAY) {
-						shadow = shadowmask * mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+						shadow = shadowmask * mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 					} else {
-#endif
-						shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+#endif // USE_LIGHTMAP
+						shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 #ifdef USE_LIGHTMAP
 					}
-#endif
+#endif // USE_LIGHTMAP
 
 #ifdef USE_VERTEX_LIGHTING
 					diffuse_light *= mix(1.0, shadow, diffuse_light_interp.a);
 					specular_light *= mix(1.0, shadow, specular_light_interp.a);
-#endif
+#endif // USE_VERTEX_LIGHTING
 
 #undef BIAS_FUNC
-				} // shadows
+				} // End of shadows.
 
 				if (i < 4) {
 					shadow0 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << (i * 8);
@@ -2240,13 +2204,13 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef USE_VERTEX_LIGHTING
 			diffuse_light *= mix(1.0, shadowmask, diffuse_light_interp.a);
 			specular_light *= mix(1.0, shadowmask, specular_light_interp.a);
-#endif
+#endif // USE_VERTEX_LIGHTING
 
 			shadow0 |= uint(clamp(shadowmask * 255.0, 0.0, 255.0));
 		}
 #endif // USE_LIGHTMAP
 
-#endif // SHADOWS_DISABLED
+#endif // !SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
 
@@ -2256,11 +2220,11 @@ void fragment_shader(in SceneData scene_data) {
 			}
 
 			if (!bool(directional_lights.data[i].mask & instances.data[instance_index].layer_mask)) {
-				continue; //not masked
+				continue; // Not masked, skip.
 			}
 
 			if (directional_lights.data[i].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-				continue; // Statically baked light and object uses lightmap, skip
+				continue; // Statically baked light and object uses lightmap, skip.
 			}
 
 #ifdef LIGHT_TRANSMITTANCE_USED
@@ -2324,12 +2288,12 @@ void fragment_shader(in SceneData scene_data) {
 			}
 
 			shadow = mix(1.0, shadow, directional_lights.data[i].shadow_opacity);
-#endif
+#endif // !SHADOWS_DISABLED
 
 			blur_shadow(shadow);
 
-#ifdef DEBUG_DRAW_PSSM_SPLITS
 			vec3 tint = vec3(1.0);
+#ifdef DEBUG_DRAW_PSSM_SPLITS
 			if (-vertex.z < directional_lights.data[i].shadow_split_offsets.x) {
 				tint = vec3(1.0, 0.0, 0.0);
 			} else if (-vertex.z < directional_lights.data[i].shadow_split_offsets.y) {
@@ -2341,180 +2305,166 @@ void fragment_shader(in SceneData scene_data) {
 			}
 			tint = mix(tint, vec3(1.0), shadow);
 			shadow = 1.0;
-#endif
+#endif // DEBUG_DRAW_PSSM_SPLITS
 
 			float size_A = sc_use_directional_soft_shadows() ? directional_lights.data[i].size : 0.0;
 
 			light_compute(normal, directional_lights.data[i].direction, normalize(view), size_A,
-#ifndef DEBUG_DRAW_PSSM_SPLITS
-					directional_lights.data[i].color * directional_lights.data[i].energy,
-#else
 					directional_lights.data[i].color * directional_lights.data[i].energy * tint,
-#endif
 					true, shadow, f0, orms, 1.0, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 					backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 					transmittance_color,
 					transmittance_depth,
 					transmittance_boost,
 					transmittance_z,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 					rim, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 					clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-					binormal,
-					tangent, anisotropy,
-#endif
+					binormal, tangent, anisotropy,
+#endif // LIGHT_ANISOTROPY_USED
 					diffuse_light,
 					specular_light);
 		}
-#endif // USE_VERTEX_LIGHTING
-	}
+#endif // !USE_VERTEX_LIGHTING
+	} // End of directional lights.
 
 #ifndef USE_VERTEX_LIGHTING
-	{ //omni lights
+	{ // Omni Lights //
 
 		uint cluster_omni_offset = cluster_offset;
 
-		uint item_min;
-		uint item_max;
-		uint item_from;
-		uint item_to;
-
+		uint item_min, item_max, item_from, item_to;
 		cluster_get_item_range(cluster_omni_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 #ifdef USE_SUBGROUPS
 		item_from = subgroupBroadcastFirst(subgroupMin(item_from));
 		item_to = subgroupBroadcastFirst(subgroupMax(item_to));
-#endif
+#endif // USE_SUBGROUPS
 
 		for (uint i = item_from; i < item_to; i++) {
 			uint mask = cluster_buffer.data[cluster_omni_offset + i];
 			mask &= cluster_get_range_clip_mask(i, item_min, item_max);
 #ifdef USE_SUBGROUPS
 			uint merged_mask = subgroupBroadcastFirst(subgroupOr(mask));
-#else
+#else // USE_SUBGROUPS
 			uint merged_mask = mask;
-#endif
+#endif // USE_SUBGROUPS
 
 			while (merged_mask != 0) {
 				uint bit = findMSB(merged_mask);
 				merged_mask &= ~(1u << bit);
 #ifdef USE_SUBGROUPS
-				if (((1u << bit) & mask) == 0) { //do not process if not originally here
-					continue;
+				if (((1u << bit) & mask) == 0) {
+					continue; // Do not process if not originally here.
 				}
-#endif
+#endif // USE_SUBGROUPS
 				uint light_index = 32 * i + bit;
 
 				if (!bool(omni_lights.data[light_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (omni_lights.data[light_index].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				light_process_omni(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, scene_data.taa_frame_count, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 						backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 						transmittance_color,
 						transmittance_depth,
 						transmittance_boost,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 						rim,
 						rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 						clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 						tangent, binormal, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 						diffuse_light, specular_light);
 			}
 		}
-	}
+	} // End of omni lights.
 
-	{ //spot lights
+	{ // Spot Lights //
 
 		uint cluster_spot_offset = cluster_offset + implementation_data.cluster_type_size;
 
-		uint item_min;
-		uint item_max;
-		uint item_from;
-		uint item_to;
-
+		uint item_min, item_max, item_from, item_to;
 		cluster_get_item_range(cluster_spot_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 #ifdef USE_SUBGROUPS
 		item_from = subgroupBroadcastFirst(subgroupMin(item_from));
 		item_to = subgroupBroadcastFirst(subgroupMax(item_to));
-#endif
+#endif // USE_SUBGROUPS
 
 		for (uint i = item_from; i < item_to; i++) {
 			uint mask = cluster_buffer.data[cluster_spot_offset + i];
 			mask &= cluster_get_range_clip_mask(i, item_min, item_max);
 #ifdef USE_SUBGROUPS
 			uint merged_mask = subgroupBroadcastFirst(subgroupOr(mask));
-#else
+#else // USE_SUBGROUPS
 			uint merged_mask = mask;
-#endif
+#endif // USE_SUBGROUPS
 
 			while (merged_mask != 0) {
 				uint bit = findMSB(merged_mask);
 				merged_mask &= ~(1u << bit);
 #ifdef USE_SUBGROUPS
-				if (((1u << bit) & mask) == 0) { //do not process if not originally here
-					continue;
+				if (((1u << bit) & mask) == 0) {
+					continue; // Do not process if not originally here.
 				}
-#endif
+#endif // USE_SUBGROUPS
 
 				uint light_index = 32 * i + bit;
 
 				if (!bool(spot_lights.data[light_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (spot_lights.data[light_index].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				light_process_spot(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, scene_data.taa_frame_count, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 						backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 						transmittance_color,
 						transmittance_depth,
 						transmittance_boost,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 						rim,
 						rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 						clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-						tangent,
-						binormal, anisotropy,
-#endif
+						tangent, binormal, anisotropy,
+#endif // LIGHT_ANISOTROPY_USED
 						diffuse_light, specular_light);
 			}
 		}
-	}
+	} // End of spot lights.
 #endif // !USE_VERTEX_LIGHTING
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
 #ifdef USE_SHADOW_TO_OPACITY
 #ifndef MODE_RENDER_DEPTH
@@ -2537,7 +2487,7 @@ void fragment_shader(in SceneData scene_data) {
 		vec3 local_pos = (implementation_data.sdf_to_bounds * vec4(vertex, 1.0)).xyz;
 		ivec3 grid_pos = implementation_data.sdf_offset + ivec3(local_pos * vec3(implementation_data.sdf_size));
 
-		uint albedo16 = 0x1; //solid flag
+		uint albedo16 = 0x1; // Solid flag.
 		albedo16 |= clamp(uint(albedo.r * 31.0), 0, 31) << 11;
 		albedo16 |= clamp(uint(albedo.g * 31.0), 0, 31) << 6;
 		albedo16 |= clamp(uint(albedo.b * 31.0), 0, 31) << 1;
@@ -2566,10 +2516,10 @@ void fragment_shader(in SceneData scene_data) {
 		}
 
 #ifdef NO_IMAGE_ATOMICS
-		imageStore(geom_facing_grid, grid_pos, uvec4(imageLoad(geom_facing_grid, grid_pos).r | facing_bits)); //store facing bits
-#else
-		imageAtomicOr(geom_facing_grid, grid_pos, facing_bits); //store facing bits
-#endif
+		imageStore(geom_facing_grid, grid_pos, uvec4(imageLoad(geom_facing_grid, grid_pos).r | facing_bits)); // Store facing bits.
+#else // NO_IMAGE_ATOMICS
+		imageAtomicOr(geom_facing_grid, grid_pos, facing_bits); // Store facing bits.
+#endif // NO_IMAGE_ATOMICS
 
 		if (length(emission) > 0.001) {
 			float lumas[6];
@@ -2590,7 +2540,7 @@ void fragment_shader(in SceneData scene_data) {
 				light_aniso |= min(31, uint((lumas[i] / luma_total) * 31.0)) << (i * 5);
 			}
 
-			//compress to RGBE9995 to save space
+			// Compress to RGBE9995 to save space.
 
 			const float pow2to9 = 512.0f;
 			const float B = 15.0f;
@@ -2616,7 +2566,7 @@ void fragment_shader(in SceneData scene_data) {
 			float sRed = floor((cRed / pow(2.0f, exps - B - N)) + 0.5f);
 			float sGreen = floor((cGreen / pow(2.0f, exps - B - N)) + 0.5f);
 			float sBlue = floor((cBlue / pow(2.0f, exps - B - N)) + 0.5f);
-			//store as 8985 to have 2 extra neighbor bits
+			// Store as 8985 to have 2 extra neighbor bits.
 			uint light_rgbe = ((uint(sRed) & 0x1FFu) >> 1) | ((uint(sGreen) & 0x1FFu) << 8) | (((uint(sBlue) & 0x1FFu) >> 1) << 17) | ((uint(exps) & 0x1Fu) << 25);
 
 			imageStore(emission_grid, grid_pos, uvec4(light_rgbe));
@@ -2624,10 +2574,9 @@ void fragment_shader(in SceneData scene_data) {
 		}
 	}
 
-#endif
+#endif // MODE_RENDER_SDF
 
 #ifdef MODE_RENDER_MATERIAL
-
 	albedo_output_buffer.rgb = albedo;
 	albedo_output_buffer.a = alpha;
 
@@ -2642,12 +2591,12 @@ void fragment_shader(in SceneData scene_data) {
 
 	emission_output_buffer.rgb = emission;
 	emission_output_buffer.a = 0.0;
-#endif
+#endif // MODE_RENDER_MATERIAL
 
 #ifdef MODE_RENDER_NORMAL_ROUGHNESS
 	normal_roughness_output_buffer = vec4(encode24(normal) * 0.5 + 0.5, roughness);
 
-	// We encode the dynamic static into roughness.
+	// We encode the dynamic/static flag into roughness.
 	// Values over 0.5 are dynamic, under 0.5 are static.
 	normal_roughness_output_buffer.w = normal_roughness_output_buffer.w * (127.0 / 255.0);
 	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_DYNAMIC)) {
@@ -2656,7 +2605,7 @@ void fragment_shader(in SceneData scene_data) {
 	normal_roughness_output_buffer.w = normal_roughness_output_buffer.w;
 
 #ifdef MODE_RENDER_VOXEL_GI
-	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_VOXEL_GI)) { // process voxel_gi_instances
+	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_VOXEL_GI)) { // Process VoxelGI instances.
 		uint index1 = instances.data[instance_index].gi_offset & 0xFFFF;
 		uint index2 = instances.data[instance_index].gi_offset >> 16;
 		voxel_gi_buffer.x = index1 & 0xFFu;
@@ -2665,70 +2614,68 @@ void fragment_shader(in SceneData scene_data) {
 		voxel_gi_buffer.x = 0xFF;
 		voxel_gi_buffer.y = 0xFF;
 	}
-#endif
+#endif // MODE_RENDER_VOXEL_GI
 
-#endif //MODE_RENDER_NORMAL_ROUGHNESS
+#endif // MODE_RENDER_NORMAL_ROUGHNESS
 
-//nothing happens, so a tree-ssa optimizer will result in no fragment shader :)
-#else
+// Nothing happens, so a tree-ssa optimizer will result in no fragment shader :)
+#else // MODE_RENDER_DEPTH
 
-	// multiply by albedo
-	diffuse_light *= albedo; // ambient must be multiplied by albedo at the end
+	// Multiply by albedo.
+	diffuse_light *= albedo; // Ambient must be multiplied by albedo at the end.
 
-	// apply direct light AO
+	// Apply direct light AO.
 	ao = unpackUnorm4x8(orms).x;
 	specular_light *= ao;
 	diffuse_light *= ao;
 
-	// apply metallic
+	// Apply metallic.
 	metallic = unpackUnorm4x8(orms).z;
 	diffuse_light *= 1.0 - metallic;
 	ambient_light *= 1.0 - metallic;
 
 #ifndef FOG_DISABLED
-	//restore fog
+	// Restore fog.
 	fog = vec4(unpackHalf2x16(fog_rg), unpackHalf2x16(fog_ba));
-#endif //!FOG_DISABLED
+#endif // !FOG_DISABLED
 
 #ifdef MODE_SEPARATE_SPECULAR
 
 #ifdef MODE_UNSHADED
 	diffuse_buffer = vec4(albedo.rgb, 0.0);
 	specular_buffer = vec4(0.0);
-
-#else
-
+#else // MODE_UNSHADED
 #ifdef SSS_MODE_SKIN
 	sss_strength = -sss_strength;
-#endif
+#endif // SSS_MODE_SKIN
 	diffuse_buffer = vec4(emission + diffuse_light + ambient_light, sss_strength);
 	specular_buffer = vec4(specular_light, metallic);
-#endif
+#endif // MODE_UNSHADED
 
 #ifndef FOG_DISABLED
 	diffuse_buffer.rgb = mix(diffuse_buffer.rgb, fog.rgb, fog.a);
 	specular_buffer.rgb = mix(specular_buffer.rgb, vec3(0.0), fog.a);
-#endif //!FOG_DISABLED
+#endif // !FOG_DISABLED
 
-#else //MODE_SEPARATE_SPECULAR
+#else // MODE_SEPARATE_SPECULAR
 
 	alpha *= scene_data.pass_alpha_multiplier;
 
 #ifdef MODE_UNSHADED
 	frag_color = vec4(albedo, alpha);
-#else
+#else // MODE_UNSHADED
 	frag_color = vec4(emission + ambient_light + diffuse_light + specular_light, alpha);
-//frag_color = vec4(1.0);
-#endif //USE_NO_SHADING
+#endif // MODE_UNSHADED
 
 #ifndef FOG_DISABLED
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
 	frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a);
-#endif //!FOG_DISABLED
+#endif // !FOG_DISABLED
 
-#endif //MODE_SEPARATE_SPECULAR
+#endif // MODE_SEPARATE_SPECULAR
 
-#endif //MODE_RENDER_DEPTH
+#endif // MODE_RENDER_DEPTH
+
 #ifdef MOTION_VECTORS
 	vec2 position_clip = (screen_position.xy / screen_position.w) - scene_data.taa_jitter;
 	vec2 prev_position_clip = (prev_screen_position.xy / prev_screen_position.w) - scene_data_block.prev_data.taa_jitter;
@@ -2737,11 +2684,11 @@ void fragment_shader(in SceneData scene_data) {
 	vec2 prev_position_uv = prev_position_clip * vec2(0.5, 0.5);
 
 	motion_vector = prev_position_uv - position_uv;
-#endif
+#endif // MOTION_VECTORS
 
 #if defined(PREMUL_ALPHA_USED) && !defined(MODE_RENDER_DEPTH)
 	frag_color.rgb *= premul_alpha;
-#endif //PREMUL_ALPHA_USED
+#endif // PREMUL_ALPHA_USED && !MODE_RENDER_DEPTH
 }
 
 void main() {
@@ -2752,12 +2699,11 @@ void main() {
 	} else if (uc_cull_mode() == POLYGON_CULL_FRONT && front_facing) {
 		discard;
 	}
-#endif
+#endif // UBERSHADER
 #ifdef MODE_DUAL_PARABOLOID
-
 	if (dp_clip > 0.0)
 		discard;
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 	fragment_shader(scene_data_block.data);
 }

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -4,7 +4,7 @@
 
 #VERSION_DEFINES
 
-/* Include our forward mobile UBOs definitions etc. */
+/* Include our Forward Mobile UBOs, definitions, etc. */
 #include "scene_forward_mobile_inc.glsl"
 
 #define SHADER_IS_SRGB false
@@ -15,50 +15,50 @@
 // Always contains vertex position in XYZ, can contain tangent angle in W.
 layout(location = 0) in vec4 vertex_angle_attrib;
 
-//only for pure render depth when normal is not used
+// Only for pure render depth when normal is not used.
 
-#ifdef NORMAL_USED
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
 // Contains Normal/Axis in RG, can contain tangent in BA.
 layout(location = 1) in vec4 axis_tangent_attrib;
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 
 // Location 2 is unused.
 
 #if defined(COLOR_USED)
 layout(location = 3) in vec4 color_attrib;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 4) in vec2 uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP) || defined(MODE_RENDER_MATERIAL)
 layout(location = 5) in vec2 uv2_attrib;
-#endif // MODE_RENDER_MATERIAL
+#endif // UV2_USED || USE_LIGHTMAP || MODE_RENDER_MATERIAL
 
 #if defined(CUSTOM0_USED)
 layout(location = 6) in vec4 custom0_attrib;
-#endif
+#endif // CUSTOM0_USED
 
 #if defined(CUSTOM1_USED)
 layout(location = 7) in vec4 custom1_attrib;
-#endif
+#endif // CUSTOM1_USED
 
 #if defined(CUSTOM2_USED)
 layout(location = 8) in vec4 custom2_attrib;
-#endif
+#endif // CUSTOM2_USED
 
 #if defined(CUSTOM3_USED)
 layout(location = 9) in vec4 custom3_attrib;
-#endif
+#endif // CUSTOM3_USED
 
 #if defined(BONES_USED) || defined(USE_PARTICLE_TRAILS)
 layout(location = 10) in uvec4 bone_attrib;
-#endif
+#endif // BONES_USED || USE_PARTICLE_TRAILS
 
 #if defined(WEIGHTS_USED) || defined(USE_PARTICLE_TRAILS)
 layout(location = 11) in vec4 weight_attrib;
-#endif
+#endif // WEIGHTS_USED || USE_PARTICLE_TRAILS
 
 vec3 oct_to_vec3(vec2 e) {
 	vec3 v = vec3(e.xy, 1.0 - abs(e.x) - abs(e.y));
@@ -95,47 +95,48 @@ layout(location = 3) mediump out vec2 uv_interp;
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 layout(location = 4) mediump out vec2 uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 layout(location = 5) mediump out vec3 tangent_interp;
 layout(location = 6) mediump out vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 layout(location = 7) highp out vec4 diffuse_light_interp;
 layout(location = 8) highp out vec4 specular_light_interp;
 
 #include "../scene_forward_vertex_lights_inc.glsl"
-#endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
 /* clang-format on */
-#endif
+#endif // MATERIAL_UNIFORMS_USED
 
 #ifdef MODE_DUAL_PARABOLOID
-
 layout(location = 9) out highp float dp_clip;
-
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 #ifdef USE_MULTIVIEW
+
 #ifdef has_VK_KHR_multiview
 #define ViewIndex gl_ViewIndex
-#else
+#else // has_VK_KHR_multiview
 // !BAS! This needs to become an input once we implement our fallback!
 #define ViewIndex 0
-#endif
+#endif // has_VK_KHR_multiview
 vec3 multiview_uv(vec2 uv) {
 	return vec3(uv, ViewIndex);
 }
 ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
-#else
-// Set to zero, not supported in non stereo
+
+#else // USE_MULTIVIEW
+
+// Set to zero, not supported in non-stereo.
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
@@ -143,12 +144,15 @@ vec2 multiview_uv(vec2 uv) {
 ivec2 multiview_uv(ivec2 uv) {
 	return uv;
 }
-#endif //USE_MULTIVIEW
+
+#endif // USE_MULTIVIEW
 
 invariant gl_Position;
+/* clang-format off */
 
 #GLOBALS
 
+/* clang-format on */
 #define scene_data scene_data_block.data
 
 #ifdef USE_DOUBLE_PRECISION
@@ -176,7 +180,7 @@ vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec
 	s = quick_two_sum(s, se, out_precision);
 	return s;
 }
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 uint multimesh_stride() {
 	uint stride = sc_multimesh_format_2d() ? 2 : 3;
@@ -189,7 +193,7 @@ void main() {
 	vec4 instance_custom = vec4(0.0);
 #if defined(COLOR_USED)
 	color_interp = color_attrib;
-#endif
+#endif // COLOR_USED
 
 	mat4 model_matrix = instances.data[draw_call.instance_index].transform;
 	mat4 inv_view_matrix = scene_data.inv_view_matrix;
@@ -203,7 +207,7 @@ void main() {
 	inv_view_matrix[0][3] = 0.0;
 	inv_view_matrix[1][3] = 0.0;
 	inv_view_matrix[2][3] = 0.0;
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 	mat3 model_normal_matrix;
 	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
@@ -215,54 +219,52 @@ void main() {
 	mat4 matrix;
 	mat4 read_model_matrix = model_matrix;
 
-	if (sc_multimesh()) {
-		//multimesh, instances are for it
-
+	if (sc_multimesh()) { // Multimesh, instances are for it.
 #ifdef USE_PARTICLE_TRAILS
 		uint trail_size = (instances.data[draw_call.instance_index].flags >> INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT) & INSTANCE_FLAGS_PARTICLE_TRAIL_MASK;
-		uint stride = 3 + 1 + 1; //particles always uses this format
+		uint stride = 3 + 1 + 1; // Particles always use this format.
 
 		uint offset = trail_size * stride * gl_InstanceIndex;
 
 #ifdef COLOR_USED
 		vec4 pcolor;
-#endif
+#endif // COLOR_USED
 		{
 			uint boffset = offset + bone_attrib.x * stride;
 			matrix = mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.x;
 #ifdef COLOR_USED
 			pcolor = transforms.data[boffset + 3] * weight_attrib.x;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.y > 0.001) {
 			uint boffset = offset + bone_attrib.y * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.y;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.y;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.z > 0.001) {
 			uint boffset = offset + bone_attrib.z * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.z;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.z;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.w > 0.001) {
 			uint boffset = offset + bone_attrib.w * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.w;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.w;
-#endif
+#endif // COLOR_USED
 		}
 
 		instance_custom = transforms.data[offset + 4];
 
 #ifdef COLOR_USED
 		color_interp *= pcolor;
-#endif
+#endif // COLOR_USED
 
-#else
+#else // USE_PARTICLE_TRAILS
 		uint stride = multimesh_stride();
 		uint offset = stride * gl_InstanceIndex;
 
@@ -277,39 +279,35 @@ void main() {
 		if (sc_multimesh_has_color()) {
 #ifdef COLOR_USED
 			color_interp *= transforms.data[offset];
-#endif
+#endif // COLOR_USED
 			offset += 1;
 		}
 
 		if (sc_multimesh_has_custom_data()) {
 			instance_custom = transforms.data[offset];
 		}
+#endif // USE_PARTICLE_TRAILS
 
-#endif
-		//transpose
 		matrix = transpose(matrix);
-
 #if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
 		// Normally we can bake the multimesh transform into the model matrix, but when using double precision
 		// we avoid baking it in so we can emulate high precision.
 		read_model_matrix = model_matrix * matrix;
 #if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
 		model_matrix = read_model_matrix;
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
+#endif // !USE_DOUBLE_PRECISION || SKIP_TRANSFORM_USED || VERTEX_WORLD_COORDS_USED
+#endif // !USE_DOUBLE_PRECISION || SKIP_TRANSFORM_USED || VERTEX_WORLD_COORDS_USED || MODEL_MATRIX_USED
 		model_normal_matrix = model_normal_matrix * mat3(matrix);
 	}
 
 	vec3 vertex = vertex_angle_attrib.xyz * instances.data[draw_call.instance_index].compressed_aabb_size_pad.xyz + instances.data[draw_call.instance_index].compressed_aabb_position_pad.xyz;
 #ifdef NORMAL_USED
 	vec3 normal = oct_to_vec3(axis_tangent_attrib.xy * 2.0 - 1.0);
-#endif
+#endif // NORMAL_USED
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-
-	vec3 binormal;
+	vec3 tangent, binormal;
 	float binormal_sign;
-	vec3 tangent;
 	if (axis_tangent_attrib.z > 0.0 || axis_tangent_attrib.w < 1.0) {
 		// Uncompressed format.
 		vec2 signed_tangent_attrib = axis_tangent_attrib.zw * 2.0 - 1.0;
@@ -320,62 +318,61 @@ void main() {
 		// Compressed format.
 		float angle = vertex_angle_attrib.w;
 		binormal_sign = angle > 0.5 ? 1.0 : -1.0; // 0.5 does not exist in UNORM16, so values are either greater or smaller.
-		angle = abs(angle * 2.0 - 1.0) * M_PI; // 0.5 is basically zero, allowing to encode both signs reliably.
+		angle = abs(angle * 2.0 - 1.0) * M_PI; // 0.5 is basically zero, allowing us to encode both signs reliably.
 		vec3 axis = normal;
 		axis_angle_to_tbn(axis, angle, tangent, binormal, normal);
 		binormal *= binormal_sign;
 	}
-#endif
+#endif // NORMAL_USED || TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #ifdef UV_USED
 	uv_interp = uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	uv2_interp = uv2_attrib;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 	vec4 uv_scale = instances.data[draw_call.instance_index].uv_scale;
 
-	if (uv_scale != vec4(0.0)) { // Compression enabled
+	if (uv_scale != vec4(0.0)) { // Compression enabled.
 #ifdef UV_USED
 		uv_interp = (uv_interp - 0.5) * uv_scale.xy;
-#endif
+#endif // UV_USED
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 		uv2_interp = (uv2_interp - 0.5) * uv_scale.zw;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 	}
 
 #ifdef OVERRIDE_POSITION
 	vec4 position = vec4(1.0);
-#endif
+#endif // OVERRIDE_POSITION
 
 #ifdef USE_MULTIVIEW
 	mat4 projection_matrix = scene_data.projection_matrix_view[ViewIndex];
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix_view[ViewIndex];
 	vec3 eye_offset = scene_data.eye_offset[ViewIndex].xyz;
-#else
+#else // USE_MULTIVIEW
 	mat4 projection_matrix = scene_data.projection_matrix;
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix;
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
 
-//using world coordinates
+	// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (model_matrix * vec4(vertex, 1.0)).xyz;
 
 #ifdef NORMAL_USED
 	normal = model_normal_matrix * normal;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-
 	tangent = model_normal_matrix * tangent;
 	binormal = model_normal_matrix * binormal;
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
-#endif
-#endif
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	float roughness = 1.0;
 
@@ -384,11 +381,12 @@ void main() {
 	mat4 read_view_matrix = scene_data.view_matrix;
 	vec2 read_viewport_size = scene_data.viewport_size;
 
+	// GDShader VERTEX function gets inserted here.
 	{
 #CODE : VERTEX
 	}
 
-// using local coordinates (default)
+	// Using local coordinates (default).
 #if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
 #ifdef USE_DOUBLE_PRECISION
@@ -401,70 +399,76 @@ void main() {
 		model_origin = double_add_vec3(model_origin, model_precision, matrix[3].xyz, vec3(0.0), model_precision);
 	}
 	vertex = mat3(inv_view_matrix * modelview) * vertex;
-	vec3 temp_precision;
+	vec3 temp_precision; // Will be ignored.
 	vertex += double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
 	vertex = mat3(scene_data.view_matrix) * vertex;
-#else
+#else // USE_DOUBLE_PRECISION
 	vertex = (modelview * vec4(vertex, 1.0)).xyz;
-#endif
+#endif // USE_DOUBLE_PRECISION
+
 #ifdef NORMAL_USED
 	normal = modelview_normal * normal;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-
 	binormal = modelview_normal * binormal;
 	tangent = modelview_normal * tangent;
-#endif
-#endif // !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
-//using world coordinates
+#endif // !SKIP_TRANSFORM_USED && !VERTEX_WORLD_COORDS_USED
+
+	// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (scene_data.view_matrix * vec4(vertex, 1.0)).xyz;
 #ifdef NORMAL_USED
 	normal = (scene_data.view_matrix * vec4(normal, 0.0)).xyz;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	binormal = (scene_data.view_matrix * vec4(binormal, 0.0)).xyz;
 	tangent = (scene_data.view_matrix * vec4(tangent, 0.0)).xyz;
-#endif
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
+
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	vertex_interp = vertex;
+
 #ifdef NORMAL_USED
 	normal_interp = normalize(normal);
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	tangent_interp = normalize(tangent);
 	binormal_interp = normalize(binormal);
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
-// VERTEX LIGHTING
+	// VERTEX LIGHTING //
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
-#ifdef USE_MULTIVIEW
-	vec3 view = -normalize(vertex_interp - eye_offset);
-#else
-	vec3 view = -normalize(vertex_interp);
-#endif
-
 	diffuse_light_interp = vec4(0.0);
 	specular_light_interp = vec4(0.0);
 
+#ifdef USE_MULTIVIEW
+	vec3 view = -normalize(vertex_interp - eye_offset);
+#else // USE_MULTIVIEW
+	vec3 view = -normalize(vertex_interp);
+#endif // USE_MULTIVIEW
+
+	// Omni Lights //
 	uvec2 omni_light_indices = instances.data[draw_call.instance_index].omni_lights;
 	for (uint i = 0; i < sc_omni_lights(); i++) {
 		uint light_index = (i > 3) ? ((omni_light_indices.y >> ((i - 4) * 8)) & 0xFF) : ((omni_light_indices.x >> (i * 8)) & 0xFF);
 		light_process_omni_vertex(light_index, vertex, view, normal_interp, roughness, diffuse_light_interp.rgb, specular_light_interp.rgb);
 	}
 
+	// Spot Lights //
 	uvec2 spot_light_indices = instances.data[draw_call.instance_index].spot_lights;
 	for (uint i = 0; i < sc_spot_lights(); i++) {
 		uint light_index = (i > 3) ? ((spot_light_indices.y >> ((i - 4) * 8)) & 0xFF) : ((spot_light_indices.x >> (i * 8)) & 0xFF);
 		light_process_spot_vertex(light_index, vertex, view, normal_interp, roughness, diffuse_light_interp.rgb, specular_light_interp.rgb);
 	}
 
+	// Directional Lights //
 	if (sc_directional_lights() > 0) {
 		// We process the first directional light separately as it may have shadows.
 		vec3 directional_diffuse = vec3(0.0);
@@ -515,15 +519,14 @@ void main() {
 		specular_light_interp.rgb += directional_specular;
 	}
 
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
 
 #ifdef MODE_RENDER_DEPTH
 
 #ifdef MODE_DUAL_PARABOLOID
-
 	vertex_interp.z *= scene_data.dual_paraboloid_side;
 
-	dp_clip = vertex_interp.z; //this attempts to avoid noise caused by objects sent to the other parabolloid side due to bias
+	dp_clip = vertex_interp.z; // This attempts to avoid noise caused by objects sent to the other paraboloid side due to bias.
 
 	//for dual paraboloid shadow mapping, this is the fastest but least correct way, as it curves straight edges
 
@@ -534,14 +537,13 @@ void main() {
 	vtx.z = (distance / scene_data.z_far);
 	vtx.z = vtx.z * 2.0 - 1.0;
 	vertex_interp = vtx;
+#endif // MODE_DUAL_PARABOLOID
 
-#endif
-
-#endif //MODE_RENDER_DEPTH
+#endif // MODE_RENDER_DEPTH
 
 #ifdef OVERRIDE_POSITION
 	gl_Position = position;
-#else
+#else // OVERRIDE_POSITION
 	gl_Position = projection_matrix * vec4(vertex_interp, 1.0);
 #endif // OVERRIDE_POSITION
 
@@ -570,7 +572,7 @@ void main() {
 #define SHADER_IS_SRGB false
 #define SHADER_SPACE_FAR 0.0
 
-/* Include our forward mobile UBOs definitions etc. */
+/* Include our Forward Mobile UBOs, definitions, etc. */
 #include "scene_forward_mobile_inc.glsl"
 
 /* Varyings */
@@ -579,38 +581,36 @@ layout(location = 0) highp in vec3 vertex_interp;
 
 #ifdef NORMAL_USED
 layout(location = 1) mediump in vec3 normal_interp;
-#endif
+#endif // NORMAL_USED
 
 #if defined(COLOR_USED)
 layout(location = 2) mediump in vec4 color_interp;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 3) mediump in vec2 uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 layout(location = 4) mediump in vec2 uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 layout(location = 5) mediump in vec3 tangent_interp;
 layout(location = 6) mediump in vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 layout(location = 7) highp in vec4 diffuse_light_interp;
 layout(location = 8) highp in vec4 specular_light_interp;
-#endif
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
 
 #ifdef MODE_DUAL_PARABOLOID
-
 layout(location = 9) highp in float dp_clip;
-
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 #ifdef USE_LIGHTMAP
-// w0, w1, w2, and w3 are the four cubic B-spline basis functions
+// w0, w1, w2, and w3 are the four cubic B-spline basis functions.
 float w0(float a) {
 	return (1.0 / 6.0) * (a * (a * (-a + 3.0) - 3.0) + 1.0);
 }
@@ -627,7 +627,7 @@ float w3(float a) {
 	return (1.0 / 6.0) * (a * a * a);
 }
 
-// g0 and g1 are the two amplitude functions
+// g0 and g1 are the two amplitude functions.
 float g0(float a) {
 	return w0(a) + w1(a);
 }
@@ -636,7 +636,7 @@ float g1(float a) {
 	return w2(a) + w3(a);
 }
 
-// h0 and h1 are the two offset functions
+// h0 and h1 are the two offset functions.
 float h0(float a) {
 	return -1.0 + w1(a) / (w0(a) + w1(a));
 }
@@ -668,23 +668,27 @@ vec4 textureArray_bicubic(texture2DArray tex, vec3 uv, vec2 texture_size) {
 	return (g0(fuv.y) * (g0x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p0, uv.z)) + g1x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p1, uv.z)))) +
 			(g1(fuv.y) * (g0x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p2, uv.z)) + g1x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p3, uv.z))));
 }
-#endif //USE_LIGHTMAP
+#endif // USE_LIGHTMAP
 
 #ifdef USE_MULTIVIEW
+
 #ifdef has_VK_KHR_multiview
 #define ViewIndex gl_ViewIndex
-#else
+#else // has_VK_KHR_multiview
 // !BAS! This needs to become an input once we implement our fallback!
 #define ViewIndex 0
-#endif
+#endif // has_VK_KHR_multiview
+
 vec3 multiview_uv(vec2 uv) {
 	return vec3(uv, ViewIndex);
 }
 ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
-#else
-// Set to zero, not supported in non stereo
+
+#else // USE_MULTIVIEW
+
+// Set to zero, not supported in non-stereo.
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
@@ -692,22 +696,22 @@ vec2 multiview_uv(vec2 uv) {
 ivec2 multiview_uv(ivec2 uv) {
 	return uv;
 }
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
 
-//defines to keep compatibility with vertex
+// Defines to keep compatibility with vertex.
 
 #ifdef USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix_view[ViewIndex]
 #define inv_projection_matrix scene_data.inv_projection_matrix_view[ViewIndex]
-#else
+#else // USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix
 #define inv_projection_matrix scene_data.inv_projection_matrix
-#endif
+#endif // USE_MULTIVIEW
 
 #if defined(ENABLE_SSS) && defined(ENABLE_TRANSMITTANCE)
-//both required for transmittance to be enabled
+// Both required for transmittance to be enabled.
 #define LIGHT_TRANSMITTANCE_USED
-#endif
+#endif // ENABLE_SSS && ENABLE_TRANSMITTANCE
 
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
@@ -715,54 +719,50 @@ layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms
 #MATERIAL_UNIFORMS
 } material;
 /* clang-format on */
-#endif
+#endif // MATERIAL_UNIFORMS_USED
+/* clang-format off */
 
 #GLOBALS
 
 /* clang-format on */
-
 #ifdef MODE_RENDER_DEPTH
 
 #ifdef MODE_RENDER_MATERIAL
-
 layout(location = 0) out vec4 albedo_output_buffer;
 layout(location = 1) out vec4 normal_output_buffer;
 layout(location = 2) out vec4 orm_output_buffer;
 layout(location = 3) out vec4 emission_output_buffer;
 layout(location = 4) out float depth_output_buffer;
-
 #endif // MODE_RENDER_MATERIAL
 
-#else // RENDER DEPTH
+#else // MODE_RENDER_DEPTH
 
 #ifdef MODE_MULTIPLE_RENDER_TARGETS
-
-layout(location = 0) out vec4 diffuse_buffer; //diffuse (rgb) and roughness
-layout(location = 1) out vec4 specular_buffer; //specular and SSS (subsurface scatter)
-#else
-
+layout(location = 0) out vec4 diffuse_buffer; // Diffuse (RGB), subsurface scattering strength (A).
+layout(location = 1) out vec4 specular_buffer; // Specular (RGB), metalness (A).
+#else // MODE_MULTIPLE_RENDER_TARGETS
 layout(location = 0) out mediump vec4 frag_color;
 #endif // MODE_MULTIPLE_RENDER_TARGETS
 
-#endif // RENDER DEPTH
+#endif // MODE_RENDER_DEPTH
 
 #include "../scene_forward_aa_inc.glsl"
 
-#if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) // && !defined(USE_VERTEX_LIGHTING)
+#if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 // Default to SPECULAR_SCHLICK_GGX.
 #if !defined(SPECULAR_DISABLED) && !defined(SPECULAR_SCHLICK_GGX) && !defined(SPECULAR_TOON)
 #define SPECULAR_SCHLICK_GGX
-#endif
+#endif // !SPECULAR_DISABLED && !SPECULAR_SCHLICK_GGX && !SPECULAR_TOON
 
 #include "../scene_forward_lights_inc.glsl"
 
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && !defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
 #ifndef MODE_RENDER_DEPTH
 
 /*
-	Only supporting normal fog here.
+	Only supporting normal fog on Mobile.
 */
 
 vec4 fog_process(vec3 vertex) {
@@ -771,16 +771,16 @@ vec4 fog_process(vec3 vertex) {
 	if (sc_use_fog_aerial_perspective()) {
 		vec3 sky_fog_color = vec3(0.0);
 		vec3 cube_view = scene_data_block.data.radiance_inverse_xform * vertex;
-		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred
+		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred.
 		float mip_level = mix(1.0 / MAX_ROUGHNESS_LOD, 1.0, 1.0 - (abs(vertex.z) - scene_data_block.data.z_near) / (scene_data_block.data.z_far - scene_data_block.data.z_near));
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(mip_level * MAX_ROUGHNESS_LOD, lod);
 		sky_fog_color = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod)).rgb;
 		sky_fog_color = mix(sky_fog_color, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod + 1)).rgb, blend);
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		sky_fog_color = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), cube_view, mip_level * MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 		fog_color = mix(fog_color, sky_fog_color, scene_data_block.data.fog_aerial_perspective);
 	}
 
@@ -803,7 +803,7 @@ vec4 fog_process(vec3 vertex) {
 		float fog_quad_amount = pow(fog_z, scene_data_block.data.fog_depth_curve) * scene_data_block.data.fog_density;
 		fog_amount = fog_quad_amount;
 	} else {
-		fog_amount = 1 - exp(min(0.0, -length(vertex) * scene_data_block.data.fog_density));
+		fog_amount = 1.0 - exp(min(0.0, -length(vertex) * scene_data_block.data.fog_density));
 	}
 
 	if (sc_use_fog_height_density()) {
@@ -819,7 +819,7 @@ vec4 fog_process(vec3 vertex) {
 	return vec4(fog_color, fog_amount);
 }
 
-#endif //!MODE_RENDER DEPTH
+#endif // !MODE_RENDER_DEPTH
 
 #define scene_data scene_data_block.data
 
@@ -831,22 +831,21 @@ void main() {
 	} else if (uc_cull_mode() == POLYGON_CULL_FRONT && front_facing) {
 		discard;
 	}
-#endif
+#endif // UBERSHADER
 #ifdef MODE_DUAL_PARABOLOID
-
 	if (dp_clip > 0.0)
 		discard;
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
-	//lay out everything, whatever is unused is optimized away anyway
+	// Lay out everything, whatever is unused is optimized away anyway.
 	vec3 vertex = vertex_interp;
 #ifdef USE_MULTIVIEW
 	vec3 eye_offset = scene_data.eye_offset[ViewIndex].xyz;
 	vec3 view = -normalize(vertex_interp - eye_offset);
-#else
+#else // USE_MULTIVIEW
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
 	vec3 view = -normalize(vertex_interp);
-#endif
+#endif // USE_MULTIVIEW
 	vec3 albedo = vec3(1.0);
 	vec3 backlight = vec3(0.0);
 	vec4 transmittance_color = vec4(0.0);
@@ -864,16 +863,19 @@ void main() {
 	vec2 anisotropy_flow = vec2(1.0, 0.0);
 #ifdef PREMUL_ALPHA_USED
 	float premul_alpha = 1.0;
-#endif
+#endif // PREMUL_ALPHA_USED
+
 #ifndef FOG_DISABLED
 	vec4 fog = vec4(0.0);
 #endif // !FOG_DISABLED
+
 #if defined(CUSTOM_RADIANCE_USED)
 	vec4 custom_radiance = vec4(0.0);
-#endif
+#endif // CUSTOM_RADIANCE_USED
+
 #if defined(CUSTOM_IRRADIANCE_USED)
 	vec4 custom_irradiance = vec4(0.0);
-#endif
+#endif // CUSTOM_IRRADIANCE_USED
 
 	float ao = 1.0;
 	float ao_light_affect = 0.0;
@@ -883,38 +885,35 @@ void main() {
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	vec3 binormal = normalize(binormal_interp);
 	vec3 tangent = normalize(tangent_interp);
-#else
+#else // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 	vec3 binormal = vec3(0.0);
 	vec3 tangent = vec3(0.0);
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #ifdef NORMAL_USED
 	vec3 normal = normalize(normal_interp);
-
 #if defined(DO_SIDE_CHECK)
 	if (!gl_FrontFacing) {
 		normal = -normal;
 	}
-#endif
-
-#endif //NORMAL_USED
+#endif // DO_SIDE_CHECK
+#endif // NORMAL_USED
 
 #ifdef UV_USED
 	vec2 uv = uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	vec2 uv2 = uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(COLOR_USED)
 	vec4 color = color_interp;
-#endif
+#endif // COLOR_USED
 
 #if defined(NORMAL_MAP_USED)
-
 	vec3 normal_map = vec3(0.5);
-#endif
+#endif // NORMAL_MAP_USED
 
 	float normal_map_depth = 1.0;
 
@@ -944,11 +943,11 @@ void main() {
 	inv_view_matrix[0][3] = 0.0;
 	inv_view_matrix[1][3] = 0.0;
 	inv_view_matrix[2][3] = 0.0;
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 #ifdef LIGHT_VERTEX_USED
 	vec3 light_vertex = vertex;
-#endif //LIGHT_VERTEX_USED
+#endif // LIGHT_VERTEX_USED
 
 	mat3 model_normal_matrix;
 	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
@@ -960,6 +959,7 @@ void main() {
 	mat4 read_view_matrix = scene_data.view_matrix;
 	vec2 read_viewport_size = scene_data.viewport_size;
 
+	// GDShader FRAGMENT function gets inserted here.
 	{
 #CODE : FRAGMENT
 	}
@@ -968,18 +968,18 @@ void main() {
 	vertex = light_vertex;
 #ifdef USE_MULTIVIEW
 	view = -normalize(vertex - eye_offset);
-#else
+#else // USE_MULTIVIEW
 	view = -normalize(vertex);
-#endif //USE_MULTIVIEW
-#endif //LIGHT_VERTEX_USED
+#endif // USE_MULTIVIEW
+#endif // LIGHT_VERTEX_USED
 
 #ifdef LIGHT_TRANSMITTANCE_USED
 #ifdef SSS_MODE_SKIN
 	transmittance_color.a = sss_strength;
-#else
+#else // SSS_MODE_SKIN
 	transmittance_color.a *= sss_strength;
-#endif
-#endif
+#endif // SSS_MODE_SKIN
+#endif // LIGHT_TRANSMITTANCE_USED
 
 #ifndef USE_SHADOW_TO_OPACITY
 
@@ -989,7 +989,7 @@ void main() {
 	}
 #endif // ALPHA_SCISSOR_USED
 
-// alpha hash can be used in unison with alpha antialiasing
+// Alpha hash can be used in unison with alpha antialiasing.
 #ifdef ALPHA_HASH_USED
 	vec3 object_pos = (inverse(read_model_matrix) * inv_view_matrix * vec4(vertex, 1.0)).xyz;
 	if (alpha < compute_alpha_hash_threshold(object_pos, alpha_hash_scale)) {
@@ -997,16 +997,16 @@ void main() {
 	}
 #endif // ALPHA_HASH_USED
 
-// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash
+// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash.
 #if (defined(ALPHA_SCISSOR_USED) || defined(ALPHA_HASH_USED)) && !defined(ALPHA_ANTIALIASING_EDGE_USED)
 	alpha = 1.0;
-#endif
+#endif // (ALPHA_SCISSOR_USED || ALPHA_HASH_USED) && !ALPHA_ANTIALIASING_EDGE_USED
 
 #ifdef ALPHA_ANTIALIASING_EDGE_USED
-// If alpha scissor is used, we must further the edge threshold, otherwise we won't get any edge feather
+// If alpha scissor is used, we must further the edge threshold, otherwise we won't get any edge feather.
 #ifdef ALPHA_SCISSOR_USED
 	alpha_antialiasing_edge = clamp(alpha_scissor_threshold + alpha_antialiasing_edge, 0.0, 1.0);
-#endif
+#endif // ALPHA_SCISSOR_USED
 	alpha = compute_alpha_antialiasing_edge(alpha, alpha_texture_coordinate, alpha_antialiasing_edge);
 #endif // ALPHA_ANTIALIASING_EDGE_USED
 
@@ -1021,53 +1021,46 @@ void main() {
 #endif // !USE_SHADOW_TO_OPACITY
 
 #ifdef NORMAL_MAP_USED
-
 	normal_map.xy = normal_map.xy * 2.0 - 1.0;
-	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); //always ignore Z, as it can be RG packed, Z may be pos/neg, etc.
+	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); // Always reconstruct Z, as it can be RG packed, Z may be pos/neg, etc.
 
 	normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
-
-#endif
+#endif // NORMAL_MAP_USED
 
 #ifdef LIGHT_ANISOTROPY_USED
-
 	if (anisotropy > 0.01) {
-		//rotation matrix
 		mat3 rot = mat3(tangent, binormal, normal);
-		//make local to space
+		// Make local to space.
 		tangent = normalize(rot * vec3(anisotropy_flow.x, anisotropy_flow.y, 0.0));
 		binormal = normalize(rot * vec3(-anisotropy_flow.y, anisotropy_flow.x, 0.0));
 	}
-
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 
 #ifdef ENABLE_CLIP_ALPHA
 	if (albedo.a < 0.99) {
-		//used for doublepass and shadowmapping
+		// Used for doublepass and shadowmapping.
 		discard;
 	}
-#endif
+#endif // ENABLE_CLIP_ALPHA
 
 	/////////////////////// FOG //////////////////////
 #ifndef MODE_RENDER_DEPTH
 
 #ifndef FOG_DISABLED
 #ifndef CUSTOM_FOG_USED
-	// fog must be processed as early as possible and then packed.
-	// to maximize VGPR usage
+	// Fog must be processed as early as possible and then packed to maximize VGPR usage.
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
-
 	if (!sc_disable_fog() && scene_data.fog_enabled) {
 		fog = fog_process(vertex);
 	}
 
-#endif //!CUSTOM_FOG_USED
+#endif // !CUSTOM_FOG_USED
 
 	uint fog_rg = packHalf2x16(fog.rg);
 	uint fog_ba = packHalf2x16(fog.ba);
 
-#endif //!FOG_DISABLED
-#endif //!MODE_RENDER_DEPTH
+#endif // !FOG_DISABLED
+#endif // !MODE_RENDER_DEPTH
 
 	/////////////////////// DECALS ////////////////////////////////
 
@@ -1080,12 +1073,12 @@ void main() {
 	for (uint i = 0; i < sc_decals(); i++) {
 		uint decal_index = (i > 3) ? ((decal_indices.y >> ((i - 4) * 8)) & 0xFF) : ((decal_indices.x >> (i * 8)) & 0xFF);
 		if (!bool(decals.data[decal_index].mask & instances.data[draw_call.instance_index].layer_mask)) {
-			continue; //not masked
+			continue; // Not masked, skip.
 		}
 
 		vec3 uv_local = (decals.data[decal_index].xform * vec4(vertex, 1.0)).xyz;
 		if (any(lessThan(uv_local, vec3(0.0, -1.0, 0.0))) || any(greaterThan(uv_local, vec3(1.0)))) {
-			continue; //out of decal
+			continue; // Out of decal.
 		}
 
 		float fade = pow(1.0 - (uv_local.y > 0.0 ? uv_local.y : -uv_local.y), uv_local.y > 0.0 ? decals.data[decal_index].upper_fade : decals.data[decal_index].lower_fade);
@@ -1094,12 +1087,12 @@ void main() {
 			fade *= smoothstep(decals.data[decal_index].normal_fade, 1.0, dot(normal_interp, decals.data[decal_index].normal) * 0.5 + 0.5);
 		}
 
-		//we need ddx/ddy for mipmaps, so simulate them
+		// We need ddx/ddy for mipmaps, so simulate them.
 		vec2 ddx = (decals.data[decal_index].xform * vec4(vertex_ddx, 0.0)).xz;
 		vec2 ddy = (decals.data[decal_index].xform * vec4(vertex_ddy, 0.0)).xz;
 
 		if (decals.data[decal_index].albedo_rect != vec4(0.0)) {
-			//has albedo
+			// Has albedo.
 			vec4 decal_albedo;
 			if (sc_decal_use_mipmaps()) {
 				decal_albedo = textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].albedo_rect.zw + decals.data[decal_index].albedo_rect.xy, ddx * decals.data[decal_index].albedo_rect.zw, ddy * decals.data[decal_index].albedo_rect.zw);
@@ -1117,9 +1110,9 @@ void main() {
 				} else {
 					decal_normal = textureLod(sampler2D(decal_atlas, decal_sampler), uv_local.xz * decals.data[decal_index].normal_rect.zw + decals.data[decal_index].normal_rect.xy, 0.0).xyz;
 				}
-				decal_normal.xy = decal_normal.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0); //users prefer flipped y normal maps in most authoring software
+				decal_normal.xy = decal_normal.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0); // Users prefer flipped Y normal maps in most authoring software.
 				decal_normal.z = sqrt(max(0.0, 1.0 - dot(decal_normal.xy, decal_normal.xy)));
-				//convert to view space, use xzy because y is up
+				// Convert to view space, use XZY because Y is up.
 				decal_normal = (decals.data[decal_index].normal_xform * decal_normal.xzy).xyz;
 
 				normal = normalize(mix(normal, decal_normal, decal_albedo.a));
@@ -1139,7 +1132,7 @@ void main() {
 		}
 
 		if (decals.data[decal_index].emission_rect != vec4(0.0)) {
-			//emission is additive, so its independent from albedo
+			// Emission is additive, so it's independent from albedo.
 			if (sc_decal_use_mipmaps()) {
 				emission += textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].emission_rect.zw + decals.data[decal_index].emission_rect.xy, ddx * decals.data[decal_index].emission_rect.zw, ddy * decals.data[decal_index].emission_rect.zw).xyz * decals.data[decal_index].emission_energy * fade;
 			} else {
@@ -1147,36 +1140,35 @@ void main() {
 			}
 		}
 	}
-#endif //!MODE_RENDER_DEPTH
+#endif // !MODE_RENDER_DEPTH
 
 	/////////////////////// LIGHTING //////////////////////////////
 
 #ifdef NORMAL_USED
 	if (sc_scene_roughness_limiter_enabled()) {
-		//https://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
+		// https://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
 		float roughness2 = roughness * roughness;
 		vec3 dndu = dFdx(normal), dndv = dFdy(normal);
 		float variance = scene_data.roughness_limiter_amount * (dot(dndu, dndu) + dot(dndv, dndv));
-		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit); //limit effect
+		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit);
 		float filteredRoughness2 = min(1.0, roughness2 + kernelRoughness2);
 		roughness = sqrt(filteredRoughness2);
 	}
 #endif // NORMAL_USED
-	//apply energy conservation
 
-	vec3 specular_light = vec3(0.0, 0.0, 0.0);
-	vec3 diffuse_light = vec3(0.0, 0.0, 0.0);
-	vec3 ambient_light = vec3(0.0, 0.0, 0.0);
-
+	vec3 specular_light = vec3(0.0);
+	vec3 diffuse_light = vec3(0.0);
+	vec3 ambient_light = vec3(0.0);
 #ifndef MODE_UNSHADED
 	// Used in regular draw pass and when drawing SDFs for SDFGI and materials for VoxelGI.
 	emission *= scene_data.emissive_exposure_normalization;
-#endif
+#endif // !MODE_UNSHADED
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #ifndef AMBIENT_LIGHT_DISABLED
 
+	// Global Radiance //
 	if (sc_scene_use_reflection_cubemap()) {
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1186,23 +1178,23 @@ void main() {
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
 		vec3 ref_vec = reflect(-view, bent_normal);
 		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
-#else
+#else // LIGHT_ANISOTROPY_USED
 		vec3 ref_vec = reflect(-view, normal);
 		ref_vec = mix(ref_vec, normal, roughness * roughness);
-#endif
+#endif // LIGHT_ANISOTROPY_USED
+
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
-#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
+#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(sqrt(roughness) * MAX_ROUGHNESS_LOD, lod);
 		specular_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
 		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
-
 #else // USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light *= sc_luminance_multiplier();
 		specular_light *= scene_data.IBL_exposure_normalization;
 		specular_light *= horizon * horizon;
@@ -1214,7 +1206,7 @@ void main() {
 #endif // CUSTOM_RADIANCE_USED
 
 #ifndef USE_LIGHTMAP
-	//lightmap overrides everything
+	// Lightmap overrides everything.
 	if (scene_data.use_ambient_light) {
 		ambient_light = scene_data.ambient_light_color_energy.rgb;
 
@@ -1222,9 +1214,9 @@ void main() {
 			vec3 ambient_dir = scene_data.radiance_inverse_xform * normal;
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 			vec3 cubemap_ambient = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ambient_dir, MAX_ROUGHNESS_LOD)).rgb;
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 			vec3 cubemap_ambient = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ambient_dir, MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 			cubemap_ambient *= sc_luminance_multiplier();
 			cubemap_ambient *= scene_data.IBL_exposure_normalization;
 			ambient_light = mix(ambient_light, cubemap_ambient * scene_data.ambient_light_color_energy.a, scene_data.ambient_color_sky_mix);
@@ -1235,14 +1227,16 @@ void main() {
 #if defined(CUSTOM_IRRADIANCE_USED)
 	ambient_light = mix(ambient_light, custom_irradiance.rgb, custom_irradiance.a);
 #endif // CUSTOM_IRRADIANCE_USED
+
 #ifdef LIGHT_CLEARCOAT_USED
 
+	// Note: We want to use geometric normal for clearcoat reflections/BRDF, ie. we ignore the normal map.
 	if (sc_scene_use_reflection_cubemap()) {
-		vec3 n = normalize(normal_interp); // We want to use geometric normal, not normal_map
+		vec3 n = normalize(normal_interp);
 		float NoV = max(dot(n, view), 0.0001);
 		vec3 ref_vec = reflect(-view, n);
 		ref_vec = mix(ref_vec, n, clearcoat_roughness * clearcoat_roughness);
-		// The clear coat layer assumes an IOR of 1.5 (4% reflectance)
+		// The clear coat layer assumes an IOR of 1.5 (4% reflectance).
 		float Fc = clearcoat * (0.04 + 0.96 * SchlickFresnel(NoV));
 		float attenuation = 1.0 - Fc;
 		ambient_light *= attenuation;
@@ -1251,31 +1245,29 @@ void main() {
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
 		float roughness_lod = mix(0.001, 0.1, sqrt(clearcoat_roughness)) * MAX_ROUGHNESS_LOD;
-#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
+#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(roughness_lod, lod);
 		vec3 clearcoat_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
 		clearcoat_light = mix(clearcoat_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
-
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		vec3 clearcoat_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, roughness_lod).rgb;
-
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light += clearcoat_light * horizon * horizon * Fc * scene_data.ambient_light_color_energy.a;
 	}
 #endif // LIGHT_CLEARCOAT_USED
 #endif // !AMBIENT_LIGHT_DISABLED
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
-	//radiance
 
+	/// GI ///
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 #ifndef AMBIENT_LIGHT_DISABLED
 #ifdef USE_LIGHTMAP
 
-	//lightmap
-	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { //has lightmap capture
+	// Lightmapping //
+	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { // Process lightmap capture (L2 SH).
 		uint index = instances.data[draw_call.instance_index].gi_offset;
 
 		vec3 wnormal = mat3(scene_data.inv_view_matrix) * normal;
@@ -1296,7 +1288,7 @@ void main() {
 								 2.0 * c2 * lightmap_captures.data[index].sh[2].rgb * wnormal.z) *
 				scene_data.emissive_exposure_normalization;
 
-	} else if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // has actual lightmap
+	} else if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // Process lightmap texture.
 		bool uses_sh = bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_SH_LIGHTMAP);
 		uint ofs = instances.data[draw_call.instance_index].gi_offset & 0xFFFF;
 		uint slice = instances.data[draw_call.instance_index].gi_offset >> 16;
@@ -1305,12 +1297,9 @@ void main() {
 		uvw.z = float(slice);
 
 		if (uses_sh) {
-			uvw.z *= 4.0; //SH textures use 4 times more data
-			vec3 lm_light_l0;
-			vec3 lm_light_l1n1;
-			vec3 lm_light_l1_0;
-			vec3 lm_light_l1p1;
+			uvw.z *= 4.0; // SH textures use 4 times more data.
 
+			vec3 lm_light_l0, lm_light_l1n1, lm_light_l1_0, lm_light_l1p1;
 			if (sc_use_lightmap_bicubic_filter()) {
 				lm_light_l0 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 0.0), lightmaps.data[ofs].light_texture_size).rgb;
 				lm_light_l1n1 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 1.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
@@ -1330,6 +1319,7 @@ void main() {
 			ambient_light += lm_light_l1n1 * n.y * (lm_light_l0 * exposure_normalization * 4.0);
 			ambient_light += lm_light_l1_0 * n.z * (lm_light_l0 * exposure_normalization * 4.0);
 			ambient_light += lm_light_l1p1 * n.x * (lm_light_l0 * exposure_normalization * 4.0);
+
 		} else {
 			if (sc_use_lightmap_bicubic_filter()) {
 				ambient_light += textureArray_bicubic(lightmap_textures[ofs], uvw, lightmaps.data[ofs].light_texture_size).rgb * lightmaps.data[ofs].exposure_normalization;
@@ -1339,15 +1329,16 @@ void main() {
 		}
 	}
 
-	// No GI nor non low end mode...
+	// No SDFGI nor VoxelGI on Mobile.
 
 #endif // USE_LIGHTMAP
 
-	// skipping ssao, do we remove ssao totally?
+	// Skipping SSAO, do we remove SSAO totally?
 
+	// Reflection Probes //
 	if (sc_reflection_probes() > 0) {
-		vec4 reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
-		vec4 ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
+		vec4 reflection_accum = vec4(0.0);
+		vec4 ambient_accum = vec4(0.0);
 
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1355,9 +1346,9 @@ void main() {
 		vec3 anisotropic_tangent = cross(anisotropic_direction, view);
 		vec3 anisotropic_normal = cross(anisotropic_tangent, anisotropic_direction);
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
-#else
+#else // LIGHT_ANISOTROPY_USED
 		vec3 bent_normal = normal;
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 		vec3 ref_vec = normalize(reflect(-view, bent_normal));
 		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
 
@@ -1375,33 +1366,30 @@ void main() {
 		if (ambient_accum.a > 0.0) {
 			ambient_light = ambient_accum.rgb / ambient_accum.a;
 		}
-#endif
-	} //Reflection probes
+#endif // !USE_LIGHTMAP
+	}
 
-	// finalize ambient light here
-
+	// Finalize ambient light.
 	ambient_light *= albedo.rgb;
 	ambient_light *= ao;
 
 #endif // !AMBIENT_LIGHT_DISABLED
 
-	// convert ao to direct light ao
+	// Convert AO to direct light AO.
 	ao = mix(1.0, ao, ao_light_affect);
 
-	//this saves some VGPRs
+	// This saves some VGPRs.
 	vec3 f0 = F0(metallic, specular, albedo);
 
 #ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
-		//simplify for toon, as
+		// Simplified toon BRDF.
 		specular_light *= specular * metallic * albedo * 2.0;
-#else
-
-		// scales the specular reflections, needs to be computed before lighting happens,
-		// but after environment, GI, and reflection probes are added
-		// Environment brdf approximation (Lazarov 2013)
-		// see https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
+#else // DIFFUSE_TOON
+		// Environment BRDF Approximation (Lazarov 2013)
+		// Scales only indirect reflections, hence is computed before direct lighting happens.
+		// See: https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
 		const vec4 c0 = vec4(-1.0, -0.0275, -0.572, 0.022);
 		const vec4 c1 = vec4(1.0, 0.0425, 1.04, -0.04);
 		vec4 r = roughness * c0 + c1;
@@ -1410,36 +1398,38 @@ void main() {
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 
 		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
-#endif
+#endif // DIFFUSE_TOON
 	}
-
 #endif // !AMBIENT_LIGHT_DISABLED
-#endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
+	// End of GI //
 
 #if !defined(MODE_RENDER_DEPTH)
-	//this saves some VGPRs
+	// This saves some VGPRs.
 	uint orms = packUnorm4x8(vec4(ao, roughness, metallic, specular));
-#endif
+#endif // !MODE_RENDER_DEPTH
 
-// LIGHTING
+	// LIGHTING //
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+
 #ifdef USE_VERTEX_LIGHTING
 	diffuse_light += diffuse_light_interp.rgb;
 	specular_light += specular_light_interp.rgb * f0;
-#endif
+#endif // USE_VERTEX_LIGHTING
 
+	 // Directional Lights //
 	if (sc_directional_lights() > 0) {
 #ifndef SHADOWS_DISABLED
-		// Do shadow and lighting in two passes to reduce register pressure
+		// Do shadows and lighting in two passes to reduce register pressure.
 		uint shadow0 = 0;
 		uint shadow1 = 0;
 
 		float shadowmask = 1.0;
-
 #ifdef USE_LIGHTMAP
 		uint shadowmask_mode = LIGHTMAP_SHADOWMASK_MODE_NONE;
 
-		if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
+		if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // Get shadowmask texture.
 			const uint ofs = instances.data[draw_call.instance_index].gi_offset & 0xFFFF;
 			shadowmask_mode = lightmaps.data[ofs].flags;
 
@@ -1462,11 +1452,12 @@ void main() {
 #ifdef USE_VERTEX_LIGHTING
 			// Only process the first light's shadow for vertex lighting.
 			for (uint i = 0; i < 1; i++) {
-#else
-		for (uint i = 0; i < sc_directional_lights(); i++) {
-#endif
+#else // USE_VERTEX_LIGHTING
+			for (uint i = 0; i < sc_directional_lights(); i++) {
+#endif // USE_VERTEX_LIGHTING
+
 				if (!bool(directional_lights.data[i].mask & instances.data[draw_call.instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (directional_lights.data[i].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
@@ -1474,8 +1465,7 @@ void main() {
 				}
 
 				float shadow = 1.0;
-
-				if (directional_lights.data[i].shadow_opacity > 0.001) {
+				if (directional_lights.data[i].shadow_opacity > 0.001) { // Compute Shadows //
 					float depth_z = -vertex.z;
 
 					vec4 pssm_coord;
@@ -1489,14 +1479,14 @@ void main() {
 	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
 	m_var.xyz += normal_bias;
 
-					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First cascade.
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 0)
 
 						pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
 						blur_factor = 1.0;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second cascade.
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 1)
@@ -1504,7 +1494,7 @@ void main() {
 						pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third cascade.
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 2)
@@ -1512,7 +1502,7 @@ void main() {
 						pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-					} else {
+					} else { // Fourth cascade.
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 3)
@@ -1532,21 +1522,21 @@ void main() {
 						float pssm_blend;
 						float blur_factor2;
 
-						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First-to-second blend.
 							vec4 v = vec4(vertex, 1.0);
 							BIAS_FUNC(v, 1)
 							pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 							pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x - directional_lights.data[i].shadow_split_offsets.x * 0.1, directional_lights.data[i].shadow_split_offsets.x, depth_z);
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second-to-third blend.
 							vec4 v = vec4(vertex, 1.0);
 							BIAS_FUNC(v, 2)
 							pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 							pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y - directional_lights.data[i].shadow_split_offsets.y * 0.1, directional_lights.data[i].shadow_split_offsets.y, depth_z);
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third-to-fourth blend.
 							vec4 v = vec4(vertex, 1.0);
 							BIAS_FUNC(v, 3)
 							pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
@@ -1554,7 +1544,7 @@ void main() {
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
 						} else {
-							pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
+							pssm_blend = 0.0; // If no blend, same coord will be used (divide by z will result in same value, and already cached).
 							blur_factor2 = 1.0;
 						}
 
@@ -1566,22 +1556,23 @@ void main() {
 
 #ifdef USE_LIGHTMAP
 					if (shadowmask_mode == LIGHTMAP_SHADOWMASK_MODE_REPLACE) {
-						shadow = mix(shadow, shadowmask, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+						shadow = mix(shadow, shadowmask, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 					} else if (shadowmask_mode == LIGHTMAP_SHADOWMASK_MODE_OVERLAY) {
-						shadow = shadowmask * mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+						shadow = shadowmask * mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 					} else {
-#endif
-						shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+#endif // USE_LIGHTMAP
+						shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 #ifdef USE_LIGHTMAP
 					}
-#endif
+#endif // USE_LIGHTMAP
 
 #ifdef USE_VERTEX_LIGHTING
 					diffuse_light *= mix(1.0, shadow, diffuse_light_interp.a);
 					specular_light *= mix(1.0, shadow, specular_light_interp.a);
-#endif
+#endif // USE_VERTEX_LIGHTING
+
 #undef BIAS_FUNC
-				}
+				} // End of shadows.
 
 				if (i < 4) {
 					shadow0 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << (i * 8);
@@ -1596,36 +1587,38 @@ void main() {
 #ifdef USE_VERTEX_LIGHTING
 			diffuse_light *= mix(1.0, shadowmask, diffuse_light_interp.a);
 			specular_light *= mix(1.0, shadowmask, specular_light_interp.a);
-#endif
+#endif // USE_VERTEX_LIGHTING
 
 			shadow0 |= uint(clamp(shadowmask * 255.0, 0.0, 255.0));
 		}
 #endif // USE_LIGHTMAP
 
-#endif // SHADOWS_DISABLED
+#endif // !SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
+
 		for (uint i = 0; i < sc_directional_lights(); i++) {
 			if (!bool(directional_lights.data[i].mask & instances.data[draw_call.instance_index].layer_mask)) {
-				continue; //not masked
+				continue; // Not masked, skip.
 			}
 
 			if (directional_lights.data[i].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
 				continue; // Statically baked light and object uses lightmap, skip.
 			}
 
-			// We're not doing light transmittence
+			// We're not doing light transmittance on Mobile.
 
 			float shadow = 1.0;
 #ifndef SHADOWS_DISABLED
 			if (i < 4) {
-				shadow = float(shadow0 >> (i * 8) & 0xFF) / 255.0;
+				shadow = float(shadow0 >> (i * 8u) & 0xFFu) / 255.0;
 			} else {
-				shadow = float(shadow1 >> ((i - 4) * 8) & 0xFF) / 255.0;
+				shadow = float(shadow1 >> ((i - 4u) * 8u) & 0xFFu) / 255.0;
 			}
 
 			shadow = mix(1.0, shadow, directional_lights.data[i].shadow_opacity);
-#endif
+#endif // !SHADOWS_DISABLED
+
 			blur_shadow(shadow);
 
 			vec3 tint = vec3(1.0);
@@ -1641,7 +1634,7 @@ void main() {
 			}
 			tint = mix(tint, vec3(1.0), shadow);
 			shadow = 1.0;
-#endif
+#endif // DEBUG_DRAW_PSSM_SPLITS
 
 			float size_A = sc_use_light_soft_shadows() ? directional_lights.data[i].size : 0.0;
 
@@ -1650,39 +1643,40 @@ void main() {
 					true, shadow, f0, orms, 1.0, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 					backlight,
-#endif
-/* not supported here
+#endif // LIGHT_BACKLIGHT_USED
+/* Not supported here.
 #ifdef LIGHT_TRANSMITTANCE_USED
 					transmittance_color,
 					transmittance_depth,
 					transmittance_boost,
 					transmittance_z,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 */
 #ifdef LIGHT_RIM_USED
 					rim, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 					clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 					binormal, tangent, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 					diffuse_light,
 					specular_light);
 		}
-#endif // USE_VERTEX_LIGHTING
-	} //directional light
+#endif // !USE_VERTEX_LIGHTING
+	} // End of directional lights.
 
 #ifndef USE_VERTEX_LIGHTING
+	// Omni Lights //
 	uvec2 omni_indices = instances.data[draw_call.instance_index].omni_lights;
 	for (uint i = 0; i < sc_omni_lights(); i++) {
 		uint light_index = (i > 3) ? ((omni_indices.y >> ((i - 4) * 8)) & 0xFF) : ((omni_indices.x >> (i * 8)) & 0xFF);
 		light_process_omni(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, scene_data.taa_frame_count, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 				backlight,
-#endif
-/*
+#endif // LIGHT_BACKLIGHT_USED
+/* Not supported here.
 #ifdef LIGHT_TRANSMITTANCE_USED
 				transmittance_color,
 				transmittance_depth,
@@ -1692,25 +1686,25 @@ void main() {
 #ifdef LIGHT_RIM_USED
 				rim,
 				rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 				clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-				tangent,
-				binormal, anisotropy,
-#endif
+				tangent, binormal, anisotropy,
+#endif // LIGHT_ANISOTROPY_USED
 				diffuse_light, specular_light);
-	}
+	} // End of omni lights.
 
+	// Spot Lights //
 	uvec2 spot_indices = instances.data[draw_call.instance_index].spot_lights;
 	for (uint i = 0; i < sc_spot_lights(); i++) {
 		uint light_index = (i > 3) ? ((spot_indices.y >> ((i - 4) * 8)) & 0xFF) : ((spot_indices.x >> (i * 8)) & 0xFF);
 		light_process_spot(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, scene_data.taa_frame_count, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 				backlight,
-#endif
-/*
+#endif // LIGHT_BACKLIGHT_USED
+/* Not supported here.
 #ifdef LIGHT_TRANSMITTANCE_USED
 				transmittance_color,
 				transmittance_depth,
@@ -1720,19 +1714,17 @@ void main() {
 #ifdef LIGHT_RIM_USED
 				rim,
 				rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 				clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-				tangent,
-				binormal, anisotropy,
-#endif
+				tangent, binormal, anisotropy,
+#endif // LIGHT_ANISOTROPY_USED
 				diffuse_light, specular_light);
-	}
-#endif // !VERTEX_LIGHTING
-
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+	} // End of spot lights.
+#endif // !USE_VERTEX_LIGHTING
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
 #ifdef USE_SHADOW_TO_OPACITY
 #ifndef MODE_RENDER_DEPTH
@@ -1742,7 +1734,7 @@ void main() {
 	if (alpha < alpha_scissor_threshold) {
 		discard;
 	}
-#endif // !ALPHA_SCISSOR_USED
+#endif // ALPHA_SCISSOR_USED
 
 #endif // !MODE_RENDER_DEPTH
 #endif // USE_SHADOW_TO_OPACITY
@@ -1750,7 +1742,6 @@ void main() {
 #ifdef MODE_RENDER_DEPTH
 
 #ifdef MODE_RENDER_MATERIAL
-
 	albedo_output_buffer.rgb = albedo;
 	albedo_output_buffer.a = alpha;
 
@@ -1769,21 +1760,21 @@ void main() {
 
 #else // MODE_RENDER_DEPTH
 
-	// multiply by albedo
-	diffuse_light *= albedo; // ambient must be multiplied by albedo at the end
+	// Multiply by albedo.
+	diffuse_light *= albedo; // Ambient must be multiplied by albedo at the end.
 
-	// apply direct light AO
+	// Apply direct light AO.
 	ao = unpackUnorm4x8(orms).x;
 	specular_light *= ao;
 	diffuse_light *= ao;
 
-	// apply metallic
+	// Apply metallic.
 	metallic = unpackUnorm4x8(orms).z;
 	diffuse_light *= 1.0 - metallic;
 	ambient_light *= 1.0 - metallic;
 
 #ifndef FOG_DISABLED
-	//restore fog
+	// Restore fog.
 	fog = vec4(unpackHalf2x16(fog_rg), unpackHalf2x16(fog_ba));
 #endif // !FOG_DISABLED
 
@@ -1792,9 +1783,7 @@ void main() {
 #ifdef MODE_UNSHADED
 	diffuse_buffer = vec4(albedo.rgb, 0.0);
 	specular_buffer = vec4(0.0);
-
 #else // MODE_UNSHADED
-
 #ifdef SSS_MODE_SKIN
 	sss_strength = -sss_strength;
 #endif // SSS_MODE_SKIN
@@ -1807,7 +1796,7 @@ void main() {
 	specular_buffer.rgb = mix(specular_buffer.rgb, vec3(0.0), fog.a);
 #endif // !FOG_DISABLED
 
-#else //MODE_MULTIPLE_RENDER_TARGETS
+#else // MODE_MULTIPLE_RENDER_TARGETS
 
 #ifdef MODE_UNSHADED
 	frag_color = vec4(albedo, alpha);
@@ -1820,14 +1809,15 @@ void main() {
 	frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a);
 #endif // !FOG_DISABLED
 
-	// On mobile we use a UNORM buffer with 10bpp which results in a range from 0.0 - 1.0 resulting in HDR breaking
-	// We divide by sc_luminance_multiplier to support a range from 0.0 - 2.0 both increasing precision on bright and darker images
+	// On mobile we use a UNORM buffer with 10bpp which results in a range from 0.0 - 1.0 resulting in HDR breaking.
+	// We divide by sc_luminance_multiplier to support a range from 0.0 - 2.0 both increasing precision on bright and darker images.
 	frag_color.rgb = frag_color.rgb / sc_luminance_multiplier();
+
 #ifdef PREMUL_ALPHA_USED
 	frag_color.rgb *= premul_alpha;
-#endif
+#endif // PREMUL_ALPHA_USED
 
-#endif //MODE_MULTIPLE_RENDER_TARGETS
+#endif // MODE_MULTIPLE_RENDER_TARGETS
 
-#endif //MODE_RENDER_DEPTH
+#endif // MODE_RENDER_DEPTH
 }

--- a/servers/rendering/renderer_rd/shaders/scene_forward_vertex_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_vertex_lights_inc.glsl
@@ -9,35 +9,6 @@ mediump float roughness_to_shininess(mediump float roughness) {
 	return r * r2 * r2 * 2000.0;
 }
 
-void light_compute_vertex(vec3 N, vec3 L, vec3 V, vec3 light_color, bool is_directional, float roughness,
-		inout vec3 diffuse_light, inout vec3 specular_light) {
-	float NdotL = min(dot(N, L), 1.0);
-	float cNdotL = max(NdotL, 0.0); // clamped NdotL
-
-#if defined(DIFFUSE_LAMBERT_WRAP)
-	// Energy conserving lambert wrap shader.
-	// https://web.archive.org/web/20210228210901/http://blog.stevemcauley.com/2011/12/03/energy-conserving-wrapped-diffuse/
-	float diffuse_brdf_NL = max(0.0, (cNdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness))) * (1.0 / M_PI);
-#else
-	// lambert
-	float diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
-#endif
-
-	diffuse_light += light_color * diffuse_brdf_NL;
-
-#if !defined(SPECULAR_DISABLED)
-	float specular_brdf_NL = 0.0;
-	// Normalized blinn always unless disabled.
-	vec3 H = normalize(V + L);
-	float cNdotH = clamp(dot(N, H), 0.0, 1.0);
-	float shininess = roughness_to_shininess(roughness);
-	float blinn = pow(cNdotH, shininess);
-	blinn *= (shininess + 2.0) * (1.0 / (8.0 * M_PI)) * cNdotL;
-	specular_brdf_NL = blinn;
-	specular_light += specular_brdf_NL * light_color;
-#endif
-}
-
 float get_omni_attenuation(float distance, float inv_range, float decay) {
 	float nd = distance * inv_range;
 	nd *= nd;
@@ -45,6 +16,33 @@ float get_omni_attenuation(float distance, float inv_range, float decay) {
 	nd = max(1.0 - nd, 0.0);
 	nd *= nd; // nd^2
 	return nd * pow(max(distance, 0.0001), -decay);
+}
+
+void light_compute_vertex(vec3 N, vec3 L, vec3 V, vec3 light_color, bool is_directional, float roughness,
+		inout vec3 diffuse_light, inout vec3 specular_light) {
+	float NdotL = min(dot(N, L), 1.0);
+	float cNdotL = max(NdotL, 0.0);
+
+#if defined(DIFFUSE_LAMBERT_WRAP)
+	// Energy conserving lambert wrap shader.
+	// https://web.archive.org/web/20210228210901/http://blog.stevemcauley.com/2011/12/03/energy-conserving-wrapped-diffuse/
+	float diffuse_brdf_NL = max(0.0, (cNdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness))) * (1.0 / M_PI);
+#else // DIFFUSE_LAMBERT_WRAP
+	// Lambert
+	float diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
+#endif // DIFFUSE_LAMBERT_WRAP
+
+	diffuse_light += light_color * diffuse_brdf_NL;
+
+#if !defined(SPECULAR_DISABLED)
+	// Normalized Blinn always unless disabled.
+	vec3 H = normalize(V + L);
+	float cNdotH = clamp(dot(N, H), 0.0, 1.0);
+	float shininess = roughness_to_shininess(roughness);
+	float blinn = pow(cNdotH, shininess);
+	blinn *= (shininess + 2.0) * (1.0 / (8.0 * M_PI)) * cNdotL;
+	specular_light += blinn * light_color;
+#endif // !SPECULAR_DISABLED
 }
 
 void light_process_omni_vertex(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, float roughness,


### PR DESCRIPTION
The result of a thorough examination of the main Forward+ scene shader and its lighting includes, this is a collection of fixes for **29** errors found therein. In particular I would like to stress that these are *only* the things I consider straight fixes, not improvements or enhancements.
Also included are many low-hanging fruit optimizations; in particular there were, for one reason or another, many instances where a quarter-rate instruction or two could be shaved off with clever use of `inversesqrt`.
Along the way I also made a point of correcting comment formatting and adding comments where it seemed prudent, in the interest of making maintenance easier for anyone delving into these not-insubstantial shaders in the future. These comment/formatting changes are contained in the first commit, while the fixes proper are in the second.

I leave this as a Draft for the time being, as I've only done the Forward+ shaders for now. Once any of my own mistakes get ironed out I'll move on to porting these fixes to the other renderers.

**ISSUES FIXED** (in no particular order):
- The normalization of the TBN vectors was reversed from what MikkTSpace expects: the vectors were left unnormalized in the vertex shader and then normalized early in the pixel shader, whereas MikkTSpace assumes the vectors will be normalized before vertex interpolation and left unnormalized for the normal map's tangent-space transformation.
Ref: http://www.mikktspace.com/

- The faux-anisotropic `bent_normal` vector, used to sample reflection cubemaps when anisotropy is enabled, mistakenly used linear roughness as opposed to perceptual roughness like in Filament.
Ref: https://github.com/google/filament/blob/6b7080e8b69f808df37eb6493cc73a2925e5f987/shaders/src/common_lighting.fs#L95

- The faux-anisotropic `bent_normal` vector used for anisotropic indirect reflections was not consistently used in place of the isotropic reflection vector, which it now always is. It was also a bit too strong, causing reflections to become visibly reversed over anisotropy values of ~0.75.

- When calculating the anisotropic tangent and bitangent, the normal-mapped normal was mistakenly used to construct the TBN matrix, rather than the geometric normal. Additionally, these tangents were only calculated when `anisotropy > 0.01` rather than `abs(anisotropy) > 0.01`, which is important given that `anisotropy` is a [-1,1] value.

- The mapping of the `anisotropy` parameter to X and Y roughness was not symmetrical, meaning it only produced correctly stretched highlights for positive `anisotropy` values, while negative values produced significantly less stretch. This is because the formulation in question, from Disney's BSDF, was designed for [0,1] `anisotropy` values, not [-1,1].
By using the absolute value of `anisotropy` and simply swapping X and Y roughness based on its sign, highlights are now stretched the same amount for both negative and positive values.

- The anisotropic tangent and bitangent were reversed in several places, causing the anisotropic flow direction to be off by 90 degrees for omni/spot lights.
The corrected behaviour now consistently matches Filament (`anisotropy` set to `1.0` is along `U`, `-1.0` is along `V`).
Note that some assets will need to be adjusted depending on the lighting conditions they were originally configured in, but this is simply a matter of negating their `anisotropy` parameter if their highlight is going the wrong direction.

- The `clearcoat_roughness` parameter was mistakenly used as-is (ie. not remapped to the intended [0.001,0.1] range) in several places, most notably when calculating the dominant light direction used to sample reflection cubemaps, causing obvious distortion of clearcoat reflections with any `clearcoat_roughness` above zero.

- The clearcoat_roughness parameter was remapped differently between direct and indirect lighting.
In `scene_forward_clustered.glsl` it was remapped to perceptual roughness as `mix(0.001, 0.1, sqrt(clearcoat_roughness))`, while in `scene_forward_lights_inc.glsl` it was remapped as linear roughness `mix(0.001, 0.1, clearcoat_roughness)`. The latter behaviour has been made the consistent behaviour in both files.

- Clearcoat specular did not properly account for light size, causing a discrepancy between primary specular reflections and clearcoat ones.

- The Geometry term used for clearcoat specular would sometimes divide by 0, producing NaNs visible as bright flickering pixels.

- Indirect clearcoat reflections were being multiplied by the same indirect BRDF as primary reflections due to them being added to `specular_light` beforehand. Additionally, the clearcoat fresnel-based attenuation term multiplied into `diffuse_light` and `specular_light` was applied too early, meaning it only affected some sources of indirect light and not others.
Indirect clearcoat reflections are now accumulated separately from primary reflections, and have their own BRDF and attenuation evaluated and applied after all other indirect light has been integrated, at which point they are finally added to `specular_light`.

- As noted in a comment, direct clearcoat specular was not energy conserving, as the underlying diffuse and specular needed to be attenuated by the clearcoat layer's fresnel.
Normally I would consider this more of an improvement than a fix, however this energy conservation was already being done for indirect lighting, so I'm inclined to consider this a fix in the name of consistency.

- The global radiance cubemap, when sampled for clearcoat reflections, was never multiplied by `scene_data.IBL_exposure_normalization`, meaning clearcoat reflections would have a different brightness from primary reflections when exposure normalization was used.

- Local reflection probes were completely absent from clearcoat reflections on account of simply never being sampled. These are now properly accounted for.

- SSAO only affected indirect reflections relative to its `Light Affect` property, resulting in highly metallic materials appearing flatter and more "glowy" under bright cubemaps compared to less reflective materials when this property was low or 0.

- The screen-space roughness limiter used the derivatives of the normal-mapped normal to calculate shading variance rather than the geometric normal, resulting in visible 2x2 quad artifacts on normal mapped surfaces, especially with strong limiter settings and a strong normal map.
It is important to note that the algorithm in question was only designed to handle geometric specular aliasing to begin with, and Godot already has a separate system for handling specular aliasing due to normal-mapping.

- The screen-space roughness limiter's effect did not apply to clearcoat roughness, meaning clearcoat specular was particularly prone to aliasing.

- The horizon-occlusion term was mistakenly calculated using the dot product of the dominant specular vector and the normal-mapped normal, as opposed to be the dot product of the pure reflection vector and the geometric normal.
Ref: https://marmosetco.tumblr.com/post/81245981087

- The specular microshadowing factor used for indirect reflections did not match that used for direct specular, using `f0.g` rather than the average `f0`. The latter is now the consistent behaviour.

- There was a redundant `if (roughness > 0.0)` around the direct specular code in `light_process` (complete with comment that it shouldn't be there), which did nothing because roughness never actually reached 0.
This has been replaced by a check that skips direct specular if both f0 and metalness are zero (excluding clearcoat specular, which has its own f0).

- The rim effect was completely unaffected by shadows cast onto the material. This *may* have been intentional to allow the rim effect to ignore self-shadowing, but if so I think this was a poor decision, as the light leaking it allows is far worse than the rim light sometimes being obscured by self-shadowing.

- The rim effect's `tint` parameter (ie. multiplication by `albedo`) was handled incorrectly due to an order of operations error, causing the tint to be applied twice. Additionally, compared to the reference Disney implementation the effect was Pi times too bright, again due to order of operations.

- The TBN vectors (`normal_interp`, `tangent_interp`, and `binormal_interp`) were not being inverted on backfaces, resulting in incorrect shading, particularly on normal-mapped materials.

- For per-vertex lighting specifically, the wrapped-Lambert diffuse model mistakenly used *clamped* `NdotL` rather than *signed* `NdotL`, meaning it could not, in fact, wrap.

- Per-vertex shading completely ignored the contributing lights' `specular_amount` and `size` parameters.

- Per-vertex specularity lacked a Geometry term entirely, resulting in overly bright rough highlights and a generally different "look" compared to per-pixel shading. It now uses the same approximate G term used for clearcoat specular.

- The `roughness_to_shininess` mapping from GGX roughness to Blinn-Phong shininess used for per-vertex shading resulted in wildly different specular responses between per-pixel and per-vertex shading. A new remapping has been made to replace it, which notably has a much lower high-end more suitable for per-vertex shading.

- Per-vertex shading incorrectly used the Blinn-Phong **RDF** normalization term `(shininess + 2.0) / (8.0 * PI)` as opposed to the **NDF** one `(shininess + 8.0) / (8.0 * PI)` (the NDF term is the one you want when multiplying by `NdotL`).

- The geometry normals used for per-vertex shading were not normalized prior to their use, causing vertex shading to be either too bright or too dark depending on the overall scale of the model matrix, especially specular shading.


| Before | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0d08a940-a0d6-45f9-b893-75745c775ef4) | ![image](https://github.com/user-attachments/assets/48e532df-d3ce-4974-9a0e-a1611507604f) | 

**TODO**:
- [ ] Port fixes to Mobile renderer.
- [ ] Port fixes to Compatibility renderer.