### PR TITLE
Add HTTP proxy Basic authentication

### DIFF
--- a/core/io/http_client.compat.inc
+++ b/core/io/http_client.compat.inc
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  http_client.compat.inc                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void HTTPClient::_set_http_proxy_bind_compat_101358(const String &p_host, int p_port) {
+	set_http_proxy(p_host, p_port, "", "");
+}
+
+void HTTPClient::_set_https_proxy_bind_compat_101358(const String &p_host, int p_port) {
+	set_https_proxy(p_host, p_port, "", "");
+}
+
+void HTTPClient::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPClient::_set_http_proxy_bind_compat_101358);
+	ClassDB::bind_compatibility_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPClient::_set_https_proxy_bind_compat_101358);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "http_client.h"
+#include "http_client.compat.inc"
 
 const char *HTTPClient::_methods[METHOD_MAX] = {
 	"GET",
@@ -49,11 +50,11 @@ HTTPClient *HTTPClient::create(bool p_notify_postinitialize) {
 	return nullptr;
 }
 
-void HTTPClient::set_http_proxy(const String &p_host, int p_port) {
+void HTTPClient::set_http_proxy(const String &p_host, int p_port, const String &p_user, const String &p_pass) {
 	WARN_PRINT("HTTP proxy feature is not available");
 }
 
-void HTTPClient::set_https_proxy(const String &p_host, int p_port) {
+void HTTPClient::set_https_proxy(const String &p_host, int p_port, const String &p_user, const String &p_pass) {
 	WARN_PRINT("HTTPS proxy feature is not available");
 }
 
@@ -161,8 +162,8 @@ void HTTPClient::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_status"), &HTTPClient::get_status);
 	ClassDB::bind_method(D_METHOD("poll"), &HTTPClient::poll);
 
-	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPClient::set_http_proxy);
-	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPClient::set_https_proxy);
+	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port", "username", "password"), &HTTPClient::set_http_proxy, DEFVAL(String()), DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port", "username", "password"), &HTTPClient::set_https_proxy, DEFVAL(String()), DEFVAL(String()));
 
 	ClassDB::bind_method(D_METHOD("query_string_from_dict", "fields"), &HTTPClient::query_string_from_dict);
 

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -160,6 +160,11 @@ protected:
 	static HTTPClient *(*_create)(bool p_notify_postinitialize);
 
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	void _set_http_proxy_bind_compat_101358(const String &p_host, int p_port);
+	void _set_https_proxy_bind_compat_101358(const String &p_host, int p_port);
+	static void _bind_compatibility_methods();
+#endif
 
 public:
 	static HTTPClient *create(bool p_notify_postinitialize = true);
@@ -194,8 +199,8 @@ public:
 	virtual Error poll() = 0;
 
 	// Use empty string or -1 to unset
-	virtual void set_http_proxy(const String &p_host, int p_port);
-	virtual void set_https_proxy(const String &p_host, int p_port);
+	virtual void set_http_proxy(const String &p_host, int p_port, const String &p_user = "", const String &p_pass = "");
+	virtual void set_https_proxy(const String &p_host, int p_port, const String &p_user = "", const String &p_pass = "");
 
 	HTTPClient() {}
 	virtual ~HTTPClient() {}

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -45,8 +45,12 @@ private:
 	String server_host;
 	int http_proxy_port = -1; // Proxy server for http requests.
 	String http_proxy_host;
+	String http_proxy_user;
+	String http_proxy_pass;
 	int https_proxy_port = -1; // Proxy server for https requests.
 	String https_proxy_host;
+	String https_proxy_user;
+	String https_proxy_pass;
 	bool blocking = false;
 	bool handshaking = false;
 	bool head_request = false;
@@ -95,7 +99,7 @@ public:
 	void set_read_chunk_size(int p_size) override;
 	int get_read_chunk_size() const override;
 	Error poll() override;
-	void set_http_proxy(const String &p_host, int p_port) override;
-	void set_https_proxy(const String &p_host, int p_port) override;
+	void set_http_proxy(const String &p_host, int p_port, const String &p_user = "", const String &p_pass = "") override;
+	void set_https_proxy(const String &p_host, int p_port, const String &p_user = "", const String &p_pass = "") override;
 	HTTPClientTCP();
 };

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -180,6 +180,8 @@
 			<return type="void" />
 			<param index="0" name="host" type="String" />
 			<param index="1" name="port" type="int" />
+			<param index="2" name="username" type="String" default="&quot;&quot;" />
+			<param index="3" name="password" type="String" default="&quot;&quot;" />
 			<description>
 				Sets the proxy server for HTTP requests.
 				The proxy server is unset if [param host] is empty or [param port] is -1.
@@ -189,6 +191,8 @@
 			<return type="void" />
 			<param index="0" name="host" type="String" />
 			<param index="1" name="port" type="int" />
+			<param index="2" name="username" type="String" default="&quot;&quot;" />
+			<param index="3" name="password" type="String" default="&quot;&quot;" />
 			<description>
 				Sets the proxy server for HTTPS requests.
 				The proxy server is unset if [param host] is empty or [param port] is -1.

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -210,6 +210,8 @@
 			<return type="void" />
 			<param index="0" name="host" type="String" />
 			<param index="1" name="port" type="int" />
