### PR TITLE
Use `GetFileAttributesW` for checking file existence on Windows

### DIFF
--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -402,13 +402,8 @@ bool FileAccessWindows::file_exists(const String &p_name) {
 	}
 
 	String filename = fix_path(p_name);
-	FILE *g = _wfsopen((LPCWSTR)(filename.utf16().get_data()), L"rb", _SH_DENYNO);
-	if (g == nullptr) {
-		return false;
-	} else {
-		fclose(g);
-		return true;
-	}
+	DWORD file_attr = GetFileAttributesW((LPCWSTR)(filename.utf16().get_data()));
+	return (file_attr != INVALID_FILE_ATTRIBUTES) && !(file_attr & FILE_ATTRIBUTE_DIRECTORY);
 }
 
 uint64_t FileAccessWindows::_get_modified_time(const String &p_file) {


### PR DESCRIPTION
~~Partially address #78645.~~ (solved by #101435)

Help to address #100109.

We are using `_wfsopen` in `FileAccessWindows::file_exists` which opens a file just to check it is there. Use `GetFileAttributesW` makes this function a lot faster. In MRP of #78645 reduce the lag by about a half (measured by eyes, not that accurate).

I used to complain that file operations on Windows were very slow. My apologies for wrongly blaming you, Windows :)
