### PR TITLE
Fix lambdas requiring extra line before End Of File

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -183,6 +183,7 @@ repos:
             .*\.svg$|
             .*\.patch$|
             .*\.out$|
+            modules/gdscript/tests/scripts/parser/features/lambda_at_eof_without_newline\.bin\.gd$|
             modules/gdscript/tests/scripts/parser/features/mixed_indentation_on_blank_lines\.gd$|
             modules/gdscript/tests/scripts/parser/warnings/empty_file_newline_comment\.norun\.gd$|
             modules/gdscript/tests/scripts/parser/warnings/empty_file_newline\.norun\.gd$|

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -294,7 +294,11 @@ void GDScriptTokenizerText::push_expression_indented_block() {
 
 void GDScriptTokenizerText::pop_expression_indented_block() {
 	ERR_FAIL_COND(indent_stack_stack.is_empty());
-	indent_stack = indent_stack_stack.back()->get();
+
+	if (!_is_at_end()) {
+		indent_stack = indent_stack_stack.back()->get();
+	}
+
 	indent_stack_stack.pop_back();
 }
 

--- a/modules/gdscript/tests/scripts/.editorconfig
+++ b/modules/gdscript/tests/scripts/.editorconfig
@@ -1,6 +1,9 @@
 # Some tests handle invalid syntax deliberately; exclude relevant attributes.
 # See also the `file-format` section in `.pre-commit-config.yaml`.
 
+[parser/features/lambda_at_eof_without_newline.bin.gd]
+insert_final_newline = false
+
 [parser/features/mixed_indentation_on_blank_lines.gd]
 trim_trailing_whitespace = false
 

--- a/modules/gdscript/tests/scripts/parser/features/lambda_at_eof_without_newline.bin.gd
+++ b/modules/gdscript/tests/scripts/parser/features/lambda_at_eof_without_newline.bin.gd
@@ -1,0 +1,5 @@
+func use_lambda(lambda: Callable) -> void:
+    lambda.call()
+
+func test():
+    use_lambda(func(): print("extra line before EOF not required!"))

--- a/modules/gdscript/tests/scripts/parser/features/lambda_at_eof_without_newline.bin.out
+++ b/modules/gdscript/tests/scripts/parser/features/lambda_at_eof_without_newline.bin.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+extra line before EOF not required!


### PR DESCRIPTION
fixes #96228

It seems that when parsing code [GDScriptTokinazer](https://github.com/godotengine/godot/blob/master/modules/gdscript/gdscript_tokenizer.cpp) was generating 2x`Token::DEDENT` at end instead of `Token::DEDENT` + `TOKEN::TK_EOF`. This was because lambdas have their own indent stack (`indent_stack_stack`) and it moved to default `indent_stack` after lambda parse, inside  `pop_expression_indented_block` method. As a result, this caused problems.

Meanwhile, `indent_stack` is clear in `check_indent()` method, when end of file reached:

https://github.com/godotengine/godot/blob/6395450b10d73bc3515763c7bbd1b2f5b7425d10/modules/gdscript/gdscript_tokenizer.cpp#L1173-L1178

I would have liked to reset `indent_stack_stack` here as well, but `pop_expression_indented_block` has error about empty stack.

https://github.com/godotengine/godot/blob/6395450b10d73bc3515763c7bbd1b2f5b7425d10/modules/gdscript/gdscript_tokenizer.cpp#L295-L299

So I had do it there.
