### PR TITLE
[DRAFT] Add a way to fully create a ConcavePolygonShape3D in calling thread

### DIFF
--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -120,6 +120,14 @@ RID JoltPhysicsServer3D::concave_polygon_shape_create() {
 	return rid;
 }
 
+RID JoltPhysicsServer3D::concave_polygon_shape_create_immediate(Variant params) {
+	JoltConcavePolygonShape3D *shape = JoltConcavePolygonShape3D::create_with_data(params);
+	ERR_FAIL_COND_V(shape == nullptr, RID());
+	RID rid = shape_owner.make_rid(shape);
+	shape->set_rid(rid);
+	return rid;
+}
+
 RID JoltPhysicsServer3D::heightmap_shape_create() {
 	JoltShape3D *shape = memnew(JoltHeightMapShape3D);
 	RID rid = shape_owner.make_rid(shape);

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -134,6 +134,7 @@ public:
 	virtual RID cylinder_shape_create() override;
 	virtual RID convex_polygon_shape_create() override;
 	virtual RID concave_polygon_shape_create() override;
+	virtual RID concave_polygon_shape_create_immediate(Variant params) override;
 	virtual RID heightmap_shape_create() override;
 	virtual RID custom_shape_create() override;
 

--- a/modules/jolt_physics/shapes/jolt_concave_polygon_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_concave_polygon_shape_3d.cpp
@@ -34,8 +34,16 @@
 #include "../misc/jolt_type_conversions.h"
 
 #include "Jolt/Physics/Collision/Shape/MeshShape.h"
+// #include "modules/voxel/util/profiling.h"
 
 JPH::ShapeRefC JoltConcavePolygonShape3D::_build() const {
+	// ZoneScoped;
+
+	if (prebuilt_shape != nullptr) {
+		// The shape was already built manually up-front
+		return prebuilt_shape;
+	}
+
 	const int vertex_count = (int)faces.size();
 	const int face_count = vertex_count / 3;
 	const int excess_vertex_count = vertex_count % 3;
@@ -78,20 +86,209 @@ JPH::ShapeRefC JoltConcavePolygonShape3D::_build() const {
 	return JoltShape3D::with_double_sided(shape_result.Get(), back_face_collision);
 }
 
-AABB JoltConcavePolygonShape3D::_calculate_aabb() const {
-	AABB result;
+// TODO This should simply be a Span, see https://github.com/godotengine/godot/pull/100293
+template <typename T>
+struct ArrayView {
+	const T *_data;
+	int _size;
 
-	for (int i = 0; i < faces.size(); ++i) {
-		const Vector3 &vertex = faces[i];
-
-		if (i == 0) {
-			result.position = vertex;
-		} else {
-			result.expand_to(vertex);
-		}
+	ArrayView(T *p_ptr, const int p_size) :
+			_data(p_ptr), _size(p_size) {
+		CRASH_COND(p_size < 0);
 	}
 
-	return result;
+	inline const T &operator[](const int p_index) const {
+#ifdef DEBUG_ENABLED
+		CRASH_BAD_INDEX(p_index, _size);
+#endif
+		return _data[p_index];
+	}
+
+	inline int size() const {
+		return _size;
+	}
+};
+
+static bool copy_to_jolt_indexed_triangle_list(const ArrayView<const int32_t> indices, JPH::IndexedTriangleList &jolt_triangle_indices) {
+	const int face_count = (int)indices.size() / 3;
+	const int excess_index_count = indices.size() % 3;
+
+	ERR_FAIL_COND_V(excess_index_count != 0, false);
+
+	ERR_FAIL_COND_V(jolt_triangle_indices.size() != 0, false);
+	jolt_triangle_indices.reserve((size_t)face_count);
+
+	for (int tri_index = 0; tri_index < face_count; ++tri_index) {
+		const unsigned int ii0 = tri_index * 3;
+		const unsigned int ii1 = ii0 + 1;
+		const unsigned int ii2 = ii0 + 2;
+
+		const int32_t i0 = indices[ii0];
+		const int32_t i1 = indices[ii1];
+		const int32_t i2 = indices[ii2];
+
+		// Jolt uses a different winding order, so we swizzle the vertices to account for that.
+		jolt_triangle_indices.emplace_back(JPH::IndexedTriangle(i2, i1, i0));
+	}
+
+	return true;
+}
+
+// Alternate build function taking an indexed triangle list, which is closer to what Jolt natively expects,
+// and faster since it doesn't have to use Indexify internally.
+static JPH::ShapeRefC build_from_indexed_triangles(const ArrayView<const Vector3> vertices, const ArrayView<const int32_t> indices, const bool back_face_collision) {
+	const int vertex_count = (int)vertices.size();
+	const int excess_index_count = indices.size() % 3;
+
+	if (unlikely(vertex_count == 0)) {
+		return nullptr;
+	}
+
+	ERR_FAIL_COND_V_MSG(vertex_count < 3, nullptr,
+			vformat("Failed to build Jolt Physics concave polygon shape. It must have a vertex count of at least 3."));
+	ERR_FAIL_COND_V_MSG(excess_index_count != 0, nullptr,
+			vformat("Failed to build Jolt Physics concave polygon shape. It must have an index count that is divisible by 3."));
+
+	JPH::VertexList jolt_vertices;
+	jolt_vertices.reserve((size_t)vertex_count);
+	// Godot could be using doubles in Vector3, so can't memcpy
+	for (int vertex_index = 0; vertex_index < vertex_count; ++vertex_index) {
+		const Vector3 v = vertices[vertex_index];
+		jolt_vertices.emplace_back(JPH::Float3(v.x, v.y, v.z));
+	}
+
+	JPH::IndexedTriangleList jolt_triangle_indices;
+	ERR_FAIL_COND_V(!copy_to_jolt_indexed_triangle_list(indices, jolt_triangle_indices), nullptr);
+
+	// TODO Why is this constructor taking arrays by value? Won't this cause unnecessary copies and allocations?
+	// JPH::MeshShapeSettings shape_settings(jolt_vertices, jolt_triangles);
+	JPH::MeshShapeSettings shape_settings;
+	shape_settings.mTriangleVertices = std::move(jolt_vertices);
+	shape_settings.mIndexedTriangles = std::move(jolt_triangle_indices);
+	shape_settings.Sanitize();
+	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
+	shape_settings.mPerTriangleUserData = JoltProjectSettings::enable_ray_cast_face_index();
+
+	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr,
+			vformat("Failed to build Jolt Physics concave polygon shape. It returned the following error: '%s'.",
+					to_godot(shape_result.GetError())));
+
+	// TODO Will this double the baking work? Need to investigate
+	return JoltShape3D::with_double_sided(shape_result.Get(), back_face_collision);
+}
+
+static PackedVector3Array deindex_mesh(const ArrayView<const Vector3> vertices, const ArrayView<const int32_t> indices) {
+	PackedVector3Array output_vertices;
+	output_vertices.resize(indices.size());
+	Vector3 *output_vertices_raw = output_vertices.ptrw();
+
+	for (int ii = 0; ii < indices.size(); ++ii) {
+		const int32_t i = indices[ii];
+		output_vertices_raw[ii] = vertices[i];
+	}
+
+	return output_vertices;
+}
+
+static AABB get_aabb_from_vertices(const ArrayView<const Vector3> vertices) {
+	const int vertex_count = (int)vertices.size();
+
+	if (vertex_count == 0) {
+		return AABB();
+	}
+
+	Vector3 min_p = vertices[0];
+	Vector3 max_p = min_p;
+
+	for (int i = 1; i < vertex_count; ++i) {
+		const Vector3 p = vertices[i];
+		min_p = min_p.min(p);
+		max_p = max_p.max(p);
+	}
+
+	return AABB(min_p, max_p - min_p);
+}
+
+static bool read_and_validate_range(const Variant &v, Vector2i &out_range, const int size_limit) {
+	ERR_FAIL_COND_V(v.get_type() != Variant::VECTOR2I, false);
+	const Vector2i range = v;
+	ERR_FAIL_COND_V(range.x > range.y, false); // Must be sorted or equal
+	ERR_FAIL_COND_V(range.x < 0, false); // Must not be negative
+	ERR_FAIL_COND_V(range.y > size_limit, false); // Must be in bounds
+	out_range = range;
+	return true;
+}
+
+JoltConcavePolygonShape3D *JoltConcavePolygonShape3D::create_with_data(const Variant &p_data) {
+	JoltConcavePolygonShape3D *self = nullptr;
+
+	// Not using a dictionary, creating strings and hashing keys sounds quite unnecessary.
+	if (p_data.get_type() == Variant::ARRAY) {
+		const Array data_array = p_data;
+		const int expected_param_count = 5;
+		ERR_FAIL_COND_V_MSG(data_array.size() != expected_param_count, nullptr, vformat("Expected %d parameters, got %d", expected_param_count, data_array.size()));
+
+		const Variant vertex_data_v = data_array[0];
+		const Variant indices_v = data_array[1];
+		const Variant vertex_range_v = data_array[2];
+		const Variant index_range_v = data_array[3];
+		const Variant back_face_collision_v = data_array[4];
+
+		// TODO In double-precision builds of Godot, expecting PackedVector3Array has extra overhead.
+		// Because Vector3 will then use doubles, which Jolt doesn't need. On the side of the caller,
+		// GDExtensions are also likely to use a different container type if they generate meshes procedurally,
+		// and having to allocate a PackedVector3Array only to "talk" to the Godot API.
+		// It would be nice if we could pass Spans around to avoid this overhead
+		// (which we could do safely here, since the current function is meant to create the shape immediately,
+		// instead of being deferred in MT mode), though it would be only a GDExtension thing.
+		ERR_FAIL_COND_V(vertex_data_v.get_type() != Variant::PACKED_VECTOR3_ARRAY, nullptr);
+		const PackedVector3Array vertices_array = vertex_data_v;
+
+		ERR_FAIL_COND_V(indices_v.get_type() != Variant::PACKED_INT32_ARRAY, nullptr);
+		const PackedInt32Array indices_array = indices_v;
+
+		ERR_FAIL_COND_V(back_face_collision_v.get_type() != Variant::BOOL, nullptr);
+		const bool back_face_collision = back_face_collision_v;
+
+		// Allow to specify a sub-region of the mesh, to avoid having to allocate extra packed arrays
+		// TODO If we had the ability to pass Spans, this wouldn't be necessary.
+		// Maybe we can do that for GDExtensions, but not sure we can in script-land.
+		Vector2i vertex_range(0, vertices_array.size());
+		if (vertex_range_v.get_type() != Variant::NIL) {
+			ERR_FAIL_COND_V(!read_and_validate_range(vertex_range_v, vertex_range, vertices_array.size()), nullptr);
+		}
+		const ArrayView<const Vector3> vertices(vertices_array.ptr() + vertex_range.x, vertex_range.y - vertex_range.x);
+
+		Vector2i index_range(0, indices_array.size());
+		if (index_range_v.get_type() != Variant::NIL) {
+			ERR_FAIL_COND_V(!read_and_validate_range(index_range_v, index_range, indices_array.size()), nullptr);
+		}
+		const ArrayView<const int32_t> indices(indices_array.ptr() + index_range.x, index_range.y - index_range.x);
+
+		self = memnew(JoltConcavePolygonShape3D);
+
+		// TODO `faces` are almost useless after the Jolt object is created.
+		// In a project that uses lots of mesh colliders, it wastes resources, especially with double-precision builds,
+		// and the fact it is deindexed (vertices are not shared). May we reset them? What about debugging?
+		// Couldn't we just get the data from Jolt if that's necessary?
+		self->faces = deindex_mesh(vertices, indices);
+
+		self->back_face_collision = back_face_collision;
+		self->prebuilt_shape = build_from_indexed_triangles(vertices, indices, back_face_collision);
+		// Don't use _get_aabb, so that we don't depend on `faces`, and will iterate less vertices when indexed
+		self->aabb = ::get_aabb_from_vertices(vertices);
+
+	} else {
+		ERR_PRINT("Invalid parameter");
+		return nullptr;
+	}
+
+	return self;
+}
+
+AABB JoltConcavePolygonShape3D::_calculate_aabb() const {
+	return get_aabb_from_vertices(ArrayView<const Vector3>(faces.ptr(), faces.size()));
 }
 
 Variant JoltConcavePolygonShape3D::get_data() const {
@@ -116,6 +313,13 @@ void JoltConcavePolygonShape3D::set_data(const Variant &p_data) {
 	back_face_collision = maybe_back_face_collision;
 
 	aabb = _calculate_aabb();
+
+	// When the physics server is set to "run in a separate thread",
+	// it is wrapped in PhysicsServer3DWrapMT, which makes `set_data` a deferred function.
+	// We can't guarantee whether `set_data` is called due to initializing the shape after creation,
+	// or if it's the user changing properties later on.
+	// `prebuilt_shape` is used when all data is specified at creation time, so we can't use it from now.
+	prebuilt_shape = JPH::ShapeRefC();
 
 	destroy();
 }

--- a/modules/jolt_physics/shapes/jolt_concave_polygon_shape_3d.h
+++ b/modules/jolt_physics/shapes/jolt_concave_polygon_shape_3d.h
@@ -37,12 +37,15 @@ class JoltConcavePolygonShape3D final : public JoltShape3D {
 	AABB aabb;
 	PackedVector3Array faces;
 	bool back_face_collision = false;
+	JPH::ShapeRefC prebuilt_shape;
 
 	virtual JPH::ShapeRefC _build() const override;
 
 	AABB _calculate_aabb() const;
 
 public:
+	static JoltConcavePolygonShape3D *create_with_data(const Variant &p_data);
+
 	virtual ShapeType get_type() const override { return ShapeType::SHAPE_CONCAVE_POLYGON; }
 	virtual bool is_convex() const override { return false; }
 

--- a/scene/resources/3d/concave_polygon_shape_3d.h
+++ b/scene/resources/3d/concave_polygon_shape_3d.h
@@ -61,6 +61,8 @@ class ConcavePolygonShape3D : public Shape3D {
 		}
 	};
 
+	ConcavePolygonShape3D(const PackedVector3Array &vertices, const PackedInt32Array &indices, const Vector2i vertex_range, const Vector2i index_range, const bool backface_enabled);
+
 protected:
 	static void _bind_methods();
 
@@ -76,6 +78,9 @@ public:
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
 	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
 	virtual real_t get_enclosing_radius() const override;
+
+	static Ref<ConcavePolygonShape3D> create_immediate_from_indexed_mesh(
+			const PackedVector3Array &vertices, const PackedInt32Array &indices, const Vector2i vertex_range, const Vector2i index_range, const bool backface_enabled);
 
 	ConcavePolygonShape3D();
 };

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -73,7 +73,12 @@ void Shape3D::set_debug_color(const Color &p_color) {
 	}
 
 	debug_color = p_color;
-	_update_shape();
+
+	// Don't update the physics shape, this is for debugging only and should not affect physics.
+	// Only invalidate the debug mesh cache, and emit a changed signal afterwards
+	// (since listeners may want to call get_debug_mesh())
+	debug_mesh_cache.unref();
+	emit_changed();
 }
 
 Color Shape3D::get_debug_color() const {
@@ -86,7 +91,9 @@ void Shape3D::set_debug_fill(bool p_fill) {
 	}
 
 	debug_fill = p_fill;
-	_update_shape();
+
+	debug_mesh_cache.unref();
+	emit_changed();
 }
 
 bool Shape3D::get_debug_fill() const {
@@ -159,7 +166,10 @@ Ref<Material> Shape3D::get_debug_collision_material() {
 }
 
 void Shape3D::_update_shape() {
+	// Does nothing special by default, actual update is implemented in derived classes
 	emit_changed();
+	// TODO Why are we invalidating the mesh afterwards? Listeners may want to call get_debug_mesh,
+	// which will either pick the old version of this mesh, or will cause it to be recreated twice.
 	debug_mesh_cache.unref();
 }
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -689,6 +689,11 @@ RID PhysicsServer3D::shape_create(ShapeType p_shape) {
 	}
 }
 
+RID PhysicsServer3D::concave_polygon_shape_create_immediate(Variant params) {
+	ERR_PRINT("Not implemented");
+	return RID();
+}
+
 void PhysicsServer3D::_bind_methods() {
 #ifndef _3D_DISABLED
 
@@ -700,6 +705,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("cylinder_shape_create"), &PhysicsServer3D::cylinder_shape_create);
 	ClassDB::bind_method(D_METHOD("convex_polygon_shape_create"), &PhysicsServer3D::convex_polygon_shape_create);
 	ClassDB::bind_method(D_METHOD("concave_polygon_shape_create"), &PhysicsServer3D::concave_polygon_shape_create);
+	ClassDB::bind_method(D_METHOD("concave_polygon_shape_create_immediate", "params"), &PhysicsServer3D::concave_polygon_shape_create_immediate);
 	ClassDB::bind_method(D_METHOD("heightmap_shape_create"), &PhysicsServer3D::heightmap_shape_create);
 	ClassDB::bind_method(D_METHOD("custom_shape_create"), &PhysicsServer3D::custom_shape_create);
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -270,6 +270,13 @@ public:
 	virtual RID heightmap_shape_create() = 0;
 	virtual RID custom_shape_create() = 0;
 
+	// This method is intented to be used in advanced cases where a lot of shapes are created procedurally at runtime.
+	// It can be called from a custom background thread to move the work away from the main thread or the physics thread.
+	// This is a specific "fast path" for GDExtensions and maybe scripts.
+	// Ideally, creating any shape should work in that way so that even loading a scene in a thread would benefit from this
+	// approach, but the current design of the physics API and properties being assignable anywhere anytime makes this difficult.
+	virtual RID concave_polygon_shape_create_immediate(Variant params);
+
 	virtual void shape_set_data(RID p_shape, const Variant &p_data) = 0;
 	virtual void shape_set_custom_solver_bias(RID p_shape, real_t p_bias) = 0;
 

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -86,6 +86,10 @@ public:
 	FUNCRID(heightmap_shape)
 	FUNCRID(custom_shape)
 
+	virtual RID concave_polygon_shape_create_immediate(Variant params) override {
+		return physics_server_3d->concave_polygon_shape_create_immediate(params);
+	}
+
 	FUNC2(shape_set_data, RID, const Variant &);
 	FUNC2(shape_set_custom_solver_bias, RID, real_t);
 


### PR DESCRIPTION
This is a work-in-progress, mainly for discussion. I don't consider it ready for now.

Attempts to solve the issue mentionned in https://github.com/godotengine/godot/pull/99895#issuecomment-2515366434
This gives control about when the heavy work is executed when creating a lof or mesh colliders at runtime, typically in procedural terrains. So creating chunks in multiple background threads, away from frame-dependent stuff, becomes easy.

Before this, a typical chunk would look like this in the profiler. Lots of these, executed in serial, either on the main thread or the physics thread:
![image](https://github.com/user-attachments/assets/1d5e9f2e-6150-4b84-a5ca-8a2043686a53)

After this, I can do the following in multiple background threads (including priority sorting and cancellation in case of spams, which wouldn't be easy if it was deferred):
![image](https://github.com/user-attachments/assets/be2ebd89-3d4b-44bb-a2d6-c3a87dcaad8b)

- Adds a new method to create concave polygon shapes on `PhysicsServer3D` and `ConcavePolygonShape3D`, which expects all properties to be specified at once. Contrary to `shape_set_data`, it is not deferred even when the physics server is wrapped inside `PhysicsServer3DWrapMT`
- Expects an indexed mesh instead of triplets of Vector3 for each triangle. This saves the hassle of having to de-index meshes that are usually indexed already. And Jolt uses indexed meshes natively, so it also saves it from using `Indexify` internally
- Allows to specify a sub-range of the passed mesh data. This saves the caller from having to allocate extra temporary packed arrays just to select a specific range of the mesh.
- Optimizes AABB calculation a little bit by moving a branch outside of the loop and having it work on the indexed mesh, which likely has less vertices
- Don't update the physics shape in Shape3D when setting its debug color or debug fill properties. These should only invalidate the debug mesh and emit a change signal, not invalidate the physics shape (which would cause it to be rebuilt, throwing out the fastpath out the window)
- Only implemented with Jolt for now

There are more details and questions in TODO comments in the code.

While this seems to work, I'm not super happy about the approach. It is a very specific API, separate from how everything else is done. I actually wish that shapes (especially those involving heavy cooking like meshes) should be creatable in that specific way by default, while also using their properties like usual. Like, somehow making `set_shape_data` non-deferred when called the first time, and deferred if called more after? It wouldn't only give control when balancing threaded tasks in projects like mine, but it would also do the expected thing when loading scenes or resources with Godot's threaded loader.

However, so far I could not think of any other way (not without refactoring more things), because in Godot, properties can be set anywhere anytime, and the fact that the `run in separate thread` option is implemented by deferring every relevant method. So it is quite difficult to guarantee that the work is done on the caller thread, while still benefiting from multi-threaded *physics simulation*, while also not disrupting the physics engine if the shape has already been attached to a body (not my case, but this is a possibility to guard for; and it is guaranteed to not be the case in a function that fully creates a shape in one call).

---

Side note: I currently realize a part of this code could be split into a separate PR that could be easier to merge: support for indexed mesh when creating a mesh shape. As you can see in the profiling screenshot, re-indexing a mesh is expensive and it currently happens because the Godot API is expecting it to be so. If an index buffer could be passed optionally, it would optimize that step, and wouldn't break compatibility.