### PR TITLE
Refactor Variant to provide easier maintenance and readability at no performance cost.

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -910,7 +910,7 @@ bool Variant::is_zero() const {
 			return *reinterpret_cast<const Rect2i *>(_data._mem) == Rect2i();
 		}
 		case TRANSFORM2D: {
-			return *_data._transform2d == Transform2D();
+			return *reinterpret_cast<const Transform2D *>(_data._ptr) == Transform2D();
 		}
 		case VECTOR3: {
 			return *reinterpret_cast<const Vector3 *>(_data._mem) == Vector3();
@@ -928,19 +928,19 @@ bool Variant::is_zero() const {
 			return *reinterpret_cast<const Plane *>(_data._mem) == Plane();
 		}
 		case AABB: {
-			return *_data._aabb == ::AABB();
+			return *reinterpret_cast<const ::AABB *>(_data._ptr) == ::AABB();
 		}
 		case QUATERNION: {
 			return *reinterpret_cast<const Quaternion *>(_data._mem) == Quaternion();
 		}
 		case BASIS: {
-			return *_data._basis == Basis();
+			return *reinterpret_cast<const Basis *>(_data._ptr) == Basis();
 		}
 		case TRANSFORM3D: {
-			return *_data._transform3d == Transform3D();
+			return *reinterpret_cast<const Transform3D *>(_data._ptr) == Transform3D();
 		}
 		case PROJECTION: {
-			return *_data._projection == Projection();
+			return *reinterpret_cast<const Projection *>(_data._ptr) == Projection();
 		}
 
 		// Miscellaneous types.
@@ -974,34 +974,34 @@ bool Variant::is_zero() const {
 
 		// Arrays.
 		case PACKED_BYTE_ARRAY: {
-			return PackedArrayRef<uint8_t>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<uint8_t>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		case PACKED_INT32_ARRAY: {
-			return PackedArrayRef<int32_t>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<int32_t>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		case PACKED_INT64_ARRAY: {
-			return PackedArrayRef<int64_t>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<int64_t>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		case PACKED_FLOAT32_ARRAY: {
-			return PackedArrayRef<float>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<float>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		case PACKED_FLOAT64_ARRAY: {
-			return PackedArrayRef<double>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<double>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		case PACKED_STRING_ARRAY: {
-			return PackedArrayRef<String>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<String>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		case PACKED_VECTOR2_ARRAY: {
-			return PackedArrayRef<Vector2>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<Vector2>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		case PACKED_VECTOR3_ARRAY: {
-			return PackedArrayRef<Vector3>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<Vector3>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		case PACKED_COLOR_ARRAY: {
-			return PackedArrayRef<Color>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<Color>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		case PACKED_VECTOR4_ARRAY: {
-			return PackedArrayRef<Vector4>::get_array(_data.packed_array).size() == 0;
+			return PackedArrayRef<Vector4>::get_array((PackedArrayRefBase *)_data._ptr).size() == 0;
 		}
 		default: {
 		}
@@ -1170,8 +1170,8 @@ void Variant::reference(const Variant &p_variant) {
 			memnew_placement(_data._mem, Rect2i(*reinterpret_cast<const Rect2i *>(p_variant._data._mem)));
 		} break;
 		case TRANSFORM2D: {
-			_data._transform2d = (Transform2D *)Pools::_bucket_small.alloc();
-			memnew_placement(_data._transform2d, Transform2D(*p_variant._data._transform2d));
+			_data._ptr = Pools::_bucket_small.alloc();
+			memnew_placement(_data._ptr, Transform2D(*reinterpret_cast<const Transform2D *>(p_variant._data._ptr)));
 		} break;
 		case VECTOR3: {
 			memnew_placement(_data._mem, Vector3(*reinterpret_cast<const Vector3 *>(p_variant._data._mem)));
@@ -1189,23 +1189,23 @@ void Variant::reference(const Variant &p_variant) {
 			memnew_placement(_data._mem, Plane(*reinterpret_cast<const Plane *>(p_variant._data._mem)));
 		} break;
 		case AABB: {
-			_data._aabb = (::AABB *)Pools::_bucket_small.alloc();
-			memnew_placement(_data._aabb, ::AABB(*p_variant._data._aabb));
+			_data._ptr = Pools::_bucket_small.alloc();
+			memnew_placement(_data._ptr, ::AABB(*reinterpret_cast<const ::AABB *>(p_variant._data._ptr)));
 		} break;
 		case QUATERNION: {
 			memnew_placement(_data._mem, Quaternion(*reinterpret_cast<const Quaternion *>(p_variant._data._mem)));
 		} break;
 		case BASIS: {
-			_data._basis = (Basis *)Pools::_bucket_medium.alloc();
-			memnew_placement(_data._basis, Basis(*p_variant._data._basis));
+			_data._ptr = Pools::_bucket_medium.alloc();
+			memnew_placement(_data._ptr, Basis(*reinterpret_cast<const Basis *>(p_variant._data._ptr)));
 		} break;
 		case TRANSFORM3D: {
-			_data._transform3d = (Transform3D *)Pools::_bucket_medium.alloc();
-			memnew_placement(_data._transform3d, Transform3D(*p_variant._data._transform3d));
+			_data._ptr = Pools::_bucket_medium.alloc();
+			memnew_placement(_data._ptr, Transform3D(*reinterpret_cast<const Transform3D *>(p_variant._data._ptr)));
 		} break;
 		case PROJECTION: {
-			_data._projection = (Projection *)Pools::_bucket_large.alloc();
-			memnew_placement(_data._projection, Projection(*p_variant._data._projection));
+			_data._ptr = (Projection *)Pools::_bucket_large.alloc();
+			memnew_placement(_data._ptr, Projection(*reinterpret_cast<const Projection *>(p_variant._data._ptr)));
 		} break;
 
 		// Miscellaneous types.
@@ -1240,63 +1240,63 @@ void Variant::reference(const Variant &p_variant) {
 
 		// Arrays.
 		case PACKED_BYTE_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<uint8_t> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<uint8_t>::create();
+			_data._ptr = static_cast<PackedArrayRef<uint8_t> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<uint8_t>::create();
 			}
 		} break;
 		case PACKED_INT32_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<int32_t> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<int32_t>::create();
+			_data._ptr = static_cast<PackedArrayRef<int32_t> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<int32_t>::create();
 			}
 		} break;
 		case PACKED_INT64_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<int64_t> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<int64_t>::create();
+			_data._ptr = static_cast<PackedArrayRef<int64_t> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<int64_t>::create();
 			}
 		} break;
 		case PACKED_FLOAT32_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<float> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<float>::create();
+			_data._ptr = static_cast<PackedArrayRef<float> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<float>::create();
 			}
 		} break;
 		case PACKED_FLOAT64_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<double> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<double>::create();
+			_data._ptr = static_cast<PackedArrayRef<double> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<double>::create();
 			}
 		} break;
 		case PACKED_STRING_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<String> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<String>::create();
+			_data._ptr = static_cast<PackedArrayRef<String> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<String>::create();
 			}
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<Vector2> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<Vector2>::create();
+			_data._ptr = static_cast<PackedArrayRef<Vector2> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<Vector2>::create();
 			}
 		} break;
 		case PACKED_VECTOR3_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<Vector3> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<Vector3>::create();
+			_data._ptr = static_cast<PackedArrayRef<Vector3> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<Vector3>::create();
 			}
 		} break;
 		case PACKED_COLOR_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<Color> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<Color>::create();
