### PR TITLE
Rename "vertex" to "control point" across the class reference

### DIFF
--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <class name="Curve2D" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Describes a Bézier curve in 2D space.
@@ -59,21 +59,21 @@
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading to the vertex [param idx]. The returned position is relative to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the control point leading to the curve point [param idx]. The returned position is relative to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_out" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading out of the vertex [param idx]. The returned position is relative to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the control point leading out of the curve point [param idx]. The returned position is relative to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="remove_point">
@@ -88,8 +88,8 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="t" type="float" />
 			<description>
-				Returns the position between the vertex [param idx] and the vertex [code]idx + 1[/code], where [param t] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &lt;= t &lt;= 1.0[/code]) give strange, but predictable results.
-				If [param idx] is out of bounds it is truncated to the first or last vertex, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position between the curve point [param idx] and the curve point [code]idx + 1[/code], where [param t] controls if the point is the first point ([code]t = 0.0[/code]), the las tpoint ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &lt;= t &lt;= 1.0[/code]) give strange, but predictable results.
+				If [param idx] is out of bounds it is truncated to the first or last curve point, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="sample_baked" qualifiers="const">
@@ -122,7 +122,7 @@
 			<return type="Vector2" />
 			<param index="0" name="fofs" type="float" />
 			<description>
-				Returns the position at the vertex [param fofs]. It calls [method sample] using the integer part of [param fofs] as [code]idx[/code], and its fractional part as [code]t[/code].
+				Returns the position at the point [param fofs]. It calls [method sample] using the integer part of [param fofs] as [code]idx[/code], and its fractional part as [code]t[/code].
 			</description>
 		</method>
 		<method name="set_point_in">
@@ -130,7 +130,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the position of the control point leading to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
+				Sets the position of the control point leading to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the curve point.
 			</description>
 		</method>
 		<method name="set_point_out">
@@ -138,7 +138,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the position of the control point leading out of the vertex [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
+				Sets the position of the control point leading out of the curve point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the curve point.
 			</description>
 		</method>
 		<method name="set_point_position">
@@ -146,7 +146,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the position for the vertex [param idx]. If the index is out of bounds, the function sends an error to the console.
+				Sets the position for the point [param idx]. If the index is out of bounds, the function sends an error to the console.
 			</description>
 		</method>
 		<method name="tessellate" qualifiers="const">

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <class name="Curve2D" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Describes a Bézier curve in 2D space.

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -88,7 +88,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="t" type="float" />
 			<description>
-				Returns the position between the control point [param idx] and the control point [code]idx + 1[/code], where [param t] controls if the point is the first point ([code]t = 0.0[/code]), the las tpoint ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &lt;= t &lt;= 1.0[/code]) give strange, but predictable results.
+				Returns the position between the control point [param idx] and the control point [code]idx + 1[/code], where [param t] controls if the point is the first point ([code]t = 0.0[/code]), the last point ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &lt;= t &lt;= 1.0[/code]) give strange, but predictable results.
 				If [param idx] is out of bounds it is truncated to the first or last control point, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -59,21 +59,21 @@
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading to the curve point [param idx]. The returned position is relative to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the control point leading to the control point [param idx]. The returned position is relative to the control point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_out" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading out of the curve point [param idx]. The returned position is relative to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the control point leading out of the control point [param idx]. The returned position is relative to the control point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position of the control point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="remove_point">
@@ -88,8 +88,8 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="t" type="float" />
 			<description>
-				Returns the position between the curve point [param idx] and the curve point [code]idx + 1[/code], where [param t] controls if the point is the first point ([code]t = 0.0[/code]), the las tpoint ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &lt;= t &lt;= 1.0[/code]) give strange, but predictable results.
-				If [param idx] is out of bounds it is truncated to the first or last curve point, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0)[/code].
+				Returns the position between the control point [param idx] and the control point [code]idx + 1[/code], where [param t] controls if the point is the first point ([code]t = 0.0[/code]), the las tpoint ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &lt;= t &lt;= 1.0[/code]) give strange, but predictable results.
+				If [param idx] is out of bounds it is truncated to the first or last control point, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0)[/code].
 			</description>
 		</method>
 		<method name="sample_baked" qualifiers="const">
@@ -130,7 +130,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the position of the control point leading to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the curve point.
+				Sets the position of the control point leading to the control point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the control point.
 			</description>
 		</method>
 		<method name="set_point_out">
@@ -138,7 +138,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector2" />
 			<description>
