### PR TITLE
Fix FileSystem Bottom Panel's toggle shortcut conflict

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8197,7 +8197,7 @@ EditorNode::EditorNode() {
 	editor_dock_manager->add_dock(ImportDock::get_singleton(), TTRC("Import"), EditorDockManager::DOCK_SLOT_LEFT_UR, ED_SHORTCUT_AND_COMMAND("docks/open_import", TTRC("Open Import Dock")), "FileAccess");
 
 	// FileSystem: Bottom left.
-	editor_dock_manager->add_dock(FileSystemDock::get_singleton(), TTRC("FileSystem"), EditorDockManager::DOCK_SLOT_LEFT_BR, ED_SHORTCUT_AND_COMMAND("docks/open_filesystem", TTRC("Open FileSystem Dock"), KeyModifierMask::ALT | Key::F), "Folder");
+	editor_dock_manager->add_dock(FileSystemDock::get_singleton(), TTRC("FileSystem"), EditorDockManager::DOCK_SLOT_LEFT_BR, ED_SHORTCUT_AND_COMMAND("docks/open_filesystem", TTRC("Open FileSystem Dock"), KeyModifierMask::ALT | Key::T), "Folder");
 
 	// Inspector: Full height right.
 	editor_dock_manager->add_dock(InspectorDock::get_singleton(), TTRC("Inspector"), EditorDockManager::DOCK_SLOT_RIGHT_UL, ED_SHORTCUT_AND_COMMAND("docks/open_inspector", TTRC("Open Inspector Dock")), "AnimationTrackList");


### PR DESCRIPTION
The default shortcut key for toggling the Bottom Panel's FileSystem conflicted with multiple other shortcuts using the same `ALT+F` key combination.
When docked at the Bottom Panel, the Fold/Unfold Line shortcut (`ALT+F`) used to conflict with the key to toggle the FileSystem when focused inside a script.

- Fixed by changing the key from `ALT+F` to `ALT+T`, as requested by the author of the issue.

Tested the solution by docking the FileSystem at the Bottom Panel, and trying the new shortcut while focusing inside a script.

Fixes #100779