### PR TITLE
Core: Refactor error macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -172,8 +172,8 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 # LambdaBodyIndentation: Signature
 # Language: Cpp
 # LineEnding: DeriveLF
-# MacroBlockBegin: ""
-# MacroBlockEnd: ""
+MacroBlockBegin: ^GD_NOEXPAND_WRAPPER_BEGIN$
+MacroBlockEnd: ^GD_NOEXPAND_WRAPPER_END$
 # MaxEmptyLinesToKeep: 1
 # NamespaceIndentation: None
 # ObjCBinPackProtocolList: Auto

--- a/SConstruct
+++ b/SConstruct
@@ -981,9 +981,6 @@ else:  # GCC, Clang
             # Regression in GCC 9/10, spams so much in our variadic templates
             # that we need to outright disable it.
             common_warnings += ["-Wno-type-limits"]
-        if cc_version_major == 12:
-            # Regression in GCC 12, false positives in our error macros, see GH-58747.
-            common_warnings += ["-Wno-return-type"]
         if cc_version_major >= 11:
             common_warnings += ["-Wenum-conversion"]
         if cc_version_major >= 16:

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -84,23 +84,20 @@ _NO_INLINE_ void _err_flush_stdout();
 
 void _physics_interpolation_warning(const char *p_function, const char *p_file, int p_line, ObjectID p_id, const char *p_warn_string);
 
-#ifdef __GNUC__
-//#define FUNCTION_STR __PRETTY_FUNCTION__ - too annoying
-#define FUNCTION_STR __FUNCTION__
-#else
-#define FUNCTION_STR __FUNCTION__
-#endif
-
 #if defined(_MSC_VER) && !defined(__clang__)
 /**
  * Don't use GENERATE_TRAP() directly, should only be used be the macros below.
  */
-#define GENERATE_TRAP() __debugbreak()
+#define GENERATE_TRAP() \
+	__debugbreak(); \
+	__assume(false)
 #else
 /**
  * Don't use GENERATE_TRAP() directly, should only be used be the macros below.
  */
-#define GENERATE_TRAP() __builtin_trap()
+#define GENERATE_TRAP() \
+	__builtin_trap(); \
+	__builtin_unreachable()
 #endif
 
 /**
@@ -112,11 +109,6 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * running application to fail or crash.
  * Always try to return processable data, so the engine can keep running well.
  * Use the _MSG versions to print a meaningful message to help with debugging.
- *
- * The `((void)0)` no-op statement is used as a trick to force us to put a semicolon after
- * those macros, making them look like proper statements.
- * The if wrappers are used to ensure that the macro replacement does not trigger unexpected
- * issues when expanded e.g. after an `if (cond) ERR_FAIL();` without braces.
  */
 
 // Index out of bounds error macros.
@@ -132,32 +124,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns.
  */
 #define ERR_FAIL_INDEX(m_index, m_size) \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) < static_cast<std::decay_t<decltype(m_index)>>(0) || (m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size)); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns.
  */
 #define ERR_FAIL_INDEX_MSG(m_index, m_size, m_msg) \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) < static_cast<std::decay_t<decltype(m_index)>>(0) || (m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_INDEX_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_INDEX_EDMSG(m_index, m_size, m_msg) \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) < static_cast<std::decay_t<decltype(m_index)>>(0) || (m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg, true); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_INDEX_V_MSG`.
@@ -167,32 +162,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns `m_retval`.
  */
 #define ERR_FAIL_INDEX_V(m_index, m_size, m_retval) \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) < static_cast<std::decay_t<decltype(m_index)>>(0) || (m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size)); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures an integer index `m_index` is less than `m_size` and greater than or equal to 0.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
 #define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg) \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) < static_cast<std::decay_t<decltype(m_index)>>(0) || (m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_INDEX_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg) \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) < static_cast<std::decay_t<decltype(m_index)>>(0) || (m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg, true); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_INDEX_MSG` or `ERR_FAIL_INDEX_V_MSG`.
@@ -203,12 +201,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the application crashes.
  */
 #define CRASH_BAD_INDEX(m_index, m_size) \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
