### PR TITLE
SCons: Treat thirdparty includes as external

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -150,6 +150,7 @@ env.__class__.disable_warnings = methods.disable_warnings
 env.__class__.force_optimization_on_debug = methods.force_optimization_on_debug
 env.__class__.module_add_dependencies = methods.module_add_dependencies
 env.__class__.module_check_dependencies = methods.module_check_dependencies
+env.__class__.AddExternalIncludes = methods.add_external_includes
 
 env["x86_libtheora_opt_gcc"] = False
 env["x86_libtheora_opt_vc"] = False
@@ -895,6 +896,17 @@ else:  # GCC, Clang
 
     if env["werror"]:
         env.Append(CCFLAGS=["-Werror"])
+
+
+# Allow marking includes as external/system to avoid raising warnings.
+if env.msvc:
+    if cc_version_major < 16 or (cc_version_major == 16 and cc_version_minor < 10):
+        env.AppendUnique(CPPFLAGS=["/experimental:external"])
+    env.AppendUnique(CPPFLAGS=["/external:W0"])
+    env["EXTHEADERPREFIX"] = "/external:I"
+else:
+    env["EXTHEADERPREFIX"] = "-isystem"
+
 
 if hasattr(detect, "get_program_suffix"):
     suffix = "." + detect.get_program_suffix()

--- a/core/SCsub
+++ b/core/SCsub
@@ -51,8 +51,8 @@ if env["brotli"] and env["builtin_brotli"]:
     ]
     thirdparty_brotli_sources = [thirdparty_brotli_dir + file for file in thirdparty_brotli_sources]
 
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
-    env.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
+    env_thirdparty.AddExternalIncludes(thirdparty_brotli_dir + "include")
+    env.AddExternalIncludes(thirdparty_brotli_dir + "include")
 
     if env.get("use_ubsan") or env.get("use_asan") or env.get("use_tsan") or env.get("use_lsan") or env.get("use_msan"):
         env_thirdparty.Append(CPPDEFINES=["BROTLI_BUILD_PORTABLE"])
@@ -69,8 +69,8 @@ if env["builtin_clipper2"]:
     ]
     thirdparty_clipper_sources = [thirdparty_clipper_dir + file for file in thirdparty_clipper_sources]
 
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_clipper_dir + "include"])
-    env.Prepend(CPPPATH=[thirdparty_clipper_dir + "include"])
+    env_thirdparty.AddExternalIncludes(thirdparty_clipper_dir + "include")
+    env.AddExternalIncludes(thirdparty_clipper_dir + "include")
 
     env_thirdparty.Append(CPPDEFINES=["CLIPPER2_ENABLED"])
     env.Append(CPPDEFINES=["CLIPPER2_ENABLED"])
@@ -94,9 +94,9 @@ if env["builtin_zlib"]:
     ]
     thirdparty_zlib_sources = [thirdparty_zlib_dir + file for file in thirdparty_zlib_sources]
 
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_zlib_dir])
+    env_thirdparty.AddExternalIncludes(thirdparty_zlib_dir)
     # Needs to be available in main env too
-    env.Prepend(CPPPATH=[thirdparty_zlib_dir])
+    env.AddExternalIncludes(thirdparty_zlib_dir)
     if env.dev_build:
         env_thirdparty.Append(CPPDEFINES=["ZLIB_DEBUG"])
 
@@ -146,9 +146,9 @@ if env["builtin_zstd"]:
         thirdparty_zstd_sources.append("decompress/huf_decompress_amd64.S")
     thirdparty_zstd_sources = [thirdparty_zstd_dir + file for file in thirdparty_zstd_sources]
 
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_zstd_dir, thirdparty_zstd_dir + "common"])
+    env_thirdparty.AddExternalIncludes([thirdparty_zstd_dir, thirdparty_zstd_dir + "common"])
     env_thirdparty.Append(CPPDEFINES=["ZSTD_STATIC_LINKING_ONLY"])
-    env.Prepend(CPPPATH=thirdparty_zstd_dir)
+    env.AddExternalIncludes(thirdparty_zstd_dir)
     # Also needed in main env includes will trigger warnings
     env.Append(CPPDEFINES=["ZSTD_STATIC_LINKING_ONLY"])
 

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -13,7 +13,7 @@ if is_builtin or not has_module:
     # Use our headers for builtin or if the module is not going to be compiled.
     # We decided not to depend on system mbedtls just for these few files that can
     # be easily extracted.
-    env_crypto.Prepend(CPPPATH=["#thirdparty/mbedtls/include"])
+    env_crypto.AddExternalIncludes("#thirdparty/mbedtls/include")
 
 # MbedTLS core functions (for CryptoCore).
 # If the mbedtls module is compiled we don't need to add the .c files with our

--- a/drivers/backtrace/SCsub
+++ b/drivers/backtrace/SCsub
@@ -26,7 +26,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_backtrace.Prepend(CPPPATH=[thirdparty_dir])
+env_backtrace.AddExternalIncludes(thirdparty_dir)
 
 env_thirdparty = env_backtrace.Clone()
 env_thirdparty.disable_warnings()

--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -15,15 +15,14 @@ thirdparty_obj = []
 
 # DirectX Headers (must take precedence over Windows SDK's).
 
-env.Prepend(CPPPATH=["#thirdparty/directx_headers/include/directx"])
-env_d3d12_rdd.Prepend(CPPPATH=["#thirdparty/directx_headers/include/directx"])
-env_d3d12_rdd.Prepend(CPPPATH=["#thirdparty/directx_headers/include/dxguids"])
-
+env.AddExternalIncludes("#thirdparty/directx_headers/include/directx")
+env_d3d12_rdd.AddExternalIncludes("#thirdparty/directx_headers/include/directx")
+env_d3d12_rdd.AddExternalIncludes("#thirdparty/directx_headers/include/dxguids")
 
 # Direct3D 12 Memory Allocator.
 
-env.Append(CPPPATH=["#thirdparty/d3d12ma"])
-env_d3d12_rdd.Append(CPPPATH=["#thirdparty/d3d12ma"])
+env.AddExternalIncludes("#thirdparty/d3d12ma")
+env_d3d12_rdd.AddExternalIncludes("#thirdparty/d3d12ma")
 
 
 # Agility SDK.
@@ -38,7 +37,7 @@ if env["agility_sdk_path"] != "" and os.path.exists(env["agility_sdk_path"]):
 
 if env["use_pix"]:
     env_d3d12_rdd.Append(CPPDEFINES=["PIX_ENABLED"])
-    env_d3d12_rdd.Append(CPPPATH=[env["pix_path"] + "/Include"])
+    env_d3d12_rdd.AddExternalIncludes(env["pix_path"] + "/Include")
 
 
 # Mesa (SPIR-V to DXIL functionality).
@@ -147,7 +146,7 @@ else:
         env.Append(CCFLAGS=["-Wno-unknown-pragmas"])
 
 # This is needed since rendering_device_d3d12.cpp needs to include some Mesa internals.
-env_d3d12_rdd.Prepend(CPPPATH=mesa_private_inc_paths)
+env_d3d12_rdd.AddExternalIncludes(mesa_private_inc_paths)
 # For the same reason as above, the defines must be the same as in the 3rd-party code itself.
 env_d3d12_rdd.Append(CPPDEFINES=extra_defines)
 

