### PR TITLE
Add swizzling for shader vector completion

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -318,15 +318,17 @@ public:
 		Vector<Pair<int, int>> last_matches = { { -1, -1 } }; // This value correspond to an impossible match
 		int location = LOCATION_OTHER;
 		String theme_color_name;
+		bool is_swizzling_component = false;
 
 		CodeCompletionOption() {}
 
-		CodeCompletionOption(const String &p_text, CodeCompletionKind p_kind, int p_location = LOCATION_OTHER, const String &p_theme_color_name = "") {
+		CodeCompletionOption(const String &p_text, CodeCompletionKind p_kind, int p_location = LOCATION_OTHER, const String &p_theme_color_name = "", bool p_is_swizzling_component = false) {
 			display = p_text;
 			insert_text = p_text;
 			kind = p_kind;
 			location = p_location;
 			theme_color_name = p_theme_color_name;
+			is_swizzling_component = p_is_swizzling_component;
 		}
 
 		TypedArray<int> get_option_characteristics(const String &p_base);

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -50,10 +50,18 @@
 			<param index="4" name="icon" type="Resource" default="null" />
 			<param index="5" name="value" type="Variant" default="null" />
 			<param index="6" name="location" type="int" default="1024" />
+			<param index="7" name="is_swizzling_component" type="bool" default="false" />
 			<description>
 				Submits an item to the queue of potential candidates for the autocomplete menu. Call [method update_code_completion_options] to update the list.
 				[param location] indicates location of the option relative to the location of the code completion query. See [enum CodeEdit.CodeCompletionLocation] for how to set this value.
 				[b]Note:[/b] This list will replace all current candidates.
+			</description>
+		</method>
+		<method name="add_code_completion_swizzling_pattern">
+			<return type="void" />
+			<param index="0" name="pattern" type="String" />
+			<description>
+				Adds a swizzling completion pattern, for example [code]xyzw[/code].
 			</description>
 		</method>
 		<method name="add_comment_delimiter">
@@ -401,6 +409,13 @@
 			<return type="void" />
 			<description>
 				Moves all lines up that are selected or have a caret on them.
+			</description>
+		</method>
+		<method name="remove_code_completion_swizzling_pattern">
+			<return type="void" />
+			<param index="0" name="pattern" type="String" />
+			<description>
+				Removes a swizzling completion pattern.
 			</description>
 		</method>
 		<method name="remove_comment_delimiter">

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1040,7 +1040,7 @@ void CodeTextEditor::_complete_request() {
 		} else if (e.insert_text.begins_with("#") || e.insert_text.begins_with("//")) {
 			font_color = completion_comment_color;
 		}
-		text_editor->add_code_completion_option((CodeEdit::CodeCompletionKind)e.kind, e.display, e.insert_text, font_color, _get_completion_icon(e), e.default_value, e.location);
+		text_editor->add_code_completion_option((CodeEdit::CodeCompletionKind)e.kind, e.display, e.insert_text, font_color, _get_completion_icon(e), e.default_value, e.location, e.is_swizzling_component);
 	}
 	text_editor->update_code_completion_options(forced);
 }

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -332,6 +332,10 @@ void ShaderTextEditor::_load_theme_settings() {
 		te->add_auto_brace_completion_pair("/*", "*/");
 	}
 
+	te->add_code_completion_swizzling_pattern("xyzw");
+	te->add_code_completion_swizzling_pattern("rgba");
+	te->add_code_completion_swizzling_pattern("stpq");
+
 	// Colorize preprocessor include strings.
 	const Color string_color = EDITOR_GET("text_editor/theme/highlighting/string_color");
 	syntax_highlighter->add_color_region("\"", "\"", string_color, false);

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -268,3 +268,12 @@ GH-98441
 Validate extension JSON: Error: Field 'global_enums/KeyModifierMask/values/KEY_MODIFIER_MASK': value changed value in new API, from 5.32677e+08 to 2130706432.
 
 Key modifier mask value corrected. API change documented for compatibility.
+
+
+GH-100521
+---------
+Validate extension JSON: Error: Field 'classes/CodeEdit/methods/add_code_completion_option/arguments': size changed value in new API, from 7 to 8.
+Validate extension JSON: Error: Field 'classes/CodeEdit/methods/add_code_completion_option/arguments': size changed value in new API, from 6 to 8.
+
+Add swizzling for shader vector completion.
+Compatibility method registered.

--- a/scene/gui/code_edit.compat.inc
+++ b/scene/gui/code_edit.compat.inc
@@ -34,13 +34,18 @@ String CodeEdit::_get_text_for_symbol_lookup_bind_compat_73196() {
 	return get_text_for_symbol_lookup();
 }
 
