### PR TITLE
Remove TODO from RenderingDevice regarding thread safety.

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -37,9 +37,6 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 
-// TODO: Thread safety
-// - Roll back thread safe attribute for RID_Owner members after the read-only/atomic update scheme is implemented.
-
 #define FORCE_SEPARATE_PRESENT_QUEUE 0
 #define PRINT_FRAMEBUFFER_FORMAT 0
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/100621.

As https://github.com/godotengine/godot/pull/97465 was merged already, there's no need to change the thread-safety of the RID Owners in RenderingDevice as the get operation is now lock-free by design.