### PR TITLE
Fix gui overflow in Android editor

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -50,6 +50,7 @@
 #include "scene/animation/tween.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/color_picker.h"
+#include "scene/gui/flow_container.h"
 #include "scene/gui/grid_container.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
@@ -7606,31 +7607,34 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	track_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
 	scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 
-	HBoxContainer *bottom_hb = memnew(HBoxContainer);
-	add_child(bottom_hb);
+	HFlowContainer *bottom_hf = memnew(HFlowContainer);
+	add_child(bottom_hf);
 
 	imported_anim_warning = memnew(Button);
 	imported_anim_warning->hide();
 	imported_anim_warning->set_text(TTR("Imported Scene"));
 	imported_anim_warning->set_tooltip_text(TTR("Warning: Editing imported animation"));
 	imported_anim_warning->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_show_imported_anim_warning));
-	bottom_hb->add_child(imported_anim_warning);
+	bottom_hf->add_child(imported_anim_warning);
 
 	dummy_player_warning = memnew(Button);
 	dummy_player_warning->hide();
 	dummy_player_warning->set_text(TTR("Dummy Player"));
 	dummy_player_warning->set_tooltip_text(TTR("Warning: Editing dummy AnimationPlayer"));
 	dummy_player_warning->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_show_dummy_player_warning));
-	bottom_hb->add_child(dummy_player_warning);
+	bottom_hf->add_child(dummy_player_warning);
 
 	inactive_player_warning = memnew(Button);
 	inactive_player_warning->hide();
 	inactive_player_warning->set_text(TTR("Inactive Player"));
 	inactive_player_warning->set_tooltip_text(TTR("Warning: AnimationPlayer is inactive"));
 	inactive_player_warning->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_show_inactive_player_warning));
-	bottom_hb->add_child(inactive_player_warning);
+	bottom_hf->add_child(inactive_player_warning);
 
-	bottom_hb->add_spacer();
+	Control *spacer = memnew(Control);
+	spacer->set_mouse_filter(MOUSE_FILTER_PASS);
+	spacer->set_h_size_flags(SIZE_EXPAND_FILL);
+	bottom_hf->add_child(spacer);
 
 	bezier_edit_icon = memnew(Button);
 	bezier_edit_icon->set_flat(true);
@@ -7639,7 +7643,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	bezier_edit_icon->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_toggle_bezier_edit));
 	bezier_edit_icon->set_tooltip_text(TTR("Toggle between the bezier curve editor and track editor."));
 
-	bottom_hb->add_child(bezier_edit_icon);
+	bottom_hf->add_child(bezier_edit_icon);
 
 	selected_filter = memnew(Button);
 	selected_filter->set_flat(true);
@@ -7647,7 +7651,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	selected_filter->set_toggle_mode(true);
 	selected_filter->set_tooltip_text(TTR("Only show tracks from nodes selected in tree."));
 
-	bottom_hb->add_child(selected_filter);
+	bottom_hf->add_child(selected_filter);
 
 	view_group = memnew(Button);
 	view_group->set_flat(true);
@@ -7655,12 +7659,12 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	view_group->set_toggle_mode(true);
 	view_group->set_tooltip_text(TTR("Group tracks by node or display them as plain list."));
 
-	bottom_hb->add_child(view_group);
-	bottom_hb->add_child(memnew(VSeparator));
+	bottom_hf->add_child(view_group);
+	bottom_hf->add_child(memnew(VSeparator));
 
 	snap_timeline = memnew(Button);
 	snap_timeline->set_flat(true);
-	bottom_hb->add_child(snap_timeline);
+	bottom_hf->add_child(snap_timeline);
 	snap_timeline->set_disabled(true);
 	snap_timeline->set_toggle_mode(true);
 	snap_timeline->set_pressed(false);
@@ -7668,7 +7672,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	snap_keys = memnew(Button);
 	snap_keys->set_flat(true);
