### PR TITLE
Fix duplicated spec constant on SPIR-V reflection.

### DIFF
--- a/servers/rendering/rendering_device_driver.cpp
+++ b/servers/rendering/rendering_device_driver.cpp
@@ -259,7 +259,7 @@ Error RenderingDeviceDriver::_reflect_spirv(VectorView<ShaderStageSPIRVData> p_s
 							}
 						}
 
-						if (existing > 0) {
+						if (existing >= 0) {
 							r_reflection.specialization_constants.write[existing].stages.set_flag(stage_flag);
 						} else {
 							r_reflection.specialization_constants.push_back(sconst);


### PR DESCRIPTION
There's a very minor error that affects the result of the SPIR-V reflection that ends up duplicating the first specialization constant in the structure.

The code intends to use -1 as the value for indicating the spec constant was not found in the existing array. However, the `if` checks for `> 0` instead of `>= 0`, so the spec constant being found in the first available slot is never a valid possibility.

This fixes any code that uses the result from the reflection from having duplicated spec constants.