### PR TITLE
Fix origin being included in per viewport grid visibility toggle, and add ability to hide it seperately

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4319,6 +4319,18 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			bool current = view_display_menu->get_popup()->is_item_checked(idx);
 			view_display_menu->get_popup()->set_item_checked(idx, !current);
 		} break;
+		case VIEW_ORIGIN: {
+			int idx = view_display_menu->get_popup()->get_item_index(VIEW_ORIGIN);
+			bool current = view_display_menu->get_popup()->is_item_checked(idx);
+			current = !current;
+			uint32_t layers = camera->get_cull_mask();
+			layers &= ~(1 << GIZMO_ORIGIN_LAYER);
+			if (current) {
+				layers |= (1 << GIZMO_ORIGIN_LAYER);
+			}
+			camera->set_cull_mask(layers);
+			view_display_menu->get_popup()->set_item_checked(idx, current);
+		} break;
 		case VIEW_GRID: {
 			int idx = view_display_menu->get_popup()->get_item_index(VIEW_GRID);
 			bool current = view_display_menu->get_popup()->is_item_checked(idx);
@@ -4860,6 +4872,14 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 			_menu_option(VIEW_TRANSFORM_GIZMO);
 		}
 	}
+	if (p_state.has("origin")) {
+		bool origin = p_state["origin"];
+
+		int idx = view_display_menu->get_popup()->get_item_index(VIEW_ORIGIN);
+		if (view_display_menu->get_popup()->is_item_checked(idx) != origin) {
+			_menu_option(VIEW_ORIGIN);
+		}
+	}
 	if (p_state.has("grid")) {
 		bool grid = p_state["grid"];
 
@@ -4956,6 +4976,7 @@ Dictionary Node3DEditorViewport::get_state() const {
 	d["doppler"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_AUDIO_DOPPLER));
 	d["gizmos"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GIZMOS));
 	d["transform_gizmo"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_TRANSFORM_GIZMO));
+	d["origin"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_ORIGIN));
 	d["grid"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_GRID));
 	d["information"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_INFORMATION));
 	d["frame_time"] = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_FRAME_TIME));
@@ -6295,7 +6316,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	surface->set_clip_contents(true);
 	camera = memnew(Camera3D);
 	camera->set_disable_gizmos(true);
-	camera->set_cull_mask(((1 << 20) - 1) | (1 << (GIZMO_BASE_LAYER + p_index)) | (1 << GIZMO_EDIT_LAYER) | (1 << GIZMO_GRID_LAYER) | (1 << MISC_TOOL_LAYER));
+	camera->set_cull_mask(((1 << 20) - 1) | (1 << (GIZMO_BASE_LAYER + p_index)) | (1 << GIZMO_EDIT_LAYER) | (1 << GIZMO_GRID_LAYER) | (1 << GIZMO_ORIGIN_LAYER) | (1 << MISC_TOOL_LAYER));
 	viewport->add_child(camera);
 	camera->make_current();
 	surface->set_focus_mode(FOCUS_ALL);
@@ -6404,6 +6425,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_environment", TTRC("View Environment")), VIEW_ENVIRONMENT);
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_gizmos", TTRC("View Gizmos")), VIEW_GIZMOS);
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_transform_gizmo", TTRC("View Transform Gizmo")), VIEW_TRANSFORM_GIZMO);
+	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_origin_lines", TTRC("View Origin")), VIEW_ORIGIN);
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid_lines", TTRC("View Grid")), VIEW_GRID);
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_information", TTRC("View Information")), VIEW_INFORMATION);
 	view_display_menu->get_popup()->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_fps", TTRC("View Frame Time")), VIEW_FRAME_TIME);
