### PR TITLE
Clarify expected types in `RayCast3D` documentation 

### DIFF
--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="RayCast3D" inherits="Node3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A ray in 3D space, used to find the first [CollisionObject3D] it intersects.
+		A ray in 3D space, used to find the first object it intersects.
 	</brief_description>
 	<description>
-		A raycast represents a ray from its origin to its [member target_position] that finds the closest [CollisionObject3D] along its path, if it intersects any.
+		A raycast represents a ray from its origin to its [member target_position] that finds the closest object along its path, if it intersects any.
 		[RayCast3D] can ignore some objects by adding them to an exception list, by making its detection reporting ignore [Area3D]s ([member collide_with_areas]) or [PhysicsBody3D]s ([member collide_with_bodies]), or by configuring physics layers.
 		[RayCast3D] calculates intersection every physics frame, and it holds the result until the next physics frame. For an immediate raycast, or if you want to configure a [RayCast3D] multiple times within the same physics frame, use [method force_raycast_update].
 		To sweep over a region of 3D space, you can approximate the region with multiple [RayCast3D]s or use [ShapeCast3D].
@@ -45,6 +45,7 @@
 			<return type="Object" />
 			<description>
 				Returns the first object that the ray intersects, or [code]null[/code] if no object is intersecting the ray (i.e. [method is_colliding] returns [code]false[/code]).
+				[b]Note:[/b] This object is not guaranteed to be a [CollisionObject3D]. For example, if the ray intersects a [CSGShape3D] or a [GridMap], the method will return a [CSGShape3D] or [GridMap] instance.
 			</description>
 		</method>
 		<method name="get_collider_rid" qualifiers="const">


### PR DESCRIPTION
Updating documentation, per https://github.com/godotengine/godot/issues/100139#issuecomment-2525247650 

[rburing](https://github.com/rburing)
[on Dec 7, 2024](https://github.com/godotengine/godot/issues/100139#issuecomment-2525247650)
Member
Yes, the documentation is wrong (too narrow). In addition to CSG there's also GridMap. Fixes to the documentation are welcome.

* *Bugsquad edit, Closes: https://github.com/godotengine/godot/issues/100139*
