### PR TITLE
ProjectManager: Update project list placeholder when project is created

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -715,9 +715,12 @@ void ProjectManager::_on_project_created(const String &dir, bool edit) {
 	project_list->add_project(dir, false);
 	project_list->save_config();
 	search_box->clear();
+
 	int i = project_list->refresh_project(dir);
 	project_list->select_project(i);
 	project_list->ensure_project_visible(i);
+	_update_project_buttons();
+	_update_list_placeholder();
 
 	if (edit) {
 		_open_selected_projects_ask();


### PR DESCRIPTION
Fixes #100847

This will hide the placeholder control when adding a project to a previously empty list. The side buttons (Edit/Run/Rename/Manage Tags/Remove) will now also be enabled on project creation. As can be seen in #100847, the buttons are disabled even though the project is selected.