### PR TITLE
Style: Enforce `AllowShortFunctionsOnASingleLine`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -63,3 +63,6 @@ b37fc1014abf7adda70dc30b0822d775b3a4433f
 
 # Style: Apply clang-tidy fixes (superficial)
 bb5f390fb9b466be35a5df7651323d7e66afca31
+
+# Style: Enforce `AllowShortFunctionsOnASingleLine`
+e06d83860d798b6766b23d6eae48557387a7db85

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -40,11 +40,15 @@
 
 class Node;
 
-#define RES_BASE_EXTENSION(m_ext)                                                                                   \
-public:                                                                                                             \
-	static void register_custom_data_to_otdb() { ClassDB::add_resource_base_extension(m_ext, get_class_static()); } \
-	virtual String get_base_extension() const override { return m_ext; }                                            \
-                                                                                                                    \
+#define RES_BASE_EXTENSION(m_ext)                                        \
+public:                                                                  \
+	static void register_custom_data_to_otdb() {                         \
+		ClassDB::add_resource_base_extension(m_ext, get_class_static()); \
+	}                                                                    \
+	virtual String get_base_extension() const override {                 \
+		return m_ext;                                                    \
+	}                                                                    \
+                                                                         \
 private:
 
 class Resource : public RefCounted {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -389,177 +389,181 @@ struct ObjectGDExtension {
  * much alone defines the object model.
  */
 
-#define GDCLASS(m_class, m_inherits)                                                                                                             \
-private:                                                                                                                                         \
-	void operator=(const m_class &p_rval) {}                                                                                                     \
-	friend class ::ClassDB;                                                                                                                      \
-                                                                                                                                                 \
-public:                                                                                                                                          \
-	typedef m_class self_type;                                                                                                                   \
-	static constexpr bool _class_is_enabled = !bool(GD_IS_DEFINED(ClassDB_Disable_##m_class)) && m_inherits::_class_is_enabled;                  \
-	virtual String get_class() const override {                                                                                                  \
-		if (_get_extension()) {                                                                                                                  \
-			return _get_extension()->class_name.operator String();                                                                               \
-		}                                                                                                                                        \
-		return String(#m_class);                                                                                                                 \
-	}                                                                                                                                            \
-	virtual const StringName *_get_class_namev() const override {                                                                                \
-		static StringName _class_name_static;                                                                                                    \
-		if (unlikely(!_class_name_static)) {                                                                                                     \
-			StringName::assign_static_unique_class_name(&_class_name_static, #m_class);                                                          \
-		}                                                                                                                                        \
-		return &_class_name_static;                                                                                                              \
-	}                                                                                                                                            \
-	static _FORCE_INLINE_ void *get_class_ptr_static() {                                                                                         \
-		static int ptr;                                                                                                                          \
-		return &ptr;                                                                                                                             \
-	}                                                                                                                                            \
-	static _FORCE_INLINE_ String get_class_static() {                                                                                            \
-		return String(#m_class);                                                                                                                 \
-	}                                                                                                                                            \
-	static _FORCE_INLINE_ String get_parent_class_static() {                                                                                     \
-		return m_inherits::get_class_static();                                                                                                   \
-	}                                                                                                                                            \
-	static void get_inheritance_list_static(List<String> *p_inheritance_list) {                                                                  \
-		m_inherits::get_inheritance_list_static(p_inheritance_list);                                                                             \
-		p_inheritance_list->push_back(String(#m_class));                                                                                         \
-	}                                                                                                                                            \
-	virtual bool is_class(const String &p_class) const override {                                                                                \
-		if (_get_extension() && _get_extension()->is_class(p_class)) {                                                                           \
-			return true;                                                                                                                         \
-		}                                                                                                                                        \
-		return (p_class == (#m_class)) ? true : m_inherits::is_class(p_class);                                                                   \
-	}                                                                                                                                            \
-	virtual bool is_class_ptr(void *p_ptr) const override { return (p_ptr == get_class_ptr_static()) ? true : m_inherits::is_class_ptr(p_ptr); } \
-                                                                                                                                                 \
-	static void get_valid_parents_static(List<String> *p_parents) {                                                                              \
-		if (m_class::_get_valid_parents_static != m_inherits::_get_valid_parents_static) {                                                       \
-			m_class::_get_valid_parents_static(p_parents);                                                                                       \
-		}                                                                                                                                        \
-                                                                                                                                                 \
-		m_inherits::get_valid_parents_static(p_parents);                                                                                         \
-	}                                                                                                                                            \
-                                                                                                                                                 \
-protected:                                                                                                                                       \
-	_FORCE_INLINE_ static void (*_get_bind_methods())() {                                                                                        \
-		return &m_class::_bind_methods;                                                                                                          \
-	}                                                                                                                                            \
-	_FORCE_INLINE_ static void (*_get_bind_compatibility_methods())() {                                                                          \
-		return &m_class::_bind_compatibility_methods;                                                                                            \
-	}                                                                                                                                            \
-                                                                                                                                                 \
-public:                                                                                                                                          \
-	static void initialize_class() {                                                                                                             \
-		static bool initialized = false;                                                                                                         \
-		if (initialized) {                                                                                                                       \
-			return;                                                                                                                              \
-		}                                                                                                                                        \
-		m_inherits::initialize_class();                                                                                                          \
-		::ClassDB::_add_class<m_class>();                                                                                                        \
-		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) {                                                                   \
-			_bind_methods();                                                                                                                     \
-		}                                                                                                                                        \
-		if (m_class::_get_bind_compatibility_methods() != m_inherits::_get_bind_compatibility_methods()) {                                       \
-			_bind_compatibility_methods();                                                                                                       \
-		}                                                                                                                                        \
-		initialized = true;                                                                                                                      \
-	}                                                                                                                                            \
-                                                                                                                                                 \
-protected:                                                                                                                                       \
-	virtual void _initialize_classv() override {                                                                                                 \
-		initialize_class();                                                                                                                      \
-	}                                                                                                                                            \
-	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &) const {                                                 \
-		return (bool(Object::*)(const StringName &, Variant &) const) & m_class::_get;                                                           \
-	}                                                                                                                                            \
-	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override {                                                                \
-		if (m_class::_get_get() != m_inherits::_get_get()) {                                                                                     \
-			if (_get(p_name, r_ret)) {                                                                                                           \
-				return true;                                                                                                                     \
-			}                                                                                                                                    \
-		}                                                                                                                                        \
-		return m_inherits::_getv(p_name, r_ret);                                                                                                 \
-	}                                                                                                                                            \
-	_FORCE_INLINE_ bool (Object::*_get_set() const)(const StringName &p_name, const Variant &p_property) {                                       \
-		return (bool(Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                           \
-	}                                                                                                                                            \
-	virtual bool _setv(const StringName &p_name, const Variant &p_property) override {                                                           \
-		if (m_inherits::_setv(p_name, p_property)) {                                                                                             \
-			return true;                                                                                                                         \
-		}                                                                                                                                        \
-		if (m_class::_get_set() != m_inherits::_get_set()) {                                                                                     \
-			return _set(p_name, p_property);                                                                                                     \
-		}                                                                                                                                        \
-		return false;                                                                                                                            \
-	}                                                                                                                                            \
-	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> * p_list) const {                                           \
-		return (void(Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                                      \
-	}                                                                                                                                            \
-	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const override {                                               \
-		if (!p_reversed) {                                                                                                                       \
-			m_inherits::_get_property_listv(p_list, p_reversed);                                                                                 \
-		}                                                                                                                                        \
-		p_list->push_back(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, get_class_static(), PROPERTY_USAGE_CATEGORY));      \
-		::ClassDB::get_property_list(#m_class, p_list, true, this);                                                                              \
-		if (m_class::_get_get_property_list() != m_inherits::_get_get_property_list()) {                                                         \
-			_get_property_list(p_list);                                                                                                          \
-		}                                                                                                                                        \
-		if (p_reversed) {                                                                                                                        \
-			m_inherits::_get_property_listv(p_list, p_reversed);                                                                                 \
-		}                                                                                                                                        \
-	}                                                                                                                                            \
-	_FORCE_INLINE_ void (Object::*_get_validate_property() const)(PropertyInfo & p_property) const {                                             \
-		return (void(Object::*)(PropertyInfo &) const) & m_class::_validate_property;                                                            \
-	}                                                                                                                                            \
-	virtual void _validate_propertyv(PropertyInfo &p_property) const override {                                                                  \
-		m_inherits::_validate_propertyv(p_property);                                                                                             \
-		if (m_class::_get_validate_property() != m_inherits::_get_validate_property()) {                                                         \
-			_validate_property(p_property);                                                                                                      \
-		}                                                                                                                                        \
-	}                                                                                                                                            \
-	_FORCE_INLINE_ bool (Object::*_get_property_can_revert() const)(const StringName &p_name) const {                                            \
-		return (bool(Object::*)(const StringName &) const) & m_class::_property_can_revert;                                                      \
-	}                                                                                                                                            \
-	virtual bool _property_can_revertv(const StringName &p_name) const override {                                                                \
-		if (m_class::_get_property_can_revert() != m_inherits::_get_property_can_revert()) {                                                     \
-			if (_property_can_revert(p_name)) {                                                                                                  \
-				return true;                                                                                                                     \
-			}                                                                                                                                    \
-		}                                                                                                                                        \
-		return m_inherits::_property_can_revertv(p_name);                                                                                        \
-	}                                                                                                                                            \
-	_FORCE_INLINE_ bool (Object::*_get_property_get_revert() const)(const StringName &p_name, Variant &) const {                                 \
-		return (bool(Object::*)(const StringName &, Variant &) const) & m_class::_property_get_revert;                                           \
-	}                                                                                                                                            \
-	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_ret) const override {                                                \
-		if (m_class::_get_property_get_revert() != m_inherits::_get_property_get_revert()) {                                                     \
-			if (_property_get_revert(p_name, r_ret)) {                                                                                           \
-				return true;                                                                                                                     \
-			}                                                                                                                                    \
-		}                                                                                                                                        \
-		return m_inherits::_property_get_revertv(p_name, r_ret);                                                                                 \
-	}                                                                                                                                            \
-	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {                                                                              \
-		return (void(Object::*)(int)) & m_class::_notification;                                                                                  \
-	}                                                                                                                                            \
-	virtual void _notificationv(int p_notification, bool p_reversed) override {                                                                  \
-		if (!p_reversed) {                                                                                                                       \
-			m_inherits::_notificationv(p_notification, p_reversed);                                                                              \
-		}                                                                                                                                        \
-		if (m_class::_get_notification() != m_inherits::_get_notification()) {                                                                   \
-			_notification(p_notification);                                                                                                       \
-		}                                                                                                                                        \
-		if (p_reversed) {                                                                                                                        \
-			m_inherits::_notificationv(p_notification, p_reversed);                                                                              \
-		}                                                                                                                                        \
-	}                                                                                                                                            \
-                                                                                                                                                 \
+#define GDCLASS(m_class, m_inherits)                                                                                                        \
+private:                                                                                                                                    \
+	void operator=(const m_class &p_rval) {}                                                                                                \
+	friend class ::ClassDB;                                                                                                                 \
+                                                                                                                                            \
+public:                                                                                                                                     \
+	typedef m_class self_type;                                                                                                              \
+	static constexpr bool _class_is_enabled = !bool(GD_IS_DEFINED(ClassDB_Disable_##m_class)) && m_inherits::_class_is_enabled;             \
+	virtual String get_class() const override {                                                                                             \
+		if (_get_extension()) {                                                                                                             \
+			return _get_extension()->class_name.operator String();                                                                          \
+		}                                                                                                                                   \
+		return String(#m_class);                                                                                                            \
+	}                                                                                                                                       \
+	virtual const StringName *_get_class_namev() const override {                                                                           \
+		static StringName _class_name_static;                                                                                               \
+		if (unlikely(!_class_name_static)) {                                                                                                \
+			StringName::assign_static_unique_class_name(&_class_name_static, #m_class);                                                     \
+		}                                                                                                                                   \
+		return &_class_name_static;                                                                                                         \
+	}                                                                                                                                       \
+	static _FORCE_INLINE_ void *get_class_ptr_static() {                                                                                    \
+		static int ptr;                                                                                                                     \
+		return &ptr;                                                                                                                        \
+	}                                                                                                                                       \
+	static _FORCE_INLINE_ String get_class_static() {                                                                                       \
+		return String(#m_class);                                                                                                            \
+	}                                                                                                                                       \
+	static _FORCE_INLINE_ String get_parent_class_static() {                                                                                \
+		return m_inherits::get_class_static();                                                                                              \
+	}                                                                                                                                       \
+	static void get_inheritance_list_static(List<String> *p_inheritance_list) {                                                             \
+		m_inherits::get_inheritance_list_static(p_inheritance_list);                                                                        \
+		p_inheritance_list->push_back(String(#m_class));                                                                                    \
+	}                                                                                                                                       \
+	virtual bool is_class(const String &p_class) const override {                                                                           \
+		if (_get_extension() && _get_extension()->is_class(p_class)) {                                                                      \
+			return true;                                                                                                                    \
+		}                                                                                                                                   \
+		return (p_class == (#m_class)) ? true : m_inherits::is_class(p_class);                                                              \
+	}                                                                                                                                       \
+	virtual bool is_class_ptr(void *p_ptr) const override {                                                                                 \
+		return (p_ptr == get_class_ptr_static()) ? true : m_inherits::is_class_ptr(p_ptr);                                                  \
+	}                                                                                                                                       \
+                                                                                                                                            \
+	static void get_valid_parents_static(List<String> *p_parents) {                                                                         \
+		if (m_class::_get_valid_parents_static != m_inherits::_get_valid_parents_static) {                                                  \
+			m_class::_get_valid_parents_static(p_parents);                                                                                  \
+		}                                                                                                                                   \
+                                                                                                                                            \
+		m_inherits::get_valid_parents_static(p_parents);                                                                                    \
+	}                                                                                                                                       \
+                                                                                                                                            \
+protected:                                                                                                                                  \
+	_FORCE_INLINE_ static void (*_get_bind_methods())() {                                                                                   \
+		return &m_class::_bind_methods;                                                                                                     \
+	}                                                                                                                                       \
+	_FORCE_INLINE_ static void (*_get_bind_compatibility_methods())() {                                                                     \
+		return &m_class::_bind_compatibility_methods;                                                                                       \
+	}                                                                                                                                       \
+                                                                                                                                            \
+public:                                                                                                                                     \
+	static void initialize_class() {                                                                                                        \
+		static bool initialized = false;                                                                                                    \
+		if (initialized) {                                                                                                                  \
+			return;                                                                                                                         \
+		}                                                                                                                                   \
+		m_inherits::initialize_class();                                                                                                     \
+		::ClassDB::_add_class<m_class>();                                                                                                   \
+		if (m_class::_get_bind_methods() != m_inherits::_get_bind_methods()) {                                                              \
+			_bind_methods();                                                                                                                \
+		}                                                                                                                                   \
+		if (m_class::_get_bind_compatibility_methods() != m_inherits::_get_bind_compatibility_methods()) {                                  \
+			_bind_compatibility_methods();                                                                                                  \
+		}                                                                                                                                   \
+		initialized = true;                                                                                                                 \
+	}                                                                                                                                       \
+                                                                                                                                            \
+protected:                                                                                                                                  \
+	virtual void _initialize_classv() override {                                                                                            \
+		initialize_class();                                                                                                                 \
+	}                                                                                                                                       \
+	_FORCE_INLINE_ bool (Object::*_get_get() const)(const StringName &p_name, Variant &) const {                                            \
+		return (bool(Object::*)(const StringName &, Variant &) const) & m_class::_get;                                                      \
+	}                                                                                                                                       \
+	virtual bool _getv(const StringName &p_name, Variant &r_ret) const override {                                                           \
+		if (m_class::_get_get() != m_inherits::_get_get()) {                                                                                \
+			if (_get(p_name, r_ret)) {                                                                                                      \
+				return true;                                                                                                                \
+			}                                                                                                                               \
+		}                                                                                                                                   \
+		return m_inherits::_getv(p_name, r_ret);                                                                                            \
+	}                                                                                                                                       \
+	_FORCE_INLINE_ bool (Object::*_get_set() const)(const StringName &p_name, const Variant &p_property) {                                  \
+		return (bool(Object::*)(const StringName &, const Variant &)) & m_class::_set;                                                      \
+	}                                                                                                                                       \
+	virtual bool _setv(const StringName &p_name, const Variant &p_property) override {                                                      \
+		if (m_inherits::_setv(p_name, p_property)) {                                                                                        \
+			return true;                                                                                                                    \
+		}                                                                                                                                   \
+		if (m_class::_get_set() != m_inherits::_get_set()) {                                                                                \
+			return _set(p_name, p_property);                                                                                                \
+		}                                                                                                                                   \
+		return false;                                                                                                                       \
+	}                                                                                                                                       \
+	_FORCE_INLINE_ void (Object::*_get_get_property_list() const)(List<PropertyInfo> * p_list) const {                                      \
+		return (void(Object::*)(List<PropertyInfo> *) const) & m_class::_get_property_list;                                                 \
+	}                                                                                                                                       \
+	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const override {                                          \
+		if (!p_reversed) {                                                                                                                  \
+			m_inherits::_get_property_listv(p_list, p_reversed);                                                                            \
+		}                                                                                                                                   \
+		p_list->push_back(PropertyInfo(Variant::NIL, get_class_static(), PROPERTY_HINT_NONE, get_class_static(), PROPERTY_USAGE_CATEGORY)); \
+		::ClassDB::get_property_list(#m_class, p_list, true, this);                                                                         \
+		if (m_class::_get_get_property_list() != m_inherits::_get_get_property_list()) {                                                    \
+			_get_property_list(p_list);                                                                                                     \
+		}                                                                                                                                   \
+		if (p_reversed) {                                                                                                                   \
+			m_inherits::_get_property_listv(p_list, p_reversed);                                                                            \
+		}                                                                                                                                   \
+	}                                                                                                                                       \
+	_FORCE_INLINE_ void (Object::*_get_validate_property() const)(PropertyInfo & p_property) const {                                        \
+		return (void(Object::*)(PropertyInfo &) const) & m_class::_validate_property;                                                       \
+	}                                                                                                                                       \
+	virtual void _validate_propertyv(PropertyInfo &p_property) const override {                                                             \
+		m_inherits::_validate_propertyv(p_property);                                                                                        \
+		if (m_class::_get_validate_property() != m_inherits::_get_validate_property()) {                                                    \
+			_validate_property(p_property);                                                                                                 \
+		}                                                                                                                                   \
+	}                                                                                                                                       \
+	_FORCE_INLINE_ bool (Object::*_get_property_can_revert() const)(const StringName &p_name) const {                                       \
+		return (bool(Object::*)(const StringName &) const) & m_class::_property_can_revert;                                                 \
+	}                                                                                                                                       \
+	virtual bool _property_can_revertv(const StringName &p_name) const override {                                                           \
+		if (m_class::_get_property_can_revert() != m_inherits::_get_property_can_revert()) {                                                \
+			if (_property_can_revert(p_name)) {                                                                                             \
+				return true;                                                                                                                \
+			}                                                                                                                               \
+		}                                                                                                                                   \
+		return m_inherits::_property_can_revertv(p_name);                                                                                   \
+	}                                                                                                                                       \
+	_FORCE_INLINE_ bool (Object::*_get_property_get_revert() const)(const StringName &p_name, Variant &) const {                            \
+		return (bool(Object::*)(const StringName &, Variant &) const) & m_class::_property_get_revert;                                      \
+	}                                                                                                                                       \
+	virtual bool _property_get_revertv(const StringName &p_name, Variant &r_ret) const override {                                           \
+		if (m_class::_get_property_get_revert() != m_inherits::_get_property_get_revert()) {                                                \
+			if (_property_get_revert(p_name, r_ret)) {                                                                                      \
+				return true;                                                                                                                \
+			}                                                                                                                               \
+		}                                                                                                                                   \
+		return m_inherits::_property_get_revertv(p_name, r_ret);                                                                            \
+	}                                                                                                                                       \
+	_FORCE_INLINE_ void (Object::*_get_notification() const)(int) {                                                                         \
+		return (void(Object::*)(int)) & m_class::_notification;                                                                             \
+	}                                                                                                                                       \
+	virtual void _notificationv(int p_notification, bool p_reversed) override {                                                             \
+		if (!p_reversed) {                                                                                                                  \
+			m_inherits::_notificationv(p_notification, p_reversed);                                                                         \
+		}                                                                                                                                   \
+		if (m_class::_get_notification() != m_inherits::_get_notification()) {                                                              \
+			_notification(p_notification);                                                                                                  \
+		}                                                                                                                                   \
+		if (p_reversed) {                                                                                                                   \
+			m_inherits::_notificationv(p_notification, p_reversed);                                                                         \
+		}                                                                                                                                   \
+	}                                                                                                                                       \
+                                                                                                                                            \
 private:
 
-#define OBJ_SAVE_TYPE(m_class)                                          \
-public:                                                                 \
-	virtual String get_save_class() const override { return #m_class; } \
-                                                                        \
+#define OBJ_SAVE_TYPE(m_class)                       \
+public:                                              \
+	virtual String get_save_class() const override { \
+		return #m_class;                             \
+	}                                                \
+                                                     \
 private:
 
 class ScriptInstance;

--- a/core/os/memory.cpp
+++ b/core/os/memory.cpp
@@ -64,7 +64,9 @@ SafeNumeric<uint64_t> Memory::max_usage;
 
 SafeNumeric<uint64_t> Memory::alloc_count;
 
-inline bool is_power_of_2(size_t x) { return x && ((x & (x - 1U)) == 0U); }
+inline bool is_power_of_2(size_t x) {
+	return x && ((x & (x - 1U)) == 0U);
+}
 
 void *Memory::alloc_aligned_static(size_t p_bytes, size_t p_alignment) {
 	DEV_ASSERT(is_power_of_2(p_alignment));

--- a/core/templates/pass_func.h
+++ b/core/templates/pass_func.h
@@ -31,70 +31,134 @@
 #ifndef PASS_FUNC_H
 #define PASS_FUNC_H
 
-#define PASS0R(m_r, m_name) \
-	m_r m_name() { return PASSBASE->m_name(); }
-#define PASS0RC(m_r, m_name) \
-	m_r m_name() const { return PASSBASE->m_name(); }
-#define PASS1R(m_r, m_name, m_type1) \
-	m_r m_name(m_type1 arg1) { return PASSBASE->m_name(arg1); }
-#define PASS1RC(m_r, m_name, m_type1) \
-	m_r m_name(m_type1 arg1) const { return PASSBASE->m_name(arg1); }
+#define PASS0R(m_r, m_name)        \
+	m_r m_name() {                 \
+		return PASSBASE->m_name(); \
+	}
+#define PASS0RC(m_r, m_name)       \
+	m_r m_name() const {           \
+		return PASSBASE->m_name(); \
+	}
+#define PASS1R(m_r, m_name, m_type1)   \
+	m_r m_name(m_type1 arg1) {         \
+		return PASSBASE->m_name(arg1); \
+	}
+#define PASS1RC(m_r, m_name, m_type1)  \
+	m_r m_name(m_type1 arg1) const {   \
+		return PASSBASE->m_name(arg1); \
+	}
 #define PASS2R(m_r, m_name, m_type1, m_type2) \
-	m_r m_name(m_type1 arg1, m_type2 arg2) { return PASSBASE->m_name(arg1, arg2); }
-#define PASS2RC(m_r, m_name, m_type1, m_type2) \
-	m_r m_name(m_type1 arg1, m_type2 arg2) const { return PASSBASE->m_name(arg1, arg2); }
-#define PASS3R(m_r, m_name, m_type1, m_type2, m_type3) \
-	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) { return PASSBASE->m_name(arg1, arg2, arg3); }
-#define PASS3RC(m_r, m_name, m_type1, m_type2, m_type3) \
-	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) const { return PASSBASE->m_name(arg1, arg2, arg3); }
-#define PASS4R(m_r, m_name, m_type1, m_type2, m_type3, m_type4) \
-	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) { return PASSBASE->m_name(arg1, arg2, arg3, arg4); }
-#define PASS4RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4) \
-	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) const { return PASSBASE->m_name(arg1, arg2, arg3, arg4); }
-#define PASS5R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5) \
-	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) { return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5); }
-#define PASS5RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5) \
-	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) const { return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5); }
-#define PASS6R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6) \
-	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) { return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6); }
-#define PASS6RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6) \
-	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) const { return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6); }
+	m_r m_name(m_type1 arg1, m_type2 arg2) {  \
+		return PASSBASE->m_name(arg1, arg2);  \
+	}
+#define PASS2RC(m_r, m_name, m_type1, m_type2)     \
+	m_r m_name(m_type1 arg1, m_type2 arg2) const { \
+		return PASSBASE->m_name(arg1, arg2);       \
+	}
+#define PASS3R(m_r, m_name, m_type1, m_type2, m_type3)     \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) { \
+		return PASSBASE->m_name(arg1, arg2, arg3);         \
+	}
+#define PASS3RC(m_r, m_name, m_type1, m_type2, m_type3)          \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) const { \
+		return PASSBASE->m_name(arg1, arg2, arg3);               \
+	}
+#define PASS4R(m_r, m_name, m_type1, m_type2, m_type3, m_type4)          \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) { \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4);                 \
+	}
+#define PASS4RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4)               \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) const { \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4);                       \
+	}
+#define PASS5R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5)               \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) { \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5);                         \
+	}
+#define PASS5RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5)                    \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) const { \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5);                               \
+	}
+#define PASS6R(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6)                    \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) { \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6);                                 \
+	}
+#define PASS6RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6)                         \
+	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) const { \
+		return PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6);                                       \
+	}
 
-#define PASS0(m_name) \
-	void m_name() { PASSBASE->m_name(); }
-#define PASS1(m_name, m_type1) \
-	void m_name(m_type1 arg1) { PASSBASE->m_name(arg1); }
-#define PASS1C(m_name, m_type1) \
-	void m_name(m_type1 arg1) const { PASSBASE->m_name(arg1); }
-#define PASS2(m_name, m_type1, m_type2) \
-	void m_name(m_type1 arg1, m_type2 arg2) { PASSBASE->m_name(arg1, arg2); }
-#define PASS2C(m_name, m_type1, m_type2) \
-	void m_name(m_type1 arg1, m_type2 arg2) const { PASSBASE->m_name(arg1, arg2); }
-#define PASS3(m_name, m_type1, m_type2, m_type3) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) { PASSBASE->m_name(arg1, arg2, arg3); }
-#define PASS4(m_name, m_type1, m_type2, m_type3, m_type4) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) { PASSBASE->m_name(arg1, arg2, arg3, arg4); }
-#define PASS5(m_name, m_type1, m_type2, m_type3, m_type4, m_type5) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5); }
-#define PASS6(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6); }
-#define PASS7(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7); }
-#define PASS8(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8); }
-#define PASS9(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9); }
-#define PASS10(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10); }
-#define PASS11(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11); }
-#define PASS12(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12); }
-#define PASS13(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12, m_type13 arg13) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13); }
-#define PASS14(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13, m_type14) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12, m_type13 arg13, m_type14 arg14) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14); }
-#define PASS15(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13, m_type14, m_type15) \
-	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12, m_type13 arg13, m_type14 arg14, m_type15 arg15) { PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15); }
+#define PASS0(m_name)       \
+	void m_name() {         \
+		PASSBASE->m_name(); \
+	}
+#define PASS1(m_name, m_type1)  \
+	void m_name(m_type1 arg1) { \
+		PASSBASE->m_name(arg1); \
+	}
+#define PASS1C(m_name, m_type1)       \
+	void m_name(m_type1 arg1) const { \
+		PASSBASE->m_name(arg1);       \
+	}
+#define PASS2(m_name, m_type1, m_type2)       \
+	void m_name(m_type1 arg1, m_type2 arg2) { \
+		PASSBASE->m_name(arg1, arg2);         \
+	}
+#define PASS2C(m_name, m_type1, m_type2)            \
+	void m_name(m_type1 arg1, m_type2 arg2) const { \
+		PASSBASE->m_name(arg1, arg2);               \
+	}
+#define PASS3(m_name, m_type1, m_type2, m_type3)            \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) { \
+		PASSBASE->m_name(arg1, arg2, arg3);                 \
+	}
+#define PASS4(m_name, m_type1, m_type2, m_type3, m_type4)                 \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4);                         \
+	}
+#define PASS5(m_name, m_type1, m_type2, m_type3, m_type4, m_type5)                      \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5);                                 \
+	}
+#define PASS6(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6)                           \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6);                                         \
+	}
+#define PASS7(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7)                                \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7);                                                 \
+	}
+#define PASS8(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8)                                     \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);                                                         \
+	}
+#define PASS9(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9)                                          \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);                                                                 \
+	}
+#define PASS10(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10)                                               \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);                                                                          \
+	}
+#define PASS11(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11)                                                     \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);                                                                                   \
+	}
+#define PASS12(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12)                                                           \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);                                                                                            \
+	}
+#define PASS13(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13)                                                                 \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12, m_type13 arg13) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);                                                                                                     \
+	}
+#define PASS14(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13, m_type14)                                                                       \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12, m_type13 arg13, m_type14 arg14) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);                                                                                                              \
+	}
+#define PASS15(m_name, m_type1, m_type2, m_type3, m_type4, m_type5, m_type6, m_type7, m_type8, m_type9, m_type10, m_type11, m_type12, m_type13, m_type14, m_type15)                                                                             \
+	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4, m_type5 arg5, m_type6 arg6, m_type7 arg7, m_type8 arg8, m_type9 arg9, m_type10 arg10, m_type11 arg11, m_type12 arg12, m_type13 arg13, m_type14 arg14, m_type15 arg15) { \
+		PASSBASE->m_name(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);                                                                                                                       \
+	}
 
 #endif // PASS_FUNC_H

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -82,60 +82,72 @@ struct VariantCaster<const T &> {
 	}
 };
 
