### PR TITLE
Add option to disable `Swipe to Dismiss` for Wear OS

### DIFF
--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -615,6 +615,10 @@
 		<member name="version/name" type="String" setter="" getter="">
 			Application version visible to the user. Falls back to [member ProjectSettings.application/config/version] if left empty.
 		</member>
+		<member name="wear_os/swipe_to_dismiss" type="bool" setter="" getter="">
+			If [code]true[/code], [url=https://developer.android.com/design/ui/wear/guides/components/swipe-to-dismiss]Swipe to dismiss[/url] will be enabled on Wear OS.
+			[b]Note:[/b] This is [code]true[/code] by default. To disable this behavior, [member EditorExportPlatformAndroid.gradle_build/use_gradle_build] is required.
+		</member>
 		<member name="xr_features/xr_mode" type="int" setter="" getter="">
 			The extended reality (XR) mode for this application.
 		</member>

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -156,6 +156,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	void _write_tmp_manifest(const Ref<EditorExportPreset> &p_preset, bool p_give_internet, bool p_debug);
 
+	void _fix_themes_xml(const Ref<EditorExportPreset> &p_preset);
+
 	void _fix_manifest(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &p_manifest, bool p_give_internet);
 
 	static String _get_keystore_path(const Ref<EditorExportPreset> &p_preset, bool p_debug);

--- a/platform/android/java/app/res/values/themes.xml
+++ b/platform/android/java/app/res/values/themes.xml
@@ -2,7 +2,8 @@
 <resources>
 
 	<style name="GodotAppMainTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
-		<item name ="android:windowDrawsSystemBarBackgrounds">false</item>
+		<item name="android:windowDrawsSystemBarBackgrounds">false</item>
+		<item name="android:windowSwipeToDismiss">false</item>
 	</style>
 
 	<style name="GodotAppSplashTheme" parent="Theme.SplashScreen">


### PR DESCRIPTION
- Implements and closes https://github.com/godotengine/godot-proposals/issues/11357

This PR introduces a new **advanced export option** for Wear OS, allowing developers to enable or disable the swipe-to-dismiss gesture. By default, this feature is enabled, preserving the current behavior.

**Use Case**:
This feature is useful for developers targeting Wear OS devices where swipe-to-dismiss may conflict with app-specific navigation or gesture handling.

**Note for reviewers**:
Instead of overriding the entire themes.xml file using a prebuilt template, this implementation selectively reads and modifies the file. This approach ensures that any manual edits made to `themes.xml` by developers are preserved while adding or removing the <item name="android:windowSwipeToDismiss"> element as needed.