### PR TITLE
Add `body_is_valid()` to PhysicsServers and remove invalid exceptions in `PhysicsBodyXD/SoftBody3D::get_collision_exceptions()`.

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -506,6 +506,13 @@
 				Returns [code]true[/code] if the body is omitting the standard force integration. See [method body_set_omit_force_integration].
 			</description>
 		</method>
+		<method name="body_is_valid" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns [code]true[/code] if the body is still valid (i.e. has not been freed and the RID is a body).
+			</description>
+		</method>
 		<method name="body_remove_collision_exception">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -514,6 +514,13 @@
 				Overridable version of [method PhysicsServer2D.body_is_omitting_force_integration].
 			</description>
 		</method>
+		<method name="_body_is_valid" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Overridable version of [method PhysicsServer2D.body_is_valid].
+			</description>
+		</method>
 		<method name="_body_remove_collision_exception" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -488,6 +488,13 @@
 				Returns [code]true[/code] if the body is omitting the standard force integration. See [method body_set_omit_force_integration].
 			</description>
 		</method>
+		<method name="body_is_valid" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns [code]true[/code] if the body is still valid (i.e. has not been freed and the RID is a body).
+			</description>
+		</method>
 		<method name="body_remove_collision_exception">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -1157,6 +1164,13 @@
 			<param index="1" name="point_index" type="int" />
 			<description>
 				Returns whether the given soft body point is pinned.
+			</description>
+		</method>
+		<method name="soft_body_is_valid" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns [code]true[/code] if the soft body is still valid (i.e. has not been freed and the RID is a soft body).
 			</description>
 		</method>
 		<method name="soft_body_move_point">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -420,6 +420,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_body_is_valid" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_body_remove_collision_exception" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
@@ -1078,6 +1084,12 @@
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_is_valid" qualifiers="virtual const">
+			<return type="bool" />
+			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -536,6 +536,10 @@ RID GodotPhysicsServer2D::body_create() {
 	return rid;
 }
 
+bool GodotPhysicsServer2D::body_is_valid(RID p_body) const {
+	return body_owner.owns(p_body);
+}
+
 void GodotPhysicsServer2D::body_set_space(RID p_body, RID p_space) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -168,6 +168,8 @@ public:
 	// create a body of a given type
 	virtual RID body_create() override;
 
+	virtual bool body_is_valid(RID p_body) const override;
+
 	virtual void body_set_space(RID p_body, RID p_space) override;
 	virtual RID body_get_space(RID p_body) const override;
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -446,6 +446,10 @@ RID GodotPhysicsServer3D::body_create() {
 	return rid;
 }
 
+bool GodotPhysicsServer3D::body_is_valid(RID p_body) const {
+	return body_owner.owns(p_body);
+}
+
 void GodotPhysicsServer3D::body_set_space(RID p_body, RID p_space) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
@@ -946,6 +950,10 @@ RID GodotPhysicsServer3D::soft_body_create() {
 	RID rid = soft_body_owner.make_rid(soft_body);
 	soft_body->set_self(rid);
 	return rid;
+}
+
+bool GodotPhysicsServer3D::soft_body_is_valid(RID p_body) const {
+	return soft_body_owner.owns(p_body);
 }
 
 void GodotPhysicsServer3D::soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) {

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -164,6 +164,8 @@ public:
 	// create a body of a given type
 	virtual RID body_create() override;
 
+	virtual bool body_is_valid(RID p_body) const override;
+
 	virtual void body_set_space(RID p_body, RID p_space) override;
 	virtual RID body_get_space(RID p_body) const override;
 
@@ -258,6 +260,8 @@ public:
 	/* SOFT BODY */
 
 	virtual RID soft_body_create() override;
+
+	virtual bool soft_body_is_valid(RID p_body) const override;
 
 	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) override;
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -506,6 +506,10 @@ RID JoltPhysicsServer3D::body_create() {
 	return rid;
 }
 
