### PR TITLE
Add options to control if ".uid" files are generated

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1198,6 +1198,13 @@ bool ResourceLoader::has_custom_uid_support(const String &p_path) {
 
 bool ResourceLoader::should_create_uid_file(const String &p_path) {
 	const String local_path = _validate_local_path(p_path);
+
+	bool generate_uid_files = GLOBAL_GET("editor/resource/generate_uid_files");
+	bool generate_uid_files_for_addons = GLOBAL_GET("editor/resource/generate_uid_files_for_addons");
+	if (!generate_uid_files || (!generate_uid_files_for_addons && local_path.begins_with("res://addons/"))) {
+		return false;
+	}
+
 	if (FileAccess::exists(local_path + ".uid")) {
 		return false;
 	}

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1012,6 +1012,12 @@
 		<member name="editor/naming/script_name_casing" type="int" setter="" getter="" default="0">
 			When generating script file names from the selected node, set the type of casing to use in this project. This is mostly an editor setting.
 		</member>
+		<member name="editor/resource/generate_uid_files" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], editor will generate ".uid" files for resources which have not custom uid support.
+		</member>
+		<member name="editor/resource/generate_uid_files_for_addons" type="bool" setter="" getter="" default="false">
+			If [code]false[/code], editor will not generate ".uid" files for resources which local in "res://addons".
+		</member>
 		<member name="editor/run/main_run_args" type="String" setter="" getter="" default="&quot;&quot;">
 			The command-line arguments to append to Godot's own command line when running the project. This doesn't affect the editor itself.
 			It is possible to make another executable run Godot by using the [code]%command%[/code] placeholder. The placeholder will be replaced with Godot's own command line. Program-specific arguments should be placed [i]before[/i] the placeholder, whereas Godot-specific arguments should be placed [i]after[/i] the placeholder.

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -300,6 +300,9 @@ void register_editor_types() {
 	EditorHelp::init_gdext_pointers();
 
 	OS::get_singleton()->benchmark_end_measure("Editor", "Register Types");
+
+	GLOBAL_DEF("editor/resource/generate_uid_files", true);
+	GLOBAL_DEF("editor/resource/generate_uid_files_for_addons", false);
 }
 
 void unregister_editor_types() {


### PR DESCRIPTION
The main purpose of this pr is to allow not generate ".uid" files for "res://addons/", by setting "editor/resource/generate_uid_files_for_addons" to false in project settings.

Sometimes plugins are not included in version control system( for example, using [gd-plug](https://github.com/imjp94/gd-plug) to reference plugins by single script), generate ".uid" for plugin's scripts and reference them by using uid are not reasonable.

Additionally, I add "editor/resource/generate_uid_files" to allow not generate ".uid" for the project, but default is true.
Generate ".uid" for each script make the file resource manager become ugly, and we should manipulate 2 files now.
There are some personal preferences here, I believe some people also have this feeling.
For old users, they should used drag files in editor's file system dock, it should not breaks the reference relationship by using this way, and uid is unreadable, we don't use them for coding directly.
In other words, ".uid" files are not necessary for some users.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/11571*