### PR TITLE
Optimize 2D lights using specialization constants in RD renderer

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2316,15 +2316,12 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 			light = light->next_ptr;
 		}
 
-		base_flags |= light_count << INSTANCE_FLAGS_LIGHT_COUNT_SHIFT;
 		base_flags |= shadow_mask << INSTANCE_FLAGS_SHADOW_MASKED_SHIFT;
 	}
 
-	bool use_lighting = (light_count > 0 || using_directional_lights);
-
-	if (use_lighting != r_current_batch->use_lighting) {
+	if (light_count != r_current_batch->positional_light_count) {
 		r_current_batch = _new_batch(r_batch_broken);
-		r_current_batch->use_lighting = use_lighting;
+		r_current_batch->positional_light_count = light_count;
 	}
 
 	const Item::Command *c = p_item->commands;
@@ -2836,9 +2833,9 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 		}
 
 		// 2: If the current batch has lighting, start a new batch.
-		if (r_current_batch->use_lighting) {
+		if (r_current_batch->positional_light_count) {
 			r_current_batch = _new_batch(r_batch_broken);
-			r_current_batch->use_lighting = false;
+			r_current_batch->positional_light_count = 0;
 		}
 
 		// 3: If the current batch has blend, start a new batch.
@@ -2955,7 +2952,8 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 	pipeline_key.framebuffer_format_id = p_framebuffer_format;
 	pipeline_key.variant = p_batch->shader_variant;
 	pipeline_key.render_primitive = p_batch->render_primitive;
-	pipeline_key.shader_specialization.use_lighting = p_batch->use_lighting;
+	pipeline_key.shader_specialization.use_directional_lighting = using_directional_lights;
+	pipeline_key.shader_specialization.positional_light_count = p_batch->positional_light_count;
 	pipeline_key.lcd_blend = p_batch->has_blend;
 
 	switch (p_batch->command_type) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -65,7 +65,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	};
 
 	enum {
-		INSTANCE_FLAGS_LIGHT_COUNT_SHIFT = 0, // 4 bits for light count.
+		// 4 bits free at the front.
 
 		INSTANCE_FLAGS_CLIP_RECT_UV = (1 << 4),
 		INSTANCE_FLAGS_TRANSPOSE_RECT = (1 << 5),
@@ -119,7 +119,8 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 	struct ShaderSpecialization {
 		union {
 			struct {
-				uint32_t use_lighting : 1;
+				uint32_t use_directional_lighting : 1;
+				uint32_t positional_light_count : 4;
 			};
 
 			uint32_t packed_0;
@@ -498,7 +499,8 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		Item::Command::Type command_type = Item::Command::TYPE_ANIMATION_SLICE; // Can default to any type that doesn't form a batch.
 		ShaderVariant shader_variant = SHADER_VARIANT_QUAD;
 		RD::RenderPrimitive render_primitive = RD::RENDER_PRIMITIVE_TRIANGLES;
-		bool use_lighting = false;
+		bool use_directional_lighting = false;
+		uint32_t positional_light_count = 0;
 
 		// batch-specific data
 		union {

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -524,8 +524,7 @@ void main() {
 		color *= texture(sampler2D(color_texture, texture_sampler), uv);
 	}
 
-	uint light_count = draw_data.flags & 15u; //max 15 lights
-	bool using_light = (light_count + canvas_data.directional_light_count) > 0;
+	bool using_light = sc_use_directional_lighting() && sc_light_count() > 0;
 
 	vec3 normal;
 
@@ -607,7 +606,7 @@ void main() {
 #endif
 
 #if !defined(MODE_UNSHADED)
-	if (sc_use_lighting()) {
+	if (sc_use_directional_lighting()) {
 		// Directional Lights
 
 		for (uint i = 0; i < canvas_data.directional_light_count; i++) {
@@ -648,95 +647,93 @@ void main() {
 			light_only_alpha += light_color.a;
 #endif
 		}
+	}
 
-		// Positional Lights
+	// Positional Lights
 
-		for (uint i = 0; i < MAX_LIGHTS_PER_ITEM; i++) {
-			if (i >= light_count) {
-				break;
-			}
-			uint light_base = bitfieldExtract(draw_data.lights[i >> 2], (int(i) & 0x3) * 8, 8);
+	for (uint i = 0; i < sc_light_count(); i++) {
+		uint light_base = bitfieldExtract(draw_data.lights[i >> 2], (int(i) & 0x3) * 8, 8);
 
-			vec2 tex_uv = (vec4(vertex, 0.0, 1.0) * mat4(light_array.data[light_base].texture_matrix[0], light_array.data[light_base].texture_matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.
-			vec2 tex_uv_atlas = tex_uv * light_array.data[light_base].atlas_rect.zw + light_array.data[light_base].atlas_rect.xy;
+		vec2 tex_uv = (vec4(vertex, 0.0, 1.0) * mat4(light_array.data[light_base].texture_matrix[0], light_array.data[light_base].texture_matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.
+		vec2 tex_uv_atlas = tex_uv * light_array.data[light_base].atlas_rect.zw + light_array.data[light_base].atlas_rect.xy;
 
-			if (any(lessThan(tex_uv, vec2(0.0, 0.0))) || any(greaterThanEqual(tex_uv, vec2(1.0, 1.0)))) {
-				//if outside the light texture, light color is zero
-				continue;
-			}
+		if (any(lessThan(tex_uv, vec2(0.0, 0.0))) || any(greaterThanEqual(tex_uv, vec2(1.0, 1.0)))) {
+			//if outside the light texture, light color is zero
+			continue;
+		}
 
-			vec4 light_color = textureLod(sampler2D(atlas_texture, texture_sampler), tex_uv_atlas, 0.0);
-			vec4 light_base_color = light_array.data[light_base].color;
+		vec4 light_color = textureLod(sampler2D(atlas_texture, texture_sampler), tex_uv_atlas, 0.0);
+		vec4 light_base_color = light_array.data[light_base].color;
 
 #ifdef LIGHT_CODE_USED
 
-			vec4 shadow_modulate = vec4(1.0);
-			vec3 light_position = vec3(light_array.data[light_base].position, light_array.data[light_base].height);
+		vec4 shadow_modulate = vec4(1.0);
+		vec3 light_position = vec3(light_array.data[light_base].position, light_array.data[light_base].height);
 
-			light_color.rgb *= light_base_color.rgb;
-			light_color = light_compute(light_vertex, light_position, normal, light_color, light_base_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, false);
+		light_color.rgb *= light_base_color.rgb;
+		light_color = light_compute(light_vertex, light_position, normal, light_color, light_base_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, false);
 #else
 
-			light_color.rgb *= light_base_color.rgb * light_base_color.a;
+		light_color.rgb *= light_base_color.rgb * light_base_color.a;
 
-			if (normal_used) {
-				vec3 light_pos = vec3(light_array.data[light_base].position, light_array.data[light_base].height);
-				vec3 pos = light_vertex;
-				vec3 light_vec = normalize(light_pos - pos);
+		if (normal_used) {
+			vec3 light_pos = vec3(light_array.data[light_base].position, light_array.data[light_base].height);
+			vec3 pos = light_vertex;
+			vec3 light_vec = normalize(light_pos - pos);
 
-				light_color.rgb = light_normal_compute(light_vec, normal, base_color.rgb, light_color.rgb, specular_shininess, specular_shininess_used);
-			} else {
-				light_color.rgb *= base_color.rgb;
-			}
-#endif
-
-			if (bool(light_array.data[light_base].flags & LIGHT_FLAGS_HAS_SHADOW) && bool(draw_data.flags & (INSTANCE_FLAGS_SHADOW_MASKED << i))) {
-				vec2 shadow_pos = (vec4(shadow_vertex, 0.0, 1.0) * mat4(light_array.data[light_base].shadow_matrix[0], light_array.data[light_base].shadow_matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.
-
-				vec2 pos_norm = normalize(shadow_pos);
-				vec2 pos_abs = abs(pos_norm);
-				vec2 pos_box = pos_norm / max(pos_abs.x, pos_abs.y);
-				vec2 pos_rot = pos_norm * mat2(vec2(0.7071067811865476, -0.7071067811865476), vec2(0.7071067811865476, 0.7071067811865476)); //is there a faster way to 45 degrees rot?
-				float tex_ofs;
-				float distance;
-				if (pos_rot.y > 0) {
-					if (pos_rot.x > 0) {
-						tex_ofs = pos_box.y * 0.125 + 0.125;
-						distance = shadow_pos.x;
-					} else {
-						tex_ofs = pos_box.x * -0.125 + (0.25 + 0.125);
-						distance = shadow_pos.y;
-					}
-				} else {
-					if (pos_rot.x < 0) {
-						tex_ofs = pos_box.y * -0.125 + (0.5 + 0.125);
-						distance = -shadow_pos.x;
-					} else {
-						tex_ofs = pos_box.x * 0.125 + (0.75 + 0.125);
-						distance = -shadow_pos.y;
-					}
-				}
-
-				distance *= light_array.data[light_base].shadow_zfar_inv;
-
-				//float distance = length(shadow_pos);
-				vec4 shadow_uv = vec4(tex_ofs, light_array.data[light_base].shadow_y_ofs, distance, 1.0);
-
-				light_color = light_shadow_compute(light_base, light_color, shadow_uv
-#ifdef LIGHT_CODE_USED
-						,
-						shadow_modulate.rgb
-#endif
-				);
-			}
-
-			light_blend_compute(light_base, light_color, color.rgb);
-#ifdef MODE_LIGHT_ONLY
-			light_only_alpha += light_color.a;
-#endif
+			light_color.rgb = light_normal_compute(light_vec, normal, base_color.rgb, light_color.rgb, specular_shininess, specular_shininess_used);
+		} else {
+			light_color.rgb *= base_color.rgb;
 		}
-	}
 #endif
+
+		if (bool(light_array.data[light_base].flags & LIGHT_FLAGS_HAS_SHADOW) && bool(draw_data.flags & (INSTANCE_FLAGS_SHADOW_MASKED << i))) {
+			vec2 shadow_pos = (vec4(shadow_vertex, 0.0, 1.0) * mat4(light_array.data[light_base].shadow_matrix[0], light_array.data[light_base].shadow_matrix[1], vec4(0.0, 0.0, 1.0, 0.0), vec4(0.0, 0.0, 0.0, 1.0))).xy; //multiply inverse given its transposed. Optimizer removes useless operations.
+
+			vec2 pos_norm = normalize(shadow_pos);
+			vec2 pos_abs = abs(pos_norm);
+			vec2 pos_box = pos_norm / max(pos_abs.x, pos_abs.y);
+			vec2 pos_rot = pos_norm * mat2(vec2(0.7071067811865476, -0.7071067811865476), vec2(0.7071067811865476, 0.7071067811865476)); //is there a faster way to 45 degrees rot?
+			float tex_ofs;
+			float distance;
+			if (pos_rot.y > 0) {
+				if (pos_rot.x > 0) {
+					tex_ofs = pos_box.y * 0.125 + 0.125;
+					distance = shadow_pos.x;
+				} else {
+					tex_ofs = pos_box.x * -0.125 + (0.25 + 0.125);
+					distance = shadow_pos.y;
+				}
+			} else {
+				if (pos_rot.x < 0) {
+					tex_ofs = pos_box.y * -0.125 + (0.5 + 0.125);
+					distance = -shadow_pos.x;
+				} else {
+					tex_ofs = pos_box.x * 0.125 + (0.75 + 0.125);
+					distance = -shadow_pos.y;
+				}
+			}
+
+			distance *= light_array.data[light_base].shadow_zfar_inv;
+
+			//float distance = length(shadow_pos);
+			vec4 shadow_uv = vec4(tex_ofs, light_array.data[light_base].shadow_y_ofs, distance, 1.0);
+
+			light_color = light_shadow_compute(light_base, light_color, shadow_uv
+#ifdef LIGHT_CODE_USED
+					,
+					shadow_modulate.rgb
+#endif
+			);
+		}
+
+		light_blend_compute(light_base, light_color, color.rgb);
+#ifdef MODE_LIGHT_ONLY
+		light_only_alpha += light_color.a;
+#endif
+	}
+
+#endif // !MODE_UNSHADED
 
 #ifdef MODE_LIGHT_ONLY
 	color.a *= light_only_alpha;

--- a/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
@@ -4,8 +4,6 @@
 
 #define SDF_MAX_LENGTH 16384.0
 
-#define INSTANCE_FLAGS_LIGHT_COUNT_SHIFT 0 // 4 bits.
-
 #define INSTANCE_FLAGS_CLIP_RECT_UV (1 << 4)
 #define INSTANCE_FLAGS_TRANSPOSE_RECT (1 << 5)
 #define INSTANCE_FLAGS_USE_MSDF (1 << 6)
@@ -78,8 +76,12 @@ uint sc_packed_0() {
 
 #endif
 
-bool sc_use_lighting() {
+bool sc_use_directional_lighting() {
 	return ((sc_packed_0() >> 0) & 1U) != 0;
+}
+
+uint sc_light_count() {
+	return (sc_packed_0() >> 1) & 15U;
 }
 
 // In vulkan, sets should always be ordered using the following logic:


### PR DESCRIPTION
This builds on our introduction of Ubershaders. By making positional light count a specialization constant we allow the shader compiler to optimize the light loop by either unrolling or not. At low values for `light_count` this results in an improvement to performance.

This breaks batching when light count changes between items, which can increase the CPU cost of rendering. Especially when there are many, small lights. However, since the lighting code is heavily GPU ALU bound, this is a net win for games using 2D lighting.

Marking as 4.x for now as I want to get much broader testing before concluding that this is a net win. So far I have only seen equal or better performance. But it would be nice to compare in real projects. And I would like to compare after we merge https://github.com/godotengine/godot/pull/100302

### Performance testing

I tested this little project on 3 devices: 
- M2 MBP
- Pixel 4 Adreno 640 
- Intel Core i7-1165G7 laptop (integrated graphics)
[light2dopt.zip](https://github.com/user-attachments/files/18161086/light2dopt.zip)

I tested 3 different scenarios:
1. Single light touching many sprites
2. Singly light touching many sprites, second light touching some
3. Many lights touching many sprites

In all cases I saw the same or better performance (which shows that all these devices are heavily GPU-bound when using 2D lighting)

I expect the performance benefit will be negligible on devices with powerful dedicated GPUs and most valuable on mobile devices

**M2 MBP**
Single light: 795 FPS -> 1130 FPS
Many lights: 212 FPS -> 212 FPS

**Pixel 4**
Single light: 31 FPS -> 39 FPS
_Note: The single light case is vsync capped on this device, so it was modified to have 4x the number of sprites and 4 lights (not overlapping)_
Many lights: 32 FPS-> 34 FPS
Isometric demo: 15 FPS -> 17 FPS

**Intel iGPU**
Single light: 263 FPS -> 277 FPS
Many lights: 117 FPS -> 120 FPS
Isometric demo: 140 -> 140