+bool JoltPhysicsServer3D::body_is_valid(RID p_body) const {
+	return body_owner.owns(p_body);
+}
+
 void JoltPhysicsServer3D::body_set_space(RID p_body, RID p_space) {
 	JoltBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
@@ -955,6 +959,10 @@ RID JoltPhysicsServer3D::soft_body_create() {
 	RID rid = soft_body_owner.make_rid(body);
 	body->set_rid(rid);
 	return rid;
+}
+
+bool JoltPhysicsServer3D::soft_body_is_valid(RID p_body) const {
+	return soft_body_owner.owns(p_body);
 }
 
 void JoltPhysicsServer3D::soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) {

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -207,6 +207,8 @@ public:
 
 	virtual RID body_create() override;
 
+	virtual bool body_is_valid(RID p_body) const override;
+
 	virtual void body_set_space(RID p_body, RID p_space) override;
 	virtual RID body_get_space(RID p_body) const override;
 
@@ -300,6 +302,8 @@ public:
 	virtual PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override;
 
 	virtual RID soft_body_create() override;
+
+	virtual bool soft_body_is_valid(RID p_body) const override;
 
 	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) override;
 

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -148,10 +148,14 @@ TypedArray<PhysicsBody2D> PhysicsBody2D::get_collision_exceptions() {
 	PhysicsServer2D::get_singleton()->body_get_collision_exceptions(get_rid(), &exceptions);
 	Array ret;
 	for (const RID &body : exceptions) {
-		ObjectID instance_id = PhysicsServer2D::get_singleton()->body_get_object_instance_id(body);
-		Object *obj = ObjectDB::get_instance(instance_id);
-		PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(obj);
-		ret.append(physics_body);
+		if (PhysicsServer2D::get_singleton()->body_is_valid(body)) {
+			ObjectID instance_id = PhysicsServer2D::get_singleton()->body_get_object_instance_id(body);
+			Object *obj = ObjectDB::get_instance(instance_id);
+			PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(obj);
+			ret.append(physics_body);
+		} else {
+			PhysicsServer2D::get_singleton()->body_remove_collision_exception(get_rid(), body);
+		}
 	}
 	return ret;
 }

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -61,10 +61,14 @@ TypedArray<PhysicsBody3D> PhysicsBody3D::get_collision_exceptions() {
 	PhysicsServer3D::get_singleton()->body_get_collision_exceptions(get_rid(), &exceptions);
 	Array ret;
 	for (const RID &body : exceptions) {
-		ObjectID instance_id = PhysicsServer3D::get_singleton()->body_get_object_instance_id(body);
-		Object *obj = ObjectDB::get_instance(instance_id);
-		PhysicsBody3D *physics_body = Object::cast_to<PhysicsBody3D>(obj);
-		ret.append(physics_body);
+		if (PhysicsServer3D::get_singleton()->body_is_valid(body)) {
+			ObjectID instance_id = PhysicsServer3D::get_singleton()->body_get_object_instance_id(body);
+			Object *obj = ObjectDB::get_instance(instance_id);
+			PhysicsBody3D *physics_body = Object::cast_to<PhysicsBody3D>(obj);
+			ret.append(physics_body);
+		} else {
+			PhysicsServer3D::get_singleton()->body_remove_collision_exception(get_rid(), body);
+		}
 	}
 	return ret;
 }

--- a/scene/3d/soft_body_3d.cpp
+++ b/scene/3d/soft_body_3d.cpp
@@ -597,10 +597,14 @@ TypedArray<PhysicsBody3D> SoftBody3D::get_collision_exceptions() {
 	PhysicsServer3D::get_singleton()->soft_body_get_collision_exceptions(physics_rid, &exceptions);
 	TypedArray<PhysicsBody3D> ret;
 	for (const RID &body : exceptions) {
-		ObjectID instance_id = PhysicsServer3D::get_singleton()->body_get_object_instance_id(body);
-		Object *obj = ObjectDB::get_instance(instance_id);
-		PhysicsBody3D *physics_body = Object::cast_to<PhysicsBody3D>(obj);
-		ret.append(physics_body);
+		if (PhysicsServer3D::get_singleton()->soft_body_is_valid(body)) {
+			ObjectID instance_id = PhysicsServer3D::get_singleton()->body_get_object_instance_id(body);
+			Object *obj = ObjectDB::get_instance(instance_id);
+			PhysicsBody3D *physics_body = Object::cast_to<PhysicsBody3D>(obj);
+			ret.append(physics_body);
+		} else {
+			PhysicsServer3D::get_singleton()->soft_body_remove_collision_exception(get_physics_rid(), body);
+		}
 	}
 	return ret;
 }

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -211,6 +211,8 @@ void PhysicsServer2DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_create);
 
+	GDVIRTUAL_BIND(_body_is_valid, "body");
+
 	GDVIRTUAL_BIND(_body_set_space, "body", "space");
 	GDVIRTUAL_BIND(_body_get_space, "body");
 

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -285,6 +285,8 @@ public:
 	//EXBIND2RID(body,BodyMode,bool);
 	EXBIND0R(RID, body_create)
 
+	EXBIND1RC(bool, body_is_valid, RID)
+
 	EXBIND2(body_set_space, RID, RID)
 	EXBIND1RC(RID, body_get_space, RID)
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -214,6 +214,8 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_body_create);
 
+	GDVIRTUAL_BIND(_body_is_valid, "body");
+
 	GDVIRTUAL_BIND(_body_set_space, "body", "space");
 	GDVIRTUAL_BIND(_body_get_space, "body");
 
