### PR TITLE
Refactor Jolt-related project settings to only be loaded as needed

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2382,13 +2382,11 @@
 			[b]Note:[/b] Setting this too high can result in objects not depenetrating properly.
 			[b]Note:[/b] This applies to all shape queries, as well as physics bodies within the simulation.
 			[b]Note:[/b] This does not apply when enabling Jolt's enhanced internal edge removal, which supersedes this.
-			[b]Note:[/b] This setting will only be read once during the lifetime of the application.
 		</member>
 		<member name="physics/jolt_physics_3d/collisions/collision_margin_fraction" type="float" setter="" getter="" default="0.08">
 			The amount of collision margin to use for certain convex collision shapes, such as [BoxShape3D], [CylinderShape3D] and [ConvexPolygonShape3D], as a fraction of the shape's shortest axis, with [member Shape3D.margin] as the upper bound. This is mainly used to speed up collision detection with convex shapes.
 			[b]Note:[/b] Collision margins in Jolt do not add any extra size to the shape. Instead the shape is first shrunk by the margin and then expanded by the same amount, resulting in a shape with rounded corners.
 			[b]Note:[/b] Setting this value too close to [code]0.0[/code] may also negatively affect the accuracy of the collision detection with convex shapes.
-			[b]Note:[/b] This setting will only be read once during the lifetime of the application.
 		</member>
 		<member name="physics/jolt_physics_3d/joints/world_node" type="int" setter="" getter="" default="0">
 			Which of the two nodes bound by a joint should represent the world when one of the two is omitted, as either [member Joint3D.node_a] or [member Joint3D.node_b]. This can be thought of as having the omitted node be a [StaticBody3D] at the joint's position. Joint limits are more easily expressed when [member Joint3D.node_a] represents the world.
@@ -2423,28 +2421,23 @@
 		<member name="physics/jolt_physics_3d/motion_queries/recovery_amount" type="float" setter="" getter="" default="0.4">
 			Fraction of the total penetration to depenetrate per iteration during motion queries.
 			[b]Note:[/b] This affects methods [method CharacterBody3D.move_and_slide], [method PhysicsBody3D.move_and_collide], [method PhysicsBody3D.test_move] and [method PhysicsServer3D.body_test_motion].
-			[b]Note:[/b] This setting will only be read once during the lifetime of the application.
 		</member>
 		<member name="physics/jolt_physics_3d/motion_queries/recovery_iterations" type="int" setter="" getter="" default="4">
 			The number of iterations to run when depenetrating during motion queries.
 			[b]Note:[/b] This affects methods [method CharacterBody3D.move_and_slide], [method PhysicsBody3D.move_and_collide], [method PhysicsBody3D.test_move] and [method PhysicsServer3D.body_test_motion].
-			[b]Note:[/b] This setting will only be read once during the lifetime of the application.
 		</member>
 		<member name="physics/jolt_physics_3d/motion_queries/use_enhanced_internal_edge_removal" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables Jolt's enhanced internal edge removal during motion queries. This can help alleviate ghost collisions, but only with edges within a single body, meaning edges between separate bodies can still cause ghost collisions.
 			[b]Note:[/b] This affects methods [method CharacterBody3D.move_and_slide], [method PhysicsBody3D.move_and_collide], [method PhysicsBody3D.test_move] and [method PhysicsServer3D.body_test_motion].
-			[b]Note:[/b] This setting will only be read once during the lifetime of the application.
 		</member>
 		<member name="physics/jolt_physics_3d/queries/enable_ray_cast_face_index" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], populates the [code]face_index[/code] field in the results of [method PhysicsDirectSpaceState3D.intersect_ray], also accessed through [method RayCast3D.get_collision_face_index]. If [code]false[/code], the [code]face_index[/code] field will be left at its default value of [code]-1[/code].
 			[b]Note:[/b] Enabling this setting will increase Jolt's memory usage for [ConcavePolygonShape3D] by around 25%.