-#define VARIANT_ENUM_CAST(m_enum)                                                                                       \
-	MAKE_ENUM_TYPE_INFO(m_enum)                                                                                         \
-	template <>                                                                                                         \
-	struct VariantCaster<m_enum> {                                                                                      \
-		static _FORCE_INLINE_ m_enum cast(const Variant &p_variant) {                                                   \
-			return (m_enum)p_variant.operator int64_t();                                                                \
-		}                                                                                                               \
-	};                                                                                                                  \
-	template <>                                                                                                         \
-	struct PtrToArg<m_enum> {                                                                                           \
-		_FORCE_INLINE_ static m_enum convert(const void *p_ptr) {                                                       \
-			return m_enum(*reinterpret_cast<const int64_t *>(p_ptr));                                                   \
-		}                                                                                                               \
-		typedef int64_t EncodeT;                                                                                        \
-		_FORCE_INLINE_ static void encode(m_enum p_val, const void *p_ptr) {                                            \
-			*(int64_t *)p_ptr = (int64_t)p_val;                                                                         \
-		}                                                                                                               \
-	};                                                                                                                  \
-	template <>                                                                                                         \
-	struct ZeroInitializer<m_enum> {                                                                                    \
-		static void initialize(m_enum &value) { value = (m_enum)0; }                                                    \
-	};                                                                                                                  \
-	template <>                                                                                                         \
-	struct VariantInternalAccessor<m_enum> {                                                                            \
-		static _FORCE_INLINE_ m_enum get(const Variant *v) { return m_enum(*VariantInternal::get_int(v)); }             \
-		static _FORCE_INLINE_ void set(Variant *v, m_enum p_value) { *VariantInternal::get_int(v) = (int64_t)p_value; } \
+#define VARIANT_ENUM_CAST(m_enum)                                            \
+	MAKE_ENUM_TYPE_INFO(m_enum)                                              \
+	template <>                                                              \
+	struct VariantCaster<m_enum> {                                           \
+		static _FORCE_INLINE_ m_enum cast(const Variant &p_variant) {        \
+			return (m_enum)p_variant.operator int64_t();                     \
+		}                                                                    \
+	};                                                                       \
+	template <>                                                              \
+	struct PtrToArg<m_enum> {                                                \
+		_FORCE_INLINE_ static m_enum convert(const void *p_ptr) {            \
+			return m_enum(*reinterpret_cast<const int64_t *>(p_ptr));        \
+		}                                                                    \
+		typedef int64_t EncodeT;                                             \
+		_FORCE_INLINE_ static void encode(m_enum p_val, const void *p_ptr) { \
+			*(int64_t *)p_ptr = (int64_t)p_val;                              \
+		}                                                                    \
+	};                                                                       \
+	template <>                                                              \
+	struct ZeroInitializer<m_enum> {                                         \
+		static void initialize(m_enum &value) {                              \
+			value = (m_enum)0;                                               \
+		}                                                                    \
+	};                                                                       \
+	template <>                                                              \
+	struct VariantInternalAccessor<m_enum> {                                 \
+		static _FORCE_INLINE_ m_enum get(const Variant *v) {                 \
+			return m_enum(*VariantInternal::get_int(v));                     \
+		}                                                                    \
+		static _FORCE_INLINE_ void set(Variant *v, m_enum p_value) {         \
+			*VariantInternal::get_int(v) = (int64_t)p_value;                 \
+		}                                                                    \
 	};
 
-#define VARIANT_BITFIELD_CAST(m_enum)                                                                                                       \
-	MAKE_BITFIELD_TYPE_INFO(m_enum)                                                                                                         \
-	template <>                                                                                                                             \
-	struct VariantCaster<BitField<m_enum>> {                                                                                                \
-		static _FORCE_INLINE_ BitField<m_enum> cast(const Variant &p_variant) {                                                             \
-			return BitField<m_enum>(p_variant.operator int64_t());                                                                          \
-		}                                                                                                                                   \
-	};                                                                                                                                      \
-	template <>                                                                                                                             \
-	struct PtrToArg<BitField<m_enum>> {                                                                                                     \
-		_FORCE_INLINE_ static BitField<m_enum> convert(const void *p_ptr) {                                                                 \
-			return BitField<m_enum>(*reinterpret_cast<const int64_t *>(p_ptr));                                                             \
-		}                                                                                                                                   \
-		typedef int64_t EncodeT;                                                                                                            \
-		_FORCE_INLINE_ static void encode(BitField<m_enum> p_val, const void *p_ptr) {                                                      \
-			*(int64_t *)p_ptr = p_val;                                                                                                      \
-		}                                                                                                                                   \
-	};                                                                                                                                      \
-	template <>                                                                                                                             \
-	struct ZeroInitializer<BitField<m_enum>> {                                                                                              \
-		static void initialize(BitField<m_enum> &value) { value = 0; }                                                                      \
-	};                                                                                                                                      \
-	template <>                                                                                                                             \
-	struct VariantInternalAccessor<BitField<m_enum>> {                                                                                      \
-		static _FORCE_INLINE_ BitField<m_enum> get(const Variant *v) { return BitField<m_enum>(*VariantInternal::get_int(v)); }             \
-		static _FORCE_INLINE_ void set(Variant *v, BitField<m_enum> p_value) { *VariantInternal::get_int(v) = p_value.operator int64_t(); } \
+#define VARIANT_BITFIELD_CAST(m_enum)                                                  \
+	MAKE_BITFIELD_TYPE_INFO(m_enum)                                                    \
+	template <>                                                                        \
+	struct VariantCaster<BitField<m_enum>> {                                           \
+		static _FORCE_INLINE_ BitField<m_enum> cast(const Variant &p_variant) {        \
+			return BitField<m_enum>(p_variant.operator int64_t());                     \
+		}                                                                              \
+	};                                                                                 \
+	template <>                                                                        \
+	struct PtrToArg<BitField<m_enum>> {                                                \
+		_FORCE_INLINE_ static BitField<m_enum> convert(const void *p_ptr) {            \
+			return BitField<m_enum>(*reinterpret_cast<const int64_t *>(p_ptr));        \
+		}                                                                              \
+		typedef int64_t EncodeT;                                                       \
+		_FORCE_INLINE_ static void encode(BitField<m_enum> p_val, const void *p_ptr) { \
+			*(int64_t *)p_ptr = p_val;                                                 \
+		}                                                                              \
+	};                                                                                 \
+	template <>                                                                        \
+	struct ZeroInitializer<BitField<m_enum>> {                                         \
+		static void initialize(BitField<m_enum> &value) {                              \
+			value = 0;                                                                 \
+		}                                                                              \
+	};                                                                                 \
+	template <>                                                                        \
+	struct VariantInternalAccessor<BitField<m_enum>> {                                 \
+		static _FORCE_INLINE_ BitField<m_enum> get(const Variant *v) {                 \
+			return BitField<m_enum>(*VariantInternal::get_int(v));                     \
+		}                                                                              \
+		static _FORCE_INLINE_ void set(Variant *v, BitField<m_enum> p_value) {         \
+			*VariantInternal::get_int(v) = p_value.operator int64_t();                 \
+		}                                                                              \
 	};
 
 // Object enum casts must go here

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -53,46 +53,70 @@ struct GDExtensionPtr {
 	operator Variant() const { return uint64_t(data); }
 };
 
-#define GDVIRTUAL_NATIVE_PTR(m_type)                                                                                                                                                               \
-	template <>                                                                                                                                                                                    \
-	struct GDExtensionConstPtr<const m_type> {                                                                                                                                                     \
-		const m_type *data = nullptr;                                                                                                                                                              \
-		GDExtensionConstPtr() {}                                                                                                                                                                   \
-		GDExtensionConstPtr(const m_type *p_assign) { data = p_assign; }                                                                                                                           \
-		static const char *get_name() { return "const " #m_type; }                                                                                                                                 \
-		operator const m_type *() const { return data; }                                                                                                                                           \
-		operator Variant() const { return uint64_t(data); }                                                                                                                                        \
-	};                                                                                                                                                                                             \
-	template <>                                                                                                                                                                                    \
-	struct VariantCaster<GDExtensionConstPtr<const m_type>> {                                                                                                                                      \
-		static _FORCE_INLINE_ GDExtensionConstPtr<const m_type> cast(const Variant &p_variant) {                                                                                                   \
-			return GDExtensionConstPtr<const m_type>((const m_type *)p_variant.operator uint64_t());                                                                                               \
-		}                                                                                                                                                                                          \
-	};                                                                                                                                                                                             \
-	template <>                                                                                                                                                                                    \
-	struct VariantInternalAccessor<GDExtensionConstPtr<const m_type>> {                                                                                                                            \
-		static _FORCE_INLINE_ const GDExtensionConstPtr<const m_type> &get(const Variant *v) { return *reinterpret_cast<const GDExtensionConstPtr<const m_type> *>(VariantInternal::get_int(v)); } \
-		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionConstPtr<const m_type> &p_value) { *VariantInternal::get_int(v) = uint64_t(p_value.data); }                                    \
-	};                                                                                                                                                                                             \
-	template <>                                                                                                                                                                                    \
-	struct GDExtensionPtr<m_type> {                                                                                                                                                                \
-		m_type *data = nullptr;                                                                                                                                                                    \
-		GDExtensionPtr() {}                                                                                                                                                                        \
-		GDExtensionPtr(m_type *p_assign) { data = p_assign; }                                                                                                                                      \
-		static const char *get_name() { return #m_type; }                                                                                                                                          \
-		operator m_type *() const { return data; }                                                                                                                                                 \
-		operator Variant() const { return uint64_t(data); }                                                                                                                                        \
-	};                                                                                                                                                                                             \
-	template <>                                                                                                                                                                                    \
-	struct VariantCaster<GDExtensionPtr<m_type>> {                                                                                                                                                 \
-		static _FORCE_INLINE_ GDExtensionPtr<m_type> cast(const Variant &p_variant) {                                                                                                              \
-			return GDExtensionPtr<m_type>((m_type *)p_variant.operator uint64_t());                                                                                                                \
-		}                                                                                                                                                                                          \
-	};                                                                                                                                                                                             \
-	template <>                                                                                                                                                                                    \
-	struct VariantInternalAccessor<GDExtensionPtr<m_type>> {                                                                                                                                       \
-		static _FORCE_INLINE_ const GDExtensionPtr<m_type> &get(const Variant *v) { return *reinterpret_cast<const GDExtensionPtr<m_type> *>(VariantInternal::get_int(v)); }                       \
-		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionPtr<m_type> &p_value) { *VariantInternal::get_int(v) = uint64_t(p_value.data); }                                               \
+#define GDVIRTUAL_NATIVE_PTR(m_type)                                                                          \
+	template <>                                                                                               \
+	struct GDExtensionConstPtr<const m_type> {                                                                \
+		const m_type *data = nullptr;                                                                         \
+		GDExtensionConstPtr() {}                                                                              \
+		GDExtensionConstPtr(const m_type *p_assign) {                                                         \
+			data = p_assign;                                                                                  \
+		}                                                                                                     \
+		static const char *get_name() {                                                                       \
+			return "const " #m_type;                                                                          \
+		}                                                                                                     \
+		operator const m_type *() const {                                                                     \
+			return data;                                                                                      \
+		}                                                                                                     \
+		operator Variant() const {                                                                            \
+			return uint64_t(data);                                                                            \
+		}                                                                                                     \
+	};                                                                                                        \
+	template <>                                                                                               \
+	struct VariantCaster<GDExtensionConstPtr<const m_type>> {                                                 \
+		static _FORCE_INLINE_ GDExtensionConstPtr<const m_type> cast(const Variant &p_variant) {              \
+			return GDExtensionConstPtr<const m_type>((const m_type *)p_variant.operator uint64_t());          \
+		}                                                                                                     \
+	};                                                                                                        \
+	template <>                                                                                               \
+	struct VariantInternalAccessor<GDExtensionConstPtr<const m_type>> {                                       \
+		static _FORCE_INLINE_ const GDExtensionConstPtr<const m_type> &get(const Variant *v) {                \
+			return *reinterpret_cast<const GDExtensionConstPtr<const m_type> *>(VariantInternal::get_int(v)); \
+		}                                                                                                     \
+		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionConstPtr<const m_type> &p_value) {        \
+			*VariantInternal::get_int(v) = uint64_t(p_value.data);                                            \
+		}                                                                                                     \
+	};                                                                                                        \
+	template <>                                                                                               \
+	struct GDExtensionPtr<m_type> {                                                                           \
+		m_type *data = nullptr;                                                                               \
+		GDExtensionPtr() {}                                                                                   \
+		GDExtensionPtr(m_type *p_assign) {                                                                    \
+			data = p_assign;                                                                                  \
+		}                                                                                                     \
+		static const char *get_name() {                                                                       \
+			return #m_type;                                                                                   \
+		}                                                                                                     \
+		operator m_type *() const {                                                                           \
+			return data;                                                                                      \
+		}                                                                                                     \
+		operator Variant() const {                                                                            \
+			return uint64_t(data);                                                                            \
+		}                                                                                                     \
+	};                                                                                                        \
+	template <>                                                                                               \
+	struct VariantCaster<GDExtensionPtr<m_type>> {                                                            \
+		static _FORCE_INLINE_ GDExtensionPtr<m_type> cast(const Variant &p_variant) {                         \
+			return GDExtensionPtr<m_type>((m_type *)p_variant.operator uint64_t());                           \
+		}                                                                                                     \
+	};                                                                                                        \
+	template <>                                                                                               \
+	struct VariantInternalAccessor<GDExtensionPtr<m_type>> {                                                  \
+		static _FORCE_INLINE_ const GDExtensionPtr<m_type> &get(const Variant *v) {                           \
+			return *reinterpret_cast<const GDExtensionPtr<m_type> *>(VariantInternal::get_int(v));            \
+		}                                                                                                     \
+		static _FORCE_INLINE_ void set(Variant *v, const GDExtensionPtr<m_type> &p_value) {                   \
+			*VariantInternal::get_int(v) = uint64_t(p_value.data);                                            \
+		}                                                                                                     \
 	};
 
 template <typename T>

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -319,10 +319,12 @@ struct ZeroInitializer<T *> {
 	static void initialize(T *&value) { value = nullptr; }
 };
 
-#define ZERO_INITIALIZER_NUMBER(m_type)                      \
-	template <>                                              \
-	struct ZeroInitializer<m_type> {                         \
-		static void initialize(m_type &value) { value = 0; } \
+#define ZERO_INITIALIZER_NUMBER(m_type)         \
+	template <>                                 \
+	struct ZeroInitializer<m_type> {            \
+		static void initialize(m_type &value) { \
+			value = 0;                          \
+		}                                       \
 	};
 
 ZERO_INITIALIZER_NUMBER(uint8_t)

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -831,11 +831,15 @@ struct VariantInternalAccessor<bool> {
 	static _FORCE_INLINE_ void set(Variant *v, bool p_value) { *VariantInternal::get_bool(v) = p_value; }
 };
 
-#define VARIANT_ACCESSOR_NUMBER(m_type)                                                                        \
-	template <>                                                                                                \
-	struct VariantInternalAccessor<m_type> {                                                                   \
-		static _FORCE_INLINE_ m_type get(const Variant *v) { return (m_type) * VariantInternal::get_int(v); }  \
-		static _FORCE_INLINE_ void set(Variant *v, m_type p_value) { *VariantInternal::get_int(v) = p_value; } \
+#define VARIANT_ACCESSOR_NUMBER(m_type)                              \
+	template <>                                                      \
+	struct VariantInternalAccessor<m_type> {                         \
+		static _FORCE_INLINE_ m_type get(const Variant *v) {         \
+			return (m_type) * VariantInternal::get_int(v);           \
+		}                                                            \
+		static _FORCE_INLINE_ void set(Variant *v, m_type p_value) { \
+			*VariantInternal::get_int(v) = p_value;                  \
+		}                                                            \
 	};
 
 VARIANT_ACCESSOR_NUMBER(int8_t)
@@ -1130,10 +1134,12 @@ struct VariantInitializer<bool> {
 	static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<bool>(v); }
 };
 
-#define INITIALIZER_INT(m_type)                                                                    \
-	template <>                                                                                    \
-	struct VariantInitializer<m_type> {                                                            \
-		static _FORCE_INLINE_ void init(Variant *v) { VariantInternal::init_generic<int64_t>(v); } \
+#define INITIALIZER_INT(m_type)                        \
+	template <>                                        \
+	struct VariantInitializer<m_type> {                \
+		static _FORCE_INLINE_ void init(Variant *v) {  \
+			VariantInternal::init_generic<int64_t>(v); \
+		}                                              \
 	};
 
 INITIALIZER_INT(uint8_t)

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -390,9 +390,15 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, v.size());                                                                                               \
 			v.write[index] = PtrToArg<m_elem_type>::convert(member);                                                                 \
 		}                                                                                                                            \
-		static Variant::Type get_index_type() { return GetTypeInfo<m_elem_type>::VARIANT_TYPE; }                                     \
-		static uint32_t get_index_usage() { return GetTypeInfo<m_elem_type>::get_class_info().usage; }                               \
-		static uint64_t get_indexed_size(const Variant *base) { return VariantGetInternalPtr<m_base_type>::get_ptr(base)->size(); }  \
+		static Variant::Type get_index_type() {                                                                                      \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                                           \
+		}                                                                                                                            \
+		static uint32_t get_index_usage() {                                                                                          \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                                 \
+		}                                                                                                                            \
+		static uint64_t get_indexed_size(const Variant *base) {                                                                      \
+			return VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                        \
+		}                                                                                                                            \
 	};
 
 #define INDEXED_SETGET_STRUCT_TYPED_NUMERIC(m_base_type, m_elem_type, m_assign_type)                                                 \
@@ -462,9 +468,15 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, v.size());                                                                                               \
 			v.write[index] = PtrToArg<m_elem_type>::convert(member);                                                                 \
 		}                                                                                                                            \