-		_err_flush_stdout(); \
-		GENERATE_TRAP(); \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) < static_cast<std::decay_t<decltype(m_index)>>(0) || (m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), "", false, true); \
+			_err_flush_stdout(); \
+			GENERATE_TRAP(); \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_INDEX_MSG` or `ERR_FAIL_INDEX_V_MSG`.
@@ -218,12 +217,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, prints `m_msg` and the application crashes.
  */
 #define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg) \
-	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
-		_err_flush_stdout(); \
-		GENERATE_TRAP(); \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) < static_cast<std::decay_t<decltype(m_index)>>(0) || (m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg, false, true); \
+			_err_flush_stdout(); \
+			GENERATE_TRAP(); \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 // Unsigned integer index out of bounds error macros.
 
@@ -235,32 +235,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns.
  */
 #define ERR_FAIL_UNSIGNED_INDEX(m_index, m_size) \
-	if (unlikely((m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size)); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg) \
-	if (unlikely((m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_EDMSG(m_index, m_size, m_msg) \
-	if (unlikely((m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg, true); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
@@ -270,32 +273,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the current function returns `m_retval`.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval) \
-	if (unlikely((m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size)); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures an unsigned integer index `m_index` is less than `m_size`.
  * If not, prints `m_msg` and the current function returns `m_retval`.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg) \
-	if (unlikely((m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_UNSIGNED_INDEX_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg) \
-	if (unlikely((m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg, true); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG` or `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
@@ -306,12 +312,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, the application crashes.
  */
 #define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size) \
-	if (unlikely((m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", false, true); \
-		_err_flush_stdout(); \
-		GENERATE_TRAP(); \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), "", false, true); \
+			_err_flush_stdout(); \
+			GENERATE_TRAP(); \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_UNSIGNED_INDEX_MSG` or `ERR_FAIL_UNSIGNED_INDEX_V_MSG`.
@@ -321,12 +328,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If not, prints `m_msg` and the application crashes.
  */
 #define CRASH_BAD_UNSIGNED_INDEX_MSG(m_index, m_size, m_msg) \
-	if (unlikely((m_index) >= (m_size))) { \
-		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, false, true); \
-		_err_flush_stdout(); \
-		GENERATE_TRAP(); \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely((m_index) >= (m_size))) { \
+			_err_print_index_error(__FUNCTION__, __FILE__, __LINE__, static_cast<int64_t>(m_index), static_cast<int64_t>(m_size), _STR(m_index), _STR(m_size), m_msg, false, true); \
+			_err_flush_stdout(); \
+			GENERATE_TRAP(); \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 // Null reference error macros.
 
@@ -338,32 +346,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If it is null, the current function returns.
  */
 #define ERR_FAIL_NULL(m_param) \
-	if (unlikely(m_param == nullptr)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_param == nullptr)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns.
  */
 #define ERR_FAIL_NULL_MSG(m_param, m_msg) \
-	if (unlikely(m_param == nullptr)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_param == nullptr)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_NULL_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_NULL_EDMSG(m_param, m_msg) \
-	if (unlikely(m_param == nullptr)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_param == nullptr)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_NULL_V_MSG`.
@@ -373,32 +384,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If it is null, the current function returns `m_retval`.
  */
 #define ERR_FAIL_NULL_V(m_param, m_retval) \
-	if (unlikely(m_param == nullptr)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_param == nullptr)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures a pointer `m_param` is not null.
  * If it is null, prints `m_msg` and the current function returns `m_retval`.
  */
 #define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg) \
-	if (unlikely(m_param == nullptr)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_param == nullptr)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_NULL_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_NULL_V_EDMSG(m_param, m_retval, m_msg) \
-	if (unlikely(m_param == nullptr)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_param == nullptr)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG`.
@@ -410,11 +424,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the current function returns.
  */
 #define ERR_FAIL_COND(m_cond) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true."); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures `m_cond` is false.
@@ -424,21 +439,23 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If checking index bounds use ERR_FAIL_INDEX_MSG instead.
  */
 #define ERR_FAIL_COND_MSG(m_cond, m_msg) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_COND_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_COND_EDMSG(m_cond, m_msg) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg, true); \
-		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true.", m_msg, true); \
+			return; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_V_MSG`.
@@ -450,11 +467,12 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the current function returns `m_retval`.
  */
 #define ERR_FAIL_COND_V(m_cond, m_retval) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval)); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval)); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures `m_cond` is false.
@@ -464,21 +482,23 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If checking index bounds use ERR_FAIL_INDEX_V_MSG instead.
  */
 #define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_COND_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_COND_V_EDMSG(m_cond, m_retval, m_msg) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg, true); \
-		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg, true); \
+			return m_retval; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_CONTINUE_MSG`.
@@ -488,32 +508,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the current loop continues.
  */
 #define ERR_CONTINUE(m_cond) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
-		continue; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing."); \
+			continue; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop continues.
  */
 #define ERR_CONTINUE_MSG(m_cond, m_msg) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg); \
-		continue; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg); \
+			continue; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_CONTINUE_MSG` but also notifies the editor.
  */
 #define ERR_CONTINUE_EDMSG(m_cond, m_msg) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg, true); \
