### PR TITLE
Style: Add `.clangd` config

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,31 @@
+# https://clangd.llvm.org/config
+---
+# Default conditions, apply everywhere.
+
+Diagnostics:
+  Includes:
+    IgnoreHeader:
+      - core/typedefs\.h # Our "main" header, featuring transitive includes; allow everywhere.
+      - \.compat\.inc
+---
+# Header-specific conditions.
+
+If:
+  PathMatch: .*\.(h|hh|hpp|hxx|inc)
+
+# Exclude certain, noisy warnings that lack full context. Replace with lowered severity if/when
+# clangd gets diagnostic severity support. (See: https://github.com/clangd/clangd/issues/1937)
+CompileFlags:
+  Add:
+    - -Wno-unneeded-internal-declaration
+    - -Wno-unused-const-variable
+    - -Wno-unused-function
+    - -Wno-unused-variable
+---
+# Suppress all third-party warnings.
+
+If:
+  PathMatch: thirdparty/.*
+
+Diagnostics:
+  Suppress: "*"

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ indent_style = space
 indent_size = 4
 
 # YAML requires indentation with spaces instead of tabs.
-[*.{yml,yaml}]
+[{*.{yml,yaml},.clang{-format,-tidy,d}}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
After testing clangd once I saw how easily the tool finds unused headers[^1], the intellisense/performance benefits it provided were immediately apparant. However, to be fully suited for the repo, a few adjustments needed to be made via configuration. This PR achieves exactly that, adding a minimal `.clangd` to allow the repo to "properly" utilize this tool. I fully expect this file to expand over time, as this is very much a jumping-off point. Also extends `.editorconfig` to recognize the clang config files as `yaml`.

[^1]: https://github.com/godotengine/godot/pull/100634#issuecomment-2556801462