### PR TITLE
Use `LocalVector` in `Animation`

### DIFF
--- a/scene/3d/physics/physical_bone_simulator_3d.cpp
+++ b/scene/3d/physics/physical_bone_simulator_3d.cpp
@@ -74,7 +74,7 @@ void PhysicalBoneSimulator3D::_pose_updated() {
 		return;
 	}
 	// If this triggers that means that we likely haven't rebuilt the bone list yet.
-	if (skeleton->get_bone_count() != bones.size()) {
+	if (skeleton->get_bone_count() != (int)bones.size()) {
 		// NOTE: this is re-entrant and will call _pose_updated again.
 		_bone_list_changed();
 	} else {
@@ -85,8 +85,8 @@ void PhysicalBoneSimulator3D::_pose_updated() {
 }
 
 void PhysicalBoneSimulator3D::_bone_pose_updated(Skeleton3D *p_skeleton, int p_bone_id) {
-	ERR_FAIL_INDEX(p_bone_id, bones.size());
-	bones.write[p_bone_id].global_pose = p_skeleton->get_bone_global_pose(p_bone_id);
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_bone_id, bones.size());
+	bones[p_bone_id].global_pose = p_skeleton->get_bone_global_pose(p_bone_id);
 }
 
 void PhysicalBoneSimulator3D::_set_active(bool p_active) {
@@ -96,7 +96,7 @@ void PhysicalBoneSimulator3D::_set_active(bool p_active) {
 }
 
 void PhysicalBoneSimulator3D::_reset_physical_bones_state() {
-	for (int i = 0; i < bones.size(); i += 1) {
+	for (uint32_t i = 0; i < bones.size(); i += 1) {
 		if (bones[i].physical_bone) {
 			bones[i].physical_bone->reset_physics_simulation_state();
 		}
@@ -140,7 +140,7 @@ void PhysicalBoneSimulator3D::bind_physical_bone_to_bone(int p_bone, PhysicalBon
 	ERR_FAIL_INDEX(p_bone, bone_size);
 	ERR_FAIL_COND(bones[p_bone].physical_bone);
 	ERR_FAIL_NULL(p_physical_bone);
-	bones.write[p_bone].physical_bone = p_physical_bone;
+	bones[p_bone].physical_bone = p_physical_bone;
 
 	_rebuild_physical_bones_cache();
 }
@@ -148,7 +148,7 @@ void PhysicalBoneSimulator3D::bind_physical_bone_to_bone(int p_bone, PhysicalBon
 void PhysicalBoneSimulator3D::unbind_physical_bone_from_bone(int p_bone) {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
-	bones.write[p_bone].physical_bone = nullptr;
+	bones[p_bone].physical_bone = nullptr;
 
 	_rebuild_physical_bones_cache();
 }
@@ -193,7 +193,7 @@ void PhysicalBoneSimulator3D::_rebuild_physical_bones_cache() {
 	for (int i = 0; i < b_size; ++i) {
 		PhysicalBone3D *parent_pb = _get_physical_bone_parent(i);
 		if (parent_pb != bones[i].cache_parent_physical_bone) {
-			bones.write[i].cache_parent_physical_bone = parent_pb;
+			bones[i].cache_parent_physical_bone = parent_pb;
 			if (bones[i].physical_bone) {
 				bones[i].physical_bone->_on_bone_parent_changed();
 			}
@@ -361,7 +361,7 @@ Transform3D PhysicalBoneSimulator3D::get_bone_global_pose(int p_bone) const {
 void PhysicalBoneSimulator3D::set_bone_global_pose(int p_bone, const Transform3D &p_pose) {
 	const int bone_size = bones.size();
 	ERR_FAIL_INDEX(p_bone, bone_size);
-	bones.write[p_bone].global_pose = p_pose;
+	bones[p_bone].global_pose = p_pose;
 }
 
 void PhysicalBoneSimulator3D::_process_modification(double p_delta) {
@@ -369,7 +369,7 @@ void PhysicalBoneSimulator3D::_process_modification(double p_delta) {
 	if (!skeleton) {
 		return;
 	}
-	ERR_FAIL_COND(skeleton->get_bone_count() != bones.size());
+	ERR_FAIL_COND(skeleton->get_bone_count() != (int)bones.size());
 	for (int i = 0; i < skeleton->get_bone_count(); i++) {
 		if (!bones[i].physical_bone) {
 			continue;

--- a/scene/3d/physics/physical_bone_simulator_3d.h
+++ b/scene/3d/physics/physical_bone_simulator_3d.h
@@ -56,7 +56,7 @@ class PhysicalBoneSimulator3D : public SkeletonModifier3D {
 		}
 	};
 
-	Vector<SimulatedBone> bones;
+	LocalVector<SimulatedBone> bones;
 
 	/// This is a slow API, so it's cached
 	PhysicalBone3D *_get_physical_bone_parent(int p_bone);

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -609,10 +609,10 @@ void AnimationMixer::_create_track_num_to_track_cache_for_animation(Ref<Animatio
 		return;
 	}
 	LocalVector<TrackCache *> &track_num_to_track_cache = animation_track_num_to_track_cache.insert_new(p_animation, LocalVector<TrackCache *>())->value;
-	const Vector<Animation::Track *> &tracks = p_animation->get_tracks();
+	const LocalVector<Animation::Track *> &tracks = p_animation->get_tracks();
 
 	track_num_to_track_cache.resize(tracks.size());
-	for (int i = 0; i < tracks.size(); i++) {
+	for (uint32_t i = 0; i < tracks.size(); i++) {
 		TrackCache **track_ptr = track_cache.getptr(tracks[i]->thash);
 		if (track_ptr == nullptr) {
 			track_num_to_track_cache[i] = nullptr;
@@ -1133,7 +1133,7 @@ void AnimationMixer::_blend_calc_total_weight() {
 		LocalVector<TrackCache *> &track_num_to_track_cache = animation_track_num_to_track_cache[a];
 		thread_local HashSet<Animation::TypeHash, HashHasher> processed_hashes;
 		processed_hashes.clear();
-		const Vector<Animation::Track *> tracks = a->get_tracks();
+		const LocalVector<Animation::Track *> &tracks = a->get_tracks();
 		Animation::Track *const *tracks_ptr = tracks.ptr();
 		int count = tracks.size();
 		for (int i = 0; i < count; i++) {
@@ -1181,7 +1181,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 #endif // _3D_DISABLED
 		ERR_CONTINUE_EDMSG(!animation_track_num_to_track_cache.has(a), "No animation in cache.");
 		LocalVector<TrackCache *> &track_num_to_track_cache = animation_track_num_to_track_cache[a];
-		const Vector<Animation::Track *> tracks = a->get_tracks();
+		const LocalVector<Animation::Track *> &tracks = a->get_tracks();
 		Animation::Track *const *tracks_ptr = tracks.ptr();
 		real_t a_length = a->get_length();
 		int count = tracks.size();

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -83,7 +83,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 		int track = prop_name.get_slicec('/', 1).to_int();
 		String what = prop_name.get_slicec('/', 2);
 
-		if (tracks.size() == track && what == "type") {
+		if (tracks.size() == (uint32_t)track && what == "type") {
 			String type = p_value;
 
 			if (type == "position_3d") {
@@ -111,7 +111,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 			return true;
 		}
 
-		ERR_FAIL_INDEX_V(track, tracks.size(), false);
+		ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)track, tracks.size(), false);
 
 		if (what == "path") {
 			track_set_path(track, p_value);
@@ -167,7 +167,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				int64_t count = vcount / POSITION_TRACK_SIZE;
 				tt->positions.resize(count);
 
-				TKey<Vector3> *tw = tt->positions.ptrw();
+				TKey<Vector3> *tw = tt->positions.ptr();
 				for (int i = 0; i < count; i++) {
 					TKey<Vector3> &tk = tw[i];
 					const real_t *ofs = &r[i * POSITION_TRACK_SIZE];
@@ -189,7 +189,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				int64_t count = vcount / ROTATION_TRACK_SIZE;
 				rt->rotations.resize(count);
 
-				TKey<Quaternion> *rw = rt->rotations.ptrw();
+				TKey<Quaternion> *rw = rt->rotations.ptr();
 				for (int i = 0; i < count; i++) {
 					TKey<Quaternion> &rk = rw[i];
 					const real_t *ofs = &r[i * ROTATION_TRACK_SIZE];
@@ -212,7 +212,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				int64_t count = vcount / SCALE_TRACK_SIZE;
 				st->scales.resize(count);
 
-				TKey<Vector3> *sw = st->scales.ptrw();
+				TKey<Vector3> *sw = st->scales.ptr();
 				for (int i = 0; i < count; i++) {
 					TKey<Vector3> &sk = sw[i];
 					const real_t *ofs = &r[i * SCALE_TRACK_SIZE];
@@ -234,7 +234,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				int64_t count = vcount / BLEND_SHAPE_TRACK_SIZE;
 				st->blend_shapes.resize(count);
 
-				TKey<float> *sw = st->blend_shapes.ptrw();
+				TKey<float> *sw = st->blend_shapes.ptr();
 				for (int i = 0; i < count; i++) {
 					TKey<float> &sk = sw[i];
 					const real_t *ofs = &r[i * BLEND_SHAPE_TRACK_SIZE];
@@ -277,8 +277,8 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 					vt->values.resize(valcount);
 
 					for (int i = 0; i < valcount; i++) {
-						vt->values.write[i].time = rt[i];
-						vt->values.write[i].value = values[i];
+						vt->values[i].time = rt[i];
+						vt->values[i].value = values[i];
 					}
 
 					if (d.has("transitions")) {
@@ -288,7 +288,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 						const real_t *rtr = transitions.ptr();
 
 						for (int i = 0; i < valcount; i++) {
-							vt->values.write[i].transition = rtr[i];
+							vt->values[i].transition = rtr[i];
 						}
 					}
 				}
@@ -359,15 +359,15 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 					bt->values.resize(valcount);
 
 					for (int i = 0; i < valcount; i++) {
-						bt->values.write[i].time = rt[i];
-						bt->values.write[i].transition = 0; //unused in bezier
-						bt->values.write[i].value.value = rv[i * 5 + 0];
-						bt->values.write[i].value.in_handle.x = rv[i * 5 + 1];
-						bt->values.write[i].value.in_handle.y = rv[i * 5 + 2];
-						bt->values.write[i].value.out_handle.x = rv[i * 5 + 3];
-						bt->values.write[i].value.out_handle.y = rv[i * 5 + 4];
+						bt->values[i].time = rt[i];
+						bt->values[i].transition = 0; //unused in bezier
+						bt->values[i].value.value = rv[i * 5 + 0];
+						bt->values[i].value.in_handle.x = rv[i * 5 + 1];
+						bt->values[i].value.in_handle.y = rv[i * 5 + 2];
+						bt->values[i].value.out_handle.x = rv[i * 5 + 3];
+						bt->values[i].value.out_handle.y = rv[i * 5 + 4];
 #ifdef TOOLS_ENABLED
-						bt->values.write[i].value.handle_mode = static_cast<HandleMode>(rh[i]);
+						bt->values[i].value.handle_mode = static_cast<HandleMode>(rh[i]);
 #endif // TOOLS_ENABLED
 					}
 				}
@@ -437,7 +437,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 						TKey<StringName> ak;
 						ak.time = rt[i];
 						ak.value = rc[i];
-						an->values.write[i] = ak;
+						an->values[i] = ak;
 					}
 				}
 
@@ -509,7 +509,7 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (prop_name.begins_with("tracks/")) {
 		int track = prop_name.get_slicec('/', 1).to_int();
 		String what = prop_name.get_slicec('/', 2);
-		ERR_FAIL_INDEX_V(track, tracks.size(), false);
+		ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)track, tracks.size(), false);
 		if (what == "type") {
 			switch (track_get_type(track)) {
 				case TYPE_POSITION_3D:
@@ -870,7 +870,7 @@ void Animation::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::DICTIONARY, "_compression", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 	}
 	p_list->push_back(PropertyInfo(Variant::ARRAY, "markers", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
-	for (int i = 0; i < tracks.size(); i++) {
+	for (uint32_t i = 0; i < tracks.size(); i++) {
 		p_list->push_back(PropertyInfo(Variant::STRING, "tracks/" + itos(i) + "/type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 		p_list->push_back(PropertyInfo(Variant::BOOL, "tracks/" + itos(i) + "/imported", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 		p_list->push_back(PropertyInfo(Variant::BOOL, "tracks/" + itos(i) + "/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
@@ -893,7 +893,7 @@ void Animation::reset_state() {
 }
 
 int Animation::add_track(TrackType p_type, int p_at_pos) {
-	if (p_at_pos < 0 || p_at_pos >= tracks.size()) {
+	if ((uint32_t)p_at_pos >= tracks.size()) {
 		p_at_pos = tracks.size();
 	}
 
@@ -943,7 +943,7 @@ int Animation::add_track(TrackType p_type, int p_at_pos) {
 }
 
 void Animation::remove_track(int p_track) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
@@ -1010,7 +1010,7 @@ bool Animation::is_capture_included() const {
 
 void Animation::_check_capture_included() {
 	capture_included = false;
-	for (int i = 0; i < tracks.size(); i++) {
+	for (uint32_t i = 0; i < tracks.size(); i++) {
 		if (tracks[i]->type == TYPE_VALUE) {
 			ValueTrack *vt = static_cast<ValueTrack *>(tracks[i]);
 			if (vt->update_mode == UPDATE_CAPTURE) {
@@ -1026,24 +1026,24 @@ int Animation::get_track_count() const {
 }
 
 Animation::TrackType Animation::track_get_type(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), TYPE_VALUE);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), TYPE_VALUE);
 	return tracks[p_track]->type;
 }
 
 void Animation::track_set_path(int p_track, const NodePath &p_path) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	tracks[p_track]->path = p_path;
 	_track_update_hash(p_track);
 	emit_changed();
 }
 
 NodePath Animation::track_get_path(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), NodePath());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), NodePath());
 	return tracks[p_track]->path;
 }
 
 int Animation::find_track(const NodePath &p_path, const TrackType p_type) const {
-	for (int i = 0; i < tracks.size(); i++) {
+	for (uint32_t i = 0; i < tracks.size(); i++) {
 		if (tracks[i]->path == p_path && tracks[i]->type == p_type) {
 			return i;
 		}
@@ -1068,29 +1068,29 @@ void Animation::_track_update_hash(int p_track) {
 }
 
 Animation::TypeHash Animation::track_get_type_hash(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), 0);
 	return tracks[p_track]->thash;
 }
 
 void Animation::track_set_interpolation_type(int p_track, InterpolationType p_interp) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	tracks[p_track]->interpolation = p_interp;
 	emit_changed();
 }
 
 Animation::InterpolationType Animation::track_get_interpolation_type(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), INTERPOLATION_NEAREST);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), INTERPOLATION_NEAREST);
 	return tracks[p_track]->interpolation;
 }
 
 void Animation::track_set_interpolation_loop_wrap(int p_track, bool p_enable) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	tracks[p_track]->loop_wrap = p_enable;
 	emit_changed();
 }
 
 bool Animation::track_get_interpolation_loop_wrap(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), INTERPOLATION_NEAREST);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), INTERPOLATION_NEAREST);
 	return tracks[p_track]->loop_wrap;
 }
 
@@ -1102,8 +1102,8 @@ int Animation::_insert(double p_time, T &p_keys, const V &p_value) {
 		// Condition for replacement.
 		if (idx > 0 && Math::is_equal_approx((double)p_keys[idx - 1].time, p_time)) {
 			float transition = p_keys[idx - 1].transition;
-			p_keys.write[idx - 1] = p_value;
-			p_keys.write[idx - 1].transition = transition;
+			p_keys[idx - 1] = p_value;
+			p_keys[idx - 1].transition = transition;
 			return idx - 1;
 
 			// Condition for insert.
@@ -1118,13 +1118,13 @@ int Animation::_insert(double p_time, T &p_keys, const V &p_value) {
 	return -1;
 }
 
-int Animation::_marker_insert(double p_time, Vector<MarkerKey> &p_keys, const MarkerKey &p_value) {
+int Animation::_marker_insert(double p_time, LocalVector<MarkerKey> &p_keys, const MarkerKey &p_value) {
 	int idx = p_keys.size();
 
 	while (true) {
 		// Condition for replacement.
 		if (idx > 0 && Math::is_equal_approx((double)p_keys[idx - 1].time, p_time)) {
-			p_keys.write[idx - 1] = p_value;
+			p_keys[idx - 1] = p_value;
 			return idx - 1;
 
 			// Condition for insert.
@@ -1142,7 +1142,7 @@ int Animation::_marker_insert(double p_time, Vector<MarkerKey> &p_keys, const Ma
 ////
 
 int Animation::position_track_insert_key(int p_track, double p_time, const Vector3 &p_position) {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_POSITION_3D, -1);
 
@@ -1160,7 +1160,7 @@ int Animation::position_track_insert_key(int p_track, double p_time, const Vecto
 }
 
 Error Animation::position_track_get_key(int p_track, int p_key, Vector3 *r_position) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
 
 	PositionTrack *tt = static_cast<PositionTrack *>(t);
@@ -1178,7 +1178,7 @@ Error Animation::position_track_get_key(int p_track, int p_key, Vector3 *r_posit
 		return OK;
 	}
 
-	ERR_FAIL_INDEX_V(p_key, tt->positions.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, tt->positions.size(), ERR_INVALID_PARAMETER);
 
 	*r_position = tt->positions[p_key].value;
 
@@ -1186,7 +1186,7 @@ Error Animation::position_track_get_key(int p_track, int p_key, Vector3 *r_posit
 }
 
 Error Animation::try_position_track_interpolate(int p_track, double p_time, Vector3 *r_interpolation, bool p_backward) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_POSITION_3D, ERR_INVALID_PARAMETER);
 
@@ -1213,7 +1213,7 @@ Error Animation::try_position_track_interpolate(int p_track, double p_time, Vect
 
 Vector3 Animation::position_track_interpolate(int p_track, double p_time, bool p_backward) const {
 	Vector3 ret = Vector3(0, 0, 0);
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ret);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ret);
 	bool err = try_position_track_interpolate(p_track, p_time, &ret, p_backward);
 	ERR_FAIL_COND_V_MSG(err, ret, "3D Position Track: '" + String(tracks[p_track]->path) + "' is unavailable.");
 	return ret;
@@ -1222,7 +1222,7 @@ Vector3 Animation::position_track_interpolate(int p_track, double p_time, bool p
 ////
 
 int Animation::rotation_track_insert_key(int p_track, double p_time, const Quaternion &p_rotation) {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ROTATION_3D, -1);
 
@@ -1240,7 +1240,7 @@ int Animation::rotation_track_insert_key(int p_track, double p_time, const Quate
 }
 
 Error Animation::rotation_track_get_key(int p_track, int p_key, Quaternion *r_rotation) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
 
 	RotationTrack *rt = static_cast<RotationTrack *>(t);
@@ -1258,7 +1258,7 @@ Error Animation::rotation_track_get_key(int p_track, int p_key, Quaternion *r_ro
 		return OK;
 	}
 
-	ERR_FAIL_INDEX_V(p_key, rt->rotations.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, rt->rotations.size(), ERR_INVALID_PARAMETER);
 
 	*r_rotation = rt->rotations[p_key].value;
 
@@ -1266,7 +1266,7 @@ Error Animation::rotation_track_get_key(int p_track, int p_key, Quaternion *r_ro
 }
 
 Error Animation::try_rotation_track_interpolate(int p_track, double p_time, Quaternion *r_interpolation, bool p_backward) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ROTATION_3D, ERR_INVALID_PARAMETER);
 
@@ -1293,7 +1293,7 @@ Error Animation::try_rotation_track_interpolate(int p_track, double p_time, Quat
 
 Quaternion Animation::rotation_track_interpolate(int p_track, double p_time, bool p_backward) const {
 	Quaternion ret = Quaternion(0, 0, 0, 1);
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ret);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ret);
 	bool err = try_rotation_track_interpolate(p_track, p_time, &ret, p_backward);
 	ERR_FAIL_COND_V_MSG(err, ret, "3D Rotation Track: '" + String(tracks[p_track]->path) + "' is unavailable.");
 	return ret;
@@ -1302,7 +1302,7 @@ Quaternion Animation::rotation_track_interpolate(int p_track, double p_time, boo
 ////
 
 int Animation::scale_track_insert_key(int p_track, double p_time, const Vector3 &p_scale) {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_SCALE_3D, -1);
 
@@ -1320,7 +1320,7 @@ int Animation::scale_track_insert_key(int p_track, double p_time, const Vector3 
 }
 
 Error Animation::scale_track_get_key(int p_track, int p_key, Vector3 *r_scale) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
 
 	ScaleTrack *st = static_cast<ScaleTrack *>(t);
@@ -1338,7 +1338,7 @@ Error Animation::scale_track_get_key(int p_track, int p_key, Vector3 *r_scale) c
 		return OK;
 	}
 
-	ERR_FAIL_INDEX_V(p_key, st->scales.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, st->scales.size(), ERR_INVALID_PARAMETER);
 
 	*r_scale = st->scales[p_key].value;
 
@@ -1346,7 +1346,7 @@ Error Animation::scale_track_get_key(int p_track, int p_key, Vector3 *r_scale) c
 }
 
 Error Animation::try_scale_track_interpolate(int p_track, double p_time, Vector3 *r_interpolation, bool p_backward) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_SCALE_3D, ERR_INVALID_PARAMETER);
 
@@ -1373,7 +1373,7 @@ Error Animation::try_scale_track_interpolate(int p_track, double p_time, Vector3
 
 Vector3 Animation::scale_track_interpolate(int p_track, double p_time, bool p_backward) const {
 	Vector3 ret = Vector3(1, 1, 1);
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ret);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ret);
 	bool err = try_scale_track_interpolate(p_track, p_time, &ret, p_backward);
 	ERR_FAIL_COND_V_MSG(err, ret, "3D Scale Track: '" + String(tracks[p_track]->path) + "' is unavailable.");
 	return ret;
@@ -1382,7 +1382,7 @@ Vector3 Animation::scale_track_interpolate(int p_track, double p_time, bool p_ba
 ////
 
 int Animation::blend_shape_track_insert_key(int p_track, double p_time, float p_blend_shape) {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BLEND_SHAPE, -1);
 
@@ -1400,7 +1400,7 @@ int Animation::blend_shape_track_insert_key(int p_track, double p_time, float p_
 }
 
 Error Animation::blend_shape_track_get_key(int p_track, int p_key, float *r_blend_shape) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
 
 	BlendShapeTrack *bst = static_cast<BlendShapeTrack *>(t);
@@ -1418,7 +1418,7 @@ Error Animation::blend_shape_track_get_key(int p_track, int p_key, float *r_blen
 		return OK;
 	}
 
-	ERR_FAIL_INDEX_V(p_key, bst->blend_shapes.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, bst->blend_shapes.size(), ERR_INVALID_PARAMETER);
 
 	*r_blend_shape = bst->blend_shapes[p_key].value;
 
@@ -1426,7 +1426,7 @@ Error Animation::blend_shape_track_get_key(int p_track, int p_key, float *r_blen
 }
 
 Error Animation::try_blend_shape_track_interpolate(int p_track, double p_time, float *r_interpolation, bool p_backward) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ERR_INVALID_PARAMETER);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BLEND_SHAPE, ERR_INVALID_PARAMETER);
 
@@ -1453,7 +1453,7 @@ Error Animation::try_blend_shape_track_interpolate(int p_track, double p_time, f
 
 float Animation::blend_shape_track_interpolate(int p_track, double p_time, bool p_backward) const {
 	float ret = 0;
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), ret);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), ret);
 	bool err = try_blend_shape_track_interpolate(p_track, p_time, &ret, p_backward);
 	ERR_FAIL_COND_V_MSG(err, ret, "Blend Shape Track: '" + String(tracks[p_track]->path) + "' is unavailable.");
 	return ret;
@@ -1468,7 +1468,7 @@ void Animation::track_remove_key_at_time(int p_track, double p_time) {
 }
 
 void Animation::track_remove_key(int p_track, int p_idx) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
@@ -1477,7 +1477,7 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 
 			ERR_FAIL_COND(tt->compressed_track >= 0);
 
-			ERR_FAIL_INDEX(p_idx, tt->positions.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, tt->positions.size());
 			tt->positions.remove_at(p_idx);
 
 		} break;
@@ -1486,7 +1486,7 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 
 			ERR_FAIL_COND(rt->compressed_track >= 0);
 
-			ERR_FAIL_INDEX(p_idx, rt->rotations.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, rt->rotations.size());
 			rt->rotations.remove_at(p_idx);
 
 		} break;
@@ -1495,7 +1495,7 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 
 			ERR_FAIL_COND(st->compressed_track >= 0);
 
-			ERR_FAIL_INDEX(p_idx, st->scales.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, st->scales.size());
 			st->scales.remove_at(p_idx);
 
 		} break;
@@ -1504,37 +1504,37 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 
 			ERR_FAIL_COND(bst->compressed_track >= 0);
 
-			ERR_FAIL_INDEX(p_idx, bst->blend_shapes.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, bst->blend_shapes.size());
 			bst->blend_shapes.remove_at(p_idx);
 
 		} break;
 		case TYPE_VALUE: {
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
-			ERR_FAIL_INDEX(p_idx, vt->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, vt->values.size());
 			vt->values.remove_at(p_idx);
 
 		} break;
 		case TYPE_METHOD: {
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
-			ERR_FAIL_INDEX(p_idx, mt->methods.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, mt->methods.size());
 			mt->methods.remove_at(p_idx);
 
 		} break;
 		case TYPE_BEZIER: {
 			BezierTrack *bz = static_cast<BezierTrack *>(t);
-			ERR_FAIL_INDEX(p_idx, bz->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, bz->values.size());
 			bz->values.remove_at(p_idx);
 
 		} break;
 		case TYPE_AUDIO: {
 			AudioTrack *ad = static_cast<AudioTrack *>(t);
-			ERR_FAIL_INDEX(p_idx, ad->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, ad->values.size());
 			ad->values.remove_at(p_idx);
 
 		} break;
 		case TYPE_ANIMATION: {
 			AnimationTrack *an = static_cast<AnimationTrack *>(t);
-			ERR_FAIL_INDEX(p_idx, an->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, an->values.size());
 			an->values.remove_at(p_idx);
 
 		} break;
@@ -1544,7 +1544,7 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 }
 
 int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, bool p_limit, bool p_backward) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
@@ -1566,7 +1566,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 			}
 
 			int k = _find(tt->positions, p_time, p_backward, p_limit);
-			if (k < 0 || k >= tt->positions.size()) {
+			if ((uint32_t)k >= tt->positions.size()) {
 				return -1;
 			}
 			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(tt->positions[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && tt->positions[k].time != p_time)) {
@@ -1593,7 +1593,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 			}
 
 			int k = _find(rt->rotations, p_time, p_backward, p_limit);
-			if (k < 0 || k >= rt->rotations.size()) {
+			if ((uint32_t)k >= rt->rotations.size()) {
 				return -1;
 			}
 			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(rt->rotations[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && rt->rotations[k].time != p_time)) {
@@ -1620,7 +1620,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 			}
 
 			int k = _find(st->scales, p_time, p_backward, p_limit);
-			if (k < 0 || k >= st->scales.size()) {
+			if ((uint32_t)k >= st->scales.size()) {
 				return -1;
 			}
 			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(st->scales[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && st->scales[k].time != p_time)) {
@@ -1647,7 +1647,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 			}
 
 			int k = _find(bst->blend_shapes, p_time, p_backward, p_limit);
-			if (k < 0 || k >= bst->blend_shapes.size()) {
+			if ((uint32_t)k >= bst->blend_shapes.size()) {
 				return -1;
 			}
 			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(bst->blend_shapes[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && bst->blend_shapes[k].time != p_time)) {
@@ -1659,7 +1659,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 		case TYPE_VALUE: {
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
 			int k = _find(vt->values, p_time, p_backward, p_limit);
-			if (k < 0 || k >= vt->values.size()) {
+			if ((uint32_t)k >= vt->values.size()) {
 				return -1;
 			}
 			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(vt->values[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && vt->values[k].time != p_time)) {
@@ -1671,7 +1671,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 		case TYPE_METHOD: {
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
 			int k = _find(mt->methods, p_time, p_backward, p_limit);
-			if (k < 0 || k >= mt->methods.size()) {
+			if ((uint32_t)k >= mt->methods.size()) {
 				return -1;
 			}
 			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(mt->methods[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && mt->methods[k].time != p_time)) {
@@ -1683,7 +1683,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 		case TYPE_BEZIER: {
 			BezierTrack *bt = static_cast<BezierTrack *>(t);
 			int k = _find(bt->values, p_time, p_backward, p_limit);
-			if (k < 0 || k >= bt->values.size()) {
+			if ((uint32_t)k >= bt->values.size()) {
 				return -1;
 			}
 			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(bt->values[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && bt->values[k].time != p_time)) {
@@ -1695,7 +1695,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 		case TYPE_AUDIO: {
 			AudioTrack *at = static_cast<AudioTrack *>(t);
 			int k = _find(at->values, p_time, p_backward, p_limit);
-			if (k < 0 || k >= at->values.size()) {
+			if ((uint32_t)k >= at->values.size()) {
 				return -1;
 			}
 			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(at->values[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && at->values[k].time != p_time)) {
@@ -1707,7 +1707,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 			int k = _find(at->values, p_time, p_backward, p_limit);
-			if (k < 0 || k >= at->values.size()) {
+			if ((uint32_t)k >= at->values.size()) {
 				return -1;
 			}
 			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(at->values[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && at->values[k].time != p_time)) {
@@ -1722,7 +1722,7 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 }
 
 int Animation::track_insert_key(int p_track, double p_time, const Variant &p_key, real_t p_transition) {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
 	int ret = -1;
@@ -1839,7 +1839,7 @@ int Animation::track_insert_key(int p_track, double p_time, const Variant &p_key
 }
 
 int Animation::track_get_key_count(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
@@ -1898,7 +1898,7 @@ int Animation::track_get_key_count(int p_track) const {
 }
 
 Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), Variant());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), Variant());
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
@@ -1924,13 +1924,13 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 		} break;
 		case TYPE_VALUE: {
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, vt->values.size(), Variant());
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, vt->values.size(), Variant());
 			return vt->values[p_key_idx].value;
 
 		} break;
 		case TYPE_METHOD: {
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, mt->methods.size(), Variant());
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, mt->methods.size(), Variant());
 			Dictionary d;
 			d["method"] = mt->methods[p_key_idx].method;
 			d["args"] = mt->methods[p_key_idx].params;
@@ -1939,7 +1939,7 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 		} break;
 		case TYPE_BEZIER: {
 			BezierTrack *bt = static_cast<BezierTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, bt->values.size(), Variant());
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, bt->values.size(), Variant());
 
 			Array arr;
 			arr.resize(5);
@@ -1953,7 +1953,7 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 		} break;
 		case TYPE_AUDIO: {
 			AudioTrack *at = static_cast<AudioTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, at->values.size(), Variant());
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, at->values.size(), Variant());
 
 			Dictionary k;
 			k["start_offset"] = at->values[p_key_idx].value.start_offset;
@@ -1964,7 +1964,7 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 		} break;
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, at->values.size(), Variant());
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, at->values.size(), Variant());
 
 			return at->values[p_key_idx].value;
 
@@ -1975,7 +1975,7 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 }
 
 double Animation::track_get_key_time(int p_track, int p_key_idx) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
@@ -1988,7 +1988,7 @@ double Animation::track_get_key_time(int p_track, int p_key_idx) const {
 				ERR_FAIL_COND_V(!fetch_compressed_success, false);
 				return time;
 			}
-			ERR_FAIL_INDEX_V(p_key_idx, tt->positions.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, tt->positions.size(), -1);
 			return tt->positions[p_key_idx].time;
 		} break;
 		case TYPE_ROTATION_3D: {
@@ -2000,7 +2000,7 @@ double Animation::track_get_key_time(int p_track, int p_key_idx) const {
 				ERR_FAIL_COND_V(!fetch_compressed_success, false);
 				return time;
 			}
-			ERR_FAIL_INDEX_V(p_key_idx, rt->rotations.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, rt->rotations.size(), -1);
 			return rt->rotations[p_key_idx].time;
 		} break;
 		case TYPE_SCALE_3D: {
@@ -2012,7 +2012,7 @@ double Animation::track_get_key_time(int p_track, int p_key_idx) const {
 				ERR_FAIL_COND_V(!fetch_compressed_success, false);
 				return time;
 			}
-			ERR_FAIL_INDEX_V(p_key_idx, st->scales.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, st->scales.size(), -1);
 			return st->scales[p_key_idx].time;
 		} break;
 		case TYPE_BLEND_SHAPE: {
@@ -2024,36 +2024,36 @@ double Animation::track_get_key_time(int p_track, int p_key_idx) const {
 				ERR_FAIL_COND_V(!fetch_compressed_success, false);
 				return time;
 			}
-			ERR_FAIL_INDEX_V(p_key_idx, bst->blend_shapes.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, bst->blend_shapes.size(), -1);
 			return bst->blend_shapes[p_key_idx].time;
 		} break;
 		case TYPE_VALUE: {
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, vt->values.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, vt->values.size(), -1);
 			return vt->values[p_key_idx].time;
 
 		} break;
 		case TYPE_METHOD: {
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, mt->methods.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, mt->methods.size(), -1);
 			return mt->methods[p_key_idx].time;
 
 		} break;
 		case TYPE_BEZIER: {
 			BezierTrack *bt = static_cast<BezierTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, bt->values.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, bt->values.size(), -1);
 			return bt->values[p_key_idx].time;
 
 		} break;
 		case TYPE_AUDIO: {
 			AudioTrack *at = static_cast<AudioTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, at->values.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, at->values.size(), -1);
 			return at->values[p_key_idx].time;
 
 		} break;
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, at->values.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, at->values.size(), -1);
 			return at->values[p_key_idx].time;
 
 		} break;
@@ -2063,14 +2063,14 @@ double Animation::track_get_key_time(int p_track, int p_key_idx) const {
 }
 
 void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
 		case TYPE_POSITION_3D: {
 			PositionTrack *tt = static_cast<PositionTrack *>(t);
 			ERR_FAIL_COND(tt->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, tt->positions.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, tt->positions.size());
 			TKey<Vector3> key = tt->positions[p_key_idx];
 			key.time = p_time;
 			tt->positions.remove_at(p_key_idx);
@@ -2080,7 +2080,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 		case TYPE_ROTATION_3D: {
 			RotationTrack *tt = static_cast<RotationTrack *>(t);
 			ERR_FAIL_COND(tt->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, tt->rotations.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, tt->rotations.size());
 			TKey<Quaternion> key = tt->rotations[p_key_idx];
 			key.time = p_time;
 			tt->rotations.remove_at(p_key_idx);
@@ -2090,7 +2090,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 		case TYPE_SCALE_3D: {
 			ScaleTrack *tt = static_cast<ScaleTrack *>(t);
 			ERR_FAIL_COND(tt->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, tt->scales.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, tt->scales.size());
 			TKey<Vector3> key = tt->scales[p_key_idx];
 			key.time = p_time;
 			tt->scales.remove_at(p_key_idx);
@@ -2100,7 +2100,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 		case TYPE_BLEND_SHAPE: {
 			BlendShapeTrack *tt = static_cast<BlendShapeTrack *>(t);
 			ERR_FAIL_COND(tt->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, tt->blend_shapes.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, tt->blend_shapes.size());
 			TKey<float> key = tt->blend_shapes[p_key_idx];
 			key.time = p_time;
 			tt->blend_shapes.remove_at(p_key_idx);
@@ -2109,7 +2109,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 		}
 		case TYPE_VALUE: {
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, vt->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, vt->values.size());
 			TKey<Variant> key = vt->values[p_key_idx];
 			key.time = p_time;
 			vt->values.remove_at(p_key_idx);
@@ -2118,7 +2118,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 		}
 		case TYPE_METHOD: {
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, mt->methods.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, mt->methods.size());
 			MethodKey key = mt->methods[p_key_idx];
 			key.time = p_time;
 			mt->methods.remove_at(p_key_idx);
@@ -2127,7 +2127,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 		}
 		case TYPE_BEZIER: {
 			BezierTrack *bt = static_cast<BezierTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, bt->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, bt->values.size());
 			TKey<BezierKey> key = bt->values[p_key_idx];
 			key.time = p_time;
 			bt->values.remove_at(p_key_idx);
@@ -2136,7 +2136,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 		}
 		case TYPE_AUDIO: {
 			AudioTrack *at = static_cast<AudioTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, at->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, at->values.size());
 			TKey<AudioKey> key = at->values[p_key_idx];
 			key.time = p_time;
 			at->values.remove_at(p_key_idx);
@@ -2145,7 +2145,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 		}
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, at->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, at->values.size());
 			TKey<StringName> key = at->values[p_key_idx];
 			key.time = p_time;
 			at->values.remove_at(p_key_idx);
@@ -2158,7 +2158,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 }
 
 real_t Animation::track_get_key_transition(int p_track, int p_key_idx) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
@@ -2167,7 +2167,7 @@ real_t Animation::track_get_key_transition(int p_track, int p_key_idx) const {
 			if (tt->compressed_track >= 0) {
 				return 1.0;
 			}
-			ERR_FAIL_INDEX_V(p_key_idx, tt->positions.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, tt->positions.size(), -1);
 			return tt->positions[p_key_idx].transition;
 		} break;
 		case TYPE_ROTATION_3D: {
@@ -2175,7 +2175,7 @@ real_t Animation::track_get_key_transition(int p_track, int p_key_idx) const {
 			if (rt->compressed_track >= 0) {
 				return 1.0;
 			}
-			ERR_FAIL_INDEX_V(p_key_idx, rt->rotations.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, rt->rotations.size(), -1);
 			return rt->rotations[p_key_idx].transition;
 		} break;
 		case TYPE_SCALE_3D: {
@@ -2183,7 +2183,7 @@ real_t Animation::track_get_key_transition(int p_track, int p_key_idx) const {
 			if (st->compressed_track >= 0) {
 				return 1.0;
 			}
-			ERR_FAIL_INDEX_V(p_key_idx, st->scales.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, st->scales.size(), -1);
 			return st->scales[p_key_idx].transition;
 		} break;
 		case TYPE_BLEND_SHAPE: {
@@ -2191,18 +2191,18 @@ real_t Animation::track_get_key_transition(int p_track, int p_key_idx) const {
 			if (bst->compressed_track >= 0) {
 				return 1.0;
 			}
-			ERR_FAIL_INDEX_V(p_key_idx, bst->blend_shapes.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, bst->blend_shapes.size(), -1);
 			return bst->blend_shapes[p_key_idx].transition;
 		} break;
 		case TYPE_VALUE: {
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, vt->values.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, vt->values.size(), -1);
 			return vt->values[p_key_idx].transition;
 
 		} break;
 		case TYPE_METHOD: {
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
-			ERR_FAIL_INDEX_V(p_key_idx, mt->methods.size(), -1);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, mt->methods.size(), -1);
 			return mt->methods[p_key_idx].transition;
 
 		} break;
@@ -2221,7 +2221,7 @@ real_t Animation::track_get_key_transition(int p_track, int p_key_idx) const {
 }
 
 bool Animation::track_is_compressed(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), false);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), false);
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
@@ -2248,7 +2248,7 @@ bool Animation::track_is_compressed(int p_track) const {
 }
 
 void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p_value) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
