### PR TITLE
Force build editor with regex module, remove checking code

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -961,7 +961,7 @@ methods.sort_module_list(env)
 
 if env.editor_build:
     # Add editor-specific dependencies to the dependency graph.
-    env.module_add_dependencies("editor", ["freetype", "svg"])
+    env.module_add_dependencies("editor", ["freetype", "regex", "svg"])
 
     # And check if they are met.
     if not env.module_check_dependencies("editor"):

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -35,6 +35,11 @@
 #include "core/os/time.h"
 
 #include "modules/modules_enabled.gen.h" // For regex.
+#ifdef MODULE_REGEX_ENABLED
+#include "modules/regex/regex.h"
+#else
+class RegEx : public RefCounted {};
+#endif // MODULE_REGEX_ENABLED
 
 #if defined(MINGW_ENABLED) || defined(_MSC_VER)
 #define sprintf sprintf_s

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -34,12 +34,10 @@
 #include "core/io/file_access.h"
 #include "core/string/ustring.h"
 #include "core/templates/vector.h"
-#include "modules/modules_enabled.gen.h" // For regex.
-#ifdef MODULE_REGEX_ENABLED
-#include "modules/regex/regex.h"
-#endif // MODULE_REGEX_ENABLED
 
 #include <stdarg.h>
