### PR TITLE
Fix warning in CollisionPolygon2D documentation description

### DIFF
--- a/doc/classes/CollisionPolygon2D.xml
+++ b/doc/classes/CollisionPolygon2D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		A node that provides a polygon shape to a [CollisionObject2D] parent and allows to edit it. The polygon can be concave or convex. This can give a detection shape to an [Area2D], turn [PhysicsBody2D] into a solid object, or give a hollow shape to a [StaticBody2D].
-		[b]Warning:[/b] A non-uniformly scaled [CollisionShape2D] will likely not behave as expected. Make sure to keep its scale the same on all axes and adjust its shape resource instead.
+		[b]Warning:[/b] A non-uniformly scaled [CollisionPolygon2D] will likely not behave as expected. Make sure to keep its scale the same on all axes and adjust its polygon instead.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This was a copy-paste error from the CollisionShape2D documentation.