@@ -2256,92 +2256,92 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 			ERR_FAIL_COND((p_value.get_type() != Variant::VECTOR3) && (p_value.get_type() != Variant::VECTOR3I));
 			PositionTrack *tt = static_cast<PositionTrack *>(t);
 			ERR_FAIL_COND(tt->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, tt->positions.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, tt->positions.size());
 
-			tt->positions.write[p_key_idx].value = p_value;
+			tt->positions[p_key_idx].value = p_value;
 
 		} break;
 		case TYPE_ROTATION_3D: {
 			ERR_FAIL_COND((p_value.get_type() != Variant::QUATERNION) && (p_value.get_type() != Variant::BASIS));
 			RotationTrack *rt = static_cast<RotationTrack *>(t);
 			ERR_FAIL_COND(rt->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, rt->rotations.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, rt->rotations.size());
 
-			rt->rotations.write[p_key_idx].value = p_value;
+			rt->rotations[p_key_idx].value = p_value;
 
 		} break;
 		case TYPE_SCALE_3D: {
 			ERR_FAIL_COND((p_value.get_type() != Variant::VECTOR3) && (p_value.get_type() != Variant::VECTOR3I));
 			ScaleTrack *st = static_cast<ScaleTrack *>(t);
 			ERR_FAIL_COND(st->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, st->scales.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, st->scales.size());
 
-			st->scales.write[p_key_idx].value = p_value;
+			st->scales[p_key_idx].value = p_value;
 
 		} break;
 		case TYPE_BLEND_SHAPE: {
 			ERR_FAIL_COND((p_value.get_type() != Variant::FLOAT) && (p_value.get_type() != Variant::INT));
 			BlendShapeTrack *bst = static_cast<BlendShapeTrack *>(t);
 			ERR_FAIL_COND(bst->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, bst->blend_shapes.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, bst->blend_shapes.size());
 
-			bst->blend_shapes.write[p_key_idx].value = p_value;
+			bst->blend_shapes[p_key_idx].value = p_value;
 
 		} break;
 		case TYPE_VALUE: {
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, vt->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, vt->values.size());
 
