### PR TITLE
Remove unnecessary `friend class` declarations of `CowData`.

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -171,10 +171,9 @@ public:
 	_FORCE_INLINE_ CharProxy<char16_t> operator[](int p_index) { return CharProxy<char16_t>(p_index, _cowdata); }
 
 	_FORCE_INLINE_ Char16String() {}
-	_FORCE_INLINE_ Char16String(const Char16String &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ Char16String(Char16String &&p_str) :
-			_cowdata(std::move(p_str._cowdata)) {}
-	_FORCE_INLINE_ void operator=(const Char16String &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ Char16String(const Char16String &p_str) = default;
+	_FORCE_INLINE_ Char16String(Char16String &&p_str) = default;
+	_FORCE_INLINE_ void operator=(const Char16String &p_str) { _cowdata = p_str._cowdata; }
 	_FORCE_INLINE_ void operator=(Char16String &&p_str) { _cowdata = std::move(p_str._cowdata); }
 	_FORCE_INLINE_ Char16String(const char16_t *p_cstr) { copy_from(p_cstr); }
 
@@ -218,10 +217,9 @@ public:
 	_FORCE_INLINE_ CharProxy<char> operator[](int p_index) { return CharProxy<char>(p_index, _cowdata); }
 
 	_FORCE_INLINE_ CharString() {}
-	_FORCE_INLINE_ CharString(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ CharString(CharString &&p_str) :
-			_cowdata(std::move(p_str._cowdata)) {}
-	_FORCE_INLINE_ void operator=(const CharString &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ CharString(const CharString &p_str) = default;
+	_FORCE_INLINE_ CharString(CharString &&p_str) = default;
+	_FORCE_INLINE_ void operator=(const CharString &p_str) { _cowdata = p_str._cowdata; }
 	_FORCE_INLINE_ void operator=(CharString &&p_str) { _cowdata = std::move(p_str._cowdata); }
 	_FORCE_INLINE_ CharString(const char *p_cstr) { copy_from(p_cstr); }
 
@@ -609,13 +607,12 @@ public:
 	 */
 
 	_FORCE_INLINE_ String() {}
-	_FORCE_INLINE_ String(const String &p_str) { _cowdata._ref(p_str._cowdata); }
-	_FORCE_INLINE_ String(String &&p_str) :
-			_cowdata(std::move(p_str._cowdata)) {}
+	_FORCE_INLINE_ String(const String &p_str) = default;
+	_FORCE_INLINE_ String(String &&p_str) = default;
 #ifdef SIZE_EXTRA
 	_NO_INLINE_ ~String() {}
 #endif
-	_FORCE_INLINE_ void operator=(const String &p_str) { _cowdata._ref(p_str._cowdata); }
+	_FORCE_INLINE_ void operator=(const String &p_str) { _cowdata = p_str._cowdata; }
 	_FORCE_INLINE_ void operator=(String &&p_str) { _cowdata = std::move(p_str._cowdata); }
 
 	Vector<uint8_t> to_ascii_buffer() const;

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -39,28 +39,12 @@
 #include <initializer_list>
 #include <type_traits>
 
-template <typename T>
-class Vector;
-class String;
-class Char16String;
-class CharString;
-template <typename T, typename V>
-class VMap;
-
 static_assert(std::is_trivially_destructible_v<std::atomic<uint64_t>>);
 
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wplacement-new") // Silence a false positive warning (see GH-52119).
 
 template <typename T>
 class CowData {
-	template <typename TV>
-	friend class Vector;
-	friend class String;
-	friend class Char16String;
-	friend class CharString;
-	template <typename TV, typename VV>
-	friend class VMap;
-
 public:
 	typedef int64_t Size;
 	typedef uint64_t USize;
@@ -129,11 +113,11 @@ private:
 		return (USize *)((uint8_t *)_ptr - DATA_OFFSET + SIZE_OFFSET);
 	}
 
-	_FORCE_INLINE_ USize _get_alloc_size(USize p_elements) const {
+	_FORCE_INLINE_ static USize _get_alloc_size(USize p_elements) {
 		return next_po2(p_elements * sizeof(T));
 	}
 
-	_FORCE_INLINE_ bool _get_alloc_size_checked(USize p_elements, USize *out) const {
+	_FORCE_INLINE_ static bool _get_alloc_size_checked(USize p_elements, USize *out) {
 		if (unlikely(p_elements == 0)) {
 			*out = 0;
 			return true;

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -46,6 +46,9 @@
 #include <initializer_list>
 
 template <typename T>
+class Vector;
+
+template <typename T>
 class VectorWriteProxy {
 public:
 	_FORCE_INLINE_ T &operator[](typename CowData<T>::Size p_index) {
@@ -167,7 +170,7 @@ public:
 		insert(i, p_val);
 	}
 
-	void operator=(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
+	void operator=(const Vector &p_from) { _cowdata = p_from._cowdata; }
 	void operator=(Vector &&p_from) { _cowdata = std::move(p_from._cowdata); }
 
 	Vector<uint8_t> to_byte_array() const {
@@ -304,9 +307,8 @@ public:
 	_FORCE_INLINE_ Vector() {}
 	_FORCE_INLINE_ Vector(std::initializer_list<T> p_init) :
 			_cowdata(p_init) {}
-	_FORCE_INLINE_ Vector(const Vector &p_from) { _cowdata._ref(p_from._cowdata); }
-	_FORCE_INLINE_ Vector(Vector &&p_from) :
-			_cowdata(std::move(p_from._cowdata)) {}
+	_FORCE_INLINE_ Vector(const Vector &p_from) = default;
+	_FORCE_INLINE_ Vector(Vector &&p_from) = default;
 
 	_FORCE_INLINE_ ~Vector() {}
 };

--- a/core/templates/vmap.h
+++ b/core/templates/vmap.h
@@ -195,9 +195,7 @@ public:
 	_FORCE_INLINE_ VMap() {}
 	_FORCE_INLINE_ VMap(std::initializer_list<T> p_init) :
 			_cowdata(p_init) {}
-	_FORCE_INLINE_ VMap(const VMap &p_from) { _cowdata._ref(p_from._cowdata); }
+	_FORCE_INLINE_ VMap(const VMap &p_from) = default;
 
-	inline void operator=(const VMap &p_from) {
-		_cowdata._ref(p_from._cowdata);
-	}
+	void operator=(const VMap &p_from) { _cowdata = p_from._cowdata; }
 };

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -38,6 +38,9 @@
 class VisualShaderNodeParameter;
 class VisualShaderNode;
 
+template <typename T, typename V>
+class VMap;
+
 class VisualShader : public Shader {
 	GDCLASS(VisualShader, Shader);
 


### PR DESCRIPTION
This is a small cleanup I did while doing sanity checks for #100619.
The `friend class` declarations are unnecessary. They should be removed because they increase coupling. It additionally makes no sense to have `friend` classes because `CowData` should be designed such that it can be used from any class, and not just some known specific classes.

There are only a few affected spots:

`_ref()` calls can be replaced with `operator=(const CowData &)` calls. The resulting call is the exact same:

https://github.com/godotengine/godot/blob/89001f91d21ebd08b59756841426f540b154b97d/core/templates/cowdata.h#L172

Forward declarations can also be removed. Two headers were passively using them before (`visual_shader` and `vector`). I moved the forward declarations to the appropriate spots.

Finally, I also made `_get_alloc_size` and `_get_alloc_size_checked` static. This is a small change that doesn't warrant a separate PR. It does not make sense to have the functions be member functions, because it is relied upon that allocation sizes are consistent across different instances of `CowData`. It has to be deterministic by class alone.