-	bottom_hb->add_child(snap_keys);
+	bottom_hf->add_child(snap_keys);
 	snap_keys->set_disabled(true);
 	snap_keys->set_toggle_mode(true);
 	snap_keys->set_pressed(true);
@@ -7676,7 +7680,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	fps_compat = memnew(Button);
 	fps_compat->set_flat(true);
-	bottom_hb->add_child(fps_compat);
+	bottom_hf->add_child(fps_compat);
 	fps_compat->set_disabled(true);
 	fps_compat->set_toggle_mode(true);
 	fps_compat->set_pressed(true);
@@ -7684,7 +7688,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	fps_compat->connect(SceneStringName(toggled), callable_mp(this, &AnimationTrackEditor::_update_fps_compat_mode));
 
 	nearest_fps_label = memnew(Label);
-	bottom_hb->add_child(nearest_fps_label);
+	bottom_hf->add_child(nearest_fps_label);
 
 	step = memnew(EditorSpinSlider);
 	step->set_min(0);
@@ -7693,22 +7697,23 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	step->set_hide_slider(true);
 	step->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 	step->set_tooltip_text(TTR("Animation step value."));
-	bottom_hb->add_child(step);
+	bottom_hf->add_child(step);
 	step->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_update_step));
 	step->set_read_only(true);
 
 	snap_mode = memnew(OptionButton);
 	snap_mode->add_item(TTR("Seconds"));
 	snap_mode->add_item(TTR("FPS"));
-	bottom_hb->add_child(snap_mode);
+	bottom_hf->add_child(snap_mode);
 	snap_mode->connect(SceneStringName(item_selected), callable_mp(this, &AnimationTrackEditor::_snap_mode_changed));
 	snap_mode->set_disabled(true);
 
-	bottom_hb->add_child(memnew(VSeparator));
+	bottom_hf->add_child(memnew(VSeparator));
 
+	HBoxContainer *zoom_hb = memnew(HBoxContainer);
 	zoom_icon = memnew(TextureRect);
 	zoom_icon->set_v_size_flags(SIZE_SHRINK_CENTER);
-	bottom_hb->add_child(zoom_icon);
+	zoom_hb->add_child(zoom_icon);
 	zoom = memnew(HSlider);
 	zoom->set_step(0.01);
 	zoom->set_min(0.0);
@@ -7716,7 +7721,8 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	zoom->set_value(1.0);
 	zoom->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	zoom->set_v_size_flags(SIZE_SHRINK_CENTER);
-	bottom_hb->add_child(zoom);
+	zoom_hb->add_child(zoom);
+	bottom_hf->add_child(zoom_hb);
 	timeline->set_zoom(zoom);
 
 	ED_SHORTCUT("animation_editor/auto_fit", TTRC("Fit to panel"), KeyModifierMask::ALT | Key::F);
@@ -7725,14 +7731,14 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	auto_fit->set_flat(true);
 	auto_fit->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_auto_fit));
 	auto_fit->set_shortcut(ED_GET_SHORTCUT("animation_editor/auto_fit"));
-	bottom_hb->add_child(auto_fit);
+	bottom_hf->add_child(auto_fit);
 
 	auto_fit_bezier = memnew(Button);
 	auto_fit_bezier->set_flat(true);
 	auto_fit_bezier->set_visible(false);
 	auto_fit_bezier->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_auto_fit_bezier));
 	auto_fit_bezier->set_shortcut(ED_GET_SHORTCUT("animation_editor/auto_fit"));
-	bottom_hb->add_child(auto_fit_bezier);
+	bottom_hf->add_child(auto_fit_bezier);
 
 	edit = memnew(MenuButton);
 	edit->set_shortcut_context(this);


### PR DESCRIPTION
This PR addresses the Android editor gui overflow issue caused by the packed bottom bar of the Animation Editor. The problem occurs when the bottom bar's content exceeds the available screen width, resulting in the interface extending off-screen.

It replaces the existing `HBoxContainer` with `HFlowContainer` to allow it to wrap when there isn't enough horizontal space.

Closes https://github.com/godotengine/godot/issues/100688