### PR TITLE
OpenXR: Fix hiding/showing composition layers using hole punching

### DIFF
--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -401,7 +401,7 @@ void OpenXRCompositionLayer::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (!fallback && openxr_session_running && is_inside_tree()) {
+			if (is_natively_supported() && openxr_session_running && is_inside_tree()) {
 				if (is_visible()) {
 					_setup_composition_layer_provider();
 				} else {


### PR DESCRIPTION
Currently, with a composition layer that uses hole punching, changing `visible` (to hide/show the composition layer) won't have an effect most of the time.

This is due to some old logic that is checking if the `fallback` node exists or not to see if we are using real composition layers (versus a fallback for OpenXR runtimes that don't support them). However, after we added the hole punching feature (in https://github.com/godotengine/godot/pull/91485), this logic no longer makes sense, because we are using the fallback mesh to setup hole punching as well.

So, this PR switches to checking `is_natively_supported()` instead, which is working in my testing