### PR TITLE
Fix `RichTextLabel` bbcode rainbow play reversed and paused

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -413,6 +413,7 @@ private:
 		float saturation = 0.8f;
 		float value = 0.8f;
 		float frequency = 1.0f;
+		float speed = 1.0f;
 
 		ItemRainbow() { type = ITEM_RAINBOW; }
 	};
@@ -716,7 +717,7 @@ public:
 	void push_shake(int p_strength, float p_rate, bool p_connected);
 	void push_wave(float p_frequency, float p_amplitude, bool p_connected);
 	void push_tornado(float p_frequency, float p_radius, bool p_connected);
-	void push_rainbow(float p_saturation, float p_value, float p_frequency);
+	void push_rainbow(float p_saturation, float p_value, float p_frequency, float p_speed);
 	void push_pulse(const Color &p_color, float p_frequency, float p_ease);
 	void push_bgcolor(const Color &p_color);
 	void push_fgcolor(const Color &p_color);


### PR DESCRIPTION
Adds the abillity to pause and reverse the bbcode `rainbow` animation as written in the documentation ([bbcode_in_richtextlabel](https://docs.godotengine.org/en/latest/tutorials/ui/bbcode_in_richtextlabel.html#rainbow))

Adds a new bbcode option:
 `speed` - a negative value will play the animation reversed, a positive value will play the animation forwards, and a value of `0` will pause the animation

I have added the argument `speed` so that it is possible to change the speed independently of the frequency.
Fixes https://github.com/godotengine/godot/issues/85031