### PR TITLE
Assign the project manager title to the node instead of DisplayServer

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1139,7 +1139,7 @@ ProjectManager::ProjectManager() {
 	}
 
 	// TRANSLATORS: This refers to the application where users manage their Godot projects.
-	DisplayServer::get_singleton()->window_set_title(VERSION_NAME + String(" - ") + TTR("Project Manager", "Application"));
+	SceneTree::get_singleton()->get_root()->set_title(VERSION_NAME + String(" - ") + TTR("Project Manager", "Application"));
 
 	SceneTree::get_singleton()->get_root()->connect("files_dropped", callable_mp(this, &ProjectManager::_files_dropped));
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -282,11 +282,13 @@ void Window::set_title(const String &p_title) {
 
 	title = p_title;
 	tr_title = atr(p_title);
+
 #ifdef DEBUG_ENABLED
-	if (window_id == DisplayServer::MAIN_WINDOW_ID) {
+	if (window_id == DisplayServer::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
 		// Append a suffix to the window title to denote that the project is running
-		// from a debug build (including the editor). Since this results in lower performance,
-		// this should be clearly presented to the user.
+		// from a debug build (including the editor, excluding the project manager).
+		// Since this results in lower performance, this should be clearly presented
+		// to the user.
 		tr_title = vformat("%s (DEBUG)", tr_title);
 	}
 #endif
@@ -1435,10 +1437,11 @@ void Window::_notification(int p_what) {
 
 			tr_title = atr(title);
 #ifdef DEBUG_ENABLED
-			if (window_id == DisplayServer::MAIN_WINDOW_ID) {
+			if (window_id == DisplayServer::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
 				// Append a suffix to the window title to denote that the project is running
-				// from a debug build (including the editor). Since this results in lower performance,
-				// this should be clearly presented to the user.
+				// from a debug build (including the editor, excluding the project manager).
+				// Since this results in lower performance, this should be clearly presented
+				// to the user.
 				tr_title = vformat("%s (DEBUG)", tr_title);
 			}
 #endif


### PR DESCRIPTION
Fixes #100727 

Project Manager title is directly given to the `DisplayServer` at initialization. 

With the changes of ff6eea5 auto-translation triggers the renaming of the window and leading to the bug since the `title` attribute of the scene root was not defined.

This fix gives the title to the root of the `SceneTree` which solves the problem.