### PR TITLE
OpenXR: Fix crash with composition layers in non-dev builds

### DIFF
--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -85,6 +85,7 @@ OpenXRCompositionLayer::~OpenXRCompositionLayer() {
 	composition_layer_nodes.erase(this);
 
 	if (openxr_layer_provider != nullptr) {
+		_clear_composition_layer_provider();
 		memdelete(openxr_layer_provider);
 		openxr_layer_provider = nullptr;
 	}
@@ -374,16 +375,7 @@ void OpenXRCompositionLayer::_reset_fallback_material() {
 
 		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, !enable_hole_punch);
 		material->set_transparency(get_alpha_blend() ? StandardMaterial3D::TRANSPARENCY_ALPHA : StandardMaterial3D::TRANSPARENCY_DISABLED);
-
-		Ref<ViewportTexture> texture = material->get_texture(StandardMaterial3D::TEXTURE_ALBEDO);
-		if (texture.is_null()) {
-			texture = layer_viewport->get_texture();
-		}
-
-		Node *loc_scene = texture->get_local_scene();
-		NodePath viewport_path = loc_scene->get_path_to(layer_viewport);
-		texture->set_viewport_path_in_scene(viewport_path);
-		material->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, texture);
+		material->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, layer_viewport->get_texture());
 	} else {
 		fallback->set_surface_override_material(0, Ref<Material>());
 	}


### PR DESCRIPTION
This fixes a crash that happens when using OpenXR composition layers, but only on non-dev builds (which is why I didn't notice it right away) and only when the fallback is used because the OpenXR runtime doesn't support a type of layer (I encountered this with the Meta XR Simulator, which supports quad and cylinder layers, but not equirect layers - [this sample](https://github.com/GodotVR/godot_openxr_vendors/tree/master/samples/meta-composition-layers-sample) uses all layer types and can reproduce the issue).

The new code is a lot simpler too!

The issue was introduced by PR https://github.com/godotengine/godot/pull/96185 (sorry!) and present in all 4.4 dev releases since 4.4-dev2
