### PR TITLE
Increase WorldBoundaryShape3D size to 8192x8192 when using Jolt

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2409,7 +2409,7 @@
 		<member name="physics/jolt_physics_3d/limits/temporary_memory_buffer_size" type="int" setter="" getter="" default="32">
 			The amount of memory to pre-allocate for the stack allocator used within Jolt, in MiB. This allocator is used within the physics step to store things that are only needed during it, like which bodies are in contact, how they form islands and the data needed to solve the contacts.
 		</member>
-		<member name="physics/jolt_physics_3d/limits/world_boundary_shape_size" type="float" setter="" getter="" default="2000.0">
+		<member name="physics/jolt_physics_3d/limits/world_boundary_shape_size" type="float" setter="" getter="" default="8192.0">
 			The size of [WorldBoundaryShape3D] boundaries, for all three dimensions. The plane is effectively centered within a box of this size, and anything outside of the box will not collide with it. This is necessary as [WorldBoundaryShape3D] is not unbounded when using Jolt, in order to prevent precision issues.
 			[b]Note:[/b] Setting this value too high can make collision detection less accurate.
 			[b]Note:[/b] Collisions against the effective edges of a [WorldBoundaryShape3D] will be inconsistent.

--- a/modules/jolt_physics/jolt_project_settings.cpp
+++ b/modules/jolt_physics/jolt_project_settings.cpp
@@ -74,7 +74,7 @@ void JoltProjectSettings::register_settings() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/jolt_physics_3d/joints/world_node", PROPERTY_HINT_ENUM, U"Node A,Node B"), JOLT_JOINT_WORLD_NODE_A);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "physics/jolt_physics_3d/limits/temporary_memory_buffer_size", PROPERTY_HINT_RANGE, U"1,32,or_greater,suffix:MiB"), 32);
-	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/limits/world_boundary_shape_size", PROPERTY_HINT_RANGE, U"2,2000,0.1,or_greater,suffix:m"), 2000.0f);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/limits/world_boundary_shape_size", PROPERTY_HINT_RANGE, U"2,32768,0.1,or_greater,suffix:m"), 8192.0f);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/limits/max_linear_velocity", PROPERTY_HINT_RANGE, U"0,500,0.01,or_greater,suffix:m/s"), 500.0f);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/limits/max_angular_velocity", PROPERTY_HINT_RANGE, U"0,2700,0.01,or_greater,radians_as_degrees,suffix:°/s"), Math::deg_to_rad(2700.0f));
 	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "physics/jolt_physics_3d/limits/max_bodies", PROPERTY_HINT_RANGE, U"1,10240,or_greater"), 10240);


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/101108.

Unlike GodotPhysics, WorldBoundaryShape3D has a finite size in Jolt Physics.

This increases the default size to suit most projects using single-precision builds. As per the [Large world coordinates](https://docs.godotengine.org/en/latest/tutorials/physics/large_world_coordinates.html) documentation, it's recommended to keep all gameplay within a 8192x8192x8192 area centered around the world origin, so the new default covers that. The precision is halved when going past every power of 2 value, which is why the new default is also a power of 2.

The size isn't currently overridden when using a double-precision build (this could be done using the `double` feature tag), but from what @mihe told me, Jolt doesn't use double precision in the same ways GodotPhysics does. It's only used for absolute positions, not relative coordinates such as velocity, so it needs further testing to see if huge WorldBoundaryShape3D sizes like `2^32` work correctly in double precision builds.

cc @jrouwe
