### PR TITLE
Replace setting by reference with ties

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -4757,7 +4757,7 @@ void RenderingDeviceDriverD3D12::command_copy_buffer_to_texture(CommandBufferID 
 
 	uint32_t pixel_size = get_image_format_pixel_size(tex_info->format);
 	uint32_t block_w = 0, block_h = 0;
-	get_compressed_image_format_block_dimensions(tex_info->format, block_w, block_h);
+	std::tie(block_w, block_h) = get_compressed_image_format_block_dimensions(tex_info->format);
 
 	for (uint32_t i = 0; i < p_regions.size(); i++) {
 		uint32_t region_pitch = (p_regions[i].texture_region_size.x * pixel_size * block_w) >> get_compressed_image_format_pixel_rshift(tex_info->format);
@@ -4825,7 +4825,7 @@ void RenderingDeviceDriverD3D12::command_copy_texture_to_buffer(CommandBufferID 
 	}
 
 	uint32_t block_w = 0, block_h = 0;
-	get_compressed_image_format_block_dimensions(tex_info->format, block_w, block_h);
+	std::tie(block_w, block_h) = get_compressed_image_format_block_dimensions(tex_info->format);
 
 	for (uint32_t i = 0; i < p_regions.size(); i++) {
 		if (!barrier_capabilities.enhanced_barriers_supported) {

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -546,7 +546,7 @@ void RenderingDeviceDriverMetal::texture_get_copyable_layout(TextureID p_texture
 		sz = mipmapLevelSizeFromSize(sz, p_subresource.mipmap);
 
 		uint32_t bw = 0, bh = 0;
-		get_compressed_image_format_block_dimensions(format, bw, bh);
+		std::tie(bw, bh) = get_compressed_image_format_block_dimensions(format);
 		uint32_t sbw = 0, sbh = 0;
 		r_layout->size = get_image_format_required_size(format, sz.width, sz.height, sz.depth, 1, &sbw, &sbh);
 		r_layout->row_pitch = r_layout->size / ((sbh / bh) * sz.depth);

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2029,7 +2029,7 @@ void RenderingDeviceDriverVulkan::texture_get_copyable_layout(TextureID p_textur
 			d = MAX(1u, d >> 1);
 		}
 		uint32_t bw = 0, bh = 0;
-		get_compressed_image_format_block_dimensions(tex_info->rd_format, bw, bh);
+		std::tie(bw, bh) = get_compressed_image_format_block_dimensions(tex_info->rd_format);
 		uint32_t sbw = 0, sbh = 0;
 		r_layout->size = get_image_format_required_size(tex_info->rd_format, w, h, d, 1, &sbw, &sbh);
 		r_layout->row_pitch = r_layout->size / ((sbh / bh) * d);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1350,7 +1350,7 @@ Error RenderingDevice::_texture_initialize(RID p_texture, uint32_t p_layer, cons
 			"Required size for texture update (" + itos(required_size) + ") does not match data supplied size (" + itos(p_data.size()) + ").");
 
 	uint32_t block_w, block_h;
-	get_compressed_image_format_block_dimensions(texture->format, block_w, block_h);
+	std::tie(block_w, block_h) = get_compressed_image_format_block_dimensions(texture->format);
 
 	uint32_t pixel_size = get_image_format_pixel_size(texture->format);
 	uint32_t pixel_rshift = get_compressed_image_format_pixel_rshift(texture->format);
@@ -1500,7 +1500,7 @@ Error RenderingDevice::texture_update(RID p_texture, uint32_t p_layer, const Vec
 	_check_transfer_worker_texture(texture);
 
 	uint32_t block_w, block_h;
-	get_compressed_image_format_block_dimensions(texture->format, block_w, block_h);
+	std::tie(block_w, block_h) = get_compressed_image_format_block_dimensions(texture->format);
 
 	uint32_t pixel_size = get_image_format_pixel_size(texture->format);
 	uint32_t pixel_rshift = get_compressed_image_format_pixel_rshift(texture->format);
@@ -1800,7 +1800,7 @@ Vector<uint8_t> RenderingDevice::_texture_get_data(Texture *tex, uint32_t p_laye
 	image_data.resize(tight_mip_size);
 
 	uint32_t blockw, blockh;
-	get_compressed_image_format_block_dimensions(tex->format, blockw, blockh);
+	std::tie(blockw, blockh) = get_compressed_image_format_block_dimensions(tex->format);
 	uint32_t block_size = get_compressed_image_format_block_byte_size(tex->format);
 	uint32_t pixel_size = get_image_format_pixel_size(tex->format);
 
@@ -1934,7 +1934,7 @@ Vector<uint8_t> RenderingDevice::texture_get_data(RID p_texture, uint32_t p_laye
 
 		uint32_t block_w = 0;
 		uint32_t block_h = 0;
-		get_compressed_image_format_block_dimensions(tex->format, block_w, block_h);
+		std::tie(block_w, block_h) = get_compressed_image_format_block_dimensions(tex->format);
 
 		Vector<uint8_t> buffer_data;
 		uint32_t tight_buffer_size = get_image_format_required_size(tex->format, tex->width, tex->height, tex->depth, tex->mipmaps);
@@ -2015,7 +2015,7 @@ Error RenderingDevice::texture_get_data_async(RID p_texture, uint32_t p_layer, c
 	get_data_request.mipmaps = tex->mipmaps;
 
 	uint32_t block_w, block_h;
-	get_compressed_image_format_block_dimensions(tex->format, block_w, block_h);
+	std::tie(block_w, block_h) = get_compressed_image_format_block_dimensions(tex->format);
 
 	uint32_t pixel_size = get_image_format_pixel_size(tex->format);
 	uint32_t pixel_rshift = get_compressed_image_format_pixel_rshift(tex->format);
@@ -6460,7 +6460,7 @@ void RenderingDevice::_stall_for_frame(uint32_t p_frame) {
 				// Find the block size of the texture's format.
 				uint32_t block_w = 0;
 				uint32_t block_h = 0;
-				get_compressed_image_format_block_dimensions(request.format, block_w, block_h);
+				std::tie(block_w, block_h) = get_compressed_image_format_block_dimensions(request.format);
 
 				uint32_t block_size = get_compressed_image_format_block_byte_size(request.format);
 				uint32_t pixel_size = get_image_format_pixel_size(request.format);

--- a/servers/rendering/rendering_device_commons.cpp
+++ b/servers/rendering/rendering_device_commons.cpp
@@ -525,7 +525,7 @@ uint32_t RenderingDeviceCommons::get_image_format_pixel_size(DataFormat p_format
 }
 
 // https://www.khronos.org/registry/DataFormat/specs/1.1/dataformat.1.1.pdf
-void RenderingDeviceCommons::get_compressed_image_format_block_dimensions(DataFormat p_format, uint32_t &r_w, uint32_t &r_h) {
+std::tuple<uint32_t, uint32_t> RenderingDeviceCommons::get_compressed_image_format_block_dimensions(DataFormat p_format) {
 	switch (p_format) {
 		case DATA_FORMAT_BC1_RGB_UNORM_BLOCK:
 		case DATA_FORMAT_BC1_RGB_SRGB_BLOCK:
@@ -554,10 +554,8 @@ void RenderingDeviceCommons::get_compressed_image_format_block_dimensions(DataFo
 		case DATA_FORMAT_EAC_R11G11_UNORM_BLOCK:
 		case DATA_FORMAT_EAC_R11G11_SNORM_BLOCK:
 		case DATA_FORMAT_ASTC_4x4_UNORM_BLOCK: // Again, not sure about astc.
-		case DATA_FORMAT_ASTC_4x4_SRGB_BLOCK: {
-			r_w = 4;
-			r_h = 4;
-		} break;
+		case DATA_FORMAT_ASTC_4x4_SRGB_BLOCK:
+			return { 4, 4 };
 		case DATA_FORMAT_ASTC_5x4_UNORM_BLOCK: // Unsupported
 		case DATA_FORMAT_ASTC_5x4_SRGB_BLOCK:
 		case DATA_FORMAT_ASTC_5x5_UNORM_BLOCK:
@@ -569,15 +567,11 @@ void RenderingDeviceCommons::get_compressed_image_format_block_dimensions(DataFo
 		case DATA_FORMAT_ASTC_8x5_UNORM_BLOCK:
 		case DATA_FORMAT_ASTC_8x5_SRGB_BLOCK:
 		case DATA_FORMAT_ASTC_8x6_UNORM_BLOCK:
-		case DATA_FORMAT_ASTC_8x6_SRGB_BLOCK: {
-			r_w = 4;
-			r_h = 4;
-		} break;
+		case DATA_FORMAT_ASTC_8x6_SRGB_BLOCK:
+			return { 4, 4 };
 		case DATA_FORMAT_ASTC_8x8_UNORM_BLOCK:
-		case DATA_FORMAT_ASTC_8x8_SRGB_BLOCK: {
-			r_w = 8;
-			r_h = 8;
-		} break;
+		case DATA_FORMAT_ASTC_8x8_SRGB_BLOCK:
+			return { 8, 8 };
 		case DATA_FORMAT_ASTC_10x5_UNORM_BLOCK: // Unsupported
 		case DATA_FORMAT_ASTC_10x5_SRGB_BLOCK:
 		case DATA_FORMAT_ASTC_10x6_UNORM_BLOCK:
@@ -590,13 +584,9 @@ void RenderingDeviceCommons::get_compressed_image_format_block_dimensions(DataFo
 		case DATA_FORMAT_ASTC_12x10_SRGB_BLOCK:
 		case DATA_FORMAT_ASTC_12x12_UNORM_BLOCK:
 		case DATA_FORMAT_ASTC_12x12_SRGB_BLOCK:
-			r_w = 4;
-			r_h = 4;
-			return;
-		default: {
-			r_w = 1;
-			r_h = 1;
-		}
+			return { 4, 4 };
+		default:
+			return { 1, 1 };
 	}
 }
 
@@ -713,7 +703,7 @@ uint32_t RenderingDeviceCommons::get_image_format_required_size(DataFormat p_for
 	uint32_t pixel_rshift = get_compressed_image_format_pixel_rshift(p_format);
 	uint32_t blockw = 0;
 	uint32_t blockh = 0;
-	get_compressed_image_format_block_dimensions(p_format, blockw, blockh);
+	std::tie(blockw, blockh) = get_compressed_image_format_block_dimensions(p_format);
 
 	for (uint32_t i = 0; i < p_mipmaps; i++) {
 		uint32_t bw = STEPIFY(w, blockw);

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -915,7 +915,7 @@ protected:
 	static const uint32_t TEXTURE_SAMPLES_COUNT[TEXTURE_SAMPLES_MAX];
 
 	static uint32_t get_image_format_pixel_size(DataFormat p_format);
-	static void get_compressed_image_format_block_dimensions(DataFormat p_format, uint32_t &r_w, uint32_t &r_h);
+	static std::tuple<uint32_t, uint32_t> get_compressed_image_format_block_dimensions(DataFormat p_format);
 	uint32_t get_compressed_image_format_block_byte_size(DataFormat p_format) const;
 	static uint32_t get_compressed_image_format_pixel_rshift(DataFormat p_format);
 	static uint32_t get_image_format_required_size(DataFormat p_format, uint32_t p_width, uint32_t p_height, uint32_t p_depth, uint32_t p_mipmaps, uint32_t *r_blockw = nullptr, uint32_t *r_blockh = nullptr, uint32_t *r_depth = nullptr);


### PR DESCRIPTION
Shortens the method signature and make the code smaller. Pure positives!