### PR TITLE
Add ability to apply forces and impulses to `SoftBody3D`

### DIFF
--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1058,6 +1058,42 @@
 				Adds the given body to the list of bodies exempt from collisions.
 			</description>
 		</method>
+		<method name="soft_body_apply_central_force">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="force" type="Vector3" />
+			<description>
+				Distributes and applies a force to all points. A force is time dependent and meant to be applied every physics update.
+			</description>
+		</method>
+		<method name="soft_body_apply_central_impulse">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="impulse" type="Vector3" />
+			<description>
+				Distributes and applies an impulse to all points.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+			</description>
+		</method>
+		<method name="soft_body_apply_point_force">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<param index="2" name="force" type="Vector3" />
+			<description>
+				Applies a force to a point. A force is time dependent and meant to be applied every physics update.
+			</description>
+		</method>
+		<method name="soft_body_apply_point_impulse">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<param index="2" name="impulse" type="Vector3" />
+			<description>
+				Applies an impulse to a point.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+			</description>
+		</method>
 		<method name="soft_body_create">
 			<return type="RID" />
 			<description>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -989,6 +989,36 @@
 			<description>
 			</description>
 		</method>
+		<method name="_soft_body_apply_central_force" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="force" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_apply_central_impulse" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="impulse" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_apply_point_force" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<param index="2" name="force" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_apply_point_impulse" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="point_index" type="int" />
+			<param index="2" name="impulse" type="Vector3" />
+			<description>
+			</description>
+		</method>
 		<method name="_soft_body_create" qualifiers="virtual">
 			<return type="RID" />
 			<description>

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -19,6 +19,38 @@
 				Adds a body to the list of bodies that this body can't collide with.
 			</description>
 		</method>
+		<method name="apply_central_force">
+			<return type="void" />
+			<param index="0" name="force" type="Vector3" />
+			<description>
+				Distributes and applies a force to all points. A force is time dependent and meant to be applied every physics update.
+			</description>
+		</method>
+		<method name="apply_central_impulse">
+			<return type="void" />
+			<param index="0" name="impulse" type="Vector3" />
+			<description>
+				Distributes and applies an impulse to all points.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+			</description>
+		</method>
+		<method name="apply_force">
+			<return type="void" />
+			<param index="0" name="point_index" type="int" />
+			<param index="1" name="force" type="Vector3" />
+			<description>
+				Applies a force to a point. A force is time dependent and meant to be applied every physics update.
+			</description>
+		</method>
+		<method name="apply_impulse">
+			<return type="void" />
+			<param index="0" name="point_index" type="int" />
+			<param index="1" name="impulse" type="Vector3" />
+			<description>
+				Applies an impulse to a point.
+				An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).
+			</description>
+		</method>
 		<method name="get_collision_exceptions">
 			<return type="PhysicsBody3D[]" />
 			<description>

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -737,6 +737,34 @@ void GodotPhysicsServer3D::body_apply_force(RID p_body, const Vector3 &p_force, 
 	body->wakeup();
 }
 
+void GodotPhysicsServer3D::soft_body_apply_point_impulse(RID p_body, int p_point_index, const Vector3 &p_impulse) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->apply_node_impulse(p_point_index, p_impulse);
+}
+
+void GodotPhysicsServer3D::soft_body_apply_point_force(RID p_body, int p_point_index, const Vector3 &p_force) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->apply_node_force(p_point_index, p_force);
+}
+
+void GodotPhysicsServer3D::soft_body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->apply_central_impulse(p_impulse);
+}
+
+void GodotPhysicsServer3D::soft_body_apply_central_force(RID p_body, const Vector3 &p_force) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->apply_central_force(p_force);
+}
+
 void GodotPhysicsServer3D::body_apply_torque(RID p_body, const Vector3 &p_torque) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -212,6 +212,11 @@ public:
 	virtual void body_apply_impulse(RID p_body, const Vector3 &p_impulse, const Vector3 &p_position = Vector3()) override;
 	virtual void body_apply_torque_impulse(RID p_body, const Vector3 &p_impulse) override;
 
