### PR TITLE
Change reset timing of the AnimationMixer and Skeleton on save

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1889,11 +1889,12 @@ void EditorNode::_save_scene(String p_file, int idx) {
 		return;
 	}
 
+	List<Pair<AnimationMixer *, Ref<AnimatedValuesBackup>>> anim_backups;
+	_reset_animation_mixers(scene, &anim_backups);
+
 	scene->propagate_notification(NOTIFICATION_EDITOR_PRE_SAVE);
 
 	editor_data.apply_changes_in_editors();
-	List<Pair<AnimationMixer *, Ref<AnimatedValuesBackup>>> anim_backups;
-	_reset_animation_mixers(scene, &anim_backups);
 	save_default_environment();
 
 	_save_editor_states(p_file, idx);

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -327,6 +327,12 @@ void Skeleton3D::_notification(int p_what) {
 			update_flags = UPDATE_FLAG_POSE;
 			_notification(NOTIFICATION_UPDATE_SKELETON);
 		} break;
+#ifdef TOOLS_ENABLED
+		case NOTIFICATION_EDITOR_PRE_SAVE: {
+			force_update_all_dirty_bones();
+			emit_signal(SceneStringName(skeleton_updated));
+		} break;
+#endif // TOOLS_ENABLED
 		case NOTIFICATION_UPDATE_SKELETON: {
 			// Update bone transforms to apply unprocessed poses.
 			force_update_all_dirty_bones();


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/95202

It should reset the AnimationMixer before notification and force the skeleton to update and fire the signal in the notification.