### PR TITLE
[FileAccess] Add method to abort backup save without overwriting original file, fail editor save operations on write errors.

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -846,4 +846,22 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define PHYSICS_INTERPOLATION_WARNING(m_string) \
 	_physics_interpolation_warning(FUNCTION_STR, __FILE__, __LINE__, ObjectID(UINT64_MAX), m_string)
 
+/**
+ * Try writing to file and restore backup on failure (use only if FileAccess::set_backup_save is enabled).
+ */
+
+#define FAIL_ON_WRITE_ERR(m_file, m_write_op)                                                            \
+	if (!m_file->m_write_op) {                                                                           \
+		m_file->abort_backup_save_and_close();                                                           \
+		ERR_FAIL_MSG(vformat("File write error at '%s': %d.", m_file->get_path(), m_file->get_error())); \
+	} else                                                                                               \
+		((void)0)
+
+#define FAIL_ON_WRITE_ERR_V(m_file, m_write_op, m_retval)                                                            \
+	if (!m_file->m_write_op) {                                                                                       \
+		m_file->abort_backup_save_and_close();                                                                       \
+		ERR_FAIL_V_MSG(m_retval, vformat("File write error at '%s': %d.", m_file->get_path(), m_file->get_error())); \
+	} else                                                                                                           \
+		((void)0)
+
 #endif // ERROR_MACROS_H

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1308,7 +1308,7 @@ void GDExtensionAPIDump::generate_extension_json_file(const String &p_path, bool
 	String text = json->stringify(api, "\t", false) + "\n";
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_MSG(fa.is_null(), vformat("Cannot open file '%s' for writing.", p_path));
-	fa->store_string(text);
+	ERR_FAIL_COND_MSG(!fa->store_string(text), vformat("Cannot write to file '%s'.", p_path));
 }
 
 static bool compare_value(const String &p_path, const String &p_field, const Variant &p_old_value, const Variant &p_new_value, bool p_allow_name_change) {

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1063,6 +1063,11 @@ static void gdextension_file_access_store_buffer(GDExtensionObjectPtr p_instance
 	fa->store_buffer(p_src, p_length);
 }
 
+static GDExtensionBool gdextension_file_access_store_buffer2(GDExtensionObjectPtr p_instance, const uint8_t *p_src, uint64_t p_length) {
+	FileAccess *fa = (FileAccess *)p_instance;
+	return fa->store_buffer(p_src, p_length);
+}
+
 static uint64_t gdextension_file_access_get_buffer(GDExtensionConstObjectPtr p_instance, uint8_t *p_dst, uint64_t p_length) {
 	const FileAccess *fa = (FileAccess *)p_instance;
 	return fa->get_buffer(p_dst, p_length);
@@ -1826,6 +1831,7 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(editor_help_load_xml_from_utf8_chars_and_len);
 	REGISTER_INTERFACE_FUNC(image_ptrw);
 	REGISTER_INTERFACE_FUNC(image_ptr);
+	REGISTER_INTERFACE_FUNC(file_access_store_buffer2);
 }
 
 #undef REGISTER_INTERFACE_FUNCTION

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -3075,6 +3075,22 @@ typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8Chars)(const char *
  */
 typedef void (*GDExtensionsInterfaceEditorHelpLoadXmlFromUtf8CharsAndLen)(const char *p_data, GDExtensionInt p_size);
 
+/**
+ * @name file_access_store_buffer2
+ * @since 4.3
+ *
+ * Stores the given buffer using an instance of FileAccess.
+ *
+ * @param p_instance A pointer to a FileAccess object.
+ * @param p_src A pointer to the buffer.
+ * @param p_length The size of the buffer.
+ *
+ * @return true if the operation is valid; otherwise false.
+ *
+ * @see FileAccess::store_buffer()
+ */
+typedef GDExtensionBool (*GDExtensionInterfaceFileAccessStoreBuffer2)(GDExtensionObjectPtr p_instance, const uint8_t *p_src, uint64_t p_length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -315,7 +315,10 @@ bool GDExtensionManager::ensure_extensions_loaded(const HashSet<String> &p_exten
 			// Extensions were added or removed.
 			Ref<FileAccess> f = FileAccess::open(extension_list_config_file, FileAccess::WRITE);
 			for (const String &E : p_extensions) {
-				f->store_line(E);
+				if (!f->store_line(E)) {
+					f->abort_backup_save_and_close();
+					break;
+				}
 			}
 		}
 	} else {

--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -44,7 +44,7 @@ class GDExtensionInterfaceDump {
             data.resize(_gdextension_interface_data_uncompressed_size);
             int ret = Compression::decompress(data.ptrw(), _gdextension_interface_data_uncompressed_size, _gdextension_interface_data_compressed, _gdextension_interface_data_compressed_size, Compression::MODE_DEFLATE);
             ERR_FAIL_COND_MSG(ret == -1, "Compressed file is corrupt.");
-            fa->store_buffer(data.ptr(), data.size());
+            ERR_FAIL_COND_MSG(!fa->store_buffer(data.ptr(), data.size()), vformat("Cannot write to file '%s'.", p_path));
         };
 };
 

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -205,16 +205,16 @@ Error ConfigFile::_internal_save(Ref<FileAccess> file) {
 		if (first) {
 			first = false;
 		} else {
-			file->store_string("\n");
+			FAIL_ON_WRITE_ERR_V(file, store_string("\n"), ERR_FILE_CANT_WRITE);
 		}
 		if (!E.key.is_empty()) {
-			file->store_string("[" + E.key.replace("]", "\\]") + "]\n\n");
+			FAIL_ON_WRITE_ERR_V(file, store_string("[" + E.key.replace("]", "\\]") + "]\n\n"), ERR_FILE_CANT_WRITE);
 		}
 
 		for (const KeyValue<String, Variant> &F : E.value) {
 			String vstr;
 			VariantWriter::write_to_string(F.value, vstr);
-			file->store_string(F.key.property_name_encode() + "=" + vstr + "\n");
+			FAIL_ON_WRITE_ERR_V(file, store_string(F.key.property_name_encode() + "=" + vstr + "\n"), ERR_FILE_CANT_WRITE);
 		}
 	}
 

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -448,9 +448,13 @@ Error DirAccess::copy(const String &p_from, const String &p_to, int p_chmod_flag
 				err = FAILED;
 				break;
 			}
-			fdst->store_buffer(buffer.ptr(), bytes_read);
+			FAIL_ON_WRITE_ERR_V(fdst, store_buffer(buffer.ptr(), bytes_read), ERR_FILE_CANT_WRITE);
 
 			size -= bytes_read;
+		}
+
+		if (err != OK) {
+			fdst->abort_backup_save_and_close();
 		}
 	}
 

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -960,6 +960,7 @@ void FileAccess::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_pascal_string"), &FileAccess::get_pascal_string);
 
 	ClassDB::bind_method(D_METHOD("close"), &FileAccess::close);
+	ClassDB::bind_method(D_METHOD("abort_backup_save_and_close"), &FileAccess::abort_backup_save_and_close);
 
 	ClassDB::bind_static_method("FileAccess", D_METHOD("file_exists", "path"), &FileAccess::exists);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_modified_time", "file"), &FileAccess::get_modified_time);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -221,6 +221,7 @@ public:
 	bool store_var(const Variant &p_var, bool p_full_objects = false);
 
 	virtual void close() = 0;
+	virtual void abort_backup_save_and_close() { close(); }
 
 	virtual bool file_exists(const String &p_name) = 0; ///< return true if a file exists
 

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1663,11 +1663,7 @@ Error ResourceFormatSaverJSON::save(const Ref<Resource> &p_resource, const Strin
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Cannot save json '%s'.", p_path));
-
-	file->store_string(source);
-	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
-		return ERR_CANT_CREATE;
-	}
+	FAIL_ON_WRITE_ERR_V(file, store_string(source), ERR_CANT_CREATE);
 
 	return OK;
 }

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -97,7 +97,7 @@ Error RemoteFilesystemClient::_store_file(const String &p_path, const LocalVecto
 
 	Ref<FileAccess> f = FileAccess::open(full_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_FILE_CANT_OPEN, vformat("Unable to open file for writing to remote filesystem cache: '%s'.", p_path));
-	f->store_buffer(p_file.ptr(), p_file.size());
+	FAIL_ON_WRITE_ERR_V(f, store_buffer(p_file.ptr(), p_file.size()), ERR_FILE_CANT_WRITE);
 	Error err = f->get_error();
 	if (err) {
 		return err;
@@ -119,10 +119,10 @@ Error RemoteFilesystemClient::_store_cache_file(const Vector<FileCache> &p_cache
 
 	Ref<FileAccess> f = FileAccess::open(full_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_FILE_CANT_OPEN, vformat("Unable to open the remote cache file for writing: '%s'.", full_path));
-	f->store_line(itos(FILESYSTEM_CACHE_VERSION));
+	FAIL_ON_WRITE_ERR_V(f, store_line(itos(FILESYSTEM_CACHE_VERSION)), ERR_FILE_CANT_WRITE);
 	for (int i = 0; i < p_cache.size(); i++) {
 		String l = p_cache[i].path + "::" + itos(p_cache[i].server_modified_time) + "::" + itos(p_cache[i].modified_time);
-		f->store_line(l);
+		FAIL_ON_WRITE_ERR_V(f, store_line(l), ERR_FILE_CANT_WRITE);
 	}
 	return OK;
 }

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -159,9 +159,9 @@ class ResourceFormatSaverBinaryInstance {
 		List<Property> properties;
 	};
 
-	static void _pad_buffer(Ref<FileAccess> f, int p_bytes);
+	static bool _pad_buffer(Ref<FileAccess> f, int p_bytes);
 	void _find_resources(const Variant &p_variant, bool p_main = false);
-	static void save_unicode_string(Ref<FileAccess> f, const String &p_string, bool p_bit_on_len = false);
+	static bool save_unicode_string(Ref<FileAccess> f, const String &p_string, bool p_bit_on_len = false);
 	int get_string_index(const String &p_string);
 
 public:
@@ -176,7 +176,7 @@ public:
 	};
 	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
 	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
-	static void write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
+	static bool write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
 };
 
 class ResourceFormatSaverBinary : public ResourceFormatSaver {

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -173,15 +173,15 @@ Error ResourceUID::save_to_cache() {
 	}
 
 	MutexLock l(mutex);
-	f->store_32(unique_ids.size());
+	FAIL_ON_WRITE_ERR_V(f, store_32(unique_ids.size()), ERR_FILE_CANT_WRITE);
 
 	cache_entries = 0;
 
 	for (KeyValue<ID, Cache> &E : unique_ids) {
-		f->store_64(E.key);
+		FAIL_ON_WRITE_ERR_V(f, store_64(E.key), ERR_FILE_CANT_WRITE);
 		uint32_t s = E.value.cs.length();
-		f->store_32(s);
-		f->store_buffer((const uint8_t *)E.value.cs.ptr(), s);
+		FAIL_ON_WRITE_ERR_V(f, store_32(s), ERR_FILE_CANT_WRITE);
+		FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)E.value.cs.ptr(), s), ERR_FILE_CANT_WRITE);
 		E.value.saved_to_cache = true;
 		cache_entries++;
 	}
@@ -241,10 +241,10 @@ Error ResourceUID::update_cache() {
 				}
 				f->seek_end();
 			}
-			f->store_64(E.key);
+			FAIL_ON_WRITE_ERR_V(f, store_64(E.key), ERR_FILE_CANT_WRITE);
 			uint32_t s = E.value.cs.length();
-			f->store_32(s);
-			f->store_buffer((const uint8_t *)E.value.cs.ptr(), s);
+			FAIL_ON_WRITE_ERR_V(f, store_32(s), ERR_FILE_CANT_WRITE);
+			FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)E.value.cs.ptr(), s), ERR_FILE_CANT_WRITE);
 			E.value.saved_to_cache = true;
 			cache_entries++;
 		}
@@ -252,7 +252,7 @@ Error ResourceUID::update_cache() {
 
 	if (f.is_valid()) {
 		f->seek(0);
-		f->store_32(cache_entries); //update amount of entries
+		FAIL_ON_WRITE_ERR_V(f, store_32(cache_entries), ERR_FILE_CANT_WRITE); //update amount of entries
 	}
 
 	changed = false;

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -111,7 +111,7 @@ uLong zipio_write(voidpf opaque, voidpf stream, const void *buf, uLong size) {
 	ERR_FAIL_NULL_V(fa, 0);
 	ERR_FAIL_COND_V(fa->is_null(), 0);
 
-	(*fa)->store_buffer((uint8_t *)buf, size);
+	ERR_FAIL_COND_V(!(*fa)->store_buffer((uint8_t *)buf, size), 0);
 	return size;
 }
 

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -43,6 +43,12 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/2755</link>
 	</tutorials>
 	<methods>
+		<method name="abort_backup_save_and_close">
+			<return type="void" />
+			<description>
+				Closes the currently opened file and prevents subsequent read/write operations. If [method OS.set_use_file_access_save_and_swap] is set to [code]true[/code], the temporary file is removed, and the original file is not modified.
+			</description>
+		</method>
 		<method name="close">
 			<return type="void" />
 			<description>

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -57,10 +57,7 @@ Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img
 
 	const uint8_t *reader = buffer.ptr();
 
-	file->store_buffer(reader, buffer.size());
-	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
-		return ERR_CANT_CREATE;
-	}
+	FAIL_ON_WRITE_ERR_V(file, store_buffer(reader, buffer.size()), ERR_CANT_CREATE);
 
 	return OK;
 }

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -166,6 +166,26 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
+void FileAccessUnix::abort_backup_save_and_close() {
+	if (!f) {
+		return;
+	}
+
+	fclose(f);
+	f = nullptr;
+
+	if (!save_path.is_empty()) {
+		save_path = "";
+
+		const CharString &path_utf8 = path.utf8();
+		::unlink(path_utf8.ptr());
+	}
+
+	if (close_notification_func) {
+		close_notification_func(path, flags);
+	}
+}
+
 void FileAccessUnix::_close() {
 	if (!f) {
 		return;

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -91,6 +91,7 @@ public:
 	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override;
 
 	virtual void close() override;
+	virtual void abort_backup_save_and_close() override;
 
 	FileAccessUnix() {}
 	virtual ~FileAccessUnix();

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -193,7 +193,7 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 	}
 #endif
 
-	if (is_backup_save_enabled() && p_mode_flags == WRITE) {
+	if (is_backup_save_enabled() && (p_mode_flags == WRITE)) {
 		save_path = path;
 		// Create a temporary file in the same directory as the target file.
 		// Note: do not use GetTempFileNameW, it's not long path aware!
@@ -230,6 +230,22 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 		last_error = OK;
 		flags = p_mode_flags;
 		return OK;
+	}
+}
+
+void FileAccessWindows::abort_backup_save_and_close() {
+	if (!f) {
+		return;
+	}
+
+	fclose(f);
+	f = nullptr;
+
+	if (!save_path.is_empty()) {
+		save_path = "";
+
+		const Char16String &path_utf16 = path.utf16();
+		DeleteFileW((LPCWSTR)(path_utf16.get_data()));
 	}
 }
 

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -89,6 +89,7 @@ public:
 	virtual Error _set_read_only_attribute(const String &p_file, bool p_ro) override;
 
 	virtual void close() override;
+	virtual void abort_backup_save_and_close() override;
 
 	static void initialize();
 	static void finalize();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -182,7 +182,7 @@ void ScriptEditorDebugger::_file_selected(const String &p_file) {
 			for (int i = 0; i < Performance::MONITOR_MAX; i++) {
 				line.write[i] = Performance::get_singleton()->get_monitor_name(Performance::Monitor(i));
 			}
-			file->store_csv_line(line);
+			FAIL_ON_WRITE_ERR(file, store_csv_line(line));
 
 			// values
 			Vector<List<float>::Element *> iterators;
@@ -203,13 +203,13 @@ void ScriptEditorDebugger::_file_selected(const String &p_file) {
 					}
 					continue_iteration = continue_iteration || iterators[i];
 				}
-				file->store_csv_line(line);
+				FAIL_ON_WRITE_ERR(file, store_csv_line(line));
 			}