-		static Variant::Type get_index_type() { return GetTypeInfo<m_elem_type>::VARIANT_TYPE; }                                     \
-		static uint32_t get_index_usage() { return GetTypeInfo<m_elem_type>::get_class_info().usage; }                               \
-		static uint64_t get_indexed_size(const Variant *base) { return VariantGetInternalPtr<m_base_type>::get_ptr(base)->size(); }  \
+		static Variant::Type get_index_type() {                                                                                      \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                                           \
+		}                                                                                                                            \
+		static uint32_t get_index_usage() {                                                                                          \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                                 \
+		}                                                                                                                            \
+		static uint64_t get_indexed_size(const Variant *base) {                                                                      \
+			return VariantGetInternalPtr<m_base_type>::get_ptr(base)->size();                                                        \
+		}                                                                                                                            \
 	};
 
 #define INDEXED_SETGET_STRUCT_BULTIN_NUMERIC(m_base_type, m_elem_type, m_assign_type, m_max)                                   \
@@ -518,9 +530,15 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, m_max);                                                                                            \
 			v[index] = PtrToArg<m_elem_type>::convert(member);                                                                 \
 		}                                                                                                                      \
-		static Variant::Type get_index_type() { return GetTypeInfo<m_elem_type>::VARIANT_TYPE; }                               \
-		static uint32_t get_index_usage() { return GetTypeInfo<m_elem_type>::get_class_info().usage; }                         \
-		static uint64_t get_indexed_size(const Variant *base) { return m_max; }                                                \
+		static Variant::Type get_index_type() {                                                                                \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                                     \
+		}                                                                                                                      \
+		static uint32_t get_index_usage() {                                                                                    \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                           \
+		}                                                                                                                      \
+		static uint64_t get_indexed_size(const Variant *base) {                                                                \
+			return m_max;                                                                                                      \
+		}                                                                                                                      \
 	};
 
 #define INDEXED_SETGET_STRUCT_BULTIN_ACCESSOR(m_base_type, m_elem_type, m_accessor, m_max)                                                \
