### PR TITLE
i18n: Fix `get_tool_locale()` not return current locale at runtime

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -503,7 +503,7 @@ String TranslationServer::get_tool_locale() {
 		// Look for best matching loaded translation.
 		Ref<Translation> t = main_domain->get_translation_object(locale);
 		if (t.is_null()) {
-			return "en";
+			return locale;
 		}
 		return t->get_locale();
 	}


### PR DESCRIPTION
- Fixes: #100642 

According to documentation, `TranslationServer::get_tool_locale()` should return the same value as `get_locale()` at runtime, but now it returns fixed value `en` when no Translation loaded. This causes some issues about text shaping as https://github.com/godotengine/godot/issues/100642#issuecomment-2573389272 explained.