### PR TITLE
Add primitive 2D meshes

### DIFF
--- a/doc/classes/CapsuleMesh2D.xml
+++ b/doc/classes/CapsuleMesh2D.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CapsuleMesh2D" inherits="PrimitiveMesh2D" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A capsule-shaped [PrimitiveMesh2D].
+	</brief_description>
+	<description>
+		A capsule-shaped [PrimitiveMesh2D].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="height" type="float" setter="set_height" getter="get_height" default="30.0">
+			Total height of the capsule mesh (including the semicircular ends).
+		</member>
+		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="32">
+			Number of radial segments on each semicircle of the capsule mesh.
+		</member>
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="10.0">
+			Radius of the semicircles on the ends of the capsule mesh.
+		</member>
+	</members>
+</class>

--- a/doc/classes/CircleMesh2D.xml
+++ b/doc/classes/CircleMesh2D.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CircleMesh2D" inherits="PrimitiveMesh2D" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A circular [PrimitiveMesh2D].
+	</brief_description>
+	<description>
+		A circular [PrimitiveMesh2D].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="64">
+			Number of radial segments on the circle.
+		</member>
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="10.0">
+			Radius of the circle.
+		</member>
+	</members>
+</class>

--- a/doc/classes/PrimitiveMesh2D.xml
+++ b/doc/classes/PrimitiveMesh2D.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PrimitiveMesh2D" inherits="Mesh" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Base class for all primitive 2D meshes.
+	</brief_description>
+	<description>
+		Base class for all primitive 2D meshes. Examples include [RectangleMesh2D], [CircleMesh2D], and [CapsuleMesh2D].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_create_mesh_array" qualifiers="virtual const">
+			<return type="Array" />
+			<description>
+				Override this method to customize how this primitive mesh should be generated. Should return an [Array] where each element is another Array of values required for the mesh (see the [enum Mesh.ArrayType] constants).
+			</description>
+		</method>
+		<method name="get_mesh_arrays" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns the mesh arrays used to make up the surface of this primitive mesh.
+			</description>
+		</method>
+		<method name="request_update">
+			<return type="void" />
+			<description>
+				Request an update of this primitive mesh based on its properties.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="antialiased" type="bool" setter="set_antialiased" getter="is_antialiased" default="false">
+			If [code]true[/code], a half transparent "skirt" will be attached to the boundary, making outlines smooth.
+		</member>
+		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
+			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
+		</member>
+	</members>
+</class>

--- a/doc/classes/RectangleMesh2D.xml
+++ b/doc/classes/RectangleMesh2D.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RectangleMesh2D" inherits="PrimitiveMesh2D" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A rectangular [PrimitiveMesh2D].
+	</brief_description>
+	<description>
+		A rectangular [PrimitiveMesh2D].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(20, 20)">
+			The rectangle's width and height.
+		</member>
+		<member name="subdivide_height" type="int" setter="set_subdivide_height" getter="get_subdivide_height" default="0">
+			Number of extra edge loops inserted along the Y axis.
+		</member>
+		<member name="subdivide_width" type="int" setter="set_subdivide_width" getter="get_subdivide_width" default="0">
+			Number of extra edge loops inserted along the X axis.
+		</member>
+	</members>
+</class>

--- a/editor/icons/CapsuleMesh2D.svg
+++ b/editor/icons/CapsuleMesh2D.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#5fb2ff" stroke-width="2" d="M4 6v4a4 4 0 0 0 8 0V6a4 4 0 0 0-8 0"/></svg>

--- a/editor/icons/CapsuleMesh2D.svg
+++ b/editor/icons/CapsuleMesh2D.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#5fb2ff" stroke-width="2" d="M4 6v4a4 4 0 0 0 8 0V6a4 4 0 0 0-8 0"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#5fb2ff" stroke="#5fb2ff" stroke-width="2" d="M4 6v4a4 4 0 0 0 8 0V6a4 4 0 0 0-8 0"/></svg>

--- a/editor/icons/CircleMesh2D.svg
+++ b/editor/icons/CircleMesh2D.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="6" fill="none" stroke="#5fb2ff" stroke-width="2"/></svg>

--- a/editor/icons/CircleMesh2D.svg
+++ b/editor/icons/CircleMesh2D.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="6" fill="none" stroke="#5fb2ff" stroke-width="2"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="6" fill="#5fb2ff" stroke="#5fb2ff" stroke-width="2"/></svg>

--- a/editor/icons/RectangleMesh2D.svg
+++ b/editor/icons/RectangleMesh2D.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#5fb2ff" stroke-linejoin="round" stroke-width="2" d="M2 4h12v8H2z"/></svg>

--- a/editor/icons/RectangleMesh2D.svg
+++ b/editor/icons/RectangleMesh2D.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#5fb2ff" stroke-linejoin="round" stroke-width="2" d="M2 4h12v8H2z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#5fb2ff" stroke="#5fb2ff" stroke-linejoin="round" stroke-width="2" d="M2 4h12v8H2z"/></svg>

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -82,6 +82,7 @@
 #include "editor/scene/2d/camera_2d_editor_plugin.h"
 #include "editor/scene/2d/light_occluder_2d_editor_plugin.h"
 #include "editor/scene/2d/line_2d_editor_plugin.h"
+#include "editor/scene/2d/mesh_instance_2d_editor_plugin.h"
 #include "editor/scene/2d/particles_2d_editor_plugin.h"
 #include "editor/scene/2d/path_2d_editor_plugin.h"
 #include "editor/scene/2d/physics/cast_2d_editor_plugin.h"
@@ -280,6 +281,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<GPUParticles2DEditorPlugin>();
 	EditorPlugins::add_by_type<LightOccluder2DEditorPlugin>();
 	EditorPlugins::add_by_type<Line2DEditorPlugin>();
+	EditorPlugins::add_by_type<MeshInstance2DEditorPlugin>();
 	EditorPlugins::add_by_type<Path2DEditorPlugin>();
 	EditorPlugins::add_by_type<Polygon2DEditorPlugin>();
 	EditorPlugins::add_by_type<Cast2DEditorPlugin>();

