### PR TITLE
Remove invalid collision exceptions in `XXXPhysicsServerXD::body_get_collision_exceptions()`.

### DIFF
--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -924,8 +924,19 @@ void GodotPhysicsServer2D::body_get_collision_exceptions(RID p_body, List<RID> *
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	for (int i = 0; i < body->get_exceptions().size(); i++) {
-		p_exceptions->push_back(body->get_exceptions()[i]);
+	const VSet<RID> &exceptions = body->get_exceptions();
+	LocalVector<RID> invalid_exceptions;
+	for (int i = 0; i < exceptions.size(); i++) {
+		RID exception = exceptions[i];
+		if (body_owner.owns(exception)) {
+			p_exceptions->push_back(exception);
+		} else {
+			invalid_exceptions.push_back(exception);
+		}
+	}
+
+	for (RID invalid_body : invalid_exceptions) {
+		body->remove_exception(invalid_body);
 	}
 }
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -850,8 +850,19 @@ void GodotPhysicsServer3D::body_get_collision_exceptions(RID p_body, List<RID> *
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	for (int i = 0; i < body->get_exceptions().size(); i++) {
-		p_exceptions->push_back(body->get_exceptions()[i]);
+	const VSet<RID> &exceptions = body->get_exceptions();
+	LocalVector<RID> invalid_exceptions;
+	for (int i = 0; i < exceptions.size(); i++) {
+		RID exception = exceptions[i];
+		if (body_owner.owns(exception)) {
+			p_exceptions->push_back(exception);
+		} else {
+			invalid_exceptions.push_back(exception);
+		}
+	}
+
+	for (RID invalid_body : invalid_exceptions) {
+		body->remove_exception(invalid_body);
 	}
 }
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -862,11 +862,22 @@ void JoltPhysicsServer3D::body_remove_collision_exception(RID p_body, RID p_exce
 }
 
 void JoltPhysicsServer3D::body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) {
-	const JoltBody3D *body = body_owner.get_or_null(p_body);
+	JoltBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	for (const RID &exception : body->get_collision_exceptions()) {
-		p_exceptions->push_back(exception);
+	const LocalVector<RID> &exceptions = body->get_collision_exceptions();
+	LocalVector<RID> invalid_exceptions;
+	for (uint32_t i = 0; i < exceptions.size(); i++) {
+		RID exception = exceptions[i];
+		if (body_owner.owns(exception)) {
+			p_exceptions->push_back(exception);
+		} else {
+			invalid_exceptions.push_back(exception);
+		}
+	}
+
+	for (RID invalid_body : invalid_exceptions) {
+		body->remove_collision_exception(invalid_body);
 	}
 }
 


### PR DESCRIPTION
Fix the bug that push an error when calling `PhysicsBody.get_collision_exceptions()` if the excepted body is invalid.

-------
How to reproduce:
```
extends Node

func _ready() -> void:
	var a := CharacterBody2D.new()
	add_child(a)
	var b := CharacterBody2D.new()
	add_child(b)

	a.add_collision_exception_with(b)

	b.free()

	print(a.get_collision_exceptions()) # push an error.

```