### PR TITLE
Document 2048 result limit from DirectSpaceState functions

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -25,8 +25,9 @@
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters2D" />
 			<param index="1" name="max_results" type="int" default="32" />
 			<description>
-				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters2D] object, against the space. The resulting array contains a list of points where the shape intersects another. Like with [method intersect_shape], the number of returned results can be limited to save processing time.
+				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters2D] object, against the space. The resulting array contains a list of points where the shape intersects another.
 				Returned points are a list of pairs of contact points. For each pair the first one is in the shape passed in [PhysicsShapeQueryParameters2D] object, second one is in the collided shape from the physics space.
+				The number of returned results can be limited with the [param max_results] parameter, to reduce the processing time. [param max_results] is clamped to a hard limit of [code]2048[/code].
 			</description>
 		</method>
 		<method name="get_rest_info">
@@ -53,7 +54,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
-				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time. [param max_results] is clamped to a hard limit of [code]2048[/code].
 				[b]Note:[/b] [ConcavePolygonShape2D]s and [CollisionPolygon2D]s in [code]Segments[/code] build mode are not solid shapes. Therefore, they will not be detected.
 			</description>
 		</method>
@@ -81,7 +82,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
-				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time. [param max_results] is clamped to a hard limit of [code]2048[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -25,8 +25,9 @@
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />
 			<param index="1" name="max_results" type="int" default="32" />
 			<description>
-				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters3D] object, against the space. The resulting array contains a list of points where the shape intersects another. Like with [method intersect_shape], the number of returned results can be limited to save processing time.
+				Checks the intersections of a shape, given through a [PhysicsShapeQueryParameters3D] object, against the space. The resulting array contains a list of points where the shape intersects another.
 				Returned points are a list of pairs of contact points. For each pair the first one is in the shape passed in [PhysicsShapeQueryParameters3D] object, second one is in the collided shape from the physics space.
+				The number of returned results can be limited with the [param max_results] parameter, to reduce the processing time. [param max_results] is clamped to a hard limit of [code]2048[/code].
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object.
 			</description>
 		</method>
@@ -55,7 +56,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
-				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time. [param max_results] is clamped to a hard limit of [code]2048[/code].
 			</description>
 		</method>
 		<method name="intersect_ray">
@@ -84,7 +85,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
-				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time.
+				The number of intersections can be limited with the [param max_results] parameter, to reduce the processing time. [param max_results] is clamped to a hard limit of [code]2048[/code].
 				[b]Note:[/b] This method does not take into account the [code]motion[/code] property of the object.
 			</description>
 		</method>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/83541 by documenting the `INTERSECTION_QUERY_MAX` limit of 2048.

Note that there are more functions that internally use this limit, but since they don't expose a `max_results` parameter, I chose not to document the limit in this PR.
