### PR TITLE
Update the warnings for CSGShape3D.

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -446,6 +446,7 @@ CSGBrush *CSGShape3D::_get_brush() {
 	node_aabb = aabb;
 	brush = n;
 	dirty = false;
+	update_configuration_warnings();
 	return brush;
 }
 


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/issues/100014

I updated the warnings for CSGShape more responsively.

With test case on the current pull request.

[csg-game-project.zip](https://github.com/user-attachments/files/18170390/csg-game-project.zip)

![image](https://github.com/user-attachments/assets/043c7111-a598-4e8c-b3e3-3a55af679736)