-		continue; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Continuing.", m_msg, true); \
+			continue; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_BREAK_MSG`.
@@ -523,32 +546,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the current loop breaks.
  */
 #define ERR_BREAK(m_cond) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
-		break; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking."); \
+			break; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Ensures `m_cond` is false.
  * If `m_cond` is true, prints `m_msg` and the current loop breaks.
  */
 #define ERR_BREAK_MSG(m_cond, m_msg) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg); \
-		break; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg); \
+			break; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_BREAK_MSG` but also notifies the editor.
  */
 #define ERR_BREAK_EDMSG(m_cond, m_msg) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg, true); \
-		break; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Breaking.", m_msg, true); \
+			break; \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG` or `ERR_FAIL_COND_V_MSG`.
@@ -559,12 +585,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, the application crashes.
  */
 #define CRASH_COND(m_cond) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
-		_err_flush_stdout(); \
-		GENERATE_TRAP(); \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
+			_err_flush_stdout(); \
+			GENERATE_TRAP(); \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG` or `ERR_FAIL_COND_V_MSG`.
@@ -574,12 +601,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If `m_cond` is true, prints `m_msg` and the application crashes.
  */
 #define CRASH_COND_MSG(m_cond, m_msg) \
-	if (unlikely(m_cond)) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", m_msg); \
-		_err_flush_stdout(); \
-		GENERATE_TRAP(); \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(m_cond)) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", m_msg); \
+			_err_flush_stdout(); \
+			GENERATE_TRAP(); \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 
 // Generic error macros.
 
@@ -591,11 +619,10 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * The current function returns.
  */
 #define ERR_FAIL() \
-	if (true) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed."); \
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Method/function failed."); \
 		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG`.
@@ -604,21 +631,19 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Prints `m_msg`, and the current function returns.
  */
 #define ERR_FAIL_MSG(m_msg) \
-	if (true) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg); \
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Method/function failed.", m_msg); \
 		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_EDMSG(m_msg) \
-	if (true) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed.", m_msg, true); \
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Method/function failed.", m_msg, true); \
 		return; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_V_MSG` or `ERR_FAIL_V_MSG`.
@@ -628,11 +653,10 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * The current function returns `m_retval`.
  */
 #define ERR_FAIL_V(m_retval) \
-	if (true) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval)); \
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval)); \
 		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_V_MSG`.
@@ -641,21 +665,19 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Prints `m_msg`, and the current function returns `m_retval`.
  */
 #define ERR_FAIL_V_MSG(m_retval, m_msg) \
-	if (true) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg); \
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg); \
 		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_FAIL_V_MSG` but also notifies the editor.
  */
 #define ERR_FAIL_V_EDMSG(m_retval, m_msg) \
-	if (true) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg, true); \
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg, true); \
 		return m_retval; \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Try using `ERR_FAIL_COND_MSG`, `ERR_FAIL_COND_V_MSG`, `ERR_CONTINUE_MSG` or `ERR_BREAK_MSG`.
@@ -665,39 +687,37 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Prints `m_msg`.
  */
 #define ERR_PRINT(m_msg) \
-	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg)
+	_err_print_error(__FUNCTION__, __FILE__, __LINE__, m_msg)
 
 /**
  * Same as `ERR_PRINT` but also notifies the editor.
  */
 #define ERR_PRINT_ED(m_msg) \
-	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true)
+	_err_print_error(__FUNCTION__, __FILE__, __LINE__, m_msg, true)
 
 /**
  * Prints `m_msg` once during the application lifetime.
  */
 #define ERR_PRINT_ONCE(m_msg) \
