### PR TITLE
Add missing `TOOLS_ENABLED` block to `RetargetModifier3D`

### DIFF
--- a/scene/3d/retarget_modifier_3d.cpp
+++ b/scene/3d/retarget_modifier_3d.cpp
@@ -452,9 +452,11 @@ void RetargetModifier3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_update_child_skeletons();
 		} break;
+#ifdef TOOLS_ENABLED
 		case NOTIFICATION_EDITOR_PRE_SAVE: {
 			_reset_child_skeleton_poses();
 		} break;
+#endif // TOOLS_ENABLED
 		case NOTIFICATION_EXIT_TREE: {
 			_reset_child_skeletons();
 		} break;


### PR DESCRIPTION
The notification `NOTIFICATION_EDITOR_PRE_SAVE` must be used for editor only.