### PR TITLE
Remove custom `--language-in` arg for the Closure compiler

### DIFF
--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -59,8 +59,12 @@ for lib in sys_env["JS_LIBS"]:
     sys_env.Append(LINKFLAGS=["--js-library", lib.abspath])
 for js in sys_env["JS_PRE"]:
     sys_env.Append(LINKFLAGS=["--pre-js", js.abspath])
+
+# Add JS externs to Closure.
+sys_env["ENV"]["EMCC_CLOSURE_ARGS"] = sys_env["ENV"].get("EMCC_CLOSURE_ARGS", "")
 for ext in sys_env["JS_EXTERNS"]:
     sys_env["ENV"]["EMCC_CLOSURE_ARGS"] += " --externs " + ext.abspath
+sys_env["ENV"]["EMCC_CLOSURE_ARGS"] = sys_env["ENV"]["EMCC_CLOSURE_ARGS"].strip()
 
 build = []
 build_targets = ["#bin/godot${PROGSUFFIX}.js", "#bin/godot${PROGSUFFIX}.wasm"]

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -166,9 +166,6 @@ def configure(env: "SConsEnvironment"):
     # Add method for creating the final zip file
     env.AddMethod(create_template_zip, "CreateTemplateZip")
 
-    # Closure compiler extern and support for ecmascript specs (const, let, etc).
-    env["ENV"]["EMCC_CLOSURE_ARGS"] = "--language_in ECMASCRIPT_2021"
-
     env["CC"] = "emcc"
     env["CXX"] = "em++"
 


### PR DESCRIPTION
This PR removes our custom set of `--language-in` for the Closure compiler, especially since emscripten recently adopted the default behavior of Closure, which is `--language-in UNSTABLE` since 3.1.71. Using any other language breaks our build. So this PR is needed not necessarily now, but if we ever want to update emscripten past 3.1.70.

See these links for more info:
- https://github.com/emscripten-core/emscripten/pull/22808
- https://github.com/emscripten-core/emscripten/issues/23179#issuecomment-2546715189

This will enable us to streamline our code, including the use of public class fields.