-	if (true) { \
+	GD_NOEXPAND_WRAPPER_BEGIN \
 		static bool warning_shown = false; \
 		if (unlikely(!warning_shown)) { \
 			warning_shown = true; \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg); \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, m_msg); \
 		} \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `ERR_PRINT_ONCE` but also notifies the editor.
  */
 #define ERR_PRINT_ONCE_ED(m_msg) \
-	if (true) { \
+	GD_NOEXPAND_WRAPPER_BEGIN \
 		static bool warning_shown = false; \
 		if (unlikely(!warning_shown)) { \
 			warning_shown = true; \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true); \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, m_msg, true); \
 		} \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 // Print warning message macros.
 
@@ -707,13 +727,13 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
  */
 #define WARN_PRINT(m_msg) \
-	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, false, ERR_HANDLER_WARNING)
+	_err_print_error(__FUNCTION__, __FILE__, __LINE__, m_msg, false, ERR_HANDLER_WARNING)
 
 /**
  * Same as `WARN_PRINT` but also notifies the editor.
  */
 #define WARN_PRINT_ED(m_msg) \
-	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true, ERR_HANDLER_WARNING)
+	_err_print_error(__FUNCTION__, __FILE__, __LINE__, m_msg, true, ERR_HANDLER_WARNING)
 
 /**
  * Prints `m_msg` once during the application lifetime.
@@ -721,37 +741,35 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * If warning about deprecated usage, use `WARN_DEPRECATED` or `WARN_DEPRECATED_MSG` instead.
  */
 #define WARN_PRINT_ONCE(m_msg) \
-	if (true) { \
+	GD_NOEXPAND_WRAPPER_BEGIN \
 		static bool warning_shown = false; \
 		if (unlikely(!warning_shown)) { \
 			warning_shown = true; \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, false, ERR_HANDLER_WARNING); \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, m_msg, false, ERR_HANDLER_WARNING); \
 		} \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Same as `WARN_PRINT_ONCE` but also notifies the editor.
  */
 #define WARN_PRINT_ONCE_ED(m_msg) \
-	if (true) { \
+	GD_NOEXPAND_WRAPPER_BEGIN \
 		static bool warning_shown = false; \
 		if (unlikely(!warning_shown)) { \
 			warning_shown = true; \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, m_msg, true, ERR_HANDLER_WARNING); \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, m_msg, true, ERR_HANDLER_WARNING); \
 		} \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Warns about `m_msg` only when verbose mode is enabled.
  */
 #define WARN_VERBOSE(m_msg) \
-	{ \
+	GD_NOEXPAND_WRAPPER_BEGIN \
 		if (is_print_verbose_enabled()) { \
 			WARN_PRINT(m_msg); \
 		} \
-	}
+	GD_NOEXPAND_WRAPPER_END
 
 // Print deprecated warning message macros.
 
@@ -759,27 +777,25 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Warns that the current function is deprecated.
  */
 #define WARN_DEPRECATED \
-	if (true) { \
+	GD_NOEXPAND_WRAPPER_BEGIN \
 		static bool warning_shown = false; \
 		if (unlikely(!warning_shown)) { \
 			warning_shown = true; \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", false, ERR_HANDLER_WARNING); \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", false, ERR_HANDLER_WARNING); \
 		} \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Warns that the current function is deprecated and prints `m_msg`.
  */
 #define WARN_DEPRECATED_MSG(m_msg) \
-	if (true) { \
+	GD_NOEXPAND_WRAPPER_BEGIN \
 		static bool warning_shown = false; \
 		if (unlikely(!warning_shown)) { \
 			warning_shown = true; \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, false, ERR_HANDLER_WARNING); \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "This method has been deprecated and will be removed in the future.", m_msg, false, ERR_HANDLER_WARNING); \
 		} \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Do not use.
@@ -788,12 +804,11 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * The application crashes.
  */
 #define CRASH_NOW() \
-	if (true) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed."); \
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "FATAL: Method/function failed."); \
 		_err_flush_stdout(); \
 		GENERATE_TRAP(); \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Only use if the application should never reach this point.
@@ -801,12 +816,11 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * Prints `m_msg`, and then the application crashes.
  */
 #define CRASH_NOW_MSG(m_msg) \
-	if (true) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method/function failed.", m_msg); \
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "FATAL: Method/function failed.", m_msg); \
 		_err_flush_stdout(); \
 		GENERATE_TRAP(); \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 
 /**
  * Note: IN MOST CASES YOU SHOULD NOT USE THIS MACRO.
@@ -825,28 +839,26 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  */
 #ifdef DEV_ENABLED
 #define DEV_ASSERT(m_cond) \
