### PR TITLE
[Dictionary Property Editor] Use property editors instead of labels to display keys.

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -109,6 +109,12 @@
 		<member name="deletable" type="bool" setter="set_deletable" getter="is_deletable" default="false">
 			Used by the inspector, set to [code]true[/code] when the property can be deleted by the user.
 		</member>
+		<member name="draw_background" type="bool" setter="set_draw_background" getter="is_draw_background" default="true">
+			Used by the inspector, set to [code]true[/code] when the property label is drawn.
+		</member>
+		<member name="draw_label" type="bool" setter="set_draw_label" getter="is_draw_label" default="true">
+			Used by the inspector, set to [code]true[/code] when the property background is drawn.
+		</member>
 		<member name="draw_warning" type="bool" setter="set_draw_warning" getter="is_draw_warning" default="false">
 			Used by the inspector, set to [code]true[/code] when the property is drawn with the editor theme's warning color. This is used for editable children's properties.
 		</member>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -164,6 +164,9 @@ void EditorProperty::_notification(int p_what) {
 				if (no_children) {
 					text_size = size.width;
 					rect = Rect2(size.width - 1, 0, 1, height);
+				} else if (!draw_label) {
+					text_size = 0;
+					rect = Rect2(1, 0, size.width - 1, height);
 				} else {
 					text_size = MAX(0, size.width - (child_room + 4 * EDSCALE));
 					if (is_layout_rtl()) {
@@ -268,10 +271,10 @@ void EditorProperty::_notification(int p_what) {
 			}
 
 			Ref<StyleBox> bg_stylebox = get_theme_stylebox(SNAME("child_bg"));
-			if (draw_top_bg && right_child_rect != Rect2()) {
+			if (draw_top_bg && right_child_rect != Rect2() && draw_background) {
 				draw_style_box(bg_stylebox, right_child_rect);
 			}
-			if (bottom_child_rect != Rect2()) {
+			if (bottom_child_rect != Rect2() && draw_background) {
 				draw_style_box(bg_stylebox, bottom_child_rect);
 			}
 
@@ -603,6 +606,25 @@ bool EditorProperty::use_keying_next() const {
 	}
 
 	return false;
+}
+
+void EditorProperty::set_draw_label(bool p_draw_label) {
+	draw_label = p_draw_label;
+	queue_redraw();
+	queue_sort();
+}
+
+bool EditorProperty::is_draw_label() const {
+	return draw_label;
+}
+
+void EditorProperty::set_draw_background(bool p_draw_background) {
+	draw_background = p_draw_background;
+	queue_redraw();
+}
+
+bool EditorProperty::is_draw_background() const {
+	return draw_background;
 }
 
 void EditorProperty::set_checkable(bool p_checkable) {
@@ -1070,6 +1092,12 @@ void EditorProperty::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_read_only", "read_only"), &EditorProperty::set_read_only);
 	ClassDB::bind_method(D_METHOD("is_read_only"), &EditorProperty::is_read_only);
 
+	ClassDB::bind_method(D_METHOD("set_draw_label", "draw_label"), &EditorProperty::set_draw_label);
+	ClassDB::bind_method(D_METHOD("is_draw_label"), &EditorProperty::is_draw_label);
+
+	ClassDB::bind_method(D_METHOD("set_draw_background", "draw_background"), &EditorProperty::set_draw_background);
+	ClassDB::bind_method(D_METHOD("is_draw_background"), &EditorProperty::is_draw_background);
+
 	ClassDB::bind_method(D_METHOD("set_checkable", "checkable"), &EditorProperty::set_checkable);
 	ClassDB::bind_method(D_METHOD("is_checkable"), &EditorProperty::is_checkable);
 
@@ -1112,6 +1140,8 @@ void EditorProperty::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "label"), "set_label", "get_label");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "read_only"), "set_read_only", "is_read_only");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_label"), "set_draw_label", "is_draw_label");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_background"), "set_draw_background", "is_draw_background");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "checkable"), "set_checkable", "is_checkable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "checked"), "set_checked", "is_checked");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draw_warning"), "set_draw_warning", "is_draw_warning");

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -89,6 +89,8 @@ private:
 
 	int property_usage;
 
+	bool draw_label = true;
+	bool draw_background = true;
 	bool read_only = false;
 	bool checkable = false;
 	bool checked = false;
@@ -169,6 +171,12 @@ public:
 
 	void set_read_only(bool p_read_only);
 	bool is_read_only() const;
+
+	void set_draw_label(bool p_draw_label);
+	bool is_draw_label() const;
+
+	void set_draw_background(bool p_draw_background);
+	bool is_draw_background() const;
 
 	Object *get_edited_object();
 	StringName get_edited_property() const;

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -146,10 +146,27 @@ bool EditorPropertyDictionaryObject::get_by_property_name(const String &p_name, 
 		return true;
 	}
 
+	if (name == "new_item_key_name") {
+		r_ret = TTR("New Key:");
+		return true;
+	}
+
+	if (name == "new_item_value_name") {
+		r_ret = TTR("New Value:");
+		return true;
+	}
+
 	if (name.begins_with("indices")) {
 		int index = name.get_slicec('/', 1).to_int();
 		Variant key = dict.get_key_at_index(index);
 		r_ret = dict[key];
+		return true;
+	}
+
+	if (name.begins_with("keys")) {
+		int index = name.get_slicec('/', 1).to_int();
+		Variant key = dict.get_key_at_index(index);
+		r_ret = key;
 		return true;
 	}
 
