### PR TITLE
Fix gaps in CSGPolygon3D spin mode at 360 degrees

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2255,7 +2255,11 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 					current_xform.translate_local(Vector3(0, 0, -depth));
 				} break;
 				case MODE_SPIN: {
-					current_xform.rotate(Vector3(0, 1, 0), spin_step);
+					if (end_count == 0 && x0 == extrusions - 1) {
+						current_xform = base_xform;
+					} else {
+						current_xform.rotate(Vector3(0, 1, 0), spin_step);
+					}
 				} break;
 				case MODE_PATH: {
 					double previous_offset = x0 * extrusion_step;


### PR DESCRIPTION
Fixes: #100817
Same problem https://github.com/godotengine/godot/pull/100020, similar cause, the same ugly solution. When the polygon is spun full circle, there might remain a small gap between the first polygon slice and the last (unless you win the floating point lottery). Hence, set the last iteration to use the same rotation (transform) as the first.