### PR TITLE
Add `ptrw()` to LocalVector, to bring it in-line with `Vector` and `String`.

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -443,7 +443,7 @@ Error DirAccess::copy(const String &p_from, const String &p_to, int p_chmod_flag
 				break;
 			}
 
-			int bytes_read = fsrc->get_buffer(buffer.ptr(), buffer_size);
+			int bytes_read = fsrc->get_buffer(buffer.ptrw(), buffer_size);
 			if (bytes_read <= 0) {
 				err = FAILED;
 				break;

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2009,7 +2009,7 @@ Error Image::generate_mipmap_roughness(RoughnessChannel p_roughness_channel, con
 	normal_h = nm->get_height();
 
 	normal_sat_vec.resize(normal_w * normal_h * 3);
-	double *normal_sat = normal_sat_vec.ptr();
+	double *normal_sat = normal_sat_vec.ptrw();
 
 	// Create summed area table.
 	for (int y = 0; y < normal_h; y++) {

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -278,7 +278,7 @@ Error RemoteFilesystemClient::_synchronize_with_server(const String &p_host, int
 		uint64_t file_size = tcp_client->get_u64();
 		file_buffer.resize(file_size);
 
-		err = tcp_client->get_data(file_buffer.ptr(), file_size);
+		err = tcp_client->get_data(file_buffer.ptrw(), file_size);
 		if (err != OK) {
 			ERR_PRINT(vformat("Error retrieving file from remote filesystem: '%s'.", file));
 			server_disconnected = true;

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -41,7 +41,7 @@ int godot_unzip_get_current_file_info(unzFile p_zip_file, unz_file_info64 &r_fil
 		LocalVector<char> long_file_path_buffer;
 		long_file_path_buffer.resize(r_file_info.size_filename);
 
-		err = unzGetCurrentFileInfo64(p_zip_file, &r_file_info, long_file_path_buffer.ptr(), long_file_path_buffer.size(), nullptr, 0, nullptr, 0);
+		err = unzGetCurrentFileInfo64(p_zip_file, &r_file_info, long_file_path_buffer.ptrw(), long_file_path_buffer.size(), nullptr, 0, nullptr, 0);
 		if (err != UNZ_OK) {
 			return err;
 		}

--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -350,7 +350,7 @@ bool AStar3D::_solve(Point *begin_point, Point *end_point, bool p_allow_partial_
 			break;
 		}
 
-		sorter.pop_heap(0, open_list.size(), open_list.ptr()); // Remove the current point from the open list.
+		sorter.pop_heap(0, open_list.size(), open_list.ptrw()); // Remove the current point from the open list.
 		open_list.remove_at(open_list.size() - 1);
 		p->closed_pass = pass; // Mark the point as closed.
 
@@ -380,9 +380,9 @@ bool AStar3D::_solve(Point *begin_point, Point *end_point, bool p_allow_partial_
 			e->abs_f_score = e->f_score - e->g_score;
 
 			if (new_point) { // The position of the new points is already known.
-				sorter.push_heap(0, open_list.size() - 1, 0, e, open_list.ptr());
+				sorter.push_heap(0, open_list.size() - 1, 0, e, open_list.ptrw());
 			} else {
-				sorter.push_heap(0, open_list.find(e), 0, e, open_list.ptr());
+				sorter.push_heap(0, open_list.find(e), 0, e, open_list.ptrw());
 			}
 		}
 	}
@@ -847,7 +847,7 @@ bool AStar2D::_solve(AStar3D::Point *begin_point, AStar3D::Point *end_point, boo
 			break;
 		}
 
-		sorter.pop_heap(0, open_list.size(), open_list.ptr()); // Remove the current point from the open list.
+		sorter.pop_heap(0, open_list.size(), open_list.ptrw()); // Remove the current point from the open list.
 		open_list.remove_at(open_list.size() - 1);
 		p->closed_pass = astar.pass; // Mark the point as closed.
 
@@ -877,9 +877,9 @@ bool AStar2D::_solve(AStar3D::Point *begin_point, AStar3D::Point *end_point, boo
 			e->abs_f_score = e->f_score - e->g_score;
 
 			if (new_point) { // The position of the new points is already known.
-				sorter.push_heap(0, open_list.size() - 1, 0, e, open_list.ptr());
+				sorter.push_heap(0, open_list.size() - 1, 0, e, open_list.ptrw());
 			} else {
-				sorter.push_heap(0, open_list.find(e), 0, e, open_list.ptr());
+				sorter.push_heap(0, open_list.find(e), 0, e, open_list.ptrw());
 			}
 		}
 	}

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -524,7 +524,7 @@ bool AStarGrid2D::_solve(Point *p_begin_point, Point *p_end_point, bool p_allow_
 			break;
 		}
 
-		sorter.pop_heap(0, open_list.size(), open_list.ptr()); // Remove the current point from the open list.
+		sorter.pop_heap(0, open_list.size(), open_list.ptrw()); // Remove the current point from the open list.
 		open_list.remove_at(open_list.size() - 1);
 		p->closed_pass = pass; // Mark the point as closed.
 
@@ -566,9 +566,9 @@ bool AStarGrid2D::_solve(Point *p_begin_point, Point *p_end_point, bool p_allow_
 			e->abs_f_score = e->f_score - e->g_score;
 
 			if (new_point) { // The position of the new points is already known.
-				sorter.push_heap(0, open_list.size() - 1, 0, e, open_list.ptr());
+				sorter.push_heap(0, open_list.size() - 1, 0, e, open_list.ptrw());
 			} else {
-				sorter.push_heap(0, open_list.find(e), 0, e, open_list.ptr());
+				sorter.push_heap(0, open_list.find(e), 0, e, open_list.ptrw());
 			}
 		}
 	}

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -139,11 +139,11 @@ public:
 		if (depth > threshold) {
 			if (aux_stack.is_empty()) {
 				aux_stack.resize(ALLOCA_STACK_SIZE * 2);
-				memcpy(aux_stack.ptr(), stack, get_alloca_stacksize());
+				memcpy(aux_stack.ptrw(), stack, get_alloca_stacksize());
 			} else {
 				aux_stack.resize(aux_stack.size() * 2);
 			}
-			stack = aux_stack.ptr();
+			stack = aux_stack.ptrw();
 			threshold = aux_stack.size() - 2;
 		}
 		return &stack[depth++];

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -2320,7 +2320,7 @@ Error ConvexHullComputer::convex_hull(const Vector<Vector3> &p_points, Geometry3
 		// reverse indices: Godot wants clockwise, but this is counter-clockwise
 		if (face.indices.size() > 2) {
 			// reverse all but the first index.
-			int *indices = face.indices.ptr();
+			int *indices = face.indices.ptrw();
 			for (uint32_t c = 0; c < (face.indices.size() - 1) / 2; c++) {
 				SWAP(indices[c + 1], indices[face.indices.size() - 1 - c]);
 			}

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -344,12 +344,12 @@ void DynamicBVH::aabb_query(const AABB &p_box, QueryResult &r_result) {
 				if (depth > threshold) {
 					if (aux_stack.is_empty()) {
 						aux_stack.resize(ALLOCA_STACK_SIZE * 2);
-						memcpy(aux_stack.ptr(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
+						memcpy(aux_stack.ptrw(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
 						alloca_stack = nullptr;
 					} else {
 						aux_stack.resize(aux_stack.size() * 2);
 					}
-					stack = aux_stack.ptr();
+					stack = aux_stack.ptrw();
 					threshold = aux_stack.size() - 2;
 				}
 				stack[depth++] = n->children[0];
@@ -397,12 +397,12 @@ void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Ve
 				if (depth > threshold) {
 					if (aux_stack.is_empty()) {
 						aux_stack.resize(ALLOCA_STACK_SIZE * 2);
-						memcpy(aux_stack.ptr(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
+						memcpy(aux_stack.ptrw(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
 						alloca_stack = nullptr;
 					} else {
 						aux_stack.resize(aux_stack.size() * 2);
 					}
-					stack = aux_stack.ptr();
+					stack = aux_stack.ptrw();
 					threshold = aux_stack.size() - 2;
 				}
 				stack[depth++] = n->children[0];
@@ -456,12 +456,12 @@ void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResu
 				if (depth > threshold) {
 					if (aux_stack.is_empty()) {
 						aux_stack.resize(ALLOCA_STACK_SIZE * 2);
-						memcpy(aux_stack.ptr(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
+						memcpy(aux_stack.ptrw(), alloca_stack, ALLOCA_STACK_SIZE * sizeof(const Node *));
 						alloca_stack = nullptr;
 					} else {
 						aux_stack.resize(aux_stack.size() * 2);
 					}
-					stack = aux_stack.ptr();
+					stack = aux_stack.ptrw();
 					threshold = aux_stack.size() - 2;
 				}
 				stack[depth++] = node->children[0];

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -392,7 +392,7 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E, bool p_execu
 							args.push_back(&binds[i]);
 						}
 
-						method_callback(method_callback_ud, obj, op.name, args.ptr(), binds.size());
+						method_callback(method_callback_ud, obj, op.name, args.ptrw(), binds.size());
 					}
 				}
 			} break;

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -49,13 +49,11 @@ private:
 	T *data = nullptr;
 
 public:
-	T *ptr() {
-		return data;
-	}
-
-	const T *ptr() const {
-		return data;
-	}
+	// This function is the same as ptr(), in that it returns a pointer to the underlying buffer.
+	// It is called ptrw() to convey write intention. This decision was made to have API uniformity
+	// to other collection types, e.g. Vector.
+	T *ptrw() { return data; }
+	const T *ptr() const { return data; }
 
 	_FORCE_INLINE_ void push_back(T p_elem) {
 		if (unlikely(count == capacity)) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -570,7 +570,7 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 			Variant base = PtrToArg<m_class>::convert(p_base);                                                                                                    \
 			Variant ret;                                                                                                                                          \
 			Callable::CallError ce;                                                                                                                               \
-			m_method_ptr(&base, vars_ptrs.ptr(), p_argcount, ret, ce);                                                                                            \
+			m_method_ptr(&base, vars_ptrs.ptrw(), p_argcount, ret, ce);                                                                                           \
 			if (m_has_return) {                                                                                                                                   \
 				m_return_type r = ret;                                                                                                                            \
 				PtrToArg<m_return_type>::encode(ret, r_ret);                                                                                                      \
@@ -626,7 +626,7 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 			Variant base = PtrToArg<m_class>::convert(p_base);                                                                                                    \
 			Variant ret;                                                                                                                                          \
 			Callable::CallError ce;                                                                                                                               \
-			m_method_ptr(&base, vars_ptrs.ptr(), p_argcount, ret, ce);                                                                                            \
+			m_method_ptr(&base, vars_ptrs.ptrw(), p_argcount, ret, ce);                                                                                           \
 		}                                                                                                                                                         \
 		static int get_argument_count() {                                                                                                                         \
 			return 1;                                                                                                                                             \

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2206,7 +2206,7 @@ void RasterizerSceneGLES3::_render_shadow_pass(RID p_light, RID p_shadow_atlas, 
 		spec_constant_base_flags |= SceneShaderGLES3::RENDER_SHADOWS_LINEAR;
 	}
 
-	RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), reverse_cull, spec_constant_base_flags, false);
+	RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), reverse_cull, spec_constant_base_flags, false);
 
 	_render_list_template<PASS_MODE_SHADOW>(&render_list_params, &render_data, 0, render_list[RENDER_LIST_SECONDARY].elements.size());
 
@@ -2508,7 +2508,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 				SceneShaderGLES3::DISABLE_LIGHTMAP | SceneShaderGLES3::DISABLE_LIGHT_OMNI |
 				SceneShaderGLES3::DISABLE_LIGHT_SPOT;
 
-		RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, spec_constant, use_wireframe);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptrw(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, spec_constant, use_wireframe);
 		_render_list_template<PASS_MODE_DEPTH>(&render_list_params, &render_data, 0, render_list[RENDER_LIST_OPAQUE].elements.size());
 
 		glColorMask(1, 1, 1, 1);
@@ -2608,7 +2608,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	}
 
 	// Render Opaque Objects.
-	RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, spec_constant_base_flags, use_wireframe);
+	RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptrw(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, spec_constant_base_flags, use_wireframe);
 
 	_render_list_template<PASS_MODE_COLOR>(&render_list_params, &render_data, 0, render_list[RENDER_LIST_OPAQUE].elements.size());
 
@@ -2684,7 +2684,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 	scene_state.enable_gl_blend(true);
 
 	//Render transparent pass
-	RenderListParameters render_list_params_alpha(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, spec_constant_base_flags, use_wireframe);
+	RenderListParameters render_list_params_alpha(render_list[RENDER_LIST_ALPHA].elements.ptrw(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, spec_constant_base_flags, use_wireframe);
 
 	_render_list_template<PASS_MODE_COLOR_TRANSPARENT>(&render_list_params_alpha, &render_data, 0, render_list[RENDER_LIST_ALPHA].elements.size(), true);
 
@@ -3705,7 +3705,7 @@ void RasterizerSceneGLES3::render_particle_collider_heightfield(RID p_collider, 
 
 	glClear(GL_DEPTH_BUFFER_BIT);
 
-	RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, 31, false);
+	RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, 31, false);
 
 	_render_list_template<PASS_MODE_SHADOW>(&render_list_params, &render_data, 0, render_list[RENDER_LIST_SECONDARY].elements.size());
 
@@ -3763,7 +3763,7 @@ void RasterizerSceneGLES3::_render_uv2(const PagedArray<RenderGeometryInstance *
 		base_spec_constant |= SceneShaderGLES3::DISABLE_LIGHT_SPOT;
 		base_spec_constant |= SceneShaderGLES3::DISABLE_LIGHTMAP;
 
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, base_spec_constant, true, Vector2(0, 0));
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, base_spec_constant, true, Vector2(0, 0));
 
 		const int uv_offset_count = 9;
 		static const Vector2 uv_offsets[uv_offset_count] = {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -600,12 +600,12 @@ private:
 
 		void sort_by_key() {
 			SortArray<GeometryInstanceSurface *, SortByKey> sorter;
-			sorter.sort(elements.ptr(), elements.size());
+			sorter.sort(elements.ptrw(), elements.size());
 		}
 
 		void sort_by_key_range(uint32_t p_from, uint32_t p_size) {
 			SortArray<GeometryInstanceSurface *, SortByKey> sorter;
-			sorter.sort(elements.ptr() + p_from, p_size);
+			sorter.sort(elements.ptrw() + p_from, p_size);
 		}
 
 		struct SortByDepth {
@@ -617,7 +617,7 @@ private:
 		void sort_by_depth() { //used for shadows
 
 			SortArray<GeometryInstanceSurface *, SortByDepth> sorter;
-			sorter.sort(elements.ptr(), elements.size());
+			sorter.sort(elements.ptrw(), elements.size());
 		}
 
 		struct SortByReverseDepthAndPriority {
@@ -629,7 +629,7 @@ private:
 		void sort_by_reverse_depth_and_priority() { //used for alpha
 
 			SortArray<GeometryInstanceSurface *, SortByReverseDepthAndPriority> sorter;
-			sorter.sort(elements.ptr(), elements.size());
+			sorter.sort(elements.ptrw(), elements.size());
 		}
 
 		_FORCE_INLINE_ void add_element(GeometryInstanceSurface *p_element) {

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -589,7 +589,7 @@ void ShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const
 		filtered_uniforms.push_back(Pair<StringName, int>(E.key, E.value.prop_order));
 	}
 	int uniform_count = filtered_uniforms.size();
-	sorter.sort(filtered_uniforms.ptr(), uniform_count);
+	sorter.sort(filtered_uniforms.ptrw(), uniform_count);
 
 	String last_group;
 	for (int i = 0; i < uniform_count; i++) {

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -2273,7 +2273,7 @@ void MeshStorage::skeleton_allocate_data(RID p_skeleton, int p_bones, bool p_2d_
 		glBindTexture(GL_TEXTURE_2D, 0);
 		GLES3::Utilities::get_singleton()->texture_allocated_data(skeleton->transforms_texture, skeleton->data.size() * sizeof(float), "Skeleton transforms texture");
 
-		memset(skeleton->data.ptr(), 0, skeleton->data.size() * sizeof(float));
+		memset(skeleton->data.ptrw(), 0, skeleton->data.size() * sizeof(float));
 
 		_skeleton_make_dirty(skeleton);
 	}
@@ -2304,7 +2304,7 @@ void MeshStorage::skeleton_bone_set_transform(RID p_skeleton, int p_bone, const 
 	ERR_FAIL_INDEX(p_bone, skeleton->size);
 	ERR_FAIL_COND(skeleton->use_2d);
 
-	float *dataptr = skeleton->data.ptr() + p_bone * 12;
+	float *dataptr = skeleton->data.ptrw() + p_bone * 12;
 
 	dataptr[0] = p_transform.basis.rows[0][0];
 	dataptr[1] = p_transform.basis.rows[0][1];
@@ -2356,7 +2356,7 @@ void MeshStorage::skeleton_bone_set_transform_2d(RID p_skeleton, int p_bone, con
 	ERR_FAIL_INDEX(p_bone, skeleton->size);
 	ERR_FAIL_COND(!skeleton->use_2d);
 
-	float *dataptr = skeleton->data.ptr() + p_bone * 8;
+	float *dataptr = skeleton->data.ptrw() + p_bone * 8;
 
 	dataptr[0] = p_transform.columns[0][0];
 	dataptr[1] = p_transform.columns[1][0];

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -808,7 +808,7 @@ void ParticlesStorage::particles_set_view_axis(RID p_particles, const Vector3 &p
 #else
 		LocalVector<ParticleInstanceData3D> particle_vector;
 		particle_vector.resize(particles->amount);
-		particle_array = particle_vector.ptr();
+		particle_array = particle_vector.ptrw();
 		godot_webgl2_glGetBufferSubData(GL_ARRAY_BUFFER, 0, particles->amount * sizeof(ParticleInstanceData3D), particle_array);
 #endif
 		SortArray<ParticleInstanceData3D, ParticlesViewSort> sorter;
@@ -1173,7 +1173,7 @@ void ParticlesStorage::_particles_reverse_lifetime_sort(Particles *particles) {
 #else
 	LocalVector<ParticleInstanceData> particle_vector;
 	particle_vector.resize(particles->amount);
-	particle_array = particle_vector.ptr();
+	particle_array = particle_vector.ptrw();
 	godot_webgl2_glGetBufferSubData(GL_ARRAY_BUFFER, 0, buffer_size, particle_array);
 #endif
 

--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -434,7 +434,7 @@ void BoundUniformSet::merge_into(ResourceUsageMap &p_dst) const {
 		resources->reserve(resources->size() + keyval.value.size());
 
 		uint32_t i = 0, j = 0;
-		__unsafe_unretained id<MTLResource> *resources_ptr = resources->ptr();
+		__unsafe_unretained id<MTLResource> *resources_ptr = resources->ptrw();
 		const __unsafe_unretained id<MTLResource> *keyval_ptr = keyval.value.ptr();
 		// 2-way merge.
 		while (i < resources->size() && j < keyval.value.size()) {

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -1303,7 +1303,7 @@ public:
 		read(len);
 		CHECK(len);
 		p_val.resize(len);
-		memcpy(p_val.ptr(), data + pos, len);
+		memcpy(p_val.ptrw(), data + pos, len);
 		pos += len;
 	}
 

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -461,7 +461,7 @@ Error RenderingContextDriverVulkan::_initialize_instance_extensions() {
 
 	TightLocalVector<VkExtensionProperties> instance_extensions;
 	instance_extensions.resize(instance_extension_count);
-	err = vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, instance_extensions.ptr());
+	err = vkEnumerateInstanceExtensionProperties(nullptr, &instance_extension_count, instance_extensions.ptrw());
 	if (err != VK_SUCCESS && err != VK_INCOMPLETE) {
 		ERR_FAIL_V(ERR_CANT_CREATE);
 	}
@@ -503,7 +503,7 @@ Error RenderingContextDriverVulkan::_find_validation_layers(TightLocalVector<con
 	if (instance_layer_count > 0) {
 		TightLocalVector<VkLayerProperties> layer_properties;
 		layer_properties.resize(instance_layer_count);
-		err = vkEnumerateInstanceLayerProperties(&instance_layer_count, layer_properties.ptr());
+		err = vkEnumerateInstanceLayerProperties(&instance_layer_count, layer_properties.ptrw());
 		ERR_FAIL_COND_V(err != VK_SUCCESS, ERR_CANT_CREATE);
 
 		// Preferred set of validation layers.
@@ -832,7 +832,7 @@ Error RenderingContextDriverVulkan::_initialize_devices() {
 		driver_devices.resize(physical_device_count);
 		physical_devices.resize(physical_device_count);
 		device_queue_families.resize(physical_device_count);
-		err = vkEnumeratePhysicalDevices(instance, &physical_device_count, physical_devices.ptr());
+		err = vkEnumeratePhysicalDevices(instance, &physical_device_count, physical_devices.ptrw());
 		ERR_FAIL_COND_V(err != VK_SUCCESS, ERR_CANT_CREATE);
 	}
 
@@ -854,7 +854,7 @@ Error RenderingContextDriverVulkan::_initialize_devices() {
 
 		if (queue_family_properties_count > 0) {
 			device_queue_families[i].properties.resize(queue_family_properties_count);
-			vkGetPhysicalDeviceQueueFamilyProperties(physical_devices[i], &queue_family_properties_count, device_queue_families[i].properties.ptr());
+			vkGetPhysicalDeviceQueueFamilyProperties(physical_devices[i], &queue_family_properties_count, device_queue_families[i].properties.ptrw());
 		}
 	}
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -545,7 +545,7 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 
 	TightLocalVector<VkExtensionProperties> device_extensions;
 	device_extensions.resize(device_extension_count);
-	err = vkEnumerateDeviceExtensionProperties(physical_device, nullptr, &device_extension_count, device_extensions.ptr());
+	err = vkEnumerateDeviceExtensionProperties(physical_device, nullptr, &device_extension_count, device_extensions.ptrw());
 	ERR_FAIL_COND_V(err != VK_SUCCESS, ERR_CANT_CREATE);
 
 #if defined(SWAPPY_FRAME_PACING_ENABLED)
@@ -553,7 +553,7 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 		char **swappy_required_extensions;
 		uint32_t swappy_required_extensions_count = 0;
 		// Determine number of extensions required by Swappy frame pacer.
-		SwappyVk_determineDeviceExtensions(physical_device, device_extension_count, device_extensions.ptr(), &swappy_required_extensions_count, nullptr);
+		SwappyVk_determineDeviceExtensions(physical_device, device_extension_count, device_extensions.ptrw(), &swappy_required_extensions_count, nullptr);
 
 		if (swappy_required_extensions_count < device_extension_count) {
 			// Determine the actual extensions.
@@ -563,7 +563,7 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 				swappy_required_extensions[i] = &pRequiredExtensionsData[i * (VK_MAX_EXTENSION_NAME_SIZE + 1)];
 			}
 			SwappyVk_determineDeviceExtensions(physical_device, device_extension_count,
-					device_extensions.ptr(), &swappy_required_extensions_count, swappy_required_extensions);
+					device_extensions.ptrw(), &swappy_required_extensions_count, swappy_required_extensions);
 
 			// Enable extensions requested by Swappy.
 			for (uint32_t i = 0; i < swappy_required_extensions_count; i++) {
@@ -2601,7 +2601,7 @@ Error RenderingDeviceDriverVulkan::command_queue_execute_and_present(CommandQueu
 		present_info.swapchainCount = swapchains.size();
 		present_info.pSwapchains = swapchains.ptr();
 		present_info.pImageIndices = image_indices.ptr();
-		present_info.pResults = results.ptr();
+		present_info.pResults = results.ptrw();
 
 		device_queue.submit_mutex.lock();
 #if defined(SWAPPY_FRAME_PACING_ENABLED)
@@ -2840,7 +2840,7 @@ RenderingDeviceDriver::SwapChainID RenderingDeviceDriverVulkan::swap_chain_creat
 
 	TightLocalVector<VkSurfaceFormatKHR> formats;
 	formats.resize(format_count);
-	err = functions.GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface->vk_surface, &format_count, formats.ptr());
+	err = functions.GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface->vk_surface, &format_count, formats.ptrw());
 	ERR_FAIL_COND_V(err != VK_SUCCESS, SwapChainID());
 
 	VkFormat format = VK_FORMAT_UNDEFINED;
@@ -2976,7 +2976,7 @@ Error RenderingDeviceDriverVulkan::swap_chain_resize(CommandQueueID p_cmd_queue,
 	ERR_FAIL_COND_V(err != VK_SUCCESS, ERR_CANT_CREATE);
 
 	present_modes.resize(present_modes_count);
-	err = functions.GetPhysicalDeviceSurfacePresentModesKHR(physical_device, surface->vk_surface, &present_modes_count, present_modes.ptr());
+	err = functions.GetPhysicalDeviceSurfacePresentModesKHR(physical_device, surface->vk_surface, &present_modes_count, present_modes.ptrw());
 	ERR_FAIL_COND_V(err != VK_SUCCESS, ERR_CANT_CREATE);
 
 	// Choose the present mode based on the display server setting.
@@ -3108,7 +3108,7 @@ Error RenderingDeviceDriverVulkan::swap_chain_resize(CommandQueueID p_cmd_queue,
 	ERR_FAIL_COND_V(err != VK_SUCCESS, ERR_CANT_CREATE);
 
 	swap_chain->images.resize(image_count);
-	err = device_functions.GetSwapchainImagesKHR(vk_device, swap_chain->vk_swapchain, &image_count, swap_chain->images.ptr());
+	err = device_functions.GetSwapchainImagesKHR(vk_device, swap_chain->vk_swapchain, &image_count, swap_chain->images.ptrw());
 	ERR_FAIL_COND_V(err != VK_SUCCESS, ERR_CANT_CREATE);
 
 	VkImageViewCreateInfo view_create_info = {};

--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -169,13 +169,13 @@ void EditorFileServer::poll() {
 		LocalVector<uint8_t> file_buffer_decompressed;
 		file_buffer_decompressed.resize(file_buffer_decompressed_size);
 
-		err = tcp_peer->get_data(file_buffer.ptr(), file_buffer_size);
+		err = tcp_peer->get_data(file_buffer.ptrw(), file_buffer_size);
 
 		pr.step(TTR("Decompressing remote file system"), 2, true);
 
 		ERR_FAIL_COND(err != OK);
 		// Decompress the text with all the files
-		Compression::decompress(file_buffer_decompressed.ptr(), file_buffer_decompressed.size(), file_buffer.ptr(), file_buffer.size(), Compression::MODE_ZSTD);
+		Compression::decompress(file_buffer_decompressed.ptrw(), file_buffer_decompressed.size(), file_buffer.ptr(), file_buffer.size(), Compression::MODE_ZSTD);
 		String files_text = String::utf8((const char *)file_buffer_decompressed.ptr(), file_buffer_decompressed.size());
 		Vector<String> files = files_text.split("\n");
 

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -248,7 +248,7 @@ void GodotSoftBody3D::update_area() {
 	LocalVector<int> counts;
 	if (nodes.size() > 0) {
 		counts.resize(nodes.size());
-		memset(counts.ptr(), 0, counts.size() * sizeof(int));
+		memset(counts.ptrw(), 0, counts.size() * sizeof(int));
 	}
 
 	for (Node &node : nodes) {
@@ -548,7 +548,7 @@ bool GodotSoftBody3D::create_from_trimesh(const Vector<int> &p_indices, const Ve
 	// Create links and faces from triangles.
 	LocalVector<bool> chks;
 	chks.resize(node_count * node_count);
-	memset(chks.ptr(), 0, chks.size() * sizeof(bool));
+	memset(chks.ptrw(), 0, chks.size() * sizeof(bool));
 
 	for (uint32_t i = 0; i < triangle_count * 3; i += 3) {
 		const int idx[] = { triangles[i], triangles[i + 1], triangles[i + 2] };

--- a/modules/jolt_physics/shapes/jolt_height_map_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_height_map_shape_3d.cpp
@@ -86,7 +86,7 @@ JPH::ShapeRefC JoltHeightMapShape3D::_build_height_field() const {
 	heights_rev.resize(heights.size());
 
 	const real_t *heights_ptr = heights.ptr();
-	float *heights_rev_ptr = heights_rev.ptr();
+	float *heights_rev_ptr = heights_rev.ptrw();
 
 	for (int z = 0; z < depth; ++z) {
 		const int z_rev = (depth - 1) - z;

--- a/modules/navigation/3d/nav_mesh_queries_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_queries_3d.cpp
@@ -542,7 +542,7 @@ void NavMeshQueries3D::_query_task_simplified_path_points(NavMeshPathQueryTask3D
 	uint32_t index_count = simplified_path_indices.size();
 
 	{
-		Vector3 *points_ptr = p_query_task.path_points.ptr();
+		Vector3 *points_ptr = p_query_task.path_points.ptrw();
 		for (uint32_t i = 0; i < index_count; i++) {
 			points_ptr[i] = points_ptr[simplified_path_indices[i]];
 		}
@@ -550,7 +550,7 @@ void NavMeshQueries3D::_query_task_simplified_path_points(NavMeshPathQueryTask3D
 	}
 
 	if (p_query_task.metadata_flags.has_flag(PathMetadataFlags::PATH_INCLUDE_TYPES)) {
-		int32_t *types_ptr = p_query_task.path_meta_point_types.ptr();
+		int32_t *types_ptr = p_query_task.path_meta_point_types.ptrw();
 		for (uint32_t i = 0; i < index_count; i++) {
 			types_ptr[i] = types_ptr[simplified_path_indices[i]];
 		}
@@ -558,7 +558,7 @@ void NavMeshQueries3D::_query_task_simplified_path_points(NavMeshPathQueryTask3D
 	}
 
 	if (p_query_task.metadata_flags.has_flag(PathMetadataFlags::PATH_INCLUDE_RIDS)) {
-		RID *rids_ptr = p_query_task.path_meta_point_rids.ptr();
+		RID *rids_ptr = p_query_task.path_meta_point_rids.ptrw();
 		for (uint32_t i = 0; i < index_count; i++) {
 			rids_ptr[i] = rids_ptr[simplified_path_indices[i]];
 		}
@@ -566,7 +566,7 @@ void NavMeshQueries3D::_query_task_simplified_path_points(NavMeshPathQueryTask3D
 	}
 
 	if (p_query_task.metadata_flags.has_flag(PathMetadataFlags::PATH_INCLUDE_OWNERS)) {
-		int64_t *owners_ptr = p_query_task.path_meta_point_owners.ptr();
+		int64_t *owners_ptr = p_query_task.path_meta_point_owners.ptrw();
 		for (uint32_t i = 0; i < index_count; i++) {
 			owners_ptr[i] = owners_ptr[simplified_path_indices[i]];
 		}

--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -691,7 +691,7 @@ void NavMap::step(real_t p_deltatime) {
 
 	if (active_2d_avoidance_agents.size() > 0) {
 		if (use_threads && avoidance_use_multiple_threads) {
-			WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &NavMap::compute_single_avoidance_step_2d, active_2d_avoidance_agents.ptr(), active_2d_avoidance_agents.size(), -1, true, SNAME("RVOAvoidanceAgents2D"));
+			WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &NavMap::compute_single_avoidance_step_2d, active_2d_avoidance_agents.ptrw(), active_2d_avoidance_agents.size(), -1, true, SNAME("RVOAvoidanceAgents2D"));
 			WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 		} else {
 			for (NavAgent *agent : active_2d_avoidance_agents) {
@@ -705,7 +705,7 @@ void NavMap::step(real_t p_deltatime) {
 
 	if (active_3d_avoidance_agents.size() > 0) {
 		if (use_threads && avoidance_use_multiple_threads) {
-			WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &NavMap::compute_single_avoidance_step_3d, active_3d_avoidance_agents.ptr(), active_3d_avoidance_agents.size(), -1, true, SNAME("RVOAvoidanceAgents3D"));
+			WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &NavMap::compute_single_avoidance_step_3d, active_3d_avoidance_agents.ptrw(), active_3d_avoidance_agents.size(), -1, true, SNAME("RVOAvoidanceAgents3D"));
 			WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 		} else {
 			for (NavAgent *agent : active_3d_avoidance_agents) {

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -77,7 +77,7 @@ void RaycastOcclusionCull::RaycastHZBuffer::resize(const Size2i &p_size) {
 	camera_rays = (CameraRayTile *)(camera_rays_unaligned_buffer + alignment - (((uint64_t)camera_rays_unaligned_buffer) % alignment));
 
 	camera_ray_masks.resize(camera_rays_tile_count * TILE_RAYS);
-	memset(camera_ray_masks.ptr(), ~0, camera_rays_tile_count * TILE_RAYS * sizeof(uint32_t));
+	memset(camera_ray_masks.ptrw(), ~0, camera_rays_tile_count * TILE_RAYS * sizeof(uint32_t));
 }
 
 void RaycastOcclusionCull::RaycastHZBuffer::update_camera_rays(const Transform3D &p_cam_transform, const Vector3 &p_near_bottom_left, const Vector2 &p_near_extents, real_t p_z_far, bool p_cam_orthogonal) {
@@ -336,7 +336,7 @@ void RaycastOcclusionCull::Scenario::_update_dirty_instance(int p_idx, RID *p_in
 	occ_inst->xformed_vertices.resize(3 * vertices_size + 3);
 
 	const Vector3 *read_ptr = occ->vertices.ptr();
-	float *write_ptr = occ_inst->xformed_vertices.ptr();
+	float *write_ptr = occ_inst->xformed_vertices.ptrw();
 
 	if (vertices_size > 1024) {
 		TransformThreadData td;
@@ -353,7 +353,7 @@ void RaycastOcclusionCull::Scenario::_update_dirty_instance(int p_idx, RID *p_in
 	}
 
 	occ_inst->indices.resize(occ->indices.size());
-	memcpy(occ_inst->indices.ptr(), occ->indices.ptr(), occ->indices.size() * sizeof(int32_t));
+	memcpy(occ_inst->indices.ptrw(), occ->indices.ptr(), occ->indices.size() * sizeof(int32_t));
 }
 
 void RaycastOcclusionCull::Scenario::_transform_vertices_thread(uint32_t p_thread, TransformThreadData *p_data) {
@@ -425,13 +425,13 @@ void RaycastOcclusionCull::Scenario::update() {
 
 	if (dirty_instances_array.size() / WorkerThreadPool::get_singleton()->get_thread_count() > 128) {
 		// Lots of instances, use per-instance threading
-		WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &Scenario::_update_dirty_instance_thread, dirty_instances_array.ptr(), dirty_instances_array.size(), -1, true, SNAME("RaycastOcclusionCullUpdate"));
+		WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &Scenario::_update_dirty_instance_thread, dirty_instances_array.ptrw(), dirty_instances_array.size(), -1, true, SNAME("RaycastOcclusionCullUpdate"));
 		WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 
 	} else {
 		// Few instances, use threading on the vertex transforms
 		for (unsigned int i = 0; i < dirty_instances_array.size(); i++) {
-			_update_dirty_instance(i, dirty_instances_array.ptr());
+			_update_dirty_instance(i, dirty_instances_array.ptrw());
 		}
 	}
 

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -71,7 +71,7 @@ Vector<uint8_t> WaylandThread::_read_fd(int fd) {
 	uint32_t bytes_read = 0;
 
 	while (true) {
-		ssize_t last_bytes_read = read(fd, data.ptr() + bytes_read, chunk_size);
+		ssize_t last_bytes_read = read(fd, data.ptrw() + bytes_read, chunk_size);
 		if (last_bytes_read < 0) {
 			ERR_PRINT(vformat("Read error %d.", errno));
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -674,7 +674,7 @@ String DisplayServerX11::_clipboard_get_impl(Atom p_source, Window x11_window, A
 							} else {
 								// New chunk, resize to be safe and append data.
 								incr_data.resize(MAX(data_size + len, prev_size));
-								memcpy(incr_data.ptr() + data_size, data, len);
+								memcpy(incr_data.ptrw() + data_size, data, len);
 								data_size += len;
 							}
 						} else {
@@ -919,7 +919,7 @@ Ref<Image> DisplayServerX11::clipboard_get_image() const {
 							uint32_t prev_size = incr_data.size();
 							// New chunk, resize to be safe and append data.
 							incr_data.resize(MAX(data_size + len, prev_size));
-							memcpy(incr_data.ptr() + data_size, data, len);
+							memcpy(incr_data.ptrw() + data_size, data, len);
 							data_size += len;
 						} else if (!(format == 0 && len == 0)) {
 							// For unclear reasons the first GetWindowProperty always returns a length and format of 0.
@@ -5429,7 +5429,7 @@ void DisplayServerX11::set_icon(const Ref<Image> &p_icon) {
 			}
 
 			if (net_wm_icon != None) {
-				XChangeProperty(x11_display, wd.x11_window, net_wm_icon, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)pd.ptr(), pd.size());
+				XChangeProperty(x11_display, wd.x11_window, net_wm_icon, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)pd.ptrw(), pd.size());
 			}
 
 			if (!g_set_icon_error) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -941,7 +941,7 @@ static void _append_to_pipe(char *p_bytes, int p_size, String *r_pipe, Mutex *p_
 	int total_wchars = MultiByteToWideChar(CP_ACP, 0, p_bytes, p_size, nullptr, 0);
 	if (total_wchars > 0) {
 		wchars.resize(total_wchars);
-		if (MultiByteToWideChar(CP_ACP, 0, p_bytes, p_size, wchars.ptr(), total_wchars) == 0) {
+		if (MultiByteToWideChar(CP_ACP, 0, p_bytes, p_size, wchars.ptrw(), total_wchars) == 0) {
 			wchars.clear();
 		}
 	}
@@ -1218,7 +1218,7 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 		DWORD read = 0;
 		for (;;) { // Read StdOut and StdErr from pipe.
 			bytes.resize(bytes_in_buffer + CHUNK_SIZE);
-			const bool success = ReadFile(pipe[0], bytes.ptr() + bytes_in_buffer, CHUNK_SIZE, &read, nullptr);
+			const bool success = ReadFile(pipe[0], bytes.ptrw() + bytes_in_buffer, CHUNK_SIZE, &read, nullptr);
 			if (!success || read == 0) {
 				break;
 			}
@@ -1238,14 +1238,14 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 			}
 
 			const int bytes_to_convert = bytes_in_buffer + (newline_index + 1);
-			_append_to_pipe(bytes.ptr(), bytes_to_convert, r_pipe, p_pipe_mutex);
+			_append_to_pipe(bytes.ptrw(), bytes_to_convert, r_pipe, p_pipe_mutex);
 
 			bytes_in_buffer = read - (newline_index + 1);
-			memmove(bytes.ptr(), bytes.ptr() + bytes_to_convert, bytes_in_buffer);
+			memmove(bytes.ptrw(), bytes.ptr() + bytes_to_convert, bytes_in_buffer);
 		}
 
 		if (bytes_in_buffer > 0) {
-			_append_to_pipe(bytes.ptr(), bytes_in_buffer, r_pipe, p_pipe_mutex);
+			_append_to_pipe(bytes.ptrw(), bytes_in_buffer, r_pipe, p_pipe_mutex);
 		}
 
 		CloseHandle(pipe[0]); // Close pipe read handle.

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -493,7 +493,7 @@ Ref<Image> GPUParticlesCollisionSDF3D::bake() {
 
 	LocalVector<BVH> bvh;
 
-	_create_bvh(bvh, face_pos.ptr(), face_pos.size(), faces.ptr(), th);
+	_create_bvh(bvh, face_pos.ptrw(), face_pos.size(), faces.ptr(), th);
 
 	Vector<uint8_t> cells_data;
 	cells_data.resize(sdf_size.z * sdf_size.y * sdf_size.x * (int)sizeof(float));

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -241,7 +241,7 @@ void Skeleton3D::_update_process_order() const {
 		return;
 	}
 
-	Bone *bonesptr = bones.ptr();
+	Bone *bonesptr = bones.ptrw();
 	int len = bones.size();
 
 	parentless_bones.clear();
@@ -335,7 +335,7 @@ void Skeleton3D::_notification(int p_what) {
 
 			updating = true;
 
-			Bone *bonesptr = bones.ptr();
+			Bone *bonesptr = bones.ptrw();
 			int len = bones.size();
 
 			thread_local LocalVector<bool> bone_global_pose_dirty_backup;
@@ -1077,7 +1077,7 @@ void Skeleton3D::_force_update_bone_children_transforms(int p_bone_idx) const {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone_idx, bone_size);
 
-	Bone *bonesptr = bones.ptr();
+	Bone *bonesptr = bones.ptrw();
 
 	// Loop through nested set.
 	for (int offset = 0; offset < bone_size; offset++) {

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -271,7 +271,7 @@ Vector<SceneState::PackState> PropertyUtils::get_node_states_stack(const Node *p
 	Vector<SceneState::PackState> states_stack_ret;
 	{
 		states_stack_ret.resize(states_stack.size());
-		_FastPackState *ps = states_stack.ptr();
+		_FastPackState *ps = states_stack.ptrw();
 		if (states_stack.size() > 0) {
 			for (int i = states_stack.size() - 1; i >= 0; --i) {
 				states_stack_ret.write[i].state.reference_ptr(ps->state);

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -433,7 +433,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 
 		{
 			const int *counts_ptr = merged_normals_counts.ptr();
-			Vector3 *merged_normals_ptrw = merged_normals.ptr();
+			Vector3 *merged_normals_ptrw = merged_normals.ptrw();
 			for (unsigned int j = 0; j < merged_vertex_count; j++) {
 				merged_normals_ptrw[j] /= counts_ptr[j];
 			}

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -186,7 +186,7 @@ void AudioStreamPlaybackWAV::do_resample(const Depth *p_src, AudioFrame *p_dst, 
 						if (p_qoa->data_ofs != new_data_ofs) {
 							p_qoa->data_ofs = new_data_ofs;
 							const uint8_t *ofs_src = (uint8_t *)p_src + p_qoa->data_ofs;
-							qoa_decode_frame(ofs_src, p_qoa->frame_len, &p_qoa->desc, p_qoa->dec.ptr(), &p_qoa->dec_len);
+							qoa_decode_frame(ofs_src, p_qoa->frame_len, &p_qoa->desc, p_qoa->dec.ptrw(), &p_qoa->dec_len);
 						}
 
 						uint32_t dec_idx = (interp_pos % QOA_FRAME_LEN) * p_qoa->desc.channels;
@@ -577,8 +577,8 @@ void AudioStreamWAV::set_data(const Vector<uint8_t> &p_data) {
 
 	int alloc_len = src_data_len + DATA_PAD * 2;
 	data.resize(alloc_len);
-	memset(data.ptr(), 0, alloc_len);
-	memcpy(data.ptr() + DATA_PAD, p_data.ptr(), src_data_len);
+	memset(data.ptrw(), 0, alloc_len);
+	memcpy(data.ptrw() + DATA_PAD, p_data.ptr(), src_data_len);
 	data_bytes = src_data_len;
 
 	AudioServer::get_singleton()->unlock();

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -1295,7 +1295,7 @@ void SurfaceTool::optimize_indices_for_cache() {
 	ERR_FAIL_COND(index_array.size() % 3 != 0);
 
 	LocalVector old_index_array = index_array;
-	memset(index_array.ptr(), 0, index_array.size() * sizeof(int));
+	memset(index_array.ptrw(), 0, index_array.size() * sizeof(int));
 	optimize_vertex_cache_func((unsigned int *)index_array.ptr(), (unsigned int *)old_index_array.ptr(), old_index_array.size(), vertex_array.size());
 }
 

--- a/servers/movie_writer/movie_writer.cpp
+++ b/servers/movie_writer/movie_writer.cpp
@@ -196,7 +196,7 @@ void MovieWriter::add_frame() {
 	cpu_time += RenderingServer::get_singleton()->get_frame_setup_time_cpu();
 	gpu_time += RenderingServer::get_singleton()->viewport_get_measured_render_time_gpu(main_vp_rid);
 
-	AudioDriverDummy::get_dummy_singleton()->mix_audio(mix_rate / fps, audio_mix_buffer.ptr());
+	AudioDriverDummy::get_dummy_singleton()->mix_audio(mix_rate / fps, audio_mix_buffer.ptrw());
 	write_frame(vp_tex, audio_mix_buffer.ptr());
 }
 

--- a/servers/rendering/dummy/storage/material_storage.cpp
+++ b/servers/rendering/dummy/storage/material_storage.cpp
@@ -105,7 +105,7 @@ void MaterialStorage::get_shader_parameter_list(RID p_shader, List<PropertyInfo>
 		filtered_uniforms.push_back(Pair<StringName, int>(E.key, E.value.prop_order));
 	}
 	int uniform_count = filtered_uniforms.size();
-	sorter.sort(filtered_uniforms.ptr(), uniform_count);
+	sorter.sort(filtered_uniforms.ptrw(), uniform_count);
 
 	String last_group;
 	for (int i = 0; i < uniform_count; i++) {

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2025,7 +2025,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		RID rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_OPAQUE, nullptr, RID(), samplers);
 
 		bool finish_depth = using_ssao || using_ssil || using_sdfgi || using_voxelgi || ce_pre_opaque_resolved_depth || ce_post_opaque_resolved_depth;
-		RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, depth_pass_mode, 0, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptrw(), render_list[RENDER_LIST_OPAQUE].element_info.ptrw(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, depth_pass_mode, 0, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
 		_render_list_with_draw_list(&render_list_params, depth_framebuffer, RD::DrawFlags(needs_pre_resolve ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_ALL), depth_pass_clear, 0.0f);
 
 		RD::get_singleton()->draw_command_end_label();
@@ -2104,7 +2104,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 			uint32_t opaque_color_pass_flags = using_motion_pass ? (color_pass_flags & ~uint32_t(COLOR_PASS_FLAG_MOTION_VECTORS)) : color_pass_flags;
 			RID opaque_framebuffer = using_motion_pass ? rb_data->get_color_pass_fb(opaque_color_pass_flags) : color_framebuffer;
-			RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, PASS_MODE_COLOR, opaque_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+			RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptrw(), render_list[RENDER_LIST_OPAQUE].element_info.ptrw(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, PASS_MODE_COLOR, opaque_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
 			_render_list_with_draw_list(&render_list_params, opaque_framebuffer, RD::DrawFlags(load_color ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_COLOR_ALL) | (depth_pre_pass ? RD::DRAW_DEFAULT_ALL : RD::DRAW_CLEAR_DEPTH), c, 0.0f);
 		}
 
@@ -2124,7 +2124,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 			rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_MOTION, p_render_data, radiance_texture, samplers, true);
 
-			RenderListParameters render_list_params(render_list[RENDER_LIST_MOTION].elements.ptr(), render_list[RENDER_LIST_MOTION].element_info.ptr(), render_list[RENDER_LIST_MOTION].elements.size(), reverse_cull, PASS_MODE_COLOR, color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+			RenderListParameters render_list_params(render_list[RENDER_LIST_MOTION].elements.ptrw(), render_list[RENDER_LIST_MOTION].element_info.ptrw(), render_list[RENDER_LIST_MOTION].elements.size(), reverse_cull, PASS_MODE_COLOR, color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
 			_render_list_with_draw_list(&render_list_params, color_framebuffer);
 
 			RD::get_singleton()->draw_command_end_label();
@@ -2303,7 +2303,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		}
 
 		RID alpha_framebuffer = rb_data.is_valid() ? rb_data->get_color_pass_fb(transparent_color_pass_flags) : color_only_framebuffer;
-		RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].element_info.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR, transparent_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptrw(), render_list[RENDER_LIST_ALPHA].element_info.ptrw(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR, transparent_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);
 		_render_list_with_draw_list(&render_list_params, alpha_framebuffer);
 	}
 
@@ -2726,7 +2726,7 @@ void RenderForwardClustered::_render_shadow_end() {
 	RD::get_singleton()->draw_command_begin_label("Shadow Render");
 
 	for (SceneState::ShadowPass &shadow_pass : scene_state.shadow_passes) {
-		RenderListParameters render_list_parameters(render_list[RENDER_LIST_SECONDARY].elements.ptr() + shadow_pass.element_from, render_list[RENDER_LIST_SECONDARY].element_info.ptr() + shadow_pass.element_from, shadow_pass.element_count, shadow_pass.flip_cull, shadow_pass.pass_mode, 0, true, false, shadow_pass.rp_uniform_set, false, Vector2(), shadow_pass.lod_distance_multiplier, shadow_pass.screen_mesh_lod_threshold, 1, shadow_pass.element_from);
+		RenderListParameters render_list_parameters(render_list[RENDER_LIST_SECONDARY].elements.ptrw() + shadow_pass.element_from, render_list[RENDER_LIST_SECONDARY].element_info.ptrw() + shadow_pass.element_from, shadow_pass.element_count, shadow_pass.flip_cull, shadow_pass.pass_mode, 0, true, false, shadow_pass.rp_uniform_set, false, Vector2(), shadow_pass.lod_distance_multiplier, shadow_pass.screen_mesh_lod_threshold, 1, shadow_pass.element_from);
 		_render_list_with_draw_list(&render_list_parameters, shadow_pass.framebuffer, shadow_pass.clear_depth ? RD::DRAW_CLEAR_DEPTH : RD::DRAW_DEFAULT_ALL, Vector<Color>(), 0.0f, 0, shadow_pass.rect);
 	}
 
@@ -2773,7 +2773,7 @@ void RenderForwardClustered::_render_particle_collider_heightfield(RID p_fb, con
 
 	{
 		//regular forward for now
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, pass_mode, 0, true, false, rp_uniform_set);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].element_info.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, pass_mode, 0, true, false, rp_uniform_set);
 		_render_list_with_draw_list(&render_list_params, p_fb);
 	}
 	RD::get_singleton()->draw_command_end_label();
@@ -2818,7 +2818,7 @@ void RenderForwardClustered::_render_material(const Transform3D &p_cam_transform
 	RENDER_TIMESTAMP("Render 3D Material");
 
 	{
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].element_info.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set);
 		//regular forward for now
 		Vector<Color> clear = {
 			Color(0, 0, 0, 0),
@@ -2869,7 +2869,7 @@ void RenderForwardClustered::_render_uv2(const PagedArray<RenderGeometryInstance
 	RENDER_TIMESTAMP("Render 3D Material");
 
 	{
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set, true);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].element_info.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set, true);
 		//regular forward for now
 		Vector<Color> clear = {
 			Color(0, 0, 0, 0),
@@ -2986,7 +2986,7 @@ void RenderForwardClustered::_render_sdfgi(Ref<RenderSceneBuffersRD> p_render_bu
 			E = sdfgi_framebuffer_size_cache.insert(fb_size, fb);
 		}
 
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set, false);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].element_info.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, 0, true, false, rp_uniform_set, false);
 		_render_list_with_draw_list(&render_list_params, E->value);
 	}
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -586,12 +586,12 @@ private:
 
 		void sort_by_key() {
 			SortArray<GeometryInstanceSurfaceDataCache *, SortByKey> sorter;
-			sorter.sort(elements.ptr(), elements.size());
+			sorter.sort(elements.ptrw(), elements.size());
 		}
 
 		void sort_by_key_range(uint32_t p_from, uint32_t p_size) {
 			SortArray<GeometryInstanceSurfaceDataCache *, SortByKey> sorter;
-			sorter.sort(elements.ptr() + p_from, p_size);
+			sorter.sort(elements.ptrw() + p_from, p_size);
 		}
 
 		struct SortByDepth {
@@ -603,7 +603,7 @@ private:
 		void sort_by_depth() { //used for shadows
 
 			SortArray<GeometryInstanceSurfaceDataCache *, SortByDepth> sorter;
-			sorter.sort(elements.ptr(), elements.size());
+			sorter.sort(elements.ptrw(), elements.size());
 		}
 
 		struct SortByReverseDepthAndPriority {
@@ -615,7 +615,7 @@ private:
 		void sort_by_reverse_depth_and_priority() { //used for alpha
 
 			SortArray<GeometryInstanceSurfaceDataCache *, SortByReverseDepthAndPriority> sorter;
-			sorter.sort(elements.ptr(), elements.size());
+			sorter.sort(elements.ptrw(), elements.size());
 		}
 
 		_FORCE_INLINE_ void add_element(GeometryInstanceSurfaceDataCache *p_element) {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1105,7 +1105,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 		}
 
 		if (render_list[RENDER_LIST_OPAQUE].elements.size() > 0) {
-			RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptr(), render_list[RENDER_LIST_OPAQUE].element_info.ptr(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, PASS_MODE_COLOR, rp_uniform_set, base_specialization, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count);
+			RenderListParameters render_list_params(render_list[RENDER_LIST_OPAQUE].elements.ptrw(), render_list[RENDER_LIST_OPAQUE].element_info.ptrw(), render_list[RENDER_LIST_OPAQUE].elements.size(), reverse_cull, PASS_MODE_COLOR, rp_uniform_set, base_specialization, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count);
 			render_list_params.framebuffer_format = fb_format;
 			render_list_params.subpass = RD::get_singleton()->draw_list_get_current_pass(); // Should now always be 0.
 
@@ -1132,7 +1132,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 
 				rp_uniform_set = _setup_render_pass_uniform_set(RENDER_LIST_ALPHA, p_render_data, radiance_texture, samplers, true);
 
-				RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].element_info.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR_TRANSPARENT, rp_uniform_set, base_specialization, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count);
+				RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptrw(), render_list[RENDER_LIST_ALPHA].element_info.ptrw(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR_TRANSPARENT, rp_uniform_set, base_specialization, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count);
 				render_list_params.framebuffer_format = fb_format;
 				render_list_params.subpass = RD::get_singleton()->draw_list_get_current_pass(); // Should now always be 0.
 
@@ -1183,7 +1183,7 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 				// this may be needed if we re-introduced steps that change info, not sure which do so in the previous implementation
 				//_setup_environment(p_render_data, is_reflection_probe, screen_size, p_default_bg_color, false);
 
-				RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].element_info.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR, rp_uniform_set, base_specialization, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count);
+				RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptrw(), render_list[RENDER_LIST_ALPHA].element_info.ptrw(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR, rp_uniform_set, base_specialization, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count);
 				render_list_params.framebuffer_format = fb_format;
 				render_list_params.subpass = RD::get_singleton()->draw_list_get_current_pass(); // Should now always be 0.
 
@@ -1490,7 +1490,7 @@ void RenderForwardMobile::_render_shadow_end() {
 	RD::get_singleton()->draw_command_begin_label("Shadow Render");
 
 	for (SceneState::ShadowPass &shadow_pass : scene_state.shadow_passes) {
-		RenderListParameters render_list_parameters(render_list[RENDER_LIST_SECONDARY].elements.ptr() + shadow_pass.element_from, render_list[RENDER_LIST_SECONDARY].element_info.ptr() + shadow_pass.element_from, shadow_pass.element_count, shadow_pass.flip_cull, shadow_pass.pass_mode, shadow_pass.rp_uniform_set, scene_shader.default_specialization, false, Vector2(), shadow_pass.lod_distance_multiplier, shadow_pass.screen_mesh_lod_threshold, 1, shadow_pass.element_from);
+		RenderListParameters render_list_parameters(render_list[RENDER_LIST_SECONDARY].elements.ptrw() + shadow_pass.element_from, render_list[RENDER_LIST_SECONDARY].element_info.ptrw() + shadow_pass.element_from, shadow_pass.element_count, shadow_pass.flip_cull, shadow_pass.pass_mode, shadow_pass.rp_uniform_set, scene_shader.default_specialization, false, Vector2(), shadow_pass.lod_distance_multiplier, shadow_pass.screen_mesh_lod_threshold, 1, shadow_pass.element_from);
 		_render_list_with_draw_list(&render_list_parameters, shadow_pass.framebuffer, shadow_pass.clear_depth ? RD::DRAW_CLEAR_DEPTH : RD::DRAW_DEFAULT_ALL, Vector<Color>(), 0.0f, 0, shadow_pass.rect);
 	}
 
@@ -1534,7 +1534,7 @@ void RenderForwardMobile::_render_material(const Transform3D &p_cam_transform, c
 	RENDER_TIMESTAMP("Render 3D Material");
 
 	{
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, rp_uniform_set, scene_shader.default_specialization);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].element_info.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, rp_uniform_set, scene_shader.default_specialization);
 		//regular forward for now
 		Vector<Color> clear = {
 			Color(0, 0, 0, 0),
@@ -1579,7 +1579,7 @@ void RenderForwardMobile::_render_uv2(const PagedArray<RenderGeometryInstance *>
 	RENDER_TIMESTAMP("Render 3D Material");
 
 	{
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, rp_uniform_set, scene_shader.default_specialization, false);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].element_info.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), true, pass_mode, rp_uniform_set, scene_shader.default_specialization, false);
 		//regular forward for now
 		Vector<Color> clear = {
 			Color(0, 0, 0, 0),
@@ -1663,7 +1663,7 @@ void RenderForwardMobile::_render_particle_collider_heightfield(RID p_fb, const 
 
 	{
 		//regular forward for now
-		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptr(), render_list[RENDER_LIST_SECONDARY].element_info.ptr(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, pass_mode, rp_uniform_set, scene_shader.default_specialization);
+		RenderListParameters render_list_params(render_list[RENDER_LIST_SECONDARY].elements.ptrw(), render_list[RENDER_LIST_SECONDARY].element_info.ptrw(), render_list[RENDER_LIST_SECONDARY].elements.size(), false, pass_mode, rp_uniform_set, scene_shader.default_specialization);
 		_render_list_with_draw_list(&render_list_params, p_fb);
 	}
 	RD::get_singleton()->draw_command_end_label();

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -284,12 +284,12 @@ private:
 
 		void sort_by_key() {
 			SortArray<GeometryInstanceSurfaceDataCache *, SortByKey> sorter;
-			sorter.sort(elements.ptr(), elements.size());
+			sorter.sort(elements.ptrw(), elements.size());
 		}
 
 		void sort_by_key_range(uint32_t p_from, uint32_t p_size) {
 			SortArray<GeometryInstanceSurfaceDataCache *, SortByKey> sorter;
-			sorter.sort(elements.ptr() + p_from, p_size);
+			sorter.sort(elements.ptrw() + p_from, p_size);
 		}
 
 		struct SortByDepth {
@@ -301,7 +301,7 @@ private:
 		void sort_by_depth() { //used for shadows
 
 			SortArray<GeometryInstanceSurfaceDataCache *, SortByDepth> sorter;
-			sorter.sort(elements.ptr(), elements.size());
+			sorter.sort(elements.ptrw(), elements.size());
 		}
 
 		struct SortByReverseDepthAndPriority {
@@ -313,7 +313,7 @@ private:
 		void sort_by_reverse_depth_and_priority() { //used for alpha
 
 			SortArray<GeometryInstanceSurfaceDataCache *, SortByReverseDepthAndPriority> sorter;
-			sorter.sort(elements.ptr(), elements.size());
+			sorter.sort(elements.ptrw(), elements.size());
 		}
 
 		_FORCE_INLINE_ void add_element(GeometryInstanceSurfaceDataCache *p_element) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -3173,7 +3173,7 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 RendererCanvasRenderRD::Batch *RendererCanvasRenderRD::_new_batch(bool &r_batch_broken) {
 	if (state.canvas_instance_batches.size() == 0) {
 		state.canvas_instance_batches.push_back(Batch());
-		return state.canvas_instance_batches.ptr();
+		return state.canvas_instance_batches.ptrw();
 	}
 
 	if (r_batch_broken || state.canvas_instance_batches[state.current_batch_index].instance_count == 0) {

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -585,7 +585,7 @@ void MaterialStorage::ShaderData::get_shader_uniform_list(List<PropertyInfo> *p_
 		filtered_uniforms.push_back(Pair<StringName, int>(E.key, E.value.prop_order));
 	}
 	int uniform_count = filtered_uniforms.size();
-	sorter.sort(filtered_uniforms.ptr(), uniform_count);
+	sorter.sort(filtered_uniforms.ptrw(), uniform_count);
 
 	String last_group;
 	for (int i = 0; i < uniform_count; i++) {

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -2258,7 +2258,7 @@ void MeshStorage::skeleton_allocate_data(RID p_skeleton, int p_bones, bool p_2d_
 	if (skeleton->size) {
 		skeleton->data.resize(skeleton->size * (skeleton->use_2d ? 8 : 12));
 		skeleton->buffer = RD::get_singleton()->storage_buffer_create(skeleton->data.size() * sizeof(float));
-		memset(skeleton->data.ptr(), 0, skeleton->data.size() * sizeof(float));
+		memset(skeleton->data.ptrw(), 0, skeleton->data.size() * sizeof(float));
 
 		_skeleton_make_dirty(skeleton);
 
@@ -2292,7 +2292,7 @@ void MeshStorage::skeleton_bone_set_transform(RID p_skeleton, int p_bone, const 
 	ERR_FAIL_INDEX(p_bone, skeleton->size);
 	ERR_FAIL_COND(skeleton->use_2d);
 
-	float *dataptr = skeleton->data.ptr() + p_bone * 12;
+	float *dataptr = skeleton->data.ptrw() + p_bone * 12;
 
 	dataptr[0] = p_transform.basis.rows[0][0];
 	dataptr[1] = p_transform.basis.rows[0][1];
@@ -2343,7 +2343,7 @@ void MeshStorage::skeleton_bone_set_transform_2d(RID p_skeleton, int p_bone, con
 	ERR_FAIL_NULL(skeleton);
 	ERR_FAIL_INDEX(p_bone, skeleton->size);
 	ERR_FAIL_COND(!skeleton->use_2d);
-	float *dataptr = skeleton->data.ptr() + p_bone * 8;
+	float *dataptr = skeleton->data.ptrw() + p_bone * 8;
 
 	dataptr[0] = p_transform.columns[0][0];
 	dataptr[1] = p_transform.columns[1][0];

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1462,7 +1462,7 @@ void ParticlesStorage::update_particles() {
 
 			if (uint32_t(history_size) != particles->frame_history.size()) {
 				particles->frame_history.resize(history_size);
-				memset(particles->frame_history.ptr(), 0, sizeof(ParticlesFrameParams) * history_size);
+				memset(particles->frame_history.ptrw(), 0, sizeof(ParticlesFrameParams) * history_size);
 				// Set the frame number so that we are able to distinguish an uninitialized
 				// frame from the true frame number zero. See issue #88712 for details.
 				for (int i = 0; i < history_size; i++) {

--- a/servers/rendering/renderer_scene_occlusion_cull.cpp
+++ b/servers/rendering/renderer_scene_occlusion_cull.cpp
@@ -105,7 +105,7 @@ void RendererSceneOcclusionCull::HZBuffer::resize(const Size2i &p_size) {
 
 	w = p_size.x;
 	h = p_size.y;
-	float *ptr = data.ptr();
+	float *ptr = data.ptrw();
 
 	for (int i = 0; i < mip_count; i++) {
 		sizes[i] = Size2i(w, h);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6304,7 +6304,7 @@ void RenderingDevice::_begin_frame(bool p_presented) {
 	}
 
 	if (frames[frame].timestamp_count) {
-		driver->timestamp_query_pool_get_results(frames[frame].timestamp_pool, frames[frame].timestamp_count, frames[frame].timestamp_result_values.ptr());
+		driver->timestamp_query_pool_get_results(frames[frame].timestamp_pool, frames[frame].timestamp_count, frames[frame].timestamp_result_values.ptrw());
 		driver->command_timestamp_query_pool_reset(frames[frame].command_buffer, frames[frame].timestamp_pool, frames[frame].timestamp_count);
 		SWAP(frames[frame].timestamp_names, frames[frame].timestamp_result_names);
 		SWAP(frames[frame].timestamp_cpu_values, frames[frame].timestamp_cpu_result_values);

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -1761,7 +1761,7 @@ void RenderingDeviceGraph::add_compute_list_end() {
 	command->self_stages = compute_instruction_list.stages;
 	command->instruction_data_size = instruction_data_size;
 	memcpy(command->instruction_data(), compute_instruction_list.data.ptr(), instruction_data_size);
-	_add_command_to_graph(compute_instruction_list.command_trackers.ptr(), compute_instruction_list.command_tracker_usages.ptr(), compute_instruction_list.command_trackers.size(), command_index, command);
+	_add_command_to_graph(compute_instruction_list.command_trackers.ptrw(), compute_instruction_list.command_tracker_usages.ptrw(), compute_instruction_list.command_trackers.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_draw_list_begin(FramebufferCache *p_framebuffer_cache, Rect2i p_region, VectorView<AttachmentOperation> p_attachment_operations, VectorView<RDD::RenderPassClearValue> p_attachment_clear_values, bool p_uses_color, bool p_uses_depth, uint32_t p_breadcrumb, bool p_split_cmd_buffer) {
@@ -2021,7 +2021,7 @@ void RenderingDeviceGraph::add_draw_list_end() {
 	}
 
 	memcpy(command->instruction_data(), draw_instruction_list.data.ptr(), instruction_data_size);
-	_add_command_to_graph(draw_instruction_list.command_trackers.ptr(), draw_instruction_list.command_tracker_usages.ptr(), draw_instruction_list.command_trackers.size(), command_index, command);
+	_add_command_to_graph(draw_instruction_list.command_trackers.ptrw(), draw_instruction_list.command_tracker_usages.ptrw(), draw_instruction_list.command_trackers.size(), command_index, command);
 }
 
 void RenderingDeviceGraph::add_texture_clear(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, const Color &p_color, const RDD::TextureSubresourceRange &p_range) {
@@ -2154,7 +2154,7 @@ void RenderingDeviceGraph::add_texture_update(RDD::TextureID p_dst, ResourceTrac
 		trackers.push_back(p_dst_tracker);
 		usages.push_back(RESOURCE_USAGE_COPY_TO);
 
-		_add_command_to_graph(trackers.ptr(), usages.ptr(), trackers.size(), command_index, command);
+		_add_command_to_graph(trackers.ptrw(), usages.ptrw(), trackers.size(), command_index, command);
 	} else {
 		ResourceUsage usage = RESOURCE_USAGE_COPY_TO;
 		_add_command_to_graph(&p_dst_tracker, &usage, 1, command_index, command);
@@ -2211,7 +2211,7 @@ void RenderingDeviceGraph::end(bool p_reorder_commands, bool p_full_barriers, RD
 
 		// Count all the incoming connections to every node by traversing their adjacency list.
 		command_degrees.resize(command_count);
-		memset(command_degrees.ptr(), 0, sizeof(uint32_t) * command_degrees.size());
+		memset(command_degrees.ptrw(), 0, sizeof(uint32_t) * command_degrees.size());
 		for (uint32_t i = 0; i < command_count; i++) {
 			const RecordedCommand &recorded_command = *reinterpret_cast<const RecordedCommand *>(&command_data[command_data_offsets[i]]);
 			adjacency_list_index = recorded_command.adjacent_command_list_index;


### PR DESCRIPTION
This helps address https://github.com/godotengine/godot-proposals/issues/5144.

Specifically, it would help users of `Vector` switch to `LocalVector`. If uses of non-const `ptr()` are changed to use `ptrw()` (a hundred or so exist), it would also help switching `LocalVector` users to `Vector`.