### PR TITLE
Optimize calls of `utf8` in a few spots to avoid calling it more than once.

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -311,18 +311,16 @@ bool FileAccessUnix::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 }
 
 bool FileAccessUnix::file_exists(const String &p_path) {
-	int err;
 	struct stat st = {};
-	String filename = fix_path(p_path);
+	const CharString filename_utf8 = fix_path(p_path).utf8();
 
 	// Does the name exist at all?
-	err = stat(filename.utf8().get_data(), &st);
-	if (err) {
+	if (stat(filename_utf8.get_data(), &st)) {
 		return false;
 	}
 
 	// See if we have access to the file
-	if (access(filename.utf8().get_data(), F_OK)) {
+	if (access(filename_utf8.get_data(), F_OK)) {
 		return false;
 	}
 

--- a/drivers/unix/file_access_unix_pipe.cpp
+++ b/drivers/unix/file_access_unix_pipe.cpp
@@ -67,10 +67,12 @@ Error FileAccessUnixPipe::open_internal(const String &p_path, int p_mode_flags) 
 	ERR_FAIL_COND_V_MSG(fd[0] >= 0 || fd[1] >= 0, ERR_ALREADY_IN_USE, "Pipe is already in use.");
 
 	path = String("/tmp/") + p_path.replace("pipe://", "").replace("/", "_");
+	const CharString path_utf8 = path.utf8();
+
 	struct stat st = {};
-	int err = stat(path.utf8().get_data(), &st);
+	int err = stat(path_utf8.get_data(), &st);
 	if (err) {
-		if (mkfifo(path.utf8().get_data(), 0600) != 0) {
+		if (mkfifo(path_utf8.get_data(), 0600) != 0) {
 			last_error = ERR_FILE_CANT_OPEN;
 			return last_error;
 		}
@@ -79,7 +81,7 @@ Error FileAccessUnixPipe::open_internal(const String &p_path, int p_mode_flags) 
 		ERR_FAIL_COND_V_MSG(!S_ISFIFO(st.st_mode), ERR_ALREADY_IN_USE, "Pipe name is already used by file.");
 	}
 
-	int f = ::open(path.utf8().get_data(), O_RDWR | O_CLOEXEC | O_NONBLOCK);
+	int f = ::open(path_utf8.get_data(), O_RDWR | O_CLOEXEC | O_NONBLOCK);
 	if (f < 0) {
 		switch (errno) {
 			case ENOENT: {

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1685,8 +1685,8 @@ void EditorExportPlatform::zip_folder_recursive(zipFile &p_zip, const String &p_
 					0x0314, // "version made by", 0x03 - Unix, 0x14 - ZIP specification version 2.0, required to store Unix file permissions
 					1 << 11); // Bit 11 is the language encoding flag. When set, filename and comment fields must be encoded using UTF-8.
 
-			String target = da->read_link(f);
-			zipWriteInFileInZip(p_zip, target.utf8().get_data(), target.utf8().size());
+			const CharString target_utf8 = da->read_link(f).utf8();
+			zipWriteInFileInZip(p_zip, target_utf8.get_data(), target_utf8.size());
 			zipCloseFileInZip(p_zip);
 		} else if (da->current_is_dir()) {
 			zip_folder_recursive(p_zip, p_root_path, p_folder.path_join(f), p_pkg_name);

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -99,10 +99,11 @@ Error CryptoKeyMbedTLS::save(const String &p_path, bool p_public_only) {
 
 Error CryptoKeyMbedTLS::load_from_string(const String &p_string_key, bool p_public_only) {
 	int ret = 0;
+	const CharString string_key_utf8 = p_string_key.utf8();
 	if (p_public_only) {
-		ret = mbedtls_pk_parse_public_key(&pkey, (unsigned char *)p_string_key.utf8().get_data(), p_string_key.utf8().size());
+		ret = mbedtls_pk_parse_public_key(&pkey, (const unsigned char *)string_key_utf8.get_data(), string_key_utf8.size());
 	} else {
-		ret = _parse_key((unsigned char *)p_string_key.utf8().get_data(), p_string_key.utf8().size());
+		ret = _parse_key((const unsigned char *)string_key_utf8.get_data(), string_key_utf8.size());
 	}
 	ERR_FAIL_COND_V_MSG(ret, FAILED, "Error parsing key '" + itos(ret) + "'.");
 


### PR DESCRIPTION
Kind of a follow-up to #99893.

For the record, I used the following search key to find more instances of the same problem:
```regex
(\w+)\.utf8\(\)(.|\n)*\1\.utf8
```
