### PR TITLE
Show tooltips for `res://` and `uid://` strings in ScriptEditor

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -277,6 +277,7 @@ class EditorHelpBit : public VBoxContainer {
 		String value;
 		Vector<ArgumentData> arguments;
 		String qualifiers;
+		String resource_path;
 	};
 
 	inline static HashMap<StringName, HelpData> doc_class_cache;

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1102,6 +1102,11 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 }
 
 void ScriptTextEditor::_show_symbol_tooltip(const String &p_symbol, int p_row, int p_column) {
+	if (p_symbol.begins_with("res://") || p_symbol.begins_with("uid://")) {
+		EditorHelpBitTooltip::show_tooltip(code_editor->get_text_editor(), "resource||" + p_symbol);
+		return;
+	}
+
 	Node *base = get_tree()->get_edited_scene_root();
 	if (base) {
 		base = _find_node_for_script(base, base, script);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5027

Following the addition of tooltips (#91060), this PR adds tooltips for `res://` and `uid://` strings.

[](https://github.com/user-attachments/assets/6650c137-1a78-4fed-92ed-5ba96c0135dd)



