### PR TITLE
Windows: Update export script's task to work even on battery power

### DIFF
--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -440,7 +440,7 @@ void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_optio
 	String run_script = "Expand-Archive -LiteralPath '{temp_dir}\\{archive_name}' -DestinationPath '{temp_dir}'\n"
 						"$action = New-ScheduledTaskAction -Execute '{temp_dir}\\{exe_name}' -Argument '{cmd_args}'\n"
 						"$trigger = New-ScheduledTaskTrigger -Once -At 00:00\n"
-						"$settings = New-ScheduledTaskSettingsSet\n"
+						"$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries\n"
 						"$task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings\n"
 						"Register-ScheduledTask godot_remote_debug -InputObject $task -Force:$true\n"
 						"Start-ScheduledTask -TaskName godot_remote_debug\n"


### PR DESCRIPTION
# Current Behavior
When generating an export profile targeting a remote windows machine over SSH, the script has this line on it:
```
$settings = New-ScheduledTaskSettingsSet
```
By default, a `ScheduledTaskSettingsSet` has the flags `AllowStartIfOnBatteries` and `DontStopIfGoingOnBatteries` set to `false`, which makes it so this line later on:

```
Start-ScheduledTask -TaskName godot_remote_debug
```
Silently fail to start the task if the target remote machine is on battery power. (Examples include a mobile device, tablet, laptop, etc)

# Resolution

Updated the script to add the flags `AllowStartIfOnBatteries` and `DontStopIfGoingOnBatteries` setting them to true
