### PR TITLE
Consolidate `Variant` int and float conversion functions to reduce duplicate logic.

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1486,147 +1486,35 @@ void Variant::_clear_internal() {
 }
 
 Variant::operator int64_t() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1 : 0;
-		case INT:
-			return int64_t(_data._int);
-		case FLOAT:
-			return int64_t(_data._float);
-		case STRING:
-			return int64_t(operator String().to_int());
-		default: {
-			return 0;
-		}
-	}
+	return _to_int<int64_t>();
 }
 
 Variant::operator int32_t() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1 : 0;
-		case INT:
-			return int32_t(_data._int);
-		case FLOAT:
-			return int32_t(_data._float);
-		case STRING:
-			return int32_t(operator String().to_int());
-		default: {
-			return 0;
-		}
-	}
+	return _to_int<int32_t>();
 }
 
 Variant::operator int16_t() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1 : 0;
-		case INT:
-			return int16_t(_data._int);
-		case FLOAT:
-			return int16_t(_data._float);
-		case STRING:
-			return int16_t(operator String().to_int());
-		default: {
-			return 0;
-		}
-	}
+	return _to_int<int16_t>();
 }
 
 Variant::operator int8_t() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1 : 0;
-		case INT:
-			return int8_t(_data._int);
-		case FLOAT:
-			return int8_t(_data._float);
-		case STRING:
-			return int8_t(operator String().to_int());
-		default: {
-			return 0;
-		}
-	}
+	return _to_int<int8_t>();
 }
 
 Variant::operator uint64_t() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1 : 0;
-		case INT:
-			return uint64_t(_data._int);
-		case FLOAT:
-			return uint64_t(_data._float);
-		case STRING:
-			return uint64_t(operator String().to_int());
-		default: {
-			return 0;
-		}
-	}
+	return _to_int<uint64_t>();
 }
 
 Variant::operator uint32_t() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1 : 0;
-		case INT:
-			return uint32_t(_data._int);
-		case FLOAT:
-			return uint32_t(_data._float);
-		case STRING:
-			return uint32_t(operator String().to_int());
-		default: {
-			return 0;
-		}
-	}
+	return _to_int<uint32_t>();
 }
 
 Variant::operator uint16_t() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1 : 0;
-		case INT:
-			return uint16_t(_data._int);
-		case FLOAT:
-			return uint16_t(_data._float);
-		case STRING:
-			return uint16_t(operator String().to_int());
-		default: {
-			return 0;
-		}
-	}
+	return _to_int<uint16_t>();
 }
 
 Variant::operator uint8_t() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1 : 0;
-		case INT:
-			return uint8_t(_data._int);
-		case FLOAT:
-			return uint8_t(_data._float);
-		case STRING:
-			return uint8_t(operator String().to_int());
-		default: {
-			return 0;
-		}
-	}
+	return _to_int<uint8_t>();
 }
 
 Variant::operator ObjectID() const {
@@ -1644,39 +1532,11 @@ Variant::operator char32_t() const {
 }
 
 Variant::operator float() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1.0 : 0.0;
-		case INT:
-			return (float)_data._int;
-		case FLOAT:
-			return _data._float;
-		case STRING:
-			return operator String().to_float();
-		default: {
-			return 0;
-		}
-	}
+	return _to_float<float>();
 }
 
 Variant::operator double() const {
-	switch (type) {
-		case NIL:
-			return 0;
-		case BOOL:
-			return _data._bool ? 1.0 : 0.0;
-		case INT:
-			return (double)_data._int;
-		case FLOAT:
-			return _data._float;
-		case STRING:
-			return operator String().to_float();
-		default: {
-			return 0;
-		}
-	}
+	return _to_float<double>();
 }
 
 Variant::operator StringName() const {

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -343,6 +343,44 @@ private:
 
 	void _variant_call_error(const String &p_method, Callable::CallError &error);
 
+	template <typename T>
+	_ALWAYS_INLINE_ T _to_int() const {
+		switch (get_type()) {
+			case NIL:
+				return 0;
+			case BOOL:
+				return _data._bool ? 1 : 0;
+			case INT:
+				return T(_data._int);
+			case FLOAT:
+				return T(_data._float);
+			case STRING:
+				return reinterpret_cast<const String *>(_data._mem)->to_int();
+			default: {
+				return 0;
+			}
+		}
+	}
+
+	template <typename T>
+	_ALWAYS_INLINE_ T _to_float() const {
+		switch (type) {
+			case NIL:
+				return 0;
+			case BOOL:
+				return _data._bool ? 1 : 0;
+			case INT:
+				return T(_data._int);
+			case FLOAT:
+				return T(_data._float);
+			case STRING:
+				return reinterpret_cast<const String *>(_data._mem)->to_float();
+			default: {
+				return 0;
+			}
+		}
+	}
+
 	// Avoid accidental conversion. If you reached this point, it's because you most likely forgot to dereference
 	// a Variant pointer (so add * like this: *variant_pointer).
 


### PR DESCRIPTION
Pretty straight-forward change. All implementations were the same, I'm simply using templates to get rid of copy-pasted code.
An alternative change would be to only keep the `int64_t` and `double` implementations and simply call and cast those from the other converters.  This would be compatible with all current cases (technically this may change in the future, although it's unlikely because that would be kind of odd).