### PR TITLE
Show MetalFX options in the Scaling 3D Mode enum on all platforms

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3670,10 +3670,9 @@ void RenderingServer::init() {
 		{
 			Vector<String> mode_hints_arr = { "Bilinear (Fastest)", "FSR 1.0 (Fast)", "FSR 2.2 (Slow)" };
 			mode_hints = String(",").join(mode_hints_arr);
-#ifdef METAL_ENABLED
+
 			mode_hints_arr.push_back("MetalFX (Spatial)");
 			mode_hints_arr.push_back("MetalFX (Temporal)");
-#endif
 			mode_hints_metal = String(",").join(mode_hints_arr);
 		}
 


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/99603.

Previously, the MetalFX scaling modes were only displayed in the `macos` and `ios` feature tag overrides if the editor had Metal support enabled. However, this is only available on the macOS editor, which caused two issues:

- You couldn't set the 3D scaling mode to MetalFX for `macos` or `ios` if you were using the editor on another platform.
- If you opened a project that was last edited on macOS with MetalFX scaling modes set for these overrides, it would show an unknown value or revert to the default when saving to the project (as the enum value didn't exist anymore on your end).

I noticed this while rebasing https://github.com/godotengine/godot/pull/79731.

Not cherry-pickable to `4.3`, as MetalFX was only merged in 4.4.
