### PR TITLE
Reduce memory overhead of `save_to_wav`

### DIFF
--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -580,8 +580,7 @@ Error AudioStreamWAV::save_to_wav(const String &p_path) {
 	file->store_32(sub_chunk_2_size); //Subchunk2Size
 
 	// Add data
-	Vector<uint8_t> stream_data = get_data();
-	const uint8_t *read_data = stream_data.ptr();
+	const uint8_t *read_data = data.ptr();
 	switch (format) {
 		case AudioStreamWAV::FORMAT_8_BITS:
 			for (unsigned int i = 0; i < data_bytes; i++) {


### PR DESCRIPTION
The current function duplicates the audio data, then takes data from the duplicate to save.

This modifies the function to take the data directly from the original.

For some reason, doing #96545 without this change would cause a segmentation fault on tests. Without that in consideration, this is not a bug fix, just a small optimization.