@@ -188,6 +205,17 @@ String EditorPropertyDictionaryObject::get_property_name_for_index(int p_index) 
 			return "new_item_value";
 		default:
 			return "indices/" + itos(p_index);
+	}
+}
+
+String EditorPropertyDictionaryObject::get_key_name_for_index(int p_index) {
+	switch (p_index) {
+		case NEW_KEY_INDEX:
+			return "new_item_key_name";
+		case NEW_VALUE_INDEX:
+			return "new_item_value_name";
+		default:
+			return "keys/" + itos(p_index);
 	}
 }
 
@@ -931,7 +959,31 @@ void EditorPropertyDictionary::_add_key_value() {
 
 void EditorPropertyDictionary::_create_new_property_slot(int p_idx) {
 	HBoxContainer *hbox = memnew(HBoxContainer);
+
+	EditorProperty *prop_key = nullptr;
+	if (p_idx != EditorPropertyDictionaryObject::NEW_KEY_INDEX && p_idx != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
+		if (key_subtype == Variant::OBJECT) {
+			EditorPropertyObjectID *editor = memnew(EditorPropertyObjectID);
+			editor->setup("Object");
+			prop_key = editor;
+		} else {
+			prop_key = EditorInspector::instantiate_property_editor(this, key_subtype, "", key_subtype_hint, key_subtype_hint_string, PROPERTY_USAGE_NONE);
+		}
+		prop_key->set_read_only(true);
+		prop_key->set_selectable(false);
+		prop_key->set_focus_mode(Control::FOCUS_NONE);
+		prop_key->set_draw_background(false);
+		prop_key->set_use_folding(is_using_folding());
+		prop_key->set_h_size_flags(SIZE_EXPAND_FILL);
+		prop_key->set_draw_label(false);
+		hbox->add_child(prop_key);
+	}
+
 	EditorProperty *prop = memnew(EditorPropertyNil);
+	prop->set_h_size_flags(SIZE_EXPAND_FILL);
+	if (p_idx != EditorPropertyDictionaryObject::NEW_KEY_INDEX && p_idx != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
+		prop->set_draw_label(false);
+	}
 	hbox->add_child(prop);
 
 	bool use_key = p_idx == EditorPropertyDictionaryObject::NEW_KEY_INDEX;
@@ -959,6 +1011,7 @@ void EditorPropertyDictionary::_create_new_property_slot(int p_idx) {
 
 	Slot slot;
 	slot.prop = prop;
+	slot.prop_key = prop_key;
 	slot.object = object;
 	slot.container = hbox;
 	int index = p_idx + (p_idx >= 0 ? page_index * page_length : 0);
@@ -1171,6 +1224,9 @@ void EditorPropertyDictionary::update_property() {
 				new_prop->connect(SNAME("property_changed"), callable_mp(this, &EditorPropertyDictionary::_property_changed));
 				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
+				if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
+					new_prop->set_draw_label(false);
+				}
 				new_prop->set_read_only(is_read_only());
 				slot.set_prop(new_prop);
 			} else if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
@@ -1188,6 +1244,9 @@ void EditorPropertyDictionary::update_property() {
 			}
 
 			slot.prop->update_property();
+			if (slot.prop_key) {
+				slot.prop_key->update_property();
+			}
 		}
 		updating = false;
 

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -89,6 +89,7 @@ public:
 
 	String get_label_for_index(int p_index);
 	String get_property_name_for_index(int p_index);
+	String get_key_name_for_index(int p_index);
 
 	EditorPropertyDictionaryObject();
 };
@@ -184,11 +185,14 @@ class EditorPropertyDictionary : public EditorProperty {
 		Variant::Type type = Variant::VARIANT_MAX;
 		bool as_id = false;
 		EditorProperty *prop = nullptr;
+		EditorProperty *prop_key = nullptr;
 		String prop_name;
+		String key_name;
 
 		void set_index(int p_idx) {
 			index = p_idx;
 			prop_name = object->get_property_name_for_index(p_idx);
+			key_name = object->get_key_name_for_index(p_idx);
 			update_prop_or_index();
 		}
 
@@ -201,7 +205,11 @@ class EditorPropertyDictionary : public EditorProperty {
 
 		void update_prop_or_index() {
 			prop->set_object_and_property(object.ptr(), prop_name);
-			prop->set_label(object->get_label_for_index(index));
+			if (prop_key) {
+				prop_key->set_object_and_property(object.ptr(), key_name);
+			} else {
+				prop->set_label(object->get_label_for_index(index));
+			}
 		}
 	};
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/96852

| Before | After |
|--|--|
|<img width="469" alt="Screenshot 2024-12-17 at 17 07 01" src="https://github.com/user-attachments/assets/45eb59c5-90eb-4ff7-8c30-f5d3cb5bb769" /> | <img width="469" alt="Screenshot 2024-12-17 at 17 04 24" src="https://github.com/user-attachments/assets/945c0fce-8c8d-484f-ad6b-5ecf2cc0896b" /> |
