### PR TITLE
Improve usage of p_cancel_sliding and snapping refractoring.

### DIFF
--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -81,7 +81,7 @@ bool CharacterBody2D::move_and_slide() {
 		}
 
 		PhysicsServer2D::MotionResult floor_result;
-		if (move_and_collide(parameters, floor_result, false, false)) {
+		if (move_and_collide(parameters, floor_result, false)) {
 			motion_results.push_back(floor_result);
 			_set_collision_direction(floor_result);
 		}
@@ -138,7 +138,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 		Vector2 prev_position = parameters.from.columns[2];
 
 		PhysicsServer2D::MotionResult result;
-		bool collided = move_and_collide(parameters, result, false, !sliding_enabled);
+		bool collided = move_and_collide(parameters, result, false);
 
 		last_motion = result.travel;
 
@@ -293,7 +293,7 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 		parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 
 		PhysicsServer2D::MotionResult result;
-		bool collided = move_and_collide(parameters, result, false, false);
+		bool collided = move_and_collide(parameters, result, false);
 
 		last_motion = result.travel;
 
@@ -345,25 +345,18 @@ void CharacterBody2D::_apply_floor_snap(bool p_wall_as_floor) {
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer2D::MotionResult result;
-	if (move_and_collide(parameters, result, true, false)) {
+	if (move_and_collide(parameters, result, true)) {
 		if ((result.get_angle(up_direction) <= floor_max_angle + FLOOR_ANGLE_THRESHOLD) ||
 				(p_wall_as_floor && result.get_angle(-up_direction) > floor_max_angle + FLOOR_ANGLE_THRESHOLD)) {
 			on_floor = true;
 			floor_normal = result.collision_normal;
 			_set_platform_data(result);
 
-			// Ensure that we only move the body along the up axis, because
-			// move_and_collide may stray the object a bit when getting it unstuck.
-			// Canceling this motion should not affect move_and_slide, as previous
-			// calls to move_and_collide already took care of freeing the body.
+			// Only move the body if we are not close enough already.
 			if (result.travel.length() > margin) {
-				result.travel = up_direction * up_direction.dot(result.travel);
-			} else {
-				result.travel = Vector2();
+				parameters.from.columns[2] += result.travel;
+				set_global_transform(parameters.from);
 			}
-
-			parameters.from.columns[2] += result.travel;
-			set_global_transform(parameters.from);
 		}
 	}
 }
@@ -389,6 +382,9 @@ bool CharacterBody2D::_on_floor_if_snapped(bool p_was_on_floor, bool p_vel_dir_f
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer2D::MotionResult result;
+	// We only want to know if there is a floor under the body,
+	// so an accurate resolution is not needed.
+	// Don't use p_cancel_sliding to speed things up a little.
 	if (move_and_collide(parameters, result, true, false)) {
 		if (result.get_angle(up_direction) <= floor_max_angle + FLOOR_ANGLE_THRESHOLD) {
 			return true;

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -100,7 +100,7 @@ bool CharacterBody3D::move_and_slide() {
 		}
 
 		PhysicsServer3D::MotionResult floor_result;
-		if (move_and_collide(parameters, floor_result, false, false)) {
+		if (move_and_collide(parameters, floor_result, false)) {
 			motion_results.push_back(floor_result);
 
 			CollisionState result_state;
@@ -161,7 +161,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 		parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 
 		PhysicsServer3D::MotionResult result;
-		bool collided = move_and_collide(parameters, result, false, !sliding_enabled);
+		bool collided = move_and_collide(parameters, result, false);
 
 		last_motion = result.travel;
 
@@ -407,7 +407,7 @@ void CharacterBody3D::_move_and_slide_floating(double p_delta) {
 		parameters.recovery_as_collision = true; // Also report collisions generated only from recovery.
 
 		PhysicsServer3D::MotionResult result;
-		bool collided = move_and_collide(parameters, result, false, false);
+		bool collided = move_and_collide(parameters, result, false);
 
 		last_motion = result.travel;
 
@@ -463,22 +463,13 @@ void CharacterBody3D::apply_floor_snap() {
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer3D::MotionResult result;
-	if (move_and_collide(parameters, result, true, false)) {
+	if (move_and_collide(parameters, result, true)) {
 		CollisionState result_state;
 		// Apply direction for floor only.
 		_set_collision_direction(result, result_state, CollisionState(true, false, false));
 
-		if (result_state.floor) {
-			// Ensure that we only move the body along the up axis, because
-			// move_and_collide may stray the object a bit when getting it unstuck.
-			// Canceling this motion should not affect move_and_slide, as previous
-			// calls to move_and_collide already took care of freeing the body.
-			if (result.travel.length() > margin) {
-				result.travel = up_direction * up_direction.dot(result.travel);
-			} else {
-				result.travel = Vector3();
-			}
-
+		// Only move the body if we are not close enough already.
+		if (result_state.floor && result.travel.length() > margin) {
 			parameters.from.origin += result.travel;
 			set_global_transform(parameters.from);
 		}
@@ -507,6 +498,9 @@ bool CharacterBody3D::_on_floor_if_snapped(bool p_was_on_floor, bool p_vel_dir_f
 	parameters.collide_separation_ray = true;
 
 	PhysicsServer3D::MotionResult result;
+	// We only want to know if there is a floor under the body,
+	// so an accurate resolution is not needed.
+	// Don't use p_cancel_sliding to speed things up a little.
 	if (move_and_collide(parameters, result, true, false)) {
 		CollisionState result_state;
 		// Don't apply direction for any type.


### PR DESCRIPTION
This addresses an issue with the usage of `p_cancel_sliding` inside of `characterBody3D`. 

### Explanation of the issue:

`move_and_collide` can place the body outside of the motion vector on the recovery phase. For this, the equivalent internal method has a parameter called `p_cancel_sliding`.  This will try and place the body in a valid place as long as the penetration isn't too deep to be safely done. This is meant to alleviate  the side effects of `move_and_collide` not being a true "sweep" when used for this purposes (Which is effectively always, the exposed GDScript method even has this parameter not exposed and set to `true` by default to match the expected behavior).

When `p_cancel_sliding` is not used, the body will "slide" out of it's intended path as a result of the recovery phase. Note that this "sliding" is not accurate to any real behavior. While it does kinematic resolution, it does it after we have tried to approximate as much as we could the exact position of the collision. This limits the penetration of the moving body into the another and therefore the kinematic resolution is not comparable to that of a complete solver. That's is the reason for the always slow but constant sliding it causes when not used.

### How it affects `move_and_slide`:

There are multiple instances inside `move_and_slide` in which `p_cancel_slide` was set to false, straying the body from the intended motion path. Some instances of this are quite visible as it was the case with https://github.com/godotengine/godot/pull/99397 in which the body could stray various cm from it's intended position. Others may be less noticeable, but the same principle applies. There was an extra "Ghost" movement always presents which contributed to the body being stuck for example as a result of being resolved against an already collided planed, decreasing the stability of the algorithm. As @rburing pointed out the original intention was probably to use this kinematic resolution as part of the sliding movement, but as i already said this resolution is not physically accurate and even if it was, we would be adding unwanted motion to an algorithm who's only purpose is to manually simulate the movement and resolution of the body against the collided planes.

### What this PR does:

It fixes all of the instances in which `p_cancel_sliding` was being set to `false` on calls to `move_and_collide` that have an impact on the motion of the body (All of them with the exception of `on_floor_if_snapped`, which never actually moves the body and therefore we can disable it to save a bit of computing).

This also allowed me to refactor `apply_floor_snap` to be simpler and easier to read. Note that this change is fully equivalent to the one of https://github.com/godotengine/godot/pull/99397 for the final user, which you can verify by using this pr and the mpr of the the other pr.  The only difference is that `p_cancel_sliding`  will make sure it's safe to perform this correction so the body doesn't get stuck.

This PR was tested by me with the 3º person demo and tested by @tracefree too. No regressions were observed and the body is slightly more precise while colliding against angled walls, for example. While this last part is hardly noticeable for itself it should contribute to less "random" and hard to identify situations as a result of a kinematic resolution we don't want and can't control.












