### PR TITLE
Detect can build from env var

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -99,7 +99,7 @@ for x in sorted(glob.glob("platform/*")):
         platform_exporters.append(platform_name)
     if os.path.exists(x + "/api/api.cpp"):
         platform_apis.append(platform_name)
-    if detect.can_build():
+    if os.getenv("GODOT_CAN_BUILD_" + platform_name.upper()) or detect.can_build():
         x = x.replace("platform/", "")  # rest of world
         x = x.replace("platform\\", "")  # win32
         platform_list += [x]


### PR DESCRIPTION
This PR allows users to manually specify whether godot can build for a platfrom from an environment variable.  Godot has logic and checks for toolchains to be present which is useful for most users.  However, when users want to override those tools (like this PR here will allow: https://github.com/godotengine/godot/pull/101043), they will need to do one of 2 things:

1. Spoof scons and create wrapper scripts at locations that scons expects.  This is not fun and is error prone.

2. Set an environment variable manually instructing scons to allow building to the specified target.  This is much more stable and easier to implement :)

It is as simple as setting an environment var such as:

```
export GODOT_CAN_BUILD_WINDOWS=true
scons ...
```

We have been using this for multiple months now without issue in the godot-src project: https://github.com/lange-studios/godot-src

Once this among a handful of other PRs we have recently put in go through, we will be able to target the main godot repo rather than our custom fork.  Thanks again for all the hard work everyone does! :)  Let me know if you have any input or need any further clarification.