### PR TITLE
Fix node cache errors on nested MultiplayerSpawners

### DIFF
--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -73,7 +73,7 @@ private:
 	HashMap<int, PeerInfo> peers_info;
 	uint32_t last_net_id = 0;
 	HashMap<ObjectID, TrackedNode> tracked_nodes;
-	HashSet<ObjectID> spawned_nodes;
+	RBSet<ObjectID> spawned_nodes;
 	HashSet<ObjectID> sync_nodes;
 
 	// Pending local spawn information (handles spawning nested nodes during ready).


### PR DESCRIPTION
Resolves #91342 by changing the replication node tracking logic to use RBSet, which preserves iteration order after entries are removed.

This prevents simplify path commands from being sent to clients out of order, so that the commands for parents are received before the commands for children.

This may not be the right fix but it does fix the MRP in issue #91342 and my own personal project where I have three layers of nested spawners which were reproducing the same issue. 

Looking for feedback or hoping this inspires a proper fix :)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