+			<param index="2" name="username" type="String" default="&quot;&quot;" />
+			<param index="3" name="password" type="String" default="&quot;&quot;" />
 			<description>
 				Sets the proxy server for HTTP requests.
 				The proxy server is unset if [param host] is empty or [param port] is -1.
@@ -219,6 +221,8 @@
 			<return type="void" />
 			<param index="0" name="host" type="String" />
 			<param index="1" name="port" type="int" />
+			<param index="2" name="username" type="String" default="&quot;&quot;" />
+			<param index="3" name="password" type="String" default="&quot;&quot;" />
 			<description>
 				Sets the proxy server for HTTPS requests.
 				The proxy server is unset if [param host] is empty or [param port] is -1.

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -267,3 +267,13 @@ Validate extension JSON: JSON file: Field was added in a way that breaks compati
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/RichTextLabel/methods/push_underline': arguments
 
 Optional "color" argument added. Compatibility methods registered.
+
+
+GH-101358
+--------
+Validate extension JSON: Error: Field 'classes/HTTPClient/methods/set_http_proxy/arguments': size changed value in new API, from 2 to 4.
+Validate extension JSON: Error: Field 'classes/HTTPClient/methods/set_https_proxy/arguments': size changed value in new API, from 2 to 4.
+Validate extension JSON: Error: Field 'classes/HTTPRequest/methods/set_http_proxy/arguments': size changed value in new API, from 2 to 4.
+Validate extension JSON: Error: Field 'classes/HTTPRequest/methods/set_https_proxy/arguments': size changed value in new API, from 2 to 4.
+
+Added optional "user" and "pass" argument allowing Basic authentication in both http and https proxy.

--- a/scene/main/http_request.compat.inc
+++ b/scene/main/http_request.compat.inc
@@ -1,0 +1,46 @@
+/**************************************************************************/
+/*  http_request.compat.inc                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+void HTTPRequest::_set_http_proxy_bind_compat_101358(const String &p_host, int p_port) {
+	set_http_proxy(p_host, p_port, "", "");
+}
+
+void HTTPRequest::_set_https_proxy_bind_compat_101358(const String &p_host, int p_port) {
+	set_https_proxy(p_host, p_port, "", "");
+}
+
+void HTTPRequest::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPRequest::_set_http_proxy_bind_compat_101358);
+	ClassDB::bind_compatibility_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPRequest::_set_https_proxy_bind_compat_101358);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "http_request.h"
+#include "http_request.compat.inc"
 
 #include "scene/main/timer.h"
 
@@ -573,12 +574,12 @@ int HTTPRequest::get_body_size() const {
 	return body_len;
 }
 
-void HTTPRequest::set_http_proxy(const String &p_host, int p_port) {
-	client->set_http_proxy(p_host, p_port);
+void HTTPRequest::set_http_proxy(const String &p_host, int p_port, const String &p_user, const String &p_pass) {
+	client->set_http_proxy(p_host, p_port, p_user, p_pass);
 }
 
-void HTTPRequest::set_https_proxy(const String &p_host, int p_port) {
-	client->set_https_proxy(p_host, p_port);
+void HTTPRequest::set_https_proxy(const String &p_host, int p_port, const String &p_user, const String &p_pass) {
+	client->set_https_proxy(p_host, p_port, p_user, p_pass);
 }
 
 void HTTPRequest::set_timeout(double p_timeout) {
@@ -632,8 +633,8 @@ void HTTPRequest::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_download_chunk_size", "chunk_size"), &HTTPRequest::set_download_chunk_size);
 	ClassDB::bind_method(D_METHOD("get_download_chunk_size"), &HTTPRequest::get_download_chunk_size);
 
-	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPRequest::set_http_proxy);
-	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPRequest::set_https_proxy);
+	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port", "username", "password"), &HTTPRequest::set_http_proxy, DEFVAL(String()), DEFVAL(String()));
+	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port", "username", "password"), &HTTPRequest::set_https_proxy, DEFVAL(String()), DEFVAL(String()));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "download_file", PROPERTY_HINT_FILE), "set_download_file", "get_download_file");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "download_chunk_size", PROPERTY_HINT_RANGE, "256,16777216,suffix:B"), "set_download_chunk_size", "get_download_chunk_size");

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -122,6 +122,11 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+#ifndef DISABLE_DEPRECATED
+	void _set_http_proxy_bind_compat_101358(const String &p_host, int p_port);
+	void _set_https_proxy_bind_compat_101358(const String &p_host, int p_port);
+	static void _bind_compatibility_methods();
+#endif
 
 public:
 	Error request(const String &p_url, const Vector<String> &p_custom_headers = Vector<String>(), HTTPClient::Method p_method = HTTPClient::METHOD_GET, const String &p_request_data = ""); //connects to a full url and perform request
@@ -157,8 +162,8 @@ public:
 	int get_downloaded_bytes() const;
 	int get_body_size() const;
 
-	void set_http_proxy(const String &p_host, int p_port);
-	void set_https_proxy(const String &p_host, int p_port);
+	void set_http_proxy(const String &p_host, int p_port, const String &p_user = "", const String &p_pass = "");
+	void set_https_proxy(const String &p_host, int p_port, const String &p_user = "", const String &p_pass = "");
 
 	void set_tls_options(const Ref<TLSOptions> &p_options);
 


### PR DESCRIPTION
Implement Basic authentication(user/pass) for http/https proxy

This commit adds two parameters(username, password) to `set_http_proxy` and `set_https_proxy`

#76442 
#99807