### PR TITLE
Add support for per-shape physics materials

### DIFF
--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -152,6 +152,13 @@
 				Returns the parent object of the given shape owner.
 			</description>
 		</method>
+		<method name="shape_owner_get_physics_material" qualifiers="const">
+			<return type="PhysicsMaterial" />
+			<param index="0" name="owner_id" type="int" />
+			<description>
+				Returns the [PhysicsMaterial] (if any) set on the shape owner.
+			</description>
+		</method>
 		<method name="shape_owner_get_shape" qualifiers="const">
 			<return type="Shape2D" />
 			<param index="0" name="owner_id" type="int" />
@@ -212,6 +219,14 @@
 			<param index="1" name="margin" type="float" />
 			<description>
 				Sets the [code]one_way_collision_margin[/code] of the shape owner identified by given [param owner_id] to [param margin] pixels.
+			</description>
+		</method>
+		<method name="shape_owner_set_physics_material">
+			<return type="void" />
+			<param index="0" name="owner_id" type="int" />
+			<param index="1" name="material" type="PhysicsMaterial" />
+			<description>
+				Sets the [PhysicsMaterial] for the shape owner.
 			</description>
 		</method>
 		<method name="shape_owner_set_transform">

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -126,6 +126,13 @@
 				Returns the parent object of the given shape owner.
 			</description>
 		</method>
+		<method name="shape_owner_get_physics_material" qualifiers="const">
+			<return type="PhysicsMaterial" />
+			<param index="0" name="owner_id" type="int" />
+			<description>
+				Returns the [PhysicsMaterial] (if any) set on the shape owner.
+			</description>
+		</method>
 		<method name="shape_owner_get_shape" qualifiers="const">
 			<return type="Shape3D" />
 			<param index="0" name="owner_id" type="int" />
@@ -170,6 +177,14 @@
 			<param index="1" name="disabled" type="bool" />
 			<description>
 				If [code]true[/code], disables the given shape owner.
+			</description>
+		</method>
+		<method name="shape_owner_set_physics_material">
+			<return type="void" />
+			<param index="0" name="owner_id" type="int" />
+			<param index="1" name="material" type="PhysicsMaterial" />
+			<description>
+				Sets the [PhysicsMaterial] for the shape owner.
 			</description>
 		</method>
 		<method name="shape_owner_set_transform">

--- a/doc/classes/CollisionShape2D.xml
+++ b/doc/classes/CollisionShape2D.xml
@@ -27,6 +27,9 @@
 		<member name="one_way_collision_margin" type="float" setter="set_one_way_collision_margin" getter="get_one_way_collision_margin" default="1.0">
 			The margin used for one-way collision (in pixels). Higher values will make the shape thicker, and work better for colliders that enter the shape at a high velocity.
 		</member>
+		<member name="physics_material" type="PhysicsMaterial" setter="set_physics_material" getter="get_physics_material">
+			The shape's physics material. Setting a physics material lets the body have different parts with different properties, such as the head and handle of a hammer. Physics materials set on a shape take priority over those set on its body.
+		</member>
 		<member name="shape" type="Shape2D" setter="set_shape" getter="get_shape">
 			The actual shape owned by this collision shape.
 		</member>

--- a/doc/classes/CollisionShape3D.xml
+++ b/doc/classes/CollisionShape3D.xml
@@ -39,6 +39,9 @@
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false" keywords="enabled">
 			A disabled collision shape has no effect in the world. This property should be changed with [method Object.set_deferred].
 		</member>
+		<member name="physics_material" type="PhysicsMaterial" setter="set_physics_material" getter="get_physics_material">
+			The shape's physics material. Setting a physics material lets the body have different parts with different properties, such as the head and handle of a hammer. Physics materials set on a shape take priority over those set on its body.
+		</member>
 		<member name="shape" type="Shape3D" setter="set_shape" getter="get_shape">
 			The actual shape owned by this collision shape.
 		</member>

--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -469,11 +469,27 @@
 				Returns the [RID] of the shape with the given index in the body's array of shapes.
 			</description>
 		</method>
+		<method name="body_get_shape_bounce_override" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<description>
+				Returns the bounciness override for the shape or [constant @GDScript.NAN] if no override is set.
+			</description>
+		</method>
 		<method name="body_get_shape_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Returns the number of shapes added to the body.
+			</description>
+		</method>
+		<method name="body_get_shape_friction_override" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<description>
+				Returns the friction override for the shape or [constant @GDScript.NAN] if no override is set.
 			</description>
 		</method>
 		<method name="body_get_shape_transform" qualifiers="const">
@@ -655,6 +671,16 @@
 				Sets the one-way collision properties of the body's shape with the given index. If [param enable] is [code]true[/code], the one-way collision direction given by the shape's local upward axis [code]body_get_shape_transform(body, shape_idx).y[/code] will be used to ignore collisions with the shape in the opposite direction, and to ensure depenetration of kinematic bodies happens in this direction.
 			</description>
 		</method>
+		<method name="body_set_shape_bounce_override">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enable" type="bool" />
+			<param index="3" name="bounce" type="float" default="0.0" />
+			<description>
+				Sets the bounce for the shape if [param enable] is [code]true[/code], resets to the body's value if [code]false[/code]. A negative value of [param bounce] is equivalent to enabling [member PhysicsMaterial.absorbent].
+			</description>
+		</method>
 		<method name="body_set_shape_disabled">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -662,6 +688,16 @@
 			<param index="2" name="disabled" type="bool" />
 			<description>
 				Sets the disabled property of the body's shape with the given index. If [param disabled] is [code]true[/code], then the shape will be ignored in all collision detection.
+			</description>
+		</method>
+		<method name="body_set_shape_friction_override">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enable" type="bool" />
+			<param index="3" name="friction" type="float" default="0.0" />
+			<description>
+				Sets the friction for the shape if [param enable] is [code]true[/code], resets to the body's value if [code]false[/code]. A negative value of [param friction] is equivalent to enabling [member PhysicsMaterial.rough].
 			</description>
 		</method>
 		<method name="body_set_shape_transform">

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -477,11 +477,27 @@
 				Overridable version of [method PhysicsServer2D.body_get_shape].
 			</description>
 		</method>
