### PR TITLE
Add typed Array and Dictionary writer and parser tests

### DIFF
--- a/tests/core/variant/test_variant.h
+++ b/tests/core/variant/test_variant.h
@@ -57,6 +57,23 @@ static inline Dictionary build_dictionary(Variant key, Variant item, Targs... Fa
 	return d;
 }
 
+static inline void collection_writer_parser(Variant p_variant, String p_serialized) {
+	String v_str;
+	VariantWriter::write_to_string(p_variant, v_str);
+
+	CHECK_EQ(v_str, p_serialized);
+
+	VariantParser::StreamString ss;
+	String errs;
+	int line;
+	Variant v_parsed;
+
+	ss.s = v_str;
+	VariantParser::parse(&ss, v_parsed, errs, line);
+
+	CHECK_MESSAGE(v_parsed == Variant(p_variant), "Should parse back.");
+}
+
 TEST_CASE("[Variant] Writer and parser integer") {
 	int64_t a32 = 2147483648; // 2^31, so out of bounds for 32-bit signed int [-2^31, +2^31-1].
 	String a32_str;
@@ -1738,21 +1755,7 @@ TEST_CASE("[Variant] Assignment To Color from Bool,Int,Float,String,Vec2,Vec2i,V
 }
 
 TEST_CASE("[Variant] Writer and parser array") {
-	Array a = build_array(1, String("hello"), build_array(Variant()));
-	String a_str;
-	VariantWriter::write_to_string(a, a_str);
-
-	CHECK_EQ(a_str, "[1, \"hello\", [null]]");
-
-	VariantParser::StreamString ss;
-	String errs;
-	int line;
-	Variant a_parsed;
-
-	ss.s = a_str;
-	VariantParser::parse(&ss, a_parsed, errs, line);
-
-	CHECK_MESSAGE(a_parsed == Variant(a), "Should parse back.");
+	collection_writer_parser(build_array(1, String("hello"), build_array(Variant())), "[1, \"hello\", [null]]");
 }
 
 TEST_CASE("[Variant] Writer recursive array") {
@@ -1787,31 +1790,38 @@ TEST_CASE("[Variant] Writer recursive array") {
 	a2.clear();
 }
 
+TEST_CASE("[Variant] Writer and parser typed Variant array") {
+	collection_writer_parser(Array(build_array(1, String("hello"), build_array(Variant())), Variant(), "", Variant()), "[1, \"hello\", [null]]");
+}
+
+TEST_CASE("[Variant] Writer and parser typed int array") {
+	collection_writer_parser(Array(build_array(), Variant::INT, "", Variant()), "Array[int]([])");
+}
+
+TEST_CASE("[Variant] Writer and parser typed Resource array") {
+	collection_writer_parser(Array(build_array(), Variant::OBJECT, "Resource", Variant()), "Array[Resource]([])");
+}
+
+TEST_CASE("[Variant] Writer and parser typed Node array") {
+	collection_writer_parser(Array(build_array(), Variant::OBJECT, "Node", Variant()), "Array[Node]([])");
+}
+
+TEST_CASE("[Variant] Writer and parser typed Array array") {
+	collection_writer_parser(Array(build_array(build_array(1, String("hello")), build_array(Variant())), Variant::ARRAY, "", Variant()), "Array[Array]([[1, \"hello\"], [null]])");
+}
+
+TEST_CASE("[Variant] Writer and parser typed Dictionary array") {
+	// a = Array[Dictionary]([{{1: 2}: 3}, {4: "hello"}, {null: []}])
+	collection_writer_parser(Array(build_array(build_dictionary(build_dictionary(1, 2), 3), build_dictionary(4, String("hello")), build_dictionary(5, build_dictionary(Variant(), build_array()))), Variant::DICTIONARY, "", Variant()), "Array[Dictionary]([{\n{\n1: 2\n}: 3\n}, {\n4: \"hello\"\n}, {\n5: {\nnull: []\n}\n}])");
+}
+
 TEST_CASE("[Variant] Writer and parser dictionary") {
 	// d = {{1: 2}: 3, 4: "hello", 5: {null: []}}
-	Dictionary d = build_dictionary(build_dictionary(1, 2), 3, 4, String("hello"), 5, build_dictionary(Variant(), build_array()));
-	String d_str;
-	VariantWriter::write_to_string(d, d_str);
-
-	CHECK_EQ(d_str, "{\n4: \"hello\",\n5: {\nnull: []\n},\n{\n1: 2\n}: 3\n}");
-
-	VariantParser::StreamString ss;
-	String errs;
-	int line;
-	Variant d_parsed;
-
-	ss.s = d_str;
-	VariantParser::parse(&ss, d_parsed, errs, line);
-
-	CHECK_MESSAGE(d_parsed == Variant(d), "Should parse back.");
+	collection_writer_parser(build_dictionary(build_dictionary(1, 2), 3, 4, String("hello"), 5, build_dictionary(Variant(), build_array())), "{\n4: \"hello\",\n5: {\nnull: []\n},\n{\n1: 2\n}: 3\n}");
 }
 
 TEST_CASE("[Variant] Writer key sorting") {
-	Dictionary d = build_dictionary(StringName("C"), 3, "A", 1, StringName("B"), 2, "D", 4);
-	String d_str;
-	VariantWriter::write_to_string(d, d_str);
-
-	CHECK_EQ(d_str, "{\n\"A\": 1,\n&\"B\": 2,\n&\"C\": 3,\n\"D\": 4\n}");
+	collection_writer_parser(build_dictionary(StringName("C"), 3, "A", 1, StringName("B"), 2, "D", 4), "{\n\"A\": 1,\n&\"B\": 2,\n&\"C\": 3,\n\"D\": 4\n}");
 }
 
 TEST_CASE("[Variant] Writer recursive dictionary") {
@@ -1879,6 +1889,40 @@ TEST_CASE("[Variant] Writer recursive dictionary on keys") {
 	d2.clear();
 }
 #endif
+
+TEST_CASE("[Variant] Writer and parser typed Variant;Variant dictionary") {
+	// d = Dictionary[Variant, Variant]({{1: 2}: 3, 4: "hello", 5: {null: []}})
+	collection_writer_parser(Dictionary(build_dictionary(build_dictionary(1, 2), 3, 4, String("hello"), 5, build_dictionary(Variant(), build_array())), Variant(), "", Variant(), Variant(), "", Variant()), "{\n4: \"hello\",\n5: {\nnull: []\n},\n{\n1: 2\n}: 3\n}");
+}
+
+TEST_CASE("[Variant] Writer and parser typed Variant;int dictionary") {
+	collection_writer_parser(Dictionary(build_dictionary(), Variant(), "", Variant(), Variant::INT, "", Variant()), "Dictionary[Variant, int]({})");
+}
+
+TEST_CASE("[Variant] Writer and parser typed int;Variant dictionary") {
+	collection_writer_parser(Dictionary(build_dictionary(), Variant::INT, "", Variant(), Variant(), "", Variant()), "Dictionary[int, Variant]({})");
+}
+
+TEST_CASE("[Variant] Writer and parser typed int;int dictionary") {
+	collection_writer_parser(Dictionary(build_dictionary(), Variant::INT, "", Variant(), Variant::INT, "", Variant()), "Dictionary[int, int]({})");
+}
+
+TEST_CASE("[Variant] Writer and parser typed Resource;Resource dictionary") {
+	collection_writer_parser(Dictionary(build_dictionary(), Variant::OBJECT, "Resource", Variant(), Variant::OBJECT, "Resource", Variant()), "Dictionary[Resource, Resource]({})");
+}
+
+TEST_CASE("[Variant] Writer and parser typed Node;Node dictionary") {
+	collection_writer_parser(Dictionary(build_dictionary(), Variant::OBJECT, "Node", Variant(), Variant::OBJECT, "Node", Variant()), "Dictionary[Node, Node]({})");
+}
+
+TEST_CASE("[Variant] Writer and parser typed Array;Array dictionary") {
+	collection_writer_parser(Dictionary(build_dictionary(build_array(1, String("hello")), build_array(Variant())), Variant::ARRAY, "", Variant(), Variant::ARRAY, "", Variant()), "Dictionary[Array, Array]({\n[1, \"hello\"]: [null]\n})");
+}
+
+TEST_CASE("[Variant] Writer and parser typed Dictionary;Dictionary dictionary") {
+	// a = Dictionary[Dictionary, Dictionary]({{1: 2}: {4: "hello"}})
+	collection_writer_parser(Dictionary(build_dictionary(build_dictionary(1, 2), build_dictionary(4, String("hello"))), Variant::DICTIONARY, "", Variant(), Variant::DICTIONARY, "", Variant()), "Dictionary[Dictionary, Dictionary]({\n{\n1: 2\n}: {\n4: \"hello\"\n}\n})");
+}
 
 TEST_CASE("[Variant] Basic comparison") {
 	CHECK_EQ(Variant(1), Variant(1));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Adds typed Array and Dictionary writer and parser tests, as suggested by @dalexeev in https://github.com/godotengine/godot/pull/100933#pullrequestreview-2534882013. This also includes `Variant` typing checks. Dictionary checks have the key type and value type the same.

**Note:** The `Resource;Resource dictionary` check will fail because of the issue in #100889. Merging #100933 will allow the check to succeed.