### PR TITLE
Fix union order to simplify empty initializers.

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -100,6 +100,8 @@ public:
 
 	struct ShaderSpecialization {
 		union {
+			uint32_t packed_0;
+
 			struct {
 				uint32_t use_forward_gi : 1;
 				uint32_t use_light_projector : 1;
@@ -114,19 +116,17 @@ public:
 				uint32_t directional_soft_shadow_samples : 6;
 				uint32_t directional_penumbra_shadow_samples : 6;
 			};
-
-			uint32_t packed_0;
 		};
 
 		union {
+			uint32_t packed_1;
+
 			struct {
 				uint32_t multimesh : 1;
 				uint32_t multimesh_format_2d : 1;
 				uint32_t multimesh_has_color : 1;
 				uint32_t multimesh_has_custom_data : 1;
 			};
-
-			uint32_t packed_1;
 		};
 
 		uint32_t packed_2;
@@ -134,11 +134,11 @@ public:
 
 	struct UbershaderConstants {
 		union {
+			uint32_t packed_0;
+
 			struct {
 				uint32_t cull_mode : 2;
 			};
-
-			uint32_t packed_0;
 		};
 	};
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -59,6 +59,8 @@ public:
 
 	struct ShaderSpecialization {
 		union {
+			uint32_t packed_0;
+
 			struct {
 				uint32_t use_light_projector : 1;
 				uint32_t use_light_soft_shadows : 1;
@@ -82,11 +84,11 @@ public:
 				uint32_t soft_shadow_samples : 6;
 				uint32_t penumbra_shadow_samples : 6;
 			};
-
-			uint32_t packed_0;
 		};
 
 		union {
+			uint32_t packed_1;
+
 			struct {
 				uint32_t directional_soft_shadow_samples : 6;
 				uint32_t directional_penumbra_shadow_samples : 6;
@@ -96,32 +98,30 @@ public:
 				uint32_t directional_lights : 4;
 				uint32_t decals : 4;
 			};
-
-			uint32_t packed_1;
 		};
 
 		union {
+			uint32_t packed_2;
+
 			struct {
 				uint32_t directional_light_blend_splits : 8;
 				uint32_t padding_1 : 24;
 			};
-
-			uint32_t packed_2;
 		};
 
 		union {
-			float luminance_multiplier;
 			float packed_3;
+			float luminance_multiplier;
 		};
 	};
 
 	struct UbershaderConstants {
 		union {
+			uint32_t packed_0;
+
 			struct {
 				uint32_t cull_mode : 2;
 			};
-
-			uint32_t packed_0;
 		};
 
 		uint32_t padding_1;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -116,11 +116,11 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 	struct ShaderSpecialization {
 		union {
+			uint32_t packed_0;
+
 			struct {
 				uint32_t use_lighting : 1;
 			};
-
-			uint32_t packed_0;
 		};
 	};
 


### PR DESCRIPTION
This one's more of a general codebase issue but the particular structures I fixed were rendering related.

There's a bit of not so common knowledge regarding union initialization where only the very first element of the union is picked when using empty initializers such as `{}` if no other element in the union has an explicit initializer.

This leads to a very significant difference when it comes to code generation when bitfields are involved, as can be verified here:
https://gcc.godbolt.org/z/6vzYnz4ae

The code difference generation can actually introduce subtle bugs where unused bits on the union were left uninitialized, causing more pipeline generation than what is necessary.

We should make sure to follow the rule of always placing first the element that covers the entire union and has the most trivial initialization to ensure subtle bugs like this can't be introduced.