### PR TITLE
Core: Bump C++ Standard to C++20

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -716,30 +716,19 @@ cc_version_metadata1 = cc_version["metadata1"]
 
 if cc_version_major == -1:
     print_warning(
-        "Couldn't detect compiler version, skipping version checks. "
-        "Build may fail if the compiler doesn't support C++17 fully."
+        "Couldn't detect compiler version, skipping version checks. Build may "
+        "fail if the compiler doesn't support C++20 fully."
     )
 elif methods.using_gcc(env):
-    if env.get("winrt"):
-        if cc_version_major < 11:
-            print_error(
-                "Detected GCC version older than 11, which does not fully support "
-                "C++20, or has bugs when compiling Godot. Supported versions are 12 "
-                "and later. Use a newer GCC version, or Clang 14 or later by passing "
-                '"use_llvm=yes" to the SCons command line, or disable WinRT support by '
-                'passing "winrt=no" to the SCons command line.'
-            )
-            Exit(255)
-    else:
-        if cc_version_major < 9:
-            print_error(
-                "Detected GCC version older than 9, which does not fully support "
-                "C++17, or has bugs when compiling Godot. Supported versions are 9 "
-                "and later. Use a newer GCC version, or Clang 6 or later by passing "
-                '"use_llvm=yes" to the SCons command line.'
-            )
-            Exit(255)
-    if cc_version_metadata1 == "win32":
+    if cc_version_major < 11:
+        print_error(
+            "Detected GCC version older than 11, which does not fully support "
+            "C++20. Supported versions are GCC 11 and later. Use a newer GCC "
+            'version, or Clang 13 or later by passing "use_llvm=yes" to the '
+            "SCons command line."
+        )
+        Exit(255)
+    elif cc_version_metadata1 == "win32":
         print_error(
             "Detected mingw version is not using posix threads. Only posix "
             "version of mingw is supported. "
@@ -757,38 +746,24 @@ elif methods.using_clang(env):
             )
             Exit(255)
     else:
-        if env.get("winrt"):
-            if cc_version_major < 13:
-                print_error(
-                    "Detected Clang version older than 13, which does not fully support "
-                    "C++20. Supported versions are Clang 14 and later, or disable WinRT "
-                    'support by passing "winrt=no" to the SCons command line.'
-                )
-                Exit(255)
-        else:
-            if cc_version_major < 6:
-                print_error(
-                    "Detected Clang version older than 6, which does not fully support "
-                    "C++17. Supported versions are Clang 6 and later."
-                )
-                Exit(255)
-            elif env["debug_paths_relative"] and cc_version_major < 10:
-                print_warning("Clang < 10 doesn't support -ffile-prefix-map, disabling `debug_paths_relative` option.")
-                env["debug_paths_relative"] = False
+        if cc_version_major < 13:
+            print_error(
+                "Detected Clang version older than 13, which does not fully support "
+                "C++20. Supported versions are Clang 13 and later."
+            )
+            Exit(255)
 
 elif env.msvc:
-    if cc_version_major == 16 and cc_version_minor < 11:
-        # Ensure latest minor build of Visual Studio 2019.
-        # https://github.com/godotengine/godot/pull/94995#issuecomment-2336464574
+    if cc_version_major < 16:
         print_error(
-            "Detected Visual Studio 2019 version older than 16.11, which has bugs "
-            "when compiling Godot. Use a newer VS2019 version, or VS2022+."
+            "Detected Visual Studio version older than 2019, which does not fully "
+            "support C++20. Supported versions are Visual Studio 2019 and later."
         )
         Exit(255)
-    elif cc_version_major < 16:
+    elif cc_version_major == 16 and cc_version_minor < 11:
         print_error(
-            "Detected Visual Studio 2017 or earlier, which is unsupported in Godot. "
-            "Supported versions are Visual Studio 2019 and later."
+            "Detected Visual Studio 2019 version older than 16.11, which does not "
+            "fully support C++20. Use a newer VS2019 version, or VS2022 and later."
         )
         Exit(255)
 
@@ -906,19 +881,17 @@ if env["lto"] != "none":
     print("Using LTO: " + env["lto"])
 
 # Set our C and C++ standard requirements.
