### PR TITLE
[DRAFT] TextEdit: merge simple multi-keypress single-caret undo actions

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -529,6 +529,12 @@
 				[b]Note:[/b] The Y position corresponds to the bottom side of the line. Use [method get_rect_at_line_column] to get the top side position.
 			</description>
 		</method>
+		<method name="get_prev_version" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the version number of the undo/redo state that will be applied if an undo is performed.
+			</description>
+		</method>
 		<method name="get_rect_at_line_column" qualifiers="const">
 			<return type="Rect2i" />
 			<param index="0" name="line" type="int" />
@@ -536,6 +542,12 @@
 			<description>
 				Returns the local position and size for the grapheme at the given [param line] and [param column]. If [code]x[/code] or [code]y[/code] position of the returned rect equal [code]-1[/code], the position is outside of the viewable area of the control.
 				[b]Note:[/b] The Y position of the returned rect corresponds to the top side of the line, unlike [method get_pos_at_line_column] which returns the bottom side.
+			</description>
+		</method>
+		<method name="get_redo_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of available "redo" actions in the undo/redo history.
 			</description>
 		</method>
 		<method name="get_saved_version" qualifiers="const">
@@ -658,6 +670,12 @@
 				Returns the total number of lines in the text. This includes wrapped lines and excludes folded lines. If [member wrap_mode] is set to [constant LINE_WRAPPING_NONE] and no lines are folded (see [method CodeEdit.is_line_folded]) then this is equivalent to [method get_line_count]. See [method get_visible_line_count_in_range] for a limited range of lines.
 			</description>
 		</method>
+		<method name="get_undo_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of available "undo" actions in the undo/redo history.
+			</description>
+		</method>
 		<method name="get_v_scroll_bar" qualifiers="const">
 			<return type="VScrollBar" />
 			<description>
@@ -667,7 +685,7 @@
 		<method name="get_version" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the current version of the [TextEdit]. The version is a count of recorded operations by the undo/redo history.
+				Returns the current version of the [TextEdit]. Different undo/redo history states have different, increasing version numbers.
 			</description>
 		</method>
 		<method name="get_visible_line_count" qualifiers="const">
@@ -1415,6 +1433,13 @@
 			<description>
 				Emitted immediately when the text changes.
 				When text is added [param from_line] will be less than [param to_line]. On a remove [param to_line] will be less than [param from_line].
