### PR TITLE
Add borders to `BitMap` in `BitMapEditor`

### DIFF
--- a/editor/plugins/bit_map_editor_plugin.h
+++ b/editor/plugins/bit_map_editor_plugin.h
@@ -34,13 +34,24 @@
 #include "editor/plugins/editor_plugin.h"
 #include "scene/resources/bit_map.h"
 
+class AspectRatioContainer;
 class TextureRect;
 
 class BitMapEditor : public VBoxContainer {
 	GDCLASS(BitMapEditor, VBoxContainer);
 
+private:
+	AspectRatioContainer *centering_container = nullptr;
+	Control *outline_overlay = nullptr;
 	TextureRect *texture_rect = nullptr;
 	Label *size_label = nullptr;
+
+	Color cached_outline_color;
+
+	void _draw_outline();
+
+protected:
+	void _notification(int p_what);
 
 public:
 	void setup(const Ref<BitMap> &p_bitmap);


### PR DESCRIPTION
**Problem:** try to guess where are borders of `BitMap` when using `Black OLED` theme:

<img src="https://github.com/user-attachments/assets/b3cd6add-8f66-4298-94fc-e502c1dfcc66" width=50% height=50%>

I guess same problem might be if someone is using full white theme.

---

**Solution:** Draw outline around `BitMap` (`TextureRect`) - same way as https://github.com/godotengine/godot/pull/100569.

Preview for different themes:
| Default theme | Light | Black OLED | passivestar minimal theme |
| --- | --- | --- | --- |
| ![1_default](https://github.com/user-attachments/assets/856d142d-672a-4da0-bcff-4bdd0cb479d6) | ![2_light](https://github.com/user-attachments/assets/41a35345-1247-40ef-9b2a-d4b3071c4a03) | ![3_black_oled](https://github.com/user-attachments/assets/c8144cd1-0445-4df8-bf36-7db559f85f9c) | ![4_passivestar_minimal](https://github.com/user-attachments/assets/a7ab93e8-facc-4e44-a492-08566aac3923) |

---

**Note:** There is a change in behavior of `BitMapEditor`. Previously `TextureRect` used `STRETCH_KEEP_ASPECT_CENTERED` so big textures tried to occupy all space they need:
![Godot_v4 4-dev7_win64_WaS7sijHzS](https://github.com/user-attachments/assets/3edb85fa-d7c8-462f-a7c1-07fe25f888f8)

Now `BitMap` texture will occupy up to 250 in height and proportional value in width.
![image](https://github.com/user-attachments/assets/5b682760-52da-457b-8a8a-8654ee32b4af)

For small-sized `BitMap` nothing has changed. Video below shows "after/before". "After" with outline around texture, "before" - without.

https://github.com/user-attachments/assets/ad3f71cd-48dd-4542-b71c-a601282f1432

- *Production edit: This closes https://github.com/godotengine/godot/issues/73391.*