### PR TITLE
Expose `VisualShaderConversionPlugin` and conversion related editor methods

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -43,6 +43,20 @@
 				Edits the given [Script]. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
 			</description>
 		</method>
+		<method name="find_resource_conversion_plugin_for_resource">
+			<return type="Array" />
+			<param index="0" name="for_resource" type="Resource" />
+			<description>
+				Returns an [Array] of [EditorResourceConversionPlugin] that can handle the [param for_resource].
+			</description>
+		</method>
+		<method name="find_resource_conversion_plugin_for_type_name">
+			<return type="Array" />
+			<param index="0" name="type" type="String" />
+			<description>
+				Returns an [Array] of [EditorResourceConversionPlugin] that can handle the [param type].
+			</description>
+		</method>
 		<method name="get_base_control" qualifiers="const">
 			<return type="Control" />
 			<description>

--- a/doc/classes/VisualShaderConversionPlugin.xml
+++ b/doc/classes/VisualShaderConversionPlugin.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisualShaderConversionPlugin" inherits="EditorResourceConversionPlugin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Plugin for converting from [VisualShader] to [Shader].
+	</brief_description>
+	<description>
+		[VisualShaderConversionPlugin] is invoked when the context menu is brought up for a [VisualShader] in the editor inspector.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="convert" qualifiers="const">
+			<return type="Resource" />
+			<param index="0" name="resource" type="Resource" />
+			<description>
+				Takes an input [Resource] expected to be of type [VisualShader] and converts it to [Shader] in [method converts_to]. The returned [Resource] is the resulting [Shader] of the conversion, and the input [Resource] remains unchanged.
+			</description>
+		</method>
+		<method name="converts_to" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns "Shader" which is the class name [Shader] this plugin converts the source resource [VisualShader] to.
+			</description>
+		</method>
+		<method name="handles" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="resource" type="Resource" />
+			<description>
+				Called to determine whether a particular [Resource] can be converted to the [Shader] resource type by this plugin. Will return false if the particular [Resource] is not of type [VisualShader].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -48,6 +48,7 @@
 #include "editor/gui/editor_toaster.h"
 #include "editor/gui/scene_tree_editor.h"
 #include "editor/inspector_dock.h"
+#include "editor/plugins/editor_resource_conversion_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/property_selector.h"
 #include "editor/themes/editor_scale.h"
@@ -366,6 +367,36 @@ void EditorInterface::set_plugin_enabled(const String &p_plugin, bool p_enabled)
 
 bool EditorInterface::is_plugin_enabled(const String &p_plugin) const {
 	return EditorNode::get_singleton()->is_addon_plugin_enabled(p_plugin);
+}
+
+Array EditorInterface::find_resource_conversion_plugin_for_resource(const Ref<Resource> &p_for_resource) {
+	Array ret = Array();
+	Vector<Ref<EditorResourceConversionPlugin>> converters = EditorNode::get_singleton()->find_resource_conversion_plugin_for_resource(p_for_resource);
+
+	if (converters.is_empty()) {
+		return ret;
+	}
+
+	for (int i = 0; i < converters.size(); i++) {
+		ret.push_back(converters[i]);
+	}
+
+	return ret;
+}
+
+Array EditorInterface::find_resource_conversion_plugin_for_type_name(const String &p_type) {
+	Array ret = Array();
+	Vector<Ref<EditorResourceConversionPlugin>> converters = EditorNode::get_singleton()->find_resource_conversion_plugin_for_type_name(p_type);
+
+	if (converters.is_empty()) {
+		return ret;
+	}
+
+	for (int i = 0; i < converters.size(); i++) {
+		ret.push_back(converters[i]);
+	}
+
+	return ret;
 }
 
 // Editor GUI.
@@ -786,6 +817,8 @@ void EditorInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_plugin_enabled", "plugin", "enabled"), &EditorInterface::set_plugin_enabled);
 	ClassDB::bind_method(D_METHOD("is_plugin_enabled", "plugin"), &EditorInterface::is_plugin_enabled);
