### PR TITLE
Draw fewer fishbones to improve Path gizmo readability and performance

### DIFF
--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -340,16 +340,19 @@ void Path3DGizmo::redraw() {
 			// Path3D as a ribbon.
 			ribbon_ptr[i] = p1;
 
-			// Fish Bone.
-			const Vector3 p_left = p1 + (side + forward - up * 0.3) * 0.06;
-			const Vector3 p_right = p1 + (-side + forward - up * 0.3) * 0.06;
+			if (i % 4 == 0) {
+				// Draw fish bone every 4 points to reduce visual noise and performance impact
+				// (compared to drawing it for every point).
+				const Vector3 p_left = p1 + (side + forward - up * 0.3) * 0.06;
+				const Vector3 p_right = p1 + (-side + forward - up * 0.3) * 0.06;
 
-			const int bone_idx = i * 4;
+				const int bone_idx = i * 4;
 
-			bones_ptr[bone_idx] = p1;
-			bones_ptr[bone_idx + 1] = p_left;
-			bones_ptr[bone_idx + 2] = p1;
-			bones_ptr[bone_idx + 3] = p_right;
+				bones_ptr[bone_idx] = p1;
+				bones_ptr[bone_idx + 1] = p_left;
+				bones_ptr[bone_idx + 2] = p1;
+				bones_ptr[bone_idx + 3] = p_right;
+			}
 		}
 
 		add_collision_segments(_collision_segments);

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -138,13 +138,14 @@ void Path2D::_notification(int p_what) {
 					draw_polyline(v2p, get_tree()->get_debug_paths_color(), line_width, false);
 				}
 
-				// Draw fish bones
+				// Draw fish bone every 4 points to reduce visual noise and performance impact
+				// (compared to drawing it for every point).
 				{
 					PackedVector2Array v2p;
 					v2p.resize(3);
 					Vector2 *w = v2p.ptrw();
 
-					for (int i = 0; i < sample_count; i++) {
+					for (int i = 0; i < sample_count; i += 4) {
 						const Vector2 p = r[i].get_origin();
 						const Vector2 side = r[i].columns[1];
 						const Vector2 forward = r[i].columns[0];

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -131,16 +131,19 @@ void Path3D::_update_debug_mesh() {
 		// Path3D as a ribbon.
 		ribbon_ptr[i] = p1;
 
-		// Fish Bone.
-		const Vector3 p_left = p1 + (side + forward - up * 0.3) * 0.06;
-		const Vector3 p_right = p1 + (-side + forward - up * 0.3) * 0.06;
+		if (i % 4 == 0) {
+			// Draw fish bone every 4 points to reduce visual noise and performance impact
+			// (compared to drawing it for every point).
+			const Vector3 p_left = p1 + (side + forward - up * 0.3) * 0.06;
+			const Vector3 p_right = p1 + (-side + forward - up * 0.3) * 0.06;
 
-		const int bone_idx = i * 4;
+			const int bone_idx = i * 4;
 
-		bones_ptr[bone_idx] = p1;
-		bones_ptr[bone_idx + 1] = p_left;
-		bones_ptr[bone_idx + 2] = p1;
-		bones_ptr[bone_idx + 3] = p_right;
+			bones_ptr[bone_idx] = p1;
+			bones_ptr[bone_idx + 1] = p_left;
+			bones_ptr[bone_idx + 2] = p1;
+			bones_ptr[bone_idx + 3] = p_right;
+		}
 	}
 
 	Array ribbon_array;


### PR DESCRIPTION
This affects both Path2D and Path3D.

- This partially addresses https://github.com/godotengine/godot-proposals/issues/9459.

**Testing project:** [test_fish_bones.zip](https://github.com/user-attachments/files/18363363/test_fish_bones.zip)

## Preview

*Top-left corner: Path2D*
*Bottom-right corner: Path3D*

Before | After
-|-
![out webp](https://github.com/user-attachments/assets/2c0f21b4-04e1-4355-b485-3bbbd2bfa235) | ![out-new webp](https://github.com/user-attachments/assets/14e7261e-f1ce-4c10-bbca-c5bcd0973a65)
