### PR TITLE
Use `LocalVector.reserve` internally instead of copying code.

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -58,12 +58,7 @@ public:
 	}
 
 	_FORCE_INLINE_ void push_back(T p_elem) {
-		if (unlikely(count == capacity)) {
-			capacity = tight ? (capacity + 1) : MAX((U)1, capacity << 1);
-			data = (T *)memrealloc(data, capacity * sizeof(T));
-			CRASH_COND_MSG(!data, "Out of memory");
-		}
-
+		reserve(size() + 1);
 		if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
 			memnew_placement(&data[count++], T(p_elem));
 		} else {
@@ -138,8 +133,8 @@ public:
 	_FORCE_INLINE_ bool is_empty() const { return count == 0; }
 	_FORCE_INLINE_ U get_capacity() const { return capacity; }
 	_FORCE_INLINE_ void reserve(U p_size) {
-		p_size = tight ? p_size : nearest_power_of_2_templated(p_size);
 		if (p_size > capacity) {
+			p_size = tight ? p_size : nearest_power_of_2_templated(p_size);
 			capacity = p_size;
 			data = (T *)memrealloc(data, capacity * sizeof(T));
 			CRASH_COND_MSG(!data, "Out of memory");
@@ -156,11 +151,7 @@ public:
 			}
 			count = p_size;
 		} else if (p_size > count) {
-			if (unlikely(p_size > capacity)) {
-				capacity = tight ? p_size : nearest_power_of_2_templated(p_size);
-				data = (T *)memrealloc(data, capacity * sizeof(T));
-				CRASH_COND_MSG(!data, "Out of memory");
-			}
+			reserve(p_size);
 			if constexpr (!std::is_trivially_constructible_v<T> && !force_trivial) {
 				for (U i = count; i < p_size; i++) {
 					memnew_placement(&data[i], T);


### PR DESCRIPTION
It's basically a small cleanup to get rid of duplicate logic.

There is a tiny behavior change: `reserve` will no longer allocate more capacity than requested even if the current capacity is not a power of 2. This is the behavior that matches the logic implemented previously in `push_back` and `resize`. The case is unlikely to be triggered, and in all cases, the new behavior is equally as correct but slightly faster (though unlikely to be noticeable).
