### PR TITLE
[3.x] Add move semantics to core containers.

### DIFF
--- a/core/list.h
+++ b/core/list.h
@@ -444,6 +444,16 @@ public:
 		}
 	}
 
+	void operator=(List &&p_list) {
+		if (unlikely(this == &p_list)) {
+			return;
+		}
+
+		clear();
+		_data = p_list._data;
+		p_list._data = nullptr;
+	}
+
 	T &operator[](int p_index) {
 		CRASH_BAD_INDEX(p_index, size());
 
@@ -683,6 +693,11 @@ public:
 			push_back(it->get());
 			it = it->next();
 		}
+	}
+
+	List(List &&p_list) {
+		_data = p_list._data;
+		p_list._data = nullptr;
 	}
 
 	List() {

--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -38,6 +38,7 @@
 #include "core/vector.h"
 
 #include <type_traits>
+#include <utility>
 
 template <class T, class U = uint32_t, bool force_trivial = false>
 class LocalVector {
@@ -67,9 +68,9 @@ public:
 		}
 
 		if (!std::is_trivially_constructible<T>::value && !force_trivial) {
-			memnew_placement(&data[count++], T(p_elem));
+			memnew_placement(&data[count++], T(std::move(p_elem)));
 		} else {
-			data[count++] = p_elem;
+			data[count++] = std::move(p_elem);
 		}
 	}
 
@@ -77,7 +78,7 @@ public:
 		ERR_FAIL_UNSIGNED_INDEX(p_index, count);
 		count--;
 		for (U i = p_index; i < count; i++) {
-			data[i] = data[i + 1];
+			data[i] = std::move(data[i + 1]);
 		}
 		if (!std::is_trivially_destructible<T>::value && !force_trivial) {
 			data[count].~T();
@@ -90,7 +91,7 @@ public:
 		ERR_FAIL_INDEX(p_index, count);
 		count--;
 		if (count > p_index) {
-			data[p_index] = data[count];
+			data[p_index] = std::move(data[count]);
 		}
 		if (!std::is_trivially_destructible<T>::value && !force_trivial) {
 			data[count].~T();
@@ -193,13 +194,13 @@ public:
 	void insert(U p_pos, T p_val) {
 		ERR_FAIL_UNSIGNED_INDEX(p_pos, count + 1);
 		if (p_pos == count) {
-			push_back(p_val);
+			push_back(std::move(p_val));
 		} else {
 			resize(count + 1);
 			for (U i = count - 1; i > p_pos; i--) {
-				data[i] = data[i - 1];
+				data[i] = std::move(data[i - 1]);
 			}
-			data[p_pos] = p_val;
+			data[p_pos] = std::move(p_val);
 		}
 	}
 
@@ -284,6 +285,17 @@ public:
 			data[i] = r[i];
 		}
 	}
+
+	LocalVector(LocalVector &&p_from) {
+		data = p_from.data;
+		count = p_from.count;
+		capacity = p_from.capacity;
+
+		p_from.data = nullptr;
+		p_from.count = 0;
+		p_from.capacity = 0;
+	}
+
 	inline LocalVector &operator=(const LocalVector &p_from) {
 		resize(p_from.size());
 		for (U i = 0; i < p_from.count; i++) {
@@ -291,6 +303,22 @@ public:
 		}
 		return *this;
 	}
+
+	inline void operator=(LocalVector &&p_from) {
+		if (unlikely(this == &p_from)) {
+			return;
+		}
+		reset();
+
+		data = p_from.data;
+		count = p_from.count;
+		capacity = p_from.capacity;
+
+		p_from.data = nullptr;
+		p_from.count = 0;
+		p_from.capacity = 0;
+	}
+
 	inline LocalVector &operator=(const Vector<T> &p_from) {
 		resize(p_from.size());
 		for (U i = 0; i < count; i++) {
@@ -298,6 +326,14 @@ public:
 		}
 		return *this;
 	}
+
+	inline void operator=(Vector<T> &&p_from) {
+		resize(p_from.size());
+		for (U i = 0; i < count; i++) {
+			data[i] = std::move(p_from[i]);
+		}
+	}
+
 	inline LocalVector &operator=(const PoolVector<T> &p_from) {
 		resize(p_from.size());
 		typename PoolVector<T>::Read r = p_from.read();

--- a/core/string_name.h
+++ b/core/string_name.h
@@ -163,6 +163,23 @@ public:
 	};
 
 	void operator=(const StringName &p_name);
+
+	StringName &operator=(StringName &&p_name) {
+		if (_data == p_name._data) {
+			return *this;
+		}
+
+		unref();
+		_data = p_name._data;
+		p_name._data = nullptr;
+		return *this;
+	}
+
+	StringName(StringName &&p_name) {
+		_data = p_name._data;
+		p_name._data = nullptr;
+	}
+
 	StringName(const char *p_name);
 	StringName(const StringName &p_name);
 	StringName(const String &p_name);

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -32,6 +32,7 @@
 #define TYPEDEFS_H
 
 #include <stddef.h>
