### PR TITLE
GLTF: Don't write unused light properties

### DIFF
--- a/modules/gltf/extensions/gltf_light.cpp
+++ b/modules/gltf/extensions/gltf_light.cpp
@@ -221,21 +221,27 @@ Ref<GLTFLight> GLTFLight::from_dictionary(const Dictionary p_dictionary) {
 
 Dictionary GLTFLight::to_dictionary() const {
 	Dictionary d;
-	Array color_array;
-	color_array.resize(3);
-	color_array[0] = color.r;
-	color_array[1] = color.g;
-	color_array[2] = color.b;
-	d["color"] = color_array;
-	d["type"] = light_type;
+	if (color != Color(1.0f, 1.0f, 1.0f)) {
+		Array color_array;
+		color_array.resize(3);
+		color_array[0] = color.r;
+		color_array[1] = color.g;
+		color_array[2] = color.b;
+		d["color"] = color_array;
+	}
+	if (intensity != 1.0f) {
+		d["intensity"] = intensity;
+	}
+	if (light_type != "directional" && range != INFINITY) {
+		d["range"] = range;
+	}
 	if (light_type == "spot") {
 		Dictionary spot_dict;
 		spot_dict["innerConeAngle"] = inner_cone_angle;
 		spot_dict["outerConeAngle"] = outer_cone_angle;
 		d["spot"] = spot_dict;
 	}
-	d["intensity"] = intensity;
-	d["range"] = range;
+	d["type"] = light_type;
 	return d;
 }
 


### PR DESCRIPTION
https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual

When exporting a glTF light in Godot, it always writes several properties even when it does not need to. Per the above spec, most of these properties have default values, only `"type"` is required. Also, we are not supposed to write the range when exporting directional lights, and glTF-Validator produces a note about the property being unused:

<img width="800" alt="Screenshot 2025-01-08 at 12 29 27 AM" src="https://github.com/user-attachments/assets/ba1129da-7287-44dc-8c3c-42db7920e5cd" />

Note: This only affects *exporting* glTF files, it doesn't break compatibility at all for importing.

I'm putting this on the 4.4 milestone because this is a very minor fix.