### PR TITLE
Use rstrings for embedded binary files instead of comma-separated numbers.

### DIFF
--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -46,10 +46,7 @@ def make_certs_header(target, source, env):
             g.write("#define BUILTIN_CERTS_ENABLED\n")
             g.write("static const int _certs_compressed_size = " + str(len(buf)) + ";\n")
             g.write("static const int _certs_uncompressed_size = " + str(decomp_size) + ";\n")
-            g.write("static const unsigned char _certs_compressed[] = {\n")
-            for i in range(len(buf)):
-                g.write("\t" + str(buf[i]) + ",\n")
-            g.write("};\n")
+            g.write('static const unsigned char _certs_compressed[] = R"~~~~({})~~~~";\n\n'.format(buf))
         g.write("#endif // CERTS_COMPRESSED_GEN_H")
 
 

--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -28,10 +28,9 @@ def run(target, source, env):
 
         g.write("static const int _gdextension_interface_data_compressed_size = " + str(len(buf)) + ";\n")
         g.write("static const int _gdextension_interface_data_uncompressed_size = " + str(decomp_size) + ";\n")
-        g.write("static const unsigned char _gdextension_interface_data_compressed[] = {\n")
-        for i in range(len(buf)):
-            g.write("\t" + str(buf[i]) + ",\n")
-        g.write("};\n")
+        g.write(
+            'static const unsigned char _gdextension_interface_data_compressed[] = R"~~~~({})~~~~";\n\n'.format(buf)
+        )
 
         g.write(
             """

--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -38,10 +38,7 @@ def make_doc_header(target, source, env):
         g.write('static const char *_doc_data_hash = "' + str(hash(buf)) + '";\n')
         g.write("static const int _doc_data_compressed_size = " + str(len(buf)) + ";\n")
         g.write("static const int _doc_data_uncompressed_size = " + str(decomp_size) + ";\n")
-        g.write("static const unsigned char _doc_data_compressed[] = {\n")
-        for i in range(len(buf)):
-            g.write("\t" + str(buf[i]) + ",\n")
-        g.write("};\n")
+        g.write('static const unsigned char _doc_data_compressed[] = R"~~~~({})~~~~";\n\n'.format(buf))
 
         g.write("#endif")
 
@@ -99,11 +96,11 @@ def make_translations_header(target, source, env, category):
             # (at the cost of initial build times).
             buf = zlib.compress(buf, zlib.Z_BEST_COMPRESSION)
 
-            g.write("static const unsigned char _{}_translation_{}_compressed[] = {{\n".format(category, name))
-            for j in range(len(buf)):
-                g.write("\t" + str(buf[j]) + ",\n")
-
-            g.write("};\n")
+            g.write(
+                'static const unsigned char _{}_translation_{}_compressed[] = R"~~~~({})~~~~";\n\n'.format(
+                    category, name, buf
+                )
+            )
 
             xl_names.append([name, len(buf), str(decomp_size)])
 

--- a/editor/themes/editor_theme_builders.py
+++ b/editor/themes/editor_theme_builders.py
@@ -20,10 +20,6 @@ def make_fonts_header(target, source, env):
             name = os.path.splitext(os.path.basename(file))[0]
 
             g.write("static const int _font_" + name + "_size = " + str(len(buf)) + ";\n")
-            g.write("static const unsigned char _font_" + name + "[] = {\n")
-            for j in range(len(buf)):
-                g.write("\t" + str(buf[j]) + ",\n")
-
-            g.write("};\n")
+            g.write('static const unsigned char _font_{}[] = R"~~~~({})~~~~";\n\n'.format(name, buf))
 
         g.write("#endif")

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -24,11 +24,7 @@ def make_icu_data(target, source, env):
             buf = f.read()
 
         g.write('extern "C" U_EXPORT const size_t U_ICUDATA_SIZE = ' + str(len(buf)) + ";\n")
-        g.write('extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = {\n')
-        for i in range(len(buf)):
-            g.write("\t" + str(buf[i]) + ",\n")
-
-        g.write("};\n")
+        g.write('extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = R"~~~~({})~~~~";\n\n'.format(buf))
         g.write("#endif")
 
 

--- a/modules/text_server_adv/gdextension_build/methods.py
+++ b/modules/text_server_adv/gdextension_build/methods.py
@@ -66,11 +66,7 @@ def make_icu_data(target, source, env):
             buf = f.read()
 
         g.write('extern "C" U_EXPORT const size_t U_ICUDATA_SIZE = ' + str(len(buf)) + ";\n")
-        g.write('extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = {\n')
-        for i in range(len(buf)):
-            g.write("\t" + str(buf[i]) + ",\n")
-
-        g.write("};\n")
+        g.write('extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = R"~~~~({})~~~~";\n\n'.format(buf))
         g.write("#endif")
 
 

--- a/modules/text_server_fb/gdextension_build/methods.py
+++ b/modules/text_server_fb/gdextension_build/methods.py
@@ -66,11 +66,7 @@ def make_icu_data(target, source, env):
             buf = f.read()
 
         g.write('extern "C" U_EXPORT const size_t U_ICUDATA_SIZE = ' + str(len(buf)) + ";\n")
-        g.write('extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = {\n')
-        for i in range(len(buf)):
-            g.write("\t" + str(buf[i]) + ",\n")
-
-        g.write("};\n")
+        g.write('extern "C" U_EXPORT const unsigned char U_ICUDATA_ENTRY_POINT[] = R"~~~~({})~~~~";\n\n'.format(buf))
         g.write("#endif")
 
 

--- a/scene/theme/default_theme_builders.py
+++ b/scene/theme/default_theme_builders.py
@@ -21,10 +21,6 @@ def make_fonts_header(target, source, env):
             name = os.path.splitext(os.path.basename(file))[0]
 
             g.write("static const int _font_" + name + "_size = " + str(len(buf)) + ";\n")
-            g.write("static const unsigned char _font_" + name + "[] = {\n")
-            for j in range(len(buf)):
-                g.write("\t" + str(buf[j]) + ",\n")
-
-            g.write("};\n")
+            g.write('static const unsigned char _font_{}[] = R"~~~~({})~~~~";\n\n'.format(name, buf))
 
         g.write("#endif")


### PR DESCRIPTION
This decreases the header size and makes it faster to parse.

In an initial test, this shaved off about 13s of CPU build time from `test_main.cpp` (61s to 48s).
The files are about half the size as before (e.g. 16mb to 8mb for `builtin_fonts.gen.h`).
Napkin math suggests about 40s of CPU time and 25mb of file size are saved in total.

It did not substantially reduce the overall build time of Godot.

### Caveats
Raw strings can be terminated. Randomly encountering the terminator `)~~~~"` in a binary file is _pretty unlikely_, but it could happen. Since all embedded files are deterministic (afaik), this is a static problem and should be caught if changes to the files are made that would trigger this problem.

A better solution would be to embed the files using binary embedding tools, or c++23' `#embed`, but this would be substantially more effort.