### PR TITLE
.clang-format: Change AllowShortFunctionsOnASingleLine back to `Inline`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -44,7 +44,7 @@ AllowAllParametersOfDeclarationOnNextLine: false
 # AllowShortBlocksOnASingleLine: Never
 # AllowShortCaseLabelsOnASingleLine: false
 # AllowShortEnumsOnASingleLine: true
-# AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Inline
 # AllowShortIfStatementsOnASingleLine: Never
 # AllowShortLambdasOnASingleLine: All
 # AllowShortLoopsOnASingleLine: false

--- a/misc/utility/.clang-format-glsl
+++ b/misc/utility/.clang-format-glsl
@@ -8,6 +8,7 @@ AlignTrailingComments:
   Kind: Never
   OverEmptyLines: 0
 AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine: Inline
 BreakConstructorInitializers: AfterColon
 ColumnLimit: 0
 ConstructorInitializerIndentWidth: 8


### PR DESCRIPTION
Reverts the workaround introduced in https://github.com/godotengine/godot/pull/63868

Due to a bug in clang-format-14, we had to change `AllowShortFunctionsOnASingleLine` to `All` as a workaround.  Now that we're up to clang-format-17, this can be changed back without issue.