### PR TITLE
Update cursor instance when calling `set_selected_palette_item`

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1854,6 +1854,7 @@ void GridMapEditorPlugin::set_selected_palette_item(int p_item) const {
 		}
 		if (p_item != grid_map_editor->selected_palette) {
 			grid_map_editor->selected_palette = p_item;
+			grid_map_editor->_update_cursor_instance();
 			grid_map_editor->update_palette();
 		}
 	}


### PR DESCRIPTION
Fixes GH-100721 by calling `_update_cursor_instance` to update the cursor mesh after changing the palette item.

See it in action:

https://github.com/user-attachments/assets/dcf1d3db-7ca3-4cc4-aa7f-1ce727655f2c