### PR TITLE
Allow adding typed collections to metadata

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -581,6 +581,61 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 			} else {
 				pi.hint_string = "Resource";
 			}
+		} else if (K.value.get_type() == Variant::ARRAY) {
+			pi.hint = PROPERTY_HINT_TYPE_STRING;
+			const int builtin = Array(K.value).get_typed_builtin();
+			pi.hint_string = itos(builtin);
+			if (builtin == Variant::OBJECT) {
+				pi.hint_string += "/" + itos(PROPERTY_HINT_RESOURCE_TYPE) + ":";
+				const Script *s = Object::cast_to<Script>(Array(K.value).get_typed_script());
+				if (s) {
+					if (s->get_global_name().is_empty()) {
+						pi.hint_string += s->get_instance_base_type();
+					} else {
+						pi.hint_string += s->get_global_name();
+					}
+				} else {
+					pi.hint_string += Array(K.value).get_typed_class_name();
+				}
+			} else {
+				pi.hint_string += ":";
+			}
+		} else if (K.value.get_type() == Variant::DICTIONARY) {
+			pi.hint = PROPERTY_HINT_TYPE_STRING;
+			const int key_builtin = Dictionary(K.value).get_typed_key_builtin();
+			pi.hint_string = itos(key_builtin);
+			if (key_builtin == Variant::OBJECT) {
+				pi.hint_string += "/" + itos(PROPERTY_HINT_RESOURCE_TYPE) + ":";
+				const Script *s = Object::cast_to<Script>(Dictionary(K.value).get_typed_key_script());
+				if (s) {
+					if (s->get_global_name().is_empty()) {
+						pi.hint_string += s->get_instance_base_type();
+					} else {
+						pi.hint_string += s->get_global_name();
+					}
+				} else {
+					pi.hint_string += Dictionary(K.value).get_typed_key_class_name();
+				}
+			} else {
+				pi.hint_string += ":";
+			}
+			const int value_builtin = Dictionary(K.value).get_typed_value_builtin();
+			pi.hint_string += ";" + itos(value_builtin);
+			if (value_builtin == Variant::OBJECT) {
+				pi.hint_string += "/" + itos(PROPERTY_HINT_RESOURCE_TYPE) + ":";
+				const Script *s = Object::cast_to<Script>(Dictionary(K.value).get_typed_value_script());
+				if (s) {
+					if (s->get_global_name().is_empty()) {
+						pi.hint_string += s->get_instance_base_type();
+					} else {
+						pi.hint_string += s->get_global_name();
+					}
+				} else {
+					pi.hint_string += Dictionary(K.value).get_typed_value_class_name();
+				}
+			} else {
+				pi.hint_string += ":";
+			}
 		}
 		p_list->push_back(pi);
 	}

