### PR TITLE
Fix loading scene for every request on script file for workspace completion

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -65,11 +65,14 @@ void GDScriptTextDocument::_bind_methods() {
 void GDScriptTextDocument::didOpen(const Variant &p_param) {
 	LSP::TextDocumentItem doc = load_document_item(p_param);
 	sync_script_content(doc.uri, doc.text);
+	String doc_path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(doc.uri);
+	GDScriptLanguageProtocol::get_singleton()->get_scene_cache()->request_scene_load_for_script(doc_path);
 }
 
 void GDScriptTextDocument::didClose(const Variant &p_param) {
-	// Left empty on purpose. Godot does nothing special on closing a document,
-	// but it satisfies LSP clients that require didClose be implemented.
+	LSP::TextDocumentItem doc = load_document_item(p_param);
+	String doc_path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(doc.uri);
+	GDScriptLanguageProtocol::get_singleton()->get_scene_cache()->unload_scene_for_script(doc_path);
 }
 
 void GDScriptTextDocument::didChange(const Variant &p_param) {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -41,7 +41,6 @@
 #include "editor/editor_node.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/settings/editor_settings.h"
-#include "scene/resources/packed_scene.h"
 
 void GDScriptWorkspace::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_new_signal"), &GDScriptWorkspace::apply_new_signal);
@@ -684,58 +683,13 @@ void GDScriptWorkspace::publish_diagnostics(const String &p_path) {
 	GDScriptLanguageProtocol::get_singleton()->notify_client("textDocument/publishDiagnostics", params);
 }
 
-void GDScriptWorkspace::_get_owners(EditorFileSystemDirectory *efsd, String p_path, List<String> &owners) {
-	if (!efsd) {
-		return;
-	}
-
-	for (int i = 0; i < efsd->get_subdir_count(); i++) {
-		_get_owners(efsd->get_subdir(i), p_path, owners);
-	}
-
-	for (int i = 0; i < efsd->get_file_count(); i++) {
-		Vector<String> deps = efsd->get_file_deps(i);
-		bool found = false;
-		for (int j = 0; j < deps.size(); j++) {
-			if (deps[j] == p_path) {
-				found = true;
-				break;
-			}
-		}
-		if (!found) {
-			continue;
-		}
-
-		owners.push_back(efsd->get_file_path(i));
-	}
-}
-
-Node *GDScriptWorkspace::_get_owner_scene_node(String p_path) {
-	Node *owner_scene_node = nullptr;
-	List<String> owners;
-
-	_get_owners(EditorFileSystem::get_singleton()->get_filesystem(), p_path, owners);
-
-	for (const String &owner : owners) {
-		NodePath owner_path = owner;
-		Ref<Resource> owner_res = ResourceLoader::load(String(owner_path));
-		if (Object::cast_to<PackedScene>(owner_res.ptr())) {
-			Ref<PackedScene> owner_packed_scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*owner_res));
-			owner_scene_node = owner_packed_scene->instantiate();
-			break;
-		}
-	}
-
-	return owner_scene_node;
-}
-
 void GDScriptWorkspace::completion(const LSP::CompletionParams &p_params, List<ScriptLanguage::CodeCompletionOption> *r_options) {
 	String path = get_file_path(p_params.textDocument.uri);
 	String call_hint;
 	bool forced = false;
 
 	if (const ExtendGDScriptParser *parser = get_parse_result(path)) {
-		Node *owner_scene_node = _get_owner_scene_node(path);
+		Node *owner_scene_node = GDScriptLanguageProtocol::get_singleton()->get_scene_cache()->get(path);
 
 		Array stack;
 		Node *current = nullptr;
@@ -761,9 +715,6 @@ void GDScriptWorkspace::completion(const LSP::CompletionParams &p_params, List<S
 
 		String code = parser->get_text_for_completion(p_params.position);
 		GDScriptLanguage::get_singleton()->complete_code(code, path, current, r_options, forced, call_hint);
-		if (owner_scene_node) {
-			memdelete(owner_scene_node);
-		}
 	}
 }
 

--- a/modules/gdscript/language_server/gdscript_workspace.h
+++ b/modules/gdscript/language_server/gdscript_workspace.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "../gdscript_parser.h"
 #include "gdscript_extend_parser.h"
 #include "godot_lsp.h"
 
@@ -39,10 +38,6 @@
 
 class GDScriptWorkspace : public RefCounted {
 	GDCLASS(GDScriptWorkspace, RefCounted);
-
-private:
-	void _get_owners(EditorFileSystemDirectory *efsd, String p_path, List<String> &owners);
-	Node *_get_owner_scene_node(String p_path);
 
 protected:
 	static void _bind_methods();

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -34,6 +34,14 @@
 #include "core/object/class_db.h"
 #include "core/templates/list.h"
 
+//#define DEBUG_LSP
+
+#ifdef DEBUG_LSP
+#define LOG_LSP(...) print_line("[ LSP -", __FILE__, ":", __LINE__, "-", __func__, "] -", ##__VA_ARGS__)
+#else
+#define LOG_LSP(...) ((void)0)
+#endif
+
 namespace LSP {
 
 typedef String DocumentUri;


### PR DESCRIPTION
For workspace completion the Scene for the script is loaded for every completion request and freed afterwards. Resulting in performance issues for scenes including large resources.

Loaded Scenes are now cached for each script. Not loading them again and only freeing them when the connection is terminated or the language server stopped.

This PR fixes #100934

---
I have no experience in C++ development - feedback is of course more than welcome. 
Unit Tests are green and auto formatting should have worked too.

_Bugsquad edit (keywords for easier searching): LSP, language server_