-				Sets the position of the control point leading out of the curve point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the curve point.
+				Sets the position of the control point leading out of the control point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the control point.
 			</description>
 		</method>
 		<method name="set_point_position">

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -72,21 +72,21 @@
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading to the curve point [param idx]. The returned position is relative to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the control point leading to the control point [param idx]. The returned position is relative to the control point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_out" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading out of the curve point [param idx]. The returned position is relative to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the control point leading out of the control point [param idx]. The returned position is relative to the control point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the control point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_tilt" qualifiers="const">
@@ -108,8 +108,8 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="t" type="float" />
 			<description>
-				Returns the position between the curve point [param idx] and the curve point [code]idx + 1[/code], where [param t] controls if the point is the first curve point ([code]t = 0.0[/code]), the last curve point ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &gt;= t &lt;=1[/code]) give strange, but predictable results.
-				If [param idx] is out of bounds it is truncated to the first or last curve point, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position between the control point [param idx] and the control point [code]idx + 1[/code], where [param t] controls if the point is the first control point ([code]t = 0.0[/code]), the last control point ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &gt;= t &lt;=1[/code]) give strange, but predictable results.
+				If [param idx] is out of bounds it is truncated to the first or last control point, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="sample_baked" qualifiers="const">
@@ -143,7 +143,7 @@
 			<return type="Vector3" />
 			<param index="0" name="fofs" type="float" />
 			<description>
-				Returns the position at the curve point [param fofs]. It calls [method sample] using the integer part of [param fofs] as [code]idx[/code], and its fractional part as [code]t[/code].
+				Returns the position at the control point [param fofs]. It calls [method sample] using the integer part of [param fofs] as [code]idx[/code], and its fractional part as [code]t[/code].
 			</description>
 		</method>
 		<method name="set_point_in">
@@ -151,7 +151,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the position of the control point leading to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the curve point.
+				Sets the position of the control point leading to the control point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the control point.
 			</description>
 		</method>
 		<method name="set_point_out">
@@ -159,7 +159,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the position of the control point leading out of the curve point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the curve point.
+				Sets the position of the control point leading out of the control point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the control point.
 			</description>
 		</method>
 		<method name="set_point_position">
@@ -167,7 +167,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the position for the curve point [param idx]. If the index is out of bounds, the function sends an error to the console.
+				Sets the position for the control point [param idx]. If the index is out of bounds, the function sends an error to the console.
 			</description>
 		</method>
 		<method name="set_point_tilt">

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <class name="Curve3D" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Describes a Bézier curve in 3D space.

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 <class name="Curve3D" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Describes a Bézier curve in 3D space.
@@ -72,21 +72,21 @@
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading to the vertex [param idx]. The returned position is relative to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the control point leading to the curve point [param idx]. The returned position is relative to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_out" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the control point leading out of the vertex [param idx]. The returned position is relative to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the control point leading out of the curve point [param idx]. The returned position is relative to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_position" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="idx" type="int" />
 			<description>
-				Returns the position of the vertex [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position of the curve point [param idx]. If the index is out of bounds, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="get_point_tilt" qualifiers="const">
@@ -108,8 +108,8 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="t" type="float" />
 			<description>
-				Returns the position between the vertex [param idx] and the vertex [code]idx + 1[/code], where [param t] controls if the point is the first vertex ([code]t = 0.0[/code]), the last vertex ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &gt;= t &lt;=1[/code]) give strange, but predictable results.
-				If [param idx] is out of bounds it is truncated to the first or last vertex, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
+				Returns the position between the curve point [param idx] and the curve point [code]idx + 1[/code], where [param t] controls if the point is the first curve point ([code]t = 0.0[/code]), the last curve point ([code]t = 1.0[/code]), or in between. Values of [param t] outside the range ([code]0.0 &gt;= t &lt;=1[/code]) give strange, but predictable results.
+				If [param idx] is out of bounds it is truncated to the first or last curve point, and [param t] is ignored. If the curve has no points, the function sends an error to the console, and returns [code](0, 0, 0)[/code].
 			</description>
 		</method>
 		<method name="sample_baked" qualifiers="const">
@@ -143,7 +143,7 @@
 			<return type="Vector3" />
 			<param index="0" name="fofs" type="float" />
 			<description>
-				Returns the position at the vertex [param fofs]. It calls [method sample] using the integer part of [param fofs] as [code]idx[/code], and its fractional part as [code]t[/code].
+				Returns the position at the curve point [param fofs]. It calls [method sample] using the integer part of [param fofs] as [code]idx[/code], and its fractional part as [code]t[/code].
 			</description>
 		</method>
 		<method name="set_point_in">
