### PR TITLE
Move non-const iteration from `Vector` to `Vector.write`.

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -52,9 +52,44 @@ template <typename T>
 class VectorWriteProxy {
 public:
 	_FORCE_INLINE_ T &operator[](typename CowData<T>::Size p_index) {
-		CRASH_BAD_INDEX(p_index, ((Vector<T> *)(this))->_cowdata.size());
+		CRASH_BAD_INDEX(p_index, ((Vector<T> *)this)->_cowdata.size());
 
-		return ((Vector<T> *)(this))->_cowdata.ptrw()[p_index];
+		return ((Vector<T> *)this)->_cowdata.ptrw()[p_index];
+	}
+
+	// NOTE: The non-const iterators need to be declared here because otherwise, these functions
+	//       are chosen as the default iteration methods on non-const objects.
+	//       This may cause an unnecessary fork of underlying data buffer.
+	struct Iterator {
+		_FORCE_INLINE_ T &operator*() const {
+			return *elem_ptr;
+		}
+		_FORCE_INLINE_ T *operator->() const { return elem_ptr; }
+		_FORCE_INLINE_ Iterator &operator++() {
+			elem_ptr++;
+			return *this;
+		}
+		_FORCE_INLINE_ Iterator &operator--() {
+			elem_ptr--;
+			return *this;
+		}
+
+		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
+		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
+
+		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
+		Iterator() {}
+		Iterator(const Iterator &p_it) { elem_ptr = p_it.elem_ptr; }
+
+	private:
+		T *elem_ptr = nullptr;
+	};
+
+	_FORCE_INLINE_ Iterator begin() {
+		return Iterator(((Vector<T> *)this)->ptrw());
+	}
+	_FORCE_INLINE_ Iterator end() {
+		return Iterator(((Vector<T> *)this)->ptrw() + ((Vector<T> *)this)->size());
 	}
 };
 
@@ -240,31 +275,6 @@ public:
 		return false;
 	}
 
