### PR TITLE
Add option to explicitly set executable output path

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -255,6 +255,7 @@ opts.Add(
     EnumVariable("warnings", "Level of compilation warnings", "all", ["extra", "all", "moderate", "no"], ignorecase=2)
 )
 opts.Add(BoolVariable("werror", "Treat compiler warnings as errors", False))
+opts.Add("output_path", "Explicit path to output Godot binary relative to source root", "")
 opts.Add("extra_suffix", "Custom extra suffix added to the base filename of all generated binary files", "")
 opts.Add("object_prefix", "Custom prefix added to the base filename of all generated object files", "")
 opts.Add(BoolVariable("vsproj", "Generate a Visual Studio solution", False))

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -40,12 +40,13 @@ if env["dbus"]:
     if env["use_sowrap"]:
         common_linuxbsd.append("dbus-so_wrap.c")
 
+godot_bin_path = f"#{env['output_path']}" if env["output_path"] else "#bin/godot"
 if env["library_type"] == "static_library":
-    prog = env.add_library("#bin/godot", common_linuxbsd)
+    prog = env.add_library(godot_bin_path, common_linuxbsd)
 elif env["library_type"] == "shared_library":
-    prog = env.add_shared_library("#bin/godot", common_linuxbsd)
+    prog = env.add_shared_library(godot_bin_path, common_linuxbsd)
 else:
-    prog = env.add_program("#bin/godot", common_linuxbsd)
+    prog = env.add_program(godot_bin_path, common_linuxbsd)
 
 if env["debug_symbols"] and env["separate_debug_symbols"]:
     env.AddPostAction(prog, env.Run(platform_linuxbsd_builders.make_debug_linuxbsd))

--- a/platform/macos/SCsub
+++ b/platform/macos/SCsub
@@ -47,12 +47,13 @@ if env["library_type"] == "executable":
 else:
     files += ["libgodot_macos.mm"]
 
+godot_bin_path = f"#{env['output_path']}" if env["output_path"] else "#bin/godot"
 if env["library_type"] == "static_library":
-    prog = env.add_library("#bin/godot", files)
+    prog = env.add_library(godot_bin_path, files)
 elif env["library_type"] == "shared_library":
-    prog = env.add_shared_library("#bin/godot", files)
+    prog = env.add_shared_library(godot_bin_path, files)
 else:
-    prog = env.add_program("#bin/godot", files)
+    prog = env.add_program(godot_bin_path, files)
 
 if env["debug_symbols"] and env["separate_debug_symbols"]:
     env.AddPostAction(prog, env.Run(platform_macos_builders.make_debug_macos))

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -95,7 +95,9 @@ if env["dlink_enabled"]:
     sys = sys_env.add_program(build_targets, ["web_runtime.cpp"])
 
     # The side library, containing all Godot code.
-    wasm = env.add_program("#bin/godot.side${PROGSUFFIX}.wasm", web_files)
+    wasm = env.add_program(
+        f"#{env['output_path']}" if env["output_path"] else "#bin/godot.side${PROGSUFFIX}.wasm", web_files
+    )
     build = sys + [wasm[0]]
 else:
     # We use IDBFS. Since Emscripten 1.39.1 it needs to be linked explicitly.

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -111,12 +111,13 @@ sources += res_obj
 if env["accesskit"] and not env.msvc:
     sources += env.DEFLIB("uiautomationcore")
 
+godot_bin_path = f"#{env['output_path']}" if env["output_path"] else "#bin/godot"
 if env["library_type"] == "static_library":
-    prog = env.add_library("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
+    prog = env.add_library(godot_bin_path, sources, PROGSUFFIX=env["PROGSUFFIX"])
 elif env["library_type"] == "shared_library":
-    prog = env.add_shared_library("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
+    prog = env.add_shared_library(godot_bin_path, sources, PROGSUFFIX=env["PROGSUFFIX"])
 else:
-    prog = env.add_program("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
+    prog = env.add_program(godot_bin_path, sources, PROGSUFFIX=env["PROGSUFFIX"])
 arrange_program_clean(prog)
 
 env.Depends(prog, "godot.manifest")


### PR DESCRIPTION
This allows more easily predictable binary names across architectures, which makes it easier to provide stable paths to `install` (in combination with `extra_suffix`) when building the Debian package.