+	virtual void soft_body_apply_point_impulse(RID p_body, int p_point_index, const Vector3 &p_impulse) override;
+	virtual void soft_body_apply_point_force(RID p_body, int p_point_index, const Vector3 &p_force) override;
+	virtual void soft_body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) override;
+	virtual void soft_body_apply_central_force(RID p_body, const Vector3 &p_force) override;
+
 	virtual void body_apply_central_force(RID p_body, const Vector3 &p_force) override;
 	virtual void body_apply_force(RID p_body, const Vector3 &p_force, const Vector3 &p_position = Vector3()) override;
 	virtual void body_apply_torque(RID p_body, const Vector3 &p_torque) override;

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -446,6 +446,30 @@ void GodotSoftBody3D::apply_node_impulse(uint32_t p_node_index, const Vector3 &p
 	node.v += p_impulse * node.im;
 }
 
+void GodotSoftBody3D::apply_node_force(uint32_t p_node_index, const Vector3 &p_force) {
+	ERR_FAIL_UNSIGNED_INDEX(p_node_index, nodes.size());
+	Node &node = nodes[p_node_index];
+	node.f += p_force;
+}
+
+void GodotSoftBody3D::apply_central_impulse(const Vector3 &p_impulse) {
+	const Vector3 impulse = p_impulse / nodes.size();
+	for (Node &node : nodes) {
+		if (node.im > 0) {
+			node.v += impulse * node.im;
+		}
+	}
+}
+
+void GodotSoftBody3D::apply_central_force(const Vector3 &p_force) {
+	const Vector3 force = p_force / nodes.size();
+	for (Node &node : nodes) {
+		if (node.im > 0) {
+			node.f += force;
+		}
+	}
+}
+
 void GodotSoftBody3D::apply_node_bias_impulse(uint32_t p_node_index, const Vector3 &p_impulse) {
 	ERR_FAIL_UNSIGNED_INDEX(p_node_index, nodes.size());
 	Node &node = nodes[p_node_index];

--- a/modules/godot_physics_3d/godot_soft_body_3d.h
+++ b/modules/godot_physics_3d/godot_soft_body_3d.h
@@ -172,6 +172,9 @@ public:
 	Vector3 get_node_velocity(uint32_t p_node_index) const;
 	Vector3 get_node_biased_velocity(uint32_t p_node_index) const;
 	void apply_node_impulse(uint32_t p_node_index, const Vector3 &p_impulse);
+	void apply_node_force(uint32_t p_node_index, const Vector3 &p_force);
+	void apply_central_impulse(const Vector3 &p_impulse);
+	void apply_central_force(const Vector3 &p_force);
 	void apply_node_bias_impulse(uint32_t p_node_index, const Vector3 &p_impulse);
 
 	uint32_t get_face_count() const;

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -288,6 +288,34 @@ void JoltPhysicsServer3D::area_set_space(RID p_area, RID p_space) {
 	area->set_space(space);
 }
 
+void JoltPhysicsServer3D::soft_body_apply_point_impulse(RID p_body, int p_point_index, const Vector3 &p_impulse) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->apply_vertex_impulse(p_point_index, p_impulse);
+}
+
+void JoltPhysicsServer3D::soft_body_apply_point_force(RID p_body, int p_point_index, const Vector3 &p_force) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->apply_vertex_force(p_point_index, p_force);
+}
+
+void JoltPhysicsServer3D::soft_body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->apply_central_impulse(p_impulse);
+}
+
+void JoltPhysicsServer3D::soft_body_apply_central_force(RID p_body, const Vector3 &p_force) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->apply_central_force(p_force);
+}
+
 RID JoltPhysicsServer3D::area_get_space(RID p_area) const {
 	const JoltArea3D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL_V(area, RID());

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -322,6 +322,11 @@ public:
 
 	virtual void soft_body_set_transform(RID p_body, const Transform3D &p_transform) override;
 
+	virtual void soft_body_apply_point_impulse(RID p_body, int p_point_index, const Vector3 &p_impulse) override;
+	virtual void soft_body_apply_point_force(RID p_body, int p_point_index, const Vector3 &p_force) override;
+	virtual void soft_body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) override;
+	virtual void soft_body_apply_central_force(RID p_body, const Vector3 &p_force) override;
+
 	virtual void soft_body_set_simulation_precision(RID p_body, int p_precision) override;
 	virtual int soft_body_get_simulation_precision(RID p_body) const override;
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -396,6 +396,57 @@ bool JoltSoftBody3D::is_sleeping() const {
 	}
 }
 
