### PR TITLE
Fix dictionary editor steals focus when reloading script.

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -1287,7 +1287,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	change_type = memnew(PopupMenu);
 	add_child(change_type);
 	change_type->connect(SceneStringName(id_pressed), callable_mp(this, &EditorPropertyDictionary::_change_type_menu));
-	changing_type_index = -1;
+	changing_type_index = EditorPropertyDictionaryObject::NOT_CHANGING_TYPE;
 	has_borders = true;
 
 	key_subtype = Variant::NIL;


### PR DESCRIPTION
Fix #96913
Supersedes #96940

value was initialised to the wrong value -1 (NEW_VALUE) instead of -3 ( NOT_CHANGING) changed it to the correct value and used the enum.
