### PR TITLE
Fix `has_font` and `has_font_size` always return true

### DIFF
--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -513,6 +513,10 @@ bool Theme::has_font(const StringName &p_name, const StringName &p_theme_type) c
 	return ((font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) || has_default_font());
 }
 
+bool Theme::has_font_no_default(const StringName &p_name, const StringName &p_theme_type) const {
+	return (font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid());
+}
+
 bool Theme::has_font_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
 	return (font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name));
 }
@@ -614,6 +618,10 @@ int Theme::get_font_size(const StringName &p_name, const StringName &p_theme_typ
 
 bool Theme::has_font_size(const StringName &p_name, const StringName &p_theme_type) const {
 	return ((font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) || has_default_font_size());
+}
+
+bool Theme::has_font_size_no_default(const StringName &p_name, const StringName &p_theme_type) const {
+	return (font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0));
 }
 
 bool Theme::has_font_size_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
@@ -923,9 +931,17 @@ bool Theme::has_theme_item(DataType p_data_type, const StringName &p_name, const
 		case DATA_TYPE_CONSTANT:
 			return has_constant(p_name, p_theme_type);
 		case DATA_TYPE_FONT:
-			return has_font(p_name, p_theme_type);
+			if (!variation_map.has(p_theme_type)) {
+				return has_font(p_name, p_theme_type);
+			} else {
+				return has_font_no_default(p_name, p_theme_type);
+			}
 		case DATA_TYPE_FONT_SIZE:
-			return has_font_size(p_name, p_theme_type);
+			if (!variation_map.has(p_theme_type)) {
+				return has_font_size(p_name, p_theme_type);
+			} else {
+				return has_font_size_no_default(p_name, p_theme_type);
+			}
 		case DATA_TYPE_ICON:
 			return has_icon(p_name, p_theme_type);
 		case DATA_TYPE_STYLEBOX:

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -155,6 +155,7 @@ public:
 	void set_font(const StringName &p_name, const StringName &p_theme_type, const Ref<Font> &p_font);
 	virtual Ref<Font> get_font(const StringName &p_name, const StringName &p_theme_type) const;
 	bool has_font(const StringName &p_name, const StringName &p_theme_type) const;
+	bool has_font_no_default(const StringName &p_name, const StringName &p_theme_type) const;
 	bool has_font_nocheck(const StringName &p_name, const StringName &p_theme_type) const;
 	void rename_font(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type);
 	void clear_font(const StringName &p_name, const StringName &p_theme_type);
@@ -166,6 +167,7 @@ public:
 	void set_font_size(const StringName &p_name, const StringName &p_theme_type, int p_font_size);
 	virtual int get_font_size(const StringName &p_name, const StringName &p_theme_type) const;
 	bool has_font_size(const StringName &p_name, const StringName &p_theme_type) const;
+	bool has_font_size_no_default(const StringName &p_name, const StringName &p_theme_type) const;
 	bool has_font_size_nocheck(const StringName &p_name, const StringName &p_theme_type) const;
 	void rename_font_size(const StringName &p_old_name, const StringName &p_name, const StringName &p_theme_type);
 	void clear_font_size(const StringName &p_name, const StringName &p_theme_type);


### PR DESCRIPTION
Fixes #80731
Related to #84993 

The check that was removed prevented ThemeOwner from going up the theme type hierarchy when getting fonts or font sizes, as it does with the other elements.