--- a/editor/inspector/add_metadata_dialog.cpp
+++ b/editor/inspector/add_metadata_dialog.cpp
@@ -58,6 +58,27 @@ AddMetadataDialog::AddMetadataDialog() {
 	vbc->add_child(spacing);
 	spacing->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
 
+	HBoxContainer *typed_container = memnew(HBoxContainer);
+	typed_container->hide();
+
+	Label *key_label = memnew(Label);
+	typed_container->add_child(key_label);
+
+	add_meta_key_type = memnew(EditorVariantTypeOptionButton);
+	typed_container->add_child(add_meta_key_type);
+
+	Label *value_label = memnew(Label(TTR("Value:")));
+	typed_container->add_child(value_label);
+
+	add_meta_value_type = memnew(EditorVariantTypeOptionButton);
+	typed_container->add_child(add_meta_value_type);
+
+	vbc->add_child(typed_container);
+
+	Control *spacing2 = memnew(Control);
+	vbc->add_child(spacing2);
+	spacing2->set_custom_minimum_size(Size2(0, 10 * EDSCALE));
+
 	set_ok_button_text(TTR("Add"));
 	register_text_enter(add_meta_name);
 
@@ -68,6 +89,7 @@ AddMetadataDialog::AddMetadataDialog() {
 	validation_panel->set_accept_button(get_ok_button());
 
 	add_meta_name->connect(SceneStringName(text_changed), callable_mp(validation_panel, &EditorValidationPanel::update).unbind(1));
+	add_meta_type->connect(SceneStringName(item_selected), callable_mp(this, &AddMetadataDialog::_update_controls).bind(typed_container, key_label, value_label).unbind(1));
 }
 
 void AddMetadataDialog::_complete_init(const StringName &p_title) {
@@ -78,6 +100,25 @@ void AddMetadataDialog::_complete_init(const StringName &p_title) {
 
 	if (add_meta_type->get_item_count() == 0) {
 		add_meta_type->populate({ Variant::NIL }, { { Variant::OBJECT, "Resource" } });
+		add_meta_key_type->populate({ Variant::NIL }, { { Variant::OBJECT, "Resource" } });
+		add_meta_value_type->populate({ Variant::NIL }, { { Variant::OBJECT, "Resource" } });
+	}
+}
+
+// Parameters bound in init to prevent needing extra private variables just for this purpose.
+void AddMetadataDialog::_update_controls(HBoxContainer *p_typed_container, Label *p_key_label, Label *p_value_label) {
+	if (add_meta_type->get_selected_id() == Variant::DICTIONARY) {
+		p_value_label->show();
+		add_meta_value_type->show();
+		p_key_label->set_text(TTR("Key:"));
+		p_typed_container->show();
+	} else if (add_meta_type->get_selected_id() == Variant::ARRAY) {
+		p_value_label->hide();
+		add_meta_value_type->hide();
+		p_key_label->set_text(TTR("Element:"));
+		p_typed_container->show();
+	} else {
+		p_typed_container->hide();
 	}
 }
 
@@ -93,9 +134,31 @@ StringName AddMetadataDialog::get_meta_name() {
 }
 
 Variant AddMetadataDialog::get_meta_defval() {
+	const int type_id = add_meta_type->get_selected_id();
+
+	if (type_id == Variant::ARRAY) {
+		const int elem_type_id = add_meta_key_type->get_selected_id();
+
+		Array defarray = Array();
+		// Do not set Array[Variant] in metadata since untyped Array serves same purpose.
+		if (elem_type_id != Variant::NIL) {
+			defarray.set_typed(elem_type_id, elem_type_id == Variant::OBJECT ? "Resource" : "", Variant());
+		}
+		return defarray;
+	} else if (type_id == Variant::DICTIONARY) {
+		const int key_type_id = add_meta_key_type->get_selected_id();
+		const int value_type_id = add_meta_value_type->get_selected_id();
+
+		Dictionary defdict = Dictionary();
+		// Can set a Variant here if the other is typed.
+		if (key_type_id != Variant::NIL || value_type_id != Variant::NIL) {
+			defdict.set_typed(key_type_id, key_type_id == Variant::OBJECT ? "Resource" : "", Variant(), value_type_id, value_type_id == Variant::OBJECT ? "Resource" : "", Variant());
+		}
+		return defdict;
+	}
 	Variant defval;
 	Callable::CallError ce;
-	Variant::construct(add_meta_type->get_selected_type(), defval, nullptr, 0, ce);
+	Variant::construct(Variant::Type(type_id), defval, nullptr, 0, ce);
 	return defval;
 }
 

--- a/editor/inspector/add_metadata_dialog.h
+++ b/editor/inspector/add_metadata_dialog.h
@@ -50,9 +50,12 @@ private:
 	List<StringName> _existing_metas;
 
 	void _check_meta_name();
-	void _complete_init(const StringName &p_label);
+	void _update_controls(HBoxContainer *p_typed_container, Label *p_key_label, Label *p_value_label);
+	void _complete_init(const StringName &p_title);
 
 	LineEdit *add_meta_name = nullptr;
 	EditorVariantTypeOptionButton *add_meta_type = nullptr;
+	EditorVariantTypeOptionButton *add_meta_key_type = nullptr;
+	EditorVariantTypeOptionButton *add_meta_value_type = nullptr;
 	EditorValidationPanel *validation_panel = nullptr;
 };


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes godotengine/godot-proposals#11445. This updates the Add Metadata Dialog to show an Element type option when `Array` is selected as the meta type, and likewise Key and Value types when `Dictionary` is selected. Additionally, Arrays and Dictionaries in metadata will now show that they are typed in the Inspector, the same way it does for object properties. Also supports classes that inherit from `Resource`, including custom resources.

I feel like the alignment could be improved because it feels a bit aesthetically unpleasing for the bottom row to not be the same length as the top, but it was the best I could do without changing things too much. I am thinking they could be center-aligned, but more feedback is welcome. Feel free to request changes.

### Images of Add Metadata Dialog:

#### Array:
![Screenshot_20250108_194420](https://github.com/user-attachments/assets/47d02f8a-0fde-4ae7-a84b-0847b952b10e)
#### Dictionary:
![Screenshot_20250108_194459](https://github.com/user-attachments/assets/e6196256-b0fa-4288-8a46-31ebdd8aca6a)
