### PR TITLE
Style: Standardize Obj-C `#import` syntax

### DIFF
--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -31,7 +31,8 @@ if env["platform"] in ["macos", "ios"]:
     SConscript("apple/SCsub")
 # Midi drivers
 SConscript("alsamidi/SCsub")
-SConscript("coremidi/SCsub")
+if env["platform"] in ["macos", "ios"]:
+    SConscript("coremidi/SCsub")
 SConscript("winmidi/SCsub")
 
 # Graphics drivers

--- a/drivers/apple/joypad_apple.mm
+++ b/drivers/apple/joypad_apple.mm
@@ -30,7 +30,7 @@
 
 #import "joypad_apple.h"
 
-#include <CoreHaptics/CoreHaptics.h>
+#import <CoreHaptics/CoreHaptics.h>
 #import <os/log.h>
 
 #include "core/config/project_settings.h"

--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "audio_driver_coreaudio.h"
+#import "audio_driver_coreaudio.h"
 
 #ifdef COREAUDIO_ENABLED
 

--- a/drivers/coremidi/SCsub
+++ b/drivers/coremidi/SCsub
@@ -4,4 +4,4 @@ from misc.utility.scons_hints import *
 Import("env")
 
 # Driver source files
-env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_source_files(env.drivers_sources, "*.mm")

