### PR TITLE
Add move semantics (constructor, assignment) to `StringName`.

### DIFF
--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -188,8 +188,22 @@ public:
 	};
 
 	StringName &operator=(const StringName &p_name);
+	StringName &operator=(StringName &&p_name) {
+		if (_data == p_name._data) {
+			return *this;
+		}
+
+		unref();
+		_data = p_name._data;
+		p_name._data = nullptr;
+		return *this;
+	}
 	StringName(const char *p_name, bool p_static = false);
 	StringName(const StringName &p_name);
+	StringName(StringName &&p_name) {
+		_data = p_name._data;
+		p_name._data = nullptr;
+	}
 	StringName(const String &p_name, bool p_static = false);
 	StringName(const StaticCString &p_static_string, bool p_static = false);
 	StringName() {}


### PR DESCRIPTION
We've recently begun to introduce move semantics to `core`, for its performance benefits. Examples of functions that can benefit a lot from move semantics include `SWAP` (#100367), `reduce_at` and `insert` (#100477), and simple data transfer. For more information on motivation, see #100426.