### PR TITLE
Compatibility: Fix ASTC HDR extension detection

### DIFF
--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -79,7 +79,7 @@ Config::Config() {
 
 	bptc_supported = extensions.has("GL_ARB_texture_compression_bptc") || extensions.has("EXT_texture_compression_bptc");
 	astc_supported = extensions.has("GL_KHR_texture_compression_astc") || extensions.has("GL_OES_texture_compression_astc") || extensions.has("GL_KHR_texture_compression_astc_ldr") || extensions.has("GL_KHR_texture_compression_astc_hdr");
-	astc_hdr_supported = extensions.has("GL_KHR_texture_compression_astc_ldr");
+	astc_hdr_supported = extensions.has("GL_KHR_texture_compression_astc_hdr");
 	astc_layered_supported = extensions.has("GL_KHR_texture_compression_astc_sliced_3d");
 
 	if (RasterizerGLES3::is_gles_over_gl()) {


### PR DESCRIPTION
Ensures that ASTC HDR support is only enabled when the `GL_KHR_texture_compression_astc_hdr` extension is detected instead of `GL_KHR_texture_compression_astc_ldr`