### PR TITLE
Save instance and global uniform data in RenderingServerDummy

### DIFF
--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -42,6 +42,8 @@ class MaterialStorage : public RendererMaterialStorage {
 private:
 	static MaterialStorage *singleton;
 
+	HashMap<StringName, RS::GlobalShaderParameterType> global_shader_variables;
+
 	struct DummyShader {
 		HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
 	};
@@ -49,6 +51,13 @@ private:
 	mutable RID_Owner<DummyShader> shader_owner;
 
 	ShaderCompiler dummy_compiler;
+
+	struct DummyMaterial {
+		RID shader;
+		RID next_pass;
+	};
+
+	mutable RID_Owner<DummyMaterial> material_owner;
 
 public:
 	static MaterialStorage *get_singleton() { return singleton; }
@@ -58,16 +67,16 @@ public:
 
 	/* GLOBAL SHADER UNIFORM API */
 
-	virtual void global_shader_parameter_add(const StringName &p_name, RS::GlobalShaderParameterType p_type, const Variant &p_value) override {}
-	virtual void global_shader_parameter_remove(const StringName &p_name) override {}
-	virtual Vector<StringName> global_shader_parameter_get_list() const override { return Vector<StringName>(); }
+	virtual void global_shader_parameter_add(const StringName &p_name, RS::GlobalShaderParameterType p_type, const Variant &p_value) override;
+	virtual void global_shader_parameter_remove(const StringName &p_name) override;
+	virtual Vector<StringName> global_shader_parameter_get_list() const override;
 
 	virtual void global_shader_parameter_set(const StringName &p_name, const Variant &p_value) override {}
 	virtual void global_shader_parameter_set_override(const StringName &p_name, const Variant &p_value) override {}
 	virtual Variant global_shader_parameter_get(const StringName &p_name) const override { return Variant(); }
-	virtual RS::GlobalShaderParameterType global_shader_parameter_get_type(const StringName &p_name) const override { return RS::GLOBAL_VAR_TYPE_MAX; }
+	virtual RS::GlobalShaderParameterType global_shader_parameter_get_type(const StringName &p_name) const override;
 
-	virtual void global_shader_parameters_load_settings(bool p_load_textures = true) override {}
+	virtual void global_shader_parameters_load_settings(bool p_load_textures = true) override;
 	virtual void global_shader_parameters_clear() override {}
 
 	virtual int32_t global_shader_parameters_instance_allocate(RID p_instance) override { return 0; }
@@ -95,23 +104,26 @@ public:
 	virtual RS::ShaderNativeSourceCode shader_get_native_source_code(RID p_shader) const override { return RS::ShaderNativeSourceCode(); }
 
 	/* MATERIAL API */
-	virtual RID material_allocate() override { return RID(); }
-	virtual void material_initialize(RID p_rid) override {}
-	virtual void material_free(RID p_rid) override {}
+
+	bool owns_material(RID p_rid) { return material_owner.owns(p_rid); }
+
+	virtual RID material_allocate() override;
+	virtual void material_initialize(RID p_rid) override;
+	virtual void material_free(RID p_rid) override;
 
 	virtual void material_set_render_priority(RID p_material, int priority) override {}
-	virtual void material_set_shader(RID p_shader_material, RID p_shader) override {}
+	virtual void material_set_shader(RID p_shader_material, RID p_shader) override;
 
 	virtual void material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) override {}
 	virtual Variant material_get_param(RID p_material, const StringName &p_param) const override { return Variant(); }
 
-	virtual void material_set_next_pass(RID p_material, RID p_next_material) override {}
+	virtual void material_set_next_pass(RID p_material, RID p_next_material) override;
 
 	virtual bool material_is_animated(RID p_material) override { return false; }
 	virtual bool material_casts_shadows(RID p_material) override { return false; }
 	virtual RS::CullMode material_get_cull_mode(RID p_material) const override { return RS::CULL_MODE_DISABLED; }
 
-	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override {}
+	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override;
 	virtual void material_update_dependency(RID p_material, DependencyTracker *p_instance) override {}
 };
 

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -77,6 +77,9 @@ public:
 		} else if (RendererDummy::MaterialStorage::get_singleton()->owns_shader(p_rid)) {
 			RendererDummy::MaterialStorage::get_singleton()->shader_free(p_rid);
 			return true;
+		} else if (RendererDummy::MaterialStorage::get_singleton()->owns_material(p_rid)) {
+			RendererDummy::MaterialStorage::get_singleton()->material_free(p_rid);
+			return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
- Fixes: https://github.com/godotengine/godot/issues/66842
*Bugsquad edit:*
- Fixes #102362
- Fixes #102364

We need to expose the material in RenderingServerDummy, but just enough to access the shader which already has all the data we need. 

For GlobalShaderParameters, we didn't need to do anything, they were already working, but exporting with them in the scene caused an annoying error to be printed during export. 

However, GlobalShaderParameter overrides weren't working (and no one reported it). So these changes both fix the error during export and fix GlobalShaderParameter overrides. 

I also did a search of every scene class' `_get_property_list()` to see if there are other places where we need to retrieve data from the RenderingServer and didn't find anything. We should be exporting everything we need now. 