### PR TITLE
Add helper methods for directions to Transform3D and Transform2D

### DIFF
--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -117,6 +117,11 @@ struct [[nodiscard]] Transform2D {
 
 	Transform2D interpolate_with(const Transform2D &p_transform, real_t p_c) const;
 
+	_FORCE_INLINE_ Vector2 right() const;
+	_FORCE_INLINE_ Vector2 left() const;
+	_FORCE_INLINE_ Vector2 up() const;
+	_FORCE_INLINE_ Vector2 down() const;
+
 	_FORCE_INLINE_ Vector2 basis_xform(const Vector2 &p_vec) const;
 	_FORCE_INLINE_ Vector2 basis_xform_inv(const Vector2 &p_vec) const;
 	_FORCE_INLINE_ Vector2 xform(const Vector2 &p_vec) const;
@@ -152,6 +157,22 @@ struct [[nodiscard]] Transform2D {
 		columns[1][1] = 1.0;
 	}
 };
+
+Vector2 Transform2D::right() const {
+    return columns[0].normalized();
+}
+
+Vector2 Transform2D::left() const {
+    return -columns[0].normalized();
+}
+
+Vector2 Transform2D::up() const {
+    return columns[1].normalized();
+}
+
+Vector2 Transform2D::down() const {
+    return -columns[1].normalized();
+}
 
 Vector2 Transform2D::basis_xform(const Vector2 &p_vec) const {
 	return Vector2(

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -159,19 +159,19 @@ struct [[nodiscard]] Transform2D {
 };
 
 Vector2 Transform2D::right() const {
-    return columns[0].normalized();
+	return columns[0].normalized();
 }
 
 Vector2 Transform2D::left() const {
-    return -columns[0].normalized();
+	return -columns[0].normalized();
 }
 
 Vector2 Transform2D::up() const {
-    return columns[1].normalized();
+	return columns[1].normalized();
 }
 
 Vector2 Transform2D::down() const {
-    return -columns[1].normalized();
+	return -columns[1].normalized();
 }
 
 Vector2 Transform2D::basis_xform(const Vector2 &p_vec) const {

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -138,27 +138,27 @@ struct [[nodiscard]] Transform3D {
 };
 
 _FORCE_INLINE_ Vector3 Transform3D::right() const {
-	return basis[0].normalized();
+	return basis.get_column(0).normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::left() const {
-	return -basis[0].normalized();
+	return -basis.get_column(0).normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::up() const {
-	return basis[1].normalized();
+	return basis.get_column(1).normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::down() const {
-	return -basis[1].normalized();
+	return -basis.get_column(1).normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::forward() const {
-	return -basis[2].normalized();
+	return -basis.get_column(2).normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::back() const {
-	return basis[2].normalized();
+	return basis.get_column(2).normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::xform(const Vector3 &p_vector) const {

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -138,27 +138,27 @@ struct [[nodiscard]] Transform3D {
 };
 
 _FORCE_INLINE_ Vector3 Transform3D::right() const {
-    return basis[0].normalized();
+	return basis[0].normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::left() const {
-    return -basis[0].normalized();
+	return -basis[0].normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::up() const {
-    return basis[1].normalized();
+	return basis[1].normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::down() const {
-    return -basis[1].normalized();
+	return -basis[1].normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::forward() const {
-    return -basis[2].normalized();
+	return -basis[2].normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::back() const {
-    return basis[2].normalized();
+	return basis[2].normalized();
 }
 
 _FORCE_INLINE_ Vector3 Transform3D::xform(const Vector3 &p_vector) const {

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -80,6 +80,13 @@ struct [[nodiscard]] Transform3D {
 	bool operator==(const Transform3D &p_transform) const;
 	bool operator!=(const Transform3D &p_transform) const;
 
+	_FORCE_INLINE_ Vector3 right() const;
+	_FORCE_INLINE_ Vector3 left() const;
+	_FORCE_INLINE_ Vector3 up() const;
+	_FORCE_INLINE_ Vector3 down() const;
+	_FORCE_INLINE_ Vector3 forward() const;
+	_FORCE_INLINE_ Vector3 back() const;
+
 	_FORCE_INLINE_ Vector3 xform(const Vector3 &p_vector) const;
 	_FORCE_INLINE_ AABB xform(const AABB &p_aabb) const;
 	_FORCE_INLINE_ Vector<Vector3> xform(const Vector<Vector3> &p_array) const;
@@ -129,6 +136,30 @@ struct [[nodiscard]] Transform3D {
 	Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin);
 	Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz);
 };
+
+_FORCE_INLINE_ Vector3 Transform3D::right() const {
+    return basis[0].normalized();
+}
+
+_FORCE_INLINE_ Vector3 Transform3D::left() const {
+    return -basis[0].normalized();
+}
+
+_FORCE_INLINE_ Vector3 Transform3D::up() const {
+    return basis[1].normalized();
+}
+
+_FORCE_INLINE_ Vector3 Transform3D::down() const {
+    return -basis[1].normalized();
+}
+
+_FORCE_INLINE_ Vector3 Transform3D::forward() const {
+    return -basis[2].normalized();
+}
+
+_FORCE_INLINE_ Vector3 Transform3D::back() const {
+    return basis[2].normalized();
+}
 
 _FORCE_INLINE_ Vector3 Transform3D::xform(const Vector3 &p_vector) const {
 	return Vector3(

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2193,6 +2193,10 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Transform2D, is_conformal, sarray(), varray());
 	bind_method(Transform2D, is_equal_approx, sarray("xform"), varray());
 	bind_method(Transform2D, is_finite, sarray(), varray());
+	bind_method(Transform2D, left, sarray(), varray());
+	bind_method(Transform2D, right, sarray(), varray());
+	bind_method(Transform2D, up, sarray(), varray());
+	bind_method(Transform2D, down, sarray(), varray());
 	// Do not bind functions like set_rotation, set_scale, set_skew, etc because this type is immutable and can't be modified.
 	bind_method(Transform2D, looking_at, sarray("target"), varray(Vector2()));
 
@@ -2261,6 +2265,12 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Transform3D, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, is_equal_approx, sarray("xform"), varray());
 	bind_method(Transform3D, is_finite, sarray(), varray());
+	bind_method(Transform3D, left, sarray(), varray());
+	bind_method(Transform3D, right, sarray(), varray());
+	bind_method(Transform3D, forward, sarray(), varray());
+	bind_method(Transform3D, back, sarray(), varray());
+	bind_method(Transform3D, up, sarray(), varray());
+	bind_method(Transform3D, down, sarray(), varray());
 
 	/* Projection */
 

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -242,6 +242,30 @@
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>
+		<method name="left" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the left direction vector of this transform.
+			</description>
+		</method>
+		<method name="right" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the right direction vector of this transform.
+			</description>
+		</method>
+		<method name="up" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the upward direction vector of this transform.
+			</description>
+		</method>
+		<method name="down" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the downward direction vector of this transform.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="origin" type="Vector2" setter="" getter="" default="Vector2(0, 0)">

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -170,6 +170,42 @@
 				This can be seen as transforming with respect to the local frame.
 			</description>
 		</method>
+		<method name="left" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the left direction vector of this transform.
+			</description>
+		</method>
+		<method name="right" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the right direction vector of this transform.
+			</description>
+		</method>
+		<method name="forward" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the forward direction vector of this transform.
+			</description>
+		</method>
+		<method name="back" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the back (opposite of forward) direction vector of this transform.
+			</description>
+		</method>
+		<method name="up" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the upward direction vector of this transform.
+			</description>
+		</method>
+		<method name="down" qualifiers="const">
+			<return type="Vector3" />
+			<description>
+				Returns the downward direction vector of this transform.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="basis" type="Basis" setter="" getter="" default="Basis(1, 0, 0, 0, 1, 0, 0, 0, 1)">


### PR DESCRIPTION
This was added in response to [this related issue](https://github.com/godotengine/godot-proposals/issues/5074) that I came across when experiencing the same issue.

This is my first time committing to Godot, or any open source project for that matter, so please excuse me if I missed a step somewhere.