-			file->store_string("\n");
+			FAIL_ON_WRITE_ERR(file, store_string("\n"));
 
 			Vector<Vector<String>> profiler_data = profiler->get_data_as_csv();
 			for (int i = 0; i < profiler_data.size(); i++) {
-				file->store_csv_line(profiler_data[i]);
+				FAIL_ON_WRITE_ERR(file, store_csv_line(profiler_data[i]));
 			}
 		} break;
 		case SAVE_VRAM_CSV: {
@@ -226,7 +226,7 @@ void ScriptEditorDebugger::_file_selected(const String &p_file) {
 			for (int i = 0; i < vmem_tree->get_columns(); ++i) {
 				headers.write[i] = vmem_tree->get_column_title(i);
 			}
-			file->store_csv_line(headers);
+			FAIL_ON_WRITE_ERR(file, store_csv_line(headers));
 
 			if (vmem_tree->get_root()) {
 				TreeItem *ti = vmem_tree->get_root()->get_first_child();
@@ -236,7 +236,7 @@ void ScriptEditorDebugger::_file_selected(const String &p_file) {
 					for (int i = 0; i < vmem_tree->get_columns(); ++i) {
 						values.write[i] = ti->get_text(i);
 					}
-					file->store_csv_line(values);
+					FAIL_ON_WRITE_ERR(file, store_csv_line(values));
 
 					ti = ti->get_next();
 				}

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -551,9 +551,9 @@ void EditorAssetInstaller::_install_asset() {
 			da->make_dir_recursive(target_path.get_base_dir());
 
 			Ref<FileAccess> f = FileAccess::open(target_path, FileAccess::WRITE);
-			if (f.is_valid()) {
-				f->store_buffer(uncomp_data.ptr(), uncomp_data.size());
-			} else {
+			if (!f.is_valid()) {
+				failed_files.push_back(target_path);
+			} else if (!f->store_buffer(uncomp_data.ptr(), uncomp_data.size())) {
 				failed_files.push_back(target_path);
 			}
 

--- a/editor/editor_build_profile.cpp
+++ b/editor/editor_build_profile.cpp
@@ -258,7 +258,7 @@ Error EditorBuildProfile::save_to_file(const String &p_path) {
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
 
 	String text = JSON::stringify(data, "\t");
-	f->store_string(text);
+	FAIL_ON_WRITE_ERR_V(f, store_string(text), ERR_FILE_CANT_WRITE);
 	return OK;
 }
 
@@ -511,7 +511,10 @@ void EditorBuildProfileManager::_detect_classes() {
 			l += c;
 			used_classes.insert(c);
 		}
-		f->store_line(l);
+		if (!f->store_line(l)) {
+			f->abort_backup_save_and_close();
+			break;
+		}
 	}
 
 	f.unref();

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -211,7 +211,7 @@ Error EditorFeatureProfile::save_to_file(const String &p_path) {
 
 	JSON json;
 	String text = json.stringify(data, "\t");
-	f->store_string(text);
+	FAIL_ON_WRITE_ERR_V(f, store_string(text), ERR_FILE_CANT_WRITE);
 	return OK;
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1456,7 +1456,10 @@ void EditorNode::ensure_uid_file(const String &p_new_resource_path) {
 		Ref<FileAccess> f = FileAccess::open(p_new_resource_path + ".uid", FileAccess::WRITE);
 		if (f.is_valid()) {
 			const ResourceUID::ID id = ResourceUID::get_singleton()->create_id();
-			f->store_line(ResourceUID::get_singleton()->id_to_text(id));
+			if (!f->store_line(ResourceUID::get_singleton()->id_to_text(id))) {
+				f->abort_backup_save_and_close();
+				ERR_PRINT("Cannot write file '" + p_new_resource_path + ".uid'.");
+			}
 		}
 	}
 }

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -383,12 +383,12 @@ void EditorResourcePreview::_iterate() {
 }
 
 void EditorResourcePreview::_write_preview_cache(Ref<FileAccess> p_file, int p_thumbnail_size, bool p_has_small_texture, uint64_t p_modified_time, const String &p_hash, const Dictionary &p_metadata) {
-	p_file->store_line(itos(p_thumbnail_size));
-	p_file->store_line(itos(p_has_small_texture));
-	p_file->store_line(itos(p_modified_time));
-	p_file->store_line(p_hash);
-	p_file->store_line(VariantUtilityFunctions::var_to_str(p_metadata).replace("\n", " "));
-	p_file->store_line(itos(CURRENT_METADATA_VERSION));
+	FAIL_ON_WRITE_ERR(p_file, store_line(itos(p_thumbnail_size)));
+	FAIL_ON_WRITE_ERR(p_file, store_line(itos(p_has_small_texture)));
+	FAIL_ON_WRITE_ERR(p_file, store_line(itos(p_modified_time)));
+	FAIL_ON_WRITE_ERR(p_file, store_line(p_hash));
+	FAIL_ON_WRITE_ERR(p_file, store_line(VariantUtilityFunctions::var_to_str(p_metadata).replace("\n", " ")));
+	FAIL_ON_WRITE_ERR(p_file, store_line(itos(CURRENT_METADATA_VERSION)));
 }
 
 void EditorResourcePreview::_read_preview_cache(Ref<FileAccess> p_file, int *r_thumbnail_size, bool *r_has_small_texture, uint64_t *r_modified_time, String *r_hash, Dictionary *r_metadata, bool *r_outdated) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1502,7 +1502,7 @@ void EditorSettings::set_favorites(const Vector<String> &p_favorites) {
 	Ref<FileAccess> f = FileAccess::open(favorites_file, FileAccess::WRITE);
 	if (f.is_valid()) {
 		for (int i = 0; i < favorites.size(); i++) {
-			f->store_line(favorites[i]);
+			FAIL_ON_WRITE_ERR(f, store_line(favorites[i]));
 		}
 	}
 }

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -365,16 +365,16 @@ void EditorVCSInterface::create_vcs_metadata_files(VCSMetadata p_vcs_metadata_ty
 		if (f.is_null()) {
 			ERR_FAIL_MSG("Couldn't create .gitignore in project path.");
 		} else {
-			f->store_line("# Godot 4+ specific ignores");
-			f->store_line(".godot/");
-			f->store_line("/android/");
+			FAIL_ON_WRITE_ERR(f, store_line("# Godot 4+ specific ignores"));
+			FAIL_ON_WRITE_ERR(f, store_line(".godot/"));
+			FAIL_ON_WRITE_ERR(f, store_line("/android/"));
 		}
 		f = FileAccess::open(p_dir.path_join(".gitattributes"), FileAccess::WRITE);
 		if (f.is_null()) {
 			ERR_FAIL_MSG("Couldn't create .gitattributes in project path.");
 		} else {
-			f->store_line("# Normalize EOL for all files that Git considers text files.");
-			f->store_line("* text=auto eol=lf");
+			FAIL_ON_WRITE_ERR(f, store_line("# Normalize EOL for all files that Git considers text files."));
+			FAIL_ON_WRITE_ERR(f, store_line("* text=auto eol=lf"));
 		}
 	}
 }

--- a/editor/export/codesign.h
+++ b/editor/export/codesign.h
@@ -131,7 +131,7 @@ public:
 	virtual int get_size() const = 0;
 	virtual uint32_t get_index_type() const = 0;
 
-	virtual void write_to_file(Ref<FileAccess> p_file) const = 0;
+	virtual bool write_to_file(Ref<FileAccess> p_file) const = 0;
 };
 
 /*************************************************************************/
@@ -167,7 +167,7 @@ public:
 	virtual int get_size() const override;
 
 	virtual uint32_t get_index_type() const override { return 0x00000002; }
-	virtual void write_to_file(Ref<FileAccess> p_file) const override;
+	virtual bool write_to_file(Ref<FileAccess> p_file) const override;
 };
 
 /*************************************************************************/
@@ -189,7 +189,7 @@ public:
 	virtual int get_size() const override;
 
 	virtual uint32_t get_index_type() const override { return 0x00000005; }
-	virtual void write_to_file(Ref<FileAccess> p_file) const override;
+	virtual bool write_to_file(Ref<FileAccess> p_file) const override;
 };
 
 /*************************************************************************/
@@ -211,7 +211,7 @@ public:
 	virtual int get_size() const override;
 
 	virtual uint32_t get_index_type() const override { return 0x00000007; }
-	virtual void write_to_file(Ref<FileAccess> p_file) const override;
+	virtual bool write_to_file(Ref<FileAccess> p_file) const override;
 };
 
 /*************************************************************************/
@@ -313,7 +313,7 @@ public:
 	virtual int get_size() const override;
 	virtual uint32_t get_index_type() const override { return 0x00000000; }
 
-	virtual void write_to_file(Ref<FileAccess> p_file) const override;
+	virtual bool write_to_file(Ref<FileAccess> p_file) const override;
 };
 
 /*************************************************************************/
@@ -332,7 +332,7 @@ public:
 	virtual int get_size() const override;
 	virtual uint32_t get_index_type() const override { return 0x00010000; }
 
-	virtual void write_to_file(Ref<FileAccess> p_file) const override;
+	virtual bool write_to_file(Ref<FileAccess> p_file) const override;
 };
 
 /*************************************************************************/
@@ -346,7 +346,7 @@ public:
 	bool add_blob(const Ref<CodeSignBlob> &p_blob);
 
 	int get_size() const;
-	void write_to_file(Ref<FileAccess> p_file) const;
+	bool write_to_file(Ref<FileAccess> p_file) const;
 };
 
 /*************************************************************************/

--- a/editor/export/lipo.cpp
+++ b/editor/export/lipo.cpp
@@ -72,27 +72,27 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 	// Write header.
 	bool is_64 = (max_size >= std::numeric_limits<uint32_t>::max());
 	if (is_64) {
-		fa->store_32(0xbfbafeca);
+		FAIL_ON_WRITE_ERR_V(fa, store_32(0xbfbafeca), false);
 	} else {
-		fa->store_32(0xbebafeca);
+		FAIL_ON_WRITE_ERR_V(fa, store_32(0xbebafeca), false);
 	}
-	fa->store_32(BSWAP32(archs.size()));
+	FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs.size())), false);
 	uint64_t offset = archs.size() * (is_64 ? 32 : 20) + 8;
 	for (int i = 0; i < archs.size(); i++) {
 		archs.write[i].offset = offset + PAD(offset, uint64_t(1) << archs[i].align);
 		if (is_64) {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_64(BSWAP64(archs[i].offset));
-			fa->store_64(BSWAP64(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
-			fa->store_32(0);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].cputype)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].cpusubtype)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_64(BSWAP64(archs[i].offset)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_64(BSWAP64(archs[i].size)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].align)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(0), false);
 		} else {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_32(BSWAP32(archs[i].offset));
-			fa->store_32(BSWAP32(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].cputype)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].cpusubtype)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].offset)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].size)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].align)), false);
 		}
 		offset = archs[i].offset + archs[i].size;
 	}
@@ -106,7 +106,7 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 		}
 		uint64_t cur = fa->get_position();
 		for (uint64_t j = cur; j < archs[i].offset; j++) {
-			fa->store_8(0);
+			FAIL_ON_WRITE_ERR_V(fa, store_8(0), false);
 		}
 		int pages = archs[i].size / 4096;
 		int remain = archs[i].size % 4096;
@@ -114,12 +114,12 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 		for (int j = 0; j < pages; j++) {
 			uint64_t br = fb->get_buffer(step, 4096);
 			if (br > 0) {
-				fa->store_buffer(step, br);
+				FAIL_ON_WRITE_ERR_V(fa, store_buffer(step, br), false);
 			}
 		}
 		uint64_t br = fb->get_buffer(step, remain);
 		if (br > 0) {
-			fa->store_buffer(step, br);
+			FAIL_ON_WRITE_ERR_V(fa, store_buffer(step, br), false);
 		}
 	}
 	return true;
@@ -166,27 +166,27 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 	// Write header.
 	bool is_64 = (max_size >= std::numeric_limits<uint32_t>::max());
 	if (is_64) {
-		fa->store_32(0xbfbafeca);
+		FAIL_ON_WRITE_ERR_V(fa, store_32(0xbfbafeca), false);
 	} else {
-		fa->store_32(0xbebafeca);
+		FAIL_ON_WRITE_ERR_V(fa, store_32(0xbebafeca), false);
 	}
-	fa->store_32(BSWAP32(archs.size()));
+	FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs.size())), false);
 	uint64_t offset = archs.size() * (is_64 ? 32 : 20) + 8;
 	for (int i = 0; i < archs.size(); i++) {
 		archs.write[i].offset = offset + PAD(offset, uint64_t(1) << archs[i].align);
 		if (is_64) {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_64(BSWAP64(archs[i].offset));
-			fa->store_64(BSWAP64(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
-			fa->store_32(0);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].cputype)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].cpusubtype)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_64(BSWAP64(archs[i].offset)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_64(BSWAP64(archs[i].size)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].align)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(0), false);
 		} else {
-			fa->store_32(BSWAP32(archs[i].cputype));
-			fa->store_32(BSWAP32(archs[i].cpusubtype));
-			fa->store_32(BSWAP32(archs[i].offset));
-			fa->store_32(BSWAP32(archs[i].size));
-			fa->store_32(BSWAP32(archs[i].align));
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].cputype)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].cpusubtype)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].offset)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].size)), false);
+			FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(archs[i].align)), false);
 		}
 		offset = archs[i].offset + archs[i].size;
 	}
