### PR TITLE
Make use of `latin1` encoding explicit in `gdextension_interface.cpp`.

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -872,84 +872,82 @@ static GDExtensionPtrUtilityFunction gdextension_variant_get_ptr_utility_functio
 //string helpers
 
 static void gdextension_string_new_with_latin1_chars(GDExtensionUninitializedStringPtr r_dest, const char *p_contents) {
-	memnew_placement(r_dest, String(p_contents));
+	String *dest = memnew_placement(r_dest, String);
+	dest->parse_latin1(Span<char>(p_contents, p_contents ? strlen(p_contents) : 0));
 }
 
 static void gdextension_string_new_with_utf8_chars(GDExtensionUninitializedStringPtr r_dest, const char *p_contents) {
-	memnew_placement(r_dest, String);
-	String *dest = reinterpret_cast<String *>(r_dest);
+	String *dest = memnew_placement(r_dest, String);
 	dest->parse_utf8(p_contents);
 }
 
 static void gdextension_string_new_with_utf16_chars(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents) {
-	memnew_placement(r_dest, String);
-	String *dest = reinterpret_cast<String *>(r_dest);
+	String *dest = memnew_placement(r_dest, String);
 	dest->parse_utf16(p_contents);
 }
 
 static void gdextension_string_new_with_utf32_chars(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents) {
-	memnew_placement(r_dest, String((const char32_t *)p_contents));
+	String *dest = memnew_placement(r_dest, String);
+	dest->parse_utf32(Span(p_contents, p_contents ? strlen(p_contents) : 0));
 }
 
 static void gdextension_string_new_with_wide_chars(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents) {
 	if constexpr (sizeof(wchar_t) == 2) {
-		// wchar_t is 16 bit, parse.
-		memnew_placement(r_dest, String);
-		String *dest = reinterpret_cast<String *>(r_dest);
+		// wchar_t is 16 bit (UTF-16).
+		String *dest = memnew_placement(r_dest, String);
 		dest->parse_utf16((const char16_t *)p_contents);
 	} else {
-		// wchar_t is 32 bit, copy.
-		memnew_placement(r_dest, String((const char32_t *)p_contents));
+		// wchar_t is 32 bit (UTF-32).
+		String *string = memnew_placement(r_dest, String);
+		string->parse_utf32(Span((const char32_t *)p_contents, p_contents ? strlen(p_contents) : 0));
 	}
 }
 
 static void gdextension_string_new_with_latin1_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size) {
-	memnew_placement(r_dest, String(p_contents, p_size));
+	String *dest = memnew_placement(r_dest, String);
+	dest->parse_latin1(Span(p_contents, p_contents ? _strlen_clipped(p_contents, p_size) : 0));
 }
 
 static void gdextension_string_new_with_utf8_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size) {
-	memnew_placement(r_dest, String);
-	String *dest = reinterpret_cast<String *>(r_dest);
+	String *dest = memnew_placement(r_dest, String);
 	dest->parse_utf8(p_contents, p_size);
 }
 
 static GDExtensionInt gdextension_string_new_with_utf8_chars_and_len2(GDExtensionUninitializedStringPtr r_dest, const char *p_contents, GDExtensionInt p_size) {
-	memnew_placement(r_dest, String);
-	String *dest = reinterpret_cast<String *>(r_dest);
+	String *dest = memnew_placement(r_dest, String);
 	return (GDExtensionInt)dest->parse_utf8(p_contents, p_size);
 }
 
 static void gdextension_string_new_with_utf16_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_char_count) {
-	memnew_placement(r_dest, String);
-	String *dest = reinterpret_cast<String *>(r_dest);
+	String *dest = memnew_placement(r_dest, String);
 	dest->parse_utf16(p_contents, p_char_count);
 }
 
 static GDExtensionInt gdextension_string_new_with_utf16_chars_and_len2(GDExtensionUninitializedStringPtr r_dest, const char16_t *p_contents, GDExtensionInt p_char_count, GDExtensionBool p_default_little_endian) {
-	memnew_placement(r_dest, String);
-	String *dest = reinterpret_cast<String *>(r_dest);
+	String *dest = memnew_placement(r_dest, String);
 	return (GDExtensionInt)dest->parse_utf16(p_contents, p_char_count, p_default_little_endian);
 }
 
 static void gdextension_string_new_with_utf32_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const char32_t *p_contents, GDExtensionInt p_char_count) {
-	memnew_placement(r_dest, String((const char32_t *)p_contents, p_char_count));
+	String *string = memnew_placement(r_dest, String);
+	string->parse_utf32(Span(p_contents, p_contents ? _strlen_clipped(p_contents, p_char_count) : 0));
 }
 
 static void gdextension_string_new_with_wide_chars_and_len(GDExtensionUninitializedStringPtr r_dest, const wchar_t *p_contents, GDExtensionInt p_char_count) {
 	if constexpr (sizeof(wchar_t) == 2) {
-		// wchar_t is 16 bit, parse.
-		memnew_placement(r_dest, String);
-		String *dest = reinterpret_cast<String *>(r_dest);
+		// wchar_t is 16 bit (UTF-16).
+		String *dest = memnew_placement(r_dest, String);
 		dest->parse_utf16((const char16_t *)p_contents, p_char_count);
 	} else {
-		// wchar_t is 32 bit, copy.
-		memnew_placement(r_dest, String((const char32_t *)p_contents, p_char_count));
+		// wchar_t is 32 bit (UTF-32).
+		String *string = memnew_placement(r_dest, String);
+		string->parse_utf32(Span((const char32_t *)p_contents, p_contents ? _strlen_clipped((const char32_t *)p_contents, p_char_count) : 0));
 	}
 }
 
 static GDExtensionInt gdextension_string_to_latin1_chars(GDExtensionConstStringPtr p_self, char *r_text, GDExtensionInt p_max_write_length) {
 	String *self = (String *)p_self;
-	CharString cs = self->ascii(true);
+	CharString cs = self->latin1();
 	GDExtensionInt len = cs.length();
 	if (r_text) {
 		const char *s_text = cs.ptr();

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -246,9 +246,6 @@ class String {
 	static const char32_t _replacement_char;
 
 	// Known-length copy.
-	void parse_latin1(const Span<char> &p_cstr);
-	void parse_utf32(const Span<char32_t> &p_cstr);
-	void parse_utf32(const char32_t &p_char);
 	void copy_from_unchecked(const char32_t *p_char, int p_length);
 
 	// NULL-terminated c string copy - automatically parse the string to find the length.
@@ -514,6 +511,13 @@ public:
 		s.parse_ascii(p_range);
 		return s;
 	}
+	CharString latin1() const { return ascii(true); }
+	void parse_latin1(const Span<char> &p_cstr);
+	static String latin1(const Span<char> &p_string) {
+		String string;
+		string.parse_latin1(p_string);
+		return string;
+	}
 
 	CharString utf8() const;
 	Error parse_utf8(const char *p_utf8, int p_len = -1, bool p_skip_cr = false);
@@ -530,6 +534,9 @@ public:
 	}
 	static String utf16(const char16_t *p_utf16, int p_len = -1);
 	static String utf16(const Span<char16_t> &p_range) { return utf16(p_range.ptr(), p_range.size()); }
+
+	void parse_utf32(const Span<char32_t> &p_cstr);
+	void parse_utf32(const char32_t &p_char);
 
 	static uint32_t hash(const char32_t *p_cstr, int p_len); /* hash the string */
 	static uint32_t hash(const char32_t *p_cstr); /* hash the string */


### PR DESCRIPTION
This is a small sanity PR with no change in behavior. `latin1` constructors and parsing functions are exposed with this PR (as is `parse_utf32` with similar reasoning).

Some functions in the gdextension interface advertise to parse `latin1`, but they currently parse "whatever the `String` constructor uses" - which is `parse_latin1`. This is correct, but imprecise.

To give more context, for most `String` constructor callers, the current `parse_latin1` is incorrect, as most use it to parse utf-8 literals[^1]. It would be sane to make the use of `latin1` explicit, to avoid confusing it with the other cases.

I also took the opportunity to clean up the `memnew` calls of related functions a bit.

[^1]: https://github.com/godotengine/godot/issues/100641