+		<method name="_body_get_shape_bounce_override" qualifiers="virtual required const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<description>
+				Overridable version of [method PhysicsServer2D.body_get_shape_bounce_override].
+			</description>
+		</method>
 		<method name="_body_get_shape_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_shape_count].
+			</description>
+		</method>
+		<method name="_body_get_shape_friction_override" qualifiers="virtual required const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<description>
+				Overridable version of [method PhysicsServer2D.body_get_shape_friction_override].
 			</description>
 		</method>
 		<method name="_body_get_shape_transform" qualifiers="virtual required const">
@@ -672,6 +688,16 @@
 				Overridable version of [method PhysicsServer2D.body_set_shape_as_one_way_collision].
 			</description>
 		</method>
+		<method name="_body_set_shape_bounce_override" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enable" type="bool" />
+			<param index="3" name="bounce" type="float" />
+			<description>
+				Overridable version of [method PhysicsServer2D.body_set_shape_bounce_override].
+			</description>
+		</method>
 		<method name="_body_set_shape_disabled" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -679,6 +705,16 @@
 			<param index="2" name="disabled" type="bool" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_set_shape_disabled].
+			</description>
+		</method>
+		<method name="_body_set_shape_friction_override" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enable" type="bool" />
+			<param index="3" name="friction" type="float" />
+			<description>
+				Overridable version of [method PhysicsServer2D.body_set_shape_friction_override].
 			</description>
 		</method>
 		<method name="_body_set_shape_transform" qualifiers="virtual required">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -437,11 +437,27 @@
 				Returns the [RID] of the nth shape of a body.
 			</description>
 		</method>
+		<method name="body_get_shape_bounce_override" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<description>
+				Returns the bounciness override for the shape or [constant @GDScript.NAN] if no override is set.
+			</description>
+		</method>
 		<method name="body_get_shape_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Returns the number of shapes assigned to a body.
+			</description>
+		</method>
+		<method name="body_get_shape_friction_override" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<description>
+				Returns the friction override for the shape or [constant @GDScript.NAN] if no override is set.
 			</description>
 		</method>
 		<method name="body_get_shape_transform" qualifiers="const">
@@ -644,12 +660,32 @@
 				Substitutes a given body shape by another. The old shape is selected by its index, the new one by its [RID].
 			</description>
 		</method>
+		<method name="body_set_shape_bounce_override">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enable" type="bool" />
+			<param index="3" name="bounce" type="float" default="0.0" />
+			<description>
+				Sets the bounciness for the shape if [param enable] is [code]true[/code], resets to the body's value if [code]false[/code]. A negative value of [param bounce] is equivalent to enabling [member PhysicsMaterial.absorbent].
+			</description>
+		</method>
 		<method name="body_set_shape_disabled">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
 			<description>
+			</description>
+		</method>
+		<method name="body_set_shape_friction_override">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enable" type="bool" />
+			<param index="3" name="friction" type="float" default="0.0" />
+			<description>
+				Sets the friction for the shape if [param enable] is [code]true[/code], resets to the body's value if [code]false[/code]. A negative value of [param friction] is equivalent to enabling [member PhysicsMaterial.rough].
 			</description>
 		</method>
 		<method name="body_set_shape_transform">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -369,10 +369,26 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_get_shape_bounce_override" qualifiers="virtual required const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<description>
+				Overridable version of [method PhysicsServer3D.body_get_shape_bounce_override].
+			</description>
+		</method>
 		<method name="_body_get_shape_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
+			</description>
+		</method>
+		<method name="_body_get_shape_friction_override" qualifiers="virtual required const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<description>
+				Overridable version of [method PhysicsServer3D.body_get_shape_friction_override].
 			</description>
 		</method>
 		<method name="_body_get_shape_transform" qualifiers="virtual required const">
@@ -556,12 +572,32 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_set_shape_bounce_override" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enable" type="bool" />
+			<param index="3" name="bounce" type="float" />
+			<description>
+				Overridable version of [method PhysicsServer3D.body_set_shape_bounce_override].
+			</description>
+		</method>
 		<method name="_body_set_shape_disabled" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<param index="2" name="disabled" type="bool" />
 			<description>
+			</description>
+		</method>
+		<method name="_body_set_shape_friction_override" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape_idx" type="int" />
+			<param index="2" name="enable" type="bool" />
+			<param index="3" name="friction" type="float" />
+			<description>
+				Overridable version of [method PhysicsServer3D.body_set_shape_friction_override].
 			</description>
 		</method>
 		<method name="_body_set_shape_transform" qualifiers="virtual required">

--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -75,6 +75,9 @@ class GodotBody2D : public GodotCollisionObject2D {
 	real_t inertia = 0.0;
 	real_t _inv_inertia = 0.0;
 
+	LocalVector<real_t> shape_frictions;
+	LocalVector<real_t> shape_bounces;
+
 	Vector2 center_of_mass_local;
 	Vector2 center_of_mass;
 
@@ -305,6 +308,9 @@ public:
 
 	void set_space(GodotSpace2D *p_space) override;
 
+	void remove_shape(GodotShape2D *p_shape) override;
+	void remove_shape(int p_index) override;
+
 	void update_mass_properties();
 	void reset_mass_properties();
 
@@ -330,6 +336,12 @@ public:
 		}
 		return Vector2();
 	}
+
+	void set_shape_friction(int p_index, real_t p_friction);
+	void set_shape_bounce(int p_index, real_t p_bounce);
+
+	real_t get_shape_friction(int p_index) const;
+	real_t get_shape_bounce(int p_index) const;
 
 	void call_queries();
 	void wakeup_neighbours();

--- a/modules/godot_physics_2d/godot_collision_object_2d.h
+++ b/modules/godot_physics_2d/godot_collision_object_2d.h
@@ -174,7 +174,7 @@ public:
 	_FORCE_INLINE_ real_t get_collision_priority() const { return collision_priority; }
 
 	void remove_shape(GodotShape2D *p_shape) override;
