### PR TITLE
Add save integrity levels.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -962,7 +962,7 @@ Error ProjectSettings::save() {
 
 Error ProjectSettings::_save_settings_binary(const String &p_file, const RBMap<String, List<String>> &p_props, const CustomMap &p_custom, const String &p_custom_features) {
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_file, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_file, FileAccess::WRITE, &err, FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Couldn't save project.binary at '%s'.", p_file));
 
 	uint8_t hdr[4] = { 'E', 'C', 'F', 'G' };
@@ -1031,7 +1031,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const RBMap<S
 
 Error ProjectSettings::_save_settings_text(const String &p_file, const RBMap<String, List<String>> &p_props, const CustomMap &p_custom, const String &p_custom_features) {
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_file, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_file, FileAccess::WRITE, &err, FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Couldn't save project.godot - %s.", p_file));
 
@@ -1343,7 +1343,7 @@ void ProjectSettings::store_global_class_list(const Array &p_classes) {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
 	cf->set_value("", "list", p_classes);
-	cf->save(get_global_class_list_path());
+	cf->save(get_global_class_list_path(), FileAccess::SAVE_INTEGRITY_NONE);
 
 	global_class_list = p_classes;
 }

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -308,8 +308,15 @@ void OS::close_midi_inputs() {
 	::OS::get_singleton()->close_midi_inputs();
 }
 
+#ifndef DISABLE_DEPRECATED
 void OS::set_use_file_access_save_and_swap(bool p_enable) {
-	FileAccess::set_backup_save(p_enable);
+	WARN_DEPRECATED_MSG("Use set_default_save_integrity_level() instead.");
+	FileAccess::set_default_save_integrity_level(p_enable ? FileAccess::SAVE_INTEGRITY_SAVE_SWAP : FileAccess::SAVE_INTEGRITY_NONE);
+}
+#endif
+
+void OS::set_default_save_integrity_level(FileAccess::SaveIntegrityLevel p_integrity_level) {
+	FileAccess::set_default_save_integrity_level(p_integrity_level);
 }
 
 void OS::set_low_processor_usage_mode(bool p_enabled) {
@@ -817,7 +824,10 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_keycode_unicode", "code"), &OS::is_keycode_unicode);
 	ClassDB::bind_method(D_METHOD("find_keycode_from_string", "string"), &OS::find_keycode_from_string);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_use_file_access_save_and_swap", "enabled"), &OS::set_use_file_access_save_and_swap);
+#endif
+	ClassDB::bind_method(D_METHOD("set_default_save_integrity_level", "integrity_level"), &OS::set_default_save_integrity_level);
 
 	ClassDB::bind_method(D_METHOD("set_thread_name", "name"), &OS::set_thread_name);
 	ClassDB::bind_method(D_METHOD("get_thread_caller_id"), &OS::get_thread_caller_id);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -261,7 +261,10 @@ public:
 	bool is_keycode_unicode(char32_t p_unicode) const;
 	Key find_keycode_from_string(const String &p_code) const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_use_file_access_save_and_swap(bool p_enable);
+#endif
+	void set_default_save_integrity_level(FileAccess::SaveIntegrityLevel p_integrity_level);
 
 	uint64_t get_static_memory_usage() const;
 	uint64_t get_static_memory_peak_usage() const;

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -224,7 +224,7 @@ String ResourceFormatLoaderCrypto::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverCrypto::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverCrypto::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err;
 	Ref<X509Certificate> cert = p_resource;
 	Ref<CryptoKey> key = p_resource;

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -162,7 +162,7 @@ public:
 
 class ResourceFormatSaverCrypto : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/core/io/config_file.compat.inc
+++ b/core/io/config_file.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  resource_saver_png.h                                                  */
+/*  config_file.compat.inc                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,19 +28,24 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef DISABLE_DEPRECATED
 
-#include "core/io/image.h"
-#include "core/io/resource_saver.h"
+Error ConfigFile::_save_compat_100447(const String &p_path) {
+	return save(p_path, FileAccess::SAVE_INTEGRITY_DEFAULT);
+}
 
-class ResourceSaverPNG : public ResourceFormatSaver {
-public:
-	static Error save_image(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level);
-	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);
+Error ConfigFile::_save_encrypted_compat_100447(const String &p_path, const Vector<uint8_t> &p_key) {
+	return save_encrypted(p_path, p_key, FileAccess::SAVE_INTEGRITY_DEFAULT);
+}
 
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
-	virtual bool recognize(const Ref<Resource> &p_resource) const override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+Error ConfigFile::_save_encrypted_pass_compat_100447(const String &p_path, const String &p_pass) {
+	return save_encrypted_pass(p_path, p_pass, FileAccess::SAVE_INTEGRITY_DEFAULT);
+}
 
-	ResourceSaverPNG();
-};
+void ConfigFile::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("save", "path"), &ConfigFile::_save_compat_100447);
+	ClassDB::bind_compatibility_method(D_METHOD("save_encrypted", "path", "key"), &ConfigFile::_save_encrypted_compat_100447);
+	ClassDB::bind_compatibility_method(D_METHOD("save_encrypted_pass", "path", "password"), &ConfigFile::_save_encrypted_pass_compat_100447);
+}
+
+#endif

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "config_file.h"
+#include "config_file.compat.inc"
 
 #include "core/io/file_access_encrypted.h"
 #include "core/string/string_builder.h"
@@ -141,9 +142,9 @@ String ConfigFile::encode_to_text() const {
 	return sb.as_string();
 }
 
-Error ConfigFile::save(const String &p_path) {
+Error ConfigFile::save(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 	if (err) {
 		return err;
@@ -152,9 +153,9 @@ Error ConfigFile::save(const String &p_path) {
 	return _internal_save(file);
 }
 
-Error ConfigFile::save_encrypted(const String &p_path, const Vector<uint8_t> &p_key) {
+Error ConfigFile::save_encrypted(const String &p_path, const Vector<uint8_t> &p_key, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err;
-	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 	if (err) {
 		return err;
@@ -169,9 +170,9 @@ Error ConfigFile::save_encrypted(const String &p_path, const Vector<uint8_t> &p_
 	return _internal_save(fae);
 }
 
-Error ConfigFile::save_encrypted_pass(const String &p_path, const String &p_pass) {
+Error ConfigFile::save_encrypted_pass(const String &p_path, const String &p_pass, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err;
-	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 	if (err) {
 		return err;
@@ -322,7 +323,7 @@ void ConfigFile::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &ConfigFile::load);
 	ClassDB::bind_method(D_METHOD("parse", "data"), &ConfigFile::parse);
-	ClassDB::bind_method(D_METHOD("save", "path"), &ConfigFile::save);
+	ClassDB::bind_method(D_METHOD("save", "path", "integrity_level"), &ConfigFile::save, DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 
 	ClassDB::bind_method(D_METHOD("encode_to_text"), &ConfigFile::encode_to_text);
 
@@ -331,8 +332,8 @@ void ConfigFile::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_encrypted", "path", "key"), &ConfigFile::load_encrypted);
 	ClassDB::bind_method(D_METHOD("load_encrypted_pass", "path", "password"), &ConfigFile::load_encrypted_pass);
 
-	ClassDB::bind_method(D_METHOD("save_encrypted", "path", "key"), &ConfigFile::save_encrypted);
-	ClassDB::bind_method(D_METHOD("save_encrypted_pass", "path", "password"), &ConfigFile::save_encrypted_pass);
+	ClassDB::bind_method(D_METHOD("save_encrypted", "path", "key", "integrity_level"), &ConfigFile::save_encrypted, DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
+	ClassDB::bind_method(D_METHOD("save_encrypted_pass", "path", "password", "integrity_level"), &ConfigFile::save_encrypted_pass, DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 
 	ClassDB::bind_method(D_METHOD("clear"), &ConfigFile::clear);
 }

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -48,6 +48,14 @@ class ConfigFile : public RefCounted {
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error _save_compat_100447(const String &p_path);
+	Error _save_encrypted_compat_100447(const String &p_path, const Vector<uint8_t> &p_key);
+	Error _save_encrypted_pass_compat_100447(const String &p_path, const String &p_pass);
+
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	void set_value(const String &p_section, const String &p_key, const Variant &p_value);
 	Variant get_value(const String &p_section, const String &p_key, const Variant &p_default = Variant()) const;
@@ -61,7 +69,7 @@ public:
 	void erase_section(const String &p_section);
 	void erase_section_key(const String &p_section, const String &p_key);
 
-	Error save(const String &p_path);
+	Error save(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	Error load(const String &p_path);
 	Error parse(const String &p_data);
 
@@ -72,6 +80,6 @@ public:
 	Error load_encrypted(const String &p_path, const Vector<uint8_t> &p_key);
 	Error load_encrypted_pass(const String &p_path, const String &p_pass);
 
-	Error save_encrypted(const String &p_path, const Vector<uint8_t> &p_key);
-	Error save_encrypted_pass(const String &p_path, const String &p_pass);
+	Error save_encrypted(const String &p_path, const Vector<uint8_t> &p_key, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
+	Error save_encrypted_pass(const String &p_path, const String &p_pass, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 };

--- a/core/io/file_access.compat.inc
+++ b/core/io/file_access.compat.inc
@@ -30,6 +30,10 @@
 
 #ifndef DISABLE_DEPRECATED
 
+Ref<FileAccess> FileAccess::_open_bind_compat_100447(const String &p_path, ModeFlags p_mode_flags) {
+	return _open(p_path, p_mode_flags, SAVE_INTEGRITY_DEFAULT);
+}
+
 Ref<FileAccess> FileAccess::_open_encrypted_bind_compat_98918(const String &p_path, ModeFlags p_mode_flags, const Vector<uint8_t> &p_key) {
 	return open_encrypted(p_path, p_mode_flags, p_key, Vector<uint8_t>());
 }
@@ -91,8 +95,6 @@ void FileAccess::store_pascal_string_bind_compat_78289(const String &p_string) {
 }
 
 void FileAccess::_bind_compatibility_methods() {
-	ClassDB::bind_compatibility_static_method("FileAccess", D_METHOD("open_encrypted", "path", "mode_flags", "key"), &FileAccess::_open_encrypted_bind_compat_98918);
-
 	ClassDB::bind_compatibility_method(D_METHOD("store_8", "value"), &FileAccess::store_8_bind_compat_78289);
 	ClassDB::bind_compatibility_method(D_METHOD("store_16", "value"), &FileAccess::store_16_bind_compat_78289);
 	ClassDB::bind_compatibility_method(D_METHOD("store_32", "value"), &FileAccess::store_32_bind_compat_78289);
@@ -107,6 +109,9 @@ void FileAccess::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("store_string", "string"), &FileAccess::store_string_bind_compat_78289);
 	ClassDB::bind_compatibility_method(D_METHOD("store_var", "value", "full_objects"), &FileAccess::store_var_bind_compat_78289, DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("store_pascal_string", "string"), &FileAccess::store_pascal_string_bind_compat_78289);
+
+	ClassDB::bind_compatibility_static_method("FileAccess", D_METHOD("open", "path", "flags"), &FileAccess::_open_bind_compat_100447);
+	ClassDB::bind_compatibility_static_method("FileAccess", D_METHOD("open_encrypted", "path", "mode_flags", "key"), &FileAccess::_open_encrypted_bind_compat_98918);
 }
 
 #endif

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -111,7 +111,7 @@ Ref<FileAccess> FileAccess::create_temp(int p_mode_flags, const String &p_prefix
 	{
 		// Create file first with WRITE mode.
 		// Otherwise, it would fail to open with a READ mode.
-		Ref<FileAccess> ret = FileAccess::open(path, FileAccess::ModeFlags::WRITE, &err);
+		Ref<FileAccess> ret = FileAccess::open(path, FileAccess::ModeFlags::WRITE, &err, SAVE_INTEGRITY_NONE);
 		if (err != OK) {
 			*r_error = err;
 			ERR_FAIL_V_MSG(Ref<FileAccess>(), vformat(R"(%s: could not create "%s".)", ERROR_COMMON_PREFIX, path));
@@ -151,11 +151,14 @@ void FileAccess::_delete_temp() {
 	DirAccess::remove_absolute(_temp_path);
 }
 
-Error FileAccess::reopen(const String &p_path, int p_mode_flags) {
-	return open_internal(p_path, p_mode_flags);
+Error FileAccess::reopen(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
+	if (p_integrity_level == SAVE_INTEGRITY_DEFAULT) {
+		p_integrity_level = default_save_integrity_level;
+	}
+	return open_internal(p_path, p_mode_flags, p_integrity_level);
 }
 
-Ref<FileAccess> FileAccess::open(const String &p_path, int p_mode_flags, Error *r_error) {
+Ref<FileAccess> FileAccess::open(const String &p_path, int p_mode_flags, Error *r_error, SaveIntegrityLevel p_integrity_level) {
 	//try packed data first
 
 	Ref<FileAccess> ret;
@@ -169,8 +172,12 @@ Ref<FileAccess> FileAccess::open(const String &p_path, int p_mode_flags, Error *
 		}
 	}
 
+	if (p_integrity_level == SAVE_INTEGRITY_DEFAULT) {
+		p_integrity_level = default_save_integrity_level;
+	}
+
 	ret = create_for_path(p_path);
-	Error err = ret->open_internal(p_path, p_mode_flags);
+	Error err = ret->open_internal(p_path, p_mode_flags, p_integrity_level);
 
 	if (r_error) {
 		*r_error = err;
@@ -182,9 +189,9 @@ Ref<FileAccess> FileAccess::open(const String &p_path, int p_mode_flags, Error *
 	return ret;
 }
 
-Ref<FileAccess> FileAccess::_open(const String &p_path, ModeFlags p_mode_flags) {
+Ref<FileAccess> FileAccess::_open(const String &p_path, ModeFlags p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	Error err = OK;
-	Ref<FileAccess> fa = open(p_path, p_mode_flags, &err);
+	Ref<FileAccess> fa = open(p_path, p_mode_flags, &err, p_integrity_level);
 	last_file_open_error = err;
 	if (err) {
 		return Ref<FileAccess>();
@@ -228,7 +235,7 @@ Ref<FileAccess> FileAccess::open_compressed(const String &p_path, ModeFlags p_mo
 	Ref<FileAccessCompressed> fac;
 	fac.instantiate();
 	fac->configure("GCPF", (Compression::Mode)p_compress_mode);
-	Error err = fac->open_internal(p_path, p_mode_flags);
+	Error err = fac->open_internal(p_path, p_mode_flags, SAVE_INTEGRITY_NONE);
 	last_file_open_error = err;
 	if (err) {
 		return Ref<FileAccess>();
@@ -869,6 +876,12 @@ String FileAccess::get_file_as_string(const String &p_path, Error *r_error) {
 	return ret;
 }
 
+void FileAccess::set_default_save_integrity_level(SaveIntegrityLevel p_integrity_level) {
+	ERR_FAIL_COND_MSG(p_integrity_level == SAVE_INTEGRITY_DEFAULT, "SAVE_INTEGRITY_DEFAULT is not a valid input setting.");
+	ERR_FAIL_INDEX(p_integrity_level, SAVE_INTEGRITY_MAX);
+	default_save_integrity_level = p_integrity_level;
+}
+
 String FileAccess::get_md5(const String &p_file) {
 	Ref<FileAccess> f = FileAccess::open(p_file, READ);
 	if (f.is_null()) {
@@ -951,7 +964,7 @@ String FileAccess::get_sha256(const String &p_file) {
 }
 
 void FileAccess::_bind_methods() {
-	ClassDB::bind_static_method("FileAccess", D_METHOD("open", "path", "flags"), &FileAccess::_open);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("open", "path", "flags", "integrity_level"), &FileAccess::_open, DEFVAL(SAVE_INTEGRITY_DEFAULT));
 	ClassDB::bind_static_method("FileAccess", D_METHOD("open_encrypted", "path", "mode_flags", "key", "iv"), &FileAccess::open_encrypted, DEFVAL(Vector<uint8_t>()));
 	ClassDB::bind_static_method("FileAccess", D_METHOD("open_encrypted_with_pass", "path", "mode_flags", "pass"), &FileAccess::open_encrypted_pass);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("open_compressed", "path", "mode_flags", "compression_mode"), &FileAccess::open_compressed, DEFVAL(0));
@@ -1034,6 +1047,12 @@ void FileAccess::_bind_methods() {
 	BIND_ENUM_CONSTANT(COMPRESSION_ZSTD);
 	BIND_ENUM_CONSTANT(COMPRESSION_GZIP);
 	BIND_ENUM_CONSTANT(COMPRESSION_BROTLI);
+
+	BIND_ENUM_CONSTANT(SAVE_INTEGRITY_DEFAULT);
+	BIND_ENUM_CONSTANT(SAVE_INTEGRITY_NONE);
+	BIND_ENUM_CONSTANT(SAVE_INTEGRITY_SAVE_SWAP);
+	BIND_ENUM_CONSTANT(SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
+	BIND_ENUM_CONSTANT(SAVE_INTEGRITY_MAX);
 
 	BIND_BITFIELD_FLAG(UNIX_READ_OWNER);
 	BIND_BITFIELD_FLAG(UNIX_WRITE_OWNER);

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -75,7 +75,7 @@ Error FileAccessCompressed::open_after_magic(Ref<FileAccess> p_base) {
 	return ret == -1 ? ERR_FILE_CORRUPT : OK;
 }
 
-Error FileAccessCompressed::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessCompressed::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	ERR_FAIL_COND_V(p_mode_flags == READ_WRITE, ERR_UNAVAILABLE);
 	_close();
 

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -70,7 +70,7 @@ public:
 
 	Error open_after_magic(Ref<FileAccess> p_base);
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -130,7 +130,7 @@ Error FileAccessEncrypted::open_and_parse_password(Ref<FileAccess> p_base, const
 	return open_and_parse(p_base, key_md5, p_mode);
 }
 
-Error FileAccessEncrypted::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessEncrypted::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	return OK;
 }
 

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -67,7 +67,7 @@ public:
 
 	Vector<uint8_t> get_iv() const { return iv; }
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -76,7 +76,7 @@ Error FileAccessMemory::open_custom(const uint8_t *p_data, uint64_t p_len) {
 	return OK;
 }
 
-Error FileAccessMemory::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessMemory::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	ERR_FAIL_NULL_V(files, ERR_FILE_NOT_FOUND);
 
 	String name = fix_path(p_path);

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -45,7 +45,7 @@ public:
 	static void cleanup();
 
 	virtual Error open_custom(const uint8_t *p_data, uint64_t p_len); ///< open a file
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual void seek(uint64_t p_position) override; ///< seek to a given position

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -371,7 +371,7 @@ void PackedSourceDirectory::add_directory(const String &p_path, bool p_replace_f
 
 //////////////////////////////////////////////////////////////////
 
-Error FileAccessPack::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessPack::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	ERR_PRINT("Can't open pack-referenced file.");
 	return ERR_UNAVAILABLE;
 }

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -169,7 +169,7 @@ class FileAccessPack : public FileAccess {
 	uint64_t off;
 
 	Ref<FileAccess> f;
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override;
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override;
 	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
 	virtual uint64_t _get_access_time(const String &p_file) override { return 0; }
 	virtual int64_t _get_size(const String &p_file) override { return -1; }

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -232,7 +232,7 @@ ZipArchive::~ZipArchive() {
 	packages.clear();
 }
 
-Error FileAccessZip::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessZip::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
 
 	ERR_FAIL_COND_V(p_mode_flags & FileAccess::WRITE, FAILED);
@@ -333,7 +333,7 @@ void FileAccessZip::close() {
 }
 
 FileAccessZip::FileAccessZip(const String &p_path, const PackedData::PackedFile &p_file) {
-	open_internal(p_path, FileAccess::READ);
+	open_internal(p_path, FileAccess::READ, SAVE_INTEGRITY_NONE);
 }
 
 FileAccessZip::~FileAccessZip() {

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -82,7 +82,7 @@ class FileAccessZip : public FileAccess {
 	void _close();
 
 public:
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual void seek(uint64_t p_position) override; ///< seek to a given position

--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  resource_saver_png.h                                                  */
+/*  image.compat.inc                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,19 +28,34 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef DISABLE_DEPRECATED
 
-#include "core/io/image.h"
-#include "core/io/resource_saver.h"
+Error Image::_save_png_compat_100447(const String &p_path) const {
+	return save_png(p_path, FileAccess::SAVE_INTEGRITY_DEFAULT);
+}
 
-class ResourceSaverPNG : public ResourceFormatSaver {
-public:
-	static Error save_image(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level);
-	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);
+Error Image::_save_jpg_compat_100447(const String &p_path, float p_quality) const {
+	return save_jpg(p_path, p_quality, FileAccess::SAVE_INTEGRITY_DEFAULT);
+}
 
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
-	virtual bool recognize(const Ref<Resource> &p_resource) const override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+Error Image::_save_dds_compat_100447(const String &p_path) const {
+	return save_dds(p_path, FileAccess::SAVE_INTEGRITY_DEFAULT);
+}
 
-	ResourceSaverPNG();
-};
+Error Image::_save_exr_compat_100447(const String &p_path, bool p_grayscale) const {
+	return save_exr(p_path, p_grayscale, FileAccess::SAVE_INTEGRITY_DEFAULT);
+}
+
+Error Image::_save_webp_compat_100447(const String &p_path, const bool p_lossy, const float p_quality) const {
+	return save_webp(p_path, p_lossy, p_quality, FileAccess::SAVE_INTEGRITY_DEFAULT);
+}
+
+void Image::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("save_png", "path"), &Image::_save_png_compat_100447);
+	ClassDB::bind_compatibility_method(D_METHOD("save_jpg", "path", "quality"), &Image::_save_jpg_compat_100447, DEFVAL(0.75));
+	ClassDB::bind_compatibility_method(D_METHOD("save_dds", "path"), &Image::_save_dds_compat_100447);
+	ClassDB::bind_compatibility_method(D_METHOD("save_exr", "path", "grayscale"), &Image::_save_exr_compat_100447, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("save_webp", "path", "lossy", "quality"), &Image::_save_webp_compat_100447, DEFVAL(false), DEFVAL(0.75f));
+}
+
+#endif

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "image.h"
+#include "image.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
@@ -2553,20 +2554,20 @@ Ref<Image> Image::load_from_file(const String &p_path) {
 	return image;
 }
 
-Error Image::save_png(const String &p_path) const {
+Error Image::save_png(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level) const {
 	if (save_png_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 
-	return save_png_func(p_path, Ref<Image>((Image *)this));
+	return save_png_func(p_path, Ref<Image>((Image *)this), p_integrity_level);
 }
 
-Error Image::save_jpg(const String &p_path, float p_quality) const {
+Error Image::save_jpg(const String &p_path, float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level) const {
 	if (save_jpg_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 
-	return save_jpg_func(p_path, Ref<Image>((Image *)this), p_quality);
+	return save_jpg_func(p_path, Ref<Image>((Image *)this), p_quality, p_integrity_level);
 }
 
 Vector<uint8_t> Image::save_png_to_buffer() const {
@@ -2585,12 +2586,12 @@ Vector<uint8_t> Image::save_jpg_to_buffer(float p_quality) const {
 	return save_jpg_buffer_func(Ref<Image>((Image *)this), p_quality);
 }
 
-Error Image::save_exr(const String &p_path, bool p_grayscale) const {
+Error Image::save_exr(const String &p_path, bool p_grayscale, FileAccess::SaveIntegrityLevel p_integrity_level) const {
 	if (save_exr_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 
-	return save_exr_func(p_path, Ref<Image>((Image *)this), p_grayscale);
+	return save_exr_func(p_path, Ref<Image>((Image *)this), p_grayscale, p_integrity_level);
 }
 
 Vector<uint8_t> Image::save_exr_to_buffer(bool p_grayscale) const {
@@ -2600,12 +2601,12 @@ Vector<uint8_t> Image::save_exr_to_buffer(bool p_grayscale) const {
 	return save_exr_buffer_func(Ref<Image>((Image *)this), p_grayscale);
 }
 
-Error Image::save_dds(const String &p_path) const {
+Error Image::save_dds(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level) const {
 	if (save_dds_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 
-	return save_dds_func(p_path, Ref<Image>((Image *)this));
+	return save_dds_func(p_path, Ref<Image>((Image *)this), p_integrity_level);
 }
 
 Vector<uint8_t> Image::save_dds_to_buffer() const {
@@ -2615,13 +2616,13 @@ Vector<uint8_t> Image::save_dds_to_buffer() const {
 	return save_dds_buffer_func(Ref<Image>((Image *)this));
 }
 
-Error Image::save_webp(const String &p_path, const bool p_lossy, const float p_quality) const {
+Error Image::save_webp(const String &p_path, const bool p_lossy, const float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level) const {
 	if (save_webp_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 	ERR_FAIL_COND_V_MSG(p_lossy && !(0.0f <= p_quality && p_quality <= 1.0f), ERR_INVALID_PARAMETER, vformat("The WebP lossy quality was set to %f, which is not valid. WebP lossy quality must be between 0.0 and 1.0 (inclusive).", p_quality));
 
-	return save_webp_func(p_path, Ref<Image>((Image *)this), p_lossy, p_quality);
+	return save_webp_func(p_path, Ref<Image>((Image *)this), p_lossy, p_quality, p_integrity_level);
 }
 
 Vector<uint8_t> Image::save_webp_to_buffer(const bool p_lossy, const float p_quality) const {
@@ -3549,16 +3550,16 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &Image::load);
 	ClassDB::bind_static_method("Image", D_METHOD("load_from_file", "path"), &Image::load_from_file);
-	ClassDB::bind_method(D_METHOD("save_png", "path"), &Image::save_png);
+	ClassDB::bind_method(D_METHOD("save_png", "path", "integrity_level"), &Image::save_png, DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 	ClassDB::bind_method(D_METHOD("save_png_to_buffer"), &Image::save_png_to_buffer);
-	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality"), &Image::save_jpg, DEFVAL(0.75));
+	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality", "integrity_level"), &Image::save_jpg, DEFVAL(0.75), DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 	ClassDB::bind_method(D_METHOD("save_jpg_to_buffer", "quality"), &Image::save_jpg_to_buffer, DEFVAL(0.75));
-	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale"), &Image::save_exr, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale", "integrity_level"), &Image::save_exr, DEFVAL(false), DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 	ClassDB::bind_method(D_METHOD("save_exr_to_buffer", "grayscale"), &Image::save_exr_to_buffer, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("save_dds", "path"), &Image::save_dds);
+	ClassDB::bind_method(D_METHOD("save_dds", "path", "integrity_level"), &Image::save_dds);
 	ClassDB::bind_method(D_METHOD("save_dds_to_buffer"), &Image::save_dds_to_buffer);
 
-	ClassDB::bind_method(D_METHOD("save_webp", "path", "lossy", "quality"), &Image::save_webp, DEFVAL(false), DEFVAL(0.75f));
+	ClassDB::bind_method(D_METHOD("save_webp", "path", "lossy", "quality", "integrity_level"), &Image::save_webp, DEFVAL(false), DEFVAL(0.75f), DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 	ClassDB::bind_method(D_METHOD("save_webp_to_buffer", "lossy", "quality"), &Image::save_webp_to_buffer, DEFVAL(false), DEFVAL(0.75f));
 
 	ClassDB::bind_method(D_METHOD("detect_alpha"), &Image::detect_alpha);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/io/file_access.h"
 #include "core/io/resource.h"
 #include "core/math/color.h"
 
@@ -43,22 +44,22 @@ class Image;
 
 // Function pointer prototypes.
 
-typedef Error (*SavePNGFunc)(const String &p_path, const Ref<Image> &p_img);
+typedef Error (*SavePNGFunc)(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level);
 typedef Vector<uint8_t> (*SavePNGBufferFunc)(const Ref<Image> &p_img);
 
-typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, float p_quality);
+typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level);
 typedef Vector<uint8_t> (*SaveJPGBufferFunc)(const Ref<Image> &p_img, float p_quality);
 
 typedef Ref<Image> (*ImageMemLoadFunc)(const uint8_t *p_data, int p_size);
 typedef Ref<Image> (*ScalableImageMemLoadFunc)(const uint8_t *p_data, int p_size, float p_scale);
 
-typedef Error (*SaveWebPFunc)(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
+typedef Error (*SaveWebPFunc)(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level);
 typedef Vector<uint8_t> (*SaveWebPBufferFunc)(const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
 
-typedef Error (*SaveEXRFunc)(const String &p_path, const Ref<Image> &p_img, bool p_grayscale);
+typedef Error (*SaveEXRFunc)(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, FileAccess::SaveIntegrityLevel p_integrity_level);
 typedef Vector<uint8_t> (*SaveEXRBufferFunc)(const Ref<Image> &p_img, bool p_grayscale);
 
-typedef Error (*SaveDDSFunc)(const String &p_path, const Ref<Image> &p_img);
+typedef Error (*SaveDDSFunc)(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level);
 typedef Vector<uint8_t> (*SaveDDSBufferFunc)(const Ref<Image> &p_img);
 
 class Image : public Resource {
@@ -248,6 +249,16 @@ protected:
 
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error _save_png_compat_100447(const String &p_path) const;
+	Error _save_jpg_compat_100447(const String &p_path, float p_quality = 0.75) const;
+	Error _save_dds_compat_100447(const String &p_path) const;
+	Error _save_exr_compat_100447(const String &p_path, bool p_grayscale = false) const;
+	Error _save_webp_compat_100447(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
+
+	static void _bind_compatibility_methods();
+#endif
+
 private:
 	Format format = FORMAT_L8;
 	Vector<uint8_t> data;
@@ -343,15 +354,15 @@ public:
 
 	Error load(const String &p_path);
 	static Ref<Image> load_from_file(const String &p_path);
-	Error save_png(const String &p_path) const;
-	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
-	Error save_dds(const String &p_path) const;
+	Error save_png(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) const;
+	Error save_jpg(const String &p_path, float p_quality = 0.75, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) const;
+	Error save_dds(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) const;
 	Vector<uint8_t> save_png_to_buffer() const;
 	Vector<uint8_t> save_jpg_to_buffer(float p_quality = 0.75) const;
 	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale = false) const;
 	Vector<uint8_t> save_dds_to_buffer() const;
-	Error save_exr(const String &p_path, bool p_grayscale = false) const;
-	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
+	Error save_exr(const String &p_path, bool p_grayscale = false, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) const;
+	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) const;
 	Vector<uint8_t> save_webp_to_buffer(const bool p_lossy = false, const float p_quality = 0.75f) const;
 
 	static Ref<Image> create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format);

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1572,14 +1572,14 @@ String ResourceFormatLoaderJSON::get_resource_type(const String &p_path) const {
 	return "";
 }
 
-Error ResourceFormatSaverJSON::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverJSON::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<JSON> json = p_resource;
 	ERR_FAIL_COND_V(json.is_null(), ERR_INVALID_PARAMETER);
 
 	String source = json->get_parsed_text().is_empty() ? JSON::stringify(json->get_data(), "\t", false, true) : json->get_parsed_text();
 
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Cannot save json '%s'.", p_path));
 

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -120,7 +120,7 @@ public:
 
 class ResourceFormatSaverJSON : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1322,7 +1322,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		Ref<FileAccessCompressed> facw;
 		facw.instantiate();
 		facw->configure("RSCC");
-		err = facw->open_internal(p_path + ".depren", FileAccess::WRITE);
+		err = facw->open_internal(p_path + ".depren", FileAccess::WRITE, FileAccess::SAVE_INTEGRITY_NONE);
 		ERR_FAIL_COND_V_MSG(err, ERR_FILE_CORRUPT, vformat("Cannot create file '%s.depren'.", p_path));
 
 		fw = facw;
@@ -2156,7 +2156,7 @@ static String _resource_get_class(Ref<Resource> p_resource) {
 	}
 }
 
-Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Resource::seed_scene_unique_id(p_path.hash());
 
 	Error err;
@@ -2166,9 +2166,9 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 		fac.instantiate();
 		fac->configure("RSCC");
 		f = fac;
-		err = fac->open_internal(p_path, FileAccess::WRITE);
+		err = fac->open_internal(p_path, FileAccess::WRITE, FileAccess::SAVE_INTEGRITY_NONE);
 	} else {
-		f = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		f = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	}
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot create file '%s'.", p_path));
@@ -2421,7 +2421,7 @@ Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceU
 		Ref<FileAccessCompressed> facw;
 		facw.instantiate();
 		facw->configure("RSCC");
-		err = facw->open_internal(p_path + ".uidren", FileAccess::WRITE);
+		err = facw->open_internal(p_path + ".uidren", FileAccess::WRITE, FileAccess::SAVE_INTEGRITY_NONE);
 		ERR_FAIL_COND_V_MSG(err, ERR_FILE_CORRUPT, vformat("Cannot create file '%s.uidren'.", p_path));
 
 		fw = facw;
@@ -2513,10 +2513,10 @@ Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceU
 	return OK;
 }
 
-Error ResourceFormatSaverBinary::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverBinary::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	ResourceFormatSaverBinaryInstance saver;
-	return saver.save(local_path, p_resource, p_flags);
+	return saver.save(local_path, p_resource, p_flags, p_integrity_level);
 }
 
 Error ResourceFormatSaverBinary::set_uid(const String &p_path, ResourceUID::ID p_uid) {

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -173,7 +173,7 @@ public:
 		// Amount of reserved 32-bit fields in resource header
 		RESERVED_FIELDS = 11
 	};
-	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	static void write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
 };
@@ -181,7 +181,7 @@ public:
 class ResourceFormatSaverBinary : public ResourceFormatSaver {
 public:
 	static inline ResourceFormatSaverBinary *singleton = nullptr;
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/core/io/resource_saver.compat.inc
+++ b/core/io/resource_saver.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  resource_saver_png.h                                                  */
+/*  resource_saver.compat.inc                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,19 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef DISABLE_DEPRECATED
 
-#include "core/io/image.h"
-#include "core/io/resource_saver.h"
+void ResourceFormatSaver::_bind_compatibility_methods() {
+	GDVIRTUAL_BIND_COMPAT(_save_compat_100447, "resource", "path", "flags");
+}
 
-class ResourceSaverPNG : public ResourceFormatSaver {
-public:
-	static Error save_image(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level);
-	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);
-
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
-	virtual bool recognize(const Ref<Resource> &p_resource) const override;
-	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
-
-	ResourceSaverPNG();
-};
+#endif

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -29,6 +29,8 @@
 /**************************************************************************/
 
 #include "resource_saver.h"
+#include "resource_saver.compat.inc"
+
 #include "core/config/project_settings.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
@@ -41,9 +43,17 @@ bool ResourceSaver::timestamp_on_save = false;
 ResourceSavedCallback ResourceSaver::save_callback = nullptr;
 ResourceSaverGetResourceIDForPath ResourceSaver::save_get_id_for_path = nullptr;
 
-Error ResourceFormatSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err = ERR_METHOD_NOT_FOUND;
-	GDVIRTUAL_CALL(_save, p_resource, p_path, p_flags, err);
+	if (GDVIRTUAL_CALL(_save, p_resource, p_path, p_flags, p_integrity_level, err)) {
+		return err;
+	}
+
+#ifndef DISABLE_DEPRECATED
+	// If not, we fall back on the old one. Notice the "_save_compat_100447" alias we're using here instead of "_save".
+	GDVIRTUAL_CALL(_save_compat_100447, p_resource, p_path, p_flags, err);
+#endif // DISABLE_DEPRECATED
+
 	return err;
 }
 
@@ -90,14 +100,14 @@ bool ResourceFormatSaver::recognize_path(const Ref<Resource> &p_resource, const 
 }
 
 void ResourceFormatSaver::_bind_methods() {
-	GDVIRTUAL_BIND(_save, "resource", "path", "flags");
+	GDVIRTUAL_BIND(_save, "resource", "path", "flags", "integrity_level");
 	GDVIRTUAL_BIND(_set_uid, "path", "uid");
 	GDVIRTUAL_BIND(_recognize, "resource");
 	GDVIRTUAL_BIND(_get_recognized_extensions, "resource");
 	GDVIRTUAL_BIND(_recognize_path, "resource", "path");
 }
 
-Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, vformat("Can't save empty resource to path '%s'.", p_path));
 	String path = p_path;
 	if (path.is_empty()) {
@@ -125,7 +135,7 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 			p_resource->set_path(local_path);
 		}
 
-		err = saver[i]->save(p_resource, path, p_flags);
+		err = saver[i]->save(p_resource, path, p_flags, p_integrity_level);
 
 		if (err == OK) {
 #ifdef TOOLS_ENABLED

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/io/file_access.h"
 #include "core/io/resource.h"
 #include "core/object/gdvirtual.gen.inc"
 
@@ -39,14 +40,20 @@ class ResourceFormatSaver : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL3R(Error, _save, Ref<Resource>, String, uint32_t)
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL3R_COMPAT(_save_compat_100447, Error, _save, Ref<Resource>, String, uint32_t)
+
+	static void _bind_compatibility_methods();
+#endif
+
+	GDVIRTUAL4R(Error, _save, Ref<Resource>, String, uint32_t, FileAccess::SaveIntegrityLevel)
 	GDVIRTUAL2R(Error, _set_uid, String, ResourceUID::ID)
 	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
 	GDVIRTUAL2RC(bool, _recognize_path, Ref<Resource>, String)
 
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
@@ -83,7 +90,7 @@ public:
 		FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
 	};
 
-	static Error save(const Ref<Resource> &p_resource, const String &p_path = "", uint32_t p_flags = (uint32_t)FLAG_NONE);
+	static Error save(const Ref<Resource> &p_resource, const String &p_path = "", uint32_t p_flags = (uint32_t)FLAG_NONE, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -195,6 +195,7 @@
 		<method name="save">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
+			<param index="1" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the contents of the [ConfigFile] object to the file specified as a parameter. The output file uses an INI-style structure.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
@@ -204,6 +205,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="key" type="PackedByteArray" />
+			<param index="2" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param key] to encrypt it. The output file uses an INI-style structure.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.
@@ -213,6 +215,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="password" type="String" />
+			<param index="2" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the contents of the [ConfigFile] object to the AES-256 encrypted file specified as a parameter, using the provided [param password] to encrypt it. The output file uses an INI-style structure.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -776,9 +776,8 @@
 		<member name="filesystem/on_save/compress_binary_resources" type="bool" setter="" getter="">
 			If [code]true[/code], uses lossless compression for binary resources.
 		</member>
-		<member name="filesystem/on_save/safe_save_on_backup_then_rename" type="bool" setter="" getter="">
-			If [code]true[/code], when saving a file, the editor will rename the old file to a different name, save a new file, then only remove the old file once the new file has been saved. This makes loss of data less likely to happen if the editor or operating system exits unexpectedly while saving (e.g. due to a crash or power outage).
-			[b]Note:[/b] On Windows, this feature can interact negatively with certain antivirus programs. In this case, you may have to set this to [code]false[/code] to prevent file locking issues.
+		<member name="filesystem/on_save/default_integrity_level" type="int" setter="" getter="">
+			What integrity value should the editor use by default when saving. See [method OS.set_default_save_integrity_level].
 		</member>
 		<member name="filesystem/quick_open_dialog/default_display_mode" type="int" setter="" getter="">
 			If set to [code]Adaptive[/code], the dialog opens in list view or grid view depending on the requested type. If set to [code]Last Used[/code], the display mode will always open the way you last used it.

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -320,6 +320,7 @@
 			<return type="FileAccess" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="flags" type="int" enum="FileAccess.ModeFlags" />
+			<param index="2" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Creates a new [FileAccess] object and opens the file for writing or reading, depending on the flags.
 				Returns [code]null[/code] if opening the file failed. You can use [method get_open_error] to check the error that occurred.
@@ -601,6 +602,43 @@
 		</constant>
 		<constant name="COMPRESSION_BROTLI" value="4" enum="CompressionMode">
 			Uses the [url=https://github.com/google/brotli]brotli[/url] compression method (only decompression is supported).
+		</constant>
+		<constant name="SAVE_INTEGRITY_DEFAULT" value="0" enum="SaveIntegrityLevel">
+			Use the default level globally set by [method OS.set_default_save_integrity_level].
+		</constant>
+		<constant name="SAVE_INTEGRITY_NONE" value="1" enum="SaveIntegrityLevel">
+			Make no attempts to keep the integrity of the saving operation.
+			If the app crashes while saving or the system experiences power failure/BSOD, the data will be lost. Even previously saved data will be lost or corrupted.
+			Useful for cache or temp data that can be regenerated from scratch if lost or corrupted.
+			[b]Note:[/b] The SaveIntegrityLevel flags are only relevant when the [enum FileAccess.ModeFlags] is set to [constant FileAccess.WRITE] and the underlying FileAccess type supports it (e.g. regular files support it, but zip or encrypted files do not). Otherwise it is ignored.
+		</constant>
+		<constant name="SAVE_INTEGRITY_SAVE_SWAP" value="2" enum="SaveIntegrityLevel">
+			Minor attempts to keep the integrity of the saving operation.
+			If the app crashes while saving, old data will remain safe. If the system experiences power failure/BSOD, there's still a chance that the data will be lost, even previously saved data.
+			Useful for most saving operations.
+			Integrity is kept using the following algorithm:
+			1. Write to [code]temp_file-x12354.tmp[code]
+			2. Rename [code]temp_file-x12354.tmp[/code] to [code]final.png[/code]
+			[b]Note:[/b] The SaveIntegrityLevel flags are only relevant when the [enum FileAccess.ModeFlags] is set to [constant FileAccess.WRITE] and the underlying FileAccess type supports it (e.g. regular files support it, but zip or encrypted files do not). Otherwise it is ignored.
+		</constant>
+		<constant name="SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC" value="3" enum="SaveIntegrityLevel">
+			Very strong guarantees to keep data integrity.
+			If the app crashes or system experiences power failure/BSOD, there's a very high chance data integrity will be preserved (old or new).
+			Useful for important data such as:
+			- Project files.
+			- Config files.
+			- User settings.
+			- Game saves.
+			[b]Warning:[/b] Frequent use of this flag can bring the performance of the entire system down, even on SSDs. It can also contribute to faster SSD level wear. Use with moderation.
+			[b]Note:[/b] Actual integrity will depend on various factors and cannot always be guaranteed, such as the type of file system involved or when writing to network shared drives.
+			Integrity is kept using the following algorithm:
+			1. Write to [code]temp_file.tmp[/code]
+			2. Flush disk IO
+			3. Rename [code]temp_file.tmp[/code] to [code]final.png[/code]
+			Flushing prevents the OS or disk controller from reordering the rename() on step 3 from happening before step 1 is finished.
+			[b]Note:[/b] The SaveIntegrityLevel flags are only relevant when the [enum FileAccess.ModeFlags] is set to [constant FileAccess.WRITE] and the underlying FileAccess type supports it (e.g. regular files support it, but zip or encrypted files do not). Otherwise it is ignored.
+		</constant>
+		<constant name="SAVE_INTEGRITY_MAX" value="4" enum="SaveIntegrityLevel">
 		</constant>
 		<constant name="UNIX_READ_OWNER" value="256" enum="UnixPermissionFlags" is_bitfield="true">
 			Read for owner bit.

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -469,6 +469,7 @@
 		<method name="save_dds" qualifiers="const">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
+			<param index="1" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" />
 			<description>
 				Saves the image as a DDS (DirectDraw Surface) file to [param path]. DDS is a container format that can store textures in various compression formats, such as DXT1, DXT5, or BC7. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the DDS module.
 				[b]Note:[/b] The DDS module may be disabled in certain builds, which means [method save_dds] will return [constant ERR_UNAVAILABLE] when it is called from an exported project.
@@ -485,6 +486,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="grayscale" type="bool" default="false" />
+			<param index="2" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the image as an EXR file to [param path]. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
 				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return [constant ERR_UNAVAILABLE] when it is called from an exported project.
@@ -502,6 +504,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="quality" type="float" default="0.75" />
+			<param index="2" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the image as a JPEG file to [param path] with the specified [param quality] between [code]0.01[/code] and [code]1.0[/code] (inclusive). Higher [param quality] values result in better-looking output at the cost of larger file sizes. Recommended [param quality] values are between [code]0.75[/code] and [code]0.90[/code]. Even at quality [code]1.00[/code], JPEG compression remains lossy.
 				[b]Note:[/b] JPEG does not save an alpha channel. If the [Image] contains an alpha channel, the image will still be saved, but the resulting JPEG file won't contain the alpha channel.
@@ -518,6 +521,7 @@
 		<method name="save_png" qualifiers="const">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
+			<param index="1" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the image as a PNG file to the file at [param path].
 			</description>
@@ -533,6 +537,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="lossy" type="bool" default="false" />
 			<param index="2" name="quality" type="float" default="0.75" />
+			<param index="3" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the image as a WebP (Web Picture) file to the file at [param path]. By default it will save lossless. If [param lossy] is [code]true[/code], the image will be saved lossy, using the [param quality] setting between [code]0.0[/code] and [code]1.0[/code] (inclusive). Lossless WebP offers more efficient compression than PNG.
 				[b]Note:[/b] The WebP format is limited to a size of 16383×16383 pixels, while PNG can save larger images.

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -799,6 +799,16 @@
 				On macOS (sandboxed applications only), this function clears list of user selected folders accessible to the application.
 			</description>
 		</method>
+		<method name="set_default_save_integrity_level">
+			<return type="void" />
+			<param index="0" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" />
+			<description>
+				Sets the default integrity level to use when for saving operations when the [constant FileAccess.SAVE_INTEGRITY_DEFAULT] value is requested.
+				[param integrity_level] must not be [constant FileAccess.SAVE_INTEGRITY_DEFAULT].
+				[b]Warning:[/b] Setting the default to [constant FileAccess.SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC] can cause a severe performance degradation. It's not recommended to set the default to this value.
+				[b]Note:[/b] On Windows, a value other than [constant FileAccess.SAVE_INTEGRITY_NONE] may interact negatively with certain antivirus programs. In this case, you'll have to set it to [constant FileAccess.SAVE_INTEGRITY_NONE] to prevent file locking issues.
+			</description>
+		</method>
 		<method name="set_environment" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="variable" type="String" />
@@ -826,7 +836,7 @@
 				Assigns the given name to the current thread. Returns [constant ERR_UNAVAILABLE] if unavailable on the current platform.
 			</description>
 		</method>
-		<method name="set_use_file_access_save_and_swap">
+		<method name="set_use_file_access_save_and_swap" deprecated="Use [method set_default_save_integrity_level] instead.">
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
 			<description>

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -38,6 +38,7 @@
 			<param index="0" name="resource" type="Resource" />
 			<param index="1" name="path" type="String" />
 			<param index="2" name="flags" type="int" />
+			<param index="3" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" />
 			<description>
 				Saves the given resource object to a file at the target [param path]. [param flags] is a bitmask composed with [enum ResourceSaver.SaverFlags] constants.
 				Returns [constant OK] on success, or an [enum Error] constant in case of failure.

--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -155,7 +155,7 @@ void EGLManager::_set_cache(const void *p_key, EGLsizeiANDROID p_key_size, const
 	String path = shader_cache_dir.path_join(name) + ".cache";
 
 	Error err = OK;
-	Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE, &err, FileAccess::SAVE_INTEGRITY_SAVE_SWAP);
 	if (err != OK) {
 		return;
 	}

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -35,7 +35,7 @@
 #include "drivers/png/png_driver_common.h"
 #include "scene/resources/image_texture.h"
 
-Error ResourceSaverPNG::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceSaverPNG::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<ImageTexture> texture = p_resource;
 
 	ERR_FAIL_COND_V_MSG(texture.is_null(), ERR_INVALID_PARAMETER, "Can't save invalid texture as PNG.");
@@ -43,16 +43,16 @@ Error ResourceSaverPNG::save(const Ref<Resource> &p_resource, const String &p_pa
 
 	Ref<Image> img = texture->get_image();
 
-	Error err = save_image(p_path, img);
+	Error err = save_image(p_path, img, p_integrity_level);
 
 	return err;
 }
 
-Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img) {
+Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Vector<uint8_t> buffer;
 	Error err = PNGDriverCommon::image_to_png(p_img, buffer);
 	ERR_FAIL_COND_V_MSG(err, err, "Can't convert image to PNG.");
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save PNG at path: '%s'.", p_path));
 
 	const uint8_t *reader = buffer.ptr();

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -62,8 +62,11 @@ void FileAccessUnix::check_errors(bool p_write) const {
 	}
 }
 
-Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
+
+	DEV_ASSERT(p_integrity_level != SAVE_INTEGRITY_DEFAULT); // It should have already been resolved.
+	ERR_FAIL_INDEX_V(p_integrity_level, SAVE_INTEGRITY_MAX, ERR_INVALID_PARAMETER);
 
 	path_src = p_path;
 	path = fix_path(p_path);
@@ -116,7 +119,9 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 	}
 #endif
 
-	if (is_backup_save_enabled() && (p_mode_flags == WRITE)) {
+	integrity_level = p_integrity_level;
+
+	if (integrity_level > SAVE_INTEGRITY_NONE && (p_mode_flags == WRITE)) {
 		save_path = path;
 		// Create a temporary file in the same directory as the target file.
 		path = path + "-XXXXXX";

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -41,6 +41,7 @@ class FileAccessUnix : public FileAccess {
 	GDSOFTCLASS(FileAccessUnix, FileAccess);
 	FILE *f = nullptr;
 	int flags = 0;
+	SaveIntegrityLevel integrity_level = SAVE_INTEGRITY_NONE;
 	void check_errors(bool p_write = false) const;
 	mutable Error last_error = OK;
 	String save_path;
@@ -57,7 +58,7 @@ public:
 	typedef void (*CloseNotificationFunc)(const String &p_file, int p_flags);
 	static CloseNotificationFunc close_notification_func;
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -61,7 +61,7 @@ Error FileAccessUnixPipe::open_existing(int p_rfd, int p_wfd, bool p_blocking) {
 	return OK;
 }
 
-Error FileAccessUnixPipe::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessUnixPipe::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
 
 	path_src = p_path;

--- a/drivers/unix/file_access_unix_pipe.h
+++ b/drivers/unix/file_access_unix_pipe.h
@@ -51,7 +51,7 @@ class FileAccessUnixPipe : public FileAccess {
 
 public:
 	Error open_existing(int p_rfd, int p_wfd, bool p_blocking);
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 
 	virtual bool is_open() const override; ///< true when file is open
 

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -41,6 +41,7 @@ class FileAccessWindows : public FileAccess {
 	GDSOFTCLASS(FileAccessWindows, FileAccess);
 	FILE *f = nullptr;
 	int flags = 0;
+	SaveIntegrityLevel integrity_level = SAVE_INTEGRITY_NONE;
 	void check_errors(bool p_write = false) const;
 	mutable int prev_op = 0;
 	mutable Error last_error = OK;
@@ -56,7 +57,7 @@ public:
 	static bool is_path_invalid(const String &p_path);
 
 	virtual String fix_path(const String &p_path) const override;
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/drivers/windows/file_access_windows_pipe.cpp
+++ b/drivers/windows/file_access_windows_pipe.cpp
@@ -54,7 +54,7 @@ Error FileAccessWindowsPipe::open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_bl
 	return OK;
 }
 
-Error FileAccessWindowsPipe::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessWindowsPipe::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
 
 	path_src = p_path;

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -52,7 +52,7 @@ class FileAccessWindowsPipe : public FileAccess {
 public:
 	Error open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_blocking);
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -57,7 +57,7 @@ void EditorFolding::save_resource_folding(const Ref<Resource> &p_resource, const
 
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
 	file = EditorPaths::get_singleton()->get_project_settings_dir().path_join(file);
-	config->save(file);
+	config->save(file, FileAccess::SAVE_INTEGRITY_NONE);
 }
 
 void EditorFolding::_set_unfolds(Object *p_object, const Vector<String> &p_unfolds) {
@@ -151,7 +151,7 @@ void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path
 
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
 	file = EditorPaths::get_singleton()->get_project_settings_dir().path_join(file);
-	config->save(file);
+	config->save(file, FileAccess::SAVE_INTEGRITY_NONE);
 }
 
 void EditorFolding::load_scene_folding(Node *p_scene, const String &p_path) {

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -238,11 +238,11 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 		if (r_texture.is_valid()) {
 			// Wow it generated a preview... save cache.
 			bool has_small_texture = r_small_texture.is_valid();
-			ResourceSaver::save(r_texture, cache_base + ".png");
+			ResourceSaver::save(r_texture, cache_base + ".png", ResourceSaver::FLAG_NONE, FileAccess::SAVE_INTEGRITY_NONE);
 			if (has_small_texture) {
-				ResourceSaver::save(r_small_texture, cache_base + "_small.png");
+				ResourceSaver::save(r_small_texture, cache_base + "_small.png", ResourceSaver::FLAG_NONE, FileAccess::SAVE_INTEGRITY_NONE);
 			}
-			Ref<FileAccess> f = FileAccess::open(cache_base + ".txt", FileAccess::WRITE);
+			Ref<FileAccess> f = FileAccess::open(cache_base + ".txt", FileAccess::WRITE, nullptr, FileAccess::SAVE_INTEGRITY_NONE);
 			ERR_FAIL_COND_MSG(f.is_null(), "Cannot create file '" + cache_base + ".txt'. Check user write permissions.");
 
 			uint64_t modtime = FileAccess::get_modified_time(p_item.path);
@@ -348,7 +348,7 @@ void EditorResourcePreview::_iterate() {
 			} else {
 				// Update modified time.
 
-				Ref<FileAccess> f2 = FileAccess::open(file, FileAccess::WRITE);
+				Ref<FileAccess> f2 = FileAccess::open(file, FileAccess::WRITE, nullptr, FileAccess::SAVE_INTEGRITY_NONE);
 				if (f2.is_null()) {
 					// Not returning as this would leave the thread hanging and would require
 					// some proper cleanup/disabling of resource preview generation.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -638,7 +638,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// On save
 	_initial_set("filesystem/on_save/compress_binary_resources", true);
-	_initial_set("filesystem/on_save/safe_save_on_backup_then_rename", true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "filesystem/on_save/default_integrity_level", 1, "None, Save Swap, Save Swap + Sync");
 
 	// EditorFileServer
 	_initial_set("filesystem/file_server/port", 6010);
@@ -1407,7 +1407,7 @@ void EditorSettings::save() {
 		return;
 	}
 
-	Error err = ResourceSaver::save(singleton);
+	Error err = ResourceSaver::save(singleton, "", ResourceSaver::FLAG_NONE, FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 
 	if (err != OK) {
 		ERR_PRINT("Error saving editor settings to " + singleton->get_path());

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3661,7 +3661,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 	p_layout->set_value("ScriptEditor", "zoom_factor", zoom_factor);
 
 	// Save the cache.
-	script_editor_cache->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("script_editor_cache.cfg"));
+	script_editor_cache->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("script_editor_cache.cfg"), FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 }
 
 void ScriptEditor::_help_class_open(const String &p_class) {

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -267,3 +267,18 @@ Validate extension JSON: JSON file: Field was added in a way that breaks compati
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/RichTextLabel/methods/push_underline': arguments
 
 Optional "color" argument added. Compatibility methods registered.
+
+
+GH-100447
+---------
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save_encrypted/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save_encrypted_pass/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/FileAccess/methods/open/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Image/methods/save_exr/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Image/methods/save_jpg/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Image/methods/save_png/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/Image/methods/save_webp/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: Error: Field 'classes/ResourceFormatSaver/methods/_save/arguments': size changed value in new API, from 3 to 4.
+
+These methods now have a new argument integrity_level. Compatibility methods registered.

--- a/modules/dds/image_saver_dds.cpp
+++ b/modules/dds/image_saver_dds.cpp
@@ -35,15 +35,18 @@
 #include "core/io/file_access.h"
 #include "core/io/stream_peer.h"
 
-Error save_dds(const String &p_path, const Ref<Image> &p_img) {
+Error save_dds(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Vector<uint8_t> buffer = save_dds_buffer(p_img);
 
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE);
-	if (file.is_null()) {
-		return ERR_CANT_CREATE;
-	}
+	Error err;
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
+	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save DDS at path: '%s'.", p_path));
 
 	file->store_buffer(buffer.ptr(), buffer.size());
+
+	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
+		return ERR_CANT_CREATE;
+	}
 
 	return OK;
 }

--- a/modules/dds/image_saver_dds.h
+++ b/modules/dds/image_saver_dds.h
@@ -32,5 +32,5 @@
 
 #include "core/io/image.h"
 
-Error save_dds(const String &p_path, const Ref<Image> &p_img);
+Error save_dds(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level);
 Vector<uint8_t> save_dds_buffer(const Ref<Image> &p_img);

--- a/modules/dds/tests/test_dds.h
+++ b/modules/dds/tests/test_dds.h
@@ -80,7 +80,7 @@ TEST_CASE("[SceneTree][DDSSaver] Save DDS - Save valid image with mipmap" * doct
 	image->fill(Color(1, 0, 0)); // Fill with red color
 	image->generate_mipmaps();
 	image->compress_from_channels(Image::COMPRESS_S3TC, Image::USED_CHANNELS_RGBA);
-	Error err = save_dds("res://valid_image_with_mipmap.dds", image);
+	Error err = save_dds("res://valid_image_with_mipmap.dds", image, FileAccess::SAVE_INTEGRITY_NONE);
 	CHECK(err == OK);
 
 	Ref<Image> loaded_image;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -3119,7 +3119,7 @@ void ResourceFormatLoaderGDScript::get_classes_used(const String &p_path, HashSe
 	}
 }
 
-Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<GDScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 
@@ -3127,7 +3127,7 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 
 	{
 		Error err;
-		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 		ERR_FAIL_COND_V_MSG(err, err, "Cannot save GDScript file '" + p_path + "'.");
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -693,7 +693,7 @@ public:
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/modules/jpg/image_loader_libjpeg_turbo.cpp
+++ b/modules/jpg/image_loader_libjpeg_turbo.cpp
@@ -170,9 +170,9 @@ static Vector<uint8_t> _jpeg_turbo_buffer_save_func(const Ref<Image> &p_img, flo
 	return output;
 }
 
-static Error _jpeg_turbo_save_func(const String &p_path, const Ref<Image> &p_img, float p_quality) {
+static Error _jpeg_turbo_save_func(const String &p_path, const Ref<Image> &p_img, float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save JPG at path: '%s'.", p_path));
 
 	Vector<uint8_t> data = _jpeg_turbo_buffer_save_func(p_img, p_quality);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2870,7 +2870,7 @@ String ResourceFormatLoaderCSharpScript::get_resource_type(const String &p_path)
 	return p_path.get_extension().to_lower() == "cs" ? CSharpLanguage::get_singleton()->get_type() : "";
 }
 
-Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<CSharpScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 
@@ -2888,7 +2888,7 @@ Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, con
 
 	{
 		Error err;
-		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save C# script file '" + p_path + "'.");
 
 		file->store_string(source);

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -598,7 +598,7 @@ public:
 
 class ResourceFormatSaverCSharpScript : public ResourceFormatSaver {
 public:
-	Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -283,13 +283,13 @@ Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale) {
 	return buffer;
 }
 
-Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) {
+Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	const Vector<uint8_t> buffer = save_exr_buffer(p_img, p_grayscale);
 	if (buffer.is_empty()) {
 		print_error(String("Saving EXR failed."));
 		return ERR_FILE_CANT_WRITE;
 	} else {
-		Ref<FileAccess> ref = FileAccess::open(p_path, FileAccess::WRITE);
+		Ref<FileAccess> ref = FileAccess::open(p_path, FileAccess::WRITE, nullptr, p_integrity_level);
 		ERR_FAIL_COND_V(ref.is_null(), ERR_FILE_CANT_WRITE);
 		ref->store_buffer(buffer.ptr(), buffer.size());
 	}

--- a/modules/tinyexr/image_saver_tinyexr.h
+++ b/modules/tinyexr/image_saver_tinyexr.h
@@ -32,5 +32,5 @@
 
 #include "core/io/image.h"
 
-Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale);
+Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, FileAccess::SaveIntegrityLevel p_integrity_level);
 Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale);

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -36,7 +36,7 @@
 #include "core/io/image.h"
 #include "scene/resources/image_texture.h"
 
-Error ResourceSaverWebP::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceSaverWebP::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<ImageTexture> texture = p_resource;
 
 	ERR_FAIL_COND_V_MSG(texture.is_null(), ERR_INVALID_PARAMETER, "Can't save invalid texture as WebP.");
@@ -44,15 +44,15 @@ Error ResourceSaverWebP::save(const Ref<Resource> &p_resource, const String &p_p
 
 	Ref<Image> img = texture->get_image();
 
-	Error err = save_image(p_path, img);
+	Error err = save_image(p_path, img, false, 0.75f, p_integrity_level);
 
 	return err;
 }
 
-Error ResourceSaverWebP::save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality) {
+Error ResourceSaverWebP::save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Vector<uint8_t> buffer = save_image_to_buffer(p_img, p_lossy, p_quality);
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save WebP at path: '%s'.", p_path));
 
 	const uint8_t *reader = buffer.ptr();

--- a/modules/webp/resource_saver_webp.h
+++ b/modules/webp/resource_saver_webp.h
@@ -35,10 +35,10 @@
 
 class ResourceSaverWebP : public ResourceFormatSaver {
 public:
-	static Error save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);
+	static Error save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);
 
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -46,7 +46,7 @@ String FileAccessAndroid::get_path_absolute() const {
 	return absolute_path;
 }
 
-Error FileAccessAndroid::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessAndroid::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
 
 	path_src = p_path;

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -52,7 +52,7 @@ class FileAccessAndroid : public FileAccess {
 	void _close();
 
 public:
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; // open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; // open a file
 	virtual bool is_open() const override; // true when file is open
 
 	/// returns the path for the current open file

--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -65,7 +65,7 @@ String FileAccessFilesystemJAndroid::get_path_absolute() const {
 	return absolute_path;
 }
 
-Error FileAccessFilesystemJAndroid::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessFilesystemJAndroid::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	if (is_open()) {
 		_close();
 	}

--- a/platform/android/file_access_filesystem_jandroid.h
+++ b/platform/android/file_access_filesystem_jandroid.h
@@ -64,7 +64,7 @@ class FileAccessFilesystemJAndroid : public FileAccess {
 	void _set_eof(bool eof);
 
 public:
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	/// returns the path for the current open file

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1700,7 +1700,7 @@ static String _resource_get_class(Ref<Resource> p_resource) {
 	}
 }
 
-Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Resource::seed_scene_unique_id(p_path.hash()); // Seeding for save path should make it deterministic for importers.
 
 	if (p_path.ends_with(".tscn")) {
@@ -1708,7 +1708,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 	}
 
 	Error err;
-	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	ERR_FAIL_COND_V_MSG(err, ERR_CANT_OPEN, "Cannot save file '" + p_path + "'.");
 	Ref<FileAccess> _fref(f);
 
@@ -2112,13 +2112,13 @@ Error ResourceLoaderText::set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid) {
 	return OK;
 }
 
-Error ResourceFormatSaverText::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverText::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	if (p_path.ends_with(".tscn") && Ref<PackedScene>(p_resource).is_null()) {
 		return ERR_FILE_UNRECOGNIZED;
 	}
 
 	ResourceFormatSaverTextInstance saver;
-	return saver.save(p_path, p_resource, p_flags);
+	return saver.save(p_path, p_resource, p_flags, p_integrity_level);
 }
 
 Error ResourceFormatSaverText::set_uid(const String &p_path, ResourceUID::ID p_uid) {

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -199,13 +199,13 @@ class ResourceFormatSaverTextInstance {
 	String _write_resource(const Ref<Resource> &res);
 
 public:
-	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 };
 
 class ResourceFormatSaverText : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverText *singleton;
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -345,14 +345,14 @@ String ResourceFormatLoaderShader::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<Shader> shader = p_resource;
 	ERR_FAIL_COND_V(shader.is_null(), ERR_INVALID_PARAMETER);
 
 	String source = shader->get_code();
 
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader '" + p_path + "'.");
 

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -115,7 +115,7 @@ public:
 
 class ResourceFormatSaverShader : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -129,14 +129,14 @@ String ResourceFormatLoaderShaderInclude::get_resource_type(const String &p_path
 
 // ResourceFormatSaverShaderInclude
 
-Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<ShaderInclude> shader_inc = p_resource;
 	ERR_FAIL_COND_V(shader_inc.is_null(), ERR_INVALID_PARAMETER);
 
 	String source = shader_inc->get_code();
 
 	Error error;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &error);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &error, p_integrity_level);
 
 	ERR_FAIL_COND_V_MSG(error, error, "Cannot save shader include '" + p_path + "'.");
 

--- a/scene/resources/shader_include.h
+++ b/scene/resources/shader_include.h
@@ -65,7 +65,7 @@ public:
 
 class ResourceFormatSaverShaderInclude : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -513,7 +513,7 @@ void ShaderRD::_save_to_cache(Version *p_version, int p_group) {
 	ERR_FAIL_COND(!shader_cache_user_dir_valid);
 	String api_safe_name = String(RD::get_singleton()->get_device_api_name()).validate_filename().to_lower();
 	const String &path = _get_cache_file_path(p_version, p_group, api_safe_name, true);
-	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE, nullptr, FileAccess::SAVE_INTEGRITY_SAVE_SWAP);
 	ERR_FAIL_COND(f.is_null());
 
 	PackedByteArray shader_cache_bytes = ShaderRD::save_shader_cache_bytes(group_to_variant_map[p_group], p_version->variant_data);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6941,7 +6941,7 @@ void RenderingDevice::_save_pipeline_cache(void *p_data) {
 	}
 	print_verbose(vformat("Updated PSO cache (%.1f MiB)", cache_blob.size() / (1024.0f * 1024.0f)));
 
-	Ref<FileAccess> f = FileAccess::open(self->pipeline_cache_file_path, FileAccess::WRITE, nullptr);
+	Ref<FileAccess> f = FileAccess::open(self->pipeline_cache_file_path, FileAccess::WRITE, nullptr, FileAccess::SAVE_INTEGRITY_SAVE_SWAP);
 	if (f.is_valid()) {
 		f->store_buffer(cache_blob);
 	}


### PR DESCRIPTION
This PR adds an argument to most save functions to specify what level of integrity should Godot attempt to guarantee when writing a file.

This in preparation for PR #98361; which will introduce a full sync barrier when performing save operations to avoid data loss.

This PR puts such expensive sync() behind the enum SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC; which should be used sparingly for important information.

This PR also sets most cache files to be saved as either SAVE_INTEGRITY_SAVE_SWAP (old default behavior) or SAVE_INTEGRITY_NONE; because Godot can easily generate thousands of these file saving operations. Performing thousands of full syncs() would be too expensive, specially when these files can be regenerated if they're corrupted or lost.

The PR is incomplete as it does not yet expose integrity levels to the user, which is relevant for certain file saving operations, such as when game save files that store the player's progress (those should be done with SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
