### PR TITLE
Fix `_forward_3d_gui_input` not working with the preview camera

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -1711,7 +1711,7 @@ void Node3DEditorViewport::input(const Ref<InputEvent> &p_event) {
 }
 
 void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
-	if (previewing || get_viewport()->gui_get_drag_data()) {
+	if (get_viewport()->gui_get_drag_data()) {
 		return; //do NONE
 	}
 
@@ -1745,6 +1745,10 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				after = EditorPlugin::AFTER_GUI_INPUT_CUSTOM;
 			}
 		}
+	}
+
+	if (previewing) {
+		return;
 	}
 
 	Ref<InputEventMouseButton> b = p_event;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: https://github.com/godotengine/godot/issues/76873

Related: https://github.com/godotengine/godot-proposals/issues/11424

I can't think of a reason why input forwarding should be disabled while the preview camera is enabled. ~~Without it developing a plugin similar to what the linked proposal above suggests implementing wouldn't be very straight-forward.~~

Edit: This can be done with RenderingServer, but the prototyping process led to that discovery, so I believe this should still be enabled. 

Below is a video using the functionality enabled by this PR to capture mouse movement events inside the editor viewport to control the character. 

https://github.com/user-attachments/assets/6f886237-7e8a-4b24-ab7d-c0e1910b7d55