+#include <utility>
 
 /**
  * Basic definitions and simple functions to be used everywhere.
@@ -175,15 +176,7 @@ T *_nullptr() {
 
 /** Generic swap template */
 #ifndef SWAP
-
-#define SWAP(m_x, m_y) __swap_tmpl((m_x), (m_y))
-template <class T>
-inline void __swap_tmpl(T &x, T &y) {
-	T aux = x;
-	x = y;
-	y = aux;
-}
-
+#define SWAP(m_x, m_y) std::swap((m_x), (m_y))
 #endif //swap
 
 /* clang-format off */

--- a/core/variant.h
+++ b/core/variant.h
@@ -159,7 +159,7 @@ private:
 		Basis *_basis;
 		Transform *_transform;
 		void *_ptr; //generic pointer
-		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)];
+		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)]{ 0 };
 	} _data GCC_ALIGNED_8;
 
 	void reference(const Variant &p_variant);
@@ -432,7 +432,21 @@ public:
 	static void construct_from_string(const String &p_string, Variant &r_value, ObjectConstruct p_obj_construct = nullptr, void *p_construct_ud = nullptr);
 
 	void operator=(const Variant &p_variant); // only this is enough for all the other types
+	void operator=(Variant &&p_variant) {
+		if (unlikely(this == &p_variant)) {
+			return;
+		}
+		clear();
+		type = p_variant.type;
+		_data = p_variant._data;
+		p_variant.type = NIL;
+	}
 	Variant(const Variant &p_variant);
+	Variant(Variant &&p_variant) {
+		type = p_variant.type;
+		_data = p_variant._data;
+		p_variant.type = NIL;
+	}
 	_FORCE_INLINE_ Variant() { type = NIL; }
 	_FORCE_INLINE_ ~Variant() {
 		if (type != Variant::NIL) {


### PR DESCRIPTION
Adds to SWAP, Variant, StringName, List, CowData and LocalVector.

Backports:
#100563
#100560
#100483
#100477
#100426
#100367

## Notes
* This backports several of @Ivorforce 's PRs to 3.x.
* I'm completely new to move semantics so this could do with checking :grin: , especially regarding any differences between 3.x and 4.x.
* Move semantics seems fairly simple to add and may result in some benefit (same reasoning as for 4.x, discussed in the core meeting). I don't see any obvious reason we shouldn't backport (at least some of) them as they appear fairly simple.
* This also improves 3.x `CowData::insert()` which was using `set()` for each element instead of a one off copy on write via `ptrw()` (used in 4.x).
* May make sense for `PoolVector` too but leaving that for a separate PR as it isn't present in 4.x, and is a bit of a minefield already with some existing thread bugs if I remember right.

## Variant
So far no bodges needed for `Variant` as in 4.x to work around MSVC bug - gdnative etc is completely different in 3.x.

Interestingly, adding the move semantics introduced warnings as `_data` isn't intialized in 3.x (only the type is set to `NIL`). I've currently solved this by adding zeroing for the union (which is done in 4.x), although I need to check the benefit of move semantics here outweighs the cost of zeroing the union (versus e.g. silencing the warning) (DONE - see below).

## Performance Testing
I've spent a little time doing some rudimentary performance testing.

### Startup
Benchmarking startup doesn't seem to show significant differences before / after the PR, for the editor or projects, from simple to TPS demo. Any differences seem within normal variation between runs.

### FPS
As expected, in games I didn't notice a difference in FPS, as in the vast majority of cases they are limited by GPU.

### Benchmarking GDScript
To try and coax some difference I wrote a CPU intensive script, this did show an improvement.

```
func my_func(var s):
	return 1

func benchmark():
	
	var before = OS.get_ticks_msec()
	
	var s = 1
	for i in range (100000000):
		s += my_func(s)
 
	var after = OS.get_ticks_msec()

	print(str(after-before) + " ms")

func _ready():
	benchmark()
```

#### Before
20107 ms
19860 ms
19858 ms

#### After
17177 ms
17224 ms
16964 ms
17294 ms

This was with all other apps / windows closed on Linux Mint.

So although I'm not sure these changes will result in noticeable difference in most games, in gdscript intensive tasks at least, there does seem to be improvement, here approx 15%. At a guess this may be the `Variant` improvements but I haven't profiled.

## Build Size
One thing I did notice was a possible increase in build size, I don't know if this has been examined in 4.x.
I'll try and see if this is repeatable, but it may be important in deciding whether to go ahead, particularly for web builds where build size is quite important.

*Regular build*
370.2 MB, 66.7 MB stripped
*This PR*
373.1 MB, 67.3 MB stripped

From the artifacts:

*Previous commit*
android 65.9
ios 20
javascript 10.1
linux-editor-mono 73.2
linux-template-mono 21.3
macos-editor 30.7
macos-template 10.9
windows-editor 36.2
windows-template 12.1

*This PR*
android 66.3
ios 20
javascript 10.1
linux-editor-mono 73.4
linux-template-mono 21.5
macos-editor 30.7
macos-template 11
windows-editor 36.4
windows-template 12.1

Hmm, looks like javascript is within the margin of 100Kb, so might be okay. Desktop 200Kb is no big deal I guess.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
