### PR TITLE
Fix GCC warning about potential stringop-overflow in AudioEffectPitcShift

### DIFF
--- a/servers/audio/effects/audio_effect_pitch_shift.h
+++ b/servers/audio/effects/audio_effect_pitch_shift.h
@@ -77,7 +77,7 @@ class AudioEffectPitchShift : public AudioEffect {
 public:
 	friend class AudioEffectPitchShiftInstance;
 
-	enum FFTSize {
+	enum FFTSize : unsigned int {
 		FFT_SIZE_256,
 		FFT_SIZE_512,
 		FFT_SIZE_1024,


### PR DESCRIPTION
Fixes #101236.