### PR TITLE
Add a context menu to quick open dialog

### DIFF
--- a/editor/gui/editor_quick_open_dialog.h
+++ b/editor/gui/editor_quick_open_dialog.h
@@ -42,6 +42,7 @@ class LineEdit;
 class HFlowContainer;
 class MarginContainer;
 class PanelContainer;
+class PopupMenu;
 class ScrollContainer;
 class StringName;
 class Texture2D;
@@ -80,6 +81,11 @@ protected:
 
 class QuickOpenResultContainer : public VBoxContainer {
 	GDCLASS(QuickOpenResultContainer, VBoxContainer)
+
+	enum {
+		FILE_SHOW_IN_FILESYSTEM,
+		FILE_SHOW_IN_FILE_MANAGER
+	};
 
 public:
 	void init(const Vector<StringName> &p_base_types);
@@ -124,6 +130,7 @@ private:
 	ScrollContainer *scroll_container = nullptr;
 	VBoxContainer *list = nullptr;
 	HFlowContainer *grid = nullptr;
+	PopupMenu *file_context_menu = nullptr;
 
 	PanelContainer *panel_container = nullptr;
 	CenterContainer *no_results_container = nullptr;
@@ -160,6 +167,7 @@ private:
 	void _toggle_display_mode();
 	void _toggle_include_addons(bool p_pressed);
 	void _toggle_fuzzy_search(bool p_pressed);
+	void _menu_option(int p_option);
 
 	static void _bind_methods();
 };


### PR DESCRIPTION
Allow showing `Quick Open` results in the FileSystem tab and in external OS file manager.

closes https://github.com/godotengine/godot-proposals/issues/10061

