### PR TITLE
Make `AnimationNodeExtension` extend `AnimationNode` instead of `AnimationRootNode`

### DIFF
--- a/doc/classes/AnimationNodeExtension.xml
+++ b/doc/classes/AnimationNodeExtension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="AnimationNodeExtension" inherits="AnimationRootNode" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="AnimationNodeExtension" inherits="AnimationNode" experimental="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Base class for extending [AnimationRootNode]s from GDScript, C#, or C++.
 	</brief_description>

--- a/scene/animation/animation_node_extension.h
+++ b/scene/animation/animation_node_extension.h
@@ -33,8 +33,8 @@
 
 #include "scene/animation/animation_tree.h"
 
-class AnimationNodeExtension : public AnimationRootNode {
-	GDCLASS(AnimationNodeExtension, AnimationRootNode);
+class AnimationNodeExtension : public AnimationNode {
+	GDCLASS(AnimationNodeExtension, AnimationNode);
 
 public:
 	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;


### PR DESCRIPTION
- Follow up #99181

Context https://github.com/godotengine/godot/pull/99181#discussion_r1885392444

> we will need two (or three) Extensions, AnimationRootNodeExtension and AnimationNodeSyncExtension (and AnimationNodeExtention). If it is not an Extension by replacement, then only the AnimationNode needs to be replaced.

This PR makes it no longer allow the AnimationNodeExtention to be placed "directly" in the StateMachine as an Extension, but provides a workaround to place it by wrapping it in a NodeBlendTree.

Perhaps this class should be deprecated in the future and this should all be done in the AnimationNode after implementing GDScript struct.