### PR TITLE
LightmapGI: Including `modules_enabled.gen.h` to properly check the configuration warning

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -34,12 +34,14 @@
 #include "core/io/config_file.h"
 #include "core/math/delaunay_3d.h"
 #include "core/object/object.h"
-#include "lightmap_probe.h"
+#include "scene/3d/lightmap_probe.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/resources/camera_attributes.h"
 #include "scene/resources/environment.h"
 #include "scene/resources/image_texture.h"
 #include "scene/resources/sky.h"
+
+#include "modules/modules_enabled.gen.h" // For lightmapper_rd.
 
 void LightmapGIData::add_user(const NodePath &p_path, const Rect2 &p_uv_scale, int p_slice_index, int32_t p_sub_instance) {
 	User user;


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/100751 removed `#include "modules/modules_enabled.gen.h"` from lots of places, which the rest of the code was silently and indirectly depending on. After https://github.com/godotengine/godot/pull/100751 all builds end up with `Lightmaps cannot be baked, as the lightmapper_rd module was disabled at compile-time.`

![image](https://github.com/user-attachments/assets/286f93ac-2747-40e5-9a85-cae1b4fd8151)

Make the dependency on the `#define`s explicit.