### PR TITLE
Fix inverted `GPUParticlesCollisionHeightField3D` in compatibility renderer.

### DIFF
--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -453,14 +453,14 @@ void main() {
 
 					vec3 uvw_pos = vec3(local_pos_bottom / colliders[i].extents.xyz) * 0.5 + 0.5;
 
-					float y = 1.0 - texture(height_field_texture, uvw_pos.xz).r;
+					float y = texture(height_field_texture, uvw_pos.xz).r;
 
 					if (y + EPSILON > uvw_pos.y) {
 						//inside heightfield
 
 						vec3 pos1 = (vec3(uvw_pos.x, y, uvw_pos.z) * 2.0 - 1.0) * colliders[i].extents.xyz;
-						vec3 pos2 = (vec3(uvw_pos.x + DELTA, 1.0 - texture(height_field_texture, uvw_pos.xz + vec2(DELTA, 0)).r, uvw_pos.z) * 2.0 - 1.0) * colliders[i].extents.xyz;
-						vec3 pos3 = (vec3(uvw_pos.x, 1.0 - texture(height_field_texture, uvw_pos.xz + vec2(0, DELTA)).r, uvw_pos.z + DELTA) * 2.0 - 1.0) * colliders[i].extents.xyz;
+						vec3 pos2 = (vec3(uvw_pos.x + DELTA, texture(height_field_texture, uvw_pos.xz + vec2(DELTA, 0)).r, uvw_pos.z) * 2.0 - 1.0) * colliders[i].extents.xyz;
+						vec3 pos3 = (vec3(uvw_pos.x, texture(height_field_texture, uvw_pos.xz + vec2(0, DELTA)).r, uvw_pos.z + DELTA) * 2.0 - 1.0) * colliders[i].extents.xyz;
 
 						normal = normalize(cross(pos1 - pos2, pos1 - pos3));
 						float local_y = (vec3(local_pos / colliders[i].extents.xyz) * 0.5 + 0.5).y;


### PR DESCRIPTION
Followed the thread from issue [100872](https://github.com/godotengine/godot/issues/100872) and implemented the fix for the particle system for the compatibility shader.