### PR TITLE
Rename `RenderingServer::is_low_end()` to `RenderingServer::is_using_gl_compatibility()`

### DIFF
--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -121,7 +121,7 @@ public:
 		gles_over_gl = p_gles_over_gl;
 		OS::get_singleton()->set_gles_over_gl(gles_over_gl);
 		_create_func = _create_current;
-		low_end = true;
+		using_gl_compatibility = true;
 	}
 
 #ifdef WINDOWS_ENABLED

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3104,7 +3104,7 @@ void EditorInspector::update_tree() {
 			category_vbox = nullptr;
 		}
 
-		if (p.usage & PROPERTY_USAGE_HIGH_END_GFX && RS::get_singleton()->is_low_end()) {
+		if (p.usage & PROPERTY_USAGE_HIGH_END_GFX && RS::get_singleton()->is_using_gl_compatibility()) {
 			// Do not show this property in low end gfx.
 			continue;
 		}

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -277,7 +277,7 @@ void ParticleProcessMaterial::_update_shader() {
 		}
 	}
 
-	if (sub_emitter_mode != SUB_EMITTER_DISABLED && !RenderingServer::get_singleton()->is_low_end()) {
+	if (sub_emitter_mode != SUB_EMITTER_DISABLED && !RenderingServer::get_singleton()->is_using_gl_compatibility()) {
 		if (sub_emitter_mode == SUB_EMITTER_CONSTANT) {
 			code += "uniform float sub_emitter_frequency;\n";
 		}
@@ -1114,7 +1114,7 @@ void ParticleProcessMaterial::_update_shader() {
 	code += "\n";
 	code += "	CUSTOM.z = params.animation_offset + lifetime_percent * params.animation_speed;\n\n";
 
-	if (sub_emitter_mode != SUB_EMITTER_DISABLED && !RenderingServer::get_singleton()->is_low_end()) {
+	if (sub_emitter_mode != SUB_EMITTER_DISABLED && !RenderingServer::get_singleton()->is_using_gl_compatibility()) {
 		code += "	int emit_count = 0;\n";
 		switch (sub_emitter_mode) {
 			case SUB_EMITTER_CONSTANT: {
@@ -1861,7 +1861,7 @@ void ParticleProcessMaterial::set_sub_emitter_mode(SubEmitterMode p_sub_emitter_
 	sub_emitter_mode = p_sub_emitter_mode;
 	_queue_shader_change();
 	notify_property_list_changed();
-	if (sub_emitter_mode != SUB_EMITTER_DISABLED && RenderingServer::get_singleton()->is_low_end()) {
+	if (sub_emitter_mode != SUB_EMITTER_DISABLED && RenderingServer::get_singleton()->is_using_gl_compatibility()) {
 		WARN_PRINT_ONCE_ED("Sub-emitter modes other than SUB_EMITTER_DISABLED are not supported in the Compatibility renderer.");
 	}
 }

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -1679,7 +1679,7 @@ String VisualShaderNodeLinearSceneDepth::generate_code(Shader::Mode p_mode, Visu
 	code += "	{\n";
 
 	code += "		float __log_depth = textureLod(" + make_unique_id(p_type, p_id, "depth_tex") + ", SCREEN_UV, 0.0).x;\n";
-	if (!RenderingServer::get_singleton()->is_low_end()) {
+	if (!RenderingServer::get_singleton()->is_using_gl_compatibility()) {
 		code += "	vec4 __depth_view = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, __log_depth, 1.0);\n";
 	} else {
 		code += "	vec4 __depth_view = INV_PROJECTION_MATRIX * vec4(vec3(SCREEN_UV, __log_depth) * 2.0 - 1.0, 1.0);\n";
@@ -1746,7 +1746,7 @@ String VisualShaderNodeWorldPositionFromDepth::generate_code(Shader::Mode p_mode
 	code += "	{\n";
 
 	code += "		float __log_depth = textureLod(" + make_unique_id(p_type, p_id, "depth_tex") + ", " + uv + ", 0.0).x;\n";
-	if (!RenderingServer::get_singleton()->is_low_end()) {
+	if (!RenderingServer::get_singleton()->is_using_gl_compatibility()) {
 		code += "	vec4 __depth_view = INV_PROJECTION_MATRIX * vec4(" + uv + " * 2.0 - 1.0, __log_depth, 1.0);\n";
 	} else {
 		code += "	vec4 __depth_view = INV_PROJECTION_MATRIX * vec4(vec3(" + uv + ", __log_depth) * 2.0 - 1.0, 1.0);\n";
@@ -3245,7 +3245,7 @@ String VisualShaderNodeColorFunc::generate_code(Shader::Mode p_mode, VisualShade
 			break;
 		case FUNC_LINEAR_TO_SRGB:
 			code += "	{\n";
-			if (RenderingServer::get_singleton()->is_low_end()) {
+			if (RenderingServer::get_singleton()->is_using_gl_compatibility()) {
 				code += "		vec3 c = " + p_input_vars[0] + ";\n";
 				code += "		" + p_output_vars[0] + " = max(vec3(1.055) * pow(c, vec3(0.416666667)) - vec3(0.055), vec3(0.0));\n";
 			} else {
@@ -3257,7 +3257,7 @@ String VisualShaderNodeColorFunc::generate_code(Shader::Mode p_mode, VisualShade
 			break;
 		case FUNC_SRGB_TO_LINEAR:
 			code += "	{\n";
-			if (RenderingServer::get_singleton()->is_low_end()) {
+			if (RenderingServer::get_singleton()->is_using_gl_compatibility()) {
 				code += "		vec3 c = " + p_input_vars[0] + ";\n";
 				code += "		" + p_output_vars[0] + " = c * (c * (c * 0.305306011 + 0.682171111) + 0.012522878);\n";
 			} else {
@@ -8000,7 +8000,7 @@ String VisualShaderNodeProximityFade::generate_code(Shader::Mode p_mode, VisualS
 	code += "	{\n";
 
 	code += "		float __depth_tex = texture(" + make_unique_id(p_type, p_id, "depth_tex") + ", SCREEN_UV).r;\n";
-	if (!RenderingServer::get_singleton()->is_low_end()) {
+	if (!RenderingServer::get_singleton()->is_using_gl_compatibility()) {
 		code += "		vec4 __depth_world_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, __depth_tex, 1.0);\n";
 	} else {
 		code += "		vec4 __depth_world_pos = INV_PROJECTION_MATRIX * vec4(vec3(SCREEN_UV, __depth_tex) * 2.0 - 1.0, 1.0);\n";

--- a/servers/rendering/dummy/rasterizer_dummy.h
+++ b/servers/rendering/dummy/rasterizer_dummy.h
@@ -104,7 +104,7 @@ public:
 
 	static void make_current() {
 		_create_func = _create_current;
-		low_end = false;
+		using_gl_compatibility = false;
 	}
 
 	uint64_t get_frame_number() const override { return frame; }

--- a/servers/rendering/renderer_compositor.cpp
+++ b/servers/rendering/renderer_compositor.cpp
@@ -36,7 +36,7 @@
 RendererCompositor *RendererCompositor::singleton = nullptr;
 
 RendererCompositor *(*RendererCompositor::_create_func)() = nullptr;
-bool RendererCompositor::low_end = false;
+bool RendererCompositor::using_gl_compatibility = false;
 
 RendererCompositor *RendererCompositor::create() {
 	return _create_func();

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -75,7 +75,7 @@ private:
 protected:
 	static RendererCompositor *(*_create_func)();
 	bool back_end = false;
-	static bool low_end;
+	static bool using_gl_compatibility;
 
 public:
 	static RendererCompositor *create();
@@ -106,7 +106,7 @@ public:
 	virtual double get_total_time() const = 0;
 	virtual bool can_create_resources_async() const = 0;
 
-	static bool is_low_end() { return low_end; }
+	static bool is_using_gl_compatibility() { return using_gl_compatibility; }
 	virtual bool is_xr_enabled() const;
 
 	static RendererCompositor *get_singleton() { return singleton; }

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -146,7 +146,7 @@ public:
 
 	static void make_current() {
 		_create_func = _create_current;
-		low_end = false;
+		using_gl_compatibility = false;
 	}
 
 	static RendererCompositorRD *get_singleton() { return singleton; }

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -833,7 +833,7 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 			// render standard mono camera
 			_draw_viewport(vp);
 
-			if (vp->viewport_to_screen != DisplayServer::INVALID_WINDOW_ID && (!vp->viewport_render_direct_to_screen || !RSG::rasterizer->is_low_end())) {
+			if (vp->viewport_to_screen != DisplayServer::INVALID_WINDOW_ID && (!vp->viewport_render_direct_to_screen || !RSG::rasterizer->is_using_gl_compatibility())) {
 				//copy to screen if set as such
 				BlitToScreen blit;
 				blit.render_target = vp->render_target;
@@ -902,7 +902,7 @@ void RendererViewport::viewport_initialize(RID p_rid) {
 	viewport->shadow_atlas = RSG::light_storage->shadow_atlas_create();
 	viewport->viewport_render_direct_to_screen = false;
 
-	viewport->fsr_enabled = !RSG::rasterizer->is_low_end() && !viewport->disable_3d;
+	viewport->fsr_enabled = !RSG::rasterizer->is_using_gl_compatibility() && !viewport->disable_3d;
 }
 
 void RendererViewport::viewport_set_use_xr(RID p_viewport, bool p_use_xr) {
@@ -1038,7 +1038,7 @@ void RendererViewport::viewport_attach_to_screen(RID p_viewport, const Rect2 &p_
 	if (p_screen != DisplayServer::INVALID_WINDOW_ID) {
 		// If using OpenGL we can optimize this operation by rendering directly to system_fbo
 		// instead of rendering to fbo and copying to system_fbo after
-		if (RSG::rasterizer->is_low_end() && viewport->viewport_render_direct_to_screen) {
+		if (RSG::rasterizer->is_using_gl_compatibility() && viewport->viewport_render_direct_to_screen) {
 			RSG::texture_storage->render_target_set_size(viewport->render_target, p_rect.size.x, p_rect.size.y, viewport->view_count);
 			RSG::texture_storage->render_target_set_position(viewport->render_target, p_rect.position.x, p_rect.position.y);
 		}
@@ -1047,7 +1047,7 @@ void RendererViewport::viewport_attach_to_screen(RID p_viewport, const Rect2 &p_
 		viewport->viewport_to_screen = p_screen;
 	} else {
 		// if render_direct_to_screen was used, reset size and position
-		if (RSG::rasterizer->is_low_end() && viewport->viewport_render_direct_to_screen) {
+		if (RSG::rasterizer->is_using_gl_compatibility() && viewport->viewport_render_direct_to_screen) {
 			RSG::texture_storage->render_target_set_position(viewport->render_target, 0, 0);
 			RSG::texture_storage->render_target_set_size(viewport->render_target, viewport->size.x, viewport->size.y, viewport->view_count);
 		}
@@ -1075,7 +1075,7 @@ void RendererViewport::viewport_set_render_direct_to_screen(RID p_viewport, bool
 	viewport->viewport_render_direct_to_screen = p_enable;
 
 	// if attached to screen already, setup screen size and position, this needs to happen after setting flag to avoid an unnecessary buffer allocation
-	if (RSG::rasterizer->is_low_end() && viewport->viewport_to_screen_rect != Rect2() && p_enable) {
+	if (RSG::rasterizer->is_using_gl_compatibility() && viewport->viewport_to_screen_rect != Rect2() && p_enable) {
 		RSG::texture_storage->render_target_set_size(viewport->render_target, viewport->viewport_to_screen_rect.size.x, viewport->viewport_to_screen_rect.size.y, viewport->view_count);
 		RSG::texture_storage->render_target_set_position(viewport->render_target, viewport->viewport_to_screen_rect.position.x, viewport->viewport_to_screen_rect.position.y);
 	}

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -355,8 +355,8 @@ void RenderingServerDefault::set_debug_generate_wireframes(bool p_generate) {
 	RSG::utilities->set_debug_generate_wireframes(p_generate);
 }
 
-bool RenderingServerDefault::is_low_end() const {
-	return RendererCompositor::is_low_end();
+bool RenderingServerDefault::is_using_gl_compatibility() const {
+	return RendererCompositor::is_using_gl_compatibility();
 }
 
 Size2i RenderingServerDefault::get_maximum_viewport_size() const {

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1165,7 +1165,7 @@ public:
 	virtual bool has_os_feature(const String &p_feature) const override;
 	virtual void set_debug_generate_wireframes(bool p_generate) override;
 
-	virtual bool is_low_end() const override;
+	virtual bool is_using_gl_compatibility() const override;
 
 	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) override;
 

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -43,7 +43,7 @@ static String _mktab(int p_level) {
 
 static String _typestr(SL::DataType p_type) {
 	String type = ShaderLanguage::get_datatype_name(p_type);
-	if (!RS::get_singleton()->is_low_end() && ShaderLanguage::is_sampler_type(p_type)) {
+	if (!RS::get_singleton()->is_using_gl_compatibility() && ShaderLanguage::is_sampler_type(p_type)) {
 		type = type.replace("sampler", "texture"); //we use textures instead of samplers in Vulkan GLSL
 	}
 	return type;
@@ -563,7 +563,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 
 				if (SL::is_sampler_type(uniform.type)) {
 					// Texture layouts are different for OpenGL GLSL and Vulkan GLSL
-					if (!RS::get_singleton()->is_low_end()) {
+					if (!RS::get_singleton()->is_using_gl_compatibility()) {
 						ucode = "layout(set = " + itos(actions.texture_layout_set) + ", binding = " + itos(actions.base_texture_binding_index + uniform.texture_binding) + ") ";
 					}
 					ucode += "uniform ";
@@ -714,7 +714,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 
 				vcode += ";\n";
 				// GLSL ES 3.0 does not allow layout qualifiers for varyings
-				if (!RS::get_singleton()->is_low_end()) {
+				if (!RS::get_singleton()->is_using_gl_compatibility()) {
 					r_gen_code.stage_globals[STAGE_VERTEX] += "layout(location=" + itos(index) + ") ";
 					r_gen_code.stage_globals[STAGE_FRAGMENT] += "layout(location=" + itos(index) + ") ";
 				}
@@ -1265,7 +1265,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 									break;
 							}
 
-							if (correct_texture_uniform && !RS::get_singleton()->is_low_end()) {
+							if (correct_texture_uniform && !RS::get_singleton()->is_using_gl_compatibility()) {
 								// Need to map from texture to sampler in order to sample when using Vulkan GLSL.
 								String sampler_name;
 								bool is_depth_texture = false;
@@ -1324,7 +1324,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 								}
 
 								code += data_type_name + "(" + node_code + ", " + sampler_name + ")";
-							} else if (actions.check_multiview_samplers && correct_texture_uniform && RS::get_singleton()->is_low_end()) {
+							} else if (actions.check_multiview_samplers && correct_texture_uniform && RS::get_singleton()->is_using_gl_compatibility()) {
 								// Texture function on low end hardware (i.e. OpenGL).
 								// We just need to know if the texture supports multiview.
 

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3629,7 +3629,7 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 				}
 
 				if (!fail) {
-					if (RenderingServer::get_singleton()->is_low_end()) {
+					if (RenderingServer::get_singleton()->is_using_gl_compatibility()) {
 						if (builtin_func_defs[idx].high_end) {
 							fail = true;
 							unsupported_builtin = true;
@@ -11166,7 +11166,7 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 				}
 
 				int idx = 0;
-				bool low_end = RenderingServer::get_singleton()->is_low_end();
+				bool using_gl_compatibility = RenderingServer::get_singleton()->is_using_gl_compatibility();
 
 				if (stages) {
 					// Stage functions can be used in custom functions as well, that why need to check them all.
@@ -11181,7 +11181,7 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 				}
 
 				while (builtin_func_defs[idx].name) {
-					if ((low_end && builtin_func_defs[idx].high_end) || _check_restricted_func(builtin_func_defs[idx].name, skip_function)) {
+					if ((using_gl_compatibility && builtin_func_defs[idx].high_end) || _check_restricted_func(builtin_func_defs[idx].name, skip_function)) {
 						idx++;
 						continue;
 					}
@@ -11192,10 +11192,10 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 
 			} else { // sub-class
 				int idx = 0;
-				bool low_end = RenderingServer::get_singleton()->is_low_end();
+				bool using_gl_compatibility = RenderingServer::get_singleton()->is_using_gl_compatibility();
 
 				while (builtin_func_defs[idx].name) {
-					if (low_end && builtin_func_defs[idx].high_end) {
+					if (using_gl_compatibility && builtin_func_defs[idx].high_end) {
 						idx++;
 						continue;
 					}
@@ -11352,10 +11352,10 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 			}
 
 			int idx = 0;
-			bool low_end = RenderingServer::get_singleton()->is_low_end();
+			bool using_gl_compatibility = RenderingServer::get_singleton()->is_using_gl_compatibility();
 
 			while (builtin_func_defs[idx].name) {
-				if ((low_end && builtin_func_defs[idx].high_end) || _check_restricted_func(builtin_func_defs[idx].name, block_function)) {
+				if ((using_gl_compatibility && builtin_func_defs[idx].high_end) || _check_restricted_func(builtin_func_defs[idx].name, block_function)) {
 					idx++;
 					continue;
 				}

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1786,7 +1786,7 @@ public:
 
 	virtual void call_set_vsync_mode(DisplayServer::VSyncMode p_mode, DisplayServer::WindowID p_window) = 0;
 
-	virtual bool is_low_end() const = 0;
+	virtual bool is_using_gl_compatibility() const = 0;
 
 	virtual void set_print_gpu_profile(bool p_enable) = 0;
 


### PR DESCRIPTION
This name is more explicit as for what the method actually does.

The original name dates back to Godot 3.1 when GLES2 was added alongside GLES3. There were only 2 rendering methods available in Godot 3.x, but we have 3 now.

Since this method isn't exposed to scripting, this doesn't break compatibility.
