### PR TITLE
Docs: Fix typo in `AudioStreamSynchronized`

### DIFF
--- a/modules/interactive_music/doc_classes/AudioStreamSynchronized.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamSynchronized.xml
@@ -4,7 +4,7 @@
 		Stream that can be fitted with sub-streams, which will be played in-sync.
 	</brief_description>
 	<description>
-		This is a stream that can be fitted with sub-streams, which will be played in-sync. The streams being at exactly the same time when play is pressed, and will end when the last of them ends. If one of the sub-streams loops, then playback will continue.
+		This is a stream that can be fitted with sub-streams, which will be played in-sync. The streams begin at exactly the same time when play is pressed, and will end when the last of them ends. If one of the sub-streams loops, then playback will continue.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Fix a typo ("being" -> "begin")

Context:

>The streams begin at exactly the same time when play is pressed

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
