### PR TITLE
Core: Cleanup Array/Dictionary implementation

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -40,7 +40,7 @@
 #include "core/variant/dictionary.h"
 #include "core/variant/variant.h"
 
-struct ArrayPrivate {
+struct Array::ArrayPrivate {
 	SafeRefCount refcount;
 	Vector<Variant> array;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
@@ -916,6 +916,12 @@ Array::Array(const Array &p_from) {
 Array::Array() {
 	_p = memnew(ArrayPrivate);
 	_p->refcount.init();
+}
+
+Array::Array(std::initializer_list<Variant> p_init) {
+	_p = memnew(ArrayPrivate);
+	_p->refcount.init();
+	_p->array = p_init;
 }
 
 Array::~Array() {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -39,10 +39,10 @@ class Callable;
 class StringName;
 class Variant;
 
-struct ArrayPrivate;
 struct ContainerType;
 
 class Array {
+	struct ArrayPrivate;
 	mutable ArrayPrivate *_p;
 	void _unref() const;
 
@@ -204,6 +204,7 @@ public:
 
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);
+	Array(std::initializer_list<Variant> p_init);
 	Array();
 	~Array();
 };

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -40,7 +40,7 @@
 #include "core/variant/type_info.h"
 #include "core/variant/variant_internal.h"
 
-struct DictionaryPrivate {
+struct Dictionary::DictionaryPrivate {
 	SafeRefCount refcount;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
 	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator> variant_map;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -31,17 +31,17 @@
 #ifndef DICTIONARY_H
 #define DICTIONARY_H
 
-#include "core/string/ustring.h"
 #include "core/templates/list.h"
 #include "core/templates/pair.h"
-#include "core/variant/array.h"
 
+class Array;
+class StringName;
 class Variant;
 
 struct ContainerType;
-struct DictionaryPrivate;
 
 class Dictionary {
+	struct DictionaryPrivate;
 	mutable DictionaryPrivate *_p;
 
 	void _ref(const Dictionary &p_from) const;

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -43,17 +43,20 @@ class TypedArray : public Array {
 public:
 	_FORCE_INLINE_ void operator=(const Array &p_array) {
 		ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type.");
-		_ref(p_array);
+		Array::operator=(p_array);
 	}
-	_FORCE_INLINE_ TypedArray(const Variant &p_variant) :
-			TypedArray(Array(p_variant)) {
-	}
-	_FORCE_INLINE_ TypedArray(const Array &p_array) {
-		set_typed(Variant::OBJECT, T::get_class_static(), Variant());
+	_FORCE_INLINE_ TypedArray(const Array &p_array) :
+			TypedArray() {
 		if (is_same_typed(p_array)) {
-			_ref(p_array);
+			Array::operator=(p_array);
 		} else {
 			assign(p_array);
+		}
+	}
+	_FORCE_INLINE_ TypedArray(std::initializer_list<T *> p_init) :
+			TypedArray() {
+		for (const T &element : p_init) {
+			push_back(element);
 		}
 	}
 	_FORCE_INLINE_ TypedArray() {
@@ -72,34 +75,88 @@ struct VariantInternalAccessor<const TypedArray<T> &> {
 	static _FORCE_INLINE_ void set(Variant *v, const TypedArray<T> &p_array) { *VariantInternal::get_array(v) = p_array; }
 };
 
-//specialization for the rest of variant types
+template <typename T>
+struct PtrToArg<TypedArray<T>> {
+	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
+		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
+	}
+	typedef Array EncodeT;
+	_FORCE_INLINE_ static void encode(TypedArray<T> p_val, void *p_ptr) {
+		*(Array *)p_ptr = p_val;
+	}
+};
 
-#define MAKE_TYPED_ARRAY(m_type, m_variant_type)                                                                 \
-	template <>                                                                                                  \
-	class TypedArray<m_type> : public Array {                                                                    \
-	public:                                                                                                      \
-		_FORCE_INLINE_ void operator=(const Array &p_array) {                                                    \
-			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type."); \
-			_ref(p_array);                                                                                       \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Variant &p_variant) :                                                    \
-				TypedArray(Array(p_variant)) {                                                                   \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray(const Array &p_array) {                                                        \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
-			if (is_same_typed(p_array)) {                                                                        \
-				_ref(p_array);                                                                                   \
-			} else {                                                                                             \
-				assign(p_array);                                                                                 \
-			}                                                                                                    \
-		}                                                                                                        \
-		_FORCE_INLINE_ TypedArray() {                                                                            \
-			set_typed(m_variant_type, StringName(), Variant());                                                  \
-		}                                                                                                        \
+template <typename T>
+struct PtrToArg<const TypedArray<T> &> {
+	typedef Array EncodeT;
+	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
+		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
+	}
+};
+
+template <typename T>
+struct GetTypeInfo<TypedArray<T>> {
+	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
+	}
+};
+
+template <typename T>
+struct GetTypeInfo<const TypedArray<T> &> {
+	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
+	}
+};
+
+// Specialization for the rest of the Variant types.
+
+#define MAKE_TYPED_ARRAY(m_type, m_variant_type)                                                                             \
+	template <>                                                                                                              \
+	class TypedArray<m_type> : public Array {                                                                                \
+	public:                                                                                                                  \
+		_FORCE_INLINE_ void operator=(const Array &p_array) {                                                                \
+			ERR_FAIL_COND_MSG(!is_same_typed(p_array), "Cannot assign an array with a different element type.");             \
+			Array::operator=(p_array);                                                                                       \
+		}                                                                                                                    \
+		_FORCE_INLINE_ TypedArray(const Array &p_array) :                                                                    \
+				TypedArray() {                                                                                               \
+			if (is_same_typed(p_array)) {                                                                                    \
+				Array::operator=(p_array);                                                                                   \
+			} else {                                                                                                         \
+				assign(p_array);                                                                                             \
+			}                                                                                                                \
+		}                                                                                                                    \
+		_FORCE_INLINE_ TypedArray(std::initializer_list<m_type> p_init) :                                                    \
+				TypedArray() {                                                                                               \
+			for (const m_type &element : p_init) {                                                                           \
+				push_back(element);                                                                                          \
+			}                                                                                                                \
+		}                                                                                                                    \
+		_FORCE_INLINE_ TypedArray() {                                                                                        \
+			set_typed(m_variant_type, StringName(), Variant());                                                              \
+		}                                                                                                                    \
+	};                                                                                                                       \
+	template <>                                                                                                              \
+	struct GetTypeInfo<TypedArray<m_type>> {                                                                                 \
+		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
+		static inline PropertyInfo get_class_info() {                                                                        \
+			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
+		}                                                                                                                    \
+	};                                                                                                                       \
+	template <>                                                                                                              \
+	struct GetTypeInfo<const TypedArray<m_type> &> {                                                                         \
+		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
+		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
+		static inline PropertyInfo get_class_info() {                                                                        \
+			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
+		}                                                                                                                    \
 	};
 
-// All Variant::OBJECT types are intentionally omitted from this list because they are handled by
-// the unspecialized TypedArray definition.
 MAKE_TYPED_ARRAY(bool, Variant::BOOL)
 MAKE_TYPED_ARRAY(uint8_t, Variant::INT)
 MAKE_TYPED_ARRAY(int8_t, Variant::INT)
@@ -147,109 +204,6 @@ MAKE_TYPED_ARRAY(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
 MAKE_TYPED_ARRAY(PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY)
 MAKE_TYPED_ARRAY(IPAddress, Variant::STRING)
 
-template <typename T>
-struct PtrToArg<TypedArray<T>> {
-	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
-		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
-	}
-	typedef Array EncodeT;
-	_FORCE_INLINE_ static void encode(TypedArray<T> p_val, void *p_ptr) {
-		*(Array *)p_ptr = p_val;
-	}
-};
-
-template <typename T>
-struct PtrToArg<const TypedArray<T> &> {
-	typedef Array EncodeT;
-	_FORCE_INLINE_ static TypedArray<T> convert(const void *p_ptr) {
-		return TypedArray<T>(*reinterpret_cast<const Array *>(p_ptr));
-	}
-};
-
-template <typename T>
-struct GetTypeInfo<TypedArray<T>> {
-	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
-	}
-};
-
-template <typename T>
-struct GetTypeInfo<const TypedArray<T> &> {
-	static const Variant::Type VARIANT_TYPE = Variant::ARRAY;
-	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
-	static inline PropertyInfo get_class_info() {
-		return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, T::get_class_static());
-	}
-};
-
-#define MAKE_TYPED_ARRAY_INFO(m_type, m_variant_type)                                                                        \
-	template <>                                                                                                              \
-	struct GetTypeInfo<TypedArray<m_type>> {                                                                                 \
-		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
-		static inline PropertyInfo get_class_info() {                                                                        \
-			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
-		}                                                                                                                    \
-	};                                                                                                                       \
-	template <>                                                                                                              \
-	struct GetTypeInfo<const TypedArray<m_type> &> {                                                                         \
-		static const Variant::Type VARIANT_TYPE = Variant::ARRAY;                                                            \
-		static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;                                        \
-		static inline PropertyInfo get_class_info() {                                                                        \
-			return PropertyInfo(Variant::ARRAY, String(), PROPERTY_HINT_ARRAY_TYPE, Variant::get_type_name(m_variant_type)); \
-		}                                                                                                                    \
-	};
-
-MAKE_TYPED_ARRAY_INFO(bool, Variant::BOOL)
-MAKE_TYPED_ARRAY_INFO(uint8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int8_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int16_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int32_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(uint64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(int64_t, Variant::INT)
-MAKE_TYPED_ARRAY_INFO(float, Variant::FLOAT)
-MAKE_TYPED_ARRAY_INFO(double, Variant::FLOAT)
-MAKE_TYPED_ARRAY_INFO(String, Variant::STRING)
-MAKE_TYPED_ARRAY_INFO(Vector2, Variant::VECTOR2)
-MAKE_TYPED_ARRAY_INFO(Vector2i, Variant::VECTOR2I)
-MAKE_TYPED_ARRAY_INFO(Rect2, Variant::RECT2)
-MAKE_TYPED_ARRAY_INFO(Rect2i, Variant::RECT2I)
-MAKE_TYPED_ARRAY_INFO(Vector3, Variant::VECTOR3)
-MAKE_TYPED_ARRAY_INFO(Vector3i, Variant::VECTOR3I)
-MAKE_TYPED_ARRAY_INFO(Transform2D, Variant::TRANSFORM2D)
-MAKE_TYPED_ARRAY_INFO(Vector4, Variant::VECTOR4)
-MAKE_TYPED_ARRAY_INFO(Vector4i, Variant::VECTOR4I)
-MAKE_TYPED_ARRAY_INFO(Plane, Variant::PLANE)
-MAKE_TYPED_ARRAY_INFO(Quaternion, Variant::QUATERNION)
-MAKE_TYPED_ARRAY_INFO(AABB, Variant::AABB)
-MAKE_TYPED_ARRAY_INFO(Basis, Variant::BASIS)
-MAKE_TYPED_ARRAY_INFO(Transform3D, Variant::TRANSFORM3D)
-MAKE_TYPED_ARRAY_INFO(Projection, Variant::PROJECTION)
-MAKE_TYPED_ARRAY_INFO(Color, Variant::COLOR)
-MAKE_TYPED_ARRAY_INFO(StringName, Variant::STRING_NAME)
-MAKE_TYPED_ARRAY_INFO(NodePath, Variant::NODE_PATH)
-MAKE_TYPED_ARRAY_INFO(RID, Variant::RID)
-MAKE_TYPED_ARRAY_INFO(Callable, Variant::CALLABLE)
-MAKE_TYPED_ARRAY_INFO(Signal, Variant::SIGNAL)
-MAKE_TYPED_ARRAY_INFO(Dictionary, Variant::DICTIONARY)
-MAKE_TYPED_ARRAY_INFO(Array, Variant::ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedByteArray, Variant::PACKED_BYTE_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedInt32Array, Variant::PACKED_INT32_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedInt64Array, Variant::PACKED_INT64_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedFloat32Array, Variant::PACKED_FLOAT32_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedFloat64Array, Variant::PACKED_FLOAT64_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedStringArray, Variant::PACKED_STRING_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector2Array, Variant::PACKED_VECTOR2_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector3Array, Variant::PACKED_VECTOR3_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedColorArray, Variant::PACKED_COLOR_ARRAY)
-MAKE_TYPED_ARRAY_INFO(PackedVector4Array, Variant::PACKED_VECTOR4_ARRAY)
-MAKE_TYPED_ARRAY_INFO(IPAddress, Variant::STRING)
-
 #undef MAKE_TYPED_ARRAY
-#undef MAKE_TYPED_ARRAY_INFO
 
 #endif // TYPED_ARRAY_H

--- a/core/variant/typed_dictionary.h
+++ b/core/variant/typed_dictionary.h
@@ -45,27 +45,22 @@ public:
 		ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign a dictionary with a different element type.");
 		Dictionary::operator=(p_dictionary);
 	}
-	_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :
-			TypedDictionary(Dictionary(p_variant)) {
-	}
-	_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {
-		set_typed(Variant::OBJECT, K::get_class_static(), Variant(), Variant::OBJECT, V::get_class_static(), Variant());
+	_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) :
+			TypedDictionary() {
 		if (is_same_typed(p_dictionary)) {
 			Dictionary::operator=(p_dictionary);
 		} else {
 			assign(p_dictionary);
 		}
 	}
+	_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<K *, V *>> p_init) :
+			TypedDictionary() {
+		for (const KeyValue<K *, V *> &element : p_init) {
+			operator[](element.key) = element.value;
+		}
+	}
 	_FORCE_INLINE_ TypedDictionary() {
 		set_typed(Variant::OBJECT, K::get_class_static(), Variant(), Variant::OBJECT, V::get_class_static(), Variant());
-	}
-
-	_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<K, V>> p_init) :
-			Dictionary() {
-		set_typed(Variant::OBJECT, K::get_class_static(), Variant(), Variant::OBJECT, V::get_class_static(), Variant());
-		for (const KeyValue<K, V> &E : p_init) {
-			operator[](E.key) = E.value;
-		}
 	}
 };
 
@@ -129,26 +124,22 @@ struct GetTypeInfo<const TypedDictionary<K, V> &> {
 			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");                         \
 			Dictionary::operator=(p_dictionary);                                                                                                   \
 		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                                 \
-				TypedDictionary(Dictionary(p_variant)) {                                                                                           \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                                           \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                                 \
+		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) :                                                                           \
+				TypedDictionary() {                                                                                                                \
 			if (is_same_typed(p_dictionary)) {                                                                                                     \
 				Dictionary::operator=(p_dictionary);                                                                                               \
 			} else {                                                                                                                               \
 				assign(p_dictionary);                                                                                                              \
 			}                                                                                                                                      \
 		}                                                                                                                                          \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<T *, m_type>> p_init) :                                                      \
+				TypedDictionary() {                                                                                                                \
+			for (const KeyValue<T *, m_type> &element : p_init) {                                                                                  \
+				operator[](element.key) = element.value;                                                                                           \
+			}                                                                                                                                      \
+		}                                                                                                                                          \
 		_FORCE_INLINE_ TypedDictionary() {                                                                                                         \
 			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                                 \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<T, m_type>> p_init) :                                                        \
-				Dictionary() {                                                                                                                     \
-			set_typed(Variant::OBJECT, T::get_class_static(), Variant(), m_variant_type, StringName(), Variant());                                 \
-			for (const KeyValue<T, m_type> &E : p_init) {                                                                                          \
-				operator[](E.key) = E.value;                                                                                                       \
-			}                                                                                                                                      \
 		}                                                                                                                                          \
 	};                                                                                                                                             \
 	template <typename T>                                                                                                                          \
@@ -176,15 +167,18 @@ struct GetTypeInfo<const TypedDictionary<K, V> &> {
 			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");                         \
 			Dictionary::operator=(p_dictionary);                                                                                                   \
 		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                                 \
-				TypedDictionary(Dictionary(p_variant)) {                                                                                           \
-		}                                                                                                                                          \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                                           \
-			set_typed(m_variant_type, StringName(), Variant(), Variant::OBJECT, T::get_class_static(), Variant());                                 \
+		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) :                                                                           \
+				TypedDictionary() {                                                                                                                \
 			if (is_same_typed(p_dictionary)) {                                                                                                     \
 				Dictionary::operator=(p_dictionary);                                                                                               \
 			} else {                                                                                                                               \
 				assign(p_dictionary);                                                                                                              \
+			}                                                                                                                                      \
+		}                                                                                                                                          \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type, T *>> p_init) :                                                      \
+				TypedDictionary() {                                                                                                                \
+			for (const KeyValue<m_type, T *> &element : p_init) {                                                                                  \
+				operator[](element.key) = element.value;                                                                                           \
 			}                                                                                                                                      \
 		}                                                                                                                                          \
 		_FORCE_INLINE_ TypedDictionary() {                                                                                                         \
@@ -218,26 +212,22 @@ struct GetTypeInfo<const TypedDictionary<K, V> &> {
 			ERR_FAIL_COND_MSG(!is_same_typed(p_dictionary), "Cannot assign an dictionary with a different element type.");        \
 			Dictionary::operator=(p_dictionary);                                                                                  \
 		}                                                                                                                         \
-		_FORCE_INLINE_ TypedDictionary(const Variant &p_variant) :                                                                \
-				TypedDictionary(Dictionary(p_variant)) {                                                                          \
-		}                                                                                                                         \
-		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {                                                          \
-			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());                \
+		_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) :                                                          \
+				TypedDictionary() {                                                                                               \
 			if (is_same_typed(p_dictionary)) {                                                                                    \
 				Dictionary::operator=(p_dictionary);                                                                              \
 			} else {                                                                                                              \
 				assign(p_dictionary);                                                                                             \
 			}                                                                                                                     \
 		}                                                                                                                         \
+		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type_key, m_type_value>> p_init) :                        \
+				TypedDictionary() {                                                                                               \
+			for (const KeyValue<m_type_key, m_type_value> &element : p_init) {                                                    \
+				operator[](element.key) = element.value;                                                                          \
+			}                                                                                                                     \
+		}                                                                                                                         \
 		_FORCE_INLINE_ TypedDictionary() {                                                                                        \
 			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());                \