+void JoltSoftBody3D::apply_vertex_impulse(int p_index, const Vector3 &p_impulse) {
+	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to apply impulse to '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
+
+	ERR_FAIL_NULL(shared);
+	ERR_FAIL_INDEX(p_index, (int)shared->mesh_to_physics.size());
+	const size_t physics_index = (size_t)shared->mesh_to_physics[p_index];
+	ERR_FAIL_COND_MSG(pinned_vertices.has(physics_index), vformat("Failed to apply impulse to point at index %d for '%s'. Point was found to be pinned.", static_cast<int>(physics_index), to_string()));
+
+	JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*jolt_body->GetMotionPropertiesUnchecked());
+
+	JPH::Array<JPH::SoftBodyVertex> &physics_vertices = motion_properties.GetVertices();
+	JPH::SoftBodyVertex &physics_vertex = physics_vertices[physics_index];
+
+	physics_vertex.mVelocity += to_jolt(p_impulse) * physics_vertex.mInvMass;
+
+	wake_up();
+}
+
+void JoltSoftBody3D::apply_vertex_force(int p_index, const Vector3 &p_force) {
+	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to apply force to '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
+
+	apply_vertex_impulse(p_index, p_force * space->get_last_step());
+}
+
+void JoltSoftBody3D::apply_central_impulse(const Vector3 &p_impulse) {
+	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to apply central impulse to '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
+	ERR_FAIL_NULL(shared);
+
+	JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*jolt_body->GetMotionPropertiesUnchecked());
+	JPH::Array<JPH::SoftBodyVertex> &physics_vertices = motion_properties.GetVertices();
+
+	const JPH::Vec3 impulse = to_jolt(p_impulse) / physics_vertices.size();
+
+	for (JPH::SoftBodyVertex &physics_vertex : physics_vertices) {
+		if (physics_vertex.mInvMass > 0.0f) {
+			physics_vertex.mVelocity += impulse * physics_vertex.mInvMass;
+		}
+	}
+
+	wake_up();
+}
+
+void JoltSoftBody3D::apply_central_force(const Vector3 &p_force) {
+	ERR_FAIL_COND_MSG(!in_space(), vformat("Failed to apply central force to '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
+	ERR_FAIL_NULL(shared);
+
+	JPH::BodyInterface &body_iface = space->get_body_iface();
+
+	body_iface.AddForce(jolt_body->GetID(), to_jolt(p_force), JPH::EActivation::Activate);
+}
+
 void JoltSoftBody3D::set_is_sleeping(bool p_enabled) {
 	if (!in_space()) {
 		return;

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -166,4 +166,9 @@ public:
 	void unpin_all_vertices();
 
 	bool is_vertex_pinned(int p_index) const;
+
+	void apply_vertex_impulse(int p_index, const Vector3 &p_impulse);
+	void apply_vertex_force(int p_index, const Vector3 &p_force);
+	void apply_central_impulse(const Vector3 &p_impulse);
+	void apply_central_force(const Vector3 &p_force);
 };

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -363,6 +363,11 @@ void SoftBody3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_point_transform", "point_index"), &SoftBody3D::get_point_transform);
 
+	ClassDB::bind_method(D_METHOD("apply_impulse", "point_index", "impulse"), &SoftBody3D::apply_impulse);
+	ClassDB::bind_method(D_METHOD("apply_force", "point_index", "force"), &SoftBody3D::apply_force);
+	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &SoftBody3D::apply_central_impulse);
+	ClassDB::bind_method(D_METHOD("apply_central_force", "force"), &SoftBody3D::apply_central_force);
+
 	ClassDB::bind_method(D_METHOD("set_point_pinned", "point_index", "pinned", "attachment_path", "insert_at"), &SoftBody3D::pin_point, DEFVAL(NodePath()), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("is_point_pinned", "point_index"), &SoftBody3D::is_point_pinned);
 
@@ -669,6 +674,22 @@ void SoftBody3D::set_drag_coefficient(real_t p_drag_coefficient) {
 
 Vector3 SoftBody3D::get_point_transform(int p_point_index) {
 	return PhysicsServer3D::get_singleton()->soft_body_get_point_global_position(physics_rid, p_point_index);
+}
+
+void SoftBody3D::apply_impulse(int p_point_index, const Vector3 &p_impulse) {
+	PhysicsServer3D::get_singleton()->soft_body_apply_point_impulse(physics_rid, p_point_index, p_impulse);
+}
+
+void SoftBody3D::apply_force(int p_point_index, const Vector3 &p_force) {
+	PhysicsServer3D::get_singleton()->soft_body_apply_point_force(physics_rid, p_point_index, p_force);
+}
+
+void SoftBody3D::apply_central_impulse(const Vector3 &p_impulse) {
+	PhysicsServer3D::get_singleton()->soft_body_apply_central_impulse(physics_rid, p_impulse);
+}
+
+void SoftBody3D::apply_central_force(const Vector3 &p_force) {
+	PhysicsServer3D::get_singleton()->soft_body_apply_central_force(physics_rid, p_force);
 }
 
 void SoftBody3D::pin_point_toggle(int p_point_index) {

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -188,6 +188,11 @@ public:
 	void set_ray_pickable(bool p_ray_pickable);
 	bool is_ray_pickable() const;
 
+	void apply_impulse(int p_point_index, const Vector3 &p_impulse);
+	void apply_force(int p_point_index, const Vector3 &p_force);
+	void apply_central_impulse(const Vector3 &p_impulse);
+	void apply_central_force(const Vector3 &p_force);
+
 	SoftBody3D();
 	~SoftBody3D();
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -358,6 +358,11 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_soft_body_pin_point, "body", "point_index", "pin");
 	GDVIRTUAL_BIND(_soft_body_is_point_pinned, "body", "point_index");
 
+	GDVIRTUAL_BIND(_soft_body_apply_point_impulse, "body", "point_index", "impulse");
+	GDVIRTUAL_BIND(_soft_body_apply_point_force, "body", "point_index", "force");
+	GDVIRTUAL_BIND(_soft_body_apply_central_impulse, "body", "impulse");
+	GDVIRTUAL_BIND(_soft_body_apply_central_force, "body", "force");
+
 	/* JOINT API */
 
 	GDVIRTUAL_BIND(_joint_create);

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -465,6 +465,11 @@ public:
 	EXBIND3(soft_body_pin_point, RID, int, bool)
 	EXBIND2RC(bool, soft_body_is_point_pinned, RID, int)
 
+	EXBIND3(soft_body_apply_point_impulse, RID, int, const Vector3 &)
+	EXBIND3(soft_body_apply_point_force, RID, int, const Vector3 &)
+	EXBIND2(soft_body_apply_central_impulse, RID, const Vector3 &)
+	EXBIND2(soft_body_apply_central_force, RID, const Vector3 &)
+
 	/* JOINT API */
 
 	EXBIND0R(RID, joint_create)

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -894,6 +894,11 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("soft_body_is_point_pinned", "body", "point_index"), &PhysicsServer3D::soft_body_is_point_pinned);
 
+	ClassDB::bind_method(D_METHOD("soft_body_apply_point_impulse", "body", "point_index", "impulse"), &PhysicsServer3D::soft_body_apply_point_impulse);
+	ClassDB::bind_method(D_METHOD("soft_body_apply_point_force", "body", "point_index", "force"), &PhysicsServer3D::soft_body_apply_point_force);
+	ClassDB::bind_method(D_METHOD("soft_body_apply_central_impulse", "body", "impulse"), &PhysicsServer3D::soft_body_apply_central_impulse);
+	ClassDB::bind_method(D_METHOD("soft_body_apply_central_force", "body", "force"), &PhysicsServer3D::soft_body_apply_central_force);
+
 	/* JOINT API */
 
 	ClassDB::bind_method(D_METHOD("joint_create"), &PhysicsServer3D::joint_create);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -619,6 +619,11 @@ public:
 	virtual void soft_body_move_point(RID p_body, int p_point_index, const Vector3 &p_global_position) = 0;
 	virtual Vector3 soft_body_get_point_global_position(RID p_body, int p_point_index) const = 0;
 
+	virtual void soft_body_apply_point_impulse(RID p_body, int p_point_index, const Vector3 &p_impulse) = 0;
+	virtual void soft_body_apply_point_force(RID p_body, int p_point_index, const Vector3 &p_force) = 0;
+	virtual void soft_body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) = 0;
+	virtual void soft_body_apply_central_force(RID p_body, const Vector3 &p_force) = 0;
+
 	virtual void soft_body_remove_all_pinned_points(RID p_body) = 0;
 	virtual void soft_body_pin_point(RID p_body, int p_point_index, bool p_pin) = 0;
 	virtual bool soft_body_is_point_pinned(RID p_body, int p_point_index) const = 0;

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -357,6 +357,11 @@ public:
 	virtual void soft_body_pin_point(RID p_body, int p_point_index, bool p_pin) override {}
 	virtual bool soft_body_is_point_pinned(RID p_body, int p_point_index) const override { return false; }
 
+	virtual void soft_body_apply_point_impulse(RID p_body, int p_point_index, const Vector3 &p_impulse) override {}
+	virtual void soft_body_apply_point_force(RID p_body, int p_point_index, const Vector3 &p_force) override {}
+	virtual void soft_body_apply_central_impulse(RID p_body, const Vector3 &p_impulse) override {}
+	virtual void soft_body_apply_central_force(RID p_body, const Vector3 &p_force) override {}
+
 	/* JOINT API */
 
 	virtual RID joint_create() override { return RID(); }

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -225,6 +225,11 @@ public:
 	FUNC3(body_apply_force, RID, const Vector3 &, const Vector3 &);
 	FUNC2(body_apply_torque, RID, const Vector3 &);
 
+	FUNC3(soft_body_apply_point_impulse, RID, int, const Vector3 &);
+	FUNC3(soft_body_apply_point_force, RID, int, const Vector3 &);
+	FUNC2(soft_body_apply_central_impulse, RID, const Vector3 &);
+	FUNC2(soft_body_apply_central_force, RID, const Vector3 &);
+
 	FUNC2(body_add_constant_central_force, RID, const Vector3 &);
 	FUNC3(body_add_constant_force, RID, const Vector3 &, const Vector3 &);
 	FUNC2(body_add_constant_torque, RID, const Vector3 &);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/1013

The goal of this PR is to add `apply_impulse` and `apply_force` to the `Softbody` node

Adding them to the `GodotPhysics` and `JoltPhysics`.

# Added functions
**Softbody3D:**
`void apply_central_force(force: Vector3)`
`void apply_force(force: Vector3, point_index: int)`
`void apply_central_impulse(impulse: Vector3)`
`void apply_impulse(impulse: Vector3, point_index: int)`

**PhysicsServer3D:**
`void soft_body_apply_central_force(body: RID, force: Vector3)`
`void soft_body_apply_central_impulse(body: RID, impulse: Vector3)`
`void soft_body_apply_point_force(body: RID, force: Vector3, point_index: int)`
`void soft_body_apply_point_impulse(body: RID, impulse: Vector3, point_index: int)`

# Built-in documentation


Edit: I think these are a bit outdated

<details>
<summary>Show documentation</summary>


## PhysicsServer3D

>`● void soft_body_apply_central_force(body: RID, force: Vector3)`
> 
>Distributes and applies an force to all vertices. A force is time dependent and meant to be applied every physics update.


> `● void soft_body_apply_central_impulse(body: RID, impulse: Vector3)`
> 
> Distributes and applies an impulse to all vertices.
> 
> An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).


