### PR TITLE
[3.x] Revert changes to `Range::set_value` #65101

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -87,7 +87,7 @@ void Range::set_value(double p_val) {
 
 void Range::set_value_no_signal(double p_val) {
 	if (shared->step > 0) {
-		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
+		p_val = Math::round(p_val / shared->step) * shared->step;
 	}
 
 	if (_rounded_values) {


### PR DESCRIPTION
#65101 introduced a breaking changes to calculations of values when changing a `Range`, taking into account the minimum value.

This fixed the "bug" seen by the user, but made the overall behaviour of `Range` more unpredictable and hard to manage.


Originally the step value was always orientated around zero, regardless of the minimum value. i.e. setting a step of 4 would guarantee the result would be a multiple of 4, which is easy to understand and expected.

After the PR, with a minimum other than zero, the value is subject to drift as the value moves further from zero. This is very hard to predict and interpret, and led to non-regular values for grid snapping, particularly when using fractional values for `min`.

Fixes #98466
May fix other regressions

## Notes
* Currently discussing in #99922 , which is an alternative approach attempting to fix regressions individually.
* I'm not super familiar with this area, so it would be good to know if any other PRs were cherry picked that may have depended on the changes here.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
