### PR TITLE
Fix mesh errors in SeparationRayShape3D debug fills

### DIFF
--- a/scene/resources/3d/separation_ray_shape_3d.cpp
+++ b/scene/resources/3d/separation_ray_shape_3d.cpp
@@ -43,7 +43,31 @@ Vector<Vector3> SeparationRayShape3D::get_debug_mesh_lines() const {
 }
 
 Ref<ArrayMesh> SeparationRayShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
-	return memnew(ArrayMesh);
+	Vector<Vector3> verts;
+	Vector<Color> colors;
+	Vector<int> indices;
+
+	verts.push_back(Vector3());
+	verts.push_back(Vector3(0.0f, 0.0f, get_length()));
+	verts.push_back(Vector3());
+
+	colors.push_back(p_modulate);
+	colors.push_back(p_modulate);
+	colors.push_back(p_modulate);
+
+	indices.push_back(0);
+	indices.push_back(1);
+	indices.push_back(2);
+
+	Ref<ArrayMesh> mesh = memnew(ArrayMesh);
+	Array a;
+	a.resize(Mesh::ARRAY_MAX);
+	a[RS::ARRAY_VERTEX] = verts;
+	a[RS::ARRAY_COLOR] = colors;
+	a[RS::ARRAY_INDEX] = indices;
+	mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, a);
+
+	return mesh;
 }
 
 real_t SeparationRayShape3D::get_enclosing_radius() const {


### PR DESCRIPTION
Fixes an issue where `SeparationRayShape3D` would generate errors when debug meshes are enabled, due to the ray's debug mesh being generated as an empty array. This fix adds a single triangle to the debug mesh, which follows the shape of the debug line.

Closes #100665

Edit: This fixes the same issue as #101014, but using a less than ideal workaround. I will leave this pull request open for now, but the other fix is likely to be preferable.