### PR TITLE
Fix crash when `Animation` is `nullptr`

### DIFF
--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -132,6 +132,7 @@ private:
 	void _capture(const StringName &p_name, bool p_from_end = false, double p_duration = -1.0, Tween::TransitionType p_trans_type = Tween::TRANS_LINEAR, Tween::EaseType p_ease_type = Tween::EASE_IN);
 	void _process_playback_data(PlaybackData &cd, double p_delta, float p_blend, bool p_seeked, bool p_internal_seeked, bool p_started, bool p_is_current = false);
 	void _blend_playback_data(double p_delta, bool p_started);
+	bool _ensure_current_animation();
 	void _stop_internal(bool p_reset, bool p_keep_state);
 	void _check_immediately_after_start();
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Based on both #95605 and https://github.com/godotengine/godot/pull/95605#discussion_r1732114286.
Partially fixes #80715.

The original author was apparently too lazy for it so i did it myself, with new changes based on... you know.

Still rarely crashes from switching selection of the `SceneTree` between `AnimationPlayer` and other `Node` with switching scene.