### PR TITLE
Highlight hovered `GraphEdit` connection by widening the line

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -551,6 +551,9 @@
 		<theme_item name="selection_stroke" data_type="color" type="Color" default="Color(1, 1, 1, 0.8)">
 			The outline color of the selection rectangle.
 		</theme_item>
+		<theme_item name="connection_hover_thickness" data_type="constant" type="int" default="0">
+			Widen the line of the connection when the mouse is hovering over it by a percentage factor. A value of [code]0[/code] disables the highlight. A value of [code]100[/code] doubles the line width.
+		</theme_item>
 		<theme_item name="port_hotzone_inner_extent" data_type="constant" type="int" default="22">
 			The horizontal range within which a port can be grabbed (inner side).
 		</theme_item>

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1563,6 +1563,7 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 		p_theme->set_color("activity", "GraphEdit", p_config.dark_theme ? Color(1, 1, 1) : Color(0, 0, 0));
 
 		p_theme->set_color("connection_hover_tint_color", "GraphEdit", p_config.dark_theme ? Color(0, 0, 0, 0.3) : Color(1, 1, 1, 0.3));
+		p_theme->set_constant("connection_hover_thickness", "GraphEdit", 0);
 		p_theme->set_color("connection_valid_target_tint_color", "GraphEdit", p_config.dark_theme ? Color(1, 1, 1, 0.4) : Color(0, 0, 0, 0.4));
 		p_theme->set_color("connection_rim_color", "GraphEdit", p_config.tree_panel_style->get_bg_color());
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1453,6 +1453,10 @@ void GraphEdit::_update_connections() {
 		Ref<Gradient> line_gradient = memnew(Gradient);
 
 		float line_width = _get_shader_line_width();
+		if (conn == hovered_connection) {
+			line_width *= 1.0f + (theme_cache.connection_hover_thickness / 100.0f);
+		}
+
 		conn->_cache.line->set_width(line_width);
 		line_gradient->set_color(0, from_color);
 		line_gradient->set_color(1, to_color);
@@ -2842,6 +2846,7 @@ void GraphEdit::_bind_methods() {
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_COLOR, GraphEdit, activity_color, "activity");
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, GraphEdit, connection_hover_tint_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, GraphEdit, connection_hover_thickness);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, GraphEdit, connection_valid_target_tint_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, GraphEdit, connection_rim_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, GraphEdit, selection_fill);

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -275,6 +275,7 @@ private:
 
 		Color activity_color;
 		Color connection_hover_tint_color;
+		int connection_hover_thickness;
 		Color connection_valid_target_tint_color;
 		Color connection_rim_color;
 

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1257,6 +1257,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("selection_stroke", "GraphEdit", Color(1, 1, 1, 0.8));
 	theme->set_color("activity", "GraphEdit", Color(1, 1, 1));
 	theme->set_color("connection_hover_tint_color", "GraphEdit", Color(0, 0, 0, 0.3));
+	theme->set_constant("connection_hover_thickness", "GraphEdit", 0);
 	theme->set_color("connection_valid_target_tint_color", "GraphEdit", Color(1, 1, 1, 0.4));
 	theme->set_color("connection_rim_color", "GraphEdit", style_normal_color);
 


### PR DESCRIPTION
Currently, GraphEdit connections are highlighted by tinting the color. With this change, the connections are highlighted by widening the line by a configurable factor.

The current method of highlighting connections has the following two properties:
1. The tint color is global for all connections, so when different colors are used, some of them can be very similar to the tint color, so that there is nearly no visual feedback for some highlighted connections.
2. If the tint color is darker than the connection color, the connection will be displayed darker while hovering. So while hovered It takes a back seat visually, even though the hovering should actually emphasize the connection.

Replacing the tint color by a configurable theme option solves these issues and also additionally allows users to change the settings in a way, that ho highlight happens.

~While this PR changes the theme-API and is therefore technically compatibility breaking, the `GraphEdit` node is still marked as experimental, so this should not be a deal-breaker.~ This is no longer an issue, since theme properties are no longer removed.

CC @Geometror

Updated 2024-12-18: Set default values to 0%.