-	void remove_shape(int p_index);
+	virtual void remove_shape(int p_index);
 
 	virtual void set_space(GodotSpace2D *p_space) = 0;
 

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -647,6 +647,46 @@ void GodotPhysicsServer2D::body_clear_shapes(RID p_body) {
 	}
 }
 
+void GodotPhysicsServer2D::body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction) {
+	GodotBody2D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
+
+	if (p_enable) {
+		body->set_shape_friction(p_shape_idx, p_friction);
+	} else {
+		body->set_shape_friction(p_shape_idx, NAN);
+	}
+}
+
+void GodotPhysicsServer2D::body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce) {
+	GodotBody2D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+	ERR_FAIL_INDEX(p_shape_idx, body->get_shape_count());
+
+	if (p_enable) {
+		body->set_shape_bounce(p_shape_idx, p_bounce);
+	} else {
+		body->set_shape_bounce(p_shape_idx, NAN);
+	}
+}
+
+real_t GodotPhysicsServer2D::body_get_shape_friction_override(RID p_body, int p_shape_idx) const {
+	GodotBody2D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, NAN);
+	ERR_FAIL_INDEX_V(p_shape_idx, body->get_shape_count(), NAN);
+
+	return body->get_shape_friction(p_shape_idx);
+}
+
+real_t GodotPhysicsServer2D::body_get_shape_bounce_override(RID p_body, int p_shape_idx) const {
+	GodotBody2D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, NAN);
+	ERR_FAIL_INDEX_V(p_shape_idx, body->get_shape_count(), NAN);
+
+	return body->get_shape_bounce(p_shape_idx);
+}
+
 void GodotPhysicsServer2D::body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -184,6 +184,12 @@ public:
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) override;
 	virtual void body_clear_shapes(RID p_body) override;
 
+	virtual void body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction = 0.0) override;
+	virtual void body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce = 0.0) override;
+
+	virtual real_t body_get_shape_friction_override(RID p_body, int p_shape_idx) const override;
+	virtual real_t body_get_shape_bounce_override(RID p_body, int p_shape_idx) const override;
+
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override;
 	virtual void body_set_shape_as_one_way_collision(RID p_body, int p_shape_idx, bool p_enable, real_t p_margin) override;
 

--- a/modules/godot_physics_3d/godot_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_3d.cpp
@@ -462,6 +462,35 @@ void GodotBody3D::set_space(GodotSpace3D *p_space) {
 	}
 }
 
+void GodotBody3D::remove_shape(GodotShape3D *p_shape) {
+	for (int i = 0; i < get_shape_count(); i++) {
+		if (get_shape(i) == p_shape) {
+			GodotCollisionObject3D::remove_shape(i);
+			i--;
+
+			if (shape_frictions.size() > (uint32_t)i) {
+				shape_frictions.remove_at(i);
+			}
+
+			if (shape_bounces.size() > (uint32_t)i) {
+				shape_bounces.remove_at(i);
+			}
+		}
+	}
+}
+
+void GodotBody3D::remove_shape(int p_index) {
+	GodotCollisionObject3D::remove_shape(p_index);
+
+	if ((int)shape_frictions.size() > p_index) {
+		shape_frictions.remove_at(p_index);
+	}
+
+	if ((int)shape_bounces.size() > p_index) {
+		shape_bounces.remove_at(p_index);
+	}
+}
+
 void GodotBody3D::set_axis_lock(PhysicsServer3D::BodyAxis p_axis, bool lock) {
 	if (lock) {
 		locked_axis |= p_axis;
@@ -797,6 +826,56 @@ bool GodotBody3D::sleep_test(real_t p_step) {
 		still_time = 0; //maybe this should be set to 0 on set_active?
 		return false;
 	}
+}
+
+void GodotBody3D::set_shape_friction(int p_index, real_t p_friction) {
+	ERR_FAIL_INDEX(p_index, get_shape_count());
+
+	int old_size = shape_frictions.size();
+	if (old_size <= p_index) {
+		shape_frictions.resize(p_index + 1);
+
+		for (int i = old_size; i < p_index; i++) {
+			shape_frictions[i] = NAN;
+		}
+	}
+
+	shape_frictions[p_index] = p_friction;
+}
+
+void GodotBody3D::set_shape_bounce(int p_index, real_t p_bounce) {
+	ERR_FAIL_INDEX(p_index, get_shape_count());
+
+	int old_size = shape_bounces.size();
+	if (old_size <= p_index) {
+		shape_bounces.resize(p_index + 1);
+
+		for (int i = old_size; i < p_index; i++) {
+			shape_bounces[i] = NAN;
+		}
+	}
+
+	shape_bounces[p_index] = p_bounce;
+}
+
+real_t GodotBody3D::get_shape_friction(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, get_shape_count(), NAN);
+
+	if ((uint32_t)p_index >= shape_frictions.size()) {
+		return NAN;
+	}
+
+	return shape_frictions[p_index];
+}
+
+real_t GodotBody3D::get_shape_bounce(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, get_shape_count(), NAN);
+
+	if ((uint32_t)p_index >= shape_bounces.size()) {
+		return NAN;
+	}
+
+	return shape_bounces[p_index];
 }
 
 void GodotBody3D::set_state_sync_callback(const Callable &p_callable) {

--- a/modules/godot_physics_3d/godot_body_3d.h
+++ b/modules/godot_physics_3d/godot_body_3d.h
@@ -57,6 +57,9 @@ class GodotBody3D : public GodotCollisionObject3D {
 	real_t friction = 1.0;
 	Vector3 inertia;
 
+	LocalVector<real_t> shape_frictions;
+	LocalVector<real_t> shape_bounces;
+
 	PhysicsServer3D::BodyDampMode linear_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
 	PhysicsServer3D::BodyDampMode angular_damp_mode = PhysicsServer3D::BODY_DAMP_MODE_COMBINE;
 
@@ -304,6 +307,9 @@ public:
 
 	void set_space(GodotSpace3D *p_space) override;
 
+	void remove_shape(GodotShape3D *p_shape) override;
+	void remove_shape(int p_index) override;
+
 	void update_mass_properties();
 	void reset_mass_properties();
 
@@ -336,6 +342,12 @@ public:
 	_FORCE_INLINE_ real_t compute_angular_impulse_denominator(const Vector3 &p_axis) const {
 		return p_axis.dot(_inv_inertia_tensor.xform_inv(p_axis));
 	}
+
+	void set_shape_friction(int p_index, real_t p_friction);
+	void set_shape_bounce(int p_index, real_t p_bounce);
+
+	real_t get_shape_friction(int p_index) const;
+	real_t get_shape_bounce(int p_index) const;
 
 	//void simulate_motion(const Transform3D& p_xform,real_t p_step);
 	void call_queries();

--- a/modules/godot_physics_3d/godot_collision_object_3d.h
+++ b/modules/godot_physics_3d/godot_collision_object_3d.h
@@ -181,7 +181,7 @@ public:
 	}
 
 	void remove_shape(GodotShape3D *p_shape) override;
-	void remove_shape(int p_index);
+	virtual void remove_shape(int p_index);
 
 	virtual void set_space(GodotSpace3D *p_space) = 0;
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -134,6 +134,38 @@ real_t GodotPhysicsServer3D::shape_get_margin(RID p_shape) const {
 	return 0.0;
 }
 
+real_t GodotPhysicsServer3D::body_get_shape_friction_override(RID p_body, int p_shape_idx) const {
+	const GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, NAN);
+	return body->get_shape_friction(p_shape_idx);
+}
+
+void GodotPhysicsServer3D::body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+	if (p_enable) {
+		body->set_shape_friction(p_shape_idx, p_friction);
+	} else {
+		body->set_shape_friction(p_shape_idx, NAN);
+	}
+}
+
+real_t GodotPhysicsServer3D::body_get_shape_bounce_override(RID p_body, int p_shape_idx) const {
+	const GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, NAN);
+	return body->get_shape_bounce(p_shape_idx);
+}
+
+void GodotPhysicsServer3D::body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce) {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+	if (p_enable) {
+		body->set_shape_bounce(p_shape_idx, p_bounce);
+	} else {
+		body->set_shape_bounce(p_shape_idx, NAN);
+	}
+}
+
 real_t GodotPhysicsServer3D::shape_get_custom_solver_bias(RID p_shape) const {
 	const GodotShape3D *shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_V(shape, 0);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -98,6 +98,12 @@ public:
 	virtual void shape_set_margin(RID p_shape, real_t p_margin) override;
 	virtual real_t shape_get_margin(RID p_shape) const override;
 
+	virtual real_t body_get_shape_friction_override(RID p_shape, int p_index) const override;
+	virtual void body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction = 0.0) override;
+
+	virtual real_t body_get_shape_bounce_override(RID p_body, int p_shape_idx) const override;
+	virtual void body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce = 0.0) override;
+
 	virtual real_t shape_get_custom_solver_bias(RID p_shape) const override;
 
 	/* SPACE API */

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -173,6 +173,42 @@ real_t JoltPhysicsServer3D::shape_get_margin(RID p_shape) const {
 	return (real_t)shape->get_margin();
 }
 
