### PR TITLE
Document limitations of refraction from using screen texture

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -315,6 +315,7 @@
 		</member>
 		<member name="refraction_enabled" type="bool" setter="set_feature" getter="get_feature" default="false">
 			If [code]true[/code], the refraction effect is enabled. Distorts transparency based on light from behind the object.
+			[b]Note:[/b] Refraction is implemented using the screen texture. Only opaque materials will appear in the refraction, since transparent materials do not appear in the screen texture.
 		</member>
 		<member name="refraction_scale" type="float" setter="set_refraction" getter="get_refraction" default="0.05">
 			The strength of the refraction effect.


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/90171.

The [existing note](https://docs.godotengine.org/en/stable/tutorials/3d/standard_material_3d.html#refraction) in the manual is *long* and I don't think it is appropriate to copy it entirely, or even to list all of these caveats in a single note in the class reference:
> Refraction is implemented as a screen-space effect and forces the material to be transparent. This makes the effect relatively fast, but this results in some limitations:
    [Transparency sorting](https://docs.godotengine.org/en/stable/tutorials/3d/3d_rendering_limitations.html#doc-3d-rendering-limitations-transparency-sorting) issues may occur.
    The refractive material cannot refract onto itself, or onto other transparent materials. A refractive material behind another transparent material will be invisible.
    Off-screen objects cannot appear in the refraction. This is most noticeable with high refraction strength values.
    Opaque materials in front of the refractive material will appear to have "refracted" edges, even though they shouldn't.

We can expand this note over time, if any other issues can be closed by adding to it.