### PR TITLE
Renderer: Minor optimization when running `gl_compatibility` mode

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -876,17 +876,16 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 					blit.dst_rect.size = vp->size;
 				}
 
-				Vector<BlitToScreen> *blits = blit_to_screen_list.getptr(vp->viewport_to_screen);
-				if (blits == nullptr) {
-					blits = &blit_to_screen_list.insert(vp->viewport_to_screen, Vector<BlitToScreen>())->value;
-				}
-
 				if (OS::get_singleton()->get_current_rendering_driver_name().begins_with("opengl3")) {
 					Vector<BlitToScreen> blit_to_screen_vec;
 					blit_to_screen_vec.push_back(blit);
 					RSG::rasterizer->blit_render_targets_to_screen(vp->viewport_to_screen, blit_to_screen_vec.ptr(), 1);
 					RSG::rasterizer->gl_end_frame(p_swap_buffers);
 				} else {
+					Vector<BlitToScreen> *blits = blit_to_screen_list.getptr(vp->viewport_to_screen);
+					if (blits == nullptr) {
+						blits = &blit_to_screen_list.insert(vp->viewport_to_screen, Vector<BlitToScreen>())->value;
+					}
 					blits->push_back(blit);
 				}
 			}


### PR DESCRIPTION
Very minor optimisation to avoid allocating an empty list and inserting it into the map when running in `gl_compatibility` mode, as the blit is never added to the list.

Specifically, this change ensures this block doesn't execute and generate unnecessary allocations:

https://github.com/godotengine/godot/blob/abd0e6990cec375c36b4f43a31c6bc29e0b2cda0/servers/rendering/renderer_viewport.cpp#L917-L921