### PR TITLE
Add a method to get (global space) AABBs of collision shapes

### DIFF
--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -136,6 +136,14 @@
 				Returns the [Shape3D] with the given ID from the given shape owner.
 			</description>
 		</method>
+		<method name="shape_owner_get_shape_aabb" qualifiers="const">
+			<return type="AABB" />
+			<param index="0" name="owner_id" type="int" />
+			<param index="1" name="shape_id" type="int" />
+			<description>
+				Returns the world-space [AABB] with the given ID from the given shape owner.
+			</description>
+		</method>
 		<method name="shape_owner_get_shape_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="owner_id" type="int" />

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -356,6 +356,14 @@
 				Use [method body_add_shape] to add shapes to it, use [method body_set_state] to set its transform, and use [method body_set_space] to add the body to a space.
 			</description>
 		</method>
+		<method name="body_get_aabb" qualifiers="const">
+			<return type="AABB" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="shape" type="int" />
+			<description>
+				Returns the [AABB] of the nth shape of a body.
+			</description>
+		</method>
 		<method name="body_get_collision_layer" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -656,6 +656,13 @@ uint32_t GodotPhysicsServer3D::body_get_user_flags(RID p_body) const {
 	return 0;
 }
 
+AABB GodotPhysicsServer3D::body_get_aabb(RID p_body, int p_shape) const {
+	GodotBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, AABB());
+
+	return body->get_shape_aabb(p_shape);
+}
+
 void GodotPhysicsServer3D::body_set_param(RID p_body, PS3DE::BodyParameter p_param, const Variant &p_value) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -200,6 +200,8 @@ public:
 	virtual void body_set_user_flags(RID p_body, uint32_t p_flags) override;
 	virtual uint32_t body_get_user_flags(RID p_body) const override;
 
+	virtual AABB body_get_aabb(RID p_body, int p_shape) const override;
+
 	virtual void body_set_param(RID p_body, PS3DE::BodyParameter p_param, const Variant &p_value) override;
 	virtual Variant body_get_param(RID p_body, PS3DE::BodyParameter p_param) const override;
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -728,6 +728,18 @@ uint32_t JoltPhysicsServer3D::body_get_user_flags(RID p_body) const {
 	return 0;
 }
 