-			vt->values.write[p_key_idx].value = p_value;
+			vt->values[p_key_idx].value = p_value;
 
 		} break;
 		case TYPE_METHOD: {
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, mt->methods.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, mt->methods.size());
 
 			Dictionary d = p_value;
 
 			if (d.has("method")) {
-				mt->methods.write[p_key_idx].method = d["method"];
+				mt->methods[p_key_idx].method = d["method"];
 			}
 			if (d.has("args")) {
-				mt->methods.write[p_key_idx].params = d["args"];
+				mt->methods[p_key_idx].params = d["args"];
 			}
 
 		} break;
 		case TYPE_BEZIER: {
 			BezierTrack *bt = static_cast<BezierTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, bt->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, bt->values.size());
 
 			Array arr = p_value;
 			ERR_FAIL_COND(arr.size() != 5);
 
-			bt->values.write[p_key_idx].value.value = arr[0];
-			bt->values.write[p_key_idx].value.in_handle.x = arr[1];
-			bt->values.write[p_key_idx].value.in_handle.y = arr[2];
-			bt->values.write[p_key_idx].value.out_handle.x = arr[3];
-			bt->values.write[p_key_idx].value.out_handle.y = arr[4];
+			bt->values[p_key_idx].value.value = arr[0];
+			bt->values[p_key_idx].value.in_handle.x = arr[1];
+			bt->values[p_key_idx].value.in_handle.y = arr[2];
+			bt->values[p_key_idx].value.out_handle.x = arr[3];
+			bt->values[p_key_idx].value.out_handle.y = arr[4];
 
 		} break;
 		case TYPE_AUDIO: {
 			AudioTrack *at = static_cast<AudioTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, at->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, at->values.size());
 
 			Dictionary k = p_value;
 			ERR_FAIL_COND(!k.has("start_offset"));
 			ERR_FAIL_COND(!k.has("end_offset"));
 			ERR_FAIL_COND(!k.has("stream"));
 
