### PR TITLE
Style: Unify `.editorconfig` logic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,24 +3,18 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
+indent_size = 4
 indent_style = tab
 insert_final_newline = true
-
-[*.{cpp,hpp,c,h,mm}]
+max_line_length = 120
 trim_trailing_whitespace = true
-
-[{*.gradle,AndroidManifest.xml}]
-indent_style = space
-indent_size = 4
 
 [{*.py,SConstruct,SCsub}]
 indent_style = space
-indent_size = 4
 
-# YAML requires indentation with spaces instead of tabs.
 [{*.{yml,yaml},.clang{-format,-tidy,d}}]
-indent_style = space
 indent_size = 2
+indent_style = space
 
 [*.svg]
 insert_final_newline = false

--- a/modules/gdscript/.editorconfig
+++ b/modules/gdscript/.editorconfig
@@ -1,3 +1,0 @@
-[*.gd]
-indent_size = 4
-trim_trailing_whitespace = true

--- a/modules/mono/.editorconfig
+++ b/modules/mono/.editorconfig
@@ -2,21 +2,14 @@
 end_of_line = crlf
 charset = utf-8-bom
 
-[*.sln]
-indent_style = tab
-
 [*.{csproj,props,targets,nuspec,resx}]
 indent_style = space
 indent_size = 2
 
 [*.cs]
 indent_style = space
-indent_size = 4
-insert_final_newline = true
-trim_trailing_whitespace = true
-max_line_length = 120
-csharp_indent_case_contents_when_block = false
 
+csharp_indent_case_contents_when_block = false
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true

--- a/platform/android/.editorconfig
+++ b/platform/android/.editorconfig
@@ -1,0 +1,2 @@
+[{*.gradle,AndroidManifest.xml}]
+indent_style = space


### PR DESCRIPTION
This aims to make our root `.editorconfig` much more centralized, applying more options by default across all files. This will make it easier to manually discern discrepancies and how to amend them, instead of letting them be either erroneously unformatted or have different behavior depending on the user's IDE. Any module/platform specific options can have their options isolated, similar to what `mono` is already doing; though some redundancies were removed as a result of the unified root.