### PR TITLE
Use 1.5x growth factor for LocalVector

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -59,9 +59,7 @@ public:
 
 	_FORCE_INLINE_ void push_back(T p_elem) {
 		if (unlikely(count == capacity)) {
-			capacity = tight ? (capacity + 1) : MAX((U)1, capacity << 1);
-			data = (T *)memrealloc(data, capacity * sizeof(T));
-			CRASH_COND_MSG(!data, "Out of memory");
+			reserve(count + 1);
 		}
 
 		if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
@@ -137,10 +135,16 @@ public:
 	}
 	_FORCE_INLINE_ bool is_empty() const { return count == 0; }
 	_FORCE_INLINE_ U get_capacity() const { return capacity; }
-	_FORCE_INLINE_ void reserve(U p_size) {
-		p_size = tight ? p_size : nearest_power_of_2_templated(p_size);
+	void reserve(U p_size) {
 		if (p_size > capacity) {
-			capacity = p_size;
+			if (tight) {
+				capacity = p_size;
+			} else {
+				capacity = MAX((U)2, capacity + ((1 + capacity) >> 1));
+				if (p_size > capacity) {
+					capacity = p_size;
+				}
+			}
 			data = (T *)memrealloc(data, capacity * sizeof(T));
 			CRASH_COND_MSG(!data, "Out of memory");
 		}
@@ -156,11 +160,7 @@ public:
 			}
 			count = p_size;
 		} else if (p_size > count) {
-			if (unlikely(p_size > capacity)) {
-				capacity = tight ? p_size : nearest_power_of_2_templated(p_size);
-				data = (T *)memrealloc(data, capacity * sizeof(T));
-				CRASH_COND_MSG(!data, "Out of memory");
-			}
+			reserve(p_size);
 			if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
 				for (U i = count; i < p_size; i++) {
 					memnew_placement(&data[i], T);

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -614,7 +614,7 @@ public:
 	};
 
 	struct AttachmentReference {
-		static const uint32_t UNUSED = 0xffffffff;
+		static constexpr uint32_t UNUSED = 0xffffffff;
 		uint32_t attachment = UNUSED;
 		TextureLayout layout = TEXTURE_LAYOUT_UNDEFINED;
 		BitField<TextureAspectBits> aspect;


### PR DESCRIPTION
This is explained here https://github.com/godotengine/godot-proposals/issues/7366.

Also, now if we use resize, as much memory as we need will be allocated if we increase the size by a value greater than `1.5 * capacity`.

I tested in tps-demo and the memory usage difference is 2-3 megabytes. Did not notice the difference in FPS.