### PR TITLE
Prevent warning emitting from `SubViewport` on scene loading

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5169,7 +5169,7 @@ void SubViewport::set_size_force(const Size2i &p_size) {
 
 void SubViewport::_internal_set_size(const Size2i &p_size, bool p_force) {
 	SubViewportContainer *c = Object::cast_to<SubViewportContainer>(get_parent());
-	if (!p_force && c && c->is_stretch_enabled()) {
+	if (!p_force && c && c->is_inside_tree() && c->is_stretch_enabled()) {
 #ifdef DEBUG_ENABLED
 		WARN_PRINT("Can't change the size of a `SubViewport` with a `SubViewportContainer` parent that has `stretch` enabled. Set `SubViewportContainer.stretch` to `false` to allow changing the size manually.");
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
Prevents possible emitting that warning every time a scene with a SubViewport loaded:

![изображение](https://github.com/user-attachments/assets/c0a66981-f57e-405e-ad8a-324d0bc53740)
