### PR TITLE
CameraFeed: Add `set_format` and `get_formats` virtual binds

### DIFF
--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -23,6 +23,20 @@
 				Called when the camera feed is deactivated.
 			</description>
 		</method>
+		<method name="_get_formats" qualifiers="virtual const">
+			<return type="Array" />
+			<description>
+				Override this method to define supported formats of the camera feed.
+			</description>
+		</method>
+		<method name="_set_format" qualifiers="virtual">
+			<return type="bool" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="parameters" type="Dictionary" />
+			<description>
+				Override this method to set the format of the camera feed.
+			</description>
+		</method>
 		<method name="get_datatype" qualifiers="const">
 			<return type="int" enum="CameraFeed.FeedDataType" />
 			<description>

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -61,6 +61,8 @@ void CameraFeed::_bind_methods() {
 
 	GDVIRTUAL_BIND(_activate_feed);
 	GDVIRTUAL_BIND(_deactivate_feed);
+	GDVIRTUAL_BIND(_set_format, "index", "parameters");
+	GDVIRTUAL_BIND(_get_formats);
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 	ADD_SIGNAL(MethodInfo("format_changed"));
@@ -309,11 +311,15 @@ void CameraFeed::deactivate_feed() {
 }
 
 bool CameraFeed::set_format(int p_index, const Dictionary &p_parameters) {
-	return false;
+	bool ret = false;
+	GDVIRTUAL_CALL(_set_format, p_index, p_parameters, ret);
+	return ret;
 }
 
 Array CameraFeed::get_formats() const {
-	return Array();
+	Array ret;
+	GDVIRTUAL_CALL(_get_formats, ret);
+	return ret;
 }
 
 CameraFeed::FeedFormat CameraFeed::get_format() const {

--- a/servers/camera/camera_feed.h
+++ b/servers/camera/camera_feed.h
@@ -124,6 +124,8 @@ public:
 	virtual bool activate_feed();
 	virtual void deactivate_feed();
 
+	GDVIRTUAL2R(bool, _set_format, int, const Dictionary &);
+	GDVIRTUAL0RC(Array, _get_formats);
 	GDVIRTUAL0R(bool, _activate_feed)
 	GDVIRTUAL0(_deactivate_feed)
 };


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This PR adds `set_format` and `get_formats` virtual bind to `CameraFeed`, so that custom feeds can provide a list of available feed formats. This can be useful for custom feeds written in GDExtension that enable camera device support on non-official platforms.