### PR TITLE
Place a hard limit on the `max_contacts_reported` property in 2D/3D physics

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -181,6 +181,7 @@ public:
 	}
 
 	_FORCE_INLINE_ void set_max_contacts_reported(int p_size) {
+		ERR_FAIL_INDEX(p_size, MAX_CONTACTS_REPORTED_2D_MAX);
 		contacts.resize(p_size);
 		contact_count = 0;
 		if (mode == PhysicsServer2D::BODY_MODE_KINEMATIC && p_size) {

--- a/modules/godot_physics_3d/godot_body_3d.h
+++ b/modules/godot_physics_3d/godot_body_3d.h
@@ -175,6 +175,7 @@ public:
 	}
 
 	_FORCE_INLINE_ void set_max_contacts_reported(int p_size) {
+		ERR_FAIL_INDEX(p_size, MAX_CONTACTS_REPORTED_3D_MAX);
 		contacts.resize(p_size);
 		contact_count = 0;
 		if (mode == PhysicsServer3D::BODY_MODE_KINEMATIC && p_size) {

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -881,7 +881,7 @@ void JoltBody3D::set_center_of_mass_custom(const Vector3 &p_center_of_mass) {
 }
 
 void JoltBody3D::set_max_contacts_reported(int p_count) {
-	ERR_FAIL_COND(p_count < 0);
+	ERR_FAIL_INDEX(p_count, MAX_CONTACTS_REPORTED_3D_MAX);
 
 	if (unlikely((int)contacts.size() == p_count)) {
 		return;

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -498,6 +498,7 @@ bool RigidBody2D::is_sleeping() const {
 }
 
 void RigidBody2D::set_max_contacts_reported(int p_amount) {
+	ERR_FAIL_INDEX_MSG(p_amount, MAX_CONTACTS_REPORTED_2D_MAX, "Max contacts reported allocates memory (about 100 bytes each), and therefore must not be set too high.");
 	max_contacts_reported = p_amount;
 	PhysicsServer2D::get_singleton()->body_set_max_contacts_reported(get_rid(), p_amount);
 }

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -521,6 +521,7 @@ bool RigidBody3D::is_sleeping() const {
 }
 
 void RigidBody3D::set_max_contacts_reported(int p_amount) {
+	ERR_FAIL_INDEX_MSG(p_amount, MAX_CONTACTS_REPORTED_3D_MAX, "Max contacts reported allocates memory (about 80 bytes each), and therefore must not be set too high.");
 	max_contacts_reported = p_amount;
 	PhysicsServer3D::get_singleton()->body_set_max_contacts_reported(get_rid(), p_amount);
 }

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -34,6 +34,8 @@
 #include "core/object/class_db.h"
 #include "core/object/ref_counted.h"
 
+constexpr int MAX_CONTACTS_REPORTED_2D_MAX = 4096;
+
 class PhysicsDirectSpaceState2D;
 template <typename T>
 class TypedArray;

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -35,6 +35,8 @@
 #include "core/io/resource.h"
 #include "core/object/gdvirtual.gen.inc"
 
+constexpr int MAX_CONTACTS_REPORTED_3D_MAX = 4096;
+
 class PhysicsDirectSpaceState3D;
 template <typename T>
 class TypedArray;


### PR DESCRIPTION
Without this PR, attempting to set max_contacts_reported to the maximum signed 32-bit integer value would attempt to allocate over 200 GiB of RAM, causing Godot and possibly the operating system to freeze.

There is now a hard limit defined by `constexpr int MAX_CONTACTS_REPORTED_3D_MAX = 100'000'000;` which will ensure that no body can use more than about 10 GiB of RAM. There is a check before the actual array resize inside of the physics server body code, and a user-friendly check at the node level to provide helpful feedback, informing the user of what the consequences are of the number they set and why there is a limit:

<img width="900" alt="Screenshot 2025-01-01 at 5 25 32 PM" src="https://github.com/user-attachments/assets/83f966f9-2fdf-448b-87e4-bad252c864a6" />

I am not sure what the best limit is, my goal here is to keep the limit high enough that no real use case will come near the limit, while also ensuring that if users try punching in very large numbers they will see the error. This PR was motivated by me watching somebody use RigidBody2D and set the max_contacts_reported to `(2**31)-1` which was accepted but would've resulted in over 160 GiB of RAM used (it seems that his Linux system refused to allocate that much though).