### PR TITLE
Improve use of `Ref.is_null/valid`

### DIFF
--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -689,7 +689,7 @@ void AnimationBezierTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 }
 
 void AnimationBezierTrackEdit::_play_position_draw() {
-	if (!animation.is_valid() || play_position_pos < 0) {
+	if (animation.is_null() || play_position_pos < 0) {
 		return;
 	}
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -8066,7 +8066,7 @@ void AnimationTrackKeyEditEditor::_time_edit_exited() {
 }
 
 AnimationTrackKeyEditEditor::AnimationTrackKeyEditEditor(Ref<Animation> p_animation, int p_track, real_t p_key_ofs, bool p_use_fps) {
-	if (!p_animation.is_valid()) {
+	if (p_animation.is_null()) {
 		return;
 	}
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -220,7 +220,7 @@ Rect2 AnimationTrackEditAudio::get_key_rect(int p_index, float p_pixels_sec) {
 
 	Ref<AudioStream> stream = object->call("get_stream");
 
-	if (!stream.is_valid()) {
+	if (stream.is_null()) {
 		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
 	}
 
@@ -260,7 +260,7 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 
 	Ref<AudioStream> stream = object->call("get_stream");
 
-	if (!stream.is_valid()) {
+	if (stream.is_null()) {
 		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
 		return;
 	}
@@ -379,7 +379,7 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 
 	if (Object::cast_to<Sprite2D>(object) || Object::cast_to<Sprite3D>(object)) {
 		Ref<Texture2D> texture = object->call("get_texture");
-		if (!texture.is_valid()) {
+		if (texture.is_null()) {
 			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
 		}
 
@@ -422,7 +422,7 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 		}
 
 		Ref<Texture2D> texture = sf->get_frame_texture(animation_name, frame);
-		if (!texture.is_valid()) {
+		if (texture.is_null()) {
 			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
 		}
 
@@ -456,7 +456,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 
 	if (Object::cast_to<Sprite2D>(object) || Object::cast_to<Sprite3D>(object)) {
 		texture = object->call("get_texture");
-		if (!texture.is_valid()) {
+		if (texture.is_null()) {
 			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
 			return;
 		}
@@ -514,7 +514,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 		}
 
 		texture = sf->get_frame_texture(animation_name, frame);
-		if (!texture.is_valid()) {
+		if (texture.is_null()) {
 			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
 			return;
 		}
@@ -808,7 +808,7 @@ int AnimationTrackEditTypeAudio::get_key_height() const {
 Rect2 AnimationTrackEditTypeAudio::get_key_rect(int p_index, float p_pixels_sec) {
 	Ref<AudioStream> stream = get_animation()->audio_track_get_key_stream(get_track(), p_index);
 
-	if (!stream.is_valid()) {
+	if (stream.is_null()) {
 		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
 	}
 
@@ -841,7 +841,7 @@ bool AnimationTrackEditTypeAudio::is_key_selectable_by_distance() const {
 
 void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	Ref<AudioStream> stream = get_animation()->audio_track_get_key_stream(get_track(), p_index);
-	if (!stream.is_valid()) {
+	if (stream.is_null()) {
 		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right); // Draw diamond.
 		return;
 	}
@@ -1025,7 +1025,7 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 		for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
 			Ref<AudioStream> stream = get_animation()->audio_track_get_key_stream(get_track(), i);
 
-			if (!stream.is_valid()) {
+			if (stream.is_null()) {
 				continue;
 			}
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -866,7 +866,7 @@ void CodeTextEditor::input(const Ref<InputEvent> &event) {
 
 	const Ref<InputEventKey> key_event = event;
 
-	if (!key_event.is_valid()) {
+	if (key_event.is_null()) {
 		return;
 	}
 	if (!key_event->is_pressed()) {
@@ -1053,7 +1053,7 @@ Ref<Texture2D> CodeTextEditor::_get_completion_icon(const ScriptLanguage::CodeCo
 				tex = get_editor_theme_icon(p_option.display);
 			} else {
 				tex = EditorNode::get_singleton()->get_class_icon(p_option.display);
-				if (!tex.is_valid()) {
+				if (tex.is_null()) {
 					tex = get_editor_theme_icon(SNAME("Object"));
 				}
 			}

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -114,7 +114,7 @@ bool CreateDialog::_is_type_preferred(const String &p_type) const {
 bool CreateDialog::_is_class_disabled_by_feature_profile(const StringName &p_class) const {
 	Ref<EditorFeatureProfile> profile = EditorFeatureProfileManager::get_singleton()->get_current_profile();
 
-	return !profile.is_null() && profile->is_class_disabled(p_class);
+	return profile.is_valid() && profile->is_class_disabled(p_class);
 }
 
 bool CreateDialog::_should_hide_type(const StringName &p_type) const {
@@ -312,7 +312,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 			r_item->set_suffix(0, "(" + suffix + ")");
 		}
 
-		ERR_FAIL_COND(!scr.is_valid());
+		ERR_FAIL_COND(scr.is_null());
 		is_abstract = scr->is_abstract();
 	} else {
 		r_item->set_metadata(0, custom_type_parents[p_type]);

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -167,7 +167,7 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 					if (debug_obj->get_script() != var) {
 						debug_obj->set_script(Ref<RefCounted>());
 						Ref<Script> scr(var);
-						if (!scr.is_null()) {
+						if (scr.is_valid()) {
 							ScriptInstance *scr_instance = scr->placeholder_instance_create(debug_obj);
 							if (scr_instance) {
 								debug_obj->set_script_and_instance(var, scr_instance);

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -331,7 +331,7 @@ void EditorDebuggerNode::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_PROCESS: {
-			if (!server.is_valid()) {
+			if (server.is_null()) {
 				return;
 			}
 

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -395,7 +395,7 @@ Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
 		scn.instantiate();
 		scn->set_path(p_path);
 		scn->reload_from_file();
-		ERR_FAIL_COND_V_MSG(!scn.is_valid(), nullptr, vformat("Failed to create an autoload, can't load from path: %s.", p_path));
+		ERR_FAIL_COND_V_MSG(scn.is_null(), nullptr, vformat("Failed to create an autoload, can't load from path: %s.", p_path));
 
 		if (scn.is_valid()) {
 			n = scn->instantiate();

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -46,7 +46,7 @@ void EditorSelectionHistory::cleanup_history() {
 		bool fail = false;
 
 		for (int j = 0; j < history[i].path.size(); j++) {
-			if (!history[i].path[j].ref.is_null()) {
+			if (history[i].path[j].ref.is_valid()) {
 				// If the node is a MultiNodeEdit node, examine it and see if anything is missing from it.
 				Ref<MultiNodeEdit> multi_node_edit = history[i].path[j].ref;
 				if (multi_node_edit.is_valid()) {
@@ -838,9 +838,9 @@ Ref<Script> EditorData::get_scene_root_script(int p_idx) const {
 		return Ref<Script>();
 	}
 	Ref<Script> s = edited_scene[p_idx].root->get_script();
-	if (!s.is_valid() && edited_scene[p_idx].root->get_child_count()) {
+	if (s.is_null() && edited_scene[p_idx].root->get_child_count()) {
 		Node *n = edited_scene[p_idx].root->get_child(0);
-		while (!s.is_valid() && n && n->get_scene_file_path().is_empty()) {
+		while (s.is_null() && n && n->get_scene_file_path().is_empty()) {
 			s = n->get_script();
 			n = n->get_parent();
 		}

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2475,7 +2475,7 @@ Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector
 		}
 
 		Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
-		ERR_FAIL_COND_V(!importer.is_valid(), ERR_FILE_CORRUPT);
+		ERR_FAIL_COND_V(importer.is_null(), ERR_FILE_CORRUPT);
 		List<ResourceImporter::ImportOption> options;
 		importer->get_import_options(p_files[i], &options);
 		//set default values

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1854,7 +1854,7 @@ void EditorInspectorArray::_panel_draw(int p_index) {
 	ERR_FAIL_INDEX(p_index, (int)array_elements.size());
 
 	Ref<StyleBox> style = get_theme_stylebox(SNAME("Focus"), EditorStringName(EditorStyles));
-	if (!style.is_valid()) {
+	if (style.is_null()) {
 		return;
 	}
 	if (array_elements[p_index].panel->has_focus()) {

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -169,7 +169,7 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 
 	for (int i = 0; i < p_meshes.size(); i++) {
 		const Ref<Mesh> &mesh = p_meshes[i];
-		if (!mesh.is_valid()) {
+		if (mesh.is_null()) {
 			textures.push_back(Ref<Texture2D>());
 			continue;
 		}
@@ -210,7 +210,7 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 		Main::iteration();
 		Main::iteration();
 		Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
-		ERR_CONTINUE(!img.is_valid() || img->is_empty());
+		ERR_CONTINUE(img.is_null() || img->is_empty());
 		Ref<ImageTexture> it = ImageTexture::create_from_image(img);
 
 		RS::get_singleton()->free(inst);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1286,7 +1286,7 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 		OS::get_singleton()->shell_open(ProjectSettings::get_singleton()->globalize_path(p_resource));
 		return OK;
 	}
-	ERR_FAIL_COND_V(!res.is_valid(), ERR_CANT_OPEN);
+	ERR_FAIL_COND_V(res.is_null(), ERR_CANT_OPEN);
 
 	if (!p_ignore_broken_deps && dependency_errors.has(p_resource)) {
 		Vector<String> errors;
@@ -1706,7 +1706,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			// This check prevents the preview from regenerating in case those scenes are then saved.
 			// The preview will be generated if no feature profile is set (as the 3D editor is enabled by default).
 			Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
-			if (!profile.is_valid() || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
+			if (profile.is_null() || !profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D)) {
 				img = Node3DEditor::get_singleton()->get_editor_viewport(0)->get_viewport_node()->get_texture()->get_image();
 			}
 		}
@@ -1815,7 +1815,7 @@ int EditorNode::_save_external_resources(bool p_also_save_external_data) {
 
 	for (const String &E : edited_resources) {
 		Ref<Resource> res = ResourceCache::get_ref(E);
-		if (!res.is_valid()) {
+		if (res.is_null()) {
 			continue; // Maybe it was erased in a thread, who knows.
 		}
 		Ref<PackedScene> ps = res;
@@ -4021,7 +4021,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		return ERR_FILE_MISSING_DEPENDENCIES;
 	}
 
-	if (!sdata.is_valid()) {
+	if (sdata.is_null()) {
 		_dialog_display_load_error(lpath, err);
 		opening_prev = false;
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -86,11 +86,11 @@ void EditorResourcePicker::_update_resource() {
 		assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + edited_resource->get_class());
 	}
 
-	assign_button->set_disabled(!editable && !edited_resource.is_valid());
+	assign_button->set_disabled(!editable && edited_resource.is_null());
 }
 
 void EditorResourcePicker::_update_resource_preview(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, ObjectID p_obj) {
-	if (!edited_resource.is_valid() || edited_resource->get_instance_id() != p_obj) {
+	if (edited_resource.is_null() || edited_resource->get_instance_id() != p_obj) {
 		return;
 	}
 
@@ -711,7 +711,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 		dropped_resource = drag_data["resource"];
 	}
 
-	if (!dropped_resource.is_valid() && drag_data.has("type") && String(drag_data["type"]) == "files") {
+	if (dropped_resource.is_null() && drag_data.has("type") && String(drag_data["type"]) == "files") {
 		Vector<String> files = drag_data["files"];
 
 		if (files.size() == 1) {
@@ -733,7 +733,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 				if (at == "BaseMaterial3D" && Ref<Texture2D>(dropped_resource).is_valid()) {
 					// Use existing resource if possible and only replace its data.
 					Ref<StandardMaterial3D> mat = edited_resource;
-					if (!mat.is_valid()) {
+					if (mat.is_null()) {
 						mat.instantiate();
 					}
 					mat->set_texture(StandardMaterial3D::TextureParam::TEXTURE_ALBEDO, dropped_resource);
@@ -743,7 +743,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 
 				if (at == "ShaderMaterial" && Ref<Shader>(dropped_resource).is_valid()) {
 					Ref<ShaderMaterial> mat = edited_resource;
-					if (!mat.is_valid()) {
+					if (mat.is_null()) {
 						mat.instantiate();
 					}
 					mat->set_shader(dropped_resource);
@@ -753,7 +753,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 
 				if (at == "ImageTexture" && Ref<Image>(dropped_resource).is_valid()) {
 					Ref<ImageTexture> texture = edited_resource;
-					if (!texture.is_valid()) {
+					if (texture.is_null()) {
 						texture.instantiate();
 					}
 					texture->set_image(dropped_resource);
@@ -888,7 +888,7 @@ Vector<String> EditorResourcePicker::get_allowed_types() const {
 }
 
 void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
-	if (!p_resource.is_valid()) {
+	if (p_resource.is_null()) {
 		edited_resource = Ref<Resource>();
 		_update_resource();
 		return;
@@ -948,7 +948,7 @@ void EditorResourcePicker::set_resource_owner(Object *p_object) {
 
 void EditorResourcePicker::set_editable(bool p_editable) {
 	editable = p_editable;
-	assign_button->set_disabled(!editable && !edited_resource.is_valid());
+	assign_button->set_disabled(!editable && edited_resource.is_null());
 	load_button->set_visible(editable);
 	edit_button->set_visible(editable);
 }
@@ -1269,7 +1269,7 @@ void EditorAudioStreamPicker::_update_resource() {
 
 void EditorAudioStreamPicker::_preview_draw() {
 	Ref<AudioStream> audio_stream = get_edited_resource();
-	if (!audio_stream.is_valid()) {
+	if (audio_stream.is_null()) {
 		get_assign_button()->set_text(TTR("<empty>"));
 		return;
 	}

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -67,7 +67,7 @@ Ref<Texture2D> EditorResourcePreviewGenerator::generate_from_path(const String &
 	}
 
 	Ref<Resource> res = ResourceLoader::load(p_path);
-	if (!res.is_valid()) {
+	if (res.is_null()) {
 		return res;
 	}
 	return generate(res, p_size, p_metadata);
@@ -217,7 +217,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 			r_small_texture = generated_small;
 		}
 
-		if (!r_small_texture.is_valid() && r_texture.is_valid() && preview_generators[i]->generate_small_preview_automatically()) {
+		if (r_small_texture.is_null() && r_texture.is_valid() && preview_generators[i]->generate_small_preview_automatically()) {
 			Ref<Image> small_image = r_texture->get_image();
 			small_image = small_image->duplicate();
 			small_image->resize(small_thumbnail_size, small_thumbnail_size, Image::INTERPOLATE_CUBIC);
@@ -230,7 +230,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 		}
 	}
 
-	if (!p_item.resource.is_valid()) {
+	if (p_item.resource.is_null()) {
 		// Cache the preview in case it's a resource on disk.
 		if (r_texture.is_valid()) {
 			// Wow it generated a preview... save cache.
@@ -450,7 +450,7 @@ EditorResourcePreview::PreviewItem EditorResourcePreview::get_resource_preview_i
 
 void EditorResourcePreview::queue_edited_resource_preview(const Ref<Resource> &p_res, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata) {
 	ERR_FAIL_NULL(p_receiver);
-	ERR_FAIL_COND(!p_res.is_valid());
+	ERR_FAIL_COND(p_res.is_null());
 	_update_thumbnail_sizes();
 
 	{

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1856,7 +1856,7 @@ Ref<Shortcut> ED_GET_SHORTCUT(const String &p_path) {
 
 	Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(p_path);
 
-	ERR_FAIL_COND_V_MSG(!sc.is_valid(), sc, "Used ED_GET_SHORTCUT with invalid shortcut: " + p_path);
+	ERR_FAIL_COND_V_MSG(sc.is_null(), sc, "Used ED_GET_SHORTCUT with invalid shortcut: " + p_path);
 
 	return sc;
 }
@@ -1867,7 +1867,7 @@ void ED_SHORTCUT_OVERRIDE(const String &p_path, const String &p_feature, Key p_k
 	}
 
 	Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(p_path);
-	ERR_FAIL_COND_MSG(!sc.is_valid(), "Used ED_SHORTCUT_OVERRIDE with invalid shortcut: " + p_path);
+	ERR_FAIL_COND_MSG(sc.is_null(), "Used ED_SHORTCUT_OVERRIDE with invalid shortcut: " + p_path);
 
 	PackedInt32Array arr;
 	arr.push_back((int32_t)p_keycode);
@@ -1881,7 +1881,7 @@ void ED_SHORTCUT_OVERRIDE_ARRAY(const String &p_path, const String &p_feature, c
 	}
 
 	Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(p_path);
-	ERR_FAIL_COND_MSG(!sc.is_valid(), "Used ED_SHORTCUT_OVERRIDE_ARRAY with invalid shortcut: " + p_path);
+	ERR_FAIL_COND_MSG(sc.is_null(), "Used ED_SHORTCUT_OVERRIDE_ARRAY with invalid shortcut: " + p_path);
 
 	// Only add the override if the OS supports the provided feature.
 	if (!OS::get_singleton()->has_feature(p_feature)) {

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -256,7 +256,7 @@ void EditorExport::load_config() {
 			}
 		}
 
-		if (!preset.is_valid()) {
+		if (preset.is_null()) {
 			index++;
 			continue; // Unknown platform, skip without error (platform might be loaded later).
 		}

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -138,7 +138,7 @@ void ProjectExportDialog::popup_export() {
 
 void ProjectExportDialog::_add_preset(int p_platform) {
 	Ref<EditorExportPreset> preset = EditorExport::get_singleton()->get_export_platform(p_platform)->create_preset();
-	ERR_FAIL_COND(!preset.is_valid());
+	ERR_FAIL_COND(preset.is_null());
 
 	String preset_name = EditorExport::get_singleton()->get_export_platform(p_platform)->get_name();
 	bool make_runnable = true;
@@ -668,7 +668,7 @@ void ProjectExportDialog::_duplicate_preset() {
 	}
 
 	Ref<EditorExportPreset> preset = current->get_platform()->create_preset();
-	ERR_FAIL_COND(!preset.is_valid());
+	ERR_FAIL_COND(preset.is_null());
 
 	String preset_name = current->get_name() + " (copy)";
 	bool make_runnable = true;

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -105,7 +105,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		}
 	} else if (p_id == BUTTON_SCRIPT) {
 		Ref<Script> script_typed = n->get_script();
-		if (!script_typed.is_null()) {
+		if (script_typed.is_valid()) {
 			emit_signal(SNAME("open_script"), script_typed);
 		}
 
@@ -565,7 +565,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 	// Show buttons only when necessary (SceneTreeDock) to avoid crashes.
 	if (can_open_instance && is_scene_tree_dock) {
 		Ref<Script> scr = p_node->get_script();
-		if (!scr.is_null()) {
+		if (scr.is_valid()) {
 			String additional_notes;
 			Color button_color = Color(1, 1, 1);
 			// Can't set tooltip after adding button, need to do it before.

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1287,7 +1287,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 				}
 			}
 
-			if (!mesh.is_null()) {
+			if (mesh.is_valid()) {
 				mi->set_mesh(mesh);
 				if (!use_mesh_builtin_materials) {
 					const Collada::MeshData &meshdata = collada.state.mesh_data_map[meshid];

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -92,7 +92,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 		}
 		BoneMap *bone_map = Object::cast_to<BoneMap>(map);
 		Ref<SkeletonProfile> profile = bone_map->get_profile();
-		if (!profile.is_valid()) {
+		if (profile.is_null()) {
 			return;
 		}
 		Skeleton3D *src_skeleton = Object::cast_to<Skeleton3D>(p_node);

--- a/editor/import/3d/post_import_plugin_skeleton_track_organizer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_track_organizer.cpp
@@ -51,7 +51,7 @@ void PostImportPluginSkeletonTrackOrganizer::internal_process(InternalImportCate
 		}
 		BoneMap *bone_map = Object::cast_to<BoneMap>(map);
 		Ref<SkeletonProfile> profile = bone_map->get_profile();
-		if (!profile.is_valid()) {
+		if (profile.is_null()) {
 			return;
 		}
 		Skeleton3D *src_skeleton = Object::cast_to<Skeleton3D>(p_node);

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -667,7 +667,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		if (m.is_valid()) {
 			for (int i = 0; i < m->get_surface_count(); i++) {
 				Ref<BaseMaterial3D> mat = m->get_surface_material(i);
-				if (!mat.is_valid()) {
+				if (mat.is_null()) {
 					continue;
 				}
 
@@ -997,7 +997,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
 
 		Ref<ImporterMesh> mesh = mi->get_mesh();
-		if (!mesh.is_null()) {
+		if (mesh.is_valid()) {
 			Vector<Ref<Shape3D>> shapes;
 			if (r_collision_map.has(mesh)) {
 				shapes = r_collision_map[mesh];
@@ -1583,7 +1583,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								col->set_transform(get_collision_shapes_transform(node_settings));
 								col->set_position(p_applied_root_scale * col->get_position());
 								const Ref<PhysicsMaterial> &pmo = node_settings["physics/physics_material_override"];
-								if (!pmo.is_null()) {
+								if (pmo.is_valid()) {
 									col->set_physics_material_override(pmo);
 								}
 								base = col;
@@ -1600,7 +1600,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								rigid_body->add_child(mi, true);
 								mi->set_owner(rigid_body->get_owner());
 								const Ref<PhysicsMaterial> &pmo = node_settings["physics/physics_material_override"];
-								if (!pmo.is_null()) {
+								if (pmo.is_valid()) {
 									rigid_body->set_physics_material_override(pmo);
 								}
 								base = rigid_body;
@@ -1616,7 +1616,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 								memdelete(p_node);
 								p_node = col;
 								const Ref<PhysicsMaterial> &pmo = node_settings["physics/physics_material_override"];
-								if (!pmo.is_null()) {
+								if (pmo.is_valid()) {
 									col->set_physics_material_override(pmo);
 								}
 								base = col;
@@ -2847,7 +2847,7 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 		}
 	}
 
-	ERR_FAIL_COND_V(!importer.is_valid(), nullptr);
+	ERR_FAIL_COND_V(importer.is_null(), nullptr);
 	ERR_FAIL_COND_V(p_options.is_empty(), nullptr);
 
 	Error err = OK;
@@ -2906,7 +2906,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		}
 	}
 
-	ERR_FAIL_COND_V(!importer.is_valid(), ERR_FILE_UNRECOGNIZED);
+	ERR_FAIL_COND_V(importer.is_null(), ERR_FILE_UNRECOGNIZED);
 	ERR_FAIL_COND_V(p_options.is_empty(), ERR_BUG);
 
 	int import_flags = 0;
@@ -3098,7 +3098,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 			post_import_script_path = p_source_file.get_base_dir().path_join(post_import_script_path);
 		}
 		Ref<Script> scr = ResourceLoader::load(post_import_script_path);
-		if (!scr.is_valid()) {
+		if (scr.is_null()) {
 			EditorNode::add_io_error(TTR("Couldn't load post-import script:") + " " + post_import_script_path);
 		} else {
 			post_import_script.instantiate();
@@ -3160,7 +3160,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 			}
 		}
 
-		if (!library.is_valid()) {
+		if (library.is_null()) {
 			library.instantiate(); // Will be empty
 		}
 
@@ -3272,7 +3272,7 @@ void EditorSceneFormatImporterESCN::get_extensions(List<String> *r_extensions) c
 Node *EditorSceneFormatImporterESCN::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {
 	Error error;
 	Ref<PackedScene> ps = ResourceFormatLoaderText::singleton->load(p_path, p_path, &error);
-	ERR_FAIL_COND_V_MSG(!ps.is_valid(), nullptr, "Cannot load scene as text resource from path '" + p_path + "'.");
+	ERR_FAIL_COND_V_MSG(ps.is_null(), nullptr, "Cannot load scene as text resource from path '" + p_path + "'.");
 	Node *scene = ps->instantiate();
 	TypedArray<Node> nodes = scene->find_children("*", "MeshInstance3D");
 	for (int32_t node_i = 0; node_i < nodes.size(); node_i++) {

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -180,7 +180,7 @@ void AudioStreamImportSettingsDialog::_preview_changed(ObjectID p_which) {
 }
 
 void AudioStreamImportSettingsDialog::_preview_zoom_in() {
-	if (!stream.is_valid()) {
+	if (stream.is_null()) {
 		return;
 	}
 	float page_size = zoom_bar->get_page();
@@ -192,7 +192,7 @@ void AudioStreamImportSettingsDialog::_preview_zoom_in() {
 }
 
 void AudioStreamImportSettingsDialog::_preview_zoom_out() {
-	if (!stream.is_valid()) {
+	if (stream.is_null()) {
 		return;
 	}
 	float page_size = zoom_bar->get_page();
@@ -204,7 +204,7 @@ void AudioStreamImportSettingsDialog::_preview_zoom_out() {
 }
 
 void AudioStreamImportSettingsDialog::_preview_zoom_reset() {
-	if (!stream.is_valid()) {
+	if (stream.is_null()) {
 		return;
 	}
 	zoom_bar->set_max(stream->get_length());
@@ -262,7 +262,7 @@ void AudioStreamImportSettingsDialog::_on_finished() {
 }
 
 void AudioStreamImportSettingsDialog::_draw_indicator() {
-	if (!stream.is_valid()) {
+	if (stream.is_null()) {
 		return;
 	}
 
@@ -401,7 +401,7 @@ void AudioStreamImportSettingsDialog::_seek_to(real_t p_x) {
 }
 
 void AudioStreamImportSettingsDialog::edit(const String &p_path, const String &p_importer, const Ref<AudioStream> &p_stream) {
-	if (!stream.is_null()) {
+	if (stream.is_valid()) {
 		stream->disconnect_changed(callable_mp(this, &AudioStreamImportSettingsDialog::_audio_changed));
 	}
 
@@ -414,7 +414,7 @@ void AudioStreamImportSettingsDialog::edit(const String &p_path, const String &p
 	String text = String::num(stream->get_length(), 2).pad_decimals(2) + "s";
 	_duration_label->set_text(text);
 
-	if (!stream.is_null()) {
+	if (stream.is_valid()) {
 		stream->connect_changed(callable_mp(this, &AudioStreamImportSettingsDialog::_audio_changed));
 		_preview->queue_redraw();
 		_indicator->queue_redraw();

--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -96,7 +96,7 @@ Error ResourceImporterShaderFile::import(ResourceUID::ID p_source_id, const Stri
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_source_file, FileAccess::READ, &err);
 	ERR_FAIL_COND_V(err != OK, ERR_CANT_OPEN);
-	ERR_FAIL_COND_V(!file.is_valid(), ERR_CANT_OPEN);
+	ERR_FAIL_COND_V(file.is_null(), ERR_CANT_OPEN);
 
 	String file_txt = file->get_as_utf8_string();
 	Ref<RDShaderFile> shader_file;

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -314,7 +314,7 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 	//update cache if existing, else create
 	Ref<Texture2D> cache;
 	cache = ResourceCache::get_ref(p_group_file);
-	if (!cache.is_valid()) {
+	if (cache.is_null()) {
 		Ref<ImageTexture> res_cache = ImageTexture::create_from_image(new_atlas);
 		res_cache->set_path(p_group_file);
 		cache = res_cache;

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -665,7 +665,7 @@ void ImportDock::_reimport() {
 
 			//handle group file
 			Ref<ResourceImporter> importer = ResourceFormatImporter::get_singleton()->get_importer_by_name(importer_name);
-			ERR_CONTINUE(!importer.is_valid());
+			ERR_CONTINUE(importer.is_null());
 			String group_file_property = importer->get_option_group_file();
 			if (!group_file_property.is_empty()) {
 				//can import from a group (as in, atlas)

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -428,7 +428,7 @@ void AnimationNodeBlendSpace1DEditor::_add_menu_type(int p_index) {
 		node = Ref<AnimationNode>(an);
 	}
 
-	if (!node.is_valid()) {
+	if (node.is_null()) {
 		EditorNode::get_singleton()->show_warning(TTR("This type of node can't be used. Only root nodes are allowed."));
 		return;
 	}
@@ -634,7 +634,7 @@ void AnimationNodeBlendSpace1DEditor::edit(const Ref<AnimationNode> &p_node) {
 	blend_space = p_node;
 	read_only = false;
 
-	if (!blend_space.is_null()) {
+	if (blend_space.is_valid()) {
 		read_only = EditorNode::get_singleton()->is_resource_read_only(blend_space);
 
 		_update_space();

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -69,7 +69,7 @@ void AnimationNodeBlendSpace2DEditor::edit(const Ref<AnimationNode> &p_node) {
 	blend_space = p_node;
 	read_only = false;
 
-	if (!blend_space.is_null()) {
+	if (blend_space.is_valid()) {
 		read_only = EditorNode::get_singleton()->is_resource_read_only(blend_space);
 
 		blend_space->connect("triangles_updated", callable_mp(this, &AnimationNodeBlendSpace2DEditor::_blend_space_changed));
@@ -353,7 +353,7 @@ void AnimationNodeBlendSpace2DEditor::_add_menu_type(int p_index) {
 		node = Ref<AnimationNode>(an);
 	}
 
-	if (!node.is_valid()) {
+	if (node.is_null()) {
 		EditorNode::get_singleton()->show_warning(TTR("This type of node can't be used. Only root nodes are allowed."));
 		return;
 	}

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -149,7 +149,7 @@ void AnimationNodeBlendTreeEditor::update_graph() {
 		node->set_draggable(!read_only);
 
 		Ref<AnimationNode> agnode = blend_tree->get_node(E);
-		ERR_CONTINUE(!agnode.is_valid());
+		ERR_CONTINUE(agnode.is_null());
 
 		node->set_position_offset(blend_tree->get_node_position(E) * EDSCALE);
 
@@ -327,7 +327,7 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		base_name = anode->get_class();
 	} else if (p_idx == MENU_PASTE) {
 		anode = EditorSettings::get_singleton()->get_resource_clipboard();
-		ERR_FAIL_COND(!anode.is_valid());
+		ERR_FAIL_COND(anode.is_null());
 		base_name = anode->get_class();
 	} else if (!add_options[p_idx].type.is_empty()) {
 		AnimationNode *an = Object::cast_to<AnimationNode>(ClassDB::instantiate(add_options[p_idx].type));
@@ -498,7 +498,7 @@ void AnimationNodeBlendTreeEditor::_anim_selected(int p_index, const Array &p_op
 	String option = p_options[p_index];
 
 	Ref<AnimationNodeAnimation> anim = blend_tree->get_node(p_node);
-	ERR_FAIL_COND(!anim.is_valid());
+	ERR_FAIL_COND(anim.is_null());
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Set Animation"));
@@ -584,14 +584,14 @@ void AnimationNodeBlendTreeEditor::_node_selected(Object *p_node) {
 	String name = gn->get_name();
 
 	Ref<AnimationNode> anode = blend_tree->get_node(name);
-	ERR_FAIL_COND(!anode.is_valid());
+	ERR_FAIL_COND(anode.is_null());
 
 	EditorNode::get_singleton()->push_item(anode.ptr(), "", true);
 }
 
 void AnimationNodeBlendTreeEditor::_open_in_editor(const String &p_which) {
 	Ref<AnimationNode> an = blend_tree->get_node(p_which);
-	ERR_FAIL_COND(!an.is_valid());
+	ERR_FAIL_COND(an.is_null());
 	AnimationTreeEditor::get_singleton()->enter_editor(p_which);
 }
 
@@ -918,7 +918,7 @@ void AnimationNodeBlendTreeEditor::_inspect_filters(const String &p_which) {
 	filter_enabled->set_disabled(read_only);
 
 	Ref<AnimationNode> anode = blend_tree->get_node(p_which);
-	ERR_FAIL_COND(!anode.is_valid());
+	ERR_FAIL_COND(anode.is_null());
 
 	_filter_edit = anode;
 	if (!_update_filters(anode)) {

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -105,7 +105,7 @@ void AnimationLibraryEditor::_add_library_confirm() {
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
 		Ref<AnimationLibrary> al = mixer->get_animation_library(adding_animation_to_library);
-		ERR_FAIL_COND(!al.is_valid());
+		ERR_FAIL_COND(al.is_null());
 
 		Ref<Animation> anim;
 		anim.instantiate();
@@ -562,7 +562,7 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 			} break;
 			case LIB_BUTTON_PASTE: {
 				Ref<Animation> anim = EditorSettings::get_singleton()->get_resource_clipboard();
-				if (!anim.is_valid()) {
+				if (anim.is_null()) {
 					error_dialog->set_text(TTR("No animation resource in clipboard!"));
 					error_dialog->popup_centered();
 					return;
@@ -628,7 +628,7 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 		StringName anim_name = p_item->get_metadata(0);
 		Ref<AnimationLibrary> al = mixer->get_animation_library(lib_name);
 		Ref<Animation> anim = al->get_animation(anim_name);
-		ERR_FAIL_COND(!anim.is_valid());
+		ERR_FAIL_COND(anim.is_null());
 		switch (p_id) {
 			case ANIM_BUTTON_COPY: {
 				if (anim->get_name() == "") {

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -97,7 +97,7 @@ void AnimationPlayerEditor::_notification(int p_what) {
 
 					if (player->has_animation(animname)) {
 						Ref<Animation> anim = player->get_animation(animname);
-						if (!anim.is_null()) {
+						if (anim.is_valid()) {
 							frame->set_max((double)anim->get_length());
 						}
 					}
@@ -1314,7 +1314,7 @@ void AnimationPlayerEditor::_animation_duplicate() {
 
 	String current = animation->get_item_text(animation->get_selected());
 	Ref<Animation> anim = player->get_animation(current);
-	if (!anim.is_valid()) {
+	if (anim.is_null()) {
 		return;
 	}
 
@@ -1713,7 +1713,7 @@ void AnimationPlayerEditor::_prepare_onion_layers_1() {
 
 void AnimationPlayerEditor::_prepare_onion_layers_2_prolog() {
 	Ref<Animation> anim = player->get_animation(player->get_assigned_animation());
-	if (!anim.is_valid()) {
+	if (anim.is_null()) {
 		return;
 	}
 
@@ -1931,7 +1931,7 @@ Node *AnimationPlayerEditor::get_cached_root_node() const {
 
 bool AnimationPlayerEditor::_validate_tracks(const Ref<Animation> p_anim) {
 	bool is_valid = true;
-	if (!p_anim.is_valid()) {
+	if (p_anim.is_null()) {
 		return true; // There is a problem outside of the animation track.
 	}
 	int len = p_anim->get_track_count();

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -93,7 +93,7 @@ String AnimationNodeStateMachineEditor::_get_root_playback_path(String &r_node_d
 		while (!is_playable_anodesm_found) {
 			base_path = String("/").join(edited_path);
 			Ref<AnimationNodeStateMachine> anodesm = !edited_path.size() ? Ref<AnimationNode>(tree->get_root_animation_node().ptr()) : tree->get_root_animation_node()->find_node_by_path(base_path);
-			if (!anodesm.is_valid()) {
+			if (anodesm.is_null()) {
 				break;
 			} else {
 				if (anodesm->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
@@ -133,7 +133,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 	String node_directory;
 	Ref<AnimationNodeStateMachinePlayback> playback = tree->get(_get_root_playback_path(node_directory));
-	if (!playback.is_valid()) {
+	if (playback.is_null()) {
 		return;
 	}
 
@@ -344,7 +344,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			Ref<AnimationNodeStateMachine> anodesm = node;
 			Ref<AnimationNodeEndState> end_node = node;
 
-			if (state_machine->has_transition(connecting_from, connecting_to_node) && state_machine->can_edit_node(connecting_to_node) && !anodesm.is_valid()) {
+			if (state_machine->has_transition(connecting_from, connecting_to_node) && state_machine->can_edit_node(connecting_to_node) && anodesm.is_null()) {
 				EditorNode::get_singleton()->show_warning(TTR("Transition exists!"));
 				connecting = false;
 			} else {
@@ -798,7 +798,7 @@ void AnimationNodeStateMachineEditor::_add_menu_type(int p_index) {
 		base_name = type.replace_first("AnimationNode", "");
 	}
 
-	if (!node.is_valid()) {
+	if (node.is_null()) {
 		EditorNode::get_singleton()->show_warning(TTR("This type of node can't be used. Only root nodes are allowed."));
 		return;
 	}
@@ -1332,7 +1332,7 @@ void AnimationNodeStateMachineEditor::_state_machine_pos_draw_individual(const S
 	}
 
 	Ref<AnimationNodeStateMachinePlayback> playback = tree->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
-	if (!playback.is_valid() || !playback->is_playing()) {
+	if (playback.is_null() || !playback->is_playing()) {
 		return;
 	}
 
@@ -1381,7 +1381,7 @@ void AnimationNodeStateMachineEditor::_state_machine_pos_draw_all() {
 	}
 
 	Ref<AnimationNodeStateMachinePlayback> playback = tree->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
-	if (!playback.is_valid() || !playback->is_playing()) {
+	if (playback.is_null() || !playback->is_playing()) {
 		return;
 	}
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -446,7 +446,7 @@ void EditorAssetLibraryItemDownload::configure(const String &p_title, int p_asse
 	title->set_text(p_title);
 	icon->set_texture(p_preview);
 	asset_id = p_asset_id;
-	if (!p_preview.is_valid()) {
+	if (p_preview.is_null()) {
 		icon->set_texture(get_editor_theme_icon(SNAME("FileBrokenBigThumb")));
 	}
 	host = p_download_url;

--- a/editor/plugins/bone_map_editor_plugin.cpp
+++ b/editor/plugins/bone_map_editor_plugin.cpp
@@ -147,7 +147,7 @@ void BoneMapperItem::_notification(int p_what) {
 			bone_map->connect("bone_map_updated", callable_mp(this, &BoneMapperItem::_update_property));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
-			if (!bone_map.is_null() && bone_map->is_connected("bone_map_updated", callable_mp(this, &BoneMapperItem::_update_property))) {
+			if (bone_map.is_valid() && bone_map->is_connected("bone_map_updated", callable_mp(this, &BoneMapperItem::_update_property))) {
 				bone_map->disconnect("bone_map_updated", callable_mp(this, &BoneMapperItem::_update_property));
 			}
 		} break;
@@ -327,7 +327,7 @@ void BoneMapper::create_editor() {
 }
 
 void BoneMapper::update_group_idx() {
-	if (!bone_map->get_profile().is_valid()) {
+	if (bone_map->get_profile().is_null()) {
 		return;
 	}
 
@@ -412,7 +412,7 @@ void BoneMapper::recreate_editor() {
 		profile_texture->set_texture(Ref<Texture2D>());
 	}
 
-	if (!profile.is_valid()) {
+	if (profile.is_null()) {
 		return;
 	}
 
@@ -534,7 +534,7 @@ void BoneMapper::_clear_mapping_current_group() {
 #ifdef MODULE_REGEX_ENABLED
 bool BoneMapper::is_match_with_bone_name(const String &p_bone_name, const String &p_word) {
 	RegEx re = RegEx(p_word);
-	return !re.search(p_bone_name.to_lower()).is_null();
+	return re.search(p_bone_name.to_lower()).is_valid();
 }
 
 int BoneMapper::search_bone_by_name(Skeleton3D *p_skeleton, const Vector<String> &p_picklist, BoneSegregation p_segregation, int p_parent, int p_child, int p_children_count) {
@@ -628,11 +628,11 @@ BoneMapper::BoneSegregation BoneMapper::guess_bone_segregation(const String &p_b
 
 	for (uint32_t i = 0; i < left_words.size(); i++) {
 		RegEx re_l = RegEx(left_words[i]);
-		if (!re_l.search(fixed_bn).is_null()) {
+		if (re_l.search(fixed_bn).is_valid()) {
 			return BONE_SEGREGATION_LEFT;
 		}
 		RegEx re_r = RegEx(right_words[i]);
-		if (!re_r.search(fixed_bn).is_null()) {
+		if (re_r.search(fixed_bn).is_valid()) {
 			return BONE_SEGREGATION_RIGHT;
 		}
 	}
@@ -681,7 +681,7 @@ void BoneMapper::auto_mapping_process(Ref<BoneMap> &p_bone_map) {
 		bool found = false;
 		for (int i = 0; i < search_path.size(); i++) {
 			RegEx re = RegEx("root");
-			if (!re.search(skeleton->get_bone_name(search_path[i]).to_lower()).is_null()) {
+			if (re.search(skeleton->get_bone_name(search_path[i]).to_lower()).is_valid()) {
 				bone_idx = search_path[i]; // Name match is preferred.
 				found = true;
 				break;
@@ -948,7 +948,7 @@ void BoneMapper::auto_mapping_process(Ref<BoneMap> &p_bone_map) {
 			Vector<String> finger_names;
 			for (int i = 0; i < search_path.size(); i++) {
 				String bn = skeleton->get_bone_name(search_path[i]);
-				if (!finger_re.search(bn.to_lower()).is_null()) {
+				if (finger_re.search(bn.to_lower()).is_valid()) {
 					finger_names.push_back(bn);
 				}
 			}
@@ -1077,7 +1077,7 @@ void BoneMapper::auto_mapping_process(Ref<BoneMap> &p_bone_map) {
 			Vector<String> finger_names;
 			for (int i = 0; i < search_path.size(); i++) {
 				String bn = skeleton->get_bone_name(search_path[i]);
-				if (!finger_re.search(bn.to_lower()).is_null()) {
+				if (finger_re.search(bn.to_lower()).is_valid()) {
 					finger_names.push_back(bn);
 				}
 			}
@@ -1392,7 +1392,7 @@ void BoneMapper::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			clear_items();
-			if (!bone_map.is_null()) {
+			if (bone_map.is_valid()) {
 				if (bone_map->is_connected("bone_map_updated", callable_mp(this, &BoneMapper::_update_state))) {
 					bone_map->disconnect("bone_map_updated", callable_mp(this, &BoneMapper::_update_state));
 				}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4375,7 +4375,7 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 	const HashMap<Node *, Object *> &selection = editor_selection->get_selection();
 
 	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
-	ERR_FAIL_COND_MSG(!te->get_current_animation().is_valid(), "Cannot insert animation key. No animation selected.");
+	ERR_FAIL_COND_MSG(te->get_current_animation().is_null(), "Cannot insert animation key. No animation selected.");
 
 	te->make_insert_queue();
 	for (const KeyValue<Node *, Object *> &E : selection) {
@@ -6007,7 +6007,7 @@ void CanvasItemEditorViewport::_create_audio_node(Node *p_parent, const String &
 
 bool CanvasItemEditorViewport::_create_instance(Node *p_parent, const String &p_path, const Point2 &p_point) {
 	Ref<PackedScene> sdata = ResourceLoader::load(p_path);
-	if (!sdata.is_valid()) { // invalid scene
+	if (sdata.is_null()) { // invalid scene
 		return false;
 	}
 

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -400,17 +400,17 @@ void EditorPlugin::remove_undo_redo_inspector_hook_callback(Callable p_callable)
 }
 
 void EditorPlugin::add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
-	ERR_FAIL_COND(!p_parser.is_valid());
+	ERR_FAIL_COND(p_parser.is_null());
 	EditorTranslationParser::get_singleton()->add_parser(p_parser, EditorTranslationParser::CUSTOM);
 }
 
 void EditorPlugin::remove_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser) {
-	ERR_FAIL_COND(!p_parser.is_valid());
+	ERR_FAIL_COND(p_parser.is_null());
 	EditorTranslationParser::get_singleton()->remove_parser(p_parser, EditorTranslationParser::CUSTOM);
 }
 
 void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer, bool p_first_priority) {
-	ERR_FAIL_COND(!p_importer.is_valid());
+	ERR_FAIL_COND(p_importer.is_null());
 	ResourceFormatImporter::get_singleton()->add_importer(p_importer, p_first_priority);
 	// Plugins are now loaded during the first scan. It's important not to start another scan,
 	// even a deferred one, as it would cause a scan during a scan at the next main thread iteration.
@@ -420,7 +420,7 @@ void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer, 
 }
 
 void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
-	ERR_FAIL_COND(!p_importer.is_valid());
+	ERR_FAIL_COND(p_importer.is_null());
 	ResourceFormatImporter::get_singleton()->remove_importer(p_importer);
 	// Plugins are now loaded during the first scan. It's important not to start another scan,
 	// even a deferred one, as it would cause a scan during a scan at the next main thread iteration.
@@ -430,12 +430,12 @@ void EditorPlugin::remove_import_plugin(const Ref<EditorImportPlugin> &p_importe
 }
 
 void EditorPlugin::add_export_plugin(const Ref<EditorExportPlugin> &p_exporter) {
-	ERR_FAIL_COND(!p_exporter.is_valid());
+	ERR_FAIL_COND(p_exporter.is_null());
 	EditorExport::get_singleton()->add_export_plugin(p_exporter);
 }
 
 void EditorPlugin::remove_export_plugin(const Ref<EditorExportPlugin> &p_exporter) {
-	ERR_FAIL_COND(!p_exporter.is_valid());
+	ERR_FAIL_COND(p_exporter.is_null());
 	EditorExport::get_singleton()->remove_export_plugin(p_exporter);
 }
 
@@ -450,32 +450,32 @@ void EditorPlugin::remove_export_platform(const Ref<EditorExportPlatform> &p_pla
 }
 
 void EditorPlugin::add_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
-	ERR_FAIL_COND(!p_gizmo_plugin.is_valid());
+	ERR_FAIL_COND(p_gizmo_plugin.is_null());
 	Node3DEditor::get_singleton()->add_gizmo_plugin(p_gizmo_plugin);
 }
 
 void EditorPlugin::remove_node_3d_gizmo_plugin(const Ref<EditorNode3DGizmoPlugin> &p_gizmo_plugin) {
-	ERR_FAIL_COND(!p_gizmo_plugin.is_valid());
+	ERR_FAIL_COND(p_gizmo_plugin.is_null());
 	Node3DEditor::get_singleton()->remove_gizmo_plugin(p_gizmo_plugin);
 }
 
 void EditorPlugin::add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
-	ERR_FAIL_COND(!p_plugin.is_valid());
+	ERR_FAIL_COND(p_plugin.is_null());
 	EditorInspector::add_inspector_plugin(p_plugin);
 }
 
 void EditorPlugin::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
-	ERR_FAIL_COND(!p_plugin.is_valid());
+	ERR_FAIL_COND(p_plugin.is_null());
 	EditorInspector::remove_inspector_plugin(p_plugin);
 }
 
 void EditorPlugin::add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority) {
-	ERR_FAIL_COND(!p_importer.is_valid());
+	ERR_FAIL_COND(p_importer.is_null());
 	ResourceImporterScene::add_scene_importer(p_importer, p_first_priority);
 }
 
 void EditorPlugin::remove_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer) {
-	ERR_FAIL_COND(!p_importer.is_valid());
+	ERR_FAIL_COND(p_importer.is_null());
 	ResourceImporterScene::remove_scene_importer(p_importer);
 }
 

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -91,12 +91,12 @@ Ref<Texture2D> EditorTexturePreviewPlugin::generate(const Ref<Resource> &p_from,
 
 	if (tex_atlas.is_valid()) {
 		Ref<Texture2D> tex = tex_atlas->get_atlas();
-		if (!tex.is_valid()) {
+		if (tex.is_null()) {
 			return Ref<Texture2D>();
 		}
 
 		Ref<Image> atlas = tex->get_image();
-		if (!atlas.is_valid()) {
+		if (atlas.is_null()) {
 			return Ref<Texture2D>();
 		}
 
@@ -347,7 +347,7 @@ Ref<Texture2D> EditorMaterialPreviewPlugin::generate(const Ref<Resource> &p_from
 		Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
 		RS::get_singleton()->mesh_surface_set_material(sphere, 0, RID());
 
-		ERR_FAIL_COND_V(!img.is_valid(), Ref<ImageTexture>());
+		ERR_FAIL_COND_V(img.is_null(), Ref<ImageTexture>());
 
 		img->convert(Image::FORMAT_RGBA8);
 		int thumbnail_size = MAX(p_size.x, p_size.y);

--- a/editor/plugins/gizmos/mesh_instance_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/mesh_instance_3d_gizmo_plugin.cpp
@@ -61,7 +61,7 @@ void MeshInstance3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	Ref<Mesh> m = mesh->get_mesh();
 
-	if (!m.is_valid()) {
+	if (m.is_null()) {
 		return; //none
 	}
 

--- a/editor/plugins/gizmos/occluder_instance_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/occluder_instance_3d_gizmo_plugin.cpp
@@ -242,7 +242,7 @@ void OccluderInstance3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	Ref<Occluder3D> o = occluder_instance->get_occluder();
 
-	if (!o.is_valid()) {
+	if (o.is_null()) {
 		return;
 	}
 

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -128,7 +128,7 @@ void MaterialEditor::edit(Ref<Material> p_material, const Ref<Environment> &p_en
 	camera->set_environment(p_env);
 
 	is_unsupported_shader_mode = false;
-	if (!material.is_null()) {
+	if (material.is_valid()) {
 		Shader::Mode mode = p_material->get_shader_mode();
 		switch (mode) {
 			case Shader::MODE_CANVAS_ITEM:
@@ -449,7 +449,7 @@ bool StandardMaterial3DConversionPlugin::handles(const Ref<Resource> &p_resource
 
 Ref<Resource> StandardMaterial3DConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<StandardMaterial3D> mat = p_resource;
-	ERR_FAIL_COND_V(!mat.is_valid(), Ref<Resource>());
+	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -495,7 +495,7 @@ bool ORMMaterial3DConversionPlugin::handles(const Ref<Resource> &p_resource) con
 
 Ref<Resource> ORMMaterial3DConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<ORMMaterial3D> mat = p_resource;
-	ERR_FAIL_COND_V(!mat.is_valid(), Ref<Resource>());
+	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -541,7 +541,7 @@ bool ParticleProcessMaterialConversionPlugin::handles(const Ref<Resource> &p_res
 
 Ref<Resource> ParticleProcessMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<ParticleProcessMaterial> mat = p_resource;
-	ERR_FAIL_COND_V(!mat.is_valid(), Ref<Resource>());
+	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -580,7 +580,7 @@ bool CanvasItemMaterialConversionPlugin::handles(const Ref<Resource> &p_resource
 
 Ref<Resource> CanvasItemMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<CanvasItemMaterial> mat = p_resource;
-	ERR_FAIL_COND_V(!mat.is_valid(), Ref<Resource>());
+	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -619,7 +619,7 @@ bool ProceduralSkyMaterialConversionPlugin::handles(const Ref<Resource> &p_resou
 
 Ref<Resource> ProceduralSkyMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<ProceduralSkyMaterial> mat = p_resource;
-	ERR_FAIL_COND_V(!mat.is_valid(), Ref<Resource>());
+	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -658,7 +658,7 @@ bool PanoramaSkyMaterialConversionPlugin::handles(const Ref<Resource> &p_resourc
 
 Ref<Resource> PanoramaSkyMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<PanoramaSkyMaterial> mat = p_resource;
-	ERR_FAIL_COND_V(!mat.is_valid(), Ref<Resource>());
+	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -697,7 +697,7 @@ bool PhysicalSkyMaterialConversionPlugin::handles(const Ref<Resource> &p_resourc
 
 Ref<Resource> PhysicalSkyMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<PhysicalSkyMaterial> mat = p_resource;
-	ERR_FAIL_COND_V(!mat.is_valid(), Ref<Resource>());
+	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -736,7 +736,7 @@ bool FogMaterialConversionPlugin::handles(const Ref<Resource> &p_resource) const
 
 Ref<Resource> FogMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<FogMaterial> mat = p_resource;
-	ERR_FAIL_COND_V(!mat.is_valid(), Ref<Resource>());
+	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -240,7 +240,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 		} break;
 		case MENU_OPTION_CREATE_UV2: {
 			Ref<Mesh> mesh2 = node->get_mesh();
-			if (!mesh.is_valid()) {
+			if (mesh.is_null()) {
 				err_dialog->set_text(TTR("No mesh to unwrap."));
 				err_dialog->popup_centered();
 				return;
@@ -281,7 +281,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				ur->commit_action();
 			} else {
 				Ref<ArrayMesh> array_mesh = mesh2;
-				if (!array_mesh.is_valid()) {
+				if (array_mesh.is_null()) {
 					err_dialog->set_text(TTR("Contained Mesh is not of type ArrayMesh."));
 					err_dialog->popup_centered();
 					return;
@@ -337,7 +337,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 		} break;
 		case MENU_OPTION_DEBUG_UV1: {
 			Ref<Mesh> mesh2 = node->get_mesh();
-			if (!mesh2.is_valid()) {
+			if (mesh2.is_null()) {
 				err_dialog->set_text(TTR("No mesh to debug."));
 				err_dialog->popup_centered();
 				return;
@@ -346,7 +346,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 		} break;
 		case MENU_OPTION_DEBUG_UV2: {
 			Ref<Mesh> mesh2 = node->get_mesh();
-			if (!mesh2.is_valid()) {
+			if (mesh2.is_null()) {
 				err_dialog->set_text(TTR("No mesh to debug."));
 				err_dialog->popup_centered();
 				return;
@@ -383,7 +383,7 @@ struct MeshInstance3DEditorEdgeSort {
 
 void MeshInstance3DEditor::_create_uv_lines(int p_layer) {
 	Ref<Mesh> mesh = node->get_mesh();
-	ERR_FAIL_COND(!mesh.is_valid());
+	ERR_FAIL_COND(mesh.is_null());
 
 	HashSet<MeshInstance3DEditorEdgeSort, MeshInstance3DEditorEdgeSort> edges;
 	uv_lines.clear();

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -198,7 +198,7 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 			shape_transform *= static_body_node->get_transform() * static_body_node->shape_owner_get_transform(E);
 			for (int k = 0; k < static_body_node->shape_owner_get_shape_count(E); k++) {
 				Ref<Shape3D> collision_shape = static_body_node->shape_owner_get_shape(E, k);
-				if (!collision_shape.is_valid()) {
+				if (collision_shape.is_null()) {
 					continue;
 				}
 				MeshLibrary::ShapeData shape_data;
@@ -216,7 +216,7 @@ void MeshLibraryEditor::_import_scene_parse_node(Ref<MeshLibrary> p_library, Has
 			continue;
 		}
 		Ref<NavigationMesh> navigation_mesh = navigation_region_node->get_navigation_mesh();
-		if (!navigation_mesh.is_null()) {
+		if (navigation_mesh.is_valid()) {
 			Transform3D navigation_mesh_transform = navigation_region_node->get_transform();
 			p_library->set_item_navigation_mesh(item_id, navigation_mesh);
 			p_library->set_item_navigation_mesh_transform(item_id, navigation_mesh_transform);

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -110,7 +110,7 @@ void MultiMeshEditor::_populate() {
 
 	MeshInstance3D *ss_instance = Object::cast_to<MeshInstance3D>(ss_node);
 
-	if (!ss_instance || !ss_instance->get_mesh().is_valid()) {
+	if (!ss_instance || ss_instance->get_mesh().is_null()) {
 		err_dialog->set_text(TTR("Surface source is invalid (no geometry)."));
 		err_dialog->popup_centered();
 		return;

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -247,7 +247,7 @@ void NavigationPolygonEditor::_rebake_timer_timeout() {
 		return;
 	}
 	Ref<NavigationPolygon> navigation_polygon = node->get_navigation_polygon();
-	if (!navigation_polygon.is_valid()) {
+	if (navigation_polygon.is_null()) {
 		return;
 	}
 

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -227,7 +227,7 @@ void EditorNode3DGizmo::Instance::create_instance(Node3D *p_base, bool p_hidden)
 
 void EditorNode3DGizmo::add_mesh(const Ref<Mesh> &p_mesh, const Ref<Material> &p_material, const Transform3D &p_xform, const Ref<SkinReference> &p_skin_reference) {
 	ERR_FAIL_NULL(spatial_node);
-	ERR_FAIL_COND_MSG(!p_mesh.is_valid(), "EditorNode3DGizmo.add_mesh() requires a valid Mesh resource.");
+	ERR_FAIL_COND_MSG(p_mesh.is_null(), "EditorNode3DGizmo.add_mesh() requires a valid Mesh resource.");
 
 	Instance ins;
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -823,7 +823,7 @@ ObjectID Node3DEditorViewport::_select_ray(const Point2 &p_pos) const {
 		for (int j = 0; j < gizmos.size(); j++) {
 			Ref<EditorNode3DGizmo> seg = gizmos[j];
 
-			if ((!seg.is_valid()) || found_gizmos.has(seg)) {
+			if (seg.is_null() || found_gizmos.has(seg)) {
 				continue;
 			}
 
@@ -887,7 +887,7 @@ void Node3DEditorViewport::_find_items_at_pos(const Point2 &p_pos, Vector<_RayRe
 		for (int j = 0; j < gizmos.size(); j++) {
 			Ref<EditorNode3DGizmo> seg = gizmos[j];
 
-			if (!seg.is_valid()) {
+			if (seg.is_null()) {
 				continue;
 			}
 
@@ -1004,7 +1004,7 @@ void Node3DEditorViewport::_select_region() {
 			Vector<Ref<Node3DGizmo>> gizmos = single_selected->get_gizmos();
 			for (int j = 0; j < gizmos.size(); j++) {
 				Ref<EditorNode3DGizmo> seg = gizmos[j];
-				if (!seg.is_valid()) {
+				if (seg.is_null()) {
 					continue;
 				}
 
@@ -1104,7 +1104,7 @@ void Node3DEditorViewport::_select_region() {
 		Vector<Ref<Node3DGizmo>> gizmos = sp->get_gizmos();
 		for (int j = 0; j < gizmos.size(); j++) {
 			Ref<EditorNode3DGizmo> seg = gizmos[j];
-			if (!seg.is_valid()) {
+			if (seg.is_null()) {
 				continue;
 			}
 
@@ -1851,7 +1851,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						for (int i = 0; i < gizmos.size(); i++) {
 							Ref<EditorNode3DGizmo> seg = gizmos[i];
 
-							if ((!seg.is_valid())) {
+							if (seg.is_null()) {
 								continue;
 							}
 
@@ -1888,7 +1888,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 						for (int i = 0; i < gizmos.size(); i++) {
 							Ref<EditorNode3DGizmo> seg = gizmos[i];
 
-							if ((!seg.is_valid())) {
+							if (seg.is_null()) {
 								continue;
 							}
 
@@ -2054,7 +2054,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 			for (int i = 0; i < gizmos.size(); i++) {
 				Ref<EditorNode3DGizmo> seg = gizmos[i];
-				if (!seg.is_valid()) {
+				if (seg.is_null()) {
 					continue;
 				}
 
@@ -2079,7 +2079,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		if (spatial_editor->get_current_hover_gizmo().is_null() && !m->get_button_mask().has_flag(MouseButtonMask::LEFT) && !_edit.gizmo.is_valid()) {
+		if (spatial_editor->get_current_hover_gizmo().is_null() && !m->get_button_mask().has_flag(MouseButtonMask::LEFT) && _edit.gizmo.is_null()) {
 			_transform_gizmo_select(_edit.mouse_pos, true);
 		}
 
@@ -4715,7 +4715,7 @@ bool Node3DEditorViewport::_create_instance(Node *p_parent, const String &p_path
 
 			instantiated_scene = mesh_instance;
 		} else {
-			if (!scene.is_valid()) { // invalid scene
+			if (scene.is_null()) { // invalid scene
 				return false;
 			} else {
 				instantiated_scene = scene->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE);
@@ -6600,7 +6600,7 @@ void Node3DEditor::edit(Node3D *p_spatial) {
 			Vector<Ref<Node3DGizmo>> gizmos = selected->get_gizmos();
 			for (int i = 0; i < gizmos.size(); i++) {
 				Ref<EditorNode3DGizmo> seg = gizmos[i];
-				if (!seg.is_valid()) {
+				if (seg.is_null()) {
 					continue;
 				}
 				seg->set_selected(false);
@@ -6624,7 +6624,7 @@ void Node3DEditor::edit(Node3D *p_spatial) {
 			Vector<Ref<Node3DGizmo>> gizmos = selected->get_gizmos();
 			for (int i = 0; i < gizmos.size(); i++) {
 				Ref<EditorNode3DGizmo> seg = gizmos[i];
-				if (!seg.is_valid()) {
+				if (seg.is_null()) {
 					continue;
 				}
 				seg->set_selected(true);
@@ -7831,7 +7831,7 @@ void Node3DEditor::_selection_changed() {
 		Vector<Ref<Node3DGizmo>> gizmos = selected->get_gizmos();
 		for (int i = 0; i < gizmos.size(); i++) {
 			Ref<EditorNode3DGizmo> seg = gizmos[i];
-			if (!seg.is_valid()) {
+			if (seg.is_null()) {
 				continue;
 			}
 			seg->set_selected(false);

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -142,7 +142,7 @@ void ResourcePreloaderEditor::_remove_resource(const String &p_to_remove) {
 
 void ResourcePreloaderEditor::_paste_pressed() {
 	Ref<Resource> r = EditorSettings::get_singleton()->get_resource_clipboard();
-	if (!r.is_valid()) {
+	if (r.is_null()) {
 		dialog->set_text(TTR("Resource clipboard is empty!"));
 		dialog->set_title(TTR("Error!"));
 		dialog->set_ok_button_text(TTR("Close"));
@@ -261,7 +261,7 @@ Variant ResourcePreloaderEditor::get_drag_data_fw(const Point2 &p_point, Control
 	String name = ti->get_metadata(0);
 
 	Ref<Resource> res = preloader->get_resource(name);
-	if (!res.is_valid()) {
+	if (res.is_null()) {
 		return Variant();
 	}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1373,7 +1373,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				}
 
 				Ref<Resource> scr = ResourceLoader::load(path);
-				if (!scr.is_valid()) {
+				if (scr.is_null()) {
 					EditorNode::get_singleton()->show_warning(TTR("Could not load file at:") + "\n\n" + path, TTR("Error!"));
 					file_dialog_option = -1;
 					return;
@@ -2841,7 +2841,7 @@ void ScriptEditor::_reload_scripts(bool p_refresh_only) {
 			Ref<Script> scr = edited_res;
 			if (scr.is_valid()) {
 				Ref<Script> rel_scr = ResourceLoader::load(scr->get_path(), scr->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
-				ERR_CONTINUE(!rel_scr.is_valid());
+				ERR_CONTINUE(rel_scr.is_null());
 				scr->set_source_code(rel_scr->get_source_code());
 				scr->set_last_modified_time(rel_scr->get_last_modified_time());
 				scr->reload(true);
@@ -2852,7 +2852,7 @@ void ScriptEditor::_reload_scripts(bool p_refresh_only) {
 			Ref<JSON> json = edited_res;
 			if (json.is_valid()) {
 				Ref<JSON> rel_json = ResourceLoader::load(json->get_path(), json->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
-				ERR_CONTINUE(!rel_json.is_valid());
+				ERR_CONTINUE(rel_json.is_null());
 				json->parse(rel_json->get_parsed_text(), true);
 				json->set_last_modified_time(rel_json->get_last_modified_time());
 			}
@@ -2888,7 +2888,7 @@ Ref<Resource> ScriptEditor::open_file(const String &p_file) {
 	ResourceLoader::get_recognized_extensions_for_type("JSON", &extensions);
 	if (extensions.find(p_file.get_extension())) {
 		Ref<Resource> scr = ResourceLoader::load(p_file);
-		if (!scr.is_valid()) {
+		if (scr.is_null()) {
 			EditorNode::get_singleton()->show_warning(TTR("Could not load file at:") + "\n\n" + p_file, TTR("Error!"));
 			return Ref<Resource>();
 		}
@@ -2925,7 +2925,7 @@ void ScriptEditor::_editor_stop() {
 void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const PackedStringArray &p_args) {
 	ERR_FAIL_NULL(p_obj);
 	Ref<Script> scr = p_obj->get_script();
-	ERR_FAIL_COND(!scr.is_valid());
+	ERR_FAIL_COND(scr.is_null());
 
 	if (!scr->get_language()->can_make_function()) {
 		return;
@@ -3143,7 +3143,7 @@ Variant ScriptEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 		preview_icon = get_editor_theme_icon(SNAME("Help"));
 	}
 
-	if (!preview_icon.is_null()) {
+	if (preview_icon.is_valid()) {
 		TextureRect *tf = memnew(TextureRect);
 		tf->set_texture(preview_icon);
 		tf->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
@@ -3412,12 +3412,10 @@ void ScriptEditor::_make_script_list_context_menu() {
 	context_menu->add_separator();
 	if (se) {
 		Ref<Script> scr = se->get_edited_resource();
-		if (scr.is_valid()) {
-			if (!scr.is_null() && scr->is_tool()) {
-				context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/reload_script_soft"), FILE_TOOL_RELOAD_SOFT);
-				context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/run_file"), FILE_RUN);
-				context_menu->add_separator();
-			}
+		if (scr.is_valid() && scr->is_tool()) {
+			context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/reload_script_soft"), FILE_TOOL_RELOAD_SOFT);
+			context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/run_file"), FILE_RUN);
+			context_menu->add_separator();
 		}
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/copy_path"), FILE_COPY_PATH);
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/show_in_file_system"), SHOW_IN_FILE_SYSTEM);
@@ -3492,7 +3490,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 
 		if (extensions.find(path.get_extension())) {
 			Ref<Resource> scr = ResourceLoader::load(path);
-			if (!scr.is_valid()) {
+			if (scr.is_null()) {
 				continue;
 			}
 			if (!edit(scr, false)) {
@@ -3501,7 +3499,7 @@ void ScriptEditor::set_window_layout(Ref<ConfigFile> p_layout) {
 		} else {
 			Error error;
 			Ref<TextFile> text_file = _load_text_file(path, &error);
-			if (error != OK || !text_file.is_valid()) {
+			if (error != OK || text_file.is_null()) {
 				continue;
 			}
 			if (!edit(text_file, false)) {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -210,7 +210,7 @@ void ScriptTextEditor::_load_theme_settings() {
 	}
 
 	theme_loaded = true;
-	if (!script.is_null()) {
+	if (script.is_valid()) {
 		_set_theme_for_script();
 	}
 }
@@ -315,7 +315,7 @@ void ScriptTextEditor::_error_clicked(const Variant &p_line) {
 			goto_line_centered(line, column);
 		} else {
 			Ref<Resource> scr = ResourceLoader::load(path);
-			if (!scr.is_valid()) {
+			if (scr.is_null()) {
 				EditorNode::get_singleton()->show_warning(TTR("Could not load file at:") + "\n\n" + path, TTR("Error!"));
 			} else {
 				int corrected_column = column;
@@ -854,7 +854,7 @@ void ScriptEditor::_update_modified_scripts_for_external_editor(Ref<Script> p_fo
 
 		if (last_date != date) {
 			Ref<Script> rel_scr = ResourceLoader::load(scr->get_path(), scr->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
-			ERR_CONTINUE(!rel_scr.is_valid());
+			ERR_CONTINUE(rel_scr.is_null());
 			scr->set_source_code(rel_scr->get_source_code());
 			scr->set_last_modified_time(rel_scr->get_last_modified_time());
 			scr->update_exports();
@@ -1280,7 +1280,7 @@ void ScriptTextEditor::_update_connected_methods() {
 				// There is a chance that the method is inherited from another script.
 				bool found_inherited_function = false;
 				Ref<Script> inherited_script = script->get_base_script();
-				while (!inherited_script.is_null()) {
+				while (inherited_script.is_valid()) {
 					if (inherited_script->has_method(method)) {
 						found_inherited_function = true;
 						break;
@@ -1315,7 +1315,7 @@ void ScriptTextEditor::_update_connected_methods() {
 		String found_base_class;
 		StringName base_class = script->get_instance_base_type();
 		Ref<Script> inherited_script = script->get_base_script();
-		while (!inherited_script.is_null()) {
+		while (inherited_script.is_valid()) {
 			if (inherited_script->has_method(name)) {
 				found_base_class = "script:" + inherited_script->get_path();
 				break;
@@ -1411,7 +1411,7 @@ void ScriptTextEditor::_gutter_clicked(int p_line, int p_gutter) {
 		if (base_class_split[0] == "script") {
 			// Go to function declaration.
 			Ref<Script> base_script = ResourceLoader::load(base_class_split[1]);
-			ERR_FAIL_COND(!base_script.is_valid());
+			ERR_FAIL_COND(base_script.is_null());
 			emit_signal(SNAME("go_to_method"), base_script, method);
 		} else if (base_class_split[0] == "builtin") {
 			// Open method documentation.

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -615,7 +615,7 @@ Variant ShaderEditorPlugin::get_drag_data_fw(const Point2 &p_point, Control *p_f
 	String preview_name = shader_list->get_item_text(idx);
 	Ref<Texture2D> preview_icon = shader_list->get_item_icon(idx);
 
-	if (!preview_icon.is_null()) {
+	if (preview_icon.is_valid()) {
 		TextureRect *tf = memnew(TextureRect);
 		tf->set_texture(preview_icon);
 		tf->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -1338,11 +1338,11 @@ void Skeleton3DEditor::_subgizmo_selection_change() {
 		Vector<Ref<Node3DGizmo>> gizmos = skeleton->get_gizmos();
 		for (int i = 0; i < gizmos.size(); i++) {
 			Ref<EditorNode3DGizmo> gizmo = gizmos[i];
-			if (!gizmo.is_valid()) {
+			if (gizmo.is_null()) {
 				continue;
 			}
 			Ref<Skeleton3DGizmoPlugin> plugin = gizmo->get_plugin();
-			if (!plugin.is_valid()) {
+			if (plugin.is_null()) {
 				continue;
 			}
 			skeleton->set_subgizmo_selection(gizmo, selected, skeleton->get_bone_global_pose(selected));

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -459,7 +459,7 @@ void Sprite2DEditor::_debug_uv_draw() {
 	debug_uv->draw_set_transform(-draw_offset * draw_zoom, 0, Vector2(draw_zoom, draw_zoom));
 
 	Ref<Texture2D> tex = node->get_texture();
-	ERR_FAIL_COND(!tex.is_valid());
+	ERR_FAIL_COND(tex.is_null());
 
 	debug_uv->draw_texture(tex, Point2());
 
@@ -480,7 +480,7 @@ void Sprite2DEditor::_debug_uv_draw() {
 
 void Sprite2DEditor::_center_view() {
 	Ref<Texture2D> tex = node->get_texture();
-	ERR_FAIL_COND(!tex.is_valid());
+	ERR_FAIL_COND(tex.is_null());
 	Vector2 zoom_factor = (debug_uv->get_size() - Vector2(1, 1) * 50 * EDSCALE) / tex->get_size();
 	zoom_widget->set_zoom(MIN(zoom_factor.x, zoom_factor.y));
 	// Recalculate scroll limits.
@@ -517,7 +517,7 @@ void Sprite2DEditor::_update_zoom_and_pan(bool p_zoom_at_center) {
 	}
 
 	Ref<Texture2D> tex = node->get_texture();
-	ERR_FAIL_COND(!tex.is_valid());
+	ERR_FAIL_COND(tex.is_null());
 
 	Point2 min_corner;
 	Point2 max_corner = tex->get_size();

--- a/editor/plugins/text_shader_editor.cpp
+++ b/editor/plugins/text_shader_editor.cpp
@@ -867,7 +867,7 @@ void TextShaderEditor::_check_for_external_edit() {
 
 void TextShaderEditor::_reload_shader_from_disk() {
 	Ref<Shader> rel_shader = ResourceLoader::load(shader->get_path(), shader->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
-	ERR_FAIL_COND(!rel_shader.is_valid());
+	ERR_FAIL_COND(rel_shader.is_null());
 
 	code_editor->set_block_shader_changed(true);
 	shader->set_code(rel_shader->get_code());
@@ -878,7 +878,7 @@ void TextShaderEditor::_reload_shader_from_disk() {
 
 void TextShaderEditor::_reload_shader_include_from_disk() {
 	Ref<ShaderInclude> rel_shader_include = ResourceLoader::load(shader_inc->get_path(), shader_inc->get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
-	ERR_FAIL_COND(!rel_shader_include.is_valid());
+	ERR_FAIL_COND(rel_shader_include.is_null());
 
 	code_editor->set_block_shader_changed(true);
 	shader_inc->set_code(rel_shader_include->get_code());

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -165,13 +165,13 @@ void Texture3DEditor::_update_gui() {
 }
 
 void Texture3DEditor::edit(Ref<Texture3D> p_texture) {
-	if (!texture.is_null()) {
+	if (texture.is_valid()) {
 		texture->disconnect_changed(callable_mp(this, &Texture3DEditor::_texture_changed));
 	}
 
 	texture = p_texture;
 
-	if (!texture.is_null()) {
+	if (texture.is_valid()) {
 		if (shader.is_null()) {
 			_make_shaders();
 		}
@@ -235,7 +235,7 @@ Texture3DEditor::Texture3DEditor() {
 }
 
 Texture3DEditor::~Texture3DEditor() {
-	if (!texture.is_null()) {
+	if (texture.is_valid()) {
 		texture->disconnect_changed(callable_mp(this, &Texture3DEditor::_texture_changed));
 	}
 }

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -256,13 +256,13 @@ void TextureLayeredEditor::_texture_rect_update_area() {
 }
 
 void TextureLayeredEditor::edit(Ref<TextureLayered> p_texture) {
-	if (!texture.is_null()) {
+	if (texture.is_valid()) {
 		texture->disconnect_changed(callable_mp(this, &TextureLayeredEditor::_texture_changed));
 	}
 
 	texture = p_texture;
 
-	if (!texture.is_null()) {
+	if (texture.is_valid()) {
 		if (shaders[0].is_null()) {
 			_make_shaders();
 		}

--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -177,7 +177,7 @@ void AtlasMergingDialog::_update_texture() {
 }
 
 void AtlasMergingDialog::_merge_confirmed(const String &p_path) {
-	ERR_FAIL_COND(!merged.is_valid());
+	ERR_FAIL_COND(merged.is_null());
 
 	Ref<ImageTexture> output_image_texture = merged->get_texture();
 	output_image_texture->get_image()->save_png(p_path);
@@ -269,7 +269,7 @@ void AtlasMergingDialog::_notification(int p_what) {
 }
 
 void AtlasMergingDialog::update_tile_set(Ref<TileSet> p_tile_set) {
-	ERR_FAIL_COND(!p_tile_set.is_valid());
+	ERR_FAIL_COND(p_tile_set.is_null());
 	tile_set = p_tile_set;
 
 	atlas_merging_atlases_list->clear();

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -513,7 +513,7 @@ Vector2i TileAtlasView::get_atlas_tile_coords_at_pos(const Vector2 p_pos, bool p
 	}
 
 	Ref<Texture2D> texture = tile_set_atlas_source->get_texture();
-	if (!texture.is_valid()) {
+	if (texture.is_null()) {
 		return TileSetSource::INVALID_ATLAS_COORDS;
 	}
 

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -64,7 +64,7 @@ void TileDataEditor::_tile_set_changed_deferred_update() {
 }
 
 TileData *TileDataEditor::_get_tile_data(TileMapCell p_cell) {
-	ERR_FAIL_COND_V(!tile_set.is_valid(), nullptr);
+	ERR_FAIL_COND_V(tile_set.is_null(), nullptr);
 	ERR_FAIL_COND_V(!tile_set->has_source(p_cell.source_id), nullptr);
 
 	TileData *td = nullptr;
@@ -129,7 +129,7 @@ void DummyObject::clear_dummy_properties() {
 }
 
 void GenericTilePolygonEditor::_base_control_draw() {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
@@ -452,7 +452,7 @@ void GenericTilePolygonEditor::_grab_polygon_segment_point(Vector2 p_pos, const 
 }
 
 void GenericTilePolygonEditor::_snap_to_tile_shape(Point2 &r_point, float &r_current_snapped_dist, float p_snap_dist) {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	Vector<Point2> polygon = tile_set->get_tile_shape_polygon();
 	for (int i = 0; i < polygon.size(); i++) {
@@ -751,7 +751,7 @@ void GenericTilePolygonEditor::set_use_undo_redo(bool p_use_undo_redo) {
 }
 
 void GenericTilePolygonEditor::set_tile_set(Ref<TileSet> p_tile_set) {
-	ERR_FAIL_COND(!p_tile_set.is_valid());
+	ERR_FAIL_COND(p_tile_set.is_null());
 	if (tile_set == p_tile_set) {
 		return;
 	}
@@ -1852,7 +1852,7 @@ void TileDataCollisionEditor::draw_over_tile(CanvasItem *p_canvas_item, Transfor
 }
 
 void TileDataTerrainsEditor::_update_terrain_selector() {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	// Update the terrain set selector.
 	Vector<String> options;
@@ -1905,7 +1905,7 @@ void TileDataTerrainsEditor::_property_value_changed(const StringName &p_propert
 }
 
 void TileDataTerrainsEditor::_tile_set_changed() {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	// Fix if wrong values are selected.
 	int terrain_set = int(dummy_object->get("terrain_set"));
@@ -1923,7 +1923,7 @@ void TileDataTerrainsEditor::_tile_set_changed() {
 }
 
 void TileDataTerrainsEditor::forward_draw_over_atlas(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_set_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	// Draw the hovered terrain bit, or the whole tile if it has the wrong terrain set.
 	Vector2i hovered_coords = TileSetSource::INVALID_ATLAS_COORDS;
@@ -2110,7 +2110,7 @@ void TileDataTerrainsEditor::forward_draw_over_atlas(TileAtlasView *p_tile_atlas
 }
 
 void TileDataTerrainsEditor::forward_draw_over_alternatives(TileAtlasView *p_tile_atlas_view, TileSetAtlasSource *p_tile_set_atlas_source, CanvasItem *p_canvas_item, Transform2D p_transform) {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	// Draw the hovered terrain bit, or the whole tile if it has the wrong terrain set.
 	Vector2i hovered_coords = TileSetSource::INVALID_ATLAS_COORDS;

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -221,7 +221,7 @@ void TileMapLayerEditorTilesPlugin::_update_tile_set_sources_list() {
 		if (item_text.is_empty()) {
 			item_text = vformat(TTR("Unknown Type Source (ID: %d)"), source_id);
 		}
-		if (!texture.is_valid()) {
+		if (texture.is_null()) {
 			texture = missing_atlas_texture_icon;
 		}
 

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
@@ -318,7 +318,7 @@ void TileProxiesManagerDialog::_bind_methods() {
 }
 
 void TileProxiesManagerDialog::update_tile_set(Ref<TileSet> p_tile_set) {
-	ERR_FAIL_COND(!p_tile_set.is_valid());
+	ERR_FAIL_COND(p_tile_set.is_null());
 	tile_set = p_tile_set;
 	commited_actions_count = 0;
 	_update_lists();

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -86,7 +86,7 @@ bool TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::_set(const StringN
 }
 
 bool TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::_get(const StringName &p_name, Variant &r_ret) const {
-	if (!tile_set_atlas_source.is_valid()) {
+	if (tile_set_atlas_source.is_null()) {
 		return false;
 	}
 	if (p_name == "id") {
@@ -119,7 +119,7 @@ void TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::_bind_methods() {
 }
 
 void TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::edit(Ref<TileSet> p_tile_set, Ref<TileSetAtlasSource> p_tile_set_atlas_source, int p_source_id) {
-	ERR_FAIL_COND(!p_tile_set_atlas_source.is_valid());
+	ERR_FAIL_COND(p_tile_set_atlas_source.is_null());
 	ERR_FAIL_COND(p_source_id < 0);
 	ERR_FAIL_COND(p_tile_set.is_valid() && p_tile_set->get_source(p_source_id) != p_tile_set_atlas_source);
 
@@ -148,7 +148,7 @@ void TileSetAtlasSourceEditor::TileSetAtlasSourceProxyObject::edit(Ref<TileSet> 
 
 // -- Proxy object used by the tile inspector --
 bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(const StringName &p_name, const Variant &p_value) {
-	if (!tile_set_atlas_source.is_valid()) {
+	if (tile_set_atlas_source.is_null()) {
 		return false;
 	}
 
@@ -305,7 +305,7 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_set(const StringName &p_na
 }
 
 bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_get(const StringName &p_name, Variant &r_ret) const {
-	if (!tile_set_atlas_source.is_valid()) {
+	if (tile_set_atlas_source.is_null()) {
 		return false;
 	}
 
@@ -392,7 +392,7 @@ bool TileSetAtlasSourceEditor::AtlasTileProxyObject::_get(const StringName &p_na
 }
 
 void TileSetAtlasSourceEditor::AtlasTileProxyObject::_get_property_list(List<PropertyInfo> *p_list) const {
-	if (!tile_set_atlas_source.is_valid()) {
+	if (tile_set_atlas_source.is_null()) {
 		return;
 	}
 
@@ -502,7 +502,7 @@ void TileSetAtlasSourceEditor::AtlasTileProxyObject::_get_property_list(List<Pro
 }
 
 void TileSetAtlasSourceEditor::AtlasTileProxyObject::edit(Ref<TileSetAtlasSource> p_tile_set_atlas_source, const RBSet<TileSelection> &p_tiles) {
-	ERR_FAIL_COND(!p_tile_set_atlas_source.is_valid());
+	ERR_FAIL_COND(p_tile_set_atlas_source.is_null());
 	ERR_FAIL_COND(p_tiles.is_empty());
 	for (const TileSelection &E : p_tiles) {
 		ERR_FAIL_COND(E.tile == TileSetSource::INVALID_ATLAS_COORDS);
@@ -2162,7 +2162,7 @@ Vector2i TileSetAtlasSourceEditor::_get_drag_offset_tile_coords(const Vector2i &
 }
 
 void TileSetAtlasSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetAtlasSource *p_tile_set_atlas_source, int p_source_id) {
-	ERR_FAIL_COND(!p_tile_set.is_valid());
+	ERR_FAIL_COND(p_tile_set.is_null());
 	ERR_FAIL_NULL(p_tile_set_atlas_source);
 	ERR_FAIL_COND(p_source_id < 0);
 	ERR_FAIL_COND(p_tile_set->get_source(p_source_id) != p_tile_set_atlas_source);

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -48,7 +48,7 @@
 TileSetEditor *TileSetEditor::singleton = nullptr;
 
 void TileSetEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	if (!_can_drop_data_fw(p_point, p_data, p_from)) {
 		return;
@@ -63,7 +63,7 @@ void TileSetEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 }
 
 bool TileSetEditor::_can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-	ERR_FAIL_COND_V(!tile_set.is_valid(), false);
+	ERR_FAIL_COND_V(tile_set.is_null(), false);
 
 	if (read_only) {
 		return false;
@@ -202,7 +202,7 @@ void TileSetEditor::_update_sources_list(int force_selected_id) {
 		if (item_text.is_empty()) {
 			item_text = vformat(TTR("Unknown Type Source (ID: %d)"), source_id);
 		}
-		if (!texture.is_valid()) {
+		if (texture.is_null()) {
 			texture = missing_texture_texture;
 		}
 
@@ -240,7 +240,7 @@ void TileSetEditor::_update_sources_list(int force_selected_id) {
 }
 
 void TileSetEditor::_source_selected(int p_source_index) {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	// Update the selected source.
 	sources_delete_button->set_disabled(p_source_index < 0 || read_only);
@@ -272,7 +272,7 @@ void TileSetEditor::_source_selected(int p_source_index) {
 }
 
 void TileSetEditor::_source_delete_pressed() {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	// Update the selected source.
 	int to_delete = sources_list->get_item_metadata(sources_list->get_current());
@@ -290,7 +290,7 @@ void TileSetEditor::_source_delete_pressed() {
 }
 
 void TileSetEditor::_source_add_id_pressed(int p_id_pressed) {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	switch (p_id_pressed) {
 		case 0: {
@@ -328,7 +328,7 @@ void TileSetEditor::_source_add_id_pressed(int p_id_pressed) {
 }
 
 void TileSetEditor::_sources_advanced_menu_id_pressed(int p_id_pressed) {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	switch (p_id_pressed) {
 		case 0: {
@@ -405,7 +405,7 @@ void TileSetEditor::_notification(int p_what) {
 }
 
 void TileSetEditor::_patterns_item_list_gui_input(const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	if (EditorNode::get_singleton()->is_resource_read_only(tile_set)) {
 		return;
@@ -436,7 +436,7 @@ void TileSetEditor::_pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Tex
 }
 
 void TileSetEditor::_update_patterns_list() {
-	ERR_FAIL_COND(!tile_set.is_valid());
+	ERR_FAIL_COND(tile_set.is_null());
 
 	// Recreate the items.
 	patterns_item_list->clear();

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -104,7 +104,7 @@ void TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::_b
 }
 
 void TileSetScenesCollectionSourceEditor::TileSetScenesCollectionProxyObject::edit(Ref<TileSet> p_tile_set, TileSetScenesCollectionSource *p_tile_set_scenes_collection_source, int p_source_id) {
-	ERR_FAIL_COND(!p_tile_set.is_valid());
+	ERR_FAIL_COND(p_tile_set.is_null());
 	ERR_FAIL_NULL(p_tile_set_scenes_collection_source);
 	ERR_FAIL_COND(p_source_id < 0);
 	ERR_FAIL_COND(p_tile_set->get_source(p_source_id) != p_tile_set_scenes_collection_source);
@@ -398,7 +398,7 @@ void TileSetScenesCollectionSourceEditor::_notification(int p_what) {
 }
 
 void TileSetScenesCollectionSourceEditor::edit(Ref<TileSet> p_tile_set, TileSetScenesCollectionSource *p_tile_set_scenes_collection_source, int p_source_id) {
-	ERR_FAIL_COND(!p_tile_set.is_valid());
+	ERR_FAIL_COND(p_tile_set.is_null());
 	ERR_FAIL_NULL(p_tile_set_scenes_collection_source);
 	ERR_FAIL_COND(p_source_id < 0);
 	ERR_FAIL_COND(p_tile_set->get_source(p_source_id) != p_tile_set_scenes_collection_source);

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -145,8 +145,8 @@ void TilesEditorUtils::_thread() {
 }
 
 void TilesEditorUtils::queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMapPattern> p_pattern, Callable p_callback) {
-	ERR_FAIL_COND(!p_tile_set.is_valid());
-	ERR_FAIL_COND(!p_pattern.is_valid());
+	ERR_FAIL_COND(p_tile_set.is_null());
+	ERR_FAIL_COND(p_pattern.is_null());
 	{
 		MutexLock lock(pattern_preview_mutex);
 		pattern_preview_queue.push_back({ p_tile_set, p_pattern, p_callback });

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -113,7 +113,7 @@ void VSGraphNode::_draw_port(int p_slot_index, Point2i p_pos, bool p_left, const
 	Ref<Texture2D> port_icon = p_left ? get_slot_custom_icon_left(p_slot_index) : get_slot_custom_icon_right(p_slot_index);
 
 	Point2 icon_offset;
-	if (!port_icon.is_valid()) {
+	if (port_icon.is_null()) {
 		port_icon = get_theme_icon(SNAME("port"), SNAME("GraphNode"));
 	}
 
@@ -333,7 +333,7 @@ void VisualShaderGraphPlugin::set_parameter_name(VisualShader::Type p_type, int 
 void VisualShaderGraphPlugin::update_curve(int p_node_id) {
 	if (links.has(p_node_id) && links[p_node_id].curve_editors[0]) {
 		Ref<VisualShaderNodeCurveTexture> tex = Object::cast_to<VisualShaderNodeCurveTexture>(links[p_node_id].visual_node);
-		ERR_FAIL_COND(!tex.is_valid());
+		ERR_FAIL_COND(tex.is_null());
 
 		if (tex->get_texture().is_valid()) {
 			links[p_node_id].curve_editors[0]->set_curve(tex->get_texture()->get_curve());
@@ -345,7 +345,7 @@ void VisualShaderGraphPlugin::update_curve(int p_node_id) {
 void VisualShaderGraphPlugin::update_curve_xyz(int p_node_id) {
 	if (links.has(p_node_id) && links[p_node_id].curve_editors[0] && links[p_node_id].curve_editors[1] && links[p_node_id].curve_editors[2]) {
 		Ref<VisualShaderNodeCurveXYZTexture> tex = Object::cast_to<VisualShaderNodeCurveXYZTexture>(links[p_node_id].visual_node);
-		ERR_FAIL_COND(!tex.is_valid());
+		ERR_FAIL_COND(tex.is_null());
 
 		if (tex->get_texture().is_valid()) {
 			links[p_node_id].curve_editors[0]->set_curve(tex->get_texture()->get_curve_x());
@@ -514,7 +514,7 @@ void VisualShaderGraphPlugin::update_frames(VisualShader::Type p_type, int p_nod
 	}
 
 	Ref<VisualShaderNode> vsnode = visual_shader->get_node(p_type, p_node);
-	if (!vsnode.is_valid()) {
+	if (vsnode.is_null()) {
 		WARN_PRINT("Update linked frames: Node not found.");
 		return;
 	}
@@ -525,7 +525,7 @@ void VisualShaderGraphPlugin::update_frames(VisualShader::Type p_type, int p_nod
 	}
 
 	Ref<VisualShaderNodeFrame> frame_node = visual_shader->get_node(p_type, frame_vsnode_id);
-	if (!frame_node.is_valid() || !links.has(frame_vsnode_id)) {
+	if (frame_node.is_null() || !links.has(frame_vsnode_id)) {
 		return;
 	}
 
@@ -605,7 +605,7 @@ bool VisualShaderGraphPlugin::is_node_has_parameter_instances_relatively(VisualS
 }
 
 void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id, bool p_just_update, bool p_update_frames) {
-	if (!visual_shader.is_valid() || p_type != visual_shader->get_shader_type()) {
+	if (visual_shader.is_null() || p_type != visual_shader->get_shader_type()) {
 		return;
 	}
 	GraphEdit *graph = editor->graph;
@@ -1597,7 +1597,7 @@ void VisualShaderEditor::clear_custom_types() {
 
 void VisualShaderEditor::add_custom_type(const String &p_name, const String &p_type, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, bool p_highend) {
 	ERR_FAIL_COND(!p_name.is_valid_ascii_identifier());
-	ERR_FAIL_COND(p_type.is_empty() && !p_script.is_valid());
+	ERR_FAIL_COND(p_type.is_empty() && p_script.is_null());
 
 	for (int i = 0; i < add_options.size(); i++) {
 		const AddOption &op = add_options[i];
@@ -2234,7 +2234,7 @@ void VisualShaderEditor::_update_options_menu() {
 
 	int current_func = -1;
 
-	if (!visual_shader.is_null()) {
+	if (visual_shader.is_valid()) {
 		current_func = visual_shader->get_mode();
 	}
 
@@ -2256,7 +2256,7 @@ void VisualShaderEditor::_update_options_menu() {
 
 				if (!add_options[i].is_custom) {
 					vsn = Ref<VisualShaderNode>(Object::cast_to<VisualShaderNode>(ClassDB::instantiate(add_options[i].type)));
-					if (!vsn.is_valid()) {
+					if (vsn.is_null()) {
 						continue;
 					}
 
@@ -2698,7 +2698,7 @@ void VisualShaderEditor::_change_input_port_name(const String &p_text, Object *p
 	VisualShader::Type type = get_current_shader_type();
 
 	Ref<VisualShaderNodeGroupBase> node = visual_shader->get_node(type, p_node_id);
-	ERR_FAIL_COND(!node.is_valid());
+	ERR_FAIL_COND(node.is_null());
 
 	String prev_name = node->get_input_port_name(p_port_id);
 	if (prev_name == p_text) {
@@ -2725,7 +2725,7 @@ void VisualShaderEditor::_change_output_port_name(const String &p_text, Object *
 	VisualShader::Type type = get_current_shader_type();
 
 	Ref<VisualShaderNodeGroupBase> node = visual_shader->get_node(type, p_node_id);
-	ERR_FAIL_COND(!node.is_valid());
+	ERR_FAIL_COND(node.is_null());
 
 	String prev_name = node->get_output_port_name(p_port_id);
 	if (prev_name == p_text) {
@@ -2752,7 +2752,7 @@ void VisualShaderEditor::_expand_output_port(int p_node, int p_port, bool p_expa
 	VisualShader::Type type = get_current_shader_type();
 
 	Ref<VisualShaderNode> node = visual_shader->get_node(type, p_node);
-	ERR_FAIL_COND(!node.is_valid());
+	ERR_FAIL_COND(node.is_null());
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	if (p_expand) {
@@ -2995,7 +2995,7 @@ void VisualShaderEditor::_set_node_size(int p_type, int p_node, const Vector2 &p
 	if (get_current_shader_type() == type) {
 		Ref<VisualShaderNodeExpression> expression_node = Object::cast_to<VisualShaderNodeExpression>(node.ptr());
 		Control *text_box = nullptr;
-		if (!expression_node.is_null()) {
+		if (expression_node.is_valid()) {
 			text_box = expression_node->is_ctrl_pressed(0);
 			if (text_box) {
 				text_box->set_custom_minimum_size(Size2(0, 0));
@@ -3208,7 +3208,7 @@ void VisualShaderEditor::_parameter_line_edit_changed(const String &p_text, int 
 	VisualShader::Type type = get_current_shader_type();
 
 	Ref<VisualShaderNodeParameter> node = visual_shader->get_node(type, p_node_id);
-	ERR_FAIL_COND(!node.is_valid());
+	ERR_FAIL_COND(node.is_null());
 
 	String validated_name = visual_shader->validate_parameter_name(p_text, node);
 
@@ -3250,7 +3250,7 @@ void VisualShaderEditor::_port_name_focus_out(Object *line_edit, int p_node_id, 
 void VisualShaderEditor::_port_edited(const StringName &p_property, const Variant &p_value, const String &p_field, bool p_changing) {
 	VisualShader::Type type = get_current_shader_type();
 	Ref<VisualShaderNode> vsn = visual_shader->get_node(type, editing_node);
-	ERR_FAIL_COND(!vsn.is_valid());
+	ERR_FAIL_COND(vsn.is_null());
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Set Input Default Port"));
@@ -4254,7 +4254,7 @@ bool VisualShaderEditor::_check_node_drop_on_connection(const Vector2 &p_positio
 	}
 
 	// Only a single node - which has both input and output ports but is not connected yet - can be inserted.
-	if (selected_node_count != 1 || !selected_vsnode.is_valid()) {
+	if (selected_node_count != 1 || selected_vsnode.is_null()) {
 		return false;
 	}
 
@@ -4462,7 +4462,7 @@ void VisualShaderEditor::_replace_node(VisualShader::Type p_type_id, int p_node_
 
 void VisualShaderEditor::_update_constant(VisualShader::Type p_type_id, int p_node_id, const Variant &p_var, int p_preview_port) {
 	Ref<VisualShaderNode> node = visual_shader->get_node(p_type_id, p_node_id);
-	ERR_FAIL_COND(!node.is_valid());
+	ERR_FAIL_COND(node.is_null());
 	ERR_FAIL_COND(!node->has_method("set_constant"));
 	node->call("set_constant", p_var);
 	if (p_preview_port != -1) {
@@ -4472,7 +4472,7 @@ void VisualShaderEditor::_update_constant(VisualShader::Type p_type_id, int p_no
 
 void VisualShaderEditor::_update_parameter(VisualShader::Type p_type_id, int p_node_id, const Variant &p_var, int p_preview_port) {
 	Ref<VisualShaderNodeParameter> parameter = visual_shader->get_node(p_type_id, p_node_id);
-	ERR_FAIL_COND(!parameter.is_valid());
+	ERR_FAIL_COND(parameter.is_null());
 
 	String valid_name = visual_shader->validate_parameter_name(parameter->get_parameter_name(), parameter);
 	parameter->set_parameter_name(valid_name);
@@ -4666,7 +4666,7 @@ void VisualShaderEditor::_convert_constants_to_parameters(bool p_vice_versa) {
 			undo_redo->add_undo_method(this, "_update_parameter", type_id, node_id, var, preview_port);
 
 			Ref<VisualShaderNodeParameter> parameter = Object::cast_to<VisualShaderNodeParameter>(node.ptr());
-			ERR_CONTINUE(!parameter.is_valid());
+			ERR_CONTINUE(parameter.is_null());
 
 			deleted_names.insert(parameter->get_parameter_name());
 		}
@@ -4689,7 +4689,7 @@ void VisualShaderEditor::_detach_nodes_from_frame(int p_type, const List<int> &p
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	for (int node_id : p_nodes) {
 		Ref<VisualShaderNode> node = visual_shader->get_node((VisualShader::Type)p_type, node_id);
-		if (!node.is_valid()) {
+		if (node.is_null()) {
 			continue;
 		}
 		int frame_id = node->get_frame();
@@ -4787,7 +4787,7 @@ void VisualShaderEditor::_node_selected(Object *p_node) {
 	int id = String(graph_element->get_name()).to_int();
 
 	Ref<VisualShaderNode> vsnode = visual_shader->get_node(type, id);
-	ERR_FAIL_COND(!vsnode.is_valid());
+	ERR_FAIL_COND(vsnode.is_null());
 }
 
 void VisualShaderEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
@@ -5780,7 +5780,7 @@ void VisualShaderEditor::_float_constant_selected(int p_which) {
 
 	VisualShader::Type type = get_current_shader_type();
 	Ref<VisualShaderNodeFloatConstant> node = visual_shader->get_node(type, selected_float_constant);
-	ERR_FAIL_COND(!node.is_valid());
+	ERR_FAIL_COND(node.is_null());
 
 	if (Math::is_equal_approx(node->get_constant(), float_constant_defs[p_which].value)) {
 		return; // same
@@ -7806,7 +7806,7 @@ public:
 			} else {
 				undo_redo->add_do_method(this, "_open_inspector", (Ref<Resource>)curr_res.ptr());
 			}
-			if (!prev_res.is_null()) {
+			if (prev_res.is_valid()) {
 				undo_redo->add_undo_method(this, "_open_inspector", (Ref<Resource>)prev_res.ptr());
 			} else {
 				undo_redo->add_undo_method(this, "_open_inspector", (Ref<Resource>)parent_resource.ptr());
@@ -8027,7 +8027,7 @@ void EditorPropertyVisualShaderMode::_option_selected(int p_which) {
 		Vector<int> nodes = visual_shader->get_node_list(type);
 		for (int j = 0; j < nodes.size(); j++) {
 			Ref<VisualShaderNodeInput> input = visual_shader->get_node(type, nodes[j]);
-			if (!input.is_valid()) {
+			if (input.is_null()) {
 				continue;
 			}
 
@@ -8227,7 +8227,7 @@ bool VisualShaderConversionPlugin::handles(const Ref<Resource> &p_resource) cons
 
 Ref<Resource> VisualShaderConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<VisualShader> vshader = p_resource;
-	ERR_FAIL_COND_V(!vshader.is_valid(), Ref<Resource>());
+	ERR_FAIL_COND_V(vshader.is_null(), Ref<Resource>());
 
 	Ref<Shader> shader;
 	shader.instantiate();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -292,7 +292,7 @@ void SceneTreeDock::_perform_instantiate_scenes(const Vector<String> &p_files, N
 
 	for (int i = 0; i < p_files.size(); i++) {
 		Ref<PackedScene> sdata = ResourceLoader::load(p_files[i]);
-		if (!sdata.is_valid()) {
+		if (sdata.is_null()) {
 			current_option = -1;
 			accept->set_text(vformat(TTR("Error loading scene from %s"), p_files[i]));
 			accept->popup_centered();
@@ -433,7 +433,7 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *base)
 	ERR_FAIL_COND_MSG(base->get_internal_mode() != INTERNAL_MODE_DISABLED, "Trying to replace internal node, this is not supported.");
 
 	Ref<PackedScene> sdata = ResourceLoader::load(p_file);
-	if (!sdata.is_valid()) {
+	if (sdata.is_null()) {
 		accept->set_text(vformat(TTR("Error loading scene from %s"), p_file));
 		accept->popup_centered();
 		return;
@@ -3581,7 +3581,7 @@ void SceneTreeDock::_files_dropped(const Vector<String> &p_files, NodePath p_to,
 
 void SceneTreeDock::_script_dropped(const String &p_file, NodePath p_to) {
 	Ref<Script> scr = ResourceLoader::load(p_file);
-	ERR_FAIL_COND(!scr.is_valid());
+	ERR_FAIL_COND(scr.is_null());
 	Node *n = get_node(p_to);
 
 	if (!n) {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4007,7 +4007,7 @@ int Main::start() {
 						scn.instantiate();
 						scn->set_path(info.path);
 						scn->reload_from_file();
-						ERR_CONTINUE_MSG(!scn.is_valid(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
+						ERR_CONTINUE_MSG(scn.is_null(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
 
 						if (scn.is_valid()) {
 							n = scn->instantiate();

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -725,7 +725,7 @@ bool CSGShape3D::_is_debug_collision_shape_visible() {
 }
 
 void CSGShape3D::_update_debug_collision_shape() {
-	if (!use_collision || !is_root_shape() || !root_collision_shape.is_valid() || !_is_debug_collision_shape_visible()) {
+	if (!use_collision || !is_root_shape() || root_collision_shape.is_null() || !_is_debug_collision_shape_visible()) {
 		return;
 	}
 
@@ -1037,7 +1037,7 @@ CSGPrimitive3D::CSGPrimitive3D() {
 /////////////////////
 
 CSGBrush *CSGMesh3D::_build_brush() {
-	if (!mesh.is_valid()) {
+	if (mesh.is_null()) {
 		return memnew(CSGBrush);
 	}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -792,7 +792,7 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 				String ext = path.get_extension();
 				if (ext == GDScriptLanguage::get_singleton()->get_extension()) {
 					Ref<GDScriptParserRef> ref = parser->get_depended_parser_for(path);
-					if (!ref.is_valid() || ref->raise_status(GDScriptParserRef::INHERITANCE_SOLVED) != OK) {
+					if (ref.is_null() || ref->raise_status(GDScriptParserRef::INHERITANCE_SOLVED) != OK) {
 						push_error(vformat(R"(Could not parse global class "%s" from "%s".)", first, ScriptServer::get_global_class_path(first)), p_type);
 						return bad_type;
 					}

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -284,10 +284,10 @@ struct GDScriptUtilityFunctionsDefinitions {
 		VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, !d.has("@path"), RTR("Invalid instance dictionary format (missing @path)."));
 
 		Ref<Script> scr = ResourceLoader::load(d["@path"]);
-		VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, !scr.is_valid(), RTR("Invalid instance dictionary format (can't load script at @path)."));
+		VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, scr.is_null(), RTR("Invalid instance dictionary format (can't load script at @path)."));
 
 		Ref<GDScript> gdscr = scr;
-		VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, !gdscr.is_valid(), RTR("Invalid instance dictionary format (invalid script at @path)."));
+		VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, gdscr.is_null(), RTR("Invalid instance dictionary format (invalid script at @path)."));
 
 		NodePath sub;
 		if (d.has("@subpath")) {
@@ -296,7 +296,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 
 		for (int i = 0; i < sub.get_name_count(); i++) {
 			gdscr = gdscr->subclasses[sub.get_name(i)];
-			VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, !gdscr.is_valid(), RTR("Invalid instance dictionary (invalid subclasses)."));
+			VALIDATE_ARG_CUSTOM(0, Variant::DICTIONARY, gdscr.is_null(), RTR("Invalid instance dictionary (invalid subclasses)."));
 		}
 
 		*r_ret = gdscr->_new(nullptr, -1 /* skip initializer */, r_error);

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -657,7 +657,7 @@ void GDScriptWorkspace::completion(const lsp::CompletionParams &p_params, List<S
 			}
 
 			Ref<GDScript> scr = current->get_script();
-			if (!scr.is_valid() || !GDScript::is_canonically_equal_paths(scr->get_path(), path)) {
+			if (scr.is_null() || !GDScript::is_canonically_equal_paths(scr->get_path(), path)) {
 				current = owner_scene_node;
 			}
 		}

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -78,7 +78,7 @@ void init_autoloads() {
 			scn.instantiate();
 			scn->set_path(info.path);
 			scn->reload_from_file();
-			ERR_CONTINUE_MSG(!scn.is_valid(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
+			ERR_CONTINUE_MSG(scn.is_null(), vformat("Failed to instantiate an autoload, can't load from path: %s.", info.path));
 
 			if (scn.is_valid()) {
 				n = scn->instantiate();

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3153,7 +3153,7 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 				v = instance_materials.get(surface_i);
 			}
 			Ref<Material> mat = v;
-			if (!mat.is_valid()) {
+			if (mat.is_null()) {
 				mat = import_mesh->get_surface_material(surface_i);
 			}
 			if (mat.is_valid()) {

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1001,7 +1001,7 @@ void GridMapEditor::update_palette() {
 		}
 
 		mesh_library_palette->add_item("");
-		if (!preview.is_null()) {
+		if (preview.is_valid()) {
 			mesh_library_palette->set_item_icon(item, preview);
 			mesh_library_palette->set_item_tooltip(item, name);
 		}
@@ -1267,7 +1267,7 @@ void GridMapEditor::_update_cursor_instance() {
 	if (mode_buttons_group->get_pressed_button() == paint_mode_button) {
 		if (selected_palette >= 0 && node && node->get_mesh_library().is_valid()) {
 			Ref<Mesh> mesh = node->get_mesh_library()->get_item_mesh(selected_palette);
-			if (!mesh.is_null() && mesh->get_rid().is_valid()) {
+			if (mesh.is_valid() && mesh->get_rid().is_valid()) {
 				cursor_instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), get_tree()->get_root()->get_world_3d()->get_scenario());
 				RS::ShadowCastingSetting cast_shadows = (RS::ShadowCastingSetting)node->get_mesh_library()->get_item_mesh_cast_shadow(selected_palette);
 				RS::get_singleton()->instance_geometry_set_cast_shadows_setting(cursor_instance, cast_shadows);

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -68,7 +68,7 @@ bool GridMap::_set(const StringName &p_name, const Variant &p_value) {
 		for (int i = 0; i < meshes.size(); i++) {
 			BakedMesh bm;
 			bm.mesh = meshes[i];
-			ERR_CONTINUE(!bm.mesh.is_valid());
+			ERR_CONTINUE(bm.mesh.is_null());
 			bm.instance = RS::get_singleton()->instance_create();
 			RS::get_singleton()->instance_set_base(bm.instance, bm.mesh->get_rid());
 			RS::get_singleton()->instance_attach_object_instance_id(bm.instance, get_instance_id());
@@ -253,11 +253,11 @@ RID GridMap::get_navigation_map() const {
 }
 
 void GridMap::set_mesh_library(const Ref<MeshLibrary> &p_mesh_library) {
-	if (!mesh_library.is_null()) {
+	if (mesh_library.is_valid()) {
 		mesh_library->disconnect_changed(callable_mp(this, &GridMap::_recreate_octant_data));
 	}
 	mesh_library = p_mesh_library;
-	if (!mesh_library.is_null()) {
+	if (mesh_library.is_valid()) {
 		mesh_library->connect_changed(callable_mp(this, &GridMap::_recreate_octant_data));
 	}
 
@@ -594,7 +594,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		ERR_CONTINUE(!cell_map.has(E));
 		const Cell &c = cell_map[E];
 
-		if (!mesh_library.is_valid() || !mesh_library->has_item(c.item)) {
+		if (mesh_library.is_null() || !mesh_library->has_item(c.item)) {
 			continue;
 		}
 
@@ -623,7 +623,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		// add the item's shape at given xform to octant's static_body
 		for (int i = 0; i < shapes.size(); i++) {
 			// add the item's shape
-			if (!shapes[i].shape.is_valid()) {
+			if (shapes[i].shape.is_null()) {
 				continue;
 			}
 			PhysicsServer3D::get_singleton()->body_add_shape(g.static_body, shapes[i].shape->get_rid(), xform * shapes[i].local_transform);
@@ -1225,7 +1225,7 @@ void GridMap::clear_baked_meshes() {
 }
 
 void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texel_size) {
-	if (!mesh_library.is_valid()) {
+	if (mesh_library.is_null()) {
 		return;
 	}
 
@@ -1241,7 +1241,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		}
 
 		Ref<Mesh> mesh = mesh_library->get_item_mesh(item);
-		if (!mesh.is_valid()) {
+		if (mesh.is_null()) {
 			continue;
 		}
 

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -592,7 +592,7 @@ void AudioStreamPlaybackInteractive::start(double p_from_pos) {
 	if (current < 0 || current >= stream->clip_count) {
 		return; // No playback possible.
 	}
-	if (!states[current].playback.is_valid()) {
+	if (states[current].playback.is_null()) {
 		return; //no playback possible
 	}
 	active = true;

--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -310,7 +310,7 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 					break;
 				}
 
-				if (!playback[play_order[play_index]].is_valid()) {
+				if (playback[play_order[play_index]].is_null()) {
 					todo = to_mix; // Weird error.
 					active = false;
 					break;

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -474,7 +474,7 @@ Vector<uint8_t> CryptoMbedTLS::sign(HashingContext::HashType p_hash_type, const 
 	ERR_FAIL_COND_V_MSG(type == MBEDTLS_MD_NONE, Vector<uint8_t>(), "Invalid hash type.");
 	ERR_FAIL_COND_V_MSG(p_hash.size() != size, Vector<uint8_t>(), "Invalid hash provided. Size must be " + itos(size));
 	Ref<CryptoKeyMbedTLS> key = static_cast<Ref<CryptoKeyMbedTLS>>(p_key);
-	ERR_FAIL_COND_V_MSG(!key.is_valid(), Vector<uint8_t>(), "Invalid key provided.");
+	ERR_FAIL_COND_V_MSG(key.is_null(), Vector<uint8_t>(), "Invalid key provided.");
 	ERR_FAIL_COND_V_MSG(key->is_public_only(), Vector<uint8_t>(), "Invalid key provided. Cannot sign with public_only keys.");
 	size_t sig_size = 0;
 #if MBEDTLS_VERSION_MAJOR >= 3
@@ -500,13 +500,13 @@ bool CryptoMbedTLS::verify(HashingContext::HashType p_hash_type, const Vector<ui
 	ERR_FAIL_COND_V_MSG(type == MBEDTLS_MD_NONE, false, "Invalid hash type.");
 	ERR_FAIL_COND_V_MSG(p_hash.size() != size, false, "Invalid hash provided. Size must be " + itos(size));
 	Ref<CryptoKeyMbedTLS> key = static_cast<Ref<CryptoKeyMbedTLS>>(p_key);
-	ERR_FAIL_COND_V_MSG(!key.is_valid(), false, "Invalid key provided.");
+	ERR_FAIL_COND_V_MSG(key.is_null(), false, "Invalid key provided.");
 	return mbedtls_pk_verify(&(key->pkey), type, p_hash.ptr(), size, p_signature.ptr(), p_signature.size()) == 0;
 }
 
 Vector<uint8_t> CryptoMbedTLS::encrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_plaintext) {
 	Ref<CryptoKeyMbedTLS> key = static_cast<Ref<CryptoKeyMbedTLS>>(p_key);
-	ERR_FAIL_COND_V_MSG(!key.is_valid(), Vector<uint8_t>(), "Invalid key provided.");
+	ERR_FAIL_COND_V_MSG(key.is_null(), Vector<uint8_t>(), "Invalid key provided.");
 	uint8_t buf[1024];
 	size_t size;
 	Vector<uint8_t> out;
@@ -519,7 +519,7 @@ Vector<uint8_t> CryptoMbedTLS::encrypt(Ref<CryptoKey> p_key, const Vector<uint8_
 
 Vector<uint8_t> CryptoMbedTLS::decrypt(Ref<CryptoKey> p_key, const Vector<uint8_t> &p_ciphertext) {
 	Ref<CryptoKeyMbedTLS> key = static_cast<Ref<CryptoKeyMbedTLS>>(p_key);
-	ERR_FAIL_COND_V_MSG(!key.is_valid(), Vector<uint8_t>(), "Invalid key provided.");
+	ERR_FAIL_COND_V_MSG(key.is_null(), Vector<uint8_t>(), "Invalid key provided.");
 	ERR_FAIL_COND_V_MSG(key->is_public_only(), Vector<uint8_t>(), "Invalid key provided. Cannot decrypt using a public_only key.");
 	uint8_t buf[2048];
 	size_t size;

--- a/modules/mbedtls/dtls_server_mbedtls.cpp
+++ b/modules/mbedtls/dtls_server_mbedtls.cpp
@@ -47,7 +47,7 @@ Ref<PacketPeerDTLS> DTLSServerMbedTLS::take_connection(Ref<PacketPeerUDP> p_udp_
 	Ref<PacketPeerMbedDTLS> out;
 
 	ERR_FAIL_COND_V(tls_options.is_null(), out);
-	ERR_FAIL_COND_V(!p_udp_peer.is_valid(), out);
+	ERR_FAIL_COND_V(p_udp_peer.is_null(), out);
 
 	out.instantiate();
 	out->accept_peer(p_udp_peer, tls_options, cookies);

--- a/modules/mbedtls/packet_peer_mbed_dtls.cpp
+++ b/modules/mbedtls/packet_peer_mbed_dtls.cpp
@@ -111,7 +111,7 @@ Error PacketPeerMbedDTLS::_do_handshake() {
 }
 
 Error PacketPeerMbedDTLS::connect_to_peer(Ref<PacketPeerUDP> p_base, const String &p_hostname, Ref<TLSOptions> p_options) {
-	ERR_FAIL_COND_V(!p_base.is_valid() || !p_base->is_socket_connected(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_base.is_null() || !p_base->is_socket_connected(), ERR_INVALID_PARAMETER);
 
 	Error err = tls_ctx->init_client(MBEDTLS_SSL_TRANSPORT_DATAGRAM, p_hostname, p_options.is_valid() ? p_options : TLSOptions::client());
 	ERR_FAIL_COND_V(err != OK, err);
@@ -132,7 +132,7 @@ Error PacketPeerMbedDTLS::connect_to_peer(Ref<PacketPeerUDP> p_base, const Strin
 }
 
 Error PacketPeerMbedDTLS::accept_peer(Ref<PacketPeerUDP> p_base, Ref<TLSOptions> p_options, Ref<CookieContextMbedTLS> p_cookies) {
-	ERR_FAIL_COND_V(!p_base.is_valid() || !p_base->is_socket_connected(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_base.is_null() || !p_base->is_socket_connected(), ERR_INVALID_PARAMETER);
 
 	Error err = tls_ctx->init_server(MBEDTLS_SSL_TRANSPORT_DATAGRAM, p_options, p_cookies);
 	ERR_FAIL_COND_V(err != OK, err);
@@ -213,7 +213,7 @@ void PacketPeerMbedDTLS::poll() {
 		return;
 	}
 
-	ERR_FAIL_COND(!base.is_valid());
+	ERR_FAIL_COND(base.is_null());
 
 	int ret = mbedtls_ssl_read(tls_ctx->get_context(), nullptr, 0);
 

--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -235,7 +235,7 @@ Error StreamPeerMbedTLS::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r
 
 void StreamPeerMbedTLS::poll() {
 	ERR_FAIL_COND(status != STATUS_CONNECTED && status != STATUS_HANDSHAKING);
-	ERR_FAIL_COND(!base.is_valid());
+	ERR_FAIL_COND(base.is_null());
 
 	if (status == STATUS_HANDSHAKING) {
 		_do_handshake();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1473,14 +1473,14 @@ Object *CSharpInstance::get_owner() {
 }
 
 bool CSharpInstance::set(const StringName &p_name, const Variant &p_value) {
-	ERR_FAIL_COND_V(!script.is_valid(), false);
+	ERR_FAIL_COND_V(script.is_null(), false);
 
 	return GDMonoCache::managed_callbacks.CSharpInstanceBridge_Set(
 			gchandle.get_intptr(), &p_name, &p_value);
 }
 
 bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
-	ERR_FAIL_COND_V(!script.is_valid(), false);
+	ERR_FAIL_COND_V(script.is_null(), false);
 
 	Variant ret_value;
 
@@ -1497,7 +1497,7 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 
 void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 	List<PropertyInfo> props;
-	ERR_FAIL_COND(!script.is_valid());
+	ERR_FAIL_COND(script.is_null());
 #ifdef TOOLS_ENABLED
 	for (const PropertyInfo &prop : script->exported_members_cache) {
 		props.push_back(prop);
@@ -1574,7 +1574,7 @@ Variant::Type CSharpInstance::get_property_type(const StringName &p_name, bool *
 }
 
 bool CSharpInstance::property_can_revert(const StringName &p_name) const {
-	ERR_FAIL_COND_V(!script.is_valid(), false);
+	ERR_FAIL_COND_V(script.is_null(), false);
 
 	Variant name_arg = p_name;
 	const Variant *args[1] = { &name_arg };
@@ -1592,7 +1592,7 @@ bool CSharpInstance::property_can_revert(const StringName &p_name) const {
 }
 
 void CSharpInstance::validate_property(PropertyInfo &p_property) const {
-	ERR_FAIL_COND(!script.is_valid());
+	ERR_FAIL_COND(script.is_null());
 
 	Variant property_arg = (Dictionary)p_property;
 	const Variant *args[1] = { &property_arg };
@@ -1610,7 +1610,7 @@ void CSharpInstance::validate_property(PropertyInfo &p_property) const {
 }
 
 bool CSharpInstance::property_get_revert(const StringName &p_name, Variant &r_ret) const {
-	ERR_FAIL_COND_V(!script.is_valid(), false);
+	ERR_FAIL_COND_V(script.is_null(), false);
 
 	Variant name_arg = p_name;
 	const Variant *args[1] = { &name_arg };
@@ -1637,7 +1637,7 @@ void CSharpInstance::get_method_list(List<MethodInfo> *p_list) const {
 }
 
 bool CSharpInstance::has_method(const StringName &p_method) const {
-	if (!script.is_valid()) {
+	if (script.is_null()) {
 		return false;
 	}
 
@@ -1678,7 +1678,7 @@ int CSharpInstance::get_method_argument_count(const StringName &p_method, bool *
 }
 
 Variant CSharpInstance::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
-	ERR_FAIL_COND_V(!script.is_valid(), Variant());
+	ERR_FAIL_COND_V(script.is_null(), Variant());
 
 	Variant ret;
 	GDMonoCache::managed_callbacks.CSharpInstanceBridge_Call(

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1373,7 +1373,7 @@ void godotsharp_weakref(Object *p_ptr, Ref<RefCounted> *r_weak_ref) {
 
 	if (rc) {
 		Ref<RefCounted> r = rc;
-		if (!r.is_valid()) {
+		if (r.is_null()) {
 			return;
 		}
 

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -490,7 +490,7 @@ void ReplicationEditor::_update_config() {
 	tree->clear();
 	tree->create_item();
 	drop_label->set_visible(true);
-	if (!config.is_valid()) {
+	if (config.is_null()) {
 		return;
 	}
 	TypedArray<NodePath> props = config->get_properties();

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -440,7 +440,7 @@ void SceneMultiplayer::disconnect_peer(int p_id) {
 
 Error SceneMultiplayer::send_bytes(Vector<uint8_t> p_data, int p_to, MultiplayerPeer::TransferMode p_mode, int p_channel) {
 	ERR_FAIL_COND_V_MSG(p_data.is_empty(), ERR_INVALID_DATA, "Trying to send an empty raw packet.");
-	ERR_FAIL_COND_V_MSG(!multiplayer_peer.is_valid(), ERR_UNCONFIGURED, "Trying to send a raw packet while no multiplayer peer is active.");
+	ERR_FAIL_COND_V_MSG(multiplayer_peer.is_null(), ERR_UNCONFIGURED, "Trying to send a raw packet while no multiplayer peer is active.");
 	ERR_FAIL_COND_V_MSG(multiplayer_peer->get_connection_status() != MultiplayerPeer::CONNECTION_CONNECTED, ERR_UNCONFIGURED, "Trying to send a raw packet via a multiplayer peer which is not connected.");
 
 	if (packet_cache.size() < p_data.size() + 1) {
@@ -530,22 +530,22 @@ void SceneMultiplayer::_process_raw(int p_from, const uint8_t *p_packet, int p_p
 }
 
 int SceneMultiplayer::get_unique_id() {
-	ERR_FAIL_COND_V_MSG(!multiplayer_peer.is_valid(), 0, "No multiplayer peer is assigned. Unable to get unique ID.");
+	ERR_FAIL_COND_V_MSG(multiplayer_peer.is_null(), 0, "No multiplayer peer is assigned. Unable to get unique ID.");
 	return multiplayer_peer->get_unique_id();
 }
 
 void SceneMultiplayer::set_refuse_new_connections(bool p_refuse) {
-	ERR_FAIL_COND_MSG(!multiplayer_peer.is_valid(), "No multiplayer peer is assigned. Unable to set 'refuse_new_connections'.");
+	ERR_FAIL_COND_MSG(multiplayer_peer.is_null(), "No multiplayer peer is assigned. Unable to set 'refuse_new_connections'.");
 	multiplayer_peer->set_refuse_new_connections(p_refuse);
 }
 
 bool SceneMultiplayer::is_refusing_new_connections() const {
-	ERR_FAIL_COND_V_MSG(!multiplayer_peer.is_valid(), false, "No multiplayer peer is assigned. Unable to get 'refuse_new_connections'.");
+	ERR_FAIL_COND_V_MSG(multiplayer_peer.is_null(), false, "No multiplayer peer is assigned. Unable to get 'refuse_new_connections'.");
 	return multiplayer_peer->is_refusing_new_connections();
 }
 
 Vector<int> SceneMultiplayer::get_peer_ids() {
-	ERR_FAIL_COND_V_MSG(!multiplayer_peer.is_valid(), Vector<int>(), "No multiplayer peer is assigned. Assume no peers are connected.");
+	ERR_FAIL_COND_V_MSG(multiplayer_peer.is_null(), Vector<int>(), "No multiplayer peer is assigned. Assume no peers are connected.");
 
 	Vector<int> ret;
 	for (const int &E : connected_peers) {

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -461,7 +461,7 @@ void SceneRPCInterface::_send_rpc(Node *p_node, int p_to, uint16_t p_rpc_id, con
 
 Error SceneRPCInterface::rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) {
 	Ref<MultiplayerPeer> peer = multiplayer->get_multiplayer_peer();
-	ERR_FAIL_COND_V_MSG(!peer.is_valid(), ERR_UNCONFIGURED, "Trying to call an RPC while no multiplayer peer is active.");
+	ERR_FAIL_COND_V_MSG(peer.is_null(), ERR_UNCONFIGURED, "Trying to call an RPC while no multiplayer peer is active.");
 	Node *node = Object::cast_to<Node>(p_obj);
 	ERR_FAIL_COND_V_MSG(!node || !node->is_inside_tree(), ERR_INVALID_PARAMETER, "The object must be a valid Node inside the SceneTree");
 	ERR_FAIL_COND_V_MSG(peer->get_connection_status() != MultiplayerPeer::CONNECTION_CONNECTED, ERR_CONNECTION_ERROR, "Trying to call an RPC via a multiplayer peer which is not connected.");

--- a/modules/navigation/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation/2d/godot_navigation_server_2d.cpp
@@ -185,7 +185,7 @@ void GodotNavigationServer2D::finish() {
 
 void GodotNavigationServer2D::parse_source_geometry_data(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback) {
 	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "The SceneTree can only be parsed on the main thread. Call this function from the main thread or use call_deferred().");
-	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation polygon.");
+	ERR_FAIL_COND_MSG(p_navigation_mesh.is_null(), "Invalid navigation polygon.");
 	ERR_FAIL_NULL_MSG(p_root_node, "No parsing root node specified.");
 	ERR_FAIL_COND_MSG(!p_root_node->is_inside_tree(), "The root node needs to be inside the SceneTree.");
 
@@ -196,8 +196,8 @@ void GodotNavigationServer2D::parse_source_geometry_data(const Ref<NavigationPol
 }
 
 void GodotNavigationServer2D::bake_from_source_geometry_data(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, const Callable &p_callback) {
-	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation polygon.");
-	ERR_FAIL_COND_MSG(!p_source_geometry_data.is_valid(), "Invalid NavigationMeshSourceGeometryData2D.");
+	ERR_FAIL_COND_MSG(p_navigation_mesh.is_null(), "Invalid navigation polygon.");
+	ERR_FAIL_COND_MSG(p_source_geometry_data.is_null(), "Invalid NavigationMeshSourceGeometryData2D.");
 
 #ifdef CLIPPER2_ENABLED
 	ERR_FAIL_NULL(NavMeshGenerator2D::get_singleton());
@@ -206,8 +206,8 @@ void GodotNavigationServer2D::bake_from_source_geometry_data(const Ref<Navigatio
 }
 
 void GodotNavigationServer2D::bake_from_source_geometry_data_async(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, const Callable &p_callback) {
-	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation mesh.");
-	ERR_FAIL_COND_MSG(!p_source_geometry_data.is_valid(), "Invalid NavigationMeshSourceGeometryData2D.");
+	ERR_FAIL_COND_MSG(p_navigation_mesh.is_null(), "Invalid navigation mesh.");
+	ERR_FAIL_COND_MSG(p_source_geometry_data.is_null(), "Invalid NavigationMeshSourceGeometryData2D.");
 
 #ifdef CLIPPER2_ENABLED
 	ERR_FAIL_NULL(NavMeshGenerator2D::get_singleton());
@@ -461,8 +461,8 @@ Vector<Vector2> GodotNavigationServer2D::obstacle_get_vertices(RID p_obstacle) c
 }
 
 void GodotNavigationServer2D::query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result, const Callable &p_callback) {
-	ERR_FAIL_COND(!p_query_parameters.is_valid());
-	ERR_FAIL_COND(!p_query_result.is_valid());
+	ERR_FAIL_COND(p_query_parameters.is_null());
+	ERR_FAIL_COND(p_query_result.is_null());
 
 	Ref<NavigationPathQueryParameters3D> query_parameters;
 	query_parameters.instantiate();

--- a/modules/navigation/2d/nav_mesh_generator_2d.cpp
+++ b/modules/navigation/2d/nav_mesh_generator_2d.cpp
@@ -144,10 +144,10 @@ void NavMeshGenerator2D::finish() {
 
 void NavMeshGenerator2D::parse_source_geometry_data(Ref<NavigationPolygon> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, Node *p_root_node, const Callable &p_callback) {
 	ERR_FAIL_COND(!Thread::is_main_thread());
-	ERR_FAIL_COND(!p_navigation_mesh.is_valid());
+	ERR_FAIL_COND(p_navigation_mesh.is_null());
 	ERR_FAIL_NULL(p_root_node);
 	ERR_FAIL_COND(!p_root_node->is_inside_tree());
-	ERR_FAIL_COND(!p_source_geometry_data.is_valid());
+	ERR_FAIL_COND(p_source_geometry_data.is_null());
 
 	generator_parse_source_geometry_data(p_navigation_mesh, p_source_geometry_data, p_root_node);
 
@@ -157,8 +157,8 @@ void NavMeshGenerator2D::parse_source_geometry_data(Ref<NavigationPolygon> p_nav
 }
 
 void NavMeshGenerator2D::bake_from_source_geometry_data(Ref<NavigationPolygon> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, const Callable &p_callback) {
-	ERR_FAIL_COND(!p_navigation_mesh.is_valid());
-	ERR_FAIL_COND(!p_source_geometry_data.is_valid());
+	ERR_FAIL_COND(p_navigation_mesh.is_null());
+	ERR_FAIL_COND(p_source_geometry_data.is_null());
 
 	if (p_navigation_mesh->get_outline_count() == 0 && !p_source_geometry_data->has_data()) {
 		p_navigation_mesh->clear();
@@ -187,8 +187,8 @@ void NavMeshGenerator2D::bake_from_source_geometry_data(Ref<NavigationPolygon> p
 }
 
 void NavMeshGenerator2D::bake_from_source_geometry_data_async(Ref<NavigationPolygon> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData2D> p_source_geometry_data, const Callable &p_callback) {
-	ERR_FAIL_COND(!p_navigation_mesh.is_valid());
-	ERR_FAIL_COND(!p_source_geometry_data.is_valid());
+	ERR_FAIL_COND(p_navigation_mesh.is_null());
+	ERR_FAIL_COND(p_source_geometry_data.is_null());
 
 	if (p_navigation_mesh->get_outline_count() == 0 && !p_source_geometry_data->has_data()) {
 		p_navigation_mesh->clear();
@@ -279,7 +279,7 @@ void NavMeshGenerator2D::generator_parse_meshinstance2d_node(const Ref<Navigatio
 	}
 
 	Ref<Mesh> mesh = mesh_instance->get_mesh();
-	if (!mesh.is_valid()) {
+	if (mesh.is_null()) {
 		return;
 	}
 
@@ -369,7 +369,7 @@ void NavMeshGenerator2D::generator_parse_multimeshinstance2d_node(const Ref<Navi
 	}
 
 	Ref<Mesh> mesh = multimesh->get_mesh();
-	if (!mesh.is_valid()) {
+	if (mesh.is_null()) {
 		return;
 	}
 
@@ -590,7 +590,7 @@ void NavMeshGenerator2D::generator_parse_tile_map_layer_node(const Ref<Navigatio
 	}
 
 	Ref<TileSet> tile_set = tile_map_layer->get_tile_set();
-	if (!tile_set.is_valid()) {
+	if (tile_set.is_null()) {
 		return;
 	}
 

--- a/modules/navigation/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation/3d/godot_navigation_server_3d.cpp
@@ -1163,7 +1163,7 @@ uint32_t GodotNavigationServer3D::obstacle_get_avoidance_layers(RID p_obstacle) 
 void GodotNavigationServer3D::parse_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback) {
 #ifndef _3D_DISABLED
 	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "The SceneTree can only be parsed on the main thread. Call this function from the main thread or use call_deferred().");
-	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation mesh.");
+	ERR_FAIL_COND_MSG(p_navigation_mesh.is_null(), "Invalid navigation mesh.");
 	ERR_FAIL_NULL_MSG(p_root_node, "No parsing root node specified.");
 	ERR_FAIL_COND_MSG(!p_root_node->is_inside_tree(), "The root node needs to be inside the SceneTree.");
 
@@ -1174,8 +1174,8 @@ void GodotNavigationServer3D::parse_source_geometry_data(const Ref<NavigationMes
 
 void GodotNavigationServer3D::bake_from_source_geometry_data(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback) {
 #ifndef _3D_DISABLED
-	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation mesh.");
-	ERR_FAIL_COND_MSG(!p_source_geometry_data.is_valid(), "Invalid NavigationMeshSourceGeometryData3D.");
+	ERR_FAIL_COND_MSG(p_navigation_mesh.is_null(), "Invalid navigation mesh.");
+	ERR_FAIL_COND_MSG(p_source_geometry_data.is_null(), "Invalid NavigationMeshSourceGeometryData3D.");
 
 	ERR_FAIL_NULL(NavMeshGenerator3D::get_singleton());
 	NavMeshGenerator3D::get_singleton()->bake_from_source_geometry_data(p_navigation_mesh, p_source_geometry_data, p_callback);
@@ -1184,8 +1184,8 @@ void GodotNavigationServer3D::bake_from_source_geometry_data(const Ref<Navigatio
 
 void GodotNavigationServer3D::bake_from_source_geometry_data_async(const Ref<NavigationMesh> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData3D> &p_source_geometry_data, const Callable &p_callback) {
 #ifndef _3D_DISABLED
-	ERR_FAIL_COND_MSG(!p_navigation_mesh.is_valid(), "Invalid navigation mesh.");
-	ERR_FAIL_COND_MSG(!p_source_geometry_data.is_valid(), "Invalid NavigationMeshSourceGeometryData3D.");
+	ERR_FAIL_COND_MSG(p_navigation_mesh.is_null(), "Invalid navigation mesh.");
+	ERR_FAIL_COND_MSG(p_source_geometry_data.is_null(), "Invalid NavigationMeshSourceGeometryData3D.");
 
 	ERR_FAIL_NULL(NavMeshGenerator3D::get_singleton());
 	NavMeshGenerator3D::get_singleton()->bake_from_source_geometry_data_async(p_navigation_mesh, p_source_geometry_data, p_callback);

--- a/modules/navigation/3d/nav_mesh_generator_3d.cpp
+++ b/modules/navigation/3d/nav_mesh_generator_3d.cpp
@@ -156,10 +156,10 @@ void NavMeshGenerator3D::finish() {
 
 void NavMeshGenerator3D::parse_source_geometry_data(Ref<NavigationMesh> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, Node *p_root_node, const Callable &p_callback) {
 	ERR_FAIL_COND(!Thread::is_main_thread());
-	ERR_FAIL_COND(!p_navigation_mesh.is_valid());
+	ERR_FAIL_COND(p_navigation_mesh.is_null());
 	ERR_FAIL_NULL(p_root_node);
 	ERR_FAIL_COND(!p_root_node->is_inside_tree());
-	ERR_FAIL_COND(!p_source_geometry_data.is_valid());
+	ERR_FAIL_COND(p_source_geometry_data.is_null());
 
 	generator_parse_source_geometry_data(p_navigation_mesh, p_source_geometry_data, p_root_node);
 
@@ -169,8 +169,8 @@ void NavMeshGenerator3D::parse_source_geometry_data(Ref<NavigationMesh> p_naviga
 }
 
 void NavMeshGenerator3D::bake_from_source_geometry_data(Ref<NavigationMesh> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, const Callable &p_callback) {
-	ERR_FAIL_COND(!p_navigation_mesh.is_valid());
-	ERR_FAIL_COND(!p_source_geometry_data.is_valid());
+	ERR_FAIL_COND(p_navigation_mesh.is_null());
+	ERR_FAIL_COND(p_source_geometry_data.is_null());
 
 	if (!p_source_geometry_data->has_data()) {
 		p_navigation_mesh->clear();
@@ -199,8 +199,8 @@ void NavMeshGenerator3D::bake_from_source_geometry_data(Ref<NavigationMesh> p_na
 }
 
 void NavMeshGenerator3D::bake_from_source_geometry_data_async(Ref<NavigationMesh> p_navigation_mesh, Ref<NavigationMeshSourceGeometryData3D> p_source_geometry_data, const Callable &p_callback) {
-	ERR_FAIL_COND(!p_navigation_mesh.is_valid());
-	ERR_FAIL_COND(!p_source_geometry_data.is_valid());
+	ERR_FAIL_COND(p_navigation_mesh.is_null());
+	ERR_FAIL_COND(p_source_geometry_data.is_null());
 
 	if (!p_source_geometry_data->has_data()) {
 		p_navigation_mesh->clear();

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
@@ -62,7 +62,7 @@ void NavigationMeshEditor::_bake_pressed() {
 
 	ERR_FAIL_NULL(node);
 	Ref<NavigationMesh> navmesh = node->get_navigation_mesh();
-	if (!navmesh.is_valid()) {
+	if (navmesh.is_null()) {
 		err_dialog->set_text(TTR("A NavigationMesh resource must be set or created for this node to work."));
 		err_dialog->popup_centered();
 		return;

--- a/modules/openxr/extensions/openxr_dpad_binding_extension.cpp
+++ b/modules/openxr/extensions/openxr_dpad_binding_extension.cpp
@@ -245,7 +245,7 @@ PackedByteArray OpenXRDpadBindingModifier::get_ip_modification() {
 	ERR_FAIL_COND_V(dpad_bindings->binding == XR_NULL_PATH, PackedByteArray());
 
 	// Get our action set
-	ERR_FAIL_COND_V(!action_set.is_valid(), PackedByteArray());
+	ERR_FAIL_COND_V(action_set.is_null(), PackedByteArray());
 	RID action_set_rid = openxr_api->find_action_set(action_set->get_name());
 	ERR_FAIL_COND_V(!action_set_rid.is_valid(), PackedByteArray());
 	dpad_bindings->actionSet = openxr_api->action_set_get_handle(action_set_rid);

--- a/modules/openxr/extensions/openxr_valve_analog_threshold_extension.cpp
+++ b/modules/openxr/extensions/openxr_valve_analog_threshold_extension.cpp
@@ -152,11 +152,11 @@ PackedByteArray OpenXRAnalogThresholdModifier::get_ip_modification() {
 	ERR_FAIL_NULL_V(ip_binding, ret);
 
 	Ref<OpenXRAction> action = ip_binding->get_action();
-	ERR_FAIL_COND_V(!action.is_valid(), ret);
+	ERR_FAIL_COND_V(action.is_null(), ret);
 
 	// Get our action set
 	Ref<OpenXRActionSet> action_set = action->get_action_set();
-	ERR_FAIL_COND_V(!action_set.is_valid(), ret);
+	ERR_FAIL_COND_V(action_set.is_null(), ret);
 	RID action_set_rid = openxr_api->find_action_set(action_set->get_name());
 	ERR_FAIL_COND_V(!action_set_rid.is_valid(), ret);
 

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -39,7 +39,7 @@
 Error ResourceSaverWebP::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<ImageTexture> texture = p_resource;
 
-	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as WebP.");
+	ERR_FAIL_COND_V_MSG(texture.is_null(), ERR_INVALID_PARAMETER, "Can't save invalid texture as WebP.");
 	ERR_FAIL_COND_V_MSG(!texture->get_width(), ERR_INVALID_PARAMETER, "Can't save empty texture as WebP.");
 
 	Ref<Image> img = texture->get_image();

--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -293,7 +293,7 @@ Error WebRTCMultiplayerPeer::add_peer(Ref<WebRTCPeerConnection> p_peer, int p_pe
 	ERR_FAIL_COND_V(p_unreliable_lifetime < 0, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(is_refusing_new_connections(), ERR_UNAUTHORIZED);
 	// Peer must be valid, and in new state (to create data channels)
-	ERR_FAIL_COND_V(!p_peer.is_valid(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_peer.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_peer->get_connection_state() != WebRTCPeerConnection::STATE_NEW, ERR_INVALID_PARAMETER);
 
 	Ref<ConnectedPeer> peer = memnew(ConnectedPeer);

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -168,7 +168,7 @@ bool OS_Android::copy_dynamic_library(const String &p_library_path, const String
 	}
 
 	Ref<DirAccess> da_ref = DirAccess::create_for_path(p_library_path);
-	if (!da_ref.is_valid()) {
+	if (da_ref.is_null()) {
 		return false;
 	}
 

--- a/platform/ios/export/godot_plugin_config.cpp
+++ b/platform/ios/export/godot_plugin_config.cpp
@@ -169,7 +169,7 @@ uint64_t PluginConfigIOS::get_plugin_modification_time(const PluginConfigIOS &pl
 PluginConfigIOS PluginConfigIOS::load_plugin_config(Ref<ConfigFile> config_file, const String &path) {
 	PluginConfigIOS plugin_config = {};
 
-	if (!config_file.is_valid()) {
+	if (config_file.is_null()) {
 		return plugin_config;
 	}
 

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3880,7 +3880,7 @@ void WaylandThread::cursor_set_shape(DisplayServer::CursorShape p_cursor_shape) 
 }
 
 void WaylandThread::cursor_shape_set_custom_image(DisplayServer::CursorShape p_cursor_shape, Ref<Image> p_image, const Point2i &p_hotspot) {
-	ERR_FAIL_COND(!p_image.is_valid());
+	ERR_FAIL_COND(p_image.is_null());
 
 	Size2i image_size = p_image->get_size();
 

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -113,7 +113,7 @@ Rect2 AnimatedSprite2D::_get_rect() const {
 }
 
 void AnimatedSprite2D::_validate_property(PropertyInfo &p_property) const {
-	if (!frames.is_valid()) {
+	if (frames.is_null()) {
 		return;
 	}
 
@@ -168,7 +168,7 @@ void AnimatedSprite2D::_validate_property(PropertyInfo &p_property) const {
 void AnimatedSprite2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			if (!Engine::get_singleton()->is_editor_hint() && !frames.is_null() && frames->has_animation(autoplay)) {
+			if (!Engine::get_singleton()->is_editor_hint() && frames.is_valid() && frames->has_animation(autoplay)) {
 				play(autoplay);
 			}
 		} break;

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -329,7 +329,7 @@ real_t CPUParticles2D::get_param_max(Parameter p_param) const {
 
 static void _adjust_curve_range(const Ref<Curve> &p_curve, real_t p_min, real_t p_max) {
 	Ref<Curve> curve = p_curve;
-	if (!curve.is_valid()) {
+	if (curve.is_null()) {
 		return;
 	}
 

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -379,7 +379,7 @@ Rect2 PointLight2D::_edit_get_rect() const {
 }
 
 bool PointLight2D::_edit_use_rect() const {
-	return !texture.is_null();
+	return texture.is_valid();
 }
 #endif // DEBUG_ENABLED
 
@@ -433,7 +433,7 @@ Vector2 PointLight2D::get_texture_offset() const {
 PackedStringArray PointLight2D::get_configuration_warnings() const {
 	PackedStringArray warnings = Light2D::get_configuration_warnings();
 
-	if (!texture.is_valid()) {
+	if (texture.is_null()) {
 		warnings.push_back(RTR("A texture with the shape of the light must be supplied to the \"Texture\" property."));
 	}
 

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -266,7 +266,7 @@ int LightOccluder2D::get_occluder_light_mask() const {
 PackedStringArray LightOccluder2D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node2D::get_configuration_warnings();
 
-	if (!occluder_polygon.is_valid()) {
+	if (occluder_polygon.is_null()) {
 		warnings.push_back(RTR("An occluder polygon must be set (or drawn) for this occluder to take effect."));
 	}
 

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -242,7 +242,7 @@ RID NavigationRegion2D::get_navigation_map() const {
 
 void NavigationRegion2D::bake_navigation_polygon(bool p_on_thread) {
 	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "The SceneTree can only be parsed on the main thread. Call this function from the main thread or use call_deferred().");
-	ERR_FAIL_COND_MSG(!navigation_polygon.is_valid(), "Baking the navigation polygon requires a valid `NavigationPolygon` resource.");
+	ERR_FAIL_COND_MSG(navigation_polygon.is_null(), "Baking the navigation polygon requires a valid `NavigationPolygon` resource.");
 
 	Ref<NavigationMeshSourceGeometryData2D> source_geometry_data;
 	source_geometry_data.instantiate();
@@ -299,7 +299,7 @@ PackedStringArray NavigationRegion2D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node2D::get_configuration_warnings();
 
 	if (is_visible_in_tree() && is_inside_tree()) {
-		if (!navigation_polygon.is_valid()) {
+		if (navigation_polygon.is_null()) {
 			warnings.push_back(RTR("A NavigationMesh resource must be set or created for this node to work. Please set a property or draw a polygon."));
 		}
 	}

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -39,7 +39,7 @@
 
 #ifdef DEBUG_ENABLED
 Rect2 Path2D::_edit_get_rect() const {
-	if (!curve.is_valid() || curve->get_point_count() == 0) {
+	if (curve.is_null() || curve->get_point_count() == 0) {
 		return Rect2(0, 0, 0, 0);
 	}
 
@@ -90,7 +90,7 @@ void Path2D::_notification(int p_what) {
 	switch (p_what) {
 		// Draw the curve if path debugging is enabled.
 		case NOTIFICATION_DRAW: {
-			if (!curve.is_valid()) {
+			if (curve.is_null()) {
 				break;
 			}
 
@@ -220,7 +220,7 @@ void PathFollow2D::_update_transform() {
 	}
 
 	Ref<Curve2D> c = path->get_curve();
-	if (!c.is_valid()) {
+	if (c.is_null()) {
 		return;
 	}
 

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -51,7 +51,7 @@ void CollisionObject2D::_notification(int p_what) {
 
 			if (!disabled || (disable_mode != DISABLE_MODE_REMOVE)) {
 				Ref<World2D> world_ref = get_world_2d();
-				ERR_FAIL_COND(!world_ref.is_valid());
+				ERR_FAIL_COND(world_ref.is_null());
 				RID space = world_ref->get_space();
 				if (area) {
 					PhysicsServer2D::get_singleton()->area_set_space(rid, space);

--- a/scene/2d/physics/collision_shape_2d.cpp
+++ b/scene/2d/physics/collision_shape_2d.cpp
@@ -89,7 +89,7 @@ void CollisionShape2D::_notification(int p_what) {
 				break;
 			}
 
-			if (!shape.is_valid()) {
+			if (shape.is_null()) {
 				break;
 			}
 
@@ -161,7 +161,7 @@ Ref<Shape2D> CollisionShape2D::get_shape() const {
 }
 
 bool CollisionShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
-	if (!shape.is_valid()) {
+	if (shape.is_null()) {
 		return false;
 	}
 
@@ -175,7 +175,7 @@ PackedStringArray CollisionShape2D::get_configuration_warnings() const {
 	if (col_object == nullptr) {
 		warnings.push_back(RTR("CollisionShape2D only serves to provide a collision shape to a CollisionObject2D derived node.\nPlease only use it as a child of Area2D, StaticBody2D, RigidBody2D, CharacterBody2D, etc. to give them a shape."));
 	}
-	if (!shape.is_valid()) {
+	if (shape.is_null()) {
 		warnings.push_back(RTR("A shape must be provided for CollisionShape2D to function. Please create a shape resource for it!"));
 	}
 	if (one_way_collision && Object::cast_to<Area2D>(col_object)) {

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -767,7 +767,7 @@ Ref<SkeletonModificationStack2D> Skeleton2D::get_modification_stack() const {
 }
 
 void Skeleton2D::execute_modifications(real_t p_delta, int p_execution_mode) {
-	if (!modification_stack.is_valid()) {
+	if (modification_stack.is_null()) {
 		return;
 	}
 

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -549,7 +549,7 @@ Ref<TileMapPattern> TileMap::get_pattern(int p_layer, TypedArray<Vector2i> p_coo
 }
 
 Vector2i TileMap::map_pattern(const Vector2i &p_position_in_tilemap, const Vector2i &p_coords_in_pattern, Ref<TileMapPattern> p_pattern) {
-	ERR_FAIL_COND_V(!tile_set.is_valid(), Vector2i());
+	ERR_FAIL_COND_V(tile_set.is_null(), Vector2i());
 	return tile_set->map_pattern(p_position_in_tilemap, p_coords_in_pattern, p_pattern);
 }
 
@@ -738,22 +738,22 @@ void TileMap::_get_property_list(List<PropertyInfo> *p_list) const {
 }
 
 Vector2 TileMap::map_to_local(const Vector2i &p_pos) const {
-	ERR_FAIL_COND_V(!tile_set.is_valid(), Vector2());
+	ERR_FAIL_COND_V(tile_set.is_null(), Vector2());
 	return tile_set->map_to_local(p_pos);
 }
 
 Vector2i TileMap::local_to_map(const Vector2 &p_pos) const {
-	ERR_FAIL_COND_V(!tile_set.is_valid(), Vector2i());
+	ERR_FAIL_COND_V(tile_set.is_null(), Vector2i());
 	return tile_set->local_to_map(p_pos);
 }
 
 bool TileMap::is_existing_neighbor(TileSet::CellNeighbor p_cell_neighbor) const {
-	ERR_FAIL_COND_V(!tile_set.is_valid(), false);
+	ERR_FAIL_COND_V(tile_set.is_null(), false);
 	return tile_set->is_existing_neighbor(p_cell_neighbor);
 }
 
 Vector2i TileMap::get_neighbor_cell(const Vector2i &p_coords, TileSet::CellNeighbor p_cell_neighbor) const {
-	ERR_FAIL_COND_V(!tile_set.is_valid(), Vector2i());
+	ERR_FAIL_COND_V(tile_set.is_null(), Vector2i());
 	return tile_set->get_neighbor_cell(p_coords, p_cell_neighbor);
 }
 
@@ -819,7 +819,7 @@ void TileMap::set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) {
 }
 
 TypedArray<Vector2i> TileMap::get_surrounding_cells(const Vector2i &p_coords) {
-	if (!tile_set.is_valid()) {
+	if (tile_set.is_null()) {
 		return TypedArray<Vector2i>();
 	}
 

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -309,7 +309,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 							rs->canvas_item_set_material(ci, mat->get_rid());
 						}
 						rs->canvas_item_set_parent(ci, get_canvas_item());
-						rs->canvas_item_set_use_parent_material(ci, !mat.is_valid());
+						rs->canvas_item_set_use_parent_material(ci, mat.is_null());
 
 						Transform2D xform(0, rendering_quadrant->canvas_items_position);
 						rs->canvas_item_set_transform(ci, xform);
@@ -668,7 +668,7 @@ void TileMapLayer::_rendering_draw_cell_debug(const RID &p_canvas_item, const Ve
 			TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
 			if (atlas_source) {
 				Vector2i grid_size = atlas_source->get_atlas_grid_size();
-				if (!atlas_source->get_runtime_texture().is_valid() || c.get_atlas_coords().x >= grid_size.x || c.get_atlas_coords().y >= grid_size.y) {
+				if (atlas_source->get_runtime_texture().is_null() || c.get_atlas_coords().x >= grid_size.x || c.get_atlas_coords().y >= grid_size.y) {
 					// Generate a random color from the hashed values of the tiles.
 					Array to_hash;
 					to_hash.push_back(c.source_id);
@@ -851,7 +851,7 @@ void TileMapLayer::_physics_update_cell(CellData &r_cell_data) {
 						ps->body_set_state(body, PhysicsServer2D::BODY_STATE_LINEAR_VELOCITY, tile_data->get_constant_linear_velocity(tile_set_physics_layer));
 						ps->body_set_state(body, PhysicsServer2D::BODY_STATE_ANGULAR_VELOCITY, tile_data->get_constant_angular_velocity(tile_set_physics_layer));
 
-						if (!physics_material.is_valid()) {
+						if (physics_material.is_null()) {
 							ps->body_set_param(body, PhysicsServer2D::BODY_PARAM_BOUNCE, 0);
 							ps->body_set_param(body, PhysicsServer2D::BODY_PARAM_FRICTION, 1);
 						} else {
@@ -1328,7 +1328,7 @@ void TileMapLayer::_scenes_draw_cell_debug(const RID &p_canvas_item, const Vecto
 
 		TileSetScenesCollectionSource *scenes_collection_source = Object::cast_to<TileSetScenesCollectionSource>(source);
 		if (scenes_collection_source) {
-			if (!scenes_collection_source->get_scene_tile_scene(c.alternative_tile).is_valid() || scenes_collection_source->get_scene_tile_display_placeholder(c.alternative_tile)) {
+			if (scenes_collection_source->get_scene_tile_scene(c.alternative_tile).is_null() || scenes_collection_source->get_scene_tile_display_placeholder(c.alternative_tile)) {
 				// Generate a random color from the hashed values of the tiles.
 				Array to_hash;
 				to_hash.push_back(c.source_id);
@@ -3078,7 +3078,7 @@ HashMap<Vector2i, TileSet::CellNeighbor> TerrainConstraint::get_overlapping_coor
 	HashMap<Vector2i, TileSet::CellNeighbor> output;
 
 	ERR_FAIL_COND_V(is_center_bit(), output);
-	ERR_FAIL_COND_V(!tile_set.is_valid(), output);
+	ERR_FAIL_COND_V(tile_set.is_null(), output);
 
 	TileSet::TileShape shape = tile_set->get_tile_shape();
 	if (shape == TileSet::TILE_SHAPE_SQUARE) {
@@ -3182,7 +3182,7 @@ HashMap<Vector2i, TileSet::CellNeighbor> TerrainConstraint::get_overlapping_coor
 }
 
 TerrainConstraint::TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, int p_terrain) {
-	ERR_FAIL_COND(!p_tile_set.is_valid());
+	ERR_FAIL_COND(p_tile_set.is_null());
 	tile_set = p_tile_set;
 	bit = 0;
 	base_cell_coords = p_position;
@@ -3191,7 +3191,7 @@ TerrainConstraint::TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_
 
 TerrainConstraint::TerrainConstraint(Ref<TileSet> p_tile_set, const Vector2i &p_position, const TileSet::CellNeighbor &p_bit, int p_terrain) {
 	// The way we build the constraint make it easy to detect conflicting constraints.
-	ERR_FAIL_COND(!p_tile_set.is_valid());
+	ERR_FAIL_COND(p_tile_set.is_null());
 	tile_set = p_tile_set;
 
 	TileSet::TileShape shape = tile_set->get_tile_shape();

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -340,7 +340,7 @@ Rect2 TouchScreenButton::_edit_get_rect() const {
 }
 
 bool TouchScreenButton::_edit_use_rect() const {
-	return !texture_normal.is_null();
+	return texture_normal.is_valid();
 }
 #endif // DEBUG_ENABLED
 

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -309,7 +309,7 @@ real_t CPUParticles3D::get_param_max(Parameter p_param) const {
 
 static void _adjust_curve_range(const Ref<Curve> &p_curve, real_t p_min, real_t p_max) {
 	Ref<Curve> curve = p_curve;
-	if (!curve.is_valid()) {
+	if (curve.is_null()) {
 		return;
 	}
 

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -381,7 +381,7 @@ PackedStringArray GPUParticles3D::get_configuration_warnings() const {
 			warnings.push_back(RTR("Only one Trail mesh is supported. If you want to use more than a single mesh, a Skin is needed (see documentation)."));
 		}
 
-		if ((dp_count || !skin.is_null()) && (missing_trails || no_materials)) {
+		if ((dp_count || skin.is_valid()) && (missing_trails || no_materials)) {
 			warnings.push_back(RTR("Trails enabled, but one or more mesh materials are either missing or not set for trails rendering."));
 		}
 		if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -172,7 +172,7 @@ void GPUParticlesCollisionSDF3D::_find_meshes(const AABB &p_aabb, Node *p_at_nod
 			for (int i = 0; i < meshes.size(); i += 2) {
 				Transform3D mxf = meshes[i];
 				Ref<Mesh> mesh = meshes[i + 1];
-				if (!mesh.is_valid()) {
+				if (mesh.is_null()) {
 					continue;
 				}
 

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -423,7 +423,7 @@ void LightmapGI::_find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound> &m
 			Transform3D xf = get_global_transform().affine_inverse() * s->get_global_transform();
 			for (int i = 0; i < bmeshes.size(); i += 2) {
 				Ref<Mesh> mesh = bmeshes[i];
-				if (!mesh.is_valid()) {
+				if (mesh.is_null()) {
 					continue;
 				}
 
@@ -1496,7 +1496,7 @@ void LightmapGI::_notification(int p_what) {
 }
 
 void LightmapGI::_assign_lightmaps() {
-	ERR_FAIL_COND(!light_data.is_valid());
+	ERR_FAIL_COND(light_data.is_null());
 
 	for (int i = 0; i < light_data->get_user_count(); i++) {
 		Node *node = get_node(light_data->get_user_path(i));
@@ -1515,7 +1515,7 @@ void LightmapGI::_assign_lightmaps() {
 }
 
 void LightmapGI::_clear_lightmaps() {
-	ERR_FAIL_COND(!light_data.is_valid());
+	ERR_FAIL_COND(light_data.is_null());
 	for (int i = 0; i < light_data->get_user_count(); i++) {
 		Node *node = get_node(light_data->get_user_path(i));
 		int instance_idx = light_data->get_user_sub_instance(i);

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -216,7 +216,7 @@ NodePath MeshInstance3D::get_skeleton_path() {
 }
 
 AABB MeshInstance3D::get_aabb() const {
-	if (!mesh.is_null()) {
+	if (mesh.is_valid()) {
 		return mesh->get_aabb();
 	}
 
@@ -413,7 +413,7 @@ MeshInstance3D *MeshInstance3D::create_debug_tangents_node() {
 	Vector<Color> colors;
 
 	Ref<Mesh> m = get_mesh();
-	if (!m.is_valid()) {
+	if (m.is_null()) {
 		return nullptr;
 	}
 

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -1116,7 +1116,7 @@ void NavigationAgent3D::_update_debug_path() {
 
 	Ref<StandardMaterial3D> debug_agent_path_line_material = NavigationServer3D::get_singleton()->get_debug_navigation_agent_path_line_material();
 	if (debug_use_custom) {
-		if (!debug_agent_path_line_custom_material.is_valid()) {
+		if (debug_agent_path_line_custom_material.is_null()) {
 			debug_agent_path_line_custom_material = debug_agent_path_line_material->duplicate();
 		}
 		debug_agent_path_line_custom_material->set_albedo(debug_path_custom_color);
@@ -1140,7 +1140,7 @@ void NavigationAgent3D::_update_debug_path() {
 
 		Ref<StandardMaterial3D> debug_agent_path_point_material = NavigationServer3D::get_singleton()->get_debug_navigation_agent_path_point_material();
 		if (debug_use_custom) {
-			if (!debug_agent_path_point_custom_material.is_valid()) {
+			if (debug_agent_path_point_custom_material.is_null()) {
 				debug_agent_path_point_custom_material = debug_agent_path_point_material->duplicate();
 			}
 			debug_agent_path_point_custom_material->set_albedo(debug_path_custom_color);

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -242,7 +242,7 @@ RID NavigationRegion3D::get_navigation_map() const {
 
 void NavigationRegion3D::bake_navigation_mesh(bool p_on_thread) {
 	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "The SceneTree can only be parsed on the main thread. Call this function from the main thread or use call_deferred().");
-	ERR_FAIL_COND_MSG(!navigation_mesh.is_valid(), "Baking the navigation mesh requires a valid `NavigationMesh` resource.");
+	ERR_FAIL_COND_MSG(navigation_mesh.is_null(), "Baking the navigation mesh requires a valid `NavigationMesh` resource.");
 
 	Ref<NavigationMeshSourceGeometryData3D> source_geometry_data;
 	source_geometry_data.instantiate();
@@ -274,7 +274,7 @@ PackedStringArray NavigationRegion3D::get_configuration_warnings() const {
 	PackedStringArray warnings = Node3D::get_configuration_warnings();
 
 	if (is_visible_in_tree() && is_inside_tree()) {
-		if (!navigation_mesh.is_valid()) {
+		if (navigation_mesh.is_null()) {
 			warnings.push_back(RTR("A NavigationMesh resource must be set or created for this node to work."));
 		}
 	}
@@ -481,7 +481,7 @@ void NavigationRegion3D::_update_debug_mesh() {
 		return;
 	}
 
-	if (!navigation_mesh.is_valid()) {
+	if (navigation_mesh.is_null()) {
 		if (debug_instance.is_valid()) {
 			RS::get_singleton()->instance_set_visible(debug_instance, false);
 		}
@@ -658,7 +658,7 @@ void NavigationRegion3D::_update_debug_edge_connections_mesh() {
 		return;
 	}
 
-	if (!navigation_mesh.is_valid()) {
+	if (navigation_mesh.is_null()) {
 		if (debug_edge_connections_instance.is_valid()) {
 			RS::get_singleton()->instance_set_visible(debug_edge_connections_instance, false);
 		}

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -92,7 +92,7 @@ void Path3D::_update_debug_mesh() {
 		debug_mesh.instantiate();
 	}
 
-	if (!(curve.is_valid())) {
+	if (curve.is_null()) {
 		RS::get_singleton()->instance_set_visible(debug_instance, false);
 		return;
 	}
@@ -222,7 +222,7 @@ void PathFollow3D::update_transform() {
 	}
 
 	Ref<Curve3D> c = path->get_curve();
-	if (!c.is_valid()) {
+	if (c.is_null()) {
 		return;
 	}
 

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -70,7 +70,7 @@ void CollisionObject3D::_notification(int p_what) {
 
 			if (!disabled || (disable_mode != DISABLE_MODE_REMOVE)) {
 				Ref<World3D> world_ref = get_world_3d();
-				ERR_FAIL_COND(!world_ref.is_valid());
+				ERR_FAIL_COND(world_ref.is_null());
 				RID space = world_ref->get_space();
 				if (area) {
 					PhysicsServer3D::get_singleton()->area_set_space(rid, space);

--- a/scene/3d/physics/collision_shape_3d.cpp
+++ b/scene/3d/physics/collision_shape_3d.cpp
@@ -127,7 +127,7 @@ PackedStringArray CollisionShape3D::get_configuration_warnings() const {
 		warnings.push_back(RTR("CollisionShape3D only serves to provide a collision shape to a CollisionObject3D derived node.\nPlease only use it as a child of Area3D, StaticBody3D, RigidBody3D, CharacterBody3D, etc. to give them a shape."));
 	}
 
-	if (!shape.is_valid()) {
+	if (shape.is_null()) {
 		warnings.push_back(RTR("A shape must be provided for CollisionShape3D to function. Please create a shape resource for it."));
 	}
 

--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -468,7 +468,7 @@ void RayCast3D::_create_debug_shape() {
 }
 
 void RayCast3D::_update_debug_shape_material(bool p_check_collision) {
-	if (!debug_material.is_valid()) {
+	if (debug_material.is_null()) {
 		Ref<StandardMaterial3D> material = memnew(StandardMaterial3D);
 		debug_material = material;
 

--- a/scene/3d/physics/shape_cast_3d.cpp
+++ b/scene/3d/physics/shape_cast_3d.cpp
@@ -498,7 +498,7 @@ void ShapeCast3D::_update_debug_shape_vertices() {
 	debug_shape_vertices.clear();
 	debug_line_vertices.clear();
 
-	if (!shape.is_null()) {
+	if (shape.is_valid()) {
 		debug_shape_vertices.append_array(shape->get_debug_mesh_lines());
 		for (int i = 0; i < debug_shape_vertices.size(); i++) {
 			debug_shape_vertices.set(i, debug_shape_vertices[i] + Vector3(target_position * get_closest_collision_safe_fraction()));
@@ -550,7 +550,7 @@ void ShapeCast3D::_create_debug_shape() {
 }
 
 void ShapeCast3D::_update_debug_shape_material(bool p_check_collision) {
-	if (!debug_material.is_valid()) {
+	if (debug_material.is_null()) {
 		Ref<StandardMaterial3D> material = memnew(StandardMaterial3D);
 		debug_material = material;
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1031,7 +1031,7 @@ void AnimatedSprite3D::_draw() {
 }
 
 void AnimatedSprite3D::_validate_property(PropertyInfo &p_property) const {
-	if (!frames.is_valid()) {
+	if (frames.is_null()) {
 		return;
 	}
 
@@ -1086,7 +1086,7 @@ void AnimatedSprite3D::_validate_property(PropertyInfo &p_property) const {
 void AnimatedSprite3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
-			if (!Engine::get_singleton()->is_editor_hint() && !frames.is_null() && frames->has_animation(autoplay)) {
+			if (!Engine::get_singleton()->is_editor_hint() && frames.is_valid() && frames->has_animation(autoplay)) {
 				play(autoplay);
 			}
 		} break;

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -361,7 +361,7 @@ void VoxelGI::_find_meshes(Node *p_at_node, List<PlotMesh> &plot_meshes) {
 			for (int i = 0; i < meshes.size(); i += 2) {
 				Transform3D mxf = meshes[i];
 				Ref<Mesh> mesh = meshes[i + 1];
-				if (!mesh.is_valid()) {
+				if (mesh.is_null()) {
 					continue;
 				}
 

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -184,7 +184,7 @@ Ref<Compositor> WorldEnvironment::get_compositor() const {
 PackedStringArray WorldEnvironment::get_configuration_warnings() const {
 	PackedStringArray warnings = Node::get_configuration_warnings();
 
-	if (!environment.is_valid() && !camera_attributes.is_valid()) {
+	if (environment.is_null() && camera_attributes.is_null()) {
 		warnings.push_back(RTR("To have any visible effect, WorldEnvironment requires its \"Environment\" property to contain an Environment, its \"Camera Attributes\" property to contain a CameraAttributes resource, or both."));
 	}
 

--- a/scene/3d/xr_body_modifier_3d.cpp
+++ b/scene/3d/xr_body_modifier_3d.cpp
@@ -250,7 +250,7 @@ void XRBodyModifier3D::_process_modification() {
 	}
 
 	const Ref<XRBodyTracker> tracker = xr_server->get_tracker(tracker_name);
-	if (!tracker.is_valid()) {
+	if (tracker.is_null()) {
 		return;
 	}
 

--- a/scene/3d/xr_face_modifier_3d.cpp
+++ b/scene/3d/xr_face_modifier_3d.cpp
@@ -577,7 +577,7 @@ void XRFaceModifier3D::_update_face_blends() const {
 
 	// Get the face tracker.
 	const Ref<XRFaceTracker> tracker = xr_server->get_tracker(tracker_name);
-	if (!tracker.is_valid()) {
+	if (tracker.is_null()) {
 		return;
 	}
 

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -612,7 +612,7 @@ Vector2 XRController3D::get_vector2(const StringName &p_name) const {
 
 XRPositionalTracker::TrackerHand XRController3D::get_tracker_hand() const {
 	// get our XRServer
-	if (!tracker.is_valid()) {
+	if (tracker.is_null()) {
 		return XRPositionalTracker::TRACKER_HAND_UNKNOWN;
 	}
 

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -379,7 +379,7 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace1D::_process(const AnimationM
 				// For ping-pong loop.
 				Ref<AnimationNodeAnimation> na_c = static_cast<Ref<AnimationNodeAnimation>>(blend_points[cur_closest].node);
 				Ref<AnimationNodeAnimation> na_n = static_cast<Ref<AnimationNodeAnimation>>(blend_points[new_closest].node);
-				if (!na_c.is_null() && !na_n.is_null()) {
+				if (na_c.is_valid() && na_n.is_valid()) {
 					na_n->set_backward(na_c->is_backward());
 				}
 				// See how much animation remains.

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -556,7 +556,7 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(const AnimationM
 				// For ping-pong loop.
 				Ref<AnimationNodeAnimation> na_c = static_cast<Ref<AnimationNodeAnimation>>(blend_points[cur_closest].node);
 				Ref<AnimationNodeAnimation> na_n = static_cast<Ref<AnimationNodeAnimation>>(blend_points[new_closest].node);
-				if (!na_c.is_null() && !na_n.is_null()) {
+				if (na_c.is_valid() && na_n.is_valid()) {
 					na_n->set_backward(na_c->is_backward());
 				}
 				// See how much animation remains.

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -201,7 +201,7 @@ void AnimationNodeStateMachinePlayback::_set_current(AnimationNodeStateMachine *
 	}
 
 	Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(current);
-	if (!anodesm.is_valid()) {
+	if (anodesm.is_null()) {
 		group_start_transition = Ref<AnimationNodeStateMachineTransition>();
 		group_end_transition = Ref<AnimationNodeStateMachineTransition>();
 		return;
@@ -353,7 +353,7 @@ void AnimationNodeStateMachinePlayback::_clear_path_children(AnimationTree *p_tr
 		Ref<AnimationNodeStateMachine> anodesm = child_node.node;
 		if (anodesm.is_valid() && anodesm->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + child_node.name + "/playback");
-			ERR_FAIL_COND(!playback.is_valid());
+			ERR_FAIL_COND(playback.is_null());
 			playback->_set_base_path(base_path + child_node.name + "/");
 			if (p_test_only) {
 				playback = playback->duplicate();
@@ -383,7 +383,7 @@ void AnimationNodeStateMachinePlayback::_start_children(AnimationTree *p_tree, A
 				ERR_FAIL_MSG("Root/Nested AnimationNodeStateMachine can't have path from parent AnimationNodeStateMachine.");
 			}
 			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + concatenated + "/playback");
-			ERR_FAIL_COND(!playback.is_valid());
+			ERR_FAIL_COND(playback.is_null());
 			playback->_set_base_path(base_path + concatenated + "/");
 			if (p_test_only) {
 				playback = playback->duplicate();
@@ -415,7 +415,7 @@ bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, 
 				ERR_FAIL_V_MSG(false, "Root/Nested AnimationNodeStateMachine can't have path from parent AnimationNodeStateMachine.");
 			}
 			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + concatenated + "/playback");
-			ERR_FAIL_COND_V(!playback.is_valid(), false);
+			ERR_FAIL_COND_V(playback.is_null(), false);
 			playback->_set_base_path(base_path + concatenated + "/");
 			if (p_test_only) {
 				playback = playback->duplicate();
@@ -434,11 +434,11 @@ bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, 
 				String child_path = "/" + playback->get_current_node();
 				while (true) {
 					Ref<AnimationNodeStateMachine> child_anodesm = p_state_machine->find_node_by_path(concatenated + child_path);
-					if (!child_anodesm.is_valid() || child_anodesm->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
+					if (child_anodesm.is_null() || child_anodesm->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 						break;
 					}
 					Ref<AnimationNodeStateMachinePlayback> child_playback = p_tree->get(base_path + concatenated + child_path + "/playback");
-					ERR_FAIL_COND_V(!child_playback.is_valid(), false);
+					ERR_FAIL_COND_V(child_playback.is_null(), false);
 					child_playback->_set_base_path(base_path + concatenated + "/");
 					if (p_test_only) {
 						child_playback = child_playback->duplicate();
@@ -645,7 +645,7 @@ bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree,
 			Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(current_path);
 			if (anodesm.is_valid() && anodesm->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 				Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + current_path + "/playback");
-				ERR_FAIL_COND_V(!playback.is_valid(), false);
+				ERR_FAIL_COND_V(playback.is_null(), false);
 				playback->_set_base_path(base_path + current_path + "/");
 				if (p_test_only) {
 					playback = playback->duplicate();
@@ -992,7 +992,7 @@ bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationTree *p
 		Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(current);
 		if (anodesm.is_valid() && anodesm->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 			Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(base_path + current + "/playback");
-			ERR_FAIL_COND_V(!playback.is_valid(), false);
+			ERR_FAIL_COND_V(playback.is_null(), false);
 			playback->_set_base_path(base_path + current + "/");
 			if (p_test_only) {
 				playback = playback->duplicate();
@@ -1148,7 +1148,7 @@ Ref<AnimationNodeStateMachinePlayback> AnimationNodeStateMachinePlayback::_get_p
 	split.remove_at(split.size() - 2);
 	String playback_path = String("/").join(split) + "playback";
 	Ref<AnimationNodeStateMachinePlayback> playback = p_tree->get(playback_path);
-	if (!playback.is_valid()) {
+	if (playback.is_null()) {
 		ERR_PRINT_ONCE("Can't get parent AnimationNodeStateMachinePlayback with path: " + playback_path + ". Maybe there is no Root/Nested AnimationNodeStateMachine in the parent of the Grouped AnimationNodeStateMachine.");
 		return Ref<AnimationNodeStateMachinePlayback>();
 	}

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -473,7 +473,7 @@ Ref<AnimationNode> AnimationNode::find_node_by_path(const String &p_name) const 
 	Ref<AnimationNode> ret = const_cast<AnimationNode *>(this);
 	for (int i = 0; i < split.size(); i++) {
 		ret = ret->get_child_by_name(split[i]);
-		if (!ret.is_valid()) {
+		if (ret.is_null()) {
 			break;
 		}
 	}
@@ -635,7 +635,7 @@ Ref<AnimationRootNode> AnimationTree::get_root_animation_node() const {
 bool AnimationTree::_blend_pre_process(double p_delta, int p_track_count, const AHashMap<NodePath, int> &p_track_map) {
 	_update_properties(); // If properties need updating, update them.
 
-	if (!root_animation_node.is_valid()) {
+	if (root_animation_node.is_null()) {
 		return false;
 	}
 
@@ -711,7 +711,7 @@ uint64_t AnimationTree::get_last_process_pass() const {
 
 PackedStringArray AnimationTree::get_configuration_warnings() const {
 	PackedStringArray warnings = AnimationMixer::get_configuration_warnings();
-	if (!root_animation_node.is_valid()) {
+	if (root_animation_node.is_null()) {
 		warnings.push_back(RTR("No root AnimationNode for the graph is set."));
 	}
 	return warnings;

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -555,7 +555,7 @@ void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 
 		PropertyHint hint = pi.hint;
 		String hint_string = pi.hint_string;
-		if (!res.is_null() && !res->get_path().is_empty()) {
+		if (res.is_valid() && !res->get_path().is_empty()) {
 			var = res->get_path();
 		} else { //only send information that can be sent..
 			int len = 0; //test how big is this to encode
@@ -793,7 +793,7 @@ void LiveEditor::_node_set_func(int p_id, const StringName &p_prop, const Varian
 
 void LiveEditor::_node_set_res_func(int p_id, const StringName &p_prop, const String &p_value) {
 	Ref<Resource> r = ResourceLoader::load(p_value);
-	if (!r.is_valid()) {
+	if (r.is_null()) {
 		return;
 	}
 	_node_set_func(p_id, p_prop, r);
@@ -875,7 +875,7 @@ void LiveEditor::_res_set_func(int p_id, const StringName &p_prop, const Variant
 	}
 
 	Ref<Resource> r = ResourceCache::get_ref(resp);
-	if (!r.is_valid()) {
+	if (r.is_null()) {
 		return;
 	}
 
@@ -884,7 +884,7 @@ void LiveEditor::_res_set_func(int p_id, const StringName &p_prop, const Variant
 
 void LiveEditor::_res_set_res_func(int p_id, const StringName &p_prop, const String &p_value) {
 	Ref<Resource> r = ResourceLoader::load(p_value);
-	if (!r.is_valid()) {
+	if (r.is_null()) {
 		return;
 	}
 	_res_set_func(p_id, p_prop, r);
@@ -902,7 +902,7 @@ void LiveEditor::_res_call_func(int p_id, const StringName &p_method, const Vari
 	}
 
 	Ref<Resource> r = ResourceCache::get_ref(resp);
-	if (!r.is_valid()) {
+	if (r.is_null()) {
 		return;
 	}
 
@@ -961,7 +961,7 @@ void LiveEditor::_instance_node_func(const NodePath &p_parent, const String &p_p
 
 	Ref<PackedScene> ps = ResourceLoader::load(p_path);
 
-	if (!ps.is_valid()) {
+	if (ps.is_null()) {
 		return;
 	}
 
@@ -1375,7 +1375,7 @@ void RuntimeNodeSelect::_root_window_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventMouseButton> b = p_event;
-	if (!b.is_valid() || !b->is_pressed()) {
+	if (b.is_null() || !b->is_pressed()) {
 		return;
 	}
 

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -35,7 +35,7 @@
 #include "scene/main/window.h"
 
 void BaseButton::_unpress_group() {
-	if (!button_group.is_valid()) {
+	if (button_group.is_null()) {
 		return;
 	}
 

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -34,28 +34,28 @@
 
 Size2 CheckBox::get_icon_size() const {
 	Size2 tex_size = Size2(0, 0);
-	if (!theme_cache.checked.is_null()) {
+	if (theme_cache.checked.is_valid()) {
 		tex_size = theme_cache.checked->get_size();
 	}
-	if (!theme_cache.unchecked.is_null()) {
+	if (theme_cache.unchecked.is_valid()) {
 		tex_size = tex_size.max(theme_cache.unchecked->get_size());
 	}
-	if (!theme_cache.radio_checked.is_null()) {
+	if (theme_cache.radio_checked.is_valid()) {
 		tex_size = tex_size.max(theme_cache.radio_checked->get_size());
 	}
-	if (!theme_cache.radio_unchecked.is_null()) {
+	if (theme_cache.radio_unchecked.is_valid()) {
 		tex_size = tex_size.max(theme_cache.radio_unchecked->get_size());
 	}
-	if (!theme_cache.checked_disabled.is_null()) {
+	if (theme_cache.checked_disabled.is_valid()) {
 		tex_size = tex_size.max(theme_cache.checked_disabled->get_size());
 	}
-	if (!theme_cache.unchecked_disabled.is_null()) {
+	if (theme_cache.unchecked_disabled.is_valid()) {
 		tex_size = tex_size.max(theme_cache.unchecked_disabled->get_size());
 	}
-	if (!theme_cache.radio_checked_disabled.is_null()) {
+	if (theme_cache.radio_checked_disabled.is_valid()) {
 		tex_size = tex_size.max(theme_cache.radio_checked_disabled->get_size());
 	}
-	if (!theme_cache.radio_unchecked_disabled.is_null()) {
+	if (theme_cache.radio_unchecked_disabled.is_valid()) {
 		tex_size = tex_size.max(theme_cache.radio_unchecked_disabled->get_size());
 	}
 	return _fit_icon_size(tex_size);

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -55,10 +55,10 @@ Size2 CheckButton::get_icon_size() const {
 	}
 
 	Size2 tex_size = Size2(0, 0);
-	if (!on_tex.is_null()) {
+	if (on_tex.is_valid()) {
 		tex_size = on_tex->get_size();
 	}
-	if (!off_tex.is_null()) {
+	if (off_tex.is_valid()) {
 		tex_size = tex_size.max(off_tex->get_size());
 	}
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -486,10 +486,10 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 
 	bool update_code_completion = false;
-	if (!k.is_valid()) {
+	if (k.is_null()) {
 		// MouseMotion events should not be handled by TextEdit logic if we're
 		// currently clicking and dragging from the code completion panel.
-		if (!mm.is_valid() || !is_code_completion_drag_started) {
+		if (mm.is_null() || !is_code_completion_drag_started) {
 			TextEdit::gui_input(p_gui_input);
 		}
 		return;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1932,7 +1932,7 @@ void ColorPicker::_pick_button_pressed_legacy() {
 			}
 
 			Ref<Image> img = w->get_texture()->get_image();
-			if (!img.is_valid() || img->is_empty()) {
+			if (img.is_null() || img->is_empty()) {
 				continue;
 			}
 			img->convert(Image::FORMAT_RGB8);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2855,7 +2855,7 @@ bool Control::has_theme_constant(const StringName &p_name, const StringName &p_t
 
 void Control::add_theme_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!p_icon.is_valid());
+	ERR_FAIL_COND(p_icon.is_null());
 
 	if (data.theme_icon_override.has(p_name)) {
 		data.theme_icon_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
@@ -2868,7 +2868,7 @@ void Control::add_theme_icon_override(const StringName &p_name, const Ref<Textur
 
 void Control::add_theme_style_override(const StringName &p_name, const Ref<StyleBox> &p_style) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!p_style.is_valid());
+	ERR_FAIL_COND(p_style.is_null());
 
 	if (data.theme_style_override.has(p_name)) {
 		data.theme_style_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
@@ -2881,7 +2881,7 @@ void Control::add_theme_style_override(const StringName &p_name, const Ref<Style
 
 void Control::add_theme_font_override(const StringName &p_name, const Ref<Font> &p_font) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!p_font.is_valid());
+	ERR_FAIL_COND(p_font.is_null());
 
 	if (data.theme_font_override.has(p_name)) {
 		data.theme_font_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -298,7 +298,7 @@ void GraphNode::draw_port(int p_slot_index, Point2i p_pos, bool p_left, const Co
 	Ref<Texture2D> port_icon = p_left ? slot.custom_port_icon_left : slot.custom_port_icon_right;
 
 	Point2 icon_offset;
-	if (!port_icon.is_valid()) {
+	if (port_icon.is_null()) {
 		port_icon = theme_cache.port;
 	}
 
@@ -384,7 +384,7 @@ void GraphNode::set_slot(int p_slot_index, bool p_enable_left, int p_type_left, 
 
 	if (!p_enable_left && p_type_left == 0 && p_color_left == Color(1, 1, 1, 1) &&
 			!p_enable_right && p_type_right == 0 && p_color_right == Color(1, 1, 1, 1) &&
-			!p_custom_left.is_valid() && !p_custom_right.is_valid()) {
+			p_custom_left.is_null() && p_custom_right.is_null()) {
 		slot_table.erase(p_slot_index);
 		return;
 	}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1189,7 +1189,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 							Ref<CharFXTransform> charfx = item_custom->char_fx_transform;
 							Ref<RichTextEffect> custom_effect = item_custom->custom_effect;
 
-							if (!custom_effect.is_null()) {
+							if (custom_effect.is_valid()) {
 								charfx->elapsed_time = item_custom->elapsed_time;
 								charfx->range = Vector2i(l.char_offset + glyphs[i].start, l.char_offset + glyphs[i].end);
 								charfx->relative_index = l.char_offset + glyphs[i].start - item_fx->char_ofs;
@@ -5443,7 +5443,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				Dictionary properties = parse_expressions_for_values(expr);
 				Ref<RichTextEffect> effect = _get_custom_effect_by_code(identifier);
 
-				if (!effect.is_null()) {
+				if (effect.is_valid()) {
 					push_customfx(effect, properties);
 					pos = brk_end + 1;
 					tag_stack.push_front(identifier);
@@ -6826,7 +6826,7 @@ void RichTextLabel::menu_option(int p_option) {
 Ref<RichTextEffect> RichTextLabel::_get_custom_effect_by_code(String p_bbcode_identifier) {
 	for (int i = 0; i < custom_effects.size(); i++) {
 		Ref<RichTextEffect> effect = custom_effects[i];
-		if (!effect.is_valid()) {
+		if (effect.is_null()) {
 			continue;
 		}
 
@@ -6863,22 +6863,22 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 		numerical.compile("^\\d+$");
 
 		for (int j = 0; j < values.size(); j++) {
-			if (!color.search(values[j]).is_null()) {
+			if (color.search(values[j]).is_valid()) {
 				a.append(Color::html(values[j]));
-			} else if (!nodepath.search(values[j]).is_null()) {
+			} else if (nodepath.search(values[j]).is_valid()) {
 				if (values[j].begins_with("$")) {
 					String v = values[j].substr(1, values[j].length());
 					a.append(NodePath(v));
 				}
-			} else if (!boolean.search(values[j]).is_null()) {
+			} else if (boolean.search(values[j]).is_valid()) {
 				if (values[j] == "true") {
 					a.append(true);
 				} else if (values[j] == "false") {
 					a.append(false);
 				}
-			} else if (!decimal.search(values[j]).is_null()) {
+			} else if (decimal.search(values[j]).is_valid()) {
 				a.append(values[j].to_float());
-			} else if (!numerical.search(values[j]).is_null()) {
+			} else if (numerical.search(values[j]).is_valid()) {
 				a.append(values[j].to_int());
 			} else {
 				a.append(values[j]);

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -130,7 +130,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventJoypadButton> joypadbutton_event = p_event;
 	bool is_joypad_event = (joypadmotion_event.is_valid() || joypadbutton_event.is_valid());
 
-	if (!mm.is_valid() && !mb.is_valid()) {
+	if (mm.is_null() && mb.is_null()) {
 		if (p_event->is_action_pressed("ui_left", true)) {
 			if (orientation != HORIZONTAL) {
 				return;

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1245,7 +1245,7 @@ Variant TabBar::_handle_get_drag_data(const String &p_type, const Point2 &p_poin
 
 	HBoxContainer *drag_preview = memnew(HBoxContainer);
 
-	if (!tabs[tab_over].icon.is_null()) {
+	if (tabs[tab_over].icon.is_valid()) {
 		const Size2 icon_size = _get_tab_icon_size(tab_over);
 
 		TextureRect *tf = memnew(TextureRect);

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -171,7 +171,7 @@ void TextureButton::_notification(int p_what) {
 			bool draw_focus = (has_focus() && focused.is_valid());
 
 			// If no other texture is valid, try using focused texture.
-			bool draw_focus_only = draw_focus && !texdraw.is_valid();
+			bool draw_focus_only = draw_focus && texdraw.is_null();
 			if (draw_focus_only) {
 				texdraw = focused;
 			}

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -105,7 +105,7 @@ void TextureRect::_notification(int p_what) {
 }
 
 Size2 TextureRect::get_minimum_size() const {
-	if (!texture.is_null()) {
+	if (texture.is_valid()) {
 		switch (expand_mode) {
 			case EXPAND_KEEP_SIZE: {
 				return texture->get_size();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1272,7 +1272,7 @@ void TreeItem::clear_buttons() {
 
 void TreeItem::add_button(int p_column, const Ref<Texture2D> &p_button, int p_id, bool p_disabled, const String &p_tooltip) {
 	ERR_FAIL_INDEX(p_column, cells.size());
-	ERR_FAIL_COND(!p_button.is_valid());
+	ERR_FAIL_COND(p_button.is_null());
 	TreeItem::Cell::Button button;
 	button.texture = p_button;
 	if (p_id < 0) {
@@ -1947,7 +1947,7 @@ void Tree::draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Co
 
 	int w = 0;
 	Size2i bmsize;
-	if (!p_cell.icon.is_null()) {
+	if (p_cell.icon.is_valid()) {
 		bmsize = _get_cell_icon_size(p_cell);
 		w += bmsize.width + theme_cache.h_separation;
 		if (rect.size.width > 0 && (w + ts.width) > rect.size.width) {
@@ -1986,7 +1986,7 @@ void Tree::draw_item_rect(TreeItem::Cell &p_cell, const Rect2i &p_rect, const Co
 		rect.size.x -= ts.width + theme_cache.h_separation;
 	}
 
-	if (!p_cell.icon.is_null()) {
+	if (p_cell.icon.is_valid()) {
 		p_cell.draw_icon(ci, rect.position + Size2i(0, Math::floor((real_t)(rect.size.y - bmsize.y) / 2)), bmsize, p_icon_color);
 		rect.position.x += bmsize.x + theme_cache.h_separation;
 		rect.size.x -= bmsize.x + theme_cache.h_separation;

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -81,10 +81,10 @@ void VideoStreamPlayer::_mix_audios(void *p_self) {
 
 // Called from audio thread
 void VideoStreamPlayer::_mix_audio() {
-	if (!stream.is_valid()) {
+	if (stream.is_null()) {
 		return;
 	}
-	if (!playback.is_valid() || !playback->is_playing() || playback->is_paused()) {
+	if (playback.is_null() || !playback->is_playing() || playback->is_paused()) {
 		return;
 	}
 
@@ -211,7 +211,7 @@ void VideoStreamPlayer::_notification(int p_notification) {
 }
 
 Size2 VideoStreamPlayer::get_minimum_size() const {
-	if (!expand && !texture.is_null()) {
+	if (!expand && texture.is_valid()) {
 		return texture->get_size();
 	} else {
 		return Size2();
@@ -264,7 +264,7 @@ void VideoStreamPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 		stream->connect_changed(callable_mp(this, &VideoStreamPlayer::set_stream).bind(stream));
 	}
 
-	if (!playback.is_null()) {
+	if (playback.is_valid()) {
 		playback->set_paused(paused);
 		texture = playback->get_texture();
 

--- a/scene/main/instance_placeholder.cpp
+++ b/scene/main/instance_placeholder.cpp
@@ -85,7 +85,7 @@ Node *InstancePlaceholder::create_instance(bool p_replace, const Ref<PackedScene
 		ps = ResourceLoader::load(path, "PackedScene");
 	}
 
-	if (!ps.is_valid()) {
+	if (ps.is_null()) {
 		return nullptr;
 	}
 	Node *instance = ps->instantiate();
@@ -163,7 +163,7 @@ void InstancePlaceholder::set_value_on_instance(InstancePlaceholder *p_placehold
 	switch (current_type) {
 		case Variant::Type::NIL: {
 			Ref<Resource> resource = p_set.value;
-			if (placeholder_type != Variant::Type::NODE_PATH && !resource.is_valid()) {
+			if (placeholder_type != Variant::Type::NODE_PATH && resource.is_null()) {
 				break;
 			}
 			// If it's nil but we have a NodePath or a Resource, we guess what works.

--- a/scene/main/resource_preloader.cpp
+++ b/scene/main/resource_preloader.cpp
@@ -41,7 +41,7 @@ void ResourcePreloader::_set_resources(const Array &p_data) {
 
 	for (int i = 0; i < resdata.size(); i++) {
 		Ref<Resource> resource = resdata[i];
-		ERR_CONTINUE(!resource.is_valid());
+		ERR_CONTINUE(resource.is_null());
 		resources[names[i]] = resource;
 
 		//add_resource(names[i],resource);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1633,7 +1633,7 @@ Ref<MultiplayerAPI> SceneTree::get_multiplayer(const NodePath &p_for_path) const
 void SceneTree::set_multiplayer(Ref<MultiplayerAPI> p_multiplayer, const NodePath &p_root_path) {
 	ERR_FAIL_COND_MSG(!Thread::is_main_thread(), "Multiplayer can only be manipulated from the main thread.");
 	if (p_root_path.is_empty()) {
-		ERR_FAIL_COND(!p_multiplayer.is_valid());
+		ERR_FAIL_COND(p_multiplayer.is_null());
 		if (multiplayer.is_valid()) {
 			multiplayer->object_configuration_remove(nullptr, NodePath("/" + root->get_name()));
 		}
@@ -1849,7 +1849,7 @@ SceneTree::SceneTree() {
 	}
 
 #ifndef _3D_DISABLED
-	if (!root->get_world_3d().is_valid()) {
+	if (root->get_world_3d().is_null()) {
 		root->set_world_3d(Ref<World3D>(memnew(World3D)));
 	}
 	root->set_as_audio_listener_3d(true);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2420,7 +2420,7 @@ bool Window::has_theme_constant(const StringName &p_name, const StringName &p_th
 
 void Window::add_theme_icon_override(const StringName &p_name, const Ref<Texture2D> &p_icon) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!p_icon.is_valid());
+	ERR_FAIL_COND(p_icon.is_null());
 
 	if (theme_icon_override.has(p_name)) {
 		theme_icon_override[p_name]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
@@ -2433,7 +2433,7 @@ void Window::add_theme_icon_override(const StringName &p_name, const Ref<Texture
 
 void Window::add_theme_style_override(const StringName &p_name, const Ref<StyleBox> &p_style) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!p_style.is_valid());
+	ERR_FAIL_COND(p_style.is_null());
 
 	if (theme_style_override.has(p_name)) {
 		theme_style_override[p_name]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));
@@ -2446,7 +2446,7 @@ void Window::add_theme_style_override(const StringName &p_name, const Ref<StyleB
 
 void Window::add_theme_font_override(const StringName &p_name, const Ref<Font> &p_font) {
 	ERR_MAIN_THREAD_GUARD;
-	ERR_FAIL_COND(!p_font.is_valid());
+	ERR_FAIL_COND(p_font.is_null());
 
 	if (theme_font_override.has(p_name)) {
 		theme_font_override[p_name]->disconnect_changed(callable_mp(this, &Window::_notify_theme_override_changed));

--- a/scene/resources/2d/skeleton/skeleton_modification_stack_2d.cpp
+++ b/scene/resources/2d/skeleton/skeleton_modification_stack_2d.cpp
@@ -71,7 +71,7 @@ void SkeletonModificationStack2D::setup() {
 	if (skeleton != nullptr) {
 		is_setup = true;
 		for (int i = 0; i < modifications.size(); i++) {
-			if (!modifications[i].is_valid()) {
+			if (modifications[i].is_null()) {
 				continue;
 			}
 			modifications.get(i)->_setup_modification(this);
@@ -100,7 +100,7 @@ void SkeletonModificationStack2D::execute(float p_delta, int p_execution_mode) {
 	}
 
 	for (int i = 0; i < modifications.size(); i++) {
-		if (!modifications[i].is_valid()) {
+		if (modifications[i].is_null()) {
 			continue;
 		}
 
@@ -117,7 +117,7 @@ void SkeletonModificationStack2D::draw_editor_gizmos() {
 
 	if (editor_gizmo_dirty) {
 		for (int i = 0; i < modifications.size(); i++) {
-			if (!modifications[i].is_valid()) {
+			if (modifications[i].is_null()) {
 				continue;
 			}
 
@@ -147,7 +147,7 @@ void SkeletonModificationStack2D::set_editor_gizmos_dirty(bool p_dirty) {
 
 void SkeletonModificationStack2D::enable_all_modifications(bool p_enabled) {
 	for (int i = 0; i < modifications.size(); i++) {
-		if (!modifications[i].is_valid()) {
+		if (modifications[i].is_null()) {
 			continue;
 		}
 		modifications.get(i)->set_enabled(p_enabled);
@@ -160,7 +160,7 @@ Ref<SkeletonModification2D> SkeletonModificationStack2D::get_modification(int p_
 }
 
 void SkeletonModificationStack2D::add_modification(Ref<SkeletonModification2D> p_mod) {
-	ERR_FAIL_COND(!p_mod.is_valid());
+	ERR_FAIL_COND(p_mod.is_null());
 
 	p_mod->_setup_modification(this);
 	modifications.push_back(p_mod);

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -471,7 +471,7 @@ void TileSet::_compute_next_source_id() {
 
 // Sources management
 int TileSet::add_source(Ref<TileSetSource> p_tile_set_source, int p_atlas_source_id_override) {
-	ERR_FAIL_COND_V(!p_tile_set_source.is_valid(), TileSet::INVALID_SOURCE);
+	ERR_FAIL_COND_V(p_tile_set_source.is_null(), TileSet::INVALID_SOURCE);
 	ERR_FAIL_COND_V_MSG(p_atlas_source_id_override >= 0 && (sources.has(p_atlas_source_id_override)), TileSet::INVALID_SOURCE, vformat("Cannot create TileSet atlas source. Another atlas source exists with id %d.", p_atlas_source_id_override));
 	ERR_FAIL_COND_V_MSG(p_atlas_source_id_override < 0 && p_atlas_source_id_override != TileSet::INVALID_SOURCE, TileSet::INVALID_SOURCE, vformat("Provided source ID %d is not valid. Negative source IDs are not allowed.", p_atlas_source_id_override));
 
@@ -1392,7 +1392,7 @@ void TileSet::clear_tile_proxies() {
 }
 
 int TileSet::add_pattern(Ref<TileMapPattern> p_pattern, int p_index) {
-	ERR_FAIL_COND_V(!p_pattern.is_valid(), -1);
+	ERR_FAIL_COND_V(p_pattern.is_null(), -1);
 	ERR_FAIL_COND_V_MSG(p_pattern->is_empty(), -1, "Cannot add an empty pattern to the TileSet.");
 	for (const Ref<TileMapPattern> &pattern : patterns) {
 		ERR_FAIL_COND_V_MSG(pattern == p_pattern, -1, "TileSet has already this pattern.");
@@ -4206,7 +4206,7 @@ void TileSet::_get_property_list(List<PropertyInfo> *p_list) const {
 
 		// physics_layer_%d/physics_material
 		property_info = PropertyInfo(Variant::OBJECT, vformat("physics_layer_%d/physics_material", i), PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial");
-		if (!physics_layers[i].physics_material.is_valid()) {
+		if (physics_layers[i].physics_material.is_null()) {
 			property_info.usage ^= PROPERTY_USAGE_STORAGE;
 		}
 		p_list->push_back(property_info);
@@ -4742,7 +4742,7 @@ bool TileSetAtlasSource::get_use_texture_padding() const {
 
 Vector2i TileSetAtlasSource::get_atlas_grid_size() const {
 	Ref<Texture2D> txt = get_texture();
-	if (!txt.is_valid()) {
+	if (txt.is_null()) {
 		return Vector2i();
 	}
 

--- a/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
+++ b/scene/resources/3d/navigation_mesh_source_geometry_data_3d.cpp
@@ -195,7 +195,7 @@ void NavigationMeshSourceGeometryData3D::_add_faces(const PackedVector3Array &p_
 }
 
 void NavigationMeshSourceGeometryData3D::add_mesh(const Ref<Mesh> &p_mesh, const Transform3D &p_xform) {
-	ERR_FAIL_COND(!p_mesh.is_valid());
+	ERR_FAIL_COND(p_mesh.is_null());
 
 #ifdef DEBUG_ENABLED
 	if (!Engine::get_singleton()->is_editor_hint()) {

--- a/scene/resources/animated_texture.cpp
+++ b/scene/resources/animated_texture.cpp
@@ -174,7 +174,7 @@ float AnimatedTexture::get_speed_scale() const {
 int AnimatedTexture::get_width() const {
 	RWLockRead r(rw_lock);
 
-	if (!frames[current_frame].texture.is_valid()) {
+	if (frames[current_frame].texture.is_null()) {
 		return 1;
 	}
 
@@ -184,7 +184,7 @@ int AnimatedTexture::get_width() const {
 int AnimatedTexture::get_height() const {
 	RWLockRead r(rw_lock);
 
-	if (!frames[current_frame].texture.is_valid()) {
+	if (frames[current_frame].texture.is_null()) {
 		return 1;
 	}
 
@@ -198,7 +198,7 @@ RID AnimatedTexture::get_rid() const {
 bool AnimatedTexture::has_alpha() const {
 	RWLockRead r(rw_lock);
 
-	if (!frames[current_frame].texture.is_valid()) {
+	if (frames[current_frame].texture.is_null()) {
 		return false;
 	}
 
@@ -208,7 +208,7 @@ bool AnimatedTexture::has_alpha() const {
 Ref<Image> AnimatedTexture::get_image() const {
 	RWLockRead r(rw_lock);
 
-	if (!frames[current_frame].texture.is_valid()) {
+	if (frames[current_frame].texture.is_null()) {
 		return Ref<Image>();
 	}
 

--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -190,7 +190,7 @@ void AtlasTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, cons
 }
 
 bool AtlasTexture::get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_rect, Rect2 &r_src_rect) const {
-	if (!atlas.is_valid()) {
+	if (atlas.is_null()) {
 		return false;
 	}
 

--- a/scene/resources/bone_map.cpp
+++ b/scene/resources/bone_map.cpp
@@ -65,11 +65,11 @@ Ref<SkeletonProfile> BoneMap::get_profile() const {
 void BoneMap::set_profile(const Ref<SkeletonProfile> &p_profile) {
 	bool is_changed = profile != p_profile;
 	if (is_changed) {
-		if (!profile.is_null() && profile->is_connected("profile_updated", callable_mp(this, &BoneMap::_update_profile))) {
+		if (profile.is_valid() && profile->is_connected("profile_updated", callable_mp(this, &BoneMap::_update_profile))) {
 			profile->disconnect("profile_updated", callable_mp(this, &BoneMap::_update_profile));
 		}
 		profile = p_profile;
-		if (!profile.is_null()) {
+		if (profile.is_valid()) {
 			profile->connect("profile_updated", callable_mp(this, &BoneMap::_update_profile));
 		}
 		_update_profile();

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -245,7 +245,7 @@ Ref<Image> CompressedTexture2D::get_image() const {
 }
 
 bool CompressedTexture2D::is_pixel_opaque(int p_x, int p_y) const {
-	if (!alpha_cache.is_valid()) {
+	if (alpha_cache.is_null()) {
 		Ref<Image> img = get_image();
 		if (img.is_valid()) {
 			if (img->is_compressed()) { //must decompress, if compressed

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1098,7 +1098,7 @@ bool FontFile::_set(const StringName &p_name, const Variant &p_value) {
 		Array textures = p_value;
 		for (int i = 0; i < textures.size(); i++) {
 			Ref<ImageTexture> tex = textures[i];
-			ERR_CONTINUE(!tex.is_valid());
+			ERR_CONTINUE(tex.is_null());
 			set_texture_image(0, Vector2i(16, 0), i, tex->get_image());
 		}
 	} else if (tokens.size() == 1 && tokens[0] == "chars") {

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -174,7 +174,7 @@ void ImageTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, cons
 }
 
 bool ImageTexture::is_pixel_opaque(int p_x, int p_y) const {
-	if (!alpha_cache.is_valid()) {
+	if (alpha_cache.is_null()) {
 		Ref<Image> img = get_image();
 		if (img.is_valid()) {
 			if (img->is_compressed()) { //must decompress, if compressed

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -239,7 +239,7 @@ bool ShaderMaterial::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
-	if (!shader.is_null()) {
+	if (shader.is_valid()) {
 		List<PropertyInfo> list;
 		shader->get_shader_uniform_list(&list, true);
 

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -905,7 +905,7 @@ Vector<Ref<Shape3D>> Mesh::convex_decompose(const Ref<MeshConvexDecompositionSet
 	ERR_FAIL_NULL_V(convex_decomposition_function, Vector<Ref<Shape3D>>());
 
 	Ref<TriangleMesh> tm = generate_triangle_mesh();
-	ERR_FAIL_COND_V(!tm.is_valid(), Vector<Ref<Shape3D>>());
+	ERR_FAIL_COND_V(tm.is_null(), Vector<Ref<Shape3D>>());
 
 	const Vector<TriangleMesh::Triangle> &triangles = tm->get_triangles();
 	int triangle_count = triangles.size();

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -211,7 +211,7 @@ void MultiMesh::set_buffer_interpolated(const Vector<float> &p_buffer_curr, cons
 
 void MultiMesh::set_mesh(const Ref<Mesh> &p_mesh) {
 	mesh = p_mesh;
-	if (!mesh.is_null()) {
+	if (mesh.is_valid()) {
 		RenderingServer::get_singleton()->multimesh_set_mesh(multimesh, mesh->get_rid());
 	} else {
 		RenderingServer::get_singleton()->multimesh_set_mesh(multimesh, RID());

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -194,7 +194,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 		if (i == 0 && base_scene_idx >= 0) {
 			// Scene inheritance on root node.
 			Ref<PackedScene> sdata = props[base_scene_idx];
-			ERR_FAIL_COND_V(!sdata.is_valid(), nullptr);
+			ERR_FAIL_COND_V(sdata.is_null(), nullptr);
 			node = sdata->instantiate(p_edit_state == GEN_EDIT_STATE_DISABLED ? PackedScene::GEN_EDIT_STATE_DISABLED : PackedScene::GEN_EDIT_STATE_INSTANCE); //only main gets main edit state
 			ERR_FAIL_NULL_V(node, nullptr);
 			if (p_edit_state != GEN_EDIT_STATE_DISABLED) {
@@ -767,7 +767,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 		} else {
 			//must instance ourselves
 			Ref<PackedScene> instance = ResourceLoader::load(p_node->get_scene_file_path());
-			if (!instance.is_valid()) {
+			if (instance.is_null()) {
 				return ERR_CANT_OPEN;
 			}
 
@@ -2146,7 +2146,7 @@ void PackedScene::reload_from_file() {
 	}
 
 	Ref<PackedScene> s = ResourceLoader::load(ResourceLoader::path_remap(path), get_class(), ResourceFormatLoader::CACHE_MODE_IGNORE);
-	if (!s.is_valid()) {
+	if (s.is_null()) {
 		return;
 	}
 

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -258,7 +258,7 @@ void PortableCompressedTexture2D::draw_rect_region(RID p_canvas_item, const Rect
 }
 
 bool PortableCompressedTexture2D::is_pixel_opaque(int p_x, int p_y) const {
-	if (!alpha_cache.is_valid()) {
+	if (alpha_cache.is_null()) {
 		Ref<Image> img = get_image();
 		if (img.is_valid()) {
 			if (img->is_compressed()) { //must decompress, if compressed

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -465,7 +465,7 @@ Error ResourceLoaderText::load() {
 		ext_resources[id].path = path;
 		ext_resources[id].type = type;
 		ext_resources[id].load_token = ResourceLoader::_load_start(path, type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, cache_mode_for_external);
-		if (!ext_resources[id].load_token.is_valid()) {
+		if (ext_resources[id].load_token.is_null()) {
 			if (ResourceLoader::get_abort_on_missing_resources()) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "[ext_resource] referenced non-existent resource at: " + path;
@@ -684,7 +684,7 @@ Error ResourceLoaderText::load() {
 				resource = cache;
 			}
 
-			if (!resource.is_valid()) {
+			if (resource.is_null()) {
 				Object *obj = ClassDB::instantiate(res_type);
 				if (!obj) {
 					if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
@@ -823,7 +823,7 @@ Error ResourceLoaderText::load() {
 
 		Ref<PackedScene> packed_scene = _parse_node_tag(rp);
 
-		if (!packed_scene.is_valid()) {
+		if (packed_scene.is_null()) {
 			return error;
 		}
 
@@ -2121,7 +2121,7 @@ Error ResourceLoaderText::set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid) {
 }
 
 Error ResourceFormatSaverText::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
-	if (p_path.ends_with(".tscn") && !Ref<PackedScene>(p_resource).is_valid()) {
+	if (p_path.ends_with(".tscn") && Ref<PackedScene>(p_resource).is_null()) {
 		return ERR_FILE_UNRECOGNIZED;
 	}
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1485,7 +1485,7 @@ bool VisualShader::is_text_shader() const {
 
 String VisualShader::generate_preview_shader(Type p_type, int p_node, int p_port, Vector<DefaultTextureParam> &default_tex_params) const {
 	Ref<VisualShaderNode> node = get_node(p_type, p_node);
-	ERR_FAIL_COND_V(!node.is_valid(), String());
+	ERR_FAIL_COND_V(node.is_null(), String());
 	ERR_FAIL_COND_V(p_port < 0 || p_port >= node->get_expanded_output_port_count(), String());
 	ERR_FAIL_COND_V(node->get_output_port_type(p_port) == VisualShaderNode::PORT_TYPE_TRANSFORM, String());
 
@@ -1996,7 +1996,7 @@ Error VisualShader::_write_node(Type type, StringBuilder *p_global_code, StringB
 
 	if (!skip_global) {
 		Ref<VisualShaderNodeParameter> parameter = vsnode;
-		if (!parameter.is_valid() || !parameter->is_global_code_generated()) {
+		if (parameter.is_null() || !parameter->is_global_code_generated()) {
 			if (p_global_code) {
 				*p_global_code += vsnode->generate_global(get_mode(), type, p_node);
 			}

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -520,7 +520,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Color> &p
 }
 
 void VisualShaderNodeParticleMeshEmitter::_update_textures() {
-	if (!mesh.is_valid()) {
+	if (mesh.is_null()) {
 		return;
 	}
 

--- a/servers/movie_writer/movie_writer_mjpeg.cpp
+++ b/servers/movie_writer/movie_writer_mjpeg.cpp
@@ -191,7 +191,7 @@ Error MovieWriterMJPEG::write_begin(const Size2i &p_movie_size, uint32_t p_fps, 
 }
 
 Error MovieWriterMJPEG::write_frame(const Ref<Image> &p_image, const int32_t *p_audio_data) {
-	ERR_FAIL_COND_V(!f.is_valid(), ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(f.is_null(), ERR_UNCONFIGURED);
 
 	Vector<uint8_t> jpg_buffer = p_image->save_jpg_to_buffer(quality);
 	uint32_t s = jpg_buffer.size();

--- a/servers/movie_writer/movie_writer_pngwav.cpp
+++ b/servers/movie_writer/movie_writer_pngwav.cpp
@@ -140,7 +140,7 @@ Error MovieWriterPNGWAV::write_begin(const Size2i &p_movie_size, uint32_t p_fps,
 }
 
 Error MovieWriterPNGWAV::write_frame(const Ref<Image> &p_image, const int32_t *p_audio_data) {
-	ERR_FAIL_COND_V(!f_wav.is_valid(), ERR_UNCONFIGURED);
+	ERR_FAIL_COND_V(f_wav.is_null(), ERR_UNCONFIGURED);
 
 	Vector<uint8_t> png_buffer = p_image->save_png_to_buffer();
 

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -329,7 +329,7 @@ void PhysicsShapeQueryParameters2D::_bind_methods() {
 ///////////////////////////////////////////////////////
 
 Dictionary PhysicsDirectSpaceState2D::_intersect_ray(const Ref<PhysicsRayQueryParameters2D> &p_ray_query) {
-	ERR_FAIL_COND_V(!p_ray_query.is_valid(), Dictionary());
+	ERR_FAIL_COND_V(p_ray_query.is_null(), Dictionary());
 
 	RayResult result;
 	bool res = intersect_ray(p_ray_query->get_parameters(), result);
@@ -375,7 +375,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_point(const Ref<Phy
 }
 
 TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), TypedArray<Dictionary>());
+	ERR_FAIL_COND_V(p_shape_query.is_null(), TypedArray<Dictionary>());
 
 	Vector<ShapeResult> sr;
 	sr.resize(p_max_results);
@@ -395,7 +395,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(const Ref<Phy
 }
 
 Vector<real_t> PhysicsDirectSpaceState2D::_cast_motion(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Vector<real_t>());
+	ERR_FAIL_COND_V(p_shape_query.is_null(), Vector<real_t>());
 
 	real_t closest_safe, closest_unsafe;
 	bool res = cast_motion(p_shape_query->get_parameters(), closest_safe, closest_unsafe);
@@ -410,7 +410,7 @@ Vector<real_t> PhysicsDirectSpaceState2D::_cast_motion(const Ref<PhysicsShapeQue
 }
 
 TypedArray<Vector2> PhysicsDirectSpaceState2D::_collide_shape(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), TypedArray<Vector2>());
+	ERR_FAIL_COND_V(p_shape_query.is_null(), TypedArray<Vector2>());
 
 	Vector<Vector2> ret;
 	ret.resize(p_max_results * 2);
@@ -428,7 +428,7 @@ TypedArray<Vector2> PhysicsDirectSpaceState2D::_collide_shape(const Ref<PhysicsS
 }
 
 Dictionary PhysicsDirectSpaceState2D::_get_rest_info(const Ref<PhysicsShapeQueryParameters2D> &p_shape_query) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Dictionary());
+	ERR_FAIL_COND_V(p_shape_query.is_null(), Dictionary());
 
 	ShapeRestInfo sri;
 
@@ -606,7 +606,7 @@ void PhysicsTestMotionResult2D::_bind_methods() {
 ///////////////////////////////////////
 
 bool PhysicsServer2D::_body_test_motion(RID p_body, const Ref<PhysicsTestMotionParameters2D> &p_parameters, const Ref<PhysicsTestMotionResult2D> &p_result) {
-	ERR_FAIL_COND_V(!p_parameters.is_valid(), false);
+	ERR_FAIL_COND_V(p_parameters.is_null(), false);
 
 	MotionResult *result_ptr = nullptr;
 	if (p_result.is_valid()) {

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -355,7 +355,7 @@ void PhysicsShapeQueryParameters3D::_bind_methods() {
 /////////////////////////////////////
 
 Dictionary PhysicsDirectSpaceState3D::_intersect_ray(const Ref<PhysicsRayQueryParameters3D> &p_ray_query) {
-	ERR_FAIL_COND_V(!p_ray_query.is_valid(), Dictionary());
+	ERR_FAIL_COND_V(p_ray_query.is_null(), Dictionary());
 
 	RayResult result;
 	bool res = intersect_ray(p_ray_query->get_parameters(), result);
@@ -402,7 +402,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(const Ref<Phy
 }
 
 TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), TypedArray<Dictionary>());
+	ERR_FAIL_COND_V(p_shape_query.is_null(), TypedArray<Dictionary>());
 
 	Vector<ShapeResult> sr;
 	sr.resize(p_max_results);
@@ -422,7 +422,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(const Ref<Phy
 }
 
 Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Vector<real_t>());
+	ERR_FAIL_COND_V(p_shape_query.is_null(), Vector<real_t>());
 
 	real_t closest_safe = 1.0f, closest_unsafe = 1.0f;
 	bool res = cast_motion(p_shape_query->get_parameters(), closest_safe, closest_unsafe);
@@ -437,7 +437,7 @@ Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(const Ref<PhysicsShapeQue
 }
 
 TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query, int p_max_results) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), TypedArray<Vector3>());
+	ERR_FAIL_COND_V(p_shape_query.is_null(), TypedArray<Vector3>());
 
 	Vector<Vector3> ret;
 	ret.resize(p_max_results * 2);
@@ -455,7 +455,7 @@ TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(const Ref<PhysicsS
 }
 
 Dictionary PhysicsDirectSpaceState3D::_get_rest_info(const Ref<PhysicsShapeQueryParameters3D> &p_shape_query) {
-	ERR_FAIL_COND_V(!p_shape_query.is_valid(), Dictionary());
+	ERR_FAIL_COND_V(p_shape_query.is_null(), Dictionary());
 
 	ShapeRestInfo sri;
 
@@ -651,7 +651,7 @@ void PhysicsTestMotionResult3D::_bind_methods() {
 ///////////////////////////////////////
 
 bool PhysicsServer3D::_body_test_motion(RID p_body, const Ref<PhysicsTestMotionParameters3D> &p_parameters, const Ref<PhysicsTestMotionResult3D> &p_result) {
-	ERR_FAIL_COND_V(!p_parameters.is_valid(), false);
+	ERR_FAIL_COND_V(p_parameters.is_null(), false);
 
 	MotionResult *result_ptr = nullptr;
 	if (p_result.is_valid()) {

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -8104,7 +8104,7 @@ RID RenderingDevice::_uniform_set_create(const TypedArray<RDUniform> &p_uniforms
 	uniforms.resize(p_uniforms.size());
 	for (int i = 0; i < p_uniforms.size(); i++) {
 		Ref<RDUniform> uniform = p_uniforms[i];
-		ERR_FAIL_COND_V(!uniform.is_valid(), RID());
+		ERR_FAIL_COND_V(uniform.is_null(), RID());
 		uniforms.write[i] = uniform->base;
 	}
 	return uniform_set_create(uniforms, p_shader, p_shader_set);

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -432,7 +432,7 @@ void XRServer::_process() {
 
 	// process all active interfaces
 	for (int i = 0; i < interfaces.size(); i++) {
-		if (!interfaces[i].is_valid()) {
+		if (interfaces[i].is_null()) {
 			// ignore, not a valid reference
 		} else if (interfaces[i]->is_initialized()) {
 			interfaces.write[i]->process();
@@ -446,7 +446,7 @@ void XRServer::pre_render() {
 
 	// process all active interfaces
 	for (int i = 0; i < interfaces.size(); i++) {
-		if (!interfaces[i].is_valid()) {
+		if (interfaces[i].is_null()) {
 			// ignore, not a valid reference
 		} else if (interfaces[i]->is_initialized()) {
 			interfaces.write[i]->pre_render();
@@ -459,7 +459,7 @@ void XRServer::end_frame() {
 
 	// process all active interfaces
 	for (int i = 0; i < interfaces.size(); i++) {
-		if (!interfaces[i].is_valid()) {
+		if (interfaces[i].is_null()) {
 			// ignore, not a valid reference
 		} else if (interfaces[i]->is_initialized()) {
 			interfaces.write[i]->end_frame();

--- a/tests/core/io/test_file_access.h
+++ b/tests/core/io/test_file_access.h
@@ -84,7 +84,7 @@ TEST_CASE("[FileAccess] CSV read") {
 
 TEST_CASE("[FileAccess] Get as UTF-8 String") {
 	Ref<FileAccess> f_lf = FileAccess::open(TestUtils::get_data_path("line_endings_lf.test.txt"), FileAccess::READ);
-	REQUIRE(!f_lf.is_null());
+	REQUIRE(f_lf.is_valid());
 	String s_lf = f_lf->get_as_utf8_string();
 	f_lf->seek(0);
 	String s_lf_nocr = f_lf->get_as_utf8_string(true);
@@ -92,7 +92,7 @@ TEST_CASE("[FileAccess] Get as UTF-8 String") {
 	CHECK(s_lf_nocr == "Hello darkness\nMy old friend\nI've come to talk\nWith you again\n");
 
 	Ref<FileAccess> f_crlf = FileAccess::open(TestUtils::get_data_path("line_endings_crlf.test.txt"), FileAccess::READ);
-	REQUIRE(!f_crlf.is_null());
+	REQUIRE(f_crlf.is_valid());
 	String s_crlf = f_crlf->get_as_utf8_string();
 	f_crlf->seek(0);
 	String s_crlf_nocr = f_crlf->get_as_utf8_string(true);
@@ -100,7 +100,7 @@ TEST_CASE("[FileAccess] Get as UTF-8 String") {
 	CHECK(s_crlf_nocr == "Hello darkness\nMy old friend\nI've come to talk\nWith you again\n");
 
 	Ref<FileAccess> f_cr = FileAccess::open(TestUtils::get_data_path("line_endings_cr.test.txt"), FileAccess::READ);
-	REQUIRE(!f_cr.is_null());
+	REQUIRE(f_cr.is_valid());
 	String s_cr = f_cr->get_as_utf8_string();
 	f_cr->seek(0);
 	String s_cr_nocr = f_cr->get_as_utf8_string(true);

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -113,7 +113,7 @@ TEST_CASE("[Image] Saving and loading") {
 	// Load BMP
 	Ref<Image> image_bmp = memnew(Image());
 	Ref<FileAccess> f_bmp = FileAccess::open(TestUtils::get_data_path("images/icon.bmp"), FileAccess::READ, &err);
-	REQUIRE(!f_bmp.is_null());
+	REQUIRE(f_bmp.is_valid());
 	PackedByteArray data_bmp;
 	data_bmp.resize(f_bmp->get_length() + 1);
 	f_bmp->get_buffer(data_bmp.ptrw(), f_bmp->get_length());
@@ -126,7 +126,7 @@ TEST_CASE("[Image] Saving and loading") {
 	// Load JPG
 	Ref<Image> image_jpg = memnew(Image());
 	Ref<FileAccess> f_jpg = FileAccess::open(TestUtils::get_data_path("images/icon.jpg"), FileAccess::READ, &err);
-	REQUIRE(!f_jpg.is_null());
+	REQUIRE(f_jpg.is_valid());
 	PackedByteArray data_jpg;
 	data_jpg.resize(f_jpg->get_length() + 1);
 	f_jpg->get_buffer(data_jpg.ptrw(), f_jpg->get_length());
@@ -139,7 +139,7 @@ TEST_CASE("[Image] Saving and loading") {
 	// Load WebP
 	Ref<Image> image_webp = memnew(Image());
 	Ref<FileAccess> f_webp = FileAccess::open(TestUtils::get_data_path("images/icon.webp"), FileAccess::READ, &err);
-	REQUIRE(!f_webp.is_null());
+	REQUIRE(f_webp.is_valid());
 	PackedByteArray data_webp;
 	data_webp.resize(f_webp->get_length() + 1);
 	f_webp->get_buffer(data_webp.ptrw(), f_webp->get_length());
@@ -151,7 +151,7 @@ TEST_CASE("[Image] Saving and loading") {
 	// Load PNG
 	Ref<Image> image_png = memnew(Image());
 	Ref<FileAccess> f_png = FileAccess::open(TestUtils::get_data_path("images/icon.png"), FileAccess::READ, &err);
-	REQUIRE(!f_png.is_null());
+	REQUIRE(f_png.is_valid());
 	PackedByteArray data_png;
 	data_png.resize(f_png->get_length() + 1);
 	f_png->get_buffer(data_png.ptrw(), f_png->get_length());
@@ -163,7 +163,7 @@ TEST_CASE("[Image] Saving and loading") {
 	// Load TGA
 	Ref<Image> image_tga = memnew(Image());
 	Ref<FileAccess> f_tga = FileAccess::open(TestUtils::get_data_path("images/icon.tga"), FileAccess::READ, &err);
-	REQUIRE(!f_tga.is_null());
+	REQUIRE(f_tga.is_valid());
 	PackedByteArray data_tga;
 	data_tga.resize(f_tga->get_length() + 1);
 	f_tga->get_buffer(data_tga.ptrw(), f_tga->get_length());


### PR DESCRIPTION
Use `is_null` over `!is_valid` and vice versa.

See:
* https://github.com/godotengine/godot/pull/96076

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
