### PR TITLE
Improve `CowData`'s implementation of `clear()` to generate less and faster code. Replace a bunch of `resize(0)` calls with `clear()` to make better use of the function.

### DIFF
--- a/core/crypto/aes_context.cpp
+++ b/core/crypto/aes_context.cpp
@@ -39,7 +39,7 @@ Error AESContext::start(Mode p_mode, const PackedByteArray &p_key, const PackedB
 	// Initialization vector.
 	if (p_mode == MODE_CBC_ENCRYPT || p_mode == MODE_CBC_DECRYPT) {
 		ERR_FAIL_COND_V_MSG(p_iv.size() != 16, ERR_INVALID_PARAMETER, "The initialization vector (IV) must be exactly 16 bytes.");
-		iv.resize(0);
+		iv.clear();
 		iv.append_array(p_iv);
 	}
 	// Encryption/decryption key.
@@ -96,7 +96,7 @@ PackedByteArray AESContext::get_iv_state() {
 
 void AESContext::finish() {
 	mode = MODE_MAX;
-	iv.resize(0);
+	iv.clear();
 }
 
 void AESContext::_bind_methods() {

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -102,7 +102,7 @@ Error PacketPeer::put_var(const Variant &p_packet, bool p_full_objects) {
 	ERR_FAIL_COND_V_MSG(len > encode_buffer_max_size, ERR_OUT_OF_MEMORY, "Failed to encode variant, encode size is bigger then encode_buffer_max_size. Consider raising it via 'set_encode_buffer_max_size'.");
 
 	if (unlikely(encode_buffer.size() < len)) {
-		encode_buffer.resize(0); // Avoid realloc
+		encode_buffer.clear(); // Avoid realloc
 		encode_buffer.resize(next_power_of_2(len));
 	}
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -130,7 +130,7 @@ const char16_t *Char16String::get_data() const {
 
 void Char16String::copy_from(const char16_t *p_cstr) {
 	if (!p_cstr) {
-		resize(0);
+		clear();
 		return;
 	}
 
@@ -140,7 +140,7 @@ void Char16String::copy_from(const char16_t *p_cstr) {
 	size_t len = s - p_cstr;
 
 	if (len == 0) {
-		resize(0);
+		clear();
 		return;
 	}
 
@@ -200,14 +200,14 @@ const char *CharString::get_data() const {
 
 void CharString::copy_from(const char *p_cstr) {
 	if (!p_cstr) {
-		resize(0);
+		clear();
 		return;
 	}
 
 	size_t len = strlen(p_cstr);
 
 	if (len == 0) {
-		resize(0);
+		clear();
 		return;
 	}
 
@@ -306,7 +306,7 @@ Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r
 
 void String::copy_from(const StrRange<char> &p_cstr) {
 	if (p_cstr.len == 0) {
-		resize(0);
+		clear();
 		return;
 	}
 
@@ -325,7 +325,7 @@ void String::copy_from(const StrRange<char> &p_cstr) {
 
 void String::copy_from(const StrRange<char32_t> &p_cstr) {
 	if (p_cstr.len == 0) {
-		resize(0);
+		clear();
 		return;
 	}
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -181,6 +181,7 @@ public:
 	_FORCE_INLINE_ const char16_t *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
+	void clear() { _cowdata.clear(); }
 
 	_FORCE_INLINE_ char16_t get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const char16_t &p_elem) { _cowdata.set(p_index, p_elem); }
@@ -226,6 +227,7 @@ public:
 	_FORCE_INLINE_ const char *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
 	Error resize(int p_size) { return _cowdata.resize(p_size); }
+	void clear() { _cowdata.clear(); }
 
 	_FORCE_INLINE_ char get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const char &p_elem) { _cowdata.set(p_index, p_elem); }
@@ -332,7 +334,7 @@ public:
 
 	void remove_at(int p_index) { _cowdata.remove_at(p_index); }
 
-	_FORCE_INLINE_ void clear() { resize(0); }
+	_FORCE_INLINE_ void clear() { _cowdata.clear(); }
 
 	_FORCE_INLINE_ char32_t get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const char32_t &p_elem) { _cowdata.set(p_index, p_elem); }

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -195,7 +195,10 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ void clear() { resize(0); }
+	_FORCE_INLINE_ void clear() {
+		_unref();
+		_ptr = nullptr;
+	}
 	_FORCE_INLINE_ bool is_empty() const { return _ptr == nullptr; }
 
 	_FORCE_INLINE_ void set(Size p_index, const T &p_elem) {
@@ -336,8 +339,7 @@ Error CowData<T>::resize(Size p_size) {
 
 	if (p_size == 0) {
 		// wants to clean up
-		_unref();
-		_ptr = nullptr;
+		clear();
 		return OK;
 	}
 

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -89,7 +89,7 @@ public:
 
 	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
-	_FORCE_INLINE_ void clear() { resize(0); }
+	_FORCE_INLINE_ void clear() { _cowdata.clear(); }
 	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
 
 	_FORCE_INLINE_ T get(Size p_index) { return _cowdata.get(p_index); }

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -1099,8 +1099,8 @@ void GodotConvexPolygonShape3D::_setup(const Vector<Vector3> &p_vertices) {
 	if (err != OK) {
 		ERR_PRINT("Failed to build convex hull");
 	}
-	extreme_vertices.resize(0);
-	vertex_neighbors.resize(0);
+	extreme_vertices.clear();
+	vertex_neighbors.clear();
 
 	AABB _aabb;
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1963,7 +1963,7 @@ void TextServerAdvanced::_font_set_data_ptr(const RID &p_font_rid, const uint8_t
 
 	MutexLock lock(fd->mutex);
 	_font_clear_cache(fd);
-	fd->data.resize(0);
+	fd->data.clear();
 	fd->data_ptr = p_data_ptr;
 	fd->data_size = p_data_size;
 }

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1068,7 +1068,7 @@ void TextServerFallback::_font_set_data_ptr(const RID &p_font_rid, const uint8_t
 
 	MutexLock lock(fd->mutex);
 	_font_clear_cache(fd);
-	fd->data.resize(0);
+	fd->data.clear();
 	fd->data_ptr = p_data_ptr;
 	fd->data_size = p_data_size;
 }

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -866,7 +866,7 @@ void WSLPeer::close(int p_code, String p_reason) {
 
 	heartbeat_waiting = false;
 	in_buffer.clear();
-	packet_buffer.resize(0);
+	packet_buffer.clear();
 	pending_message.clear();
 }
 

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -540,7 +540,7 @@ Error EditorExportPlatformWeb::export_project(const Ref<EditorExportPreset> &p_p
 		// Message is supplied by the subroutine method.
 		return err;
 	}
-	html.resize(0);
+	html.clear();
 
 	// Export splash (why?)
 	Ref<Image> splash = _get_project_splash();

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -113,8 +113,8 @@ void HTTPClientWeb::close() {
 	use_tls = false;
 	status = STATUS_DISCONNECTED;
 	polled_response_code = 0;
-	response_headers.resize(0);
-	response_buffer.resize(0);
+	response_headers.clear();
+	response_buffer.clear();
 	if (js_id) {
 		godot_js_fetch_free(js_id);
 		js_id = 0;

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -60,7 +60,7 @@ void SoftBodyRenderingServerHandler::prepare(RID p_mesh, int p_surface) {
 }
 
 void SoftBodyRenderingServerHandler::clear() {
-	buffer.resize(0);
+	buffer.clear();
 	stride = 0;
 	normal_stride = 0;
 	offset_vertices = 0;

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -1747,7 +1747,7 @@ void Curve3D::_bake() const {
 	}
 
 	if (!up_vector_enabled) {
-		baked_up_vector_cache.resize(0);
+		baked_up_vector_cache.clear();
 		return;
 	}
 

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -514,7 +514,7 @@ bool RenderingLightCuller::prepare_camera(const Transform3D &p_cam_transform, co
 	data.regular_rejected_count = 0;
 #endif
 
-	data.directional_cull_planes.resize(0);
+	data.directional_cull_planes.clear();
 
 #ifdef LIGHT_CULLER_DEBUG_LOGGING
 	if (is_logging()) {


### PR DESCRIPTION
This is a pretty straightforward change. It's intended to make the code slightly faster and less dense. I've checked all callees; they're either `LocalVector` (where it doesn't make a difference yet, but may in the future), and `String` / `Vector` / `CowData`, where it will make a small difference now.