### PR TITLE
Compatibility: Avoid converting to compressed formats when retrieving image data

### DIFF
--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1072,7 +1072,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 		// It also allows for reading compressed textures, mipmaps, and more formats.
 		Vector<uint8_t> data;
 
-		int data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, texture->real_format, texture->mipmaps > 1);
+		int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, texture->real_format, texture->mipmaps > 1);
 
 		data.resize(data_size * 2); // Add some memory at the end, just in case for buggy drivers.
 		uint8_t *w = data.ptrw();
@@ -1084,7 +1084,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 		glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
 		for (int i = 0; i < texture->mipmaps; i++) {
-			int ofs = Image::get_image_mipmap_offset(texture->alloc_width, texture->alloc_height, texture->real_format, i);
+			int64_t ofs = Image::get_image_mipmap_offset(texture->alloc_width, texture->alloc_height, texture->real_format, i);
 
 			if (texture->compressed) {
 				glPixelStorei(GL_PACK_ALIGNMENT, 4);
@@ -1104,7 +1104,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 			ERR_FAIL_V_MSG(Ref<Image>(), vformat("Texture %s has no data.", path_str));
 		}
 
-		if (texture->format != texture->real_format) {
+		if (texture->format != texture->real_format && !Image::is_format_compressed(texture->real_format)) {
 			image->convert(texture->format);
 		}
 	}
@@ -1114,7 +1114,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 		Vector<uint8_t> data;
 
 		// On web and mobile we always read an RGBA8 image with no mipmaps.
-		int data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, Image::FORMAT_RGBA8, false);
+		int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, Image::FORMAT_RGBA8, false);
 
 		data.resize(data_size * 2); // Add some memory at the end, just in case for buggy drivers.
 		uint8_t *w = data.ptrw();
@@ -1164,7 +1164,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 			ERR_FAIL_V_MSG(Ref<Image>(), vformat("Texture %s has no data.", path_str));
 		}
 
-		if (texture->format != Image::FORMAT_RGBA8) {
+		if (texture->format != Image::FORMAT_RGBA8 && !Image::is_format_compressed(texture->format)) {
 			image->convert(texture->format);
 		}
 
@@ -1189,7 +1189,7 @@ Ref<Image> TextureStorage::texture_2d_layer_get(RID p_texture, int p_layer) cons
 
 	Vector<uint8_t> data;
 
-	int data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, Image::FORMAT_RGBA8, false);
+	int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, Image::FORMAT_RGBA8, false);
 
 	data.resize(data_size * 2); //add some memory at the end, just in case for buggy drivers
 	uint8_t *w = data.ptrw();
@@ -1239,7 +1239,7 @@ Ref<Image> TextureStorage::texture_2d_layer_get(RID p_texture, int p_layer) cons
 		ERR_FAIL_V_MSG(Ref<Image>(), vformat("Texture %s has no data.", path_str));
 	}
 
-	if (texture->format != Image::FORMAT_RGBA8) {
+	if (texture->format != Image::FORMAT_RGBA8 && !Image::is_format_compressed(texture->format)) {
 		image->convert(texture->format);
 	}
 
@@ -1261,7 +1261,7 @@ Vector<Ref<Image>> TextureStorage::_texture_3d_read_framebuffer(GLES3::Texture *
 	int depth = p_texture->depth;
 
 	for (int mipmap_level = 0; mipmap_level < p_texture->mipmaps; mipmap_level++) {
-		int data_size = Image::get_image_data_size(width, height, Image::FORMAT_RGBA8, false);
+		int64_t data_size = Image::get_image_data_size(width, height, Image::FORMAT_RGBA8, false);
 		glViewport(0, 0, width, height);
 		glClearColor(0.0, 0.0, 0.0, 0.0);
 		glClear(GL_COLOR_BUFFER_BIT);
@@ -1280,7 +1280,7 @@ Vector<Ref<Image>> TextureStorage::_texture_3d_read_framebuffer(GLES3::Texture *
 			Ref<Image> img = Image::create_from_data(width, height, false, Image::FORMAT_RGBA8, data);
 			ERR_FAIL_COND_V(img->is_empty(), Vector<Ref<Image>>());
 
-			if (p_texture->format != Image::FORMAT_RGBA8) {
+			if (p_texture->format != Image::FORMAT_RGBA8 && !Image::is_format_compressed(p_texture->format)) {
 				img->convert(p_texture->format);
 			}
 


### PR DESCRIPTION
The Compatibility renderer (GLES with Texture2D or GLES/OpenGL with TextureLayered) attempts to convert the temporary framebuffer-rendered textures retrieved from the GPU from RGBA8 into their original formats, even if they are compressed. This causes errors to appear randomly when generating thumbnails, for example. 

This PR disallows that behavior, although a better solution would likely be to improve the texture reading logic