### PR TITLE
Replace `List` used as stack with `LocalVector`

### DIFF
--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -658,7 +658,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 	int pos = 0;
 	bool in_plist = false;
 	bool done_plist = false;
-	List<Ref<PListNode>> stack;
+	LocalVector<Ref<PListNode>> stack;
 	String key;
 	while (pos >= 0) {
 		int open_token_s = p_string.find_char('<', pos);
@@ -701,7 +701,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 				// Add subnode end enter it.
 				Ref<PListNode> dict = PListNode::new_dict();
 				dict->data_type = PList::PLNodeType::PL_NODE_TYPE_DICT;
-				if (!stack.back()->get()->push_subnode(dict, key)) {
+				if (!stack.back()->push_subnode(dict, key)) {
 					r_err_out = "Can't push subnode, invalid parent type.";
 					return false;
 				}
@@ -721,7 +721,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 
 		if (token == "/dict") {
 			// Exit current dict.
-			if (stack.is_empty() || stack.back()->get()->data_type != PList::PLNodeType::PL_NODE_TYPE_DICT) {
+			if (stack.is_empty() || stack.back()->data_type != PList::PLNodeType::PL_NODE_TYPE_DICT) {
 				r_err_out = "Mismatched </dict> tag.";
 				return false;
 			}
@@ -733,7 +733,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 			if (!stack.is_empty()) {
 				// Add subnode end enter it.
 				Ref<PListNode> arr = PListNode::new_array();
-				if (!stack.back()->get()->push_subnode(arr, key)) {
+				if (!stack.back()->push_subnode(arr, key)) {
 					r_err_out = "Can't push subnode, invalid parent type.";
 					return false;
 				}
@@ -753,7 +753,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 
 		if (token == "/array") {
 			// Exit current array.
-			if (stack.is_empty() || stack.back()->get()->data_type != PList::PLNodeType::PL_NODE_TYPE_ARRAY) {
+			if (stack.is_empty() || stack.back()->data_type != PList::PLNodeType::PL_NODE_TYPE_ARRAY) {
 				r_err_out = "Mismatched </array> tag.";
 				return false;
 			}
@@ -800,7 +800,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 				r_err_out = vformat("Invalid value type: %s.", token);
 				return false;
 			}
-			if (stack.is_empty() || !stack.back()->get()->push_subnode(var, key)) {
+			if (stack.is_empty() || !stack.back()->push_subnode(var, key)) {
 				r_err_out = "Can't push subnode, invalid parent type.";
 				return false;
 			}

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -401,7 +401,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 		r_valid = &valid;
 	}
 
-	List<Variant> value_stack;
+	LocalVector<Variant> value_stack;
 
 	value_stack.push_back(get(p_names[0], r_valid));
 
@@ -411,7 +411,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 	}
 
 	for (int i = 1; i < p_names.size() - 1; i++) {
-		value_stack.push_back(value_stack.back()->get().get_named(p_names[i], valid));
+		value_stack.push_back(value_stack.back().get_named(p_names[i], valid));
 		if (r_valid) {
 			*r_valid = valid;
 		}
@@ -425,7 +425,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 	value_stack.push_back(p_value); // p_names[p_names.size() - 1]
 
 	for (int i = p_names.size() - 1; i > 0; i--) {
-		value_stack.back()->prev()->get().set_named(p_names[i], value_stack.back()->get(), valid);
+		value_stack[value_stack.size() - 2].set_named(p_names[i], value_stack.back(), valid);
 		value_stack.pop_back();
 
 		if (r_valid) {
@@ -437,7 +437,7 @@ void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_val
 		}
 	}
 
-	set(p_names[0], value_stack.back()->get(), r_valid);
+	set(p_names[0], value_stack.back(), r_valid);
 	value_stack.pop_back();
 
 	ERR_FAIL_COND(!value_stack.is_empty());

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -57,6 +57,16 @@ public:
 		return data;
 	}
 
+	T &back() {
+		CRASH_BAD_UNSIGNED_INDEX(0, count);
+		return data[count - 1];
+	}
+
+	const T &back() const {
+		CRASH_BAD_UNSIGNED_INDEX(0, count);
+		return data[count - 1];
+	}
+
 	_FORCE_INLINE_ void push_back(T p_elem) {
 		if (unlikely(count == capacity)) {
 			capacity = tight ? (capacity + 1) : MAX((U)1, capacity << 1);
@@ -68,6 +78,14 @@ public:
 			memnew_placement(&data[count++], T(p_elem));
 		} else {
 			data[count++] = p_elem;
+		}
+	}
+
+	void pop_back() {
+		ERR_FAIL_COND(count == 0);
+		count--;
+		if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
+			data[count].~T();
 		}
 	}
 

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -51,7 +51,7 @@ void EditorVisualProfiler::add_frame_metric(const Metric &p_metric) {
 
 	frame_metrics.write[last_metric] = p_metric;
 
-	List<String> stack;
+	LocalVector<String> stack;
 	for (int i = 0; i < frame_metrics[last_metric].areas.size(); i++) {
 		String name = frame_metrics[last_metric].areas[i].name;
 		frame_metrics.write[last_metric].areas.write[i].color_cache = _get_color_from_signature(name);
@@ -62,7 +62,7 @@ void EditorVisualProfiler::add_frame_metric(const Metric &p_metric) {
 		}
 
 		if (stack.size()) {
-			full_name = stack.back()->get() + name;
+			full_name = stack.back() + name;
 		} else {
 			full_name = name;
 		}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -346,11 +346,11 @@ Vector<String> FileSystemDock::get_uncollapsed_paths() const {
 		// BFS to find all uncollapsed paths of the resource directory.
 		TreeItem *res_subtree = root->get_first_child()->get_next();
 		if (res_subtree) {
-			List<TreeItem *> queue;
+			LocalVector<TreeItem *> queue;
 			queue.push_back(res_subtree);
 
 			while (!queue.is_empty()) {
-				TreeItem *ti = queue.back()->get();
+				TreeItem *ti = queue.back();
 				queue.pop_back();
 				if (!ti->is_collapsed() && ti->get_child_count() > 0) {
 					Variant path = ti->get_metadata(0);

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -1203,10 +1203,10 @@ HashMap<Vector2i, TileMapCell> TileMapLayerEditorTilesPlugin::_draw_bucket_fill(
 		if (p_contiguous) {
 			// Replace continuous tiles like the source.
 			RBSet<Vector2i> already_checked;
-			List<Vector2i> to_check;
+			LocalVector<Vector2i> to_check;
 			to_check.push_back(p_coords);
 			while (!to_check.is_empty()) {
-				Vector2i coords = to_check.back()->get();
+				Vector2i coords = to_check.back();
 				to_check.pop_back();
 				if (!already_checked.has(coords)) {
 					if (source_cell.source_id == edited_layer->get_cell_source_id(coords) &&
@@ -2726,10 +2726,10 @@ RBSet<Vector2i> TileMapLayerEditorTerrainsPlugin::_get_cells_for_bucket_fill(Vec
 	if (p_contiguous) {
 		// Replace continuous tiles like the source.
 		RBSet<Vector2i> already_checked;
-		List<Vector2i> to_check;
+		LocalVector<Vector2i> to_check;
 		to_check.push_back(p_coords);
 		while (!to_check.is_empty()) {
-			Vector2i coords = to_check.back()->get();
+			Vector2i coords = to_check.back();
 			to_check.pop_back();
 			if (!already_checked.has(coords)) {
 				// Get the candidate cell pattern.

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -147,11 +147,11 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 		} break;
 		case CompletionKind::SCENE_PATHS: {
 			Ref<DirAccess> dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-			List<String> directories;
+			LocalVector<String> directories;
 			directories.push_back(dir_access->get_current_dir());
 
 			while (!directories.is_empty()) {
-				dir_access->change_dir(directories.back()->get());
+				dir_access->change_dir(directories.back());
 				directories.pop_back();
 
 				dir_access->list_dir_begin();


### PR DESCRIPTION
Needs #99955 and include it.

Replace local variable `List` used as stack (which means no `push_front()/pop_front()`). Class members are planned in following PR.

Most of these variables have a lifetime no longer than a screen of code, so should be easy to review.

The one in `editor/filesystem_dock.cpp` is named as `queue` while it is actually a stack.
