### PR TITLE
Preview Dictionary and Array values in the inspector instead of showing size.

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -412,7 +412,7 @@ void EditorPropertyArray::update_property() {
 		edit->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 		edit->set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 		edit->set_button_icon(get_editor_theme_icon(array_type_name));
-		edit->set_text(vformat("%s%s", array_sub_type_name, ctr_str));
+		edit->set_text(vformat("%s(%d) - %s", array_sub_type_name, size, ctr_str));
 		edit->set_tooltip_text(vformat(TTR("%s%s (size %d)"), array_type_name, array_sub_type_name, size));
 	} else {
 		edit->set_text_alignment(HORIZONTAL_ALIGNMENT_CENTER);
@@ -1184,7 +1184,7 @@ void EditorPropertyDictionary::update_property() {
 		edit->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
 		edit->set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 		edit->set_button_icon(get_editor_theme_icon(dict_type_name));
-		edit->set_text(vformat("%s%s", dict_sub_type_name, ctr_str));
+		edit->set_text(vformat("%s(%d) - %s", dict_sub_type_name, dict.size(), ctr_str));
 		edit->set_tooltip_text(vformat(TTR("%s%s (size %d)"), dict_type_name, dict_sub_type_name, dict.size()));
 	} else {
 		edit->set_text_alignment(HORIZONTAL_ALIGNMENT_CENTER);
@@ -1282,14 +1282,6 @@ void EditorPropertyDictionary::update_property() {
 					new_prop->set_use_folding(is_using_folding());
 					new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 					new_prop->set_draw_label(false);
-					EditorPropertyArray *arr_prop = Object::cast_to<EditorPropertyArray>(new_prop);
-					if (arr_prop) {
-						arr_prop->set_preview_value(true);
-					}
-					EditorPropertyDictionary *dict_prop = Object::cast_to<EditorPropertyDictionary>(new_prop);
-					if (dict_prop) {
-						dict_prop->set_preview_value(true);
-					}
 					slot.set_key_prop(new_prop);
 				}
 			}

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -115,7 +115,7 @@ class EditorPropertyArray : public EditorProperty {
 
 	PopupMenu *change_type = nullptr;
 
-	bool preview_value = false;
+	bool preview_value = true;
 	int page_length = 20;
 	int page_index = 0;
 	int changing_type_index = EditorPropertyArrayObject::NOT_CHANGING_TYPE;
@@ -228,7 +228,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	PopupMenu *change_type = nullptr;
 	bool updating = false;
 
-	bool preview_value = false;
+	bool preview_value = true;
 	Ref<EditorPropertyDictionaryObject> object;
 	int page_length = 20;
 	int page_index = 0;


### PR DESCRIPTION
Should fix https://github.com/godotengine/godot/pull/101278#issuecomment-2577347868

| Before | After |
|--|--|
| <img width="707" alt="Screenshot 2025-01-09 at 10 22 24" src="https://github.com/user-attachments/assets/d529a8e9-e1a9-4a7a-840e-c5299bed2e63" /> | <img width="707" alt="Screenshot 2025-01-09 at 10 18 00" src="https://github.com/user-attachments/assets/0dafd64e-a37d-4b99-8f42-10c4898d3fb6" /> |