-			at->values.write[p_key_idx].value.start_offset = k["start_offset"];
-			at->values.write[p_key_idx].value.end_offset = k["end_offset"];
-			at->values.write[p_key_idx].value.stream = k["stream"];
+			at->values[p_key_idx].value.start_offset = k["start_offset"];
+			at->values[p_key_idx].value.end_offset = k["end_offset"];
+			at->values[p_key_idx].value.stream = k["stream"];
 
 		} break;
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, at->values.size());
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, at->values.size());
 
-			at->values.write[p_key_idx].value = p_value;
+			at->values[p_key_idx].value = p_value;
 
 		} break;
 	}
@@ -2350,44 +2350,44 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 }
 
 void Animation::track_set_key_transition(int p_track, int p_key_idx, real_t p_transition) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 
 	switch (t->type) {
 		case TYPE_POSITION_3D: {
 			PositionTrack *tt = static_cast<PositionTrack *>(t);
 			ERR_FAIL_COND(tt->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, tt->positions.size());
-			tt->positions.write[p_key_idx].transition = p_transition;
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, tt->positions.size());
+			tt->positions[p_key_idx].transition = p_transition;
 		} break;
 		case TYPE_ROTATION_3D: {
 			RotationTrack *rt = static_cast<RotationTrack *>(t);
 			ERR_FAIL_COND(rt->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, rt->rotations.size());
-			rt->rotations.write[p_key_idx].transition = p_transition;
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, rt->rotations.size());
+			rt->rotations[p_key_idx].transition = p_transition;
 		} break;
 		case TYPE_SCALE_3D: {
 			ScaleTrack *st = static_cast<ScaleTrack *>(t);
 			ERR_FAIL_COND(st->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, st->scales.size());
-			st->scales.write[p_key_idx].transition = p_transition;
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, st->scales.size());
+			st->scales[p_key_idx].transition = p_transition;
 		} break;
 		case TYPE_BLEND_SHAPE: {
 			BlendShapeTrack *bst = static_cast<BlendShapeTrack *>(t);
 			ERR_FAIL_COND(bst->compressed_track >= 0);
-			ERR_FAIL_INDEX(p_key_idx, bst->blend_shapes.size());
-			bst->blend_shapes.write[p_key_idx].transition = p_transition;
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, bst->blend_shapes.size());
+			bst->blend_shapes[p_key_idx].transition = p_transition;
 		} break;
 		case TYPE_VALUE: {
 			ValueTrack *vt = static_cast<ValueTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, vt->values.size());
