### PR TITLE
Fix UID path remap

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1226,6 +1226,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 	} else {
 		// Try file remap.
 		// Usually, there's no remap file and FileAccess::exists() is faster than FileAccess::open().
+		new_path = ResourceUID::ensure_path(new_path);
 		if (FileAccess::exists(new_path + ".remap")) {
 			Error err;
 			Ref<FileAccess> f = FileAccess::open(new_path + ".remap", FileAccess::READ, &err);


### PR DESCRIPTION
Fixes invalid UID errors in https://github.com/godotengine/godot/pull/101441#pullrequestreview-2545212669 and https://github.com/godotengine/godot/issues/100943#issue-2763507031

I did not track source of these errors. They seem to have appeared recently, but they are also related to script preloading, so probably just couldn't happen before.