### PR TITLE
Performance and memory optimization for open addressing hash structures(`AHashMap`, `OAHashMap`, `HashSet`)

### DIFF
--- a/core/simd/simd.h
+++ b/core/simd/simd.h
@@ -1,0 +1,44 @@
+/**************************************************************************/
+/*  simd.h                                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#define SIMD_AVAILABLE
+
+#if defined(__SSE2__) || defined(_M_X64) || defined(__x86_64__)
+#include <emmintrin.h>
+#define SIMD_SSE2
+#elif defined(__ARM_FP) && defined(__ARM_NEON)
+#include <arm_neon.h>
+#define SIMD_NEON
+#else
+#define SIMD_SCALAR
+#undef SIMD_AVAILABLE
+#endif

--- a/core/templates/hashes.cpp
+++ b/core/templates/hashes.cpp
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*  hashes.cpp                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "hashes.h"
+
+uint32_t Hashes::insert_hash(uint32_t p_hash, uint32_t p_capacity) {
+	uint32_t pos = p_hash & p_capacity;
+	uint8_t stored_hash = _get_stored_hash(p_hash);
+
+	if (ptr[pos] <= DELETED_HASH) {
+		ptr[pos] = stored_hash;
+		return pos;
+	}
+	pos = (pos + 1) & p_capacity;
+
+#ifdef SIMD_AVAILABLE
+	while (true) {
+		HashGroup group(&ptr[pos]);
+		int mask = group.get_compare_mask(EMPTY_HASH) | group.get_compare_mask(DELETED_HASH);
+		if (likely(mask)) {
+			int bit_pos = count_trailing_zeros(mask);
+			uint32_t actual_pos = pos + bit_pos;
+			ptr[actual_pos] = stored_hash;
+			return actual_pos;
+		}
+		pos += HashGroup::GROUP_SIZE;
+		if (pos > p_capacity) {
+			pos = 0;
+		}
+	}
+#else
+	while (true) {
+		if (ptr[pos] <= DELETED_HASH) {
+			ptr[pos] = stored_hash;
+
+			return pos;
+		}
+		pos = (pos + 1) & p_capacity;
+	}
+#endif
+}

--- a/core/templates/hashes.h
+++ b/core/templates/hashes.h
@@ -1,0 +1,177 @@
+/**************************************************************************/
+/*  hashes.h                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/simd/simd.h"
+#include "core/templates/hashfuncs.h"
+#include "core/templates/index_array.h"
+#include "core/typedefs.h"
+
+struct HashGroup {
+#ifdef SIMD_AVAILABLE
+	static constexpr uint32_t GROUP_SIZE = 16;
+
+private:
+#ifdef SIMD_SSE2
+	__m128i vector;
+#elif defined(SIMD_NEON)
+	uint8x16_t vector;
+#endif
+
+public:
+	_FORCE_INLINE_ HashGroup(const uint8_t *p_begin) {
+#ifdef SIMD_SSE2
+		vector = _mm_loadu_si128(reinterpret_cast<const __m128i *>(p_begin));
+#elif defined(SIMD_NEON)
+		vector = vld1q_s8(reinterpret_cast<const int8_t *>(p_begin));
+#endif
+	}
+
+	_FORCE_INLINE_ int get_compare_mask(uint8_t p_value) {
+#ifdef SIMD_SSE2
+		__m128i target_vector = _mm_set1_epi8(p_value);
+		__m128i cmp = _mm_cmpeq_epi8(target_vector, vector);
+		return _mm_movemask_epi8(cmp);
+#elif defined(SIMD_NEON)
+		uint8x16_t target_vector = vdupq_n_u8(p_value);
+		uint8x16_t cmp = vceqq_u8(target_vector, vector);
+		alignas(16) const uint8_t _powers[16] = { 1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128 };
+
+		uint8x16_t powers = vld1q_u8(_powers);
+		uint64x2_t mask = vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(vandq_u8(cmp, powers))));
+		uint16_t output;
+		vst1q_lane_u8((uint8_t *)&output + 0, (uint8x16_t)mask, 0);
+		vst1q_lane_u8((uint8_t *)&output + 1, (uint8x16_t)mask, 8);
+		return static_cast<int>(output);
+#endif
+	}
+#else
+	static constexpr uint32_t GROUP_SIZE = 1;
+#endif // SIMD_AVAILABLE
+};
+
+struct Hashes {
+private:
+	static _FORCE_INLINE_ uint8_t _get_stored_hash(uint32_t p_hash) {
+		uint8_t stored_hash = (p_hash >> 24) & HASH_MASK;
+		if (unlikely(stored_hash <= END_HASH)) {
+			stored_hash += END_HASH + 1;
+		}
+		return stored_hash;
+	}
+
+public:
+	static constexpr uint32_t EMPTY_HASH = 0;
+	static constexpr uint32_t DELETED_HASH = 1;
+	static constexpr uint32_t END_HASH = 2;
+
+	static_assert(EMPTY_HASH == 0 && DELETED_HASH == 1 && END_HASH == 2);
+
+	static constexpr uint32_t HASH_MASK = (1 << (8 * sizeof(uint8_t))) - 1;
+	uint8_t *ptr = nullptr;
+
+	template <typename Container, typename TKey>
+	inline bool lookup_pos_with_hash(const Container *p_container, const TKey &p_key, uint32_t p_hash, uint32_t p_capacity, uint32_t &r_hash_pos) const {
+		uint32_t pos = p_hash & p_capacity;
+
+		if (ptr[pos] == EMPTY_HASH) {
+			return false;
+		}
+
+		uint8_t stored_hash = _get_stored_hash(p_hash);
+
+		if (ptr[pos] == stored_hash && likely(p_container->_compare_function(pos, p_key))) {
+			r_hash_pos = pos;
+			return true;
+		}
+		pos = (pos + 1) & p_capacity;
+		uint32_t distance = 1;
+#ifdef SIMD_AVAILABLE
+		while (true) { // This will compare 16 hahses at once.
+			HashGroup group(&ptr[pos]);
+			int mask = group.get_compare_mask(stored_hash);
+			while (mask) {
+				int bit_pos = count_trailing_zeros(mask);
+				uint32_t actual_pos = pos + bit_pos;
+				if (likely(p_container->_compare_function(actual_pos, p_key))) {
+					r_hash_pos = actual_pos;
+					return true;
+				}
+
+				mask &= mask - 1;
+			}
+			mask = group.get_compare_mask(EMPTY_HASH);
+
+			if (likely(mask)) {
+				return false;
+			}
+
+			pos += HashGroup::GROUP_SIZE;
+			if (pos > p_capacity) {
+				distance += p_capacity + HashGroup::GROUP_SIZE + 1 - pos;
+				if (unlikely(distance > p_capacity)) {
+					return false;
+				}
+				pos = 0;
+			} else {
+				distance += HashGroup::GROUP_SIZE;
+			}
+		}
+#else
+		while (true) {
+			if (ptr[pos] == stored_hash && likely(p_container->_compare_function(pos, p_key))) {
+				r_hash_pos = pos;
+				return true;
+			}
+
+			if (ptr[pos] == EMPTY_HASH) {
+				return false;
+			}
+
+			pos = (pos + 1) & p_capacity;
+			distance++;
+			if (unlikely(distance > p_capacity)) {
+				return false;
+			}
+		}
+#endif
+	}
+
+	uint32_t insert_hash(uint32_t p_hash, uint32_t p_capacity);
+
+	_FORCE_INLINE_ const uint8_t &operator[](uint32_t p_index) const {
+		return ptr[p_index];
+	}
+
+	_FORCE_INLINE_ void delete_hash(uint32_t p_index) {
+		ptr[p_index] = DELETED_HASH;
+	}
+};

--- a/core/templates/index_array.cpp
+++ b/core/templates/index_array.cpp
@@ -1,0 +1,86 @@
+/**************************************************************************/
+/*  index_array.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "index_array.h"
+
+#include <cstring>
+
+void IndexArray::_allocate(uint32_t p_size) {
+	size = p_size;
+	size_t alloc_size = get_allocated_size();
+
+	small = reinterpret_cast<uint8_t *>(Memory::alloc_static(alloc_size));
+}
+
+size_t IndexArray::get_allocated_size() {
+	size_t alloc_size = 0;
+	switch (state) {
+		case Small:
+			alloc_size = size * sizeof(uint8_t);
+			break;
+		case Medium:
+			alloc_size = size * sizeof(uint16_t);
+			break;
+		case Large:
+			alloc_size = size * sizeof(uint32_t);
+			break;
+	}
+	return alloc_size;
+}
+
+void IndexArray::initialize(uint32_t p_size, uint32_t p_max_index) {
+	reset();
+	if (p_max_index <= (1u << 8 * (sizeof(uint8_t)))) {
+		state = Small;
+	} else if (p_max_index <= (1u << 8 * (sizeof(uint16_t)))) {
+		state = Medium;
+	} else {
+		state = Large;
+	}
+	_allocate(p_size);
+}
+
+void IndexArray::operator=(const IndexArray &p_other) {
+	reset();
+	state = p_other.state;
+	_allocate(p_other.size);
+	memcpy(small, p_other.small, get_allocated_size());
+}
+
+IndexArray::IndexArray(const IndexArray &p_other) {
+	operator=(p_other);
+}
+
+void IndexArray::reset() {
+	if (small != nullptr) {
+		Memory::free_static(small);
+		small = nullptr;
+	}
+}

--- a/core/templates/index_array.h
+++ b/core/templates/index_array.h
@@ -1,0 +1,103 @@
+/**************************************************************************/
+/*  index_array.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/os/memory.h"
+
+/** The idea behind this class is to use as little memory as possible to store the index of an element in the array.
+ **/
+class IndexArray {
+public:
+	enum State : uint8_t {
+		Small = 1,
+		Medium = 2,
+		Large = 4
+	};
+
+private:
+	union {
+		uint8_t *small = nullptr;
+		uint16_t *meduim;
+		uint32_t *large;
+	};
+
+	State state;
+	uint32_t size;
+
+	void _allocate(uint32_t p_size);
+
+public:
+	_FORCE_INLINE_ State get_size_state() const {
+		return state;
+	}
+
+	_FORCE_INLINE_ void set_index(uint32_t p_pos, uint32_t p_index) {
+		switch (state) {
+			case Small:
+				small[p_pos] = static_cast<uint8_t>(p_index);
+				break;
+			case Medium:
+				meduim[p_pos] = static_cast<uint16_t>(p_index);
+				break;
+			default:
+				large[p_pos] = p_index;
+				break;
+		}
+	}
+
+	_FORCE_INLINE_ uint32_t get_index(uint32_t p_pos) const {
+		switch (state) {
+			case Small:
+				return static_cast<uint32_t>(small[p_pos]);
+			case Medium:
+				return static_cast<uint32_t>(meduim[p_pos]);
+			default:
+				return large[p_pos];
+		}
+	}
+
+	size_t get_allocated_size();
+
+	void initialize(uint32_t p_size, uint32_t p_max_index);
+
+	void operator=(const IndexArray &p_other);
+
+	IndexArray(const IndexArray &p_other);
+
+	inline IndexArray() {
+	}
+
+	void reset();
+
+	inline ~IndexArray() {
+		reset();
+	}
+};

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -153,6 +153,40 @@ inline bool is_power_of_2(const T x) {
 	return x && ((x & (x - 1)) == 0);
 }
 
