### PR TITLE
Allow to disable canvas instance ID checking in point intersection queries

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -48,6 +48,7 @@
 			<param index="4" name="collide_with_areas" type="bool" />
 			<param index="5" name="r_results" type="PhysicsServer2DExtensionShapeResult*" />
 			<param index="6" name="max_results" type="int" />
+			<param index="7" name="check_canvas_instance_id" type="bool" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsPointQueryParameters2D.xml
+++ b/doc/classes/PhysicsPointQueryParameters2D.xml
@@ -10,8 +10,12 @@
 	</tutorials>
 	<members>
 		<member name="canvas_instance_id" type="int" setter="set_canvas_instance_id" getter="get_canvas_instance_id" default="0">
-			If different from [code]0[/code], restricts the query to a specific canvas layer specified by its instance ID. See [method Object.get_instance_id].
+			If different from [code]0[/code], restricts the query to a specific canvas instance ID. See [method PhysicsServer2D.area_get_canvas_instance_id] and [method PhysicsServer2D.body_get_canvas_instance_id].
 			If [code]0[/code], restricts the query to the Viewport's default canvas layer.
+			[member check_canvas_instance_id] needs to be enabled for this property to be taken into account.
+		</member>
+		<member name="check_canvas_instance_id" type="bool" setter="set_check_canvas_instance_id" getter="get_check_canvas_instance_id" default="true">
+			If [code]true[/code], the query will take the set [member canvas_instance_id] into account.
 		</member>
 		<member name="collide_with_areas" type="bool" setter="set_collide_with_areas" getter="is_collide_with_areas_enabled" default="false">
 			If [code]true[/code], the query will take [Area2D]s into account.

--- a/misc/extension_api_validation/4.7-stable/GH-101300.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-101300.txt
@@ -1,0 +1,5 @@
+GH-101300
+---------
+Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState2DExtension/methods/_intersect_point/arguments': size changed value in new API, from 7 to 8.
+
+Added argument to disable checking the canvas instance ID on point intersection queries.

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -84,7 +84,7 @@ int GodotPhysicsDirectSpaceState2D::intersect_point(const PointParameters &p_par
 			continue;
 		}
 
-		if (col_obj->get_canvas_instance_id() != p_parameters.canvas_instance_id) {
+		if (p_parameters.check_canvas_instance_id && col_obj->get_canvas_instance_id() != p_parameters.canvas_instance_id) {
 			continue;
 		}
 

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -242,6 +242,9 @@ void PhysicsPointQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &PhysicsPointQueryParameters2D::set_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &PhysicsPointQueryParameters2D::get_position);
 
+	ClassDB::bind_method(D_METHOD("set_check_canvas_instance_id", "canvas_instance_id"), &PhysicsPointQueryParameters2D::set_check_canvas_instance_id);
+	ClassDB::bind_method(D_METHOD("get_check_canvas_instance_id"), &PhysicsPointQueryParameters2D::get_check_canvas_instance_id);
+
 	ClassDB::bind_method(D_METHOD("set_canvas_instance_id", "canvas_instance_id"), &PhysicsPointQueryParameters2D::set_canvas_instance_id);
 	ClassDB::bind_method(D_METHOD("get_canvas_instance_id"), &PhysicsPointQueryParameters2D::get_canvas_instance_id);
 
