### PR TITLE
Improve consistency of code regions

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -150,6 +150,12 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 								break;
 							}
 						}
+						// "#region" and "#endregion" only highlighted if they're the first region on the line.
+						if (color_regions[c].type == ColorRegion::TYPE_CODE_REGION &&
+								str.strip_edges().split_spaces()[0] != "#region" &&
+								str.strip_edges().split_spaces()[0] != "#endregion") {
+							match = false;
+						}
 						if (!match) {
 							continue;
 						}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1869,7 +1869,8 @@ bool CodeEdit::is_line_code_region_start(int p_line) const {
 	if (is_in_string(p_line) != -1) {
 		return false;
 	}
-	return get_line(p_line).strip_edges().begins_with(code_region_start_string);
+	Vector<String> split = get_line(p_line).strip_edges().split_spaces();
+	return split.size() > 0 && split[0] == code_region_start_string;
 }
 
 bool CodeEdit::is_line_code_region_end(int p_line) const {
@@ -1880,7 +1881,8 @@ bool CodeEdit::is_line_code_region_end(int p_line) const {
 	if (is_in_string(p_line) != -1) {
 		return false;
 	}
-	return get_line(p_line).strip_edges().begins_with(code_region_end_string);
+	Vector<String> split = get_line(p_line).strip_edges().split_spaces();
+	return split.size() > 0 && split[0] == code_region_end_string;
 }
 
 /* Delimiters */


### PR DESCRIPTION
As pointed out in #101187, code regions match the "#region" and "#endregion" keywords too loosely. This could cause unexpected highlighting when commenting out code.

This changes these keywords to require whitespace after them, both for the regions themselves in the CodeEdit node, and for syntax highlighting in Godot itself.

AFAIK, code regions aren't an exposed feature in the CodeEdit node, but if they are this could break backwards compatibility.

Before on left, after on right:
![image](https://github.com/user-attachments/assets/b5c4470b-c534-4401-a09c-91407d955410) ![image](https://github.com/user-attachments/assets/e317a19f-03e4-4c42-bf88-eea07fb1a086)

(With the last example there, it looks like there's some other discrepancies with the highlighting, but that's a separate issue.)