+static _FORCE_INLINE_ int count_trailing_zeros(uint32_t value) {
+	if (value == 0) {
+		return 32;
+	}
+#if defined(__GNUC__) || defined(__clang__)
+	return __builtin_ctz(value);
+
+#elif defined(_MSC_VER)
+	unsigned long index;
+	_BitScanForward(&index, value);
+	return static_cast<int>(index);
+
+#else
+	int c = 31;
+	uint32_t x = value & (~value + 1);
+	if (x & 0x0000FFFF) {
+		c -= 16;
+	}
+	if (x & 0x00FF00FF) {
+		c -= 8;
+	}
+	if (x & 0x0F0F0F0F) {
+		c -= 4;
+	}
+	if (x & 0x33333333) {
+		c -= 2;
+	}
+	if (x & 0x55555555) {
+		c -= 1;
+	}
+	return c;
+#endif
+}
+
 // Function to find the next power of 2 to an integer.
 constexpr uint64_t next_power_of_2(uint64_t p_number) {
 	if (p_number == 0) {

--- a/scene/resources/surface_tool.cpp
+++ b/scene/resources/surface_tool.cpp
@@ -749,7 +749,7 @@ void SurfaceTool::index() {
 		return; //already indexed
 	}
 
-	AHashMap<Vertex &, int, VertexHasher> indices = vertex_array.size();
+	AHashMap<const Vertex &, int, VertexHasher> indices = vertex_array.size();
 
 	uint32_t new_size = 0;
 	for (Vertex &vertex : vertex_array) {
@@ -766,6 +766,8 @@ void SurfaceTool::index() {
 
 		index_array.push_back(idx);
 	}
+
+	indices.reset();
 
 	vertex_array.resize(new_size);
 	format |= Mesh::ARRAY_FORMAT_INDEX;


### PR DESCRIPTION
Supersedes:  #90126, #90210

# About PR
In this PR I applied optimizations based on https://www.youtube.com/watch?v=ncHmEUmJZf4. 
In short, we can store only 1 byte of hash and with the help of SIMD instructions we can check for equality of 16 hashes at once. 

By the way, I added a lot of optimizations myself, which allowed to save a lot of memory and increase the maximum load factor to 93.75%.

One of these is the new `IndexArray` class. This class can store an index for an element from an array and take into account the size of the array. For example, if our array has 100 elements, then the indexed array will use `uint8_t`. If the number of elements increased to 1000, then `uint16_t`. 

Also use 8-bit hashes, not 7-bit as in the video, use a separate `elements_capacity` in `AHashMap` and `HashSet`. And a lot of micro-optimizations.

# Benchmarks
I did tests in tps-demo on minimum graphics settings.
- Average fps increased from 408 to 428 fps.
- Memory usage decreased from 184 MB to 172 MB.

It should be noted that most of the changes are due to `HashSet`, as it is widely used in the engine.

# Recommendations
I would almost always recommend using `AHashMap` or `OAHashMap` instead of the standard `HashMap`, because these maps outperform `HashMap` significantly.

Approximate average `AHashMap` vs `HashMap` benchmark results:
- `AHashMap` uses only 2-6 bytes of metadata per element, while `HashMap` uses 32-64 bytes.
- 3 times faster insertion/erase.
- 5 times faster iteration.
- 2 times faster lookup.

# TODO
- [ ] GodotBenchmarks
