### PR TITLE
Add unit tests for StreamPeer, StreamPeerBuffer and StreamPeerExtension

### DIFF
--- a/tests/core/io/test_stream_peer.h
+++ b/tests/core/io/test_stream_peer.h
@@ -306,6 +306,93 @@ TEST_CASE("[StreamPeer] Get UTF8 string when there is no string") {
 	ERR_PRINT_ON;
 }
 
+TEST_CASE("[StreamPeer] Put data through binded method") {
+	Ref<StreamPeerBuffer> spb;
+	spb.instantiate();
+	Vector<uint8_t> buffer = { 42 };
+
+	Variant result = spb->call("put_data", buffer);
+	uint32_t error = uint32_t(result);
+
+	CHECK_EQ(error, OK);
+	CHECK_EQ(spb->get_size(), 1);
+}
+
+TEST_CASE("[StreamPeer] Put zero data through binded method") {
+	Ref<StreamPeerBuffer> spb;
+	spb.instantiate();
+	Vector<uint8_t> buffer = {};
+
+	Variant result = spb->call("put_data", buffer);
+	uint32_t error = uint32_t(result);
+
+	CHECK_EQ(error, OK);
+	CHECK_EQ(spb->get_size(), 0);
+}
+
+TEST_CASE("[StreamPeer] Put partial data through binded method") {
+	Ref<StreamPeerBuffer> spb;
+	spb.instantiate();
+	Vector<uint8_t> buffer = { 42 };
+
+	Variant result = spb->call("put_partial_data", buffer);
+	Array array = Array(result);
+	uint32_t error = uint32_t(array[0]);
+	uint32_t sent_bytes = uint32_t(array[1]);
+
+	CHECK_EQ(error, OK);
+	CHECK_EQ(sent_bytes, 1);
+	CHECK_EQ(spb->get_size(), 1);
+}
+
+TEST_CASE("[StreamPeer] Put empty partial data through binded method") {
+	Ref<StreamPeerBuffer> spb;
+	spb.instantiate();
+	Vector<uint8_t> buffer = {};
+
+	Variant result = spb->call("put_partial_data", buffer);
+	Array array = Array(result);
+	uint32_t error = uint32_t(array[0]);
+	uint32_t sent_bytes = uint32_t(array[1]);
+
+	CHECK_EQ(error, OK);
+	CHECK_EQ(sent_bytes, 0);
+	CHECK_EQ(spb->get_size(), 0);
+}
+
+TEST_CASE("[StreamPeer] Get one byte from empty buffer through binded method") {
+	Ref<StreamPeerBuffer> spb;
+	spb.instantiate();
+
+	Variant result = spb->call("get_data", 1);
+	Array array = Array(result);
+	uint32_t error = uint32_t(array[0]);
+
+	CHECK_EQ(error, ERR_INVALID_PARAMETER);
+}
+
+TEST_CASE("[StreamPeer] Get zero partial data through binded method") {
+	Ref<StreamPeerBuffer> spb;
+	spb.instantiate();
+
+	Variant result = spb->call("get_partial_data", 0);
+	Array array = Array(result);
+	uint32_t error = uint32_t(array[0]);
+
+	CHECK_EQ(error, OK);
+}
+
+TEST_CASE("[StreamPeer] Get one partial byte from empty buffer through binded method") {
+	Ref<StreamPeerBuffer> spb;
+	spb.instantiate();
+
+	Variant result = spb->call("get_partial_data", 1);
+	Array array = Array(result);
+	uint32_t error = uint32_t(array[0]);
+
+	CHECK_EQ(error, OK);
+}
+
 } // namespace TestStreamPeer
 
 #endif // TEST_STREAM_PEER_H

--- a/tests/core/io/test_stream_peer_buffer.h
+++ b/tests/core/io/test_stream_peer_buffer.h
@@ -180,6 +180,36 @@ TEST_CASE("[StreamPeerBuffer] Get data with invalid size returns an error") {
 	CHECK_EQ(spb->get_position(), 1);
 }
 
