### PR TITLE
[TextServer] Fix use of `find_char` in text servers

### DIFF
--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -175,7 +175,11 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 				if (parser->has_attribute("id")) {
 					const String &gl_name = parser->get_named_attribute_value("id");
 					if (gl_name.begins_with("glyph")) {
+#ifdef GDEXTENSION
+						int dot_pos = gl_name.find(".");
+#else
 						int dot_pos = gl_name.find_char('.');
+#endif // GDEXTENSION
 						int64_t gl_idx = gl_name.substr(5, (dot_pos > 0) ? dot_pos - 5 : -1).to_int();
 
 						TVG_NodeCache node_cache = TVG_NodeCache();

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -175,7 +175,11 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 				if (parser->has_attribute("id")) {
 					const String &gl_name = parser->get_named_attribute_value("id");
 					if (gl_name.begins_with("glyph")) {
+#ifdef GDEXTENSION
+						int dot_pos = gl_name.find(".");
+#else
 						int dot_pos = gl_name.find_char('.');
+#endif // GDEXTENSION
 						int64_t gl_idx = gl_name.substr(5, (dot_pos > 0) ? dot_pos - 5 : -1).to_int();
 
 						TVG_NodeCache node_cache = TVG_NodeCache();


### PR DESCRIPTION
The `find_char` method is not (currently) available to extensions and
can't be used in the text servers which can be built as extensions, so
now controlled by compile option

I missed this when reviewing #100024

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
