### PR TITLE
[Android] Fix path to AAB in copyAndRenameBinary task

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -250,7 +250,7 @@ task copyAndRenameBinary(type: Copy) {
 
     boolean isAab = exportFormat == "aab"
     boolean isMono = exportEdition == "mono"
-    String filenameSuffix = exportBuildType
+    String filenameSuffix = isAab ? "${exportEdition}-${exportBuildType}" : exportBuildType
     if (isMono) {
         filenameSuffix = isAab ? "${exportEdition}-${exportBuildType}" : "${exportEdition}${exportBuildTypeCapitalized}"
     }


### PR DESCRIPTION
It looks like the path to the bundles includes the edition also for standard builds and I didn't notice because I was only testing the Mono builds.

- Fixes https://github.com/godotengine/godot/issues/100689