### PR TITLE
ColorPicker: Improve the accuracy of hue slider in OKHSL mode

### DIFF
--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -168,9 +168,6 @@
 		<theme_item name="color_hue" data_type="icon" type="Texture2D">
 			Custom texture for the hue selection slider on the right.
 		</theme_item>
-		<theme_item name="color_okhsl_hue" data_type="icon" type="Texture2D">
-			Custom texture for the H slider in the OKHSL color mode.
-		</theme_item>
 		<theme_item name="expanded_arrow" data_type="icon" type="Texture2D">
 			The icon for color preset drop down menu when expanded.
 		</theme_item>

--- a/scene/gui/color_mode.h
+++ b/scene/gui/color_mode.h
@@ -33,6 +33,8 @@
 
 #include "scene/gui/color_picker.h"
 
+class GradientTexture2D;
+
 class ColorMode {
 public:
 	ColorPicker *color_picker = nullptr;
@@ -129,6 +131,7 @@ public:
 	float slider_max[4] = { 359, 100, 100, 255 };
 	float cached_hue = 0.0;
 	float cached_saturation = 0.0;
+	Ref<GradientTexture2D> hue_texture = nullptr;
 
 	virtual String get_name() const override { return "OKHSL"; }
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -46,6 +46,7 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/color_palette.h"
+#include "scene/resources/gradient_texture.h"
 #include "scene/resources/image_texture.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_texture.h"
@@ -2152,7 +2153,6 @@ void ColorPicker::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, overbright_indicator);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, picker_cursor);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, color_hue);
-	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, ColorPicker, color_okhsl_hue);
 
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_normal, "tab_unselected", "TabContainer");
 	BIND_THEME_ITEM_EXT(Theme::DATA_TYPE_STYLEBOX, ColorPicker, mode_button_pressed, "tab_selected", "TabContainer");

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -264,7 +264,6 @@ private:
 		Ref<Texture2D> overbright_indicator;
 		Ref<Texture2D> picker_cursor;
 		Ref<Texture2D> color_hue;
-		Ref<Texture2D> color_okhsl_hue;
 
 		/* Mode buttons */
 		Ref<StyleBox> mode_button_normal;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1081,33 +1081,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 		theme->set_icon("color_hue", "ColorPicker", hue_texture);
 	}
 
-	{
-		const int precision = 7;
-
-		Ref<Gradient> hue_gradient;
-		hue_gradient.instantiate();
-		PackedFloat32Array offsets;
-		offsets.resize(precision);
-		PackedColorArray colors;
-		colors.resize(precision);
-
-		for (int i = 0; i < precision; i++) {
-			float h = i / float(precision - 1);
-			offsets.write[i] = h;
-			colors.write[i] = Color::from_ok_hsl(h, 1, 0.5);
-		}
-		hue_gradient->set_offsets(offsets);
-		hue_gradient->set_colors(colors);
-
-		Ref<GradientTexture2D> hue_texture;
-		hue_texture.instantiate();
-		hue_texture->set_width(800);
-		hue_texture->set_height(6);
-		hue_texture->set_gradient(hue_gradient);
-
-		theme->set_icon("color_okhsl_hue", "ColorPicker", hue_texture);
-	}
-
 	// ColorPickerButton
 
 	theme->set_icon("bg", "ColorPickerButton", icons["mini_checkerboard"]);


### PR DESCRIPTION
This PR improve the accuracy of hue slider in OKHSL mode, especially when lightness and saturation are high, by using dynamically generated gradient texture and removing `color_okhsl_hue` theme property. 

Before:
![屏幕截图_20241230_224756](https://github.com/user-attachments/assets/afcf7134-3996-4503-b204-650f764fbfdc)

After this PR:
![屏幕截图_20241230_230418](https://github.com/user-attachments/assets/7ab756e8-3914-4eb9-8264-934a5b00c01a)
