### PR TITLE
[Windows, LLVM] Fix `colorize` flag.

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -807,7 +807,7 @@ def configure_mingw(env: "SConsEnvironment"):
         env.Append(CCFLAGS=san_flags)
         env.Append(LINKFLAGS=san_flags)
 
-    if env["use_llvm"] and os.name == "nt" and methods._colorize:
+    if env["use_llvm"] and os.name == "nt" and methods._can_color:
         env.Append(CCFLAGS=["$(-fansi-escape-codes$)", "$(-fcolor-diagnostics$)"])
 
     if get_is_ar_thin_supported(env):


### PR DESCRIPTION
Fixes build with `use_llvm=yes` on Windows.