### PR TITLE
Editor: Restore old `Ctrl+Click` behavior

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -968,7 +968,7 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 	} else if (lc_error == OK) {
 		_goto_line(p_row);
 
-		if (!result.class_name.is_empty() && EditorHelp::get_doc_data()->class_list.has(result.class_name)) {
+		if (!result.class_name.is_empty() && EditorHelp::get_doc_data()->class_list.has(result.class_name) && !EditorHelp::get_doc_data()->class_list[result.class_name].is_script_doc) {
 			switch (result.type) {
 				case ScriptLanguage::LOOKUP_RESULT_CLASS: {
 					emit_signal(SNAME("go_to_help"), "class_name:" + result.class_name);


### PR DESCRIPTION
* Closes #100680.
* I've noticed that many users are disappointed with the change in <kbd>Ctrl+Click</kbd> behavior in 4.4 dev 7, so I think a simple and quick fix would make sense.
* Separating the "Lookup Symbol" and "Go to Definition" functionality (#100692) is something that needs more consideration, perhaps not even for 4.4.