### PR TITLE
Expose `GLTFDocument.get_registered_gltf_document_extensions`

### DIFF
--- a/modules/gltf/doc_classes/GLTFDocument.xml
+++ b/modules/gltf/doc_classes/GLTFDocument.xml
@@ -73,11 +73,18 @@
 				The [param bake_fps] parameter overrides the bake_fps in [param state].
 			</description>
 		</method>
+		<method name="get_registered_gltf_document_extensions" qualifiers="static">
+			<return type="GLTFDocumentExtension[]" />
+			<description>
+				Returns all registered [GLTFDocumentExtension] instances, including a default [GLTFDocumentExtensionConvertImporterMesh] instance at runtime.
+				[b]Note:[/b] This method is static: Registered instances will be shared by all [GLTFDocument] instances. Consider using this method to check if a given [GLTFDocumentExtension] is already registered.
+			</description>
+		</method>
 		<method name="get_supported_gltf_extensions" qualifiers="static">
 			<return type="PackedStringArray" />
 			<description>
 				Returns a list of all support glTF extensions, including extensions supported directly by the engine, and extensions supported by user plugins registering [GLTFDocumentExtension] classes.
-				[b]Note:[/b] If this method is run before a GLTFDocumentExtension is registered, its extensions won't be included in the list. Be sure to only run this method after all extensions are registered. If you run this when the engine starts, consider waiting a frame before calling this method to ensure all extensions are registered.
+				[b]Note:[/b] This method is static: Registered instances will be shared by all [GLTFDocument] instances. Consider using this method to check if a given [GLTFDocumentExtension] is already registered. If this method is run before a GLTFDocumentExtension is registered, its extensions won't be included in the list. Be sure to only run this method after all extensions are registered. If you run this when the engine starts, consider waiting a frame before calling this method to ensure all extensions are registered.
 			</description>
 		</method>
 		<method name="import_object_model_property" qualifiers="static">
@@ -95,6 +102,7 @@
 			<description>
 				Registers the given [GLTFDocumentExtension] instance with GLTFDocument. If [param first_priority] is [code]true[/code], this extension will be run first. Otherwise, it will be run last.
 				[b]Note:[/b] Like GLTFDocument itself, all GLTFDocumentExtension classes must be stateless in order to function properly. If you need to store data, use the [code]set_additional_data[/code] and [code]get_additional_data[/code] methods in [GLTFState] or [GLTFNode].
+				[b]Note:[/b] This method is static: Registered instances will be shared by all [GLTFDocument] instances. Beware that multiple instances of a single [GLTFDocumentExtension] class can often lead to unexpected behavior, and consider using [method get_registered_gltf_document_extensions] or [method get_supported_gltf_extensions] to verify that only one instance of a given extension is registered.
 			</description>
 		</method>
 		<method name="unregister_gltf_document_extension" qualifiers="static">
@@ -102,6 +110,7 @@
 			<param index="0" name="extension" type="GLTFDocumentExtension" />
 			<description>
 				Unregisters the given [GLTFDocumentExtension] instance.
+				[b]Note:[/b] This method is static: Registering and unregistering instances will affect all [GLTFDocument] instances.
 			</description>
 		</method>
 		<method name="write_to_filesystem">

--- a/modules/gltf/doc_classes/GLTFDocumentExtensionConvertImporterMesh.xml
+++ b/modules/gltf/doc_classes/GLTFDocumentExtensionConvertImporterMesh.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="GLTFDocumentExtensionConvertImporterMesh" inherits="GLTFDocumentExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
+		A default [GLTFDocumentExtension] to convert [ImporterMeshInstance3D] nodes to [MeshInstance3D].
 	</brief_description>
 	<description>
