### PR TITLE
Add path tooltips to script editor

### DIFF
--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -185,6 +185,7 @@ protected:
 	void _warning_clicked(const Variant &p_line);
 
 	void _notification(int p_what);
+	static void _bind_methods();
 
 	HashMap<String, Ref<EditorSyntaxHighlighter>> highlighters;
 	void _change_syntax_highlighter(int p_idx);
@@ -201,6 +202,8 @@ protected:
 	void _validate_symbol(const String &p_symbol);
 
 	void _show_symbol_tooltip(const String &p_symbol, int p_row, int p_column);
+	void _show_resource_path_tooltip(const String &p_path, const String &p_uid);
+	void _resource_thumbnail_ready(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
 
 	void _convert_case(CodeTextEditor::CaseStyle p_case);
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/d86b429d-4bf0-44fc-a783-eb10bed05d56

It's a very quick implementation and also a bit broken, but the base functionality is there. You can hover a path or UID and you'll see a tooltip with both path and UID (useful for inspecting UIDs), resource type and a preview.