### PR TITLE
[Core] Align naming and args of `(SceneTree)Timer` time scale methods

### DIFF
--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -45,7 +45,7 @@
 			[b]Note:[/b] After the timer enters the tree, this property is automatically set to [code]false[/code].
 			[b]Note:[/b] This property does nothing when the timer is running in the editor.
 		</member>
-		<member name="ignore_time_scale" type="bool" setter="set_ignore_time_scale" getter="get_ignore_time_scale" default="false">
+		<member name="ignore_time_scale" type="bool" setter="set_ignore_time_scale" getter="is_ignoring_time_scale" default="false">
 			If [code]true[/code], the timer will ignore [member Engine.time_scale] and update with the real, elapsed time.
 		</member>
 		<member name="one_shot" type="bool" setter="set_one_shot" getter="is_one_shot" default="false">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -94,7 +94,7 @@ void SceneTreeTimer::set_ignore_time_scale(bool p_ignore) {
 	ignore_time_scale = p_ignore;
 }
 
-bool SceneTreeTimer::is_ignore_time_scale() {
+bool SceneTreeTimer::is_ignoring_time_scale() {
 	return ignore_time_scale;
 }
 
@@ -657,7 +657,7 @@ void SceneTree::process_timers(double p_delta, bool p_physics_frame) {
 		}
 
 		double time_left = E->get()->get_time_left();
-		if (E->get()->is_ignore_time_scale()) {
+		if (E->get()->is_ignoring_time_scale()) {
 			time_left -= Engine::get_singleton()->get_process_step();
 		} else {
 			time_left -= p_delta;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -74,7 +74,7 @@ public:
 	bool is_process_in_physics();
 
 	void set_ignore_time_scale(bool p_ignore);
-	bool is_ignore_time_scale();
+	bool is_ignoring_time_scale();
 
 	void release_connections();
 

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -146,7 +146,7 @@ void Timer::set_ignore_time_scale(bool p_ignore) {
 	ignore_time_scale = p_ignore;
 }
 
-bool Timer::get_ignore_time_scale() {
+bool Timer::is_ignoring_time_scale() {
 	return ignore_time_scale;
 }
 
@@ -223,7 +223,7 @@ void Timer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_paused"), &Timer::is_paused);
 
 	ClassDB::bind_method(D_METHOD("set_ignore_time_scale", "ignore"), &Timer::set_ignore_time_scale);
-	ClassDB::bind_method(D_METHOD("get_ignore_time_scale"), &Timer::get_ignore_time_scale);
+	ClassDB::bind_method(D_METHOD("is_ignoring_time_scale"), &Timer::is_ignoring_time_scale);
 
 	ClassDB::bind_method(D_METHOD("is_stopped"), &Timer::is_stopped);
 
@@ -239,7 +239,7 @@ void Timer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "one_shot"), "set_one_shot", "is_one_shot");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "has_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_paused", "is_paused");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_time_scale"), "set_ignore_time_scale", "get_ignore_time_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_time_scale"), "set_ignore_time_scale", "is_ignoring_time_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_left", PROPERTY_HINT_NONE, "suffix:s", PROPERTY_USAGE_NONE), "", "get_time_left");
 
 	BIND_ENUM_CONSTANT(TIMER_PROCESS_PHYSICS);

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -71,7 +71,7 @@ public:
 	bool is_paused() const;
 
 	void set_ignore_time_scale(bool p_ignore);
-	bool get_ignore_time_scale();
+	bool is_ignoring_time_scale();
 
 	bool is_stopped() const;
 


### PR DESCRIPTION
Renamed `get_ignore_time_scale` to `is_ignoring_time_scale` following general naming standards.

See conversation in:
* https://github.com/godotengine/godot/pull/100735

Left the default argument as is, the `Tween` code is different in that regard

Doesn't break compatibility as it was introduced during 4.4

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