--- a/drivers/d3d12/d3d12ma.cpp
+++ b/drivers/d3d12/d3d12ma.cpp
@@ -30,35 +30,4 @@
 
 #include "rendering_context_driver_d3d12.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#pragma GCC diagnostic ignored "-Wduplicated-branches"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wsign-compare"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#pragma GCC diagnostic ignored "-Wunused-function"
-#pragma GCC diagnostic ignored "-Wnonnull-compare"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wtautological-undefined-compare"
-#pragma clang diagnostic ignored "-Wunused-variable"
-#pragma clang diagnostic ignored "-Wunused-but-set-variable"
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wunused-private-field"
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-
-#if defined(_MSC_VER)
-#pragma warning(disable : 4189 4505)
-#endif
-
-#include "thirdparty/d3d12ma/D3D12MemAlloc.cpp"
+#include "D3D12MemAlloc.cpp"

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -37,27 +37,7 @@
 #include "core/version.h"
 #include "servers/rendering/rendering_device.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#endif
-
 #include "dxcapi.h"
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 
 #if !defined(_MSC_VER)
 #include <guiddef.h>

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -39,22 +39,6 @@
 #include "servers/display_server.h"
 #include "servers/rendering/rendering_context_driver.h"
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-
 #if defined(AS)
 #undef AS
 #endif
@@ -77,12 +61,6 @@
 #include <dxgi1_6.h>
 
 #include <wrl/client.h>
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 
 using Microsoft::WRL::ComPtr;
 

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -39,43 +39,12 @@
 #include "dxil_hash.h"
 #include "rendering_context_driver_d3d12.h"
 
-// No point in fighting warnings in Mesa.
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4200) // "nonstandard extension used: zero-sized array in struct/union".
-#pragma warning(disable : 4806) // "'&': unsafe operation: no value of type 'bool' promoted to type 'uint32_t' can equal the given constant".
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#endif
-
 #include "nir_spirv.h"
 #include "nir_to_dxil.h"
 #include "spirv_to_dxil.h"
 extern "C" {
 #include "dxil_spirv_nir.h"
 }
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
-#endif
-
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
 
 #if !defined(_MSC_VER)
 #include <guiddef.h>

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -41,22 +41,6 @@
 #define __REQUIRED_RPCNDR_H_VERSION__ 475
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wshadow"
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#elif defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnon-virtual-dtor"
-#pragma clang diagnostic ignored "-Wstring-plus-int"
-#pragma clang diagnostic ignored "-Wswitch"
-#pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-
 #include "d3dx12.h"
 #include <dxgi1_6.h>
 #define D3D12MA_D3D12_HEADERS_ALREADY_INCLUDED
@@ -67,12 +51,6 @@
 #if defined(_MSC_VER) && defined(MemoryBarrier)
 // Annoying define from winnt.h. Reintroduced by some of the headers above.
 #undef MemoryBarrier
-#endif
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#elif defined(__clang__)
-#pragma clang diagnostic pop
 #endif
 
 using Microsoft::WRL::ComPtr;

--- a/drivers/gl_context/SCsub
+++ b/drivers/gl_context/SCsub
@@ -13,12 +13,7 @@ if env["platform"] in ["macos", "windows", "linuxbsd"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    # Treat glad headers as system headers to avoid raising warnings. Not supported on MSVC.
-    if not env.msvc:
-        env.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
-    else:
-        env.Prepend(CPPPATH=[thirdparty_dir])
-
+    env.AddExternalIncludes(thirdparty_dir)
     env.Append(CPPDEFINES=["GLAD_ENABLED"])
     env.Append(CPPDEFINES=["EGL_ENABLED"])
 

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -22,7 +22,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_metal.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "/include"])
+env_metal.AddExternalIncludes([thirdparty_dir, thirdparty_dir + "/include"])
 
 # Must enable exceptions for SPIRV-Cross; otherwise, it will abort the process on errors.
 if "-fno-exceptions" in env_metal["CXXFLAGS"]:

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -30,9 +30,9 @@ if env["builtin_libpng"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_png.Prepend(CPPPATH=[thirdparty_dir])
+    env_png.AddExternalIncludes(thirdparty_dir)
     # Needed for drivers includes and in platform/web.
-    env.Prepend(CPPPATH=[thirdparty_dir])
+    env.AddExternalIncludes(thirdparty_dir)
 
     env_thirdparty = env_png.Clone()
     env_thirdparty.disable_warnings()

--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -8,11 +8,11 @@ thirdparty_dir = "#thirdparty/vulkan"
 thirdparty_volk_dir = "#thirdparty/volk"
 
 # Use bundled Vulkan headers
-env.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "/include"])
+env.AddExternalIncludes([thirdparty_dir, thirdparty_dir + "/include"])
 
 if env["use_volk"]:
     env.AppendUnique(CPPDEFINES=["USE_VOLK"])
-    env.Prepend(CPPPATH=[thirdparty_volk_dir])
+    env.AddExternalIncludes(thirdparty_volk_dir)
 
 if env["platform"] == "android":
     env.AppendUnique(CPPDEFINES=["VK_USE_PLATFORM_ANDROID_KHR"])

--- a/methods.py
+++ b/methods.py
@@ -202,6 +202,11 @@ def disable_warnings(self):
         self.AppendUnique(CCFLAGS=["-w"])
 
 
+def add_external_includes(self, dirs) -> None:
+    for dir in dirs if isinstance(dirs, list) else [dirs]:
+        self.AppendUnique(CPPFLAGS=["${EXTHEADERPREFIX}" + self.Dir(dir).path])
+
+
 def force_optimization_on_debug(self):
     # 'self' is the environment
     if self["target"] == "template_release":

--- a/modules/astcenc/SCsub
+++ b/modules/astcenc/SCsub
@@ -37,7 +37,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_astcenc.Prepend(CPPPATH=[thirdparty_dir])
+env_astcenc.AddExternalIncludes(thirdparty_dir)
 
 env_thirdparty = env_astcenc.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/basis_universal/SCsub
+++ b/modules/basis_universal/SCsub
@@ -42,18 +42,14 @@ if basisu_encoder:
 
 transcoder_sources = [thirdparty_dir + "transcoder/basisu_transcoder.cpp"]
 
-# Treat Basis headers as system headers to avoid raising warnings. Not supported on MSVC.
-if not env.msvc:
-    env_basisu.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
-else:
-    env_basisu.Prepend(CPPPATH=[thirdparty_dir])
+env_basisu.AddExternalIncludes(thirdparty_dir)
 
 if basisu_encoder:
-    env_basisu.Prepend(CPPPATH=["#thirdparty/jpeg-compressor"])
-    env_basisu.Prepend(CPPPATH=["#thirdparty/tinyexr"])
+    env_basisu.AddExternalIncludes("#thirdparty/jpeg-compressor")
+    env_basisu.AddExternalIncludes("#thirdparty/tinyexr")
 
 if env["builtin_zstd"]:
-    env_basisu.Prepend(CPPPATH=["#thirdparty/zstd"])
+    env_basisu.AddExternalIncludes("#thirdparty/zstd")
 
 env_thirdparty = env_basisu.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/betsy/SCsub
+++ b/modules/betsy/SCsub
@@ -14,7 +14,7 @@ env_betsy.Depends(Glob("*.glsl.gen.h"), ["#glsl_builders.py"])
 # Thirdparty source files
 thirdparty_obj = []
 thirdparty_dir = "#thirdparty/betsy/"
