### PR TITLE
Allow binds and unbinds to be used at the same time in the signal connection dialog.

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -33,6 +33,8 @@
 #include "core/object/object.h"
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"
+#include "core/templates/list.h"
+#include "core/templates/vector.h"
 #include "core/variant/callable_bind.h"
 #include "core/variant/variant_callable.h"
 

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -33,7 +33,6 @@
 
 #include "core/object/object_id.h"
 #include "core/string/string_name.h"
-#include "core/templates/list.h"
 
 class Object;
 class Variant;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -2064,7 +2064,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			if (binds.size()) {
 				String vars;
 				VariantWriter::write_to_string(binds, vars, _write_resources, this, use_compat);
-				f->store_string(" binds= " + vars);
+				f->store_string(" binds=" + vars);
 			}
 
 			f->store_line("]");


### PR DESCRIPTION
Fixes #98686 and behaves like `source_signal.connect(target_function.bind(args).unbind(n))`.

Enables the red highlighted options:
![image](https://github.com/user-attachments/assets/46157c70-1436-4d44-bc8b-74b36a687dd1)
