### PR TITLE
Improve script class display in Create dialog

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -278,7 +278,6 @@
 			<param index="2" name="current_type" type="String" default="&quot;&quot;" />
 			<param index="3" name="dialog_title" type="String" default="&quot;&quot;" />
 			<param index="4" name="type_blocklist" type="StringName[]" default="[]" />
-			<param index="5" name="type_suffixes" type="Dictionary" default="{}" />
 			<description>
 				Pops up an editor dialog for creating an object.
 				The [param callback] must take a single argument of type [StringName] which will contain the type name of the selected object or be empty if no item is selected.
@@ -286,17 +285,6 @@
 				The [param current_type] will be passed in the search box of the create dialog, and the specified type can be immediately selected when the dialog pops up. If the [param current_type] is not derived from [param base_type], there will be no result of the type in the dialog.
 				The [param dialog_title] allows you to define a custom title for the dialog. This is useful if you want to accurately hint the usage of the dialog. If the [param dialog_title] is an empty string, the dialog will use "Create New 'Base Type'" as the default title.
 				The [param type_blocklist] contains a list of type names, and the types in the blocklist will be hidden from the create dialog.
-				The [param type_suffixes] is a dictionary, with keys being [StringName]s and values being [String]s. Custom suffixes override the default suffixes which are file names of their scripts. For example, if you set a custom suffix as "Custom Suffix" for a global script type,
-				[codeblock lang=text]
-				Node
-				|- MyCustomNode (my_custom_node.gd)
-				[/codeblock]
-				will be
-				[codeblock lang=text]
-				Node
-				|- MyCustomNode (Custom Suffix)
-				[/codeblock]
-				Bear in mind that when a built-in type does not have any custom suffix, its suffix will be removed. The suffix of a type created from a script will fall back to its script file name. For global types by scripts, if you customize their suffixes to an empty string, their suffixes will be removed.
 				[b]Note:[/b] Trying to list the base type in the [param type_blocklist] will hide all types derived from the base type from the create dialog.
 			</description>
 		</method>

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -111,6 +111,24 @@ bool CreateDialog::_is_type_preferred(const String &p_type) const {
 	return EditorNode::get_editor_data().script_class_is_parent(p_type, preferred_search_result_type);
 }
 