-			[b]Note:[/b] This setting will only be read once during the lifetime of the application.
 		</member>
 		<member name="physics/jolt_physics_3d/queries/use_enhanced_internal_edge_removal" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables Jolt's enhanced internal edge removal during shape queries. This can help alleviate ghost collisions when using shape queries for things like character movement, but only with edges within a single body, meaning edges between separate bodies can still cause ghost collisions.
 			[b]Note:[/b] This affects methods [method PhysicsDirectSpaceState3D.cast_motion], [method PhysicsDirectSpaceState3D.collide_shape], [method PhysicsDirectSpaceState3D.get_rest_info] and [method PhysicsDirectSpaceState3D.intersect_shape].
 			[b]Note:[/b] Enabling this setting can cause certain shapes to be culled from the results entirely, but you will get at least one intersection per body.
-			[b]Note:[/b] This setting will only be read once during the lifetime of the application.
 		</member>
 		<member name="physics/jolt_physics_3d/simulation/allow_sleep" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], [RigidBody3D] nodes are allowed to go to sleep if their velocity is below the threshold defined in [member physics/jolt_physics_3d/simulation/sleep_velocity_threshold] for the duration set in [member physics/jolt_physics_3d/simulation/sleep_time_threshold]. This can improve physics simulation performance when there are non-moving [RigidBody3D] nodes, at the cost of some nodes possibly failing to wake up in certain scenarios. Consider disabling this temporarily to troubleshoot [RigidBody3D] nodes not moving when they should.
@@ -2470,7 +2463,6 @@
 		</member>
 		<member name="physics/jolt_physics_3d/simulation/bounce_velocity_threshold" type="float" setter="" getter="" default="1.0">
 			The minimum velocity needed before a collision can be bouncy, in meters per second.
-			[b]Note:[/b] This setting will only be read once during the lifetime of the application.
 		</member>
 		<member name="physics/jolt_physics_3d/simulation/continuous_cd_max_penetration" type="float" setter="" getter="" default="0.25">
 			Fraction of a body's inner radius that may penetrate another body while using continuous collision detection.

--- a/modules/jolt_physics/joints/jolt_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_joint_3d.cpp
@@ -118,7 +118,7 @@ JoltJoint3D::JoltJoint3D(const JoltJoint3D &p_old_joint, JoltBody3D *p_body_a, J
 		body_b->add_joint(this);
 	}
 
