### PR TITLE
Expose functions from `AudioStreamPlaybackMicrophone` to access the microphone `AudioDriver::input_buffer` independently of the rest of the Audio system

### DIFF
--- a/doc/classes/AudioStreamPlaybackMicrophone.xml
+++ b/doc/classes/AudioStreamPlaybackMicrophone.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioStreamPlaybackMicrophone" inherits="AudioStreamPlaybackResampled" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Playback instance for [AudioStreamMicrophone].
+	</brief_description>
+	<description>
+		Playback instance for [AudioStreamMicrophone]. When this class is instantiated on its own it can be used to control and extract the microphone audio data directly.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_microphone_buffer">
+			<return type="PackedVector2Array" />
+			<param index="0" name="frames" type="int" />
+			<description>
+				Gets the next [param frames] audio samples from the AudioDevice ring buffer.
+				Returns a [PackedVector2Array] containing exactly [param frames] audio samples if available, or an empty [PackedVector2Array] if insufficient data was available.
+				The samples are signed floating-point PCM between [code]-1[/code] and [code]1[/code]. You will have to scale them if you want to use them as 8 or 16-bit integer samples. ([code]v = 0x7fff * samples[0].x[/code])
+			</description>
+		</method>
+		<method name="is_microphone_playing" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Check if this object has instructed the AudioDevice to record.
+			</description>
+		</method>
+		<method name="start_microphone">
+			<return type="void" />
+			<description>
+				Instruct the AudioDevice to begin recording if it has not already doing so.
+			</description>
+		</method>
+		<method name="stop_microphone">
+			<return type="void" />
+			<description>
+				Instruct the AudioDevice to stop recording if no other [AudioStreamPlaybackMicrophone] instances are active.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -117,7 +117,7 @@ public:
 	virtual Error input_start() override;
 	virtual Error input_stop() override;
 
