### PR TITLE
Optimize `String::match` / `String::matchn` / `_wildcard_match` to use a loop instead of a recursive solution.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3680,33 +3680,83 @@ float String::similarity(const String &p_string) const {
 	return (2.0f * inter) / sum;
 }
 
-static bool _wildcard_match(const char32_t *p_pattern, const char32_t *p_string, bool p_case_sensitive) {
-	switch (*p_pattern) {
-		case '\0':
-			return !*p_string;
-		case '*':
-			return _wildcard_match(p_pattern + 1, p_string, p_case_sensitive) || (*p_string && _wildcard_match(p_pattern, p_string + 1, p_case_sensitive));
-		case '?':
-			return *p_string && (*p_string != '.') && _wildcard_match(p_pattern + 1, p_string + 1, p_case_sensitive);
-		default:
-
-			return (p_case_sensitive ? (*p_string == *p_pattern) : (_find_upper(*p_string) == _find_upper(*p_pattern))) && _wildcard_match(p_pattern + 1, p_string + 1, p_case_sensitive);
+static bool _wildcard_match(const String &p_pattern, const String &p_string, bool p_case_sensitive) {
+	if (p_string.is_empty() || p_pattern.is_empty()) {
+		return false;
 	}
+
+	const char32_t *pattern = p_pattern.ptr();
+	const char32_t *pattern_end = pattern + p_pattern.length();
+
+	const char32_t *str = p_string.ptr();
+	const char32_t *str_end = str + p_string.length();
+
+	// Positions in the string when we encountered the last wildcard.
+	const char32_t *star_pattern = nullptr;
+	const char32_t *star_string = nullptr;
+
+	// This loop conservatively uses wildcards.
+	// It will first attempt to skip wildcards entirely and
+	//  continue consuming from both the string and the pattern.
+	// Only if that fails will it consume a single character with the wildcard,
+	//  and continue forward matching.
+	while (str < str_end) {
+		if (pattern < pattern_end) {
+			const char32_t pattern_char = *pattern;
+
+			if (pattern_char == '*') {
+				// Wildcard found. Move past the wildcard.
+				pattern++;
+				// Remember the location of the pattern and string.
+				// We may reset to this later if parsing forward doesn't work out.
+				star_pattern = pattern;
+				star_string = str;
+				continue;
+			}
+			// Dots aren't matched for wildcard searches to improve UX for filename matching.
+			if (pattern_char == '?' && *str != '.') {
+				// Single-char wildcard.
+				pattern++;
+				str++;
+				continue;
+			}
+			if (p_case_sensitive ? (*str == pattern_char) : (_find_upper(*str) == _find_upper(pattern_char))) {
+				// Normal char match. Consume both.
+				pattern++;
+				str++;
+				continue;
+			}
+		}
+		// Else the pattern fully consumed but the string isn't, yet.
+		// In that case, we need to backtrack and consume (at least) one more char with the wildcard.
+
+		// Try to backtrack to the last wildcard, if any.
+		if (!star_pattern) {
+			// No prior wildcard found; give up.
+			return false;
+		}
+
+		// Reset to the prior wildcard.
+		pattern = star_pattern;
+		// Consume one character with the wildcard, resume normal forward parsing.
+		str = ++star_string;
+	}
+
+	// Consume any trailing wildcards.
+	while (pattern < pattern_end && *pattern == '*') {
+		pattern++;
+	}
+
+	// Due to the minimality of the prior loop, if there's any pattern left, we know the match failed.
+	return pattern == pattern_end;
 }
 
 bool String::match(const String &p_wildcard) const {
-	if (!p_wildcard.length() || !length()) {
-		return false;
-	}
-
-	return _wildcard_match(p_wildcard.get_data(), get_data(), true);
+	return _wildcard_match(p_wildcard, *this, true);
 }
 
 bool String::matchn(const String &p_wildcard) const {
-	if (!p_wildcard.length() || !length()) {
-		return false;
-	}
-	return _wildcard_match(p_wildcard.get_data(), get_data(), false);
+	return _wildcard_match(p_wildcard, *this, false);
 }
 
 String String::format(const Variant &values, const String &placeholder) const {

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1356,10 +1356,34 @@ TEST_CASE("[String] is_lowercase") {
 }
 
 TEST_CASE("[String] match") {
+	// Base cases.
+	CHECK(String("img1.png").match("img1.png"));
+	CHECK(!String("iMG1.png").match("img1.png"));
+	CHECK(String("iMG1.png").matchn("img1.png"));
+
+	// Single-char wildcard cases.
+	CHECK(String("img2.png").matchn("img?.png"));
+	CHECK(!String("img23.png").matchn("img?.png"));
+	CHECK(String("img12345.png").matchn("img?????.???"));
+	CHECK(!String("img123456.png").matchn("img?????.???"));
+
+	// Single wildcard cases.
 	CHECK(String("img1.png").match("*.png"));
 	CHECK(!String("img1.jpeg").match("*.png"));
 	CHECK(!String("img1.Png").match("*.png"));
 	CHECK(String("img1.Png").matchn("*.png"));
+
+	// Double wildcard cases.
+	CHECK(String("img-24.jpg").match("img-*.*"));
+	CHECK(!String("img24.jpg").match("img-*.*"));
+
+	// Triple wildcard cases.
+	CHECK(String("img24-23.jpg").match("img*-*.*"));
+	CHECK(!String("img24_23.jpg").match("img*-*.*"));
+
+	// Single-char wildcard + triple wildcard cases.
+	CHECK(String("img24-23.jpg").match("???*-*.*"));
+	CHECK(!String("img24_23.jpg").match("???*-*.*"));
 }
 
 TEST_CASE("[String] IPVX address to string") {


### PR DESCRIPTION
`string.match()` searches for patterns in a string, like to match filenames: `"file.png".match("*.png")`

This optimizes the function and further eliminates the risk of stack overflow. 
Optimizing the function is warranted because it may be called hundreds or thousands of times from user UI queries to match filenames.
The overflow risk was very low if tail call optimization was used by the compiler (as was the case with clang), but was very high if it wasn't.

I have added some tests to prove feature parity. They were passing for both the old and the new implementation.

## Benchmark

Of course I benchmarked the new solution with several different challenges.
It is slightly faster in trivial tasks, and can be about 4x faster in nontrivial tasks.

<details>
<summary>Test Code</summary>

```c++
	String s = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";

	{
		String m = s;  // Exact match.
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 5000000; i ++) {
			// Test
			bool res = s.match(m);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		String m = "Lorem ipsum dolor";  // Partial match.
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 100000000; i ++) {
			// Test
			bool res = s.match(m);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}

	{
		String m = "Lorem ipsum dolor*";  // Forward wildcard match.
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 2000000; i ++) {
			// Test
			bool res = s.match(m);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		String m = "*id est laborum.";  // Backward wildcard match.
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 1000000; i ++) {
			// Test
			bool res = s.match(m);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		String m = "*exercitation*";  // Outer wildcard match.
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 2000000; i ++) {
			// Test
			bool res = s.match(m);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		String m = "Lorem ipsum dolor*exercitation*anim id est laborum.";  // Inner wildcard match.
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 1000000; i ++) {
			// Test
			bool res = s.match(m);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
```
</details>

On `master` (eb4a9977c33237a6ac0fdec5c1b1d40230eb6404):

```
2207ms
1928ms
1509ms
1250ms
1880ms
1154ms
```

On this PR (2b07c8aeb941f5715c9e1c7eb2290e3f5483835c):

```
2183ms
1867ms
329ms
392ms
508ms
382ms
```

Tail call optimization of `clang` were saving the old implementation from being a lot worse performance wise, but the new implementation still manages to beat it through better reasoning about the problem, and simply by being an iterative solution instead of a recursive one. It is possible that the old solution is way slower with less well-optimizing compilers (I'm looking at you, MSVC).

Future implementers may want to optimize the new solution further through more reasoning. It would be possible to early-exit in some situations, or appropriately skip a number of characters with wildcards. However, there is no specific need for this, so I'll leave it simple for now.

### Behavior change
The new solution doesn't end the match when `\0` is encountered within either of the strings (we currently try to avoid this, but it may happen anyway). Instead, it will treat in-string `\0` as part of the string.