### PR TITLE
Gridmap control tweak: allow "previous/next floor" keys to change selection height after selection is made

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -61,18 +61,21 @@ void GridMapEditor::_configure() {
 void GridMapEditor::_menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_OPTION_PREV_LEVEL: {
-			floor->set_value(floor->get_value() - 1);
-			if (selection.active && input_action == INPUT_SELECT) {
+			if (selection.active && input_action != INPUT_SELECT) {
 				selection.current[edit_axis]--;
 				_validate_selection();
+			} else {
+				floor->set_value(floor->get_value() - 1);
 			}
+
 		} break;
 
 		case MENU_OPTION_NEXT_LEVEL: {
-			floor->set_value(floor->get_value() + 1);
-			if (selection.active && input_action == INPUT_SELECT) {
+			if (selection.active && input_action != INPUT_SELECT) {
 				selection.current[edit_axis]++;
 				_validate_selection();
+			} else {
+				floor->set_value(floor->get_value() + 1);
 			}
 		} break;
 


### PR DESCRIPTION
Related to: [#87131](https://github.com/godotengine/godot/pull/87131)

Currently, when making a selection with the gridmap, you can only change the height of the selection by changing the height of the mouse cursor's edit plane while still dragging the selection.

This PR changes the height keys, while a selection is active and not being dragged, to change the selection height instead of the mouse cursor height. While the selection is being dragged, the height keys still change the mouse cursor height, which updates the selection volume with it. 

(Height here meaning "the direction of the normal of the edit plane")

This is much more convenient for a large amount of gridmap work, and the position of the mouse cursor can still be modified while a selection is active via ctrl+mouse wheel.  

This is the minimally invasive way of making this tweak: A more invasive option would be to breakout this functionality to an add'l action, (and perhaps also including actions to modify the other two axes similarly), as that would have the benefit of changing just the selection height while dragging, and being able to change the mouse height while a selection is active. That change would also involve changing the selection update transformation to not reset the selection boundaries on a modified axis when the mouse is dragged. 

This is useful for my own project, and it is also useful for Brenton Wilde's Lingo 2 project, at whose request I finally started looking into this.