### PR TITLE
Fix opacity when deleting or renaming a node in AnimationNodeStateMachine

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1642,6 +1642,8 @@ void AnimationNodeStateMachineEditor::_name_edited(const String &p_text) {
 	name_edit_popup->hide();
 	updating = false;
 
+	selected_nodes.clear();
+	connected_nodes.clear();
 	state_machine_draw->queue_redraw();
 }
 
@@ -1701,6 +1703,7 @@ void AnimationNodeStateMachineEditor::_erase_selected(const bool p_nested_action
 			updating = false;
 		}
 
+		connected_nodes.clear();
 		selected_nodes.clear();
 	}
 


### PR DESCRIPTION
In `AnimationNodeStateMachine`, fixes opacity not being correctly reset when deleting a node or connection, or renaming a node.

https://github.com/user-attachments/assets/6c5bd721-c761-478d-ba09-e00b511c940f

