### PR TITLE
Optimize raycast occlusion culling

### DIFF
--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -97,6 +97,8 @@ struct [[nodiscard]] Vector3 {
 
 	_FORCE_INLINE_ void normalize();
 	_FORCE_INLINE_ Vector3 normalized() const;
+	_FORCE_INLINE_ Vector3 normalized_nonzero() const;
+
 	_FORCE_INLINE_ bool is_normalized() const;
 	_FORCE_INLINE_ Vector3 inverse() const;
 	Vector3 limit_length(real_t p_len = 1.0) const;
@@ -510,6 +512,12 @@ void Vector3::normalize() {
 		y /= length;
 		z /= length;
 	}
+}
+
+Vector3 Vector3::normalized_nonzero() const {
+	float lengthsq = x * x + y * y + z * z;
+	float length = Math::sqrt(lengthsq);
+	return Vector3(x / length, y / length, z / length);
 }
 
 Vector3 Vector3::normalized() const {

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -281,6 +281,12 @@ struct _GlobalLock {
 #define _PRINTF_FORMAT_ATTRIBUTE_2_3
 #endif
 
+#if defined(__GNUC__)
+#define assume_aligned_gd(x, y) __builtin_assume_aligned(x, y)
+#else
+#define assume_aligned_gd(x, y) x
+#endif
+
 // This is needed due to a strange OpenGL API that expects a pointer
 // type for an argument that is actually an offset.
 #define CAST_INT_TO_UCHAR_PTR(ptr) ((uint8_t *)(uintptr_t)(ptr))

--- a/modules/raycast/raycast_occlusion_cull.h
+++ b/modules/raycast/raycast_occlusion_cull.h
@@ -46,21 +46,22 @@ public:
 	private:
 		Size2i tile_grid_size;
 
-		struct CameraRayThreadData {
+		struct alignas(16) CameraRayThreadData {
 			int thread_count;
 			float z_near;
 			float z_far;
-			Vector3 camera_dir;
-			Vector3 camera_pos;
-			Vector3 pixel_corner;
-			Vector3 pixel_u_interp;
-			Vector3 pixel_v_interp;
+			alignas(16) Vector3 camera_dir;
+			alignas(16) Vector3 camera_pos;
+			alignas(16) Vector3 pixel_corner;
+			alignas(16) Vector3 pixel_u_interp;
+			alignas(16) Vector3 pixel_v_interp;
 			bool camera_orthogonal;
 			Size2i buffer_size;
 		};
 
 		void _camera_rays_threaded(uint32_t p_thread, const CameraRayThreadData *p_data);
-		void _generate_camera_rays(const CameraRayThreadData *p_data, int p_from, int p_to);
+		template <bool orthogonal>
+		void _generate_camera_rays(const CameraRayThreadData *p_data, int p_from, int p_to) const;
 
 	public:
 		unsigned int camera_rays_tile_count = 0;


### PR DESCRIPTION
This helps the compiler (gcc at least) to vectorize this loop, which then leads to the compiler emiting packed loads for the vectors.

This leads to a modest but measurable improvement in mspf for the TPS demo.

This is still a draft as I'm still noodling with it, some of the extra alignments aren't actually necessary I think.

But basically I have discovered the wonders of gcc's `-fopt-info-vec-all` and it is a lot of fun to see the improvements in objdump as it complains less! 