### PR TITLE
Add `AtlasTexture` nesting support before `canvas_item_add_nine_patch()` calls

### DIFF
--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -30,6 +30,7 @@
 
 #include "nine_patch_rect.h"
 
+#include "scene/resources/atlas_texture.h"
 #include "servers/rendering_server.h"
 
 void NinePatchRect::_notification(int p_what) {
@@ -43,6 +44,12 @@ void NinePatchRect::_notification(int p_what) {
 			Rect2 src_rect = region_rect;
 
 			texture->get_rect_region(rect, src_rect, rect, src_rect);
+
+			Ref<AtlasTexture> atlas = texture;
+			while (atlas.is_valid() && atlas->get_atlas().is_valid()) {
+				atlas->get_atlas()->get_rect_region(rect, src_rect, rect, src_rect);
+				atlas = atlas->get_atlas();
+			}
 
 			RID ci = get_canvas_item();
 			RS::get_singleton()->canvas_item_add_nine_patch(ci, rect, src_rect, texture->get_rid(), Vector2(margin[SIDE_LEFT], margin[SIDE_TOP]), Vector2(margin[SIDE_RIGHT], margin[SIDE_BOTTOM]), RS::NinePatchAxisMode(axis_h), RS::NinePatchAxisMode(axis_v), draw_center);

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -30,6 +30,8 @@
 
 #include "texture_progress_bar.h"
 
+#include "scene/resources/atlas_texture.h"
+
 void TextureProgressBar::set_under_texture(const Ref<Texture2D> &p_texture) {
 	_set_texture(&under, p_texture);
 }
@@ -418,6 +420,12 @@ void TextureProgressBar::draw_nine_patch_stretched(const Ref<Texture2D> &p_textu
 		dst_rect.position += progress_offset;
 	}
 	p_texture->get_rect_region(dst_rect, src_rect, dst_rect, src_rect);
+
+	Ref<AtlasTexture> atlas = p_texture;
+	while (atlas.is_valid() && atlas->get_atlas().is_valid()) {
+		atlas->get_atlas()->get_rect_region(dst_rect, src_rect, dst_rect, src_rect);
+		atlas = atlas->get_atlas();
+	}
 
 	RID ci = get_canvas_item();
 	RS::get_singleton()->canvas_item_add_nine_patch(ci, dst_rect, src_rect, p_texture->get_rid(), topleft, bottomright, RS::NINE_PATCH_STRETCH, RS::NINE_PATCH_STRETCH, true, p_modulate);

--- a/scene/resources/style_box_texture.cpp
+++ b/scene/resources/style_box_texture.cpp
@@ -30,6 +30,8 @@
 
 #include "style_box_texture.h"
 
+#include "scene/resources/atlas_texture.h"
+
 float StyleBoxTexture::get_style_margin(Side p_side) const {
 	ERR_FAIL_INDEX_V((int)p_side, 4, 0.0);
 
@@ -169,6 +171,12 @@ void StyleBoxTexture::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	Rect2 src_rect = region_rect;
 
 	texture->get_rect_region(rect, src_rect, rect, src_rect);
+
+	Ref<AtlasTexture> atlas = texture;
+	while (atlas.is_valid() && atlas->get_atlas().is_valid()) {
+		atlas->get_atlas()->get_rect_region(rect, src_rect, rect, src_rect);
+		atlas = atlas->get_atlas();
+	}
 
 	rect.position.x -= expand_margin[SIDE_LEFT];
 	rect.position.y -= expand_margin[SIDE_TOP];


### PR DESCRIPTION
This allows to use nested `AtlasTexture` where `canvas_item_add_nine_patch()` is called, i.e. in:
- `StyleBoxTexture`,
- `NinePatchRect`,
- `TextureProgressBar` (linear modes + nine patch stretch enabled).

Addresses first part of https://github.com/godotengine/godot/issues/69036#issuecomment-2524001281