### PR TITLE
Use `AHashMap` for `SurfaceTool`

### DIFF
--- a/scene/resources/surface_tool.h
+++ b/scene/resources/surface_tool.h
@@ -43,17 +43,23 @@ class SurfaceTool : public RefCounted {
 
 public:
 	struct Vertex {
-		Vector3 vertex;
+		// Trivial data for which the hash is computed using hash_buffer.
+		// ----------------------------------------------------------------
+		uint32_t smooth_group = 0; // Must be first.
+
 		Color color;
-		Vector3 normal; // normal, binormal, tangent
+		Vector3 normal; // normal, binormal, tangent.
 		Vector3 binormal;
 		Vector3 tangent;
 		Vector2 uv;
 		Vector2 uv2;
+		Color custom[RS::ARRAY_CUSTOM_COUNT];
+
+		Vector3 vertex; // Must be last.
+		// ----------------------------------------------------------------
+
 		Vector<int> bones;
 		Vector<float> weights;
-		Color custom[RS::ARRAY_CUSTOM_COUNT];
-		uint32_t smooth_group = 0;
 
 		bool operator==(const Vertex &p_vertex) const;
 


### PR DESCRIPTION
Makes `index` method 6x faster and `generate_normals` 3x faster.

Tested in https://github.com/godotengine/godot-demo-projects/tree/master/3d/voxel.

In the `_generate_chunk_mesh` method of the `Chunk` class, I used `Time.get_ticks_usec` to get the elapsed time.

Master:
```
Total mesh generation time:1990
Generate normals time:132
index time:798
 
Total mesh generation time:2402
Generate normals time:150
index time:980
 
Total mesh generation time:1976
Generate normals time:122
index time:786
 
Total mesh generation time:2403
Generate normals time:158
index time:967
 
Total mesh generation time:2205
Generate normals time:132
index time:875
 
Total mesh generation time:2415
Generate normals time:154
index time:970
 
Total mesh generation time:2590
Generate normals time:165
index time:1039
```
Current PR:
```
Total mesh generation time:1556
Generate normals time:69
index time:182
 
Total mesh generation time:1350
Generate normals time:60
index time:157
 
Total mesh generation time:1558
Generate normals time:72
index time:184
 
Total mesh generation time:1087
Generate normals time:51
index time:132
 
Total mesh generation time:1408
Generate normals time:61
index time:161
 
Total mesh generation time:1709
Generate normals time:90
index time:153
 
Total mesh generation time:1348
Generate normals time:59
index time:156
```
It is worth noting that GDScript has now become the bottleneck, and if we were to do the same generation in C#, the total generation time would decrease many times.