### PR TITLE
Fix compiling Godot 2.1.x on macOS 15/Xcode 16

### DIFF
--- a/thirdparty/freetype/src/gzip/ftzconf.h
+++ b/thirdparty/freetype/src/gzip/ftzconf.h
@@ -215,7 +215,7 @@
 #   define FAR
 #endif
 
-#if !defined(MACOS) && !defined(TARGET_OS_MAC)
+#if !defined(__MACTYPES__)
 typedef unsigned char  Byte;  /* 8 bits */
 #endif
 typedef unsigned int   uInt;  /* 16 bits or more */


### PR DESCRIPTION
Updated a line in the included FreeType 1.8.1 from FreeType 1.12.0+ to be compatible with Xcode 16. Fixes: https://github.com/godotengine/godot/issues/101035