### PR TITLE
Add templated version of `ObjectDB::get_instance()`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1350,7 +1350,7 @@ void Thread::_start_func(void *ud) {
 	target_callable.callp(nullptr, 0, ret, ce);
 	// If script properly kept a reference to the thread, we should be able to re-reference it now
 	// (well, or if the call failed, since we had to break chains anyway because the outcome isn't known upfront).
-	t = Ref<Thread>(ObjectDB::get_instance(th_instance_id));
+	t = ObjectDB::get_ref<Thread>(th_instance_id);
 	if (t.is_valid()) {
 		t->ret = ret;
 		t->running.clear();

--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -188,7 +188,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 			} else {
 				String node_name;
 				if (p_id.is_valid()) {
-					Node *node = Object::cast_to<Node>(ObjectDB::get_instance(p_id));
+					Node *node = ObjectDB::get_instance<Node>(p_id);
 					if (node && node->is_inside_tree()) {
 						node_name = "\"" + String(node->get_path()) + "\"";
 					} else {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -46,6 +46,9 @@
 template <typename T>
 class TypedArray;
 
+template <typename T>
+class Ref;
+
 enum PropertyHint {
 	PROPERTY_HINT_NONE, ///< no hint provided.
 	PROPERTY_HINT_RANGE, ///< hint_text = "min,max[,step][,or_greater][,or_less][,hide_slider][,radians_as_degrees][,degrees][,exp][,suffix:<keyword>] range.
@@ -1052,6 +1055,15 @@ public:
 
 		return object;
 	}
+
+	template <typename T>
+	_ALWAYS_INLINE_ static T *get_instance(ObjectID p_instance_id) {
+		return Object::cast_to<T>(get_instance(p_instance_id));
+	}
+
+	template <typename T>
+	_ALWAYS_INLINE_ static Ref<T> get_ref(ObjectID p_instance_id); // Defined in ref_counted.h
+
 	static void debug_objects(DebugFunc p_func);
 	static int get_object_count();
 };

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -285,3 +285,8 @@ struct VariantInternalAccessor<const Ref<T> &> {
 // Zero-constructing Ref initializes reference to nullptr (and thus empty).
 template <typename T>
 struct is_zero_constructible<Ref<T>> : std::true_type {};
+
+template <typename T>
+Ref<T> ObjectDB::get_ref(ObjectID p_instance_id) {
+	return Ref<T>(get_instance(p_instance_id));
+}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -3098,7 +3098,7 @@ void EditorFileSystem::_queue_refresh_filesystem() {
 
 void EditorFileSystem::_refresh_filesystem() {
 	for (const ObjectID &id : folders_to_sort) {
-		EditorFileSystemDirectory *dir = Object::cast_to<EditorFileSystemDirectory>(ObjectDB::get_instance(id));
+		EditorFileSystemDirectory *dir = ObjectDB::get_instance<EditorFileSystemDirectory>(id);
 		if (dir) {
 			dir->subdirs.sort_custom<DirectoryComparator>();
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2424,7 +2424,7 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 			if (kv.key == owner_id || !kv.value.has(plugin)) {
 				continue;
 			}
-			EditorPropertyResource *epres = Object::cast_to<EditorPropertyResource>(ObjectDB::get_instance(kv.key));
+			EditorPropertyResource *epres = ObjectDB::get_instance<EditorPropertyResource>(kv.key);
 			if (epres) {
 				// If it's resource property editing the same resource type, fold it later to avoid premature modifications
 				// that may result in unsafe iteration of active_plugins.
@@ -2555,7 +2555,7 @@ void EditorNode::_add_to_history(const Object *p_object, const String &p_propert
 	ObjectID history_id = editor_history.get_current();
 	if (id != history_id) {
 		const MultiNodeEdit *multi_node_edit = Object::cast_to<const MultiNodeEdit>(p_object);
-		const MultiNodeEdit *history_multi_node_edit = Object::cast_to<const MultiNodeEdit>(ObjectDB::get_instance(history_id));
+		const MultiNodeEdit *history_multi_node_edit = ObjectDB::get_instance<MultiNodeEdit>(history_id);
 		if (multi_node_edit && history_multi_node_edit && multi_node_edit->is_same_selection(history_multi_node_edit)) {
 			return;
 		}

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1291,7 +1291,7 @@ void SceneTreeEditor::_cell_multi_selected(Object *p_object, int p_cell, bool p_
 
 void SceneTreeEditor::_tree_scroll_to_item(ObjectID p_item_id) {
 	ERR_FAIL_NULL(tree);
-	TreeItem *item = Object::cast_to<TreeItem>(ObjectDB::get_instance(p_item_id));
+	TreeItem *item = ObjectDB::get_instance<TreeItem>(p_item_id);
 	if (item) {
 		tree->scroll_to_item(item, true);
 	}

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1932,7 +1932,7 @@ AnimationMixer *AnimationPlayerEditor::fetch_mixer_for_library() const {
 }
 
 Node *AnimationPlayerEditor::get_cached_root_node() const {
-	return Object::cast_to<Node>(ObjectDB::get_instance(cached_root_node_id));
+	return ObjectDB::get_instance<Node>(cached_root_node_id);
 }
 
 bool AnimationPlayerEditor::_validate_tracks(const Ref<Animation> p_anim) {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4739,7 +4739,7 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 
 			undo_redo->create_action(TTR("Paste Pose"));
 			for (const PoseClipboard &E : pose_clipboard) {
-				Node2D *n2d = Object::cast_to<Node2D>(ObjectDB::get_instance(E.id));
+				Node2D *n2d = ObjectDB::get_instance<Node2D>(E.id);
 				if (!n2d) {
 					continue;
 				}

--- a/editor/plugins/editor_resource_tooltip_plugins.cpp
+++ b/editor/plugins/editor_resource_tooltip_plugins.cpp
@@ -38,7 +38,7 @@
 
 void EditorResourceTooltipPlugin::_thumbnail_ready(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata) {
 	ObjectID trid = p_udata;
-	TextureRect *tr = Object::cast_to<TextureRect>(ObjectDB::get_instance(trid));
+	TextureRect *tr = ObjectDB::get_instance<TextureRect>(trid);
 
 	if (!tr) {
 		return;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -758,7 +758,7 @@ void Node3DEditorViewport::_clear_selected() {
 }
 
 void Node3DEditorViewport::_select_clicked(bool p_allow_locked) {
-	Node *node = Object::cast_to<Node3D>(ObjectDB::get_instance(clicked));
+	Node *node = ObjectDB::get_instance<Node3D>(clicked);
 	Node3D *selected = Object::cast_to<Node3D>(node);
 	clicked = ObjectID();
 
@@ -2118,7 +2118,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				const bool movement_threshold_passed = _edit.original_mouse_pos.distance_to(_edit.mouse_pos) > 8 * EDSCALE;
 
 				if (selection_in_progress && movement_threshold_passed && clicked.is_valid()) {
-					if (clicked_wants_append || !editor_selection->is_selected(Object::cast_to<Node>(ObjectDB::get_instance(clicked)))) {
+					if (clicked_wants_append || !editor_selection->is_selected(ObjectDB::get_instance<Node>(clicked))) {
 						cursor.region_select = true;
 						cursor.region_begin = _edit.original_mouse_pos;
 						clicked = ObjectID();
@@ -4849,8 +4849,8 @@ bool Node3DEditorViewport::_create_audio_node(Node *p_parent, const String &p_pa
 void Node3DEditorViewport::_perform_drop_data() {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	if (spatial_editor->get_preview_material_target().is_valid()) {
-		GeometryInstance3D *geometry_instance = Object::cast_to<GeometryInstance3D>(ObjectDB::get_instance(spatial_editor->get_preview_material_target()));
-		MeshInstance3D *mesh_instance = Object::cast_to<MeshInstance3D>(ObjectDB::get_instance(spatial_editor->get_preview_material_target()));
+		GeometryInstance3D *geometry_instance = ObjectDB::get_instance<GeometryInstance3D>(spatial_editor->get_preview_material_target());
+		MeshInstance3D *mesh_instance = ObjectDB::get_instance<MeshInstance3D>(spatial_editor->get_preview_material_target());
 		if (mesh_instance && spatial_editor->get_preview_material_surface() != -1) {
 			undo_redo->create_action(vformat(TTR("Set Surface %d Override Material"), spatial_editor->get_preview_material_surface()));
 			undo_redo->add_do_method(geometry_instance, "set_surface_override_material", spatial_editor->get_preview_material_surface(), spatial_editor->get_preview_material());
@@ -8519,7 +8519,7 @@ void Node3DEditor::_request_gizmo(Object *p_obj) {
 }
 
 void Node3DEditor::_request_gizmo_for_id(ObjectID p_id) {
-	Node3D *node = Object::cast_to<Node3D>(ObjectDB::get_instance(p_id));
+	Node3D *node = ObjectDB::get_instance<Node3D>(p_id);
 	if (node) {
 		_request_gizmo(node);
 	}

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -48,7 +48,7 @@
 #include "core/os/keyboard.h"
 
 TileMapLayer *TileMapLayerSubEditorPlugin::_get_edited_layer() const {
-	return Object::cast_to<TileMapLayer>(ObjectDB::get_instance(edited_tile_map_layer_id));
+	return ObjectDB::get_instance<TileMapLayer>(edited_tile_map_layer_id);
 }
 
 void TileMapLayerSubEditorPlugin::draw_tile_coords_over_viewport(Control *p_overlay, const TileMapLayer *p_edited_layer, Ref<TileSet> p_tile_set, bool p_show_rectangle_size, const Vector2i &p_rectangle_origin) {
@@ -2177,7 +2177,7 @@ void TileMapLayerEditorTilesPlugin::edit(ObjectID p_tile_map_layer_id) {
 		}
 	}
 
-	TileMapLayer *new_tile_map_layer = Object::cast_to<TileMapLayer>(ObjectDB::get_instance(edited_tile_map_layer_id));
+	TileMapLayer *new_tile_map_layer = ObjectDB::get_instance<TileMapLayer>(edited_tile_map_layer_id);
 	Ref<TileSet> new_tile_set;
 	if (new_tile_map_layer) {
 		new_tile_set = new_tile_map_layer->get_tile_set();
@@ -3641,7 +3641,7 @@ TileMapLayerEditorTerrainsPlugin::TileMapLayerEditorTerrainsPlugin() {
 }
 
 TileMapLayer *TileMapLayerEditor::_get_edited_layer() const {
-	return Object::cast_to<TileMapLayer>(ObjectDB::get_instance(edited_tile_map_layer_id));
+	return ObjectDB::get_instance<TileMapLayer>(edited_tile_map_layer_id);
 }
 
 void TileMapLayerEditor::_find_tile_map_layers_in_scene(Node *p_current, const Node *p_owner, Vector<TileMapLayer *> &r_list) const {

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -784,7 +784,7 @@ void TileSetEditor::remove_expanded_editor() {
 		return;
 	}
 
-	Node *original_parent = Object::cast_to<Node>(ObjectDB::get_instance(expanded_editor_parent));
+	Node *original_parent = ObjectDB::get_instance<Node>(expanded_editor_parent);
 	if (original_parent) {
 		expanded_editor->remove_meta("reparented");
 		expanded_editor->reparent(original_parent);

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -339,14 +339,14 @@ void TileMapEditorPlugin::_tile_map_layer_changed() {
 
 void TileMapEditorPlugin::_tile_map_layer_removed() {
 	// Workaround for TileMap, making sure the editor stays open when you delete the currently edited layer.
-	TileMap *tile_map = Object::cast_to<TileMap>(ObjectDB::get_instance(tile_map_group_id));
+	TileMap *tile_map = ObjectDB::get_instance<TileMap>(tile_map_group_id);
 	if (tile_map) {
 		edit(tile_map);
 	}
 }
 
 void TileMapEditorPlugin::_update_tile_map() {
-	TileMapLayer *edited_layer = Object::cast_to<TileMapLayer>(ObjectDB::get_instance(tile_map_layer_id));
+	TileMapLayer *edited_layer = ObjectDB::get_instance<TileMapLayer>(tile_map_layer_id);
 	if (edited_layer) {
 		Ref<TileSet> tile_set = edited_layer->get_tile_set();
 		if (tile_set.is_valid() && tile_set_id != tile_set->get_instance_id()) {
@@ -363,7 +363,7 @@ void TileMapEditorPlugin::_update_tile_map() {
 }
 
 void TileMapEditorPlugin::_select_layer(const StringName &p_name) {
-	TileMapLayer *edited_layer = Object::cast_to<TileMapLayer>(ObjectDB::get_instance(tile_map_layer_id));
+	TileMapLayer *edited_layer = ObjectDB::get_instance<TileMapLayer>(tile_map_layer_id);
 	ERR_FAIL_NULL(edited_layer);
 
 	Node *parent = edited_layer->get_parent();
@@ -415,7 +415,7 @@ void TileMapEditorPlugin::_notification(int p_notification) {
 }
 
 void TileMapEditorPlugin::edit(Object *p_object) {
-	TileMapLayer *edited_layer = Object::cast_to<TileMapLayer>(ObjectDB::get_instance(tile_map_layer_id));
+	TileMapLayer *edited_layer = ObjectDB::get_instance<TileMapLayer>(tile_map_layer_id);
 	if (edited_layer) {
 		edited_layer->disconnect(CoreStringName(changed), callable_mp(this, &TileMapEditorPlugin::_tile_map_layer_changed));
 		edited_layer->disconnect(SceneStringName(tree_exited), callable_mp(this, &TileMapEditorPlugin::_tile_map_layer_removed));

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -180,7 +180,7 @@ void PropertySelector::_update_search() {
 			Variant::construct(type, v, nullptr, 0, ce);
 			v.get_method_list(&methods);
 		} else {
-			Ref<Script> script_ref = Object::cast_to<Script>(ObjectDB::get_instance(script));
+			Ref<Script> script_ref = ObjectDB::get_ref<Script>(script);
 			if (script_ref.is_valid()) {
 				if (script_ref->is_built_in()) {
 					script_ref->reload(true);

--- a/modules/multiplayer/multiplayer_debugger.cpp
+++ b/modules/multiplayer/multiplayer_debugger.cpp
@@ -198,7 +198,7 @@ void MultiplayerDebugger::RPCProfiler::init_node(const ObjectID p_node) {
 	}
 	rpc_node_data.insert(p_node, RPCNodeInfo());
 	rpc_node_data[p_node].node = p_node;
-	rpc_node_data[p_node].node_path = Object::cast_to<Node>(ObjectDB::get_instance(p_node))->get_path();
+	rpc_node_data[p_node].node_path = ObjectDB::get_instance<Node>(p_node)->get_path();
 }
 
 void MultiplayerDebugger::RPCProfiler::toggle(bool p_enable, const Array &p_opts) {
@@ -304,7 +304,7 @@ void MultiplayerDebugger::ReplicationProfiler::add(const Array &p_data) {
 	const String what = p_data[0];
 	const ObjectID id = p_data[1];
 	const uint64_t size = p_data[2];
-	MultiplayerSynchronizer *sync = Object::cast_to<MultiplayerSynchronizer>(ObjectDB::get_instance(id));
+	MultiplayerSynchronizer *sync = ObjectDB::get_instance<MultiplayerSynchronizer>(id);
 	ERR_FAIL_NULL(sync);
 	if (!sync_data.has(id)) {
 		sync_data[id] = SyncInfo(sync);

--- a/modules/multiplayer/multiplayer_spawner.cpp
+++ b/modules/multiplayer/multiplayer_spawner.cpp
@@ -185,7 +185,7 @@ void MultiplayerSpawner::_update_spawn_node() {
 	}
 #endif
 	if (spawn_node.is_valid()) {
-		Node *node = Object::cast_to<Node>(ObjectDB::get_instance(spawn_node));
+		Node *node = ObjectDB::get_instance<Node>(spawn_node);
 		if (node && node->is_connected("child_entered_tree", callable_mp(this, &MultiplayerSpawner::_node_added))) {
 			node->disconnect("child_entered_tree", callable_mp(this, &MultiplayerSpawner::_node_added));
 		}
@@ -211,7 +211,7 @@ void MultiplayerSpawner::_notification(int p_what) {
 			_update_spawn_node();
 
 			for (const KeyValue<ObjectID, SpawnInfo> &E : tracked_nodes) {
-				Node *node = Object::cast_to<Node>(ObjectDB::get_instance(E.key));
+				Node *node = ObjectDB::get_instance<Node>(E.key);
 				ERR_CONTINUE(!node);
 				node->disconnect(SceneStringName(tree_exiting), callable_mp(this, &MultiplayerSpawner::_node_exit));
 				get_multiplayer()->object_configuration_remove(node, this);
@@ -265,7 +265,7 @@ void MultiplayerSpawner::_spawn_notify(ObjectID p_id) {
 }
 
 void MultiplayerSpawner::_node_exit(ObjectID p_id) {
-	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(p_id));
+	Node *node = ObjectDB::get_instance<Node>(p_id);
 	ERR_FAIL_NULL(node);
 	if (tracked_nodes.has(p_id)) {
 		tracked_nodes.erase(p_id);

--- a/modules/multiplayer/multiplayer_spawner.h
+++ b/modules/multiplayer/multiplayer_spawner.h
@@ -90,7 +90,7 @@ public:
 	PackedStringArray get_configuration_warnings() const override;
 
 	Node *get_spawn_node() const {
-		return spawn_node.is_valid() ? Object::cast_to<Node>(ObjectDB::get_instance(spawn_node)) : nullptr;
+		return spawn_node.is_valid() ? ObjectDB::get_instance<Node>(spawn_node) : nullptr;
 	}
 
 	void add_spawnable_scene(const String &p_path);

--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -100,7 +100,7 @@ void MultiplayerSynchronizer::_update_process() {
 }
 
 Node *MultiplayerSynchronizer::get_root_node() {
-	return root_node_cache.is_valid() ? Object::cast_to<Node>(ObjectDB::get_instance(root_node_cache)) : nullptr;
+	return root_node_cache.is_valid() ? ObjectDB::get_instance<Node>(root_node_cache) : nullptr;
 }
 
 void MultiplayerSynchronizer::reset() {

--- a/modules/multiplayer/scene_cache_interface.cpp
+++ b/modules/multiplayer/scene_cache_interface.cpp
@@ -154,7 +154,7 @@ void SceneCacheInterface::process_confirm_path(int p_from, const uint8_t *p_pack
 	}
 
 	if (valid_rpc_checksum == false) {
-		const Node *node = Object::cast_to<Node>(ObjectDB::get_instance(*oid));
+		const Node *node = ObjectDB::get_instance<Node>(*oid);
 		ERR_FAIL_NULL(node); // Bug.
 		ERR_PRINT("The rpc node checksum failed. Make sure to have the same methods on both nodes. Node path: " + node->get_path());
 	}
@@ -280,7 +280,7 @@ Object *SceneCacheInterface::get_cached_object(int p_from, uint32_t p_cache_id) 
 
 	RecvNode *recv_node = pinfo->recv_nodes.getptr(p_cache_id);
 	ERR_FAIL_NULL_V_MSG(recv_node, nullptr, vformat("ID %d not found in cache of peer %d.", p_cache_id, p_from));
-	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(recv_node->oid));
+	Node *node = ObjectDB::get_instance<Node>(recv_node->oid);
 	if (!node) {
 		// Fallback to path lookup.
 		Node *root_node = SceneTree::get_singleton()->get_root()->get_node(multiplayer->get_root_path());

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -113,7 +113,7 @@ private:
 
 	template <typename T>
 	static T *get_id_as(const ObjectID &p_id) {
-		return p_id.is_valid() ? Object::cast_to<T>(ObjectDB::get_instance(p_id)) : nullptr;
+		return p_id.is_valid() ? ObjectDB::get_instance<T>(p_id) : nullptr;
 	}
 
 #ifdef DEBUG_ENABLED

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -409,7 +409,7 @@ void CharacterBody2D::_set_collision_direction(const PhysicsServer2D::MotionResu
 		on_wall = true;
 		wall_normal = p_result.collision_normal;
 		// Don't apply wall velocity when the collider is a CharacterBody2D.
-		if (Object::cast_to<CharacterBody2D>(ObjectDB::get_instance(p_result.collider_id)) == nullptr) {
+		if (ObjectDB::get_instance<CharacterBody2D>(p_result.collider_id) == nullptr) {
 			_set_platform_data(p_result);
 		}
 	}

--- a/scene/2d/physics/kinematic_collision_2d.cpp
+++ b/scene/2d/physics/kinematic_collision_2d.cpp
@@ -58,7 +58,7 @@ real_t KinematicCollision2D::get_depth() const {
 }
 
 Object *KinematicCollision2D::get_local_shape() const {
-	PhysicsBody2D *owner = Object::cast_to<PhysicsBody2D>(ObjectDB::get_instance(owner_id));
+	PhysicsBody2D *owner = ObjectDB::get_instance<PhysicsBody2D>(owner_id);
 	if (!owner) {
 		return nullptr;
 	}

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -51,7 +51,7 @@ void RemoteTransform2D::_update_remote() {
 		return;
 	}
 
-	Node2D *n = Object::cast_to<Node2D>(ObjectDB::get_instance(cache));
+	Node2D *n = ObjectDB::get_instance<Node2D>(cache);
 	if (!n) {
 		return;
 	}
@@ -117,7 +117,7 @@ void RemoteTransform2D::_notification(int p_what) {
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
 			if (cache.is_valid()) {
 				_update_remote();
-				Node2D *n = Object::cast_to<Node2D>(ObjectDB::get_instance(cache));
+				Node2D *n = ObjectDB::get_instance<Node2D>(cache);
 				if (n) {
 					n->reset_physics_interpolation();
 				}

--- a/scene/2d/visible_on_screen_notifier_2d.cpp
+++ b/scene/2d/visible_on_screen_notifier_2d.cpp
@@ -187,7 +187,7 @@ NodePath VisibleOnScreenEnabler2D::get_enable_node_path() {
 }
 
 void VisibleOnScreenEnabler2D::_update_enable_mode(bool p_enable) {
-	Node *node = static_cast<Node *>(ObjectDB::get_instance(node_id));
+	Node *node = ObjectDB::get_instance<Node>(node_id);
 	if (node) {
 		if (p_enable) {
 			switch (enable_mode) {

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -37,7 +37,7 @@ void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
 		const Skeleton3D *parent = nullptr;
 		if (use_external_skeleton) {
 			if (external_skeleton_node_cache.is_valid()) {
-				parent = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(external_skeleton_node_cache));
+				parent = ObjectDB::get_instance<Skeleton3D>(external_skeleton_node_cache);
 			}
 		} else {
 			parent = Object::cast_to<Skeleton3D>(get_parent());
@@ -151,11 +151,11 @@ void BoneAttachment3D::_check_bind() {
 Skeleton3D *BoneAttachment3D::get_skeleton() {
 	if (use_external_skeleton) {
 		if (external_skeleton_node_cache.is_valid()) {
-			return Object::cast_to<Skeleton3D>(ObjectDB::get_instance(external_skeleton_node_cache));
+			return ObjectDB::get_instance<Skeleton3D>(external_skeleton_node_cache);
 		} else {
 			_update_external_skeleton_cache();
 			if (external_skeleton_node_cache.is_valid()) {
-				return Object::cast_to<Skeleton3D>(ObjectDB::get_instance(external_skeleton_node_cache));
+				return ObjectDB::get_instance<Skeleton3D>(external_skeleton_node_cache);
 			}
 		}
 	} else {
@@ -341,7 +341,7 @@ void BoneAttachment3D::notify_skeleton_bones_renamed(Node *p_base_scene, Skeleto
 	const Skeleton3D *parent = nullptr;
 	if (use_external_skeleton) {
 		if (external_skeleton_node_cache.is_valid()) {
-			parent = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(external_skeleton_node_cache));
+			parent = ObjectDB::get_instance<Skeleton3D>(external_skeleton_node_cache);
 		}
 	} else {
 		parent = Object::cast_to<Skeleton3D>(get_parent());

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -569,7 +569,7 @@ void CharacterBody3D::_set_collision_direction(const PhysicsServer3D::MotionResu
 			wall_normal = collision.normal;
 
 			// Don't apply wall velocity when the collider is a CharacterBody3D.
-			if (Object::cast_to<CharacterBody3D>(ObjectDB::get_instance(collision.collider_id)) == nullptr) {
+			if (ObjectDB::get_instance<CharacterBody3D>(collision.collider_id) == nullptr) {
 				_set_platform_data(collision);
 			}
 		}

--- a/scene/3d/physics/kinematic_collision_3d.cpp
+++ b/scene/3d/physics/kinematic_collision_3d.cpp
@@ -66,7 +66,7 @@ real_t KinematicCollision3D::get_angle(int p_collision_index, const Vector3 &p_u
 
 Object *KinematicCollision3D::get_local_shape(int p_collision_index) const {
 	ERR_FAIL_INDEX_V(p_collision_index, result.collision_count, nullptr);
-	PhysicsBody3D *owner = Object::cast_to<PhysicsBody3D>(ObjectDB::get_instance(owner_id));
+	PhysicsBody3D *owner = ObjectDB::get_instance<PhysicsBody3D>(owner_id);
 	if (!owner) {
 		return nullptr;
 	}

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -1056,7 +1056,7 @@ void PhysicalBone3D::_update_simulator_path() {
 }
 
 PhysicalBoneSimulator3D *PhysicalBone3D::get_simulator() const {
-	return Object::cast_to<PhysicalBoneSimulator3D>(ObjectDB::get_instance(simulator_id));
+	return ObjectDB::get_instance<PhysicalBoneSimulator3D>(simulator_id);
 }
 
 Skeleton3D *PhysicalBone3D::get_skeleton() const {

--- a/scene/3d/remote_transform_3d.cpp
+++ b/scene/3d/remote_transform_3d.cpp
@@ -51,7 +51,7 @@ void RemoteTransform3D::_update_remote() {
 		return;
 	}
 
-	Node3D *target_node = Object::cast_to<Node3D>(ObjectDB::get_instance(cache));
+	Node3D *target_node = ObjectDB::get_instance<Node3D>(cache);
 	if (!target_node) {
 		return;
 	}
@@ -108,7 +108,7 @@ void RemoteTransform3D::_notification(int p_what) {
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
 			if (cache.is_valid()) {
 				_update_remote();
-				Node3D *n = Object::cast_to<Node3D>(ObjectDB::get_instance(cache));
+				Node3D *n = ObjectDB::get_instance<Node3D>(cache);
 				if (n) {
 					n->reset_physics_interpolation();
 				}

--- a/scene/3d/retarget_modifier_3d.cpp
+++ b/scene/3d/retarget_modifier_3d.cpp
@@ -161,7 +161,7 @@ Vector<RetargetModifier3D::RetargetBoneInfo> RetargetModifier3D::cache_bone_rest
 
 void RetargetModifier3D::_update_child_skeleton_rests(int p_child_skeleton_idx) {
 	ERR_FAIL_INDEX(p_child_skeleton_idx, child_skeletons.size());
-	Skeleton3D *c = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(child_skeletons[p_child_skeleton_idx].skeleton_id));
+	Skeleton3D *c = ObjectDB::get_instance<Skeleton3D>(child_skeletons[p_child_skeleton_idx].skeleton_id);
 	if (!c) {
 		return;
 	}
@@ -192,7 +192,7 @@ void RetargetModifier3D::_update_child_skeletons() {
 
 void RetargetModifier3D::_reset_child_skeleton_poses() {
 	for (const RetargetInfo &E : child_skeletons) {
-		Skeleton3D *c = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(E.skeleton_id));
+		Skeleton3D *c = ObjectDB::get_instance<Skeleton3D>(E.skeleton_id);
 		if (!c) {
 			continue;
 		}
@@ -216,7 +216,7 @@ void RetargetModifier3D::_reset_child_skeletons() {
 #ifdef TOOLS_ENABLED
 void RetargetModifier3D::_force_update_child_skeletons() {
 	for (const RetargetInfo &E : child_skeletons) {
-		Skeleton3D *c = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(E.skeleton_id));
+		Skeleton3D *c = ObjectDB::get_instance<Skeleton3D>(E.skeleton_id);
 		if (!c) {
 			continue;
 		}
@@ -304,7 +304,7 @@ void RetargetModifier3D::_retarget_global_pose() {
 	}
 
 	for (const RetargetInfo &E : child_skeletons) {
-		Skeleton3D *target_skeleton = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(E.skeleton_id));
+		Skeleton3D *target_skeleton = ObjectDB::get_instance<Skeleton3D>(E.skeleton_id);
 		if (!target_skeleton) {
 			continue;
 		}
@@ -338,7 +338,7 @@ void RetargetModifier3D::_retarget_pose() {
 	}
 
 	for (const RetargetInfo &E : child_skeletons) {
-		Skeleton3D *target_skeleton = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(E.skeleton_id));
+		Skeleton3D *target_skeleton = ObjectDB::get_instance<Skeleton3D>(E.skeleton_id);
 		if (!target_skeleton) {
 			continue;
 		}

--- a/scene/3d/skeleton_modifier_3d.cpp
+++ b/scene/3d/skeleton_modifier_3d.cpp
@@ -45,7 +45,7 @@ PackedStringArray SkeletonModifier3D::get_configuration_warnings() const {
 /* Skeleton3D */
 
 Skeleton3D *SkeletonModifier3D::get_skeleton() const {
-	return Object::cast_to<Skeleton3D>(ObjectDB::get_instance(skeleton_id));
+	return ObjectDB::get_instance<Skeleton3D>(skeleton_id);
 }
 
 void SkeletonModifier3D::_update_skeleton_path() {

--- a/scene/3d/visible_on_screen_notifier_3d.cpp
+++ b/scene/3d/visible_on_screen_notifier_3d.cpp
@@ -144,7 +144,7 @@ NodePath VisibleOnScreenEnabler3D::get_enable_node_path() {
 }
 
 void VisibleOnScreenEnabler3D::_update_enable_mode(bool p_enable) {
-	Node *node = static_cast<Node *>(ObjectDB::get_instance(node_id));
+	Node *node = ObjectDB::get_instance<Node>(node_id);
 	if (node) {
 		if (p_enable) {
 			switch (enable_mode) {

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -997,7 +997,7 @@ Variant AnimationMixer::_post_process_key_value(const Ref<Animation> &p_anim, in
 	switch (p_anim->track_get_type(p_track)) {
 		case Animation::TYPE_POSITION_3D: {
 			if (p_object_sub_idx >= 0) {
-				Skeleton3D *skel = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(p_object_id));
+				Skeleton3D *skel = ObjectDB::get_instance<Skeleton3D>(p_object_id);
 				if (skel) {
 					return Vector3(p_value) * skel->get_motion_scale();
 				}
@@ -1867,7 +1867,7 @@ void AnimationMixer::_blend_apply() {
 					root_motion_rotation_accumulator = t->rot;
 					root_motion_scale_accumulator = t->scale;
 				} else if (t->skeleton_id.is_valid() && t->bone_idx >= 0) {
-					Skeleton3D *t_skeleton = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(t->skeleton_id));
+					Skeleton3D *t_skeleton = ObjectDB::get_instance<Skeleton3D>(t->skeleton_id);
 					if (!t_skeleton) {
 						return;
 					}
@@ -1882,7 +1882,7 @@ void AnimationMixer::_blend_apply() {
 					}
 
 				} else if (!t->skeleton_id.is_valid()) {
-					Node3D *t_node_3d = Object::cast_to<Node3D>(ObjectDB::get_instance(t->object_id));
+					Node3D *t_node_3d = ObjectDB::get_instance<Node3D>(t->object_id);
 					if (!t_node_3d) {
 						return;
 					}
@@ -1902,7 +1902,7 @@ void AnimationMixer::_blend_apply() {
 #ifndef _3D_DISABLED
 				TrackCacheBlendShape *t = static_cast<TrackCacheBlendShape *>(track);
 
-				MeshInstance3D *t_mesh_3d = Object::cast_to<MeshInstance3D>(ObjectDB::get_instance(t->object_id));
+				MeshInstance3D *t_mesh_3d = ObjectDB::get_instance<MeshInstance3D>(t->object_id);
 				if (t_mesh_3d) {
 					t_mesh_3d->set_blend_shape_value(t->shape_index, t->value);
 				}
@@ -2131,7 +2131,7 @@ void AnimationMixer::_build_backup_track_cache() {
 				if (t->root_motion) {
 					// Do nothing.
 				} else if (t->skeleton_id.is_valid() && t->bone_idx >= 0) {
-					Skeleton3D *t_skeleton = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(t->skeleton_id));
+					Skeleton3D *t_skeleton = ObjectDB::get_instance<Skeleton3D>(t->skeleton_id);
 					if (!t_skeleton) {
 						return;
 					}
@@ -2145,7 +2145,7 @@ void AnimationMixer::_build_backup_track_cache() {
 						t->scale = t_skeleton->get_bone_pose_scale(t->bone_idx);
 					}
 				} else if (!t->skeleton_id.is_valid()) {
-					Node3D *t_node_3d = Object::cast_to<Node3D>(ObjectDB::get_instance(t->object_id));
+					Node3D *t_node_3d = ObjectDB::get_instance<Node3D>(t->object_id);
 					if (!t_node_3d) {
 						return;
 					}
@@ -2164,7 +2164,7 @@ void AnimationMixer::_build_backup_track_cache() {
 			case Animation::TYPE_BLEND_SHAPE: {
 #ifndef _3D_DISABLED
 				TrackCacheBlendShape *t = static_cast<TrackCacheBlendShape *>(track);
-				MeshInstance3D *t_mesh_3d = Object::cast_to<MeshInstance3D>(ObjectDB::get_instance(t->object_id));
+				MeshInstance3D *t_mesh_3d = ObjectDB::get_instance<MeshInstance3D>(t->object_id);
 				if (t_mesh_3d) {
 					t->value = t_mesh_3d->get_blend_shape_value(t->shape_index);
 				}

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -63,7 +63,7 @@ void Tweener::start() {
 }
 
 Ref<Tween> Tweener::_get_tween() {
-	return Ref<Tween>(ObjectDB::get_instance(tween_id));
+	return ObjectDB::get_ref<Tween>(tween_id);
 }
 
 void Tweener::_finish() {
@@ -432,7 +432,7 @@ bool Tween::can_process(bool p_tree_paused) const {
 
 Node *Tween::get_bound_node() const {
 	if (is_bound) {
-		return Object::cast_to<Node>(ObjectDB::get_instance(bound_node));
+		return ObjectDB::get_instance<Node>(bound_node);
 	} else {
 		return nullptr;
 	}

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -331,7 +331,7 @@ Error SceneDebugger::parse_message(void *p_user, const String &p_msg, const Arra
 }
 
 void SceneDebugger::_save_node(ObjectID id, const String &p_path) {
-	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(id));
+	Node *node = ObjectDB::get_instance<Node>(id);
 	ERR_FAIL_NULL(node);
 
 #ifdef TOOLS_ENABLED
@@ -383,7 +383,7 @@ void SceneDebugger::_send_object_ids(const Vector<ObjectID> &p_ids, bool p_updat
 		}
 
 		if (p_update_selection) {
-			if (Node *node = Object::cast_to<Node>(ObjectDB::get_instance(id))) {
+			if (Node *node = ObjectDB::get_instance<Node>(id)) {
 				nodes.push_back(node);
 			}
 		}
@@ -1763,12 +1763,12 @@ void RuntimeNodeSelect::_send_ids(const Vector<Node *> &p_picked_nodes, bool p_i
 
 	for (ObjectID id : selected_ci_nodes) {
 		ids.push_back(id);
-		nodes.push_back(Object::cast_to<Node>(ObjectDB::get_instance(id)));
+		nodes.push_back(ObjectDB::get_instance<Node>(id));
 	}
 #ifndef _3D_DISABLED
 	for (const KeyValue<ObjectID, Ref<SelectionBox3D>> &KV : selected_3d_nodes) {
 		ids.push_back(KV.key);
-		nodes.push_back(Object::cast_to<Node>(ObjectDB::get_instance(KV.key)));
+		nodes.push_back(ObjectDB::get_instance<Node>(KV.key));
 	}
 #endif // _3D_DISABLED
 
@@ -1903,7 +1903,7 @@ void RuntimeNodeSelect::_update_selection() {
 
 	for (LocalVector<ObjectID>::Iterator E = selected_ci_nodes.begin(); E != selected_ci_nodes.end(); ++E) {
 		ObjectID id = *E;
-		CanvasItem *ci = Object::cast_to<CanvasItem>(ObjectDB::get_instance(id));
+		CanvasItem *ci = ObjectDB::get_instance<CanvasItem>(id);
 		if (!ci) {
 			selected_ci_nodes.erase(id);
 			--E;
@@ -1949,7 +1949,7 @@ void RuntimeNodeSelect::_update_selection() {
 #ifndef _3D_DISABLED
 	for (HashMap<ObjectID, Ref<SelectionBox3D>>::ConstIterator KV = selected_3d_nodes.begin(); KV != selected_3d_nodes.end(); ++KV) {
 		ObjectID id = KV->key;
-		Node3D *node_3d = Object::cast_to<Node3D>(ObjectDB::get_instance(id));
+		Node3D *node_3d = ObjectDB::get_instance<Node3D>(id);
 		if (!node_3d) {
 			selected_3d_nodes.erase(id);
 			--KV;

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -221,7 +221,7 @@ void MenuBar::bind_global_menu() {
 		for (int i = 0; i < count; i++) {
 			String tag = nmenu->get_item_tag(main_menu, i).operator String().get_slicec('#', 1);
 			if (!tag.is_empty() && tag != prev_tag) {
-				MenuBar *mb = Object::cast_to<MenuBar>(ObjectDB::get_instance(ObjectID(static_cast<uint64_t>(tag.to_int()))));
+				MenuBar *mb = ObjectDB::get_instance<MenuBar>(ObjectID(static_cast<uint64_t>(tag.to_int())));
 				if (mb && mb->get_start_index() >= start_index) {
 					global_start_idx = i;
 					break;
@@ -548,7 +548,7 @@ int MenuBar::get_menu_idx_from_control(PopupMenu *p_child) const {
 }
 
 void MenuBar::_popup_changed(ObjectID p_menu) {
-	PopupMenu *pm = Object::cast_to<PopupMenu>(ObjectDB::get_instance(p_menu));
+	PopupMenu *pm = ObjectDB::get_instance<PopupMenu>(p_menu);
 	if (!pm) {
 		return;
 	}

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -179,7 +179,7 @@ private:
 		RID rid;
 
 		void _clear_children() {
-			RichTextLabel *owner_rtl = Object::cast_to<RichTextLabel>(ObjectDB::get_instance(owner));
+			RichTextLabel *owner_rtl = ObjectDB::get_instance<RichTextLabel>(owner);
 			while (subitems.size()) {
 				Item *subitem = subitems.front()->get();
 				if (subitem && subitem->rid.is_valid() && owner_rtl) {
@@ -249,7 +249,7 @@ private:
 		ItemImage() { type = ITEM_IMAGE; }
 		~ItemImage() {
 			if (image.is_valid()) {
-				RichTextLabel *owner_rtl = Object::cast_to<RichTextLabel>(ObjectDB::get_instance(owner));
+				RichTextLabel *owner_rtl = ObjectDB::get_instance<RichTextLabel>(owner);
 				if (owner_rtl) {
 					image->disconnect_changed(callable_mp(owner_rtl, &RichTextLabel::_texture_changed));
 				}

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -951,7 +951,7 @@ void TabContainer::set_popup(Node *p_popup) {
 
 Popup *TabContainer::get_popup() const {
 	if (popup_obj_id.is_valid()) {
-		Popup *popup = Object::cast_to<Popup>(ObjectDB::get_instance(popup_obj_id));
+		Popup *popup = ObjectDB::get_instance<Popup>(popup_obj_id);
 		if (popup) {
 			return popup;
 		} else {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1338,7 +1338,7 @@ void SceneTree::_call_input_pause(const StringName &p_group, CallInputType p_cal
 		if (p_viewport->is_input_handled()) {
 			break;
 		}
-		Node *n = Object::cast_to<Node>(ObjectDB::get_instance(id));
+		Node *n = ObjectDB::get_instance<Node>(id);
 		if (n) {
 			n->_call_shortcut_input(p_input);
 		}
@@ -1508,7 +1508,7 @@ Node *SceneTree::get_current_scene() const {
 void SceneTree::_flush_scene_change() {
 	if (prev_scene_id.is_valid()) {
 		// Might have already been freed externally.
-		Node *prev_scene = Object::cast_to<Node>(ObjectDB::get_instance(prev_scene_id));
+		Node *prev_scene = ObjectDB::get_instance<Node>(prev_scene_id);
 		if (prev_scene) {
 			memdelete(prev_scene);
 		}
@@ -1516,7 +1516,7 @@ void SceneTree::_flush_scene_change() {
 	}
 
 	DEV_ASSERT(pending_new_scene_id.is_valid());
-	Node *pending_new_scene = Object::cast_to<Node>(ObjectDB::get_instance(pending_new_scene_id));
+	Node *pending_new_scene = ObjectDB::get_instance<Node>(pending_new_scene_id);
 	if (pending_new_scene) {
 		// Ensure correct state before `add_child` (might enqueue subsequent scene change).
 		current_scene = pending_new_scene;
@@ -1553,7 +1553,7 @@ Error SceneTree::change_scene_to_packed(const Ref<PackedScene> &p_scene) {
 
 	// If called again while a change is pending.
 	if (pending_new_scene_id.is_valid()) {
-		Node *pending_new_scene = Object::cast_to<Node>(ObjectDB::get_instance(pending_new_scene_id));
+		Node *pending_new_scene = ObjectDB::get_instance<Node>(pending_new_scene_id);
 		if (pending_new_scene) {
 			queue_delete(pending_new_scene);
 		}
@@ -2026,14 +2026,14 @@ SceneTree::SceneTree() {
 
 SceneTree::~SceneTree() {
 	if (prev_scene_id.is_valid()) {
-		Node *prev_scene = Object::cast_to<Node>(ObjectDB::get_instance(prev_scene_id));
+		Node *prev_scene = ObjectDB::get_instance<Node>(prev_scene_id);
 		if (prev_scene) {
 			memdelete(prev_scene);
 		}
 		prev_scene_id = ObjectID();
 	}
 	if (pending_new_scene_id.is_valid()) {
-		Node *pending_new_scene = Object::cast_to<Node>(ObjectDB::get_instance(pending_new_scene_id));
+		Node *pending_new_scene = ObjectDB::get_instance<Node>(pending_new_scene_id);
 		if (pending_new_scene) {
 			memdelete(pending_new_scene);
 		}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -905,7 +905,7 @@ void Viewport::_process_picking() {
 
 		CollisionObject3D *capture_object = nullptr;
 		if (physics_object_capture.is_valid()) {
-			capture_object = Object::cast_to<CollisionObject3D>(ObjectDB::get_instance(physics_object_capture));
+			capture_object = ObjectDB::get_instance<CollisionObject3D>(physics_object_capture);
 			if (!capture_object || !camera_3d || (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed())) {
 				physics_object_capture = ObjectID();
 			} else {
@@ -954,7 +954,7 @@ void Viewport::_process_picking() {
 
 					if (is_mouse && new_collider != physics_object_over) {
 						if (physics_object_over.is_valid()) {
-							CollisionObject3D *previous_co = Object::cast_to<CollisionObject3D>(ObjectDB::get_instance(physics_object_over));
+							CollisionObject3D *previous_co = ObjectDB::get_instance<CollisionObject3D>(physics_object_over);
 							if (previous_co) {
 								previous_co->_mouse_exit();
 							}
@@ -2090,7 +2090,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			}
 		} else {
 			ObjectID control_id = gui.touch_focus[touch_index];
-			Control *over = control_id.is_valid() ? Object::cast_to<Control>(ObjectDB::get_instance(control_id)) : nullptr;
+			Control *over = control_id.is_valid() ? ObjectDB::get_instance<Control>(control_id) : nullptr;
 			if (over && over->can_process()) {
 				touch_event = touch_event->xformed_by(Transform2D()); // Make a copy.
 				pos = over->get_global_transform_with_canvas().affine_inverse().xform(pos);
@@ -2125,7 +2125,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 	if (drag_event.is_valid()) {
 		const int drag_event_index = drag_event->get_index();
 		ObjectID control_id = gui.touch_focus[drag_event_index];
-		Control *over = control_id.is_valid() ? Object::cast_to<Control>(ObjectDB::get_instance(control_id)) : nullptr;
+		Control *over = control_id.is_valid() ? ObjectDB::get_instance<Control>(control_id) : nullptr;
 		if (!over) {
 			over = gui_find_control(drag_event->get_position());
 		}
@@ -2329,7 +2329,7 @@ Control *Viewport::_gui_get_drag_preview() {
 	if (gui.drag_preview_id.is_null()) {
 		return nullptr;
 	} else {
-		Control *drag_preview = Object::cast_to<Control>(ObjectDB::get_instance(gui.drag_preview_id));
+		Control *drag_preview = ObjectDB::get_instance<Control>(gui.drag_preview_id);
 		if (!drag_preview) {
 			ERR_PRINT("Don't free the control set as drag preview.");
 			gui.drag_preview_id = ObjectID();
@@ -2559,7 +2559,7 @@ void Viewport::_drop_physics_mouseover(bool p_paused_only) {
 
 #ifndef _3D_DISABLED
 	if (physics_object_over.is_valid()) {
-		CollisionObject3D *co = Object::cast_to<CollisionObject3D>(ObjectDB::get_instance(physics_object_over));
+		CollisionObject3D *co = ObjectDB::get_instance<CollisionObject3D>(physics_object_over);
 		if (co) {
 			if (!co->is_inside_tree()) {
 				physics_object_over = ObjectID();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -275,7 +275,7 @@ Window *Window::get_from_id(DisplayServer::WindowID p_window_id) {
 	if (p_window_id == DisplayServer::INVALID_WINDOW_ID) {
 		return nullptr;
 	}
-	return Object::cast_to<Window>(ObjectDB::get_instance(DisplayServer::get_singleton()->window_get_attached_instance_id(p_window_id)));
+	return ObjectDB::get_instance<Window>(DisplayServer::get_singleton()->window_get_attached_instance_id(p_window_id));
 }
 
 void Window::set_title(const String &p_title) {

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_ccdik.cpp
@@ -171,13 +171,13 @@ void SkeletonModification2DCCDIK::_execute(float p_delta) {
 		return;
 	}
 
-	Node2D *target = Object::cast_to<Node2D>(ObjectDB::get_instance(target_node_cache));
+	Node2D *target = ObjectDB::get_instance<Node2D>(target_node_cache);
 	if (!target || !target->is_inside_tree()) {
 		ERR_PRINT_ONCE("Target node is not in the scene tree. Cannot execute modification!");
 		return;
 	}
 
-	Node2D *tip = Object::cast_to<Node2D>(ObjectDB::get_instance(tip_node_cache));
+	Node2D *tip = ObjectDB::get_instance<Node2D>(tip_node_cache);
 	if (!tip || !tip->is_inside_tree()) {
 		ERR_PRINT_ONCE("Tip node is not in the scene tree. Cannot execute modification!");
 		return;

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_fabrik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_fabrik.cpp
@@ -116,7 +116,7 @@ void SkeletonModification2DFABRIK::_execute(float p_delta) {
 		return;
 	}
 
-	Node2D *target = Object::cast_to<Node2D>(ObjectDB::get_instance(target_node_cache));
+	Node2D *target = ObjectDB::get_instance<Node2D>(target_node_cache);
 	if (!target || !target->is_inside_tree()) {
 		ERR_PRINT_ONCE("Target node is not in the scene tree. Cannot execute modification!");
 		return;
@@ -128,7 +128,7 @@ void SkeletonModification2DFABRIK::_execute(float p_delta) {
 		WARN_PRINT("Bone2D cache for origin joint is out of date. Updating...");
 	}
 
-	Bone2D *origin_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[0].bone2d_node_cache));
+	Bone2D *origin_bone2d_node = ObjectDB::get_instance<Bone2D>(fabrik_data_chain[0].bone2d_node_cache);
 	if (!origin_bone2d_node || !origin_bone2d_node->is_inside_tree()) {
 		ERR_PRINT_ONCE("Origin joint's Bone2D node is not in the scene tree. Cannot execute modification!");
 		return;
@@ -146,7 +146,7 @@ void SkeletonModification2DFABRIK::_execute(float p_delta) {
 			WARN_PRINT_ONCE("Bone2D cache for joint " + itos(i) + " is out of date.. Attempting to update...");
 			fabrik_joint_update_bone2d_cache(i);
 		}
-		Bone2D *joint_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[i].bone2d_node_cache));
+		Bone2D *joint_bone2d_node = ObjectDB::get_instance<Bone2D>(fabrik_data_chain[i].bone2d_node_cache);
 		if (!joint_bone2d_node) {
 			ERR_PRINT_ONCE("FABRIK Joint " + itos(i) + " does not have a Bone2D node set! Cannot execute modification!");
 			return;
@@ -154,7 +154,7 @@ void SkeletonModification2DFABRIK::_execute(float p_delta) {
 		fabrik_transform_chain.write[i] = joint_bone2d_node->get_global_transform();
 	}
 
-	Bone2D *final_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[fabrik_data_chain.size() - 1].bone2d_node_cache));
+	Bone2D *final_bone2d_node = ObjectDB::get_instance<Bone2D>(fabrik_data_chain[fabrik_data_chain.size() - 1].bone2d_node_cache);
 	float final_bone2d_angle = final_bone2d_node->get_global_rotation();
 	if (fabrik_data_chain[fabrik_data_chain.size() - 1].use_target_rotation) {
 		final_bone2d_angle = target_global_pose.get_rotation();
@@ -183,7 +183,7 @@ void SkeletonModification2DFABRIK::_execute(float p_delta) {
 
 	// Apply all of the saved transforms to the Bone2D nodes
 	for (int i = 0; i < fabrik_data_chain.size(); i++) {
-		Bone2D *joint_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[i].bone2d_node_cache));
+		Bone2D *joint_bone2d_node = ObjectDB::get_instance<Bone2D>(fabrik_data_chain[i].bone2d_node_cache);
 		if (!joint_bone2d_node) {
 			ERR_PRINT_ONCE("FABRIK Joint " + itos(i) + " does not have a Bone2D node set!");
 			continue;
@@ -214,7 +214,7 @@ void SkeletonModification2DFABRIK::_execute(float p_delta) {
 
 void SkeletonModification2DFABRIK::chain_backwards() {
 	int final_joint_index = fabrik_data_chain.size() - 1;
-	Bone2D *final_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[final_joint_index].bone2d_node_cache));
+	Bone2D *final_bone2d_node = ObjectDB::get_instance<Bone2D>(fabrik_data_chain[final_joint_index].bone2d_node_cache);
 	Transform2D final_bone2d_trans = fabrik_transform_chain[final_joint_index];
 
 	// Apply magnet position
@@ -241,7 +241,7 @@ void SkeletonModification2DFABRIK::chain_backwards() {
 	while (i >= 1) {
 		Transform2D previous_pose = fabrik_transform_chain[i];
 		i -= 1;
-		Bone2D *current_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[i].bone2d_node_cache));
+		Bone2D *current_bone2d_node = ObjectDB::get_instance<Bone2D>(fabrik_data_chain[i].bone2d_node_cache);
 		Transform2D current_pose = fabrik_transform_chain[i];
 
 		// Apply magnet position
@@ -266,7 +266,7 @@ void SkeletonModification2DFABRIK::chain_forwards() {
 	fabrik_transform_chain.write[0] = origin_bone2d_trans;
 
 	for (int i = 0; i < fabrik_data_chain.size() - 1; i++) {
-		Bone2D *current_bone2d_node = Object::cast_to<Bone2D>(ObjectDB::get_instance(fabrik_data_chain[i].bone2d_node_cache));
+		Bone2D *current_bone2d_node = ObjectDB::get_instance<Bone2D>(fabrik_data_chain[i].bone2d_node_cache);
 		Transform2D current_pose = fabrik_transform_chain[i];
 		Transform2D next_pose = fabrik_transform_chain[i + 1];
 

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_jiggle.cpp
@@ -143,7 +143,7 @@ void SkeletonModification2DJiggle::_execute(float p_delta) {
 		update_target_cache();
 		return;
 	}
-	Node2D *target = Object::cast_to<Node2D>(ObjectDB::get_instance(target_node_cache));
+	Node2D *target = ObjectDB::get_instance<Node2D>(target_node_cache);
 	if (!target || !target->is_inside_tree()) {
 		ERR_PRINT_ONCE("Target node is not in the scene tree. Cannot execute modification!");
 		return;

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_lookat.cpp
@@ -124,7 +124,7 @@ void SkeletonModification2DLookAt::_execute(float p_delta) {
 	}
 
 	if (target_node_reference == nullptr) {
-		target_node_reference = Object::cast_to<Node2D>(ObjectDB::get_instance(target_node_cache));
+		target_node_reference = ObjectDB::get_instance<Node2D>(target_node_cache);
 	}
 	if (!target_node_reference || !target_node_reference->is_inside_tree()) {
 		ERR_PRINT_ONCE("Target node is not in the scene tree. Cannot execute modification!");

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_physicalbones.cpp
@@ -118,7 +118,7 @@ void SkeletonModification2DPhysicalBones::_execute(float p_delta) {
 			continue;
 		}
 
-		PhysicalBone2D *physical_bone = Object::cast_to<PhysicalBone2D>(ObjectDB::get_instance(bone_data.physical_bone_node_cache));
+		PhysicalBone2D *physical_bone = ObjectDB::get_instance<PhysicalBone2D>(bone_data.physical_bone_node_cache);
 		if (!physical_bone) {
 			ERR_PRINT_ONCE("PhysicalBone2D not found at index " + itos(i) + "!");
 			return;
@@ -249,7 +249,7 @@ void SkeletonModification2DPhysicalBones::_update_simulation_state() {
 		}
 	} else {
 		for (int i = 0; i < physical_bone_chain.size(); i++) {
-			PhysicalBone2D *physical_bone = Object::cast_to<PhysicalBone2D>(ObjectDB::get_instance(physical_bone_chain[i].physical_bone_node_cache));
+			PhysicalBone2D *physical_bone = ObjectDB::get_instance<PhysicalBone2D>(physical_bone_chain[i].physical_bone_node_cache);
 			if (!physical_bone) {
 				continue;
 			}

--- a/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_2d_twoboneik.cpp
@@ -124,7 +124,7 @@ void SkeletonModification2DTwoBoneIK::_execute(float p_delta) {
 		update_joint_two_bone2d_cache();
 	}
 
-	Node2D *target = Object::cast_to<Node2D>(ObjectDB::get_instance(target_node_cache));
+	Node2D *target = ObjectDB::get_instance<Node2D>(target_node_cache);
 	if (!target || !target->is_inside_tree()) {
 		ERR_PRINT_ONCE("Target node is not in the scene tree. Cannot execute modification!");
 		return;
@@ -235,7 +235,7 @@ void SkeletonModification2DTwoBoneIK::_draw_editor_gizmo() {
 				Vector2 target_direction = Vector2(0, 1);
 				if (target_node_cache.is_valid()) {
 					stack->skeleton->draw_set_transform(Vector2(0, 0), 0.0);
-					Node2D *target = Object::cast_to<Node2D>(ObjectDB::get_instance(target_node_cache));
+					Node2D *target = ObjectDB::get_instance<Node2D>(target_node_cache);
 					target_direction = operation_bone_one->get_global_position().direction_to(target->get_global_position());
 				}
 

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -521,7 +521,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 
 	for (const DeferredNodePathProperties &dnp : deferred_node_paths) {
 		// Replace properties stored as NodePaths with actual Nodes.
-		Node *base = Object::cast_to<Node>(ObjectDB::get_instance(dnp.base));
+		Node *base = ObjectDB::get_instance<Node>(dnp.base);
 		ERR_CONTINUE_EDMSG(!base, vformat("Failed to set deferred property '%s' as the base node disappeared.", dnp.property));
 		if (dnp.value.get_type() == Variant::ARRAY) {
 			Array paths = dnp.value;


### PR DESCRIPTION
Adds 2 helper to ObjectID:
- `object_id.get_object<Type>()`, equivalent of `Object::cast_to<Type>(ObjectDB::get_instance(object_id))`
- `object_id.get_ref<Type>()`, equivalent of `Ref<Type>(ObjectDB::get_instance(object_id))`

Makes it easier to get specific type from ObjectID.