### PR TITLE
Fix deadlock possibility in threaded load of materials

### DIFF
--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -157,9 +157,13 @@ void CanvasItemMaterial::flush_changes() {
 }
 
 void CanvasItemMaterial::_queue_shader_change() {
+	if (!_is_initialized()) {
+		return;
+	}
+
 	MutexLock lock(material_mutex);
 
-	if (_is_initialized() && !element.in_list()) {
+	if (!element.in_list()) {
 		dirty_materials.add(&element);
 	}
 }

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1878,9 +1878,13 @@ void BaseMaterial3D::flush_changes() {
 }
 
 void BaseMaterial3D::_queue_shader_change() {
+	if (!_is_initialized()) {
+		return;
+	}
+
 	MutexLock lock(material_mutex);
 
-	if (_is_initialized() && !element.in_list()) {
+	if (!element.in_list()) {
 		dirty_materials.add(&element);
 	}
 }

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1164,9 +1164,13 @@ void ParticleProcessMaterial::flush_changes() {
 }
 
 void ParticleProcessMaterial::_queue_shader_change() {
+	if (!_is_initialized()) {
+		return;
+	}
+
 	MutexLock lock(material_mutex);
 
-	if (_is_initialized() && !element.in_list()) {
+	if (!element.in_list()) {
 		dirty_materials.add(&element);
 	}
 }


### PR DESCRIPTION
`_is_initialized()` checks the initialization state of the material, which is only a concern of the thread that is creating or loading it. Therefore, no locking is needed. Splitting the creation or loading of a material among threads is not supported, also. What's more, locking can lead to deadlocks involving the main thread, as it tries to flush the update list, and loader threads. That's the hazard (seen in practice) this PR avoids.

Version of this PR for 4.3 submitted as #100357 .