### PR TITLE
Add `String::ascii` creator functions, to parse a char buffer as ASCII.

### DIFF
--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -383,14 +383,16 @@ void PListNode::store_text(String &p_stream, uint8_t p_indent) const {
 			p_stream += String("\t").repeat(p_indent);
 			p_stream += "<data>\n";
 			p_stream += String("\t").repeat(p_indent);
-			p_stream += String(data_string.get_data()) + "\n";
+			// Data should be Base64 (i.e. ASCII only).
+			p_stream += String::ascii(data_string) + "\n";
 			p_stream += String("\t").repeat(p_indent);
 			p_stream += "</data>\n";
 		} break;
 		case PList::PLNodeType::PL_NODE_TYPE_DATE: {
 			p_stream += String("\t").repeat(p_indent);
 			p_stream += "<date>";
-			p_stream += String(data_string.get_data());
+			// Data should be ISO 8601 (i.e. ASCII only).
+			p_stream += String::ascii(data_string);
 			p_stream += "</date>\n";
 		} break;
 		case PList::PLNodeType::PL_NODE_TYPE_STRING: {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -519,6 +519,15 @@ public:
 	char32_t unicode_at(int p_idx) const;
 
 	CharString ascii(bool p_allow_extended = false) const;
+	// Parse an ascii string.
+	// If any character is > 127, an error will be logged, and 0xfffd will be inserted.
+	Error parse_ascii(const StrRange<char> &p_range);
+	static String ascii(const StrRange<char> &p_range) {
+		String s;
+		s.parse_ascii(p_range);
+		return s;
+	}
+
 	CharString utf8() const;
 	Error parse_utf8(const char *p_utf8, int p_len = -1, bool p_skip_cr = false);
 	Error parse_utf8(const StrRange<char> &p_range, bool p_skip_cr = false) {


### PR DESCRIPTION
The function will log errors if any characters above value 127 are found. This is most similar to `parse_latin1`, but `parse_latin1` will silently and incorrectly parse values above 127 as 'extended latin set' characters, when `ASCII` only is expected. This would be especially incorrect if the input is `utf8`, because the string will silently have incorrect length and misinterpreted characters.

As discussed in https://github.com/godotengine/godot/pull/101293#discussion_r1907518247, two functions in `plist` are known to expect `ASCII`-only strings, so they are used as an excuse to call the new function. It would be correct to call `parse_ascii` on many other occasions (see https://github.com/godotengine/godot/issues/100641), but I do not have the broad knowledge to search out all these instances. Instead, the function is added here such that future contributions can call it to safely parse `ASCII` when it is expected.

Requires and includes #101293 (because of implicit conversions).