### PR TITLE
Don't recursively call `_update_tree`

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -369,7 +369,7 @@ void SceneTreeEditor::_update_node_subtree(Node *p_node, TreeItem *p_parent, boo
 			item->set_selectable(0, false);
 			item->deselect(0);
 			if (selected == p_node) {
-				set_selected(nullptr, false);
+				selected = nullptr;
 			}
 		}
 	}


### PR DESCRIPTION
When a node was previously selected and the test "selected == p_node" was true the code would use set_selected() to change the selection to nullptr. However, if the tree is dirty, which is always true in this codepath, this would lead to a recursive call to _update_tree() ultimately leading to a crash due to us running out of stack.

This fixes #100666