-	struct Iterator {
-		_FORCE_INLINE_ T &operator*() const {
-			return *elem_ptr;
-		}
-		_FORCE_INLINE_ T *operator->() const { return elem_ptr; }
-		_FORCE_INLINE_ Iterator &operator++() {
-			elem_ptr++;
-			return *this;
-		}
-		_FORCE_INLINE_ Iterator &operator--() {
-			elem_ptr--;
-			return *this;
-		}
-
-		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
-
-		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
-		Iterator() {}
-		Iterator(const Iterator &p_it) { elem_ptr = p_it.elem_ptr; }
-
-	private:
-		T *elem_ptr = nullptr;
-	};
-
 	struct ConstIterator {
 		_FORCE_INLINE_ const T &operator*() const {
 			return *elem_ptr;
@@ -290,16 +300,11 @@ public:
 		const T *elem_ptr = nullptr;
 	};
 
-	_FORCE_INLINE_ Iterator begin() {
-		return Iterator(ptrw());
-	}
-	_FORCE_INLINE_ Iterator end() {
-		return Iterator(ptrw() + size());
-	}
-
+	// For non-const iteration, iterate the .write property.
 	_FORCE_INLINE_ ConstIterator begin() const {
 		return ConstIterator(ptr());
 	}
+	// For non-const iteration, iterate the .write property.
 	_FORCE_INLINE_ ConstIterator end() const {
 		return ConstIterator(ptr() + size());
 	}

--- a/drivers/alsamidi/midi_driver_alsamidi.cpp
+++ b/drivers/alsamidi/midi_driver_alsamidi.cpp
@@ -63,7 +63,7 @@ void MIDIDriverALSAMidi::thread_func(void *p_udata) {
 
 	while (!md->exit_thread.is_set()) {
 		md->lock();
-		for (InputConnection &conn : md->connected_inputs) {
+		for (InputConnection &conn : md->connected_inputs.write) {
 			conn.read();
 		}
 		md->unlock();

--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -1695,7 +1695,7 @@ bool MDAttachment::shouldClear(const MDSubpass &p_subpass, bool p_is_stencil) co
 
 MDRenderPass::MDRenderPass(Vector<MDAttachment> &p_attachments, Vector<MDSubpass> &p_subpasses) :
 		attachments(p_attachments), subpasses(p_subpasses) {
-	for (MDAttachment &att : attachments) {
+	for (MDAttachment &att : attachments.write) {
 		att.linkToSubpass(*this);
 	}
 }

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -122,7 +122,7 @@ static void merge_constructors(Vector<DocData::MethodDoc> &p_to, const Vector<Do
 	int64_t from_size = p_from.size();
 
 	// TODO: Improve constructor merging.
-	for (DocData::MethodDoc &to : p_to) {
+	for (DocData::MethodDoc &to : p_to.write) {
 		for (int64_t from_i = 0; from_i < from_size; ++from_i) {
 			const DocData::MethodDoc &from = from_ptr[from_i];
 
@@ -208,7 +208,7 @@ static void merge_constants(Vector<DocData::ConstantDoc> &p_to, const Vector<Doc
 
 	SearchArray<DocData::ConstantDoc> search_array;
 
-	for (DocData::ConstantDoc &to : p_to) {
+	for (DocData::ConstantDoc &to : p_to.write) {
 		int64_t found = search_array.bisect(from_ptr, from_size, to, true);
 
 		if (found >= from_size) {

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -141,7 +141,7 @@ void EditorSelectionHistory::add_object(ObjectID p_object, const String &p_prope
 }
 
 void EditorSelectionHistory::replace_object(ObjectID p_old_object, ObjectID p_new_object) {
-	for (HistoryElement &element : history) {
+	for (HistoryElement &element : history.write) {
 		for (int index = 0; index < element.path.size(); index++) {
 			if (element.path[index].object == p_old_object) {
 				element.path.write[index].object = p_new_object;

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -666,7 +666,7 @@ PackedStringArray EditorInterface::get_open_scenes() const {
 	PackedStringArray ret;
 	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
 
-	for (EditorData::EditedScene &edited_scene : scenes) {
+	for (const EditorData::EditedScene &edited_scene : scenes) {
 		if (edited_scene.root == nullptr) {
 			continue;
 		}
@@ -679,7 +679,7 @@ TypedArray<Node> EditorInterface::get_open_scene_roots() const {
 	TypedArray<Node> ret;
 	Vector<EditorData::EditedScene> scenes = EditorNode::get_editor_data().get_edited_scenes();
 
-	for (EditorData::EditedScene &edited_scene : scenes) {
+	for (const EditorData::EditedScene &edited_scene : scenes) {
 		if (edited_scene.root == nullptr) {
 			continue;
 		}

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -118,7 +118,7 @@ void EditorFileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_file
 
 	Vector<String> files = p_files;
 	if (access != ACCESS_FILESYSTEM) {
-		for (String &file_name : files) {
+		for (String &file_name : files.write) {
 			file_name = ProjectSettings::get_singleton()->localize_path(file_name);
 		}
 	}

--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -112,7 +112,7 @@ void GameViewDebugger::set_suspend(bool p_enabled) {
 	Array message;
 	message.append(p_enabled);
 
-	for (Ref<EditorDebuggerSession> &I : sessions) {
+	for (const Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
 			I->send_message("scene:suspend_changed", message);
 		}
@@ -120,7 +120,7 @@ void GameViewDebugger::set_suspend(bool p_enabled) {
 }
 
 void GameViewDebugger::next_frame() {
-	for (Ref<EditorDebuggerSession> &I : sessions) {
+	for (const Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
 			I->send_message("scene:next_frame", Array());
 		}
@@ -133,7 +133,7 @@ void GameViewDebugger::set_node_type(int p_type) {
 	Array message;
 	message.append(p_type);
 
-	for (Ref<EditorDebuggerSession> &I : sessions) {
+	for (const Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
 			I->send_message("scene:runtime_node_select_set_type", message);
 		}
@@ -146,7 +146,7 @@ void GameViewDebugger::set_selection_visible(bool p_visible) {
 	Array message;
 	message.append(p_visible);
 
-	for (Ref<EditorDebuggerSession> &I : sessions) {
+	for (const Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
 			I->send_message("scene:runtime_node_select_set_visible", message);
 		}
@@ -159,7 +159,7 @@ void GameViewDebugger::set_select_mode(int p_mode) {
 	Array message;
 	message.append(p_mode);
 
-	for (Ref<EditorDebuggerSession> &I : sessions) {
+	for (const Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
 			I->send_message("scene:runtime_node_select_set_mode", message);
 		}
@@ -184,7 +184,7 @@ void GameViewDebugger::set_camera_manipulate_mode(EditorDebuggerNode::CameraOver
 }
 
 void GameViewDebugger::reset_camera_2d_position() {
-	for (Ref<EditorDebuggerSession> &I : sessions) {
+	for (const Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
 			I->send_message("scene:runtime_node_select_reset_camera_2d", Array());
 		}
@@ -192,7 +192,7 @@ void GameViewDebugger::reset_camera_2d_position() {
 }
 
 void GameViewDebugger::reset_camera_3d_position() {
-	for (Ref<EditorDebuggerSession> &I : sessions) {
+	for (const Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
 			I->send_message("scene:runtime_node_select_reset_camera_3d", Array());
 		}

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2308,7 +2308,7 @@ void TileSetAtlasSourceEditor::_cleanup_outside_tiles() {
 }
 
 void TileSetAtlasSourceEditor::_auto_create_tiles() {
-	for (Ref<TileSetAtlasSource> &atlas_source : atlases_to_auto_create_tiles) {
+	for (const Ref<TileSetAtlasSource> &atlas_source : atlases_to_auto_create_tiles) {
 		if (atlas_source.is_valid()) {
 			Ref<Texture2D> texture = atlas_source->get_texture();
 			if (texture.is_valid()) {

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -461,7 +461,7 @@ bool ProjectConverter3To4::convert() {
 			} else if (file_name.ends_with(".csproj")) {
 				// TODO
 			} else if (file_name.ends_with(".import")) {
-				for (SourceLine &source_line : source_lines) {
+				for (SourceLine &source_line : source_lines.write) {
 					String &line = source_line.line;
 					if (line.contains("nodes/root_type=\"Spatial\"")) {
 						line = "nodes/root_type=\"Node3D\"";
@@ -474,12 +474,12 @@ bool ProjectConverter3To4::convert() {
 				continue;
 			}
 
-			for (SourceLine &source_line : source_lines) {
+			for (const SourceLine &source_line : source_lines) {
 				if (source_line.is_comment) {
 					continue;
 				}
 
-				String &line = source_line.line;
+				const String &line = source_line.line;
 				if (uint64_t(line.length()) > maximum_line_length) {
 					ignored_lines += 1;
 				}
@@ -649,7 +649,7 @@ bool ProjectConverter3To4::validate_conversion() {
 				continue;
 			}
 
-			for (String &line : lines) {
+			for (const String &line : lines) {
 				if (uint64_t(line.length()) > maximum_line_length) {
 					ignored_lines += 1;
 				}
@@ -732,7 +732,7 @@ Vector<String> ProjectConverter3To4::check_for_files() {
 Vector<SourceLine> ProjectConverter3To4::split_lines(const String &text) {
 	Vector<String> lines = text.split("\n");
 	Vector<SourceLine> source_lines;
-	for (String &line : lines) {
+	for (const String &line : lines) {
 		SourceLine source_line;
 		source_line.line = line;
 		source_line.is_comment = false;
@@ -1095,7 +1095,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		Vector<String> got_vector = parse_arguments(line);
 		String got = "";
 		String expected = "";
-		for (String &part : got_vector) {
+		for (const String &part : got_vector) {
 			got += part + "|||";
 		}
 		if (got != expected) {
@@ -1108,7 +1108,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		Vector<String> got_vector = parse_arguments(line);
 		String got = "";
 		String expected = "a|||b|||c|||";
-		for (String &part : got_vector) {
+		for (const String &part : got_vector) {
 			got += part + "|||";
 		}
 		if (got != expected) {
@@ -1121,7 +1121,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		Vector<String> got_vector = parse_arguments(line);
 		String got = "";
 		String expected = "a|||\"b,\"|||c|||";
-		for (String &part : got_vector) {
+		for (const String &part : got_vector) {
 			got += part + "|||";
 		}
 		if (got != expected) {
@@ -1134,7 +1134,7 @@ bool ProjectConverter3To4::test_conversion(RegExContainer &reg_container) {
 		Vector<String> got_vector = parse_arguments(line);
 		String got = "";
 		String expected = "a|||\"(,),,,,\"|||c|||";
-		for (String &part : got_vector) {
+		for (const String &part : got_vector) {
 			got += part + "|||";
 		}
 		if (got != expected) {
@@ -1327,7 +1327,7 @@ Vector<String> ProjectConverter3To4::parse_arguments(const String &line) {
 	}
 
 	Vector<String> clean_parts;
-	for (String &part : parts) {
+	for (String &part : parts.write) {
 		part = part.strip_edges();
 		if (!part.is_empty()) {
 			clean_parts.append(part);
@@ -1453,7 +1453,7 @@ String ProjectConverter3To4::get_object_of_execution(const String &line) const {
 }
 
 void ProjectConverter3To4::rename_colors(Vector<SourceLine> &source_lines, const RegExContainer &reg_container) {
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -1471,7 +1471,7 @@ void ProjectConverter3To4::rename_colors(Vector<SourceLine> &source_lines, const
 
 // Convert hexadecimal colors from ARGB to RGBA
 void ProjectConverter3To4::convert_hexadecimal_colors(Vector<SourceLine> &source_lines, const RegExContainer &reg_container) {
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -1490,7 +1490,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_colors(Vector<String> &lin
 	Vector<String> found_renames;
 
 	int current_line = 1;
-	for (String &line : lines) {
+	for (const String &line : lines) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			if (line.contains("Color.")) {
 				for (unsigned int current_index = 0; RenamesMap3To4::color_renames[current_index][0]; current_index++) {
@@ -1522,7 +1522,7 @@ void ProjectConverter3To4::fix_pause_mode(Vector<SourceLine> &source_lines, cons
 	// In Godot 3, the pause_mode 2 equals the PAUSE_MODE_PROCESS value.
 	// In Godot 4, the pause_mode PAUSE_MODE_PROCESS was renamed to PROCESS_MODE_ALWAYS and equals the number 3.
 	// We therefore convert pause_mode = 2 to pause_mode = 3.
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		String &line = source_line.line;
 
 		if (line == "pause_mode = 2") {
@@ -1533,7 +1533,7 @@ void ProjectConverter3To4::fix_pause_mode(Vector<SourceLine> &source_lines, cons
 }
 
 void ProjectConverter3To4::rename_classes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container) {
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -1571,7 +1571,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_classes(Vector<String> &li
 
 	int current_line = 1;
 
-	for (String &line : lines) {
+	for (String &line : lines.write) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			for (unsigned int current_index = 0; RenamesMap3To4::class_renames[current_index][0]; current_index++) {
 				if (line.contains(RenamesMap3To4::class_renames[current_index][0])) {
@@ -1606,7 +1606,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_classes(Vector<String> &li
 }
 
 void ProjectConverter3To4::rename_gdscript_functions(Vector<SourceLine> &source_lines, const RegExContainer &reg_container, bool builtin) {
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -1623,7 +1623,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_gdscript_functions(Vector<
 
 	Vector<String> found_renames;
 
-	for (String &line : lines) {
+	for (String &line : lines.write) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			String old_line = line;
 			process_gdscript_line(line, reg_container, builtin);
@@ -2426,7 +2426,7 @@ void ProjectConverter3To4::process_csharp_line(String &line, const RegExContaine
 }
 
 void ProjectConverter3To4::rename_csharp_functions(Vector<SourceLine> &source_lines, const RegExContainer &reg_container) {
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -2443,7 +2443,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_csharp_functions(Vector<St
 
 	Vector<String> found_renames;
 
-	for (String &line : lines) {
+	for (String &line : lines.write) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			String old_line = line;
 			process_csharp_line(line, reg_container);
@@ -2459,7 +2459,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_csharp_functions(Vector<St
 void ProjectConverter3To4::rename_csharp_attributes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container) {
 	static String error_message = "The master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using Multiplayer.GetRemoteSenderId()\n";
 
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -2481,7 +2481,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_csharp_attributes(Vector<S
 
 	Vector<String> found_renames;
 
-	for (String &line : lines) {
+	for (String &line : lines.write) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			String old;
 			old = line;
@@ -2537,7 +2537,7 @@ _FORCE_INLINE_ static String builtin_escape(const String &p_str, bool p_builtin)
 void ProjectConverter3To4::rename_gdscript_keywords(Vector<SourceLine> &source_lines, const RegExContainer &reg_container, bool builtin) {
 	static String error_message = "The master and mastersync rpc behavior is not officially supported anymore. Try using another keyword or making custom logic using get_multiplayer().get_remote_sender_id()\n";
 
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -2585,7 +2585,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_gdscript_keywords(Vector<S
 	Vector<String> found_renames;
 
 	int current_line = 1;
-	for (String &line : lines) {
+	for (String &line : lines.write) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			String old;
 
@@ -2695,7 +2695,7 @@ void ProjectConverter3To4::rename_input_map_scancode(Vector<SourceLine> &source_
 	// The old Special Key, now colliding with CMD_OR_CTRL.
 	const int old_spkey = (1 << 24);
 
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -2721,7 +2721,7 @@ void ProjectConverter3To4::rename_input_map_scancode(Vector<SourceLine> &source_
 }
 
 void ProjectConverter3To4::rename_joypad_buttons_and_axes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container) {
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -2765,7 +2765,7 @@ void ProjectConverter3To4::rename_joypad_buttons_and_axes(Vector<SourceLine> &so
 Vector<String> ProjectConverter3To4::check_for_rename_joypad_buttons_and_axes(Vector<String> &lines, const RegExContainer &reg_container) {
 	Vector<String> found_renames;
 	int current_line = 1;
-	for (String &line : lines) {
+	for (String &line : lines.write) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			// Remap button indexes.
 			TypedArray<RegExMatch> reg_match = reg_container.joypad_button_index.search_all(line);
@@ -2810,7 +2810,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_input_map_scancode(Vector<
 	const int old_spkey = (1 << 24);
 
 	int current_line = 1;
-	for (String &line : lines) {
+	for (const String &line : lines) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			TypedArray<RegExMatch> reg_match = reg_container.input_map_keycode.search_all(line);
 
@@ -2835,7 +2835,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_input_map_scancode(Vector<
 void ProjectConverter3To4::custom_rename(Vector<SourceLine> &source_lines, const String &from, const String &to) {
 	RegEx reg = RegEx(String("\\b") + from + "\\b");
 	CRASH_COND(!reg.is_valid());
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -2854,7 +2854,7 @@ Vector<String> ProjectConverter3To4::check_for_custom_rename(Vector<String> &lin
 	CRASH_COND(!reg.is_valid());
 
 	int current_line = 1;
-	for (String &line : lines) {
+	for (const String &line : lines) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			TypedArray<RegExMatch> reg_match = reg.search_all(line);
 			if (reg_match.size() > 0) {
@@ -2867,7 +2867,7 @@ Vector<String> ProjectConverter3To4::check_for_custom_rename(Vector<String> &lin
 }
 
 void ProjectConverter3To4::rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<SourceLine> &source_lines) {
-	for (SourceLine &source_line : source_lines) {
+	for (SourceLine &source_line : source_lines.write) {
 		if (source_line.is_comment) {
 			continue;
 		}
@@ -2888,7 +2888,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_common(const char *array[]
 
 	int current_line = 1;
 
-	for (String &line : lines) {
+	for (const String &line : lines) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			for (unsigned int current_index = 0; current_index < cached_regexes.size(); current_index++) {
 				if (line.contains(array[current_index][0])) {

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -908,7 +908,7 @@ void ProjectList::add_project(const String &dir_path, bool favorite) {
 }
 
 void ProjectList::set_project_version(const String &p_project_path, int p_version) {
-	for (ProjectList::Item &E : _projects) {
+	for (ProjectList::Item &E : _projects.write) {
 		if (E.path == p_project_path) {
 			E.version = p_version;
 			break;

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -569,7 +569,7 @@ void ScriptCreateDialog::_update_template_menu() {
 						template_menu->set_item_auto_translate_mode(-1, AUTO_TRANSLATE_MODE_ALWAYS);
 						separator = true;
 					}
-					for (ScriptLanguage::ScriptTemplate &t : templates_found) {
+					for (ScriptLanguage::ScriptTemplate &t : templates_found.write) {
 						template_menu->add_item(t.inherit + ": " + t.name);
 						int id = template_menu->get_item_count() - 1;
 						// Check if this template should be preselected if node isn't in the last used dictionary.

--- a/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
@@ -185,7 +185,7 @@ void EditorSceneExporterGLTFSettings::generate_property_list(Ref<GLTFDocument> p
 	_document = p_document;
 	String image_format_hint_string = "None,PNG,JPEG";
 	// Add properties from all document extensions.
-	for (Ref<GLTFDocumentExtension> &extension : GLTFDocument::get_all_gltf_document_extensions()) {
+	for (const Ref<GLTFDocumentExtension> &extension : GLTFDocument::get_all_gltf_document_extensions()) {
 		const Callable on_prop_changed = callable_mp(this, &EditorSceneExporterGLTFSettings::_on_extension_property_list_changed);
 		if (!extension->is_connected(CoreStringName(property_list_changed), on_prop_changed)) {
 			extension->connect(CoreStringName(property_list_changed), on_prop_changed);

--- a/modules/mono/utils/naming_utils.cpp
+++ b/modules/mono/utils/naming_utils.cpp
@@ -160,7 +160,7 @@ String pascal_to_pascal_case(const String &p_identifier) {
 
 	String ret;
 
-	for (String &part : parts) {
+	for (String &part : parts.write) {
 		String part_override = _get_pascal_case_part_override(part);
 		if (!part_override.is_empty()) {
 			// Use hardcoded value for part.

--- a/modules/openxr/action_map/openxr_interaction_profile_metadata.cpp
+++ b/modules/openxr/action_map/openxr_interaction_profile_metadata.cpp
@@ -93,7 +93,7 @@ void OpenXRInteractionProfileMetadata::register_io_path(const String &p_interact
 	ERR_FAIL_COND_MSG(!has_interaction_profile(p_interaction_profile), "Unknown interaction profile " + p_interaction_profile);
 	ERR_FAIL_COND_MSG(!has_top_level_path(p_toplevel_path), "Unknown top level path " + p_toplevel_path);
 
-	for (InteractionProfile &interaction_profile : interaction_profiles) {
+	for (InteractionProfile &interaction_profile : interaction_profiles.write) {
 		if (interaction_profile.openxr_path == p_interaction_profile) {
 			ERR_FAIL_COND_MSG(interaction_profile.has_io_path(p_openxr_path), p_interaction_profile + " already has io path " + p_openxr_path + " registered!");
 

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -145,7 +145,7 @@ void OpenXRAPI::OpenXRSwapChainInfo::queue_free() {
 }
 
 void OpenXRAPI::OpenXRSwapChainInfo::free_queued() {
-	for (OpenXRAPI::OpenXRSwapChainInfo &swapchain_info : free_queue) {
+	for (OpenXRAPI::OpenXRSwapChainInfo &swapchain_info : free_queue.write) {
 		swapchain_info.free();
 	}
 	free_queue.clear();
@@ -569,7 +569,7 @@ bool OpenXRAPI::create_instance() {
 	// Check which extensions are supported.
 	enabled_extensions.clear();
 
-	for (RequestExtension &requested_extension : requested_extensions) {
+	for (const RequestExtension &requested_extension : requested_extensions) {
 		if (!is_extension_supported(requested_extension.name)) {
 			if (requested_extension.enabled == nullptr) {
 				// Null means this is a mandatory extension so we fail.
@@ -2567,7 +2567,7 @@ void OpenXRAPI::end_frame() {
 
 	// Now make a list we can pass on to OpenXR.
 	Vector<const XrCompositionLayerBaseHeader *> layers_list;
-	for (OrderedCompositionLayer &ordered_layer : ordered_layers_list) {
+	for (const OrderedCompositionLayer &ordered_layer : ordered_layers_list) {
 		layers_list.push_back(ordered_layer.composition_layer);
 	}
 

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -149,7 +149,7 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 			Vector<TVG_NodeCache> &ncs = cache.node_caches[p_slot->glyph_index];
 
 			uint64_t offset = 0;
-			for (TVG_NodeCache &nc : ncs) {
+			for (const TVG_NodeCache &nc : ncs) {
 				// Seek will call read() internally.
 				if (parser->seek(nc.document_offset) == OK) {
 					int64_t tag_count = 0;

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -149,7 +149,7 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 			Vector<TVG_NodeCache> &ncs = cache.node_caches[p_slot->glyph_index];
 
 			uint64_t offset = 0;
-			for (TVG_NodeCache &nc : ncs) {
+			for (const TVG_NodeCache &nc : ncs) {
 				// Seek will call read() internally.
 				if (parser->seek(nc.document_offset) == OK) {
 					int64_t tag_count = 0;

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -1022,7 +1022,7 @@ FreeDesktopPortalDesktop::~FreeDesktopPortalDesktop() {
 
 	if (monitor_connection) {
 		DBusError err;
-		for (FreeDesktopPortalDesktop::FileDialogData &fd : file_dialogs) {
+		for (const FreeDesktopPortalDesktop::FileDialogData &fd : file_dialogs) {
 			dbus_error_init(&err);
 			dbus_bus_remove_match(monitor_connection, fd.filter.utf8().get_data(), &err);
 			dbus_error_free(&err);

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -872,7 +872,7 @@ void TileMapLayer::_physics_update(bool p_force_cleanup) {
 					// Create shapes for each polygon.
 					int body_shape_index = 0;
 					Vector<Vector<Vector2>> convex_polygons = Geometry2D::decompose_many_polygons_in_convex(out_polygons, out_holes);
-					for (Vector<Vector2> &convex_polygon : convex_polygons) {
+					for (const Vector<Vector2> &convex_polygon : convex_polygons) {
 						Ref<ConvexPolygonShape2D> shape;
 						shape.instantiate();
 						shape->set_points(convex_polygon);

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -358,7 +358,7 @@ StringName AudioStreamPlayer3D::_get_actual_bus() {
 Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 	Vector<AudioFrame> output_volume_vector;
 	output_volume_vector.resize(4);
-	for (AudioFrame &frame : output_volume_vector) {
+	for (AudioFrame &frame : output_volume_vector.write) {
 		frame = AudioFrame(0, 0);
 	}
 
@@ -432,7 +432,7 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 			if (dist > total_max || total_max > max_distance) {
 				if (!was_further_than_max_distance_last_frame) {
 					HashMap<StringName, Vector<AudioFrame>> bus_volumes;
-					for (Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
+					for (const Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
 						// So the player gets muted and mostly stops mixing when out of range.
 						AudioServer::get_singleton()->set_playback_bus_volumes_linear(playback, bus_volumes);
 					}
@@ -460,7 +460,7 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 		}
 
 		linear_attenuation = Math::db_to_linear(db_att);
-		for (Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
+		for (const Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
 			AudioServer::get_singleton()->set_playback_highshelf_params(playback, linear_attenuation, attenuation_filter_cutoff_hz);
 		}
 
@@ -500,7 +500,7 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 			bus_volumes[internal->bus] = output_volume_vector;
 		}
 
-		for (Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
+		for (const Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
 			AudioServer::get_singleton()->set_playback_bus_volumes_linear(playback, bus_volumes);
 		}
 
@@ -528,7 +528,7 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 		} else {
 			actual_pitch_scale = internal->pitch_scale;
 		}
-		for (Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
+		for (const Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
 			AudioServer::get_singleton()->set_playback_pitch_scale(playback, actual_pitch_scale);
 			if (playback->get_is_sample()) {
 				Ref<AudioSamplePlayback> sample_playback = playback->get_sample_playback();

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -70,7 +70,7 @@ void AudioStreamPlayer::set_volume_db(float p_volume) {
 	internal->volume_db = p_volume;
 
 	Vector<AudioFrame> volume_vector = _get_volume_vector();
-	for (Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
+	for (const Ref<AudioStreamPlayback> &playback : internal->stream_playbacks) {
 		AudioServer::get_singleton()->set_playback_all_bus_volumes_linear(playback, volume_vector);
 	}
 }
@@ -183,7 +183,7 @@ Vector<AudioFrame> AudioStreamPlayer::_get_volume_vector() {
 	volume_vector.resize(4);
 
 	// Initialize the volume vector to zero.
-	for (AudioFrame &channel_volume_db : volume_vector) {
+	for (AudioFrame &channel_volume_db : volume_vector.write) {
 		channel_volume_db = AudioFrame(0, 0);
 	}
 

--- a/scene/audio/audio_stream_player_internal.cpp
+++ b/scene/audio/audio_stream_player_internal.cpp
@@ -62,13 +62,13 @@ void AudioStreamPlayerInternal::_update_stream_parameters() {
 
 void AudioStreamPlayerInternal::process() {
 	Vector<Ref<AudioStreamPlayback>> playbacks_to_remove;
-	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+	for (const Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 		if (playback.is_valid() && !AudioServer::get_singleton()->is_playback_active(playback) && !AudioServer::get_singleton()->is_playback_paused(playback)) {
 			playbacks_to_remove.push_back(playback);
 		}
 	}
 	// Now go through and remove playbacks that have finished. Removing elements from a Vector in a range based for is asking for trouble.
-	for (Ref<AudioStreamPlayback> &playback : playbacks_to_remove) {
+	for (const Ref<AudioStreamPlayback> &playback : playbacks_to_remove) {
 		stream_playbacks.erase(playback);
 	}
 	if (!playbacks_to_remove.is_empty() && stream_playbacks.is_empty()) {
@@ -106,7 +106,7 @@ void AudioStreamPlayerInternal::notification(int p_what) {
 		} break;
 
 		case Node::NOTIFICATION_PREDELETE: {
-			for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+			for (const Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 				AudioServer::get_singleton()->stop_playback_stream(playback);
 			}
 			stream_playbacks.clear();
@@ -176,7 +176,7 @@ Ref<AudioStreamPlayback> AudioStreamPlayerInternal::play_basic() {
 
 void AudioStreamPlayerInternal::set_stream_paused(bool p_pause) {
 	// TODO this does not have perfect recall, fix that maybe? If there are zero playbacks registered with the AudioServer, this bool isn't persisted.
-	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+	for (const Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 		AudioServer::get_singleton()->set_playback_paused(playback, p_pause);
 		if (_is_sample() && playback->get_sample_playback().is_valid()) {
 			AudioServer::get_singleton()->set_sample_playback_pause(playback->get_sample_playback(), p_pause);
@@ -213,7 +213,7 @@ bool AudioStreamPlayerInternal::set(const StringName &p_name, const Variant &p_v
 		return false;
 	}
 	pd->value = p_value;
-	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+	for (const Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 		playback->set_parameter(pd->path, pd->value);
 	}
 	return true;
@@ -268,7 +268,7 @@ void AudioStreamPlayerInternal::seek(float p_seconds) {
 }
 
 void AudioStreamPlayerInternal::stop_basic() {
-	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+	for (const Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 		AudioServer::get_singleton()->stop_playback_stream(playback);
 	}
 	stream_playbacks.clear();
@@ -310,7 +310,7 @@ void AudioStreamPlayerInternal::set_pitch_scale(float p_pitch_scale) {
 	ERR_FAIL_COND(p_pitch_scale <= 0.0);
 	pitch_scale = p_pitch_scale;
 
-	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+	for (const Ref<AudioStreamPlayback> &playback : stream_playbacks) {
 		AudioServer::get_singleton()->set_playback_pitch_scale(playback, pitch_scale);
 	}
 }

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -3616,7 +3616,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 				}
 			}
 			Vector<Vector<Pair<int, int>>> next_subsequence_matches;
-			for (Vector<Pair<int, int>> &subsequence_match : all_possible_subsequence_matches) {
+			for (const Vector<Pair<int, int>> &subsequence_match : all_possible_subsequence_matches) {
 				Pair<int, int> match_last_segment = subsequence_match[subsequence_match.size() - 1];
 				int next_index = match_last_segment.first + match_last_segment.second;
 				// get the last index from current sequence
@@ -3648,7 +3648,7 @@ void CodeEdit::_filter_code_completion_candidates_impl() {
 				CodeCompletionOptionCompare compare;
 				ScriptLanguage::CodeCompletionOption compared_option = option;
 				compared_option.clear_characteristics();
-				for (Vector<Pair<int, int>> &matches : all_possible_subsequence_matches) {
+				for (const Vector<Pair<int, int>> &matches : all_possible_subsequence_matches) {
 					compared_option.matches = matches;
 					compared_option.get_option_characteristics(string_to_complete);
 					if (compare(compared_option, option)) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -144,7 +144,7 @@ void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> 
 
 	Vector<String> files = p_files;
 	if (access != ACCESS_FILESYSTEM) {
-		for (String &file_name : files) {
+		for (String &file_name : files.write) {
 			file_name = ProjectSettings::get_singleton()->localize_path(file_name);
 		}
 	}

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1577,7 +1577,7 @@ void GraphEdit::_draw_minimap_connection_line(const Vector2 &p_from_graph_positi
 	Vector<Vector2> points = get_connection_line(p_from_graph_position, p_to_graph_position);
 	ERR_FAIL_COND_MSG(points.size() < 2, "\"_get_connection_line()\" returned an invalid line.");
 	// Convert to minimap points.
-	for (Vector2 &point : points) {
+	for (Vector2 &point : points.write) {
 		point = minimap->_convert_from_graph_position(point) + minimap->minimap_offset;
 	}
 
@@ -2334,7 +2334,7 @@ void GraphEdit::reset_all_connection_activity() {
 	ERR_FAIL_NULL_MSG(connections_layer, "connections_layer is missing.");
 
 	bool changed = false;
-	for (Ref<Connection> &conn : connections) {
+	for (const Ref<Connection> &conn : connections) {
 		if (conn->activity > 0) {
 			changed = true;
 			conn->_cache.dirty = true;
@@ -2349,7 +2349,7 @@ void GraphEdit::reset_all_connection_activity() {
 void GraphEdit::clear_connections() {
 	ERR_FAIL_NULL_MSG(connections_layer, "connections_layer is missing.");
 
-	for (Ref<Connection> &conn : connections) {
+	for (const Ref<Connection> &conn : connections) {
 		conn->_cache.line->queue_free();
 	}
 
@@ -2592,7 +2592,7 @@ void GraphEdit::_update_zoom_label() {
 }
 
 void GraphEdit::_invalidate_connection_line_cache() {
-	for (Ref<Connection> &conn : connections) {
+	for (const Ref<Connection> &conn : connections) {
 		conn->_cache.dirty = true;
 	}
 }

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -40,7 +40,7 @@ void Label::set_autowrap_mode(TextServer::AutowrapMode p_mode) {
 	}
 
 	autowrap_mode = p_mode;
-	for (Paragraph &para : paragraphs) {
+	for (Paragraph &para : paragraphs.write) {
 		para.lines_dirty = true;
 	}
 	queue_redraw();
@@ -61,7 +61,7 @@ void Label::set_autowrap_trim_flags(BitField<TextServer::LineBreakFlag> p_flags)
 	}
 
 	autowrap_flags_trim = p_flags & TextServer::BREAK_TRIM_MASK;
-	for (Paragraph &para : paragraphs) {
+	for (Paragraph &para : paragraphs.write) {
 		para.lines_dirty = true;
 	}
 	queue_redraw();
@@ -82,7 +82,7 @@ void Label::set_justification_flags(BitField<TextServer::JustificationFlag> p_fl
 	}
 
 	jst_flags = p_flags;
-	for (Paragraph &para : paragraphs) {
+	for (Paragraph &para : paragraphs.write) {
 		para.lines_dirty = true;
 	}
 	queue_redraw();
@@ -140,7 +140,7 @@ void Label::_shape() const {
 	int width = (get_size().width - style->get_minimum_size().width);
 
 	if (text_dirty) {
-		for (Paragraph &para : paragraphs) {
+		for (Paragraph &para : paragraphs.write) {
 			for (const RID &line_rid : para.lines_rid) {
 				TS->free_rid(line_rid);
 			}
@@ -168,7 +168,7 @@ void Label::_shape() const {
 	}
 
 	total_line_count = 0;
-	for (Paragraph &para : paragraphs) {
+	for (Paragraph &para : paragraphs.write) {
 		if (para.dirty || font_dirty) {
 			if (para.dirty) {
 				TS->shaped_text_clear(para.text_rid);
@@ -246,7 +246,7 @@ void Label::_shape() const {
 	if (autowrap_mode == TextServer::AUTOWRAP_OFF) {
 		minsize.width = 0.0f;
 	}
-	for (Paragraph &para : paragraphs) {
+	for (Paragraph &para : paragraphs.write) {
 		if (autowrap_mode == TextServer::AUTOWRAP_OFF) {
 			for (const RID &line_rid : para.lines_rid) {
 				if (minsize.width < TS->shaped_text_get_size(line_rid).x) {
@@ -728,7 +728,7 @@ void Label::_notification(int p_what) {
 			}
 
 			// When a shaped text is invalidated by an external source, we want to reshape it.
-			for (Paragraph &para : paragraphs) {
+			for (Paragraph &para : paragraphs.write) {
 				if (!TS->shaped_text_is_ready(para.text_rid)) {
 					para.dirty = true;
 				}
@@ -917,7 +917,7 @@ void Label::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESIZED: {
-			for (Paragraph &para : paragraphs) {
+			for (Paragraph &para : paragraphs.write) {
 				para.lines_dirty = true;
 			}
 		} break;
@@ -1080,7 +1080,7 @@ void Label::set_horizontal_alignment(HorizontalAlignment p_alignment) {
 	}
 
 	if (horizontal_alignment == HORIZONTAL_ALIGNMENT_FILL || p_alignment == HORIZONTAL_ALIGNMENT_FILL) {
-		for (Paragraph &para : paragraphs) {
+		for (Paragraph &para : paragraphs.write) {
 			para.lines_dirty = true; // Reshape lines.
 		}
 	}
@@ -1150,7 +1150,7 @@ void Label::set_text_direction(Control::TextDirection p_text_direction) {
 	ERR_FAIL_COND((int)p_text_direction < -1 || (int)p_text_direction > 3);
 	if (text_direction != p_text_direction) {
 		text_direction = p_text_direction;
-		for (Paragraph &para : paragraphs) {
+		for (Paragraph &para : paragraphs.write) {
 			para.dirty = true;
 		}
 		queue_redraw();
@@ -1160,7 +1160,7 @@ void Label::set_text_direction(Control::TextDirection p_text_direction) {
 void Label::set_structured_text_bidi_override(TextServer::StructuredTextParser p_parser) {
 	if (st_parser != p_parser) {
 		st_parser = p_parser;
-		for (Paragraph &para : paragraphs) {
+		for (Paragraph &para : paragraphs.write) {
 			para.dirty = true;
 		}
 		queue_redraw();
@@ -1177,7 +1177,7 @@ void Label::set_structured_text_bidi_override_options(Array p_args) {
 	}
 
 	st_args = p_args;
-	for (Paragraph &para : paragraphs) {
+	for (Paragraph &para : paragraphs.write) {
 		para.dirty = true;
 	}
 	queue_redraw();
@@ -1194,7 +1194,7 @@ Control::TextDirection Label::get_text_direction() const {
 void Label::set_language(const String &p_language) {
 	if (language != p_language) {
 		language = p_language;
-		for (Paragraph &para : paragraphs) {
+		for (Paragraph &para : paragraphs.write) {
 			para.dirty = true;
 		}
 		queue_redraw();
@@ -1235,7 +1235,7 @@ bool Label::is_clipping_text() const {
 void Label::set_tab_stops(const PackedFloat32Array &p_tab_stops) {
 	if (tab_stops != p_tab_stops) {
 		tab_stops = p_tab_stops;
-		for (Paragraph &para : paragraphs) {
+		for (Paragraph &para : paragraphs.write) {
 			para.dirty = true;
 		}
 		queue_redraw();
@@ -1252,7 +1252,7 @@ void Label::set_text_overrun_behavior(TextServer::OverrunBehavior p_behavior) {
 	}
 
 	overrun_behavior = p_behavior;
-	for (Paragraph &para : paragraphs) {
+	for (Paragraph &para : paragraphs.write) {
 		para.lines_dirty = true;
 	}
 	queue_redraw();
@@ -1275,7 +1275,7 @@ void Label::set_ellipsis_char(const String &p_char) {
 		return;
 	}
 	el_char = c;
-	for (Paragraph &para : paragraphs) {
+	for (Paragraph &para : paragraphs.write) {
 		para.lines_dirty = true;
 	}
 	queue_redraw();
@@ -1490,7 +1490,7 @@ Label::Label(const String &p_text) {
 }
 
 Label::~Label() {
-	for (Paragraph &para : paragraphs) {
+	for (Paragraph &para : paragraphs.write) {
 		for (const RID &line_rid : para.lines_rid) {
 			TS->free_rid(line_rid);
 		}

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -2786,7 +2786,7 @@ void PopupMenu::add_separator(const String &p_text, int p_id) {
 }
 
 void PopupMenu::clear(bool p_free_submenus) {
-	for (Item &I : items) {
+	for (const Item &I : items) {
 		if (I.accessibility_item_element.is_valid()) {
 			DisplayServer::get_singleton()->accessibility_free_element(I.accessibility_item_element);
 			I.accessibility_item_element = RID();

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3399,7 +3399,7 @@ void RichTextLabel::_fetch_item_fx_stack(Item *p_item, Vector<ItemFX *> &r_stack
 }
 
 void RichTextLabel::_normalize_subtags(Vector<String> &subtags) {
-	for (String &subtag : subtags) {
+	for (String &subtag : subtags.write) {
 		subtag = subtag.unquote();
 	}
 }

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -156,12 +156,12 @@ void TreeItem::_change_tree(Tree *p_tree) {
 		DisplayServer::get_singleton()->accessibility_free_element(accessibility_row_element);
 		accessibility_row_element = RID();
 	}
-	for (Cell &cell : cells) {
+	for (const Cell &cell : cells) {
 		if (cell.accessibility_cell_element.is_valid()) {
 			DisplayServer::get_singleton()->accessibility_free_element(cell.accessibility_cell_element);
 			cell.accessibility_cell_element = RID();
 		}
-		for (Cell::Button &btn : cell.buttons) {
+		for (const Cell::Button &btn : cell.buttons) {
 			if (btn.accessibility_button_element.is_valid()) {
 				DisplayServer::get_singleton()->accessibility_free_element(btn.accessibility_button_element);
 				btn.accessibility_button_element = RID();
@@ -853,7 +853,7 @@ void TreeItem::set_custom_minimum_height(int p_height) {
 
 	custom_min_height = p_height;
 
-	for (Cell &c : cells) {
+	for (Cell &c : cells.write) {
 		c.cached_minimum_size_dirty = true;
 	}
 
@@ -1303,9 +1303,9 @@ void TreeItem::deselect(int p_column) {
 
 void TreeItem::clear_buttons() {
 	int i = 0;
-	for (Cell &cell : cells) {
+	for (Cell &cell : cells.write) {
 		if (!cell.buttons.is_empty()) {
-			for (Cell::Button &btn : cell.buttons) {
+			for (const Cell::Button &btn : cell.buttons) {
 				if (btn.accessibility_button_element.is_valid()) {
 					DisplayServer::get_singleton()->accessibility_free_element(btn.accessibility_button_element);
 				}
@@ -1643,7 +1643,7 @@ void TreeItem::set_disable_folding(bool p_disable) {
 
 	disable_folding = p_disable;
 
-	for (Cell &c : cells) {
+	for (Cell &c : cells.write) {
 		c.cached_minimum_size_dirty = true;
 	}
 
@@ -4585,9 +4585,9 @@ RID Tree::get_focused_accessibility_element() const {
 
 void Tree::_accessibility_clean_info(TreeItem *p_item) {
 	p_item->accessibility_row_element = RID();
-	for (TreeItem::Cell &cell : p_item->cells) {
+	for (const TreeItem::Cell &cell : p_item->cells) {
 		cell.accessibility_cell_element = RID();
-		for (TreeItem::Cell::Button &btn : cell.buttons) {
+		for (const TreeItem::Cell::Button &btn : cell.buttons) {
 			btn.accessibility_button_element = RID();
 		}
 	}
@@ -4738,7 +4738,7 @@ void Tree::_notification(int p_what) {
 			if (root) {
 				_accessibility_clean_info(root);
 			}
-			for (ColumnInfo &col : columns) {
+			for (const ColumnInfo &col : columns) {
 				col.accessibility_col_element = RID();
 			}
 			accessibility_scroll_element = RID();
@@ -5444,12 +5444,12 @@ int Tree::get_column_width(int p_column) const {
 void Tree::propagate_set_columns(TreeItem *p_item) {
 	p_item->cells.resize(columns.size());
 	p_item->accessibility_row_dirty = true;
-	for (TreeItem::Cell &cell : p_item->cells) {
+	for (const TreeItem::Cell &cell : p_item->cells) {
 		if (cell.accessibility_cell_element.is_valid()) {
 			DisplayServer::get_singleton()->accessibility_free_element(cell.accessibility_cell_element);
 			cell.accessibility_cell_element = RID();
 		}
-		for (TreeItem::Cell::Button &btn : cell.buttons) {
+		for (const TreeItem::Cell::Button &btn : cell.buttons) {
 			if (btn.accessibility_button_element.is_valid()) {
 				DisplayServer::get_singleton()->accessibility_free_element(btn.accessibility_button_element);
 				btn.accessibility_button_element = RID();

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -176,12 +176,12 @@ private:
 			DisplayServer::get_singleton()->accessibility_free_element(accessibility_row_element);
 			accessibility_row_element = RID();
 		}
-		for (Cell &cell : cells) {
+		for (const Cell &cell : cells) {
 			if (cell.accessibility_cell_element.is_valid()) {
 				DisplayServer::get_singleton()->accessibility_free_element(cell.accessibility_cell_element);
 				cell.accessibility_cell_element = RID();
 			}
-			for (Cell::Button &btn : cell.buttons) {
+			for (const Cell::Button &btn : cell.buttons) {
 				if (btn.accessibility_button_element.is_valid()) {
 					DisplayServer::get_singleton()->accessibility_free_element(btn.accessibility_button_element);
 					btn.accessibility_button_element = RID();

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -944,7 +944,7 @@ void CanvasItem::draw_polygon(const Vector<Point2> &p_points, const Vector<Color
 		const Vector2 remap_max = atlas->get_region().get_end() / atlas_size;
 
 		PackedVector2Array uvs = p_uvs;
-		for (Vector2 &p : uvs) {
+		for (Vector2 &p : uvs.write) {
 			p.x = Math::remap(p.x, 0, 1, remap_min.x, remap_max.x);
 			p.y = Math::remap(p.y, 0, 1, remap_min.y, remap_max.y);
 		}

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -2043,7 +2043,7 @@ void SceneState::add_editable_instance(const NodePath &p_path) {
 
 bool SceneState::remove_group_references(const StringName &p_name) {
 	bool edited = false;
-	for (NodeData &node : nodes) {
+	for (NodeData &node : nodes.write) {
 		for (const int &group : node.groups) {
 			if (names[group] == p_name) {
 				node.groups.erase(group);

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -614,7 +614,7 @@ Ref<AudioStreamPlayback> AudioStreamRandomizer::instance_playback_random() {
 	}
 	double chosen_cumulative_weight = Math::random(0.0, total_weight);
 	double cumulative_weight = 0;
-	for (PoolEntry &entry : local_pool) {
+	for (const PoolEntry &entry : local_pool) {
 		cumulative_weight += entry.weight;
 		if (cumulative_weight > chosen_cumulative_weight) {
 			playback->playback = entry.stream->instantiate_playback();
@@ -656,7 +656,7 @@ Ref<AudioStreamPlayback> AudioStreamRandomizer::instance_playback_no_repeats() {
 	playback->randomizer = Ref<AudioStreamRandomizer>((AudioStreamRandomizer *)this);
 	double chosen_cumulative_weight = Math::random(0.0, total_weight);
 	double cumulative_weight = 0;
-	for (PoolEntry &entry : local_pool) {
+	for (const PoolEntry &entry : local_pool) {
 		cumulative_weight += entry.weight;
 		if (cumulative_weight > chosen_cumulative_weight) {
 			last_playback = entry.stream;
@@ -693,7 +693,7 @@ Ref<AudioStreamPlayback> AudioStreamRandomizer::instance_playback_sequential() {
 		return playback;
 	}
 	bool found_last_stream = false;
-	for (Ref<AudioStream> &entry : local_pool) {
+	for (const Ref<AudioStream> &entry : local_pool) {
 		if (found_last_stream) {
 			last_playback = entry;
 			playback->playback = entry->instantiate_playback();

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -61,11 +61,11 @@ LightStorage::LightStorage() {
 			shadowmask_textures.resize(1024);
 		}
 
-		for (RID &lightmap_texture : lightmap_textures) {
+		for (RID &lightmap_texture : lightmap_textures.write) {
 			lightmap_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 		}
 
-		for (RID &shadowmask_texture : shadowmask_textures) {
+		for (RID &shadowmask_texture : shadowmask_textures.write) {
 			shadowmask_texture = texture_storage->texture_rd_get_default(TextureStorage::DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE);
 		}
 	}

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -488,7 +488,7 @@ void RenderSceneBuffersRD::clear_context(const StringName &p_context) {
 	}
 
 	// Now free these and remove them from our textures
-	for (NTKey &key : to_free) {
+	for (const NTKey &key : to_free) {
 		free_named_texture(named_textures[key]);
 		named_textures.erase(key);
 	}

--- a/tests/core/io/test_tcp_server.h
+++ b/tests/core/io/test_tcp_server.h
@@ -136,7 +136,7 @@ TEST_CASE("[TCPServer] Handle multiple clients at the same time") {
 
 	wait_for_condition([&]() {
 		bool should_exit = true;
-		for (Ref<StreamPeerTCP> &c : clients) {
+		for (const Ref<StreamPeerTCP> &c : clients) {
 			if (c->poll() != Error::OK) {
 				return true;
 			}
@@ -151,7 +151,7 @@ TEST_CASE("[TCPServer] Handle multiple clients at the same time") {
 		return should_exit;
 	});
 
-	for (Ref<StreamPeerTCP> &c : clients) {
+	for (const Ref<StreamPeerTCP> &c : clients) {
 		REQUIRE_EQ(c->get_status(), StreamPeerTCP::STATUS_CONNECTED);
 	}
 
@@ -162,7 +162,7 @@ TEST_CASE("[TCPServer] Handle multiple clients at the same time") {
 		CHECK_EQ(clients_from_server[i]->get_string(), hello_client);
 	}
 
-	for (Ref<StreamPeerTCP> &c : clients) {
+	for (const Ref<StreamPeerTCP> &c : clients) {
 		c->disconnect_from_host();
 	}
 	server->stop();

--- a/tests/core/io/test_udp_server.h
+++ b/tests/core/io/test_udp_server.h
@@ -165,7 +165,7 @@ TEST_CASE("[UDPServer] Handle multiple clients at the same time") {
 
 	wait_for_condition([&]() {
 		bool should_exit = true;
-		for (Ref<PacketPeerUDP> &c : clients) {
+		for (const Ref<PacketPeerUDP> &c : clients) {
 			int count = c->get_available_packet_count();
 			if (count < 0) {
 				return true;
@@ -187,7 +187,7 @@ TEST_CASE("[UDPServer] Handle multiple clients at the same time") {
 		CHECK_EQ(received_var.operator float(), expected);
 	}
 
-	for (Ref<PacketPeerUDP> &c : clients) {
+	for (const Ref<PacketPeerUDP> &c : clients) {
 		c->close();
 	}
 	server->stop();

--- a/tests/servers/rendering/test_shader_preprocessor.h
+++ b/tests/servers/rendering/test_shader_preprocessor.h
@@ -91,7 +91,7 @@ String remove_spaces(String &p_str) {
 String compact_spaces(String &p_str) {
 	Vector<String> lines = p_str.split("\n", false);
 	erase_all_empty(lines);
-	for (String &line : lines) {
+	for (String &line : lines.write) {
 		line = remove_spaces(line);
 	}
 	return String("\n").join(lines);


### PR DESCRIPTION
This allows owners of non-const `Vector` to const-iterate it, avoiding an accidental fork, which would be inefficient.

To re-iterate (no pun intended): It was previously _impossible_ to iterate a `Vector` without risking a copy if you had a non-const reference to it. Take the following example:

```c++
// Non-const function
void Something::do_something() {
    for (const A &a : vector) {
         print_line(a);
    }
}
```

Even though `a` is declared `const`, the functions called by the iteration were non-const `begin` and `end`, because c++ doesn't have reverse type inference and is forced to call the function that better matches the type of `vector`, which is non-const `Vector<a>`. 

It is difficult to measure how many unnecessary forks were created during a normal run because of this detail, so I'm not going to do it. But it's likely at least some forks are avoided due to this change.