### PR TITLE
Add the ability to only generate code without compiling

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -185,6 +185,7 @@ opts.Add(
 )
 opts.Add(BoolVariable("production", "Set defaults to build Godot for use in production", False))
 opts.Add(BoolVariable("threads", "Enable threading support", True))
+opts.Add(BoolVariable("gen_only", "Only generate source code / headers. Don't compile any code.", False))
 
 # Components
 opts.Add(BoolVariable("deprecated", "Enable compatibility code for deprecated and removed features", True))

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -41,7 +41,7 @@ if env["builtin_libpng"]:
     if env["arch"].startswith("arm"):
         if env.msvc:  # Can't compile assembly files with MSVC.
             env_thirdparty.Append(CPPDEFINES=[("PNG_ARM_NEON_OPT", 0)])
-        else:
+        elif not env["gen_only"]:
             env_neon = env_thirdparty.Clone()
             if "S_compiler" in env:
                 env_neon["CC"] = env["S_compiler"]

--- a/methods.py
+++ b/methods.py
@@ -32,6 +32,8 @@ def set_scu_folders(scu_folders):
 
 
 def add_source_files_orig(self, sources, files, allow_gen=False):
+    if self["gen_only"]:
+        return []
     # Convert string to list of absolute paths (including expanding wildcard)
     if isinstance(files, str):
         # Exclude .gen.cpp files from globbing, to avoid including obsolete ones.
@@ -51,6 +53,8 @@ def add_source_files_orig(self, sources, files, allow_gen=False):
 
 
 def add_source_files_scu(self, sources, files, allow_gen=False):
+    if self["gen_only"]:
+        return []
     if self["scu_build"] and isinstance(files, str):
         if "*." not in files:
             return False
@@ -76,6 +80,8 @@ def add_source_files_scu(self, sources, files, allow_gen=False):
 # Either builds the folder using the SCU system,
 # or reverts to regular build.
 def add_source_files(self, sources, files, allow_gen=False):
+    if self["gen_only"]:
+        return []
     if not add_source_files_scu(self, sources, files, allow_gen):
         # Wraps the original function when scu build is not active.
         add_source_files_orig(self, sources, files, allow_gen)
@@ -574,24 +580,32 @@ def glob_recursive(pattern, node="."):
 
 
 def precious_program(env, program, sources, **args):
+    if env["gen_only"]:
+        return []
     program = env.Program(program, sources, **args)
     env.Precious(program)
     return program
 
 
 def add_shared_library(env, name, sources, **args):
+    if env["gen_only"]:
+        return []
     library = env.SharedLibrary(name, sources, **args)
     env.NoCache(library)
     return library
 
 
 def add_library(env, name, sources, **args):
+    if env["gen_only"]:
+        return []
     library = env.Library(name, sources, **args)
     env.NoCache(library)
     return library
 
 
 def add_program(env, name, sources, **args):
+    if env["gen_only"]:
+        return []
     program = env.Program(name, sources, **args)
     env.NoCache(program)
     return program


### PR DESCRIPTION
This is especially useful for building ios plugins in pipelines.  Otherwise we would have to wait for the entire engine to compile even though our pipelines already have prebuilt engines.  The docs describing this process is here: https://docs.godotengine.org/en/stable/tutorials/platform/ios/ios_plugin.html#creating-an-ios-plugin

Now all you have to do is pass ``gen_only=true`` to scons and tadaaa!! 🪄 Headers are generated without needing manual intervention to prevent scons from compiling any code! :)

Let me know if there are any changes you would like made to this PR.  We have been using this in our fork for at least a couple of months now without issue.  I was going through changes I made to the engine to see if I forgot to contribute anything back and I missed this one. :)