### PR TITLE
Editor: Fix crash when using `--import --verbose` due to use-after-free

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -522,6 +522,14 @@ void EditorResourcePreview::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("preview_invalidated", PropertyInfo(Variant::STRING, "path")));
 }
 
+void EditorResourcePreview::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_EXIT_TREE: {
+			stop();
+		} break;
+	}
+}
+
 void EditorResourcePreview::check_for_invalidation(const String &p_path) {
 	bool call_invalidated = false;
 	{

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -123,6 +123,7 @@ class EditorResourcePreview : public Node {
 	void _update_thumbnail_sizes();
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Whilst executing `--import --verbose` that includes add-ons, I observed a use-after-free bug when the editor was shutting down, as the `ErrorLog` was deleted, and the `EditorResourcePreview` background thread was still running an printing messages to the log when `--verbose` is enabled.