### PR TITLE
Add `LocalVector` move semantics (constructor and operator=).

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -322,6 +322,16 @@ public:
 			data[i] = p_from.data[i];
 		}
 	}
+	_FORCE_INLINE_ LocalVector(LocalVector &&p_from) {
+		data = p_from.data;
+		count = p_from.count;
+		capacity = p_from.capacity;
+
+		p_from.data = nullptr;
+		p_from.count = 0;
+		p_from.capacity = 0;
+	}
+
 	inline void operator=(const LocalVector &p_from) {
 		resize(p_from.size());
 		for (U i = 0; i < p_from.count; i++) {
@@ -332,6 +342,26 @@ public:
 		resize(p_from.size());
 		for (U i = 0; i < count; i++) {
 			data[i] = p_from[i];
+		}
+	}
+	inline void operator=(LocalVector &&p_from) {
+		if (unlikely(this == &p_from)) {
+			return;
+		}
+		reset();
+
+		data = p_from.data;
+		count = p_from.count;
+		capacity = p_from.capacity;
+
+		p_from.data = nullptr;
+		p_from.count = 0;
+		p_from.capacity = 0;
+	}
+	inline void operator=(Vector<T> &&p_from) {
+		resize(p_from.size());
+		for (U i = 0; i < count; i++) {
+			data[i] = std::move(p_from[i]);
 		}
 	}
 


### PR DESCRIPTION
We've recently begun to introduce move semantics to core, for its performance benefits. Examples of functions that can benefit a lot from move semantics include SWAP (https://github.com/godotengine/godot/pull/100367), reduce_at and insert (https://github.com/godotengine/godot/pull/100477), and simple data transfer. For more information on motivation, see https://github.com/godotengine/godot/pull/100426.

For `LocalVector`, this is especially important because a copy-constructor and copy-assignment is forced to copy the entire array, and all elements in it.

## Examples

This time I've gathered relevant beneficiaries through a `[[deprecated]]` trick. Here are some examples:

https://github.com/godotengine/godot/blob/6395450b10d73bc3515763c7bbd1b2f5b7425d10/modules/navigation/3d/nav_mesh_queries_3d.cpp#L923-L929

(the memory no longer has to be re-allocated to return the vector)

The same was happening in `ShaderPreprocessor::advance`:

https://github.com/godotengine/godot/blob/6395450b10d73bc3515763c7bbd1b2f5b7425d10/servers/rendering/shader_preprocessor.cpp#L122

`SWAP` calls also required double reallocations in e.g. OAHashMap on insert:

https://github.com/godotengine/godot/blob/6395450b10d73bc3515763c7bbd1b2f5b7425d10/core/templates/oa_hash_map.h#L133-L135

e.g .from ShaderGLES3::Version::Specialization items:

https://github.com/godotengine/godot/blob/6395450b10d73bc3515763c7bbd1b2f5b7425d10/drivers/gles3/shader_gles3.h#L95-L100

There's some more examples but I think that should be enough evidence that the addition is warranted :)