+	ClassDB::bind_method(D_METHOD("find_resource_conversion_plugin_for_resource", "for_resource"), &EditorInterface::find_resource_conversion_plugin_for_resource);
+	ClassDB::bind_method(D_METHOD("find_resource_conversion_plugin_for_type_name", "type"), &EditorInterface::find_resource_conversion_plugin_for_type_name);
 
 	// Editor GUI.
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -43,6 +43,7 @@ class EditorFileSystem;
 class EditorInspector;
 class EditorPaths;
 class EditorPlugin;
+class EditorResourceConversionPlugin;
 class EditorResourcePreview;
 class EditorSelection;
 class EditorSettings;
@@ -115,6 +116,8 @@ public:
 
 	void set_plugin_enabled(const String &p_plugin, bool p_enabled);
 	bool is_plugin_enabled(const String &p_plugin) const;
+	Array find_resource_conversion_plugin_for_resource(const Ref<Resource> &p_for_resource);
+	Array find_resource_conversion_plugin_for_type_name(const String &p_type);
 
 	// Editor GUI.
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/math/math_defs.h"
+#include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_node.h"
 #include "editor/editor_properties.h"
@@ -8215,6 +8216,12 @@ void VisualShaderNodePortPreview::_notification(int p_what) {
 }
 
 //////////////////////////////////
