### PR TITLE
Fix selection in 3D Game view

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -915,6 +915,13 @@ PackedStringArray CSGShape3D::get_configuration_warnings() const {
 	return warnings;
 }
 
+Ref<TriangleMesh> CSGShape3D::generate_triangle_mesh() const {
+	if (root_mesh.is_valid()) {
+		return root_mesh->generate_triangle_mesh();
+	}
+	return Ref<TriangleMesh>();
+}
+
 void CSGShape3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_shape"), &CSGShape3D::_update_shape);
 	ClassDB::bind_method(D_METHOD("is_root_shape"), &CSGShape3D::is_root_shape);

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -169,6 +169,8 @@ public:
 	Ref<ArrayMesh> bake_static_mesh();
 	Ref<ConcavePolygonShape3D> bake_collision_shape();
 
+	virtual Ref<TriangleMesh> generate_triangle_mesh() const override;
+
 	CSGShape3D();
 	~CSGShape3D();
 };

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -253,7 +253,7 @@ public:
 	StandardMaterial3D::TextureFilter get_texture_filter() const;
 
 	virtual AABB get_aabb() const override;
-	Ref<TriangleMesh> generate_triangle_mesh() const;
+	virtual Ref<TriangleMesh> generate_triangle_mesh() const override;
 
 	Label3D();
 	~Label3D();

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -835,6 +835,13 @@ Ref<ArrayMesh> MeshInstance3D::bake_mesh_from_current_skeleton_pose(Ref<ArrayMes
 	return bake_mesh;
 }
 
+Ref<TriangleMesh> MeshInstance3D::generate_triangle_mesh() const {
+	if (mesh.is_valid()) {
+		return mesh->generate_triangle_mesh();
+	}
+	return Ref<TriangleMesh>();
+}
+
 void MeshInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &MeshInstance3D::set_mesh);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &MeshInstance3D::get_mesh);

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -104,6 +104,8 @@ public:
 	Ref<ArrayMesh> bake_mesh_from_current_blend_shape_mix(Ref<ArrayMesh> p_existing = Ref<ArrayMesh>());
 	Ref<ArrayMesh> bake_mesh_from_current_skeleton_pose(Ref<ArrayMesh> p_existing = Ref<ArrayMesh>());
 
+	virtual Ref<TriangleMesh> generate_triangle_mesh() const override;
+
 	MeshInstance3D();
 	~MeshInstance3D();
 };

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -172,7 +172,7 @@ public:
 
 	virtual AABB get_aabb() const override;
 
-	Ref<TriangleMesh> generate_triangle_mesh() const;
+	virtual Ref<TriangleMesh> generate_triangle_mesh() const override;
 
 	SpriteBase3D();
 	~SpriteBase3D();

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -530,6 +530,10 @@ bool GeometryInstance3D::is_ignoring_occlusion_culling() {
 	return ignore_occlusion_culling;
 }
 
+Ref<TriangleMesh> GeometryInstance3D::generate_triangle_mesh() const {
+	return Ref<TriangleMesh>();
+}
+
 PackedStringArray GeometryInstance3D::get_configuration_warnings() const {
 	PackedStringArray warnings = VisualInstance3D::get_configuration_warnings();
 

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -202,6 +202,8 @@ public:
 	void set_ignore_occlusion_culling(bool p_enabled);
 	bool is_ignoring_occlusion_culling();
 
+	virtual Ref<TriangleMesh> generate_triangle_mesh() const;
+
 	PackedStringArray get_configuration_warnings() const override;
 	GeometryInstance3D();
 	virtual ~GeometryInstance3D();


### PR DESCRIPTION
- Fixes #98997

This PR should fix the issue for the selection in 3D. I was no able to reproduce the issue in 2D.

The problem was the calculation of the distance between the raycast collision point and the camera position. Since the camera position and the raycast hit point are in global space, we don't need to apply any other transformation to calculate the distance between them.

In addition, the selection did not work on CSG if collision is not enabled. I added support for CSGShape without collision.

Exemple:

https://github.com/user-attachments/assets/aafe6c5a-ad36-494d-aaed-3a8dc313f617


There's a little MRP project to test:
[test-godot-select-game-workspace.zip](https://github.com/user-attachments/files/18367196/test-godot-select-game-workspace.zip)
