### PR TITLE
Core: Add shared constructors for core templates

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -82,12 +82,7 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 Vector<String> ResourceLoader::get_recognized_extensions_for_type(const String &p_type) {
 	List<String> exts;
 	::ResourceLoader::get_recognized_extensions_for_type(p_type, &exts);
-	Vector<String> ret;
-	for (const String &E : exts) {
-		ret.push_back(E);
-	}
-
-	return ret;
+	return Vector<String>(exts);
 }
 
 void ResourceLoader::add_resource_format_loader(Ref<ResourceFormatLoader> p_format_loader, bool p_at_front) {
@@ -105,13 +100,7 @@ void ResourceLoader::set_abort_on_missing_resources(bool p_abort) {
 PackedStringArray ResourceLoader::get_dependencies(const String &p_path) {
 	List<String> deps;
 	::ResourceLoader::get_dependencies(p_path, &deps);
-
-	PackedStringArray ret;
-	for (const String &E : deps) {
-		ret.push_back(E);
-	}
-
-	return ret;
+	return PackedStringArray(deps);
 }
 
 bool ResourceLoader::has_cached(const String &p_path) {
@@ -174,11 +163,7 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 Vector<String> ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource) {
 	List<String> exts;
 	::ResourceSaver::get_recognized_extensions(p_resource, &exts);
-	Vector<String> ret;
-	for (const String &E : exts) {
-		ret.push_back(E);
-	}
-	return ret;
+	return Vector<String>(exts);
 }
 
 void ResourceSaver::add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front) {
@@ -329,13 +314,9 @@ OS::StdHandleType OS::get_stderr_type() const {
 }
 
 int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r_output, bool p_read_stderr, bool p_open_console) {
-	List<String> args;
-	for (const String &arg : p_arguments) {
-		args.push_back(arg);
-	}
 	String pipe;
 	int exitcode = 0;
-	Error err = ::OS::get_singleton()->execute(p_path, args, &pipe, &exitcode, p_read_stderr, nullptr, p_open_console);
+	Error err = ::OS::get_singleton()->execute(p_path, List<String>(p_arguments), &pipe, &exitcode, p_read_stderr, nullptr, p_open_console);
 	// Default array should never be modified, it causes the hash of the method to change.
 	if (!ClassDB::is_default_array_arg(r_output)) {
 		r_output.push_back(pipe);
@@ -347,20 +328,12 @@ int OS::execute(const String &p_path, const Vector<String> &p_arguments, Array r
 }
 
 Dictionary OS::execute_with_pipe(const String &p_path, const Vector<String> &p_arguments, bool p_blocking) {
-	List<String> args;
-	for (const String &arg : p_arguments) {
-		args.push_back(arg);
-	}
-	return ::OS::get_singleton()->execute_with_pipe(p_path, args, p_blocking);
+	return ::OS::get_singleton()->execute_with_pipe(p_path, List<String>(p_arguments), p_blocking);
 }
 
 int OS::create_instance(const Vector<String> &p_arguments) {
-	List<String> args;
-	for (const String &arg : p_arguments) {
-		args.push_back(arg);
-	}
 	::OS::ProcessID pid = 0;
-	Error err = ::OS::get_singleton()->create_instance(args, &pid);
+	Error err = ::OS::get_singleton()->create_instance(List<String>(p_arguments), &pid);
 	if (err != OK) {
 		return -1;
 	}
@@ -368,12 +341,8 @@ int OS::create_instance(const Vector<String> &p_arguments) {
 }
 
 int OS::create_process(const String &p_path, const Vector<String> &p_arguments, bool p_open_console) {
-	List<String> args;
-	for (const String &arg : p_arguments) {
-		args.push_back(arg);
-	}
 	::OS::ProcessID pid = 0;
-	Error err = ::OS::get_singleton()->create_process(p_path, args, &pid, p_open_console);
+	Error err = ::OS::get_singleton()->create_process(p_path, List<String>(p_arguments), &pid, p_open_console);
 	if (err != OK) {
 		return -1;
 	}
@@ -433,32 +402,15 @@ Vector<String> OS::get_video_adapter_driver_info() const {
 }
 
 Vector<String> OS::get_cmdline_args() {
-	List<String> cmdline = ::OS::get_singleton()->get_cmdline_args();
-	Vector<String> cmdlinev;
-	for (const String &E : cmdline) {
-		cmdlinev.push_back(E);
-	}
-
-	return cmdlinev;
+	return Vector<String>(::OS::get_singleton()->get_cmdline_args());
 }
 
 Vector<String> OS::get_cmdline_user_args() {
-	List<String> cmdline = ::OS::get_singleton()->get_cmdline_user_args();
-	Vector<String> cmdlinev;
-	for (const String &E : cmdline) {
-		cmdlinev.push_back(E);
-	}
-
-	return cmdlinev;
+	return Vector<String>(::OS::get_singleton()->get_cmdline_user_args());
 }
 
 void OS::set_restart_on_exit(bool p_restart, const Vector<String> &p_restart_arguments) {
-	List<String> args_list;
-	for (const String &restart_argument : p_restart_arguments) {
-		args_list.push_back(restart_argument);
-	}
-
-	::OS::get_singleton()->set_restart_on_exit(p_restart, args_list);
+	::OS::get_singleton()->set_restart_on_exit(p_restart, List<String>(p_restart_arguments));
 }
 
 bool OS::is_restart_on_exit_set() const {
@@ -466,13 +418,7 @@ bool OS::is_restart_on_exit_set() const {
 }
 
 Vector<String> OS::get_restart_on_exit_arguments() const {
-	List<String> args = ::OS::get_singleton()->get_restart_on_exit_arguments();
-	Vector<String> args_vector;
-	for (List<String>::Element *E = args.front(); E; E = E->next()) {
-		args_vector.push_back(E->get());
-	}
-
-	return args_vector;
+	return Vector<String>(::OS::get_singleton()->get_restart_on_exit_arguments());
 }
 
 String OS::get_locale() const {
@@ -842,139 +788,58 @@ Vector<Point2> Geometry2D::convex_hull(const Vector<Point2> &p_points) {
 }
 
 TypedArray<PackedVector2Array> Geometry2D::decompose_polygon_in_convex(const Vector<Vector2> &p_polygon) {
-	Vector<Vector<Point2>> decomp = ::Geometry2D::decompose_polygon_in_convex(p_polygon);
-
-	TypedArray<PackedVector2Array> ret;
-
-	for (int i = 0; i < decomp.size(); ++i) {
-		ret.push_back(decomp[i]);
-	}
-	return ret;
+	return TypedArray<PackedVector2Array>(::Geometry2D::decompose_polygon_in_convex(p_polygon));
 }
 
 TypedArray<PackedVector2Array> Geometry2D::merge_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::merge_polygons(p_polygon_a, p_polygon_b);
-
-	TypedArray<PackedVector2Array> ret;
-
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
-	}
-	return ret;
+	return TypedArray<PackedVector2Array>(::Geometry2D::merge_polygons(p_polygon_a, p_polygon_b));
 }
 
 TypedArray<PackedVector2Array> Geometry2D::clip_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polygons(p_polygon_a, p_polygon_b);
-
-	TypedArray<PackedVector2Array> ret;
-
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
-	}
-	return ret;
+	return TypedArray<PackedVector2Array>(::Geometry2D::clip_polygons(p_polygon_a, p_polygon_b));
 }
 
 TypedArray<PackedVector2Array> Geometry2D::intersect_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polygons(p_polygon_a, p_polygon_b);
-
-	TypedArray<PackedVector2Array> ret;
-
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
-	}
-	return ret;
+	return TypedArray<PackedVector2Array>(::Geometry2D::intersect_polygons(p_polygon_a, p_polygon_b));
 }
 
 TypedArray<PackedVector2Array> Geometry2D::exclude_polygons(const Vector<Vector2> &p_polygon_a, const Vector<Vector2> &p_polygon_b) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::exclude_polygons(p_polygon_a, p_polygon_b);
-
-	TypedArray<PackedVector2Array> ret;
-
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
-	}
-	return ret;
+	return TypedArray<PackedVector2Array>(::Geometry2D::exclude_polygons(p_polygon_a, p_polygon_b));
 }
 
 TypedArray<PackedVector2Array> Geometry2D::clip_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polyline_with_polygon(p_polyline, p_polygon);
