### PR TITLE
Allow for manually building the res files for windows platforms

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -194,6 +194,16 @@ def get_opts():
         BoolVariable("debug_crt", "Compile with MSVC's debug CRT (/MDd)", False),
         BoolVariable("incremental_link", "Use MSVC incremental linking. May increase or decrease build times.", False),
         BoolVariable("silence_msvc", "Silence MSVC's cl/link stdout bloat, redirecting any errors to stderr.", True),
+        BoolVariable(
+            "use_windres",
+            "Use the windres compiler, even if Microsoft's rc is installed. Only applicable if manual_build_res_file is True",
+            True,
+        ),
+        BoolVariable(
+            "manual_build_res_file",
+            "Manually build the res files instead of relying on scons to do it automatically",
+            False,
+        ),
         ("angle_libs", "Path to the ANGLE static libraries", ""),
         # Direct3D 12 support.
         (
@@ -238,6 +248,61 @@ def get_flags():
         "d3d12": True,
         "supported": ["d3d12", "dcomp", "library", "mono", "xaudio2"],
     }
+
+
+def build_res_file(target, source, env: "SConsEnvironment"):
+    arch_aliases = {
+        "x86_32": "pe-i386",
+        "x86_64": "pe-x86-64",
+        "arm32": "armv7-w64-mingw32",
+        "arm64": "aarch64-w64-mingw32",
+    }
+
+    if env["platform_tools"]:
+        if env["use_windres"]:
+            cmdbase = "windres"
+            mingw_bin_prefix = get_mingw_bin_prefix(env["mingw_prefix"], env["arch"])
+        else:
+            cmdbase = "rc"
+            mingw_bin_prefix = ""
+    else:
+        cmdbase = env["RC"]
+        mingw_bin_prefix = ""
+
+    if env["use_windres"]:
+        cmdbase += " --include-dir . --target=" + arch_aliases[env["arch"]]
+    else:
+        # rc doesn't seem to have a target architecture arg.  So not passing.
+        cmdbase += " /nologo /i ."
+
+    for x in range(len(source)):
+        ok = True
+        # Try prefixed executable (MinGW on Linux).
+        if env["use_windres"]:
+            cmd = mingw_bin_prefix + cmdbase + " -i " + str(source[x]) + " -o " + str(target[x])
+        else:
+            cmd = cmdbase + " /fo " + str(target[x]) + " " + str(source[x])
+        try:
+            out = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
+            if len(out[1]):
+                ok = False
+        except Exception:
+            ok = False
+
+        # Try generic executable (MSYS2).
+        if not ok:
+            if env["use_windres"]:
+                cmd = cmdbase + " -i " + str(source[x]) + " -o " + str(target[x])
+            else:
+                cmd = cmdbase + " /fo " + str(target[x]) + " " + str(source[x])
+            try:
+                out = subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
+                if len(out[1]):
+                    return -1
+            except Exception:
+                return -1
+
+    return 0
 
 
 def configure_msvc(env: "SConsEnvironment"):
@@ -874,6 +939,9 @@ def configure_mingw(env: "SConsEnvironment"):
         env.Prepend(CPPPATH=["#thirdparty/angle/include"])
 
     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])
+
+    if env["manual_build_res_file"]:
+        env.Append(BUILDERS={"RES": env.Builder(action=build_res_file, suffix=".o", src_suffix=".rc")})
 
     # dlltool
     env["DEF"] = get_detected(env, "dlltool")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ ignore-words-list = [
 	"doubleclick",
 	"expct",
 	"findn",
+	"fo",
 	"gird",
 	"hel",
 	"inout",


### PR DESCRIPTION
Godot recently removed the logic for building res files since scons is taking care of it automatically when using the default platform build tools.  However, scons no longer takes care of it automatically when overriding those custom tools.  The pr here: https://github.com/godotengine/godot/pull/101042 adds support to override those tools.

This PR allows users to opt back into that logic if they go the manual route such as what I've been doing in the godot-src project: https://github.com/lange-studios/godot-src

It is necessary in order to do cross compilation with zig.

Let me know if you would like any changes or need further clarification :)