### PR TITLE
Metal: Fix occasional use-after-free in Metal driver

### DIFF
--- a/drivers/metal/inflection_map.h
+++ b/drivers/metal/inflection_map.h
@@ -1,0 +1,125 @@
+/**************************************************************************/
+/*  inflection_map.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef INFLECTION_MAP_H
+#define INFLECTION_MAP_H
+
+#include "core/templates/hash_map.h"
+#include "core/templates/local_vector.h"
+
+/// An unordered map that splits elements between a fast-access vector of LinearCount consecutively
+/// indexed elements, and a slower-access map holding sparse indexes larger than LinearCount.
+///
+/// \tparam KeyType is used to lookup values, and must be a type that is convertible to an unsigned integer.
+/// \tparam ValueType must have an empty constructor (default or otherwise).
+/// \tparam LinearCount
+/// \tparam IndexType must be a type that is convertible to an unsigned integer (eg. uint8_t...uint64_t), and which is large enough to represent the number of values in this map.
+template <typename KeyType, typename ValueType, size_t LinearCount, typename IndexType = uint16_t>
+class InflectionMap {
+public:
+	using value_type = ValueType;
+	class Iterator {
+		InflectionMap *map;
+		IndexType index;
+
+	public:
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = ValueType;
+		using pointer = value_type *;
+		using reference = value_type &;
+
+		Iterator() :
+				map(nullptr), index(0) {}
+		Iterator(InflectionMap &p_m, const IndexType p_i) :
+				map(&p_m), index(p_i) {}
+
+		Iterator &operator=(const Iterator &p_it) {
+			map = p_it.map;
+			index = p_it.index;
+			return *this;
+		}
+
+		ValueType *operator->() { return &map->_values[index]; }
+		ValueType &operator*() { return map->_values[index]; }
+		operator ValueType *() { return &map->_values[index]; }
+
+		bool operator==(const Iterator &p_it) const { return map == p_it.map && index == p_it.index; }
+		bool operator!=(const Iterator &p_it) const { return map != p_it.map || index != p_it.index; }
+
+		Iterator &operator++() {
+			index++;
+			return *this;
+		}
+		Iterator operator++(int) {
+			Iterator t = *this;
+			index++;
+			return t;
+		}
+
+		bool is_valid() const { return index < map->_values.size(); }
+	};
+
+	const ValueType &operator[](const KeyType p_idx) const { return get_value(p_idx); }
+	ValueType &operator[](const KeyType p_idx) { return get_value(p_idx); }
+
+	Iterator begin() { return Iterator(*this, 0); }
+	Iterator end() { return Iterator(*this, _values.size()); }
+
+	bool is_empty() { return _values.is_empty(); }
+	size_t size() { return _values.size(); }
+	void reserve(size_t p_new_cap) { _values.reserve(p_new_cap); }
+
+protected:
+	static constexpr IndexType INVALID = std::numeric_limits<IndexType>::max();
+	typedef struct IndexValue {
+		IndexType value = INVALID;
+	} IndexValue;
+
+	// Returns a reference to the value at the index.
+	// If the index has not been initialized, add an empty element at
+	// the end of the values array, and set the index to its position.
+	ValueType &get_value(KeyType p_idx) {
+		IndexValue *val_idx = p_idx < LinearCount ? &_linear_indexes[p_idx] : _inflection_indexes.getptr(p_idx);
+		if (val_idx == nullptr || val_idx->value == INVALID) {
+			_values.push_back({});
+			if (val_idx == nullptr) {
+				val_idx = &_inflection_indexes.insert(p_idx, {})->value;
+			}
+			val_idx->value = _values.size() - 1;
+		}
+		return _values[val_idx->value];
+	}
+
+	TightLocalVector<ValueType> _values;
+	HashMap<KeyType, IndexValue> _inflection_indexes;
+	IndexValue _linear_indexes[LinearCount];
+};
+
+#endif // INFLECTION_MAP_H

--- a/drivers/metal/metal_device_properties.h
+++ b/drivers/metal/metal_device_properties.h
@@ -70,9 +70,14 @@ typedef NS_OPTIONS(NSUInteger, SampleCount) {
 	SampleCount64 = (1UL << 6),
 };
 
-struct API_AVAILABLE(macos(11.0), ios(14.0)) MetalFeatures {
+struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MetalFeatures {
 	uint32_t mslVersion = 0;
 	MTLGPUFamily highestFamily = MTLGPUFamilyApple4;
+	bool supportsBCTextureCompression = false;
+	bool supportsDepth24Stencil8 = false;
+	bool supports32BitFloatFiltering = false;
+	bool supports32BitMSAA = false;
+	bool supportsMac = TARGET_OS_OSX;
 	MTLLanguageVersion mslVersionEnum = MTLLanguageVersion1_2;
 	SampleCount supportedSampleCounts = SampleCount1;
 	long hostMemoryPageSize = 0;
@@ -84,6 +89,8 @@ struct API_AVAILABLE(macos(11.0), ios(14.0)) MetalFeatures {
 	bool tessellationShader = false; /**< If true, tessellation shaders are supported. */
 	bool imageCubeArray = false; /**< If true, image cube arrays are supported. */
 	MTLArgumentBuffersTier argument_buffers_tier = MTLArgumentBuffersTier1;
