### PR TITLE
Cache StringNames and NodePaths in implicit casts from string in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringName.cs
@@ -1,6 +1,7 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
 using Godot.NativeInterop;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 
@@ -17,7 +18,11 @@ namespace Godot
     {
         internal godot_string_name.movable NativeValue;
 
-        private WeakReference<IDisposable>? _weakReferenceToSelf;
+        private readonly WeakReference<IDisposable>? _weakReferenceToSelf;
+
+        private static readonly ConcurrentDictionary<string, WeakReference<IDisposable>> _stringNameCache = new();
+        private readonly string? _inputString;
+        private readonly string? _outputString;
 
         ~StringName()
         {
@@ -35,10 +40,16 @@ namespace Godot
 
         public void Dispose(bool disposing)
         {
+            // Remove from cache
+            if (_inputString is not null && _weakReferenceToSelf is not null)
+            {
+                _stringNameCache.TryRemove(new(_inputString, _weakReferenceToSelf));
+            }
+
             // Always dispose `NativeValue` even if disposing is true
             NativeValue.DangerousSelfRef.Dispose();
 
-            if (_weakReferenceToSelf != null)
+            if (_weakReferenceToSelf is not null)
             {
                 DisposablesTracker.UnregisterDisposable(_weakReferenceToSelf);
             }
@@ -48,6 +59,15 @@ namespace Godot
         {
             NativeValue = (godot_string_name.movable)nativeValueToOwn;
             _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+            // Store input string (string passed to constructor)
+            _inputString = null;
+            // Store output string (string outputted by ToString())
+            NativeFuncs.godotsharp_string_name_as_string(out godot_string asNativeString, nativeValueToOwn);
+            using (asNativeString)
+            {
+                _outputString = Marshaling.ConvertStringToManaged(asNativeString);
+            }
         }
 
         // Explicit name to make it very clear
@@ -59,6 +79,10 @@ namespace Godot
         /// </summary>
         public StringName()
         {
+            // Store input string (used to create this StringName)
+            _inputString = string.Empty;
+            // Store output string (outputted by ToString())
+            _outputString = string.Empty;
         }
 
         /// <summary>
@@ -67,25 +91,58 @@ namespace Godot
         /// <param name="name">String to construct the <see cref="StringName"/> from.</param>
         public StringName(string name)
         {
-            if (!string.IsNullOrEmpty(name))
+            if (name is not null)
             {
                 NativeValue = (godot_string_name.movable)NativeFuncs.godotsharp_string_name_new_from_string(name);
                 _weakReferenceToSelf = DisposablesTracker.RegisterDisposable(this);
+
+                // Store input string (used to create this StringName)
+                _inputString = name;
+                // Store output string (string outputted by ToString())
+                // (No need to convert native value; StringNames can never change or simplify)
+                _outputString = name;
             }
         }
 
         /// <summary>
-        /// Converts a string to a <see cref="StringName"/>.
+        /// Converts a <see cref="string"/> to a <see cref="StringName"/>.<br/>
+        /// The resulting <see cref="StringName"/> is temporarily cached for future casts.
         /// </summary>
         /// <param name="from">The string to convert.</param>
-        public static implicit operator StringName(string from) => new StringName(from);
+        [return: NotNullIfNotNull(nameof(from))]
+        public static implicit operator StringName?(string? from)
+        {
+            if (from is null)
+                return null;
+
+            // Try get StringName from cache
+            if (_stringNameCache.TryGetValue(from, out WeakReference<IDisposable>? cachedStringNameWeakReference))
+            {
+                if (cachedStringNameWeakReference.TryGetTarget(out IDisposable? cachedStringName))
+                {
+                    return (StringName)cachedStringName;
+                }
+            }
+
+            // Create new StringName
+            var stringName = new StringName(from);
+            // Add new StringName to cache
+            if (stringName._weakReferenceToSelf is not null)
+            {
+                _stringNameCache.TryAdd(from, stringName._weakReferenceToSelf);
+            }
+            return stringName;
+        }
 
         /// <summary>
-        /// Converts a <see cref="StringName"/> to a string.
+        /// Converts a <see cref="StringName"/> to a <see cref="string"/>.
         /// </summary>
         /// <param name="from">The <see cref="StringName"/> to convert.</param>
-        [return: NotNullIfNotNull("from")]
-        public static implicit operator string?(StringName? from) => from?.ToString();
+        [return: NotNullIfNotNull(nameof(from))]
+        public static implicit operator string?(StringName? from)
+        {
+            return from?.ToString();
+        }
 
         /// <summary>
         /// Converts this <see cref="StringName"/> to a string.
@@ -93,13 +150,7 @@ namespace Godot
         /// <returns>A string representation of this <see cref="StringName"/>.</returns>
         public override string ToString()
         {
-            if (IsEmpty)
-                return string.Empty;
-
-            var src = (godot_string_name)NativeValue;
-            NativeFuncs.godotsharp_string_name_as_string(out godot_string dest, src);
-            using (dest)
-                return Marshaling.ConvertStringToManaged(dest);
+            return _outputString ?? string.Empty;
         }
 
         /// <summary>
@@ -125,6 +176,16 @@ namespace Godot
             if (other is null)
                 return false;
             return NativeValue.DangerousSelfRef == other.NativeValue.DangerousSelfRef;
+        }
+
+        public bool Equals([NotNullWhen(true)] string? other)
+        {
+            if (other is null)
+                return false;
+
+            // Compare output string (string outputted by ToString())
+            // (No need to convert native value; StringNames can never change or simplify)
+            return _outputString == other;
         }
 
         public static bool operator ==(StringName? left, in godot_string_name right)


### PR DESCRIPTION
This pull request addresses https://github.com/godotengine/godot-proposals/discussions/10826 (please take a look).
To summarise, StringNames and NodePaths are now cached when implicitly casting from strings to avoid allocations like:
```cs
Input.IsActionPressed("action"); // Created a StringName.
GetNode("path/to/node"); // Created a NodePath.
```

This pull request adds a [FusionCache](https://github.com/ZiggyCreatures/FusionCache) dependency since there is no cache built-in to C#. This could be replaced with a [MemoryCache](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.caching.memory.memorycache) dependency, or an in-house solution could be created using a `ConcurrentDictionary`.

In my opinion, StringNames (and NodePaths) do not make sense in C# and should be removed from the API. The reason is the garbage collection spike issues I detailed in the [discussion](https://github.com/godotengine/godot-proposals/discussions/10826). There are very few benefits to StringNames since identifiers are generally less than 20 characters long, and NodePaths don't seem to provide any value.

That being said, as long as StringNames and NodePaths remain in the API, implicit allocations should not exist, especially when it's so common to use string literals as StringNames and NodePaths.

If this pull request is added, the developer can still opt for a non-cached StringName or NodePath using `new StringName(string)` or `new NodePath(string)`.

Another related issue is there is currently no equality operator between StringName and string, so comparing them will result in the string being converted to a StringName, which is not ideal. It may be a good idea to add an `==` operator to StringName which accepts a string and compares them by converting the StringName to a string (instead of converting the string to a StringName).

By no means is this the only solution to the problem - I am open to discussions about better alternatives.