### PR TITLE
Tree: Fix cusor selection in `multi` selection-mode

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3451,7 +3451,8 @@ void Tree::_go_up() {
 			return;
 		}
 
-		select_single_item(prev, get_root(), col);
+		selected_item = prev;
+		emit_signal(SNAME("cell_selected"));
 		queue_redraw();
 	} else {
 		while (prev && !prev->cells[col].selectable) {
@@ -3484,7 +3485,8 @@ void Tree::_go_down() {
 			return;
 		}
 
-		select_single_item(next, get_root(), col);
+		selected_item = next;
+		emit_signal(SNAME("cell_selected"));
 		queue_redraw();
 	} else {
 		while (next && !next->cells[col].selectable) {


### PR DESCRIPTION
Fixes the tree cursor always selecting the current item (as shown in the video) by reverting the change made in https://github.com/godotengine/godot/pull/86218/. The feature of #86218 (selecting nodes in the scene tree dock using arrow keys) was also implemented by https://github.com/godotengine/godot/pull/93543 and is still present in the editor.
<details><summary>Video</summary>
<p>

https://github.com/user-attachments/assets/c848641a-0165-42cc-a1b0-93cc1279d377

</p>
</details> 


_If you think this feature (cursor element of the tree is selected with arrow keys) should be kept, I would create a separate pull request to fix the left and right arrow keys and add a checkbox to the inspector. If so, please what the default value should be._