-		}                                                                                                                         \
-		_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<m_type_key, m_type_value>> p_init) :                        \
-				Dictionary() {                                                                                                    \
-			set_typed(m_variant_type_key, StringName(), Variant(), m_variant_type_value, StringName(), Variant());                \
-			for (const KeyValue<m_type_key, m_type_value> &E : p_init) {                                                          \
-				operator[](E.key) = E.value;                                                                                      \
-			}                                                                                                                     \
 		}                                                                                                                         \
 	};                                                                                                                            \
 	template <>                                                                                                                   \

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -66,6 +66,10 @@ class RefCounted;
 
 template <typename T>
 class Ref;
+template <typename T>
+class TypedArray;
+template <typename K, typename V>
+class TypedDictionary;
 
 struct PropertyInfo;
 struct MethodInfo;
@@ -447,6 +451,11 @@ public:
 
 	operator IPAddress() const;
 
+	template <typename T>
+	_FORCE_INLINE_ operator TypedArray<T>() const { return operator Array(); }
+	template <typename K, typename V>
+	_FORCE_INLINE_ operator TypedDictionary<K, V>() const { return operator Dictionary(); }
+
 	Object *get_validated_object() const;
 	Object *get_validated_object_with_check(bool &r_previously_freed) const;
 
@@ -508,6 +517,13 @@ public:
 	Variant(const Vector<StringName> &p_array);
 
 	Variant(const IPAddress &p_address);
