### PR TITLE
Change how variant buckets are allocated to optimize memory.

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -147,14 +147,18 @@ private:
 		union BucketSmall {
 			BucketSmall() {}
 			~BucketSmall() {}
-			Transform2D _transform2d;
-			::AABB _aabb;
+			union {
+				Transform2D _transform2d;
+				::AABB _aabb;
+			};
 		};
 		union BucketMedium {
 			BucketMedium() {}
 			~BucketMedium() {}
-			Basis _basis;
-			Transform3D _transform3d;
+			union {
+				Basis _basis;
+				Transform3D _transform3d;
+			};
 		};
 		union BucketLarge {
 			BucketLarge() {}


### PR DESCRIPTION
optimization: Reduces wasted memory.
![image](https://github.com/user-attachments/assets/74d693b5-b234-4d93-bbcf-76b4b22641d5)
Only one field is used here when it is being allocated.