-			vt->values.write[p_key_idx].transition = p_transition;
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, vt->values.size());
+			vt->values[p_key_idx].transition = p_transition;
 
 		} break;
 		case TYPE_METHOD: {
 			MethodTrack *mt = static_cast<MethodTrack *>(t);
-			ERR_FAIL_INDEX(p_key_idx, mt->methods.size());
-			mt->methods.write[p_key_idx].transition = p_transition;
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, mt->methods.size());
+			mt->methods[p_key_idx].transition = p_transition;
 
 		} break;
 		case TYPE_BEZIER:
@@ -2401,7 +2401,7 @@ void Animation::track_set_key_transition(int p_track, int p_key_idx, real_t p_tr
 }
 
 template <typename K>
-int Animation::_find(const Vector<K> &p_keys, double p_time, bool p_backward, bool p_limit) const {
+int Animation::_find(const LocalVector<K> &p_keys, double p_time, bool p_backward, bool p_limit) const {
 	int len = p_keys.size();
 	if (len == 0) {
 		return -2;
@@ -2521,7 +2521,7 @@ Variant Animation::_cubic_interpolate_angle_in_time(const Variant &p_pre_a, cons
 }
 
 template <typename T>
-T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok, bool p_backward) const {
+T Animation::_interpolate(const LocalVector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok, bool p_backward) const {
 	int len = _find(p_keys, length) + 1; // try to find last key (there may be more past the end)
 
 	if (len <= 0) {
@@ -2726,7 +2726,7 @@ T Animation::_interpolate(const Vector<TKey<T>> &p_keys, double p_time, Interpol
 }
 
 Variant Animation::value_track_interpolate(int p_track, double p_time, bool p_backward) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), 0);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_VALUE, Variant());
 	ValueTrack *vt = static_cast<ValueTrack *>(t);
@@ -2743,7 +2743,7 @@ Variant Animation::value_track_interpolate(int p_track, double p_time, bool p_ba
 }
 
 void Animation::value_track_set_update_mode(int p_track, UpdateMode p_mode) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_VALUE);
 	ERR_FAIL_INDEX((int)p_mode, 3);
@@ -2756,7 +2756,7 @@ void Animation::value_track_set_update_mode(int p_track, UpdateMode p_mode) {
 }
 
 Animation::UpdateMode Animation::value_track_get_update_mode(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), UPDATE_CONTINUOUS);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), UPDATE_CONTINUOUS);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_VALUE, UPDATE_CONTINUOUS);
 
@@ -2765,7 +2765,7 @@ Animation::UpdateMode Animation::value_track_get_update_mode(int p_track) const 
 }
 
 template <typename T>
