### PR TITLE
Add arithmethic operations between float and integer vectors

### DIFF
--- a/core/variant/variant_op.cpp
+++ b/core/variant/variant_op.cpp
@@ -257,14 +257,22 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorAdd<double, double, double>>(Variant::OP_ADD, Variant::FLOAT, Variant::FLOAT);
 	register_string_op(OperatorEvaluatorStringConcat, Variant::OP_ADD);
 	register_op<OperatorEvaluatorAdd<Vector2, Vector2, Vector2>>(Variant::OP_ADD, Variant::VECTOR2, Variant::VECTOR2);
+	register_op<OperatorEvaluatorAdd<Vector2, Vector2, Vector2i>>(Variant::OP_ADD, Variant::VECTOR2, Variant::VECTOR2I);
 	register_op<OperatorEvaluatorAdd<Vector2i, Vector2i, Vector2i>>(Variant::OP_ADD, Variant::VECTOR2I, Variant::VECTOR2I);
+	register_op<OperatorEvaluatorAdd<Vector2, Vector2i, Vector2>>(Variant::OP_ADD, Variant::VECTOR2I, Variant::VECTOR2);
 	register_op<OperatorEvaluatorAdd<Vector3, Vector3, Vector3>>(Variant::OP_ADD, Variant::VECTOR3, Variant::VECTOR3);
+	register_op<OperatorEvaluatorAdd<Vector3, Vector3, Vector3i>>(Variant::OP_ADD, Variant::VECTOR3, Variant::VECTOR3I);
 	register_op<OperatorEvaluatorAdd<Vector3i, Vector3i, Vector3i>>(Variant::OP_ADD, Variant::VECTOR3I, Variant::VECTOR3I);
+	register_op<OperatorEvaluatorAdd<Vector3, Vector3i, Vector3>>(Variant::OP_ADD, Variant::VECTOR3I, Variant::VECTOR3);
 	register_op<OperatorEvaluatorAdd<Vector4, Vector4, Vector4>>(Variant::OP_ADD, Variant::VECTOR4, Variant::VECTOR4);
+	register_op<OperatorEvaluatorAdd<Vector4, Vector4, Vector4i>>(Variant::OP_ADD, Variant::VECTOR4, Variant::VECTOR4I);
 	register_op<OperatorEvaluatorAdd<Vector4i, Vector4i, Vector4i>>(Variant::OP_ADD, Variant::VECTOR4I, Variant::VECTOR4I);
+	// register_op<OperatorEvaluatorAdd<Vector4, Vector4i, Vector4>>(Variant::OP_ADD, Variant::VECTOR4I, Variant::VECTOR4);
 	register_op<OperatorEvaluatorAdd<Quaternion, Quaternion, Quaternion>>(Variant::OP_ADD, Variant::QUATERNION, Variant::QUATERNION);
 	register_op<OperatorEvaluatorAdd<Color, Color, Color>>(Variant::OP_ADD, Variant::COLOR, Variant::COLOR);
+
 	register_op<OperatorEvaluatorAddArray>(Variant::OP_ADD, Variant::ARRAY, Variant::ARRAY);
+
 	register_op<OperatorEvaluatorAppendArray<uint8_t>>(Variant::OP_ADD, Variant::PACKED_BYTE_ARRAY, Variant::PACKED_BYTE_ARRAY);
 	register_op<OperatorEvaluatorAppendArray<int32_t>>(Variant::OP_ADD, Variant::PACKED_INT32_ARRAY, Variant::PACKED_INT32_ARRAY);
 	register_op<OperatorEvaluatorAppendArray<int64_t>>(Variant::OP_ADD, Variant::PACKED_INT64_ARRAY, Variant::PACKED_INT64_ARRAY);
