### PR TITLE
Autocompletion: Use correct completion type for argument options

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2936,7 +2936,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 										opt = "^" + opt;
 									}
 								}
-								ScriptLanguage::CodeCompletionOption option(opt, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
+								ScriptLanguage::CodeCompletionOption option(opt, ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
 								r_result.insert(option.display, option);
 							}
 						}


### PR DESCRIPTION
Fixes #87509