-	bool try_lock();
+	virtual bool try_lock() override;
 	void stop();
 
 	AudioDriverCoreAudio();

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -537,6 +537,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 					ERR_PRINT("pa_stream_peek error");
 				} else {
 					int16_t *srcptr = (int16_t *)ptr;
+					ad->lock();
 					for (size_t i = bytes >> 1; i > 0; i--) {
 						int32_t sample = int32_t(*srcptr++) << 16;
 						ad->input_buffer_write(sample);
@@ -546,6 +547,7 @@ void AudioDriverPulseAudio::thread_func(void *p_udata) {
 							ad->input_buffer_write(sample);
 						}
 					}
+					ad->unlock();
 
 					read_bytes += bytes;
 					ret = pa_stream_drop(ad->pa_rec_str);

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -899,6 +899,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 					ERR_BREAK(hr != S_OK);
 
 					// fixme: Only works for floating point atm
+					ad->lock();
 					for (UINT32 j = 0; j < num_frames_available; j++) {
 						int32_t l, r;
 
@@ -919,6 +920,7 @@ void AudioDriverWASAPI::thread_func(void *p_udata) {
 						ad->input_buffer_write(l);
 						ad->input_buffer_write(r);
 					}
+					ad->unlock();
 
 					read_frames += num_frames_available;
 

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -96,6 +96,7 @@ public:
 	virtual SpeakerMode get_speaker_mode() const override;
 
 	virtual void lock() override;
+	virtual bool try_lock() override;
 	virtual void unlock() override;
 	virtual void finish() override;
 

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -566,9 +566,12 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_filePickerCallback(JN
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResult(JNIEnv *env, jclass clazz, jstring p_permission, jboolean p_result) {
 	String permission = jstring_to_string(p_permission, env);
-	if (permission == "android.permission.RECORD_AUDIO" && p_result) {
-		AudioDriver::get_singleton()->input_start();
-	}
+
+	// this code block is not helpful due to the lack of error handling and the
+	// information not getting back to the AudioStreamPlaybackMicrophone
+	//if (permission == "android.permission.RECORD_AUDIO" && p_result) {
+	//	AudioDriver::get_singleton()->input_start();
+	//}
 
 	if (os_android->get_main_loop()) {
 		os_android->get_main_loop()->emit_signal(SNAME("on_request_permissions_result"), permission, p_result == JNI_TRUE);

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -567,12 +567,6 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_filePickerCallback(JN
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_requestPermissionResult(JNIEnv *env, jclass clazz, jstring p_permission, jboolean p_result) {
 	String permission = jstring_to_string(p_permission, env);
 
-	// this code block is not helpful due to the lack of error handling and the
-	// information not getting back to the AudioStreamPlaybackMicrophone
-	//if (permission == "android.permission.RECORD_AUDIO" && p_result) {
-	//	AudioDriver::get_singleton()->input_start();
-	//}
-
 	if (os_android->get_main_loop()) {
 		os_android->get_main_loop()->emit_signal(SNAME("on_request_permissions_result"), permission, p_result == JNI_TRUE);
 	}

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -105,6 +105,8 @@ void AudioDriverWeb::_audio_driver_capture(int p_from, int p_samples) {
 	if (to_read == 0) {
 		to_read = max_samples;
 	}
+
+	lock();
 	// High part
 	if (read_pos + to_read > max_samples) {
 		const int samples_high = max_samples - read_pos;
@@ -118,6 +120,7 @@ void AudioDriverWeb::_audio_driver_capture(int p_from, int p_samples) {
 	for (int i = read_pos; i < read_pos + to_read; i++) {
 		input_buffer_write(int32_t(input_rb[i] * 32768.f) * (1U << 16));
 	}
+	unlock();
 }
 
 Error AudioDriverWeb::init() {

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -472,7 +472,7 @@ PackedVector2Array AudioStreamPlaybackMicrophone::get_microphone_buffer(int p_fr
 }
 
 /*
-// not able to implement filling an array, instead having to return an array by value as above
+// Not able to implement filling an array, instead having to return an array by value as above.
 bool AudioStreamPlaybackMicrophone::mix_microphone(GDExtensionPtr<AudioFrame> p_buffer, int p_frames) {
 	DEV_ASSERT(p_buffer != nullptr);
 	if (!microphone.is_null())

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -451,19 +451,23 @@ PackedVector2Array AudioStreamPlaybackMicrophone::get_microphone_buffer(int p_fr
 
 	unsigned int input_position = AudioDriver::get_singleton()->get_input_position();
 	Vector<int32_t> &buf = AudioDriver::get_singleton()->get_input_buffer();
-	if (input_position < input_ofs)
+	if (input_position < input_ofs) {
 		input_position += buf.size();
-	if (p_frames == -1)
+	}
+	if (p_frames == -1) {
 		p_frames = (input_position - input_ofs) / 2;
+	}
 	if (input_ofs + p_frames * 2 <= input_position) {
 		ret.resize(p_frames);
 		for (int i = 0; i < p_frames; i++) { // inline of _mix_internal()
 			float l = (buf[input_ofs++] >> 16) / 32768.f;
-			if (input_ofs >= buf.size())
+			if (input_ofs >= buf.size()) {
 				input_ofs = 0;
+			}
 			float r = (buf[input_ofs++] >> 16) / 32768.f;
-			if (input_ofs >= buf.size())
+			if (input_ofs >= buf.size()) {
 				input_ofs = 0;
+			}
 			ret.write[i] = Vector2(l, r);
 		}
 	}
@@ -584,8 +588,9 @@ void AudioStreamPlaybackMicrophone::_bind_methods() {
 }
 
 AudioStreamPlaybackMicrophone::~AudioStreamPlaybackMicrophone() {
-	if (!microphone.is_null())
+	if (!microphone.is_null()) {
 		microphone->playbacks.erase(this);
+	}
 	stop();
 }
 

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -243,6 +243,8 @@ class AudioStreamPlaybackMicrophone : public AudioStreamPlaybackResampled {
 	Ref<AudioStreamMicrophone> microphone;
 
 protected:
+	static void _bind_methods();
+
 	virtual int _mix_internal(AudioFrame *p_buffer, int p_frames) override;
 	virtual float get_stream_sampling_rate() override;
 	virtual double get_playback_position() const override;
@@ -253,6 +255,13 @@ public:
 	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
 	virtual bool is_playing() const override;
+
+	void start_microphone();
+	void stop_microphone();
+	PackedVector2Array get_microphone_buffer(int p_frames);
+
+	// not able to implement function to fill an existing array
+	// bool mix_microphone(GDExtensionPtr<AudioFrame> p_buffer, int p_frames);
 
 	virtual int get_loop_count() const override; //times it looped
 

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -260,7 +260,8 @@ public:
 	void stop_microphone();
 	PackedVector2Array get_microphone_buffer(int p_frames);
 
-	// not able to implement function to fill an existing array
+	// The GDExtension interface does not allow for functions to fill an existing array which would be
+	// more efficient as it would not put memory on the heap every frame.
 	// bool mix_microphone(GDExtensionPtr<AudioFrame> p_buffer, int p_frames);
 
 	virtual int get_loop_count() const override; //times it looped

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -101,6 +101,7 @@ void AudioDriver::input_buffer_init(int driver_buffer_frames) {
 	input_size = 0;
 }
 
+// this should only be called from inside a locked block
 void AudioDriver::input_buffer_write(int32_t sample) {
 	if ((int)input_position < input_buffer.size()) {
 		input_buffer.write[input_position++] = sample;
@@ -111,6 +112,7 @@ void AudioDriver::input_buffer_write(int32_t sample) {
 			input_size++;
 		}
 	} else {
+		// this can only happen if this function is called by threads which are not mutually locked
 		WARN_PRINT("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
 	}
 }

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -101,7 +101,7 @@ void AudioDriver::input_buffer_init(int driver_buffer_frames) {
 	input_size = 0;
 }
 
-// this should only be called from inside a locked block
+// This function should only be called from inside a locked block.
 void AudioDriver::input_buffer_write(int32_t sample) {
 	if ((int)input_position < input_buffer.size()) {
 		input_buffer.write[input_position++] = sample;
@@ -112,7 +112,7 @@ void AudioDriver::input_buffer_write(int32_t sample) {
 			input_size++;
 		}
 	} else {
-		// this can only happen if this function is called by threads which are not mutually locked
+		// This error condition could only have happened if this function was called from multiple threads that were not locked. 
 		WARN_PRINT("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
 	}
 }

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -112,7 +112,7 @@ void AudioDriver::input_buffer_write(int32_t sample) {
 			input_size++;
 		}
 	} else {
-		// This error condition could only have happened if this function was called from multiple threads that were not locked. 
+		// This error condition could only have happened if this function was called from multiple threads that were not locked.
 		WARN_PRINT("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
 	}
 }

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -57,10 +57,13 @@ class AudioDriver {
 	SafeNumeric<uint64_t> prof_time;
 #endif
 
+	friend class AudioStreamPlaybackMicrophone;
+
 protected:
 	Vector<int32_t> input_buffer;
 	unsigned int input_position = 0;
 	unsigned int input_size = 0;
+	int32_t input_start_count = 0;
 
 	void audio_server_process(int p_frames, int32_t *p_buffer, bool p_update_mix_time = true);
 	void update_mix_time(int p_frames);
@@ -103,6 +106,10 @@ public:
 	virtual float get_latency() { return 0; }
 
 	virtual void lock() = 0;
+	virtual bool try_lock() {
+		lock();
+		return true;
+	}
 	virtual void unlock() = 0;
 	virtual void finish() = 0;
 
@@ -122,7 +129,7 @@ public:
 	SpeakerMode get_speaker_mode_by_total_channels(int p_channels) const;
 	int get_total_channels_by_speaker_mode(SpeakerMode) const;
 
-	Vector<int32_t> get_input_buffer() { return input_buffer; }
+	Vector<int32_t> &get_input_buffer() { return input_buffer; }
 	unsigned int get_input_position() { return input_position; }
 	unsigned int get_input_size() { return input_size; }
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -167,6 +167,7 @@ void register_server_types() {
 	GDREGISTER_CLASS(AudioStreamPlayback);
 	GDREGISTER_VIRTUAL_CLASS(AudioStreamPlaybackResampled);
 	GDREGISTER_CLASS(AudioStreamMicrophone);
+	GDREGISTER_CLASS(AudioStreamPlaybackMicrophone);
 	GDREGISTER_CLASS(AudioStreamRandomizer);
 	GDREGISTER_CLASS(AudioSample);
 	GDREGISTER_CLASS(AudioSamplePlayback);


### PR DESCRIPTION
This solves all the issues raised in the proposal: https://github.com/godotengine/godot-proposals/issues/11347

Changes made:

1) My new `AudioDriver::input_start_count` counter is to prevent multiple calls to `AudioDriver::input_start()` from different AudioStreamPlaybackMicrophone instances that result in multiple conflicting processes to popping data from the same buffer.

2) Change the return type of `AudioDriver::get_input_buffer()` to `Vector<int32_t>&` to avoid copying out entire buffer 
to access it.

3) `GDREGISTER_CLASS(AudioStreamPlaybackMicrophone)` was missing from `register_server_types.cpp`

4) Expose functions `start()`, `stop()` and `is_playing()` from `AudioStreamPlaybackMicrophone` to GDScript

5) New function `PackedVector2Array AudioStreamPlaybackMicrophone::get_microphone_buffer(int p_frames)`.  This does the same as [PackedVector2Array AudioEffectCapture::get_buffer(frames: int)](https://docs.godotengine.org/en/stable/classes/class_audioeffectcapture.html#class-audioeffectcapture-method-get-buffer) but it fetches the frames directly from the `AudioDriver::input_buffer` without going through an AudioStream, AudioBus and an AudioEffect, all of which operate on the duty cycle of the Audio system output frequency.

 
**Need help with:**

I would like to expose 
[int AudioStreamPlaybackMicrophone::mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames)](https://github.com/godotengine/godot/blob/master/servers/audio/audio_stream.h#L254)
to GDExtension, but this has an `AudioFrame*` pointer in its parameters list  

This ought to be possible, because there is already one like this with [int AudioStreamPlaybackResampled::_mix_resampled(dst_buffer: AudioFrame*, frame_count: int)](https://docs.godotengine.org/en/stable/classes/class_audiostreamplaybackresampled.html#class-audiostreamplaybackresampled-private-method-mix-resampled), 
but it is created by the special virtual function template `GDVIRTUAL2R(int, _mix_resampled, GDExtensionPtr<AudioFrame>, int)`

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/11347*
