### PR TITLE
Improve CharacterBody script templates.

### DIFF
--- a/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody2D/basic_movement.gd
@@ -3,25 +3,40 @@
 extends _BASE_
 
 
-const SPEED = 300.0
-const JUMP_VELOCITY = -400.0
+# The @export annotation allows a variable to be shown and modified from the inspector.
+@export var speed: float = 300.0
+@export var accel: float = 300.0
+@export var jump_speed: float = -400.0
 
 
 func _physics_process(delta: float) -> void:
-	# Add the gravity.
+	# Handle gravity.
 	if not is_on_floor():
 		velocity += get_gravity() * delta
 
+	# Get the vertical velocity.
+	var vertical_velocity: Vector2 = velocity.project(up_direction)
+
+	# Get the horizontal velocity.
+	var horizontal_velocity: Vector2 = velocity - vertical_velocity
+
 	# Handle jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
-		velocity.y = JUMP_VELOCITY
+		vertical_velocity = up_direction * jump_speed
 
-	# Get the input direction and handle the movement/deceleration.
 	# As good practice, you should replace UI actions with custom gameplay actions.
-	var direction := Input.get_axis("ui_left", "ui_right")
-	if direction:
-		velocity.x = direction * SPEED
-	else:
-		velocity.x = move_toward(velocity.x, 0, SPEED)
+	var input_axis: float = Input.get_axis("ui_left", "ui_right")
+
+	# Calculate the intended direction in 2D plane.
+	var input_direction: Vector2 = Vector2(input_axis, 0).rotated(rotation)
+
+	# Calculate the target horizontal velocity.
+	var target_horizontal_velocity: Vector2 = input_direction * speed
+
+	# Move the current horizontal velocity towards the target horizontal velocity.
+	horizontal_velocity = horizontal_velocity.move_toward(target_horizontal_velocity, accel * delta)
+
+	# Compose the final velocity.
+	velocity = horizontal_velocity + vertical_velocity
 
 	move_and_slide()

--- a/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
+++ b/modules/gdscript/editor/script_templates/CharacterBody3D/basic_movement.gd
@@ -2,29 +2,40 @@
 
 extends _BASE_
 
-
-const SPEED = 5.0
-const JUMP_VELOCITY = 4.5
+# The @export annotation allows a variable to be shown and modified from the inspector.
+@export var speed: float = 5.0
+@export var accel: float = 5.0
+@export var jump_speed: float = 4.5
 
 
 func _physics_process(delta: float) -> void:
-	# Add the gravity.
+	# Handle gravity.
 	if not is_on_floor():
 		velocity += get_gravity() * delta
 
+	# Get the vertical velocity.
+	var vertical_velocity: Vector3 = velocity.project(up_direction)
+
+	# Get the horizontal velocity.
+	var horizontal_velocity: Vector3 = velocity - vertical_velocity
+
 	# Handle jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
-		velocity.y = JUMP_VELOCITY
+		vertical_velocity = up_direction * jump_speed
 
-	# Get the input direction and handle the movement/deceleration.
 	# As good practice, you should replace UI actions with custom gameplay actions.
-	var input_dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
-	var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
-	if direction:
-		velocity.x = direction.x * SPEED
-		velocity.z = direction.z * SPEED
-	else:
-		velocity.x = move_toward(velocity.x, 0, SPEED)
-		velocity.z = move_toward(velocity.z, 0, SPEED)
+	var input_vector: Vector2 = Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down", 0.15)
+
+	# Calculate the intended direction in 3D space.
+	var input_direction: Vector3 = transform.basis.orthonormalized() * Vector3(input_vector.x, 0, input_vector.y)
+
+	# Calculate the target horizontal velocity.
+	var target_horizontal_velocity: Vector3 = input_direction * speed
+
+	# Move the current horizontal velocity towards the target horizontal velocity.
+	horizontal_velocity = horizontal_velocity.move_toward(target_horizontal_velocity, accel * delta)
+
+	# Compose the final velocity.
+	velocity = horizontal_velocity + vertical_velocity
 
 	move_and_slide()

