### PR TITLE
Update 3D Physics Engine tooltip to indicate Jolt is available

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2316,7 +2316,8 @@
 		</member>
 		<member name="physics/3d/physics_engine" type="String" setter="" getter="" default="&quot;DEFAULT&quot;">
 			Sets which physics engine to use for 3D physics.
-			"DEFAULT" and "GodotPhysics3D" are the same, as there is currently no alternative 3D physics server implemented.
+			"DEFAULT" and "GodotPhysics3D" are the same.
+			"Jolt Physics" is currently experimental, and may change in future releases.
 			"Dummy" is a 3D physics server that does nothing and returns only dummy values, effectively disabling all 3D physics functionality.
 		</member>
 		<member name="physics/3d/run_on_separate_thread" type="bool" setter="" getter="" default="false">


### PR DESCRIPTION
This change updates the tooltip text for selecting the 3D physics server in the editor settings.

![Picture of the Editor Settings panel with the 3D Physics option highlighted](https://github.com/user-attachments/assets/4bcc1fe4-ddbc-43d1-9dfc-013a907b9c36)

Please let me know if there's something more appropriate for here.
