### PR TITLE
Preserve emission ring shape properties during conversion from GPUParticles3D to CPUParticles3D and vice versa

### DIFF
--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1409,6 +1409,11 @@ void CPUParticles3D::convert_from_particles(Node *p_particles) {
 	set_emission_shape(EmissionShape(material->get_emission_shape()));
 	set_emission_sphere_radius(material->get_emission_sphere_radius());
 	set_emission_box_extents(material->get_emission_box_extents());
+	set_emission_ring_height(material->get_emission_ring_height());
+	set_emission_ring_radius(material->get_emission_ring_radius());
+	set_emission_ring_inner_radius(material->get_emission_ring_inner_radius());
+	set_emission_ring_cone_angle(material->get_emission_ring_cone_angle());
+
 	Ref<CurveXYZTexture> scale3D = material->get_param_texture(ParticleProcessMaterial::PARAM_SCALE);
 	if (scale3D.is_valid()) {
 		split_scale = true;

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -627,6 +627,10 @@ void GPUParticles3D::convert_from_particles(Node *p_particles) {
 	proc_mat->set_emission_shape(ParticleProcessMaterial::EmissionShape(cpu_particles->get_emission_shape()));
 	proc_mat->set_emission_sphere_radius(cpu_particles->get_emission_sphere_radius());
 	proc_mat->set_emission_box_extents(cpu_particles->get_emission_box_extents());
+	proc_mat->set_emission_ring_height(cpu_particles->get_emission_ring_height());
+	proc_mat->set_emission_ring_radius(cpu_particles->get_emission_ring_radius());
+	proc_mat->set_emission_ring_inner_radius(cpu_particles->get_emission_ring_inner_radius());
+	proc_mat->set_emission_ring_cone_angle(cpu_particles->get_emission_ring_cone_angle());
 
 	if (cpu_particles->get_split_scale()) {
 		Ref<CurveXYZTexture> scale3D = memnew(CurveXYZTexture);


### PR DESCRIPTION
* Fixes: #100946
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