--- a/drivers/coremidi/midi_driver_coremidi.mm
+++ b/drivers/coremidi/midi_driver_coremidi.mm
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  midi_driver_coremidi.cpp                                              */
+/*  midi_driver_coremidi.mm                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "midi_driver_coremidi.h"
+#import "midi_driver_coremidi.h"
 
 #ifdef COREMIDI_ENABLED
 

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -54,7 +54,7 @@
 #import "metal_utils.h"
 #import "pixel_formats.h"
 
-#import "servers/rendering/rendering_device_driver.h"
+#include "servers/rendering/rendering_device_driver.h"
 
 #import <CommonCrypto/CommonDigest.h>
 #import <Foundation/Foundation.h>

--- a/drivers/metal/pixel_formats.h
+++ b/drivers/metal/pixel_formats.h
@@ -56,7 +56,7 @@
 #import "inflection_map.h"
 #import "metal_device_properties.h"
 
-#import "servers/rendering/rendering_device.h"
+#include "servers/rendering/rendering_device.h"
 
 #import <Metal/Metal.h>
 

--- a/drivers/metal/rendering_context_driver_metal.h
+++ b/drivers/metal/rendering_context_driver_metal.h
@@ -32,8 +32,8 @@
 
 #ifdef METAL_ENABLED
 
-#import "servers/rendering/rendering_context_driver.h"
-#import "servers/rendering/rendering_device_driver.h"
+#include "servers/rendering/rendering_context_driver.h"
+#include "servers/rendering/rendering_device_driver.h"
 
 #import <CoreGraphics/CGGeometry.h>
 

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -32,7 +32,7 @@
 
 #import "metal_objects.h"
 
-#import "servers/rendering/rendering_device_driver.h"
+#include "servers/rendering/rendering_device_driver.h"
 
 #import <Metal/Metal.h>
 #import <variant>

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -53,10 +53,10 @@
 #import "pixel_formats.h"
 #import "rendering_context_driver_metal.h"
 
-#import "core/io/compression.h"
-#import "core/io/marshalls.h"
-#import "core/string/ustring.h"
-#import "core/templates/hash_map.h"
+#include "core/io/compression.h"
+#include "core/io/marshalls.h"
+#include "core/string/ustring.h"
+#include "core/templates/hash_map.h"
 
 #import <Metal/MTLTexture.h>
 #import <Metal/Metal.h>

--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -31,7 +31,7 @@
 ///@TODO this is a near duplicate of CameraIOS, we should find a way to combine those to minimize code duplication!!!!
 // If you fix something here, make sure you fix it there as well!
 
-#include "camera_macos.h"
+#import "camera_macos.h"
 
 #include "servers/camera/camera_feed.h"
 

--- a/modules/mono/utils/macos_utils.cpp
+++ b/modules/mono/utils/macos_utils.cpp
@@ -28,9 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "macos_utils.h"
-
 #ifdef MACOS_ENABLED
+
+#import "macos_utils.h"
 
 #include "core/string/print_string.h"
 

--- a/modules/openxr/extensions/platform/openxr_metal_extension.mm
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.mm
@@ -28,10 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "openxr_metal_extension.h"
+#import "openxr_metal_extension.h"
 
 #include "../../openxr_util.h"
-#include "drivers/metal/rendering_device_driver_metal.h"
+
+#import "drivers/metal/rendering_device_driver_metal.h"
 #include "servers/rendering/rendering_server_globals.h"
 
 HashMap<String, bool *> OpenXRMetalExtension::get_requested_extensions() {

--- a/platform/ios/display_server_ios.h
+++ b/platform/ios/display_server_ios.h
@@ -44,7 +44,7 @@
 #endif // VULKAN_ENABLED
 
 #if defined(METAL_ENABLED)
-#include "drivers/metal/rendering_context_driver_metal.h"
+#import "drivers/metal/rendering_context_driver_metal.h"
 #endif // METAL_ENABLED
 #endif // RD_ENABLED
 

--- a/platform/ios/ios_terminal_logger.mm
+++ b/platform/ios/ios_terminal_logger.mm
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "ios_terminal_logger.h"
+#import "ios_terminal_logger.h"
 
 #ifdef IOS_ENABLED
 
-#include <os/log.h>
+#import <os/log.h>
 
 void IOSTerminalLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type) {
 	if (!should_log(true)) {

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "crash_handler_macos.h"
+#import "crash_handler_macos.h"
 
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
@@ -50,8 +50,8 @@
 #include <signal.h>
 #include <stdlib.h>
 
-#include <mach-o/dyld.h>
-#include <mach-o/getsect.h>
+#import <mach-o/dyld.h>
+#import <mach-o/getsect.h>
 
 static uint64_t load_address() {
 	const struct segment_command_64 *cmd = getsegbyname("__TEXT");

--- a/platform/macos/dir_access_macos.mm
+++ b/platform/macos/dir_access_macos.mm
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "dir_access_macos.h"
-
-#include "core/config/project_settings.h"
+#import "dir_access_macos.h"
 
 #if defined(UNIX_ENABLED)
+
+#include "core/config/project_settings.h"
 
 #include <errno.h>
 

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -38,16 +38,16 @@
 #include "gl_manager_macos_legacy.h"
 #endif // GLES3_ENABLED
 
-#include "native_menu_macos.h"
+#import "native_menu_macos.h"
 
 #if defined(RD_ENABLED)
 #include "servers/rendering/rendering_device.h"
 
 #if defined(VULKAN_ENABLED)
-#include "rendering_context_driver_vulkan_macos.h"
+#import "rendering_context_driver_vulkan_macos.h"
 #endif // VULKAN_ENABLED
 #if defined(METAL_ENABLED)
-#include "drivers/metal/rendering_context_driver_metal.h"
+#import "drivers/metal/rendering_context_driver_metal.h"
 #endif
 #endif // RD_ENABLED
 

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -28,19 +28,19 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "display_server_macos.h"
+#import "display_server_macos.h"
 
-#include "godot_button_view.h"
-#include "godot_content_view.h"
-#include "godot_menu_delegate.h"
-#include "godot_menu_item.h"
-#include "godot_open_save_delegate.h"
-#include "godot_status_item.h"
-#include "godot_window.h"
-#include "godot_window_delegate.h"
-#include "key_mapping_macos.h"
-#include "os_macos.h"
-#include "tts_macos.h"
+#import "godot_button_view.h"
+#import "godot_content_view.h"
+#import "godot_menu_delegate.h"
+#import "godot_menu_item.h"
+#import "godot_open_save_delegate.h"
+#import "godot_status_item.h"
+#import "godot_window.h"
+#import "godot_window_delegate.h"
+#import "key_mapping_macos.h"
+#import "os_macos.h"
+#import "tts_macos.h"
 
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"

--- a/platform/macos/gl_manager_macos_angle.h
+++ b/platform/macos/gl_manager_macos_angle.h
@@ -38,9 +38,9 @@
 #include "drivers/egl/egl_manager.h"
 #include "servers/display_server.h"
 
-#include <AppKit/AppKit.h>
-#include <ApplicationServices/ApplicationServices.h>
-#include <CoreVideo/CoreVideo.h>
+#import <AppKit/AppKit.h>
+#import <ApplicationServices/ApplicationServices.h>
+#import <CoreVideo/CoreVideo.h>
 
 class GLManagerANGLE_MacOS : public EGLManager {
 private:

--- a/platform/macos/gl_manager_macos_angle.mm
+++ b/platform/macos/gl_manager_macos_angle.mm
@@ -28,14 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "gl_manager_macos_angle.h"
+#import "gl_manager_macos_angle.h"
 
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <EGL/eglext_angle.h>
+#import <EGL/eglext_angle.h>
 
 const char *GLManagerANGLE_MacOS::_get_platform_extension_name() const {
 	return "EGL_ANGLE_platform_angle";

--- a/platform/macos/gl_manager_macos_legacy.mm
+++ b/platform/macos/gl_manager_macos_legacy.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "gl_manager_macos_legacy.h"
+#import "gl_manager_macos_legacy.h"
 
 #if defined(MACOS_ENABLED) && defined(GLES3_ENABLED)
 

--- a/platform/macos/godot_application.mm
+++ b/platform/macos/godot_application.mm
@@ -28,9 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_application.h"
+#import "godot_application.h"
 
-#include "display_server_macos.h"
+#import "display_server_macos.h"
 
 @implementation GodotApplication
 

--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_application_delegate.h"
+#import "godot_application_delegate.h"
 
-#include "display_server_macos.h"
-#include "native_menu_macos.h"
-#include "os_macos.h"
+#import "display_server_macos.h"
+#import "native_menu_macos.h"
+#import "os_macos.h"
 
 @implementation GodotApplicationDelegate
 

--- a/platform/macos/godot_button_view.mm
+++ b/platform/macos/godot_button_view.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_button_view.h"
+#import "godot_button_view.h"
 
 @implementation GodotButtonView
 

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_content_view.h"
+#import "godot_content_view.h"
 
-#include "display_server_macos.h"
-#include "key_mapping_macos.h"
+#import "display_server_macos.h"
+#import "key_mapping_macos.h"
 
 #include "main/main.h"
 

--- a/platform/macos/godot_main_macos.mm
+++ b/platform/macos/godot_main_macos.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "os_macos.h"
+#import "os_macos.h"
 
 #include "main/main.h"
 

--- a/platform/macos/godot_menu_delegate.mm
+++ b/platform/macos/godot_menu_delegate.mm
@@ -28,12 +28,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_menu_delegate.h"
+#import "godot_menu_delegate.h"
 
-#include "display_server_macos.h"
-#include "godot_menu_item.h"
-#include "key_mapping_macos.h"
-#include "native_menu_macos.h"
+#import "display_server_macos.h"
+#import "godot_menu_item.h"
+#import "key_mapping_macos.h"
+#import "native_menu_macos.h"
 
 @implementation GodotMenuDelegate
 

--- a/platform/macos/godot_menu_item.mm
+++ b/platform/macos/godot_menu_item.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_menu_item.h"
+#import "godot_menu_item.h"
 
 @implementation GodotMenuItem
 

--- a/platform/macos/godot_open_save_delegate.mm
+++ b/platform/macos/godot_open_save_delegate.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_open_save_delegate.h"
+#import "godot_open_save_delegate.h"
 
 @implementation GodotOpenSaveDelegate
 

--- a/platform/macos/godot_status_item.mm
+++ b/platform/macos/godot_status_item.mm
@@ -28,9 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_status_item.h"
+#import "godot_status_item.h"
 
-#include "display_server_macos.h"
+#import "display_server_macos.h"
 
 @implementation GodotStatusItemDelegate
 

--- a/platform/macos/godot_window.mm
+++ b/platform/macos/godot_window.mm
@@ -28,9 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_window.h"
+#import "godot_window.h"
 
-#include "display_server_macos.h"
+#import "display_server_macos.h"
 
 @implementation GodotWindow
 

--- a/platform/macos/godot_window_delegate.mm
+++ b/platform/macos/godot_window_delegate.mm
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "godot_window_delegate.h"
+#import "godot_window_delegate.h"
 
-#include "display_server_macos.h"
-#include "godot_button_view.h"
-#include "godot_window.h"
+#import "display_server_macos.h"
+#import "godot_button_view.h"
+#import "godot_window.h"
 
 @implementation GodotWindowDelegate
 

--- a/platform/macos/key_mapping_macos.mm
+++ b/platform/macos/key_mapping_macos.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "key_mapping_macos.h"
+#import "key_mapping_macos.h"
 
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"

--- a/platform/macos/macos_terminal_logger.mm
+++ b/platform/macos/macos_terminal_logger.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "macos_terminal_logger.h"
+#import "macos_terminal_logger.h"
 
 #ifdef MACOS_ENABLED
 

--- a/platform/macos/native_menu_macos.mm
+++ b/platform/macos/native_menu_macos.mm
@@ -28,11 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "native_menu_macos.h"
+#import "native_menu_macos.h"
 
-#include "display_server_macos.h"
-#include "godot_menu_item.h"
-#include "key_mapping_macos.h"
+#import "display_server_macos.h"
+#import "godot_menu_item.h"
+#import "key_mapping_macos.h"
 
 #include "scene/resources/image_texture.h"
 

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -28,13 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "os_macos.h"
+#import "os_macos.h"
 
-#include "dir_access_macos.h"
-#include "display_server_macos.h"
-#include "godot_application.h"
-#include "godot_application_delegate.h"
-#include "macos_terminal_logger.h"
+#import "dir_access_macos.h"
+#import "display_server_macos.h"
+#import "godot_application.h"
+#import "godot_application_delegate.h"
+#import "macos_terminal_logger.h"
 
 #include "core/crypto/crypto_core.h"
 #include "core/version_generated.gen.h"
@@ -42,7 +42,7 @@
 
 #include <dlfcn.h>
 #include <libproc.h>
-#include <mach-o/dyld.h>
+#import <mach-o/dyld.h>
 #include <os/log.h>
 #include <sys/sysctl.h>
 

--- a/platform/macos/rendering_context_driver_vulkan_macos.mm
+++ b/platform/macos/rendering_context_driver_vulkan_macos.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "rendering_context_driver_vulkan_macos.h"
+#import "rendering_context_driver_vulkan_macos.h"
 
 #ifdef VULKAN_ENABLED
 

--- a/platform/macos/tts_macos.mm
+++ b/platform/macos/tts_macos.mm
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "tts_macos.h"
+#import "tts_macos.h"
 
 @implementation TTS_MacOS
 


### PR DESCRIPTION
After #101158 made me realize just how many Obj-C files are using header guards & not using `#import` syntax, this PR rectifies those discrepancies. Inspired by this thread[^1], `#import` is used on the Obj-C system headers & headers with matching `.mm` source files; everything else uses `#include` instead. Two instances of `.cpp` files were changed to `.mm`, with minor tweaks to their respective `SCsub` scripts to account for this. ~~Lastly, `.pre-commit-config.yaml` had its header-guard hook exclusions revamped to account for the changes in scope.~~ **EDIT:** No longer necessary with the `#pragma once` change.

[^1]: https://github.com/godotengine/godot/pull/75932/files#r1162759595