### PR TITLE
LightmapGI: Fix crash during baking when sky is null

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -138,7 +138,7 @@ Ref<Image> RendererSceneRenderRD::environment_bake_panorama(RID p_env, bool p_ba
 
 	if (use_cube_map) {
 		Ref<Image> panorama = sky_bake_panorama(environment_get_sky(p_env), environment_get_bg_energy_multiplier(p_env), p_bake_irradiance, p_size);
-		if (use_ambient_light) {
+		if (use_ambient_light && panorama.is_valid()) {
 			for (int x = 0; x < p_size.width; x++) {
 				for (int y = 0; y < p_size.height; y++) {
 					panorama->set_pixel(x, y, ambient_color.lerp(panorama->get_pixel(x, y), ambient_color_sky_mix));


### PR DESCRIPTION
LightmapGI was missing a `null` check on the baked Sky panorama in a specific code path (blending with ambient colour).

Might need extra discussion on what the expected behaviour here is as currently ambient light will not be factored in at all, but an error is printed to the console to warn the user and at least it shouldn't crash any more.

Fixes https://github.com/godotengine/godot/issues/100542