@@ -281,11 +289,17 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorSub<double, double, int64_t>>(Variant::OP_SUBTRACT, Variant::FLOAT, Variant::INT);
 	register_op<OperatorEvaluatorSub<double, double, double>>(Variant::OP_SUBTRACT, Variant::FLOAT, Variant::FLOAT);
 	register_op<OperatorEvaluatorSub<Vector2, Vector2, Vector2>>(Variant::OP_SUBTRACT, Variant::VECTOR2, Variant::VECTOR2);
+	register_op<OperatorEvaluatorSub<Vector2, Vector2, Vector2i>>(Variant::OP_SUBTRACT, Variant::VECTOR2, Variant::VECTOR2I);
 	register_op<OperatorEvaluatorSub<Vector2i, Vector2i, Vector2i>>(Variant::OP_SUBTRACT, Variant::VECTOR2I, Variant::VECTOR2I);
+	register_op<OperatorEvaluatorSub<Vector2, Vector2i, Vector2>>(Variant::OP_SUBTRACT, Variant::VECTOR2I, Variant::VECTOR2);
 	register_op<OperatorEvaluatorSub<Vector3, Vector3, Vector3>>(Variant::OP_SUBTRACT, Variant::VECTOR3, Variant::VECTOR3);
+	register_op<OperatorEvaluatorSub<Vector3, Vector3, Vector3i>>(Variant::OP_SUBTRACT, Variant::VECTOR3, Variant::VECTOR3I);
 	register_op<OperatorEvaluatorSub<Vector3i, Vector3i, Vector3i>>(Variant::OP_SUBTRACT, Variant::VECTOR3I, Variant::VECTOR3I);
+	register_op<OperatorEvaluatorSub<Vector3, Vector3i, Vector3>>(Variant::OP_SUBTRACT, Variant::VECTOR3I, Variant::VECTOR3);
 	register_op<OperatorEvaluatorSub<Vector4, Vector4, Vector4>>(Variant::OP_SUBTRACT, Variant::VECTOR4, Variant::VECTOR4);
+	register_op<OperatorEvaluatorSub<Vector4, Vector4, Vector4i>>(Variant::OP_SUBTRACT, Variant::VECTOR4, Variant::VECTOR4I);
 	register_op<OperatorEvaluatorSub<Vector4i, Vector4i, Vector4i>>(Variant::OP_SUBTRACT, Variant::VECTOR4I, Variant::VECTOR4I);
+	// register_op<OperatorEvaluatorSub<Vector4, Vector4i, Vector4>>(Variant::OP_SUBTRACT, Variant::VECTOR4I, Variant::VECTOR4);
 	register_op<OperatorEvaluatorSub<Quaternion, Quaternion, Quaternion>>(Variant::OP_SUBTRACT, Variant::QUATERNION, Variant::QUATERNION);
 	register_op<OperatorEvaluatorSub<Color, Color, Color>>(Variant::OP_SUBTRACT, Variant::COLOR, Variant::COLOR);
 
@@ -310,26 +324,32 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorMul<Vector2, Vector2, Vector2>>(Variant::OP_MULTIPLY, Variant::VECTOR2, Variant::VECTOR2);
 	register_op<OperatorEvaluatorMul<Vector2, Vector2, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR2, Variant::INT);
 	register_op<OperatorEvaluatorMul<Vector2, Vector2, double>>(Variant::OP_MULTIPLY, Variant::VECTOR2, Variant::FLOAT);
+	register_op<OperatorEvaluatorMul<Vector2, Vector2, Vector2i>>(Variant::OP_MULTIPLY, Variant::VECTOR2, Variant::VECTOR2I);
 
 	register_op<OperatorEvaluatorMul<Vector2i, Vector2i, Vector2i>>(Variant::OP_MULTIPLY, Variant::VECTOR2I, Variant::VECTOR2I);
 	register_op<OperatorEvaluatorMul<Vector2i, Vector2i, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR2I, Variant::INT);
 	register_op<OperatorEvaluatorMul<Vector2, Vector2i, double>>(Variant::OP_MULTIPLY, Variant::VECTOR2I, Variant::FLOAT);
