### PR TITLE
Remove rect from Line2D

### DIFF
--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -33,27 +33,7 @@
 #include "core/math/geometry_2d.h"
 #include "line_builder.h"
 
-Line2D::Line2D() {
-}
-
 #ifdef DEBUG_ENABLED
-Rect2 Line2D::_edit_get_rect() const {
-	if (_points.size() == 0) {
-		return Rect2(0, 0, 0, 0);
-	}
-	Vector2 d = Vector2(_width, _width);
-	Rect2 bounding_rect = Rect2(_points[0] - d, 2 * d);
-	for (int i = 1; i < _points.size(); i++) {
-		bounding_rect.expand_to(_points[i] - d);
-		bounding_rect.expand_to(_points[i] + d);
-	}
-	return bounding_rect;
-}
-
-bool Line2D::_edit_use_rect() const {
-	return true;
-}
-
 bool Line2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 	const real_t d = _width / 2 + p_tolerance;
 	const Vector2 *points = _points.ptr();

--- a/scene/2d/line_2d.h
+++ b/scene/2d/line_2d.h
@@ -56,12 +56,8 @@ public:
 	};
 
 #ifdef DEBUG_ENABLED
-	virtual Rect2 _edit_get_rect() const override;
-	virtual bool _edit_use_rect() const override;
 	virtual bool _edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const override;
 #endif
-
-	Line2D();
 
 	void set_points(const Vector<Vector2> &p_points);
 	Vector<Vector2> get_points() const;


### PR DESCRIPTION
Closes #30012

Line2D has pretty useless support for rectangle editing. I don't see why would you want to stretch a Line2D and the behavior is confusing in Add Point mode.

https://github.com/user-attachments/assets/893a272f-e37e-4ebc-bc85-6c879d3c9504

This PR removes the rectangle.

https://github.com/user-attachments/assets/9fe4ed6a-8210-4395-9146-20cad0a634f4

You can use scale tool if you still want to resize the node.

EDIT:
Related to #91027 (I forgot about it xd)