### PR TITLE
[3.x] Physics Interpolation - Auto-reset on `set_physics_interpolation_mode()`

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -294,6 +294,7 @@ void Camera2D::_notification(int p_what) {
 			// Force the limits etc to update.
 			_interpolation_data.xform_curr = get_camera_transform();
 			_interpolation_data.xform_prev = _interpolation_data.xform_curr;
+			_update_process_mode();
 		} break;
 		case NOTIFICATION_PAUSED: {
 			if (is_physics_interpolated_and_enabled()) {

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -224,6 +224,7 @@ void Camera::_notification(int p_what) {
 			if (is_inside_tree()) {
 				_interpolation_data.xform_curr = get_global_transform();
 				_interpolation_data.xform_prev = _interpolation_data.xform_curr;
+				_update_process_mode();
 			}
 		} break;
 		case NOTIFICATION_PAUSED: {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -894,13 +894,12 @@ void Node::set_physics_interpolation_mode(PhysicsInterpolationMode p_mode) {
 		} break;
 	}
 
-	// if swapping from interpolated to non-interpolated, use this as
-	// an extra means to cause a reset
-	if (is_physics_interpolated() && !interpolate && is_inside_tree()) {
+	_propagate_physics_interpolated(interpolate);
+
+	// Auto-reset on changing interpolation mode.
+	if (is_physics_interpolated() && is_inside_tree()) {
 		propagate_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 	}
-
-	_propagate_physics_interpolated(interpolate);
 }
 
 void Node::reset_physics_interpolation() {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -537,6 +537,11 @@ void SceneTree::set_physics_interpolation_enabled(bool p_enabled) {
 
 	_physics_interpolation_enabled = p_enabled;
 	VisualServer::get_singleton()->set_physics_interpolation_enabled(p_enabled);
+
+	// Perform an auto reset on the root node for convenience for the user.
+	if (root) {
+		root->reset_physics_interpolation();
+	}
 }
 
 bool SceneTree::is_physics_interpolation_enabled() const {


### PR DESCRIPTION
Fixes historical bug where auto-reset wasn't working correctly.
Also fixes keeping process mode up to date in Cameras when changing physics interpolation mode. 

Fixes #101192 for 3.x
(non-hidden aspects, will likely have to wait until general unhiding is addressed for hidden to work automatically - this is on the todo list) 

## Notes
* Looking back through the history this appears just to be a historical bug in a rarely used section of code.
* It looks possible that `interpolate` may have earlier been the previous interpolate state, hence why the bug crept in.
* The `reset` is moved _after_ the propagate of the interpolation state to ensure it is properly executed in children.
* Changing interpolation mode isn't really designed for use at runtime (it is usually done in the editor where interpolation is always disabled) so this had never come up before.
* Also adds an auto-reset when changing global interpolation on / off switch in `SceneTree`.
* Also fixes up `Camera` and `Camera2D`, which didn't properly respect changes to mode at runtime - they need their process mode updating.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