-	if (unlikely(!(m_cond))) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
-		_err_flush_stdout(); \
-		GENERATE_TRAP(); \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(!(m_cond))) { \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
+			_err_flush_stdout(); \
+			GENERATE_TRAP(); \
+		} \
+	GD_NOEXPAND_WRAPPER_END
 #else
-#define DEV_ASSERT(m_cond)
+#define DEV_ASSERT(m_cond) GD_FORCE_SEMICOLON
 #endif
 
 #ifdef DEV_ENABLED
 #define DEV_CHECK_ONCE(m_cond) \
-	if (true) { \
-		static bool first_print = true; \
-		if (first_print && unlikely(!(m_cond))) { \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "DEV_CHECK_ONCE failed  \"" _STR(m_cond) "\" is false."); \
-			first_print = false; \
+	GD_NOEXPAND_WRAPPER_BEGIN \
+		if (unlikely(!(m_cond))) { \
+			ERR_PRINT_ONCE("DEV_CHECK_ONCE failed  \"" _STR(m_cond) "\" is false."); \
 		} \
-	} else \
-		((void)0)
+	GD_NOEXPAND_WRAPPER_END
 #else
-#define DEV_CHECK_ONCE(m_cond)
+#define DEV_CHECK_ONCE(m_cond) GD_FORCE_SEMICOLON
 #endif
 
 /**
@@ -854,7 +866,7 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * These are spam protection warnings.
  */
 #define PHYSICS_INTERPOLATION_NODE_WARNING(m_object_id, m_string) \
-	_physics_interpolation_warning(FUNCTION_STR, __FILE__, __LINE__, m_object_id, m_string)
+	_physics_interpolation_warning(__FUNCTION__, __FILE__, __LINE__, m_object_id, m_string)
 
 #define PHYSICS_INTERPOLATION_WARNING(m_string) \
-	_physics_interpolation_warning(FUNCTION_STR, __FILE__, __LINE__, ObjectID(UINT64_MAX), m_string)
+	_physics_interpolation_warning(__FUNCTION__, __FILE__, __LINE__, ObjectID(UINT64_MAX), m_string)

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1722,7 +1722,7 @@ void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 	}
 
 	Joypad &joy = joy_names[p_device];
-	ERR_FAIL_INDEX((int)p_button, (int)JoyButton::MAX);
+	ERR_FAIL_INDEX(p_button, JoyButton::MAX);
 
 	if (joy.last_buttons[(size_t)p_button] == p_pressed) {
 		return;
@@ -1753,7 +1753,7 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, float p_value) {
 		return;
 	}
 
-	ERR_FAIL_INDEX((int)p_axis, (int)JoyAxis::MAX);
+	ERR_FAIL_INDEX(p_axis, JoyAxis::MAX);
 
 	Joypad &joy = joy_names[p_device];
 

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1165,7 +1165,7 @@ bool ResourceLoader::_ensure_load_progress() {
 }
 
 void ResourceLoader::resource_changed_connect(Resource *p_source, const Callable &p_callable, uint32_t p_flags) {
-	print_lt(vformat("%d\t%ud:%s\t" FUNCTION_STR "\t%d", Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class(), p_callable.get_object_id()));
+	print_lt(vformat("%d\t%ud:%s\t" __FUNCTION__ "\t%d", Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class(), p_callable.get_object_id()));
 
 	MutexLock lock(thread_load_mutex);
 
@@ -1184,7 +1184,7 @@ void ResourceLoader::resource_changed_connect(Resource *p_source, const Callable
 }
 
 void ResourceLoader::resource_changed_disconnect(Resource *p_source, const Callable &p_callable) {
-	print_lt(vformat("%d\t%ud:%s\t" FUNCTION_STR "t%d", Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class(), p_callable.get_object_id()));
+	print_lt(vformat("%d\t%ud:%s\t" __FUNCTION__ "t%d", Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class(), p_callable.get_object_id()));
 
 	MutexLock lock(thread_load_mutex);
 
@@ -1199,7 +1199,7 @@ void ResourceLoader::resource_changed_disconnect(Resource *p_source, const Calla
 }
 
 void ResourceLoader::resource_changed_emit(Resource *p_source) {
-	print_lt(vformat("%d\t%ud:%s\t" FUNCTION_STR, Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class()));
+	print_lt(vformat("%d\t%ud:%s\t" __FUNCTION__, Thread::get_caller_id(), p_source->get_instance_id(), p_source->get_class()));
 
 	MutexLock lock(thread_load_mutex);
 

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -651,7 +651,6 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			ERR_FAIL_V_MSG(Vector3(), "Invalid parameter for get_euler(order)");
 		}
 	}
-	return Vector3();
 }
 
 void Basis::set_euler(const Vector3 &p_euler, EulerOrder p_order) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -1153,7 +1153,7 @@ public:
 
 #define TMPL_EXTRACT_PARAM_OR_FAIL(m_name, m_param, m_retval, m_msg, m_editor) \
 	if (unlikely(m_param._is_null_dont_use())) { \
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Required object \"" _STR(m_param) "\" is null.", m_msg, m_editor); \
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Required object \"" _STR(m_param) "\" is null.", m_msg, m_editor); \
 		return m_retval; \
 	} \
 	typename std::decay_t<decltype(m_param)>::extracted_type m_name = m_param._internal_ptr_dont_use(); \

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -145,6 +145,17 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #define _LIFETIME_BOUND_
 #endif
 
