### PR TITLE
Correct aspect ratio used in FSR2 calculations

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2354,7 +2354,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 			for (uint32_t v = 0; v < rb->get_view_count(); v++) {
 				real_t fov = p_render_data->scene_data->cam_projection.get_fov();
 				real_t aspect = p_render_data->scene_data->cam_projection.get_aspect();
-				real_t fovy = p_render_data->scene_data->cam_projection.get_fovy(fov, aspect);
+				real_t fovy = p_render_data->scene_data->cam_projection.get_fovy(fov, 1.0 / aspect);
 				Vector2 jitter = p_render_data->scene_data->taa_jitter * Vector2(rb->get_internal_size()) * 0.5f;
 				RendererRD::FSR2Effect::Parameters params;
 				params.context = rb_data->get_fsr2_context();


### PR DESCRIPTION
Thanks to @Flarkk for noticing and documenting that `get_fovy` needs the inverse aspect ratio in https://github.com/godotengine/godot/pull/99921. I searched the codebase for uses of `get_fovy` and found that (outside of core) this is the only place it is used and it is used wrong. 

Following the FSR code, I found that fovy is only used in one place, to calculate the view space position during the DepthClip pass. The depth clip pass rejects samples where the depth changes too quickly.

I tested this change in the GDQuest TPS demo by sliding the main character back and forth quickly in the editor. In master, the character leaves a streak across the screen which is especially visible on animated characters. Further, the ghosting artifacts take a while to resolve.

Master:
![Screenshot from 2025-01-06 13-56-46](https://github.com/user-attachments/assets/0696ba30-de91-47f1-8f2c-940dc20b9f6d)

With this change, there is almost no ghosting (I could see a bit in motion, but I couldn't capture it because it resolved so quickly):
![Screenshot from 2025-01-06 13-59-46](https://github.com/user-attachments/assets/3d595ada-32f1-4654-8cb3-aec6426260d3)

With this change there is less depth-based ghosting and the ghosting that does happen resolves much quicker. 

CC @mrjustaguy This might be part of the "super ghosting" you have noticed. I would appreciate if you could test with this change and confirm if it helps in any of your test cases