### PR TITLE
Fix menus and dropdowns requiring two clicks

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -151,11 +151,13 @@ void BaseButton::_toggled(bool p_pressed) {
 void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 	Ref<InputEventMouseButton> mouse_button = p_event;
 
-	if (!status.pressed_down_with_focus && p_event->is_pressed() && (mouse_button.is_null() || status.hovering)) {
+	if (p_event->is_pressed() && (mouse_button.is_null() || status.hovering)) {
 		status.press_attempt = true;
 		status.pressing_inside = true;
-		status.pressed_down_with_focus = true;
-		emit_signal(SNAME("button_down"));
+		if (!status.pressed_down_with_focus) {
+			status.pressed_down_with_focus = true;
+			emit_signal(SNAME("button_down"));
+		}
 	}
 
 	if (status.press_attempt && status.pressing_inside) {
@@ -181,11 +183,13 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 		}
 	}
 
-	if (status.pressed_down_with_focus && !p_event->is_pressed()) {
+	if (!p_event->is_pressed()) {
 		status.press_attempt = false;
 		status.pressing_inside = false;
-		status.pressed_down_with_focus = false;
-		emit_signal(SNAME("button_up"));
+		if (status.pressed_down_with_focus) {
+			status.pressed_down_with_focus = false;
+			emit_signal(SNAME("button_up"));
+		}
 	}
 
 	queue_redraw();


### PR DESCRIPTION
Fixes #101214. Makes handling of all pressed status elements consistent on toggle buttons with `ACTION_MODE_BUTTON_PRESSED`.


https://github.com/user-attachments/assets/27b88e0f-9cc5-463d-9fab-98fcbd45f3b1

