### PR TITLE
Add EditorInterface methods to get the 2D current grid snapping options

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -43,6 +43,42 @@
 				Edits the given [Script]. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
 			</description>
 		</method>
+		<method name="get_2d_editor_grid_offset" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the current 2D editor grid offset in pixels. This affects grid snapping when enabled (see [method is_2d_editor_grid_snap_enabled]).
+			</description>
+		</method>
+		<method name="get_2d_editor_grid_primary_steps" qualifiers="const">
+			<return type="Vector2i" />
+			<description>
+				Returns the current 2D editor grid offset in pixels.
+			</description>
+		</method>
+		<method name="get_2d_editor_grid_step" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the current 2D editor grid step in pixels. This takes the temporary multiplier into account (when pressing the shortcuts that multiply or divide the grid size by 2). This affects grid snapping when enabled (see [method is_2d_editor_grid_snap_enabled]).
+			</description>
+		</method>
+		<method name="get_2d_editor_snap_rotation_offset" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the current 2D editor snap rotation offset in radians.
+			</description>
+		</method>
+		<method name="get_2d_editor_snap_rotation_step" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the current 2D editor snap rotation step in radians.
+			</description>
+		</method>
+		<method name="get_2d_editor_snap_scale_step" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the current 2D editor snap scale step.
+			</description>
+		</method>
 		<method name="get_base_control" qualifiers="const">
 			<return type="Control" />
 			<description>
@@ -206,6 +242,36 @@
 			<param index="2" name="inspector_only" type="bool" default="false" />
 			<description>
 				Shows the given property on the given [param object] in the editor's Inspector dock. If [param inspector_only] is [code]true[/code], plugins will not attempt to edit [param object].
+			</description>
+		</method>
+		<method name="is_2d_editor_grid_snap_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if grid snapping is enabled in the 2D editor, [code]false[/code] otherwise. See also [method get_2d_editor_grid_step] and [method get_2d_editor_grid_offset].
+			</description>
+		</method>
+		<method name="is_2d_editor_smart_snap_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if smart snapping is enabled in the 2D editor, [code]false[/code] otherwise.
+			</description>
+		</method>
+		<method name="is_2d_editor_snap_relative_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if relative snapping is enabled in the 2D editor, [code]false[/code] otherwise (absolute snapping is used instead).
+			</description>
+		</method>
+		<method name="is_2d_editor_snap_rotation_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if rotation snapping is enabled in the 2D editor, [code]false[/code] otherwise.
+			</description>
+		</method>
+		<method name="is_2d_editor_snap_scale_enabled" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if scale snapping is enabled in the 2D editor, [code]false[/code] otherwise.
 			</description>
 		</method>
 		<method name="is_multi_window_enabled" qualifiers="const">

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -48,6 +48,7 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/gui/scene_tree_editor.h"
 #include "editor/inspector_dock.h"
+#include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/property_selector.h"
 #include "editor/themes/editor_scale.h"
