### PR TITLE
Fix last character deletion in Wayland IME input

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2734,7 +2734,7 @@ void WaylandThread::_wp_text_input_on_done(void *data, struct zwp_text_input_v3 
 		msg.instantiate();
 		msg->text = ss->ime_text_commit;
 		ss->wayland_thread->push_message(msg);
-	} else if (!ss->ime_text.is_empty()) {
+	} else {
 		Ref<IMEUpdateEventMessage> msg;
 		msg.instantiate();
 		msg->text = ss->ime_text;


### PR DESCRIPTION
This PR fixes an issue where the last character can't be deleted with backspace during IME input on the Wayland platform.

## Details

When deleting IME characters, wp_text_input_on_done() is called, but currently no message is pushed when ss->ime_text is empty.
The issue is fixed by always pushing the message regardless of whether ss->ime_text is empty or not.