### PR TITLE
AudioStreamPlaylist: Fix doubled sample when switching streams

### DIFF
--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -324,10 +324,11 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 					}
 					fade_index = -1;
 				} else {
-					// Move current mixed data to fade buffer.
-					for (int j = i; j < to_mix; j++) {
+					// Move remaining mixed data to fade buffer.
+					for (int j = i + 1; j < to_mix; j++) {
 						fade_buffer[j] = mix_buffer[j];
 					}
+					fade_buffer[i] = AudioFrame(0.0, 0.0);
 
 					fade_index = prev;
 					fade_volume = 1.0;


### PR DESCRIPTION
When moving the old stream's mixed data into the fade buffer, it erroneously included the current frame, which had already been added to the p_buffer. As the fade buffer is also added to the p_buffer later, this resulted in a double-counting of the sample, which could cause a click in some cases.

The current frame is now zeroed rather than copied in the fade buffer, preventing this double-counting.

Here is an MRP that demonstrates an example where this issue was causing a click—
Run the default scene, which will start autoplay, and observe the transition at ~20sec:
[Playlist Testing.zip](https://github.com/user-attachments/files/18283693/Playlist.Testing.zip)