### PR TITLE
Fix Mold-search in older systems

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -123,10 +123,16 @@ def configure(env: "SConsEnvironment"):
                         found_wrapper = True
                         break
                 if not found_wrapper:
-                    print_error(
-                        "Couldn't locate mold installation path. Make sure it's installed in /usr or /usr/local."
-                    )
-                    sys.exit(255)
+                    for path in os.environ["PATH"].split(os.pathsep):
+                        if os.path.isfile(path + "/ld.mold"):
+                            env.Append(LINKFLAGS=["-B" + path])
+                            found_wrapper = True
+                            break
+                    if not found_wrapper:
+                        print_error(
+                            "Couldn't locate mold installation path. Make sure it's installed in /usr, /usr/local or in PATH environment variable."
+                        )
+                        sys.exit(255)
             else:
                 env.Append(LINKFLAGS=["-fuse-ld=mold"])
         else:


### PR DESCRIPTION
I fixed a bug in a compiling script so that using Mold for faster development [corresponds to official documentation](https://docs.godotengine.org/en/stable/contributing/development/compiling/compiling_for_linuxbsd.html#using-mold-for-faster-development).

This bug show itself if the user's computer has an old version of GCC installed. As you can see in the commentary inside code, it affects systems with GCC version < 12.1. Especially old systems of Ubuntu, where user just can't install newer version of GCC. In this case script starts to search for specific mold link inside "/usr/libexec/mold", "/usr/local/libexec/mold", "/usr/lib/mold" and "/usr/local/lib/mold" instead of place, where user installed mold binaries manually (the way as it said in documentation), and prints an error.

I didn't change the existing code, but just added a search for Mold link inside user's PATH variable (where Mold should be as mentioned in documentation). So the old looking-for-mold-in-specific-folders will still work, despite the fact that this point is missed in the documentation.

_Here is a screeshot of terminal before and after fix.
![image](https://github.com/user-attachments/assets/afdff198-87ad-4893-8e3d-66dc6bad3121)_

How this bug occures (my hypothesis):
1) Godot developers uses newer versions of software and missed that issue, or...
2) Godot developers uses self-compiled version of Mold, becouse `cmake install` installs Mold right into one of the folders, mentioned in the script. User don't even need to add it into PATH. And this even more possible becouse for 32-bit Linux Mold is not provided in compiled form. In any case, this shortcoming went unnoticed.

It should be fixed in some way, otherwise, users risk encountering a problem and having troubles with finding ways to solve it.

UPD: I checked [mold-1.1](https://github.com/rui314/mold/releases/tag/v1.1) and [mold-2.35.1](https://github.com/rui314/mold/releases/tag/v2.35.1) files as the first mold version wich have compiled binaries and the last mold release respectively. Both have the same file structure, and I don't think any other version between should be checked. The added code will find Mold link in any of those.