### PR TITLE
Support custom sky rotation in SDFGI

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -392,9 +392,9 @@ private:
 		};
 		struct IntegratePushConstant {
 			enum {
-				SKY_MODE_DISABLED,
-				SKY_MODE_COLOR,
-				SKY_MODE_SKY,
+				SKY_FLAGS_MODE_COLOR = 0x01,
+				SKY_FLAGS_MODE_SKY = 0x02,
+				SKY_FLAGS_ORIENTATION_SIGN = 0x04,
 			};
 
 			float grid_size[3];
@@ -410,12 +410,12 @@ private:
 			int32_t image_size[2];
 
 			int32_t world_offset[3];
-			uint32_t sky_mode;
+			uint32_t sky_flags;
 
 			int32_t scroll[3];
 			float sky_energy;
 
-			float sky_color[3];
+			float sky_color_or_orientation[3];
 			float y_mult;
 
 			uint32_t store_ambient_texture;


### PR DESCRIPTION
Custom sky rotation was not factored into SDFGI integration.

I've encoded the rotation as a quaternion into unused bits of existing sky push-constants - accuracy of reconstruction could be improved (I've gone for the simplest method), but I'm not sure there would be a noticeable benefit from doing so in this case.

Before:
![before-result](https://github.com/user-attachments/assets/126e5195-98de-4a3d-9889-10cbf42d5dd9)
After:
![after-result](https://github.com/user-attachments/assets/56036b77-ed64-496a-949d-00d241414dea)
Reference (VoxelGI):
![reference](https://user-images.githubusercontent.com/180032/177639122-6220f6ea-a601-4ec1-b93c-58e01ebf3a21.png)

GPU performance is equivalent on my 3080Ti ~(0.06ms-0.07ms for both).

Before:
![before-perf](https://github.com/user-attachments/assets/c13d6a65-1ead-43b3-abe1-d449cdb82c6c)
After:
![after-perf](https://github.com/user-attachments/assets/bfeb76a2-3d8c-4401-b3b5-b15fe5d73407)

Fixes https://github.com/godotengine/godot/issues/62793