+real_t JoltPhysicsServer3D::body_get_shape_friction_override(RID p_body, int p_shape_idx) const {
+	const JoltBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, NAN);
+
+	return (real_t)body->get_shape_friction(p_shape_idx);
+}
+
+void JoltPhysicsServer3D::body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction) {
+	JoltBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	if (p_enable) {
+		body->set_shape_friction(p_shape_idx, (float)p_friction);
+	} else {
+		body->set_shape_friction(p_shape_idx, NAN);
+	}
+}
+
+real_t JoltPhysicsServer3D::body_get_shape_bounce_override(RID p_body, int p_shape_idx) const {
+	const JoltBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, NAN);
+
+	return (real_t)body->get_shape_bounce(p_shape_idx);
+}
+
+void JoltPhysicsServer3D::body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce) {
+	JoltBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	if (p_enable) {
+		body->set_shape_bounce(p_shape_idx, (float)p_bounce);
+	} else {
+		body->set_shape_bounce(p_shape_idx, NAN);
+	}
+}
+
 real_t JoltPhysicsServer3D::shape_get_custom_solver_bias(RID p_shape) const {
 	const JoltShape3D *shape = shape_owner.get_or_null(p_shape);
 	ERR_FAIL_NULL_V(shape, 0.0);

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -144,6 +144,12 @@ public:
 	virtual void shape_set_margin(RID p_shape, real_t p_margin) override;
 	virtual real_t shape_get_margin(RID p_shape) const override;
 
+	virtual real_t body_get_shape_friction_override(RID p_body, int p_shape_idx) const override;
+	virtual void body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction = 0.0) override;
+
+	virtual real_t body_get_shape_bounce_override(RID p_body, int p_shape_idx) const override;
+	virtual void body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce = 0.0) override;
+
 	virtual PhysicsServer3D::ShapeType shape_get_type(RID p_shape) const override;
 
 	virtual real_t shape_get_custom_solver_bias(RID p_shape) const override;

--- a/modules/jolt_physics/misc/jolt_math_funcs.h
+++ b/modules/jolt_physics/misc/jolt_math_funcs.h
@@ -53,4 +53,12 @@ public:
 		decompose(new_transform, r_scale);
 		r_new_transform = new_transform;
 	}
+
+	static _FORCE_INLINE_ float combine_friction(float p_friction1, float p_friction2) {
+		return Math::abs(MIN(p_friction1, p_friction2));
+	}
+
+	static _FORCE_INLINE_ float combine_bounce(float p_bounce1, float p_bounce2) {
+		return CLAMP(p_bounce1 + p_bounce2, 0.0f, 1.0f);
+	}
 };

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -64,6 +64,8 @@ private:
 	LocalVector<Contact> contacts;
 	LocalVector<JoltArea3D *> areas;
 	LocalVector<JoltJoint3D *> joints;