+// Some of our macros require a trailing semicolon; appending this to the end of a macro
+// enforces that behavior without increasing build size or compilation time whatsoever.
+#define GD_FORCE_SEMICOLON static_assert(true)
+
+// Ensure that macro replacement does not trigger unexpected issues when expanded by
+// constraining them to "if" wrappers. e.g. `if (cond) SOME_MACRO();` without braces.
+/* clang-format off */
+#define GD_NOEXPAND_WRAPPER_BEGIN if constexpr (true) {
+#define GD_NOEXPAND_WRAPPER_END } else GD_FORCE_SEMICOLON
+/* clang-format on */
+
 // Make room for our constexpr's below by overriding potential system-specific macros.
 #undef SIGN
 #undef MIN

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -138,7 +138,7 @@ RenderingContextDriverVulkan::VkTrackedObjectType vk_object_to_tracked_object(Vk
 			case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
 				return RenderingContextDriverVulkan::VK_TRACKED_OBJECT_TYPE_ACCELERATION_STRUCTURE;
 			default:
-				_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Unknown VkObjectType enum value " + itos((uint32_t)p_type) + ".Please add it to VkTrackedObjectType, switch statement in "
+				_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Unknown VkObjectType enum value " + itos((uint32_t)p_type) + ".Please add it to VkTrackedObjectType, switch statement in "
 																																 "vk_object_to_tracked_object and get_tracked_object_name.",
 						(int)p_type);
 				return (RenderingContextDriverVulkan::VkTrackedObjectType)VK_OBJECT_TYPE_UNKNOWN;

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -6927,7 +6927,7 @@ void RenderingDeviceDriverVulkan::command_insert_breadcrumb(CommandBufferID p_cm
 
 void RenderingDeviceDriverVulkan::on_device_lost() const {
 	if (device_functions.GetDeviceFaultInfoEXT == nullptr) {
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "VK_EXT_device_fault not available.");
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "VK_EXT_device_fault not available.");
 		return;
 	}
 
@@ -6936,7 +6936,7 @@ void RenderingDeviceDriverVulkan::on_device_lost() const {
 	VkResult vkres = device_functions.GetDeviceFaultInfoEXT(vk_device, &fault_counts, nullptr);
 
 	if (vkres != VK_SUCCESS) {
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "vkGetDeviceFaultInfoEXT returned " + itos(vkres) + " when getting fault count, skipping VK_EXT_device_fault report...");
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "vkGetDeviceFaultInfoEXT returned " + itos(vkres) + " when getting fault count, skipping VK_EXT_device_fault report...");
 		return;
 	}
 
@@ -6953,7 +6953,7 @@ void RenderingDeviceDriverVulkan::on_device_lost() const {
 	fault_counts.vendorBinarySize = 0;
 	vkres = device_functions.GetDeviceFaultInfoEXT(vk_device, &fault_counts, &fault_info);
 	if (vkres != VK_SUCCESS) {
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "vkGetDeviceFaultInfoEXT returned " + itos(vkres) + " when getting fault info, skipping VK_EXT_device_fault report...");
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "vkGetDeviceFaultInfoEXT returned " + itos(vkres) + " when getting fault info, skipping VK_EXT_device_fault report...");
 	} else {
 		err_msg += "** Report from VK_EXT_device_fault **";
 		err_msg += "\nDescription: " + String(fault_info.description);
@@ -6990,7 +6990,7 @@ void RenderingDeviceDriverVulkan::on_device_lost() const {
 		}
 	}
 
