### PR TITLE
[1.1] Build fixes for modern toolchains + new portable 1.1-stable Linux binaries

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -219,6 +219,21 @@ if selected_platform in platform_list:
 
 	detect.configure(env)
 
+	# Set our C and C++ standard requirements.
+	# Prepending to make it possible to override.
+	# This MSVC "detection" is an extreme hack.
+	is_msvc = (os.name=="nt") and (os.getenv("VSINSTALLDIR")!=None or os.getenv("VCINSTALLDIR")!=None) and (selected_platform in ["windows", "winrt"])
+	if (not is_msvc):
+		# Specifying GNU extensions support explicitly, which are supported by both GCC and Clang.
+		# We don't support C++17 so stick to earlier standards.
+		# Godot 1.0 definitely started as a C++98 codebase.
+		env.Prepend(CFLAGS=["-std=gnu11"])
+		env.Prepend(CXXFLAGS=["-std=gnu++98"])
+		# Disable these auto-enabled warnings which are treated as errors by modern compilers.
+		env.Prepend(CCFLAGS=["-Wno-error=implicit-function-declaration", "-Wno-error=incompatible-pointer-types"])
+	else:
+		# MSVC doesn't support setting C++ to pre-C++14 standards, so do nothing and hope it works.
+		pass
 
 	flag_list = platform_flags[selected_platform]
 	for f in flag_list:

--- a/drivers/gl_context/glew-remove-glu-dependency.patch
+++ b/drivers/gl_context/glew-remove-glu-dependency.patch
@@ -1,0 +1,22 @@
+diff --git a/drivers/gl_context/glew.h b/drivers/gl_context/glew.h
+index 4eed47708f..5f937862bf 100644
+--- a/drivers/gl_context/glew.h
++++ b/drivers/gl_context/glew.h
+@@ -1168,12 +1168,17 @@ GLAPI void GLAPIENTRY glViewport (GLint x, GLint y, GLsizei width, GLsizei heigh
+ 
+ /* ---------------------------------- GLU ---------------------------------- */
+ 
++// -- GODOT start --
++// We don't use GLU, so remove a dependency.
++#if 0
+ /* this is where we can safely include GLU */
+ #if defined(__APPLE__) && defined(__MACH__)
+ #include <OpenGL/glu.h>
+ #else
+ #include <GL/glu.h>
+ #endif
++#endif
++// -- GODOT end --
+ 
+ /* ----------------------------- GL_VERSION_1_2 ---------------------------- */
+ 

--- a/drivers/gl_context/glew.h
+++ b/drivers/gl_context/glew.h
@@ -1168,12 +1168,17 @@ GLAPI void GLAPIENTRY glViewport (GLint x, GLint y, GLsizei width, GLsizei heigh
 
 /* ---------------------------------- GLU ---------------------------------- */
 
+// -- GODOT start --
+// We don't use GLU, so remove a dependency.
+#if 0
 /* this is where we can safely include GLU */
 #if defined(__APPLE__) && defined(__MACH__)
 #include <OpenGL/glu.h>
 #else
 #include <GL/glu.h>
 #endif
+#endif
+// -- GODOT end --
 
 /* ----------------------------- GL_VERSION_1_2 ---------------------------- */
 

--- a/methods.py
+++ b/methods.py
@@ -42,6 +42,7 @@ def build_shader_header( target, source, env ):
 			line=fs.readline()
 			
 		fd.write(";\n")
+		fd.close()
 			
 	return 0
 		
@@ -1098,6 +1099,7 @@ def update_version():
 	f.write("#define VERSION_MINOR "+str(version.minor)+"\n")
 	f.write("#define VERSION_REVISION "+str(rev)+"\n")
 	f.write("#define VERSION_STATUS "+str(version.status)+"\n")
+	f.close()
 
 def parse_cg_file(fname, uniforms, sizes, conditionals):
 
@@ -1167,8 +1169,8 @@ def build_cg_shader(sname):
 		fd.write('\t\tVP_%s,\n' % vp_uniforms[i].upper())
 
 	fd.write("\t};\n");
+	fd.close()
 
-		
 
 import glob
 def detect_modules():
@@ -1219,6 +1221,7 @@ void unregister_module_types() {
 
 	f=open("modules/register_module_types.cpp","wb")
 	f.write(modules_cpp)
+	f.close()
 
 	return module_list
 
@@ -1323,6 +1326,7 @@ def save_active_platforms(apnames,ap):
 		wf = x+"/logo.h"
 		logow = open(wf,"wb")
 		logow.write(str)
+		logow.close()
 
 
 def colored(sys,env):

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -59,6 +59,7 @@ manifest = manifest.replace("$$ADD_APPLICATION_CHUNKS$$",env.android_manifest_ch
 manifest = manifest.replace("$$ADD_PERMISSION_CHUNKS$$",env.android_permission_chunk)
 manifest = manifest.replace("$$ADD_APPATTRIBUTE_CHUNKS$$",env.android_appattributes_chunk)
 pp_baseout.write( manifest )
+pp_baseout.close()
 
 
 for x in env.android_source_files:

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -150,7 +150,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-D_DEBUG', '-g1', '-Wall', '-O0', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-D_DEBUG', '-g1', '-O0', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
 
 	if env["armv6"] == "no" and env['x86'] != 'yes':

--- a/platform/flash/detect.py
+++ b/platform/flash/detect.py
@@ -98,7 +98,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-D_DEBUG', '-g0', '-Wall', '-O0', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-D_DEBUG', '-g0', '-O0', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
 
 	env.Append(CPPFLAGS=['-DFLASH_ENABLED', '-DGLES1_ENABLED', '-DNO_FCNTL', '-DUNIX_ENABLED'])

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -109,17 +109,17 @@ def configure(env):
 
 	if (env["target"]=="release"):
 
-		env.Append(CCFLAGS=['-O3', '-ffast-math', '-DNS_BLOCK_ASSERTIONS=1','-Wall'])
+		env.Append(CCFLAGS=['-O3', '-ffast-math', '-DNS_BLOCK_ASSERTIONS=1'])
 		env.Append(LINKFLAGS=['-O3', '-ffast-math'])
 
 	elif env["target"] == "release_debug":
-		env.Append(CCFLAGS=['-Os', '-ffast-math', '-DNS_BLOCK_ASSERTIONS=1','-Wall','-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-Os', '-ffast-math', '-DNS_BLOCK_ASSERTIONS=1','-DDEBUG_ENABLED'])
 		env.Append(LINKFLAGS=['-Os', '-ffast-math'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ENABLED'])
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-D_DEBUG', '-DDEBUG=1', '-gdwarf-2', '-Wall', '-O0', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-D_DEBUG', '-DDEBUG=1', '-gdwarf-2', '-O0', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ENABLED'])
 
 	elif (env["target"]=="profile"):

--- a/platform/isim/detect.py
+++ b/platform/isim/detect.py
@@ -51,7 +51,7 @@ def configure(env):
 	env['AR'] = 'ar'
 
 	import string
-	env['CCFLAGS'] = string.split('-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fasm-blocks  -Wall -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $ISIMSDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"')
+	env['CCFLAGS'] = string.split('-arch i386 -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fasm-blocks -D__IPHONE_OS_VERSION_MIN_REQUIRED=40100 -isysroot $ISIMSDK -mios-simulator-version-min=4.3 -DCUSTOM_MATRIX_TRANSFORM_H=\\\"build/iphone/matrix4_iphone.h\\\" -DCUSTOM_VECTOR3_TRANSFORM_H=\\\"build/iphone/vector3_iphone.h\\\"')
 
 	env.Append(LINKFLAGS=['-arch', 'i386',
 							'-mios-simulator-version-min=4.3',
@@ -84,7 +84,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-DDEBUG', '-D_DEBUG', '-gdwarf-2', '-Wall', '-O0', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-DDEBUG', '-D_DEBUG', '-gdwarf-2', '-O0', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
 
 	elif (env["target"]=="profile"):

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -73,8 +73,8 @@ def configure(env):
 	elif (env["target"]=="release_debug"):
 		env.Append(CCFLAGS=['-O2','-DDEBUG_ENABLED'])
 	elif (env["target"]=="debug"):
-		env.Append(CCFLAGS=['-D_DEBUG', '-Wall', '-O2', '-DDEBUG_ENABLED'])
-		#env.Append(CCFLAGS=['-D_DEBUG', '-Wall', '-g4', '-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-D_DEBUG', '-O2', '-DDEBUG_ENABLED'])
+		#env.Append(CCFLAGS=['-D_DEBUG', '-g4', '-DDEBUG_ENABLED'])
 		env.Append(CPPFLAGS=['-DDEBUG_MEMORY_ALLOC'])
 
 	env.Append(CPPFLAGS=["-fno-exceptions",'-DNO_SAFE_CAST','-fno-rtti'])

--- a/platform/nacl/detect.py
+++ b/platform/nacl/detect.py
@@ -54,7 +54,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-g', '-O0', '-Wall','-DDEBUG_ENABLED'])
+		env.Append(CCFLAGS=['-g', '-O0', '-DDEBUG_ENABLED'])
 
 
 	elif (env["target"]=="profile"):

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -51,7 +51,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-g3', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+		env.Append(CCFLAGS=['-g3', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
 
 	if (env["freetype"]!="no"):

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -11,16 +11,16 @@ def get_name():
 
 def can_build():
 
-	if (sys.platform != "darwin"):
-		return False
+	if (sys.platform == "darwin" or ("OSXCROSS_ROOT" in os.environ)):
+		return True
 
-	return True # osx enabled
+	return False
 
 def get_opts():
 
 	return [
 	    ('force_64_bits','Force 64 bits binary','no'),
-
+	    ('osxcross_sdk', 'OSXCross SDK version', 'darwin14'),
 	 ]
 
 def get_flags():
@@ -59,12 +59,25 @@ def configure(env):
 		env.Append(CPPPATH=['#tools/freetype'])
 		env.Append(CPPPATH=['#tools/freetype/freetype/include'])
 
-	if (env["bits"]=="64"):
-		env.Append(CCFLAGS=['-arch', 'x86_64'])
-		env.Append(LINKFLAGS=['-arch', 'x86_64'])
+	if ("OSXCROSS_ROOT" not in os.environ):
+		# regular native build
+		if (env["bits"]=="64"):
+			env.Append(CCFLAGS=['-arch', 'x86_64'])
+			env.Append(LINKFLAGS=['-arch', 'x86_64'])
+		else:
+			env.Append(CCFLAGS=['-arch', 'i386'])
+			env.Append(LINKFLAGS=['-arch', 'i386'])
 	else:
-		env.Append(CCFLAGS=['-arch', 'i386'])
-		env.Append(LINKFLAGS=['-arch', 'i386'])
+		# osxcross build
+		root = os.environ.get("OSXCROSS_ROOT", 0)
+		arch = "i686" if env["bits"]=="32" else "x86_64"
+		basecmd = root + "/target/bin/" + arch + "-apple-" + env["osxcross_sdk"] + "-"
+
+		env['CC'] = basecmd + "cc"
+		env['CXX'] = basecmd + "c++"
+		env['AR'] = basecmd + "ar"
+		env['RANLIB'] = basecmd + "ranlib"
+		env['AS'] = basecmd + "as"
 
 #	env.Append(CPPPATH=['#platform/osx/include/freetype2', '#platform/osx/include'])
 #	env.Append(LIBPATH=['#platform/osx/lib'])

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -69,7 +69,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-g2', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+		env.Append(CCFLAGS=['-g2', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
 	env.Append(CPPFLAGS=['-DSERVER_ENABLED','-DUNIX_ENABLED'])
 	env.Append(LIBS=['pthread','z']) #TODO detect linux/BSD!

--- a/platform/server/detect.py
+++ b/platform/server/detect.py
@@ -27,8 +27,10 @@ def get_opts():
 def get_flags():
 
 	return [
-	('builtin_zlib', 'no'),
-	('theora','no'), #use builtin openssl
+	('builtin_zlib', 'yes'),
+	('openssl', 'builtin'),
+	("freetype", "builtin"),
+	('theora','no'),
 	]
 			
 
@@ -71,8 +73,22 @@ def configure(env):
 
 		env.Append(CCFLAGS=['-g2', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
+
+	if (env["openssl"]=="yes"):
+		env.ParseConfig('pkg-config openssl --cflags --libs')
+
+	if (env["freetype"]!="no"):
+		env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
+		if (env["freetype"]=="builtin"):
+			env.Append(CPPPATH=['#tools/freetype'])
+			env.Append(CPPPATH=['#tools/freetype/freetype/include'])
+		else:
+			env.ParseConfig('pkg-config freetype2 --cflags --libs')
+
 	env.Append(CPPFLAGS=['-DSERVER_ENABLED','-DUNIX_ENABLED'])
-	env.Append(LIBS=['pthread','z']) #TODO detect linux/BSD!
+	env.Append(LIBS=['pthread']) #TODO detect linux/BSD!
+	if (env["builtin_zlib"]=="no"):
+		env.Append(LIBS=['z'])
 
 	if (env["CXX"]=="clang++"):
 		env.Append(CPPFLAGS=['-DTYPED_METHOD_BIND'])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -325,7 +325,7 @@ def configure(env):
 
 		elif (env["target"]=="debug"):
 					
-			env.Append(CCFLAGS=['-g', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+			env.Append(CCFLAGS=['-g', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
 		if (env["freetype"]!="no"):
 			env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -29,11 +29,6 @@ def can_build():
 		print("X11 not found.. x11 disabled.")
 		return False
 
-        ssl_error=os.system("pkg-config openssl --modversion > /dev/null ")
-        if (ssl_error):
-                print("OpenSSL not found.. x11 disabled.")
-                return False
-
 	x11_error=os.system("pkg-config xcursor --modversion > /dev/null ")
 	if (x11_error):
 		print("xcursor not found.. x11 disabled.")
@@ -61,8 +56,9 @@ def get_opts():
 def get_flags():
 
 	return [
-	('builtin_zlib', 'no'),
-	("openssl", "yes"),
+	('builtin_zlib', 'yes'),
+	("openssl", "builtin"),
+	("freetype", "builtin"),
 	("theora","no"),
         ]
 			
@@ -126,13 +122,18 @@ def configure(env):
 	env.ParseConfig('pkg-config x11 --cflags --libs')
 	env.ParseConfig('pkg-config xinerama --cflags --libs')
 	env.ParseConfig('pkg-config xcursor --cflags --libs')
-	env.ParseConfig('pkg-config openssl --cflags --libs')
 
+	if (env["openssl"]=="yes"):
+		env.ParseConfig('pkg-config openssl --cflags --libs')
 
-	env.ParseConfig('pkg-config freetype2 --cflags --libs')
-	env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
+	if (env["freetype"]!="no"):
+		env.Append(CCFLAGS=['-DFREETYPE_ENABLED'])
+		if (env["freetype"]=="builtin"):
+			env.Append(CPPPATH=['#tools/freetype'])
+			env.Append(CPPPATH=['#tools/freetype/freetype/include'])
+		else:
+			env.ParseConfig('pkg-config freetype2 --cflags --libs')
 
-	
 	env.Append(CPPFLAGS=['-DOPENGL_ENABLED','-DGLEW_ENABLED'])
 	env.Append(CPPFLAGS=["-DALSA_ENABLED"])
 
@@ -145,17 +146,19 @@ def configure(env):
 			print("PulseAudio development libraries not found, disabling driver")
 
 	env.Append(CPPFLAGS=['-DX11_ENABLED','-DUNIX_ENABLED','-DGLES2_ENABLED','-DGLES_OVER_GL'])
-	env.Append(LIBS=['GL', 'GLU', 'pthread','asound','z']) #TODO detect linux/BSD!
+	env.Append(LIBS=['GL', 'pthread', 'asound']) #TODO detect linux/BSD!
+	if (env["builtin_zlib"]=="no"):
+		env.Append(LIBS=['z'])
 	#env.Append(CPPFLAGS=['-DMPC_FIXED_POINT'])
 
 #host compiler is default..
 
 	if (is64 and env["bits"]=="32"):
 		env.Append(CPPFLAGS=['-m32'])
-		env.Append(LINKFLAGS=['-m32','-L/usr/lib/i386-linux-gnu'])
+		env.Append(LINKFLAGS=['-m32'])
 	elif (not is64 and env["bits"]=="64"):
 		env.Append(CPPFLAGS=['-m64'])
-		env.Append(LINKFLAGS=['-m64','-L/usr/lib/i686-linux-gnu'])
+		env.Append(LINKFLAGS=['-m64'])
 
 
 	import methods

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -121,7 +121,7 @@ def configure(env):
 
 	elif (env["target"]=="debug"):
 
-		env.Append(CCFLAGS=['-g2', '-Wall','-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
+		env.Append(CCFLAGS=['-g2', '-DDEBUG_ENABLED','-DDEBUG_MEMORY_ENABLED'])
 
 	env.ParseConfig('pkg-config x11 --cflags --libs')
 	env.ParseConfig('pkg-config xinerama --cflags --libs')

--- a/tools/docdump/doc_merge.py
+++ b/tools/docdump/doc_merge.py
@@ -205,4 +205,4 @@ for c in list(new_doc):
 	write_class(c)
 write_string(f,'</doc>\n')
 
-
+f.close()

--- a/tools/docdump/makedoku.py
+++ b/tools/docdump/makedoku.py
@@ -75,8 +75,9 @@ def make_class_list(class_list,columns):
 			
 		s+="\n"
 		f.write(s)
-	
-	
+	f.close()
+
+
 def dokuize_text(txt):
 	
 	return txt
@@ -220,7 +221,7 @@ def make_method(f,name,m,declare,event=False):
 		s+=" "+m.attrib["qualifiers"]
 		
 	f.write(s+"\n")
-	
+	f.close()
   
 def make_doku_class(node):
 
@@ -302,8 +303,7 @@ def make_doku_class(node):
 			f.write(dokuize_text(d.text.strip()))
 			f.write("\n")
 			
-			
-				
+	f.close()
 
 			
 	"""

--- a/tools/docdump/makemd.py
+++ b/tools/docdump/makemd.py
@@ -85,6 +85,7 @@ def make_class_list(class_list, columns):
 
 		s += '\n'
 		f.write(s)
+	f.close()
 
 
 def dokuize_text(txt):
@@ -317,6 +318,7 @@ def make_doku_class(node):
 			f.write('\n')
 			f.write(dokuize_text(d.text.strip()))
 			f.write('\n')
+	f.close()
 
 
 for file in input_list:

--- a/tools/editor/SCsub
+++ b/tools/editor/SCsub
@@ -23,6 +23,7 @@ def make_doc_header(target,source,env):
 		g.write(str(ord(buf[i]))+",\n")
 	g.write("};\n")
 	g.write("#endif")
+	g.close()
 
 
 

--- a/tools/export/blender25/io_scene_dae/export_dae.py
+++ b/tools/export/blender25/io_scene_dae/export_dae.py
@@ -1656,6 +1656,7 @@ class DaeExporter:
 		f.write(bytes('\t<instance_visual_scene url="#'+self.scene_name+'" />\n',"UTF-8"))
 		f.write(bytes('</scene>\n',"UTF-8"))
 		f.write(bytes('</COLLADA>\n',"UTF-8"))
+		f.close()
 		return True
 
 	def __init__(self,path,kwargs,operator):

--- a/tools/glwrapper/makewrapper.py
+++ b/tools/glwrapper/makewrapper.py
@@ -157,6 +157,7 @@ f.write("void glWrapperInit( GLWrapperFuncPtr (*wrapperFunc)(const char*) );\n")
 f.write("#ifdef __cplusplus\n}\n#endif\n")
 
 f.write("#endif\n\n")
+f.close()
   
 f=open("glwrapper.c","w")
 
@@ -177,8 +178,7 @@ for x in functions:
 f.write("\n\n")
 f.write("}\n")
 f.write("\n\n")
-
-
+f.close()
 
       
     


### PR DESCRIPTION
Same rationale as #101105 and #101040, this time for `1.1-stable`. The commits are cherry-picked from #101105, minus the mingw one which wasn't needed.

For that release we still have original binaries, albeit the Linux ones are not properly portable, as they are compiled against openssl as a shared library, and the old 1.0.x version of openssl it used is hardly provided in Linux distros anymore (and if it is, it's with packager-defined SONAME which make it incompatible anyway, at least between Debian/RedHat families of distros).

So reusing the same setup as for `1.0-stable`, I'm going to remake Linux binaries, suffixed `_portable`.

Here they are: https://github.com/godotengine/godot-builds/releases/tag/1.1-stable

The new `_portable` binaries have been compiled with the same Linux SDK we use for current 4.x releases, using GCC 13.2.0 compiled against glibc 2.28, so it should be supported on most Linux distros newer than Ubuntu 18.04 (excluded).

I also updated the export templates tpz with a new `_portable.tpz`, where the Linux export templates have been replaced by the new builds.