+	LocalVector<float> shape_frictions;
+	LocalVector<float> shape_bounces;
 
 	Variant custom_integration_userdata;
 
@@ -103,11 +105,14 @@ private:
 	bool sleep_initially = false;
 	bool custom_center_of_mass = false;
 	bool custom_integrator = false;
+	bool shape_materials = false;
 
 	virtual JPH::BroadPhaseLayer _get_broad_phase_layer() const override;
 	virtual JPH::ObjectLayer _get_object_layer() const override;
 
 	virtual JPH::EMotionType _get_motion_type() const override;
+
+	bool _can_use_manifold_reduction() const { return !reports_contacts() && !uses_shape_materials(); }
 
 	virtual void _add_to_space() override;
 
@@ -133,12 +138,15 @@ private:
 	void _update_joint_constraints();
 	void _update_possible_kinematic_contacts();
 	void _update_sleep_allowed();
+	void _update_manifold_reduction();
+	void _update_uses_shape_materials();
 
 	void _destroy_joint_constraints();
 
 	void _exit_all_areas();
 
 	void _mode_changed();
+	virtual void _shape_removed(int p_index) override;
 	virtual void _shapes_committed() override;
 	virtual void _space_changing() override;
 	virtual void _space_changed() override;
@@ -150,6 +158,7 @@ private:
 	void _axis_lock_changed();
 	void _contact_reporting_changed();
 	void _sleep_allowed_changed();
+	void _shape_materials_changed();
 
 public:
 	JoltBody3D();
@@ -306,4 +315,12 @@ public:
 	virtual bool can_interact_with(const JoltBody3D &p_other) const override;
 	virtual bool can_interact_with(const JoltSoftBody3D &p_other) const override;
 	virtual bool can_interact_with(const JoltArea3D &p_other) const override;
+
+	float get_shape_friction(int p_index) const;
+	void set_shape_friction(int p_index, float p_friction);
+
+	float get_shape_bounce(int p_index) const;
+	void set_shape_bounce(int p_index, float p_bounce);
+
+	bool uses_shape_materials() const { return shape_materials; }
 };

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
@@ -32,7 +32,6 @@
 
 #include "../misc/jolt_math_funcs.h"
 #include "../misc/jolt_type_conversions.h"
-#include "../shapes/jolt_custom_double_sided_shape.h"
 #include "../shapes/jolt_shape_3d.h"
 #include "../spaces/jolt_space_3d.h"
 
@@ -341,6 +340,7 @@ void JoltShapedObject3D::remove_shape(const JoltShape3D *p_shape) {
 	for (int i = shapes.size() - 1; i >= 0; i--) {
 		if (shapes[i].get_shape() == p_shape) {
 			shapes.remove_at(i);
+			_shape_removed(i);
 		}
 	}
 
@@ -350,6 +350,7 @@ void JoltShapedObject3D::remove_shape(const JoltShape3D *p_shape) {
 void JoltShapedObject3D::remove_shape(int p_index) {
 	ERR_FAIL_INDEX(p_index, (int)shapes.size());
 	shapes.remove_at(p_index);
+	_shape_removed(p_index);
 
 	_shapes_changed();
 }

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.h
@@ -67,6 +67,7 @@ protected:
 	void _enqueue_needs_optimization();
 	void _dequeue_needs_optimization();
 
+	virtual void _shape_removed(int p_index) {}
 	virtual void _shapes_changed();
 	virtual void _shapes_committed();
 	virtual void _space_changing() override;

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
@@ -112,6 +112,7 @@ class JoltContactListener3D final
 	bool _try_evaluate_area_overlap(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold);
 	bool _try_remove_contacts(const JPH::SubShapeIDPair &p_shape_pair);
 	bool _try_remove_area_overlap(const JPH::SubShapeIDPair &p_shape_pair);
+	bool _try_override_material(const JPH::Body &p_jolt_body1, const JPH::Body &p_jolt_body2, const JPH::ContactManifold &p_manifold, JPH::ContactSettings &p_settings);
 
 #ifdef DEBUG_ENABLED
 	bool _try_add_debug_contacts(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold);

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -33,6 +33,7 @@
 #include "../joints/jolt_joint_3d.h"
 #include "../jolt_physics_server_3d.h"
 #include "../jolt_project_settings.h"
+#include "../misc/jolt_math_funcs.h"
 #include "../misc/jolt_stream_wrappers.h"
 #include "../objects/jolt_area_3d.h"
 #include "../objects/jolt_body_3d.h"
@@ -141,11 +142,11 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem *p_job_system) :
 	});
 
 	physics_system->SetCombineFriction([](const JPH::Body &p_body1, const JPH::SubShapeID &p_sub_shape_id1, const JPH::Body &p_body2, const JPH::SubShapeID &p_sub_shape_id2) {
-		return Math::abs(MIN(p_body1.GetFriction(), p_body2.GetFriction()));
+		return JoltMath::combine_friction(p_body1.GetFriction(), p_body2.GetFriction());
 	});
 
 	physics_system->SetCombineRestitution([](const JPH::Body &p_body1, const JPH::SubShapeID &p_sub_shape_id1, const JPH::Body &p_body2, const JPH::SubShapeID &p_sub_shape_id2) {
-		return CLAMP(p_body1.GetRestitution() + p_body2.GetRestitution(), 0.0f, 1.0f);
+		return JoltMath::combine_bounce(p_body1.GetRestitution(), p_body2.GetRestitution());
 	});
 }
 

--- a/scene/2d/physics/collision_object_2d.h
+++ b/scene/2d/physics/collision_object_2d.h
@@ -33,6 +33,7 @@
 #include "scene/2d/node_2d.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/2d/shape_2d.h"
+#include "scene/resources/physics_material.h"
 #include "servers/physics_server_2d.h"
 
 class CollisionObject2D : public Node2D {
@@ -72,6 +73,8 @@ private:
 		bool disabled = false;
 		bool one_way_collision = false;
 		real_t one_way_collision_margin = 0.0;
+
+		Ref<PhysicsMaterial> material;
 	};
 
 	int total_subshapes = 0;
