### PR TITLE
Fix debug contact count not being initialized when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
@@ -93,7 +93,7 @@ class JoltContactListener3D final
 
 #ifdef DEBUG_ENABLED
 	PackedVector3Array debug_contacts;
-	std::atomic_int debug_contact_count;
+	std::atomic_int debug_contact_count = 0;
 #endif
 
 	virtual void OnContactAdded(const JPH::Body &p_body1, const JPH::Body &p_body2, const JPH::ContactManifold &p_manifold, JPH::ContactSettings &p_settings) override;


### PR DESCRIPTION
Fixes #101212.

This adds a zeroing out of the `JoltContactListener3D::debug_contact_count` member variable.

Without this you would (at least with the libstdc++ implementation of `std::atomic`) end up with a random (typically large) value on the first engine iteration in optimized builds, which caused out-of-bounds crashes when using the "Visible Collision Shapes" debug option, aka `--debug-collisions`.