### PR TITLE
Add filters to Find in Files, to ignore Code, Strings, or Comments for find/replace

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -39,6 +39,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/code_edit.h"
 #include "scene/gui/file_dialog.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/label.h"
@@ -47,6 +48,7 @@
 #include "scene/gui/tree.h"
 
 const char *FindInFiles::SIGNAL_RESULT_FOUND = "result_found";
+CodeEdit *_dummy_code_edit = nullptr;
 
 // TODO: Would be nice in Vector and Vectors.
 template <typename T>
@@ -54,8 +56,9 @@ inline void pop_back(T &container) {
 	container.resize(container.size() - 1);
 }
 
-static bool find_next(const String &line, const String &pattern, int from, bool match_case, bool whole_words, int &out_begin, int &out_end) {
+static bool find_next(const String &line, const String &pattern, int from, bool match_case, bool whole_words, bool ignore_code, bool ignore_strings, bool ignore_comments, int line_number, int &out_begin, int &out_end) {
 	int end = from;
+	int line_index = line_number - 1;
 
 	while (true) {
 		int begin = match_case ? line.find(pattern, end) : line.findn(pattern, end);
@@ -77,6 +80,16 @@ static bool find_next(const String &line, const String &pattern, int from, bool 
 			}
 		}
 
+		if (ignore_code && _dummy_code_edit->is_in_comment(line_index, begin) == -1 && _dummy_code_edit->is_in_string(line_index, begin) == -1) {
+			continue;
+		}
+		if (ignore_strings && _dummy_code_edit->is_in_string(line_index, begin) != -1) {
+			continue;
+		}
+		if (ignore_comments && _dummy_code_edit->is_in_comment(line_index, begin) != -1) {
+			continue;
+		}
+
 		return true;
 	}
 }
@@ -87,12 +100,40 @@ void FindInFiles::set_search_text(const String &p_pattern) {
 	_pattern = p_pattern;
 }
 
