### PR TITLE
Remove solid boxes in gizmos of VoxelGI and ReflectionProbe

### DIFF
--- a/editor/plugins/gizmos/reflection_probe_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/reflection_probe_gizmo_plugin.cpp
@@ -47,9 +47,6 @@ ReflectionProbeGizmoPlugin::ReflectionProbeGizmoPlugin() {
 	gizmo_color.a = 0.5;
 	create_material("reflection_internal_material", gizmo_color);
 
-	gizmo_color.a = 0.025;
-	create_material("reflection_probe_solid_material", gizmo_color);
-
 	create_icon_material("reflection_probe_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoReflectionProbe"), EditorStringName(EditorIcons)));
 	create_handle_material("handles");
 }
@@ -209,11 +206,6 @@ void ReflectionProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 		p_gizmo->add_lines(lines, material);
 		p_gizmo->add_lines(internal_lines, material_internal);
-
-		if (p_gizmo->is_selected()) {
-			Ref<Material> solid_material = get_material("reflection_probe_solid_material", p_gizmo);
-			p_gizmo->add_solid_box(solid_material, probe->get_size());
-		}
 
 		p_gizmo->add_handles(handles, get_material("handles"));
 	}

--- a/editor/plugins/gizmos/voxel_gi_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/voxel_gi_gizmo_plugin.cpp
@@ -46,11 +46,8 @@ VoxelGIGizmoPlugin::VoxelGIGizmoPlugin() {
 	create_material("voxel_gi_material", gizmo_color);
 
 	// This gizmo draws a lot of lines. Use a low opacity to make it not too intrusive.
-	gizmo_color.a = 0.03;
+	gizmo_color.a = 0.02;
 	create_material("voxel_gi_internal_material", gizmo_color);
-
-	gizmo_color.a = 0.025;
-	create_material("voxel_gi_solid_material", gizmo_color);
 
 	create_icon_material("voxel_gi_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoVoxelGI"), EditorStringName(EditorIcons)));
 	create_handle_material("handles");
@@ -163,11 +160,6 @@ void VoxelGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(lines, material_internal);
 
 		Vector<Vector3> handles = helper->box_get_handles(probe->get_size());
-
-		if (p_gizmo->is_selected()) {
-			Ref<Material> solid_material = get_material("voxel_gi_solid_material", p_gizmo);
-			p_gizmo->add_solid_box(solid_material, aabb.get_size());
-		}
 
 		p_gizmo->add_handles(handles, get_material("handles"));
 	}


### PR DESCRIPTION
- *Production edit: Follow-up to https://github.com/godotengine/godot/pull/99920
and https://github.com/godotengine/godot/pull/99969.*

Removes the solid boxes in the gizmos of VoxelGI and ReflectionProbes for improved visibility.

This is definitely a tradeoff since their scale and positioning is less obvious now, especially for ReflectionProbes, however the solid box is extremely intrusive. It requires users to move their view inside of the probe, or constantly toggle gizmos, which is really cumbersome. You can't get a decent view of how the probe is sitting in the environment and what effect your adjustments have. You're either only seeing whatever is outside the probe or whatever is inside.

An additional issue with the boxes is that their amount of obstructing differs from scene to scene, in some scenes the opacity is very low, while in other scenes it prevents you from seeing what's happening inside the bounds.

In the same vein, I've slightly reduced the opacity of the VoxelGI gridlines, since they're mostly just an indication of voxel size, and are (still) very obstructive.

In an ideal world we would be able to show the solid boxes only when the size is being adjusted, but (I believe) there's no way at the moment to detect whether or not a handle is grabbed in the gizmo, and then there's also the question of how that behavior would combine with adjustments done in the inspector.

This solution is not ideal, but I'd argue the lesser of two evils for now.

| PR | Master |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/3e1335ed-48d1-482f-a53c-ed505a3571c7) | ![image](https://github.com/user-attachments/assets/87cb8b8e-f6ff-4db4-82da-7e32aa3b25cf) |
| ![image](https://github.com/user-attachments/assets/af9545bf-5eee-4216-865b-e38935b7d81c) | ![image](https://github.com/user-attachments/assets/2f71ac91-1bfe-4902-9897-4d7afb8a6ace) |
| ![image](https://github.com/user-attachments/assets/beb3ca9a-f052-4b54-9879-a27c4f242624) | ![image](https://github.com/user-attachments/assets/baca6e31-081b-4f47-a39a-a817c8b60860) |
| ![image](https://github.com/user-attachments/assets/cf23491a-6b34-4c87-b606-e5752a910610) | ![image](https://github.com/user-attachments/assets/4cc6b679-a77b-4479-85ef-4a146209fea6) |


