### PR TITLE
[4.3] Fix deadlock possibility in threaded load of materials

### DIFF
--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -157,9 +157,13 @@ void CanvasItemMaterial::flush_changes() {
 }
 
 void CanvasItemMaterial::_queue_shader_change() {
+	if (!_is_initialized()) {
+		return;
+	}
+
 	MutexLock lock(material_mutex);
 
-	if (_is_initialized() && !element.in_list()) {
+	if (!element.in_list()) {
 		dirty_materials.add(&element);
 	}
 }

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1878,9 +1878,13 @@ void BaseMaterial3D::flush_changes() {
 }
 
 void BaseMaterial3D::_queue_shader_change() {
+	if (!_is_initialized()) {
+		return;
+	}
+
 	MutexLock lock(material_mutex);
 
-	if (_is_initialized() && !element.in_list()) {
+	if (!element.in_list()) {
 		dirty_materials.add(&element);
 	}
 }

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -1164,9 +1164,13 @@ void ParticleProcessMaterial::flush_changes() {
 }
 
 void ParticleProcessMaterial::_queue_shader_change() {
+	if (!_is_initialized()) {
+		return;
+	}
+
 	MutexLock lock(material_mutex);
 
-	if (_is_initialized() && !element.in_list()) {
+	if (!element.in_list()) {
 		dirty_materials.add(&element);
 	}
 }


### PR DESCRIPTION
This is the version of #100363 for 4.3.

Submitted separately despite the diff looking similar to avoid conflicts as this code was changed back and forth in 4.4.
