### PR TITLE
`save_to_wav`: Improve error and remove unhandled format code

### DIFF
--- a/scene/resources/audio/audio_stream_wav.cpp
+++ b/scene/resources/audio/audio_stream_wav.cpp
@@ -531,17 +531,11 @@ Vector<uint8_t> AudioStreamWAV::get_data() const {
 
 Error AudioStreamWAV::save_to_wav(const String &p_path) {
 	if (format == AudioStreamWAV::FORMAT_IMA_ADPCM || format == AudioStreamWAV::FORMAT_QOA) {
-		WARN_PRINT("Saving IMA_ADPCM and QOA samples is not supported yet");
-		return ERR_UNAVAILABLE;
+		ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Saving IMA ADPCM or Quite OK Audio samples is not supported. Quite OK Audio data can still be saved as a .qoa file using FileAccess.");
 	}
 
 	uint64_t sub_chunk_2_size = data.size(); // Subchunk2Size = Size of data in bytes
 	ERR_FAIL_COND_V_MSG(sub_chunk_2_size > UINT32_MAX - 36, ERR_FILE_CANT_WRITE, "Data size exceeds maximum WAV file size of 4 GiB.");
-
-	// Format code
-	// 1:PCM format (for 8 or 16 bit)
-	// 3:IEEE float format
-	int format_code = (format == FORMAT_IMA_ADPCM) ? 3 : 1;
 
 	int n_channels = stereo ? 2 : 1;
 
@@ -553,11 +547,9 @@ Error AudioStreamWAV::save_to_wav(const String &p_path) {
 			byte_pr_sample = 1;
 			break;
 		case AudioStreamWAV::FORMAT_16_BITS:
-		case AudioStreamWAV::FORMAT_QOA:
 			byte_pr_sample = 2;
 			break;
-		case AudioStreamWAV::FORMAT_IMA_ADPCM:
-			byte_pr_sample = 4;
+		default: // Other formats not supported.
 			break;
 	}
 
@@ -576,7 +568,7 @@ Error AudioStreamWAV::save_to_wav(const String &p_path) {
 	file->store_string("WAVE"); //Format
 	file->store_string("fmt "); //Subchunk1ID
 	file->store_32(16); //Subchunk1Size = 16
-	file->store_16(format_code); //AudioFormat
+	file->store_16(1); // Format code (1 = PCM)
 	file->store_16(n_channels); //Number of Channels
 	file->store_32(sample_rate); //SampleRate
 	file->store_32(sample_rate * n_channels * byte_pr_sample); //ByteRate
@@ -595,14 +587,12 @@ Error AudioStreamWAV::save_to_wav(const String &p_path) {
 			}
 			break;
 		case AudioStreamWAV::FORMAT_16_BITS:
-		case AudioStreamWAV::FORMAT_QOA:
 			for (uint64_t i = 0; i < sub_chunk_2_size / 2; i++) {
 				uint16_t data_point = decode_uint16(&read_data[i * 2]);
 				file->store_16(data_point);
 			}
 			break;
-		case AudioStreamWAV::FORMAT_IMA_ADPCM:
-			//Unimplemented
+		default: // Unsupported.
 			break;
 	}
 

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -526,16 +526,15 @@ Vector<uint8_t> AudioStreamWAV::get_data() const {
 
 Error AudioStreamWAV::save_to_wav(const String &p_path) {
 	if (format == AudioStreamWAV::FORMAT_IMA_ADPCM || format == AudioStreamWAV::FORMAT_QOA) {
-		WARN_PRINT("Saving IMA_ADPCM and QOA samples is not supported yet");
-		return ERR_UNAVAILABLE;
+		ERR_FAIL_V_MSG(ERR_UNAVAILABLE, "Saving IMA ADPCM or Quite OK Audio samples is not supported. Quite OK Audio data can still be saved as a .qoa file using FileAccess.");
 	}
 
 	int sub_chunk_2_size = data_bytes; //Subchunk2Size = Size of data in bytes
 
 	// Format code
-	// 1:PCM format (for 8 or 16 bit)
-	// 3:IEEE float format
-	int format_code = (format == FORMAT_IMA_ADPCM) ? 3 : 1;
+	// 1: PCM format (for 8 or 16 bit)
+	// 17: IMA ADPCM format, unhandled since Godot's IMA ADPCM compression is too messy to be saved.
+	int format_code = 1;
 
 	int n_channels = stereo ? 2 : 1;
 
@@ -547,11 +546,10 @@ Error AudioStreamWAV::save_to_wav(const String &p_path) {
 			byte_pr_sample = 1;
 			break;
 		case AudioStreamWAV::FORMAT_16_BITS:
-		case AudioStreamWAV::FORMAT_QOA:
 			byte_pr_sample = 2;
 			break;
-		case AudioStreamWAV::FORMAT_IMA_ADPCM:
-			byte_pr_sample = 4;
+		default:
+			// Other formats not supported.
 			break;
 	}
 
@@ -590,14 +588,13 @@ Error AudioStreamWAV::save_to_wav(const String &p_path) {
 			}
 			break;
 		case AudioStreamWAV::FORMAT_16_BITS:
-		case AudioStreamWAV::FORMAT_QOA:
 			for (unsigned int i = 0; i < data_bytes / 2; i++) {
 				uint16_t data_point = decode_uint16(&read_data[i * 2]);
 				file->store_16(data_point);
 			}
 			break;
-		case AudioStreamWAV::FORMAT_IMA_ADPCM:
-			//Unimplemented
+		default:
+			// Unsupported.
 			break;
 	}
 


### PR DESCRIPTION
Modified the message to use an `ERR_FAIL_V_MSG` and to state Quite OK Audio can only be saved as a .qoa file through `FileAccess`.

I also removed the `yet` because Godot's IMA ADPCM is too messy to be saved:
- On stereo, you have one stream for each channel, meaning the first half of the data is the left channel, and the second half is the right channel;
- The entire data is saved to a single block (well, two if you count each channel separately);

Maybe a compatibility breaking change could fix it, then either the "yet" or a working implementation could be added.

Either way, I don't see a reason to support it anymore when we have Quite OK Audio. I even made a PR to deprecate it: #91492 

Last, IMA ADPCM's format code is `17`. `3` is IEEE float which is unsupported in AudioStreamWAV. [Source](https://www.signalogic.com/index.pl?page=audio_waveform_file_formats).

**Update:** I didn't think it was fair having "unimplemented feature to be filled later", so I removed that too.