### PR TITLE
Add `Camera3D::project_local_ray_origin()`

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -82,6 +82,13 @@
 				Returns a normal vector from the screen point location directed along the camera. Orthogonal cameras are normalized. Perspective cameras account for perspective, screen width/height, etc.
 			</description>
 		</method>
+		<method name="project_local_ray_origin" qualifiers="const">
+			<return type="Vector3" />
+			<param index="0" name="screen_point" type="Vector2" />
+			<description>
+				Returns a 3D position in local camera space, that is the result of projecting a point on the [Viewport] rectangle by the inverse camera projection. This is useful for casting rays in the form of (origin, normal) for object intersection or picking.
+			</description>
+		</method>
 		<method name="project_position" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="screen_point" type="Vector2" />

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -445,6 +445,14 @@ Vector3 Camera3D::project_local_ray_normal(const Point2 &p_pos) const {
 }
 
 Vector3 Camera3D::project_ray_origin(const Point2 &p_pos) const {
+	if (mode == PROJECTION_ORTHOGONAL) {
+		Vector3 ray = project_local_ray_origin(p_pos);
+		return get_camera_transform().xform(ray);
+	}
+	return get_camera_transform().origin;
+}
+
+Vector3 Camera3D::project_local_ray_origin(const Point2 &p_pos) const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_camera_rect_size();
@@ -466,11 +474,9 @@ Vector3 Camera3D::project_ray_origin(const Point2 &p_pos) const {
 		ray.x = pos.x * (hsize)-hsize / 2;
 		ray.y = (1.0 - pos.y) * (vsize)-vsize / 2;
 		ray.z = -_near;
-		ray = get_camera_transform().xform(ray);
 		return ray;
-	} else {
-		return get_camera_transform().origin;
-	};
+	}
+	return Vector3();
 }
 
 bool Camera3D::is_position_behind(const Vector3 &p_pos) const {
@@ -648,6 +654,7 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("project_ray_normal", "screen_point"), &Camera3D::project_ray_normal);
 	ClassDB::bind_method(D_METHOD("project_local_ray_normal", "screen_point"), &Camera3D::project_local_ray_normal);
 	ClassDB::bind_method(D_METHOD("project_ray_origin", "screen_point"), &Camera3D::project_ray_origin);
+	ClassDB::bind_method(D_METHOD("project_local_ray_origin", "screen_point"), &Camera3D::project_local_ray_origin);
 	ClassDB::bind_method(D_METHOD("unproject_position", "world_point"), &Camera3D::unproject_position);
 	ClassDB::bind_method(D_METHOD("is_position_behind", "world_point"), &Camera3D::is_position_behind);
 	ClassDB::bind_method(D_METHOD("project_position", "screen_point", "z_depth"), &Camera3D::project_position);

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -180,6 +180,7 @@ public:
 	virtual Vector3 project_ray_normal(const Point2 &p_pos) const;
 	virtual Vector3 project_ray_origin(const Point2 &p_pos) const;
 	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const;
+	virtual Vector3 project_local_ray_origin(const Point2 &p_pos) const;
 	virtual Point2 unproject_position(const Vector3 &p_pos) const;
 	bool is_position_behind(const Vector3 &p_pos) const;
 	virtual Vector3 project_position(const Point2 &p_point, real_t p_z_depth) const;


### PR DESCRIPTION
This PR adds `project_local_ray_origin()` to `Camera3D` and makes `project_ray_origin()` wrap a call to the former.

This harmonizes `Camera3D`'s interface for ray origins with the way it's already done for projecting ray normals.