### PR TITLE
astcenc: Allow decompression in non-editor builds

### DIFF
--- a/modules/astcenc/SCsub
+++ b/modules/astcenc/SCsub
@@ -41,6 +41,13 @@ env_astcenc.Prepend(CPPPATH=[thirdparty_dir])
 
 env_thirdparty = env_astcenc.Clone()
 env_thirdparty.disable_warnings()
+
+# Build the encoder only for editor builds
+astc_encoder = env.editor_build
+
+if not astc_encoder:
+    env_thirdparty.Append(CPPDEFINES=[("ASTCENC_DECOMPRESS_ONLY")])
+
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 env.modules_sources += thirdparty_obj
 

--- a/modules/astcenc/config.py
+++ b/modules/astcenc/config.py
@@ -1,7 +1,5 @@
 def can_build(env, platform):
-    # Godot only uses it in the editor, but ANGLE depends on it and we had
-    # to remove the copy from prebuilt ANGLE libs to solve symbol clashes.
-    return env.editor_build or env.get("angle_libs")
+    return True
 
 
 def configure(env):

--- a/modules/astcenc/image_compress_astcenc.cpp
+++ b/modules/astcenc/image_compress_astcenc.cpp
@@ -35,6 +35,7 @@
 
 #include <astcenc.h>
 
+#ifdef TOOLS_ENABLED
 void _compress_astc(Image *r_img, Image::ASTCFormat p_format) {
 	const uint64_t start_time = OS::get_singleton()->get_ticks_msec();
 
@@ -171,6 +172,7 @@ void _compress_astc(Image *r_img, Image::ASTCFormat p_format) {
 
 	print_verbose(vformat("astcenc: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
+#endif // TOOLS_ENABLED
 
 void _decompress_astc(Image *r_img) {
 	const uint64_t start_time = OS::get_singleton()->get_ticks_msec();
@@ -213,8 +215,9 @@ void _decompress_astc(Image *r_img) {
 
 	astcenc_config config;
 	const float quality = ASTCENC_PRE_MEDIUM;
+	const uint32_t flags = ASTCENC_FLG_DECOMPRESS_ONLY;
 
-	astcenc_error status = astcenc_config_init(profile, block_x, block_y, 1, quality, 0, &config);
+	astcenc_error status = astcenc_config_init(profile, block_x, block_y, 1, quality, flags, &config);
 	ERR_FAIL_COND_MSG(status != ASTCENC_SUCCESS,
 			vformat("astcenc: Configuration initialization failed: %s.", astcenc_get_error_string(status)));
 

--- a/modules/astcenc/image_compress_astcenc.h
+++ b/modules/astcenc/image_compress_astcenc.h
@@ -33,7 +33,10 @@
 
 #include "core/io/image.h"
 
+#ifdef TOOLS_ENABLED
 void _compress_astc(Image *r_img, Image::ASTCFormat p_format);
+#endif
+
 void _decompress_astc(Image *r_img);
 
 #endif // IMAGE_COMPRESS_ASTCENC_H

--- a/modules/astcenc/register_types.cpp
+++ b/modules/astcenc/register_types.cpp
@@ -37,7 +37,10 @@ void initialize_astcenc_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
+#ifdef TOOLS_ENABLED
 	Image::_image_compress_astc_func = _compress_astc;
+#endif
+
 	Image::_image_decompress_astc = _decompress_astc;
 }
 


### PR DESCRIPTION
Depends on #100848
Fixes #100644

This PR changes astcenc's build configuration to allow decompressing ASTC formats in non-editor builds. This will be useful for devices which don't support ASTC formats (especially the HDR variants).

TODO:
- [x] Find out whether Angle needs the compressor as well and enable it accordingly.

MRP:
[astc-runtime.zip](https://github.com/user-attachments/files/18285222/astc-runtime.zip)

Testing: Export the project using the custom export template from this PR. Before this PR, the results would vary depending on whether Angle was enabled by default. The Windows version (with Angle, and therefore astcenc always enabled) looked like this:
![old](https://github.com/user-attachments/assets/a1ca4def-4557-4bb2-91b5-d770648bd8df)

Now, every version should look like this: 
![new](https://github.com/user-attachments/assets/8d4658af-b92c-4fc6-9f4b-22ed465468e0)
