### PR TITLE
Fix typo in EditorDebuggerPlugin documentation

### DIFF
--- a/doc/classes/EditorDebuggerPlugin.xml
+++ b/doc/classes/EditorDebuggerPlugin.xml
@@ -103,7 +103,7 @@
 			<return type="bool" />
 			<param index="0" name="capture" type="String" />
 			<description>
-				Override this method to enable receiving messages from the debugger. If [param capture] is "my_message" then messages starting with "my_message:" will be passes to the [method _capture] method.
+				Override this method to enable receiving messages from the debugger. If [param capture] is "my_message" then messages starting with "my_message:" will be passed to the [method _capture] method.
 			</description>
 		</method>
 		<method name="_setup_session" qualifiers="virtual">


### PR DESCRIPTION
Fixed what I believe was a typo in line 106 in doc/classes/EditorDebuggerPlugin.xml:
- From: 
"Override this method to enable receiving messages from the debugger. If [param capture] is "my_message" then messages starting with "my_message:" will be **passes** to the [method _capture] method."
- To: 
"Override this method to enable receiving messages from the debugger. If [param capture] is "my_message" then messages starting with "my_message:" will be **passed** to the [method _capture] method."

Line in question as viewed in the built docs:
![Pasted image 20250108201610](https://github.com/user-attachments/assets/6647ed92-0d05-45ec-bc1d-bb59518a4499)