-	if (body_b == nullptr && JoltProjectSettings::use_joint_world_node_a()) {
+	if (body_b == nullptr && JoltProjectSettings::joint_world_node == JOLT_JOINT_WORLD_NODE_A) {
 		// The joint scene nodes will, when omitting one of the two body nodes, always pass in a
 		// null `body_b` to indicate it being the "world node", regardless of which body node you
 		// leave blank. So we need to correct for that if we wish to use the arguably more intuitive

--- a/modules/jolt_physics/jolt_project_settings.h
+++ b/modules/jolt_physics/jolt_project_settings.h
@@ -33,49 +33,55 @@
 
 #include <stdint.h>
 
+enum JoltJointWorldNode : int {
+	JOLT_JOINT_WORLD_NODE_A,
+	JOLT_JOINT_WORLD_NODE_B,
+};
+
 class JoltProjectSettings {
 public:
+	inline static int simulation_velocity_steps;
+	inline static int simulation_position_steps;
+	inline static bool use_enhanced_internal_edge_removal_for_bodies;
+	inline static bool areas_detect_static_bodies;
+	inline static bool generate_all_kinematic_contacts;
+	inline static float penetration_slop;
+	inline static float speculative_contact_distance;
+	inline static float baumgarte_stabilization_factor;
+	inline static float soft_body_point_radius;
+	inline static float bounce_velocity_threshold;
+	inline static bool sleep_allowed;
+	inline static float sleep_velocity_threshold;
+	inline static float sleep_time_threshold;
+	inline static float ccd_movement_threshold;
+	inline static float ccd_max_penetration;
+	inline static bool body_pair_contact_cache_enabled;
+	inline static float body_pair_cache_distance_sq;
+	inline static float body_pair_cache_angle_cos_div2;
+
+	inline static bool use_enhanced_internal_edge_removal_for_queries;
+	inline static bool enable_ray_cast_face_index;
+
+	inline static bool use_enhanced_internal_edge_removal_for_motion_queries;
+	inline static int motion_query_recovery_iterations;
+	inline static float motion_query_recovery_amount;
+
+	inline static float collision_margin_fraction;
+	inline static float active_edge_threshold_cos;
+
+	inline static JoltJointWorldNode joint_world_node;
+
+	inline static int temp_memory_mib;
+	inline static int64_t temp_memory_b;
+	inline static float world_boundary_shape_size;
+	inline static float max_linear_velocity;
+	inline static float max_angular_velocity;
+	inline static int max_bodies;
+	inline static int max_body_pairs;
+	inline static int max_contact_constraints;
+
 	static void register_settings();
-
-	static int get_simulation_velocity_steps();
-	static int get_simulation_position_steps();
-	static bool use_enhanced_internal_edge_removal_for_bodies();
-	static bool areas_detect_static_bodies();
-	static bool should_generate_all_kinematic_contacts();
-	static float get_penetration_slop();
-	static float get_speculative_contact_distance();
-	static float get_baumgarte_stabilization_factor();
-	static float get_soft_body_point_radius();
-	static float get_bounce_velocity_threshold();
-	static bool is_sleep_allowed();
-	static float get_sleep_velocity_threshold();
-	static float get_sleep_time_threshold();
-	static float get_ccd_movement_threshold();
-	static float get_ccd_max_penetration();
-	static bool is_body_pair_contact_cache_enabled();
-	static float get_body_pair_cache_distance_sq();
-	static float get_body_pair_cache_angle_cos_div2();
-
-	static bool use_enhanced_internal_edge_removal_for_queries();
-	static bool enable_ray_cast_face_index();
-
-	static bool use_enhanced_internal_edge_removal_for_motion_queries();
-	static int get_motion_query_recovery_iterations();
-	static float get_motion_query_recovery_amount();
-
-	static float get_collision_margin_fraction();
-	static float get_active_edge_threshold();
-
-	static bool use_joint_world_node_a();
-
-	static int get_temp_memory_mib();
-	static int64_t get_temp_memory_b();
-	static float get_world_boundary_shape_size();
-	static float get_max_linear_velocity();
-	static float get_max_angular_velocity();
-	static int get_max_bodies();
-	static int get_max_pairs();
-	static int get_max_contact_constraints();
+	static void read_settings();
 };
 
 #endif // JOLT_PROJECT_SETTINGS_H

--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -93,7 +93,7 @@ void JoltArea3D::_add_to_space() {
 	jolt_settings->mIsSensor = true;
 	jolt_settings->mUseManifoldReduction = false;
 
-	if (JoltProjectSettings::areas_detect_static_bodies()) {
+	if (JoltProjectSettings::areas_detect_static_bodies) {
 		jolt_settings->mCollideKinematicVsNonDynamic = true;
 	}
 

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -131,10 +131,10 @@ void JoltBody3D::_add_to_space() {
 	jolt_settings->mAllowSleeping = is_sleep_actually_allowed();
 	jolt_settings->mLinearDamping = 0.0f;
 	jolt_settings->mAngularDamping = 0.0f;
-	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::get_max_linear_velocity();
-	jolt_settings->mMaxAngularVelocity = JoltProjectSettings::get_max_angular_velocity();
+	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::max_linear_velocity;
+	jolt_settings->mMaxAngularVelocity = JoltProjectSettings::max_angular_velocity;
 
-	if (JoltProjectSettings::use_enhanced_internal_edge_removal_for_bodies()) {
+	if (JoltProjectSettings::use_enhanced_internal_edge_removal_for_bodies) {
 		jolt_settings->mEnhancedInternalEdgeRemoval = true;
 	}
 
@@ -906,7 +906,7 @@ void JoltBody3D::set_max_contacts_reported(int p_count) {
 }
 
 bool JoltBody3D::reports_all_kinematic_contacts() const {
-	return reports_contacts() && JoltProjectSettings::should_generate_all_kinematic_contacts();
+	return reports_contacts() && JoltProjectSettings::generate_all_kinematic_contacts;
 }
 
 void JoltBody3D::add_contact(const JoltBody3D *p_collider, float p_depth, int p_shape_index, int p_collider_shape_index, const Vector3 &p_normal, const Vector3 &p_position, const Vector3 &p_collider_position, const Vector3 &p_velocity, const Vector3 &p_collider_velocity, const Vector3 &p_impulse) {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -115,7 +115,7 @@ void JoltSoftBody3D::_add_to_space() {
 	jolt_settings->mUserData = reinterpret_cast<JPH::uint64>(this);
 	jolt_settings->mObjectLayer = _get_object_layer();
 	jolt_settings->mCollisionGroup = JPH::CollisionGroup(nullptr, group_id, sub_group_id);
-	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::get_max_linear_velocity();
+	jolt_settings->mMaxLinearVelocity = JoltProjectSettings::max_linear_velocity;
 
 	const JPH::BodyID new_jolt_id = space->add_soft_body(*this, *jolt_settings);
 	if (new_jolt_id.IsInvalid()) {
@@ -148,7 +148,7 @@ bool JoltSoftBody3D::_ref_shared_data() {
 		LocalVector<int> &mesh_to_physics = iter_shared_data->value.mesh_to_physics;
 
 		JPH::SoftBodySharedSettings &settings = *iter_shared_data->value.settings;
-		settings.mVertexRadius = JoltProjectSettings::get_soft_body_point_radius();
+		settings.mVertexRadius = JoltProjectSettings::soft_body_point_radius;
 
 		JPH::Array<JPH::SoftBodySharedSettings::Vertex> &physics_vertices = settings.mVertices;
 		JPH::Array<JPH::SoftBodySharedSettings::Face> &physics_faces = settings.mFaces;

--- a/modules/jolt_physics/shapes/jolt_box_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_box_shape_3d.cpp
@@ -37,7 +37,7 @@
 
 JPH::ShapeRefC JoltBoxShape3D::_build() const {
 	const float min_half_extent = (float)half_extents[half_extents.min_axis_index()];
-	const float actual_margin = MIN(margin, min_half_extent * JoltProjectSettings::get_collision_margin_fraction());
+	const float actual_margin = MIN(margin, min_half_extent * JoltProjectSettings::collision_margin_fraction);
 
 	const JPH::BoxShapeSettings shape_settings(to_jolt(half_extents), actual_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();

--- a/modules/jolt_physics/shapes/jolt_concave_polygon_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_concave_polygon_shape_3d.cpp
@@ -69,8 +69,8 @@ JPH::ShapeRefC JoltConcavePolygonShape3D::_build() const {
 	}
 
 	JPH::MeshShapeSettings shape_settings(jolt_faces);
-	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
-	shape_settings.mPerTriangleUserData = JoltProjectSettings::enable_ray_cast_face_index();
+	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::active_edge_threshold_cos;
+	shape_settings.mPerTriangleUserData = JoltProjectSettings::enable_ray_cast_face_index;
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics concave polygon shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));

--- a/modules/jolt_physics/shapes/jolt_convex_polygon_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_convex_polygon_shape_3d.cpp
@@ -55,7 +55,7 @@ JPH::ShapeRefC JoltConvexPolygonShape3D::_build() const {
 	}
 
 	const float min_half_extent = _calculate_aabb().get_shortest_axis_size() * 0.5f;
-	const float actual_margin = MIN(margin, min_half_extent * JoltProjectSettings::get_collision_margin_fraction());
+	const float actual_margin = MIN(margin, min_half_extent * JoltProjectSettings::collision_margin_fraction);
 
 	const JPH::ConvexHullShapeSettings shape_settings(jolt_vertices, actual_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();

--- a/modules/jolt_physics/shapes/jolt_cylinder_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_cylinder_shape_3d.cpp
@@ -38,7 +38,7 @@
 JPH::ShapeRefC JoltCylinderShape3D::_build() const {
 	const float half_height = height / 2.0f;
 	const float min_half_extent = MIN(half_height, radius);
-	const float actual_margin = MIN(margin, min_half_extent * JoltProjectSettings::get_collision_margin_fraction());
+	const float actual_margin = MIN(margin, min_half_extent * JoltProjectSettings::collision_margin_fraction);
 
 	const JPH::CylinderShapeSettings shape_settings(half_height, radius, actual_margin);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();

--- a/modules/jolt_physics/shapes/jolt_height_map_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_height_map_shape_3d.cpp
@@ -106,7 +106,7 @@ JPH::ShapeRefC JoltHeightMapShape3D::_build_height_field() const {
 	JPH::HeightFieldShapeSettings shape_settings(heights_rev.ptr(), JPH::Vec3(offset_x, 0, offset_y), JPH::Vec3::sReplicate(1.0f), (JPH::uint32)width);
 
 	shape_settings.mBitsPerSample = shape_settings.CalculateBitsPerSampleForError(0.0f);
-	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
+	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::active_edge_threshold_cos;
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics height map shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
@@ -160,7 +160,7 @@ JPH::ShapeRefC JoltHeightMapShape3D::_build_mesh() const {
 	}
 
 	JPH::MeshShapeSettings shape_settings(std::move(vertices), std::move(indices));
-	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::get_active_edge_threshold();
+	shape_settings.mActiveEdgeCosThresholdAngle = JoltProjectSettings::active_edge_threshold_cos;
 
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics height map shape (as polygon) with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));

--- a/modules/jolt_physics/shapes/jolt_world_boundary_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_world_boundary_shape_3d.cpp
@@ -39,7 +39,7 @@ JPH::ShapeRefC JoltWorldBoundaryShape3D::_build() const {
 	const Plane normalized_plane = plane.normalized();
 	ERR_FAIL_COND_V_MSG(normalized_plane == Plane(), nullptr, vformat("Failed to build Jolt Physics world boundary shape with %s. The plane's normal must not be zero. This shape belongs to %s.", to_string(), _owners_to_string()));
 
-	const float half_size = JoltProjectSettings::get_world_boundary_shape_size() / 2.0f;
+	const float half_size = JoltProjectSettings::world_boundary_shape_size / 2.0f;
 	const JPH::PlaneShapeSettings shape_settings(to_jolt(normalized_plane), nullptr, half_size);
 	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
 	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics world boundary shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
@@ -65,7 +65,7 @@ void JoltWorldBoundaryShape3D::set_data(const Variant &p_data) {
 }
 
 AABB JoltWorldBoundaryShape3D::get_aabb() const {
-	const float size = JoltProjectSettings::get_world_boundary_shape_size();
+	const float size = JoltProjectSettings::world_boundary_shape_size;
 	const float half_size = size / 2.0f;
 	return AABB(Vector3(-half_size, -half_size, -half_size), Vector3(size, half_size, size));
 }

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
@@ -200,7 +200,7 @@ bool JoltContactListener3D::_try_add_contacts(const JPH::Body &p_jolt_body1, con
 	manifold.depth = p_manifold.mPenetrationDepth;
 
 	JPH::CollisionEstimationResult collision;
-	JPH::EstimateCollisionResponse(p_jolt_body1, p_jolt_body2, p_manifold, collision, p_settings.mCombinedFriction, p_settings.mCombinedRestitution, JoltProjectSettings::get_bounce_velocity_threshold(), 5);
+	JPH::EstimateCollisionResponse(p_jolt_body1, p_jolt_body2, p_manifold, collision, p_settings.mCombinedFriction, p_settings.mCombinedRestitution, JoltProjectSettings::bounce_velocity_threshold, 5);
 
 	for (JPH::uint i = 0; i < contact_count; ++i) {
 		const JPH::RVec3 relative_point1 = JPH::RVec3(p_manifold.mRelativeContactPointsOn1[i]);

--- a/modules/jolt_physics/spaces/jolt_layers.cpp
+++ b/modules/jolt_physics/spaces/jolt_layers.cpp
@@ -64,7 +64,7 @@ public:
 		allow_collision(AREA_UNDETECTABLE, BODY_DYNAMIC);
 		allow_collision(AREA_UNDETECTABLE, AREA_DETECTABLE);
 
-		if (JoltProjectSettings::areas_detect_static_bodies()) {
+		if (JoltProjectSettings::areas_detect_static_bodies) {
 			allow_collision(BODY_STATIC, AREA_DETECTABLE);
 			allow_collision(BODY_STATIC, AREA_UNDETECTABLE);
 			allow_collision(BODY_STATIC_BIG, AREA_DETECTABLE);

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -104,23 +104,23 @@ JoltSpace3D::JoltSpace3D(JPH::JobSystem *p_job_system) :
 		layers(new JoltLayers()),
 		contact_listener(new JoltContactListener3D(this)),
 		physics_system(new JPH::PhysicsSystem()) {
-	physics_system->Init((JPH::uint)JoltProjectSettings::get_max_bodies(), 0, (JPH::uint)JoltProjectSettings::get_max_pairs(), (JPH::uint)JoltProjectSettings::get_max_contact_constraints(), *layers, *layers, *layers);
+	physics_system->Init((JPH::uint)JoltProjectSettings::max_bodies, 0, (JPH::uint)JoltProjectSettings::max_body_pairs, (JPH::uint)JoltProjectSettings::max_contact_constraints, *layers, *layers, *layers);
 
 	JPH::PhysicsSettings settings;
-	settings.mBaumgarte = JoltProjectSettings::get_baumgarte_stabilization_factor();
-	settings.mSpeculativeContactDistance = JoltProjectSettings::get_speculative_contact_distance();
-	settings.mPenetrationSlop = JoltProjectSettings::get_penetration_slop();
-	settings.mLinearCastThreshold = JoltProjectSettings::get_ccd_movement_threshold();
-	settings.mLinearCastMaxPenetration = JoltProjectSettings::get_ccd_max_penetration();
-	settings.mBodyPairCacheMaxDeltaPositionSq = JoltProjectSettings::get_body_pair_cache_distance_sq();
-	settings.mBodyPairCacheCosMaxDeltaRotationDiv2 = JoltProjectSettings::get_body_pair_cache_angle_cos_div2();
-	settings.mNumVelocitySteps = (JPH::uint)JoltProjectSettings::get_simulation_velocity_steps();
-	settings.mNumPositionSteps = (JPH::uint)JoltProjectSettings::get_simulation_position_steps();
-	settings.mMinVelocityForRestitution = JoltProjectSettings::get_bounce_velocity_threshold();
-	settings.mTimeBeforeSleep = JoltProjectSettings::get_sleep_time_threshold();
-	settings.mPointVelocitySleepThreshold = JoltProjectSettings::get_sleep_velocity_threshold();
-	settings.mUseBodyPairContactCache = JoltProjectSettings::is_body_pair_contact_cache_enabled();
-	settings.mAllowSleeping = JoltProjectSettings::is_sleep_allowed();
+	settings.mBaumgarte = JoltProjectSettings::baumgarte_stabilization_factor;
+	settings.mSpeculativeContactDistance = JoltProjectSettings::speculative_contact_distance;
+	settings.mPenetrationSlop = JoltProjectSettings::penetration_slop;
+	settings.mLinearCastThreshold = JoltProjectSettings::ccd_movement_threshold;
+	settings.mLinearCastMaxPenetration = JoltProjectSettings::ccd_max_penetration;
+	settings.mBodyPairCacheMaxDeltaPositionSq = JoltProjectSettings::body_pair_cache_distance_sq;
+	settings.mBodyPairCacheCosMaxDeltaRotationDiv2 = JoltProjectSettings::body_pair_cache_angle_cos_div2;
+	settings.mNumVelocitySteps = (JPH::uint)JoltProjectSettings::simulation_velocity_steps;
+	settings.mNumPositionSteps = (JPH::uint)JoltProjectSettings::simulation_position_steps;
+	settings.mMinVelocityForRestitution = JoltProjectSettings::bounce_velocity_threshold;
+	settings.mTimeBeforeSleep = JoltProjectSettings::sleep_time_threshold;
+	settings.mPointVelocitySleepThreshold = JoltProjectSettings::sleep_velocity_threshold;
+	settings.mUseBodyPairContactCache = JoltProjectSettings::body_pair_contact_cache_enabled;
+	settings.mAllowSleeping = JoltProjectSettings::sleep_allowed;
 
 	physics_system->SetPhysicsSettings(settings);
 	physics_system->SetGravity(JPH::Vec3::sZero());
@@ -175,21 +175,21 @@ void JoltSpace3D::step(float p_step) {
 		WARN_PRINT_ONCE(vformat("Jolt Physics manifold cache exceeded capacity and contacts were ignored. "
 								"Consider increasing maximum number of contact constraints in project settings. "
 								"Maximum number of contact constraints is currently set to %d.",
-				JoltProjectSettings::get_max_contact_constraints()));
+				JoltProjectSettings::max_contact_constraints));
 	}
 
 	if ((update_error & JPH::EPhysicsUpdateError::BodyPairCacheFull) != JPH::EPhysicsUpdateError::None) {
 		WARN_PRINT_ONCE(vformat("Jolt Physics body pair cache exceeded capacity and contacts were ignored. "
 								"Consider increasing maximum number of body pairs in project settings. "
 								"Maximum number of body pairs is currently set to %d.",
-				JoltProjectSettings::get_max_pairs()));
+				JoltProjectSettings::max_body_pairs));
 	}
 
 	if ((update_error & JPH::EPhysicsUpdateError::ContactConstraintsFull) != JPH::EPhysicsUpdateError::None) {
 		WARN_PRINT_ONCE(vformat("Jolt Physics contact constraint buffer exceeded capacity and contacts were ignored. "
 								"Consider increasing maximum number of contact constraints in project settings. "
 								"Maximum number of contact constraints is currently set to %d.",
-				JoltProjectSettings::get_max_contact_constraints()));
+				JoltProjectSettings::max_contact_constraints));
 	}
 
 	_post_step(p_step);
@@ -233,7 +233,7 @@ double JoltSpace3D::get_param(PhysicsServer3D::SpaceParameter p_param) const {
 			return DEFAULT_SLEEP_THRESHOLD_ANGULAR;
 		}
 		case PhysicsServer3D::SPACE_PARAM_BODY_TIME_TO_SLEEP: {
-			return JoltProjectSettings::get_sleep_time_threshold();
+			return JoltProjectSettings::sleep_time_threshold;
 		}
 		case PhysicsServer3D::SPACE_PARAM_SOLVER_ITERATIONS: {
 			return DEFAULT_SOLVER_ITERATIONS;
@@ -359,7 +359,7 @@ JPH::BodyID JoltSpace3D::add_rigid_body(const JoltObject3D &p_object, const JPH:
 		ERR_PRINT_ONCE(vformat("Failed to create underlying Jolt Physics body for '%s'. "
 							   "Consider increasing maximum number of bodies in project settings. "
 							   "Maximum number of bodies is currently set to %d.",
-				p_object.to_string(), JoltProjectSettings::get_max_bodies()));
+				p_object.to_string(), JoltProjectSettings::max_bodies));
 
 		return JPH::BodyID();
 	}
@@ -376,7 +376,7 @@ JPH::BodyID JoltSpace3D::add_soft_body(const JoltObject3D &p_object, const JPH::
 		ERR_PRINT_ONCE(vformat("Failed to create underlying Jolt Physics body for '%s'. "
 							   "Consider increasing maximum number of bodies in project settings. "
 							   "Maximum number of bodies is currently set to %d.",
-				p_object.to_string(), JoltProjectSettings::get_max_bodies()));
+				p_object.to_string(), JoltProjectSettings::max_bodies));
 
 		return JPH::BodyID();
 	}

--- a/modules/jolt_physics/spaces/jolt_temp_allocator.cpp
+++ b/modules/jolt_physics/spaces/jolt_temp_allocator.cpp
@@ -64,7 +64,7 @@ constexpr TValue align_up(TValue p_value, TAlignment p_alignment) {
 } //namespace
 
 JoltTempAllocator::JoltTempAllocator() :
-		capacity((uint64_t)JoltProjectSettings::get_temp_memory_b()),
+		capacity((uint64_t)JoltProjectSettings::temp_memory_b),
 		base(static_cast<uint8_t *>(JPH::Allocate((size_t)capacity))) {
 }
 
@@ -89,7 +89,7 @@ void *JoltTempAllocator::Allocate(uint32_t p_size) {
 		WARN_PRINT_ONCE(vformat("Jolt Physics temporary memory allocator exceeded capacity of %d MiB. "
 								"Falling back to slower general-purpose allocator. "
 								"Consider increasing maximum temporary memory in project settings.",
-				JoltProjectSettings::get_temp_memory_mib()));
+				JoltProjectSettings::temp_memory_mib));
 
 		ptr = JPH::Allocate(p_size);
 	}


### PR DESCRIPTION
As suggested in #101237, this refactors the `JoltProjectSettings` class to not just be a class of getters that themselves just call `GLOBAL_GET` (which in some cases also get cached as a `static` variable) but instead a class of actual values.

This is then coupled with `ProjectSettings::get_singleton()->connect("settings_changed", ...);` to read the settings again whenever they're changed, ensuring that we have up-to-date values without needing to call `GLOBAL_GET` all the time.

This might perhaps provide a tiny performance boost, but mostly just cleans things up a bit and lets us get rid of the caveat in the documentation about certain settings only being read once.

It should probably be noted that `bounce_velocity_threshold` can now technically be read from the physics thread (when using `physics/3d/run_on_separate_thread`) while the main thread is writing to it, but given that it's a `float` I would assume that there are no concern about "torn reads" or anything like that, and having the most up-to-date value when reading it isn't really a concern in this case.