### PR TITLE
Android: Fix `Window` size changes ignored when node is not in tree

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -399,7 +399,7 @@ void Window::move_to_center() {
 void Window::set_size(const Size2i &p_size) {
 	ERR_MAIN_THREAD_GUARD;
 #if defined(ANDROID_ENABLED)
-	if (!get_parent()) {
+	if (!get_parent() && is_inside_tree()) {
 		// Can't set root window size on Android.
 		return;
 	}
@@ -475,7 +475,7 @@ void Window::_validate_limit_size() {
 void Window::set_max_size(const Size2i &p_max_size) {
 	ERR_MAIN_THREAD_GUARD;
 #if defined(ANDROID_ENABLED)
-	if (!get_parent()) {
+	if (!get_parent() && is_inside_tree()) {
 		// Can't set root window size on Android.
 		return;
 	}
@@ -498,7 +498,7 @@ Size2i Window::get_max_size() const {
 void Window::set_min_size(const Size2i &p_min_size) {
 	ERR_MAIN_THREAD_GUARD;
 #if defined(ANDROID_ENABLED)
-	if (!get_parent()) {
+	if (!get_parent() && is_inside_tree()) {
 		// Can't set root window size on Android.
 		return;
 	}


### PR DESCRIPTION
Fixes a regression from my PR (#99669) on Android where window size changes are ignored if the node is not in the tree.

Fixes https://github.com/godotengine/godot/issues/100743