### PR TITLE
Fix SkeletonProfileHumanoid documentation error

### DIFF
--- a/doc/classes/SkeletonProfileHumanoid.xml
+++ b/doc/classes/SkeletonProfileHumanoid.xml
@@ -31,6 +31,7 @@
 		                │        └─ LeftHand
 		                │           ├─ LeftThumbMetacarpal
 		                │           │  └─ LeftThumbProximal
+		                │           │    └─ LeftThumbDistal
 		                │           ├─ LeftIndexProximal
 		                │           │  └─ LeftIndexIntermediate
 		                │           │    └─ LeftIndexDistal
@@ -49,6 +50,7 @@
 		                         └─ RightHand
 		                            ├─ RightThumbMetacarpal
 		                            │  └─ RightThumbProximal
+		                            │     └─ RightThumbDistal
 		                            ├─ RightIndexProximal
 		                            │  └─ RightIndexIntermediate
 		                            │     └─ RightIndexDistal


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #100992.

Added LeftThumbDistal and RightThumbDistal to the SkeletonProfileHumanoid documentation XML file (originally https://github.com/godotengine/godot/blob/master/doc/classes/SkeletonProfileHumanoid.xml).

Please let me know if this is the right way to address the issue!