### PR TITLE
Use UIDs in addition to paths for extracted meshes, materials and animations

### DIFF
--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -210,7 +210,7 @@ class ResourceImporterScene : public ResourceImporter {
 		SHAPE_TYPE_AUTOMATIC,
 	};
 
-	static Error _check_resource_save_paths(const Dictionary &p_data);
+	static Error _check_resource_save_paths(ResourceUID::ID p_source_id, const String &p_hash_suffix, const Dictionary &p_data);
 	Array _get_skinned_pose_transforms(ImporterMeshInstance3D *p_src_mesh_node);
 	void _replace_owner(Node *p_node, Node *p_scene, Node *p_new_owner);
 	Node *_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1585,6 +1585,10 @@ void SceneImportSettingsDialog::_save_dir_confirm() {
 			continue; //ignore
 		}
 		String path = item->get_text(1);
+		String uid_path = path;
+		if (path.begins_with("uid://")) {
+			path = ResourceUID::uid_to_path(uid_path);
+		}
 		if (!path.is_resource_file()) {
 			continue;
 		}
@@ -1601,9 +1605,11 @@ void SceneImportSettingsDialog::_save_dir_confirm() {
 					EditorNode::get_singleton()->add_io_error(TTR("Can't make material external to file, write error:") + "\n\t" + path);
 					continue;
 				}
+				uid_path = ResourceUID::path_to_uid(path);
 
 				md.settings["use_external/enabled"] = true;
-				md.settings["use_external/path"] = path;
+				md.settings["use_external/path"] = uid_path;
+				md.settings["use_external/fallback_path"] = path;
 
 			} break;
 			case ACTION_CHOOSE_MESH_SAVE_PATHS: {
@@ -1611,14 +1617,16 @@ void SceneImportSettingsDialog::_save_dir_confirm() {
 				MeshData &md = mesh_map[id];
 
 				md.settings["save_to_file/enabled"] = true;
-				md.settings["save_to_file/path"] = path;
+				md.settings["save_to_file/path"] = uid_path;
+				md.settings["save_to_file/fallback_path"] = path;
 			} break;
 			case ACTION_CHOOSE_ANIMATION_SAVE_PATHS: {
 				ERR_CONTINUE(!animation_map.has(id));
 				AnimationData &ad = animation_map[id];
 
 				ad.settings["save_to_file/enabled"] = true;
-				ad.settings["save_to_file/path"] = path;
+				ad.settings["save_to_file/path"] = uid_path;
+				ad.settings["save_to_file/fallback_path"] = path;
 
 			} break;
 		}


### PR DESCRIPTION
Fixes #68672

edit 2025-02-12: rewrote this PR from scratch.
edit 2025-02-16: migrate existing UIDs, use hash function to derive consistent UIDs for meshes and animations.

This doesn't necessarily fix a bug, but this is trying to migrate more things to support UIDs. In this case, the extracted file paths for meshes and animations did not support UID, so if the paths were renamed it was possible for the import to fail.

Similarly, renaming materials could cause them to get lost between imports. This change will keep the uid updated so that the material can be referenced even after it is renamed.

This PR adds `use_external/fallback_path` and `save_to_file/fallback_path` to the existing `use_external/path` and `save_to_file/path` properties. These properties already use the ResourceUID::ensure_path() function which means they support UIDs already. The main change is to handle the case where the UID lookup fails (is_empty()) and to regenerate the UID from the fallback path.
Additionally, refresh `fallback_path` properties on every import to ensure that the path is kept up to date.
Finally, this changes Material, Mesh and Animation extraction buttons in the SceneImportSettings dialog to generate UIDs and assign the fallback_path initially.

Also, fix a bug in CSV translations related to UID hashing (as this was the only other place in the code which used a hash function to construct a UID, but did so incorrectly (allowing negative numbers) and without checking for collision.