### PR TITLE
Fix GridMap freeing edge connection debug mesh too early

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -850,7 +850,7 @@ void GridMap::_octant_exit_world(const OctantKey &p_key) {
 			g.navigation_debug_edge_connections_instance = RID();
 		}
 		if (g.navigation_debug_edge_connections_mesh.is_valid()) {
-			RenderingServer::get_singleton()->free(g.navigation_debug_edge_connections_mesh->get_rid());
+			g.navigation_debug_edge_connections_mesh.unref();
 		}
 	}
 #endif // DEBUG_ENABLED
@@ -891,7 +891,7 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 			g.navigation_debug_edge_connections_instance = RID();
 		}
 		if (g.navigation_debug_edge_connections_mesh.is_valid()) {
-			RenderingServer::get_singleton()->free(g.navigation_debug_edge_connections_mesh->get_rid());
+			g.navigation_debug_edge_connections_mesh.unref();
 		}
 	}
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
Fixes GridMap freeing edge connection debug mesh too early.

Fixes https://github.com/godotengine/godot/issues/98821


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