-void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool p_is_backward) const {
+void Animation::_track_get_key_indices_in_range(const LocalVector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool p_is_backward) const {
 	int len = p_array.size();
 	if (len == 0) {
 		return;
@@ -2819,7 +2819,7 @@ void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, double
 }
 
 void Animation::track_get_key_indices_in_range(int p_track, double p_time, double p_delta, List<int> *p_indices, Animation::LoopedFlag p_looped_flag) const {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 
 	if (p_delta == 0) {
 		return; // Prevent to get key continuously.
@@ -3213,10 +3213,10 @@ void Animation::track_get_key_indices_in_range(int p_track, double p_time, doubl
 void Animation::add_marker(const StringName &p_name, double p_time) {
 	int idx = _find(marker_names, p_time);
 
-	if (idx >= 0 && idx < marker_names.size() && Math::is_equal_approx(p_time, marker_names[idx].time)) {
+	if ((uint32_t)idx < marker_names.size() && Math::is_equal_approx(p_time, marker_names[idx].time)) {
 		marker_times.erase(marker_names[idx].name);
 		marker_colors.erase(marker_names[idx].name);
-		marker_names.write[idx].name = p_name;
+		marker_names[idx].name = p_name;
 		marker_times.insert(p_name, p_time);
 		marker_colors.insert(p_name, Color(1, 1, 1));
 	} else {
@@ -3230,7 +3230,7 @@ void Animation::remove_marker(const StringName &p_name) {
 	HashMap<StringName, double>::Iterator E = marker_times.find(p_name);
 	ERR_FAIL_COND(!E);
 	int idx = _find(marker_names, E->value);
-	bool success = idx >= 0 && idx < marker_names.size() && Math::is_equal_approx(marker_names[idx].time, E->value);
+	bool success = (uint32_t)idx < marker_names.size() && Math::is_equal_approx(marker_names[idx].time, E->value);
 	ERR_FAIL_COND(!success);
 	marker_names.remove_at(idx);
 	marker_times.remove(E);
@@ -3244,7 +3244,7 @@ bool Animation::has_marker(const StringName &p_name) const {
 StringName Animation::get_marker_at_time(double p_time) const {
 	int idx = _find(marker_names, p_time);
 
-	if (idx >= 0 && idx < marker_names.size() && Math::is_equal_approx(marker_names[idx].time, p_time)) {
+	if ((uint32_t)idx < marker_names.size() && Math::is_equal_approx(marker_names[idx].time, p_time)) {
 		return marker_names[idx].name;
 	}
 
@@ -3254,7 +3254,7 @@ StringName Animation::get_marker_at_time(double p_time) const {
 StringName Animation::get_next_marker(double p_time) const {
 	int idx = _find(marker_names, p_time);
 
-	if (idx >= -1 && idx < marker_names.size() - 1) {
+	if (idx >= -1 && idx < (int)marker_names.size() - 1) {
 		// _find ensures that the time at idx is always the closest time to p_time that is also smaller to it.
 		// So we add 1 to get the next marker.
 		return marker_names[idx + 1].name;
@@ -3265,7 +3265,7 @@ StringName Animation::get_next_marker(double p_time) const {
 StringName Animation::get_prev_marker(double p_time) const {
 	int idx = _find(marker_names, p_time);
 
-	if (idx >= 0 && idx < marker_names.size()) {
+	if ((uint32_t)idx < marker_names.size()) {
 		return marker_names[idx].name;
 	}
 	return StringName();
@@ -3295,13 +3295,13 @@ void Animation::set_marker_color(const StringName &p_name, const Color &p_color)
 }
 
 Vector<Variant> Animation::method_track_get_params(int p_track, int p_key_idx) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), Vector<Variant>());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), Vector<Variant>());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_METHOD, Vector<Variant>());
 
 	MethodTrack *pm = static_cast<MethodTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_key_idx, pm->methods.size(), Vector<Variant>());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, pm->methods.size(), Vector<Variant>());
 
 	const MethodKey &mk = pm->methods[p_key_idx];
 
@@ -3309,13 +3309,13 @@ Vector<Variant> Animation::method_track_get_params(int p_track, int p_key_idx) c
 }
 
 StringName Animation::method_track_get_name(int p_track, int p_key_idx) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), StringName());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), StringName());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_METHOD, StringName());
 
 	MethodTrack *pm = static_cast<MethodTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_key_idx, pm->methods.size(), StringName());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, pm->methods.size(), StringName());
 
 	return pm->methods[p_key_idx].method;
 }
@@ -3335,7 +3335,7 @@ Array Animation::make_default_bezier_key(float p_value) {
 }
 
 int Animation::bezier_track_insert_key(int p_track, double p_time, real_t p_value, const Vector2 &p_in_handle, const Vector2 &p_out_handle) {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BEZIER, -1);
 
@@ -3361,38 +3361,38 @@ int Animation::bezier_track_insert_key(int p_track, double p_time, real_t p_valu
 }
 
 void Animation::bezier_track_set_key_value(int p_track, int p_index, real_t p_value) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_BEZIER);
 
 	BezierTrack *bt = static_cast<BezierTrack *>(t);
 
-	ERR_FAIL_INDEX(p_index, bt->values.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_index, bt->values.size());
 
-	bt->values.write[p_index].value.value = p_value;
+	bt->values[p_index].value.value = p_value;
 
 	emit_changed();
 }
 
 void Animation::bezier_track_set_key_in_handle(int p_track, int p_index, const Vector2 &p_handle, real_t p_balanced_value_time_ratio) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_BEZIER);
 
 	BezierTrack *bt = static_cast<BezierTrack *>(t);
 
-	ERR_FAIL_INDEX(p_index, bt->values.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_index, bt->values.size());
 
 	Vector2 in_handle = p_handle;
 	if (in_handle.x > 0) {
 		in_handle.x = 0;
 	}
-	bt->values.write[p_index].value.in_handle = in_handle;
+	bt->values[p_index].value.in_handle = in_handle;
 
 #ifdef TOOLS_ENABLED
 	if (bt->values[p_index].value.handle_mode == HANDLE_MODE_LINEAR) {
-		bt->values.write[p_index].value.in_handle = Vector2();
-		bt->values.write[p_index].value.out_handle = Vector2();
+		bt->values[p_index].value.in_handle = Vector2();
+		bt->values[p_index].value.out_handle = Vector2();
 	} else if (bt->values[p_index].value.handle_mode == HANDLE_MODE_BALANCED) {
 		Transform2D xform;
 		xform.set_scale(Vector2(1.0, 1.0 / p_balanced_value_time_ratio));
@@ -3400,9 +3400,9 @@ void Animation::bezier_track_set_key_in_handle(int p_track, int p_index, const V
 		Vector2 vec_out = xform.xform(bt->values[p_index].value.out_handle);
 		Vector2 vec_in = xform.xform(in_handle);
 
-		bt->values.write[p_index].value.out_handle = xform.affine_inverse().xform(-vec_in.normalized() * vec_out.length());
+		bt->values[p_index].value.out_handle = xform.affine_inverse().xform(-vec_in.normalized() * vec_out.length());
 	} else if (bt->values[p_index].value.handle_mode == HANDLE_MODE_MIRRORED) {
-		bt->values.write[p_index].value.out_handle = -in_handle;
+		bt->values[p_index].value.out_handle = -in_handle;
 	}
 #endif // TOOLS_ENABLED
 
@@ -3410,24 +3410,24 @@ void Animation::bezier_track_set_key_in_handle(int p_track, int p_index, const V
 }
 
 void Animation::bezier_track_set_key_out_handle(int p_track, int p_index, const Vector2 &p_handle, real_t p_balanced_value_time_ratio) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_BEZIER);
 
 	BezierTrack *bt = static_cast<BezierTrack *>(t);
 
-	ERR_FAIL_INDEX(p_index, bt->values.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_index, bt->values.size());
 
 	Vector2 out_handle = p_handle;
 	if (out_handle.x < 0) {
 		out_handle.x = 0;
 	}
-	bt->values.write[p_index].value.out_handle = out_handle;
+	bt->values[p_index].value.out_handle = out_handle;
 
 #ifdef TOOLS_ENABLED
 	if (bt->values[p_index].value.handle_mode == HANDLE_MODE_LINEAR) {
-		bt->values.write[p_index].value.in_handle = Vector2();
-		bt->values.write[p_index].value.out_handle = Vector2();
+		bt->values[p_index].value.in_handle = Vector2();
+		bt->values[p_index].value.out_handle = Vector2();
 	} else if (bt->values[p_index].value.handle_mode == HANDLE_MODE_BALANCED) {
 		Transform2D xform;
 		xform.set_scale(Vector2(1.0, 1.0 / p_balanced_value_time_ratio));
@@ -3435,9 +3435,9 @@ void Animation::bezier_track_set_key_out_handle(int p_track, int p_index, const 
 		Vector2 vec_in = xform.xform(bt->values[p_index].value.in_handle);
 		Vector2 vec_out = xform.xform(out_handle);
 
-		bt->values.write[p_index].value.in_handle = xform.affine_inverse().xform(-vec_out.normalized() * vec_in.length());
+		bt->values[p_index].value.in_handle = xform.affine_inverse().xform(-vec_out.normalized() * vec_in.length());
 	} else if (bt->values[p_index].value.handle_mode == HANDLE_MODE_MIRRORED) {
-		bt->values.write[p_index].value.in_handle = -out_handle;
+		bt->values[p_index].value.in_handle = -out_handle;
 	}
 #endif // TOOLS_ENABLED
 
@@ -3445,56 +3445,56 @@ void Animation::bezier_track_set_key_out_handle(int p_track, int p_index, const 
 }
 
 real_t Animation::bezier_track_get_key_value(int p_track, int p_index) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), 0);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BEZIER, 0);
 
 	BezierTrack *bt = static_cast<BezierTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_index, bt->values.size(), 0);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_index, bt->values.size(), 0);
 
 	return bt->values[p_index].value.value;
 }
 
 Vector2 Animation::bezier_track_get_key_in_handle(int p_track, int p_index) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), Vector2());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), Vector2());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BEZIER, Vector2());
 
 	BezierTrack *bt = static_cast<BezierTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_index, bt->values.size(), Vector2());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_index, bt->values.size(), Vector2());
 
 	return bt->values[p_index].value.in_handle;
 }
 
 Vector2 Animation::bezier_track_get_key_out_handle(int p_track, int p_index) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), Vector2());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), Vector2());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BEZIER, Vector2());
 
 	BezierTrack *bt = static_cast<BezierTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_index, bt->values.size(), Vector2());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_index, bt->values.size(), Vector2());
 
 	return bt->values[p_index].value.out_handle;
 }
 
 #ifdef TOOLS_ENABLED
 void Animation::bezier_track_set_key_handle_mode(int p_track, int p_index, HandleMode p_mode, HandleSetMode p_set_mode) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_BEZIER);
 
 	BezierTrack *bt = static_cast<BezierTrack *>(t);
 
-	ERR_FAIL_INDEX(p_index, bt->values.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_index, bt->values.size());
 
-	bt->values.write[p_index].value.handle_mode = p_mode;
+	bt->values[p_index].value.handle_mode = p_mode;
 
 	if (p_mode != HANDLE_MODE_FREE && p_set_mode != HANDLE_SET_MODE_NONE) {
-		Vector2 &in_handle = bt->values.write[p_index].value.in_handle;
-		Vector2 &out_handle = bt->values.write[p_index].value.out_handle;
+		Vector2 &in_handle = bt->values[p_index].value.in_handle;
+		Vector2 &out_handle = bt->values[p_index].value.out_handle;
 		bezier_track_calculate_handles(p_track, p_index, p_mode, p_set_mode, &in_handle, &out_handle);
 	}
 
@@ -3502,27 +3502,27 @@ void Animation::bezier_track_set_key_handle_mode(int p_track, int p_index, Handl
 }
 
 Animation::HandleMode Animation::bezier_track_get_key_handle_mode(int p_track, int p_index) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), HANDLE_MODE_FREE);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), HANDLE_MODE_FREE);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BEZIER, HANDLE_MODE_FREE);
 
 	BezierTrack *bt = static_cast<BezierTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_index, bt->values.size(), HANDLE_MODE_FREE);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_index, bt->values.size(), HANDLE_MODE_FREE);
 
 	return bt->values[p_index].value.handle_mode;
 }
 
 bool Animation::bezier_track_calculate_handles(int p_track, int p_index, HandleMode p_mode, HandleSetMode p_set_mode, Vector2 *r_in_handle, Vector2 *r_out_handle) {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), false);
+	ERR_FAIL_INDEX_V(p_track, (int)tracks.size(), false);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_BEZIER, false);
 
 	BezierTrack *bt = static_cast<BezierTrack *>(t);
-	ERR_FAIL_INDEX_V(p_index, bt->values.size(), false);
+	ERR_FAIL_INDEX_V(p_index, (int)bt->values.size(), false);
 
 	int prev_key = MAX(0, p_index - 1);
