### PR TITLE
Prevent errors when drawing debug meshes with no mesh data.

### DIFF
--- a/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/collision_shape_3d_gizmo_plugin.cpp
@@ -350,7 +350,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	if (cs->get_debug_fill_enabled()) {
 		Ref<ArrayMesh> array_mesh = s->get_debug_arraymesh_faces(collision_color);
-		if (array_mesh.is_valid()) {
+		if (array_mesh.is_valid() && array_mesh->get_surface_count() > 0) {
 			p_gizmo->add_mesh(array_mesh, material_arraymesh);
 		}
 	}

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -132,9 +132,12 @@ Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 		debug_mesh_cache->surface_set_material(0, material);
 
 		if (debug_fill) {
-			Array solid_array = get_debug_arraymesh_faces(debug_color * Color(1.0, 1.0, 1.0, 0.0625))->surface_get_arrays(0);
-			debug_mesh_cache->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, solid_array);
-			debug_mesh_cache->surface_set_material(1, material);
+			Ref<ArrayMesh> array_mesh = get_debug_arraymesh_faces(debug_color * Color(1.0, 1.0, 1.0, 0.0625));
+			if (array_mesh.is_valid() && array_mesh->get_surface_count() > 0) {
+				Array solid_array = array_mesh->surface_get_arrays(0);
+				debug_mesh_cache->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, solid_array);
+				debug_mesh_cache->surface_set_material(1, material);
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds a few checks to ensure a debug collision mesh contains mesh data before attempting to add it to the gizmo draw list. This prevents errors when using `SeparationRayShape3D`, which is only intended to draw a single line, and contains no mesh data.

Closes #100665

This fixes the same issue as #100968, just using a different method that performs a check for null mesh data before adding the debug mesh. This is probably the more proper fix, but I'll leave the other pull request open for now.