### PR TITLE
Add `reset` to `CowData`, to bring it on-par with other collections.

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -330,7 +330,12 @@ public:
 
 	void remove_at(int p_index) { _cowdata.remove_at(p_index); }
 
-	_FORCE_INLINE_ void clear() { resize(0); }
+	// Destructs all elements and resets size to 0.
+	// Note: In other APIs, this keeps the capacity as before.
+	//       In String, it also resets the capacity, making it an alias of reset().
+	_FORCE_INLINE_ void clear() { _cowdata.clear(); }
+	// Destructs all elements and resets capacity to 0.
+	_FORCE_INLINE_ void reset() { _cowdata.reset(); }
 
 	_FORCE_INLINE_ char32_t get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const char32_t &p_elem) { _cowdata.set(p_index, p_elem); }

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -200,7 +200,12 @@ public:
 		}
 	}
 
-	_FORCE_INLINE_ void clear() { resize(0); }
+	// Destructs all elements and resets size to 0.
+	// Note: In other APIs, this keeps the capacity as before.
+	//       In CowData, it also resets the capacity, making it an alias of reset().
+	_FORCE_INLINE_ void clear() { _unref(); }
+	// Destructs all elements and resets capacity to 0.
+	_FORCE_INLINE_ void reset() { _unref(); }
 	_FORCE_INLINE_ bool is_empty() const { return _ptr == nullptr; }
 
 	_FORCE_INLINE_ void set(Size p_index, const T &p_elem) {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -89,9 +89,13 @@ public:
 
 	_FORCE_INLINE_ T *ptrw() { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
-	_FORCE_INLINE_ void clear() { resize(0); }
+	// Destructs all elements and resets size to 0.
+	// Note: In other APIs, this keeps the capacity as before.
+	//       In Vector, it also resets the capacity, making it an alias of reset().
+	_FORCE_INLINE_ void clear() { _cowdata.clear(); }
+	// Destructs all elements and resets capacity to 0.
+	_FORCE_INLINE_ void reset() { _cowdata.reset(); }
 	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
-
 	_FORCE_INLINE_ T get(Size p_index) { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ const T &get(Size p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(Size p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }


### PR DESCRIPTION
In most APIs, `clear()` destroys all elements but keeps the capacity intact. This is the case for STL collections, as well as `LocalVector`. `LocalVector` additionally declares `reset` to give up the backing buffer.

`CowData` and related classes have no way to shrink without giving up the buffer (https://github.com/godotengine/godot-proposals/issues/2954). As such, `clear()` behavior cannot be changed to be on-par with `LocalVector`. But we can certainly bring the APIs closer together by adding `reset()` and letting users use that instead of `clear()` if an explicit dealloc of the buffer is wanted (which is probably most cases).