### PR TITLE
Force update RetargetModifier3D's child skeletons on save

### DIFF
--- a/scene/3d/retarget_modifier_3d.cpp
+++ b/scene/3d/retarget_modifier_3d.cpp
@@ -213,6 +213,19 @@ void RetargetModifier3D::_reset_child_skeletons() {
 	child_skeletons.clear();
 }
 
+#ifdef TOOLS_ENABLED
+void RetargetModifier3D::_force_update_child_skeletons() {
+	for (const RetargetInfo &E : child_skeletons) {
+		Skeleton3D *c = Object::cast_to<Skeleton3D>(ObjectDB::get_instance(E.skeleton_id));
+		if (!c) {
+			continue;
+		}
+		c->force_update_all_dirty_bones();
+		c->emit_signal(SceneStringName(skeleton_updated));
+	}
+}
+#endif // TOOLS_ENABLED
+
 /// General functions
 
 void RetargetModifier3D::add_child_notify(Node *p_child) {
@@ -452,9 +465,12 @@ void RetargetModifier3D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_update_child_skeletons();
 		} break;
+#ifdef TOOLS_ENABLED
 		case NOTIFICATION_EDITOR_PRE_SAVE: {
 			_reset_child_skeleton_poses();
+			_force_update_child_skeletons();
 		} break;
+#endif // TOOLS_ENABLED
 		case NOTIFICATION_EXIT_TREE: {
 			_reset_child_skeletons();
 		} break;

--- a/scene/3d/retarget_modifier_3d.h
+++ b/scene/3d/retarget_modifier_3d.h
@@ -70,6 +70,10 @@ private:
 	void _reset_child_skeleton_poses();
 	void _reset_child_skeletons();
 
+#ifdef TOOLS_ENABLED
+	void _force_update_child_skeletons();
+#endif // TOOLS_ENABLED
+
 	void cache_rests_with_reset();
 	void cache_rests();
 	Vector<RetargetBoneInfo> cache_bone_global_rests(Skeleton3D *p_skeleton);


### PR DESCRIPTION
- Related https://github.com/godotengine/godot/pull/101450

Calling reset is not enough. Especially if the child skelton has a BoneAttachment, it needs to be called force_update to fix the problem.