@@ -258,6 +261,7 @@ void PhysicsPointQueryParameters2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_collide_with_areas_enabled"), &PhysicsPointQueryParameters2D::is_collide_with_areas_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "check_canvas_instance_id"), "set_check_canvas_instance_id", "get_check_canvas_instance_id");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "canvas_instance_id", PROPERTY_HINT_OBJECT_ID), "set_canvas_instance_id", "get_canvas_instance_id");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_2D_PHYSICS), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "exclude", PROPERTY_HINT_ARRAY_TYPE, "RID"), "set_exclude", "get_exclude");

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -166,6 +166,7 @@ public:
 
 	struct PointParameters {
 		Vector2 position;
+		bool check_canvas_instance_id = true;
 		ObjectID canvas_instance_id;
 		HashSet<RID> exclude;
 		uint32_t collision_mask = UINT32_MAX;
@@ -676,6 +677,9 @@ public:
 
 	void set_position(const Vector2 &p_position) { parameters.position = p_position; }
 	const Vector2 &get_position() const { return parameters.position; }
+
+	void set_check_canvas_instance_id(bool p_check_canvas_instance_id) { parameters.check_canvas_instance_id = p_check_canvas_instance_id; }
+	bool get_check_canvas_instance_id() const { return parameters.check_canvas_instance_id; }
 
 	void set_canvas_instance_id(ObjectID p_canvas_instance_id) { parameters.canvas_instance_id = p_canvas_instance_id; }
 	ObjectID get_canvas_instance_id() const { return parameters.canvas_instance_id; }

--- a/servers/physics_2d/physics_server_2d_extension.cpp
+++ b/servers/physics_2d/physics_server_2d_extension.cpp
@@ -42,11 +42,15 @@ void PhysicsDirectSpaceState2DExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_body_excluded_from_query", "body"), &PhysicsDirectSpaceState2DExtension::is_body_excluded_from_query);
 
 	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "r_result");
-	GDVIRTUAL_BIND(_intersect_point, "position", "canvas_instance_id", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results");
+	GDVIRTUAL_BIND(_intersect_point, "position", "canvas_instance_id", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results", "check_canvas_instance_id");
 	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_result", "max_results");
 	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_closest_safe", "r_closest_unsafe");
 	GDVIRTUAL_BIND(_collide_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results", "r_result_count");
 	GDVIRTUAL_BIND(_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_rest_info");
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_intersect_point_compat_101300, "position", "canvas_instance_id", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results");
+#endif
 }
 
 PhysicsDirectSpaceState2DExtension::PhysicsDirectSpaceState2DExtension() {

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -132,11 +132,15 @@ protected:
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
 	GDVIRTUAL7R_REQUIRED(bool, _intersect_ray, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionRayResult>)
-	GDVIRTUAL7R_REQUIRED(int, _intersect_point, const Vector2 &, ObjectID, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
+	GDVIRTUAL8R_REQUIRED(int, _intersect_point, const Vector2 &, ObjectID, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int, bool);
 	GDVIRTUAL9R_REQUIRED(int, _intersect_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
 	GDVIRTUAL9R_REQUIRED(bool, _cast_motion, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<real_t>, GDExtensionPtr<real_t>)
 	GDVIRTUAL10R_REQUIRED(bool, _collide_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<Vector2>, int, GDExtensionPtr<int>)
 	GDVIRTUAL8R_REQUIRED(bool, _rest_info, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeRestInfo>)
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL7R_COMPAT(_intersect_point_compat_101300, int, _intersect_point, const Vector2 &, ObjectID, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int);
+#endif // DISABLE_DEPRECATED
 
 public:
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
@@ -149,7 +153,13 @@ public:
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override {
 		exclude = &p_parameters.exclude;
 		int ret = false;
-		GDVIRTUAL_CALL(_intersect_point, p_parameters.position, p_parameters.canvas_instance_id, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
+
+		if (!GDVIRTUAL_CALL(_intersect_point, p_parameters.position, p_parameters.canvas_instance_id, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, p_parameters.check_canvas_instance_id, ret)) {
+#ifndef DISABLE_DEPRECATED
+			GDVIRTUAL_CALL(_intersect_point_compat_101300, p_parameters.position, p_parameters.canvas_instance_id, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
+#endif // DISABLE_DEPRECATED
+		}
+
 		exclude = nullptr;
 		return ret;
 	}


### PR DESCRIPTION
This allows for doing queries in 2D physical objects inside `CanvasLayer`s which the layers aren't set to `0`.