### PR TITLE
Fix debugging embedded game does not refocus on continue

### DIFF
--- a/editor/plugins/embedded_process.cpp
+++ b/editor/plugins/embedded_process.cpp
@@ -296,6 +296,7 @@ void EmbeddedProcess::_check_focused_process_id() {
 		focused_process_id = process_id;
 		if (focused_process_id == current_process_id) {
 			// The embedded process got the focus.
+			emit_signal(SNAME("embedded_process_focused"));
 			if (has_focus()) {
 				// Redraw to updated the focus style.
 				queue_redraw();
@@ -312,6 +313,7 @@ void EmbeddedProcess::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("embedding_completed"));
 	ADD_SIGNAL(MethodInfo("embedding_failed"));
 	ADD_SIGNAL(MethodInfo("embedded_process_updated"));
+	ADD_SIGNAL(MethodInfo("embedded_process_focused"));
 }
 
 EmbeddedProcess::EmbeddedProcess() {

--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -260,6 +260,12 @@ void GameView::_embedded_process_updated() {
 	game_size_label->set_text(vformat("%dx%d", game_rect.size.x, game_rect.size.y));
 }
 
+void GameView::_embedded_process_focused() {
+	if (embed_on_play && !window_wrapper->get_window_enabled()) {
+		EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_GAME);
+	}
+}
+
 void GameView::_project_settings_changed() {
 	// Update the window size and aspect ratio.
 	_update_embed_window_size();
@@ -730,6 +736,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, WindowWrapper *p_wrapper) {
 	embedded_process->connect("embedding_failed", callable_mp(this, &GameView::_embedding_failed));
 	embedded_process->connect("embedding_completed", callable_mp(this, &GameView::_embedding_completed));
 	embedded_process->connect("embedded_process_updated", callable_mp(this, &GameView::_embedded_process_updated));
+	embedded_process->connect("embedded_process_focused", callable_mp(this, &GameView::_embedded_process_focused));
 	embedded_process->set_custom_minimum_size(Size2i(100, 100));
 
 	state_label = memnew(Label());

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -143,6 +143,7 @@ class GameView : public VBoxContainer {
 	void _embedding_completed();
 	void _embedding_failed();
 	void _embedded_process_updated();
+	void _embedded_process_focused();
 	void _project_settings_changed();
 
 	void _update_ui();


### PR DESCRIPTION
- Fixes #100902

Added an signal from `embedded_process` permitting `GameView` to refocus the plugin when the embedded game gets the focus.

Tested with the MRP on Windows 11.