### PR TITLE
C#: Fix `RefCounted` not disposed correctly in certain case

### DIFF
--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -203,6 +203,11 @@ void godotsharp_internal_refcounted_disposed(Object *p_ptr, GCHandleIntPtr p_gch
 			CSharpScriptBinding &script_binding = ((RBMap<Object *, CSharpScriptBinding>::Element *)data)->get();
 			if (script_binding.inited) {
 				if (!script_binding.gchandle.is_released()) {
+					if (rc->get_reference_count() == 1 && script_binding.gchandle.is_weak()) {
+						// The GCHandle is just swapped, so get the swapped handle to release
+						// See: CSharpLanguage::_instance_binding_reference_callback(void *p_token, void *p_binding, GDExtensionBool p_reference)
+						p_gchandle_to_free = script_binding.gchandle.get_intptr();
+					}
 					CSharpLanguage::release_binding_gchandle_thread_safe(p_gchandle_to_free, script_binding);
 				}
 			}


### PR DESCRIPTION
- Fixes: #100691

When the reference count is decreased to 1 and the current GCHandle is strong, it is assumed that the `RefCounted` is only referenced by managed side, so the strong handle needs to be replaced with a weak handle to ensure that the RefCounted can be correctly GCed.

See: https://github.com/godotengine/godot/blob/2582793d408ade0b6ed42f913ae33e7da5fb9184/modules/mono/csharp_script.cpp#L1233-L1309

It is expected in most cases, but there is one case that is just the opposite: **The RefCounted has only one reference in unmanaged side, and the managed reference is about to be disposed.** In this case, after replacing the GCHandle, can't use old handle to release managed binding.

This fix checks if it is this case when the managed reference is disposing, if so, use the replaced GCHandle to release binding.