### PR TITLE
Fix `@export` open scene button not working

### DIFF
--- a/editor/plugins/packed_scene_editor_plugin.cpp
+++ b/editor/plugins/packed_scene_editor_plugin.cpp
@@ -36,7 +36,7 @@
 
 void PackedSceneEditor::_on_open_scene_pressed() {
 	// Using deferred call because changing scene updates the Inspector and thus destroys this plugin.
-	callable_mp(EditorNode::get_singleton(), &EditorNode::open_request).call_deferred(packed_scene->get_path());
+	callable_mp(EditorNode::get_singleton(), &EditorNode::open_request).call_deferred(packed_scene->get_path(), false);
 }
 
 void PackedSceneEditor::_notification(int p_what) {


### PR DESCRIPTION
Fixing #100649 by adding missing argument to `EditorNode::open_request`.

The problem was caused by this [commit](https://github.com/godotengine/godot/commit/7f098041546eb877ce2b28a4a127245995725fe5) that added a parameter to `open_request` with a default value. The default value is not taken into account in the deferred_call (probably because of the templating ? not entirely sure) and was thus producing the error. 

I have also checked for other occurrences of `open_request` deferred calls but could not find any, so I think this is just the one.