### PR TITLE
Optimize `CowData`'s `remove_at` and `insert` functions to avoid repeated copy assignments for non-trivial types.

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -99,7 +99,7 @@ public:
 	Error resize(Size p_size) { return _cowdata.resize(p_size); }
 	Error resize_zeroed(Size p_size) { return _cowdata.template resize<true>(p_size); }
 	_FORCE_INLINE_ const T &operator[](Size p_index) const { return _cowdata.get(p_index); }
-	Error insert(Size p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }
+	Error insert(Size p_pos, const T &p_val) { return _cowdata.insert(p_pos, p_val); }
 	Size find(const T &p_val, Size p_from = 0) const { return _cowdata.find(p_val, p_from); }
 	Size rfind(const T &p_val, Size p_from = -1) const { return _cowdata.rfind(p_val, p_from); }
 	Size count(const T &p_val) const { return _cowdata.count(p_val); }


### PR DESCRIPTION
This PR uses memory magic to move regions in `CowData`, avoiding repeated copy assignments and destructions. 

Assuming I made no mistakes, this logic should be safe for all types that are trivially relocatable. I don't think we have any of that aren't, but for reference, [here is a list](https://open-std.org/JTC1/SC22/WG21/docs/papers/2020/p1144r5.html#non-trivial-samples).

Beneficiaries of this change include `Array`, `PackedStringArray`, and other internal `Vector` types that use non-trivial elements.

## Benchmark

I benchmarked the following code:
```c++
	int N = 10000;
	int M = 1000;
	Array vectors[N];
	for (int i = 0; i < N; i++) {
		for (int j = 0; j < M; ++j) {
			vectors[i].push_back("Test");
		}
	}

	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < N; i ++) {
			vectors[i].remove_at(0);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}

	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < N; i ++) {
			vectors[i].insert(0, vectors[0][0]);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
```

This yields:
- `118ms` and `107ms` on master (ba2c5c1e6196b774d55baa45de54aab530db08e9)
- `20ms` and `13ms` on this PR (499067d983013871968585e57480a5429ef80951)

As such, it can be concluded that `remove_at` can be 6x as fast as before, and `insert` can be 8x as fast.

## Addendum
If this is merged, a similar PR should address `insert` and `remove_at` of `LocalVector` (ideally without copying the rather fiddly logic, using a template function).
Arguably, `push_back` and `pop_back()` should be added, because quite a few callers have various ways of implementing these operations themselves. They would benefit the most of an in-place assignment without unnecessary temporary allocations could be implemented.