### PR TITLE
[EditorFileDialog] Do not update file selection on filter change if nothing was previously selected.

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1504,9 +1504,11 @@ void EditorFileDialog::_filter_changed(const String &p_text) {
 	search_string = p_text;
 	invalidate();
 
-	item_list->deselect_all();
-	if (item_list->get_item_count() > 0) {
-		item_list->call_deferred("select", 0);
+	if (item_list->get_selected_items().size() > 0) {
+		item_list->deselect_all();
+		if (item_list->get_item_count() > 0) {
+			item_list->call_deferred("select", 0);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/100077
