### PR TITLE
Optimize usability of VisibleOnScreenNotifier2D

### DIFF
--- a/doc/classes/VisibleOnScreenNotifier2D.xml
+++ b/doc/classes/VisibleOnScreenNotifier2D.xml
@@ -24,6 +24,9 @@
 		<member name="rect" type="Rect2" setter="set_rect" getter="get_rect" default="Rect2(-10, -10, 20, 20)">
 			The VisibleOnScreenNotifier2D's bounding rectangle.
 		</member>
+		<member name="show_rect" type="bool" setter="set_show_rect" getter="is_showing_rect" default="true">
+			If [code]true[/code], shows the rectangle area of [member rect] in the editor with a translucent magenta fill. Unlike changing the visibility of the VisibleOnScreenNotifier2D, this does not affect the screen culling detection.
+		</member>
 	</members>
 	<signals>
 		<signal name="screen_entered">

--- a/scene/2d/visible_on_screen_notifier_2d.cpp
+++ b/scene/2d/visible_on_screen_notifier_2d.cpp
@@ -31,12 +31,28 @@
 #include "visible_on_screen_notifier_2d.h"
 
 #ifdef DEBUG_ENABLED
+Dictionary VisibleOnScreenNotifier2D::_edit_get_state() const {
+	Dictionary state = Node2D::_edit_get_state();
+	state["rect"] = rect;
+	return state;
+}
+
+void VisibleOnScreenNotifier2D::_edit_set_state(const Dictionary &p_state) {
+	ERR_FAIL_COND(p_state.is_empty() || !p_state.has("rect"));
+	set_rect(p_state["rect"]);
+	Node2D::_edit_set_state(p_state);
+}
+
+void VisibleOnScreenNotifier2D::_edit_set_rect(const Rect2 &p_edit_rect) {
+	set_rect(p_edit_rect);
+}
+
 Rect2 VisibleOnScreenNotifier2D::_edit_get_rect() const {
 	return rect;
 }
 
 bool VisibleOnScreenNotifier2D::_edit_use_rect() const {
-	return true;
+	return show_rect;
 }
 #endif // DEBUG_ENABLED
 
@@ -71,6 +87,18 @@ Rect2 VisibleOnScreenNotifier2D::get_rect() const {
 	return rect;
 }
 
+void VisibleOnScreenNotifier2D::set_show_rect(bool p_show_rect) {
+	if (show_rect == p_show_rect) {
+		return;
+	}
+	show_rect = p_show_rect;
+	queue_redraw();
+}
+
+bool VisibleOnScreenNotifier2D::is_showing_rect() const {
+	return show_rect;
+}
+
 void VisibleOnScreenNotifier2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -79,7 +107,7 @@ void VisibleOnScreenNotifier2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			if (Engine::get_singleton()->is_editor_hint()) {
+			if (show_rect && Engine::get_singleton()->is_editor_hint()) {
 				draw_rect(rect, Color(1, 0.5, 1, 0.2));
 			}
 		} break;
@@ -98,9 +126,12 @@ bool VisibleOnScreenNotifier2D::is_on_screen() const {
 void VisibleOnScreenNotifier2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_rect", "rect"), &VisibleOnScreenNotifier2D::set_rect);
 	ClassDB::bind_method(D_METHOD("get_rect"), &VisibleOnScreenNotifier2D::get_rect);
+	ClassDB::bind_method(D_METHOD("set_show_rect", "show_rect"), &VisibleOnScreenNotifier2D::set_show_rect);
+	ClassDB::bind_method(D_METHOD("is_showing_rect"), &VisibleOnScreenNotifier2D::is_showing_rect);
 	ClassDB::bind_method(D_METHOD("is_on_screen"), &VisibleOnScreenNotifier2D::is_on_screen);
 
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "rect", PROPERTY_HINT_NONE, "suffix:px"), "set_rect", "get_rect");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_rect"), "set_show_rect", "is_showing_rect");
 
 	ADD_SIGNAL(MethodInfo("screen_entered"));
 	ADD_SIGNAL(MethodInfo("screen_exited"));

--- a/scene/2d/visible_on_screen_notifier_2d.h
+++ b/scene/2d/visible_on_screen_notifier_2d.h
@@ -40,6 +40,7 @@ class VisibleOnScreenNotifier2D : public Node2D {
 	HashSet<Viewport *> viewports;
 
 	Rect2 rect;
+	bool show_rect = true;
 
 private:
 	bool on_screen = false;
@@ -55,12 +56,22 @@ protected:
 
 public:
 #ifdef DEBUG_ENABLED
+	virtual Dictionary _edit_get_state() const override;
+	virtual void _edit_set_state(const Dictionary &p_state) override;
+
+	virtual Vector2 _edit_get_minimum_size() const override { return Vector2(); }
+
+	virtual void _edit_set_rect(const Rect2 &p_edit_rect) override;
 	virtual Rect2 _edit_get_rect() const override;
+
 	virtual bool _edit_use_rect() const override;
 #endif // DEBUG_ENABLED
 
 	void set_rect(const Rect2 &p_rect);
 	Rect2 get_rect() const;
+
+	void set_show_rect(bool p_show_rect);
+	bool is_showing_rect() const;
 
 	bool is_on_screen() const;
 


### PR DESCRIPTION
Partially implements: https://github.com/godotengine/godot-proposals/issues/526
This pr allows:
* Dragging the rectangle of a `VisibleOnScreenNotifier2D` only changes its `rect`, instead of `scale` and `position`.
* Added `show_rect` and `guard_rect_selection`.

# New properties:
* `show_rect`: If `true`, the rectangle will be drawn on the screen. Unlike `visible`, **this does not affect its screen culling detection**.
~~* `guard_rect_selection`: If `true`, the `VisibleOnScreenNotifier2D` will not be selectable by clicking on the rectangle of it, but you can still select it in the scene tree editor. This will be very useful when there are 2d instances covered by the rectangle and you need to select them one by one by clicking on each of them with `ctrl` or `shift` being held. When the `VisibleOnScreenNotifier2D` was in a packed scene, the owner would be inaccurately selected, so this property prevents it and allows you to select the other 2d instances covered by the rectangle. Watch the video to see how this protects the owner from being mistakenly selected:~~
<video src="https://github.com/user-attachments/assets/79895de8-c55c-45b6-acb2-578a5be3c3f6" controls="" height=400 width=600> </video>
*The `guard_rect_selection` has been removed and will be superseded in another pr in plan*