### PR TITLE
Stop AudioStreamPlayback only if it's not playing

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1272,7 +1272,9 @@ void AudioServer::stop_playback_stream(Ref<AudioStreamPlayback> p_playback) {
 		return;
 	}
 
-	p_playback->stop();
+	if (!p_playback->is_playing()) {
+		p_playback->stop();
+	}
 
 	AudioStreamPlaybackListNode *playback_node = _find_playback_list_node(p_playback);
 	if (!playback_node) {


### PR DESCRIPTION
This PRs adds a check to make sure to not stop an active audio stream playback.

Fixes #100819
May fix #100173 (could not reproduce personally)
Does not introduce a regression about #97466