### PR TITLE
Remove unused variable in `GDScriptLanguage`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2727,8 +2727,6 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 }
 
 void GDScriptLanguage::frame() {
-	calls = 0;
-
 #ifdef DEBUG_ENABLED
 	if (profiling) {
 		MutexLock lock(mutex);
@@ -2942,7 +2940,6 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 thread_local GDScriptLanguage::CallStack GDScriptLanguage::_call_stack;
 
 GDScriptLanguage::GDScriptLanguage() {
-	calls = 0;
 	ERR_FAIL_COND(singleton);
 	singleton = this;
 	strings._init = StaticCString::create("_init");

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -476,8 +476,6 @@ class GDScriptLanguage : public ScriptLanguage {
 #endif
 
 public:
-	int calls;
-
 	bool debug_break(const String &p_error, bool p_allow_continue = true);
 	bool debug_break_parse(const String &p_file, int p_line, const String &p_error);
 

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -511,12 +511,6 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	Variant **instruction_args = nullptr;
 	int defarg = 0;
 
-#ifdef DEBUG_ENABLED
-
-	//GDScriptLanguage::get_singleton()->calls++;
-
-#endif
-
 	uint32_t alloca_size = 0;
 	GDScript *script;
 	int ip = 0;


### PR DESCRIPTION
This line of code has been commented out for at least four years, nobody should need that anymore.

And without that usage, variable `calls` is obsoleted (despite initialization), remove to save some space.