### PR TITLE
Change navigation map synchronization to an async process

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -562,6 +562,13 @@
 				Returns all navigation regions [RID]s that are currently assigned to the requested navigation [param map].
 			</description>
 		</method>
+		<method name="map_get_use_async_iterations" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="map" type="RID" />
+			<description>
+				Returns [code]true[/code] if the [param map] synchronization uses an async process that runs on a background thread.
+			</description>
+		</method>
 		<method name="map_get_use_edge_connections" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="map" type="RID" />
@@ -606,6 +613,14 @@
 			<param index="1" name="radius" type="float" />
 			<description>
 				Set the map's link connection radius used to connect links to navigation polygons.
+			</description>
+		</method>
+		<method name="map_set_use_async_iterations">
+			<return type="void" />
+			<param index="0" name="map" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				If [param enabled] is [code]true[/code] the [param map] synchronization uses an async process that runs on a background thread.
 			</description>
 		</method>
 		<method name="map_set_use_edge_connections">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -641,6 +641,13 @@
 				Returns the map's up direction.
 			</description>
 		</method>
+		<method name="map_get_use_async_iterations" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="map" type="RID" />
+			<description>
+				Returns [code]true[/code] if the [param map] synchronization uses an async process that runs on a background thread.
+			</description>
+		</method>
 		<method name="map_get_use_edge_connections" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="map" type="RID" />
@@ -709,6 +716,14 @@
 			<param index="1" name="up" type="Vector3" />
 			<description>
 				Sets the map up direction.
+			</description>
+		</method>
+		<method name="map_set_use_async_iterations">
+			<return type="void" />
+			<param index="0" name="map" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				If [param enabled] is [code]true[/code] the [param map] synchronization uses an async process that runs on a background thread.
 			</description>
 		</method>
 		<method name="map_set_use_edge_connections">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2165,6 +2165,9 @@
 		<member name="navigation/pathfinding/max_threads" type="int" setter="" getter="" default="4">
 			Maximum number of threads that can run pathfinding queries simultaneously on the same pathfinding graph, for example the same navigation map. Additional threads increase memory consumption and synchronization time due to the need for extra data copies prepared for each thread. A value of [code]-1[/code] means unlimited and the maximum available OS processor count is used. Defaults to [code]1[/code] when the OS does not support threads.
 		</member>
+		<member name="navigation/world/map_use_async_iterations" type="bool" setter="" getter="" default="true">
+			If enabled, navigation map synchronization uses an async process that runs on a background thread. This avoids stalling the main thread but adds an additional delay to any navigation map change.
+		</member>
 		<member name="network/limits/debugger/max_chars_per_second" type="int" setter="" getter="" default="32768">
 			Maximum number of characters allowed to send as output from the debugger. Over this value, content is dropped. This helps not to stall the debugger connection.
 		</member>

--- a/modules/navigation/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation/2d/godot_navigation_server_2d.cpp
@@ -259,6 +259,14 @@ uint32_t GodotNavigationServer2D::map_get_iteration_id(RID p_map) const {
 	return NavigationServer3D::get_singleton()->map_get_iteration_id(p_map);
 }
 
+void GodotNavigationServer2D::map_set_use_async_iterations(RID p_map, bool p_enabled) {
+	return NavigationServer3D::get_singleton()->map_set_use_async_iterations(p_map, p_enabled);
+}
+
+bool GodotNavigationServer2D::map_get_use_async_iterations(RID p_map) const {
+	return NavigationServer3D::get_singleton()->map_get_use_async_iterations(p_map);
+}
+
 void FORWARD_2(map_set_cell_size, RID, p_map, real_t, p_cell_size, rid_to_rid, real_to_real);
 real_t FORWARD_1_C(map_get_cell_size, RID, p_map, rid_to_rid);
 

--- a/modules/navigation/2d/godot_navigation_server_2d.h
+++ b/modules/navigation/2d/godot_navigation_server_2d.h
@@ -78,6 +78,8 @@ public:
 	virtual void map_force_update(RID p_map) override;
 	virtual Vector2 map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const override;
 	virtual uint32_t map_get_iteration_id(RID p_map) const override;
+	virtual void map_set_use_async_iterations(RID p_map, bool p_enabled) override;
+	virtual bool map_get_use_async_iterations(RID p_map) const override;
 
 	virtual RID region_create() override;
 	virtual void region_set_enabled(RID p_region, bool p_enabled) override;

--- a/modules/navigation/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation/3d/godot_navigation_server_3d.cpp
@@ -364,6 +364,19 @@ RID GodotNavigationServer3D::agent_get_map(RID p_agent) const {
 	return RID();
 }
 
