### PR TITLE
Make sure marked nodes are reset on scene change

### DIFF
--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -892,6 +892,15 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 		return;
 	}
 
+	Node *scene_node = get_scene_node();
+
+	if (node_cache.current_scene_node != scene_node) {
+		_reset();
+		marked.clear();
+		node_cache.current_scene_node = scene_node;
+		node_cache.force_update = true;
+	}
+
 	if (!update_when_invisible && !is_visible_in_tree()) {
 		return;
 	}
@@ -903,13 +912,6 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 	updating_tree = true;
 
 	last_hash = hash_djb2_one_64(0);
-	Node *scene_node = get_scene_node();
-
-	if (node_cache.current_scene_node != scene_node) {
-		_reset();
-		node_cache.current_scene_node = scene_node;
-		node_cache.force_update = true;
-	}
 
 	if (node_cache.current_scene_node) {
 		// Handle pinning/unpinning the animation player only do this once per iteration.


### PR DESCRIPTION
The performance improvement on the SceneTreeEditor caused the previous state of the SceneTreeEditor::marked HashSet to matter, when it previously was always just overwritten when markings changed. The old code thus had no reason to ever clear the marking list.

We now make sure that whether the SceneTreeEditor is hidden or not that when the edited scene changes we always reset the entire state of the editor, including the marked HashSet.

This fixes #100812 and fixes #101056

I tested the MRP from 100812 and this solves the problem. 