### PR TITLE
GLTF: Only pad zeros when exporting numbered images

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3832,10 +3832,9 @@ Error GLTFDocument::_serialize_images(Ref<GLTFState> p_state) {
 		if (p_state->filename.to_lower().ends_with("gltf")) {
 			String img_name = p_state->images[i]->get_name();
 			if (img_name.is_empty()) {
-				img_name = itos(i);
+				img_name = itos(i).pad_zeros(3);
 			}
 			img_name = _gen_unique_name(p_state, img_name);
-			img_name = img_name.pad_zeros(3);
 			String relative_texture_dir = "textures";
 			String full_texture_dir = p_state->base_path.path_join(relative_texture_dir);
 			Ref<DirAccess> da = DirAccess::open(p_state->base_path);


### PR DESCRIPTION
Before this PR, when exporting glTF files, Godot would produce image filenames like `000.png` for files without a name and `myname000.png` for files that do have a name. This is silly. Also, the padding happened after the unique name was reserved, making the name uniqueness feature not work in all cases.

This PR fixes it so that the zero padding happens only when generating a number for the filename, and so if the image has a name, it will look like `myname.png`. Note that if there are 2 images with the same name, one will get `myname2.png` etc, because of the name uniqueness feature, so there will be no ambiguity with the names of exported files.

Note: This only affects *exporting* glTF files, it doesn't break compatibility at all for importing.