@@ -200,7 +200,7 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 		}
 		uint64_t cur = fa->get_position();
 		for (uint64_t j = cur; j < archs[i].offset; j++) {
-			fa->store_8(0);
+			FAIL_ON_WRITE_ERR_V(fa, store_8(0), false);
 		}
 		int pages = archs[i].size / 4096;
 		int remain = archs[i].size % 4096;
@@ -208,12 +208,12 @@ bool LipO::create_file(const String &p_output_path, const Vector<String> &p_file
 		for (int j = 0; j < pages; j++) {
 			uint64_t br = fb->get_buffer(step, 4096);
 			if (br > 0) {
-				fa->store_buffer(step, br);
+				FAIL_ON_WRITE_ERR_V(fa, store_buffer(step, br), false);
 			}
 		}
 		uint64_t br = fb->get_buffer(step, remain);
 		if (br > 0) {
-			fa->store_buffer(step, br);
+			FAIL_ON_WRITE_ERR_V(fa, store_buffer(step, br), false);
 		}
 	}
 	return true;
@@ -319,12 +319,12 @@ bool LipO::extract_arch(int p_index, const String &p_path) {
 	for (int i = 0; i < pages; i++) {
 		uint64_t br = fa->get_buffer(step, 4096);
 		if (br > 0) {
-			fb->store_buffer(step, br);
+			FAIL_ON_WRITE_ERR_V(fb, store_buffer(step, br), false);
 		}
 	}
 	uint64_t br = fa->get_buffer(step, remain);
 	if (br > 0) {
-		fb->store_buffer(step, br);
+		FAIL_ON_WRITE_ERR_V(fb, store_buffer(step, br), false);
 	}
 	return true;
 }

--- a/editor/export/macho.cpp
+++ b/editor/export/macho.cpp
@@ -63,7 +63,7 @@ bool MachO::alloc_signature(uint64_t p_size) {
 		if (swap) {
 			lc.cmdsize = BSWAP32(lc.cmdsize);
 		}
-		fa->store_buffer((const uint8_t *)&lc, sizeof(LoadCommandHeader));
+		FAIL_ON_WRITE_ERR_V(fa, store_buffer((const uint8_t *)&lc, sizeof(LoadCommandHeader)), false);
 
 		uint32_t lc_offset = fa->get_length() + PAD(fa->get_length(), 16);
 		uint32_t lc_size = 0;
@@ -71,8 +71,8 @@ bool MachO::alloc_signature(uint64_t p_size) {
 			lc_offset = BSWAP32(lc_offset);
 			lc_size = BSWAP32(lc_size);
 		}
-		fa->store_32(lc_offset);
-		fa->store_32(lc_size);
+		FAIL_ON_WRITE_ERR_V(fa, store_32(lc_offset), false);
+		FAIL_ON_WRITE_ERR_V(fa, store_32(lc_size), false);
 
 		// Write new command number.
 		fa->seek(0x10);
@@ -89,8 +89,8 @@ bool MachO::alloc_signature(uint64_t p_size) {
 			cmdssize = BSWAP32(cmdssize);
 		}
 		fa->seek(0x10);
-		fa->store_32(ncmds);
-		fa->store_32(cmdssize);
+		FAIL_ON_WRITE_ERR_V(fa, store_32(ncmds), false);
+		FAIL_ON_WRITE_ERR_V(fa, store_32(cmdssize), false);
 
 		lc_limit = lc_limit + sizeof(LoadCommandHeader) + 8;
 
@@ -489,16 +489,16 @@ bool MachO::set_signature_size(uint64_t p_size) {
 	if (new_size <= old_size) {
 		fa->seek(get_signature_offset());
 		for (uint64_t i = 0; i < old_size; i++) {
-			fa->store_8(0x00);
+			FAIL_ON_WRITE_ERR_V(fa, store_8(0x00), false);
 		}
 		return true;
 	}
 
 	fa->seek(signature_offset + 12);
 	if (swap) {
-		fa->store_32(BSWAP32(new_size));
+		FAIL_ON_WRITE_ERR_V(fa, store_32(BSWAP32(new_size)), false);
 	} else {
-		fa->store_32(new_size);
+		FAIL_ON_WRITE_ERR_V(fa, store_32(new_size), false);
 	}
 
 	uint64_t end = get_signature_offset() + new_size;
@@ -530,7 +530,7 @@ bool MachO::set_signature_size(uint64_t p_size) {
 				lc_seg.filesize = BSWAP32(lc_seg.filesize);
 			}
 			fa->seek(link_edit_offset + 8);
-			fa->store_buffer((const uint8_t *)&lc_seg, sizeof(LoadCommandSegment));
+			FAIL_ON_WRITE_ERR_V(fa, store_buffer((const uint8_t *)&lc_seg, sizeof(LoadCommandSegment)), false);
 		} break;
 		case LC_SEGMENT_64: {
 			LoadCommandSegment64 lc_seg;
@@ -548,7 +548,7 @@ bool MachO::set_signature_size(uint64_t p_size) {
 				lc_seg.filesize = BSWAP64(lc_seg.filesize);
 			}
 			fa->seek(link_edit_offset + 8);
-			fa->store_buffer((const uint8_t *)&lc_seg, sizeof(LoadCommandSegment64));
+			FAIL_ON_WRITE_ERR_V(fa, store_buffer((const uint8_t *)&lc_seg, sizeof(LoadCommandSegment64)), false);
 		} break;
 		default: {
 			ERR_FAIL_V_MSG(false, "MachO: Invalid __LINKEDIT segment type.");
@@ -556,7 +556,7 @@ bool MachO::set_signature_size(uint64_t p_size) {
 	}
 	fa->seek(get_signature_offset());
 	for (uint64_t i = 0; i < new_size; i++) {
-		fa->store_8(0x00);
+		FAIL_ON_WRITE_ERR_V(fa, store_8(0x00), false);
 	}
 	return true;
 }

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -993,7 +993,7 @@ void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<
 	Error err = f->reopen(fpath, FileAccess::WRITE);
 	ERR_FAIL_COND_MSG(err != OK, "Cannot create file in path '" + fpath + "'.");
 
-	f->store_string(buffer);
+	FAIL_ON_WRITE_ERR(f, store_string(buffer));
 }
 
 String FindInFilesPanel::get_replace_text() {

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -665,10 +665,10 @@ Error ResourceImporterOBJ::import(ResourceUID::ID p_source_id, const String &p_s
 	if (mesh_lightmap_caches.size()) {
 		Ref<FileAccess> f = FileAccess::open(p_source_file + ".unwrap_cache", FileAccess::WRITE);
 		if (f.is_valid()) {
-			f->store_32(mesh_lightmap_caches.size());
+			FAIL_ON_WRITE_ERR_V(f, store_32(mesh_lightmap_caches.size()), ERR_FILE_CANT_WRITE);
 			for (int i = 0; i < mesh_lightmap_caches.size(); i++) {
 				String md5 = String::md5(mesh_lightmap_caches[i].ptr());
-				f->store_buffer(mesh_lightmap_caches[i].ptr(), mesh_lightmap_caches[i].size());
+				FAIL_ON_WRITE_ERR_V(f, store_buffer(mesh_lightmap_caches[i].ptr(), mesh_lightmap_caches[i].size()), ERR_FILE_CANT_WRITE);
 			}
 		}
 	}

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3080,10 +3080,10 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	if (mesh_lightmap_caches.size()) {
 		Ref<FileAccess> f = FileAccess::open(p_source_file + ".unwrap_cache", FileAccess::WRITE);
 		if (f.is_valid()) {
-			f->store_32(mesh_lightmap_caches.size());
+			FAIL_ON_WRITE_ERR_V(f, store_32(mesh_lightmap_caches.size()), ERR_FILE_CANT_WRITE);
 			for (int i = 0; i < mesh_lightmap_caches.size(); i++) {
 				String md5 = String::md5(mesh_lightmap_caches[i].ptr());
-				f->store_buffer(mesh_lightmap_caches[i].ptr(), mesh_lightmap_caches[i].size());
+				FAIL_ON_WRITE_ERR_V(f, store_buffer(mesh_lightmap_caches[i].ptr(), mesh_lightmap_caches[i].size()), ERR_FILE_CANT_WRITE);
 			}
 		}
 	}

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -86,11 +86,11 @@ Error ResourceImporterImage::import(ResourceUID::ID p_source_id, const String &p
 
 	//save the header GDIM
 	const uint8_t header[4] = { 'G', 'D', 'I', 'M' };
-	f->store_buffer(header, 4);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer(header, 4), ERR_FILE_CANT_WRITE);
 	//SAVE the extension (so it can be recognized by the loader later
-	f->store_pascal_string(p_source_file.get_extension().to_lower());
+	FAIL_ON_WRITE_ERR_V(f, store_pascal_string(p_source_file.get_extension().to_lower()), ERR_FILE_CANT_WRITE);
 	//SAVE the actual image
-	f->store_buffer(data.ptr(), len);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer(data.ptr(), len), ERR_FILE_CANT_WRITE);
 
 	return OK;
 }

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -87,7 +87,7 @@ protected:
 	static ResourceImporterLayeredTexture *singleton;
 
 public:
-	void _check_compress_ctex(const String &p_source_file, Ref<LayeredTextureImport> r_texture_import);
+	bool _check_compress_ctex(const String &p_source_file, Ref<LayeredTextureImport> r_texture_import);
 
 	static ResourceImporterLayeredTexture *get_singleton() { return singleton; }
 	virtual String get_importer_name() const override;
@@ -110,7 +110,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2);
+	bool _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2);
 
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -74,8 +74,8 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
-	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
+	bool _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	bool _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 
 	static inline void _clamp_hdr_exposure(Ref<Image> &r_image);
@@ -83,7 +83,7 @@ protected:
 	static inline void _print_callback_message(const String &p_message);
 
 public:
-	static void save_to_ctex_format(Ref<FileAccess> f, const Ref<Image> &p_image, CompressMode p_compress_mode, Image::UsedChannels p_channels, Image::CompressMode p_compress_format, float p_lossy_quality);
+	static bool save_to_ctex_format(Ref<FileAccess> f, const Ref<Image> &p_image, CompressMode p_compress_mode, Image::UsedChannels p_channels, Image::CompressMode p_compress_format, float p_lossy_quality);
 
 	static ResourceImporterTexture *get_singleton() { return singleton; }
 	virtual String get_importer_name() const override;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2449,7 +2449,7 @@ Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_p
 
 		ERR_FAIL_COND_V_MSG(err, err, "Cannot save text file '" + p_path + "'.");
 
-		file->store_string(source);
+		FAIL_ON_WRITE_ERR_V(file, store_string(source), ERR_FILE_CANT_WRITE);
 		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
 			return ERR_CANT_CREATE;
 		}

--- a/editor/pot_generator.cpp
+++ b/editor/pot_generator.cpp
@@ -134,7 +134,7 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			"\"Content-Type: text/plain; charset=UTF-8\\n\"\n"
 			"\"Content-Transfer-Encoding: 8-bit\\n\"\n";
 
-	file->store_string(header);
+	FAIL_ON_WRITE_ERR(file, store_string(header));
 
 	for (const KeyValue<String, Vector<MsgidData>> &E_pair : all_translation_strings) {
 		String msgid = E_pair.key;
@@ -146,27 +146,27 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			const HashSet<String> &comments = v_msgid_data[i].comments;
 
 			// Put the blank line at the start, to avoid a double at the end when closing the file.
-			file->store_line("");
+			FAIL_ON_WRITE_ERR(file, store_line(""));
 
 			// Write comments.
 			bool is_first_comment = true;
 			for (const String &E : comments) {
 				if (is_first_comment) {
-					file->store_line("#. TRANSLATORS: " + E.replace("\n", "\n#. "));
+					FAIL_ON_WRITE_ERR(file, store_line("#. TRANSLATORS: " + E.replace("\n", "\n#. ")));
 				} else {
-					file->store_line("#. " + E.replace("\n", "\n#. "));
+					FAIL_ON_WRITE_ERR(file, store_line("#. " + E.replace("\n", "\n#. ")));
 				}
 				is_first_comment = false;
 			}
 
 			// Write file locations.
 			for (const String &E : locations) {
-				file->store_line("#: " + E.trim_prefix("res://").replace("\n", "\\n"));
+				FAIL_ON_WRITE_ERR(file, store_line("#: " + E.trim_prefix("res://").replace("\n", "\\n")));
 			}
 
 			// Write context.
 			if (!context.is_empty()) {
-				file->store_line("msgctxt " + context.json_escape().quote());
+				FAIL_ON_WRITE_ERR(file, store_line("msgctxt " + context.json_escape().quote()));
 			}
 
 			// Write msgid.
@@ -175,10 +175,10 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 			// Write msgid_plural.
 			if (!plural.is_empty()) {
 				_write_msgid(file, plural, true);
-				file->store_line("msgstr[0] \"\"");
-				file->store_line("msgstr[1] \"\"");
+				FAIL_ON_WRITE_ERR(file, store_line("msgstr[0] \"\""));
+				FAIL_ON_WRITE_ERR(file, store_line("msgstr[1] \"\""));
 			} else {
-				file->store_line("msgstr \"\"");
+				FAIL_ON_WRITE_ERR(file, store_line("msgstr \"\""));
 			}
 		}
 	}