-	int next_key = MIN(bt->values.size() - 1, p_index + 1);
+	int next_key = MIN((int)bt->values.size() - 1, p_index + 1);
 	if (prev_key == next_key) {
 		return false;
 	}
@@ -3602,7 +3602,7 @@ bool Animation::bezier_track_calculate_handles(float p_time, float p_prev_time, 
 
 real_t Animation::bezier_track_interpolate(int p_track, double p_time) const {
 	//this uses a different interpolation scheme
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), 0);
 	Track *track = tracks[p_track];
 	ERR_FAIL_COND_V(track->type != TYPE_BEZIER, 0);
 
@@ -3627,7 +3627,7 @@ real_t Animation::bezier_track_interpolate(int p_track, double p_time) const {
 		return bt->values[0].value.value;
 	}
 
-	if (idx >= bt->values.size() - 1) {
+	if (idx >= (int)bt->values.size() - 1) {
 		return bt->values[bt->values.size() - 1].value.value;
 	}
 
@@ -3666,7 +3666,7 @@ real_t Animation::bezier_track_interpolate(int p_track, double p_time) const {
 }
 
 int Animation::audio_track_insert_key(int p_track, double p_time, const Ref<Resource> &p_stream, real_t p_start_offset, real_t p_end_offset) {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, -1);
 
@@ -3692,93 +3692,93 @@ int Animation::audio_track_insert_key(int p_track, double p_time, const Ref<Reso
 }
 
 void Animation::audio_track_set_key_stream(int p_track, int p_key, const Ref<Resource> &p_stream) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_AUDIO);
 
 	AudioTrack *at = static_cast<AudioTrack *>(t);
 
-	ERR_FAIL_INDEX(p_key, at->values.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, at->values.size());
 
-	at->values.write[p_key].value.stream = p_stream;
+	at->values[p_key].value.stream = p_stream;
 
 	emit_changed();
 }
 
 void Animation::audio_track_set_key_start_offset(int p_track, int p_key, real_t p_offset) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_AUDIO);
 
 	AudioTrack *at = static_cast<AudioTrack *>(t);
 
-	ERR_FAIL_INDEX(p_key, at->values.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, at->values.size());
 
 	if (p_offset < 0) {
 		p_offset = 0;
 	}
 
-	at->values.write[p_key].value.start_offset = p_offset;
+	at->values[p_key].value.start_offset = p_offset;
 
 	emit_changed();
 }
 
 void Animation::audio_track_set_key_end_offset(int p_track, int p_key, real_t p_offset) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_AUDIO);
 
 	AudioTrack *at = static_cast<AudioTrack *>(t);
 
-	ERR_FAIL_INDEX(p_key, at->values.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, at->values.size());
 
 	if (p_offset < 0) {
 		p_offset = 0;
 	}
 
-	at->values.write[p_key].value.end_offset = p_offset;
+	at->values[p_key].value.end_offset = p_offset;
 
 	emit_changed();
 }
 
 Ref<Resource> Animation::audio_track_get_key_stream(int p_track, int p_key) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), Ref<Resource>());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), Ref<Resource>());
 	const Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, Ref<Resource>());
 
 	const AudioTrack *at = static_cast<const AudioTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_key, at->values.size(), Ref<Resource>());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, at->values.size(), Ref<Resource>());
 
 	return at->values[p_key].value.stream;
 }
 
 real_t Animation::audio_track_get_key_start_offset(int p_track, int p_key) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), 0);
 	const Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, 0);
 
 	const AudioTrack *at = static_cast<const AudioTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_key, at->values.size(), 0);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, at->values.size(), 0);
 
 	return at->values[p_key].value.start_offset;
 }
 
 real_t Animation::audio_track_get_key_end_offset(int p_track, int p_key) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), 0);
 	const Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, 0);
 
 	const AudioTrack *at = static_cast<const AudioTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_key, at->values.size(), 0);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, at->values.size(), 0);
 
 	return at->values[p_key].value.end_offset;
 }
 
 void Animation::audio_track_set_use_blend(int p_track, bool p_enable) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_AUDIO);
 
@@ -3789,7 +3789,7 @@ void Animation::audio_track_set_use_blend(int p_track, bool p_enable) {
 }
 
 bool Animation::audio_track_is_use_blend(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), false);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), false);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, false);
 
@@ -3801,7 +3801,7 @@ bool Animation::audio_track_is_use_blend(int p_track) const {
 //
 
 int Animation::animation_track_insert_key(int p_track, double p_time, const StringName &p_animation) {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, -1);
 
@@ -3819,27 +3819,27 @@ int Animation::animation_track_insert_key(int p_track, double p_time, const Stri
 }
 
 void Animation::animation_track_set_key_animation(int p_track, int p_key, const StringName &p_animation) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_ANIMATION);
 
 	AnimationTrack *at = static_cast<AnimationTrack *>(t);
 
-	ERR_FAIL_INDEX(p_key, at->values.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, at->values.size());
 
-	at->values.write[p_key].value = p_animation;
+	at->values[p_key].value = p_animation;
 
 	emit_changed();
 }
 
 StringName Animation::animation_track_get_key_animation(int p_track, int p_key) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), StringName());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), StringName());
 	const Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, StringName());
 
 	const AnimationTrack *at = static_cast<const AnimationTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_key, at->values.size(), StringName());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, at->values.size(), StringName());
 
 	return at->values[p_key].value;
 }
