### PR TITLE
Decal: Fix crash when setting empty texture

### DIFF
--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -46,14 +46,14 @@ void Decal::set_texture(DecalTexture p_type, const Ref<Texture2D> &p_texture) {
 	RID texture_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 
 #ifdef DEBUG_ENABLED
-	if (
-			p_texture->is_class("AnimatedTexture") ||
-			p_texture->is_class("AtlasTexture") ||
-			p_texture->is_class("CameraTexture") ||
-			p_texture->is_class("CanvasTexture") ||
-			p_texture->is_class("MeshTexture") ||
-			p_texture->is_class("Texture2DRD") ||
-			p_texture->is_class("ViewportTexture")) {
+	if (p_texture.is_valid() &&
+			(p_texture->is_class("AnimatedTexture") ||
+					p_texture->is_class("AtlasTexture") ||
+					p_texture->is_class("CameraTexture") ||
+					p_texture->is_class("CanvasTexture") ||
+					p_texture->is_class("MeshTexture") ||
+					p_texture->is_class("Texture2DRD") ||
+					p_texture->is_class("ViewportTexture"))) {
 		WARN_PRINT(vformat("%s cannot be used as a Decal texture (%s). As a workaround, assign the value returned by %s's `get_image()` instead.", p_texture->get_class(), get_path(), p_texture->get_class()));
 	}
 #endif


### PR DESCRIPTION
Fix-up to #88349.