### PR TITLE
Don't print error when updating terrains tree without layer

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -3345,7 +3345,9 @@ void TileMapLayerEditorTerrainsPlugin::_update_terrains_tree() {
 	terrains_tree->create_item();
 
 	const TileMapLayer *edited_layer = _get_edited_layer();
-	ERR_FAIL_NULL(edited_layer);
+	if (!edited_layer) {
+		return;
+	}
 
 	Ref<TileSet> tile_set = edited_layer->get_tile_set();
 	if (tile_set.is_null()) {


### PR DESCRIPTION
Closes #100007
Other methods already don't print error, so I don't see why this one should.
https://github.com/godotengine/godot/blob/bdf625bd54958c737fa6b7213b07581cc91059ad/editor/plugins/tiles/tile_map_layer_editor.cpp#L3278-L3281
https://github.com/godotengine/godot/blob/bdf625bd54958c737fa6b7213b07581cc91059ad/editor/plugins/tiles/tile_map_layer_editor.cpp#L3392-L3395