### PR TITLE
Add SkyMaterial base class

### DIFF
--- a/doc/classes/PanoramaSkyMaterial.xml
+++ b/doc/classes/PanoramaSkyMaterial.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="PanoramaSkyMaterial" inherits="Material" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="PanoramaSkyMaterial" inherits="SkyMaterial" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A material that provides a special texture to a [Sky], usually an HDR panorama.
 	</brief_description>

--- a/doc/classes/PhysicalSkyMaterial.xml
+++ b/doc/classes/PhysicalSkyMaterial.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="PhysicalSkyMaterial" inherits="Material" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="PhysicalSkyMaterial" inherits="SkyMaterial" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A material that defines a sky for a [Sky] resource by a set of physical properties.
 	</brief_description>

--- a/doc/classes/ProceduralSkyMaterial.xml
+++ b/doc/classes/ProceduralSkyMaterial.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="ProceduralSkyMaterial" inherits="Material" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="ProceduralSkyMaterial" inherits="SkyMaterial" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A material that defines a simple sky for a [Sky] resource.
 	</brief_description>

--- a/doc/classes/SkyMaterial.xml
+++ b/doc/classes/SkyMaterial.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SkyMaterial" inherits="Material" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -7,3 +7,10 @@ should instead be used to justify these changes and describe how users should wo
 Add new entries at the end of the file.
 
 ## Changes between 4.4-stable and 4.5-stable
