### PR TITLE
Add comments to protect against regressions of accidental memory overwrites.

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -57,6 +57,8 @@ public:
 		return data;
 	}
 
+	// Must take a copy instead of a reference.
+	// See https://github.com/godotengine/godot/issues/31736.
 	_FORCE_INLINE_ void push_back(T p_elem) {
 		if (unlikely(count == capacity)) {
 			capacity = tight ? (capacity + 1) : MAX((U)1, capacity << 1);

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -71,6 +71,8 @@ private:
 	CowData<T> _cowdata;
 
 public:
+	// Must take a copy instead of a reference.
+	// See https://github.com/godotengine/godot/issues/31736.
 	bool push_back(T p_elem);
 	_FORCE_INLINE_ bool append(const T &p_elem) { return push_back(p_elem); } //alias
 	void fill(T p_elem);
@@ -99,6 +101,8 @@ public:
 	Error resize(Size p_size) { return _cowdata.resize(p_size); }
 	Error resize_zeroed(Size p_size) { return _cowdata.template resize<true>(p_size); }
 	_FORCE_INLINE_ const T &operator[](Size p_index) const { return _cowdata.get(p_index); }
+	// Must take a copy instead of a reference.
+	// See https://github.com/godotengine/godot/issues/31736.
 	Error insert(Size p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }
 	Size find(const T &p_val, Size p_from = 0) const { return _cowdata.find(p_val, p_from); }
 	Size rfind(const T &p_val, Size p_from = -1) const { return _cowdata.rfind(p_val, p_from); }


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/31736/

The code was not sufficiently commented to protect against regression.

I have recently almost accidentally caused a regression, and now https://github.com/godotengine/godot/pull/100944 has almost fallen into the same trap.