### PR TITLE
Fix example in `OS.shell_open()` method documentation and add a new one

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -809,7 +809,8 @@
 			<param index="0" name="uri" type="String" />
 			<description>
 				Requests the OS to open a resource identified by [param uri] with the most appropriate program. For example:
-				- [code]OS.shell_open("C:\\Users\name\Downloads")[/code] on Windows opens the file explorer at the user's Downloads folder.
+				- [code]OS.shell_open("C:\\Users\\name\\Downloads")[/code] on Windows opens the file explorer at the user's Downloads folder.
+				- [code]OS.shell_open("C:/Users/name/Downloads")[/code] also works on Windows and opens the file explorer at the user's Downloads folder.
 				- [code]OS.shell_open("https://godotengine.org")[/code] opens the default web browser on the official Godot website.
 				- [code]OS.shell_open("mailto:example@example.com")[/code] opens the default email client with the "To" field set to [code]example@example.com[/code]. See [url=https://datatracker.ietf.org/doc/html/rfc2368]RFC 2368 - The [code]mailto[/code] URL scheme[/url] for a list of fields that can be added.
 				Use [method ProjectSettings.globalize_path] to convert a [code]res://[/code] or [code]user://[/code] project path into a system path for use with this method.


### PR DESCRIPTION
Closes [#10367](https://github.com/godotengine/godot-docs/issues/10453)

### What I Did:
- Fixed an issue with string escaping in an example provided for the `OS.shell_open()` method documentation. Now the example is properly escaped to reflect valid Windows path syntax.
- Added a new example of how to open a Windows path using the `OS.shell_open()` method with a different syntax from the first Windows path example.

### Demonstrations:
- Current Windows path example shown in the `OS.shell_open()` documentation displaying error:
   ![image](https://github.com/user-attachments/assets/7b43d50c-d79f-41dd-b0d3-d2e2ee24ab61)
- Corrected Windows path example showing no errors:
   ![image](https://github.com/user-attachments/assets/ba98cb62-50be-4160-8e32-ef4890f6e1e2)
   - Note: I've tested this GDScript, and it opens the folder as expected. I attached the script to a node and ran the scene, and it worked perfectly. If needed, I can provide a GIF.

