### PR TITLE
Remove implicit conversions from `String`, `Char16String` and `CharString` to data pointers. 

### DIFF
--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -383,14 +383,14 @@ void PListNode::store_text(String &p_stream, uint8_t p_indent) const {
 			p_stream += String("\t").repeat(p_indent);
 			p_stream += "<data>\n";
 			p_stream += String("\t").repeat(p_indent);
-			p_stream += data_string + "\n";
+			p_stream += String(data_string.get_data()) + "\n";
 			p_stream += String("\t").repeat(p_indent);
 			p_stream += "</data>\n";
 		} break;
 		case PList::PLNodeType::PL_NODE_TYPE_DATE: {
 			p_stream += String("\t").repeat(p_indent);
 			p_stream += "<date>";
-			p_stream += data_string;
+			p_stream += String(data_string.get_data());
 			p_stream += "</date>\n";
 		} break;
 		case PList::PLNodeType::PL_NODE_TYPE_STRING: {

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -298,7 +298,7 @@ String ResourceUID::get_path_from_cache(Ref<FileAccess> &p_cache_file, const Str
 		ERR_FAIL_COND_V(rl != len, String());
 
 		if (singleton->id_to_text(id) == p_uid_string) {
-			return String(cs);
+			return String(cs.get_data());
 		}
 	}
 	return String();

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -204,8 +204,7 @@ public:
 	Char16String &operator+=(char16_t p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char16_t *get_data() const;
-	operator const char16_t *() const { return get_data(); }
-	explicit operator StrRange<char16_t>() const { return StrRange(get_data(), length()); }
+	operator StrRange<char16_t>() const { return StrRange(get_data(), length()); }
 
 protected:
 	void copy_from(const char16_t *p_cstr);
@@ -250,8 +249,7 @@ public:
 	CharString &operator+=(char p_char);
 	int length() const { return size() ? size() - 1 : 0; }
 	const char *get_data() const;
-	operator const char *() const { return get_data(); }
-	explicit operator StrRange<char>() const { return StrRange(get_data(), length()); }
+	operator StrRange<char>() const { return StrRange(get_data(), length()); }
 
 protected:
 	void copy_from(const char *p_cstr);
@@ -523,11 +521,19 @@ public:
 	CharString ascii(bool p_allow_extended = false) const;
 	CharString utf8() const;
 	Error parse_utf8(const char *p_utf8, int p_len = -1, bool p_skip_cr = false);
+	Error parse_utf8(const StrRange<char> &p_range, bool p_skip_cr = false) {
+		return parse_utf8(p_range.c_str, p_range.len, p_skip_cr);
+	}
 	static String utf8(const char *p_utf8, int p_len = -1);
+	static String utf8(const StrRange<char> &p_range) { return utf8(p_range.c_str, p_range.len); }
 
 	Char16String utf16() const;
 	Error parse_utf16(const char16_t *p_utf16, int p_len = -1, bool p_default_little_endian = true);
+	Error parse_utf16(const StrRange<char16_t> p_range, bool p_skip_cr = false) {
+		return parse_utf16(p_range.c_str, p_range.len, p_skip_cr);
+	}
 	static String utf16(const char16_t *p_utf16, int p_len = -1);
+	static String utf16(const StrRange<char16_t> &p_range) { return utf16(p_range.c_str, p_range.len); }
 
 	static uint32_t hash(const char32_t *p_cstr, int p_len); /* hash the string */
 	static uint32_t hash(const char32_t *p_cstr); /* hash the string */
@@ -642,7 +648,7 @@ public:
 		parse_utf32(p_cstr);
 	}
 
-	explicit operator StrRange<char32_t>() const { return StrRange(get_data(), length()); }
+	operator StrRange<char32_t>() const { return StrRange(get_data(), length()); }
 };
 
 bool operator==(const char *p_chr, const String &p_str);

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -469,13 +469,13 @@ _FORCE_INLINE_ void CodeSignRequirements::_parse_certificate_slot(uint32_t &r_po
 _FORCE_INLINE_ void CodeSignRequirements::_parse_key(uint32_t &r_pos, String &r_out, uint32_t p_rq_size) const {
 #define _R(x) BSWAP32(*(uint32_t *)(blob.ptr() + x))
 	ERR_FAIL_COND_MSG(r_pos >= p_rq_size, "CodeSign/Requirements: Out of bounds.");
-	uint32_t key_size = _R(r_pos);
+	const uint32_t key_size = _R(r_pos);
 	ERR_FAIL_COND_MSG(r_pos + key_size > p_rq_size, "CodeSign/Requirements: Out of bounds.");
 	CharString key;
 	key.resize(key_size);
 	memcpy(key.ptrw(), blob.ptr() + r_pos + 4, key_size);
 	r_pos += 4 + key_size + PAD(key_size, 4);
-	r_out += "[" + String::utf8(key, key_size) + "]";
+	r_out += "[" + String::utf8(key) + "]";
 #undef _R
 }
 
@@ -526,13 +526,13 @@ _FORCE_INLINE_ void CodeSignRequirements::_parse_hash_string(uint32_t &r_pos, St
 _FORCE_INLINE_ void CodeSignRequirements::_parse_value(uint32_t &r_pos, String &r_out, uint32_t p_rq_size) const {
 #define _R(x) BSWAP32(*(uint32_t *)(blob.ptr() + x))
 	ERR_FAIL_COND_MSG(r_pos >= p_rq_size, "CodeSign/Requirements: Out of bounds.");
-	uint32_t key_size = _R(r_pos);
+	const uint32_t key_size = _R(r_pos);
 	ERR_FAIL_COND_MSG(r_pos + key_size > p_rq_size, "CodeSign/Requirements: Out of bounds.");
 	CharString key;
 	key.resize(key_size);
 	memcpy(key.ptrw(), blob.ptr() + r_pos + 4, key_size);
 	r_pos += 4 + key_size + PAD(key_size, 4);
-	r_out += "\"" + String::utf8(key, key_size) + "\"";
+	r_out += "\"" + String::utf8(key) + "\"";
 #undef _R
 }
 

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -52,7 +52,7 @@ void CameraFeedLinux::_update_buffer() {
 }
 
 void CameraFeedLinux::_query_device(const String &p_device_name) {
-	file_descriptor = open(p_device_name.ascii(), O_RDWR | O_NONBLOCK, 0);
+	file_descriptor = open(p_device_name.ascii().get_data(), O_RDWR | O_NONBLOCK, 0);
 	ERR_FAIL_COND_MSG(file_descriptor == -1, vformat("Cannot open file descriptor for %s. Error: %d.", p_device_name, errno));
 
 	struct v4l2_capability capability;
@@ -235,7 +235,7 @@ String CameraFeedLinux::get_device_name() const {
 
 bool CameraFeedLinux::activate_feed() {
 	ERR_FAIL_COND_V_MSG(selected_format == -1, false, "CameraFeed format needs to be set before activating.");
-	file_descriptor = open(device_name.ascii(), O_RDWR | O_NONBLOCK, 0);
+	file_descriptor = open(device_name.ascii().get_data(), O_RDWR | O_NONBLOCK, 0);
 	if (_request_buffers() && _start_capturing()) {
 		buffer_decoder = _create_buffer_decoder();
 		_start_thread();
@@ -315,7 +315,7 @@ bool CameraFeedLinux::set_format(int p_index, const Dictionary &p_parameters) {
 
 	FeedFormat feed_format = formats[p_index];
 
-	file_descriptor = open(device_name.ascii(), O_RDWR | O_NONBLOCK, 0);
+	file_descriptor = open(device_name.ascii().get_data(), O_RDWR | O_NONBLOCK, 0);
 
 	struct v4l2_format format;
 	memset(&format, 0, sizeof(format));

--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -113,7 +113,7 @@ void CameraLinux::_add_device(const String &p_device_name) {
 int CameraLinux::_open_device(const String &p_device_name) {
 	struct stat s;
 
-	if (stat(p_device_name.ascii(), &s) == -1) {
+	if (stat(p_device_name.ascii().get_data(), &s) == -1) {
 		return -1;
 	}
 
@@ -121,7 +121,7 @@ int CameraLinux::_open_device(const String &p_device_name) {
 		return -1;
 	}
 
-	return open(p_device_name.ascii(), O_RDWR | O_NONBLOCK, 0);
+	return open(p_device_name.ascii().get_data(), O_RDWR | O_NONBLOCK, 0);
 }
 
 // TODO any cheaper/cleaner way to check if file descriptor is invalid?

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1059,7 +1059,7 @@ void CSharpLanguage::_editor_init_callback() {
 	const void **interop_funcs = godotsharp::get_editor_interop_funcs(interop_funcs_size);
 
 	Object *editor_plugin_obj = GDMono::get_singleton()->get_plugin_callbacks().LoadToolsAssemblyCallback(
-			GodotSharpDirs::get_data_editor_tools_dir().path_join("GodotTools.dll").utf16(),
+			GodotSharpDirs::get_data_editor_tools_dir().path_join("GodotTools.dll").utf16().get_data(),
 			interop_funcs, interop_funcs_size);
 	CRASH_COND(editor_plugin_obj == nullptr);
 

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -636,7 +636,7 @@ bool GDMono::_load_project_assembly() {
 	}
 
 	String loaded_assembly_path;
-	bool success = plugin_callbacks.LoadProjectAssemblyCallback(assembly_path.utf16(), &loaded_assembly_path);
+	bool success = plugin_callbacks.LoadProjectAssemblyCallback(assembly_path.utf16().get_data(), &loaded_assembly_path);
 
 	if (success) {
 		project_assembly_path = loaded_assembly_path.simplify_path();

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -578,7 +578,7 @@ bool OpenXRAPI::create_instance() {
 
 	Vector<const char *> extension_ptrs;
 	for (int i = 0; i < enabled_extensions.size(); i++) {
-		print_verbose(String("OpenXR: Enabling extension ") + String(enabled_extensions[i]));
+		print_verbose(String("OpenXR: Enabling extension ") + String(enabled_extensions[i].get_data()));
 		extension_ptrs.push_back(enabled_extensions[i].get_data());
 	}
 

--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -197,7 +197,7 @@ Error RegEx::compile(const String &p_pattern, bool p_show_error) {
 			PCRE2_UCHAR32 buf[256];
 			pcre2_get_error_message_32(err, buf, 256);
 			String message = String::num_int64(offset) + ": " + String((const char32_t *)buf);
-			ERR_PRINT(message.utf8());
+			ERR_PRINT(message);
 		}
 		return FAILED;
 	}
@@ -348,7 +348,7 @@ String RegEx::sub(const String &p_subject, const String &p_replacement, bool p_a
 		PCRE2_UCHAR32 buf[256];
 		pcre2_get_error_message_32(res, buf, 256);
 		String message = "PCRE2 Error: " + String((const char32_t *)buf);
-		ERR_PRINT(message.utf8());
+		ERR_PRINT(message);
 
 		if (res == PCRE2_ERROR_NOSUBSTRING) {
 			flags |= PCRE2_SUBSTITUTE_UNKNOWN_UNSET;

--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -774,7 +774,7 @@ bool DisplayServerIOS::has_hardware_keyboard() const {
 }
 
 void DisplayServerIOS::clipboard_set(const String &p_text) {
-	[UIPasteboard generalPasteboard].string = [NSString stringWithUTF8String:p_text.utf8()];
+	[UIPasteboard generalPasteboard].string = [NSString stringWithUTF8String:p_text.utf8().get_data()];
 }
 
 String DisplayServerIOS::clipboard_get() const {

--- a/platform/linuxbsd/tts_linux.cpp
+++ b/platform/linuxbsd/tts_linux.cpp
@@ -63,7 +63,7 @@ void TTS_Linux::speech_init_thread_func(void *p_userdata) {
 			} else {
 				class_str = config_name.utf8();
 			}
-			tts->synth = spd_open(class_str, "Godot_Engine_Speech_API", "Godot_Engine", SPD_MODE_THREADED);
+			tts->synth = spd_open(class_str.get_data(), "Godot_Engine_Speech_API", "Godot_Engine", SPD_MODE_THREADED);
 			if (tts->synth) {
 				tts->synth->callback_end = &speech_event_callback;
 				tts->synth->callback_cancel = &speech_event_callback;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3670,12 +3670,12 @@ void WaylandThread::window_set_title(DisplayServer::WindowID p_window_id, const 
 
 #ifdef LIBDECOR_ENABLED
 	if (ws.libdecor_frame) {
-		libdecor_frame_set_title(ws.libdecor_frame, p_title.utf8());
+		libdecor_frame_set_title(ws.libdecor_frame, p_title.utf8().get_data());
 	}
 #endif // LIBDECOR_ENABLE
 
 	if (ws.xdg_toplevel) {
-		xdg_toplevel_set_title(ws.xdg_toplevel, p_title.utf8());
+		xdg_toplevel_set_title(ws.xdg_toplevel, p_title.utf8().get_data());
 	}
 }
 
@@ -3685,13 +3685,13 @@ void WaylandThread::window_set_app_id(DisplayServer::WindowID p_window_id, const
 
 #ifdef LIBDECOR_ENABLED
 	if (ws.libdecor_frame) {
-		libdecor_frame_set_app_id(ws.libdecor_frame, p_app_id.utf8());
+		libdecor_frame_set_app_id(ws.libdecor_frame, p_app_id.utf8().get_data());
 		return;
 	}
 #endif // LIBDECOR_ENABLED
 
 	if (ws.xdg_toplevel) {
-		xdg_toplevel_set_app_id(ws.xdg_toplevel, p_app_id.utf8());
+		xdg_toplevel_set_app_id(ws.xdg_toplevel, p_app_id.utf8().get_data());
 		return;
 	}
 }
@@ -4179,7 +4179,7 @@ Vector<uint8_t> WaylandThread::selection_get_mime(const String &p_mime) const {
 		return Vector<uint8_t>();
 	}
 
-	return _wl_data_offer_read(wl_display, p_mime.utf8(), ss->wl_data_offer_selection);
+	return _wl_data_offer_read(wl_display, p_mime.utf8().get_data(), ss->wl_data_offer_selection);
 }
 
 bool WaylandThread::primary_has_mime(const String &p_mime) const {
@@ -4222,7 +4222,7 @@ Vector<uint8_t> WaylandThread::primary_get_mime(const String &p_mime) const {
 		return Vector<uint8_t>();
 	}
 
-	return _wp_primary_selection_offer_read(wl_display, p_mime.utf8(), ss->wp_primary_selection_offer);
+	return _wp_primary_selection_offer_read(wl_display, p_mime.utf8().get_data(), ss->wp_primary_selection_offer);
 }
 
 void WaylandThread::primary_set_text(const String &p_text) {


### PR DESCRIPTION
This is mostly a _sanity_ change to avoid accidental conversions leading to unexpected behavior.

I have not tested how many callers are affected (e.g. `String s = char_string`).
All that are will experience a noticeable improvement of speed because `strlen` does not have to be called.

## Notes on implicitness

I have made conversions from `String`-likes to `StrRange` implicit to aid the transition. 
I thought long and hard about whether I want to 'contribute' another implicit conversion to the codebase, seeing as though they are already leading to quite a lot of problems.

However, I think conversion _to_ StrRange is one of the rare cases where it actually is warranted:
- The conversion does not lose metadata about the contents (pointer and length).
- No data is allocated, and the conversion is trivial.

The only gotcha for this conversion is really that it may lead to ambiguous calls, and it may lead to unintentional loss of ownership. However, both are true about the `const char *` conversions, so it's an upgrade all around.

## Behavior changes
There are a few behavior changes that may lead to problems (though they are unlikely to). If problems are experienced somewhere, it's likely the caller should have been more explicit from the start, and should be addressed to do so.

Especially, callers will change behavior when encountering a `\0`: Instead of cutting the string short, they will add the character to the middle of the string. In terms of `UTF-32`, the _new_ behavior is correct. Still, if unexpected behavior is observed, it should be evaluated on a case-by-case basis - most likely, the previous behavior was incorrect other behavior should be adjusted to fit.
