### PR TITLE
Web: Export ASTC/BPTC compressed textures

### DIFF
--- a/platform/web/doc_classes/EditorExportPlatformWeb.xml
+++ b/platform/web/doc_classes/EditorExportPlatformWeb.xml
@@ -87,10 +87,10 @@
 			If [code]false[/code], the exported game will not support threads. As a result, it is more prone to performance and audio issues, but will only require to be run on an HTTPS website.
 		</member>
 		<member name="vram_texture_compression/for_desktop" type="bool" setter="" getter="">
-			If [code]true[/code], allows textures to be optimized for desktop through the S3TC algorithm.
+			If [code]true[/code], allows textures to be optimized for desktop through the S3TC/BPTC algorithm.
 		</member>
 		<member name="vram_texture_compression/for_mobile" type="bool" setter="" getter="">
-			If [code]true[/code] allows textures to be optimized for mobile through the ETC2 algorithm.
+			If [code]true[/code] allows textures to be optimized for mobile through the ETC2/ASTC algorithm.
 		</member>
 	</members>
 </class>

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -334,9 +334,11 @@ Error EditorExportPlatformWeb::_build_pwa(const Ref<EditorExportPreset> &p_prese
 void EditorExportPlatformWeb::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
 	if (p_preset->get("vram_texture_compression/for_desktop")) {
 		r_features->push_back("s3tc");
+		r_features->push_back("bptc");
 	}
 	if (p_preset->get("vram_texture_compression/for_mobile")) {
 		r_features->push_back("etc2");
+		r_features->push_back("astc");
 	}
 	if (p_preset->get("variant/thread_support").operator bool()) {
 		r_features->push_back("threads");


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/issues/100644#issuecomment-2567649343

Enables the export of BPTC/ASTC-compressed textures for web platforms. Previously, only S3TC/ETC2 were supported