### PR TITLE
Improve performance with many static/sleeping bodies when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -89,6 +89,8 @@ private:
 
 	typedef HashMap<JPH::BodyID, Overlap, BodyIDHasher> OverlapsById;
 
+	SelfList<JoltArea3D> call_queries_element;
+
 	OverlapsById bodies_by_id;
 	OverlapsById areas_by_id;
 
@@ -115,7 +117,12 @@ private:
 
 	virtual JPH::EMotionType _get_motion_type() const override { return JPH::EMotionType::Kinematic; }
 
+	bool _has_pending_events() const;
+
 	virtual void _add_to_space() override;
+
+	void _enqueue_call_queries();
+	void _dequeue_call_queries();
 
 	void _add_shape_pair(Overlap &p_overlap, const JPH::BodyID &p_body_id, const JPH::SubShapeID &p_other_shape_id, const JPH::SubShapeID &p_self_shape_id);
 	bool _remove_shape_pair(Overlap &p_overlap, const JPH::SubShapeID &p_other_shape_id, const JPH::SubShapeID &p_self_shape_id);
@@ -217,10 +224,12 @@ public:
 	void body_exited(const JPH::BodyID &p_body_id, bool p_notify = true);
 	void area_exited(const JPH::BodyID &p_body_id);
 
-	void call_queries(JPH::Body &p_jolt_body);
+	void call_queries();
 
 	virtual bool has_custom_center_of_mass() const override { return false; }
 	virtual Vector3 get_center_of_mass_custom() const override { return Vector3(); }
