### PR TITLE
SCons: Properly `NoCache` all text files

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1039,6 +1039,9 @@ env.Append(BUILDERS=GLSL_BUILDERS)
 if env["compiledb"]:
     env.Tool("compilation_db")
     env.Alias("compiledb", env.CompilationDatabase())
+    env.NoCache(env.CompilationDatabase())
+    if not env["verbose"]:
+        env["COMPILATIONDB_COMSTR"] = "$GENCOMSTR"
 
 if env["ninja"]:
     if env.scons_version < (4, 2, 0):

--- a/editor/icons/SCsub
+++ b/editor/icons/SCsub
@@ -7,20 +7,18 @@ import os
 
 import editor_icons_builders
 
-env["BUILDERS"]["MakeEditorIconsBuilder"] = Builder(
-    action=env.Run(editor_icons_builders.make_editor_icons_action),
-    suffix=".h",
-    src_suffix=".svg",
-)
-
 # Editor's own icons
 icon_sources = Glob("*.svg")
 
 # Module icons
 for path in env.module_icons_paths:
     if not os.path.isabs(path):
-        icon_sources += Glob("#" + path + "/*.svg")  # Built-in.
+        icon_sources += Glob(f"#{path}/*.svg")  # Built-in.
     else:
-        icon_sources += Glob(path + "/*.svg")  # Custom.
+        icon_sources += Glob(f"{path}/*.svg")  # Custom.
 
