### PR TITLE
Fix `get_meta_list` return type in description

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -759,7 +759,7 @@
 		<method name="get_meta_list" qualifiers="const">
 			<return type="StringName[]" />
 			<description>
-				Returns the object's metadata entry names as a [PackedStringArray].
+				Returns the object's metadata entry names as an [Array] of [StringName]s.
 			</description>
 		</method>
 		<method name="get_method_argument_count" qualifiers="const">


### PR DESCRIPTION
The return type was wrong.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
