### PR TITLE
Change `StringName.operator const void *` to `explicit operator bool`.

### DIFF
--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -97,7 +97,7 @@ class StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
-	operator const void *() const { return (_data && (_data->cname || !_data->name.is_empty())) ? (void *)1 : nullptr; }
+	explicit operator bool() const { return _data && (_data->cname || !_data->name.is_empty()); }
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -872,7 +872,7 @@ static String _make_arguments_hint(const GDScriptParser::FunctionNode *p_functio
 
 static void _get_directory_contents(EditorFileSystemDirectory *p_dir, HashMap<String, ScriptLanguage::CodeCompletionOption> &r_list, const StringName &p_required_type = StringName()) {
 	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
-	const bool requires_type = p_required_type;
+	const bool requires_type = !p_required_type.is_empty();
 
 	for (int i = 0; i < p_dir->get_file_count(); i++) {
 		if (requires_type && !ClassDB::is_parent_class(p_dir->get_file_type(i), p_required_type)) {


### PR DESCRIPTION
This is a small sanity cleanup to avoid unexpected implicit conversions, which may lead to subtle bugs or inefficiencies.

The function was essentially already a bool conversion, but not declared as such.
I first tried removing it and replacing callers with `is_empty`, but it turns out there are quite a few callers to the function. Luckily, they all appear to be happy with `explicit operator bool` too - except a single case, which I changed to an `is_empty` call (which is a better fit anyway).