### PR TITLE
Improve and fix packed arrays usage

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5378,6 +5378,7 @@ Variant GDScriptAnalyzer::make_variable_default_value(GDScriptParser::VariableNo
 		bool is_initializer_value_reduced = false;
 		Variant initializer_value = make_expression_reduced_value(p_variable->initializer, is_initializer_value_reduced);
 		if (is_initializer_value_reduced) {
+			check_if_conversion_needed(p_variable, initializer_value);
 			result = initializer_value;
 		}
 	} else {
@@ -5400,6 +5401,18 @@ Variant GDScriptAnalyzer::make_variable_default_value(GDScriptParser::VariableNo
 	}
 
 	return result;
+}
+
+void GDScriptAnalyzer::check_if_conversion_needed(GDScriptParser::VariableNode *p_variable, Variant &p_initializer_value) {
+	GDScriptParser::DataType datatype = p_variable->get_datatype();
+
+	if (Variant::can_convert_strict(datatype.builtin_type, p_initializer_value.get_type())) {
+		Variant value = p_initializer_value;
+		const Variant *args = &p_initializer_value;
+		Callable::CallError err;
+		Variant::construct(datatype.builtin_type, value, &args, 1, err);
+		p_initializer_value = value;
+	}
 }
 
 GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source) {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -161,6 +161,7 @@ public:
 	Error analyze();
 
 	Variant make_variable_default_value(GDScriptParser::VariableNode *p_variable);
+	void check_if_conversion_needed(GDScriptParser::VariableNode *p_variable, Variant &p_initializer_value);
 
 	static bool check_type_compatibility(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source, bool p_allow_implicit_conversion = false, const GDScriptParser::Node *p_source_node = nullptr);
 	static GDScriptParser::DataType type_from_metatype(const GDScriptParser::DataType &p_meta_type);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/77133 with some additional improvements.

- [ ] ~~Add type checks to packed arrays the same way it works for typed arrays~~ WIP in https://github.com/godotengine/godot/pull/99950;
- [x] Fix storing elements as typed arrays in resources when instead it should have used the packed version (https://github.com/godotengine/godot/issues/77133);
- [x] Commenting/Uncommenting `@tools` resets the packed array if it was saved as a typed array.

The approach here is to make sure in `GDScriptAnalyzer::make_variable_default_value` that the `initializer_value` is converted to the `p_variable` built in type (e.g. `Array` to `PackedVector3Array`).
I feel the implementation can be improved (avoiding a new method, using a different method name, etc.), but I'll wait for a review for that.

The logic of the new code is taken from the body of `GDScriptInstance::set` for the data conversion part:
https://github.com/godotengine/godot/blob/0f95e9f8e665cedaa5aace5f6f86de2b4b5a8c60/modules/gdscript/gdscript.cpp#L1697C1-L1702C6

Before this commit, any packed array initialized with an empty `Array` would result in a typed `Array` being stored in the `test.tres` file.

#### Minimal reproduction project
[MinimalProject.zip](https://github.com/user-attachments/files/18247292/MinimalProject.zip)