### PR TITLE
Show "transparent background" texture only behind actual texture in `TexturePreview` class + add borders for readability

### DIFF
--- a/editor/plugins/camera_3d_editor_plugin.cpp
+++ b/editor/plugins/camera_3d_editor_plugin.cpp
@@ -91,6 +91,7 @@ Camera3DPreview::Camera3DPreview(Camera3D *p_camera) :
 	TextureRect *display = get_texture_display();
 	display->set_texture(sub_viewport->get_texture());
 	sub_viewport->connect("size_changed", callable_mp((CanvasItem *)display, &CanvasItem::queue_redraw));
+	sub_viewport->get_texture()->connect_changed(callable_mp((TexturePreview *)this, &Camera3DPreview::_update_texture_display_ratio));
 
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Camera3DPreview::_update_sub_viewport_size));
 	_update_sub_viewport_size();

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -36,6 +36,8 @@
 #include "scene/gui/margin_container.h"
 #include "scene/resources/texture.h"
 
+class AspectRatioContainer;
+class ColorRect;
 class TextureRect;
 
 class TexturePreview : public MarginContainer {
@@ -44,13 +46,20 @@ class TexturePreview : public MarginContainer {
 private:
 	TextureRect *texture_display = nullptr;
 
+	MarginContainer *margin_container = nullptr;
+	AspectRatioContainer *centering_container = nullptr;
+	ColorRect *bg_rect = nullptr;
 	TextureRect *checkerboard = nullptr;
 	Label *metadata_label = nullptr;
 
+	Color cached_outline_color;
+
+	void _draw_outline();
 	void _update_metadata_label_text();
 
 protected:
 	void _notification(int p_what);
+	void _update_texture_display_ratio();
 
 public:
 	TextureRect *get_texture_display();


### PR DESCRIPTION
This is how it affects textures preview in Inspector:
| How it was before | Default theme | Light | Black OLED | passivestar minimal theme 2.0 |
| --- | --- | --- | --- | --- |
| ![0_before](https://github.com/user-attachments/assets/37bc0ec7-6138-4cc5-bfcb-ab86e8c0dfb9) | ![1_default](https://github.com/user-attachments/assets/f683dad3-2fe2-4e90-a65d-b53666b5e66e) | ![2_light](https://github.com/user-attachments/assets/08e887b6-0cc9-468b-aac0-e83e3036dbe5) | ![3_black_oled](https://github.com/user-attachments/assets/30907df3-2f55-40d4-88c4-be010b9b8072) | ![4_passivestar_2](https://github.com/user-attachments/assets/f2164658-216f-48cd-8a79-481fbb3640e2) |

Also, as `TexturePreview` is used in `Camera3DEditorPlugin` and `SubViewportPreviewEditorPlugin`, it affects how they will look.

`Camera3DEditorPlugin` will not benefit much from this change, it will just look a bit different:
| Before | After |
| --- | --- |
| ![camera3d_before](https://github.com/user-attachments/assets/75f60da1-25f4-4421-854d-0f513f0b8bee) | ![camera3d_after](https://github.com/user-attachments/assets/427a6578-a670-44c2-8ef2-87a36f712a53) |

`SubViewportPreviewEditorPlugin` will benefit from this change when used with `transparent_bg` enabled:
| Before | After |
| --- | --- |
| ![subviewport_transparent_before](https://github.com/user-attachments/assets/e016a3d8-c73b-4115-8cf5-61d8fa65d027) | ![subviewport_transparent_after](https://github.com/user-attachments/assets/bb626f93-990c-4667-b08a-93c1e350eed7) |

Closes https://github.com/godotengine/godot-proposals/issues/11380