+
+	template <typename T>
+	_FORCE_INLINE_ Variant(const TypedArray<T> &p_typed_array) :
+			Variant(static_cast<Array>(p_typed_array)) {}
+	template <typename K, typename V>
+	_FORCE_INLINE_ Variant(const TypedDictionary<K, V> &p_typed_dictionary) :
+			Variant(static_cast<Dictionary>(p_typed_dictionary)) {}
 
 #define VARIANT_ENUM_CLASS_CONSTRUCTOR(m_enum) \
 	Variant(m_enum p_value) :                  \

--- a/tests/core/variant/test_array.h
+++ b/tests/core/variant/test_array.h
@@ -84,6 +84,22 @@ TEST_CASE("[Array] Assignment and comparison operators") {
 	CHECK(arr3 == arr2);
 }
 
+TEST_CASE("[Array] List init") {
+	Array arr = { 0, PackedStringArray({ "array", "of", "values" }), Dictionary({ { "nested", 200 } }), Vector2(1, 2) };
+	CHECK(arr.size() == 4);
+	CHECK(int(arr[0]) == 0);
+	CHECK(PackedStringArray(arr[1])[2] == "values");
+	CHECK(Dictionary(arr[2])["nested"] == Variant(200));
+	CHECK(Vector2(arr[3]) == Vector2(1, 2));
+
+	TypedArray<double> tarr = { 0.0, 1.0f, 5, size_t(2) };
+	CHECK(tarr.size() == 4);
+	CHECK(double(tarr[0]) == 0.0);
+	CHECK(double(tarr[1]) == 1.0f);
+	CHECK(double(tarr[2]) == 5);
+	CHECK(double(tarr[3]) == size_t(2));
+}
+
 TEST_CASE("[Array] append_array()") {
 	Array arr1;
 	Array arr2;


### PR DESCRIPTION
- Partially supersedes #96741
- Partially supersedes #89782
- Partially supersedes #86015

A collection of fixes/improvements for Arrays & Dictionaries, particularly the typed variants. In no particular order:
- Fixed `std::initializer_list` support on `TypedDictionary` by adding a few missing declarations & ensuring that `Object` types are passed as pointers.
- Added `std::initializer_list` support for `Array`/`TypedArray` along with dedicated tests.
- Moved `Variant` conversion logic from `TypedArray`/`TypedDictionary` to `Variant` via forward-declared templates.
- Consolidated `typed_array.h` specialization macros into one, much like `typed_dictionary.h`.
- Migrated `ArrayPrivate`/`DictionaryPrivate`; they're now nested within their respective base classes.