### PR TITLE
Fix Script metadata usage

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -520,7 +520,13 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 		PropertyInfo pi = PropertyInfo(K.value.get_type(), "metadata/" + K.key.operator String());
 		if (K.value.get_type() == Variant::OBJECT) {
 			pi.hint = PROPERTY_HINT_RESOURCE_TYPE;
-			pi.hint_string = "Resource";
+			Object *obj = K.value;
+			if (Object::cast_to<Script>(obj)) {
+				pi.hint_string = "Script";
+				pi.usage |= PROPERTY_USAGE_NEVER_DUPLICATE;
+			} else {
+				pi.hint_string = "Resource";
+			}
 		}
 		p_list->push_back(pi);
 	}


### PR DESCRIPTION
_🍾 Happy New Year everyone! 🎉_

This PR makes sure that Scripts set in metadata (namely `metadata/_custom_type_script` since #91341) aren't duplicated  when `Resource::duplicate(true)`.

Fixes #100154