### PR TITLE
Add Support for String to Uint64

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -2575,6 +2575,74 @@ int64_t String::to_int(const wchar_t *p_str, int p_len) {
 	return integer * sign;
 }
 
+uint64_t String::to_uint64(bool p_clamp) const {
+	int str_length = length();
+	if (str_length == 0) {
+		return 0;
+	}
+
+	int start = 0;
+	// Skip leading whitespace and + symbols
+	// This is intentionally greedy to keep the parsing simple
+	while (start < str_length &&
+			(is_whitespace(operator[](start)) || operator[](start) == '+')) {
+		start++;
+	}
+
+	// Check for negative sign
+	if (start < str_length && operator[](start) == '-') {
+		if (!p_clamp) {
+			ERR_FAIL_V_MSG(0,
+					"Cannot represent " + *this + " as a 64-bit unsigned integer, since the value is negative.");
+		}
+		return 0;
+	}
+
+	uint64_t integer = 0;
+	for (int i = start; i < str_length; i++) {
+		char32_t c = operator[](i);
+		if (!is_digit(c)) {
+			// By design we ignore ANYTHING after the number
+			break;
+		}
+
+		bool overflow = (integer > UINT64_MAX / 10) ||
+				(integer == UINT64_MAX / 10 && (c > '5')); // 18446744073709551615 is UINT64_MAX
+		if (overflow) {
+			if (!p_clamp) {
+				ERR_FAIL_V_MSG(UINT64_MAX,
+						"Cannot represent " + *this + " as a 64-bit unsigned integer, since the value is too large.");
+			}
+			return UINT64_MAX;
+		}
+		integer *= 10;
+		integer += c - '0';
+	}
+	return integer;
+}
+
+uint64_t String::to_uint64(const char *p_str, int p_len) {
+	String str;
+	if (p_len >= 0) {
+		str = String(p_str, p_len);
+	} else {
+		str = String(p_str);
+	}
+
+	return str.to_uint64();
+}
+
+uint64_t String::to_uint64(const wchar_t *p_str, int p_len) {
+	String str;
+	if (p_len >= 0) {
+		str = String(p_str, p_len);
+	} else {
+		str = String(p_str);
+	}
+
+	return str.to_uint64();
+}
+
 bool String::is_numeric() const {
 	if (length() == 0) {
 		return false;
@@ -2914,6 +2982,17 @@ int64_t String::to_int(const char32_t *p_str, int p_len, bool p_clamp) {
 	}
 
 	return sign * integer;
+}
+
+uint64_t String::to_uint64(const char32_t *p_str, int p_len, bool p_clamp) {
+	String str;
+	if (p_len >= 0) {
+		str = String(p_str, p_len);
+	} else {
+		str = String(p_str);
+	}
+
+	return str.to_uint64(p_clamp);
 }
 
 double String::to_float() const {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -465,10 +465,15 @@ public:
 	int64_t hex_to_int() const;
 	int64_t bin_to_int() const;
 	int64_t to_int() const;
+	uint64_t to_uint64(bool p_clamp = true) const;
 
 	static int64_t to_int(const char *p_str, int p_len = -1);
 	static int64_t to_int(const wchar_t *p_str, int p_len = -1);
 	static int64_t to_int(const char32_t *p_str, int p_len = -1, bool p_clamp = false);
+
+	static uint64_t to_uint64(const char *p_str, int p_len = -1);
+	static uint64_t to_uint64(const wchar_t *p_str, int p_len = -1);
+	static uint64_t to_uint64(const char32_t *p_str, int p_len = -1, bool p_clamp = false);
 
 	static double to_float(const char *p_str);
 	static double to_float(const wchar_t *p_str, const wchar_t **r_end = nullptr);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1780,6 +1780,7 @@ static void _register_variant_builtin_methods_string() {
 	bind_string_method(is_valid_filename, sarray(), varray());
 
 	bind_string_method(to_int, sarray(), varray());
+	bind_string_method(to_uint64, sarray("clamp"), varray());
 	bind_string_method(to_float, sarray(), varray());
 	bind_string_method(hex_to_int, sarray(), varray());
 	bind_string_method(bin_to_int, sarray(), varray());

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -553,6 +553,61 @@ TEST_CASE("[String] String to integer") {
 	ERR_PRINT_ON
 }
 
+TEST_CASE("[String] String to unsigned integer") {
+	// Test normal valid cases
+	CHECK(String("1237461283").to_uint64(false) == 1237461283);
+	CHECK(String("0").to_uint64(false) == 0);
+	CHECK(String("").to_uint64(false) == 0);
+	CHECK(String("10_000_000").to_uint64(false) == 10);
+	CHECK(String("10__000").to_uint64(false) == 10);
+	CHECK(String("  1  2  34 ").to_uint64(false) == 1);
+	CHECK(String("007").to_uint64(false) == 7);
+	CHECK(String("18446744073709551615").to_uint64(false) == 18446744073709551615ULL);
+	CHECK(String("+123").to_uint64(false) == 123);
+	CHECK(String(" + 123 ").to_uint64(false) == 123);
+
+	// Test negative numbers and out of range values
+	ERR_PRINT_OFF;
+	CHECK(String("-1").to_uint64(false) == 0);
+	CHECK(String("-9223372036854775808").to_uint64(false) == 0);
+	CHECK(String("-9223372036854775809").to_uint64(false) == 0);
+	CHECK(String("-18446744073709551615").to_uint64(false) == 0);
+	CHECK(String("-18446744073709551616").to_uint64(false) == 0);
+	CHECK(String("18446744073709551616").to_uint64(false) == UINT64_MAX);
+	CHECK(String("18446744073709551620").to_uint64(false) == UINT64_MAX);
+	CHECK(String("999999999999999999999999999999999999").to_uint64(false) == UINT64_MAX);
+	CHECK(String("-999999999999999999999999999999999999").to_uint64(false) == 0);
+	ERR_PRINT_ON;
+
+	// Test Clamp
+	CHECK(String("-123").to_uint64(true) == 0);
+	CHECK(String("999999999999999999999999999999999999").to_uint64(true) == UINT64_MAX);
+	CHECK(String("-123").to_uint64(true) == 0);
+	CHECK(String("- 22").to_uint64(true) == 0);
+	CHECK(String("-0").to_uint64(true) == 0);
+	CHECK(String("--45").to_uint64(true) == 0);
+	CHECK(String("12a34").to_uint64(true) == 12);
+	CHECK(String("abc").to_uint64(true) == 0);
+
+	// Spell out some clear edge cases
+	CHECK(String(" +  ").to_uint64(false) == 0);
+	CHECK(String("++-123").to_uint64(true) == 0);
+	CHECK(String("+ + + +123").to_uint64(true) == 123);
+	CHECK(String("123-").to_uint64(true) == 123);
+	CHECK(String("123\n").to_uint64(true) == 123);
+	CHECK(String("123 everything afterwards is ignored").to_uint64(true) == 123);
+
+	// Test different string types
+	CHECK(String::to_uint64("12345") == 12345);
+	CHECK(String::to_uint64(L"12345") == 12345);
+	CHECK(String::to_uint64(U"12345") == 12345);
+
+	// Test length parameter
+	CHECK(String::to_uint64("12345", 3) == 123);
+	CHECK(String::to_uint64("12.345", 2) == 12);
+	CHECK(String::to_uint64("12345", 10) == 12345);
+}
+
 TEST_CASE("[String] Hex to integer") {
 	static const char *nums[12] = { "0xFFAE", "22", "0", "AADDAD", "0x7FFFFFFFFFFFFFFF", "-0xf", "", "000", "000f", "0xaA", "-ff", "-" };
 	static const int64_t num[12] = { 0xFFAE, 0x22, 0, 0xAADDAD, 0x7FFFFFFFFFFFFFFF, -0xf, 0, 0, 0xf, 0xaa, -0xff, 0x0 };


### PR DESCRIPTION
Needed this for some platform specific api stuff and it seemed like a good general improvement. No point exposing to scripting as there is no uint64 type in GDScript.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
