### PR TITLE
Support `OS::request_permission("CAMERA")` on linuxbsd using XDG Desktop Portal

### DIFF
--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -52,6 +52,15 @@
 #define BUS_INTERFACE_SETTINGS "org.freedesktop.portal.Settings"
 #define BUS_INTERFACE_FILE_CHOOSER "org.freedesktop.portal.FileChooser"
 
+FreeDesktopPortalDesktop *FreeDesktopPortalDesktop::singleton = nullptr;
+
+FreeDesktopPortalDesktop *FreeDesktopPortalDesktop::get_singleton() {
+	if (singleton == nullptr) {
+		singleton = memnew(FreeDesktopPortalDesktop);
+	}
+	return singleton;
+}
+
 bool FreeDesktopPortalDesktop::try_parse_variant(DBusMessage *p_reply_message, int p_type, void *r_value) {
 	DBusMessageIter iter[3];
 

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -61,6 +61,11 @@ private:
 	static void append_dbus_dict_bool(DBusMessageIter *p_iter, const String &p_key, bool p_value);
 	static bool file_chooser_parse_response(DBusMessageIter *p_iter, const Vector<String> &p_names, const HashMap<String, String> &p_ids, bool &r_cancel, Vector<String> &r_urls, int &r_index, Dictionary &r_options);
 
+	struct AccessCameraData {
+		String filter;
+		String path;
+	};
+
 	struct FileDialogData {
 		Vector<String> filter_names;
 		HashMap<String, String> option_ids;
@@ -81,6 +86,8 @@ private:
 	};
 	List<FileDialogCallback> pending_cbs;
 
+	Mutex access_camera_mutex;
+	Vector<AccessCameraData> access_camera_data;
 	Mutex file_dialog_mutex;
 	Vector<FileDialogData> file_dialogs;
 	Thread monitor_thread;
@@ -97,6 +104,8 @@ public:
 	static FreeDesktopPortalDesktop *get_singleton();
 
 	bool is_supported() { return !unsupported; }
+
+	bool access_camera();
 
 	Error file_dialog_show(DisplayServer::WindowID p_window_id, const String &p_xid, const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, DisplayServer::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb);
 	void process_file_dialog_callbacks();

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -43,6 +43,11 @@ struct DBusMessageIter;
 
 class FreeDesktopPortalDesktop : public Object {
 private:
+	FreeDesktopPortalDesktop();
+	~FreeDesktopPortalDesktop();
+
+	static FreeDesktopPortalDesktop *singleton;
+
 	bool unsupported = false;
 
 	static bool try_parse_variant(DBusMessage *p_reply_message, int p_type, void *r_value);
@@ -89,8 +94,7 @@ private:
 	static void _thread_monitor(void *p_ud);
 
 public:
-	FreeDesktopPortalDesktop();
-	~FreeDesktopPortalDesktop();
+	static FreeDesktopPortalDesktop *get_singleton();
 
 	bool is_supported() { return !unsupported; }
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -44,6 +44,10 @@
 #include "wayland/display_server_wayland.h"
 #endif
 
+#ifdef DBUS_ENABLED
+#include "freedesktop_portal_desktop.h"
+#endif
+
 #include "modules/modules_enabled.gen.h" // For regex.
 #ifdef MODULE_REGEX_ENABLED
 #include "modules/regex/regex.h"
@@ -213,6 +217,19 @@ bool OS_LinuxBSD::is_sandboxed() const {
 
 	return false;
 }
+
+#ifdef DBUS_ENABLED
+bool OS_LinuxBSD::request_permission(const String &p_name) {
+	if (p_name == "CAMERA") {
+		if (FreeDesktopPortalDesktop::get_singleton()->access_camera()) {
+			// Always return false here, because we cannot know if permission is granted in advance.
+			return false;
+		}
+		// Desktop portal is not available in this case, return true like every other permission does.
+	}
+	return true;
+}
+#endif
 
 void OS_LinuxBSD::finalize() {
 	if (main_loop) {

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -125,6 +125,10 @@ public:
 
 	virtual bool is_sandboxed() const override;
 
+#ifdef DBUS_ENABLED
+	virtual bool request_permission(const String &p_name) override;
+#endif
+
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1543,7 +1543,7 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 #endif // RD_ENABLED
 
 #ifdef DBUS_ENABLED
-	portal_desktop = memnew(FreeDesktopPortalDesktop);
+	portal_desktop = FreeDesktopPortalDesktop::get_singleton();
 	screensaver = memnew(FreeDesktopScreenSaver);
 #endif // DBUS_ENABLED
 
@@ -1604,8 +1604,7 @@ DisplayServerWayland::~DisplayServerWayland() {
 #endif
 
 #ifdef DBUS_ENABLED
-	if (portal_desktop) {
-		memdelete(portal_desktop);
+	if (screensaver) {
 		memdelete(screensaver);
 	}
 #endif

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -6864,7 +6864,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	screensaver = memnew(FreeDesktopScreenSaver);
 	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
 
-	portal_desktop = memnew(FreeDesktopPortalDesktop);
+	portal_desktop = FreeDesktopPortalDesktop::get_singleton();
 #endif // DBUS_ENABLED
 
 	XSetErrorHandler(&default_window_error_handler);
@@ -6989,7 +6989,6 @@ DisplayServerX11::~DisplayServerX11() {
 
 #ifdef DBUS_ENABLED
 	memdelete(screensaver);
-	memdelete(portal_desktop);
 #endif
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This change enables requesting camera access permission from XDG desktop portal, can be useful in sandboxed environment.