### PR TITLE
Fix the use of `Object::_instance_bindings` when GDExtensions are uninitialized

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2159,6 +2159,9 @@ Object::~Object() {
 			for (uint32_t i = 0; i < _instance_binding_count; i++) {
 				gdextension_manager->untrack_instance_binding(_instance_bindings[i].token, this);
 			}
+		} else {
+			memfree(_instance_bindings);
+			_instance_bindings = nullptr;
 		}
 	}
 #endif


### PR DESCRIPTION
Fixes #101465