### PR TITLE
GLTF: Always read `alphaCutoff` property

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4822,12 +4822,12 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 				material->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA_DEPTH_PRE_PASS);
 			} else if (am == "MASK") {
 				material->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA_SCISSOR);
-				if (material_dict.has("alphaCutoff")) {
-					material->set_alpha_scissor_threshold(material_dict["alphaCutoff"]);
-				} else {
-					material->set_alpha_scissor_threshold(0.5f);
-				}
 			}
+		}
+		if (material_dict.has("alphaCutoff")) {
+			material->set_alpha_scissor_threshold(material_dict["alphaCutoff"]);
+		} else {
+			material->set_alpha_scissor_threshold(0.5f);
 		}
 
 		if (material_dict.has("extras")) {


### PR DESCRIPTION
According to both Godot and glTF, the `alphaCutoff` / `alpha_scissor_threshold` property is only used when the alpha transparency mode is set to `"MASK"` / `ALPHA_SCISSOR`, and is otherwise ignored. Therefore, the existing code in master assumes that we can just skip reading this property.

However, not reading is the wrong thing to do, because it means that this property is unavailable in all other situations: such as a material extension uses it, a scripting extension wants to use it, user code sets the generated Godot material to `ALPHA_SCISSOR`, or the user editing the scene changes the generated Godot material to `ALPHA_SCISSOR`.