### PR TITLE
Improve `&&` and `&` syntax highlighting by altering `StringName` highlighting

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -560,12 +560,17 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			}
 		}
 
-		// Keep symbol color for binary '&&'. In the case of '&&&' use StringName color for the last ampersand.
+		// Set color of StringName, keeping symbol color for binary '&&' and '&'.
 		if (!in_string_name && in_region == -1 && str[j] == '&' && !is_binary_op) {
-			if (j >= 2 && str[j - 1] == '&' && str[j - 2] != '&' && prev_is_binary_op) {
-				is_binary_op = true;
-			} else if (j == 0 || (j > 0 && str[j - 1] != '&') || prev_is_binary_op) {
+			if (j + 1 <= line_length - 1 && (str[j + 1] == '\'' || str[j + 1] == '"')) {
 				in_string_name = true;
+				// Cover edge cases of i.e. '+&""' and '&&&""', so the StringName is properly colored.
+				if (prev_is_binary_op && j >= 2 && str[j - 1] == '&' && str[j - 2] != '&') {
+					in_string_name = false;
+					is_binary_op = true;
+				}
+			} else {
+				is_binary_op = true;
 			}
 		} else if (in_region != -1 || is_a_symbol) {
 			in_string_name = false;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11381

Not much to say about this PR, new code should be fairly easy to understand. Check out the proposal for an explanation and some details. That said, it could probably be cleaned up a bit, I always seem to miss something.

![Image](https://github.com/user-attachments/assets/4530097d-9424-469f-98d3-c817da7f925a)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
