### PR TITLE
LRU-Cache font height to optimize repeated calls.

### DIFF
--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -127,6 +127,7 @@ void Font::_invalidate_rids() {
 
 	cache.clear();
 	cache_wrap.clear();
+	cache_height.clear();
 
 	emit_changed();
 }
@@ -207,14 +208,16 @@ TypedArray<RID> Font::get_rids() const {
 
 // Drawing string.
 real_t Font::get_height(int p_font_size) const {
-	if (dirty_rids) {
-		_update_rids();
+	if (cache_height.has(p_font_size)) {
+		return cache_height.get(p_font_size);
 	}
 	real_t ret = 0.f;
 	for (int i = 0; i < rids.size(); i++) {
 		ret = MAX(ret, TS->font_get_ascent(rids[i], p_font_size) + TS->font_get_descent(rids[i], p_font_size));
 	}
-	return ret + get_spacing(TextServer::SPACING_BOTTOM) + get_spacing(TextServer::SPACING_TOP);
+	ret += get_spacing(TextServer::SPACING_BOTTOM) + get_spacing(TextServer::SPACING_TOP);
+	cache_height.insert(p_font_size, ret);
+	return ret;
 }
 
 real_t Font::get_ascent(int p_font_size) const {
@@ -564,6 +567,7 @@ int64_t Font::get_face_count() const {
 Font::Font() {
 	cache.set_capacity(64);
 	cache_wrap.set_capacity(16);
+	cache_height.set_capacity(16);
 }
 
 Font::~Font() {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -84,6 +84,7 @@ class Font : public Resource {
 	// Shaped string cache.
 	mutable LRUCache<ShapedTextKey, Ref<TextLine>, ShapedTextKeyHasher> cache;
 	mutable LRUCache<ShapedTextKey, Ref<TextParagraph>, ShapedTextKeyHasher> cache_wrap;
+	mutable LRUCache<int, real_t, HashHasher> cache_height;
 
 protected:
 	// Output.


### PR DESCRIPTION
I profiled the launch of the Godot launcher.
Calls to `Font.get_height` took up to half of the launch time. I found this to be peculiar given that Godot doesn't use _that_ many font and font size combinations.

I use a simple 16-size LRU cache to reduce the number of recalculations. I don't use a hashing algorithm (`HashHasher` returns the input verbatim), so collisions are expected with multiples of 16. I think collisions are unlikely, and the speed up of cache hits are worth the overhead of the LRU cache in most scenarios. The additional RAM use of the cache is also unlikely to be a factor, I think.

## Effects

This change reduced the launch time of the Godot launcher by 17%, from `3.03Gc` (`1.4Gc` of which were `get_height` calls) to `2.53Gc` (`0.54Gc` of which were `get_height` calls). This suggests this PR can shortcut a total of ``2/3`` of the `get_height` calls.

I am aware the improvement in speed is not consistent with the improvement of `get_height` call (~1Gc vs ~0.5Gc), I'm not sure why that is. However, the numbers are consistent across launches.

## Notes

I first tried caching the height in the most common caller, `Label`. This unfortunately didn't improve the launch time much. I'm guessing this is because caching is already happening higher up in the UI chain.