### PR TITLE
Fix `LookAtModifier3D` rest space incorrect rotation

### DIFF
--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -501,9 +501,11 @@ void LookAtModifier3D::_process_modification() {
 	Transform3D bone_rest_space;
 	int parent_bone = skeleton->get_bone_parent(bone);
 	if (parent_bone < 0) {
-		bone_rest_space = skeleton->get_global_transform() * skeleton->get_bone_rest(bone);
+		bone_rest_space = skeleton->get_global_transform();
+		bone_rest_space.origin += skeleton->get_bone_rest(bone).origin;
 	} else {
-		bone_rest_space = skeleton->get_global_transform() * skeleton->get_bone_global_pose(parent_bone) * skeleton->get_bone_rest(bone);
+		bone_rest_space = skeleton->get_global_transform() * skeleton->get_bone_global_pose(parent_bone);
+		bone_rest_space.origin += skeleton->get_bone_rest(bone).origin;
 	}
 
 	// Calculate forward_vector and destination.


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/98446

The rest space should only consider origin, excluding rotation.

Current incorrect result:
![image](https://github.com/user-attachments/assets/17dcd995-7deb-49ac-8107-40631e8f2172)

After fixed:
![image](https://github.com/user-attachments/assets/a0a52671-2773-4f8a-b3eb-169738e9934a)
