### PR TITLE
Refactor `Variant` `can_convert` and `can_convert_strict` to produce a bit less and easier to read code.

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -186,11 +186,21 @@ Variant::Type Variant::get_type_by_name(const String &p_type_name) {
 	return (ptr == nullptr) ? VARIANT_MAX : *ptr;
 }
 
+template <size_t N>
+constexpr bool _contains(const Variant::Type (&p_types)[N], Variant::Type p_type) {
+	for (const Variant::Type type : p_types) {
+		if (type == p_type) {
+			return true;
+		}
+	}
+	return false;
+}
+
 bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 	if (p_type_from == p_type_to) {
 		return true;
 	}
-	if (p_type_to == NIL) { //nil can convert to anything
+	if (p_type_to == NIL) { // Anything can convert to NIL.
 		return true;
 	}
 
@@ -198,215 +208,131 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 		return (p_type_to == OBJECT);
 	}
 
-	const Type *valid_types = nullptr;
-	const Type *invalid_types = nullptr;
-
+	// clang-format off
 	switch (p_type_to) {
 		case BOOL: {
-			static const Type valid[] = {
+			return _contains({
 				INT,
 				FLOAT,
 				STRING,
-				NIL,
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case INT: {
-			static const Type valid[] = {
+			return _contains({
 				BOOL,
 				FLOAT,
 				STRING,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case FLOAT: {
-			static const Type valid[] = {
+			return _contains({
 				BOOL,
 				INT,
 				STRING,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case STRING: {
-			static const Type invalid[] = {
+			return !_contains({
 				OBJECT,
-				NIL
-			};
-
-			invalid_types = invalid;
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR2: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR2I,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR2I: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR2,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case RECT2: {
-			static const Type valid[] = {
+			return _contains({
 				RECT2I,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case RECT2I: {
-			static const Type valid[] = {
+			return _contains({
 				RECT2,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case TRANSFORM2D: {
-			static const Type valid[] = {
+			return _contains({
 				TRANSFORM3D,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR3: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR3I,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR3I: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR3,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR4: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR4I,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR4I: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR4,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 
 		case QUATERNION: {
-			static const Type valid[] = {
+			return _contains({
 				BASIS,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case BASIS: {
-			static const Type valid[] = {
+			return _contains({
 				QUATERNION,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case TRANSFORM3D: {
-			static const Type valid[] = {
+			return _contains({
 				TRANSFORM2D,
 				QUATERNION,
 				BASIS,
 				PROJECTION,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case PROJECTION: {
-			static const Type valid[] = {
+			return _contains({
 				TRANSFORM3D,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 
 		case COLOR: {
-			static const Type valid[] = {
+			return _contains({
 				STRING,
 				INT,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 
 		case RID: {
-			static const Type valid[] = {
+			return _contains({
 				OBJECT,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case OBJECT: {
-			static const Type valid[] = {
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			return false;
+		}
 		case STRING_NAME: {
-			static const Type valid[] = {
+			return _contains({
 				STRING,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case NODE_PATH: {
-			static const Type valid[] = {
+			return _contains({
 				STRING,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				PACKED_BYTE_ARRAY,
 				PACKED_INT32_ARRAY,
 				PACKED_INT64_ARRAY,
@@ -417,123 +343,71 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 				PACKED_VECTOR2_ARRAY,
 				PACKED_VECTOR3_ARRAY,
 				PACKED_VECTOR4_ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		// arrays
 		case PACKED_BYTE_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_INT32_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_INT64_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_FLOAT32_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_FLOAT64_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_STRING_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_VECTOR2_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_VECTOR3_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_COLOR_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_VECTOR4_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		default: {
+			return false;
 		}
 	}
-
-	if (valid_types) {
-		int i = 0;
-		while (valid_types[i] != NIL) {
-			if (p_type_from == valid_types[i]) {
-				return true;
-			}
-			i++;
-		}
-
-	} else if (invalid_types) {
-		int i = 0;
-		while (invalid_types[i] != NIL) {
-			if (p_type_from == invalid_types[i]) {
-				return false;
-			}
-			i++;
-		}
-
-		return true;
-	}
-
-	return false;
+	// clang-format on
 }
 
 bool Variant::can_convert_strict(Variant::Type p_type_from, Variant::Type p_type_to) {
 	if (p_type_from == p_type_to) {
 		return true;
 	}
-	if (p_type_to == NIL) { //nil can convert to anything
+	if (p_type_to == NIL) { // Anything can convert to NIL.
 		return true;
 	}
 
@@ -541,215 +415,132 @@ bool Variant::can_convert_strict(Variant::Type p_type_from, Variant::Type p_type
 		return (p_type_to == OBJECT);
 	}
 
-	const Type *valid_types = nullptr;
-
+	// clang-format off
 	switch (p_type_to) {
 		case BOOL: {
-			static const Type valid[] = {
+			return _contains({
 				INT,
 				FLOAT,
 				//STRING,
-				NIL,
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case INT: {
-			static const Type valid[] = {
+			return _contains({
 				BOOL,
 				FLOAT,
 				//STRING,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case FLOAT: {
-			static const Type valid[] = {
+			return _contains({
 				BOOL,
 				INT,
 				//STRING,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case STRING: {
-			static const Type valid[] = {
+			return _contains({
 				NODE_PATH,
 				STRING_NAME,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR2: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR2I,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR2I: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR2,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case RECT2: {
-			static const Type valid[] = {
+			return _contains({
 				RECT2I,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case RECT2I: {
-			static const Type valid[] = {
+			return _contains({
 				RECT2,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case TRANSFORM2D: {
-			static const Type valid[] = {
+			return _contains({
 				TRANSFORM3D,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR3: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR3I,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR3I: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR3,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR4: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR4I,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case VECTOR4I: {
-			static const Type valid[] = {
+			return _contains({
 				VECTOR4,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 
 		case QUATERNION: {
-			static const Type valid[] = {
+			return _contains({
 				BASIS,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case BASIS: {
-			static const Type valid[] = {
+			return _contains({
 				QUATERNION,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case TRANSFORM3D: {
-			static const Type valid[] = {
+			return _contains({
 				TRANSFORM2D,
 				QUATERNION,
 				BASIS,
 				PROJECTION,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case PROJECTION: {
-			static const Type valid[] = {
+			return _contains({
 				TRANSFORM3D,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 
 		case COLOR: {
-			static const Type valid[] = {
+			return _contains({
 				STRING,
 				INT,
-				NIL,
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 
 		case RID: {
-			static const Type valid[] = {
+			return _contains({
 				OBJECT,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case OBJECT: {
-			static const Type valid[] = {
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			return false;
+		}
 		case STRING_NAME: {
-			static const Type valid[] = {
+			return _contains({
 				STRING,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case NODE_PATH: {
-			static const Type valid[] = {
+			return _contains({
 				STRING,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				PACKED_BYTE_ARRAY,
 				PACKED_INT32_ARRAY,
 				PACKED_INT64_ARRAY,
@@ -760,105 +551,64 @@ bool Variant::can_convert_strict(Variant::Type p_type_from, Variant::Type p_type
 				PACKED_VECTOR2_ARRAY,
 				PACKED_VECTOR3_ARRAY,
 				PACKED_VECTOR4_ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		// arrays
 		case PACKED_BYTE_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_INT32_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_INT64_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_FLOAT32_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_FLOAT64_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_STRING_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_VECTOR2_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_VECTOR3_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_COLOR_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		case PACKED_VECTOR4_ARRAY: {
-			static const Type valid[] = {
+			return _contains({
 				ARRAY,
-				NIL
-			};
-			valid_types = valid;
-
-		} break;
+			}, p_type_from);
+		}
 		default: {
+			return false;
 		}
 	}
-
-	if (valid_types) {
-		int i = 0;
-		while (valid_types[i] != NIL) {
-			if (p_type_from == valid_types[i]) {
-				return true;
-			}
-			i++;
-		}
-	}
-
-	return false;
+	// clang-format on
 }
 
 bool Variant::operator==(const Variant &p_variant) const {

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -196,7 +196,7 @@ constexpr bool _contains(const Variant::Type (&p_types)[N], Variant::Type p_type
 	return false;
 }
 
-bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
+bool Variant::can_convert(Type p_type_from, Type p_type_to, bool p_strict) {
 	if (p_type_from == p_type_to) {
 		return true;
 	}
@@ -211,6 +211,12 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 	// clang-format off
 	switch (p_type_to) {
 		case BOOL: {
+			if (p_strict) {
+				return _contains({
+					INT,
+					FLOAT,
+				}, p_type_from);
+			}
 			return _contains({
 				INT,
 				FLOAT,
@@ -218,6 +224,12 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 			}, p_type_from);
 		}
 		case INT: {
+			if (p_strict) {
+				return _contains({
+					BOOL,
+					FLOAT,
+				}, p_type_from);
+			}
 			return _contains({
 				BOOL,
 				FLOAT,
@@ -225,6 +237,12 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 			}, p_type_from);
 		}
 		case FLOAT: {
+			if (p_strict) {
+				return _contains({
+					BOOL,
+					INT,
+				}, p_type_from);
+			}
 			return _contains({
 				BOOL,
 				INT,
@@ -232,216 +250,14 @@ bool Variant::can_convert(Variant::Type p_type_from, Variant::Type p_type_to) {
 			}, p_type_from);
 		}
 		case STRING: {
+			if (p_strict) {
+				return _contains({
+					NODE_PATH,
+					STRING_NAME,
+				}, p_type_from);
+			}
 			return !_contains({
 				OBJECT,
-			}, p_type_from);
-		}
-		case VECTOR2: {
-			return _contains({
-				VECTOR2I,
-			}, p_type_from);
-		}
-		case VECTOR2I: {
-			return _contains({
-				VECTOR2,
-			}, p_type_from);
-		}
-		case RECT2: {
-			return _contains({
-				RECT2I,
-			}, p_type_from);
-		}
-		case RECT2I: {
-			return _contains({
-				RECT2,
-			}, p_type_from);
-		}
-		case TRANSFORM2D: {
-			return _contains({
-				TRANSFORM3D,
-			}, p_type_from);
-		}
-		case VECTOR3: {
-			return _contains({
-				VECTOR3I,
-			}, p_type_from);
-		}
-		case VECTOR3I: {
-			return _contains({
-				VECTOR3,
-			}, p_type_from);
-		}
-		case VECTOR4: {
-			return _contains({
-				VECTOR4I,
-			}, p_type_from);
-		}
-		case VECTOR4I: {
-			return _contains({
-				VECTOR4,
-			}, p_type_from);
-		}
-
-		case QUATERNION: {
-			return _contains({
-				BASIS,
-			}, p_type_from);
-		}
-		case BASIS: {
-			return _contains({
-				QUATERNION,
-			}, p_type_from);
-		}
-		case TRANSFORM3D: {
-			return _contains({
-				TRANSFORM2D,
-				QUATERNION,
-				BASIS,
-				PROJECTION,
-			}, p_type_from);
-		}
-		case PROJECTION: {
-			return _contains({
-				TRANSFORM3D,
-			}, p_type_from);
-		}
-
-		case COLOR: {
-			return _contains({
-				STRING,
-				INT,
-			}, p_type_from);
-		}
-
-		case RID: {
-			return _contains({
-				OBJECT,
-			}, p_type_from);
-		}
-		case OBJECT: {
-			return false;
-		}
-		case STRING_NAME: {
-			return _contains({
-				STRING,
-			}, p_type_from);
-		}
-		case NODE_PATH: {
-			return _contains({
-				STRING,
-			}, p_type_from);
-		}
-		case ARRAY: {
-			return _contains({
-				PACKED_BYTE_ARRAY,
-				PACKED_INT32_ARRAY,
-				PACKED_INT64_ARRAY,
-				PACKED_FLOAT32_ARRAY,
-				PACKED_FLOAT64_ARRAY,
-				PACKED_STRING_ARRAY,
-				PACKED_COLOR_ARRAY,
-				PACKED_VECTOR2_ARRAY,
-				PACKED_VECTOR3_ARRAY,
-				PACKED_VECTOR4_ARRAY,
-			}, p_type_from);
-		}
-		// arrays
-		case PACKED_BYTE_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		case PACKED_INT32_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		case PACKED_INT64_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		case PACKED_FLOAT32_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		case PACKED_FLOAT64_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		case PACKED_STRING_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		case PACKED_VECTOR2_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		case PACKED_VECTOR3_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		case PACKED_COLOR_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		case PACKED_VECTOR4_ARRAY: {
-			return _contains({
-				ARRAY,
-			}, p_type_from);
-		}
-		default: {
-			return false;
-		}
-	}
-	// clang-format on
-}
-
-bool Variant::can_convert_strict(Variant::Type p_type_from, Variant::Type p_type_to) {
-	if (p_type_from == p_type_to) {
-		return true;
-	}
-	if (p_type_to == NIL) { // Anything can convert to NIL.
-		return true;
-	}
-
-	if (p_type_from == NIL) {
-		return (p_type_to == OBJECT);
-	}
-
-	// clang-format off
-	switch (p_type_to) {
-		case BOOL: {
-			return _contains({
-				INT,
-				FLOAT,
-				//STRING,
-			}, p_type_from);
-		}
-		case INT: {
-			return _contains({
-				BOOL,
-				FLOAT,
-				//STRING,
-			}, p_type_from);
-		}
-		case FLOAT: {
-			return _contains({
-				BOOL,
-				INT,
-				//STRING,
-			}, p_type_from);
-		}
-		case STRING: {
-			return _contains({
-				NODE_PATH,
-				STRING_NAME,
 			}, p_type_from);
 		}
 		case VECTOR2: {

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -355,8 +355,10 @@ public:
 	}
 	static String get_type_name(Variant::Type p_type);
 	static Variant::Type get_type_by_name(const String &p_type_name);
-	static bool can_convert(Type p_type_from, Type p_type_to);
-	static bool can_convert_strict(Type p_type_from, Type p_type_to);
+	static bool can_convert(Type p_type_from, Type p_type_to, bool p_strict = false);
+	static bool can_convert_strict(Type p_type_from, Type p_type_to) {
+		return can_convert(p_type_from, p_type_to, true);
+	}
 	static bool is_type_shared(Variant::Type p_type);
 
 	bool is_ref_counted() const;


### PR DESCRIPTION
This is a pretty brainless change, little more than "search and replace". There should be no changes in behavior, although the new code is likely to be slightly faster.

The reason for the change is to make the code a bit more readable and maintainable by reducing boilerplate logic.

I added `	// clang-format off` to these parts because the clang-format version of this code is near unreadable, e.g.:
```c++
			return _contains({
									 INT,
									 FLOAT,
									 STRING,
							 },
					p_type_from);
```

`NIL` entries could be removed because they were used as a hack to stop iteration on the while loop.