### PR TITLE
Don't rebuild tree when selecting a file in FileSystem list view

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3556,9 +3556,6 @@ void FileSystemDock::_file_multi_selected(int p_index, bool p_selected) {
 		String fpath = files->get_item_metadata(current);
 		if (!fpath.ends_with("/")) {
 			current_path = fpath;
-			if (display_mode != DISPLAY_MODE_TREE_ONLY) {
-				_update_tree(get_uncollapsed_paths());
-			}
 		}
 	}
 


### PR DESCRIPTION
Similar to #100010

Ever since #21426 the FileSystem tree has been rebuilt everytime a file is selected while using the split view. I cannot find a reason for this.

Since only folders are shown in the tree when using the split view this has not had a huge performance impact, but could potentially be noticeable in a large project with many folders.