### PR TITLE
Manually specify build tools for compiling godot

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -342,10 +342,22 @@ opts.Add(BoolVariable("builtin_zstd", "Use the built-in Zstd library", True))
 
 # Compilation environment setup
 # CXX, CC, and LINK directly set the equivalent `env` values (which may still
-# be overridden for a specific platform), the lowercase ones are appended.
+# be overridden for a specific platform if platform_tools is True), the lowercase ones are appended.
+opts.Add(
+    BoolVariable(
+        "platform_tools", "Allow the platform to override CC, CXX, LINK, AS, AR, RANLIB, WINDRES, and ARCOM", True
+    )
+)
 opts.Add("CXX", "C++ compiler binary")
 opts.Add("CC", "C compiler binary")
 opts.Add("LINK", "Linker binary")
+opts.Add("AS", "Assembler binary")
+opts.Add("AR", "Archiver binary")
+opts.Add("RANLIB", "Ranlib binary")
+opts.Add("RC", "Resource compiler binary")
+# Set this to something like "${TEMPFILE('$AR rcs $TARGET $SOURCES','$ARCOMSTR')}" if you get errors related to a command being too long.
+# This is a common error on Windows machines.
+opts.Add("ARCOM", "Custom command used to generate an object file from an assembly-language source file.")
 opts.Add("cppdefines", "Custom defines for the pre-processor")
 opts.Add("ccflags", "Custom flags for both the C and C++ compilers")
 opts.Add("cxxflags", "Custom flags for the C++ compiler")
@@ -361,6 +373,13 @@ opts.Add("cpp_compiler_launcher", "C++ compiler launcher (e.g. `ccache`)")
 # Update the environment to have all above options defined
 # in following code (especially platform and custom_modules).
 opts.Update(env)
+
+# When using custom tools, we need to update the environment here so that "auto" is considered a supported arch.
+if not env["platform_tools"]:
+    tmppath = "./platform/" + env["platform"]
+    sys.path.insert(0, tmppath)
+    env.Tool("default")
+    opts.Update(env)
 
 # Setup caching logic early to catch everything.
 methods.prepare_cache(env)
@@ -500,13 +519,14 @@ tmppath = "./platform/" + env["platform"]
 sys.path.insert(0, tmppath)
 import detect
 
-custom_tools = ["default"]
-try:  # Platform custom tools are optional
-    custom_tools = detect.get_tools(env)
-except AttributeError:
-    pass
-for tool in custom_tools:
-    env.Tool(tool)
+if env["platform_tools"]:
+    custom_tools = ["default"]
+    try:  # Platform custom tools are optional
+        custom_tools = detect.get_tools(env)
+    except AttributeError:
+        pass
+    for tool in custom_tools:
+        env.Tool(tool)
 
 
 # Add default include paths.

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -178,11 +178,12 @@ def configure(env: "SConsEnvironment"):
     toolchain_path = os.path.join(ndk_root, "toolchains", "llvm", "prebuilt", host_subpath)
     compiler_path = os.path.join(toolchain_path, "bin")
 
