### PR TITLE
MeshInstance3D: Implement the use of overriden virtual _get_aabb

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -218,13 +218,11 @@ NodePath MeshInstance3D::get_skeleton_path() {
 AABB MeshInstance3D::get_aabb() const {
 	if (!mesh.is_null()) {
 		return mesh->get_aabb();
-	} else {
-		AABB ret;
-		GDVIRTUAL_CALL(_get_aabb, ret);
-		return ret;
 	}
 
-	return AABB();
+	AABB aabb;
+	GDVIRTUAL_CALL(_get_aabb, aabb);
+	return aabb;
 }
 
 Node *MeshInstance3D::create_trimesh_collision_node() {

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -218,6 +218,10 @@ NodePath MeshInstance3D::get_skeleton_path() {
 AABB MeshInstance3D::get_aabb() const {
 	if (!mesh.is_null()) {
 		return mesh->get_aabb();
+	} else {
+		AABB ret;
+		GDVIRTUAL_CALL(_get_aabb, ret);
+		return ret;
 	}
 
 	return AABB();


### PR DESCRIPTION
This PR refers to [Make GeometryInstance3D accessible for custom Geometry Scenes ](https://github.com/godotengine/godot-proposals/issues/11252) (and implementing the alternative approach)

There is a virtual method `_get_aabb` in VisualInstance3D->MeshInstance3D that cannot be used in GDScript anymore because it is routed to the Mesh. If there is no Mesh an empty AABB is returned. This PR fixes this so that if there is no Mesh, the GDScript overriden `_get_aabb` in MeshInstance3D is used.

[[debug]meshinstance3d_get_aabb.zip](https://github.com/user-attachments/files/18253196/debug.meshinstance3d_get_aabb.zip)

