### PR TITLE
Camera: Skip non platform-specifc `CameraFeed` types in Linux/macOS driver

### DIFF
--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -52,6 +52,9 @@ void CameraLinux::_update_devices() {
 
 			for (int i = feeds.size() - 1; i >= 0; i--) {
 				Ref<CameraFeedLinux> feed = (Ref<CameraFeedLinux>)feeds[i];
+				if (feed.is_null()) {
+					continue;
+				}
 				String device_name = feed->get_device_name();
 				if (!_is_active(device_name)) {
 					remove_feed(feed);
@@ -84,6 +87,9 @@ void CameraLinux::_update_devices() {
 bool CameraLinux::_has_device(const String &p_device_name) {
 	for (int i = 0; i < feeds.size(); i++) {
 		Ref<CameraFeedLinux> feed = (Ref<CameraFeedLinux>)feeds[i];
+		if (feed.is_null()) {
+			continue;
+		}
 		if (feed->get_device_name() == p_device_name) {
 			return true;
 		}

--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -323,6 +323,9 @@ void CameraMacOS::update_feeds() {
 	// remove devices that are gone..
 	for (int i = feeds.size() - 1; i >= 0; i--) {
 		Ref<CameraFeedMacOS> feed = (Ref<CameraFeedMacOS>)feeds[i];
+		if (feed.is_null()) {
+			continue;
+		}
 
 		if (![devices containsObject:feed->get_device()]) {
 			// remove it from our array, this will also destroy it ;)
@@ -334,6 +337,9 @@ void CameraMacOS::update_feeds() {
 		bool found = false;
 		for (int i = 0; i < feeds.size() && !found; i++) {
 			Ref<CameraFeedMacOS> feed = (Ref<CameraFeedMacOS>)feeds[i];
+			if (feed.is_null()) {
+				continue;
+			}
 			if (feed->get_device() == device) {
 				found = true;
 			};


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes #100522

Platform implementations of `CameraServer` was expecting added camera feeds always being corresponding `CameraFeed` subclass, this breaks the possibility of implementing custom camera feeds with either GDScript or GDExtension.

This PR add type check, ignoring feeds that are not added by the server itself.