### PR TITLE
Fix `CPUParticles2D` repeatedly scaling particles with 0 velocity and Align Y

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1097,10 +1097,11 @@ void CPUParticles2D::_particles_process(double p_delta) {
 
 		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
 			if (p.velocity.length() > 0.0) {
-				p.transform.columns[1] = p.velocity.normalized();
-				p.transform.columns[0] = p.transform.columns[1].orthogonal();
+				p.transform.columns[1] = p.velocity;
 			}
 
+			p.transform.columns[1] = p.transform.columns[1].normalized();
+			p.transform.columns[0] = p.transform.columns[1].orthogonal();
 		} else {
 			p.transform.columns[0] = Vector2(Math::cos(p.rotation), -Math::sin(p.rotation));
 			p.transform.columns[1] = Vector2(Math::sin(p.rotation), Math::cos(p.rotation));


### PR DESCRIPTION
`CPUParticles2D` with Align Y turned on would update particles' transforms based on the velocity when velocity was non-zero, but would not set the transform for zero velocity.  This left the transfrom value from the previous call, which may have already been scaled.  In this case, each call to `_particles_process` would apply the scale again, causing the particle to repeatedly grow (or shrink for scales < 1.0).

Updated the Align Y logic to always normalize the transform values before scale is applied.

Fixes #99645

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