-env_betsy.Prepend(CPPPATH=[thirdparty_dir])
+env_betsy.AddExternalIncludes(thirdparty_dir)
 
 env_thirdparty = env_betsy.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -31,7 +31,7 @@ thirdparty_sources = [
 ]
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
-env_csg.Prepend(CPPPATH=[thirdparty_dir + "include"])
+env_csg.AddExternalIncludes(thirdparty_dir + "include")
 env_thirdparty = env_csg.Clone()
 env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)

--- a/modules/cvtt/SCsub
+++ b/modules/cvtt/SCsub
@@ -26,7 +26,7 @@ thirdparty_sources = [
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_cvtt.Prepend(CPPPATH=[thirdparty_dir])
+env_cvtt.AddExternalIncludes(thirdparty_dir)
 
 env_thirdparty = env_cvtt.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/enet/SCsub
+++ b/modules/enet/SCsub
@@ -24,7 +24,7 @@ if env["builtin_enet"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_enet.Prepend(CPPPATH=[thirdparty_dir])
+    env_enet.AddExternalIncludes(thirdparty_dir)
     env_enet.Append(CPPDEFINES=["GODOT_ENET"])
 
     env_thirdparty = env_enet.Clone()

--- a/modules/etcpak/SCsub
+++ b/modules/etcpak/SCsub
@@ -19,7 +19,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_etcpak.Prepend(CPPPATH=[thirdparty_dir])
+env_etcpak.AddExternalIncludes(thirdparty_dir)
 
 env_thirdparty = env_etcpak.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/fbx/SCsub
+++ b/modules/fbx/SCsub
@@ -13,7 +13,7 @@ thirdparty_obj = []
 thirdparty_dir = "#thirdparty/ufbx/"
 thirdparty_sources = [thirdparty_dir + "ufbx.c"]
 
-env_fbx.Prepend(CPPPATH=[thirdparty_dir])
+env_fbx.AddExternalIncludes(thirdparty_dir)
 
 env_thirdparty = env_fbx.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -62,9 +62,9 @@ if env["builtin_freetype"]:
     if env["brotli"]:
         env_freetype.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
 
-    env_freetype.Prepend(CPPPATH=[thirdparty_dir + "/include"])
+    env_freetype.AddExternalIncludes(thirdparty_dir + "/include")
     # Also needed in main env for scene/
-    env.Prepend(CPPPATH=[thirdparty_dir + "/include"])
+    env.AddExternalIncludes(thirdparty_dir + "/include")
 
     env_freetype.Append(CPPDEFINES=["FT2_BUILD_LIBRARY", "FT_CONFIG_OPTION_USE_PNG", "FT_CONFIG_OPTION_SYSTEM_ZLIB"])
     if env.dev_build:
@@ -72,7 +72,7 @@ if env["builtin_freetype"]:
 
     # Also requires libpng headers
     if env["builtin_libpng"]:
-        env_freetype.Prepend(CPPPATH=["#thirdparty/libpng"])
+        env_freetype.AddExternalIncludes("#thirdparty/libpng")
 
     sfnt = thirdparty_dir + "src/sfnt/sfnt.c"
     # Must be done after all CPPDEFINES are being set so we can copy them.
@@ -81,7 +81,7 @@ if env["builtin_freetype"]:
         # since currently unsupported in WASM
         tmp_env = env_freetype.Clone()
         tmp_env.disable_warnings()
-        tmp_env.Append(CPPFLAGS=["-U__OPTIMIZE__"])
+        tmp_env.Append(CCFLAGS=["-U__OPTIMIZE__"])
         sfnt = tmp_env.Object(sfnt)
     thirdparty_sources += [sfnt]
 

--- a/modules/glslang/SCsub
+++ b/modules/glslang/SCsub
@@ -62,13 +62,9 @@ if env["builtin_glslang"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    # Treat glslang headers as system headers to avoid raising warnings. Not supported on MSVC.
     # Include `#thirdparty` to workaround mismatch between location of `SPIRV` in library source
     # and in installed public headers.
-    if not env.msvc:
-        env_glslang.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path, "-isystem", Dir("#thirdparty").path])
-    else:
-        env_glslang.Prepend(CPPPATH=[thirdparty_dir, "#thirdparty"])
+    env_glslang.AddExternalIncludes([thirdparty_dir, "#thirdparty"])
 
     env_glslang.Append(CPPDEFINES=["ENABLE_OPT=0"])
 

--- a/modules/jolt_physics/SCsub
+++ b/modules/jolt_physics/SCsub
@@ -144,7 +144,7 @@ thirdparty_sources = [
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_jolt.Prepend(CPPPATH=[thirdparty_dir])
+env_jolt.AddExternalIncludes(thirdparty_dir)
 
 if env.dev_build:
     env_jolt.Append(CPPDEFINES=["JPH_ENABLE_ASSERTS"])

--- a/modules/jpg/SCsub
+++ b/modules/jpg/SCsub
@@ -18,7 +18,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_jpg.Prepend(CPPPATH=[thirdparty_dir])
+env_jpg.AddExternalIncludes(thirdparty_dir)
 
 env_thirdparty = env_jpg.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/ktx/SCsub
+++ b/modules/ktx/SCsub
@@ -33,18 +33,18 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_ktx.Prepend(CPPPATH=[thirdparty_dir + "include"])
-env_ktx.Prepend(CPPPATH=[thirdparty_dir + "utils"])
-env_ktx.Prepend(CPPPATH=[thirdparty_dir + "lib"])
-env_ktx.Prepend(CPPPATH=[thirdparty_dir + "other_include"])
+env_ktx.AddExternalIncludes(thirdparty_dir + "include")
+env_ktx.AddExternalIncludes(thirdparty_dir + "utils")
+env_ktx.AddExternalIncludes(thirdparty_dir + "lib")
+env_ktx.AddExternalIncludes(thirdparty_dir + "other_include")
 
-env_ktx.Prepend(CPPPATH=["#thirdparty/basis_universal"])
+env_ktx.AddExternalIncludes("#thirdparty/basis_universal")
 if env.editor_build:
     # We already build miniz in the basis_universal module (editor only).
     env_ktx.Append(CPPDEFINES=["MINIZ_HEADER_FILE_ONLY"])
 
 if env["vulkan"]:
-    env_ktx.Prepend(CPPPATH=["#thirdparty/vulkan/include"])
+    env_ktx.AddExternalIncludes("#thirdparty/vulkan/include")
 else:
     # Falls back on bundled `vkformat_enum.h`.
     env_ktx.Append(CPPDEFINES=["LIBKTX"])

--- a/modules/mbedtls/SCsub
+++ b/modules/mbedtls/SCsub
@@ -120,7 +120,7 @@ if env["builtin_mbedtls"]:
     thirdparty_dir = "#thirdparty/mbedtls/library/"
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_mbed_tls.Prepend(CPPPATH=["#thirdparty/mbedtls/include/"])
+    env_mbed_tls.AddExternalIncludes("#thirdparty/mbedtls/include/")
     config_path = "thirdparty/mbedtls/include/godot_module_mbedtls_config.h"
     config_path = f"<{config_path}>" if env_mbed_tls["ninja"] and env_mbed_tls.msvc else f'\\"{config_path}\\"'
     env_mbed_tls.Append(CPPDEFINES=[("MBEDTLS_CONFIG_FILE", config_path)])

--- a/modules/minimp3/SCsub
+++ b/modules/minimp3/SCsub
@@ -8,11 +8,7 @@ env_minimp3 = env_modules.Clone()
 
 thirdparty_dir = "#thirdparty/minimp3/"
 
-# Treat minimp3 headers as system headers to avoid raising warnings. Not supported on MSVC.
-if not env.msvc:
-    env_minimp3.Append(CPPFLAGS=["-isystem", Dir(thirdparty_dir).path])
-else:
-    env_minimp3.Prepend(CPPPATH=[thirdparty_dir])
+env_minimp3.AddExternalIncludes(thirdparty_dir)
 
 if not env["minimp3_extra_formats"]:
     env_minimp3.Append(CPPDEFINES=["MINIMP3_ONLY_MP3"])

--- a/modules/msdfgen/SCsub
+++ b/modules/msdfgen/SCsub
@@ -36,7 +36,7 @@ if env["builtin_msdfgen"]:
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
     env_msdfgen.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    env_msdfgen.Prepend(CPPPATH=["#thirdparty/freetype/include", "#thirdparty/msdfgen", "#thirdparty/nanosvg"])
+    env_msdfgen.AddExternalIncludes(["#thirdparty/freetype/include", "#thirdparty/msdfgen", "#thirdparty/nanosvg"])
 
     lib = env_msdfgen.add_library("msdfgen_builtin", thirdparty_sources)
     thirdparty_obj += lib

--- a/modules/navigation/SCsub
+++ b/modules/navigation/SCsub
@@ -28,7 +28,7 @@ if env["builtin_recastnavigation"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_navigation.Prepend(CPPPATH=[thirdparty_dir + "Include"])
+    env_navigation.AddExternalIncludes(thirdparty_dir + "Include")
 
     env_thirdparty = env_navigation.Clone()
     env_thirdparty.disable_warnings()
@@ -45,7 +45,7 @@ if env["builtin_rvo2_2d"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_navigation.Prepend(CPPPATH=[thirdparty_dir])
+    env_navigation.AddExternalIncludes(thirdparty_dir)
 
     env_thirdparty = env_navigation.Clone()
     env_thirdparty.disable_warnings()
@@ -61,7 +61,7 @@ if env["builtin_rvo2_3d"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_navigation.Prepend(CPPPATH=[thirdparty_dir])
+    env_navigation.AddExternalIncludes(thirdparty_dir)
 
     env_thirdparty = env_navigation.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/noise/SCsub
+++ b/modules/noise/SCsub
@@ -7,7 +7,7 @@ Import("env_modules")
 env_noise = env_modules.Clone()
 
 thirdparty_dir = "#thirdparty/noise/"
-env_noise.Prepend(CPPPATH=[thirdparty_dir])
+env_noise.AddExternalIncludes(thirdparty_dir)
 
 # Godot source files
 

--- a/modules/ogg/SCsub
+++ b/modules/ogg/SCsub
@@ -18,7 +18,7 @@ if env["builtin_libogg"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_ogg.Prepend(CPPPATH=[thirdparty_dir])
+    env_ogg.AddExternalIncludes(thirdparty_dir)
 
     env_thirdparty = env_ogg.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -48,8 +48,8 @@ elif env["platform"] == "macos":
 if env["builtin_openxr"]:
     thirdparty_dir = "#thirdparty/openxr"
 
-    env_openxr.Prepend(
-        CPPPATH=[
+    env_openxr.AddExternalIncludes(
+        [
             thirdparty_dir,
             thirdparty_dir + "/include",
             thirdparty_dir + "/src",
@@ -65,7 +65,7 @@ if env["builtin_openxr"]:
     if env["disable_exceptions"]:
         env_thirdparty.AppendUnique(CPPDEFINES=["XRLOADER_DISABLE_EXCEPTION_HANDLING", ("JSON_USE_EXCEPTION", 0)])
 
-    env_thirdparty.Append(CPPPATH=[thirdparty_dir + "/src/loader"])
+    env_thirdparty.AddExternalIncludes(thirdparty_dir + "/src/loader")
 
     # add in external jsoncpp dependency
     thirdparty_jsoncpp_dir = thirdparty_dir + "/src/external/jsoncpp/src/lib_json/"

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -62,7 +62,7 @@ if env["builtin_embree"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in embree_src]
 
-    env_raycast.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "include"])
+    env_raycast.AddExternalIncludes([thirdparty_dir, thirdparty_dir + "include"])
     env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2", "EMBREE_LOWEST_ISA", "TASKING_INTERNAL"])
     env_raycast.AppendUnique(CPPDEFINES=["NDEBUG"])  # No assert() even in debug builds.
 

--- a/modules/regex/SCsub
+++ b/modules/regex/SCsub
@@ -52,7 +52,7 @@ if env["builtin_pcre2"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_regex.Prepend(CPPPATH=[thirdparty_dir])
+    env_regex.AddExternalIncludes(thirdparty_dir)
     env_regex.Append(CPPDEFINES=thirdparty_flags)
 
     def pcre2_builtin(width):

--- a/modules/svg/SCsub
+++ b/modules/svg/SCsub
@@ -65,15 +65,15 @@ if env["module_webp_enabled"]:
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_svg.Prepend(CPPPATH=[thirdparty_dir + "inc"])
+env_svg.AddExternalIncludes(thirdparty_dir + "inc")
 
 # Enable ThorVG static object linking.
 env_svg.Append(CPPDEFINES=["TVG_STATIC"])
 
 env_thirdparty = env_svg.Clone()
 env_thirdparty.disable_warnings()
-env_thirdparty.Prepend(
-    CPPPATH=[
+env_thirdparty.AddExternalIncludes(
+    [
         thirdparty_dir + "src/common",
         thirdparty_dir + "src/loaders/svg",
         thirdparty_dir + "src/renderer",
@@ -84,11 +84,11 @@ env_thirdparty.Prepend(
     ]
 )
 if env["builtin_libpng"]:
-    env_thirdparty.Prepend(CPPPATH=["#thirdparty/libpng"])
+    env_thirdparty.AddExternalIncludes("#thirdparty/libpng")
 if env["module_webp_enabled"]:
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_dir + "src/loaders/external_webp"])
+    env_thirdparty.AddExternalIncludes(thirdparty_dir + "src/loaders/external_webp")
     if env["builtin_libwebp"]:
-        env_thirdparty.Prepend(CPPPATH=["#thirdparty/libwebp/src"])
+        env_thirdparty.AddExternalIncludes("#thirdparty/libwebp/src")
 
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 env.modules_sources += thirdparty_obj

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -39,8 +39,8 @@ freetype_enabled = "freetype" in env.module_list
 msdfgen_enabled = "msdfgen" in env.module_list
 
 if "svg" in env.module_list:
-    env_text_server_adv.Prepend(
-        CPPPATH=[
+    env_text_server_adv.AddExternalIncludes(
+        [
             "#thirdparty/thorvg/inc",
             "#thirdparty/thorvg/src/common",
             "#thirdparty/thorvg/src/renderer",
@@ -139,11 +139,11 @@ if env["builtin_harfbuzz"]:
             ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_harfbuzz.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
+    env_harfbuzz.AddExternalIncludes("#thirdparty/harfbuzz/src")
 
     env_harfbuzz.Append(CCFLAGS=["-DHAVE_ICU"])
     if env["builtin_icu4c"]:
-        env_harfbuzz.Prepend(CPPPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
+        env_harfbuzz.AddExternalIncludes(["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
         env_harfbuzz.Append(
             CCFLAGS=[
                 "-DU_STATIC_IMPLEMENTATION",
@@ -166,15 +166,15 @@ if env["builtin_harfbuzz"]:
                 ]
             )
         if env["builtin_freetype"]:
-            env_harfbuzz.Prepend(CPPPATH=["#thirdparty/freetype/include"])
+            env_harfbuzz.AddExternalIncludes("#thirdparty/freetype/include")
         if env["builtin_graphite"] and env["graphite"]:
-            env_harfbuzz.Prepend(CPPPATH=["#thirdparty/graphite/include"])
+            env_harfbuzz.AddExternalIncludes("#thirdparty/graphite/include")
             env_harfbuzz.Append(CCFLAGS=["-DGRAPHITE2_STATIC"])
 
     if env["platform"] in ["android", "linuxbsd", "web"]:
         env_harfbuzz.Append(CCFLAGS=["-DHAVE_PTHREAD"])
 
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
+    env_text_server_adv.AddExternalIncludes("#thirdparty/harfbuzz/src")
 
     lib = env_harfbuzz.add_library("harfbuzz_builtin", thirdparty_sources)
     thirdparty_obj += lib
@@ -237,7 +237,7 @@ if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_graphite.Prepend(CPPPATH=["#thirdparty/graphite/src", "#thirdparty/graphite/include"])
+    env_graphite.AddExternalIncludes(["#thirdparty/graphite/src", "#thirdparty/graphite/include"])
     env_graphite.Append(
         CCFLAGS=[
             "-DGRAPHITE2_STATIC",
@@ -480,13 +480,14 @@ if env["builtin_icu4c"]:
     icu_data_name = "icudt76l.dat"
 
     if env.editor_build:
-        env_icu.Depends("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name)
-        env_icu.Command("#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name, make_icu_data)
-        env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/"])
+        thirdparty_obj += env_icu.CommandNoCache(
+            "#thirdparty/icu4c/icudata.gen.h", "#thirdparty/icu4c/" + icu_data_name, env.Run(make_icu_data)
+        )
+        env_text_server_adv.AddExternalIncludes("#thirdparty/icu4c/")
     else:
         thirdparty_sources += ["icu_data/icudata_stub.cpp"]
 
-    env_icu.Prepend(CPPPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
+    env_icu.AddExternalIncludes(["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
     env_icu.Append(
         CXXFLAGS=[
             "-DU_STATIC_IMPLEMENTATION",
@@ -517,7 +518,7 @@ if env["builtin_icu4c"]:
     if env.editor_build:
         env_text_server_adv.Append(CXXFLAGS=["-DICU_STATIC_DATA"])
 
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
+    env_text_server_adv.AddExternalIncludes(["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
 
     lib = env_icu.add_library("icu_builtin", thirdparty_sources)
     thirdparty_obj += lib
@@ -541,19 +542,15 @@ if env["builtin_icu4c"]:
 module_obj = []
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
-    # Treat msdfgen headers as system headers to avoid raising warnings. Not supported on MSVC.
     env_text_server_adv.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    if not env.msvc:
-        env_text_server_adv.Append(CPPFLAGS=["-isystem", Dir("#thirdparty/msdfgen").path])
-    else:
-        env_text_server_adv.Prepend(CPPPATH=["#thirdparty/msdfgen"])
+    env_text_server_adv.AddExternalIncludes("#thirdparty/msdfgen")
 
 if env["builtin_freetype"] and freetype_enabled:
     env_text_server_adv.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/freetype/include"])
+    env_text_server_adv.AddExternalIncludes("#thirdparty/freetype/include")
 
 if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
-    env_text_server_adv.Prepend(CPPPATH=["#thirdparty/graphite/include"])
+    env_text_server_adv.AddExternalIncludes("#thirdparty/graphite/include")
 
 env_text_server_adv.add_source_files(module_obj, "*.cpp")
 env.modules_sources += module_obj

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -21,6 +21,7 @@ time_at_start = time.time()
 
 env = SConscript("./godot-cpp/SConstruct")
 env.__class__.disable_warnings = methods.disable_warnings
+env.__class__.AddExternalIncludes = methods.add_external_includes
 
 opts = Variables([], ARGUMENTS)
 opts.Add(BoolVariable("brotli_enabled", "Use Brotli library", True))
@@ -36,8 +37,13 @@ opts.Update(env)
 if not env["verbose"]:
     methods.no_verbose(env)
 
+# Allow marking includes as external/system to avoid raising warnings.
 if env["platform"] == "windows" and not env["use_mingw"]:
     env.AppendUnique(CCFLAGS=["/utf-8"])  # Force to use Unicode encoding.
+    env.AppendUnique(CPPFLAGS=["/external:W0"])
+    env["EXTHEADERPREFIX"] = "/external:I"
+else:
+    env["EXTHEADERPREFIX"] = "-isystem"
 
 # ThorVG
 if env["thorvg_enabled"] and env["freetype_enabled"]:
@@ -94,8 +100,8 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     ]
     thirdparty_tvg_sources = [thirdparty_tvg_dir + file for file in thirdparty_tvg_sources]
 
-    env_tvg.Append(
-        CPPPATH=[
+    env_tvg.AddExternalIncludes(
+        [
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/common",
             "../../../thirdparty/thorvg/src/renderer",
@@ -111,8 +117,8 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     # Enable ThorVG static object linking.
     env_tvg.Append(CPPDEFINES=["TVG_STATIC"])
 
-    env.Append(
-        CPPPATH=[
+    env.AddExternalIncludes(
+        [
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/common",
             "../../../thirdparty/thorvg/src/renderer",
@@ -154,8 +160,8 @@ if env["msdfgen_enabled"] and env["freetype_enabled"]:
     thirdparty_msdfgen_sources = [thirdparty_msdfgen_dir + file for file in thirdparty_msdfgen_sources]
 
     env_msdfgen.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    env_msdfgen.Append(CPPPATH=["../../../thirdparty/freetype/include", "../../../thirdparty/msdfgen"])
-    env.Append(CPPPATH=["../../../thirdparty/msdfgen"])
+    env_msdfgen.AddExternalIncludes(["../../../thirdparty/freetype/include", "../../../thirdparty/msdfgen"])
+    env.AddExternalIncludes("../../../thirdparty/msdfgen")
     env.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
     env.Append(CPPDEFINES=["MODULE_MSDFGEN_ENABLED"])
 
@@ -270,11 +276,11 @@ if env["freetype_enabled"]:
         ]
         thirdparty_freetype_sources += [thirdparty_brotli_dir + file for file in thirdparty_brotli_sources]
         env_freetype.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
-        env_freetype.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
+        env_freetype.AddExternalIncludes(thirdparty_brotli_dir + "include")
         env.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
 
-    env_freetype.Append(CPPPATH=[thirdparty_freetype_dir + "/include", thirdparty_zlib_dir, thirdparty_png_dir])
-    env.Append(CPPPATH=[thirdparty_freetype_dir + "/include"])
+    env_freetype.AddExternalIncludes([thirdparty_freetype_dir + "/include", thirdparty_zlib_dir, thirdparty_png_dir])
+    env.AddExternalIncludes(thirdparty_freetype_dir + "/include")
 
     env_freetype.Append(
         CPPDEFINES=[
@@ -381,8 +387,8 @@ if env["freetype_enabled"]:
     ]
 thirdparty_harfbuzz_sources = [thirdparty_harfbuzz_dir + file for file in thirdparty_harfbuzz_sources]
 
-env_harfbuzz.Append(
-    CPPPATH=[
+env_harfbuzz.AddExternalIncludes(
+    [
         "../../../thirdparty/harfbuzz/src",
         "../../../thirdparty/icu4c/common/",
         "../../../thirdparty/icu4c/i18n/",
@@ -390,8 +396,8 @@ env_harfbuzz.Append(
 )
 
 if env["freetype_enabled"]:
-    env_harfbuzz.Append(
-        CPPPATH=[
+    env_harfbuzz.AddExternalIncludes(
+        [
             "../../../thirdparty/freetype/include",
             "../../../thirdparty/graphite/include",
         ]
@@ -419,7 +425,7 @@ if env["freetype_enabled"]:
         ]
     )
 
-env.Append(CPPPATH=["../../../thirdparty/harfbuzz/src"])
+env.AddExternalIncludes("../../../thirdparty/harfbuzz/src")
 
 lib = env_harfbuzz.Library(
     f'harfbuzz_builtin{env["suffix"]}{env["LIBSUFFIX"]}',
@@ -472,7 +478,7 @@ if env["graphite_enabled"] and env["freetype_enabled"]:
 
     thirdparty_graphite_sources = [thirdparty_graphite_dir + file for file in thirdparty_graphite_sources]
 
-    env_graphite.Append(CPPPATH=["../../../thirdparty/graphite/src", "../../../thirdparty/graphite/include"])
+    env_graphite.AddExternalIncludes(["../../../thirdparty/graphite/src", "../../../thirdparty/graphite/include"])
     env_graphite.Append(
         CCFLAGS=[
             "-DGRAPHITE2_STATIC",
@@ -704,16 +710,15 @@ thirdparty_icu_sources = [thirdparty_icu_dir + file for file in thirdparty_icu_s
 icu_data_name = "icudt76l.dat"
 
 if env["static_icu_data"]:
-    env_icu.Depends("../../../thirdparty/icu4c/icudata.gen.h", "../../../thirdparty/icu4c/" + icu_data_name)
-    env_icu.Command(
+    thirdparty_icu_sources += env_icu.Command(
         "../../../thirdparty/icu4c/icudata.gen.h", "../../../thirdparty/icu4c/" + icu_data_name, methods.make_icu_data
     )
     env.Append(CXXFLAGS=["-DICU_STATIC_DATA"])
-    env.Append(CPPPATH=["../../../thirdparty/icu4c/"])
+    env.AddExternalIncludes("../../../thirdparty/icu4c/")
 else:
     thirdparty_icu_sources += ["../icu_data/icudata_stub.cpp"]
 
-env_icu.Append(CPPPATH=["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])
+env_icu.AddExternalIncludes(["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])
 env_icu.Append(
     CXXFLAGS=[
         "-DU_STATIC_IMPLEMENTATION",
@@ -740,7 +745,7 @@ env.Append(
         "-DICU_DATA_NAME=" + icu_data_name,
     ]
 )
-env.Append(CPPPATH=["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])
+env.AddExternalIncludes(["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])
 
 if env["platform"] == "windows":
     env.Append(LIBS=["advapi32"])

--- a/modules/text_server_adv/gdextension_build/methods.py
+++ b/modules/text_server_adv/gdextension_build/methods.py
@@ -50,6 +50,11 @@ def disable_warnings(self):
         self.AppendUnique(CCFLAGS=["-w"])
 
 
+def add_external_includes(self, dirs) -> None:
+    for dir in dirs if isinstance(dirs, list) else [dirs]:
+        self.AppendUnique(CPPFLAGS=["${EXTHEADERPREFIX}" + self.Dir(dir).path])
+
+
 def make_icu_data(target, source, env):
     dst = target[0].srcnode().abspath
     with open(dst, "w", encoding="utf-8", newline="\n") as g:

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -66,16 +66,10 @@ using namespace godot;
 // Thirdparty headers.
 
 #ifdef MODULE_MSDFGEN_ENABLED
-#ifdef _MSC_VER
-#pragma warning(disable : 4458)
-#endif
 #include <core/ShapeDistanceFinder.h>
 #include <core/contour-combiners.h>
 #include <core/edge-selectors.h>
 #include <msdfgen.h>
-#ifdef _MSC_VER
-#pragma warning(default : 4458)
-#endif
 #endif
 
 #ifdef MODULE_SVG_ENABLED

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -95,11 +95,6 @@ using namespace godot;
 
 // Thirdparty headers.
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
-#endif
-
 #include <unicode/ubidi.h>
 #include <unicode/ubrk.h>
 #include <unicode/uchar.h>
@@ -112,10 +107,6 @@ using namespace godot;
 #include <unicode/uspoof.h>
 #include <unicode/ustring.h>
 #include <unicode/utypes.h>
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 #ifdef MODULE_FREETYPE_ENABLED
 #include <ft2build.h>

--- a/modules/text_server_fb/SCsub
+++ b/modules/text_server_fb/SCsub
@@ -10,22 +10,18 @@ msdfgen_enabled = "msdfgen" in env.module_list
 env_text_server_fb = env_modules.Clone()
 
 if "svg" in env.module_list:
-    env_text_server_fb.Prepend(
-        CPPPATH=["#thirdparty/thorvg/inc", "#thirdparty/thorvg/src/common", "#thirdparty/thorvg/src/renderer"]
+    env_text_server_fb.AddExternalIncludes(
+        ["#thirdparty/thorvg/inc", "#thirdparty/thorvg/src/common", "#thirdparty/thorvg/src/renderer"]
     )
     # Enable ThorVG static object linking.
     env_text_server_fb.Append(CPPDEFINES=["TVG_STATIC"])
 
 if env["builtin_msdfgen"] and msdfgen_enabled:
-    # Treat msdfgen headers as system headers to avoid raising warnings. Not supported on MSVC.
     env_text_server_fb.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    if not env.msvc:
-        env_text_server_fb.Append(CPPFLAGS=["-isystem", Dir("#thirdparty/msdfgen").path])
-    else:
-        env_text_server_fb.Prepend(CPPPATH=["#thirdparty/msdfgen"])
+    env_text_server_fb.AddExternalIncludes("#thirdparty/msdfgen")
 
 if env["builtin_freetype"] and freetype_enabled:
     env_text_server_fb.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
-    env_text_server_fb.Prepend(CPPPATH=["#thirdparty/freetype/include"])
+    env_text_server_fb.AddExternalIncludes("#thirdparty/freetype/include")
 
 env_text_server_fb.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -21,6 +21,7 @@ time_at_start = time.time()
 
 env = SConscript("./godot-cpp/SConstruct")
 env.__class__.disable_warnings = methods.disable_warnings
+env.__class__.AddExternalIncludes = methods.add_external_includes
 
 opts = Variables([], ARGUMENTS)
 opts.Add(BoolVariable("brotli_enabled", "Use Brotli library", True))
@@ -33,6 +34,14 @@ opts.Update(env)
 
 if not env["verbose"]:
     methods.no_verbose(env)
+
+# Allow marking includes as external/system to avoid raising warnings.
+if env["platform"] == "windows" and not env["use_mingw"]:
+    env.AppendUnique(CCFLAGS=["/utf-8"])  # Force to use Unicode encoding.
+    env.AppendUnique(CPPFLAGS=["/external:W0"])
+    env["EXTHEADERPREFIX"] = "/external:I"
+else:
+    env["EXTHEADERPREFIX"] = "-isystem"
 
 # ThorVG
 if env["thorvg_enabled"] and env["freetype_enabled"]:
@@ -89,8 +98,8 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     ]
     thirdparty_tvg_sources = [thirdparty_tvg_dir + file for file in thirdparty_tvg_sources]
 
-    env_tvg.Append(
-        CPPPATH=[
+    env_tvg.AddExternalIncludes(
+        [
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/common",
             "../../../thirdparty/thorvg/src/renderer",
@@ -106,8 +115,8 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     # Enable ThorVG static object linking.
     env_tvg.Append(CPPDEFINES=["TVG_STATIC"])
 
-    env.Append(
-        CPPPATH=[
+    env.AddExternalIncludes(
+        [
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/common",
             "../../../thirdparty/thorvg/src/renderer",
@@ -149,8 +158,8 @@ if env["msdfgen_enabled"] and env["freetype_enabled"]:
     thirdparty_msdfgen_sources = [thirdparty_msdfgen_dir + file for file in thirdparty_msdfgen_sources]
 
     env_msdfgen.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    env_msdfgen.Append(CPPPATH=["../../../thirdparty/freetype/include", "../../../thirdparty/msdfgen"])
-    env.Append(CPPPATH=["../../../thirdparty/msdfgen"])
+    env_msdfgen.AddExternalIncludes(["../../../thirdparty/freetype/include", "../../../thirdparty/msdfgen"])
+    env.AddExternalIncludes("../../../thirdparty/msdfgen")
     env.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
     env.Append(CPPDEFINES=["MODULE_MSDFGEN_ENABLED"])
 
@@ -265,11 +274,11 @@ if env["freetype_enabled"]:
         ]
         thirdparty_freetype_sources += [thirdparty_brotli_dir + file for file in thirdparty_brotli_sources]
         env_freetype.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
-        env_freetype.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
+        env_freetype.AddExternalIncludes(thirdparty_brotli_dir + "include")
         env.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
 
-    env_freetype.Append(CPPPATH=[thirdparty_freetype_dir + "/include", thirdparty_zlib_dir, thirdparty_png_dir])
-    env.Append(CPPPATH=[thirdparty_freetype_dir + "/include"])
+    env_freetype.AddExternalIncludes([thirdparty_freetype_dir + "/include", thirdparty_zlib_dir, thirdparty_png_dir])
+    env.AddExternalIncludes(thirdparty_freetype_dir + "/include")
 
     env_freetype.Append(
         CPPDEFINES=[

--- a/modules/text_server_fb/gdextension_build/methods.py
+++ b/modules/text_server_fb/gdextension_build/methods.py
@@ -50,6 +50,11 @@ def disable_warnings(self):
         self.AppendUnique(CCFLAGS=["-w"])
 
 
+def add_external_includes(self, dirs) -> None:
+    for dir in dirs if isinstance(dirs, list) else [dirs]:
+        self.AppendUnique(CPPFLAGS=["${EXTHEADERPREFIX}" + self.Dir(dir).path])
+
+
 def make_icu_data(target, source, env):
     dst = target[0].srcnode().abspath
     with open(dst, "w", encoding="utf-8", newline="\n") as g:

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -61,16 +61,10 @@ using namespace godot;
 // Thirdparty headers.
 
 #ifdef MODULE_MSDFGEN_ENABLED
-#ifdef _MSC_VER
-#pragma warning(disable : 4458)
-#endif
 #include <core/ShapeDistanceFinder.h>
 #include <core/contour-combiners.h>
 #include <core/edge-selectors.h>
 #include <msdfgen.h>
-#ifdef _MSC_VER
-#pragma warning(default : 4458)
-#endif
 #endif
 
 #ifdef MODULE_FREETYPE_ENABLED

--- a/modules/theora/SCsub
+++ b/modules/theora/SCsub
@@ -79,13 +79,13 @@ if env["builtin_libtheora"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_theora.Prepend(CPPPATH=[thirdparty_dir])
+    env_theora.AddExternalIncludes(thirdparty_dir)
 
     # also requires libogg and libvorbis
     if env["builtin_libogg"]:
-        env_theora.Prepend(CPPPATH=["#thirdparty/libogg"])
+        env_theora.AddExternalIncludes("#thirdparty/libogg")
     if env["builtin_libvorbis"]:
-        env_theora.Prepend(CPPPATH=["#thirdparty/libvorbis"])
+        env_theora.AddExternalIncludes("#thirdparty/libvorbis")
 
     env_thirdparty = env_theora.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/tinyexr/SCsub
+++ b/modules/tinyexr/SCsub
@@ -17,7 +17,7 @@ thirdparty_sources = [
 ]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_tinyexr.Prepend(CPPPATH=[thirdparty_dir])
+env_tinyexr.AddExternalIncludes(thirdparty_dir)
 
 # Enable threaded loading with C++11.
 env_tinyexr.Append(CPPDEFINES=["TINYEXR_USE_THREAD"])

--- a/modules/upnp/SCsub
+++ b/modules/upnp/SCsub
@@ -29,13 +29,13 @@ if env["builtin_miniupnpc"] and env["platform"] != "web":
     ]
     thirdparty_sources = [thirdparty_dir + "src/" + file for file in thirdparty_sources]
 
-    env_upnp.Prepend(CPPPATH=[thirdparty_dir + "include"])
+    env_upnp.AddExternalIncludes(thirdparty_dir + "include")
     env_upnp.Append(CPPDEFINES=["MINIUPNP_STATICLIB"])
     if env["platform"] != "windows":
         env_upnp.Append(CPPDEFINES=["MINIUPNPC_SET_SOCKET_TIMEOUT"])
 
     env_thirdparty = env_upnp.Clone()
-    env_thirdparty.Prepend(CPPPATH=[thirdparty_dir + "include/miniupnpc"])
+    env_thirdparty.AddExternalIncludes(thirdparty_dir + "include/miniupnpc")
     env_thirdparty.disable_warnings()
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
     env.modules_sources += thirdparty_obj

--- a/modules/vhacd/SCsub
+++ b/modules/vhacd/SCsub
@@ -27,7 +27,7 @@ thirdparty_sources = [
 
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_vhacd.Prepend(CPPPATH=[thirdparty_dir + "inc"])
+env_vhacd.AddExternalIncludes(thirdparty_dir + "inc")
 
 env_thirdparty = env_vhacd.Clone()
 env_thirdparty.disable_warnings()

--- a/modules/vorbis/SCsub
+++ b/modules/vorbis/SCsub
@@ -42,11 +42,11 @@ if env["builtin_libvorbis"]:
 
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_vorbis.Prepend(CPPPATH=[thirdparty_dir])
+    env_vorbis.AddExternalIncludes(thirdparty_dir)
 
     # also requires libogg
     if env["builtin_libogg"]:
-        env_vorbis.Prepend(CPPPATH=["#thirdparty/libogg"])
+        env_vorbis.AddExternalIncludes("#thirdparty/libogg")
 
     env_thirdparty = env_vorbis.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/webp/SCsub
+++ b/modules/webp/SCsub
@@ -139,7 +139,7 @@ if env["builtin_libwebp"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_webp.Prepend(CPPPATH=[thirdparty_dir, thirdparty_dir + "src/"])
+    env_webp.AddExternalIncludes([thirdparty_dir, thirdparty_dir + "src/"])
 
     env_thirdparty = env_webp.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -23,7 +23,7 @@ elif env["builtin_wslay"]:
     ]
     thirdparty_sources = [thirdparty_dir + s for s in thirdparty_sources]
 
-    env_ws.Prepend(CPPPATH=[thirdparty_dir])
+    env_ws.AddExternalIncludes(thirdparty_dir)
     env_ws.Append(CPPDEFINES=["HAVE_CONFIG_H"])
 
     if env["platform"] == "windows":

--- a/modules/xatlas_unwrap/SCsub
+++ b/modules/xatlas_unwrap/SCsub
@@ -17,7 +17,7 @@ if env["builtin_xatlas"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    env_xatlas_unwrap.Prepend(CPPPATH=[thirdparty_dir])
+    env_xatlas_unwrap.AddExternalIncludes(thirdparty_dir)
 
     env_thirdparty = env_xatlas_unwrap.Clone()
     env_thirdparty.disable_warnings()

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -164,7 +164,7 @@ def configure(env: "SConsEnvironment"):
                 "$IOS_SDK_PATH/System/Library/Frameworks/QuartzCore.framework/Headers",
             ]
         )
-        env.Prepend(CPPPATH=["#thirdparty/spirv-cross"])
+        env.AddExternalIncludes("#thirdparty/spirv-cross")
 
     if env["vulkan"]:
         env.AppendUnique(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -305,7 +305,7 @@ def configure(env: "SConsEnvironment"):
 
     if not env["builtin_recastnavigation"]:
         # No pkgconfig file so far, hardcode default paths.
-        env.Prepend(CPPPATH=["/usr/include/recastnavigation"])
+        env.AddExternalIncludes("/usr/include/recastnavigation")
         env.Append(LIBS=["Recast"])
 
     if not env["builtin_embree"] and env["arch"] in ["x86_64", "arm64"]:
@@ -406,7 +406,7 @@ def configure(env: "SConsEnvironment"):
 
     env.Prepend(CPPPATH=["#platform/linuxbsd"])
     if env["use_sowrap"]:
-        env.Prepend(CPPPATH=["#thirdparty/linuxbsd_headers"])
+        env.AddExternalIncludes("#thirdparty/linuxbsd_headers")
 
     env.Append(
         CPPDEFINES=[
@@ -471,7 +471,7 @@ def configure(env: "SConsEnvironment"):
         if env["libdecor"]:
             env.Append(CPPDEFINES=["LIBDECOR_ENABLED"])
 
-        env.Prepend(CPPPATH=["#platform/linuxbsd", "#thirdparty/linuxbsd_headers/wayland/"])
+        env.AddExternalIncludes("#thirdparty/linuxbsd_headers/wayland/")
         env.Append(CPPDEFINES=["WAYLAND_ENABLED"])
         env.Append(LIBS=["rt"])  # Needed by glibc, used by _allocate_shm_file
 

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -231,7 +231,7 @@ def configure(env: "SConsEnvironment"):
             env.Append(LINKFLAGS=["-lANGLE.macos." + env["arch"]])
             env.Append(LINKFLAGS=["-lEGL.macos." + env["arch"]])
             env.Append(LINKFLAGS=["-lGLES.macos." + env["arch"]])
-        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+        env.AddExternalIncludes("#thirdparty/angle/include")
 
     env.Append(LINKFLAGS=["-rpath", "@executable_path/../Frameworks", "-rpath", "@executable_path"])
 
@@ -246,7 +246,7 @@ def configure(env: "SConsEnvironment"):
         extra_frameworks.add("Metal")
         extra_frameworks.add("MetalKit")
         extra_frameworks.add("MetalFX")
-        env.Prepend(CPPPATH=["#thirdparty/spirv-cross"])
+        env.AddExternalIncludes("#thirdparty/spirv-cross")
 
     if env["vulkan"]:
         env.AppendUnique(CPPDEFINES=["VULKAN_ENABLED", "RD_ENABLED"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -453,7 +453,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
 
     if vcvars_msvc_config:  # should be automatic if SCons found it
         if os.getenv("WindowsSdkDir") is not None:
-            env.Prepend(CPPPATH=[str(os.getenv("WindowsSdkDir")) + "/Include"])
+            env.AddExternalIncludes(str(os.getenv("WindowsSdkDir")) + "/Include")
         else:
             print_warning("Missing environment variable: WindowsSdkDir")
 
@@ -555,7 +555,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
                 "libGLES.windows." + env["arch"] + prebuilt_lib_extra_suffix,
             ]
             LIBS += ["dxgi", "d3d9", "d3d11"]
-        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+        env.AddExternalIncludes("#thirdparty/angle/include")
 
     if env["target"] in ["editor", "template_debug"]:
         LIBS += ["psapi", "dbghelp"]
@@ -594,7 +594,7 @@ def configure_msvc(env: "SConsEnvironment", vcvars_msvc_config):
         env.AppendUnique(ARFLAGS=["/LTCG"])
 
     if vcvars_msvc_config:
-        env.Prepend(CPPPATH=[p for p in str(os.getenv("INCLUDE")).split(";")])
+        env.AddExternalIncludes(str(os.getenv("INCLUDE")).split(";"))
         env.Append(LIBPATH=[p for p in str(os.getenv("LIB")).split(";")])
 
     # Incremental linking fix
@@ -896,7 +896,7 @@ def configure_mingw(env: "SConsEnvironment"):
                 ]
             )
             env.Append(LIBS=["dxgi", "d3d9", "d3d11"])
-        env.Prepend(CPPPATH=["#thirdparty/angle/include"])
+        env.AddExternalIncludes("#thirdparty/angle/include")
 
     env.Append(CPPDEFINES=["MINGW_ENABLED", ("MINGW_HAS_SECURE_API", 1)])
 

--- a/servers/rendering/renderer_rd/effects/SCsub
+++ b/servers/rendering/renderer_rd/effects/SCsub
@@ -13,7 +13,7 @@ thirdparty_dir = "#thirdparty/amd-fsr2/"
 thirdparty_sources = ["ffx_assert.cpp", "ffx_fsr2.cpp"]
 thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-env_effects.Prepend(CPPPATH=[thirdparty_dir])
+env_effects.AddExternalIncludes(thirdparty_dir)
 
 # This flag doesn't actually control anything GCC specific in FSR2. It determines
 # if symbols should be exported, which is not required for Godot.


### PR DESCRIPTION
I noticed that a few `SCsub` files were using a non-msvc exclusive method of suppressing warnings for external headers. It turns out that separation is no longer necessary; msvc has an equivalent implementation! Moreover, because this is now universal, the process can be safely applied to *all* thirdparty/external includes; this PR achieves that via `AddExternalIncludes`. In practice, this replaced the lion's share of Append/Prepend `CPPPATH` calls. This means that all remaining warning suppression wrappers around external `#include *` files are no longer necessary, and have also been cleaned up!