### PR TITLE
Add movement threshold before activating viewport rotation gizmo dragging

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -424,7 +424,9 @@ void ViewportRotationControl::_process_click(int p_index, Vector2 p_position, bo
 }
 
 void ViewportRotationControl::_process_drag(Ref<InputEventWithModifiers> p_event, int p_index, Vector2 p_position, Vector2 p_relative_position) {
-	if (orbiting_index == p_index && gizmo_activated) {
+	Point2 mouse_pos = get_local_mouse_position();
+	const bool movement_threshold_passed = original_mouse_pos.distance_to(mouse_pos) > 4 * EDSCALE;
+	if (orbiting_index == p_index && gizmo_activated && movement_threshold_passed) {
 		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_VISIBLE) {
 			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
 			orbiting_mouse_start = p_position;
@@ -459,6 +461,7 @@ void ViewportRotationControl::gui_input(const Ref<InputEvent> &p_event) {
 			_process_click(100, mb->get_position(), mb->is_pressed());
 			if (mb->is_pressed()) {
 				gizmo_activated = true;
+				original_mouse_pos = get_local_mouse_position();
 				grab_focus();
 			}
 		} else if (mb->get_button_index() == MouseButton::RIGHT) {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -83,6 +83,7 @@ class ViewportRotationControl : public Control {
 	Vector<Color> axis_colors;
 	Vector<int> axis_menu_options;
 	Vector2i orbiting_mouse_start;
+	Point2 original_mouse_pos;
 	int orbiting_index = -1;
 	int focused_axis = -2;
 	bool gizmo_activated = false;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
~~Requires and Includes: https://github.com/godotengine/godot/pull/101369~~ (This was merged, and this PR was rebased).



This gets activated too quickly, and sometimes accidentally activates when trying to select an axis. This PR adds a movement threshold before activating. 

LMB is being held down at the start of the video:

https://github.com/user-attachments/assets/766bc1e5-fc1e-41ee-a48a-3637be2e93e9

