### PR TITLE
Scene Shaders - Comment Styles and Formatting

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -48,16 +48,16 @@ LIGHTMAP_BICUBIC_FILTER = false
 
 #include "stdlib_inc.glsl"
 
-#if !defined(MODE_RENDER_DEPTH) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED) ||defined(LIGHT_CLEARCOAT_USED)
+#if !defined(MODE_RENDER_DEPTH) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED) || defined(LIGHT_CLEARCOAT_USED)
 #ifndef NORMAL_USED
 #define NORMAL_USED
-#endif
-#endif
+#endif // !NORMAL_USED
+#endif // !MODE_RENDER_DEPTH || TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED || LIGHT_CLEARCOAT_USED
 
 #ifdef MODE_UNSHADED
 #ifdef USE_ADDITIVE_LIGHTING
 #undef USE_ADDITIVE_LIGHTING
-#endif
+#endif // USE_ADDITIVE_LIGHTING
 #endif // MODE_UNSHADED
 
 /*
@@ -82,48 +82,48 @@ ARRAY_WEIGHTS = 11, // RGBA16UNORM (x2 if 8 weights)
 layout(location = 0) in highp vec4 vertex_angle_attrib;
 /* clang-format on */
 
-#ifdef NORMAL_USED
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
 // Contains Normal/Axis in RG, can contain tangent in BA.
 layout(location = 1) in vec4 axis_tangent_attrib;
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 
-// location 2 is unused.
+// Location 2 is unused.
 
 #if defined(COLOR_USED)
 layout(location = 3) in vec4 color_attrib;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 4) in vec2 uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP) || defined(RENDER_MATERIAL)
 layout(location = 5) in vec2 uv2_attrib;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP || RENDER_MATERIAL
 
 #if defined(CUSTOM0_USED)
 layout(location = 6) in vec4 custom0_attrib;
-#endif
+#endif // CUSTOM0_USED
 
 #if defined(CUSTOM1_USED)
 layout(location = 7) in vec4 custom1_attrib;
-#endif
+#endif // CUSTOM1_USED
 
 #if defined(CUSTOM2_USED)
 layout(location = 8) in vec4 custom2_attrib;
-#endif
+#endif // CUSTOM2_USED
 
 #if defined(CUSTOM3_USED)
 layout(location = 9) in vec4 custom3_attrib;
-#endif
+#endif // CUSTOM3_USED
 
 #if defined(BONES_USED)
 layout(location = 10) in uvec4 bone_attrib;
-#endif
+#endif // BONES_USED
 
 #if defined(WEIGHTS_USED)
 layout(location = 11) in vec4 weight_attrib;