@@ -568,9 +586,15 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, m_max);                                                                                                       \
 			v m_accessor[index] = PtrToArg<m_elem_type>::convert(member);                                                                 \
 		}                                                                                                                                 \
-		static Variant::Type get_index_type() { return GetTypeInfo<m_elem_type>::VARIANT_TYPE; }                                          \
-		static uint32_t get_index_usage() { return GetTypeInfo<m_elem_type>::get_class_info().usage; }                                    \
-		static uint64_t get_indexed_size(const Variant *base) { return m_max; }                                                           \
+		static Variant::Type get_index_type() {                                                                                           \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                                                \
+		}                                                                                                                                 \
+		static uint32_t get_index_usage() {                                                                                               \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                                      \
+		}                                                                                                                                 \
+		static uint64_t get_indexed_size(const Variant *base) {                                                                           \
+			return m_max;                                                                                                                 \
+		}                                                                                                                                 \
 	};
 
 #define INDEXED_SETGET_STRUCT_BULTIN_FUNC(m_base_type, m_elem_type, m_set, m_get, m_max)                                           \
@@ -618,9 +642,15 @@ Variant Variant::get_named(const StringName &p_member, bool &r_valid) const {
 			OOB_TEST(index, m_max);                                                                                                \
 			v.m_set(index, PtrToArg<m_elem_type>::convert(member));                                                                \
 		}                                                                                                                          \
