### PR TITLE
Fix parsing Resource type as value type of a Dictionary

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1223,7 +1223,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 						r_err_str = String();
 						value_type = Variant::OBJECT;
 						value_class_name = token.value;
-						got_comma_token = true;
+						got_bracket_token = true;
 					} else {
 						return err;
 					}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #100889.

A line was forgotten, so I added it. I do not believe it affects anything else as the scope is specifically for this use case.