### PR TITLE
Scene Shaders - Anisotropy Fixes

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1293,7 +1293,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-		vec3 B, vec3 T, float anisotropy,
+		vec3 T, vec3 B, float anisotropy,
 #endif
 		inout vec3 diffuse_light, inout vec3 specular_light) {
 
@@ -1386,9 +1386,14 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 		// shlick+ggx as default
 		float alpha_ggx = roughness * roughness;
 #if defined(LIGHT_ANISOTROPY_USED)
-		float aspect = sqrt(1.0 - anisotropy * 0.9);
+		float aspect = sqrt(1.0 - abs(anisotropy) * 0.9);
 		float ax = alpha_ggx / aspect;
 		float ay = alpha_ggx * aspect;
+		if (anisotropy < 0.0) {
+			float atemp = ax;
+			ax = ay;
+			ay = atemp;
+		}
 		float XdotH = dot(T, H);
 		float YdotH = dot(B, H);
 		float D = D_GGX_anisotropic(cNdotH, ax, ay, XdotH, YdotH);
@@ -1457,7 +1462,7 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-		vec3 binormal, vec3 tangent, float anisotropy,
+		vec3 tangent, vec3 binormal, float anisotropy,
 #endif
 		inout vec3 diffuse_light, inout vec3 specular_light) {
 	vec3 light_rel_vec = omni_lights[idx].position - vertex;
@@ -1484,7 +1489,7 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 			clearcoat, clearcoat_roughness, vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-			binormal, tangent, anisotropy,
+			tangent, binormal, anisotropy,
 #endif
 			diffuse_light,
 			specular_light);
@@ -1503,7 +1508,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-		vec3 binormal, vec3 tangent, float anisotropy,
+		vec3 tangent, vec3 binormal, float anisotropy,
 #endif
 		inout vec3 diffuse_light,
 		inout vec3 specular_light) {
@@ -1540,7 +1545,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 f
 			clearcoat, clearcoat_roughness, vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-			binormal, tangent, anisotropy,
+			tangent, binormal, anisotropy,
 #endif
 			diffuse_light, specular_light);
 }
@@ -1922,14 +1927,17 @@ void main() {
 #endif // NORMAL_MAP_USED
 
 #ifdef LIGHT_ANISOTROPY_USED
+	// Tangent basis must be reconstructed from per-pixel normal and normalized, otherwise specular highlights become warped.
+	// This has the added benefit of allowing normal maps to affect anisotropic specularity.
+	tangent = normalize(cross(binormal, normal));
+	binormal = cross(normal, tangent); // No need to normalize, as the cross product of two orthogonal normalized vectors is itself normalized.
 
-	if (anisotropy > 0.01) {
-		mat3 rot = mat3(normalize(tangent), normalize(binormal), normal);
-		// Make local to space.
-		tangent = normalize(rot * vec3(anisotropy_flow.x, anisotropy_flow.y, 0.0));
-		binormal = normalize(rot * vec3(-anisotropy_flow.y, anisotropy_flow.x, 0.0));
+	if (abs(anisotropy) > 0.01) { // Make anisotropic basis local to view space.
+		mat3 rot = mat3(tangent, binormal, normal);
+		anisotropy_flow = normalize(anisotropy_flow);
+		tangent = rot * vec3(anisotropy_flow.x, anisotropy_flow.y, 0.0);
+		binormal = rot * vec3(-anisotropy_flow.y, anisotropy_flow.x, 0.0);
 	}
-
 #endif
 
 #ifndef MODE_RENDER_DEPTH
@@ -1975,7 +1983,7 @@ void main() {
 		vec3 anisotropic_direction = anisotropy >= 0.0 ? binormal : tangent;
 		vec3 anisotropic_tangent = cross(anisotropic_direction, view);
 		vec3 anisotropic_normal = cross(anisotropic_tangent, anisotropic_direction);
-		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * clamp(5.0 * roughness, 0.0, 1.0)));
+		vec3 bent_normal = normalize(mix(normal, anisotropic_normal, abs(anisotropy) * 0.75 * clamp(5.0 * roughness, 0.0, 1.0)));
 		vec3 ref_vec = reflect(-view, bent_normal);
 #else
 		vec3 ref_vec = reflect(-view, normal);
@@ -2160,8 +2168,7 @@ void main() {
 				clearcoat, clearcoat_roughness, geo_normal,
 #endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-				binormal,
-				tangent, anisotropy,
+				tangent, binormal, anisotropy,
 #endif
 				diffuse_light,
 				specular_light);
@@ -2186,7 +2193,7 @@ void main() {
 				clearcoat, clearcoat_roughness, geo_normal,
 #endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-				binormal, tangent, anisotropy,
+				tangent, binormal, anisotropy,
 #endif
 				diffuse_light, specular_light);
 	}
@@ -2210,8 +2217,7 @@ void main() {
 				clearcoat, clearcoat_roughness, geo_normal,
 #endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-				tangent,
-				binormal, anisotropy,
+				tangent, binormal, anisotropy,
 #endif
 				diffuse_light, specular_light);
 	}
@@ -2470,8 +2476,7 @@ void main() {
 			clearcoat, clearcoat_roughness, geo_normal,
 #endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-			binormal,
-			tangent, anisotropy,
+			tangent, binormal, anisotropy,
 #endif
 			diffuse_light,
 			specular_light);
@@ -2503,7 +2508,7 @@ void main() {
 			clearcoat, clearcoat_roughness, geo_normal,
 #endif // LIGHT_CLEARCOAT_USED
 #ifdef LIGHT_ANISOTROPY_USED
-			binormal, tangent, anisotropy,
+			tangent, binormal, anisotropy,
 #endif
 			diffuse_light, specular_light);
 #else
