### PR TITLE
Add some tests for `uid://` encoding and decoding

### DIFF
--- a/tests/core/io/test_resource_uid.h
+++ b/tests/core/io/test_resource_uid.h
@@ -47,6 +47,25 @@ TEST_CASE("[ResourceUID] Must encode/decode maximum/minimum UID correctly") {
 	CHECK_MESSAGE(ResourceUID::get_singleton()->text_to_id("uid://a") == 0, "Minimum UID must decode correctly.");
 }
 
+TEST_CASE("[ResourceUID] Must encode and decode invalid UIDs correctly") {
+	ResourceUID *rid = ResourceUID::get_singleton();
+	CHECK_MESSAGE(rid->id_to_text(-1) == "uid://<invalid>", "Invalid UID -1 must encode correctly.");
+	CHECK_MESSAGE(rid->text_to_id("uid://<invalid>") == -1, "Invalid UID -1 must decode correctly.");
+
+	CHECK_MESSAGE(rid->id_to_text(-2) == rid->id_to_text(-1), "Invalid UID -2 must encode to the same as -1.");
+
+	CHECK_MESSAGE(rid->text_to_id("dm3rdgs30kfci") == -1, "UID without scheme must decode correctly.");
+}
+
+TEST_CASE("[ResourceUID] Must encode and decode various UIDs correctly") {
+	ResourceUID *rid = ResourceUID::get_singleton();
+	CHECK_MESSAGE(rid->id_to_text(1) == "uid://b", "UID 1 must encode correctly.");
+	CHECK_MESSAGE(rid->text_to_id("uid://b") == 1, "UID 1 must decode correctly.");
+
+	CHECK_MESSAGE(rid->id_to_text(8060368642360689600) == "uid://dm3rdgs30kfci", "A normal UID must encode correctly.");
+	CHECK_MESSAGE(rid->text_to_id("uid://dm3rdgs30kfci") == 8060368642360689600, "A normal UID must decode correctly.");
+}
+
 } // namespace TestResourceUID
 
 #endif // TEST_RESOURCE_UID_H


### PR DESCRIPTION
I have added some basic uid encoding tests. See also https://github.com/godotengine/godot/issues/100969 for some details on the corner cases of our current implementation, documented in the test cases here.