### PR TITLE
Optimize `_count` by replacing a full copy with a CoW copy for the full-string count case.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3707,8 +3707,7 @@ int String::_count(const String &p_string, int p_from, int p_to, bool p_case_ins
 			return 0;
 		}
 		if (p_from == 0 && p_to == len) {
-			str = String();
-			str.copy_from_unchecked(&get_data()[0], len);
+			str = *this;
 		} else {
 			str = substr(p_from, p_to - p_from);
 		}
@@ -3744,8 +3743,7 @@ int String::_count(const char *p_string, int p_from, int p_to, bool p_case_insen
 			return 0;
 		}
 		if (p_from == 0 && search_limit == source_length) {
-			str = String();
-			str.copy_from_unchecked(&get_data()[0], source_length);
+			str = *this;
 		} else {
 			str = substr(p_from, search_limit - p_from);
 		}


### PR DESCRIPTION
Let me know if you think it needs a benchmark, but I think it's clear that the new version will be substantially faster for the full-string count case.

Thanks to @AThousandShips for spotting this!