### PR TITLE
Fix non-creation of editor temporary dir

### DIFF
--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -237,6 +237,17 @@ EditorPaths::EditorPaths() {
 		}
 	}
 
+	// Temporary dir.
+	{
+		if (dir->change_dir(temp_dir) != OK) {
+			dir->make_dir_recursive(temp_dir);
+			if (dir->change_dir(temp_dir) != OK) {
+				ERR_PRINT("Could not create editor temporary directory: " + temp_dir);
+				paths_valid = false;
+			}
+		}
+	}
+
 	// Validate or create project-specific editor data dir,
 	// including shader cache subdir.
 	if (Engine::get_singleton()->is_project_manager_hint() || (Main::is_cmdline_tool() && !ProjectSettings::get_singleton()->is_project_loaded())) {


### PR DESCRIPTION
Simple PR. This makes sure that the temporary dir for the editor is created, the same way we do for the cache dir.

Fixes #100362