### PR TITLE
Make`per_pixel_transparency` enabled by default

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -846,8 +846,8 @@
 			If [code]true[/code], it will require two swipes to access iOS UI that uses gestures.
 			[b]Note:[/b] This setting has no effect on the home indicator if [code]hide_home_indicator[/code] is [code]true[/code].
 		</member>
-		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, so leave it on [code]false[/code] unless you need it. See also [member display/window/size/transparent] and [member rendering/viewport/transparent_background].
+		<member name="display/window/per_pixel_transparency/allowed" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], allows per-pixel transparency for the window background. This affects performance, but is necessary to allow non-embedded [Popup]s to have visible shadows. If you don't need this, you can change it to [code]false[/code]. See also [member display/window/size/transparent] and [member rendering/viewport/transparent_background].
 		</member>
 		<member name="display/window/size/always_on_top" type="bool" setter="" getter="" default="false">
 			Forces the main window to be always on top.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2531,7 +2531,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_BASIC("internationalization/locale/include_text_server_data", false);
 
 	OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", true);
-	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);
+	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", true);
 
 #ifdef TOOLS_ENABLED
 	if (editor || project_manager) {


### PR DESCRIPTION
The logical next step now that #91333 is merged.

_Technically_ a compatibility break, since this changes a default project setting.