### PR TITLE
Improve 2D Particle Emission Mask dialog

### DIFF
--- a/editor/scene/2d/particles_2d_editor_plugin.cpp
+++ b/editor/scene/2d/particles_2d_editor_plugin.cpp
@@ -32,12 +32,14 @@
 
 #include "core/io/image_loader.h"
 #include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "scene/2d/cpu_particles_2d.h"
 #include "scene/2d/gpu_particles_2d.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/spin_box.h"
@@ -61,154 +63,257 @@ void GPUParticles2DEditorPlugin::_add_menu_options(PopupMenu *p_menu) {
 	p_menu->add_item(TTR("Generate Visibility Rect"), MENU_GENERATE_VISIBILITY_RECT);
 }
 
-void Particles2DEditorPlugin::_file_selected(const String &p_file) {
-	source_emission_file = p_file;
-	emission_mask->popup_centered();
+void Particles2DEditorPlugin::_browse_mask_texture_pressed() {
+	browsing_texture_type = TEXTURE_TYPE_MASK;
+	file_dialog->popup_file_dialog();
 }
 
-void Particles2DEditorPlugin::_get_base_emission_mask(PackedVector2Array &r_valid_positions, PackedVector2Array &r_valid_normals, PackedByteArray &r_valid_colors, Vector2i &r_image_size) {
-	Ref<Image> img;
-	img.instantiate();
-	Error err = ImageLoader::load_image(source_emission_file, img);
-	ERR_FAIL_COND_MSG(err != OK, "Error loading image '" + source_emission_file + "'.");
+void Particles2DEditorPlugin::_browse_direction_texture_pressed() {
+	browsing_texture_type = TEXTURE_TYPE_DIRECTION;
+	file_dialog->popup_centered();
+}
 
-	if (img->is_compressed()) {
-		img->decompress();
-	}
-	img->convert(Image::FORMAT_RGBA8);
-	ERR_FAIL_COND(img->get_format() != Image::FORMAT_RGBA8);
-	Size2i s = img->get_size();
-	ERR_FAIL_COND(s.width == 0 || s.height == 0);
-
-	r_image_size = s;
-
-	r_valid_positions.resize(s.width * s.height);
-
-	EmissionMode emode = (EmissionMode)emission_mask_mode->get_selected();
-
-	if (emode == EMISSION_MODE_BORDER_DIRECTED) {
-		r_valid_normals.resize(s.width * s.height);
+void Particles2DEditorPlugin::_file_selected(const String &p_file) {
+	switch (browsing_texture_type) {
+		case TEXTURE_TYPE_MASK: {
+			mask_img_path_line_edit->set_text(p_file);
+			break;
+		}
+		case TEXTURE_TYPE_DIRECTION: {
+			direction_img_path_line_edit->set_text(p_file);
+			break;
+		}
 	}
 
-	bool capture_colors = emission_colors->is_pressed();
+	_validate_textures();
+}
+
+void Particles2DEditorPlugin::_process_emission_masks(PackedVector2Array &r_valid_positions, PackedVector2Array &r_valid_normals, PackedByteArray &r_valid_colors, Vector2i &r_image_size) {
+	Ref<Image> mask_img;
+	mask_img.instantiate();
+	Error err = ImageLoader::load_image(mask_img_path_line_edit->get_text(), mask_img);
+	ERR_FAIL_COND_MSG(err != OK, vformat("Error loading image '%s'.", mask_img_path_line_edit->get_text()));
+
+	if (mask_img->is_compressed()) {
+		mask_img->decompress();
+	}
+	mask_img->convert(Image::FORMAT_RGBA8);
+	ERR_FAIL_COND(mask_img->get_format() != Image::FORMAT_RGBA8);
+	Size2i mask_img_size = mask_img->get_size();
+	ERR_FAIL_COND(mask_img_size.width == 0 || mask_img_size.height == 0);
+
+	r_image_size = mask_img_size;
+
+	r_valid_positions.resize(mask_img_size.width * mask_img_size.height);
+
+	MaskMode emission_mode = static_cast<MaskMode>(emission_mask_mode->get_selected());
+	DirectionMode direction_mode = static_cast<DirectionMode>(emission_direction_mode->get_selected());
+
+	if (direction_mode != DIRECTION_MODE_NONE) {
+		r_valid_normals.resize(mask_img_size.width * mask_img_size.height);
+	}
+
+	bool capture_colors = emission_mask_colors->is_pressed();
 
 	if (capture_colors) {
-		r_valid_colors.resize(s.width * s.height * 4);
+		r_valid_colors.resize(mask_img_size.width * mask_img_size.height * 4);
 	}
 
-	int vpc = 0;
+	int valid_point_count = 0;
 
 	{
-		Vector<uint8_t> img_data = img->get_data();
-		const uint8_t *r = img_data.ptr();
+		Vector<uint8_t> mask_img_data = mask_img->get_data();
+		const uint8_t *mask_img_ptr = mask_img_data.ptr();
 
-		for (int i = 0; i < s.width; i++) {
-			for (int j = 0; j < s.height; j++) {
-				uint8_t a = r[(j * s.width + i) * 4 + 3];
+		for (int mask_img_x = 0; mask_img_x < mask_img_size.width; mask_img_x++) {
+			for (int mask_img_y = 0; mask_img_y < mask_img_size.height; mask_img_y++) {
+				uint8_t mask_alpha = mask_img_ptr[(mask_img_y * mask_img_size.width + mask_img_x) * 4 + 3];
 
-				if (a > 128) {
-					if (emode == EMISSION_MODE_SOLID) {
-						if (capture_colors) {
-							r_valid_colors.write[vpc * 4 + 0] = r[(j * s.width + i) * 4 + 0];
-							r_valid_colors.write[vpc * 4 + 1] = r[(j * s.width + i) * 4 + 1];
-							r_valid_colors.write[vpc * 4 + 2] = r[(j * s.width + i) * 4 + 2];
-							r_valid_colors.write[vpc * 4 + 3] = r[(j * s.width + i) * 4 + 3];
-						}
-						r_valid_positions.write[vpc++] = Point2(i, j);
+				if (mask_alpha <= 128) {
+					continue;
+				}
 
-					} else {
-						bool on_border = false;
-						for (int x = i - 1; x <= i + 1; x++) {
-							for (int y = j - 1; y <= j + 1; y++) {
-								if (x < 0 || y < 0 || x >= s.width || y >= s.height || r[(y * s.width + x) * 4 + 3] <= 128) {
-									on_border = true;
-									break;
-								}
-							}
-
-							if (on_border) {
+				if (emission_mode == MASK_MODE_SOLID) {
+					r_valid_positions.write[valid_point_count++] = Point2(mask_img_x, mask_img_y);
+				} else {
+					bool pixel_is_on_border = false;
+					for (int x = mask_img_x - 1; x <= mask_img_x + 1; x++) {
+						for (int y = mask_img_y - 1; y <= mask_img_y + 1; y++) {
+							if (x < 0 || y < 0 || x >= mask_img_size.width || y >= mask_img_size.height || mask_img_ptr[(y * mask_img_size.width + x) * 4 + 3] <= 128) {
+								pixel_is_on_border = true;
 								break;
 							}
 						}
 
-						if (on_border) {
-							r_valid_positions.write[vpc] = Point2(i, j);
-
-							if (emode == EMISSION_MODE_BORDER_DIRECTED) {
-								Vector2 normal;
-								for (int x = i - 2; x <= i + 2; x++) {
-									for (int y = j - 2; y <= j + 2; y++) {
-										if (x == i && y == j) {
-											continue;
-										}
-
-										if (x < 0 || y < 0 || x >= s.width || y >= s.height || r[(y * s.width + x) * 4 + 3] <= 128) {
-											normal += Vector2(x - i, y - j).normalized();
-										}
-									}
-								}
-
-								normal.normalize();
-								r_valid_normals.write[vpc] = normal;
-							}
-
-							if (capture_colors) {
-								r_valid_colors.write[vpc * 4 + 0] = r[(j * s.width + i) * 4 + 0];
-								r_valid_colors.write[vpc * 4 + 1] = r[(j * s.width + i) * 4 + 1];
-								r_valid_colors.write[vpc * 4 + 2] = r[(j * s.width + i) * 4 + 2];
-								r_valid_colors.write[vpc * 4 + 3] = r[(j * s.width + i) * 4 + 3];
-							}
-
-							vpc++;
+						if (pixel_is_on_border) {
+							break;
 						}
 					}
+
+					if (!pixel_is_on_border) {
+						continue;
+					}
+
+					r_valid_positions.write[valid_point_count] = Point2(mask_img_x, mask_img_y);
+
+					if (direction_mode == DIRECTION_MODE_GENERATE) {
+						Vector2 normal;
+						for (int x = mask_img_x - 2; x <= mask_img_x + 2; x++) {
+							for (int y = mask_img_y - 2; y <= mask_img_y + 2; y++) {
+								if (x == mask_img_x && y == mask_img_y) {
+									continue;
+								}
+
+								if (x < 0 || y < 0 || x >= mask_img_size.width || y >= mask_img_size.height || mask_img_ptr[(y * mask_img_size.width + x) * 4 + 3] <= 128) {
+									normal += Vector2(x - mask_img_x, y - mask_img_y).normalized();
+								}
+							}
+						}
+
+						normal.normalize();
+						r_valid_normals.write[valid_point_count] = normal;
+					}
+
+					valid_point_count++;
 				}
+			}
+		}
+
+		if (capture_colors) {
+			for (int i = 0; i < valid_point_count; ++i) {
+				const Point2i point = r_valid_positions.get(i);
+				r_valid_colors.write[i * 4 + 0] = mask_img_ptr[(point.y * mask_img_size.width + point.x) * 4 + 0];
+				r_valid_colors.write[i * 4 + 1] = mask_img_ptr[(point.y * mask_img_size.width + point.x) * 4 + 1];
+				r_valid_colors.write[i * 4 + 2] = mask_img_ptr[(point.y * mask_img_size.width + point.x) * 4 + 2];
+				r_valid_colors.write[i * 4 + 3] = mask_img_ptr[(point.y * mask_img_size.width + point.x) * 4 + 3];
 			}
 		}
 	}
 
-	r_valid_positions.resize(vpc);
+	if (direction_mode == DIRECTION_MODE_TEXTURE) {
+		Ref<Image> normal_img;
+		normal_img.instantiate();
+		err = ImageLoader::load_image(direction_img_path_line_edit->get_text(), normal_img);
+		ERR_FAIL_COND_MSG(err != OK, vformat("Error loading image '%s'.", direction_img_path_line_edit->get_text()));
+
+		if (normal_img->is_compressed()) {
+			normal_img->decompress();
+		}
+		normal_img->convert(Image::FORMAT_RGB8);
+		ERR_FAIL_COND(normal_img->get_format() != Image::FORMAT_RGB8);
+		Size2i normal_img_size = normal_img->get_size();
+		ERR_FAIL_COND(normal_img_size.width == 0 || normal_img_size.height == 0);
+		ERR_FAIL_COND_MSG(normal_img_size != mask_img_size, "Mask and Normal texture must have the same size.");
+
+		Vector<uint8_t> normal_img_data = normal_img->get_data();
+		const uint8_t *normal_img_ptr = normal_img_data.ptr();
+
+		for (int i = 0; i < valid_point_count; ++i) {
+			const Point2i point = r_valid_positions.get(i);
+			const uint8_t normal_r = normal_img_ptr[(point.y * normal_img_size.width + point.x) * 3 + 0];
+			const uint8_t normal_g = normal_img_ptr[(point.y * normal_img_size.width + point.x) * 3 + 1];
+
+			Vector2 normal;
+			normal.x = static_cast<float>(normal_r) / 255.0f - 0.5f;
+			normal.y = static_cast<float>(normal_g) / 255.0f - 0.5f;
+
+			normal.normalize();
+
+			r_valid_normals.write[i] = normal;
+		}
+	}
+
+	r_valid_positions.resize(valid_point_count);
 	if (!r_valid_normals.is_empty()) {
-		r_valid_normals.resize(vpc);
+		r_valid_normals.resize(valid_point_count);
 	}
 }
 
 Particles2DEditorPlugin::Particles2DEditorPlugin() {
-	file = memnew(EditorFileDialog);
+	file_dialog = memnew(EditorFileDialog);
 
 	List<String> ext;
 	ImageLoader::get_recognized_extensions(&ext);
 	for (const String &E : ext) {
-		file->add_filter("*." + E, E.to_upper());
+		file_dialog->add_filter("*." + E, E.to_upper());
 	}
 
-	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
-	EditorNode::get_singleton()->get_gui_base()->add_child(file);
-	file->connect("file_selected", callable_mp(this, &Particles2DEditorPlugin::_file_selected));
+	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
+	file_dialog->connect("file_selected", callable_mp(this, &Particles2DEditorPlugin::_file_selected));
 
-	emission_mask = memnew(ConfirmationDialog);
-	emission_mask->set_title(TTR("Load Emission Mask"));
+	emission_mask_dialog = memnew(ConfirmationDialog);
+	emission_mask_dialog->set_title(TTRC("Load Emission Mask"));
+	emission_mask_dialog->add_child(file_dialog);
+	emission_mask_dialog->get_ok_button()->set_disabled(true);
 
 	VBoxContainer *emvb = memnew(VBoxContainer);
-	emission_mask->add_child(emvb);
+	emission_mask_dialog->add_child(emvb);
+
+	HBoxContainer *mask_img_hbox = memnew(HBoxContainer);
+
+	mask_img_path_line_edit = memnew(LineEdit);
+	mask_img_hbox->add_child(mask_img_path_line_edit);
+	mask_img_path_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	mask_img_path_line_edit->set_editable(false);
+	mask_img_path_line_edit->connect(SceneStringName(text_changed), callable_mp(this, &Particles2DEditorPlugin::_validate_textures).unbind(1));
+
+	mask_browse_button = memnew(Button);
+	mask_img_hbox->add_child(mask_browse_button);
+	mask_browse_button->connect(SceneStringName(pressed), callable_mp(this, &Particles2DEditorPlugin::_browse_mask_texture_pressed));
+	emvb->add_margin_child(TTRC("Mask Texture"), mask_img_hbox);
 
 	emission_mask_mode = memnew(OptionButton);
-	emission_mask_mode->add_item(TTR("Solid Pixels"), EMISSION_MODE_SOLID);
-	emission_mask_mode->add_item(TTR("Border Pixels"), EMISSION_MODE_BORDER);
-	emission_mask_mode->add_item(TTR("Directed Border Pixels"), EMISSION_MODE_BORDER_DIRECTED);
-	emvb->add_margin_child(TTR("Emission Mask"), emission_mask_mode);
+	emission_mask_mode->add_item(TTRC("Solid Pixels"), MASK_MODE_SOLID);
+	emission_mask_mode->add_item(TTRC("Border Pixels"), MASK_MODE_BORDER);
+	emission_mask_mode->connect(SceneStringName(item_selected), callable_mp(this, &Particles2DEditorPlugin::_emission_mask_mode_item_changed));
+	emvb->add_margin_child(TTRC("Mask Mode"), emission_mask_mode);
+
+	emission_direction_mode = memnew(OptionButton);
+	emission_direction_mode->add_item(TTRC("None"), DIRECTION_MODE_NONE);
+	emission_direction_mode->add_item(TTRC("Generate"), DIRECTION_MODE_GENERATE);
+	emission_direction_mode->add_item(TTRC("Texture"), DIRECTION_MODE_TEXTURE);
+	emission_direction_mode->connect(SceneStringName(item_selected), callable_mp(this, &Particles2DEditorPlugin::_validate_textures).unbind(1));
+	emission_direction_mode->set_item_disabled(DIRECTION_MODE_GENERATE, true);
+	emvb->add_margin_child(TTRC("Direction Mode"), emission_direction_mode);
+
+	direction_img_label = memnew(Label);
+	direction_img_label->set_text(TTRC("Direction Texture"));
+	direction_img_label->set_theme_type_variation("HeaderSmall");
+	emvb->add_child(direction_img_label);
+	direction_img_label->hide();
+
+	direction_img_hbox = memnew(HBoxContainer);
+	direction_img_path_line_edit = memnew(LineEdit);
+	direction_img_hbox->add_child(direction_img_path_line_edit);
+	direction_img_path_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	direction_img_path_line_edit->set_editable(false);
+	direction_img_path_line_edit->connect(SceneStringName(text_changed), callable_mp(this, &Particles2DEditorPlugin::_validate_textures).unbind(1));
+
+	direction_browse_button = memnew(Button);
+	direction_img_hbox->add_child(direction_browse_button);
+	direction_browse_button->connect(SceneStringName(pressed), callable_mp(this, &Particles2DEditorPlugin::_browse_direction_texture_pressed));
+	emvb->add_child(direction_img_hbox);
+	direction_img_hbox->hide();
 
 	VBoxContainer *optionsvb = memnew(VBoxContainer);
-	emvb->add_margin_child(TTR("Options"), optionsvb);
+	emvb->add_margin_child(TTRC("Options"), optionsvb);
 
-	emission_mask_centered = memnew(CheckBox(TTR("Centered")));
+	emission_mask_centered = memnew(CheckBox(TTRC("Centered")));
+	emission_mask_centered->set_pressed(true);
 	optionsvb->add_child(emission_mask_centered);
-	emission_colors = memnew(CheckBox(TTR("Capture Colors from Pixel")));
-	optionsvb->add_child(emission_colors);
+	emission_mask_colors = memnew(CheckBox(TTRC("Copy Color from Mask Texture")));
+	optionsvb->add_child(emission_mask_colors);
 
-	EditorNode::get_singleton()->get_gui_base()->add_child(emission_mask);
+	error_message = memnew(Label);
+	error_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+	error_message->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	error_message->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
+	emvb->add_child(error_message);
 
-	emission_mask->connect(SceneStringName(confirmed), callable_mp(this, &Particles2DEditorPlugin::_generate_emission_mask));
+	EditorNode::get_singleton()->get_gui_base()->add_child(emission_mask_dialog);
+
+	emission_mask_dialog->connect(SceneStringName(confirmed), callable_mp(this, &Particles2DEditorPlugin::_generate_emission_mask));
+	emission_mask_dialog->connect(SceneStringName(theme_changed), callable_mp(this, &Particles2DEditorPlugin::_theme_changed));
 }
 
 void Particles2DEditorPlugin::_set_show_gizmos(Node *p_node, bool p_show) {
@@ -244,6 +349,13 @@ void Particles2DEditorPlugin::_selection_changed() {
 			selected_particles.insert(node);
 		}
 	}
+
+	mask_img_path_line_edit->set_text("");
+	emission_mask_mode->select(MASK_MODE_SOLID);
+	emission_direction_mode->select(DIRECTION_MODE_NONE);
+	emission_mask_centered->set_pressed(true);
+	emission_mask_colors->set_pressed(false);
+	direction_img_path_line_edit->set_text("");
 
 	// Turn gizmos off for nodes that are no longer selected.
 	LocalVector<Node *> to_erase;
@@ -315,6 +427,11 @@ void Particles2DEditorPlugin::_notification(int p_what) {
 	}
 }
 
+void Particles2DEditorPlugin::_theme_changed() {
+	mask_browse_button->set_button_icon(mask_browse_button->get_editor_theme_icon(SNAME("FileBrowse")));
+	direction_browse_button->set_button_icon(direction_browse_button->get_editor_theme_icon(SNAME("FileBrowse")));
+}
+
 void Particles2DEditorPlugin::_menu_callback(int p_idx) {
 	if (p_idx == MENU_LOAD_EMISSION_MASK) {
 		GPUParticles2D *particles = Object::cast_to<GPUParticles2D>(edited_node);
@@ -323,7 +440,7 @@ void Particles2DEditorPlugin::_menu_callback(int p_idx) {
 			return;
 		}
 
-		file->popup_file_dialog();
+		emission_mask_dialog->popup_centered();
 	} else {
 		ParticlesEditorPlugin::_menu_callback(p_idx);
 	}
@@ -331,6 +448,99 @@ void Particles2DEditorPlugin::_menu_callback(int p_idx) {
 
 void Particles2DEditorPlugin::_add_menu_options(PopupMenu *p_menu) {
 	p_menu->add_item(TTR("Load Emission Mask"), MENU_LOAD_EMISSION_MASK);
+}
+
+void Particles2DEditorPlugin::_validate_textures() {
+	DirectionMode direction_mode = static_cast<DirectionMode>(emission_direction_mode->get_selected());
+	direction_img_label->set_visible(direction_mode == DIRECTION_MODE_TEXTURE);
+	direction_img_hbox->set_visible(direction_mode == DIRECTION_MODE_TEXTURE);
+
+	error_message->hide();
+	emission_mask_dialog->get_ok_button()->set_disabled(true);
+
+	if (mask_img_path_line_edit->get_text().is_empty()) {
+		emission_mask_dialog->reset_size();
+		return;
+	}
+
+	Ref<Image> mask_img;
+	mask_img.instantiate();
+	Error err = ImageLoader::load_image(mask_img_path_line_edit->get_text(), mask_img);
+	if (err != OK) {
+		error_message->show();
+		error_message->set_text(TTRC("Failed to load mask texture."));
+		emission_mask_dialog->reset_size();
+		return;
+	}
+
+	if (mask_img->is_compressed()) {
+		mask_img->decompress();
+	}
+	mask_img->convert(Image::FORMAT_RGBA8);
+
+	if (mask_img->get_format() != Image::FORMAT_RGBA8) {
+		error_message->show();
+		error_message->set_text(TTRC("Failed to convert mask texture to RGBA8."));
+		emission_mask_dialog->reset_size();
+		return;
+	}
+
+	Size2i mask_img_size = mask_img->get_size();
+	if (mask_img_size.width == 0 || mask_img_size.height == 0) {
+		error_message->show();
+		error_message->set_text(TTRC("Mask texture has an invalid size."));
+		emission_mask_dialog->reset_size();
+		return;
+	}
+
+	if (direction_mode == DIRECTION_MODE_TEXTURE) {
+		if (direction_img_path_line_edit->get_text().is_empty()) {
+			return;
+		}
+
+		Ref<Image> direction_img;
+		direction_img.instantiate();
+		err = ImageLoader::load_image(direction_img_path_line_edit->get_text(), direction_img);
+
+		if (err != OK) {
+			error_message->show();
+			error_message->set_text(TTRC("Failed to load direction texture."));
+			emission_mask_dialog->reset_size();
+			return;
+		}
+
+		if (direction_img->is_compressed()) {
+			direction_img->decompress();
+		}
+		direction_img->convert(Image::FORMAT_RGBA8);
+
+		if (direction_img->get_format() != Image::FORMAT_RGBA8) {
+			error_message->show();
+			error_message->set_text(TTRC("Failed to convert direction texture to RGBA8."));
+			emission_mask_dialog->reset_size();
+			return;
+		}
+
+		Size2i direction_img_size = direction_img->get_size();
+
+		if (direction_img_size.width == 0 || direction_img_size.height == 0 || direction_img_size != mask_img_size) {
+			error_message->show();
+			error_message->set_text(TTRC("Direction texture has an invalid size. It must have the same size as the mask texture."));
+			emission_mask_dialog->reset_size();
+			return;
+		}
+	}
+
+	emission_mask_dialog->get_ok_button()->set_disabled(false);
+	emission_mask_dialog->reset_size();
+}
+
+void Particles2DEditorPlugin::_emission_mask_mode_item_changed(int p_idx) const {
+	emission_direction_mode->set_item_disabled(DIRECTION_MODE_GENERATE, p_idx == static_cast<int>(MASK_MODE_SOLID));
+
+	if (emission_direction_mode->get_selected() == DIRECTION_MODE_GENERATE) {
+		emission_direction_mode->select(DIRECTION_MODE_NONE);
+	}
 }
 
 Node *GPUParticles2DEditorPlugin::_convert_particles() {
@@ -351,84 +561,84 @@ void GPUParticles2DEditorPlugin::_generate_emission_mask() {
 	Ref<ParticleProcessMaterial> pm = particles->get_process_material();
 	ERR_FAIL_COND(pm.is_null());
 
-	PackedVector2Array valid_positions;
-	PackedVector2Array valid_normals;
-	PackedByteArray valid_colors;
-	Vector2i image_size;
-	_get_base_emission_mask(valid_positions, valid_normals, valid_colors, image_size);
+	PackedVector2Array emission_positions;
+	PackedVector2Array emission_normals;
+	PackedByteArray emission_colors;
+	Vector2i texture_size;
+	_process_emission_masks(emission_positions, emission_normals, emission_colors, texture_size);
 
-	ERR_FAIL_COND_MSG(valid_positions.is_empty(), "No pixels with transparency > 128 in image...");
+	ERR_FAIL_COND_MSG(emission_positions.is_empty(), "No pixels with transparency > 128 in image...");
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Load Emission Mask"));
 	ParticleProcessMaterial *pmptr = pm.ptr();
 
-	Vector<uint8_t> texdata;
+	Vector<uint8_t> mask_texture_data;
 
-	int vpc = valid_positions.size();
+	int valid_positions_count = emission_positions.size();
 	int w = 2048;
-	int h = (vpc / 2048) + 1;
+	int h = (valid_positions_count / 2048) + 1;
 
-	texdata.resize(w * h * 2 * sizeof(float));
+	mask_texture_data.resize_initialized(w * h * 2 * sizeof(float));
 
 	{
 		Vector2 offset;
 		if (emission_mask_centered->is_pressed()) {
-			offset = Vector2(-image_size.width * 0.5, -image_size.height * 0.5);
+			offset = Vector2(-texture_size.width * 0.5, -texture_size.height * 0.5);
 		}
 
-		uint8_t *tw = texdata.ptrw();
+		uint8_t *tw = mask_texture_data.ptrw();
 		float *twf = reinterpret_cast<float *>(tw);
-		for (int i = 0; i < vpc; i++) {
-			twf[i * 2 + 0] = valid_positions[i].x + offset.x;
-			twf[i * 2 + 1] = valid_positions[i].y + offset.y;
+		for (int i = 0; i < valid_positions_count; i++) {
+			twf[i * 2 + 0] = emission_positions[i].x + offset.x;
+			twf[i * 2 + 1] = emission_positions[i].y + offset.y;
 		}
 	}
 
 	Ref<Image> img;
 	img.instantiate();
-	img->set_data(w, h, false, Image::FORMAT_RGF, texdata);
+	img->set_data(w, h, false, Image::FORMAT_RGF, mask_texture_data);
 	undo_redo->add_do_property(pmptr, "emission_point_texture", ImageTexture::create_from_image(img));
 	undo_redo->add_undo_property(pmptr, "emission_point_texture", pm->get_emission_point_texture());
-	undo_redo->add_do_property(pmptr, "emission_point_count", vpc);
+	undo_redo->add_do_property(pmptr, "emission_point_count", valid_positions_count);
 	undo_redo->add_undo_property(pmptr, "emission_point_count", pm->get_emission_point_count());
 
-	if (emission_colors->is_pressed()) {
-		Vector<uint8_t> colordata;
-		colordata.resize(w * h * 4); //use RG texture
+	if (emission_mask_colors->is_pressed()) {
+		Vector<uint8_t> color_texture_data;
+		color_texture_data.resize_initialized(w * h * 4);
 
 		{
-			uint8_t *tw = colordata.ptrw();
-			for (int i = 0; i < vpc * 4; i++) {
-				tw[i] = valid_colors[i];
+			uint8_t *tw = color_texture_data.ptrw();
+			for (int i = 0; i < valid_positions_count * 4; i++) {
+				tw[i] = emission_colors[i];
 			}
 		}
 
 		img.instantiate();
-		img->set_data(w, h, false, Image::FORMAT_RGBA8, colordata);
+		img->set_data(w, h, false, Image::FORMAT_RGBA8, color_texture_data);
 		undo_redo->add_do_property(pmptr, "emission_color_texture", ImageTexture::create_from_image(img));
 		undo_redo->add_undo_property(pmptr, "emission_color_texture", pm->get_emission_color_texture());
 	}
 
-	if (!valid_normals.is_empty()) {
+	if (emission_normals.size()) {
 		undo_redo->add_do_property(pmptr, "emission_shape", ParticleProcessMaterial::EMISSION_SHAPE_DIRECTED_POINTS);
 		undo_redo->add_undo_property(pmptr, "emission_shape", pm->get_emission_shape());
 		pm->set_emission_shape(ParticleProcessMaterial::EMISSION_SHAPE_DIRECTED_POINTS);
 
-		Vector<uint8_t> normdata;
-		normdata.resize(w * h * 2 * sizeof(float)); //use RG texture
+		Vector<uint8_t> normal_texture_data;
+		normal_texture_data.resize_initialized(w * h * 2 * sizeof(float));
 
 		{
-			uint8_t *tw = normdata.ptrw();
+			uint8_t *tw = normal_texture_data.ptrw();
 			float *twf = reinterpret_cast<float *>(tw);
-			for (int i = 0; i < vpc; i++) {
-				twf[i * 2 + 0] = valid_normals[i].x;
-				twf[i * 2 + 1] = valid_normals[i].y;
+			for (int i = 0; i < valid_positions_count; i++) {
+				twf[i * 2 + 0] = emission_normals[i].x;
+				twf[i * 2 + 1] = emission_normals[i].y;
 			}
 		}
 
 		img.instantiate();
-		img->set_data(w, h, false, Image::FORMAT_RGF, normdata);
+		img->set_data(w, h, false, Image::FORMAT_RGF, normal_texture_data);
 		undo_redo->add_do_property(pmptr, "emission_normal_texture", ImageTexture::create_from_image(img));
 		undo_redo->add_undo_property(pmptr, "emission_normal_texture", pm->get_emission_normal_texture());
 	} else {
@@ -478,19 +688,19 @@ void CPUParticles2DEditorPlugin::_generate_emission_mask() {
 	PackedVector2Array valid_normals;
 	PackedByteArray valid_colors;
 	Vector2i image_size;
-	_get_base_emission_mask(valid_positions, valid_normals, valid_colors, image_size);
+	_process_emission_masks(valid_positions, valid_normals, valid_colors, image_size);
 
 	ERR_FAIL_COND_MSG(valid_positions.is_empty(), "No pixels with transparency > 128 in image...");
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Load Emission Mask"));
 
-	int vpc = valid_positions.size();
-	if (emission_colors->is_pressed()) {
+	int valid_point_count = valid_positions.size();
+	if (emission_mask_colors->is_pressed()) {
 		PackedColorArray pca;
-		pca.resize(vpc);
+		pca.resize(valid_point_count);
 		Color *pcaw = pca.ptrw();
-		for (int i = 0; i < vpc; i += 1) {
+		for (int i = 0; i < valid_point_count; i += 1) {
 			Color color;
 			color.r = valid_colors[i * 4 + 0] / 255.0f;
 			color.g = valid_colors[i * 4 + 1] / 255.0f;

--- a/editor/scene/2d/particles_2d_editor_plugin.h
+++ b/editor/scene/2d/particles_2d_editor_plugin.h
@@ -33,6 +33,8 @@
 #include "editor/scene/particles_editor_plugin.h"
 
 class EditorFileDialog;
+class MarginContainer;
+class LineEdit;
 
 class Particles2DEditorPlugin : public ParticlesEditorPlugin {
 	GDCLASS(Particles2DEditorPlugin, ParticlesEditorPlugin);
@@ -50,20 +52,52 @@ protected:
 		EMISSION_MODE_BORDER_DIRECTED
 	};
 
-	EditorFileDialog *file = nullptr;
-	ConfirmationDialog *emission_mask = nullptr;
+	enum MaskMode {
+		MASK_MODE_SOLID,
+		MASK_MODE_BORDER,
+	};
+
+	enum DirectionMode {
+		DIRECTION_MODE_NONE,
+		DIRECTION_MODE_GENERATE,
+		DIRECTION_MODE_TEXTURE,
+	};
+
+	enum TextureType {
+		TEXTURE_TYPE_MASK,
+		TEXTURE_TYPE_DIRECTION,
+	};
+
+	EditorFileDialog *file_dialog = nullptr;
+	ConfirmationDialog *emission_mask_dialog = nullptr;
 	OptionButton *emission_mask_mode = nullptr;
+	OptionButton *emission_direction_mode = nullptr;
 	CheckBox *emission_mask_centered = nullptr;
-	CheckBox *emission_colors = nullptr;
-	String source_emission_file;
+	CheckBox *emission_mask_colors = nullptr;
+	LineEdit *mask_img_path_line_edit = nullptr;
+	LineEdit *direction_img_path_line_edit = nullptr;
+	HBoxContainer *direction_img_hbox = nullptr;
+	Label *direction_img_label = nullptr;
+	Button *mask_browse_button = nullptr;
+	Button *direction_browse_button = nullptr;
+	Label *error_message = nullptr;
+	TextureType browsing_texture_type = TEXTURE_TYPE_MASK;
 
 	virtual void _menu_callback(int p_idx) override;
 	virtual void _add_menu_options(PopupMenu *p_menu) override;
 
+	void _validate_textures();
+	void _mask_img_path_line_edit_text_changed(const String &p_text);
+	void _direction_img_path_line_edit_text_changed(const String &p_text);
+	void _emission_mask_mode_item_changed(int p_idx) const;
+	void _emission_direction_mode_item_changed(int p_idx);
+	void _browse_mask_texture_pressed();
+	void _browse_direction_texture_pressed();
 	void _file_selected(const String &p_file);
-	void _get_base_emission_mask(PackedVector2Array &r_valid_positions, PackedVector2Array &r_valid_normals, PackedByteArray &r_valid_colors, Vector2i &r_image_size);
+	void _process_emission_masks(PackedVector2Array &r_valid_positions, PackedVector2Array &r_valid_normals, PackedByteArray &r_valid_colors, Vector2i &r_image_size);
 	virtual void _generate_emission_mask() = 0;
 	void _notification(int p_what);
+	void _theme_changed();
 	void _set_show_gizmos(Node *p_node, bool p_show);
 	void _selection_changed();
 	void _node_removed(Node *p_node);


### PR DESCRIPTION
In this PR I reworked the 2D particles emission mask dialog (C/GPUParticles2D → Load Emission Mask in the 2D viewport).


https://github.com/user-attachments/assets/73000145-aa12-4522-8d9f-38f466892529


Before, it was only possible to let Godot generate an emission direction texture when using the "Directed Border Pixels" mode. With this PR, you can specify a custom normal map to use. Additionally, the "Centered" checkbox is now checked by default because all other emission shapes are also centered by default.

I refactored some code as well because I found some parts of it hard to read and understand due to undocumented abbreviations.

~~**If you want to test this**, make sure to also merge https://github.com/godotengine/godot/pull/101162 because emission mask textures are currently broken for GPUParticles2D.~~