### PR TITLE
Editor: Split "Lookup Symbol" and "Go to Definition" functionality

### DIFF
--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -157,6 +157,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 		DEBUG_GOTO_PREV_BREAKPOINT,
 		HELP_CONTEXTUAL,
 		LOOKUP_SYMBOL,
+		GOTO_DEFINITION,
 	};
 
 	void _enable_code_editor();
@@ -164,7 +165,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 protected:
 	void _update_breakpoint_list();
 	void _breakpoint_item_pressed(int p_idx);
-	void _breakpoint_toggled(int p_row);
+	void _breakpoint_toggled(int p_line);
 
 	void _on_caret_moved();
 
@@ -197,10 +198,11 @@ protected:
 	void _prepare_edit_menu();
 
 	void _goto_line(int p_line) { goto_line(p_line); }
-	void _lookup_symbol(const String &p_symbol, int p_row, int p_column);
+	void _lookup_symbol(const String &p_symbol, int p_line, int p_column, bool p_goto_definition);
+	void _lookup_symbol_handler(const String &p_symbol, int p_line, int p_column);
 	void _validate_symbol(const String &p_symbol);
 
-	void _show_symbol_tooltip(const String &p_symbol, int p_row, int p_column);
+	void _show_symbol_tooltip(const String &p_symbol, int p_line, int p_column);
 
 	void _convert_case(CodeTextEditor::CaseStyle p_case);
 


### PR DESCRIPTION
* See #100680.

I'm not sure which option is better from a user experience perspective, for now I've used the easiest to implement option (since <kbd>Ctrl+LMB</kbd> is hardcoded into `CodeEdit`):

* <kbd>Ctrl+LMB</kbd> - Lookup Symbol (Open Documntation).
* <kbd>Ctrl+Shift+LMB</kbd> - Go to Definition.

It would also be nice to merge #95821 first so that the behavior is deterministic. And optionally add a GitHub search for native symbols.