@@ -146,6 +149,9 @@ public:
 	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
 	bool is_shape_owner_disabled(uint32_t p_owner) const;
 
+	void shape_owner_set_physics_material(uint32_t p_owner, const Ref<PhysicsMaterial> &p_material);
+	Ref<PhysicsMaterial> shape_owner_get_physics_material(uint32_t p_owner) const;
+
 	void shape_owner_set_one_way_collision(uint32_t p_owner, bool p_enable);
 	bool is_shape_owner_one_way_collision_enabled(uint32_t p_owner) const;
 
@@ -168,6 +174,8 @@ public:
 	PackedStringArray get_configuration_warnings() const override;
 
 	_FORCE_INLINE_ RID get_rid() const { return rid; }
+
+	_FORCE_INLINE_ bool is_area() const { return area; }
 
 	CollisionObject2D();
 	~CollisionObject2D();

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -44,9 +44,16 @@ void CollisionShape2D::_update_in_shape_owner(bool p_xform_only) {
 	if (p_xform_only) {
 		return;
 	}
+	collision_object->shape_owner_set_physics_material(owner_id, physics_material);
 	collision_object->shape_owner_set_disabled(owner_id, disabled);
 	collision_object->shape_owner_set_one_way_collision(owner_id, one_way_collision);
 	collision_object->shape_owner_set_one_way_collision_margin(owner_id, one_way_collision_margin);
+}
+
+void CollisionShape2D::_material_changed() const {
+	if (collision_object) {
+		collision_object->shape_owner_set_physics_material(owner_id, physics_material);
+	}
 }
 
 void CollisionShape2D::_notification(int p_what) {
@@ -245,6 +252,28 @@ Color CollisionShape2D::get_debug_color() const {
 	return debug_color;
 }
 
+void CollisionShape2D::set_physics_material(const Ref<PhysicsMaterial> &p_material) {
+	if (p_material == physics_material) {
+		return;
+	}
+
+	physics_material = p_material;
+
+	if (shape.is_null()) {
+		return;
+	}
+
+	_material_changed();
+
+	if (p_material.is_valid()) {
+		p_material->connect_changed(callable_mp(this, &CollisionShape2D::_material_changed));
+	}
+}
+
+Ref<PhysicsMaterial> CollisionShape2D::get_physics_material() const {
+	return physics_material;
+}
+
 #ifdef DEBUG_ENABLED
 
 bool CollisionShape2D::_property_can_revert(const StringName &p_name) const {
@@ -283,12 +312,15 @@ void CollisionShape2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_one_way_collision_enabled"), &CollisionShape2D::is_one_way_collision_enabled);
 	ClassDB::bind_method(D_METHOD("set_one_way_collision_margin", "margin"), &CollisionShape2D::set_one_way_collision_margin);
 	ClassDB::bind_method(D_METHOD("get_one_way_collision_margin"), &CollisionShape2D::get_one_way_collision_margin);
+	ClassDB::bind_method(D_METHOD("set_physics_material", "material"), &CollisionShape2D::set_physics_material);
+	ClassDB::bind_method(D_METHOD("get_physics_material"), &CollisionShape2D::get_physics_material);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shape", PROPERTY_HINT_RESOURCE_TYPE, "Shape2D"), "set_shape", "get_shape");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
 	ADD_GROUP("One Way Collision", "one_way_collision");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_way_collision", PROPERTY_HINT_GROUP_ENABLE), "set_one_way_collision", "is_one_way_collision_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "one_way_collision_margin", PROPERTY_HINT_RANGE, "0,128,0.1,suffix:px"), "set_one_way_collision_margin", "get_one_way_collision_margin");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "physics_material", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial"), "set_physics_material", "get_physics_material");
 
 	ClassDB::bind_method(D_METHOD("set_debug_color", "color"), &CollisionShape2D::set_debug_color);
 	ClassDB::bind_method(D_METHOD("get_debug_color"), &CollisionShape2D::get_debug_color);

--- a/scene/2d/physics/collision_shape_2d.h
+++ b/scene/2d/physics/collision_shape_2d.h
@@ -32,6 +32,7 @@
 
 #include "scene/2d/node_2d.h"
 #include "scene/resources/2d/shape_2d.h"
+#include "scene/resources/physics_material.h"
 
 class CollisionObject2D;
 
