### PR TITLE
Improve performance of certain physics queries when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -76,7 +76,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(const JPH::Shape &p_jolt_s
 	aabb_translated.Translate(motion);
 	aabb.Encapsulate(aabb_translated);
 
-	JoltQueryCollectorAnyMulti<JPH::CollideShapeBodyCollector, 2048> aabb_collector;
+	JoltQueryCollectorAnyMulti<JPH::CollideShapeBodyCollector, 1024> aabb_collector;
 	space->get_broad_phase_query().CollideAABox(aabb, aabb_collector, p_broad_phase_layer_filter, p_object_layer_filter);
 
 	if (!aabb_collector.had_hit()) {

--- a/modules/jolt_physics/spaces/jolt_query_collectors.h
+++ b/modules/jolt_physics/spaces/jolt_query_collectors.h
@@ -34,10 +34,9 @@
 #include "../jolt_project_settings.h"
 #include "jolt_space_3d.h"
 
-#include "core/templates/local_vector.h"
-
 #include "Jolt/Jolt.h"
 
+#include "Jolt/Core/STLLocalAllocator.h"
 #include "Jolt/Physics/Collision/InternalEdgeRemovingCollector.h"
 #include "Jolt/Physics/Collision/Shape/Shape.h"
 
@@ -45,11 +44,16 @@ template <typename TBase, int TDefaultCapacity>
 class JoltQueryCollectorAll final : public TBase {
 public:
 	typedef typename TBase::ResultType Hit;
+	typedef JPH::Array<Hit, JPH::STLLocalAllocator<Hit, TDefaultCapacity>> HitArray;
 
 private:
-	JPH::Array<Hit> hits;
+	HitArray hits;
 
 public:
+	JoltQueryCollectorAll() {
+		hits.reserve(TDefaultCapacity);
+	}
+
 	bool had_hit() const {
 		return !hits.is_empty();
 	}
@@ -109,14 +113,17 @@ template <typename TBase, int TDefaultCapacity>
 class JoltQueryCollectorAnyMulti final : public TBase {
 public:
 	typedef typename TBase::ResultType Hit;
+	typedef JPH::Array<Hit, JPH::STLLocalAllocator<Hit, TDefaultCapacity>> HitArray;
 
 private:
-	JPH::Array<Hit> hits;
+	HitArray hits;
 	int max_hits = 0;
 
 public:
 	explicit JoltQueryCollectorAnyMulti(int p_max_hits = TDefaultCapacity) :
-			max_hits(p_max_hits) {}
+			max_hits(p_max_hits) {
+		hits.reserve(TDefaultCapacity);
+	}
 
 	bool had_hit() const {
 		return hits.size() > 0;
@@ -189,14 +196,17 @@ template <typename TBase, int TDefaultCapacity>
 class JoltQueryCollectorClosestMulti final : public TBase {
 public:
 	typedef typename TBase::ResultType Hit;
+	typedef JPH::Array<Hit, JPH::STLLocalAllocator<Hit, TDefaultCapacity + 1>> HitArray;
 
 private:
-	JPH::Array<Hit> hits;
+	HitArray hits;
 	int max_hits = 0;
 
 public:
 	explicit JoltQueryCollectorClosestMulti(int p_max_hits = TDefaultCapacity) :
-			max_hits(p_max_hits) {}
+			max_hits(p_max_hits) {
+		hits.reserve(TDefaultCapacity + 1);
+	}
 
 	bool had_hit() const {
 		return hits.size() > 0;
@@ -220,7 +230,7 @@ public:
 	}
 
 	virtual void AddHit(const Hit &p_hit) override {
-		typename JPH::Array<Hit>::const_iterator E = hits.cbegin();
+		typename HitArray::const_iterator E = hits.cbegin();
 		for (; E != hits.cend(); ++E) {
 			if (p_hit.GetEarlyOutFraction() < E->GetEarlyOutFraction()) {
 				break;


### PR DESCRIPTION
(This addresses the to-do list item in #99895 titled "Get rid of heap allocations in shape queries when requested hits are less or equal to default" and brings the Jolt Physics module in line with the Godot Jolt extension, which also utilizes this optimization, albeit implemented differently.)

Since most physics queries in Godot have a default upper limit to how many hits they can return (e.g. 32 hits for [`intersect_point`](https://docs.godotengine.org/en/latest/classes/class_physicsdirectspacestate3d.html#class-physicsdirectspacestate3d-method-intersect-point)) there is a ripe opportunity for omitting the memory allocations associated with storing these hits in the cases where we don't in fact exceed this default limit, which is almost certainly the vast majority of cases.

~~This pull request adds a new container to the Jolt Physics module called `JoltInlineVector`, which acts as a hybrid between a stack-allocated buffer and a heap-allocated one, and switches from the former to the latter once a certain templatized capacity has been exceeded. These containers are sometimes referred to as a "small vector" in other codebases.~~

EDIT: This PR now instead uses the backported `JPH::STLLocalAllocator<T, N>` from #102614, as discussed below, which allows `JPH::Array` to become an inline/small array, behaving exactly like the `JoltInlineVector` implementation that was here previously.

This is then used in the `JoltQueryCollector*Multi` classes, which themselves take a templatized default capacity appropriate for the callsite, allowing us to omit[^1] the memory allocations associated with storing the hits for the following physics queries:

- [`PhysicsDirectSpaceState3D.cast_motion`](https://docs.godotengine.org/en/latest/classes/class_physicsdirectspacestate3d.html#class-physicsdirectspacestate3d-method-cast-motion)
- [`PhysicsDirectSpaceState3D.collide_shape`](https://docs.godotengine.org/en/latest/classes/class_physicsdirectspacestate3d.html#class-physicsdirectspacestate3d-method-collide-shape)
- [`PhysicsDirectSpaceState3D.intersect_point`](https://docs.godotengine.org/en/latest/classes/class_physicsdirectspacestate3d.html#class-physicsdirectspacestate3d-method-intersect-point)
- [`PhysicsDirectSpaceState3D.intersect_shape`](https://docs.godotengine.org/en/latest/classes/class_physicsdirectspacestate3d.html#class-physicsdirectspacestate3d-method-intersect-shape)
- [`PhysicsBody3D.move_and_collide`](https://docs.godotengine.org/en/latest/classes/class_physicsbody3d.html#class-physicsbody3d-method-move-and-collide)
- [`PhysicsBody3D.test_move`](https://docs.godotengine.org/en/latest/classes/class_physicsbody3d.html#class-physicsbody3d-method-test-move)
- [`PhysicsServer3D.body_test_motion`](https://docs.godotengine.org/en/latest/classes/class_physicsserver3d.html#class-physicsserver3d-method-body-test-motion)

The actual performance benefits of this will likely vary greatly depending on the platform, but in my measurements on Windows (both in Superluminal and measuring with `QueryPerformanceCounter`) I'm seeing roughly an average reduction of 10-15% CPU time, with certain larger spikes (presumably from occasional page faults) disappearing completely.

Here's a before-and-after profiling of `PhysicsDirectSpaceState3D.cast_motion`, where the motion vector spans most of the level in GDQuest's [Robo Blast](https://github.com/gdquest-demos/godot-4-3d-third-person-controller) demo:

![Before](https://github.com/user-attachments/assets/d810c2d7-02c6-4f2e-8211-bc555d6556d6)
![After](https://github.com/user-attachments/assets/a43de5a7-9ad8-4ea8-abcf-aee76e4f76e2)

~~I tried to keep the implementation of this new container as minimal as possible, but I'll admit it turned out to be a few lines longer than I hoped it would be. I do still think this optimization is worthwhile though, since physics queries tend to be plentiful in a lot of games.~~

[^1]: Note that even with this optimization there are still memory allocations happening when performing physics queries from scripts, as the script interface relies on things like `TypedArray<Dictionary>` for its results, which still allocate plenty of memory, so this by no means removes all allocations from the queries listed here.