+void CreateDialog::_script_button_clicked(TreeItem *p_item, int p_column, int p_button_id, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index != MouseButton::LEFT) {
+		return;
+	}
+	// The id of opening-script button is 1.
+	if (p_button_id != 1) {
+		return;
+	}
+
+	String scr_path = ScriptServer::get_global_class_path(p_item->get_text(0));
+	Ref<Script> scr = ResourceLoader::load(scr_path, "Script");
+	ERR_FAIL_COND_MSG(scr.is_null(), vformat("Could not load the script from resource path: %s", scr_path));
+	EditorNode::get_singleton()->push_item_no_inspector(scr.ptr());
+
+	hide();
+	_cleanup();
+}
+
 bool CreateDialog::_is_class_disabled_by_feature_profile(const StringName &p_class) const {
 	Ref<EditorFeatureProfile> profile = EditorFeatureProfileManager::get_singleton()->get_current_profile();
 
@@ -291,29 +309,28 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 	bool is_abstract = false;
 	if (p_type_category == TypeCategory::CPP_TYPE) {
 		r_item->set_text(0, p_type);
-		if (custom_type_suffixes.has(p_type)) {
-			String suffix = custom_type_suffixes.get(p_type);
-			if (!suffix.is_empty()) {
-				r_item->set_suffix(0, "(" + suffix + ")");
-			}
-		}
 	} else if (p_type_category == TypeCategory::PATH_TYPE) {
 		r_item->set_text(0, "\"" + p_type + "\"");
 	} else if (script_type) {
 		r_item->set_metadata(0, p_type);
 		r_item->set_text(0, p_type);
+
 		String script_path = ScriptServer::get_global_class_path(p_type);
 		Ref<Script> scr = ResourceLoader::load(script_path, "Script");
-		String suffix = script_path.get_file();
-		if (scr.is_valid() && custom_type_suffixes.has(p_type)) {
-			suffix = custom_type_suffixes.get(p_type);
-		}
-		if (!suffix.is_empty()) {
-			r_item->set_suffix(0, "(" + suffix + ")");
-		}
 
 		ERR_FAIL_COND(scr.is_null());
 		is_abstract = scr->is_abstract();
+
+		String tooltip = TTR("Script path: %s");
+		bool is_tool = scr->is_tool();
+		if (is_tool) {
+			tooltip = TTR("The script will run in the editor.") + "\n" + tooltip;
+		}
+		r_item->add_button(0, get_editor_theme_icon(SNAME("Script")), 1, false, vformat(tooltip, script_path));
+		if (is_tool) {
+			int button_index = r_item->get_button_count(0) - 1;
+			r_item->set_button_color(0, button_index, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
+		}
 	} else {
 		r_item->set_metadata(0, custom_type_parents[p_type]);
 		r_item->set_text(0, p_type);
@@ -827,6 +844,7 @@ CreateDialog::CreateDialog() {
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	search_options->connect("item_activated", callable_mp(this, &CreateDialog::_confirmed));
 	search_options->connect("cell_selected", callable_mp(this, &CreateDialog::_item_selected));
+	search_options->connect("button_clicked", callable_mp(this, &CreateDialog::_script_button_clicked));
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 
 	help_bit = memnew(EditorHelpBit);

--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -67,7 +67,6 @@ class CreateDialog : public ConfirmationDialog {
 	List<StringName> type_list;
 	HashSet<StringName> type_blacklist;
 	HashSet<StringName> custom_type_blocklist;
-	HashMap<StringName, String> custom_type_suffixes;
 
 	void _update_search();
 	bool _should_hide_type(const StringName &p_type) const;
@@ -75,6 +74,7 @@ class CreateDialog : public ConfirmationDialog {
 	void _configure_search_option_item(TreeItem *r_item, const StringName &p_type, TypeCategory p_type_category);
 	float _score_type(const String &p_type, const String &p_search) const;
 	bool _is_type_preferred(const String &p_type) const;
+	void _script_button_clicked(TreeItem *p_item, int p_column, int p_button_id, MouseButton p_mouse_button_index);
 
 	void _fill_type_list();
 	void _cleanup();
@@ -118,8 +118,6 @@ public:
 	void select_base();
 
 	void set_type_blocklist(const HashSet<StringName> &p_blocklist) { custom_type_blocklist = p_blocklist; }
-	void set_type_suffixes(const HashMap<StringName, String> &p_suffixes) { custom_type_suffixes = p_suffixes; }
-
 	void set_preferred_search_result_type(const String &p_preferred_type) { preferred_search_result_type = p_preferred_type; }
 
 	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_current_type = "", const String &p_current_name = "");

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -512,7 +512,7 @@ void EditorInterface::popup_quick_open(const Callable &p_callback, const TypedAr
 	quick_open->popup_dialog(base_types, callable_mp(this, &EditorInterface::_quick_open).bind(p_callback));
 }
 
-void EditorInterface::popup_create_dialog(const Callable &p_callback, const StringName &p_base_type, const String &p_current_type, const String &p_dialog_title, const TypedArray<StringName> &p_custom_type_blocklist, const Dictionary &p_custom_suffix) {
+void EditorInterface::popup_create_dialog(const Callable &p_callback, const StringName &p_base_type, const String &p_current_type, const String &p_dialog_title, const TypedArray<StringName> &p_custom_type_blocklist) {
 	if (!create_dialog) {
 		create_dialog = memnew(CreateDialog);
 		get_base_control()->add_child(create_dialog);
@@ -523,18 +523,6 @@ void EditorInterface::popup_create_dialog(const Callable &p_callback, const Stri
 		blocklist.insert(E);
 	}
 	create_dialog->set_type_blocklist(blocklist);
-
-	HashMap<StringName, String> suffix_map;
-	List<Variant> keys;
-	p_custom_suffix.get_key_list(&keys);
-	for (Variant &k : keys) {
-		const StringName key = k;
-		if (key.is_empty()) {
-			continue;
-		}
-		suffix_map.insert(key, p_custom_suffix[key]);
-	}
-	create_dialog->set_type_suffixes(suffix_map);
 
 	String safe_base_type = p_base_type;
 	if (p_base_type.is_empty() || (!ClassDB::class_exists(p_base_type) && !ScriptServer::is_global_class(p_base_type))) {
@@ -819,7 +807,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("popup_property_selector", "object", "callback", "type_filter", "current_value"), &EditorInterface::popup_property_selector, DEFVAL(PackedInt32Array()), DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("popup_method_selector", "object", "callback", "current_value"), &EditorInterface::popup_method_selector, DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("popup_quick_open", "callback", "base_types"), &EditorInterface::popup_quick_open, DEFVAL(TypedArray<StringName>()));
-	ClassDB::bind_method(D_METHOD("popup_create_dialog", "callback", "base_type", "current_type", "dialog_title", "type_blocklist", "type_suffixes"), &EditorInterface::popup_create_dialog, DEFVAL(""), DEFVAL(""), DEFVAL(""), DEFVAL(TypedArray<StringName>()), DEFVAL(Dictionary()));
+	ClassDB::bind_method(D_METHOD("popup_create_dialog", "callback", "base_type", "current_type", "dialog_title", "type_blocklist"), &EditorInterface::popup_create_dialog, DEFVAL(""), DEFVAL(""), DEFVAL(""), DEFVAL(TypedArray<StringName>()));
 
 	// Editor docks.
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -148,7 +148,7 @@ public:
 	void popup_property_selector(Object *p_object, const Callable &p_callback, const PackedInt32Array &p_type_filter = PackedInt32Array(), const String &p_current_value = String());
 	void popup_method_selector(Object *p_object, const Callable &p_callback, const String &p_current_value = String());
 	void popup_quick_open(const Callable &p_callback, const TypedArray<StringName> &p_base_types = TypedArray<StringName>());
-	void popup_create_dialog(const Callable &p_callback, const StringName &p_base_type = "", const String &p_current_type = "", const String &p_dialog_title = "", const TypedArray<StringName> &p_custom_type_blocklist = TypedArray<String>(), const Dictionary &p_custom_suffix = Dictionary());
+	void popup_create_dialog(const Callable &p_callback, const StringName &p_base_type = "", const String &p_current_type = "", const String &p_dialog_title = "", const TypedArray<StringName> &p_custom_type_blocklist = TypedArray<StringName>());
 
 	// Editor docks.
 


### PR DESCRIPTION
The idea comes from: https://github.com/godotengine/godot-proposals/issues/11238#issuecomment-2558096697
I tried to implement the feature and it did look better than simply removing the suffix.

# Feature
Now each type from a script will get its suffix removed. Instead, a button with script icon will display at the end of the selection.
Hovering the mouse on the button will display the script path.
When you click it, the editor will jump to editing the script linked to the type you selected.
<video src="https://github.com/user-attachments/assets/a800fc10-fb83-4e2b-bff9-d8cea978ebc6" controls="" height=400 width=600> </video>

Say goodbye to irritating suffixes!