### PR TITLE
[3.x] Enable builds with miniupnpc API 18

### DIFF
--- a/modules/upnp/upnp.cpp
+++ b/modules/upnp/upnp.cpp
@@ -145,7 +145,11 @@ void UPNP::parse_igd(Ref<UPNPDevice> dev, UPNPDev *devlist) {
 	}
 
 	char addr[16];
+#if MINIUPNPC_API_VERSION >= 18
+	int i = UPNP_GetValidIGD(devlist, urls, &data, (char *)&addr, 16, nullptr, 0);
+#else
 	int i = UPNP_GetValidIGD(devlist, urls, &data, (char *)&addr, 16);
+#endif
 
 	if (i != 1) {
 		FreeUPNPUrls(urls);


### PR DESCRIPTION
Backports https://github.com/godotengine/godot/pull/97139 without bumping the embedded miniupnpc library.

I recognize that the maintainers typically cherry-pick in batches, but since #97139 was not marked for cherry-picking to 3.x I figured I would manually do it.

This is to get Godot 3.6 packaged in Debian, which is on miniupnpc 2.2.8 (API 18).