@@ -393,6 +394,50 @@ SubViewport *EditorInterface::get_editor_viewport_2d() const {
 SubViewport *EditorInterface::get_editor_viewport_3d(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, static_cast<int>(Node3DEditor::VIEWPORTS_COUNT), nullptr);
 	return Node3DEditor::get_singleton()->get_editor_viewport(p_idx)->get_viewport_node();
+}
+
+Vector2 EditorInterface::get_2d_editor_grid_offset() const {
+	return CanvasItemEditor::get_singleton()->get_grid_offset();
+}
+
+bool EditorInterface::is_2d_editor_grid_snap_enabled() const {
+	return CanvasItemEditor::get_singleton()->is_grid_snap_enabled();
+}
+
+bool EditorInterface::is_2d_editor_smart_snap_enabled() const {
+	return CanvasItemEditor::get_singleton()->is_smart_snap_enabled();
+}
+
+bool EditorInterface::is_2d_editor_snap_relative_enabled() const {
+	return CanvasItemEditor::get_singleton()->is_snap_relative_enabled();
+}
+
+bool EditorInterface::is_2d_editor_snap_rotation_enabled() const {
+	return CanvasItemEditor::get_singleton()->is_snap_rotation_enabled();
+}
+
+bool EditorInterface::is_2d_editor_snap_scale_enabled() const {
+	return CanvasItemEditor::get_singleton()->is_snap_scale_enabled();
+}
+
+Vector2 EditorInterface::get_2d_editor_grid_step() const {
+	return CanvasItemEditor::get_singleton()->get_grid_step();
+}
+
+Vector2i EditorInterface::get_2d_editor_grid_primary_steps() const {
+	return CanvasItemEditor::get_singleton()->get_grid_primary_steps();
+}
+
+float EditorInterface::get_2d_editor_snap_rotation_step() const {
+	return CanvasItemEditor::get_singleton()->get_snap_rotation_step();
+}
+
+float EditorInterface::get_2d_editor_snap_rotation_offset() const {
+	return CanvasItemEditor::get_singleton()->get_snap_rotation_offset();
+}
+
+float EditorInterface::get_2d_editor_snap_scale_step() const {
+	return CanvasItemEditor::get_singleton()->get_snap_scale_step();
 }
 
 void EditorInterface::set_main_screen_editor(const String &p_name) {
@@ -851,6 +896,21 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_movie_maker_enabled"), &EditorInterface::is_movie_maker_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_maker_enabled"), "set_movie_maker_enabled", "is_movie_maker_enabled");
+
+	// 2D (canvas) editor.
+
+	ClassDB::bind_method(D_METHOD("is_2d_editor_grid_snap_enabled"), &EditorInterface::is_2d_editor_grid_snap_enabled);
+	ClassDB::bind_method(D_METHOD("is_2d_editor_smart_snap_enabled"), &EditorInterface::is_2d_editor_smart_snap_enabled);
+	ClassDB::bind_method(D_METHOD("is_2d_editor_snap_relative_enabled"), &EditorInterface::is_2d_editor_snap_relative_enabled);
+	ClassDB::bind_method(D_METHOD("is_2d_editor_snap_rotation_enabled"), &EditorInterface::is_2d_editor_snap_rotation_enabled);
+	ClassDB::bind_method(D_METHOD("is_2d_editor_snap_scale_enabled"), &EditorInterface::is_2d_editor_snap_scale_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_2d_editor_grid_offset"), &EditorInterface::get_2d_editor_grid_offset);
+	ClassDB::bind_method(D_METHOD("get_2d_editor_grid_step"), &EditorInterface::get_2d_editor_grid_step);
+	ClassDB::bind_method(D_METHOD("get_2d_editor_grid_primary_steps"), &EditorInterface::get_2d_editor_grid_primary_steps);
+	ClassDB::bind_method(D_METHOD("get_2d_editor_snap_rotation_step"), &EditorInterface::get_2d_editor_snap_rotation_step);
+	ClassDB::bind_method(D_METHOD("get_2d_editor_snap_rotation_offset"), &EditorInterface::get_2d_editor_snap_rotation_offset);
+	ClassDB::bind_method(D_METHOD("get_2d_editor_snap_scale_step"), &EditorInterface::get_2d_editor_snap_scale_step);
 }
 
 void EditorInterface::create() {

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -190,6 +190,19 @@ public:
 	void set_movie_maker_enabled(bool p_enabled);
 	bool is_movie_maker_enabled() const;
 
+	bool is_2d_editor_grid_snap_enabled() const;
+	bool is_2d_editor_smart_snap_enabled() const;
+	bool is_2d_editor_snap_relative_enabled() const;
+	bool is_2d_editor_snap_rotation_enabled() const;
+	bool is_2d_editor_snap_scale_enabled() const;
+
+	Vector2 get_2d_editor_grid_offset() const;
+	Vector2 get_2d_editor_grid_step() const;
+	Vector2i get_2d_editor_grid_primary_steps() const;
+	float get_2d_editor_snap_rotation_step() const;
+	float get_2d_editor_snap_rotation_offset() const;
+	float get_2d_editor_snap_scale_step() const;
+
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;
 #endif

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -553,6 +553,20 @@ public:
 	Point2 snap_point(Point2 p_target, unsigned int p_modes = SNAP_DEFAULT, unsigned int p_forced_modes = 0, const CanvasItem *p_self_canvas_item = nullptr, const List<CanvasItem *> &p_other_nodes_exceptions = List<CanvasItem *>());
 	real_t snap_angle(real_t p_target, real_t p_start = 0) const;
 
+	bool is_grid_snap_enabled() const { return grid_snap_active; }
+	bool is_smart_snap_enabled() const { return smart_snap_active; }
+	bool is_snap_relative_enabled() const { return snap_relative; }
+	bool is_snap_rotation_enabled() const { return snap_rotation; }
+	bool is_snap_scale_enabled() const { return snap_scale; }
+
+	Point2 get_grid_offset() const { return grid_offset; }
+	Point2 get_grid_step() const { return grid_step * Math::pow(2.0, grid_step_multiplier); }
+	Vector2i get_grid_primary_steps() const { return primary_grid_step; }
+
+	real_t get_snap_rotation_step() const { return snap_rotation_step; }
+	real_t get_snap_rotation_offset() const { return snap_rotation_offset; }
+	real_t get_snap_scale_step() const { return snap_scale_step; }
+
 	Transform2D get_canvas_transform() const { return transform; }
 
 	static CanvasItemEditor *get_singleton() { return singleton; }


### PR DESCRIPTION
The following methods are available:

- `EditorInterface.is_2d_editor_grid_snap_enabled()`
- `EditorInterface.is_2d_editor_smart_snap_enabled()`
- `EditorInterface.is_2d_editor_snap_relative_enabled()`
- `EditorInterface.is_2d_editor_snap_rotation_enabled()`
- `EditorInterface.is_2d_editor_snap_scale_enabled()`
- `EditorInterface.get_2d_editor_grid_offset()`
- `EditorInterface.get_2d_editor_grid_offset()`
- `EditorInterface.get_2d_editor_grid_primary_steps()`
- `EditorInterface.get_2d_editor_grid_step()`
- `EditorInterface.get_2d_editor_snap_rotation_offset()`
- `EditorInterface.get_2d_editor_snap_rotation_step()`
- `EditorInterface.get_2d_editor_snap_scale_step()`

Note that in 3D, the grid size is defined by the `editors/3d/grid_size` editor setting, but it's separate from snapping which is defined on a per-scene basis like in 2D. I suggest unifying this to make it work more like the 2D editor before adding methods that expose it to editor plugins.

___

- This closes https://github.com/godotengine/godot-proposals/issues/10529.

**Testing project:** [test-2d-editor-grid-plugin.zip](https://github.com/user-attachments/files/18305054/test-2d-editor-grid-plugin.zip)