@@ -44,8 +45,10 @@ class CollisionShape2D : public Node2D {
 	bool disabled = false;
 	bool one_way_collision = false;
 	real_t one_way_collision_margin = 1.0;
+	Ref<PhysicsMaterial> physics_material;
 
 	void _shape_changed();
+	void _material_changed() const;
 	void _update_in_shape_owner(bool p_xform_only = false);
 
 	// Not wrapped in `#ifdef DEBUG_ENABLED` as it is used for rendering.
@@ -85,6 +88,9 @@ public:
 
 	void set_debug_color(const Color &p_color);
 	Color get_debug_color() const;
+
+	void set_physics_material(const Ref<PhysicsMaterial> &p_material);
+	Ref<PhysicsMaterial> get_physics_material() const;
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -32,6 +32,7 @@
 
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/node_3d.h"
+#include "scene/resources/physics_material.h"
 
 class CollisionObject3D : public Node3D {
 	GDCLASS(CollisionObject3D, Node3D);
@@ -68,6 +69,7 @@ private:
 
 		Vector<ShapeBase> shapes;
 		bool disabled = false;
+		Ref<PhysicsMaterial> material;
 	};
 
 	int total_subshapes = 0;
@@ -154,6 +156,9 @@ public:
 	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
 	bool is_shape_owner_disabled(uint32_t p_owner) const;
 
+	void shape_owner_set_physics_material(uint32_t p_owner, const Ref<PhysicsMaterial> &p_material);
+	Ref<PhysicsMaterial> shape_owner_get_physics_material(uint32_t p_owner) const;
+
 	void shape_owner_add_shape(uint32_t p_owner, const Ref<Shape3D> &p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
 	Ref<Shape3D> shape_owner_get_shape(uint32_t p_owner, int p_shape) const;
@@ -171,6 +176,8 @@ public:
 	bool get_capture_input_on_drag() const;
 
 	_FORCE_INLINE_ RID get_rid() const { return rid; }
+
+	_FORCE_INLINE_ bool is_area() const { return area; }
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/scene/3d/physics/collision_shape_3d.h
+++ b/scene/3d/physics/collision_shape_3d.h
@@ -32,12 +32,14 @@
 
 #include "scene/3d/node_3d.h"
 #include "scene/resources/3d/shape_3d.h"
+#include "scene/resources/physics_material.h"
 
 class CollisionObject3D;
 class CollisionShape3D : public Node3D {
 	GDCLASS(CollisionShape3D, Node3D);
 
 	Ref<Shape3D> shape;
+	Ref<PhysicsMaterial> physics_material;
 
 	uint32_t owner_id = 0;
 	CollisionObject3D *collision_object = nullptr;
@@ -50,6 +52,8 @@ class CollisionShape3D : public Node3D {
 #ifdef DEBUG_ENABLED
 	void _shape_changed();
 #endif // DEBUG_ENABLED
+
+	void _material_changed() const;
 
 #ifndef DISABLE_DEPRECATED
 	void resource_changed(Ref<Resource> res);
@@ -74,6 +78,9 @@ public:
 
 	void set_shape(const Ref<Shape3D> &p_shape);
 	Ref<Shape3D> get_shape() const;
+
+	void set_physics_material(const Ref<PhysicsMaterial> &p_material);
+	Ref<PhysicsMaterial> get_physics_material() const;
 
 	void set_disabled(bool p_disabled);
 	bool is_disabled() const;

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -144,6 +144,7 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_shape_get_type, "shape");
 	GDVIRTUAL_BIND(_shape_get_data, "shape");
 	GDVIRTUAL_BIND(_shape_get_custom_solver_bias, "shape");
+
 	GDVIRTUAL_BIND(_shape_collide, "shape_A", "xform_A", "motion_A", "shape_B", "xform_B", "motion_B", "results", "result_max", "result_count");
 
 	/* SPACE API */
@@ -179,6 +180,12 @@ void PhysicsServer2DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_area_remove_shape, "area", "shape_idx");
 	GDVIRTUAL_BIND(_area_clear_shapes, "area");
+
+	GDVIRTUAL_BIND(_body_set_shape_friction_override, "body", "shape_idx", "enable", "friction");
+	GDVIRTUAL_BIND(_body_set_shape_bounce_override, "body", "shape_idx", "enable", "bounce");
+
+	GDVIRTUAL_BIND(_body_get_shape_friction_override, "body", "shape_idx");
+	GDVIRTUAL_BIND(_body_get_shape_bounce_override, "body", "shape_idx");
 
 	GDVIRTUAL_BIND(_area_attach_object_instance_id, "area", "id");
 	GDVIRTUAL_BIND(_area_get_object_instance_id, "area");

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -304,6 +304,12 @@ public:
 	EXBIND2(body_remove_shape, RID, int)
 	EXBIND1(body_clear_shapes, RID)
 
+	EXBIND4(body_set_shape_friction_override, RID, int, bool, real_t)
+	EXBIND4(body_set_shape_bounce_override, RID, int, bool, real_t)
+
+	EXBIND2RC(real_t, body_get_shape_friction_override, RID, int)
+	EXBIND2RC(real_t, body_get_shape_bounce_override, RID, int)
+
 	EXBIND2(body_attach_object_instance_id, RID, ObjectID)
 	EXBIND1RC(ObjectID, body_get_object_instance_id, RID)
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -232,6 +232,12 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_body_remove_shape, "body", "shape_idx");
 	GDVIRTUAL_BIND(_body_clear_shapes, "body");
 
+	GDVIRTUAL_BIND(_body_set_shape_bounce_override, "body", "shape_idx", "enable", "bounce");
+	GDVIRTUAL_BIND(_body_set_shape_friction_override, "body", "shape_idx", "enable", "friction");
+
+	GDVIRTUAL_BIND(_body_get_shape_bounce_override, "body", "shape_idx");
+	GDVIRTUAL_BIND(_body_get_shape_friction_override, "body", "shape_idx");
+
 	GDVIRTUAL_BIND(_body_attach_object_instance_id, "body", "id");
 	GDVIRTUAL_BIND(_body_get_object_instance_id, "body");
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -305,6 +305,12 @@ public:
 	EXBIND2(body_remove_shape, RID, int)
 	EXBIND1(body_clear_shapes, RID)
 
+	EXBIND4(body_set_shape_friction_override, RID, int, bool, real_t)
+	EXBIND4(body_set_shape_bounce_override, RID, int, bool, real_t)
+
+	EXBIND2RC(real_t, body_get_shape_friction_override, RID, int)
+	EXBIND2RC(real_t, body_get_shape_bounce_override, RID, int)
+
 	EXBIND2(body_attach_object_instance_id, RID, ObjectID)
 	EXBIND1RC(ObjectID, body_get_object_instance_id, RID)
 

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -695,6 +695,12 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_remove_shape", "body", "shape_idx"), &PhysicsServer2D::body_remove_shape);
 	ClassDB::bind_method(D_METHOD("body_clear_shapes", "body"), &PhysicsServer2D::body_clear_shapes);
 
+	ClassDB::bind_method(D_METHOD("body_set_shape_bounce_override", "body", "shape_idx", "enable", "bounce"), &PhysicsServer2D::body_set_shape_bounce_override, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("body_set_shape_friction_override", "body", "shape_idx", "enable", "friction"), &PhysicsServer2D::body_set_shape_friction_override, DEFVAL(0.0));
+
+	ClassDB::bind_method(D_METHOD("body_get_shape_bounce_override", "body", "shape_idx"), &PhysicsServer2D::body_get_shape_bounce_override);
+	ClassDB::bind_method(D_METHOD("body_get_shape_friction_override", "body", "shape_idx"), &PhysicsServer2D::body_get_shape_friction_override);
+
 	ClassDB::bind_method(D_METHOD("body_set_shape_disabled", "body", "shape_idx", "disabled"), &PhysicsServer2D::body_set_shape_disabled);
 	ClassDB::bind_method(D_METHOD("body_set_shape_as_one_way_collision", "body", "shape_idx", "enable", "margin"), &PhysicsServer2D::body_set_shape_as_one_way_collision);
 

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -379,6 +379,12 @@ public:
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) = 0;
 	virtual void body_clear_shapes(RID p_body) = 0;
 
