### PR TITLE
Update official export templates architecture list in docs

### DIFF
--- a/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
+++ b/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
@@ -12,7 +12,7 @@
 		<member name="binary_format/architecture" type="String" setter="" getter="">
 			Application executable architecture.
 			Supported architectures: [code]x86_32[/code], [code]x86_64[/code], [code]arm64[/code], [code]arm32[/code], [code]rv64[/code], [code]ppc64[/code], [code]ppc32[/code], and [code]loongarch64[/code].
-			Official export templates include [code]x86_32[/code] and [code]x86_64[/code] binaries only.
+			Official export templates include [code]x86_32[/code], [code]x86_64[/code], [code]arm32[/code], and [code]arm64[/code] binaries only.
 		</member>
 		<member name="binary_format/embed_pck" type="bool" setter="" getter="">
 			If [code]true[/code], project resources are embedded into the executable.

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -55,7 +55,6 @@
 		<member name="binary_format/architecture" type="String" setter="" getter="">
 			Application executable architecture.
 			Supported architectures: [code]x86_32[/code], [code]x86_64[/code], and [code]arm64[/code].
-			Official export templates include [code]x86_32[/code] and [code]x86_64[/code] binaries only.
 		</member>
 		<member name="binary_format/embed_pck" type="bool" setter="" getter="">
 			If [code]true[/code], project resources are embedded into the executable.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Noticed some outdated docs about architectures included in official export templates.
Docs:
![изображение](https://github.com/user-attachments/assets/ed6940e6-1d31-4837-8662-597ac1626fbd)
![изображение](https://github.com/user-attachments/assets/51bcb0a3-33a0-42ce-a724-48bec388d402)
Actual:
![изображение](https://github.com/user-attachments/assets/b1d9924f-9481-4583-bae2-35067bafdadf)
![изображение](https://github.com/user-attachments/assets/7a7eed7a-99da-45de-9327-9f79b8d56fc3)
