### PR TITLE
Rendering: MoltenVK hack is no longer required, as bug was fixed.

### DIFF
--- a/servers/rendering/renderer_rd/effects/fsr.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr.cpp
@@ -36,18 +36,11 @@ using namespace RendererRD;
 
 FSR::FSR() {
 	Vector<String> FSR_upscale_modes;
-
-#if defined(MACOS_ENABLED) || defined(IOS_ENABLED)
-	// MoltenVK does not support some of the operations used by the normal mode of FSR. Fallback works just fine though.
-	FSR_upscale_modes.push_back("\n#define MODE_FSR_UPSCALE_FALLBACK\n");
-#else
-	// Everyone else can use normal mode when available.
 	if (RD::get_singleton()->has_feature(RD::SUPPORTS_FSR_HALF_FLOAT)) {
 		FSR_upscale_modes.push_back("\n#define MODE_FSR_UPSCALE_NORMAL\n");
 	} else {
 		FSR_upscale_modes.push_back("\n#define MODE_FSR_UPSCALE_FALLBACK\n");
 	}
-#endif
 
 	fsr_shader.initialize(FSR_upscale_modes);
 


### PR DESCRIPTION
This workaround is no longer required. The original reason was found here:

Original issue: https://github.com/godotengine/godot/pull/51679#issuecomment-976900929

And related issue and fix in SPIRV-Cross: https://github.com/KhronosGroup/SPIRV-Cross/issues/2046

I also confirmed that Vulkan on my MacBook Pro works fine without the workaround.