### PR TITLE
Replace QOA channel multiplication with bit shift

### DIFF
--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -189,7 +189,7 @@ void AudioStreamPlaybackWAV::do_resample(const Depth *p_src, AudioFrame *p_dst, 
 							qoa_decode_frame(ofs_src, p_qoa->frame_len, &p_qoa->desc, p_qoa->dec.ptr(), &p_qoa->dec_len);
 						}
 
-						uint32_t dec_idx = (interp_pos % QOA_FRAME_LEN) * p_qoa->desc.channels;
+						uint32_t dec_idx = interp_pos % QOA_FRAME_LEN << (is_stereo ? 1 : 0);
 
 						if ((sign > 0 && i == 0) || (sign < 0 && i == 1)) {
 							final = p_qoa->dec[dec_idx];


### PR DESCRIPTION
`do_resample` has one version for mono and other for stereo. No other channel amounts.

By taking advantage of this you can just bit shift by one to the left instead of using a channel multiplication.