### PR TITLE
Add `get_connection_list_from_node` function to `GraphEdit`

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -208,6 +208,23 @@
 				Returns the points which would make up a connection between [param from_node] and [param to_node].
 			</description>
 		</method>
+		<method name="get_connection_list_from_node" qualifiers="const">
+			<return type="Dictionary[]" />
+			<param index="0" name="node" type="StringName" />
+			<description>
+				Returns an [Array] containing a list of all connections for [param node].
+				A connection is represented as a [Dictionary] in the form of:
+				[codeblock]
+				{
+				    from_node: StringName,
+				    from_port: int,
+				    to_node: StringName,
+				    to_port: int,
+				    keep_alive: bool
+				}
+				[/codeblock]
+			</description>
+		</method>
 		<method name="get_connections_intersecting_with_rect" qualifiers="const">
 			<return type="Dictionary[]" />
 			<param index="0" name="rect" type="Rect2" />

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -2329,6 +2329,22 @@ TypedArray<Dictionary> GraphEdit::_get_connections_intersecting_with_rect(const 
 	return arr;
 }
 
+TypedArray<Dictionary> GraphEdit::_get_connection_list_from_node(const StringName &p_node) const {
+	List<Ref<GraphEdit::Connection>> connections_from_node = connection_map.get(p_node);
+	TypedArray<Dictionary> connections_from_node_dict;
+
+	for (const Ref<Connection> &conn : connections_from_node) {
+		Dictionary d;
+		d["from_node"] = conn->from_node;
+		d["from_port"] = conn->from_port;
+		d["to_node"] = conn->to_node;
+		d["to_port"] = conn->to_port;
+		d["keep_alive"] = conn->keep_alive;
+		connections_from_node_dict.push_back(d);
+	}
+	return connections_from_node_dict;
+}
+
 void GraphEdit::_zoom_minus() {
 	set_zoom(zoom / zoom_step);
 }
@@ -2689,6 +2705,7 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_connection_list"), &GraphEdit::_get_connection_list);
 	ClassDB::bind_method(D_METHOD("get_connection_count", "from_node", "from_port"), &GraphEdit::get_connection_count);
 	ClassDB::bind_method(D_METHOD("get_closest_connection_at_point", "point", "max_distance"), &GraphEdit::_get_closest_connection_at_point, DEFVAL(4.0));
+	ClassDB::bind_method(D_METHOD("get_connection_list_from_node", "node"), &GraphEdit::_get_connection_list_from_node);
 	ClassDB::bind_method(D_METHOD("get_connections_intersecting_with_rect", "rect"), &GraphEdit::_get_connections_intersecting_with_rect);
 	ClassDB::bind_method(D_METHOD("clear_connections"), &GraphEdit::clear_connections);
 	ClassDB::bind_method(D_METHOD("force_connection_drag_end"), &GraphEdit::force_connection_drag_end);

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -345,6 +345,7 @@ private:
 	TypedArray<Dictionary> _get_connection_list() const;
 	Dictionary _get_closest_connection_at_point(const Vector2 &p_point, float p_max_distance = 4.0) const;
 	TypedArray<Dictionary> _get_connections_intersecting_with_rect(const Rect2 &p_rect) const;
+	TypedArray<Dictionary> _get_connection_list_from_node(const StringName &p_node) const;
 
 	Rect2 _compute_shrinked_frame_rect(const GraphFrame *p_frame);
 	void _set_drag_frame_attached_nodes(GraphFrame *p_frame, bool p_drag);


### PR DESCRIPTION
Replaces [Add `get_connection_list_from_port` function to `GraphEdit`](https://github.com/godotengine/godot/pull/100048).

Adds a way to get all connections for a specific node (Analogous to `connection_map`) as recommended by @Geometror https://github.com/godotengine/godot/pull/100048#issuecomment-2545061960

This should speed up the process of finding the right connections among `GraphEdit` nodes .

Example function to get all connections on a specific port using the new function:
```
func get_connection_list_from_port(node: StringName, port: int)->Array:
	var connection: Array = get_connection_list_from_node(node)
	var arr: Array
	for conn in connection:
		if conn["from_node"] == node and conn["from_port"] == port:
			var dict: Dictionary
			dict["node"] = conn["to_node"]
			dict["port"] = conn["to_port"]
			dict["type"] = "left"
			arr.push_back(dict)
		elif conn["to_node"] == node and conn["to_port"] == port:
			var dict: Dictionary
			dict["node"] = conn["from_node"]
			dict["port"] = conn["from_port"]
			dict["type"] = "right"
			arr.push_back(dict)
	return arr
```

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/11287*