### PR TITLE
Speed up `Line2D._edit_get_rect()`

### DIFF
--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -41,13 +41,13 @@ Rect2 Line2D::_edit_get_rect() const {
 	if (_points.size() == 0) {
 		return Rect2(0, 0, 0, 0);
 	}
-	Vector2 d = Vector2(_width, _width);
-	Rect2 bounding_rect = Rect2(_points[0] - d, 2 * d);
+	Vector2 min = _points[0];
+	Vector2 max = min;
 	for (int i = 1; i < _points.size(); i++) {
-		bounding_rect.expand_to(_points[i] - d);
-		bounding_rect.expand_to(_points[i] + d);
+		min = min.min(_points[i]);
+		max = max.max(_points[i]);
 	}
-	return bounding_rect;
+	return Rect2(min, max - min).grow(_width);
 }
 
 bool Line2D::_edit_use_rect() const {


### PR DESCRIPTION
This method is called constantly on viewport movement and when `Line2D` node is selected.
Current implementation is not bottleneck for editor, but objectively not as effective as it could be even without doing over-optimization.
This PR replaces excessive `expand_to()` calls in for-loop with finding minimum and maximum positions among all points and then creating `Rect2D`. 

For one `Line2D` node with 116 points, single `Line2D._edit_get_rect()` call.

| Editor build | Before, average time, ns | After, average time, ns | Speed gain |
| --- | --- | --- | --- |
| Dev build | 9048 | 4756  | ~x1.9 faster |
| Production build | 2405 | 1150 | ~x2.1 faster |