### PR TITLE
Don't scroll to selected file in FileSystem when saving scenes

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -367,7 +367,7 @@ Vector<String> FileSystemDock::get_uncollapsed_paths() const {
 	return uncollapsed_paths;
 }
 
-void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, bool p_uncollapse_root, bool p_select_in_favorites, bool p_unfold_path) {
+void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, bool p_uncollapse_root, bool p_scroll_to_selected) {
 	// Recreate the tree.
 	tree->clear();
 	tree_update_id++;
@@ -436,10 +436,7 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 		ti->set_tooltip_text(0, favorite);
 		ti->set_selectable(0, true);
 		ti->set_metadata(0, favorite);
-		if (p_select_in_favorites && favorite == current_path) {
-			ti->select(0);
-			ti->set_as_cursor(0);
-		}
+
 		if (!favorite.ends_with("/")) {
 			Array udata;
 			udata.push_back(tree_update_id);
@@ -454,12 +451,15 @@ void FileSystemDock::_update_tree(const Vector<String> &p_uncollapsed_paths, boo
 	}
 
 	// Create the remaining of the tree.
-	_create_tree(root, EditorFileSystem::get_singleton()->get_filesystem(), uncollapsed_paths, p_select_in_favorites, p_unfold_path);
+	_create_tree(root, EditorFileSystem::get_singleton()->get_filesystem(), uncollapsed_paths, false);
 	if (!searched_tokens.is_empty()) {
 		_update_filtered_items();
 	}
 
-	tree->ensure_cursor_is_visible();
+	if (p_scroll_to_selected) {
+		tree->ensure_cursor_is_visible();
+	}
+
 	updating_tree = false;
 }
 
@@ -1375,7 +1375,6 @@ void FileSystemDock::_update_history() {
 	if (tree->is_visible()) {
 		_update_tree(get_uncollapsed_paths());
 		tree->grab_focus();
-		tree->ensure_cursor_is_visible();
 	}
 
 	if (file_list_vb->is_visible()) {
@@ -2717,7 +2716,7 @@ void FileSystemDock::fix_dependencies(const String &p_for_file) {
 
 void FileSystemDock::update_all() {
 	if (tree->is_visible()) {
-		_update_tree(get_uncollapsed_paths());
+		_update_tree(get_uncollapsed_paths(), false, false);
 	}
 
 	if (file_list_vb->is_visible()) {

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -249,7 +249,7 @@ private:
 
 	Ref<Texture2D> _get_tree_item_icon(bool p_is_valid, const String &p_file_type, const String &p_icon_path);
 	void _create_tree(TreeItem *p_parent, EditorFileSystemDirectory *p_dir, Vector<String> &uncollapsed_paths, bool p_select_in_favorites, bool p_unfold_path = false);
-	void _update_tree(const Vector<String> &p_uncollapsed_paths = Vector<String>(), bool p_uncollapse_root = false, bool p_select_in_favorites = false, bool p_unfold_path = false);
+	void _update_tree(const Vector<String> &p_uncollapsed_paths = Vector<String>(), bool p_uncollapse_root = false, bool p_scroll_to_selected = true);
 	void _navigate_to_path(const String &p_path, bool p_select_in_favorites = false);
 	bool _update_filtered_items(TreeItem *p_tree_item = nullptr);
 


### PR DESCRIPTION
Fixes #101065

When a scene is saved, `FileSystemDock::_fs_changed()` > `update_all()` > `_update_tree()` is called.
I added an argument to `_update_tree()` to keep the scroll bar position the same, instead of scrolling to the selected file. (I also removed two arguments that were never used).

I went through all other calls to:
- `update_all()` and confirmed they also benefit from not scrolling to the file (they are actions unrelated to the file).
- `_update_tree()` and confirmed they still want to scroll to the file (which is the default option).