### PR TITLE
[1.0] Build fixes for modern toolchains + new official `1.0-stable` binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ drivers/gles2/shaders/*.h
 modules/register_module_types.cpp
 core/version.h
 core/method_bind.inc
+core/method_bind_ext.inc
 core/script_encryption_key.cpp
 core/global_defaults.cpp
 tools/editor/register_exporters.cpp

--- a/SConstruct
+++ b/SConstruct
@@ -189,6 +189,21 @@ if selected_platform in platform_list:
 
 	detect.configure(env)
 
+	# Set our C and C++ standard requirements.
+	# Prepending to make it possible to override.
+	# This MSVC "detection" is an extreme hack.
+	is_msvc = (os.name=="nt") and (os.getenv("VSINSTALLDIR")!=None or os.getenv("VCINSTALLDIR")!=None) and (selected_platform in ["windows", "winrt"])
+	if (not is_msvc):
+		# Specifying GNU extensions support explicitly, which are supported by both GCC and Clang.
+		# We don't support C++17 so stick to earlier standards.
+		# Godot 1.0 definitely started as a C++98 codebase.
+		env.Prepend(CFLAGS=["-std=gnu11"])
+		env.Prepend(CXXFLAGS=["-std=gnu++98"])
+		# Disable these auto-enabled warnings which are treated as errors by modern compilers.
+		env.Prepend(CCFLAGS=["-Wno-error=implicit-function-declaration", "-Wno-error=incompatible-pointer-types"])
+	else:
+		# MSVC doesn't support setting C++ to pre-C++14 standards, so do nothing and hope it works.
+		pass
 
 	flag_list = platform_flags[selected_platform]
 	for f in flag_list:

--- a/drivers/gl_context/glew-remove-glu-dependency.patch
+++ b/drivers/gl_context/glew-remove-glu-dependency.patch
@@ -1,0 +1,22 @@
+diff --git a/drivers/gl_context/glew.h b/drivers/gl_context/glew.h
+index 4eed47708f..5f937862bf 100644
+--- a/drivers/gl_context/glew.h
++++ b/drivers/gl_context/glew.h
+@@ -1168,12 +1168,17 @@ GLAPI void GLAPIENTRY glViewport (GLint x, GLint y, GLsizei width, GLsizei heigh
+ 
+ /* ---------------------------------- GLU ---------------------------------- */
+ 
++// -- GODOT start --
++// We don't use GLU, so remove a dependency.
++#if 0
+ /* this is where we can safely include GLU */
+ #if defined(__APPLE__) && defined(__MACH__)
+ #include <OpenGL/glu.h>
+ #else
+ #include <GL/glu.h>
+ #endif
++#endif
++// -- GODOT end --
+ 
+ /* ----------------------------- GL_VERSION_1_2 ---------------------------- */
+ 

