### PR TITLE
Warn if `virtual_keyboard_get_height()` is unsupported

### DIFF
--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -631,7 +631,8 @@ void DisplayServer::virtual_keyboard_hide() {
 
 // returns height of the currently shown keyboard (0 if keyboard is hidden)
 int DisplayServer::virtual_keyboard_get_height() const {
-	ERR_FAIL_V_MSG(0, "Virtual keyboard not supported by this display server.");
+	WARN_PRINT("Virtual keyboard not supported by this display server.");
+	return 0;
 }
 
 bool DisplayServer::has_hardware_keyboard() const {


### PR DESCRIPTION
This PR updates the `DisplayServer::virtual_keyboard_get_height()` method to return `0` with a warning instead of throwing an error when it is not supported.

closes https://github.com/godotengine/godot/issues/85512