### PR TITLE
Fix variant rejecting dying RefCounted

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1092,10 +1092,16 @@ void Variant::ObjData::ref(const ObjData &p_from) {
 
 	*this = p_from;
 	if (id.is_ref_counted()) {
-		RefCounted *reference = static_cast<RefCounted *>(obj);
 		// Assuming reference is not null because id.is_ref_counted() was true.
-		if (!reference->reference()) {
-			*this = ObjData();
+		RefCounted *reference = static_cast<RefCounted *>(obj);
+		// The RefCounted object might be dying (count == 0) but there are
+		// still reasons of using it (e.g. predeleted callback). In such case
+		// we treat it as a regular object and do not attempt to ref-count it
+		// (will not succeed and end up with a null object).
+		if (reference->get_reference_count() > 0) {
+			if (!reference->reference()) {
+				*this = ObjData();
+			}
 		}
 	}
 
@@ -1114,8 +1120,10 @@ void Variant::ObjData::ref_pointer(Object *p_object) {
 		*this = ObjData{ p_object->get_instance_id(), p_object };
 		if (p_object->is_ref_counted()) {
 			RefCounted *reference = static_cast<RefCounted *>(p_object);
-			if (!reference->init_ref()) {
-				*this = ObjData();
+			if (reference->get_reference_count() > 0) {
+				if (!reference->init_ref()) {
+					*this = ObjData();
+				}
 			}
 		}
 	} else {
@@ -1129,9 +1137,11 @@ void Variant::ObjData::unref() {
 	// Mirrors Ref::unref in refcounted.h
 	if (id.is_ref_counted()) {
 		RefCounted *reference = static_cast<RefCounted *>(obj);
-		// Assuming reference is not null because id.is_ref_counted() was true.
-		if (reference->unreference()) {
-			memdelete(reference);
+		if (reference->get_reference_count() > 0) {
+			// Assuming reference is not null because id.is_ref_counted() was true.
+			if (reference->unreference()) {
+				memdelete(reference);
+			}
 		}
 	}
 	*this = ObjData();

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -509,7 +509,7 @@
 		<method name="cancel_free">
 			<return type="void" />
 			<description>
-				If this method is called during [constant NOTIFICATION_PREDELETE], this object will reject being freed and will remain allocated. This is mostly an internal function used for error handling to avoid the user from freeing objects when they are not intended to.
+				If this method is called during [constant NOTIFICATION_PREDELETE], this object will reject being freed and will remain allocated. This is mostly an internal function used for error handling to avoid the user from freeing objects when they are not intended to. After cancellation the reference count of a [RefCounted] will remain zero and cannot be revived, it must be manually freed.
 			</description>
 		</method>
 		<method name="connect">

--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -31,8 +31,10 @@
 #ifndef TEST_VARIANT_H
 #define TEST_VARIANT_H
 
+#include "core/object/ref_counted.h"
 #include "core/variant/variant.h"
 #include "core/variant/variant_parser.h"
+#include "core/variant/variant_utility.h"
 
 #include "tests/test_macros.h"
 
@@ -2214,6 +2216,24 @@ TEST_CASE("[Variant] Operator NOT") {
 		REQUIRE_EQ(result.get_type(), Variant::BOOL);
 		CHECK_EQ(!value.booleanize(), result.operator bool());
 	}
+}
+
+TEST_CASE("[Variant] Constructed from a dying RefCounted") {
+	RefCounted *obj = memnew(RefCounted);
+	const uint64_t obj_id = obj->get_instance_id();
+	obj->init_ref();
+	CHECK(obj->get_reference_count() == 1);
+	obj->unreference();
+	CHECK(obj->get_reference_count() == 0);
+	{
+		Variant v(obj);
+		CHECK(!v.is_null());
+		CHECK(VariantUtilityFunctions::is_instance_valid(v));
+		Object *o = v;
+		CHECK(o == (Object *)obj);
+	}
+	CHECK(VariantUtilityFunctions::is_instance_id_valid(obj_id));
+	memdelete(obj);
 }
 
 } // namespace TestVariant


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/80834

To summarize, the following code tries to do something in the predelete callback
```gdscript
extends RefCounted

var _instance_id = get_instance_id()

func _init() -> void:
    pass

func _notification(what: int) -> void:
    if what == NOTIFICATION_PREDELETE:
        print("predelete. self:%s is_instance_id_valid:%s instance_from_id:%s" %
              [self, is_instance_id_valid(_instance_id), instance_from_id(_instance_id)])
```

But unfortunately `self` becomes `null` so we can not access the members of the instance. The same happens to `instance_from_id` which gives `<Object#null>` but `is_instance_id_valid` correctly returns `true`. This bug only applies to `RefCounted` and subclasses. The print statement gives

```text
predelete. self:<Object#null> is_instance_id_valid:true instance_from_id:<Object#null>
```

The reason behind it is that `Variant` does not accept a dying RefCounted because it can not perform a success reference operation. In `Variant::ObjData::ref`

```c++
if (id.is_ref_counted()) {
    RefCounted *reference = static_cast<RefCounted *>(obj);
    // Assuming reference is not null because id.is_ref_counted() was true.
    if (!reference->reference()) {
        *this = ObjData();
    }
}
```

`reference->reference()` returns `false` because the count is zero, so `Variant` sets itself a null object.

This PR fixes the issue by making `Variant::ObjData`  treat RefCounted as a regular Object if the count is zero, meaning it will skip the ref/unref operations. This is okay because the object is still valid and no one else is holding the object, so there is no difference between such an object and a regular unmanaged object.

After the fix the above experiment gives the following output as expected:

```text
predelete. self:<RefCounted#-9223372007175879347> is_instance_id_valid:true instance_from_id:<RefCounted#-9223372007175879347>
```

Test project:
[test-predelete-refcounted.tar.gz](https://github.com/user-attachments/files/18343973/test-predelete-refcounted.tar.gz)

