### PR TITLE
Fix `BVH::ray_query()` numerical precision

### DIFF
--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -310,7 +310,7 @@ public:
 	template <typename QueryResult>
 	_FORCE_INLINE_ void convex_query(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, QueryResult &r_result);
 	template <typename QueryResult>
-	_FORCE_INLINE_ void ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResult &r_result);
+	_FORCE_INLINE_ void ray_query(const Vector3 &p_from, const Vector3 &p_dir, real_t p_length, QueryResult &r_result);
 
 	void set_index(uint32_t p_index);
 	uint32_t get_index() const;
@@ -416,13 +416,12 @@ void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Ve
 	} while (depth > 0);
 }
 template <typename QueryResult>
-void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResult &r_result) {
+void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_dir, real_t p_length, QueryResult &r_result) {
 	if (!bvh_root) {
 		return;
 	}
 
-	Vector3 ray_dir = (p_to - p_from);
-	ray_dir.normalize();
+	Vector3 ray_dir = p_dir;
 
 	///what about division by zero? --> just set rayDirection[i] to INF/B3_LARGE_FLOAT
 	Vector3 inv_dir;
@@ -431,7 +430,7 @@ void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResu
 	inv_dir[2] = ray_dir[2] == real_t(0.0) ? real_t(1e20) : real_t(1.0) / ray_dir[2];
 	unsigned int signs[3] = { inv_dir[0] < 0.0, inv_dir[1] < 0.0, inv_dir[2] < 0.0 };
 
-	real_t lambda_max = ray_dir.dot(p_to - p_from);
+	real_t lambda_max = p_length;
 
 	Vector3 bounds[2];
 

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -316,7 +316,7 @@ public:
 	template <typename QueryResult>
 	_FORCE_INLINE_ void convex_query(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, QueryResult &r_result);
 	template <typename QueryResult>
-	_FORCE_INLINE_ void ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResult &r_result);
+	_FORCE_INLINE_ void ray_query(const Vector3 &p_from, const Vector3 &p_dir, real_t p_length, QueryResult &r_result);
 
 	void set_index(uint32_t p_index);
 	uint32_t get_index() const;
@@ -422,13 +422,12 @@ void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Ve
 	} while (depth > 0);
 }
 template <typename QueryResult>
-void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResult &r_result) {
+void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_dir, real_t p_length, QueryResult &r_result) {
 	if (!bvh_root) {
 		return;
 	}
 
-	Vector3 ray_dir = (p_to - p_from);
-	ray_dir.normalize();
+	Vector3 ray_dir = p_dir;
 
 	///what about division by zero? --> just set rayDirection[i] to INF/B3_LARGE_FLOAT
 	Vector3 inv_dir;
@@ -437,7 +436,7 @@ void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResu
 	inv_dir[2] = ray_dir[2] == real_t(0.0) ? real_t(1e20) : real_t(1.0) / ray_dir[2];
 	unsigned int signs[3] = { inv_dir[0] < 0.0, inv_dir[1] < 0.0, inv_dir[2] < 0.0 };
 
-	real_t lambda_max = ray_dir.dot(p_to - p_from);
+	real_t lambda_max = p_length;
 
 	Vector3 bounds[2];
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -9579,7 +9579,9 @@ Vector<Node3D *> Node3DEditor::gizmo_bvh_ray_query(const Vector3 &p_ray_start, c
 		}
 	} result;
 
-	gizmo_bvh.ray_query(p_ray_start, p_ray_end, result);
+	Vector3 segment = p_ray_end - p_ray_start;
+	real_t length = segment.length();
+	gizmo_bvh.ray_query(p_ray_start, segment / length, length, result);
 
 	return result.nodes;
 }

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4103,7 +4103,9 @@ Vector<Node3D *> Node3DEditor::gizmo_bvh_ray_query(const Vector3 &p_ray_start, c
 		}
 	} result;
 
