### PR TITLE
Add ability to temporarily add a collision to a mesh behind the cursor to enable snapping/measuring functions

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -242,6 +242,10 @@ private:
 	Node *target_node = nullptr;
 	Point2 drop_pos;
 
+	ObjectID target;
+	bool collision_checked = false;
+	bool create_temp_collision = false;
+
 	EditorSelection *editor_selection = nullptr;
 
 	Button *translation_preview_button = nullptr;
@@ -292,6 +296,8 @@ private:
 		real_t depth = 0;
 		_FORCE_INLINE_ bool operator<(const _RayResult &p_rr) const { return depth < p_rr.depth; }
 	};
+
+	bool has_collision(Node *node);
 
 	void _update_name();
 	void _compute_edit(const Point2 &p_point);

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -266,6 +266,18 @@ void MeshInstance3D::create_trimesh_collision() {
 	}
 }
 
+void MeshInstance3D::create_trimesh_collision_internal() {
+	StaticBody3D *static_body = Object::cast_to<StaticBody3D>(create_trimesh_collision_node());
+	ERR_FAIL_NULL(static_body);
+	static_body->set_name(String(get_name()) + "_col");
+	static_body->set_meta("_edit_lock_", true);
+
+	add_child(static_body);
+
+	CollisionShape3D *cshape = Object::cast_to<CollisionShape3D>(static_body->get_child(0));
+	cshape->set_meta("_edit_lock_", true);
+}
+
 Node *MeshInstance3D::create_convex_collision_node(bool p_clean, bool p_simplify) {
 	if (mesh.is_null()) {
 		return nullptr;

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -95,6 +95,8 @@ public:
 	Node *create_trimesh_collision_node();
 	void create_trimesh_collision();
 
+	void create_trimesh_collision_internal();
+
 	Node *create_convex_collision_node(bool p_clean = true, bool p_simplify = false);
 	void create_convex_collision(bool p_clean = true, bool p_simplify = false);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Replicates the function of the image below on demand while the "Create Temporary Collisions" key is pressed (currently the C key), and a snapping/measuring functionality is enabled (Shift + G Collision Repositioning, Preview Scenes, 3D Ruler Tool). This allows users to snap to meshes that are not normally associated with collisions and to measure distances between them.

![image](https://github.com/user-attachments/assets/2382578b-4684-4094-afa0-66d1d3bbb4d2)

https://github.com/user-attachments/assets/e96e8f57-c2d8-4563-a5e8-c5cea2308f0b