@@ -306,6 +308,8 @@ void PhysicsServer3DExtension::_bind_methods() {
 	/* SOFT BODY API */
 
 	GDVIRTUAL_BIND(_soft_body_create);
+
+	GDVIRTUAL_BIND(_soft_body_is_valid, "body");
 
 	GDVIRTUAL_BIND(_soft_body_update_rendering_server, "body", "rendering_server_handler");
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -288,6 +288,8 @@ public:
 	//EXBIND2RID(body,BodyMode,bool);
 	EXBIND0R(RID, body_create)
 
+	EXBIND1RC(bool, body_is_valid, RID)
+
 	EXBIND2(body_set_space, RID, RID)
 	EXBIND1RC(RID, body_get_space, RID)
 
@@ -405,6 +407,8 @@ public:
 	/* SOFT BODY API */
 
 	EXBIND0R(RID, soft_body_create)
+
+	EXBIND1RC(bool, soft_body_is_valid, RID)
 
 	EXBIND2(soft_body_update_rendering_server, RID, PhysicsServer3DRenderingServerHandler *)
 

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -678,6 +678,8 @@ void PhysicsServer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("body_create"), &PhysicsServer2D::body_create);
 
+	ClassDB::bind_method(D_METHOD("body_is_valid", "body"), &PhysicsServer2D::body_is_valid);
+
 	ClassDB::bind_method(D_METHOD("body_set_space", "body", "space"), &PhysicsServer2D::body_set_space);
 	ClassDB::bind_method(D_METHOD("body_get_space", "body"), &PhysicsServer2D::body_get_space);
 

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -358,6 +358,8 @@ public:
 
 	virtual RID body_create() = 0;
 
+	virtual bool body_is_valid(RID p_body) const = 0;
+
 	virtual void body_set_space(RID p_body, RID p_space) = 0;
 	virtual RID body_get_space(RID p_body) const = 0;
 

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -207,6 +207,8 @@ public:
 
 	virtual RID body_create() override { return RID(); }
 
+	virtual bool body_is_valid(RID p_body) const override { return false; }
+
 	virtual void body_set_space(RID p_body, RID p_space) override {}
 	virtual RID body_get_space(RID p_body) const override { return RID(); }
 

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -169,6 +169,8 @@ public:
 	//FUNC2RID(body,BodyMode,bool);
 	FUNCRID(body)
 
+	FUNC1RC(bool, body_is_valid, RID);
+
 	FUNC2(body_set_space, RID, RID);
 	FUNC1RC(RID, body_get_space, RID);
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -755,6 +755,8 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("body_create"), &PhysicsServer3D::body_create);
 
+	ClassDB::bind_method(D_METHOD("body_is_valid", "body"), &PhysicsServer3D::body_is_valid);
+
 	ClassDB::bind_method(D_METHOD("body_set_space", "body", "space"), &PhysicsServer3D::body_set_space);
 	ClassDB::bind_method(D_METHOD("body_get_space", "body"), &PhysicsServer3D::body_get_space);
 
@@ -841,6 +843,8 @@ void PhysicsServer3D::_bind_methods() {
 	/* SOFT BODY API */
 
 	ClassDB::bind_method(D_METHOD("soft_body_create"), &PhysicsServer3D::soft_body_create);
+
+	ClassDB::bind_method(D_METHOD("soft_body_is_valid", "body"), &PhysicsServer3D::soft_body_is_valid);
 
 	ClassDB::bind_method(D_METHOD("soft_body_update_rendering_server", "body", "rendering_server_handler"), &PhysicsServer3D::soft_body_update_rendering_server);
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -395,6 +395,8 @@ public:
 
 	virtual RID body_create() = 0;
 
+	virtual bool body_is_valid(RID p_body) const = 0;
+
 	virtual void body_set_space(RID p_body, RID p_space) = 0;
 	virtual RID body_get_space(RID p_body) const = 0;
 
@@ -570,6 +572,8 @@ public:
 	/* SOFT BODY */
 
 	virtual RID soft_body_create() = 0;
+
+	virtual bool soft_body_is_valid(RID p_body) const = 0;
 
 	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) = 0;
 

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -213,6 +213,8 @@ public:
 
 	virtual RID body_create() override { return RID(); }
 
+	virtual bool body_is_valid(RID p_body) const override { return false; }
+
 	virtual void body_set_space(RID p_body, RID p_space) override {}
 	virtual RID body_get_space(RID p_body) const override { return RID(); }
 
@@ -306,6 +308,8 @@ public:
 	/* SOFT BODY */
 
 	virtual RID soft_body_create() override { return RID(); }
+
+	virtual bool soft_body_is_valid(RID p_body) const override { return false; }
 
 	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) override {}
 

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -173,6 +173,8 @@ public:
 	//FUNC2RID(body,BodyMode,bool);
 	FUNCRID(body)
 
+	FUNC1RC(bool, body_is_valid, RID);
+
 	FUNC2(body_set_space, RID, RID);
 	FUNC1RC(RID, body_get_space, RID);
 
@@ -273,6 +275,8 @@ public:
 	/* SOFT BODY API */
 
 	FUNCRID(soft_body)
+
+	FUNC1RC(bool, soft_body_is_valid, RID)
 
 	FUNC2(soft_body_update_rendering_server, RID, PhysicsServer3DRenderingServerHandler *)
 


### PR DESCRIPTION
An alternate of [#101064](https://github.com/godotengine/godot/pull/101064).

