### PR TITLE
Core: Add missing postfix increment/decrement operators

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -470,6 +470,16 @@ public:
 			}
 			return *this;
 		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator++(int) {
+			ConstIterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator--(int) {
+			ConstIterator old = *this;
+			operator--();
+			return old;
+		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
 		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
@@ -505,6 +515,16 @@ public:
 				E = E->prev;
 			}
 			return *this;
+		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator++(int) {
+			Iterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator--(int) {
+			Iterator old = *this;
+			operator--();
+			return old;
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -343,6 +343,16 @@ public:
 			}
 			return *this;
 		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator++(int) {
+			Iterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator--(int) {
+			Iterator old = *this;
+			operator--();
+			return old;
+		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return keys == b.keys && index == b.index; }
 		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return keys != b.keys || index != b.index; }

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -152,6 +152,16 @@ public:
 			E = E->prev();
 			return *this;
 		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator++(int) {
+			ConstIterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator--(int) {
+			ConstIterator old = *this;
+			operator--();
+			return old;
+		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
 		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
@@ -176,6 +186,16 @@ public:
 		_FORCE_INLINE_ Iterator &operator--() {
 			E = E->prev();
 			return *this;
+		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator++(int) {
+			Iterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator--(int) {
+			Iterator old = *this;
+			operator--();
+			return old;
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -191,6 +191,16 @@ public:
 			elem_ptr--;
 			return *this;
 		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator++(int) {
+			Iterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator--(int) {
+			Iterator old = *this;
+			operator--();
+			return old;
+		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
 		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
@@ -215,6 +225,16 @@ public:
 		_FORCE_INLINE_ ConstIterator &operator--() {
 			elem_ptr--;
 			return *this;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator++(int) {
+			ConstIterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator--(int) {
+			ConstIterator old = *this;
+			operator--();
+			return old;
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -110,6 +110,16 @@ public:
 			E = E->prev();
 			return *this;
 		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator++(int) {
+			Iterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator--(int) {
+			Iterator old = *this;
+			operator--();
+			return old;
+		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &p_it) const { return E == p_it.E; }
 		_FORCE_INLINE_ bool operator!=(const Iterator &p_it) const { return E != p_it.E; }
@@ -141,6 +151,16 @@ public:
 		_FORCE_INLINE_ ConstIterator &operator--() {
 			E = E->prev();
 			return *this;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator++(int) {
+			ConstIterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator--(int) {
+			ConstIterator old = *this;
+			operator--();
+			return old;
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &p_it) const { return E == p_it.E; }

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -95,6 +95,16 @@ public:
 			E = E->prev();
 			return *this;
 		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator++(int) {
+			Iterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator--(int) {
+			Iterator old = *this;
+			operator--();
+			return old;
+		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
 		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
@@ -120,6 +130,16 @@ public:
 		_FORCE_INLINE_ ConstIterator &operator--() {
 			E = E->prev();
 			return *this;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator++(int) {
+			ConstIterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator--(int) {
+			ConstIterator old = *this;
+			operator--();
+			return old;
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -228,6 +228,16 @@ public:
 			elem_ptr--;
 			return *this;
 		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator++(int) {
+			Iterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator--(int) {
+			Iterator old = *this;
+			operator--();
+			return old;
+		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
 		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
@@ -252,6 +262,16 @@ public:
 		_FORCE_INLINE_ ConstIterator &operator--() {
 			elem_ptr--;
 			return *this;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator++(int) {
+			ConstIterator old = *this;
+			operator++();
+			return old;
+		}
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator--(int) {
+			ConstIterator old = *this;
+			operator--();
+			return old;
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -55,6 +55,9 @@ public:
 		_FORCE_INLINE_ ConstIterator &operator++();
 		_FORCE_INLINE_ ConstIterator &operator--();
 
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator++(int);
+		[[nodiscard]] _FORCE_INLINE_ ConstIterator operator--(int);
+
 		_FORCE_INLINE_ bool operator==(const ConstIterator &p_other) const { return element_ptr == p_other.element_ptr; }
 		_FORCE_INLINE_ bool operator!=(const ConstIterator &p_other) const { return element_ptr != p_other.element_ptr; }
 
@@ -81,6 +84,9 @@ public:
 
 		_FORCE_INLINE_ Iterator &operator++();
 		_FORCE_INLINE_ Iterator &operator--();
+
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator++(int);
+		[[nodiscard]] _FORCE_INLINE_ Iterator operator--(int);
 
 		_FORCE_INLINE_ bool operator==(const Iterator &p_other) const { return element_ptr == p_other.element_ptr; }
 		_FORCE_INLINE_ bool operator!=(const Iterator &p_other) const { return element_ptr != p_other.element_ptr; }

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -957,6 +957,18 @@ Array::Iterator &Array::Iterator::operator--() {
 	return *this;
 }
 
+Array::Iterator Array::Iterator::operator++(int) {
+	Array::Iterator old = *this;
+	operator++();
+	return old;
+}
+
+Array::Iterator Array::Iterator::operator--(int) {
+	Array::Iterator old = *this;
+	operator--();
+	return old;
+}
+
 const Variant &Array::ConstIterator::operator*() const {
 	if (unlikely(read_only)) {
 		*read_only = *element_ptr;
@@ -981,6 +993,18 @@ Array::ConstIterator &Array::ConstIterator::operator++() {
 Array::ConstIterator &Array::ConstIterator::operator--() {
 	element_ptr--;
 	return *this;
+}
+
+Array::ConstIterator Array::ConstIterator::operator++(int) {
+	Array::ConstIterator old = *this;
+	operator++();
+	return old;
+}
+
+Array::ConstIterator Array::ConstIterator::operator--(int) {
+	Array::ConstIterator old = *this;
+	operator--();
+	return old;
 }
 
 #endif // VARIANT_H


### PR DESCRIPTION
I realized that our increment/decrement operators were only ever implemented with the prefix syntax. By adding an empty `int` argument, those operators are designated as postfix[^1]. That is, instead of only being able to use `++iter`, we will now have the option to also use `iter++`. This doesn't change any existing functionality, particularly when the use of the operators as-is was uncommmon, but this means that anyone *wanting* to use the operators will have access to the expected behavior of both implementations.

[^1]: https://en.cppreference.com/w/cpp/language/operator_incdec