-env.Alias("editor_icons", [env.MakeEditorIconsBuilder("#editor/themes/editor_icons.gen.h", icon_sources)])
+env.CommandNoCache(
+    "#editor/themes/editor_icons.gen.h",
+    icon_sources,
+    env.Run(editor_icons_builders.make_editor_icons_action),
+)

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -585,5 +585,6 @@ def build_gles3_header(
 
 
 def build_gles3_headers(target, source, env):
+    env.NoCache(target)
     for x in source:
         build_gles3_header(str(x), include="drivers/gles3/shader_gles3.h", class_suffix="GLES3")

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -148,6 +148,7 @@ public:
 
 
 def build_rd_headers(target, source, env):
+    env.NoCache(target)
     for x in source:
         build_rd_header(filename=str(x))
 
@@ -205,5 +206,6 @@ static const char {out_file_base}[] = {{
 
 
 def build_raw_headers(target, source, env):
+    env.NoCache(target)
     for x in source:
         build_raw_header(filename=str(x))

--- a/modules/gdscript/editor/script_templates/SCsub
+++ b/modules/gdscript/editor/script_templates/SCsub
@@ -5,13 +5,4 @@ Import("env")
 
 import editor.template_builders as build_template_gd
 
-env["BUILDERS"]["MakeGDTemplateBuilder"] = Builder(
-    action=env.Run(build_template_gd.make_templates),
-    suffix=".h",
-    src_suffix=".gd",
-)
-
-# Template files
-templates_sources = Glob("*/*.gd")
-
-env.Alias("editor_template_gd", [env.MakeGDTemplateBuilder("templates.gen.h", templates_sources)])
+env.CommandNoCache("templates.gen.h", Glob("*/*.gd"), env.Run(build_template_gd.make_templates))

--- a/modules/mono/editor/script_templates/SCsub
+++ b/modules/mono/editor/script_templates/SCsub
@@ -5,13 +5,4 @@ Import("env")
 
 import editor.template_builders as build_template_cs
 
-env["BUILDERS"]["MakeCSharpTemplateBuilder"] = Builder(
-    action=env.Run(build_template_cs.make_templates),
-    suffix=".h",
-    src_suffix=".cs",
-)
-
-# Template files
-templates_sources = Glob("*/*.cs")
-
-env.Alias("editor_template_cs", [env.MakeCSharpTemplateBuilder("templates.gen.h", templates_sources)])
+env.CommandNoCache("templates.gen.h", Glob("*/*.cs"), env.Run(build_template_cs.make_templates))

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -479,8 +479,9 @@ if env["builtin_icu4c"]:
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     if env.editor_build:
-        env_icu.Depends("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/icudt_godot.dat")
-        env_icu.Command("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/icudt_godot.dat", make_icu_data)
+        env_icu.CommandNoCache(
+            "#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/icudt_godot.dat", env.Run(make_icu_data)
+        )
         env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/"])
     else:
         thirdparty_sources += ["icu_data/icudata_stub.cpp"]

--- a/platform/linuxbsd/wayland/SCsub
+++ b/platform/linuxbsd/wayland/SCsub
@@ -11,16 +11,16 @@ if env["use_sowrap"]:
 
     WAYLAND_BUILDERS_SOWRAP = {
         "WAYLAND_API_HEADER": Builder(
-            action=Action(
-                r"wayland-scanner -c client-header < ${SOURCE} | sed 's:wayland-client-core\.h:../dynwrappers/wayland-client-core-so_wrap\.h:' > ${TARGET}",
-                'Generating Wayland client header: "${TARGET}"',
+            action=env.Run(
+                r"wayland-scanner -c client-header < ${SOURCE} | "
+                r"sed 's:wayland-client-core\.h:../dynwrappers/wayland-client-core-so_wrap\.h:' > ${TARGET}",
             ),
             single_source=True,
         ),
         "WAYLAND_API_CODE": Builder(
-            action=Action(
-                r"wayland-scanner -c private-code < ${SOURCE} | sed 's:wayland-util\.h:../dynwrappers/wayland-client-core-so_wrap\.h:' > ${TARGET}",
-                'Generating Wayland protocol marshaling code: "${TARGET}"',
+            action=env.Run(
+                r"wayland-scanner -c private-code < ${SOURCE} | "
+                r"sed 's:wayland-util\.h:../dynwrappers/wayland-client-core-so_wrap\.h:' > ${TARGET}",
             ),
             single_source=True,
         ),
@@ -29,168 +29,131 @@ if env["use_sowrap"]:
 else:
     WAYLAND_BUILDERS = {
         "WAYLAND_API_HEADER": Builder(
-            action=Action(
-                r"wayland-scanner -c client-header < ${SOURCE} > ${TARGET}",
-                'Generating Wayland client header: "${TARGET}"',
-            ),
+            action=env.Run(r"wayland-scanner -c client-header < ${SOURCE} > ${TARGET}"),
             single_source=True,
         ),
         "WAYLAND_API_CODE": Builder(
-            action=Action(
-                r"wayland-scanner -c private-code < ${SOURCE} > ${TARGET}",
-                'Generating Wayland protocol marshaling code: "${TARGET}"',
-            ),
+            action=env.Run(r"wayland-scanner -c private-code < ${SOURCE} > ${TARGET}"),
             single_source=True,
         ),
     }
     env.Append(BUILDERS=WAYLAND_BUILDERS)
 
-env.WAYLAND_API_HEADER(target="protocol/wayland.gen.h", source="#thirdparty/wayland/protocol/wayland.xml")
-env.WAYLAND_API_CODE(target="protocol/wayland.gen.c", source="#thirdparty/wayland/protocol/wayland.xml")
-
-env.WAYLAND_API_HEADER(
-    target="protocol/viewporter.gen.h", source="#thirdparty/wayland-protocols/stable/viewporter/viewporter.xml"
-)
-env.WAYLAND_API_CODE(
-    target="protocol/viewporter.gen.c", source="#thirdparty/wayland-protocols/stable/viewporter/viewporter.xml"
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/fractional_scale.gen.h",
-    source="#thirdparty/wayland-protocols/staging/fractional-scale/fractional-scale-v1.xml",
-)
-env.WAYLAND_API_CODE(
-    target="protocol/fractional_scale.gen.c",
-    source="#thirdparty/wayland-protocols/staging/fractional-scale/fractional-scale-v1.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/xdg_shell.gen.h", source="#thirdparty/wayland-protocols/stable/xdg-shell/xdg-shell.xml"
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/xdg_shell.gen.c", source="#thirdparty/wayland-protocols/stable/xdg-shell/xdg-shell.xml"
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/xdg_decoration.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/xdg_decoration.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/xdg_activation.gen.h",
-    source="#thirdparty/wayland-protocols/staging/xdg-activation/xdg-activation-v1.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/xdg_activation.gen.c",
-    source="#thirdparty/wayland-protocols/staging/xdg-activation/xdg-activation-v1.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/relative_pointer.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/relative-pointer/relative-pointer-unstable-v1.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/relative_pointer.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/relative-pointer/relative-pointer-unstable-v1.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/pointer_constraints.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/pointer_constraints.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/pointer_gestures.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/pointer-gestures/pointer-gestures-unstable-v1.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/pointer_gestures.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/pointer-gestures/pointer-gestures-unstable-v1.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/primary_selection.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/primary-selection/primary-selection-unstable-v1.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/primary_selection.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/primary-selection/primary-selection-unstable-v1.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/idle_inhibit.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/idle_inhibit.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/tablet.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/tablet/tablet-unstable-v2.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/tablet.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/tablet/tablet-unstable-v2.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/text_input.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/text_input.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml",
+env.NoCache(
+    env.WAYLAND_API_HEADER("protocol/wayland.gen.h", "#thirdparty/wayland/protocol/wayland.xml"),
+    env.WAYLAND_API_CODE("protocol/wayland.gen.c", "#thirdparty/wayland/protocol/wayland.xml"),
+    env.WAYLAND_API_HEADER(
+        "protocol/viewporter.gen.h", "#thirdparty/wayland-protocols/stable/viewporter/viewporter.xml"
+    ),
+    env.WAYLAND_API_CODE("protocol/viewporter.gen.c", "#thirdparty/wayland-protocols/stable/viewporter/viewporter.xml"),
+    env.WAYLAND_API_HEADER(
+        "protocol/fractional_scale.gen.h",
+        "#thirdparty/wayland-protocols/staging/fractional-scale/fractional-scale-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/fractional_scale.gen.c",
+        "#thirdparty/wayland-protocols/staging/fractional-scale/fractional-scale-v1.xml",
+    ),
+    env.WAYLAND_API_HEADER("protocol/xdg_shell.gen.h", "#thirdparty/wayland-protocols/stable/xdg-shell/xdg-shell.xml"),
+    env.WAYLAND_API_CODE("protocol/xdg_shell.gen.c", "#thirdparty/wayland-protocols/stable/xdg-shell/xdg-shell.xml"),
+    env.WAYLAND_API_HEADER(
+        "protocol/xdg_decoration.gen.h",
+        "#thirdparty/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/xdg_decoration.gen.c",
+        "#thirdparty/wayland-protocols/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/xdg_activation.gen.h",
+        "#thirdparty/wayland-protocols/staging/xdg-activation/xdg-activation-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/xdg_activation.gen.c",
+        "#thirdparty/wayland-protocols/staging/xdg-activation/xdg-activation-v1.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/relative_pointer.gen.h",
+        "#thirdparty/wayland-protocols/unstable/relative-pointer/relative-pointer-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/relative_pointer.gen.c",
+        "#thirdparty/wayland-protocols/unstable/relative-pointer/relative-pointer-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/pointer_constraints.gen.h",
+        "#thirdparty/wayland-protocols/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/pointer_constraints.gen.c",
+        "#thirdparty/wayland-protocols/unstable/pointer-constraints/pointer-constraints-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/pointer_gestures.gen.h",
+        "#thirdparty/wayland-protocols/unstable/pointer-gestures/pointer-gestures-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/pointer_gestures.gen.c",
+        "#thirdparty/wayland-protocols/unstable/pointer-gestures/pointer-gestures-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/primary_selection.gen.h",
+        "#thirdparty/wayland-protocols/unstable/primary-selection/primary-selection-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/primary_selection.gen.c",
+        "#thirdparty/wayland-protocols/unstable/primary-selection/primary-selection-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/idle_inhibit.gen.h",
+        "#thirdparty/wayland-protocols/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/idle_inhibit.gen.c",
+        "#thirdparty/wayland-protocols/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/tablet.gen.h",
+        "#thirdparty/wayland-protocols/unstable/tablet/tablet-unstable-v2.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/tablet.gen.c",
+        "#thirdparty/wayland-protocols/unstable/tablet/tablet-unstable-v2.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/text_input.gen.h",
+        "#thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/text_input.gen.c",
+        "#thirdparty/wayland-protocols/unstable/text-input/text-input-unstable-v3.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/xdg_foreign_v1.gen.h",
+        "#thirdparty/wayland-protocols/unstable/xdg-foreign/xdg-foreign-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/xdg_foreign_v1.gen.c",
+        "#thirdparty/wayland-protocols/unstable/xdg-foreign/xdg-foreign-unstable-v1.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/xdg_foreign_v2.gen.h",
+        "#thirdparty/wayland-protocols/unstable/xdg-foreign/xdg-foreign-unstable-v2.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/xdg_foreign_v2.gen.c",
+        "#thirdparty/wayland-protocols/unstable/xdg-foreign/xdg-foreign-unstable-v2.xml",
+    ),
+    env.WAYLAND_API_HEADER(
+        "protocol/xdg_system_bell.gen.h",
+        "#thirdparty/wayland-protocols/staging/xdg-system-bell/xdg-system-bell-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/xdg_system_bell.gen.c",
+        "#thirdparty/wayland-protocols/staging/xdg-system-bell/xdg-system-bell-v1.xml",
+    ),
 )
 
-env.WAYLAND_API_HEADER(
-    target="protocol/xdg_foreign_v1.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/xdg-foreign/xdg-foreign-unstable-v1.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/xdg_foreign_v1.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/xdg-foreign/xdg-foreign-unstable-v1.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/xdg_foreign_v2.gen.h",
-    source="#thirdparty/wayland-protocols/unstable/xdg-foreign/xdg-foreign-unstable-v2.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/xdg_foreign_v2.gen.c",
-    source="#thirdparty/wayland-protocols/unstable/xdg-foreign/xdg-foreign-unstable-v2.xml",
-)
-
-env.WAYLAND_API_HEADER(
-    target="protocol/xdg_system_bell.gen.h",
-    source="#thirdparty/wayland-protocols/staging/xdg-system-bell/xdg-system-bell-v1.xml",
-)
-
-env.WAYLAND_API_CODE(
-    target="protocol/xdg_system_bell.gen.c",
-    source="#thirdparty/wayland-protocols/staging/xdg-system-bell/xdg-system-bell-v1.xml",
-)
 
 source_files = [
     "protocol/wayland.gen.c",

--- a/scene/theme/icons/SCsub
+++ b/scene/theme/icons/SCsub
@@ -5,16 +5,8 @@ Import("env")
 
 import default_theme_icons_builders
 
-env["BUILDERS"]["MakeDefaultThemeIconsBuilder"] = Builder(
-    action=env.Run(default_theme_icons_builders.make_default_theme_icons_action),
-    suffix=".h",
-    src_suffix=".svg",
-)
-
-# Default theme icons
-icon_sources = Glob("*.svg")
-
-env.Alias(
-    "default_theme_icons",
-    [env.MakeDefaultThemeIconsBuilder("#scene/theme/default_theme_icons.gen.h", icon_sources)],
+env.CommandNoCache(
+    "#scene/theme/default_theme_icons.gen.h",
+    Glob("*.svg"),
+    env.Run(default_theme_icons_builders.make_default_theme_icons_action),
 )


### PR DESCRIPTION
Turns out, reading files in the cache becomes prohibitively slow once it achieves moderate size. Instead of attempting to optimize what was already a bandage solution, this tackles the root issue of text files being incorrectly cached. `NoCache` was never properly applied to several builders, most notably *all* `.glsl.gen.h` files, so this sweeps through and ensures they're actually enforced. Consequently, the dedicated text cache check has been entirely discarded; there's no reasonable situation where that will occur anymore, and the performance hit isn't worth it in the first place.