### PR TITLE
Add two global settings to operate type blocklist and suffixes in (native) create dialogs

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -951,6 +951,15 @@
 			Directory that contains the [code].sln[/code] file. By default, the [code].sln[/code] files is in the root of the project directory, next to the [code]project.godot[/code] and [code].csproj[/code] files.
 			Changing this value allows setting up a multi-project scenario where there are multiple [code].csproj[/code]. Keep in mind that the Godot project is considered one of the C# projects in the workspace and it's root directory should contain the [code]project.godot[/code] and [code].csproj[/code] next to each other.
 		</member>
+		<member name="editor/create_dialog/global_type_blocklist" type="PackedStringArray" setter="" getter="" default="PackedStringArray()">
+			A create dialog will hide all types in the blocklist.
+			[b]Note:[/b] Trying to list the base type (the root item in the dialog tree item component) will hide all types derived from the base type from the create dialog.
+		</member>
+		<member name="editor/create_dialog/global_type_suffixes" type="Dictionary" setter="" getter="" default="{}">
+			A create dialog will set a custom suffix to a specific type name. The suffix will follow the name of the type item with braces.
+			If a type is global and comes from a script, whose suffix should have been its file name, the suffix will be set to the mapped one.
+			[b]Note:[/b] As built-in types and GDExtension types does not have a suffix, the custom suffix will be removed if the type is not in the map list.
+		</member>
 		<member name="editor/export/convert_text_resources_to_binary" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], text resource ([code]tres[/code]) and text scene ([code]tscn[/code]) files are converted to their corresponding binary format on export. This decreases file sizes and speeds up loading slightly.
 			[b]Note:[/b] Because a resource's file extension may change in an exported project, it is heavily recommended to use [method @GDScript.load] or [ResourceLoader] instead of [FileAccess] to load resources dynamically.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -952,14 +952,16 @@
 			Changing this value allows setting up a multi-project scenario where there are multiple [code].csproj[/code]. Keep in mind that the Godot project is considered one of the C# projects in the workspace and it's root directory should contain the [code]project.godot[/code] and [code].csproj[/code] next to each other.
 		</member>
 		<member name="editor/create_dialog/global_type_blocklist" type="PackedStringArray" setter="" getter="" default="PackedStringArray()">
-			A create dialog will hide all types in the blocklist.
+			Types in the global type blocklist will be hidden from all create dialogs, no matter if the dialogs are native or popped up by calling [method EditorInterface.popup_create_dialog].
 			[b]Note:[/b] Trying to list the base type (the root item in the dialog tree item component) will hide all types derived from the base type from the create dialog.
+			[b]Note:[/b] If you have used [method EditorInterface.popup_create_dialog], and its parameter [code]type_blocklist[/code] has the same element as one in the global type blocklist, the parameter [code]type_blocklist[/code] will be preferred over the global type blocklist.
 		</member>
 		<member name="editor/create_dialog/global_type_suffixes" type="Dictionary" setter="" getter="" default="{}">
-			A create dialog will set a custom suffix to a specific type name. The suffix will follow the name of the type item with braces.
+			Types in the global type suffixes map list will contain a custom suffix following the type name in all create dialogs, no matter if the dialogs are native or popped up by calling [method EditorInterface.popup_create_dialog].
 			If a type is global and comes from a script, whose suffix should have been its file name, the suffix will be set to the mapped one.
 			[b]Note:[/b] As built-in types and GDExtension types does not have a suffix, the custom suffix will be removed if the type is not in the map list.
 			[b]Note:[/b] The keys of the dictionary should be [StringName]s and the values should be [String]s, otherwise it would lead to unexpected behaviors.
