### PR TITLE
Fix large `TextEdit` width resize performance when wrapping disabled

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7955,12 +7955,13 @@ void TextEdit::_update_wrap_at_column(bool p_force) {
 			}
 			text.set_brk_flags(autowrap_flags);
 			text.set_width(wrap_at_column);
-		} else {
+			text.invalidate_all_lines();
+			_update_placeholder();
+		} else if (text.get_width() != -1) {
 			text.set_width(-1);
+			text.invalidate_all_lines();
+			_update_placeholder();
 		}
-
-		text.invalidate_all_lines();
-		_update_placeholder();
 	}
 
 	// Update viewport.


### PR DESCRIPTION
Fixes #101143.

This is kind of a hack, and I'm not actually sure what the best possible fix would be here, but if wrapping is disabled I don't think invalidation needs to happen when the flags and wrap width don't change, so this shouuuuld be safe...? I think?

PS: Sublime Text 4 has a much faster (vaguely ~10x the speed I think) wrapping algorithm than godot, but just like godot, it wraps the entire buffer when resizing, so it chokes on gigantic (multi-gigabyte) files. (Godot starts to choke on buffers that are about 10% the size of where Sublime starts choking.) Kate, on the other hand, seems to only re-wrap things locally near where the viewport is! I have not managed to get Kate line wrapping to choke. Kate seems to scroll based on line number (vaguely), not height, and its minimap doesn't reflect changes in wrap width like godot and sublime's do, so I'm like 85% sure that it really does only re-wrap things locally. That might be worth thinking about in the future.