### PR TITLE
Remove trailing double quote from link in GLTFState class documentation

### DIFF
--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -9,7 +9,7 @@
 	</description>
 	<tutorials>
 		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
-		<link title="glTF asset header schema">https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json"</link>
+		<link title="glTF asset header schema">https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json</link>
 	</tutorials>
 	<methods>
 		<method name="add_used_extension">


### PR DESCRIPTION
Another PR for https://github.com/godotengine/godot-docs/pull/10435 as I was not aware of the auto-generation, sorry!

A link in the `GLTFState` class documentation currently points to a _404 Not Found_ page due to a trailing double quote.
This PR fixes this typo:

- old: [https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json"](https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json%22)
- fixed: https://github.com/KhronosGroup/glTF/blob/main/specification/2.0/schema/asset.schema.json

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