+	register_op<OperatorEvaluatorMul<Vector2, Vector2i, Vector2>>(Variant::OP_MULTIPLY, Variant::VECTOR2I, Variant::VECTOR2);
 
 	register_op<OperatorEvaluatorMul<Vector3, Vector3, Vector3>>(Variant::OP_MULTIPLY, Variant::VECTOR3, Variant::VECTOR3);
 	register_op<OperatorEvaluatorMul<Vector3, Vector3, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR3, Variant::INT);
 	register_op<OperatorEvaluatorMul<Vector3, Vector3, double>>(Variant::OP_MULTIPLY, Variant::VECTOR3, Variant::FLOAT);
+	register_op<OperatorEvaluatorMul<Vector3, Vector3, Vector3i>>(Variant::OP_MULTIPLY, Variant::VECTOR3, Variant::VECTOR3I);
 
 	register_op<OperatorEvaluatorMul<Vector3i, Vector3i, Vector3i>>(Variant::OP_MULTIPLY, Variant::VECTOR3I, Variant::VECTOR3I);
 	register_op<OperatorEvaluatorMul<Vector3i, Vector3i, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR3I, Variant::INT);
 	register_op<OperatorEvaluatorMul<Vector3, Vector3i, double>>(Variant::OP_MULTIPLY, Variant::VECTOR3I, Variant::FLOAT);
+	register_op<OperatorEvaluatorMul<Vector3, Vector3i, Vector3>>(Variant::OP_MULTIPLY, Variant::VECTOR3I, Variant::VECTOR3);
 
 	register_op<OperatorEvaluatorMul<Vector4, Vector4, Vector4>>(Variant::OP_MULTIPLY, Variant::VECTOR4, Variant::VECTOR4);
 	register_op<OperatorEvaluatorMul<Vector4, Vector4, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR4, Variant::INT);
 	register_op<OperatorEvaluatorMul<Vector4, Vector4, double>>(Variant::OP_MULTIPLY, Variant::VECTOR4, Variant::FLOAT);
+	register_op<OperatorEvaluatorMul<Vector4, Vector4, Vector4i>>(Variant::OP_MULTIPLY, Variant::VECTOR4, Variant::VECTOR4I);
 
 	register_op<OperatorEvaluatorMul<Vector4i, Vector4i, Vector4i>>(Variant::OP_MULTIPLY, Variant::VECTOR4I, Variant::VECTOR4I);
 	register_op<OperatorEvaluatorMul<Vector4i, Vector4i, int64_t>>(Variant::OP_MULTIPLY, Variant::VECTOR4I, Variant::INT);
 	register_op<OperatorEvaluatorMul<Vector4, Vector4i, double>>(Variant::OP_MULTIPLY, Variant::VECTOR4I, Variant::FLOAT);
+	// register_op<OperatorEvaluatorMul<Vector4, Vector4i, Vector4>>(Variant::OP_MULTIPLY, Variant::VECTOR4I, Variant::VECTOR4);
 
 	register_op<OperatorEvaluatorMul<Quaternion, Quaternion, Quaternion>>(Variant::OP_MULTIPLY, Variant::QUATERNION, Variant::QUATERNION);
 	register_op<OperatorEvaluatorMul<Quaternion, Quaternion, int64_t>>(Variant::OP_MULTIPLY, Variant::QUATERNION, Variant::INT);
@@ -394,26 +414,32 @@ void Variant::_register_variant_operators() {
 	register_op<OperatorEvaluatorDiv<Vector2, Vector2, Vector2>>(Variant::OP_DIVIDE, Variant::VECTOR2, Variant::VECTOR2);
 	register_op<OperatorEvaluatorDiv<Vector2, Vector2, double>>(Variant::OP_DIVIDE, Variant::VECTOR2, Variant::FLOAT);
 	register_op<OperatorEvaluatorDiv<Vector2, Vector2, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR2, Variant::INT);
