### PR TITLE
Wayland: Handle `fifo_v1` and clean up suspension logic

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -216,6 +216,10 @@ public:
 
 		struct zwp_text_input_manager_v3 *wp_text_input_manager = nullptr;
 		uint32_t wp_text_input_manager_name = 0;
+
+		// We're really not meant to use this one directly but we still need to know
+		// whether it's available.
+		uint32_t wp_fifo_manager_name = 0;
 	};
 
 	// General Wayland-specific states. Shouldn't be accessed directly.
@@ -1068,6 +1072,7 @@ public:
 	void set_frame();
 	bool get_reset_frame();
 	bool wait_frame_suspend_ms(int p_timeout);
+	bool is_fifo_available() const;
 
 	uint64_t window_get_last_frame_time(DisplayServer::WindowID p_window_id) const;
 	bool window_is_suspended(DisplayServer::WindowID p_window_id) const;


### PR DESCRIPTION
Before, the WSI was unfortunately quite broken and we had work around it by manually pacing frames. Needless to say it was not an ideal solution.

Now, the WSI can make use of the new fifo_v1 protocol to work properly. If it's available, we'll trust the WSI by disabling manual frame pacing.

While we're at it, let's clean up the suspension code a bit by removing some duplicated stuff and handling the suspension state through a switch case.

---

Note that fifo_v1 seems to be only used by the Vulkan WSI and not mesa's EGL implementation. For the time being the opengl backend will always manually throttle frames. I only found out about this while writing this PR.

As usual with this part of the backend, we need thorough testing for every combination. I did my best to try every compositor I could find but regular use with stuff like LSPs would be better.

Note that to try this new protocol you're going to need mesa starting from commit [63cbbf2a1c80742a4485417d984b1426b5262ac7](https://gitlab.freedesktop.org/mesa/mesa/-/commit/63cbbf2a1c80742a4485417d984b1426b5262ac7) and one of the following:

 - mutter commit starting from [fd39ca9f2096aea7d59fd9e4a774a05d6c8cb7d4](https://gitlab.gnome.org/GNOME/mutter/-/commit/fd39ca9f2096aea7d59fd9e4a774a05d6c8cb7d4)
 - kwin commit starting from [9a9443e0a2d6ec102f5de7235109f29e6be60c99](https://invent.kde.org/plasma/kwin/-/commit/9a9443e0a2d6ec102f5de7235109f29e6be60c99)
 - [jay compositor](https://github.com/mahkoh/jay) starting from version 1.7.0

There's also a WIP wlroots implementation but I had issues during my initial tests a month or two ago. If you want to play around with it it's over at MR [!4463](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4463)