### PR TITLE
Tweak `TextureProgressBar` `NOTIFICATION_DRAW` to support 9-patch stretch in radial modes

### DIFF
--- a/doc/classes/TextureProgressBar.xml
+++ b/doc/classes/TextureProgressBar.xml
@@ -31,7 +31,7 @@
 		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="1" />
 		<member name="nine_patch_stretch" type="bool" setter="set_nine_patch_stretch" getter="get_nine_patch_stretch" default="false">
-			If [code]true[/code], Godot treats the bar's textures like in [NinePatchRect]. Use the [code]stretch_margin_*[/code] properties like [member stretch_margin_bottom] to set up the nine patch's 3×3 grid. When using a radial [member fill_mode], this setting will enable stretching.
+			If [code]true[/code], Godot treats the bar's textures like in [NinePatchRect]. Use the [code]stretch_margin_*[/code] properties like [member stretch_margin_bottom] to set up the nine patch's 3×3 grid. When using a radial [member fill_mode], this setting will only enable stretching for [member texture_progress], while [member texture_under] and [member texture_over] will be treated like in [NinePatchRect].
 		</member>
 		<member name="radial_center_offset" type="Vector2" setter="set_radial_center_offset" getter="get_radial_center_offset" default="Vector2(0, 0)">
 			Offsets [member texture_progress] if [member fill_mode] is [constant FILL_CLOCKWISE], [constant FILL_COUNTER_CLOCKWISE], or [constant FILL_CLOCKWISE_AND_COUNTER_CLOCKWISE].

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -426,36 +426,20 @@ void TextureProgressBar::draw_nine_patch_stretched(const Ref<Texture2D> &p_textu
 void TextureProgressBar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {
-			if (nine_patch_stretch && (mode == FILL_LEFT_TO_RIGHT || mode == FILL_RIGHT_TO_LEFT || mode == FILL_TOP_TO_BOTTOM || mode == FILL_BOTTOM_TO_TOP || mode == FILL_BILINEAR_LEFT_AND_RIGHT || mode == FILL_BILINEAR_TOP_AND_BOTTOM)) {
-				if (under.is_valid()) {
+			if (under.is_valid()) {
+				if (nine_patch_stretch) {
 					draw_nine_patch_stretched(under, mode, 1.0, tint_under);
+				} else {
+					draw_texture(under, Point2(), tint_under);
 				}
-				if (progress.is_valid()) {
+			}
+
+			if (progress.is_valid()) {
+				const bool is_radial_mode = (mode == FILL_CLOCKWISE || mode == FILL_COUNTER_CLOCKWISE || mode == FILL_CLOCKWISE_AND_COUNTER_CLOCKWISE);
+
+				if (nine_patch_stretch && !is_radial_mode) {
 					draw_nine_patch_stretched(progress, mode, get_as_ratio(), tint_progress);
-				}
-				if (over.is_valid()) {
-					draw_nine_patch_stretched(over, mode, 1.0, tint_over);
-				}
-			} else {
-				if (under.is_valid()) {
-					switch (mode) {
-						case FILL_CLOCKWISE:
-						case FILL_COUNTER_CLOCKWISE:
-						case FILL_CLOCKWISE_AND_COUNTER_CLOCKWISE: {
-							if (nine_patch_stretch) {
-								Rect2 region = Rect2(Point2(), get_size());
-								draw_texture_rect(under, region, false, tint_under);
-							} else {
-								draw_texture(under, Point2(), tint_under);
-							}
-						} break;
-						case FILL_MODE_MAX:
-							break;
-						default:
-							draw_texture(under, Point2(), tint_under);
-					}
-				}
-				if (progress.is_valid()) {
+				} else {
 					Size2 s = progress->get_size();
 					switch (mode) {
 						case FILL_LEFT_TO_RIGHT: {
@@ -532,23 +516,6 @@ void TextureProgressBar::_notification(int p_what) {
 									draw_polygon(points, colors, uvs, progress);
 								}
 							}
-
-							// Draw a reference cross.
-							if (is_part_of_edited_scene()) {
-								Point2 p;
-
-								if (nine_patch_stretch) {
-									p = get_size();
-								} else {
-									p = progress->get_size();
-								}
-
-								p *= get_relative_center();
-								p += progress_offset;
-								p = p.floor();
-								draw_line(p - Point2(8, 0), p + Point2(8, 0), Color(0.9, 0.5, 0.5), 2);
-								draw_line(p - Point2(0, 8), p + Point2(0, 8), Color(0.9, 0.5, 0.5), 2);
-							}
 						} break;
 						case FILL_BILINEAR_LEFT_AND_RIGHT: {
 							Rect2 region = Rect2(progress_offset + Point2(s.x / 2 - s.x * get_as_ratio() / 2, 0), Size2(s.x * get_as_ratio(), s.y));
@@ -562,27 +529,32 @@ void TextureProgressBar::_notification(int p_what) {
 						} break;
 						case FILL_MODE_MAX:
 							break;
-						default:
-							draw_texture_rect_region(progress, Rect2(progress_offset, Size2(s.x * get_as_ratio(), s.y)), Rect2(Point2(), Size2(s.x * get_as_ratio(), s.y)), tint_progress);
 					}
 				}
-				if (over.is_valid()) {
-					switch (mode) {
-						case FILL_CLOCKWISE:
-						case FILL_COUNTER_CLOCKWISE:
-						case FILL_CLOCKWISE_AND_COUNTER_CLOCKWISE: {
-							if (nine_patch_stretch) {
-								Rect2 region = Rect2(Point2(), get_size());
-								draw_texture_rect(over, region, false, tint_over);
-							} else {
-								draw_texture(over, Point2(), tint_over);
-							}
-						} break;
-						case FILL_MODE_MAX:
-							break;
-						default:
-							draw_texture(over, Point2(), tint_over);
+#ifdef TOOLS_ENABLED
+				// Draw a reference cross for radial modes.
+				if (is_radial_mode && is_part_of_edited_scene()) {
+					Point2 p;
+
+					if (nine_patch_stretch) {
+						p = get_size();
+					} else {
+						p = progress->get_size();
 					}
+
+					p *= get_relative_center();
+					p += progress_offset;
+					draw_line(p - Point2(8, 0), p + Point2(8, 0), Color(0.9, 0.5, 0.5), 2);
+					draw_line(p - Point2(0, 8), p + Point2(0, 8), Color(0.9, 0.5, 0.5), 2);
+				}
+#endif
+			}
+
+			if (over.is_valid()) {
+				if (nine_patch_stretch) {
+					draw_nine_patch_stretched(over, mode, 1.0, tint_over);
+				} else {
+					draw_texture(over, Point2(), tint_over);
 				}
 			}
 		} break;


### PR DESCRIPTION
The original reason for the changes -  9-patch stretching is ignored for `under` and `over` textures in radial modes.

1) Code is splitted into 3 sections:
- draw `under` texture;
- draw `progress` texture + draw radial modes reference cross;
- draw `over` texture. 

Each draw texture section handles nine-patch stretching. Except for the progress texture in radial modes, which does not support nine-patch stretching (because it is not possible). 

2) The reference cross position now is not misaligned to real center position (`floor()` call removed). 
3) The reference cross drawing code is additionally surrounded by `TOOLS_ENABLED` check.

Preview "before-after":
![NcnIPMH19e](https://github.com/user-attachments/assets/232acf56-c538-43ac-9c7d-c4948926c157)