@@ -151,7 +151,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the position of the control point leading to the vertex [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
+				Sets the position of the control point leading to the curve point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the curve point.
 			</description>
 		</method>
 		<method name="set_point_out">
@@ -159,7 +159,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the position of the control point leading out of the vertex [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the vertex.
+				Sets the position of the control point leading out of the curve point [param idx]. If the index is out of bounds, the function sends an error to the console. The position is relative to the curve point.
 			</description>
 		</method>
 		<method name="set_point_position">
@@ -167,7 +167,7 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
-				Sets the position for the vertex [param idx]. If the index is out of bounds, the function sends an error to the console.
+				Sets the position for the curve point [param idx]. If the index is out of bounds, the function sends an error to the console.
 			</description>
 		</method>
 		<method name="set_point_tilt">

--- a/doc/classes/PathFollow2D.xml
+++ b/doc/classes/PathFollow2D.xml
@@ -4,7 +4,7 @@
 		Point sampler for a [Path2D].
 	</brief_description>
 	<description>
-		This node takes its parent [Path2D], and returns the coordinates of a point within it, given a distance from the first vertex.
+		This node takes its parent [Path2D], and returns the coordinates of a point within it, given a distance from the first point of the path.
 		It is useful for making other nodes follow a path, without coding the movement pattern. For that, the nodes must be children of this node. The descendant nodes will then move accordingly when setting the [member progress] in this node.
 	</description>
 	<tutorials>
@@ -25,7 +25,7 @@
 			The distance along the path, in pixels. Changing this value sets this node's position to a point within the path.
 		</member>
 		<member name="progress_ratio" type="float" setter="set_progress_ratio" getter="get_progress_ratio" default="0.0">
-			The distance along the path as a number in the range 0.0 (for the first vertex) to 1.0 (for the last). This is just another way of expressing the progress within the path, as the offset supplied is multiplied internally by the path's length.
+			The distance along the path as a number in the range 0.0 (for the first point of the path) to 1.0 (for the last). This is just another way of expressing the progress within the path, as the offset supplied is multiplied internally by the path's length.
 			It can be set or get only if the [PathFollow2D] is the child of a [Path2D] which is part of the scene tree, and that this [Path2D] has a [Curve2D] with a non-zero length. Otherwise, trying to set this field will print an error, and getting this field will return [code]0.0[/code].
 		</member>
 		<member name="rotates" type="bool" setter="set_rotates" getter="is_rotating" default="true">

--- a/doc/classes/PathFollow3D.xml
+++ b/doc/classes/PathFollow3D.xml
@@ -4,7 +4,7 @@
 		Point sampler for a [Path3D].
 	</brief_description>
 	<description>
-		This node takes its parent [Path3D], and returns the coordinates of a point within it, given a distance from the first vertex.
+		This node takes its parent [Path3D], and returns the coordinates of a point within it, given a distance from the first point of the path.
 		It is useful for making other nodes follow a path, without coding the movement pattern. For that, the nodes must be children of this node. The descendant nodes will then move accordingly when setting the [member progress] in this node.
 	</description>
 	<tutorials>
@@ -32,10 +32,10 @@
 			If [code]true[/code], any offset outside the path's length will wrap around, instead of stopping at the ends. Use it for cyclic paths.
 		</member>
 		<member name="progress" type="float" setter="set_progress" getter="get_progress" default="0.0">
-			The distance from the first vertex, measured in 3D units along the path. Changing this value sets this node's position to a point within the path.
+			The distance from the first point of the path, measured in 3D units along the path. Changing this value sets this node's position to a point within the path.
 		</member>
 		<member name="progress_ratio" type="float" setter="set_progress_ratio" getter="get_progress_ratio" default="0.0">
-			The distance from the first vertex, considering 0.0 as the first vertex and 1.0 as the last. This is just another way of expressing the progress within the path, as the progress supplied is multiplied internally by the path's length.
+			The distance from the first point of the path, considering 0.0 as the first point and 1.0 as the last. This is just another way of expressing the progress within the path, as the progress supplied is multiplied internally by the path's length.
 			It can be set or get only if the [PathFollow3D] is the child of a [Path3D] which is part of the scene tree, and that this [Path3D] has a [Curve3D] with a non-zero length. Otherwise, trying to set this field will print an error, and getting this field will return [code]0.0[/code].
 		</member>
 		<member name="rotation_mode" type="int" setter="set_rotation_mode" getter="get_rotation_mode" enum="PathFollow3D.RotationMode" default="3">


### PR DESCRIPTION
Renamed 'vertex' to 'curve point' in the Curve2D and Curve3D class documentation because curves don't have vertices.