### PR TITLE
[MenuBar] Use PopupMenu title property as a menu name.

### DIFF
--- a/doc/classes/MenuBar.xml
+++ b/doc/classes/MenuBar.xml
@@ -4,7 +4,7 @@
 		A horizontal menu bar that creates a menu for each [PopupMenu] child.
 	</brief_description>
 	<description>
-		A horizontal menu bar that creates a menu for each [PopupMenu] child. New items are created by adding [PopupMenu]s to this node.
+		A horizontal menu bar that creates a menu for each [PopupMenu] child. New items are created by adding [PopupMenu]s to this node. Item title is determined by [member Window.title], or node name if [member Window.title] is empty. Item title can be overridden using [method set_menu_title].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -768,6 +768,11 @@
 				Emitted when the [constant NOTIFICATION_THEME_CHANGED] notification is sent.
 			</description>
 		</signal>
+		<signal name="title_changed">
+			<description>
+				Emitted when window title bar text is changed.
+			</description>
+		</signal>
 		<signal name="titlebar_changed">
 			<description>
 				Emitted when window title bar decorations are changed, e.g. macOS window enter/exit full screen mode, or extend-to-title flag is changed.

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -507,8 +507,9 @@ void MenuBar::_refresh_menu_names() {
 
 	Vector<PopupMenu *> popups = _get_popups();
 	for (int i = 0; i < popups.size(); i++) {
-		if (!popups[i]->has_meta("_menu_name") && String(popups[i]->get_name()) != get_menu_title(i)) {
-			menu_cache.write[i].name = popups[i]->get_name();
+		String menu_name = popups[i]->get_title().is_empty() ? String(popups[i]->get_name()) : popups[i]->get_title();
+		if (!popups[i]->has_meta("_menu_name") && menu_name != get_menu_title(i)) {
+			menu_cache.write[i].name = menu_name;
 			shape(menu_cache.write[i]);
 			queue_redraw();
 			if (is_global && menu_cache[i].submenu_rid.is_valid()) {
@@ -547,6 +548,24 @@ int MenuBar::get_menu_idx_from_control(PopupMenu *p_child) const {
 	return -1;
 }
 
+void MenuBar::_popup_changed(ObjectID p_menu) {
+	PopupMenu *pm = Object::cast_to<PopupMenu>(ObjectDB::get_instance(p_menu));
+	if (!pm) {
+		return;
+	}
+
+	int idx = get_menu_idx_from_control(pm);
+
+	String menu_name = pm->get_title().is_empty() ? String(pm->get_name()) : pm->get_title();
+	menu_name = String(pm->get_meta("_menu_name", menu_name));
+
+	menu_cache.write[idx].name = menu_name;
+	shape(menu_cache.write[idx]);
+
+	update_minimum_size();
+	queue_redraw();
+}
+
 void MenuBar::add_child_notify(Node *p_child) {
 	Control::add_child_notify(p_child);
 
@@ -554,8 +573,11 @@ void MenuBar::add_child_notify(Node *p_child) {
 	if (!pm) {
 		return;
 	}
-	Menu menu = Menu(p_child->get_name());
+	String menu_name = pm->get_title().is_empty() ? String(pm->get_name()) : pm->get_title();
+	Menu menu = Menu(menu_name);
 	shape(menu);
+
+	pm->connect("title_changed", callable_mp(this, &MenuBar::_popup_changed).bind(pm->get_instance_id()), CONNECT_REFERENCE_COUNTED);
 
 	menu_cache.push_back(menu);
 	p_child->connect("renamed", callable_mp(this, &MenuBar::_refresh_menu_names));
@@ -584,7 +606,8 @@ void MenuBar::move_child_notify(Node *p_child) {
 	}
 
 	int old_idx = -1;
-	String menu_name = String(pm->get_meta("_menu_name", pm->get_name()));
+	String menu_name = pm->get_title().is_empty() ? String(pm->get_name()) : pm->get_title();
+	menu_name = String(pm->get_meta("_menu_name", menu_name));
 	// Find the previous menu index of the control.
 	for (int i = 0; i < get_menu_count(); i++) {
 		if (get_menu_title(i) == menu_name) {
@@ -640,6 +663,7 @@ void MenuBar::remove_child_notify(Node *p_child) {
 		}
 	}
 
+	pm->disconnect("title_changed", callable_mp(this, &MenuBar::_popup_changed));
 	menu_cache.remove_at(idx);
 
 	p_child->remove_meta("_menu_name");
@@ -827,7 +851,8 @@ int MenuBar::get_menu_count() const {
 void MenuBar::set_menu_title(int p_menu, const String &p_title) {
 	ERR_FAIL_INDEX(p_menu, menu_cache.size());
 	PopupMenu *pm = get_menu_popup(p_menu);
-	if (p_title == pm->get_name()) {
+	String menu_name = pm->get_title().is_empty() ? String(pm->get_name()) : pm->get_title();
+	if (p_title == menu_name) {
 		pm->remove_meta("_menu_name");
 	} else {
 		pm->set_meta("_menu_name", p_title);

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -135,6 +135,8 @@ class MenuBar : public Control {
 		return -1;
 	}
 
+	void _popup_changed(ObjectID p_menu);
+
 	void bind_global_menu();
 	void unbind_global_menu();
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -303,6 +303,7 @@ void Window::set_title(const String &p_title) {
 			}
 		}
 	}
+	emit_signal("title_changed");
 }
 
 String Window::get_title() const {
@@ -3044,6 +3045,7 @@ void Window::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("theme_changed"));
 	ADD_SIGNAL(MethodInfo("dpi_changed"));
 	ADD_SIGNAL(MethodInfo("titlebar_changed"));
+	ADD_SIGNAL(MethodInfo("title_changed"));
 
 	BIND_CONSTANT(NOTIFICATION_VISIBILITY_CHANGED);
 	BIND_CONSTANT(NOTIFICATION_THEME_CHANGED);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/100660

`title` property is used first, if it's empty node name is used like it was before. `set_menu_title` still can be used to override it.