+void FindInFiles::set_search_file_context(const Ref<FileAccess> &file) {
+	_dummy_code_edit->set_text(file->get_as_text());
+	String extension = file->get_path().get_extension();
+
+	TypedArray<String> delimiters;
+	if (extension == "gd") {
+		delimiters.append("#");
+	} else { // This is for gdshader and csharp. Later, we could expose a way to set delimiters per extension.
+		delimiters.append("//");
+		delimiters.append("/* */");
+	}
+
+	// Only change comment delimiters, default string delimiters should be fine.
+	_dummy_code_edit->set_comment_delimiters(delimiters);
+}
+
 void FindInFiles::set_whole_words(bool p_whole_word) {
 	_whole_words = p_whole_word;
 }
 
 void FindInFiles::set_match_case(bool p_match_case) {
 	_match_case = p_match_case;
+}
+
+void FindInFiles::set_ignore_code(bool p_ignore_code) {
+	_ignore_code = p_ignore_code;
+}
+
+void FindInFiles::set_ignore_strings(bool p_ignore_strings) {
+	_ignore_strings = p_ignore_strings;
+}
+
+void FindInFiles::set_ignore_comments(bool p_ignore_comments) {
+	_ignore_comments = p_ignore_comments;
 }
 
 void FindInFiles::set_folder(const String &folder) {
@@ -266,6 +307,10 @@ void FindInFiles::_scan_file(const String &fpath) {
 		return;
 	}
 
+	if (_ignore_code || _ignore_strings || _ignore_comments) {
+		set_search_file_context(f);
+	}
+
 	int line_number = 0;
 
 	while (!f->eof_reached()) {
@@ -277,7 +322,7 @@ void FindInFiles::_scan_file(const String &fpath) {
 
 		String line = f->get_line();
 
-		while (find_next(line, _pattern, end, _match_case, _whole_words, begin, end)) {
+		while (find_next(line, _pattern, end, _match_case, _whole_words, _ignore_code, _ignore_strings, _ignore_comments, line_number, begin, end)) {
 			emit_signal(SNAME(SIGNAL_RESULT_FOUND), fpath, line_number, begin, end, line);
 		}
 	}
@@ -352,6 +397,31 @@ FindInFilesDialog::FindInFilesDialog() {
 		gc->add_child(hbc);
 	}
 
+	Label *search_in_label = memnew(Label);
+	search_in_label->set_text(TTR("Inside:"));
+	gc->add_child(search_in_label);
+
+	{
+		HBoxContainer *hbc = memnew(HBoxContainer);
+
+		_include_code_checkbox = memnew(CheckBox);
+		_include_code_checkbox->set_text(TTR("Code"));
+		_include_code_checkbox->set_pressed(true);
+		hbc->add_child(_include_code_checkbox);
+
+		_include_strings_checkbox = memnew(CheckBox);
+		_include_strings_checkbox->set_text(TTR("Strings"));
+		_include_strings_checkbox->set_pressed(true);
+		hbc->add_child(_include_strings_checkbox);
+
+		_include_comments_checkbox = memnew(CheckBox);
+		_include_comments_checkbox->set_text(TTR("Comments"));
+		_include_comments_checkbox->set_pressed(true);
+		hbc->add_child(_include_comments_checkbox);
+
+		gc->add_child(hbc);
+	}
+
 	Label *folder_label = memnew(Label);
 	folder_label->set_text(TTR("Folder:"));
 	gc->add_child(folder_label);
@@ -397,6 +467,8 @@ FindInFilesDialog::FindInFilesDialog() {
 
 	Button *cancel_button = get_ok_button();
 	cancel_button->set_text(TTR("Cancel"));
+
+	_dummy_code_edit = memnew(CodeEdit); // Intentionally an orphan, used in file search.
 
 	_mode = SEARCH_MODE;
 }
@@ -461,6 +533,18 @@ bool FindInFilesDialog::is_match_case() const {
 
 bool FindInFilesDialog::is_whole_words() const {
 	return _whole_words_checkbox->is_pressed();
+}
+
+bool FindInFilesDialog::is_ignore_code() const {
+	return !_include_code_checkbox->is_pressed();
+}
+
+bool FindInFilesDialog::is_ignore_strings() const {
+	return !_include_strings_checkbox->is_pressed();
+}
+
+bool FindInFilesDialog::is_ignore_comments() const {
+	return !_include_comments_checkbox->is_pressed();
 }
 
 String FindInFilesDialog::get_folder() const {
@@ -972,6 +1056,10 @@ void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<
 	Ref<FileAccess> f = FileAccess::open(fpath, FileAccess::READ);
 	ERR_FAIL_COND_MSG(f.is_null(), "Cannot open file from path '" + fpath + "'.");
 
+	if (_finder->is_ignore_code() || _finder->is_ignore_strings() || _finder->is_ignore_comments()) {
+		_finder->set_search_file_context(f);
+	}
+
 	String buffer;
 	int current_line = 1;
 
@@ -996,7 +1084,7 @@ void FindInFilesPanel::apply_replaces_in_file(const String &fpath, const Vector<
 		int repl_end = locations[i].end + offset;
 
 		int _;
-		if (!find_next(line, search_text, repl_begin, _finder->is_match_case(), _finder->is_whole_words(), _, _)) {
+		if (!find_next(line, search_text, repl_begin, _finder->is_match_case(), _finder->is_whole_words(), _finder->is_ignore_code(), _finder->is_ignore_strings(), _finder->is_ignore_comments(), repl_line_number, _, _)) {
 			// Make sure the replace is still valid in case the file was tampered with.
 			print_verbose(String("Occurrence no longer matches, replace will be ignored in {0}: line {1}, col {2}").format(varray(fpath, repl_line_number, repl_begin)));
 			continue;

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -42,8 +42,12 @@ public:
 	static const char *SIGNAL_FINISHED;
 
 	void set_search_text(const String &p_pattern);
+	void set_search_file_context(const Ref<FileAccess> &file);
 	void set_whole_words(bool p_whole_word);
 	void set_match_case(bool p_match_case);
+	void set_ignore_code(bool p_ignore_code);
+	void set_ignore_strings(bool p_ignore_strings);
+	void set_ignore_comments(bool p_ignore_comments);
 	void set_folder(const String &folder);
 	void set_filter(const HashSet<String> &exts);
 
@@ -51,6 +55,9 @@ public:
 
 	bool is_whole_words() const { return _whole_words; }
 	bool is_match_case() const { return _match_case; }
+	bool is_ignore_code() const { return _ignore_code; }
+	bool is_ignore_strings() const { return _ignore_strings; }
+	bool is_ignore_comments() const { return _ignore_comments; }
 
 	void start();
 	void stop();
@@ -75,6 +82,9 @@ private:
 	String _root_dir;
 	bool _whole_words = true;
 	bool _match_case = true;
+	bool _ignore_code = false;
+	bool _ignore_strings = false;
+	bool _ignore_comments = false;
 
 	// State
 	bool _searching = false;
@@ -113,6 +123,9 @@ public:
 	String get_replace_text() const;
 	bool is_match_case() const;
 	bool is_whole_words() const;
+	bool is_ignore_code() const;
+	bool is_ignore_strings() const;
+	bool is_ignore_comments() const;
 	String get_folder() const;
 	HashSet<String> get_filter() const;
 
@@ -139,6 +152,9 @@ private:
 	LineEdit *_folder_line_edit = nullptr;
 	CheckBox *_match_case_checkbox = nullptr;
 	CheckBox *_whole_words_checkbox = nullptr;
+	CheckBox *_include_code_checkbox = nullptr;
+	CheckBox *_include_strings_checkbox = nullptr;
+	CheckBox *_include_comments_checkbox = nullptr;
 	Button *_find_button = nullptr;
 	Button *_replace_button = nullptr;
 	FileDialog *_folder_dialog = nullptr;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4081,6 +4081,9 @@ void ScriptEditor::_start_find_in_files(bool with_replace) {
 	f->set_search_text(find_in_files_dialog->get_search_text());
 	f->set_match_case(find_in_files_dialog->is_match_case());
 	f->set_whole_words(find_in_files_dialog->is_whole_words());
+	f->set_ignore_code(find_in_files_dialog->is_ignore_code());
+	f->set_ignore_strings(find_in_files_dialog->is_ignore_strings());
+	f->set_ignore_comments(find_in_files_dialog->is_ignore_comments());
 	f->set_folder(find_in_files_dialog->get_folder());
 	f->set_filter(find_in_files_dialog->get_filter());
 


### PR DESCRIPTION
Partially supersedes #67796 
Partially addresses [Proposal #563](https://github.com/godotengine/godot-proposals/issues/563)

PR: For Find in Files, add filters to include/exclude Code, Strings, or Comments from your search results.

See it in action:

[godot.windows.editor.x86_64_B5vbC8DonX.webm](https://github.com/user-attachments/assets/38f88ed9-78d5-48e5-8354-fbbc80a88263)

Notes:
 - Multiline string/comment aware, including mid line usage like `func pie(/*old_param,*/ new_param);`.
 - "Language Agnostic".
   - Right now it either chooses gdscript `#` or c style `// /**/`, which as far as I'm aware are the only other languages(gdshader, csharp) supported in the editor. Maybe we could expose an option so users can add delimiters.
 - Should not affect search speed if you leave everything enabled, implementation wise it's opt-in ignores.
 - Find and Replace for Code Editor toolbar is not affected in this PR, it could be added in a follow up PR.
   - This is primarily due to the Code Editor using `TextEdit` to handle and draw the search highlights, which we can't do much about unless we copy pasta a lot of code or add coding related flags to `TextEdit::SearchFlags`. The latter of which was [said to be avoided](https://github.com/godotengine/godot/pull/67796#pullrequestreview-1153599911) in the superseded PR.
 - Uses the phrase "Inside:" on its own line. You could also put them alongside "Match Case" and "Whole Words", but it causes the prompt to widen in a way that makes it more ugly I think.
 - Strings filter is just a bonus while I was working on it, it could be removed if it's seen as not very useful. I for one don't have a use for it, but I saw a comment on the superseded PR bring it up.
<!--


Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