+		This [GLTFDocumentExtension] is installed by default at runtime, but not in the editor. It converts all [ImporterMeshInstance3D] nodes and related [ImporterMesh] resources to [MeshInstance3D] nodes with [ArrayMesh] resources.
+		If it is important for a custom [GLTFDocumentExtension] to work with [ImporterMesh] at runtime, it is recommended to call [method GLTFDocument.register_gltf_document_extension] with the [code]true[/code] argument to ensure it runs before this built-in extension.
 	</description>
 	<tutorials>
 		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -8152,6 +8152,7 @@ void GLTFDocument::_bind_methods() {
 			&GLTFDocument::register_gltf_document_extension, DEFVAL(false));
 	ClassDB::bind_static_method("GLTFDocument", D_METHOD("unregister_gltf_document_extension", "extension"),
 			&GLTFDocument::unregister_gltf_document_extension);
+	ClassDB::bind_static_method("GLTFDocument", D_METHOD("get_registered_gltf_document_extensions"), &GLTFDocument::get_registered_gltf_document_extensions);
 	ClassDB::bind_static_method("GLTFDocument", D_METHOD("get_supported_gltf_extensions"),
 			&GLTFDocument::get_supported_gltf_extensions);
 }
@@ -8192,6 +8193,14 @@ void GLTFDocument::unregister_all_gltf_document_extensions() {
 
 Vector<Ref<GLTFDocumentExtension>> GLTFDocument::get_all_gltf_document_extensions() {
 	return all_document_extensions;
+}
+
+TypedArray<GLTFDocumentExtension> GLTFDocument::get_registered_gltf_document_extensions() {
+	TypedArray<GLTFDocumentExtension> ret;
+	for (Ref<GLTFDocumentExtension> ext : all_document_extensions) {
+		ret.append(ext);
+	}
+	return ret;
 }
 
 Vector<String> GLTFDocument::get_supported_gltf_extensions() {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -85,6 +85,7 @@ public:
 	static void unregister_gltf_document_extension(Ref<GLTFDocumentExtension> p_extension);
 	static void unregister_all_gltf_document_extensions();
 	static Vector<Ref<GLTFDocumentExtension>> get_all_gltf_document_extensions();
+	static TypedArray<GLTFDocumentExtension> get_registered_gltf_document_extensions();
 	static Vector<String> get_supported_gltf_extensions();
 	static HashSet<String> get_supported_gltf_extensions_hashset();
 


### PR DESCRIPTION
These APIs were not exposed, but I found I had a lot of difficulty using GLTFDocumentExtensions, particularly at runtime, without the ability to see and modify the current static list of extensions. My game only needs `get_registered_gltf_document_extensions`. 

I explained some context for this change from chat:

> I was trying to make a node with a gltf URI as a property. It would load the referenced gltf document as a sibling.
> ...And I wanted all the logic contained within the node
> But then I discovered that the vrm extensions were not registered at runtime... and so I said oh that's easy, I will just add the extensions when I import and remove them when I finish import to avoid doubling up, but then I wanted to do it in a thread and sometimes they weren't getting cleaned up etc
> And sometimes i had more than one instance of the node
> But I didn't want to require users of my node to modify their project autoload settings
> And VRM maybe should register the extensions at runtime in an autoload but I didn't because when I wrote VRM I didn't realize extensions list was static so all the example code is wrong and it is still wrong because there is no way to do it right for now
> So that's the root cause of this discussion: I was trying to figure out how a node, without knowing anything else, can make sure the VRM extensions are added to the static gltf document extensions list
> Even the VRM viewer code (which I maintain) technically does it wrong by registering it in the load function.
> https://github.com/V-Sekai/TOOL_model_explorer/blob/main/vsk_model_explorer/core/ModelExplorer.gd#L90

I also improved the documentation, particularly to warn against the pitfalls I encountered, notably not realizing the list was static, and registering multiple copies of the same extension.

Also, a note about `get_supported_gltf_extensions()`: I know this API already exists, but it only works in cases where a GLTFDocumentExtension implements a glTF extension, and it also doesn't allow for getting a reference to the extension itself if it needs to be unregistered. Not all extensions, notably the built-in GLTFDocumentExtensionConvertImporterMesh, implement a glTF extension, so they will not appear in `get_supported_gltf_extensions`. That's why I want a new API to return the instances themselves.