### PR TITLE
[DRAFT] Update `ResourceFormatSaver::_save()` virtual method for new integrity level argument

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -884,7 +884,7 @@ Error ProjectSettings::save() {
 
 Error ProjectSettings::_save_settings_binary(const String &p_file, const RBMap<String, List<String>> &p_props, const CustomMap &p_custom, const String &p_custom_features) {
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_file, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_file, FileAccess::WRITE, &err, FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Couldn't save project.binary at '%s'.", p_file));
 
 	uint8_t hdr[4] = { 'E', 'C', 'F', 'G' };
@@ -953,7 +953,7 @@ Error ProjectSettings::_save_settings_binary(const String &p_file, const RBMap<S
 
 Error ProjectSettings::_save_settings_text(const String &p_file, const RBMap<String, List<String>> &p_props, const CustomMap &p_custom, const String &p_custom_features) {
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_file, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_file, FileAccess::WRITE, &err, FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Couldn't save project.godot - %s.", p_file));
 
@@ -1261,7 +1261,7 @@ void ProjectSettings::store_global_class_list(const Array &p_classes) {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
 	cf->set_value("", "list", p_classes);
-	cf->save(get_global_class_list_path());
+	cf->save(get_global_class_list_path(), FileAccess::SAVE_INTEGRITY_NONE);
 
 	global_class_list = p_classes;
 }

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -238,8 +238,15 @@ void OS::close_midi_inputs() {
 	::OS::get_singleton()->close_midi_inputs();
 }
 
+#ifndef DISABLE_DEPRECATED
 void OS::set_use_file_access_save_and_swap(bool p_enable) {
-	FileAccess::set_backup_save(p_enable);
+	WARN_DEPRECATED_MSG("Use set_default_save_integrity_level() instead.");
+	FileAccess::set_default_save_integrity_level(p_enable ? FileAccess::SAVE_INTEGRITY_SAVE_SWAP : FileAccess::SAVE_INTEGRITY_NONE);
+}
+#endif
+
+void OS::set_default_save_integrity_level(FileAccess::SaveIntegrityLevel p_integrity_level) {
+	FileAccess::set_default_save_integrity_level(p_integrity_level);
 }
 
 void OS::set_low_processor_usage_mode(bool p_enabled) {
@@ -722,7 +729,10 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_keycode_unicode", "code"), &OS::is_keycode_unicode);
 	ClassDB::bind_method(D_METHOD("find_keycode_from_string", "string"), &OS::find_keycode_from_string);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_use_file_access_save_and_swap", "enabled"), &OS::set_use_file_access_save_and_swap);
+#endif
+	ClassDB::bind_method(D_METHOD("set_default_save_integrity_level", "integrity_level"), &OS::set_default_save_integrity_level);
 
 	ClassDB::bind_method(D_METHOD("set_thread_name", "name"), &OS::set_thread_name);
 	ClassDB::bind_method(D_METHOD("get_thread_caller_id"), &OS::get_thread_caller_id);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -227,7 +227,10 @@ public:
 	bool is_keycode_unicode(char32_t p_unicode) const;
 	Key find_keycode_from_string(const String &p_code) const;
 
+#ifndef DISABLE_DEPRECATED
 	void set_use_file_access_save_and_swap(bool p_enable);
+#endif
+	void set_default_save_integrity_level(FileAccess::SaveIntegrityLevel p_integrity_level);
 
 	uint64_t get_static_memory_usage() const;
 	uint64_t get_static_memory_peak_usage() const;

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -228,7 +228,7 @@ String ResourceFormatLoaderCrypto::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverCrypto::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverCrypto::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err;
 	Ref<X509Certificate> cert = p_resource;
 	Ref<CryptoKey> key = p_resource;

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -163,7 +163,7 @@ public:
 
 class ResourceFormatSaverCrypto : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -1020,7 +1020,19 @@ Dictionary GDExtensionAPIDump::generate_extension_api(bool p_include_docs) {
 						d2["is_required"] = (F.flags & METHOD_FLAG_VIRTUAL_REQUIRED) ? true : false;
 						d2["is_vararg"] = false;
 						d2["is_virtual"] = true;
-						// virtual functions have no hash since no MethodBind is involved
+						d2["hash"] = mi.get_compatibility_hash();
+
+						Vector<uint32_t> compat_hashes = ClassDB::get_virtual_method_compatibility_hashes(class_name, method_name);
+						Array compatibility;
+						if (compat_hashes.size()) {
+							for (int i = 0; i < compat_hashes.size(); i++) {
+								compatibility.push_back(compat_hashes[i]);
+							}
+						}
+						if (compatibility.size() > 0) {
+							d2["hash_compatibility"] = compatibility;
+						}
+
 						bool has_return = mi.return_val.type != Variant::NIL || (mi.return_val.usage & PROPERTY_USAGE_NIL_IS_VARIANT);
 						if (has_return) {
 							PropertyInfo pinfo = mi.return_val;
@@ -1473,8 +1485,8 @@ static bool compare_dict_array(const Dictionary &p_old_api, const Dictionary &p_
 
 		if (p_compare_hashes) {
 			if (!old_elem.has("hash")) {
-				if (old_elem.has("is_virtual") && bool(old_elem["is_virtual"]) && !new_elem.has("hash")) {
-					continue; // No hash for virtual methods, go on.
+				if (old_elem.has("is_virtual") && bool(old_elem["is_virtual"]) && !old_elem.has("hash")) {
+					continue; // Virtual methods didn't used to have hashes, so skip check if it's missing in the old file.
 				}
 
 				failed = true;

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -259,7 +259,7 @@ void GDExtension::_register_extension_class(GDExtensionClassLibraryPtr p_library
 		nullptr, // GDExtensionClassCreateInstance2 create_instance_func; /* this one is mandatory */
 		p_extension_funcs->free_instance_func, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
 		nullptr, // GDExtensionClassRecreateInstance recreate_instance_func;
-		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
+		nullptr, // GDExtensionClassGetVirtual get_virtual_func;
 		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
 		nullptr, // GDExtensionClassCallVirtualWithData call_virtual_func;
 		p_extension_funcs->class_userdata, // void *class_userdata;
@@ -270,6 +270,8 @@ void GDExtension::_register_extension_class(GDExtensionClassLibraryPtr p_library
 		p_extension_funcs->free_property_list_func, // GDExtensionClassFreePropertyList free_property_list_func;
 		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance create_instance_func;
 		p_extension_funcs->get_rid_func, // GDExtensionClassGetRID get_rid;
+		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
+		nullptr,
 	};
 	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info4, &legacy);
 }
@@ -294,8 +296,8 @@ void GDExtension::_register_extension_class2(GDExtensionClassLibraryPtr p_librar
 		nullptr, // GDExtensionClassCreateInstance2 create_instance_func; /* this one is mandatory */
 		p_extension_funcs->free_instance_func, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
 		p_extension_funcs->recreate_instance_func, // GDExtensionClassRecreateInstance recreate_instance_func;
-		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
-		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
+		nullptr, // GDExtensionClassGetVirtual get_virtual_func;
+		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
 		p_extension_funcs->call_virtual_with_data_func, // GDExtensionClassCallVirtualWithData call_virtual_func;
 		p_extension_funcs->class_userdata, // void *class_userdata;
 	};
@@ -305,6 +307,8 @@ void GDExtension::_register_extension_class2(GDExtensionClassLibraryPtr p_librar
 		p_extension_funcs->free_property_list_func, // GDExtensionClassFreePropertyList free_property_list_func;
 		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance create_instance_func;
 		p_extension_funcs->get_rid_func, // GDExtensionClassGetRID get_rid;
+		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
+		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtual get_virtual_func;
 	};
 	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info4, &legacy);
 }
@@ -329,8 +333,8 @@ void GDExtension::_register_extension_class3(GDExtensionClassLibraryPtr p_librar
 		nullptr, // GDExtensionClassCreateInstance2 create_instance_func; /* this one is mandatory */
 		p_extension_funcs->free_instance_func, // GDExtensionClassFreeInstance free_instance_func; /* this one is mandatory */
 		p_extension_funcs->recreate_instance_func, // GDExtensionClassRecreateInstance recreate_instance_func;
-		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
-		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
+		nullptr, // GDExtensionClassGetVirtual get_virtual_func;
+		nullptr, // GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
 		p_extension_funcs->call_virtual_with_data_func, // GDExtensionClassCallVirtualWithData call_virtual_func;
 		p_extension_funcs->class_userdata, // void *class_userdata;
 	};
@@ -340,6 +344,8 @@ void GDExtension::_register_extension_class3(GDExtensionClassLibraryPtr p_librar
 		nullptr, // GDExtensionClassFreePropertyList free_property_list_func;
 		p_extension_funcs->create_instance_func, // GDExtensionClassCreateInstance2 create_instance_func;
 		p_extension_funcs->get_rid_func, // GDExtensionClassGetRID get_rid;
+		p_extension_funcs->get_virtual_func, // GDExtensionClassGetVirtual get_virtual_func;
+		p_extension_funcs->get_virtual_call_data_func, // GDExtensionClassGetVirtual get_virtual_func;
 	};
 	_register_extension_class_internal(p_library, p_class_name, p_parent_class_name, &class_info4, &legacy);
 }
@@ -428,6 +434,8 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 		extension->gdextension.free_property_list = p_deprecated_funcs->free_property_list_func;
 		extension->gdextension.create_instance = p_deprecated_funcs->create_instance_func;
 		extension->gdextension.get_rid = p_deprecated_funcs->get_rid_func;
+		extension->gdextension.get_virtual = p_deprecated_funcs->get_virtual_func;
+		extension->gdextension.get_virtual_call_data = p_deprecated_funcs->get_virtual_call_data_func;
 	}
 #endif // DISABLE_DEPRECATED
 	extension->gdextension.notification2 = p_extension_funcs->notification_func;
@@ -438,8 +446,8 @@ void GDExtension::_register_extension_class_internal(GDExtensionClassLibraryPtr 
 	extension->gdextension.create_instance2 = p_extension_funcs->create_instance_func;
 	extension->gdextension.free_instance = p_extension_funcs->free_instance_func;
 	extension->gdextension.recreate_instance = p_extension_funcs->recreate_instance_func;
-	extension->gdextension.get_virtual = p_extension_funcs->get_virtual_func;
-	extension->gdextension.get_virtual_call_data = p_extension_funcs->get_virtual_call_data_func;
+	extension->gdextension.get_virtual2 = p_extension_funcs->get_virtual_func;
+	extension->gdextension.get_virtual_call_data2 = p_extension_funcs->get_virtual_call_data_func;
 	extension->gdextension.call_virtual_with_data = p_extension_funcs->call_virtual_with_data_func;
 
 	extension->gdextension.reloadable = self->reloadable;

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -72,6 +72,8 @@ class GDExtension : public Resource {
 		GDExtensionClassFreePropertyList free_property_list_func = nullptr;
 		GDExtensionClassCreateInstance create_instance_func = nullptr;
 		GDExtensionClassGetRID get_rid_func = nullptr;
+		GDExtensionClassGetVirtual get_virtual_func = nullptr;
+		GDExtensionClassGetVirtualCallData get_virtual_call_data_func = nullptr;
 #endif // DISABLE_DEPRECATED
 	};
 

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -273,7 +273,9 @@ typedef GDExtensionObjectPtr (*GDExtensionClassCreateInstance2)(void *p_class_us
 typedef void (*GDExtensionClassFreeInstance)(void *p_class_userdata, GDExtensionClassInstancePtr p_instance);
 typedef GDExtensionClassInstancePtr (*GDExtensionClassRecreateInstance)(void *p_class_userdata, GDExtensionObjectPtr p_object);
 typedef GDExtensionClassCallVirtual (*GDExtensionClassGetVirtual)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name);
+typedef GDExtensionClassCallVirtual (*GDExtensionClassGetVirtual2)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name, uint32_t p_hash);
 typedef void *(*GDExtensionClassGetVirtualCallData)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name);
+typedef void *(*GDExtensionClassGetVirtualCallData2)(void *p_class_userdata, GDExtensionConstStringNamePtr p_name, uint32_t p_hash);
 typedef void (*GDExtensionClassCallVirtualWithData)(GDExtensionClassInstancePtr p_instance, GDExtensionConstStringNamePtr p_name, void *p_virtual_call_userdata, const GDExtensionConstTypePtr *p_args, GDExtensionTypePtr r_ret);
 
 typedef struct {
@@ -383,14 +385,14 @@ typedef struct {
 	GDExtensionClassFreeInstance free_instance_func; // Destructor; mandatory.
 	GDExtensionClassRecreateInstance recreate_instance_func;
 	// Queries a virtual function by name and returns a callback to invoke the requested virtual function.
-	GDExtensionClassGetVirtual get_virtual_func;
+	GDExtensionClassGetVirtual2 get_virtual_func;
 	// Paired with `call_virtual_with_data_func`, this is an alternative to `get_virtual_func` for extensions that
 	// need or benefit from extra data when calling virtual functions.
 	// Returns user data that will be passed to `call_virtual_with_data_func`.
 	// Returning `NULL` from this function signals to Godot that the virtual function is not overridden.
 	// Data returned from this function should be managed by the extension and must be valid until the extension is deinitialized.
 	// You should supply either `get_virtual_func`, or `get_virtual_call_data_func` with `call_virtual_with_data_func`.
-	GDExtensionClassGetVirtualCallData get_virtual_call_data_func;
+	GDExtensionClassGetVirtualCallData2 get_virtual_call_data_func;
 	// Used to call virtual functions when `get_virtual_call_data_func` is not null.
 	GDExtensionClassCallVirtualWithData call_virtual_with_data_func;
 	void *class_userdata; // Per-class user data, later accessible in instance bindings.

--- a/core/io/config_file.compat.inc
+++ b/core/io/config_file.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  image_saver_tinyexr.h                                                 */
+/*  config_file.compat.inc                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,12 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef IMAGE_SAVER_TINYEXR_H
-#define IMAGE_SAVER_TINYEXR_H
+#ifndef DISABLE_DEPRECATED
 
-#include "core/io/image.h"
+Error ConfigFile::_save_compat_100447(const String &p_path) {
+	return save(p_path);
+}
 
-Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, FileAccess::SaveIntegrityLevel p_integrity_level);
-Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale);
+void ConfigFile::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("save", "path"), &ConfigFile::_save_compat_100447);
+}
 
-#endif // IMAGE_SAVER_TINYEXR_H
+#endif

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "config_file.h"
+#include "config_file.compat.inc"
 
 #include "core/io/file_access_encrypted.h"
 #include "core/os/keyboard.h"
@@ -153,9 +154,9 @@ String ConfigFile::encode_to_text() const {
 	return sb.as_string();
 }
 
-Error ConfigFile::save(const String &p_path) {
+Error ConfigFile::save(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 	if (err) {
 		return err;
@@ -334,7 +335,7 @@ void ConfigFile::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &ConfigFile::load);
 	ClassDB::bind_method(D_METHOD("parse", "data"), &ConfigFile::parse);
-	ClassDB::bind_method(D_METHOD("save", "path"), &ConfigFile::save);
+	ClassDB::bind_method(D_METHOD("save", "path", "integrity_level"), &ConfigFile::save, DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 
 	ClassDB::bind_method(D_METHOD("encode_to_text"), &ConfigFile::encode_to_text);
 

--- a/core/io/config_file.h
+++ b/core/io/config_file.h
@@ -51,6 +51,12 @@ class ConfigFile : public RefCounted {
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error _save_compat_100447(const String &p_path);
+
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	void set_value(const String &p_section, const String &p_key, const Variant &p_value);
 	Variant get_value(const String &p_section, const String &p_key, const Variant &p_default = Variant()) const;
@@ -64,7 +70,7 @@ public:
 	void erase_section(const String &p_section);
 	void erase_section_key(const String &p_section, const String &p_key);
 
-	Error save(const String &p_path);
+	Error save(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	Error load(const String &p_path);
 	Error parse(const String &p_data);
 

--- a/core/io/file_access.compat.inc
+++ b/core/io/file_access.compat.inc
@@ -30,6 +30,10 @@
 
 #ifndef DISABLE_DEPRECATED
 
+Ref<FileAccess> FileAccess::_open_bind_compat_100447(const String &p_path, ModeFlags p_mode_flags) {
+	return _open(p_path, p_mode_flags);
+}
+
 Ref<FileAccess> FileAccess::_open_encrypted_bind_compat_98918(const String &p_path, ModeFlags p_mode_flags, const Vector<uint8_t> &p_key) {
 	return open_encrypted(p_path, p_mode_flags, p_key, Vector<uint8_t>());
 }
@@ -91,6 +95,7 @@ void FileAccess::store_pascal_string_bind_compat_78289(const String &p_string) {
 }
 
 void FileAccess::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_static_method("FileAccess", D_METHOD("open", "path", "flags"), &FileAccess::_open_bind_compat_100447);
 	ClassDB::bind_compatibility_static_method("FileAccess", D_METHOD("open_encrypted", "path", "mode_flags", "key"), &FileAccess::_open_encrypted_bind_compat_98918);
 
 	ClassDB::bind_compatibility_method(D_METHOD("store_8", "value"), &FileAccess::store_8_bind_compat_78289);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -84,6 +84,16 @@ public:
 		COMPRESSION_BROTLI = Compression::MODE_BROTLI,
 	};
 
+	// These enum values only make sense when p_mode_flags == WRITE and the underlying FileAccess
+	// type supports it (e.g. regular files support it, but zip or encrypted files do not).
+	enum SaveIntegrityLevel {
+		SAVE_INTEGRITY_DEFAULT,
+		SAVE_INTEGRITY_NONE,
+		SAVE_INTEGRITY_SAVE_SWAP,
+		SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC,
+		SAVE_INTEGRITY_MAX,
+	};
+
 	typedef void (*FileCloseFailNotify)(const String &);
 
 	typedef Ref<FileAccess> (*CreateFunc)();
@@ -103,13 +113,15 @@ protected:
 
 	AccessType get_access_type() const;
 	virtual String fix_path(const String &p_path) const;
-	virtual Error open_internal(const String &p_path, int p_mode_flags) = 0; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) = 0; ///< open a file
 	virtual uint64_t _get_modified_time(const String &p_file) = 0;
 	virtual void _set_access_type(AccessType p_access);
 
 	static FileCloseFailNotify close_fail_notify;
 
 #ifndef DISABLE_DEPRECATED
+	static Ref<FileAccess> _open_bind_compat_100447(const String &p_path, ModeFlags p_mode_flags);
+
 	static Ref<FileAccess> _open_encrypted_bind_compat_98918(const String &p_path, ModeFlags p_mode_flags, const Vector<uint8_t> &p_key);
 
 	void store_8_bind_compat_78289(uint8_t p_dest);
@@ -131,7 +143,7 @@ protected:
 #endif
 
 private:
-	static bool backup_save;
+	static SaveIntegrityLevel default_save_integrity_level;
 	thread_local static Error last_file_open_error;
 
 	AccessType _access_type = ACCESS_FILESYSTEM;
@@ -141,7 +153,7 @@ private:
 		return memnew(T);
 	}
 
-	static Ref<FileAccess> _open(const String &p_path, ModeFlags p_mode_flags);
+	static Ref<FileAccess> _open(const String &p_path, ModeFlags p_mode_flags, SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 
 	bool _is_temp_file = false;
 	bool _temp_keep_after_use = false;
@@ -224,11 +236,11 @@ public:
 
 	virtual bool file_exists(const String &p_name) = 0; ///< return true if a file exists
 
-	virtual Error reopen(const String &p_path, int p_mode_flags); ///< does not change the AccessType
+	virtual Error reopen(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level = SAVE_INTEGRITY_DEFAULT); ///< does not change the AccessType
 
 	static Ref<FileAccess> create(AccessType p_access); /// Create a file access (for the current platform) this is the only portable way of accessing files.
 	static Ref<FileAccess> create_for_path(const String &p_path);
-	static Ref<FileAccess> open(const String &p_path, int p_mode_flags, Error *r_error = nullptr); /// Create a file access (for the current platform) this is the only portable way of accessing files.
+	static Ref<FileAccess> open(const String &p_path, int p_mode_flags, Error *r_error = nullptr, SaveIntegrityLevel p_integrity_level = SAVE_INTEGRITY_DEFAULT); /// Create a file access (for the current platform) this is the only portable way of accessing files.
 	static Ref<FileAccess> create_temp(int p_mode_flags, const String &p_prefix = "", const String &p_extension = "", bool p_keep = false, Error *r_error = nullptr);
 
 	static Ref<FileAccess> open_encrypted(const String &p_path, ModeFlags p_mode_flags, const Vector<uint8_t> &p_key, const Vector<uint8_t> &p_iv = Vector<uint8_t>());
@@ -247,8 +259,8 @@ public:
 	static bool get_read_only_attribute(const String &p_file);
 	static Error set_read_only_attribute(const String &p_file, bool p_ro);
 
-	static void set_backup_save(bool p_enable) { backup_save = p_enable; }
-	static bool is_backup_save_enabled() { return backup_save; }
+	static void set_default_save_integrity_level(SaveIntegrityLevel p_integrity_level);
+	static SaveIntegrityLevel get_default_save_integrity_level() { return default_save_integrity_level; }
 
 	static String get_md5(const String &p_file);
 	static String get_sha256(const String &p_file);
@@ -267,11 +279,12 @@ public:
 
 public:
 	FileAccess() {}
-	virtual ~FileAccess();
+	virtual ~FileAccess() override;
 };
 
 VARIANT_ENUM_CAST(FileAccess::CompressionMode);
 VARIANT_ENUM_CAST(FileAccess::ModeFlags);
+VARIANT_ENUM_CAST(FileAccess::SaveIntegrityLevel);
 VARIANT_BITFIELD_CAST(FileAccess::UnixPermissionFlags);
 
 #endif // FILE_ACCESS_H

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -77,7 +77,7 @@ Error FileAccessCompressed::open_after_magic(Ref<FileAccess> p_base) {
 	return ret == -1 ? ERR_FILE_CORRUPT : OK;
 }
 
-Error FileAccessCompressed::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessCompressed::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	ERR_FAIL_COND_V(p_mode_flags == READ_WRITE, ERR_UNAVAILABLE);
 	_close();
 

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -70,7 +70,7 @@ public:
 
 	Error open_after_magic(Ref<FileAccess> p_base);
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -119,7 +119,7 @@ Error FileAccessEncrypted::open_and_parse_password(Ref<FileAccess> p_base, const
 	return open_and_parse(p_base, key_md5, p_mode);
 }
 
-Error FileAccessEncrypted::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessEncrypted::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	return OK;
 }
 

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -63,7 +63,7 @@ public:
 
 	Vector<uint8_t> get_iv() const { return iv; }
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -78,7 +78,7 @@ Error FileAccessMemory::open_custom(const uint8_t *p_data, uint64_t p_len) {
 	return OK;
 }
 
-Error FileAccessMemory::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessMemory::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	ERR_FAIL_NULL_V(files, ERR_FILE_NOT_FOUND);
 
 	String name = fix_path(p_path);

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -45,7 +45,7 @@ public:
 	static void cleanup();
 
 	virtual Error open_custom(const uint8_t *p_data, uint64_t p_len); ///< open a file
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual void seek(uint64_t p_position) override; ///< seek to a given position

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -333,7 +333,7 @@ Ref<FileAccess> PackedSourcePCK::get_file(const String &p_path, PackedData::Pack
 
 //////////////////////////////////////////////////////////////////
 
-Error FileAccessPack::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessPack::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	ERR_PRINT("Can't open pack-referenced file.");
 	return ERR_UNAVAILABLE;
 }

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -156,7 +156,7 @@ class FileAccessPack : public FileAccess {
 	uint64_t off;
 
 	Ref<FileAccess> f;
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override;
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override;
 	virtual uint64_t _get_modified_time(const String &p_file) override { return 0; }
 	virtual BitField<FileAccess::UnixPermissionFlags> _get_unix_permissions(const String &p_file) override { return 0; }
 	virtual Error _set_unix_permissions(const String &p_file, BitField<FileAccess::UnixPermissionFlags> p_permissions) override { return FAILED; }

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -234,7 +234,7 @@ ZipArchive::~ZipArchive() {
 	packages.clear();
 }
 
-Error FileAccessZip::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessZip::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
 
 	ERR_FAIL_COND_V(p_mode_flags & FileAccess::WRITE, FAILED);
@@ -335,7 +335,7 @@ void FileAccessZip::close() {
 }
 
 FileAccessZip::FileAccessZip(const String &p_path, const PackedData::PackedFile &p_file) {
-	open_internal(p_path, FileAccess::READ);
+	open_internal(p_path, FileAccess::READ, SAVE_INTEGRITY_NONE);
 }
 
 FileAccessZip::~FileAccessZip() {

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -85,7 +85,7 @@ class FileAccessZip : public FileAccess {
 	void _close();
 
 public:
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual void seek(uint64_t p_position) override; ///< seek to a given position

--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  image_saver_tinyexr.h                                                 */
+/*  image.compat.inc                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,12 +28,29 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef IMAGE_SAVER_TINYEXR_H
-#define IMAGE_SAVER_TINYEXR_H
+#ifndef DISABLE_DEPRECATED
 
-#include "core/io/image.h"
+Error Image::_save_png_compat_100447(const String &p_path) const {
+	return save_png(p_path);
+}
 
-Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, FileAccess::SaveIntegrityLevel p_integrity_level);
-Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale);
+Error Image::_save_jpg_compat_100447(const String &p_path, float p_quality) const {
+	return save_jpg(p_path, p_quality);
+}
 
-#endif // IMAGE_SAVER_TINYEXR_H
+Error Image::_save_exr_compat_100447(const String &p_path, bool p_grayscale) const {
+	return save_exr(p_path, p_grayscale);
+}
+
+Error Image::_save_webp_compat_100447(const String &p_path, const bool p_lossy, const float p_quality) const {
+	return save_webp(p_path, p_lossy, p_quality);
+}
+
+void Image::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("save_png", "path"), &Image::_save_png_compat_100447);
+	ClassDB::bind_compatibility_method(D_METHOD("save_jpg", "path", "quality"), &Image::_save_jpg_compat_100447, DEFVAL(0.75));
+	ClassDB::bind_compatibility_method(D_METHOD("save_exr", "path", "grayscale"), &Image::_save_exr_compat_100447, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("save_webp", "path", "lossy", "quality"), &Image::_save_webp_compat_100447, DEFVAL(false), DEFVAL(0.75f));
+}
+
+#endif

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "image.h"
+#include "image.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/error/error_list.h"
@@ -2558,20 +2559,20 @@ Ref<Image> Image::load_from_file(const String &p_path) {
 	return image;
 }
 
-Error Image::save_png(const String &p_path) const {
+Error Image::save_png(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level) const {
 	if (save_png_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 
-	return save_png_func(p_path, Ref<Image>((Image *)this));
+	return save_png_func(p_path, Ref<Image>((Image *)this), p_integrity_level);
 }
 
-Error Image::save_jpg(const String &p_path, float p_quality) const {
+Error Image::save_jpg(const String &p_path, float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level) const {
 	if (save_jpg_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 
-	return save_jpg_func(p_path, Ref<Image>((Image *)this), p_quality);
+	return save_jpg_func(p_path, Ref<Image>((Image *)this), p_quality, p_integrity_level);
 }
 
 Vector<uint8_t> Image::save_png_to_buffer() const {
@@ -2590,12 +2591,12 @@ Vector<uint8_t> Image::save_jpg_to_buffer(float p_quality) const {
 	return save_jpg_buffer_func(Ref<Image>((Image *)this), p_quality);
 }
 
-Error Image::save_exr(const String &p_path, bool p_grayscale) const {
+Error Image::save_exr(const String &p_path, bool p_grayscale, FileAccess::SaveIntegrityLevel p_integrity_level) const {
 	if (save_exr_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 
-	return save_exr_func(p_path, Ref<Image>((Image *)this), p_grayscale);
+	return save_exr_func(p_path, Ref<Image>((Image *)this), p_grayscale, p_integrity_level);
 }
 
 Vector<uint8_t> Image::save_exr_to_buffer(bool p_grayscale) const {
@@ -2605,13 +2606,13 @@ Vector<uint8_t> Image::save_exr_to_buffer(bool p_grayscale) const {
 	return save_exr_buffer_func(Ref<Image>((Image *)this), p_grayscale);
 }
 
-Error Image::save_webp(const String &p_path, const bool p_lossy, const float p_quality) const {
+Error Image::save_webp(const String &p_path, const bool p_lossy, const float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level) const {
 	if (save_webp_func == nullptr) {
 		return ERR_UNAVAILABLE;
 	}
 	ERR_FAIL_COND_V_MSG(p_lossy && !(0.0f <= p_quality && p_quality <= 1.0f), ERR_INVALID_PARAMETER, vformat("The WebP lossy quality was set to %f, which is not valid. WebP lossy quality must be between 0.0 and 1.0 (inclusive).", p_quality));
 
-	return save_webp_func(p_path, Ref<Image>((Image *)this), p_lossy, p_quality);
+	return save_webp_func(p_path, Ref<Image>((Image *)this), p_lossy, p_quality, p_integrity_level);
 }
 
 Vector<uint8_t> Image::save_webp_to_buffer(const bool p_lossy, const float p_quality) const {
@@ -3520,13 +3521,13 @@ void Image::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &Image::load);
 	ClassDB::bind_static_method("Image", D_METHOD("load_from_file", "path"), &Image::load_from_file);
-	ClassDB::bind_method(D_METHOD("save_png", "path"), &Image::save_png);
+	ClassDB::bind_method(D_METHOD("save_png", "path", "integrity_level"), &Image::save_png, DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 	ClassDB::bind_method(D_METHOD("save_png_to_buffer"), &Image::save_png_to_buffer);
-	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality"), &Image::save_jpg, DEFVAL(0.75));
+	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality", "integrity_level"), &Image::save_jpg, DEFVAL(0.75), DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 	ClassDB::bind_method(D_METHOD("save_jpg_to_buffer", "quality"), &Image::save_jpg_to_buffer, DEFVAL(0.75));
-	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale"), &Image::save_exr, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale", "integrity_level"), &Image::save_exr, DEFVAL(false), DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 	ClassDB::bind_method(D_METHOD("save_exr_to_buffer", "grayscale"), &Image::save_exr_to_buffer, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("save_webp", "path", "lossy", "quality"), &Image::save_webp, DEFVAL(false), DEFVAL(0.75f));
+	ClassDB::bind_method(D_METHOD("save_webp", "path", "lossy", "quality", "integrity_level"), &Image::save_webp, DEFVAL(false), DEFVAL(0.75f), DEFVAL(FileAccess::SAVE_INTEGRITY_DEFAULT));
 	ClassDB::bind_method(D_METHOD("save_webp_to_buffer", "lossy", "quality"), &Image::save_webp_to_buffer, DEFVAL(false), DEFVAL(0.75f));
 
 	ClassDB::bind_method(D_METHOD("detect_alpha"), &Image::detect_alpha);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -31,6 +31,7 @@
 #ifndef IMAGE_H
 #define IMAGE_H
 
+#include "core/io/file_access.h"
 #include "core/io/resource.h"
 #include "core/math/color.h"
 #include "core/math/rect2.h"
@@ -45,19 +46,19 @@ class Image;
 
 // Function pointer prototypes.
 
-typedef Error (*SavePNGFunc)(const String &p_path, const Ref<Image> &p_img);
+typedef Error (*SavePNGFunc)(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level);
 typedef Vector<uint8_t> (*SavePNGBufferFunc)(const Ref<Image> &p_img);
 
-typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, float p_quality);
+typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level);
 typedef Vector<uint8_t> (*SaveJPGBufferFunc)(const Ref<Image> &p_img, float p_quality);
 
 typedef Ref<Image> (*ImageMemLoadFunc)(const uint8_t *p_png, int p_size);
 typedef Ref<Image> (*ScalableImageMemLoadFunc)(const uint8_t *p_data, int p_size, float p_scale);
 
-typedef Error (*SaveWebPFunc)(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
+typedef Error (*SaveWebPFunc)(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level);
 typedef Vector<uint8_t> (*SaveWebPBufferFunc)(const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
 
-typedef Error (*SaveEXRFunc)(const String &p_path, const Ref<Image> &p_img, bool p_grayscale);
+typedef Error (*SaveEXRFunc)(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, FileAccess::SaveIntegrityLevel p_integrity_level);
 typedef Vector<uint8_t> (*SaveEXRBufferFunc)(const Ref<Image> &p_img, bool p_grayscale);
 
 class Image : public Resource {
@@ -237,6 +238,15 @@ public:
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error _save_png_compat_100447(const String &p_path) const;
+	Error _save_jpg_compat_100447(const String &p_path, float p_quality = 0.75) const;
+	Error _save_exr_compat_100447(const String &p_path, bool p_grayscale = false) const;
+	Error _save_webp_compat_100447(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
+
+	static void _bind_compatibility_methods();
+#endif
+
 private:
 	Format format = FORMAT_L8;
 	Vector<uint8_t> data;
@@ -333,13 +343,13 @@ public:
 
 	Error load(const String &p_path);
 	static Ref<Image> load_from_file(const String &p_path);
-	Error save_png(const String &p_path) const;
-	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
+	Error save_png(const String &p_path, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) const;
+	Error save_jpg(const String &p_path, float p_quality = 0.75, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) const;
 	Vector<uint8_t> save_png_to_buffer() const;
 	Vector<uint8_t> save_jpg_to_buffer(float p_quality = 0.75) const;
 	Vector<uint8_t> save_exr_to_buffer(bool p_grayscale = false) const;
-	Error save_exr(const String &p_path, bool p_grayscale = false) const;
-	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
+	Error save_exr(const String &p_path, bool p_grayscale = false, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) const;
+	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) const;
 	Vector<uint8_t> save_webp_to_buffer(const bool p_lossy = false, const float p_quality = 0.75f) const;
 
 	static Ref<Image> create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format);

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1657,14 +1657,14 @@ String ResourceFormatLoaderJSON::get_resource_type(const String &p_path) const {
 	return "";
 }
 
-Error ResourceFormatSaverJSON::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverJSON::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<JSON> json = p_resource;
 	ERR_FAIL_COND_V(json.is_null(), ERR_INVALID_PARAMETER);
 
 	String source = json->get_parsed_text().is_empty() ? JSON::stringify(json->get_data(), "\t", false, true) : json->get_parsed_text();
 
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Cannot save json '%s'.", p_path));
 

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -121,7 +121,7 @@ public:
 
 class ResourceFormatSaverJSON : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1330,7 +1330,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		Ref<FileAccessCompressed> facw;
 		facw.instantiate();
 		facw->configure("RSCC");
-		err = facw->open_internal(p_path + ".depren", FileAccess::WRITE);
+		err = facw->open_internal(p_path + ".depren", FileAccess::WRITE, FileAccess::SAVE_INTEGRITY_NONE);
 		ERR_FAIL_COND_V_MSG(err, ERR_FILE_CORRUPT, vformat("Cannot create file '%s.depren'.", p_path));
 
 		fw = facw;
@@ -2142,7 +2142,7 @@ static String _resource_get_class(Ref<Resource> p_resource) {
 	}
 }
 
-Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Resource::seed_scene_unique_id(p_path.hash());
 
 	Error err;
@@ -2152,9 +2152,9 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 		fac.instantiate();
 		fac->configure("RSCC");
 		f = fac;
-		err = fac->open_internal(p_path, FileAccess::WRITE);
+		err = fac->open_internal(p_path, FileAccess::WRITE, FileAccess::SAVE_INTEGRITY_NONE);
 	} else {
-		f = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		f = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	}
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, vformat("Cannot create file '%s'.", p_path));
@@ -2407,7 +2407,7 @@ Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceU
 		Ref<FileAccessCompressed> facw;
 		facw.instantiate();
 		facw->configure("RSCC");
-		err = facw->open_internal(p_path + ".uidren", FileAccess::WRITE);
+		err = facw->open_internal(p_path + ".uidren", FileAccess::WRITE, FileAccess::SAVE_INTEGRITY_NONE);
 		ERR_FAIL_COND_V_MSG(err, ERR_FILE_CORRUPT, vformat("Cannot create file '%s.uidren'.", p_path));
 
 		fw = facw;
@@ -2502,10 +2502,10 @@ Error ResourceFormatSaverBinaryInstance::set_uid(const String &p_path, ResourceU
 	return OK;
 }
 
-Error ResourceFormatSaverBinary::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverBinary::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	ResourceFormatSaverBinaryInstance saver;
-	return saver.save(local_path, p_resource, p_flags);
+	return saver.save(local_path, p_resource, p_flags, p_integrity_level);
 }
 
 Error ResourceFormatSaverBinary::set_uid(const String &p_path, ResourceUID::ID p_uid) {

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -174,7 +174,7 @@ public:
 		// Amount of reserved 32-bit fields in resource header
 		RESERVED_FIELDS = 11
 	};
-	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	static void write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
 };
@@ -182,7 +182,7 @@ public:
 class ResourceFormatSaverBinary : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverBinary *singleton;
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -41,8 +41,10 @@ bool ResourceSaver::timestamp_on_save = false;
 ResourceSavedCallback ResourceSaver::save_callback = nullptr;
 ResourceSaverGetResourceIDForPath ResourceSaver::save_get_id_for_path = nullptr;
 
-Error ResourceFormatSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err = ERR_METHOD_NOT_FOUND;
+	// TODO: once there is a system to deal with backwards compatibility, we will finally be able to pass p_integrity_level (added in PR #100447).
+	// For now, it's not the end of the world if we just drop p_integrity_level when passing to GDScript.
 	GDVIRTUAL_CALL(_save, p_resource, p_path, p_flags, err);
 	return err;
 }
@@ -97,7 +99,7 @@ void ResourceFormatSaver::_bind_methods() {
 	GDVIRTUAL_BIND(_recognize_path, "resource", "path");
 }
 
-Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, vformat("Can't save empty resource to path '%s'.", p_path));
 	String path = p_path;
 	if (path.is_empty()) {
@@ -125,7 +127,7 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 			p_resource->set_path(local_path);
 		}
 
-		err = saver[i]->save(p_resource, path, p_flags);
+		err = saver[i]->save(p_resource, path, p_flags, p_integrity_level);
 
 		if (err == OK) {
 #ifdef TOOLS_ENABLED

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -41,7 +41,11 @@ class ResourceFormatSaver : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL3R(Error, _save, Ref<Resource>, String, uint32_t)
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL3R_COMPAT(_save_compat_100447, Error, _save, Ref<Resource>, String, uint32_t)
+#endif
+
+	GDVIRTUAL4R(Error, _save, Ref<Resource>, String, uint32_t, FileAccess::SaveIntegrityLevel)
 	GDVIRTUAL2R(Error, _set_uid, String, ResourceUID::ID)
 	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -31,6 +31,7 @@
 #ifndef RESOURCE_SAVER_H
 #define RESOURCE_SAVER_H
 
+#include "core/io/file_access.h"
 #include "core/io/resource.h"
 #include "core/object/gdvirtual.gen.inc"
 
@@ -47,7 +48,7 @@ protected:
 	GDVIRTUAL2RC(bool, _recognize_path, Ref<Resource>, String)
 
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
@@ -84,7 +85,7 @@ public:
 		FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
 	};
 
-	static Error save(const Ref<Resource> &p_resource, const String &p_path = "", uint32_t p_flags = (uint32_t)FLAG_NONE);
+	static Error save(const Ref<Resource> &p_resource, const String &p_path = "", uint32_t p_flags = (uint32_t)FLAG_NONE, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -126,6 +126,9 @@ public:
 		HashMap<StringName, Vector<Error>> method_error_values;
 		HashMap<StringName, List<StringName>> linked_properties;
 #endif
+#ifndef DISABLE_DEPRECATED
+		HashMap<StringName, Vector<uint32_t>> virtual_methods_compat;
+#endif
 		HashMap<StringName, PropertySetGet> property_setget;
 
 		StringName inherits;
@@ -452,8 +455,10 @@ public:
 	static Vector<uint32_t> get_method_compatibility_hashes(const StringName &p_class, const StringName &p_name);
 
 	static void add_virtual_method(const StringName &p_class, const MethodInfo &p_method, bool p_virtual = true, const Vector<String> &p_arg_names = Vector<String>(), bool p_object_core = false);
+	static void add_virtual_compatibility_method(const StringName &p_class, const MethodInfo &p_method, bool p_virtual = true, const Vector<String> &p_arg_names = Vector<String>(), bool p_object_core = false);
 	static void get_virtual_methods(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance = false);
 	static void add_extension_class_virtual_method(const StringName &p_class, const GDExtensionClassVirtualMethodInfo *p_method_info);
+	static Vector<uint32_t> get_virtual_method_compatibility_hashes(const StringName &p_class, const StringName &p_name);
 
 	static void bind_integer_constant(const StringName &p_class, const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield = false);
 	static void get_integer_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance = false);

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -1,36 +1,46 @@
-proto = """#define GDVIRTUAL$VER($RET m_name $ARG)\\
-	StringName _gdvirtual_##m_name##_sn = #m_name;\\
-	mutable bool _gdvirtual_##m_name##_initialized = false;\\
-	mutable void *_gdvirtual_##m_name = nullptr;\\
-	_FORCE_INLINE_ bool _gdvirtual_##m_name##_call($CALLARGS) $CONST {\\
-		ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\\
+script_call = """ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\\
 		if (_script_instance) {\\
 			Callable::CallError ce;\\
 			$CALLSIARGS\\
-			$CALLSIBEGIN_script_instance->callp(_gdvirtual_##m_name##_sn, $CALLSIARGPASS, ce);\\
+			$CALLSIBEGIN_script_instance->callp(_gdvirtual_##$VARNAME##_sn, $CALLSIARGPASS, ce);\\
 			if (ce.error == Callable::CallError::CALL_OK) {\\
 				$CALLSIRET\\
 				return true;\\
 			}\\
-		}\\
-		if (unlikely(_get_extension() && !_gdvirtual_##m_name##_initialized)) {\\
-			_gdvirtual_##m_name = nullptr;\\
-			if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
-				_gdvirtual_##m_name = _get_extension()->get_virtual_call_data(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
-			} else if (_get_extension()->get_virtual) {\\
-				_gdvirtual_##m_name = (void *)_get_extension()->get_virtual(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
+		}"""
+
+script_has_method = """ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\\
+		if (_script_instance && _script_instance->has_method(_gdvirtual_##$VARNAME##_sn)) {\\
+			return true;\\
+		}"""
+
+proto = """#define GDVIRTUAL$VER($ALIAS $RET m_name $ARG)\\
+	StringName _gdvirtual_##$VARNAME##_sn = #m_name;\\
+	mutable bool _gdvirtual_##$VARNAME##_initialized = false;\\
+	mutable void *_gdvirtual_##$VARNAME = nullptr;\\
+	_FORCE_INLINE_ bool _gdvirtual_##$VARNAME##_call($CALLARGS) $CONST {\\
+		$SCRIPTCALL\\
+		if (unlikely(_get_extension() && !_gdvirtual_##$VARNAME##_initialized)) {\\
+			MethodInfo mi = _gdvirtual_##$VARNAME##_get_method_info();\\
+			uint32_t hash = mi.get_compatibility_hash();\\
+			_gdvirtual_##$VARNAME = nullptr;\\
+			if (_get_extension()->get_virtual_call_data2 && _get_extension()->call_virtual_with_data) {\\
+				_gdvirtual_##$VARNAME = _get_extension()->get_virtual_call_data2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
+			} else if (_get_extension()->get_virtual2) {\\
+				_gdvirtual_##$VARNAME = (void *)_get_extension()->get_virtual2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
 			}\\
-			GDVIRTUAL_TRACK(_gdvirtual_##m_name, _gdvirtual_##m_name##_initialized);\\
-			_gdvirtual_##m_name##_initialized = true;\\
+			_GDVIRTUAL_GET_DEPRECATED(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_sn, $COMPAT)\\
+			_GDVIRTUAL_TRACK(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_initialized);\\
+			_gdvirtual_##$VARNAME##_initialized = true;\\
 		}\\
-		if (_gdvirtual_##m_name) {\\
+		if (_gdvirtual_##$VARNAME) {\\
 			$CALLPTRARGS\\
 			$CALLPTRRETDEF\\
-			if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
-				_get_extension()->call_virtual_with_data(_get_extension_instance(), &_gdvirtual_##m_name##_sn, _gdvirtual_##m_name, $CALLPTRARGPASS, $CALLPTRRETPASS);\\
+			if (_get_extension()->call_virtual_with_data) {\\
+				_get_extension()->call_virtual_with_data(_get_extension_instance(), &_gdvirtual_##$VARNAME##_sn, _gdvirtual_##$VARNAME, $CALLPTRARGPASS, $CALLPTRRETPASS);\\
 				$CALLPTRRET\\
 			} else {\\
-				((GDExtensionClassCallVirtual)_gdvirtual_##m_name)(_get_extension_instance(), $CALLPTRARGPASS, $CALLPTRRETPASS);\\
+				((GDExtensionClassCallVirtual)_gdvirtual_##$VARNAME)(_get_extension_instance(), $CALLPTRARGPASS, $CALLPTRRETPASS);\\
 				$CALLPTRRET\\
 			}\\
 			return true;\\
@@ -39,27 +49,27 @@ proto = """#define GDVIRTUAL$VER($RET m_name $ARG)\\
 		$RVOID\\
 		return false;\\
 	}\\
-	_FORCE_INLINE_ bool _gdvirtual_##m_name##_overridden() const {\\
-		ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\\
-		if (_script_instance && _script_instance->has_method(_gdvirtual_##m_name##_sn)) {\\
-			return true;\\
-		}\\
-		if (unlikely(_get_extension() && !_gdvirtual_##m_name##_initialized)) {\\
-			_gdvirtual_##m_name = nullptr;\\
-			if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
-				_gdvirtual_##m_name = _get_extension()->get_virtual_call_data(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
-			} else if (_get_extension()->get_virtual) {\\
-				_gdvirtual_##m_name = (void *)_get_extension()->get_virtual(_get_extension()->class_userdata, &_gdvirtual_##m_name##_sn);\\
+	_FORCE_INLINE_ bool _gdvirtual_##$VARNAME##_overridden() const {\\
+		$SCRIPTHASMETHOD\\
+		if (unlikely(_get_extension() && !_gdvirtual_##$VARNAME##_initialized)) {\\
+			MethodInfo mi = _gdvirtual_##$VARNAME##_get_method_info();\\
+			uint32_t hash = mi.get_compatibility_hash();\\
+			_gdvirtual_##$VARNAME = nullptr;\\
+			if (_get_extension()->get_virtual_call_data2 && _get_extension()->call_virtual_with_data) {\\
+				_gdvirtual_##$VARNAME = _get_extension()->get_virtual_call_data2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
+			} else if (_get_extension()->get_virtual2) {\\
+				_gdvirtual_##$VARNAME = (void *)_get_extension()->get_virtual2(_get_extension()->class_userdata, &_gdvirtual_##$VARNAME##_sn, hash);\\
 			}\\
-			GDVIRTUAL_TRACK(_gdvirtual_##m_name, _gdvirtual_##m_name##_initialized);\\
-			_gdvirtual_##m_name##_initialized = true;\\
+			_GDVIRTUAL_GET_DEPRECATED(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_sn, $COMPAT)\\
+			_GDVIRTUAL_TRACK(_gdvirtual_##$VARNAME, _gdvirtual_##$VARNAME##_initialized);\\
+			_gdvirtual_##$VARNAME##_initialized = true;\\
 		}\\
-		if (_gdvirtual_##m_name) {\\
+		if (_gdvirtual_##$VARNAME) {\\
 			return true;\\
 		}\\
 		return false;\\
 	}\\
-	_FORCE_INLINE_ static MethodInfo _gdvirtual_##m_name##_get_method_info() {\\
+	_FORCE_INLINE_ static MethodInfo _gdvirtual_##$VARNAME##_get_method_info() {\\
 		MethodInfo method_info;\\
 		method_info.name = #m_name;\\
 		method_info.flags = $METHOD_FLAGS;\\
@@ -70,8 +80,15 @@ proto = """#define GDVIRTUAL$VER($RET m_name $ARG)\\
 """
 
 
-def generate_version(argcount, const=False, returns=False, required=False):
+def generate_version(argcount, const=False, returns=False, required=False, compat=False):
     s = proto
+    if compat:
+        s = s.replace("$SCRIPTCALL", "")
+        s = s.replace("$SCRIPTHASMETHOD", "")
+    else:
+        s = s.replace("$SCRIPTCALL", script_call)
+        s = s.replace("$SCRIPTHASMETHOD", script_has_method)
+
     sproto = str(argcount)
     method_info = ""
     method_flags = "METHOD_FLAG_VIRTUAL"
@@ -103,6 +120,16 @@ def generate_version(argcount, const=False, returns=False, required=False):
         )
     else:
         s = s.replace("\t\t$REQCHECK\\\n", "")
+
+    if compat:
+        sproto += "_COMPAT"
+        s = s.replace("$COMPAT", "true")
+        s = s.replace("$ALIAS", "m_alias,")
+        s = s.replace("$VARNAME", "m_alias")
+    else:
+        s = s.replace("$COMPAT", "false")
+        s = s.replace("$ALIAS ", "")
+        s = s.replace("$VARNAME", "m_name")
 
     s = s.replace("$METHOD_FLAGS", method_flags)
     s = s.replace("$VER", sproto)
@@ -188,7 +215,7 @@ def run(target, source, env):
 #include <utility>
 
 #ifdef TOOLS_ENABLED
-#define GDVIRTUAL_TRACK(m_virtual, m_initialized)\\
+#define _GDVIRTUAL_TRACK(m_virtual, m_initialized)\\
 	if (_get_extension()->reloadable) {\\
 		VirtualMethodTracker *tracker = memnew(VirtualMethodTracker);\\
 		tracker->method = (void **)&m_virtual;\\
@@ -197,7 +224,20 @@ def run(target, source, env):
 		virtual_method_list = tracker;\\
 	}
 #else
-#define GDVIRTUAL_TRACK(m_virtual, m_initialized)
+#define _GDVIRTUAL_TRACK(m_virtual, m_initialized)
+#endif
+
+#ifndef DISABLE_DEPRECATED
+#define _GDVIRTUAL_GET_DEPRECATED(m_virtual, m_name_sn, m_compat)\\
+	else if (m_compat || ClassDB::get_virtual_method_compatibility_hashes(get_class_static(), m_name_sn).size() == 0) {\\
+		if (_get_extension()->get_virtual_call_data && _get_extension()->call_virtual_with_data) {\\
+			m_virtual = _get_extension()->get_virtual_call_data(_get_extension()->class_userdata, &m_name_sn);\\
+		} else if (_get_extension()->get_virtual) {\\
+			m_virtual = (void *)_get_extension()->get_virtual(_get_extension()->class_userdata, &m_name_sn);\\
+		}\\
+	}
+#else
+#define _GDVIRTUAL_GET_DEPRECATED(m_name, m_name_sn, m_compat)
 #endif
 
 // MSVC WORKAROUND START
@@ -243,6 +283,10 @@ _to_variant(T&& t) {
         txt += generate_version(i, False, True, True)
         txt += generate_version(i, True, False, True)
         txt += generate_version(i, True, True, True)
+        txt += generate_version(i, False, False, False, True)
+        txt += generate_version(i, False, True, False, True)
+        txt += generate_version(i, True, False, False, True)
+        txt += generate_version(i, True, True, False, True)
 
     txt += "#endif // GDVIRTUAL_GEN_H\n"
 

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -166,6 +166,37 @@ MethodInfo MethodInfo::from_dict(const Dictionary &p_dict) {
 	return mi;
 }
 
+uint32_t MethodInfo::get_compatibility_hash() const {
+	bool has_return = (return_val.type != Variant::NIL) || (return_val.usage & PROPERTY_USAGE_NIL_IS_VARIANT);
+
+	uint32_t hash = hash_murmur3_one_32(has_return);
+	hash = hash_murmur3_one_32(arguments.size(), hash);
+
+	if (has_return) {
+		hash = hash_murmur3_one_32(return_val.type, hash);
+		if (return_val.class_name != StringName()) {
+			hash = hash_murmur3_one_32(return_val.class_name.operator String().hash(), hash);
+		}
+	}
+
+	for (const PropertyInfo &arg : arguments) {
+		hash = hash_murmur3_one_32(arg.type, hash);
+		if (arg.class_name != StringName()) {
+			hash = hash_murmur3_one_32(arg.class_name.operator String().hash(), hash);
+		}
+	}
+
+	hash = hash_murmur3_one_32(default_arguments.size(), hash);
+	for (const Variant &v : default_arguments) {
+		hash = hash_murmur3_one_32(v.hash(), hash);
+	}
+
+	hash = hash_murmur3_one_32(flags & METHOD_FLAG_CONST ? 1 : 0, hash);
+	hash = hash_murmur3_one_32(flags & METHOD_FLAG_VARARG ? 1 : 0, hash);
+
+	return hash_fmix32(hash);
+}
+
 Object::Connection::operator Variant() const {
 	Dictionary d;
 	d["signal"] = signal;

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -247,6 +247,8 @@ struct MethodInfo {
 
 	static MethodInfo from_dict(const Dictionary &p_dict);
 
+	uint32_t get_compatibility_hash() const;
+
 	MethodInfo() {}
 
 	explicit MethodInfo(const GDExtensionMethodInfo &pinfo) :
@@ -360,8 +362,12 @@ struct ObjectGDExtension {
 #endif // DISABLE_DEPRECATED
 	GDExtensionClassCreateInstance2 create_instance2;
 	GDExtensionClassFreeInstance free_instance;
+#ifndef DISABLE_DEPRECATED
 	GDExtensionClassGetVirtual get_virtual;
 	GDExtensionClassGetVirtualCallData get_virtual_call_data;
+#endif // DISABLE_DEPRECATED
+	GDExtensionClassGetVirtual2 get_virtual2;
+	GDExtensionClassGetVirtualCallData2 get_virtual_call_data2;
 	GDExtensionClassCallVirtualWithData call_virtual_with_data;
 	GDExtensionClassRecreateInstance recreate_instance;
 
@@ -380,6 +386,7 @@ struct ObjectGDExtension {
 #else
 #define GDVIRTUAL_BIND(m_name, ...)
 #endif
+#define GDVIRTUAL_BIND_COMPAT(m_alias, ...) ::ClassDB::add_virtual_compatibility_method(get_class_static(), _gdvirtual_##m_alias##_get_method_info(), true, sarray(__VA_ARGS__));
 #define GDVIRTUAL_IS_OVERRIDDEN(m_name) _gdvirtual_##m_name##_overridden()
 #define GDVIRTUAL_IS_OVERRIDDEN_PTR(m_obj, m_name) m_obj->_gdvirtual_##m_name##_overridden()
 

--- a/doc/classes/ConfigFile.xml
+++ b/doc/classes/ConfigFile.xml
@@ -195,6 +195,7 @@
 		<method name="save">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
+			<param index="1" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the contents of the [ConfigFile] object to the file specified as a parameter. The output file uses an INI-style structure.
 				Returns [constant OK] on success, or one of the other [enum Error] values if the operation failed.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -717,9 +717,8 @@
 		<member name="filesystem/on_save/compress_binary_resources" type="bool" setter="" getter="">
 			If [code]true[/code], uses lossless compression for binary resources.
 		</member>
-		<member name="filesystem/on_save/safe_save_on_backup_then_rename" type="bool" setter="" getter="">
-			If [code]true[/code], when saving a file, the editor will rename the old file to a different name, save a new file, then only remove the old file once the new file has been saved. This makes loss of data less likely to happen if the editor or operating system exits unexpectedly while saving (e.g. due to a crash or power outage).
-			[b]Note:[/b] On Windows, this feature can interact negatively with certain antivirus programs. In this case, you may have to set this to [code]false[/code] to prevent file locking issues.
+		<member name="filesystem/on_save/default_integrity_level" type="int" setter="" getter="">
+			What integrity value should the editor use by default when saving. See [method OS.set_default_save_integrity_level].
 		</member>
 		<member name="filesystem/quick_open_dialog/default_display_mode" type="int" setter="" getter="">
 			If set to [code]Adaptive[/code], the dialog opens in list view or grid view depending on the requested type. If set to [code]Last Used[/code], the display mode will always open the way you last used it.

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -307,6 +307,7 @@
 			<return type="FileAccess" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="flags" type="int" enum="FileAccess.ModeFlags" />
+			<param index="2" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Creates a new [FileAccess] object and opens the file for writing or reading, depending on the flags.
 				Returns [code]null[/code] if opening the file failed. You can use [method get_open_error] to check the error that occurred.
@@ -588,6 +589,43 @@
 		</constant>
 		<constant name="COMPRESSION_BROTLI" value="4" enum="CompressionMode">
 			Uses the [url=https://github.com/google/brotli]brotli[/url] compression method (only decompression is supported).
+		</constant>
+		<constant name="SAVE_INTEGRITY_DEFAULT" value="0" enum="SaveIntegrityLevel">
+			Use the default level globally set by [method OS.set_default_save_integrity_level].
+		</constant>
+		<constant name="SAVE_INTEGRITY_NONE" value="1" enum="SaveIntegrityLevel">
+			Make no attempts to keep the integrity of the saving operation.
+			If the app crashes while saving or the system experiences power failure/BSOD, the data will be lost. Even previously saved data will be lost or corrupted.
+			Useful for cache or temp data that can be regenerated from scratch if lost or corrupted.
+			[b]Note:[/b] All SaveIntegrityLevel flags are only relevant when the [enum FileAccess.ModeFlags] is set to [constant FileAccess.WRITE] and the underlying FileAccess type supports it (e.g. regular files support it, but zip or encrypted files do not). Otherwise it is ignored.
+		</constant>
+		<constant name="SAVE_INTEGRITY_SAVE_SWAP" value="2" enum="SaveIntegrityLevel">
+			Minor attempts to keep the integrity of the saving operation.
+			If the app crashes while saving, old data will remain safe. If the system experiences power failure/BSOD, there's still a chance the data will be lost, even previously saved data.
+			Useful for most saving operations.
+			Integrity is kept using the following algorithm:
+			1. Write to temp_file-x12354.tmp
+			2. Rename temp_file-x12354.tmp to final.png
+			[b]Note:[/b] All SaveIntegrityLevel flags are only relevant when the [enum FileAccess.ModeFlags] is set to [constant FileAccess.WRITE] and the underlying FileAccess type supports it (e.g. regular files support it, but zip or encrypted files do not). Otherwise it is ignored.
+		</constant>
+		<constant name="SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC" value="3" enum="SaveIntegrityLevel">
+			Very strong guarantees to keep data integrity.
+			If the app crashes or system experiences power failure/BSOD, there's a very high chance data integrity will be preserved (old or new).
+			Useful for important data such as:
+			- Project files.
+			- Config files.
+			- User settings.
+			- Game saves.
+			[b]Warning:[/b] Frequent use of this flag can bring the performance of the entire system down, even on SSDs. It can also contribute to faster SSD level wear down. Use with moderation.
+			[b]Note:[/b] Actual integrity will depend on various factors and cannot always be guaranteed, such as the type of file system involved or when writing to network shared drives.
+			Integrity is kept using the following algorithm:
+			1. Write to temp_file.tmp
+			2. Flush disk IO
+			3. Rename temp_file.tmp to final.png
+			Flushing prevents the OS or disk controller from reordering the rename() on step 3 from happening before step 1 is finished.
+			[b]Note:[/b] All SaveIntegrityLevel flags are only relevant when the [enum FileAccess.ModeFlags] is set to [constant FileAccess.WRITE] and the underlying FileAccess type supports it (e.g. regular files support it, but zip or encrypted files do not). Otherwise it is ignored.
+		</constant>
+		<constant name="SAVE_INTEGRITY_MAX" value="4" enum="SaveIntegrityLevel">
 		</constant>
 		<constant name="UNIX_READ_OWNER" value="256" enum="UnixPermissionFlags" is_bitfield="true">
 			Read for owner bit.

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -462,6 +462,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="grayscale" type="bool" default="false" />
+			<param index="2" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the image as an EXR file to [param path]. If [param grayscale] is [code]true[/code] and the image has only one channel, it will be saved explicitly as monochrome rather than one red channel. This function will return [constant ERR_UNAVAILABLE] if Godot was compiled without the TinyEXR module.
 				[b]Note:[/b] The TinyEXR module is disabled in non-editor builds, which means [method save_exr] will return [constant ERR_UNAVAILABLE] when it is called from an exported project.
@@ -479,6 +480,7 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="quality" type="float" default="0.75" />
+			<param index="2" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the image as a JPEG file to [param path] with the specified [param quality] between [code]0.01[/code] and [code]1.0[/code] (inclusive). Higher [param quality] values result in better-looking output at the cost of larger file sizes. Recommended [param quality] values are between [code]0.75[/code] and [code]0.90[/code]. Even at quality [code]1.00[/code], JPEG compression remains lossy.
 				[b]Note:[/b] JPEG does not save an alpha channel. If the [Image] contains an alpha channel, the image will still be saved, but the resulting JPEG file won't contain the alpha channel.
@@ -495,6 +497,7 @@
 		<method name="save_png" qualifiers="const">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
+			<param index="1" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the image as a PNG file to the file at [param path].
 			</description>
@@ -510,6 +513,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="lossy" type="bool" default="false" />
 			<param index="2" name="quality" type="float" default="0.75" />
+			<param index="3" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" default="0" />
 			<description>
 				Saves the image as a WebP (Web Picture) file to the file at [param path]. By default it will save lossless. If [param lossy] is [code]true[/code], the image will be saved lossy, using the [param quality] setting between [code]0.0[/code] and [code]1.0[/code] (inclusive). Lossless WebP offers more efficient compression than PNG.
 				[b]Note:[/b] The WebP format is limited to a size of 16383×16383 pixels, while PNG can save larger images.

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -764,6 +764,16 @@
 				On macOS (sandboxed applications only), this function clears list of user selected folders accessible to the application.
 			</description>
 		</method>
+		<method name="set_default_save_integrity_level">
+			<return type="void" />
+			<param index="0" name="integrity_level" type="int" enum="FileAccess.SaveIntegrityLevel" />
+			<description>
+				Sets the default integrity level to use when for saving operations when the [constant FileAccess.SAVE_INTEGRITY_DEFAULT] value is requested.
+				[param integrity_level] must not be [constant FileAccess.SAVE_INTEGRITY_DEFAULT].
+				[b]Warning:[/b] Setting the default to [constant FileAccess.SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC] can cause a severe performance degradation. It's not recommended to set the default to this value.
+				[b]Note:[/b] On Windows, a value other than [constant FileAccess.SAVE_INTEGRITY_NONE] may interact negatively with certain antivirus programs. In this case, you'll have to set it to [constant FileAccess.SAVE_INTEGRITY_NONE] to prevent file locking issues.
+			</description>
+		</method>
 		<method name="set_environment" qualifiers="const">
 			<return type="void" />
 			<param index="0" name="variable" type="String" />
@@ -791,7 +801,7 @@
 				Assigns the given name to the current thread. Returns [constant ERR_UNAVAILABLE] if unavailable on the current platform.
 			</description>
 		</method>
-		<method name="set_use_file_access_save_and_swap">
+		<method name="set_use_file_access_save_and_swap" deprecated="Use [method set_default_save_integrity_level] instead.">
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
 			<description>

--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -153,7 +153,7 @@ void EGLManager::_set_cache(const void *p_key, EGLsizeiANDROID p_key_size, const
 	String path = shader_cache_dir.path_join(name) + ".cache";
 
 	Error err = OK;
-	Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE, &err, FileAccess::SAVE_INTEGRITY_SAVE_SWAP);
 	if (err != OK) {
 		return;
 	}

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -35,7 +35,7 @@
 #include "drivers/png/png_driver_common.h"
 #include "scene/resources/image_texture.h"
 
-Error ResourceSaverPNG::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceSaverPNG::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<ImageTexture> texture = p_resource;
 
 	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as PNG.");
@@ -43,16 +43,16 @@ Error ResourceSaverPNG::save(const Ref<Resource> &p_resource, const String &p_pa
 
 	Ref<Image> img = texture->get_image();
 
-	Error err = save_image(p_path, img);
+	Error err = save_image(p_path, img, p_integrity_level);
 
 	return err;
 }
 
-Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img) {
+Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Vector<uint8_t> buffer;
 	Error err = PNGDriverCommon::image_to_png(p_img, buffer);
 	ERR_FAIL_COND_V_MSG(err, err, "Can't convert image to PNG.");
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save PNG at path: '%s'.", p_path));
 
 	const uint8_t *reader = buffer.ptr();

--- a/drivers/png/resource_saver_png.h
+++ b/drivers/png/resource_saver_png.h
@@ -36,10 +36,10 @@
 
 class ResourceSaverPNG : public ResourceFormatSaver {
 public:
-	static Error save_image(const String &p_path, const Ref<Image> &p_img);
+	static Error save_image(const String &p_path, const Ref<Image> &p_img, FileAccess::SaveIntegrityLevel p_integrity_level);
 	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);
 
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -62,8 +62,11 @@ void FileAccessUnix::check_errors(bool p_write) const {
 	}
 }
 
-Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
+
+	DEV_ASSERT(p_integrity_level != SAVE_INTEGRITY_DEFAULT); // It should have already been resolved.
+	ERR_FAIL_INDEX_V(p_integrity_level, SAVE_INTEGRITY_MAX, ERR_INVALID_PARAMETER);
 
 	path_src = p_path;
 	path = fix_path(p_path);
@@ -116,7 +119,9 @@ Error FileAccessUnix::open_internal(const String &p_path, int p_mode_flags) {
 	}
 #endif
 
-	if (is_backup_save_enabled() && (p_mode_flags == WRITE)) {
+	integrity_level = p_integrity_level;
+
+	if (integrity_level > SAVE_INTEGRITY_NONE && (p_mode_flags == WRITE)) {
 		save_path = path;
 		// Create a temporary file in the same directory as the target file.
 		path = path + "-XXXXXX";

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -43,6 +43,7 @@ typedef void (*CloseNotificationFunc)(const String &p_file, int p_flags);
 class FileAccessUnix : public FileAccess {
 	FILE *f = nullptr;
 	int flags = 0;
+	SaveIntegrityLevel integrity_level = SAVE_INTEGRITY_NONE;
 	void check_errors(bool p_write = false) const;
 	mutable Error last_error = OK;
 	String save_path;
@@ -58,7 +59,7 @@ class FileAccessUnix : public FileAccess {
 public:
 	static CloseNotificationFunc close_notification_func;
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -60,7 +60,7 @@ Error FileAccessUnixPipe::open_existing(int p_rfd, int p_wfd, bool p_blocking) {
 	return OK;
 }
 
-Error FileAccessUnixPipe::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessUnixPipe::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
 
 	path_src = p_path;

--- a/drivers/unix/file_access_unix_pipe.h
+++ b/drivers/unix/file_access_unix_pipe.h
@@ -51,7 +51,7 @@ class FileAccessUnixPipe : public FileAccess {
 
 public:
 	Error open_existing(int p_rfd, int p_wfd, bool p_blocking);
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 
 	virtual bool is_open() const override; ///< true when file is open
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -97,7 +97,7 @@ String FileAccessWindows::fix_path(const String &p_path) const {
 	return r_path;
 }
 
-Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	if (is_path_invalid(p_path)) {
 #ifdef DEBUG_ENABLED
 		if (p_mode_flags != READ) {
@@ -108,6 +108,9 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 	}
 
 	_close();
+
+	DEV_ASSERT(p_integrity_level != SAVE_INTEGRITY_DEFAULT); // It should have already been resolved.
+	ERR_FAIL_INDEX_V(p_integrity_level, SAVE_INTEGRITY_MAX, ERR_INVALID_PARAMETER);
 
 	path_src = p_path;
 	path = fix_path(p_path);
@@ -193,7 +196,9 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 	}
 #endif
 
-	if (is_backup_save_enabled() && p_mode_flags == WRITE) {
+	integrity_level = p_integrity_level;
+
+	if (integrity_level > SAVE_INTEGRITY_NONE && p_mode_flags == WRITE) {
 		save_path = path;
 		// Create a temporary file in the same directory as the target file.
 		// Note: do not use GetTempFileNameW, it's not long path aware!
@@ -214,7 +219,7 @@ Error FileAccessWindows::open_internal(const String &p_path, int p_mode_flags) {
 		path = tmpfile;
 	}
 
-	f = _wfsopen((LPCWSTR)(path.utf16().get_data()), mode_string, is_backup_save_enabled() ? _SH_SECURE : _SH_DENYNO);
+	f = _wfsopen((LPCWSTR)(path.utf16().get_data()), mode_string, (integrity_level > SAVE_INTEGRITY_NONE) ? _SH_SECURE : _SH_DENYNO);
 
 	if (f == nullptr) {
 		switch (errno) {

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -41,6 +41,7 @@
 class FileAccessWindows : public FileAccess {
 	FILE *f = nullptr;
 	int flags = 0;
+	SaveIntegrityLevel integrity_level = SAVE_INTEGRITY_NONE;
 	void check_errors(bool p_write = false) const;
 	mutable int prev_op = 0;
 	mutable Error last_error = OK;
@@ -56,7 +57,7 @@ public:
 	static bool is_path_invalid(const String &p_path);
 
 	virtual String fix_path(const String &p_path) const override;
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/drivers/windows/file_access_windows_pipe.cpp
+++ b/drivers/windows/file_access_windows_pipe.cpp
@@ -54,7 +54,7 @@ Error FileAccessWindowsPipe::open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_bl
 	return OK;
 }
 
-Error FileAccessWindowsPipe::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessWindowsPipe::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
 
 	path_src = p_path;

--- a/drivers/windows/file_access_windows_pipe.h
+++ b/drivers/windows/file_access_windows_pipe.h
@@ -51,7 +51,7 @@ class FileAccessWindowsPipe : public FileAccess {
 public:
 	Error open_existing(HANDLE p_rfd, HANDLE p_wfd, bool p_blocking);
 
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	virtual String get_path() const override; /// returns the path for the current open file

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -57,7 +57,7 @@ void EditorFolding::save_resource_folding(const Ref<Resource> &p_resource, const
 
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
 	file = EditorPaths::get_singleton()->get_project_settings_dir().path_join(file);
-	config->save(file);
+	config->save(file, FileAccess::SAVE_INTEGRITY_NONE);
 }
 
 void EditorFolding::_set_unfolds(Object *p_object, const Vector<String> &p_unfolds) {
@@ -151,7 +151,7 @@ void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path
 
 	String file = p_path.get_file() + "-folding-" + p_path.md5_text() + ".cfg";
 	file = EditorPaths::get_singleton()->get_project_settings_dir().path_join(file);
-	config->save(file);
+	config->save(file, FileAccess::SAVE_INTEGRITY_NONE);
 }
 
 void EditorFolding::load_scene_folding(Node *p_scene, const String &p_path) {

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -354,7 +354,7 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 		cache_base = temp_path.path_join("resthumb-" + cache_base);
 
 		post_process_preview(img);
-		img->save_png(cache_base + ".png");
+		img->save_png(cache_base + ".png", FileAccess::SAVE_INTEGRITY_NONE);
 	}
 
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_path);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1327,7 +1327,7 @@ void EditorNode::save_resource_in_path(const Ref<Resource> &p_resource, const St
 	}
 
 	String path = ProjectSettings::get_singleton()->localize_path(p_path);
-	Error err = ResourceSaver::save(p_resource, path, flg | ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS);
+	Error err = ResourceSaver::save(p_resource, path, flg | ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS, FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 
 	if (err != OK) {
 		if (ResourceLoader::is_imported(p_resource->get_path())) {
@@ -1748,7 +1748,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 
 			// Does not have it, try to load a cached thumbnail.
 			post_process_preview(img);
-			img->save_png(cache_base + ".png");
+			img->save_png(cache_base + ".png", FileAccess::SAVE_INTEGRITY_NONE);
 		}
 	}
 
@@ -1913,13 +1913,13 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		return;
 	}
 
-	int flg = 0;
+	uint32_t flg = 0;
 	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
 		flg |= ResourceSaver::FLAG_COMPRESS;
 	}
 	flg |= ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS;
 
-	err = ResourceSaver::save(sdata, p_file, flg);
+	err = ResourceSaver::save(sdata, p_file, flg, FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 
 	// This needs to be emitted before saving external resources.
 	emit_signal(SNAME("scene_saved"), p_file);
@@ -5250,7 +5250,7 @@ void EditorNode::_save_editor_layout() {
 	_save_window_settings_to_config(config, "EditorWindow");
 	editor_data.get_plugin_window_layout(config);
 
-	config->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
+	config->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"), FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 }
 
 void EditorNode::_save_open_scenes_to_config(Ref<ConfigFile> p_layout) {
@@ -6794,7 +6794,10 @@ EditorNode::EditorNode() {
 	ED_SHORTCUT("editor/group_selected_nodes", TTRC("Group Selected Node(s)"), KeyModifierMask::CMD_OR_CTRL | Key::G);
 	ED_SHORTCUT("editor/ungroup_selected_nodes", TTRC("Ungroup Selected Node(s)"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::G);
 
-	FileAccess::set_backup_save(EDITOR_GET("filesystem/on_save/safe_save_on_backup_then_rename"));
+	{
+		const int integrity_level = CLAMP(int(EDITOR_GET("filesystem/on_save/default_integrity_level")) + 1, FileAccess::SAVE_INTEGRITY_NONE, FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
+		FileAccess::set_default_save_integrity_level(FileAccess::SaveIntegrityLevel(integrity_level));
+	}
 
 	_update_vsync_mode();
 

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -235,11 +235,11 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 		if (r_texture.is_valid()) {
 			// Wow it generated a preview... save cache.
 			bool has_small_texture = r_small_texture.is_valid();
-			ResourceSaver::save(r_texture, cache_base + ".png");
+			ResourceSaver::save(r_texture, cache_base + ".png", ResourceSaver::FLAG_NONE, FileAccess::SAVE_INTEGRITY_NONE);
 			if (has_small_texture) {
-				ResourceSaver::save(r_small_texture, cache_base + "_small.png");
+				ResourceSaver::save(r_small_texture, cache_base + "_small.png", ResourceSaver::FLAG_NONE, FileAccess::SAVE_INTEGRITY_NONE);
 			}
-			Ref<FileAccess> f = FileAccess::open(cache_base + ".txt", FileAccess::WRITE);
+			Ref<FileAccess> f = FileAccess::open(cache_base + ".txt", FileAccess::WRITE, nullptr, FileAccess::SAVE_INTEGRITY_NONE);
 			ERR_FAIL_COND_MSG(f.is_null(), "Cannot create file '" + cache_base + ".txt'. Check user write permissions.");
 
 			uint64_t modtime = FileAccess::get_modified_time(p_item.path);
@@ -339,7 +339,7 @@ void EditorResourcePreview::_iterate() {
 			} else {
 				// Update modified time.
 
-				Ref<FileAccess> f2 = FileAccess::open(file, FileAccess::WRITE);
+				Ref<FileAccess> f2 = FileAccess::open(file, FileAccess::WRITE, nullptr, FileAccess::SAVE_INTEGRITY_NONE);
 				if (f2.is_null()) {
 					// Not returning as this would leave the thread hanging and would require
 					// some proper cleanup/disabling of resource preview generation.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -598,7 +598,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// On save
 	_initial_set("filesystem/on_save/compress_binary_resources", true);
-	_initial_set("filesystem/on_save/safe_save_on_backup_then_rename", true);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "filesystem/on_save/default_integrity_level", 1, "None, Save Swap, Save Swap + Sync");
 
 	// EditorFileServer
 	_initial_set("filesystem/file_server/port", 6010);
@@ -1308,7 +1308,7 @@ void EditorSettings::save() {
 		return;
 	}
 
-	Error err = ResourceSaver::save(singleton);
+	Error err = ResourceSaver::save(singleton, "", ResourceSaver::FLAG_NONE, FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 
 	if (err != OK) {
 		ERR_PRINT("Error saving editor settings to " + singleton->get_path());

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3610,7 +3610,7 @@ void ScriptEditor::get_window_layout(Ref<ConfigFile> p_layout) {
 	p_layout->set_value("ScriptEditor", "zoom_factor", zoom_factor);
 
 	// Save the cache.
-	script_editor_cache->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("script_editor_cache.cfg"));
+	script_editor_cache->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("script_editor_cache.cfg"), FileAccess::SAVE_INTEGRITY_SAVE_SWAP_PLUS_SYNC);
 }
 
 void ScriptEditor::_help_class_open(const String &p_class) {

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -261,3 +261,15 @@ Validate extension JSON: Error: Field 'classes/PointLight2D/properties/texture':
 
 Property hints modified to disallow resource types that don't work. The types allowed are now more restricted, but this change only impacts the editor and not the actual exposed API. No adjustments should be necessary.
 Decal properties were previously changed from Texture to Texture2D in 4.2, so we need to silence those warnings too.
+
+
+GH-100447
+--------
+Validate extension JSON: Error: Field 'classes/ConfigFile/methods/save/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/FileAccess/methods/open/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Image/methods/save_exr/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Image/methods/save_jpg/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Image/methods/save_png/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/Image/methods/save_webp/arguments': size changed value in new API, from 3 to 4.
+
+These methods now added a new argument integrity_level. Compatibility method registered.

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -3084,7 +3084,7 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 	}
 }
 
-Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<GDScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 
@@ -3092,7 +3092,7 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 
 	{
 		Error err;
-		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 		ERR_FAIL_COND_V_MSG(err, err, "Cannot save GDScript file '" + p_path + "'.");
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -653,7 +653,7 @@ public:
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/modules/jpg/image_loader_jpegd.cpp
+++ b/modules/jpg/image_loader_jpegd.cpp
@@ -196,9 +196,9 @@ static Vector<uint8_t> _jpgd_buffer_save_func(const Ref<Image> &p_img, float p_q
 	return output;
 }
 
-static Error _jpgd_save_func(const String &p_path, const Ref<Image> &p_img, float p_quality) {
+static Error _jpgd_save_func(const String &p_path, const Ref<Image> &p_img, float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save JPG at path: '%s'.", p_path));
 	ImageLoaderJPGOSFile ob;
 	ob.f = file;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2875,7 +2875,7 @@ String ResourceFormatLoaderCSharpScript::get_resource_type(const String &p_path)
 	return p_path.get_extension().to_lower() == "cs" ? CSharpLanguage::get_singleton()->get_type() : "";
 }
 
-Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<CSharpScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 
@@ -2893,7 +2893,7 @@ Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, con
 
 	{
 		Error err;
-		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save C# script file '" + p_path + "'.");
 
 		file->store_string(source);

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -599,7 +599,7 @@ public:
 
 class ResourceFormatSaverCSharpScript : public ResourceFormatSaver {
 public:
-	Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -283,13 +283,13 @@ Vector<uint8_t> save_exr_buffer(const Ref<Image> &p_img, bool p_grayscale) {
 	return buffer;
 }
 
-Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) {
+Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	const Vector<uint8_t> buffer = save_exr_buffer(p_img, p_grayscale);
 	if (buffer.size() == 0) {
 		print_error(String("Saving EXR failed."));
 		return ERR_FILE_CANT_WRITE;
 	} else {
-		Ref<FileAccess> ref = FileAccess::open(p_path, FileAccess::WRITE);
+		Ref<FileAccess> ref = FileAccess::open(p_path, FileAccess::WRITE, nullptr, p_integrity_level);
 		ERR_FAIL_COND_V(ref.is_null(), ERR_FILE_CANT_WRITE);
 		ref->store_buffer(buffer.ptr(), buffer.size());
 	}

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -36,7 +36,7 @@
 #include "core/io/image.h"
 #include "scene/resources/image_texture.h"
 
-Error ResourceSaverWebP::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceSaverWebP::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<ImageTexture> texture = p_resource;
 
 	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as WebP.");
@@ -44,15 +44,15 @@ Error ResourceSaverWebP::save(const Ref<Resource> &p_resource, const String &p_p
 
 	Ref<Image> img = texture->get_image();
 
-	Error err = save_image(p_path, img);
+	Error err = save_image(p_path, img, false, 0.75f, p_integrity_level);
 
 	return err;
 }
 
-Error ResourceSaverWebP::save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality) {
+Error ResourceSaverWebP::save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Vector<uint8_t> buffer = save_image_to_buffer(p_img, p_lossy, p_quality);
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save WebP at path: '%s'.", p_path));
 
 	const uint8_t *reader = buffer.ptr();

--- a/modules/webp/resource_saver_webp.h
+++ b/modules/webp/resource_saver_webp.h
@@ -36,10 +36,10 @@
 
 class ResourceSaverWebP : public ResourceFormatSaver {
 public:
-	static Error save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);
+	static Error save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);
 
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -46,7 +46,7 @@ String FileAccessAndroid::get_path_absolute() const {
 	return absolute_path;
 }
 
-Error FileAccessAndroid::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessAndroid::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	_close();
 
 	path_src = p_path;

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -52,7 +52,7 @@ class FileAccessAndroid : public FileAccess {
 	void _close();
 
 public:
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; // open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; // open a file
 	virtual bool is_open() const override; // true when file is open
 
 	/// returns the path for the current open file

--- a/platform/android/file_access_filesystem_jandroid.cpp
+++ b/platform/android/file_access_filesystem_jandroid.cpp
@@ -63,7 +63,7 @@ String FileAccessFilesystemJAndroid::get_path_absolute() const {
 	return absolute_path;
 }
 
-Error FileAccessFilesystemJAndroid::open_internal(const String &p_path, int p_mode_flags) {
+Error FileAccessFilesystemJAndroid::open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) {
 	if (is_open()) {
 		_close();
 	}

--- a/platform/android/file_access_filesystem_jandroid.h
+++ b/platform/android/file_access_filesystem_jandroid.h
@@ -62,7 +62,7 @@ class FileAccessFilesystemJAndroid : public FileAccess {
 	void _set_eof(bool eof);
 
 public:
-	virtual Error open_internal(const String &p_path, int p_mode_flags) override; ///< open a file
+	virtual Error open_internal(const String &p_path, int p_mode_flags, SaveIntegrityLevel p_integrity_level) override; ///< open a file
 	virtual bool is_open() const override; ///< true when file is open
 
 	/// returns the path for the current open file

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1708,7 +1708,7 @@ static String _resource_get_class(Ref<Resource> p_resource) {
 	}
 }
 
-Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Resource::seed_scene_unique_id(p_path.hash()); // Seeding for save path should make it deterministic for importers.
 
 	if (p_path.ends_with(".tscn")) {
@@ -1716,7 +1716,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 	}
 
 	Error err;
-	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 	ERR_FAIL_COND_V_MSG(err, ERR_CANT_OPEN, "Cannot save file '" + p_path + "'.");
 	Ref<FileAccess> _fref(f);
 
@@ -2120,13 +2120,13 @@ Error ResourceLoaderText::set_uid(Ref<FileAccess> p_f, ResourceUID::ID p_uid) {
 	return OK;
 }
 
-Error ResourceFormatSaverText::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverText::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	if (p_path.ends_with(".tscn") && !Ref<PackedScene>(p_resource).is_valid()) {
 		return ERR_FILE_UNRECOGNIZED;
 	}
 
 	ResourceFormatSaverTextInstance saver;
-	return saver.save(p_path, p_resource, p_flags);
+	return saver.save(p_path, p_resource, p_flags, p_integrity_level);
 }
 
 Error ResourceFormatSaverText::set_uid(const String &p_path, ResourceUID::ID p_uid) {

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -200,13 +200,13 @@ class ResourceFormatSaverTextInstance {
 	String _write_resource(const Ref<Resource> &res);
 
 public:
-	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT);
 };
 
 class ResourceFormatSaverText : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverText *singleton;
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual Error set_uid(const String &p_path, ResourceUID::ID p_uid) override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -345,14 +345,14 @@ String ResourceFormatLoaderShader::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<Shader> shader = p_resource;
 	ERR_FAIL_COND_V(shader.is_null(), ERR_INVALID_PARAMETER);
 
 	String source = shader->get_code();
 
 	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err, p_integrity_level);
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader '" + p_path + "'.");
 

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -116,7 +116,7 @@ public:
 
 class ResourceFormatSaverShader : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -129,14 +129,14 @@ String ResourceFormatLoaderShaderInclude::get_resource_type(const String &p_path
 
 // ResourceFormatSaverShaderInclude
 
-Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags, FileAccess::SaveIntegrityLevel p_integrity_level) {
 	Ref<ShaderInclude> shader_inc = p_resource;
 	ERR_FAIL_COND_V(shader_inc.is_null(), ERR_INVALID_PARAMETER);
 
 	String source = shader_inc->get_code();
 
 	Error error;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &error);
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &error, p_integrity_level);
 
 	ERR_FAIL_COND_V_MSG(error, error, "Cannot save shader include '" + p_path + "'.");
 

--- a/scene/resources/shader_include.h
+++ b/scene/resources/shader_include.h
@@ -66,7 +66,7 @@ public:
 
 class ResourceFormatSaverShaderInclude : public ResourceFormatSaver {
 public:
-	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0, FileAccess::SaveIntegrityLevel p_integrity_level = FileAccess::SAVE_INTEGRITY_DEFAULT) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	virtual bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -511,7 +511,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 void ShaderRD::_save_to_cache(Version *p_version, int p_group) {
 	ERR_FAIL_COND(!shader_cache_dir_valid);
 	const String &path = _get_cache_file_path(p_version, p_group);
-	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
+	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE, nullptr, FileAccess::SAVE_INTEGRITY_SAVE_SWAP);
 	ERR_FAIL_COND(f.is_null());
 	f->store_buffer((const uint8_t *)shader_file_header, 4);
 	f->store_32(cache_file_version); // File version.

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6818,7 +6818,7 @@ void RenderingDevice::_save_pipeline_cache(void *p_data) {
 	}
 	print_verbose(vformat("Updated PSO cache (%.1f MiB)", cache_blob.size() / (1024.0f * 1024.0f)));
 
-	Ref<FileAccess> f = FileAccess::open(self->pipeline_cache_file_path, FileAccess::WRITE, nullptr);
+	Ref<FileAccess> f = FileAccess::open(self->pipeline_cache_file_path, FileAccess::WRITE, nullptr, FileAccess::SAVE_INTEGRITY_SAVE_SWAP);
 	if (f.is_valid()) {
 		f->store_buffer(cache_blob);
 	}


### PR DESCRIPTION
This builds on PR #100674 and #100447, in order to make the changes the `ResourceFormatSaver::_save()` virtual method in a way that doesn't break GDExtension compatibility.

(These changes used to be part of PR #100674 but I've extracted them here)

This will be a DRAFT until those other two have been merged.