### PR TITLE
Clear syntax highlighter cache when theme or syntax highlighter is changed

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2956,6 +2956,7 @@ void TextEdit::_update_caches() {
 	if (syntax_highlighter.is_valid()) {
 		syntax_highlighter->set_text_edit(this);
 	}
+	_clear_syntax_highlighting_cache();
 }
 
 void TextEdit::_close_ime_window() {
@@ -6428,6 +6429,7 @@ void TextEdit::set_syntax_highlighter(Ref<SyntaxHighlighter> p_syntax_highlighte
 	if (syntax_highlighter.is_valid()) {
 		syntax_highlighter->set_text_edit(this);
 	}
+	_clear_syntax_highlighting_cache();
 	queue_redraw();
 }
 


### PR DESCRIPTION
- Fixes #98367
- Fixes #100431