### PR TITLE
Betsy: Compress mipmaps in parallel

### DIFF
--- a/modules/betsy/CrossPlatformSettings_piece_all.glsl
+++ b/modules/betsy/CrossPlatformSettings_piece_all.glsl
@@ -61,9 +61,9 @@
 
 #define OGRE_Load3D(tex, iuv, lod) texelFetch(tex, ivec3(iuv), lod)
 
-#define OGRE_GatherRed(tex, sampler, uv) textureGather(tex, uv, 0)
-#define OGRE_GatherGreen(tex, sampler, uv) textureGather(tex, uv, 1)
-#define OGRE_GatherBlue(tex, sampler, uv) textureGather(tex, uv, 2)
+#define OGRE_GatherRed(tex, uv) textureGather(tex, uv, 0)
+#define OGRE_GatherGreen(tex, uv) textureGather(tex, uv, 1)
+#define OGRE_GatherBlue(tex, uv) textureGather(tex, uv, 2)
 
 #define bufferFetch1(buffer, idx) texelFetch(buffer, idx).x
 

--- a/modules/betsy/alpha_stitch.glsl
+++ b/modules/betsy/alpha_stitch.glsl
@@ -8,17 +8,24 @@
 #include "CrossPlatformSettings_piece_all.glsl"
 #include "UavCrossPlatform_piece_all.glsl"
 
+layout(binding = 0) uniform texture2D srcRGB[32];
+layout(binding = 1) uniform texture2D srcAlpha[32];
+layout(binding = 2) uniform sampler SAMPLER_NEAREST_CLAMP;
+layout(binding = 3, rgba32ui) uniform restrict writeonly uimage2D dstTextures[32];
+
+layout(push_constant, std430) uniform Params {
+	uint p_textureIndex;
+	uint p_padding[3];
+}
+params;
+
 layout(local_size_x = 8, //
 		local_size_y = 8, //
 		local_size_z = 1) in;
 
