### PR TITLE
[WS] Fix wslay multi-frame message parsing

### DIFF
--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -55,7 +55,6 @@ private:
 	static ssize_t _wsl_recv_callback(wslay_event_context_ptr ctx, uint8_t *data, size_t len, int flags, void *user_data);
 	static void _wsl_recv_start_callback(wslay_event_context_ptr ctx, const struct wslay_event_on_frame_recv_start_arg *arg, void *user_data);
 	static void _wsl_frame_recv_chunk_callback(wslay_event_context_ptr ctx, const struct wslay_event_on_frame_recv_chunk_arg *arg, void *user_data);
-	static void _wsl_frame_recv_end_callback(wslay_event_context_ptr ctx, void *user_data);
 
 	static ssize_t _wsl_send_callback(wslay_event_context_ptr ctx, const uint8_t *data, size_t len, int flags, void *user_data);
 	static int _wsl_genmask_callback(wslay_event_context_ptr ctx, uint8_t *buf, size_t len, void *user_data);


### PR DESCRIPTION
The wslay library, somehow unintuitively, will call the frame recv end callback for control frames.

This has the side effect that while receiving a long message (i.e. a multi-frame message), if a control frame (e.g. a ping or pong) is received it may seem that a FIN frame has been received, resulting in the current code truncating the message.

To avoid this, this commit now ignores the frame recv end callback, and instead rely on the msg recv callback where we can check the opcode, and is guaranteed to be called only when the FIN frame is received for text and binary frames.

Follow up on #98343