> `● void soft_body_apply_point_force(body: RID, force: Vector3, point_index: int)`
> 
> Applies a force to a vertex. A force is time dependent and meant to be applied every physics update.


> `● void soft_body_apply_point_impulse(body: RID, impulse: Vector3, point_index: int)`
> 
> Applies an impulse to a vertex.
> 
> An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).

## SoftBody3D

> `● void apply_central_force(force: Vector3)`
>
> Distributes and applies an force to all vertices. A force is time dependent and meant to be applied every physics update.


> `● void apply_central_impulse(impulse: Vector3)`
>
> Distributes and applies an impulse to all vertices.
> 
> An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).


> `● void apply_force(force: Vector3, point_index: int)`
> 
> Applies a force to a vertex. A force is time dependent and meant to be applied every physics update.


> `● void apply_impulse(impulse: Vector3, point_index: int)`
> 
> Applies an impulse to a vertex.
> 
> An impulse is time-independent! Applying an impulse every frame would result in a framerate-dependent force. For this reason, it should only be used when simulating one-time impacts (use the "_force" functions otherwise).

</details>

# Demo

Demo project: [godot-softbody-apply-force-and-impulse-test.zip](https://github.com/user-attachments/files/19620871/godot-softbody-apply-force-and-impulse-test.zip)


These are how the functions compared to rigidbody.

The impulses have a strength of 0.2.
The forces have a strength of 15.

### Jolt physics:

https://github.com/user-attachments/assets/0a781599-1a6d-4ba4-804c-c3b230b152ba

### Godot physics:

https://github.com/user-attachments/assets/025d1047-9319-4db6-9bb7-7865b0f5d91c

### Player Controller (Jolt physics):

https://github.com/user-attachments/assets/84ba9d9c-8dd7-49d9-a557-4115a61be1cd

# Implementation Details
<details>

<summary>Godot apply_impulse</summary>

`GodotSoftbody3D` already have `apply_node_impulse` method which apply impulse to a vertex. So I just use that for the `softbody.apply_impulse`.
</details>
<details>

<summary>Godot apply_force</summary>

`GodotSoftbody3D` have `vertex.f` which stores the applied forces, and it will handle it somewhere. Therefore, I only need to add a method that add the forces to it.
</details>
<details>

<summary>Jolt apply_impulse</summary>

`JoltSoftbody3D` didn't have a method to apply impulse. So I added  `JoltSoftBody3D::apply_node_impulse`. It works like the `GodotSoftBody3D::apply_node_impulse` which just add `impulse * vertex.inverse_mass` to the vertex velocity.
</details>
<details>

<summary>Jolt apply_force</summary>

[Outdated]
I notice that the core JoltPhysics didn't have a way to apply force to softbody vertex. Hence, I have to add that functionality into the core of the JoltPhysics engine.

I added `vertex.mForce`, which store the forces that are going to be applied. Then applies it in the `SoftBodyMotionProperties::IntegratePositions` and reset the force on `SoftBodyMotionProperties::UpdateSoftBodyState`.
</details>
<details>

<summary>apply_central_impulse/force</summary>

For `SoftBody.apply_central_impulse` and `SoftBody.apply_central_force` I added `apply_central_impulse` and `apply_central_force` methods to jolt and godot. It works like the `apply_node_impulse/force` but the impulse/force is divided by the vertex count and applies it to all vertices.
</details>


