### PR TITLE
Fix Android native file picker

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/io/FilePicker.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/FilePicker.kt
@@ -144,14 +144,10 @@ internal class FilePicker {
 			}
 			// ACTION_OPEN_DOCUMENT_TREE does not support intent type
 			if (fileMode != FILE_MODE_OPEN_DIR) {
-				intent.type = "*/*"
-				if (filters.isNotEmpty()) {
-					val resolvedFilters = filters.map { resolveMimeType(it) }.distinct()
-					if (resolvedFilters.size == 1) {
-						intent.type = resolvedFilters[0]
-					} else {
-						intent.putExtra(Intent.EXTRA_MIME_TYPES, resolvedFilters.toTypedArray())
-					}
+				val resolvedFilters = filters.map { resolveMimeType(it) }.distinct()
+				intent.type = resolvedFilters.firstOrNull { it != "application/octet-stream" } ?: "*/*"
+				if (resolvedFilters.size > 1) {
+					intent.putExtra(Intent.EXTRA_MIME_TYPES, resolvedFilters.toTypedArray())
 				}
 				intent.addCategory(Intent.CATEGORY_OPENABLE)
 			}

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -329,7 +329,7 @@ Error GodotJavaWrapper::show_file_picker(const String &p_current_directory, cons
 		jint j_mode = p_mode;
 		jobjectArray j_filters = env->NewObjectArray(p_filters.size(), env->FindClass("java/lang/String"), nullptr);
 		for (int i = 0; i < p_filters.size(); ++i) {
-			jstring j_filter = env->NewStringUTF(p_filters[i].utf8().get_data());
+			jstring j_filter = env->NewStringUTF(p_filters[i].get_slice(";", 0).utf8().get_data());
 			env->SetObjectArrayElement(j_filters, i, j_filter);
 			env->DeleteLocalRef(j_filter);
 		}


### PR DESCRIPTION
- closes https://github.com/godotengine/godot/issues/99326

After two new alpha releases since I opened the issue, and me completely forgetting about it, the Android file picker is still broken. This PR finally addresses and fixes the problem.

These changes ensure that if the mimeType is invalid, it will default to showing all files.