### PR TITLE
CI: Add problem matcher for Godot, fail tests if triggered

### DIFF
--- a/misc/utility/problem-matchers.json
+++ b/misc/utility/problem-matchers.json
@@ -27,6 +27,21 @@
 					"message": 6
 				}
 			]
+		},
+		{
+			"owner": "godot",
+			"pattern": [
+				{
+					"regexp": "^(?:\\x1b\\[[;\\d]+m)?(?:(?:SCRIPT|SHADER|UNKNOWN)\\s)?(ERROR|WARNING):(?:\\x1b\\[[;\\d]+m)?\\s(.*)$",
+					"severity": 1,
+					"message": 2
+				},
+				{
+					"regexp": "^(?:\\x1b\\[[;\\d]+m)?\\s+at:.*\\((.*):(\\d+)\\)(?:\\x1b\\[[;\\d]+m)?$",
+					"file": 1,
+					"line": 2
+				}
+			]
 		}
 	]
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -293,7 +293,24 @@ int test_main(int argc, char *argv[]) {
 		delete[] doctest_args;
 	}
 
-	return test_context.run();
+	// Catch any error messages that aren't properly suppressed, the content doesn't matter.
+	// Consider the operation a failure if any were leaked.
+	int err_leaks = 0;
+	ErrorHandlerList err_handler;
+	err_handler.userdata = &err_leaks;
+	err_handler.errfunc = [](void *p_self, const char *, const char *, int, const char *, const char *, bool, ErrorHandlerType) {
+		if (CoreGlobals::print_error_enabled) {
+			(*static_cast<int *>(p_self))++;
+		}
+	};
+	add_error_handler(&err_handler);
+	const int ret = test_context.run();
+	remove_error_handler(&err_handler);
+
+	CoreGlobals::print_error_enabled = true;
+	ERR_FAIL_COND_V_MSG(err_leaks, err_leaks, "Error/warning messages leaked: " + itos(err_leaks) + "! If any errors or warnings were expected, please ensure their output is properly suppressed by surrounding them with `ERR_PRINT_OFF` and `ERR_PRINT_ON`.");
+
+	return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There's been quite a lot of additions to tests lately that absolutely explode the CI output with error messages. This attempts to be a twofold solution to the problem:
- Add dedicated problem-matcher for Godot errors, so GHA can track them
- Detect if any warnings/errors aren't properly suppressed & fail a `--test` operation if so

The former worked like a charm, and the latter *mostly* works, but there's still some discrepancies that need ironing out. Namely, figuring out where exactly errors are accumulating when outputs are supposed to be suppressed. This might come down to how there's a shocking amount of places where print functionality can be toggled, causing weird overlaps. But the core of the functionality is in place: CI *will not pass* if warning/error output is not properly suppressed!