### PR TITLE
Unset last focused window when it is destroyed.

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1844,6 +1844,10 @@ void DisplayServerX11::delete_sub_window(WindowID p_id) {
 	window_set_drop_files_callback(Callable(), p_id);
 
 	windows.erase(p_id);
+
+	if (last_focused_window == p_id) {
+		last_focused_window = INVALID_WINDOW_ID;
+	}
 }
 
 int64_t DisplayServerX11::window_get_native_handle(HandleType p_handle_type, WindowID p_window) const {

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -733,6 +733,10 @@ void DisplayServerMacOS::window_destroy(WindowID p_window) {
 	}
 #endif
 	windows.erase(p_window);
+
+	if (last_focused_window == p_window) {
+		last_focused_window = INVALID_WINDOW_ID;
+	}
 	update_presentation_mode();
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/95282

Note: the same is already done on Windows.