### PR TITLE
Show shortcut without events in tooltip if it has name

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -75,7 +75,7 @@
 			If [code]true[/code], the button will highlight for a short amount of time when its shortcut is activated. If [code]false[/code] and [member toggle_mode] is [code]false[/code], the shortcut will activate without any visual feedback.
 		</member>
 		<member name="shortcut_in_tooltip" type="bool" setter="set_shortcut_in_tooltip" getter="is_shortcut_in_tooltip_enabled" default="true">
-			If [code]true[/code], the button will add information about its shortcut in the tooltip.
+			If [code]true[/code], the button will add information about its shortcut in the tooltip. This includes the shortcut's events and its [member Resource.resource_name]. If both events and name are empty, the shortcut will not be included.
 			[b]Note:[/b] This property does nothing when the tooltip control is customized using [method Control._make_custom_tooltip].
 		</member>
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" default="false">

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -473,11 +473,21 @@ Control *BaseButton::make_custom_tooltip(const String &p_text) const {
 	if (control) {
 		return control;
 	}
-	if (!shortcut_in_tooltip || shortcut.is_null() || !shortcut->has_valid_event()) {
+
+	if (!shortcut_in_tooltip || shortcut.is_null()) {
 		return nullptr; // Use the default tooltip label.
 	}
 
-	String text = atr(shortcut->get_name()) + " (" + shortcut->get_as_text() + ")";
+	bool shortcut_has_events = shortcut->has_valid_event();
+	if (!shortcut_has_events && shortcut->get_name().is_empty()) {
+		return nullptr;
+	}
+
+	String text = atr(shortcut->get_name());
+	if (shortcut_has_events) {
+		text += " (" + shortcut->get_as_text() + ")";
+	}
+
 	if (!p_text.is_empty() && shortcut->get_name().nocasecmp_to(p_text) != 0) {
 		text += "\n" + atr(p_text);
 	}


### PR DESCRIPTION
If `shortcut_in_tooltip` is enabled, but a named Shortcut has no events, it will be not displayed.
This PR changes this behavior and the shortcut will show in tooltip if it has either events or name.

We have many cases of button tooltip texts equal to their shortcuts and special check for that. These can be now removed, as the shortcuts will display regardless.

Addresses https://github.com/godotengine/godot/pull/99949#issuecomment-2585880391