+COMMAND_2(map_set_use_async_iterations, RID, p_map, bool, p_enabled) {
+	NavMap *map = map_owner.get_or_null(p_map);
+	ERR_FAIL_NULL(map);
+	map->set_use_async_iterations(p_enabled);
+}
+
+bool GodotNavigationServer3D::map_get_use_async_iterations(RID p_map) const {
+	const NavMap *map = map_owner.get_or_null(p_map);
+	ERR_FAIL_NULL_V(map, false);
+
+	return map->get_use_async_iterations();
+}
+
 Vector3 GodotNavigationServer3D::map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const {
 	const NavMap *map = map_owner.get_or_null(p_map);
 	ERR_FAIL_NULL_V(map, Vector3());

--- a/modules/navigation/3d/godot_navigation_server_3d.h
+++ b/modules/navigation/3d/godot_navigation_server_3d.h
@@ -147,6 +147,9 @@ public:
 	virtual void map_force_update(RID p_map) override;
 	virtual uint32_t map_get_iteration_id(RID p_map) const override;
 
+	COMMAND_2(map_set_use_async_iterations, RID, p_map, bool, p_enabled);
+	virtual bool map_get_use_async_iterations(RID p_map) const override;
+
 	virtual Vector3 map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const override;
 
 	virtual RID region_create() override;

--- a/modules/navigation/3d/nav_base_iteration_3d.h
+++ b/modules/navigation/3d/nav_base_iteration_3d.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  nav_region.h                                                          */
+/*  nav_base_iteration_3d.h                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,86 +28,21 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef NAV_REGION_H
-#define NAV_REGION_H
+#ifndef NAV_BASE_ITERATION_3D_H
+#define NAV_BASE_ITERATION_3D_H
 
-#include "nav_base.h"
-#include "nav_utils.h"
+#include "servers/navigation/navigation_utilities.h"
 
-#include "core/os/rw_lock.h"
-#include "scene/resources/navigation_mesh.h"
-
-struct NavRegionIteration;
-
-class NavRegion : public NavBase {
-	RWLock region_rwlock;
-
-	NavMap *map = nullptr;
-	Transform3D transform;
+struct NavBaseIteration {
+	uint32_t id = UINT32_MAX;
 	bool enabled = true;
-
-	bool use_edge_connections = true;
-
-	bool polygons_dirty = true;
-
-	LocalVector<gd::Polygon> navmesh_polygons;
-
-	real_t surface_area = 0.0;
-	AABB bounds;
-
-	RWLock navmesh_rwlock;
-	Vector<Vector3> pending_navmesh_vertices;
-	Vector<Vector<int>> pending_navmesh_polygons;
-
-	SelfList<NavRegion> sync_dirty_request_list_element;
-
-public:
-	NavRegion();
-	~NavRegion();
-
-	void scratch_polygons() {
-		polygons_dirty = true;
-	}
-
-	void set_enabled(bool p_enabled);
-	bool get_enabled() const { return enabled; }
-
-	void set_map(NavMap *p_map);
-	NavMap *get_map() const {
-		return map;
-	}
-
-	void set_use_edge_connections(bool p_enabled);
-	bool get_use_edge_connections() const {
-		return use_edge_connections;
-	}
-
-	void set_transform(Transform3D transform);
-	const Transform3D &get_transform() const {
-		return transform;
-	}
-
-	void set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh);
-
-	LocalVector<gd::Polygon> const &get_polygons() const {
-		return navmesh_polygons;
-	}
-
-	Vector3 get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, bool p_use_collision) const;
-	gd::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
-	Vector3 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
-
-	real_t get_surface_area() const { return surface_area; }
-	AABB get_bounds() const { return bounds; }
-
-	bool sync();
-	void request_sync();
-	void cancel_sync_request();
-
-	void get_iteration_update(NavRegionIteration &r_iteration);
-
-private:
-	void update_polygons();
+	uint32_t navigation_layers = 1;
+	real_t enter_cost = 0.0;
+	real_t travel_cost = 1.0;
+	NavigationUtilities::PathSegmentType owner_type;
+	ObjectID owner_object_id;
+	RID owner_rid;
+	bool owner_use_edge_connections = false;
 };
 
-#endif // NAV_REGION_H
+#endif // NAV_BASE_ITERATION_3D_H

--- a/modules/navigation/3d/nav_map_builder_3d.cpp
+++ b/modules/navigation/3d/nav_map_builder_3d.cpp
@@ -1,0 +1,399 @@
+/**************************************************************************/
+/*  nav_map_builder_3d.cpp                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef _3D_DISABLED
+
+#include "nav_map_builder_3d.h"
+
+#include "../nav_link.h"
+#include "../nav_map.h"
+#include "../nav_region.h"
+#include "nav_map_iteration_3d.h"
+#include "nav_region_iteration_3d.h"
+
+gd::PointKey NavMapBuilder3D::get_point_key(const Vector3 &p_pos, const Vector3 &p_cell_size) {
+	const int x = static_cast<int>(Math::floor(p_pos.x / p_cell_size.x));
+	const int y = static_cast<int>(Math::floor(p_pos.y / p_cell_size.y));
+	const int z = static_cast<int>(Math::floor(p_pos.z / p_cell_size.z));
+
+	gd::PointKey p;
+	p.key = 0;
+	p.x = x;
+	p.y = y;
+	p.z = z;
+	return p;
+}
+
+void NavMapBuilder3D::build_navmap_iteration(NavMapIterationBuild &r_build) {
+	_build_step_gather_region_polygons(r_build);
+
+	_build_step_find_edge_connection_pairs(r_build);
+
+	_build_step_merge_edge_connection_pairs(r_build);
+
+	_build_step_edge_connection_margin_connections(r_build);
+
+	_build_step_navlink_connections(r_build);
+
+	_build_update_map_iteration(r_build);
+}
+
+void NavMapBuilder3D::_build_step_gather_region_polygons(NavMapIterationBuild &r_build) {
+	NavMapIteration *map_iteration = r_build.map_iteration;
+	gd::PerformanceData &performance_data = r_build.performance_data;
+	int polygon_count = r_build.polygon_count;
+	int navmesh_polygon_count = r_build.navmesh_polygon_count;
+
+	// Remove regions connections.
+	map_iteration->external_region_connections.clear();
+	for (const NavRegionIteration &region : map_iteration->region_iterations) {
+		map_iteration->external_region_connections[region.id] = LocalVector<gd::Edge::Connection>();
+	}
+
+	polygon_count = 0;
+	navmesh_polygon_count = 0;
+	for (NavRegionIteration &region : map_iteration->region_iterations) {
+		for (gd::Polygon &region_polygon : region.navmesh_polygons) {
+			region_polygon.id = polygon_count;
+			region_polygon.owner = &region;
+
+			polygon_count++;
+			navmesh_polygon_count++;
+		}
+	}
+
+	performance_data.pm_polygon_count = polygon_count;
+	r_build.polygon_count = polygon_count;
+	r_build.navmesh_polygon_count = navmesh_polygon_count;
+}
+
+void NavMapBuilder3D::_build_step_find_edge_connection_pairs(NavMapIterationBuild &r_build) {
+	NavMapIteration *map_iteration = r_build.map_iteration;
+	HashMap<gd::EdgeKey, gd::EdgeConnectionPair, gd::EdgeKey> &iter_connection_pairs_map = r_build.iter_connection_pairs_map;
+	gd::PerformanceData &performance_data = r_build.performance_data;
+	int free_edge_count = r_build.free_edge_count;
+
+	iter_connection_pairs_map.clear();
+	iter_connection_pairs_map.reserve(map_iteration->region_iterations.size());
+
+	for (NavRegionIteration &region : map_iteration->region_iterations) {
+		for (gd::Polygon &region_polygon : region.navmesh_polygons) {
+			for (uint32_t p = 0; p < region_polygon.points.size(); p++) {
+				const int next_point = (p + 1) % region_polygon.points.size();
+				const gd::EdgeKey ek(region_polygon.points[p].key, region_polygon.points[next_point].key);
+
+				HashMap<gd::EdgeKey, gd::EdgeConnectionPair, gd::EdgeKey>::Iterator pair_it = iter_connection_pairs_map.find(ek);
+				if (!pair_it) {
+					pair_it = iter_connection_pairs_map.insert(ek, gd::EdgeConnectionPair());
+					performance_data.pm_edge_count += 1;
+					++free_edge_count;
+				}
+				gd::EdgeConnectionPair &pair = pair_it->value;
+				if (pair.size < 2) {
+					pair.connections[pair.size].polygon = &region_polygon;
+					pair.connections[pair.size].edge = p;
+					pair.connections[pair.size].pathway_start = region_polygon.points[p].pos;
+					pair.connections[pair.size].pathway_end = region_polygon.points[next_point].pos;
+					++pair.size;
+					if (pair.size == 2) {
+						--free_edge_count;
+					}
+
+				} else {
+					// The edge is already connected with another edge, skip.
+					ERR_PRINT_ONCE("Navigation map synchronization error. Attempted to merge a navigation mesh polygon edge with another already-merged edge. This is usually caused by crossing edges, overlapping polygons, or a mismatch of the NavigationMesh / NavigationPolygon baked 'cell_size' and navigation map 'cell_size'. If you're certain none of above is the case, change 'navigation/3d/merge_rasterizer_cell_scale' to 0.001.");
+				}
+			}
+		}
+	}
+	r_build.free_edge_count = free_edge_count;
+}
+
+void NavMapBuilder3D::_build_step_merge_edge_connection_pairs(NavMapIterationBuild &r_build) {
+	HashMap<gd::EdgeKey, gd::EdgeConnectionPair, gd::EdgeKey> &iter_connection_pairs_map = r_build.iter_connection_pairs_map;
+	LocalVector<gd::Edge::Connection> &iter_free_edges = r_build.iter_free_edges;
+	bool use_edge_connections = r_build.use_edge_connections;
+	gd::PerformanceData &performance_data = r_build.performance_data;
+
+	iter_free_edges.clear();
+	iter_free_edges.resize(r_build.free_edge_count);
+	uint32_t iter_free_edge_index = 0;
+
+	for (const KeyValue<gd::EdgeKey, gd::EdgeConnectionPair> &pair_it : iter_connection_pairs_map) {
+		const gd::EdgeConnectionPair &pair = pair_it.value;
+
+		if (pair.size == 2) {
+			// Connect edge that are shared in different polygons.
+			const gd::Edge::Connection &c1 = pair.connections[0];
+			const gd::Edge::Connection &c2 = pair.connections[1];
+			c1.polygon->edges[c1.edge].connections.push_back(c2);
+			c2.polygon->edges[c2.edge].connections.push_back(c1);
+			// Note: The pathway_start/end are full for those connection and do not need to be modified.
+			performance_data.pm_edge_merge_count += 1;
+		} else {
+			CRASH_COND_MSG(pair.size != 1, vformat("Number of connection != 1. Found: %d", pair.size));
+			if (use_edge_connections && pair.connections[0].polygon->owner->owner_use_edge_connections) {
+				iter_free_edges[iter_free_edge_index++] = pair.connections[0];
+			}
+		}
+	}
+
+	iter_free_edges.resize(iter_free_edge_index);
+}
+
+void NavMapBuilder3D::_build_step_edge_connection_margin_connections(NavMapIterationBuild &r_build) {
+	NavMapIteration *map_iteration = r_build.map_iteration;
+	const LocalVector<gd::Edge::Connection> &iter_free_edges = r_build.iter_free_edges;
+	bool use_edge_connections = r_build.use_edge_connections;
+	gd::PerformanceData &performance_data = r_build.performance_data;
+	const real_t edge_connection_margin = r_build.edge_connection_margin;
+	// Find the compatible near edges.
+	//
+	// Note:
+	// Considering that the edges must be compatible (for obvious reasons)
+	// to be connected, create new polygons to remove that small gap is
+	// not really useful and would result in wasteful computation during
+	// connection, integration and path finding.
+
+	performance_data.pm_edge_free_count = iter_free_edges.size();
+
+	if (!use_edge_connections) {
+		return;
+	}
+
+	const real_t edge_connection_margin_squared = edge_connection_margin * edge_connection_margin;
+
+	for (uint32_t i = 0; i < iter_free_edges.size(); i++) {
+		const gd::Edge::Connection &free_edge = iter_free_edges[i];
+
+		Vector3 edge_p1 = free_edge.polygon->points[free_edge.edge].pos;
+		Vector3 edge_p2 = free_edge.polygon->points[(free_edge.edge + 1) % free_edge.polygon->points.size()].pos;
+
+		Vector3 edge_vector = edge_p2 - edge_p1;
+		real_t edge_vector_length_squared = edge_vector.length_squared();
+
+		for (uint32_t j = 0; j < iter_free_edges.size(); j++) {
+			const gd::Edge::Connection &other_edge = iter_free_edges[j];
+			if (i == j || free_edge.polygon->owner == other_edge.polygon->owner) {
+				continue;
+			}
+
+			Vector3 other_edge_p1 = other_edge.polygon->points[other_edge.edge].pos;
+			Vector3 other_edge_p2 = other_edge.polygon->points[(other_edge.edge + 1) % other_edge.polygon->points.size()].pos;
+
+			// Compute the projection of the opposite edge on the current one
+			real_t projected_p1_ratio = edge_vector.dot(other_edge_p1 - edge_p1) / (edge_vector_length_squared);
+			real_t projected_p2_ratio = edge_vector.dot(other_edge_p2 - edge_p1) / (edge_vector_length_squared);
+			if ((projected_p1_ratio < 0.0 && projected_p2_ratio < 0.0) || (projected_p1_ratio > 1.0 && projected_p2_ratio > 1.0)) {
+				continue;
+			}
+
+			// Check if the two edges are close to each other enough and compute a pathway between the two regions.
+			Vector3 self1 = edge_vector * CLAMP(projected_p1_ratio, 0.0, 1.0) + edge_p1;
+			Vector3 other1;
+			if (projected_p1_ratio >= 0.0 && projected_p1_ratio <= 1.0) {
+				other1 = other_edge_p1;
+			} else {
+				other1 = other_edge_p1.lerp(other_edge_p2, (1.0 - projected_p1_ratio) / (projected_p2_ratio - projected_p1_ratio));
+			}
+			if (other1.distance_squared_to(self1) > edge_connection_margin_squared) {
+				continue;
+			}
+
+			Vector3 self2 = edge_vector * CLAMP(projected_p2_ratio, 0.0, 1.0) + edge_p1;
+			Vector3 other2;
+			if (projected_p2_ratio >= 0.0 && projected_p2_ratio <= 1.0) {
+				other2 = other_edge_p2;
+			} else {
+				other2 = other_edge_p1.lerp(other_edge_p2, (0.0 - projected_p1_ratio) / (projected_p2_ratio - projected_p1_ratio));
+			}
+			if (other2.distance_squared_to(self2) > edge_connection_margin_squared) {
+				continue;
+			}
+
+			// The edges can now be connected.
+			gd::Edge::Connection new_connection = other_edge;
+			new_connection.pathway_start = (self1 + other1) / 2.0;
+			new_connection.pathway_end = (self2 + other2) / 2.0;
+			free_edge.polygon->edges[free_edge.edge].connections.push_back(new_connection);
+
+			// Add the connection to the region_connection map.
+			map_iteration->external_region_connections[(uint32_t)free_edge.polygon->owner->id].push_back(new_connection);
+			performance_data.pm_edge_connection_count += 1;
+		}
+	}
+}
+
+void NavMapBuilder3D::_build_step_navlink_connections(NavMapIterationBuild &r_build) {
+	NavMapIteration *map_iteration = r_build.map_iteration;
+	const Vector3 &merge_rasterizer_cell_size = r_build.merge_rasterizer_cell_size;
+	real_t link_connection_radius = r_build.link_connection_radius;
+	real_t link_connection_radius_sqr = link_connection_radius * link_connection_radius;
+	int polygon_count = r_build.polygon_count;
+	int link_polygon_count = r_build.link_polygon_count;
+
+	// Search for polygons within range of a nav link.
+	for (NavLinkIteration &link : map_iteration->link_iterations) {
+		if (!link.enabled) {
+			continue;
+		}
+		const Vector3 link_start_pos = link.start_position;
+		const Vector3 link_end_pos = link.end_position;
+
+		gd::Polygon *closest_start_polygon = nullptr;
+		real_t closest_start_sqr_dist = link_connection_radius_sqr;
+		Vector3 closest_start_point;
+
+		gd::Polygon *closest_end_polygon = nullptr;
+		real_t closest_end_sqr_dist = link_connection_radius_sqr;
+		Vector3 closest_end_point;
+
+		for (NavRegionIteration &region : map_iteration->region_iterations) {
+			AABB region_bounds = region.bounds.grow(link_connection_radius);
+			if (!region_bounds.has_point(link_start_pos) && !region_bounds.has_point(link_end_pos)) {
+				continue;
+			}
+			for (gd::Polygon &polyon : region.navmesh_polygons) {
+				for (uint32_t point_id = 2; point_id < polyon.points.size(); point_id += 1) {
+					const Face3 face(polyon.points[0].pos, polyon.points[point_id - 1].pos, polyon.points[point_id].pos);
+
+					{
+						const Vector3 start_point = face.get_closest_point_to(link_start_pos);
+						const real_t sqr_dist = start_point.distance_squared_to(link_start_pos);
+
+						// Pick the polygon that is within our radius and is closer than anything we've seen yet.
+						if (sqr_dist < closest_start_sqr_dist) {
+							closest_start_sqr_dist = sqr_dist;
+							closest_start_point = start_point;
+							closest_start_polygon = &polyon;
+						}
+					}
+
+					{
+						const Vector3 end_point = face.get_closest_point_to(link_end_pos);
+						const real_t sqr_dist = end_point.distance_squared_to(link_end_pos);
+
+						// Pick the polygon that is within our radius and is closer than anything we've seen yet.
+						if (sqr_dist < closest_end_sqr_dist) {
+							closest_end_sqr_dist = sqr_dist;
+							closest_end_point = end_point;
+							closest_end_polygon = &polyon;
+						}
+					}
+				}
+			}
+		}
+
+		// If we have both a start and end point, then create a synthetic polygon to route through.
+		if (closest_start_polygon && closest_end_polygon) {
+			link.navmesh_polygons.resize(1);
+			gd::Polygon &new_polygon = link.navmesh_polygons[0];
+			new_polygon.id = polygon_count++;
+			new_polygon.owner = &link;
+
+			link_polygon_count++;
+
+			new_polygon.edges.clear();
+			new_polygon.edges.resize(4);
+			new_polygon.points.resize(4);
+
+			// Build a set of vertices that create a thin polygon going from the start to the end point.
+			new_polygon.points[0] = { closest_start_point, get_point_key(closest_start_point, merge_rasterizer_cell_size) };
+			new_polygon.points[1] = { closest_start_point, get_point_key(closest_start_point, merge_rasterizer_cell_size) };
+			new_polygon.points[2] = { closest_end_point, get_point_key(closest_end_point, merge_rasterizer_cell_size) };
+			new_polygon.points[3] = { closest_end_point, get_point_key(closest_end_point, merge_rasterizer_cell_size) };
+
+			// Setup connections to go forward in the link.
+			{
+				gd::Edge::Connection entry_connection;
+				entry_connection.polygon = &new_polygon;
+				entry_connection.edge = -1;
+				entry_connection.pathway_start = new_polygon.points[0].pos;
+				entry_connection.pathway_end = new_polygon.points[1].pos;
+				closest_start_polygon->edges[0].connections.push_back(entry_connection);
+
+				gd::Edge::Connection exit_connection;
+				exit_connection.polygon = closest_end_polygon;
+				exit_connection.edge = -1;
+				exit_connection.pathway_start = new_polygon.points[2].pos;
+				exit_connection.pathway_end = new_polygon.points[3].pos;
+				new_polygon.edges[2].connections.push_back(exit_connection);
+			}
+
+			// If the link is bi-directional, create connections from the end to the start.
+			if (link.bidirectional) {
+				gd::Edge::Connection entry_connection;
+				entry_connection.polygon = &new_polygon;
+				entry_connection.edge = -1;
+				entry_connection.pathway_start = new_polygon.points[2].pos;
+				entry_connection.pathway_end = new_polygon.points[3].pos;
+				closest_end_polygon->edges[0].connections.push_back(entry_connection);
+
+				gd::Edge::Connection exit_connection;
+				exit_connection.polygon = closest_start_polygon;
+				exit_connection.edge = -1;
+				exit_connection.pathway_start = new_polygon.points[0].pos;
+				exit_connection.pathway_end = new_polygon.points[1].pos;
+				new_polygon.edges[0].connections.push_back(exit_connection);
+			}
+		}
+	}
+
+	r_build.polygon_count = polygon_count;
+	r_build.link_polygon_count = link_polygon_count;
+}
+
+void NavMapBuilder3D::_build_update_map_iteration(NavMapIterationBuild &r_build) {
+	NavMapIteration *map_iteration = r_build.map_iteration;
+
+	map_iteration->navmesh_polygon_count = r_build.navmesh_polygon_count;
+	map_iteration->link_polygon_count = r_build.link_polygon_count;
+
+	// TODO: This copying is for compatibility with legacy functions that expect a big polygon soup array.
+	// Those functions should be changed to work hierarchical with the region iteration polygons directly.
+	map_iteration->navmesh_polygons.resize(map_iteration->navmesh_polygon_count);
+	uint32_t polygon_index = 0;
+	for (NavRegionIteration &region : map_iteration->region_iterations) {
+		for (gd::Polygon &region_polygon : region.navmesh_polygons) {
+			map_iteration->navmesh_polygons[polygon_index++] = region_polygon;
+		}
+	}
+
+	map_iteration->path_query_slots_mutex.lock();
+	for (NavMeshQueries3D::PathQuerySlot &p_path_query_slot : map_iteration->path_query_slots) {
+		p_path_query_slot.path_corridor.clear();
+		p_path_query_slot.path_corridor.resize(map_iteration->navmesh_polygon_count + map_iteration->link_polygon_count);
+		p_path_query_slot.traversable_polys.clear();
+		p_path_query_slot.traversable_polys.reserve(map_iteration->navmesh_polygon_count * 0.25);
+	}
+	map_iteration->path_query_slots_mutex.unlock();
+}
+
+#endif // _3D_DISABLED

--- a/modules/navigation/3d/nav_map_builder_3d.h
+++ b/modules/navigation/3d/nav_map_builder_3d.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  nav_region.h                                                          */
+/*  nav_map_builder_3d.h                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,86 +28,25 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef NAV_REGION_H
-#define NAV_REGION_H
+#ifndef NAV_MAP_BUILDER_3D_H
+#define NAV_MAP_BUILDER_3D_H
 
-#include "nav_base.h"
-#include "nav_utils.h"
+#include "../nav_utils.h"
 
-#include "core/os/rw_lock.h"
-#include "scene/resources/navigation_mesh.h"
+struct NavMapIterationBuild;
 
-struct NavRegionIteration;
-
-class NavRegion : public NavBase {
-	RWLock region_rwlock;
-
-	NavMap *map = nullptr;
-	Transform3D transform;
-	bool enabled = true;
-
-	bool use_edge_connections = true;
-
-	bool polygons_dirty = true;
-
-	LocalVector<gd::Polygon> navmesh_polygons;
-
-	real_t surface_area = 0.0;
-	AABB bounds;
-
-	RWLock navmesh_rwlock;
-	Vector<Vector3> pending_navmesh_vertices;
-	Vector<Vector<int>> pending_navmesh_polygons;
-
-	SelfList<NavRegion> sync_dirty_request_list_element;
+class NavMapBuilder3D {
+	static void _build_step_gather_region_polygons(NavMapIterationBuild &r_build);
+	static void _build_step_find_edge_connection_pairs(NavMapIterationBuild &r_build);
+	static void _build_step_merge_edge_connection_pairs(NavMapIterationBuild &r_build);
+	static void _build_step_edge_connection_margin_connections(NavMapIterationBuild &r_build);
+	static void _build_step_navlink_connections(NavMapIterationBuild &r_build);
+	static void _build_update_map_iteration(NavMapIterationBuild &r_build);
 
 public:
-	NavRegion();
-	~NavRegion();
+	static gd::PointKey get_point_key(const Vector3 &p_pos, const Vector3 &p_cell_size);
 
-	void scratch_polygons() {
-		polygons_dirty = true;
-	}
-
-	void set_enabled(bool p_enabled);
-	bool get_enabled() const { return enabled; }
-
-	void set_map(NavMap *p_map);
-	NavMap *get_map() const {
-		return map;
-	}
-
-	void set_use_edge_connections(bool p_enabled);
-	bool get_use_edge_connections() const {
-		return use_edge_connections;
-	}
-
-	void set_transform(Transform3D transform);
-	const Transform3D &get_transform() const {
-		return transform;
-	}
-
-	void set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh);
-
-	LocalVector<gd::Polygon> const &get_polygons() const {
-		return navmesh_polygons;
-	}
-
-	Vector3 get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, bool p_use_collision) const;
-	gd::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
-	Vector3 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
-
-	real_t get_surface_area() const { return surface_area; }
-	AABB get_bounds() const { return bounds; }
-
-	bool sync();
-	void request_sync();
-	void cancel_sync_request();
-
-	void get_iteration_update(NavRegionIteration &r_iteration);
-
-private:
-	void update_polygons();
+	static void build_navmap_iteration(NavMapIterationBuild &r_build);
 };
 
-#endif // NAV_REGION_H
+#endif // NAV_MAP_BUILDER_3D_H

--- a/modules/navigation/3d/nav_map_iteration_3d.h
+++ b/modules/navigation/3d/nav_map_iteration_3d.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  nav_region.h                                                          */
+/*  nav_map_iteration_3d.h                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,86 +28,87 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef NAV_REGION_H
-#define NAV_REGION_H
+#ifndef NAV_MAP_ITERATION_3D_H
+#define NAV_MAP_ITERATION_3D_H
 
-#include "nav_base.h"
-#include "nav_utils.h"
+#include "../nav_rid.h"
+#include "../nav_utils.h"
+#include "nav_mesh_queries_3d.h"
 
-#include "core/os/rw_lock.h"
-#include "scene/resources/navigation_mesh.h"
+#include "core/math/math_defs.h"
+#include "core/os/semaphore.h"
 
+struct NavLinkIteration;
+class NavRegion;
 struct NavRegionIteration;
+struct NavMapIteration;
 
-class NavRegion : public NavBase {
-	RWLock region_rwlock;
-
-	NavMap *map = nullptr;
-	Transform3D transform;
-	bool enabled = true;
-
+struct NavMapIterationBuild {
+	Vector3 merge_rasterizer_cell_size;
 	bool use_edge_connections = true;
+	real_t edge_connection_margin;
+	real_t link_connection_radius;
+	gd::PerformanceData performance_data;
+	int polygon_count = 0;
+	int free_edge_count = 0;
 
-	bool polygons_dirty = true;
+	HashMap<gd::EdgeKey, gd::EdgeConnectionPair, gd::EdgeKey> iter_connection_pairs_map;
+	LocalVector<gd::Edge::Connection> iter_free_edges;
 
-	LocalVector<gd::Polygon> navmesh_polygons;
+	NavMapIteration *map_iteration = nullptr;
 
-	real_t surface_area = 0.0;
-	AABB bounds;
+	int navmesh_polygon_count = 0;
+	int link_polygon_count = 0;
 
-	RWLock navmesh_rwlock;
-	Vector<Vector3> pending_navmesh_vertices;
-	Vector<Vector<int>> pending_navmesh_polygons;
+	void reset() {
+		performance_data.reset();
 
-	SelfList<NavRegion> sync_dirty_request_list_element;
+		iter_connection_pairs_map.clear();
+		iter_free_edges.clear();
+		polygon_count = 0;
+		free_edge_count = 0;
 
-public:
-	NavRegion();
-	~NavRegion();
-
-	void scratch_polygons() {
-		polygons_dirty = true;
+		navmesh_polygon_count = 0;
+		link_polygon_count = 0;
 	}
-
-	void set_enabled(bool p_enabled);
-	bool get_enabled() const { return enabled; }
-
-	void set_map(NavMap *p_map);
-	NavMap *get_map() const {
-		return map;
-	}
-
-	void set_use_edge_connections(bool p_enabled);
-	bool get_use_edge_connections() const {
-		return use_edge_connections;
-	}
-
-	void set_transform(Transform3D transform);
-	const Transform3D &get_transform() const {
-		return transform;
-	}
-
-	void set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh);
-
-	LocalVector<gd::Polygon> const &get_polygons() const {
-		return navmesh_polygons;
-	}
-
-	Vector3 get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, bool p_use_collision) const;
-	gd::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
-	Vector3 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
-
-	real_t get_surface_area() const { return surface_area; }
-	AABB get_bounds() const { return bounds; }
-
-	bool sync();
-	void request_sync();
-	void cancel_sync_request();
-
-	void get_iteration_update(NavRegionIteration &r_iteration);
-
-private:
-	void update_polygons();
 };
 
-#endif // NAV_REGION_H
+struct NavMapIteration {
+	mutable SafeNumeric<uint32_t> users;
+	RWLock rwlock;
+
+	Vector3 map_up;
+	LocalVector<gd::Polygon> navmesh_polygons;
+
+	LocalVector<NavRegionIteration> region_iterations;
+	LocalVector<NavLinkIteration> link_iterations;
+
+	int navmesh_polygon_count = 0;
+	int link_polygon_count = 0;
+
+	// The edge connections that the map builds on top with the edge connection margin.
+	HashMap<uint32_t, LocalVector<gd::Edge::Connection>> external_region_connections;
+
+	HashMap<NavRegion *, uint32_t> region_ptr_to_region_id;
+
+	LocalVector<NavMeshQueries3D::PathQuerySlot> path_query_slots;
+	Mutex path_query_slots_mutex;
+	Semaphore path_query_slots_semaphore;
+};
+
+class NavMapIterationRead {
+	const NavMapIteration &map_iteration;
+
+public:
+	_ALWAYS_INLINE_ NavMapIterationRead(const NavMapIteration &p_iteration) :
+			map_iteration(p_iteration) {
+		map_iteration.rwlock.read_lock();
+		map_iteration.users.increment();
+	}
+	_ALWAYS_INLINE_ ~NavMapIterationRead() {
+		map_iteration.users.decrement();
+		map_iteration.rwlock.read_unlock();
+	}
+};
+
+#endif // NAV_MAP_ITERATION_3D_H

--- a/modules/navigation/3d/nav_mesh_queries_3d.h
+++ b/modules/navigation/3d/nav_mesh_queries_3d.h
@@ -74,10 +74,15 @@ public:
 		// Path building.
 		Vector3 begin_position;
 		Vector3 end_position;
+		const gd::Polygon *begin_polygon = nullptr;
+		const gd::Polygon *end_polygon = nullptr;
 		uint32_t least_cost_id = 0;
+
+		// Map.
 		Vector3 map_up;
 		NavMap *map = nullptr;
 		PathQuerySlot *path_query_slot = nullptr;
+		uint32_t link_polygons_size = 0;
 
 		// Path points.
 		LocalVector<Vector3> path_points;
@@ -103,17 +108,15 @@ public:
 
 	static void map_query_path(NavMap *map, const Ref<NavigationPathQueryParameters3D> &p_query_parameters, Ref<NavigationPathQueryResult3D> p_query_result, const Callable &p_callback);
 
-	static void query_task_polygons_get_path(NavMeshPathQueryTask3D &p_query_task, const LocalVector<gd::Polygon> &p_polygons, const Vector3 &p_map_up, uint32_t p_link_polygons_size);
-
-	static void _query_task_create_same_polygon_two_point_path(NavMeshPathQueryTask3D &p_query_task, const gd::Polygon *begin_poly, Vector3 begin_point, const gd::Polygon *end_poly, Vector3 end_point);
-	static void _query_task_push_back_point_with_metadata(NavMeshPathQueryTask3D &p_query_task, Vector3 p_point, const gd::Polygon *p_point_polygon);
-	static void _query_task_find_start_end_positions(NavMeshPathQueryTask3D &p_query_task, const LocalVector<gd::Polygon> &p_polygons, const gd::Polygon **r_begin_poly, Vector3 &r_begin_point, const gd::Polygon **r_end_poly, Vector3 &r_end_point);
-	static void _query_task_build_path_corridor(NavMeshPathQueryTask3D &p_query_task, const LocalVector<gd::Polygon> &p_polygons, const Vector3 &p_map_up, uint32_t p_link_polygons_size, const gd::Polygon *begin_poly, Vector3 begin_point, const gd::Polygon *end_polygon, Vector3 end_point);
-	static void _path_corridor_post_process_corridorfunnel(NavMeshPathQueryTask3D &p_query_task, int p_least_cost_id, const gd::Polygon *p_begin_poly, Vector3 p_begin_point, const gd::Polygon *p_end_polygon, Vector3 p_end_point, const Vector3 &p_map_up);
-	static void _path_corridor_post_process_edgecentered(NavMeshPathQueryTask3D &p_query_task, int p_least_cost_id, const gd::Polygon *p_begin_poly, Vector3 p_begin_point, const gd::Polygon *p_end_polygon, Vector3 p_end_point);
-	static void _path_corridor_post_process_nopostprocessing(NavMeshPathQueryTask3D &p_query_task, int p_least_cost_id, const gd::Polygon *p_begin_poly, Vector3 p_begin_point, const gd::Polygon *p_end_polygon, Vector3 p_end_point);
-
-	static void clip_path(NavMeshPathQueryTask3D &p_query_task, const LocalVector<gd::NavigationPoly> &p_navigation_polys, const gd::NavigationPoly *from_poly, const Vector3 &p_to_point, const gd::NavigationPoly *p_to_poly, const Vector3 &p_map_up);
+	static void query_task_polygons_get_path(NavMeshPathQueryTask3D &p_query_task, const LocalVector<gd::Polygon> &p_polygons);
+	static void _query_task_create_same_polygon_two_point_path(NavMeshPathQueryTask3D &p_query_task, const gd::Polygon *p_begin_polygon, const gd::Polygon *p_end_polygon);
+	static void _query_task_push_back_point_with_metadata(NavMeshPathQueryTask3D &p_query_task, const Vector3 &p_point, const gd::Polygon *p_point_polygon);
+	static void _query_task_find_start_end_positions(NavMeshPathQueryTask3D &p_query_task, const LocalVector<gd::Polygon> &p_polygons);
+	static void _query_task_build_path_corridor(NavMeshPathQueryTask3D &p_query_task, const LocalVector<gd::Polygon> &p_polygons);
+	static void _query_task_post_process_corridorfunnel(NavMeshPathQueryTask3D &p_query_task);
+	static void _query_task_post_process_edgecentered(NavMeshPathQueryTask3D &p_query_task);
+	static void _query_task_post_process_nopostprocessing(NavMeshPathQueryTask3D &p_query_task);
+	static void _query_task_clip_path(NavMeshPathQueryTask3D &p_query_task, const gd::NavigationPoly *from_poly, const Vector3 &p_to_point, const gd::NavigationPoly *p_to_poly);
 	static void _query_task_simplified_path_points(NavMeshPathQueryTask3D &p_query_task);
 
 	static void simplify_path_segment(int p_start_inx, int p_end_inx, const LocalVector<Vector3> &p_points, real_t p_epsilon, LocalVector<uint32_t> &r_simplified_path_indices);

--- a/modules/navigation/3d/nav_region_iteration_3d.h
+++ b/modules/navigation/3d/nav_region_iteration_3d.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  nav_region.h                                                          */
+/*  nav_region_iteration_3d.h                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,86 +28,19 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef NAV_REGION_H
-#define NAV_REGION_H
+#ifndef NAV_REGION_ITERATION_3D_H
+#define NAV_REGION_ITERATION_3D_H
 
-#include "nav_base.h"
-#include "nav_utils.h"
+#include "../nav_utils.h"
+#include "nav_base_iteration_3d.h"
 
-#include "core/os/rw_lock.h"
-#include "scene/resources/navigation_mesh.h"
+#include "core/math/aabb.h"
 
-struct NavRegionIteration;
-
-class NavRegion : public NavBase {
-	RWLock region_rwlock;
-
-	NavMap *map = nullptr;
+struct NavRegionIteration : NavBaseIteration {
 	Transform3D transform;
-	bool enabled = true;
-
-	bool use_edge_connections = true;
-
-	bool polygons_dirty = true;
-
 	LocalVector<gd::Polygon> navmesh_polygons;
-
 	real_t surface_area = 0.0;
 	AABB bounds;
-
-	RWLock navmesh_rwlock;
-	Vector<Vector3> pending_navmesh_vertices;
-	Vector<Vector<int>> pending_navmesh_polygons;
-
-	SelfList<NavRegion> sync_dirty_request_list_element;
-
-public:
-	NavRegion();
-	~NavRegion();
-
-	void scratch_polygons() {
-		polygons_dirty = true;
-	}
-
-	void set_enabled(bool p_enabled);
-	bool get_enabled() const { return enabled; }
-
-	void set_map(NavMap *p_map);
-	NavMap *get_map() const {
-		return map;
-	}
-
-	void set_use_edge_connections(bool p_enabled);
-	bool get_use_edge_connections() const {
-		return use_edge_connections;
-	}
-
-	void set_transform(Transform3D transform);
-	const Transform3D &get_transform() const {
-		return transform;
-	}
-
-	void set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh);
-
-	LocalVector<gd::Polygon> const &get_polygons() const {
-		return navmesh_polygons;
-	}
-
-	Vector3 get_closest_point_to_segment(const Vector3 &p_from, const Vector3 &p_to, bool p_use_collision) const;
-	gd::ClosestPointQueryResult get_closest_point_info(const Vector3 &p_point) const;
-	Vector3 get_random_point(uint32_t p_navigation_layers, bool p_uniformly) const;
-
-	real_t get_surface_area() const { return surface_area; }
-	AABB get_bounds() const { return bounds; }
-
-	bool sync();
-	void request_sync();
-	void cancel_sync_request();
-
-	void get_iteration_update(NavRegionIteration &r_iteration);
-
-private:
-	void update_polygons();
 };
 
-#endif // NAV_REGION_H
+#endif // NAV_REGION_ITERATION_3D_H

--- a/modules/navigation/nav_link.cpp
+++ b/modules/navigation/nav_link.cpp
@@ -122,3 +122,15 @@ NavLink::NavLink() :
 NavLink::~NavLink() {
 	cancel_sync_request();
 }
+
+void NavLink::get_iteration_update(NavLinkIteration &r_iteration) {
+	r_iteration.navigation_layers = get_navigation_layers();
+	r_iteration.enter_cost = get_enter_cost();
+	r_iteration.travel_cost = get_travel_cost();
+	r_iteration.owner_object_id = get_owner_id();
+	r_iteration.owner_type = get_type();
+
+	r_iteration.enabled = enabled;
+	r_iteration.start_position = start_position;
+	r_iteration.end_position = end_position;
+}

--- a/modules/navigation/nav_link.h
+++ b/modules/navigation/nav_link.h
@@ -31,8 +31,16 @@
 #ifndef NAV_LINK_H
 #define NAV_LINK_H
 
+#include "3d/nav_base_iteration_3d.h"
 #include "nav_base.h"
 #include "nav_utils.h"
+
+struct NavLinkIteration : NavBaseIteration {
+	bool bidirectional = true;
+	Vector3 start_position;
+	Vector3 end_position;
+	LocalVector<gd::Polygon> navmesh_polygons;
+};
 
 #include "core/templates/self_list.h"
 
@@ -78,6 +86,8 @@ public:
 	void sync();
 	void request_sync();
 	void cancel_sync_request();
+
+	void get_iteration_update(NavLinkIteration &r_iteration);
 };
 
 #endif // NAV_LINK_H

--- a/modules/navigation/nav_region.cpp
+++ b/modules/navigation/nav_region.cpp
@@ -32,7 +32,9 @@
 
 #include "nav_map.h"
 
+#include "3d/nav_map_builder_3d.h"
 #include "3d/nav_mesh_queries_3d.h"
+#include "3d/nav_region_iteration_3d.h"
 
 void NavRegion::set_map(NavMap *p_map) {
 	if (map == p_map) {
@@ -153,8 +155,9 @@ void NavRegion::update_polygons() {
 	if (!polygons_dirty) {
 		return;
 	}
-	polygons.clear();
+	navmesh_polygons.clear();
 	surface_area = 0.0;
+	bounds = AABB();
 	polygons_dirty = false;
 
 	if (map == nullptr) {
@@ -174,14 +177,15 @@ void NavRegion::update_polygons() {
 
 	const Vector3 *vertices_r = pending_navmesh_vertices.ptr();
 
-	polygons.resize(pending_navmesh_polygons.size());
+	navmesh_polygons.resize(pending_navmesh_polygons.size());
 
 	real_t _new_region_surface_area = 0.0;
+	AABB _new_bounds;
 
-	// Build
+	bool first_vertex = true;
 	int navigation_mesh_polygon_index = 0;
-	for (gd::Polygon &polygon : polygons) {
-		polygon.owner = this;
+
+	for (gd::Polygon &polygon : navmesh_polygons) {
 		polygon.surface_area = 0.0;
 
 		Vector<int> navigation_mesh_polygon = pending_navmesh_polygons[navigation_mesh_polygon_index];
@@ -221,7 +225,14 @@ void NavRegion::update_polygons() {
 
 			Vector3 point_position = transform.xform(vertices_r[idx]);
 			polygon.points[j].pos = point_position;
-			polygon.points[j].key = map->get_point_key(point_position);
+			polygon.points[j].key = NavMapBuilder3D::get_point_key(point_position, map->get_merge_rasterizer_cell_size());
+
+			if (first_vertex) {
+				first_vertex = false;
+				_new_bounds.position = point_position;
+			} else {
+				_new_bounds.expand_to(point_position);
+			}
 		}
 
 		if (!valid) {
@@ -230,6 +241,60 @@ void NavRegion::update_polygons() {
 	}
 
 	surface_area = _new_region_surface_area;
+	bounds = _new_bounds;
+}
+
+void NavRegion::get_iteration_update(NavRegionIteration &r_iteration) {
+	r_iteration.navigation_layers = get_navigation_layers();
+	r_iteration.enter_cost = get_enter_cost();
+	r_iteration.travel_cost = get_travel_cost();
+	r_iteration.owner_object_id = get_owner_id();
+	r_iteration.owner_type = get_type();
+
+	r_iteration.enabled = enabled;
+	r_iteration.transform = transform;
+	r_iteration.owner_use_edge_connections = use_edge_connections;
+	r_iteration.bounds = get_bounds();
+
+	r_iteration.navmesh_polygons.resize(navmesh_polygons.size());
+
+	for (uint32_t i = 0; i < navmesh_polygons.size(); i++) {
+		const gd::Polygon &from_polygon = navmesh_polygons[i];
+		gd::Polygon &to_polygon = r_iteration.navmesh_polygons[i];
+
+		to_polygon.surface_area = from_polygon.surface_area;
+		to_polygon.owner = &r_iteration;
+		to_polygon.points.resize(from_polygon.points.size());
+
+		const LocalVector<gd::Point> &from_points = from_polygon.points;
+		LocalVector<gd::Point> &to_points = to_polygon.points;
+
+		to_points.resize(from_points.size());
+
+		for (uint32_t j = 0; j < from_points.size(); j++) {
+			to_points[j].pos = from_points[j].pos;
+			to_points[j].key = from_points[j].key;
+		}
+
+		const LocalVector<gd::Edge> &from_edges = from_polygon.edges;
+		LocalVector<gd::Edge> &to_edges = to_polygon.edges;
+
+		to_edges.resize(from_edges.size());
+
+		for (uint32_t j = 0; j < from_edges.size(); j++) {
+			const LocalVector<gd::Edge::Connection> &from_connections = from_edges[j].connections;
+			LocalVector<gd::Edge::Connection> &to_connections = to_edges[j].connections;
+
+			to_connections.resize(from_connections.size());
+
+			for (uint32_t k = 0; k < from_connections.size(); k++) {
+				to_connections[k] = from_connections[k];
+			}
+		}
+	}
+
+	r_iteration.surface_area = surface_area;
+	r_iteration.owner_rid = get_self();
 }
 
 void NavRegion::request_sync() {

--- a/modules/navigation/nav_utils.h
+++ b/modules/navigation/nav_utils.h
@@ -35,8 +35,9 @@
 #include "core/templates/hash_map.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/local_vector.h"
+#include "servers/navigation/navigation_utilities.h"
 
-class NavBase;
+struct NavBaseIteration;
 
 namespace gd {
 struct Polygon;
@@ -102,7 +103,7 @@ struct Polygon {
 	uint32_t id = UINT32_MAX;
 
 	/// Navigation region or link that contains this polygon.
-	const NavBase *owner = nullptr;
+	const NavBaseIteration *owner = nullptr;
 
 	/// The points of this `Polygon`
 	LocalVector<Point> points;
@@ -308,6 +309,11 @@ private:
 	}
 };
 
+struct EdgeConnectionPair {
+	gd::Edge::Connection connections[2];
+	int size = 0;
+};
+
 struct PerformanceData {
 	int pm_region_count = 0;
 	int pm_agent_count = 0;
@@ -318,6 +324,18 @@ struct PerformanceData {
 	int pm_edge_connection_count = 0;
 	int pm_edge_free_count = 0;
 	int pm_obstacle_count = 0;
+
+	void reset() {
+		pm_region_count = 0;
+		pm_agent_count = 0;
+		pm_link_count = 0;
+		pm_polygon_count = 0;
+		pm_edge_count = 0;
+		pm_edge_merge_count = 0;
+		pm_edge_connection_count = 0;
+		pm_edge_free_count = 0;
+		pm_obstacle_count = 0;
+	}
 };
 
 } // namespace gd

--- a/servers/navigation/navigation_globals.h
+++ b/servers/navigation/navigation_globals.h
@@ -39,6 +39,7 @@ namespace NavigationDefaults3D {
 // each cell has the following cell_size and cell_height.
 constexpr float navmesh_cell_size{ 0.25f }; // Must match ProjectSettings default 3D cell_size and NavigationMesh cell_size.
 constexpr float navmesh_cell_height{ 0.25f }; // Must match ProjectSettings default 3D cell_height and NavigationMesh cell_height.
+constexpr float navmesh_cell_size_min{ 0.01f };
 constexpr auto navmesh_cell_size_hint{ "0.001,100,0.001,or_greater" };
 
 // Map.

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -60,6 +60,8 @@ void NavigationServer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("map_force_update", "map"), &NavigationServer2D::map_force_update);
 	ClassDB::bind_method(D_METHOD("map_get_iteration_id", "map"), &NavigationServer2D::map_get_iteration_id);
+	ClassDB::bind_method(D_METHOD("map_set_use_async_iterations", "map", "enabled"), &NavigationServer2D::map_set_use_async_iterations);
+	ClassDB::bind_method(D_METHOD("map_get_use_async_iterations", "map"), &NavigationServer2D::map_get_use_async_iterations);
 
 	ClassDB::bind_method(D_METHOD("map_get_random_point", "map", "navigation_layers", "uniformly"), &NavigationServer2D::map_get_random_point);
 

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -104,6 +104,9 @@ public:
 	virtual void map_force_update(RID p_map) = 0;
 	virtual uint32_t map_get_iteration_id(RID p_map) const = 0;
 
+	virtual void map_set_use_async_iterations(RID p_map, bool p_enabled) = 0;
+	virtual bool map_get_use_async_iterations(RID p_map) const = 0;
+
 	virtual Vector2 map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const = 0;
 
 	/// Creates a new region.

--- a/servers/navigation_server_2d_dummy.h
+++ b/servers/navigation_server_2d_dummy.h
@@ -60,6 +60,8 @@ public:
 	void map_force_update(RID p_map) override {}
 	Vector2 map_get_random_point(RID p_map, uint32_t p_naviation_layers, bool p_uniformly) const override { return Vector2(); }
 	uint32_t map_get_iteration_id(RID p_map) const override { return 0; }
+	void map_set_use_async_iterations(RID p_map, bool p_enabled) override {}
+	bool map_get_use_async_iterations(RID p_map) const override { return false; }
 
 	RID region_create() override { return RID(); }
 	void region_set_enabled(RID p_region, bool p_enabled) override {}

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -70,6 +70,8 @@ void NavigationServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("map_force_update", "map"), &NavigationServer3D::map_force_update);
 	ClassDB::bind_method(D_METHOD("map_get_iteration_id", "map"), &NavigationServer3D::map_get_iteration_id);
+	ClassDB::bind_method(D_METHOD("map_set_use_async_iterations", "map", "enabled"), &NavigationServer3D::map_set_use_async_iterations);
+	ClassDB::bind_method(D_METHOD("map_get_use_async_iterations", "map"), &NavigationServer3D::map_get_use_async_iterations);
 
 	ClassDB::bind_method(D_METHOD("map_get_random_point", "map", "navigation_layers", "uniformly"), &NavigationServer3D::map_get_random_point);
 
@@ -244,6 +246,8 @@ NavigationServer3D::NavigationServer3D() {
 	GLOBAL_DEF("navigation/3d/use_edge_connections", true);
 	GLOBAL_DEF_BASIC("navigation/3d/default_edge_connection_margin", NavigationDefaults3D::edge_connection_margin);
 	GLOBAL_DEF_BASIC("navigation/3d/default_link_connection_radius", NavigationDefaults3D::link_connection_radius);
+
+	GLOBAL_DEF("navigation/world/map_use_async_iterations", true);
 
 	GLOBAL_DEF("navigation/avoidance/thread_model/avoidance_use_multiple_threads", true);
 	GLOBAL_DEF("navigation/avoidance/thread_model/avoidance_use_high_priority_threads", true);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -118,6 +118,9 @@ public:
 	virtual void map_force_update(RID p_map) = 0;
 	virtual uint32_t map_get_iteration_id(RID p_map) const = 0;
 
+	virtual void map_set_use_async_iterations(RID p_map, bool p_enabled) = 0;
+	virtual bool map_get_use_async_iterations(RID p_map) const = 0;
+
 	virtual Vector3 map_get_random_point(RID p_map, uint32_t p_navigation_layers, bool p_uniformly) const = 0;
 
 	/// Creates a new region.

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -67,6 +67,8 @@ public:
 	TypedArray<RID> map_get_obstacles(RID p_map) const override { return TypedArray<RID>(); }
 	void map_force_update(RID p_map) override {}
 	uint32_t map_get_iteration_id(RID p_map) const override { return 0; }
+	void map_set_use_async_iterations(RID p_map, bool p_enabled) override {}
+	bool map_get_use_async_iterations(RID p_map) const override { return false; }
 
 	RID region_create() override { return RID(); }
 	void region_set_enabled(RID p_region, bool p_enabled) override {}

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -572,6 +572,7 @@ TEST_SUITE("[Navigation]") {
 		RID map = navigation_server->map_create();
 		RID region = navigation_server->region_create();
 		Ref<NavigationMesh> navigation_mesh = memnew(NavigationMesh);
+		navigation_server->map_set_use_async_iterations(map, false);
 		navigation_server->map_set_active(map, true);
 		navigation_server->region_set_map(region, map);
 		navigation_server->region_set_navigation_mesh(region, navigation_mesh);
@@ -667,6 +668,7 @@ TEST_SUITE("[Navigation]") {
 		RID map = navigation_server->map_create();
 		RID region = navigation_server->region_create();
 		Ref<NavigationMesh> navigation_mesh = memnew(NavigationMesh);
+		navigation_server->map_set_use_async_iterations(map, false);
 		navigation_server->map_set_active(map, true);
 		navigation_server->region_set_map(region, map);
 		navigation_server->region_set_navigation_mesh(region, navigation_mesh);
@@ -716,6 +718,7 @@ TEST_SUITE("[Navigation]") {
 		RID map = navigation_server->map_create();
 		RID region = navigation_server->region_create();
 		navigation_server->map_set_active(map, true);
+		navigation_server->map_set_use_async_iterations(map, false);
 		navigation_server->region_set_map(region, map);
 		navigation_server->region_set_navigation_mesh(region, navigation_mesh);
 		navigation_server->process(0.0); // Give server some cycles to commit.


### PR DESCRIPTION
Changes the navigation map synchronization to an async process to avoid stalling the main thread.

Fixes https://github.com/godotengine/godot/issues/96820 with new iteration slots that avoid stalling query threads.
Resolves https://github.com/godotengine/godot/issues/96483
*Bugsquad edit:* Fixes https://github.com/godotengine/godot/issues/100716

### Performance

Pretty good.

![iteration_compare ](https://github.com/user-attachments/assets/1b35776a-1162-4fa6-841f-d7d2953f04d6)

To be clear this PR does largely not improve the performance of the underlying code of the actual map sync (something for future PRs). In fact the navigation map sync might be even slightly slower on simple maps or single-threaded builds. because the sync needs to do a few more new things.

What this PR primary does is that it pushes the majority of all the time consuming sync work to a background thread unblocking the main thread. So any project that can use threads will see a giant performance boost on larger navigation maps.

Since the sync happenes in the middle of the physics process step this also avoids final performance death from running into a physics process death spiral.

What this PR also does is solve a majority of all the thread locking cases as the map no longer write locks in full until the sync is finished. Threads can now query the navigation map more or less unimpeded by locks.

### How does it work?

This PR explained in one picture:

![async_iter](https://github.com/user-attachments/assets/d97f4666-fc20-4282-822a-62ddec536059)

Each navigation map now has 2 iterations, aka the map navmesh graph and everything that needs to be out of harm's way from other navobjects getting changed or deleted while threads use said graph.

One iteration is active and all new queries route to it. The Second iteration waits until the navigation map changes and builds on a background thread a new map graph. When finished the two iterations swap places by changing the current iteration slot index routing new queries to the newer iteration. This way long running pathfinding threads are able to finish without causing long thread locks. As soon as all old threads have stopped using the now free iteration the cycle continues.

This way
- The main thread is never stalled by the map sync apart from the bare sync minimum.
- The memory for the map builder and each map graph iteration is mostly kept speeding up new map builds.
- Queries can run and finish without running into  or causing long thread locks.

Now what async in general means is that there is always at least some delay between the map change and until the map update is actually registered due to the thread sync. This was already the case due to the physics process sync but now the delay will vary depending on what is going on on the map.

The delay extends when the map is more complex and has more things to process. The delay also extends if long running path query threads block the old iteration for a while until the iteration is free again. In this case the map sync checks if the old iteration is unused. While it is still used by a thread user instead of write blocking it it skips the sync and checks again on the next sync.

### New settings and API

This PR adds the new map property `use_async_iterations` and related ProjectSettings and NavigationServer API to push the sync to an async process run on a background thread. It is enabled by default but if you need the old main thread sync back for your project you can disable it.

For new navigation maps this uses the ProjectSettings value from `navigation/world/map_use_async_iterations`.

The async sync can also be toggled for each map with the `NavigationServer.map_set_use_async_iterations(map, enabled)` function.

```gdscript
void NavigationServer2D.map_set_use_async_iterations(map: RID, enabled: bool)
bool NavigationServer2D.map_get_use_async_iterations(map: RID)

void NavigationServer3D.map_set_use_async_iterations(map: RID, enabled: bool)
bool NavigationServer3D.map_get_use_async_iterations(map: RID)
```

### Spaghetti Notes

![spaghetti](https://github.com/user-attachments/assets/90beb83c-ff8a-4084-a010-1371d603ceb0)

The old owner pointer spaghetti used with the NavRegions and NavLinks was async unworkable as they could turn invalid while threads were still using them. This is why the new structs `NavRegionIteration` and `NavLinkIteration` were added.

Those are full snapshots of the regions and links used by the navigation map that can not be touched by user changes anymore as long as the map iteration needs them. This is also why the iteration update functions do full copies with them so nothing uses or points back at the NavRegion or NavLink except a single HashMap that has a pointer to id mapping. Previously all those things just pointed to the owner to avoid data duplicates but the owner could get changed or deleted in the middle of threaded queries.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->



<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
