### PR TITLE
Improve OpenGL 3 fallback documentation wording

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2966,7 +2966,7 @@
 			[b]Note:[/b] This setting is implemented only on Windows.
 		</member>
 		<member name="rendering/rendering_device/fallback_to_opengl3" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the forward renderer will fall back to OpenGL 3 if both Direct3D 12, Metal and Vulkan are not supported.
+			If [code]true[/code], the forward renderer will fall back to OpenGL 3 if Direct3D 12, Metal, and Vulkan are not supported.
 			[b]Note:[/b] This setting is implemented only on Windows, Android, macOS, iOS, and Linux/X11.
 		</member>
 		<member name="rendering/rendering_device/fallback_to_vulkan" type="bool" setter="" getter="" default="true">


### PR DESCRIPTION
`both` is used in `...will fall back to OpenGL 3 if both Direct3D 12, Metal and Vulkan...` but should not be since there are three rendering APIs listed.
It appears to have been originally added with that wording in #97142, possibly due to Metal support being introduced while it was being worked on.