### PR TITLE
Fix 3D camera override when there is no camera in scene tree

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -1365,7 +1365,7 @@ void RuntimeNodeSelect::_root_window_input(const Ref<InputEvent> &p_event) {
 			}
 		} else if (node_select_type == NODE_TYPE_3D) {
 #ifndef _3D_DISABLED
-			if (root->get_camera_3d() && _handle_3d_input(p_event)) {
+			if (_handle_3d_input(p_event)) {
 				return;
 			}
 #endif // _3D_DISABLED
@@ -1865,10 +1865,6 @@ void RuntimeNodeSelect::_update_view_2d() {
 void RuntimeNodeSelect::_find_3d_items_at_pos(const Point2 &p_pos, Vector<SelectResult> &r_items) {
 	Window *root = SceneTree::get_singleton()->get_root();
 	Camera3D *camera = root->get_viewport()->get_camera_3d();
-	if (!camera) {
-		return;
-	}
-
 	Vector3 ray, pos, to;
 	if (root->get_viewport()->is_camera_3d_override_enabled()) {
 		Viewport *vp = root->get_viewport();
@@ -2127,21 +2123,21 @@ Transform3D RuntimeNodeSelect::_get_cursor_transform() {
 void RuntimeNodeSelect::_reset_camera_3d() {
 	camera_first_override = true;
 
+	cursor = Cursor();
 	Window *root = SceneTree::get_singleton()->get_root();
 	Camera3D *camera = root->get_camera_3d();
-	if (!camera) {
-		return;
+	if (camera) {
+		Transform3D transform = camera->get_global_transform();
+		transform.translate_local(0, 0, -cursor.distance);
+		cursor.pos = transform.origin;
+
+		cursor.x_rot = -camera->get_global_rotation().x;
+		cursor.y_rot = -camera->get_global_rotation().y;
+
+		cursor.fov_scale = CLAMP(camera->get_fov() / CAMERA_BASE_FOV, CAMERA_MIN_FOV_SCALE, CAMERA_MAX_FOV_SCALE);
+	} else {
+		cursor.fov_scale = 1.0;
 	}
-
-	cursor = Cursor();
-	Transform3D transform = camera->get_global_transform();
-	transform.translate_local(0, 0, -cursor.distance);
-	cursor.pos = transform.origin;
-
-	cursor.x_rot = -camera->get_global_rotation().x;
-	cursor.y_rot = -camera->get_global_rotation().y;
-
-	cursor.fov_scale = CLAMP(camera->get_fov() / CAMERA_BASE_FOV, CAMERA_MIN_FOV_SCALE, CAMERA_MAX_FOV_SCALE);
 
 	SceneTree::get_singleton()->get_root()->set_camera_3d_override_transform(_get_cursor_transform());
 	SceneTree::get_singleton()->get_root()->set_camera_3d_override_perspective(CAMERA_BASE_FOV * cursor.fov_scale, CAMERA_ZNEAR, CAMERA_ZFAR);


### PR DESCRIPTION
Previously if there was no camera in the scene tree, on overriding the camera, it would receive no input, this P.R. fixes it.

**Preview**

[Screencast from 2024-12-21 18-27-25.webm](https://github.com/user-attachments/assets/2cea32a4-6c4e-4cf9-9964-74086c64673d)

**MRP**

[test.zip](https://github.com/user-attachments/files/18218576/test.zip)
