### PR TITLE
Fix autostart indicator going to wrong debugger

### DIFF
--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -269,12 +269,12 @@ void EditorRunBar::_profiler_autostart_indicator_pressed() {
 	EditorNode::get_singleton()->get_bottom_panel()->make_item_visible(EditorDebuggerNode::get_singleton(), true);
 
 	if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false)) {
-		EditorDebuggerNode::get_singleton()->get_current_debugger()->switch_to_debugger(2);
-	} else if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_visual_profiler", false)) {
 		EditorDebuggerNode::get_singleton()->get_current_debugger()->switch_to_debugger(3);
+	} else if (EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_visual_profiler", false)) {
+		EditorDebuggerNode::get_singleton()->get_current_debugger()->switch_to_debugger(4);
 	} else {
 		// Switch to the network profiler tab.
-		EditorDebuggerNode::get_singleton()->get_current_debugger()->switch_to_debugger(7);
+		EditorDebuggerNode::get_singleton()->get_current_debugger()->switch_to_debugger(8);
 	}
 }
 


### PR DESCRIPTION
**Before**

[Screencast from 2024-12-20 16-03-16.webm](https://github.com/user-attachments/assets/99bfc363-887e-46b4-bdc9-ae16dc7ac255)

**After**

[Screencast from 2024-12-20 16-14-24.webm](https://github.com/user-attachments/assets/ca4ea16d-da43-49e9-9b86-7d780d047cd6)
