### PR TITLE
Fix 3D Ruler stuck in viewport if tool mode is switched during measurement

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1985,7 +1985,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 					surface->queue_redraw();
 				} else {
-					if (spatial_editor->get_tool_mode() == Node3DEditor::TOOL_RULER) {
+					if (ruler->is_inside_tree()) {
 						EditorNode::get_singleton()->get_scene_root()->remove_child(ruler);
 						ruler_start_point->set_visible(false);
 						ruler_end_point->set_visible(false);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related: https://github.com/godotengine/godot/pull/86930

If the tool mode is switched during measurement (LMB is held down), then the ruler gets stuck in the viewport. The fix is to check if the ruler node is inside the tree when LMB is released rather than checking the tool mode. 