-# C++17 is required as we need guaranteed copy elision as per GH-36436.
-# Prepending to make it possible to override.
 # This needs to come after `configure`, otherwise we don't have env.msvc.
 if not env.msvc:
     # Specifying GNU extensions support explicitly, which are supported by
-    # both GCC and Clang. Both currently default to gnu17 and gnu++17.
+    # both GCC and Clang. Both currently default to gnu17 and gnu++20.
     env.Prepend(CFLAGS=["-std=gnu17"])
-    env.Prepend(CXXFLAGS=["-std=gnu++17"])
+    env.Prepend(CXXFLAGS=["-std=gnu++20"])
 else:
     # MSVC started offering C standard support with Visual Studio 2019 16.8, which covers all
     # of our supported Visual Studio versions.
     env.Prepend(CFLAGS=["/std:c17"])
-    env.Prepend(CXXFLAGS=["/std:c++17"])
+    env.Prepend(CXXFLAGS=["/std:c++20"])
     # MSVC is non-conforming with the C++ standard by default, so we enable more conformance.
     # Note that this is still not complete conformance, as certain Windows-related headers
     # don't compile under complete conformance.
@@ -976,25 +949,18 @@ if env.msvc and not methods.using_clang(env):  # MSVC
 else:  # GCC, Clang
     common_warnings = []
     if methods.using_gcc(env):
-        common_warnings += ["-Wshadow", "-Wno-misleading-indentation"]
-        if cc_version_major < 11:
-            # Regression in GCC 9/10, spams so much in our variadic templates
-            # that we need to outright disable it.
-            common_warnings += ["-Wno-type-limits"]
+        common_warnings += ["-Wshadow", "-Wno-misleading-indentation", "-Wenum-conversion"]
         if cc_version_major == 12:
             # Regression in GCC 12, false positives in our error macros, see GH-58747.
             common_warnings += ["-Wno-return-type"]
-        if cc_version_major >= 11:
-            common_warnings += ["-Wenum-conversion"]
         if cc_version_major >= 16:
             # GCC 16 flags type-incompleteness assertions on their intended behavior, see GH-119269.
             env.AppendUnique(CXXFLAGS=["-Wno-sfinae-incomplete"])
     elif methods.using_clang(env) or methods.using_emcc(env):
-        common_warnings += ["-Wshadow-field-in-constructor", "-Wshadow-uncaptured-local"]
+        common_warnings += ["-Wshadow-field-in-constructor", "-Wshadow-uncaptured-local", "-Wenum-conversion"]
         # We often implement `operator<` for structs of pointers as a requirement
         # for putting them in `Set` or `Map`. We don't mind about unreliable ordering.
         common_warnings += ["-Wno-ordered-compare-function-pointers"]
-        common_warnings += ["-Wenum-conversion"]
 
     # clang-cl will interpret `-Wall` as `-Weverything`, workaround with compatibility cast.
     env["WARNLEVEL"] = "-Wall" if not env.msvc else "-W3"
@@ -1006,19 +972,14 @@ else:  # GCC, Clang
             env.AppendUnique(
                 CCFLAGS=[
                     "-Walloc-zero",
+                    "-Wattribute-alias=2",
                     "-Wduplicated-branches",
                     "-Wduplicated-cond",
+                    "-Wlogical-op",
                     "-Wstringop-overflow=4",
                 ]
             )
             env.AppendUnique(CXXFLAGS=["-Wplacement-new=1", "-Wvirtual-inheritance"])
-            # Need to fix a warning with AudioServer lambdas before enabling.
-            # if cc_version_major != 9:  # GCC 9 had a regression (GH-36325).
-            #    env.Append(CXXFLAGS=["-Wnoexcept"])
-            if cc_version_major >= 9:
-                env.AppendUnique(CCFLAGS=["-Wattribute-alias=2"])
-            if cc_version_major >= 11:  # Broke on MethodBind templates before GCC 11.
-                env.AppendUnique(CCFLAGS=["-Wlogical-op"])
         elif methods.using_clang(env) or methods.using_emcc(env):
             env.AppendUnique(CCFLAGS=["-Wimplicit-fallthrough"])
     elif env["warnings"] == "all":

