### PR TITLE
Clarify ambiguous String comparison methods documentation

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -112,7 +112,7 @@
 			<param index="0" name="to" type="String" />
 			<description>
 				Performs a case-sensitive comparison to another string. Returns [code]-1[/code] if less than, [code]1[/code] if greater than, or [code]0[/code] if equal. "Less than" and "greater than" are determined by the [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode code points[/url] of each string, which roughly matches the alphabetical order.
-				With different string lengths, returns [code]1[/code] if this string is longer than the [param to] string, or [code]-1[/code] if shorter. Note that the length of empty strings is [i]always[/i] [code]0[/code].
+				If the character comparison reaches the end of one string, but the other string contains more characters, then it will use length as the deciding factor: [code]1[/code] will be returned if this string is longer than the [param to] string, or [code]-1[/code] if shorter. Note that the length of empty strings is always [code]0[/code].
 				To get a [bool] result from a string comparison, use the [code]==[/code] operator instead. See also [method nocasecmp_to], [method filecasecmp_to], and [method naturalcasecmp_to].
 			</description>
 		</method>
@@ -651,7 +651,7 @@
 			<description>
 				Performs a [b]case-sensitive[/b], [i]natural order[/i] comparison to another string. Returns [code]-1[/code] if less than, [code]1[/code] if greater than, or [code]0[/code] if equal. "Less than" or "greater than" are determined by the [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode code points[/url] of each string, which roughly matches the alphabetical order.
 				When used for sorting, natural order comparison orders sequences of numbers by the combined value of each digit as is often expected, instead of the single digit's value. A sorted sequence of numbered strings will be [code]["1", "2", "3", ...][/code], not [code]["1", "10", "2", "3", ...][/code].
-				With different string lengths, returns [code]1[/code] if this string is longer than the [param to] string, or [code]-1[/code] if shorter. Note that the length of empty strings is [i]always[/i] [code]0[/code].
+				If the character comparison reaches the end of one string, but the other string contains more characters, then it will use length as the deciding factor: [code]1[/code] will be returned if this string is longer than the [param to] string, or [code]-1[/code] if shorter. Note that the length of empty strings is always [code]0[/code].
 				To get a [bool] result from a string comparison, use the [code]==[/code] operator instead. See also [method naturalnocasecmp_to], [method filecasecmp_to], and [method nocasecmp_to].
 			</description>
 		</method>
@@ -661,7 +661,7 @@
 			<description>
 				Performs a [b]case-insensitive[/b], [i]natural order[/i] comparison to another string. Returns [code]-1[/code] if less than, [code]1[/code] if greater than, or [code]0[/code] if equal. "Less than" or "greater than" are determined by the [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode code points[/url] of each string, which roughly matches the alphabetical order. Internally, lowercase characters are converted to uppercase for the comparison.
 				When used for sorting, natural order comparison orders sequences of numbers by the combined value of each digit as is often expected, instead of the single digit's value. A sorted sequence of numbered strings will be [code]["1", "2", "3", ...][/code], not [code]["1", "10", "2", "3", ...][/code].
-				With different string lengths, returns [code]1[/code] if this string is longer than the [param to] string, or [code]-1[/code] if shorter. Note that the length of empty strings is [i]always[/i] [code]0[/code].
+				If the character comparison reaches the end of one string, but the other string contains more characters, then it will use length as the deciding factor: [code]1[/code] will be returned if this string is longer than the [param to] string, or [code]-1[/code] if shorter. Note that the length of empty strings is always [code]0[/code].
 				To get a [bool] result from a string comparison, use the [code]==[/code] operator instead. See also [method naturalcasecmp_to], [method filenocasecmp_to], and [method casecmp_to].
 			</description>
 		</method>
@@ -670,7 +670,7 @@
 			<param index="0" name="to" type="String" />
 			<description>
 				Performs a [b]case-insensitive[/b] comparison to another string. Returns [code]-1[/code] if less than, [code]1[/code] if greater than, or [code]0[/code] if equal. "Less than" or "greater than" are determined by the [url=https://en.wikipedia.org/wiki/List_of_Unicode_characters]Unicode code points[/url] of each string, which roughly matches the alphabetical order. Internally, lowercase characters are converted to uppercase for the comparison.
-				With different string lengths, returns [code]1[/code] if this string is longer than the [param to] string, or [code]-1[/code] if shorter. Note that the length of empty strings is [i]always[/i] [code]0[/code].
+				If the character comparison reaches the end of one string, but the other string contains more characters, then it will use length as the deciding factor: [code]1[/code] will be returned if this string is longer than the [param to] string, or [code]-1[/code] if shorter. Note that the length of empty strings is always [code]0[/code].
 				To get a [bool] result from a string comparison, use the [code]==[/code] operator instead. See also [method casecmp_to], [method filenocasecmp_to], and [method naturalnocasecmp_to].
 			</description>
 		</method>


### PR DESCRIPTION
The documentation for the native String Class contains an ambiguity in the description of the CompareTo functions `(casecmp_to()`, `nocasecmp_to()`, `naturalcasecmpto()`, and `naturalnocasecmp_to()`

The description currently reads:

> Performs a case-sensitive comparison to another string. Returns -1 if less than, 1 if greater than, or 0 if equal. "Less than" and "greater than" are determined by the [Unicode code points](https://en.wikipedia.org/wiki/List_of_Unicode_characters) of each string, which roughly matches the alphabetical order.

> With different string lengths, returns 1 if this string is longer than the to string, or -1 if shorter. Note that the length of empty strings is always 0.

When looking at an example such as 
`"aab".nocasecmp_to("aaaa")`
The most direct interpretation of the current wording suggests the `nocasecmp_to()` would return `-1` because this string is shorter than the to string. The actual behavior of the function is that it returns 1 because the character comparison reaches 'b' v. 'a' and determines 'b' and the first string are greater than the second string (matching the common definition of Lexicographical Order). The length comparison only occurs conditionally, if the comparison had not yet already resolved.

I suggest updating this wording in the relevant to locations to 

> If the character comparison reaches the end of one string, but the other contains more characters, then it will use length as the deciding factor: `1` will be returned if this string is longer than the `to` string, or `-1` if shorter.

Which I believe more accurately communicates the behavior of the function. Thanks!

