### PR TITLE
[Core] Fix UID encoding

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -47,7 +47,7 @@ String ResourceUID::get_cache_file() {
 
 static constexpr uint8_t uuid_characters[] = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', '0', '1', '2', '3', '4', '5', '6', '7', '8' };
 static constexpr uint32_t uuid_characters_element_count = (sizeof(uuid_characters) / sizeof(*uuid_characters));
-static constexpr uint8_t max_uuid_number_length = 19; // Max 0x7FFFFFFFFFFFFFFF size is 19 digits.
+static constexpr uint8_t max_uuid_number_length = 13; // Max 0x7FFFFFFFFFFFFFFF (uid://d4n4ub6itg400) size is 13 characters.
 
 String ResourceUID::id_to_text(ID p_id) const {
 	if (p_id < 0) {
@@ -56,12 +56,12 @@ String ResourceUID::id_to_text(ID p_id) const {
 
 	char32_t tmp[max_uuid_number_length];
 	uint32_t tmp_size = 0;
-	while (p_id) {
+	do {
 		uint32_t c = p_id % uuid_characters_element_count;
 		tmp[tmp_size] = uuid_characters[c];
 		p_id /= uuid_characters_element_count;
 		++tmp_size;
-	}
+	} while (p_id);
 
 	// tmp_size + uid:// (6) + 1 for null.
 	String txt;

--- a/tests/core/io/test_resource_uid.h
+++ b/tests/core/io/test_resource_uid.h
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  test_resource_uid.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_RESOURCE_UID_H
+#define TEST_RESOURCE_UID_H
+
+#include "core/io/resource_uid.h"
+
+#include "thirdparty/doctest/doctest.h"
+
+#include "tests/test_macros.h"
+
+namespace TestResourceUID {
+
+TEST_CASE("[ResourceUID] Must encode/decode maximum/minimum UID correctly") {
+	CHECK_MESSAGE(ResourceUID::get_singleton()->id_to_text(0x7fffffffffffffff) == "uid://d4n4ub6itg400", "Maximum UID must encode correctly.");
+	CHECK_MESSAGE(ResourceUID::get_singleton()->text_to_id("uid://d4n4ub6itg400") == 0x7fffffffffffffff, "Maximum UID must decode correctly.");
+
+	CHECK_MESSAGE(ResourceUID::get_singleton()->id_to_text(0) == "uid://a", "Minimum UID must encode correctly.");
+	CHECK_MESSAGE(ResourceUID::get_singleton()->text_to_id("uid://a") == 0, "Minimum UID must decode correctly.");
+}
+
+} // namespace TestResourceUID
+
+#endif // TEST_RESOURCE_UID_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -53,6 +53,7 @@
 #include "tests/core/io/test_packet_peer.h"
 #include "tests/core/io/test_pck_packer.h"
 #include "tests/core/io/test_resource.h"
+#include "tests/core/io/test_resource_uid.h"
 #include "tests/core/io/test_stream_peer.h"
 #include "tests/core/io/test_stream_peer_buffer.h"
 #include "tests/core/io/test_tcp_server.h"


### PR DESCRIPTION
Fixes edge case where `0` encoded as `uid://` instead of `uid://a`, and fixes the size of the temporary buffer storing encoded UID strings.

Added two simple test cases, to be expanded on by:
* #100970

These tests are to ensure the upper limit of the buffer is safe, and that the encoding of `0` is correct.

---

* Closes: https://github.com/godotengine/godot/issues/100969 (the out of bounds cases and leading `a` cases are not considered bugs, but could be discussed as usability improvements with errors)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
