### PR TITLE
[4.3] Fix various code examples in documentation

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -21,11 +21,11 @@
 		var array = new Godot.Collections.Array{"First", 2, 3, "Last"};
 		GD.Print(array[0]); // Prints "First"
 		GD.Print(array[2]); // Prints 3
-		GD.Print(array[array.Count - 1]); // Prints "Last"
+		GD.Print(array[^1]); // Prints "Last"
 
-		array[2] = "Second";
+		array[1] = "Second";
 		GD.Print(array[1]); // Prints "Second"
-		GD.Print(array[array.Count - 3]); // Prints "Second"
+		GD.Print(array[^3]); // Prints "Second"
 		[/csharp]
 		[/codeblocks]
 		[b]Note:[/b] Arrays are always passed by [b]reference[/b]. To get a copy of an array that can be modified independently of the original array, use [method duplicate].

--- a/doc/classes/DTLSServer.xml
+++ b/doc/classes/DTLSServer.xml
@@ -19,7 +19,7 @@
 		    server.listen(4242)
 		    var key = load("key.key") # Your private key.
 		    var cert = load("cert.crt") # Your X509 certificate.
-		    dtls.setup(key, cert)
+		    dtls.setup(TlsOptions.server(key, cert))
 
 		func _process(delta):
 		    while server.is_connection_available():
@@ -52,12 +52,12 @@
 		        _server.Listen(4242);
 		        var key = GD.Load&lt;CryptoKey&gt;("key.key"); // Your private key.
 		        var cert = GD.Load&lt;X509Certificate&gt;("cert.crt"); // Your X509 certificate.
-		        _dtls.Setup(key, cert);
+		        _dtls.Setup(TlsOptions.Server(key, cert));
 		    }
 
 		    public override void _Process(double delta)
 		    {
-		        while (Server.IsConnectionAvailable())
+		        while (_server.IsConnectionAvailable())
 		        {
 		            PacketPeerUdp peer = _server.TakeConnection();
 		            PacketPeerDtls dtlsPeer = _dtls.TakeConnection(peer);

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -638,13 +638,13 @@
 			[/gdscript]
 			[csharp]
 			// Set region, using Path2D node.
-			GetNode&lt;Window&gt;("Window").MousePassthrough = GetNode&lt;Path2D&gt;("Path2D").Curve.GetBakedPoints();
+			GetNode&lt;Window&gt;("Window").MousePassthroughPolygon = GetNode&lt;Path2D&gt;("Path2D").Curve.GetBakedPoints();
 
 			// Set region, using Polygon2D node.
-			GetNode&lt;Window&gt;("Window").MousePassthrough = GetNode&lt;Polygon2D&gt;("Polygon2D").Polygon;
+			GetNode&lt;Window&gt;("Window").MousePassthroughPolygon = GetNode&lt;Polygon2D&gt;("Polygon2D").Polygon;
 
 			// Reset region to default.
-			GetNode&lt;Window&gt;("Window").MousePassthrough = new Vector2[] {};
+			GetNode&lt;Window&gt;("Window").MousePassthroughPolygon = new Vector2[] {};
 			[/csharp]
 			[/codeblocks]
 			[b]Note:[/b] This property is ignored if [member mouse_passthrough] is set to [code]true[/code].


### PR DESCRIPTION
Backport of a few fixes I found in the docs while working on:
 - https://github.com/godotengine/godot/pull/100685

It's mostly changes to the C# examples, except for the changes to `DTLSServer.xml` that also touches the GDScript example.

The changes to `DTLSServer.xml` and `Window.xml` can be backported all the way to 4.0.
- https://github.com/godotengine/godot/pull/71502
- https://github.com/godotengine/godot/pull/71995

The changes to `Array.xml` only affect documentation that was introduced in 4.3.
- https://github.com/godotengine/godot/pull/69451