### PR TITLE
LSP: cast id in JSONRPC::process_action to int64 Variant

### DIFF
--- a/modules/jsonrpc/jsonrpc.cpp
+++ b/modules/jsonrpc/jsonrpc.cpp
@@ -121,7 +121,7 @@ Variant JSONRPC::process_action(const Variant &p_action, bool p_process_arr_elem
 
 		Variant id;
 		if (dict.has("id")) {
-			id = dict["id"];
+			id = (int64_t)dict["id"];
 		}
 
 		if (object == nullptr || !object->has_method(method)) {


### PR DESCRIPTION
bug caused by #47502
issue reported by me in #100914

Im glad the godot codebase has a reasonably easy and fast build system compared to some cpp codebases i've worked in. Plus decent docs for a cpp codebase, not bad!