-		static Variant::Type get_index_type() { return GetTypeInfo<m_elem_type>::VARIANT_TYPE; }                                   \
-		static uint32_t get_index_usage() { return GetTypeInfo<m_elem_type>::get_class_info().usage; }                             \
-		static uint64_t get_indexed_size(const Variant *base) { return m_max; }                                                    \
+		static Variant::Type get_index_type() {                                                                                    \
+			return GetTypeInfo<m_elem_type>::VARIANT_TYPE;                                                                         \
+		}                                                                                                                          \
+		static uint32_t get_index_usage() {                                                                                        \
+			return GetTypeInfo<m_elem_type>::get_class_info().usage;                                                               \
+		}                                                                                                                          \
+		static uint64_t get_indexed_size(const Variant *base) {                                                                    \
+			return m_max;                                                                                                          \
+		}                                                                                                                          \
 	};
 
 struct VariantIndexedSetGet_Array {

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -67,7 +67,9 @@
 			b.m_member = PtrToArg<m_member_type>::convert(member);                                                                   \
 			PtrToArg<m_base_type>::encode(b, base);                                                                                  \
 		}                                                                                                                            \
-		static Variant::Type get_type() { return GetTypeInfo<m_member_type>::VARIANT_TYPE; }                                         \
+		static Variant::Type get_type() {                                                                                            \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                         \
+		}                                                                                                                            \
 	};
 
 #define SETGET_NUMBER_STRUCT(m_base_type, m_member_type, m_member)                                                                \
