### PR TITLE
Optimize `CowData` and `LocalVector` functions `.insert` and `.remove_at` by using move semantics.

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -37,6 +37,7 @@
 
 #include <string.h>
 #include <type_traits>
+#include <utility>
 
 template <typename T>
 class Vector;
@@ -224,7 +225,7 @@ public:
 		T *p = ptrw();
 		Size len = size();
 		for (Size i = p_index; i < len - 1; i++) {
-			p[i] = p[i + 1];
+			p[i] = std::move(p[i + 1]);
 		}
 
 		resize(len - 1);
@@ -237,7 +238,7 @@ public:
 		ERR_FAIL_COND_V(err, err);
 		T *p = ptrw();
 		for (Size i = new_size - 1; i > p_pos; i--) {
-			p[i] = p[i - 1];
+			p[i] = std::move(p[i - 1]);
 		}
 		p[p_pos] = p_val;
 

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -67,7 +67,7 @@ public:
 		if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
 			memnew_placement(&data[count++], T(p_elem));
 		} else {
-			data[count++] = p_elem;
+			data[count++] = std::move(p_elem);
 		}
 	}
 
@@ -75,7 +75,7 @@ public:
 		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
 		count--;
 		for (U i = p_index; i < count; i++) {
-			data[i] = data[i + 1];
+			data[i] = std::move(data[i + 1]);
 		}
 		if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
 			data[count].~T();
@@ -88,7 +88,7 @@ public:
 		ERR_FAIL_INDEX(p_index, count);
 		count--;
 		if (count > p_index) {
-			data[p_index] = data[count];
+			data[p_index] = std::move(data[count]);
 		}
 		if constexpr (!std::is_trivially_destructible_v<T> && !force_trivial) {
 			data[count].~T();
@@ -245,13 +245,13 @@ public:
 	void insert(U p_pos, T p_val) {
 		ERR_FAIL_UNSIGNED_INDEX(p_pos, count + 1);
 		if (p_pos == count) {
-			push_back(p_val);
+			push_back(std::move(p_val));
 		} else {
 			resize(count + 1);
 			for (U i = count - 1; i > p_pos; i--) {
-				data[i] = data[i - 1];
+				data[i] = std::move(data[i - 1]);
 			}
-			data[p_pos] = p_val;
+			data[p_pos] = std::move(p_val);
 		}
 	}
 


### PR DESCRIPTION
This PR uses move semantics to move regions in CowData, avoiding repeated copy assignments and destructions.

Safer, but still very fast, version of #100468. #100468 may still be re-opened if needed at some point, but it turns out most of the performance loss from these functions can already be avoided with this simple change.

Beneficiaries of this change include `Array`, `PackedStringArray`, and other internal Vector types that use non-trivial elements.

Additionally, some minor inefficiencies are addressed in `Vector` and `LocalVector` implementations.

## Benchmark

I benchmarked the following code:

```c++
	int N = 10000;
	int M = 1000;
	Array vectors[N];
	for (int i = 0; i < N; i++) {
		for (int j = 0; j < M; ++j) {
			vectors[i].push_back("Test");
		}
	}

	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < N; i ++) {
			vectors[i].remove_at(0);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}

	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < N; i ++) {
			vectors[i].insert(0, vectors[0][0]);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
```

This yields:

- `121ms` and `110ms` on https://github.com/godotengine/godot/pull/100426 (34fa0bf3ec531cd0545200eaabe80af04c8de127)
- `22ms` and `13ms` on a combined merge of this PR and https://github.com/godotengine/godot/pull/100426 

As such, it can be concluded that `remove_at` can be 5.5x as fast as before, and `insert` can be 8x as fast.

## Addendum 
Arguably, push_back and pop_back() should be added to `CowData`, because quite a few callers have various ways of implementing these operations themselves. They could be accelerated with move semantics quite easily, and an efficient implementation would be considerably faster than `insert` and `remove_at`.