### PR TITLE
[3.x] Simplify `ObjectDB::get_instance()` casting

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -2036,6 +2036,7 @@ void ObjectDB::remove_instance(Object *p_object) {
 
 	rw_lock.write_unlock();
 }
+
 Object *ObjectDB::get_instance(ObjectID p_instance_id) {
 	rw_lock.read_lock();
 	Object **obj = instances.getptr(p_instance_id);

--- a/core/object.h
+++ b/core/object.h
@@ -798,6 +798,12 @@ public:
 	typedef void (*DebugFunc)(Object *p_obj);
 
 	static Object *get_instance(ObjectID p_instance_id);
+
+	template <class T>
+	static T *get_instance(ObjectID p_instance_id) {
+		return Object::cast_to<T>(get_instance(p_instance_id));
+	}
+
 	static void debug_objects(DebugFunc p_func);
 	static int get_object_count();
 


### PR DESCRIPTION
Reduces boiler plate by templating `get_instance()` for the cast type, while remaining backward compatible to the existing functionality.

Alternative 3.x method to #100602 

The approach:
```
Spatial * my_obj = Object::cast_to<Spatial>(ObjectDB::get_instance(object_id));
```
now becomes:
```
Spatial * my_obj = ObjectDB::get_instance<Spatial>(object_id);
```

## Notes
* @KoBeWi noted today that the boiler plate for getting instances and then casting was excessive so we brainstormed a few alternatives.
* Added this simple PR for discussion as there are at least 2 alternatives available for 3.x (see later).
* This is just the implementation, it would need another PR to change existing code to take advantage, so leaving that until any decisions are made.
* Specialization is left for the old version, so that there will be no cost for casting when not being requested (i.e. the backward compatible code has no cost).

## Discussion
In 4.x, `ObjectID` is a class so it made some sense to add a method to that class.
In 3.x, `ObjectID` is a typedefed `uint64_t`.

There was thus a choice for 3.x:
* Utilize the existing `ObjectDB` (as in this PR)
* Create a `uint64_t` compatible class as in 4.x and add a similar function to #100602 (_if this is indeed possible, as it has to be backward compatible_)

This approach is simpler, however changing `ObjectID` in 3.x to a class may offer the ability to offer more compatibility between both, in terms of back / forward porting. Compatibility may be the clincher in this case.

For reference, the other method uses the form:
```
Spatial * my_obj = object_id.get_object<Spatial>;
```

## Update
Based on tests so far, I'm not 100% sure yet we can replace the `ObjectID` typedef to `uint64_t` in 3.x with a class (as in 4.x) without breaking backward compatibility, I'm getting a lot of ambiguous conversion problems.

I think we can fix it to work in the engine, but if the above is true, third party modules might need changes to work with that approach, making it less favourable.

This does swing things in favour of not changing `ObjectID` and using this PRs approach.

It does suggest that the changes in #100602 might make cherry picking etc more involved, so I'll note that on that PR. For forward porting, we could easily add change as in this PR to 4.x, but it is unlikely to be necessary, as the small amount of forward ports could be changed manually without much work.

It sounds likely that 3.x and 4.x may diverge on this anyway, if #100602 is merged.

Another alternative is to use a similar macro in both, rather than a function:
e.g.:
```
Spatial * my_obj = GD_GET_OBJECT(object_id, Spatial);
```
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
