### PR TITLE
Tests: Integrate minor formatting/stylistic fixes

### DIFF
--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -35,15 +35,12 @@
 #include "../gdscript_compiler.h"
 #include "../gdscript_parser.h"
 #include "../gdscript_tokenizer_buffer.h"
-
 #include "core/config/project_settings.h"
 #include "core/core_globals.h"
 #include "core/io/dir_access.h"
-#include "core/io/file_access_pack.h"
 #include "core/os/os.h"
 #include "core/string/string_builder.h"
 #include "scene/resources/packed_scene.h"
-
 #include "tests/test_macros.h"
 
 namespace GDScriptTests {

--- a/modules/gdscript/tests/gdscript_test_runner_suite.h
+++ b/modules/gdscript/tests/gdscript_test_runner_suite.h
@@ -32,7 +32,6 @@
 #define GDSCRIPT_TEST_RUNNER_SUITE_H
 
 #include "gdscript_test_runner.h"
-
 #include "tests/test_macros.h"
 
 namespace GDScriptTests {

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -33,6 +33,7 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "../gdscript.h"
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"
@@ -40,15 +41,12 @@
 #include "core/object/script_language.h"
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
+#include "editor/editor_settings.h"
 #include "gdscript_test_runner.h"
 #include "modules/modules_enabled.gen.h" // For mono.
 #include "scene/resources/packed_scene.h"
-
-#include "../gdscript.h"
-#include "tests/test_macros.h"
-
-#include "editor/editor_settings.h"
 #include "scene/theme/theme_db.h"
+#include "tests/test_macros.h"
 
 namespace GDScriptTests {
 

--- a/modules/gdscript/tests/test_gdscript.h
+++ b/modules/gdscript/tests/test_gdscript.h
@@ -32,7 +32,6 @@
 #define TEST_GDSCRIPT_H
 
 #include "gdscript_test_runner.h"
-
 #include "tests/test_macros.h"
 
 namespace GDScriptTests {

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -33,22 +33,14 @@
 
 #ifdef TOOLS_ENABLED
 
-#include "tests/test_macros.h"
-
 #include "../language_server/gdscript_extend_parser.h"
 #include "../language_server/gdscript_language_protocol.h"
 #include "../language_server/gdscript_workspace.h"
 #include "../language_server/godot_lsp.h"
-
 #include "core/io/dir_access.h"
-#include "core/io/file_access_pack.h"
-#include "core/os/os.h"
-#include "editor/editor_help.h"
-#include "editor/editor_node.h"
 #include "modules/gdscript/gdscript_analyzer.h"
 #include "modules/regex/regex.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 template <>
 struct doctest::StringMaker<lsp::Position> {

--- a/modules/mbedtls/tests/test_crypto_mbedtls.cpp
+++ b/modules/mbedtls/tests/test_crypto_mbedtls.cpp
@@ -31,7 +31,6 @@
 #include "test_crypto_mbedtls.h"
 
 #include "../crypto_mbedtls.h"
-
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 

--- a/modules/mbedtls/tests/test_crypto_mbedtls.h
+++ b/modules/mbedtls/tests/test_crypto_mbedtls.h
@@ -31,9 +31,7 @@
 #ifndef TEST_CRYPTO_MBEDTLS_H
 #define TEST_CRYPTO_MBEDTLS_H
 
-#include "core/crypto/crypto.h"
 #include "core/crypto/hashing_context.h"
-
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 

--- a/modules/noise/tests/test_fastnoise_lite.h
+++ b/modules/noise/tests/test_fastnoise_lite.h
@@ -32,7 +32,6 @@
 #define TEST_FASTNOISE_LITE_H
 
 #include "../fastnoise_lite.h"
-
 #include "tests/test_macros.h"
 
 namespace TestFastNoiseLite {

--- a/modules/noise/tests/test_noise_texture_2d.h
+++ b/modules/noise/tests/test_noise_texture_2d.h
@@ -31,8 +31,8 @@
 #ifndef TEST_NOISE_TEXTURE_2D_H
 #define TEST_NOISE_TEXTURE_2D_H
 
+#include "../fastnoise_lite.h"
 #include "../noise_texture_2d.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNoiseTexture2D {

--- a/modules/noise/tests/test_noise_texture_3d.h
+++ b/modules/noise/tests/test_noise_texture_3d.h
@@ -31,8 +31,8 @@
 #ifndef TEST_NOISE_TEXTURE_3D_H
 #define TEST_NOISE_TEXTURE_3D_H
 
+#include "../fastnoise_lite.h"
 #include "../noise_texture_3d.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNoiseTexture3D {

--- a/modules/regex/tests/test_regex.h
+++ b/modules/regex/tests/test_regex.h
@@ -34,7 +34,6 @@
 #include "../regex.h"
 
 #include "core/string/ustring.h"
-
 #include "tests/test_macros.h"
 
 namespace TestRegEx {

--- a/tests/core/input/test_input_event.h
+++ b/tests/core/input/test_input_event.h
@@ -33,9 +33,7 @@
 
 #include "core/input/input_event.h"
 #include "core/math/rect2.h"
-#include "core/os/memory.h"
 #include "core/variant/array.h"
-
 #include "tests/test_macros.h"
 
 namespace TestInputEvent {

--- a/tests/core/input/test_input_event_key.h
+++ b/tests/core/input/test_input_event_key.h
@@ -33,7 +33,6 @@
 
 #include "core/input/input_event.h"
 #include "core/os/keyboard.h"
-
 #include "tests/test_macros.h"
 
 namespace TestInputEventKey {

--- a/tests/core/input/test_shortcut.h
+++ b/tests/core/input/test_shortcut.h
@@ -37,7 +37,6 @@
 #include "core/object/ref_counted.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
-
 #include "tests/test_macros.h"
 
 namespace TestShortcut {

--- a/tests/core/io/test_config_file.h
+++ b/tests/core/io/test_config_file.h
@@ -33,7 +33,6 @@
 
 #include "core/io/config_file.h"
 #include "core/os/os.h"
-
 #include "tests/test_macros.h"
 
 namespace TestConfigFile {

--- a/tests/core/io/test_http_client.h
+++ b/tests/core/io/test_http_client.h
@@ -32,10 +32,8 @@
 #define TEST_HTTP_CLIENT_H
 
 #include "core/io/http_client.h"
-
-#include "tests/test_macros.h"
-
 #include "modules/modules_enabled.gen.h"
+#include "tests/test_macros.h"
 
 namespace TestHTTPClient {
 

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -33,9 +33,8 @@
 
 #include "core/io/image.h"
 #include "core/os/os.h"
-
+#include "tests/test_macros.h"
 #include "tests/test_utils.h"
-#include "thirdparty/doctest/doctest.h"
 
 #include "modules/modules_enabled.gen.h"
 

--- a/tests/core/io/test_ip.h
+++ b/tests/core/io/test_ip.h
@@ -32,7 +32,6 @@
 #define TEST_IP_H
 
 #include "core/io/ip.h"
-
 #include "tests/test_macros.h"
 
 namespace TestIP {

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -32,8 +32,7 @@
 #define TEST_JSON_H
 
 #include "core/io/json.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 namespace TestJSON {
 

--- a/tests/core/io/test_marshalls.h
+++ b/tests/core/io/test_marshalls.h
@@ -32,7 +32,6 @@
 #define TEST_MARSHALLS_H
 
 #include "core/io/marshalls.h"
-
 #include "tests/test_macros.h"
 
 namespace TestMarshalls {

--- a/tests/core/io/test_pck_packer.h
+++ b/tests/core/io/test_pck_packer.h
@@ -34,9 +34,8 @@
 #include "core/io/file_access_pack.h"
 #include "core/io/pck_packer.h"
 #include "core/os/os.h"
-
+#include "tests/test_macros.h"
 #include "tests/test_utils.h"
-#include "thirdparty/doctest/doctest.h"
 
 namespace TestPCKPacker {
 

--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -35,9 +35,6 @@
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/os/os.h"
-
-#include "thirdparty/doctest/doctest.h"
-
 #include "tests/test_macros.h"
 
 namespace TestResource {

--- a/tests/core/io/test_xml_parser.h
+++ b/tests/core/io/test_xml_parser.h
@@ -32,7 +32,6 @@
 #define TEST_XML_PARSER_H
 
 #include "core/io/xml_parser.h"
-
 #include "tests/test_macros.h"
 
 namespace TestXMLParser {

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -32,7 +32,6 @@
 #define TEST_AABB_H
 
 #include "core/math/aabb.h"
-
 #include "tests/test_macros.h"
 
 namespace TestAABB {

--- a/tests/core/math/test_astar.h
+++ b/tests/core/math/test_astar.h
@@ -32,7 +32,6 @@
 #define TEST_ASTAR_H
 
 #include "core/math/a_star.h"
-
 #include "tests/test_macros.h"
 
 namespace TestAStar {

--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -33,7 +33,6 @@
 
 #include "core/math/basis.h"
 #include "core/math/random_number_generator.h"
-
 #include "tests/test_macros.h"
 
 namespace TestBasis {

--- a/tests/core/math/test_color.h
+++ b/tests/core/math/test_color.h
@@ -32,7 +32,6 @@
 #define TEST_COLOR_H
 
 #include "core/math/color.h"
-
 #include "tests/test_macros.h"
 
 namespace TestColor {

--- a/tests/core/math/test_expression.h
+++ b/tests/core/math/test_expression.h
@@ -32,7 +32,6 @@
 #define TEST_EXPRESSION_H
 
 #include "core/math/expression.h"
-
 #include "tests/test_macros.h"
 
 namespace TestExpression {

--- a/tests/core/math/test_geometry_2d.h
+++ b/tests/core/math/test_geometry_2d.h
@@ -32,8 +32,7 @@
 #define TEST_GEOMETRY_2D_H
 
 #include "core/math/geometry_2d.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 namespace TestGeometry2D {
 

--- a/tests/core/math/test_plane.h
+++ b/tests/core/math/test_plane.h
@@ -32,8 +32,7 @@
 #define TEST_PLANE_H
 
 #include "core/math/plane.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 namespace TestPlane {
 

--- a/tests/core/math/test_projection.h
+++ b/tests/core/math/test_projection.h
@@ -36,8 +36,7 @@
 #include "core/math/projection.h"
 #include "core/math/rect2.h"
 #include "core/math/transform_3d.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 namespace TestProjection {
 

--- a/tests/core/math/test_quaternion.h
+++ b/tests/core/math/test_quaternion.h
@@ -35,7 +35,6 @@
 #include "core/math/math_funcs.h"
 #include "core/math/quaternion.h"
 #include "core/math/vector3.h"
-
 #include "tests/test_macros.h"
 
 namespace TestQuaternion {

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -33,8 +33,7 @@
 
 #include "core/math/rect2.h"
 #include "core/math/rect2i.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 namespace TestRect2 {
 TEST_CASE("[Rect2] Constructor methods") {

--- a/tests/core/math/test_rect2i.h
+++ b/tests/core/math/test_rect2i.h
@@ -33,8 +33,7 @@
 
 #include "core/math/rect2.h"
 #include "core/math/rect2i.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 namespace TestRect2i {
 TEST_CASE("[Rect2i] Constructor methods") {

--- a/tests/core/math/test_transform_2d.h
+++ b/tests/core/math/test_transform_2d.h
@@ -32,7 +32,6 @@
 #define TEST_TRANSFORM_2D_H
 
 #include "core/math/transform_2d.h"
-
 #include "tests/test_macros.h"
 
 namespace TestTransform2D {

--- a/tests/core/math/test_transform_3d.h
+++ b/tests/core/math/test_transform_3d.h
@@ -32,7 +32,6 @@
 #define TEST_TRANSFORM_3D_H
 
 #include "core/math/transform_3d.h"
-
 #include "tests/test_macros.h"
 
 namespace TestTransform3D {

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -34,7 +34,6 @@
 #include "core/core_bind.h"
 #include "core/core_constants.h"
 #include "core/object/class_db.h"
-
 #include "tests/test_macros.h"
 
 namespace TestClassDB {

--- a/tests/core/object/test_method_bind.h
+++ b/tests/core/object/test_method_bind.h
@@ -32,7 +32,6 @@
 #define TEST_METHOD_BIND_H
 
 #include "core/object/class_db.h"
-
 #include "tests/test_macros.h"
 
 namespace TestMethodBind {

--- a/tests/core/object/test_undo_redo.h
+++ b/tests/core/object/test_undo_redo.h
@@ -34,17 +34,16 @@
 #include "core/object/undo_redo.h"
 #include "tests/test_macros.h"
 
-// Declared in global namespace because of GDCLASS macro warning (Windows):
-// "Unqualified friend declaration referring to type outside of the nearest enclosing namespace
-// is a Microsoft extension; add a nested name specifier".
-class _TestUndoRedoObject : public Object {
-	GDCLASS(_TestUndoRedoObject, Object);
+namespace TestUndoRedo {
+
+class TestUndoRedoObject : public Object {
+	GDCLASS(TestUndoRedoObject, Object);
 	int property_value = 0;
 
 protected:
 	static void _bind_methods() {
-		ClassDB::bind_method(D_METHOD("set_property", "property"), &_TestUndoRedoObject::set_property);
-		ClassDB::bind_method(D_METHOD("get_property"), &_TestUndoRedoObject::get_property);
+		ClassDB::bind_method(D_METHOD("set_property", "property"), &TestUndoRedoObject::set_property);
+		ClassDB::bind_method(D_METHOD("get_property"), &TestUndoRedoObject::get_property);
 		ADD_PROPERTY(PropertyInfo(Variant::INT, "property"), "set_property", "get_property");
 	}
 
@@ -55,27 +54,25 @@ public:
 	void subtract_from_property(int value) { property_value -= value; }
 };
 
-namespace TestUndoRedo {
-
-void set_property_action(UndoRedo *undo_redo, const String &name, _TestUndoRedoObject *test_object, int value, UndoRedo::MergeMode merge_mode = UndoRedo::MERGE_DISABLE) {
+void set_property_action(UndoRedo *undo_redo, const String &name, TestUndoRedoObject *test_object, int value, UndoRedo::MergeMode merge_mode = UndoRedo::MERGE_DISABLE) {
 	undo_redo->create_action(name, merge_mode);
 	undo_redo->add_do_property(test_object, "property", value);
 	undo_redo->add_undo_property(test_object, "property", test_object->get_property());
 	undo_redo->commit_action();
 }
 
-void increment_property_action(UndoRedo *undo_redo, const String &name, _TestUndoRedoObject *test_object, int value, UndoRedo::MergeMode merge_mode = UndoRedo::MERGE_DISABLE) {
+void increment_property_action(UndoRedo *undo_redo, const String &name, TestUndoRedoObject *test_object, int value, UndoRedo::MergeMode merge_mode = UndoRedo::MERGE_DISABLE) {
 	undo_redo->create_action(name, merge_mode);
-	undo_redo->add_do_method(callable_mp(test_object, &_TestUndoRedoObject::add_to_property).bind(value));
-	undo_redo->add_undo_method(callable_mp(test_object, &_TestUndoRedoObject::subtract_from_property).bind(value));
+	undo_redo->add_do_method(callable_mp(test_object, &TestUndoRedoObject::add_to_property).bind(value));
+	undo_redo->add_undo_method(callable_mp(test_object, &TestUndoRedoObject::subtract_from_property).bind(value));
 	undo_redo->commit_action();
 }
 
 TEST_CASE("[UndoRedo] Simple Property UndoRedo") {
-	GDREGISTER_CLASS(_TestUndoRedoObject);
+	GDREGISTER_CLASS(TestUndoRedoObject);
 	UndoRedo *undo_redo = memnew(UndoRedo());
 
-	_TestUndoRedoObject *test_object = memnew(_TestUndoRedoObject());
+	TestUndoRedoObject *test_object = memnew(TestUndoRedoObject());
 
 	CHECK(test_object->get_property() == 0);
 	CHECK(undo_redo->get_version() == 1);
@@ -122,10 +119,10 @@ TEST_CASE("[UndoRedo] Simple Property UndoRedo") {
 }
 
 TEST_CASE("[UndoRedo] Merge Property UndoRedo") {
-	GDREGISTER_CLASS(_TestUndoRedoObject);
+	GDREGISTER_CLASS(TestUndoRedoObject);
 	UndoRedo *undo_redo = memnew(UndoRedo());
 
-	_TestUndoRedoObject *test_object = memnew(_TestUndoRedoObject());
+	TestUndoRedoObject *test_object = memnew(TestUndoRedoObject());
 
 	CHECK(test_object->get_property() == 0);
 	CHECK(undo_redo->get_version() == 1);
@@ -154,10 +151,10 @@ TEST_CASE("[UndoRedo] Merge Property UndoRedo") {
 }
 
 TEST_CASE("[UndoRedo] Merge Method UndoRedo") {
-	GDREGISTER_CLASS(_TestUndoRedoObject);
+	GDREGISTER_CLASS(TestUndoRedoObject);
 	UndoRedo *undo_redo = memnew(UndoRedo());
 
-	_TestUndoRedoObject *test_object = memnew(_TestUndoRedoObject());
+	TestUndoRedoObject *test_object = memnew(TestUndoRedoObject());
 
 	CHECK(test_object->get_property() == 0);
 	CHECK(undo_redo->get_version() == 1);

--- a/tests/core/os/test_os.h
+++ b/tests/core/os/test_os.h
@@ -32,8 +32,7 @@
 #define TEST_OS_H
 
 #include "core/os/os.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 namespace TestOS {
 

--- a/tests/core/string/test_node_path.h
+++ b/tests/core/string/test_node_path.h
@@ -32,7 +32,6 @@
 #define TEST_NODE_PATH_H
 
 #include "core/string/node_path.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNodePath {

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -32,7 +32,6 @@
 #define TEST_STRING_H
 
 #include "core/string/ustring.h"
-
 #include "tests/test_macros.h"
 
 namespace TestString {

--- a/tests/core/string/test_translation_server.h
+++ b/tests/core/string/test_translation_server.h
@@ -32,7 +32,6 @@
 #define TEST_TRANSLATION_SERVER_H
 
 #include "core/string/translation_server.h"
-
 #include "tests/test_macros.h"
 
 namespace TestTranslationServer {

--- a/tests/core/templates/test_a_hash_map.h
+++ b/tests/core/templates/test_a_hash_map.h
@@ -32,7 +32,6 @@
 #define TEST_A_HASH_MAP_H
 
 #include "core/templates/a_hash_map.h"
-
 #include "tests/test_macros.h"
 
 namespace TestAHashMap {

--- a/tests/core/templates/test_hash_map.h
+++ b/tests/core/templates/test_hash_map.h
@@ -32,7 +32,6 @@
 #define TEST_HASH_MAP_H
 
 #include "core/templates/hash_map.h"
-
 #include "tests/test_macros.h"
 
 namespace TestHashMap {

--- a/tests/core/templates/test_hash_set.h
+++ b/tests/core/templates/test_hash_set.h
@@ -32,7 +32,6 @@
 #define TEST_HASH_SET_H
 
 #include "core/templates/hash_set.h"
-
 #include "tests/test_macros.h"
 
 namespace TestHashSet {

--- a/tests/core/templates/test_list.h
+++ b/tests/core/templates/test_list.h
@@ -32,7 +32,6 @@
 #define TEST_LIST_H
 
 #include "core/templates/list.h"
-
 #include "tests/test_macros.h"
 
 namespace TestList {

--- a/tests/core/templates/test_local_vector.h
+++ b/tests/core/templates/test_local_vector.h
@@ -32,7 +32,6 @@
 #define TEST_LOCAL_VECTOR_H
 
 #include "core/templates/local_vector.h"
-
 #include "tests/test_macros.h"
 
 namespace TestLocalVector {

--- a/tests/core/templates/test_lru.h
+++ b/tests/core/templates/test_lru.h
@@ -32,7 +32,6 @@
 #define TEST_LRU_H
 
 #include "core/templates/lru.h"
-
 #include "tests/test_macros.h"
 
 namespace TestLRU {

--- a/tests/core/templates/test_oa_hash_map.h
+++ b/tests/core/templates/test_oa_hash_map.h
@@ -33,7 +33,6 @@
 
 #include "core/templates/oa_hash_map.h"
 #include "scene/resources/texture.h"
-
 #include "tests/test_macros.h"
 
 namespace TestOAHashMap {

--- a/tests/core/templates/test_paged_array.h
+++ b/tests/core/templates/test_paged_array.h
@@ -32,8 +32,7 @@
 #define TEST_PAGED_ARRAY_H
 
 #include "core/templates/paged_array.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 namespace TestPagedArray {
 

--- a/tests/core/templates/test_rid.h
+++ b/tests/core/templates/test_rid.h
@@ -32,7 +32,6 @@
 #define TEST_RID_H
 
 #include "core/templates/rid.h"
-
 #include "tests/test_macros.h"
 
 namespace TestRID {

--- a/tests/core/templates/test_vector.h
+++ b/tests/core/templates/test_vector.h
@@ -32,7 +32,6 @@
 #define TEST_VECTOR_H
 
 #include "core/templates/vector.h"
-
 #include "tests/test_macros.h"
 
 namespace TestVector {

--- a/tests/core/test_hashing_context.h
+++ b/tests/core/test_hashing_context.h
@@ -32,7 +32,6 @@
 #define TEST_HASHING_CONTEXT_H
 
 #include "core/crypto/hashing_context.h"
-
 #include "tests/test_macros.h"
 
 namespace TestHashingContext {

--- a/tests/core/test_time.h
+++ b/tests/core/test_time.h
@@ -32,8 +32,7 @@
 #define TEST_TIME_H
 
 #include "core/os/time.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 #define YEAR_KEY "year"
 #define MONTH_KEY "month"

--- a/tests/core/threads/test_worker_thread_pool.h
+++ b/tests/core/threads/test_worker_thread_pool.h
@@ -32,7 +32,6 @@
 #define TEST_WORKER_THREAD_POOL_H
 
 #include "core/object/worker_thread_pool.h"
-
 #include "tests/test_macros.h"
 
 namespace TestWorkerThreadPool {

--- a/tests/core/variant/test_callable.h
+++ b/tests/core/variant/test_callable.h
@@ -33,7 +33,6 @@
 
 #include "core/object/class_db.h"
 #include "core/object/object.h"
-
 #include "tests/test_macros.h"
 
 namespace TestCallable {

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -33,7 +33,6 @@
 
 #include "core/variant/variant.h"
 #include "core/variant/variant_parser.h"
-
 #include "tests/test_macros.h"
 
 namespace TestVariant {

--- a/tests/core/variant/test_variant_utility.h
+++ b/tests/core/variant/test_variant_utility.h
@@ -32,7 +32,6 @@
 #define TEST_VARIANT_UTILITY_H
 
 #include "core/variant/variant_utility.h"
-
 #include "tests/test_macros.h"
 
 namespace TestVariantUtility {

--- a/tests/display_server_mock.h
+++ b/tests/display_server_mock.h
@@ -32,7 +32,6 @@
 #define DISPLAY_SERVER_MOCK_H
 
 #include "servers/display_server_headless.h"
-
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 // Specialized DisplayServer for unittests based on DisplayServerHeadless, that

--- a/tests/scene/test_animation.h
+++ b/tests/scene/test_animation.h
@@ -32,7 +32,6 @@
 #define TEST_ANIMATION_H
 
 #include "scene/resources/animation.h"
-
 #include "tests/test_macros.h"
 
 namespace TestAnimation {

--- a/tests/scene/test_arraymesh.h
+++ b/tests/scene/test_arraymesh.h
@@ -33,7 +33,6 @@
 
 #include "scene/resources/3d/primitive_meshes.h"
 #include "scene/resources/mesh.h"
-
 #include "tests/test_macros.h"
 
 namespace TestArrayMesh {

--- a/tests/scene/test_audio_stream_wav.h
+++ b/tests/scene/test_audio_stream_wav.h
@@ -34,7 +34,6 @@
 #include "core/math/math_defs.h"
 #include "core/math/math_funcs.h"
 #include "scene/resources/audio_stream_wav.h"
-
 #include "tests/test_macros.h"
 
 namespace TestAudioStreamWAV {

--- a/tests/scene/test_button.h
+++ b/tests/scene/test_button.h
@@ -33,7 +33,6 @@
 
 #include "scene/gui/button.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestButton {

--- a/tests/scene/test_camera_3d.h
+++ b/tests/scene/test_camera_3d.h
@@ -34,7 +34,6 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 // Constants.

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -32,7 +32,6 @@
 #define TEST_CODE_EDIT_H
 
 #include "scene/gui/code_edit.h"
-
 #include "tests/test_macros.h"
 
 namespace TestCodeEdit {

--- a/tests/scene/test_color_picker.h
+++ b/tests/scene/test_color_picker.h
@@ -32,7 +32,6 @@
 #define TEST_COLOR_PICKER_H
 
 #include "scene/gui/color_picker.h"
-
 #include "tests/test_macros.h"
 
 namespace TestColorPicker {

--- a/tests/scene/test_control.h
+++ b/tests/scene/test_control.h
@@ -32,7 +32,6 @@
 #define TEST_CONTROL_H
 
 #include "scene/gui/control.h"
-
 #include "tests/test_macros.h"
 
 namespace TestControl {

--- a/tests/scene/test_curve.h
+++ b/tests/scene/test_curve.h
@@ -33,7 +33,6 @@
 
 #include "core/math/math_funcs.h"
 #include "scene/resources/curve.h"
-
 #include "tests/test_macros.h"
 
 namespace TestCurve {

--- a/tests/scene/test_curve_2d.h
+++ b/tests/scene/test_curve_2d.h
@@ -33,7 +33,6 @@
 
 #include "core/math/math_funcs.h"
 #include "scene/resources/curve.h"
-
 #include "tests/test_macros.h"
 
 namespace TestCurve2D {

--- a/tests/scene/test_curve_3d.h
+++ b/tests/scene/test_curve_3d.h
@@ -33,7 +33,6 @@
 
 #include "core/math/math_funcs.h"
 #include "scene/resources/curve.h"
-
 #include "tests/test_macros.h"
 
 namespace TestCurve3D {

--- a/tests/scene/test_gradient.h
+++ b/tests/scene/test_gradient.h
@@ -32,8 +32,7 @@
 #define TEST_GRADIENT_H
 
 #include "scene/resources/gradient.h"
-
-#include "thirdparty/doctest/doctest.h"
+#include "tests/test_macros.h"
 
 namespace TestGradient {
 

--- a/tests/scene/test_gradient_texture.h
+++ b/tests/scene/test_gradient_texture.h
@@ -32,7 +32,6 @@
 #define TEST_GRADIENT_TEXTURE_H
 
 #include "scene/resources/gradient_texture.h"
-
 #include "tests/test_macros.h"
 
 namespace TestGradientTexture {

--- a/tests/scene/test_graph_node.h
+++ b/tests/scene/test_graph_node.h
@@ -33,7 +33,6 @@
 
 #include "scene/gui/graph_node.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestGraphNode {

--- a/tests/scene/test_height_map_shape_3d.h
+++ b/tests/scene/test_height_map_shape_3d.h
@@ -33,7 +33,6 @@
 
 #include "scene/resources/3d/height_map_shape_3d.h"
 #include "scene/resources/image_texture.h"
-
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 

--- a/tests/scene/test_image_texture.h
+++ b/tests/scene/test_image_texture.h
@@ -33,7 +33,6 @@
 
 #include "core/io/image.h"
 #include "scene/resources/image_texture.h"
-
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 

--- a/tests/scene/test_image_texture_3d.h
+++ b/tests/scene/test_image_texture_3d.h
@@ -33,7 +33,6 @@
 
 #include "core/io/image.h"
 #include "scene/resources/image_texture.h"
-
 #include "tests/test_macros.h"
 #include "tests/test_utils.h"
 

--- a/tests/scene/test_instance_placeholder.h
+++ b/tests/scene/test_instance_placeholder.h
@@ -33,7 +33,6 @@
 
 #include "scene/main/instance_placeholder.h"
 #include "scene/resources/packed_scene.h"
-
 #include "tests/test_macros.h"
 
 class _TestInstancePlaceholderNode : public Node {

--- a/tests/scene/test_navigation_agent_2d.h
+++ b/tests/scene/test_navigation_agent_2d.h
@@ -35,7 +35,6 @@
 #include "scene/2d/node_2d.h"
 #include "scene/main/window.h"
 #include "scene/resources/world_2d.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNavigationAgent2D {

--- a/tests/scene/test_navigation_agent_3d.h
+++ b/tests/scene/test_navigation_agent_3d.h
@@ -34,7 +34,6 @@
 #include "scene/3d/navigation_agent_3d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNavigationAgent3D {

--- a/tests/scene/test_navigation_obstacle_2d.h
+++ b/tests/scene/test_navigation_obstacle_2d.h
@@ -33,7 +33,6 @@
 
 #include "scene/2d/navigation_obstacle_2d.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNavigationObstacle2D {

--- a/tests/scene/test_navigation_obstacle_3d.h
+++ b/tests/scene/test_navigation_obstacle_3d.h
@@ -33,7 +33,6 @@
 
 #include "scene/3d/navigation_obstacle_3d.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNavigationObstacle3D {

--- a/tests/scene/test_navigation_region_2d.h
+++ b/tests/scene/test_navigation_region_2d.h
@@ -33,7 +33,6 @@
 
 #include "scene/2d/navigation_region_2d.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNavigationRegion2D {

--- a/tests/scene/test_navigation_region_3d.h
+++ b/tests/scene/test_navigation_region_3d.h
@@ -35,7 +35,6 @@
 #include "scene/3d/navigation_region_3d.h"
 #include "scene/main/window.h"
 #include "scene/resources/3d/primitive_meshes.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNavigationRegion3D {

--- a/tests/scene/test_node.h
+++ b/tests/scene/test_node.h
@@ -34,7 +34,6 @@
 #include "core/object/class_db.h"
 #include "scene/main/node.h"
 #include "scene/resources/packed_scene.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNode {

--- a/tests/scene/test_node_2d.h
+++ b/tests/scene/test_node_2d.h
@@ -33,7 +33,6 @@
 
 #include "scene/2d/node_2d.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNode2D {

--- a/tests/scene/test_option_button.h
+++ b/tests/scene/test_option_button.h
@@ -32,7 +32,6 @@
 #define TEST_OPTION_BUTTON_H
 
 #include "scene/gui/option_button.h"
-
 #include "tests/test_macros.h"
 
 namespace TestOptionButton {

--- a/tests/scene/test_packed_scene.h
+++ b/tests/scene/test_packed_scene.h
@@ -32,7 +32,6 @@
 #define TEST_PACKED_SCENE_H
 
 #include "scene/resources/packed_scene.h"
-
 #include "tests/test_macros.h"
 
 namespace TestPackedScene {

--- a/tests/scene/test_path_2d.h
+++ b/tests/scene/test_path_2d.h
@@ -32,7 +32,6 @@
 #define TEST_PATH_2D_H
 
 #include "scene/2d/path_2d.h"
-
 #include "tests/test_macros.h"
 
 namespace TestPath2D {

--- a/tests/scene/test_path_3d.h
+++ b/tests/scene/test_path_3d.h
@@ -32,7 +32,6 @@
 #define TEST_PATH_3D_H
 
 #include "scene/3d/path_3d.h"
-
 #include "tests/test_macros.h"
 
 namespace TestPath3D {

--- a/tests/scene/test_path_follow_2d.h
+++ b/tests/scene/test_path_follow_2d.h
@@ -33,7 +33,6 @@
 
 #include "scene/2d/path_2d.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestPathFollow2D {

--- a/tests/scene/test_path_follow_3d.h
+++ b/tests/scene/test_path_follow_3d.h
@@ -33,7 +33,6 @@
 
 #include "scene/3d/path_3d.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestPathFollow3D {

--- a/tests/scene/test_primitives.h
+++ b/tests/scene/test_primitives.h
@@ -32,7 +32,6 @@
 #define TEST_PRIMITIVES_H
 
 #include "scene/resources/3d/primitive_meshes.h"
-
 #include "tests/test_macros.h"
 
 namespace TestPrimitives {

--- a/tests/scene/test_skeleton_3d.h
+++ b/tests/scene/test_skeleton_3d.h
@@ -31,9 +31,8 @@
 #ifndef TEST_SKELETON_3D_H
 #define TEST_SKELETON_3D_H
 
-#include "tests/test_macros.h"
-
 #include "scene/3d/skeleton_3d.h"
+#include "tests/test_macros.h"
 
 namespace TestSkeleton3D {
 

--- a/tests/scene/test_sky.h
+++ b/tests/scene/test_sky.h
@@ -32,7 +32,6 @@
 #define TEST_SKY_H
 
 #include "scene/resources/sky.h"
-
 #include "tests/test_macros.h"
 
 namespace TestSky {

--- a/tests/scene/test_split_container.h
+++ b/tests/scene/test_split_container.h
@@ -33,7 +33,6 @@
 
 #include "scene/gui/split_container.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestSplitContainer {

--- a/tests/scene/test_sprite_frames.h
+++ b/tests/scene/test_sprite_frames.h
@@ -32,7 +32,6 @@
 #define TEST_SPRITE_FRAMES_H
 
 #include "scene/resources/sprite_frames.h"
-
 #include "tests/test_macros.h"
 
 namespace TestSpriteFrames {

--- a/tests/scene/test_style_box_texture.h
+++ b/tests/scene/test_style_box_texture.h
@@ -32,7 +32,6 @@
 #define TEST_STYLE_BOX_TEXTURE_H
 
 #include "scene/resources/style_box_texture.h"
-
 #include "tests/test_macros.h"
 
 namespace TestStyleBoxTexture {

--- a/tests/scene/test_tab_bar.h
+++ b/tests/scene/test_tab_bar.h
@@ -33,7 +33,6 @@
 
 #include "scene/gui/tab_bar.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestTabBar {

--- a/tests/scene/test_tab_container.h
+++ b/tests/scene/test_tab_container.h
@@ -32,7 +32,6 @@
 #define TEST_TAB_CONTAINER_H
 
 #include "scene/gui/tab_container.h"
-
 #include "tests/test_macros.h"
 
 namespace TestTabContainer {

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -32,7 +32,6 @@
 #define TEST_TEXT_EDIT_H
 
 #include "scene/gui/text_edit.h"
-
 #include "tests/test_macros.h"
 
 namespace TestTextEdit {

--- a/tests/scene/test_texture_progress_bar.h
+++ b/tests/scene/test_texture_progress_bar.h
@@ -32,7 +32,6 @@
 #define TEST_TEXTURE_PROGRESS_BAR_H
 
 #include "scene/gui/texture_progress_bar.h"
-
 #include "tests/test_macros.h"
 
 namespace TestTextureProgressBar {

--- a/tests/scene/test_theme.h
+++ b/tests/scene/test_theme.h
@@ -34,9 +34,8 @@
 #include "scene/resources/image_texture.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/theme.h"
+#include "tests/test_macros.h"
 #include "tests/test_tools.h"
-
-#include "thirdparty/doctest/doctest.h"
 
 namespace TestTheme {
 

--- a/tests/scene/test_timer.h
+++ b/tests/scene/test_timer.h
@@ -32,7 +32,6 @@
 #define TEST_TIMER_H
 
 #include "scene/main/timer.h"
-
 #include "tests/test_macros.h"
 
 namespace TestTimer {

--- a/tests/scene/test_tree.h
+++ b/tests/scene/test_tree.h
@@ -32,7 +32,6 @@
 #define TEST_TREE_H
 
 #include "scene/gui/tree.h"
-
 #include "tests/test_macros.h"
 
 namespace TestTree {

--- a/tests/scene/test_viewport.h
+++ b/tests/scene/test_viewport.h
@@ -39,7 +39,6 @@
 #include "scene/main/window.h"
 #include "scene/resources/2d/rectangle_shape_2d.h"
 #include "servers/physics_server_2d_dummy.h"
-
 #include "tests/test_macros.h"
 
 namespace TestViewport {

--- a/tests/scene/test_visual_shader.h
+++ b/tests/scene/test_visual_shader.h
@@ -32,7 +32,6 @@
 #define TEST_VISUAL_SHADER_H
 
 #include "scene/resources/visual_shader.h"
-
 #include "tests/test_macros.h"
 
 namespace TestVisualArray {

--- a/tests/scene/test_window.h
+++ b/tests/scene/test_window.h
@@ -33,7 +33,6 @@
 
 #include "scene/gui/control.h"
 #include "scene/main/window.h"
-
 #include "tests/test_macros.h"
 
 namespace TestWindow {

--- a/tests/servers/rendering/test_shader_preprocessor.h
+++ b/tests/servers/rendering/test_shader_preprocessor.h
@@ -32,7 +32,6 @@
 #define TEST_SHADER_PREPROCESSOR_H
 
 #include "servers/rendering/shader_preprocessor.h"
-
 #include "tests/test_macros.h"
 
 #include <cctype>

--- a/tests/servers/test_navigation_server_2d.h
+++ b/tests/servers/test_navigation_server_2d.h
@@ -32,7 +32,6 @@
 #define TEST_NAVIGATION_SERVER_2D_H
 
 #include "servers/navigation_server_2d.h"
-
 #include "tests/test_macros.h"
 
 namespace TestNavigationServer2D {

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -31,12 +31,11 @@
 #ifndef TEST_MACROS_H
 #define TEST_MACROS_H
 
-#include "display_server_mock.h"
-
 #include "core/core_globals.h"
 #include "core/input/input_map.h"
 #include "core/object/message_queue.h"
 #include "core/variant/variant.h"
+#include "tests/display_server_mock.h"
 
 // See documentation for doctest at:
 // https://github.com/onqtam/doctest/blob/master/doc/markdown/readme.md#reference
@@ -451,7 +450,7 @@ public:
 	}
 
 #define MULTICHECK_SPLIT(m_obj, m_func, m_param1, m_param2, m_param3, m_slices, m_expected_size) \
-	do {                                                                                         \
+	if constexpr (true) {                                                                        \
 		Vector<String> string_list;                                                              \
                                                                                                  \
 		string_list = m_obj.m_func(m_param1, m_param2, m_param3);                                \
@@ -477,6 +476,7 @@ public:
 		for (int i = 0; i < string_list.size(); ++i) {                                           \
 			CHECK(string_list[i] == m_slices[i]);                                                \
 		}                                                                                        \
-	} while (false)
+	} else                                                                                       \
+		((void)0)
 
 #endif // TEST_MACROS_H

--- a/tests/test_tools.h
+++ b/tests/test_tools.h
@@ -31,6 +31,8 @@
 #ifndef TEST_TOOLS_H
 #define TEST_TOOLS_H
 
+#include "core/error/error_macros.h"
+
 struct ErrorDetector {
 	ErrorDetector() {
 		eh.errfunc = _detect_error;

--- a/tests/test_validate_testing.h
+++ b/tests/test_validate_testing.h
@@ -32,8 +32,6 @@
 #define TEST_VALIDATE_TESTING_H
 
 #include "core/core_globals.h"
-#include "core/os/os.h"
-
 #include "tests/test_macros.h"
 #include "tests/test_tools.h"
 


### PR DESCRIPTION
A collection of minor adjustments to the test scripts. Primiarly ensures proper header syntax/sorting, including `tests/test_macros.h` uniformly (and NOT `thirdparty/doctest/doctest.h`), and ensuring absolutely everything is captured within a given testing namespace. 