### PR TITLE
[Input] Get mapped joy events for joypad

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -147,6 +147,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_action_raw_strength", "action", "exact_match"), &Input::get_action_raw_strength, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("get_axis", "negative_action", "positive_action"), &Input::get_axis);
 	ClassDB::bind_method(D_METHOD("get_vector", "negative_x", "positive_x", "negative_y", "positive_y", "deadzone"), &Input::get_vector, DEFVAL(-1.0f));
+	ClassDB::bind_method(D_METHOD("get_mapped_joy_events", "device"), &Input::get_mapped_joy_events);
 	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &Input::remove_joy_mapping);
 	ClassDB::bind_method(D_METHOD("is_joy_known", "device"), &Input::is_joy_known);
@@ -1695,6 +1696,40 @@ void Input::parse_mapping(const String &p_mapping) {
 	}
 
 	map_db.push_back(mapping);
+}
+
+Dictionary Input::get_mapped_joy_events(int p_device) {
+	ERR_FAIL_COND_V(!joy_names.has(p_device), Dictionary());
+	int index = joy_names[p_device].mapping;
+	if (index == -1) {
+		return Dictionary();
+	}
+
+	const JoyDeviceMapping &mapping = map_db[index];
+	Array buttons;
+	Array axes;
+
+	for (int i = 0; i < mapping.bindings.size(); i++) {
+		const JoyBinding binding = mapping.bindings[i];
+		switch (binding.outputType) {
+			case TYPE_BUTTON:
+				buttons.push_back(binding.output.button);
+				break;
+			case TYPE_AXIS:
+				axes.push_back(binding.input.axis.axis);
+				break;
+			default:
+				break; // Ignoring TYPE_HAT.
+		}
+	}
+	buttons.sort();
+	axes.sort();
+
+	Dictionary ret;
+	ret["buttons"] = buttons;
+	ret["axes"] = axes;
+
+	return ret;
 }
 
 void Input::add_joy_mapping(const String &p_mapping, bool p_update_existing) {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -366,6 +366,7 @@ public:
 	void joy_axis(int p_device, JoyAxis p_axis, float p_value);
 	void joy_hat(int p_device, BitField<HatMask> p_val);
 
+	Dictionary get_mapped_joy_events(int p_device);
 	void add_joy_mapping(const String &p_mapping, bool p_update_existing = false);
 	void remove_joy_mapping(const String &p_guid);
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -179,6 +179,17 @@
 				[b]Note:[/b] This method only works on Android and iOS. On other platforms, it always returns [constant Vector3.ZERO].
 			</description>
 		</method>
+		<method name="get_mapped_joy_events">
+			<return type="Dictionary" />
+			<param index="0" name="device" type="int" />
+			<description>
+				Returns a dictionary which contains all buttons and axes that are mapped to the given joypad.
+				The dictionary contains the following fields:
+				[code]buttons[/code]: for all mapped [enum JoyButton].
+				[code]axes[/code]: for all mapped [enum JoyAxis].
+				If the joypad is not mapped, an empty dictionary is returned.
+			</description>
+		</method>
 		<method name="get_mouse_button_mask" qualifiers="const">
 			<return type="int" enum="MouseButtonMask" is_bitfield="true" />
 			<description>


### PR DESCRIPTION
Get the buttons and axes mapped to the connected joypad w/o having to use them all.

Motivation behind this PR:
* I want the user to be able to change their mappings in-game. This requires knowledge about the capabilities of their connected joypad. It also allows me to fetch a different joypad image.
  * different joypads have different buttons/axes available: some joypads have `JOY_BUTTON_PADDLE_*`, some don't. Some don't have `JOY_BUTTON_MISC1`, or `JOY_AXIS_RIGHT_*`, etc.
* Using the joypad name is not reliable, as the same joypad can have different names on different platforms/APIs.
  * the guid is also not sensible


See attached test project:
[joypad-event-test.zip](https://github.com/user-attachments/files/18240367/joypad-event-test.zip)


Output for my joypad using the test project:
```
Xbox 360 Controller
["a", "b", "x", "y", "back", "guide", "start", "leftstick", "rightstick", "leftshoulder", "rightshoulder", "dpup", "dpdown", "dpleft", "dpright"]
["leftx", "lefty", "rightx", "righty", "lefttrigger", "righttrigger"]
```

fixes https://github.com/godotengine/godot-proposals/issues/12564