### PR TITLE
Increase precision in `linear_to_srgb()` and `srgb_to_linear()`

### DIFF
--- a/core/math/color.h
+++ b/core/math/color.h
@@ -187,16 +187,16 @@ struct [[nodiscard]] Color {
 
 	_FORCE_INLINE_ Color srgb_to_linear() const {
 		return Color(
-				r < 0.04045f ? r * (1.0f / 12.92f) : Math::pow((r + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
-				g < 0.04045f ? g * (1.0f / 12.92f) : Math::pow((g + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
-				b < 0.04045f ? b * (1.0f / 12.92f) : Math::pow((b + 0.055f) * (float)(1.0 / (1.0 + 0.055)), 2.4f),
+				r < 0.04045f ? r * (1.0f / 12.92f) : Math::pow(float((r + 0.055) * (1.0 / (1.0 + 0.055))), 2.4f),
+				g < 0.04045f ? g * (1.0f / 12.92f) : Math::pow(float((g + 0.055) * (1.0 / (1.0 + 0.055))), 2.4f),
+				b < 0.04045f ? b * (1.0f / 12.92f) : Math::pow(float((b + 0.055) * (1.0 / (1.0 + 0.055))), 2.4f),
 				a);
 	}
 	_FORCE_INLINE_ Color linear_to_srgb() const {
 		return Color(
-				r < 0.0031308f ? 12.92f * r : (1.0f + 0.055f) * Math::pow(r, 1.0f / 2.4f) - 0.055f,
-				g < 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * Math::pow(g, 1.0f / 2.4f) - 0.055f,
-				b < 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * Math::pow(b, 1.0f / 2.4f) - 0.055f, a);
+				r < 0.0031308f ? 12.92f * r : (1.0 + 0.055) * Math::pow(r, 1.0f / 2.4f) - 0.055,
+				g < 0.0031308f ? 12.92f * g : (1.0 + 0.055) * Math::pow(g, 1.0f / 2.4f) - 0.055,
+				b < 0.0031308f ? 12.92f * b : (1.0 + 0.055) * Math::pow(b, 1.0f / 2.4f) - 0.055, a);
 	}
 
 	static Color hex(uint32_t p_hex);

--- a/tests/core/math/test_color.h
+++ b/tests/core/math/test_color.h
@@ -160,6 +160,12 @@ TEST_CASE("[Color] Linear <-> sRGB conversion") {
 	CHECK_MESSAGE(
 			color_srgb.srgb_to_linear().is_equal_approx(Color(0.35, 0.5, 0.6, 0.7)),
 			"The sRGB color converted back to linear color space should match the expected value.");
+	CHECK_MESSAGE(
+			Color(1.0, 1.0, 1.0, 1.0).srgb_to_linear() == (Color(1.0, 1.0, 1.0, 1.0)),
+			"White converted from sRGB to linear should remain white.");
+	CHECK_MESSAGE(
+			Color(1.0, 1.0, 1.0, 1.0).linear_to_srgb() == (Color(1.0, 1.0, 1.0, 1.0)),
+			"White converted from linear to sRGB should remain white.");
 }
 
 TEST_CASE("[Color] Named colors") {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/100517

This was a combined regression from https://github.com/godotengine/godot/pull/93802 and https://github.com/godotengine/godot/pull/57703

https://github.com/godotengine/godot/pull/57703 forced most color functions to use floating point operations which is nice for performance and generally makes sense. However, in this specific case, double precision is needed. 

This PR removes the float literal qualifiers from just enough places to allow the compiler to make a smart decision about how much to keep in floating point and how much to do with doubles. In theory this will be slightly slower, but we have no choice. 

The regression became apparent after https://github.com/godotengine/godot/pull/93802 because the canvas modulate color is always 1 by default and converting it to linear (which is needed when using a linear viewport) turns it into 0.99999988. Which, when applied over many frames by ping-ponging the buffer, results in a darkening of the viewport. Presumably every other place where these functions are called is tolerant of this slight precision error. 

I added tests to ensure that we don't accidentally make the same mistake again. This is a case where `is_equal_approx()` has too high of a tolerance and we need to use exact floating point comparison with `==`.