@@ -186,13 +186,13 @@ void POTGenerator::_write_to_pot(const String &p_file) {
 
 void POTGenerator::_write_msgid(Ref<FileAccess> r_file, const String &p_id, bool p_plural) {
 	if (p_plural) {
-		r_file->store_string("msgid_plural ");
+		FAIL_ON_WRITE_ERR(r_file, store_string("msgid_plural "));
 	} else {
-		r_file->store_string("msgid ");
+		FAIL_ON_WRITE_ERR(r_file, store_string("msgid "));
 	}
 
 	if (p_id.is_empty()) {
-		r_file->store_line("\"\"");
+		FAIL_ON_WRITE_ERR(r_file, store_line("\"\""));
 		return;
 	}
 
@@ -204,15 +204,15 @@ void POTGenerator::_write_msgid(Ref<FileAccess> r_file, const String &p_id, bool
 	}
 
 	if (pot_line_count > 1) {
-		r_file->store_line("\"\"");
+		FAIL_ON_WRITE_ERR(r_file, store_line("\"\""));
 	}
 
 	for (int i = 0; i < lines.size() - 1; i++) {
-		r_file->store_line((lines[i] + "\n").json_escape().quote());
+		FAIL_ON_WRITE_ERR(r_file, store_line((lines[i] + "\n").json_escape().quote()));
 	}
 
 	if (!last_line.is_empty()) {
-		r_file->store_line(last_line.json_escape().quote());
+		FAIL_ON_WRITE_ERR(r_file, store_line(last_line.json_escape().quote()));
 	}
 }
 

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1006,7 +1006,7 @@ GLTFImageIndex FBXDocument::_parse_image_save_image(Ref<FBXState> p_state, const
 					// If a file extension was specified, save the original bytes to a file with that extension.
 					Ref<FileAccess> file = FileAccess::open(file_path, FileAccess::WRITE, &err);
 					ERR_FAIL_COND_V(err != OK, -1);
-					file->store_buffer(p_bytes);
+					FAIL_ON_WRITE_ERR_V(file, store_buffer(p_bytes), -1);
 					file->close();
 				}
 				// ResourceLoader::import will crash if not is_editor_hint(), so this case is protected above and will fall through to uncompressed.

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -3094,10 +3094,7 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 
 		ERR_FAIL_COND_V_MSG(err, err, "Cannot save GDScript file '" + p_path + "'.");
 
-		file->store_string(source);
-		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
-			return ERR_CANT_CREATE;
-		}
+		FAIL_ON_WRITE_ERR_V(file, store_string(source), ERR_CANT_CREATE);
 	}
 
 	if (ScriptServer::is_reload_scripts_on_save_enabled()) {

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -716,7 +716,10 @@ bool GDScriptTest::generate_output() {
 	String output = result.output.strip_edges(); // TODO: may be hacky.
 	output += "\n"; // Make sure to insert newline for CI static checks.
 
-	out_file->store_string(output);
+	if (!out_file->store_string(output)) {
+		out_file->abort_backup_save_and_close();
+		return false;
+	}
 
 	return true;
 }

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -736,7 +736,7 @@ Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_p
 			return OK;
 		}
 		file->create(FileAccess::ACCESS_RESOURCES);
-		file->store_buffer(buffer_data.ptr(), buffer_data.size());
+		FAIL_ON_WRITE_ERR_V(file, store_buffer(buffer_data.ptr(), buffer_data.size()), ERR_FILE_CANT_WRITE);
 		gltf_buffer["uri"] = filename;
 		gltf_buffer["byteLength"] = buffer_data.size();
 		buffers.push_back(gltf_buffer);
@@ -768,7 +768,7 @@ Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_
 			return OK;
 		}
 		file->create(FileAccess::ACCESS_RESOURCES);
-		file->store_buffer(buffer_data.ptr(), buffer_data.size());
+		FAIL_ON_WRITE_ERR_V(file, store_buffer(buffer_data.ptr(), buffer_data.size()), ERR_FILE_CANT_WRITE);
 		gltf_buffer["uri"] = filename;
 		gltf_buffer["byteLength"] = buffer_data.size();
 		buffers.push_back(gltf_buffer);
@@ -3985,7 +3985,7 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 					// If a file extension was specified, save the original bytes to a file with that extension.
 					Ref<FileAccess> file = FileAccess::open(file_path, FileAccess::WRITE, &err);
 					ERR_FAIL_COND(err != OK);
-					file->store_buffer(p_bytes);
+					FAIL_ON_WRITE_ERR(file, store_buffer(p_bytes));
 					file->close();
 				}
 				// ResourceLoader::import will crash if not is_editor_hint(), so this case is protected above and will fall through to uncompressed.
@@ -8076,29 +8076,30 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 		const uint32_t binary_chunk_type = 0x004E4942; //BIN
 
 		file->create(FileAccess::ACCESS_RESOURCES);
-		file->store_32(magic);
-		file->store_32(p_state->major_version); // version
+		FAIL_ON_WRITE_ERR_V(file, store_32(magic), ERR_FILE_CANT_WRITE);
+		;
+		FAIL_ON_WRITE_ERR_V(file, store_32(p_state->major_version), ERR_FILE_CANT_WRITE); // version
 		uint32_t total_length = header_size + chunk_header_size + text_chunk_length;
 		if (binary_chunk_length) {
 			total_length += chunk_header_size + binary_chunk_length;
 		}
-		file->store_32(total_length);
+		FAIL_ON_WRITE_ERR_V(file, store_32(total_length), ERR_FILE_CANT_WRITE);
 
 		// Write the JSON text chunk.
-		file->store_32(text_chunk_length);
-		file->store_32(text_chunk_type);
-		file->store_buffer((uint8_t *)&cs[0], cs.length());
+		FAIL_ON_WRITE_ERR_V(file, store_32(text_chunk_length), ERR_FILE_CANT_WRITE);
+		FAIL_ON_WRITE_ERR_V(file, store_32(text_chunk_type), ERR_FILE_CANT_WRITE);
+		FAIL_ON_WRITE_ERR_V(file, store_buffer((uint8_t *)&cs[0], cs.length()), ERR_FILE_CANT_WRITE);
 		for (uint32_t pad_i = text_data_length; pad_i < text_chunk_length; pad_i++) {
-			file->store_8(' ');
+			FAIL_ON_WRITE_ERR_V(file, store_8(' '), ERR_FILE_CANT_WRITE);
 		}
 
 		// Write a single binary chunk.
 		if (binary_chunk_length) {
-			file->store_32(binary_chunk_length);
-			file->store_32(binary_chunk_type);
-			file->store_buffer(p_state->buffers[0].ptr(), binary_data_length);
+			FAIL_ON_WRITE_ERR_V(file, store_32(binary_chunk_length), ERR_FILE_CANT_WRITE);
+			FAIL_ON_WRITE_ERR_V(file, store_32(binary_chunk_type), ERR_FILE_CANT_WRITE);
+			FAIL_ON_WRITE_ERR_V(file, store_buffer(p_state->buffers[0].ptr(), binary_data_length), ERR_FILE_CANT_WRITE);
 			for (uint32_t pad_i = binary_data_length; pad_i < binary_chunk_length; pad_i++) {
-				file->store_8(0);
+				FAIL_ON_WRITE_ERR_V(file, store_8(0), ERR_FILE_CANT_WRITE);
 			}
 		}
 	} else {
@@ -8109,7 +8110,7 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 
 		file->create(FileAccess::ACCESS_RESOURCES);
 		String json = Variant(p_state->json).to_json_string();
-		file->store_string(json);
+		FAIL_ON_WRITE_ERR_V(file, store_string(json), ERR_FILE_CANT_WRITE);
 	}
 	return err;
 }

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -138,8 +138,7 @@ public:
 	Ref<FileAccess> f;
 
 	virtual bool put_buf(const void *Pbuf, int len) {
-		f->store_buffer((const uint8_t *)Pbuf, len);
-		return true;
+		return f->store_buffer((const uint8_t *)Pbuf, len);
 	}
 };
 

--- a/modules/ktx/texture_loader_ktx.cpp
+++ b/modules/ktx/texture_loader_ktx.cpp
@@ -53,8 +53,11 @@ KTX_error_code ktx_skip(ktxStream *stream, const ktx_size_t count) {
 
 KTX_error_code ktx_write(ktxStream *stream, const void *src, const ktx_size_t size, const ktx_size_t count) {
 	Ref<FileAccess> *f = reinterpret_cast<Ref<FileAccess> *>(stream->data.custom_ptr.address);
-	(*f)->store_buffer(reinterpret_cast<const uint8_t *>(src), size * count);
-	return KTX_SUCCESS;
+	if ((*f)->store_buffer(reinterpret_cast<const uint8_t *>(src), size * count)) {
+		return KTX_SUCCESS;
+	} else {
+		return KTX_FILE_WRITE_ERROR;
+	}
 }
 
 KTX_error_code ktx_getpos(ktxStream *stream, ktx_off_t *const offset) {

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -838,14 +838,14 @@ Error LightmapperRD::_store_pfm(RenderingDevice *p_rd, RID p_atlas_tex, int p_in
 	Error err = OK;
 	Ref<FileAccess> file = FileAccess::open(p_name, FileAccess::WRITE, &err);
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save PFN at path: '%s'.", p_name));
-	file->store_line("PF");
-	file->store_line(vformat("%d %d", img->get_width(), img->get_height()));
+	FAIL_ON_WRITE_ERR_V(file, store_line("PF"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(file, store_line(vformat("%d %d", img->get_width(), img->get_height())), ERR_FILE_CANT_WRITE);
 #ifdef BIG_ENDIAN_ENABLED
-	file->store_line("1.0");
+	FAIL_ON_WRITE_ERR_V(file, store_line("1.0"), ERR_FILE_CANT_WRITE);
 #else
-	file->store_line("-1.0");
+	FAIL_ON_WRITE_ERR_V(file, store_line("-1.0"), ERR_FILE_CANT_WRITE);
 #endif
-	file->store_buffer(data_float);
+	FAIL_ON_WRITE_ERR_V(file, store_buffer(data_float), ERR_FILE_CANT_WRITE);
 	file->close();
 
 	return OK;

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -98,7 +98,7 @@ Error CryptoKeyMbedTLS::save(const String &p_path, bool p_public_only) {
 	}
 
 	size_t len = strlen((char *)w);
-	f->store_buffer(w, len);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer(w, len), ERR_FILE_CANT_WRITE);
 	mbedtls_platform_zeroize(w, sizeof(w)); // Zeroize temporary buffer.
 	return OK;
 }
@@ -202,7 +202,7 @@ Error X509CertificateMbedTLS::save(const String &p_path) {
 			ERR_FAIL_V_MSG(FAILED, "Error writing certificate '" + itos(ret) + "'.");
 		}
 
-		f->store_buffer(w, wrote - 1); // don't write the string terminator
+		FAIL_ON_WRITE_ERR_V(f, store_buffer(w, wrote - 1), ERR_FILE_CANT_WRITE); // don't write the string terminator
 		crt = crt->next;
 	}
 	return OK;

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -227,7 +227,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 	Ref<FileAccess> f = FileAccess::open(p_output_file, FileAccess::WRITE);
 	ERR_FAIL_COND_MSG(f.is_null(), "Cannot open file '" + p_output_file + "'.");
-	f->store_string(JSON::stringify(classes_dict, "\t"));
+	FAIL_ON_WRITE_ERR(f, store_string(JSON::stringify(classes_dict, "\t")));
 
 	print_line(String() + "ClassDB API JSON written to: " + ProjectSettings::get_singleton()->globalize_path(p_output_file));
 }

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2896,11 +2896,7 @@ Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, con
 		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save C# script file '" + p_path + "'.");
 
-		file->store_string(source);
-
-		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
-			return ERR_CANT_CREATE;
-		}
+		FAIL_ON_WRITE_ERR_V(file, store_string(source), ERR_CANT_CREATE);
 	}
 
 #ifdef TOOLS_ENABLED

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -3599,7 +3599,7 @@ Error BindingsGenerator::_save_file(const String &p_path, const StringBuilder &p
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(file.is_null(), ERR_FILE_CANT_WRITE, "Cannot open file: '" + p_path + "'.");
 
-	file->store_string(p_content.as_string());
+	FAIL_ON_WRITE_ERR_V(file, store_string(p_content.as_string()), ERR_FILE_CANT_WRITE);
 
 	return OK;
 }

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -492,7 +492,10 @@ bool TextServerAdvanced::_save_support_data(const String &p_filename) const {
 	PackedByteArray icu_data_static;
 	icu_data_static.resize(U_ICUDATA_SIZE);
 	memcpy(icu_data_static.ptrw(), U_ICUDATA_ENTRY_POINT, U_ICUDATA_SIZE);
-	f->store_buffer(icu_data_static);
+	if (!f->store_buffer(icu_data_static)) {
+		f->abort_backup_save_and_close();
+		return false;
+	}
 
 	return true;
 #else

--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -291,7 +291,7 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 	} else {
 		Ref<FileAccess> ref = FileAccess::open(p_path, FileAccess::WRITE);
 		ERR_FAIL_COND_V(ref.is_null(), ERR_FILE_CANT_WRITE);
-		ref->store_buffer(buffer.ptr(), buffer.size());
+		FAIL_ON_WRITE_ERR_V(ref, store_buffer(buffer.ptr(), buffer.size()), ERR_FILE_CANT_WRITE);
 	}
 
 	return OK;

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -57,7 +57,7 @@ Error ResourceSaverWebP::save_image(const String &p_path, const Ref<Image> &p_im
 
 	const uint8_t *reader = buffer.ptr();
 
-	file->store_buffer(reader, buffer.size());
+	FAIL_ON_WRITE_ERR_V(file, store_buffer(reader, buffer.size()), ERR_FILE_CANT_WRITE);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
 		return ERR_CANT_CREATE;
 	}

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3193,7 +3193,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			}
 			if (user_data.libs.size() > 0) {
 				Ref<FileAccess> fa = FileAccess::open(gdextension_libs_path, FileAccess::WRITE);
-				fa->store_string(JSON::stringify(user_data.libs, "\t"));
+				FAIL_ON_WRITE_ERR_V(fa, store_string(JSON::stringify(user_data.libs, "\t")), ERR_FILE_CANT_WRITE);
 			}
 		} else {
 			print_verbose("Saving apk expansion file...");

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -143,7 +143,7 @@ Error store_file_at_path(const String &p_path, const Vector<uint8_t> &p_data) {
 	}
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
-	fa->store_buffer(p_data.ptr(), p_data.size());
+	FAIL_ON_WRITE_ERR_V(fa, store_buffer(p_data.ptr(), p_data.size()), ERR_FILE_CANT_WRITE);
 	return OK;
 }
 
@@ -160,7 +160,7 @@ Error store_string_at_path(const String &p_path, const String &p_data) {
 	}
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
-	fa->store_string(p_data);
+	FAIL_ON_WRITE_ERR_V(fa, store_string(p_data), ERR_FILE_CANT_WRITE);
 	return OK;
 }
 

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -52,10 +52,10 @@ Error EditorExportPlatformLinuxBSD::_export_debug_script(const Ref<EditorExportP
 		return ERR_CANT_CREATE;
 	}
 