+
+void VisualShaderConversionPlugin::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("converts_to"), &VisualShaderConversionPlugin::converts_to);
+	ClassDB::bind_method(D_METHOD("handles", "resource"), &VisualShaderConversionPlugin::handles);
+	ClassDB::bind_method(D_METHOD("convert", "resource"), &VisualShaderConversionPlugin::convert);
+}
 
 String VisualShaderConversionPlugin::converts_to() const {
 	return "Shader";

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -712,6 +712,9 @@ public:
 class VisualShaderConversionPlugin : public EditorResourceConversionPlugin {
 	GDCLASS(VisualShaderConversionPlugin, EditorResourceConversionPlugin);
 
+protected:
+	static void _bind_methods();
+
 public:
 	virtual String converts_to() const override;
 	virtual bool handles(const Ref<Resource> &p_resource) const override;

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -127,6 +127,7 @@
 #include "editor/plugins/theme_editor_plugin.h"
 #include "editor/plugins/tiles/tiles_editor_plugin.h"
 #include "editor/plugins/tool_button_editor_plugin.h"
+#include "editor/plugins/visual_shader_editor_plugin.h"
 #include "editor/plugins/voxel_gi_editor_plugin.h"
 #include "editor/register_exporters.h"
 
@@ -168,6 +169,7 @@ void register_editor_types() {
 	register_exporter_types();
 
 	GDREGISTER_CLASS(EditorResourceConversionPlugin);
+	GDREGISTER_CLASS(VisualShaderConversionPlugin);
 	GDREGISTER_CLASS(EditorSceneFormatImporter);
 	GDREGISTER_CLASS(EditorScenePostImportPlugin);
 	GDREGISTER_CLASS(EditorInspector);


### PR DESCRIPTION
This PR exposes some methods and classes to the ``ClassDB`` that further allow for converting ``VisualShader``s to ``Shader``s in script.  This is especially useful for writing custom ``EditorExportPlugin``s where one wants the benefits of ``VisualShader`` at edit time, but ``Shader`` in the final project.  Here is a short summary of the benefits followed by additional details as to what lead me here and some potential things we can do in the future.

1. ``VisualShaders`` can now be converted to ``Shader`` via custom scripts so we can get the benefits of ``Shader`` without losing the convenience of shader graph.  I do this via a custom EditorExportPlugin I have shared below.
2. ``VisualShader`` cannot be loaded in parallel via ``ResourceLoader::load_threaded_request`` as this causes errors and crashes.  I intend to open a separate issue for this.
3. ``Shader`` can be loaded in parallel and significantly improves load time.
4. ``Shader`` is significantly smaller than ``VisualShader``.  This makes exports much smaller and is especially useful for mobile games where keeping the game under 100 MB (which some mobile data carries require unless on wifi) is essential.  Here is a picture of the difference with our few simple shaders:

![image](https://github.com/user-attachments/assets/1e67cafe-17de-4c0e-8983-b0a71cda9f84)

This is something that can be a huge disk saving for larger projects.

Now what lead me to this?  I was trying to improve the load times of our game.  I learned about ``ResourceLoader::load_threaded_request`` and figured loading things in parallel should improve performance.  I immediately started running into errors and crashes related to ``VisualShader`` which I intend to open another issue for.  I tried debugging it myself, but found it is likely a race condition that I didn't want to spend too much more time on.  I started looking for workarounds and noticed the "Convert To Shader" context menu item

![image](https://github.com/user-attachments/assets/68100703-fa83-4cdc-b8ed-54ca0bcf6d39)

After doing a quick POC and converted all my ``VisualShader``s to ``Shader``, I noticed the game stopped crashing and load times improved tremendously.  Especially noticeable in our mobile builds.  Granted this is likely because I can now load in parallel rather than linearly.  But I then noticed the disk space improvement and realized these are useful apis to expose beyond just the context menu even when the ``VisualShader`` bug is fixed.  Here is my export plugin I currently used to convert ``VisualShader`` to ``Shader`` at export time:

```py
# MIT License
# 
# Copyright (c) 2025 Lange Studios LLC
# 
# Permission is hereby granted, free of charge, to any person obtaining a copy
# of this software and associated documentation files (the "Software"), to deal
# in the Software without restriction, including without limitation the rights
# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
# copies of the Software, and to permit persons to whom the Software is
# furnished to do so, subject to the following conditions:
# 
# The above copyright notice and this permission notice shall be included in all
# copies or substantial portions of the Software.
# 
# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
# SOFTWARE.

@tool
extends EditorPlugin

var export_plugin: VisualShaderToCodeExportPlugin

func _enter_tree():
    export_plugin = VisualShaderToCodeExportPlugin.new()
    add_export_plugin(export_plugin)


func _exit_tree():
    remove_export_plugin(export_plugin)
    export_plugin = null

class VisualShaderToCodeExportPlugin extends EditorExportPlugin:
    func _get_name():
        return "VisualShaderToCodeExportPlugin"

    func _supports_platform(platform: EditorExportPlatform) -> bool:
        return true

    func _export_file(path: String, type: String, features: PackedStringArray) -> void:
        if type != "VisualShader":
            return

        var converters: Array = EditorInterface.find_resource_conversion_plugin_for_type_name(type);
        if converters.size() == 0:
            return

        for c in converters:
            if c is VisualShaderConversionPlugin:
                var visual_shader: VisualShader = load(path)
                var shader: Shader = c.convert(visual_shader)
                path = "res://.godot/visual_shader_to_code/" + path.substr("res://".length())
                if ProjectSettings.get_setting("editor/export/convert_text_resources_to_binary"):
                    path = path.trim_suffix(path.get_extension()) + "res"
                DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(path.get_base_dir()))
                ResourceSaver.save(shader, path)
                add_file(path, FileAccess.get_file_as_bytes(path), true)
                break
```

After this PR goes through, a future PR would be useful to make this a standard part of the engine.  Maybe something where there is a boolean on the ``VisualShader`` to convert to ``Shader`` at export time:

![image](https://github.com/user-attachments/assets/0e6f8db9-cd4c-4eda-b5d9-c541f0ac57b1)

Thank you for all the help and special shoutout to @KoBeWi @arkology @akien-mga @QbieShay for helping on these recent shader issues!

Edit:

And shoutout to @Calinou !  He's been there to help in pretty much every issue I run into including this one! :)