@@ -7712,13 +7734,9 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 		case MENU_VIEW_ORIGIN: {
 			bool is_checked = view_layout_menu->get_popup()->is_item_checked(view_layout_menu->get_popup()->get_item_index(p_option));
 
-			origin_enabled = !is_checked;
-			RenderingServer::get_singleton()->instance_set_visible(origin_instance, origin_enabled);
-			// Update the grid since its appearance depends on whether the origin is enabled
-			_finish_grid();
-			_init_grid();
+			RenderingServer::get_singleton()->instance_set_visible(origin_instance, !is_checked);
 
-			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(p_option), origin_enabled);
+			view_layout_menu->get_popup()->set_item_checked(view_layout_menu->get_popup()->get_item_index(p_option), !is_checked);
 		} break;
 		case MENU_VIEW_GRID: {
 			bool is_checked = view_layout_menu->get_popup()->is_item_checked(view_layout_menu->get_popup()->get_item_index(p_option));
@@ -7838,7 +7856,6 @@ void Node3DEditor::_menu_item_pressed(int p_option) {
 
 void Node3DEditor::_init_indicators() {
 	{
-		origin_enabled = true;
 		grid_enabled = true;
 
 		Ref<Shader> origin_shader = memnew(Shader);
@@ -7891,6 +7908,7 @@ void fragment() {
 
 		origin_mat.instantiate();
 		origin_mat->set_shader(origin_shader);
+		origin_mat->set_render_priority(-1);
 
 		Vector<Vector3> origin_points;
 		origin_points.resize(6);
@@ -7960,7 +7978,7 @@ void fragment() {
 		}
 
 		origin_instance = RenderingServer::get_singleton()->instance_create2(origin_multimesh, get_tree()->get_root()->get_world_3d()->get_scenario());
-		RS::get_singleton()->instance_set_layer_mask(origin_instance, 1 << Node3DEditorViewport::GIZMO_GRID_LAYER);
+		RS::get_singleton()->instance_set_layer_mask(origin_instance, 1 << Node3DEditorViewport::GIZMO_ORIGIN_LAYER);
 		RS::get_singleton()->instance_geometry_set_flag(origin_instance, RSE::INSTANCE_FLAG_IGNORE_OCCLUSION_CULLING, true);
 		RS::get_singleton()->instance_geometry_set_flag(origin_instance, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 
@@ -8004,6 +8022,7 @@ void fragment() {
 		for (int i = 0; i < 3; i++) {
 			grid_mat[i].instantiate();
 			grid_mat[i]->set_shader(grid_shader);
+			grid_mat[i]->set_render_priority(-2);
 		}
 
 		grid_enable[0] = EDITOR_GET("editors/3d/grid_xy_plane");
@@ -8624,17 +8643,7 @@ void Node3DEditor::_init_grid() {
 		// Count our elements same as code below it.
 		int expected_size = 0;
 		for (int i = -grid_size; i <= grid_size; i++) {
-			const real_t position_a = center_a + i * small_step_size;
-			const real_t position_b = center_b + i * small_step_size;
-
-			// Don't draw lines over the origin if it's enabled.
-			if (!(origin_enabled && Math::is_zero_approx(position_a))) {
-				expected_size += 2;
-			}
-
-			if (!(origin_enabled && Math::is_zero_approx(position_b))) {
-				expected_size += 2;
-			}
+			expected_size += 4;
 		}
 
 		int idx = 0;
@@ -8656,38 +8665,32 @@ void Node3DEditor::_init_grid() {
 			real_t position_a = center_a + i * small_step_size;
 			real_t position_b = center_b + i * small_step_size;
 
-			// Don't draw lines over the origin if it's enabled.
-			if (!(origin_enabled && Math::is_zero_approx(position_a))) {
-				Vector3 line_bgn;
-				Vector3 line_end;
-				line_bgn[a] = position_a;
-				line_end[a] = position_a;
-				line_bgn[b] = bgn_b;
-				line_end[b] = end_b;
-				ref_grid[idx] = line_bgn;
-				ref_grid[idx + 1] = line_end;
-				ref_grid_colors[idx] = line_color;
-				ref_grid_colors[idx + 1] = line_color;
-				ref_grid_normals[idx] = normal;
-				ref_grid_normals[idx + 1] = normal;
-				idx += 2;
-			}
+			Vector3 line_bgn;
+			Vector3 line_end;
 
-			if (!(origin_enabled && Math::is_zero_approx(position_b))) {
-				Vector3 line_bgn;
-				Vector3 line_end;
-				line_bgn[b] = position_b;
-				line_end[b] = position_b;
-				line_bgn[a] = bgn_a;
-				line_end[a] = end_a;
-				ref_grid[idx] = line_bgn;
-				ref_grid[idx + 1] = line_end;
-				ref_grid_colors[idx] = line_color;
-				ref_grid_colors[idx + 1] = line_color;
-				ref_grid_normals[idx] = normal;
-				ref_grid_normals[idx + 1] = normal;
-				idx += 2;
-			}
+			line_bgn[a] = position_a;
+			line_end[a] = position_a;
+			line_bgn[b] = bgn_b;
+			line_end[b] = end_b;
+			ref_grid[idx] = line_bgn;
+			ref_grid[idx + 1] = line_end;
+			ref_grid_colors[idx] = line_color;
+			ref_grid_colors[idx + 1] = line_color;
+			ref_grid_normals[idx] = normal;
+			ref_grid_normals[idx + 1] = normal;
+			idx += 2;
+
+			line_bgn[b] = position_b;
+			line_end[b] = position_b;
+			line_bgn[a] = bgn_a;
+			line_end[a] = end_a;
+			ref_grid[idx] = line_bgn;
+			ref_grid[idx + 1] = line_end;
+			ref_grid_colors[idx] = line_color;
+			ref_grid_colors[idx + 1] = line_color;
+			ref_grid_normals[idx] = normal;
+			ref_grid_normals[idx + 1] = normal;
+			idx += 2;
 		}
 
 		// Create a mesh from the pushed vector points and colors.

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -130,6 +130,7 @@ class Node3DEditorViewport : public Control {
 		VIEW_AUDIO_DOPPLER,
 		VIEW_GIZMOS,
 		VIEW_TRANSFORM_GIZMO,
+		VIEW_ORIGIN,
 		VIEW_GRID,
 		VIEW_INFORMATION,
 		VIEW_FRAME_TIME,
@@ -187,7 +188,8 @@ public:
 	static constexpr int32_t GIZMO_BASE_LAYER = 27;
 	static constexpr int32_t GIZMO_EDIT_LAYER = 26;
 	static constexpr int32_t GIZMO_GRID_LAYER = 25;
-	static constexpr int32_t MISC_TOOL_LAYER = 24;
+	static constexpr int32_t GIZMO_ORIGIN_LAYER = 24;
+	static constexpr int32_t MISC_TOOL_LAYER = 23;
 
 	static constexpr int32_t FRAME_TIME_HISTORY = 20;
 
@@ -716,7 +718,6 @@ private:
 	RID origin_mesh;
 	RID origin_multimesh;
 	RID origin_instance;
-	bool origin_enabled = false;
 	RID grid[3];
 	RID grid_instance[3];
 	bool grid_visible[3] = { false, false, false }; //currently visible


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

* Related: https://github.com/godotengine/godot-proposals/issues/11363

https://github.com/godotengine/godot/pull/88584 added the ability to hide the grid per viewport, but accidentally included the origin, which is technically a bug. This PR separates them out, and now both can be toggled. 

https://github.com/user-attachments/assets/6bb07d6f-6705-402e-9e4e-d9539dfd831c


