### PR TITLE
Add displaying child node count in scene tree and debugger tree tooltips

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -168,9 +168,9 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		TreeItem *item = create_item(parent);
 		item->set_text(0, node.name);
 		if (node.scene_file_path.is_empty()) {
-			item->set_tooltip_text(0, node.name + "\n" + TTR("Type:") + " " + node.type_name);
+			item->set_tooltip_text(0, node.name + "\n" + TTR("Type:") + " " + node.type_name + "\n" + TTR("Child nodes:") + " " + String::num_int64(node.child_count));
 		} else {
-			item->set_tooltip_text(0, node.name + "\n" + TTR("Instance:") + " " + node.scene_file_path + "\n" + TTR("Type:") + " " + node.type_name);
+			item->set_tooltip_text(0, node.name + "\n" + TTR("Instance:") + " " + node.scene_file_path + "\n" + TTR("Type:") + " " + node.type_name + "\n" + TTR("Child nodes:") + " " + String::num_int64(node.child_count));
 		}
 		Ref<Texture2D> icon = EditorNode::get_singleton()->get_class_icon(node.type_name, "");
 		if (icon.is_valid()) {

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -642,6 +642,7 @@ void SceneTreeEditor::_update_node_tooltip(Node *p_node, TreeItem *p_item) {
 
 	StringName custom_type = EditorNode::get_singleton()->get_object_custom_type_name(p_node);
 	tooltip += "\n" + TTR("Type:") + " " + (custom_type != StringName() ? String(custom_type) : p_node->get_class());
+	tooltip += "\n" + TTR("Child nodes:") + " " + String::num_int64(p_node->get_child_count());
 
 	if (!p_node->get_editor_description().is_empty()) {
 		const PackedInt32Array boundaries = TS->string_get_word_breaks(p_node->get_editor_description(), "", 80);


### PR DESCRIPTION
Now scene tree and debugger tree tooltips display child node counts. 

I find this useful when a node contains a lot of child nodes, for example hundreds or thousands of bullets in a bullet hell game. For example a few hundred child nodes could be ok, but a few thousand would mean that bullets are not being freed. Without an actual number displayed it is pretty difficult to find out the child node count.

Scene tree:
![kuva](https://github.com/user-attachments/assets/91ec7259-b566-4a7b-8907-9e245b1bb2fa)

Debugger tree:
![kuva](https://github.com/user-attachments/assets/d0a32e08-86f2-40f1-9d71-b6b11532d481)

