### PR TITLE
Core: Isolate `Ref` forward declare logic

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -36,10 +36,9 @@
 #include "core/templates/rb_set.h"
 
 #include "modules/modules_enabled.gen.h" // For regex.
+
 #ifdef MODULE_REGEX_ENABLED
 #include "modules/regex/regex.h"
-#else
-class RegEx : public RefCounted {};
 #endif // MODULE_REGEX_ENABLED
 
 #if defined(MINGW_ENABLED) || defined(_MSC_VER)

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -180,10 +180,15 @@ public:
 		// do a lot of referencing on references and stuff
 		// mutexes will avoid more crashes?
 
-		if (reference && reference->unreference()) {
-			memdelete(reference);
+		if (reference) {
+			// NOTE: `reinterpret_cast` is "safe" here because we know `T` has simple linear
+			// inheritance to `RefCounted`. This guarantees that `T * == `RefCounted *`, which
+			// allows us to declare `Ref<T>` with forward declared `T` types.
+			if (reinterpret_cast<RefCounted *>(reference)->unreference()) {
+				memdelete(reinterpret_cast<RefCounted *>(reference));
+			}
+			reference = nullptr;
 		}
-		reference = nullptr;
 	}
 
 	template <typename... VarArgs>


### PR DESCRIPTION
- Related: #80330

While reading [this discussion](https://github.com/godotengine/godot/pull/100751#discussion_r1905267588) from a recent merge, I realized the error brought up was the same as the one mentioned in the above PR. Given this is such a persistant issue, especially with our header include system likely to undergo bigger changes in the future, I was hoping to find a true solution to the problem that didn't rely on external workarounds. As it turns out, Because the forward-declared type is only ever handled as a pointer, the issue could be bypassed *entirely* via `dynamic_cast<RefCounted *>`! This isn't an unsafe operation either, as the only way something can reach that point of the code is if the internal reference isn't null; the only way that can happen is through `ref_pointer`, which *does* validate the type!

I'm unsure of how many files required extraneous headers to workaround this issue, so I didn't attempt to track that down here. The only exception was the section brought up in the prior discussion, to showcase that the build succeeds on the minimal template.