--- a/editor/scene/2d/mesh_instance_2d_editor_plugin.cpp
+++ b/editor/scene/2d/mesh_instance_2d_editor_plugin.cpp
@@ -1,0 +1,299 @@
+/**************************************************************************/
+/*  mesh_instance_2d_editor_plugin.cpp                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "mesh_instance_2d_editor_plugin.h"
+
+#include "core/object/callable_mp.h"
+#include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
+#include "editor/inspector/multi_node_edit.h"
+#include "editor/scene/canvas_item_editor_plugin.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/aspect_ratio_container.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
+
+void MeshInstance2DEditor::_node_removed(Node *p_node) {
+	if (p_node == node) {
+		node = nullptr;
+		options->hide();
+	}
+}
+
+void MeshInstance2DEditor::edit(MeshInstance2D *p_mesh) {
+	node = p_mesh;
+}
+
+void MeshInstance2DEditor::_menu_option(int p_option) {
+	Ref<Mesh> mesh = node->get_mesh();
+	if (mesh.is_null()) {
+		err_dialog->set_text(TTR("Mesh is empty!"));
+		err_dialog->popup_centered();
+		return;
+	}
+
+	switch (p_option) {
+		case MENU_OPTION_DEBUG_UV1: {
+			Ref<Mesh> mesh2 = node->get_mesh();
+			if (!mesh2.is_valid()) {
+				err_dialog->set_text(TTR("No mesh to debug."));
+				err_dialog->popup_centered();
+				return;
+			}
+			_create_uv_lines(0);
+		} break;
+	}
+}
+
+struct MeshInstance2DEditorEdgeSort {
+	Vector2 a;
+	Vector2 b;
+
+	static uint32_t hash(const MeshInstance2DEditorEdgeSort &p_edge) {
+		uint32_t h = hash_murmur3_one_32(HashMapHasherDefault::hash(p_edge.a));
+		return hash_fmix32(hash_murmur3_one_32(HashMapHasherDefault::hash(p_edge.b), h));
+	}
+
+	bool operator==(const MeshInstance2DEditorEdgeSort &p_b) const {
+		return a == p_b.a && b == p_b.b;
+	}
+
+	MeshInstance2DEditorEdgeSort() {}
+	MeshInstance2DEditorEdgeSort(const Vector2 &p_a, const Vector2 &p_b) {
+		if (p_a < p_b) {
+			a = p_a;
+			b = p_b;
+		} else {
+			b = p_a;
+			a = p_b;
+		}
+	}
+};
+
+void MeshInstance2DEditor::_create_uv_lines(int p_layer) {
+	Ref<Mesh> mesh = node->get_mesh();
+	ERR_FAIL_COND(!mesh.is_valid());
+
+	HashSet<MeshInstance2DEditorEdgeSort, MeshInstance2DEditorEdgeSort> edges;
+	uv_lines.clear();
+	for (int i = 0; i < mesh->get_surface_count(); i++) {
+		if (mesh->surface_get_primitive_type(i) != Mesh::PRIMITIVE_TRIANGLES) {
+			continue;
+		}
+		Array a = mesh->surface_get_arrays(i);
+
+		Vector<Vector2> uv = a[p_layer == 0 ? Mesh::ARRAY_TEX_UV : Mesh::ARRAY_TEX_UV2];
+		if (uv.size() == 0) {
+			err_dialog->set_text(vformat(TTR("Mesh has no UV in layer %d."), p_layer + 1));
+			err_dialog->popup_centered();
+			return;
+		}
+
+		const Vector2 *r = uv.ptr();
+
+		Vector<int> indices = a[Mesh::ARRAY_INDEX];
+		const int *ri = nullptr;
+
+		int ic;
+
+		if (indices.size()) {
+			ic = indices.size();
+			ri = indices.ptr();
+		} else {
+			ic = uv.size();
+		}
+
+		for (int j = 0; j < ic; j += 3) {
+			for (int k = 0; k < 3; k++) {
+				MeshInstance2DEditorEdgeSort edge;
+				if (ri) {
+					edge.a = r[ri[j + k]];
+					edge.b = r[ri[j + ((k + 1) % 3)]];
+				} else {
+					edge.a = r[j + k];
+					edge.b = r[j + ((k + 1) % 3)];
+				}
+
+				if (edges.has(edge)) {
+					continue;
+				}
+
+				uv_lines.push_back(edge.a);
+				uv_lines.push_back(edge.b);
+				edges.insert(edge);
+			}
+		}
+	}
+
+	debug_uv_dialog->popup_centered();
+}
+
+void MeshInstance2DEditor::_debug_uv_draw() {
+	if (uv_lines.size() == 0) {
+		return;
+	}
+
+	debug_uv->set_clip_contents(true);
+	debug_uv->draw_rect(
+			Rect2(Vector2(), debug_uv->get_size()),
+			get_theme_color(SNAME("dark_color_3"), EditorStringName(Editor)));
+
+	// Draw an outline to represent the UV2's beginning and end area (useful on Black OLED theme).
+	// Top-left coordinate needs to be `(1, 1)` to prevent `clip_contents` from clipping the top and left lines.
+	debug_uv->draw_rect(
+			Rect2(Vector2(1, 1), debug_uv->get_size() - Vector2(1, 1)),
+			get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.125),
+			false,
+			Math::round(EDSCALE));
+
+	for (int x = 1; x <= 7; x++) {
+		debug_uv->draw_line(
+				Vector2(debug_uv->get_size().x * 0.125 * x, 0),
+				Vector2(debug_uv->get_size().x * 0.125 * x, debug_uv->get_size().y),
+				get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.125),
+				Math::round(EDSCALE));
+	}
+
+	for (int y = 1; y <= 7; y++) {
+		debug_uv->draw_line(
+				Vector2(0, debug_uv->get_size().y * 0.125 * y),
+				Vector2(debug_uv->get_size().x, debug_uv->get_size().y * 0.125 * y),
+				get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.125),
+				Math::round(EDSCALE));
+	}
+
+	debug_uv->draw_set_transform(Vector2(), 0, debug_uv->get_size());
+
+	// Use a translucent color to allow overlapping triangles to be visible.
+	// Divide line width by the drawing scale set above, so that line width is consistent regardless of dialog size.
+	// Aspect ratio is preserved by the parent AspectRatioContainer, so we only need to check the X size which is always equal to Y.
+	debug_uv->draw_multiline(
+			uv_lines,
+			get_theme_color(SNAME("mono_color"), EditorStringName(Editor)) * Color(1, 1, 1, 0.5),
+			Math::round(EDSCALE) / debug_uv->get_size().x);
+}
+
+void MeshInstance2DEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			options->set_button_icon(get_editor_theme_icon(SNAME("MeshInstance2D")));
+		} break;
+	}
+}
+
+MeshInstance2DEditor::MeshInstance2DEditor() {
+	options = memnew(MenuButton);
+	options->set_text(TTR("Mesh"));
+	options->set_switch_on_hover(true);
+	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(options);
+
+	options->get_popup()->add_item(TTR("View UV1"), MENU_OPTION_DEBUG_UV1);
+
+	options->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &MeshInstance2DEditor::_menu_option));
+
+	err_dialog = memnew(AcceptDialog);
+	add_child(err_dialog);
+
+	debug_uv_dialog = memnew(AcceptDialog);
+	debug_uv_dialog->set_title(TTR("UV Channel Debug"));
+	add_child(debug_uv_dialog);
+
+	debug_uv_arc = memnew(AspectRatioContainer);
+	debug_uv_dialog->add_child(debug_uv_arc);
+
+	debug_uv = memnew(Control);
+	debug_uv->set_custom_minimum_size(Size2(600, 600) * EDSCALE);
+	debug_uv->connect(SceneStringName(draw), callable_mp(this, &MeshInstance2DEditor::_debug_uv_draw));
+	debug_uv_arc->add_child(debug_uv);
+}
+
+void MeshInstance2DEditorPlugin::edit(Object *p_object) {
+	{
+		MeshInstance2D *mi = Object::cast_to<MeshInstance2D>(p_object);
+		if (mi) {
+			mesh_editor->edit(mi);
+			return;
+		}
+	}
+
+	Ref<MultiNodeEdit> mne = Ref<MultiNodeEdit>(p_object);
+	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
+	if (mne.is_valid() && edited_scene) {
+		for (int i = 0; i < mne->get_node_count(); i++) {
+			MeshInstance2D *mi = Object::cast_to<MeshInstance2D>(edited_scene->get_node(mne->get_node(i)));
+			if (mi) {
+				mesh_editor->edit(mi);
+				return;
+			}
+		}
+	}
+	mesh_editor->edit(nullptr);
+}
+
+bool MeshInstance2DEditorPlugin::handles(Object *p_object) const {
+	if (Object::cast_to<MeshInstance2D>(p_object)) {
+		return true;
+	}
+
+	Ref<MultiNodeEdit> mne = Ref<MultiNodeEdit>(p_object);
+	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
+	if (mne.is_valid() && edited_scene) {
+		bool has_mesh = false;
+		for (int i = 0; i < mne->get_node_count(); i++) {
+			if (Object::cast_to<MeshInstance2D>(edited_scene->get_node(mne->get_node(i)))) {
+				if (has_mesh) {
+					return true;
+				} else {
+					has_mesh = true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+void MeshInstance2DEditorPlugin::make_visible(bool p_visible) {
+	if (p_visible) {
+		mesh_editor->options->show();
+	} else {
+		mesh_editor->options->hide();
+		mesh_editor->edit(nullptr);
+	}
+}
+
+MeshInstance2DEditorPlugin::MeshInstance2DEditorPlugin() {
+	mesh_editor = memnew(MeshInstance2DEditor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(mesh_editor);
+
+	mesh_editor->options->hide();
+}
+
+MeshInstance2DEditorPlugin::~MeshInstance2DEditorPlugin() {
+}

--- a/editor/scene/2d/mesh_instance_2d_editor_plugin.h
+++ b/editor/scene/2d/mesh_instance_2d_editor_plugin.h
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*  mesh_instance_2d_editor_plugin.h                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/plugins/editor_plugin.h"
+#include "scene/2d/mesh_instance_2d.h"
+
+class AcceptDialog;
+class AspectRatioContainer;
+class MenuButton;
+
+class MeshInstance2DEditor : public Control {
+	GDCLASS(MeshInstance2DEditor, Control);
+
+	enum Menu {
+		MENU_OPTION_DEBUG_UV1,
+	};
+
+	MeshInstance2D *node = nullptr;
+
+	MenuButton *options = nullptr;
+
+	AcceptDialog *err_dialog = nullptr;
+
+	AcceptDialog *debug_uv_dialog = nullptr;
+	AspectRatioContainer *debug_uv_arc = nullptr;
+	Control *debug_uv = nullptr;
+	Vector<Vector2> uv_lines;
+
+	void _menu_option(int p_option);
+
+	void _create_uv_lines(int p_layer);
+	friend class MeshInstance2DEditorPlugin;
+
+	void _debug_uv_draw();
+
+protected:
+	void _node_removed(Node *p_node);
+
+	void _notification(int p_what);
+
+public:
+	void edit(MeshInstance2D *p_mesh);
+	MeshInstance2DEditor();
+};
+
+class MeshInstance2DEditorPlugin : public EditorPlugin {
+	GDCLASS(MeshInstance2DEditorPlugin, EditorPlugin);
+
+	MeshInstance2DEditor *mesh_editor = nullptr;
+
+public:
+	virtual String get_plugin_name() const override { return "MeshInstance2D"; }
+	bool has_main_screen() const override { return false; }
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override;
+	virtual void make_visible(bool p_visible) override;
+
+	MeshInstance2DEditorPlugin();
+	~MeshInstance2DEditorPlugin();
+};

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -198,6 +198,7 @@
 #include "scene/2d/tile_map_layer.h"
 #include "scene/2d/visible_on_screen_notifier_2d.h"
 #include "scene/resources/2d/polygon_path_finder.h"
+#include "scene/resources/2d/primitive_meshes_2d.h"
 #include "scene/resources/2d/skeleton/skeleton_modification_2d.h"
 #include "scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.h"
 #include "scene/resources/2d/skeleton/skeleton_modification_2d_fabrik.h"
@@ -885,6 +886,11 @@ void register_scene_types() {
 	GDREGISTER_CLASS(MultiMesh);
 	GDREGISTER_CLASS(SurfaceTool);
 	GDREGISTER_CLASS(MeshDataTool);
+
+	GDREGISTER_VIRTUAL_CLASS(PrimitiveMesh2D);
+	GDREGISTER_CLASS(RectangleMesh2D);
+	GDREGISTER_CLASS(CircleMesh2D);
+	GDREGISTER_CLASS(CapsuleMesh2D);
 
 #ifndef _3D_DISABLED
 	GDREGISTER_CLASS(AudioStreamPlayer3D);

--- a/scene/resources/2d/SCsub
+++ b/scene/resources/2d/SCsub
@@ -3,6 +3,7 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
+env.add_source_files(env.scene_sources, "primitive_meshes_2d.cpp")
 env.add_source_files(env.scene_sources, "tile_set.cpp")
 
 if not env["disable_physics_2d"]:

--- a/scene/resources/2d/primitive_meshes_2d.cpp
+++ b/scene/resources/2d/primitive_meshes_2d.cpp
@@ -1,0 +1,910 @@
+/**************************************************************************/
+/*  primitive_meshes_2d.cpp                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "primitive_meshes_2d.h"
+
+#include "core/math/math_funcs.h"
+#include "core/object/class_db.h"
+#include "servers/rendering/rendering_server.h"
+
+#include <thirdparty/misc/polypartition.h>
+
+// Vertex colors used for antialiasing.
+const static Color SOLID_COLOR = Color(1, 1, 1, 1);
+const static Color TRANSPARENT_COLOR = Color(1, 1, 1, 0);
+
+/**
+  PrimitiveMesh2D
+*/
+void PrimitiveMesh2D::_update() const {
+	Array arr;
+	if (GDVIRTUAL_CALL(_create_mesh_array, arr)) {
+		ERR_FAIL_COND_MSG(arr.size() != ARRAY_MAX, "_create_mesh_array must return an array of Mesh.ARRAY_MAX elements.");
+	} else {
+		arr.resize(ARRAY_MAX);
+		_create_mesh_array(arr);
+	}
+
+	Vector<Vector2> points = arr[ARRAY_VERTEX];
+
+	ERR_FAIL_COND_MSG(points.is_empty(), "_create_mesh_array must return at least a vertex array.");
+
+	aabb = AABB();
+
+	int pc = points.size();
+	ERR_FAIL_COND(pc == 0);
+	{
+		const Vector2 *r = points.ptr();
+		for (int i = 0; i < pc; i++) {
+			if (i == 0) {
+				aabb.position = Vector3(r[i].x, r[i].y, 0);
+			} else {
+				aabb.expand_to(Vector3(r[i].x, r[i].y, 0));
+			}
+		}
+	}
+
+	array_len = pc;
+
+	Vector<int> indices = arr[ARRAY_INDEX];
+	index_array_len = indices.size();
+
+	// Out with the old.
+	RenderingServer::get_singleton()->mesh_clear(mesh);
+	// In with the new.
+	RenderingServer::get_singleton()->mesh_add_surface_from_arrays(mesh, (RenderingServerEnums::PrimitiveType)primitive_type, arr);
+
+	pending_request = false;
+
+	clear_cache();
+
+	const_cast<PrimitiveMesh2D *>(this)->emit_changed();
+}
+
+void PrimitiveMesh2D::request_update() {
+	if (pending_request) {
+		return;
+	}
+	_update();
+}
+
+int PrimitiveMesh2D::get_surface_count() const {
+	if (pending_request) {
+		_update();
+	}
+	return 1;
+}
+
+int PrimitiveMesh2D::surface_get_array_len(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, 1, -1);
+	if (pending_request) {
+		_update();
+	}
+
+	return array_len;
+}
+
+int PrimitiveMesh2D::surface_get_array_index_len(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, 1, -1);
+	if (pending_request) {
+		_update();
+	}
+
+	return index_array_len;
+}
+
+Array PrimitiveMesh2D::surface_get_arrays(int p_surface) const {
+	ERR_FAIL_INDEX_V(p_surface, 1, Array());
+	if (pending_request) {
+		_update();
+	}
+
+	return RenderingServer::get_singleton()->mesh_surface_get_arrays(mesh, 0);
+}
+
+Dictionary PrimitiveMesh2D::surface_get_lods(int p_surface) const {
+	return Dictionary(); // Not really supported.
+}
+
+TypedArray<Array> PrimitiveMesh2D::surface_get_blend_shape_arrays(int p_surface) const {
+	return TypedArray<Array>(); // Not really supported.
+}
+
+BitField<Mesh::ArrayFormat> PrimitiveMesh2D::surface_get_format(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, 1, 0);
+
+	uint64_t mesh_format = ARRAY_FORMAT_VERTEX | ARRAY_FORMAT_TEX_UV | ARRAY_FORMAT_INDEX | ARRAY_FLAG_USE_2D_VERTICES;
+	if (antialiased) {
+		mesh_format |= ARRAY_FORMAT_COLOR;
+	}
+
+	return mesh_format;
+}
+
+Mesh::PrimitiveType PrimitiveMesh2D::surface_get_primitive_type(int p_idx) const {
+	return primitive_type;
+}
+
+void PrimitiveMesh2D::surface_set_material(int p_idx, const Ref<Material> &p_material) {
+	ERR_FAIL_INDEX(p_idx, 1);
+	// Not used. The CanvasItem material is used instead.
+}
+
+Ref<Material> PrimitiveMesh2D::surface_get_material(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, 1, nullptr);
+	// Not used. The CanvasItem material is used instead.
+	return nullptr;
+}
+
+int PrimitiveMesh2D::get_blend_shape_count() const {
+	return 0;
+}
+
+StringName PrimitiveMesh2D::get_blend_shape_name(int p_index) const {
+	return StringName();
+}
+
+void PrimitiveMesh2D::set_blend_shape_name(int p_index, const StringName &p_name) {
+}
+
+AABB PrimitiveMesh2D::get_aabb() const {
+	if (pending_request) {
+		_update();
+	}
+
+	return aabb;
+}
+
+RID PrimitiveMesh2D::get_rid() const {
+	if (pending_request) {
+		_update();
+	}
+	return mesh;
+}
+
+void PrimitiveMesh2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_mesh_arrays"), &PrimitiveMesh2D::get_mesh_arrays);
+
+	ClassDB::bind_method(D_METHOD("set_antialiased", "p_antialiased"), &PrimitiveMesh2D::set_antialiased);
+	ClassDB::bind_method(D_METHOD("is_antialiased"), &PrimitiveMesh2D::is_antialiased);
+
+	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &PrimitiveMesh2D::set_custom_aabb);
+	ClassDB::bind_method(D_METHOD("get_custom_aabb"), &PrimitiveMesh2D::get_custom_aabb);
+
+	ClassDB::bind_method(D_METHOD("request_update"), &PrimitiveMesh2D::request_update);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "antialiased"), "set_antialiased", "is_antialiased");
+	ADD_PROPERTY(PropertyInfo(Variant::AABB, "custom_aabb", PROPERTY_HINT_NONE, "suffix:px"), "set_custom_aabb", "get_custom_aabb");
+
+	GDVIRTUAL_BIND(_create_mesh_array);
+}
+
+void PrimitiveMesh2D::_validate_property(PropertyInfo &p_property) const {
+	// Remove unused lightmap size hint.
+	if (p_property.name == "lightmap_size_hint") {
+		p_property.usage = PROPERTY_USAGE_NONE;
+	}
+}
+
+Array PrimitiveMesh2D::get_mesh_arrays() const {
+	return surface_get_arrays(0);
+}
+
+bool PrimitiveMesh2D::is_antialiased() const {
+	return antialiased;
+}
+
+void PrimitiveMesh2D::set_antialiased(bool p_antialiased) {
+	if (antialiased == p_antialiased) {
+		return;
+	}
+	antialiased = p_antialiased;
+	request_update();
+}
+
+void PrimitiveMesh2D::set_custom_aabb(const AABB &p_custom) {
+	if (p_custom.is_equal_approx(custom_aabb)) {
+		return;
+	}
+	custom_aabb = p_custom;
+	RS::get_singleton()->mesh_set_custom_aabb(mesh, custom_aabb);
+	emit_changed();
+}
+
+AABB PrimitiveMesh2D::get_custom_aabb() const {
+	return custom_aabb;
+}
+
+PrimitiveMesh2D::PrimitiveMesh2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	mesh = RenderingServer::get_singleton()->mesh_create();
+}
+
+PrimitiveMesh2D::~PrimitiveMesh2D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	RenderingServer::get_singleton()->free_rid(mesh);
+}
+
+/**
+  RectangleMesh2D
+*/
+
+void RectangleMesh2D::_create_mesh_array(Array &p_arr) const {
+	int i, j, prevrow, thisrow, point;
+	float x, y;
+
+	Vector<Vector2> points;
+	Vector<Color> colors;
+	Vector<Vector2> uvs;
+	Vector<int> indices;
+	point = 0;
+
+	Vector2 rect_size = size;
+	Vector2 uv_scale = Vector2(1, 1);
+	Vector2 uv_offset = Vector2(0, 0);
+	if (antialiased) {
+		rect_size -= Vector2(FEATHER_SIZE, FEATHER_SIZE);
+		uv_scale = Vector2(rect_size.x / (size.x + FEATHER_SIZE), rect_size.y / (size.y + FEATHER_SIZE));
+		uv_offset = Vector2(FEATHER_SIZE / (size.x + FEATHER_SIZE), FEATHER_SIZE / (size.y + FEATHER_SIZE));
+	}
+	Vector2 start_pos = rect_size * -0.5;
+
+	thisrow = point;
+	prevrow = 0;
+	for (j = 0; j <= (subdivide_h + 1); j++) {
+		float v = j;
+		v /= (subdivide_h + 1.0);
+		y = start_pos.y + v * rect_size.y;
+
+		for (i = 0; i <= (subdivide_w + 1); i++) {
+			float u = i;
+			u /= (subdivide_w + 1.0);
+			x = start_pos.x + u * rect_size.x;
+			points.push_back(Vector2(x, y));
+			if (antialiased) {
+				colors.push_back(SOLID_COLOR);
+			}
+			uvs.push_back(uv_offset + uv_scale * Vector2(u, v));
+			point++;
+			if (i > 0 && j > 0) {
+				indices.push_back(prevrow + i - 1);
+				indices.push_back(thisrow + i - 1);
+				indices.push_back(thisrow + i);
+				indices.push_back(thisrow + i);
+				indices.push_back(prevrow + i);
+				indices.push_back(prevrow + i - 1);
+			}
+		}
+		prevrow = thisrow;
+		thisrow = point;
+	}
+
+	if (antialiased) {
+		int top_left_idx = 0;
+		int top_right_idx = subdivide_w + 1;
+		int bottom_left_idx = (subdivide_w + 2) * (subdivide_h + 1);
+		int bottom_right_idx = (subdivide_w + 2) * (subdivide_h + 2) - 1;
+
+		Vector2 outline_size = size + Vector2(FEATHER_SIZE, FEATHER_SIZE);
+
+		points.push_back(outline_size * -0.5);
+		colors.push_back(TRANSPARENT_COLOR);
+		uvs.push_back(Vector2(0, 0));
+		point++;
+		points.push_back(outline_size * Vector2(0.5, -0.5));
+		colors.push_back(TRANSPARENT_COLOR);
+		uvs.push_back(Vector2(1, 0));
+		point++;
+		points.push_back(outline_size * 0.5);
+		colors.push_back(TRANSPARENT_COLOR);
+		uvs.push_back(Vector2(1, 1));
+		point++;
+		points.push_back(outline_size * Vector2(-0.5, 0.5));
+		colors.push_back(TRANSPARENT_COLOR);
+		uvs.push_back(Vector2(0, 1));
+		point++;
+
+		// Top.
+		indices.push_back(point - 4);
+		indices.push_back(top_left_idx);
+		indices.push_back(top_right_idx);
+
+		indices.push_back(top_right_idx);
+		indices.push_back(point - 3);
+		indices.push_back(point - 4);
+
+		// Right.
+		indices.push_back(point - 3);
+		indices.push_back(top_right_idx);
+		indices.push_back(bottom_right_idx);
+
+		indices.push_back(bottom_right_idx);
+		indices.push_back(point - 2);
+		indices.push_back(point - 3);
+
+		// Bottom.
+		indices.push_back(point - 2);
+		indices.push_back(bottom_right_idx);
+		indices.push_back(bottom_left_idx);
+
+		indices.push_back(bottom_left_idx);
+		indices.push_back(point - 1);
+		indices.push_back(point - 2);
+
+		// Left.
+		indices.push_back(point - 1);
+		indices.push_back(bottom_left_idx);
+		indices.push_back(top_left_idx);
+
+		indices.push_back(top_left_idx);
+		indices.push_back(point - 4);
+		indices.push_back(point - 1);
+	}
+
+	p_arr[ARRAY_VERTEX] = points;
+	if (antialiased) {
+		p_arr[ARRAY_COLOR] = colors;
+	}
+	p_arr[ARRAY_TEX_UV] = uvs;
+	p_arr[ARRAY_INDEX] = indices;
+}
+
+void RectangleMesh2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &RectangleMesh2D::set_size);
+	ClassDB::bind_method(D_METHOD("get_size"), &RectangleMesh2D::get_size);
+
+	ClassDB::bind_method(D_METHOD("set_subdivide_width", "subdivide"), &RectangleMesh2D::set_subdivide_width);
+	ClassDB::bind_method(D_METHOD("get_subdivide_width"), &RectangleMesh2D::get_subdivide_width);
+	ClassDB::bind_method(D_METHOD("set_subdivide_height", "divisions"), &RectangleMesh2D::set_subdivide_height);
+	ClassDB::bind_method(D_METHOD("get_subdivide_height"), &RectangleMesh2D::get_subdivide_height);
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "size", PROPERTY_HINT_NONE, "suffix:px"), "set_size", "get_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdivide_width", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), "set_subdivide_width", "get_subdivide_width");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "subdivide_height", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), "set_subdivide_height", "get_subdivide_height");
+}
+
+void RectangleMesh2D::set_size(const Vector2 &p_size) {
+	if (p_size.is_equal_approx(size)) {
+		return;
+	}
+
+	size = p_size;
+	request_update();
+}
+
+Vector2 RectangleMesh2D::get_size() const {
+	return size;
+}
+
+void RectangleMesh2D::set_subdivide_width(const int p_divisions) {
+	if (p_divisions == subdivide_w) {
+		return;
+	}
+
+	subdivide_w = p_divisions > 0 ? p_divisions : 0;
+	request_update();
+}
+
+int RectangleMesh2D::get_subdivide_width() const {
+	return subdivide_w;
+}
+
+void RectangleMesh2D::set_subdivide_height(const int p_divisions) {
+	if (p_divisions == subdivide_h) {
+		return;
+	}
+
+	subdivide_h = p_divisions > 0 ? p_divisions : 0;
+	request_update();
+}
+
+int RectangleMesh2D::get_subdivide_height() const {
+	return subdivide_h;
+}
+
+RectangleMesh2D::RectangleMesh2D() {}
+
+/**
+  CircleMesh2D
+*/
+
+void CircleMesh2D::_create_mesh_array(Array &p_arr) const {
+	int i, point;
+	float x, y, u, v;
+
+	Vector<Vector2> points;
+	Vector<Color> colors;
+	Vector<Vector2> uvs;
+	Vector<int> indices;
+	point = 0;
+
+	float circle_radius = radius;
+	float uv_scale = 1.0;
+	if (radial_segments == 3) {
+		// Make sure the triangle respects the given radius.
+		circle_radius *= 2.0f / Math::sqrt(3.0f);
+	}
+	if (antialiased) {
+		uv_scale = circle_radius / (circle_radius + FEATHER_SIZE);
+		circle_radius -= FEATHER_SIZE * 0.5f;
+	}
+
+	if (radius > 0.0) {
+		points.push_back(Vector2(0.0, 0.0));
+		if (antialiased) {
+			colors.push_back(SOLID_COLOR);
+		}
+		uvs.push_back(Vector2(0.5, 0.5));
+		int center_idx = 0;
+		point++;
+
+		for (i = 0; i <= radial_segments; i++) {
+			float r = i;
+			r /= radial_segments;
+
+			if (i == radial_segments) {
+				x = 0.0;
+				y = 1.0;
+			} else {
+				x = Math::sin(r * Math::TAU);
+				y = Math::cos(r * Math::TAU);
+			}
+
+			u = 0.5 + uv_scale * x * 0.5;
+			v = 0.5 + uv_scale * y * 0.5;
+
+			Vector2 p = Vector2(x * circle_radius, y * circle_radius);
+			points.push_back(p);
+			if (antialiased) {
+				colors.push_back(SOLID_COLOR);
+			}
+			uvs.push_back(Vector2(u, v));
+			point++;
+
+			if (i > 0) {
+				indices.push_back(center_idx);
+				indices.push_back(point - 2);
+				indices.push_back(point - 1);
+			}
+		}
+
+		if (antialiased) {
+			float outer_circle_radius = circle_radius + FEATHER_SIZE;
+
+			for (i = 0; i <= radial_segments; i++) {
+				float r = i;
+				r /= radial_segments;
+
+				if (i == radial_segments) {
+					x = 0.0;
+					y = 1.0;
+				} else {
+					x = Math::sin(r * Math::TAU);
+					y = Math::cos(r * Math::TAU);
+				}
+
+				u = 0.5 + x * 0.5;
+				v = 0.5 + y * 0.5;
+
+				Vector2 p = Vector2(x * outer_circle_radius, y * outer_circle_radius);
+				points.push_back(p);
+				colors.push_back(TRANSPARENT_COLOR);
+				uvs.push_back(Vector2(u, v));
+				point++;
+
+				if (i > 0) {
+					indices.push_back(i + 1);
+					indices.push_back(i);
+					indices.push_back(point - 1);
+
+					indices.push_back(i);
+					indices.push_back(point - 2);
+					indices.push_back(point - 1);
+				}
+			}
+		}
+	}
+
+	p_arr[ARRAY_VERTEX] = points;
+	if (antialiased) {
+		p_arr[ARRAY_COLOR] = colors;
+	}
+	p_arr[ARRAY_TEX_UV] = uvs;
+	p_arr[ARRAY_INDEX] = indices;
+}
+
+void CircleMesh2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &CircleMesh2D::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius"), &CircleMesh2D::get_radius);
+	ClassDB::bind_method(D_METHOD("set_radial_segments", "segments"), &CircleMesh2D::set_radial_segments);
+	ClassDB::bind_method(D_METHOD("get_radial_segments"), &CircleMesh2D::get_radial_segments);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0,1024,0.001,or_greater,suffix:px"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "radial_segments", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_radial_segments", "get_radial_segments");
+}
+
+void CircleMesh2D::set_radius(const float p_radius) {
+	if (Math::is_equal_approx(p_radius, radius)) {
+		return;
+	}
+
+	radius = p_radius;
+	request_update();
+}
+
+float CircleMesh2D::get_radius() const {
+	return radius;
+}
+
+void CircleMesh2D::set_radial_segments(const int p_segments) {
+	if (p_segments == radial_segments) {
+		return;
+	}
+
+	radial_segments = p_segments > 3 ? p_segments : 3;
+	request_update();
+}
+
+int CircleMesh2D::get_radial_segments() const {
+	return radial_segments;
+}
+
+CircleMesh2D::CircleMesh2D() {}
+
+/**
+  CapsuleMesh2D
+*/
+
+void CapsuleMesh2D::_create_mesh_array(Array &p_arr) const {
+	int i, point;
+	float x, y, u, v;
+
+	Vector<Vector2> points;
+	Vector<Color> colors;
+	Vector<Vector2> uvs;
+	Vector<int> indices;
+	point = 0;
+
+	float circle_radius = radius;
+	float uv_scale = 1.0;
+	if (antialiased) {
+		circle_radius -= 0.5 * FEATHER_SIZE;
+		uv_scale = height / (height + FEATHER_SIZE);
+	}
+
+	if (circle_radius > 0.0) {
+		float circle_center_offset = 0.5 * height - circle_radius;
+		float radius_v = circle_radius / height;
+		float circle_center_offset_v = 0.5 - radius_v;
+
+		// Bottom.
+		int bottom_circle_center_idx = point;
+		points.push_back(Vector2(0.0, circle_center_offset));
+		if (antialiased) {
+			colors.push_back(SOLID_COLOR);
+		}
+		uvs.push_back(Vector2(0.5, 0.5 + circle_center_offset_v));
+		point++;
+
+		for (i = 0; i <= radial_segments; i++) {
+			float r = i;
+			r /= radial_segments;
+
+			if (i == radial_segments) {
+				x = -1.0;
+				y = 0.0;
+			} else {
+				x = Math::cos(r * Math::PI);
+				y = Math::sin(r * Math::PI);
+			}
+
+			u = 0.5 + uv_scale * x * 0.5;
+			v = 0.5 + circle_center_offset_v + uv_scale * y * radius_v;
+
+			Vector2 p = Vector2(x * circle_radius, circle_center_offset + y * circle_radius);
+			points.push_back(p);
+			if (antialiased) {
+				colors.push_back(SOLID_COLOR);
+			}
+			uvs.push_back(Vector2(u, v));
+			point++;
+
+			if (i > 0) {
+				indices.push_back(bottom_circle_center_idx);
+				indices.push_back(point - 1);
+				indices.push_back(point - 2);
+			}
+		}
+
+		// Middle.
+		if (height > 2.0f * radius) {
+			float left_side = 0.0;
+			float right_side = 1.0;
+			if (antialiased) {
+				left_side = 0.5 - uv_scale * 0.5;
+				right_side = 0.5 + uv_scale * 0.5;
+			}
+
+			points.push_back(Vector2(-circle_radius, circle_center_offset));
+			uvs.push_back(Vector2(left_side, 0.5 + circle_center_offset_v));
+			point++;
+
+			points.push_back(Vector2(circle_radius, circle_center_offset));
+			uvs.push_back(Vector2(right_side, 0.5 + circle_center_offset_v));
+			point++;
+
+			points.push_back(Vector2(circle_radius, -circle_center_offset));
+			uvs.push_back(Vector2(right_side, 0.5 - circle_center_offset_v));
+			point++;
+
+			points.push_back(Vector2(-circle_radius, -circle_center_offset));
+			uvs.push_back(Vector2(left_side, 0.5 - circle_center_offset_v));
+			point++;
+
+			if (antialiased) {
+				colors.push_back(SOLID_COLOR);
+				colors.push_back(SOLID_COLOR);
+				colors.push_back(SOLID_COLOR);
+				colors.push_back(SOLID_COLOR);
+			}
+
+			indices.push_back(point - 4);
+			indices.push_back(point - 3);
+			indices.push_back(point - 2);
+			indices.push_back(point - 2);
+			indices.push_back(point - 1);
+			indices.push_back(point - 4);
+		}
+
+		// Top.
+		int top_circle_center_idx = point;
+		points.push_back(Vector2(0.0, -circle_center_offset));
+		if (antialiased) {
+			colors.push_back(SOLID_COLOR);
+		}
+		uvs.push_back(Vector2(0.5, 0.5 - circle_center_offset_v));
+		point++;
+
+		for (i = 0; i <= radial_segments; i++) {
+			float r = i;
+			r /= radial_segments;
+
+			if (i == radial_segments) {
+				x = -1.0;
+				y = 0.0;
+			} else {
+				x = Math::cos(r * Math::PI);
+				y = Math::sin(r * Math::PI);
+			}
+
+			u = 0.5 + uv_scale * x * 0.5;
+			v = 0.5 - circle_center_offset_v - uv_scale * y * radius_v;
+
+			Vector2 p = Vector2(x * circle_radius, -circle_center_offset - y * circle_radius);
+			points.push_back(p);
+			if (antialiased) {
+				colors.push_back(SOLID_COLOR);
+			}
+			uvs.push_back(Vector2(u, v));
+			point++;
+
+			if (i > 0) {
+				indices.push_back(top_circle_center_idx);
+				indices.push_back(point - 2);
+				indices.push_back(point - 1);
+			}
+		}
+
+		if (antialiased) {
+			float outer_circle_radius = circle_radius + FEATHER_SIZE;
+
+			// Bottom.
+			for (i = 0; i <= radial_segments; i++) {
+				float r = i;
+				r /= radial_segments;
+
+				if (i == radial_segments) {
+					x = -1.0;
+					y = 0.0;
+				} else {
+					x = Math::cos(r * Math::PI);
+					y = Math::sin(r * Math::PI);
+				}
+
+				u = 0.5 + x * 0.5;
+				v = 0.5 + circle_center_offset_v + y * radius_v;
+
+				Vector2 p = Vector2(x * outer_circle_radius, circle_center_offset + y * outer_circle_radius);
+				points.push_back(p);
+				colors.push_back(TRANSPARENT_COLOR);
+				uvs.push_back(Vector2(u, v));
+				point++;
+
+				if (i > 0) {
+					indices.push_back(point - 2);
+					indices.push_back(bottom_circle_center_idx + i);
+					indices.push_back(bottom_circle_center_idx + i + 1);
+
+					indices.push_back(bottom_circle_center_idx + i + 1);
+					indices.push_back(point - 1);
+					indices.push_back(point - 2);
+				}
+			}
+
+			// Middle.
+			if (height > 2.0f * radius) {
+				int bottom_left_idx = radial_segments + 2;
+				int bottom_right_idx = radial_segments + 3;
+				int top_right_idx = radial_segments + 4;
+				int top_left_idx = radial_segments + 5;
+
+				points.push_back(Vector2(-outer_circle_radius, circle_center_offset));
+				colors.push_back(TRANSPARENT_COLOR);
+				uvs.push_back(Vector2(0, 0.5 + circle_center_offset_v));
+				point++;
+
+				points.push_back(Vector2(outer_circle_radius, circle_center_offset));
+				colors.push_back(TRANSPARENT_COLOR);
+				uvs.push_back(Vector2(1, 0.5 + circle_center_offset_v));
+				point++;
+
+				points.push_back(Vector2(outer_circle_radius, -circle_center_offset));
+				colors.push_back(TRANSPARENT_COLOR);
+				uvs.push_back(Vector2(1, 0.5 - circle_center_offset_v));
+				point++;
+
+				points.push_back(Vector2(-outer_circle_radius, -circle_center_offset));
+				colors.push_back(TRANSPARENT_COLOR);
+				uvs.push_back(Vector2(0, 0.5 - circle_center_offset_v));
+				point++;
+
+				indices.push_back(point - 4);
+				indices.push_back(bottom_left_idx);
+				indices.push_back(top_left_idx);
+
+				indices.push_back(top_left_idx);
+				indices.push_back(point - 1);
+				indices.push_back(point - 4);
+
+				indices.push_back(point - 2);
+				indices.push_back(top_right_idx);
+				indices.push_back(bottom_right_idx);
+
+				indices.push_back(bottom_right_idx);
+				indices.push_back(point - 3);
+				indices.push_back(point - 2);
+			}
+
+			// Top.
+			for (i = 0; i <= radial_segments; i++) {
+				float r = i;
+				r /= radial_segments;
+
+				if (i == radial_segments) {
+					x = -1.0;
+					y = 0.0;
+				} else {
+					x = Math::cos(r * Math::PI);
+					y = Math::sin(r * Math::PI);
+				}
+
+				u = 0.5 + x * 0.5;
+				v = 0.5 - circle_center_offset_v - y * radius_v;
+
+				Vector2 p = Vector2(x * outer_circle_radius, -circle_center_offset - y * outer_circle_radius);
+				points.push_back(p);
+				colors.push_back(TRANSPARENT_COLOR);
+				uvs.push_back(Vector2(u, v));
+				point++;
+
+				if (i > 0) {
+					indices.push_back(top_circle_center_idx + i + 1);
+					indices.push_back(top_circle_center_idx + i);
+					indices.push_back(point - 1);
+
+					indices.push_back(top_circle_center_idx + i);
+					indices.push_back(point - 2);
+					indices.push_back(point - 1);
+				}
+			}
+		}
+	}
+
+	p_arr[ARRAY_VERTEX] = points;
+	if (antialiased) {
+		p_arr[ARRAY_COLOR] = colors;
+	}
+	p_arr[ARRAY_TEX_UV] = uvs;
+	p_arr[ARRAY_INDEX] = indices;
+}
+
+void CapsuleMesh2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &CapsuleMesh2D::set_radius);
+	ClassDB::bind_method(D_METHOD("get_radius"), &CapsuleMesh2D::get_radius);
+	ClassDB::bind_method(D_METHOD("set_height", "height"), &CapsuleMesh2D::set_height);
+	ClassDB::bind_method(D_METHOD("get_height"), &CapsuleMesh2D::get_height);
+
+	ClassDB::bind_method(D_METHOD("set_radial_segments", "segments"), &CapsuleMesh2D::set_radial_segments);
+	ClassDB::bind_method(D_METHOD("get_radial_segments"), &CapsuleMesh2D::get_radial_segments);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.001,1024.0,0.001,or_greater,suffix:px"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,1024.0,0.001,or_greater,suffix:px"), "set_height", "get_height");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "radial_segments", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_radial_segments", "get_radial_segments");
+
+	ADD_LINKED_PROPERTY("radius", "height");
+	ADD_LINKED_PROPERTY("height", "radius");
+}
+
+void CapsuleMesh2D::set_radius(const float p_radius) {
+	if (Math::is_equal_approx(radius, p_radius)) {
+		return;
+	}
+
+	radius = p_radius;
+	if (radius > height * 0.5) {
+		height = radius * 2.0;
+	}
+	request_update();
+}
+
+float CapsuleMesh2D::get_radius() const {
+	return radius;
+}
+
+void CapsuleMesh2D::set_height(const float p_height) {
+	if (Math::is_equal_approx(height, p_height)) {
+		return;
+	}
+
+	height = p_height;
+	if (radius > height * 0.5) {
+		radius = height * 0.5;
+	}
+	request_update();
+}
+
+float CapsuleMesh2D::get_height() const {
+	return height;
+}
+
+void CapsuleMesh2D::set_radial_segments(const int p_segments) {
+	if (radial_segments == p_segments) {
+		return;
+	}
+
+	radial_segments = p_segments > 2 ? p_segments : 2;
+	request_update();
+}
+
+int CapsuleMesh2D::get_radial_segments() const {
+	return radial_segments;
+}
+
+CapsuleMesh2D::CapsuleMesh2D() {}

