### PR TITLE
Remove dead code in `DynamicBVH`

### DIFF
--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -394,17 +394,6 @@ void DynamicBVH::remove(const ID &p_id) {
 	--total_leaves;
 }
 
-void DynamicBVH::_extract_leaves(Node *p_node, List<ID> *r_elements) {
-	if (p_node->is_internal()) {
-		_extract_leaves(p_node->children[0], r_elements);
-		_extract_leaves(p_node->children[1], r_elements);
-	} else {
-		ID id;
-		id.node = p_node;
-		r_elements->push_back(id);
-	}
-}
-
 void DynamicBVH::set_index(uint32_t p_index) {
 	ERR_FAIL_COND(bvh_root != nullptr);
 	index = p_index;
@@ -412,12 +401,6 @@ void DynamicBVH::set_index(uint32_t p_index) {
 
 uint32_t DynamicBVH::get_index() const {
 	return index;
-}
-
-void DynamicBVH::get_elements(List<ID> *r_elements) {
-	if (bvh_root) {
-		_extract_leaves(bvh_root, r_elements);
-	}
 }
 
 int DynamicBVH::get_leaf_count() const {

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -247,8 +247,6 @@ private:
 
 	_FORCE_INLINE_ void _update(Node *leaf, int lookahead = -1);
 
-	void _extract_leaves(Node *p_node, List<ID> *r_elements);
-
 	_FORCE_INLINE_ bool _ray_aabb(const Vector3 &rayFrom, const Vector3 &rayInvDirection, const unsigned int raySign[3], const Vector3 bounds[2], real_t &tmin, real_t lambda_min, real_t lambda_max) {
 		real_t tmax, tymin, tymax, tzmin, tzmax;
 		tmin = (bounds[raySign[0]].x - rayFrom.x) * rayInvDirection.x;
@@ -293,7 +291,6 @@ public:
 	ID insert(const AABB &p_box, void *p_userdata);
 	bool update(const ID &p_id, const AABB &p_box);
 	void remove(const ID &p_id);
-	void get_elements(List<ID> *r_elements);
 
 	int get_leaf_count() const;
 	int get_max_depth() const;


### PR DESCRIPTION
It seems that no one calls `DynamicBVH::get_elements`. Should be safe to remove.
