### PR TITLE
Make the GridMap editor cursor translucent

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1286,6 +1286,10 @@ void GridMapEditor::_update_cursor_instance() {
 		cursor_outer_mat->set_albedo(Color(pick_color, 0.8));
 		cursor_instance = RenderingServer::get_singleton()->instance_create2(cursor_mesh, get_tree()->get_root()->get_world_3d()->get_scenario());
 	}
+
+	// Make the cursor translucent so that it can be distinguished from already-placed tiles.
+	RenderingServer::get_singleton()->instance_geometry_set_transparency(cursor_instance, 0.5);
+
 	_update_cursor_transform();
 }
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/101101 (can be merged independently).

This makes it possible to distinguish GridMap tiles that haven't been placed yet from those that are already in place.

Tested with all transparency modes on the source mesh material.

## Preview

https://github.com/user-attachments/assets/a77f94f1-1636-45f3-95db-2829a9fbeda4


