### PR TITLE
Add `@hide_from_dialog` and `@suffix` annotations for GDScript classes

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -114,6 +114,10 @@ protected:
 	// Scripts are reloaded via the Script Editor when edited in Godot,
 	// the LSP server when edited in a connected external editor, or
 	// through EditorFileSystem::_update_script_documentation when updated directly on disk.
+	bool hide_from_dialog = false;
+	bool use_custom_suffix = false;
+	String script_custom_suffix;
+
 	virtual bool editor_can_reload_from_file() override { return false; }
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -162,6 +166,10 @@ public:
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const = 0;
+
+	virtual bool is_hidden_from_dialog() const { return hide_from_dialog; }
+	virtual bool is_using_custom_script_suffix() const { return use_custom_suffix; }
+	virtual String get_script_custom_suffix() const { return script_custom_suffix; }
 
 	virtual bool is_tool() const = 0;
 	virtual bool is_valid() const = 0;

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -250,6 +250,10 @@ void CreateDialog::_add_type(const StringName &p_type, TypeCategory p_type_categ
 			}
 			ERR_FAIL_COND(scr.is_null());
 
+			if (scr->is_hidden_from_dialog()) {
+				return;
+			}
+
 			Ref<Script> base = scr->get_base_script();
 			if (base.is_null()) {
 				// Must be a native base type.
@@ -262,6 +266,11 @@ void CreateDialog::_add_type(const StringName &p_type, TypeCategory p_type_categ
 				inherits = extends;
 				inherited_type = TypeCategory::CPP_TYPE;
 			} else {
+				// If the base script is hidden from dialog, the child should not appear as well.
+				if (base->is_hidden_from_dialog()) {
+					return;
+				}
+
 				inherits = base->get_global_name();
 
 				if (inherits == StringName()) {
@@ -306,8 +315,12 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		String script_path = ScriptServer::get_global_class_path(p_type);
 		Ref<Script> scr = ResourceLoader::load(script_path, "Script");
 		String suffix = script_path.get_file();
-		if (scr.is_valid() && custom_type_suffixes.has(p_type)) {
-			suffix = custom_type_suffixes.get(p_type);
+		if (scr.is_valid()) {
+			if (custom_type_suffixes.has(p_type)) {
+				suffix = custom_type_suffixes.get(p_type);
+			} else if (scr->is_using_custom_script_suffix()) {
+				suffix = scr->get_script_custom_suffix();
+			}
 		}
 		if (!suffix.is_empty()) {
 			r_item->set_suffix(0, "(" + suffix + ")");

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -716,6 +716,12 @@
 				[b]Note:[/b] Avoid storing lambda callables in member variables of [RefCounted]-based classes (e.g. resources), as this can lead to memory leaks. Use only method callables and optionally [method Callable.bind] or [method Callable.unbind].
 			</description>
 		</annotation>
+		<annotation name="@hide_from_dialog">
+			<return type="void" />
+			<description>
+				Hides the current script from all create dialogs, if the current class has a global type name. This does not take effect for a script that has no global type name, as it is generally hidden from the dialogs.
+			</description>
+		</annotation>
 		<annotation name="@icon">
 			<return type="void" />
 			<param index="0" name="icon_path" type="String" />
@@ -769,6 +775,14 @@
 				Make a script with static variables to not persist after all references are lost. If the script is loaded again the static variables will revert to their default values.
 				[b]Note:[/b] As annotations describe their subject, the [annotation @static_unload] annotation must be placed before the class definition and inheritance.
 				[b]Warning:[/b] Currently, due to a bug, scripts are never freed, even if [annotation @static_unload] annotation is used.
+			</description>
+		</annotation>
+		<annotation name="@suffix">
+			<return type="void" />
+			<param index="0" name="suffix" type="String" />
+			<description>
+				Set a custom suffix for the current script. In a create dialog, if the class has a global type name, this annotation will replace the file name (which is following the type name and quoted in a couple of braces) with the suffix you set.
+				[b]Note:[/b] An empty suffix is allowed, but it will hide the suffix from all create dialogs.
 			</description>
 		</annotation>
 		<annotation name="@tool">

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -3090,6 +3090,9 @@ void GDScriptCompiler::make_scripts(GDScript *p_script, const GDScriptParser::Cl
 	p_script->local_name = p_class->identifier ? p_class->identifier->name : StringName();
 	p_script->global_name = p_class->get_global_name();
 	p_script->simplified_icon_path = p_class->simplified_icon_path;
+	p_script->hide_from_dialog = p_class->hide_from_dialog;
+	p_script->use_custom_suffix = p_class->set_custom_suffix;
+	p_script->script_custom_suffix = p_class->suffix;
 
 	HashMap<StringName, Ref<GDScript>> old_subclasses;
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4290,7 +4290,7 @@ bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_ta
 bool GDScriptParser::hide_from_dialog_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
 	ERR_FAIL_COND_V_MSG(p_target->type != Node::CLASS, false, vformat(R"("%s" annotation can only be applied to classes.)", p_annotation->name));
 	ClassNode *class_node = static_cast<ClassNode *>(p_target);
-	if (class_node->set_custom_suffix) {
+	if (class_node->hide_from_dialog) {
 		push_error(vformat(R"("%s" annotation can only be used once per script.)", p_annotation->name), p_annotation);
 		return false;
 	}

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -744,6 +744,9 @@ public:
 		IdentifierNode *identifier = nullptr;
 		String icon_path;
 		String simplified_icon_path;
+		bool hide_from_dialog = false;
+		bool set_custom_suffix = false;
+		String suffix;
 		Vector<Member> members;
 		HashMap<StringName, int> members_indices;
 		ClassNode *outer = nullptr;
@@ -1510,6 +1513,8 @@ private:
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool hide_from_dialog_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool suffix_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);


### PR DESCRIPTION
Another alternative that closes: https://github.com/godotengine/godot-proposals/issues/11238
Follows up #100135
For the discussion, see the proposal

`@hide_from_dialog` allows you to hide a global script with a global type name hidden from the create dialog. `@suffix` allows you to set a custom suffix for the script. A custom suffix will replace the file name with the suffix you set. An empty custom suffix will hide the suffix from all create dialogs.
E.g.
```GDScript
@suffix("Custom suffix")
class_name MyClass
extends Node
```
this will turn
```
Node
| - MyClass (my_class.gd)
```
into
```
Node
| - MyClass (Custom suffix)
```

# Note
I added few protected variables in `Script` class and getter methods, which is beneficial for the future continuations based on this pr

Alternative: https://github.com/godotengine/godot/pull/100349
Only one of the two pr will be merged, and the other one will be closed if not.