### PR TITLE
C#: Add OKHSL properties to Color

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Color.cs
@@ -194,6 +194,51 @@ namespace Godot
         }
 
         /// <summary>
+        /// The OKHSL hue of this color, on the range 0 to 1.
+        /// </summary>
+        public float OkHslH
+        {
+            readonly get
+            {
+                return NativeFuncs.godotsharp_color_get_ok_hsl_h(this);
+            }
+            set
+            {
+                this = FromOkHsl(value, OkHslS, OkHslL, A);
+            }
+        }
+
+        /// <summary>
+        /// The OKHSL saturation of this color, on the range 0 to 1.
+        /// </summary>
+        public float OkHslS
+        {
+            readonly get
+            {
+                return NativeFuncs.godotsharp_color_get_ok_hsl_s(this);
+            }
+            set
+            {
+                this = FromOkHsl(OkHslH, value, OkHslL, A);
+            }
+        }
+
+        /// <summary>
+        /// The OKHSL lightness of this color, on the range 0 to 1.
+        /// </summary>
+        public float OkHslL
+        {
+            readonly get
+            {
+                return NativeFuncs.godotsharp_color_get_ok_hsl_l(this);
+            }
+            set
+            {
+                this = FromOkHsl(OkHslH, OkHslS, value, A);
+            }
+        }
+
+        /// <summary>
         /// Returns the light intensity of the color, as a value between 0.0 and 1.0 (inclusive).
         /// This is useful when determining light or dark color. Colors with a luminance smaller
         /// than 0.5 can be generally considered dark.

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/NativeFuncs.cs
@@ -167,6 +167,12 @@ namespace Godot.NativeInterop
 
         internal static partial Color godotsharp_color_from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha);
 
+        internal static partial float godotsharp_color_get_ok_hsl_h(in Color p_self);
+
+        internal static partial float godotsharp_color_get_ok_hsl_s(in Color p_self);
+
+        internal static partial float godotsharp_color_get_ok_hsl_l(in Color p_self);
+
         // GDNative functions
 
         // gdnative.h

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -559,6 +559,18 @@ godot_color godotsharp_color_from_ok_hsl(float p_h, float p_s, float p_l, float 
 	return ret;
 }
 
+float godotsharp_color_get_ok_hsl_h(const Color *p_self) {
+	return p_self->get_ok_hsl_h();
+}
+
+float godotsharp_color_get_ok_hsl_s(const Color *p_self) {
+	return p_self->get_ok_hsl_s();
+}
+
+float godotsharp_color_get_ok_hsl_l(const Color *p_self) {
+	return p_self->get_ok_hsl_l();
+}
+
 // GDNative functions
 
 // gdnative.h
@@ -1551,6 +1563,9 @@ static const void *unmanaged_callbacks[]{
 	(void *)godotsharp_callable_call,
 	(void *)godotsharp_callable_call_deferred,
 	(void *)godotsharp_color_from_ok_hsl,
+	(void *)godotsharp_color_get_ok_hsl_h,
+	(void *)godotsharp_color_get_ok_hsl_s,
+	(void *)godotsharp_color_get_ok_hsl_l,
 	(void *)godotsharp_method_bind_ptrcall,
 	(void *)godotsharp_method_bind_call,
 	(void *)godotsharp_variant_new_string_name,


### PR DESCRIPTION
Adds OKHSL properties to C# Color, which were exposed to gdscript by #82845 but still missing in C#.