-	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, err_msg);
+	_err_print_error(__FUNCTION__, __FILE__, __LINE__, err_msg);
 
 	if (fault_info.pVendorInfos) {
 		memfree(fault_info.pVendorInfos);
@@ -6999,7 +6999,7 @@ void RenderingDeviceDriverVulkan::on_device_lost() const {
 		memfree(fault_info.pAddressInfos);
 	}
 
-	_err_print_error(FUNCTION_STR, __FILE__, __LINE__, context_driver->get_driver_and_device_memory_report());
+	_err_print_error(__FUNCTION__, __FILE__, __LINE__, context_driver->get_driver_and_device_memory_report());
 }
 
 void RenderingDeviceDriverVulkan::print_lost_device_info() {
@@ -7009,7 +7009,7 @@ void RenderingDeviceDriverVulkan::print_lost_device_info() {
 		if (!Engine::get_singleton()->is_accurate_breadcrumbs_enabled()) {
 			error_msg += "\nSome of them might be inaccurate. Try running with --accurate-breadcrumbs for precise information.";
 		}
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, error_msg);
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, error_msg);
 	}
 
 	uint8_t *breadcrumb_ptr = nullptr;
@@ -7117,7 +7117,7 @@ void RenderingDeviceDriverVulkan::print_lost_device_info() {
 		vmaUnmapMemory(allocator, ((BufferInfo *)breadcrumb_buffer.id)->allocation.handle);
 		breadcrumb_ptr = nullptr;
 	} else {
-		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Couldn't map breadcrumb buffer. VkResult = " + itos(map_result));
+		_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Couldn't map breadcrumb buffer. VkResult = " + itos(map_result));
 	}
 #endif
 	on_device_lost();

--- a/misc/utility/clang_format_glsl.yml
+++ b/misc/utility/clang_format_glsl.yml
@@ -37,6 +37,8 @@ JavaImportGroups:
   - java
   - javax
 KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ^GD_NOEXPAND_WRAPPER_BEGIN$
