### PR TITLE
Move enum BoneAxis to SkeletonModifier from LookAtModifier

### DIFF
--- a/doc/classes/LookAtModifier3D.xml
+++ b/doc/classes/LookAtModifier3D.xml
@@ -47,7 +47,7 @@
 		<member name="ease_type" type="int" setter="set_ease_type" getter="get_ease_type" enum="Tween.EaseType" default="0">
 			The ease type of the time-based interpolation. See also [enum Tween.EaseType].
 		</member>
-		<member name="forward_axis" type="int" setter="set_forward_axis" getter="get_forward_axis" enum="LookAtModifier3D.BoneAxis" default="4">
+		<member name="forward_axis" type="int" setter="set_forward_axis" getter="get_forward_axis" enum="SkeletonModifier3D.BoneAxis" default="4">
 			The forward axis of the bone. This [SkeletonModifier3D] modifies the bone so that this axis points toward the [member target_node].
 		</member>
 		<member name="origin_bone" type="int" setter="set_origin_bone" getter="get_origin_bone">
@@ -129,24 +129,6 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="BONE_AXIS_PLUS_X" value="0" enum="BoneAxis">
-			Enumerated value for the +X axis.
-		</constant>
-		<constant name="BONE_AXIS_MINUS_X" value="1" enum="BoneAxis">
-			Enumerated value for the -X axis.
-		</constant>
-		<constant name="BONE_AXIS_PLUS_Y" value="2" enum="BoneAxis">
-			Enumerated value for the +Y axis.
-		</constant>
-		<constant name="BONE_AXIS_MINUS_Y" value="3" enum="BoneAxis">
-			Enumerated value for the -Y axis.
-		</constant>
-		<constant name="BONE_AXIS_PLUS_Z" value="4" enum="BoneAxis">
-			Enumerated value for the +Z axis.
-		</constant>
-		<constant name="BONE_AXIS_MINUS_Z" value="5" enum="BoneAxis">
-			Enumerated value for the -Z axis.
-		</constant>
 		<constant name="ORIGIN_FROM_SELF" value="0" enum="OriginFrom">
 			The bone rest position of the bone specified in [member bone] is used as origin.
 		</constant>

--- a/doc/classes/SkeletonModifier3D.xml
+++ b/doc/classes/SkeletonModifier3D.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="SkeletonModifier3D" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A Node that may modify Skeleton3D's bone.
+		A node that may modify Skeleton3D's bone.
 	</brief_description>
 	<description>
 		[SkeletonModifier3D] retrieves a target [Skeleton3D] by having a [Skeleton3D] parent.
@@ -43,4 +43,24 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="BONE_AXIS_PLUS_X" value="0" enum="BoneAxis">
+			Enumerated value for the +X axis.
+		</constant>
+		<constant name="BONE_AXIS_MINUS_X" value="1" enum="BoneAxis">
+			Enumerated value for the -X axis.
+		</constant>
+		<constant name="BONE_AXIS_PLUS_Y" value="2" enum="BoneAxis">
+			Enumerated value for the +Y axis.
+		</constant>
+		<constant name="BONE_AXIS_MINUS_Y" value="3" enum="BoneAxis">
+			Enumerated value for the -Y axis.
+		</constant>
+		<constant name="BONE_AXIS_PLUS_Z" value="4" enum="BoneAxis">
+			Enumerated value for the +Z axis.
+		</constant>
+		<constant name="BONE_AXIS_MINUS_Z" value="5" enum="BoneAxis">
+			Enumerated value for the -Z axis.
+		</constant>
+	</constants>
 </class>

--- a/scene/3d/look_at_modifier_3d.h
+++ b/scene/3d/look_at_modifier_3d.h
@@ -38,15 +38,6 @@ class LookAtModifier3D : public SkeletonModifier3D {
 	GDCLASS(LookAtModifier3D, SkeletonModifier3D);
 
 public:
-	enum BoneAxis {
-		BONE_AXIS_PLUS_X,
-		BONE_AXIS_MINUS_X,
-		BONE_AXIS_PLUS_Y,
-		BONE_AXIS_MINUS_Y,
-		BONE_AXIS_PLUS_Z,
-		BONE_AXIS_MINUS_Z,
-	};
-
 	enum OriginFrom {
 		ORIGIN_FROM_SELF,
 		ORIGIN_FROM_SPECIFIC_BONE,
@@ -104,11 +95,6 @@ private:
 	float remaining = 0;
 	float time_step = 1.0;
 
-	Vector3 get_basis_vector_from_bone_axis(const Basis &p_basis, BoneAxis p_axis) const;
-	Vector3 get_vector_from_bone_axis(const BoneAxis &p_axis) const;
-	Vector3 get_vector_from_axis(const Vector3::Axis &p_axis) const;
-	Vector3::Axis get_axis_from_bone_axis(BoneAxis p_axis) const;
-	Vector2 get_projection_vector(const Vector3 &p_vector, Vector3::Axis p_axis) const;
 	float remap_damped(float p_from, float p_to, float p_damp_threshold, float p_value) const;
 	double get_bspline_y(const Vector2 &p_from, const Vector2 &p_control, const Vector2 &p_to, double p_x) const;
 	bool is_intersecting_axis(const Vector3 &p_prev, const Vector3 &p_current, Vector3::Axis p_flipping_axis, Vector3::Axis p_check_axis, bool p_check_plane = false) const;
@@ -197,9 +183,12 @@ public:
 	float get_interpolation_remaining() const;
 	bool is_interpolating() const;
 	bool is_target_within_limitation() const;
+
+	static Vector3::Axis get_secondary_rotation_axis(BoneAxis p_forward_axis, Vector3::Axis p_primary_rotation_axis);
+	static Vector3 get_basis_vector_from_bone_axis(const Basis &p_basis, BoneAxis p_axis);
+	static Vector2 get_projection_vector(const Vector3 &p_vector, Vector3::Axis p_axis);
 };
 
-VARIANT_ENUM_CAST(LookAtModifier3D::BoneAxis);
 VARIANT_ENUM_CAST(LookAtModifier3D::OriginFrom);
 
 #endif // LOOK_AT_MODIFIER_3D_H

--- a/scene/3d/skeleton_modifier_3d.cpp
+++ b/scene/3d/skeleton_modifier_3d.cpp
@@ -152,6 +152,73 @@ void SkeletonModifier3D::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("modification_processed"));
 	GDVIRTUAL_BIND(_process_modification);