+AABB JoltPhysicsServer3D::body_get_aabb(RID p_body, int p_shape) const {
+	JoltBody3D *body = body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, AABB());
+
+	// Unlike Godot Physics, JoltBody3D::get_aabb() does not accept an index. Instead, it combines
+	// all of its shapes' AABBs into a single AABB. For parity, we manually retrieve and transform a
+	// single shape here.
+	//
+	// TODO: Check that this behaves as expected (not familiar with JoltPhysics).
+	return body->get_transform_scaled().xform(body->get_shape(p_shape)->get_aabb());
+}
+
 void JoltPhysicsServer3D::body_set_param(RID p_body, PS3DE::BodyParameter p_param, const Variant &p_value) {
 	JoltBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -245,6 +245,8 @@ public:
 	virtual void body_set_user_flags(RID p_body, uint32_t p_flags) override;
 	virtual uint32_t body_get_user_flags(RID p_body) const override;
 
+	virtual AABB body_get_aabb(RID p_body, int p_shape) const override;
+
 	virtual void body_set_param(RID p_body, PS3DE::BodyParameter p_param, const Variant &p_value) override;
 	virtual Variant body_get_param(RID p_body, PS3DE::BodyParameter p_param) const override;
 

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "scene/3d/physics/collision_shape_3d.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/3d/shape_3d.h"
 #include "scene/resources/mesh.h"
@@ -496,6 +497,7 @@ void CollisionObject3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shape_owner_remove_shape", "owner_id", "shape_id"), &CollisionObject3D::shape_owner_remove_shape);
 	ClassDB::bind_method(D_METHOD("shape_owner_clear_shapes", "owner_id"), &CollisionObject3D::shape_owner_clear_shapes);
 	ClassDB::bind_method(D_METHOD("shape_find_owner", "shape_index"), &CollisionObject3D::shape_find_owner);
+	ClassDB::bind_method(D_METHOD("shape_owner_get_shape_aabb", "owner_id", "shape_id"), &CollisionObject3D::shape_owner_get_shape_aabb);
 
 	GDVIRTUAL_BIND(_input_event, "camera", "event", "event_position", "normal", "shape_idx");
 	GDVIRTUAL_BIND(_mouse_enter);
@@ -653,6 +655,13 @@ int CollisionObject3D::shape_owner_get_shape_index(uint32_t p_owner, int p_shape
 	ERR_FAIL_INDEX_V(p_shape, shapes[p_owner].shapes.size(), -1);
 
 	return shapes[p_owner].shapes[p_shape].index;
+}
+
+AABB CollisionObject3D::shape_owner_get_shape_aabb(uint32_t p_owner, int p_shape) const {
+	ERR_FAIL_COND_V(!shapes.has(p_owner), AABB());
+	ERR_FAIL_INDEX_V(p_shape, shapes[p_owner].shapes.size(), AABB());
+
+	return PhysicsServer3D::get_singleton()->body_get_aabb(rid, shapes[p_owner].shapes[p_shape].index);
 }
 
 void CollisionObject3D::shape_owner_remove_shape(uint32_t p_owner, int p_shape) {

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -162,6 +162,7 @@ public:
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
 	Ref<Shape3D> shape_owner_get_shape(uint32_t p_owner, int p_shape) const;
 	int shape_owner_get_shape_index(uint32_t p_owner, int p_shape) const;
+	AABB shape_owner_get_shape_aabb(uint32_t p_owner, int p_shape) const;
 
 	void shape_owner_remove_shape(uint32_t p_owner, int p_shape);
 	void shape_owner_clear_shapes(uint32_t p_owner);

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -160,6 +160,8 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_collision_priority", "body", "priority"), &PhysicsServer3D::body_set_collision_priority);
 	ClassDB::bind_method(D_METHOD("body_get_collision_priority", "body"), &PhysicsServer3D::body_get_collision_priority);
 
+	ClassDB::bind_method(D_METHOD("body_get_aabb", "body", "shape"), &PhysicsServer3D::body_get_aabb);
+
 	ClassDB::bind_method(D_METHOD("body_add_shape", "body", "shape", "transform", "disabled"), &PhysicsServer3D::body_add_shape, DEFVAL(Transform3D()), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("body_set_shape", "body", "shape_idx", "shape"), &PhysicsServer3D::body_set_shape);
 	ClassDB::bind_method(D_METHOD("body_set_shape_transform", "body", "shape_idx", "transform"), &PhysicsServer3D::body_set_shape_transform);

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -190,6 +190,8 @@ public:
 	virtual void body_set_user_flags(RID p_body, uint32_t p_flags) = 0;
 	virtual uint32_t body_get_user_flags(RID p_body) const = 0;
 
+	virtual AABB body_get_aabb(RID p_body, int p_shape) const = 0;
+
 	// common body variables
 
 	virtual void body_set_param(RID p_body, PS3DE::BodyParameter p_param, const Variant &p_value) = 0;

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -255,6 +255,8 @@ public:
 	virtual void body_set_user_flags(RID p_body, uint32_t p_flags) override {}
 	virtual uint32_t body_get_user_flags(RID p_body) const override { return 0; }
 
+	virtual AABB body_get_aabb(RID p_body, int p_shape) const override { return AABB(); }
+
 	virtual void body_set_param(RID p_body, PS3DE::BodyParameter p_param, const Variant &p_value) override {}
 	virtual Variant body_get_param(RID p_body, PS3DE::BodyParameter p_param) const override { return Variant(); }
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -329,6 +329,8 @@ public:
 	EXBIND2(body_set_user_flags, RID, uint32_t)
 	EXBIND1RC(uint32_t, body_get_user_flags, RID)
 
+	EXBIND2RC(AABB, body_get_aabb, RID, int)
+
 	EXBIND3(body_set_param, RID, PS3DE::BodyParameter, const Variant &)
 	EXBIND2RC(Variant, body_get_param, RID, PS3DE::BodyParameter)
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -216,6 +216,8 @@ public:
 	FUNC2(body_set_user_flags, RID, uint32_t);
 	FUNC1RC(uint32_t, body_get_user_flags, RID);
 
+	FUNC2RC(AABB, body_get_aabb, RID, int);
+
 	FUNC3(body_set_param, RID, PS3DE::BodyParameter, const Variant &);
 	FUNC2RC(Variant, body_get_param, RID, PS3DE::BodyParameter);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This draft PR adds a new function to PhysicsServer3D, `body_get_aabb(RID p_body, int p_shape)`, to provide access to global space AABBs for collision shapes. The scope of this change was larger than expected, requiring changes to multiple files and systems that I'm not familiar with.

Before I begin to attempt the same for 2D, I'd like to review that the changes I've made so far are appropriate and perform as expected. This draft PR is for visibility and tracking.

This is also my first PR for Godot, is my first foray into the C++ side of Godot, and is the result of some weekend prototyping, so I'm not confident in its changes yet.

- [ ] Check that the "PhysicsServer3DWrapMT" changes are correct and appropriate
- [ ] Implement for 2D
- [ ] Write unit tests
- [ ] Update documentation for new method
- [ ] Checked against pre-commit hook
    - (It is installed and in-use, but pending 2D implementation before marking as finished)

Closes https://github.com/godotengine/godot-proposals/issues/3453