### PR TITLE
Fix converting root Sprite2D

### DIFF
--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -139,7 +139,7 @@ void Sprite2DEditor::_menu_option(int p_option) {
 
 void Sprite2DEditor::_popup_debug_uv_dialog() {
 	String error_message;
-	if (node->get_owner() != get_tree()->get_edited_scene_root()) {
+	if (node->get_owner() != get_tree()->get_edited_scene_root() && node != get_tree()->get_edited_scene_root()) {
 		error_message = TTR("Can't convert a sprite from a foreign scene.");
 	}
 	Ref<Texture2D> texture = node->get_texture();


### PR DESCRIPTION
Trying to convert Sprite2D to e.g. Polygon2D, while the sprite is root of the scene, will result in
```
Can't convert a sprite from a foreign scene.
```
The editor does not check properly for foreign node.

Somewhat related to #100437. `is_foreign()` is one of the methods I plan to add.