+
+	BIND_ENUM_CONSTANT(BONE_AXIS_PLUS_X);
+	BIND_ENUM_CONSTANT(BONE_AXIS_MINUS_X);
+	BIND_ENUM_CONSTANT(BONE_AXIS_PLUS_Y);
+	BIND_ENUM_CONSTANT(BONE_AXIS_MINUS_Y);
+	BIND_ENUM_CONSTANT(BONE_AXIS_PLUS_Z);
+	BIND_ENUM_CONSTANT(BONE_AXIS_MINUS_Z);
+}
+
+Vector3 SkeletonModifier3D::get_vector_from_bone_axis(BoneAxis p_axis) {
+	Vector3 ret;
+	switch (p_axis) {
+		case BONE_AXIS_PLUS_X: {
+			ret = Vector3(1, 0, 0);
+		} break;
+		case BONE_AXIS_MINUS_X: {
+			ret = Vector3(-1, 0, 0);
+		} break;
+		case BONE_AXIS_PLUS_Y: {
+			ret = Vector3(0, 1, 0);
+		} break;
+		case BONE_AXIS_MINUS_Y: {
+			ret = Vector3(0, -1, 0);
+		} break;
+		case BONE_AXIS_PLUS_Z: {
+			ret = Vector3(0, 0, 1);
+		} break;
+		case BONE_AXIS_MINUS_Z: {
+			ret = Vector3(0, 0, -1);
+		} break;
+	}
+	return ret;
+}
+
+Vector3 SkeletonModifier3D::get_vector_from_axis(Vector3::Axis p_axis) {
+	Vector3 ret;
+	switch (p_axis) {
+		case Vector3::AXIS_X: {
+			ret = Vector3(1, 0, 0);
+		} break;
+		case Vector3::AXIS_Y: {
+			ret = Vector3(0, 1, 0);
+		} break;
+		case Vector3::AXIS_Z: {
+			ret = Vector3(0, 0, 1);
+		} break;
+	}
+	return ret;
+}
+
+Vector3::Axis SkeletonModifier3D::get_axis_from_bone_axis(BoneAxis p_axis) {
+	Vector3::Axis ret = Vector3::AXIS_X;
+	switch (p_axis) {
+		case BONE_AXIS_PLUS_X:
+		case BONE_AXIS_MINUS_X: {
+			ret = Vector3::AXIS_X;
+		} break;
+		case BONE_AXIS_PLUS_Y:
+		case BONE_AXIS_MINUS_Y: {
+			ret = Vector3::AXIS_Y;
+		} break;
+		case BONE_AXIS_PLUS_Z:
+		case BONE_AXIS_MINUS_Z: {
+			ret = Vector3::AXIS_Z;
+		} break;
+	}
+	return ret;
 }
 
 SkeletonModifier3D::SkeletonModifier3D() {

--- a/scene/3d/skeleton_modifier_3d.h
+++ b/scene/3d/skeleton_modifier_3d.h
@@ -40,6 +40,16 @@ class SkeletonModifier3D : public Node3D {
 
 	void rebind();
 
+public:
+	enum BoneAxis {
+		BONE_AXIS_PLUS_X,
+		BONE_AXIS_MINUS_X,
+		BONE_AXIS_PLUS_Y,
+		BONE_AXIS_MINUS_Y,
+		BONE_AXIS_PLUS_Z,
+		BONE_AXIS_MINUS_Z,
+	};
+
 protected:
 	bool active = true;
 	real_t influence = 1.0;
@@ -76,7 +86,14 @@ public:
 
 	void process_modification();
 
+	// Utility APIs.
+	static Vector3 get_vector_from_bone_axis(BoneAxis p_axis);
+	static Vector3 get_vector_from_axis(Vector3::Axis p_axis);
+	static Vector3::Axis get_axis_from_bone_axis(BoneAxis p_axis);
+
 	SkeletonModifier3D();
 };
+
+VARIANT_ENUM_CAST(SkeletonModifier3D::BoneAxis);
 
 #endif // SKELETON_MODIFIER_3D_H


### PR DESCRIPTION
- Separate from https://github.com/godotengine/godot/pull/100984

The enum and helper functions for the axes are moved to SkeletonModifire for reuse since they may be used frequently in the bone processing.