### PR TITLE
Add right click popup options in Connections to Method dialog.

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -1000,7 +1000,7 @@ void ConnectionsDock::_make_or_edit_connection() {
 /*
  * Creates single connection w/ undo-redo functionality.
  */
-void ConnectionsDock::_connect(const ConnectDialog::ConnectionData &p_cd) {
+void ConnectionsDock::_connect(const ConnectDialog::ConnectionData &p_cd, const bool &commit_action) {
 	Node *source = Object::cast_to<Node>(p_cd.source);
 	Node *target = Object::cast_to<Node>(p_cd.target);
 
@@ -1018,13 +1018,15 @@ void ConnectionsDock::_connect(const ConnectDialog::ConnectionData &p_cd) {
 	undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
 	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
-	undo_redo->commit_action();
+	if (commit_action) {
+		undo_redo->commit_action();
+	}
 }
 
 /*
  * Break single connection w/ undo-redo functionality.
  */
-void ConnectionsDock::_disconnect(const ConnectDialog::ConnectionData &p_cd) {
+void ConnectionsDock::_disconnect(const ConnectDialog::ConnectionData &p_cd, const bool &commit_action) {
 	ERR_FAIL_COND(p_cd.source != selected_node); // Shouldn't happen but... Bugcheck.
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
@@ -1038,7 +1040,9 @@ void ConnectionsDock::_disconnect(const ConnectDialog::ConnectionData &p_cd) {
 	undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
 	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
-	undo_redo->commit_action();
+	if (commit_action) {
+		undo_redo->commit_action();
+	}
 }
 
 /*
@@ -1589,6 +1593,8 @@ void ConnectionsDock::update_tree() {
 	connect_button->set_disabled(true);
 }
 
+ConnectionsDock *ConnectionsDock::singleton = nullptr;
+
 ConnectionsDock::ConnectionsDock() {
 	set_name(TTR("Signals"));
 
@@ -1657,6 +1663,8 @@ ConnectionsDock::ConnectionsDock() {
 	tree->connect(SceneStringName(gui_input), callable_mp(this, &ConnectionsDock::_tree_gui_input));
 
 	add_theme_constant_override("separation", 3 * EDSCALE);
+
+	singleton = this;
 }
 
 ConnectionsDock::~ConnectionsDock() {

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -199,6 +199,8 @@ class ConnectionsDockTree : public Tree {
 class ConnectionsDock : public VBoxContainer {
 	GDCLASS(ConnectionsDock, VBoxContainer);
 
+	static ConnectionsDock *singleton;
+
 	enum TreeItemType {
 		TREE_ITEM_TYPE_ROOT,
 		TREE_ITEM_TYPE_CLASS,
@@ -237,8 +239,8 @@ class ConnectionsDock : public VBoxContainer {
 	void _filter_changed(const String &p_text);
 
 	void _make_or_edit_connection();
-	void _connect(const ConnectDialog::ConnectionData &p_cd);
-	void _disconnect(const ConnectDialog::ConnectionData &p_cd);
+	void _connect(const ConnectDialog::ConnectionData &p_cd, const bool &commit_action = true);
+	void _disconnect(const ConnectDialog::ConnectionData &p_cd, const bool &commit_action = true);
 	void _disconnect_all();
 
 	void _tree_item_selected();
@@ -265,6 +267,13 @@ protected:
 	static void _bind_methods();
 
 public:
+	static ConnectionsDock *get_singleton() { return singleton; }
+	void connect_connection(const ConnectDialog::ConnectionData &p_cd, const bool &commit_action = true) {
+		_connect(p_cd, commit_action);
+	}
+	void disconnect_connection(const ConnectDialog::ConnectionData &p_cd, const bool &commit_action = true) {
+		_disconnect(p_cd, commit_action);
+	}
 	void set_node(Node *p_node);
 	void update_tree();
 

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -31,25 +31,51 @@
 #ifndef SCRIPT_TEXT_EDITOR_H
 #define SCRIPT_TEXT_EDITOR_H
 
-#include "script_editor_plugin.h"
-
 #include "editor/code_editor.h"
+#include "editor/connections_dialog.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/tree.h"
+#include "script_editor_plugin.h"
 
 class RichTextLabel;
+class PopupMenu;
 
 class ConnectionInfoDialog : public AcceptDialog {
 	GDCLASS(ConnectionInfoDialog, AcceptDialog);
 
 	Label *method = nullptr;
 	Tree *tree = nullptr;
+	PopupMenu *slot_menu = nullptr;
+	ConnectDialog *connect_dialog = nullptr;
+	Node *selected_node = nullptr;
+
+	enum SlotMenuOption {
+		SLOT_MENU_EDIT,
+		SLOT_MENU_DISCONNECT,
+		SLOT_MENU_SHOW_SOURCE_NODE,
+		SLOT_MENU_SHOW_TARGET_NODE
+	};
+
+	void _connect(const ConnectDialog::ConnectionData &connection);
+	void _disconnect(const ConnectDialog::ConnectionData &connection);
+	void _edit_connection();
+	void _show_node(Node &_node_to_show);
+	void _handle_slot_menu_option(const int &p_option);
+	void _open_edit_connection_dialog(const ConnectDialog::ConnectionData &cd, const TreeItem &parent_tree_item);
+	void _slot_menu_about_to_popup();
+	void _tree_gui_input(const Ref<InputEvent> &p_event);
+	void _tree_item_activated();
+	void update_popup(const String &p_method);
 
 	virtual void ok_pressed() override;
 
+protected:
+	static void _bind_methods();
+
 public:
 	void popup_connections(const String &p_method, const Vector<Node *> &p_nodes);
+	Callable _script_text_editor_update_connected;
 
 	ConnectionInfoDialog();
 };
@@ -210,6 +236,8 @@ protected:
 
 	String _get_absolute_path(const String &rel_path);
 
+	static void _bind_methods();
+
 public:
 	void _update_connected_methods();
 
@@ -267,6 +295,7 @@ public:
 
 	virtual void validate() override;
 
+	Ref<Script> *get_current_script();
 	Variant get_previous_state();
 	void store_previous_state();
 


### PR DESCRIPTION
Connections to method is quite baron in it’s current read-only form, lacking quick access to useful connection functionality. In this pull request I have added the following right click options:

1. Edit…
~~2. Show Node in Tree~~
2. Show Source Node in Tree
3. Show Target Node in Tree
4. Disconnect

I decided to preserve the ordering found in the signals tab for consistency. ~~However, I did switch out “Go to Method” in lieu of the “Show Node in Tree” option because we had to come from the method to open this dialog.~~

Double clicking on either the source node or target node will show the node in the tree. 

<img width="601" alt="updated-connections-to-method" src="https://github.com/user-attachments/assets/2886d097-61ff-47db-b896-d54a8233fb33" />

~~Show Node in Tree goes to the appropriate node for both source and target, and signal defaults to using the source node.~~

Closes godotengine/godot-proposals#1849
Closes godotengine/godot-proposals#10840