+
+class RegEx;
 
 class Logger {
 protected:
@@ -90,9 +88,7 @@ class RotatedFileLogger : public Logger {
 	void clear_old_backups();
 	void rotate_file();
 
-#ifdef MODULE_REGEX_ENABLED
 	Ref<RegEx> strip_ansi_regex;
-#endif // MODULE_REGEX_ENABLED
 
 public:
 	explicit RotatedFileLogger(const String &p_base_path, int p_max_files = 10);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -164,9 +164,9 @@
 #include "editor/themes/editor_theme_manager.h"
 #include "editor/window_wrapper.h"
 
-#include <stdlib.h>
-
 #include "modules/modules_enabled.gen.h" // For gdscript, mono.
+
+#include <stdlib.h>
 
 EditorNode *EditorNode::singleton = nullptr;
 

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -32,19 +32,14 @@
 
 #include "core/crypto/crypto_core.h"
 #include "core/io/dir_access.h"
+#include "core/io/plist.h"
+#include "editor/editor_paths.h"
 #include "lipo.h"
 #include "macho.h"
 
-#include "core/io/plist.h"
-#include "editor/editor_paths.h"
-
-#include "modules/modules_enabled.gen.h" // For regex.
+#include "modules/regex/regex.h"
 
 #include <ctime>
-
-#ifdef MODULE_REGEX_ENABLED
-
-#include "modules/regex/regex.h"
 
 /*************************************************************************/
 /* CodeSignCodeResources                                                 */
@@ -1571,5 +1566,3 @@ Error CodeSign::codesign(bool p_use_hardened_runtime, bool p_force, const String
 		ERR_FAIL_V_MSG(FAILED, "CodeSign: Unknown object type.");
 	}
 }
-
-#endif // MODULE_REGEX_ENABLED

--- a/editor/export/codesign.h
+++ b/editor/export/codesign.h
@@ -44,10 +44,6 @@
 #include "core/io/file_access.h"
 #include "core/object/ref_counted.h"
 
-#include "modules/modules_enabled.gen.h" // For regex.
-
-#ifdef MODULE_REGEX_ENABLED
-
 /*************************************************************************/
 /* CodeSignCodeResources                                                 */
 /*************************************************************************/
@@ -355,7 +351,5 @@ class CodeSign {
 public:
 	static Error codesign(bool p_use_hardened_runtime, bool p_force, const String &p_path, const String &p_ent_path, String &r_error_msg);
 };
-
-#endif // MODULE_REGEX_ENABLED
 
 #endif // CODESIGN_H

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -36,8 +36,6 @@
 #include "scene/resources/font.h"
 #include "servers/text_server.h"
 
-#include "modules/modules_enabled.gen.h" // For freetype.
-
 String ResourceImporterDynamicFont::get_importer_name() const {
 	return "font_data_dynamic";
 }
@@ -48,7 +46,6 @@ String ResourceImporterDynamicFont::get_visible_name() const {
 
 void ResourceImporterDynamicFont::get_recognized_extensions(List<String> *p_extensions) const {
 	if (p_extensions) {
-#ifdef MODULE_FREETYPE_ENABLED
 		p_extensions->push_back("ttf");
 		p_extensions->push_back("ttc");
 		p_extensions->push_back("otf");
@@ -57,7 +54,6 @@ void ResourceImporterDynamicFont::get_recognized_extensions(List<String> *p_exte
 		p_extensions->push_back("woff2");
 		p_extensions->push_back("pfb");
 		p_extensions->push_back("pfm");
-#endif
 	}
 }
 

--- a/editor/plugins/bone_map_editor_plugin.cpp
+++ b/editor/plugins/bone_map_editor_plugin.cpp
@@ -41,6 +41,8 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/texture_rect.h"
 
+#include "modules/regex/regex.h"
+
 void BoneMapperButton::fetch_textures() {
 	if (selected) {
 		set_texture_normal(get_editor_theme_icon(SNAME("BoneMapperHandleSelected")));
@@ -531,7 +533,6 @@ void BoneMapper::_clear_mapping_current_group() {
 	}
 }
 
-#ifdef MODULE_REGEX_ENABLED
 bool BoneMapper::is_match_with_bone_name(const String &p_bone_name, const String &p_word) {
 	RegEx re = RegEx(p_word);
 	return re.search(p_bone_name.to_lower()).is_valid();
@@ -1352,7 +1353,6 @@ void BoneMapper::auto_mapping_process(Ref<BoneMap> &p_bone_map) {
 
 	WARN_PRINT("Finish auto mapping.");
 }
-#endif // MODULE_REGEX_ENABLED
 
 void BoneMapper::_value_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	set(p_property, p_value);
@@ -1367,9 +1367,7 @@ void BoneMapper::_profile_changed(const String &p_property, const Variant &p_val
 	if (profile.is_valid()) {
 		SkeletonProfileHumanoid *hmn = Object::cast_to<SkeletonProfileHumanoid>(profile.ptr());
 		if (hmn) {
-#ifdef MODULE_REGEX_ENABLED
 			_run_auto_mapping();
-#endif // MODULE_REGEX_ENABLED
 		}
 	}
 }

--- a/editor/plugins/bone_map_editor_plugin.h
+++ b/editor/plugins/bone_map_editor_plugin.h
@@ -35,11 +35,6 @@
 #include "editor/editor_properties.h"
 #include "editor/plugins/editor_plugin.h"
 
-#include "modules/modules_enabled.gen.h" // For regex.
-#ifdef MODULE_REGEX_ENABLED
-#include "modules/regex/regex.h"
-#endif
-
 #include "scene/3d/skeleton_3d.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/color_rect.h"
@@ -170,7 +165,6 @@ class BoneMapper : public VBoxContainer {
 	void _apply_picker_selection();
 	void _clear_mapping_current_group();
 
-#ifdef MODULE_REGEX_ENABLED
 	/* For auto mapping */
 	enum BoneSegregation {
 		BONE_SEGREGATION_NONE,
@@ -182,7 +176,6 @@ class BoneMapper : public VBoxContainer {
 	BoneSegregation guess_bone_segregation(const String &p_bone_name);
 	void auto_mapping_process(Ref<BoneMap> &p_bone_map);
 	void _run_auto_mapping();
-#endif // MODULE_REGEX_ENABLED
 
 protected:
 	void _notification(int p_what);

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -32,10 +32,6 @@
 
 #ifndef DISABLE_DEPRECATED
 
-#include "modules/modules_enabled.gen.h" // For regex.
-
-#ifdef MODULE_REGEX_ENABLED
-
 #include "core/error/error_macros.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
@@ -43,6 +39,7 @@
 #include "core/os/time.h"
 #include "core/templates/list.h"
 #include "editor/renames_map_3_to_4.h"
+
 #include "modules/regex/regex.h"
 
 // Find "OS.set_property(x)", capturing x into $1.
@@ -2956,7 +2953,5 @@ String ProjectConverter3To4::collect_string_from_vector(Vector<SourceLine> &vect
 	}
 	return string;
 }
-
-#endif // MODULE_REGEX_ENABLED
 
 #endif // DISABLE_DEPRECATED

--- a/editor/project_converter_3_to_4.h
+++ b/editor/project_converter_3_to_4.h
@@ -33,27 +33,6 @@
 
 #ifndef DISABLE_DEPRECATED
 
-#include "modules/modules_enabled.gen.h" // For regex.
-
-#ifndef MODULE_REGEX_ENABLED
-
-#include "core/error/error_macros.h"
-
-class ProjectConverter3To4 {
-public:
-	ProjectConverter3To4(int, int) {}
-
-	bool validate_conversion() {
-		ERR_FAIL_V_MSG(false, "Can't validate conversion for Godot 3.x projects, because RegEx module is disabled.");
-	}
-
-	bool convert() {
-		ERR_FAIL_V_MSG(false, "Can't run converter for Godot 3.x projects, because RegEx module is disabled.");
-	}
-};
-
-#else // Has regex.
-
 #include "core/string/ustring.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
@@ -133,8 +112,6 @@ public:
 	bool validate_conversion();
 	bool convert();
 };
-
-#endif // MODULE_REGEX_ENABLED
 
 #endif // DISABLE_DEPRECATED
 

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -30,14 +30,10 @@
 
 #include "rename_dialog.h"
 
-#include "modules/modules_enabled.gen.h" // For regex.
-#ifdef MODULE_REGEX_ENABLED
-
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/plugins/script_editor_plugin.h"
-#include "modules/regex/regex.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/control.h"
@@ -47,6 +43,8 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/tab_container.h"
+
+#include "modules/regex/regex.h"
 
 RenameDialog::RenameDialog(SceneTreeEditor *p_scene_tree_editor) {
 	scene_tree_editor = p_scene_tree_editor;
@@ -656,5 +654,3 @@ void RenameDialog::_features_toggled(bool pressed) {
 	new_size.y = 0;
 	set_size(new_size);
 }
-
-#endif // MODULE_REGEX_ENABLED

--- a/editor/rename_dialog.h
+++ b/editor/rename_dialog.h
@@ -31,9 +31,6 @@
 #ifndef RENAME_DIALOG_H
 #define RENAME_DIALOG_H
 
-#include "modules/modules_enabled.gen.h" // For regex.
-#ifdef MODULE_REGEX_ENABLED
-
 #include "editor/gui/scene_tree_editor.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
@@ -113,7 +110,5 @@ public:
 
 	RenameDialog(SceneTreeEditor *p_scene_tree_editor);
 };
-
-#endif // MODULE_REGEX_ENABLED
 
 #endif // RENAME_DIALOG_H

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -55,6 +55,7 @@
 #include "editor/plugins/editor_context_menu_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
+#include "editor/rename_dialog.h"
 #include "editor/reparent_dialog.h"
 #include "editor/shader_create_dialog.h"
 #include "editor/themes/editor_scale.h"
@@ -65,11 +66,6 @@
 #include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/display_server.h"
-
-#include "modules/modules_enabled.gen.h" // For regex.
-#ifdef MODULE_REGEX_ENABLED
-#include "editor/rename_dialog.h"
-#endif // MODULE_REGEX_ENABLED
 
 void SceneTreeDock::_nodes_drag_begin() {
 	pending_click_select = nullptr;
@@ -178,10 +174,8 @@ void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 		_tool_selected(TOOL_RENAME);
-#ifdef MODULE_REGEX_ENABLED
 	} else if (ED_IS_SHORTCUT("scene_tree/batch_rename", p_event)) {
 		_tool_selected(TOOL_BATCH_RENAME);
-#endif // MODULE_REGEX_ENABLED
 	} else if (ED_IS_SHORTCUT("scene_tree/add_child_node", p_event)) {
 		_tool_selected(TOOL_NEW);
 	} else if (ED_IS_SHORTCUT("scene_tree/instantiate_scene", p_event)) {
@@ -551,7 +545,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 	current_option = p_tool;
 
 	switch (p_tool) {
-#ifdef MODULE_REGEX_ENABLED
 		case TOOL_BATCH_RENAME: {
 			if (!profile_allow_editing) {
 				break;
@@ -563,7 +556,6 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				rename_dialog->popup_centered();
 			}
 		} break;
-#endif // MODULE_REGEX_ENABLED
 		case TOOL_RENAME: {
 			if (!profile_allow_editing) {
 				break;
@@ -3925,13 +3917,11 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		}
 	}
 
-#ifdef MODULE_REGEX_ENABLED
 	if (profile_allow_editing && selection.size() > 1) {
 		//this is not a commonly used action, it makes no sense for it to be where it was nor always present.
 		menu->add_separator();
 		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Rename")), ED_GET_SHORTCUT("scene_tree/batch_rename"), TOOL_BATCH_RENAME);
 	}
-#endif // MODULE_REGEX_ENABLED
 	menu->add_separator();
 
 	if (full_selection.size() == 1 && !selection.front()->get()->get_scene_file_path().is_empty()) {
@@ -4795,10 +4785,8 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	create_dialog->connect("create", callable_mp(this, &SceneTreeDock::_create));
 	create_dialog->connect("favorites_updated", callable_mp(this, &SceneTreeDock::_update_create_root_dialog).bind(false));
 
-#ifdef MODULE_REGEX_ENABLED
 	rename_dialog = memnew(RenameDialog(scene_tree));
 	add_child(rename_dialog);
-#endif // MODULE_REGEX_ENABLED
 
 	script_create_dialog = memnew(ScriptCreateDialog);
 	script_create_dialog->set_inheritance_base_type("Node");

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -40,14 +40,10 @@ class CheckBox;
 class EditorData;
 class EditorSelection;
 class MenuButton;
+class RenameDialog;
 class ReparentDialog;
 class ShaderCreateDialog;
 class TextureRect;
-
-#include "modules/modules_enabled.gen.h" // For regex.
-#ifdef MODULE_REGEX_ENABLED
-class RenameDialog;
-#endif // MODULE_REGEX_ENABLED
 
 class SceneTreeDock : public VBoxContainer {
 	GDCLASS(SceneTreeDock, VBoxContainer);
@@ -61,9 +57,7 @@ class SceneTreeDock : public VBoxContainer {
 		TOOL_PASTE,
 		TOOL_PASTE_AS_SIBLING,
 		TOOL_RENAME,
-#ifdef MODULE_REGEX_ENABLED
 		TOOL_BATCH_RENAME,
-#endif // MODULE_REGEX_ENABLED
 		TOOL_REPLACE,
 		TOOL_EXTEND_SCRIPT,
 		TOOL_ATTACH_SCRIPT,
@@ -107,9 +101,7 @@ class SceneTreeDock : public VBoxContainer {
 
 	int current_option = 0;
 	CreateDialog *create_dialog = nullptr;
-#ifdef MODULE_REGEX_ENABLED
 	RenameDialog *rename_dialog = nullptr;
-#endif // MODULE_REGEX_ENABLED
 
 	Button *button_add = nullptr;
 	Button *button_instance = nullptr;

--- a/editor/themes/editor_icons.cpp
+++ b/editor/themes/editor_icons.cpp
@@ -36,28 +36,20 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/resources/image_texture.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
-#ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
-#endif
 
 void editor_configure_icons(bool p_dark_theme) {
-#ifdef MODULE_SVG_ENABLED
 	if (p_dark_theme) {
 		ImageLoaderSVG::set_forced_color_map(HashMap<Color, Color>());
 	} else {
 		ImageLoaderSVG::set_forced_color_map(EditorColorMap::get_color_conversion_map());
 	}
-#else
-	WARN_PRINT("SVG support disabled, editor icons won't be rendered.");
-#endif
 }
 
 // See also `generate_icon()` in `scene/theme/default_theme.cpp`.
 Ref<ImageTexture> editor_generate_icon(int p_index, float p_scale, float p_saturation, const HashMap<Color, Color> &p_convert_colors = HashMap<Color, Color>()) {
 	Ref<Image> img = memnew(Image);
 
-#ifdef MODULE_SVG_ENABLED
 	// Upsample icon generation only if the editor scale isn't an integer multiplier.
 	// Generating upsampled icons is slower, and the benefit is hardly visible
 	// with integer editor scales.
@@ -67,11 +59,6 @@ Ref<ImageTexture> editor_generate_icon(int p_index, float p_scale, float p_satur
 	if (p_saturation != 1.0) {
 		img->adjust_bcs(1.0, 1.0, p_saturation);
 	}
-#else
-	// If the SVG module is disabled, we can't really display the UI well, but at least we won't crash.
-	// 16 pixels is used as it's the most common base size for Godot icons.
-	img = Image::create_empty(16 * p_scale, 16 * p_scale, false, Image::FORMAT_RGBA8);
-#endif
 
 	return ImageTexture::create_from_image(img);
 }

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -32,11 +32,11 @@
 
 #ifdef TOOLS_ENABLED
 
-#include "editor_scene_importer_ufbx.h"
-#include "modules/gltf/gltf_document.h"
-
 #include "core/config/project_settings.h"
 #include "editor/editor_settings.h"
+#include "editor_scene_importer_ufbx.h"
+
+#include "modules/gltf/gltf_document.h"
 
 uint32_t EditorSceneFormatImporterFBX2GLTF::get_import_flags() const {
 	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -33,6 +33,11 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "tests/test_macros.h"
+
+#include "../gdscript.h"
+#include "gdscript_test_runner.h"
+
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"
@@ -40,15 +45,11 @@
 #include "core/object/script_language.h"
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
-#include "gdscript_test_runner.h"
-#include "modules/modules_enabled.gen.h" // For mono.
-#include "scene/resources/packed_scene.h"
-
-#include "../gdscript.h"
-#include "tests/test_macros.h"
-
 #include "editor/editor_settings.h"
+#include "scene/resources/packed_scene.h"
 #include "scene/theme/theme_db.h"
+
+#include "modules/modules_enabled.gen.h" // For mono.
 
 namespace GDScriptTests {
 

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -45,6 +45,7 @@
 #include "core/os/os.h"
 #include "editor/editor_help.h"
 #include "editor/editor_node.h"
+
 #include "modules/gdscript/gdscript_analyzer.h"
 #include "modules/regex/regex.h"
 

--- a/modules/gltf/tests/test_gltf.h
+++ b/modules/gltf/tests/test_gltf.h
@@ -40,9 +40,6 @@
 #include "editor/editor_resource_preview.h"
 #include "editor/import/3d/resource_importer_scene.h"
 #include "editor/import/resource_importer_texture.h"
-#include "modules/gltf/editor/editor_scene_importer_gltf.h"
-#include "modules/gltf/gltf_document.h"
-#include "modules/gltf/gltf_state.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/main/window.h"
@@ -51,6 +48,10 @@
 #include "scene/resources/material.h"
 #include "scene/resources/packed_scene.h"
 #include "tests/core/config/test_project_settings.h"
+
+#include "modules/gltf/editor/editor_scene_importer_gltf.h"
+#include "modules/gltf/gltf_document.h"
+#include "modules/gltf/gltf_state.h"
 
 namespace TestGltf {
 

--- a/modules/gltf/tests/test_gltf_extras.h
+++ b/modules/gltf/tests/test_gltf_extras.h
@@ -38,15 +38,16 @@
 
 #include "core/os/os.h"
 #include "editor/import/3d/resource_importer_scene.h"
-#include "modules/gltf/editor/editor_scene_importer_gltf.h"
-#include "modules/gltf/gltf_document.h"
-#include "modules/gltf/gltf_state.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/main/window.h"
 #include "scene/resources/3d/primitive_meshes.h"
 #include "scene/resources/material.h"
 #include "scene/resources/packed_scene.h"
+
+#include "modules/gltf/editor/editor_scene_importer_gltf.h"
+#include "modules/gltf/gltf_document.h"
+#include "modules/gltf/gltf_state.h"
 
 namespace TestGltf {
 

--- a/modules/mono/editor/semver.h
+++ b/modules/mono/editor/semver.h
@@ -32,6 +32,7 @@
 #define SEMVER_H
 
 #include "core/string/ustring.h"
+
 #include "modules/regex/regex.h"
 
 // <sys/sysmacros.h> is included somewhere, which defines major(dev) to gnu_dev_major(dev)

--- a/modules/navigation/3d/nav_mesh_generator_3d.h
+++ b/modules/navigation/3d/nav_mesh_generator_3d.h
@@ -36,6 +36,7 @@
 #include "core/object/class_db.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/templates/rid_owner.h"
+
 #include "modules/modules_enabled.gen.h" // For csg, gridmap.
 
 class Node;

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -31,6 +31,7 @@
 #include "audio_stream_ogg_vorbis.h"
 
 #include "modules/vorbis/resource_importer_ogg_vorbis.h"
+
 #include <ogg/ogg.h>
 
 int AudioStreamPlaybackOggVorbis::_mix_internal(AudioFrame *p_buffer, int p_frames) {

--- a/modules/vorbis/audio_stream_ogg_vorbis.h
+++ b/modules/vorbis/audio_stream_ogg_vorbis.h
@@ -32,8 +32,9 @@
 #define AUDIO_STREAM_OGG_VORBIS_H
 
 #include "core/variant/variant.h"
-#include "modules/ogg/ogg_packet_sequence.h"
 #include "servers/audio/audio_stream.h"
+
+#include "modules/ogg/ogg_packet_sequence.h"
 
 #include <vorbis/codec.h>
 

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -52,10 +52,8 @@
 #include "main/splash.gen.h"
 #include "scene/resources/image_texture.h"
 
-#include "modules/modules_enabled.gen.h" // For mono and svg.
-#ifdef MODULE_SVG_ENABLED
+#include "modules/modules_enabled.gen.h" // For mono.
 #include "modules/svg/image_loader_svg.h"
-#endif
 
 #ifdef ANDROID_ENABLED
 #include "../os_android.h"
@@ -3830,7 +3828,6 @@ void EditorExportPlatformAndroid::resolve_platform_feature_priorities(const Ref<
 
 EditorExportPlatformAndroid::EditorExportPlatformAndroid() {
 	if (EditorNode::get_singleton()) {
-#ifdef MODULE_SVG_ENABLED
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);
 
@@ -3839,7 +3836,6 @@ EditorExportPlatformAndroid::EditorExportPlatformAndroid() {
 
 		ImageLoaderSVG::create_image_from_string(img, _android_run_icon_svg, EDSCALE, upsample, false);
 		run_icon = ImageTexture::create_from_image(img);
-#endif
 
 		devices_changed.set();
 #ifndef DISABLE_DEPRECATED

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -46,10 +46,8 @@
 #include "editor/plugins/script_editor_plugin.h"
 #include "editor/themes/editor_scale.h"
 
-#include "modules/modules_enabled.gen.h" // For mono and svg.
-#ifdef MODULE_SVG_ENABLED
+#include "modules/modules_enabled.gen.h" // For mono.
 #include "modules/svg/image_loader_svg.h"
-#endif
 
 void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	// Vulkan and OpenGL ES 3.0 both mandate ETC2 support.
@@ -3349,7 +3347,6 @@ Error EditorExportPlatformIOS::run(const Ref<EditorExportPreset> &p_preset, int 
 
 EditorExportPlatformIOS::EditorExportPlatformIOS() {
 	if (EditorNode::get_singleton()) {
-#ifdef MODULE_SVG_ENABLED
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);
 
@@ -3358,7 +3355,6 @@ EditorExportPlatformIOS::EditorExportPlatformIOS() {
 
 		ImageLoaderSVG::create_image_from_string(img, _ios_run_icon_svg, EDSCALE, upsample, false);
 		run_icon = ImageTexture::create_from_image(img);
-#endif
 
 		plugins_changed.set();
 		devices_changed.set();

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -40,10 +40,7 @@
 #include "editor/export/editor_export.h"
 #include "editor/themes/editor_scale.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
-#ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
-#endif
 
 Error EditorExportPlatformLinuxBSD::_export_debug_script(const Ref<EditorExportPreset> &p_preset, const String &p_app_name, const String &p_pkg_name, const String &p_path) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
@@ -610,7 +607,6 @@ Error EditorExportPlatformLinuxBSD::run(const Ref<EditorExportPreset> &p_preset,
 
 EditorExportPlatformLinuxBSD::EditorExportPlatformLinuxBSD() {
 	if (EditorNode::get_singleton()) {
-#ifdef MODULE_SVG_ENABLED
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);
 
@@ -619,7 +615,6 @@ EditorExportPlatformLinuxBSD::EditorExportPlatformLinuxBSD() {
 
 		ImageLoaderSVG::create_image_from_string(img, _linuxbsd_run_icon_svg, EDSCALE, upsample, false);
 		run_icon = ImageTexture::create_from_image(img);
-#endif
 
 		Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
 		if (theme.is_valid()) {

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -47,10 +47,7 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/resources/image_texture.h"
 
-#include "modules/modules_enabled.gen.h" // For svg and regex.
-#ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
-#endif
 
 void EditorExportPlatformMacOS::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	r_features->push_back(p_preset->get("binary_format/architecture"));
@@ -1091,16 +1088,12 @@ void EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pres
 	switch (codesign_tool) {
 		case 1: { // built-in ad-hoc
 			print_verbose("using built-in codesign...");
-#ifdef MODULE_REGEX_ENABLED
 			String error_msg;
 			Error err = CodeSign::codesign(false, true, p_path, p_ent_path, error_msg);
 			if (err != OK) {
 				add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), vformat(TTR("Built-in CodeSign failed with error \"%s\"."), error_msg));
 				return;
 			}
-#else
-			add_message(EXPORT_MESSAGE_WARNING, TTR("Code Signing"), TTR("Built-in CodeSign require regex module."));
-#endif
 		} break;
 		case 2: { // "rcodesign"
 			print_verbose("using rcodesign codesign...");
@@ -2716,7 +2709,6 @@ Error EditorExportPlatformMacOS::run(const Ref<EditorExportPreset> &p_preset, in
 
 EditorExportPlatformMacOS::EditorExportPlatformMacOS() {
 	if (EditorNode::get_singleton()) {
-#ifdef MODULE_SVG_ENABLED
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);
 
@@ -2725,7 +2717,6 @@ EditorExportPlatformMacOS::EditorExportPlatformMacOS() {
 
 		ImageLoaderSVG::create_image_from_string(img, _macos_run_icon_svg, EDSCALE, upsample, false);
 		run_icon = ImageTexture::create_from_image(img);
-#endif
 
 		Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
 		if (theme.is_valid()) {

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -41,10 +41,8 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/resources/image_texture.h"
 
-#include "modules/modules_enabled.gen.h" // For mono and svg.
-#ifdef MODULE_SVG_ENABLED
+#include "modules/modules_enabled.gen.h" // For mono.
 #include "modules/svg/image_loader_svg.h"
-#endif
 
 Error EditorExportPlatformWeb::_extract_template(const String &p_template, const String &p_dir, const String &p_name, bool pwa) {
 	Ref<FileAccess> io_fa;
@@ -904,7 +902,6 @@ EditorExportPlatformWeb::EditorExportPlatformWeb() {
 	if (EditorNode::get_singleton()) {
 		server.instantiate();
 
-#ifdef MODULE_SVG_ENABLED
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);
 
@@ -913,7 +910,6 @@ EditorExportPlatformWeb::EditorExportPlatformWeb() {
 
 		ImageLoaderSVG::create_image_from_string(img, _web_run_icon_svg, EDSCALE, upsample, false);
 		run_icon = ImageTexture::create_from_image(img);
-#endif
 
 		Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
 		if (theme.is_valid()) {

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -41,10 +41,7 @@
 #include "editor/export/editor_export.h"
 #include "editor/themes/editor_scale.h"
 
-#include "modules/modules_enabled.gen.h" // For svg.
-#ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
-#endif
 
 Error EditorExportPlatformWindows::_process_icon(const Ref<EditorExportPreset> &p_preset, const String &p_src_path, const String &p_dst_path) {
 	static const uint8_t icon_size[] = { 16, 32, 48, 64, 128, 0 /*256*/ };
@@ -1150,7 +1147,6 @@ Error EditorExportPlatformWindows::run(const Ref<EditorExportPreset> &p_preset, 
 
 EditorExportPlatformWindows::EditorExportPlatformWindows() {
 	if (EditorNode::get_singleton()) {
-#ifdef MODULE_SVG_ENABLED
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);
 
@@ -1159,7 +1155,6 @@ EditorExportPlatformWindows::EditorExportPlatformWindows() {
 
 		ImageLoaderSVG::create_image_from_string(img, _windows_run_icon_svg, EDSCALE, upsample, false);
 		run_icon = ImageTexture::create_from_image(img);
-#endif
 
 		Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
 		if (theme.is_valid()) {

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -35,9 +35,10 @@
 #include "core/os/os.h"
 
 #include "tests/test_utils.h"
-#include "thirdparty/doctest/doctest.h"
 
 #include "modules/modules_enabled.gen.h"
+
+#include "thirdparty/doctest/doctest.h"
 
 namespace TestImage {
 

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -31,10 +31,11 @@
 #ifndef TEST_NAVIGATION_SERVER_3D_H
 #define TEST_NAVIGATION_SERVER_3D_H
 
-#include "modules/navigation/nav_utils.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/resources/3d/primitive_meshes.h"
 #include "servers/navigation_server_3d.h"
+
+#include "modules/navigation/nav_utils.h"
 
 namespace TestNavigationServer3D {
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11407

For motivation of this PR please check linked proposal.

Two other files are checking if `svg` and `freetype` module exist, while according to our `SConstruct` we cannot build editor without them, so remove their checking code too.

Mark as draft for discussion.
