### PR TITLE
GLTF: Don't write unused `"targetNames"` on meshes

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3193,9 +3193,11 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 			primitives.push_back(primitive);
 		}
 
-		Dictionary e;
-		e["targetNames"] = target_names;
-		gltf_mesh["extras"] = e;
+		if (!target_names.is_empty()) {
+			Dictionary e;
+			e["targetNames"] = target_names;
+			gltf_mesh["extras"] = e;
+		}
 		_attach_meta_to_extras(import_mesh, gltf_mesh);
 
 		weights.resize(target_names.size());


### PR DESCRIPTION
When exporting a default box mesh to glTF from Godot, it looks like this:

<img width="760" alt="Screenshot 2025-01-08 at 1 02 57 AM" src="https://github.com/user-attachments/assets/809db407-9ffc-4c22-a35c-b610673f8f8d" />

The empty material and warnings about unused tangent and texcoord is unfortunate, but we need to keep those as-is in case a material extension wants to add content or use those parameters.

However, we can at least get rid of the unused `"targetNames"` in `"extras"`. We don't need to save this if it's empty. If an extension needs it for some reason, they should be using the `get_or_add` function regardless of this PR.

Note: This only affects *exporting* glTF files, it doesn't break compatibility at all for importing.

I'm labeling this as an enhancement because technically this does not fix any validator warnings or anything, it is purely an improvement to efficiently encoding meshes by removing the unused field.