### PR TITLE
Rename `String` `.find_char` -> `find`, `rfind_char` -> `rfind`, `contains_char` -> `contains`.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -194,7 +194,7 @@ String ProjectSettings::localize_path(const String &p_path) const {
 
 		return cwd.replace_first(res_path, "res://");
 	} else {
-		int sep = path.rfind_char('/');
+		int sep = path.rfind('/');
 		if (sep == -1) {
 			return "res://" + path;
 		}
@@ -306,7 +306,7 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 		}
 
 		{ // Feature overrides.
-			int dot = p_name.operator String().find_char('.');
+			int dot = p_name.operator String().find('.');
 			if (dot != -1) {
 				Vector<String> s = p_name.operator String().split(".");
 
@@ -441,7 +441,7 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	for (const _VCSort &E : vclist) {
 		String prop_info_name = E.name;
-		int dot = prop_info_name.find_char('.');
+		int dot = prop_info_name.find('.');
 		if (dot != -1 && !custom_prop_info.has(prop_info_name)) {
 			prop_info_name = prop_info_name.substr(0, dot);
 		}
@@ -1101,7 +1101,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		String category = E.name;
 		String name = E.name;
 
-		int div = category.find_char('/');
+		int div = category.find('/');
 
 		if (div < 0) {
 			category = "";

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -163,7 +163,7 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, co
 
 	for (int i = 0; i < p_breakpoints.size(); i++) {
 		const String &bp = p_breakpoints[i];
-		int sp = bp.rfind_char(':');
+		int sp = bp.rfind(':');
 		ERR_CONTINUE_MSG(sp == -1, vformat("Invalid breakpoint: '%s', expected file:line format.", bp));
 
 		singleton_script_debugger->insert_breakpoint(bp.substr(sp + 1, bp.length()).to_int(), bp.substr(0, sp));

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -171,7 +171,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 
 			} else {
 				String key_value = line.get_slicec(' ', 1);
-				int value_pos = key_value.find_char('=');
+				int value_pos = key_value.find('=');
 
 				if (value_pos < 0) {
 					print_line("Error: Invalid set format. Use: set key=value");
@@ -208,7 +208,7 @@ void LocalDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 			print_variables(members, values, variable_prefix);
 
 		} else if (line.begins_with("p") || line.begins_with("print")) {
-			if (line.find_char(' ') < 0) {
+			if (line.find(' ') < 0) {
 				print_line("Usage: print <expression>");
 			} else {
 				String expr = line.split(" ", true, 1)[1];
@@ -344,7 +344,7 @@ Pair<String, int> LocalDebugger::to_breakpoint(const String &p_line) {
 	String breakpoint_part = p_line.get_slicec(' ', 1);
 	Pair<String, int> breakpoint;
 
-	int last_colon = breakpoint_part.rfind_char(':');
+	int last_colon = breakpoint_part.rfind(':');
 	if (last_colon < 0) {
 		print_line("Error: Invalid breakpoint format. Expected [source:line]");
 		return breakpoint;

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -338,7 +338,7 @@ void RemoteDebugger::_send_stack_vars(List<String> &p_names, List<Variant> &p_va
 }
 
 Error RemoteDebugger::_try_capture(const String &p_msg, const Array &p_data, bool &r_captured) {
-	const int idx = p_msg.find_char(':');
+	const int idx = p_msg.find(':');
 	r_captured = false;
 	if (idx < 0) { // No prefix, unknown message.
 		return OK;
@@ -610,7 +610,7 @@ void RemoteDebugger::poll_events(bool p_is_idle) {
 		ERR_CONTINUE(arr[1].get_type() != Variant::ARRAY);
 
 		const String cmd = arr[0];
-		const int idx = cmd.find_char(':');
+		const int idx = cmd.find(':');
 		bool parsed = false;
 		if (idx < 0) { // Not prefix, use scripts capture.
 			capture_parse("core", cmd, arr[1], parsed);

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -223,8 +223,8 @@ RemoteDebuggerPeer *RemoteDebuggerPeerTCP::create(const String &p_uri) {
 	String debug_host = p_uri.replace("tcp://", "");
 	uint16_t debug_port = 6007;
 
-	if (debug_host.contains_char(':')) {
-		int sep_pos = debug_host.rfind_char(':');
+	if (debug_host.contains(':')) {
+		int sep_pos = debug_host.rfind(':');
 		debug_port = debug_host.substr(sep_pos + 1).to_int();
 		debug_host = debug_host.substr(0, sep_pos);
 	}

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1205,7 +1205,7 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 					if (F.name.begins_with("_")) {
 						continue; //hidden property
 					}
-					if (F.name.contains_char('/')) {
+					if (F.name.contains('/')) {
 						// Ignore properties with '/' (slash) in the name. These are only meant for use in the inspector.
 						continue;
 					}

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -236,7 +236,7 @@ void Input::get_argument_options(const StringName &p_function, int p_idx, List<S
 				continue;
 			}
 
-			String name = pi.name.substr(pi.name.find_char('/') + 1, pi.name.length());
+			String name = pi.name.substr(pi.name.find('/') + 1, pi.name.length());
 			r_options->push_back(name.quote());
 		}
 	}

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -106,7 +106,7 @@ void InputMap::get_argument_options(const StringName &p_function, int p_idx, Lis
 				continue;
 			}
 
-			String name = pi.name.substr(pi.name.find_char('/') + 1, pi.name.length());
+			String name = pi.name.substr(pi.name.find('/') + 1, pi.name.length());
 			r_options->push_back(name.quote());
 		}
 	}
@@ -304,7 +304,7 @@ void InputMap::load_from_project_settings() {
 			continue;
 		}
 
-		String name = pi.name.substr(pi.name.find_char('/') + 1, pi.name.length());
+		String name = pi.name.substr(pi.name.find('/') + 1, pi.name.length());
 
 		Dictionary action = GLOBAL_GET(pi.name);
 		float deadzone = action.has("deadzone") ? (float)action["deadzone"] : DEFAULT_DEADZONE;

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -155,9 +155,9 @@ Error DirAccess::make_dir_recursive(const String &p_dir) {
 	} else if (full_dir.begins_with("user://")) {
 		base = "user://";
 	} else if (full_dir.is_network_share_path()) {
-		int pos = full_dir.find_char('/', 2);
+		int pos = full_dir.find('/', 2);
 		ERR_FAIL_COND_V(pos < 0, ERR_INVALID_PARAMETER);
-		pos = full_dir.find_char('/', pos + 1);
+		pos = full_dir.find('/', pos + 1);
 		ERR_FAIL_COND_V(pos < 0, ERR_INVALID_PARAMETER);
 		base = full_dir.substr(0, pos + 1);
 	} else if (full_dir.begins_with("/")) {

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -740,7 +740,7 @@ bool FileAccess::store_csv_line(const Vector<String> &p_values, const String &p_
 	for (int i = 0; i < size; ++i) {
 		String value = p_values[i];
 
-		if (value.contains_char('"') || value.contains(p_delim) || value.contains_char('\n')) {
+		if (value.contains('"') || value.contains(p_delim) || value.contains('\n')) {
 			value = "\"" + value.replace("\"", "\"\"") + "\"";
 		}
 		if (i < size - 1) {

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -71,7 +71,7 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 		// Search for directory.
 		PackedDir *cd = root;
 
-		if (simplified_path.contains_char('/')) { // In a subdirectory.
+		if (simplified_path.contains('/')) { // In a subdirectory.
 			Vector<String> ds = simplified_path.get_base_dir().split("/");
 
 			for (int j = 0; j < ds.size(); j++) {
@@ -104,7 +104,7 @@ void PackedData::remove_path(const String &p_path) {
 	// Search for directory.
 	PackedDir *cd = root;
 
-	if (simplified_path.contains_char('/')) { // In a subdirectory.
+	if (simplified_path.contains('/')) { // In a subdirectory.
 		Vector<String> ds = simplified_path.get_base_dir().split("/");
 
 		for (int j = 0; j < ds.size(); j++) {

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -101,7 +101,7 @@ Error HTTPClient::verify_headers(const Vector<String> &p_headers) {
 	for (int i = 0; i < p_headers.size(); i++) {
 		String sanitized = p_headers[i].strip_edges();
 		ERR_FAIL_COND_V_MSG(sanitized.is_empty(), ERR_INVALID_PARAMETER, vformat("Invalid HTTP header at index %d: empty.", i));
-		ERR_FAIL_COND_V_MSG(sanitized.find_char(':') < 1, ERR_INVALID_PARAMETER,
+		ERR_FAIL_COND_V_MSG(sanitized.find(':') < 1, ERR_INVALID_PARAMETER,
 				vformat("Invalid HTTP header at index %d: String must contain header-value pair, delimited by ':', but was: '%s'.", i, p_headers[i]));
 	}
 
@@ -113,7 +113,7 @@ Dictionary HTTPClient::_get_response_headers_as_dictionary() {
 	get_response_headers(&rh);
 	Dictionary ret;
 	for (const String &s : rh) {
-		int sp = s.find_char(':');
+		int sp = s.find(':');
 		if (sp == -1) {
 			continue;
 		}

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -132,7 +132,7 @@ static bool _check_request_url(HTTPClientTCP::Method p_method, const String &p_u
 	switch (p_method) {
 		case HTTPClientTCP::METHOD_CONNECT: {
 			// Authority in host:port format, as in RFC7231.
-			int pos = p_url.find_char(':');
+			int pos = p_url.find(':');
 			return 0 < pos && pos < p_url.length() - 1;
 		}
 		case HTTPClientTCP::METHOD_OPTIONS: {
@@ -508,11 +508,11 @@ Error HTTPClientTCP::poll() {
 							continue;
 						}
 						if (s.begins_with("content-length:")) {
-							body_size = s.substr(s.find_char(':') + 1, s.length()).strip_edges().to_int();
+							body_size = s.substr(s.find(':') + 1, s.length()).strip_edges().to_int();
 							body_left = body_size;
 
 						} else if (s.begins_with("transfer-encoding:")) {
-							String encoding = header.substr(header.find_char(':') + 1, header.length()).strip_edges();
+							String encoding = header.substr(header.find(':') + 1, header.length()).strip_edges();
 							if (encoding == "chunked") {
 								chunked = true;
 							}

--- a/core/io/ip_address.cpp
+++ b/core/io/ip_address.cpp
@@ -202,7 +202,7 @@ IPAddress::IPAddress(const String &p_string) {
 		// Wildcard (not a valid IP)
 		wildcard = true;
 
-	} else if (p_string.contains_char(':')) {
+	} else if (p_string.contains(':')) {
 		// IPv6
 		_parse_ipv6(p_string);
 		valid = true;

--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -661,12 +661,12 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 	List<Ref<PListNode>> stack;
 	String key;
 	while (pos >= 0) {
-		int open_token_s = p_string.find_char('<', pos);
+		int open_token_s = p_string.find('<', pos);
 		if (open_token_s == -1) {
 			r_err_out = "Unexpected end of data. No tags found.";
 			return false;
 		}
-		int open_token_e = p_string.find_char('>', open_token_s);
+		int open_token_e = p_string.find('>', open_token_s);
 		pos = open_token_e;
 
 		String token = p_string.substr(open_token_s + 1, open_token_e - open_token_s - 1);
@@ -676,7 +676,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 		}
 		String value;
 		if (token[0] == '?' || token[0] == '!') { // Skip <?xml ... ?> and <!DOCTYPE ... >
-			int end_token_e = p_string.find_char('>', open_token_s);
+			int end_token_e = p_string.find('>', open_token_s);
 			pos = end_token_e;
 			continue;
 		}
@@ -769,7 +769,7 @@ bool PList::load_string(const String &p_string, String &r_err_out) {
 				r_err_out = vformat("Mismatched <%s> tag.", token);
 				return false;
 			}
-			int end_token_e = p_string.find_char('>', end_token_s);
+			int end_token_e = p_string.find('>', end_token_s);
 			pos = end_token_e;
 			String end_token = p_string.substr(end_token_s + 2, end_token_e - end_token_s - 2);
 			if (end_token != token) {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1197,7 +1197,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 
 		int best_score = 0;
 		for (int i = 0; i < res_remaps.size(); i++) {
-			int split = res_remaps[i].rfind_char(':');
+			int split = res_remaps[i].rfind(':');
 			if (split == -1) {
 				continue;
 			}
@@ -1489,11 +1489,11 @@ Vector<String> ResourceLoader::list_directory(const String &p_directory) {
 			}
 		} else {
 			if (d.ends_with(".import") || d.ends_with(".remap") || d.ends_with(".uid")) {
-				d = d.substr(0, d.rfind_char('.'));
+				d = d.substr(0, d.rfind('.'));
 			}
 
 			if (d.ends_with(".gdc")) {
-				d = d.substr(0, d.rfind_char('.'));
+				d = d.substr(0, d.rfind('.'));
 				d += ".gd";
 			}
 

--- a/core/io/translation_loader_po.cpp
+++ b/core/io/translation_loader_po.cpp
@@ -108,7 +108,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 					// Record plural rule.
 					int p_start = config.find("Plural-Forms");
 					if (p_start != -1) {
-						int p_end = config.find_char('\n', p_start);
+						int p_end = config.find('\n', p_start);
 						translation->set_plural_rule(config.substr(p_start, p_end - p_start));
 					}
 				} else {
@@ -224,7 +224,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 					// Record plural rule.
 					int p_start = config.find("Plural-Forms");
 					if (p_start != -1) {
-						int p_end = config.find_char('\n', p_start);
+						int p_end = config.find('\n', p_start);
 						translation->set_plural_rule(config.substr(p_start, p_end - p_start));
 						plural_forms = translation->get_plural_forms();
 					}
@@ -324,7 +324,7 @@ Ref<Resource> TranslationLoaderPO::load_translation(Ref<FileAccess> f, Error *r_
 	Vector<String> configs = config.split("\n");
 	for (int i = 0; i < configs.size(); i++) {
 		String c = configs[i].strip_edges();
-		int p = c.find_char(':');
+		int p = c.find(':');
 		if (p == -1) {
 			continue;
 		}

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1116,7 +1116,7 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 
 	String enum_name = p_enum;
 	if (!enum_name.is_empty()) {
-		if (enum_name.contains_char('.')) {
+		if (enum_name.contains('.')) {
 			enum_name = enum_name.get_slicec('.', 1);
 		}
 

--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -136,22 +136,22 @@ static const uint8_t MONTH_DAYS_TABLE[2][12] = {
 	{                                                                                         \
 		bool has_date = false, has_time = false;                                              \
 		String date, time;                                                                    \
-		if (p_datetime.find_char('T') > 0) {                                                  \
+		if (p_datetime.find('T') > 0) {                                                       \
 			has_date = has_time = true;                                                       \
 			PackedStringArray array = p_datetime.split("T");                                  \
 			ERR_FAIL_COND_V_MSG(array.size() < 2, ret, "Invalid ISO 8601 date/time string."); \
 			date = array[0];                                                                  \
 			time = array[1];                                                                  \
-		} else if (p_datetime.find_char(' ') > 0) {                                           \
+		} else if (p_datetime.find(' ') > 0) {                                                \
 			has_date = has_time = true;                                                       \
 			PackedStringArray array = p_datetime.split(" ");                                  \
 			ERR_FAIL_COND_V_MSG(array.size() < 2, ret, "Invalid ISO 8601 date/time string."); \
 			date = array[0];                                                                  \
 			time = array[1];                                                                  \
-		} else if (p_datetime.find_char('-', 1) > 0) {                                        \
+		} else if (p_datetime.find('-', 1) > 0) {                                             \
 			has_date = true;                                                                  \
 			date = p_datetime;                                                                \
-		} else if (p_datetime.find_char(':') > 0) {                                           \
+		} else if (p_datetime.find(':') > 0) {                                                \
 			has_time = true;                                                                  \
 			time = p_datetime;                                                                \
 		}                                                                                     \
@@ -163,7 +163,7 @@ static const uint8_t MONTH_DAYS_TABLE[2][12] = {
 			month = (Month)array[1];                                                          \
 			day = array[2];                                                                   \
 			/* Handle negative years. */                                                      \
-			if (p_datetime.find_char('-') == 0) {                                             \
+			if (p_datetime.find('-') == 0) {                                                  \
 				year *= -1;                                                                   \
 			}                                                                                 \
 		}                                                                                     \

--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -53,7 +53,7 @@ static bool _is_word_boundary(const String &p_str, int p_index) {
 	if (p_index == -1 || p_index == p_str.size()) {
 		return true;
 	}
-	return boundary_chars.find_char(p_str[p_index]) != -1;
+	return boundary_chars.find(p_str[p_index]) != -1;
 }
 
 bool FuzzySearchToken::try_exact_match(FuzzyTokenMatch &p_match, const String &p_target, int p_offset) const {
@@ -76,7 +76,7 @@ bool FuzzySearchToken::try_fuzzy_match(FuzzyTokenMatch &p_match, const String &p
 	// Search for the subsequence p_token in p_target starting from p_offset, recording each substring for
 	// later scoring and display.
 	for (int i = 0; i < string.length(); i++) {
-		int new_offset = p_target.find_char(string[i], p_offset);
+		int new_offset = p_target.find(string[i], p_offset);
 		if (new_offset < 0) {
 			p_miss_budget--;
 			if (p_miss_budget < 0) {
@@ -287,7 +287,7 @@ void FuzzySearch::set_query(const String &p_query) {
 
 bool FuzzySearch::search(const String &p_target, FuzzySearchResult &p_result) const {
 	p_result.target = p_target;
-	p_result.dir_index = p_target.rfind_char('/');
+	p_result.dir_index = p_target.rfind('/');
 	p_result.miss_budget = max_misses;
 
 	String adjusted_target = case_sensitive ? p_target : p_target.to_lower();

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -407,7 +407,7 @@ NodePath::NodePath(const String &p_path) {
 	bool absolute = (path[0] == '/');
 	bool last_is_slash = true;
 	int slices = 0;
-	int subpath_pos = path.find_char(':');
+	int subpath_pos = path.find(':');
 
 	if (subpath_pos != -1) {
 		int from = subpath_pos + 1;

--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -97,7 +97,7 @@ void __print_line_rich(const String &p_string) {
 	String output;
 	int pos = 0;
 	while (pos <= p_string.length()) {
-		int brk_pos = p_string.find_char('[', pos);
+		int brk_pos = p_string.find('[', pos);
 
 		if (brk_pos < 0) {
 			brk_pos = p_string.length();
@@ -109,7 +109,7 @@ void __print_line_rich(const String &p_string) {
 			break;
 		}
 
-		int brk_end = p_string.find_char(']', brk_pos + 1);
+		int brk_end = p_string.find(']', brk_pos + 1);
 
 		if (brk_end == -1) {
 			txt += p_string.substr(brk_pos, p_string.length() - brk_pos);

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -227,11 +227,11 @@ void TranslationPO::set_plural_rule(const String &p_plural_rule) {
 	// Set plural_forms and plural_rule.
 	// p_plural_rule passed in has the form "Plural-Forms: nplurals=2; plural=(n >= 2);".
 
-	int first_semi_col = p_plural_rule.find_char(';');
-	plural_forms = p_plural_rule.substr(p_plural_rule.find_char('=') + 1, first_semi_col - (p_plural_rule.find_char('=') + 1)).to_int();
+	int first_semi_col = p_plural_rule.find(';');
+	plural_forms = p_plural_rule.substr(p_plural_rule.find('=') + 1, first_semi_col - (p_plural_rule.find('=') + 1)).to_int();
 
-	int expression_start = p_plural_rule.find_char('=', first_semi_col) + 1;
-	int second_semi_col = p_plural_rule.rfind_char(';');
+	int expression_start = p_plural_rule.find('=', first_semi_col) + 1;
+	int second_semi_col = p_plural_rule.rfind(';');
 	plural_rule = p_plural_rule.substr(expression_start, second_semi_col - expression_start).strip_edges();
 
 	// Setup the cache to make evaluating plural rule faster later on.

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -246,27 +246,27 @@ Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r
 			base = base.substr(pos + 3, base.length() - pos - 3);
 		}
 	}
-	pos = base.find_char('#');
+	pos = base.find('#');
 	// Fragment
 	if (pos != -1) {
 		r_fragment = base.substr(pos + 1);
 		base = base.substr(0, pos);
 	}
-	pos = base.find_char('/');
+	pos = base.find('/');
 	// Path
 	if (pos != -1) {
 		r_path = base.substr(pos, base.length() - pos);
 		base = base.substr(0, pos);
 	}
 	// Host
-	pos = base.find_char('@');
+	pos = base.find('@');
 	if (pos != -1) {
 		// Strip credentials
 		base = base.substr(pos + 1, base.length() - pos - 1);
 	}
 	if (base.begins_with("[")) {
 		// Literal IPv6
-		pos = base.rfind_char(']');
+		pos = base.rfind(']');
 		if (pos == -1) {
 			return ERR_INVALID_PARAMETER;
 		}
@@ -277,7 +277,7 @@ Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r
 		if (base.get_slice_count(":") > 2) {
 			return ERR_INVALID_PARAMETER;
 		}
-		pos = base.rfind_char(':');
+		pos = base.rfind(':');
 		if (pos == -1) {
 			r_host = base;
 			base = "";
@@ -2492,7 +2492,7 @@ int64_t String::to_int() const {
 		return 0;
 	}
 
-	int to = (find_char('.') >= 0) ? find_char('.') : length();
+	int to = (find('.') >= 0) ? find('.') : length();
 
 	int64_t integer = 0;
 	int64_t sign = 1;
@@ -3162,7 +3162,7 @@ int String::find(const String &p_str, int p_from) const {
 	}
 
 	if (src_len == 1) {
-		return find_char(p_str[0], p_from); // Optimize with single-char find.
+		return find(p_str[0], p_from); // Optimize with single-char find.
 	}
 
 	const char32_t *src = get_data();
@@ -3206,7 +3206,7 @@ int String::find(const char *p_str, int p_from) const {
 	}
 
 	if (src_len == 1) {
-		return find_char(*p_str, p_from); // Optimize with single-char find.
+		return find(*p_str, p_from); // Optimize with single-char find.
 	}
 
 	const char32_t *src = get_data();
@@ -3246,7 +3246,7 @@ int String::find(const char *p_str, int p_from) const {
 	return -1;
 }
 
-int String::find_char(char32_t p_char, int p_from) const {
+int String::find(char32_t p_char, int p_from) const {
 	return _cowdata.find(p_char, p_from);
 }
 
@@ -3483,7 +3483,7 @@ int String::rfind(const char *p_str, int p_from) const {
 	return -1;
 }
 
-int String::rfind_char(char32_t p_char, int p_from) const {
+int String::rfind(char32_t p_char, int p_from) const {
 	return _cowdata.rfind(p_char, p_from);
 }
 
@@ -3932,7 +3932,7 @@ String String::format(const Variant &values, const String &placeholder) const {
 				Variant v_val = values_arr[i];
 				String val = v_val;
 
-				if (placeholder.contains_char('_')) {
+				if (placeholder.contains('_')) {
 					new_string = new_string.replace(placeholder.replace("_", i_as_str), val);
 				} else {
 					new_string = new_string.replace_first(placeholder, val);
@@ -4366,7 +4366,7 @@ String String::lstrip(const String &p_chars) const {
 	int beg;
 
 	for (beg = 0; beg < len; beg++) {
-		if (p_chars.find_char(get(beg)) == -1) {
+		if (p_chars.find(get(beg)) == -1) {
 			break;
 		}
 	}
@@ -4383,7 +4383,7 @@ String String::rstrip(const String &p_chars) const {
 	int end;
 
 	for (end = len - 1; end >= 0; end--) {
-		if (p_chars.find_char(get(end)) == -1) {
+		if (p_chars.find(get(end)) == -1) {
 			break;
 		}
 	}
@@ -4435,7 +4435,7 @@ String String::simplify_path() const {
 			if (p == -1) {
 				p = s.find(":\\");
 			}
-			if (p != -1 && p < s.find_char('/')) {
+			if (p != -1 && p < s.find('/')) {
 				drive = s.substr(0, p + 2);
 				s = s.substr(p + 2);
 			}
@@ -4880,7 +4880,7 @@ String String::xml_unescape() const {
 
 String String::pad_decimals(int p_digits) const {
 	String s = *this;
-	int c = s.find_char('.');
+	int c = s.find('.');
 
 	if (c == -1) {
 		if (p_digits <= 0) {
@@ -4904,7 +4904,7 @@ String String::pad_decimals(int p_digits) const {
 
 String String::pad_zeros(int p_digits) const {
 	String s = *this;
-	int end = s.find_char('.');
+	int end = s.find('.');
 
 	if (end == -1) {
 		end = s.length();
@@ -5169,7 +5169,7 @@ String String::validate_filename() const {
 }
 
 bool String::is_valid_ip_address() const {
-	if (find_char(':') >= 0) {
+	if (find(':') >= 0) {
 		Vector<String> ip = split(":");
 		for (int i = 0; i < ip.size(); i++) {
 			const String &n = ip[i];
@@ -5239,13 +5239,13 @@ String String::get_base_dir() const {
 	// Windows UNC network share path.
 	if (end == 0) {
 		if (is_network_share_path()) {
-			basepos = find_char('/', 2);
+			basepos = find('/', 2);
 			if (basepos == -1) {
-				basepos = find_char('\\', 2);
+				basepos = find('\\', 2);
 			}
-			int servpos = find_char('/', basepos + 1);
+			int servpos = find('/', basepos + 1);
 			if (servpos == -1) {
-				servpos = find_char('\\', basepos + 1);
+				servpos = find('\\', basepos + 1);
 			}
 			if (servpos != -1) {
 				end = servpos + 1;
@@ -5269,7 +5269,7 @@ String String::get_base_dir() const {
 		rs = *this;
 	}
 
-	int sep = MAX(rs.rfind_char('/'), rs.rfind_char('\\'));
+	int sep = MAX(rs.rfind('/'), rs.rfind('\\'));
 	if (sep == -1) {
 		return base;
 	}
@@ -5278,7 +5278,7 @@ String String::get_base_dir() const {
 }
 
 String String::get_file() const {
-	int sep = MAX(rfind_char('/'), rfind_char('\\'));
+	int sep = MAX(rfind('/'), rfind('\\'));
 	if (sep == -1) {
 		return *this;
 	}
@@ -5287,8 +5287,8 @@ String String::get_file() const {
 }
 
 String String::get_extension() const {
-	int pos = rfind_char('.');
-	if (pos < 0 || pos < MAX(rfind_char('/'), rfind_char('\\'))) {
+	int pos = rfind('.');
+	if (pos < 0 || pos < MAX(rfind('/'), rfind('\\'))) {
 		return "";
 	}
 
@@ -5386,8 +5386,8 @@ String String::validate_node_name() const {
 }
 
 String String::get_basename() const {
-	int pos = rfind_char('.');
-	if (pos < 0 || pos < MAX(rfind_char('/'), rfind_char('\\'))) {
+	int pos = rfind('.');
+	if (pos < 0 || pos < MAX(rfind('/'), rfind('\\'))) {
 		return *this;
 	}
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -404,12 +404,12 @@ public:
 	String substr(int p_from, int p_chars = -1) const;
 	int find(const String &p_str, int p_from = 0) const; ///< return <0 if failed
 	int find(const char *p_str, int p_from = 0) const; ///< return <0 if failed
-	int find_char(char32_t p_char, int p_from = 0) const; ///< return <0 if failed
+	int find(char32_t p_char, int p_from = 0) const; ///< return <0 if failed
 	int findn(const String &p_str, int p_from = 0) const; ///< return <0 if failed, case insensitive
 	int findn(const char *p_str, int p_from = 0) const; ///< return <0 if failed
 	int rfind(const String &p_str, int p_from = -1) const; ///< return <0 if failed
 	int rfind(const char *p_str, int p_from = -1) const; ///< return <0 if failed
-	int rfind_char(char32_t p_char, int p_from = -1) const; ///< return <0 if failed
+	int rfind(char32_t p_char, int p_from = -1) const; ///< return <0 if failed
 	int rfindn(const String &p_str, int p_from = -1) const; ///< return <0 if failed, case insensitive
 	int rfindn(const char *p_str, int p_from = -1) const; ///< return <0 if failed
 	int findmk(const Vector<String> &p_keys, int p_from = 0, int *r_key = nullptr) const; ///< return <0 if failed
@@ -549,7 +549,7 @@ public:
 	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 	_FORCE_INLINE_ bool contains(const char *p_str) const { return find(p_str) != -1; }
 	_FORCE_INLINE_ bool contains(const String &p_str) const { return find(p_str) != -1; }
-	_FORCE_INLINE_ bool contains_char(char32_t p_chr) const { return find_char(p_chr) != -1; }
+	_FORCE_INLINE_ bool contains(char32_t p_chr) const { return find(p_chr) != -1; }
 	_FORCE_INLINE_ bool containsn(const char *p_str) const { return findn(p_str) != -1; }
 	_FORCE_INLINE_ bool containsn(const String &p_str) const { return findn(p_str) != -1; }
 

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1961,7 +1961,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 		case Variant::FLOAT: {
 			String s = rtos_fix(p_variant.operator double());
 			if (s != "inf" && s != "inf_neg" && s != "nan") {
-				if (!s.contains_char('.') && !s.contains_char('e')) {
+				if (!s.contains('.') && !s.contains('e')) {
 					s += ".0";
 				}
 			}

--- a/drivers/alsa/audio_driver_alsa.cpp
+++ b/drivers/alsa/audio_driver_alsa.cpp
@@ -80,7 +80,7 @@ Error AudioDriverALSA::init_output_device() {
 		status = snd_pcm_open(&pcm_handle, "default", SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK);
 	} else {
 		String device = output_device_name;
-		int pos = device.find_char(';');
+		int pos = device.find(';');
 		if (pos != -1) {
 			device = device.substr(0, pos);
 		}

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -864,7 +864,7 @@ String OS_Unix::get_locale() const {
 	}
 
 	String locale = get_environment("LANG");
-	int tp = locale.find_char('.');
+	int tp = locale.find('.');
 	if (tp != -1) {
 		locale = locale.substr(0, tp);
 	}
@@ -949,13 +949,13 @@ String OS_Unix::get_environment(const String &p_var) const {
 }
 
 void OS_Unix::set_environment(const String &p_var, const String &p_value) const {
-	ERR_FAIL_COND_MSG(p_var.is_empty() || p_var.contains_char('='), vformat("Invalid environment variable name '%s', cannot be empty or include '='.", p_var));
+	ERR_FAIL_COND_MSG(p_var.is_empty() || p_var.contains('='), vformat("Invalid environment variable name '%s', cannot be empty or include '='.", p_var));
 	int err = setenv(p_var.utf8().get_data(), p_value.utf8().get_data(), /* overwrite: */ 1);
 	ERR_FAIL_COND_MSG(err != 0, vformat("Failed setting environment variable '%s', the system is out of memory.", p_var));
 }
 
 void OS_Unix::unset_environment(const String &p_var) const {
-	ERR_FAIL_COND_MSG(p_var.is_empty() || p_var.contains_char('='), vformat("Invalid environment variable name '%s', cannot be empty or include '='.", p_var));
+	ERR_FAIL_COND_MSG(p_var.is_empty() || p_var.contains('='), vformat("Invalid environment variable name '%s', cannot be empty or include '='.", p_var));
 	unsetenv(p_var.utf8().get_data());
 }
 

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -230,7 +230,7 @@ String DirAccessWindows::get_current_dir(bool p_include_drive) const {
 		return cdir;
 	} else {
 		if (_get_root_string().is_empty()) {
-			int pos = cdir.find_char(':');
+			int pos = cdir.find(':');
 			if (pos != -1) {
 				return cdir.substr(pos + 1);
 			}
@@ -344,7 +344,7 @@ String DirAccessWindows::get_filesystem_type() const {
 		return "Network Share";
 	}
 
-	int unit_end = path.find_char(':');
+	int unit_end = path.find(':');
 	ERR_FAIL_COND_V(unit_end == -1, String());
 	String unit = path.substr(0, unit_end + 1) + "\\";
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -72,7 +72,7 @@ bool FileAccessWindows::is_path_invalid(const String &p_path) {
 	// Check for invalid operating system file.
 	String fname = p_path.get_file().to_lower();
 
-	int dot = fname.find_char('.');
+	int dot = fname.find('.');
 	if (dot != -1) {
 		fname = fname.substr(0, dot);
 	}

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -275,7 +275,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 				}
 
 				String base_path = animation->track_get_path(i);
-				int end = base_path.find_char(':');
+				int end = base_path.find(':');
 				if (end != -1) {
 					base_path = base_path.substr(0, end + 1);
 				}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4354,7 +4354,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 			if (track_path == np) {
 				actual_value = value; // All good.
 			} else {
-				int sep = track_path.rfind_char(':');
+				int sep = track_path.rfind(':');
 				if (sep != -1) {
 					String base_path = track_path.substr(0, sep);
 					if (base_path == np) {
@@ -6509,7 +6509,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 					path = NodePath(node->get_path().get_names(), path.get_subnames(), true); // Store full path instead for copying.
 				} else {
 					text = path;
-					int sep = text.find_char(':');
+					int sep = text.find(':');
 					if (sep != -1) {
 						text = text.substr(sep + 1, text.length());
 					}

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -523,8 +523,8 @@ void ConnectDialog::set_dst_node(Node *p_node) {
 
 StringName ConnectDialog::get_dst_method_name() const {
 	String txt = dst_method->get_text();
-	if (txt.contains_char('(')) {
-		txt = txt.left(txt.find_char('(')).strip_edges();
+	if (txt.contains('(')) {
+		txt = txt.left(txt.find('(')).strip_edges();
 	}
 	return txt;
 }

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -169,13 +169,13 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 
 		String script_path = ScriptServer::get_global_class_path(p_type);
 		if (script_path.begins_with("res://addons/")) {
-			int i = script_path.find_char('/', 13); // 13 is length of "res://addons/".
+			int i = script_path.find('/', 13); // 13 is length of "res://addons/".
 			while (i > -1) {
 				const String plugin_path = script_path.substr(0, i).path_join("plugin.cfg");
 				if (FileAccess::exists(plugin_path)) {
 					return !EditorNode::get_singleton()->is_addon_plugin_enabled(plugin_path);
 				}
-				i = script_path.find_char('/', i + 1);
+				i = script_path.find('/', i + 1);
 			}
 		}
 	}

--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -147,7 +147,7 @@ Dictionary DebugAdapterParser::req_initialize(const Dictionary &p_params) const 
 		for (List<String>::Element *E = breakpoints.front(); E; E = E->next()) {
 			String breakpoint = E->get();
 
-			String path = breakpoint.left(breakpoint.find_char(':', 6)); // Skip initial part of path, aka "res://"
+			String path = breakpoint.left(breakpoint.find(':', 6)); // Skip initial part of path, aka "res://"
 			int line = breakpoint.substr(path.size()).to_int();
 
 			DebugAdapterProtocol::get_singleton()->on_debug_breakpoint_toggled(path, line, true);
@@ -359,7 +359,7 @@ Dictionary DebugAdapterParser::req_setBreakpoints(const Dictionary &p_params) co
 	}
 
 	// If path contains \, it's a Windows path, so we need to convert it to /, and make the drive letter uppercase
-	if (source.path.contains_char('\\')) {
+	if (source.path.contains('\\')) {
 		source.path = source.path.replace("\\", "/");
 		source.path = source.path.substr(0, 1).to_upper() + source.path.substr(1);
 	}

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -47,7 +47,7 @@ private:
 
 	_FORCE_INLINE_ bool is_valid_path(const String &p_path) const {
 		// If path contains \, it's a Windows path, so we need to convert it to /, and check as case-insensitive.
-		if (p_path.contains_char('\\')) {
+		if (p_path.contains('\\')) {
 			String project_path = ProjectSettings::get_singleton()->get_resource_path();
 			String path = p_path.replace("\\", "/");
 			return path.containsn(project_path);

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -160,9 +160,9 @@ void EditorDebuggerNode::_text_editor_stack_goto(const ScriptEditorDebugger *p_d
 	} else {
 		// If the script is built-in, it can be opened only if the scene is loaded in memory.
 		int i = file.find("::");
-		int j = file.rfind_char('(', i);
+		int j = file.rfind('(', i);
 		if (j > -1) { // If the script is named, the string is "name (file)", so we need to extract the path.
-			file = file.substr(j + 1, file.find_char(')', i) - j - 1);
+			file = file.substr(j + 1, file.find(')', i) - j - 1);
 		}
 		Ref<PackedScene> ps = ResourceLoader::load(file.get_slice("::", 0));
 		stack_script = ResourceLoader::load(file);
@@ -183,9 +183,9 @@ void EditorDebuggerNode::_text_editor_stack_clear(const ScriptEditorDebugger *p_
 	} else {
 		// If the script is built-in, it can be opened only if the scene is loaded in memory.
 		int i = file.find("::");
-		int j = file.rfind_char('(', i);
+		int j = file.rfind('(', i);
 		if (j > -1) { // If the script is named, the string is "name (file)", so we need to extract the path.
-			file = file.substr(j + 1, file.find_char(')', i) - j - 1);
+			file = file.substr(j + 1, file.find(')', i) - j - 1);
 		}
 		Ref<PackedScene> ps = ResourceLoader::load(file.get_slice("::", 0));
 		stack_script = ResourceLoader::load(file);
@@ -833,7 +833,7 @@ void EditorDebuggerNode::remove_debugger_plugin(const Ref<EditorDebuggerPlugin> 
 bool EditorDebuggerNode::plugins_capture(ScriptEditorDebugger *p_debugger, const String &p_message, const Array &p_data) {
 	int session_index = tabs->get_tab_idx_from_control(p_debugger);
 	ERR_FAIL_COND_V(session_index < 0, false);
-	int colon_index = p_message.find_char(':');
+	int colon_index = p_message.find(':');
 	ERR_FAIL_COND_V_MSG(colon_index < 1, false, "Invalid message received.");
 
 	const String cap = p_message.substr(0, colon_index);

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -382,7 +382,7 @@ void EditorDebuggerTree::_item_menu_id_pressed(int p_option) {
 				text = ".";
 			} else {
 				text = text.replace("/root/", "");
-				int slash = text.find_char('/');
+				int slash = text.find('/');
 				if (slash < 0) {
 					text = ".";
 				} else {

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -830,7 +830,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread
 	} else if (p_msg == "evaluation_return") {
 		expression_evaluator->add_value(p_data);
 	} else {
-		int colon_index = p_msg.find_char(':');
+		int colon_index = p_msg.find(':');
 		ERR_FAIL_COND_MSG(colon_index < 1, "Invalid message received");
 
 		bool parsed = EditorDebuggerNode::get_singleton()->plugins_capture(this, p_msg, p_data);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -471,7 +471,7 @@ void DependencyRemoveDialog::_find_localization_remaps_of_removed_files(Vector<R
 			for (int j = 0; j < remap_keys.size(); j++) {
 				PackedStringArray remapped_files = remaps[remap_keys[j]];
 				for (int k = 0; k < remapped_files.size(); k++) {
-					int splitter_pos = remapped_files[k].rfind_char(':');
+					int splitter_pos = remapped_files[k].rfind(':');
 					String res_path = remapped_files[k].substr(0, splitter_pos);
 					if (res_path == path) {
 						String locale_name = remapped_files[k].substr(splitter_pos + 1);

--- a/editor/directory_create_dialog.cpp
+++ b/editor/directory_create_dialog.cpp
@@ -67,8 +67,8 @@ String DirectoryCreateDialog::_validate_path(const String &p_path) const {
 				return TTR("Folder name cannot be empty.");
 			}
 		}
-		if (part.contains_char('\\') || part.contains_char(':') || part.contains_char('*') ||
-				part.contains_char('|') || part.contains_char('>') || part.ends_with(".") || part.ends_with(" ")) {
+		if (part.contains('\\') || part.contains(':') || part.contains('*') ||
+				part.contains('|') || part.contains('>') || part.ends_with(".") || part.ends_with(" ")) {
 			if (is_file) {
 				return TTR("File name contains invalid characters.");
 			} else {
@@ -101,7 +101,7 @@ void DirectoryCreateDialog::_on_dir_path_changed() {
 	const String error = _validate_path(path);
 
 	if (error.is_empty()) {
-		if (path.contains_char('/')) {
+		if (path.contains('/')) {
 			if (mode == MODE_DIRECTORY) {
 				validation_panel->set_message(EditorValidationPanel::MSG_ID_DEFAULT, TTR("Using slashes in folder names will create subfolders recursively."), EditorValidationPanel::MSG_OK);
 			} else {
@@ -142,7 +142,7 @@ void DirectoryCreateDialog::config(const String &p_base_dir, const Callable &p_a
 	validation_panel->update();
 
 	if (p_mode == MODE_FILE) {
-		int extension_pos = p_default_name.rfind_char('.');
+		int extension_pos = p_default_name.rfind('.');
 		if (extension_pos > -1) {
 			dir_path->select(0, extension_pos);
 			return;

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -130,14 +130,14 @@ void EditorAssetInstaller::open_asset(const String &p_path, bool p_autoskip_topl
 
 		// Create intermediate directories if they aren't reported by unzip.
 		// We are only interested in subfolders, so skip the root slash.
-		int separator = source_name.find_char('/', 1);
+		int separator = source_name.find('/', 1);
 		while (separator != -1) {
 			String dir_name = source_name.substr(0, separator + 1);
 			if (!dir_name.is_empty() && !asset_files.has(dir_name)) {
 				asset_files.insert(dir_name);
 			}
 
-			separator = source_name.find_char('/', separator + 1);
+			separator = source_name.find('/', separator + 1);
 		}
 
 		if (!source_name.is_empty() && !asset_files.has(source_name)) {
@@ -214,7 +214,7 @@ void EditorAssetInstaller::_rebuild_source_tree() {
 
 		TreeItem *parent_item;
 
-		int separator = path.rfind_char('/');
+		int separator = path.rfind('/');
 		if (separator == -1) {
 			parent_item = root;
 		} else {
@@ -313,7 +313,7 @@ void EditorAssetInstaller::_rebuild_destination_tree() {
 
 		TreeItem *parent_item;
 
-		int separator = path.rfind_char('/');
+		int separator = path.rfind('/');
 		if (separator == -1) {
 			parent_item = root;
 		} else {

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -472,7 +472,7 @@ void EditorFeatureProfileManager::_erase_selected_profile() {
 
 void EditorFeatureProfileManager::_create_new_profile() {
 	String name = new_profile_name->get_text().strip_edges();
-	if (!name.is_valid_filename() || name.contains_char('.')) {
+	if (!name.is_valid_filename() || name.contains('.')) {
 		EditorNode::get_singleton()->show_warning(TTR("Profile must be a valid filename and must not contain '.'"));
 		return;
 	}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -384,7 +384,7 @@ void EditorFileSystem::_scan_filesystem() {
 
 					FileCache fc;
 					fc.type = split[1];
-					if (fc.type.contains_char('/')) {
+					if (fc.type.contains('/')) {
 						fc.type = split[1].get_slice("/", 0);
 						fc.resource_script_class = split[1].get_slice("/", 1);
 					}

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -249,7 +249,7 @@ void EditorFolding::_do_object_unfolds(Object *p_object, HashSet<Ref<Resource>> 
 					}
 				}
 			} else { //path
-				int last = E.name.rfind_char('/');
+				int last = E.name.rfind('/');
 				if (last != -1) {
 					bool can_revert = EditorPropertyRevert::can_property_revert(p_object, E.name);
 					if (can_revert) {

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -170,7 +170,7 @@ static String _contextualize_class_specifier(const String &p_class_specifier, co
 
 	// Here equal `length()` and `begins_with()` from above implies `p_class_specifier == p_edited_class`.
 	if (p_class_specifier.length() == p_edited_class.length()) {
-		int rfind = p_class_specifier.rfind_char('.');
+		int rfind = p_class_specifier.rfind('.');
 		if (rfind == -1) { // Single identifier.
 			return p_class_specifier;
 		}
@@ -289,7 +289,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 			enum_class_name = "@GlobalScope";
 			enum_name = link;
 		} else {
-			const int dot_pos = link.rfind_char('.');
+			const int dot_pos = link.rfind('.');
 			if (dot_pos >= 0) {
 				enum_class_name = link.left(dot_pos);
 				enum_name = link.substr(dot_pos + 1);
@@ -303,7 +303,7 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 	} else if (p_select.begins_with("#")) { // Class.
 		emit_signal(SNAME("go_to_help"), "class_name:" + p_select.substr(1));
 	} else if (p_select.begins_with("@")) { // Member.
-		const int tag_end = p_select.find_char(' ');
+		const int tag_end = p_select.find(' ');
 		const String tag = p_select.substr(1, tag_end - 1);
 		const String link = p_select.substr(tag_end + 1).lstrip(" ");
 
@@ -375,8 +375,8 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 				}
 			}
 
-			if (link.contains_char('.')) {
-				const int class_end = link.rfind_char('.');
+			if (link.contains('.')) {
+				const int class_end = link.rfind('.');
 				emit_signal(SNAME("go_to_help"), topic + ":" + link.left(class_end) + ":" + link.substr(class_end + 1));
 			}
 		}
@@ -420,7 +420,7 @@ static void _add_type_to_rt(const String &p_type, const String &p_enum, bool p_i
 
 	bool is_enum_type = !p_enum.is_empty();
 	bool is_bitfield = p_is_bitfield && is_enum_type;
-	bool can_ref = !p_type.contains_char('*') || is_enum_type;
+	bool can_ref = !p_type.contains('*') || is_enum_type;
 
 	String link_t = p_type; // For links in metadata
 	String display_t; // For display purposes.
@@ -1607,7 +1607,7 @@ void EditorHelp::_update_doc() {
 			class_desc->push_color(theme_cache.comment_color);
 
 			const String descr = HANDLE_DOC(signal.description);
-			const bool is_multiline = descr.find_char('\n') > 0;
+			const bool is_multiline = descr.find('\n') > 0;
 			bool has_prev_text = false;
 
 			if (signal.is_deprecated) {
@@ -1738,7 +1738,7 @@ void EditorHelp::_update_doc() {
 				// Enum description.
 				if (key != "@unnamed_enums" && cd.enums.has(key)) {
 					const String descr = HANDLE_DOC(cd.enums[key].description);
-					const bool is_multiline = descr.find_char('\n') > 0;
+					const bool is_multiline = descr.find('\n') > 0;
 					if (cd.enums[key].is_deprecated || cd.enums[key].is_experimental || !descr.is_empty()) {
 						class_desc->add_newline();
 
@@ -1787,7 +1787,7 @@ void EditorHelp::_update_doc() {
 				bool prev_is_multiline = true; // Use a large margin for the first item.
 				for (const DocData::ConstantDoc &enum_value : E.value) {
 					const String descr = HANDLE_DOC(enum_value.description);
-					const bool is_multiline = descr.find_char('\n') > 0;
+					const bool is_multiline = descr.find('\n') > 0;
 
 					class_desc->add_newline();
 					if (prev_is_multiline || is_multiline) {
@@ -1886,7 +1886,7 @@ void EditorHelp::_update_doc() {
 			bool prev_is_multiline = true; // Use a large margin for the first item.
 			for (const DocData::ConstantDoc &constant : constants) {
 				const String descr = HANDLE_DOC(constant.description);
-				const bool is_multiline = descr.find_char('\n') > 0;
+				const bool is_multiline = descr.find('\n') > 0;
 
 				class_desc->add_newline();
 				if (prev_is_multiline || is_multiline) {
@@ -2496,7 +2496,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 
 	int pos = 0;
 	while (pos < bbcode.length()) {
-		int brk_pos = bbcode.find_char('[', pos);
+		int brk_pos = bbcode.find('[', pos);
 
 		if (brk_pos < 0) {
 			brk_pos = bbcode.length();
@@ -2510,7 +2510,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			break; // Nothing else to add.
 		}
 
-		int brk_end = bbcode.find_char(']', brk_pos + 1);
+		int brk_end = bbcode.find(']', brk_pos + 1);
 
 		if (brk_end == -1) {
 			p_rt->add_text(bbcode.substr(brk_pos, bbcode.length() - brk_pos).replace("\n", "\n\n"));
@@ -2541,7 +2541,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 				p_rt->pop();
 			}
 		} else if (tag.begins_with("method ") || tag.begins_with("constructor ") || tag.begins_with("operator ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ") || tag.begins_with("annotation ") || tag.begins_with("theme_item ")) {
-			const int tag_end = tag.find_char(' ');
+			const int tag_end = tag.find(' ');
 			const String link_tag = tag.left(tag_end);
 			const String link_target = tag.substr(tag_end + 1).lstrip(" ");
 
@@ -2566,7 +2566,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			p_rt->push_meta("@" + link_tag + " " + link_target, underline_mode);
 
 			if (link_tag == "member" &&
-					((!link_target.contains_char('.') && (p_class == "ProjectSettings" || p_class == "EditorSettings")) ||
+					((!link_target.contains('.') && (p_class == "ProjectSettings" || p_class == "EditorSettings")) ||
 							link_target.begins_with("ProjectSettings.") || link_target.begins_with("EditorSettings."))) {
 				// Special formatting for both ProjectSettings and EditorSettings.
 				String prefix;
@@ -2594,7 +2594,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 
 			pos = brk_end + 1;
 		} else if (tag.begins_with("param ")) {
-			const int tag_end = tag.find_char(' ');
+			const int tag_end = tag.find(' ');
 			const String param_name = tag.substr(tag_end + 1).lstrip(" ");
 
 			// Use monospace font with translucent background color to make code easier to distinguish from other text.
@@ -2810,7 +2810,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			if (tag.begins_with("url=")) {
 				url = tag.substr(4);
 			} else {
-				int end = bbcode.find_char('[', brk_end);
+				int end = bbcode.find('[', brk_end);
 				if (end == -1) {
 					end = bbcode.length();
 				}
@@ -2831,7 +2831,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 				HashMap<String, String> bbcode_options;
 				for (int i = 0; i < subtags.size(); i++) {
 					const String &expr = subtags[i];
-					int value_pos = expr.find_char('=');
+					int value_pos = expr.find('=');
 					if (value_pos > -1) {
 						bbcode_options[expr.left(value_pos)] = expr.substr(value_pos + 1).unquote();
 					}
@@ -2852,7 +2852,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 					}
 				}
 			}
-			int end = bbcode.find_char('[', brk_end);
+			int end = bbcode.find('[', brk_end);
 			if (end == -1) {
 				end = bbcode.length();
 			}
@@ -3384,7 +3384,7 @@ EditorHelpBit::HelpData EditorHelpBit::_get_property_help_data(const StringName 
 				enum_class_name = "@GlobalScope";
 				enum_name = property.enumeration;
 			} else {
-				const int dot_pos = property.enumeration.rfind_char('.');
+				const int dot_pos = property.enumeration.rfind('.');
 				if (dot_pos >= 0) {
 					enum_class_name = property.enumeration.left(dot_pos);
 					enum_name = property.enumeration.substr(dot_pos + 1);
@@ -3889,7 +3889,7 @@ void EditorHelpBit::_meta_clicked(const String &p_select) {
 			enum_class_name = "@GlobalScope";
 			enum_name = link;
 		} else {
-			const int dot_pos = link.rfind_char('.');
+			const int dot_pos = link.rfind('.');
 			if (dot_pos >= 0) {
 				enum_class_name = link.left(dot_pos);
 				enum_name = link.substr(dot_pos + 1);
@@ -3903,7 +3903,7 @@ void EditorHelpBit::_meta_clicked(const String &p_select) {
 	} else if (p_select.begins_with("#")) { // Class.
 		_go_to_help("class_name:" + p_select.substr(1));
 	} else if (p_select.begins_with("@")) { // Member.
-		const int tag_end = p_select.find_char(' ');
+		const int tag_end = p_select.find(' ');
 		const String tag = p_select.substr(1, tag_end - 1);
 		const String link = p_select.substr(tag_end + 1).lstrip(" ");
 
@@ -3943,8 +3943,8 @@ void EditorHelpBit::_meta_clicked(const String &p_select) {
 			}
 		}
 
-		if (link.contains_char('.')) {
-			const int class_end = link.rfind_char('.');
+		if (link.contains('.')) {
+			const int class_end = link.rfind('.');
 			_go_to_help(topic + ":" + link.left(class_end) + ":" + link.substr(class_end + 1));
 		} else {
 			_go_to_help(topic + ":" + symbol_class_name + ":" + link);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -281,7 +281,7 @@ void EditorProperty::_notification(int p_what) {
 			} else {
 				color = get_theme_color(is_read_only() ? SNAME("readonly_color") : SNAME("property_color"));
 			}
-			if (label.contains_char('.')) {
+			if (label.contains('.')) {
 				// FIXME: Move this to the project settings editor, as this is only used
 				// for project settings feature tag overrides.
 				color.a = 0.5;
@@ -3140,7 +3140,7 @@ void EditorInspector::update_tree() {
 
 		if (!array_prefix.is_empty()) {
 			path = path.trim_prefix(array_prefix);
-			int char_index = path.find_char('/');
+			int char_index = path.find('/');
 			if (char_index >= 0) {
 				path = path.right(-char_index - 1);
 			} else {
@@ -3180,10 +3180,10 @@ void EditorInspector::update_tree() {
 		}
 
 		// Get the property label's string.
-		String name_override = (path.contains_char('/')) ? path.substr(path.rfind_char('/') + 1) : path;
+		String name_override = (path.contains('/')) ? path.substr(path.rfind('/') + 1) : path;
 		String feature_tag;
 		{
-			const int dot = name_override.find_char('.');
+			const int dot = name_override.find('.');
 			if (dot != -1) {
 				feature_tag = name_override.substr(dot);
 				name_override = name_override.substr(0, dot);
@@ -3198,7 +3198,7 @@ void EditorInspector::update_tree() {
 		const String property_label_string = EditorPropertyNameProcessor::get_singleton()->process_name(name_override, name_style, p.name, doc_name) + feature_tag;
 
 		// Remove the property from the path.
-		int idx = path.rfind_char('/');
+		int idx = path.rfind('/');
 		if (idx > -1) {
 			path = path.left(idx);
 		} else {
@@ -3329,7 +3329,7 @@ void EditorInspector::update_tree() {
 				array_element_prefix = class_name_components[0];
 				editor_inspector_array = memnew(EditorInspectorArray(all_read_only));
 
-				String array_label = path.contains_char('/') ? path.substr(path.rfind_char('/') + 1) : path;
+				String array_label = path.contains('/') ? path.substr(path.rfind('/') + 1) : path;
 				array_label = EditorPropertyNameProcessor::get_singleton()->process_name(property_label_string, property_name_style, p.name, doc_name);
 				int page = per_array_page.has(array_element_prefix) ? per_array_page[array_element_prefix] : 0;
 				editor_inspector_array->setup_with_move_element_function(object, array_label, array_element_prefix, page, c, use_folding);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -253,8 +253,8 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 				// append that to yield "folder/foo.tscn".
 				if (difference > 0) {
 					String parent = full_path.substr(0, difference);
-					int slash_idx = parent.rfind_char('/');
-					slash_idx = parent.rfind_char('/', slash_idx - 1);
+					int slash_idx = parent.rfind('/');
+					slash_idx = parent.rfind('/', slash_idx - 1);
 					parent = (slash_idx >= 0 && parent.length() > 1) ? parent.substr(slash_idx + 1) : parent;
 					r_filenames.write[set_idx] = parent + r_filenames[set_idx];
 				}

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -837,7 +837,7 @@ void EditorPropertyLayersGrid::_rename_operation_confirm() {
 	if (new_name.length() == 0) {
 		EditorNode::get_singleton()->show_warning(TTR("No name provided."));
 		return;
-	} else if (new_name.contains_char('/') || new_name.contains_char('\\') || new_name.contains_char(':')) {
+	} else if (new_name.contains('/') || new_name.contains('\\') || new_name.contains(':')) {
 		EditorNode::get_singleton()->show_warning(TTR("Name contains invalid characters."));
 		return;
 	}
@@ -2873,7 +2873,7 @@ void EditorPropertyNodePath::update_property() {
 	const Node *target_node = base_node->get_node(p);
 	ERR_FAIL_NULL(target_node);
 
-	if (String(target_node->get_name()).contains_char('@')) {
+	if (String(target_node->get_name()).contains('@')) {
 		assign->set_button_icon(Ref<Texture2D>());
 		assign->set_text(p);
 		return;

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -740,10 +740,10 @@ void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint
 	// The format of p_hint_string is:
 	// subType/subTypeHint:nextSubtype ... etc.
 	if (!p_hint_string.is_empty()) {
-		int hint_subtype_separator = p_hint_string.find_char(':');
+		int hint_subtype_separator = p_hint_string.find(':');
 		if (hint_subtype_separator >= 0) {
 			String subtype_string = p_hint_string.substr(0, hint_subtype_separator);
-			int slash_pos = subtype_string.find_char('/');
+			int slash_pos = subtype_string.find('/');
 			if (slash_pos >= 0) {
 				subtype_hint = PropertyHint(subtype_string.substr(slash_pos + 1, subtype_string.size() - slash_pos - 1).to_int());
 				subtype_string = subtype_string.substr(0, slash_pos);
@@ -1006,10 +1006,10 @@ void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_s
 	PackedStringArray types = p_hint_string.split(";");
 	if (types.size() > 0 && !types[0].is_empty()) {
 		String key = types[0];
-		int hint_key_subtype_separator = key.find_char(':');
+		int hint_key_subtype_separator = key.find(':');
 		if (hint_key_subtype_separator >= 0) {
 			String key_subtype_string = key.substr(0, hint_key_subtype_separator);
-			int slash_pos = key_subtype_string.find_char('/');
+			int slash_pos = key_subtype_string.find('/');
 			if (slash_pos >= 0) {
 				key_subtype_hint = PropertyHint(key_subtype_string.substr(slash_pos + 1, key_subtype_string.size() - slash_pos - 1).to_int());
 				key_subtype_string = key_subtype_string.substr(0, slash_pos);
@@ -1025,10 +1025,10 @@ void EditorPropertyDictionary::setup(PropertyHint p_hint, const String &p_hint_s
 	}
 	if (types.size() > 1 && !types[1].is_empty()) {
 		String value = types[1];
-		int hint_value_subtype_separator = value.find_char(':');
+		int hint_value_subtype_separator = value.find(':');
 		if (hint_value_subtype_separator >= 0) {
 			String value_subtype_string = value.substr(0, hint_value_subtype_separator);
-			int slash_pos = value_subtype_string.find_char('/');
+			int slash_pos = value_subtype_string.find('/');
 			if (slash_pos >= 0) {
 				value_subtype_hint = PropertyHint(value_subtype_string.substr(slash_pos + 1, value_subtype_string.size() - slash_pos - 1).to_int());
 				value_subtype_string = value_subtype_string.substr(0, slash_pos);

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -96,7 +96,7 @@ class SectionedInspectorFilter : public Object {
 		List<PropertyInfo> pinfo;
 		edited->get_property_list(&pinfo);
 		for (PropertyInfo &pi : pinfo) {
-			int sp = pi.name.find_char('/');
+			int sp = pi.name.find('/');
 
 			if (pi.name == "resource_path" || pi.name == "resource_name" || pi.name == "resource_local_to_scene" || pi.name.begins_with("script/") || pi.name.begins_with("_global_script")) { //skip resource stuff
 				continue;
@@ -108,7 +108,7 @@ class SectionedInspectorFilter : public Object {
 
 			if (pi.name.begins_with(section + "/")) {
 				pi.name = pi.name.replace_first(section + "/", "");
-				if (!allow_sub && pi.name.contains_char('/')) {
+				if (!allow_sub && pi.name.contains('/')) {
 					continue;
 				}
 				p_list->push_back(pi);
@@ -247,7 +247,7 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		if (pi.name.contains_char(':') || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script")) {
+		if (pi.name.contains(':') || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script")) {
 			continue;
 		}
 
@@ -255,7 +255,7 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		int sp = pi.name.find_char('/');
+		int sp = pi.name.find('/');
 		if (sp == -1) {
 			pi.name = "global/" + pi.name;
 		}

--- a/editor/engine_update_label.cpp
+++ b/editor/engine_update_label.cpp
@@ -240,8 +240,8 @@ EngineUpdateLabel::VersionType EngineUpdateLabel::_get_version_type(const String
 }
 
 String EngineUpdateLabel::_extract_sub_string(const String &p_line) const {
-	int j = p_line.find_char('"') + 1;
-	return p_line.substr(j, p_line.find_char('"', j) - j);
+	int j = p_line.find('"') + 1;
+	return p_line.substr(j, p_line.find('"', j) - j);
 }
 
 void EngineUpdateLabel::_notification(int p_what) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -137,7 +137,7 @@ bool FileSystemList::edit_selected() {
 
 	String name = get_item_text(s);
 	line_editor->set_text(name);
-	line_editor->select(0, name.rfind_char('.'));
+	line_editor->select(0, name.rfind('.'));
 
 	popup_edit_commited = false; // Start edit popup processing.
 	popup_editor->popup();
@@ -1777,7 +1777,7 @@ void FileSystemDock::_rename_operation_confirm() {
 	if (new_name.length() == 0) {
 		EditorNode::get_singleton()->show_warning(TTR("No name provided."));
 		rename_error = true;
-	} else if (new_name.contains_char('/') || new_name.contains_char('\\') || new_name.contains_char(':')) {
+	} else if (new_name.contains('/') || new_name.contains('\\') || new_name.contains(':')) {
 		EditorNode::get_singleton()->show_warning(TTR("Name contains invalid characters."));
 		rename_error = true;
 	} else if (new_name[0] == '.') {
@@ -2240,7 +2240,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 				test_args.push_back("command -v " + terminal_emulator);
 				const Error err = OS::get_singleton()->execute("bash", test_args, &pipe);
 				// Check if a path to the terminal executable exists.
-				if (err == OK && pipe.contains_char('/')) {
+				if (err == OK && pipe.contains('/')) {
 					chosen_terminal_emulator = terminal_emulator;
 					break;
 				} else if (err == ERR_CANT_FORK) {
@@ -2456,7 +2456,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 
 					if (to_rename.is_file) {
 						String name = to_rename.path.get_file();
-						tree->set_editor_selection(0, name.rfind_char('.'));
+						tree->set_editor_selection(0, name.rfind('.'));
 					} else {
 						String name = to_rename.path.left(-1).get_file(); // Removes the "/" suffix for folders.
 						tree->set_editor_selection(0, name.length());
@@ -3688,10 +3688,10 @@ void FileSystemDock::_file_list_gui_input(Ref<InputEvent> p_event) {
 			tree_item->select(0);
 		} else {
 			// Find parent folder.
-			fpath = fpath.substr(0, fpath.rfind_char('/') + 1);
+			fpath = fpath.substr(0, fpath.rfind('/') + 1);
 			if (fpath.size() > String("res://").size()) {
 				fpath = fpath.left(fpath.size() - 2); // Remove last '/'.
-				const int slash_idx = fpath.rfind_char('/');
+				const int slash_idx = fpath.rfind('/');
 				fpath = fpath.substr(slash_idx + 1, fpath.size() - slash_idx - 1);
 			}
 

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -165,7 +165,7 @@ void EditorFileDialog::popup_file_dialog() {
 }
 
 void EditorFileDialog::_focus_file_text() {
-	int lp = file->get_text().rfind_char('.');
+	int lp = file->get_text().rfind('.');
 	if (lp != -1) {
 		file->select(0, lp);
 		file->grab_focus();
@@ -1353,7 +1353,7 @@ void EditorFileDialog::set_current_path(const String &p_path) {
 	if (!p_path.size()) {
 		return;
 	}
-	int pos = MAX(p_path.rfind_char('/'), p_path.rfind_char('\\'));
+	int pos = MAX(p_path.rfind('/'), p_path.rfind('\\'));
 	if (pos == -1) {
 		set_current_file(p_path);
 	} else {

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1014,7 +1014,7 @@ bool SceneTreeEditor::_item_matches_all_terms(TreeItem *p_item, const PackedStri
 		const String &term = p_terms[i];
 
 		// Recognize special filter.
-		if (term.contains_char(':') && !term.get_slicec(':', 0).is_empty()) {
+		if (term.contains(':') && !term.get_slicec(':', 0).is_empty()) {
 			String parameter = term.get_slicec(':', 0);
 			String argument = term.get_slicec(':', 1);
 

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -1808,10 +1808,10 @@ void Collada::_parse_animation(XMLParser &p_parser) {
 				}
 			}
 
-			if (target.contains_char('/')) { //transform component
+			if (target.contains('/')) { //transform component
 				track.target = target.get_slicec('/', 0);
 				track.param = target.get_slicec('/', 1);
-				if (track.param.contains_char('.')) {
+				if (track.param.contains('.')) {
 					track.component = track.param.get_slice(".", 1).to_upper();
 				}
 				track.param = track.param.get_slice(".", 0);

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -239,7 +239,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 				List<StringName> anims;
 				ap->get_animation_list(&anims);
 				for (const StringName &name : anims) {
-					if (String(name).contains_char('/')) {
+					if (String(name).contains('/')) {
 						continue; // Avoid animation library which may be created by importer dynamically.
 					}
 

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -200,7 +200,7 @@ Error ResourceImporterImageFont::import(ResourceUID::ID p_source_id, const Strin
 					case STEP_OFF_Y_BEGIN: {
 						// Read advance and offset.
 						if (range[c] == ' ') {
-							int next = range.find_char(' ', c + 1);
+							int next = range.find(' ', c + 1);
 							if (next < c) {
 								next = range.length();
 							}

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -441,7 +441,7 @@ void LocalizationEditor::_filesystem_files_moved(const String &p_old_file, const
 		bool remapped_files_updated = false;
 
 		for (int j = 0; j < remapped_files.size(); j++) {
-			int splitter_pos = remapped_files[j].rfind_char(':');
+			int splitter_pos = remapped_files[j].rfind(':');
 			String res_path = remapped_files[j].substr(0, splitter_pos);
 
 			if (res_path == p_old_file) {
@@ -482,7 +482,7 @@ void LocalizationEditor::_filesystem_file_removed(const String &p_file) {
 		for (int i = 0; i < remap_keys.size() && !remaps_changed; i++) {
 			PackedStringArray remapped_files = remaps[remap_keys[i]];
 			for (int j = 0; j < remapped_files.size() && !remaps_changed; j++) {
-				int splitter_pos = remapped_files[j].rfind_char(':');
+				int splitter_pos = remapped_files[j].rfind(':');
 				String res_path = remapped_files[j].substr(0, splitter_pos);
 				remaps_changed = p_file == res_path;
 				if (remaps_changed) {
@@ -567,7 +567,7 @@ void LocalizationEditor::update_translations() {
 				PackedStringArray selected = remaps[keys[i]];
 				for (int j = 0; j < selected.size(); j++) {
 					const String &s2 = selected[j];
-					int qp = s2.rfind_char(':');
+					int qp = s2.rfind(':');
 					String path = s2.substr(0, qp);
 					String locale = s2.substr(qp + 1, s2.length());
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -1068,7 +1068,7 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 
 	const String &new_name = p_text;
 
-	ERR_FAIL_COND(new_name.is_empty() || new_name.contains_char('.') || new_name.contains_char('/'));
+	ERR_FAIL_COND(new_name.is_empty() || new_name.contains('.') || new_name.contains('/'));
 
 	if (new_name == prev_name) {
 		return; //nothing to do

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -470,7 +470,7 @@ void AnimationLibraryEditor::_item_renamed() {
 	bool restore_text = false;
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
-	if (String(text).contains_char('/') || String(text).contains_char(':') || String(text).contains_char(',') || String(text).contains_char('[')) {
+	if (String(text).contains('/') || String(text).contains(':') || String(text).contains(',') || String(text).contains('[')) {
 		restore_text = true;
 	} else {
 		if (ti->get_parent() == tree->get_root()) {

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -504,7 +504,7 @@ void AnimationPlayerEditor::_animation_rename() {
 	String selected_name = animation->get_item_text(selected);
 
 	// Remove library prefix if present.
-	if (selected_name.contains_char('/')) {
+	if (selected_name.contains('/')) {
 		selected_name = selected_name.get_slice("/", 1);
 	}
 
@@ -537,7 +537,7 @@ void AnimationPlayerEditor::_animation_remove_confirmed() {
 	ERR_FAIL_COND(al.is_null());
 
 	// For names of form lib_name/anim_name, remove library name prefix.
-	if (current.contains_char('/')) {
+	if (current.contains('/')) {
 		current = current.get_slice("/", 1);
 	}
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -626,7 +626,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 
 			// Extract library prefix if present.
 			String new_library_prefix = "";
-			if (current.contains_char('/')) {
+			if (current.contains('/')) {
 				new_library_prefix = current.get_slice("/", 0) + "/";
 				current = current.get_slice("/", 1);
 			}
@@ -1340,7 +1340,7 @@ void AnimationPlayerEditor::_animation_duplicate() {
 		break;
 	}
 
-	if (new_name.contains_char('/')) {
+	if (new_name.contains('/')) {
 		// Discard library prefix.
 		new_name = new_name.get_slice("/", 1);
 	}

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1618,7 +1618,7 @@ void AnimationNodeStateMachineEditor::_open_editor(const String &p_name) {
 void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 	const String &new_name = p_text;
 
-	ERR_FAIL_COND(new_name.is_empty() || new_name.contains_char('.') || new_name.contains_char('/'));
+	ERR_FAIL_COND(new_name.is_empty() || new_name.contains('.') || new_name.contains('/'));
 
 	if (new_name == prev_name) {
 		return; // Nothing to do.

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -907,7 +907,7 @@ void EditorAssetLibrary::_image_request_completed(int p_status, int p_code, cons
 			for (int i = 0; i < headers.size(); i++) {
 				if (headers[i].findn("ETag:") == 0) { // Save etag
 					String cache_filename_base = EditorPaths::get_singleton()->get_cache_dir().path_join("assetimage_" + image_queue[p_queue_id].image_url.md5_text());
-					String new_etag = headers[i].substr(headers[i].find_char(':') + 1, headers[i].length()).strip_edges();
+					String new_etag = headers[i].substr(headers[i].find(':') + 1, headers[i].length()).strip_edges();
 					Ref<FileAccess> file = FileAccess::open(cache_filename_base + ".etag", FileAccess::WRITE);
 					if (file.is_valid()) {
 						file->store_line(new_etag);

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -113,7 +113,7 @@ void ResourcePreloaderEditor::_item_edited() {
 			return;
 		}
 
-		if (new_name.is_empty() || new_name.contains_char('\\') || new_name.contains_char('/') || preloader->has_resource(new_name)) {
+		if (new_name.is_empty() || new_name.contains('\\') || new_name.contains('/') || preloader->has_resource(new_name)) {
 			s->set_text(0, old_name);
 			return;
 		}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -183,7 +183,7 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 				if (E.usage & PROPERTY_USAGE_CATEGORY || E.usage & PROPERTY_USAGE_GROUP || E.usage & PROPERTY_USAGE_SUBGROUP) {
 					continue;
 				}
-				if (prop_name.contains_char('/')) {
+				if (prop_name.contains('/')) {
 					continue;
 				}
 				highlighter->add_member_keyword_color(prop_name, member_variable_color);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -285,7 +285,7 @@ void ScriptTextEditor::_warning_clicked(const Variant &p_line) {
 		CodeEdit *text_editor = code_editor->get_text_editor();
 		String prev_line = line > 0 ? text_editor->get_line(line - 1) : "";
 		if (prev_line.contains("@warning_ignore")) {
-			const int closing_bracket_idx = prev_line.find_char(')');
+			const int closing_bracket_idx = prev_line.find(')');
 			const String text_to_insert = ", " + code.quote(quote_style);
 			text_editor->insert_text(text_to_insert, line - 1, closing_bracket_idx);
 		} else {
@@ -1304,7 +1304,7 @@ void ScriptTextEditor::_update_connected_methods() {
 
 		// Account for inner classes by stripping the class names from the method,
 		// starting from the right since our inner class might be inside of another inner class.
-		int pos = raw_name.rfind_char('.');
+		int pos = raw_name.rfind('.');
 		if (pos != -1) {
 			name = raw_name.substr(pos + 1);
 		}
@@ -1734,7 +1734,7 @@ void ScriptTextEditor::_edit_option_toggle_inline_comment() {
 	script->get_language()->get_comment_delimiters(&comment_delimiters);
 
 	for (const String &script_delimiter : comment_delimiters) {
-		if (!script_delimiter.contains_char(' ')) {
+		if (!script_delimiter.contains(' ')) {
 			delimiter = script_delimiter;
 			break;
 		}

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -226,7 +226,7 @@ void VersionControlEditorPlugin::_refresh_commit_list() {
 		TreeItem *item = commit_list->create_item();
 
 		// Only display the first line of a commit message
-		int line_ending = commit.msg.find_char('\n');
+		int line_ending = commit.msg.find('\n');
 		String commit_display_msg = commit.msg.substr(0, line_ending);
 		String commit_date_string = _get_date_string_from(commit.unix_timestamp, commit.offset_minutes);
 

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -1677,7 +1677,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	}
 
 	// -- \t.func() -> \tsuper.func()       Object
-	if (line.contains_char('(') && line.contains_char('.')) {
+	if (line.contains('(') && line.contains('.')) {
 		line = reg_container.reg_super.sub(line, "$1super.$2", true); // TODO, not sure if possible, but for now this broke String text e.g. "Chosen .gitignore" -> "Chosen super.gitignore"
 	}
 
@@ -1970,7 +1970,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	// -- func c(var a, var b) -> func c(a, b)
 	if (line.contains("func ") && line.contains("var ")) {
 		int start = line.find("func ");
-		start = line.substr(start).find_char('(') + start;
+		start = line.substr(start).find('(') + start;
 		int end = get_end_parenthesis(line.substr(start)) + 1;
 		if (end > -1) {
 			Vector<String> parts = parse_arguments(line.substr(start, end));
@@ -2120,12 +2120,12 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 		}
 	}
 	// -- func _init(p_x:int).(p_x):  -> func _init(p_x:int):\n\tsuper(p_x)    Object # https://github.com/godotengine/godot/issues/70542
-	if (line.contains(" _init(") && line.rfind_char(':') > 0) {
+	if (line.contains(" _init(") && line.rfind(':') > 0) {
 		//     func _init(p_arg1).(super4, super5, super6)->void:
 		// ^--^indent            ^super_start   super_end^
 		int indent = line.count("\t", 0, line.find("func"));
 		int super_start = line.find(".(");
-		int super_end = line.rfind_char(')');
+		int super_end = line.rfind(')');
 		if (super_start > 0 && super_end > super_start) {
 			line = line.substr(0, super_start) + line.substr(super_end + 1) + "\n" + String("\t").repeat(indent + 1) + "super" + line.substr(super_start + 1, super_end - super_start);
 		}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -837,7 +837,7 @@ void ProjectManager::_set_new_tag_name(const String p_name) {
 		return;
 	}
 
-	if (p_name.contains_char(' ')) {
+	if (p_name.contains(' ')) {
 		tag_error->set_text(TTR("Tag name can't contain spaces."));
 		return;
 	}

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -352,7 +352,7 @@ const char *ProjectList::SIGNAL_PROJECT_ASK_OPEN = "project_ask_open";
 // Helpers.
 
 bool ProjectList::project_feature_looks_like_version(const String &p_feature) {
-	return p_feature.contains_char('.') && p_feature.substr(0, 3).is_numeric();
+	return p_feature.contains('.') && p_feature.substr(0, 3).is_numeric();
 }
 
 // Notifications.
@@ -632,7 +632,7 @@ void ProjectList::sort_projects() {
 		bool item_visible = true;
 		if (!_search_term.is_empty()) {
 			String search_path;
-			if (search_term.contains_char('/')) {
+			if (search_term.contains('/')) {
 				// Search path will match the whole path
 				search_path = item.path;
 			} else {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -268,7 +268,7 @@ void ProjectSettingsEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 
 String ProjectSettingsEditor::_get_setting_name() const {
 	String name = property_box->get_text().strip_edges();
-	if (!name.begins_with("_") && !name.contains_char('/')) {
+	if (!name.begins_with("_") && !name.contains('/')) {
 		name = "global/" + name;
 	}
 	return name;

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -258,7 +258,7 @@ void PropertySelector::_update_search() {
 			TreeItem *item = search_options->create_item(category ? category : root);
 
 			String desc;
-			if (mi.name.contains_char(':')) {
+			if (mi.name.contains(':')) {
 				desc = mi.name.get_slice(":", 1) + " ";
 				mi.name = mi.name.get_slice(":", 0);
 			} else if (mi.return_val.type != Variant::NIL) {
@@ -278,7 +278,7 @@ void PropertySelector::_update_search() {
 
 				if (arg_itr->type == Variant::NIL) {
 					desc += ": Variant";
-				} else if (arg_itr->name.contains_char(':')) {
+				} else if (arg_itr->name.contains(':')) {
 					desc += vformat(": %s", arg_itr->name.get_slice(":", 1));
 					arg_itr->name = arg_itr->name.get_slice(":", 0);
 				} else {

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -160,7 +160,7 @@ void ScriptCreateDialog::_notification(int p_what) {
 
 void ScriptCreateDialog::_path_hbox_sorted() {
 	if (is_visible()) {
-		int filename_start_pos = file_path->get_text().rfind_char('/') + 1;
+		int filename_start_pos = file_path->get_text().rfind('/') + 1;
 		int filename_end_pos = file_path->get_text().get_basename().length();
 
 		if (!is_built_in) {
@@ -744,7 +744,7 @@ ScriptLanguage::ScriptTemplate ScriptCreateDialog::_parse_template(const ScriptL
 	List<String> comment_delimiters;
 	p_language->get_comment_delimiters(&comment_delimiters);
 	for (const String &script_delimiter : comment_delimiters) {
-		if (!script_delimiter.contains_char(' ')) {
+		if (!script_delimiter.contains(' ')) {
 			meta_delimiter = script_delimiter;
 			break;
 		}

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -103,7 +103,7 @@ void ShaderCreateDialog::_update_language_info() {
 
 void ShaderCreateDialog::_path_hbox_sorted() {
 	if (is_visible()) {
-		int filename_start_pos = initial_base_path.rfind_char('/') + 1;
+		int filename_start_pos = initial_base_path.rfind('/') + 1;
 		int filename_end_pos = initial_base_path.length();
 
 		if (!is_built_in) {
@@ -292,7 +292,7 @@ void ShaderCreateDialog::_type_changed(int p_language) {
 	String extension = "";
 
 	if (!path.is_empty()) {
-		if (path.contains_char('.')) {
+		if (path.contains('.')) {
 			extension = path.get_extension();
 		}
 		if (extension.length() == 0) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1290,7 +1290,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			if (N) {
 				String vm = N->get();
 
-				if (!vm.contains_char('x')) { // invalid parameter format
+				if (!vm.contains('x')) { // invalid parameter format
 
 					OS::get_singleton()->print("Invalid resolution '%s', it should be e.g. '1280x720'.\n",
 							vm.utf8().get_data());
@@ -1333,7 +1333,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			if (N) {
 				String vm = N->get();
 
-				if (!vm.contains_char(',')) { // invalid parameter format
+				if (!vm.contains(',')) { // invalid parameter format
 
 					OS::get_singleton()->print("Invalid position '%s', it should be e.g. '80,128'.\n",
 							vm.utf8().get_data());
@@ -1611,7 +1611,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg.ends_with("project.godot")) {
 			String path;
 			String file = arg;
-			int sep = MAX(file.rfind_char('/'), file.rfind_char('\\'));
+			int sep = MAX(file.rfind('/'), file.rfind('\\'));
 			if (sep == -1) {
 				path = ".";
 			} else {
@@ -1832,7 +1832,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// 'project.godot' file which will only be available through the network if this is enabled
 	if (!remotefs.is_empty()) {
 		int port;
-		if (remotefs.contains_char(':')) {
+		if (remotefs.contains(':')) {
 			port = remotefs.get_slicec(':', 1).to_int();
 			remotefs = remotefs.get_slicec(':', 0);
 		} else {
@@ -3279,7 +3279,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 				// Dummy text driver cannot draw any text, making the editor unusable if selected.
 				continue;
 			}
-			if (!text_driver_options.is_empty() && !text_driver_options.contains_char(',')) {
+			if (!text_driver_options.is_empty() && !text_driver_options.contains(',')) {
 				// Not the first option; add a comma before it as a separator for the property hint.
 				text_driver_options += ",";
 			}
@@ -4165,7 +4165,7 @@ int Main::start() {
 						local_game_path = "res://" + local_game_path;
 
 					} else {
-						int sep = local_game_path.rfind_char('/');
+						int sep = local_game_path.rfind('/');
 
 						if (sep == -1) {
 							Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -139,7 +139,7 @@ void GDScriptDocGen::_doctype_from_gdtype(const GDType &p_gdtype, String &r_type
 			r_type = "int";
 			r_enum = String(p_gdtype.native_type).replace("::", ".");
 			if (r_enum.begins_with("res://")) {
-				int dot_pos = r_enum.rfind_char('.');
+				int dot_pos = r_enum.rfind('.');
 				if (dot_pos >= 0) {
 					r_enum = _get_script_name(r_enum.left(dot_pos)) + r_enum.substr(dot_pos);
 				} else {

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -163,7 +163,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 							}
 							if (from + end_key_length > line_length) {
 								// If it's key length and there is a '\', dont skip to highlight esc chars.
-								if (str.find_char('\\', from) >= 0) {
+								if (str.find('\\', from) >= 0) {
 									break;
 								}
 							}
@@ -236,7 +236,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 						for (; from < line_length; from++) {
 							if (line_length - from < end_key_length) {
 								// Don't break if '\' to highlight esc chars.
-								if (str.find_char('\\', from) < 0) {
+								if (str.find('\\', from) < 0) {
 									break;
 								}
 							}
@@ -815,7 +815,7 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 				if (E.usage & PROPERTY_USAGE_CATEGORY || E.usage & PROPERTY_USAGE_GROUP || E.usage & PROPERTY_USAGE_SUBGROUP) {
 					continue;
 				}
-				if (prop_name.contains_char('/')) {
+				if (prop_name.contains('/')) {
 					continue;
 				}
 				member_keywords[prop_name] = member_variable_color;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1213,7 +1213,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 								if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 									continue;
 								}
-								if (E.name.contains_char('/')) {
+								if (E.name.contains('/')) {
 									continue;
 								}
 								int location = p_recursion_depth + _get_property_location(scr, E.name);
@@ -1304,7 +1304,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 							if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 								continue;
 							}
-							if (E.name.contains_char('/')) {
+							if (E.name.contains('/')) {
 								continue;
 							}
 							int location = p_recursion_depth + _get_property_location(type, E.name);
@@ -1386,7 +1386,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 						if (E.usage & (PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_INTERNAL)) {
 							continue;
 						}
-						if (!String(E.name).contains_char('/')) {
+						if (!String(E.name).contains('/')) {
 							ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_MEMBER, location);
 							if (base_type.kind == GDScriptParser::DataType::ENUM) {
 								// Sort enum members in their declaration order.
@@ -2722,7 +2722,7 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 }
 
 static void _find_enumeration_candidates(GDScriptParser::CompletionContext &p_context, const String &p_enum_hint, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_result) {
-	if (!p_enum_hint.contains_char('.')) {
+	if (!p_enum_hint.contains('.')) {
 		// Global constant or in the current class.
 		StringName current_enum = p_enum_hint;
 		if (p_context.current_class && p_context.current_class->has_member(current_enum) && p_context.current_class->get_member(current_enum).type == GDScriptParser::ClassNode::Member::ENUM) {
@@ -3477,7 +3477,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 			for (const MethodInfo &mi : virtual_methods) {
 				String method_hint = mi.name;
-				if (method_hint.contains_char(':')) {
+				if (method_hint.contains(':')) {
 					method_hint = method_hint.get_slice(":", 0);
 				}
 				method_hint += "(";
@@ -3487,8 +3487,8 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						method_hint += ", ";
 					}
 					String arg = arg_itr->name;
-					if (arg.contains_char(':')) {
-						arg = arg.substr(0, arg.find_char(':'));
+					if (arg.contains(':')) {
+						arg = arg.substr(0, arg.find(':'));
 					}
 					method_hint += arg;
 					if (use_type_hint) {
@@ -3545,7 +3545,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					if (path_needs_quote) {
 						// Ignore quote_style and just use double quotes for paths with apostrophes.
 						// Double quotes don't need to be checked because they're not valid in node and property names.
-						opt = opt.quote(opt.contains_char('\'') ? "\"" : quote_style); // Handle user preference.
+						opt = opt.quote(opt.contains('\'') ? "\"" : quote_style); // Handle user preference.
 					}
 					ScriptLanguage::CodeCompletionOption option(opt, ScriptLanguage::CODE_COMPLETION_KIND_NODE_PATH);
 					options.insert(option.display, option);
@@ -3944,7 +3944,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 							r_result.class_member = p_symbol;
 							return OK;
 						} else {
-							const int dot_pos = enum_name.rfind_char('.');
+							const int dot_pos = enum_name.rfind('.');
 							if (dot_pos >= 0) {
 								r_result.type = ScriptLanguage::LOOKUP_RESULT_CLASS_CONSTANT;
 								r_result.class_name = enum_name.left(dot_pos);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3742,12 +3742,12 @@ static String _process_doc_line(const String &p_line, const String &p_text, cons
 	while (process) {
 		switch (r_state) {
 			case DOC_LINE_NORMAL: {
-				int lb_pos = line.find_char('[', from);
+				int lb_pos = line.find('[', from);
 				if (lb_pos < 0) {
 					process = false;
 					break;
 				}
-				int rb_pos = line.find_char(']', lb_pos + 1);
+				int rb_pos = line.find(']', lb_pos + 1);
 				if (rb_pos < 0) {
 					process = false;
 					break;
@@ -4424,7 +4424,7 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 				push_error(vformat(R"(Argument %d of annotation "%s" is empty.)", i + 1, p_annotation->name), p_annotation->arguments[i]);
 				return false;
 			}
-			if (arg_string.contains_char(',')) {
+			if (arg_string.contains(',')) {
 				push_error(vformat(R"(Argument %d of annotation "%s" contains a comma. Use separate arguments instead.)", i + 1, p_annotation->name), p_annotation->arguments[i]);
 				return false;
 			}

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -67,7 +67,7 @@ lsp::Position GodotPosition::to_lsp(const Vector<String> &p_lines) const {
 	res.character = column - 1;
 
 	String pos_line = p_lines[res.line];
-	if (pos_line.contains_char('\t')) {
+	if (pos_line.contains('\t')) {
 		int tab_size = get_indent_size();
 
 		int in_col = 1;

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -112,7 +112,7 @@ static void test_directory(const String &p_dir) {
 			// For ease of reading ➡ (0x27A1) acts as sentinel char instead of 0xFFFF in the files.
 			code = code.replace_first(String::chr(0x27A1), String::chr(0xFFFF));
 			// Require pointer sentinel char in scripts.
-			int location = code.find_char(0xFFFF);
+			int location = code.find(0xFFFF);
 			CHECK(location != -1);
 
 			String res_path = ProjectSettings::get_singleton()->localize_path(path.path_join(next));

--- a/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
@@ -34,7 +34,7 @@ const uint32_t PROP_EDITOR_SCRIPT_VAR = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_S
 
 bool EditorSceneExporterGLTFSettings::_set(const StringName &p_name, const Variant &p_value) {
 	String name_str = String(p_name);
-	if (name_str.contains_char('/')) {
+	if (name_str.contains('/')) {
 		return _set_extension_setting(name_str, p_value);
 	}
 	if (p_name == StringName("image_format")) {
@@ -55,7 +55,7 @@ bool EditorSceneExporterGLTFSettings::_set(const StringName &p_name, const Varia
 
 bool EditorSceneExporterGLTFSettings::_get(const StringName &p_name, Variant &r_ret) const {
 	String name_str = String(p_name);
-	if (name_str.contains_char('/')) {
+	if (name_str.contains('/')) {
 		return _get_extension_setting(name_str, r_ret);
 	}
 	if (p_name == StringName("image_format")) {

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -80,7 +80,7 @@ static bool _get_blender_version(const String &p_path, int &r_major, int &r_mino
 	}
 	pipe = pipe.substr(bl);
 	pipe = pipe.replace_first("Blender ", "");
-	int pp = pipe.find_char('.');
+	int pp = pipe.find('.');
 	if (pp == -1) {
 		if (r_err) {
 			*r_err = vformat(TTR("Couldn't extract version information from Blender executable at: %s."), p_path);
@@ -96,7 +96,7 @@ static bool _get_blender_version(const String &p_path, int &r_major, int &r_mino
 		return false;
 	}
 
-	int pp2 = pipe.find_char('.', pp + 1);
+	int pp2 = pipe.find('.', pp + 1);
 	r_minor = pp2 > pp ? pipe.substr(pp + 1, pp2 - pp - 1).to_int() : 0;
 
 	return true;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -690,7 +690,7 @@ void GLTFDocument::_compute_node_heights(Ref<GLTFState> p_state) {
 }
 
 static Vector<uint8_t> _parse_base64_uri(const String &p_uri) {
-	int start = p_uri.find_char(',');
+	int start = p_uri.find(',');
 	ERR_FAIL_COND_V(start == -1, Vector<uint8_t>());
 
 	CharString substr = p_uri.substr(start + 1).ascii();
@@ -4079,7 +4079,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_p
 			if (uri.begins_with("data:")) { // Embedded data using base64.
 				data = _parse_base64_uri(uri);
 				// mimeType is optional, but if we have it defined in the URI, let's use it.
-				if (mime_type.is_empty() && uri.contains_char(';')) {
+				if (mime_type.is_empty() && uri.contains(';')) {
 					// Trim "data:" prefix which is 5 characters long, and end at ";base64".
 					mime_type = uri.substr(5, uri.find(";base64") - 5);
 				}

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2815,7 +2815,7 @@ Ref<Resource> ResourceFormatLoaderCSharpScript::load(const String &p_path, const
 	if (p_path.begins_with("csharp://")) {
 		// This is a virtual path used by generic types, extract the real path.
 		real_path = "res://" + p_path.trim_prefix("csharp://");
-		real_path = real_path.substr(0, real_path.rfind_char(':'));
+		real_path = real_path.substr(0, real_path.rfind(':'));
 	}
 
 	Ref<CSharpScript> scr;

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -195,7 +195,7 @@ String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInter
 
 	int pos = 0;
 	while (pos < bbcode.length()) {
-		int brk_pos = bbcode.find_char('[', pos);
+		int brk_pos = bbcode.find('[', pos);
 
 		if (brk_pos < 0) {
 			brk_pos = bbcode.length();
@@ -215,7 +215,7 @@ String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInter
 			break;
 		}
 
-		int brk_end = bbcode.find_char(']', brk_pos + 1);
+		int brk_end = bbcode.find(']', brk_pos + 1);
 
 		if (brk_end == -1) {
 			String text = bbcode.substr(brk_pos, bbcode.length() - brk_pos);
@@ -244,7 +244,7 @@ String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInter
 			output.append("[");
 			pos = brk_pos + 1;
 		} else if (tag.begins_with("method ") || tag.begins_with("constructor ") || tag.begins_with("operator ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ") || tag.begins_with("theme_item ") || tag.begins_with("param ")) {
-			const int tag_end = tag.find_char(' ');
+			const int tag_end = tag.find(' ');
 			const String link_tag = tag.substr(0, tag_end);
 			const String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
 
@@ -390,7 +390,7 @@ String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInter
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "url") {
-			int end = bbcode.find_char('[', brk_end);
+			int end = bbcode.find('[', brk_end);
 			if (end == -1) {
 				end = bbcode.length();
 			}
@@ -408,7 +408,7 @@ String BindingsGenerator::bbcode_to_text(const String &p_bbcode, const TypeInter
 			pos = brk_end + 1;
 			tag_stack.push_front("url");
 		} else if (tag == "img") {
-			int end = bbcode.find_char('[', brk_end);
+			int end = bbcode.find('[', brk_end);
 			if (end == -1) {
 				end = bbcode.length();
 			}
@@ -460,7 +460,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 
 	int pos = 0;
 	while (pos < bbcode.length()) {
-		int brk_pos = bbcode.find_char('[', pos);
+		int brk_pos = bbcode.find('[', pos);
 
 		if (brk_pos < 0) {
 			brk_pos = bbcode.length();
@@ -493,7 +493,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			break;
 		}
 
-		int brk_end = bbcode.find_char(']', brk_pos + 1);
+		int brk_end = bbcode.find(']', brk_pos + 1);
 
 		if (brk_end == -1) {
 			if (!line_del) {
@@ -556,7 +556,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			xml_output.append("[");
 			pos = brk_pos + 1;
 		} else if (tag.begins_with("method ") || tag.begins_with("constructor ") || tag.begins_with("operator ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ") || tag.begins_with("theme_item ") || tag.begins_with("param ")) {
-			const int tag_end = tag.find_char(' ');
+			const int tag_end = tag.find(' ');
 			const String link_tag = tag.substr(0, tag_end);
 			const String link_target = tag.substr(tag_end + 1, tag.length()).lstrip(" ");
 
@@ -695,7 +695,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "code" || tag.begins_with("code ")) {
-			int end = bbcode.find_char('[', brk_end);
+			int end = bbcode.find('[', brk_end);
 			if (end == -1) {
 				end = bbcode.length();
 			}
@@ -750,7 +750,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
 		} else if (tag == "url") {
-			int end = bbcode.find_char('[', brk_end);
+			int end = bbcode.find('[', brk_end);
 			if (end == -1) {
 				end = bbcode.length();
 			}
@@ -771,7 +771,7 @@ String BindingsGenerator::bbcode_to_xml(const String &p_bbcode, const TypeInterf
 			pos = brk_end + 1;
 			tag_stack.push_front("url");
 		} else if (tag == "img") {
-			int end = bbcode.find_char('[', brk_end);
+			int end = bbcode.find('[', brk_end);
 			if (end == -1) {
 				end = bbcode.length();
 			}
@@ -876,7 +876,7 @@ void BindingsGenerator::_append_text_method(StringBuilder &p_output, const TypeI
 }
 
 void BindingsGenerator::_append_text_member(StringBuilder &p_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts) {
-	if (p_link_target.contains_char('/')) {
+	if (p_link_target.contains('/')) {
 		// Properties with '/' (slash) in the name are not declared in C#, so there is nothing to reference.
 		_append_text_undeclared(p_output, p_link_target);
 	} else if (!p_target_itype || !p_target_itype->is_object_type) {
@@ -1160,7 +1160,7 @@ void BindingsGenerator::_append_xml_method(StringBuilder &p_xml_output, const Ty
 }
 
 void BindingsGenerator::_append_xml_member(StringBuilder &p_xml_output, const TypeInterface *p_target_itype, const StringName &p_target_cname, const String &p_link_target, const Vector<String> &p_link_target_parts, const TypeInterface *p_source_itype) {
-	if (p_link_target.contains_char('/')) {
+	if (p_link_target.contains('/')) {
 		// Properties with '/' (slash) in the name are not declared in C#, so there is nothing to reference.
 		_append_xml_undeclared(p_xml_output, p_link_target);
 	} else if (!p_target_itype || !p_target_itype->is_object_type) {
@@ -1671,7 +1671,7 @@ void BindingsGenerator::_generate_global_constants(StringBuilder &p_output) {
 
 		bool enum_in_static_class = false;
 
-		if (enum_proxy_name.find_char('.') > 0) {
+		if (enum_proxy_name.find('.') > 0) {
 			enum_in_static_class = true;
 			String enum_class_name = enum_proxy_name.get_slicec('.', 0);
 			enum_proxy_name = enum_proxy_name.get_slicec('.', 1);
@@ -3932,7 +3932,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				continue;
 			}
 
-			if (property.name.contains_char('/')) {
+			if (property.name.contains('/')) {
 				// Ignore properties with '/' (slash) in the name. These are only meant for use in the inspector.
 				continue;
 			}

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -116,7 +116,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 					continue;
 				}
 
-				String name = prop.name.substr(prop.name.find_char('/') + 1, prop.name.length());
+				String name = prop.name.substr(prop.name.find('/') + 1, prop.name.length());
 				suggestions.push_back(quoted(name));
 			}
 		} break;

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -212,7 +212,7 @@ String relative_to_impl(const String &p_path, const String &p_relative_to) {
 #ifdef WINDOWS_ENABLED
 String get_drive_letter(const String &p_norm_path) {
 	int idx = p_norm_path.find(":/");
-	if (idx != -1 && idx < p_norm_path.find_char('/')) {
+	if (idx != -1 && idx < p_norm_path.find('/')) {
 		return p_norm_path.substr(0, idx + 1);
 	}
 	return String();

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -375,7 +375,7 @@ void ReplicationEditor::_add_pressed() {
 		return;
 	}
 
-	int idx = np_text.find_char(':');
+	int idx = np_text.find(':');
 	if (idx == -1) {
 		np_text = ".:" + np_text;
 	} else if (idx == 0) {
@@ -554,7 +554,7 @@ void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, 
 	Node *root_node = current && !current->get_root_path().is_empty() ? current->get_node(current->get_root_path()) : nullptr;
 	Ref<Texture2D> icon = _get_class_icon(root_node);
 	if (root_node) {
-		String path = prop.substr(0, prop.find_char(':'));
+		String path = prop.substr(0, prop.find(':'));
 		String subpath = prop.substr(path.size());
 		Node *node = root_node->get_node_or_null(path);
 		if (!node) {

--- a/modules/openxr/action_map/openxr_interaction_profile.cpp
+++ b/modules/openxr/action_map/openxr_interaction_profile.cpp
@@ -269,7 +269,7 @@ void OpenXRInteractionProfile::set_bindings(const Array &p_bindings) {
 
 	for (Ref<OpenXRIPBinding> binding : p_bindings) {
 		String binding_path = binding->get_binding_path();
-		if (binding_path.find_char(',') >= 0) {
+		if (binding_path.find(',') >= 0) {
 			// Convert old binding approach to new...
 			add_new_binding(binding->get_action(), binding_path);
 		} else {

--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -435,7 +435,7 @@ void OpenXRCompositionLayer::_get_property_list(List<PropertyInfo> *p_property_l
 
 	for (const PropertyInfo &pinfo : extension_properties) {
 		StringName prop_name = pinfo.name;
-		if (!String(prop_name).contains_char('/')) {
+		if (!String(prop_name).contains('/')) {
 			WARN_PRINT_ONCE(vformat("Discarding OpenXRCompositionLayer property name '%s' from extension because it doesn't contain a '/'."));
 			continue;
 		}

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -53,7 +53,7 @@ void ImageLoaderSVG::_replace_color_property(const HashMap<Color, Color> &p_colo
 	int pos = r_string.find(p_prefix);
 	while (pos != -1) {
 		pos += prefix_len; // Skip prefix.
-		int end_pos = r_string.find_char('"', pos);
+		int end_pos = r_string.find('"', pos);
 		ERR_FAIL_COND_MSG(end_pos == -1, vformat("Malformed SVG string after property \"%s\".", p_prefix));
 		const String color_code = r_string.substr(pos, end_pos - pos);
 		if (color_code != "none" && !color_code.begins_with("url(")) {

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -97,7 +97,7 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 			if (parser->has_attribute("id")) {
 				const String &gl_name = parser->get_named_attribute_value("id");
 				if (gl_name.begins_with("glyph")) {
-					int dot_pos = gl_name.find_char('.');
+					int dot_pos = gl_name.find('.');
 					int64_t gl_idx = gl_name.substr(5, (dot_pos > 0) ? dot_pos - 5 : -1).to_int();
 					if (p_slot->glyph_index != gl_idx) {
 						parser->skip_section();

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -97,7 +97,7 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 			if (parser->has_attribute("id")) {
 				const String &gl_name = parser->get_named_attribute_value("id");
 				if (gl_name.begins_with("glyph")) {
-					int dot_pos = gl_name.find_char('.');
+					int dot_pos = gl_name.find('.');
 					int64_t gl_idx = gl_name.substr(5, (dot_pos > 0) ? dot_pos - 5 : -1).to_int();
 					if (p_slot->glyph_index != gl_idx) {
 						parser->skip_section();

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -1577,7 +1577,7 @@ void EditorExportPlatformAndroid::_fix_resources(const Ref<EditorExportPreset> &
 				str = get_project_name(package_name);
 
 			} else {
-				String lang = str.substr(str.rfind_char('-') + 1, str.length()).replace("-", "_");
+				String lang = str.substr(str.rfind('-') + 1, str.length()).replace("-", "_");
 				if (appnames.has(lang)) {
 					str = appnames[lang];
 				} else {

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -970,7 +970,7 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 				return Error::FAILED;
 			} else {
 				print_verbose("rcodesign (" + p_path + "):\n" + str);
-				int next_nl = str.find_char('\n', rq_offset);
+				int next_nl = str.find('\n', rq_offset);
 				String request_uuid = (next_nl == -1) ? str.substr(rq_offset + 23, -1) : str.substr(rq_offset + 23, next_nl - rq_offset - 23);
 				add_message(EXPORT_MESSAGE_INFO, TTR("Notarization"), vformat(TTR("Notarization request UUID: \"%s\""), request_uuid));
 				add_message(EXPORT_MESSAGE_INFO, TTR("Notarization"), TTR("The notarization process generally takes less than an hour."));
@@ -1054,7 +1054,7 @@ Error EditorExportPlatformMacOS::_notarize(const Ref<EditorExportPreset> &p_pres
 				return Error::FAILED;
 			} else {
 				print_verbose("notarytool (" + p_path + "):\n" + str);
-				int next_nl = str.find_char('\n', rq_offset);
+				int next_nl = str.find('\n', rq_offset);
 				String request_uuid = (next_nl == -1) ? str.substr(rq_offset + 4, -1) : str.substr(rq_offset + 4, next_nl - rq_offset - 4);
 				add_message(EXPORT_MESSAGE_INFO, TTR("Notarization"), vformat(TTR("Notarization request UUID: \"%s\""), request_uuid));
 				add_message(EXPORT_MESSAGE_INFO, TTR("Notarization"), TTR("The notarization process generally takes less than an hour."));

--- a/platform/web/editor/web_tools_editor_plugin.cpp
+++ b/platform/web/editor/web_tools_editor_plugin.cpp
@@ -78,7 +78,7 @@ void WebToolsEditorPlugin::_download_zip() {
 	const String output_path = String("/tmp").path_join(output_name);
 
 	zipFile zip = zipOpen2(output_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io);
-	const String base_path = resource_path.substr(0, resource_path.rfind_char('/')) + "/";
+	const String base_path = resource_path.substr(0, resource_path.rfind('/')) + "/";
 	_zip_recursive(resource_path, base_path, zip);
 	zipClose(zip, nullptr);
 	{

--- a/platform/web/export/editor_http_server.cpp
+++ b/platform/web/export/editor_http_server.cpp
@@ -81,7 +81,7 @@ void EditorHTTPServer::_send_response() {
 	// Wrong protocol
 	ERR_FAIL_COND_MSG(req[0] != "GET" || req[2] != "HTTP/1.1", "Invalid method or HTTP version.");
 
-	const int query_index = req[1].find_char('?');
+	const int query_index = req[1].find('?');
 	const String path = (query_index == -1) ? req[1] : req[1].substr(0, query_index);
 
 	const String req_file = path.get_file();

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -349,7 +349,7 @@ String EditorExportPlatformWindows::get_export_option_warning(const EditorExport
 				PackedStringArray version_array = file_version.split(".", false);
 				if (version_array.size() != 4 || !version_array[0].is_valid_int() ||
 						!version_array[1].is_valid_int() || !version_array[2].is_valid_int() ||
-						!version_array[3].is_valid_int() || file_version.contains_char('-')) {
+						!version_array[3].is_valid_int() || file_version.contains('-')) {
 					return TTR("Invalid file version.");
 				}
 			}
@@ -359,7 +359,7 @@ String EditorExportPlatformWindows::get_export_option_warning(const EditorExport
 				PackedStringArray version_array = product_version.split(".", false);
 				if (version_array.size() != 4 || !version_array[0].is_valid_int() ||
 						!version_array[1].is_valid_int() || !version_array[2].is_valid_int() ||
-						!version_array[3].is_valid_int() || product_version.contains_char('-')) {
+						!version_array[3].is_valid_int() || product_version.contains('-')) {
 					return TTR("Invalid product version.");
 				}
 			}

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1785,7 +1785,7 @@ String OS_Windows::get_environment(const String &p_var) const {
 }
 
 void OS_Windows::set_environment(const String &p_var, const String &p_value) const {
-	ERR_FAIL_COND_MSG(p_var.is_empty() || p_var.contains_char('='), vformat("Invalid environment variable name '%s', cannot be empty or include '='.", p_var));
+	ERR_FAIL_COND_MSG(p_var.is_empty() || p_var.contains('='), vformat("Invalid environment variable name '%s', cannot be empty or include '='.", p_var));
 	Char16String var = p_var.utf16();
 	Char16String value = p_value.utf16();
 	ERR_FAIL_COND_MSG(var.length() + value.length() + 2 > 32767, vformat("Invalid definition for environment variable '%s', cannot exceed 32767 characters.", p_var));
@@ -1793,7 +1793,7 @@ void OS_Windows::set_environment(const String &p_var, const String &p_value) con
 }
 
 void OS_Windows::unset_environment(const String &p_var) const {
-	ERR_FAIL_COND_MSG(p_var.is_empty() || p_var.contains_char('='), vformat("Invalid environment variable name '%s', cannot be empty or include '='.", p_var));
+	ERR_FAIL_COND_MSG(p_var.is_empty() || p_var.contains('='), vformat("Invalid environment variable name '%s', cannot be empty or include '='.", p_var));
 	SetEnvironmentVariableW((LPCWSTR)(p_var.utf16().get_data()), nullptr); // Null to delete.
 }
 

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -608,7 +608,7 @@ uint64_t Skeleton3D::get_version() const {
 }
 
 int Skeleton3D::add_bone(const String &p_name) {
-	ERR_FAIL_COND_V_MSG(p_name.is_empty() || p_name.contains_char(':') || p_name.contains_char('/'), -1, vformat("Bone name cannot be empty or contain ':' or '/'.", p_name));
+	ERR_FAIL_COND_V_MSG(p_name.is_empty() || p_name.contains(':') || p_name.contains('/'), -1, vformat("Bone name cannot be empty or contain ':' or '/'.", p_name));
 	ERR_FAIL_COND_V_MSG(name_to_bone_index.has(p_name), -1, vformat("Skeleton3D \"%s\" already has a bone with name \"%s\".", to_string(), p_name));
 
 	Bone b;

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -1437,7 +1437,7 @@ void AnimationNodeBlendTree::add_node(const StringName &p_name, Ref<AnimationNod
 	ERR_FAIL_COND(nodes.has(p_name));
 	ERR_FAIL_COND(p_node.is_null());
 	ERR_FAIL_COND(p_name == SceneStringName(output));
-	ERR_FAIL_COND(String(p_name).contains_char('/'));
+	ERR_FAIL_COND(String(p_name).contains('/'));
 
 	Node n;
 	n.node = p_node;

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -294,7 +294,7 @@ StringName AnimationMixer::find_animation_library(const Ref<Animation> &p_animat
 Error AnimationMixer::add_animation_library(const StringName &p_name, const Ref<AnimationLibrary> &p_animation_library) {
 	ERR_FAIL_COND_V(p_animation_library.is_null(), ERR_INVALID_PARAMETER);
 #ifdef DEBUG_ENABLED
-	ERR_FAIL_COND_V_MSG(String(p_name).contains_char('/') || String(p_name).contains_char(':') || String(p_name).contains_char(',') || String(p_name).contains_char('['), ERR_INVALID_PARAMETER, "Invalid animation name: " + String(p_name) + ".");
+	ERR_FAIL_COND_V_MSG(String(p_name).contains('/') || String(p_name).contains(':') || String(p_name).contains(',') || String(p_name).contains('['), ERR_INVALID_PARAMETER, "Invalid animation name: " + String(p_name) + ".");
 #endif
 
 	int insert_pos = 0;
@@ -356,7 +356,7 @@ void AnimationMixer::rename_animation_library(const StringName &p_name, const St
 		return;
 	}
 #ifdef DEBUG_ENABLED
-	ERR_FAIL_COND_MSG(String(p_new_name).contains_char('/') || String(p_new_name).contains_char(':') || String(p_new_name).contains_char(',') || String(p_new_name).contains_char('['), "Invalid animation library name: " + String(p_new_name) + ".");
+	ERR_FAIL_COND_MSG(String(p_new_name).contains('/') || String(p_new_name).contains(':') || String(p_new_name).contains(',') || String(p_new_name).contains('['), "Invalid animation library name: " + String(p_new_name) + ".");
 #endif
 
 	bool found = false;

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -51,7 +51,7 @@ AnimationNodeStateMachineTransition::AdvanceMode AnimationNodeStateMachineTransi
 
 void AnimationNodeStateMachineTransition::set_advance_condition(const StringName &p_condition) {
 	String cs = p_condition;
-	ERR_FAIL_COND(cs.contains_char('/') || cs.contains_char(':'));
+	ERR_FAIL_COND(cs.contains('/') || cs.contains(':'));
 	advance_condition = p_condition;
 	if (!cs.is_empty()) {
 		advance_condition_name = "conditions/" + cs;
@@ -1254,7 +1254,7 @@ bool AnimationNodeStateMachine::is_parameter_read_only(const StringName &p_param
 void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position) {
 	ERR_FAIL_COND(states.has(p_name));
 	ERR_FAIL_COND(p_node.is_null());
-	ERR_FAIL_COND(String(p_name).contains_char('/'));
+	ERR_FAIL_COND(String(p_name).contains('/'));
 
 	State state_new;
 	state_new.node = p_node;
@@ -1273,7 +1273,7 @@ void AnimationNodeStateMachine::add_node(const StringName &p_name, Ref<Animation
 void AnimationNodeStateMachine::replace_node(const StringName &p_name, Ref<AnimationNode> p_node) {
 	ERR_FAIL_COND(states.has(p_name) == false);
 	ERR_FAIL_COND(p_node.is_null());
-	ERR_FAIL_COND(String(p_name).contains_char('/'));
+	ERR_FAIL_COND(String(p_name).contains('/'));
 
 	{
 		Ref<AnimationNode> node = states[p_name].node;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -325,7 +325,7 @@ bool AnimationNode::add_input(const String &p_name) {
 	// Root nodes can't add inputs.
 	ERR_FAIL_COND_V(Object::cast_to<AnimationRootNode>(this) != nullptr, false);
 	Input input;
-	ERR_FAIL_COND_V(p_name.contains_char('.') || p_name.contains_char('/'), false);
+	ERR_FAIL_COND_V(p_name.contains('.') || p_name.contains('/'), false);
 	input.name = p_name;
 	inputs.push_back(input);
 	emit_changed();
@@ -340,7 +340,7 @@ void AnimationNode::remove_input(int p_index) {
 
 bool AnimationNode::set_input_name(int p_input, const String &p_name) {
 	ERR_FAIL_INDEX_V(p_input, inputs.size(), false);
-	ERR_FAIL_COND_V(p_name.contains_char('.') || p_name.contains_char('/'), false);
+	ERR_FAIL_COND_V(p_name.contains('.') || p_name.contains('/'), false);
 	inputs.write[p_input].name = p_name;
 	emit_changed();
 	return true;

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3592,7 +3592,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 			// find all occurrences of ssq_lower to avoid looking everywhere each time
 			Vector<int> all_occurrences;
 			if (long_option) {
-				all_occurrences.push_back(target_lower.find_char(*string_to_complete_char_lower));
+				all_occurrences.push_back(target_lower.find(*string_to_complete_char_lower));
 			} else {
 				for (int j = i; j < target_lower.length(); j++) {
 					if (target_lower[j] == *string_to_complete_char_lower) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -50,7 +50,7 @@ void FileDialog::popup_file_dialog() {
 }
 
 void FileDialog::_focus_file_text() {
-	int lp = file->get_text().rfind_char('.');
+	int lp = file->get_text().rfind('.');
 	if (lp != -1) {
 		file->select(0, lp);
 		if (file->is_inside_tree() && !is_part_of_edited_scene()) {
@@ -1095,7 +1095,7 @@ void FileDialog::set_current_path(const String &p_path) {
 	if (!p_path.size()) {
 		return;
 	}
-	int pos = MAX(p_path.rfind_char('/'), p_path.rfind_char('\\'));
+	int pos = MAX(p_path.rfind('/'), p_path.rfind('\\'));
 	if (pos == -1) {
 		set_current_file(p_path);
 	} else {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3139,7 +3139,7 @@ void RichTextLabel::add_text(const String &p_text) {
 	String t = p_text.replace("\r\n", "\n");
 
 	while (pos < t.length()) {
-		int end = t.find_char('\n', pos);
+		int end = t.find('\n', pos);
 		String line;
 		bool eol = false;
 		if (end == -1) {
@@ -4228,7 +4228,7 @@ void RichTextLabel::parse_bbcode(const String &p_bbcode) {
 }
 
 String RichTextLabel::_get_tag_value(const String &p_tag) {
-	return p_tag.substr(p_tag.find_char('=') + 1);
+	return p_tag.substr(p_tag.find('=') + 1);
 }
 
 int RichTextLabel::_find_unquoted(const String &p_src, char32_t p_chr, int p_from) {
@@ -4311,7 +4311,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 	String bbcode = p_bbcode.replace("\r\n", "\n");
 
 	while (pos <= bbcode.length()) {
-		int brk_pos = bbcode.find_char('[', pos);
+		int brk_pos = bbcode.find('[', pos);
 
 		if (brk_pos < 0) {
 			brk_pos = bbcode.length();
@@ -4356,7 +4356,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			bbcode_name = split_tag_block[0];
 			for (int i = 1; i < split_tag_block.size(); i++) {
 				const String &expr = split_tag_block[i];
-				int value_pos = expr.find_char('=');
+				int value_pos = expr.find('=');
 				if (value_pos > -1) {
 					bbcode_options[expr.substr(0, value_pos)] = expr.substr(value_pos + 1).unquote();
 				}
@@ -4367,7 +4367,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 		// Find main parameter.
 		String bbcode_value;
-		int main_value_pos = bbcode_name.find_char('=');
+		int main_value_pos = bbcode_name.find('=');
 		if (main_value_pos > -1) {
 			bbcode_value = bbcode_name.substr(main_value_pos + 1);
 			bbcode_name = bbcode_name.substr(0, main_value_pos);
@@ -4803,7 +4803,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			pos = brk_end + 1;
 			tag_stack.push_front("p");
 		} else if (tag == "url") {
-			int end = bbcode.find_char('[', brk_end);
+			int end = bbcode.find('[', brk_end);
 			if (end == -1) {
 				end = bbcode.length();
 			}
@@ -4899,7 +4899,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				outline_color = Color::from_string(outline_color_option->value, outline_color);
 			}
 
-			int end = bbcode.find_char('[', brk_end);
+			int end = bbcode.find('[', brk_end);
 			if (end == -1) {
 				end = bbcode.length();
 			}
@@ -4944,7 +4944,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				}
 			}
 
-			int end = bbcode.find_char('[', brk_end);
+			int end = bbcode.find('[', brk_end);
 			if (end == -1) {
 				end = bbcode.length();
 			}
@@ -4977,7 +4977,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				String tooltip;
 				bool size_in_percent = false;
 				if (!bbcode_value.is_empty()) {
-					int sep = bbcode_value.find_char('x');
+					int sep = bbcode_value.find('x');
 					if (sep == -1) {
 						width = bbcode_value.to_int();
 					} else {
@@ -5070,7 +5070,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			tag_stack.push_front("font_size");
 
 		} else if (tag.begins_with("opentype_features=") || tag.begins_with("otf=")) {
-			int value_pos = tag.find_char('=');
+			int value_pos = tag.find('=');
 			String fnt_ftr = tag.substr(value_pos + 1);
 			Vector<String> subtag = fnt_ftr.split(",");
 			_normalize_subtags(subtag);

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -87,7 +87,7 @@ String HTTPRequest::get_header_value(const PackedStringArray &p_headers, const S
 
 	String lowwer_case_header_name = p_header_name.to_lower();
 	for (int i = 0; i < p_headers.size(); i++) {
-		if (p_headers[i].find_char(':') > 0) {
+		if (p_headers[i].find(':') > 0) {
 			Vector<String> parts = p_headers[i].split(":", false, 1);
 			if (parts.size() > 1 && parts[0].strip_edges().to_lower() == lowwer_case_header_name) {
 				value = parts[1].strip_edges();

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -182,7 +182,7 @@ Variant PropertyUtils::get_property_default_value(const Object *p_object, const 
 			// Heuristically check if this is a synthetic property (whatever/0, whatever/1, etc.)
 			// because they are not in the class DB yet must have a default (null).
 			String prop_str = String(p_property);
-			int p = prop_str.rfind_char('/');
+			int p = prop_str.rfind('/');
 			if (p != -1 && p < prop_str.length() - 1) {
 				bool all_digits = true;
 				for (int i = p + 1; i < prop_str.length(); i++) {

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -33,11 +33,11 @@
 #include "scene/scene_string_names.h"
 
 bool AnimationLibrary::is_valid_animation_name(const String &p_name) {
-	return !(p_name.is_empty() || p_name.contains_char('/') || p_name.contains_char(':') || p_name.contains_char(',') || p_name.contains_char('['));
+	return !(p_name.is_empty() || p_name.contains('/') || p_name.contains(':') || p_name.contains(',') || p_name.contains('['));
 }
 
 bool AnimationLibrary::is_valid_library_name(const String &p_name) {
-	return !(p_name.contains_char('/') || p_name.contains_char(':') || p_name.contains_char(',') || p_name.contains_char('['));
+	return !(p_name.contains('/') || p_name.contains(':') || p_name.contains(',') || p_name.contains('['));
 }
 
 String AnimationLibrary::validate_library_name(const String &p_name) {

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -535,7 +535,7 @@ String Font::get_supported_chars() const {
 	for (int i = 0; i < rids.size(); i++) {
 		String data_chars = TS->font_get_supported_chars(rids[i]);
 		for (int j = 0; j < data_chars.length(); j++) {
-			if (chars.find_char(data_chars[j]) == -1) {
+			if (chars.find(data_chars[j]) == -1) {
 				chars += data_chars[j];
 			}
 		}
@@ -1741,7 +1741,7 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 		while (true) {
 			String line = f->get_line();
 
-			int delimiter = line.find_char(' ');
+			int delimiter = line.find(' ');
 			String type = line.substr(0, delimiter);
 			int pos = delimiter + 1;
 			HashMap<String, String> keys;
@@ -1751,7 +1751,7 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 			}
 
 			while (pos < line.size()) {
-				int eq = line.find_char('=', pos);
+				int eq = line.find('=', pos);
 				if (eq == -1) {
 					break;
 				}
@@ -1759,14 +1759,14 @@ Error FontFile::_load_bitmap_font(const String &p_path, List<String> *r_image_fi
 				int end = -1;
 				String value;
 				if (line[eq + 1] == '"') {
-					end = line.find_char('"', eq + 2);
+					end = line.find('"', eq + 2);
 					if (end == -1) {
 						break;
 					}
 					value = line.substr(eq + 2, end - 1 - eq - 1);
 					pos = end + 1;
 				} else {
-					end = line.find_char(' ', eq + 1);
+					end = line.find(' ', eq + 1);
 					if (end == -1) {
 						end = line.size();
 					}

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1315,7 +1315,7 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 	String sname = p_name;
 
 	if (sname.begins_with("surface_")) {
-		int sl = sname.find_char('/');
+		int sl = sname.find('/');
 		if (sl == -1) {
 			return false;
 		}
@@ -1708,7 +1708,7 @@ bool ArrayMesh::_get(const StringName &p_name, Variant &r_ret) const {
 
 	String sname = p_name;
 	if (sname.begins_with("surface_")) {
-		int sl = sname.find_char('/');
+		int sl = sname.find('/');
 		if (sl == -1) {
 			return false;
 		}

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -822,10 +822,10 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				value = missing_resource_properties[E.name];
 			}
 		} else if (E.type == Variant::ARRAY && E.hint == PROPERTY_HINT_TYPE_STRING) {
-			int hint_subtype_separator = E.hint_string.find_char(':');
+			int hint_subtype_separator = E.hint_string.find(':');
 			if (hint_subtype_separator >= 0) {
 				String subtype_string = E.hint_string.substr(0, hint_subtype_separator);
-				int slash_pos = subtype_string.find_char('/');
+				int slash_pos = subtype_string.find('/');
 				PropertyHint subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
 				if (slash_pos >= 0) {
 					subtype_hint = PropertyHint(subtype_string.get_slice("/", 1).to_int());
@@ -851,11 +851,11 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				}
 			}
 		} else if (E.type == Variant::DICTIONARY && E.hint == PROPERTY_HINT_TYPE_STRING) {
-			int key_value_separator = E.hint_string.find_char(';');
+			int key_value_separator = E.hint_string.find(';');
 			if (key_value_separator >= 0) {
-				int key_subtype_separator = E.hint_string.find_char(':');
+				int key_subtype_separator = E.hint_string.find(':');
 				String key_subtype_string = E.hint_string.substr(0, key_subtype_separator);
-				int key_slash_pos = key_subtype_string.find_char('/');
+				int key_slash_pos = key_subtype_string.find('/');
 				PropertyHint key_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
 				if (key_slash_pos >= 0) {
 					key_subtype_hint = PropertyHint(key_subtype_string.get_slice("/", 1).to_int());
@@ -864,9 +864,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 				Variant::Type key_subtype = Variant::Type(key_subtype_string.to_int());
 				bool convert_key = key_subtype == Variant::OBJECT && key_subtype_hint == PROPERTY_HINT_NODE_TYPE;
 
-				int value_subtype_separator = E.hint_string.find_char(':', key_value_separator) - (key_value_separator + 1);
+				int value_subtype_separator = E.hint_string.find(':', key_value_separator) - (key_value_separator + 1);
 				String value_subtype_string = E.hint_string.substr(key_value_separator + 1, value_subtype_separator);
-				int value_slash_pos = value_subtype_string.find_char('/');
+				int value_slash_pos = value_subtype_string.find('/');
 				PropertyHint value_subtype_hint = PropertyHint::PROPERTY_HINT_NONE;
 				if (value_slash_pos >= 0) {
 					value_subtype_hint = PropertyHint(value_subtype_string.get_slice("/", 1).to_int());
@@ -2230,14 +2230,14 @@ HashSet<StringName> PackedScene::get_scene_groups(const String &p_path) {
 				continue;
 			}
 
-			int j = line.find_char(']', i);
+			int j = line.find(']', i);
 			while (i < j) {
-				i = line.find_char('"', i);
+				i = line.find('"', i);
 				if (i == -1) {
 					break;
 				}
 
-				int k = line.find_char('"', i + 1);
+				int k = line.find('"', i + 1);
 				if (k == -1) {
 					break;
 				}

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1782,7 +1782,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 	for (KeyValue<Ref<Resource>, String> &E : external_resources) {
 		String cached_id = E.key->get_id_for_path(local_path);
 		if (cached_id.is_empty() || cached_ids_found.has(cached_id)) {
-			int sep_pos = E.value.find_char('_');
+			int sep_pos = E.value.find('_');
 			if (sep_pos != -1) {
 				E.value = E.value.substr(0, sep_pos + 1); // Keep the order found, for improved thread loading performance.
 			} else {

--- a/scene/resources/syntax_highlighter.cpp
+++ b/scene/resources/syntax_highlighter.cpp
@@ -205,7 +205,7 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 						if (end_key_length == 0 || color_regions[c].line_only || from + end_key_length > line_length) {
 							if (from + end_key_length > line_length && (color_regions[in_region].start_key == "\"" || color_regions[in_region].start_key == "\'")) {
 								// If it's key length and there is a '\', dont skip to highlight esc chars.
-								if (str.find_char('\\', from) >= 0) {
+								if (str.find('\\', from) >= 0) {
 									break;
 								}
 							}
@@ -242,7 +242,7 @@ Dictionary CodeHighlighter::_get_line_syntax_highlighting_impl(int p_line) {
 					for (; from < line_length; from++) {
 						if (line_length - from < end_key_length) {
 							// Don't break if '\' to highlight esc chars.
-							if (!is_string || str.find_char('\\', from) < 0) {
+							if (!is_string || str.find('\\', from) < 0) {
 								break;
 							}
 						}

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -37,7 +37,7 @@
 bool Theme::_set(const StringName &p_name, const Variant &p_value) {
 	String sname = p_name;
 
-	if (sname.contains_char('/')) {
+	if (sname.contains('/')) {
 		String type = sname.get_slicec('/', 1);
 		String theme_type = sname.get_slicec('/', 0);
 		String prop_name = sname.get_slicec('/', 2);
@@ -69,7 +69,7 @@ bool Theme::_set(const StringName &p_name, const Variant &p_value) {
 bool Theme::_get(const StringName &p_name, Variant &r_ret) const {
 	String sname = p_name;
 
-	if (sname.contains_char('/')) {
+	if (sname.contains('/')) {
 		String type = sname.get_slicec('/', 1);
 		String theme_type = sname.get_slicec('/', 0);
 		String prop_name = sname.get_slicec('/', 2);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -4147,7 +4147,7 @@ String VisualShaderNodeOutput::generate_code(Shader::Mode p_mode, VisualShader::
 		if (ports[idx].mode == shader_mode && ports[idx].shader_type == shader_type) {
 			if (!p_input_vars[count].is_empty()) {
 				String s = ports[idx].string;
-				if (s.contains_char(':')) {
+				if (s.contains(':')) {
 					shader_code += "	" + s.get_slicec(':', 0) + " = " + p_input_vars[count] + "." + s.get_slicec(':', 1) + ";\n";
 				} else {
 					shader_code += "	" + s + " = " + p_input_vars[count] + ";\n";

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -83,7 +83,7 @@ void ShaderRD::_add_stage(const char *p_code, StageType p_stage_type) {
 		} else if (l.begins_with("#include ")) {
 			String include_file = l.replace("#include ", "").strip_edges();
 			if (include_file[0] == '"') {
-				int end_pos = include_file.find_char('"', 1);
+				int end_pos = include_file.find('"', 1);
 				if (end_pos >= 0) {
 					include_file = include_file.substr(1, end_pos - 1);
 

--- a/servers/rendering/rendering_device_binds.cpp
+++ b/servers/rendering/rendering_device_binds.cpp
@@ -106,11 +106,11 @@ Error RDShaderFile::parse_versions_from_text(const String &p_text, const String 
 		if (reading_versions) {
 			String l = line.strip_edges();
 			if (!l.is_empty()) {
-				if (!l.contains_char('=')) {
+				if (!l.contains('=')) {
 					base_error = "Missing `=` in '" + l + "'. Version syntax is `version = \"<defines with C escaping>\";`.";
 					break;
 				}
-				if (!l.contains_char(';')) {
+				if (!l.contains(';')) {
 					// We don't require a semicolon per se, but it's needed for clang-format to handle things properly.
 					base_error = "Missing `;` in '" + l + "'. Version syntax is `version = \"<defines with C escaping>\";`.";
 					break;

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -181,7 +181,7 @@ static String _mkid(const String &p_id) {
 
 static String f2sp0(float p_float) {
 	String num = rtos(p_float);
-	if (!num.contains_char('.') && !num.contains_char('e')) {
+	if (!num.contains('.') && !num.contains('e')) {
 		num += ".0";
 	}
 	return num;

--- a/servers/rendering/shader_include_db.cpp
+++ b/servers/rendering/shader_include_db.cpp
@@ -79,7 +79,7 @@ String ShaderIncludeDB::parse_include_files(const String &p_code) {
 		if (l.begins_with(include)) {
 			String include_file = l.replace(include, "").strip_edges();
 			if (include_file[0] == '"') {
-				int end_pos = include_file.find_char('"', 1);
+				int end_pos = include_file.find('"', 1);
 				if (end_pos >= 0) {
 					include_file = include_file.substr(1, end_pos - 1);
 

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -11498,7 +11498,7 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 					}
 
 					for (const String &option_text : options) {
-						String hint_name = option_text.substr(0, option_text.find_char(char32_t('(')));
+						String hint_name = option_text.substr(0, option_text.find(char32_t('(')));
 						ScriptLanguage::CodeCompletionOption option(hint_name, ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
 						option.insert_text = option_text;
 						r_options->push_back(option);

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -391,15 +391,15 @@ TEST_CASE("[String] Find") {
 
 TEST_CASE("[String] Find character") {
 	String s = "racecar";
-	CHECK_EQ(s.find_char('r'), 0);
-	CHECK_EQ(s.find_char('r', 1), 6);
-	CHECK_EQ(s.find_char('e'), 3);
-	CHECK_EQ(s.find_char('e', 4), -1);
+	CHECK_EQ(s.find('r'), 0);
+	CHECK_EQ(s.find('r', 1), 6);
+	CHECK_EQ(s.find('e'), 3);
+	CHECK_EQ(s.find('e', 4), -1);
 
-	CHECK_EQ(s.rfind_char('r'), 6);
-	CHECK_EQ(s.rfind_char('r', 5), 0);
-	CHECK_EQ(s.rfind_char('e'), 3);
-	CHECK_EQ(s.rfind_char('e', 2), -1);
+	CHECK_EQ(s.rfind('r'), 6);
+	CHECK_EQ(s.rfind('r', 5), 0);
+	CHECK_EQ(s.rfind('e'), 3);
+	CHECK_EQ(s.rfind('e', 2), -1);
 }
 
 TEST_CASE("[String] Find case insensitive") {


### PR DESCRIPTION
**Disclaimer:** This is a change _proposal_, so if you have reservations about the rename, please comment them.

In my opinion, there is no real reason for the `_char` suffix. Instead, it reduces findability of these functions.

The PR itself is just a find-replace of `find_char(` -> `find(` and `contains_char(` -> `contains(`.