+
+GH-101292
+--------
+Validate extension JSON: Error: Field 'classes/Sky/properties/sky_material': type changed value in new API, from "PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial,ShaderMaterial" to "SkyMaterial,ShaderMaterial".
+Validate extension JSON: Error: Field 'classes/Sky/properties/sky_material': type changed value in new API, from "ShaderMaterial,PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial" to "SkyMaterial,ShaderMaterial".
+
+SkyMaterial is now the base class of PanoramaSkyMaterial, ProceduralSkyMaterial and PhysicalSkyMaterial.

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -898,6 +898,7 @@ void register_scene_types() {
 	GDREGISTER_ABSTRACT_CLASS(BaseMaterial3D);
 	GDREGISTER_CLASS(StandardMaterial3D);
 	GDREGISTER_CLASS(ORMMaterial3D);
+	GDREGISTER_CLASS(SkyMaterial);
 	GDREGISTER_CLASS(ProceduralSkyMaterial);
 	GDREGISTER_CLASS(PanoramaSkyMaterial);
 	GDREGISTER_CLASS(PhysicalSkyMaterial);

--- a/scene/resources/3d/sky_material.cpp
+++ b/scene/resources/3d/sky_material.cpp
@@ -33,6 +33,14 @@
 #include "core/config/project_settings.h"
 #include "core/version.h"
 
+SkyMaterial::SkyMaterial() {
+	_set_material(RS::get_singleton()->material_create());
+}
+
+Shader::Mode SkyMaterial::get_shader_mode() const {
+	return Shader::MODE_SKY;
+}
+
 Mutex ProceduralSkyMaterial::shader_mutex;
 RID ProceduralSkyMaterial::shader_cache[2];
 
@@ -168,10 +176,6 @@ void ProceduralSkyMaterial::set_energy_multiplier(float p_multiplier) {
 
 float ProceduralSkyMaterial::get_energy_multiplier() const {
 	return global_energy_multiplier;
-}
-
-Shader::Mode ProceduralSkyMaterial::get_shader_mode() const {
-	return Shader::MODE_SKY;
 }
 
 RID ProceduralSkyMaterial::get_rid() const {
@@ -357,7 +361,6 @@ void sky() {
 }
 
 ProceduralSkyMaterial::ProceduralSkyMaterial() {
-	_set_material(RS::get_singleton()->material_create());
 	set_sky_top_color(Color(0.385, 0.454, 0.55));
 	set_sky_horizon_color(Color(0.6463, 0.6558, 0.6708));
 	set_sky_curve(0.15);
@@ -415,10 +418,6 @@ void PanoramaSkyMaterial::set_energy_multiplier(float p_multiplier) {
 
 float PanoramaSkyMaterial::get_energy_multiplier() const {
 	return energy_multiplier;
-}
-
-Shader::Mode PanoramaSkyMaterial::get_shader_mode() const {
-	return Shader::MODE_SKY;
 }
 
 RID PanoramaSkyMaterial::get_rid() const {
@@ -487,7 +486,6 @@ void sky() {
 }
 
 PanoramaSkyMaterial::PanoramaSkyMaterial() {
-	_set_material(RS::get_singleton()->material_create());
 	set_energy_multiplier(1.0);
 }
 
@@ -602,10 +600,6 @@ void PhysicalSkyMaterial::set_night_sky(const Ref<Texture2D> &p_night_sky) {
 
 Ref<Texture2D> PhysicalSkyMaterial::get_night_sky() const {
 	return night_sky;
-}
-
-Shader::Mode PhysicalSkyMaterial::get_shader_mode() const {
-	return Shader::MODE_SKY;
 }
 
 RID PhysicalSkyMaterial::get_rid() const {
@@ -787,7 +781,6 @@ void sky() {
 }
 
 PhysicalSkyMaterial::PhysicalSkyMaterial() {
-	_set_material(RS::get_singleton()->material_create());
 	set_rayleigh_coefficient(2.0);
 	set_rayleigh_color(Color(0.3, 0.405, 0.6));
 	set_mie_coefficient(0.005);

--- a/scene/resources/3d/sky_material.h
+++ b/scene/resources/3d/sky_material.h
@@ -34,8 +34,19 @@
 #include "core/templates/rid.h"
 #include "scene/resources/material.h"
 
-class ProceduralSkyMaterial : public Material {
-	GDCLASS(ProceduralSkyMaterial, Material);
+class SkyMaterial : public Material {
+	GDCLASS(SkyMaterial, Material);
+
+protected:
+	static void _bind_methods() {}
+	virtual Shader::Mode get_shader_mode() const override;
+
+public:
+	SkyMaterial();
+};
+
+class ProceduralSkyMaterial : public SkyMaterial {
+	GDCLASS(ProceduralSkyMaterial, SkyMaterial);
 
 private:
 	Color sky_top_color;
@@ -107,7 +118,6 @@ public:
 	void set_energy_multiplier(float p_multiplier);
 	float get_energy_multiplier() const;
 
-	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;
 	virtual RID get_rid() const override;
 
@@ -120,8 +130,8 @@ public:
 //////////////////////////////////////////////////////
 /* PanoramaSkyMaterial */
 
-class PanoramaSkyMaterial : public Material {
-	GDCLASS(PanoramaSkyMaterial, Material);
+class PanoramaSkyMaterial : public SkyMaterial {
+	GDCLASS(PanoramaSkyMaterial, SkyMaterial);
 
 private:
 	Ref<Texture2D> panorama;
@@ -147,7 +157,6 @@ public:
 	void set_energy_multiplier(float p_multiplier);
 	float get_energy_multiplier() const;
 
-	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;
 	virtual RID get_rid() const override;
 
@@ -160,8 +169,8 @@ public:
 //////////////////////////////////////////////////////
 /* PanoramaSkyMaterial */
 
-class PhysicalSkyMaterial : public Material {
-	GDCLASS(PhysicalSkyMaterial, Material);
+class PhysicalSkyMaterial : public SkyMaterial {
+	GDCLASS(PhysicalSkyMaterial, SkyMaterial);
 
 private:
 	static Mutex shader_mutex;
@@ -222,7 +231,6 @@ public:
 	void set_night_sky(const Ref<Texture2D> &p_night_sky);
 	Ref<Texture2D> get_night_sky() const;
 
-	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;
 
 	static void cleanup_shader();

--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -80,7 +80,7 @@ void Sky::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &Sky::set_material);
 	ClassDB::bind_method(D_METHOD("get_material"), &Sky::get_material);
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sky_material", PROPERTY_HINT_RESOURCE_TYPE, "PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial,ShaderMaterial"), "set_material", "get_material");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sky_material", PROPERTY_HINT_RESOURCE_TYPE, "SkyMaterial,ShaderMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Automatic,High-Quality,High-Quality Incremental,Real-Time"), "set_process_mode", "get_process_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radiance_size", PROPERTY_HINT_ENUM, "32,64,128,256,512,1024,2048"), "set_radiance_size", "get_radiance_size");
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/11518

CI failed at "Check for GDExtension compatibility". I know it is because it changes inheritance, but what am I suppose to do with this error?