### PR TITLE
Inline `String::utf8` and `String::utf16` for their simplicity.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1790,13 +1790,6 @@ Error String::append_ascii(const Span<char> &p_range) {
 	return decode_failed ? ERR_INVALID_DATA : OK;
 }
 
-String String::utf8(const char *p_utf8, int p_len) {
-	String ret;
-	ret.append_utf8(p_utf8, p_len);
-
-	return ret;
-}
-
 Error String::append_utf8(const char *p_utf8, int p_len, bool p_skip_cr) {
 	if (!p_utf8) {
 		return ERR_INVALID_DATA;
@@ -2064,13 +2057,6 @@ CharString String::utf8(Vector<uint8_t> *r_ch_length_map) const {
 	*cdst = 0; //trailing zero
 
 	return utf8s;
-}
-
-String String::utf16(const char16_t *p_utf16, int p_len) {
-	String ret;
-	ret.append_utf16(p_utf16, p_len, true);
-
-	return ret;
 }
 
 Error String::append_utf16(const char16_t *p_utf16, int p_len, bool p_default_little_endian) {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -545,7 +545,11 @@ public:
 	Error append_utf8(const Span<char> &p_range, bool p_skip_cr = false) {
 		return append_utf8(p_range.ptr(), p_range.size(), p_skip_cr);
 	}
-	static String utf8(const char *p_utf8, int p_len = -1);
+	static String utf8(const char *p_utf8, int p_len = -1) {
+		String ret;
+		ret.append_utf8(p_utf8, p_len);
+		return ret;
+	}
 	static String utf8(const Span<char> &p_range) { return utf8(p_range.ptr(), p_range.size()); }
 
 	Char16String utf16() const;
@@ -553,7 +557,11 @@ public:
 	Error append_utf16(const Span<char16_t> p_range, bool p_skip_cr = false) {
 		return append_utf16(p_range.ptr(), p_range.size(), p_skip_cr);
 	}
-	static String utf16(const char16_t *p_utf16, int p_len = -1);
+	static String utf16(const char16_t *p_utf16, int p_len = -1) {
+		String ret;
+		ret.append_utf16(p_utf16, p_len);
+		return ret;
+	}
 	static String utf16(const Span<char16_t> &p_range) { return utf16(p_range.ptr(), p_range.size()); }
 
 	void append_utf32(const Span<char32_t> &p_cstr);


### PR DESCRIPTION
Continuing from https://github.com/godotengine/godot/pull/101352#discussion_r1909063745 - might as well get it out of the way now.

The functions are trivial, and inlining them allows the compiler to reason better about them. Technically it's a tiny optimization since the compiler may now optimize the intermediate `String` away (though it won't make a practical difference).