### PR TITLE
Fix `create_instance` in Android GodotApp so non-editor apps can restart

### DIFF
--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotXRGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotXRGame.kt
@@ -40,7 +40,7 @@ open class GodotXRGame: GodotGame() {
 
 	override fun overrideOrientationRequest() = true
 
-	override fun updateCommandLineParams(args: List<String>) {
+	override fun updateCommandLineParams(args: Array<String>) {
 		val updatedArgs = ArrayList<String>()
 		if (!args.contains(XRMode.OPENXR.cmdLineArg)) {
 			updatedArgs.add(XRMode.OPENXR.cmdLineArg)
@@ -51,7 +51,7 @@ open class GodotXRGame: GodotGame() {
 		}
 		updatedArgs.addAll(args)
 
-		super.updateCommandLineParams(updatedArgs)
+		super.updateCommandLineParams(updatedArgs.toTypedArray())
 	}
 
 	override fun getEditorWindowInfo() = XR_RUN_GAME_INFO

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -823,9 +823,26 @@ class Godot(private val context: Context) {
 	 * Returns true if `Vulkan` is used for rendering.
 	 */
 	private fun usesVulkan(): Boolean {
-		val renderer = GodotLib.getGlobal("rendering/renderer/rendering_method")
-		val renderingDevice = GodotLib.getGlobal("rendering/rendering_device/driver")
-		return ("forward_plus" == renderer || "mobile" == renderer) && "vulkan" == renderingDevice
+		var rendererSource = "ProjectSettings"
+		var renderer = GodotLib.getGlobal("rendering/renderer/rendering_method")
+		var renderingDeviceSource = "ProjectSettings"
+		var renderingDevice = GodotLib.getGlobal("rendering/rendering_device/driver")
+		val cmdline = getCommandLine()
+		var index = cmdline.indexOf("--rendering-method")
+		if (index > -1 && cmdline.size > index + 1) {
+			rendererSource = "CommandLine"
+			renderer = cmdline.get(index + 1)
+		}
+		index = cmdline.indexOf("--rendering-driver")
+		if (index > -1 && cmdline.size > index + 1) {
+			renderingDeviceSource = "CommandLine"
+			renderingDevice = cmdline.get(index + 1)
+		}
+		val result = ("forward_plus" == renderer || "mobile" == renderer) && "vulkan" == renderingDevice
+		Log.d(TAG, """usesVulkan(): ${result}
+			renderingDevice: ${renderingDevice} (${renderingDeviceSource})
+			renderer: ${renderer} (${rendererSource})""")
+		return result
 	}
 
 	/**

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
@@ -31,6 +31,7 @@
 package org.godotengine.godot
 
 import android.app.Activity
+import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -53,17 +54,31 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 		private val TAG = GodotActivity::class.java.simpleName
 
 		@JvmStatic
+		protected val EXTRA_COMMAND_LINE_PARAMS = "command_line_params"
+
+		@JvmStatic
 		protected val EXTRA_NEW_LAUNCH = "new_launch_requested"
+
+		// This window must not match those in BaseGodotEditor.RUN_GAME_INFO etc
+		@JvmStatic
+		private final val DEFAULT_WINDOW_ID = 664;
 	}
 
+	private val commandLineParams = ArrayList<String>()
 	/**
 	 * Interaction with the [Godot] object is delegated to the [GodotFragment] class.
 	 */
 	protected var godotFragment: GodotFragment? = null
 		private set
 
+	@CallSuper
 	override fun onCreate(savedInstanceState: Bundle?) {
+		val params = intent.getStringArrayExtra(EXTRA_COMMAND_LINE_PARAMS)
+		Log.d(TAG, "Starting intent $intent with parameters ${params.contentToString()}")
+		updateCommandLineParams(params ?: emptyArray())
+
 		super.onCreate(savedInstanceState)
+
 		setContentView(getGodotAppLayout())
 
 		handleStartIntent(intent, true)
@@ -76,6 +91,29 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 			Log.v(TAG, "Creating new Godot fragment instance.")
 			godotFragment = initGodotInstance()
 			supportFragmentManager.beginTransaction().replace(R.id.godot_fragment_container, godotFragment!!).setPrimaryNavigationFragment(godotFragment).commitNowAllowingStateLoss()
+		}
+	}
+
+	override fun onNewGodotInstanceRequested(args: Array<String>): Int {
+		Log.d(TAG, "Restarting with parameters ${args.contentToString()}")
+		val intent = Intent()
+			.setComponent(ComponentName(this, javaClass.name))
+			.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+			.putExtra(EXTRA_COMMAND_LINE_PARAMS, args)
+		triggerRebirth(null, intent)
+		// fake 'process' id returned by create_instance() etc
+		return DEFAULT_WINDOW_ID;
+	}
+
+	protected fun triggerRebirth(bundle: Bundle?, intent: Intent) {
+		// Launch a new activity
+		val godot = godot
+		if (godot != null) {
+			godot.destroyAndKillProcess {
+				ProcessPhoenix.triggerRebirth(this, bundle, intent)
+			}
+		} else {
+			ProcessPhoenix.triggerRebirth(this, bundle, intent)
 		}
 	}
 
@@ -176,4 +214,15 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 	protected open fun initGodotInstance(): GodotFragment {
 		return GodotFragment()
 	}
+
+	@CallSuper
+	protected open fun updateCommandLineParams(args: Array<String>) {
+		// Update the list of command line params with the new args
+		commandLineParams.clear()
+		if (args.isNotEmpty()) {
+			commandLineParams.addAll(args)
+		}
+	}
+
+	final override fun getCommandLine() = commandLineParams
 }


### PR DESCRIPTION
Enables OS.create_instance(args) and OS.set_restart_on_exit(true, args) on android.

Borrowed the logic from the editor, so it completely restarts the process so you can pass --rendering-method, --rendering-driver to switch between forward_plus, mobile, gl_compatibility etc on an exported app.

Related:
https://github.com/godotengine/godot/issues/31541
https://github.com/godotengine/godot-proposals/issues/6423

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