+			_data._ptr = static_cast<PackedArrayRef<Color> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<Color>::create();
 			}
 		} break;
 		case PACKED_VECTOR4_ARRAY: {
-			_data.packed_array = static_cast<PackedArrayRef<Vector4> *>(p_variant._data.packed_array)->reference();
-			if (!_data.packed_array) {
-				_data.packed_array = PackedArrayRef<Vector4>::create();
+			_data._ptr = static_cast<PackedArrayRef<Vector4> *>((PackedArrayRefBase *)p_variant._data._ptr)->reference();
+			if (!_data._ptr) {
+				_data._ptr = PackedArrayRef<Vector4>::create();
 			}
 		} break;
 		default: {
@@ -1373,38 +1373,38 @@ void Variant::_clear_internal() {
 
 		// Math types.
 		case TRANSFORM2D: {
-			if (_data._transform2d) {
-				_data._transform2d->~Transform2D();
-				Pools::_bucket_small.free((Pools::BucketSmall *)_data._transform2d);
-				_data._transform2d = nullptr;
+			if (_data._ptr) {
+				reinterpret_cast<Transform2D *>(_data._ptr)->~Transform2D();
+				Pools::_bucket_small.free((Pools::BucketSmall *)_data._ptr);
+				_data._ptr = nullptr;
 			}
 		} break;
 		case AABB: {
-			if (_data._aabb) {
-				_data._aabb->~AABB();
-				Pools::_bucket_small.free((Pools::BucketSmall *)_data._aabb);
-				_data._aabb = nullptr;
+			if (_data._ptr) {
+				reinterpret_cast<::AABB *>(_data._ptr)->~AABB();
+				Pools::_bucket_small.free((Pools::BucketSmall *)_data._ptr);
+				_data._ptr = nullptr;
 			}
 		} break;
 		case BASIS: {
-			if (_data._basis) {
-				_data._basis->~Basis();
-				Pools::_bucket_medium.free((Pools::BucketMedium *)_data._basis);
-				_data._basis = nullptr;
+			if (_data._ptr) {
+				reinterpret_cast<Basis *>(_data._ptr)->~Basis();
+				Pools::_bucket_medium.free((Pools::BucketMedium *)_data._ptr);
+				_data._ptr = nullptr;
 			}
 		} break;
 		case TRANSFORM3D: {
-			if (_data._transform3d) {
-				_data._transform3d->~Transform3D();
-				Pools::_bucket_medium.free((Pools::BucketMedium *)_data._transform3d);
-				_data._transform3d = nullptr;
+			if (_data._ptr) {
+				reinterpret_cast<Transform3D *>(_data._ptr)->~Transform3D();
+				Pools::_bucket_medium.free((Pools::BucketMedium *)_data._ptr);
+				_data._ptr = nullptr;
 			}
 		} break;
 		case PROJECTION: {
-			if (_data._projection) {
-				_data._projection->~Projection();
-				Pools::_bucket_large.free((Pools::BucketLarge *)_data._projection);
-				_data._projection = nullptr;
+			if (_data._ptr) {
+				reinterpret_cast<Projection *>(_data._ptr)->~Projection();
+				Pools::_bucket_large.free((Pools::BucketLarge *)_data._ptr);
+				_data._ptr = nullptr;
 			}
 		} break;
 
@@ -1439,34 +1439,34 @@ void Variant::_clear_internal() {
 
 		// Arrays.
 		case PACKED_BYTE_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		case PACKED_INT32_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		case PACKED_INT64_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		case PACKED_FLOAT32_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		case PACKED_FLOAT64_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		case PACKED_STRING_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		case PACKED_VECTOR3_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		case PACKED_COLOR_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		case PACKED_VECTOR4_ARRAY: {
-			PackedArrayRefBase::destroy(_data.packed_array);
+			PackedArrayRefBase::destroy((PackedArrayRefBase *)_data._ptr);
 		} break;
 		default: {
 			// Not needed, there is no point. The following do not allocate memory:
@@ -2016,7 +2016,7 @@ Variant::operator Plane() const {
 
 Variant::operator ::AABB() const {
 	if (type == AABB) {
-		return *_data._aabb;
+		return *(const ::AABB *)_data._ptr;
 	} else {
 		return ::AABB();
 	}
@@ -2024,11 +2024,11 @@ Variant::operator ::AABB() const {
 
 Variant::operator Basis() const {
 	if (type == BASIS) {
-		return *_data._basis;
+		return *reinterpret_cast<Basis *>(_data._ptr);
 	} else if (type == QUATERNION) {
 		return *reinterpret_cast<const Quaternion *>(_data._mem);
 	} else if (type == TRANSFORM3D) { // unexposed in Variant::can_convert?
-		return _data._transform3d->basis;
+		return reinterpret_cast<Transform3D *>(_data._ptr)->basis;
 	} else {
 		return Basis();
 	}
@@ -2038,9 +2038,9 @@ Variant::operator Quaternion() const {
 	if (type == QUATERNION) {
 		return *reinterpret_cast<const Quaternion *>(_data._mem);
 	} else if (type == BASIS) {
-		return *_data._basis;
+		return *reinterpret_cast<Basis *>(_data._ptr);
 	} else if (type == TRANSFORM3D) {
-		return _data._transform3d->basis;
+		return reinterpret_cast<Transform3D *>(_data._ptr)->basis;
 	} else {
 		return Quaternion();
 	}
@@ -2048,13 +2048,13 @@ Variant::operator Quaternion() const {
 
 Variant::operator Transform3D() const {
 	if (type == TRANSFORM3D) {
-		return *_data._transform3d;
+		return *reinterpret_cast<Transform3D *>(_data._ptr);
 	} else if (type == BASIS) {
-		return Transform3D(*_data._basis, Vector3());
+		return Transform3D(*reinterpret_cast<Basis *>(_data._ptr), Vector3());
 	} else if (type == QUATERNION) {
 		return Transform3D(Basis(*reinterpret_cast<const Quaternion *>(_data._mem)), Vector3());
 	} else if (type == TRANSFORM2D) {
-		const Transform2D &t = *_data._transform2d;
+		const Transform2D &t = *reinterpret_cast<Transform2D *>(_data._ptr);
 		Transform3D m;
 		m.basis.rows[0][0] = t.columns[0][0];
 		m.basis.rows[1][0] = t.columns[0][1];
@@ -2064,7 +2064,7 @@ Variant::operator Transform3D() const {
 		m.origin[1] = t.columns[2][1];
 		return m;
 	} else if (type == PROJECTION) {
-		return *_data._projection;
+		return *reinterpret_cast<Projection *>(_data._ptr);
 	} else {
 		return Transform3D();
 	}
@@ -2072,13 +2072,13 @@ Variant::operator Transform3D() const {
 
 Variant::operator Projection() const {
 	if (type == TRANSFORM3D) {
-		return *_data._transform3d;
+		return *reinterpret_cast<Transform3D *>(_data._ptr);
 	} else if (type == BASIS) {
-		return Transform3D(*_data._basis, Vector3());
+		return Transform3D(*reinterpret_cast<Basis *>(_data._ptr), Vector3());
 	} else if (type == QUATERNION) {
 		return Transform3D(Basis(*reinterpret_cast<const Quaternion *>(_data._mem)), Vector3());
 	} else if (type == TRANSFORM2D) {
-		const Transform2D &t = *_data._transform2d;
+		const Transform2D &t = *reinterpret_cast<Transform2D *>(_data._ptr);
 		Transform3D m;
 		m.basis.rows[0][0] = t.columns[0][0];
 		m.basis.rows[1][0] = t.columns[0][1];
@@ -2088,7 +2088,7 @@ Variant::operator Projection() const {
 		m.origin[1] = t.columns[2][1];
 		return m;
 	} else if (type == PROJECTION) {
-		return *_data._projection;
+		return *reinterpret_cast<Projection *>(_data._ptr);
 	} else {
 		return Projection();
 	}
@@ -2096,9 +2096,9 @@ Variant::operator Projection() const {
 
 Variant::operator Transform2D() const {
 	if (type == TRANSFORM2D) {
-		return *_data._transform2d;
+		return *reinterpret_cast<Transform2D *>(_data._ptr);
 	} else if (type == TRANSFORM3D) {
-		const Transform3D &t = *_data._transform3d;
+		const Transform3D &t = *reinterpret_cast<Transform3D *>(_data._ptr);
 		Transform2D m;
 		m.columns[0][0] = t.basis.rows[0][0];
 		m.columns[0][1] = t.basis.rows[1][0];
@@ -2271,7 +2271,7 @@ Variant::operator Array() const {
 
 Variant::operator PackedByteArray() const {
 	if (type == PACKED_BYTE_ARRAY) {
-		return static_cast<PackedArrayRef<uint8_t> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<uint8_t> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedByteArray>(*this);
 	}
@@ -2279,7 +2279,7 @@ Variant::operator PackedByteArray() const {
 
 Variant::operator PackedInt32Array() const {
 	if (type == PACKED_INT32_ARRAY) {
-		return static_cast<PackedArrayRef<int32_t> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<int32_t> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedInt32Array>(*this);
 	}
@@ -2287,7 +2287,7 @@ Variant::operator PackedInt32Array() const {
 
 Variant::operator PackedInt64Array() const {
 	if (type == PACKED_INT64_ARRAY) {
-		return static_cast<PackedArrayRef<int64_t> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<int64_t> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedInt64Array>(*this);
 	}
@@ -2295,7 +2295,7 @@ Variant::operator PackedInt64Array() const {
 
 Variant::operator PackedFloat32Array() const {
 	if (type == PACKED_FLOAT32_ARRAY) {
-		return static_cast<PackedArrayRef<float> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<float> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedFloat32Array>(*this);
 	}
@@ -2303,7 +2303,7 @@ Variant::operator PackedFloat32Array() const {
 
 Variant::operator PackedFloat64Array() const {
 	if (type == PACKED_FLOAT64_ARRAY) {
-		return static_cast<PackedArrayRef<double> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<double> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedFloat64Array>(*this);
 	}
@@ -2311,7 +2311,7 @@ Variant::operator PackedFloat64Array() const {
 
 Variant::operator PackedStringArray() const {
 	if (type == PACKED_STRING_ARRAY) {
-		return static_cast<PackedArrayRef<String> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<String> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedStringArray>(*this);
 	}
@@ -2319,7 +2319,7 @@ Variant::operator PackedStringArray() const {
 
 Variant::operator PackedVector2Array() const {
 	if (type == PACKED_VECTOR2_ARRAY) {
-		return static_cast<PackedArrayRef<Vector2> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<Vector2> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedVector2Array>(*this);
 	}
@@ -2327,7 +2327,7 @@ Variant::operator PackedVector2Array() const {
 
 Variant::operator PackedVector3Array() const {
 	if (type == PACKED_VECTOR3_ARRAY) {
-		return static_cast<PackedArrayRef<Vector3> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<Vector3> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedVector3Array>(*this);
 	}
@@ -2335,7 +2335,7 @@ Variant::operator PackedVector3Array() const {
 
 Variant::operator PackedColorArray() const {
 	if (type == PACKED_COLOR_ARRAY) {
-		return static_cast<PackedArrayRef<Color> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<Color> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedColorArray>(*this);
 	}
@@ -2343,7 +2343,7 @@ Variant::operator PackedColorArray() const {
 
 Variant::operator PackedVector4Array() const {
 	if (type == PACKED_VECTOR4_ARRAY) {
-		return static_cast<PackedArrayRef<Vector4> *>(_data.packed_array)->array;
+		return static_cast<PackedArrayRef<Vector4> *>((PackedArrayRefBase *)_data._ptr)->array;
 	} else {
 		return _convert_array_from_variant<PackedVector4Array>(*this);
 	}
@@ -2572,14 +2572,14 @@ Variant::Variant(const Plane &p_plane) :
 
 Variant::Variant(const ::AABB &p_aabb) :
 		type(AABB) {
-	_data._aabb = (::AABB *)Pools::_bucket_small.alloc();
-	memnew_placement(_data._aabb, ::AABB(p_aabb));
+	_data._ptr = (::AABB *)Pools::_bucket_small.alloc();
+	memnew_placement(_data._ptr, ::AABB(p_aabb));
 }
 
 Variant::Variant(const Basis &p_matrix) :
 		type(BASIS) {
-	_data._basis = (Basis *)Pools::_bucket_medium.alloc();
-	memnew_placement(_data._basis, Basis(p_matrix));
+	_data._ptr = (Basis *)Pools::_bucket_medium.alloc();
+	memnew_placement(_data._ptr, Basis(p_matrix));
 }
 
 Variant::Variant(const Quaternion &p_quaternion) :
@@ -2589,20 +2589,20 @@ Variant::Variant(const Quaternion &p_quaternion) :
 
 Variant::Variant(const Transform3D &p_transform) :
 		type(TRANSFORM3D) {
-	_data._transform3d = (Transform3D *)Pools::_bucket_medium.alloc();
-	memnew_placement(_data._transform3d, Transform3D(p_transform));
+	_data._ptr = (Transform3D *)Pools::_bucket_medium.alloc();
+	memnew_placement(_data._ptr, Transform3D(p_transform));
 }
 
 Variant::Variant(const Projection &pp_projection) :
 		type(PROJECTION) {
-	_data._projection = (Projection *)Pools::_bucket_large.alloc();
-	memnew_placement(_data._projection, Projection(pp_projection));
+	_data._ptr = (Projection *)Pools::_bucket_large.alloc();
+	memnew_placement(_data._ptr, Projection(pp_projection));
 }
 
 Variant::Variant(const Transform2D &p_transform) :
 		type(TRANSFORM2D) {
-	_data._transform2d = (Transform2D *)Pools::_bucket_small.alloc();
-	memnew_placement(_data._transform2d, Transform2D(p_transform));
+	_data._ptr = (Transform2D *)Pools::_bucket_small.alloc();
+	memnew_placement(_data._ptr, Transform2D(p_transform));
 }
 
 Variant::Variant(const Color &p_color) :
@@ -2648,52 +2648,52 @@ Variant::Variant(const Array &p_array) :
 
 Variant::Variant(const PackedByteArray &p_byte_array) :
 		type(PACKED_BYTE_ARRAY) {
-	_data.packed_array = PackedArrayRef<uint8_t>::create(p_byte_array);
+	_data._ptr = PackedArrayRef<uint8_t>::create(p_byte_array);
 }
 
 Variant::Variant(const PackedInt32Array &p_int32_array) :
 		type(PACKED_INT32_ARRAY) {
-	_data.packed_array = PackedArrayRef<int32_t>::create(p_int32_array);
+	_data._ptr = PackedArrayRef<int32_t>::create(p_int32_array);
 }
 
 Variant::Variant(const PackedInt64Array &p_int64_array) :
 		type(PACKED_INT64_ARRAY) {
-	_data.packed_array = PackedArrayRef<int64_t>::create(p_int64_array);
+	_data._ptr = PackedArrayRef<int64_t>::create(p_int64_array);
 }
 
 Variant::Variant(const PackedFloat32Array &p_float32_array) :
 		type(PACKED_FLOAT32_ARRAY) {
-	_data.packed_array = PackedArrayRef<float>::create(p_float32_array);
+	_data._ptr = PackedArrayRef<float>::create(p_float32_array);
 }
 
 Variant::Variant(const PackedFloat64Array &p_float64_array) :
 		type(PACKED_FLOAT64_ARRAY) {
-	_data.packed_array = PackedArrayRef<double>::create(p_float64_array);
+	_data._ptr = PackedArrayRef<double>::create(p_float64_array);
 }
 
 Variant::Variant(const PackedStringArray &p_string_array) :
 		type(PACKED_STRING_ARRAY) {
-	_data.packed_array = PackedArrayRef<String>::create(p_string_array);
+	_data._ptr = PackedArrayRef<String>::create(p_string_array);
 }
 
 Variant::Variant(const PackedVector2Array &p_vector2_array) :
 		type(PACKED_VECTOR2_ARRAY) {
-	_data.packed_array = PackedArrayRef<Vector2>::create(p_vector2_array);
+	_data._ptr = PackedArrayRef<Vector2>::create(p_vector2_array);
 }
 
 Variant::Variant(const PackedVector3Array &p_vector3_array) :
 		type(PACKED_VECTOR3_ARRAY) {
-	_data.packed_array = PackedArrayRef<Vector3>::create(p_vector3_array);
+	_data._ptr = PackedArrayRef<Vector3>::create(p_vector3_array);
 }
 
 Variant::Variant(const PackedColorArray &p_color_array) :
 		type(PACKED_COLOR_ARRAY) {
-	_data.packed_array = PackedArrayRef<Color>::create(p_color_array);
+	_data._ptr = PackedArrayRef<Color>::create(p_color_array);
 }
 
 Variant::Variant(const PackedVector4Array &p_vector4_array) :
 		type(PACKED_VECTOR4_ARRAY) {
-	_data.packed_array = PackedArrayRef<Vector4>::create(p_vector4_array);
+	_data._ptr = PackedArrayRef<Vector4>::create(p_vector4_array);
 }
 
 /* helpers */
@@ -2800,7 +2800,7 @@ void Variant::operator=(const Variant &p_variant) {
 			*reinterpret_cast<Rect2i *>(_data._mem) = *reinterpret_cast<const Rect2i *>(p_variant._data._mem);
 		} break;
 		case TRANSFORM2D: {
-			*_data._transform2d = *(p_variant._data._transform2d);
+			*reinterpret_cast<Transform2D *>(_data._ptr) = *(reinterpret_cast<Transform2D *>(p_variant._data._ptr));
 		} break;
 		case VECTOR3: {
 			*reinterpret_cast<Vector3 *>(_data._mem) = *reinterpret_cast<const Vector3 *>(p_variant._data._mem);
@@ -2819,19 +2819,19 @@ void Variant::operator=(const Variant &p_variant) {
 		} break;
 
 		case AABB: {
-			*_data._aabb = *(p_variant._data._aabb);
+			*reinterpret_cast<::AABB *>(_data._ptr) = *reinterpret_cast<const ::AABB *>(p_variant._data._ptr);
 		} break;
 		case QUATERNION: {
 			*reinterpret_cast<Quaternion *>(_data._mem) = *reinterpret_cast<const Quaternion *>(p_variant._data._mem);
 		} break;
 		case BASIS: {
-			*_data._basis = *(p_variant._data._basis);
+			*reinterpret_cast<Basis *>(_data._ptr) = *(reinterpret_cast<const Basis *>(p_variant._data._ptr));
 		} break;
 		case TRANSFORM3D: {
-			*_data._transform3d = *(p_variant._data._transform3d);
+			*reinterpret_cast<Transform3D *>(_data._ptr) = *(reinterpret_cast<const Transform3D *>(p_variant._data._ptr));
 		} break;
 		case PROJECTION: {
-			*_data._projection = *(p_variant._data._projection);
+			*reinterpret_cast<Projection *>(_data._ptr) = *(reinterpret_cast<const Projection *>(p_variant._data._ptr));
 		} break;
 
 		// misc types
@@ -2866,34 +2866,34 @@ void Variant::operator=(const Variant &p_variant) {
 
 		// arrays
 		case PACKED_BYTE_ARRAY: {
-			_data.packed_array = PackedArrayRef<uint8_t>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<uint8_t>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		case PACKED_INT32_ARRAY: {
-			_data.packed_array = PackedArrayRef<int32_t>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<int32_t>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		case PACKED_INT64_ARRAY: {
-			_data.packed_array = PackedArrayRef<int64_t>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<int64_t>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		case PACKED_FLOAT32_ARRAY: {
-			_data.packed_array = PackedArrayRef<float>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<float>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		case PACKED_FLOAT64_ARRAY: {
-			_data.packed_array = PackedArrayRef<double>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<double>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		case PACKED_STRING_ARRAY: {
-			_data.packed_array = PackedArrayRef<String>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<String>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
-			_data.packed_array = PackedArrayRef<Vector2>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<Vector2>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		case PACKED_VECTOR3_ARRAY: {
-			_data.packed_array = PackedArrayRef<Vector3>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<Vector3>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		case PACKED_COLOR_ARRAY: {
-			_data.packed_array = PackedArrayRef<Color>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<Color>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		case PACKED_VECTOR4_ARRAY: {
-			_data.packed_array = PackedArrayRef<Vector4>::reference_from(_data.packed_array, p_variant._data.packed_array);
+			_data._ptr = PackedArrayRef<Vector4>::reference_from((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr);
 		} break;
 		default: {
 		}
@@ -2946,7 +2946,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case TRANSFORM2D: {
 			uint32_t h = HASH_MURMUR3_SEED;
-			const Transform2D &t = *_data._transform2d;
+			const Transform2D &t = *reinterpret_cast<Transform2D *>(_data._ptr);
 			h = hash_murmur3_one_real(t[0].x, h);
 			h = hash_murmur3_one_real(t[0].y, h);
 			h = hash_murmur3_one_real(t[1].x, h);
@@ -2978,7 +2978,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 			return hash_fmix32(h);
 		} break;
 		case AABB: {
-			return HashMapHasherDefault::hash(*_data._aabb);
+			return HashMapHasherDefault::hash(*(const ::AABB *)_data._ptr);
 		} break;
 		case QUATERNION: {
 			uint32_t h = HASH_MURMUR3_SEED;
@@ -2991,7 +2991,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case BASIS: {
 			uint32_t h = HASH_MURMUR3_SEED;
-			const Basis &b = *_data._basis;
+			const Basis &b = *reinterpret_cast<Basis *>(_data._ptr);
 			h = hash_murmur3_one_real(b[0].x, h);
 			h = hash_murmur3_one_real(b[0].y, h);
 			h = hash_murmur3_one_real(b[0].z, h);
@@ -3005,7 +3005,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case TRANSFORM3D: {
 			uint32_t h = HASH_MURMUR3_SEED;
-			const Transform3D &t = *_data._transform3d;
+			const Transform3D &t = *reinterpret_cast<Transform3D *>(_data._ptr);
 			h = hash_murmur3_one_real(t.basis[0].x, h);
 			h = hash_murmur3_one_real(t.basis[0].y, h);
 			h = hash_murmur3_one_real(t.basis[0].z, h);
@@ -3022,7 +3022,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PROJECTION: {
 			uint32_t h = HASH_MURMUR3_SEED;
-			const Projection &t = *_data._projection;
+			const Projection &t = *reinterpret_cast<Projection *>(_data._ptr);
 			h = hash_murmur3_one_real(t.columns[0].x, h);
 			h = hash_murmur3_one_real(t.columns[0].y, h);
 			h = hash_murmur3_one_real(t.columns[0].z, h);
@@ -3082,7 +3082,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_BYTE_ARRAY: {
-			const PackedByteArray &arr = PackedArrayRef<uint8_t>::get_array(_data.packed_array);
+			const PackedByteArray &arr = PackedArrayRef<uint8_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 			if (likely(len)) {
 				const uint8_t *r = arr.ptr();
@@ -3093,7 +3093,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_INT32_ARRAY: {
-			const PackedInt32Array &arr = PackedArrayRef<int32_t>::get_array(_data.packed_array);
+			const PackedInt32Array &arr = PackedArrayRef<int32_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 			if (likely(len)) {
 				const int32_t *r = arr.ptr();
@@ -3104,7 +3104,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_INT64_ARRAY: {
-			const PackedInt64Array &arr = PackedArrayRef<int64_t>::get_array(_data.packed_array);
+			const PackedInt64Array &arr = PackedArrayRef<int64_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 			if (likely(len)) {
 				const int64_t *r = arr.ptr();
@@ -3115,7 +3115,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_FLOAT32_ARRAY: {
-			const PackedFloat32Array &arr = PackedArrayRef<float>::get_array(_data.packed_array);
+			const PackedFloat32Array &arr = PackedArrayRef<float>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3131,7 +3131,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 
 		} break;
 		case PACKED_FLOAT64_ARRAY: {
-			const PackedFloat64Array &arr = PackedArrayRef<double>::get_array(_data.packed_array);
+			const PackedFloat64Array &arr = PackedArrayRef<double>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3148,7 +3148,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PACKED_STRING_ARRAY: {
 			uint32_t hash = HASH_MURMUR3_SEED;
-			const PackedStringArray &arr = PackedArrayRef<String>::get_array(_data.packed_array);
+			const PackedStringArray &arr = PackedArrayRef<String>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3164,7 +3164,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
 			uint32_t hash = HASH_MURMUR3_SEED;
-			const PackedVector2Array &arr = PackedArrayRef<Vector2>::get_array(_data.packed_array);
+			const PackedVector2Array &arr = PackedArrayRef<Vector2>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3181,7 +3181,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PACKED_VECTOR3_ARRAY: {
 			uint32_t hash = HASH_MURMUR3_SEED;
-			const PackedVector3Array &arr = PackedArrayRef<Vector3>::get_array(_data.packed_array);
+			const PackedVector3Array &arr = PackedArrayRef<Vector3>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3199,7 +3199,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PACKED_COLOR_ARRAY: {
 			uint32_t hash = HASH_MURMUR3_SEED;
-			const PackedColorArray &arr = PackedArrayRef<Color>::get_array(_data.packed_array);
+			const PackedColorArray &arr = PackedArrayRef<Color>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3218,7 +3218,7 @@ uint32_t Variant::recursive_hash(int recursion_count) const {
 		} break;
 		case PACKED_VECTOR4_ARRAY: {
 			uint32_t hash = HASH_MURMUR3_SEED;
-			const PackedVector4Array &arr = PackedArrayRef<Vector4>::get_array(_data.packed_array);
+			const PackedVector4Array &arr = PackedArrayRef<Vector4>::get_array((PackedArrayRefBase *)_data._ptr);
 			int len = arr.size();
 
 			if (likely(len)) {
@@ -3341,8 +3341,8 @@ bool Variant::hash_compare(const Variant &p_variant, int recursion_count, bool s
 		} break;
 
 		case TRANSFORM2D: {
-			Transform2D *l = _data._transform2d;
-			Transform2D *r = p_variant._data._transform2d;
+			Transform2D *l = reinterpret_cast<Transform2D *>(_data._ptr);
+			Transform2D *r = reinterpret_cast<Transform2D *>(p_variant._data._ptr);
 
 			for (int i = 0; i < 3; i++) {
 				if (!hash_compare_vector2(l->columns[i], r->columns[i])) {
@@ -3387,8 +3387,8 @@ bool Variant::hash_compare(const Variant &p_variant, int recursion_count, bool s
 		} break;
 
 		case AABB: {
-			const ::AABB *l = _data._aabb;
-			const ::AABB *r = p_variant._data._aabb;
+			const ::AABB *l = (const ::AABB *)_data._ptr;
+			const ::AABB *r = (const ::AABB *)p_variant._data._ptr;
 
 			return hash_compare_vector3(l->position, r->position) &&
 					hash_compare_vector3(l->size, r->size);
@@ -3403,8 +3403,8 @@ bool Variant::hash_compare(const Variant &p_variant, int recursion_count, bool s
 		} break;
 
 		case BASIS: {
-			const Basis *l = _data._basis;
-			const Basis *r = p_variant._data._basis;
+			const Basis *l = reinterpret_cast<Basis *>(_data._ptr);
+			const Basis *r = reinterpret_cast<Basis *>(p_variant._data._ptr);
 
 			for (int i = 0; i < 3; i++) {
 				if (!hash_compare_vector3(l->rows[i], r->rows[i])) {
@@ -3416,8 +3416,8 @@ bool Variant::hash_compare(const Variant &p_variant, int recursion_count, bool s
 		} break;
 
 		case TRANSFORM3D: {
-			const Transform3D *l = _data._transform3d;
-			const Transform3D *r = p_variant._data._transform3d;
+			const Transform3D *l = reinterpret_cast<Transform3D *>(_data._ptr);
+			const Transform3D *r = reinterpret_cast<Transform3D *>(p_variant._data._ptr);
 
 			for (int i = 0; i < 3; i++) {
 				if (!hash_compare_vector3(l->basis.rows[i], r->basis.rows[i])) {
@@ -3428,8 +3428,8 @@ bool Variant::hash_compare(const Variant &p_variant, int recursion_count, bool s
 			return hash_compare_vector3(l->origin, r->origin);
 		} break;
 		case PROJECTION: {
-			const Projection *l = _data._projection;
-			const Projection *r = p_variant._data._projection;
+			const Projection *l = reinterpret_cast<Projection *>(_data._ptr);
+			const Projection *r = reinterpret_cast<Projection *>(p_variant._data._ptr);
 
 			for (int i = 0; i < 4; i++) {
 				if (!hash_compare_vector4(l->columns[i], r->columns[i])) {
@@ -3471,27 +3471,27 @@ bool Variant::hash_compare(const Variant &p_variant, int recursion_count, bool s
 
 		// This is for floating point comparisons only.
 		case PACKED_FLOAT32_ARRAY: {
-			hash_compare_packed_array(_data.packed_array, p_variant._data.packed_array, float, hash_compare_scalar);
+			hash_compare_packed_array((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr, float, hash_compare_scalar);
 		} break;
 
 		case PACKED_FLOAT64_ARRAY: {
-			hash_compare_packed_array(_data.packed_array, p_variant._data.packed_array, double, hash_compare_scalar);
+			hash_compare_packed_array((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr, double, hash_compare_scalar);
 		} break;
 
 		case PACKED_VECTOR2_ARRAY: {
-			hash_compare_packed_array(_data.packed_array, p_variant._data.packed_array, Vector2, hash_compare_vector2);
+			hash_compare_packed_array((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr, Vector2, hash_compare_vector2);
 		} break;
 
 		case PACKED_VECTOR3_ARRAY: {
-			hash_compare_packed_array(_data.packed_array, p_variant._data.packed_array, Vector3, hash_compare_vector3);
+			hash_compare_packed_array((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr, Vector3, hash_compare_vector3);
 		} break;
 
 		case PACKED_COLOR_ARRAY: {
-			hash_compare_packed_array(_data.packed_array, p_variant._data.packed_array, Color, hash_compare_color);
+			hash_compare_packed_array((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr, Color, hash_compare_color);
 		} break;
 
 		case PACKED_VECTOR4_ARRAY: {
-			hash_compare_packed_array(_data.packed_array, p_variant._data.packed_array, Vector4, hash_compare_vector4);
+			hash_compare_packed_array((PackedArrayRefBase *)_data._ptr, (PackedArrayRefBase *)p_variant._data._ptr, Vector4, hash_compare_vector4);
 		} break;
 
 		default:
@@ -3534,7 +3534,7 @@ bool Variant::identity_compare(const Variant &p_variant) const {
 		case PACKED_VECTOR3_ARRAY:
 		case PACKED_COLOR_ARRAY:
 		case PACKED_VECTOR4_ARRAY: {
-			return _data.packed_array == p_variant._data.packed_array;
+			return _data._ptr == p_variant._data._ptr;
 		} break;
 
 		default: {

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -261,12 +261,6 @@ private:
 		bool _bool;
 		int64_t _int;
 		double _float;
-		Transform2D *_transform2d;
-		::AABB *_aabb;
-		Basis *_basis;
-		Transform3D *_transform3d;
-		Projection *_projection;
-		PackedArrayRefBase *packed_array;
 		void *_ptr; //generic pointer
 		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)]{ 0 };
 	} _data alignas(8);

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -125,6 +125,17 @@ public:
 		}
 	}
 
+#define GET_MEM(p_name, p_type)                                                                            \
+	_FORCE_INLINE_ static p_type *p_name(Variant *v) { return reinterpret_cast<p_type *>(v->_data._mem); } \
+	_FORCE_INLINE_ static const p_type *p_name(const Variant *v) { return reinterpret_cast<const p_type *>(v->_data._mem); }
+
+#define GET_PTR(p_name, p_type)                                                                            \
+	_FORCE_INLINE_ static p_type *p_name(Variant *v) { return reinterpret_cast<p_type *>(v->_data._ptr); } \
+	_FORCE_INLINE_ static const p_type *p_name(const Variant *v) { return reinterpret_cast<const p_type *>(v->_data._ptr); }
+#define GET_TYPEDARRAY(p_name, p_rettype, p_type)                                                                                                                        \
+	_FORCE_INLINE_ static p_rettype *p_name(Variant *v) { return &static_cast<Variant::PackedArrayRef<p_type> *>((Variant::PackedArrayRefBase *)v->_data._ptr)->array; } \
+	_FORCE_INLINE_ static const p_rettype *p_name(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<p_type> *>((const Variant::PackedArrayRefBase *)v->_data._ptr)->array; }
+
 	// Atomic types.
 	_FORCE_INLINE_ static bool *get_bool(Variant *v) { return &v->_data._bool; }
 	_FORCE_INLINE_ static const bool *get_bool(const Variant *v) { return &v->_data._bool; }
@@ -132,80 +143,50 @@ public:
 	_FORCE_INLINE_ static const int64_t *get_int(const Variant *v) { return &v->_data._int; }
 	_FORCE_INLINE_ static double *get_float(Variant *v) { return &v->_data._float; }
 	_FORCE_INLINE_ static const double *get_float(const Variant *v) { return &v->_data._float; }
-	_FORCE_INLINE_ static String *get_string(Variant *v) { return reinterpret_cast<String *>(v->_data._mem); }
-	_FORCE_INLINE_ static const String *get_string(const Variant *v) { return reinterpret_cast<const String *>(v->_data._mem); }
+	GET_MEM(get_string, String)
 
 	// Math types.
-	_FORCE_INLINE_ static Vector2 *get_vector2(Variant *v) { return reinterpret_cast<Vector2 *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector2 *get_vector2(const Variant *v) { return reinterpret_cast<const Vector2 *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector2i *get_vector2i(Variant *v) { return reinterpret_cast<Vector2i *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector2i *get_vector2i(const Variant *v) { return reinterpret_cast<const Vector2i *>(v->_data._mem); }
-	_FORCE_INLINE_ static Rect2 *get_rect2(Variant *v) { return reinterpret_cast<Rect2 *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Rect2 *get_rect2(const Variant *v) { return reinterpret_cast<const Rect2 *>(v->_data._mem); }
-	_FORCE_INLINE_ static Rect2i *get_rect2i(Variant *v) { return reinterpret_cast<Rect2i *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Rect2i *get_rect2i(const Variant *v) { return reinterpret_cast<const Rect2i *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector3 *get_vector3(Variant *v) { return reinterpret_cast<Vector3 *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector3 *get_vector3(const Variant *v) { return reinterpret_cast<const Vector3 *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector3i *get_vector3i(Variant *v) { return reinterpret_cast<Vector3i *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector3i *get_vector3i(const Variant *v) { return reinterpret_cast<const Vector3i *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector4 *get_vector4(Variant *v) { return reinterpret_cast<Vector4 *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector4 *get_vector4(const Variant *v) { return reinterpret_cast<const Vector4 *>(v->_data._mem); }
-	_FORCE_INLINE_ static Vector4i *get_vector4i(Variant *v) { return reinterpret_cast<Vector4i *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Vector4i *get_vector4i(const Variant *v) { return reinterpret_cast<const Vector4i *>(v->_data._mem); }
-	_FORCE_INLINE_ static Transform2D *get_transform2d(Variant *v) { return v->_data._transform2d; }
-	_FORCE_INLINE_ static const Transform2D *get_transform2d(const Variant *v) { return v->_data._transform2d; }
-	_FORCE_INLINE_ static Plane *get_plane(Variant *v) { return reinterpret_cast<Plane *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Plane *get_plane(const Variant *v) { return reinterpret_cast<const Plane *>(v->_data._mem); }
-	_FORCE_INLINE_ static Quaternion *get_quaternion(Variant *v) { return reinterpret_cast<Quaternion *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Quaternion *get_quaternion(const Variant *v) { return reinterpret_cast<const Quaternion *>(v->_data._mem); }
-	_FORCE_INLINE_ static ::AABB *get_aabb(Variant *v) { return v->_data._aabb; }
-	_FORCE_INLINE_ static const ::AABB *get_aabb(const Variant *v) { return v->_data._aabb; }
-	_FORCE_INLINE_ static Basis *get_basis(Variant *v) { return v->_data._basis; }
-	_FORCE_INLINE_ static const Basis *get_basis(const Variant *v) { return v->_data._basis; }
-	_FORCE_INLINE_ static Transform3D *get_transform(Variant *v) { return v->_data._transform3d; }
-	_FORCE_INLINE_ static const Transform3D *get_transform(const Variant *v) { return v->_data._transform3d; }
-	_FORCE_INLINE_ static Projection *get_projection(Variant *v) { return v->_data._projection; }
-	_FORCE_INLINE_ static const Projection *get_projection(const Variant *v) { return v->_data._projection; }
+	GET_MEM(get_vector2, Vector2)
+	GET_MEM(get_vector2i, Vector2i)
+	GET_MEM(get_vector3, Vector3)
+	GET_MEM(get_vector3i, Vector3i)
+	GET_MEM(get_vector4, Vector4)
+	GET_MEM(get_vector4i, Vector4i)
+	GET_MEM(get_rect2, Rect2)
+	GET_MEM(get_rect2i, Rect2i)
+	GET_MEM(get_plane, Plane)
+	GET_MEM(get_quaternion, Quaternion)
+	GET_PTR(get_transform2d, Transform2D)
+	GET_PTR(get_aabb, ::AABB)
+	GET_PTR(get_basis, Basis)
+	GET_PTR(get_transform, Transform3D)
+	GET_PTR(get_projection, Projection)
 
 	// Misc types.
-	_FORCE_INLINE_ static Color *get_color(Variant *v) { return reinterpret_cast<Color *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Color *get_color(const Variant *v) { return reinterpret_cast<const Color *>(v->_data._mem); }
-	_FORCE_INLINE_ static StringName *get_string_name(Variant *v) { return reinterpret_cast<StringName *>(v->_data._mem); }
-	_FORCE_INLINE_ static const StringName *get_string_name(const Variant *v) { return reinterpret_cast<const StringName *>(v->_data._mem); }
-	_FORCE_INLINE_ static NodePath *get_node_path(Variant *v) { return reinterpret_cast<NodePath *>(v->_data._mem); }
-	_FORCE_INLINE_ static const NodePath *get_node_path(const Variant *v) { return reinterpret_cast<const NodePath *>(v->_data._mem); }
-	_FORCE_INLINE_ static ::RID *get_rid(Variant *v) { return reinterpret_cast<::RID *>(v->_data._mem); }
-	_FORCE_INLINE_ static const ::RID *get_rid(const Variant *v) { return reinterpret_cast<const ::RID *>(v->_data._mem); }
-	_FORCE_INLINE_ static Callable *get_callable(Variant *v) { return reinterpret_cast<Callable *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Callable *get_callable(const Variant *v) { return reinterpret_cast<const Callable *>(v->_data._mem); }
-	_FORCE_INLINE_ static Signal *get_signal(Variant *v) { return reinterpret_cast<Signal *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Signal *get_signal(const Variant *v) { return reinterpret_cast<const Signal *>(v->_data._mem); }
-	_FORCE_INLINE_ static Dictionary *get_dictionary(Variant *v) { return reinterpret_cast<Dictionary *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Dictionary *get_dictionary(const Variant *v) { return reinterpret_cast<const Dictionary *>(v->_data._mem); }
-	_FORCE_INLINE_ static Array *get_array(Variant *v) { return reinterpret_cast<Array *>(v->_data._mem); }
-	_FORCE_INLINE_ static const Array *get_array(const Variant *v) { return reinterpret_cast<const Array *>(v->_data._mem); }
+	GET_MEM(get_color, Color)
+	GET_MEM(get_string_name, StringName)
+	GET_MEM(get_node_path, NodePath)
+	GET_MEM(get_rid, ::RID)
+	GET_MEM(get_callable, Callable)
+	GET_MEM(get_signal, Signal)
+	GET_MEM(get_dictionary, Dictionary)
+	GET_MEM(get_array, Array)
 
 	// Typed arrays.
-	_FORCE_INLINE_ static PackedByteArray *get_byte_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedByteArray *get_byte_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<uint8_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedInt32Array *get_int32_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedInt32Array *get_int32_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<int32_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedInt64Array *get_int64_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedInt64Array *get_int64_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<int64_t> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedFloat32Array *get_float32_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<float> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedFloat32Array *get_float32_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<float> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedFloat64Array *get_float64_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<double> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedFloat64Array *get_float64_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<double> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedStringArray *get_string_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<String> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedStringArray *get_string_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<String> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedVector2Array *get_vector2_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedVector2Array *get_vector2_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector2> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedVector3Array *get_vector3_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedVector3Array *get_vector3_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector3> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedColorArray *get_color_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedColorArray *get_color_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Color> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static PackedVector4Array *get_vector4_array(Variant *v) { return &static_cast<Variant::PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
-	_FORCE_INLINE_ static const PackedVector4Array *get_vector4_array(const Variant *v) { return &static_cast<const Variant::PackedArrayRef<Vector4> *>(v->_data.packed_array)->array; }
+	GET_TYPEDARRAY(get_byte_array, PackedByteArray, uint8_t)
+	GET_TYPEDARRAY(get_int32_array, PackedInt32Array, int32_t)
+	GET_TYPEDARRAY(get_int64_array, PackedInt64Array, int64_t)
+	GET_TYPEDARRAY(get_float32_array, PackedFloat32Array, float)
+	GET_TYPEDARRAY(get_float64_array, PackedFloat64Array, double)
+	GET_TYPEDARRAY(get_string_array, PackedStringArray, String)
+	GET_TYPEDARRAY(get_vector2_array, PackedVector2Array, Vector2)
+	GET_TYPEDARRAY(get_vector3_array, PackedVector3Array, Vector3)
+	GET_TYPEDARRAY(get_color_array, PackedColorArray, Color)
+	GET_TYPEDARRAY(get_vector4_array, PackedVector4Array, Vector4)
+
+#undef GET_MEM
+#undef GET_PTR
+#undef GET_TYPEDARRAY
 
 	_FORCE_INLINE_ static Object **get_object(Variant *v) { return (Object **)&v->_get_obj().obj; }
 	_FORCE_INLINE_ static const Object **get_object(const Variant *v) { return (const Object **)&v->_get_obj().obj; }
@@ -221,107 +202,54 @@ public:
 	// Those primitive and vector types don't need an `init_` method:
 	// Nil, bool, float, Vector2/i, Rect2/i, Vector3/i, Plane, Quat, RID.
 	// Object is a special case, handled via `object_reset_data`.
-	_FORCE_INLINE_ static void init_string(Variant *v) {
-		memnew_placement(v->_data._mem, String);
-		v->type = Variant::STRING;
+
+#define INIT_MEM(p_func_name, p_type)                    \
+	_FORCE_INLINE_ static void p_func_name(Variant *v) { \
+		memnew_placement(v->_data._mem, p_type);         \
+		v->type = GetTypeInfo<p_type>::VARIANT_TYPE;     \
 	}
-	_FORCE_INLINE_ static void init_transform2d(Variant *v) {
-		v->_data._transform2d = (Transform2D *)Variant::Pools::_bucket_small.alloc();
-		memnew_placement(v->_data._transform2d, Transform2D);
-		v->type = Variant::TRANSFORM2D;
+#define INIT_BUCKET(p_func_name, p_type, p_bucket_name)                     \
+	_FORCE_INLINE_ static void p_func_name(Variant *v) {                    \
+		v->_data._ptr = (p_type *)Variant::Pools::_##p_bucket_name.alloc(); \
+		memnew_placement(v->_data._ptr, p_type);                            \
+		v->type = GetTypeInfo<p_type>::VARIANT_TYPE;                        \
 	}
-	_FORCE_INLINE_ static void init_aabb(Variant *v) {
-		v->_data._aabb = (AABB *)Variant::Pools::_bucket_small.alloc();
-		memnew_placement(v->_data._aabb, AABB);
-		v->type = Variant::AABB;
+#define INIT_ARRAY(p_func_name, p_type, p_enum_type)                               \
+	_FORCE_INLINE_ static void p_func_name(Variant *v) {                           \
+		v->_data._ptr = Variant::PackedArrayRef<p_type>::create(Vector<p_type>()); \
+		v->type = p_enum_type;                                                     \
 	}
-	_FORCE_INLINE_ static void init_basis(Variant *v) {
-		v->_data._basis = (Basis *)Variant::Pools::_bucket_medium.alloc();
-		memnew_placement(v->_data._basis, Basis);
-		v->type = Variant::BASIS;
-	}
-	_FORCE_INLINE_ static void init_transform3d(Variant *v) {
-		v->_data._transform3d = (Transform3D *)Variant::Pools::_bucket_medium.alloc();
-		memnew_placement(v->_data._transform3d, Transform3D);
-		v->type = Variant::TRANSFORM3D;
-	}
-	_FORCE_INLINE_ static void init_projection(Variant *v) {
-		v->_data._projection = (Projection *)Variant::Pools::_bucket_large.alloc();
-		memnew_placement(v->_data._projection, Projection);
-		v->type = Variant::PROJECTION;
-	}
-	_FORCE_INLINE_ static void init_color(Variant *v) {
-		memnew_placement(v->_data._mem, Color);
-		v->type = Variant::COLOR;
-	}
-	_FORCE_INLINE_ static void init_string_name(Variant *v) {
-		memnew_placement(v->_data._mem, StringName);
-		v->type = Variant::STRING_NAME;
-	}
-	_FORCE_INLINE_ static void init_node_path(Variant *v) {
-		memnew_placement(v->_data._mem, NodePath);
-		v->type = Variant::NODE_PATH;
-	}
-	_FORCE_INLINE_ static void init_callable(Variant *v) {
-		memnew_placement(v->_data._mem, Callable);
-		v->type = Variant::CALLABLE;
-	}
-	_FORCE_INLINE_ static void init_signal(Variant *v) {
-		memnew_placement(v->_data._mem, Signal);
-		v->type = Variant::SIGNAL;
-	}
-	_FORCE_INLINE_ static void init_dictionary(Variant *v) {
-		memnew_placement(v->_data._mem, Dictionary);
-		v->type = Variant::DICTIONARY;
-	}
-	_FORCE_INLINE_ static void init_array(Variant *v) {
-		memnew_placement(v->_data._mem, Array);
-		v->type = Variant::ARRAY;
-	}
-	_FORCE_INLINE_ static void init_byte_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<uint8_t>::create(Vector<uint8_t>());
-		v->type = Variant::PACKED_BYTE_ARRAY;
-	}
-	_FORCE_INLINE_ static void init_int32_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<int32_t>::create(Vector<int32_t>());
-		v->type = Variant::PACKED_INT32_ARRAY;
-	}
-	_FORCE_INLINE_ static void init_int64_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<int64_t>::create(Vector<int64_t>());
-		v->type = Variant::PACKED_INT64_ARRAY;
-	}
-	_FORCE_INLINE_ static void init_float32_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<float>::create(Vector<float>());
-		v->type = Variant::PACKED_FLOAT32_ARRAY;
-	}
-	_FORCE_INLINE_ static void init_float64_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<double>::create(Vector<double>());
-		v->type = Variant::PACKED_FLOAT64_ARRAY;
-	}
-	_FORCE_INLINE_ static void init_string_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<String>::create(Vector<String>());
-		v->type = Variant::PACKED_STRING_ARRAY;
-	}
-	_FORCE_INLINE_ static void init_vector2_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<Vector2>::create(Vector<Vector2>());
-		v->type = Variant::PACKED_VECTOR2_ARRAY;
-	}
-	_FORCE_INLINE_ static void init_vector3_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<Vector3>::create(Vector<Vector3>());
-		v->type = Variant::PACKED_VECTOR3_ARRAY;
-	}
-	_FORCE_INLINE_ static void init_color_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<Color>::create(Vector<Color>());
-		v->type = Variant::PACKED_COLOR_ARRAY;
-	}
-	_FORCE_INLINE_ static void init_vector4_array(Variant *v) {
-		v->_data.packed_array = Variant::PackedArrayRef<Vector4>::create(Vector<Vector4>());
-		v->type = Variant::PACKED_VECTOR4_ARRAY;
-	}
+	INIT_MEM(init_string, String)
+	INIT_BUCKET(init_transform2d, Transform2D, bucket_small)
+	INIT_BUCKET(init_aabb, ::AABB, bucket_small)
+	INIT_BUCKET(init_basis, Basis, bucket_medium)
+	INIT_BUCKET(init_transform3d, Transform3D, bucket_medium)
+	INIT_BUCKET(init_projection, Projection, bucket_large)
+	INIT_MEM(init_color, Color)
+	INIT_MEM(init_string_name, StringName)
+	INIT_MEM(init_node_path, NodePath)
+	INIT_MEM(init_callable, Callable)
+	INIT_MEM(init_signal, Signal)
+	INIT_MEM(init_dictionary, Dictionary)
+	INIT_MEM(init_array, Array)
+	INIT_ARRAY(init_byte_array, uint8_t, Variant::PACKED_BYTE_ARRAY)
+	INIT_ARRAY(init_int32_array, int32_t, Variant::PACKED_INT32_ARRAY)
+	INIT_ARRAY(init_int64_array, int64_t, Variant::PACKED_INT64_ARRAY)
+	INIT_ARRAY(init_float32_array, float, Variant::PACKED_FLOAT32_ARRAY)
+	INIT_ARRAY(init_float64_array, double, Variant::PACKED_FLOAT64_ARRAY)
+	INIT_ARRAY(init_string_array, String, Variant::PACKED_STRING_ARRAY)
+	INIT_ARRAY(init_vector2_array, Vector2, Variant::PACKED_VECTOR2_ARRAY)
+	INIT_ARRAY(init_vector3_array, Vector3, Variant::PACKED_VECTOR3_ARRAY)
+	INIT_ARRAY(init_color_array, Color, Variant::PACKED_COLOR_ARRAY)
+	INIT_ARRAY(init_vector4_array, Vector4, Variant::PACKED_VECTOR4_ARRAY)
 	_FORCE_INLINE_ static void init_object(Variant *v) {
 		object_reset_data(v);
 		v->type = Variant::OBJECT;
 	}
+
+#undef INIT_MEM
+#undef INIT_BUCKET
+#undef INIT_ARRAY
 
 	_FORCE_INLINE_ static void clear(Variant *v) {
 		v->clear();
@@ -532,294 +460,69 @@ template <typename T>
 struct VariantGetInternalPtr {
 };
 
-template <>
-struct VariantGetInternalPtr<bool> {
-	static bool *get_ptr(Variant *v) { return VariantInternal::get_bool(v); }
-	static const bool *get_ptr(const Variant *v) { return VariantInternal::get_bool(v); }
-};
+#define GET_INTERNAL_PTR(p_type, p_method)                                                                      \
+	template <>                                                                                                 \
+	struct VariantGetInternalPtr<p_type> {                                                                      \
+		static p_type *get_ptr(Variant *v) { return (p_type *)VariantInternal::p_method(v); }                   \
+		static const p_type *get_ptr(const Variant *v) { return (const p_type *)VariantInternal::p_method(v); } \
+	};
+#define GET_INTERNAL_PTR_INT(p_type) GET_INTERNAL_PTR(p_type, get_int)
 
-template <>
-struct VariantGetInternalPtr<int8_t> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
+GET_INTERNAL_PTR(bool, get_bool)
 
-template <>
-struct VariantGetInternalPtr<uint8_t> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
+GET_INTERNAL_PTR_INT(int8_t)
+GET_INTERNAL_PTR_INT(uint8_t)
+GET_INTERNAL_PTR_INT(int16_t)
+GET_INTERNAL_PTR_INT(uint16_t)
+GET_INTERNAL_PTR_INT(int32_t)
+GET_INTERNAL_PTR_INT(uint32_t)
+GET_INTERNAL_PTR_INT(int64_t)
+GET_INTERNAL_PTR_INT(uint64_t)
+GET_INTERNAL_PTR_INT(char32_t)
+GET_INTERNAL_PTR_INT(ObjectID)
+GET_INTERNAL_PTR_INT(Error)
 
-template <>
-struct VariantGetInternalPtr<int16_t> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
+GET_INTERNAL_PTR(float, get_float)
+GET_INTERNAL_PTR(double, get_float)
 
-template <>
-struct VariantGetInternalPtr<uint16_t> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
+GET_INTERNAL_PTR(String, get_string)
+GET_INTERNAL_PTR(Transform2D, get_transform2d)
+GET_INTERNAL_PTR(::AABB, get_aabb)
+GET_INTERNAL_PTR(Basis, get_basis)
+GET_INTERNAL_PTR(Transform3D, get_transform)
+GET_INTERNAL_PTR(Projection, get_projection)
+GET_INTERNAL_PTR(Color, get_color)
+GET_INTERNAL_PTR(StringName, get_string_name)
+GET_INTERNAL_PTR(NodePath, get_node_path)
+GET_INTERNAL_PTR(Callable, get_callable)
+GET_INTERNAL_PTR(Signal, get_signal)
+GET_INTERNAL_PTR(Dictionary, get_dictionary)
+GET_INTERNAL_PTR(Array, get_array)
+GET_INTERNAL_PTR(Vector2, get_vector2)
+GET_INTERNAL_PTR(Vector3, get_vector3)
+GET_INTERNAL_PTR(Vector4, get_vector4)
+GET_INTERNAL_PTR(Vector2i, get_vector2i)
+GET_INTERNAL_PTR(Vector3i, get_vector3i)
+GET_INTERNAL_PTR(Vector4i, get_vector4i)
+GET_INTERNAL_PTR(Rect2, get_rect2)
+GET_INTERNAL_PTR(Rect2i, get_rect2i)
+GET_INTERNAL_PTR(Plane, get_plane)
+GET_INTERNAL_PTR(Quaternion, get_quaternion)
+GET_INTERNAL_PTR(::RID, get_rid)
 
-template <>
-struct VariantGetInternalPtr<int32_t> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
+GET_INTERNAL_PTR(PackedByteArray, get_byte_array)
+GET_INTERNAL_PTR(PackedInt32Array, get_int32_array)
+GET_INTERNAL_PTR(PackedInt64Array, get_int64_array)
+GET_INTERNAL_PTR(PackedFloat32Array, get_float32_array)
+GET_INTERNAL_PTR(PackedFloat64Array, get_float64_array)
+GET_INTERNAL_PTR(PackedStringArray, get_string_array)
+GET_INTERNAL_PTR(PackedVector2Array, get_vector2_array)
+GET_INTERNAL_PTR(PackedVector3Array, get_vector3_array)
+GET_INTERNAL_PTR(PackedColorArray, get_color_array)
+GET_INTERNAL_PTR(PackedVector4Array, get_vector4_array)
 
-template <>
-struct VariantGetInternalPtr<uint32_t> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<int64_t> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<uint64_t> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<char32_t> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<ObjectID> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Error> {
-	static int64_t *get_ptr(Variant *v) { return VariantInternal::get_int(v); }
-	static const int64_t *get_ptr(const Variant *v) { return VariantInternal::get_int(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<float> {
-	static double *get_ptr(Variant *v) { return VariantInternal::get_float(v); }
-	static const double *get_ptr(const Variant *v) { return VariantInternal::get_float(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<double> {
-	static double *get_ptr(Variant *v) { return VariantInternal::get_float(v); }
-	static const double *get_ptr(const Variant *v) { return VariantInternal::get_float(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<String> {
-	static String *get_ptr(Variant *v) { return VariantInternal::get_string(v); }
-	static const String *get_ptr(const Variant *v) { return VariantInternal::get_string(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Vector2> {
-	static Vector2 *get_ptr(Variant *v) { return VariantInternal::get_vector2(v); }
-	static const Vector2 *get_ptr(const Variant *v) { return VariantInternal::get_vector2(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Vector2i> {
-	static Vector2i *get_ptr(Variant *v) { return VariantInternal::get_vector2i(v); }
-	static const Vector2i *get_ptr(const Variant *v) { return VariantInternal::get_vector2i(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Rect2> {
-	static Rect2 *get_ptr(Variant *v) { return VariantInternal::get_rect2(v); }
-	static const Rect2 *get_ptr(const Variant *v) { return VariantInternal::get_rect2(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Rect2i> {
-	static Rect2i *get_ptr(Variant *v) { return VariantInternal::get_rect2i(v); }
-	static const Rect2i *get_ptr(const Variant *v) { return VariantInternal::get_rect2i(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Vector3> {
-	static Vector3 *get_ptr(Variant *v) { return VariantInternal::get_vector3(v); }
-	static const Vector3 *get_ptr(const Variant *v) { return VariantInternal::get_vector3(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Vector3i> {
-	static Vector3i *get_ptr(Variant *v) { return VariantInternal::get_vector3i(v); }
-	static const Vector3i *get_ptr(const Variant *v) { return VariantInternal::get_vector3i(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Vector4> {
-	static Vector4 *get_ptr(Variant *v) { return VariantInternal::get_vector4(v); }
-	static const Vector4 *get_ptr(const Variant *v) { return VariantInternal::get_vector4(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Vector4i> {
-	static Vector4i *get_ptr(Variant *v) { return VariantInternal::get_vector4i(v); }
-	static const Vector4i *get_ptr(const Variant *v) { return VariantInternal::get_vector4i(v); }
-};
-template <>
-struct VariantGetInternalPtr<Transform2D> {
-	static Transform2D *get_ptr(Variant *v) { return VariantInternal::get_transform2d(v); }
-	static const Transform2D *get_ptr(const Variant *v) { return VariantInternal::get_transform2d(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Transform3D> {
-	static Transform3D *get_ptr(Variant *v) { return VariantInternal::get_transform(v); }
-	static const Transform3D *get_ptr(const Variant *v) { return VariantInternal::get_transform(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Projection> {
-	static Projection *get_ptr(Variant *v) { return VariantInternal::get_projection(v); }
-	static const Projection *get_ptr(const Variant *v) { return VariantInternal::get_projection(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Plane> {
-	static Plane *get_ptr(Variant *v) { return VariantInternal::get_plane(v); }
-	static const Plane *get_ptr(const Variant *v) { return VariantInternal::get_plane(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Quaternion> {
-	static Quaternion *get_ptr(Variant *v) { return VariantInternal::get_quaternion(v); }
-	static const Quaternion *get_ptr(const Variant *v) { return VariantInternal::get_quaternion(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<::AABB> {
-	static ::AABB *get_ptr(Variant *v) { return VariantInternal::get_aabb(v); }
-	static const ::AABB *get_ptr(const Variant *v) { return VariantInternal::get_aabb(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Basis> {
-	static Basis *get_ptr(Variant *v) { return VariantInternal::get_basis(v); }
-	static const Basis *get_ptr(const Variant *v) { return VariantInternal::get_basis(v); }
-};
-
-//
-
-template <>
-struct VariantGetInternalPtr<Color> {
-	static Color *get_ptr(Variant *v) { return VariantInternal::get_color(v); }
-	static const Color *get_ptr(const Variant *v) { return VariantInternal::get_color(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<StringName> {
-	static StringName *get_ptr(Variant *v) { return VariantInternal::get_string_name(v); }
-	static const StringName *get_ptr(const Variant *v) { return VariantInternal::get_string_name(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<NodePath> {
-	static NodePath *get_ptr(Variant *v) { return VariantInternal::get_node_path(v); }
-	static const NodePath *get_ptr(const Variant *v) { return VariantInternal::get_node_path(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<::RID> {
-	static ::RID *get_ptr(Variant *v) { return VariantInternal::get_rid(v); }
-	static const ::RID *get_ptr(const Variant *v) { return VariantInternal::get_rid(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Callable> {
-	static Callable *get_ptr(Variant *v) { return VariantInternal::get_callable(v); }
-	static const Callable *get_ptr(const Variant *v) { return VariantInternal::get_callable(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Signal> {
-	static Signal *get_ptr(Variant *v) { return VariantInternal::get_signal(v); }
-	static const Signal *get_ptr(const Variant *v) { return VariantInternal::get_signal(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Dictionary> {
-	static Dictionary *get_ptr(Variant *v) { return VariantInternal::get_dictionary(v); }
-	static const Dictionary *get_ptr(const Variant *v) { return VariantInternal::get_dictionary(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<Array> {
-	static Array *get_ptr(Variant *v) { return VariantInternal::get_array(v); }
-	static const Array *get_ptr(const Variant *v) { return VariantInternal::get_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedByteArray> {
-	static PackedByteArray *get_ptr(Variant *v) { return VariantInternal::get_byte_array(v); }
-	static const PackedByteArray *get_ptr(const Variant *v) { return VariantInternal::get_byte_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedInt32Array> {
-	static PackedInt32Array *get_ptr(Variant *v) { return VariantInternal::get_int32_array(v); }
-	static const PackedInt32Array *get_ptr(const Variant *v) { return VariantInternal::get_int32_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedInt64Array> {
-	static PackedInt64Array *get_ptr(Variant *v) { return VariantInternal::get_int64_array(v); }
-	static const PackedInt64Array *get_ptr(const Variant *v) { return VariantInternal::get_int64_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedFloat32Array> {
-	static PackedFloat32Array *get_ptr(Variant *v) { return VariantInternal::get_float32_array(v); }
-	static const PackedFloat32Array *get_ptr(const Variant *v) { return VariantInternal::get_float32_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedFloat64Array> {
-	static PackedFloat64Array *get_ptr(Variant *v) { return VariantInternal::get_float64_array(v); }
-	static const PackedFloat64Array *get_ptr(const Variant *v) { return VariantInternal::get_float64_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedStringArray> {
-	static PackedStringArray *get_ptr(Variant *v) { return VariantInternal::get_string_array(v); }
-	static const PackedStringArray *get_ptr(const Variant *v) { return VariantInternal::get_string_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedVector2Array> {
-	static PackedVector2Array *get_ptr(Variant *v) { return VariantInternal::get_vector2_array(v); }
-	static const PackedVector2Array *get_ptr(const Variant *v) { return VariantInternal::get_vector2_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedVector3Array> {
-	static PackedVector3Array *get_ptr(Variant *v) { return VariantInternal::get_vector3_array(v); }
-	static const PackedVector3Array *get_ptr(const Variant *v) { return VariantInternal::get_vector3_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedColorArray> {
-	static PackedColorArray *get_ptr(Variant *v) { return VariantInternal::get_color_array(v); }
-	static const PackedColorArray *get_ptr(const Variant *v) { return VariantInternal::get_color_array(v); }
-};
-
-template <>
-struct VariantGetInternalPtr<PackedVector4Array> {
-	static PackedVector4Array *get_ptr(Variant *v) { return VariantInternal::get_vector4_array(v); }
-	static const PackedVector4Array *get_ptr(const Variant *v) { return VariantInternal::get_vector4_array(v); }
-};
+#undef GET_INTERNAL_PTR
+#undef GET_INTERNAL_PTR_INT
 
 template <typename T>
 struct VariantInternalAccessor {
@@ -847,12 +550,7 @@ VARIANT_ACCESSOR_NUMBER(uint32_t)
 VARIANT_ACCESSOR_NUMBER(int64_t)
 VARIANT_ACCESSOR_NUMBER(uint64_t)
 VARIANT_ACCESSOR_NUMBER(char32_t)
-
-template <>
-struct VariantInternalAccessor<ObjectID> {
-	static _FORCE_INLINE_ ObjectID get(const Variant *v) { return ObjectID(*VariantInternal::get_int(v)); }
-	static _FORCE_INLINE_ void set(Variant *v, ObjectID p_value) { *VariantInternal::get_int(v) = p_value; }
-};
+VARIANT_ACCESSOR_NUMBER(ObjectID)
 
 template <typename T>
 struct VariantInternalAccessor<T *> {
@@ -1169,57 +867,27 @@ struct VariantInitializer<String> {
 	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_string(v); }
 };
 
-template <>
-struct VariantInitializer<Vector2> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Vector2>(v); }
-};
+#define INITIALIZER_GENERIC(m_type)                                                               \
+	template <>                                                                                   \
+	struct VariantInitializer<m_type> {                                                           \
+		static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<m_type>(v); } \
+	};
 
-template <>
-struct VariantInitializer<Vector2i> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Vector2i>(v); }
-};
-
-template <>
-struct VariantInitializer<Rect2> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Rect2>(v); }
-};
-
-template <>
-struct VariantInitializer<Rect2i> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Rect2i>(v); }
-};
-
-template <>
-struct VariantInitializer<Vector3> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Vector3>(v); }
-};
-
-template <>
-struct VariantInitializer<Vector3i> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Vector3i>(v); }
-};
-template <>
-struct VariantInitializer<Vector4> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Vector4>(v); }
-};
-
-template <>
-struct VariantInitializer<Vector4i> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Vector4i>(v); }
-};
+INITIALIZER_GENERIC(Vector2)
+INITIALIZER_GENERIC(Vector2i)
+INITIALIZER_GENERIC(Rect2)
+INITIALIZER_GENERIC(Rect2i)
+INITIALIZER_GENERIC(Vector3)
+INITIALIZER_GENERIC(Vector3i)
+INITIALIZER_GENERIC(Vector4)
+INITIALIZER_GENERIC(Vector4i)
+INITIALIZER_GENERIC(Plane)
+INITIALIZER_GENERIC(Quaternion)
+INITIALIZER_GENERIC(Color)
+INITIALIZER_GENERIC(::RID)
 template <>
 struct VariantInitializer<Transform2D> {
 	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_transform2d(v); }
-};
-
-template <>
-struct VariantInitializer<Plane> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Plane>(v); }
-};
-
-template <>
-struct VariantInitializer<Quaternion> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Quaternion>(v); }
 };
 
 template <>
@@ -1242,11 +910,6 @@ struct VariantInitializer<Projection> {
 };
 
 template <>
-struct VariantInitializer<Color> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<Color>(v); }
-};
-
-template <>
 struct VariantInitializer<StringName> {
 	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_string_name(v); }
 };
@@ -1254,11 +917,6 @@ struct VariantInitializer<StringName> {
 template <>
 struct VariantInitializer<NodePath> {
 	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_node_path(v); }
-};
-
-template <>
-struct VariantInitializer<::RID> {
-	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<::RID>(v); }
 };
 
 template <>

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -1396,7 +1396,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case PACKED_BYTE_ARRAY: {
-			const Vector<uint8_t> *arr = &PackedArrayRef<uint8_t>::get_array(_data.packed_array);
+			const Vector<uint8_t> *arr = &PackedArrayRef<uint8_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1405,7 +1405,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_INT32_ARRAY: {
-			const Vector<int32_t> *arr = &PackedArrayRef<int32_t>::get_array(_data.packed_array);
+			const Vector<int32_t> *arr = &PackedArrayRef<int32_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1414,7 +1414,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_INT64_ARRAY: {
-			const Vector<int64_t> *arr = &PackedArrayRef<int64_t>::get_array(_data.packed_array);
+			const Vector<int64_t> *arr = &PackedArrayRef<int64_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1423,7 +1423,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_FLOAT32_ARRAY: {
-			const Vector<float> *arr = &PackedArrayRef<float>::get_array(_data.packed_array);
+			const Vector<float> *arr = &PackedArrayRef<float>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1432,7 +1432,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_FLOAT64_ARRAY: {
-			const Vector<double> *arr = &PackedArrayRef<double>::get_array(_data.packed_array);
+			const Vector<double> *arr = &PackedArrayRef<double>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1441,7 +1441,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_STRING_ARRAY: {
-			const Vector<String> *arr = &PackedArrayRef<String>::get_array(_data.packed_array);
+			const Vector<String> *arr = &PackedArrayRef<String>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1449,7 +1449,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
-			const Vector<Vector2> *arr = &PackedArrayRef<Vector2>::get_array(_data.packed_array);
+			const Vector<Vector2> *arr = &PackedArrayRef<Vector2>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1457,7 +1457,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case PACKED_VECTOR3_ARRAY: {
-			const Vector<Vector3> *arr = &PackedArrayRef<Vector3>::get_array(_data.packed_array);
+			const Vector<Vector3> *arr = &PackedArrayRef<Vector3>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1465,7 +1465,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case PACKED_COLOR_ARRAY: {
-			const Vector<Color> *arr = &PackedArrayRef<Color>::get_array(_data.packed_array);
+			const Vector<Color> *arr = &PackedArrayRef<Color>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1474,7 +1474,7 @@ bool Variant::iter_init(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_VECTOR4_ARRAY: {
-			const Vector<Vector4> *arr = &PackedArrayRef<Vector4>::get_array(_data.packed_array);
+			const Vector<Vector4> *arr = &PackedArrayRef<Vector4>::get_array((PackedArrayRefBase *)_data._ptr);
 			if (arr->size() == 0) {
 				return false;
 			}
@@ -1636,7 +1636,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case PACKED_BYTE_ARRAY: {
-			const Vector<uint8_t> *arr = &PackedArrayRef<uint8_t>::get_array(_data.packed_array);
+			const Vector<uint8_t> *arr = &PackedArrayRef<uint8_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1647,7 +1647,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_INT32_ARRAY: {
-			const Vector<int32_t> *arr = &PackedArrayRef<int32_t>::get_array(_data.packed_array);
+			const Vector<int32_t> *arr = &PackedArrayRef<int32_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			int32_t idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1658,7 +1658,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_INT64_ARRAY: {
-			const Vector<int64_t> *arr = &PackedArrayRef<int64_t>::get_array(_data.packed_array);
+			const Vector<int64_t> *arr = &PackedArrayRef<int64_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			int64_t idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1669,7 +1669,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_FLOAT32_ARRAY: {
-			const Vector<float> *arr = &PackedArrayRef<float>::get_array(_data.packed_array);
+			const Vector<float> *arr = &PackedArrayRef<float>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1680,7 +1680,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_FLOAT64_ARRAY: {
-			const Vector<double> *arr = &PackedArrayRef<double>::get_array(_data.packed_array);
+			const Vector<double> *arr = &PackedArrayRef<double>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1691,7 +1691,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 
 		} break;
 		case PACKED_STRING_ARRAY: {
-			const Vector<String> *arr = &PackedArrayRef<String>::get_array(_data.packed_array);
+			const Vector<String> *arr = &PackedArrayRef<String>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1701,7 +1701,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
-			const Vector<Vector2> *arr = &PackedArrayRef<Vector2>::get_array(_data.packed_array);
+			const Vector<Vector2> *arr = &PackedArrayRef<Vector2>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1711,7 +1711,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case PACKED_VECTOR3_ARRAY: {
-			const Vector<Vector3> *arr = &PackedArrayRef<Vector3>::get_array(_data.packed_array);
+			const Vector<Vector3> *arr = &PackedArrayRef<Vector3>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1721,7 +1721,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case PACKED_COLOR_ARRAY: {
-			const Vector<Color> *arr = &PackedArrayRef<Color>::get_array(_data.packed_array);
+			const Vector<Color> *arr = &PackedArrayRef<Color>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1731,7 +1731,7 @@ bool Variant::iter_next(Variant &r_iter, bool &valid) const {
 			return true;
 		} break;
 		case PACKED_VECTOR4_ARRAY: {
-			const Vector<Vector4> *arr = &PackedArrayRef<Vector4>::get_array(_data.packed_array);
+			const Vector<Vector4> *arr = &PackedArrayRef<Vector4>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 			idx++;
 			if (idx >= arr->size()) {
@@ -1816,7 +1816,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_BYTE_ARRAY: {
-			const Vector<uint8_t> *arr = &PackedArrayRef<uint8_t>::get_array(_data.packed_array);
+			const Vector<uint8_t> *arr = &PackedArrayRef<uint8_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {
@@ -1827,7 +1827,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_INT32_ARRAY: {
-			const Vector<int32_t> *arr = &PackedArrayRef<int32_t>::get_array(_data.packed_array);
+			const Vector<int32_t> *arr = &PackedArrayRef<int32_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			int32_t idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {
@@ -1838,7 +1838,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_INT64_ARRAY: {
-			const Vector<int64_t> *arr = &PackedArrayRef<int64_t>::get_array(_data.packed_array);
+			const Vector<int64_t> *arr = &PackedArrayRef<int64_t>::get_array((PackedArrayRefBase *)_data._ptr);
 			int64_t idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {
@@ -1849,7 +1849,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_FLOAT32_ARRAY: {
-			const Vector<float> *arr = &PackedArrayRef<float>::get_array(_data.packed_array);
+			const Vector<float> *arr = &PackedArrayRef<float>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {
@@ -1860,7 +1860,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_FLOAT64_ARRAY: {
-			const Vector<double> *arr = &PackedArrayRef<double>::get_array(_data.packed_array);
+			const Vector<double> *arr = &PackedArrayRef<double>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {
@@ -1871,7 +1871,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_STRING_ARRAY: {
-			const Vector<String> *arr = &PackedArrayRef<String>::get_array(_data.packed_array);
+			const Vector<String> *arr = &PackedArrayRef<String>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {
@@ -1882,7 +1882,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_VECTOR2_ARRAY: {
-			const Vector<Vector2> *arr = &PackedArrayRef<Vector2>::get_array(_data.packed_array);
+			const Vector<Vector2> *arr = &PackedArrayRef<Vector2>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {
@@ -1893,7 +1893,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_VECTOR3_ARRAY: {
-			const Vector<Vector3> *arr = &PackedArrayRef<Vector3>::get_array(_data.packed_array);
+			const Vector<Vector3> *arr = &PackedArrayRef<Vector3>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {
@@ -1904,7 +1904,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_COLOR_ARRAY: {
-			const Vector<Color> *arr = &PackedArrayRef<Color>::get_array(_data.packed_array);
+			const Vector<Color> *arr = &PackedArrayRef<Color>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {
@@ -1915,7 +1915,7 @@ Variant Variant::iter_get(const Variant &r_iter, bool &r_valid) const {
 			return arr->get(idx);
 		} break;
 		case PACKED_VECTOR4_ARRAY: {
-			const Vector<Vector4> *arr = &PackedArrayRef<Vector4>::get_array(_data.packed_array);
+			const Vector<Vector4> *arr = &PackedArrayRef<Vector4>::get_array((PackedArrayRefBase *)_data._ptr);
 			int idx = r_iter;
 #ifdef DEBUG_ENABLED
 			if (idx < 0 || idx >= arr->size()) {

--- a/platform/windows/godot.natvis
+++ b/platform/windows/godot.natvis
@@ -168,18 +168,18 @@
 		<DisplayString Condition="type == Variant::BOOL">{_data._bool}</DisplayString>
 		<DisplayString Condition="type == Variant::INT">{_data._int}</DisplayString>
 		<DisplayString Condition="type == Variant::FLOAT">{_data._float}</DisplayString>
-		<DisplayString Condition="type == Variant::TRANSFORM2D">{_data._transform2d}</DisplayString>
-		<DisplayString Condition="type == Variant::AABB">{_data._aabb}</DisplayString>
-		<DisplayString Condition="type == Variant::BASIS">{_data._basis}</DisplayString>
-		<DisplayString Condition="type == Variant::TRANSFORM3D">{_data._transform3d}</DisplayString>
-		<DisplayString Condition="type == Variant::PROJECTION">{_data._projection}</DisplayString>
+		<DisplayString Condition="type == Variant::TRANSFORM2D">{*(Transform2D *)_data._ptr}</DisplayString>
+		<DisplayString Condition="type == Variant::AABB">{*(::AABB *)_data._ptr}</DisplayString>
+		<DisplayString Condition="type == Variant::BASIS">{*(Basis *)_data._ptr}</DisplayString>
+		<DisplayString Condition="type == Variant::TRANSFORM3D">{*(Transform3D *)_data._ptr}</DisplayString>
+		<DisplayString Condition="type == Variant::PROJECTION">{*(Projection *)_data._ptr}</DisplayString>
+		<DisplayString Condition="type == Variant::QUATERNION">{*(Quaternion *)_data._ptr}</DisplayString>
 		<DisplayString Condition="type == Variant::STRING">{*(String *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::VECTOR2">{*(Vector2 *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::RECT2">{*(Rect2 *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::VECTOR3">{*(Vector3 *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::VECTOR4">{*(Vector4 *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::PLANE">{*(Plane *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::QUATERNION">{*(Quaternion *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::COLOR">{*(Color *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::STRING_NAME">{*(StringName *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::NODE_PATH">{*(NodePath *)_data._mem}</DisplayString>
@@ -187,16 +187,16 @@
 		<DisplayString Condition="type == Variant::OBJECT">{*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj}</DisplayString>
 		<DisplayString Condition="type == Variant::DICTIONARY">{*(Dictionary *)_data._mem}</DisplayString>
 		<DisplayString Condition="type == Variant::ARRAY">{*(Array *)_data._mem}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_BYTE_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_INT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_INT64_ARRAY">{*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_FLOAT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_FLOAT64_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_STRING_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_VECTOR2_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_VECTOR3_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_COLOR_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array}</DisplayString>
-		<DisplayString Condition="type == Variant::PACKED_VECTOR4_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_BYTE_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_INT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_INT64_ARRAY">{*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;(PackedArrayRefBase*)_data._ptr[1])}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_FLOAT32_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_FLOAT64_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_STRING_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_VECTOR2_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_VECTOR3_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_COLOR_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array}</DisplayString>
+		<DisplayString Condition="type == Variant::PACKED_VECTOR4_ARRAY">{reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array}</DisplayString>
 		<DisplayString Condition="type &lt; 0 || type >= Variant::VARIANT_MAX">[INVALID]</DisplayString>
 
 		<StringView Condition="type == Variant::STRING &amp;&amp; ((String *)(_data._mem))->_cowdata._ptr">((String *)(_data._mem))->_cowdata._ptr,s32</StringView>
@@ -205,10 +205,11 @@
 			<Item Name="[value]" Condition="type == Variant::BOOL">_data._bool</Item>
 			<Item Name="[value]" Condition="type == Variant::INT">_data._int</Item>
 			<Item Name="[value]" Condition="type == Variant::FLOAT">_data._float</Item>
-			<Item Name="[value]" Condition="type == Variant::TRANSFORM2D">_data._transform2d</Item>
-			<Item Name="[value]" Condition="type == Variant::AABB">_data._aabb</Item>
-			<Item Name="[value]" Condition="type == Variant::BASIS">_data._basis</Item>
-			<Item Name="[value]" Condition="type == Variant::TRANSFORM3D">_data._transform3d</Item>
+			<Item Name="[value]" Condition="type == Variant::TRANSFORM2D">*(Transform2D *)_data._ptr</Item>
+			<Item Name="[value]" Condition="type == Variant::AABB">*(::AABB *)_data._ptr</Item>
+			<Item Name="[value]" Condition="type == Variant::BASIS">*(Basis *)_data._ptr</Item>
+			<Item Name="[value]" Condition="type == Variant::TRANSFORM3D">*(Transform3D *)_data._ptr</Item>
+			<Item Name="[value]" Condition="type == Variant::PROJECTION">*(Projection *)_data._ptr</Item>
 			<Item Name="[value]" Condition="type == Variant::STRING">*(String *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::VECTOR2">*(Vector2 *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::RECT2">*(Rect2 *)_data._mem</Item>
@@ -222,16 +223,16 @@
 			<Item Name="[value]" Condition="type == Variant::OBJECT">*(*reinterpret_cast&lt;ObjData*&gt;(&amp;_data._mem[0])).obj</Item>
 			<Item Name="[value]" Condition="type == Variant::DICTIONARY">*(Dictionary *)_data._mem</Item>
 			<Item Name="[value]" Condition="type == Variant::ARRAY">*(Array *)_data._mem</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_BYTE_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_INT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_INT64_ARRAY">*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;_data.packed_array[1])</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT64_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_STRING_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR2_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR3_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_COLOR_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;(_data.packed_array)->array</Item>
-			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR4_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;(_data.packed_array)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_BYTE_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;unsigned char&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_INT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;int&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_INT64_ARRAY">*reinterpret_cast&lt;PackedInt64Array *&gt;(&amp;(PackedArrayRefBase*)_data._ptr[1])</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT32_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;float&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_FLOAT64_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;double&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_STRING_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;String&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR2_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector2&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR3_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector3&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_COLOR_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Color&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array</Item>
+			<Item Name="[value]" Condition="type == Variant::PACKED_VECTOR4_ARRAY">reinterpret_cast&lt;const Variant::PackedArrayRef&lt;Vector4&gt;*&gt;((PackedArrayRefBase*)_data._ptr)->array</Item>
 
 		</Expand>
 	</Type>


### PR DESCRIPTION
As the engine grew, we havent had many refactors to favor maintainability and readability in the core ever since 4.0.
This PR's objective is to make Variant easier, make copy pasting code better and make it so maintaining specific types and even adding them is easier.