### PR TITLE
Remove unintentional use of zero-width space.

### DIFF
--- a/core/string/locales.h
+++ b/core/string/locales.h
@@ -1110,7 +1110,7 @@ static const char *script_list[][2] = {
 	{ "Meitei Mayek", "Mtei" },
 	{ "Multani", "Mult" },
 	{ "Myanmar / Burmese", "Mymr" },
-	{ "​Nag Mundari", "Nagm" },
+	{ "Nag Mundari", "Nagm" },
 	{ "Nandinagari", "Nand" },
 	{ "Old North Arabian", "Narb" },
 	{ "Nabataean", "Nbat" },


### PR DESCRIPTION
Opening this fix separately as #101301 is still in active discussion.

I used the regex `[\u200B\uFEFF]` to find the these uses.
This may fix a problem where Nag Mundari scripts were not properly mapped to NagM.

This may fix a problem where `Toggle Autoplay` may display incorrectly in Catalan translations.