### PR TITLE
CI: Ensure default branch cache persists

### DIFF
--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -11,24 +11,42 @@ inputs:
 runs:
   using: composite
   steps:
+    # Because all branches can refer to the repository's default branch's cache, we want it to
+    # persist as the de-facto fallback. However, it easily expunges in a matter of hours if
+    # nothing explicitly calls to it, so we work around that by ensuring it's *always* pinged
+    # prior to any cache operations.
+    - name: Ping main cache
+      uses: actions/cache/restore@v4
+      id: cache-ping
+      with:
+        path: ${{ inputs.scons-cache }}
+        key: " " # Dummy key; we have to rely on the fallback value.
+        restore-keys: ${{ inputs.cache-name }}|${{ github.event.repository.default_branch }}
+        lookup-only: true
+
+    # Fallback access isn't logged, so register an explicit cache-hit if found.
+    - name: Ping main cache (exact)
+      if: steps.cache-ping.outputs.cache-matched-key
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ inputs.scons-cache }}
+        key: ${{ steps.cache-ping.outputs.cache-matched-key }}
+        lookup-only: true
+
+    # We try to match an existing cache to restore from it. Each potential key is checked against
+    # all existing caches as a prefix. E.g. 'linux-template-minimal' would match any cache that
+    # starts with "linux-template-minimal", such as
+    # "linux-template-minimal|master|6588a4a29af1621086feac0117d5d4d37af957fd".
+    #
+    # We check these prefixes in this order:
+    #   1. An exact match for the base branch, reference name, and SHA hash.
+    #   2. A partial match for the same cache name and reference name.
+    #   3. A partial match for the same cache name and default branch name.
     - name: Restore SCons cache directory
       uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.scons-cache }}
-        key: ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}
-
-        # We try to match an existing cache to restore from it. Each potential key is checked against
-        # all existing caches as a prefix. E.g. 'linux-template-minimal' would match any cache that
-        # starts with "linux-template-minimal", such as "linux-template-minimal-master-refs/heads/master-6588a4a29af1621086feac0117d5d4d37af957fd".
-        #
-        # We check these prefixes in this order:
-        #
-        #   1. The exact match, including the base branch, the commit reference, and the SHA hash of the commit.
-        #   2. A partial match for the same base branch and the same commit reference.
-        #   3. A partial match for the same base branch and the base branch commit reference.
-        #   4. A partial match for the same base branch only (not ideal, matches any PR with the same base branch).
-
+        key: ${{ inputs.cache-name }}|${{ github.ref_name }}|${{ github.sha }}
         restore-keys: |
-          ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}
-          ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-refs/heads/${{ env.GODOT_BASE_BRANCH }}
-          ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}
+          ${{ inputs.cache-name }}|${{ github.ref_name }}
+          ${{ inputs.cache-name }}|${{ github.event.repository.default_branch }}

--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -15,4 +15,4 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ${{ inputs.scons-cache }}
-        key: ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}
+        key: ${{ inputs.cache-name }}|${{ github.ref_name }}|${{ github.sha }}

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -4,8 +4,6 @@ on:
 
 # Global Settings
 env:
-  # Used for the cache key. Add version suffix to force clean build.
-  GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
 
 jobs:

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -4,8 +4,6 @@ on:
 
 # Global Settings
 env:
-  # Used for the cache key. Add version suffix to force clean build.
-  GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
 
 jobs:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -4,8 +4,6 @@ on:
 
 # Global Settings
 env:
-  # Used for the cache key. Add version suffix to force clean build.
-  GODOT_BASE_BRANCH: master
   GODOT_CPP_BRANCH: 4.4
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes strict_checks=yes
   DOTNET_NOLOGO: true

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -4,8 +4,6 @@ on:
 
 # Global Settings
 env:
-  # Used for the cache key. Add version suffix to force clean build.
-  GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes strict_checks=yes
 
 jobs:

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -4,8 +4,6 @@ on:
 
 # Global Settings
 env:
-  # Used for the cache key. Add version suffix to force clean build.
-  GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no use_closure_compiler=yes strict_checks=yes
   EM_VERSION: 3.1.64
 

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -5,8 +5,6 @@ on:
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment
 env:
-  # Used for the cache key. Add version suffix to force clean build.
-  GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes d3d12=yes strict_checks=yes "angle_libs=${{ github.workspace }}/"
   SCONS_CACHE_MSVC_CONFIG: true
 