@@ -2533,8 +2538,7 @@ void main() {
 			clearcoat, clearcoat_roughness, geo_normal,
 #endif // LIGHT_RIM_USED
 #ifdef LIGHT_ANISOTROPY_USED
-			tangent,
-			binormal, anisotropy,
+			tangent, binormal, anisotropy,
 #endif
 			diffuse_light, specular_light);
 #else

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -56,7 +56,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-		vec3 B, vec3 T, float anisotropy,
+		vec3 T, vec3 B, float anisotropy,
 #endif
 		inout vec3 diffuse_light, inout vec3 specular_light) {
 	vec4 orms_unpacked = unpackUnorm4x8(orms);
@@ -198,9 +198,14 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 			// shlick+ggx as default
 			float alpha_ggx = roughness * roughness;
 #if defined(LIGHT_ANISOTROPY_USED)
-			float aspect = sqrt(1.0 - anisotropy * 0.9);
+			float aspect = sqrt(1.0 - abs(anisotropy) * 0.9);
 			float ax = alpha_ggx / aspect;
 			float ay = alpha_ggx * aspect;
+			if (anisotropy < 0.0) {
+				float atemp = ax;
+				ax = ay;
+				ay = atemp;
+			}
 			float XdotH = dot(T, H);
 			float YdotH = dot(B, H);
 			float D = D_GGX_anisotropic(cNdotH, ax, ay, XdotH, YdotH);
@@ -402,7 +407,7 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-		vec3 binormal, vec3 tangent, float anisotropy,
+		vec3 tangent, vec3 binormal, float anisotropy,
 #endif
 		inout vec3 diffuse_light, inout vec3 specular_light) {
 	const float EPSILON = 1e-3f;
@@ -662,7 +667,7 @@ void light_process_omni(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 			clearcoat, clearcoat_roughness, vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-			binormal, tangent, anisotropy,
+			tangent, binormal, anisotropy,
 #endif
 			diffuse_light,
 			specular_light);
@@ -696,7 +701,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 		float clearcoat, float clearcoat_roughness, vec3 vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-		vec3 binormal, vec3 tangent, float anisotropy,
+		vec3 tangent, vec3 binormal, float anisotropy,
 #endif
 		inout vec3 diffuse_light,
 		inout vec3 specular_light) {
@@ -862,7 +867,7 @@ void light_process_spot(uint idx, vec3 vertex, vec3 eye_vec, vec3 normal, vec3 v
 			clearcoat, clearcoat_roughness, vertex_normal,
 #endif
 #ifdef LIGHT_ANISOTROPY_USED
-			binormal, tangent, anisotropy,
+			tangent, binormal, anisotropy,
 #endif
 			diffuse_light, specular_light);
 }


### PR DESCRIPTION
Part four of: #100348

Addresses six errors found in the scene shader files that relate to anisotropic specularity.

- Anisotropic specular highlights were warped compared to isotropic highlights, and also unaffected by normal mapping.
The fix for both of these issues, as found in #78339, is to reconstruct the anisotropic tangent basis from the shading normal in the fragment shader.
**Note**: I can confirm that, as mentioned in https://github.com/godotengine/godot/pull/78339#discussion_r1265776711, this must be done whether normal mapping is used or not. To offset the added cost of this, I've made some minor optimizations to this section of code, so the final performance difference should be negligible.

- The mapping of the `anisotropy` parameter to X and Y roughness was not symmetrical, meaning it only produced correctly stretched highlights for positive `anisotropy` values, while negative values produced significantly less stretch. This is because the formulation in question, from Disney's BSDF, was designed for [0,1] `anisotropy` values, not [-1,1].
By using the absolute value of `anisotropy` and simply swapping X and Y roughness based on its sign, highlights are now stretched the same amount for both negative and positive values.

- The anisotropic `tangent` and `binormal` were reversed in several places, causing the anisotropic flow direction to be off by 90 degrees for omni/spot lights.
The corrected behaviour now matches Filament (positive `anisotropy` is along U, negative is along V).
For future reference, you should _always_ do `tangent` followed by `binormal` to avoid confusion.

- The anisotropic tangent and binormal were only calculated when `anisotropy > 0.01` rather than `abs(anisotropy) > 0.01`, which is important given that anisotropy is a [-1,1] value.

- The faux-anisotropic `bent_normal` vector used for sampling indirect reflections was a bit too strong, causing reflections to become visibly reversed over `anisotropy` values of ~0.75.

- In the **Mobile** renderer, `reflection_process` was called using `bent_normal` in place of `normal`.
`normal` is only used to get the diffuse contribution of the probe, and we don't do anisotropic diffuse in any capacity, so this is incorrect.

Note that due to point three, some assets will need to be adjusted depending on the lighting conditions they were originally configured in, but this is simply a matter of negating their `anisotropy` parameter if their highlight is going the wrong direction.

Below is a material tester comparison. The top row shows an `anisotropy` value of `1.0`, the bottom shows `-1.0`.
| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b489f48c-1f22-4973-844a-9a2e0b04ef68) | ![image](https://github.com/user-attachments/assets/45f9b0c3-195a-4190-950b-9958445ef302) |
| ![image](https://github.com/user-attachments/assets/5216a082-555e-4019-8f5b-3dd6c45f758a) | ![image](https://github.com/user-attachments/assets/83191318-365c-4b23-bfa9-4eaae9599ad9) | 