--- a/modules/mono/editor/script_templates/CharacterBody2D/basic_movement.cs
+++ b/modules/mono/editor/script_templates/CharacterBody2D/basic_movement.cs
@@ -5,38 +5,54 @@ using System;
 
 public partial class _CLASS_ : _BASE_
 {
-    public const float Speed = 300.0f;
-    public const float JumpVelocity = -400.0f;
+    // The [Export] attribute allows a variable to be shown and modified from the inspector.
+    [Export]
+	public float speed = 300.0f;
 
-    public override void _PhysicsProcess(double delta)
-    {
-        Vector2 velocity = Velocity;
+    [Export]
+	public float accel = 300.0f;
 
-        // Add the gravity.
-        if (!IsOnFloor())
-        {
-            velocity += GetGravity() * (float)delta;
-        }
+    [Export]
+	public float jumpSpeed = -400.0f;
 
-        // Handle Jump.
-        if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())
-        {
-            velocity.Y = JumpVelocity;
-        }
+	public override void _PhysicsProcess(double delta)
+	{
+		Vector2 velocity = Velocity;
 
-        // Get the input direction and handle the movement/deceleration.
-        // As good practice, you should replace UI actions with custom gameplay actions.
-        Vector2 direction = Input.GetVector("ui_left", "ui_right", "ui_up", "ui_down");
-        if (direction != Vector2.Zero)
-        {
-            velocity.X = direction.X * Speed;
-        }
-        else
-        {
-            velocity.X = Mathf.MoveToward(Velocity.X, 0, Speed);
-        }
+		// Handle gravity.
+		if (!IsOnFloor())
+		{
+			velocity += GetGravity() * (float)delta;
+		}
 
-        Velocity = velocity;
-        MoveAndSlide();
-    }
+		// Get the vertical velocity.
+		Vector2 verticalVelocity = velocity.Project(UpDirection);
+
+		// Get the horizontal velocity.
+		Vector2 horizontalVelocity = velocity - verticalVelocity;
+
+		// Handle Jump.
+		if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())
+		{
+			verticalVelocity = UpDirection * jumpSpeed;
+		}
+
+		// As good practice, you should replace UI actions with custom gameplay actions.
+		float inputAxis = Input.GetAxis("ui_left", "ui_right");
+
+		// Calculate the intended direction in 2D plane.
+		Vector2 inputDirection = new Vector2(inputAxis, 0).Rotated(Rotation);
+
+		// Calculate the target horizontal velocity.
+		Vector2 targetHorizontalVelocity = inputDirection * speed;
+
+		// Move the current horizontal velocity towards the target horizontal velocity.
+		horizontalVelocity = horizontalVelocity.MoveToward(targetHorizontalVelocity, accel * (float)delta);
+
+		// Compose the final velocity.
+		velocity = horizontalVelocity + verticalVelocity;
+
+		Velocity = velocity;
+		MoveAndSlide();
+	}
 }


### PR DESCRIPTION
This PR improves the default CharacterBody template for both 2D and 3D.  It fixes the following issues:

**Input distortion:**

The line:

`var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()`

Performs the basis multiplication against a potentially non orthonormal basis.  This is often the result of an object which doesn't have an scale of 1. However, because the normalization happens after the possibly wrong basis multiplication, the direction of the original input is now lost. This can be observed if you scale one of the axis to be bigger and move diagonally.

This has been fixed by removing the normalization (Which is not necessary because get_vector always reports at max a unit vector) and using an orthonormal basis instead. The scale no longer alters the input direction. This also allowed to use an smaller deadzone for the joystick, allowing the template to work with controllers too and illustrate how is done.

**Acceleration had multiple issues:**

It was accelerating instantly, but slowing down is done by moving the speed towards zero in an FPS dependent way, as there is no use of delta involved. Also, accelerating per axis is geometrically incorrect (Same issue as with non normalized vectors) and causes a very unnatural feeling. Also, the fps deceleration was the max speed.

```
if direction:
		velocity.x = direction.x * SPEED
		velocity.z = direction.z * SPEED
	else:
		velocity.x = move_toward(velocity.x, 0, SPEED)
		velocity.z = move_toward(velocity.z, 0, SPEED)
```

Now we isolate the horizontal component of our velocity and perform correct acceleration/deceleration

```
# Move the current horizontal velocity towards the target horizontal velocity by the acceleration factor multiplied by delta.
horizontal_velocity = horizontal_velocity.move_toward(target_horizontal_velocity, ACCEL * delta)
```

I have also taken into account the up vector of the CharacterBody node. We were ignoring it and assuming always an up vector of ` 0 1 0`. Now everything is done having into account that the up vector is arbitrary.

I have tested it and works nicely. The c# versions are my first attempt with MONO, so i  would appreciate some help in those to make sure i followed conventions properly.
