### PR TITLE
Store view depth instead of ray length in occlusion buffer

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -173,7 +173,8 @@ void RaycastOcclusionCull::RaycastHZBuffer::sort_rays(const Vector3 &p_camera_di
 					}
 					int k = tile_i * TILE_SIZE + tile_j;
 					int tile_index = i * tile_grid_size.x + j;
-					mips[0][y * buffer_size.x + x] = camera_rays[tile_index].ray.tfar[k];
+					Vector3 ray_dir(camera_rays[tile_index].ray.dir_x[k], camera_rays[tile_index].ray.dir_y[k], camera_rays[tile_index].ray.dir_z[k]);
+					mips[0][y * buffer_size.x + x] = camera_rays[tile_index].ray.tfar[k] * p_camera_dir.dot(ray_dir); // Store z-depth in view space.
 				}
 			}
 		}

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -72,7 +72,7 @@ public:
 				return false;
 			}
 
-			float min_depth = (closest_point - p_cam_position).length();
+			float min_depth = -closest_point_view.z;
 
 			Vector2 rect_min = Vector2(FLT_MAX, FLT_MAX);
 			Vector2 rect_max = Vector2(FLT_MIN, FLT_MIN);


### PR DESCRIPTION
This has two advantages :
- Trades buffer update performance (constant time per frame) for geometry culling performance (linear time with the number of objects). Considering Occlusion Culling is primarily designed for large scenes, this should have a small positive impact
- Removes the need for calling `length()` on the geometry position vector (Z coordinate is used instead) which avoids overflows with very far away objects (> ~1e19m in single precision) and makes Occlusion Culling suitable for large scenes

This may also allow removing orthogonal vs perspective code paths during culling (to be investigated)