### PR TITLE
Thread: Re-add `<new>` include for `std::hardware_destructive_interference_size`

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -29,13 +29,13 @@
 /**************************************************************************/
 
 #include "platform_config.h"
-#ifndef PLATFORM_THREAD_OVERRIDE // See details in thread.h
+
+#ifndef PLATFORM_THREAD_OVERRIDE // See details in thread.h.
 
 #include "thread.h"
 
 #ifdef THREADS_ENABLED
 #include "core/object/script_language.h"
-#include "core/templates/safe_refcount.h"
 
 SafeNumeric<uint64_t> Thread::id_counter(1); // The first value after .increment() is 2, hence by default the main thread ID should be 1.
 

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -29,18 +29,27 @@
 /**************************************************************************/
 
 #include "platform_config.h"
+
 // Define PLATFORM_THREAD_OVERRIDE in your platform's `platform_config.h`
-// to use a custom Thread implementation defined in `platform/[your_platform]/platform_thread.h`
-// Overriding the platform implementation is required in some proprietary platforms
+// to use a custom Thread implementation defined in `platform/[your_platform]/platform_thread.h`.
+// Overriding the Thread implementation is required in some proprietary platforms.
+
 #ifdef PLATFORM_THREAD_OVERRIDE
+
 #include "platform_thread.h"
+
 #else
 
 #ifndef THREAD_H
 #define THREAD_H
 
-#include "core/templates/safe_refcount.h"
 #include "core/typedefs.h"
+
+#ifdef THREADS_ENABLED
+
+#include "core/templates/safe_refcount.h"
+
+#include <new> // IWYU pragma: keep // For hardware interference size.
 
 #ifdef MINGW_ENABLED
 #define MINGW_STDTHREAD_REDUNDANCY_WARNING
@@ -52,8 +61,6 @@
 #endif
 
 class String;
-
-#ifdef THREADS_ENABLED
 
 class Thread {
 public:
@@ -142,6 +149,8 @@ public:
 };
 
 #else // No threads.
+
+class String;
 
 class Thread {
 public:

--- a/core/os/thread_safe.h
+++ b/core/os/thread_safe.h
@@ -31,6 +31,8 @@
 #ifndef THREAD_SAFE_H
 #define THREAD_SAFE_H
 
+#include "core/os/mutex.h" // IWYU pragma: keep // Used in macro.
+
 #define _THREAD_SAFE_CLASS_ mutable Mutex _thread_safe_;
 #define _THREAD_SAFE_METHOD_ MutexLock _thread_safe_method_(_thread_safe_);
 #define _THREAD_SAFE_LOCK_ _thread_safe_.lock();


### PR DESCRIPTION
Somehow it would still build fine, but would crash when compiled with GCC 12.2 on Debian 12.

Also re-add wrongly removed Mutex include from `thread_safe.h`, where it's used in macros.
    
Add IWYU pragma comments to prevent it from mistakenly flagging those as unused.

- Fixes #100768.
- Fixes up #100564 which introduced the regression.

CC @RandomShaper @hpvb 
I still don't know *why* it would compile OK without `<new>`, but then crash, but I've confirmed that this patch fixes the crash with Debian 12's GCC 12.2.0.