### PR TITLE
Increase NavigationLink3D gizmo detail to match other circle/sphere 3D gizmos

### DIFF
--- a/editor/plugins/gizmos/navigation_link_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/navigation_link_3d_gizmo_plugin.cpp
@@ -70,9 +70,9 @@ void NavigationLink3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	p_gizmo->clear();
 
-	// Number of points in an octant. So there ill be 8 * points_in_octant points in total.
+	// Number of points in an octant. So there will be 8 * points_in_octant points in total.
 	// Correspond to the smoothness of the circle.
-	const uint32_t points_in_octant = 4;
+	const uint32_t points_in_octant = 8;
 	real_t inc = (Math_PI / (4 * points_in_octant));
 
 	Vector<Vector3> lines;


### PR DESCRIPTION
This makes the gizmo look less "angular".

## Preview

*GPUParticlesCollisionSphere3D on the left, NavigationLink3D on the right.*

### Before

![image](https://github.com/user-attachments/assets/731add60-61aa-41a0-8208-66be8977c686)

### After

![image](https://github.com/user-attachments/assets/2a5f5cda-9303-4275-ac7e-109e16c39c96)