@@ -101,7 +103,9 @@
 			b.m_member = PtrToArg<m_member_type>::convert(member);                                                                \
 			PtrToArg<m_base_type>::encode(b, base);                                                                               \
 		}                                                                                                                         \
-		static Variant::Type get_type() { return GetTypeInfo<m_member_type>::VARIANT_TYPE; }                                      \
+		static Variant::Type get_type() {                                                                                         \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                      \
+		}                                                                                                                         \
 	};
 
 #define SETGET_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                                         \
@@ -132,7 +136,9 @@
 			b.m_custom = PtrToArg<m_member_type>::convert(member);                                                                   \
 			PtrToArg<m_base_type>::encode(b, base);                                                                                  \
 		}                                                                                                                            \
-		static Variant::Type get_type() { return GetTypeInfo<m_member_type>::VARIANT_TYPE; }                                         \
+		static Variant::Type get_type() {                                                                                            \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                         \
+		}                                                                                                                            \
 	};
 
 #define SETGET_NUMBER_STRUCT_CUSTOM(m_base_type, m_member_type, m_member, m_custom)                                               \
@@ -166,7 +172,9 @@
 			b.m_custom = PtrToArg<m_member_type>::convert(member);                                                                \
 			PtrToArg<m_base_type>::encode(b, base);                                                                               \
 		}                                                                                                                         \