@@ -3866,50 +3866,50 @@ Animation::LoopMode Animation::get_loop_mode() const {
 }
 
 void Animation::track_set_imported(int p_track, bool p_imported) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	tracks[p_track]->imported = p_imported;
 }
 
 bool Animation::track_is_imported(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), false);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), false);
 	return tracks[p_track]->imported;
 }
 
 void Animation::track_set_enabled(int p_track, bool p_enabled) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
 	tracks[p_track]->enabled = p_enabled;
 	emit_changed();
 }
 
 bool Animation::track_is_enabled(int p_track) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), false);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), false);
 	return tracks[p_track]->enabled;
 }
 
 void Animation::track_move_up(int p_track) {
-	if (p_track >= 0 && p_track < (tracks.size() - 1)) {
-		SWAP(tracks.write[p_track], tracks.write[p_track + 1]);
+	if (p_track < ((int)tracks.size() - 1)) {
+		SWAP(tracks[p_track], tracks[p_track + 1]);
 	}
 
 	emit_changed();
 }
 
 void Animation::track_move_down(int p_track) {
-	if (p_track > 0 && p_track < tracks.size()) {
-		SWAP(tracks.write[p_track], tracks.write[p_track - 1]);
+	if ((uint32_t)p_track < tracks.size()) {
+		SWAP(tracks[p_track], tracks[p_track - 1]);
 	}
 
 	emit_changed();
 }
 
 void Animation::track_move_to(int p_track, int p_to_index) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
-	ERR_FAIL_INDEX(p_to_index, tracks.size() + 1);
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_to_index, tracks.size() + 1);
 	if (p_track == p_to_index || p_track == p_to_index - 1) {
 		return;
 	}
 
-	Track *track = tracks.get(p_track);
+	Track *track = tracks[p_track];
 	tracks.remove_at(p_track);
 	// Take into account that the position of the tracks that come after the one removed will change.
 	tracks.insert(p_to_index > p_track ? p_to_index - 1 : p_to_index, track);
@@ -3918,12 +3918,12 @@ void Animation::track_move_to(int p_track, int p_to_index) {
 }
 
 void Animation::track_swap(int p_track, int p_with_track) {
-	ERR_FAIL_INDEX(p_track, tracks.size());
-	ERR_FAIL_INDEX(p_with_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_with_track, tracks.size());
 	if (p_track == p_with_track) {
 		return;
 	}
-	SWAP(tracks.write[p_track], tracks.write[p_with_track]);
+	SWAP(tracks[p_track], tracks[p_with_track]);
 
 	emit_changed();
 }
@@ -4109,7 +4109,7 @@ void Animation::_bind_methods() {
 }
 
 void Animation::clear() {
-	for (int i = 0; i < tracks.size(); i++) {
+	for (uint32_t i = 0; i < tracks.size(); i++) {
 		memdelete(tracks[i]);
 	}
 	tracks.clear();
@@ -4260,7 +4260,7 @@ bool Animation::_quaternion_track_optimize_key(const TKey<Quaternion> t0, const 
 }
 
 void Animation::_position_track_optimize(int p_idx, real_t p_allowed_velocity_err, real_t p_allowed_angular_err, real_t p_allowed_precision_error) {
-	ERR_FAIL_INDEX(p_idx, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, tracks.size());
 	ERR_FAIL_COND(tracks[p_idx]->type != TYPE_POSITION_3D);
 	bool is_nearest = false;
 	if (tracks[p_idx]->interpolation == INTERPOLATION_NEAREST) {
@@ -4270,7 +4270,7 @@ void Animation::_position_track_optimize(int p_idx, real_t p_allowed_velocity_er
 	}
 	PositionTrack *tt = static_cast<PositionTrack *>(tracks[p_idx]);
 	int i = 0;
-	while (i < tt->positions.size() - 2) {
+	while (i < (int)tt->positions.size() - 2) {
 		TKey<Vector3> t0 = tt->positions[i];
 		TKey<Vector3> t1 = tt->positions[i + 1];
 		TKey<Vector3> t2 = tt->positions[i + 2];
@@ -4290,7 +4290,7 @@ void Animation::_position_track_optimize(int p_idx, real_t p_allowed_velocity_er
 }
 
 void Animation::_rotation_track_optimize(int p_idx, real_t p_allowed_velocity_err, real_t p_allowed_angular_err, real_t p_allowed_precision_error) {
-	ERR_FAIL_INDEX(p_idx, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, tracks.size());
 	ERR_FAIL_COND(tracks[p_idx]->type != TYPE_ROTATION_3D);
 	bool is_nearest = false;
 	if (tracks[p_idx]->interpolation == INTERPOLATION_NEAREST) {
@@ -4300,7 +4300,7 @@ void Animation::_rotation_track_optimize(int p_idx, real_t p_allowed_velocity_er
 	}
 	RotationTrack *rt = static_cast<RotationTrack *>(tracks[p_idx]);
 	int i = 0;
-	while (i < rt->rotations.size() - 2) {
+	while (i < (int)rt->rotations.size() - 2) {
 		TKey<Quaternion> t0 = rt->rotations[i];
 		TKey<Quaternion> t1 = rt->rotations[i + 1];
 		TKey<Quaternion> t2 = rt->rotations[i + 2];
@@ -4320,7 +4320,7 @@ void Animation::_rotation_track_optimize(int p_idx, real_t p_allowed_velocity_er
 }
 
 void Animation::_scale_track_optimize(int p_idx, real_t p_allowed_velocity_err, real_t p_allowed_angular_err, real_t p_allowed_precision_error) {
-	ERR_FAIL_INDEX(p_idx, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, tracks.size());
 	ERR_FAIL_COND(tracks[p_idx]->type != TYPE_SCALE_3D);
 	bool is_nearest = false;
 	if (tracks[p_idx]->interpolation == INTERPOLATION_NEAREST) {
@@ -4330,7 +4330,7 @@ void Animation::_scale_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 	}
 	ScaleTrack *st = static_cast<ScaleTrack *>(tracks[p_idx]);
 	int i = 0;
-	while (i < st->scales.size() - 2) {
+	while (i < (int)st->scales.size() - 2) {
 		TKey<Vector3> t0 = st->scales[i];
 		TKey<Vector3> t1 = st->scales[i + 1];
 		TKey<Vector3> t2 = st->scales[i + 2];
@@ -4350,7 +4350,7 @@ void Animation::_scale_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 }
 
 void Animation::_blend_shape_track_optimize(int p_idx, real_t p_allowed_velocity_err, real_t p_allowed_precision_error) {
-	ERR_FAIL_INDEX(p_idx, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, tracks.size());
 	ERR_FAIL_COND(tracks[p_idx]->type != TYPE_BLEND_SHAPE);
 	bool is_nearest = false;
 	if (tracks[p_idx]->interpolation == INTERPOLATION_NEAREST) {
@@ -4360,7 +4360,7 @@ void Animation::_blend_shape_track_optimize(int p_idx, real_t p_allowed_velocity
 	}
 	BlendShapeTrack *bst = static_cast<BlendShapeTrack *>(tracks[p_idx]);
 	int i = 0;
-	while (i < bst->blend_shapes.size() - 2) {
+	while (i < (int)bst->blend_shapes.size() - 2) {
 		TKey<float> t0 = bst->blend_shapes[i];
 		TKey<float> t1 = bst->blend_shapes[i + 1];
 		TKey<float> t2 = bst->blend_shapes[i + 2];
@@ -4381,7 +4381,7 @@ void Animation::_blend_shape_track_optimize(int p_idx, real_t p_allowed_velocity
 }
 
 void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, real_t p_allowed_angular_err, real_t p_allowed_precision_error) {
-	ERR_FAIL_INDEX(p_idx, tracks.size());
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, tracks.size());
 	ERR_FAIL_COND(tracks[p_idx]->type != TYPE_VALUE);
 	bool is_nearest = false;
 	if (tracks[p_idx]->interpolation == INTERPOLATION_NEAREST) {
@@ -4398,7 +4398,7 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 	// Special case for angle interpolation.
 	bool is_using_angle = vt->interpolation == Animation::INTERPOLATION_LINEAR_ANGLE || vt->interpolation == Animation::INTERPOLATION_CUBIC_ANGLE;
 	int i = 0;
-	while (i < vt->values.size() - 2) {
+	while (i < (int)vt->values.size() - 2) {
 		bool erase = false;
 		switch (type) {
 			case Variant::FLOAT: {
@@ -4507,7 +4507,7 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 
 void Animation::optimize(real_t p_allowed_velocity_err, real_t p_allowed_angular_err, int p_precision) {
 	real_t precision = Math::pow(0.1, p_precision);
-	for (int i = 0; i < tracks.size(); i++) {
+	for (uint32_t i = 0; i < tracks.size(); i++) {
 		if (track_is_compressed(i)) {
 			continue; //not possible to optimize compressed track
 		}
@@ -6511,7 +6511,7 @@ Animation::Animation() {
 }
 
 Animation::~Animation() {
-	for (int i = 0; i < tracks.size(); i++) {
+	for (uint32_t i = 0; i < tracks.size(); i++) {
 		memdelete(tracks[i]);
 	}
 }

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -135,7 +135,7 @@ private:
 	/* POSITION TRACK */
 
 	struct PositionTrack : public Track {
-		Vector<TKey<Vector3>> positions;
+		LocalVector<TKey<Vector3>> positions;
 		int32_t compressed_track = -1;
 		PositionTrack() { type = TYPE_POSITION_3D; }
 	};
@@ -143,7 +143,7 @@ private:
 	/* ROTATION TRACK */
 
 	struct RotationTrack : public Track {
-		Vector<TKey<Quaternion>> rotations;
+		LocalVector<TKey<Quaternion>> rotations;
 		int32_t compressed_track = -1;
 		RotationTrack() { type = TYPE_ROTATION_3D; }
 	};
@@ -151,7 +151,7 @@ private:
 	/* SCALE TRACK */
 
 	struct ScaleTrack : public Track {
-		Vector<TKey<Vector3>> scales;
+		LocalVector<TKey<Vector3>> scales;
 		int32_t compressed_track = -1;
 		ScaleTrack() { type = TYPE_SCALE_3D; }
 	};
@@ -159,7 +159,7 @@ private:
 	/* BLEND SHAPE TRACK */
 
 	struct BlendShapeTrack : public Track {
-		Vector<TKey<float>> blend_shapes;
+		LocalVector<TKey<float>> blend_shapes;
 		int32_t compressed_track = -1;
 		BlendShapeTrack() { type = TYPE_BLEND_SHAPE; }
 	};
@@ -169,7 +169,7 @@ private:
 	struct ValueTrack : public Track {
 		UpdateMode update_mode = UPDATE_CONTINUOUS;
 		bool update_on_seek = false;
-		Vector<TKey<Variant>> values;
+		LocalVector<TKey<Variant>> values;
 
 		ValueTrack() {
 			type = TYPE_VALUE;
@@ -184,7 +184,7 @@ private:
 	};
 
 	struct MethodTrack : public Track {
-		Vector<MethodKey> methods;
+		LocalVector<MethodKey> methods;
 		MethodTrack() { type = TYPE_METHOD; }
 	};
 
@@ -200,7 +200,7 @@ private:
 	};
 
 	struct BezierTrack : public Track {
-		Vector<TKey<BezierKey>> values;
+		LocalVector<TKey<BezierKey>> values;
 
 		BezierTrack() {
 			type = TYPE_BEZIER;
@@ -218,7 +218,7 @@ private:
 	};
 
 	struct AudioTrack : public Track {
-		Vector<TKey<AudioKey>> values;
+		LocalVector<TKey<AudioKey>> values;
 		bool use_blend = true;
 
 		AudioTrack() {
@@ -229,7 +229,7 @@ private:
 	/* ANIMATION TRACK */
 
 	struct AnimationTrack : public Track {
-		Vector<TKey<StringName>> values;
+		LocalVector<TKey<StringName>> values;
 
 		AnimationTrack() {
 			type = TYPE_ANIMATION;
@@ -246,20 +246,20 @@ private:
 		MarkerKey() = default;
 	};
 
-	Vector<MarkerKey> marker_names; // time -> name
+	LocalVector<MarkerKey> marker_names; // time -> name
 	HashMap<StringName, double> marker_times; // name -> time
 	HashMap<StringName, Color> marker_colors; // name -> color
 
-	Vector<Track *> tracks;
+	LocalVector<Track *> tracks;
 
 	template <typename T, typename V>
 	int _insert(double p_time, T &p_keys, const V &p_value);
 
-	int _marker_insert(double p_time, Vector<MarkerKey> &p_keys, const MarkerKey &p_value);
+	int _marker_insert(double p_time, LocalVector<MarkerKey> &p_keys, const MarkerKey &p_value);
 
 	template <typename K>
 
-	inline int _find(const Vector<K> &p_keys, double p_time, bool p_backward = false, bool p_limit = false) const;
+	inline int _find(const LocalVector<K> &p_keys, double p_time, bool p_backward = false, bool p_limit = false) const;
 
 	_FORCE_INLINE_ Vector3 _interpolate(const Vector3 &p_a, const Vector3 &p_b, real_t p_c) const;
 	_FORCE_INLINE_ Quaternion _interpolate(const Quaternion &p_a, const Quaternion &p_b, real_t p_c) const;
@@ -274,10 +274,10 @@ private:
 	_FORCE_INLINE_ Variant _cubic_interpolate_angle_in_time(const Variant &p_pre_a, const Variant &p_a, const Variant &p_b, const Variant &p_post_b, real_t p_c, real_t p_pre_a_t, real_t p_b_t, real_t p_post_b_t) const;
 
 	template <typename T>
-	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok, bool p_backward = false) const;
+	_FORCE_INLINE_ T _interpolate(const LocalVector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok, bool p_backward = false) const;
 
 	template <typename T>
-	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool p_is_backward) const;
+	_FORCE_INLINE_ void _track_get_key_indices_in_range(const LocalVector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool p_is_backward) const;
 
 	double length = 1.0;
 	real_t step = DEFAULT_STEP;
@@ -408,7 +408,7 @@ public:
 	int add_track(TrackType p_type, int p_at_pos = -1);
 	void remove_track(int p_track);
 
-	_FORCE_INLINE_ const Vector<Track *> get_tracks() {
+	_FORCE_INLINE_ const LocalVector<Track *> &get_tracks() {
 		return tracks;
 	}
 


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/10594

Replaced only those that are often used by the animation system.

Number of `get`/`_copy_on_write` calls in tps-demo every 5 seconds:
```
Structure Name: Error CowData<Animation::TKey<Vector3>>::resize(CowData::Size) [T = Animation::TKey<Vector3>, p_ensure_zero = false]
Lookup times: 180652
Structure Name: Error CowData<Animation::Track *>::resize(CowData::Size) [T = Animation::Track *, p_ensure_zero = false]
Lookup times: 310430
Structure Name: Error CowData<Animation::TKey<Quaternion>>::resize(CowData::Size) [T = Animation::TKey<Quaternion>, p_ensure_zero = false]
Lookup times: 644596
Structure Name: Error CowData<PhysicalBoneSimulator3D::SimulatedBone>::resize(CowData::Size) [T = PhysicalBoneSimulator3D::SimulatedBone, p_ensure_zero = false]
Lookup times: 738642
```



I will make benchmarks later.