### PR TITLE
Cache contacts for sleeping bodies when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
@@ -407,28 +407,24 @@ void JoltContactListener3D::_flush_contacts() {
 		const JPH::SubShapeIDPair &shape_pair = E.key;
 		Manifold &manifold = E.value;
 
-		const JoltReadableBody3D jolt_body1 = space->read_body(shape_pair.GetBody1ID());
-		const JoltReadableBody3D jolt_body2 = space->read_body(shape_pair.GetBody2ID());
+		const JPH::BodyID body_ids[2] = { shape_pair.GetBody1ID(), shape_pair.GetBody2ID() };
+		const JoltReadableBodies3D jolt_bodies = space->read_bodies(body_ids, 2);
 
-		JoltBody3D *body1 = jolt_body1.as_body();
+		JoltBody3D *body1 = jolt_bodies[0].as_body();
 		ERR_FAIL_NULL(body1);
 
-		JoltBody3D *body2 = jolt_body2.as_body();
+		JoltBody3D *body2 = jolt_bodies[1].as_body();
 		ERR_FAIL_NULL(body2);
 
 		const int shape_index1 = body1->find_shape_index(shape_pair.GetSubShapeID1());
 		const int shape_index2 = body2->find_shape_index(shape_pair.GetSubShapeID2());
 
-		if (jolt_body1->IsActive()) {
-			for (const Contact &contact : manifold.contacts1) {
-				body1->add_contact(body2, manifold.depth, shape_index1, shape_index2, contact.normal, contact.point_self, contact.point_other, contact.velocity_self, contact.velocity_other, contact.impulse);
-			}
+		for (const Contact &contact : manifold.contacts1) {
+			body1->add_contact(body2, manifold.depth, shape_index1, shape_index2, contact.normal, contact.point_self, contact.point_other, contact.velocity_self, contact.velocity_other, contact.impulse);
 		}
 
-		if (jolt_body2->IsActive()) {
-			for (const Contact &contact : manifold.contacts2) {
-				body2->add_contact(body1, manifold.depth, shape_index2, shape_index1, contact.normal, contact.point_self, contact.point_other, contact.velocity_self, contact.velocity_other, contact.impulse);
-			}
+		for (const Contact &contact : manifold.contacts2) {
+			body2->add_contact(body1, manifold.depth, shape_index2, shape_index1, contact.normal, contact.point_self, contact.point_other, contact.velocity_self, contact.velocity_other, contact.impulse);
 		}
 
 		manifold.contacts1.clear();


### PR DESCRIPTION
Reverts #100533.
Fixes #100515.
Fixes #100700.

This pull request does two things:

1. It reverts the changes to `jolt_contact_listener_3d.cpp` introduced in [#100533](https://github.com/godotengine/godot/pull/100533), due to taking a different approach to solving [#100515](https://github.com/godotengine/godot/issues/100515).
2. It solves [#100515](https://github.com/godotengine/godot/issues/100515) by instead emulating what Godot Physics does, which is to only clear the list of contacts while a body is actually active/awake. This means we're now deliberately keeping (potentially stale) contacts around when a body goes to sleep, in order to better facilitate contact-based logic in scripts, as discussed in [#100533](https://github.com/godotengine/godot/pull/100533).