### PR TITLE
Disallow generating ".uid" files in "res://addons/".

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1198,6 +1198,10 @@ bool ResourceLoader::has_custom_uid_support(const String &p_path) {
 
 bool ResourceLoader::should_create_uid_file(const String &p_path) {
 	const String local_path = _validate_local_path(p_path);
+	if (local_path.begins_with("res://addons/")) {
+		return false;
+	}
+
 	if (FileAccess::exists(local_path + ".uid")) {
 		return false;
 	}


### PR DESCRIPTION
An alternate of [#100973](https://github.com/godotengine/godot/pull/100973).

Close [#11464](https://github.com/godotengine/godot-proposals/issues/11464).
