### PR TITLE
Allow overriding SpinBox value on `focus_exited`

### DIFF
--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -58,13 +58,13 @@ class SpinBox : public Range {
 	void _range_click_timeout();
 	void _release_mouse_from_drag_mode();
 
-	void _update_text(bool p_keep_line_edit = false);
+	void _update_text(bool p_only_update_if_value_changed = false);
 	void _text_submitted(const String &p_string);
 	void _text_changed(const String &p_string);
 
 	String prefix;
 	String suffix;
-	String last_updated_text;
+	String last_text_value;
 	double custom_arrow_step = 0.0;
 	bool use_custom_arrow_step = false;
 


### PR DESCRIPTION
Fixes #100836

When setting `SpinBox`'s value the text is only updated on `NOTIFICATION_DRAW`. If the value is changed on the same frame as the focus is lost, this means the old text will be submitted instead. This PR thus checks if the value has changed before submitting the text.

With this PR the MRP will:
- Correctly override the value on `focus_exited`.
- Not call `_val_changed()` when using `set_value_no_signal()`.
- Only call `_val_changed()` once when directly setting `value`.