+	register_op<OperatorEvaluatorDiv<Vector2, Vector2, Vector2i>>(Variant::OP_DIVIDE, Variant::VECTOR2, Variant::VECTOR2I);
 
 	register_op<OperatorEvaluatorDivNZ<Vector2i, Vector2i, Vector2i>>(Variant::OP_DIVIDE, Variant::VECTOR2I, Variant::VECTOR2I);
 	register_op<OperatorEvaluatorDivNZ<Vector2, Vector2i, double>>(Variant::OP_DIVIDE, Variant::VECTOR2I, Variant::FLOAT);
 	register_op<OperatorEvaluatorDivNZ<Vector2i, Vector2i, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR2I, Variant::INT);
+	// register_op<OperatorEvaluatorDivNZ<Vector2, Vector2i, Vector2>>(Variant::OP_DIVIDE, Variant::VECTOR2I, Variant::VECTOR2);
 
 	register_op<OperatorEvaluatorDiv<Vector3, Vector3, Vector3>>(Variant::OP_DIVIDE, Variant::VECTOR3, Variant::VECTOR3);
 	register_op<OperatorEvaluatorDiv<Vector3, Vector3, double>>(Variant::OP_DIVIDE, Variant::VECTOR3, Variant::FLOAT);
 	register_op<OperatorEvaluatorDiv<Vector3, Vector3, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR3, Variant::INT);
+	register_op<OperatorEvaluatorDiv<Vector3, Vector3, Vector3i>>(Variant::OP_DIVIDE, Variant::VECTOR3, Variant::VECTOR3I);
 
 	register_op<OperatorEvaluatorDivNZ<Vector3i, Vector3i, Vector3i>>(Variant::OP_DIVIDE, Variant::VECTOR3I, Variant::VECTOR3I);
 	register_op<OperatorEvaluatorDivNZ<Vector3, Vector3i, double>>(Variant::OP_DIVIDE, Variant::VECTOR3I, Variant::FLOAT);
 	register_op<OperatorEvaluatorDivNZ<Vector3i, Vector3i, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR3I, Variant::INT);
+	// register_op<OperatorEvaluatorDivNZ<Vector3, Vector3i, Vector3>>(Variant::OP_DIVIDE, Variant::VECTOR3I, Variant::VECTOR3);
 
 	register_op<OperatorEvaluatorDiv<Vector4, Vector4, Vector4>>(Variant::OP_DIVIDE, Variant::VECTOR4, Variant::VECTOR4);
 	register_op<OperatorEvaluatorDiv<Vector4, Vector4, double>>(Variant::OP_DIVIDE, Variant::VECTOR4, Variant::FLOAT);
 	register_op<OperatorEvaluatorDiv<Vector4, Vector4, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR4, Variant::INT);
+	register_op<OperatorEvaluatorDiv<Vector4, Vector4, Vector4i>>(Variant::OP_DIVIDE, Variant::VECTOR4, Variant::VECTOR4I);
 
 	register_op<OperatorEvaluatorDivNZ<Vector4i, Vector4i, Vector4i>>(Variant::OP_DIVIDE, Variant::VECTOR4I, Variant::VECTOR4I);
 	register_op<OperatorEvaluatorDivNZ<Vector4, Vector4i, double>>(Variant::OP_DIVIDE, Variant::VECTOR4I, Variant::FLOAT);
 	register_op<OperatorEvaluatorDivNZ<Vector4i, Vector4i, int64_t>>(Variant::OP_DIVIDE, Variant::VECTOR4I, Variant::INT);
