### PR TITLE
Fix crash when duplicating `Decal` or `Light3D` nodes

### DIFF
--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -46,14 +46,14 @@ void Decal::set_texture(DecalTexture p_type, const Ref<Texture2D> &p_texture) {
 	RID texture_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 
 #ifdef DEBUG_ENABLED
-	if (
-			p_texture->is_class("AnimatedTexture") ||
-			p_texture->is_class("AtlasTexture") ||
-			p_texture->is_class("CameraTexture") ||
-			p_texture->is_class("CanvasTexture") ||
-			p_texture->is_class("MeshTexture") ||
-			p_texture->is_class("Texture2DRD") ||
-			p_texture->is_class("ViewportTexture")) {
+	if (p_texture.is_valid() &&
+			(p_texture->is_class("AnimatedTexture") ||
+					p_texture->is_class("AtlasTexture") ||
+					p_texture->is_class("CameraTexture") ||
+					p_texture->is_class("CanvasTexture") ||
+					p_texture->is_class("MeshTexture") ||
+					p_texture->is_class("Texture2DRD") ||
+					p_texture->is_class("ViewportTexture"))) {
 		WARN_PRINT(vformat("%s cannot be used as a Decal texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class(), get_path(), p_texture->get_class()));
 	}
 #endif

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -202,14 +202,14 @@ void Light3D::set_projector(const Ref<Texture2D> &p_texture) {
 	RID tex_id = projector.is_valid() ? projector->get_rid() : RID();
 
 #ifdef DEBUG_ENABLED
-	if (
-			p_texture->is_class("AnimatedTexture") ||
-			p_texture->is_class("AtlasTexture") ||
-			p_texture->is_class("CameraTexture") ||
-			p_texture->is_class("CanvasTexture") ||
-			p_texture->is_class("MeshTexture") ||
-			p_texture->is_class("Texture2DRD") ||
-			p_texture->is_class("ViewportTexture")) {
+	if (p_texture.is_valid() &&
+			(p_texture->is_class("AnimatedTexture") ||
+					p_texture->is_class("AtlasTexture") ||
+					p_texture->is_class("CameraTexture") ||
+					p_texture->is_class("CanvasTexture") ||
+					p_texture->is_class("MeshTexture") ||
+					p_texture->is_class("Texture2DRD") ||
+					p_texture->is_class("ViewportTexture"))) {
 		WARN_PRINT(vformat("%s cannot be used as a Light3D projector texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class(), get_path(), p_texture->get_class()));
 	}
 #endif


### PR DESCRIPTION
Crash was caused by duplicating `Node` properties generically with no textures assigned to the `Decal` triggering a null-deref in some validation code.

Change in code style was by `clang-format`.

Fixes https://github.com/godotengine/godot/issues/100629