### PR TITLE
Fix `NodePath::slice()` incorrect behavior for subname indexing

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -255,7 +255,7 @@ NodePath NodePath::slice(int p_begin, int p_end) const {
 	if (end < 0) {
 		end += total_count;
 	}
-	const int sub_begin = MAX(begin - name_count - 1, 0);
+	const int sub_begin = MAX(begin - name_count, 0);
 	const int sub_end = MAX(end - name_count, 0);
 
 	const Vector<StringName> names = get_names().slice(begin, end);

--- a/tests/core/string/test_node_path.h
+++ b/tests/core/string/test_node_path.h
@@ -169,28 +169,31 @@ TEST_CASE("[NodePath] Empty path") {
 }
 
 TEST_CASE("[NodePath] Slice") {
-	const NodePath node_path_relative = NodePath("Parent/Child:prop");
+	const NodePath node_path_relative = NodePath("Parent/Child:prop:subprop");
 	const NodePath node_path_absolute = NodePath("/root/Parent/Child:prop");
 	CHECK_MESSAGE(
 			node_path_relative.slice(0, 2) == NodePath("Parent/Child"),
 			"The slice lower bound should be inclusive and the slice upper bound should be exclusive.");
 	CHECK_MESSAGE(
-			node_path_relative.slice(3) == NodePath(":prop"),
-			"Slicing on the length of the path should return the last entry.");
+			node_path_relative.slice(3) == NodePath(":subprop"),
+			"Slicing on the last index (length - 1) should return the last entry.");
+	CHECK_MESSAGE(
+			node_path_relative.slice(1) == NodePath("Child:prop:subprop"),
+			"Slicing without upper bound should return remaining entries after index.");
 	CHECK_MESSAGE(
 			node_path_relative.slice(1, 3) == NodePath("Child:prop"),
 			"Slicing should include names and subnames.");
 	CHECK_MESSAGE(
-			node_path_relative.slice(-1) == NodePath(":prop"),
+			node_path_relative.slice(-1) == NodePath(":subprop"),
 			"Slicing on -1 should return the last entry.");
 	CHECK_MESSAGE(
-			node_path_relative.slice(0, -1) == NodePath("Parent/Child"),
+			node_path_relative.slice(0, -1) == NodePath("Parent/Child:prop"),
 			"Slicing up to -1 should include the second-to-last entry.");
 	CHECK_MESSAGE(
-			node_path_relative.slice(-2, -1) == NodePath("Child"),
+			node_path_relative.slice(-2, -1) == NodePath(":prop"),
 			"Slicing from negative to negative should treat lower bound as inclusive and upper bound as exclusive.");
 	CHECK_MESSAGE(
-			node_path_relative.slice(0, 10) == NodePath("Parent/Child:prop"),
+			node_path_relative.slice(0, 10) == NodePath("Parent/Child:prop:subprop"),
 			"Slicing past the length of the path should work like slicing up to the last entry.");
 	CHECK_MESSAGE(
 			node_path_relative.slice(-10, 2) == NodePath("Parent/Child"),


### PR DESCRIPTION
Following GDScript code:
```gdscript
var path = NodePath("Parent/Child:prop:subprop")
print("slice(0, 1): ", path.slice(0, 1))
print("slice(1, 2): ", path.slice(1, 2))
print("slice(2, 3): ", path.slice(2, 3))
print("slice(3, 4): ", path.slice(3, 4))
print("slice(4, 5): ", path.slice(4, 5))
print("slice(-1):   ", path.slice(-1))
print("slice(-2):   ", path.slice(-2))
print("slice(-3):   ", path.slice(-3))
print("slice(-4):   ", path.slice(-4))
```

Behavior on `master`:
```py
slice(0, 1): Parent
slice(1, 2): Child
slice(2, 3): :prop
slice(3, 4): :prop:subprop     <---
slice(4, 5): :subprop          <---

slice(-1):   :prop:subprop     <---
slice(-2):   :prop:subprop
slice(-3):   Child:prop:subprop
slice(-4):   Parent/Child:prop:subprop
```

I believe the 3 marked results are not intended.
Behavior after this PR:
```py
slice(0, 1): Parent
slice(1, 2): Child
slice(2, 3): :prop
slice(3, 4): :subprop
slice(4, 5): 

slice(-1):   :subprop
slice(-2):   :prop:subprop
slice(-3):   Child:prop:subprop
slice(-4):   Parent/Child:prop:subprop
```

I updated the unit tests to include 2 subnames, which reveals the problem.

---

Previously this test existed:

> "Slicing on the length of the path should return the last entry."

But this is unintuitive, the last valid index in arrays is always `size-1`, not `size`. At least it's not clear to me why one would want this behavior, and it makes iterating through slices non-continuous. So I changed the test, but let me know if there was a reason for this.