### PR DESCRIPTION
I've been brainstorming solutions to our cache system & this is what I've come up with: a peristent cache for the default branch. Presently, after a merge batch happens on main, we're lucky if that cache lasts the entire day; when traffic is high, we're lucky if it lasts mere hours. This comes down to a double-whammy of caches being immutable (can't override existing versions) & fallback keys **not** counting as "accessing" the cache. While the former is something we just have to live with, this PR works around the latter with this new system:
1. Before the local branch's cache is restored, attempt a read-only detection of the *default* branch's cache via fallback key.
2. If the previous step succeeded, use its output to cache-hit the key explicitly; this registers that cache as "accessed".

I've cleaned out my cache to demonstrate how integrating this affects a cache list. When quota is reached, the oldest cache *accessed* are what will go away first.
```
ID     KEY                                                                                           SIZE        CREATED                 ACCESSED
24446  windows-editor|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520                  222.32 MiB  less than a minute ago  less than a minute ago
24445  windows-template|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520                120.11 MiB  less than a minute ago  less than a minute ago
24444  linux-editor-double-sanitizers|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520  430.62 MiB  about 3 minutes ago     about 3 minutes ago
24443  windows-template-gcc|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520            58.41 MiB   about 4 minutes ago     about 4 minutes ago
24442  web-nothreads-template|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520          157.14 MiB  about 4 minutes ago     about 4 minutes ago
24441  web-template|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520                    130.58 MiB  about 4 minutes ago     about 4 minutes ago
24440  windows-editor-clang|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520            102.66 MiB  about 5 minutes ago     about 5 minutes ago
24439  linux-template-minimal|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520          25.51 MiB   about 5 minutes ago     about 5 minutes ago
24438  linux-editor-mono|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520               95.17 MiB   about 6 minutes ago     about 6 minutes ago
24437  macos-editor|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520                    229.29 MiB  about 6 minutes ago     about 6 minutes ago
24436  macos-template|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520                  88.45 MiB   about 6 minutes ago     about 6 minutes ago
24435  linux-editor-llvm-sanitizers|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520    623.16 MiB  about 6 minutes ago     about 6 minutes ago
24411  linux-template-minimal|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089          25.51 MiB   about 28 minutes ago    about 6 minutes ago
24389  linux-template-minimal|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                        25.51 MiB   about 1 hour ago        about 6 minutes ago
24434  linux-template-mono|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520             48.76 MiB   about 6 minutes ago     about 6 minutes ago
24426  linux-editor-double-sanitizers|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089  420.56 MiB  about 23 minutes ago    about 7 minutes ago
24414  linux-editor-mono|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089               93.63 MiB   about 27 minutes ago    about 7 minutes ago
24390  linux-editor-mono|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                             90.61 MiB   about 1 hour ago        about 7 minutes ago
24418  linux-template-mono|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089             48.75 MiB   about 26 minutes ago    about 7 minutes ago
24388  linux-editor-double-sanitizers|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                400.08 MiB  about 1 hour ago        about 7 minutes ago
24392  linux-template-mono|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                           48.75 MiB   about 1 hour ago        about 7 minutes ago
24433  ios-template|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520                    218.70 MiB  about 7 minutes ago     about 7 minutes ago
24432  linux-editor-thread-sanitizer|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520   333.24 MiB  about 7 minutes ago     about 7 minutes ago
24431  android-editor|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520                  313.83 MiB  about 7 minutes ago     about 7 minutes ago
24430  android-template-arm32|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520          273.23 MiB  about 7 minutes ago     about 7 minutes ago
24429  android-template-arm64|ci/cache-persistence|65babb99028518cf92ddb0e404c66f67b5b89520          261.74 MiB  about 7 minutes ago     about 7 minutes ago
24421  linux-editor-llvm-sanitizers|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089    620.74 MiB  about 25 minutes ago    about 8 minutes ago
24425  web-nothreads-template|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089          148.83 MiB  about 24 minutes ago    about 8 minutes ago
24423  web-template|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089                    130.56 MiB  about 24 minutes ago    about 8 minutes ago
24385  web-nothreads-template|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                        148.81 MiB  about 1 hour ago        about 8 minutes ago
24386  web-template|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                                  131.25 MiB  about 1 hour ago        about 8 minutes ago
24419  linux-editor-thread-sanitizer|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089   331.30 MiB  about 26 minutes ago    about 8 minutes ago
24428  windows-editor|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089                  217.08 MiB  about 19 minutes ago    about 8 minutes ago
24387  linux-editor-llvm-sanitizers|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                  615.57 MiB  about 1 hour ago        about 8 minutes ago
24427  windows-template|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089                119.36 MiB  about 20 minutes ago    about 8 minutes ago
24391  linux-editor-thread-sanitizer|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                 327.60 MiB  about 1 hour ago        about 8 minutes ago
24424  windows-editor-clang|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089            101.15 MiB  about 24 minutes ago    about 8 minutes ago
24422  windows-template-gcc|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089            57.81 MiB   about 24 minutes ago    about 8 minutes ago
24382  windows-template|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                              117.73 MiB  about 1 hour ago        about 8 minutes ago
24416  ios-template|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089                    218.08 MiB  about 27 minutes ago    about 8 minutes ago
24383  windows-template-gcc|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                          56.57 MiB   about 1 hour ago        about 8 minutes ago
24381  windows-editor-clang|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                          98.19 MiB   about 1 hour ago        about 8 minutes ago
24420  macos-editor|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089                    219.86 MiB  about 25 minutes ago    about 8 minutes ago
24384  windows-editor|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                                205.93 MiB  about 1 hour ago        about 8 minutes ago
24412  android-template-arm32|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089          273.18 MiB  about 27 minutes ago    about 8 minutes ago
24417  macos-template|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089                  87.41 MiB   about 26 minutes ago    about 8 minutes ago
24415  android-editor|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089                  313.85 MiB  about 27 minutes ago    about 8 minutes ago
24380  ios-template|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                                  216.99 MiB  about 1 hour ago        about 8 minutes ago
24378  macos-editor|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                                  201.12 MiB  about 1 hour ago        about 8 minutes ago
24413  android-template-arm64|ci/cache-persistence|d2767e8fbdf32b5170bfaa8b4fa675b510586089          243.38 MiB  about 27 minutes ago    about 8 minutes ago
24375  macos-template|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                                85.36 MiB   about 1 hour ago        about 8 minutes ago
24377  android-template-arm32|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                        232.45 MiB  about 1 hour ago        about 8 minutes ago
24379  android-editor|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                                310.96 MiB  about 1 hour ago        about 8 minutes ago
24376  android-template-arm64|master|adc54f127d3e66be5f5b07e8c65b7886fb74089b                        206.61 MiB  about 1 hour ago        about 8 minutes ago
24147  pre-commit-3||607cb7f10e088734ecdb7dfc5497153b214291e33cf4f3a1936bb64509aef747                51.87 MiB   about 10 hours ago      about 9 minutes ago
24146  cache-apt-pkgs_90e68416d72c033bca307201aa6958f4                                               43.80 KiB   about 10 hours ago      about 9 minutes ago
24399  linux-template-mono|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9             48.75 MiB   about 1 hour ago        about 26 minutes ago
24407  linux-editor-double-sanitizers|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9  410.31 MiB  about 1 hour ago        about 27 minutes ago
24408  linux-editor-thread-sanitizer|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9   329.51 MiB  about 1 hour ago        about 27 minutes ago
24406  linux-editor-llvm-sanitizers|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9    618.06 MiB  about 1 hour ago        about 27 minutes ago
24404  web-nothreads-template|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9          140.44 MiB  about 1 hour ago        about 28 minutes ago
24402  web-template|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9                    130.52 MiB  about 1 hour ago        about 28 minutes ago
24410  windows-editor|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9                  211.88 MiB  about 1 hour ago        about 28 minutes ago
24395  linux-editor-mono|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9               92.12 MiB   about 1 hour ago        about 28 minutes ago
24405  windows-template-gcc|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9            57.18 MiB   about 1 hour ago        about 28 minutes ago
24409  windows-template|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9                118.59 MiB  about 1 hour ago        about 28 minutes ago
24398  linux-template-minimal|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9          25.51 MiB   about 1 hour ago        about 28 minutes ago
24403  windows-editor-clang|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9            99.66 MiB   about 1 hour ago        about 28 minutes ago
24401  macos-editor|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9                    210.53 MiB  about 1 hour ago        about 28 minutes ago
24397  ios-template|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9                    217.56 MiB  about 1 hour ago        about 28 minutes ago
24393  android-template-arm64|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9          225.03 MiB  about 1 hour ago        about 28 minutes ago
24400  macos-template|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9                  86.37 MiB   about 1 hour ago        about 28 minutes ago
24394  android-editor|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9                  312.41 MiB  about 1 hour ago        about 28 minutes ago
24396  android-template-arm32|ci/cache-persistence|5f8d7e2219a0eadda0223475559a16c4150d3fa9          252.88 MiB  about 1 hour ago        about 28 minutes ago
```