### PR TITLE
Rework dock layout management

### DIFF
--- a/editor/editor_dock_manager.cpp
+++ b/editor/editor_dock_manager.cpp
@@ -40,7 +40,6 @@
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
-#include "editor/filesystem_dock.h"
 #include "editor/gui/editor_bottom_panel.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/window_wrapper.h"
@@ -480,6 +479,8 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 	Array bottom_docks_dump;
 	Array closed_docks_dump;
 	for (const KeyValue<Control *, DockInfo> &d : all_docks) {
+		d.key->call(SNAME("_save_layout_to_config"), p_layout, p_section);
+
 		if (!d.value.at_bottom && d.value.open && (!d.value.previous_at_bottom || !d.value.dock_window)) {
 			continue;
 		}
@@ -516,8 +517,6 @@ void EditorDockManager::save_docks_to_config(Ref<ConfigFile> p_layout, const Str
 	for (int i = 0; i < hsplits.size(); i++) {
 		p_layout->set_value(p_section, "dock_hsplit_" + itos(i + 1), int(hsplits[i]->get_split_offset() / EDSCALE));
 	}
-
-	FileSystemDock::get_singleton()->save_layout_to_config(p_layout, p_section);
 }
 
 void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
@@ -548,6 +547,7 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 				continue;
 			}
 			Control *dock = dock_map[name];
+			dock->call(SNAME("_load_layout_from_config"), p_layout, p_section);
 
 			if (!all_docks[dock].enabled) {
 				// Don't open disabled docks.
@@ -612,9 +612,6 @@ void EditorDockManager::load_docks_from_config(Ref<ConfigFile> p_layout, const S
 		int ofs = p_layout->get_value(p_section, "dock_hsplit_" + itos(i + 1));
 		hsplits[i]->set_split_offset(ofs * EDSCALE);
 	}
-
-	FileSystemDock::get_singleton()->load_layout_from_config(p_layout, p_section);
-
 	_update_docks_menu();
 }
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -184,8 +184,6 @@ FileSystemList::FileSystemList() {
 	popup_editor->connect("popup_hide", callable_mp(this, &FileSystemList::_text_editor_popup_modal_close));
 }
 
