### PR TITLE
[Editor] Add editor setting to globally override project game mode settings.

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1136,6 +1136,9 @@
 			- [b]Launch in PiP mode[/b] will launch the Play window directly in picture-in-picture (PiP) mode if PiP mode is supported and enabled. When maximized, the Play window will occupy the same window as the Editor.
 			[b]Note:[/b] Only available in the Android editor.
 		</member>
+		<member name="run/window_placement/game_embed_mode" type="int" setter="" getter="">
+			Overrides game embedding setting for all newly opened projects. If enabled, game embedding settings are not saved.
+		</member>
 		<member name="run/window_placement/play_window_pip_mode" type="int" setter="" getter="">
 			Specifies the picture-in-picture (PiP) mode for the Play window.
 			- [b]Disabled:[/b] PiP is disabled for the Play window.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -940,6 +940,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	String android_window_hints = "Auto (based on screen size):0,Same as Editor:1,Side-by-side with Editor:2,Launch in PiP mode:3";
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "run/window_placement/android_window", 0, android_window_hints)
 
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "run/window_placement/game_embed_mode", 0, "Use Per-Project Configuration:0,Embed Game:1,Make Game Workspace Floating:2,Disabled:3");
+
 	int default_play_window_pip_mode = 0;
 #ifdef ANDROID_ENABLED
 	default_play_window_pip_mode = 2;

--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -401,11 +401,17 @@ void GameView::_embed_options_menu_menu_id_pressed(int p_id) {
 	switch (p_id) {
 		case EMBED_RUN_GAME_EMBEDDED: {
 			embed_on_play = !embed_on_play;
-			EditorSettings::get_singleton()->set_project_metadata("game_view", "embed_on_play", embed_on_play);
+			int game_mode = EDITOR_GET("run/window_placement/game_embed_mode");
+			if (game_mode == 0) { // Save only if not overridden by editor.
+				EditorSettings::get_singleton()->set_project_metadata("game_view", "embed_on_play", embed_on_play);
+			}
 		} break;
 		case EMBED_MAKE_FLOATING_ON_PLAY: {
 			make_floating_on_play = !make_floating_on_play;
-			EditorSettings::get_singleton()->set_project_metadata("game_view", "make_floating_on_play", make_floating_on_play);
+			int game_mode = EDITOR_GET("run/window_placement/game_embed_mode");
+			if (game_mode == 0) { // Save only if not overridden by editor.
+				EditorSettings::get_singleton()->set_project_metadata("game_view", "make_floating_on_play", make_floating_on_play);
+			}
 		} break;
 	}
 	_update_embed_menu_options();
@@ -585,9 +591,27 @@ void GameView::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_WINDOW_EMBEDDING)) {
 				// Embedding available.
-				embed_on_play = EditorSettings::get_singleton()->get_project_metadata("game_view", "embed_on_play", true);
-				make_floating_on_play = EditorSettings::get_singleton()->get_project_metadata("game_view", "make_floating_on_play", true);
+				int game_mode = EDITOR_GET("run/window_placement/game_embed_mode");
+				switch (game_mode) {
+					case 1: { // Embed.
+						embed_on_play = true;
+						make_floating_on_play = false;
+					} break;
+					case 2: { // Floating.
+						embed_on_play = true;
+						make_floating_on_play = true;
+					} break;
+					case 3: { // Disabled.
+						embed_on_play = false;
+						make_floating_on_play = false;
+					} break;
+					default: {
+						embed_on_play = EditorSettings::get_singleton()->get_project_metadata("game_view", "embed_on_play", true);
+						make_floating_on_play = EditorSettings::get_singleton()->get_project_metadata("game_view", "make_floating_on_play", true);
+					} break;
+				}
 				embed_size_mode = (EmbedSizeMode)(int)EditorSettings::get_singleton()->get_project_metadata("game_view", "embed_size_mode", SIZE_MODE_FIXED);
+				keep_aspect_button->set_pressed(EditorSettings::get_singleton()->get_project_metadata("game_view", "keep_aspect", true));
 				_update_embed_menu_options();
 
 				EditorRunBar::get_singleton()->connect("play_pressed", callable_mp(this, &GameView::_play_pressed));


### PR DESCRIPTION
Adds editor setting to override game mode config (set to use project settings by default, so default behavior is not changed). It's extremely annoying to have embedding enabled for every new project I open.