### PR TITLE
[Android Editor] Update handling of the `REQUEST_INSTALL_PACKAGES` permission

### DIFF
--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -52,7 +52,7 @@ void register_android_exporter() {
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/debug_keystore_pass", PROPERTY_HINT_PASSWORD));
 
 #ifdef ANDROID_ENABLED
-	EDITOR_DEF_BASIC("export/android/install_exported_apk", true);
+	EDITOR_DEF_BASIC("export/android/install_exported_apk", !OS::get_singleton()->has_feature("horizonos"));
 #else
 	EDITOR_DEF_BASIC("export/android/java_sdk_path", OS::get_singleton()->get_environment("JAVA_HOME"));
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/java_sdk_path", PROPERTY_HINT_GLOBAL_DIR));

--- a/platform/android/java/editor/src/horizonos/AndroidManifest.xml
+++ b/platform/android/java/editor/src/horizonos/AndroidManifest.xml
@@ -34,6 +34,9 @@
     <!-- Scene api -->
     <uses-permission android:name="com.oculus.permission.USE_SCENE" />
 
+    <!-- Temp removal of the 'REQUEST_INSTALL_PACKAGES' permission as it's currently forbidden by the Horizon OS store -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove" />
+
     <application>
 
         <activity

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -130,11 +130,20 @@ abstract class BaseGodotEditor : GodotActivity() {
 	 */
 	@CallSuper
 	protected open fun getExcludedPermissions(): MutableSet<String> {
-		return mutableSetOf(
+		val excludedPermissions = mutableSetOf(
 			// The RECORD_AUDIO permission is requested when the "audio/driver/enable_input" project
 			// setting is enabled.
-			Manifest.permission.RECORD_AUDIO
+			Manifest.permission.RECORD_AUDIO,
 		)
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			excludedPermissions.add(
+				// The REQUEST_INSTALL_PACKAGES permission is requested the first time we attempt to
+				// open an apk file.
+				Manifest.permission.REQUEST_INSTALL_PACKAGES,
+			)
+		}
+		return excludedPermissions
 	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -1039,7 +1039,8 @@ class Godot(private val context: Context) {
 	}
 
 	fun requestPermission(name: String?): Boolean {
-		return requestPermission(name, getActivity())
+		val activity = getActivity() ?: return false
+		return requestPermission(name, activity)
 	}
 
 	fun requestPermissions(): Boolean {

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -30,13 +30,12 @@
 
 package org.godotengine.godot;
 
+import org.godotengine.godot.error.Error;
 import org.godotengine.godot.input.GodotEditText;
 
 import android.app.Activity;
-import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
-import android.graphics.Point;
 import android.graphics.Rect;
 import android.net.Uri;
 import android.os.Build;
@@ -47,7 +46,6 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
 import android.view.DisplayCutout;
-import android.view.Surface;
 import android.view.WindowInsets;
 
 import androidx.core.content.FileProvider;
@@ -121,10 +119,10 @@ public class GodotIO {
 			}
 
 			activity.startActivity(intent);
-			return 0;
+			return Error.OK.toNativeValue();
 		} catch (Exception e) {
 			Log.e(TAG, "Unable to open uri " + uriString, e);
-			return 1;
+			return Error.FAILED.toNativeValue();
 		}
 	}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/error/Error.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/error/Error.kt
@@ -92,7 +92,7 @@ enum class Error(private val description: String) {
 		}
 	}
 
-	internal fun toNativeValue(): Int = this.ordinal
+	fun toNativeValue(): Int = this.ordinal
 
 	override fun toString(): String {
 		return description


### PR DESCRIPTION
- Only request the `REQUEST_INSTALL_PACKAGES` permission the first time the editor tries to install an exported apk
- Disable the permission for the HorizonOS build as the HorizonOS store doesn't support it yet

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