-layout(binding = 0) uniform usampler2D srcRGB;
-layout(binding = 1) uniform usampler2D srcAlpha;
-layout(binding = 2, rgba32ui) uniform restrict writeonly uimage2D dstTexture;
-
 void main() {
-	uint2 rgbBlock = OGRE_Load2D(srcRGB, int2(gl_GlobalInvocationID.xy), 0).xy;
-	uint2 alphaBlock = OGRE_Load2D(srcAlpha, int2(gl_GlobalInvocationID.xy), 0).xy;
+	float2 rgbBlock = OGRE_Load2D(sampler2D(srcRGB[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), int2(gl_GlobalInvocationID.xy), 0).xy;
+	float2 alphaBlock = OGRE_Load2D(sampler2D(srcAlpha[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), int2(gl_GlobalInvocationID.xy), 0).xy;
 
-	imageStore(dstTexture, int2(gl_GlobalInvocationID.xy), uint4(rgbBlock.xy, alphaBlock.xy));
+	imageStore(dstTextures[params.p_textureIndex], int2(gl_GlobalInvocationID.xy), floatBitsToUint(float4(rgbBlock.xy, alphaBlock.xy)));
 }

--- a/modules/betsy/bc1.glsl
+++ b/modules/betsy/bc1.glsl
@@ -11,17 +11,19 @@ dithered = "#define BC1_DITHER";
 
 #define FLT_MAX 340282346638528859811704183484516925440.0f
 
-layout(binding = 0) uniform sampler2D srcTex;
-layout(binding = 1, rg32ui) uniform restrict writeonly uimage2D dstTexture;
+layout(binding = 0) uniform texture2D srcTextures[32];
+layout(binding = 1) uniform sampler SAMPLER_NEAREST_CLAMP;
+layout(binding = 2, rgba32ui) uniform restrict writeonly uimage2D dstTextures[32];
 
-layout(std430, binding = 2) readonly restrict buffer globalBuffer {
+layout(std430, binding = 3) readonly restrict buffer globalBuffer {
 	float2 c_oMatch5[256];
 	float2 c_oMatch6[256];
 };
 
 layout(push_constant, std430) uniform Params {
 	uint p_numRefinements;
-	uint p_padding[3];
+	uint p_textureIndex;
+	uint p_padding[2];
 }
 params;
 
@@ -414,7 +416,7 @@ void main() {
 	const uint2 pixelsToLoadBase = gl_GlobalInvocationID.xy << 2u;
 	for (uint i = 0u; i < 16u; ++i) {
 		const uint2 pixelsToLoad = pixelsToLoadBase + uint2(i & 0x03u, i >> 2u);
-		const float3 srcPixels0 = OGRE_Load2D(srcTex, int2(pixelsToLoad), 0).xyz;
+		const float3 srcPixels0 = OGRE_Load2D(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), int2(pixelsToLoad), 0).xyz;
 		srcPixelsBlock[i] = packUnorm4x8(float4(srcPixels0, 1.0f));
 		bAllColorsEqual = bAllColorsEqual && srcPixelsBlock[0] == srcPixelsBlock[i];
 	}
@@ -479,5 +481,5 @@ void main() {
 	outputBytes.y = mask;
 
 	uint2 dstUV = gl_GlobalInvocationID.xy;
-	imageStore(dstTexture, int2(dstUV), uint4(outputBytes.xy, 0u, 0u));
+	imageStore(dstTextures[params.p_textureIndex], int2(dstUV), uint4(outputBytes.xy, 0u, 0u));
 }

--- a/modules/betsy/bc4.glsl
+++ b/modules/betsy/bc4.glsl
@@ -14,12 +14,14 @@ signed = "#define SNORM";
 shared float2 g_minMaxValues[4u * 4u * 4u];
 shared uint2 g_mask[4u * 4u];
 
-layout(binding = 0) uniform sampler2D srcTex;
-layout(binding = 1, rg32ui) uniform restrict writeonly uimage2D dstTexture;
+layout(binding = 0) uniform texture2D srcTextures[32];
+layout(binding = 1) uniform sampler SAMPLER_NEAREST_CLAMP;
+layout(binding = 2, rgba32ui) uniform restrict writeonly uimage2D dstTextures[32];
 
 layout(push_constant, std430) uniform Params {
 	uint p_channelIdx;
-	uint p_padding[3];
+	uint p_textureIndex;
+	uint p_padding[2];
 }
 params;
 
@@ -50,7 +52,7 @@ void main() {
 	for (uint i = 0u; i < 4u; ++i) {
 		const uint2 pixelsToLoad = pixelsToLoadBase + uint2(i, blockThreadId);
 
-		const float4 value = OGRE_Load2D(srcTex, int2(pixelsToLoad), 0).xyzw;
+		const float4 value = OGRE_Load2D(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), int2(pixelsToLoad), 0).xyzw;
 		srcPixel[i] = params.p_channelIdx == 0 ? value.x : (params.p_channelIdx == 1 ? value.y : value.w);
 		srcPixel[i] *= 255.0f;
 	}
@@ -146,6 +148,6 @@ void main() {
 		outputBytes.y = g_mask[maskIdxBase].y;
 
 		uint2 dstUV = gl_GlobalInvocationID.yz;
-		imageStore(dstTexture, int2(dstUV), uint4(outputBytes.xy, 0u, 0u));
+		imageStore(dstTextures[params.p_textureIndex], int2(dstUV), uint4(outputBytes.xy, 0u, 0u));
 	}
 }

--- a/modules/betsy/bc6h.glsl
+++ b/modules/betsy/bc6h.glsl
@@ -31,12 +31,13 @@ float f16tof32(uint value) {
 	return unpackHalf2x16(value.x).x;
 }
 
-layout(binding = 0) uniform sampler2D srcTexture;
-layout(binding = 1, rgba32ui) uniform restrict writeonly uimage2D dstTexture;
+layout(binding = 0) uniform texture2D srcTextures[32];
+layout(binding = 1) uniform sampler SAMPLER_NEAREST_CLAMP;
+layout(binding = 2, rgba32ui) uniform restrict writeonly uimage2D dstTextures[32];
 
 layout(push_constant, std430) uniform Params {
 	float2 p_textureSizeRcp;
-	uint padding0;
+	uint p_textureIndex;
 	uint padding1;
 }
 params;
@@ -663,18 +664,18 @@ void main() {
 	float2 block1UV = uv + float2(2.0f * params.p_textureSizeRcp.x, 0.0f);
 	float2 block2UV = uv + float2(0.0f, 2.0f * params.p_textureSizeRcp.y);
 	float2 block3UV = uv + float2(2.0f * params.p_textureSizeRcp.x, 2.0f * params.p_textureSizeRcp.y);
-	float4 block0X = OGRE_GatherRed(srcTexture, pointSampler, block0UV);
-	float4 block1X = OGRE_GatherRed(srcTexture, pointSampler, block1UV);
-	float4 block2X = OGRE_GatherRed(srcTexture, pointSampler, block2UV);
-	float4 block3X = OGRE_GatherRed(srcTexture, pointSampler, block3UV);
-	float4 block0Y = OGRE_GatherGreen(srcTexture, pointSampler, block0UV);
-	float4 block1Y = OGRE_GatherGreen(srcTexture, pointSampler, block1UV);
-	float4 block2Y = OGRE_GatherGreen(srcTexture, pointSampler, block2UV);
-	float4 block3Y = OGRE_GatherGreen(srcTexture, pointSampler, block3UV);
-	float4 block0Z = OGRE_GatherBlue(srcTexture, pointSampler, block0UV);
-	float4 block1Z = OGRE_GatherBlue(srcTexture, pointSampler, block1UV);
-	float4 block2Z = OGRE_GatherBlue(srcTexture, pointSampler, block2UV);
-	float4 block3Z = OGRE_GatherBlue(srcTexture, pointSampler, block3UV);
+	float4 block0X = OGRE_GatherRed(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block0UV);
+	float4 block1X = OGRE_GatherRed(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block1UV);
+	float4 block2X = OGRE_GatherRed(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block2UV);
+	float4 block3X = OGRE_GatherRed(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block3UV);
+	float4 block0Y = OGRE_GatherGreen(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block0UV);
+	float4 block1Y = OGRE_GatherGreen(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block1UV);
+	float4 block2Y = OGRE_GatherGreen(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block2UV);
+	float4 block3Y = OGRE_GatherGreen(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block3UV);
+	float4 block0Z = OGRE_GatherBlue(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block0UV);
+	float4 block1Z = OGRE_GatherBlue(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block1UV);
+	float4 block2Z = OGRE_GatherBlue(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block2UV);
+	float4 block3Z = OGRE_GatherBlue(sampler2D(srcTextures[params.p_textureIndex], SAMPLER_NEAREST_CLAMP), block3UV);
 
 	float3 texels[16];
 	texels[0] = float3(block0X.w, block0Y.w, block0Z.w);
@@ -715,5 +716,5 @@ void main() {
 	EncodeP2Pattern(block, blockMSLE, bestPattern, texels);
 #endif
 
-	imageStore(dstTexture, int2(gl_GlobalInvocationID.xy), block);
+	imageStore(dstTextures[params.p_textureIndex], int2(gl_GlobalInvocationID.xy), block);
 }

--- a/modules/betsy/image_compress_betsy.h
+++ b/modules/betsy/image_compress_betsy.h
@@ -73,16 +73,24 @@ enum BetsyShaderType {
 struct BC6PushConstant {
 	float sizeX;
 	float sizeY;
-	uint32_t padding[2] = { 0 };
+	uint32_t index;
+	uint32_t padding = 0;
 };
 
 struct BC1PushConstant {
 	uint32_t num_refines;
-	uint32_t padding[3] = { 0 };
+	uint32_t index;
+	uint32_t padding[2] = { 0 };
 };
 
 struct BC4PushConstant {
 	uint32_t channel_idx;
+	uint32_t index;
+	uint32_t padding[2] = { 0 };
+};
+
+struct StitchPushConstant {
+	uint32_t index;
 	uint32_t padding[3] = { 0 };
 };
 
@@ -101,11 +109,22 @@ class BetsyCompressor : public Object {
 		RID pipeline;
 	};
 
+	struct BetsyMipmap {
+		RID src_texture;
+		RID dst_temp_primary_texture;
+		RID dst_temp_second_texture;
+		RID dst_texture;
+		uint32_t width;
+		uint32_t height;
+	};
+
 	// Resources shared by all compression formats.
 	RenderingDevice *compress_rd = nullptr;
 	RenderingContextDriver *compress_rcd = nullptr;
 	BetsyShader cached_shaders[BETSY_SHADER_MAX];
 	RID src_sampler;
+	RID default_tex;
+	RID default_image;
 
 	// Format-specific resources.
 	RID dxt1_encoding_table_buffer;


### PR DESCRIPTION
Changes the Betsy implementation to compress mipmaps in parallel. This is meant to improve GPU utilization and speed up the compression process.
This was achieved by using 32 texture/image slots in each shader. This ensures that the reserved space is big enough for any supported texture (The maximal pixel count on each axis is 2^24).

The performance difference is about 15 - 25%, depending on the texture (and CPU bottlenecks).

Results:
Windows 10 - Vulkan (Forward+) - dedicated NVIDIA GeForce RTX 4060 Ti (NVIDIA; 32.0.15.6094) - AMD Ryzen 9 5900X 12-Core Processor (24 threads)

| Image | Old | New |
|-------|-----|------|
| BC1 4k 12 mipmaps | 147 ms | 132 ms |
| BC3 4k 12 mipmaps | 219 ms | 158 ms |
| BC4 4k 12 mipmaps | 153 ms | 109 ms |
| BC5 4k 12 mipmaps | 215 ms | 178 ms |
| BC6 8x4k 13 mipmaps | 829 ms | 783 ms |

TODO:
- [x] Measure the performance difference,
- [ ] Test on low-end GPUs,
- [x] Ensure the resulting textures look correct.