### PR TITLE
Fix space transformations in WorldPositionFromDepth visual shader node generation

### DIFF
--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -1747,12 +1747,13 @@ String VisualShaderNodeWorldPositionFromDepth::generate_code(Shader::Mode p_mode
 
 	code += "		float __log_depth = textureLod(" + make_unique_id(p_type, p_id, "depth_tex") + ", " + uv + ", 0.0).x;\n";
 	if (!RenderingServer::get_singleton()->is_low_end()) {
-		code += "	vec4 __depth_view = INV_PROJECTION_MATRIX * vec4(" + uv + " * 2.0 - 1.0, __log_depth, 1.0);\n";
+		code += "		vec4 __ndc = vec4(" + uv + " * 2.0 - 1.0, __log_depth, 1.0);\n";
 	} else {
-		code += "	vec4 __depth_view = INV_PROJECTION_MATRIX * vec4(vec3(" + uv + ", __log_depth) * 2.0 - 1.0, 1.0);\n";
+		code += "		vec4 __ndc = vec4(vec3(" + uv + ", __log_depth) * 2.0 - 1.0, 1.0);\n";
 	}
-	code += "		__depth_view.xyz /= __depth_view.w;\n";
-	code += vformat("		%s = (INV_VIEW_MATRIX * __depth_view).xyz;\n", p_output_vars[0]);
+	code += "		vec4 __position_world = INV_VIEW_MATRIX * INV_PROJECTION_MATRIX * __ndc;\n";
+	code += "		__position_world.xyz /= __position_world.w;\n";
+	code += vformat("		%s = __position_world.xyz;\n", p_output_vars[0]);
 
 	code += "	}\n";
 	return code;


### PR DESCRIPTION
`WorldPositionFromDepth` Visual Shader node was only normalizing `xyz` components after transforming from NDC -> view-space, then transforming view-space -> world-space using the still homogenous `w` component, giving incorrect results.

Fix would be to simply divide `__depth_view.xyzw / __depth_view.w` before view->world transformation, however at the recommendation of @tetrapod00 I have opted to align the node's generated code with the example given in [Advanced post-processing](https://docs.godotengine.org/en/stable/tutorials/shaders/advanced_postprocessing.html#depth-texture).

![working world position](https://github.com/user-attachments/assets/371ee4c8-e499-4cdb-880d-b9b016bbac4c)

Fixes https://github.com/godotengine/godot/issues/100345