### PR TITLE
Simplify `NavMeshQueries3D::simplify_path_segment`

### DIFF
--- a/modules/navigation/3d/nav_mesh_queries_3d.h
+++ b/modules/navigation/3d/nav_mesh_queries_3d.h
@@ -116,7 +116,7 @@ public:
 	static void clip_path(NavMeshPathQueryTask3D &p_query_task, const LocalVector<gd::NavigationPoly> &p_navigation_polys, const gd::NavigationPoly *from_poly, const Vector3 &p_to_point, const gd::NavigationPoly *p_to_poly, const Vector3 &p_map_up);
 	static void _query_task_simplified_path_points(NavMeshPathQueryTask3D &p_query_task);
 
-	static void simplify_path_segment(int p_start_inx, int p_end_inx, const LocalVector<Vector3> &p_points, real_t p_epsilon, LocalVector<bool> &r_valid_points);
+	static void simplify_path_segment(int p_start_inx, int p_end_inx, const LocalVector<Vector3> &p_points, real_t p_epsilon, LocalVector<uint32_t> &r_simplified_path_indices);
 	static LocalVector<uint32_t> get_simplified_path_indices(const LocalVector<Vector3> &p_path, real_t p_epsilon);
 };
 


### PR DESCRIPTION
Remove the use of intermediate sparse vector, and directly push into result.

No need to reconstruct at the end.

During my tests, this was saving around 2 000 cycles of startup time. The algorithm is the same, so no gain there.

This was discussed in [this code review]( https://github.com/godotengine/godot/pull/100129#issuecomment-2537424621)