### PR TITLE
Make `LocalVector` -> `Vector` automatic conversion safe for non-trivial types.

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -295,10 +295,16 @@ public:
 
 	operator Vector<T>() const {
 		Vector<T> ret;
-		ret.resize(size());
+		ret.resize(count);
 		T *w = ret.ptrw();
 		if (w) {
-			memcpy(w, data, sizeof(T) * count);
+			if constexpr (std::is_trivially_copyable_v<T>) {
+				memcpy(w, data, sizeof(T) * count);
+			} else {
+				for (U i = 0; i < count; i++) {
+					w[i] = data[i];
+				}
+			}
 		}
 		return ret;
 	}


### PR DESCRIPTION
We can be lucky it hasn't caused problems so far. I've looked through all its uses, and it appears so far it's only been used for trivial types.