### PR TITLE
Fix `taa_resolve.glsl` path in COPYRIGHT.txt

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -151,7 +151,7 @@ Comment: Intel ASSAO and related files
 Copyright: 2016, Intel Corporation
 License: Expat
 
-Files: ./servers/rendering/renderer_rd/shaders/taa_resolve.glsl
+Files: ./servers/rendering/renderer_rd/shaders/effects/taa_resolve.glsl
 Comment: Temporal Anti-Aliasing resolve implementation
 Copyright: 2016, Panos Karabelas
 License: Expat


### PR DESCRIPTION
It was moved to /effects back in 2022, someone missed this.