### PR TITLE
Fix embedded game focus border

### DIFF
--- a/editor/plugins/embedded_process.cpp
+++ b/editor/plugins/embedded_process.cpp
@@ -66,8 +66,8 @@ void EmbeddedProcess::_notification(int p_what) {
 			focus_style_box = get_theme_stylebox(SNAME("FocusViewport"), EditorStringName(EditorStyles));
 			Ref<StyleBoxFlat> focus_style_box_flat = focus_style_box;
 			if (focus_style_box_flat.is_valid()) {
-				margin_top_left = Point2i(focus_style_box_flat->get_corner_radius(CORNER_TOP_LEFT), focus_style_box_flat->get_corner_radius(CORNER_TOP_LEFT));
-				margin_bottom_right = Point2i(focus_style_box_flat->get_corner_radius(CORNER_BOTTOM_RIGHT), focus_style_box_flat->get_corner_radius(CORNER_BOTTOM_RIGHT));
+				margin_top_left = Point2i(focus_style_box_flat->get_border_width(SIDE_LEFT), focus_style_box_flat->get_border_width(SIDE_TOP));
+				margin_bottom_right = Point2i(focus_style_box_flat->get_border_width(SIDE_RIGHT), focus_style_box_flat->get_border_width(SIDE_BOTTOM));
 			} else if (focus_style_box.is_valid()) {
 				margin_top_left = Point2i(focus_style_box->get_margin(SIDE_LEFT), focus_style_box->get_margin(SIDE_TOP));
 				margin_bottom_right = Point2i(focus_style_box->get_margin(SIDE_RIGHT), focus_style_box->get_margin(SIDE_BOTTOM));


### PR DESCRIPTION
- Fixes #101152

The corner size was used to calculate the border size in `EmbeddedProcess`. In the Godot Minimal Theme from Passivestar, the corner size is zero. Using the `get_border_width` fixed the issue with the theme and works even better with default Godot theme, removing some empty space around the game window.

With the theme:
![image](https://github.com/user-attachments/assets/05c00072-b948-4817-bd28-e82fa44454cf)

Default theme:
![image](https://github.com/user-attachments/assets/9f85056f-5c46-4c56-bef3-1bdcfb4f1467)

