### PR TITLE
Make references of editor viewport freelook active consistent and remove unused accessor

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -577,7 +577,7 @@ void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 		//-------
 		// Perform smoothing
 
-		if (is_freelook_active()) {
+		if (freelook_active) {
 			// Higher inertia should increase "lag" (lerp with factor between 0 and 1)
 			// Inertia of zero should produce instant movement (lerp with factor of 1) in this case it returns a really high value and gets clamped to 1.
 			const real_t inertia = EDITOR_GET("editors/3d/freelook/freelook_inertia");
@@ -1873,14 +1873,14 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		const real_t zoom_factor = 1 + (ZOOM_FREELOOK_MULTIPLIER - 1) * b->get_factor();
 		switch (b->get_button_index()) {
 			case MouseButton::WHEEL_UP: {
-				if (is_freelook_active()) {
+				if (freelook_active) {
 					scale_freelook_speed(zoom_factor);
 				} else {
 					scale_cursor_distance(1.0 / zoom_factor);
 				}
 			} break;
 			case MouseButton::WHEEL_DOWN: {
-				if (is_freelook_active()) {
+				if (freelook_active) {
 					scale_freelook_speed(1.0 / zoom_factor);
 				} else {
 					scale_cursor_distance(zoom_factor);
@@ -2430,7 +2430,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMagnifyGesture> magnify_gesture = p_event;
 	if (magnify_gesture.is_valid()) {
-		if (is_freelook_active()) {
+		if (freelook_active) {
 			scale_freelook_speed(magnify_gesture->get_factor());
 		} else {
 			scale_cursor_distance(1.0 / magnify_gesture->get_factor());
@@ -2536,7 +2536,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 
 		if (_edit.mode == TRANSFORM_NONE) {
-			if (_edit.gizmo.is_null() && is_freelook_active() && k->get_keycode() == Key::ESCAPE) {
+			if (_edit.gizmo.is_null() && freelook_active && k->get_keycode() == Key::ESCAPE) {
 				set_freelook_active(false);
 				return;
 			}
@@ -2684,7 +2684,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		if (ED_IS_SHORTCUT("spatial_editor/cancel_transform", event_mod) && _edit.mode != TRANSFORM_NONE) {
 			cancel_transform();
 		}
-		if (!is_freelook_active() && !k->is_echo()) {
+		if (!freelook_active && !k->is_echo()) {
 			if (ED_IS_SHORTCUT("spatial_editor/reset_transform_position", event_mod)) {
 				_reset_transform(TransformType::POSITION);
 			}
@@ -2734,7 +2734,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 		// Freelook doesn't work in orthogonal mode.
 		if (!orthogonal && ED_IS_SHORTCUT("spatial_editor/freelook_toggle", event_mod)) {
-			set_freelook_active(!is_freelook_active());
+			set_freelook_active(!freelook_active);
 
 		} else if (k->get_keycode() == Key::ESCAPE) {
 			set_freelook_active(false);
@@ -3060,7 +3060,7 @@ Point2 Node3DEditorViewport::_get_warped_mouse_motion(const Ref<InputEventMouseM
 }
 
 void Node3DEditorViewport::_update_freelook(real_t delta) {
-	if (!is_freelook_active()) {
+	if (!freelook_active) {
 		return;
 	}
 
@@ -3881,7 +3881,7 @@ void Node3DEditorViewport::_draw() {
 
 	} else {
 		if (zoom_indicator_delay > 0.0) {
-			if (is_freelook_active()) {
+			if (freelook_active) {
 				// Show speed
 
 				real_t min_speed = MAX(camera->get_near() * 4, ZOOM_FREELOOK_MIN);

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -568,7 +568,6 @@ public:
 	void set_state(const Dictionary &p_state);
 	Dictionary get_state() const;
 	void reset();
-	bool is_freelook_active() const { return freelook_active; }
 
 	Vector3 get_ray_pos(const Vector2 &p_pos) const;
 	Vector3 get_ray(const Vector2 &p_pos) const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Freelook active is not accessed outside the class anymore, so this PR make references to it consistent and removes the subsequent unused accessor. 