+	// register_op<OperatorEvaluatorDivNZ<Vector4, Vector4i, Vector4>>(Variant::OP_DIVIDE, Variant::VECTOR4I, Variant::VECTOR4);
 
 	register_op<OperatorEvaluatorDiv<Transform2D, Transform2D, int64_t>>(Variant::OP_DIVIDE, Variant::TRANSFORM2D, Variant::INT);
 	register_op<OperatorEvaluatorDiv<Transform2D, Transform2D, double>>(Variant::OP_DIVIDE, Variant::TRANSFORM2D, Variant::FLOAT);

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -483,6 +483,12 @@
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2" />
+			<param index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2" />
 			<param index="0" name="right" type="float" />
 			<description>
 				Multiplies each component of the [Vector2] by the given [float].
@@ -505,6 +511,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator +">
+			<return type="Vector2" />
+			<param index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator -">
 			<return type="Vector2" />
 			<param index="0" name="right" type="Vector2" />
@@ -515,6 +527,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator -">
+			<return type="Vector2" />
+			<param index="0" name="right" type="Vector2i" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator /">
 			<return type="Vector2" />
 			<param index="0" name="right" type="Vector2" />
@@ -523,6 +541,12 @@
 				[codeblock]
 				print(Vector2(10, 20) / Vector2(2, 5)) # Prints (5.0, 4.0)
 				[/codeblock]
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector2" />
+			<param index="0" name="right" type="Vector2i" />
+			<description>
 			</description>
 		</operator>
 		<operator name="operator /">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -524,6 +524,12 @@
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
+			<param index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
 			<param index="0" name="right" type="float" />
 			<description>
 				Multiplies each component of the [Vector3] by the given [float].
@@ -546,6 +552,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator +">
+			<return type="Vector3" />
+			<param index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator -">
 			<return type="Vector3" />
 			<param index="0" name="right" type="Vector3" />
@@ -556,6 +568,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator -">
+			<return type="Vector3" />
+			<param index="0" name="right" type="Vector3i" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator /">
 			<return type="Vector3" />
 			<param index="0" name="right" type="Vector3" />
@@ -564,6 +582,12 @@
 				[codeblock]
 				print(Vector3(10, 20, 30) / Vector3(2, 5, 3)) # Prints (5.0, 4.0, 10.0)
 				[/codeblock]
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector3" />
+			<param index="0" name="right" type="Vector3i" />
+			<description>
 			</description>
 		</operator>
 		<operator name="operator /">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -339,6 +339,12 @@
 		</operator>
 		<operator name="operator *">
 			<return type="Vector4" />
+			<param index="0" name="right" type="Vector4i" />
+			<description>
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector4" />
 			<param index="0" name="right" type="float" />
 			<description>
 				Multiplies each component of the [Vector4] by the given [float].
@@ -364,6 +370,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator +">
+			<return type="Vector4" />
+			<param index="0" name="right" type="Vector4i" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator -">
 			<return type="Vector4" />
 			<param index="0" name="right" type="Vector4" />
@@ -374,6 +386,12 @@
 				[/codeblock]
 			</description>
 		</operator>
+		<operator name="operator -">
+			<return type="Vector4" />
+			<param index="0" name="right" type="Vector4i" />
+			<description>
+			</description>
+		</operator>
 		<operator name="operator /">
 			<return type="Vector4" />
 			<param index="0" name="right" type="Vector4" />
@@ -382,6 +400,12 @@
 				[codeblock]
 				print(Vector4(10, 20, 30, 40) / Vector4(2, 5, 3, 4)) # Prints (5.0, 4.0, 10.0, 10.0)
 				[/codeblock]
+			</description>
+		</operator>
+		<operator name="operator /">
+			<return type="Vector4" />
+			<param index="0" name="right" type="Vector4i" />
+			<description>
 			</description>
 		</operator>
 		<operator name="operator /">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/5545
Adds `+ - * /` operators between Vector2/3/4 and Vector2i/3i/4i. The result of mixed operations is float vector, like with scalars.

Surprisingly you can just register operators between vectors and they will work properly for the most part, but some types have problems. I'll need some help with finishing this.