### PR TITLE
Add an option for tweens to ignore `Engine.time_scale`

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -228,6 +228,13 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="set_ignore_time_scale">
+			<return type="Tween" />
+			<param index="0" name="ignore" type="bool" default="true" />
+			<description>
+				If [param ignore] is [code]true[/code], the tween will ignore [member Engine.time_scale] and update with the real, elapsed time. This affects all [Tweener]s and their delays. Default value is [code]false[/code].
+			</description>
+		</method>
 		<method name="set_loops">
 			<return type="Tween" />
 			<param index="0" name="loops" type="int" default="0" />

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -226,6 +226,15 @@ Tween::TweenPauseMode Tween::get_pause_mode() {
 	return pause_mode;
 }
 
+Ref<Tween> Tween::set_ignore_time_scale(bool p_ignore) {
+	ignore_time_scale = p_ignore;
+	return this;
+}
+
+bool Tween::is_ignoring_time_scale() const {
+	return ignore_time_scale;
+}
+
 Ref<Tween> Tween::set_parallel(bool p_parallel) {
 	default_parallel = p_parallel;
 	parallel_enabled = p_parallel;
@@ -451,6 +460,7 @@ void Tween::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("bind_node", "node"), &Tween::bind_node);
 	ClassDB::bind_method(D_METHOD("set_process_mode", "mode"), &Tween::set_process_mode);
 	ClassDB::bind_method(D_METHOD("set_pause_mode", "mode"), &Tween::set_pause_mode);
+	ClassDB::bind_method(D_METHOD("set_ignore_time_scale", "ignore"), &Tween::set_ignore_time_scale, DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("set_parallel", "parallel"), &Tween::set_parallel, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("set_loops", "loops"), &Tween::set_loops, DEFVAL(0));

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -115,6 +115,7 @@ private:
 	int loops = 1;
 	int loops_done = 0;
 	float speed_scale = 1;
+	bool ignore_time_scale = false;
 
 	bool is_bound = false;
 	bool started = false;
@@ -161,6 +162,8 @@ public:
 	TweenProcessMode get_process_mode();
 	Ref<Tween> set_pause_mode(TweenPauseMode p_mode);
 	TweenPauseMode get_pause_mode();
+	Ref<Tween> set_ignore_time_scale(bool p_ignore = true);
+	bool is_ignoring_time_scale() const;
 
 	Ref<Tween> set_parallel(bool p_parallel);
 	Ref<Tween> set_loops(int p_loops);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -701,7 +701,8 @@ void SceneTree::process_tweens(double p_delta, bool p_physics) {
 			continue;
 		}
 
-		if (!E->get()->step(p_delta)) {
+		double time_step = E->get()->is_ignoring_time_scale() ? Engine::get_singleton()->get_process_step() : p_delta;
+		if (!E->get()->step(time_step)) {
 			E->get()->clear();
 			tweens.erase(E);
 		}


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/11404

Adds `.set_ignore_time_scale(ignore:bool)` method to tweens.

_Bugsquad edit: closes https://github.com/godotengine/godot-proposals/issues/11404_