### PR TITLE
Update Light2D `rect_cache` even when not using shadows.

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -403,7 +403,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 					tsize *= cl->scale;
 
 					Vector2 offset = tsize / 2.0;
-					cl->rect_cache = Rect2(-offset + cl->texture_offset, tsize);
+					Rect2 local_rect = Rect2(-offset + cl->texture_offset, tsize);
 
 					if (!RSG::canvas->_interpolation_data.interpolation_enabled || !cl->interpolated) {
 						cl->xform_cache = xf * cl->xform_curr;
@@ -413,25 +413,24 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 						cl->xform_cache = xf * cl->xform_cache;
 					}
 
-					Rect2 temp_rect = cl->xform_cache.xform(cl->rect_cache);
+					cl->rect_cache = cl->xform_cache.xform(local_rect);
 
-					if (clip_rect.intersects(temp_rect)) {
+					if (clip_rect.intersects(cl->rect_cache)) {
 						cl->filter_next_ptr = lights;
 						lights = cl;
 						Transform2D scale;
-						scale.scale(cl->rect_cache.size);
-						scale.columns[2] = cl->rect_cache.position;
+						scale.scale(local_rect.size);
+						scale.columns[2] = local_rect.position;
 						cl->light_shader_xform = cl->xform_cache * scale;
 						if (cl->use_shadow) {
 							cl->shadows_next_ptr = lights_with_shadow;
 							if (lights_with_shadow == nullptr) {
-								shadow_rect = temp_rect;
+								shadow_rect = cl->rect_cache;
 							} else {
-								shadow_rect = shadow_rect.merge(temp_rect);
+								shadow_rect = shadow_rect.merge(cl->rect_cache);
 							}
 							lights_with_shadow = cl;
-							cl->radius_cache = cl->rect_cache.size.length();
-							cl->rect_cache = temp_rect;
+							cl->radius_cache = local_rect.size.length();
 						}
 					}
 				}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/100922

Regression introduced in https://github.com/godotengine/godot/pull/100677

https://github.com/godotengine/godot/pull/100677 Updated the `rect_cache` to be in canvas space instead of light local space. However, it mistakenly only did that when shadows were enabled. So unshadowed lights had the `rect_cache` in the wrong coordinate space.

The simplest solution would be to just move the line that updates the `rect_cache` outside the scope of the `use_shadow` block. However, to avoid this sort of confusion, I have updated how the cache is calculated. Instead of setting it in one coordinate space then updating it, we initialize it in the proper coordinate space and only use the local rect in this code path. 