+			[b]Note:[/b] If you have used [method EditorInterface.popup_create_dialog], and its parameter [code]type_suffixes[/code] has the same key as one in the global type suffixes list, the value in the parameter [code]type_suffixes[/code] will be preferred over the value in the global type blocklist.
 		</member>
 		<member name="editor/export/convert_text_resources_to_binary" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], text resource ([code]tres[/code]) and text scene ([code]tscn[/code]) files are converted to their corresponding binary format on export. This decreases file sizes and speeds up loading slightly.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -959,6 +959,7 @@
 			A create dialog will set a custom suffix to a specific type name. The suffix will follow the name of the type item with braces.
 			If a type is global and comes from a script, whose suffix should have been its file name, the suffix will be set to the mapped one.
 			[b]Note:[/b] As built-in types and GDExtension types does not have a suffix, the custom suffix will be removed if the type is not in the map list.
+			[b]Note:[/b] The keys of the dictionary should be [StringName]s and the values should be [String]s, otherwise it would lead to unexpected behaviors.
 		</member>
 		<member name="editor/export/convert_text_resources_to_binary" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], text resource ([code]tres[/code]) and text scene ([code]tscn[/code]) files are converted to their corresponding binary format on export. This decreases file sizes and speeds up loading slightly.

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -299,14 +299,16 @@ void CreateDialog::_add_type(const StringName &p_type, TypeCategory p_type_categ
 void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringName &p_type, TypeCategory p_type_category) {
 	bool script_type = ScriptServer::is_global_class(p_type);
 	bool is_abstract = false;
-	Dictionary gts = GLOBAL_GET("editor/create_dialog/global_type_suffixes");
 	if (p_type_category == TypeCategory::CPP_TYPE) {
 		r_item->set_text(0, p_type);
 		String suffix;
 		if (custom_type_suffixes.has(p_type)) {
 			suffix = custom_type_suffixes.get(p_type);
-		} else if (gts.has(p_type)) {
-			suffix = gts[p_type];
+		} else {
+			Dictionary gts = GLOBAL_GET("editor/create_dialog/global_type_suffixes");
+			if (gts.has(p_type)) {
+				suffix = gts[p_type];
+			}
 		}
 		if (!suffix.is_empty()) {
 			r_item->set_suffix(0, "(" + suffix + ")");
@@ -322,8 +324,11 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		if (scr.is_valid()) {
 			if (custom_type_suffixes.has(p_type)) {
 				suffix = custom_type_suffixes.get(p_type);
-			} else if (gts.has(p_type)) {
-				suffix = gts[p_type];
+			} else {
+				Dictionary gts = GLOBAL_GET("editor/create_dialog/global_type_suffixes");
+				if (gts.has(p_type)) {
+					suffix = gts[p_type];
+				}
 			}
 		}
 		if (!suffix.is_empty()) {

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -270,6 +270,9 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<TileMapEditorPlugin>();
 
 	// For correct doc generation.
+	GLOBAL_DEF(PropertyInfo(Variant::PACKED_STRING_ARRAY, "editor/create_dialog/global_type_blocklist", PROPERTY_HINT_NONE, ""), PackedStringArray());
+	GLOBAL_DEF(PropertyInfo(Variant::DICTIONARY, "editor/create_dialog/global_type_suffixes", PROPERTY_HINT_NONE, ""), Dictionary());
+
 	GLOBAL_DEF("editor/run/main_run_args", "");
 
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "editor/script/templates_search_path", PROPERTY_HINT_DIR), "res://script_templates");


### PR DESCRIPTION
Continuation of #100135
Closes https://github.com/godotengine/godot-proposals/issues/11238 in another way

The second part of the pr 100135: Adding two project settings that even allows native create dialogs to hide some types (`editor/create_dialog/global_type_blocklist`, a `PackedStringArray`) and customize suffixes for types (`editor/create_dialog/global_type_suffixes`, a `Dictionary`, whose keys should be `StringName` and the values should belong to any of string types).

**Note:** 
* Priorities of type blocklist: Built-in > `popup_create_dialog(...)` > global type blocklist
* Priorities of type suffixes: the same as priorities of type blocklist.

Alternative: https://github.com/godotengine/godot/pull/100690
Only one of the two pr will be merged, and the other one will be closed if not.