### PR TITLE
Fix duplicate buttons style to match the other buttons in the SpriteFrames editor plugin

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1904,7 +1904,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	add_anim->connect(SceneStringName(pressed), callable_mp(this, &SpriteFramesEditor::_animation_add));
 
 	duplicate_anim = memnew(Button);
-	duplicate_anim->set_flat(true);
+	duplicate_anim->set_theme_type_variation(SceneStringName(FlatButton));
 	hbc_animlist->add_child(duplicate_anim);
 	duplicate_anim->connect(SceneStringName(pressed), callable_mp(this, &SpriteFramesEditor::_animation_duplicate));
 


### PR DESCRIPTION
If you hover over the buttons in the SpriteFrames editor plugin, you will see that
the duplicate buttons style doesn't match the other buttons style.

Before:
![Képernyőkép 2025-01-08 220822](https://github.com/user-attachments/assets/894986b1-40da-433f-8b31-8a02b0d78d34)
After:
![Képernyőkép 2025-01-08 220636](https://github.com/user-attachments/assets/f31d079b-a74c-4731-8484-d4c24f3ffbde)


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