+	/// If true, argument encoders are required to encode arguments into an argument buffer.
+	bool needs_arg_encoders = true;
 	bool metal_fx_spatial = false; /**< If true, Metal FX spatial functions are supported. */
 	bool metal_fx_temporal = false; /**< If true, Metal FX temporal functions are supported. */
 };
@@ -126,7 +133,7 @@ struct MetalLimits {
 	BitField<RD::SubgroupOperations> subgroupSupportedOperations; /**< The subgroup operations supported by the device. */
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MetalDeviceProperties {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MetalDeviceProperties {
 private:
 	void init_features(id<MTLDevice> p_device);
 	void init_limits(id<MTLDevice> p_device);

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -180,7 +180,7 @@ struct ClearAttKey {
 	}
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDResourceFactory {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDResourceFactory {
 private:
 	RenderingDeviceDriverMetal *device_driver;
 
@@ -198,7 +198,7 @@ public:
 	~MDResourceFactory() = default;
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDResourceCache {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDResourceCache {
 private:
 	typedef HashMap<ClearAttKey, id<MTLRenderPipelineState>, HashableHasher<ClearAttKey>> HashMap;
 	std::unique_ptr<MDResourceFactory> resource_factory;
@@ -247,7 +247,7 @@ struct MDSubpass {
 	MTLFmtCaps getRequiredFmtCapsForAttachmentAt(uint32_t p_index) const;
 };
 
-struct API_AVAILABLE(macos(11.0), ios(14.0)) MDAttachment {
+struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDAttachment {
 private:
 	uint32_t index = 0;
 	uint32_t firstUseSubpassIndex = 0;
@@ -299,7 +299,7 @@ public:
 	bool shouldClear(MDSubpass const &p_subpass, bool p_is_stencil) const;
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDRenderPass {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDRenderPass {
 public:
 	Vector<MDAttachment> attachments;
 	Vector<MDSubpass> subpasses;
@@ -311,7 +311,7 @@ public:
 	MDRenderPass(Vector<MDAttachment> &p_attachments, Vector<MDSubpass> &p_subpasses);
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDCommandBuffer {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDCommandBuffer {
 private:
 	RenderingDeviceDriverMetal *device_driver = nullptr;
 	id<MTLCommandQueue> queue = nil;
@@ -557,7 +557,7 @@ public:
 #define MTLBindingAccessWriteOnly MTLArgumentAccessWriteOnly
 #endif
 
-struct API_AVAILABLE(macos(11.0), ios(14.0)) BindingInfo {
+struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) BindingInfo {
 	MTLDataType dataType = MTLDataTypeNone;
 	uint32_t index = 0;
 	MTLBindingAccess access = MTLBindingAccessReadOnly;
@@ -608,16 +608,16 @@ struct API_AVAILABLE(macos(11.0), ios(14.0)) BindingInfo {
 
 using RDC = RenderingDeviceCommons;
 
-typedef API_AVAILABLE(macos(11.0), ios(14.0)) HashMap<RDC::ShaderStage, BindingInfo> BindingInfoMap;
+typedef API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) HashMap<RDC::ShaderStage, BindingInfo> BindingInfoMap;
 
-struct API_AVAILABLE(macos(11.0), ios(14.0)) UniformInfo {
+struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) UniformInfo {
 	uint32_t binding;
 	ShaderStageUsage active_stages = None;
 	BindingInfoMap bindings;
 	BindingInfoMap bindings_secondary;
 };
 
-struct API_AVAILABLE(macos(11.0), ios(14.0)) UniformSet {
+struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) UniformSet {
 	LocalVector<UniformInfo> uniforms;
 	uint32_t buffer_size = 0;
 	HashMap<RDC::ShaderStage, uint32_t> offsets;
@@ -694,7 +694,7 @@ struct ShaderCacheEntry {
 	~ShaderCacheEntry() = default;
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDShader {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDShader {
 public:
 	CharString name;
 	Vector<UniformSet> sets;
@@ -707,7 +707,7 @@ public:
 	virtual ~MDShader() = default;
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDComputeShader final : public MDShader {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDComputeShader final : public MDShader {
 public:
 	struct {
 		uint32_t binding = -1;
@@ -725,7 +725,7 @@ public:
 	MDComputeShader(CharString p_name, Vector<UniformSet> p_sets, bool p_uses_argument_buffers, MDLibrary *p_kernel);
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDRenderShader final : public MDShader {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDRenderShader final : public MDShader {
 public:
 	struct {
 		struct {
@@ -786,7 +786,7 @@ struct BoundUniformSet {
 	void merge_into(ResourceUsageMap &p_dst) const;
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDUniformSet {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDUniformSet {
 private:
 	void bind_uniforms_argument_buffers(MDShader *p_shader, MDCommandBuffer::RenderState &p_state);
 	void bind_uniforms_direct(MDShader *p_shader, MDCommandBuffer::RenderState &p_state);
@@ -804,7 +804,7 @@ public:
 	BoundUniformSet &bound_uniform_set(MDShader *p_shader, id<MTLDevice> p_device, ResourceUsageMap &p_resource_usage);
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDPipeline {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDPipeline {
 public:
 	MDPipelineType type;
 
@@ -813,7 +813,7 @@ public:
 	virtual ~MDPipeline() = default;
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDRenderPipeline final : public MDPipeline {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDRenderPipeline final : public MDPipeline {
 public:
 	id<MTLRenderPipelineState> state = nil;
 	id<MTLDepthStencilState> depth_stencil = nil;
@@ -890,7 +890,7 @@ public:
 	~MDRenderPipeline() final = default;
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDComputePipeline final : public MDPipeline {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDComputePipeline final : public MDPipeline {
 public:
 	id<MTLComputePipelineState> state = nil;
 	struct {
@@ -904,7 +904,7 @@ public:
 	~MDComputePipeline() final = default;
 };
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) MDFrameBuffer {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MDFrameBuffer {
 	Vector<MTL::Texture> textures;
 
 public:

--- a/drivers/metal/metal_objects.mm
+++ b/drivers/metal/metal_objects.mm
@@ -62,7 +62,7 @@
 
 void MDCommandBuffer::begin() {
 	DEV_ASSERT(commandBuffer == nil);
-	commandBuffer = queue.commandBufferWithUnretainedReferences;
+	commandBuffer = queue.commandBuffer;
 }
 
 void MDCommandBuffer::end() {

--- a/drivers/metal/pixel_formats.h
+++ b/drivers/metal/pixel_formats.h
@@ -54,13 +54,12 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
+#import "inflection_map.h"
+#import "metal_device_properties.h"
+
 #import "servers/rendering/rendering_device.h"
 
 #import <Metal/Metal.h>
-
-static const uint32_t _mtlPixelFormatCount = 256;
-static const uint32_t _mtlPixelFormatCoreCount = MTLPixelFormatX32_Stencil8 + 2; // The actual last enum value is not available on iOS.
-static const uint32_t _mtlVertexFormatCount = MTLVertexFormatHalf + 1;
 
 #pragma mark -
 #pragma mark Metal format capabilities
@@ -182,13 +181,20 @@ enum class MTLFormatType {
 	Compressed, /**< A block-compressed color. */
 };
 
-typedef struct Extent2D {
+struct Extent2D {
 	uint32_t width;
 	uint32_t height;
-} Extent2D;
+};
+
+struct ComponentMapping {
+	RD::TextureSwizzle r = RD::TEXTURE_SWIZZLE_IDENTITY;
+	RD::TextureSwizzle g = RD::TEXTURE_SWIZZLE_IDENTITY;
+	RD::TextureSwizzle b = RD::TEXTURE_SWIZZLE_IDENTITY;
+	RD::TextureSwizzle a = RD::TEXTURE_SWIZZLE_IDENTITY;
+};
 
 /** Describes the properties of a DataFormat, including the corresponding Metal pixel and vertex format. */
-typedef struct DataFormatDesc {
+struct DataFormatDesc {
 	RD::DataFormat dataFormat;
 	MTLPixelFormat mtlPixelFormat;
 	MTLPixelFormat mtlPixelFormatSubstitute;
@@ -199,6 +205,7 @@ typedef struct DataFormatDesc {
 	Extent2D blockTexelSize;
 	uint32_t bytesPerBlock;
 	MTLFormatType formatType;
+	ComponentMapping componentMapping;
 	const char *name;
 	bool hasReportedSubstitution;
 
@@ -209,24 +216,31 @@ typedef struct DataFormatDesc {
 
 	inline bool vertexIsSupported() const { return (mtlVertexFormat != MTLVertexFormatInvalid); }
 	inline bool vertexIsSupportedOrSubstitutable() const { return vertexIsSupported() || (mtlVertexFormatSubstitute != MTLVertexFormatInvalid); }
-} DataFormatDesc;
+
+	bool needsSwizzle() const {
+		return (componentMapping.r != RD::TEXTURE_SWIZZLE_IDENTITY ||
+				componentMapping.g != RD::TEXTURE_SWIZZLE_IDENTITY ||
+				componentMapping.b != RD::TEXTURE_SWIZZLE_IDENTITY ||
+				componentMapping.a != RD::TEXTURE_SWIZZLE_IDENTITY);
+	}
+};
 
 /** Describes the properties of a MTLPixelFormat or MTLVertexFormat. */
-typedef struct MTLFormatDesc {
+struct MTLFormatDesc {
 	union {
 		MTLPixelFormat mtlPixelFormat;
 		MTLVertexFormat mtlVertexFormat;
 	};
-	RD::DataFormat dataFormat;
+	RD::DataFormat dataFormat = RD::DATA_FORMAT_MAX;
 	MTLFmtCaps mtlFmtCaps;
 	MTLViewClass mtlViewClass;
 	MTLPixelFormat mtlPixelFormatLinear;
 	const char *name = nullptr;
 
 	inline bool isSupported() const { return (mtlPixelFormat != MTLPixelFormatInvalid) && (mtlFmtCaps != kMTLFmtCapsNone); }
-} MTLFormatDesc;
+};
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) PixelFormats {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) PixelFormats {
 	using DataFormat = RD::DataFormat;
 
 public:
@@ -353,6 +367,9 @@ public:
 	 */
 	size_t getBytesPerLayer(MTLPixelFormat p_format, size_t p_bytes_per_row, uint32_t p_texel_rows_per_layer);
 
+	/** Returns whether or not the specified Godot format requires swizzling to use with Metal. */
+	bool needsSwizzle(DataFormat p_format);
+
 	/** Returns the Metal format capabilities supported by the specified Godot format, without substitution. */
 	MTLFmtCaps getCapabilities(DataFormat p_format, bool p_extended = false);
 
@@ -367,48 +384,28 @@ public:
 
 #pragma mark Construction
 
-	explicit PixelFormats(id<MTLDevice> p_device);
+	explicit PixelFormats(id<MTLDevice> p_device, const MetalFeatures &p_feat);
 
 protected:
-	id<MTLDevice> device;
-
 	DataFormatDesc &getDataFormatDesc(DataFormat p_format);
 	DataFormatDesc &getDataFormatDesc(MTLPixelFormat p_format);
 	MTLFormatDesc &getMTLPixelFormatDesc(MTLPixelFormat p_format);
+	MTLFmtCaps &getMTLPixelFormatCapsIf(MTLPixelFormat mtlPixFmt, bool cond);
 	MTLFormatDesc &getMTLVertexFormatDesc(MTLVertexFormat p_format);
+
 	void initDataFormatCapabilities();
 	void initMTLPixelFormatCapabilities();
-	void initMTLVertexFormatCapabilities();
-	void buildMTLFormatMaps();
+	void initMTLVertexFormatCapabilities(const MetalFeatures &p_feat);
+	void modifyMTLFormatCapabilities(const MetalFeatures &p_feat);
 	void buildDFFormatMaps();
-	void modifyMTLFormatCapabilities();
-	void modifyMTLFormatCapabilities(id<MTLDevice> p_device);
-	void addMTLPixelFormatCapabilities(id<MTLDevice> p_device,
-			MTLFeatureSet p_feature_set,
-			MTLPixelFormat p_format,
-			MTLFmtCaps p_caps);
-	void addMTLPixelFormatCapabilities(id<MTLDevice> p_device,
-			MTLGPUFamily p_family,
-			MTLPixelFormat p_format,
-			MTLFmtCaps p_caps);
-	void disableMTLPixelFormatCapabilities(MTLPixelFormat p_format,
-			MTLFmtCaps p_caps);
-	void disableAllMTLPixelFormatCapabilities(MTLPixelFormat p_format);
-	void addMTLVertexFormatCapabilities(id<MTLDevice> p_device,
-			MTLFeatureSet p_feature_set,
-			MTLVertexFormat p_format,
-			MTLFmtCaps p_caps);
+	void addMTLPixelFormatDescImpl(MTLPixelFormat p_pix_fmt, MTLPixelFormat p_pix_fmt_linear,
+			MTLViewClass p_view_class, MTLFmtCaps p_fmt_caps, const char *p_name);
+	void addMTLVertexFormatDescImpl(MTLVertexFormat p_vert_fmt, MTLFmtCaps p_vert_caps, const char *name);
 
-	DataFormatDesc _dataFormatDescriptions[RD::DATA_FORMAT_MAX];
-	MTLFormatDesc _mtlPixelFormatDescriptions[_mtlPixelFormatCount];
-	MTLFormatDesc _mtlVertexFormatDescriptions[_mtlVertexFormatCount];
-
-	// Most Metal formats have small values and are mapped by simple lookup array.
-	// Outliers are mapped by a map.
-	uint16_t _mtlFormatDescIndicesByMTLPixelFormatsCore[_mtlPixelFormatCoreCount];
-	HashMap<uint32_t, uint32_t> _mtlFormatDescIndicesByMTLPixelFormatsExt;
-
-	uint16_t _mtlFormatDescIndicesByMTLVertexFormats[_mtlVertexFormatCount];
+	id<MTLDevice> device;
+	InflectionMap<DataFormat, DataFormatDesc, RD::DATA_FORMAT_MAX> _data_format_descs;
+	InflectionMap<uint16_t, MTLFormatDesc, MTLPixelFormatX32_Stencil8 + 2> _mtl_pixel_format_descs; // The actual last enum value is not available on iOS.
+	TightLocalVector<MTLFormatDesc> _mtl_vertex_format_descs;
 };
 
 #pragma clang diagnostic pop

--- a/drivers/metal/rendering_context_driver_metal.h
+++ b/drivers/metal/rendering_context_driver_metal.h
@@ -56,7 +56,7 @@ class MDCommandBuffer;
 class PixelFormats;
 class MDResourceCache;
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) RenderingContextDriverMetal : public RenderingContextDriver {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) RenderingContextDriverMetal : public RenderingContextDriver {
 protected:
 #ifdef __OBJC__
 	id<MTLDevice> metal_device = nullptr;
@@ -94,7 +94,7 @@ public:
 #endif
 	};
 
-	class API_AVAILABLE(macos(11.0), ios(14.0)) Surface {
+	class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) Surface {
 	protected:
 #ifdef __OBJC__
 		id<MTLDevice> device;

--- a/drivers/metal/rendering_context_driver_metal.mm
+++ b/drivers/metal/rendering_context_driver_metal.mm
@@ -79,7 +79,7 @@ void RenderingContextDriverMetal::driver_free(RenderingDeviceDriver *p_driver) {
 	memdelete(p_driver);
 }
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) SurfaceLayer : public RenderingContextDriverMetal::Surface {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) SurfaceLayer : public RenderingContextDriverMetal::Surface {
 	CAMetalLayer *__unsafe_unretained layer = nil;
 	LocalVector<MDFrameBuffer> frame_buffers;
 	LocalVector<id<MTLDrawable>> drawables;

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -36,7 +36,6 @@
 #import "servers/rendering/rendering_device_driver.h"
 
 #import <Metal/Metal.h>
-#import <spirv.hpp>
 #import <variant>
 
 #ifdef DEBUG_ENABLED
@@ -47,7 +46,7 @@
 
 class RenderingContextDriverMetal;
 
-class API_AVAILABLE(macos(11.0), ios(14.0)) RenderingDeviceDriverMetal : public RenderingDeviceDriver {
+class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) RenderingDeviceDriverMetal : public RenderingDeviceDriver {
 	friend struct ShaderCacheEntry;
 
 	template <typename T>

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -62,6 +62,7 @@
 #import <Metal/Metal.h>
 #import <os/log.h>
 #import <os/signpost.h>
+#import <spirv.hpp>
 #import <spirv_msl.hpp>
 #import <spirv_parser.hpp>
 
@@ -299,8 +300,10 @@ RDD::TextureID RenderingDeviceDriverMetal::texture_create(const TextureFormat &p
 		desc.usage |= MTLTextureUsageShaderWrite;
 	}
 
-	if (p_format.usage_bits & TEXTURE_USAGE_STORAGE_ATOMIC_BIT) {
-		desc.usage |= MTLTextureUsageShaderWrite;
+	if (@available(macOS 14.0, iOS 17.0, tvOS 17.0, *)) {
+		if (format_caps & kMTLFmtCapsAtomic) {
+			desc.usage |= MTLTextureUsageShaderAtomic;
+		}
 	}
 
 	bool can_be_attachment = flags::any(format_caps, (kMTLFmtCapsColorAtt | kMTLFmtCapsDSAtt));
@@ -689,7 +692,7 @@ static const MTLBlendOperation BLEND_OPERATIONS[RD::BLEND_OP_MAX] = {
 	MTLBlendOperationMax,
 };
 
-static const API_AVAILABLE(macos(11.0), ios(14.0)) MTLSamplerAddressMode ADDRESS_MODES[RD::SAMPLER_REPEAT_MODE_MAX] = {
+static const API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MTLSamplerAddressMode ADDRESS_MODES[RD::SAMPLER_REPEAT_MODE_MAX] = {
 	MTLSamplerAddressModeRepeat,
 	MTLSamplerAddressModeMirrorRepeat,
 	MTLSamplerAddressModeClampToEdge,
@@ -697,7 +700,7 @@ static const API_AVAILABLE(macos(11.0), ios(14.0)) MTLSamplerAddressMode ADDRESS
 	MTLSamplerAddressModeMirrorClampToEdge,
 };
 
-static const API_AVAILABLE(macos(11.0), ios(14.0)) MTLSamplerBorderColor SAMPLER_BORDER_COLORS[RD::SAMPLER_BORDER_COLOR_MAX] = {
+static const API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MTLSamplerBorderColor SAMPLER_BORDER_COLORS[RD::SAMPLER_BORDER_COLOR_MAX] = {
 	MTLSamplerBorderColorTransparentBlack,
 	MTLSamplerBorderColorTransparentBlack,
 	MTLSamplerBorderColorOpaqueBlack,
@@ -732,7 +735,7 @@ RDD::SamplerID RenderingDeviceDriverMetal::sampler_create(const SamplerState &p_
 	desc.normalizedCoordinates = !p_state.unnormalized_uvw;
 
 	if (p_state.lod_bias != 0.0) {
-		WARN_VERBOSE("Metal does not support LOD bias for samplers.");
+		WARN_PRINT_ONCE("Metal does not support LOD bias for samplers.");
 	}
 
 	id<MTLSamplerState> obj = [device newSamplerStateWithDescriptor:desc];
@@ -1425,7 +1428,7 @@ struct SpecializationConstantData {
 	}
 };
 
-struct API_AVAILABLE(macos(11.0), ios(14.0)) UniformData {
+struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) UniformData {
 	RD::UniformType type = RD::UniformType::UNIFORM_TYPE_MAX;
 	uint32_t binding = UINT32_MAX;
 	bool writable = false;
@@ -1481,7 +1484,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0)) UniformData {
 	}
 };
 
-struct API_AVAILABLE(macos(11.0), ios(14.0)) UniformSetData {
+struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) UniformSetData {
 	uint32_t index = UINT32_MAX;
 	LocalVector<UniformData> uniforms;
 
@@ -1539,7 +1542,7 @@ struct PushConstantData {
 	}
 };
 
-struct API_AVAILABLE(macos(11.0), ios(14.0)) ShaderBinaryData {
+struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) ShaderBinaryData {
 	enum Flags : uint32_t {
 		NONE = 0,
 		NEEDS_VIEW_MASK_BUFFER = 1 << 0,
@@ -2032,7 +2035,7 @@ Vector<uint8_t> RenderingDeviceDriverMetal::shader_compile_binary_from_spirv(Vec
 	msl_options.platform = CompilerMSL::Options::iOS;
 #endif
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IPHONE
 	msl_options.ios_use_simdgroup_functions = (*device_properties).features.simdPermute;
 #endif
 
@@ -2907,7 +2910,7 @@ void RenderingDeviceDriverMetal::command_clear_color_texture(CommandBufferID p_c
 	}
 }
 
-API_AVAILABLE(macos(11.0), ios(14.0))
+API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0))
 bool isArrayTexture(MTLTextureType p_type) {
 	return (p_type == MTLTextureType3D ||
 			p_type == MTLTextureType2DArray ||
@@ -4123,7 +4126,7 @@ Error RenderingDeviceDriverMetal::initialize(uint32_t p_device_index, uint32_t p
 	pipeline_cache_id = "metal-driver-" + get_api_version();
 
 	device_properties = memnew(MetalDeviceProperties(device));
-	pixel_formats = memnew(PixelFormats(device));
+	pixel_formats = memnew(PixelFormats(device, device_properties->features));
 	if (device_properties->features.layeredRendering) {
 		multiview_capabilities.is_supported = true;
 		multiview_capabilities.max_view_count = device_properties->limits.maxViewports;


### PR DESCRIPTION
Occasionally, when launching a game from the editor, I would observe a crash due to using a Metal object that had already been freed. This should be resolved by switching the `MTLCommandBuffer` to retaining references (which is was originally) and is the normal usage of the API. I will revisit using the optimised API in the future, when I can guarantee that references are always retained by the Metal rendering driver for the duration of the frame.

I have also updated the availability API declarations to include `tvOS`, for any future work in this area, which should have no side effects to the editor or existing Apple platforms.

Finally, the code which maps pixel formats had a number of `#ifdef`s for each platform, which was unnecessarily complex, and this has been condensed, so that it is shared across all platforms. As such, this will pave the way for future platform support, such as tvOS.