### PR TITLE
SCons: Specify optional dependencies for modules

### DIFF
--- a/modules/gltf/config.py
+++ b/modules/gltf/config.py
@@ -1,4 +1,5 @@
 def can_build(env, platform):
+    env.module_add_dependencies("gltf", ["csg", "gridmap"], True)
     return not env["disable_3d"]
 
 

--- a/modules/navigation/config.py
+++ b/modules/navigation/config.py
@@ -1,4 +1,5 @@
 def can_build(env, platform):
+    env.module_add_dependencies("navigation", ["csg", "gridmap"], True)
     return not env["disable_3d"]
 
 

--- a/modules/text_server_adv/config.py
+++ b/modules/text_server_adv/config.py
@@ -1,4 +1,5 @@
 def can_build(env, platform):
+    env.module_add_dependencies("text_server_adv", ["freetype", "msdfgen", "svg"], True)
     return True
 
 

--- a/modules/text_server_fb/config.py
+++ b/modules/text_server_fb/config.py
@@ -1,4 +1,5 @@
 def can_build(env, platform):
+    env.module_add_dependencies("text_server_fb", ["freetype", "msdfgen", "svg"], True)
     return True
 
 


### PR DESCRIPTION
Noticed this while double-checking module overlaps after #100751, and realized that GDScript is the only module using optional dependencies that's specifying this fact. I'm unsure if the information for optional dependencies is even being used anywhere, but this brings the other 4 modules in that same camp up to speed.