### PR TITLE
Allow using any-case constants in Expression

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -441,36 +441,37 @@ Error Expression::_get_token(Token &r_token) {
 
 					str_ofs--; //go back one
 
-					if (id == "in") {
+					const String lowercase_id = id.to_lower();
+					if (lowercase_id == "in") {
 						r_token.type = TK_OP_IN;
-					} else if (id == "null") {
+					} else if (lowercase_id == "null") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = Variant();
-					} else if (id == "true") {
+					} else if (lowercase_id == "true") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = true;
-					} else if (id == "false") {
+					} else if (lowercase_id == "false") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = false;
-					} else if (id == "PI") {
+					} else if (lowercase_id == "pi") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = Math::PI;
-					} else if (id == "TAU") {
+					} else if (lowercase_id == "tau") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = Math::TAU;
-					} else if (id == "INF") {
+					} else if (lowercase_id == "inf") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = Math::INF;
-					} else if (id == "NAN") {
+					} else if (lowercase_id == "nan") {
 						r_token.type = TK_CONSTANT;
 						r_token.value = Math::NaN;
-					} else if (id == "not") {
+					} else if (lowercase_id == "not") {
 						r_token.type = TK_OP_NOT;
-					} else if (id == "or") {
+					} else if (lowercase_id == "or") {
 						r_token.type = TK_OP_OR;
-					} else if (id == "and") {
+					} else if (lowercase_id == "and") {
 						r_token.type = TK_OP_AND;
-					} else if (id == "self") {
+					} else if (lowercase_id == "self") {
 						r_token.type = TK_SELF;
 					} else {
 						{


### PR DESCRIPTION
This is a general usability improvement for people using the Expression class with user-supplied input, such as the Godot editor inspector. This way, users will not have to capitalize things like `pi/2`, it will just work. Without this change, users would have to write `PI/2`, `PI / 2`, or similar.

This won't break user code unless they were using `pi`, `tau`, `inf`, or `nan` as variable names, but I doubt that.

EDIT: Updated the PR to support any casing. `pi`, `PI`, `Pi`, `pI`, `true`, `True`, `TRUE`, etc.