### PR TITLE
Optimize `Thread::get_caller_id()`

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -38,8 +38,8 @@
 #include "core/object/script_language.h"
 
 SafeNumeric<uint64_t> Thread::id_counter(1); // The first value after .increment() is 2, hence by default the main thread ID should be 1.
+thread_local Thread::ID Thread::caller_id = Thread::id_counter.increment();
 
-thread_local Thread::ID Thread::caller_id = Thread::UNASSIGNED_ID;
 #endif
 
 Thread::PlatformFunctions Thread::platform_functions;

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -112,6 +112,7 @@ private:
 	static PlatformFunctions platform_functions;
 
 	ID id = UNASSIGNED_ID;
+
 	static SafeNumeric<uint64_t> id_counter;
 	static thread_local ID caller_id;
 	THREADING_NAMESPACE::thread thread;
@@ -119,7 +120,7 @@ private:
 	static void callback(ID p_caller_id, const Settings &p_settings, Thread::Callback p_callback, void *p_userdata);
 
 	static void make_main_thread() { caller_id = MAIN_ID; }
-	static void release_main_thread() { caller_id = UNASSIGNED_ID; }
+	static void release_main_thread() { caller_id = id_counter.increment(); }
 
 public:
 	static void _set_platform_functions(const PlatformFunctions &p_functions);
@@ -127,9 +128,6 @@ public:
 	_FORCE_INLINE_ ID get_id() const { return id; }
 	// get the ID of the caller thread
 	_FORCE_INLINE_ static ID get_caller_id() {
-		if (unlikely(caller_id == UNASSIGNED_ID)) {
-			caller_id = id_counter.increment();
-		}
 		return caller_id;
 	}
 	// get the ID of the main thread


### PR DESCRIPTION
By making sure that Thread always has a valid caller_id we can remove the check making the function a straightforward getter instead.

In some quick tests we see a repeatable performance improvement of somewhere around 0.32 mspf in TPS demo.