-    env["CC"] = os.path.join(compiler_path, "clang")
-    env["CXX"] = os.path.join(compiler_path, "clang++")
-    env["AR"] = os.path.join(compiler_path, "llvm-ar")
-    env["RANLIB"] = os.path.join(compiler_path, "llvm-ranlib")
-    env["AS"] = os.path.join(compiler_path, "clang")
+    if env["platform_tools"]:
+        env["CC"] = os.path.join(compiler_path, "clang")
+        env["CXX"] = os.path.join(compiler_path, "clang++")
+        env["AR"] = os.path.join(compiler_path, "llvm-ar")
+        env["RANLIB"] = os.path.join(compiler_path, "llvm-ranlib")
+        env["AS"] = os.path.join(compiler_path, "clang")
 
     env.Append(
         CCFLAGS=(["-fpic", "-ffunction-sections", "-funwind-tables", "-fstack-protector-strong", "-fvisibility=hidden"])

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -86,18 +86,20 @@ def configure(env: "SConsEnvironment"):
     compiler_path = "$APPLE_TOOLCHAIN_PATH/usr/bin/${apple_target_triple}"
 
     ccache_path = os.environ.get("CCACHE")
-    if ccache_path is None:
-        env["CC"] = compiler_path + "clang"
-        env["CXX"] = compiler_path + "clang++"
-        env["S_compiler"] = compiler_path + "clang"
-    else:
-        # there aren't any ccache wrappers available for iOS,
-        # to enable caching we need to prepend the path to the ccache binary
-        env["CC"] = ccache_path + " " + compiler_path + "clang"
-        env["CXX"] = ccache_path + " " + compiler_path + "clang++"
-        env["S_compiler"] = ccache_path + " " + compiler_path + "clang"
-    env["AR"] = compiler_path + "ar"
-    env["RANLIB"] = compiler_path + "ranlib"
+
+    if env["platform_tools"]:
+        if ccache_path is None:
+            env["CC"] = compiler_path + "clang"
+            env["CXX"] = compiler_path + "clang++"
+            env["S_compiler"] = compiler_path + "clang"
+        else:
+            # there aren't any ccache wrappers available for iOS,
+            # to enable caching we need to prepend the path to the ccache binary
+            env["CC"] = ccache_path + " " + compiler_path + "clang"
+            env["CXX"] = ccache_path + " " + compiler_path + "clang++"
+            env["S_compiler"] = ccache_path + " " + compiler_path + "clang"
+        env["AR"] = compiler_path + "ar"
+        env["RANLIB"] = compiler_path + "ranlib"
 
     ## Compile flags
 

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -105,7 +105,7 @@ def configure(env: "SConsEnvironment"):
         env["use_llvm"] = True
 
     if env["use_llvm"]:
-        if "clang++" not in os.path.basename(env["CXX"]):
+        if env["platform_tools"] and "clang++" not in os.path.basename(env["CXX"]):
             env["CC"] = "clang"
             env["CXX"] = "clang++"
         env.extra_suffix = ".llvm" + env.extra_suffix
@@ -204,7 +204,7 @@ def configure(env: "SConsEnvironment"):
             env.Append(CCFLAGS=["-flto"])
             env.Append(LINKFLAGS=["-flto"])
 
-        if not env["use_llvm"]:
+        if env["platform_tools"] and not env["use_llvm"]:
             env["RANLIB"] = "gcc-ranlib"
             env["AR"] = "gcc-ar"
 

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -107,35 +107,36 @@ def configure(env: "SConsEnvironment"):
     if ccache_path != "":
         ccache_path = ccache_path + " "
 
-    if "osxcross" not in env:  # regular native build
-        if env["macports_clang"] != "no":
-            mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
-            mpclangver = env["macports_clang"]
-            env["CC"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang"
-            env["CXX"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang++"
-            env["AR"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ar"
-            env["RANLIB"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ranlib"
-            env["AS"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-as"
-        else:
-            env["CC"] = ccache_path + "clang"
-            env["CXX"] = ccache_path + "clang++"
+    if env["platform_tools"]:
+        if "osxcross" not in env:  # regular native build
+            if env["macports_clang"] != "no":
+                mpprefix = os.environ.get("MACPORTS_PREFIX", "/opt/local")
+                mpclangver = env["macports_clang"]
+                env["CC"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang"
+                env["CXX"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/clang++"
+                env["AR"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ar"
+                env["RANLIB"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-ranlib"
+                env["AS"] = mpprefix + "/libexec/llvm-" + mpclangver + "/bin/llvm-as"
+            else:
+                env["CC"] = ccache_path + "clang"
+                env["CXX"] = ccache_path + "clang++"
 
-        detect_darwin_sdk_path("macos", env)
-        env.Append(CCFLAGS=["-isysroot", "$MACOS_SDK_PATH"])
-        env.Append(LINKFLAGS=["-isysroot", "$MACOS_SDK_PATH"])
+            detect_darwin_sdk_path("macos", env)
+            env.Append(CCFLAGS=["-isysroot", "$MACOS_SDK_PATH"])
+            env.Append(LINKFLAGS=["-isysroot", "$MACOS_SDK_PATH"])
 
-    else:  # osxcross build
-        root = os.environ.get("OSXCROSS_ROOT", "")
-        if env["arch"] == "arm64":
-            basecmd = root + "/target/bin/arm64-apple-" + env["osxcross_sdk"] + "-"
-        else:
-            basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
+        else:  # osxcross build
+            root = os.environ.get("OSXCROSS_ROOT", "")
+            if env["arch"] == "arm64":
+                basecmd = root + "/target/bin/arm64-apple-" + env["osxcross_sdk"] + "-"
+            else:
+                basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
 
-        env["CC"] = ccache_path + basecmd + "cc"
-        env["CXX"] = ccache_path + basecmd + "c++"
-        env["AR"] = basecmd + "ar"
-        env["RANLIB"] = basecmd + "ranlib"
-        env["AS"] = basecmd + "as"
+            env["CC"] = ccache_path + basecmd + "cc"
+            env["CXX"] = ccache_path + basecmd + "c++"
+            env["AR"] = basecmd + "ar"
+            env["RANLIB"] = basecmd + "ranlib"
+            env["AS"] = basecmd + "as"
 
     # LTO
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -101,11 +101,12 @@ def library_emitter(target, source, env):
 
 
 def configure(env: "SConsEnvironment"):
-    env["CC"] = "emcc"
-    env["CXX"] = "em++"
+    if env["platform_tools"]:
+        env["CC"] = "emcc"
+        env["CXX"] = "em++"
 
-    env["AR"] = "emar"
-    env["RANLIB"] = "emranlib"
+        env["AR"] = "emar"
+        env["RANLIB"] = "emranlib"
 
     # Get version info for checks below.
     cc_version = get_compiler_version(env)

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -599,8 +599,10 @@ def configure_mingw(env: "SConsEnvironment"):
         )
         sys.exit(255)
 
-    if not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]) and not try_cmd(
-        "clang --version", env["mingw_prefix"], env["arch"]
+    if (
+        env["platform_tools"]
+        and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"])
+        and not try_cmd("clang --version", env["mingw_prefix"], env["arch"])
     ):
         print_error("No valid compilers found, use MINGW_PREFIX environment variable to set MinGW path.")
         sys.exit(255)
@@ -625,10 +627,10 @@ def configure_mingw(env: "SConsEnvironment"):
 
     ## Build type
 
-    if not env["use_llvm"] and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]):
+    if env["platform_tools"] and not env["use_llvm"] and not try_cmd("gcc --version", env["mingw_prefix"], env["arch"]):
         env["use_llvm"] = True
 
-    if env["use_llvm"] and not try_cmd("clang --version", env["mingw_prefix"], env["arch"]):
+    if env["platform_tools"] and env["use_llvm"] and not try_cmd("clang --version", env["mingw_prefix"], env["arch"]):
         env["use_llvm"] = False
 
     if not env["use_llvm"] and try_cmd("gcc --version", env["mingw_prefix"], env["arch"], True):
@@ -642,6 +644,11 @@ def configure_mingw(env: "SConsEnvironment"):
         env.AppendUnique(CPPDEFINES=["WINDOWS_SUBSYSTEM_CONSOLE"])
 
     ## Compiler configuration
+
+    # If env["platform_tools"] is true, this will be handled by env.Tool("mingw").
+    # Otherwise we need to set it here.
+    if not env["platform_tools"] and os.name != "nt":
+        env["PROGSUFFIX"] = env["PROGSUFFIX"] + ".exe"
 
     if env["arch"] == "x86_32":
         if env["use_static_cpp"]:
@@ -662,32 +669,26 @@ def configure_mingw(env: "SConsEnvironment"):
     env.Append(CCFLAGS=["-ffp-contract=off"])
 
     if env["use_llvm"]:
-        env["CC"] = get_detected(env, "clang")
-        env["CXX"] = get_detected(env, "clang++")
-        env["AR"] = get_detected(env, "ar")
-        env["RANLIB"] = get_detected(env, "ranlib")
-        env["AS"] = get_detected(env, "clang")
-        env.Append(ASFLAGS=["-c"])
         env.extra_suffix = ".llvm" + env.extra_suffix
-    else:
-        env["CC"] = get_detected(env, "gcc")
-        env["CXX"] = get_detected(env, "g++")
-        env["AR"] = get_detected(env, "gcc-ar" if os.name != "nt" else "ar")
-        env["RANLIB"] = get_detected(env, "gcc-ranlib")
-        env["AS"] = get_detected(env, "gcc")
-        env.Append(ASFLAGS=["-c"])
 
-    env["RC"] = get_detected(env, "windres")
-    ARCH_TARGETS = {
-        "x86_32": "pe-i386",
-        "x86_64": "pe-x86-64",
-        "arm32": "armv7-w64-mingw32",
-        "arm64": "aarch64-w64-mingw32",
-    }
-    env.AppendUnique(RCFLAGS=f"--target={ARCH_TARGETS[env['arch']]}")
+    if env["platform_tools"]:
+        if env["use_llvm"]:
+            env["CC"] = get_detected(env, "clang")
+            env["CXX"] = get_detected(env, "clang++")
+            env["AR"] = get_detected(env, "ar")
+            env["RANLIB"] = get_detected(env, "ranlib")
+            env["AS"] = get_detected(env, "clang")
+            env.Append(ASFLAGS=["-c"])
+        else:
+            env["CC"] = get_detected(env, "gcc")
+            env["CXX"] = get_detected(env, "g++")
+            env["AR"] = get_detected(env, "gcc-ar" if os.name != "nt" else "ar")
+            env["RANLIB"] = get_detected(env, "gcc-ranlib")
+            env["AS"] = get_detected(env, "gcc")
+            env.Append(ASFLAGS=["-c"])
 
-    env["OBJCOPY"] = get_detected(env, "objcopy")
-    env["STRIP"] = get_detected(env, "strip")
+        env["OBJCOPY"] = get_detected(env, "objcopy")
+        env["STRIP"] = get_detected(env, "strip")
 
     ## LTO
 


### PR DESCRIPTION
### NOTE

Supercedes PR: https://github.com/godotengine/godot/pull/91743

The PR above was getting bloated with features added in order to support building godot from source with zig.  I broke those features up into separate PRs.

### Description

Currently Godot overrides build tools such as CC and CXX depending on which platform is being targeted. This adds a boolean to the build process that prevents this from happening. It helps solve a lot of the pain points that I have been running into in the godot-src project: https://github.com/lange-studios/godot-src

This allows me to more easily use zig and other tools for cross compilation. Example:

```
  "CC=zig cc -target x86_64-linux-gnu"
  "CXX=zig c++ -target x86_64-linux-gnu"
  "LINK=zig c++ -target x86_64-linux-gnu"
  "AS=zig c++ -target x86_64-linux-gnu"
  "AR=zig ar"
  "RANLIB=zig ranlib"
  "WINDRES=zig rc"
```

And just like that, I can compile godot from any platform zig supports compiling from to any platform zig supports compiling to! In this case from Windows, Mac, or Linux to Linux! :)

We have been using this to build godot from source for months now without issue :).  Let me know if you would like anything changed.  Once this goes through, I can probably start asking other users to test out ``godot-src`` and let me know what they think / if it makes the process any easier.