-#endif
+#endif // WEIGHTS_USED
 
 vec3 oct_to_vec3(vec2 e) {
 	vec3 v = vec3(e.xy, 1.0 - abs(e.x) - abs(e.y));
@@ -147,13 +147,15 @@ layout(location = 12) in highp vec4 instance_xform0;
 layout(location = 13) in highp vec4 instance_xform1;
 layout(location = 14) in highp vec4 instance_xform2;
 layout(location = 15) in highp uvec4 instance_color_custom_data; // Color packed into xy, Custom data into zw.
-#endif
+#endif // USE_INSTANCING
 
 #define FLAGS_NON_UNIFORM_SCALE (1 << 4)
 
-layout(std140) uniform GlobalShaderUniformData { //ubo:1
+/* clang-format off */
+layout(std140) uniform GlobalShaderUniformData { // ubo:1
 	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
+/* clang-format on */
 
 layout(std140) uniform SceneData { // ubo:2
 	highp mat4 projection_matrix;
@@ -217,9 +219,11 @@ struct PositionalShadowData {
 	highp float shadow_atlas_pixel_size;
 };
 
+/* clang-format off */
 layout(std140) uniform PositionalShadows { // ubo:9
 	PositionalShadowData positional_shadows[MAX_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 
 uniform lowp uint positional_shadow_index;
 
@@ -239,9 +243,11 @@ struct DirectionalShadowData {
 	mediump vec2 pad;
 };
 
+/* clang-format off */
 layout(std140) uniform DirectionalShadows { // ubo:10
 	DirectionalShadowData directional_shadows[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 
 uniform lowp uint directional_shadow_index;
 
@@ -272,14 +278,16 @@ struct DirectionalLightData {
 	mediump float specular;
 };
 
+/* clang-format off */
 layout(std140) uniform DirectionalLights { // ubo:7
 	DirectionalLightData directional_lights[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 
 #define LIGHT_BAKE_DISABLED 0u
 #define LIGHT_BAKE_STATIC 1u
 #define LIGHT_BAKE_DYNAMIC 2u
-#endif // !DISABLE_LIGHT_DIRECTIONAL
+#endif // !DISABLE_LIGHT_DIRECTIONAL || (!ADDITIVE_OMNI && !ADDITIVE_SPOT && USE_ADDITIVE_LIGHTING)
 
 // Omni and spot light data.
 #if !defined(DISABLE_LIGHT_OMNI) || !defined(DISABLE_LIGHT_SPOT) || (defined(ADDITIVE_OMNI) || defined(ADDITIVE_SPOT) && defined(USE_ADDITIVE_LIGHTING))
@@ -304,33 +312,37 @@ struct LightData { // This structure needs to be as packed as possible.
 };
 
 #if !defined(DISABLE_LIGHT_OMNI) || defined(ADDITIVE_OMNI)
+/* clang-format off */
 layout(std140) uniform OmniLightData { // ubo:5
 	LightData omni_lights[MAX_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 #ifdef BASE_PASS
 uniform uint omni_light_indices[MAX_FORWARD_LIGHTS];
 uniform uint omni_light_count;
 #endif // BASE_PASS
-#endif // DISABLE_LIGHT_OMNI
+#endif // !DISABLE_LIGHT_OMNI || ADDITIVE_OMNI
 
 #if !defined(DISABLE_LIGHT_SPOT) || defined(ADDITIVE_SPOT)
+/* clang-format off */
 layout(std140) uniform SpotLightData { // ubo:6
 	LightData spot_lights[MAX_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 #ifdef BASE_PASS
 uniform uint spot_light_indices[MAX_FORWARD_LIGHTS];
 uniform uint spot_light_count;
 #endif // BASE_PASS
-#endif // DISABLE_LIGHT_SPOT
-#endif // !defined(DISABLE_LIGHT_OMNI) || !defined(DISABLE_LIGHT_SPOT) || (defined(ADDITIVE_OMNI) || defined(ADDITIVE_SPOT) && defined(USE_ADDITIVE_LIGHTING))
+#endif // !DISABLE_LIGHT_SPOT || ADDITIVE_SPOT
+#endif // !DISABLE_LIGHT_OMNI || !DISABLE_LIGHT_SPOT || (ADDITIVE_OMNI || ADDITIVE_SPOT && USE_ADDITIVE_LIGHTING)
 
 #ifdef USE_ADDITIVE_LIGHTING
 #ifdef ADDITIVE_OMNI
 uniform lowp uint omni_light_index;
-#endif
+#endif // ADDITIVE_OMNI
 #ifdef ADDITIVE_SPOT
 uniform lowp uint spot_light_index;
-#endif
+#endif // ADDITIVE_SPOT
 #endif // USE_ADDITIVE_LIGHTING
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
@@ -347,30 +359,28 @@ mediump float roughness_to_shininess(mediump float roughness) {
 void light_compute(vec3 N, vec3 L, vec3 V, vec3 light_color, bool is_directional, float roughness,
 		inout vec3 diffuse_light, inout vec3 specular_light) {
 	float NdotL = min(dot(N, L), 1.0);
-	float cNdotL = max(NdotL, 0.0); // clamped NdotL
+	float cNdotL = max(NdotL, 0.0);
 
 #if defined(DIFFUSE_LAMBERT_WRAP)
 	// Energy conserving lambert wrap shader.
 	// https://web.archive.org/web/20210228210901/http://blog.stevemcauley.com/2011/12/03/energy-conserving-wrapped-diffuse/
 	float diffuse_brdf_NL = max(0.0, (cNdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness))) * (1.0 / M_PI);
-#else
-	// lambert
+#else // DIFFUSE_LAMBERT_WRAP
+	// Lambert.
 	float diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
-#endif
+#endif // DIFFUSE_LAMBERT_WRAP
 
 	diffuse_light += light_color * diffuse_brdf_NL;
 
 #if !defined(SPECULAR_DISABLED)
-	float specular_brdf_NL = 0.0;
-	// Normalized blinn always unless disabled.
+	// Normalized Blinn always unless disabled.
 	vec3 H = normalize(V + L);
 	float cNdotH = clamp(dot(N, H), 0.0, 1.0);
 	float shininess = roughness_to_shininess(roughness);
 	float blinn = pow(cNdotH, shininess);
 	blinn *= (shininess + 2.0) * (1.0 / (8.0 * M_PI)) * cNdotL;
-	specular_brdf_NL = blinn;
-	specular_light += specular_brdf_NL * light_color;
-#endif
+	specular_light += blinn * light_color;
+#endif // !SPECULAR_DISABLED
 }
 
 float get_omni_spot_attenuation(float distance, float inv_range, float decay) {
@@ -394,7 +404,7 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, float 
 			diffuse_light,
 			specular_light);
 }
-#endif // !defined(DISABLE_LIGHT_OMNI) || (defined(ADDITIVE_OMNI) && defined(USE_ADDITIVE_LIGHTING))
+#endif // !DISABLE_LIGHT_OMNI || (ADDITIVE_OMNI && USE_ADDITIVE_LIGHTING)
 
 #if !defined(DISABLE_LIGHT_SPOT) || (defined(ADDITIVE_SPOT) && defined(USE_ADDITIVE_LIGHTING))
 void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, float roughness,
@@ -415,9 +425,9 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, float 
 	light_compute(normal, normalize(light_rel_vec), eye_vec, color, false, roughness,
 			diffuse_light, specular_light);
 }
-#endif // !defined(DISABLE_LIGHT_SPOT) || (defined(ADDITIVE_SPOT) && defined(USE_ADDITIVE_LIGHTING))
+#endif // !DISABLE_LIGHT_SPOT || (ADDITIVE_SPOT && USE_ADDITIVE_LIGHTING)
 
-#endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
 
 #endif // USE_VERTEX_LIGHTING
 
@@ -428,7 +438,7 @@ layout(std140) uniform MultiviewData { // ubo:8
 	highp vec4 eye_offset[MAX_VIEWS];
 }
 multiview_data;
-#endif
+#endif // USE_MULTIVIEW
 
 uniform highp mat4 world_transform;
 uniform highp vec3 compressed_aabb_position;
@@ -440,56 +450,52 @@ uniform highp uint model_flags;
 
 #ifdef RENDER_MATERIAL
 uniform mediump vec2 uv_offset;
-#endif
+#endif // RENDER_MATERIAL
 
 /* Varyings */
 
 out highp vec3 vertex_interp;
 #ifdef NORMAL_USED
 out vec3 normal_interp;
-#endif
+#endif // NORMAL_USED
 
 #if defined(COLOR_USED)
 out vec4 color_interp;
-#endif
+#endif // COLOR_USED
 
 #if defined(UV_USED)
 out vec2 uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 out vec2 uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 out vec3 tangent_interp;
 out vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #ifdef USE_ADDITIVE_LIGHTING
 out highp vec4 shadow_coord;
 
 #if defined(LIGHT_USE_PSSM2) || defined(LIGHT_USE_PSSM4)
 out highp vec4 shadow_coord2;
-#endif
+#endif // LIGHT_USE_PSSM2 || LIGHT_USE_PSSM4
 
 #ifdef LIGHT_USE_PSSM4
 out highp vec4 shadow_coord3;
 out highp vec4 shadow_coord4;
-#endif //LIGHT_USE_PSSM4
-#endif
+#endif // LIGHT_USE_PSSM4
+#endif // USE_ADDITIVE_LIGHTING
 
 #ifdef MATERIAL_UNIFORMS_USED
-
 /* clang-format off */
 layout(std140) uniform MaterialUniforms { // ubo:3
-
 #MATERIAL_UNIFORMS
-
 };
 /* clang-format on */
-
-#endif
+#endif // MATERIAL_UNIFORMS_USED
 
 /* clang-format off */
 
@@ -505,11 +511,11 @@ void main() {
 #ifdef USE_INSTANCING
 	highp mat4 m = mat4(instance_xform0, instance_xform1, instance_xform2, vec4(0.0, 0.0, 0.0, 1.0));
 	model_matrix = model_matrix * transpose(m);
-#endif
+#endif // USE_INSTANCING
 
 #ifdef NORMAL_USED
 	vec3 normal = oct_to_vec3(axis_tangent_attrib.xy * 2.0 - 1.0);
-#endif
+#endif // NORMAL_USED
 
 	highp mat3 model_normal_matrix;
 
@@ -520,10 +526,9 @@ void main() {
 	}
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-
+	vec3 tangent;
 	vec3 binormal;
 	float binormal_sign;
-	vec3 tangent;
 	if (axis_tangent_attrib.z > 0.0 || axis_tangent_attrib.w < 1.0) {
 		// Uncompressed format.
 		vec2 signed_tangent_attrib = axis_tangent_attrib.zw * 2.0 - 1.0;
@@ -534,12 +539,12 @@ void main() {
 		// Compressed format.
 		float angle = vertex_angle_attrib.w;
 		binormal_sign = angle > 0.5 ? 1.0 : -1.0; // 0.5 does not exist in UNORM16, so values are either greater or smaller.
-		angle = abs(angle * 2.0 - 1.0) * M_PI; // 0.5 is basically zero, allowing to encode both signs reliably.
+		angle = abs(angle * 2.0 - 1.0) * M_PI; // 0.5 is basically zero, allowing us to encode both signs reliably.
 		vec3 axis = normal;
 		axis_angle_to_tbn(axis, angle, tangent, binormal, normal);
 		binormal *= binormal_sign;
 	}
-#endif
+#endif // NORMAL_USED || TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #if defined(COLOR_USED)
 	color_interp = color_attrib;
@@ -548,64 +553,63 @@ void main() {
 	instance_color.xy = unpackHalf2x16(instance_color_custom_data.x);
 	instance_color.zw = unpackHalf2x16(instance_color_custom_data.y);
 	color_interp *= instance_color;
-#endif
-#endif
+#endif // USE_INSTANCING
+#endif // COLOR_USED
 
 #if defined(UV_USED)
 	uv_interp = uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	uv2_interp = uv2_attrib;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
-	if (uv_scale != vec4(0.0)) { // Compression enabled
+	if (uv_scale != vec4(0.0)) { // Compression enabled.
 #ifdef UV_USED
 		uv_interp = (uv_interp - 0.5) * uv_scale.xy;
-#endif
+#endif // UV_USED
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 		uv2_interp = (uv2_interp - 0.5) * uv_scale.zw;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 	}
 
 #if defined(OVERRIDE_POSITION)
 	highp vec4 position;
-#endif
+#endif // OVERRIDE_POSITION
 
 #ifdef USE_MULTIVIEW
 	mat4 projection_matrix = multiview_data.projection_matrix_view[ViewIndex];
 	mat4 inv_projection_matrix = multiview_data.inv_projection_matrix_view[ViewIndex];
 	vec3 eye_offset = multiview_data.eye_offset[ViewIndex].xyz;
-#else
+#else // USE_MULTIVIEW
 	mat4 projection_matrix = scene_data.projection_matrix;
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix;
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
 
 #ifdef USE_INSTANCING
 	vec4 instance_custom;
 	instance_custom.xy = unpackHalf2x16(instance_color_custom_data.z);
 	instance_custom.zw = unpackHalf2x16(instance_color_custom_data.w);
-#else
+#else // USE_INSTANCING
 	vec4 instance_custom = vec4(0.0);
-#endif
+#endif // USE_INSTANCING
 
-	// Using world coordinates
+	// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (model_matrix * vec4(vertex, 1.0)).xyz;
 
 #ifdef NORMAL_USED
 	normal = model_normal_matrix * normal;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-
 	tangent = model_normal_matrix * tangent;
 	binormal = model_normal_matrix * binormal;
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
-#endif
-#endif
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	float roughness = 1.0;
 
@@ -614,50 +618,53 @@ void main() {
 
 	float point_size = 1.0;
 
+	// GDShader VERTEX function gets inserted here.
 	{
 #CODE : VERTEX
 	}
 
 	gl_PointSize = point_size;
 
-	// Using local coordinates (default)
+	// Using local coordinates (default).
 #if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (modelview * vec4(vertex, 1.0)).xyz;
 #ifdef NORMAL_USED
 	normal = modelview_normal * normal;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-
 	binormal = modelview_normal * binormal;
 	tangent = modelview_normal * tangent;
-#endif
-#endif // !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
-	// Using world coordinates
+#endif // !SKIP_TRANSFORM_USED && !VERTEX_WORLD_COORDS_USED
+
+	// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (scene_data.view_matrix * vec4(vertex, 1.0)).xyz;
 #ifdef NORMAL_USED
 	normal = (scene_data.view_matrix * vec4(normal, 0.0)).xyz;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	binormal = (scene_data.view_matrix * vec4(binormal, 0.0)).xyz;
 	tangent = (scene_data.view_matrix * vec4(tangent, 0.0)).xyz;
-#endif
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
+
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	vertex_interp = vertex;
+
 #ifdef NORMAL_USED
 	normal_interp = normal;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	tangent_interp = tangent;
 	binormal_interp = binormal;
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 	// Calculate shadows.
 #ifdef USE_ADDITIVE_LIGHTING
@@ -671,12 +678,13 @@ void main() {
 #ifdef ADDITIVE_SPOT
 	// Calculate coord here so we can take advantage of prefetch.
 	shadow_coord = positional_shadows[positional_shadow_index].shadow_matrix * vec4(vertex_interp + normal_offset, 1.0);
-#endif
+#endif // ADDITIVE_SPOT
 
 #ifdef ADDITIVE_OMNI
 	// Can't interpolate unit direction nicely, so forget about prefetch.
 	shadow_coord = vec4(vertex_interp + normal_offset, 1.0);
-#endif
+#endif // ADDITIVE_OMNI
+
 #else // ADDITIVE_DIRECTIONAL
 	vec3 base_normal_bias = normalize(normal_interp) * (1.0 - max(0.0, dot(directional_shadows[directional_shadow_index].direction, -normalize(normal_interp))));
 	vec3 normal_offset = base_normal_bias * directional_shadows[directional_shadow_index].shadow_normal_bias.x;
@@ -685,45 +693,48 @@ void main() {
 #if defined(LIGHT_USE_PSSM2) || defined(LIGHT_USE_PSSM4)
 	normal_offset = base_normal_bias * directional_shadows[directional_shadow_index].shadow_normal_bias.y;
 	shadow_coord2 = directional_shadows[directional_shadow_index].shadow_matrix2 * vec4(vertex_interp + normal_offset, 1.0);
-#endif
+#endif // LIGHT_USE_PSSM2 || LIGHT_USE_PSSM4
 
 #ifdef LIGHT_USE_PSSM4
 	normal_offset = base_normal_bias * directional_shadows[directional_shadow_index].shadow_normal_bias.z;
 	shadow_coord3 = directional_shadows[directional_shadow_index].shadow_matrix3 * vec4(vertex_interp + normal_offset, 1.0);
 	normal_offset = base_normal_bias * directional_shadows[directional_shadow_index].shadow_normal_bias.w;
 	shadow_coord4 = directional_shadows[directional_shadow_index].shadow_matrix4 * vec4(vertex_interp + normal_offset, 1.0);
-#endif //LIGHT_USE_PSSM4
+#endif // LIGHT_USE_PSSM4
 
-#endif // !(defined(ADDITIVE_OMNI) || defined(ADDITIVE_SPOT))
+#endif // !(ADDITIVE_OMNI || ADDITIVE_SPOT)
 #endif // USE_ADDITIVE_LIGHTING
 
 #if defined(RENDER_SHADOWS) && !defined(RENDER_SHADOWS_LINEAR)
 	// This is an optimized version of normalize(vertex_interp) * scene_data.shadow_bias / length(vertex_interp).
 	float light_length_sq = dot(vertex_interp, vertex_interp);
 	vertex_interp += vertex_interp * scene_data.shadow_bias / light_length_sq;
-#endif
+#endif // RENDER_SHADOWS && !RENDER_SHADOWS_LINEAR
 
 #if defined(OVERRIDE_POSITION)
 	gl_Position = position;
-#else
+#else // OVERRIDE_POSITION
 	gl_Position = projection_matrix * vec4(vertex_interp, 1.0);
-#endif
+#endif // OVERRIDE_POSITION
 
 #ifdef RENDER_MATERIAL
 	gl_Position.xy = (uv2_attrib.xy + uv_offset) * 2.0 - 1.0;
 	gl_Position.z = 0.00001;
 	gl_Position.w = 1.0;
-#endif
+#endif // RENDER_MATERIAL
 
 #ifdef USE_VERTEX_LIGHTING
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+
 #ifdef USE_MULTIVIEW
 	vec3 view = -normalize(vertex_interp - eye_offset);
-#else
+#else // USE_MULTIVIEW
 	vec3 view = -normalize(vertex_interp);
-#endif
+#endif // USE_MULTIVIEW
+
 	diffuse_light_interp = vec3(0.0);
 	specular_light_interp = vec3(0.0);
+
 #ifdef BASE_PASS
 #ifndef DISABLE_LIGHT_DIRECTIONAL
 	for (uint i = uint(0); i < scene_data.directional_light_count; i++) {
@@ -731,7 +742,7 @@ void main() {
 		if (directional_lights[i].bake_mode == LIGHT_BAKE_STATIC) {
 			continue;
 		}
-#endif
+#endif // USE_LIGHTMAP && !DISABLE_LIGHTMAP
 		light_compute(normal_interp, normalize(directional_lights[i].direction), normalize(view), directional_lights[i].color * directional_lights[i].energy, true, roughness,
 				diffuse_light_interp.rgb,
 				specular_light_interp.rgb);
@@ -762,7 +773,7 @@ void main() {
 	light_compute(normal_interp, normalize(directional_lights[directional_shadow_index].direction), normalize(view), directional_lights[directional_shadow_index].color * directional_lights[directional_shadow_index].energy, true, roughness,
 			additive_diffuse_light_interp.rgb,
 			additive_specular_light_interp.rgb);
-#endif // !defined(ADDITIVE_OMNI) && !defined(ADDITIVE_SPOT)
+#endif // !ADDITIVE_OMNI && !ADDITIVE_SPOT
 
 #ifdef ADDITIVE_OMNI
 	light_process_omni(omni_light_index, vertex_interp, view, normal_interp, roughness,
@@ -775,7 +786,7 @@ void main() {
 #endif // ADDITIVE_SPOT
 
 #endif // USE_ADDITIVE_LIGHTING
-#endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 #endif // USE_VERTEX_LIGHTING
 }
 /* clang-format off */
@@ -784,23 +795,23 @@ void main() {
 // Default to SPECULAR_SCHLICK_GGX.
 #if !defined(SPECULAR_DISABLED) && !defined(SPECULAR_SCHLICK_GGX) && !defined(SPECULAR_TOON)
 #define SPECULAR_SCHLICK_GGX
-#endif
+#endif // !SPECULAR_DISABLED && !SPECULAR_SCHLICK_GGX && !SPECULAR_TOON
 
 #if !defined(MODE_RENDER_DEPTH) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED) ||defined(LIGHT_CLEARCOAT_USED)
 #ifndef NORMAL_USED
 #define NORMAL_USED
-#endif
-#endif
+#endif // !NORMAL_USED
+#endif // !MODE_RENDER_DEPTH || TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED || LIGHT_CLEARCOAT_USED
 
 #ifdef MODE_UNSHADED
 #ifdef USE_ADDITIVE_LIGHTING
 #undef USE_ADDITIVE_LIGHTING
-#endif
+#endif // USE_ADDITIVE_LIGHTING
 #endif // MODE_UNSHADED
 
 #ifndef MODE_RENDER_DEPTH
 #include "tonemap_inc.glsl"
-#endif
+#endif // !MODE_RENDER_DEPTH
 #include "stdlib_inc.glsl"
 
 /* texture unit usage, N is max_texture_unit-N
@@ -829,28 +840,28 @@ void main() {
 
 #if defined(COLOR_USED)
 in vec4 color_interp;
-#endif
+#endif // COLOR_USED
 
 #if defined(UV_USED)
 in vec2 uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED)
 in vec2 uv2_interp;
-#else
+#else // UV2_USED
 #ifdef USE_LIGHTMAP
 in vec2 uv2_interp;
-#endif
-#endif
+#endif // USE_LIGHTMAP
+#endif // UV2_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 in vec3 tangent_interp;
 in vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #ifdef NORMAL_USED
 in vec3 normal_interp;
-#endif
+#endif // NORMAL_USED
 
 in highp vec3 vertex_interp;
 
@@ -859,13 +870,13 @@ in highp vec4 shadow_coord;
 
 #if defined(LIGHT_USE_PSSM2) || defined(LIGHT_USE_PSSM4)
 in highp vec4 shadow_coord2;
-#endif
+#endif // LIGHT_USE_PSSM2 || LIGHT_USE_PSSM4
 
 #ifdef LIGHT_USE_PSSM4
 in highp vec4 shadow_coord3;
 in highp vec4 shadow_coord4;
 #endif //LIGHT_USE_PSSM4
-#endif
+#endif // USE_ADDITIVE_LIGHTING
 
 #ifdef USE_RADIANCE_MAP
 
@@ -907,23 +918,21 @@ uniform samplerCube refprobe2_texture; // texunit:-9
 
 #endif // SECOND_REFLECTION_PROBE
 
-#endif // DISABLE_REFLECTION_PROBE
+#endif // !DISABLE_REFLECTION_PROBE
 
+/* clang-format off */
 layout(std140) uniform GlobalShaderUniformData { //ubo:1
 	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
+/* clang-format on */
 
 /* Material Uniforms */
 #ifdef MATERIAL_UNIFORMS_USED
-
 /* clang-format off */
 layout(std140) uniform MaterialUniforms { // ubo:3
-
 #MATERIAL_UNIFORMS
-
 };
 /* clang-format on */
-
 #endif
 
 layout(std140) uniform SceneData { // ubo:2
@@ -998,6 +1007,7 @@ multiview_data;
 
 #ifndef MODE_RENDER_DEPTH
 #ifdef USE_VERTEX_LIGHTING
+
 in vec3 diffuse_light_interp;
 in vec3 specular_light_interp;
 
@@ -1021,16 +1031,18 @@ struct DirectionalLightData {
 	mediump float specular;
 };
 
+/* clang-format off */
 layout(std140) uniform DirectionalLights { // ubo:7
 	DirectionalLightData directional_lights[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 
 #if defined(USE_ADDITIVE_LIGHTING) && (!defined(ADDITIVE_OMNI) && !defined(ADDITIVE_SPOT))
-// Directional shadows can be in the base pass or in the additive passes
+// Directional shadows can be in the base pass or in the additive passes.
 uniform highp sampler2DShadow directional_shadow_atlas; // texunit:-3
-#endif // defined(USE_ADDITIVE_LIGHTING) && (!defined(ADDITIVE_OMNI) && !defined(ADDITIVE_SPOT))
+#endif // USE_ADDITIVE_LIGHTING && (!ADDITIVE_OMNI && !ADDITIVE_SPOT)
 
-#endif // !DISABLE_LIGHT_DIRECTIONAL
+#endif // !DISABLE_LIGHT_DIRECTIONAL || (!ADDITIVE_OMNI && !ADDITIVE_SPOT)
 
 // Omni and spot light data.
 #if !defined(DISABLE_LIGHT_OMNI) || !defined(DISABLE_LIGHT_SPOT) || defined(ADDITIVE_OMNI) || defined(ADDITIVE_SPOT)
@@ -1055,35 +1067,41 @@ struct LightData { // This structure needs to be as packed as possible.
 };
 
 #if !defined(DISABLE_LIGHT_OMNI) || defined(ADDITIVE_OMNI)
+/* clang-format off */
 layout(std140) uniform OmniLightData { // ubo:5
 	LightData omni_lights[MAX_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 #if defined(BASE_PASS) && !defined(USE_VERTEX_LIGHTING)
 uniform uint omni_light_indices[MAX_FORWARD_LIGHTS];
 uniform uint omni_light_count;
-#endif // defined(BASE_PASS) && !defined(USE_VERTEX_LIGHTING)
-#endif // !defined(DISABLE_LIGHT_OMNI) || defined(ADDITIVE_OMNI)
+#endif // BASE_PASS && !USE_VERTEX_LIGHTING
+#endif // !DISABLE_LIGHT_OMNI || ADDITIVE_OMNI
 
 #if !defined(DISABLE_LIGHT_SPOT) || defined(ADDITIVE_SPOT)
+/* clang-format off */
 layout(std140) uniform SpotLightData { // ubo:6
 	LightData spot_lights[MAX_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 #if defined(BASE_PASS) && !defined(USE_VERTEX_LIGHTING)
 uniform uint spot_light_indices[MAX_FORWARD_LIGHTS];
 uniform uint spot_light_count;
-#endif // defined(BASE_PASS) && !defined(USE_VERTEX_LIGHTING)
-#endif // !defined(DISABLE_LIGHT_SPOT) || defined(ADDITIVE_SPOT)
-#endif // !defined(DISABLE_LIGHT_OMNI) || !defined(DISABLE_LIGHT_SPOT) || defined(ADDITIVE_OMNI) || defined(ADDITIVE_SPOT)
+#endif // BASE_PASS && !USE_VERTEX_LIGHTING
+#endif // !DISABLE_LIGHT_SPOT || ADDITIVE_SPOT
+#endif // !DISABLE_LIGHT_OMNI || !DISABLE_LIGHT_SPOT || ADDITIVE_OMNI || ADDITIVE_SPOT
 
 #ifdef USE_ADDITIVE_LIGHTING
+
 #ifdef ADDITIVE_OMNI
 uniform highp samplerCubeShadow omni_shadow_texture; // texunit:-3
 uniform lowp uint omni_light_index;
-#endif
+#endif // ADDITIVE_OMNI
+
 #ifdef ADDITIVE_SPOT
 uniform highp sampler2DShadow spot_shadow_texture; // texunit:-3
 uniform lowp uint spot_light_index;
-#endif
+#endif // ADDITIVE_SPOT
 
 #if defined(ADDITIVE_OMNI) || defined(ADDITIVE_SPOT)
 struct PositionalShadowData {
@@ -1094,9 +1112,11 @@ struct PositionalShadowData {
 	highp float shadow_atlas_pixel_size;
 };
 
+/* clang-format off */
 layout(std140) uniform PositionalShadows { // ubo:9
 	PositionalShadowData positional_shadows[MAX_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 
 uniform lowp uint positional_shadow_index;
 #else // ADDITIVE_DIRECTIONAL
@@ -1114,16 +1134,18 @@ struct DirectionalShadowData {
 	mediump vec2 pad;
 };
 
+/* clang-format off */
 layout(std140) uniform DirectionalShadows { // ubo:10
 	DirectionalShadowData directional_shadows[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
 };
+/* clang-format on */
 
 uniform lowp uint directional_shadow_index;
-#endif // !(defined(ADDITIVE_OMNI) || defined(ADDITIVE_SPOT))
+#endif // !(ADDITIVE_OMNI || ADDITIVE_SPOT)
 
 #if !defined(ADDITIVE_OMNI)
 float sample_shadow(highp sampler2DShadow shadow, float shadow_pixel_size, vec4 pos) {
-	// Use textureProjLod with LOD set to 0.0 over textureProj, as textureProj not working correctly on ANGLE with Metal backend.
+	// Use textureProjLod with LOD set to 0.0 over textureProj, as textureProj is not working correctly on ANGLE with Metal backend.
 	// https://github.com/godotengine/godot/issues/93537
 	float avg = textureProjLod(shadow, pos, 0.0);
 #ifdef SHADOW_MODE_PCF_13
@@ -1151,7 +1173,7 @@ float sample_shadow(highp sampler2DShadow shadow, float shadow_pixel_size, vec4 
 	avg += textureProjLod(shadow, vec4(pos.xy + vec2(shadow_pixel_size, -shadow_pixel_size), pos.zw), 0.0);
 	avg += textureProjLod(shadow, vec4(pos.xy + vec2(-shadow_pixel_size, -shadow_pixel_size), pos.zw), 0.0);
 	return avg * (1.0 / 13.0);
-#endif
+#endif // SHADOW_MODE_PCF_13
 
 #ifdef SHADOW_MODE_PCF_5
 	pos /= pos.w;
@@ -1160,20 +1182,19 @@ float sample_shadow(highp sampler2DShadow shadow, float shadow_pixel_size, vec4 
 	avg += textureProjLod(shadow, vec4(pos.xy + vec2(0.0, shadow_pixel_size), pos.zw), 0.0);
 	avg += textureProjLod(shadow, vec4(pos.xy + vec2(0.0, -shadow_pixel_size), pos.zw), 0.0);
 	return avg * (1.0 / 5.0);
-
-#endif
+#endif // SHADOW_MODE_PCF_5
 
 	return avg;
 }
-#endif //!defined(ADDITIVE_OMNI)
+#endif // !ADDITIVE_OMNI
 #endif // USE_ADDITIVE_LIGHTING
 
 #endif // !MODE_RENDER_DEPTH
 
 #ifndef DISABLE_LIGHTMAP
 #ifdef USE_LIGHTMAP
-uniform mediump sampler2DArray lightmap_textures; //texunit:-4
-uniform lowp sampler2DArray shadowmask_textures; //texunit:-5
+uniform mediump sampler2DArray lightmap_textures; // texunit:-4
+uniform lowp sampler2DArray shadowmask_textures; // texunit:-5
 uniform lowp uint lightmap_slice;
 uniform highp vec4 lightmap_uv_scale;
 uniform float lightmap_exposure_normalization;
@@ -1186,7 +1207,7 @@ uniform uint lightmap_shadowmask_mode;
 
 #ifdef LIGHTMAP_BICUBIC_FILTER
 uniform highp vec2 lightmap_texture_size;
-#endif
+#endif // LIGHTMAP_BICUBIC_FILTER
 
 #ifdef USE_SH_LIGHTMAP
 uniform mediump mat3 lightmap_normal_xform;
@@ -1199,6 +1220,7 @@ uniform mediump vec4[9] lightmap_captures;
 #endif // !DISABLE_LIGHTMAP
 
 #ifdef USE_MULTIVIEW
+
 uniform highp sampler2DArray depth_buffer; // texunit:-7
 uniform highp sampler2DArray color_buffer; // texunit:-6
 vec3 multiview_uv(vec2 uv) {
@@ -1207,7 +1229,9 @@ vec3 multiview_uv(vec2 uv) {
 ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
-#else
+
+#else // USE_MULTIVIEW
+
 uniform highp sampler2D depth_buffer; // texunit:-7
 uniform highp sampler2D color_buffer; // texunit:-6
 vec2 multiview_uv(vec2 uv) {
@@ -1216,7 +1240,8 @@ vec2 multiview_uv(vec2 uv) {
 ivec2 multiview_uv(ivec2 uv) {
 	return uv;
 }
-#endif
+
+#endif // USE_MULTIVIEW
 
 uniform highp mat4 world_transform;
 uniform mediump float opaque_prepass_threshold;
@@ -1228,17 +1253,15 @@ layout(location = 0) out vec4 albedo_output_buffer;
 layout(location = 1) out vec4 normal_output_buffer;
 layout(location = 2) out vec4 orm_output_buffer;
 layout(location = 3) out vec4 emission_output_buffer;
-
-#else // !RENDER_MATERIAL
+#else // RENDER_MATERIAL
 // Normal color rendering.
 layout(location = 0) out vec4 frag_color;
-
-#endif // !RENDER_MATERIAL
+#endif // RENDER_MATERIAL
 
 vec3 F0(float metallic, float specular, vec3 albedo) {
 	float dielectric = 0.16 * specular * specular;
-	// use albedo * metallic as colored specular reflectance at 0 angle for metallic materials;
-	// see https://google.github.io/filament/Filament.md.html
+	// Use albedo * metallic as colored specular reflectance at 0 angle for metallic materials.
+	// See: https://google.github.io/filament/Filament.md.html
 	return mix(vec3(dielectric), albedo, vec3(metallic));
 }
 #ifndef MODE_RENDER_DEPTH
@@ -1281,20 +1304,20 @@ float SchlickFresnel(float u) {
 void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_directional, float attenuation, vec3 f0, float roughness, float metallic, float specular_amount, vec3 albedo, inout float alpha, vec2 screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 		float rim, float rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 		vec3 B, vec3 T, float anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 		inout vec3 diffuse_light, inout vec3 specular_light) {
 
 #if defined(LIGHT_CODE_USED)
-	// light is written by the light shader
+	// Light is written by the user shader.
 
 	highp mat4 model_matrix = world_transform;
 	mat4 projection_matrix = scene_data.projection_matrix;
@@ -1303,84 +1326,72 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 	vec3 normal = N;
 	vec3 light = L;
 	vec3 view = V;
-
 	/* clang-format off */
 
+	// GDShader LIGHT function gets inserted here.
+	{
 #CODE : LIGHT
+	}
 
 	/* clang-format on */
-
-#else
+#else // LIGHT_CODE_USED
 	float NdotL = min(A + dot(N, L), 1.0);
-	float cNdotL = max(NdotL, 0.0); // clamped NdotL
+	float cNdotL = max(NdotL, 0.0);
 	float NdotV = dot(N, V);
 	float cNdotV = max(NdotV, 1e-4);
 
 #if defined(DIFFUSE_BURLEY) || defined(SPECULAR_SCHLICK_GGX) || defined(LIGHT_CLEARCOAT_USED)
 	vec3 H = normalize(V + L);
-#endif
+	float cLdotH = clamp(A + dot(L, H), 0.0, 1.0);
+#endif // DIFFUSE_BURLEY || SPECULAR_SCHLICK_GGX || LIGHT_CLEARCOAT_USED
 
 #if defined(SPECULAR_SCHLICK_GGX)
 	float cNdotH = clamp(A + dot(N, H), 0.0, 1.0);
-#endif
+#endif // SPECULAR_SCHLICK_GGX
 
-#if defined(DIFFUSE_BURLEY) || defined(SPECULAR_SCHLICK_GGX) || defined(LIGHT_CLEARCOAT_USED)
-	float cLdotH = clamp(A + dot(L, H), 0.0, 1.0);
-#endif
-
-	if (metallic < 1.0) {
-		float diffuse_brdf_NL; // BRDF times N.L for calculating diffuse radiance
-
+	if (metallic < 1.0) { // Skip diffuse for 100% metallic materials, as they have no diffuse component.
 #if defined(DIFFUSE_LAMBERT_WRAP)
 		// Energy conserving lambert wrap shader.
 		// https://web.archive.org/web/20210228210901/http://blog.stevemcauley.com/2011/12/03/energy-conserving-wrapped-diffuse/
-		diffuse_brdf_NL = max(0.0, (NdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness))) * (1.0 / M_PI);
+		float diffuse_brdf_NL = max(0.0, (NdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness))) * (1.0 / M_PI);
 #elif defined(DIFFUSE_TOON)
-		diffuse_brdf_NL = smoothstep(-roughness, max(roughness, 0.01), NdotL) * (1.0 / M_PI);
+		float diffuse_brdf_NL = smoothstep(-roughness, max(roughness, 0.01), NdotL) * (1.0 / M_PI);
 #elif defined(DIFFUSE_BURLEY)
-		{
-			float FD90_minus_1 = 2.0 * cLdotH * cLdotH * roughness - 0.5;
-			float FdV = 1.0 + FD90_minus_1 * SchlickFresnel(cNdotV);
-			float FdL = 1.0 + FD90_minus_1 * SchlickFresnel(cNdotL);
-			diffuse_brdf_NL = (1.0 / M_PI) * FdV * FdL * cNdotL;
-		}
-#else
-		// Lambert
-		diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
-#endif
+		float FD90_minus_1 = 2.0 * cLdotH * cLdotH * roughness - 0.5;
+		float FdV = 1.0 + FD90_minus_1 * SchlickFresnel(cNdotV);
+		float FdL = 1.0 + FD90_minus_1 * SchlickFresnel(cNdotL);
+		float diffuse_brdf_NL = (1.0 / M_PI) * FdV * FdL * cNdotL;
+#else // DIFFUSE_LAMBERT
+		float diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
+#endif // DIFFUSE
 
 		diffuse_light += light_color * diffuse_brdf_NL * attenuation;
 
 #if defined(LIGHT_BACKLIGHT_USED)
 		diffuse_light += light_color * (vec3(1.0 / M_PI) - diffuse_brdf_NL) * backlight * attenuation;
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 
 #if defined(LIGHT_RIM_USED)
 		// Epsilon min to prevent pow(0, 0) singularity which results in undefined behavior.
 		float rim_light = pow(max(1e-4, 1.0 - cNdotV), max(0.0, (1.0 - roughness) * 16.0));
 		diffuse_light += rim_light * rim * mix(vec3(1.0), albedo, rim_tint) * light_color;
-#endif
+#endif // LIGHT_RIM_USED
 	}
 
-	if (roughness > 0.0) { // FIXME: roughness == 0 should not disable specular light entirely
-
-		// D
-
+	if (roughness > 0.0) { // FIXME: roughness == 0 should not disable specular light entirely.
 #if defined(SPECULAR_TOON)
-
 		vec3 R = normalize(-reflect(L, N));
 		float RdotV = dot(R, V);
 		float mid = 1.0 - roughness;
 		mid *= mid;
 		float intensity = smoothstep(mid - roughness * 0.5, mid + roughness * 0.5, RdotV) * mid;
-		diffuse_light += light_color * intensity * attenuation * specular_amount; // write to diffuse_light, as in toon shading you generally want no reflection
-
+		diffuse_light += light_color * intensity * attenuation * specular_amount; // Write to diffuse_light, as in toon shading you generally want no reflection.
 #elif defined(SPECULAR_DISABLED)
-		// none..
-
+		// Do nothing.
 #elif defined(SPECULAR_SCHLICK_GGX)
-		// shlick+ggx as default
+		// Shlick+GGX as default.
 		float alpha_ggx = roughness * roughness;
+
 #if defined(LIGHT_ANISOTROPY_USED)
 		float aspect = sqrt(1.0 - anisotropy * 0.9);
 		float ax = alpha_ggx / aspect;
@@ -1389,45 +1400,42 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 		float YdotH = dot(B, H);
 		float D = D_GGX_anisotropic(cNdotH, ax, ay, XdotH, YdotH);
 		float G = V_GGX_anisotropic(ax, ay, dot(T, V), dot(T, L), dot(B, V), dot(B, L), cNdotV, cNdotL);
-#else
+#else // LIGHT_ANISOTROPY_USED
 		float D = D_GGX(cNdotH, alpha_ggx);
 		float G = V_GGX(cNdotL, cNdotV, alpha_ggx);
 #endif // LIGHT_ANISOTROPY_USED
-	   // F
 		float cLdotH5 = SchlickFresnel(cLdotH);
 		// Calculate Fresnel using cheap approximate specular occlusion term from Filament:
 		// https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion
 		float f90 = clamp(50.0 * f0.g, 0.0, 1.0);
 		vec3 F = f0 + (f90 - f0) * cLdotH5;
-
 		vec3 specular_brdf_NL = cNdotL * D * F * G;
-
 		specular_light += specular_brdf_NL * light_color * attenuation * specular_amount;
-#endif
+#endif // SPECULAR
 
 #if defined(LIGHT_CLEARCOAT_USED)
-		// Clearcoat ignores normal_map, use vertex normal instead
+		// Clearcoat ignores normal_map, use vertex normal instead.
 		float ccNdotL = max(min(A + dot(vertex_normal, L), 1.0), 0.0);
 		float ccNdotH = clamp(A + dot(vertex_normal, H), 0.0, 1.0);
 		float ccNdotV = max(dot(vertex_normal, V), 1e-4);
 
 #if !defined(SPECULAR_SCHLICK_GGX)
 		float cLdotH5 = SchlickFresnel(cLdotH);
-#endif
+#endif // !SPECULAR_SCHLICK_GGX
 		float Dr = D_GGX(ccNdotH, mix(0.001, 0.1, clearcoat_roughness));
 		float Gr = 0.25 / (cLdotH * cLdotH);
-		float Fr = mix(.04, 1.0, cLdotH5);
+		float Fr = mix(0.04, 1.0, cLdotH5);
 		float clearcoat_specular_brdf_NL = clearcoat * Gr * Fr * Dr * cNdotL;
 
 		specular_light += clearcoat_specular_brdf_NL * light_color * attenuation * specular_amount;
 		// TODO: Clearcoat adds light to the scene right now (it is non-energy conserving), both diffuse and specular need to be scaled by (1.0 - FR)
-		// but to do so we need to rearrange this entire function
+		// but to do so we need to rearrange this entire function.
 #endif // LIGHT_CLEARCOAT_USED
 	}
 
 #ifdef USE_SHADOW_TO_OPACITY
 	alpha = min(alpha, clamp(1.0 - attenuation, 0.0, 1.0));
-#endif
+#endif // USE_SHADOW_TO_OPACITY
 
 #endif // LIGHT_CODE_USED
 }
@@ -1445,23 +1453,26 @@ float get_omni_spot_attenuation(float distance, float inv_range, float decay) {
 void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f0, float roughness, float metallic, float shadow, vec3 albedo, inout float alpha, vec2 screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 		float rim, float rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 		vec3 binormal, vec3 tangent, float anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 		inout vec3 diffuse_light, inout vec3 specular_light) {
+
+	// Omni light attenuation.
 	vec3 light_rel_vec = omni_lights[idx].position - vertex;
 	float light_length = length(light_rel_vec);
 	float omni_attenuation = get_omni_spot_attenuation(light_length, omni_lights[idx].inv_radius, omni_lights[idx].attenuation);
 	vec3 color = omni_lights[idx].color;
-	float size_A = 0.0;
 
+	// Compute area light solid angle.
+	float size_A = 0.0;
 	if (omni_lights[idx].size > 0.0) {
 		float t = omni_lights[idx].size / max(0.001, light_length);
 		size_A = max(0.0, 1.0 - 1.0 / sqrt(1.0 + t * t));
@@ -1472,20 +1483,20 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 	light_compute(normal, normalize(light_rel_vec), eye_vec, size_A, color, false, omni_attenuation, f0, roughness, metallic, omni_lights[idx].specular_amount, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 			backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 			rim * omni_attenuation, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 			clearcoat, clearcoat_roughness, vertex_normal,
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 			binormal, tangent, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 			diffuse_light,
 			specular_light);
 }
-#endif // !DISABLE_LIGHT_OMNI
+#endif // !DISABLE_LIGHT_OMNI || ADDITIVE_OMNI
 
 #if !defined(DISABLE_LIGHT_SPOT) || defined(ADDITIVE_SPOT)
 void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f0, float roughness, float metallic, float shadow, vec3 albedo, inout float alpha, vec2 screen_uv,
@@ -1504,6 +1515,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 		inout vec3 diffuse_light,
 		inout vec3 specular_light) {
 
+	// Spot light attenuation.
 	vec3 light_rel_vec = spot_lights[idx].position - vertex;
 	float light_length = length(light_rel_vec);
 	float spot_attenuation = get_omni_spot_attenuation(light_length, spot_lights[idx].inv_radius, spot_lights[idx].attenuation);
@@ -1516,8 +1528,8 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 
 	vec3 color = spot_lights[idx].color;
 
+	// Compute area light solid angle.
 	float size_A = 0.0;
-
 	if (spot_lights[idx].size > 0.0) {
 		float t = spot_lights[idx].size / max(0.001, light_length);
 		size_A = max(0.0, 1.0 - 1.0 / sqrt(1.0 + t * t));
@@ -1528,21 +1540,21 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 	light_compute(normal, normalize(light_rel_vec), eye_vec, size_A, color, false, spot_attenuation, f0, roughness, metallic, spot_lights[idx].specular_amount, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 			backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 			rim * spot_attenuation, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 			clearcoat, clearcoat_roughness, vertex_normal,
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 			binormal, tangent, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 			diffuse_light, specular_light);
 }
-#endif // !defined(DISABLE_LIGHT_SPOT) || defined(ADDITIVE_SPOT)
+#endif // !DISABLE_LIGHT_SPOT || ADDITIVE_SPOT
 
-#endif // !defined(DISABLE_LIGHT_DIRECTIONAL) || !defined(DISABLE_LIGHT_OMNI) || !defined(DISABLE_LIGHT_SPOT)
+#endif // !DISABLE_LIGHT_DIRECTIONAL || !DISABLE_LIGHT_OMNI || !DISABLE_LIGHT_SPOT
 #endif // !USE_VERTEX_LIGHTING
 
 vec4 fog_process(vec3 vertex) {
@@ -1560,7 +1572,7 @@ vec4 fog_process(vec3 vertex) {
 
 		fog_color = mix(fog_color, sky_fog_color, scene_data.fog_aerial_perspective);
 	}
-	*/
+*/
 #endif
 
 #ifndef DISABLE_LIGHT_DIRECTIONAL
@@ -1581,7 +1593,7 @@ vec4 fog_process(vec3 vertex) {
 #ifdef USE_DEPTH_FOG
 	float fog_z = smoothstep(scene_data.fog_depth_begin, scene_data.fog_depth_end, length(vertex));
 	fog_amount = pow(fog_z, scene_data.fog_depth_curve) * scene_data.fog_density;
-#else
+#else // USE_DEPTH_FOG
 	fog_amount = 1.0 - exp(min(0.0, -length(vertex) * scene_data.fog_density));
 #endif // USE_DEPTH_FOG
 
@@ -1615,7 +1627,7 @@ void reflection_process(samplerCube reflection_map,
 
 	vec3 local_pos = (local_matrix * vec4(vertex, 1.0)).xyz;
 
-	if (any(greaterThan(abs(local_pos), box_extents))) { //out of the reflection box
+	if (any(greaterThan(abs(local_pos), box_extents))) { // Out of the reflection box.
 		return;
 	}
 
@@ -1629,11 +1641,11 @@ void reflection_process(samplerCube reflection_map,
 		blend = pow(blend_axes.x * blend_axes.y * blend_axes.z, 2.0);
 	}
 
-	//reflect and make local
+	// Reflect and make local.
 	vec3 ref_normal = normalize(reflect(vertex, normal));
 	ref_normal = (local_matrix * vec4(ref_normal, 0.0)).xyz;
 
-	if (use_box_project) { //box project
+	if (use_box_project) { // Box project.
 
 		vec3 nrdir = normalize(ref_normal);
 		vec3 rbmax = (box_extents - local_pos) / nrdir;
@@ -1681,15 +1693,15 @@ void reflection_process(samplerCube reflection_map,
 		ambient_out.rgb *= blend;
 		ambient_accum += ambient_out;
 	}
-#endif // USE_LIGHTMAP
+#endif // !USE_LIGHTMAP
 }
 
-#endif // DISABLE_REFLECTION_PROBE
+#endif // !DISABLE_REFLECTION_PROBE
 
 #endif // !MODE_RENDER_DEPTH
 
 #ifdef LIGHTMAP_BICUBIC_FILTER
-// w0, w1, w2, and w3 are the four cubic B-spline basis functions
+// w0, w1, w2, and w3 are the four cubic B-spline basis functions.
 float w0(float a) {
 	return (1.0 / 6.0) * (a * (a * (-a + 3.0) - 3.0) + 1.0);
 }
@@ -1706,7 +1718,7 @@ float w3(float a) {
 	return (1.0 / 6.0) * (a * a * a);
 }
 
-// g0 and g1 are the two amplitude functions
+// g0 and g1 are the two amplitude functions.
 float g0(float a) {
 	return w0(a) + w1(a);
 }
@@ -1715,7 +1727,7 @@ float g1(float a) {
 	return w2(a) + w3(a);
 }
 
-// h0 and h1 are the two offset functions
+// h0 and h1 are the two offset functions.
 float h0(float a) {
 	return -1.0 + w1(a) / (w0(a) + w1(a));
 }
@@ -1747,22 +1759,22 @@ vec4 textureArray_bicubic(sampler2DArray tex, vec3 uv, vec2 texture_size) {
 	return (g0(fuv.y) * (g0x * texture(tex, vec3(p0, uv.z)) + g1x * texture(tex, vec3(p1, uv.z)))) +
 			(g1(fuv.y) * (g0x * texture(tex, vec3(p2, uv.z)) + g1x * texture(tex, vec3(p3, uv.z))));
 }
-#endif //LIGHTMAP_BICUBIC_FILTER
+#endif // LIGHTMAP_BICUBIC_FILTER
 
 void main() {
-	//lay out everything, whatever is unused is optimized away anyway
+	// Lay out everything, whatever is unused is optimized away anyway.
 	vec3 vertex = vertex_interp;
 #ifdef USE_MULTIVIEW
 	vec3 eye_offset = multiview_data.eye_offset[ViewIndex].xyz;
 	vec3 view = -normalize(vertex_interp - eye_offset);
 	mat4 projection_matrix = multiview_data.projection_matrix_view[ViewIndex];
 	mat4 inv_projection_matrix = multiview_data.inv_projection_matrix_view[ViewIndex];
-#else
+#else // USE_MULTIVIEW
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
 	vec3 view = -normalize(vertex_interp);
 	mat4 projection_matrix = scene_data.projection_matrix;
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix;
-#endif
+#endif // USE_MULTIVIEW
 	highp mat4 model_matrix = world_transform;
 	vec3 albedo = vec3(1.0);
 	vec3 backlight = vec3(0.0);
@@ -1787,10 +1799,10 @@ void main() {
 #endif // !FOG_DISABLED
 #if defined(CUSTOM_RADIANCE_USED)
 	vec4 custom_radiance = vec4(0.0);
-#endif
+#endif // CUSTOM_RADIANCE_USED
 #if defined(CUSTOM_IRRADIANCE_USED)
 	vec4 custom_irradiance = vec4(0.0);
-#endif
+#endif // CUSTOM_IRRADIANCE_USED
 
 	float ao = 1.0;
 	float ao_light_affect = 0.0;
@@ -1800,38 +1812,35 @@ void main() {
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	vec3 binormal = normalize(binormal_interp);
 	vec3 tangent = normalize(tangent_interp);
-#else
+#else // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 	vec3 binormal = vec3(0.0);
 	vec3 tangent = vec3(0.0);
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #ifdef NORMAL_USED
 	vec3 normal = normalize(normal_interp);
-
 #if defined(DO_SIDE_CHECK)
 	if (!gl_FrontFacing) {
 		normal = -normal;
 	}
-#endif
-
-#endif //NORMAL_USED
+#endif // DO_SIDE_CHECK
+#endif // NORMAL_USED
 
 #ifdef UV_USED
 	vec2 uv = uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	vec2 uv2 = uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(COLOR_USED)
 	vec4 color = color_interp;
-#endif
+#endif // COLOR_USED
 
 #if defined(NORMAL_MAP_USED)
-
 	vec3 normal_map = vec3(0.5);
-#endif
+#endif // NORMAL_MAP_USED
 
 	float normal_map_depth = 1.0;
 
@@ -1863,21 +1872,22 @@ void main() {
 		model_normal_matrix = mat3(model_matrix);
 	}
 
+	// GDShader FRAGMENT function gets inserted here.
 	{
 #CODE : FRAGMENT
 	}
 
-	// Keep albedo values in positive number range as negative values "wraparound" into positive numbers resulting in wrong colors
+	// Keep albedo values in positive number range as negative values "wraparound" into positive numbers resulting in wrong colors.
 	albedo = max(albedo, vec3(0.0));
 
 #ifdef LIGHT_VERTEX_USED
 	vertex = light_vertex;
 #ifdef USE_MULTIVIEW
 	view = -normalize(vertex - eye_offset);
-#else
+#else // USE_MULTIVIEW
 	view = -normalize(vertex);
-#endif //USE_MULTIVIEW
-#endif //LIGHT_VERTEX_USED
+#endif // USE_MULTIVIEW
+#endif // LIGHT_VERTEX_USED
 
 #ifndef USE_SHADOW_TO_OPACITY
 
@@ -1886,7 +1896,7 @@ void main() {
 		discard;
 	}
 	alpha = 1.0;
-#else
+#else // ALPHA_SCISSOR_USED
 #ifdef MODE_RENDER_DEPTH
 #ifdef USE_OPAQUE_PREPASS
 
@@ -1895,53 +1905,45 @@ void main() {
 	}
 #endif // USE_OPAQUE_PREPASS
 #endif // MODE_RENDER_DEPTH
-#endif // !ALPHA_SCISSOR_USED
+#endif // ALPHA_SCISSOR_USED
 
 #endif // !USE_SHADOW_TO_OPACITY
 
 #ifdef NORMAL_MAP_USED
-
 	normal_map.xy = normal_map.xy * 2.0 - 1.0;
-	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); //always ignore Z, as it can be RG packed, Z may be pos/neg, etc.
+	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); // Always reconstruct Z, as it can be RG packed, Z may be pos/neg, etc.
 
 	normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
-
-#endif
+#endif // NORMAL_MAP_USED
 
 #ifdef LIGHT_ANISOTROPY_USED
-
 	if (anisotropy > 0.01) {
-		//rotation matrix
 		mat3 rot = mat3(tangent, binormal, normal);
-		//make local to space
+		// Make local to space.
 		tangent = normalize(rot * vec3(anisotropy_flow.x, anisotropy_flow.y, 0.0));
 		binormal = normalize(rot * vec3(-anisotropy_flow.y, anisotropy_flow.x, 0.0));
 	}
-
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 
 #ifndef MODE_RENDER_DEPTH
 
 #ifndef FOG_DISABLED
 #ifndef CUSTOM_FOG_USED
 #ifndef DISABLE_FOG
-	// fog must be processed as early as possible and then packed.
-	// to maximize VGPR usage
-
+	// Fog must be processed as early as possible and then packed to maximize VGPR usage.
 	if (scene_data.fog_enabled) {
 		fog = fog_process(vertex);
 	}
 #endif // !DISABLE_FOG
 #endif // !CUSTOM_FOG_USED
-
 	uint fog_rg = packHalf2x16(fog.rg);
 	uint fog_ba = packHalf2x16(fog.ba);
 #endif // !FOG_DISABLED
 
-	// Convert colors to linear
+	// Convert colors to linear.
 	albedo = srgb_to_linear(albedo);
 	emission = srgb_to_linear(emission);
-	// TODO Backlight and transmittance when used
+	// TODO: Backlight and transmittance when used.
 #ifndef MODE_UNSHADED
 	vec3 f0 = F0(metallic, specular, albedo);
 	vec3 specular_light = vec3(0.0, 0.0, 0.0);
@@ -1952,7 +1954,7 @@ void main() {
 	/////////////////////// LIGHTING //////////////////////////////
 
 #ifndef AMBIENT_LIGHT_DISABLED
-	// IBL precalculations
+	// IBL precalculations.
 	float ndotv = clamp(dot(normal, view), 0.0, 1.0);
 	vec3 F = f0 + (max(vec3(1.0 - roughness), f0) - f0) * pow(1.0 - ndotv, 5.0);
 
@@ -1965,9 +1967,9 @@ void main() {
 		vec3 anisotropic_normal = cross(anisotropic_tangent, anisotropic_direction);
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
 		vec3 ref_vec = reflect(-view, bent_normal);
-#else
+#else // LIGHT_ANISOTROPY_USED
 		vec3 ref_vec = reflect(-view, normal);
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 		ref_vec = mix(ref_vec, normal, roughness * roughness);
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
@@ -1978,7 +1980,7 @@ void main() {
 	}
 #endif // USE_RADIANCE_MAP
 
-	// Calculate Reflection probes
+	// Reflection Probes //
 #ifndef DISABLE_REFLECTION_PROBE
 	vec4 ambient_accum = vec4(0.0);
 	{
@@ -2002,14 +2004,14 @@ void main() {
 			specular_light = reflection_accum.rgb / reflection_accum.a;
 		}
 	}
-#endif // DISABLE_REFLECTION_PROBE
+#endif // !DISABLE_REFLECTION_PROBE
 
 #if defined(CUSTOM_RADIANCE_USED)
 	specular_light = mix(specular_light, custom_radiance.rgb, custom_radiance.a);
 #endif // CUSTOM_RADIANCE_USED
 
 #ifndef USE_LIGHTMAP
-	//lightmap overrides everything
+	// Lightmap overrides everything.
 	if (scene_data.use_ambient_light) {
 		ambient_light = scene_data.ambient_light_color_energy.rgb;
 
@@ -2026,9 +2028,9 @@ void main() {
 		if (ambient_accum.a > 0.0) {
 			ambient_light = mix(ambient_light, (ambient_accum.rgb / ambient_accum.a) * scene_data.ambient_light_color_energy.a, scene_data.ambient_color_sky_mix);
 		}
-#endif // DISABLE_REFLECTION_PROBE
+#endif // !DISABLE_REFLECTION_PROBE
 	}
-#endif // USE_LIGHTMAP
+#endif // !USE_LIGHTMAP
 
 #if defined(CUSTOM_IRRADIANCE_USED)
 	ambient_light = mix(ambient_light, custom_irradiance.rgb, custom_irradiance.a);
@@ -2036,7 +2038,7 @@ void main() {
 
 #ifndef DISABLE_LIGHTMAP
 #ifdef USE_LIGHTMAP_CAPTURE
-	{
+	{ // Process lightmap capture (L2 SH).
 		vec3 wnormal = mat3(scene_data.inv_view_matrix) * normal;
 		const float c1 = 0.429043;
 		const float c2 = 0.511664;
@@ -2055,9 +2057,9 @@ void main() {
 								 2.0 * c2 * lightmap_captures[2].rgb * wnormal.z) *
 				scene_data.emissive_exposure_normalization;
 	}
-#else
+#else // USE_LIGHTMAP_CAPTURE
 #ifdef USE_LIGHTMAP
-	{
+	{ // Process lightmap texture.
 		vec3 uvw;
 		uvw.xy = uv2 * lightmap_uv_scale.zw + lightmap_uv_scale.xy;
 		uvw.z = float(lightmap_slice);
@@ -2070,12 +2072,12 @@ void main() {
 		vec3 lm_light_l1n1 = (textureArray_bicubic(lightmap_textures, uvw + vec3(0.0, 0.0, 1.0), lightmap_texture_size).rgb - vec3(0.5)) * 2.0;
 		vec3 lm_light_l1_0 = (textureArray_bicubic(lightmap_textures, uvw + vec3(0.0, 0.0, 2.0), lightmap_texture_size).rgb - vec3(0.5)) * 2.0;
 		vec3 lm_light_l1p1 = (textureArray_bicubic(lightmap_textures, uvw + vec3(0.0, 0.0, 3.0), lightmap_texture_size).rgb - vec3(0.5)) * 2.0;
-#else
+#else // LIGHTMAP_BICUBIC_FILTER
 		vec3 lm_light_l0 = textureLod(lightmap_textures, uvw + vec3(0.0, 0.0, 0.0), 0.0).rgb;
 		vec3 lm_light_l1n1 = (textureLod(lightmap_textures, uvw + vec3(0.0, 0.0, 1.0), 0.0).rgb - vec3(0.5)) * 2.0;
 		vec3 lm_light_l1_0 = (textureLod(lightmap_textures, uvw + vec3(0.0, 0.0, 2.0), 0.0).rgb - vec3(0.5)) * 2.0;
 		vec3 lm_light_l1p1 = (textureLod(lightmap_textures, uvw + vec3(0.0, 0.0, 3.0), 0.0).rgb - vec3(0.5)) * 2.0;
-#endif
+#endif // LIGHTMAP_BICUBIC_FILTER
 
 		vec3 n = normalize(lightmap_normal_xform * normal);
 
@@ -2083,45 +2085,46 @@ void main() {
 		ambient_light += lm_light_l1n1 * n.y * (lm_light_l0 * lightmap_exposure_normalization * 4.0);
 		ambient_light += lm_light_l1_0 * n.z * (lm_light_l0 * lightmap_exposure_normalization * 4.0);
 		ambient_light += lm_light_l1p1 * n.x * (lm_light_l0 * lightmap_exposure_normalization * 4.0);
-#else
+#else // USE_SH_LIGHTMAP
 #ifdef LIGHTMAP_BICUBIC_FILTER
 		ambient_light += textureArray_bicubic(lightmap_textures, uvw, lightmap_texture_size).rgb * lightmap_exposure_normalization;
-#else
+#else // LIGHTMAP_BICUBIC_FILTER
 		ambient_light += textureLod(lightmap_textures, uvw, 0.0).rgb * lightmap_exposure_normalization;
-#endif
-#endif
+#endif // LIGHTMAP_BICUBIC_FILTER
+#endif // USE_SH_LIGHTMAP
 	}
 #endif // USE_LIGHTMAP
 #endif // USE_LIGHTMAP_CAPTURE
 #endif // !DISABLE_LIGHTMAP
 
+	// Finalize ambient light.
 	ambient_light *= albedo.rgb;
 	ambient_light *= ao;
 
 #endif // !AMBIENT_LIGHT_DISABLED
 
-	// convert ao to direct light ao
+	// Convert AO to direct light AO.
 	ao = mix(1.0, ao, ao_light_affect);
+
 #ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
-		//simplify for toon, as
+		// Simplified toon BRDF.
 		specular_light *= specular * metallic * albedo * 2.0;
-#else
+#else // DIFFUSE_TOON
 
-		// scales the specular reflections, needs to be be computed before lighting happens,
-		// but after environment, GI, and reflection probes are added
-		// Environment brdf approximation (Lazarov 2013)
-		// see https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
+		// Environment BRDF Approximation (Lazarov 2013)
+		// Scales only indirect reflections, hence is computed before direct lighting happens.
+		// See: https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
 		const vec4 c0 = vec4(-1.0, -0.0275, -0.572, 0.022);
 		const vec4 c1 = vec4(1.0, 0.0425, 1.04, -0.04);
 		vec4 r = roughness * c0 + c1;
 		float ndotv = clamp(dot(normal, view), 0.0, 1.0);
-
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
+
 		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
-#endif
+#endif // DIFFUSE_TOON
 	}
 #endif // !AMBIENT_LIGHT_DISABLED
 
@@ -2130,32 +2133,34 @@ void main() {
 	diffuse_light += diffuse_light_interp;
 #else
 
+	// Directional Lights //
 #ifndef DISABLE_LIGHT_DIRECTIONAL
 	for (uint i = uint(0); i < scene_data.directional_light_count; i++) {
 #if defined(USE_LIGHTMAP) && !defined(DISABLE_LIGHTMAP)
 		if (directional_lights[i].bake_mode == LIGHT_BAKE_STATIC) {
 			continue;
 		}
-#endif
+#endif // USE_LIGHTMAP && !DISABLE_LIGHTMAP
 		light_compute(normal, normalize(directional_lights[i].direction), normalize(view), directional_lights[i].size, directional_lights[i].color * directional_lights[i].energy, true, 1.0, f0, roughness, metallic, 1.0, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 				backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 				rim, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 				clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 				binormal,
 				tangent, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 				diffuse_light,
 				specular_light);
 	}
 #endif // !DISABLE_LIGHT_DIRECTIONAL
 
+	// Omni Lights //
 #ifndef DISABLE_LIGHT_OMNI
 	for (uint i = 0u; i < MAX_FORWARD_LIGHTS; i++) {
 		if (i >= omni_light_count) {
@@ -2165,21 +2170,22 @@ void main() {
 		light_process_omni(omni_light_indices[i], vertex, view, normal, f0, roughness, metallic, 1.0, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 				backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 				rim,
 				rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 				clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 				binormal, tangent, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 				diffuse_light, specular_light);
 	}
 #endif // !DISABLE_LIGHT_OMNI
 
+	// Spot Lights //
 #ifndef DISABLE_LIGHT_SPOT
 	for (uint i = 0u; i < MAX_FORWARD_LIGHTS; i++) {
 		if (i >= spot_light_count) {
@@ -2189,21 +2195,22 @@ void main() {
 		light_process_spot(spot_light_indices[i], vertex, view, normal, f0, roughness, metallic, 1.0, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 				backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 				rim,
 				rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 				clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 				tangent,
 				binormal, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 				diffuse_light, specular_light);
 	}
 #endif // !DISABLE_LIGHT_SPOT
+
 #endif // !USE_VERTEX_LIGHTING
 #endif // BASE_PASS
 #endif // !MODE_UNSHADED
@@ -2218,7 +2225,7 @@ void main() {
 	if (alpha < alpha_scissor_threshold) {
 		discard;
 	}
-#endif // !ALPHA_SCISSOR_USED
+#endif // ALPHA_SCISSOR_USED
 
 #endif // !MODE_RENDER_DEPTH
 #endif // USE_SHADOW_TO_OPACITY
@@ -2227,13 +2234,12 @@ void main() {
 #ifdef RENDER_SHADOWS_LINEAR
 	// Linearize the depth buffer if rendering cubemap shadows.
 	gl_FragDepth = (scene_data.z_far - (length(vertex) + scene_data.shadow_bias)) / scene_data.z_far;
-#endif
+#endif // RENDER_SHADOWS_LINEAR
 
 // Nothing happens, so a tree-ssa optimizer will result in no fragment shader :)
-#else // !MODE_RENDER_DEPTH
+#else // MODE_RENDER_DEPTH
 
 #ifdef RENDER_MATERIAL
-
 	albedo_output_buffer.rgb = albedo;
 	albedo_output_buffer.a = alpha;
 
@@ -2248,18 +2254,18 @@ void main() {
 	emission_output_buffer.rgb = emission;
 	emission_output_buffer.a = 0.0;
 #else // !RENDER_MATERIAL
+
 #ifdef BASE_PASS
 #ifdef MODE_UNSHADED
 	frag_color = vec4(albedo, alpha);
-#else
-
+#else // MODE_UNSHADED
 	diffuse_light *= albedo;
 	diffuse_light *= 1.0 - metallic;
 	ambient_light *= 1.0 - metallic;
 
 	frag_color = vec4(diffuse_light + specular_light, alpha);
 	frag_color.rgb += emission + ambient_light;
-#endif //!MODE_UNSHADED
+#endif // MODE_UNSHADED
 
 #ifndef FOG_DISABLED
 	fog.xy = unpackHalf2x16(fog_rg);
@@ -2268,18 +2274,18 @@ void main() {
 	frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a);
 #endif // !FOG_DISABLED
 
-	// Tonemap before writing as we are writing to an sRGB framebuffer
+	// Tonemap before writing as we are writing to an sRGB framebuffer.
 	frag_color.rgb *= exposure;
 #ifdef APPLY_TONEMAPPING
 	frag_color.rgb = apply_tonemapping(frag_color.rgb, white);
-#endif
+#endif // APPLY_TONEMAPPING
 	frag_color.rgb = linear_to_srgb(frag_color.rgb);
 
-#else // !BASE_PASS
+#else // BASE_PASS
 	frag_color = vec4(0.0, 0.0, 0.0, alpha);
-#endif // !BASE_PASS
+#endif // BASE_PASS
 
-/* ADDITIVE LIGHTING PASS */
+// ADDITIVE LIGHTING PASS //
 #ifdef USE_ADDITIVE_LIGHTING
 	diffuse_light = vec3(0.0);
 	specular_light = vec3(0.0);
@@ -2292,7 +2298,7 @@ void main() {
 #if !defined(ADDITIVE_OMNI) && !defined(ADDITIVE_SPOT)
 
 #ifndef SHADOWS_DISABLED
-// Baked shadowmasks
+// Baked shadowmasks.
 #ifdef USE_LIGHTMAP
 	float shadowmask = 1.0f;
 
@@ -2303,24 +2309,24 @@ void main() {
 
 #ifdef LIGHTMAP_BICUBIC_FILTER
 		shadowmask = textureArray_bicubic(shadowmask_textures, uvw, lightmap_texture_size).x;
-#else
+#else // LIGHTMAP_BICUBIC_FILTER
 		shadowmask = textureLod(shadowmask_textures, uvw, 0.0).x;
-#endif
+#endif // LIGHTMAP_BICUBIC_FILTER
 	}
-#endif //USE_LIGHTMAP
+#endif // USE_LIGHTMAP
 
 	float directional_shadow = 1.0;
 
 #ifdef USE_LIGHTMAP
 	if (lightmap_shadowmask_mode != SHADOWMASK_MODE_ONLY) {
-#endif
+#endif // USE_LIGHTMAP
 
-// Orthogonal shadows
+// Orthogonal shadows.
 #if !defined(LIGHT_USE_PSSM2) && !defined(LIGHT_USE_PSSM4)
 		directional_shadow = sample_shadow(directional_shadow_atlas, directional_shadows[directional_shadow_index].shadow_atlas_pixel_size, shadow_coord);
-#endif // !defined(LIGHT_USE_PSSM2) && !defined(LIGHT_USE_PSSM4)
+#endif // !LIGHT_USE_PSSM2 && !LIGHT_USE_PSSM4
 
-// PSSM2 shadows
+// PSSM2 shadows.
 #ifdef LIGHT_USE_PSSM2
 		float depth_z = -vertex.z;
 		vec4 light_split_offsets = directional_shadows[directional_shadow_index].shadow_split_offsets;
@@ -2334,29 +2340,29 @@ void main() {
 			float directional_shadow2 = 1.0;
 			float pssm_blend = 0.0;
 			bool use_blend = true;
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 			if (depth_z < light_split_offsets.x) {
 				directional_shadow = shadow1;
 
 #ifdef LIGHT_USE_PSSM_BLEND
 				directional_shadow2 = shadow2;
 				pssm_blend = smoothstep(0.0, light_split_offsets.x, depth_z);
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 			} else {
 				directional_shadow = shadow2;
 #ifdef LIGHT_USE_PSSM_BLEND
 				use_blend = false;
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 			}
 #ifdef LIGHT_USE_PSSM_BLEND
 			if (use_blend) {
 				directional_shadow = mix(directional_shadow, directional_shadow2, pssm_blend);
 			}
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 		}
+#endif // LIGHT_USE_PSSM2
 
-#endif //LIGHT_USE_PSSM2
-// PSSM4 shadows
+// PSSM4 shadows.
 #ifdef LIGHT_USE_PSSM4
 		float depth_z = -vertex.z;
 		vec4 light_split_offsets = directional_shadows[directional_shadow_index].shadow_split_offsets;
@@ -2371,7 +2377,7 @@ void main() {
 			float directional_shadow2 = 1.0;
 			float pssm_blend = 0.0;
 			bool use_blend = true;
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 			if (depth_z < light_split_offsets.y) {
 				if (depth_z < light_split_offsets.x) {
 					directional_shadow = shadow1;
@@ -2380,7 +2386,7 @@ void main() {
 					directional_shadow2 = shadow2;
 
 					pssm_blend = smoothstep(0.0, light_split_offsets.x, depth_z);
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 				} else {
 					directional_shadow = shadow2;
 
@@ -2388,7 +2394,7 @@ void main() {
 					directional_shadow2 = shadow3;
 
 					pssm_blend = smoothstep(light_split_offsets.x, light_split_offsets.y, depth_z);
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 				}
 			} else {
 				if (depth_z < light_split_offsets.z) {
@@ -2397,24 +2403,24 @@ void main() {
 #if defined(LIGHT_USE_PSSM_BLEND)
 					directional_shadow2 = shadow4;
 					pssm_blend = smoothstep(light_split_offsets.y, light_split_offsets.z, depth_z);
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 
 				} else {
 					directional_shadow = shadow4;
 
 #if defined(LIGHT_USE_PSSM_BLEND)
 					use_blend = false;
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 				}
 			}
 #if defined(LIGHT_USE_PSSM_BLEND)
 			if (use_blend) {
 				directional_shadow = mix(directional_shadow, directional_shadow2, pssm_blend);
 			}
-#endif
+#endif // LIGHT_USE_PSSM_BLEND
 		}
 
-#endif //LIGHT_USE_PSSM4
+#endif // LIGHT_USE_PSSM4
 
 #ifdef USE_LIGHTMAP
 		if (lightmap_shadowmask_mode == SHADOWMASK_MODE_REPLACE) {
@@ -2422,7 +2428,7 @@ void main() {
 		} else if (lightmap_shadowmask_mode == SHADOWMASK_MODE_OVERLAY) {
 			directional_shadow = shadowmask * mix(directional_shadow, 1.0, smoothstep(directional_shadows[directional_shadow_index].fade_from, directional_shadows[directional_shadow_index].fade_to, vertex.z));
 		} else {
-#endif
+#endif // USE_LIGHTMAP
 			directional_shadow = mix(directional_shadow, 1.0, smoothstep(directional_shadows[directional_shadow_index].fade_from, directional_shadows[directional_shadow_index].fade_to, vertex.z));
 #ifdef USE_LIGHTMAP
 		}
@@ -2430,37 +2436,36 @@ void main() {
 	} else { // lightmap_shadowmask_mode == SHADOWMASK_MODE_ONLY
 		directional_shadow = shadowmask;
 	}
-#endif
+#endif // USE_LIGHTMAP
 
 	directional_shadow = mix(1.0, directional_shadow, directional_lights[directional_shadow_index].shadow_opacity);
 
-#else
+#else // !SHADOWS_DISABLED
 	float directional_shadow = 1.0f;
-#endif // SHADOWS_DISABLED
+#endif // !SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
 	light_compute(normal, normalize(directional_lights[directional_shadow_index].direction), normalize(view), directional_lights[directional_shadow_index].size, directional_lights[directional_shadow_index].color * directional_lights[directional_shadow_index].energy, true, directional_shadow, f0, roughness, metallic, 1.0, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 			backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 			rim, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 			clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-			binormal,
-			tangent, anisotropy,
-#endif
+			binormal, tangent, anisotropy,
+#endif // LIGHT_ANISOTROPY_USED
 			diffuse_light,
 			specular_light);
-#else
+#else // !USE_VERTEX_LIGHTING
 	// Just apply shadows to vertex lighting.
 	diffuse_light *= directional_shadow;
 	specular_light *= directional_shadow;
 #endif // !USE_VERTEX_LIGHTING
-#endif // !defined(ADDITIVE_OMNI) && !defined(ADDITIVE_SPOT)
+#endif // !ADDITIVE_OMNI && !ADDITIVE_SPOT
 
 #ifdef ADDITIVE_OMNI
 	float omni_shadow = 1.0f;
@@ -2468,25 +2473,25 @@ void main() {
 	vec3 light_ray = ((positional_shadows[positional_shadow_index].shadow_matrix * vec4(shadow_coord.xyz, 1.0))).xyz;
 	omni_shadow = texture(omni_shadow_texture, vec4(light_ray, 1.0 - length(light_ray) * omni_lights[omni_light_index].inv_radius));
 	omni_shadow = mix(1.0, omni_shadow, omni_lights[omni_light_index].shadow_opacity);
-#endif // SHADOWS_DISABLED
+#endif // !SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
 	light_process_omni(omni_light_index, vertex, view, normal, f0, roughness, metallic, omni_shadow, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 			backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 			rim,
 			rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 			clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 			binormal, tangent, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 			diffuse_light, specular_light);
-#else
+#else // !USE_VERTEX_LIGHTING
 	// Just apply shadows to vertex lighting.
 	diffuse_light *= omni_shadow;
 	specular_light *= omni_shadow;
@@ -2498,31 +2503,30 @@ void main() {
 #ifndef SHADOWS_DISABLED
 	spot_shadow = sample_shadow(spot_shadow_texture, positional_shadows[positional_shadow_index].shadow_atlas_pixel_size, shadow_coord);
 	spot_shadow = mix(1.0, spot_shadow, spot_lights[spot_light_index].shadow_opacity);
-#endif // SHADOWS_DISABLED
+#endif // !SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
 	light_process_spot(spot_light_index, vertex, view, normal, f0, roughness, metallic, spot_shadow, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 			backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_RIM_USED
 			rim,
 			rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 			clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_ANISOTROPY_USED
 			tangent,
 			binormal, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 			diffuse_light, specular_light);
-#else
+#else // !USE_VERTEX_LIGHTING
 	// Just apply shadows to vertex lighting.
 	diffuse_light *= spot_shadow;
 	specular_light *= spot_shadow;
 #endif // !USE_VERTEX_LIGHTING
-
 #endif // ADDITIVE_SPOT
 
 	diffuse_light *= albedo;
@@ -2536,11 +2540,11 @@ void main() {
 	additive_light_color *= (1.0 - fog.a);
 #endif // !FOG_DISABLED
 
-	// Tonemap before writing as we are writing to an sRGB framebuffer
+	// Tonemap before writing as we are writing to an sRGB framebuffer.
 	additive_light_color *= exposure;
 #ifdef APPLY_TONEMAPPING
 	additive_light_color = apply_tonemapping(additive_light_color, white);
-#endif
+#endif // APPLY_TONEMAPPING
 	additive_light_color = linear_to_srgb(additive_light_color);
 
 	frag_color.rgb += additive_light_color;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -4,6 +4,7 @@
 
 #VERSION_DEFINES
 
+/* Include our Forward+ UBOs, definitions, etc. */
 #include "scene_forward_clustered_inc.glsl"
 
 #define SHADER_IS_SRGB false
@@ -14,58 +15,57 @@
 // Always contains vertex position in XYZ, can contain tangent angle in W.
 layout(location = 0) in vec4 vertex_angle_attrib;
 
-//only for pure render depth when normal is not used
+// Only for pure render depth when normal is not used.
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 // Contains Normal/Axis in RG, can contain tangent in BA.
 layout(location = 1) in vec4 axis_tangent_attrib;
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 
 // Location 2 is unused.
 
 #if defined(COLOR_USED)
 layout(location = 3) in vec4 color_attrib;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 4) in vec2 uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP) || defined(MODE_RENDER_MATERIAL)
 layout(location = 5) in vec2 uv2_attrib;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP || MODE_RENDER_MATERIAL
 
 #if defined(CUSTOM0_USED)
 layout(location = 6) in vec4 custom0_attrib;
-#endif
+#endif // CUSTOM0_USED
 
 #if defined(CUSTOM1_USED)
 layout(location = 7) in vec4 custom1_attrib;
-#endif
+#endif // CUSTOM1_USED
 
 #if defined(CUSTOM2_USED)
 layout(location = 8) in vec4 custom2_attrib;
-#endif
+#endif // CUSTOM2_USED
 
 #if defined(CUSTOM3_USED)
 layout(location = 9) in vec4 custom3_attrib;
-#endif
+#endif // CUSTOM3_USED
 
 #if defined(BONES_USED) || defined(USE_PARTICLE_TRAILS)
 layout(location = 10) in uvec4 bone_attrib;
-#endif
+#endif // BONES_USED || USE_PARTICLE_TRAILS
 
 #if defined(WEIGHTS_USED) || defined(USE_PARTICLE_TRAILS)
 layout(location = 11) in vec4 weight_attrib;
-#endif
+#endif // WEIGHTS_USED || USE_PARTICLE_TRAILS
 
 #ifdef MOTION_VECTORS
 layout(location = 12) in vec4 previous_vertex_attrib;
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 layout(location = 13) in vec4 previous_normal_attrib;
-#endif
-
+#endif // NORMAL_USED || TANGENT_USED
 #endif // MOTION_VECTORS
 
 vec3 oct_to_vec3(vec2 e) {
@@ -91,29 +91,29 @@ layout(location = 0) out vec3 vertex_interp;
 
 #ifdef NORMAL_USED
 layout(location = 1) out vec3 normal_interp;
-#endif
+#endif // NORMAL_USED
 
 #if defined(COLOR_USED)
 layout(location = 2) out vec4 color_interp;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 3) out vec2 uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 layout(location = 4) out vec2 uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #ifdef TANGENT_USED
 layout(location = 5) out vec3 tangent_interp;
 layout(location = 6) out vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED
 
 #ifdef MOTION_VECTORS
 layout(location = 7) out vec4 screen_position;
 layout(location = 8) out vec4 prev_screen_position;
-#endif
+#endif // MOTION_VECTORS
 
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
@@ -121,19 +121,18 @@ layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms
 #MATERIAL_UNIFORMS
 } material;
 /* clang-format on */
-#endif
+#endif // MATERIAL_UNIFORMS_USED
 
 float global_time;
 
 #ifdef MODE_DUAL_PARABOLOID
-
 layout(location = 9) out float dp_clip;
-
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 layout(location = 10) out flat uint instance_index_interp;
 
 #ifdef USE_MULTIVIEW
+
 #ifdef has_VK_KHR_multiview
 #define ViewIndex gl_ViewIndex
 #else // has_VK_KHR_multiview
@@ -147,8 +146,10 @@ ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
 layout(location = 11) out vec4 combined_projected;
+
 #else // USE_MULTIVIEW
-// Set to zero, not supported in non stereo
+
+// Set to zero, not supported in non-stereo.
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
@@ -157,9 +158,10 @@ ivec2 multiview_uv(ivec2 uv) {
 	return uv;
 }
 
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+
 layout(location = 12) highp out vec4 diffuse_light_interp;
 layout(location = 13) highp out vec4 specular_light_interp;
 
@@ -171,7 +173,7 @@ void cluster_get_item_range(uint p_offset, out uint item_min, out uint item_max,
 	item_max = item_min_max >> 16;
 
 	item_from = item_min >> 5;
-	item_to = (item_max == 0) ? 0 : ((item_max - 1) >> 5) + 1; //side effect of how it is stored, as item_max 0 means no elements
+	item_to = (item_max == 0) ? 0 : ((item_max - 1) >> 5) + 1; // Side effect of how it is stored, as item_max 0 means no elements.
 }
 
 uint cluster_get_range_clip_mask(uint i, uint z_min, uint z_max) {
@@ -179,11 +181,14 @@ uint cluster_get_range_clip_mask(uint i, uint z_min, uint z_max) {
 	int mask_width = min(int(z_max) - int(z_min), 32 - local_min);
 	return bitfieldInsert(uint(0), uint(0xFFFFFFFF), local_min, mask_width);
 }
-#endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
+
 invariant gl_Position;
+/* clang-format off */
 
 #GLOBALS
 
+/* clang-format on */
 #ifdef USE_DOUBLE_PRECISION
 // Helper functions for emulating double precision when adding floats.
 vec3 quick_two_sum(vec3 a, vec3 b, out vec3 out_p) {
@@ -209,7 +214,7 @@ vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec
 	s = quick_two_sum(s, se, out_precision);
 	return s;
 }
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 uint multimesh_stride() {
 	uint stride = sc_multimesh_format_2d() ? 2 : 3;
@@ -221,16 +226,16 @@ uint multimesh_stride() {
 void vertex_shader(vec3 vertex_input,
 #ifdef NORMAL_USED
 		in vec3 normal_input,
-#endif
+#endif // NORMAL_USED
 #ifdef TANGENT_USED
 		in vec3 tangent_input,
 		in vec3 binormal_input,
-#endif
+#endif // TANGENT_USED
 		in uint instance_index, in uint multimesh_offset, in SceneData scene_data, in mat4 model_matrix, out vec4 screen_pos) {
 	vec4 instance_custom = vec4(0.0);
 #if defined(COLOR_USED)
 	color_interp = color_attrib;
-#endif
+#endif // COLOR_USED
 
 	mat4 inv_view_matrix = scene_data.inv_view_matrix;
 
@@ -243,7 +248,7 @@ void vertex_shader(vec3 vertex_input,
 	inv_view_matrix[0][3] = 0.0;
 	inv_view_matrix[1][3] = 0.0;
 	inv_view_matrix[2][3] = 0.0;
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 	mat3 model_normal_matrix;
 	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
@@ -255,54 +260,52 @@ void vertex_shader(vec3 vertex_input,
 	mat4 matrix;
 	mat4 read_model_matrix = model_matrix;
 
-	if (sc_multimesh()) {
-		//multimesh, instances are for it
-
+	if (sc_multimesh()) { // Multimesh, instances are for it.
 #ifdef USE_PARTICLE_TRAILS
 		uint trail_size = (instances.data[instance_index].flags >> INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT) & INSTANCE_FLAGS_PARTICLE_TRAIL_MASK;
-		uint stride = 3 + 1 + 1; //particles always uses this format
+		uint stride = 3 + 1 + 1; // Particles always use this format.
 
 		uint offset = trail_size * stride * gl_InstanceIndex;
 
 #ifdef COLOR_USED
 		vec4 pcolor;
-#endif
+#endif // COLOR_USED
 		{
 			uint boffset = offset + bone_attrib.x * stride;
 			matrix = mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.x;
 #ifdef COLOR_USED
 			pcolor = transforms.data[boffset + 3] * weight_attrib.x;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.y > 0.001) {
 			uint boffset = offset + bone_attrib.y * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.y;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.y;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.z > 0.001) {
 			uint boffset = offset + bone_attrib.z * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.z;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.z;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.w > 0.001) {
 			uint boffset = offset + bone_attrib.w * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.w;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.w;
-#endif
+#endif // COLOR_USED
 		}
 
 		instance_custom = transforms.data[offset + 4];
 
 #ifdef COLOR_USED
 		color_interp *= pcolor;
-#endif
+#endif // COLOR_USED
 
-#else
+#else // USE_PARTICLE_TRAILS
 		uint stride = multimesh_stride();
 		uint offset = stride * (gl_InstanceIndex + multimesh_offset);
 
@@ -317,16 +320,15 @@ void vertex_shader(vec3 vertex_input,
 		if (sc_multimesh_has_color()) {
 #ifdef COLOR_USED
 			color_interp *= transforms.data[offset];
-#endif
+#endif // COLOR_USED
 			offset += 1;
 		}
 
 		if (sc_multimesh_has_custom_data()) {
 			instance_custom = transforms.data[offset];
 		}
+#endif // USE_PARTICLE_TRAILS
 
-#endif
-		//transpose
 		matrix = transpose(matrix);
 #if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
 		// Normally we can bake the multimesh transform into the model matrix, but when using double precision
@@ -334,71 +336,70 @@ void vertex_shader(vec3 vertex_input,
 		read_model_matrix = model_matrix * matrix;
 #if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
 		model_matrix = read_model_matrix;
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
+#endif // !USE_DOUBLE_PRECISION || SKIP_TRANSFORM_USED || VERTEX_WORLD_COORDS_USED
+#endif // !USE_DOUBLE_PRECISION || SKIP_TRANSFORM_USED || VERTEX_WORLD_COORDS_USED || MODEL_MATRIX_USED
 		model_normal_matrix = model_normal_matrix * mat3(matrix);
 	}
 
 	vec3 vertex = vertex_input;
 #ifdef NORMAL_USED
 	vec3 normal = normal_input;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
 	vec3 tangent = tangent_input;
 	vec3 binormal = binormal_input;
-#endif
+#endif // TANGENT_USED
 
 #ifdef UV_USED
 	uv_interp = uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	uv2_interp = uv2_attrib;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 	vec4 uv_scale = instances.data[instance_index].uv_scale;
 
-	if (uv_scale != vec4(0.0)) { // Compression enabled
+	if (uv_scale != vec4(0.0)) { // Compression enabled.
 #ifdef UV_USED
 		uv_interp = (uv_interp - 0.5) * uv_scale.xy;
-#endif
+#endif // UV_USED
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 		uv2_interp = (uv2_interp - 0.5) * uv_scale.zw;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 	}
 
 #ifdef OVERRIDE_POSITION
 	vec4 position = vec4(1.0);
-#endif
+#endif // OVERRIDE_POSITION
 
 #ifdef USE_MULTIVIEW
 	mat4 combined_projection = scene_data.projection_matrix;
 	mat4 projection_matrix = scene_data.projection_matrix_view[ViewIndex];
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix_view[ViewIndex];
 	vec3 eye_offset = scene_data.eye_offset[ViewIndex].xyz;
-#else
+#else // USE_MULTIVIEW
 	mat4 projection_matrix = scene_data.projection_matrix;
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix;
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
 
-//using world coordinates
+// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (model_matrix * vec4(vertex, 1.0)).xyz;
 
 #ifdef NORMAL_USED
 	normal = model_normal_matrix * normal;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
-
 	tangent = model_normal_matrix * tangent;
 	binormal = model_normal_matrix * binormal;
+#endif // TANGENT_USED
 
-#endif
-#endif
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	float roughness = 1.0;
 
@@ -407,11 +408,12 @@ void vertex_shader(vec3 vertex_input,
 	mat4 read_view_matrix = scene_data.view_matrix;
 	vec2 read_viewport_size = scene_data.viewport_size;
 
+	// GDShader VERTEX function gets inserted here.
 	{
 #CODE : VERTEX
 	}
 
-// using local coordinates (default)
+// Using local coordinates (default).
 #if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
 #ifdef USE_DOUBLE_PRECISION
@@ -427,44 +429,46 @@ void vertex_shader(vec3 vertex_input,
 	vec3 temp_precision; // Will be ignored.
 	vertex += double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
 	vertex = mat3(scene_data.view_matrix) * vertex;
-#else
+#else // USE_DOUBLE_PRECISION
 	vertex = (modelview * vec4(vertex, 1.0)).xyz;
-#endif
+#endif // USE_DOUBLE_PRECISION
+
 #ifdef NORMAL_USED
 	normal = modelview_normal * normal;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
-
 	binormal = modelview_normal * binormal;
 	tangent = modelview_normal * tangent;
-#endif
-#endif // !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
+#endif // TANGENT_USED
 
-//using world coordinates
+#endif // !SKIP_TRANSFORM_USED && !VERTEX_WORLD_COORDS_USED
+
+// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (scene_data.view_matrix * vec4(vertex, 1.0)).xyz;
 #ifdef NORMAL_USED
 	normal = (scene_data.view_matrix * vec4(normal, 0.0)).xyz;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
 	binormal = (scene_data.view_matrix * vec4(binormal, 0.0)).xyz;
 	tangent = (scene_data.view_matrix * vec4(tangent, 0.0)).xyz;
-#endif
-#endif
+#endif // TANGENT_USED
+
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	vertex_interp = vertex;
 
 #ifdef NORMAL_USED
 	normal_interp = normal;
-#endif
+#endif // NORMAL_USED
 
 #ifdef TANGENT_USED
 	tangent_interp = tangent;
 	binormal_interp = binormal;
-#endif
+#endif // TANGENT_USED
 
 #ifdef MODE_RENDER_DEPTH
 
@@ -472,10 +476,9 @@ void vertex_shader(vec3 vertex_input,
 
 	vertex_interp.z *= scene_data.dual_paraboloid_side;
 
-	dp_clip = vertex_interp.z; //this attempts to avoid noise caused by objects sent to the other parabolloid side due to bias
+	dp_clip = vertex_interp.z; // This attempts to avoid noise caused by objects sent to the other paraboloid side due to bias.
 
-	//for dual paraboloid shadow mapping, this is the fastest but least correct way, as it curves straight edges
-
+	// For dual paraboloid shadow mapping, this is the fastest but least correct way, as it curves straight edges.
 	vec3 vtx = vertex_interp;
 	float distance = length(vtx);
 	vtx = normalize(vtx);
@@ -484,24 +487,25 @@ void vertex_shader(vec3 vertex_input,
 	vtx.z = vtx.z * 2.0 - 1.0;
 	vertex_interp = vtx;
 
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
-#endif //MODE_RENDER_DEPTH
+#endif // MODE_RENDER_DEPTH
 
 #ifdef OVERRIDE_POSITION
 	gl_Position = position;
-#else
+#else // OVERRIDE_POSITION
 	gl_Position = projection_matrix * vec4(vertex_interp, 1.0);
-#endif
+#endif // OVERRIDE_POSITION
 
 #ifdef USE_MULTIVIEW
 	combined_projected = combined_projection * vec4(vertex_interp, 1.0);
-#endif
+#endif // USE_MULTIVIEW
 
 #ifdef MOTION_VECTORS
 	screen_pos = gl_Position;
-#endif
+#endif // MOTION_VECTORS
 
+	// VERTEX LIGHTING //
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 	diffuse_light_interp = vec4(0.0);
 	specular_light_interp = vec4(0.0);
@@ -509,24 +513,22 @@ void vertex_shader(vec3 vertex_input,
 #ifdef USE_MULTIVIEW
 	vec3 view = -normalize(vertex_interp - eye_offset);
 	vec2 clip_pos = clamp((combined_projected.xy / combined_projected.w) * 0.5 + 0.5, 0.0, 1.0);
-#else
+#else // USE_MULTIVIEW
 	vec3 view = -normalize(vertex_interp);
 	vec2 clip_pos = clamp((gl_Position.xy / gl_Position.w) * 0.5 + 0.5, 0.0, 1.0);
-#endif
+#endif // USE_MULTIVIEW
 
 	uvec2 cluster_pos = uvec2(clip_pos / scene_data.screen_pixel_size) >> implementation_data.cluster_shift;
 	uint cluster_offset = (implementation_data.cluster_width * cluster_pos.y + cluster_pos.x) * (implementation_data.max_cluster_element_count_div_32 + 32);
 	uint cluster_z = uint(clamp((-vertex_interp.z / scene_data.z_far) * 32.0, 0.0, 31.0));
 
-	{ //omni lights
-
+	{ // Omni Lights //
 		uint cluster_omni_offset = cluster_offset;
 
 		uint item_min;
 		uint item_max;
 		uint item_from;
 		uint item_to;
-
 		cluster_get_item_range(cluster_omni_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 		for (uint i = item_from; i < item_to; i++) {
@@ -540,11 +542,11 @@ void vertex_shader(vec3 vertex_input,
 				uint light_index = 32 * i + bit;
 
 				if (!bool(omni_lights.data[light_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (omni_lights.data[light_index].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				light_process_omni_vertex(light_index, vertex, view, normal, roughness,
@@ -553,14 +555,13 @@ void vertex_shader(vec3 vertex_input,
 		}
 	}
 
-	{ //spot lights
+	{ // Spot Lights //
 		uint cluster_spot_offset = cluster_offset + implementation_data.cluster_type_size;
 
 		uint item_min;
 		uint item_max;
 		uint item_from;
 		uint item_to;
-
 		cluster_get_item_range(cluster_spot_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 		for (uint i = item_from; i < item_to; i++) {
@@ -575,11 +576,11 @@ void vertex_shader(vec3 vertex_input,
 				uint light_index = 32 * i + bit;
 
 				if (!bool(spot_lights.data[light_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (spot_lights.data[light_index].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				light_process_spot_vertex(light_index, vertex, view, normal, roughness,
@@ -588,7 +589,7 @@ void vertex_shader(vec3 vertex_input,
 		}
 	}
 
-	{ // Directional light.
+	{ // Directional Lights //
 
 		// We process the first directional light separately as it may have shadows.
 		vec3 directional_diffuse = vec3(0.0);
@@ -639,7 +640,7 @@ void vertex_shader(vec3 vertex_input,
 		specular_light_interp.rgb += directional_specular;
 	}
 
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
 
 #ifdef MODE_RENDER_DEPTH
 	if (scene_data.pancake_shadows) {
@@ -647,7 +648,7 @@ void vertex_shader(vec3 vertex_input,
 			gl_Position.z = 0.9999;
 		}
 	}
-#endif
+#endif // MODE_RENDER_DEPTH
 #ifdef MODE_RENDER_MATERIAL
 	if (scene_data.material_uv2_mode) {
 		vec2 uv_offset = unpackHalf2x16(draw_call.uv_offset);
@@ -655,7 +656,7 @@ void vertex_shader(vec3 vertex_input,
 		gl_Position.z = 0.00001;
 		gl_Position.w = 1.0;
 	}
-#endif
+#endif // MODE_RENDER_MATERIAL
 }
 
 void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position, vec3 p_compressed_aabb_size,
@@ -663,16 +664,16 @@ void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position
 		vec4 p_normal_in,
 #ifdef NORMAL_USED
 		out vec3 r_normal,
-#endif
+#endif // NORMAL_USED
 		out vec3 r_tangent,
 		out vec3 r_binormal,
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 		out vec3 r_vertex) {
 
 	r_vertex = p_vertex_in.xyz * p_compressed_aabb_size + p_compressed_aabb_position;
 #ifdef NORMAL_USED
 	r_normal = oct_to_vec3(p_normal_in.xy * 2.0 - 1.0);
-#endif
+#endif // NORMAL_USED
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 
@@ -695,7 +696,7 @@ void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position
 		axis_angle_to_tbn(axis, angle, r_tangent, r_binormal, r_normal);
 		r_binormal *= binormal_sign;
 	}
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 }
 
 void main() {
@@ -709,54 +710,52 @@ void main() {
 	mat4 model_matrix = instances.data[instance_index].transform;
 
 #ifdef MOTION_VECTORS
-	// Previous vertex.
-	vec3 prev_vertex;
+	vec3 prev_vertex; // Previous vertex position.
 #ifdef NORMAL_USED
 	vec3 prev_normal;
-#endif
+#endif // NORMAL_USED
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 	vec3 prev_tangent;
 	vec3 prev_binormal;
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 
 	_unpack_vertex_attributes(
 			previous_vertex_attrib,
 			instances.data[instance_index].compressed_aabb_position_pad.xyz,
 			instances.data[instance_index].compressed_aabb_size_pad.xyz,
-
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 			previous_normal_attrib,
 #ifdef NORMAL_USED
 			prev_normal,
-#endif
+#endif // NORMAL_USED
 			prev_tangent,
 			prev_binormal,
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 			prev_vertex);
 
 	global_time = scene_data_block.prev_data.time;
 	vertex_shader(prev_vertex,
 #ifdef NORMAL_USED
 			prev_normal,
-#endif
+#endif // NORMAL_USED
 #ifdef TANGENT_USED
 			prev_tangent,
 			prev_binormal,
-#endif
+#endif // TANGENT_USED
 			instance_index, draw_call.multimesh_motion_vectors_previous_offset, scene_data_block.prev_data, instances.data[instance_index].prev_transform, prev_screen_position);
-#else
+#else // MOTION_VECTORS
 	// Unused output.
 	vec4 screen_position;
-#endif
+#endif // MOTION_VECTORS
 
 	vec3 vertex;
 #ifdef NORMAL_USED
 	vec3 normal;
-#endif
+#endif // NORMAL_USED
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
 	vec3 tangent;
 	vec3 binormal;
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 
 	_unpack_vertex_attributes(
 			vertex_angle_attrib,
@@ -766,10 +765,10 @@ void main() {
 			axis_tangent_attrib,
 #ifdef NORMAL_USED
 			normal,
-#endif
+#endif // NORMAL_USED
 			tangent,
 			binormal,
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 			vertex);
 
 	// Current vertex.
@@ -777,11 +776,11 @@ void main() {
 	vertex_shader(vertex,
 #ifdef NORMAL_USED
 			normal,
-#endif
+#endif // NORMAL_USED
 #ifdef TANGENT_USED
 			tangent,
 			binormal,
-#endif
+#endif // TANGENT_USED
 			instance_index, draw_call.multimesh_motion_vectors_current_offset, scene_data_block.data, model_matrix, screen_position);
 }
 
@@ -794,6 +793,7 @@ void main() {
 #define SHADER_IS_SRGB false
 #define SHADER_SPACE_FAR 0.0
 
+/* Include our Forward+ UBOs, definitions, etc. */
 #include "scene_forward_clustered_inc.glsl"
 
 /* Varyings */
@@ -802,40 +802,38 @@ layout(location = 0) in vec3 vertex_interp;
 
 #ifdef NORMAL_USED
 layout(location = 1) in vec3 normal_interp;
-#endif
+#endif // NORMAL_USED
 
 #if defined(COLOR_USED)
 layout(location = 2) in vec4 color_interp;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 3) in vec2 uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 layout(location = 4) in vec2 uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #ifdef TANGENT_USED
 layout(location = 5) in vec3 tangent_interp;
 layout(location = 6) in vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED
 
 #ifdef MOTION_VECTORS
 layout(location = 7) in vec4 screen_position;
 layout(location = 8) in vec4 prev_screen_position;
-#endif
+#endif // MOTION_VECTORS
 
 #ifdef MODE_DUAL_PARABOLOID
-
 layout(location = 9) in float dp_clip;
-
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 layout(location = 10) in flat uint instance_index_interp;
 
 #ifdef USE_LIGHTMAP
-// w0, w1, w2, and w3 are the four cubic B-spline basis functions
+// w0, w1, w2, and w3 are the four cubic B-spline basis functions.
 float w0(float a) {
 	return (1.0 / 6.0) * (a * (a * (-a + 3.0) - 3.0) + 1.0);
 }
@@ -852,7 +850,7 @@ float w3(float a) {
 	return (1.0 / 6.0) * (a * a * a);
 }
 
-// g0 and g1 are the two amplitude functions
+// g0 and g1 are the two amplitude functions.
 float g0(float a) {
 	return w0(a) + w1(a);
 }
@@ -861,7 +859,7 @@ float g1(float a) {
 	return w2(a) + w3(a);
 }
 
-// h0 and h1 are the two offset functions
+// h0 and h1 are the two offset functions.
 float h0(float a) {
 	return -1.0 + w1(a) / (w0(a) + w1(a));
 }
@@ -893,15 +891,17 @@ vec4 textureArray_bicubic(texture2DArray tex, vec3 uv, vec2 texture_size) {
 	return (g0(fuv.y) * (g0x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p0, uv.z)) + g1x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p1, uv.z)))) +
 			(g1(fuv.y) * (g0x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p2, uv.z)) + g1x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p3, uv.z))));
 }
-#endif //USE_LIGHTMAP
+#endif // USE_LIGHTMAP
 
 #ifdef USE_MULTIVIEW
+
 #ifdef has_VK_KHR_multiview
 #define ViewIndex gl_ViewIndex
 #else // has_VK_KHR_multiview
 // !BAS! This needs to become an input once we implement our fallback!
 #define ViewIndex 0
 #endif // has_VK_KHR_multiview
+
 vec3 multiview_uv(vec2 uv) {
 	return vec3(uv, ViewIndex);
 }
@@ -909,8 +909,10 @@ ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
 layout(location = 11) in vec4 combined_projected;
+
 #else // USE_MULTIVIEW
-// Set to zero, not supported in non stereo
+
+// Set to zero, not supported in non-stereo.
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
@@ -918,27 +920,28 @@ vec2 multiview_uv(vec2 uv) {
 ivec2 multiview_uv(ivec2 uv) {
 	return uv;
 }
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
+
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 layout(location = 12) highp in vec4 diffuse_light_interp;
 layout(location = 13) highp in vec4 specular_light_interp;
-#endif
-//defines to keep compatibility with vertex
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
+// Defines to keep compatibility with vertex.
 
 #ifdef USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix_view[ViewIndex]
 #define inv_projection_matrix scene_data.inv_projection_matrix_view[ViewIndex]
-#else
+#else // USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix
 #define inv_projection_matrix scene_data.inv_projection_matrix
-#endif
+#endif // USE_MULTIVIEW
 
 #define global_time scene_data_block.data.time
 
 #if defined(ENABLE_SSS) && defined(ENABLE_TRANSMITTANCE)
-//both required for transmittance to be enabled
+// Both required for transmittance to be enabled.
 #define LIGHT_TRANSMITTANCE_USED
-#endif
+#endif // ENABLE_SSS && ENABLE_TRANSMITTANCE
 
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
@@ -946,20 +949,20 @@ layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms
 #MATERIAL_UNIFORMS
 } material;
 /* clang-format on */
-#endif
+#endif // MATERIAL_UNIFORMS_USED
+/* clang-format off */
 
 #GLOBALS
 
+/* clang-format on */
 #ifdef MODE_RENDER_DEPTH
 
 #ifdef MODE_RENDER_MATERIAL
-
 layout(location = 0) out vec4 albedo_output_buffer;
 layout(location = 1) out vec4 normal_output_buffer;
 layout(location = 2) out vec4 orm_output_buffer;
 layout(location = 3) out vec4 emission_output_buffer;
 layout(location = 4) out float depth_output_buffer;
-
 #endif // MODE_RENDER_MATERIAL
 
 #ifdef MODE_RENDER_NORMAL_ROUGHNESS
@@ -967,25 +970,24 @@ layout(location = 0) out vec4 normal_roughness_output_buffer;
 
 #ifdef MODE_RENDER_VOXEL_GI
 layout(location = 1) out uvec2 voxel_gi_buffer;
-#endif
+#endif // MODE_RENDER_VOXEL_GI
 
-#endif //MODE_RENDER_NORMAL
-#else // RENDER DEPTH
+#endif // MODE_RENDER_NORMAL_ROUGHNESS
+
+#else // MODE_RENDER_DEPTH
 
 #ifdef MODE_SEPARATE_SPECULAR
-
-layout(location = 0) out vec4 diffuse_buffer; //diffuse (rgb) and roughness
-layout(location = 1) out vec4 specular_buffer; //specular and SSS (subsurface scatter)
-#else
-
+layout(location = 0) out vec4 diffuse_buffer; // Diffuse (RGB), subsurface scattering strength (A).
+layout(location = 1) out vec4 specular_buffer; // Specular (RGB), metalness (A).
+#else // MODE_SEPARATE_SPECULAR
 layout(location = 0) out vec4 frag_color;
 #endif // MODE_SEPARATE_SPECULAR
 
-#endif // RENDER DEPTH
+#endif // MODE_RENDER_DEPTH
 
 #ifdef MOTION_VECTORS
 layout(location = 2) out vec2 motion_vector;
-#endif
+#endif // MOTION_VECTORS
 
 #include "../scene_forward_aa_inc.glsl"
 
@@ -994,13 +996,13 @@ layout(location = 2) out vec2 motion_vector;
 // Default to SPECULAR_SCHLICK_GGX.
 #if !defined(SPECULAR_DISABLED) && !defined(SPECULAR_SCHLICK_GGX) && !defined(SPECULAR_TOON)
 #define SPECULAR_SCHLICK_GGX
-#endif
+#endif // !SPECULAR_DISABLED && !SPECULAR_SCHLICK_GGX && !SPECULAR_TOON
 
 #include "../scene_forward_lights_inc.glsl"
 
 #include "../scene_forward_gi_inc.glsl"
 
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
 #ifndef MODE_RENDER_DEPTH
 
@@ -1021,16 +1023,16 @@ vec4 fog_process(vec3 vertex) {
 	if (scene_data_block.data.fog_aerial_perspective > 0.0) {
 		vec3 sky_fog_color = vec3(0.0);
 		vec3 cube_view = scene_data_block.data.radiance_inverse_xform * vertex;
-		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred
+		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred.
 		float mip_level = mix(1.0 / MAX_ROUGHNESS_LOD, 1.0, 1.0 - (abs(vertex.z) - scene_data_block.data.z_near) / (scene_data_block.data.z_far - scene_data_block.data.z_near));
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(mip_level * MAX_ROUGHNESS_LOD, lod);
 		sky_fog_color = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod)).rgb;
 		sky_fog_color = mix(sky_fog_color, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod + 1)).rgb, blend);
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		sky_fog_color = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), cube_view, mip_level * MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 		fog_color = mix(fog_color, sky_fog_color, scene_data_block.data.fog_aerial_perspective);
 	}
 
@@ -1053,7 +1055,7 @@ vec4 fog_process(vec3 vertex) {
 		float fog_quad_amount = pow(fog_z, scene_data_block.data.fog_depth_curve) * scene_data_block.data.fog_density;
 		fog_amount = fog_quad_amount;
 	} else {
-		fog_amount = 1 - exp(min(0.0, -length(vertex) * scene_data_block.data.fog_density));
+		fog_amount = 1.0 - exp(min(0.0, -length(vertex) * scene_data_block.data.fog_density));
 	}
 
 	if (abs(scene_data_block.data.fog_height_density) >= 0.0001) {
@@ -1075,7 +1077,7 @@ void cluster_get_item_range(uint p_offset, out uint item_min, out uint item_max,
 	item_max = item_min_max >> 16;
 
 	item_from = item_min >> 5;
-	item_to = (item_max == 0) ? 0 : ((item_max - 1) >> 5) + 1; //side effect of how it is stored, as item_max 0 means no elements
+	item_to = (item_max == 0) ? 0 : ((item_max - 1) >> 5) + 1; // Side effect of how it is stored, as item_max 0 means no elements.
 }
 
 uint cluster_get_range_clip_mask(uint i, uint z_min, uint z_max) {
@@ -1084,29 +1086,29 @@ uint cluster_get_range_clip_mask(uint i, uint z_min, uint z_max) {
 	return bitfieldInsert(uint(0), uint(0xFFFFFFFF), local_min, mask_width);
 }
 
-#endif //!MODE_RENDER DEPTH
+#endif // !MODE_RENDER_DEPTH
 
 #if defined(MODE_RENDER_NORMAL_ROUGHNESS) || defined(MODE_RENDER_MATERIAL)
 // https://advances.realtimerendering.com/s2010/Kaplanyan-CryEngine3(SIGGRAPH%202010%20Advanced%20RealTime%20Rendering%20Course).pdf
 vec3 encode24(vec3 v) {
-	// Unsigned normal (handles most symmetry)
+	// Unsigned normal (handles most symmetry).
 	vec3 vNormalUns = abs(v);
-	// Get the major axis for our collapsed cubemap lookup
+	// Get the major axis for our collapsed cubemap lookup.
 	float maxNAbs = max(vNormalUns.z, max(vNormalUns.x, vNormalUns.y));
-	// Get the collapsed cubemap texture coordinates
+	// Get the collapsed cubemap texture coordinates.
 	vec2 vTexCoord = vNormalUns.z < maxNAbs ? (vNormalUns.y < maxNAbs ? vNormalUns.yz : vNormalUns.xz) : vNormalUns.xy;
 	vTexCoord /= maxNAbs;
 	vTexCoord = vTexCoord.x < vTexCoord.y ? vTexCoord.yx : vTexCoord.xy;
 	// Stretch:
 	vTexCoord.y /= vTexCoord.x;
 	float fFittingScale = texture(sampler2D(best_fit_normal_texture, SAMPLER_NEAREST_CLAMP), vTexCoord).r;
-	// Make vector touch unit cube
+	// Make vector touch unit cube.
 	vec3 result = v / maxNAbs;
-	// scale the normal to get the best fit
+	// Scale the normal to get the best fit.
 	result *= fFittingScale;
 	return result;
 }
-#endif // MODE_RENDER_NORMAL_ROUGHNESS
+#endif // MODE_RENDER_NORMAL_ROUGHNESS || MODE_RENDER_MATERIAL
 
 void fragment_shader(in SceneData scene_data) {
 	uint instance_index = instance_index_interp;
@@ -1114,19 +1116,19 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef PREMUL_ALPHA_USED
 	float premul_alpha = 1.0;
 #endif // PREMUL_ALPHA_USED
-	//lay out everything, whatever is unused is optimized away anyway
+	// Lay out everything, whatever is unused is optimized away anyway.
 	vec3 vertex = vertex_interp;
 #ifdef USE_MULTIVIEW
 	vec3 eye_offset = scene_data.eye_offset[ViewIndex].xyz;
 	vec3 view = -normalize(vertex_interp - eye_offset);
 
 	// UV in our combined frustum space is used for certain screen uv processes where it's
-	// overkill to render separate left and right eye views
+	// overkill to render separate left and right eye views.
 	vec2 combined_uv = (combined_projected.xy / combined_projected.w) * 0.5 + 0.5;
-#else
+#else // USE_MULTIVIEW
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
 	vec3 view = -normalize(vertex_interp);
-#endif
+#endif // USE_MULTIVIEW
 	vec3 albedo = vec3(1.0);
 	vec3 backlight = vec3(0.0);
 	vec4 transmittance_color = vec4(0.0, 0.0, 0.0, 1.0);
@@ -1145,12 +1147,14 @@ void fragment_shader(in SceneData scene_data) {
 #ifndef FOG_DISABLED
 	vec4 fog = vec4(0.0);
 #endif // !FOG_DISABLED
+
 #if defined(CUSTOM_RADIANCE_USED)
 	vec4 custom_radiance = vec4(0.0);
-#endif
+#endif // CUSTOM_RADIANCE_USED
+
 #if defined(CUSTOM_IRRADIANCE_USED)
 	vec4 custom_irradiance = vec4(0.0);
-#endif
+#endif // CUSTOM_IRRADIANCE_USED
 
 	float ao = 1.0;
 	float ao_light_affect = 0.0;
@@ -1160,38 +1164,35 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef TANGENT_USED
 	vec3 binormal = normalize(binormal_interp);
 	vec3 tangent = normalize(tangent_interp);
-#else
+#else // TANGENT_USED
 	vec3 binormal = vec3(0.0);
 	vec3 tangent = vec3(0.0);
-#endif
+#endif // TANGENT_USED
 
 #ifdef NORMAL_USED
 	vec3 normal = normalize(normal_interp);
-
 #if defined(DO_SIDE_CHECK)
 	if (!gl_FrontFacing) {
 		normal = -normal;
 	}
-#endif
-
-#endif //NORMAL_USED
+#endif // DO_SIDE_CHECK
+#endif // NORMAL_USED
 
 #ifdef UV_USED
 	vec2 uv = uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	vec2 uv2 = uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(COLOR_USED)
 	vec4 color = color_interp;
-#endif
+#endif // COLOR_USED
 
 #if defined(NORMAL_MAP_USED)
-
 	vec3 normal_map = vec3(0.5);
-#endif
+#endif // NORMAL_MAP_USED
 
 	float normal_map_depth = 1.0;
 
@@ -1221,11 +1222,11 @@ void fragment_shader(in SceneData scene_data) {
 	inv_view_matrix[0][3] = 0.0;
 	inv_view_matrix[1][3] = 0.0;
 	inv_view_matrix[2][3] = 0.0;
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 #ifdef LIGHT_VERTEX_USED
 	vec3 light_vertex = vertex;
-#endif //LIGHT_VERTEX_USED
+#endif // LIGHT_VERTEX_USED
 
 	mat3 model_normal_matrix;
 	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
@@ -1236,22 +1237,24 @@ void fragment_shader(in SceneData scene_data) {
 
 	mat4 read_view_matrix = scene_data.view_matrix;
 	vec2 read_viewport_size = scene_data.viewport_size;
+
+	// GDShader FRAGMENT function gets inserted here.
 	{
 #CODE : FRAGMENT
 	}
-
-#ifdef LIGHT_TRANSMITTANCE_USED
-	transmittance_color.a *= sss_strength;
-#endif
 
 #ifdef LIGHT_VERTEX_USED
 	vertex = light_vertex;
 #ifdef USE_MULTIVIEW
 	view = -normalize(vertex - eye_offset);
-#else
+#else // USE_MULTIVIEW
 	view = -normalize(vertex);
-#endif //USE_MULTIVIEW
-#endif //LIGHT_VERTEX_USED
+#endif // USE_MULTIVIEW
+#endif // LIGHT_VERTEX_USED
+
+#ifdef LIGHT_TRANSMITTANCE_USED
+	transmittance_color.a *= sss_strength;
+#endif // LIGHT_TRANSMITTANCE_USED
 
 #ifndef USE_SHADOW_TO_OPACITY
 
@@ -1261,7 +1264,7 @@ void fragment_shader(in SceneData scene_data) {
 	}
 #endif // ALPHA_SCISSOR_USED
 
-// alpha hash can be used in unison with alpha antialiasing
+// Alpha hash can be used in unison with alpha antialiasing.
 #ifdef ALPHA_HASH_USED
 	vec3 object_pos = (inverse(read_model_matrix) * inv_view_matrix * vec4(vertex, 1.0)).xyz;
 	if (alpha < compute_alpha_hash_threshold(object_pos, alpha_hash_scale)) {
@@ -1269,16 +1272,16 @@ void fragment_shader(in SceneData scene_data) {
 	}
 #endif // ALPHA_HASH_USED
 
-// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash
+// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash.
 #if (defined(ALPHA_SCISSOR_USED) || defined(ALPHA_HASH_USED)) && !defined(ALPHA_ANTIALIASING_EDGE_USED)
 	alpha = 1.0;
-#endif
+#endif // (ALPHA_SCISSOR_USED || ALPHA_HASH_USED) && !ALPHA_ANTIALIASING_EDGE_USED
 
 #ifdef ALPHA_ANTIALIASING_EDGE_USED
-// If alpha scissor is used, we must further the edge threshold, otherwise we won't get any edge feather
+// If alpha scissor is used, we must further the edge threshold, otherwise we won't get any edge feather.
 #ifdef ALPHA_SCISSOR_USED
 	alpha_antialiasing_edge = clamp(alpha_scissor_threshold + alpha_antialiasing_edge, 0.0, 1.0);
-#endif
+#endif // ALPHA_SCISSOR_USED
 	alpha = compute_alpha_antialiasing_edge(alpha, alpha_texture_coordinate, alpha_antialiasing_edge);
 #endif // ALPHA_ANTIALIASING_EDGE_USED
 
@@ -1293,42 +1296,35 @@ void fragment_shader(in SceneData scene_data) {
 #endif // !USE_SHADOW_TO_OPACITY
 
 #ifdef NORMAL_MAP_USED
-
 	normal_map.xy = normal_map.xy * 2.0 - 1.0;
-	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); //always ignore Z, as it can be RG packed, Z may be pos/neg, etc.
+	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); // Always reconstruct Z, as it can be RG packed, Z may be pos/neg, etc.
 
 	normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
-
-#endif
+#endif // NORMAL_MAP_USED
 
 #ifdef LIGHT_ANISOTROPY_USED
-
 	if (anisotropy > 0.01) {
-		//rotation matrix
 		mat3 rot = mat3(tangent, binormal, normal);
-		//make local to space
+		// Make local to space.
 		tangent = normalize(rot * vec3(anisotropy_flow.x, anisotropy_flow.y, 0.0));
 		binormal = normalize(rot * vec3(-anisotropy_flow.y, anisotropy_flow.x, 0.0));
 	}
-
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 
 #ifdef ENABLE_CLIP_ALPHA
 	if (albedo.a < 0.99) {
-		//used for doublepass and shadowmapping
+		// Used for doublepass and shadowmapping.
 		discard;
 	}
-#endif
+#endif // ENABLE_CLIP_ALPHA
 
 	/////////////////////// FOG //////////////////////
 #ifndef MODE_RENDER_DEPTH
 
 #ifndef FOG_DISABLED
 #ifndef CUSTOM_FOG_USED
-	// fog must be processed as early as possible and then packed.
-	// to maximize VGPR usage
+	// Fog must be processed as early as possible and then packed to maximize VGPR usage.
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
-
 	if (scene_data.fog_enabled) {
 		fog = fog_process(vertex);
 	}
@@ -1336,11 +1332,11 @@ void fragment_shader(in SceneData scene_data) {
 	if (implementation_data.volumetric_fog_enabled) {
 #ifdef USE_MULTIVIEW
 		vec4 volumetric_fog = volumetric_fog_process(combined_uv, -vertex.z);
-#else
+#else // USE_MULTIVIEW
 		vec4 volumetric_fog = volumetric_fog_process(screen_uv, -vertex.z);
-#endif
+#endif // USE_MULTIVIEW
 		if (scene_data.fog_enabled) {
-			//must use the full blending equation here to blend fogs
+			// Must use the full blending equation here to blend fogs.
 			vec4 res;
 			float sa = 1.0 - volumetric_fog.a;
 			res.a = fog.a * sa + volumetric_fog.a;
@@ -1354,13 +1350,13 @@ void fragment_shader(in SceneData scene_data) {
 			fog = volumetric_fog;
 		}
 	}
-#endif //!CUSTOM_FOG_USED
+#endif // !CUSTOM_FOG_USED
 
 	uint fog_rg = packHalf2x16(fog.rg);
 	uint fog_ba = packHalf2x16(fog.ba);
 
-#endif //!FOG_DISABLED
-#endif //!MODE_RENDER_DEPTH
+#endif // !FOG_DISABLED
+#endif // !MODE_RENDER_DEPTH
 
 	/////////////////////// DECALS ////////////////////////////////
 
@@ -1368,18 +1364,18 @@ void fragment_shader(in SceneData scene_data) {
 
 #ifdef USE_MULTIVIEW
 	uvec2 cluster_pos = uvec2(combined_uv.xy / scene_data.screen_pixel_size) >> implementation_data.cluster_shift;
-#else
+#else // USE_MULTIVIEW
 	uvec2 cluster_pos = uvec2(gl_FragCoord.xy) >> implementation_data.cluster_shift;
-#endif
+#endif // USE_MULTIVIEW
 	uint cluster_offset = (implementation_data.cluster_width * cluster_pos.y + cluster_pos.x) * (implementation_data.max_cluster_element_count_div_32 + 32);
 
 	uint cluster_z = uint(clamp((-vertex.z / scene_data.z_far) * 32.0, 0.0, 31.0));
 
-	//used for interpolating anything cluster related
+	// Used for interpolating anything cluster related.
 	vec3 vertex_ddx = dFdx(vertex);
 	vec3 vertex_ddy = dFdy(vertex);
 
-	{ // process decals
+	{ // Process Decals //
 
 		uint cluster_decal_offset = cluster_offset + implementation_data.cluster_type_size * 2;
 
@@ -1387,40 +1383,39 @@ void fragment_shader(in SceneData scene_data) {
 		uint item_max;
 		uint item_from;
 		uint item_to;
-
 		cluster_get_item_range(cluster_decal_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 #ifdef USE_SUBGROUPS
 		item_from = subgroupBroadcastFirst(subgroupMin(item_from));
 		item_to = subgroupBroadcastFirst(subgroupMax(item_to));
-#endif
+#endif // USE_SUBGROUPS
 
 		for (uint i = item_from; i < item_to; i++) {
 			uint mask = cluster_buffer.data[cluster_decal_offset + i];
 			mask &= cluster_get_range_clip_mask(i, item_min, item_max);
 #ifdef USE_SUBGROUPS
 			uint merged_mask = subgroupBroadcastFirst(subgroupOr(mask));
-#else
+#else // USE_SUBGROUPS
 			uint merged_mask = mask;
-#endif
+#endif // USE_SUBGROUPS
 
 			while (merged_mask != 0) {
 				uint bit = findMSB(merged_mask);
 				merged_mask &= ~(1u << bit);
 #ifdef USE_SUBGROUPS
-				if (((1u << bit) & mask) == 0) { //do not process if not originally here
-					continue;
+				if (((1u << bit) & mask) == 0) {
+					continue; // Do not process if not originally here.
 				}
-#endif
+#endif // USE_SUBGROUPS
 				uint decal_index = 32 * i + bit;
 
 				if (!bool(decals.data[decal_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				vec3 uv_local = (decals.data[decal_index].xform * vec4(vertex, 1.0)).xyz;
 				if (any(lessThan(uv_local, vec3(0.0, -1.0, 0.0))) || any(greaterThan(uv_local, vec3(1.0)))) {
-					continue; //out of decal
+					continue; // Out of decal.
 				}
 
 				float fade = pow(1.0 - (uv_local.y > 0.0 ? uv_local.y : -uv_local.y), uv_local.y > 0.0 ? decals.data[decal_index].upper_fade : decals.data[decal_index].lower_fade);
@@ -1429,12 +1424,12 @@ void fragment_shader(in SceneData scene_data) {
 					fade *= smoothstep(decals.data[decal_index].normal_fade, 1.0, dot(normal_interp, decals.data[decal_index].normal) * 0.5 + 0.5);
 				}
 
-				//we need ddx/ddy for mipmaps, so simulate them
+				// We need ddx/ddy for mipmaps, so simulate them.
 				vec2 ddx = (decals.data[decal_index].xform * vec4(vertex_ddx, 0.0)).xz;
 				vec2 ddy = (decals.data[decal_index].xform * vec4(vertex_ddy, 0.0)).xz;
 
 				if (decals.data[decal_index].albedo_rect != vec4(0.0)) {
-					//has albedo
+					// Has albedo.
 					vec4 decal_albedo;
 					if (sc_decal_use_mipmaps()) {
 						decal_albedo = textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].albedo_rect.zw + decals.data[decal_index].albedo_rect.xy, ddx * decals.data[decal_index].albedo_rect.zw, ddy * decals.data[decal_index].albedo_rect.zw);
@@ -1452,9 +1447,9 @@ void fragment_shader(in SceneData scene_data) {
 						} else {
 							decal_normal = textureLod(sampler2D(decal_atlas, decal_sampler), uv_local.xz * decals.data[decal_index].normal_rect.zw + decals.data[decal_index].normal_rect.xy, 0.0).xyz;
 						}
-						decal_normal.xy = decal_normal.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0); //users prefer flipped y normal maps in most authoring software
+						decal_normal.xy = decal_normal.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0); // Users prefer flipped Y normal maps in most authoring software.
 						decal_normal.z = sqrt(max(0.0, 1.0 - dot(decal_normal.xy, decal_normal.xy)));
-						//convert to view space, use xzy because y is up
+						// Convert to view space, use XZY because Y is up.
 						decal_normal = (decals.data[decal_index].normal_xform * decal_normal.xzy).xyz;
 
 						normal = normalize(mix(normal, decal_normal, decal_albedo.a));
@@ -1474,7 +1469,7 @@ void fragment_shader(in SceneData scene_data) {
 				}
 
 				if (decals.data[decal_index].emission_rect != vec4(0.0)) {
-					//emission is additive, so its independent from albedo
+					// Emission is additive, so it's independent from albedo.
 					if (sc_decal_use_mipmaps()) {
 						emission += textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].emission_rect.zw + decals.data[decal_index].emission_rect.xy, ddx * decals.data[decal_index].emission_rect.zw, ddy * decals.data[decal_index].emission_rect.zw).xyz * decals.data[decal_index].modulate.rgb * decals.data[decal_index].emission_energy * fade;
 					} else {
@@ -1484,37 +1479,35 @@ void fragment_shader(in SceneData scene_data) {
 			}
 		}
 	}
+#endif // !MODE_RENDER_DEPTH
 
-	//pack albedo until needed again, saves 2 VGPRs in the meantime
-
-#endif //not render depth
 	/////////////////////// LIGHTING //////////////////////////////
 
 #ifdef NORMAL_USED
 	if (scene_data.roughness_limiter_enabled) {
-		//https://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
+		// https://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
 		float roughness2 = roughness * roughness;
 		vec3 dndu = dFdx(normal), dndv = dFdy(normal);
 		float variance = scene_data.roughness_limiter_amount * (dot(dndu, dndu) + dot(dndv, dndv));
-		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit); //limit effect
+		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit);
 		float filteredRoughness2 = min(1.0, roughness2 + kernelRoughness2);
 		roughness = sqrt(filteredRoughness2);
 	}
-#endif
-	//apply energy conservation
+#endif // NORMAL_USED
 
-	vec3 specular_light = vec3(0.0, 0.0, 0.0);
-	vec3 diffuse_light = vec3(0.0, 0.0, 0.0);
-	vec3 ambient_light = vec3(0.0, 0.0, 0.0);
+	vec3 specular_light = vec3(0.0);
+	vec3 diffuse_light = vec3(0.0);
+	vec3 ambient_light = vec3(0.0);
 #ifndef MODE_UNSHADED
 	// Used in regular draw pass and when drawing SDFs for SDFGI and materials for VoxelGI.
 	emission *= scene_data.emissive_exposure_normalization;
-#endif
+#endif // !MODE_UNSHADED
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #ifndef AMBIENT_LIGHT_DISABLED
 
+	// Global Radiance //
 	if (scene_data.use_reflection_cubemap) {
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1524,25 +1517,23 @@ void fragment_shader(in SceneData scene_data) {
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
 		vec3 ref_vec = reflect(-view, bent_normal);
 		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
-#else
+#else // LIGHT_ANISOTROPY_USED
 		vec3 ref_vec = reflect(-view, normal);
 		ref_vec = mix(ref_vec, normal, roughness * roughness);
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
+
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
-
 		float lod, blend;
-
 		blend = modf(sqrt(roughness) * MAX_ROUGHNESS_LOD, lod);
 		specular_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
 		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
-
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light *= scene_data.IBL_exposure_normalization;
 		specular_light *= horizon * horizon;
 		specular_light *= scene_data.ambient_light_color_energy.a;
@@ -1550,10 +1541,10 @@ void fragment_shader(in SceneData scene_data) {
 
 #if defined(CUSTOM_RADIANCE_USED)
 	specular_light = mix(specular_light, custom_radiance.rgb, custom_radiance.a);
-#endif
+#endif // CUSTOM_RADIANCE_USED
 
 #ifndef USE_LIGHTMAP
-	//lightmap overrides everything
+	// Lightmap overrides everything.
 	if (scene_data.use_ambient_light) {
 		ambient_light = scene_data.ambient_light_color_energy.rgb;
 
@@ -1561,60 +1552,58 @@ void fragment_shader(in SceneData scene_data) {
 			vec3 ambient_dir = scene_data.radiance_inverse_xform * normal;
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 			vec3 cubemap_ambient = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ambient_dir, MAX_ROUGHNESS_LOD)).rgb;
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 			vec3 cubemap_ambient = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ambient_dir, MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 			cubemap_ambient *= scene_data.IBL_exposure_normalization;
 			ambient_light = mix(ambient_light, cubemap_ambient * scene_data.ambient_light_color_energy.a, scene_data.ambient_color_sky_mix);
 		}
 	}
-#endif // USE_LIGHTMAP
+#endif // !USE_LIGHTMAP
+
 #if defined(CUSTOM_IRRADIANCE_USED)
 	ambient_light = mix(ambient_light, custom_irradiance.rgb, custom_irradiance.a);
-#endif
+#endif // CUSTOM_IRRADIANCE_USED
 
 #ifdef LIGHT_CLEARCOAT_USED
 
+	// Note: We want to use geometric normal for clearcoat reflections/BRDF, ie. we ignore the normal map.
 	if (scene_data.use_reflection_cubemap) {
-		vec3 n = normalize(normal_interp); // We want to use geometric normal, not normal_map
+		vec3 n = normalize(normal_interp);
 		float NoV = max(dot(n, view), 0.0001);
 		vec3 ref_vec = reflect(-view, n);
-		// The clear coat layer assumes an IOR of 1.5 (4% reflectance)
+		ref_vec = mix(ref_vec, n, clearcoat_roughness * clearcoat_roughness);
+		// The clear coat layer assumes an IOR of 1.5 (4% reflectance).
 		float Fc = clearcoat * (0.04 + 0.96 * SchlickFresnel(NoV));
 		float attenuation = 1.0 - Fc;
 		ambient_light *= attenuation;
 		specular_light *= attenuation;
 
-		ref_vec = mix(ref_vec, n, clearcoat_roughness * clearcoat_roughness);
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
 		float roughness_lod = mix(0.001, 0.1, sqrt(clearcoat_roughness)) * MAX_ROUGHNESS_LOD;
-#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
+#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(roughness_lod, lod);
 		vec3 clearcoat_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
 		clearcoat_light = mix(clearcoat_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
-
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		vec3 clearcoat_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, roughness_lod).rgb;
-
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light += clearcoat_light * horizon * horizon * Fc * scene_data.ambient_light_color_energy.a;
 	}
 #endif // LIGHT_CLEARCOAT_USED
 #endif // !AMBIENT_LIGHT_DISABLED
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
-	//radiance
-
-/// GI ///
+	/// GI ///
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 #ifndef AMBIENT_LIGHT_DISABLED
 #ifdef USE_LIGHTMAP
 
-	//lightmap
-	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { //has lightmap capture
+	// Lightmapping //
+	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { // Process lightmap capture (L2 SH).
 		uint index = instances.data[instance_index].gi_offset;
 
 		vec3 wnormal = mat3(scene_data.inv_view_matrix) * normal;
@@ -1635,7 +1624,7 @@ void fragment_shader(in SceneData scene_data) {
 								 2.0 * c2 * lightmap_captures.data[index].sh[2].rgb * wnormal.z) *
 				scene_data.emissive_exposure_normalization;
 
-	} else if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // has actual lightmap
+	} else if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // Process lightmap texture.
 		bool uses_sh = bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_SH_LIGHTMAP);
 		uint ofs = instances.data[instance_index].gi_offset & 0xFFFF;
 		uint slice = instances.data[instance_index].gi_offset >> 16;
@@ -1644,12 +1633,12 @@ void fragment_shader(in SceneData scene_data) {
 		uvw.z = float(slice);
 
 		if (uses_sh) {
-			uvw.z *= 4.0; //SH textures use 4 times more data
+			uvw.z *= 4.0; // SH textures use 4 times more data.
+
 			vec3 lm_light_l0;
 			vec3 lm_light_l1n1;
 			vec3 lm_light_l1_0;
 			vec3 lm_light_l1p1;
-
 			if (sc_use_lightmap_bicubic_filter()) {
 				lm_light_l0 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 0.0), lightmaps.data[ofs].light_texture_size).rgb;
 				lm_light_l1n1 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 1.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
@@ -1678,16 +1667,16 @@ void fragment_shader(in SceneData scene_data) {
 			}
 		}
 	}
-#else
+#else // USE_LIGHTMAP
 
-	if (sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_SDFGI)) { //has lightmap capture
+	if (sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_SDFGI)) { // Process SDFGI.
 
-		//make vertex orientation the world one, but still align to camera
+		// Make vertex orientation the world one, but still align to camera.
 		vec3 cam_pos = mat3(scene_data.inv_view_matrix) * vertex;
 		vec3 cam_normal = mat3(scene_data.inv_view_matrix) * normal;
 		vec3 cam_reflection = mat3(scene_data.inv_view_matrix) * reflect(-view, normal);
 
-		//apply y-mult
+		// Apply y-mult.
 		cam_pos.y *= sdfgi.y_mult;
 		cam_normal.y *= sdfgi.y_mult;
 		cam_normal = normalize(cam_normal);
@@ -1703,7 +1692,7 @@ void fragment_shader(in SceneData scene_data) {
 
 		float blend = -1.0;
 
-		// helper constants, compute once
+		// Helper constants, compute once.
 
 		uint cascade = 0xFFFFFFFF;
 		vec3 cascade_pos;
@@ -1713,7 +1702,7 @@ void fragment_shader(in SceneData scene_data) {
 			cascade_pos = (cam_pos - sdfgi.cascades[i].position) * sdfgi.cascades[i].to_probe;
 
 			if (any(lessThan(cascade_pos, vec3(0.0))) || any(greaterThanEqual(cascade_pos, sdfgi.cascade_probe_size))) {
-				continue; //skip cascade
+				continue; // Skip cascade.
 			}
 
 			cascade = i;
@@ -1727,7 +1716,7 @@ void fragment_shader(in SceneData scene_data) {
 			sdfgi_process(cascade, cascade_pos, cam_pos, cam_normal, cam_reflection, use_specular, roughness, diffuse, specular, blend);
 
 			if (blend > 0.0) {
-				//blend
+				// Blend cascades.
 				if (cascade == sdfgi.max_cascades - 1) {
 					diffuse = mix(diffuse, ambient_light, blend);
 					if (use_specular) {
@@ -1752,14 +1741,14 @@ void fragment_shader(in SceneData scene_data) {
 		}
 	}
 
-	if (sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_VOXEL_GI)) { // process voxel_gi_instances
+	if (sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_VOXEL_GI)) { // Process VoxelGI instances.
 		uint index1 = instances.data[instance_index].gi_offset & 0xFFFF;
 		// Make vertex orientation the world one, but still align to camera.
 		vec3 cam_pos = mat3(scene_data.inv_view_matrix) * vertex;
 		vec3 cam_normal = mat3(scene_data.inv_view_matrix) * normal;
 		vec3 ref_vec = mat3(scene_data.inv_view_matrix) * normalize(reflect(-view, normal));
 
-		//find arbitrary tangent and bitangent, then build a matrix
+		// Find arbitrary tangent and bitangent, then build a matrix.
 		vec3 v0 = abs(cam_normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(0.0, 1.0, 0.0);
 		vec3 tangent = normalize(cross(v0, cam_normal));
 		vec3 bitangent = normalize(cross(tangent, cam_normal));
@@ -1787,10 +1776,9 @@ void fragment_shader(in SceneData scene_data) {
 		ambient_light = amb_accum.rgb;
 	}
 
-	if (!sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_GI_BUFFERS)) { //use GI buffers
+	if (!sc_use_forward_gi() && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_GI_BUFFERS)) { // Get deferred GI buffers.
 
-		vec2 coord;
-
+		vec2 coord = screen_uv;
 		if (implementation_data.gi_upscale_for_msaa) {
 			vec2 base_coord = screen_uv;
 			vec2 closest_coord = base_coord;
@@ -1815,9 +1803,6 @@ void fragment_shader(in SceneData scene_data) {
 			}
 
 			coord = closest_coord;
-
-		} else {
-			coord = screen_uv;
 		}
 
 #ifdef USE_MULTIVIEW
@@ -1831,22 +1816,22 @@ void fragment_shader(in SceneData scene_data) {
 		ambient_light = mix(ambient_light, buffer_ambient.rgb, buffer_ambient.a);
 		specular_light = mix(specular_light, buffer_reflection.rgb, buffer_reflection.a);
 	}
-#endif // !USE_LIGHTMAP
+#endif // USE_LIGHTMAP
 
 	if (bool(implementation_data.ss_effects_flags & SCREEN_SPACE_EFFECTS_FLAGS_USE_SSAO)) {
 #ifdef USE_MULTIVIEW
 		float ssao = texture(sampler2DArray(ao_buffer, SAMPLER_LINEAR_CLAMP), vec3(screen_uv, ViewIndex)).r;
-#else
+#else // USE_MULTIVIEW
 		float ssao = texture(sampler2D(ao_buffer, SAMPLER_LINEAR_CLAMP), screen_uv).r;
-#endif
+#endif // USE_MULTIVIEW
 		ao = min(ao, ssao);
 		ao_light_affect = mix(ao_light_affect, max(ao_light_affect, implementation_data.ssao_light_affect), implementation_data.ssao_ao_affect);
 	}
 
-	{ // process reflections
+	{ // Reflection Probes //
 
-		vec4 reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
-		vec4 ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
+		vec4 reflection_accum = vec4(0.0);
+		vec4 ambient_accum = vec4(0.0);
 
 		uint cluster_reflection_offset = cluster_offset + implementation_data.cluster_type_size * 3;
 
@@ -1854,13 +1839,12 @@ void fragment_shader(in SceneData scene_data) {
 		uint item_max;
 		uint item_from;
 		uint item_to;
-
 		cluster_get_item_range(cluster_reflection_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 #ifdef USE_SUBGROUPS
 		item_from = subgroupBroadcastFirst(subgroupMin(item_from));
 		item_to = subgroupBroadcastFirst(subgroupMax(item_to));
-#endif
+#endif // USE_SUBGROUPS
 
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1868,9 +1852,9 @@ void fragment_shader(in SceneData scene_data) {
 		vec3 anisotropic_tangent = cross(anisotropic_direction, view);
 		vec3 anisotropic_normal = cross(anisotropic_tangent, anisotropic_direction);
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
-#else
+#else // LIGHT_ANISOTROPY_USED
 		vec3 bent_normal = normal;
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 		vec3 ref_vec = normalize(reflect(-view, bent_normal));
 		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
 
@@ -1879,22 +1863,22 @@ void fragment_shader(in SceneData scene_data) {
 			mask &= cluster_get_range_clip_mask(i, item_min, item_max);
 #ifdef USE_SUBGROUPS
 			uint merged_mask = subgroupBroadcastFirst(subgroupOr(mask));
-#else
+#else // USE_SUBGROUPS
 			uint merged_mask = mask;
-#endif
+#endif // USE_SUBGROUPS
 
 			while (merged_mask != 0) {
 				uint bit = findMSB(merged_mask);
 				merged_mask &= ~(1u << bit);
 #ifdef USE_SUBGROUPS
-				if (((1u << bit) & mask) == 0) { //do not process if not originally here
-					continue;
+				if (((1u << bit) & mask) == 0) {
+					continue; // Do not process if not originally here.
 				}
-#endif
+#endif // USE_SUBGROUPS
 				uint reflection_index = 32 * i + bit;
 
 				if (!bool(reflections.data[reflection_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				reflection_process(reflection_index, vertex, ref_vec, normal, roughness, ambient_light, specular_light, ambient_accum, reflection_accum);
@@ -1909,10 +1893,10 @@ void fragment_shader(in SceneData scene_data) {
 		if (ambient_accum.a > 0.0) {
 			ambient_light = ambient_accum.rgb / ambient_accum.a;
 		}
-#endif
+#endif // !USE_LIGHTMAP
 	}
 
-	//finalize ambient light here
+	// Finalize ambient light.
 	{
 		ambient_light *= albedo.rgb;
 		ambient_light *= ao;
@@ -1920,30 +1904,31 @@ void fragment_shader(in SceneData scene_data) {
 		if (bool(implementation_data.ss_effects_flags & SCREEN_SPACE_EFFECTS_FLAGS_USE_SSIL)) {
 #ifdef USE_MULTIVIEW
 			vec4 ssil = textureLod(sampler2DArray(ssil_buffer, SAMPLER_LINEAR_CLAMP), vec3(screen_uv, ViewIndex), 0.0);
-#else
+#else // USE_MULTIVIEW
 			vec4 ssil = textureLod(sampler2D(ssil_buffer, SAMPLER_LINEAR_CLAMP), screen_uv, 0.0);
 #endif // USE_MULTIVIEW
 			ambient_light *= 1.0 - ssil.a;
 			ambient_light += ssil.rgb * albedo.rgb;
 		}
 	}
-#endif // AMBIENT_LIGHT_DISABLED
-	// convert ao to direct light ao
+#endif // !AMBIENT_LIGHT_DISABLED
+
+	// Convert AO to direct light AO.
 	ao = mix(1.0, ao, ao_light_affect);
 
-	//this saves some VGPRs
+	// This saves some VGPRs.
 	vec3 f0 = F0(metallic, specular, albedo);
+
 #ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
-		//simplify for toon, as
+		// Simplified toon BRDF.
 		specular_light *= specular * metallic * albedo * 2.0;
-#else
+#else // DIFFUSE_TOON
 
-		// scales the specular reflections, needs to be computed before lighting happens,
-		// but after environment, GI, and reflection probes are added
-		// Environment brdf approximation (Lazarov 2013)
-		// see https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
+		// Environment BRDF Approximation (Lazarov 2013)
+		// Scales only indirect reflections, hence is computed before direct lighting happens.
+		// See: https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
 		const vec4 c0 = vec4(-1.0, -0.0275, -0.572, 0.022);
 		const vec4 c1 = vec4(1.0, 0.0425, 1.04, -0.04);
 		vec4 r = roughness * c0 + c1;
@@ -1952,38 +1937,38 @@ void fragment_shader(in SceneData scene_data) {
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 
 		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
-#endif
+#endif // DIFFUSE_TOON
 	}
-
 #endif // !AMBIENT_LIGHT_DISABLED
-#endif //GI !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
+	// End of GI //
 
 #if !defined(MODE_RENDER_DEPTH)
-	//this saves some VGPRs
+	// This saves some VGPRs.
 	uint orms = packUnorm4x8(vec4(ao, roughness, metallic, specular));
-#endif
+#endif // !MODE_RENDER_DEPTH
 
-// LIGHTING
+	// LIGHTING //
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #ifdef USE_VERTEX_LIGHTING
 	diffuse_light += diffuse_light_interp.rgb;
 	specular_light += specular_light_interp.rgb * f0;
-#endif
+#endif // USE_VERTEX_LIGHTING
 
-	{ // Directional light.
-
-		// Do shadow and lighting in two passes to reduce register pressure.
+	{ // Directional Lights //
 #ifndef SHADOWS_DISABLED
+
+		// Do shadows and lighting in two passes to reduce register pressure.
 		uint shadow0 = 0;
 		uint shadow1 = 0;
 
 		float shadowmask = 1.0;
-
 #ifdef USE_LIGHTMAP
 		uint shadowmask_mode = LIGHTMAP_SHADOWMASK_MODE_NONE;
 
-		if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
+		if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // Get shadowmask texture.
 			const uint ofs = instances.data[instance_index].gi_offset & 0xFFFF;
 			shadowmask_mode = lightmaps.data[ofs].flags;
 
@@ -2004,26 +1989,29 @@ void fragment_shader(in SceneData scene_data) {
 #endif // USE_LIGHTMAP
 
 #ifdef USE_VERTEX_LIGHTING
+			// Clang tries to dedent the second part of this ifdef.
+			/* clang-format off */
+
 			// Only process the first light's shadow for vertex lighting.
 			for (uint i = 0; i < 1; i++) {
-#else
-		for (uint i = 0; i < 8; i++) {
-			if (i >= scene_data.directional_light_count) {
-				break;
-			}
-#endif
+#else // USE_VERTEX_LIGHTING
+			for (uint i = 0; i < 8; i++) {
+				if (i >= scene_data.directional_light_count) {
+					break;
+				}
+			/* clang-format on */
+#endif // USE_VERTEX_LIGHTING
 
 				if (!bool(directional_lights.data[i].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (directional_lights.data[i].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				float shadow = 1.0;
-
-				if (directional_lights.data[i].shadow_opacity > 0.001) {
+				if (directional_lights.data[i].shadow_opacity > 0.001) { // Compute Shadows //
 					float depth_z = -vertex.z;
 					vec3 light_dir = directional_lights.data[i].direction;
 					vec3 base_normal_bias = normalize(normal_interp) * (1.0 - max(0.0, dot(light_dir, -normalize(normal_interp))));
@@ -2034,12 +2022,11 @@ void fragment_shader(in SceneData scene_data) {
 	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
 	m_var.xyz += normal_bias;
 
-					//version with soft shadows, more expensive
-					if (sc_use_directional_soft_shadows() && directional_lights.data[i].softshadow_angle > 0) {
+					if (sc_use_directional_soft_shadows() && directional_lights.data[i].softshadow_angle > 0) { // Soft Shadows //
 						uint blend_count = 0;
 						const uint blend_max = directional_lights.data[i].blend_splits ? 2 : 1;
 
-						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 0)
@@ -2055,7 +2042,7 @@ void fragment_shader(in SceneData scene_data) {
 							blend_count++;
 						}
 
-						if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+						if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 1)
@@ -2071,8 +2058,7 @@ void fragment_shader(in SceneData scene_data) {
 
 							if (blend_count == 0) {
 								shadow = s;
-							} else {
-								//blend
+							} else { // Blend cascades.
 								float blend = smoothstep(0.0, directional_lights.data[i].shadow_split_offsets.x, depth_z);
 								shadow = mix(shadow, s, blend);
 							}
@@ -2080,7 +2066,7 @@ void fragment_shader(in SceneData scene_data) {
 							blend_count++;
 						}
 
-						if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+						if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 2)
@@ -2096,8 +2082,7 @@ void fragment_shader(in SceneData scene_data) {
 
 							if (blend_count == 0) {
 								shadow = s;
-							} else {
-								//blend
+							} else { // Blend cascades.
 								float blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x, directional_lights.data[i].shadow_split_offsets.y, depth_z);
 								shadow = mix(shadow, s, blend);
 							}
@@ -2105,7 +2090,7 @@ void fragment_shader(in SceneData scene_data) {
 							blend_count++;
 						}
 
-						if (blend_count < blend_max) {
+						if (blend_count < blend_max) { // Fourth cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 3)
@@ -2121,26 +2106,25 @@ void fragment_shader(in SceneData scene_data) {
 
 							if (blend_count == 0) {
 								shadow = s;
-							} else {
-								//blend
+							} else { // Blend cascades.
 								float blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y, directional_lights.data[i].shadow_split_offsets.z, depth_z);
 								shadow = mix(shadow, s, blend);
 							}
 						}
 
-					} else { //no soft shadows
+					} else { // Hard Shadows //
 
 						vec4 pssm_coord;
 						float blur_factor;
 
-						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 0)
 
 							pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
 							blur_factor = 1.0;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 1)
@@ -2148,7 +2132,7 @@ void fragment_shader(in SceneData scene_data) {
 							pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 2)
@@ -2156,7 +2140,7 @@ void fragment_shader(in SceneData scene_data) {
 							pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-						} else {
+						} else { // Fourth cascade.
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 3)
@@ -2174,21 +2158,21 @@ void fragment_shader(in SceneData scene_data) {
 							float pssm_blend;
 							float blur_factor2;
 
-							if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+							if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First-to-second blend.
 								vec4 v = vec4(vertex, 1.0);
 								BIAS_FUNC(v, 1)
 								pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 								pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x - directional_lights.data[i].shadow_split_offsets.x * 0.1, directional_lights.data[i].shadow_split_offsets.x, depth_z);
 								// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 								blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-							} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+							} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second-to-third blend.
 								vec4 v = vec4(vertex, 1.0);
 								BIAS_FUNC(v, 2)
 								pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 								pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y - directional_lights.data[i].shadow_split_offsets.y * 0.1, directional_lights.data[i].shadow_split_offsets.y, depth_z);
 								// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 								blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-							} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+							} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third-to-fourth blend.
 								vec4 v = vec4(vertex, 1.0);
 								BIAS_FUNC(v, 3)
 								pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
@@ -2196,7 +2180,7 @@ void fragment_shader(in SceneData scene_data) {
 								// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 								blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
 							} else {
-								pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
+								pssm_blend = 0.0; // If no blend, same coord will be used (divide by z will result in same value, and already cached).
 								blur_factor2 = 1.0;
 							}
 
@@ -2209,23 +2193,23 @@ void fragment_shader(in SceneData scene_data) {
 
 #ifdef USE_LIGHTMAP
 					if (shadowmask_mode == LIGHTMAP_SHADOWMASK_MODE_REPLACE) {
-						shadow = mix(shadow, shadowmask, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+						shadow = mix(shadow, shadowmask, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 					} else if (shadowmask_mode == LIGHTMAP_SHADOWMASK_MODE_OVERLAY) {
-						shadow = shadowmask * mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+						shadow = shadowmask * mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 					} else {
-#endif
-						shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+#endif // USE_LIGHTMAP
+						shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 #ifdef USE_LIGHTMAP
 					}
-#endif
+#endif // USE_LIGHTMAP
 
 #ifdef USE_VERTEX_LIGHTING
 					diffuse_light *= mix(1.0, shadow, diffuse_light_interp.a);
 					specular_light *= mix(1.0, shadow, specular_light_interp.a);
-#endif
+#endif // USE_VERTEX_LIGHTING
 
 #undef BIAS_FUNC
-				} // shadows
+				} // End of shadows.
 
 				if (i < 4) {
 					shadow0 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << (i * 8);
@@ -2240,13 +2224,13 @@ void fragment_shader(in SceneData scene_data) {
 #ifdef USE_VERTEX_LIGHTING
 			diffuse_light *= mix(1.0, shadowmask, diffuse_light_interp.a);
 			specular_light *= mix(1.0, shadowmask, specular_light_interp.a);
-#endif
+#endif // USE_VERTEX_LIGHTING
 
 			shadow0 |= uint(clamp(shadowmask * 255.0, 0.0, 255.0));
 		}
 #endif // USE_LIGHTMAP
 
-#endif // SHADOWS_DISABLED
+#endif // !SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
 
@@ -2256,11 +2240,11 @@ void fragment_shader(in SceneData scene_data) {
 			}
 
 			if (!bool(directional_lights.data[i].mask & instances.data[instance_index].layer_mask)) {
-				continue; //not masked
+				continue; // Not masked, skip.
 			}
 
 			if (directional_lights.data[i].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-				continue; // Statically baked light and object uses lightmap, skip
+				continue; // Statically baked light and object uses lightmap, skip.
 			}
 
 #ifdef LIGHT_TRANSMITTANCE_USED
@@ -2324,12 +2308,12 @@ void fragment_shader(in SceneData scene_data) {
 			}
 
 			shadow = mix(1.0, shadow, directional_lights.data[i].shadow_opacity);
-#endif
+#endif // !SHADOWS_DISABLED
 
 			blur_shadow(shadow);
 
-#ifdef DEBUG_DRAW_PSSM_SPLITS
 			vec3 tint = vec3(1.0);
+#ifdef DEBUG_DRAW_PSSM_SPLITS
 			if (-vertex.z < directional_lights.data[i].shadow_split_offsets.x) {
 				tint = vec3(1.0, 0.0, 0.0);
 			} else if (-vertex.z < directional_lights.data[i].shadow_split_offsets.y) {
@@ -2341,44 +2325,39 @@ void fragment_shader(in SceneData scene_data) {
 			}
 			tint = mix(tint, vec3(1.0), shadow);
 			shadow = 1.0;
-#endif
+#endif // DEBUG_DRAW_PSSM_SPLITS
 
 			float size_A = sc_use_directional_soft_shadows() ? directional_lights.data[i].size : 0.0;
 
 			light_compute(normal, directional_lights.data[i].direction, normalize(view), size_A,
-#ifndef DEBUG_DRAW_PSSM_SPLITS
-					directional_lights.data[i].color * directional_lights.data[i].energy,
-#else
 					directional_lights.data[i].color * directional_lights.data[i].energy * tint,
-#endif
 					true, shadow, f0, orms, 1.0, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 					backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 					transmittance_color,
 					transmittance_depth,
 					transmittance_boost,
 					transmittance_z,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 					rim, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 					clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-					binormal,
-					tangent, anisotropy,
-#endif
+					binormal, tangent, anisotropy,
+#endif // LIGHT_ANISOTROPY_USED
 					diffuse_light,
 					specular_light);
 		}
-#endif // USE_VERTEX_LIGHTING
-	}
+#endif // !USE_VERTEX_LIGHTING
+	} // End of directional lights.
 
 #ifndef USE_VERTEX_LIGHTING
-	{ //omni lights
+	{ // Omni Lights //
 
 		uint cluster_omni_offset = cluster_offset;
 
@@ -2386,66 +2365,65 @@ void fragment_shader(in SceneData scene_data) {
 		uint item_max;
 		uint item_from;
 		uint item_to;
-
 		cluster_get_item_range(cluster_omni_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 #ifdef USE_SUBGROUPS
 		item_from = subgroupBroadcastFirst(subgroupMin(item_from));
 		item_to = subgroupBroadcastFirst(subgroupMax(item_to));
-#endif
+#endif // USE_SUBGROUPS
 
 		for (uint i = item_from; i < item_to; i++) {
 			uint mask = cluster_buffer.data[cluster_omni_offset + i];
 			mask &= cluster_get_range_clip_mask(i, item_min, item_max);
 #ifdef USE_SUBGROUPS
 			uint merged_mask = subgroupBroadcastFirst(subgroupOr(mask));
-#else
+#else // USE_SUBGROUPS
 			uint merged_mask = mask;
-#endif
+#endif // USE_SUBGROUPS
 
 			while (merged_mask != 0) {
 				uint bit = findMSB(merged_mask);
 				merged_mask &= ~(1u << bit);
 #ifdef USE_SUBGROUPS
-				if (((1u << bit) & mask) == 0) { //do not process if not originally here
-					continue;
+				if (((1u << bit) & mask) == 0) {
+					continue; // Do not process if not originally here.
 				}
-#endif
+#endif // USE_SUBGROUPS
 				uint light_index = 32 * i + bit;
 
 				if (!bool(omni_lights.data[light_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (omni_lights.data[light_index].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				light_process_omni(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, scene_data.taa_frame_count, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 						backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 						transmittance_color,
 						transmittance_depth,
 						transmittance_boost,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 						rim,
 						rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 						clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 						tangent, binormal, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 						diffuse_light, specular_light);
 			}
 		}
-	}
+	} // End of omni lights.
 
-	{ //spot lights
+	{ // Spot Lights //
 
 		uint cluster_spot_offset = cluster_offset + implementation_data.cluster_type_size;
 
@@ -2453,68 +2431,66 @@ void fragment_shader(in SceneData scene_data) {
 		uint item_max;
 		uint item_from;
 		uint item_to;
-
 		cluster_get_item_range(cluster_spot_offset + implementation_data.max_cluster_element_count_div_32 + cluster_z, item_min, item_max, item_from, item_to);
 
 #ifdef USE_SUBGROUPS
 		item_from = subgroupBroadcastFirst(subgroupMin(item_from));
 		item_to = subgroupBroadcastFirst(subgroupMax(item_to));
-#endif
+#endif // USE_SUBGROUPS
 
 		for (uint i = item_from; i < item_to; i++) {
 			uint mask = cluster_buffer.data[cluster_spot_offset + i];
 			mask &= cluster_get_range_clip_mask(i, item_min, item_max);
 #ifdef USE_SUBGROUPS
 			uint merged_mask = subgroupBroadcastFirst(subgroupOr(mask));
-#else
+#else // USE_SUBGROUPS
 			uint merged_mask = mask;
-#endif
+#endif // USE_SUBGROUPS
 
 			while (merged_mask != 0) {
 				uint bit = findMSB(merged_mask);
 				merged_mask &= ~(1u << bit);
 #ifdef USE_SUBGROUPS
-				if (((1u << bit) & mask) == 0) { //do not process if not originally here
-					continue;
+				if (((1u << bit) & mask) == 0) {
+					continue; // Do not process if not originally here.
 				}
-#endif
+#endif // USE_SUBGROUPS
 
 				uint light_index = 32 * i + bit;
 
 				if (!bool(spot_lights.data[light_index].mask & instances.data[instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (spot_lights.data[light_index].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
-					continue; // Statically baked light and object uses lightmap, skip
+					continue; // Statically baked light and object uses lightmap, skip.
 				}
 
 				light_process_spot(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, scene_data.taa_frame_count, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 						backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 						transmittance_color,
 						transmittance_depth,
 						transmittance_boost,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 						rim,
 						rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 						clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-						tangent,
-						binormal, anisotropy,
-#endif
+						tangent, binormal, anisotropy,
+#endif // LIGHT_ANISOTROPY_USED
 						diffuse_light, specular_light);
 			}
 		}
-	}
+	} // End of spot lights.
 #endif // !USE_VERTEX_LIGHTING
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
 #ifdef USE_SHADOW_TO_OPACITY
 #ifndef MODE_RENDER_DEPTH
@@ -2537,7 +2513,7 @@ void fragment_shader(in SceneData scene_data) {
 		vec3 local_pos = (implementation_data.sdf_to_bounds * vec4(vertex, 1.0)).xyz;
 		ivec3 grid_pos = implementation_data.sdf_offset + ivec3(local_pos * vec3(implementation_data.sdf_size));
 
-		uint albedo16 = 0x1; //solid flag
+		uint albedo16 = 0x1; // Solid flag.
 		albedo16 |= clamp(uint(albedo.r * 31.0), 0, 31) << 11;
 		albedo16 |= clamp(uint(albedo.g * 31.0), 0, 31) << 6;
 		albedo16 |= clamp(uint(albedo.b * 31.0), 0, 31) << 1;
@@ -2566,10 +2542,10 @@ void fragment_shader(in SceneData scene_data) {
 		}
 
 #ifdef NO_IMAGE_ATOMICS
-		imageStore(geom_facing_grid, grid_pos, uvec4(imageLoad(geom_facing_grid, grid_pos).r | facing_bits)); //store facing bits
-#else
-		imageAtomicOr(geom_facing_grid, grid_pos, facing_bits); //store facing bits
-#endif
+		imageStore(geom_facing_grid, grid_pos, uvec4(imageLoad(geom_facing_grid, grid_pos).r | facing_bits)); // Store facing bits.
+#else // NO_IMAGE_ATOMICS
+		imageAtomicOr(geom_facing_grid, grid_pos, facing_bits); // Store facing bits.
+#endif // NO_IMAGE_ATOMICS
 
 		if (length(emission) > 0.001) {
 			float lumas[6];
@@ -2590,7 +2566,7 @@ void fragment_shader(in SceneData scene_data) {
 				light_aniso |= min(31, uint((lumas[i] / luma_total) * 31.0)) << (i * 5);
 			}
 
-			//compress to RGBE9995 to save space
+			// Compress to RGBE9995 to save space.
 
 			const float pow2to9 = 512.0f;
 			const float B = 15.0f;
@@ -2616,7 +2592,7 @@ void fragment_shader(in SceneData scene_data) {
 			float sRed = floor((cRed / pow(2.0f, exps - B - N)) + 0.5f);
 			float sGreen = floor((cGreen / pow(2.0f, exps - B - N)) + 0.5f);
 			float sBlue = floor((cBlue / pow(2.0f, exps - B - N)) + 0.5f);
-			//store as 8985 to have 2 extra neighbor bits
+			// Store as 8985 to have 2 extra neighbor bits.
 			uint light_rgbe = ((uint(sRed) & 0x1FFu) >> 1) | ((uint(sGreen) & 0x1FFu) << 8) | (((uint(sBlue) & 0x1FFu) >> 1) << 17) | ((uint(exps) & 0x1Fu) << 25);
 
 			imageStore(emission_grid, grid_pos, uvec4(light_rgbe));
@@ -2624,10 +2600,9 @@ void fragment_shader(in SceneData scene_data) {
 		}
 	}
 
-#endif
+#endif // MODE_RENDER_SDF
 
 #ifdef MODE_RENDER_MATERIAL
-
 	albedo_output_buffer.rgb = albedo;
 	albedo_output_buffer.a = alpha;
 
@@ -2642,12 +2617,12 @@ void fragment_shader(in SceneData scene_data) {
 
 	emission_output_buffer.rgb = emission;
 	emission_output_buffer.a = 0.0;
-#endif
+#endif // MODE_RENDER_MATERIAL
 
 #ifdef MODE_RENDER_NORMAL_ROUGHNESS
 	normal_roughness_output_buffer = vec4(encode24(normal) * 0.5 + 0.5, roughness);
 
-	// We encode the dynamic static into roughness.
+	// We encode the dynamic/static flag into roughness.
 	// Values over 0.5 are dynamic, under 0.5 are static.
 	normal_roughness_output_buffer.w = normal_roughness_output_buffer.w * (127.0 / 255.0);
 	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_DYNAMIC)) {
@@ -2656,7 +2631,7 @@ void fragment_shader(in SceneData scene_data) {
 	normal_roughness_output_buffer.w = normal_roughness_output_buffer.w;
 
 #ifdef MODE_RENDER_VOXEL_GI
-	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_VOXEL_GI)) { // process voxel_gi_instances
+	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_USE_VOXEL_GI)) { // Process VoxelGI instances.
 		uint index1 = instances.data[instance_index].gi_offset & 0xFFFF;
 		uint index2 = instances.data[instance_index].gi_offset >> 16;
 		voxel_gi_buffer.x = index1 & 0xFFu;
@@ -2665,70 +2640,68 @@ void fragment_shader(in SceneData scene_data) {
 		voxel_gi_buffer.x = 0xFF;
 		voxel_gi_buffer.y = 0xFF;
 	}
-#endif
+#endif // MODE_RENDER_VOXEL_GI
 
-#endif //MODE_RENDER_NORMAL_ROUGHNESS
+#endif // MODE_RENDER_NORMAL_ROUGHNESS
 
-//nothing happens, so a tree-ssa optimizer will result in no fragment shader :)
-#else
+// Nothing happens, so a tree-ssa optimizer will result in no fragment shader :)
+#else // MODE_RENDER_DEPTH
 
-	// multiply by albedo
-	diffuse_light *= albedo; // ambient must be multiplied by albedo at the end
+	// Multiply by albedo.
+	diffuse_light *= albedo; // Ambient must be multiplied by albedo at the end.
 
-	// apply direct light AO
+	// Apply direct light AO.
 	ao = unpackUnorm4x8(orms).x;
 	specular_light *= ao;
 	diffuse_light *= ao;
 
-	// apply metallic
+	// Apply metallic.
 	metallic = unpackUnorm4x8(orms).z;
 	diffuse_light *= 1.0 - metallic;
 	ambient_light *= 1.0 - metallic;
 
 #ifndef FOG_DISABLED
-	//restore fog
+	// Restore fog.
 	fog = vec4(unpackHalf2x16(fog_rg), unpackHalf2x16(fog_ba));
-#endif //!FOG_DISABLED
+#endif // !FOG_DISABLED
 
 #ifdef MODE_SEPARATE_SPECULAR
 
 #ifdef MODE_UNSHADED
 	diffuse_buffer = vec4(albedo.rgb, 0.0);
 	specular_buffer = vec4(0.0);
-
-#else
-
+#else // MODE_UNSHADED
 #ifdef SSS_MODE_SKIN
 	sss_strength = -sss_strength;
-#endif
+#endif // SSS_MODE_SKIN
 	diffuse_buffer = vec4(emission + diffuse_light + ambient_light, sss_strength);
 	specular_buffer = vec4(specular_light, metallic);
-#endif
+#endif // MODE_UNSHADED
 
 #ifndef FOG_DISABLED
 	diffuse_buffer.rgb = mix(diffuse_buffer.rgb, fog.rgb, fog.a);
 	specular_buffer.rgb = mix(specular_buffer.rgb, vec3(0.0), fog.a);
-#endif //!FOG_DISABLED
+#endif // !FOG_DISABLED
 
-#else //MODE_SEPARATE_SPECULAR
+#else // MODE_SEPARATE_SPECULAR
 
 	alpha *= scene_data.pass_alpha_multiplier;
 
 #ifdef MODE_UNSHADED
 	frag_color = vec4(albedo, alpha);
-#else
+#else // MODE_UNSHADED
 	frag_color = vec4(emission + ambient_light + diffuse_light + specular_light, alpha);
-//frag_color = vec4(1.0);
-#endif //USE_NO_SHADING
+#endif // MODE_UNSHADED
 
 #ifndef FOG_DISABLED
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
 	frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a);
-#endif //!FOG_DISABLED
+#endif // !FOG_DISABLED
 
-#endif //MODE_SEPARATE_SPECULAR
+#endif // MODE_SEPARATE_SPECULAR
 
-#endif //MODE_RENDER_DEPTH
+#endif // MODE_RENDER_DEPTH
+
 #ifdef MOTION_VECTORS
 	vec2 position_clip = (screen_position.xy / screen_position.w) - scene_data.taa_jitter;
 	vec2 prev_position_clip = (prev_screen_position.xy / prev_screen_position.w) - scene_data_block.prev_data.taa_jitter;
@@ -2737,11 +2710,11 @@ void fragment_shader(in SceneData scene_data) {
 	vec2 prev_position_uv = prev_position_clip * vec2(0.5, 0.5);
 
 	motion_vector = prev_position_uv - position_uv;
-#endif
+#endif // MOTION_VECTORS
 
 #if defined(PREMUL_ALPHA_USED) && !defined(MODE_RENDER_DEPTH)
 	frag_color.rgb *= premul_alpha;
-#endif //PREMUL_ALPHA_USED
+#endif // PREMUL_ALPHA_USED && !MODE_RENDER_DEPTH
 }
 
 void main() {
@@ -2752,12 +2725,11 @@ void main() {
 	} else if (uc_cull_mode() == POLYGON_CULL_FRONT && front_facing) {
 		discard;
 	}
-#endif
+#endif // UBERSHADER
 #ifdef MODE_DUAL_PARABOLOID
-
 	if (dp_clip > 0.0)
 		discard;
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 	fragment_shader(scene_data_block.data);
 }

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -4,7 +4,7 @@
 
 #VERSION_DEFINES
 
-/* Include our forward mobile UBOs definitions etc. */
+/* Include our Forward Mobile UBOs, definitions, etc. */
 #include "scene_forward_mobile_inc.glsl"
 
 #define SHADER_IS_SRGB false
@@ -15,50 +15,50 @@
 // Always contains vertex position in XYZ, can contain tangent angle in W.
 layout(location = 0) in vec4 vertex_angle_attrib;
 
-//only for pure render depth when normal is not used
+// Only for pure render depth when normal is not used.
 
-#ifdef NORMAL_USED
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
 // Contains Normal/Axis in RG, can contain tangent in BA.
 layout(location = 1) in vec4 axis_tangent_attrib;
-#endif
+#endif // NORMAL_USED || TANGENT_USED
 
 // Location 2 is unused.
 
 #if defined(COLOR_USED)
 layout(location = 3) in vec4 color_attrib;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 4) in vec2 uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP) || defined(MODE_RENDER_MATERIAL)
 layout(location = 5) in vec2 uv2_attrib;
-#endif // MODE_RENDER_MATERIAL
+#endif // UV2_USED || USE_LIGHTMAP || MODE_RENDER_MATERIAL
 
 #if defined(CUSTOM0_USED)
 layout(location = 6) in vec4 custom0_attrib;
-#endif
+#endif // CUSTOM0_USED
 
 #if defined(CUSTOM1_USED)
 layout(location = 7) in vec4 custom1_attrib;
-#endif
+#endif // CUSTOM1_USED
 
 #if defined(CUSTOM2_USED)
 layout(location = 8) in vec4 custom2_attrib;
-#endif
+#endif // CUSTOM2_USED
 
 #if defined(CUSTOM3_USED)
 layout(location = 9) in vec4 custom3_attrib;
-#endif
+#endif // CUSTOM3_USED
 
 #if defined(BONES_USED) || defined(USE_PARTICLE_TRAILS)
 layout(location = 10) in uvec4 bone_attrib;
-#endif
+#endif // BONES_USED || USE_PARTICLE_TRAILS
 
 #if defined(WEIGHTS_USED) || defined(USE_PARTICLE_TRAILS)
 layout(location = 11) in vec4 weight_attrib;
-#endif
+#endif // WEIGHTS_USED || USE_PARTICLE_TRAILS
 
 vec3 oct_to_vec3(vec2 e) {
 	vec3 v = vec3(e.xy, 1.0 - abs(e.x) - abs(e.y));
@@ -95,47 +95,48 @@ layout(location = 3) mediump out vec2 uv_interp;
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 layout(location = 4) mediump out vec2 uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 layout(location = 5) mediump out vec3 tangent_interp;
 layout(location = 6) mediump out vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 layout(location = 7) highp out vec4 diffuse_light_interp;
 layout(location = 8) highp out vec4 specular_light_interp;
 
 #include "../scene_forward_vertex_lights_inc.glsl"
-#endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
 layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms {
 #MATERIAL_UNIFORMS
 } material;
 /* clang-format on */
-#endif
+#endif // MATERIAL_UNIFORMS_USED
 
 #ifdef MODE_DUAL_PARABOLOID
-
 layout(location = 9) out highp float dp_clip;
-
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 #ifdef USE_MULTIVIEW
+
 #ifdef has_VK_KHR_multiview
 #define ViewIndex gl_ViewIndex
-#else
+#else // has_VK_KHR_multiview
 // !BAS! This needs to become an input once we implement our fallback!
 #define ViewIndex 0
-#endif
+#endif // has_VK_KHR_multiview
 vec3 multiview_uv(vec2 uv) {
 	return vec3(uv, ViewIndex);
 }
 ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
-#else
-// Set to zero, not supported in non stereo
+
+#else // USE_MULTIVIEW
+
+// Set to zero, not supported in non-stereo.
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
@@ -143,12 +144,15 @@ vec2 multiview_uv(vec2 uv) {
 ivec2 multiview_uv(ivec2 uv) {
 	return uv;
 }
-#endif //USE_MULTIVIEW
+
+#endif // USE_MULTIVIEW
 
 invariant gl_Position;
+/* clang-format off */
 
 #GLOBALS
 
+/* clang-format on */
 #define scene_data scene_data_block.data
 
 #ifdef USE_DOUBLE_PRECISION
@@ -176,7 +180,7 @@ vec3 double_add_vec3(vec3 base_a, vec3 prec_a, vec3 base_b, vec3 prec_b, out vec
 	s = quick_two_sum(s, se, out_precision);
 	return s;
 }
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 uint multimesh_stride() {
 	uint stride = sc_multimesh_format_2d() ? 2 : 3;
@@ -189,7 +193,7 @@ void main() {
 	vec4 instance_custom = vec4(0.0);
 #if defined(COLOR_USED)
 	color_interp = color_attrib;
-#endif
+#endif // COLOR_USED
 
 	mat4 model_matrix = instances.data[draw_call.instance_index].transform;
 	mat4 inv_view_matrix = scene_data.inv_view_matrix;
@@ -203,7 +207,7 @@ void main() {
 	inv_view_matrix[0][3] = 0.0;
 	inv_view_matrix[1][3] = 0.0;
 	inv_view_matrix[2][3] = 0.0;
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 	mat3 model_normal_matrix;
 	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
@@ -215,54 +219,52 @@ void main() {
 	mat4 matrix;
 	mat4 read_model_matrix = model_matrix;
 
-	if (sc_multimesh()) {
-		//multimesh, instances are for it
-
+	if (sc_multimesh()) { // Multimesh, instances are for it.
 #ifdef USE_PARTICLE_TRAILS
 		uint trail_size = (instances.data[draw_call.instance_index].flags >> INSTANCE_FLAGS_PARTICLE_TRAIL_SHIFT) & INSTANCE_FLAGS_PARTICLE_TRAIL_MASK;
-		uint stride = 3 + 1 + 1; //particles always uses this format
+		uint stride = 3 + 1 + 1; // Particles always use this format.
 
 		uint offset = trail_size * stride * gl_InstanceIndex;
 
 #ifdef COLOR_USED
 		vec4 pcolor;
-#endif
+#endif // COLOR_USED
 		{
 			uint boffset = offset + bone_attrib.x * stride;
 			matrix = mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.x;
 #ifdef COLOR_USED
 			pcolor = transforms.data[boffset + 3] * weight_attrib.x;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.y > 0.001) {
 			uint boffset = offset + bone_attrib.y * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.y;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.y;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.z > 0.001) {
 			uint boffset = offset + bone_attrib.z * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.z;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.z;
-#endif
+#endif // COLOR_USED
 		}
 		if (weight_attrib.w > 0.001) {
 			uint boffset = offset + bone_attrib.w * stride;
 			matrix += mat4(transforms.data[boffset + 0], transforms.data[boffset + 1], transforms.data[boffset + 2], vec4(0.0, 0.0, 0.0, 1.0)) * weight_attrib.w;
 #ifdef COLOR_USED
 			pcolor += transforms.data[boffset + 3] * weight_attrib.w;
-#endif
+#endif // COLOR_USED
 		}
 
 		instance_custom = transforms.data[offset + 4];
 
 #ifdef COLOR_USED
 		color_interp *= pcolor;
-#endif
+#endif // COLOR_USED
 
-#else
+#else // USE_PARTICLE_TRAILS
 		uint stride = multimesh_stride();
 		uint offset = stride * gl_InstanceIndex;
 
@@ -277,39 +279,36 @@ void main() {
 		if (sc_multimesh_has_color()) {
 #ifdef COLOR_USED
 			color_interp *= transforms.data[offset];
-#endif
+#endif // COLOR_USED
 			offset += 1;
 		}
 
 		if (sc_multimesh_has_custom_data()) {
 			instance_custom = transforms.data[offset];
 		}
+#endif // USE_PARTICLE_TRAILS
 
-#endif
-		//transpose
 		matrix = transpose(matrix);
-
 #if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
 		// Normally we can bake the multimesh transform into the model matrix, but when using double precision
 		// we avoid baking it in so we can emulate high precision.
 		read_model_matrix = model_matrix * matrix;
 #if !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
 		model_matrix = read_model_matrix;
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED)
-#endif // !defined(USE_DOUBLE_PRECISION) || defined(SKIP_TRANSFORM_USED) || defined(VERTEX_WORLD_COORDS_USED) || defined(MODEL_MATRIX_USED)
+#endif // !USE_DOUBLE_PRECISION || SKIP_TRANSFORM_USED || VERTEX_WORLD_COORDS_USED
+#endif // !USE_DOUBLE_PRECISION || SKIP_TRANSFORM_USED || VERTEX_WORLD_COORDS_USED || MODEL_MATRIX_USED
 		model_normal_matrix = model_normal_matrix * mat3(matrix);
 	}
 
 	vec3 vertex = vertex_angle_attrib.xyz * instances.data[draw_call.instance_index].compressed_aabb_size_pad.xyz + instances.data[draw_call.instance_index].compressed_aabb_position_pad.xyz;
 #ifdef NORMAL_USED
 	vec3 normal = oct_to_vec3(axis_tangent_attrib.xy * 2.0 - 1.0);
-#endif
+#endif // NORMAL_USED
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-
+	vec3 tangent;
 	vec3 binormal;
 	float binormal_sign;
-	vec3 tangent;
 	if (axis_tangent_attrib.z > 0.0 || axis_tangent_attrib.w < 1.0) {
 		// Uncompressed format.
 		vec2 signed_tangent_attrib = axis_tangent_attrib.zw * 2.0 - 1.0;
@@ -320,62 +319,61 @@ void main() {
 		// Compressed format.
 		float angle = vertex_angle_attrib.w;
 		binormal_sign = angle > 0.5 ? 1.0 : -1.0; // 0.5 does not exist in UNORM16, so values are either greater or smaller.
-		angle = abs(angle * 2.0 - 1.0) * M_PI; // 0.5 is basically zero, allowing to encode both signs reliably.
+		angle = abs(angle * 2.0 - 1.0) * M_PI; // 0.5 is basically zero, allowing us to encode both signs reliably.
 		vec3 axis = normal;
 		axis_angle_to_tbn(axis, angle, tangent, binormal, normal);
 		binormal *= binormal_sign;
 	}
-#endif
+#endif // NORMAL_USED || TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #ifdef UV_USED
 	uv_interp = uv_attrib;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	uv2_interp = uv2_attrib;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 	vec4 uv_scale = instances.data[draw_call.instance_index].uv_scale;
 
-	if (uv_scale != vec4(0.0)) { // Compression enabled
+	if (uv_scale != vec4(0.0)) { // Compression enabled.
 #ifdef UV_USED
 		uv_interp = (uv_interp - 0.5) * uv_scale.xy;
-#endif
+#endif // UV_USED
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 		uv2_interp = (uv2_interp - 0.5) * uv_scale.zw;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 	}
 
 #ifdef OVERRIDE_POSITION
 	vec4 position = vec4(1.0);
-#endif
+#endif // OVERRIDE_POSITION
 
 #ifdef USE_MULTIVIEW
 	mat4 projection_matrix = scene_data.projection_matrix_view[ViewIndex];
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix_view[ViewIndex];
 	vec3 eye_offset = scene_data.eye_offset[ViewIndex].xyz;
-#else
+#else // USE_MULTIVIEW
 	mat4 projection_matrix = scene_data.projection_matrix;
 	mat4 inv_projection_matrix = scene_data.inv_projection_matrix;
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
 
-//using world coordinates
+	// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (model_matrix * vec4(vertex, 1.0)).xyz;
 
 #ifdef NORMAL_USED
 	normal = model_normal_matrix * normal;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-
 	tangent = model_normal_matrix * tangent;
 	binormal = model_normal_matrix * binormal;
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
-#endif
-#endif
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	float roughness = 1.0;
 
@@ -384,11 +382,12 @@ void main() {
 	mat4 read_view_matrix = scene_data.view_matrix;
 	vec2 read_viewport_size = scene_data.viewport_size;
 
+	// GDShader VERTEX function gets inserted here.
 	{
 #CODE : VERTEX
 	}
 
-// using local coordinates (default)
+	// Using local coordinates (default).
 #if !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
 #ifdef USE_DOUBLE_PRECISION
@@ -401,70 +400,76 @@ void main() {
 		model_origin = double_add_vec3(model_origin, model_precision, matrix[3].xyz, vec3(0.0), model_precision);
 	}
 	vertex = mat3(inv_view_matrix * modelview) * vertex;
-	vec3 temp_precision;
+	vec3 temp_precision; // Will be ignored.
 	vertex += double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
 	vertex = mat3(scene_data.view_matrix) * vertex;
-#else
+#else // USE_DOUBLE_PRECISION
 	vertex = (modelview * vec4(vertex, 1.0)).xyz;
-#endif
+#endif // USE_DOUBLE_PRECISION
+
 #ifdef NORMAL_USED
 	normal = modelview_normal * normal;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
-
 	binormal = modelview_normal * binormal;
 	tangent = modelview_normal * tangent;
-#endif
-#endif // !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
-//using world coordinates
+#endif // !SKIP_TRANSFORM_USED && !VERTEX_WORLD_COORDS_USED
+
+	// Using world coordinates.
 #if !defined(SKIP_TRANSFORM_USED) && defined(VERTEX_WORLD_COORDS_USED)
 
 	vertex = (scene_data.view_matrix * vec4(vertex, 1.0)).xyz;
 #ifdef NORMAL_USED
 	normal = (scene_data.view_matrix * vec4(normal, 0.0)).xyz;
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	binormal = (scene_data.view_matrix * vec4(binormal, 0.0)).xyz;
 	tangent = (scene_data.view_matrix * vec4(tangent, 0.0)).xyz;
-#endif
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
+
+#endif // !SKIP_TRANSFORM_USED && VERTEX_WORLD_COORDS_USED
 
 	vertex_interp = vertex;
+
 #ifdef NORMAL_USED
 	normal_interp = normalize(normal);
-#endif
+#endif // NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	tangent_interp = normalize(tangent);
 	binormal_interp = normalize(binormal);
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
-// VERTEX LIGHTING
+	// VERTEX LIGHTING //
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
-#ifdef USE_MULTIVIEW
-	vec3 view = -normalize(vertex_interp - eye_offset);
-#else
-	vec3 view = -normalize(vertex_interp);
-#endif
-
 	diffuse_light_interp = vec4(0.0);
 	specular_light_interp = vec4(0.0);
 
+#ifdef USE_MULTIVIEW
+	vec3 view = -normalize(vertex_interp - eye_offset);
+#else // USE_MULTIVIEW
+	vec3 view = -normalize(vertex_interp);
+#endif // USE_MULTIVIEW
+
+	// Omni Lights //
 	uvec2 omni_light_indices = instances.data[draw_call.instance_index].omni_lights;
 	for (uint i = 0; i < sc_omni_lights(); i++) {
 		uint light_index = (i > 3) ? ((omni_light_indices.y >> ((i - 4) * 8)) & 0xFF) : ((omni_light_indices.x >> (i * 8)) & 0xFF);
 		light_process_omni_vertex(light_index, vertex, view, normal_interp, roughness, diffuse_light_interp.rgb, specular_light_interp.rgb);
 	}
 
+	// Spot Lights //
 	uvec2 spot_light_indices = instances.data[draw_call.instance_index].spot_lights;
 	for (uint i = 0; i < sc_spot_lights(); i++) {
 		uint light_index = (i > 3) ? ((spot_light_indices.y >> ((i - 4) * 8)) & 0xFF) : ((spot_light_indices.x >> (i * 8)) & 0xFF);
 		light_process_spot_vertex(light_index, vertex, view, normal_interp, roughness, diffuse_light_interp.rgb, specular_light_interp.rgb);
 	}
 
+	// Directional Lights //
 	if (sc_directional_lights() > 0) {
 		// We process the first directional light separately as it may have shadows.
 		vec3 directional_diffuse = vec3(0.0);
@@ -515,15 +520,14 @@ void main() {
 		specular_light_interp.rgb += directional_specular;
 	}
 
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
 
 #ifdef MODE_RENDER_DEPTH
 
 #ifdef MODE_DUAL_PARABOLOID
-
 	vertex_interp.z *= scene_data.dual_paraboloid_side;
 
-	dp_clip = vertex_interp.z; //this attempts to avoid noise caused by objects sent to the other parabolloid side due to bias
+	dp_clip = vertex_interp.z; // This attempts to avoid noise caused by objects sent to the other paraboloid side due to bias.
 
 	//for dual paraboloid shadow mapping, this is the fastest but least correct way, as it curves straight edges
 
@@ -534,14 +538,13 @@ void main() {
 	vtx.z = (distance / scene_data.z_far);
 	vtx.z = vtx.z * 2.0 - 1.0;
 	vertex_interp = vtx;
+#endif // MODE_DUAL_PARABOLOID
 
-#endif
-
-#endif //MODE_RENDER_DEPTH
+#endif // MODE_RENDER_DEPTH
 
 #ifdef OVERRIDE_POSITION
 	gl_Position = position;
-#else
+#else // OVERRIDE_POSITION
 	gl_Position = projection_matrix * vec4(vertex_interp, 1.0);
 #endif // OVERRIDE_POSITION
 
@@ -570,7 +573,7 @@ void main() {
 #define SHADER_IS_SRGB false
 #define SHADER_SPACE_FAR 0.0
 
-/* Include our forward mobile UBOs definitions etc. */
+/* Include our Forward Mobile UBOs, definitions, etc. */
 #include "scene_forward_mobile_inc.glsl"
 
 /* Varyings */
@@ -579,38 +582,36 @@ layout(location = 0) highp in vec3 vertex_interp;
 
 #ifdef NORMAL_USED
 layout(location = 1) mediump in vec3 normal_interp;
-#endif
+#endif // NORMAL_USED
 
 #if defined(COLOR_USED)
 layout(location = 2) mediump in vec4 color_interp;
-#endif
+#endif // COLOR_USED
 
 #ifdef UV_USED
 layout(location = 3) mediump in vec2 uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 layout(location = 4) mediump in vec2 uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 layout(location = 5) mediump in vec3 tangent_interp;
 layout(location = 6) mediump in vec3 binormal_interp;
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 layout(location = 7) highp in vec4 diffuse_light_interp;
 layout(location = 8) highp in vec4 specular_light_interp;
-#endif
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED && USE_VERTEX_LIGHTING
 
 #ifdef MODE_DUAL_PARABOLOID
-
 layout(location = 9) highp in float dp_clip;
-
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
 #ifdef USE_LIGHTMAP
-// w0, w1, w2, and w3 are the four cubic B-spline basis functions
+// w0, w1, w2, and w3 are the four cubic B-spline basis functions.
 float w0(float a) {
 	return (1.0 / 6.0) * (a * (a * (-a + 3.0) - 3.0) + 1.0);
 }
@@ -627,7 +628,7 @@ float w3(float a) {
 	return (1.0 / 6.0) * (a * a * a);
 }
 
-// g0 and g1 are the two amplitude functions
+// g0 and g1 are the two amplitude functions.
 float g0(float a) {
 	return w0(a) + w1(a);
 }
@@ -636,7 +637,7 @@ float g1(float a) {
 	return w2(a) + w3(a);
 }
 
-// h0 and h1 are the two offset functions
+// h0 and h1 are the two offset functions.
 float h0(float a) {
 	return -1.0 + w1(a) / (w0(a) + w1(a));
 }
@@ -668,23 +669,27 @@ vec4 textureArray_bicubic(texture2DArray tex, vec3 uv, vec2 texture_size) {
 	return (g0(fuv.y) * (g0x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p0, uv.z)) + g1x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p1, uv.z)))) +
 			(g1(fuv.y) * (g0x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p2, uv.z)) + g1x * texture(sampler2DArray(tex, SAMPLER_LINEAR_CLAMP), vec3(p3, uv.z))));
 }
-#endif //USE_LIGHTMAP
+#endif // USE_LIGHTMAP
 
 #ifdef USE_MULTIVIEW
+
 #ifdef has_VK_KHR_multiview
 #define ViewIndex gl_ViewIndex
-#else
+#else // has_VK_KHR_multiview
 // !BAS! This needs to become an input once we implement our fallback!
 #define ViewIndex 0
-#endif
+#endif // has_VK_KHR_multiview
+
 vec3 multiview_uv(vec2 uv) {
 	return vec3(uv, ViewIndex);
 }
 ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
-#else
-// Set to zero, not supported in non stereo
+
+#else // USE_MULTIVIEW
+
+// Set to zero, not supported in non-stereo.
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
@@ -692,22 +697,22 @@ vec2 multiview_uv(vec2 uv) {
 ivec2 multiview_uv(ivec2 uv) {
 	return uv;
 }
-#endif //USE_MULTIVIEW
+#endif // USE_MULTIVIEW
 
-//defines to keep compatibility with vertex
+// Defines to keep compatibility with vertex.
 
 #ifdef USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix_view[ViewIndex]
 #define inv_projection_matrix scene_data.inv_projection_matrix_view[ViewIndex]
-#else
+#else // USE_MULTIVIEW
 #define projection_matrix scene_data.projection_matrix
 #define inv_projection_matrix scene_data.inv_projection_matrix
-#endif
+#endif // USE_MULTIVIEW
 
 #if defined(ENABLE_SSS) && defined(ENABLE_TRANSMITTANCE)
-//both required for transmittance to be enabled
+// Both required for transmittance to be enabled.
 #define LIGHT_TRANSMITTANCE_USED
-#endif
+#endif // ENABLE_SSS && ENABLE_TRANSMITTANCE
 
 #ifdef MATERIAL_UNIFORMS_USED
 /* clang-format off */
@@ -715,54 +720,50 @@ layout(set = MATERIAL_UNIFORM_SET, binding = 0, std140) uniform MaterialUniforms
 #MATERIAL_UNIFORMS
 } material;
 /* clang-format on */
-#endif
+#endif // MATERIAL_UNIFORMS_USED
+/* clang-format off */
 
 #GLOBALS
 
 /* clang-format on */
-
 #ifdef MODE_RENDER_DEPTH
 
 #ifdef MODE_RENDER_MATERIAL
-
 layout(location = 0) out vec4 albedo_output_buffer;
 layout(location = 1) out vec4 normal_output_buffer;
 layout(location = 2) out vec4 orm_output_buffer;
 layout(location = 3) out vec4 emission_output_buffer;
 layout(location = 4) out float depth_output_buffer;
-
 #endif // MODE_RENDER_MATERIAL
 
-#else // RENDER DEPTH
+#else // MODE_RENDER_DEPTH
 
 #ifdef MODE_MULTIPLE_RENDER_TARGETS
-
-layout(location = 0) out vec4 diffuse_buffer; //diffuse (rgb) and roughness
-layout(location = 1) out vec4 specular_buffer; //specular and SSS (subsurface scatter)
-#else
-
+layout(location = 0) out vec4 diffuse_buffer; // Diffuse (RGB), subsurface scattering strength (A).
+layout(location = 1) out vec4 specular_buffer; // Specular (RGB), metalness (A).
+#else // MODE_MULTIPLE_RENDER_TARGETS
 layout(location = 0) out mediump vec4 frag_color;
 #endif // MODE_MULTIPLE_RENDER_TARGETS
 
-#endif // RENDER DEPTH
+#endif // MODE_RENDER_DEPTH
 
 #include "../scene_forward_aa_inc.glsl"
 
-#if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) // && !defined(USE_VERTEX_LIGHTING)
+#if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 // Default to SPECULAR_SCHLICK_GGX.
 #if !defined(SPECULAR_DISABLED) && !defined(SPECULAR_SCHLICK_GGX) && !defined(SPECULAR_TOON)
 #define SPECULAR_SCHLICK_GGX
-#endif
+#endif // !SPECULAR_DISABLED && !SPECULAR_SCHLICK_GGX && !SPECULAR_TOON
 
 #include "../scene_forward_lights_inc.glsl"
 
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && !defined(USE_VERTEX_LIGHTING)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
 #ifndef MODE_RENDER_DEPTH
 
 /*
-	Only supporting normal fog here.
+	Only supporting normal fog on Mobile.
 */
 
 vec4 fog_process(vec3 vertex) {
@@ -771,16 +772,16 @@ vec4 fog_process(vec3 vertex) {
 	if (sc_use_fog_aerial_perspective()) {
 		vec3 sky_fog_color = vec3(0.0);
 		vec3 cube_view = scene_data_block.data.radiance_inverse_xform * vertex;
-		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred
+		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred.
 		float mip_level = mix(1.0 / MAX_ROUGHNESS_LOD, 1.0, 1.0 - (abs(vertex.z) - scene_data_block.data.z_near) / (scene_data_block.data.z_far - scene_data_block.data.z_near));
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(mip_level * MAX_ROUGHNESS_LOD, lod);
 		sky_fog_color = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod)).rgb;
 		sky_fog_color = mix(sky_fog_color, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(cube_view, lod + 1)).rgb, blend);
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		sky_fog_color = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), cube_view, mip_level * MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 		fog_color = mix(fog_color, sky_fog_color, scene_data_block.data.fog_aerial_perspective);
 	}
 
@@ -803,7 +804,7 @@ vec4 fog_process(vec3 vertex) {
 		float fog_quad_amount = pow(fog_z, scene_data_block.data.fog_depth_curve) * scene_data_block.data.fog_density;
 		fog_amount = fog_quad_amount;
 	} else {
-		fog_amount = 1 - exp(min(0.0, -length(vertex) * scene_data_block.data.fog_density));
+		fog_amount = 1.0 - exp(min(0.0, -length(vertex) * scene_data_block.data.fog_density));
 	}
 
 	if (sc_use_fog_height_density()) {
@@ -819,7 +820,7 @@ vec4 fog_process(vec3 vertex) {
 	return vec4(fog_color, fog_amount);
 }
 
-#endif //!MODE_RENDER DEPTH
+#endif // !MODE_RENDER_DEPTH
 
 #define scene_data scene_data_block.data
 
@@ -831,22 +832,21 @@ void main() {
 	} else if (uc_cull_mode() == POLYGON_CULL_FRONT && front_facing) {
 		discard;
 	}
-#endif
+#endif // UBERSHADER
 #ifdef MODE_DUAL_PARABOLOID
-
 	if (dp_clip > 0.0)
 		discard;
-#endif
+#endif // MODE_DUAL_PARABOLOID
 
-	//lay out everything, whatever is unused is optimized away anyway
+	// Lay out everything, whatever is unused is optimized away anyway.
 	vec3 vertex = vertex_interp;
 #ifdef USE_MULTIVIEW
 	vec3 eye_offset = scene_data.eye_offset[ViewIndex].xyz;
 	vec3 view = -normalize(vertex_interp - eye_offset);
-#else
+#else // USE_MULTIVIEW
 	vec3 eye_offset = vec3(0.0, 0.0, 0.0);
 	vec3 view = -normalize(vertex_interp);
-#endif
+#endif // USE_MULTIVIEW
 	vec3 albedo = vec3(1.0);
 	vec3 backlight = vec3(0.0);
 	vec4 transmittance_color = vec4(0.0);
@@ -864,16 +864,19 @@ void main() {
 	vec2 anisotropy_flow = vec2(1.0, 0.0);
 #ifdef PREMUL_ALPHA_USED
 	float premul_alpha = 1.0;
-#endif
+#endif // PREMUL_ALPHA_USED
+
 #ifndef FOG_DISABLED
 	vec4 fog = vec4(0.0);
 #endif // !FOG_DISABLED
+
 #if defined(CUSTOM_RADIANCE_USED)
 	vec4 custom_radiance = vec4(0.0);
-#endif
+#endif // CUSTOM_RADIANCE_USED
+
 #if defined(CUSTOM_IRRADIANCE_USED)
 	vec4 custom_irradiance = vec4(0.0);
-#endif
+#endif // CUSTOM_IRRADIANCE_USED
 
 	float ao = 1.0;
 	float ao_light_affect = 0.0;
@@ -883,38 +886,35 @@ void main() {
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	vec3 binormal = normalize(binormal_interp);
 	vec3 tangent = normalize(tangent_interp);
-#else
+#else // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 	vec3 binormal = vec3(0.0);
 	vec3 tangent = vec3(0.0);
-#endif
+#endif // TANGENT_USED || NORMAL_MAP_USED || LIGHT_ANISOTROPY_USED
 
 #ifdef NORMAL_USED
 	vec3 normal = normalize(normal_interp);
-
 #if defined(DO_SIDE_CHECK)
 	if (!gl_FrontFacing) {
 		normal = -normal;
 	}
-#endif
-
-#endif //NORMAL_USED
+#endif // DO_SIDE_CHECK
+#endif // NORMAL_USED
 
 #ifdef UV_USED
 	vec2 uv = uv_interp;
-#endif
+#endif // UV_USED
 
 #if defined(UV2_USED) || defined(USE_LIGHTMAP)
 	vec2 uv2 = uv2_interp;
-#endif
+#endif // UV2_USED || USE_LIGHTMAP
 
 #if defined(COLOR_USED)
 	vec4 color = color_interp;
-#endif
+#endif // COLOR_USED
 
 #if defined(NORMAL_MAP_USED)
-
 	vec3 normal_map = vec3(0.5);
-#endif
+#endif // NORMAL_MAP_USED
 
 	float normal_map_depth = 1.0;
 
@@ -944,11 +944,11 @@ void main() {
 	inv_view_matrix[0][3] = 0.0;
 	inv_view_matrix[1][3] = 0.0;
 	inv_view_matrix[2][3] = 0.0;
-#endif
+#endif // USE_DOUBLE_PRECISION
 
 #ifdef LIGHT_VERTEX_USED
 	vec3 light_vertex = vertex;
-#endif //LIGHT_VERTEX_USED
+#endif // LIGHT_VERTEX_USED
 
 	mat3 model_normal_matrix;
 	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
@@ -960,6 +960,7 @@ void main() {
 	mat4 read_view_matrix = scene_data.view_matrix;
 	vec2 read_viewport_size = scene_data.viewport_size;
 
+	// GDShader FRAGMENT function gets inserted here.
 	{
 #CODE : FRAGMENT
 	}
@@ -968,18 +969,18 @@ void main() {
 	vertex = light_vertex;
 #ifdef USE_MULTIVIEW
 	view = -normalize(vertex - eye_offset);
-#else
+#else // USE_MULTIVIEW
 	view = -normalize(vertex);
-#endif //USE_MULTIVIEW
-#endif //LIGHT_VERTEX_USED
+#endif // USE_MULTIVIEW
+#endif // LIGHT_VERTEX_USED
 
 #ifdef LIGHT_TRANSMITTANCE_USED
 #ifdef SSS_MODE_SKIN
 	transmittance_color.a = sss_strength;
-#else
+#else // SSS_MODE_SKIN
 	transmittance_color.a *= sss_strength;
-#endif
-#endif
+#endif // SSS_MODE_SKIN
+#endif // LIGHT_TRANSMITTANCE_USED
 
 #ifndef USE_SHADOW_TO_OPACITY
 
@@ -989,7 +990,7 @@ void main() {
 	}
 #endif // ALPHA_SCISSOR_USED
 
-// alpha hash can be used in unison with alpha antialiasing
+// Alpha hash can be used in unison with alpha antialiasing.
 #ifdef ALPHA_HASH_USED
 	vec3 object_pos = (inverse(read_model_matrix) * inv_view_matrix * vec4(vertex, 1.0)).xyz;
 	if (alpha < compute_alpha_hash_threshold(object_pos, alpha_hash_scale)) {
@@ -997,16 +998,16 @@ void main() {
 	}
 #endif // ALPHA_HASH_USED
 
-// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash
+// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash.
 #if (defined(ALPHA_SCISSOR_USED) || defined(ALPHA_HASH_USED)) && !defined(ALPHA_ANTIALIASING_EDGE_USED)
 	alpha = 1.0;
-#endif
+#endif // (ALPHA_SCISSOR_USED || ALPHA_HASH_USED) && !ALPHA_ANTIALIASING_EDGE_USED
 
 #ifdef ALPHA_ANTIALIASING_EDGE_USED
-// If alpha scissor is used, we must further the edge threshold, otherwise we won't get any edge feather
+// If alpha scissor is used, we must further the edge threshold, otherwise we won't get any edge feather.
 #ifdef ALPHA_SCISSOR_USED
 	alpha_antialiasing_edge = clamp(alpha_scissor_threshold + alpha_antialiasing_edge, 0.0, 1.0);
-#endif
+#endif // ALPHA_SCISSOR_USED
 	alpha = compute_alpha_antialiasing_edge(alpha, alpha_texture_coordinate, alpha_antialiasing_edge);
 #endif // ALPHA_ANTIALIASING_EDGE_USED
 
@@ -1021,53 +1022,46 @@ void main() {
 #endif // !USE_SHADOW_TO_OPACITY
 
 #ifdef NORMAL_MAP_USED
-
 	normal_map.xy = normal_map.xy * 2.0 - 1.0;
-	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); //always ignore Z, as it can be RG packed, Z may be pos/neg, etc.
+	normal_map.z = sqrt(max(0.0, 1.0 - dot(normal_map.xy, normal_map.xy))); // Always reconstruct Z, as it can be RG packed, Z may be pos/neg, etc.
 
 	normal = normalize(mix(normal, tangent * normal_map.x + binormal * normal_map.y + normal * normal_map.z, normal_map_depth));
-
-#endif
+#endif // NORMAL_MAP_USED
 
 #ifdef LIGHT_ANISOTROPY_USED
-
 	if (anisotropy > 0.01) {
-		//rotation matrix
 		mat3 rot = mat3(tangent, binormal, normal);
-		//make local to space
+		// Make local to space.
 		tangent = normalize(rot * vec3(anisotropy_flow.x, anisotropy_flow.y, 0.0));
 		binormal = normalize(rot * vec3(-anisotropy_flow.y, anisotropy_flow.x, 0.0));
 	}
-
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 
 #ifdef ENABLE_CLIP_ALPHA
 	if (albedo.a < 0.99) {
-		//used for doublepass and shadowmapping
+		// Used for doublepass and shadowmapping.
 		discard;
 	}
-#endif
+#endif // ENABLE_CLIP_ALPHA
 
 	/////////////////////// FOG //////////////////////
 #ifndef MODE_RENDER_DEPTH
 
 #ifndef FOG_DISABLED
 #ifndef CUSTOM_FOG_USED
-	// fog must be processed as early as possible and then packed.
-	// to maximize VGPR usage
+	// Fog must be processed as early as possible and then packed to maximize VGPR usage.
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
-
 	if (!sc_disable_fog() && scene_data.fog_enabled) {
 		fog = fog_process(vertex);
 	}
 
-#endif //!CUSTOM_FOG_USED
+#endif // !CUSTOM_FOG_USED
 
 	uint fog_rg = packHalf2x16(fog.rg);
 	uint fog_ba = packHalf2x16(fog.ba);
 
-#endif //!FOG_DISABLED
-#endif //!MODE_RENDER_DEPTH
+#endif // !FOG_DISABLED
+#endif // !MODE_RENDER_DEPTH
 
 	/////////////////////// DECALS ////////////////////////////////
 
@@ -1080,12 +1074,12 @@ void main() {
 	for (uint i = 0; i < sc_decals(); i++) {
 		uint decal_index = (i > 3) ? ((decal_indices.y >> ((i - 4) * 8)) & 0xFF) : ((decal_indices.x >> (i * 8)) & 0xFF);
 		if (!bool(decals.data[decal_index].mask & instances.data[draw_call.instance_index].layer_mask)) {
-			continue; //not masked
+			continue; // Not masked, skip.
 		}
 
 		vec3 uv_local = (decals.data[decal_index].xform * vec4(vertex, 1.0)).xyz;
 		if (any(lessThan(uv_local, vec3(0.0, -1.0, 0.0))) || any(greaterThan(uv_local, vec3(1.0)))) {
-			continue; //out of decal
+			continue; // Out of decal.
 		}
 
 		float fade = pow(1.0 - (uv_local.y > 0.0 ? uv_local.y : -uv_local.y), uv_local.y > 0.0 ? decals.data[decal_index].upper_fade : decals.data[decal_index].lower_fade);
@@ -1094,12 +1088,12 @@ void main() {
 			fade *= smoothstep(decals.data[decal_index].normal_fade, 1.0, dot(normal_interp, decals.data[decal_index].normal) * 0.5 + 0.5);
 		}
 
-		//we need ddx/ddy for mipmaps, so simulate them
+		// We need ddx/ddy for mipmaps, so simulate them.
 		vec2 ddx = (decals.data[decal_index].xform * vec4(vertex_ddx, 0.0)).xz;
 		vec2 ddy = (decals.data[decal_index].xform * vec4(vertex_ddy, 0.0)).xz;
 
 		if (decals.data[decal_index].albedo_rect != vec4(0.0)) {
-			//has albedo
+			// Has albedo.
 			vec4 decal_albedo;
 			if (sc_decal_use_mipmaps()) {
 				decal_albedo = textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].albedo_rect.zw + decals.data[decal_index].albedo_rect.xy, ddx * decals.data[decal_index].albedo_rect.zw, ddy * decals.data[decal_index].albedo_rect.zw);
@@ -1117,9 +1111,9 @@ void main() {
 				} else {
 					decal_normal = textureLod(sampler2D(decal_atlas, decal_sampler), uv_local.xz * decals.data[decal_index].normal_rect.zw + decals.data[decal_index].normal_rect.xy, 0.0).xyz;
 				}
-				decal_normal.xy = decal_normal.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0); //users prefer flipped y normal maps in most authoring software
+				decal_normal.xy = decal_normal.xy * vec2(2.0, -2.0) - vec2(1.0, -1.0); // Users prefer flipped Y normal maps in most authoring software.
 				decal_normal.z = sqrt(max(0.0, 1.0 - dot(decal_normal.xy, decal_normal.xy)));
-				//convert to view space, use xzy because y is up
+				// Convert to view space, use XZY because Y is up.
 				decal_normal = (decals.data[decal_index].normal_xform * decal_normal.xzy).xyz;
 
 				normal = normalize(mix(normal, decal_normal, decal_albedo.a));
@@ -1139,7 +1133,7 @@ void main() {
 		}
 
 		if (decals.data[decal_index].emission_rect != vec4(0.0)) {
-			//emission is additive, so its independent from albedo
+			// Emission is additive, so it's independent from albedo.
 			if (sc_decal_use_mipmaps()) {
 				emission += textureGrad(sampler2D(decal_atlas_srgb, decal_sampler), uv_local.xz * decals.data[decal_index].emission_rect.zw + decals.data[decal_index].emission_rect.xy, ddx * decals.data[decal_index].emission_rect.zw, ddy * decals.data[decal_index].emission_rect.zw).xyz * decals.data[decal_index].emission_energy * fade;
 			} else {
@@ -1147,36 +1141,35 @@ void main() {
 			}
 		}
 	}
-#endif //!MODE_RENDER_DEPTH
+#endif // !MODE_RENDER_DEPTH
 
 	/////////////////////// LIGHTING //////////////////////////////
 
 #ifdef NORMAL_USED
 	if (sc_scene_roughness_limiter_enabled()) {
-		//https://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
+		// https://www.jp.square-enix.com/tech/library/pdf/ImprovedGeometricSpecularAA.pdf
 		float roughness2 = roughness * roughness;
 		vec3 dndu = dFdx(normal), dndv = dFdy(normal);
 		float variance = scene_data.roughness_limiter_amount * (dot(dndu, dndu) + dot(dndv, dndv));
-		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit); //limit effect
+		float kernelRoughness2 = min(2.0 * variance, scene_data.roughness_limiter_limit);
 		float filteredRoughness2 = min(1.0, roughness2 + kernelRoughness2);
 		roughness = sqrt(filteredRoughness2);
 	}
 #endif // NORMAL_USED
-	//apply energy conservation
 
-	vec3 specular_light = vec3(0.0, 0.0, 0.0);
-	vec3 diffuse_light = vec3(0.0, 0.0, 0.0);
-	vec3 ambient_light = vec3(0.0, 0.0, 0.0);
-
+	vec3 specular_light = vec3(0.0);
+	vec3 diffuse_light = vec3(0.0);
+	vec3 ambient_light = vec3(0.0);
 #ifndef MODE_UNSHADED
 	// Used in regular draw pass and when drawing SDFs for SDFGI and materials for VoxelGI.
 	emission *= scene_data.emissive_exposure_normalization;
-#endif
+#endif // !MODE_UNSHADED
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
 #ifndef AMBIENT_LIGHT_DISABLED
 
+	// Global Radiance //
 	if (sc_scene_use_reflection_cubemap()) {
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1186,23 +1179,23 @@ void main() {
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
 		vec3 ref_vec = reflect(-view, bent_normal);
 		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
-#else
+#else // LIGHT_ANISOTROPY_USED
 		vec3 ref_vec = reflect(-view, normal);
 		ref_vec = mix(ref_vec, normal, roughness * roughness);
-#endif
+#endif // LIGHT_ANISOTROPY_USED
+
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
-#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
+#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(sqrt(roughness) * MAX_ROUGHNESS_LOD, lod);
 		specular_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
 		specular_light = mix(specular_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
-
 #else // USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb;
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light *= sc_luminance_multiplier();
 		specular_light *= scene_data.IBL_exposure_normalization;
 		specular_light *= horizon * horizon;
@@ -1214,7 +1207,7 @@ void main() {
 #endif // CUSTOM_RADIANCE_USED
 
 #ifndef USE_LIGHTMAP
-	//lightmap overrides everything
+	// Lightmap overrides everything.
 	if (scene_data.use_ambient_light) {
 		ambient_light = scene_data.ambient_light_color_energy.rgb;
 
@@ -1222,9 +1215,9 @@ void main() {
 			vec3 ambient_dir = scene_data.radiance_inverse_xform * normal;
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
 			vec3 cubemap_ambient = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ambient_dir, MAX_ROUGHNESS_LOD)).rgb;
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 			vec3 cubemap_ambient = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ambient_dir, MAX_ROUGHNESS_LOD).rgb;
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 			cubemap_ambient *= sc_luminance_multiplier();
 			cubemap_ambient *= scene_data.IBL_exposure_normalization;
 			ambient_light = mix(ambient_light, cubemap_ambient * scene_data.ambient_light_color_energy.a, scene_data.ambient_color_sky_mix);
@@ -1235,14 +1228,16 @@ void main() {
 #if defined(CUSTOM_IRRADIANCE_USED)
 	ambient_light = mix(ambient_light, custom_irradiance.rgb, custom_irradiance.a);
 #endif // CUSTOM_IRRADIANCE_USED
+
 #ifdef LIGHT_CLEARCOAT_USED
 
+	// Note: We want to use geometric normal for clearcoat reflections/BRDF, ie. we ignore the normal map.
 	if (sc_scene_use_reflection_cubemap()) {
-		vec3 n = normalize(normal_interp); // We want to use geometric normal, not normal_map
+		vec3 n = normalize(normal_interp);
 		float NoV = max(dot(n, view), 0.0001);
 		vec3 ref_vec = reflect(-view, n);
 		ref_vec = mix(ref_vec, n, clearcoat_roughness * clearcoat_roughness);
-		// The clear coat layer assumes an IOR of 1.5 (4% reflectance)
+		// The clear coat layer assumes an IOR of 1.5 (4% reflectance).
 		float Fc = clearcoat * (0.04 + 0.96 * SchlickFresnel(NoV));
 		float attenuation = 1.0 - Fc;
 		ambient_light *= attenuation;
@@ -1251,31 +1246,28 @@ void main() {
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
 		float roughness_lod = mix(0.001, 0.1, sqrt(clearcoat_roughness)) * MAX_ROUGHNESS_LOD;
-#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 
+#ifdef USE_RADIANCE_CUBEMAP_ARRAY
 		float lod, blend;
 		blend = modf(roughness_lod, lod);
 		vec3 clearcoat_light = texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb;
 		clearcoat_light = mix(clearcoat_light, texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb, blend);
-
-#else
+#else // USE_RADIANCE_CUBEMAP_ARRAY
 		vec3 clearcoat_light = textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ref_vec, roughness_lod).rgb;
-
-#endif //USE_RADIANCE_CUBEMAP_ARRAY
+#endif // USE_RADIANCE_CUBEMAP_ARRAY
 		specular_light += clearcoat_light * horizon * horizon * Fc * scene_data.ambient_light_color_energy.a;
 	}
 #endif // LIGHT_CLEARCOAT_USED
 #endif // !AMBIENT_LIGHT_DISABLED
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
-	//radiance
-
+	/// GI ///
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 #ifndef AMBIENT_LIGHT_DISABLED
 #ifdef USE_LIGHTMAP
 
-	//lightmap
-	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { //has lightmap capture
+	// Lightmapping //
+	if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP_CAPTURE)) { // Process lightmap capture (L2 SH).
 		uint index = instances.data[draw_call.instance_index].gi_offset;
 
 		vec3 wnormal = mat3(scene_data.inv_view_matrix) * normal;
@@ -1296,7 +1288,7 @@ void main() {
 								 2.0 * c2 * lightmap_captures.data[index].sh[2].rgb * wnormal.z) *
 				scene_data.emissive_exposure_normalization;
 
-	} else if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // has actual lightmap
+	} else if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // Process lightmap texture.
 		bool uses_sh = bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_SH_LIGHTMAP);
 		uint ofs = instances.data[draw_call.instance_index].gi_offset & 0xFFFF;
 		uint slice = instances.data[draw_call.instance_index].gi_offset >> 16;
@@ -1305,12 +1297,12 @@ void main() {
 		uvw.z = float(slice);
 
 		if (uses_sh) {
-			uvw.z *= 4.0; //SH textures use 4 times more data
+			uvw.z *= 4.0; // SH textures use 4 times more data.
+
 			vec3 lm_light_l0;
 			vec3 lm_light_l1n1;
 			vec3 lm_light_l1_0;
 			vec3 lm_light_l1p1;
-
 			if (sc_use_lightmap_bicubic_filter()) {
 				lm_light_l0 = textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 0.0), lightmaps.data[ofs].light_texture_size).rgb;
 				lm_light_l1n1 = (textureArray_bicubic(lightmap_textures[ofs], uvw + vec3(0.0, 0.0, 1.0), lightmaps.data[ofs].light_texture_size).rgb - vec3(0.5)) * 2.0;
@@ -1330,6 +1322,7 @@ void main() {
 			ambient_light += lm_light_l1n1 * n.y * (lm_light_l0 * exposure_normalization * 4.0);
 			ambient_light += lm_light_l1_0 * n.z * (lm_light_l0 * exposure_normalization * 4.0);
 			ambient_light += lm_light_l1p1 * n.x * (lm_light_l0 * exposure_normalization * 4.0);
+
 		} else {
 			if (sc_use_lightmap_bicubic_filter()) {
 				ambient_light += textureArray_bicubic(lightmap_textures[ofs], uvw, lightmaps.data[ofs].light_texture_size).rgb * lightmaps.data[ofs].exposure_normalization;
@@ -1339,15 +1332,16 @@ void main() {
 		}
 	}
 
-	// No GI nor non low end mode...
+	// No SDFGI nor VoxelGI on Mobile.
 
 #endif // USE_LIGHTMAP
 
-	// skipping ssao, do we remove ssao totally?
+	// Skipping SSAO, do we remove SSAO totally?
 
+	// Reflection Probes //
 	if (sc_reflection_probes() > 0) {
-		vec4 reflection_accum = vec4(0.0, 0.0, 0.0, 0.0);
-		vec4 ambient_accum = vec4(0.0, 0.0, 0.0, 0.0);
+		vec4 reflection_accum = vec4(0.0);
+		vec4 ambient_accum = vec4(0.0);
 
 #ifdef LIGHT_ANISOTROPY_USED
 		// https://google.github.io/filament/Filament.html#lighting/imagebasedlights/anisotropy
@@ -1355,9 +1349,9 @@ void main() {
 		vec3 anisotropic_tangent = cross(anisotropic_direction, view);
 		vec3 anisotropic_normal = cross(anisotropic_tangent, anisotropic_direction);
 		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
-#else
+#else // LIGHT_ANISOTROPY_USED
 		vec3 bent_normal = normal;
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 		vec3 ref_vec = normalize(reflect(-view, bent_normal));
 		ref_vec = mix(ref_vec, bent_normal, roughness * roughness);
 
@@ -1375,33 +1369,31 @@ void main() {
 		if (ambient_accum.a > 0.0) {
 			ambient_light = ambient_accum.rgb / ambient_accum.a;
 		}
-#endif
-	} //Reflection probes
+#endif // !USE_LIGHTMAP
+	}
 
-	// finalize ambient light here
-
+	// Finalize ambient light.
 	ambient_light *= albedo.rgb;
 	ambient_light *= ao;
 
 #endif // !AMBIENT_LIGHT_DISABLED
 
-	// convert ao to direct light ao
+	// Convert AO to direct light AO.
 	ao = mix(1.0, ao, ao_light_affect);
 
-	//this saves some VGPRs
+	// This saves some VGPRs.
 	vec3 f0 = F0(metallic, specular, albedo);
 
 #ifndef AMBIENT_LIGHT_DISABLED
 	{
 #if defined(DIFFUSE_TOON)
-		//simplify for toon, as
+		// Simplified toon BRDF.
 		specular_light *= specular * metallic * albedo * 2.0;
-#else
+#else // DIFFUSE_TOON
 
-		// scales the specular reflections, needs to be computed before lighting happens,
-		// but after environment, GI, and reflection probes are added
-		// Environment brdf approximation (Lazarov 2013)
-		// see https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
+		// Environment BRDF Approximation (Lazarov 2013)
+		// Scales only indirect reflections, hence is computed before direct lighting happens.
+		// See: https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
 		const vec4 c0 = vec4(-1.0, -0.0275, -0.572, 0.022);
 		const vec4 c1 = vec4(1.0, 0.0425, 1.04, -0.04);
 		vec4 r = roughness * c0 + c1;
@@ -1410,36 +1402,38 @@ void main() {
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 
 		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
-#endif
+#endif // DIFFUSE_TOON
 	}
-
 #endif // !AMBIENT_LIGHT_DISABLED
-#endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
+	// End of GI //
 
 #if !defined(MODE_RENDER_DEPTH)
-	//this saves some VGPRs
+	// This saves some VGPRs.
 	uint orms = packUnorm4x8(vec4(ao, roughness, metallic, specular));
-#endif
+#endif // !MODE_RENDER_DEPTH
 
-// LIGHTING
+	// LIGHTING //
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+
 #ifdef USE_VERTEX_LIGHTING
 	diffuse_light += diffuse_light_interp.rgb;
 	specular_light += specular_light_interp.rgb * f0;
-#endif
+#endif // USE_VERTEX_LIGHTING
 
+	// Directional Lights //
 	if (sc_directional_lights() > 0) {
 #ifndef SHADOWS_DISABLED
-		// Do shadow and lighting in two passes to reduce register pressure
+		// Do shadows and lighting in two passes to reduce register pressure.
 		uint shadow0 = 0;
 		uint shadow1 = 0;
 
 		float shadowmask = 1.0;
-
 #ifdef USE_LIGHTMAP
 		uint shadowmask_mode = LIGHTMAP_SHADOWMASK_MODE_NONE;
 
-		if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
+		if (bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) { // Get shadowmask texture.
 			const uint ofs = instances.data[draw_call.instance_index].gi_offset & 0xFFFF;
 			shadowmask_mode = lightmaps.data[ofs].flags;
 
@@ -1460,13 +1454,18 @@ void main() {
 #endif // USE_LIGHTMAP
 
 #ifdef USE_VERTEX_LIGHTING
+			// Clang tries to dedent the second part of this ifdef.
+			/* clang-format off */
+
 			// Only process the first light's shadow for vertex lighting.
 			for (uint i = 0; i < 1; i++) {
-#else
-		for (uint i = 0; i < sc_directional_lights(); i++) {
-#endif
+#else // USE_VERTEX_LIGHTING
+			for (uint i = 0; i < sc_directional_lights(); i++) {
+			/* clang-format on */
+#endif // USE_VERTEX_LIGHTING
+
 				if (!bool(directional_lights.data[i].mask & instances.data[draw_call.instance_index].layer_mask)) {
-					continue; //not masked
+					continue; // Not masked, skip.
 				}
 
 				if (directional_lights.data[i].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
@@ -1474,8 +1473,7 @@ void main() {
 				}
 
 				float shadow = 1.0;
-
-				if (directional_lights.data[i].shadow_opacity > 0.001) {
+				if (directional_lights.data[i].shadow_opacity > 0.001) { // Compute Shadows //
 					float depth_z = -vertex.z;
 
 					vec4 pssm_coord;
@@ -1489,14 +1487,14 @@ void main() {
 	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
 	m_var.xyz += normal_bias;
 
-					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First cascade.
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 0)
 
 						pssm_coord = (directional_lights.data[i].shadow_matrix1 * v);
 						blur_factor = 1.0;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second cascade.
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 1)
@@ -1504,7 +1502,7 @@ void main() {
 						pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+					} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third cascade.
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 2)
@@ -1512,7 +1510,7 @@ void main() {
 						pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 						// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 						blur_factor = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-					} else {
+					} else { // Fourth cascade.
 						vec4 v = vec4(vertex, 1.0);
 
 						BIAS_FUNC(v, 3)
@@ -1532,21 +1530,21 @@ void main() {
 						float pssm_blend;
 						float blur_factor2;
 
-						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {
+						if (depth_z < directional_lights.data[i].shadow_split_offsets.x) { // First-to-second blend.
 							vec4 v = vec4(vertex, 1.0);
 							BIAS_FUNC(v, 1)
 							pssm_coord = (directional_lights.data[i].shadow_matrix2 * v);
 							pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.x - directional_lights.data[i].shadow_split_offsets.x * 0.1, directional_lights.data[i].shadow_split_offsets.x, depth_z);
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.y;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) {
+						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.y) { // Second-to-third blend.
 							vec4 v = vec4(vertex, 1.0);
 							BIAS_FUNC(v, 2)
 							pssm_coord = (directional_lights.data[i].shadow_matrix3 * v);
 							pssm_blend = smoothstep(directional_lights.data[i].shadow_split_offsets.y - directional_lights.data[i].shadow_split_offsets.y * 0.1, directional_lights.data[i].shadow_split_offsets.y, depth_z);
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.z;
-						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) {
+						} else if (depth_z < directional_lights.data[i].shadow_split_offsets.z) { // Third-to-fourth blend.
 							vec4 v = vec4(vertex, 1.0);
 							BIAS_FUNC(v, 3)
 							pssm_coord = (directional_lights.data[i].shadow_matrix4 * v);
@@ -1554,7 +1552,7 @@ void main() {
 							// Adjust shadow blur with reference to the first split to reduce discrepancy between shadow splits.
 							blur_factor2 = directional_lights.data[i].shadow_split_offsets.x / directional_lights.data[i].shadow_split_offsets.w;
 						} else {
-							pssm_blend = 0.0; //if no blend, same coord will be used (divide by z will result in same value, and already cached)
+							pssm_blend = 0.0; // If no blend, same coord will be used (divide by z will result in same value, and already cached).
 							blur_factor2 = 1.0;
 						}
 
@@ -1566,22 +1564,23 @@ void main() {
 
 #ifdef USE_LIGHTMAP
 					if (shadowmask_mode == LIGHTMAP_SHADOWMASK_MODE_REPLACE) {
-						shadow = mix(shadow, shadowmask, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+						shadow = mix(shadow, shadowmask, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 					} else if (shadowmask_mode == LIGHTMAP_SHADOWMASK_MODE_OVERLAY) {
-						shadow = shadowmask * mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+						shadow = shadowmask * mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 					} else {
-#endif
-						shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); //done with negative values for performance
+#endif // USE_LIGHTMAP
+						shadow = mix(shadow, 1.0, smoothstep(directional_lights.data[i].fade_from, directional_lights.data[i].fade_to, vertex.z)); // Done with negative values for performance.
 #ifdef USE_LIGHTMAP
 					}
-#endif
+#endif // USE_LIGHTMAP
 
 #ifdef USE_VERTEX_LIGHTING
 					diffuse_light *= mix(1.0, shadow, diffuse_light_interp.a);
 					specular_light *= mix(1.0, shadow, specular_light_interp.a);
-#endif
+#endif // USE_VERTEX_LIGHTING
+
 #undef BIAS_FUNC
-				}
+				} // End of shadows.
 
 				if (i < 4) {
 					shadow0 |= uint(clamp(shadow * 255.0, 0.0, 255.0)) << (i * 8);
@@ -1596,36 +1595,38 @@ void main() {
 #ifdef USE_VERTEX_LIGHTING
 			diffuse_light *= mix(1.0, shadowmask, diffuse_light_interp.a);
 			specular_light *= mix(1.0, shadowmask, specular_light_interp.a);
-#endif
+#endif // USE_VERTEX_LIGHTING
 
 			shadow0 |= uint(clamp(shadowmask * 255.0, 0.0, 255.0));
 		}
 #endif // USE_LIGHTMAP
 
-#endif // SHADOWS_DISABLED
+#endif // !SHADOWS_DISABLED
 
 #ifndef USE_VERTEX_LIGHTING
+
 		for (uint i = 0; i < sc_directional_lights(); i++) {
 			if (!bool(directional_lights.data[i].mask & instances.data[draw_call.instance_index].layer_mask)) {
-				continue; //not masked
+				continue; // Not masked, skip.
 			}
 
 			if (directional_lights.data[i].bake_mode == LIGHT_BAKE_STATIC && bool(instances.data[draw_call.instance_index].flags & INSTANCE_FLAGS_USE_LIGHTMAP)) {
 				continue; // Statically baked light and object uses lightmap, skip.
 			}
 
-			// We're not doing light transmittence
+			// We're not doing light transmittance on Mobile.
 
 			float shadow = 1.0;
 #ifndef SHADOWS_DISABLED
 			if (i < 4) {
-				shadow = float(shadow0 >> (i * 8) & 0xFF) / 255.0;
+				shadow = float(shadow0 >> (i * 8u) & 0xFFu) / 255.0;
 			} else {
-				shadow = float(shadow1 >> ((i - 4) * 8) & 0xFF) / 255.0;
+				shadow = float(shadow1 >> ((i - 4u) * 8u) & 0xFFu) / 255.0;
 			}
 
 			shadow = mix(1.0, shadow, directional_lights.data[i].shadow_opacity);
-#endif
+#endif // !SHADOWS_DISABLED
+
 			blur_shadow(shadow);
 
 			vec3 tint = vec3(1.0);
@@ -1641,7 +1642,7 @@ void main() {
 			}
 			tint = mix(tint, vec3(1.0), shadow);
 			shadow = 1.0;
-#endif
+#endif // DEBUG_DRAW_PSSM_SPLITS
 
 			float size_A = sc_use_light_soft_shadows() ? directional_lights.data[i].size : 0.0;
 
@@ -1650,39 +1651,40 @@ void main() {
 					true, shadow, f0, orms, 1.0, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 					backlight,
-#endif
-/* not supported here
+#endif // LIGHT_BACKLIGHT_USED
+/* Not supported here.
 #ifdef LIGHT_TRANSMITTANCE_USED
 					transmittance_color,
 					transmittance_depth,
 					transmittance_boost,
 					transmittance_z,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 */
 #ifdef LIGHT_RIM_USED
 					rim, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 					clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 					binormal, tangent, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 					diffuse_light,
 					specular_light);
 		}
-#endif // USE_VERTEX_LIGHTING
-	} //directional light
+#endif // !USE_VERTEX_LIGHTING
+	} // End of directional lights.
 
 #ifndef USE_VERTEX_LIGHTING
+	// Omni Lights //
 	uvec2 omni_indices = instances.data[draw_call.instance_index].omni_lights;
 	for (uint i = 0; i < sc_omni_lights(); i++) {
 		uint light_index = (i > 3) ? ((omni_indices.y >> ((i - 4) * 8)) & 0xFF) : ((omni_indices.x >> (i * 8)) & 0xFF);
 		light_process_omni(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, scene_data.taa_frame_count, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 				backlight,
-#endif
-/*
+#endif // LIGHT_BACKLIGHT_USED
+/* Not supported here.
 #ifdef LIGHT_TRANSMITTANCE_USED
 				transmittance_color,
 				transmittance_depth,
@@ -1692,25 +1694,25 @@ void main() {
 #ifdef LIGHT_RIM_USED
 				rim,
 				rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 				clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-				tangent,
-				binormal, anisotropy,
-#endif
+				tangent, binormal, anisotropy,
+#endif // LIGHT_ANISOTROPY_USED
 				diffuse_light, specular_light);
-	}
+	} // End of omni lights.
 
+	// Spot Lights //
 	uvec2 spot_indices = instances.data[draw_call.instance_index].spot_lights;
 	for (uint i = 0; i < sc_spot_lights(); i++) {
 		uint light_index = (i > 3) ? ((spot_indices.y >> ((i - 4) * 8)) & 0xFF) : ((spot_indices.x >> (i * 8)) & 0xFF);
 		light_process_spot(light_index, vertex, view, normal, vertex_ddx, vertex_ddy, f0, orms, scene_data.taa_frame_count, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 				backlight,
-#endif
-/*
+#endif // LIGHT_BACKLIGHT_USED
+/* Not supported here.
 #ifdef LIGHT_TRANSMITTANCE_USED
 				transmittance_color,
 				transmittance_depth,
@@ -1720,19 +1722,17 @@ void main() {
 #ifdef LIGHT_RIM_USED
 				rim,
 				rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 				clearcoat, clearcoat_roughness, normalize(normal_interp),
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-				tangent,
-				binormal, anisotropy,
-#endif
+				tangent, binormal, anisotropy,
+#endif // LIGHT_ANISOTROPY_USED
 				diffuse_light, specular_light);
-	}
-#endif // !VERTEX_LIGHTING
-
-#endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
+	} // End of spot lights.
+#endif // !USE_VERTEX_LIGHTING
+#endif // !MODE_RENDER_DEPTH && !MODE_UNSHADED
 
 #ifdef USE_SHADOW_TO_OPACITY
 #ifndef MODE_RENDER_DEPTH
@@ -1742,7 +1742,7 @@ void main() {
 	if (alpha < alpha_scissor_threshold) {
 		discard;
 	}
-#endif // !ALPHA_SCISSOR_USED
+#endif // ALPHA_SCISSOR_USED
 
 #endif // !MODE_RENDER_DEPTH
 #endif // USE_SHADOW_TO_OPACITY
@@ -1750,7 +1750,6 @@ void main() {
 #ifdef MODE_RENDER_DEPTH
 
 #ifdef MODE_RENDER_MATERIAL
-
 	albedo_output_buffer.rgb = albedo;
 	albedo_output_buffer.a = alpha;
 
@@ -1769,21 +1768,21 @@ void main() {
 
 #else // MODE_RENDER_DEPTH
 
-	// multiply by albedo
-	diffuse_light *= albedo; // ambient must be multiplied by albedo at the end
+	// Multiply by albedo.
+	diffuse_light *= albedo; // Ambient must be multiplied by albedo at the end.
 
-	// apply direct light AO
+	// Apply direct light AO.
 	ao = unpackUnorm4x8(orms).x;
 	specular_light *= ao;
 	diffuse_light *= ao;
 
-	// apply metallic
+	// Apply metallic.
 	metallic = unpackUnorm4x8(orms).z;
 	diffuse_light *= 1.0 - metallic;
 	ambient_light *= 1.0 - metallic;
 
 #ifndef FOG_DISABLED
-	//restore fog
+	// Restore fog.
 	fog = vec4(unpackHalf2x16(fog_rg), unpackHalf2x16(fog_ba));
 #endif // !FOG_DISABLED
 
@@ -1792,9 +1791,7 @@ void main() {
 #ifdef MODE_UNSHADED
 	diffuse_buffer = vec4(albedo.rgb, 0.0);
 	specular_buffer = vec4(0.0);
-
 #else // MODE_UNSHADED
-
 #ifdef SSS_MODE_SKIN
 	sss_strength = -sss_strength;
 #endif // SSS_MODE_SKIN
@@ -1807,7 +1804,7 @@ void main() {
 	specular_buffer.rgb = mix(specular_buffer.rgb, vec3(0.0), fog.a);
 #endif // !FOG_DISABLED
 
-#else //MODE_MULTIPLE_RENDER_TARGETS
+#else // MODE_MULTIPLE_RENDER_TARGETS
 
 #ifdef MODE_UNSHADED
 	frag_color = vec4(albedo, alpha);
@@ -1820,14 +1817,15 @@ void main() {
 	frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a);
 #endif // !FOG_DISABLED
 
-	// On mobile we use a UNORM buffer with 10bpp which results in a range from 0.0 - 1.0 resulting in HDR breaking
-	// We divide by sc_luminance_multiplier to support a range from 0.0 - 2.0 both increasing precision on bright and darker images
+	// On mobile we use a UNORM buffer with 10bpp which results in a range from 0.0 - 1.0 resulting in HDR breaking.
+	// We divide by sc_luminance_multiplier to support a range from 0.0 - 2.0 both increasing precision on bright and darker images.
 	frag_color.rgb = frag_color.rgb / sc_luminance_multiplier();
+
 #ifdef PREMUL_ALPHA_USED
 	frag_color.rgb *= premul_alpha;
-#endif
+#endif // PREMUL_ALPHA_USED
 
-#endif //MODE_MULTIPLE_RENDER_TARGETS
+#endif // MODE_MULTIPLE_RENDER_TARGETS
 
-#endif //MODE_RENDER_DEPTH
+#endif // MODE_RENDER_DEPTH
 }

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -34,9 +34,30 @@ float SchlickFresnel(float u) {
 
 vec3 F0(float metallic, float specular, vec3 albedo) {
 	float dielectric = 0.16 * specular * specular;
-	// use albedo * metallic as colored specular reflectance at 0 angle for metallic materials;
+	// Use albedo * metallic as colored specular reflectance at 0 angle for metallic materials.
 	// see https://google.github.io/filament/Filament.md.html
 	return mix(vec3(dielectric), albedo, vec3(metallic));
+}
+
+float get_omni_attenuation(float distance, float inv_range, float decay) {
+	float nd = distance * inv_range;
+	nd *= nd;
+	nd *= nd; // nd^4
+	nd = max(1.0 - nd, 0.0);
+	nd *= nd; // nd^2
+	return nd * pow(max(distance, 0.0001), -decay);
+}
+
+vec2 normal_to_panorama(vec3 n) {
+	n = normalize(n);
+	vec2 panorama_coords = vec2(atan(n.x, n.z), acos(-n.y));
+
+	if (panorama_coords.x < 0.0) {
+		panorama_coords.x += M_PI * 2.0;
+	}
+
+	panorama_coords /= vec2(M_PI * 2.0, M_PI);
+	return panorama_coords;
 }
 
 void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_directional, float attenuation, vec3 f0, uint orms, float specular_amount, vec3 albedo, inout float alpha, vec2 screen_uv,
@@ -70,9 +91,9 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 
 #ifdef USING_MOBILE_RENDERER
 	mat4 read_model_matrix = instances.data[draw_call.instance_index].transform;
-#else
+#else // USING_MOBILE_RENDERER
 	mat4 read_model_matrix = instances.data[instance_index_interp].transform;
-#endif
+#endif // USING_MOBILE_RENDERER
 
 #undef projection_matrix
 #define projection_matrix scene_data_block.data.projection_matrix
@@ -84,118 +105,108 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 	vec3 light = L;
 	vec3 view = V;
 
+	// GDShader LIGHT function gets inserted here.
+	{
 #CODE : LIGHT
-#else // !LIGHT_CODE_USED
+	}
+
+#else // LIGHT_CODE_USED
 	float NdotL = min(A + dot(N, L), 1.0);
 	float cNdotV = max(dot(N, V), 1e-4);
 
 #ifdef LIGHT_TRANSMITTANCE_USED
 	{
-#ifdef SSS_MODE_SKIN
 		float scale = 8.25 / transmittance_depth;
 		float d = scale * abs(transmittance_z);
 		float dd = -d * d;
-		vec3 profile = vec3(0.233, 0.455, 0.649) * exp(dd / 0.0064) +
+#ifdef SSS_MODE_SKIN
+		vec3 profile =
+				vec3(0.233, 0.455, 0.649) * exp(dd / 0.0064) +
 				vec3(0.1, 0.336, 0.344) * exp(dd / 0.0484) +
 				vec3(0.118, 0.198, 0.0) * exp(dd / 0.187) +
 				vec3(0.113, 0.007, 0.007) * exp(dd / 0.567) +
 				vec3(0.358, 0.004, 0.0) * exp(dd / 1.99) +
 				vec3(0.078, 0.0, 0.0) * exp(dd / 7.41);
-
 		diffuse_light += profile * transmittance_color.a * light_color * clamp(transmittance_boost - NdotL, 0.0, 1.0) * (1.0 / M_PI);
-#else
-
-		float scale = 8.25 / transmittance_depth;
-		float d = scale * abs(transmittance_z);
-		float dd = -d * d;
+#else // SSS_MODE_SKIN
 		diffuse_light += exp(dd) * transmittance_color.rgb * transmittance_color.a * light_color * clamp(transmittance_boost - NdotL, 0.0, 1.0) * (1.0 / M_PI);
-#endif
+#endif // SSS_MODE_SKIN
 	}
-#endif //LIGHT_TRANSMITTANCE_USED
+#endif // LIGHT_TRANSMITTANCE_USED
 
 #if defined(LIGHT_RIM_USED)
 	// Epsilon min to prevent pow(0, 0) singularity which results in undefined behavior.
 	float rim_light = pow(max(1e-4, 1.0 - cNdotV), max(0.0, (1.0 - roughness) * 16.0));
 	diffuse_light += rim_light * rim * mix(vec3(1.0), albedo, rim_tint) * light_color;
-#endif
+#endif // LIGHT_RIM_USED
 
-	// We skip checking on attenuation on directional lights to avoid a branch that is not as beneficial for directional lights as the other ones.
-	const float EPSILON = 1e-3f;
-	if (is_directional || attenuation > EPSILON) {
+	if (is_directional || attenuation > 0.001) { // Skip shading if attenuation/shadows are dark enough, except on directional lights where this branch is less beneficial.
 		float cNdotL = max(NdotL, 0.0);
 #if defined(DIFFUSE_BURLEY) || defined(SPECULAR_SCHLICK_GGX) || defined(LIGHT_CLEARCOAT_USED)
 		vec3 H = normalize(V + L);
-#endif
-#if defined(DIFFUSE_BURLEY) || defined(SPECULAR_SCHLICK_GGX) || defined(LIGHT_CLEARCOAT_USED)
 		float cLdotH = clamp(A + dot(L, H), 0.0, 1.0);
-#endif
+#endif // DIFFUSE_BURLEY || SPECULAR_SCHLICK_GGX || LIGHT_CLEARCOAT_USED
+
+		// Specular //
 #if defined(LIGHT_CLEARCOAT_USED)
-		// Clearcoat ignores normal_map, use vertex normal instead
-		float ccNdotL = max(min(A + dot(vertex_normal, L), 1.0), 0.0);
+		// Clearcoat ignores normal_map, use vertex normal instead.
+		float ccNdotL = clamp(A + dot(vertex_normal, L), 0.0, 1.0);
 		float ccNdotH = clamp(A + dot(vertex_normal, H), 0.0, 1.0);
 		float ccNdotV = max(dot(vertex_normal, V), 1e-4);
 		float cLdotH5 = SchlickFresnel(cLdotH);
 
 		float Dr = D_GGX(ccNdotH, mix(0.001, 0.1, clearcoat_roughness));
 		float Gr = 0.25 / (cLdotH * cLdotH);
-		float Fr = mix(.04, 1.0, cLdotH5);
+		float Fr = mix(0.04, 1.0, cLdotH5);
 		float clearcoat_specular_brdf_NL = clearcoat * Gr * Fr * Dr * cNdotL;
 
 		specular_light += clearcoat_specular_brdf_NL * light_color * attenuation * specular_amount;
 
 		// TODO: Clearcoat adds light to the scene right now (it is non-energy conserving), both diffuse and specular need to be scaled by (1.0 - FR)
-		// but to do so we need to rearrange this entire function
+		// but to do so we need to rearrange this entire function.
 #endif // LIGHT_CLEARCOAT_USED
 
-		if (metallic < 1.0) {
-			float diffuse_brdf_NL; // BRDF times N.L for calculating diffuse radiance
-
+		// Diffuse //
+		if (metallic < 1.0) { // Skip diffuse for 100% metallic materials, as they have no diffuse component.
 #if defined(DIFFUSE_LAMBERT_WRAP)
-			// Energy conserving lambert wrap shader.
+			// Energy conserving Lambert wrap shader.
 			// https://web.archive.org/web/20210228210901/http://blog.stevemcauley.com/2011/12/03/energy-conserving-wrapped-diffuse/
-			diffuse_brdf_NL = max(0.0, (NdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness))) * (1.0 / M_PI);
+			float diffuse_brdf_NL = max(0.0, (NdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness))) * (1.0 / M_PI);
 #elif defined(DIFFUSE_TOON)
-
-			diffuse_brdf_NL = smoothstep(-roughness, max(roughness, 0.01), NdotL) * (1.0 / M_PI);
-
+			float diffuse_brdf_NL = smoothstep(-roughness, max(roughness, 0.01), NdotL) * (1.0 / M_PI);
 #elif defined(DIFFUSE_BURLEY)
-			{
-				float FD90_minus_1 = 2.0 * cLdotH * cLdotH * roughness - 0.5;
-				float FdV = 1.0 + FD90_minus_1 * SchlickFresnel(cNdotV);
-				float FdL = 1.0 + FD90_minus_1 * SchlickFresnel(cNdotL);
-				diffuse_brdf_NL = (1.0 / M_PI) * FdV * FdL * cNdotL;
-			}
-#else
-			// lambert
-			diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
-#endif
+			float FD90_minus_1 = 2.0 * cLdotH * cLdotH * roughness - 0.5;
+			float FdV = 1.0 + FD90_minus_1 * SchlickFresnel(cNdotV);
+			float FdL = 1.0 + FD90_minus_1 * SchlickFresnel(cNdotL);
+			float diffuse_brdf_NL = (1.0 / M_PI) * FdV * FdL * cNdotL;
+#else // DIFFUSE_LAMBERT
+			float diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
+#endif // DIFFUSE
 
 			diffuse_light += light_color * diffuse_brdf_NL * attenuation;
 
 #if defined(LIGHT_BACKLIGHT_USED)
 			diffuse_light += light_color * (vec3(1.0 / M_PI) - diffuse_brdf_NL) * backlight * attenuation;
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 		}
 
-		if (roughness > 0.0) {
+		if (roughness > 0.0) { // FIXME: roughness == 0 should not disable specular light entirely
 #if defined(SPECULAR_SCHLICK_GGX)
 			float cNdotH = clamp(A + dot(N, H), 0.0, 1.0);
-#endif
+#endif // SPECULAR_SCHLICK_GGX
+
 			// Apply specular light.
-			// FIXME: roughness == 0 should not disable specular light entirely
 #if defined(SPECULAR_TOON)
 			vec3 R = normalize(-reflect(L, N));
 			float RdotV = dot(R, V);
 			float mid = 1.0 - roughness;
 			mid *= mid;
 			float intensity = smoothstep(mid - roughness * 0.5, mid + roughness * 0.5, RdotV) * mid;
-			diffuse_light += light_color * intensity * attenuation * specular_amount; // write to diffuse_light, as in toon shading you generally want no reflection
-
+			diffuse_light += light_color * intensity * attenuation * specular_amount; // Write to diffuse_light, as in toon shading you generally want no reflection.
 #elif defined(SPECULAR_DISABLED)
 			// Do nothing.
-
 #elif defined(SPECULAR_SCHLICK_GGX)
-			// shlick+ggx as default
+			// Shlick+GGX as default.
 			float alpha_ggx = roughness * roughness;
 #if defined(LIGHT_ANISOTROPY_USED)
 			float aspect = sqrt(1.0 - anisotropy * 0.9);
@@ -209,22 +220,23 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 			float D = D_GGX(cNdotH, alpha_ggx);
 			float G = V_GGX(cNdotL, cNdotV, alpha_ggx);
 #endif // LIGHT_ANISOTROPY_USED
-	   // F
+
 #if !defined(LIGHT_CLEARCOAT_USED)
 			float cLdotH5 = SchlickFresnel(cLdotH);
-#endif
-			// Calculate Fresnel using specular occlusion term from Filament:
+#endif // !LIGHT_CLEARCOAT_USED
+
+			// Calculate Fresnel using specular microshadowing term from Filament:
 			// https://google.github.io/filament/Filament.html#lighting/occlusion/specularocclusion
-			float f90 = clamp(dot(f0, vec3(50.0 * 0.33)), metallic, 1.0);
+			float f90 = clamp(dot(f0, vec3(50.0 * 0.333)), metallic, 1.0);
 			vec3 F = f0 + (f90 - f0) * cLdotH5;
 			vec3 specular_brdf_NL = cNdotL * D * F * G;
 			specular_light += specular_brdf_NL * light_color * attenuation * specular_amount;
-#endif
+#endif // SPECULAR
 		}
 
 #ifdef USE_SHADOW_TO_OPACITY
 		alpha = min(alpha, clamp(1.0 - attenuation, 0.0, 1.0));
-#endif
+#endif // USE_SHADOW_TO_OPACITY
 	}
 #endif // LIGHT_CODE_USED
 }
@@ -242,7 +254,7 @@ float sample_directional_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, ve
 	vec2 pos = coord.xy;
 	float depth = coord.z;
 
-	//if only one sample is taken, take it from the center
+	// If only one sample is taken, take it from the center.
 	if (sc_directional_soft_shadow_samples() == 0) {
 		return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
 	}
@@ -268,7 +280,7 @@ float sample_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec3 coord, fl
 	vec2 pos = coord.xy;
 	float depth = coord.z;
 
-	//if only one sample is taken, take it from the center
+	// If only one sample is taken, take it from the center.
 	if (sc_soft_shadow_samples() == 0) {
 		return textureProj(sampler2DShadow(shadow, shadow_sampler), vec4(pos, depth, 1.0));
 	}
@@ -291,7 +303,7 @@ float sample_pcf_shadow(texture2D shadow, vec2 shadow_pixel_size, vec3 coord, fl
 }
 
 float sample_omni_pcf_shadow(texture2D shadow, float blur_scale, vec2 coord, vec4 uv_rect, vec2 flip_offset, float depth, float taa_frame_count) {
-	//if only one sample is taken, take it from the center
+	// If only one sample is taken, take it from the center.
 	if (sc_soft_shadow_samples() == 0) {
 		vec2 pos = coord * 0.5 + 0.5;
 		pos = uv_rect.xy + pos * uv_rect.zw;
@@ -334,7 +346,7 @@ float sample_omni_pcf_shadow(texture2D shadow, float blur_scale, vec2 coord, vec
 }
 
 float sample_directional_soft_shadow(texture2D shadow, vec3 pssm_coord, vec2 tex_scale, float taa_frame_count) {
-	//find blocker
+	// Find blockers.
 	float blocker_count = 0.0;
 	float blocker_average = 0.0;
 
@@ -356,7 +368,7 @@ float sample_directional_soft_shadow(texture2D shadow, vec3 pssm_coord, vec2 tex
 	}
 
 	if (blocker_count > 0.0) {
-		//blockers found, do soft shadow
+		// Blockers found, do soft shadow.
 		blocker_average /= blocker_count;
 		float penumbra = (-pssm_coord.z + blocker_average) / (1.0 - blocker_average);
 		tex_scale *= penumbra;
@@ -370,81 +382,67 @@ float sample_directional_soft_shadow(texture2D shadow, vec3 pssm_coord, vec2 tex
 		return s / float(sc_directional_penumbra_shadow_samples());
 
 	} else {
-		//no blockers found, so no shadow
+		// No blockers found, so no shadow.
 		return 1.0;
 	}
 }
 
-#endif // SHADOWS_DISABLED
-
-float get_omni_attenuation(float distance, float inv_range, float decay) {
-	float nd = distance * inv_range;
-	nd *= nd;
-	nd *= nd; // nd^4
-	nd = max(1.0 - nd, 0.0);
-	nd *= nd; // nd^2
-	return nd * pow(max(distance, 0.0001), -decay);
-}
+#endif // !SHADOWS_DISABLED
 
 void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, vec3 f0, uint orms, float taa_frame_count, vec3 albedo, inout float alpha, vec2 screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 		vec4 transmittance_color,
 		float transmittance_depth,
 		float transmittance_boost,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 		float rim, float rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 		vec3 binormal, vec3 tangent, float anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 		inout vec3 diffuse_light, inout vec3 specular_light) {
-	const float EPSILON = 1e-3f;
 
 	// Omni light attenuation.
 	vec3 light_rel_vec = omni_lights.data[idx].position - vertex;
 	float light_length = length(light_rel_vec);
 	float omni_attenuation = get_omni_attenuation(light_length, omni_lights.data[idx].inv_radius, omni_lights.data[idx].attenuation);
 
-	// Compute size.
-	float size = 0.0;
+	// Compute area light solid angle.
+	float size_A = 0.0;
 	if (sc_use_light_soft_shadows() && omni_lights.data[idx].size > 0.0) {
 		float t = omni_lights.data[idx].size / max(0.001, light_length);
-		size = max(0.0, 1.0 - 1 / sqrt(1 + t * t));
+		size_A = max(0.0, 1.0 - 1.0 / sqrt(1.0 + t * t));
 	}
 
 	float shadow = 1.0;
 #ifndef SHADOWS_DISABLED
 	// Omni light shadow.
-	if (omni_attenuation > EPSILON && omni_lights.data[idx].shadow_opacity > 0.001) {
-		// there is a shadowmap
+	if (omni_attenuation > 0.001 && omni_lights.data[idx].shadow_opacity > 0.001) {
 		vec2 texel_size = scene_data_block.data.shadow_atlas_pixel_size;
 		vec4 base_uv_rect = omni_lights.data[idx].atlas_rect;
 		base_uv_rect.xy += texel_size;
 		base_uv_rect.zw -= texel_size * 2.0;
 
-		// Omni lights use direction.xy to store to store the offset between the two paraboloid regions
+		// Omni lights use direction.xy to store the offset between the two paraboloid regions.
 		vec2 flip_offset = omni_lights.data[idx].direction.xy;
 
 		vec3 local_vert = (omni_lights.data[idx].shadow_matrix * vec4(vertex, 1.0)).xyz;
 
-		float shadow_len = length(local_vert); //need to remember shadow len from here
+		float shadow_len = length(local_vert); // Need to remember shadow len from here.
 		vec3 shadow_dir = normalize(local_vert);
 
 		vec3 local_normal = normalize(mat3(omni_lights.data[idx].shadow_matrix) * normal);
 		vec3 normal_bias = local_normal * omni_lights.data[idx].shadow_normal_bias * (1.0 - abs(dot(local_normal, shadow_dir)));
 
-		if (sc_use_light_soft_shadows() && omni_lights.data[idx].soft_shadow_size > 0.0) {
-			//soft shadow
-
-			//find blocker
-
+		if (sc_use_light_soft_shadows() && omni_lights.data[idx].soft_shadow_size > 0.0) { // Soft Shadows //
+			// Find blockers.
 			float blocker_count = 0.0;
 			float blocker_average = 0.0;
 
@@ -492,7 +490,7 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 			}
 
 			if (blocker_count > 0.0) {
-				//blockers found, do soft shadow
+				// Blockers found, do soft shadow.
 				blocker_average /= blocker_count;
 				float penumbra = (-z_norm + blocker_average) / (1.0 - blocker_average);
 				tangent *= penumbra;
@@ -526,10 +524,10 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 				shadow = mix(1.0, shadow, omni_lights.data[idx].shadow_opacity);
 
 			} else {
-				//no blockers found, so no shadow
+				// No blockers found, so no shadow.
 				shadow = 1.0;
 			}
-		} else {
+		} else { // Hard Shadows //
 			vec4 uv_rect = base_uv_rect;
 
 			vec3 shadow_sample = normalize(shadow_dir + normal_bias);
@@ -546,27 +544,27 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 			shadow = mix(1.0, sample_omni_pcf_shadow(shadow_atlas, omni_lights.data[idx].soft_shadow_scale / shadow_sample.z, pos, uv_rect, flip_offset, depth, taa_frame_count), omni_lights.data[idx].shadow_opacity);
 		}
 	}
-#endif
+#endif // !SHADOWS_DISABLED
 
 	vec3 color = omni_lights.data[idx].color;
 
 #ifdef LIGHT_TRANSMITTANCE_USED
-	float transmittance_z = transmittance_depth; //no transmittance by default
+	float transmittance_z = transmittance_depth; // No transmittance by default.
 	transmittance_color.a *= omni_attenuation;
 #ifndef SHADOWS_DISABLED
-	if (omni_lights.data[idx].shadow_opacity > 0.001) {
+	if (omni_lights.data[idx].shadow_opacity > 0.001) { // Get transmittance depth from shadow map.
 		// Redo shadowmapping, but shrink the model a bit to avoid artifacts.
 		vec2 texel_size = scene_data_block.data.shadow_atlas_pixel_size;
 		vec4 uv_rect = omni_lights.data[idx].atlas_rect;
 		uv_rect.xy += texel_size;
 		uv_rect.zw -= texel_size * 2.0;
 
-		// Omni lights use direction.xy to store to store the offset between the two paraboloid regions
+		// Omni lights use direction.xy to store the offset between the two paraboloid regions.
 		vec2 flip_offset = omni_lights.data[idx].direction.xy;
 
 		vec3 local_vert = (omni_lights.data[idx].shadow_matrix * vec4(vertex - normalize(normal) * omni_lights.data[idx].transmittance_bias, 1.0)).xyz;
 
-		float shadow_len = length(local_vert); //need to remember shadow len from here
+		float shadow_len = length(local_vert); // Need to remember shadow len from here.
 		vec3 shadow_sample = normalize(local_vert);
 
 		if (shadow_sample.z >= 0.0) {
@@ -587,9 +585,8 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 #endif // !SHADOWS_DISABLED
 #endif // LIGHT_TRANSMITTANCE_USED
 
-	if (sc_use_light_projector() && omni_lights.data[idx].projector_rect != vec4(0.0)) {
-		vec3 local_v = (omni_lights.data[idx].shadow_matrix * vec4(vertex, 1.0)).xyz;
-		local_v = normalize(local_v);
+	if (sc_use_light_projector() && omni_lights.data[idx].projector_rect != vec4(0.0)) { // Process projector texture.
+		vec3 local_v = normalize((omni_lights.data[idx].shadow_matrix * vec4(vertex, 1.0)).xyz);
 
 		vec4 atlas_rect = omni_lights.data[idx].projector_rect;
 
@@ -603,12 +600,11 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 		local_v.xy = local_v.xy * 0.5 + 0.5;
 		vec2 proj_uv = local_v.xy * atlas_rect.zw;
 
-		if (sc_projector_use_mipmaps()) {
+		if (sc_projector_use_mipmaps()) { // Only compute derivatives if mipmaps are present.
 			vec2 proj_uv_ddx;
 			vec2 proj_uv_ddy;
 			{
-				vec3 local_v_ddx = (omni_lights.data[idx].shadow_matrix * vec4(vertex + vertex_ddx, 1.0)).xyz;
-				local_v_ddx = normalize(local_v_ddx);
+				vec3 local_v_ddx = normalize((omni_lights.data[idx].shadow_matrix * vec4(vertex + vertex_ddx, 1.0)).xyz);
 
 				if (local_v_ddx.z >= 0.0) {
 					local_v_ddx.z += 1.0;
@@ -621,8 +617,7 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 
 				proj_uv_ddx = local_v_ddx.xy * atlas_rect.zw - proj_uv;
 
-				vec3 local_v_ddy = (omni_lights.data[idx].shadow_matrix * vec4(vertex + vertex_ddy, 1.0)).xyz;
-				local_v_ddy = normalize(local_v_ddy);
+				vec3 local_v_ddy = normalize((omni_lights.data[idx].shadow_matrix * vec4(vertex + vertex_ddy, 1.0)).xyz);
 
 				if (local_v_ddy.z >= 0.0) {
 					local_v_ddy.z += 1.0;
@@ -645,62 +640,49 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 	}
 
 	vec3 light_rel_vec_norm = light_rel_vec / light_length;
-	light_compute(normal, light_rel_vec_norm, eye_vec, size, color, false, omni_attenuation * shadow, f0, orms, omni_lights.data[idx].specular_amount, albedo, alpha, screen_uv,
+	light_compute(normal, light_rel_vec_norm, eye_vec, size_A, color, false, omni_attenuation * shadow, f0, orms, omni_lights.data[idx].specular_amount, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 			backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 			transmittance_color,
 			transmittance_depth,
 			transmittance_boost,
 			transmittance_z,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 			rim * omni_attenuation, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 			clearcoat, clearcoat_roughness, vertex_normal,
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 			binormal, tangent, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 			diffuse_light,
 			specular_light);
-}
-
-vec2 normal_to_panorama(vec3 n) {
-	n = normalize(n);
-	vec2 panorama_coords = vec2(atan(n.x, n.z), acos(-n.y));
-
-	if (panorama_coords.x < 0.0) {
-		panorama_coords.x += M_PI * 2.0;
-	}
-
-	panorama_coords /= vec2(M_PI * 2.0, M_PI);
-	return panorama_coords;
 }
 
 void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 vertex_ddx, vec3 vertex_ddy, vec3 f0, uint orms, float taa_frame_count, vec3 albedo, inout float alpha, vec2 screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 		vec3 backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 		vec4 transmittance_color,
 		float transmittance_depth,
 		float transmittance_boost,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 		float rim, float rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 		vec3 binormal, vec3 tangent, float anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 		inout vec3 diffuse_light,
 		inout vec3 specular_light) {
-	const float EPSILON = 1e-3f;
 
 	// Spot light attenuation.
 	vec3 light_rel_vec = spot_lights.data[idx].position - vertex;
@@ -716,30 +698,27 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 	float spot_rim = max(0.0001, (1.0 - scos) / (1.0 - cone_angle));
 	spot_attenuation *= 1.0 - pow(spot_rim, spot_lights.data[idx].cone_attenuation);
 
-	// Compute size.
-	float size = 0.0;
+	// Compute area light solid angle.
+	float size_A = 0.0;
 	if (sc_use_light_soft_shadows() && spot_lights.data[idx].size > 0.0) {
 		float t = spot_lights.data[idx].size / max(0.001, light_length);
-		size = max(0.0, 1.0 - 1 / sqrt(1 + t * t));
+		size_A = max(0.0, 1.0 - 1.0 / sqrt(1.0 + t * t));
 	}
 
 	float shadow = 1.0;
 #ifndef SHADOWS_DISABLED
 	// Spot light shadow.
-	if (spot_attenuation > EPSILON && spot_lights.data[idx].shadow_opacity > 0.001) {
+	if (spot_attenuation > 0.001 && spot_lights.data[idx].shadow_opacity > 0.001) {
 		vec3 normal_bias = normal * light_length * spot_lights.data[idx].shadow_normal_bias * (1.0 - abs(dot(normal, light_rel_vec_norm)));
 
-		//there is a shadowmap
 		vec4 v = vec4(vertex + normal_bias, 1.0);
 
 		vec4 splane = (spot_lights.data[idx].shadow_matrix * v);
 		splane.z += spot_lights.data[idx].shadow_bias / (light_length * spot_lights.data[idx].inv_radius);
 		splane /= splane.w;
 
-		if (sc_use_light_soft_shadows() && spot_lights.data[idx].soft_shadow_size > 0.0) {
-			//soft shadow
-
-			//find blocker
+		if (sc_use_light_soft_shadows() && spot_lights.data[idx].soft_shadow_size > 0.0) { // Soft Shadows //
+			// Find blockers.
 			float z_norm = dot(spot_dir, -light_rel_vec) * spot_lights.data[idx].inv_radius;
 
 			vec2 shadow_uv = splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy;
@@ -768,7 +747,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 			}
 
 			if (blocker_count > 0.0) {
-				//blockers found, do soft shadow
+				// Blockers found, do soft shadow.
 				blocker_average /= blocker_count;
 				float penumbra = (-z_norm + blocker_average) / (1.0 - blocker_average);
 				uv_size *= penumbra;
@@ -784,16 +763,15 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 				shadow = mix(1.0, shadow, spot_lights.data[idx].shadow_opacity);
 
 			} else {
-				//no blockers found, so no shadow
+				// No blockers found, so no shadow.
 				shadow = 1.0;
 			}
-		} else {
-			//hard shadow
+		} else { // Hard Shadows //
 			vec3 shadow_uv = vec3(splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy, splane.z);
 			shadow = mix(1.0, sample_pcf_shadow(shadow_atlas, spot_lights.data[idx].soft_shadow_scale * scene_data_block.data.shadow_atlas_pixel_size, shadow_uv, taa_frame_count), spot_lights.data[idx].shadow_opacity);
 		}
 	}
-#endif // SHADOWS_DISABLED
+#endif // !SHADOWS_DISABLED
 
 	vec3 color = spot_lights.data[idx].color;
 	float specular_amount = spot_lights.data[idx].specular_amount;
@@ -802,7 +780,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 	float transmittance_z = transmittance_depth;
 	transmittance_color.a *= spot_attenuation;
 #ifndef SHADOWS_DISABLED
-	if (spot_lights.data[idx].shadow_opacity > 0.001) {
+	if (spot_lights.data[idx].shadow_opacity > 0.001) { // Get transmittance depth from shadow map.
 		vec4 splane = (spot_lights.data[idx].shadow_matrix * vec4(vertex - normalize(normal) * spot_lights.data[idx].transmittance_bias, 1.0));
 		splane /= splane.w;
 
@@ -814,21 +792,20 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 		float z_near = 0.01;
 		shadow_z = 2.0 * z_near * z_far / (z_far + z_near - shadow_z * (z_far - z_near));
 
-		//distance to light plane
+		// Distance to light plane.
 		float z = dot(spot_dir, -light_rel_vec);
 		transmittance_z = z - shadow_z;
 	}
 #endif // !SHADOWS_DISABLED
 #endif // LIGHT_TRANSMITTANCE_USED
 
-	if (sc_use_light_projector() && spot_lights.data[idx].projector_rect != vec4(0.0)) {
+	if (sc_use_light_projector() && spot_lights.data[idx].projector_rect != vec4(0.0)) { // Process projector texture.
 		vec4 splane = (spot_lights.data[idx].shadow_matrix * vec4(vertex, 1.0));
 		splane /= splane.w;
 
 		vec2 proj_uv = splane.xy * spot_lights.data[idx].projector_rect.zw;
 
-		if (sc_projector_use_mipmaps()) {
-			//ensure we have proper mipmaps
+		if (sc_projector_use_mipmaps()) { // Only compute derivatives if mipmaps are present.
 			vec4 splane_ddx = (spot_lights.data[idx].shadow_matrix * vec4(vertex + vertex_ddx, 1.0));
 			splane_ddx /= splane_ddx.w;
 			vec2 proj_uv_ddx = splane_ddx.xy * spot_lights.data[idx].projector_rect.zw - proj_uv;
@@ -845,25 +822,25 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 		}
 	}
 
-	light_compute(normal, light_rel_vec_norm, eye_vec, size, color, false, spot_attenuation * shadow, f0, orms, spot_lights.data[idx].specular_amount, albedo, alpha, screen_uv,
+	light_compute(normal, light_rel_vec_norm, eye_vec, size_A, color, false, spot_attenuation * shadow, f0, orms, spot_lights.data[idx].specular_amount, albedo, alpha, screen_uv,
 #ifdef LIGHT_BACKLIGHT_USED
 			backlight,
-#endif
+#endif // LIGHT_BACKLIGHT_USED
 #ifdef LIGHT_TRANSMITTANCE_USED
 			transmittance_color,
 			transmittance_depth,
 			transmittance_boost,
 			transmittance_z,
-#endif
+#endif // LIGHT_TRANSMITTANCE_USED
 #ifdef LIGHT_RIM_USED
 			rim * spot_attenuation, rim_tint,
-#endif
+#endif // LIGHT_RIM_USED
 #ifdef LIGHT_CLEARCOAT_USED
 			clearcoat, clearcoat_roughness, vertex_normal,
-#endif
+#endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
 			binormal, tangent, anisotropy,
-#endif
+#endif // LIGHT_ANISOTROPY_USED
 			diffuse_light, specular_light);
 }
 
@@ -871,7 +848,7 @@ void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, 
 	vec3 box_extents = reflections.data[ref_index].box_extents;
 	vec3 local_pos = (reflections.data[ref_index].local_matrix * vec4(vertex, 1.0)).xyz;
 
-	if (any(greaterThan(abs(local_pos), box_extents))) { //out of the reflection box
+	if (any(greaterThan(abs(local_pos), box_extents))) { // Out of the reflection box, skip.
 		return;
 	}
 
@@ -885,11 +862,11 @@ void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, 
 		blend = pow(blend_axes.x * blend_axes.y * blend_axes.z, 2.0);
 	}
 
-	if (reflections.data[ref_index].intensity > 0.0) { // compute reflection
+	if (reflections.data[ref_index].intensity > 0.0) { // Compute reflection.
 
 		vec3 local_ref_vec = (reflections.data[ref_index].local_matrix * vec4(ref_vec, 0.0)).xyz;
 
-		if (reflections.data[ref_index].box_project) { //box project
+		if (reflections.data[ref_index].box_project) { // Box project.
 
 			vec3 nrdir = normalize(local_ref_vec);
 			vec3 rbmax = (box_extents - local_pos) / nrdir;
@@ -903,14 +880,13 @@ void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, 
 		}
 
 		vec4 reflection;
-
 		reflection.rgb = textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_ref_vec, reflections.data[ref_index].index), sqrt(roughness) * MAX_ROUGHNESS_LOD).rgb * sc_luminance_multiplier();
 		reflection.rgb *= reflections.data[ref_index].exposure_normalization;
 		if (reflections.data[ref_index].exterior) {
 			reflection.rgb = mix(specular_light, reflection.rgb, blend);
 		}
 
-		reflection.rgb *= reflections.data[ref_index].intensity; //intensity
+		reflection.rgb *= reflections.data[ref_index].intensity;
 		reflection.a = blend;
 		reflection.rgb *= reflection.a;
 
@@ -919,14 +895,12 @@ void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, 
 
 	switch (reflections.data[ref_index].ambient_mode) {
 		case REFLECTION_AMBIENT_DISABLED: {
-			//do nothing
+			// Do nothing.
 		} break;
 		case REFLECTION_AMBIENT_ENVIRONMENT: {
-			//do nothing
 			vec3 local_amb_vec = (reflections.data[ref_index].local_matrix * vec4(normal, 0.0)).xyz;
 
 			vec4 ambient_out;
-
 			ambient_out.rgb = textureLod(samplerCubeArray(reflection_atlas, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(local_amb_vec, reflections.data[ref_index].index), MAX_ROUGHNESS_LOD).rgb;
 			ambient_out.rgb *= reflections.data[ref_index].exposure_normalization;
 			ambient_out.a = blend;
@@ -953,10 +927,10 @@ void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, 
 float blur_shadow(float shadow) {
 	return shadow;
 #if 0
-	//disabling for now, will investigate later
+	// Disabling for now, will investigate later.
 	float interp_shadow = shadow;
 	if (gl_HelperInvocation) {
-		interp_shadow = -4.0; // technically anything below -4 will do but just to make sure
+		interp_shadow = -4.0; // Technically anything below -4 will do but just to make sure.
 	}
 
 	uvec2 fc2 = uvec2(gl_FragCoord.xy);

--- a/servers/rendering/renderer_rd/shaders/scene_forward_vertex_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_vertex_lights_inc.glsl
@@ -9,35 +9,6 @@ mediump float roughness_to_shininess(mediump float roughness) {
 	return r * r2 * r2 * 2000.0;
 }
 
-void light_compute_vertex(vec3 N, vec3 L, vec3 V, vec3 light_color, bool is_directional, float roughness,
-		inout vec3 diffuse_light, inout vec3 specular_light) {
-	float NdotL = min(dot(N, L), 1.0);
-	float cNdotL = max(NdotL, 0.0); // clamped NdotL
-
-#if defined(DIFFUSE_LAMBERT_WRAP)
-	// Energy conserving lambert wrap shader.
-	// https://web.archive.org/web/20210228210901/http://blog.stevemcauley.com/2011/12/03/energy-conserving-wrapped-diffuse/
-	float diffuse_brdf_NL = max(0.0, (cNdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness))) * (1.0 / M_PI);
-#else
-	// lambert
-	float diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
-#endif
-
-	diffuse_light += light_color * diffuse_brdf_NL;
-
-#if !defined(SPECULAR_DISABLED)
-	float specular_brdf_NL = 0.0;
-	// Normalized blinn always unless disabled.
-	vec3 H = normalize(V + L);
-	float cNdotH = clamp(dot(N, H), 0.0, 1.0);
-	float shininess = roughness_to_shininess(roughness);
-	float blinn = pow(cNdotH, shininess);
-	blinn *= (shininess + 2.0) * (1.0 / (8.0 * M_PI)) * cNdotL;
-	specular_brdf_NL = blinn;
-	specular_light += specular_brdf_NL * light_color;
-#endif
-}
-
 float get_omni_attenuation(float distance, float inv_range, float decay) {
 	float nd = distance * inv_range;
 	nd *= nd;
@@ -45,6 +16,33 @@ float get_omni_attenuation(float distance, float inv_range, float decay) {
 	nd = max(1.0 - nd, 0.0);
 	nd *= nd; // nd^2
 	return nd * pow(max(distance, 0.0001), -decay);
+}
+
+void light_compute_vertex(vec3 N, vec3 L, vec3 V, vec3 light_color, bool is_directional, float roughness,
+		inout vec3 diffuse_light, inout vec3 specular_light) {
+	float NdotL = min(dot(N, L), 1.0);
+	float cNdotL = max(NdotL, 0.0);
+
+#if defined(DIFFUSE_LAMBERT_WRAP)
+	// Energy conserving Lambert wrap shader.
+	// https://web.archive.org/web/20210228210901/http://blog.stevemcauley.com/2011/12/03/energy-conserving-wrapped-diffuse/
+	float diffuse_brdf_NL = max(0.0, (cNdotL + roughness) / ((1.0 + roughness) * (1.0 + roughness))) * (1.0 / M_PI);
+#else // DIFFUSE_LAMBERT_WRAP
+	// Lambert.
+	float diffuse_brdf_NL = cNdotL * (1.0 / M_PI);
+#endif // DIFFUSE_LAMBERT_WRAP
+
+	diffuse_light += light_color * diffuse_brdf_NL;
+
+#if !defined(SPECULAR_DISABLED)
+	// Normalized Blinn always unless disabled.
+	vec3 H = normalize(V + L);
+	float cNdotH = clamp(dot(N, H), 0.0, 1.0);
+	float shininess = roughness_to_shininess(roughness);
+	float blinn = pow(cNdotH, shininess);
+	blinn *= (shininess + 2.0) * (1.0 / (8.0 * M_PI)) * cNdotL;
+	specular_light += blinn * light_color;
+#endif // !SPECULAR_DISABLED
 }
 
 void light_process_omni_vertex(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, float roughness,


### PR DESCRIPTION
Adjusts formatting of code and cleans-up/clarifies comments throughout the scene shaders of all three renderers, in the interest of making maintenance a bit easier for anyone delving into these shaders in the future, and in anticipation of a series of more substantive fixes coming down the pipe.

Originally split off from #100348
