### PR TITLE
Fix error when connecting signal to non-tool script deferred

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1281,6 +1281,18 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 			}
 		}
 
+		Object *target = callable.get_object();
+
+#ifdef TOOLS_ENABLED
+		if (target && flags & CONNECT_PERSIST && Engine::get_singleton()->is_editor_hint()) {
+			Ref<Script> other_scr = target->get_script();
+			if (other_scr.is_valid() && !other_scr->is_tool()) {
+				// Trying to call not-tool method in editor, just ignore it.
+				continue;
+			}
+		}
+#endif
+
 		if (flags & CONNECT_DEFERRED) {
 			MessageQueue::get_singleton()->push_callablep(callable, args, argc, true);
 		} else {
@@ -1291,16 +1303,6 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 			_emitting = false;
 
 			if (ce.error != Callable::CallError::CALL_OK) {
-				Object *target = callable.get_object();
-#ifdef DEBUG_ENABLED
-				if (target && flags & CONNECT_PERSIST && Engine::get_singleton()->is_editor_hint()) {
-					Ref<Script> other_scr = target->get_script();
-					if (other_scr.is_valid() && !other_scr->is_tool()) {
-						// Trying to call not-tool method in editor, just ignore it.
-						continue;
-					}
-				}
-#endif
 				if (ce.error == Callable::CallError::CALL_ERROR_INVALID_METHOD && target && !ClassDB::class_exists(target->get_class_name())) {
 					// Most likely object is not initialized yet, do not throw error.
 				} else {


### PR DESCRIPTION
We'll start by creating a new scene and attaching a non-tool script, then connect the `ready` signal to this script's method as shown here, and check the `deferred` option:
![Godot_v4 4-dev6_win64_2Q9oRKYIEt](https://github.com/user-attachments/assets/f9b8864a-cdf1-481a-ad12-f77d18009f61)

Save & close this scene, reopen it and we get a error message:
![Godot_v4 4-dev6_win64_qT66E40PkG](https://github.com/user-attachments/assets/37c8fd30-f504-4a25-994c-14d525cb86be)

**Cause analysis:**
In previous implementations, only signals that did not have `deferred` enabled were checked to ensure that non-toolscript method calls were not triggered in the `editor_hint` state.

By this PR, the timing of this check has been moved forward so that non-toolscript method calls can be avoided even in `deferred` enabled signal connections.
