### PR TITLE
Pre-commit: Fix applying ruff to SCsub files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,11 +50,15 @@ repos:
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.8.4
     hooks:
       - id: ruff
         args: [--fix]
+        files: (\.py|SConstruct|SCsub)$
+        types_or: [text]
       - id: ruff-format
+        files: (\.py|SConstruct|SCsub)$
+        types_or: [text]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0
@@ -170,7 +174,7 @@ repos:
         language: python
         entry: python misc/scripts/header_guards.py
         files: \.(h|hpp|hh|hxx)$
-        exclude: ^.*/(thread|platform_config|platform_gl)\.h$
+        exclude: ^.*/(dummy|thread|platform_config|platform_gl)\.h$
 
       - id: file-format
         name: file-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python_version = "3.8"
 
 [tool.ruff]
 extend-exclude = ["thirdparty"]
-extend-include = ["SConstruct", "SCsub"]
+extend-include = ["*SConstruct", "*SCsub"]
 line-length = 120
 target-version = "py38"
 

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -10,7 +10,7 @@ thirdparty_obj = []
 thirdparty_dir = "#thirdparty/misc/"
 thirdparty_sources = [
     "mikktspace.c",
-    "qoa.c"
+    "qoa.c",
 ]
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]


### PR DESCRIPTION
Also ignore iOS template dummy.h file for header guards check.

Update ruff to 0.8.4 while at it.