### PR TITLE
Change print warnings to config ones for popups that need transparency

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2531,7 +2531,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_BASIC("internationalization/locale/include_text_server_data", false);
 
 	OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", true);
-	OS::get_singleton()->_allow_layered = GLOBAL_DEF("display/window/per_pixel_transparency/allowed", false);
+	OS::get_singleton()->_allow_layered = GLOBAL_DEF_RST("display/window/per_pixel_transparency/allowed", false);
 
 #ifdef TOOLS_ENABLED
 	if (editor || project_manager) {

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -204,6 +204,14 @@ void MenuButton::set_disable_shortcuts(bool p_disabled) {
 	disable_shortcuts = p_disabled;
 }
 
+#ifdef TOOLS_ENABLED
+PackedStringArray MenuButton::get_configuration_warnings() const {
+	PackedStringArray warnings = Button::get_configuration_warnings();
+	warnings.append_array(popup->get_configuration_warnings());
+	return warnings;
+}
+#endif
+
 MenuButton::MenuButton(const String &p_text) :
 		Button(p_text) {
 	set_flat(true);

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -71,6 +71,10 @@ public:
 	void set_item_count(int p_count);
 	int get_item_count() const;
 
+#ifdef TOOLS_ENABLED
+	PackedStringArray get_configuration_warnings() const override;
+#endif
+
 	MenuButton(const String &p_text = String());
 	~MenuButton();
 };

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -582,6 +582,14 @@ void OptionButton::set_disable_shortcuts(bool p_disabled) {
 	disable_shortcuts = p_disabled;
 }
 
+#ifdef TOOLS_ENABLED
+PackedStringArray OptionButton::get_configuration_warnings() const {
+	PackedStringArray warnings = Button::get_configuration_warnings();
+	warnings.append_array(popup->get_configuration_warnings());
+	return warnings;
+}
+#endif
+
 OptionButton::OptionButton(const String &p_text) :
 		Button(p_text) {
 	set_toggle_mode(true);

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -143,6 +143,10 @@ public:
 
 	void set_disable_shortcuts(bool p_disabled);
 
+#ifdef TOOLS_ENABLED
+	PackedStringArray get_configuration_warnings() const override;
+#endif
+
 	OptionButton(const String &p_text = String());
 	~OptionButton();
 };

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -101,6 +101,10 @@ protected:
 	virtual Size2 _get_contents_minimum_size() const override;
 
 public:
+#ifdef TOOLS_ENABLED
+	PackedStringArray get_configuration_warnings() const override;
+#endif
+
 	PopupPanel();
 };
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -356,6 +356,10 @@ public:
 
 	virtual String get_tooltip(const Point2 &p_pos) const;
 
+#ifdef TOOLS_ENABLED
+	PackedStringArray get_configuration_warnings() const override;
+#endif
+
 	void add_autohide_area(const Rect2 &p_area);
 	void clear_autohide_areas();
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/pull/91333#discussion_r1907870242.