### PR TITLE
Cache value of Jolt Physics project setting `bounce_velocity_threshold`

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2464,6 +2464,7 @@
 		</member>
 		<member name="physics/jolt_physics_3d/simulation/bounce_velocity_threshold" type="float" setter="" getter="" default="1.0">
 			The minimum velocity needed before a collision can be bouncy, in meters per second.
+			[b]Note:[/b] This setting will only be read once during the lifetime of the application.
 		</member>
 		<member name="physics/jolt_physics_3d/simulation/continuous_cd_max_penetration" type="float" setter="" getter="" default="0.25">
 			Fraction of a body's inner radius that may penetrate another body while using continuous collision detection.

--- a/modules/jolt_physics/jolt_project_settings.cpp
+++ b/modules/jolt_physics/jolt_project_settings.cpp
@@ -119,7 +119,8 @@ float JoltProjectSettings::get_soft_body_point_radius() {
 }
 
 float JoltProjectSettings::get_bounce_velocity_threshold() {
-	return GLOBAL_GET("physics/jolt_physics_3d/simulation/bounce_velocity_threshold");
+	static const float value = GLOBAL_GET("physics/jolt_physics_3d/simulation/bounce_velocity_threshold");
+	return value;
 }
 
 bool JoltProjectSettings::is_sleep_allowed() {


### PR DESCRIPTION
Currently a number of Jolt-related project settings are being cached after their initial read, due to being used in potentially hot codepaths where the overhead and/or thread synchronization from `ProjectSettings::get_setting_with_override` and `StringName` may be detrimental to performance.

This pull request makes that same change to the `physics/jolt_physics_3d/simulation/bounce_velocity_threshold` project setting, which is currently being read in `JoltContactListener3D::_try_add_contacts` (see [here](https://github.com/godotengine/godot/blob/aa65940a8509fb880e2c666eb8a901525d9200ff/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp#L203)) which is potentially executed in parallel from multiple threads during the simulation step, and as such would likely suffer from the thread synchronization mentioned above.

I'll admit I haven't profiled this, but it's a small and risk-free change either way.

(This is also already happening in the Godot Jolt extension, where every project setting is cached on first read, in case there's any worry about correctness.)