-
-	TypedArray<PackedVector2Array> ret;
-
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
-	}
-	return ret;
+	return TypedArray<PackedVector2Array>(::Geometry2D::clip_polyline_with_polygon(p_polyline, p_polygon));
 }
 
 TypedArray<PackedVector2Array> Geometry2D::intersect_polyline_with_polygon(const Vector<Vector2> &p_polyline, const Vector<Vector2> &p_polygon) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polyline_with_polygon(p_polyline, p_polygon);
-
-	TypedArray<PackedVector2Array> ret;
-
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
-	}
-	return ret;
+	return TypedArray<PackedVector2Array>(::Geometry2D::intersect_polyline_with_polygon(p_polyline, p_polygon));
 }
 
 TypedArray<PackedVector2Array> Geometry2D::offset_polygon(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::offset_polygon(p_polygon, p_delta, ::Geometry2D::PolyJoinType(p_join_type));
-
-	TypedArray<PackedVector2Array> ret;
-
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
-	}
-	return ret;
+	return TypedArray<PackedVector2Array>(::Geometry2D::offset_polygon(p_polygon, p_delta, ::Geometry2D::PolyJoinType(p_join_type)));
 }
 
 TypedArray<PackedVector2Array> Geometry2D::offset_polyline(const Vector<Vector2> &p_polygon, real_t p_delta, PolyJoinType p_join_type, PolyEndType p_end_type) {
-	Vector<Vector<Point2>> polys = ::Geometry2D::offset_polyline(p_polygon, p_delta, ::Geometry2D::PolyJoinType(p_join_type), ::Geometry2D::PolyEndType(p_end_type));
-
-	TypedArray<PackedVector2Array> ret;
-
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
-	}
-	return ret;
+	return TypedArray<PackedVector2Array>(::Geometry2D::offset_polyline(p_polygon, p_delta, ::Geometry2D::PolyJoinType(p_join_type), ::Geometry2D::PolyEndType(p_end_type)));
 }
 
 Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	Dictionary ret;
 