--- a/drivers/gl_context/glew.h
+++ b/drivers/gl_context/glew.h
@@ -1168,12 +1168,17 @@ GLAPI void GLAPIENTRY glViewport (GLint x, GLint y, GLsizei width, GLsizei heigh
 
 /* ---------------------------------- GLU ---------------------------------- */
 
+// -- GODOT start --
+// We don't use GLU, so remove a dependency.
+#if 0
 /* this is where we can safely include GLU */
 #if defined(__APPLE__) && defined(__MACH__)
 #include <OpenGL/glu.h>
 #else
 #include <GL/glu.h>
 #endif
+#endif
+// -- GODOT end --
 
 /* ----------------------------- GL_VERSION_1_2 ---------------------------- */
 

--- a/methods.py
+++ b/methods.py
@@ -42,6 +42,7 @@ def build_shader_header( target, source, env ):
 			line=fs.readline()
 			
 		fd.write(";\n")
+		fd.close()
 			
 	return 0
 		
@@ -1098,6 +1099,7 @@ def update_version():
 	f.write("#define VERSION_MINOR "+str(version.minor)+"\n")
 	f.write("#define VERSION_REVISION "+str(rev)+"\n")
 	f.write("#define VERSION_STATUS "+str(version.status)+"\n")
+	f.close()
 
 def parse_cg_file(fname, uniforms, sizes, conditionals):
 
@@ -1167,8 +1169,8 @@ def build_cg_shader(sname):
 		fd.write('\t\tVP_%s,\n' % vp_uniforms[i].upper())
 
 	fd.write("\t};\n");
+	fd.close()
 
-		
 
 import glob
 def detect_modules():
@@ -1219,6 +1221,7 @@ void unregister_module_types() {
 
 	f=open("modules/register_module_types.cpp","wb")
 	f.write(modules_cpp)
+	f.close()
 
 	return module_list
 
@@ -1315,4 +1318,5 @@ def save_active_platforms(apnames,ap):
 		wf = x+"/logo.h"
 		logow = open(wf,"wb")
 		logow.write(str)
+		logow.close()
 

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -57,6 +57,7 @@ pp_baseout = open(abspath+"/java/AndroidManifest.xml","wb")
 manifest = pp_basein.read()
 manifest = manifest.replace("$$ADD_APPLICATION_CHUNKS$$",env.android_manifest_chunk)
 pp_baseout.write( manifest )
+pp_baseout.close()
 
 
 for x in env.android_source_files:

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -150,7 +150,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-D_DEBUG', '-g1', '-Wall', '-O0', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-D_DEBUG', '-g1', '-O0', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
 
 	if env["armv6"] == "no" and env['x86'] != 'yes':

--- a/platform/flash/detect.py
+++ b/platform/flash/detect.py
@@ -98,7 +98,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-D_DEBUG', '-g0', '-Wall', '-O0', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-D_DEBUG', '-g0', '-O0', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
 
 	env.Append(CPPFLAGS=['-DFLASH_ENABLED', '-DGLES1_ENABLED', '-DNO_FCNTL', '-DUNIX_ENABLED'])

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -54,7 +54,7 @@ def configure(env):
 	env['AR'] = 'ar'
 
 	import string
-	#env['CCFLAGS'] = string.split('-arch armv7 -Wall  -fno-strict-aliasing -fno-common -D__IPHONE_OS_VERSION_MIN_REQUIRED=20000 -isysroot $IPHONESDK -fvisibility=hidden -mmacosx-version-min=10.5 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\" -DNO_THUMB')
+	#env['CCFLAGS'] = string.split('-arch armv7 -fno-strict-aliasing -fno-common -D__IPHONE_OS_VERSION_MIN_REQUIRED=20000 -isysroot $IPHONESDK -fvisibility=hidden -mmacosx-version-min=10.5 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\" -DNO_THUMB')
 	env['CCFLAGS'] = string.split('-fno-objc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -Wno-trigraphs -fpascal-strings -Wmissing-prototypes -Wreturn-type -Wparentheses -Wswitch -Wno-unused-parameter -Wunused-variable -Wunused-value -Wno-shorten-64-to-32 -isysroot /Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.0.sdk -gdwarf-2 -fvisibility=hidden -Wno-sign-conversion -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -miphoneos-version-min=4.3 -MMD -MT dependencies -isysroot $IPHONESDK')
 
 
@@ -95,17 +95,17 @@ def configure(env):
 
 	if (env["target"]=="release"):
 
-		env.Append(CCFLAGS=['-O3', '-ffast-math', '-DNS_BLOCK_ASSERTIONS=1','-Wall'])
+		env.Append(CCFLAGS=['-O3', '-ffast-math', '-DNS_BLOCK_ASSERTIONS=1'])
 		env.Append(LINKFLAGS=['-O3', '-ffast-math'])
 
 	elif env["target"] == "release_debug":
-		env.Append(CCFLAGS=['-Os', '-ffast-math', '-DNS_BLOCK_ASSERTIONS=1','-Wall','-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-Os', '-ffast-math', '-DNS_BLOCK_ASSERTIONS=1','-DDEBUG_ENABLED'])
 		env.Append(LINKFLAGS=['-Os', '-ffast-math'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ENABLED'])
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-D_DEBUG', '-DDEBUG=1', '-gdwarf-2', '-Wall', '-O0', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-D_DEBUG', '-DDEBUG=1', '-gdwarf-2', '-O0', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ENABLED'])
 
 	elif (env["target"]=="profile"):

--- a/platform/isim/detect.py
+++ b/platform/isim/detect.py
@@ -51,7 +51,7 @@ def configure(env):
 	env['AR'] = 'ar'
 
 	import string
-	env['CCFLAGS'] = string.split('-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fasm-blocks  -Wall -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $ISIMSDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"')
+	env['CCFLAGS'] = string.split('-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fasm-blocks -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $ISIMSDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"')
 
 	env.Append(LINKFLAGS=['-arch', 'i386',
 							'-mios-simulator-version-min=4.3',
@@ -84,7 +84,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-DDEBUG', '-D_DEBUG', '-gdwarf-2', '-Wall', '-O0', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-DDEBUG', '-D_DEBUG', '-gdwarf-2', '-O0', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
 
 	elif (env["target"]=="profile"):

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -70,7 +70,7 @@ def configure(env):
 		env.Append(CCFLAGS=['-O2','-DDEBUG_ENABLED'])
 
 	elif (env["target"]=="debug"):
-		env.Append(CCFLAGS=['-D_DEBUG', '-Wall', '-O2', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-D_DEBUG', '-O2', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
 
 	env.Append(CPPFLAGS=["-fno-exceptions",'-DNO_SAFE_CAST','-fno-rtti'])

--- a/platform/nacl/detect.py
+++ b/platform/nacl/detect.py
@@ -54,7 +54,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-g', '-O0', '-Wall','-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-g', '-O0', '-DDEBUG_ENABLED'])
 
 
 	elif (env["target"]=="profile"):

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -51,7 +51,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-g3', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+		env.Append(CCFLAGS=['-g3', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
 
 	if (env["freetype"]!="no"):

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -11,16 +11,16 @@ def get_name():
 
 def can_build():
 
-	if (sys.platform != "darwin"):
-		return False
+	if (sys.platform == "darwin" or ("OSXCROSS_ROOT" in os.environ)):
+		return True
 
-	return True # osx enabled
+	return False
 
 def get_opts():
 
 	return [
 	    ('force_64_bits','Force 64 bits binary','no'),
-
+	    ('osxcross_sdk', 'OSXCross SDK version', 'darwin14'),
 	 ]
 
 def get_flags():
@@ -59,12 +59,25 @@ def configure(env):
 		env.Append(CPPPATH=['#tools/freetype'])
 		env.Append(CPPPATH=['#tools/freetype/freetype/include'])
 
-	if (env["bits"]=="64"):
-		env.Append(CCFLAGS=['-arch', 'x86_64'])
-		env.Append(LINKFLAGS=['-arch', 'x86_64'])
+	if ("OSXCROSS_ROOT" not in os.environ):
+		# regular native build
+		if (env["bits"]=="64"):
+			env.Append(CCFLAGS=['-arch', 'x86_64'])
+			env.Append(LINKFLAGS=['-arch', 'x86_64'])
+		else:
+			env.Append(CCFLAGS=['-arch', 'i386'])
+			env.Append(LINKFLAGS=['-arch', 'i386'])
 	else:
-		env.Append(CCFLAGS=['-arch', 'i386'])
-		env.Append(LINKFLAGS=['-arch', 'i386'])
+		# osxcross build
+		root = os.environ.get("OSXCROSS_ROOT", 0)
+		arch = "i686" if env["bits"]=="32" else "x86_64"
+		basecmd = root + "/target/bin/" + arch + "-apple-" + env["osxcross_sdk"] + "-"
+
+		env['CC'] = basecmd + "cc"
+		env['CXX'] = basecmd + "c++"
+		env['AR'] = basecmd + "ar"
+		env['RANLIB'] = basecmd + "ranlib"
+		env['AS'] = basecmd + "as"
 
 #	env.Append(CPPPATH=['#platform/osx/include/freetype2', '#platform/osx/include'])
 #	env.Append(LIBPATH=['#platform/osx/lib'])

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -66,7 +66,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-g2', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+		env.Append(CCFLAGS=['-g2', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
 	env.Append(CPPFLAGS=['-DSERVER_ENABLED','-DUNIX_ENABLED'])
 	env.Append(LIBS=['pthread','z']) #TODO detect linux/BSD!

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -27,8 +27,10 @@ def get_opts():
 def get_flags():
 
 	return [
-	('builtin_zlib', 'no'),
-	('theora','no'), #use builtin openssl
+	('builtin_zlib', 'yes'),
+	('openssl', 'builtin'),
+	("freetype", "builtin"),
+	('theora','no'),
 	]
 			
 
@@ -68,8 +70,22 @@ def configure(env):
 
 		env.Append(CCFLAGS=['-g2', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
+
+	if (env["openssl"]=="yes"):
+		env.ParseConfig('pkg-config openssl --cflags --libs')
+
+	if (env["freetype"]!="no"):
+		env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
+		if (env["freetype"]=="builtin"):
+			env.Append(CPPPATH=['#tools/freetype'])
+			env.Append(CPPPATH=['#tools/freetype/freetype/include'])
+		else:
+			env.ParseConfig('pkg-config freetype2 --cflags --libs')
+
 	env.Append(CPPFLAGS=['-DSERVER_ENABLED','-DUNIX_ENABLED'])
-	env.Append(LIBS=['pthread','z']) #TODO detect linux/BSD!
+	env.Append(LIBS=['pthread']) #TODO detect linux/BSD!
+	if (env["builtin_zlib"]=="no"):
+		env.Append(LIBS=['z'])
 
 	if (env["CXX"]=="clang++"):
 		env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -26,8 +26,8 @@ def can_build():
 			
 	if (os.name=="posix"):
 
-		mingw = "i586-mingw32msvc-"
-		mingw64 = "i686-w64-mingw32-"
+		mingw = "i686-w64-mingw32-"
+		mingw64 = "x86_64-w64-mingw32-"
 		if (os.getenv("MINGW32_PREFIX")):
 			mingw=os.getenv("MINGW32_PREFIX")
 		if (os.getenv("MINGW64_PREFIX")):
@@ -45,8 +45,8 @@ def get_opts():
 	mingw=""
 	mingw64=""
 	if (os.name!="nt"):
-		mingw = "i586-mingw32msvc-"
-		mingw64 = "i686-w64-mingw32-"
+		mingw = "i686-w64-mingw32-"
+		mingw64 = "x86_64-w64-mingw32-"
 		if (os.getenv("MINGW32_PREFIX")):
 			mingw=os.getenv("MINGW32_PREFIX")
 		if (os.getenv("MINGW64_PREFIX")):

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -188,7 +188,7 @@ def configure(env):
 
 		elif (env["target"]=="debug"):
 					
-			env.Append(CCFLAGS=['-g', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+			env.Append(CCFLAGS=['-g', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
 		if (env["freetype"]!="no"):
 			env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -29,11 +29,6 @@ def can_build():
 		print("X11 not found.. x11 disabled.")
 		return False
 
-        ssl_error=os.system("pkg-config openssl --modversion > /dev/null ")
-        if (ssl_error):
-                print("OpenSSL not found.. x11 disabled.")
-                return False
-
 	x11_error=os.system("pkg-config xcursor --modversion > /dev/null ")
 	if (x11_error):
 		print("xcursor not found.. x11 disabled.")
@@ -52,8 +47,9 @@ def get_opts():
 def get_flags():
 
 	return [
-	('builtin_zlib', 'no'),
-	("openssl", "yes"),
+	('builtin_zlib', 'yes'),
+	("openssl", "builtin"),
+	("freetype", "builtin"),
 	("theora","no"),
         ]
 			
@@ -101,31 +97,38 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-g2', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+		env.Append(CCFLAGS=['-g2', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
 	env.ParseConfig('pkg-config x11 --cflags --libs')
 	env.ParseConfig('pkg-config xcursor --cflags --libs')
-	env.ParseConfig('pkg-config openssl --cflags --libs')
 
+	if (env["openssl"]=="yes"):
+		env.ParseConfig('pkg-config openssl --cflags --libs')
 
-	env.ParseConfig('pkg-config freetype2 --cflags --libs')
-	env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
+	if (env["freetype"]!="no"):
+		env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
+		if (env["freetype"]=="builtin"):
+			env.Append(CPPPATH=['#tools/freetype'])
+			env.Append(CPPPATH=['#tools/freetype/freetype/include'])
+		else:
+			env.ParseConfig('pkg-config freetype2 --cflags --libs')
 
-	
 	env.Append(CPPFLAGS=['-DOPENGL_ENABLED','-DGLEW_ENABLED'])
 	env.Append(CPPFLAGS=["-DALSA_ENABLED"])
 	env.Append(CPPFLAGS=['-DX11_ENABLED','-DUNIX_ENABLED','-DGLES2_ENABLED','-DGLES1_ENABLED','-DGLES_OVER_GL'])
-	env.Append(LIBS=['GL', 'GLU', 'pthread','asound','z']) #TODO detect linux/BSD!
+	env.Append(LIBS=['GL', 'pthread', 'asound']) #TODO detect linux/BSD!
+	if (env["builtin_zlib"]=="no"):
+		env.Append(LIBS=['z'])
 	#env.Append(CPPFLAGS=['-DMPC_FIXED_POINT'])
 
 #host compiler is default..
 
 	if (is64 and env["bits"]=="32"):
 		env.Append(CPPFLAGS=['-m32'])
-		env.Append(LINKFLAGS=['-m32','-L/usr/lib/i386-linux-gnu'])
+		env.Append(LINKFLAGS=['-m32'])
 	elif (not is64 and env["bits"]=="64"):
 		env.Append(CPPFLAGS=['-m64'])
-		env.Append(LINKFLAGS=['-m64','-L/usr/lib/i686-linux-gnu'])
+		env.Append(LINKFLAGS=['-m64'])
 
 
 	if (env["CXX"]=="clang++"):

--- a/tools/docdump/doc_merge.py
+++ b/tools/docdump/doc_merge.py
@@ -205,4 +205,4 @@ for c in list(new_doc):
 	write_class(c)
 write_string(f,'</doc>\n')
 
-
+f.close()

--- a/tools/docdump/makedoku.py
+++ b/tools/docdump/makedoku.py
@@ -75,8 +75,9 @@ def make_class_list(class_list,columns):
 			
 		s+="\n"
 		f.write(s)
-	
-	
+	f.close()
+
+
 def dokuize_text(txt):
 	
 	return txt
@@ -220,7 +221,7 @@ def make_method(f,name,m,declare,event=False):
 		s+=" "+m.attrib["qualifiers"]
 		
 	f.write(s+"\n")
-	
+	f.close()
   
 def make_doku_class(node):
 
@@ -302,8 +303,7 @@ def make_doku_class(node):
 			f.write(dokuize_text(d.text.strip()))
 			f.write("\n")
 			
-			
-				
+	f.close()
 
 			
 	"""

--- a/tools/docdump/makemd.py
+++ b/tools/docdump/makemd.py
@@ -85,6 +85,7 @@ def make_class_list(class_list, columns):
 
 		s += '\n'
 		f.write(s)
+	f.close()
 
 
 def dokuize_text(txt):
@@ -317,6 +318,7 @@ def make_doku_class(node):
 			f.write('\n')
 			f.write(dokuize_text(d.text.strip()))
 			f.write('\n')
+	f.close()
 
 
 for file in input_list:

--- a/tools/editor/SCsub
+++ b/tools/editor/SCsub
@@ -23,6 +23,7 @@ def make_doc_header(target,source,env):
 		g.write(str(ord(buf[i]))+",\n")
 	g.write("};\n")
 	g.write("#endif")
+	g.close()
 
 
 

--- a/tools/export/blender25/io_scene_dae/export_dae.py
+++ b/tools/export/blender25/io_scene_dae/export_dae.py
@@ -1588,6 +1588,7 @@ class DaeExporter:
 		f.write(bytes('\t<instance_visual_scene url="#'+self.scene_name+'" />\n',"UTF-8"))
 		f.write(bytes('</scene>\n',"UTF-8"))
 		f.write(bytes('</COLLADA>\n',"UTF-8"))
+		f.close()
 		return True
 
 	def __init__(self,path,kwargs):

--- a/tools/glwrapper/makewrapper.py
+++ b/tools/glwrapper/makewrapper.py
@@ -157,6 +157,7 @@ f.write("void glWrapperInit( GLWrapperFuncPtr (*wrapperFunc)(const char*) );\n")
 f.write("#ifdef __cplusplus\n}\n#endif\n")
 
 f.write("#endif\n\n")
+f.close()
   
 f=open("glwrapper.c","w")
 
@@ -177,8 +178,7 @@ for x in functions:
 f.write("\n\n")
 f.write("}\n")
 f.write("\n\n")
-
-
+f.close()
 
       
     


### PR DESCRIPTION
After #101040, I had to give a go at making a new set of official builds for 1.0-stable, which is the only release we don't have builds for yet.

So here we go, a set of fixes that make it possible to build 1.0-stable (+ fixes), i.e. the new `1.0` branch, with modern GCC and Clang, including mingw-gcc for Windows and osxcross for macOS.

I didn't bother with Android, iOS, and JavaScript (or the other unmaintained legacy platforms that 1.0 still had old code for), as those are more complex and way outdated, and wouldn't run (a priori) on modern devices.

Like #101040, this work is just for archival reason, game preservation, and just poking a bit of fun at Godot's history, making it possible for current users to experience the thrill of the **1.0** release... and maybe see how much work happened in the past 10 years :)

The `1.0` branch is still **unmaintained**, and aside from potential build fixes, there's no plan to reopen its development, fix bugs, and make any sort of new official patch release.

For reviewers, I've intentionally tried to match the pre-existing code style and not to clean the mess of trailing whitespace and mixed indentation in the buildsystem files. Style fixes in 1.0 is out of scope of this effort ;)

---

Alongside those source code changes, I've made a `1.0` branch to godot-build-scripts too,  to be able to make reproducible official builds: https://github.com/godotengine/godot-build-scripts/tree/1.0

Thanks to it, I've been able to make official builds for the following platforms:

- Linux: Editor and export templates (x86_64, x86_32)
- Windows: Editor and export templates (x86_64, x86_32)
- macOS: Editor and export templates (x86_64)
- Linux Server: Headless editor (x86_64)

The builds are available here: https://github.com/godotengine/godot-builds/releases/1.0-stable

I might update them as issues are found and fixed in this PR or godot-build-scripts, and then I'll also upload them to the `1.0-stable` tag on godotengine/godot.

The original 1.0-stable export templates likely also had Android and iOS, and maybe JavaScript (Web, asm.js). Those could likely be made to build with old versions of the NDK, Xcode, Emscripten, etc., but I doubt they'd run on any modern device. I'll leave that to motivated contributors if someone wants to push the archival work this far.

---

Screenshot:

![image](https://github.com/user-attachments/assets/e931f212-5df1-40df-95d2-5fbb916a8366)

This is from https://github.com/KOBUGE-Games/jetpaca checked out at one of its earlier commits (be223231e02a59a65dc90dde1bd8f52040589c60) which is somewhat compatible with 1.0-stable.

---

BTW, I'm not the first to do this, @Calinou did something similar in https://github.com/Calinou/godot-vintage-builds

The main difference here is that these binaries are compiled on a modern distro (Fedora 41) with recent compilers, and include macOS x86_64 builds too, and export templates for Windows, macOS and Linux.

The Windows and macOS binaries are also signed (and notarized for macOS) like official 3.x and 4.x releases.