### PR TITLE
Fix `is_anything_pressed` by using `physical_keys_pressed` to detect if a key is pressed

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -295,7 +295,7 @@ bool Input::is_anything_pressed() const {
 		return false;
 	}
 
-	if (!keys_pressed.is_empty() || !joy_buttons_pressed.is_empty() || !mouse_button_mask.is_empty()) {
+	if (!physical_keys_pressed.is_empty() || !joy_buttons_pressed.is_empty() || !mouse_button_mask.is_empty()) {
 		return true;
 	}
 
@@ -315,7 +315,7 @@ bool Input::is_anything_pressed_except_mouse() const {
 		return false;
 	}
 
-	if (!keys_pressed.is_empty() || !joy_buttons_pressed.is_empty()) {
+	if (!physical_keys_pressed.is_empty() || !joy_buttons_pressed.is_empty()) {
 		return true;
 	}
 
@@ -676,19 +676,6 @@ Vector3 Input::get_gyroscope() const {
 	return gyroscope;
 }
 
-void Input::remove_modifiers(Ref<InputEventKey> k) {
-	Vector<Key> keys_to_remove = Vector<Key>();
-	for (const Key &key : keys_pressed) {
-		Key mod = key & k->get_modifiers_mask();
-		if (mod != Key::NONE) {
-			keys_to_remove.push_back(key);
-		}
-	}
-	for (const Key &key : keys_to_remove) {
-		keys_pressed.erase(key);
-	}
-}
-
 void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_emulated) {
 	// This function does the final delivery of the input event to user land.
 	// Regardless where the event came from originally, this has to happen on the main thread.
@@ -704,15 +691,9 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && !k->is_echo() && k->get_keycode() != Key::NONE) {
 		if (k->is_pressed()) {
-			keys_pressed.insert(k->get_keycode_with_modifiers());
+			keys_pressed.insert(k->get_keycode());
 		} else {
-			if (k->get_modifiers_mask() > 0) {
-				keys_pressed.erase(k->get_keycode());
-				remove_modifiers(k);
-
-			} else {
-				keys_pressed.erase(k->get_keycode_with_modifiers());
-			}
+			keys_pressed.erase(k->get_keycode());
 		}
 	}
 	if (k.is_valid() && !k->is_echo() && k->get_physical_keycode() != Key::NONE) {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -141,6 +141,7 @@ private:
 	bool use_accumulated_input = true;
 
 	int mouse_from_touch_index = -1;
+	void remove_modifiers(Ref<InputEventKey> k);
 
 	struct VibrationInfo {
 		float weak_magnitude;

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -141,7 +141,6 @@ private:
 	bool use_accumulated_input = true;
 
 	int mouse_from_touch_index = -1;
-	void remove_modifiers(Ref<InputEventKey> k);
 
 	struct VibrationInfo {
 		float weak_magnitude;

--- a/tests/core/input/test_input.h
+++ b/tests/core/input/test_input.h
@@ -34,80 +34,8 @@
 #include "tests/test_macros.h"
 
 namespace TestInput {
-TEST_CASE("[Input] Correctly removes keys from keyset when modifier pushed first") {
-	InputMap *map = memnew(InputMap);
-	Input *input = memnew(Input);
 
-	input->set_use_accumulated_input(false);
-
-	// Press "shift"
-	// modifier is not set when pressed
-	InputEventKey *shift = memnew(InputEventKey());
-	shift->set_keycode(Key::SHIFT);
-	shift->set_pressed(true);
-	input->parse_input_event(shift);
-
-	// Press "_"
-	InputEventKey *underscore = memnew(InputEventKey());
-	underscore->set_pressed(true);
-	underscore->set_shift_pressed(true);
-	underscore->set_keycode(Key::UNDERSCORE);
-	input->parse_input_event(underscore);
-	CHECK(input->is_anything_pressed());
-
-	// Release "shift"
-	// Modifier is set when released
-	InputEventKey *shift_release = memnew(InputEventKey());
-	shift_release->set_keycode(Key::SHIFT);
-	shift_release->set_shift_pressed(true);
-	shift_release->set_pressed(false);
-	input->parse_input_event(shift_release);
-	CHECK_FALSE(input->is_anything_pressed());
-	memdelete(input);
-	memdelete(map);
-}
-
-TEST_CASE("[Input] Correctly removes keys from keyset when modifier pushed second") {
-	InputMap *map = memnew(InputMap);
-	Input *input = memnew(Input);
-
-	input->set_use_accumulated_input(false);
-
-	// Press "-"
-	InputEventKey *minus = memnew(InputEventKey());
-	minus->set_pressed(true);
-	minus->set_keycode(Key::MINUS);
-	input->parse_input_event(minus);
-
-	// Press "shift"
-	// modifier is not set when pressed
-	InputEventKey *shift = memnew(InputEventKey());
-	shift->set_keycode(Key::SHIFT);
-	shift->set_pressed(true);
-	input->parse_input_event(shift);
-
-	// Release "_"
-	InputEventKey *underscore = memnew(InputEventKey());
-	underscore->set_pressed(false);
-	underscore->set_shift_pressed(true);
-	underscore->set_keycode(Key::UNDERSCORE);
-	input->parse_input_event(underscore);
-
-	CHECK(input->is_anything_pressed());
-
-	// Release "shift"
-	// Modifier is set when released
-	InputEventKey *shift_release = memnew(InputEventKey());
-	shift_release->set_keycode(Key::SHIFT);
-	shift_release->set_shift_pressed(true);
-	shift_release->set_pressed(false);
-	input->parse_input_event(shift_release);
-	CHECK_FALSE(input->is_anything_pressed());
-	memdelete(input);
-	memdelete(map);
-}
-
-TEST_CASE("[Input] Correctly removes modifier from keyset") {
+TEST_CASE("[Input] Correctly removes keys from physical keyset") {
 	InputMap *map = memnew(InputMap);
 	Input *input = memnew(Input);
 
@@ -115,7 +43,7 @@ TEST_CASE("[Input] Correctly removes modifier from keyset") {
 	InputEventKey *shift = memnew(InputEventKey);
 
 	// Press "shift"
-	shift->set_keycode(Key::SHIFT);
+	shift->set_physical_keycode(Key::SHIFT);
 	shift->set_pressed(true);
 	input->parse_input_event(shift);
 
@@ -123,7 +51,7 @@ TEST_CASE("[Input] Correctly removes modifier from keyset") {
 
 	// Release "shift"
 	InputEventKey *shift_release = memnew(InputEventKey());
-	shift_release->set_keycode(Key::SHIFT);
+	shift_release->set_physical_keycode(Key::SHIFT);
 	shift_release->set_shift_pressed(true);
 	shift_release->set_pressed(false);
 	input->parse_input_event(shift_release);

--- a/tests/core/input/test_input.h
+++ b/tests/core/input/test_input.h
@@ -1,0 +1,137 @@
+/**************************************************************************/
+/*  test_input.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef TEST_INPUT_H
+#define TEST_INPUT_H
+
+#include "tests/test_macros.h"
+
+namespace TestInput {
+TEST_CASE("[Input] Correctly removes keys from keyset when modifier pushed first") {
+	InputMap *map = memnew(InputMap);
+	Input *input = memnew(Input);
+
+	input->set_use_accumulated_input(false);
+
+	// Press "shift"
+	// modifier is not set when pressed
+	InputEventKey *shift = memnew(InputEventKey());
+	shift->set_keycode(Key::SHIFT);
+	shift->set_pressed(true);
+	input->parse_input_event(shift);
+
+	// Press "_"
+	InputEventKey *underscore = memnew(InputEventKey());
+	underscore->set_pressed(true);
+	underscore->set_shift_pressed(true);
+	underscore->set_keycode(Key::UNDERSCORE);
+	input->parse_input_event(underscore);
+	CHECK(input->is_anything_pressed());
+
+	// Release "shift"
+	// Modifier is set when released
+	InputEventKey *shift_release = memnew(InputEventKey());
+	shift_release->set_keycode(Key::SHIFT);
+	shift_release->set_shift_pressed(true);
+	shift_release->set_pressed(false);
+	input->parse_input_event(shift_release);
+	CHECK_FALSE(input->is_anything_pressed());
+	memdelete(input);
+	memdelete(map);
+}
+
+TEST_CASE("[Input] Correctly removes keys from keyset when modifier pushed second") {
+	InputMap *map = memnew(InputMap);
+	Input *input = memnew(Input);
+
+	input->set_use_accumulated_input(false);
+
+	// Press "-"
+	InputEventKey *minus = memnew(InputEventKey());
+	minus->set_pressed(true);
+	minus->set_keycode(Key::MINUS);
+	input->parse_input_event(minus);
+
+	// Press "shift"
+	// modifier is not set when pressed
+	InputEventKey *shift = memnew(InputEventKey());
+	shift->set_keycode(Key::SHIFT);
+	shift->set_pressed(true);
+	input->parse_input_event(shift);
+
+	// Release "_"
+	InputEventKey *underscore = memnew(InputEventKey());
+	underscore->set_pressed(false);
+	underscore->set_shift_pressed(true);
+	underscore->set_keycode(Key::UNDERSCORE);
+	input->parse_input_event(underscore);
+
+	CHECK(input->is_anything_pressed());
+
+	// Release "shift"
+	// Modifier is set when released
+	InputEventKey *shift_release = memnew(InputEventKey());
+	shift_release->set_keycode(Key::SHIFT);
+	shift_release->set_shift_pressed(true);
+	shift_release->set_pressed(false);
+	input->parse_input_event(shift_release);
+	CHECK_FALSE(input->is_anything_pressed());
+	memdelete(input);
+	memdelete(map);
+}
+
+TEST_CASE("[Input] Correctly removes modifier from keyset") {
+	InputMap *map = memnew(InputMap);
+	Input *input = memnew(Input);
+
+	input->set_use_accumulated_input(false);
+	InputEventKey *shift = memnew(InputEventKey);
+
+	// Press "shift"
+	shift->set_keycode(Key::SHIFT);
+	shift->set_pressed(true);
+	input->parse_input_event(shift);
+
+	CHECK(input->is_anything_pressed());
+
+	// Release "shift"
+	InputEventKey *shift_release = memnew(InputEventKey());
+	shift_release->set_keycode(Key::SHIFT);
+	shift_release->set_shift_pressed(true);
+	shift_release->set_pressed(false);
+	input->parse_input_event(shift_release);
+	CHECK_FALSE(input->is_anything_pressed());
+	memdelete(input);
+	memdelete(map);
+}
+
+} // namespace TestInput
+
+#endif // TEST_INPUT_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -38,6 +38,7 @@
 #endif // TOOLS_ENABLED
 
 #include "tests/core/config/test_project_settings.h"
+#include "tests/core/input/test_input.h"
 #include "tests/core/input/test_input_event.h"
 #include "tests/core/input/test_input_event_key.h"
 #include "tests/core/input/test_input_event_mouse.h"
@@ -144,7 +145,6 @@
 #include "tests/servers/rendering/test_shader_preprocessor.h"
 #include "tests/servers/test_text_server.h"
 #include "tests/test_validate_testing.h"
-
 #ifndef ADVANCED_GUI_DISABLED
 #include "tests/scene/test_code_edit.h"
 #include "tests/scene/test_color_picker.h"


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

~When a modifier key is released (shift, ctl, alt, etc.), keys that use a modifier will now be removed from the pressed keyset map. This fixes an issue with the `is_anything_pressed` method on `Input` ([steps to reproduce here](https://github.com/godotengine/godot/issues/100879#issuecomment-2566728979)).~

~Things to consider...~
~- Instead of removing the keys from the set, the key could be modified (e.g. `_` becomes `-`, `I` becomes `i`). This doesn't seem to matter since a new keypress event for `-` or `i` will be generated after shift is released.~

I found an easier solution: This will now change the `is_anything_pressed` method to use the `physical_keys_pressed` set instead of `keys_pressed` because `keys_pressed` will have stale keys if you press a modifier and then release the modified key, which causes `is_anything_pressed` to always return true. Physical keys pressed seems to make more sense anyways for detecting if a key is pressed or not. 