-	f->store_line("#!/bin/sh");
-	f->store_line("echo -ne '\\033c\\033]0;" + p_app_name + "\\a'");
-	f->store_line("base_path=\"$(dirname \"$(realpath \"$0\")\")\"");
-	f->store_line("\"$base_path/" + p_pkg_name + "\" \"$@\"");
+	FAIL_ON_WRITE_ERR_V(f, store_line("#!/bin/sh"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("echo -ne '\\033c\\033]0;" + p_app_name + "\\a'"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("base_path=\"$(dirname \"$(realpath \"$0\")\")\""), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("\"$base_path/" + p_pkg_name + "\" \"$@\""), ERR_FILE_CANT_WRITE);
 
 	return OK;
 }
@@ -374,12 +374,12 @@ Error EditorExportPlatformLinuxBSD::fixup_embedded_pck(const String &p_path, int
 
 			if (bits == 32) {
 				f->seek(section_header_pos + 0x10);
-				f->store_32(p_embedded_start);
-				f->store_32(p_embedded_size);
+				FAIL_ON_WRITE_ERR_V(f, store_32(p_embedded_start), ERR_FILE_CANT_WRITE);
+				FAIL_ON_WRITE_ERR_V(f, store_32(p_embedded_size), ERR_FILE_CANT_WRITE);
 			} else { // 64
 				f->seek(section_header_pos + 0x18);
-				f->store_64(p_embedded_start);
-				f->store_64(p_embedded_size);
+				FAIL_ON_WRITE_ERR_V(f, store_64(p_embedded_start), ERR_FILE_CANT_WRITE);
+				FAIL_ON_WRITE_ERR_V(f, store_64(p_embedded_size), ERR_FILE_CANT_WRITE);
 			}
 
 			found = true;
@@ -553,7 +553,10 @@ Error EditorExportPlatformLinuxBSD::run(const Ref<EditorExportPreset> &p_preset,
 			CLEANUP_AND_RETURN(err);
 		}
 
-		f->store_string(run_script);
+		if (!f->store_string(run_script)) {
+			f->abort_backup_save_and_close();
+			CLEANUP_AND_RETURN(ERR_FILE_CANT_WRITE);
+		}
 	}
 
 	{
@@ -568,7 +571,10 @@ Error EditorExportPlatformLinuxBSD::run(const Ref<EditorExportPreset> &p_preset,
 			CLEANUP_AND_RETURN(err);
 		}
 
-		f->store_string(clean_script);
+		if (!f->store_string(clean_script)) {
+			f->abort_backup_save_and_close();
+			CLEANUP_AND_RETURN(ERR_FILE_CANT_WRITE);
+		}
 	}
 
 	print_line("Uploading scripts...");

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -1116,7 +1116,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 		{
 			Ref<FileAccess> file = FileAccess::open(trash_path + "/info/" + file_name + ".trashinfo", FileAccess::WRITE, &err);
 			ERR_FAIL_COND_V_MSG(err != OK, err, "Can't create trashinfo file: \"" + trash_path + "/info/" + file_name + ".trashinfo\"");
-			file->store_string(trash_info);
+			FAIL_ON_WRITE_ERR_V(file, store_string(trash_info), ERR_FILE_CANT_WRITE);
 		}
 
 		// Rename our resource before moving it to the trash can.

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -1352,7 +1352,7 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 			err = dir_access->make_dir_recursive(p_in_app_path.path_join("Resources"));
 			Ref<FileAccess> f = FileAccess::open(p_in_app_path.path_join("Resources").path_join("Info.plist"), FileAccess::WRITE);
 			if (f.is_valid()) {
-				f->store_string(info_plist);
+				FAIL_ON_WRITE_ERR_V(f, store_string(info_plist), ERR_FILE_CANT_WRITE);
 			}
 		}
 	} else {
@@ -1492,22 +1492,22 @@ Error EditorExportPlatformMacOS::_export_debug_script(const Ref<EditorExportPres
 		return ERR_CANT_CREATE;
 	}
 
-	f->store_line("#!/bin/sh");
-	f->store_line("echo -ne '\\033c\\033]0;" + p_app_name + "\\a'");
-	f->store_line("");
-	f->store_line("function app_realpath() {");
-	f->store_line("    SOURCE=$1");
-	f->store_line("    while [ -h \"$SOURCE\" ]; do");
-	f->store_line("        DIR=$(dirname \"$SOURCE\")");
-	f->store_line("        SOURCE=$(readlink \"$SOURCE\")");
-	f->store_line("        [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE");
-	f->store_line("    done");
-	f->store_line("    echo \"$( cd -P \"$( dirname \"$SOURCE\" )\" >/dev/null 2>&1 && pwd )\"");
-	f->store_line("}");
-	f->store_line("");
-	f->store_line("BASE_PATH=\"$(app_realpath \"${BASH_SOURCE[0]}\")\"");
-	f->store_line("\"$BASE_PATH/" + p_pkg_name + "\" \"$@\"");
-	f->store_line("");
+	FAIL_ON_WRITE_ERR_V(f, store_line("#!/bin/sh"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("echo -ne '\\033c\\033]0;" + p_app_name + "\\a'"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line(""), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("function app_realpath() {"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("    SOURCE=$1"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("    while [ -h \"$SOURCE\" ]; do"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("        DIR=$(dirname \"$SOURCE\")"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("        SOURCE=$(readlink \"$SOURCE\")"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("        [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("    done"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("    echo \"$( cd -P \"$( dirname \"$SOURCE\" )\" >/dev/null 2>&1 && pwd )\""), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("}"), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line(""), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("BASE_PATH=\"$(app_realpath \"${BASH_SOURCE[0]}\")\""), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line("\"$BASE_PATH/" + p_pkg_name + "\" \"$@\""), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_line(""), ERR_FILE_CANT_WRITE);
 
 	return OK;
 }
@@ -1673,43 +1673,43 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			String fname = tmp_app_path_name + "/Contents/Resources/en.lproj";
 			tmp_app_dir->make_dir_recursive(fname);
 			Ref<FileAccess> f = FileAccess::open(fname + "/InfoPlist.strings", FileAccess::WRITE);
-			f->store_line("/* Localized versions of Info.plist keys */");
-			f->store_line("");
-			f->store_line("CFBundleDisplayName = \"" + GLOBAL_GET("application/config/name").operator String() + "\";");
+			FAIL_ON_WRITE_ERR_V(f, store_line("/* Localized versions of Info.plist keys */"), ERR_FILE_CANT_WRITE);
+			FAIL_ON_WRITE_ERR_V(f, store_line(""), ERR_FILE_CANT_WRITE);
+			FAIL_ON_WRITE_ERR_V(f, store_line("CFBundleDisplayName = \"" + GLOBAL_GET("application/config/name").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			if (!((String)p_preset->get("privacy/microphone_usage_description")).is_empty()) {
-				f->store_line("NSMicrophoneUsageDescription = \"" + p_preset->get("privacy/microphone_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSMicrophoneUsageDescription = \"" + p_preset->get("privacy/microphone_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/camera_usage_description")).is_empty()) {
-				f->store_line("NSCameraUsageDescription = \"" + p_preset->get("privacy/camera_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSCameraUsageDescription = \"" + p_preset->get("privacy/camera_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/location_usage_description")).is_empty()) {
-				f->store_line("NSLocationUsageDescription = \"" + p_preset->get("privacy/location_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSLocationUsageDescription = \"" + p_preset->get("privacy/location_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/address_book_usage_description")).is_empty()) {
-				f->store_line("NSContactsUsageDescription = \"" + p_preset->get("privacy/address_book_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSContactsUsageDescription = \"" + p_preset->get("privacy/address_book_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/calendar_usage_description")).is_empty()) {
-				f->store_line("NSCalendarsUsageDescription = \"" + p_preset->get("privacy/calendar_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSCalendarsUsageDescription = \"" + p_preset->get("privacy/calendar_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/photos_library_usage_description")).is_empty()) {
-				f->store_line("NSPhotoLibraryUsageDescription = \"" + p_preset->get("privacy/photos_library_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSPhotoLibraryUsageDescription = \"" + p_preset->get("privacy/photos_library_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/desktop_folder_usage_description")).is_empty()) {
-				f->store_line("NSDesktopFolderUsageDescription = \"" + p_preset->get("privacy/desktop_folder_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSDesktopFolderUsageDescription = \"" + p_preset->get("privacy/desktop_folder_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/documents_folder_usage_description")).is_empty()) {
-				f->store_line("NSDocumentsFolderUsageDescription = \"" + p_preset->get("privacy/documents_folder_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSDocumentsFolderUsageDescription = \"" + p_preset->get("privacy/documents_folder_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/downloads_folder_usage_description")).is_empty()) {
-				f->store_line("NSDownloadsFolderUsageDescription = \"" + p_preset->get("privacy/downloads_folder_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSDownloadsFolderUsageDescription = \"" + p_preset->get("privacy/downloads_folder_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/network_volumes_usage_description")).is_empty()) {
-				f->store_line("NSNetworkVolumesUsageDescription = \"" + p_preset->get("privacy/network_volumes_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSNetworkVolumesUsageDescription = \"" + p_preset->get("privacy/network_volumes_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (!((String)p_preset->get("privacy/removable_volumes_usage_description")).is_empty()) {
-				f->store_line("NSRemovableVolumesUsageDescription = \"" + p_preset->get("privacy/removable_volumes_usage_description").operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSRemovableVolumesUsageDescription = \"" + p_preset->get("privacy/removable_volumes_usage_description").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
-			f->store_line("NSHumanReadableCopyright = \"" + p_preset->get("application/copyright").operator String() + "\";");
+			FAIL_ON_WRITE_ERR_V(f, store_line("NSHumanReadableCopyright = \"" + p_preset->get("application/copyright").operator String() + "\";"), ERR_FILE_CANT_WRITE);
 		}
 
 		HashSet<String> languages;
@@ -1724,46 +1724,46 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			String fname = tmp_app_path_name + "/Contents/Resources/" + lang + ".lproj";
 			tmp_app_dir->make_dir_recursive(fname);
 			Ref<FileAccess> f = FileAccess::open(fname + "/InfoPlist.strings", FileAccess::WRITE);
-			f->store_line("/* Localized versions of Info.plist keys */");
-			f->store_line("");
+			FAIL_ON_WRITE_ERR_V(f, store_line("/* Localized versions of Info.plist keys */"), ERR_FILE_CANT_WRITE);
+			FAIL_ON_WRITE_ERR_V(f, store_line(""), ERR_FILE_CANT_WRITE);
 			if (appnames.has(lang)) {
-				f->store_line("CFBundleDisplayName = \"" + appnames[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("CFBundleDisplayName = \"" + appnames[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (microphone_usage_descriptions.has(lang)) {
-				f->store_line("NSMicrophoneUsageDescription = \"" + microphone_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSMicrophoneUsageDescription = \"" + microphone_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (camera_usage_descriptions.has(lang)) {
-				f->store_line("NSCameraUsageDescription = \"" + camera_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSCameraUsageDescription = \"" + camera_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (location_usage_descriptions.has(lang)) {
-				f->store_line("NSLocationUsageDescription = \"" + location_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSLocationUsageDescription = \"" + location_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (address_book_usage_descriptions.has(lang)) {
-				f->store_line("NSContactsUsageDescription = \"" + address_book_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSContactsUsageDescription = \"" + address_book_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (calendar_usage_descriptions.has(lang)) {
-				f->store_line("NSCalendarsUsageDescription = \"" + calendar_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSCalendarsUsageDescription = \"" + calendar_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (photos_library_usage_descriptions.has(lang)) {
-				f->store_line("NSPhotoLibraryUsageDescription = \"" + photos_library_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSPhotoLibraryUsageDescription = \"" + photos_library_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (desktop_folder_usage_descriptions.has(lang)) {
-				f->store_line("NSDesktopFolderUsageDescription = \"" + desktop_folder_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSDesktopFolderUsageDescription = \"" + desktop_folder_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (documents_folder_usage_descriptions.has(lang)) {
-				f->store_line("NSDocumentsFolderUsageDescription = \"" + documents_folder_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSDocumentsFolderUsageDescription = \"" + documents_folder_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (downloads_folder_usage_descriptions.has(lang)) {
-				f->store_line("NSDownloadsFolderUsageDescription = \"" + downloads_folder_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSDownloadsFolderUsageDescription = \"" + downloads_folder_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (network_volumes_usage_descriptions.has(lang)) {
-				f->store_line("NSNetworkVolumesUsageDescription = \"" + network_volumes_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSNetworkVolumesUsageDescription = \"" + network_volumes_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (removable_volumes_usage_descriptions.has(lang)) {
-				f->store_line("NSRemovableVolumesUsageDescription = \"" + removable_volumes_usage_descriptions[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSRemovableVolumesUsageDescription = \"" + removable_volumes_usage_descriptions[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 			if (copyrights.has(lang)) {
-				f->store_line("NSHumanReadableCopyright = \"" + copyrights[lang].operator String() + "\";");
+				FAIL_ON_WRITE_ERR_V(f, store_line("NSHumanReadableCopyright = \"" + copyrights[lang].operator String() + "\";"), ERR_FILE_CANT_WRITE);
 			}
 		}
 	}
@@ -1900,7 +1900,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			if (err == OK) {
 				Ref<FileAccess> f = FileAccess::open(file, FileAccess::WRITE);
 				if (f.is_valid()) {
-					f->store_buffer(data.ptr(), data.size());
+					FAIL_ON_WRITE_ERR_V(f, store_buffer(data.ptr(), data.size()), ERR_FILE_CANT_WRITE);
 					f.unref();
 					if (is_executable(file)) {
 						// chmod with 0755 if the file is executable.
@@ -1993,68 +1993,69 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 
 			Ref<FileAccess> ent_f = FileAccess::open(ent_path, FileAccess::WRITE);
 			if (ent_f.is_valid()) {
-				ent_f->store_line("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-				ent_f->store_line("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">");
-				ent_f->store_line("<plist version=\"1.0\">");
-				ent_f->store_line("<dict>");
+				FAIL_ON_WRITE_ERR_V(ent_f, store_line("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"), ERR_FILE_CANT_WRITE);
+				FAIL_ON_WRITE_ERR_V(ent_f, store_line("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">"), ERR_FILE_CANT_WRITE);
+				FAIL_ON_WRITE_ERR_V(ent_f, store_line("<plist version=\"1.0\">"), ERR_FILE_CANT_WRITE);
+				FAIL_ON_WRITE_ERR_V(ent_f, store_line("<dict>"), ERR_FILE_CANT_WRITE);
 				if (ClassDB::class_exists("CSharpScript")) {
 					// These entitlements are required to run managed code, and are always enabled in Mono builds.
-					ent_f->store_line("<key>com.apple.security.cs.allow-jit</key>");
-					ent_f->store_line("<true/>");
-					ent_f->store_line("<key>com.apple.security.cs.allow-unsigned-executable-memory</key>");
-					ent_f->store_line("<true/>");
-					ent_f->store_line("<key>com.apple.security.cs.allow-dyld-environment-variables</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.cs.allow-jit</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
+					;
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.cs.allow-unsigned-executable-memory</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.cs.allow-dyld-environment-variables</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				} else {
 					if ((bool)p_preset->get("codesign/entitlements/allow_jit_code_execution")) {
-						ent_f->store_line("<key>com.apple.security.cs.allow-jit</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.cs.allow-jit</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((bool)p_preset->get("codesign/entitlements/allow_unsigned_executable_memory")) {
-						ent_f->store_line("<key>com.apple.security.cs.allow-unsigned-executable-memory</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.cs.allow-unsigned-executable-memory</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((bool)p_preset->get("codesign/entitlements/allow_dyld_environment_variables")) {
-						ent_f->store_line("<key>com.apple.security.cs.allow-dyld-environment-variables</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.cs.allow-dyld-environment-variables</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 				}
 
 				if (lib_validation) {
-					ent_f->store_line("<key>com.apple.security.cs.disable-library-validation</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.cs.disable-library-validation</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				}
 				if ((bool)p_preset->get("codesign/entitlements/audio_input")) {
-					ent_f->store_line("<key>com.apple.security.device.audio-input</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.device.audio-input</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				}
 				if ((bool)p_preset->get("codesign/entitlements/camera")) {
-					ent_f->store_line("<key>com.apple.security.device.camera</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.device.camera</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				}
 				if ((bool)p_preset->get("codesign/entitlements/location")) {
-					ent_f->store_line("<key>com.apple.security.personal-information.location</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.personal-information.location</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				}
 				if ((bool)p_preset->get("codesign/entitlements/address_book")) {
-					ent_f->store_line("<key>com.apple.security.personal-information.addressbook</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.personal-information.addressbook</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				}
 				if ((bool)p_preset->get("codesign/entitlements/calendars")) {
-					ent_f->store_line("<key>com.apple.security.personal-information.calendars</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.personal-information.calendars</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				}
 				if ((bool)p_preset->get("codesign/entitlements/photos_library")) {
-					ent_f->store_line("<key>com.apple.security.personal-information.photos-library</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.personal-information.photos-library</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				}
 				if ((bool)p_preset->get("codesign/entitlements/apple_events")) {
-					ent_f->store_line("<key>com.apple.security.automation.apple-events</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.automation.apple-events</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				}
 				if ((bool)p_preset->get("codesign/entitlements/debugging")) {
-					ent_f->store_line("<key>com.apple.security.get-task-allow</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.get-task-allow</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 				}
 
 				int dist_type = p_preset->get("export/distribution_type");
@@ -2063,82 +2064,82 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 					String teamid = p_preset->get("codesign/apple_team_id");
 					String bid = p_preset->get("application/bundle_identifier");
 					if (!pprof.is_empty() && !teamid.is_empty()) {
-						ent_f->store_line("<key>com.apple.developer.team-identifier</key>");
-						ent_f->store_line("<string>" + teamid + "</string>");
-						ent_f->store_line("<key>com.apple.application-identifier</key>");
-						ent_f->store_line("<string>" + teamid + "." + bid + "</string>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.developer.team-identifier</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<string>" + teamid + "</string>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.application-identifier</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<string>" + teamid + "." + bid + "</string>"), ERR_FILE_CANT_WRITE);
 					}
 				}
 
 				if ((bool)p_preset->get("codesign/entitlements/app_sandbox/enabled")) {
-					ent_f->store_line("<key>com.apple.security.app-sandbox</key>");
-					ent_f->store_line("<true/>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.app-sandbox</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 
 					if ((bool)p_preset->get("codesign/entitlements/app_sandbox/network_server")) {
-						ent_f->store_line("<key>com.apple.security.network.server</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.network.server</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((bool)p_preset->get("codesign/entitlements/app_sandbox/network_client")) {
-						ent_f->store_line("<key>com.apple.security.network.client</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.network.client</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((bool)p_preset->get("codesign/entitlements/app_sandbox/device_usb")) {
-						ent_f->store_line("<key>com.apple.security.device.usb</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.device.usb</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((bool)p_preset->get("codesign/entitlements/app_sandbox/device_bluetooth")) {
-						ent_f->store_line("<key>com.apple.security.device.bluetooth</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.device.bluetooth</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_downloads") == 1) {
-						ent_f->store_line("<key>com.apple.security.files.downloads.read-only</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.downloads.read-only</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_downloads") == 2) {
-						ent_f->store_line("<key>com.apple.security.files.downloads.read-write</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.downloads.read-write</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_pictures") == 1) {
-						ent_f->store_line("<key>com.apple.security.files.pictures.read-only</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.pictures.read-only</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_pictures") == 2) {
-						ent_f->store_line("<key>com.apple.security.files.pictures.read-write</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.pictures.read-write</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_music") == 1) {
-						ent_f->store_line("<key>com.apple.security.files.music.read-only</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.music.read-only</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_music") == 2) {
-						ent_f->store_line("<key>com.apple.security.files.music.read-write</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.music.read-write</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_movies") == 1) {
-						ent_f->store_line("<key>com.apple.security.files.movies.read-only</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.movies.read-only</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_movies") == 2) {
-						ent_f->store_line("<key>com.apple.security.files.movies.read-write</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.movies.read-write</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_user_selected") == 1) {
-						ent_f->store_line("<key>com.apple.security.files.user-selected.read-only</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.user-selected.read-only</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 					if ((int)p_preset->get("codesign/entitlements/app_sandbox/files_user_selected") == 2) {
-						ent_f->store_line("<key>com.apple.security.files.user-selected.read-write</key>");
-						ent_f->store_line("<true/>");
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.files.user-selected.read-write</key>"), ERR_FILE_CANT_WRITE);
+						FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
 					}
 				}
 
 				const String &additional_entitlements = p_preset->get("codesign/entitlements/additional");
 				if (!additional_entitlements.is_empty()) {
-					ent_f->store_line(additional_entitlements);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line(additional_entitlements), ERR_FILE_CANT_WRITE);
 				}
 
-				ent_f->store_line("</dict>");
-				ent_f->store_line("</plist>");
+				FAIL_ON_WRITE_ERR_V(ent_f, store_line("</dict>"), ERR_FILE_CANT_WRITE);
+				FAIL_ON_WRITE_ERR_V(ent_f, store_line("</plist>"), ERR_FILE_CANT_WRITE);
 			} else {
 				add_message(EXPORT_MESSAGE_ERROR, TTR("Code Signing"), TTR("Could not create entitlements file."));
 				err = ERR_CANT_CREATE;
@@ -2147,16 +2148,16 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			if ((err == OK) && sandbox && (helpers.size() > 0 || shared_objects.size() > 0)) {
 				ent_f = FileAccess::open(hlp_ent_path, FileAccess::WRITE);
 				if (ent_f.is_valid()) {
-					ent_f->store_line("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-					ent_f->store_line("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">");
-					ent_f->store_line("<plist version=\"1.0\">");
-					ent_f->store_line("<dict>");
-					ent_f->store_line("<key>com.apple.security.app-sandbox</key>");
-					ent_f->store_line("<true/>");
-					ent_f->store_line("<key>com.apple.security.inherit</key>");
-					ent_f->store_line("<true/>");
-					ent_f->store_line("</dict>");
-					ent_f->store_line("</plist>");
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<plist version=\"1.0\">"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<dict>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.app-sandbox</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<key>com.apple.security.inherit</key>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("<true/>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("</dict>"), ERR_FILE_CANT_WRITE);
+					FAIL_ON_WRITE_ERR_V(ent_f, store_line("</plist>"), ERR_FILE_CANT_WRITE);
 				} else {
 					add_message(EXPORT_MESSAGE_ERROR, TTR("Code Signing"), TTR("Could not create helper entitlements file."));
 					err = ERR_CANT_CREATE;
@@ -2647,7 +2648,10 @@ Error EditorExportPlatformMacOS::run(const Ref<EditorExportPreset> &p_preset, in
 			CLEANUP_AND_RETURN(err);
 		}
 
-		f->store_string(run_script);
+		if (!f->store_string(run_script)) {
+			f->abort_backup_save_and_close();
+			CLEANUP_AND_RETURN(ERR_FILE_CANT_WRITE);
+		}
 	}
 
 	{
@@ -2662,7 +2666,10 @@ Error EditorExportPlatformMacOS::run(const Ref<EditorExportPreset> &p_preset, in
 			CLEANUP_AND_RETURN(err);
 		}
 
-		f->store_string(clean_script);
+		if (!f->store_string(clean_script)) {
+			f->abort_backup_save_and_close();
+			CLEANUP_AND_RETURN(ERR_FILE_CANT_WRITE);
+		}
 	}
 
 	print_line("Uploading scripts...");

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -91,11 +91,16 @@ Error EditorExportPlatformWeb::_extract_template(const String &p_template, const
 		String dst = p_dir.path_join(file.replace("godot", p_name));
 		Ref<FileAccess> f = FileAccess::open(dst, FileAccess::WRITE);
 		if (f.is_null()) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), vformat(TTR("Could not open file: \"%s\"."), dst));
+			unzClose(pkg);
+			return ERR_FILE_CANT_WRITE;
+		}
+		if (!f->store_buffer(data.ptr(), data.size())) {
+			f->abort_backup_save_and_close();
 			add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Templates"), vformat(TTR("Could not write file: \"%s\"."), dst));
 			unzClose(pkg);
 			return ERR_FILE_CANT_WRITE;
 		}
-		f->store_buffer(data.ptr(), data.size());
 
 	} while (unzGoToNextFile(pkg) == UNZ_OK);
 	unzClose(pkg);
@@ -108,7 +113,7 @@ Error EditorExportPlatformWeb::_write_or_error(const uint8_t *p_content, int p_s
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Export"), vformat(TTR("Could not write file: \"%s\"."), p_path));
 		return ERR_FILE_CANT_WRITE;
 	}
-	f->store_buffer(p_content, p_size);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer(p_content, p_size), ERR_FILE_CANT_WRITE);
 	return OK;
 }
 

--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -226,14 +226,14 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 
 		Vector<uint8_t> u8 = new_pdb_name.to_utf8_buffer();
 		file->seek(pdb_info.address);
-		file->store_buffer(u8);
+		FAIL_ON_WRITE_ERR_V(file, store_buffer(u8), ERR_FILE_CANT_WRITE);
 
 		// Terminate string and fill the remaining part of the original string with the '\0'.
 		// Can be replaced by file->store_8('\0');
 		Vector<uint8_t> padding_buffer;
 		padding_buffer.resize((int64_t)original_path_size - u8.size());
 		padding_buffer.fill('\0');
-		file->store_buffer(padding_buffer);
+		FAIL_ON_WRITE_ERR_V(file, store_buffer(padding_buffer), ERR_FILE_CANT_WRITE);
 		ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Failed to write a new PDB path to '%s'.", p_dll_path));
 
 		return OK;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -437,8 +437,7 @@ bool HTTPRequest::_update_connection() {
 			if (chunk.size()) {
 				if (file.is_valid()) {
 					const uint8_t *r = chunk.ptr();
-					file->store_buffer(r, chunk.size());
-					if (file->get_error() != OK) {
+					if (!file->store_buffer(r, chunk.size())) {
 						_defer_done(RESULT_DOWNLOAD_FILE_WRITE_ERROR, response_code, response_headers, PackedByteArray());
 						return true;
 					}

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -636,19 +636,19 @@ Error AudioStreamWAV::save_to_wav(const String &p_path) {
 	ERR_FAIL_COND_V(file.is_null(), ERR_FILE_CANT_WRITE);
 
 	// Create WAV Header
-	file->store_string("RIFF"); //ChunkID
-	file->store_32(sub_chunk_2_size + 36); //ChunkSize = 36 + SubChunk2Size (size of entire file minus the 8 bits for this and previous header)
-	file->store_string("WAVE"); //Format
-	file->store_string("fmt "); //Subchunk1ID
-	file->store_32(16); //Subchunk1Size = 16
-	file->store_16(format_code); //AudioFormat
-	file->store_16(n_channels); //Number of Channels
-	file->store_32(sample_rate); //SampleRate
-	file->store_32(sample_rate * n_channels * byte_pr_sample); //ByteRate
-	file->store_16(n_channels * byte_pr_sample); //BlockAlign = NumChannels * BytePrSample
-	file->store_16(byte_pr_sample * 8); //BitsPerSample
-	file->store_string("data"); //Subchunk2ID
-	file->store_32(sub_chunk_2_size); //Subchunk2Size
+	FAIL_ON_WRITE_ERR_V(file, store_string("RIFF"), ERR_FILE_CANT_WRITE); //ChunkID
+	FAIL_ON_WRITE_ERR_V(file, store_32(sub_chunk_2_size + 36), ERR_FILE_CANT_WRITE); //ChunkSize = 36 + SubChunk2Size (size of entire file minus the 8 bits for this and previous header)
+	FAIL_ON_WRITE_ERR_V(file, store_string("WAVE"), ERR_FILE_CANT_WRITE); //Format
+	FAIL_ON_WRITE_ERR_V(file, store_string("fmt "), ERR_FILE_CANT_WRITE); //Subchunk1ID
+	FAIL_ON_WRITE_ERR_V(file, store_32(16), ERR_FILE_CANT_WRITE); //Subchunk1Size = 16
+	FAIL_ON_WRITE_ERR_V(file, store_16(format_code), ERR_FILE_CANT_WRITE); //AudioFormat
+	FAIL_ON_WRITE_ERR_V(file, store_16(n_channels), ERR_FILE_CANT_WRITE); //Number of Channels
+	FAIL_ON_WRITE_ERR_V(file, store_32(sample_rate), ERR_FILE_CANT_WRITE); //SampleRate
+	FAIL_ON_WRITE_ERR_V(file, store_32(sample_rate * n_channels * byte_pr_sample), ERR_FILE_CANT_WRITE); //ByteRate
+	FAIL_ON_WRITE_ERR_V(file, store_16(n_channels * byte_pr_sample), ERR_FILE_CANT_WRITE); //BlockAlign = NumChannels * BytePrSample
+	FAIL_ON_WRITE_ERR_V(file, store_16(byte_pr_sample * 8), ERR_FILE_CANT_WRITE); //BitsPerSample
+	FAIL_ON_WRITE_ERR_V(file, store_string("data"), ERR_FILE_CANT_WRITE); //Subchunk2ID
+	FAIL_ON_WRITE_ERR_V(file, store_32(sub_chunk_2_size), ERR_FILE_CANT_WRITE); //Subchunk2Size
 
 	// Add data
 	Vector<uint8_t> stream_data = get_data();
@@ -657,14 +657,14 @@ Error AudioStreamWAV::save_to_wav(const String &p_path) {
 		case AudioStreamWAV::FORMAT_8_BITS:
 			for (unsigned int i = 0; i < data_bytes; i++) {
 				uint8_t data_point = (read_data[i] + 128);
-				file->store_8(data_point);
+				FAIL_ON_WRITE_ERR_V(file, store_8(data_point), ERR_FILE_CANT_WRITE);
 			}
 			break;
 		case AudioStreamWAV::FORMAT_16_BITS:
 		case AudioStreamWAV::FORMAT_QOA:
 			for (unsigned int i = 0; i < data_bytes / 2; i++) {
 				uint16_t data_point = decode_uint16(&read_data[i * 2]);
-				file->store_16(data_point);
+				FAIL_ON_WRITE_ERR_V(file, store_16(data_point), ERR_FILE_CANT_WRITE);
 			}
 			break;
 		case AudioStreamWAV::FORMAT_IMA_ADPCM:

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -976,13 +976,13 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 				}
 
 				if (is_scene) {
-					fw->store_line("[gd_scene load_steps=" + itos(resources_total) + " format=" + itos(format_version) + uid_text + "]\n");
+					FAIL_ON_WRITE_ERR_V(fw, store_line("[gd_scene load_steps=" + itos(resources_total) + " format=" + itos(format_version) + uid_text + "]\n"), ERR_FILE_CANT_WRITE);
 				} else {
 					String script_res_text;
 					if (!script_class.is_empty()) {
 						script_res_text = "script_class=\"" + script_class + "\" ";
 					}
-					fw->store_line("[gd_resource type=\"" + res_type + "\" " + script_res_text + "load_steps=" + itos(resources_total) + " format=" + itos(format_version) + uid_text + "]\n");
+					FAIL_ON_WRITE_ERR_V(fw, store_line("[gd_resource type=\"" + res_type + "\" " + script_res_text + "load_steps=" + itos(resources_total) + " format=" + itos(format_version) + uid_text + "]\n"), ERR_FILE_CANT_WRITE);
 				}
 			}
 
@@ -1025,7 +1025,7 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 				s += " uid=\"" + ResourceUID::get_singleton()->id_to_text(uid) + "\"";
 			}
 			s += " path=\"" + path + "\" id=\"" + id + "\"]";
-			fw->store_line(s); // Bundled.
+			FAIL_ON_WRITE_ERR_V(fw, store_line(s), ERR_FILE_CANT_WRITE); // Bundled.
 
 			tag_end = f->get_position();
 		}
@@ -1044,15 +1044,15 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 	if (*buffer == '\n') {
 		// Skip first newline character since we added one.
 		if (num_read > 1) {
-			fw->store_buffer(buffer + 1, num_read - 1);
+			FAIL_ON_WRITE_ERR_V(fw, store_buffer(buffer + 1, num_read - 1), ERR_FILE_CANT_WRITE);
 		}
 	} else {
-		fw->store_buffer(buffer, num_read);
+		FAIL_ON_WRITE_ERR_V(fw, store_buffer(buffer, num_read), ERR_FILE_CANT_WRITE);
 	}
 
 	while (!f->eof_reached()) {
 		num_read = f->get_buffer(buffer, buffer_size);
-		fw->store_buffer(buffer, num_read);
+		FAIL_ON_WRITE_ERR_V(fw, store_buffer(buffer, num_read), ERR_FILE_CANT_WRITE);
 	}
 
 	bool all_ok = fw->get_error() == OK;
@@ -1772,8 +1772,8 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			title += " uid=\"" + ResourceUID::get_singleton()->id_to_text(uid) + "\"";
 		}
 
-		f->store_string(title);
-		f->store_line("]\n"); // One empty line.
+		FAIL_ON_WRITE_ERR_V(f, store_string(title), ERR_FILE_CANT_WRITE);
+		FAIL_ON_WRITE_ERR_V(f, store_line("]\n"), ERR_FILE_CANT_WRITE); // One empty line.
 	}
 
 #ifdef TOOLS_ENABLED
@@ -1843,11 +1843,11 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			s += " uid=\"" + ResourceUID::get_singleton()->id_to_text(uid) + "\"";
 		}
 		s += " path=\"" + p + "\" id=\"" + sorted_er[i].id + "\"]\n";
-		f->store_string(s); // Bundled.
+		FAIL_ON_WRITE_ERR_V(f, store_string(s), ERR_FILE_CANT_WRITE); // Bundled.
 	}
 
 	if (external_resources.size()) {
-		f->store_line(String()); // Separate.
+		FAIL_ON_WRITE_ERR_V(f, store_line(String()), ERR_FILE_CANT_WRITE); // Separate.
 	}
 
 	HashSet<String> used_unique_ids;
@@ -1875,7 +1875,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 		}
 
 		if (main) {
-			f->store_line("[resource]");
+			FAIL_ON_WRITE_ERR_V(f, store_line("[resource]"), ERR_FILE_CANT_WRITE);
 		} else {
 			String line = "[sub_resource ";
 			if (res->get_scene_unique_id().is_empty()) {
@@ -1894,7 +1894,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 			String id = res->get_scene_unique_id();
 			line += "type=\"" + _resource_get_class(res) + "\" id=\"" + id;
-			f->store_line(line + "\"]");
+			FAIL_ON_WRITE_ERR_V(f, store_line(line + "\"]"), ERR_FILE_CANT_WRITE);
 			if (takeover_paths) {
 				res->set_path(p_path + "::" + id, true);
 			}
@@ -1951,12 +1951,12 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 				String vars;
 				VariantWriter::write_to_string(value, vars, _write_resources, this, use_compat);
-				f->store_string(name.property_name_encode() + " = " + vars + "\n");
+				FAIL_ON_WRITE_ERR_V(f, store_string(name.property_name_encode() + " = " + vars + "\n"), ERR_FILE_CANT_WRITE);
 			}
 		}
 
 		if (E->next()) {
-			f->store_line(String());
+			FAIL_ON_WRITE_ERR_V(f, store_line(String()), ERR_FILE_CANT_WRITE);
 		}
 	}
 
@@ -2009,39 +2009,39 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 				header += sgroups;
 			}
 
-			f->store_string(header);
+			FAIL_ON_WRITE_ERR_V(f, store_string(header), ERR_FILE_CANT_WRITE);
 
 			if (!instance_placeholder.is_empty()) {
 				String vars;
-				f->store_string(" instance_placeholder=");
+				FAIL_ON_WRITE_ERR_V(f, store_string(" instance_placeholder="), ERR_FILE_CANT_WRITE);
 				VariantWriter::write_to_string(instance_placeholder, vars, _write_resources, this, use_compat);
-				f->store_string(vars);
+				FAIL_ON_WRITE_ERR_V(f, store_string(vars), ERR_FILE_CANT_WRITE);
 			}
 
 			if (instance.is_valid()) {
 				String vars;
-				f->store_string(" instance=");
+				FAIL_ON_WRITE_ERR_V(f, store_string(" instance="), ERR_FILE_CANT_WRITE);
 				VariantWriter::write_to_string(instance, vars, _write_resources, this, use_compat);
-				f->store_string(vars);
+				FAIL_ON_WRITE_ERR_V(f, store_string(vars), ERR_FILE_CANT_WRITE);
 			}
 
-			f->store_line("]");
+			FAIL_ON_WRITE_ERR_V(f, store_line("]"), ERR_FILE_CANT_WRITE);
 
 			for (int j = 0; j < state->get_node_property_count(i); j++) {
 				String vars;
 				VariantWriter::write_to_string(state->get_node_property_value(i, j), vars, _write_resources, this, use_compat);
 
-				f->store_string(String(state->get_node_property_name(i, j)).property_name_encode() + " = " + vars + "\n");
+				FAIL_ON_WRITE_ERR_V(f, store_string(String(state->get_node_property_name(i, j)).property_name_encode() + " = " + vars + "\n"), ERR_FILE_CANT_WRITE);
 			}
 
 			if (i < state->get_node_count() - 1) {
-				f->store_line(String());
+				FAIL_ON_WRITE_ERR_V(f, store_line(String()), ERR_FILE_CANT_WRITE);
 			}
 		}
 
 		for (int i = 0; i < state->get_connection_count(); i++) {
 			if (i == 0) {
-				f->store_line("");
+				FAIL_ON_WRITE_ERR_V(f, store_line(""), ERR_FILE_CANT_WRITE);
 			}
 
 			String connstr = "[connection";
@@ -2060,22 +2060,22 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			}
 
 			Array binds = state->get_connection_binds(i);
-			f->store_string(connstr);
+			FAIL_ON_WRITE_ERR_V(f, store_string(connstr), ERR_FILE_CANT_WRITE);
 			if (binds.size()) {
 				String vars;
 				VariantWriter::write_to_string(binds, vars, _write_resources, this, use_compat);
-				f->store_string(" binds= " + vars);
+				FAIL_ON_WRITE_ERR_V(f, store_string(" binds= " + vars), ERR_FILE_CANT_WRITE);
 			}
 
-			f->store_line("]");
+			FAIL_ON_WRITE_ERR_V(f, store_line("]"), ERR_FILE_CANT_WRITE);
 		}
 
 		Vector<NodePath> editable_instances = state->get_editable_instances();
 		for (int i = 0; i < editable_instances.size(); i++) {
 			if (i == 0) {
-				f->store_line("");
+				FAIL_ON_WRITE_ERR_V(f, store_line(""), ERR_FILE_CANT_WRITE);
 			}
-			f->store_line("[editable path=\"" + editable_instances[i].operator String().c_escape() + "\"]");
+			FAIL_ON_WRITE_ERR_V(f, store_line("[editable path=\"" + editable_instances[i].operator String().c_escape() + "\"]"), ERR_FILE_CANT_WRITE);
 		}
 	}
 
@@ -2095,19 +2095,19 @@ Error ResourceLoaderText::set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid) {
 
 	fw = FileAccess::open(local_path + ".uidren", FileAccess::WRITE);
 	if (is_scene) {
-		fw->store_string("[gd_scene load_steps=" + itos(resources_total) + " format=" + itos(format_version) + " uid=\"" + ResourceUID::get_singleton()->id_to_text(p_uid) + "\"]");
+		FAIL_ON_WRITE_ERR_V(fw, store_string("[gd_scene load_steps=" + itos(resources_total) + " format=" + itos(format_version) + " uid=\"" + ResourceUID::get_singleton()->id_to_text(p_uid) + "\"]"), ERR_FILE_CANT_WRITE);
 	} else {
 		String script_res_text;
 		if (!script_class.is_empty()) {
 			script_res_text = "script_class=\"" + script_class + "\" ";
 		}
 
-		fw->store_string("[gd_resource type=\"" + res_type + "\" " + script_res_text + "load_steps=" + itos(resources_total) + " format=" + itos(format_version) + " uid=\"" + ResourceUID::get_singleton()->id_to_text(p_uid) + "\"]");
+		FAIL_ON_WRITE_ERR_V(fw, store_string("[gd_resource type=\"" + res_type + "\" " + script_res_text + "load_steps=" + itos(resources_total) + " format=" + itos(format_version) + " uid=\"" + ResourceUID::get_singleton()->id_to_text(p_uid) + "\"]"), ERR_FILE_CANT_WRITE);
 	}
 
 	uint8_t c = f->get_8();
 	while (!f->eof_reached()) {
-		fw->store_8(c);
+		FAIL_ON_WRITE_ERR_V(fw, store_8(c), ERR_FILE_CANT_WRITE);
 		c = f->get_8();
 	}
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -356,10 +356,7 @@ Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const Str
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader '" + p_path + "'.");
 
-	file->store_string(source);
-	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
-		return ERR_CANT_CREATE;
-	}
+	FAIL_ON_WRITE_ERR_V(file, store_string(source), ERR_CANT_CREATE);
 
 	return OK;
 }

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -140,10 +140,7 @@ Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, co
 
 	ERR_FAIL_COND_V_MSG(error, error, "Cannot save shader include '" + p_path + "'.");
 
-	file->store_string(source);
-	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
-		return ERR_CANT_CREATE;
-	}
+	FAIL_ON_WRITE_ERR_V(file, store_string(source), ERR_CANT_CREATE);
 
 	return OK;
 }

--- a/servers/movie_writer/movie_writer_mjpeg.cpp
+++ b/servers/movie_writer/movie_writer_mjpeg.cpp
@@ -62,74 +62,74 @@ Error MovieWriterMJPEG::write_begin(const Size2i &p_movie_size, uint32_t p_fps, 
 
 	ERR_FAIL_COND_V(f.is_null(), ERR_CANT_OPEN);
 
-	f->store_buffer((const uint8_t *)"RIFF", 4);
-	f->store_32(0); // Total length (update later)
-	f->store_buffer((const uint8_t *)"AVI ", 4);
-	f->store_buffer((const uint8_t *)"LIST", 4);
-	f->store_32(300); // 4 + 4 + 4 + 56 + 4 + 4 + 132 + 4 + 4 + 84
-	f->store_buffer((const uint8_t *)"hdrl", 4);
-	f->store_buffer((const uint8_t *)"avih", 4);
-	f->store_32(56);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"RIFF", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Total length (update later)
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"AVI ", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"LIST", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(300), ERR_FILE_CANT_WRITE); // 4 + 4 + 4 + 56 + 4 + 4 + 132 + 4 + 4 + 84
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"hdrl", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"avih", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(56), ERR_FILE_CANT_WRITE);
 
-	f->store_32(1000000 / p_fps); // Microsecs per frame.
-	f->store_32(7000); // Max bytes per second
-	f->store_32(0); // Padding Granularity
-	f->store_32(16);
+	FAIL_ON_WRITE_ERR_V(f, store_32(1000000 / p_fps), ERR_FILE_CANT_WRITE); // Microsecs per frame.
+	FAIL_ON_WRITE_ERR_V(f, store_32(7000), ERR_FILE_CANT_WRITE); // Max bytes per second
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Padding Granularity
+	FAIL_ON_WRITE_ERR_V(f, store_32(16), ERR_FILE_CANT_WRITE);
 	total_frames_ofs = f->get_position();
-	f->store_32(0); // Total frames (update later)
-	f->store_32(0); // Initial frames
-	f->store_32(1); // Streams
-	f->store_32(0); // Suggested buffer size
-	f->store_32(p_movie_size.width); // Movie Width
-	f->store_32(p_movie_size.height); // Movie Height
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Total frames (update later)
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Initial frames
+	FAIL_ON_WRITE_ERR_V(f, store_32(1), ERR_FILE_CANT_WRITE); // Streams
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Suggested buffer size
+	FAIL_ON_WRITE_ERR_V(f, store_32(p_movie_size.width), ERR_FILE_CANT_WRITE); // Movie Width
+	FAIL_ON_WRITE_ERR_V(f, store_32(p_movie_size.height), ERR_FILE_CANT_WRITE); // Movie Height
 	for (uint32_t i = 0; i < 4; i++) {
-		f->store_32(0); // Reserved.
+		FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Reserved.
 	}
-	f->store_buffer((const uint8_t *)"LIST", 4);
-	f->store_32(132); // 4 + 4 + 4 + 48 + 4 + 4 + 40 + 4 + 4 + 16
-	f->store_buffer((const uint8_t *)"strl", 4);
-	f->store_buffer((const uint8_t *)"strh", 4);
-	f->store_32(48);
-	f->store_buffer((const uint8_t *)"vids", 4);
-	f->store_buffer((const uint8_t *)"MJPG", 4);
-	f->store_32(0); // Flags
-	f->store_16(0); // Priority
-	f->store_16(0); // Language
-	f->store_32(0); // Initial Frames
-	f->store_32(1); // Scale
-	f->store_32(p_fps); // FPS
-	f->store_32(0); // Start
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"LIST", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(132), ERR_FILE_CANT_WRITE); // 4 + 4 + 4 + 48 + 4 + 4 + 40 + 4 + 4 + 16
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"strl", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"strh", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(48), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"vids", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"MJPG", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Flags
+	FAIL_ON_WRITE_ERR_V(f, store_16(0), ERR_FILE_CANT_WRITE); // Priority
+	FAIL_ON_WRITE_ERR_V(f, store_16(0), ERR_FILE_CANT_WRITE); // Language
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Initial Frames
+	FAIL_ON_WRITE_ERR_V(f, store_32(1), ERR_FILE_CANT_WRITE); // Scale
+	FAIL_ON_WRITE_ERR_V(f, store_32(p_fps), ERR_FILE_CANT_WRITE); // FPS
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Start
 	total_frames_ofs2 = f->get_position();
-	f->store_32(0); // Number of frames (to be updated later)
-	f->store_32(0); // Suggested Buffer Size
-	f->store_32(0); // Quality
-	f->store_32(0); // Sample Size
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Number of frames (to be updated later)
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Suggested Buffer Size
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Quality
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Sample Size
 
-	f->store_buffer((const uint8_t *)"strf", 4);
-	f->store_32(40); // Size.
-	f->store_32(40); // Size.
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"strf", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(40), ERR_FILE_CANT_WRITE); // Size.
+	FAIL_ON_WRITE_ERR_V(f, store_32(40), ERR_FILE_CANT_WRITE); // Size.
 
-	f->store_32(p_movie_size.width); // Width
-	f->store_32(p_movie_size.height); // Width
-	f->store_16(1); // Planes
-	f->store_16(24); // Bitcount
-	f->store_buffer((const uint8_t *)"MJPG", 4); // Compression
+	FAIL_ON_WRITE_ERR_V(f, store_32(p_movie_size.width), ERR_FILE_CANT_WRITE); // Width
+	FAIL_ON_WRITE_ERR_V(f, store_32(p_movie_size.height), ERR_FILE_CANT_WRITE); // Width
+	FAIL_ON_WRITE_ERR_V(f, store_16(1), ERR_FILE_CANT_WRITE); // Planes
+	FAIL_ON_WRITE_ERR_V(f, store_16(24), ERR_FILE_CANT_WRITE); // Bitcount
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"MJPG", 4), ERR_FILE_CANT_WRITE); // Compression
 
-	f->store_32(((p_movie_size.width * 24 / 8 + 3) & 0xFFFFFFFC) * p_movie_size.height); // SizeImage
-	f->store_32(0); // XPelsXMeter
-	f->store_32(0); // YPelsXMeter
-	f->store_32(0); // ClrUsed
-	f->store_32(0); // ClrImportant
+	FAIL_ON_WRITE_ERR_V(f, store_32(((p_movie_size.width * 24 / 8 + 3) & 0xFFFFFFFC) * p_movie_size.height), ERR_FILE_CANT_WRITE); // SizeImage
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // XPelsXMeter
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // YPelsXMeter
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // ClrUsed
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // ClrImportant
 
-	f->store_buffer((const uint8_t *)"LIST", 4);
-	f->store_32(16);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"LIST", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(16), ERR_FILE_CANT_WRITE);
 
-	f->store_buffer((const uint8_t *)"odml", 4);
-	f->store_buffer((const uint8_t *)"dmlh", 4);
-	f->store_32(4); // sizes
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"odml", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"dmlh", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(4), ERR_FILE_CANT_WRITE); // sizes
 
 	total_frames_ofs3 = f->get_position();
-	f->store_32(0); // Number of frames (to be updated later)
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Number of frames (to be updated later)
 
 	// Audio //
 
@@ -151,41 +151,41 @@ Error MovieWriterMJPEG::write_begin(const Size2i &p_movie_size, uint32_t p_fps, 
 	}
 	uint32_t blockalign = bit_depth / 8 * channels;
 
-	f->store_buffer((const uint8_t *)"LIST", 4);
-	f->store_32(84); // 4 + 4 + 4 + 48 + 4 + 4 + 16
-	f->store_buffer((const uint8_t *)"strl", 4);
-	f->store_buffer((const uint8_t *)"strh", 4);
-	f->store_32(48);
-	f->store_buffer((const uint8_t *)"auds", 4);
-	f->store_32(0); // Handler
-	f->store_32(0); // Flags
-	f->store_16(0); // Priority
-	f->store_16(0); // Language
-	f->store_32(0); // Initial Frames
-	f->store_32(blockalign); // Scale
-	f->store_32(mix_rate * blockalign); // mix rate
-	f->store_32(0); // Start
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"LIST", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(84), ERR_FILE_CANT_WRITE); // 4 + 4 + 4 + 48 + 4 + 4 + 16
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"strl", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"strh", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(48), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"auds", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Handler
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Flags
+	FAIL_ON_WRITE_ERR_V(f, store_16(0), ERR_FILE_CANT_WRITE); // Priority
+	FAIL_ON_WRITE_ERR_V(f, store_16(0), ERR_FILE_CANT_WRITE); // Language
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Initial Frames
+	FAIL_ON_WRITE_ERR_V(f, store_32(blockalign), ERR_FILE_CANT_WRITE); // Scale
+	FAIL_ON_WRITE_ERR_V(f, store_32(mix_rate * blockalign), ERR_FILE_CANT_WRITE); // mix rate
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Start
 	total_audio_frames_ofs4 = f->get_position();
-	f->store_32(0); // Number of frames (to be updated later)
-	f->store_32(12288); // Suggested Buffer Size
-	f->store_32(0xFFFFFFFF); // Quality
-	f->store_32(blockalign); // Block Align to 32 bits
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Number of frames (to be updated later)
+	FAIL_ON_WRITE_ERR_V(f, store_32(12288), ERR_FILE_CANT_WRITE); // Suggested Buffer Size
+	FAIL_ON_WRITE_ERR_V(f, store_32(0xFFFFFFFF), ERR_FILE_CANT_WRITE); // Quality
+	FAIL_ON_WRITE_ERR_V(f, store_32(blockalign), ERR_FILE_CANT_WRITE); // Block Align to 32 bits
 
 	audio_block_size = (mix_rate / fps) * blockalign;
 
-	f->store_buffer((const uint8_t *)"strf", 4);
-	f->store_32(16); // Standard format, no extra fields
-	f->store_16(1); // Compression code, standard PCM
-	f->store_16(channels);
-	f->store_32(mix_rate); // Samples (frames) / Sec
-	f->store_32(mix_rate * blockalign); // Bytes / sec
-	f->store_16(blockalign); // Bytes / sec
-	f->store_16(bit_depth); // Bytes / sec
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"strf", 4), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(16), ERR_FILE_CANT_WRITE); // Standard format, no extra fields
+	FAIL_ON_WRITE_ERR_V(f, store_16(1), ERR_FILE_CANT_WRITE); // Compression code, standard PCM
+	FAIL_ON_WRITE_ERR_V(f, store_16(channels), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_32(mix_rate), ERR_FILE_CANT_WRITE); // Samples (frames) / Sec
+	FAIL_ON_WRITE_ERR_V(f, store_32(mix_rate * blockalign), ERR_FILE_CANT_WRITE); // Bytes / sec
+	FAIL_ON_WRITE_ERR_V(f, store_16(blockalign), ERR_FILE_CANT_WRITE); // Bytes / sec
+	FAIL_ON_WRITE_ERR_V(f, store_16(bit_depth), ERR_FILE_CANT_WRITE); // Bytes / sec
 
-	f->store_buffer((const uint8_t *)"LIST", 4);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"LIST", 4), ERR_FILE_CANT_WRITE);
 	movi_data_ofs = f->get_position();
-	f->store_32(0); // Number of frames (to be updated later)
-	f->store_buffer((const uint8_t *)"movi", 4);
+	FAIL_ON_WRITE_ERR_V(f, store_32(0), ERR_FILE_CANT_WRITE); // Number of frames (to be updated later)
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"movi", 4), ERR_FILE_CANT_WRITE);
 
 	return OK;
 }
@@ -196,18 +196,18 @@ Error MovieWriterMJPEG::write_frame(const Ref<Image> &p_image, const int32_t *p_
 	Vector<uint8_t> jpg_buffer = p_image->save_jpg_to_buffer(quality);
 	uint32_t s = jpg_buffer.size();
 
-	f->store_buffer((const uint8_t *)"00db", 4); // Stream 0, Video
-	f->store_32(jpg_buffer.size()); // sizes
-	f->store_buffer(jpg_buffer.ptr(), jpg_buffer.size());
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"00db", 4), ERR_FILE_CANT_WRITE); // Stream 0, Video
+	FAIL_ON_WRITE_ERR_V(f, store_32(jpg_buffer.size()), ERR_FILE_CANT_WRITE); // sizes
+	FAIL_ON_WRITE_ERR_V(f, store_buffer(jpg_buffer.ptr(), jpg_buffer.size()), ERR_FILE_CANT_WRITE);
 	if (jpg_buffer.size() & 1) {
-		f->store_8(0);
+		FAIL_ON_WRITE_ERR_V(f, store_8(0), ERR_FILE_CANT_WRITE);
 		s++;
 	}
 	jpg_frame_sizes.push_back(s);
 
-	f->store_buffer((const uint8_t *)"01wb", 4); // Stream 1, Audio.
-	f->store_32(audio_block_size);
-	f->store_buffer((const uint8_t *)p_audio_data, audio_block_size);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)"01wb", 4), ERR_FILE_CANT_WRITE); // Stream 1, Audio.
+	FAIL_ON_WRITE_ERR_V(f, store_32(audio_block_size), ERR_FILE_CANT_WRITE);
+	FAIL_ON_WRITE_ERR_V(f, store_buffer((const uint8_t *)p_audio_data, audio_block_size), ERR_FILE_CANT_WRITE);
 
 	frame_count++;
 
@@ -217,22 +217,22 @@ Error MovieWriterMJPEG::write_frame(const Ref<Image> &p_image, const int32_t *p_
 void MovieWriterMJPEG::write_end() {
 	if (f.is_valid()) {
 		// Finalize the file (frame indices)
-		f->store_buffer((const uint8_t *)"idx1", 4);
-		f->store_32(8 * 4 * frame_count);
+		FAIL_ON_WRITE_ERR(f, store_buffer((const uint8_t *)"idx1", 4));
+		FAIL_ON_WRITE_ERR(f, store_32(8 * 4 * frame_count));
 		uint32_t ofs = 4;
 		uint32_t all_data_size = 0;
 		for (uint32_t i = 0; i < frame_count; i++) {
-			f->store_buffer((const uint8_t *)"00db", 4);
-			f->store_32(16); // AVI_KEYFRAME
-			f->store_32(ofs);
-			f->store_32(jpg_frame_sizes[i]);
+			FAIL_ON_WRITE_ERR(f, store_buffer((const uint8_t *)"00db", 4));
+			FAIL_ON_WRITE_ERR(f, store_32(16)); // AVI_KEYFRAME
+			FAIL_ON_WRITE_ERR(f, store_32(ofs));
+			FAIL_ON_WRITE_ERR(f, store_32(jpg_frame_sizes[i]));
 
 			ofs += jpg_frame_sizes[i] + 8;
 
-			f->store_buffer((const uint8_t *)"01wb", 4);
-			f->store_32(16); // AVI_KEYFRAME
-			f->store_32(ofs);
-			f->store_32(audio_block_size);
+			FAIL_ON_WRITE_ERR(f, store_buffer((const uint8_t *)"01wb", 4));
+			FAIL_ON_WRITE_ERR(f, store_32(16)); // AVI_KEYFRAME
+			FAIL_ON_WRITE_ERR(f, store_32(ofs));
+			FAIL_ON_WRITE_ERR(f, store_32(audio_block_size));
 
 			ofs += audio_block_size + 8;
 			all_data_size += jpg_frame_sizes[i] + audio_block_size;
@@ -240,17 +240,17 @@ void MovieWriterMJPEG::write_end() {
 
 		uint32_t file_size = f->get_position();
 		f->seek(4);
-		f->store_32(file_size - 78);
+		FAIL_ON_WRITE_ERR(f, store_32(file_size - 78));
 		f->seek(total_frames_ofs);
-		f->store_32(frame_count);
+		FAIL_ON_WRITE_ERR(f, store_32(frame_count));
 		f->seek(total_frames_ofs2);
-		f->store_32(frame_count);
+		FAIL_ON_WRITE_ERR(f, store_32(frame_count));
 		f->seek(total_frames_ofs3);
-		f->store_32(frame_count);
+		FAIL_ON_WRITE_ERR(f, store_32(frame_count));
 		f->seek(total_audio_frames_ofs4);
-		f->store_32(frame_count * mix_rate / fps);
+		FAIL_ON_WRITE_ERR(f, store_32(frame_count * mix_rate / fps));
 		f->seek(movi_data_ofs);
-		f->store_32(all_data_size + 4 + 16 * frame_count);
+		FAIL_ON_WRITE_ERR(f, store_32(all_data_size + 4 + 16 * frame_count));
 
 		f.unref();
 	}


### PR DESCRIPTION
- Adds `abort_backup_save_and_close` method to close and delete temporary file without overwriting original file (when `OS.set_use_file_access_save_and_swap` is enabled).
- Fail various editor save operations on write errors, and use aforementioned method to ensure original file is not overwritten.

TODO:
- [x] Apply to all save operations.