### PR TITLE
LSP: Improve function default arg representation

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -28,10 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include "gdscript_editor.h"
+
 #include "gdscript.h"
 
 #include "gdscript_analyzer.h"
-#include "gdscript_parser.h"
 #include "gdscript_tokenizer.h"
 #include "gdscript_utility_functions.h"
 
@@ -741,7 +742,7 @@ static String _get_visual_datatype(const PropertyInfo &p_info, bool p_is_arg, co
 	return Variant::get_type_name(p_info.type);
 }
 
-static String _make_arguments_hint(const MethodInfo &p_info, int p_arg_idx, bool p_is_annotation = false) {
+String make_arguments_hint(const MethodInfo &p_info, int p_arg_idx, bool p_is_annotation) {
 	String arghint;
 	if (!p_is_annotation) {
 		arghint += _get_visual_datatype(p_info.return_val, false) + " ";
@@ -789,7 +790,7 @@ static String _make_arguments_hint(const MethodInfo &p_info, int p_arg_idx, bool
 	return arghint;
 }
 
-static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_function, int p_arg_idx, bool p_just_args = false) {
+String make_arguments_hint(const GDScriptParser::FunctionNode *p_function, int p_arg_idx, bool p_just_args) {
 	String arghint;
 
 	if (p_just_args) {
@@ -910,7 +911,7 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 	ERR_FAIL_NULL(p_annotation);
 
 	if (p_annotation->info != nullptr) {
-		r_arghint = _make_arguments_hint(p_annotation->info->info, p_argument, true);
+		r_arghint = make_arguments_hint(p_annotation->info->info, p_argument, true);
 	}
 	if (p_annotation->name == SNAME("@export_range")) {
 		if (p_argument == 3 || p_argument == 4 || p_argument == 5) {
@@ -2873,7 +2874,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 							const GDScriptParser::ClassNode::Member &member = current->get_member("_init");
 
 							if (member.type == GDScriptParser::ClassNode::Member::FUNCTION) {
-								r_arghint = base_type.class_type->get_datatype().to_string() + " new" + _make_arguments_hint(member.function, p_argidx, true);
+								r_arghint = base_type.class_type->get_datatype().to_string() + " new" + make_arguments_hint(member.function, p_argidx, true);
 								return;
 							}
 						}
@@ -2888,7 +2889,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					const GDScriptParser::ClassNode::Member &member = base_type.class_type->get_member(p_method);
 
 					if (member.type == GDScriptParser::ClassNode::Member::FUNCTION) {
-						r_arghint = _make_arguments_hint(member.function, p_argidx);
+						r_arghint = make_arguments_hint(member.function, p_argidx);
 						return;
 					}
 				}
@@ -2897,7 +2898,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			} break;
 			case GDScriptParser::DataType::SCRIPT: {
 				if (base_type.script_type->is_valid() && base_type.script_type->has_method(p_method)) {
-					r_arghint = _make_arguments_hint(base_type.script_type->get_method_info(p_method), p_argidx);
+					r_arghint = make_arguments_hint(base_type.script_type->get_method_info(p_method), p_argidx);
 					return;
 				}
 				Ref<Script> base_script = base_type.script_type->get_base_script();
@@ -2949,7 +2950,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						}
 					}
 
-					r_arghint = _make_arguments_hint(info, p_argidx);
+					r_arghint = make_arguments_hint(info, p_argidx);
 				}
 
 				if (p_argidx == 1 && p_context.node && p_context.node->type == GDScriptParser::Node::CALL && ClassDB::is_parent_class(class_name, SNAME("Tween")) && p_method == SNAME("tween_property")) {
@@ -3093,7 +3094,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 				base.get_method_list(&methods);
 				for (const MethodInfo &E : methods) {
 					if (E.name == p_method) {
-						r_arghint = _make_arguments_hint(E, p_argidx);
+						r_arghint = make_arguments_hint(E, p_argidx);
 						return;
 					}
 				}
@@ -3195,7 +3196,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 		}
 
 		MethodInfo mi(PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource"), "preload", PropertyInfo(Variant::STRING, "path"));
-		r_arghint = _make_arguments_hint(mi, p_argidx);
+		r_arghint = make_arguments_hint(mi, p_argidx);
 		return;
 	} else if (p_call->type != GDScriptParser::Node::CALL) {
 		return;
@@ -3229,7 +3230,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						continue;
 					}
 					if (E.name == call->function_name) {
-						r_arghint += _make_arguments_hint(E, p_argidx);
+						r_arghint += make_arguments_hint(E, p_argidx);
 						return;
 					}
 				}
@@ -3253,11 +3254,11 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 		}
 	} else if (Variant::has_utility_function(call->function_name)) {
 		MethodInfo info = Variant::get_utility_function_info(call->function_name);
-		r_arghint = _make_arguments_hint(info, p_argidx);
+		r_arghint = make_arguments_hint(info, p_argidx);
 		return;
 	} else if (GDScriptUtilityFunctions::function_exists(call->function_name)) {
 		MethodInfo info = GDScriptUtilityFunctions::get_function_info(call->function_name);
-		r_arghint = _make_arguments_hint(info, p_argidx);
+		r_arghint = make_arguments_hint(info, p_argidx);
 		return;
 	} else if (GDScriptParser::get_builtin_type(call->function_name) < Variant::VARIANT_MAX) {
 		// Complete constructor.
@@ -3272,7 +3273,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			if (i > 0) {
 				r_arghint += "\n";
 			}
-			r_arghint += _make_arguments_hint(E, p_argidx);
+			r_arghint += make_arguments_hint(E, p_argidx);
 			i++;
 		}
 		return;

--- a/modules/gdscript/gdscript_editor.h
+++ b/modules/gdscript/gdscript_editor.h
@@ -1,0 +1,38 @@
+/**************************************************************************/
+/*  gdscript_editor.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/object.h"
+#include "core/string/ustring.h"
+#include "gdscript_parser.h"
+
+String make_arguments_hint(const MethodInfo &p_info, int p_arg_idx, bool p_is_annotation = false);
+String make_arguments_hint(const GDScriptParser::FunctionNode *p_function, int p_arg_idx, bool p_just_args = false);


### PR DESCRIPTION
Fixes #51617

Reuses the more reliable arghint creation logic from the builtin editor to create the parameter representation for the lsp details.

We still need to create the stuff that isn't the parameters on lsp site, since the lsp represents functions as `func name() -> void` while arghints take the form: `void name()`. I find the later actually confusing but that's a different topic.

TODO:
- [ ] Move the shared utils into `GDScriptEditorLanguage` instead of the `gdscript_editor.h` solution this PR uses at the moment.
