### PR TITLE
[BVH precision] Make 3D physics use precision-proof version of `BVH::ray_query()`

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -122,7 +122,7 @@ AABB AABB::intersection(const AABB &p_aabb) const {
 // The caller can therefore decide when INSIDE whether to use the
 // backtracked intersection, or use p_from as the intersection, and
 // carry on progressing without e.g. reflecting against the normal.
-bool AABB::find_intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, bool &r_inside, Vector3 *r_intersection_point, Vector3 *r_normal) const {
+bool AABB::find_intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, bool &r_inside, Vector3 *r_intersection_point, Vector3 *r_normal, real_t p_max_distance) const {
 #ifdef MATH_CHECKS
 	if (unlikely(size.x < 0 || size.y < 0 || size.z < 0)) {
 		ERR_PRINT("AABB size is negative, this is not supported. Use AABB.abs() to get an AABB with a positive size.");
@@ -159,7 +159,7 @@ bool AABB::find_intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, bool
 				}
 				tmax = t2;
 			}
-			if (tmin > tmax) {
+			if (tmin > tmax || (p_max_distance > 0 && tmin > p_max_distance)) {
 				return false;
 			}
 		}
@@ -180,71 +180,6 @@ bool AABB::find_intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, bool
 	if (r_normal) {
 		*r_normal = Vector3();
 		(*r_normal)[axis] = (p_dir[axis] >= 0) ? -1 : 1;
-	}
-
-	return true;
-}
-
-bool AABB::intersects_segment(const Vector3 &p_from, const Vector3 &p_to, Vector3 *r_intersection_point, Vector3 *r_normal) const {
-#ifdef MATH_CHECKS
-	if (unlikely(size.x < 0 || size.y < 0 || size.z < 0)) {
-		ERR_PRINT("AABB size is negative, this is not supported. Use AABB.abs() to get an AABB with a positive size.");
-	}
-#endif
-	real_t min = 0, max = 1;
-	int axis = 0;
-	real_t sign = 0;
-
-	for (int i = 0; i < 3; i++) {
-		real_t seg_from = p_from[i];
-		real_t seg_to = p_to[i];
-		real_t box_begin = position[i];
-		real_t box_end = box_begin + size[i];
-		real_t cmin, cmax;
-		real_t csign;
-
-		if (seg_from < seg_to) {
-			if (seg_from > box_end || seg_to < box_begin) {
-				return false;
-			}
-			real_t length = seg_to - seg_from;
-			cmin = (seg_from < box_begin) ? ((box_begin - seg_from) / length) : 0;
-			cmax = (seg_to > box_end) ? ((box_end - seg_from) / length) : 1;
-			csign = -1.0;
-
-		} else {
-			if (seg_to > box_end || seg_from < box_begin) {
-				return false;
-			}
-			real_t length = seg_to - seg_from;
-			cmin = (seg_from > box_end) ? (box_end - seg_from) / length : 0;
-			cmax = (seg_to < box_begin) ? (box_begin - seg_from) / length : 1;
-			csign = 1.0;
-		}
-
-		if (cmin > min) {
-			min = cmin;
-			axis = i;
-			sign = csign;
-		}
-		if (cmax < max) {
-			max = cmax;
-		}
-		if (max < min) {
-			return false;
-		}
-	}
-
-	Vector3 rel = p_to - p_from;
-
-	if (r_normal) {
-		Vector3 normal;
-		normal[axis] = sign;
-		*r_normal = normal;
-	}
-
-	if (r_intersection_point) {
-		*r_intersection_point = p_from + rel * min;
 	}
 
 	return true;

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -73,12 +73,27 @@ struct [[nodiscard]] AABB {
 	AABB intersection(const AABB &p_aabb) const; ///get box where two intersect, empty if no intersection occurs
 	_FORCE_INLINE_ bool smits_intersect_ray(const Vector3 &p_from, const Vector3 &p_dir, real_t p_t0, real_t p_t1) const;
 
-	bool intersects_segment(const Vector3 &p_from, const Vector3 &p_to, Vector3 *r_intersection_point = nullptr, Vector3 *r_normal = nullptr) const;
+	bool intersects_segment(const Vector3 &p_from, const Vector3 &p_to, Vector3 *r_intersection_point = nullptr, Vector3 *r_normal = nullptr) const {
+		Vector3 segment = p_to - p_from;
+		real_t length = segment.length();
+		Vector3 ray = Math::is_equal_approx(length, 0) ? Vector3() : segment / length;
+		bool inside;
+		bool inter = find_intersects_ray(p_from, ray, inside, r_intersection_point, r_normal, length);
+		if (inter && inside) {
+			if (r_intersection_point != nullptr) {
+				*r_intersection_point = p_from;
+			}
+			if (r_normal != nullptr) {
+				*r_normal = Vector3();
+			}
+		}
+		return inter;
+	}
 	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir) const {
 		bool inside;
 		return find_intersects_ray(p_from, p_dir, inside);
 	}
-	bool find_intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, bool &r_inside, Vector3 *r_intersection_point = nullptr, Vector3 *r_normal = nullptr) const;
+	bool find_intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, bool &r_inside, Vector3 *r_intersection_point = nullptr, Vector3 *r_normal = nullptr, real_t p_max_distance = 0) const;
 
 	_FORCE_INLINE_ bool intersects_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count) const;
 	_FORCE_INLINE_ bool inside_convex_shape(const Plane *p_planes, int p_plane_count) const;

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -310,7 +310,7 @@ public:
 	template <typename QueryResult>
 	_FORCE_INLINE_ void convex_query(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, QueryResult &r_result);
 	template <typename QueryResult>
