### PR TITLE
Improve performance of changing compound shapes when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -80,7 +80,7 @@ bool JoltArea3D::_has_pending_events() const {
 }
 
 void JoltArea3D::_add_to_space() {
-	jolt_shape = build_shape();
+	jolt_shape = build_shapes(true);
 
 	JPH::CollisionGroup::GroupID group_id = 0;
 	JPH::CollisionGroup::SubGroupID sub_group_id = 0;
@@ -97,7 +97,7 @@ void JoltArea3D::_add_to_space() {
 		jolt_settings->mCollideKinematicVsNonDynamic = true;
 	}
 
-	jolt_settings->SetShape(build_shape());
+	jolt_settings->SetShape(jolt_shape);
 
 	const JPH::BodyID new_jolt_id = space->add_rigid_body(*this, *jolt_settings);
 	if (new_jolt_id.IsInvalid()) {

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -114,7 +114,7 @@ JPH::EMotionType JoltBody3D::_get_motion_type() const {
 }
 
 void JoltBody3D::_add_to_space() {
-	jolt_shape = build_shape();
+	jolt_shape = build_shapes(true);
 
 	JPH::CollisionGroup::GroupID group_id = 0;
 	JPH::CollisionGroup::SubGroupID sub_group_id = 0;
@@ -477,8 +477,8 @@ void JoltBody3D::_mode_changed() {
 	wake_up();
 }
 
-void JoltBody3D::_shapes_built() {
-	JoltShapedObject3D::_shapes_built();
+void JoltBody3D::_shapes_committed() {
+	JoltShapedObject3D::_shapes_committed();
 
 	_update_mass_properties();
 	_update_joint_constraints();

--- a/modules/jolt_physics/objects/jolt_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_body_3d.h
@@ -139,7 +139,7 @@ private:
 	void _exit_all_areas();
 
 	void _mode_changed();
-	virtual void _shapes_built() override;
+	virtual void _shapes_committed() override;
 	virtual void _space_changing() override;
 	virtual void _space_changed() override;
 	void _areas_changed();

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.h
@@ -33,6 +33,8 @@
 
 #include "jolt_object_3d.h"
 
+#include "core/templates/self_list.h"
+
 #include "Jolt/Jolt.h"
 
 #include "Jolt/Physics/Body/Body.h"
@@ -42,6 +44,8 @@ class JoltShapedObject3D : public JoltObject3D {
 	friend class JoltShape3D;
 
 protected:
+	SelfList<JoltShapedObject3D> needs_optimization_element;
+
 	Vector3 scale = Vector3(1, 1, 1);
 
 	JPH::ShapeRefC jolt_shape;
@@ -53,15 +57,16 @@ protected:
 
 	bool _is_big() const;
 
-	JPH::ShapeRefC _try_build_shape();
+	JPH::ShapeRefC _try_build_shape(bool p_optimize_compound);
 	JPH::ShapeRefC _try_build_single_shape();
-	JPH::ShapeRefC _try_build_compound_shape();
+	JPH::ShapeRefC _try_build_compound_shape(bool p_optimize);
+
+	void _enqueue_needs_optimization();
+	void _dequeue_needs_optimization();
 
 	virtual void _shapes_changed();
-	virtual void _shapes_built() {}
+	virtual void _shapes_committed() {}
 	virtual void _space_changing() override;
-
-	void _update_shape();
 
 public:
 	explicit JoltShapedObject3D(ObjectType p_object_type);
@@ -86,7 +91,9 @@ public:
 	virtual bool has_custom_center_of_mass() const = 0;
 	virtual Vector3 get_center_of_mass_custom() const = 0;
 
-	JPH::ShapeRefC build_shape();
+	JPH::ShapeRefC build_shapes(bool p_optimize_compound);
+
+	void commit_shapes(bool p_optimize_compound);
 
 	const JPH::Shape *get_jolt_shape() const { return jolt_shape; }
 	const JPH::Shape *get_previous_jolt_shape() const { return previous_jolt_shape; }

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -63,6 +63,12 @@ constexpr double DEFAULT_SOLVER_ITERATIONS = 8;
 } // namespace
 
 void JoltSpace3D::_pre_step(float p_step) {
+	while (needs_optimization_list.first()) {
+		JoltShapedObject3D *object = needs_optimization_list.first()->self();
+		needs_optimization_list.remove(needs_optimization_list.first());
+		object->commit_shapes(true);
+	}
+
 	contact_listener->pre_step();
 
 	const JPH::BodyLockInterface &lock_iface = get_lock_iface();
@@ -424,6 +430,18 @@ void JoltSpace3D::dequeue_call_queries(SelfList<JoltBody3D> *p_body) {
 void JoltSpace3D::dequeue_call_queries(SelfList<JoltArea3D> *p_area) {
 	if (p_area->in_list()) {
 		area_call_queries_list.remove(p_area);
+	}
+}
+
+void JoltSpace3D::enqueue_needs_optimization(SelfList<JoltShapedObject3D> *p_object) {
+	if (!p_object->in_list()) {
+		needs_optimization_list.add(p_object);
+	}
+}
+
+void JoltSpace3D::dequeue_needs_optimization(SelfList<JoltShapedObject3D> *p_object) {
+	if (p_object->in_list()) {
+		needs_optimization_list.remove(p_object);
 	}
 }
 

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -54,10 +54,12 @@ class JoltJoint3D;
 class JoltLayers;
 class JoltObject3D;
 class JoltPhysicsDirectSpaceState3D;
+class JoltShapedObject3D;
 
 class JoltSpace3D {
 	SelfList<JoltBody3D>::List body_call_queries_list;
 	SelfList<JoltArea3D>::List area_call_queries_list;
+	SelfList<JoltShapedObject3D>::List needs_optimization_list;
 
 	RID rid;
 
@@ -100,6 +102,8 @@ public:
 
 	JPH::PhysicsSystem &get_physics_system() const { return *physics_system; }
 
+	JPH::TempAllocator &get_temp_allocator() const { return *temp_allocator; }
+
 	JPH::BodyInterface &get_body_iface();
 	const JPH::BodyInterface &get_body_iface() const;
 	const JPH::BodyLockInterface &get_lock_iface() const;
@@ -137,6 +141,9 @@ public:
 	void enqueue_call_queries(SelfList<JoltArea3D> *p_area);
 	void dequeue_call_queries(SelfList<JoltBody3D> *p_body);
 	void dequeue_call_queries(SelfList<JoltArea3D> *p_area);
+
+	void enqueue_needs_optimization(SelfList<JoltShapedObject3D> *p_object);
+	void dequeue_needs_optimization(SelfList<JoltShapedObject3D> *p_object);
 
 	void add_joint(JPH::Constraint *p_jolt_ref);
 	void add_joint(JoltJoint3D *p_joint);


### PR DESCRIPTION
(This relates to the to-do list item in #99895 titled "Implement the deferred compound shape mentioned above".)

This PR lessens (albeit not a lot) a long-standing performance discrepancy between the Jolt Physics module and Godot Physics, where multiple additions/removals/modifications to a compound shape (i.e. an object with multiple shapes) during a single physics frame will incur a significantly heavier cost when compared to Godot Physics.

## Problem

The reason for this performance discrepancy is due to several factors, but in short, there's just more work happening when adding shapes with the Jolt Physics module when compared to Godot Physics. To start with, the Jolt Physics module uses a compound shape that's better optimized for complex shape structures, called `JPH::StaticCompoundShape`, which incurs a heavier cost upon creation in order to build its spatial partitioning. On top of that, we also calculate the object's mass properties and update the broadphase on any shape addition/removal/modification, unlike Godot Physics, which instead defers these things to the next physics step[^1].

This isn't so much a problem when you're dealing with an object that hasn't yet been added to a scene tree, since we have no real reason to (and currently do not) create/commit the underlying Jolt shape at that time, but as soon as the object is added to a scene tree we have no choice but to assume that every shape addition/removal/modification is the last one before any number of operations happen that will require an up-to-date Jolt shape, bounds and/or mass properties (such as the simulation itself) and as a result we're forced to rebuild the compound shape from scratch[^2] with every change.

## Change

The original plan for addressing this (as discussed in jrouwe/JoltPhysics#1165) was to make a custom compound shape type that acted as a lazily built compound shape, which would within itself preserve a `JPH::StaticCompoundShapeSettings` (its "blueprint" if you will) and only actually create/commit the `JPH::StaticCompoundShape` when any of the lazy compound shape's methods were invoked, such as when getting any of its properties or performing a query against it (e.g. during simulation).

This however proved to be somewhat messy and error-prone in practice, since we now had to (similar to Godot Physics and its mass properties update) be mindful about always committing the shape before doing anything to the object that required its shape, bounds and/or mass properties to be up-to-date.

As a result, this PR takes a more conservative approach, by simply switching between creating a `JPH::StaticCompoundShape` and the cheaper `JPH::MutableCompoundShape` depending on the context, with the latter always being "upgraded" to a `JPH::StaticCompoundShape` at the next physics step. This allows us to at least avoid paying for some of the cost of `JPH::StaticCompoundShape` while also ensuring that we always have an up-to-date shape, bounds and mass properties. However, things can now also be a bit slower if you, for example, perform a physics query against an object that hasn't yet had its `JPH::MutableCompoundShape` upgraded to a `JPH::StaticCompoundShape`, but I would consider this a rare edge-case.

The heuristic for picking between the two compound shape types is as follows:

1. If we're adding an object to a scene tree, and the object only has one shape, no compound shape is built at all (same as before) and this PR has no relevance/impact.
2. If we're adding an object to a scene tree, and the object has multiple shapes already[^3], assume that no more shape changes will be made and build a `JPH::StaticCompoundShape` right away.
3. If we're changing an object that's already in a scene tree, and the object only has one shape, no compound shape is built at all (same as before) and this PR has no relevance/impact.
4. If we're changing an object that's already in a scene tree, and the object has multiple shapes, assume that more changes will be made and build a `JPH::MutableCompoundShape`, and queue it up to be upgraded to a `JPH::StaticCompoundShape` later.

---

There are also some other improvements included in this:

1. We now reserve the memory used for the sub-shapes in `JPH::CompoundShapeSettings`, reducing the amount of memory allocations needed.
2. We now pass a `JPH::TempAllocator` to `JPH::StaticCompoundShapeSettings::Create`, reducing the amount of memory allocations needed.
3. `Area3D` no longer (incorrectly) builds its compound shapes twice when added to a scene tree.

## Results

This is a before-and-after profiling of `SceneTree::physics_process`, in a scene where a `StaticBody3D` is being created every `_physics_process`, with 200 `BoxShape3D` added to the body _after_ it's has been added to the scene tree:

![Before](https://github.com/user-attachments/assets/08640000-0cbe-40c5-8f2f-d6b62df7bc21)
![After](https://github.com/user-attachments/assets/62bb851d-27b9-4951-82bd-d2f68d16a14e)

For reference, here is the same scene in Godot Physics:

![GodotPhysics](https://github.com/user-attachments/assets/7878b5fe-841e-4ec8-81a5-cb1828fbccb7)

Note that these numbers don't include the cost you pay at the next physics step. That cost is quite small in this particular scene, with either engine, but could become more relevant as you modify more objects instead.

You may find the project here: [jolt-compound-performance.zip](https://github.com/user-attachments/files/18323149/jolt-compound-performance.zip)

[^1]: This is currently the source of some bugs, such as [#75934](https://github.com/godotengine/godot/issues/75934), and in general seems quite error-prone.
[^2]: Note that the individual shapes themselves are still cached inbetween rebuilds.
[^3]: This will be the vast majority of cases for compound shapes, as this is what happens when you instantiate a scene, as opposed to programmatically creating/adding the shapes.