+
+	virtual void post_step(float p_step, JPH::Body &p_jolt_body) override;
 };
 
 #endif // JOLT_AREA_3D_H

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -128,6 +128,7 @@ void JoltBody3D::_add_to_space() {
 	jolt_settings->mAllowDynamicOrKinematic = true;
 	jolt_settings->mCollideKinematicVsNonDynamic = reports_all_kinematic_contacts();
 	jolt_settings->mUseManifoldReduction = !reports_contacts();
+	jolt_settings->mAllowSleeping = is_sleep_actually_allowed();
 	jolt_settings->mLinearDamping = 0.0f;
 	jolt_settings->mAngularDamping = 0.0f;
 	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::get_max_linear_velocity();
@@ -153,11 +154,19 @@ void JoltBody3D::_add_to_space() {
 	jolt_settings = nullptr;
 }
 
-void JoltBody3D::_integrate_forces(float p_step, JPH::Body &p_jolt_body) {
-	if (!p_jolt_body.IsActive()) {
-		return;
+void JoltBody3D::_enqueue_call_queries() {
+	if (space != nullptr) {
+		space->enqueue_call_queries(&call_queries_element);
 	}
+}
 
+void JoltBody3D::_dequeue_call_queries() {
+	if (space != nullptr) {
+		space->dequeue_call_queries(&call_queries_element);
+	}
+}
+
+void JoltBody3D::_integrate_forces(float p_step, JPH::Body &p_jolt_body) {
 	_update_gravity(p_jolt_body);
 
 	if (!custom_integrator) {
@@ -182,8 +191,6 @@ void JoltBody3D::_integrate_forces(float p_step, JPH::Body &p_jolt_body) {
 		p_jolt_body.AddForce(to_jolt(constant_force));
 		p_jolt_body.AddTorque(to_jolt(constant_torque));
 	}
-
-	sync_state = true;
 }
 
 void JoltBody3D::_move_kinematic(float p_step, JPH::Body &p_jolt_body) {
@@ -201,27 +208,19 @@ void JoltBody3D::_move_kinematic(float p_step, JPH::Body &p_jolt_body) {
 	}
 
 	p_jolt_body.MoveKinematic(new_position, new_rotation, p_step);
-
-	sync_state = true;
-}
-
-void JoltBody3D::_pre_step_static(float p_step, JPH::Body &p_jolt_body) {
-	// Nothing to do.
 }
 
 void JoltBody3D::_pre_step_rigid(float p_step, JPH::Body &p_jolt_body) {
 	_integrate_forces(p_step, p_jolt_body);
+	_enqueue_call_queries();
 }
 
 void JoltBody3D::_pre_step_kinematic(float p_step, JPH::Body &p_jolt_body) {
 	_update_gravity(p_jolt_body);
-
 	_move_kinematic(p_step, p_jolt_body);
 
 	if (reports_contacts()) {
-		// This seems to emulate the behavior of Godot Physics, where kinematic bodies are set as active (and thereby
-		// have their state synchronized on every step) only if its max reported contacts is non-zero.
-		sync_state = true;
+		_enqueue_call_queries();
 	}
 }
 
@@ -428,6 +427,20 @@ void JoltBody3D::_update_possible_kinematic_contacts() {
 	}
 }
 
+void JoltBody3D::_update_sleep_allowed() {
+	const bool value = is_sleep_actually_allowed();
+
+	if (!in_space()) {
+		jolt_settings->mAllowSleeping = value;
+		return;
+	}
+
+	const JoltWritableBody3D body = space->write_body(jolt_id);
+	ERR_FAIL_COND(body.is_invalid());
+
+	body->SetAllowSleeping(value);
+}
+
 void JoltBody3D::_destroy_joint_constraints() {
 	for (JoltJoint3D *joint : joints) {
 		joint->destroy();
@@ -460,6 +473,7 @@ void JoltBody3D::_mode_changed() {
 	_update_object_layer();
 	_update_kinematic_transform();
 	_update_mass_properties();
+	_update_sleep_allowed();
 	wake_up();
 }
 
@@ -478,6 +492,7 @@ void JoltBody3D::_space_changing() {
 
 	_destroy_joint_constraints();
 	_exit_all_areas();
+	_dequeue_call_queries();
 }
 
 void JoltBody3D::_space_changed() {
@@ -486,9 +501,8 @@ void JoltBody3D::_space_changed() {
 	_update_kinematic_transform();
 	_update_group_filter();
 	_update_joint_constraints();
+	_update_sleep_allowed();
 	_areas_changed();
-
-	sync_state = false;
 }
 
 void JoltBody3D::_areas_changed() {
@@ -519,11 +533,18 @@ void JoltBody3D::_axis_lock_changed() {
 
 void JoltBody3D::_contact_reporting_changed() {
 	_update_possible_kinematic_contacts();
+	_update_sleep_allowed();
+	wake_up();
+}
+
+void JoltBody3D::_sleep_allowed_changed() {
+	_update_sleep_allowed();
 	wake_up();
 }
 
 JoltBody3D::JoltBody3D() :
-		JoltShapedObject3D(OBJECT_TYPE_BODY) {
+		JoltShapedObject3D(OBJECT_TYPE_BODY),
+		call_queries_element(this) {
 }
 
 JoltBody3D::~JoltBody3D() {
@@ -573,7 +594,7 @@ Variant JoltBody3D::get_state(PhysicsServer3D::BodyState p_state) const {
 			return is_sleeping();
 		}
 		case PhysicsServer3D::BODY_STATE_CAN_SLEEP: {
-			return can_sleep();
+			return is_sleep_allowed();
 		}
 		default: {
 			ERR_FAIL_V_MSG(Variant(), vformat("Unhandled body state: '%d'. This should not happen. Please report this.", p_state));
@@ -596,7 +617,7 @@ void JoltBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant &p_
 			set_is_sleeping(p_value);
 		} break;
 		case PhysicsServer3D::BODY_STATE_CAN_SLEEP: {
-			set_can_sleep(p_value);
+			set_is_sleep_allowed(p_value);
 		} break;
 		default: {
 			ERR_FAIL_MSG(vformat("Unhandled body state: '%d'. This should not happen. Please report this.", p_state));
@@ -712,6 +733,10 @@ bool JoltBody3D::is_sleeping() const {
 	return !body->IsActive();
 }
 
+bool JoltBody3D::is_sleep_actually_allowed() const {
+	return sleep_allowed && !(is_kinematic() && reports_contacts());
+}
+
 void JoltBody3D::set_is_sleeping(bool p_enabled) {
 	if (!in_space()) {
 		sleep_initially = p_enabled;
@@ -727,27 +752,14 @@ void JoltBody3D::set_is_sleeping(bool p_enabled) {
 	}
 }
 
-bool JoltBody3D::can_sleep() const {
-	if (!in_space()) {
-		return jolt_settings->mAllowSleeping;
-	}
-
-	const JoltReadableBody3D body = space->read_body(jolt_id);
-	ERR_FAIL_COND_V(body.is_invalid(), false);
-
-	return body->GetAllowSleeping();
-}
-
-void JoltBody3D::set_can_sleep(bool p_enabled) {
-	if (!in_space()) {
-		jolt_settings->mAllowSleeping = p_enabled;
+void JoltBody3D::set_is_sleep_allowed(bool p_enabled) {
+	if (sleep_allowed == p_enabled) {
 		return;
 	}
 
-	const JoltWritableBody3D body = space->write_body(jolt_id);
-	ERR_FAIL_COND(body.is_invalid());
+	sleep_allowed = p_enabled;
 
-	body->SetAllowSleeping(p_enabled);
+	_sleep_allowed_changed();
 }
 
 Basis JoltBody3D::get_principal_inertia_axes() const {
@@ -1187,11 +1199,7 @@ void JoltBody3D::remove_joint(JoltJoint3D *p_joint) {
 	_joints_changed();
 }
 
-void JoltBody3D::call_queries(JPH::Body &p_jolt_body) {
-	if (!sync_state) {
-		return;
-	}
-
+void JoltBody3D::call_queries() {
 	if (custom_integration_callback.is_valid()) {
 		const Variant direct_state_variant = get_direct_state();
 		const Variant *args[2] = { &direct_state_variant, &custom_integration_userdata };
@@ -1218,8 +1226,6 @@ void JoltBody3D::call_queries(JPH::Body &p_jolt_body) {
 			ERR_PRINT_ONCE(vformat("Failed to call state synchronization callback for '%s'. It returned the following error: '%s'.", to_string(), Variant::get_callable_error_text(state_sync_callback, args, 1, ce)));
 		}
 	}
-
-	sync_state = false;
 }
 
 void JoltBody3D::pre_step(float p_step, JPH::Body &p_jolt_body) {
@@ -1227,7 +1233,7 @@ void JoltBody3D::pre_step(float p_step, JPH::Body &p_jolt_body) {
 
 	switch (mode) {
 		case PhysicsServer3D::BODY_MODE_STATIC: {
-			_pre_step_static(p_step, p_jolt_body);
+			// Will never happen.
 		} break;
 		case PhysicsServer3D::BODY_MODE_RIGID:
 		case PhysicsServer3D::BODY_MODE_RIGID_LINEAR: {

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -57,6 +57,8 @@ public:
 	};
 
 private:
+	SelfList<JoltBody3D> call_queries_element;
+
 	LocalVector<RID> exceptions;
 	LocalVector<Contact> contacts;
 	LocalVector<JoltArea3D *> areas;
@@ -96,7 +98,7 @@ private:
 
 	uint32_t locked_axes = 0;
 
-	bool sync_state = false;
+	bool sleep_allowed = true;
 	bool sleep_initially = false;
 	bool custom_center_of_mass = false;
 	bool custom_integrator = false;
@@ -108,11 +110,13 @@ private:
 
 	virtual void _add_to_space() override;
 
+	void _enqueue_call_queries();
+	void _dequeue_call_queries();
+
 	void _integrate_forces(float p_step, JPH::Body &p_jolt_body);
 
 	void _move_kinematic(float p_step, JPH::Body &p_jolt_body);
 
-	void _pre_step_static(float p_step, JPH::Body &p_jolt_body);
 	void _pre_step_rigid(float p_step, JPH::Body &p_jolt_body);
 	void _pre_step_kinematic(float p_step, JPH::Body &p_jolt_body);
 
@@ -128,6 +132,7 @@ private:
 	void _update_group_filter();
 	void _update_joint_constraints();
 	void _update_possible_kinematic_contacts();
+	void _update_sleep_allowed();
 
 	void _destroy_joint_constraints();
 
@@ -144,6 +149,7 @@ private:
 	void _exceptions_changed();
 	void _axis_lock_changed();
 	void _contact_reporting_changed();
+	void _sleep_allowed_changed();
 
 public:
 	JoltBody3D();
@@ -175,8 +181,9 @@ public:
 	void put_to_sleep() { set_is_sleeping(true); }
 	void wake_up() { set_is_sleeping(false); }
 
-	bool can_sleep() const;
-	void set_can_sleep(bool p_enabled);
+	bool is_sleep_allowed() const { return sleep_allowed; }
+	bool is_sleep_actually_allowed() const;
+	void set_is_sleep_allowed(bool p_enabled);
 
 	Basis get_principal_inertia_axes() const;
 	Vector3 get_inverse_inertia() const;
@@ -238,7 +245,7 @@ public:
 	void add_joint(JoltJoint3D *p_joint);
 	void remove_joint(JoltJoint3D *p_joint);
 
-	void call_queries(JPH::Body &p_jolt_body);
+	void call_queries();
 
 	virtual void pre_step(float p_step, JPH::Body &p_jolt_body) override;
 

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
@@ -160,12 +160,13 @@ void JoltShapedObject3D::_update_shape() {
 	const JoltWritableBody3D body = space->write_body(jolt_id);
 	ERR_FAIL_COND(body.is_invalid());
 
-	previous_jolt_shape = jolt_shape;
-	jolt_shape = build_shape();
-
-	if (jolt_shape == previous_jolt_shape) {
+	JPH::ShapeRefC new_shape = build_shape();
+	if (new_shape == jolt_shape) {
 		return;
 	}
+
+	previous_jolt_shape = jolt_shape;
+	jolt_shape = new_shape;
 
 	space->get_body_iface().SetShape(jolt_id, jolt_shape, false, JPH::EActivation::DontActivate);
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -438,7 +438,7 @@ void JoltSoftBody3D::set_is_sleeping(bool p_enabled) {
 	}
 }
 
-bool JoltSoftBody3D::can_sleep() const {
+bool JoltSoftBody3D::is_sleep_allowed() const {
 	if (!in_space()) {
 		return true;
 	}
@@ -449,7 +449,7 @@ bool JoltSoftBody3D::can_sleep() const {
 	return body->GetAllowSleeping();
 }
 
-void JoltSoftBody3D::set_can_sleep(bool p_enabled) {
+void JoltSoftBody3D::set_is_sleep_allowed(bool p_enabled) {
 	if (!in_space()) {
 		return;
 	}
@@ -532,7 +532,7 @@ Variant JoltSoftBody3D::get_state(PhysicsServer3D::BodyState p_state) const {
 			return is_sleeping();
 		}
 		case PhysicsServer3D::BODY_STATE_CAN_SLEEP: {
-			return can_sleep();
+			return is_sleep_allowed();
 		}
 		default: {
 			ERR_FAIL_V_MSG(Variant(), vformat("Unhandled body state: '%d'. This should not happen. Please report this.", p_state));
@@ -555,7 +555,7 @@ void JoltSoftBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant
 			set_is_sleeping(p_value);
 		} break;
 		case PhysicsServer3D::BODY_STATE_CAN_SLEEP: {
-			set_can_sleep(p_value);
+			set_is_sleep_allowed(p_value);
 		} break;
 		default: {
 			ERR_FAIL_MSG(vformat("Unhandled body state: '%d'. This should not happen. Please report this.", p_state));

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -124,8 +124,8 @@ public:
 	bool is_sleeping() const;
 	void set_is_sleeping(bool p_enabled);
 
-	bool can_sleep() const;
-	void set_can_sleep(bool p_enabled);
+	bool is_sleep_allowed() const;
+	void set_is_sleep_allowed(bool p_enabled);
 
 	void put_to_sleep() { set_is_sleeping(true); }
 	void wake_up() { set_is_sleeping(false); }

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
@@ -85,7 +85,6 @@ class JoltContactListener3D final
 	};
 
 	HashMap<JPH::SubShapeIDPair, Manifold, ShapePairHasher> manifolds_by_shape_pair;
-	HashSet<JPH::BodyID, BodyIDHasher> listening_for;
 	HashSet<JPH::SubShapeIDPair, ShapePairHasher> area_overlaps;
 	HashSet<JPH::SubShapeIDPair, ShapePairHasher> area_enters;
 	HashSet<JPH::SubShapeIDPair, ShapePairHasher> area_exits;
@@ -107,12 +106,10 @@ class JoltContactListener3D final
 	virtual void OnSoftBodyContactAdded(const JPH::Body &p_soft_body, const JPH::SoftBodyManifold &p_manifold) override;
 #endif
 
-	bool _is_listening_for(const JPH::Body &p_body) const;
-
 	bool _try_override_collision_response(const JPH::Body &p_jolt_body1, const JPH::Body &p_jolt_body2, JPH::ContactSettings &p_settings);
 	bool _try_override_collision_response(const JPH::Body &p_jolt_soft_body, const JPH::Body &p_jolt_other_body, JPH::SoftBodyContactSettings &p_settings);
 	bool _try_apply_surface_velocities(const JPH::Body &p_jolt_body1, const JPH::Body &p_jolt_body2, JPH::ContactSettings &p_settings);
-	bool _try_add_contacts(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold, JPH::ContactSettings &p_settings);
+	bool _try_add_contacts(const JPH::Body &p_jolt_body1, const JPH::Body &p_jolt_body2, const JPH::ContactManifold &p_manifold, JPH::ContactSettings &p_settings);
 	bool _try_evaluate_area_overlap(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold);
 	bool _try_remove_contacts(const JPH::SubShapeIDPair &p_shape_pair);
 	bool _try_remove_area_overlap(const JPH::SubShapeIDPair &p_shape_pair);
@@ -130,8 +127,6 @@ class JoltContactListener3D final
 public:
 	explicit JoltContactListener3D(JoltSpace3D *p_space) :
 			space(p_space) {}
-
-	void listen_for(JoltShapedObject3D *p_object);
 
 	void pre_step();
 	void post_step();

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -48,6 +48,7 @@
 #include <stdint.h>
 
 class JoltArea3D;
+class JoltBody3D;
 class JoltContactListener3D;
 class JoltJoint3D;
 class JoltLayers;
@@ -55,7 +56,8 @@ class JoltObject3D;
 class JoltPhysicsDirectSpaceState3D;
 
 class JoltSpace3D {
-	JoltBodyWriter3D body_accessor;
+	SelfList<JoltBody3D>::List body_call_queries_list;
+	SelfList<JoltArea3D>::List area_call_queries_list;
 
 	RID rid;
 
@@ -73,7 +75,6 @@ class JoltSpace3D {
 
 	bool active = false;
 	bool stepping = false;
-	bool has_stepped = false;
 
 	void _pre_step(float p_step);
 	void _post_step(float p_step);
@@ -131,6 +132,11 @@ public:
 	void remove_body(const JPH::BodyID &p_body_id);
 
 	void try_optimize();
+
+	void enqueue_call_queries(SelfList<JoltBody3D> *p_body);
+	void enqueue_call_queries(SelfList<JoltArea3D> *p_area);
+	void dequeue_call_queries(SelfList<JoltBody3D> *p_body);
+	void dequeue_call_queries(SelfList<JoltArea3D> *p_area);
 
 	void add_joint(JPH::Constraint *p_jolt_ref);
 	void add_joint(JoltJoint3D *p_joint);


### PR DESCRIPTION
Fixes #100700 (albeit not intentionally).

(While this is a somewhat scary change, I would recommend that this be merged in time for 4.4-beta1.)

This addresses a long-standing performance discrepancy between the Jolt Physics module and Godot Physics, inherited from the Godot Jolt extension in part from godot-jolt/godot-jolt#410, which is that the Jolt Physics module currently iterates over every single physics body (including sleeping and static bodies) three times during a physics step (not including potential work done within Jolt itself), albeit with no real work happening for sleeping/static bodies.

The Jolt Physics module currently iterates over every physics body once during `JoltSpace3D::_pre_step`, once during `JoltSpace3D::_post_step` and once during `JoltSpace3D::call_queries`. Godot Physics on the other hand only ever iterates over active bodies during `GodotPhysicsServer3D::step`, and only iterates over explicitly registered bodies/areas in `GodotSpace3D::call_queries`, meaning sleeping and static bodies are excluded.

Fixing this was mentioned in my "nice-to-have" to-do list in #99895 as:

> Try remove the use of `JPH::PhysicsSystem::GetBodies`, to avoid the overhead of iterating over static/sleeping bodies.

This isn't that big of a problem so long as you stay within a few thousand physics bodies (at least on desktop machines) so is largely fine for most projects, but once you get into the tens of thousands the overhead from these needless iterations start to add up quickly, with mobile devices presumably being even worse off.

This pull request resolves this by largely replicating what Godot Physics does, which is to only iterate over active bodies (retrieved through `JPH::PhysicsSystem::GetActiveBodiesUnsafe`) in `JoltSpace3D::_pre_step` and `JoltSpace3D::_post_step` and only iterate over explicitly registered bodies in `JoltSpace3D::call_queries`.

The registering for `call_queries` (which is what invokes the synchronization callbacks) is done using a `SelfList` (a doubly-linked intrusive list), mostly just to align with Godot Physics, but also to allow for quick deregistering when removing active bodies from a `SceneTree`. It's possible that a `LocalVector<JoltBody3D*>` would still be the better choice, but I haven't really compared the two.

Here's a (somewhat skewed, see below) before-and-after profiling of `JoltPhysicsServer3D::step` with 50k static bodies over two seconds, done in Superluminal:

![Jolt_Before](https://github.com/user-attachments/assets/d641cb1c-b752-4163-bb6f-062e4698fe8b)

![Jolt_After](https://github.com/user-attachments/assets/8aafb355-55b4-41bd-8e95-2b8a23bfdbda)

Note that most of the remaining time spent in the latter profiling seems to be Windows ETW overhead introduced by Superluminal, specifically when unlocking mutexes in `WorkerThreadPool::_add_task`, which is indirectly called from `JoltJobSystem`.

---

This change has a couple of knock-on effects, namely:

1. We can get rid of the `JoltSpace3D::has_stepped` hack.
2. We can get rid of the `JoltBody3D::sync_state` hack.
3. We're now "forced"[^1] to disable sleeping for kinematic bodies that report contacts, since we would otherwise never clear the list of contacts for sleeping kinematic bodies. Godot Physics does the exact same thing. This also happens to fix #100700.

I also threw in some other semi-related refactorings:

1. We don't need `JoltContactListener3D::listening_for`, since we can just check `reports_contacts()` in `JoltContactListener3D::_try_add_contacts`.
2. I changed the early-out in `JoltShapedObject3D::_update_shape` a bit, to ensure that we don't set `previous_jolt_shape` without waking up the body.
4. I renamed `can_sleep` to `sleep_allowed` to make some naming a bit easier.

[^1]: We could probably maintain a separate list of kinematic bodies that need their contacts cleared, but it doesn't seem worth the effort.