-		static Variant::Type get_type() { return GetTypeInfo<m_member_type>::VARIANT_TYPE; }                                      \
+		static Variant::Type get_type() {                                                                                         \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                      \
+		}                                                                                                                         \
 	};
 
 #define SETGET_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                                \
@@ -197,7 +205,9 @@
 			b.m_setter(PtrToArg<m_member_type>::convert(member));                                                                   \
 			PtrToArg<m_base_type>::encode(b, base);                                                                                 \
 		}                                                                                                                           \
-		static Variant::Type get_type() { return GetTypeInfo<m_member_type>::VARIANT_TYPE; }                                        \
+		static Variant::Type get_type() {                                                                                           \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                        \
+		}                                                                                                                           \
 	};
 
 #define SETGET_NUMBER_STRUCT_FUNC(m_base_type, m_member_type, m_member, m_setter, m_getter)                                         \
@@ -231,7 +241,9 @@
 			b.m_setter(PtrToArg<m_member_type>::convert(member));                                                                   \
 			PtrToArg<m_base_type>::encode(b, base);                                                                                 \
 		}                                                                                                                           \
-		static Variant::Type get_type() { return GetTypeInfo<m_member_type>::VARIANT_TYPE; }                                        \
+		static Variant::Type get_type() {                                                                                           \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                        \
+		}                                                                                                                           \
 	};
 
 #define SETGET_STRUCT_FUNC_INDEX(m_base_type, m_member_type, m_member, m_setter, m_getter, m_index)                                          \
@@ -262,7 +274,9 @@
 			b.m_setter(m_index, PtrToArg<m_member_type>::convert(member));                                                                   \
 			PtrToArg<m_base_type>::encode(b, base);                                                                                          \
 		}                                                                                                                                    \
-		static Variant::Type get_type() { return GetTypeInfo<m_member_type>::VARIANT_TYPE; }                                                 \
+		static Variant::Type get_type() {                                                                                                    \
+			return GetTypeInfo<m_member_type>::VARIANT_TYPE;                                                                                 \
+		}                                                                                                                                    \
 	};
 
 SETGET_NUMBER_STRUCT(Vector2, double, x)

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1370,8 +1370,12 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static bool has_return_type() {                                                                          \
 			return true;                                                                                         \
 		}                                                                                                        \
-		static bool is_vararg() { return false; }                                                                \
-		static Variant::UtilityFunctionType get_type() { return m_category; }                                    \
+		static bool is_vararg() {                                                                                \
+			return false;                                                                                        \
+		}                                                                                                        \
+		static Variant::UtilityFunctionType get_type() {                                                         \
+			return m_category;                                                                                   \
+		}                                                                                                        \
 	};                                                                                                           \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
@@ -1402,8 +1406,12 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static bool has_return_type() {                                                                                 \
 			return true;                                                                                                \
 		}                                                                                                               \
-		static bool is_vararg() { return false; }                                                                       \
-		static Variant::UtilityFunctionType get_type() { return m_category; }                                           \
+		static bool is_vararg() {                                                                                       \
+			return false;                                                                                               \
+		}                                                                                                               \
+		static Variant::UtilityFunctionType get_type() {                                                                \
+			return m_category;                                                                                          \
+		}                                                                                                               \
 	};                                                                                                                  \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
@@ -1436,8 +1444,12 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static bool has_return_type() {                                                                                            \
 			return true;                                                                                                           \
 		}                                                                                                                          \
-		static bool is_vararg() { return false; }                                                                                  \
-		static Variant::UtilityFunctionType get_type() { return m_category; }                                                      \
+		static bool is_vararg() {                                                                                                  \
+			return false;                                                                                                          \
+		}                                                                                                                          \
+		static Variant::UtilityFunctionType get_type() {                                                                           \
+			return m_category;                                                                                                     \
+		}                                                                                                                          \
 	};                                                                                                                             \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
@@ -1470,8 +1482,12 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static bool has_return_type() {                                                                                                                                   \
 			return true;                                                                                                                                                  \
 		}                                                                                                                                                                 \
-		static bool is_vararg() { return false; }                                                                                                                         \
-		static Variant::UtilityFunctionType get_type() { return m_category; }                                                                                             \
+		static bool is_vararg() {                                                                                                                                         \
+			return false;                                                                                                                                                 \
+		}                                                                                                                                                                 \
+		static Variant::UtilityFunctionType get_type() {                                                                                                                  \
+			return m_category;                                                                                                                                            \
+		}                                                                                                                                                                 \
 	};                                                                                                                                                                    \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
