### PR TITLE
Make `EditorSceneFormatImporter::_get_import_options` match EditorScenePostImportPlugin API

### DIFF
--- a/doc/classes/EditorSceneFormatImporter.xml
+++ b/doc/classes/EditorSceneFormatImporter.xml
@@ -13,9 +13,10 @@
 		<method name="_get_extensions" qualifiers="virtual const">
 			<return type="PackedStringArray" />
 			<description>
+				Return supported file extensions for this scene importer.
 			</description>
 		</method>
-		<method name="_get_import_flags" qualifiers="virtual const">
+		<method name="_get_import_flags" qualifiers="virtual const" deprecated="Unused by the engine, and will be removed in a future version. Implementing this has no effect.">
 			<return type="int" />
 			<description>
 			</description>
@@ -24,6 +25,9 @@
 			<return type="void" />
 			<param index="0" name="path" type="String" />
 			<description>
+				Override to add general import options. These will appear in the main import dock on the editor. Add options via [method add_import_option] and [method add_import_option_advanced].
+				[b]Note:[/b] All [EditorSceneFormatImporter] and [EditorScenePostImportPlugin] instances will add options for all files. It is good practice to check the file extension when [param path] is non-empty.
+				When the user is editing project settings, [param path] will be empty. It is recommended to add all options when [param path] is empty to allow the user to customize Import Defaults.
 			</description>
 		</method>
 		<method name="_get_option_visibility" qualifiers="virtual const">
@@ -32,6 +36,7 @@
 			<param index="1" name="for_animation" type="bool" />
 			<param index="2" name="option" type="String" />
 			<description>
+				Should return [code]true[/code] to show the given option, [code]false[/code] to hide the given option, or [code]null[/code] to ignore.
 			</description>
 		</method>
 		<method name="_import_scene" qualifiers="virtual">
@@ -40,6 +45,27 @@
 			<param index="1" name="flags" type="int" />
 			<param index="2" name="options" type="Dictionary" />
 			<description>
+				Perform the bulk of the scene import logic here, for example using [GLTFDocument] or [FBXDocument].
+			</description>
+		</method>
+		<method name="add_import_option">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="value" type="Variant" />
+			<description>
+				Add a specific import option (name and default value only). This function can only be called from [method _get_import_options].
+			</description>
+		</method>
+		<method name="add_import_option_advanced">
+			<return type="void" />
+			<param index="0" name="type" type="int" enum="Variant.Type" />
+			<param index="1" name="name" type="String" />
+			<param index="2" name="default_value" type="Variant" />
+			<param index="3" name="hint" type="int" enum="PropertyHint" default="0" />
+			<param index="4" name="hint_string" type="String" default="&quot;&quot;" />
+			<param index="5" name="usage_flags" type="int" default="6" />
+			<description>
+				Add a specific import option. This function can only be called from [method _get_import_options].
 			</description>
 		</method>
 	</methods>

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -91,8 +91,20 @@ Node *EditorSceneFormatImporter::import_scene(const String &p_path, uint32_t p_f
 	ERR_FAIL_V(nullptr);
 }
 
+void EditorSceneFormatImporter::add_import_option(const String &p_name, const Variant &p_default_value) {
+	ERR_FAIL_NULL_MSG(current_option_list, "add_import_option() can only be called from get_import_options().");
+	add_import_option_advanced(p_default_value.get_type(), p_name, p_default_value);
+}
+
+void EditorSceneFormatImporter::add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint, const String &p_hint_string, int p_usage_flags) {
+	ERR_FAIL_NULL_MSG(current_option_list, "add_import_option_advanced() can only be called from get_import_options().");
+	current_option_list->push_back(ResourceImporter::ImportOption(PropertyInfo(p_type, p_name, p_hint, p_hint_string, p_usage_flags), p_default_value));
+}
+
 void EditorSceneFormatImporter::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options) {
+	current_option_list = r_options;
 	GDVIRTUAL_CALL(_get_import_options, p_path);
+	current_option_list = nullptr;
 }
 
 Variant EditorSceneFormatImporter::get_option_visibility(const String &p_path, const String &p_scene_import_type, const String &p_option, const HashMap<StringName, Variant> &p_options) {
@@ -103,6 +115,9 @@ Variant EditorSceneFormatImporter::get_option_visibility(const String &p_path, c
 }
 
 void EditorSceneFormatImporter::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_import_option", "name", "value"), &EditorSceneFormatImporter::add_import_option);
+	ClassDB::bind_method(D_METHOD("add_import_option_advanced", "type", "name", "default_value", "hint", "hint_string", "usage_flags"), &EditorSceneFormatImporter::add_import_option_advanced, DEFVAL(PROPERTY_HINT_NONE), DEFVAL(""), DEFVAL(PROPERTY_USAGE_DEFAULT));
+
 	GDVIRTUAL_BIND(_get_import_flags);
 	GDVIRTUAL_BIND(_get_extensions);
 	GDVIRTUAL_BIND(_import_scene, "path", "flags", "options");

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -50,6 +50,8 @@ class Material;
 class EditorSceneFormatImporter : public RefCounted {
 	GDCLASS(EditorSceneFormatImporter, RefCounted);
 
+	List<ResourceImporter::ImportOption> *current_option_list = nullptr;
+
 protected:
 	static void _bind_methods();
 
@@ -73,6 +75,8 @@ public:
 		IMPORT_FORCE_DISABLE_MESH_COMPRESSION = 64,
 	};
 
+	void add_import_option(const String &p_name, const Variant &p_default_value);
+	void add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = String(), int p_usage_flags = PROPERTY_USAGE_DEFAULT);
 	virtual uint32_t get_import_flags() const;
 	virtual void get_extensions(List<String> *r_extensions) const;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr);


### PR DESCRIPTION
Fixes #84516

After a lot of contemplating, I discovered that the EditorScenePostImportPlugin class had a similar API to the seemingly-broken `_get_import_options` in `EditorSceneFormatImporter`. However, the difference is that reduz stored the options list in a local class member and added `add_import_option` (and `add_import_option_advanced`) to allow registering import options inside of `_get_import_options`, so we do the same thing here.

Also added some documentation mostly copied from the working APIs in `EditorScenePostImportPlugin`, since `EditorSceneFormatImporter` was missing a bunch of docs despite predating the post-import plugin system.