### PR TITLE
CI: Fix GHA bug by defining a single concurrency

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -8,10 +8,6 @@ env:
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
 
-concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-android
-  cancel-in-progress: true
-
 jobs:
   build-android:
     runs-on: ubuntu-24.04

--- a/.github/workflows/godot_cpp_test.yml
+++ b/.github/workflows/godot_cpp_test.yml
@@ -9,10 +9,6 @@ env:
   # Used for the godot-cpp checkout.
   GODOT_CPP_BRANCH: 4.3
 
-concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-cpp-tests
-  cancel-in-progress: true
-
 jobs:
   godot-cpp-tests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -8,10 +8,6 @@ env:
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no module_text_server_fb_enabled=yes strict_checks=yes
 
-concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-ios
-  cancel-in-progress: true
-
 jobs:
   ios-template:
     runs-on: macos-latest

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -12,10 +12,6 @@ env:
   TSAN_OPTIONS: suppressions=misc/error_suppressions/tsan.txt
   UBSAN_OPTIONS: suppressions=misc/error_suppressions/ubsan.txt
 
-concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-linux
-  cancel-in-progress: true
-
 jobs:
   build-linux:
     # Stay one LTS before latest to increase portability of Linux artifacts.

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -8,10 +8,6 @@ env:
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes strict_checks=yes
 
-concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-macos
-  cancel-in-progress: true
-
 jobs:
   build-macos:
     runs-on: macos-latest

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -2,7 +2,7 @@ name: 🔗 GHA
 on: [push, pull_request, merge_group]
 
 concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-runner
+  group: ${{ github.workflow }}|${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -2,10 +2,6 @@ name: 📊 Static Checks
 on:
   workflow_call:
 
-concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-static
-  cancel-in-progress: true
-
 jobs:
   static-checks:
     name: Code style, file formatting, and docs

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -9,10 +9,6 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no use_closure_compiler=yes strict_checks=yes
   EM_VERSION: 3.1.64
 
-concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-web
-  cancel-in-progress: true
-
 jobs:
   web-template:
     runs-on: ubuntu-24.04

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -10,10 +10,6 @@ env:
   SCONSFLAGS: verbose=yes warnings=extra werror=yes module_text_server_fb_enabled=yes d3d12=yes strict_checks=yes "angle_libs=${{ github.workspace }}/"
   SCONS_CACHE_MSVC_CONFIG: true
 
-concurrency:
-  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-windows
-  cancel-in-progress: true
-
 jobs:
   build-windows:
     # Windows 10 with latest image


### PR DESCRIPTION
Some local testing revealed a pretty egregious oversight regarding how runners are currently handled. Thanks to having a dedicated workflow caller via `runner.yml`, their concurrency rules are the ONLY one that need to be specified. The name given to the concurrency was also guaranteed to be different each time for non-PR actions, which is the reason multiple merges would start a backlog of jobs; it's now been changed to something uniform without overlapping other branches/workflows. In other words: all future actions, including individual merge commits, will **automatically close older instances** with these changes!