-	_FORCE_INLINE_ void ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResult &r_result);
+	_FORCE_INLINE_ void ray_query(const Vector3 &p_from, const Vector3 &p_dir, real_t p_length, QueryResult &r_result);
 
 	void set_index(uint32_t p_index);
 	uint32_t get_index() const;
@@ -416,13 +416,12 @@ void DynamicBVH::convex_query(const Plane *p_planes, int p_plane_count, const Ve
 	} while (depth > 0);
 }
 template <typename QueryResult>
-void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResult &r_result) {
+void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_dir, real_t p_length, QueryResult &r_result) {
 	if (!bvh_root) {
 		return;
 	}
 
-	Vector3 ray_dir = (p_to - p_from);
-	ray_dir.normalize();
+	Vector3 ray_dir = p_dir;
 
 	///what about division by zero? --> just set rayDirection[i] to INF/B3_LARGE_FLOAT
 	Vector3 inv_dir;
@@ -431,7 +430,7 @@ void DynamicBVH::ray_query(const Vector3 &p_from, const Vector3 &p_to, QueryResu
 	inv_dir[2] = ray_dir[2] == real_t(0.0) ? real_t(1e20) : real_t(1.0) / ray_dir[2];
 	unsigned int signs[3] = { inv_dir[0] < 0.0, inv_dir[1] < 0.0, inv_dir[2] < 0.0 };
 
-	real_t lambda_max = ray_dir.dot(p_to - p_from);
+	real_t lambda_max = p_length;
 
 	Vector3 bounds[2];
 

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -94,7 +94,7 @@ bool Plane::intersect_3(const Plane &p_plane1, const Plane &p_plane2, Vector3 *r
 	return true;
 }
 
-bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection) const {
+bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection, real_t max_distance) const {
 	Vector3 segment = p_dir;
 	real_t den = normal.dot(segment);
 
@@ -104,8 +104,7 @@ bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 
 
 	real_t dist = (normal.dot(p_from) - d) / den;
 
-	if (dist > (real_t)CMP_EPSILON) { //this is a ray, before the emitting pos (p_from) doesn't exist
-
+	if (dist > (real_t)CMP_EPSILON || (max_distance > 0 && dist < -max_distance)) {
 		return false;
 	}
 
@@ -116,23 +115,9 @@ bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 
 }
 
 bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 *p_intersection) const {
-	Vector3 segment = p_begin - p_end;
-	real_t den = normal.dot(segment);
-
-	if (Math::is_zero_approx(den)) {
-		return false;
-	}
-
-	real_t dist = (normal.dot(p_begin) - d) / den;
-
-	if (dist < (real_t)-CMP_EPSILON || dist > (1.0f + (real_t)CMP_EPSILON)) {
-		return false;
-	}
-
-	dist = -dist;
-	*p_intersection = p_begin + segment * dist;
-
-	return true;
+	Vector3 segment = p_end - p_begin;
+	real_t length = segment.length();
+	return intersects_ray(p_begin, segment / length, p_intersection, length);
 }
 
 Variant Plane::intersect_3_bind(const Plane &p_plane1, const Plane &p_plane2) const {

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -57,7 +57,7 @@ struct [[nodiscard]] Plane {
 	/* intersections */
 
 	bool intersect_3(const Plane &p_plane1, const Plane &p_plane2, Vector3 *r_result = nullptr) const;
-	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection) const;
+	bool intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 *p_intersection, real_t max_distance = 0) const;
 	bool intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 *p_intersection) const;
 
 	// For Variant bindings.

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -9579,7 +9579,9 @@ Vector<Node3D *> Node3DEditor::gizmo_bvh_ray_query(const Vector3 &p_ray_start, c
 		}
 	} result;
 