-	Vector<Size2i> rects;
-	for (int i = 0; i < p_rects.size(); i++) {
-		rects.push_back(p_rects[i]);
-	}
-
+	Vector<Size2i> rects = Vector<Size2i>(p_rects);
 	Vector<Point2i> result;
 	Size2i size;
 
 	::Geometry2D::make_atlas(rects, result, size);
 
-	Vector<Point2> r_result;
-	for (int i = 0; i < result.size(); i++) {
-		r_result.push_back(result[i]);
-	}
-
-	ret["points"] = r_result;
+	ret["points"] = Vector<Point2>(result);
 	ret["size"] = size;
 
 	return ret;
 }
 
 TypedArray<Point2i> Geometry2D::bresenham_line(const Point2i &p_from, const Point2i &p_to) {
-	Vector<Point2i> points = ::Geometry2D::bresenham_line(p_from, p_to);
-
-	TypedArray<Point2i> result;
-	result.resize(points.size());
-
-	for (int i = 0; i < points.size(); i++) {
-		result[i] = points[i];
-	}
-
-	return result;
+	return TypedArray<Point2i>(::Geometry2D::bresenham_line(p_from, p_to));
 }
 
 void Geometry2D::_bind_methods() {
@@ -1038,13 +903,8 @@ Geometry3D *Geometry3D::get_singleton() {
 }
 
 Vector<Vector3> Geometry3D::compute_convex_mesh_points(const TypedArray<Plane> &p_planes) {
-	Vector<Plane> planes_vec;
-	int size = p_planes.size();
-	planes_vec.resize(size);
-	for (int i = 0; i < size; ++i) {
-		planes_vec.set(i, p_planes[i]);
-	}
-	Variant ret = ::Geometry3D::compute_convex_mesh_points(planes_vec.ptr(), size);
+	Vector<Plane> planes_vec = Vector<Plane>(p_planes);
+	Variant ret = ::Geometry3D::compute_convex_mesh_points(planes_vec.ptr(), planes_vec.size());
 	return ret;
 }
 
@@ -1428,29 +1288,13 @@ namespace special {
 PackedStringArray ClassDB::get_class_list() const {
 	List<StringName> classes;
 	::ClassDB::get_class_list(&classes);
-
-	PackedStringArray ret;
-	ret.resize(classes.size());
-	int idx = 0;
-	for (const StringName &E : classes) {
-		ret.set(idx++, E);
-	}
-
-	return ret;
+	return PackedStringArray(classes);
 }
 
 PackedStringArray ClassDB::get_inheriters_from_class(const StringName &p_class) const {
 	List<StringName> classes;
 	::ClassDB::get_inheriters_from_class(p_class, &classes);
-
-	PackedStringArray ret;
-	ret.resize(classes.size());
-	int idx = 0;
-	for (const StringName &E : classes) {
-		ret.set(idx++, E);
-	}
-
-	return ret;
+	return PackedStringArray(classes);
 }
 
 StringName ClassDB::get_parent_class(const StringName &p_class) const {
@@ -1604,15 +1448,7 @@ Variant ClassDB::class_call_static(const Variant **p_arguments, int p_argcount, 
 PackedStringArray ClassDB::class_get_integer_constant_list(const StringName &p_class, bool p_no_inheritance) const {
 	List<String> constants;
 	::ClassDB::get_integer_constant_list(p_class, &constants, p_no_inheritance);
-
-	PackedStringArray ret;
-	ret.resize(constants.size());
-	int idx = 0;
-	for (const String &E : constants) {
-		ret.set(idx++, E);
-	}
-
-	return ret;
+	return PackedStringArray(constants);
 }
 
 bool ClassDB::class_has_integer_constant(const StringName &p_class, const StringName &p_name) const {
@@ -1635,29 +1471,13 @@ bool ClassDB::class_has_enum(const StringName &p_class, const StringName &p_name
 PackedStringArray ClassDB::class_get_enum_list(const StringName &p_class, bool p_no_inheritance) const {
 	List<StringName> enums;
 	::ClassDB::get_enum_list(p_class, &enums, p_no_inheritance);
-
-	PackedStringArray ret;
-	ret.resize(enums.size());
-	int idx = 0;
-	for (const StringName &E : enums) {
-		ret.set(idx++, E);
-	}
-
-	return ret;
+	return PackedStringArray(enums);
 }
 
 PackedStringArray ClassDB::class_get_enum_constants(const StringName &p_class, const StringName &p_enum, bool p_no_inheritance) const {
 	List<StringName> constants;
 	::ClassDB::get_enum_constants(p_class, p_enum, &constants, p_no_inheritance);
-
-	PackedStringArray ret;
-	ret.resize(constants.size());
-	int idx = 0;
-	for (const StringName &E : constants) {
-		ret.set(idx++, E);
-	}
-
-	return ret;
+	return PackedStringArray(constants);
 }
 
 StringName ClassDB::class_get_integer_constant_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) const {

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -35,6 +35,11 @@
 #include "core/os/memory.h"
 #include "core/templates/sort_array.h"
 
+template <typename T>
+class Vector;
+template <typename T>
+class TypedArray;
+
 /**
  * Generic Templatized Linked List Implementation.
  * The implementation differs from the STL one because
@@ -763,6 +768,17 @@ public:
 
 	List() {}
 
+	template <typename T_Other>
+	_FORCE_INLINE_ explicit List(const List<T_Other> &p_other) {
+		for (const T_Other &element : p_other) {
+			push_back((T)element);
+		}
+	}
+	_FORCE_INLINE_ explicit List(const Vector<T> &p_vector);
+	template <typename T_Other>
+	_FORCE_INLINE_ explicit List(const Vector<T_Other> &p_vector);
+	_FORCE_INLINE_ explicit List(const TypedArray<std::remove_pointer_t<T>> &p_array);
+
 	~List() {
 		clear();
 		if (_data) {
@@ -807,6 +823,21 @@ void List<T, A>::Element::transfer_to_back(List<T, A> *p_dst_list) {
 
 	data = p_dst_list->_data;
 	p_dst_list->_data->size_cache++;
+}
+
+template <typename T, typename A>
+List<T, A>::List(const Vector<T> &p_vector) {
+	for (const T &element : p_vector) {
+		push_back(element);
+	}
+}
+
+template <typename T, typename A>
+template <typename T_Other>
+List<T, A>::List(const Vector<T_Other> &p_vector) {
+	for (const T_Other &element : p_vector) {
+		push_back((T)element);
+	}
 }
 
 #endif // LIST_H

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -49,6 +49,11 @@
 #include <initializer_list>
 #include <utility>
 
+template <typename T, typename A>
+class List;
+template <typename T>
+class TypedArray;
+
 template <typename T>
 class VectorWriteProxy {
 public:
@@ -293,6 +298,23 @@ public:
 	_FORCE_INLINE_ Vector(Vector &&p_from) :
 			_cowdata(std::move(p_from._cowdata)) {}
 
+	template <typename T_Other>
+	_FORCE_INLINE_ explicit Vector(const Vector<T_Other> &p_other) {
+		// FIXME: `resize()` can cause unnecessary initialization of elements if they are not
+		// trivially destructible. Something like LocalVector's `reserve()` would be better,
+		// but Vector does not support it yet.
+		resize(p_other.size());
+		T *ptr = ptrw();
+		for (const T_Other &element : p_other) {
+			*(ptr++) = (T)element;
+		}
+	}
+	template <typename A = DefaultAllocator>
+	_FORCE_INLINE_ explicit Vector(const List<T, A> &p_list);
+	template <typename T_Other, typename A = DefaultAllocator>
+	_FORCE_INLINE_ explicit Vector(const List<T_Other, A> &p_list);
+	_FORCE_INLINE_ explicit Vector(const TypedArray<std::remove_pointer_t<T>> &p_array);
+
 	_FORCE_INLINE_ ~Vector() {}
 };
 
@@ -331,6 +353,26 @@ void Vector<T>::fill(T p_elem) {
 	T *p = ptrw();
 	for (Size i = 0; i < size(); i++) {
 		p[i] = p_elem;
+	}
+}
+
+template <typename T>
+template <typename A>
+Vector<T>::Vector(const List<T, A> &p_list) {
+	resize(p_list.size());
+	T *ptr = ptrw();
+	for (const T &element : p_list) {
+		*(ptr++) = element;
+	}
+}
+
+template <typename T>
+template <typename T_Other, typename A>
+Vector<T>::Vector(const List<T_Other, A> &p_list) {
+	resize(p_list.size());
+	T *ptr = ptrw();
+	for (const T_Other &element : p_list) {
+		*(ptr++) = (T)element;
 	}
 }
 

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -59,6 +59,23 @@ public:
 	_FORCE_INLINE_ TypedArray() {
 		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
 	}
+
+	_FORCE_INLINE_ explicit TypedArray(const Vector<std::add_pointer_t<T>> &p_vector) {
+		resize(p_vector.size());
+		Array::Iterator itr = begin();
+		for (const std::add_pointer_t<T> &element : p_vector) {
+			*itr = element;
+			++itr;
+		}
+	}
+	_FORCE_INLINE_ explicit TypedArray(const List<std::add_pointer_t<T>> &p_list) {
+		resize(p_list.size());
+		Array::Iterator itr = begin();
+		for (const std::add_pointer_t<T> &element : p_list) {
+			*itr = element;
+			++itr;
+		}
+	}
 };
 
 template <typename T>
@@ -95,6 +112,23 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 		}                                                                                                        \
 		_FORCE_INLINE_ TypedArray() {                                                                            \
 			set_typed(m_variant_type, StringName(), Variant());                                                  \
+		}                                                                                                        \
+                                                                                                                 \
+		_FORCE_INLINE_ explicit TypedArray(const Vector<m_type> &p_vector) {                                     \
+			resize(p_vector.size());                                                                             \
+			Array::Iterator itr = begin();                                                                       \
+			for (const m_type &element : p_vector) {                                                             \
+				*itr = element;                                                                                  \
+				++itr;                                                                                           \
+			}                                                                                                    \
+		}                                                                                                        \
+		_FORCE_INLINE_ explicit TypedArray(const List<m_type> &p_list) {                                         \
+			resize(p_list.size());                                                                               \
+			Array::Iterator itr = begin();                                                                       \
+			for (const m_type &element : p_list) {                                                               \
+				*itr = element;                                                                                  \
+				++itr;                                                                                           \
+			}                                                                                                    \
 		}                                                                                                        \
 	};
 
@@ -251,5 +285,21 @@ MAKE_TYPED_ARRAY_INFO(IPAddress, Variant::STRING)
 
 #undef MAKE_TYPED_ARRAY
 #undef MAKE_TYPED_ARRAY_INFO
+
+template <typename T>
+Vector<T>::Vector(const TypedArray<std::remove_pointer_t<T>> &p_array) {
+	resize(p_array.size());
+	T *ptr = ptrw();
+	for (const Variant &element : p_array) {
+		*(ptr++) = element;
+	}
+}
+
+template <typename T, typename A>
+List<T, A>::List(const TypedArray<std::remove_pointer_t<T>> &p_array) {
+	for (const Variant &element : p_array) {
+		push_back((T)element);
+	}
+}
 
 #endif // TYPED_ARRAY_H

--- a/tests/core/templates/test_list.h
+++ b/tests/core/templates/test_list.h
@@ -543,6 +543,37 @@ TEST_CASE("[Stress][List] Swap random 10 elements, 1000 iterations.") {
 	populate_integers(list, n, 10);
 	swap_random(list, n, 10, 1000);
 }
+
+TEST_CASE("[List] Construct from List of different type") {
+	List<int> list_int;
+	list_int.push_back(1);
+	list_int.push_back(10);
+	list_int.push_back(100);
+	List<float> list_float = List<float>(list_int);
+	CHECK_EQ(list_int.size(), list_float.size());
+	CHECK_EQ(list_int.get(0), list_float.get(0));
+	CHECK_EQ(list_int.get(1), list_float.get(1));
+	CHECK_EQ(list_int.get(2), list_float.get(2));
+}
+
+TEST_CASE("[Vector] Construct from Vector") {
+	Vector<int> vector = { 1, 10, 100 };
+	List<int> list = List<int>(vector);
+	CHECK_EQ(list.size(), vector.size());
+	CHECK_EQ(list.get(0), vector[0]);
+	CHECK_EQ(list.get(1), vector[1]);
+	CHECK_EQ(list.get(2), vector[2]);
+}
+
+TEST_CASE("[Vector] Construct from Vector of different type") {
+	Vector<int> vector_int = { 1, 10, 100 };
+	List<float> list_float = List<float>(vector_int);
+	CHECK_EQ(list_float.size(), vector_int.size());
+	CHECK_EQ(list_float.get(0), vector_int[0]);
+	CHECK_EQ(list_float.get(1), vector_int[1]);
+	CHECK_EQ(list_float.get(2), vector_int[2]);
+}
+
 } // namespace TestList
 
 #endif // TEST_LIST_H

--- a/tests/core/templates/test_vector.h
+++ b/tests/core/templates/test_vector.h
@@ -532,6 +532,39 @@ TEST_CASE("[Vector] Operators") {
 	CHECK(vector != vector_other);
 }
 
+TEST_CASE("[Vector] Construct from Vector of different type") {
+	Vector<int> vector_int = { 1, 10, 100 };
+	Vector<float> vector_float = Vector<float>(vector_int);
+	CHECK_EQ(vector_int.size(), vector_float.size());
+	CHECK_EQ(vector_int.get(0), vector_float[0]);
+	CHECK_EQ(vector_int.get(1), vector_float[1]);
+	CHECK_EQ(vector_int.get(2), vector_float[2]);
+}
+
+TEST_CASE("[Vector] Construct from List") {
+	List<int> list;
+	list.push_back(1);
+	list.push_back(10);
+	list.push_back(100);
+	Vector<int> vector = Vector<int>(list);
+	CHECK_EQ(list.size(), vector.size());
+	CHECK_EQ(list.get(0), vector[0]);
+	CHECK_EQ(list.get(1), vector[1]);
+	CHECK_EQ(list.get(2), vector[2]);
+}
+
+TEST_CASE("[Vector] Construct from List of different type") {
+	List<int> list_int;
+	list_int.push_back(1);
+	list_int.push_back(10);
+	list_int.push_back(100);
+	Vector<float> vector_float = Vector<float>(list_int);
+	CHECK_EQ(list_int.size(), vector_float.size());
+	CHECK_EQ(list_int.get(0), vector_float[0]);
+	CHECK_EQ(list_int.get(1), vector_float[1]);
+	CHECK_EQ(list_int.get(2), vector_float[2]);
+}
+
 } // namespace TestVector
 
 #endif // TEST_VECTOR_H

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -652,6 +652,99 @@ TEST_CASE("[Array] Test rfind_custom") {
 	CHECK_EQ(index, 4);
 }
 
+TEST_CASE("[Array] Typed construction from other types") {
+	Object *obj1 = memnew(Object);
+	Object *obj2 = memnew(Object);
+	Object *obj3 = memnew(Object);
+
+	SUBCASE("To Vector") {
+		TypedArray<int> array_int;
+		array_int.append(1);
+		array_int.append(10);
+		array_int.append(100);
+		Vector<int> vector_int = Vector<int>(array_int);
+		CHECK_EQ(vector_int.size(), array_int.size());
+		// FIXME: Needs explicit casts to workaround error C2593: 'operator ==' is ambiguous
+		CHECK_EQ((int)vector_int[0], (int)array_int[0]);
+		CHECK_EQ((int)vector_int[1], (int)array_int[1]);
+		CHECK_EQ((int)vector_int[2], (int)array_int[2]);
+
+		TypedArray<Object> array_obj;
+		array_obj.append(obj1);
+		array_obj.append(obj2);
+		array_obj.append(obj3);
+		Vector<Object *> vector_obj = Vector<Object *>(array_obj);
+		CHECK_EQ(vector_obj.size(), array_obj.size());
+		CHECK_EQ(vector_obj[0], array_obj[0]);
+		CHECK_EQ(vector_obj[1], array_obj[1]);
+		CHECK_EQ(vector_obj[2], array_obj[2]);
+	}
+
+	SUBCASE("From Vector") {
+		Vector<int> vector_int = { 1, 10, 100 };
+		TypedArray<int> array_int = TypedArray<int>(vector_int);
+		CHECK_EQ(vector_int.size(), array_int.size());
+		CHECK_EQ((int)vector_int[0], (int)array_int[0]);
+		CHECK_EQ((int)vector_int[1], (int)array_int[1]);
+		CHECK_EQ((int)vector_int[2], (int)array_int[2]);
+
+		Vector<Object *> vector_obj = { obj1, obj2, obj3 };
+		TypedArray<Object> array_obj = TypedArray<Object>(vector_obj);
+		CHECK_EQ(vector_obj.size(), array_obj.size());
+		CHECK_EQ(vector_obj[0], array_obj[0]);
+		CHECK_EQ(vector_obj[1], array_obj[1]);
+		CHECK_EQ(vector_obj[2], array_obj[2]);
+	}
+
+	SUBCASE("To List") {
+		TypedArray<int> array_int;
+		array_int.append(1);
+		array_int.append(10);
+		array_int.append(100);
+		Vector<int> list_int = Vector<int>(array_int);
+		CHECK_EQ(list_int.size(), array_int.size());
+		CHECK_EQ((int)list_int.get(0), (int)array_int[0]);
+		CHECK_EQ((int)list_int.get(1), (int)array_int[1]);
+		CHECK_EQ((int)list_int.get(2), (int)array_int[2]);
+
+		TypedArray<Object> array_obj;
+		array_obj.append(obj1);
+		array_obj.append(obj2);
+		array_obj.append(obj3);
+		Vector<Object *> list_obj = Vector<Object *>(array_obj);
+		CHECK_EQ(list_obj.size(), array_obj.size());
+		CHECK_EQ(list_obj.get(0), array_obj[0]);
+		CHECK_EQ(list_obj.get(1), array_obj[1]);
+		CHECK_EQ(list_obj.get(2), array_obj[2]);
+	}
+
+	SUBCASE("From List") {
+		List<int> list_int;
+		list_int.push_back(1);
+		list_int.push_back(10);
+		list_int.push_back(100);
+		TypedArray<int> array_int = TypedArray<int>(list_int);
+		CHECK_EQ(list_int.size(), array_int.size());
+		CHECK_EQ((int)list_int.get(0), (int)array_int[0]);
+		CHECK_EQ((int)list_int.get(1), (int)array_int[1]);
+		CHECK_EQ((int)list_int.get(2), (int)array_int[2]);
+
+		List<Object *> list_obj;
+		list_obj.push_back(obj1);
+		list_obj.push_back(obj2);
+		list_obj.push_back(obj3);
+		TypedArray<Object> array_obj = TypedArray<Object>(list_obj);
+		CHECK_EQ(list_obj.size(), array_obj.size());
+		CHECK_EQ(list_obj.get(0), array_obj[0]);
+		CHECK_EQ(list_obj.get(1), array_obj[1]);
+		CHECK_EQ(list_obj.get(2), array_obj[2]);
+	}
+
+	memfree(obj1);
+	memfree(obj2);
+	memfree(obj3);
+}
+
 } // namespace TestArray
 
 #endif // TEST_ARRAY_H


### PR DESCRIPTION
- Alternative to #96622

Implements conversions to-and-from `TypedArray`, `Vector`, and `List`. Instead of named functions, these conversions are handled via `explicit` constructors. The logic is laid out such that it doesn't require defining both at all times nor a dedicated header that has to be included in every shared `.cpp` file.

Beyond the aforementioned, the main difference in this PR is the ability for `TypedArray` conversions to handle `Object` types. It didn't come up in `core_bind.cpp`, but `(Vector<Object *>)TypedArray<Object>()` wouldn't have worked as expected without the extra `<type_traits>` logic. I could've technically expanded the typing systems to just accept *any* input, but I prefer keeping our functionality explicit, *especially* when we don't currently have a universal means of validating types in a `static_assert` manner.