### PR TITLE
Add `RichTextLabel::set_clearing_enabled`

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -460,6 +460,7 @@ EditorLog::EditorLog() {
 	log->set_h_size_flags(SIZE_EXPAND_FILL);
 	log->set_deselect_on_focus_loss_enabled(false);
 	log->connect("meta_clicked", callable_mp(this, &EditorLog::_meta_clicked));
+	log->set_clearing_enabled(true);
 	vb_left->add_child(log);
 
 	// Search box

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4175,6 +4175,14 @@ bool RichTextLabel::is_fit_content_enabled() const {
 	return fit_content;
 }
 
+void RichTextLabel::set_clearing_enabled(bool p_clear) {
+	clearing_enabled = p_clear;
+}
+
+bool RichTextLabel::is_clearing_enabled() {
+	return clearing_enabled;
+}
+
 void RichTextLabel::set_meta_underline(bool p_underline) {
 	if (underline_meta == p_underline) {
 		return;
@@ -6763,6 +6771,7 @@ void RichTextLabel::_generate_context_menu() {
 	add_child(menu, false, INTERNAL_MODE_FRONT);
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &RichTextLabel::menu_option));
 
+	menu->add_item(ETR("Clear"), MENU_CLEAR);
 	menu->add_item(ETR("Copy"), MENU_COPY);
 	menu->add_item(ETR("Select All"), MENU_SELECT_ALL);
 }
@@ -6781,6 +6790,7 @@ void RichTextLabel::_update_context_menu() {
 		m_menu->set_item_disabled(idx, m_disabled);                                                                    \
 	}
 
+	MENU_ITEM_ACTION_DISABLED(menu, MENU_CLEAR, "ui_clear", !clearing_enabled)
 	MENU_ITEM_ACTION_DISABLED(menu, MENU_COPY, "ui_copy", !selection.enabled)
 	MENU_ITEM_ACTION_DISABLED(menu, MENU_SELECT_ALL, "ui_text_select_all", !selection.enabled)
 
@@ -6814,6 +6824,9 @@ Key RichTextLabel::_get_menu_action_accelerator(const String &p_action) {
 
 void RichTextLabel::menu_option(int p_option) {
 	switch (p_option) {
+		case MENU_CLEAR: {
+			clear();
+		} break;
 		case MENU_COPY: {
 			selection_copy();
 		} break;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -100,6 +100,7 @@ public:
 	};
 
 	enum MenuItems {
+		MENU_CLEAR,
 		MENU_COPY,
 		MENU_SELECT_ALL,
 		MENU_MAX
@@ -547,6 +548,8 @@ private:
 	bool context_menu_enabled = false;
 	bool shortcut_keys_enabled = true;
 
+	bool clearing_enabled = false;
+
 	// Context menu.
 	PopupMenu *menu = nullptr;
 	void _generate_context_menu();
@@ -761,6 +764,9 @@ public:
 
 	void set_fit_content(bool p_enabled);
 	bool is_fit_content_enabled() const;
+
+	void set_clearing_enabled(bool p_clear);
+	bool is_clearing_enabled();
 
 	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false);
 


### PR DESCRIPTION
Adds a clear option to the context menu. Disabled by default. Enabled in EditorLog
