### PR TITLE
Add move semantics (constructor, operator=) to `List`.

### DIFF
--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -522,6 +522,15 @@ public:
 			it = it->next();
 		}
 	}
+	void operator=(List &&p_list) {
+		if (unlikely(this == &p_list)) {
+			return;
+		}
+
+		clear();
+		_data = p_list._data;
+		p_list._data = nullptr;
+	}
 
 	// Random access to elements, use with care,
 	// do not use for iteration.
@@ -759,6 +768,10 @@ public:
 			push_back(it->get());
 			it = it->next();
 		}
+	}
+	List(List &&p_list) {
+		_data = p_list._data;
+		p_list._data = nullptr;
 	}
 
 	List() {}


### PR DESCRIPTION
We've recently begun to introduce move semantics to core, for its performance benefits. Examples of functions that can benefit a lot from move semantics include SWAP (https://github.com/godotengine/godot/pull/100367), reduce_at and insert (https://github.com/godotengine/godot/pull/100477), and simple data transfer. For more information on motivation, see https://github.com/godotengine/godot/pull/100426.

For `List`, this is especially important because a copy-constructor and copy-assignment are forced to copy the entire array, and all elements in it. And worse, because `List` is not contiguous, this is slow.

I first wanted to do a use-case analysis like in #100560, but quickly gave up because there were just too many beneficiaries of `List` move semantics.