### PR TITLE
Return fast for built-in class icon

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4941,7 +4941,7 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 	String script_path;
 	if (ScriptServer::is_global_class(p_class)) {
 		script_path = ScriptServer::get_global_class_path(p_class);
-	} else if (ResourceLoader::exists(p_class)) { // If the script is not a class_name we check if the script resource exists.
+	} else if (!p_class.get_extension().is_empty() && ResourceLoader::exists(p_class)) { // If the script is not a class_name we check if the script resource exists.
 		script_path = p_class;
 	}
 


### PR DESCRIPTION
~~Add a fast path for built-in class in `EditorNode::get_class_icon`.~~

#78645 MRP with 28K objects now runs smoothly, 91K objects still sucks.

~~Would be good if someone knows what `EditorNode::get_object_icon` does could refactor these code.~~

Refactor get icon logic.
- ~Split `_get_class_or_script_icon` into `_get_class_icon` and `_get_script_icon`.~
- ~Change `get_class/object_icon` to avoid multiple checking.~
- Use file extension to identify resource path. This should be cheaper than `ResourceLoader::exists`.

Test with [test_custom_icon.zip](https://github.com/user-attachments/files/18389824/test_custom_icon.zip), `class_name` and `@icon` seems to work without problem. And the performance boost remains true.

*Bugsquad edit:*
- Fixes #98666.