### PR TITLE
CI: Install apt dependencies directly, works around issue with `awalsh128/cache-apt-pkgs-action`

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -13,9 +13,8 @@ jobs:
           fetch-depth: 2
 
       - name: Install APT dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libxml2-utils
+        run: |
+          sudo apt install -y libxml2-utils
 
       - name: Install Python dependencies and general setup
         run: |


### PR DESCRIPTION
Works around https://github.com/awalsh128/cache-apt-pkgs-action/issues/141, this shouldn't add too much to the build iteration time as it's a single package (it used to be several when we added this back then).