-FileSystemDock *FileSystemDock::singleton = nullptr;
-
 Ref<Texture2D> FileSystemDock::_get_tree_item_icon(bool p_is_valid, const String &p_file_type, const String &p_icon_path) {
 	if (!p_icon_path.is_empty()) {
 		Ref<Texture2D> icon = ResourceLoader::load(p_icon_path);
@@ -3940,6 +3938,9 @@ void FileSystemDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_dock_horizontal", "enable"), &FileSystemDock::_set_dock_horizontal);
 	ClassDB::bind_method(D_METHOD("_can_dock_horizontal"), &FileSystemDock::_can_dock_horizontal);
 
+	ClassDB::bind_method(D_METHOD("_save_layout_to_config"), &FileSystemDock::_save_layout_to_config);
+	ClassDB::bind_method(D_METHOD("_load_layout_from_config"), &FileSystemDock::_load_layout_from_config);
+
 	ADD_SIGNAL(MethodInfo("inherit", PropertyInfo(Variant::STRING, "file")));
 	ADD_SIGNAL(MethodInfo("instantiate", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files")));
 
@@ -3953,7 +3954,7 @@ void FileSystemDock::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("display_mode_changed"));
 }
 
-void FileSystemDock::save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const {
+void FileSystemDock::_save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const {
 	p_layout->set_value(p_section, "dock_filesystem_h_split_offset", get_h_split_offset());
 	p_layout->set_value(p_section, "dock_filesystem_v_split_offset", get_v_split_offset());
 	p_layout->set_value(p_section, "dock_filesystem_display_mode", get_display_mode());
@@ -3965,7 +3966,7 @@ void FileSystemDock::save_layout_to_config(Ref<ConfigFile> p_layout, const Strin
 	p_layout->set_value(p_section, "dock_filesystem_uncollapsed_paths", uncollapsed_paths);
 }
 
-void FileSystemDock::load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
+void FileSystemDock::_load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
 	if (p_layout->has_section_key(p_section, "dock_filesystem_h_split_offset")) {
 		int fs_h_split_ofs = p_layout->get_value(p_section, "dock_filesystem_h_split_offset");
 		set_h_split_offset(fs_h_split_ofs);

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -357,8 +357,11 @@ private:
 	bool _can_dock_horizontal() const;
 	void _set_dock_horizontal(bool p_enable);
 
+	void _save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
+	void _load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section);
+
 private:
-	static FileSystemDock *singleton;
+	inline static FileSystemDock *singleton = nullptr;
 
 public:
 	static FileSystemDock *get_singleton() { return singleton; }
@@ -413,9 +416,6 @@ public:
 	void add_resource_tooltip_plugin(const Ref<EditorResourceTooltipPlugin> &p_plugin);
 	void remove_resource_tooltip_plugin(const Ref<EditorResourceTooltipPlugin> &p_plugin);
 	Control *create_tooltip_for_path(const String &p_path) const;
-
-	void save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
-	void load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section);
 
 	FileSystemDock();
 	~FileSystemDock();

--- a/editor/history_dock.cpp
+++ b/editor/history_dock.cpp
@@ -30,6 +30,7 @@
 
 #include "history_dock.h"
 
+#include "core/io/config_file.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_string_names.h"
@@ -172,6 +173,17 @@ void HistoryDock::refresh_version() {
 	action_list->set_current(idx);
 }
 
+void HistoryDock::_save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const {
+	p_layout->set_value(p_section, "dock_history_include_scene", current_scene_checkbox->is_pressed());
+	p_layout->set_value(p_section, "dock_history_include_global", global_history_checkbox->is_pressed());
+}
+
+void HistoryDock::_load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
+	current_scene_checkbox->set_pressed_no_signal(p_layout->get_value(p_section, "dock_history_include_scene", true));
+	global_history_checkbox->set_pressed_no_signal(p_layout->get_value(p_section, "dock_history_include_global", true));
+	refresh_history();
+}
+
 void HistoryDock::seek_history(int p_index) {
 	bool include_scene = current_scene_checkbox->is_pressed();
 	bool include_global = global_history_checkbox->is_pressed();
@@ -220,9 +232,9 @@ void HistoryDock::_notification(int p_notification) {
 	}
 }
 
-void HistoryDock::save_options() {
-	EditorSettings::get_singleton()->set_project_metadata("history", "include_scene", current_scene_checkbox->is_pressed());
-	EditorSettings::get_singleton()->set_project_metadata("history", "include_global", global_history_checkbox->is_pressed());
+void HistoryDock::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_save_layout_to_config"), &HistoryDock::_save_layout_to_config);
+	ClassDB::bind_method(D_METHOD("_load_layout_from_config"), &HistoryDock::_load_layout_from_config);
 }
 
 HistoryDock::HistoryDock() {
@@ -235,28 +247,21 @@ HistoryDock::HistoryDock() {
 	HBoxContainer *mode_hb = memnew(HBoxContainer);
 	add_child(mode_hb);
 
-	bool include_scene = EditorSettings::get_singleton()->get_project_metadata("history", "include_scene", true);
-	bool include_global = EditorSettings::get_singleton()->get_project_metadata("history", "include_global", true);
-
 	current_scene_checkbox = memnew(CheckBox);
 	mode_hb->add_child(current_scene_checkbox);
 	current_scene_checkbox->set_flat(true);
-	current_scene_checkbox->set_pressed(include_scene);
 	current_scene_checkbox->set_text(TTR("Scene"));
 	current_scene_checkbox->set_h_size_flags(SIZE_EXPAND_FILL);
 	current_scene_checkbox->set_clip_text(true);
 	current_scene_checkbox->connect(SceneStringName(toggled), callable_mp(this, &HistoryDock::refresh_history).unbind(1));
-	current_scene_checkbox->connect(SceneStringName(toggled), callable_mp(this, &HistoryDock::save_options).unbind(1));
 
 	global_history_checkbox = memnew(CheckBox);
 	mode_hb->add_child(global_history_checkbox);
 	global_history_checkbox->set_flat(true);
-	global_history_checkbox->set_pressed(include_global);
 	global_history_checkbox->set_text(TTR("Global"));
 	global_history_checkbox->set_h_size_flags(SIZE_EXPAND_FILL);
 	global_history_checkbox->set_clip_text(true);
 	global_history_checkbox->connect(SceneStringName(toggled), callable_mp(this, &HistoryDock::refresh_history).unbind(1));
-	global_history_checkbox->connect(SceneStringName(toggled), callable_mp(this, &HistoryDock::save_options).unbind(1));
 
 	action_list = memnew(ItemList);
 	action_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);

--- a/editor/history_dock.h
+++ b/editor/history_dock.h
@@ -34,6 +34,7 @@
 #include "scene/gui/box_container.h"
 
 class CheckBox;
+class ConfigFile;
 class ItemList;
 class EditorUndoRedoManager;
 
@@ -53,10 +54,13 @@ class HistoryDock : public VBoxContainer {
 	void refresh_history();
 	void on_version_changed();
 	void refresh_version();
-	void save_options();
+
+	void _save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
+	void _load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section);
 
 protected:
 	void _notification(int p_notification);
+	static void _bind_methods();
 
 public:
 	void seek_history(int p_index);

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -30,6 +30,7 @@
 
 #include "node_dock.h"
 
+#include "core/io/config_file.h"
 #include "editor/connections_dialog.h"
 #include "editor/editor_node.h"
 #include "editor/themes/editor_scale.h"
@@ -48,9 +49,21 @@ void NodeDock::show_connections() {
 	connections->show();
 }
 
+void NodeDock::_save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const {
+	p_layout->set_value(p_section, "dock_node_current_tab", int(groups_button->is_pressed()));
+}
+
+void NodeDock::_load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
+	const int current_tab = p_layout->get_value(p_section, "dock_node_current_tab", 0);
+	if (current_tab == 0) {
+		show_connections();
+	} else if (current_tab == 1) {
+		show_groups();
+	}
+}
+
 void NodeDock::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			connections_button->set_button_icon(get_editor_theme_icon(SNAME("Signals")));
 			groups_button->set_button_icon(get_editor_theme_icon(SNAME("Groups")));
@@ -58,7 +71,10 @@ void NodeDock::_notification(int p_what) {
 	}
 }
 
-NodeDock *NodeDock::singleton = nullptr;
+void NodeDock::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_save_layout_to_config"), &NodeDock::_save_layout_to_config);
+	ClassDB::bind_method(D_METHOD("_load_layout_from_config"), &NodeDock::_load_layout_from_config);
+}
 
 void NodeDock::update_lists() {
 	connections->update_tree();

--- a/editor/node_dock.h
+++ b/editor/node_dock.h
@@ -33,6 +33,7 @@
 
 #include "groups_editor.h"
 
+class ConfigFile;
 class ConnectionsDock;
 
 class NodeDock : public VBoxContainer {
@@ -48,14 +49,18 @@ class NodeDock : public VBoxContainer {
 
 	Label *select_a_node = nullptr;
 
+	void _save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
+	void _load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section);
+
 private:
-	static NodeDock *singleton;
+	inline static NodeDock *singleton = nullptr;
 
 public:
 	static NodeDock *get_singleton() { return singleton; }
 
 protected:
 	void _notification(int p_what);
+	static void _bind_methods();
 
 public:
 	void set_node(Node *p_node);


### PR DESCRIPTION
This changes how docks manage their layout (i.e. dock-specific layout, not the docks overall). EditorDockManager will now do a `call()` for `_save_layout_to_config` and `_load_layout_from_config` for each dock, instead of hard-coding a call for FileSystem dock. The History dock options were moved from project metadata to the new layout method, Node dock now remembers it's last tab. Also, since this uses generic calls, users are able to store/load layout for their docks in this way. There is no base class for docks, so there is nowhere to document this.

Also included some minor codestyle tweaks.