### PR TITLE
Style: Begin integrating `.clangd` fixes

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -5,7 +5,6 @@
 Diagnostics:
   Includes:
     IgnoreHeader:
-      - core/typedefs\.h # Our "main" header, featuring transitive includes; allow everywhere.
       - \.compat\.inc
 ---
 # Header-specific conditions.

--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -31,6 +31,7 @@
 #include "error_macros.h"
 
 #include "core/io/logger.h"
+#include "core/object/object_id.h"
 #include "core/os/os.h"
 #include "core/string/ustring.h"
 

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -31,12 +31,12 @@
 #ifndef ERROR_MACROS_H
 #define ERROR_MACROS_H
 
-#include "core/object/object_id.h"
 #include "core/typedefs.h"
 
-#include <atomic> // We'd normally use safe_refcount.h, but that would cause circular includes.
+#include <atomic> // IWYU pragma: keep // We'd normally use `safe_refcount.h`, but that would cause circular includes.
 
 class String;
+class ObjectID;
 
 enum ErrorHandlerType {
 	ERR_HANDLER_ERROR,

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -347,9 +347,9 @@ float FileAccess::get_half() const {
 }
 
 float FileAccess::get_float() const {
-	MarshallFloat m;
-	m.i = get_32();
-	return m.f;
+	BitCastFloat bitcast;
+	bitcast.i = get_32();
+	return bitcast.f;
 }
 
 real_t FileAccess::get_real() const {
@@ -375,9 +375,9 @@ Variant FileAccess::get_var(bool p_allow_objects) const {
 }
 
 double FileAccess::get_double() const {
-	MarshallDouble m;
-	m.l = get_64();
-	return m.d;
+	BitCastDouble bitcast;
+	bitcast.i = get_64();
+	return bitcast.f;
 }
 
 String FileAccess::get_token() const {
@@ -610,15 +610,13 @@ bool FileAccess::store_half(float p_dest) {
 }
 
 bool FileAccess::store_float(float p_dest) {
-	MarshallFloat m;
-	m.f = p_dest;
-	return store_32(m.i);
+	BitCastFloat bitcast = { p_dest };
+	return store_32(bitcast.i);
 }
 
 bool FileAccess::store_double(double p_dest) {
-	MarshallDouble m;
-	m.d = p_dest;
-	return store_64(m.l);
+	BitCastDouble bitcast = { p_dest };
+	return store_64(bitcast.i);
 }
 
 uint64_t FileAccess::get_modified_time(const String &p_file) {

--- a/core/io/marshalls.h
+++ b/core/io/marshalls.h
@@ -43,27 +43,6 @@ typedef uint64_t uintr_t;
 typedef uint32_t uintr_t;
 #endif
 
-/**
- * Miscellaneous helpers for marshaling data types, and encoding
- * in an endian independent way
- */
-
-union MarshallFloat {
-	uint32_t i; ///< int
-	float f; ///< float
-};
-
-union MarshallDouble {
-	uint64_t l; ///< long long
-	double d; ///< double
-};
-
-// Behaves like one of the above, depending on compilation setting.
-union MarshallReal {
-	uintr_t i;
-	real_t r;
-};
-
 static inline unsigned int encode_uint16(uint16_t p_uint, uint8_t *p_arr) {
 	for (int i = 0; i < 2; i++) {
 		*p_arr = p_uint & 0xFF;
@@ -91,9 +70,8 @@ static inline unsigned int encode_half(float p_float, uint8_t *p_arr) {
 }
 
 static inline unsigned int encode_float(float p_float, uint8_t *p_arr) {
-	MarshallFloat mf;
-	mf.f = p_float;
-	encode_uint32(mf.i, p_arr);
+	BitCastFloat bitcast = { p_float };
+	encode_uint32(bitcast.i, p_arr);
 
 	return sizeof(uint32_t);
 }
@@ -109,9 +87,8 @@ static inline unsigned int encode_uint64(uint64_t p_uint, uint8_t *p_arr) {
 }
 
 static inline unsigned int encode_double(double p_double, uint8_t *p_arr) {
-	MarshallDouble md;
-	md.d = p_double;
-	encode_uint64(md.l, p_arr);
+	BitCastDouble bitcast = { p_double };
+	encode_uint64(bitcast.i, p_arr);
 
 	return sizeof(uint64_t);
 }
@@ -127,9 +104,8 @@ static inline unsigned int encode_uintr(uintr_t p_uint, uint8_t *p_arr) {
 }
 
 static inline unsigned int encode_real(real_t p_real, uint8_t *p_arr) {
-	MarshallReal mr;
-	mr.r = p_real;
-	encode_uintr(mr.i, p_arr);
+	BitCastReal bitcast = { p_real };
+	encode_uintr(bitcast.i, p_arr);
 
 	return sizeof(uintr_t);
 }
@@ -183,9 +159,9 @@ static inline float decode_half(const uint8_t *p_arr) {
 }
 
 static inline float decode_float(const uint8_t *p_arr) {
-	MarshallFloat mf;
-	mf.i = decode_uint32(p_arr);
-	return mf.f;
+	BitCastFloat bitcast;
+	bitcast.i = decode_uint32(p_arr);
+	return bitcast.f;
 }
 
 static inline uint64_t decode_uint64(const uint8_t *p_arr) {
@@ -202,9 +178,9 @@ static inline uint64_t decode_uint64(const uint8_t *p_arr) {
 }
 
 static inline double decode_double(const uint8_t *p_arr) {
-	MarshallDouble md;
-	md.l = decode_uint64(p_arr);
-	return md.d;
+	BitCastDouble bitcast;
+	bitcast.i = decode_uint64(p_arr);
+	return bitcast.f;
 }
 
 class EncodedObjectAsID : public RefCounted {

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -129,11 +129,9 @@ struct [[nodiscard]] AABB {
 
 	operator String() const;
 
-	_FORCE_INLINE_ AABB() {}
-	inline AABB(const Vector3 &p_pos, const Vector3 &p_size) :
-			position(p_pos),
-			size(p_size) {
-	}
+	constexpr AABB() = default;
+	constexpr AABB(const Vector3 &p_pos, const Vector3 &p_size) :
+			position(p_pos), size(p_size) {}
 };
 
 inline bool AABB::intersects(const AABB &p_aabb) const {

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -204,9 +204,12 @@ struct [[nodiscard]] Basis {
 				rows[0].z * p_m[0].y + rows[1].z * p_m[1].y + rows[2].z * p_m[2].y,
 				rows[0].z * p_m[0].z + rows[1].z * p_m[1].z + rows[2].z * p_m[2].z);
 	}
-	Basis(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz) {
-		set(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz);
-	}
+	constexpr Basis(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz) :
+			rows{
+				{ p_xx, p_xy, p_xz },
+				{ p_yx, p_yy, p_yz },
+				{ p_zx, p_zy, p_zz },
+			} {}
 
 	void orthonormalize();
 	Basis orthonormalized() const;
@@ -230,11 +233,14 @@ struct [[nodiscard]] Basis {
 	Basis(const Vector3 &p_axis, real_t p_angle, const Vector3 &p_scale) { set_axis_angle_scale(p_axis, p_angle, p_scale); }
 	static Basis from_scale(const Vector3 &p_scale);
 
-	_FORCE_INLINE_ Basis(const Vector3 &p_x_axis, const Vector3 &p_y_axis, const Vector3 &p_z_axis) {
-		set_columns(p_x_axis, p_y_axis, p_z_axis);
-	}
+	constexpr Basis(const Vector3 &p_x_axis, const Vector3 &p_y_axis, const Vector3 &p_z_axis) :
+			rows{
+				{ p_x_axis.x, p_y_axis.x, p_z_axis.x },
+				{ p_x_axis.y, p_y_axis.y, p_z_axis.y },
+				{ p_x_axis.z, p_y_axis.z, p_z_axis.z },
+			} {}
 
-	_FORCE_INLINE_ Basis() {}
+	constexpr Basis() = default;
 
 private:
 	// Helper method.

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -52,6 +52,8 @@
 // and pairable_mask is either 0 if static, or set to all if non static
 
 #include "bvh_tree.h"
+
+#include "core/math/geometry_3d.h"
 #include "core/os/mutex.h"
 
 #define BVHTREE_CLASS BVH_Tree<T, NUM_TREES, 2, MAX_ITEMS, USER_PAIR_TEST_FUNCTION, USER_CULL_TEST_FUNCTION, USE_PAIRS, BOUNDS, POINT>
@@ -434,8 +436,6 @@ private:
 			// noop
 			return;
 		}
-
-		BOUNDS bb;
 
 		typename BVHTREE_CLASS::CullParams params;
 

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -31,6 +31,8 @@
 #ifndef BVH_ABB_H
 #define BVH_ABB_H
 
+#include "core/math/aabb.h"
+
 // special optimized version of axis aligned bounding box
 template <typename BOUNDS = AABB, typename POINT = Vector3>
 struct BVH_ABB {

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -41,7 +41,6 @@
 
 #include "core/math/aabb.h"
 #include "core/math/bvh_abb.h"
-#include "core/math/geometry_3d.h"
 #include "core/math/vector3.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/pooled_list.h"
@@ -94,7 +93,7 @@ struct BVHHandle {
 	operator uint32_t() const { return _data; }
 	void set(uint32_t p_value) { _data = p_value; }
 
-	uint32_t _data;
+	uint32_t _data = BVHCommon::INVALID;
 
 	void set_invalid() { _data = BVHCommon::INVALID; }
 	bool is_invalid() const { return _data == BVHCommon::INVALID; }

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -145,21 +145,16 @@ struct [[nodiscard]] Color {
 		// add 15 to it.  When added to the channels, it causes the implicit '1.0'
 		// bit and the first 8 mantissa bits to be shifted down to the low 9 bits
 		// of the mantissa, rounding the truncated bits.
-		union {
-			float f;
-			uint32_t i;
-		} R, G, B, E;
-
-		E.f = MaxChannel;
+		BitCastFloat E = { MaxChannel };
 		E.i += 0x07804000; // Add 15 to the exponent and 0x4000 to the mantissa
 		E.i &= 0x7F800000; // Zero the mantissa
 
 		// This shifts the 9-bit values we need into the lowest bits, rounding as
 		// needed. Note that if the channel has a smaller exponent than the max
 		// channel, it will shift even more.  This is intentional.
-		R.f = _r + E.f;
-		G.f = _g + E.f;
-		B.f = _b + E.f;
+		BitCastFloat R = { _r + E.f };
+		BitCastFloat G = { _g + E.f };
+		BitCastFloat B = { _b + E.f };
 
 		// Convert the Bias to the correct exponent in the upper 5 bits.
 		E.i <<= 4;
@@ -235,40 +230,30 @@ struct [[nodiscard]] Color {
 	_FORCE_INLINE_ void set_ok_hsl_s(float p_s) { set_ok_hsl(get_ok_hsl_h(), p_s, get_ok_hsl_l(), a); }
 	_FORCE_INLINE_ void set_ok_hsl_l(float p_l) { set_ok_hsl(get_ok_hsl_h(), get_ok_hsl_s(), p_l, a); }
 
-	_FORCE_INLINE_ Color() {}
+	constexpr Color() :
+			r(0), g(0), b(0), a(1) {}
 
 	/**
 	 * RGBA construct parameters.
 	 * Alpha is not optional as otherwise we can't bind the RGB version for scripting.
 	 */
-	_FORCE_INLINE_ Color(float p_r, float p_g, float p_b, float p_a) {
-		r = p_r;
-		g = p_g;
-		b = p_b;
-		a = p_a;
-	}
+	constexpr Color(float p_r, float p_g, float p_b, float p_a) :
+			r(p_r), g(p_g), b(p_b), a(p_a) {}
 
 	/**
 	 * RGB construct parameters.
 	 */
-	_FORCE_INLINE_ Color(float p_r, float p_g, float p_b) {
-		r = p_r;
-		g = p_g;
-		b = p_b;
-		a = 1.0f;
-	}
+	constexpr Color(float p_r, float p_g, float p_b) :
+			r(p_r), g(p_g), b(p_b), a(1) {}
 
 	/**
 	 * Construct a Color from another Color, but with the specified alpha value.
 	 */
-	_FORCE_INLINE_ Color(const Color &p_c, float p_a) {
-		r = p_c.r;
-		g = p_c.g;
-		b = p_c.b;
-		a = p_a;
-	}
+	constexpr Color(const Color &p_c, float p_a) :
+			r(p_c.r), g(p_c.g), b(p_c.b), a(p_a) {}
 
-	Color(const String &p_code) {
+	Color(const String &p_code) :
+			Color() {
 		if (html_is_valid(p_code)) {
 			*this = html(p_code);
 		} else {
@@ -276,8 +261,8 @@ struct [[nodiscard]] Color {
 		}
 	}
 
-	Color(const String &p_code, float p_a) {
-		*this = Color(p_code);
+	Color(const String &p_code, float p_a) :
+			Color(p_code) {
 		a = p_a;
 	}
 };

--- a/core/math/color_names.inc
+++ b/core/math/color_names.inc
@@ -34,8 +34,10 @@
 // the old way leaked memory
 // this is not used as often as for more performance to make sense
 
+#include "core/math/color.h"
+
 struct NamedColor {
-	const char *name;
+	const char *name = nullptr;
 	Color color;
 };
 

--- a/core/math/delaunay_2d.h
+++ b/core/math/delaunay_2d.h
@@ -37,9 +37,9 @@
 class Delaunay2D {
 public:
 	struct Triangle {
-		int points[3];
+		int points[3] = {};
 		Vector2 circum_center;
-		real_t circum_radius_squared;
+		real_t circum_radius_squared = 0;
 		Triangle() {}
 		Triangle(int p_a, int p_b, int p_c) {
 			points[0] = p_a;

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -31,14 +31,13 @@
 #ifndef DELAUNAY_3D_H
 #define DELAUNAY_3D_H
 
-#include "core/io/file_access.h"
 #include "core/math/aabb.h"
 #include "core/math/projection.h"
 #include "core/math/vector3.h"
+#include "core/templates/list.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/oa_hash_map.h"
 #include "core/templates/vector.h"
-#include "core/variant/variant.h"
 
 #include "thirdparty/misc/r128.h"
 

--- a/core/math/disjoint_set.h
+++ b/core/math/disjoint_set.h
@@ -31,7 +31,7 @@
 #ifndef DISJOINT_SET_H
 #define DISJOINT_SET_H
 
-#include "core/templates/rb_map.h"
+#include "core/templates/hash_map.h"
 #include "core/templates/vector.h"
 
 /* This DisjointSet class uses Find with path compression and Union by rank */

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -183,7 +183,7 @@ private:
 		Node *parent = nullptr;
 		union {
 			Node *children[2];
-			void *data;
+			void *data = nullptr;
 		};
 
 		_FORCE_INLINE_ bool is_leaf() const { return children[1] == nullptr; }
@@ -215,10 +215,8 @@ private:
 			return axis.dot(volume.get_center() - org) <= 0;
 		}
 
-		Node() {
-			children[0] = nullptr;
-			children[1] = nullptr;
-		}
+		Node() :
+				children{ nullptr, nullptr } {}
 	};
 
 	PagedAllocator<Node> node_allocator;

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -44,7 +44,11 @@ struct [[nodiscard]] Face3 {
 		SIDE_COPLANAR
 	};
 
-	Vector3 vertex[3];
+	Vector3 vertex[3] = {
+		{ 0, 0, 0 },
+		{ 0, 0, 0 },
+		{ 0, 0, 0 },
+	};
 
 	/**
 	 * @param p_plane plane used to split the face
@@ -79,12 +83,9 @@ struct [[nodiscard]] Face3 {
 	_FORCE_INLINE_ bool intersects_aabb2(const AABB &p_aabb) const;
 	operator String() const;
 
-	inline Face3() {}
-	inline Face3(const Vector3 &p_v1, const Vector3 &p_v2, const Vector3 &p_v3) {
-		vertex[0] = p_v1;
-		vertex[1] = p_v2;
-		vertex[2] = p_v3;
-	}
+	constexpr Face3() = default;
+	constexpr Face3(const Vector3 &p_v1, const Vector3 &p_v2, const Vector3 &p_v3) :
+			vertex{ p_v1, p_v2, p_v3 } {}
 };
 
 bool Face3::intersects_aabb2(const AABB &p_aabb) const {

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "geometry_3d.h"
 
+#include "core/templates/hash_map.h"
+
 void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1, Vector3 &r_ps, Vector3 &r_qt) {
 	// Based on David Eberly's Computation of Distance Between Line Segments algorithm.
 

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -33,7 +33,6 @@
 
 #include "core/math/delaunay_3d.h"
 #include "core/math/face3.h"
-#include "core/object/object.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
 
@@ -560,8 +559,8 @@ public:
 		LocalVector<Face> faces;
 
 		struct Edge {
-			int vertex_a, vertex_b;
-			int face_a, face_b;
+			int vertex_a = 0, vertex_b = 0;
+			int face_a = 0, face_b = 0;
 		};
 
 		LocalVector<Edge> edges;

--- a/core/math/math_defs.h
+++ b/core/math/math_defs.h
@@ -31,6 +31,8 @@
 #ifndef MATH_DEFS_H
 #define MATH_DEFS_H
 
+#include "core/typedefs.h"
+
 #define CMP_EPSILON 0.00001
 #define CMP_EPSILON2 (CMP_EPSILON * CMP_EPSILON)
 
@@ -126,15 +128,29 @@ enum class EulerOrder {
 	ZYX
 };
 
+// TODO: Replace BitCast unions with `bit::bit_cast` in C++20.
+
+union BitCastDouble {
+	double f = 0.0;
+	uint64_t i;
+};
+
+union BitCastFloat {
+	float f = 0.0f;
+	uint32_t i;
+};
+
 /**
  * The "Real" type is an abstract type used for real numbers, such as 1.5,
  * in contrast to integer numbers. Precision can be controlled with the
  * presence or absence of the REAL_T_IS_DOUBLE define.
  */
 #ifdef REAL_T_IS_DOUBLE
-typedef double real_t;
+using real_t = double;
+using BitCastReal = BitCastDouble;
 #else
-typedef float real_t;
+using real_t = float;
+using BitCastReal = BitCastFloat;
 #endif
 
 #endif // MATH_DEFS_H

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -80,12 +80,12 @@ struct [[nodiscard]] Plane {
 	_FORCE_INLINE_ bool operator!=(const Plane &p_plane) const;
 	operator String() const;
 
-	_FORCE_INLINE_ Plane() {}
-	_FORCE_INLINE_ Plane(real_t p_a, real_t p_b, real_t p_c, real_t p_d) :
-			normal(p_a, p_b, p_c),
-			d(p_d) {}
+	constexpr Plane() = default;
+	constexpr Plane(real_t p_a, real_t p_b, real_t p_c, real_t p_d) :
+			normal(p_a, p_b, p_c), d(p_d) {}
+	constexpr Plane(const Vector3 &p_normal, real_t p_d = 0.0) :
+			normal(p_normal), d(p_d) {}
 
-	_FORCE_INLINE_ Plane(const Vector3 &p_normal, real_t p_d = 0.0);
 	_FORCE_INLINE_ Plane(const Vector3 &p_normal, const Vector3 &p_point);
 	_FORCE_INLINE_ Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_point3, ClockDirection p_dir = CLOCKWISE);
 };
@@ -102,11 +102,6 @@ bool Plane::has_point(const Vector3 &p_point, real_t p_tolerance) const {
 	real_t dist = normal.dot(p_point) - d;
 	dist = ABS(dist);
 	return (dist <= p_tolerance);
-}
-
-Plane::Plane(const Vector3 &p_normal, real_t p_d) :
-		normal(p_normal),
-		d(p_d) {
 }
 
 Plane::Plane(const Vector3 &p_normal, const Vector3 &p_point) :

--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -827,10 +827,6 @@ void Projection::flip_y() {
 	}
 }
 
-Projection::Projection() {
-	set_identity();
-}
-
 Projection Projection::operator*(const Projection &p_matrix) const {
 	Projection new_matrix;
 
@@ -1028,13 +1024,6 @@ Projection::operator Transform3D() const {
 	return tr;
 }
 
-Projection::Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w) {
-	columns[0] = p_x;
-	columns[1] = p_y;
-	columns[2] = p_z;
-	columns[3] = p_w;
-}
-
 Projection::Projection(const Transform3D &p_transform) {
 	const Transform3D &tr = p_transform;
 	real_t *m = &columns[0][0];
@@ -1055,7 +1044,4 @@ Projection::Projection(const Transform3D &p_transform) {
 	m[13] = tr.origin.y;
 	m[14] = tr.origin.z;
 	m[15] = 1.0;
-}
-
-Projection::~Projection() {
 }

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -53,7 +53,12 @@ struct [[nodiscard]] Projection {
 		PLANE_BOTTOM
 	};
 
-	Vector4 columns[4];
+	Vector4 columns[4] = {
+		{ 1, 0, 0, 0 },
+		{ 0, 1, 0, 0 },
+		{ 0, 0, 1, 0 },
+		{ 0, 0, 0, 1 },
+	};
 
 	_FORCE_INLINE_ const Vector4 &operator[](int p_axis) const {
 		DEV_ASSERT((unsigned int)p_axis < 4);
@@ -150,10 +155,10 @@ struct [[nodiscard]] Projection {
 
 	real_t get_lod_multiplier() const;
 
-	Projection();
-	Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w);
+	constexpr Projection() = default;
+	constexpr Projection(const Vector4 &p_x, const Vector4 &p_y, const Vector4 &p_z, const Vector4 &p_w) :
+			columns{ p_x, p_y, p_z, p_w } {}
 	Projection(const Transform3D &p_transform);
-	~Projection();
 };
 
 Vector3 Projection::xform(const Vector3 &p_vec3) const {

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -160,7 +160,7 @@ Quaternion Quaternion::slerpni(const Quaternion &p_to, real_t p_weight) const {
 
 	real_t dot = from.dot(p_to);
 
-	if (Math::absf(dot) > 0.9999f) {
+	if (Math::abs(dot) > 0.9999f) {
 		return from;
 	}
 

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -115,23 +115,16 @@ struct [[nodiscard]] Quaternion {
 
 	operator String() const;
 
-	_FORCE_INLINE_ Quaternion() {}
+	constexpr Quaternion() :
+			x(0), y(0), z(0), w(1) {}
 
-	_FORCE_INLINE_ Quaternion(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
-			x(p_x),
-			y(p_y),
-			z(p_z),
-			w(p_w) {
-	}
+	constexpr Quaternion(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
+			x(p_x), y(p_y), z(p_z), w(p_w) {}
 
 	Quaternion(const Vector3 &p_axis, real_t p_angle);
 
-	Quaternion(const Quaternion &p_q) :
-			x(p_q.x),
-			y(p_q.y),
-			z(p_q.z),
-			w(p_q.w) {
-	}
+	constexpr Quaternion(const Quaternion &p_q) :
+			x(p_q.x), y(p_q.y), z(p_q.z), w(p_q.w) {}
 
 	void operator=(const Quaternion &p_q) {
 		x = p_q.x;

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -30,6 +30,9 @@
 
 #include "quick_hull.h"
 
+#include "core/templates/hash_map.h"
+#include "core/templates/hash_set.h"
+
 uint32_t QuickHull::debug_stop_after = 0xFFFFFFFF;
 
 Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_mesh) {

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -361,15 +361,11 @@ struct [[nodiscard]] Rect2 {
 	operator String() const;
 	operator Rect2i() const;
 
-	Rect2() {}
-	Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :
-			position(Point2(p_x, p_y)),
-			size(Size2(p_width, p_height)) {
-	}
-	Rect2(const Point2 &p_pos, const Size2 &p_size) :
-			position(p_pos),
-			size(p_size) {
-	}
+	constexpr Rect2() = default;
+	constexpr Rect2(real_t p_x, real_t p_y, real_t p_width, real_t p_height) :
+			position(Point2(p_x, p_y)), size(Size2(p_width, p_height)) {}
+	constexpr Rect2(const Point2 &p_pos, const Size2 &p_size) :
+			position(p_pos), size(p_size) {}
 };
 
 #endif // RECT2_H

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -227,15 +227,11 @@ struct [[nodiscard]] Rect2i {
 	operator String() const;
 	operator Rect2() const;
 
-	Rect2i() {}
-	Rect2i(int p_x, int p_y, int p_width, int p_height) :
-			position(Point2i(p_x, p_y)),
-			size(Size2i(p_width, p_height)) {
-	}
-	Rect2i(const Point2i &p_pos, const Size2i &p_size) :
-			position(p_pos),
-			size(p_size) {
-	}
+	constexpr Rect2i() = default;
+	constexpr Rect2i(int32_t p_x, int32_t p_y, int32_t p_width, int32_t p_height) :
+			position(Point2i(p_x, p_y)), size(Size2i(p_width, p_height)) {}
+	constexpr Rect2i(const Point2i &p_pos, const Size2i &p_size) :
+			position(p_pos), size(p_size) {}
 };
 
 #endif // RECT2I_H

--- a/core/math/static_raycaster.h
+++ b/core/math/static_raycaster.h
@@ -33,16 +33,6 @@
 
 #include "core/object/ref_counted.h"
 
-#if !defined(__aligned)
-
-#if defined(_WIN32) && defined(_MSC_VER)
-#define __aligned(...) __declspec(align(__VA_ARGS__))
-#else
-#define __aligned(...) __attribute__((aligned(__VA_ARGS__)))
-#endif
-
-#endif
-
 class StaticRaycaster : public RefCounted {
 	GDCLASS(StaticRaycaster, RefCounted)
 protected:
@@ -50,7 +40,7 @@ protected:
 
 public:
 	// Compatible with embree4 rays.
-	struct __aligned(16) Ray {
+	struct alignas(16) Ray {
 		const static unsigned int INVALID_GEOMETRY_ID = ((unsigned int)-1); // from rtcore_common.h
 
 		/*! Default construction does nothing. */

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -53,7 +53,11 @@ struct [[nodiscard]] Transform2D {
 	// WARNING: Be aware that unlike 3D code, 2D code uses a left-handed coordinate system:
 	// Y-axis points down, and angle is measure from +X to +Y in a clockwise-fashion.
 
-	Vector2 columns[3];
+	Vector2 columns[3] = {
+		{ 1, 0 },
+		{ 0, 1 },
+		{ 0, 0 },
+	};
 
 	_FORCE_INLINE_ real_t tdotx(const Vector2 &p_v) const { return columns[0][0] * p_v.x + columns[1][0] * p_v.y; }
 	_FORCE_INLINE_ real_t tdoty(const Vector2 &p_v) const { return columns[0][1] * p_v.x + columns[1][1] * p_v.y; }
@@ -128,29 +132,21 @@ struct [[nodiscard]] Transform2D {
 
 	operator String() const;
 
-	Transform2D(real_t p_xx, real_t p_xy, real_t p_yx, real_t p_yy, real_t p_ox, real_t p_oy) {
-		columns[0][0] = p_xx;
-		columns[0][1] = p_xy;
-		columns[1][0] = p_yx;
-		columns[1][1] = p_yy;
-		columns[2][0] = p_ox;
-		columns[2][1] = p_oy;
-	}
+	constexpr Transform2D(real_t p_xx, real_t p_xy, real_t p_yx, real_t p_yy, real_t p_ox, real_t p_oy) :
+			columns{
+				{ p_xx, p_xy },
+				{ p_yx, p_yy },
+				{ p_ox, p_oy },
+			} {}
 
-	Transform2D(const Vector2 &p_x, const Vector2 &p_y, const Vector2 &p_origin) {
-		columns[0] = p_x;
-		columns[1] = p_y;
-		columns[2] = p_origin;
-	}
+	constexpr Transform2D(const Vector2 &p_x, const Vector2 &p_y, const Vector2 &p_origin) :
+			columns{ p_x, p_y, p_origin } {}
 
 	Transform2D(real_t p_rot, const Vector2 &p_pos);
 
 	Transform2D(real_t p_rot, const Size2 &p_scale, real_t p_skew, const Vector2 &p_pos);
 
-	Transform2D() {
-		columns[0][0] = 1.0;
-		columns[1][1] = 1.0;
-	}
+	constexpr Transform2D() = default;
 };
 
 Vector2 Transform2D::basis_xform(const Vector2 &p_vec) const {

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -224,20 +224,3 @@ Transform3D::operator String() const {
 			", Z: " + basis.get_column(2).operator String() +
 			", O: " + origin.operator String() + "]";
 }
-
-Transform3D::Transform3D(const Basis &p_basis, const Vector3 &p_origin) :
-		basis(p_basis),
-		origin(p_origin) {
-}
-
-Transform3D::Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin) :
-		origin(p_origin) {
-	basis.set_column(0, p_x);
-	basis.set_column(1, p_y);
-	basis.set_column(2, p_z);
-}
-
-Transform3D::Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz) {
-	basis = Basis(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz);
-	origin = Vector3(p_ox, p_oy, p_oz);
-}

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -124,10 +124,14 @@ struct [[nodiscard]] Transform3D {
 
 	operator String() const;
 
-	Transform3D() {}
-	Transform3D(const Basis &p_basis, const Vector3 &p_origin = Vector3());
-	Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin);
-	Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz);
+	constexpr Transform3D() = default;
+	constexpr Transform3D(const Basis &p_basis, const Vector3 &p_origin = Vector3()) :
+			basis(p_basis), origin(p_origin) {}
+	constexpr Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin) :
+			basis(p_x, p_y, p_z), origin(p_origin) {}
+	constexpr Transform3D(real_t p_xx, real_t p_xy, real_t p_xz, real_t p_yx, real_t p_yy, real_t p_yz, real_t p_zx, real_t p_zy, real_t p_zz, real_t p_ox, real_t p_oy, real_t p_oz) :
+			basis(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz),
+			origin(p_ox, p_oy, p_oz) {}
 };
 
 _FORCE_INLINE_ Vector3 Transform3D::xform(const Vector3 &p_vector) const {

--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -40,8 +40,8 @@ class TriangleMesh : public RefCounted {
 public:
 	struct Triangle {
 		Vector3 normal;
-		int indices[3];
-		int32_t surface_index;
+		int indices[3] = {};
+		int32_t surface_index = 0;
 	};
 
 private:
@@ -51,10 +51,10 @@ private:
 	struct BVH {
 		AABB aabb;
 		Vector3 center; //used for sorting
-		int left;
-		int right;
+		int left = 0;
+		int right = 0;
 
-		int face_index;
+		int face_index = 0;
 	};
 
 	struct BVHCmpX {

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -184,11 +184,10 @@ struct [[nodiscard]] Vector2 {
 	operator String() const;
 	operator Vector2i() const;
 
-	_FORCE_INLINE_ Vector2() {}
-	_FORCE_INLINE_ Vector2(real_t p_x, real_t p_y) {
-		x = p_x;
-		y = p_y;
-	}
+	constexpr Vector2() :
+			x(0), y(0) {}
+	constexpr Vector2(real_t p_x, real_t p_y) :
+			x(p_x), y(p_y) {}
 };
 
 _FORCE_INLINE_ Vector2 Vector2::plane_project(real_t p_d, const Vector2 &p_vec) const {

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -142,11 +142,10 @@ struct [[nodiscard]] Vector2i {
 	operator String() const;
 	operator Vector2() const;
 
-	inline Vector2i() {}
-	inline Vector2i(int32_t p_x, int32_t p_y) {
-		x = p_x;
-		y = p_y;
-	}
+	constexpr Vector2i() :
+			x(0), y(0) {}
+	constexpr Vector2i(int32_t p_x, int32_t p_y) :
+			x(p_x), y(p_y) {}
 };
 
 // Multiplication operators required to workaround issues with LLVM using implicit conversion.

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -187,12 +187,10 @@ struct [[nodiscard]] Vector3 {
 	operator String() const;
 	operator Vector3i() const;
 
-	_FORCE_INLINE_ Vector3() {}
-	_FORCE_INLINE_ Vector3(real_t p_x, real_t p_y, real_t p_z) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-	}
+	constexpr Vector3() :
+			x(0), y(0), z(0) {}
+	constexpr Vector3(real_t p_x, real_t p_y, real_t p_z) :
+			x(p_x), y(p_y), z(p_z) {}
 };
 
 Vector3 Vector3::cross(const Vector3 &p_with) const {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -132,12 +132,10 @@ struct [[nodiscard]] Vector3i {
 	operator String() const;
 	operator Vector3() const;
 
-	_FORCE_INLINE_ Vector3i() {}
-	_FORCE_INLINE_ Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-	}
+	constexpr Vector3i() :
+			x(0), y(0), z(0) {}
+	constexpr Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) :
+			x(p_x), y(p_y), z(p_z) {}
 };
 
 int64_t Vector3i::length_squared() const {

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -144,13 +144,10 @@ struct [[nodiscard]] Vector4 {
 	operator String() const;
 	operator Vector4i() const;
 
-	_FORCE_INLINE_ Vector4() {}
-	_FORCE_INLINE_ Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-		w = p_w;
-	}
+	constexpr Vector4() :
+			x(0), y(0), z(0), w(0) {}
+	constexpr Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
+			x(p_x), y(p_y), z(p_z), w(p_w) {}
 };
 
 real_t Vector4::dot(const Vector4 &p_vec4) const {

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -134,14 +134,11 @@ struct [[nodiscard]] Vector4i {
 	operator String() const;
 	operator Vector4() const;
 
-	_FORCE_INLINE_ Vector4i() {}
+	constexpr Vector4i() :
+			x(0), y(0), z(0), w(0) {}
 	Vector4i(const Vector4 &p_vec4);
-	_FORCE_INLINE_ Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) {
-		x = p_x;
-		y = p_y;
-		z = p_z;
-		w = p_w;
-	}
+	constexpr Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) :
+			x(p_x), y(p_y), z(p_z), w(p_w) {}
 };
 
 int64_t Vector4i::length_squared() const {

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -33,11 +33,11 @@
 
 #include "core/object/method_bind.h"
 #include "core/object/object.h"
-#include "core/string/print_string.h"
+#include "core/string/print_string.h" // IWYU pragma: export
 
 // Makes callable_mp readily available in all classes connecting signals.
 // Needs to come after method_bind and object have been included.
-#include "core/object/callable_method_pointer.h"
+#include "core/object/callable_method_pointer.h" // IWYU pragma: export
 #include "core/templates/hash_set.h"
 
 #include <type_traits>
@@ -561,6 +561,6 @@ _FORCE_INLINE_ Vector<Error> errarray(P... p_args) {
 
 #define GDREGISTER_NATIVE_STRUCT(m_class, m_code) ClassDB::register_native_struct(#m_class, m_code, sizeof(m_class))
 
-#include "core/disabled_classes.gen.h"
+#include "core/disabled_classes.gen.h" // IWYU pragma: export
 
 #endif // CLASS_DB_H

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -31,11 +31,8 @@
 #ifndef HASH_SET_H
 #define HASH_SET_H
 
-#include "core/math/math_funcs.h"
 #include "core/os/memory.h"
-#include "core/templates/hash_map.h"
 #include "core/templates/hashfuncs.h"
-#include "core/templates/paged_allocator.h"
 
 /**
  * Implementation of Set using a bidi indexed hash map.

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -137,21 +137,18 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_one_32(uint32_t p_in, uint32_t p_see
 }
 
 static _FORCE_INLINE_ uint32_t hash_murmur3_one_float(float p_in, uint32_t p_seed = HASH_MURMUR3_SEED) {
-	union {
-		float f;
-		uint32_t i;
-	} u;
+	BitCastFloat bitcast;
 
 	// Normalize +/- 0.0 and NaN values so they hash the same.
 	if (p_in == 0.0f) {
-		u.f = 0.0;
+		bitcast.f = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.f = NAN;
+		bitcast.f = NAN;
 	} else {
-		u.f = p_in;
+		bitcast.f = p_in;
 	}
 
-	return hash_murmur3_one_32(u.i, p_seed);
+	return hash_murmur3_one_32(bitcast.i, p_seed);
 }
 
 static _FORCE_INLINE_ uint32_t hash_murmur3_one_64(uint64_t p_in, uint32_t p_seed = HASH_MURMUR3_SEED) {
@@ -160,21 +157,18 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_one_64(uint64_t p_in, uint32_t p_see
 }
 
 static _FORCE_INLINE_ uint32_t hash_murmur3_one_double(double p_in, uint32_t p_seed = HASH_MURMUR3_SEED) {
-	union {
-		double d;
-		uint64_t i;
-	} u;
+	BitCastDouble bitcast;
 
 	// Normalize +/- 0.0 and NaN values so they hash the same.
 	if (p_in == 0.0f) {
-		u.d = 0.0;
+		bitcast.f = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.d = NAN;
+		bitcast.f = NAN;
 	} else {
-		u.d = p_in;
+		bitcast.f = p_in;
 	}
 
-	return hash_murmur3_one_64(u.i, p_seed);
+	return hash_murmur3_one_64(bitcast.i, p_seed);
 }
 
 static _FORCE_INLINE_ uint32_t hash_murmur3_one_real(real_t p_in, uint32_t p_seed = HASH_MURMUR3_SEED) {
@@ -248,50 +242,43 @@ static _FORCE_INLINE_ uint32_t hash_murmur3_buffer(const void *key, int length, 
 }
 
 static _FORCE_INLINE_ uint32_t hash_djb2_one_float(double p_in, uint32_t p_prev = 5381) {
-	union {
-		double d;
-		uint64_t i;
-	} u;
+	BitCastDouble bitcast;
 
 	// Normalize +/- 0.0 and NaN values so they hash the same.
 	if (p_in == 0.0f) {
-		u.d = 0.0;
+		bitcast.f = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.d = NAN;
+		bitcast.f = NAN;
 	} else {
-		u.d = p_in;
+		bitcast.f = p_in;
 	}
 
-	return ((p_prev << 5) + p_prev) + hash_one_uint64(u.i);
+	return ((p_prev << 5) + p_prev) + hash_one_uint64(bitcast.i);
 }
 
 template <typename T>
 static _FORCE_INLINE_ uint32_t hash_make_uint32_t(T p_in) {
 	union {
 		T t;
-		uint32_t _u32;
+		uint32_t _u32 = 0;
 	} _u;
-	_u._u32 = 0;
 	_u.t = p_in;
 	return _u._u32;
 }
 
 static _FORCE_INLINE_ uint64_t hash_djb2_one_float_64(double p_in, uint64_t p_prev = 5381) {
-	union {
-		double d;
-		uint64_t i;
-	} u;
+	BitCastDouble bitcast;
 
 	// Normalize +/- 0.0 and NaN values so they hash the same.
 	if (p_in == 0.0f) {
-		u.d = 0.0;
+		bitcast.f = 0.0;
 	} else if (Math::is_nan(p_in)) {
-		u.d = NAN;
+		bitcast.f = NAN;
 	} else {
-		u.d = p_in;
+		bitcast.f = p_in;
 	}
 
-	return ((p_prev << 5) + p_prev) + u.i;
+	return ((p_prev << 5) + p_prev) + bitcast.i;
 }
 
 static _FORCE_INLINE_ uint64_t hash_djb2_one_64(uint64_t p_in, uint64_t p_prev = 5381) {
@@ -302,10 +289,8 @@ template <typename T>
 static _FORCE_INLINE_ uint64_t hash_make_uint64_t(T p_in) {
 	union {
 		T t;
-		uint64_t _u64;
+		uint64_t _u64 = 0;
 	} _u;
-	_u._u64 = 0; // in case p_in is smaller
-
 	_u.t = p_in;
 	return _u._u64;
 }

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -280,7 +280,7 @@ public:
 	}
 
 	void sort() {
-		sort_custom<_DefaultComparator<T>>();
+		sort_custom<Comparator<T>>();
 	}
 
 	void ordered_insert(T p_val) {

--- a/core/templates/lru.h
+++ b/core/templates/lru.h
@@ -31,7 +31,6 @@
 #ifndef LRU_H
 #define LRU_H
 
-#include "core/math/math_funcs.h"
 #include "hash_map.h"
 #include "list.h"
 

--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -31,7 +31,6 @@
 #ifndef OA_HASH_MAP_H
 #define OA_HASH_MAP_H
 
-#include "core/math/math_funcs.h"
 #include "core/os/memory.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/pair.h"
@@ -308,13 +307,13 @@ public:
 	}
 
 	struct Iterator {
-		bool valid;
+		bool valid = false;
 
-		const TKey *key;
+		const TKey *key = nullptr;
 		TValue *value = nullptr;
 
 	private:
-		uint32_t pos;
+		uint32_t pos = 0;
 		friend class OAHashMap;
 	};
 

--- a/core/templates/paged_allocator.h
+++ b/core/templates/paged_allocator.h
@@ -38,7 +38,7 @@
 #include "core/typedefs.h"
 
 #include <type_traits>
-#include <typeinfo>
+#include <typeinfo> // IWYU pragma: keep // Used in macro.
 
 template <typename T, bool thread_safe = false, uint32_t DEFAULT_PAGE_SIZE = 4096>
 class PagedAllocator {

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -39,7 +39,7 @@
 #include "core/templates/safe_refcount.h"
 
 #include <stdio.h>
-#include <typeinfo>
+#include <typeinfo> // IWYU pragma: keep // Used in macro.
 
 #ifdef SANITIZERS_ENABLED
 #ifdef __has_feature

--- a/core/templates/safe_list.h
+++ b/core/templates/safe_list.h
@@ -37,7 +37,6 @@
 #include <atomic>
 #include <functional>
 #include <initializer_list>
-#include <type_traits>
 
 // Design goals for these classes:
 // - Accessing this list with an iterator will never result in a use-after free,

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -38,7 +38,7 @@
 #endif
 
 #include <atomic>
-#include <type_traits>
+#include <type_traits> // IWYU pragma: keep // Used in macros.
 
 // Design goals for these classes:
 // - No automatic conversions or arithmetic operators,

--- a/core/templates/search_array.h
+++ b/core/templates/search_array.h
@@ -33,10 +33,10 @@
 
 #include <core/templates/sort_array.h>
 
-template <typename T, typename Comparator = _DefaultComparator<T>>
+template <typename T, typename Comparator = Comparator<T>>
 class SearchArray {
 public:
-	Comparator compare;
+	Comparator compare{};
 
 	inline int64_t bisect(const T *p_array, int64_t p_len, const T &p_value, bool p_before) const {
 		int64_t lo = 0;

--- a/core/templates/sort_array.h
+++ b/core/templates/sort_array.h
@@ -40,25 +40,20 @@
 		break;                                                        \
 	}
 
-template <typename T>
-struct _DefaultComparator {
-	_FORCE_INLINE_ bool operator()(const T &a, const T &b) const { return (a < b); }
-};
-
 #ifdef DEBUG_ENABLED
 #define SORT_ARRAY_VALIDATE_ENABLED true
 #else
 #define SORT_ARRAY_VALIDATE_ENABLED false
 #endif
 
-template <typename T, typename Comparator = _DefaultComparator<T>, bool Validate = SORT_ARRAY_VALIDATE_ENABLED>
+template <typename T, typename Comparator = Comparator<T>, bool Validate = SORT_ARRAY_VALIDATE_ENABLED>
 class SortArray {
 	enum {
 		INTROSORT_THRESHOLD = 16
 	};
 
 public:
-	Comparator compare;
+	Comparator compare{};
 
 	inline const T &median_of_3(const T &a, const T &b, const T &c) const {
 		if (compare(a, b)) {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -40,12 +40,11 @@
  */
 
 #include "core/error/error_macros.h"
-#include "core/os/memory.h"
 #include "core/templates/cowdata.h"
 #include "core/templates/search_array.h"
 #include "core/templates/sort_array.h"
+#include "core/typedefs.h"
 
-#include <climits>
 #include <initializer_list>
 #include <utility>
 
@@ -109,7 +108,7 @@ public:
 	_FORCE_INLINE_ bool has(const T &p_val) const { return find(p_val) != -1; }
 
 	void sort() {
-		sort_custom<_DefaultComparator<T>>();
+		sort_custom<Comparator<T>>();
 	}
 
 	template <typename Comparator, bool Validate = SORT_ARRAY_VALIDATE_ENABLED, typename... Args>
@@ -125,7 +124,7 @@ public:
 	}
 
 	Size bsearch(const T &p_value, bool p_before) {
-		return bsearch_custom<_DefaultComparator<T>>(p_value, p_before);
+		return bsearch_custom<Comparator<T>>(p_value, p_before);
 	}
 
 	template <typename Comparator, typename Value, typename... Args>

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -31,19 +31,24 @@
 #ifndef TYPEDEFS_H
 #define TYPEDEFS_H
 
-#include <stddef.h>
-
 /**
  * Basic definitions and simple functions to be used everywhere.
  */
+
+// IWYU pragma: always_keep
+// IWYU pragma: begin_exports
 
 // Include first in case the platform needs to pre-define/include some things.
 #include "platform_config.h"
 
 // Should be available everywhere.
 #include "core/error/error_list.h"
+
+#include <cstddef>
 #include <cstdint>
 #include <utility>
+
+// IWYU pragma: end_exports
 
 // Ensure that C++ standard is at least C++17. If on MSVC, also ensures that the `Zc:__cplusplus` flag is present.
 static_assert(__cplusplus >= 201703L);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -247,7 +247,7 @@ Variant VariantUtilityFunctions::abs(const Variant &x, Callable::CallError &r_er
 			return ABS(VariantInternalAccessor<int64_t>::get(&x));
 		} break;
 		case Variant::FLOAT: {
-			return Math::absd(VariantInternalAccessor<double>::get(&x));
+			return Math::abs(VariantInternalAccessor<double>::get(&x));
 		} break;
 		case Variant::VECTOR2: {
 			return VariantInternalAccessor<Vector2>::get(&x).abs();
@@ -277,7 +277,7 @@ Variant VariantUtilityFunctions::abs(const Variant &x, Callable::CallError &r_er
 }
 
 double VariantUtilityFunctions::absf(double x) {
-	return Math::absd(x);
+	return Math::abs(x);
 }
 
 int64_t VariantUtilityFunctions::absi(int64_t x) {

--- a/core/version.h
+++ b/core/version.h
@@ -31,7 +31,7 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#include "core/version_generated.gen.h"
+#include "core/version_generated.gen.h" // IWYU pragma: export
 
 #include <stdint.h>
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1520,7 +1520,7 @@ void EditorPropertyEasing::_drag_easing(const Ref<InputEvent> &p_ev) {
 
 		float val = get_edited_property_value();
 		bool sg = val < 0;
-		val = Math::absf(val);
+		val = Math::abs(val);
 
 		val = Math::log(val) / Math::log((float)2.0);
 		// Logarithmic space.

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -208,7 +208,6 @@ Vector<float> Collada::AnimationTrack::get_value_at_time(float p_time) const {
 
 				Vector<float> ret;
 				ret.resize(16);
-				Transform3D tr;
 				// i wonder why collada matrices are transposed, given that's opposed to opengl..
 				ret.write[0] = interp.basis.rows[0][0];
 				ret.write[1] = interp.basis.rows[0][1];

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4870,7 +4870,6 @@ void CanvasItemEditor::_set_owner_for_node_and_children(Node *p_node, Node *p_ow
 }
 
 void CanvasItemEditor::_focus_selection(int p_op) {
-	Vector2 center(0.f, 0.f);
 	Rect2 rect;
 	int count = 0;
 

--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
@@ -204,7 +204,6 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 			Vector3 right, up;
 			Vector3 back(0, 0, -1.0);
-			Vector3 front(0, 0, 0);
 
 			if (aspect == Camera3D::KeepAspect::KEEP_WIDTH) {
 				right = Vector3(keep_size, 0, 0);

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -475,7 +475,7 @@ void Polygon3DEditor::_polygon_draw() {
 		va.resize(poly.size());
 		Vector3 *w = va.ptrw();
 		for (int i = 0; i < poly.size(); i++) {
-			Vector2 p, p2;
+			Vector2 p;
 			p = i == edited_point ? edited_point_pos : poly[i];
 
 			Vector3 point = Vector3(p.x, p.y, depth);

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -755,7 +755,7 @@ bool GodotCylinderShape3D::intersect_point(const Vector3 &p_point) const {
 }
 
 Vector3 GodotCylinderShape3D::get_closest_point_to(const Vector3 &p_point) const {
-	if (Math::absf(p_point.y) > height * 0.5) {
+	if (Math::abs(p_point.y) > height * 0.5) {
 		// Project point to top disk.
 		real_t dir = p_point.y > 0.0 ? 1.0 : -1.0;
 		Vector3 circle_pos(0.0, dir * height * 0.5, 0.0);

--- a/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp
@@ -112,7 +112,7 @@ bool GodotConeTwistJoint3D::setup(real_t p_timestep) {
 	}
 
 	Vector3 b1Axis1, b1Axis2, b1Axis3;
-	Vector3 b2Axis1, b2Axis2;
+	Vector3 b2Axis1;
 
 	b1Axis1 = A->get_transform().basis.xform(m_rbAFrame.basis.get_column(0));
 	b2Axis1 = B->get_transform().basis.xform(m_rbBFrame.basis.get_column(0));

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -135,7 +135,6 @@ void MobileVRInterface::set_position_from_sensors() {
 	// few things we need
 	Input *input = Input::get_singleton();
 	Vector3 down(0.0, -1.0, 0.0); // Down is Y negative
-	Vector3 north(0.0, 0.0, 1.0); // North is Z positive
 
 	// make copies of our inputs
 	bool has_grav = false;

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2803,8 +2803,6 @@ Transform3D OpenXRAPI::transform_from_pose(const XrPosef &p_pose) {
 
 template <typename T>
 XRPose::TrackingConfidence _transform_from_location(const T &p_location, Transform3D &r_transform) {
-	Basis basis;
-	Vector3 origin;
 	XRPose::TrackingConfidence confidence = XRPose::XR_TRACKING_CONFIDENCE_NONE;
 	const XrPosef &pose = p_location.pose;
 

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -78,7 +78,6 @@ enum StartupStep {
 
 static SafeNumeric<int> step; // Shared between UI and render threads
 
-static Size2 new_size;
 static Vector3 accelerometer;
 static Vector3 gravity;
 static Vector3 magnetometer;

--- a/scene/3d/lightmapper.h
+++ b/scene/3d/lightmapper.h
@@ -35,16 +35,6 @@
 
 class Image;
 
-#if !defined(__aligned)
-
-#if defined(_WIN32) && defined(_MSC_VER)
-#define __aligned(...) __declspec(align(__VA_ARGS__))
-#else
-#define __aligned(...) __attribute__((aligned(__VA_ARGS__)))
-#endif
-
-#endif
-
 class LightmapDenoiser : public RefCounted {
 	GDCLASS(LightmapDenoiser, RefCounted)
 protected:
@@ -62,7 +52,7 @@ protected:
 
 public:
 	// Compatible with embree4 rays.
-	struct __aligned(16) Ray {
+	struct alignas(16) Ray {
 		const static unsigned int INVALID_GEOMETRY_ID = ((unsigned int)-1); // from rtcore_common.h
 
 		/*! Default construction does nothing. */

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -285,7 +285,7 @@ void AnimationPlayer::_blend_playback_data(double p_delta, bool p_started) {
 	List<List<Blend>::Element *> to_erase;
 	for (List<Blend>::Element *E = c.blend.front(); E; E = E->next()) {
 		Blend &b = E->get();
-		b.blend_left = MAX(0, b.blend_left - Math::absf(speed_scale * p_delta) / b.blend_time);
+		b.blend_left = MAX(0, b.blend_left - Math::abs(speed_scale * p_delta) / b.blend_time);
 		if (Animation::is_less_or_equal_approx(b.blend_left, 0)) {
 			to_erase.push_back(E);
 			b.blend_left = CMP_EPSILON; // May want to play last frame.

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -666,7 +666,6 @@ void Label::_notification(int p_what) {
 
 			bool has_settings = settings.is_valid();
 
-			Size2 string_size;
 			Ref<StyleBox> style = theme_cache.normal_style;
 			Ref<Font> font = (settings.is_valid() && settings->get_font().is_valid()) ? settings->get_font() : theme_cache.font;
 			int font_size = settings.is_valid() ? settings->get_font_size() : theme_cache.font_size;

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -370,13 +370,13 @@ static float perpendicular_distance(const Vector2 &i, const Vector2 &start, cons
 	float intercept;
 
 	if (start.x == end.x) {
-		res = Math::absf(i.x - end.x);
+		res = Math::abs(i.x - end.x);
 	} else if (start.y == end.y) {
-		res = Math::absf(i.y - end.y);
+		res = Math::abs(i.y - end.y);
 	} else {
 		slope = (end.y - start.y) / (end.x - start.x);
 		intercept = start.y - (slope * start.x);
-		res = Math::absf(slope * i.x - i.y + intercept) / Math::sqrt(Math::pow(slope, 2.0f) + 1.0);
+		res = Math::abs(slope * i.x - i.y + intercept) / Math::sqrt(Math::pow(slope, 2.0f) + 1.0);
 	}
 	return res;
 }
@@ -523,7 +523,6 @@ static void fill_bits(const BitMap *p_src, Ref<BitMap> &p_map, const Point2i &p_
 Vector<Vector<Vector2>> BitMap::clip_opaque_to_polygons(const Rect2i &p_rect, float p_epsilon) const {
 	Rect2i r = Rect2i(0, 0, width, height).intersection(p_rect);
 
-	Point2i from;
 	Ref<BitMap> fill;
 	fill.instantiate();
 	fill->create(get_size());

--- a/tests/core/math/test_projection.h
+++ b/tests/core/math/test_projection.h
@@ -183,12 +183,6 @@ TEST_CASE("[Projection] Vector transformation") {
 			Vector4(4, 7, 11, 15),
 			Vector4(4, 8, 12, 16));
 
-	Projection inverse(
-			Vector4(-4.0 / 12, 0, 1, -8.0 / 12),
-			Vector4(8.0 / 12, -1, -1, 16.0 / 12),
-			Vector4(-20.0 / 12, 2, -1, 5.0 / 12),
-			Vector4(1, -1, 1, -0.75));
-
 	Vector4 vec4(1, 2, 3, 4);
 	CHECK(proj.xform(vec4).is_equal_approx(Vector4(33, 70, 112, 152)));
 	CHECK(proj.xform_inv(vec4).is_equal_approx(Vector4(90, 107, 111, 120)));


### PR DESCRIPTION
- Followup to #100828
- Supersedes #92059

A simple, initial pass of common headers through the new intellisense provided by `.clangd`. Mostly adding forward-declares & adding suppression wrappers (with comments) where appropriate. This'll be our first steps to slowly, but surely, cleanup header noise by only including what's absolutely necessary.