### PR TITLE
Re-implement `String.get_slice_count` as `count() + 1`, which has the same logic.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1059,45 +1059,6 @@ String String::get_with_code_lines() const {
 	return ret;
 }
 
-int String::get_slice_count(const String &p_splitter) const {
-	if (is_empty()) {
-		return 0;
-	}
-	if (p_splitter.is_empty()) {
-		return 0;
-	}
-
-	int pos = 0;
-	int slices = 1;
-
-	while ((pos = find(p_splitter, pos)) >= 0) {
-		slices++;
-		pos += p_splitter.length();
-	}
-
-	return slices;
-}
-
-int String::get_slice_count(const char *p_splitter) const {
-	if (is_empty()) {
-		return 0;
-	}
-	if (p_splitter == nullptr || *p_splitter == '\0') {
-		return 0;
-	}
-
-	int pos = 0;
-	int slices = 1;
-	int splitter_length = strlen(p_splitter);
-
-	while ((pos = find(p_splitter, pos)) >= 0) {
-		slices++;
-		pos += splitter_length;
-	}
-
-	return slices;
-}
-
 String String::get_slice(const String &p_splitter, int p_slice) const {
 	if (is_empty() || p_splitter.is_empty()) {
 		return "";

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -479,8 +479,8 @@ public:
 	String to_snake_case() const;
 
 	String get_with_code_lines() const;
-	int get_slice_count(const String &p_splitter) const;
-	int get_slice_count(const char *p_splitter) const;
+	int get_slice_count(const String &p_splitter) const { return count(p_splitter) + 1; }
+	int get_slice_count(const char *p_splitter) const { return count(p_splitter) + 1; }
 	String get_slice(const String &p_splitter, int p_slice) const;
 	String get_slice(const char *p_splitter, int p_slice) const;
 	String get_slicec(char32_t p_splitter, int p_slice) const;


### PR DESCRIPTION
I think the new version is more readable :)
There may be a tiny speed difference because the `_count` implementation supports `p_from` and `p_to`, but it's unlikely to be even measurable.

Both implementations skip over the full occurrence, i.e. `"fff".count("ff") = 1`.