### PR TITLE
Fix: `RayCast3D.get_collider` does not return a `CollisionShape3D`

### DIFF
--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -85,7 +85,9 @@ Object *RayCast3D::get_collider() const {
 		return nullptr;
 	}
 
-	return ObjectDB::get_instance(against);
+	Object *object = ObjectDB::get_instance(against);
+
+	return Object::cast_to<CollisionObject3D>(object);
 }
 
 RID RayCast3D::get_collider_rid() const {


### PR DESCRIPTION
- Modified the `RayCast3D.get_collider()` function to ensure it only returns `CollisionObject3D` instances.
- The function now uses `Object::cast_to<CollisionObject3D>(object)` to perform a safe cast and return null if the object is not of the expected type.
- This resolves issues where `RayCast3D.get_collider()` could return objects like `CSGShape3D`, leading to runtime errors and incorrect behavior.

Fixes: #100139

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