-void CodeEdit::_add_code_completion_option_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location) {
-	add_code_completion_option(p_type, p_display_text, p_insert_text, p_text_color, p_icon, p_value, p_location);
+void CodeEdit::_add_code_completion_option_bind_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location) {
+	add_code_completion_option(p_type, p_display_text, p_insert_text, p_text_color, p_icon, p_value, p_location, false);
+}
+
+void CodeEdit::_add_code_completion_option_bind_compat_100521(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value, int p_location) {
+	add_code_completion_option(p_type, p_display_text, p_insert_text, p_text_color, p_icon, p_value, p_location, false);
 }
 
 void CodeEdit::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("get_text_for_symbol_lookup"), &CodeEdit::_get_text_for_symbol_lookup_bind_compat_73196);
-	ClassDB::bind_compatibility_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location"), &CodeEdit::_add_code_completion_option_compat_84906, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant::NIL), DEFVAL(LOCATION_OTHER));
+	ClassDB::bind_compatibility_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location"), &CodeEdit::_add_code_completion_option_bind_compat_84906, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant::NIL), DEFVAL(LOCATION_OTHER));
+	ClassDB::bind_compatibility_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value", "location"), &CodeEdit::_add_code_completion_option_bind_compat_100521, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant()), DEFVAL(LOCATION_OTHER));
 }
 
 #endif

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -220,6 +220,7 @@ private:
 	float code_completion_pan_offset = 0.0f;
 
 	HashSet<char32_t> code_completion_prefixes;
+	HashSet<String> code_completion_swizzling_patterns;
 	List<ScriptLanguage::CodeCompletionOption> code_completion_option_submitted;
 	List<ScriptLanguage::CodeCompletionOption> code_completion_option_sources;
 	String code_completion_base;
@@ -318,7 +319,8 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	String _get_text_for_symbol_lookup_bind_compat_73196();
-	void _add_code_completion_option_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant::NIL, int p_location = LOCATION_OTHER);
+	void _add_code_completion_option_bind_compat_84906(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant::NIL, int p_location = LOCATION_OTHER);
+	void _add_code_completion_option_bind_compat_100521(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant(), int p_location = LOCATION_OTHER);
 	static void _bind_compatibility_methods();
 #endif
 
@@ -476,11 +478,14 @@ public:
 	void set_code_completion_prefixes(const TypedArray<String> &p_prefixes);
 	TypedArray<String> get_code_completion_prefixes() const;
 
+	void add_code_completion_swizzling_pattern(const String &p_pattern);
+	void remove_code_completion_swizzling_pattern(const String &p_pattern);
+
 	String get_text_for_code_completion() const;
 
 	void request_code_completion(bool p_force = false);
 
-	void add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant(), int p_location = LOCATION_OTHER);
+	void add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant(), int p_location = LOCATION_OTHER, bool p_is_swizzling_component = false);
 	void update_code_completion_options(bool p_forced = false);
 
 	TypedArray<Dictionary> get_code_completion_options() const;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -10925,7 +10925,7 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 
 #ifdef DEBUG_ENABLED
 	// Adds context keywords.
-	if (keyword_completion_context != CF_UNSPECIFIED) {
+	if (keyword_completion_context != CF_UNSPECIFIED && completion_type != COMPLETION_INDEX) {
 		int sz = sizeof(keyword_list) / sizeof(KeyWord);
 		for (int i = 0; i < sz; i++) {
 			if (keyword_list[i].flags == CF_UNSPECIFIED) {
@@ -11473,9 +11473,9 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 			}
 
 			for (int i = 0; i < limit; i++) {
-				r_options->push_back(ScriptLanguage::CodeCompletionOption(String::chr(colv[i]), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT, ScriptLanguage::LOCATION_OTHER, theme_color_names[i]));
-				r_options->push_back(ScriptLanguage::CodeCompletionOption(String::chr(coordv[i]), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT, ScriptLanguage::LOCATION_OTHER, theme_color_names[i]));
-				r_options->push_back(ScriptLanguage::CodeCompletionOption(String::chr(coordt[i]), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT, ScriptLanguage::LOCATION_OTHER, theme_color_names[i]));
+				r_options->push_back(ScriptLanguage::CodeCompletionOption(String::chr(colv[i]), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT, ScriptLanguage::LOCATION_OTHER, theme_color_names[i], true));
+				r_options->push_back(ScriptLanguage::CodeCompletionOption(String::chr(coordv[i]), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT, ScriptLanguage::LOCATION_OTHER, theme_color_names[i], true));
+				r_options->push_back(ScriptLanguage::CodeCompletionOption(String::chr(coordt[i]), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT, ScriptLanguage::LOCATION_OTHER, theme_color_names[i], true));
 			}
 
 		} break;


### PR DESCRIPTION
This is an enhancement which enables code completion of swizzling components in shaders:

![swizzling](https://github.com/user-attachments/assets/1438c690-ec65-4569-a653-062f5c21deea)
