### PR TITLE
Fix NavLinkIteration bidirectional

### DIFF
--- a/modules/navigation/nav_link.cpp
+++ b/modules/navigation/nav_link.cpp
@@ -129,8 +129,10 @@ void NavLink::get_iteration_update(NavLinkIteration &r_iteration) {
 	r_iteration.travel_cost = get_travel_cost();
 	r_iteration.owner_object_id = get_owner_id();
 	r_iteration.owner_type = get_type();
+	r_iteration.owner_rid = get_self();
 
-	r_iteration.enabled = enabled;
-	r_iteration.start_position = start_position;
-	r_iteration.end_position = end_position;
+	r_iteration.enabled = get_enabled();
+	r_iteration.start_position = get_start_position();
+	r_iteration.end_position = get_end_position();
+	r_iteration.bidirectional = is_bidirectional();
 }


### PR DESCRIPTION
Fixes missing NavLinkIteration `bidirectional` property that got lost in some file shuffling.

Fixes https://github.com/godotengine/godot/issues/100769

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
