### PR TITLE
Properly transform light rect and occluder rect to perform Light2D culling in canvas space

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -857,7 +857,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 		Light *light = p_lights;
 
 		while (light) {
-			if (light->render_index_cache >= 0 && p_item->light_mask & light->item_mask && p_item->z_final >= light->z_min && p_item->z_final <= light->z_max && p_item->global_rect_cache.intersects_transformed(light->xform_cache, light->rect_cache)) {
+			if (light->render_index_cache >= 0 && p_item->light_mask & light->item_mask && p_item->z_final >= light->z_min && p_item->z_final <= light->z_max && p_item->global_rect_cache.intersects(light->rect_cache)) {
 				uint32_t light_index = light->render_index_cache;
 				lights[light_count >> 2] |= light_index << ((light_count & 3) * 8);
 

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1035,14 +1035,14 @@ void RendererCanvasRenderRD::light_update_shadow(RID p_rid, int p_shadow_index, 
 	while (instance) {
 		OccluderPolygon *co = occluder_polygon_owner.get_or_null(instance->occluder);
 
+		occluder_count++;
+
 		if (!co || co->index_array.is_null()) {
 			instance = instance->next;
 			continue;
 		}
 
-		occluder_count++;
-
-		if (!(p_light_mask & instance->light_mask) || !p_light_rect.intersects(instance->aabb_cache)) {
+		if (!(p_light_mask & instance->light_mask) || !p_light_rect.intersects_transformed(instance->xform_cache, instance->aabb_cache)) {
 			instance = instance->next;
 			continue;
 		}
@@ -2353,7 +2353,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 		Light *light = p_lights;
 
 		while (light) {
-			if (light->render_index_cache >= 0 && p_item->light_mask & light->item_mask && p_item->z_final >= light->z_min && p_item->z_final <= light->z_max && p_item->global_rect_cache.intersects_transformed(light->xform_cache, light->rect_cache)) {
+			if (light->render_index_cache >= 0 && p_item->light_mask & light->item_mask && p_item->z_final >= light->z_min && p_item->z_final <= light->z_max && p_item->global_rect_cache.intersects(light->rect_cache)) {
 				uint32_t light_index = light->render_index_cache;
 				lights[light_count >> 2] |= light_index << ((light_count & 3) * 8);
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -413,7 +413,9 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 						cl->xform_cache = xf * cl->xform_cache;
 					}
 
-					if (clip_rect.intersects_transformed(cl->xform_cache, cl->rect_cache)) {
+					Rect2 temp_rect = cl->xform_cache.xform(cl->rect_cache);
+
+					if (clip_rect.intersects(temp_rect)) {
 						cl->filter_next_ptr = lights;
 						lights = cl;
 						Transform2D scale;
@@ -423,12 +425,13 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 						if (cl->use_shadow) {
 							cl->shadows_next_ptr = lights_with_shadow;
 							if (lights_with_shadow == nullptr) {
-								shadow_rect = cl->xform_cache.xform(cl->rect_cache);
+								shadow_rect = temp_rect;
 							} else {
-								shadow_rect = shadow_rect.merge(cl->xform_cache.xform(cl->rect_cache));
+								shadow_rect = shadow_rect.merge(temp_rect);
 							}
 							lights_with_shadow = cl;
 							cl->radius_cache = cl->rect_cache.size.length();
+							cl->rect_cache = temp_rect;
 						}
 					}
 				}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/100664

There were two problems reported by #100664:
1. Weird crash when adding a light occluder
2. Shadows not appearing

The crash was caused by incrementing the occluder count after checking if the occluder had a valid polygon. Later, we copy over the transform for each occluder regardless of whether the polygon exists, so the occluder count needs to increment for each occluder, not each _valid_ occluder.

The shadows not appearing came from false negatives when culling occluders against individual lights. The culling was done using the rect of the light against the aabb (rect) of the occluder which are both in their own local spaces. If the item transforms were similar, then this didn't create any issues. But when the transforms differ enough, then the culling fails when it shouldn't. The solution was to transform both rects into canvas space and do culling in canvas space. For the `light->rect_cache` I was able to do the transformation early and save a bunch of transformations later (we were doing the transformation 2 times for each light + once for each light for each canvasitem on screen), now we do it only once per frame per light). 

This further optimizes the CPU cost of using PointLight2Ds. On my M2 MBP, this increases the FPS in a release build of my light performance benchmark from 550 FPS to 650 FPS and from 400 FPS to 500 FPS in dev builds. The benchmark is from https://github.com/godotengine/godot/pull/100302