-	gizmo_bvh.ray_query(p_ray_start, p_ray_end, result);
+	Vector3 segment = p_ray_end - p_ray_start;
+	real_t length = segment.length();
+	gizmo_bvh.ray_query(p_ray_start, segment / length, length, result);
 
 	return result.nodes;
 }

--- a/modules/godot_physics_3d/godot_body_pair_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_pair_3d.cpp
@@ -211,7 +211,6 @@ bool GodotBodyPair3D::_test_ccd(real_t p_step, GodotBody3D *p_A, int p_shape_A, 
 		supports_A[i] = p_xform_A.xform(supports_A[i]);
 
 		Vector3 from = supports_A[i];
-		Vector3 to = from + motion;
 
 		Transform3D from_inv = predicted_xform_B.affine_inverse();
 
@@ -219,11 +218,12 @@ bool GodotBodyPair3D::_test_ccd(real_t p_step, GodotBody3D *p_A, int p_shape_A, 
 		// At high speeds, this may mean we're actually casting from well behind the body instead of inside it, which is odd.
 		// But it still works out.
 		Vector3 local_from = from_inv.xform(from - motion * 0.1);
-		Vector3 local_to = from_inv.xform(to);
+		Vector3 local_motion = predicted_xform_B.basis.transposed().xform(motion * 1.1);
+		real_t local_motion_length = local_motion.length();
 
 		Vector3 rpos, rnorm;
 		int fi = -1;
-		if (p_B->get_shape(p_shape_B)->intersect_segment(local_from, local_to, rpos, rnorm, fi, true)) {
+		if (p_B->get_shape(p_shape_B)->intersect_segment(local_from, local_motion / local_motion_length, local_motion_length, rpos, rnorm, fi, true)) {
 			float hit_length = local_from.distance_to(rpos);
 			if (hit_length < segment_hit_length) {
 				segment_support_idx = i;

--- a/modules/godot_physics_3d/godot_shape_3d.h
+++ b/modules/godot_physics_3d/godot_shape_3d.h
@@ -80,7 +80,7 @@ public:
 	virtual Vector3 get_support(const Vector3 &p_normal) const;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const = 0;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const = 0;
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_point, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const = 0;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_point, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const = 0;
 	virtual bool intersect_point(const Vector3 &p_point) const = 0;
 	virtual Vector3 get_moment_of_inertia(real_t p_mass) const = 0;
 
@@ -126,7 +126,7 @@ public:
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override { r_amount = 0; }
 
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 	virtual Vector3 get_moment_of_inertia(real_t p_mass) const override;
@@ -153,7 +153,7 @@ public:
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override;
 
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 
@@ -180,7 +180,7 @@ public:
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override;
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 
@@ -205,7 +205,7 @@ public:
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override;
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 
@@ -234,7 +234,7 @@ public:
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override;
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 
@@ -263,7 +263,7 @@ public:
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override;
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 
@@ -290,7 +290,7 @@ public:
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override;
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 
@@ -338,7 +338,7 @@ struct GodotConcavePolygonShape3D : public GodotConcaveShape3D {
 
 	struct _SegmentCullParams {
 		Vector3 from;
-		Vector3 to;
+		real_t dist;
 		Vector3 dir;
 		const Face *faces = nullptr;
 		const Vector3 *vertices = nullptr;
@@ -369,7 +369,7 @@ public:
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 
@@ -419,7 +419,7 @@ struct GodotHeightMapShape3D : public GodotConcaveShape3D {
 	void _build_accelerator();
 
 	template <typename ProcessFunction>
-	bool _intersect_grid_segment(ProcessFunction &p_process, const Vector3 &p_begin, const Vector3 &p_end, int p_width, int p_depth, const Vector3 &offset, Vector3 &r_point, Vector3 &r_normal) const;
+	bool _intersect_grid_segment(ProcessFunction &p_process, const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, int p_width, int p_depth, const Vector3 &offset, Vector3 &r_point, Vector3 &r_normal) const;
 
 	void _setup(const Vector<real_t> &p_heights, int p_width, int p_depth, real_t p_min_height, real_t p_max_height);
 
@@ -432,7 +432,7 @@ public:
 
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_point, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_point, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
@@ -460,7 +460,7 @@ struct GodotFaceShape3D : public GodotShape3D {
 	virtual void project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const override;
 	virtual Vector3 get_support(const Vector3 &p_normal) const override;
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override;
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 
@@ -499,7 +499,7 @@ struct GodotMotionShape3D : public GodotShape3D {
 	}
 
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override { r_amount = 0; }
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override { return false; }
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override { return false; }
 	virtual bool intersect_point(const Vector3 &p_point) const override { return false; }
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override { return p_point; }
 

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -1153,7 +1153,9 @@ void GodotSoftBody3D::query_ray(const Vector3 &p_from, const Vector3 &p_to, Godo
 	query_result.result_callback = p_result_callback;
 	query_result.userdata = p_userdata;
 
-	face_tree.ray_query(p_from, p_to, query_result);
+	Vector3 segment = p_to - p_from;
+	real_t length = segment.length();
+	face_tree.ray_query(p_from, segment / length, length, query_result);
 }
 
 void GodotSoftBody3D::initialize_face_tree() {

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -1143,7 +1143,7 @@ struct RayQueryResult {
 	}
 };
 
-void GodotSoftBody3D::query_ray(const Vector3 &p_from, const Vector3 &p_to, GodotSoftBody3D::QueryResultCallback p_result_callback, void *p_userdata) {
+void GodotSoftBody3D::query_ray(const Vector3 &p_from, const Vector3 &p_dir, real_t p_dist, GodotSoftBody3D::QueryResultCallback p_result_callback, void *p_userdata) {
 	if (face_tree.is_empty()) {
 		initialize_face_tree();
 	}
@@ -1153,9 +1153,7 @@ void GodotSoftBody3D::query_ray(const Vector3 &p_from, const Vector3 &p_to, Godo
 	query_result.result_callback = p_result_callback;
 	query_result.userdata = p_userdata;
 
-	Vector3 segment = p_to - p_from;
-	real_t length = segment.length();
-	face_tree.ray_query(p_from, segment / length, length, query_result);
+	face_tree.ray_query(p_from, p_dir, p_dist, query_result);
 }
 
 void GodotSoftBody3D::initialize_face_tree() {
@@ -1271,13 +1269,13 @@ struct _SoftBodyIntersectSegmentInfo {
 	}
 };
 
-bool GodotSoftBodyShape3D::intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const {
+bool GodotSoftBodyShape3D::intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const {
 	_SoftBodyIntersectSegmentInfo query_info;
 	query_info.soft_body = soft_body;
 	query_info.from = p_begin;
-	query_info.dir = (p_end - p_begin).normalized();
+	query_info.dir = p_dir;
 
-	soft_body->query_ray(p_begin, p_end, _SoftBodyIntersectSegmentInfo::process_hit, &query_info);
+	soft_body->query_ray(p_begin, p_dir, p_dist, _SoftBodyIntersectSegmentInfo::process_hit, &query_info);
 
 	if (query_info.hit_dist_sq != INFINITY) {
 		r_result = query_info.hit_position;

--- a/modules/godot_physics_3d/godot_soft_body_3d.h
+++ b/modules/godot_physics_3d/godot_soft_body_3d.h
@@ -212,7 +212,7 @@ public:
 	typedef bool (*QueryResultCallback)(uint32_t p_index, void *p_userdata);
 
 	void query_aabb(const AABB &p_aabb, QueryResultCallback p_result_callback, void *p_userdata);
-	void query_ray(const Vector3 &p_from, const Vector3 &p_to, QueryResultCallback p_result_callback, void *p_userdata);
+	void query_ray(const Vector3 &p_from, const Vector3 &p_dir, real_t p_dist, QueryResultCallback p_result_callback, void *p_userdata);
 
 protected:
 	virtual void _shapes_changed() override;
@@ -259,7 +259,7 @@ public:
 	virtual Vector3 get_support(const Vector3 &p_normal) const override { return Vector3(); }
 	virtual void get_supports(const Vector3 &p_normal, int p_max, Vector3 *r_supports, int &r_amount, FeatureType &r_type) const override { r_amount = 0; }
 
-	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
+	virtual bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_dir, real_t p_dist, Vector3 &r_result, Vector3 &r_normal, int &r_face_index, bool p_hit_back_faces) const override;
 	virtual bool intersect_point(const Vector3 &p_point) const override;
 	virtual Vector3 get_closest_point_to(const Vector3 &p_point) const override;
 	virtual Vector3 get_moment_of_inertia(real_t p_mass) const override { return Vector3(); }

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1279,8 +1279,10 @@ Vector<ObjectID> RendererSceneCull::instances_cull_ray(const Vector3 &p_from, co
 	};
 
 	CullRay cull_ray;
-	scenario->indexers[Scenario::INDEXER_GEOMETRY].ray_query(p_from, p_to, cull_ray);
-	scenario->indexers[Scenario::INDEXER_VOLUMES].ray_query(p_from, p_to, cull_ray);
+	Vector3 segment = p_to - p_from;
+	real_t length = segment.length();
+	scenario->indexers[Scenario::INDEXER_GEOMETRY].ray_query(p_from, segment / length, length, cull_ray);
+	scenario->indexers[Scenario::INDEXER_VOLUMES].ray_query(p_from, segment / length, length, cull_ray);
 	return cull_ray.instances;
 }
 

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -186,24 +186,52 @@ TEST_CASE("[AABB] Intersection") {
 			!aabb_big.intersects_plane(Plane(Vector3(0, 1, 0), 200)),
 			"intersects_plane() should return the expected result.");
 
+	Vector3 result, normal;
+	result = Vector3();
+	normal = Vector3();
 	CHECK_MESSAGE(
-			aabb_big.intersects_segment(Vector3(1, 3, 0), Vector3(0, 3, 0)),
+			aabb_big.intersects_segment(Vector3(1, 3, 0), Vector3(0, 3, 0), &result, &normal),
 			"intersects_segment() should return the expected result.");
+	CHECK(result == Vector3(1, 3, 0));
+	CHECK(normal == Vector3());
+	result = Vector3();
+	normal = Vector3();
 	CHECK_MESSAGE(
-			aabb_big.intersects_segment(Vector3(0, 3, 0), Vector3(0, -300, 0)),
+			aabb_big.intersects_segment(Vector3(0, 3, 0), Vector3(0, -300, 0), &result, &normal),
 			"intersects_segment() should return the expected result.");
+	CHECK(result == Vector3(0, 3, 0));
+	CHECK(normal == Vector3());
+	result = Vector3();
+	normal = Vector3();
 	CHECK_MESSAGE(
-			aabb_big.intersects_segment(Vector3(-50, 3, -50), Vector3(50, 3, 50)),
+			aabb_big.intersects_segment(Vector3(-50, 3, -50), Vector3(50, 3, 50), &result, &normal),
 			"intersects_segment() should return the expected result.");
+	CHECK(result.is_equal_approx(Vector3(-1.5, 3.0, -1.5)));
+	CHECK(normal == Vector3(-1, 0, 0));
+	result = Vector3();
+	normal = Vector3();
 	CHECK_MESSAGE(
-			!aabb_big.intersects_segment(Vector3(-50, 25, -50), Vector3(50, 25, 50)),
+			!aabb_big.intersects_segment(Vector3(-50, 25, -50), Vector3(50, 25, 50), &result, &normal),
 			"intersects_segment() should return the expected result.");
+	CHECK(result == Vector3());
+	CHECK(normal == Vector3());
+	result = Vector3();
+	normal = Vector3();
 	CHECK_MESSAGE(
-			aabb_big.intersects_segment(Vector3(0, 3, 0), Vector3(0, 3, 0)),
+			aabb_big.intersects_segment(Vector3(0, 3, 0), Vector3(0, 3, 0), &result, &normal),
 			"intersects_segment() should return the expected result with segment of length 0.");
+	CHECK(result == Vector3(0, 3, 0));
+	CHECK(normal == Vector3());
+	result = Vector3();
+	normal = Vector3();
 	CHECK_MESSAGE(
-			!aabb_big.intersects_segment(Vector3(0, 300, 0), Vector3(0, 300, 0)),
+			!aabb_big.intersects_segment(Vector3(0, 300, 0), Vector3(0, 300, 0), &result, &normal),
 			"intersects_segment() should return the expected result with segment of length 0.");
+	CHECK(result == Vector3());
+	CHECK(normal == Vector3());
+	result = Vector3();
+	normal = Vector3();
+
 	CHECK_MESSAGE( // Simple ray intersection test.
 			aabb_big.intersects_ray(Vector3(-100, 3, 0), Vector3(1, 0, 0)),
 			"intersects_ray() should return true when ray points directly to AABB from outside.");

--- a/tests/core/math/test_geometry_3d.h
+++ b/tests/core/math/test_geometry_3d.h
@@ -147,14 +147,14 @@ TEST_CASE("[Geometry3D] Is Point in Projected Triangle") {
 	CHECK(Geometry3D::point_in_projected_triangle(Vector3(3, 0, 0), Vector3(3, 0, 0), Vector3(0, 3, 0), Vector3(-3, 0, 0)) == true);
 }
 
-TEST_CASE("[Geometry3D] Does Ray Intersect Triangle") {
+TEST_CASE("[Geometry3D] Ray Intersects Triangle") {
 	Vector3 result;
 	CHECK(Geometry3D::ray_intersects_triangle(Vector3(0, 1, 1), Vector3(0, 0, -10), Vector3(0, 3, 0), Vector3(-3, 0, 0), Vector3(3, 0, 0), &result) == true);
 	CHECK(Geometry3D::ray_intersects_triangle(Vector3(5, 10, 1), Vector3(0, 0, -10), Vector3(0, 3, 0), Vector3(-3, 0, 0), Vector3(3, 0, 0), &result) == false);
 	CHECK(Geometry3D::ray_intersects_triangle(Vector3(0, 1, 1), Vector3(0, 0, 10), Vector3(0, 3, 0), Vector3(-3, 0, 0), Vector3(3, 0, 0), &result) == false);
 }
 
-TEST_CASE("[Geometry3D] Does Segment Intersect Convex") {
+TEST_CASE("[Geometry3D] Segment Intersects Convex") {
 	Vector<Plane> box_planes = Geometry3D::build_box_planes(Vector3(5, 5, 5));
 	Vector3 result, normal;
 	CHECK(Geometry3D::segment_intersects_convex(Vector3(10, 10, 10), Vector3(0, 0, 0), &box_planes[0], box_planes.size(), &result, &normal) == true);
@@ -162,17 +162,56 @@ TEST_CASE("[Geometry3D] Does Segment Intersect Convex") {
 	CHECK(Geometry3D::segment_intersects_convex(Vector3(10, 10, 10), Vector3(6, 5, 5), &box_planes[0], box_planes.size(), &result, &normal) == false);
 }
 
-TEST_CASE("[Geometry3D] Segment Intersects Cylinder") {
+TEST_CASE("[Geometry3D] Ray Intersects Convex") {
+	constexpr real_t sqrt2 = 1.41421356237309504880;
+	constexpr real_t sqrt3 = 1.7320508075688772935274463415059;
+	Vector<Plane> box_planes = Geometry3D::build_box_planes(Vector3(5, 5, 5));
 	Vector3 result, normal;
-	CHECK(Geometry3D::segment_intersects_cylinder(Vector3(10, 10, 10), Vector3(0, 0, 0), 5, 5, &result, &normal) == true);
-	CHECK(Geometry3D::segment_intersects_cylinder(Vector3(10, 10, 10), Vector3(6, 6, 6), 5, 5, &result, &normal) == false);
+	CHECK(Geometry3D::ray_intersects_convex(Vector3(10, 10, 10), Vector3(-1.0 / sqrt3, -1.0 / sqrt3, -1.0 / sqrt3), &box_planes[0], box_planes.size(), &result, &normal) == true);
+	CHECK(Geometry3D::ray_intersects_convex(Vector3(0, 0, 1), Vector3(1.0 / sqrt3, 1.0 / sqrt3, -1.0 / sqrt3), &box_planes[0], box_planes.size(), &result, &normal) == false);
+	CHECK(Geometry3D::ray_intersects_convex(Vector3(10, 10, 10), Vector3(-1.0 / sqrt3, -1.0 / sqrt3, -1.0 / sqrt3), &box_planes[0], box_planes.size(), &result, &normal, 2.0) == false);
+	CHECK(Geometry3D::ray_intersects_convex(Vector3(7, 7, 1), Vector3(-1.0 / sqrt2, -1.0 / sqrt2, 0), &box_planes[0], box_planes.size(), &result, &normal) == true);
 }
 
 TEST_CASE("[Geometry3D] Segment Intersects Cylinder") {
 	Vector3 result, normal;
+	CHECK(Geometry3D::segment_intersects_cylinder(Vector3(10, 10, 10), Vector3(0, 0, 0), 5, 5, &result, &normal) == true);
+	CHECK(result.is_equal_approx(Vector3(2.5, 2.5, 2.5)));
+	CHECK(normal.is_equal_approx(Vector3(0, 0, 1)));
+	CHECK(Geometry3D::segment_intersects_cylinder(Vector3(10, 10, 10), Vector3(6, 6, 6), 5, 5, &result, &normal) == false);
+}
+
+TEST_CASE("[Geometry3D] Ray Intersects Cylinder") {
+	constexpr real_t sqrt2 = 1.41421356237309504880;
+	constexpr real_t sqrt3 = 1.7320508075688772935274463415059;
+	Vector3 result, normal;
+	CHECK(Geometry3D::ray_intersects_cylinder(Vector3(10, 10, 10), Vector3(-1.0 / sqrt3, -1.0 / sqrt3, -1.0 / sqrt3), 50, 5, &result, &normal) == true);
+	CHECK(result.is_equal_approx(Vector3(5.0 * sqrt2 / 2.0, 5.0 * sqrt2 / 2.0, 5.0 * sqrt2 / 2.0)));
+	CHECK(normal.is_equal_approx(Vector3(1.0 / sqrt2, 1.0 / sqrt2, 0)));
+	CHECK(Geometry3D::ray_intersects_cylinder(Vector3(10, 10, 10), Vector3(-1.0 / sqrt3, -1.0 / sqrt3, -1.0 / sqrt3), 5, 5, &result, &normal, 2, 3.0) == false);
+	CHECK(Geometry3D::ray_intersects_cylinder(Vector3(1, 10, -1), Vector3(0, -1, 0), 5, 5, &result, &normal, 1) == true);
+	CHECK(result.is_equal_approx(Vector3(1, 2.5, -1)));
+	CHECK(normal.is_equal_approx(Vector3(0, 1, 0)));
+	CHECK(Geometry3D::ray_intersects_cylinder(Vector3(1, 10, -1), Vector3(0, -1, 0), 5, 5, &result, &normal, 2, 2.0) == false);
+	CHECK(Geometry3D::ray_intersects_cylinder(Vector3(10, 10, 10), Vector3(1.0 / sqrt2, 0, 1.0 / sqrt2), 5, 5, &result, &normal) == false);
+}
+
+TEST_CASE("[Geometry3D] Segment Intersects Sphere") {
+	Vector3 result, normal;
 	CHECK(Geometry3D::segment_intersects_sphere(Vector3(10, 10, 10), Vector3(0, 0, 0), Vector3(0, 0, 0), 5, &result, &normal) == true);
 	CHECK(Geometry3D::segment_intersects_sphere(Vector3(10, 10, 10), Vector3(0, 0, 2.5), Vector3(0, 0, 0), 5, &result, &normal) == true);
 	CHECK(Geometry3D::segment_intersects_sphere(Vector3(10, 10, 10), Vector3(5, 5, 5), Vector3(0, 0, 0), 5, &result, &normal) == false);
+}
+
+TEST_CASE("[Geometry3D] Ray Intersects Sphere") {
+	constexpr real_t sqrt2 = 1.41421356237309504880;
+	constexpr real_t sqrt3 = 1.7320508075688772935274463415059;
+	Vector3 result, normal;
+	CHECK(Geometry3D::ray_intersects_sphere(Vector3(-25, -25, -25), Vector3(1.0 / sqrt3, 1.0 / sqrt3, 1.0 / sqrt3), Vector3(0, -1, 0), 5, &result, &normal) == true);
+	CHECK(Geometry3D::ray_intersects_sphere(Vector3(-25, -25, -25), Vector3(1.0 / sqrt3, 1.0 / sqrt3, 1.0 / sqrt3), Vector3(0, -1, 0), 5, &result, &normal, 5.0) == false);
+	CHECK(Geometry3D::ray_intersects_sphere(Vector3(-25, -25, -25), Vector3(-1.0 / sqrt3, 1.0 / sqrt3, 1.0 / sqrt3), Vector3(0, 0, 1), 200, &result, &normal) == false);
+	CHECK(Geometry3D::ray_intersects_sphere(Vector3(-25, -25, -25), Vector3(1.0 / sqrt2, 1.0 / sqrt2, 0), Vector3(0, 0, -20), 8, &result, &normal) == true);
+	CHECK(Geometry3D::ray_intersects_sphere(Vector3(-25, -25, -25), Vector3(1.0 / sqrt2, 1.0 / sqrt2, 0), Vector3(0, 0, -20), 8, &result, &normal, 2.0) == false);
 }
 
 TEST_CASE("[Geometry3D] Segment Intersects Triangle") {


### PR DESCRIPTION
Follow-up PR of https://github.com/godotengine/godot/pull/100475. More context there.
Depends on #100511

This PR makes sure 3D physics uses the numerical precision-proof version of BVH::ray_query().