### PR TITLE
Metal: Fix crash when uniform set is empty for slot binding mode

### DIFF
--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -56,6 +56,10 @@
 
 #import <os/signpost.h>
 
+// We have to undefine these macros because they are defined in NSObjCRuntime.h.
+#undef MIN
+#undef MAX
+
 void MDCommandBuffer::begin() {
 	DEV_ASSERT(commandBuffer == nil);
 	commandBuffer = queue.commandBufferWithUnretainedReferences;
@@ -764,6 +768,7 @@ void MDCommandBuffer::render_bind_vertex_buffers(uint32_t p_binding_count, const
 		[render.encoder setVertexBuffers:render.vertex_buffers.ptr()
 								 offsets:render.vertex_offsets.ptr()
 							   withRange:NSMakeRange(first, p_binding_count)];
+		render.dirty.clear_flag(RenderState::DIRTY_VERTEX);
 	} else {
 		render.dirty.set_flag(RenderState::DIRTY_VERTEX);
 	}
@@ -1082,7 +1087,7 @@ void MDUniformSet::bind_uniforms_direct(MDShader *p_shader, MDCommandBuffer::Ren
 
 	UniformSet const &set = p_shader->sets[index];
 
-	for (uint32_t i = 0; i < uniforms.size(); i++) {
+	for (uint32_t i = 0; i < MIN(uniforms.size(), set.uniforms.size()); i++) {
 		RDD::BoundUniform const &uniform = uniforms[i];
 		UniformInfo ui = set.uniforms[i];
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -541,13 +541,15 @@ void ParticlesStorage::_particles_allocate_emission_buffer(Particles *particles)
 
 void ParticlesStorage::_particles_ensure_unused_emission_buffer(Particles *particles) {
 	if (particles->unused_emission_storage_buffer.is_null()) {
-		particles->unused_emission_storage_buffer = RD::get_singleton()->storage_buffer_create(sizeof(uint32_t) * 4);
+		// For rendering devices that do not support empty arrays (like C++),
+		// we need to size the buffer with at least 1 element.
+		particles->unused_emission_storage_buffer = RD::get_singleton()->storage_buffer_create(sizeof(ParticleEmissionBuffer));
 	}
 }
 
 void ParticlesStorage::_particles_ensure_unused_trail_buffer(Particles *particles) {
 	if (particles->unused_trail_storage_buffer.is_null()) {
-		particles->unused_trail_storage_buffer = RD::get_singleton()->storage_buffer_create(sizeof(uint32_t) * 4);
+		particles->unused_trail_storage_buffer = RD::get_singleton()->storage_buffer_create(16 * sizeof(float)); // Size of mat4.
 	}
 }
 


### PR DESCRIPTION
Closes #100764

Resolves a `CRASH_BAD_INDEX` error when binding uniform sets that are empty, specifically for A12 devices and earlier, which use slot-based binding vs argument buffers.

Resolves a Metal CPU API validation error when binding "empty" particle buffers, that were incorrectly sized. Metal doesn't support defining a struct with an empty array.

# Overview

An example of this in GLSL is:

```glsl
struct ParticleEmission {
  vec3 velocity;
  uint flags;
};

layout(set = 1, binding = 2, std430) restrict buffer SourceEmission {
  int particle_count;
  uint pad0;
  uint pad1;
  uint pad2;
  ParticleEmission data[];
}
src_particles;
```

The minimum size of `SourceEmission` is 16 bytes when binding a buffer for backends that support empty arrays.

However, when this is converted to Metal, note the data member is an array of size `1`:

```metal
struct ParticleEmission {
  float3 velocity;
  uint flags;
};

struct SourceEmission {
  int particle_count;
  uint pad0;
  uint pad1;
  uint pad2;
  ParticleEmission data[1];
};
```

This means that the minimum size of the struct when binding an "empty" array is 32 bytes. This doesn't cause an issue when Metal API validation is disabled, but this feature is often enabled when running code from Xcode, which iPhone developers are likely to do.