--- a/scene/resources/2d/primitive_meshes_2d.h
+++ b/scene/resources/2d/primitive_meshes_2d.h
@@ -1,0 +1,185 @@
+/**************************************************************************/
+/*  primitive_meshes_2d.h                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/resources/mesh.h"
+
+// Use the same antialiasing feather size as StyleBoxFlat's default.
+// This value is empirically determined to provide good antialiasing quality
+// while not making lines appear too soft.
+const static float FEATHER_SIZE = 1.25f;
+
+// @TODO Probably should change a few integers to unsigned integers...
+
+/**
+	Base class for all the classes in this file, handles a number of code functions that are shared among all meshes.
+	This class is set apart that it assumes a single surface is always generated for our mesh.
+*/
+
+class PrimitiveMesh2D : public Mesh {
+	GDCLASS(PrimitiveMesh2D, Mesh);
+
+private:
+	RID mesh;
+	mutable AABB aabb;
+	AABB custom_aabb;
+
+	mutable int array_len = 0;
+	mutable int index_array_len = 0;
+
+	// Make sure we do an update after we've finished constructing our object.
+	mutable bool pending_request = true;
+	void _update() const;
+
+protected:
+	// Assume primitive triangles as the type, correct for all but one and it will change this :)
+	Mesh::PrimitiveType primitive_type = Mesh::PRIMITIVE_TRIANGLES;
+
+	bool antialiased = false;
+
+	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
+
+	virtual void _create_mesh_array(Array &p_arr) const {}
+	GDVIRTUAL0RC(Array, _create_mesh_array)
+
+	void _on_settings_changed();
+
+public:
+	virtual int get_surface_count() const override;
+	virtual int surface_get_array_len(int p_idx) const override;
+	virtual int surface_get_array_index_len(int p_idx) const override;
+	virtual Array surface_get_arrays(int p_surface) const override;
+	virtual TypedArray<Array> surface_get_blend_shape_arrays(int p_surface) const override;
+	virtual Dictionary surface_get_lods(int p_surface) const override;
+	virtual BitField<ArrayFormat> surface_get_format(int p_idx) const override;
+	virtual Mesh::PrimitiveType surface_get_primitive_type(int p_idx) const override;
+	virtual void surface_set_material(int p_idx, const Ref<Material> &p_material) override;
+	virtual Ref<Material> surface_get_material(int p_idx) const override;
+	virtual int get_blend_shape_count() const override;
+	virtual StringName get_blend_shape_name(int p_index) const override;
+	virtual void set_blend_shape_name(int p_index, const StringName &p_name) override;
+	virtual AABB get_aabb() const override;
+	virtual RID get_rid() const override;
+
+	Array get_mesh_arrays() const;
+
+	bool is_antialiased() const;
+	void set_antialiased(bool p_antialiased);
+
+	void set_custom_aabb(const AABB &p_custom);
+	AABB get_custom_aabb() const;
+
+	void request_update();
+
+	PrimitiveMesh2D();
+	~PrimitiveMesh2D();
+};
+
+/**
+	A rectangle
+*/
+class RectangleMesh2D : public PrimitiveMesh2D {
+	GDCLASS(RectangleMesh2D, PrimitiveMesh2D);
+
+private:
+	Vector2 size = Vector2(20, 20);
+	int subdivide_w = 0;
+	int subdivide_h = 0;
+
+protected:
+	virtual void _create_mesh_array(Array &p_arr) const override;
+	static void _bind_methods();
+
+public:
+	void set_size(const Vector2 &p_size);
+	Vector2 get_size() const;
+
+	void set_subdivide_width(const int p_divisions);
+	int get_subdivide_width() const;
+
+	void set_subdivide_height(const int p_divisions);
+	int get_subdivide_height() const;
+
+	RectangleMesh2D();
+};
+
+/**
+	A circle
+*/
+class CircleMesh2D : public PrimitiveMesh2D {
+	GDCLASS(CircleMesh2D, PrimitiveMesh2D);
+
+private:
+	float radius = 10;
+	int radial_segments = 64;
+
+protected:
+	virtual void _create_mesh_array(Array &p_arr) const override;
+	static void _bind_methods();
+
+public:
+	void set_radius(const float p_radius);
+	float get_radius() const;
+
+	void set_radial_segments(const int p_segments);
+	int get_radial_segments() const;
+
+	CircleMesh2D();
+};
+
+/**
+	A capsule
+*/
+class CapsuleMesh2D : public PrimitiveMesh2D {
+	GDCLASS(CapsuleMesh2D, PrimitiveMesh2D);
+
+private:
+	float radius = 10;
+	float height = 30;
+	int radial_segments = 32;
+
+protected:
+	virtual void _create_mesh_array(Array &p_arr) const override;
+	static void _bind_methods();
+
+public:
+	void set_radius(const float p_radius);
+	float get_radius() const;
+
+	void set_height(const float p_height);
+	float get_height() const;
+
+	void set_radial_segments(const int p_segments);
+	int get_radial_segments() const;
+
+	CapsuleMesh2D();
+};


### PR DESCRIPTION
Adds `RectangleMesh2D`, `CircleMesh2D`, and `CapsuleMesh2D`, inheriting from the virtual base class `PrimitiveMesh2D`.

Allows drawing 2D shapes by using the *existing* (but so far perhaps underused) `MeshInstance2D` node:

![primitive_mesh_2d](https://github.com/user-attachments/assets/39248985-1478-4acc-b113-90a79ad1b3bf)

Example project: [godot-primitive-mesh-2d.zip](https://github.com/user-attachments/files/18187813/godot-primitive-mesh-2d.zip)

![primitive_mesh_2d_examples](https://github.com/user-attachments/assets/be7e5097-3d6e-4764-8c74-b758d94d35d1)

The two fancy shapes on the right are obtained by applying vertex shaders to primitive meshes (kind of silly, but it works).

~~If you want a triangle, use a `Polygon2D` instead.~~

The code is based on the code for primitive 3D meshes.

- Closes https://github.com/godotengine/godot-proposals/issues/1126