+			</description>
+		</signal>
+		<signal name="operation_done">
+			<param index="0" name="from_line" type="int" />
+			<param index="1" name="to_line" type="int" />
+			<description>
+				Emitted when the text changes and a new undo operation has been created for the change.
 			</description>
 		</signal>
 		<signal name="text_changed">

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4087,10 +4087,24 @@ void TextEdit::end_complex_operation() {
 	undo_stack.back()->get().end_carets = carets;
 	if (undo_stack.back()->get().chain_forward) {
 		undo_stack.back()->get().chain_forward = false;
+		emit_signal(SNAME("operation_done"), undo_stack.back()->get().from_line, undo_stack.back()->get().to_line);
 		return;
 	}
 
-	undo_stack.back()->get().chain_backward = true;
+	int min_line = undo_stack.back()->get().from_line;
+	int max_line = undo_stack.back()->get().to_line;
+
+	List<TextOperation>::Element *op = undo_stack.back();
+	op->get().chain_backward = true;
+	while (op) {
+		min_line = MIN(min_line, op->get().from_line);
+		max_line = MIN(max_line, op->get().to_line);
+		if (op->get().chain_forward) {
+			break;
+		}
+		op = op->prev();
+	}
+	emit_signal(SNAME("operation_done"), min_line, max_line);
 }
 
 bool TextEdit::has_undo() const {
@@ -4105,6 +4119,41 @@ bool TextEdit::has_redo() const {
 	return undo_stack_pos != nullptr;
 }
 
+int TextEdit::get_undo_count() const {
+	if (undo_stack_pos == nullptr) {
+		int pending = current_op.type == TextOperation::TYPE_NONE ? 0 : 1;
+		return undo_stack.size() + pending;
+	}
+	return undo_stack.size() - undo_stack_idx;
+}
+
+int TextEdit::get_redo_count() const {
+	return undo_stack_idx;
+}
+
+int TextEdit::get_prev_version() const {
+	if (undo_stack.is_empty()) {
+		return -1;
+	}
+	if (current_op.type != TextOperation::TYPE_NONE) {
+		return current_op.prev_version;
+	}
+	const List<TextOperation>::Element *pos = undo_stack_pos;
+	if (pos == nullptr) {
+		pos = undo_stack.back();
+	} else {
+		pos = pos->prev();
+	}
+	if (pos == nullptr) {
+		return -1;
+	}
+	if (pos->get().chain_backward) {
+		while (pos && !pos->get().chain_forward) {
+			pos = pos->prev();
+		}
+	}
+	return pos ? pos->get().prev_version : -5;
+}
 void TextEdit::undo() {
 	if (!editable) {
 		return;
@@ -4121,11 +4170,13 @@ void TextEdit::undo() {
 		}
 
 		undo_stack_pos = undo_stack.back();
+		undo_stack_idx = 1;
 
 	} else if (undo_stack_pos == undo_stack.front()) {
 		return; // At the bottom of the undo stack.
 	} else {
 		undo_stack_pos = undo_stack_pos->prev();
+		undo_stack_idx += 1;
 	}
 
 	deselect();
@@ -4139,6 +4190,7 @@ void TextEdit::undo() {
 		while (true) {
 			ERR_BREAK(!undo_stack_pos->prev());
 			undo_stack_pos = undo_stack_pos->prev();
+			undo_stack_idx += 1;
 			op = undo_stack_pos->get();
 			_do_text_op(op, true);
 			current_op.version = op.prev_version;
@@ -4194,6 +4246,7 @@ void TextEdit::redo() {
 		while (true) {
 			ERR_BREAK(!undo_stack_pos->next());
 			undo_stack_pos = undo_stack_pos->next();
+			undo_stack_idx -= 1;
 			op = undo_stack_pos->get();
 			_do_text_op(op, false);
 			current_op.version = op.version;
@@ -4216,6 +4269,7 @@ void TextEdit::redo() {
 
 	carets = undo_stack_pos->get().end_carets;
 	undo_stack_pos = undo_stack_pos->next();
+	undo_stack_idx -= 1;
 
 	_unhide_carets();
 
@@ -4230,6 +4284,7 @@ void TextEdit::clear_undo_history() {
 	saved_version = 0;
 	current_op.type = TextOperation::TYPE_NONE;
 	undo_stack_pos = nullptr;
+	undo_stack_idx = 0;
 	undo_stack.clear();
 }
 
@@ -6690,6 +6745,9 @@ void TextEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_undo"), &TextEdit::has_undo);
 	ClassDB::bind_method(D_METHOD("has_redo"), &TextEdit::has_redo);
+	ClassDB::bind_method(D_METHOD("get_undo_count"), &TextEdit::get_undo_count);
+	ClassDB::bind_method(D_METHOD("get_redo_count"), &TextEdit::get_redo_count);
+	ClassDB::bind_method(D_METHOD("get_prev_version"), &TextEdit::get_prev_version);
 	ClassDB::bind_method(D_METHOD("undo"), &TextEdit::undo);
 	ClassDB::bind_method(D_METHOD("redo"), &TextEdit::redo);
 	ClassDB::bind_method(D_METHOD("clear_undo_history"), &TextEdit::clear_undo_history);
@@ -7040,6 +7098,7 @@ void TextEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("text_set"));
 	ADD_SIGNAL(MethodInfo("text_changed"));
 	ADD_SIGNAL(MethodInfo("lines_edited_from", PropertyInfo(Variant::INT, "from_line"), PropertyInfo(Variant::INT, "to_line")));
+	ADD_SIGNAL(MethodInfo("operation_done", PropertyInfo(Variant::INT, "from_line"), PropertyInfo(Variant::INT, "to_line")));
 
 	/* Caret. */
 	ADD_SIGNAL(MethodInfo("caret_changed"));
@@ -7561,6 +7620,7 @@ void TextEdit::_clear_redo() {
 		undo_stack_pos = undo_stack_pos->next();
 		undo_stack.erase(elem);
 	}
+	undo_stack_idx = 0;
 }
 
 /* Search */

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7594,7 +7594,9 @@ void TextEdit::_push_current_op() {
 			a.chain_backward = b.chain_backward;
 			a.end_carets = b.end_carets;
 		};
-		if (current_op.type == TextOperation::TYPE_INSERT && last->end_carets[0].column + 1 == current_op.start_carets[0].column) {
+		if ((current_op.type == TextOperation::TYPE_INSERT && last->end_carets[0].column + 1 == current_op.start_carets[0].column)
+				// for delete key inputs, the cursor doesn't move between the end of the first and the start of the second input; also, the 'deleted text' is on the right instead of the left
+				|| (current_op.type == TextOperation::TYPE_REMOVE && last->end_carets[0].column == current_op.start_carets[0].column)) {
 			merge_info(undo_stack.back()->get(), current_op);
 			last->text += current_op.text;
 		} else if (current_op.type == TextOperation::TYPE_REMOVE && last->end_carets[0].column - 1 == current_op.start_carets[0].column) {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7579,7 +7579,29 @@ void TextEdit::_push_current_op() {
 		next_operation_is_complex = false;
 	}
 
-	undo_stack.push_back(current_op);
+	TextOperation *last = !undo_stack.is_empty() ? &undo_stack.back()->get() : nullptr;
+	// merge simple edits of the same kind and same logical operation, but only if we're not going to thrash anything
+	if (last && last->type == current_op.type && current_op.type != TextOperation::TYPE_NONE && !current_op.chain_forward && complex_operation_count > 0
+			// careful: multicursor edits have their actions split up and the inputs associated with a given caret are not directly adjacent in the undo buffer!
+			// so, we can only easily merge single-caret edits
+			&& last->end_carets.size() == 1 && current_op.start_carets.size() == 1 && last->end_carets[0].line == current_op.start_carets[0].line) {
+		auto merge_bounds = [](TextOperation &a, TextOperation &b) {
+			a.from_line = MIN(a.from_line, b.from_line);
+			a.from_column = MIN(a.from_column, b.from_column);
+			a.to_line = MAX(a.to_line, b.to_line);
+			a.to_column = MAX(a.to_column, b.to_column);
+		};
+		if (current_op.type == TextOperation::TYPE_INSERT && last->end_carets[0].column + last->text.length() == current_op.start_carets[0].column) {
+			merge_bounds(undo_stack.back()->get(), current_op);
+			last->text = current_op.text + last->text;
+		} else if (current_op.type == TextOperation::TYPE_REMOVE && last->end_carets[0].column - last->text.length() == current_op.start_carets[0].column) {
+			merge_bounds(undo_stack.back()->get(), current_op);
+			last->text = current_op.text + last->text;
+		}
+	} else {
+		undo_stack.push_back(current_op);
+	}
+
 	current_op.type = TextOperation::TYPE_NONE;
 	current_op.text = "";
 	current_op.chain_forward = false;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -369,6 +369,7 @@ private:
 	TextOperation current_op;
 	List<TextOperation> undo_stack;
 	List<TextOperation>::Element *undo_stack_pos = nullptr;
+	size_t undo_stack_idx = 0; // number of elements away from top undo_stack_pos is
 
 	Timer *idle_detect = nullptr;
 
@@ -831,6 +832,9 @@ public:
 
 	bool has_undo() const;
 	bool has_redo() const;
+	int get_undo_count() const;
+	int get_redo_count() const;
+	int get_prev_version() const;
 	void undo();
 	void redo();
 	void clear_undo_history();


### PR DESCRIPTION
This is a proof of concept (do not merge!) of safely (I think?) fixing the simplest case of https://github.com/godotengine/godot/issues/101204. Something similar to this used to be done already, but was done in an unsafe way, caused bugs, and eventually got removed.

**The relevant changes in this PR are the ones in `_push_current_op()`, starting at `TextOperation *last = [....]`, and are only ~30 lines.** I merged in https://github.com/godotengine/godot/pull/101203 for the sake of making testing simple; a "real" version of this PR would not have this other PR merged into it. You can use the test project attached to that PR for testing this PR. I'm leaving this draft PR's commit history as multiple commits for the time being because I want the commit history to document what I have to go through to get this fully working; if this becomes submittable then I'll make it a single commit as is standard.

Code is added to `TextEdit::_push_current_op()` that checks if the newest undo action and its previous would be undone/redone together, are consecutive, and are of the same type (so they can be easily merged), and if so, merges them into the same action object instead of leaving them as two.

As far as I can tell (based on thinking about how the TYPE_REMOVE/delete/backspace-related code works), different carets have their own `TextOperation`s even for the same keystroke, so peeking at the end of the undo/redo buffer like this doesn't work for them, so it only runs if there's only one caret. I think if I was in charge of this section of the codebase, I'd add a `Vector<String>` to `TextOperation`, and populate it for multi-caret operations instead of producing a new `TextOperation` for each caret.

~~Oh, wait, I didn't even test this with the delete key, only backspace. Uhhh. Yeah. Proof of concept. Do not merge!~~ Delete key inputs are now handled.