### PR TITLE
Replace `List` with `LocalVector` in various loader

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -78,8 +78,8 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 }
 
 Vector<String> ResourceLoader::get_recognized_extensions_for_type(const String &p_type) {
-	List<String> exts;
-	::ResourceLoader::get_recognized_extensions_for_type(p_type, &exts);
+	LocalVector<String> exts;
+	::ResourceLoader::get_recognized_extensions_for_type(p_type, exts);
 	Vector<String> ret;
 	for (const String &E : exts) {
 		ret.push_back(E);

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -204,10 +204,10 @@ Ref<Resource> ResourceFormatLoaderCrypto::load(const String &p_path, const Strin
 	return nullptr;
 }
 
-void ResourceFormatLoaderCrypto::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("crt");
-	p_extensions->push_back("key");
-	p_extensions->push_back("pub");
+void ResourceFormatLoaderCrypto::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("crt");
+	p_extensions.push_back("key");
+	p_extensions.push_back("pub");
 }
 
 bool ResourceFormatLoaderCrypto::handles_type(const String &p_type) const {

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -152,7 +152,7 @@ public:
 class ResourceFormatLoaderCrypto : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -831,8 +831,8 @@ Ref<Resource> GDExtensionResourceLoader::load(const String &p_path, const String
 	return lib;
 }
 
-void GDExtensionResourceLoader::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gdextension");
+void GDExtensionResourceLoader::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("gdextension");
 }
 
 bool GDExtensionResourceLoader::handles_type(const String &p_type) const {

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -176,7 +176,7 @@ public:
 	static Error load_gdextension_resource(const String &p_path, Ref<GDExtension> &p_extension);
 
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -37,8 +37,8 @@ void ImageFormatLoader::_bind_methods() {
 }
 
 bool ImageFormatLoader::recognize(const String &p_extension) const {
-	List<String> extensions;
-	get_recognized_extensions(&extensions);
+	LocalVector<String> extensions;
+	get_recognized_extensions(extensions);
 	for (const String &E : extensions) {
 		if (E.nocasecmp_to(p_extension) == 0) {
 			return true;
@@ -54,11 +54,11 @@ Error ImageFormatLoaderExtension::load_image(Ref<Image> p_image, Ref<FileAccess>
 	return err;
 }
 
-void ImageFormatLoaderExtension::get_recognized_extensions(List<String> *p_extension) const {
+void ImageFormatLoaderExtension::get_recognized_extensions(LocalVector<String> &p_extension) const {
 	PackedStringArray ext;
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, ext)) {
 		for (int i = 0; i < ext.size(); i++) {
-			p_extension->push_back(ext[i]);
+			p_extension.push_back(ext[i]);
 		}
 	}
 }
@@ -108,7 +108,7 @@ Error ImageLoader::load_image(const String &p_file, Ref<Image> p_image, Ref<File
 	return ERR_FILE_UNRECOGNIZED;
 }
 
-void ImageLoader::get_recognized_extensions(List<String> *p_extensions) {
+void ImageLoader::get_recognized_extensions(LocalVector<String> &p_extensions) {
 	for (int i = 0; i < loader.size(); i++) {
 		loader[i]->get_recognized_extensions(p_extensions);
 	}
@@ -199,8 +199,8 @@ Ref<Resource> ResourceFormatLoaderImage::load(const String &p_path, const String
 	return image;
 }
 
-void ResourceFormatLoaderImage::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("image");
+void ResourceFormatLoaderImage::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("image");
 }
 
 bool ResourceFormatLoaderImage::handles_type(const String &p_type) const {

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -59,7 +59,7 @@ protected:
 	static void _bind_methods();
 
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) = 0;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const = 0;
 	bool recognize(const String &p_extension) const;
 
 public:
@@ -76,7 +76,7 @@ protected:
 
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags = FLAG_NONE, float p_scale = 1.0) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 
 	void add_format_loader();
 	void remove_format_loader();
@@ -92,7 +92,7 @@ class ImageLoader {
 protected:
 public:
 	static Error load_image(const String &p_file, Ref<Image> p_image, Ref<FileAccess> p_custom = Ref<FileAccess>(), BitField<ImageFormatLoader::LoaderFlags> p_flags = ImageFormatLoader::FLAG_NONE, float p_scale = 1.0);
-	static void get_recognized_extensions(List<String> *p_extensions);
+	static void get_recognized_extensions(LocalVector<String> &p_extensions);
 	static Ref<ImageFormatLoader> recognize(const String &p_extension);
 
 	static void add_image_format_loader(Ref<ImageFormatLoader> p_loader);
@@ -104,7 +104,7 @@ public:
 class ResourceFormatLoaderImage : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1641,8 +1641,8 @@ Ref<Resource> ResourceFormatLoaderJSON::load(const String &p_path, const String 
 	return json;
 }
 
-void ResourceFormatLoaderJSON::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("json");
+void ResourceFormatLoaderJSON::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("json");
 }
 
 bool ResourceFormatLoaderJSON::handles_type(const String &p_type) const {

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -110,7 +110,7 @@ public:
 class ResourceFormatLoaderJSON : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1260,7 +1260,7 @@ Ref<Resource> ResourceFormatLoaderBinary::load(const String &p_path, const Strin
 	return loader.resource;
 }
 
-void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
+void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &p_extensions) const {
 	if (p_type.is_empty()) {
 		get_recognized_extensions(p_extensions);
 		return;
@@ -1278,18 +1278,18 @@ void ResourceFormatLoaderBinary::get_recognized_extensions_for_type(const String
 
 	for (const String &E : extensions) {
 		String ext = E.to_lower();
-		p_extensions->push_back(ext);
+		p_extensions.push_back(ext);
 	}
 }
 
-void ResourceFormatLoaderBinary::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceFormatLoaderBinary::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	List<String> extensions;
 	ClassDB::get_resource_base_extensions(&extensions);
 	extensions.sort();
 
 	for (const String &E : extensions) {
 		String ext = E.to_lower();
-		p_extensions->push_back(ext);
+		p_extensions.push_back(ext);
 	}
 }
 

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -111,8 +111,8 @@ public:
 class ResourceFormatLoaderBinary : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual String get_resource_script_class(const String &p_path) const override;

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/os/os.h"
+#include "core/templates/local_vector.h"
 #include "core/variant/variant_parser.h"
 
 ResourceFormatImporterLoadOnStartup ResourceImporter::load_on_startup = nullptr;
@@ -183,22 +184,22 @@ Ref<Resource> ResourceFormatImporter::load_internal(const String &p_path, Error 
 	return res;
 }
 
-void ResourceFormatImporter::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceFormatImporter::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	HashSet<String> found;
 
 	for (int i = 0; i < importers.size(); i++) {
-		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
+		LocalVector<String> local_exts;
+		importers[i]->get_recognized_extensions(local_exts);
 		for (const String &F : local_exts) {
 			if (!found.has(F)) {
-				p_extensions->push_back(F);
+				p_extensions.push_back(F);
 				found.insert(F);
 			}
 		}
 	}
 }
 
-void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
+void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &p_extensions) const {
 	if (p_type.is_empty()) {
 		get_recognized_extensions(p_extensions);
 		return;
@@ -216,11 +217,11 @@ void ResourceFormatImporter::get_recognized_extensions_for_type(const String &p_
 			continue;
 		}
 
-		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
+		LocalVector<String> local_exts;
+		importers[i]->get_recognized_extensions(local_exts);
 		for (const String &F : local_exts) {
 			if (!found.has(F)) {
-				p_extensions->push_back(F);
+				p_extensions.push_back(F);
 				found.insert(F);
 			}
 		}
@@ -461,8 +462,8 @@ void ResourceFormatImporter::add_importer(const Ref<ResourceImporter> &p_importe
 
 void ResourceFormatImporter::get_importers_for_extension(const String &p_extension, List<Ref<ResourceImporter>> *r_importers) {
 	for (int i = 0; i < importers.size(); i++) {
-		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
+		LocalVector<String> local_exts;
+		importers[i]->get_recognized_extensions(local_exts);
 		for (const String &F : local_exts) {
 			if (p_extension.to_lower() == F) {
 				r_importers->push_back(importers[i]);
@@ -483,8 +484,8 @@ Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_extension(const St
 	float priority = 0;
 
 	for (int i = 0; i < importers.size(); i++) {
-		List<String> local_exts;
-		importers[i]->get_recognized_extensions(&local_exts);
+		LocalVector<String> local_exts;
+		importers[i]->get_recognized_extensions(local_exts);
 		for (const String &F : local_exts) {
 			if (p_extension.to_lower() == F && importers[i]->get_priority() > priority) {
 				importer = importers[i];

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -64,8 +64,8 @@ public:
 	static ResourceFormatImporter *get_singleton() { return singleton; }
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	Ref<Resource> load_internal(const String &p_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode, bool p_silence_errors);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
-	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
+	virtual void get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &p_extensions) const override;
 	virtual bool recognize_path(const String &p_path, const String &p_for_type = String()) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
@@ -114,7 +114,7 @@ public:
 
 	virtual String get_importer_name() const = 0;
 	virtual String get_visible_name() const = 0;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const = 0;
 	virtual String get_save_extension() const = 0;
 	virtual String get_resource_type() const = 0;
 	virtual float get_priority() const { return 1.0; }

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -63,11 +63,11 @@ bool ResourceFormatLoader::recognize_path(const String &p_path, const String &p_
 
 	String extension = p_path.get_extension();
 
-	List<String> extensions;
+	LocalVector<String> extensions;
 	if (p_for_type.is_empty()) {
-		get_recognized_extensions(&extensions);
+		get_recognized_extensions(extensions);
 	} else {
-		get_recognized_extensions_for_type(p_for_type, &extensions);
+		get_recognized_extensions_for_type(p_for_type, extensions);
 	}
 
 	for (const String &E : extensions) {
@@ -129,13 +129,13 @@ bool ResourceFormatLoader::has_custom_uid_support() const {
 	return GDVIRTUAL_IS_OVERRIDDEN(_get_resource_uid);
 }
 
-void ResourceFormatLoader::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
+void ResourceFormatLoader::get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &p_extensions) const {
 	if (p_type.is_empty() || handles_type(p_type)) {
 		get_recognized_extensions(p_extensions);
 	}
 }
 
-void ResourceLoader::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) {
+void ResourceLoader::get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &p_extensions) {
 	for (int i = 0; i < loader_count; i++) {
 		loader[i]->get_recognized_extensions_for_type(p_type, p_extensions);
 	}
@@ -149,12 +149,12 @@ bool ResourceFormatLoader::exists(const String &p_path) const {
 	return FileAccess::exists(p_path); // By default just check file.
 }
 
-void ResourceFormatLoader::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceFormatLoader::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	PackedStringArray exts;
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, exts)) {
 		const String *r = exts.ptr();
 		for (int i = 0; i < exts.size(); ++i) {
-			p_extensions->push_back(r[i]);
+			p_extensions.push_back(r[i]);
 		}
 	}
 }

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -72,8 +72,8 @@ protected:
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual bool exists(const String &p_path) const;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
-	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const;
+	virtual void get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &p_extensions) const;
 	virtual bool recognize_path(const String &p_path, const String &p_for_type = String()) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);
@@ -231,7 +231,7 @@ public:
 	static Ref<Resource> load(const String &p_path, const String &p_type_hint = "", ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE, Error *r_error = nullptr);
 	static bool exists(const String &p_path, const String &p_type_hint = "");
 
-	static void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions);
+	static void get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &p_extensions);
 	static void add_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader, bool p_at_front = false);
 	static void remove_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader);
 	static void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -354,9 +354,9 @@ Ref<Resource> TranslationLoaderPO::load(const String &p_path, const String &p_or
 	return load_translation(f, r_error);
 }
 
-void TranslationLoaderPO::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("po");
-	p_extensions->push_back("mo");
+void TranslationLoaderPO::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("po");
+	p_extensions.push_back("mo");
 }
 
 bool TranslationLoaderPO::handles_type(const String &p_type) const {

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -39,7 +39,7 @@ class TranslationLoaderPO : public ResourceFormatLoader {
 public:
 	static Ref<Resource> load_translation(Ref<FileAccess> f, Error *r_error = nullptr);
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -420,7 +420,7 @@ public:
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) = 0;
 	/* LOADER FUNCTIONS */
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const = 0;
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const = 0;
 	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const = 0;
 	virtual void get_public_annotations(List<MethodInfo> *p_annotations) const = 0;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -608,11 +608,11 @@ public:
 
 	GDVIRTUAL0RC_REQUIRED(PackedStringArray, _get_recognized_extensions)
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override {
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override {
 		PackedStringArray ret;
 		GDVIRTUAL_CALL(_get_recognized_extensions, ret);
 		for (int i = 0; i < ret.size(); i++) {
-			p_extensions->push_back(ret[i]);
+			p_extensions.push_back(ret[i]);
 		}
 	}
 

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -49,8 +49,8 @@ Error ImageLoaderPNG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return PNGDriverCommon::png_to_image(reader, buffer_size, p_flags & FLAG_FORCE_LINEAR, p_image);
 }
 
-void ImageLoaderPNG::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("png");
+void ImageLoaderPNG::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("png");
 }
 
 Ref<Image> ImageLoaderPNG::load_mem_png(const uint8_t *p_png, int p_size) {

--- a/drivers/png/image_loader_png.h
+++ b/drivers/png/image_loader_png.h
@@ -42,7 +42,7 @@ private:
 
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const;
 	ImageLoaderPNG();
 };
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -63,8 +63,8 @@ void DependencyEditor::_load_pressed(Object *p_item, int p_cell, int p_button, M
 	search->set_current_dir(replacing.get_base_dir());
 
 	search->clear_filters();
-	List<String> ext;
-	ResourceLoader::get_recognized_extensions_for_type(ti->get_metadata(0), &ext);
+	LocalVector<String> ext;
+	ResourceLoader::get_recognized_extensions_for_type(ti->get_metadata(0), ext);
 	for (const String &E : ext) {
 		search->add_filter("*." + E);
 	}

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1389,8 +1389,8 @@ EditorAudioBuses::EditorAudioBuses() {
 	edited_path = GLOBAL_GET("audio/buses/default_bus_layout");
 
 	file_dialog = memnew(EditorFileDialog);
-	List<String> ext;
-	ResourceLoader::get_recognized_extensions_for_type("AudioBusLayout", &ext);
+	LocalVector<String> ext;
+	ResourceLoader::get_recognized_extensions_for_type("AudioBusLayout", ext);
 	for (const String &E : ext) {
 		file_dialog->add_filter("*." + E, TTR("Audio Bus Layout"));
 	}

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -46,9 +46,9 @@
 void EditorAutoloadSettings::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			List<String> afn;
-			ResourceLoader::get_recognized_extensions_for_type("Script", &afn);
-			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &afn);
+			LocalVector<String> afn;
+			ResourceLoader::get_recognized_extensions_for_type("Script", afn);
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", afn);
 
 			for (const String &E : afn) {
 				file_dialog->add_filter("*." + E);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -250,8 +250,8 @@ void EditorFileSystem::_first_scan_filesystem() {
 
 	// Preloading GDExtensions file extensions to prevent looping on all the resource loaders
 	// for each files in _first_scan_process_scripts.
-	List<String> gdextension_extensions;
-	ResourceLoader::get_recognized_extensions_for_type("GDExtension", &gdextension_extensions);
+	LocalVector<String> gdextension_extensions;
+	ResourceLoader::get_recognized_extensions_for_type("GDExtension", gdextension_extensions);
 
 	// This loads the global class names from the scripts and ensures that even if the
 	// global_script_class_cache.cfg was missing or invalid, the global class names are valid in ScriptServer.
@@ -281,7 +281,7 @@ void EditorFileSystem::_first_scan_filesystem() {
 	ep.step(TTR("Starting file scan..."), 5, true);
 }
 
-void EditorFileSystem::_first_scan_process_scripts(const ScannedDirectory *p_scan_dir, List<String> &p_gdextension_extensions, HashSet<String> &p_existing_class_names, HashSet<String> &p_extensions) {
+void EditorFileSystem::_first_scan_process_scripts(const ScannedDirectory *p_scan_dir, LocalVector<String> &p_gdextension_extensions, HashSet<String> &p_existing_class_names, HashSet<String> &p_extensions) {
 	for (ScannedDirectory *scan_sub_dir : p_scan_dir->subdirs) {
 		_first_scan_process_scripts(scan_sub_dir, p_gdextension_extensions, p_existing_class_names, p_extensions);
 	}
@@ -315,7 +315,7 @@ void EditorFileSystem::_first_scan_process_scripts(const ScannedDirectory *p_sca
 		}
 
 		// Check for GDExtensions.
-		if (p_gdextension_extensions.find(ext)) {
+		if (p_gdextension_extensions.has(ext)) {
 			const String path = p_scan_dir->full_path.path_join(scan_file);
 			const String type = ResourceLoader::get_resource_type(path);
 			if (type == SNAME("GDExtension")) {
@@ -3503,8 +3503,8 @@ void EditorFileSystem::_update_extensions() {
 	textfile_extensions.clear();
 	other_file_extensions.clear();
 
-	List<String> extensionsl;
-	ResourceLoader::get_recognized_extensions_for_type("", &extensionsl);
+	LocalVector<String> extensionsl;
+	ResourceLoader::get_recognized_extensions_for_type("", extensionsl);
 	for (const String &E : extensionsl) {
 		valid_extensions.insert(E);
 	}
@@ -3527,7 +3527,7 @@ void EditorFileSystem::_update_extensions() {
 	}
 
 	extensionsl.clear();
-	ResourceFormatImporter::get_singleton()->get_recognized_extensions(&extensionsl);
+	ResourceFormatImporter::get_singleton()->get_recognized_extensions(extensionsl);
 	for (const String &E : extensionsl) {
 		import_extensions.insert(E);
 	}

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -193,7 +193,7 @@ class EditorFileSystem : public Node {
 	void _notify_filesystem_changed();
 	void _scan_filesystem();
 	void _first_scan_filesystem();
-	void _first_scan_process_scripts(const ScannedDirectory *p_scan_dir, List<String> &p_gdextension_extensions, HashSet<String> &p_existing_class_names, HashSet<String> &p_extensions);
+	void _first_scan_process_scripts(const ScannedDirectory *p_scan_dir, LocalVector<String> &p_gdextension_extensions, HashSet<String> &p_existing_class_names, HashSet<String> &p_extensions);
 
 	HashSet<String> late_update_files;
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2681,8 +2681,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_NEW_INHERITED_SCENE:
 		case FILE_OPEN_SCENE: {
 			file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-			List<String> extensions;
-			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
+			LocalVector<String> extensions;
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", extensions);
 			file->clear_filters();
 			for (const String &extension : extensions) {
 				file->add_filter("*." + extension, extension.to_upper());
@@ -3134,8 +3134,8 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		} break;
 		case SETTINGS_PICK_MAIN_SCENE: {
 			file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-			List<String> extensions;
-			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
+			LocalVector<String> extensions;
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", extensions);
 			file->clear_filters();
 			for (const String &extension : extensions) {
 				file->add_filter("*." + extension, extension.to_upper());
@@ -7704,8 +7704,8 @@ EditorNode::EditorNode() {
 	file_script->set_title(TTR("Open & Run a Script"));
 	file_script->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	file_script->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-	List<String> sexts;
-	ResourceLoader::get_recognized_extensions_for_type("Script", &sexts);
+	LocalVector<String> sexts;
+	ResourceLoader::get_recognized_extensions_for_type("Script", sexts);
 	for (const String &E : sexts) {
 		file_script->add_filter("*." + E);
 	}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2985,8 +2985,8 @@ void EditorPropertyResource::_set_read_only(bool p_read_only) {
 void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource, bool p_inspect) {
 	if (p_resource->is_built_in() && !p_resource->get_path().is_empty()) {
 		String parent = p_resource->get_path().get_slice("::", 0);
-		List<String> extensions;
-		ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
+		LocalVector<String> extensions;
+		ResourceLoader::get_recognized_extensions_for_type("PackedScene", extensions);
 
 		if (p_inspect) {
 			if (extensions.find(parent.get_extension()) && (!EditorNode::get_singleton()->get_edited_scene() || EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path() != parent)) {

--- a/editor/editor_translation_parser.h
+++ b/editor/editor_translation_parser.h
@@ -49,7 +49,7 @@ protected:
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural);
 	virtual void get_comments(Vector<String> *r_ids_comment, Vector<String> *r_ids_ctx_plural_comment);
-	virtual void get_recognized_extensions(List<String> *r_extensions) const;
+	virtual void get_recognized_extensions(LocalVector<String> &r_extensions) const;
 };
 
 class EditorTranslationParser {
@@ -66,7 +66,7 @@ public:
 	Vector<Ref<EditorTranslationParserPlugin>> standard_parsers;
 	Vector<Ref<EditorTranslationParserPlugin>> custom_parsers;
 
-	void get_recognized_extensions(List<String> *r_extensions) const;
+	void get_recognized_extensions(LocalVector<String> &r_extensions) const;
 	bool can_parse(const String &p_extension) const;
 	Ref<EditorTranslationParserPlugin> get_parser(const String &p_extension) const;
 	void add_parser(const Ref<EditorTranslationParserPlugin> &p_parser, ParserType p_type);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1239,8 +1239,8 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 			bool is_imported = false;
 
 			{
-				List<String> importer_exts;
-				ResourceImporterScene::get_scene_importer_extensions(&importer_exts);
+				LocalVector<String> importer_exts;
+				ResourceImporterScene::get_scene_importer_extensions(importer_exts);
 				String extension = fpath.get_extension();
 				for (const String &E : importer_exts) {
 					if (extension.nocasecmp_to(E) == 0) {
@@ -3346,8 +3346,8 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 		}
 
 		{
-			List<String> resource_extensions;
-			ResourceFormatImporter::get_singleton()->get_recognized_extensions_for_type("Resource", &resource_extensions);
+			LocalVector<String> resource_extensions;
+			ResourceFormatImporter::get_singleton()->get_recognized_extensions_for_type("Resource", resource_extensions);
 			HashSet<String> extension_list;
 			for (const String &extension : resource_extensions) {
 				extension_list.insert(extension);

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1800,8 +1800,8 @@ uint32_t EditorSceneFormatImporterCollada::get_import_flags() const {
 	return IMPORT_SCENE | IMPORT_ANIMATION;
 }
 
-void EditorSceneFormatImporterCollada::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("dae");
+void EditorSceneFormatImporterCollada::get_extensions(LocalVector<String> &r_extensions) const {
+	r_extensions.push_back("dae");
 }
 
 Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {

--- a/editor/import/3d/editor_import_collada.h
+++ b/editor/import/3d/editor_import_collada.h
@@ -38,7 +38,7 @@ class EditorSceneFormatImporterCollada : public EditorSceneFormatImporter {
 
 public:
 	virtual uint32_t get_import_flags() const override;
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(LocalVector<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps = nullptr, Error *r_err = nullptr) override;
 
 	EditorSceneFormatImporterCollada();

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -584,8 +584,8 @@ Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, co
 	return scene;
 }
 
-void EditorOBJImporter::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("obj");
+void EditorOBJImporter::get_extensions(LocalVector<String> &r_extensions) const {
+	r_extensions.push_back("obj");
 }
 
 EditorOBJImporter::EditorOBJImporter() {
@@ -601,8 +601,8 @@ String ResourceImporterOBJ::get_visible_name() const {
 	return "OBJ as Mesh";
 }
 
-void ResourceImporterOBJ::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("obj");
+void ResourceImporterOBJ::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("obj");
 }
 
 String ResourceImporterOBJ::get_save_extension() const {

--- a/editor/import/3d/resource_importer_obj.h
+++ b/editor/import/3d/resource_importer_obj.h
@@ -38,7 +38,7 @@ class EditorOBJImporter : public EditorSceneFormatImporter {
 
 public:
 	virtual uint32_t get_import_flags() const override;
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(LocalVector<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 
 	EditorOBJImporter();
@@ -50,7 +50,7 @@ class ResourceImporterOBJ : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 	virtual int get_format_version() const override;

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -66,11 +66,11 @@ uint32_t EditorSceneFormatImporter::get_import_flags() const {
 	ERR_FAIL_V(0);
 }
 
-void EditorSceneFormatImporter::get_extensions(List<String> *r_extensions) const {
+void EditorSceneFormatImporter::get_extensions(LocalVector<String> &r_extensions) const {
 	Vector<String> arr;
 	if (GDVIRTUAL_CALL(_get_extensions, arr)) {
 		for (int i = 0; i < arr.size(); i++) {
-			r_extensions->push_back(arr[i]);
+			r_extensions.push_back(arr[i]);
 		}
 		return;
 	}
@@ -266,7 +266,7 @@ String ResourceImporterScene::get_visible_name() const {
 	return _scene_import_type.capitalize();
 }
 
-void ResourceImporterScene::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterScene::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	get_scene_importer_extensions(p_extensions);
 }
 
@@ -2363,8 +2363,8 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "nodes/root_type", PROPERTY_HINT_TYPE_STRING, "Node"), ""));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "nodes/root_name"), ""));
 
-	List<String> script_extentions;
-	ResourceLoader::get_recognized_extensions_for_type("Script", &script_extentions);
+	LocalVector<String> script_extentions;
+	ResourceLoader::get_recognized_extensions_for_type("Script", script_extentions);
 
 	String script_ext_hint;
 
@@ -2832,8 +2832,8 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 	progress.step(TTR("Importing Scene..."), 0);
 
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
-		List<String> extensions;
-		importer_elem->get_extensions(&extensions);
+		LocalVector<String> extensions;
+		importer_elem->get_extensions(extensions);
 
 		for (const String &F : extensions) {
 			if (F.to_lower() == ext) {
@@ -2891,8 +2891,8 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	progress.step(TTR("Importing Scene..."), 0);
 
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
-		List<String> extensions;
-		importer_elem->get_extensions(&extensions);
+		LocalVector<String> extensions;
+		importer_elem->get_extensions(extensions);
 
 		for (const String &F : extensions) {
 			if (F.to_lower() == ext) {
@@ -3253,7 +3253,7 @@ void ResourceImporterScene::clean_up_importer_plugins() {
 	post_importer_plugins.clear();
 }
 
-void ResourceImporterScene::get_scene_importer_extensions(List<String> *p_extensions) {
+void ResourceImporterScene::get_scene_importer_extensions(LocalVector<String> &p_extensions) {
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		importer_elem->get_extensions(p_extensions);
 	}
@@ -3265,8 +3265,8 @@ uint32_t EditorSceneFormatImporterESCN::get_import_flags() const {
 	return IMPORT_SCENE;
 }
 
-void EditorSceneFormatImporterESCN::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("escn");
+void EditorSceneFormatImporterESCN::get_extensions(LocalVector<String> &r_extensions) const {
+	r_extensions.push_back("escn");
 }
 
 Node *EditorSceneFormatImporterESCN::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -74,7 +74,7 @@ public:
 	};
 
 	virtual uint32_t get_import_flags() const;
-	virtual void get_extensions(List<String> *r_extensions) const;
+	virtual void get_extensions(LocalVector<String> &r_extensions) const;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr);
 	virtual void get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options);
 	virtual Variant get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option, const HashMap<StringName, Variant> &p_options);
@@ -249,7 +249,7 @@ public:
 	const Vector<Ref<EditorSceneFormatImporter>> &get_scene_importers() const { return scene_importers; }
 	static void add_scene_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority = false);
 	static void remove_scene_importer(Ref<EditorSceneFormatImporter> p_importer);
-	static void get_scene_importer_extensions(List<String> *p_extensions);
+	static void get_scene_importer_extensions(LocalVector<String> &p_extensions);
 
 	static void clean_up_importer_plugins();
 
@@ -258,7 +258,7 @@ public:
 
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 	virtual int get_format_version() const override;
@@ -319,7 +319,7 @@ class EditorSceneFormatImporterESCN : public EditorSceneFormatImporter {
 
 public:
 	virtual uint32_t get_import_flags() const override;
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(LocalVector<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 };
 

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -52,12 +52,12 @@ String EditorImportPlugin::get_visible_name() const {
 	ERR_FAIL_V_MSG(String(), "Unimplemented _get_visible_name in add-on.");
 }
 
-void EditorImportPlugin::get_recognized_extensions(List<String> *p_extensions) const {
+void EditorImportPlugin::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	Vector<String> extensions;
 
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, extensions)) {
 		for (int i = 0; i < extensions.size(); i++) {
-			p_extensions->push_back(extensions[i]);
+			p_extensions.push_back(extensions[i]);
 		}
 		return;
 	}

--- a/editor/import/editor_import_plugin.h
+++ b/editor/import/editor_import_plugin.h
@@ -61,7 +61,7 @@ public:
 	EditorImportPlugin();
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_preset_name(int p_idx) const override;
 	virtual int get_preset_count() const override;
 	virtual String get_save_extension() const override;

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -43,7 +43,7 @@ String ResourceImporterBitMap::get_visible_name() const {
 	return "BitMap";
 }
 
-void ResourceImporterBitMap::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterBitMap::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_bitmask.h
+++ b/editor/import/resource_importer_bitmask.h
@@ -39,7 +39,7 @@ class ResourceImporterBitMap : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_bmfont.cpp
+++ b/editor/import/resource_importer_bmfont.cpp
@@ -41,11 +41,9 @@ String ResourceImporterBMFont::get_visible_name() const {
 	return "Font Data (AngelCode BMFont)";
 }
 
-void ResourceImporterBMFont::get_recognized_extensions(List<String> *p_extensions) const {
-	if (p_extensions) {
-		p_extensions->push_back("font");
-		p_extensions->push_back("fnt");
-	}
+void ResourceImporterBMFont::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("font");
+	p_extensions.push_back("fnt");
 }
 
 String ResourceImporterBMFont::get_save_extension() const {

--- a/editor/import/resource_importer_bmfont.h
+++ b/editor/import/resource_importer_bmfont.h
@@ -41,7 +41,7 @@ class ResourceImporterBMFont : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -43,8 +43,8 @@ String ResourceImporterCSVTranslation::get_visible_name() const {
 	return "CSV Translation";
 }
 
-void ResourceImporterCSVTranslation::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("csv");
+void ResourceImporterCSVTranslation::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("csv");
 }
 
 String ResourceImporterCSVTranslation::get_save_extension() const {

--- a/editor/import/resource_importer_csv_translation.h
+++ b/editor/import/resource_importer_csv_translation.h
@@ -39,7 +39,7 @@ class ResourceImporterCSVTranslation : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -46,19 +46,17 @@ String ResourceImporterDynamicFont::get_visible_name() const {
 	return "Font Data (Dynamic Font)";
 }
 
-void ResourceImporterDynamicFont::get_recognized_extensions(List<String> *p_extensions) const {
-	if (p_extensions) {
+void ResourceImporterDynamicFont::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 #ifdef MODULE_FREETYPE_ENABLED
-		p_extensions->push_back("ttf");
-		p_extensions->push_back("ttc");
-		p_extensions->push_back("otf");
-		p_extensions->push_back("otc");
-		p_extensions->push_back("woff");
-		p_extensions->push_back("woff2");
-		p_extensions->push_back("pfb");
-		p_extensions->push_back("pfm");
+	p_extensions.push_back("ttf");
+	p_extensions.push_back("ttc");
+	p_extensions.push_back("otf");
+	p_extensions.push_back("otc");
+	p_extensions.push_back("woff");
+	p_extensions.push_back("woff2");
+	p_extensions.push_back("pfb");
+	p_extensions.push_back("pfm");
 #endif
-	}
 }
 
 String ResourceImporterDynamicFont::get_save_extension() const {

--- a/editor/import/resource_importer_dynamic_font.h
+++ b/editor/import/resource_importer_dynamic_font.h
@@ -45,7 +45,7 @@ class ResourceImporterDynamicFont : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -41,7 +41,7 @@ String ResourceImporterImage::get_visible_name() const {
 	return "Image";
 }
 
-void ResourceImporterImage::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterImage::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_image.h
+++ b/editor/import/resource_importer_image.h
@@ -40,7 +40,7 @@ class ResourceImporterImage : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -41,10 +41,8 @@ String ResourceImporterImageFont::get_visible_name() const {
 	return "Font Data (Image Font)";
 }
 
-void ResourceImporterImageFont::get_recognized_extensions(List<String> *p_extensions) const {
-	if (p_extensions) {
-		ImageLoader::get_recognized_extensions(p_extensions);
-	}
+void ResourceImporterImageFont::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	ImageLoader::get_recognized_extensions(p_extensions);
 }
 
 String ResourceImporterImageFont::get_save_extension() const {

--- a/editor/import/resource_importer_imagefont.h
+++ b/editor/import/resource_importer_imagefont.h
@@ -41,7 +41,7 @@ class ResourceImporterImageFont : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -77,7 +77,7 @@ String ResourceImporterLayeredTexture::get_visible_name() const {
 	ERR_FAIL_V("");
 }
 
-void ResourceImporterLayeredTexture::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterLayeredTexture::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -92,7 +92,7 @@ public:
 	static ResourceImporterLayeredTexture *get_singleton() { return singleton; }
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -44,8 +44,8 @@ String ResourceImporterShaderFile::get_visible_name() const {
 	return "GLSL Shader File";
 }
 
-void ResourceImporterShaderFile::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("glsl");
+void ResourceImporterShaderFile::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("glsl");
 }
 
 String ResourceImporterShaderFile::get_save_extension() const {

--- a/editor/import/resource_importer_shader_file.h
+++ b/editor/import/resource_importer_shader_file.h
@@ -39,7 +39,7 @@ class ResourceImporterShaderFile : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -175,7 +175,7 @@ String ResourceImporterTexture::get_visible_name() const {
 	return "Texture2D";
 }
 
-void ResourceImporterTexture::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterTexture::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -87,7 +87,7 @@ public:
 	static ResourceImporterTexture *get_singleton() { return singleton; }
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -50,7 +50,7 @@ String ResourceImporterTextureAtlas::get_visible_name() const {
 	return "TextureAtlas";
 }
 
-void ResourceImporterTextureAtlas::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterTextureAtlas::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 	ImageLoader::get_recognized_extensions(p_extensions);
 }
 

--- a/editor/import/resource_importer_texture_atlas.h
+++ b/editor/import/resource_importer_texture_atlas.h
@@ -53,7 +53,7 @@ public:
 
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -40,8 +40,8 @@ String ResourceImporterWAV::get_visible_name() const {
 	return "Microsoft WAV";
 }
 
-void ResourceImporterWAV::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("wav");
+void ResourceImporterWAV::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("wav");
 }
 
 String ResourceImporterWAV::get_save_extension() const {

--- a/editor/import/resource_importer_wav.h
+++ b/editor/import/resource_importer_wav.h
@@ -40,7 +40,7 @@ class ResourceImporterWAV : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -233,8 +233,8 @@ void InspectorDock::_new_resource() {
 void InspectorDock::_load_resource(const String &p_type) {
 	load_resource_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 
-	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type(p_type, &extensions);
+	LocalVector<String> extensions;
+	ResourceLoader::get_recognized_extensions_for_type(p_type, extensions);
 
 	load_resource_dialog->clear_filters();
 	for (const String &extension : extensions) {

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -47,15 +47,15 @@ void LocalizationEditor::_notification(int p_what) {
 			translation_pot_list->connect("button_clicked", callable_mp(this, &LocalizationEditor::_pot_delete));
 			translation_pot_add_builtin->set_pressed(GLOBAL_GET("internationalization/locale/translation_add_builtin_strings_to_pot"));
 
-			List<String> tfn;
-			ResourceLoader::get_recognized_extensions_for_type("Translation", &tfn);
+			LocalVector<String> tfn;
+			ResourceLoader::get_recognized_extensions_for_type("Translation", tfn);
 			tfn.erase("csv"); // CSV is recognized by the resource importer to generate translation files, but it's not a translation file itself.
 			for (const String &E : tfn) {
 				translation_file_open->add_filter("*." + E);
 			}
 
-			List<String> rfn;
-			ResourceLoader::get_recognized_extensions_for_type("Resource", &rfn);
+			LocalVector<String> rfn;
+			ResourceLoader::get_recognized_extensions_for_type("Resource", rfn);
 			for (const String &E : rfn) {
 				translation_res_file_open_dialog->add_filter("*." + E);
 				translation_res_option_file_open_dialog->add_filter("*." + E);
@@ -405,8 +405,8 @@ void LocalizationEditor::_pot_generate(const String &p_file) {
 
 void LocalizationEditor::_update_pot_file_extensions() {
 	pot_file_open_dialog->clear_filters();
-	List<String> translation_parse_file_extensions;
-	EditorTranslationParser::get_singleton()->get_recognized_extensions(&translation_parse_file_extensions);
+	LocalVector<String> translation_parse_file_extensions;
+	EditorTranslationParser::get_singleton()->get_recognized_extensions(translation_parse_file_extensions);
 	for (const String &E : translation_parse_file_extensions) {
 		pot_file_open_dialog->add_filter("*." + E);
 	}

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -405,8 +405,8 @@ void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 	Ref<AnimationRootNode> node;
 	if (p_index == MENU_LOAD_FILE) {
 		open_file->clear_filters();
-		List<String> filters;
-		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", &filters);
+		LocalVector<String> filters;
+		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", filters);
 		for (const String &E : filters) {
 			open_file->add_filter("*." + E);
 		}

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -330,8 +330,8 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 	Ref<AnimationRootNode> node;
 	if (p_index == MENU_LOAD_FILE) {
 		open_file->clear_filters();
-		List<String> filters;
-		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", &filters);
+		LocalVector<String> filters;
+		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", filters);
 		for (const String &E : filters) {
 			open_file->add_filter("*." + E);
 		}

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -314,8 +314,8 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 
 	if (p_idx == MENU_LOAD_FILE) {
 		open_file->clear_filters();
-		List<String> ext_filters;
-		ResourceLoader::get_recognized_extensions_for_type("AnimationNode", &ext_filters);
+		LocalVector<String> ext_filters;
+		ResourceLoader::get_recognized_extensions_for_type("AnimationNode", ext_filters);
 		for (const String &E : ext_filters) {
 			open_file->add_filter("*." + E);
 		}

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -134,8 +134,8 @@ void AnimationLibraryEditor::_add_library_confirm() {
 }
 
 void AnimationLibraryEditor::_load_library() {
-	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("AnimationLibrary", &extensions);
+	LocalVector<String> extensions;
+	ResourceLoader::get_recognized_extensions_for_type("AnimationLibrary", extensions);
 
 	file_dialog->set_title(TTR("Load Animation"));
 	file_dialog->clear_filters();
@@ -196,8 +196,8 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 				file_dialog->set_current_file(String(file_dialog_library) + ".res");
 			}
 			file_dialog->clear_filters();
-			List<String> exts;
-			ResourceLoader::get_recognized_extensions_for_type("AnimationLibrary", &exts);
+			LocalVector<String> exts;
+			ResourceLoader::get_recognized_extensions_for_type("AnimationLibrary", exts);
 			for (const String &K : exts) {
 				file_dialog->add_filter("*." + K);
 			}
@@ -274,8 +274,8 @@ void AnimationLibraryEditor::_file_popup_selected(int p_id) {
 				file_dialog->set_current_file(String(file_dialog_animation) + ".res");
 			}
 			file_dialog->clear_filters();
-			List<String> exts;
-			ResourceLoader::get_recognized_extensions_for_type("Animation", &exts);
+			LocalVector<String> exts;
+			ResourceLoader::get_recognized_extensions_for_type("Animation", exts);
 			for (const String &K : exts) {
 				file_dialog->add_filter("*." + K);
 			}
@@ -544,8 +544,8 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 			} break;
 			case LIB_BUTTON_LOAD: {
 				adding_animation_to_library = p_item->get_metadata(0);
-				List<String> extensions;
-				ResourceLoader::get_recognized_extensions_for_type("Animation", &extensions);
+				LocalVector<String> extensions;
+				ResourceLoader::get_recognized_extensions_for_type("Animation", extensions);
 
 				file_dialog->clear_filters();
 				for (const String &K : extensions) {

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -773,8 +773,8 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 
 	if (p_index == MENU_LOAD_FILE) {
 		open_file->clear_filters();
-		List<String> filters;
-		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", &filters);
+		LocalVector<String> filters;
+		ResourceLoader::get_recognized_extensions_for_type("AnimationRootNode", filters);
 		for (const String &E : filters) {
 			open_file->add_filter("*." + E);
 		}

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -263,8 +263,8 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	file = memnew(EditorFileDialog);
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	//not for now?
-	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &extensions);
+	LocalVector<String> extensions;
+	ResourceLoader::get_recognized_extensions_for_type("PackedScene", extensions);
 	file->clear_filters();
 	file->set_title(TTR("Import Scene"));
 	for (const String &extension : extensions) {

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -34,7 +34,7 @@
 #include "core/object/script_language.h"
 #include "scene/resources/packed_scene.h"
 
-void PackedSceneEditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
+void PackedSceneEditorTranslationParserPlugin::get_recognized_extensions(LocalVector<String> &r_extensions) const {
 	ResourceLoader::get_recognized_extensions_for_type("PackedScene", r_extensions);
 }
 

--- a/editor/plugins/packed_scene_translation_parser_plugin.h
+++ b/editor/plugins/packed_scene_translation_parser_plugin.h
@@ -44,7 +44,7 @@ class PackedSceneEditorTranslationParserPlugin : public EditorTranslationParserP
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) override;
 	bool match_property(const String &p_property_name, const String &p_node_type);
-	virtual void get_recognized_extensions(List<String> *r_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 
 	PackedSceneEditorTranslationParserPlugin();
 };

--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -256,8 +256,8 @@ void Particles2DEditorPlugin::_get_base_emission_mask(PackedVector2Array &r_vali
 Particles2DEditorPlugin::Particles2DEditorPlugin() {
 	file = memnew(EditorFileDialog);
 
-	List<String> ext;
-	ImageLoader::get_recognized_extensions(&ext);
+	LocalVector<String> ext;
+	ImageLoader::get_recognized_extensions(ext);
 	for (const String &E : ext) {
 		file->add_filter("*." + E, E.to_upper());
 	}

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -87,8 +87,8 @@ void ResourcePreloaderEditor::_load_pressed() {
 	loading_scene = false;
 
 	file->clear_filters();
-	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("", &extensions);
+	LocalVector<String> extensions;
+	ResourceLoader::get_recognized_extensions_for_type("", extensions);
 	for (const String &extension : extensions) {
 		file->add_filter("*." + extension);
 	}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -838,9 +838,9 @@ void ScriptEditor::_open_recent_script(int p_idx) {
 	String path = rc[p_idx];
 	// if its not on disk its a help file or deleted
 	if (FileAccess::exists(path)) {
-		List<String> extensions;
-		ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
-		ResourceLoader::get_recognized_extensions_for_type("JSON", &extensions);
+		LocalVector<String> extensions;
+		ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
+		ResourceLoader::get_recognized_extensions_for_type("JSON", extensions);
 
 		if (extensions.find(path.get_extension())) {
 			Ref<Resource> scr = ResourceLoader::load(path);
@@ -1332,8 +1332,8 @@ void ScriptEditor::_menu_option(int p_option) {
 			file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 			file_dialog_option = FILE_OPEN;
 
-			List<String> extensions;
-			ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
+			LocalVector<String> extensions;
+			ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
 			file_dialog->clear_filters();
 			for (const String &extension : extensions) {
 				file_dialog->add_filter("*." + extension, extension.to_upper());
@@ -1355,9 +1355,9 @@ void ScriptEditor::_menu_option(int p_option) {
 			String path = previous_scripts.back()->get();
 			previous_scripts.pop_back();
 
-			List<String> extensions;
-			ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
-			ResourceLoader::get_recognized_extensions_for_type("JSON", &extensions);
+			LocalVector<String> extensions;
+			ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
+			ResourceLoader::get_recognized_extensions_for_type("JSON", extensions);
 			bool built_in = !path.is_resource_file();
 
 			if (extensions.find(path.get_extension()) || built_in) {
@@ -1487,8 +1487,8 @@ void ScriptEditor::_menu_option(int p_option) {
 					file_dialog->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 					file_dialog_option = FILE_SAVE_AS;
 
-					List<String> extensions;
-					ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
+					LocalVector<String> extensions;
+					ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
 					file_dialog->clear_filters();
 					file_dialog->set_current_dir(text_file->get_path().get_base_dir());
 					file_dialog->set_current_file(text_file->get_path().get_file());
@@ -2883,9 +2883,9 @@ void ScriptEditor::open_text_file_create_dialog(const String &p_base_path, const
 }
 
 Ref<Resource> ScriptEditor::open_file(const String &p_file) {
-	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
-	ResourceLoader::get_recognized_extensions_for_type("JSON", &extensions);
+	LocalVector<String> extensions;
+	ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
+	ResourceLoader::get_recognized_extensions_for_type("JSON", extensions);
 	if (extensions.find(p_file.get_extension())) {
 		Ref<Resource> scr = ResourceLoader::load(p_file);
 		if (scr.is_null()) {
@@ -3468,9 +3468,9 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 	restoring_layout = true;
 
 	HashSet<String> loaded_scripts;
-	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
-	ResourceLoader::get_recognized_extensions_for_type("JSON", &extensions);
+	LocalVector<String> extensions;
+	ResourceLoader::get_recognized_extensions_for_type("Script", extensions);
+	ResourceLoader::get_recognized_extensions_for_type("JSON", extensions);
 
 	for (int i = 0; i < scripts.size(); i++) {
 		String path = scripts[i];

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -960,8 +960,8 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 			symbol = ResourceUID::uid_to_path(symbol);
 		}
 
-		List<String> scene_extensions;
-		ResourceLoader::get_recognized_extensions_for_type("PackedScene", &scene_extensions);
+		LocalVector<String> scene_extensions;
+		ResourceLoader::get_recognized_extensions_for_type("PackedScene", scene_extensions);
 
 		if (scene_extensions.find(symbol.get_extension())) {
 			EditorNode::get_singleton()->load_scene(symbol);
@@ -1062,8 +1062,8 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 		// Every symbol other than absolute path is relative path so keep this condition at last.
 		String path = _get_absolute_path(p_symbol);
 		if (FileAccess::exists(path)) {
-			List<String> scene_extensions;
-			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &scene_extensions);
+			LocalVector<String> scene_extensions;
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", scene_extensions);
 
 			if (scene_extensions.find(path.get_extension())) {
 				EditorNode::get_singleton()->load_scene(path);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -610,8 +610,8 @@ void Skeleton3DEditor::export_skeleton_profile() {
 	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	file_dialog->set_title(TTR("Export Skeleton Profile As..."));
 
-	List<String> exts;
-	ResourceLoader::get_recognized_extensions_for_type("SkeletonProfile", &exts);
+	LocalVector<String> exts;
+	ResourceLoader::get_recognized_extensions_for_type("SkeletonProfile", exts);
 	file_dialog->clear_filters();
 	for (const String &K : exts) {
 		file_dialog->add_filter("*." + K);

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -59,8 +59,8 @@ static void _draw_shadowed_line(Control *p_control, const Point2 &p_from, const 
 
 void SpriteFramesEditor::_open_sprite_sheet() {
 	file_split_sheet->clear_filters();
-	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("Texture2D", &extensions);
+	LocalVector<String> extensions;
+	ResourceLoader::get_recognized_extensions_for_type("Texture2D", extensions);
 	for (const String &extension : extensions) {
 		file_split_sheet->add_filter("*." + extension);
 	}
@@ -745,8 +745,8 @@ void SpriteFramesEditor::_load_pressed() {
 	loading_scene = false;
 
 	file->clear_filters();
-	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("Texture2D", &extensions);
+	LocalVector<String> extensions;
+	ResourceLoader::get_recognized_extensions_for_type("Texture2D", extensions);
 	for (const String &extension : extensions) {
 		file->add_filter("*." + extension);
 	}

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2104,8 +2104,8 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	import_another_theme_dialog = memnew(EditorFileDialog);
 	import_another_theme_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	import_another_theme_dialog->set_title(TTR("Select Another Theme Resource:"));
-	List<String> ext;
-	ResourceLoader::get_recognized_extensions_for_type("Theme", &ext);
+	LocalVector<String> ext;
+	ResourceLoader::get_recognized_extensions_for_type("Theme", ext);
 	for (const String &E : ext) {
 		import_another_theme_dialog->add_filter("*." + E, TTR("Theme Resource"));
 	}
@@ -3782,8 +3782,8 @@ ThemeEditor::ThemeEditor() {
 	preview_scene_dialog = memnew(EditorFileDialog);
 	preview_scene_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	preview_scene_dialog->set_title(TTR("Select UI Scene:"));
-	List<String> ext;
-	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &ext);
+	LocalVector<String> ext;
+	ResourceLoader::get_recognized_extensions_for_type("PackedScene", ext);
 	for (const String &E : ext) {
 		preview_scene_dialog->add_filter("*." + E, TTR("Scene"));
 	}

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -300,8 +300,8 @@ void TileSetEditor::_source_add_id_pressed(int p_id_pressed) {
 				texture_file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILES);
 				texture_file_dialog->connect("files_selected", callable_mp(this, &TileSetEditor::_load_texture_files));
 
-				List<String> extensions;
-				ResourceLoader::get_recognized_extensions_for_type("Texture2D", &extensions);
+				LocalVector<String> extensions;
+				ResourceLoader::get_recognized_extensions_for_type("Texture2D", extensions);
 				for (const String &E : extensions) {
 					texture_file_dialog->add_filter("*." + E, E.to_upper());
 				}

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -265,11 +265,11 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 
 	// Check file extension.
 	String extension = p.get_extension();
-	List<String> extensions;
+	LocalVector<String> extensions;
 
 	// Get all possible extensions for script.
 	for (int l = 0; l < language_menu->get_item_count(); l++) {
-		ScriptServer::get_language(l)->get_recognized_extensions(&extensions);
+		ScriptServer::get_language(l)->get_recognized_extensions(extensions);
 	}
 
 	bool found = false;
@@ -445,10 +445,10 @@ void ScriptCreateDialog::_browse_path(bool browse_parent, bool p_save) {
 
 	file_browse->set_disable_overwrite_warning(true);
 	file_browse->clear_filters();
-	List<String> extensions;
+	LocalVector<String> extensions;
 
 	int lang = language_menu->get_selected();
-	ScriptServer::get_language(lang)->get_recognized_extensions(&extensions);
+	ScriptServer::get_language(lang)->get_recognized_extensions(extensions);
 
 	for (const String &E : extensions) {
 		file_browse->add_filter("*." + E);

--- a/modules/bmp/image_loader_bmp.cpp
+++ b/modules/bmp/image_loader_bmp.cpp
@@ -311,8 +311,8 @@ Error ImageLoaderBMP::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return err;
 }
 
-void ImageLoaderBMP::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("bmp");
+void ImageLoaderBMP::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("bmp");
 }
 
 static Ref<Image> _bmp_mem_loader_func(const uint8_t *p_bmp, int p_size) {

--- a/modules/bmp/image_loader_bmp.h
+++ b/modules/bmp/image_loader_bmp.h
@@ -103,7 +103,7 @@ protected:
 
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const;
 	ImageLoaderBMP();
 };
 

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -818,8 +818,8 @@ Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_orig
 	return Ref<Resource>();
 }
 
-void ResourceFormatDDS::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("dds");
+void ResourceFormatDDS::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("dds");
 }
 
 bool ResourceFormatDDS::handles_type(const String &p_type) const {

--- a/modules/dds/texture_loader_dds.h
+++ b/modules/dds/texture_loader_dds.h
@@ -36,7 +36,7 @@
 class ResourceFormatDDS : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -42,8 +42,8 @@ uint32_t EditorSceneFormatImporterFBX2GLTF::get_import_flags() const {
 	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
 }
 
-void EditorSceneFormatImporterFBX2GLTF::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("fbx");
+void EditorSceneFormatImporterFBX2GLTF::get_extensions(LocalVector<String> &r_extensions) const {
+	r_extensions.push_back("fbx");
 }
 
 Node *EditorSceneFormatImporterFBX2GLTF::import_scene(const String &p_path, uint32_t p_flags,

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
@@ -43,7 +43,7 @@ class EditorSceneFormatImporterFBX2GLTF : public EditorSceneFormatImporter {
 
 public:
 	virtual uint32_t get_import_flags() const override;
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(LocalVector<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;

--- a/modules/fbx/editor/editor_scene_importer_ufbx.cpp
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.cpp
@@ -41,8 +41,8 @@ uint32_t EditorSceneFormatImporterUFBX::get_import_flags() const {
 	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
 }
 
-void EditorSceneFormatImporterUFBX::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("fbx");
+void EditorSceneFormatImporterUFBX::get_extensions(LocalVector<String> &r_extensions) const {
+	r_extensions.push_back("fbx");
 }
 
 Node *EditorSceneFormatImporterUFBX::import_scene(const String &p_path, uint32_t p_flags,

--- a/modules/fbx/editor/editor_scene_importer_ufbx.h
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.h
@@ -47,7 +47,7 @@ public:
 		FBX_IMPORTER_FBX2GLTF,
 	};
 	virtual uint32_t get_import_flags() const override;
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(LocalVector<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -35,7 +35,7 @@
 
 #include "core/io/resource_loader.h"
 
-void GDScriptEditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
+void GDScriptEditorTranslationParserPlugin::get_recognized_extensions(LocalVector<String> &r_extensions) const {
 	GDScriptLanguage::get_singleton()->get_recognized_extensions(r_extensions);
 }
 

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.h
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.h
@@ -83,7 +83,7 @@ class GDScriptEditorTranslationParserPlugin : public EditorTranslationParserPlug
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) override;
 	virtual void get_comments(Vector<String> *r_ids_comment, Vector<String> *r_ids_ctx_plural_comment) override;
-	virtual void get_recognized_extensions(List<String> *r_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &r_extensions) const override;
 
 	GDScriptEditorTranslationParserPlugin();
 };

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -3043,9 +3043,9 @@ Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const Str
 	return scr;
 }
 
-void ResourceFormatLoaderGDScript::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gd");
-	p_extensions->push_back("gdc");
+void ResourceFormatLoaderGDScript::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("gd");
+	p_extensions.push_back("gdc");
 }
 
 bool ResourceFormatLoaderGDScript::handles_type(const String &p_type) const {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -633,7 +633,7 @@ public:
 
 	/* LOADER FUNCTIONS */
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 
 	/* GLOBAL CLASSES */
 
@@ -652,7 +652,7 @@ public:
 class ResourceFormatLoaderGDScript : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -454,8 +454,8 @@ String GDScriptLanguage::debug_parse_stack_level_expression(int p_level, const S
 	return String();
 }
 
-void GDScriptLanguage::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gd");
+void GDScriptLanguage::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("gd");
 }
 
 void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const {

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -106,8 +106,8 @@ uint32_t EditorSceneFormatImporterBlend::get_import_flags() const {
 	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
 }
 
-void EditorSceneFormatImporterBlend::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("blend");
+void EditorSceneFormatImporterBlend::get_extensions(LocalVector<String> &r_extensions) const {
+	r_extensions.push_back("blend");
 }
 
 Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_t p_flags,

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -68,7 +68,7 @@ public:
 	};
 
 	virtual uint32_t get_import_flags() const override;
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(LocalVector<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -39,9 +39,9 @@ uint32_t EditorSceneFormatImporterGLTF::get_import_flags() const {
 	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
 }
 
-void EditorSceneFormatImporterGLTF::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("gltf");
-	r_extensions->push_back("glb");
+void EditorSceneFormatImporterGLTF::get_extensions(LocalVector<String> &r_extensions) const {
+	r_extensions.push_back("gltf");
+	r_extensions.push_back("glb");
 }
 
 Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t p_flags,

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -43,7 +43,7 @@ class EditorSceneFormatImporterGLTF : public EditorSceneFormatImporter {
 
 public:
 	virtual uint32_t get_import_flags() const override;
-	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual void get_extensions(LocalVector<String> &r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;

--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -152,8 +152,8 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return OK;
 }
 
-void ImageLoaderHDR::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("hdr");
+void ImageLoaderHDR::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("hdr");
 }
 
 ImageLoaderHDR::ImageLoaderHDR() {

--- a/modules/hdr/image_loader_hdr.h
+++ b/modules/hdr/image_loader_hdr.h
@@ -36,7 +36,7 @@
 class ImageLoaderHDR : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const;
 
 	ImageLoaderHDR();
 };

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -117,9 +117,9 @@ Error ImageLoaderJPG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return err;
 }
 
-void ImageLoaderJPG::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("jpg");
-	p_extensions->push_back("jpeg");
+void ImageLoaderJPG::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("jpg");
+	p_extensions.push_back("jpeg");
 }
 
 static Ref<Image> _jpegd_mem_loader_func(const uint8_t *p_png, int p_size) {

--- a/modules/jpg/image_loader_jpegd.h
+++ b/modules/jpg/image_loader_jpegd.h
@@ -36,7 +36,7 @@
 class ImageLoaderJPG : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const;
 	ImageLoaderJPG();
 };
 

--- a/modules/ktx/texture_loader_ktx.cpp
+++ b/modules/ktx/texture_loader_ktx.cpp
@@ -541,9 +541,9 @@ static Ref<Image> _ktx_mem_loader_func(const uint8_t *p_ktx, int p_size) {
 	return img;
 }
 
-void ResourceFormatKTX::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ktx");
-	p_extensions->push_back("ktx2");
+void ResourceFormatKTX::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("ktx");
+	p_extensions.push_back("ktx2");
 }
 
 bool ResourceFormatKTX::handles_type(const String &p_type) const {

--- a/modules/ktx/texture_loader_ktx.h
+++ b/modules/ktx/texture_loader_ktx.h
@@ -37,7 +37,7 @@
 class ResourceFormatKTX : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -45,12 +45,12 @@ String ResourceImporterMP3::get_visible_name() const {
 	return "MP3";
 }
 
-void ResourceImporterMP3::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceImporterMP3::get_recognized_extensions(LocalVector<String> &p_extensions) const {
 #ifndef MINIMP3_ONLY_MP3
-	p_extensions->push_back("mp1");
-	p_extensions->push_back("mp2");
+	p_extensions.push_back("mp1");
+	p_extensions.push_back("mp2");
 #endif
-	p_extensions->push_back("mp3");
+	p_extensions.push_back("mp3");
 }
 
 String ResourceImporterMP3::get_save_extension() const {

--- a/modules/minimp3/resource_importer_mp3.h
+++ b/modules/minimp3/resource_importer_mp3.h
@@ -41,7 +41,7 @@ class ResourceImporterMP3 : public ResourceImporter {
 public:
 	virtual String get_importer_name() const override;
 	virtual String get_visible_name() const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1012,8 +1012,8 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 }
 #endif
 
-void CSharpLanguage::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("cs");
+void CSharpLanguage::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("cs");
 }
 
 #ifdef TOOLS_ENABLED
@@ -2863,8 +2863,8 @@ Ref<Resource> ResourceFormatLoaderCSharpScript::load(const String &p_path, const
 	return scr;
 }
 
-void ResourceFormatLoaderCSharpScript::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("cs");
+void ResourceFormatLoaderCSharpScript::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("cs");
 }
 
 bool ResourceFormatLoaderCSharpScript::handles_type(const String &p_type) const {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -568,7 +568,7 @@ public:
 	void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) override;
 
 	/* LOADER FUNCTIONS */
-	void get_recognized_extensions(List<String> *p_extensions) const override;
+	void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 
 #ifdef TOOLS_ENABLED
 	Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) override;
@@ -592,7 +592,7 @@ public:
 class ResourceFormatLoaderCSharpScript : public ResourceFormatLoader {
 public:
 	Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	void get_recognized_extensions(List<String> *p_extensions) const override;
+	void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	bool handles_type(const String &p_type) const override;
 	String get_resource_type(const String &p_path) const override;
 };

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -69,8 +69,8 @@ bool MultiplayerSpawner::_get(const StringName &p_name, Variant &r_ret) const {
 
 void MultiplayerSpawner::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::INT, "_spawnable_scene_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ARRAY, "Auto Spawn List,scenes/"));
-	List<String> exts;
-	ResourceLoader::get_recognized_extensions_for_type("PackedScene", &exts);
+	LocalVector<String> exts;
+	ResourceLoader::get_recognized_extensions_for_type("PackedScene", exts);
 	String ext_hint;
 	for (const String &E : exts) {
 		if (!ext_hint.is_empty()) {

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -150,8 +150,8 @@ Error ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, String p_stri
 	return create_image_from_utf8_buffer(p_image, bytes, p_scale, p_upsample);
 }
 
-void ImageLoaderSVG::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("svg");
+void ImageLoaderSVG::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("svg");
 }
 
 Error ImageLoaderSVG::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -49,7 +49,7 @@ public:
 	static Error create_image_from_string(Ref<Image> p_image, String p_string, float p_scale, bool p_upsample, const HashMap<Color, Color> &p_color_map);
 
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 
 	ImageLoaderSVG();
 };

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -359,8 +359,8 @@ Error ImageLoaderTGA::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 	return err;
 }
 
-void ImageLoaderTGA::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("tga");
+void ImageLoaderTGA::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("tga");
 }
 
 static Ref<Image> _tga_mem_loader_func(const uint8_t *p_tga, int p_size) {

--- a/modules/tga/image_loader_tga.h
+++ b/modules/tga/image_loader_tga.h
@@ -76,7 +76,7 @@ class ImageLoaderTGA : public ImageFormatLoader {
 
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const;
 	ImageLoaderTGA();
 };
 

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -660,8 +660,8 @@ Ref<Resource> ResourceFormatLoaderTheora::load(const String &p_path, const Strin
 	return ogv_stream;
 }
 
-void ResourceFormatLoaderTheora::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ogv");
+void ResourceFormatLoaderTheora::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("ogv");
 }
 
 bool ResourceFormatLoaderTheora::handles_type(const String &p_type) const {

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -170,7 +170,7 @@ public:
 class ResourceFormatLoaderTheora : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };

--- a/modules/tinyexr/image_loader_tinyexr.cpp
+++ b/modules/tinyexr/image_loader_tinyexr.cpp
@@ -287,8 +287,8 @@ Error ImageLoaderTinyEXR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitF
 	return OK;
 }
 
-void ImageLoaderTinyEXR::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("exr");
+void ImageLoaderTinyEXR::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("exr");
 }
 
 ImageLoaderTinyEXR::ImageLoaderTinyEXR() {

--- a/modules/tinyexr/image_loader_tinyexr.h
+++ b/modules/tinyexr/image_loader_tinyexr.h
@@ -36,7 +36,7 @@
 class ImageLoaderTinyEXR : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const;
 	ImageLoaderTinyEXR();
 };
 

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -48,8 +48,8 @@ String ResourceImporterOggVorbis::get_visible_name() const {
 	return "oggvorbisstr";
 }
 
-void ResourceImporterOggVorbis::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ogg");
+void ResourceImporterOggVorbis::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("ogg");
 }
 
 String ResourceImporterOggVorbis::get_save_extension() const {

--- a/modules/vorbis/resource_importer_ogg_vorbis.h
+++ b/modules/vorbis/resource_importer_ogg_vorbis.h
@@ -53,7 +53,7 @@ public:
 
 	static Ref<AudioStreamOggVorbis> load_from_file(const String &p_path);
 	static Ref<AudioStreamOggVorbis> load_from_buffer(const Vector<uint8_t> &file_data);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual String get_save_extension() const override;
 	virtual String get_resource_type() const override;
 	virtual String get_importer_name() const override;

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -58,8 +58,8 @@ Error ImageLoaderWebP::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitFiel
 	return err;
 }
 
-void ImageLoaderWebP::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("webp");
+void ImageLoaderWebP::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("webp");
 }
 
 ImageLoaderWebP::ImageLoaderWebP() {

--- a/modules/webp/image_loader_webp.h
+++ b/modules/webp/image_loader_webp.h
@@ -36,7 +36,7 @@
 class ImageLoaderWebP : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale);
-	virtual void get_recognized_extensions(List<String> *p_extensions) const;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const;
 	ImageLoaderWebP();
 };
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -835,8 +835,8 @@ void ColorPicker::_add_recent_preset_button(int p_size, const Color &p_color) {
 }
 
 void ColorPicker::_load_palette() {
-	List<String> extensions;
-	ResourceLoader::get_recognized_extensions_for_type("ColorPalette", &extensions);
+	LocalVector<String> extensions;
+	ResourceLoader::get_recognized_extensions_for_type("ColorPalette", extensions);
 
 	file_dialog->set_title(RTR("Load Color Palette"));
 	file_dialog->clear_filters();
@@ -855,8 +855,8 @@ void ColorPicker::_save_palette(bool p_is_save_as) {
 		_palette_file_selected(palette_path);
 		return;
 	} else {
-		List<String> extensions;
-		ResourceLoader::get_recognized_extensions_for_type("ColorPalette", &extensions);
+		LocalVector<String> extensions;
+		ResourceLoader::get_recognized_extensions_for_type("ColorPalette", extensions);
 
 		file_dialog->set_title(RTR("Save Color Palette"));
 		file_dialog->clear_filters();

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1945,8 +1945,8 @@ SceneTree::SceneTree() {
 #ifndef _3D_DISABLED
 	{ // Load default fallback environment.
 		// Get possible extensions.
-		List<String> exts;
-		ResourceLoader::get_recognized_extensions_for_type("Environment", &exts);
+		LocalVector<String> exts;
+		ResourceLoader::get_recognized_extensions_for_type("Environment", exts);
 		String ext_hint;
 		for (const String &E : exts) {
 			if (!ext_hint.is_empty()) {

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -480,8 +480,8 @@ Ref<Resource> ResourceFormatLoaderCompressedTexture2D::load(const String &p_path
 	return st;
 }
 
-void ResourceFormatLoaderCompressedTexture2D::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ctex");
+void ResourceFormatLoaderCompressedTexture2D::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("ctex");
 }
 
 bool ResourceFormatLoaderCompressedTexture2D::handles_type(const String &p_type) const {
@@ -669,8 +669,8 @@ Ref<Resource> ResourceFormatLoaderCompressedTexture3D::load(const String &p_path
 	return st;
 }
 
-void ResourceFormatLoaderCompressedTexture3D::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ctex3d");
+void ResourceFormatLoaderCompressedTexture3D::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("ctex3d");
 }
 
 bool ResourceFormatLoaderCompressedTexture3D::handles_type(const String &p_type) const {
@@ -884,10 +884,10 @@ Ref<Resource> ResourceFormatLoaderCompressedTextureLayered::load(const String &p
 	return ct;
 }
 
-void ResourceFormatLoaderCompressedTextureLayered::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("ctexarray");
-	p_extensions->push_back("ccube");
-	p_extensions->push_back("ccubearray");
+void ResourceFormatLoaderCompressedTextureLayered::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("ctexarray");
+	p_extensions.push_back("ccube");
+	p_extensions.push_back("ccubearray");
 }
 
 bool ResourceFormatLoaderCompressedTextureLayered::handles_type(const String &p_type) const {

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -115,7 +115,7 @@ public:
 class ResourceFormatLoaderCompressedTexture2D : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };
@@ -180,7 +180,7 @@ public:
 class ResourceFormatLoaderCompressedTextureLayered : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };
@@ -266,7 +266,7 @@ public:
 class ResourceFormatLoaderCompressedTexture3D : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1422,25 +1422,25 @@ Ref<Resource> ResourceFormatLoaderText::load(const String &p_path, const String 
 	}
 }
 
-void ResourceFormatLoaderText::get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const {
+void ResourceFormatLoaderText::get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &p_extensions) const {
 	if (p_type.is_empty()) {
 		get_recognized_extensions(p_extensions);
 		return;
 	}
 
 	if (ClassDB::is_parent_class("PackedScene", p_type)) {
-		p_extensions->push_back("tscn");
+		p_extensions.push_back("tscn");
 	}
 
 	// Don't allow .tres for PackedScenes or GDExtension.
 	if (p_type != "PackedScene" && p_type != "GDExtension") {
-		p_extensions->push_back("tres");
+		p_extensions.push_back("tres");
 	}
 }
 
-void ResourceFormatLoaderText::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("tscn");
-	p_extensions->push_back("tres");
+void ResourceFormatLoaderText::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("tscn");
+	p_extensions.push_back("tres");
 }
 
 bool ResourceFormatLoaderText::handles_type(const String &p_type) const {

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -147,8 +147,8 @@ class ResourceFormatLoaderText : public ResourceFormatLoader {
 public:
 	static ResourceFormatLoaderText *singleton;
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions_for_type(const String &p_type, LocalVector<String> &r_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -329,8 +329,8 @@ Ref<Resource> ResourceFormatLoaderShader::load(const String &p_path, const Strin
 	return shader;
 }
 
-void ResourceFormatLoaderShader::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gdshader");
+void ResourceFormatLoaderShader::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("gdshader");
 }
 
 bool ResourceFormatLoaderShader::handles_type(const String &p_type) const {

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -109,7 +109,7 @@ VARIANT_ENUM_CAST(Shader::Mode);
 class ResourceFormatLoaderShader : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -111,8 +111,8 @@ Ref<Resource> ResourceFormatLoaderShaderInclude::load(const String &p_path, cons
 	return shader_inc;
 }
 
-void ResourceFormatLoaderShaderInclude::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gdshaderinc");
+void ResourceFormatLoaderShaderInclude::get_recognized_extensions(LocalVector<String> &p_extensions) const {
+	p_extensions.push_back("gdshaderinc");
 }
 
 bool ResourceFormatLoaderShaderInclude::handles_type(const String &p_type) const {

--- a/scene/resources/shader_include.h
+++ b/scene/resources/shader_include.h
@@ -59,7 +59,7 @@ public:
 class ResourceFormatLoaderShaderInclude : public ResourceFormatLoader {
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual void get_recognized_extensions(LocalVector<String> &p_extensions) const override;
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 };


### PR DESCRIPTION
Originally just want to start from `ImageLoader` but it turns out they are all tied together by inheritance, result in this all in one PR. I managed to split `ResourceSaver`s out, though.

Fetching extensions are usually cheap and should not appear in any profile, so performance should not be a problem. The main concern here is if we don't need LinkedList, we should not use `List`, otherwise we are forcing callers of these code to use `List` too. A collection of read-only exts have no special needs, `LocalVector` should be enough for them.

Some callers will gather exts from multiple loader, so it is not appropriate to move `p_extensions` to return value.

This PR is really too big for review, if anyone knows how to split it I'd be happy to go with.
