### PR TITLE
[XR Editor] Allow specifying whether to play the current scene or a specific scene in XR or regular mode

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -46,7 +46,7 @@ String EditorRun::get_running_scene() const {
 	return running_scene;
 }
 
-Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
+Error EditorRun::run(const String &p_scene, const String &p_write_movie, const Vector<String> &p_run_args) {
 	List<String> args;
 
 	for (const String &a : Main::get_forwardable_cli_arguments(Main::CLI_SCOPE_PROJECT)) {
@@ -221,6 +221,12 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 
 	if (!p_scene.is_empty()) {
 		args.push_back(p_scene);
+	}
+
+	if (!p_run_args.is_empty()) {
+		for (const String &run_arg : p_run_args) {
+			args.push_back(run_arg);
+		}
 	}
 
 	String exec = OS::get_singleton()->get_executable_path();

--- a/editor/editor_run.h
+++ b/editor/editor_run.h
@@ -55,7 +55,7 @@ public:
 	Status get_status() const;
 	String get_running_scene() const;
 
-	Error run(const String &p_scene, const String &p_write_movie = "");
+	Error run(const String &p_scene, const String &p_write_movie = "", const Vector<String> &p_run_args = Vector<String>());
 	void run_native_notify() { status = STATUS_PLAY; }
 	void stop();
 

--- a/editor/gui/editor_run_bar.h
+++ b/editor/gui/editor_run_bar.h
@@ -84,15 +84,18 @@ class EditorRunBar : public MarginContainer {
 	void _update_play_buttons();
 
 	void _write_movie_toggled(bool p_enabled);
-	void _quick_run_selected(const String &p_file_path);
+	void _quick_run_selected(const String &p_file_path, int p_id = -1);
 
-	void _play_current_pressed();
-	void _play_custom_pressed();
+	void _play_current_pressed(int p_id = -1);
+	void _play_custom_pressed(int p_id = -1);
 
-	void _run_scene(const String &p_scene_path = "");
+	void _run_scene(const String &p_scene_path = "", const Vector<String> &p_run_args = Vector<String>());
 	void _run_native(const Ref<EditorExportPreset> &p_preset);
 
 	void _profiler_autostart_indicator_pressed();
+
+private:
+	static Vector<String> _get_xr_mode_play_args(int p_xr_mode_id);
 
 protected:
 	void _notification(int p_what);
@@ -105,8 +108,8 @@ public:
 	void recovery_mode_reload_project();
 
 	void play_main_scene(bool p_from_native = false);
-	void play_current_scene(bool p_reload = false);
-	void play_custom_scene(const String &p_custom);
+	void play_current_scene(bool p_reload = false, const Vector<String> &p_play_args = Vector<String>());
+	void play_custom_scene(const String &p_custom, const Vector<String> &p_play_args = Vector<String>());
 
 	void stop_playing();
 	bool is_playing() const;

--- a/platform/android/java/editor/src/horizonos/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/horizonos/java/org/godotengine/editor/GodotEditor.kt
@@ -43,6 +43,19 @@ open class GodotEditor : BaseGodotEditor() {
 	companion object {
 		private val TAG = GodotEditor::class.java.simpleName
 
+		/** Default behavior, means we check project settings **/
+		private const val XR_MODE_DEFAULT = "default"
+
+		/**
+		 * Ignore project settings, OpenXR is disabled
+		 */
+		private const val XR_MODE_OFF = "off"
+
+		/**
+		 * Ignore project settings, OpenXR is enabled
+		 */
+		private const val XR_MODE_ON = "on"
+
 		internal val XR_RUN_GAME_INFO = EditorWindowInfo(GodotXRGame::class.java, 1667, ":GodotXRGame")
 
 		internal val USE_SCENE_PERMISSIONS = listOf("com.oculus.permission.USE_SCENE", "horizonos.permission.USE_SCENE")
@@ -58,15 +71,14 @@ open class GodotEditor : BaseGodotEditor() {
 
 	override fun retrieveEditorWindowInfo(args: Array<String>): EditorWindowInfo {
 		var hasEditor = false
-		var xrModeOn = false
+		var xrMode = XR_MODE_DEFAULT
 
 		var i = 0
 		while (i < args.size) {
 			when (args[i++]) {
 				EDITOR_ARG, EDITOR_ARG_SHORT, EDITOR_PROJECT_MANAGER_ARG, EDITOR_PROJECT_MANAGER_ARG_SHORT -> hasEditor = true
 				XR_MODE_ARG -> {
-					val argValue = args[i++]
-					xrModeOn = xrModeOn || ("on" == argValue)
+					xrMode = args[i++]
 				}
 			}
 		}
@@ -74,7 +86,8 @@ open class GodotEditor : BaseGodotEditor() {
 		return if (hasEditor) {
 			EDITOR_MAIN_INFO
 		} else {
-			val openxrEnabled = GodotLib.getGlobal("xr/openxr/enabled").toBoolean()
+			val openxrEnabled = xrMode == XR_MODE_ON ||
+				(xrMode == XR_MODE_DEFAULT && GodotLib.getGlobal("xr/openxr/enabled").toBoolean())
 			if (openxrEnabled && isNativeXRDevice()) {
 				XR_RUN_GAME_INFO
 			} else {


### PR DESCRIPTION
The feature introduces a drop down menu to allow users to play a scene either in regular mode or in XR mode. It is **only activated for the XR Editor, when a project has OpenXR enabled**. 
This is needed because otherwise the `Play current scene` and `Play specific scene` buttons always launch a scene in XR when OpenXR is enabled.

<img width="362" alt="Screenshot 2025-01-03 at 7 27 57 PM" src="https://github.com/user-attachments/assets/a18d9b94-68ff-4782-95df-27891395625c" />

<img width="372" alt="Screenshot 2025-01-03 at 7 28 09 PM" src="https://github.com/user-attachments/assets/3f3186fc-f297-485b-85bb-42ec49a3d4da" />




<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
