### PR TITLE
Capitalize INF, -INF, and NAN in serializing

### DIFF
--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -46,7 +46,7 @@ String DocData::get_default_value_string(const Variant &p_value) {
 		// documentation values to avoid garbage digits at the end.
 		const String s = String::num_scientific((float)p_value);
 		// Use float literals for floats in the documentation for clarity.
-		if (s != "inf" && s != "-inf" && s != "nan") {
+		if (s != "INF" && s != "-INF" && s != "NAN") {
 			if (!s.contains_char('.') && !s.contains_char('e')) {
 				return s + ".0";
 			}

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1073,7 +1073,13 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 				return s.substr(2).to_int();
 			} else if (s.begins_with("f:")) {
 				const String sub = s.substr(2);
-				if (sub == "inf") {
+				if (sub == "INF") {
+					return Math::INF;
+				} else if (sub == "-INF") {
+					return -Math::INF;
+				} else if (sub == "NAN") {
+					return Math::NaN;
+				} else if (sub == "inf") {
 					return Math::INF;
 				} else if (sub == "-inf") {
 					return -Math::INF;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1409,14 +1409,14 @@ String String::to_lower() const {
 
 String String::num(double p_num, int p_decimals) {
 	if (Math::is_nan(p_num)) {
-		return "nan";
+		return "NAN";
 	}
 
 	if (Math::is_inf(p_num)) {
 		if (std::signbit(p_num)) {
-			return "-inf";
+			return "-INF";
 		} else {
-			return "inf";
+			return "INF";
 		}
 	}
 

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3526,7 +3526,7 @@ void Variant::construct_from_string(const String &p_string, Variant &r_value, Ob
 
 String Variant::get_construct_string() const {
 	String vars;
-	VariantWriter::write_to_string(*this, vars, false);
+	VariantWriter::write_to_string(*this, vars, false, nullptr, nullptr, false);
 
 	return vars;
 }

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -148,12 +148,12 @@ const char *VariantParser::tk_name[TK_MAX] = {
 };
 
 static double stor_fix(const String &p_str) {
-	if (p_str == "inf") {
+	// Lowercase inf, -inf, inf_neg, and nan kept for compatibility.
+	if (p_str == "INF" || p_str == "inf") {
 		return Math::INF;
-	} else if (p_str == "-inf" || p_str == "inf_neg") {
-		// inf_neg kept for compatibility.
+	} else if (p_str == "-INF" || p_str == "-inf" || p_str == "inf_neg") {
 		return -Math::INF;
-	} else if (p_str == "nan") {
+	} else if (p_str == "NAN" || p_str == "nan") {
 		return Math::NaN;
 	}
 	return -1;
@@ -699,12 +699,14 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			r_value = false;
 		} else if (id == "null" || id == "nil") {
 			r_value = Variant();
-		} else if (id == "inf") {
+		} else if (id == "INF" || id == "inf") {
+			// Lowercase inf is kept for compatibility.
 			r_value = Math::INF;
-		} else if (id == "-inf" || id == "inf_neg") {
-			// inf_neg kept for compatibility.
+		} else if (id == "-INF" || id == "-inf" || id == "inf_neg") {
+			// Lowercase -inf and inf_neg are kept for compatibility.
 			r_value = -Math::INF;
-		} else if (id == "nan") {
+		} else if (id == "NAN" || id == "nan") {
+			// Lowercase nan is kept for compatibility.
 			r_value = Math::NaN;
 		} else if (id == "Vector2") {
 			Vector<real_t> args;
@@ -1987,9 +1989,15 @@ static String rtos_fix(double p_value, bool p_compat) {
 	if (p_value == 0.0) {
 		return "0"; // Avoid negative zero (-0) being written, which may annoy git, svn, etc. for changes when they don't exist.
 	} else if (p_compat) {
-		// Write old inf_neg for compatibility.
-		if (std::isinf(p_value) && p_value < 0.0) {
-			return "inf_neg";
+		// Write old lowercase and inf_neg for compatibility.
+		if (std::isnan(p_value)) {
+			return "nan";
+		} else if (std::isinf(p_value)) {
+			if (p_value > 0) {
+				return "inf";
+			} else {
+				return "inf_neg";
+			}
 		}
 	}
 	// Hack to avoid garbage digits when the underlying float is 32-bit.
@@ -2024,7 +2032,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 			const double value = p_variant.operator double();
 			String s = rtos_fix(value, p_compat);
 			// Append ".0" to floats to ensure they are float literals.
-			if (s != "inf" && s != "-inf" && s != "nan" && !s.contains_char('.') && !s.contains_char('e') && !s.contains_char('E')) {
+			if (s != "INF" && s != "-INF" && s != "NAN" && s != "inf" && s != "inf_neg" && s != "nan" && !s.contains_char('.') && !s.contains_char('e') && !s.contains_char('E')) {
 				s += ".0";
 			}
 			p_store_string_func(p_store_string_ud, s);

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -438,7 +438,7 @@
 		<constant name="ONE" value="Vector2(1, 1)">
 			One vector, a vector with all components set to [code]1[/code].
 		</constant>
-		<constant name="INF" value="Vector2(inf, inf)">
+		<constant name="INF" value="Vector2(INF, INF)">
 			Infinity vector, a vector with all components set to [constant @GDScript.INF].
 		</constant>
 		<constant name="LEFT" value="Vector2(-1, 0)">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -436,7 +436,7 @@
 		<constant name="ONE" value="Vector3(1, 1, 1)">
 			One vector, a vector with all components set to [code]1[/code].
 		</constant>
-		<constant name="INF" value="Vector3(inf, inf, inf)">
+		<constant name="INF" value="Vector3(INF, INF, INF)">
 			Infinity vector, a vector with all components set to [constant @GDScript.INF].
 		</constant>
 		<constant name="LEFT" value="Vector3(-1, 0, 0)">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -305,7 +305,7 @@
 		<constant name="ONE" value="Vector4(1, 1, 1, 1)">
 			One vector, a vector with all components set to [code]1[/code].
 		</constant>
-		<constant name="INF" value="Vector4(inf, inf, inf, inf)">
+		<constant name="INF" value="Vector4(INF, INF, INF, INF)">
 			Infinity vector, a vector with all components set to [constant @GDScript.INF].
 		</constant>
 	</constants>

--- a/misc/extension_api_validation/4.7-stable/GH-100414.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-100414.txt
@@ -1,0 +1,7 @@
+GH-100414
+---------
+Validate extension JSON: Error: Field 'builtin_classes/Vector2/constants/INF': value changed value in new API, from "Vector2(inf, inf)" to "Vector2(INF, INF)".
+Validate extension JSON: Error: Field 'builtin_classes/Vector3/constants/INF': value changed value in new API, from "Vector3(inf, inf, inf)" to "Vector3(INF, INF, INF)".
+Validate extension JSON: Error: Field 'builtin_classes/Vector4/constants/INF': value changed value in new API, from "Vector4(inf, inf, inf, inf)" to "Vector4(INF, INF, INF, INF)".
+
+Infinity is now serialized as "INF" instead of "inf".

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -285,11 +285,11 @@
 		<constant name="TAU" value="6.28318530717959">
 			The circle constant, the circumference of the unit circle in radians. This is equivalent to [code]PI * 2[/code], or 360 degrees in rotations.
 		</constant>
-		<constant name="INF" value="inf">
+		<constant name="INF" value="INF">
 			Positive floating-point infinity. This is the result of floating-point division when the divisor is [code]0.0[/code]. For negative infinity, use [code]-INF[/code]. Dividing by [code]-0.0[/code] will result in negative infinity if the numerator is positive, so dividing by [code]0.0[/code] is not the same as dividing by [code]-0.0[/code] (despite [code]0.0 == -0.0[/code] returning [code]true[/code]).
 			[b]Warning:[/b] Numeric infinity is only a concept with floating-point numbers, and has no equivalent for integers. Dividing an integer number by [code]0[/code] will not result in [constant INF] and will result in a run-time error instead.
 		</constant>
-		<constant name="NAN" value="nan">
+		<constant name="NAN" value="NAN">
 			"Not a Number", an invalid floating-point value. It is returned by some invalid operations, such as dividing floating-point [code]0.0[/code] by [code]0.0[/code].
 			[constant NAN] has special properties, including that [code]!=[/code] always returns [code]true[/code], while other comparison operators always return [code]false[/code]. This is true even when comparing with itself ([code]NAN == NAN[/code] returns [code]false[/code] and [code]NAN != NAN[/code] returns [code]true[/code]). Due to this, you must use [method @GlobalScope.is_nan] to check whether a number is equal to [constant NAN].
 			[b]Warning:[/b] "Not a Number" is only a concept with floating-point numbers, and has no equivalent for integers. Dividing an integer [code]0[/code] by [code]0[/code] will not result in [constant NAN] and will result in a run-time error instead.

--- a/modules/gltf/doc_classes/GLTFLight.xml
+++ b/modules/gltf/doc_classes/GLTFLight.xml
@@ -70,7 +70,7 @@
 			The outer angle of the cone in a spotlight. Must be greater than or equal to the inner angle.
 			At this angle, the light drops off to zero brightness. Between the inner and outer cone angles, there is a transition from full brightness to zero brightness. If this angle is a half turn, then the spotlight emits in all directions. When creating a Godot [SpotLight3D], the outer cone angle is used as the angle of the spotlight.
 		</member>
-		<member name="range" type="float" setter="set_range" getter="get_range" default="inf">
+		<member name="range" type="float" setter="set_range" getter="get_range" default="INF">
 			The range of the light, beyond which the light has no effect. glTF lights with no range defined behave like physical lights (which have infinite range). When creating a Godot light, the range is clamped to [code]4096.0[/code].
 		</member>
 	</members>

--- a/tests/core/io/test_json_native.cpp
+++ b/tests/core/io/test_json_native.cpp
@@ -60,9 +60,9 @@ TEST_CASE("[JSON][Native] Conversion between native and JSON formats") {
 	// Numbers and strings (represented as JSON strings).
 	test(1, R"("i:1")");
 	test(1.0, R"("f:1.0")");
-	test(Math::INF, R"("f:inf")");
-	test(-Math::INF, R"("f:-inf")");
-	test(Math::NaN, R"("f:nan")");
+	test(Math::INF, R"("f:INF")");
+	test(-Math::INF, R"("f:-INF")");
+	test(Math::NaN, R"("f:NAN")");
 	test(String("abc"), R"("s:abc")");
 	test(StringName("abc"), R"("sn:abc")");
 	test(NodePath("abc"), R"("np:abc")");

--- a/tests/core/string/test_string.cpp
+++ b/tests/core/string/test_string.cpp
@@ -569,9 +569,9 @@ TEST_CASE("[String] Number to string") {
 	CHECK(String::num_scientific(3e100) == "3e+100");
 	CHECK(String::num_scientific(7e-100) == "7e-100");
 	CHECK(String::num_scientific(Math::TAU) == "6.283185307179586");
-	CHECK(String::num_scientific(Math::INF) == "inf");
-	CHECK(String::num_scientific(-Math::INF) == "-inf");
-	CHECK(String::num_scientific(Math::NaN) == "nan");
+	CHECK(String::num_scientific(Math::INF) == "INF");
+	CHECK(String::num_scientific(-Math::INF) == "-INF");
+	CHECK(String::num_scientific(Math::NaN) == "NAN");
 	CHECK(String::num_scientific(2.0) == "2");
 	CHECK(String::num_scientific(1.0) == "1");
 	CHECK(String::num_scientific(0.0) == "0");
@@ -1048,7 +1048,7 @@ TEST_CASE("[String] sprintf") {
 	args.push_back(Math::INF);
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
-	CHECK(output == String("fish         inf frog"));
+	CHECK(output == String("fish         INF frog"));
 
 	// Real right-padded.
 	format = "fish %-11f frog";
@@ -1166,13 +1166,13 @@ TEST_CASE("[String] sprintf") {
 	REQUIRE(error == false);
 	CHECK(output == String("fish (  19.990000,    1.000000,   -2.050000) frog"));
 
-	// Vector left-padded with inf/nan
+	// Vector left-padded with INF/NAN.
 	format = "fish %11v frog";
 	args.clear();
 	args.push_back(Variant(Vector2(Math::INF, Math::NaN)));
 	output = format.sprintf(args, &error);
 	REQUIRE(error == false);
-	CHECK(output == String("fish (        inf,         nan) frog"));
+	CHECK(output == String("fish (        INF,         NAN) frog"));
 
 	// Vector right-padded.
 	format = "fish %-11v frog";

--- a/tests/core/variant/test_variant.cpp
+++ b/tests/core/variant/test_variant.cpp
@@ -83,8 +83,8 @@ TEST_CASE("[Variant] Writer and parser Variant::FLOAT") {
 	VariantWriter::write_to_string(a64, a64_str);
 
 	CHECK_MESSAGE(a64_str == "1.7976931348623157e+308", "Writes in scientific notation.");
-	CHECK_MESSAGE(a64_str != "inf", "Should not overflow.");
-	CHECK_MESSAGE(a64_str != "nan", "The result should be defined.");
+	CHECK_MESSAGE(a64_str != "INF", "Should not overflow.");
+	CHECK_MESSAGE(a64_str != "NAN", "The result should be defined.");
 
 	String errs;
 	int line;


### PR DESCRIPTION
- Implements https://github.com/godotengine/godot-proposals/issues/3398
- alternative to https://github.com/godotengine/godot-proposals/issues/3390
- undoes https://github.com/godotengine/godot/pull/81076
- fixed previously https://github.com/godotengine/godot/issues/88006
- fixes https://github.com/godotengine/godot/issues/87664
- used to fix part of https://github.com/godotengine/godot-proposals/issues/10068
- supersedes https://github.com/godotengine/godot/pull/53698
- related to https://github.com/godotengine/godot/pull/88354
- would be nice to merge after https://github.com/godotengine/godot/pull/100395

As explained by bug report #88006, the editor inspector is unable to display non-finite values such as infinity and NaN. This is due to this check in Range (`range.cpp`) added by https://github.com/godotengine/godot/pull/81076:

<img width="440" alt="Screenshot 2024-12-13 at 10 57 05 PM" src="https://github.com/user-attachments/assets/55239740-42a9-41a5-8767-834223678d81" />

If we remove this check, then non-finite values become allowed. They have to be typed as `INF`, `-INF`, or `NAN` like GDScript, and then get displayed as `inf`, `-inf`, or `nan`:

<img width="210" alt="Screenshot 2024-12-13 at 11 00 22 PM" src="https://github.com/user-attachments/assets/c57b36de-d3e0-4882-8f0e-cdcadd00e72a" />

Inside of the `.tscn` file the values get serialized as `inf`, `inf_neg`, or `nan`:

<img width="300" alt="Screenshot 2024-12-13 at 10 59 48 PM" src="https://github.com/user-attachments/assets/9d5fb14a-994b-4b8c-889d-33bbe64b8ab2" />

So, it's clear that simply removing this check is not enough. We need to fix these problems:

* The text the user can type is not the same as the displayed text (vital for good UX).
* The constants in GDScript are not the same as the displayed text (ideal for good UX).
* The value serialized in the file is not the same as the displayed text in the case of `-inf` and `inf_neg` (less important, but we should still be consistent).

Allowing the user to type both `inf` and `INF` is just generally a good idea, and stands on its own, so I put this into a separate PR here: #100395. This fixes the first point, since users can type `inf` like they see `inf`.

However, I think there is value in fixing the other two points as well. Capitalizing the displayed and serialized text is pretty straightforward, it's just an arbitrary choice we make as engine developers, although we need to keep the code being able to read `inf` and such to keep reading old files (and if this is merged, we should backport a fix to older branches to allow `INF` etc to be read by older Godot versions).

As for `inf_neg`, the current reason for this is that VariantParser is not able to parse `-INF` as a single thing. It has this code in master which checks for `-` or a number as a start of a numeric literal:

```cpp
if (cchar == '-' || (cchar >= '0' && cchar <= '9')) {
	StringBuffer<> num;
	if (cchar == '-') {
		num += '-';
		cchar = p_stream->get_char();
	}
	// and so on
```

However, if you look closely at the code, we can see that it's needlessly checking for `'-'` twice. A simple fix would be to rearrange this code slightly, so that it only needs to check for a leading `'-'` once:

```cpp
StringBuffer<> num;
if (cchar == '-') {
	num += '-';
	cchar = p_stream->get_char();
}
if (cchar >= '0' && cchar <= '9') {
	// and so on
```

This way, we can handle reading `-INF` or really any negated identifier (`-INF` would be the only one at the moment, but I could imagine adding `-PI` or something, in any case making this code work for all cases has no downsides).

---

~~If desired, I can undo the change in `range.cpp`, un-undoing https://github.com/godotengine/godot/pull/81076, leaving #88354 to be the PR changing the exposed behavior of Range.~~ However, as for the rest of this PR, I think it's a good improvement to have the serialization and display of `INF`, `-INF`, and `NAN` values match what users already expect from GDScript. Aside from capitalization, it's important that this PR fixes reading negated identifiers such as `-inf` and `-INF`, so we can be consistent and avoid `inf_neg` / `INF_NEG`.