### PR TITLE
Selecting a new tile from tileset palette should turn off the eraser toggle

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -463,7 +463,7 @@ void TileMapLayerEditorTilesPlugin::_scenes_list_multi_selected(int p_index, boo
 		return;
 	}
 
-	// Add or remove the Tile form the selection.
+	// Add or remove the Tile from the selection.
 	int scene_id = scene_tiles_list->get_item_metadata(p_index);
 	int source_id = sources_list->get_item_metadata(sources_list->get_current());
 	TileSetSource *source = *tile_set->get_source(source_id);
@@ -1958,6 +1958,7 @@ void TileMapLayerEditorTilesPlugin::_tile_atlas_control_gui_input(const Ref<Inpu
 				} else {
 					tile_set_selection.insert(TileMapCell(source_id, hovered_tile.get_atlas_coords(), 0));
 				}
+				erase_button->set_pressed(false);
 			}
 			_update_selection_pattern_from_tileset_tiles_selection();
 		} else { // Released


### PR DESCRIPTION
If you are in eraser mode, move your mouse down to the palette, and click a new tile to draw with, I think it's a really good guess that you want to draw with that tile, rather than continue erasing with a different tile selected. 

In fact, I kept assuming that was how it worked, and it was annoying to have to manually toggle the eraser off every time. 

This PR turns off 'eraser' mode whenever you select a new tile to draw with. 


I also fixed a misspelled comment, hope it's okay to squish these together but it felt too small for a PR on its own.

