### PR TITLE
Add warning to `InputMap.load_from_project_settings()` about running it in a tool script

### DIFF
--- a/doc/classes/InputMap.xml
+++ b/doc/classes/InputMap.xml
@@ -107,6 +107,7 @@
 			<return type="void" />
 			<description>
 				Clears all [InputEventAction] in the [InputMap] and load it anew from [ProjectSettings].
+				[b]Warning:[/b] Calling this method inside a [code]tool[/code] script will cause certain editor-specific inputs to stop working.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

For example, it will break 3D viewports navigation because those rely on the editor action system, which is being overwritten. 

See: https://github.com/godotengine/godot/pull/54513