+TEST_CASE("[StreamPeerBuffer] Get zero partial bytes return OK") {
+	Ref<StreamPeerBuffer> spb;
+	spb.instantiate();
+	uint8_t data = 42;
+	spb->put_u8(data);
+	spb->seek(0);
+
+	uint8_t data_out = 0;
+	int received_bytes = 0;
+	Error error = spb->get_partial_data(&data_out, 0, received_bytes);
+
+	CHECK_EQ(error, OK);
+	CHECK_EQ(received_bytes, 0);
+	CHECK_EQ(data_out, 0);
+	CHECK_EQ(spb->get_size(), 1);
+}
+
+TEST_CASE("[StreamPeerBuffer] Put one byte as partial data return OK") {
+	Ref<StreamPeerBuffer> spb;
+	spb.instantiate();
+	Vector<uint8_t> buffer = { 42, 24 };
+
+	int sent_bytes = 0;
+	Error error = spb->put_partial_data(buffer.ptr(), 1, sent_bytes);
+
+	CHECK_EQ(error, OK);
+	CHECK_EQ(sent_bytes, 1);
+	CHECK_EQ(spb->get_size(), 1);
+}
+
 } // namespace TestStreamPeerBuffer
 
 #endif // TEST_STREAM_PEER_BUFFER_H

--- a/tests/core/io/test_stream_peer_extension.h
+++ b/tests/core/io/test_stream_peer_extension.h
@@ -1,0 +1,91 @@
+/**************************************************************************/
+/*  test_stream_peer_extension.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_STREAM_PEER_EXTENSION_H
+#define TEST_STREAM_PEER_EXTENSION_H
+
+#include "core/io/stream_peer.h"
+#include "tests/test_macros.h"
+
+namespace TestStreamPeerExtension {
+
+TEST_CASE("[StreamPeerExtension] Initialization") {
+	Ref<StreamPeerExtension> spb;
+	spb.instantiate();
+	CHECK_EQ(spb->get_available_bytes(), 0);
+}
+
+TEST_CASE("[StreamPeerExtension] Put data without overridden method return FAILED") {
+	Ref<StreamPeerExtension> spb;
+	spb.instantiate();
+
+	uint8_t data = 42;
+	Error error = spb->put_data(&data, 1);
+
+	CHECK_EQ(error, FAILED);
+}
+
+TEST_CASE("[StreamPeerExtension] Put partial data without overridden method return FAILED") {
+	Ref<StreamPeerExtension> spb;
+	spb.instantiate();
+
+	uint8_t data = 42;
+	int sent_bytes = 0;
+	Error error = spb->put_partial_data(&data, 1, sent_bytes);
+
+	CHECK_EQ(error, FAILED);
+	CHECK_EQ(sent_bytes, 0);
+}
+
+TEST_CASE("[StreamPeerExtension] Get data without overridden method return FAILED") {
+	Ref<StreamPeerExtension> spb;
+	spb.instantiate();
+
+	uint8_t data_out = 0;
+	Error error = spb->get_data(&data_out, 1);
+
+	CHECK_EQ(error, FAILED);
+}
+
+TEST_CASE("[StreamPeerExtension] Get partial data without overridden method return FAILED") {
+	Ref<StreamPeerExtension> spb;
+	spb.instantiate();
+
+	uint8_t data = 42;
+	int received_bytes = 0;
+	Error error = spb->get_partial_data(&data, 1, received_bytes);
+
+	CHECK_EQ(error, FAILED);
+	CHECK_EQ(received_bytes, 0);
+}
+
+} // namespace TestStreamPeerExtension
+
+#endif // TEST_STREAM_PEER_EXTENSION_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -55,6 +55,7 @@
 #include "tests/core/io/test_resource.h"
 #include "tests/core/io/test_stream_peer.h"
 #include "tests/core/io/test_stream_peer_buffer.h"
+#include "tests/core/io/test_stream_peer_extension.h"
 #include "tests/core/io/test_tcp_server.h"
 #include "tests/core/io/test_udp_server.h"
 #include "tests/core/io/test_xml_parser.h"


### PR DESCRIPTION
Fixes (partially) #43440

In this PR:

- add unit tests for get\put partial data for StreamPeerBuffer
- add unit tests for StreamPeer binded method
- add unit tests for StreamPeerExtension

As a result, increase code lines coverage from ~80% to ~97% and branches coverage from ~60% to ~78% for `stream_peer.cpp` file.

[coverage.core_io_stream_peer.cpp.html.zip](https://github.com/user-attachments/files/18265691/coverage.core_io_stream_peer.cpp.html.zip)