+MacroBlockEnd: ^GD_NOEXPAND_WRAPPER_END$
 ObjCBlockIndentWidth: 4
 PackConstructorInitializers: NextLine
 RemoveSemicolon: false # Differs from base .clang-format

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -673,7 +673,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #define GD_ERR_BREAK(m_cond) \
 	{ \
 		if (unlikely(m_cond)) { \
-			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:"); \
+			_err_print_error(__FUNCTION__, __FILE__, __LINE__, "Condition ' " _STR(m_cond) " ' is true. Breaking..:"); \
 			OPCODE_BREAK; \
 		} \
 	}

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -212,7 +212,7 @@ Error WSLPeer::_do_server_handshake() {
 	if (use_tls) {
 		Ref<StreamPeerTLS> tls = static_cast<Ref<StreamPeerTLS>>(connection);
 		if (tls.is_null()) {
-			ERR_FAIL_V_MSG(ERR_BUG, "Couldn't get StreamPeerTLS for WebSocket handshake.");
+			ERR_PRINT("Couldn't get StreamPeerTLS for WebSocket handshake.");
 			close(-1);
 			return FAILED;
 		}

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -932,12 +932,12 @@ Error Node::rpc_id(int p_peer_id, const StringName &p_method, VarArgs... p_args)
 }
 
 #ifdef DEBUG_ENABLED
-#define ERR_THREAD_GUARD ERR_FAIL_COND_MSG(!is_accessible_from_caller_thread(), vformat("%s: The caller thread can't call the function `%s()` on this node. Use `call_deferred()` or `call_deferred_thread_group()` instead.", get_description(), FUNCTION_STR));
-#define ERR_THREAD_GUARD_V(m_ret) ERR_FAIL_COND_V_MSG(!is_accessible_from_caller_thread(), (m_ret), vformat("%s: The caller thread can't call the function `%s()` on this node. Use `call_deferred()` or `call_deferred_thread_group()` instead.", get_description(), FUNCTION_STR));
-#define ERR_MAIN_THREAD_GUARD ERR_FAIL_COND_MSG(is_inside_tree() && !is_current_thread_safe_for_nodes(), vformat("%s: The function `%s()` on this node can only be accessed from the main thread. Use `call_deferred()` instead.", get_description(), FUNCTION_STR));
-#define ERR_MAIN_THREAD_GUARD_V(m_ret) ERR_FAIL_COND_V_MSG(is_inside_tree() && !is_current_thread_safe_for_nodes(), (m_ret), vformat("%s: The function `%s()` on this node can only be accessed from the main thread. Use `call_deferred()` instead.", get_description(), FUNCTION_STR));
-#define ERR_READ_THREAD_GUARD ERR_FAIL_COND_MSG(!is_readable_from_caller_thread(), vformat("%s: The function `%s()` on this node can only be accessed from either the main thread or a thread group. Use `call_deferred()` instead.", get_description(), FUNCTION_STR));
-#define ERR_READ_THREAD_GUARD_V(m_ret) ERR_FAIL_COND_V_MSG(!is_readable_from_caller_thread(), (m_ret), vformat("%s: The function `%s()` on this node can only be accessed from either the main thread or a thread group. Use `call_deferred()` instead.", get_description(), FUNCTION_STR));
+#define ERR_THREAD_GUARD ERR_FAIL_COND_MSG(!is_accessible_from_caller_thread(), vformat("%s: The caller thread can't call the function `%s()` on this node. Use `call_deferred()` or `call_deferred_thread_group()` instead.", get_description(), __FUNCTION__));
+#define ERR_THREAD_GUARD_V(m_ret) ERR_FAIL_COND_V_MSG(!is_accessible_from_caller_thread(), (m_ret), vformat("%s: The caller thread can't call the function `%s()` on this node. Use `call_deferred()` or `call_deferred_thread_group()` instead.", get_description(), __FUNCTION__));
+#define ERR_MAIN_THREAD_GUARD ERR_FAIL_COND_MSG(is_inside_tree() && !is_current_thread_safe_for_nodes(), vformat("%s: The function `%s()` on this node can only be accessed from the main thread. Use `call_deferred()` instead.", get_description(), __FUNCTION__));
+#define ERR_MAIN_THREAD_GUARD_V(m_ret) ERR_FAIL_COND_V_MSG(is_inside_tree() && !is_current_thread_safe_for_nodes(), (m_ret), vformat("%s: The function `%s()` on this node can only be accessed from the main thread. Use `call_deferred()` instead.", get_description(), __FUNCTION__));
+#define ERR_READ_THREAD_GUARD ERR_FAIL_COND_MSG(!is_readable_from_caller_thread(), vformat("%s: The function `%s()` on this node can only be accessed from either the main thread or a thread group. Use `call_deferred()` instead.", get_description(), __FUNCTION__));
+#define ERR_READ_THREAD_GUARD_V(m_ret) ERR_FAIL_COND_V_MSG(!is_readable_from_caller_thread(), (m_ret), vformat("%s: The function `%s()` on this node can only be accessed from either the main thread or a thread group. Use `call_deferred()` instead.", get_description(), __FUNCTION__));
 #else
 #define ERR_THREAD_GUARD
 #define ERR_THREAD_GUARD_V(m_ret)


### PR DESCRIPTION
- Supersedes #89485
- Supersedes #89487 

The scope of the latter PR got large enough to the point it warranted a new PR entirely. The following improvements have been integrated:
- Add `FORCE_SEMICOLON` macro as alternative to `(void(0))`, which is universally applicable and doesn't affect build size or compile time.
- Add `NOEXPAND_WRAPPER_BEGIN` and `NOEXPAND_WRAPPER_END` macros to streamline & standardize the syntax we use to enforce semicolons and ensure safely scoped macros.
- Add aforementioned macros to `.clang-format` so they're recognized as wrappers & will properly indent as such.
- Made the wrappers evaluate in a `constexpr` context; binary size is (potentially) saved & more compile-time errors can be discovered.
- Remove `-Wno-return-type` from GCC common warnings, as a `constexpr` branch lacks the ambiguity shown in the original issue.
- Index error macros now cast their `0` to the type of the index & index/size arguments to `int64_t` when passed to `_err_print_index_error`; this allows enum classes to be passed.
- Remove `FUNCTION_STR`, as it's been identical to the builtin `__FUNCTION__` for over a decade.