### PR TITLE
Windows: Implement native menu close callback

### DIFF
--- a/doc/classes/NativeMenu.xml
+++ b/doc/classes/NativeMenu.xml
@@ -366,7 +366,7 @@
 			<param index="0" name="rid" type="RID" />
 			<description>
 				Returns global menu close callback.
-				b]Note:[/b] This method is implemented only on macOS.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>
 		<method name="get_popup_open_callback" qualifiers="const">
@@ -708,7 +708,7 @@
 			<description>
 				Registers callable to emit when the menu is about to show.
 				[b]Note:[/b] The OS can simulate menu opening to track menu item changes and global shortcuts, in which case the corresponding close callback is not triggered. Use [method is_opened] to check if the menu is currently opened.
-				[b]Note:[/b] This method is implemented only on macOS.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
 			</description>
 		</method>
 		<method name="set_popup_open_callback">

--- a/platform/windows/native_menu_windows.h
+++ b/platform/windows/native_menu_windows.h
@@ -61,6 +61,8 @@ class NativeMenuWindows : public NativeMenu {
 
 	struct MenuData {
 		HMENU menu = 0;
+
+		Callable close_cb;
 		bool is_rtl = false;
 	};
 


### PR DESCRIPTION
First ever PR to the project, need some help to know if something is wrong and/or if I missed some sort of commit or code style.

This fixes an issue I opened earlier: #100978 where the Windows native menu does not emit the popup_hide signal. The issue has a simple project where you can reproduce the issue and validate that this fixes it.

Video 1: example with the 4.3 stable release

https://github.com/user-attachments/assets/7eb442a5-4504-4bac-95f8-dc9281c61458

Video 2: example with this fix

https://github.com/user-attachments/assets/81db8300-73cd-4d5f-9c8f-78408f967798

*Bugsquad edit:*
- Fixes #100978