### PR TITLE
Fix nullptr crash with freed `GraphNode` in GraphEditArranger

### DIFF
--- a/scene/gui/graph_edit_arranger.cpp
+++ b/scene/gui/graph_edit_arranger.cpp
@@ -79,6 +79,9 @@ void GraphEditArranger::arrange_nodes() {
 
 			for (const Ref<GraphEdit::Connection> &connection : connection_list) {
 				GraphNode *p_from = Object::cast_to<GraphNode>(node_names[connection->from_node]);
+				if (!p_from) {
+					continue;
+				}
 				if (connection->to_node == graph_element->get_name() && (p_from->is_selected() || arrange_entire_graph) && connection->to_node != connection->from_node) {
 					if (!s.has(p_from->get_name())) {
 						s.insert(p_from->get_name());


### PR DESCRIPTION
When using `queue_free()` on GraphNodes, `p_from` can become `nullprt`. This PR adds a check to prevent crashes in these situations.

```
================================================================
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.4.dev.custom_build (2582793d408ade0b6ed42f913ae33e7da5fb9184)
Dumping the backtrace. Please include this when reporting the bug to the project developer.
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x3c050) [0x7f361a4d0050] (??:0)
[2] GraphElement::is_selected() (/srv/nobackup/godot-compile/godot/./scene/gui/graph_element.cpp:124)
[3] GraphEditArranger::arrange_nodes() (/srv/nobackup/godot-compile/godot/./scene/gui/graph_edit_arranger.cpp:82)
[4] GraphEdit::arrange_nodes() (/srv/nobackup/godot-compile/godot/./scene/gui/graph_edit.cpp:2681)
[5] void call_with_validated_variant_args_helper<__UnexistingClass>(__UnexistingClass*, void (__UnexistingClass::*)(), Variant const**, IndexSequence<>) (/srv/nobackup/godot-compile/godot/./core/variant/binder_common.h:365)
[6] void call_with_validated_object_instance_args<__UnexistingClass>(__UnexistingClass*, void (__UnexistingClass::*)(), Variant const**) (/srv/nobackup/godot-compile/godot/./core/variant/binder_common.h:652)
[7] MethodBindT<>::validated_call(Object*, Variant const**, Variant*) const (/srv/nobackup/godot-compile/godot/./core/object/method_bind.h:359)
[8] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript_vm.cpp:2297)
[9] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript.cpp:2073)
[10] Object::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/object/object.cpp:790)
[11] Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/variant/variant_call.cpp:1239)
[12] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript_vm.cpp:1922)
[13] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript.cpp:2073)
[14] Object::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/object/object.cpp:790)
[15] Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/variant/variant_call.cpp:1239)
[16] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript_vm.cpp:1922)
[17] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript.cpp:2073)
[18] Object::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/object/object.cpp:790)
[19] Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/variant/variant_call.cpp:1239)
[20] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript_vm.cpp:1922)
[21] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript.cpp:2073)
[22] Object::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/object/object.cpp:790)
[23] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/srv/nobackup/godot-compile/godot/./core/variant/callable.cpp:69)
[24] Object::emit_signalp(StringName const&, Variant const**, int) (/srv/nobackup/godot-compile/godot/./core/object/object.cpp:1199)
[25] Node::emit_signalp(StringName const&, Variant const**, int) (/srv/nobackup/godot-compile/godot/./scene/main/node.cpp:4021)
[26] Signal::emit(Variant const**, int) const (/srv/nobackup/godot-compile/godot/./core/variant/callable.cpp:539)
[27] _VariantCall::func_Signal_emit(Variant*, Variant const**, int, Variant&, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/variant/variant_call.cpp:1078)
[28] /srv/nobackup/godot-compile/godot/bin/master-godot(+0xbcd6c97) [0x55ac49fd5c97] (/srv/nobackup/godot-compile/godot/./core/variant/variant_call.cpp:2172)
[29] Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/variant/variant_call.cpp:1253)
[30] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript_vm.cpp:1922)
[31] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript.cpp:2073)
[32] Object::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/object/object.cpp:790)
[33] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/srv/nobackup/godot-compile/godot/./core/variant/callable.cpp:69)
[34] Object::emit_signalp(StringName const&, Variant const**, int) (/srv/nobackup/godot-compile/godot/./core/object/object.cpp:1199)
[35] Node::emit_signalp(StringName const&, Variant const**, int) (/srv/nobackup/godot-compile/godot/./scene/main/node.cpp:4021)
[36] Signal::emit(Variant const**, int) const (/srv/nobackup/godot-compile/godot/./core/variant/callable.cpp:539)
[37] _VariantCall::func_Signal_emit(Variant*, Variant const**, int, Variant&, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/variant/variant_call.cpp:1078)
[38] /srv/nobackup/godot-compile/godot/bin/master-godot(+0xbcd6c97) [0x55ac49fd5c97] (/srv/nobackup/godot-compile/godot/./core/variant/variant_call.cpp:2172)
[39] Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/variant/variant_call.cpp:1253)
[40] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript_vm.cpp:1922)
[41] GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./modules/gdscript/gdscript.cpp:2073)
[42] Object::callp(StringName const&, Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/object/object.cpp:790)
[43] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/srv/nobackup/godot-compile/godot/./core/variant/callable.cpp:69)
[44] Object::emit_signalp(StringName const&, Variant const**, int) (/srv/nobackup/godot-compile/godot/./core/object/object.cpp:1199)
[45] Node::emit_signalp(StringName const&, Variant const**, int) (/srv/nobackup/godot-compile/godot/./scene/main/node.cpp:4021)
[46] Error Object::emit_signal<>(StringName const&) (/srv/nobackup/godot-compile/godot/./core/object/object.h:922)
[47] BaseButton::_pressed() (/srv/nobackup/godot-compile/godot/./scene/gui/base_button.cpp:138)
[48] BaseButton::on_action_event(Ref<InputEvent>) (/srv/nobackup/godot-compile/godot/./scene/gui/base_button.cpp:?)
[49] BaseButton::gui_input(Ref<InputEvent> const&) (/srv/nobackup/godot-compile/godot/./scene/gui/base_button.cpp:68)
[50] Control::_call_gui_input(Ref<InputEvent> const&) (/srv/nobackup/godot-compile/godot/./scene/gui/control.cpp:1826)
[51] Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) (/srv/nobackup/godot-compile/godot/./scene/main/viewport.cpp:1627)
[52] Viewport::_gui_input_event(Ref<InputEvent>) (/srv/nobackup/godot-compile/godot/./scene/main/viewport.cpp:1895)
[53] Viewport::push_input(Ref<InputEvent> const&, bool) (/srv/nobackup/godot-compile/godot/./scene/main/viewport.cpp:3241)
[54] Window::_window_input(Ref<InputEvent> const&) (/srv/nobackup/godot-compile/godot/./scene/main/window.cpp:1696)
[55] void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) (/srv/nobackup/godot-compile/godot/./core/variant/binder_common.h:303)
[56] void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) (/srv/nobackup/godot-compile/godot/./core/variant/binder_common.h:418)
[57] CallableCustomMethodPointer<Window, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const (/srv/nobackup/godot-compile/godot/./core/object/callable_method_pointer.h:109)
[58] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/srv/nobackup/godot-compile/godot/./core/variant/callable.cpp:58)
[59] Variant Callable::call<Ref<InputEvent> >(Ref<InputEvent>) const (/srv/nobackup/godot-compile/godot/./core/variant/variant.h:921)
[60] DisplayServerX11::_dispatch_input_event(Ref<InputEvent> const&) (/srv/nobackup/godot-compile/godot/platform/linuxbsd/x11/display_server_x11.cpp:4137)
[61] DisplayServerX11::_dispatch_input_events(Ref<InputEvent> const&) (/srv/nobackup/godot-compile/godot/platform/linuxbsd/x11/display_server_x11.cpp:4114)
[62] Input::_parse_input_event_impl(Ref<InputEvent> const&, bool) (/srv/nobackup/godot-compile/godot/./core/input/input.cpp:921)
[63] Input::flush_buffered_events() (/srv/nobackup/godot-compile/godot/./core/input/input.cpp:1203)
[64] DisplayServerX11::process_events() (/srv/nobackup/godot-compile/godot/platform/linuxbsd/x11/display_server_x11.cpp:5268)
[65] OS_LinuxBSD::run() (/srv/nobackup/godot-compile/godot/platform/linuxbsd/os_linuxbsd.cpp:958)
[66] /srv/nobackup/godot-compile/godot/bin/master-godot(main+0x18e) [0x55ac443b403e] (/srv/nobackup/godot-compile/godot/platform/linuxbsd/godot_linuxbsd.cpp:86)
[67] /lib/x86_64-linux-gnu/libc.so.6(+0x2724a) [0x7f361a4bb24a] (??:0)
[68] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85) [0x7f361a4bb305] (??:0)
[69] /srv/nobackup/godot-compile/godot/bin/master-godot(_start+0x21) [0x55ac443b3de1] (??:?)
-- END OF BACKTRACE --
================================================================
```