--- a/core/math/rect2.cpp
+++ b/core/math/rect2.cpp
@@ -409,3 +409,10 @@ Rect2::operator String() const {
 Rect2::operator Rect2i() const {
 	return Rect2i(position, size);
 }
+
+bool Rect2::operator==(const Rect2i &p_rect2i) const {
+	return operator==(Rect2(p_rect2i));
+}
+bool Rect2::operator!=(const Rect2i &p_rect2i) const {
+	return operator!=(Rect2(p_rect2i));
+}

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -211,6 +211,9 @@ struct [[nodiscard]] Rect2 {
 	constexpr bool operator==(const Rect2 &p_rect) const { return position == p_rect.position && size == p_rect.size; }
 	constexpr bool operator!=(const Rect2 &p_rect) const { return position != p_rect.position || size != p_rect.size; }
 
+	bool operator==(const Rect2i &p_rect2i) const;
+	bool operator!=(const Rect2i &p_rect2i) const;
+
 	inline Rect2 grow(real_t p_amount) const {
 		Rect2 g = *this;
 		g.grow_by(p_amount);

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -223,3 +223,22 @@ Vector2::operator String() const {
 Vector2::operator Vector2i() const {
 	return Vector2i(x, y);
 }
+
+bool Vector2::operator==(const Vector2i &p_vector2i) const {
+	return operator==(Vector2(p_vector2i));
+}
+bool Vector2::operator!=(const Vector2i &p_vector2i) const {
+	return operator!=(Vector2(p_vector2i));
+}
+bool Vector2::operator<(const Vector2i &p_vector2i) const {
+	return operator<(Vector2(p_vector2i));
+}
+bool Vector2::operator>(const Vector2i &p_vector2i) const {
+	return operator>(Vector2(p_vector2i));
+}
+bool Vector2::operator<=(const Vector2i &p_vector2i) const {
+	return operator<=(Vector2(p_vector2i));
+}
+bool Vector2::operator>=(const Vector2i &p_vector2i) const {
+	return operator>=(Vector2(p_vector2i));
+}

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -168,6 +168,13 @@ struct [[nodiscard]] Vector2 {
 	constexpr bool operator<=(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y <= p_vec2.y) : (x < p_vec2.x); }
 	constexpr bool operator>=(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y >= p_vec2.y) : (x > p_vec2.x); }
 
+	bool operator==(const Vector2i &p_vector2i) const;
+	bool operator!=(const Vector2i &p_vector2i) const;
+	bool operator<(const Vector2i &p_vector2i) const;
+	bool operator>(const Vector2i &p_vector2i) const;
+	bool operator<=(const Vector2i &p_vector2i) const;
+	bool operator>=(const Vector2i &p_vector2i) const;
+
 	real_t angle() const;
 	static Vector2 from_angle(real_t p_angle);
 

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -161,3 +161,22 @@ Vector3::operator String() const {
 Vector3::operator Vector3i() const {
 	return Vector3i(x, y, z);
 }
+
+bool Vector3::operator==(const Vector3i &p_vector3i) const {
+	return operator==(Vector3(p_vector3i));
+}
+bool Vector3::operator!=(const Vector3i &p_vector3i) const {
+	return operator!=(Vector3(p_vector3i));
+}
+bool Vector3::operator<(const Vector3i &p_vector3i) const {
+	return operator<(Vector3(p_vector3i));
+}
+bool Vector3::operator>(const Vector3i &p_vector3i) const {
+	return operator>(Vector3(p_vector3i));
+}
+bool Vector3::operator<=(const Vector3i &p_vector3i) const {
+	return operator<=(Vector3(p_vector3i));
+}
+bool Vector3::operator>=(const Vector3i &p_vector3i) const {
+	return operator>=(Vector3(p_vector3i));
+}

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -211,6 +211,13 @@ struct [[nodiscard]] Vector3 {
 	constexpr bool operator>(const Vector3 &p_v) const;
 	constexpr bool operator>=(const Vector3 &p_v) const;
 
+	bool operator==(const Vector3i &p_vector3i) const;
+	bool operator!=(const Vector3i &p_vector3i) const;
+	bool operator<(const Vector3i &p_vector3i) const;
+	bool operator>(const Vector3i &p_vector3i) const;
+	bool operator<=(const Vector3i &p_vector3i) const;
+	bool operator>=(const Vector3i &p_vector3i) const;
+
 	explicit operator String() const;
 	operator Vector3i() const;
 

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -233,3 +233,22 @@ static_assert(sizeof(Vector4) == 4 * sizeof(real_t));
 Vector4::operator Vector4i() const {
 	return Vector4i(x, y, z, w);
 }
+
+bool Vector4::operator==(const Vector4i &p_vector4i) const {
+	return operator==(Vector4(p_vector4i));
+}
+bool Vector4::operator!=(const Vector4i &p_vector4i) const {
+	return operator!=(Vector4(p_vector4i));
+}
+bool Vector4::operator<(const Vector4i &p_vector4i) const {
+	return operator<(Vector4(p_vector4i));
+}
+bool Vector4::operator>(const Vector4i &p_vector4i) const {
+	return operator>(Vector4(p_vector4i));
+}
+bool Vector4::operator<=(const Vector4i &p_vector4i) const {
+	return operator<=(Vector4(p_vector4i));
+}
+bool Vector4::operator>=(const Vector4i &p_vector4i) const {
+	return operator>=(Vector4(p_vector4i));
+}

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -146,6 +146,13 @@ struct [[nodiscard]] Vector4 {
 	constexpr bool operator>=(const Vector4 &p_vec4) const;
 	constexpr bool operator<=(const Vector4 &p_vec4) const;
 
+	bool operator==(const Vector4i &p_vector4i) const;
+	bool operator!=(const Vector4i &p_vector4i) const;
+	bool operator<(const Vector4i &p_vector4i) const;
+	bool operator>(const Vector4i &p_vector4i) const;
+	bool operator<=(const Vector4i &p_vector4i) const;
+	bool operator>=(const Vector4i &p_vector4i) const;
+
 	explicit operator String() const;
 	operator Vector4i() const;
 

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -114,6 +114,15 @@ public:
 		return reference != p_r.reference;
 	}
 
+	template <typename T_Other>
+	_FORCE_INLINE_ bool operator==(const Ref<T_Other> &p_other) const {
+		return reference == p_other.ptr();
+	}
+	template <typename T_Other>
+	_FORCE_INLINE_ bool operator!=(const Ref<T_Other> &p_other) const {
+		return reference != p_other.ptr();
+	}
+
 	_FORCE_INLINE_ T *operator*() const {
 		return reference;
 	}

--- a/core/os/spin_lock.h
+++ b/core/os/spin_lock.h
@@ -93,11 +93,7 @@ static_assert(std::atomic_bool::is_always_lock_free);
 
 class SpinLock {
 	union {
-#if __cplusplus >= 202002L
 		mutable std::atomic<bool> locked = false;
-#else
-		mutable std::atomic<bool> locked = ATOMIC_VAR_INIT(false);
-#endif
 		char aligner[Thread::CACHE_LINE_BYTES];
 	};
 

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -36,9 +36,9 @@
 
 // IWYU pragma: always_keep
 
-// Ensure that C++ standard is at least C++17.
+// Ensure that C++ standard is at least C++20.
 // If on MSVC, also ensures that the `Zc:__cplusplus` flag is present.
-static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
+static_assert(__cplusplus >= 202002L, "Minimum of C++20 required.");
 
 // IWYU pragma: begin_exports
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -822,6 +822,22 @@ public:
 	[[nodiscard]] _ALWAYS_INLINE_ bool operator>(const Variant &p_variant) const { return p_variant < *this; }
 	[[nodiscard]] _ALWAYS_INLINE_ bool operator>=(const Variant &p_variant) const { return !(*this < p_variant); }
 
+	// HACK: Simplest way to ensure a nearly-complete set of comparison operations across all
+	//       supported types. Only excludes unscoped enumerations, as they clash with builtin
+	//       operators in such a way that can't easily be worked around.
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator==(const T &p_value) const { return *this == Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator!=(const T &p_value) const { return *this != Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator<(const T &p_value) const { return *this < Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator<=(const T &p_value) const { return *this <= Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator>(const T &p_value) const { return *this > Variant(p_value); }
+	template <typename T, std::enable_if_t<std::is_convertible_v<T, Variant> && (!std::is_enum_v<T> || !std::is_convertible_v<T, int>), int> = 0>
+	[[nodiscard]] _ALWAYS_INLINE_ bool operator>=(const T &p_value) const { return *this >= Variant(p_value); }
+
 	uint32_t hash() const;
 	uint32_t recursive_hash(int recursion_count) const;
 

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -44,11 +44,6 @@ env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 env_metal.drivers_sources += thirdparty_obj
 
-# Enable C++20 for the Objective-C++ Metal code, which uses C++20 concepts.
-if "-std=gnu++17" in env_metal["CXXFLAGS"]:
-    env_metal["CXXFLAGS"].remove("-std=gnu++17")
-env_metal.Append(CXXFLAGS=["-std=gnu++20"])
-
 # Enable module support
 env_metal.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -423,10 +423,10 @@ String GridMapEditor::_get_cursor_coordinates() const {
 	if (cursor_visible || !set_items.is_empty() || !clipboard_items.is_empty()) {
 		if (selection.active) {
 			if (selection.begin == selection.end) {
-				text = vformat(String::utf8(u8"(%d, %d, %d)  \u2317  (%d, %d, %d)"),
+				text = vformat(String::utf8("(%d, %d, %d)  \u2317  (%d, %d, %d)"),
 						(int)cursor_gridpos.x, (int)cursor_gridpos.y, (int)cursor_gridpos.z, (int)selection.begin.x, (int)selection.begin.y, (int)selection.begin.z);
 			} else {
-				text = vformat(String::utf8(u8"(%d, %d, %d)  \u2317  (%d, %d, %d) \u2192 (%d, %d, %d)"),
+				text = vformat(String::utf8("(%d, %d, %d)  \u2317  (%d, %d, %d) \u2192 (%d, %d, %d)"),
 						(int)cursor_gridpos.x, (int)cursor_gridpos.y, (int)cursor_gridpos.z, (int)selection.begin.x, (int)selection.begin.y, (int)selection.begin.z, (int)selection.end.x, (int)selection.end.y, (int)selection.end.z);
 			}
 		} else {

--- a/modules/mono/mono_gc_handle.h
+++ b/modules/mono/mono_gc_handle.h
@@ -49,10 +49,14 @@ extern "C" {
 struct GCHandleIntPtr {
 	void *value;
 
-	_FORCE_INLINE_ bool operator==(const GCHandleIntPtr &p_other) { return value == p_other.value; }
-	_FORCE_INLINE_ bool operator!=(const GCHandleIntPtr &p_other) { return value != p_other.value; }
+	_FORCE_INLINE_ bool operator==(const GCHandleIntPtr &p_other) const { return value == p_other.value; }
+	_FORCE_INLINE_ bool operator!=(const GCHandleIntPtr &p_other) const { return value != p_other.value; }
 
+	// FIXME: C++20 doesn't allow aggregate initializers to bypass deleted constructors.
+	// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1008r1.pdf
+#if 0
 	GCHandleIntPtr() = delete;
+#endif
 };
 }
 

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import platform_windows_builders
 
-from methods import get_compiler_version, redirect_emitter
+from methods import redirect_emitter
 
 sources = []
 
@@ -85,18 +85,10 @@ env_winrt = env.Clone()
 tts_sources = ["tts_windows.cpp", "tts_driver_sapi.cpp", "winrt_utils.cpp"]
 if env["winrt"]:
     if not env_winrt.msvc:
-        if "-std=gnu++17" in env_winrt["CXXFLAGS"]:
-            env_winrt["CXXFLAGS"].remove("-std=gnu++17")
-        env_winrt.Append(CXXFLAGS=["-std=gnu++20"])
         if "-fno-exceptions" in env_winrt["CXXFLAGS"]:
             env_winrt["CXXFLAGS"].remove("-fno-exceptions")
         env_winrt.Append(CXXFLAGS=["-fexceptions"])
     else:
-        cc_version = get_compiler_version(env)
-        cc_version_major = cc_version["major"]
-        if "/std:c++17" in env_winrt["CXXFLAGS"]:
-            env_winrt["CXXFLAGS"].remove("/std:c++17")
-        env_winrt.Append(CXXFLAGS=["/std:c++20"])
         if "_HAS_EXCEPTIONS" in env_winrt["CPPDEFINES"]:
             env_winrt["CPPDEFINES"].remove("_HAS_EXCEPTIONS")
         env_winrt.Append(CXXFLAGS=["/EHsc"])

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -91,6 +91,7 @@ Patches:
 - `0004-clang-warning-exclude.patch` ([GH-111346](https://github.com/godotengine/godot/pull/111346))
 - `0005-unused-typedef.patch` ([GH-111445](https://github.com/godotengine/godot/pull/111445))
 - `0006-explicit-includes.patch` ([GH-111557](https://github.com/godotengine/godot/pull/111557))
+- `0007-enum-to-int32.patch` ([GH-100749](https://github.com/godotengine/godot/pull/100749))
 
 
 ## brotli

--- a/thirdparty/basis_universal/encoder/basisu_math.h
+++ b/thirdparty/basis_universal/encoder/basisu_math.h
@@ -35,10 +35,7 @@ namespace bu_math
 	{
 	public:
 		typedef T scalar_type;
-		enum
-		{
-			num_elements = N
-		};
+		static constexpr int32_t num_elements = N;
 
 		inline vec()
 		{
@@ -1186,11 +1183,8 @@ namespace bu_math
 	{
 	public:
 		typedef T scalar_type;
-		enum
-		{
-			num_rows = R,
-			num_cols = C
-		};
+		static constexpr int32_t num_rows = R;
+		static constexpr int32_t num_cols = C;
 
 		typedef vec<R, T> col_vec;
 		typedef vec < (R > 1) ? (R - 1) : 0, T > subcol_vec;

--- a/thirdparty/basis_universal/patches/0007-enum-to-int32.patch
+++ b/thirdparty/basis_universal/patches/0007-enum-to-int32.patch
@@ -1,0 +1,30 @@
+diff --git a/thirdparty/basis_universal/encoder/basisu_math.h b/thirdparty/basis_universal/encoder/basisu_math.h
+index 3e56747bea..d4aa219a36 100644
+--- a/thirdparty/basis_universal/encoder/basisu_math.h
++++ b/thirdparty/basis_universal/encoder/basisu_math.h
+@@ -35,10 +35,7 @@ namespace bu_math
+ 	{
+ 	public:
+ 		typedef T scalar_type;
+-		enum
+-		{
+-			num_elements = N
+-		};
++		static constexpr int32_t num_elements = N;
+ 
+ 		inline vec()
+ 		{
+@@ -1186,11 +1183,8 @@ namespace bu_math
+ 	{
+ 	public:
+ 		typedef T scalar_type;
+-		enum
+-		{
+-			num_rows = R,
+-			num_cols = C
+-		};
++		static constexpr int32_t num_rows = R;
++		static constexpr int32_t num_cols = C;
+ 
+ 		typedef vec<R, T> col_vec;
+ 		typedef vec < (R > 1) ? (R - 1) : 0, T > subcol_vec;


### PR DESCRIPTION
- Supersedes #89660

In contrast to the above PR, which attempted to simultaneously support C++17 alongside later standards, this PR aims to make our baseline C++20 outright. The *immediate* benefit is removing the need for several workarounds via macros & `#if __cplusplus` wrappers, making for a much cleaner codebase overall. The much, much bigger benefit is the freedom to actually *integrate* C++20 features, allowing this PR to satisfy our contribution Best Practices & not exist as a solution looking for a problem.

**EDIT:** After a core meeting, it was instead decided that integrations of features would be best handled in entirely separate PRs, so that we can pick-and-choose which features are best to integrate. While that dampens the effect of this PR in isolation, it's now doing so with the knowledge that it will not exist in isolation and would soon be followed with proper integrations of the new features that the repo would directly benefit from. Future edits of this OP will point to specific discussions/implementations of said features up until this is merged.