### PR TITLE
Optimize `StringName` by storing `Span<char>` instead of `const char *` for static C strings.

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -33,15 +33,9 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 
-StaticCString StaticCString::create(const char *p_ptr) {
-	StaticCString scs;
-	scs.ptr = p_ptr;
-	return scs;
-}
-
 bool StringName::_Data::operator==(const String &p_name) const {
-	if (cname) {
-		return p_name == cname;
+	if (cname.ptr()) {
+		return p_name == cname.ptr();
 	} else {
 		return name == p_name;
 	}
@@ -52,8 +46,8 @@ bool StringName::_Data::operator!=(const String &p_name) const {
 }
 
 bool StringName::_Data::operator==(const char *p_name) const {
-	if (cname) {
-		return strcmp(cname, p_name) == 0;
+	if (cname.ptr()) {
+		return strcmp(cname.ptr(), p_name) == 0;
 	} else {
 		return name == p_name;
 	}
@@ -115,7 +109,8 @@ void StringName::cleanup() {
 				lost_strings++;
 
 				if (OS::get_singleton()->is_stdout_verbose()) {
-					String dname = String(d->cname ? d->cname : d->name);
+					// FIXME Should be utf8, see https://github.com/godotengine/godot/issues/100641.
+					String dname = d->cname.ptr() ? String::latin1(d->cname) : d->name;
 
 					print_line(vformat("Orphan StringName: %s (static: %d, total: %d)", dname, d->static_count.get(), d->refcount.get()));
 				}
@@ -138,8 +133,8 @@ void StringName::unref() {
 		MutexLock lock(mutex);
 
 		if (CoreGlobals::leak_reporting_enabled && _data->static_count.get() > 0) {
-			if (_data->cname) {
-				ERR_PRINT("BUG: Unreferenced static string to 0: " + String(_data->cname));
+			if (_data->cname.ptr()) {
+				ERR_PRINT("BUG: Unreferenced static string to 0: " + String(_data->cname.ptr()));
 			} else {
 				ERR_PRINT("BUG: Unreferenced static string to 0: " + String(_data->name));
 			}
@@ -193,9 +188,9 @@ bool StringName::operator!=(const char *p_name) const {
 
 char32_t StringName::operator[](int p_index) const {
 	if (_data) {
-		if (_data->cname) {
-			CRASH_BAD_INDEX(p_index, static_cast<long>(strlen(_data->cname)));
-			return _data->cname[p_index];
+		if (_data->cname.ptr()) {
+			CRASH_BAD_INDEX(p_index, static_cast<long>(_data->cname.size()));
+			return _data->cname.ptr()[p_index];
 		} else {
 			return _data->name[p_index];
 		}
@@ -207,8 +202,8 @@ char32_t StringName::operator[](int p_index) const {
 
 int StringName::length() const {
 	if (_data) {
-		if (_data->cname) {
-			return strlen(_data->cname);
+		if (_data->cname.ptr()) {
+			return _data->cname.size();
 		} else {
 			return _data->name.length();
 		}
@@ -219,8 +214,8 @@ int StringName::length() const {
 
 bool StringName::is_empty() const {
 	if (_data) {
-		if (_data->cname) {
-			return _data->cname[0] == 0;
+		if (_data->cname.ptr()) {
+			return _data->cname.size() == 0;
 		} else {
 			return _data->name.is_empty();
 		}
@@ -302,7 +297,7 @@ StringName::StringName(const char *p_name, bool p_static) {
 	_data->static_count.set(p_static ? 1 : 0);
 	_data->hash = hash;
 	_data->idx = idx;
-	_data->cname = nullptr;
+	_data->cname = Span<char>();
 	_data->next = _table[idx];
 	_data->prev = nullptr;
 
@@ -324,9 +319,9 @@ StringName::StringName(const StaticCString &p_static_string, bool p_static) {
 
 	ERR_FAIL_COND(!configured);
 
-	ERR_FAIL_COND(!p_static_string.ptr || !p_static_string.ptr[0]);
+	ERR_FAIL_COND(!p_static_string.span.ptr() || p_static_string.span.ptr()[p_static_string.span.size()] != 0);
 
-	const uint32_t hash = String::hash(p_static_string.ptr);
+	const uint32_t hash = String::hash(p_static_string.span.ptr(), p_static_string.span.size());
 	const uint32_t idx = hash & STRING_TABLE_MASK;
 
 	MutexLock lock(mutex);
@@ -334,7 +329,7 @@ StringName::StringName(const StaticCString &p_static_string, bool p_static) {
 
 	while (_data) {
 		// compare hash first
-		if (_data->hash == hash && _data->operator==(p_static_string.ptr)) {
+		if (_data->hash == hash && _data->operator==(p_static_string.span.ptr())) {
 			break;
 		}
 		_data = _data->next;
@@ -359,7 +354,7 @@ StringName::StringName(const StaticCString &p_static_string, bool p_static) {
 	_data->static_count.set(p_static ? 1 : 0);
 	_data->hash = hash;
 	_data->idx = idx;
-	_data->cname = p_static_string.ptr;
+	_data->cname = p_static_string.span;
 	_data->next = _table[idx];
 	_data->prev = nullptr;
 #ifdef DEBUG_ENABLED
@@ -416,7 +411,7 @@ StringName::StringName(const String &p_name, bool p_static) {
 	_data->static_count.set(p_static ? 1 : 0);
 	_data->hash = hash;
 	_data->idx = idx;
-	_data->cname = nullptr;
+	_data->cname = Span<char>();
 	_data->next = _table[idx];
 	_data->prev = nullptr;
 #ifdef DEBUG_ENABLED

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -39,8 +39,12 @@
 class Main;
 
 struct StaticCString {
-	const char *ptr;
-	static StaticCString create(const char *p_ptr);
+	const Span<char> span;
+
+	// Argument must be a static, null-terminated C string.
+	static StaticCString create(const char *p_ptr) {
+		return StaticCString{ Span(p_ptr, p_ptr ? strlen(p_ptr) : 0) };
+	}
 };
 
 class StringName {
@@ -53,12 +57,13 @@ class StringName {
 	struct _Data {
 		SafeRefCount refcount;
 		SafeNumeric<uint32_t> static_count;
-		const char *cname = nullptr;
+		Span<char> cname = Span<char>();
 		String name;
 #ifdef DEBUG_ENABLED
 		uint32_t debug_references = 0;
 #endif
-		String get_name() const { return cname ? String(cname) : name; }
+		// FIXME Should be utf8, see https://github.com/godotengine/godot/issues/100641.
+		String get_name() const { return cname.ptr() ? String::latin1(cname) : name; }
 		bool operator==(const String &p_name) const;
 		bool operator!=(const String &p_name) const;
 		bool operator==(const char *p_name) const;
@@ -97,7 +102,7 @@ class StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
-	operator const void *() const { return (_data && (_data->cname || !_data->name.is_empty())) ? (void *)1 : nullptr; }
+	operator const void *() const { return (_data && (_data->cname.ptr() || !_data->name.is_empty())) ? (void *)1 : nullptr; }
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;
@@ -112,8 +117,8 @@ public:
 		if (!_data) {
 			return false;
 		}
-		if (_data->cname != nullptr) {
-			return (char32_t)_data->cname[0] == (char32_t)UNIQUE_NODE_PREFIX[0];
+		if (_data->cname.ptr() != nullptr) {
+			return (char32_t)_data->cname.ptr()[0] == (char32_t)UNIQUE_NODE_PREFIX[0];
 		} else {
 			return (char32_t)_data->name[0] == (char32_t)UNIQUE_NODE_PREFIX[0];
 		}
@@ -150,15 +155,7 @@ public:
 	}
 
 	_FORCE_INLINE_ operator String() const {
-		if (_data) {
-			if (_data->cname) {
-				return String(_data->cname);
-			} else {
-				return _data->name;
-			}
-		}
-
-		return String();
+		return _data ? _data->get_name() : String();
 	}
 
 	static StringName search(const char *p_name);
@@ -167,8 +164,8 @@ public:
 
 	struct AlphCompare {
 		_FORCE_INLINE_ bool operator()(const StringName &l, const StringName &r) const {
-			const char *l_cname = l._data ? l._data->cname : "";
-			const char *r_cname = r._data ? r._data->cname : "";
+			const char *l_cname = l._data ? l._data->cname.ptr() : "";
+			const char *r_cname = r._data ? r._data->cname.ptr() : "";
 
 			if (l_cname) {
 				if (r_cname) {


### PR DESCRIPTION
This avoids needless repeated `strlen` calls for simple operations on `StringName`, and will enable further optimizations in follow-up PRs.

The `PR` also adds the `String::ascii` factory method for `String` which constructs the string from a known-length `ascii` string. No implementation is needed for this constructor since it merely calls the appropriate `copy_from`.

## Benchmark
I tested one of the most affected beneficiaries, which is `operator[]` since it called `strlen` to verify the index. `string_name[x]` now runs at complexity `O(1)` instead of `O(n)`, which can lead to a 4x speed up for one arbitrary long StringName actually used in the codebase:

```c++
	StringName test = StaticCString::create("node_configuration_warning_changed");

	auto t0 = std::chrono::high_resolution_clock::now();
	for (int i = 0; i < 100000000; i ++) {
		char32_t c = test[5];
	}
	auto t1 = std::chrono::high_resolution_clock::now();
	std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
```

This yields
- `452ms` for `master` (ba2c5c1e6196b774d55baa45de54aab530db08e9)
- `114ms` for this PR (487cc07c67b24593ffbd3211b0879d3142346bcd)

Other beneficiaries are (currently) `length()`, `operator String()` and the `StaticCString` constructor, which can now (sometimes) be evaluated for length at compile time rather than needing to call `strlen`.

## Discussion
Future PRs should address other functions like `operator==` and `AlphCompare`, as well as the `const char *` constructor, which could be accelerated by using the known length.
A future PR could also accelerate `D_METHODP` by taking `StaticCString` instead of `const char*` as arguments, so the `strlen` can be evaluated at compile time there too.

It might be good to store `String` instead of `Span<char>`, see https://github.com/godotengine/godot-proposals/issues/11517. This would partially supersede this PR.