@@ -1633,8 +1649,12 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		static bool has_return_type() {                                                                          \
 			return false;                                                                                        \
 		}                                                                                                        \
-		static bool is_vararg() { return false; }                                                                \
-		static Variant::UtilityFunctionType get_type() { return m_category; }                                    \
+		static bool is_vararg() {                                                                                \
+			return false;                                                                                        \
+		}                                                                                                        \
+		static Variant::UtilityFunctionType get_type() {                                                         \
+			return m_category;                                                                                   \
+		}                                                                                                        \
 	};                                                                                                           \
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -70,12 +70,14 @@
 // These types can be used in Vector and other containers that use
 // pointer operations not supported by ARC.
 namespace MTL {
-#define MTL_CLASS(name)                                  \
-	class name {                                         \
-	public:                                              \
-		name(id<MTL##name> obj = nil) : m_obj(obj) {}    \
-		operator id<MTL##name>() const { return m_obj; } \
-		id<MTL##name> m_obj;                             \
+#define MTL_CLASS(name)                               \
+	class name {                                      \
+	public:                                           \
+		name(id<MTL##name> obj = nil) : m_obj(obj) {} \
+		operator id<MTL##name>() const {              \
+			return m_obj;                             \
+		}                                             \
+		id<MTL##name> m_obj;                          \
 	};
 
 MTL_CLASS(Texture)
@@ -949,8 +951,10 @@ void *owned(id p_id) {
 	return (__bridge_retained void *)p_id;
 }
 
-#define MAKE_ID(FROM, TO) \
-	_FORCE_INLINE_ TO make(FROM p_obj) { return TO(owned(p_obj)); }
+#define MAKE_ID(FROM, TO)                \
+	_FORCE_INLINE_ TO make(FROM p_obj) { \
+		return TO(owned(p_obj));         \
+	}
 
 MAKE_ID(id<MTLTexture>, RDD::TextureID)
 MAKE_ID(id<MTLBuffer>, RDD::BufferID)

--- a/drivers/metal/metal_utils.h
+++ b/drivers/metal/metal_utils.h
@@ -53,11 +53,15 @@ void clear(Tv &p_value, Tm p_mask) {
 
 /*! Returns whether the specified value has any of the bits specified in mask set to 1. */
 template <typename Tv, typename Tm>
-static constexpr bool any(Tv p_value, const Tm p_mask) { return ((p_value & p_mask) != 0); }
+static constexpr bool any(Tv p_value, const Tm p_mask) {
+	return ((p_value & p_mask) != 0);
+}
 
 /*! Returns whether the specified value has all of the bits specified in mask set to 1. */
 template <typename Tv, typename Tm>
-static constexpr bool all(Tv p_value, const Tm p_mask) { return ((p_value & p_mask) == p_mask); }
+static constexpr bool all(Tv p_value, const Tm p_mask) {
+	return ((p_value & p_mask) == p_mask);
+}
 
 } //namespace flags
 

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -33,18 +33,26 @@
 
 #include "servers/rendering/rendering_device.h"
 
-#define RD_SETGET(m_type, m_member)                                            \
-	void set_##m_member(m_type p_##m_member) { base.m_member = p_##m_member; } \
-	m_type get_##m_member() const { return base.m_member; }
+#define RD_SETGET(m_type, m_member)            \
+	void set_##m_member(m_type p_##m_member) { \
+		base.m_member = p_##m_member;          \
+	}                                          \
+	m_type get_##m_member() const {            \
+		return base.m_member;                  \
+	}
 
 #define RD_BIND(m_variant_type, m_class, m_member)                                                          \
 	ClassDB::bind_method(D_METHOD("set_" _MKSTR(m_member), "p_" _MKSTR(member)), &m_class::set_##m_member); \
 	ClassDB::bind_method(D_METHOD("get_" _MKSTR(m_member)), &m_class::get_##m_member);                      \
 	ADD_PROPERTY(PropertyInfo(m_variant_type, #m_member), "set_" _MKSTR(m_member), "get_" _MKSTR(m_member))
 
-#define RD_SETGET_SUB(m_type, m_sub, m_member)                                                 \
-	void set_##m_sub##_##m_member(m_type p_##m_member) { base.m_sub.m_member = p_##m_member; } \
-	m_type get_##m_sub##_##m_member() const { return base.m_sub.m_member; }
+#define RD_SETGET_SUB(m_type, m_sub, m_member)           \
+	void set_##m_sub##_##m_member(m_type p_##m_member) { \
+		base.m_sub.m_member = p_##m_member;              \
+	}                                                    \
+	m_type get_##m_sub##_##m_member() const {            \
+		return base.m_sub.m_member;                      \
+	}
 
 #define RD_BIND_SUB(m_variant_type, m_class, m_sub, m_member)                                                                           \
 	ClassDB::bind_method(D_METHOD("set_" _MKSTR(m_sub) "_" _MKSTR(m_member), "p_" _MKSTR(member)), &m_class::set_##m_sub##_##m_member); \

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -125,20 +125,28 @@ public:
 				id(p_id) {}
 	};
 
-#define DEFINE_ID(m_name)                                                                             \
-	struct m_name##ID : public ID {                                                                   \
-		_ALWAYS_INLINE_ explicit operator bool() const { return id != 0; }                            \
-		_ALWAYS_INLINE_ m_name##ID &operator=(m_name##ID p_other) {                                   \
-			id = p_other.id;                                                                          \
-			return *this;                                                                             \
-		}                                                                                             \
-		_ALWAYS_INLINE_ bool operator<(const m_name##ID &p_other) const { return id < p_other.id; }   \
-		_ALWAYS_INLINE_ bool operator==(const m_name##ID &p_other) const { return id == p_other.id; } \
-		_ALWAYS_INLINE_ bool operator!=(const m_name##ID &p_other) const { return id != p_other.id; } \
-		_ALWAYS_INLINE_ m_name##ID(const m_name##ID &p_other) : ID(p_other.id) {}                     \
-		_ALWAYS_INLINE_ explicit m_name##ID(uint64_t p_int) : ID(p_int) {}                            \
-		_ALWAYS_INLINE_ explicit m_name##ID(void *p_ptr) : ID((uint64_t)p_ptr) {}                     \
-		_ALWAYS_INLINE_ m_name##ID() = default;                                                       \
+#define DEFINE_ID(m_name)                                                         \
+	struct m_name##ID : public ID {                                               \
+		_ALWAYS_INLINE_ explicit operator bool() const {                          \
+			return id != 0;                                                       \
+		}                                                                         \
+		_ALWAYS_INLINE_ m_name##ID &operator=(m_name##ID p_other) {               \
+			id = p_other.id;                                                      \
+			return *this;                                                         \
+		}                                                                         \
+		_ALWAYS_INLINE_ bool operator<(const m_name##ID &p_other) const {         \
+			return id < p_other.id;                                               \
+		}                                                                         \
+		_ALWAYS_INLINE_ bool operator==(const m_name##ID &p_other) const {        \
+			return id == p_other.id;                                              \
+		}                                                                         \
+		_ALWAYS_INLINE_ bool operator!=(const m_name##ID &p_other) const {        \
+			return id != p_other.id;                                              \
+		}                                                                         \
+		_ALWAYS_INLINE_ m_name##ID(const m_name##ID &p_other) : ID(p_other.id) {} \
+		_ALWAYS_INLINE_ explicit m_name##ID(uint64_t p_int) : ID(p_int) {}        \
+		_ALWAYS_INLINE_ explicit m_name##ID(void *p_ptr) : ID((uint64_t)p_ptr) {} \
+		_ALWAYS_INLINE_ m_name##ID() = default;                                   \
 	};
 
 	// Id types declared before anything else to prevent cyclic dependencies between the different concerns.


### PR DESCRIPTION
- Followup to #100830

Jumped the gun in merging the above PR, as it didn't do a pass applying the changes. This PR fixes that, and thankfully only a handful of files were affected. This *technically* causes class-specific macros — those that create a classes or are used in classes exclusively — to not be formatted correctly (should be treated as "inline"), but that scenario is relatively niche so it isn't a dealbreaker. Any macros that only had partial changes were given `/*****/` spacers to not clutter the diffs, inspired by [the same strategy](https://github.com/godotengine/godot-cpp/blob/47f11bc5c79b78c453805bcdd506d47ce163c60a/include/godot_cpp/classes/wrapped.hpp#L187-L189) in godot-cpp.