-	gizmo_bvh.ray_query(p_ray_start, p_ray_end, result);
+	Vector3 segment = p_ray_end - p_ray_start;
+	real_t length = segment.length();
+	gizmo_bvh.ray_query(p_ray_start, segment / length, length, result);
 
 	return result.nodes;
 }

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -1153,7 +1153,9 @@ void GodotSoftBody3D::query_ray(const Vector3 &p_from, const Vector3 &p_to, Godo
 	query_result.result_callback = p_result_callback;
 	query_result.userdata = p_userdata;
 
-	face_tree.ray_query(p_from, p_to, query_result);
+	Vector3 segment = p_to - p_from;
+	real_t length = segment.length();
+	face_tree.ray_query(p_from, segment / length, length, query_result);
 }
 
 void GodotSoftBody3D::initialize_face_tree() {

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -1188,7 +1188,9 @@ void GodotSoftBody3D::query_ray(const Vector3 &p_from, const Vector3 &p_to, Godo
 	query_result.result_callback = p_result_callback;
 	query_result.userdata = p_userdata;
 
-	face_tree.ray_query(p_from, p_to, query_result);
+	Vector3 segment = p_to - p_from;
+	real_t length = segment.length();
+	face_tree.ray_query(p_from, segment / length, length, query_result);
 }
 
 void GodotSoftBody3D::initialize_face_tree() {

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1279,8 +1279,10 @@ Vector<ObjectID> RendererSceneCull::instances_cull_ray(const Vector3 &p_from, co
 	};
 
 	CullRay cull_ray;
-	scenario->indexers[Scenario::INDEXER_GEOMETRY].ray_query(p_from, p_to, cull_ray);
-	scenario->indexers[Scenario::INDEXER_VOLUMES].ray_query(p_from, p_to, cull_ray);
+	Vector3 segment = p_to - p_from;
+	real_t length = segment.length();
+	scenario->indexers[Scenario::INDEXER_GEOMETRY].ray_query(p_from, segment / length, length, cull_ray);
+	scenario->indexers[Scenario::INDEXER_VOLUMES].ray_query(p_from, segment / length, length, cull_ray);
 	return cull_ray.instances;
 }
 

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1210,8 +1210,10 @@ Vector<ObjectID> RendererSceneCull::instances_cull_ray(const Vector3 &p_from, co
 	};
 
 	CullRay cull_ray;
-	scenario->indexers[Scenario::INDEXER_GEOMETRY].ray_query(p_from, p_to, cull_ray);
-	scenario->indexers[Scenario::INDEXER_VOLUMES].ray_query(p_from, p_to, cull_ray);
+	Vector3 segment = p_to - p_from;
+	real_t length = segment.length();
+	scenario->indexers[Scenario::INDEXER_GEOMETRY].ray_query(p_from, segment / length, length, cull_ray);
+	scenario->indexers[Scenario::INDEXER_VOLUMES].ray_query(p_from, segment / length, length, cull_ray);
 	return cull_ray.instances;
 }
 


### PR DESCRIPTION
The current BVH ray query implementation starts generating false positive / negative hits on small objects when the ray's starting point is farther than ~1000km away from the origin (with single precision build).

As an example, with `p_ray_from = Vector3(1e+7, 0.0, 1e+7)` and `p_ray_to = Vector3(5.0, 0.0, 0.0)`, `BHV::ray_query()` will hit any 1 meter large object at the origin although the ray doesn't pass there. 

This PR circumvents the numerical precision issue involved there by making `ray_query()` taking the ray direction and length instead of the ray's endpoint. This avoids the precision-killing operation `p_ray_end - p_ray_start` in the function's body.

Note that making Godot's raycasting actually precision-proof will require to move away from the ray_start / ray_end pattern (in favor of ray_start / ray_dir / ray_length) at various places in the codebase.
As these additional changes would affect several independant subparts of the engine (physic server, editor picking, scene culling) they will be splitted into specific PRs for easier review :
- [x] Editor picking : #100478
- [x] Scene culling : #100480
- [x] 3D Physics : #100604
- [ ] 3D Physics - `GodotBroadPhase3D`

The current PR lays the foundations, and for now just makes sure non precision-proof code interoperates smoothly with it. This way it can be independently review and merged.