+	virtual void body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction = 0.0) = 0;
+	virtual void body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce = 0.0) = 0;
+
+	virtual real_t body_get_shape_friction_override(RID p_body, int p_shape_idx) const = 0;
+	virtual real_t body_get_shape_bounce_override(RID p_body, int p_shape_idx) const = 0;
+
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) = 0;
 	virtual ObjectID body_get_object_instance_id(RID p_body) const = 0;
 

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -226,6 +226,12 @@ public:
 	virtual void body_remove_shape(RID p_body, int p_shape_idx) override {}
 	virtual void body_clear_shapes(RID p_body) override {}
 
+	virtual void body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction = 0.0) override {}
+	virtual void body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce = 0.0) override {}
+
+	virtual real_t body_get_shape_friction_override(RID p_body, int p_shape_idx) const override { return NAN; }
+	virtual real_t body_get_shape_bounce_override(RID p_body, int p_shape_idx) const override { return NAN; }
+
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) override {}
 	virtual ObjectID body_get_object_instance_id(RID p_body) const override { return ObjectID(); }
 

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -188,6 +188,12 @@ public:
 	FUNC2(body_remove_shape, RID, int);
 	FUNC1(body_clear_shapes, RID);
 
+	FUNC4(body_set_shape_friction_override, RID, int, bool, real_t);
+	FUNC4(body_set_shape_bounce_override, RID, int, bool, real_t);
+
+	FUNC2RC(real_t, body_get_shape_friction_override, RID, int);
+	FUNC2RC(real_t, body_get_shape_bounce_override, RID, int);
+
 	FUNC2(body_attach_object_instance_id, RID, ObjectID);
 	FUNC1RC(ObjectID, body_get_object_instance_id, RID);
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -782,6 +782,12 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_remove_shape", "body", "shape_idx"), &PhysicsServer3D::body_remove_shape);
 	ClassDB::bind_method(D_METHOD("body_clear_shapes", "body"), &PhysicsServer3D::body_clear_shapes);
 
+	ClassDB::bind_method(D_METHOD("body_set_shape_friction_override", "body", "shape_idx", "enable", "friction"), &PhysicsServer3D::body_set_shape_friction_override, DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("body_set_shape_bounce_override", "body", "shape_idx", "enable", "bounce"), &PhysicsServer3D::body_set_shape_bounce_override, DEFVAL(0.0));
+
+	ClassDB::bind_method(D_METHOD("body_get_shape_friction_override", "body", "shape_idx"), &PhysicsServer3D::body_get_shape_friction_override);
+	ClassDB::bind_method(D_METHOD("body_get_shape_bounce_override", "body", "shape_idx"), &PhysicsServer3D::body_get_shape_bounce_override);
+
 	ClassDB::bind_method(D_METHOD("body_attach_object_instance_id", "body", "id"), &PhysicsServer3D::body_attach_object_instance_id);
 	ClassDB::bind_method(D_METHOD("body_get_object_instance_id", "body"), &PhysicsServer3D::body_get_object_instance_id);
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -415,6 +415,12 @@ public:
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) = 0;
 
+	virtual real_t body_get_shape_friction_override(RID p_body, int p_index) const = 0;
+	virtual void body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction = 0.0) = 0;
+
+	virtual real_t body_get_shape_bounce_override(RID p_body, int p_shape_idx) const = 0;
+	virtual void body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce = 0.0) = 0;
+
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) = 0;
 	virtual ObjectID body_get_object_instance_id(RID p_body) const = 0;
 

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -231,6 +231,12 @@ public:
 
 	virtual void body_set_shape_disabled(RID p_body, int p_shape_idx, bool p_disabled) override {}
 
+	virtual real_t body_get_shape_friction_override(RID p_shape, int p_index) const override { return NAN; }
+	virtual void body_set_shape_friction_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_friction = 0.0) override {}
+
+	virtual real_t body_get_shape_bounce_override(RID p_body, int p_shape_idx) const override { return NAN; }
+	virtual void body_set_shape_bounce_override(RID p_body, int p_shape_idx, bool p_enable, real_t p_bounce = 0.0) override {}
+
 	virtual void body_attach_object_instance_id(RID p_body, ObjectID p_id) override {}
 	virtual ObjectID body_get_object_instance_id(RID p_body) const override { return ObjectID(); }
 

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -91,6 +91,12 @@ public:
 	FUNC2(shape_set_margin, RID, real_t)
 	FUNC1RC(real_t, shape_get_margin, RID)
 
+	FUNC4(body_set_shape_friction_override, RID, int, bool, real_t)
+	FUNC4(body_set_shape_bounce_override, RID, int, bool, real_t)
+
+	FUNC2RC(real_t, body_get_shape_friction_override, RID, int)
+	FUNC2RC(real_t, body_get_shape_bounce_override, RID, int)
+
 	FUNC1RC(ShapeType, shape_get_type, RID);
 	FUNC1RC(Variant, shape_get_data, RID);
 	FUNC1RC(real_t, shape_get_custom_solver_bias, RID);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7401.

This PR adds:
- Methods `shape_set_friction`,  `shape_get_friction`,  `shape_set_bounce`,  `shape_get_bounce` to `PhysicsServer3D`
- Property `physics_material` to `Shape3D`

This is implemented for both Godot and Jolt Physics (using a custom Jolt physics material like [one of the official samples](https://github.com/jrouwe/JoltPhysics/blob/master/Samples/Tests/General/FrictionPerTriangleTest.cpp)).

Example project that uses two different materials on one body: [per-shape-materials.zip](https://github.com/user-attachments/files/18373092/per-shape-materials.zip)