### PR TITLE
Remove unnecessary allocations and memcpy  in `codesign.cpp`

### DIFF
--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -471,11 +471,8 @@ _FORCE_INLINE_ void CodeSignRequirements::_parse_key(uint32_t &r_pos, String &r_
 	ERR_FAIL_COND_MSG(r_pos >= p_rq_size, "CodeSign/Requirements: Out of bounds.");
 	const uint32_t key_size = _R(r_pos);
 	ERR_FAIL_COND_MSG(r_pos + key_size > p_rq_size, "CodeSign/Requirements: Out of bounds.");
-	CharString key;
-	key.resize(key_size);
-	memcpy(key.ptrw(), blob.ptr() + r_pos + 4, key_size);
 	r_pos += 4 + key_size + PAD(key_size, 4);
-	r_out += "[" + String::utf8(key) + "]";
+	r_out += "[" + String::utf8((const char *)blob.ptr() + r_pos + 4, key_size) + "]";
 #undef _R
 }
 
@@ -515,10 +512,7 @@ _FORCE_INLINE_ void CodeSignRequirements::_parse_hash_string(uint32_t &r_pos, St
 	ERR_FAIL_COND_MSG(r_pos >= p_rq_size, "CodeSign/Requirements: Out of bounds.");
 	uint32_t tag_size = _R(r_pos);
 	ERR_FAIL_COND_MSG(r_pos + tag_size > p_rq_size, "CodeSign/Requirements: Out of bounds.");
-	PackedByteArray data;
-	data.resize(tag_size);
-	memcpy(data.ptrw(), blob.ptr() + r_pos + 4, tag_size);
-	r_out += "H\"" + String::hex_encode_buffer(data.ptr(), data.size()) + "\"";
+	r_out += "H\"" + String::hex_encode_buffer(blob.ptr() + r_pos + 4, tag_size) + "\"";
 	r_pos += 4 + tag_size + PAD(tag_size, 4);
 #undef _R
 }
@@ -528,11 +522,8 @@ _FORCE_INLINE_ void CodeSignRequirements::_parse_value(uint32_t &r_pos, String &
 	ERR_FAIL_COND_MSG(r_pos >= p_rq_size, "CodeSign/Requirements: Out of bounds.");
 	const uint32_t key_size = _R(r_pos);
 	ERR_FAIL_COND_MSG(r_pos + key_size > p_rq_size, "CodeSign/Requirements: Out of bounds.");
-	CharString key;
-	key.resize(key_size);
-	memcpy(key.ptrw(), blob.ptr() + r_pos + 4, key_size);
 	r_pos += 4 + key_size + PAD(key_size, 4);
-	r_out += "\"" + String::utf8(key) + "\"";
+	r_out += "\"" + String::utf8((const char *)blob.ptr() + r_pos + 4, key_size) + "\"";
 #undef _R
 }
 


### PR DESCRIPTION
Remove unnecessary allocations and memcpy in `:_parse_key`, `_parse_hash_string` and `_parse_value`.

Spotted during [code review here](https://github.com/godotengine/godot/pull/101293#discussion_r1907405137)
