### PR TITLE
Fix AgX sigmoid contrast curve approximation

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -265,15 +265,15 @@ vec3 tonemap_aces(vec3 color, float white) {
 }
 
 // Polynomial approximation of EaryChow's AgX sigmoid curve.
-// In Blender's implementation, numbers could go a little bit over 1.0, so it's best to ensure
-// this behaves the same as Blender's with values up to 1.1. Input values cannot be lower than 0.
+// x must be within the range [0.0, 1.0]
 vec3 agx_default_contrast_approx(vec3 x) {
 	// Generated with Excel trendline
 	// Input data: Generated using python sigmoid with EaryChow's configuration and 57 steps
+	// Additional padding values were added to give correct intersections at 0.0 and 1.0
 	// 6th order, intercept of 0.0 to remove an operation and ensure intersection at 0.0
 	vec3 x2 = x * x;
 	vec3 x4 = x2 * x2;
-	return -0.20687445 * x + 6.80888933 * x2 - 37.60519607 * x2 * x + 93.32681938 * x4 - 95.2780858 * x4 * x + 33.96372259 * x4 * x2;
+	return 0.021 * x + 4.0111 * x2 - 25.682 * x2 * x + 70.359 * x4 - 74.778 * x4 * x + 27.069 * x4 * x2;
 }
 
 const mat3 LINEAR_SRGB_TO_LINEAR_REC2020 = mat3(
@@ -315,7 +315,8 @@ vec3 tonemap_agx(vec3 color) {
 
 	// Log2 space encoding.
 	color = max(color, 1e-10); // Prevent log2(0.0). Possibly unnecessary.
-	// Must be clamped because agx_blender_default_contrast_approx may not work well with values above 1.0
+	// Must be clamped because agx_blender_default_contrast_approx may not work
+	// well with values outside of the range [0.0, 1.0]
 	color = clamp(log2(color), min_ev, max_ev);
 	color = (color - min_ev) / (max_ev - min_ev);
 


### PR DESCRIPTION
- Fixes/improves #87260.

Not cherry-pickable to 4.3, as AgX is only in 4.4.

This changes the polynomial function so that a lower input always results in a lower output and vice-versa. Additionally, the new function returns a value that is much closer to `1.0` when given an input of `1.0`.

The polynomial regression for the AgX sigmoid contrast curve was my first attempt because I was rushed to get the change in before going on holiday. Upon review, I discovered a mistake that causes incorrect behavior in some cases.

Given:

```
x = agx_default_contrast_approx(a)
y = agx_default_contrast_approx(b)
```

For all values of `a` and `b` in the range `[0.0, 1.0`], `x` should always be less than `y` when `a` is less than `b`.

This is not the case with the current function in `master` for near-zero values. Additionally, when given an input of `1.0` the current function returns `1.00927498` when it should return `1.0`.

After having more time to fiddle with polynomial regression calculators, I generated a new formula that fits the logical requirements of a tonemapper’s contrast function and gives an output of `1.0001` when given an input of `1.0`.

![image](https://github.com/user-attachments/assets/117a9762-86a3-473f-a8ef-dfd65643d712)

This new function reduces banding in the transition from green to white in the Compatibility renderer:

| master | this PR
| --- | ---
| ![image](https://github.com/user-attachments/assets/64564b19-dd3d-447a-9074-a513ebd82398) | ![image](https://github.com/user-attachments/assets/e274794b-65ed-43a9-89b1-a4a5f11dbf71)