### PR TITLE
[RTL] Add cell option to control if cell is shrunk to its contents width.

### DIFF
--- a/core/extension/gdextension_special_compat_hashes.cpp
+++ b/core/extension/gdextension_special_compat_hashes.cpp
@@ -776,7 +776,7 @@ void GDExtensionSpecialCompatHashes::initialize() {
 		{ "push_paragraph", 3218895358, 3089306873 },
 		{ "push_list", 4036303897, 3017143144 },
 		{ "push_table", 1125058220, 2623499273 },
-		{ "set_table_column_expand", 4132157579, 2185176273 },
+		{ "set_table_column_expand", 4258957458, 2185176273 },
 #ifdef REAL_T_IS_DOUBLE
 		{ "add_image", 3346058748, 1507062345 },
 		{ "push_dropcap", 981432822, 763534173 },

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -597,6 +597,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="expand" type="bool" />
 			<param index="2" name="ratio" type="int" default="1" />
+			<param index="3" name="shrink" type="bool" default="true" />
 			<description>
 				Edits the selected column's expansion options. If [param expand] is [code]true[/code], the column expands in proportion to its expansion ratio versus the other columns' ratios.
 				For example, 2 columns with ratios 3 and 4 plus 70 pixels in available width would expand 30 and 40 pixels, respectively.

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -278,3 +278,10 @@ Validate extension JSON: JSON file: Field was added in a way that breaks compati
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/GPUParticles3D/methods/restart': arguments
 
 Added an optional keep_seed parameter to restart particles, to avoid modifying the seed to do particle seeking.
+
+
+GH-101482
+---------
+Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/set_table_column_expand/arguments': size changed value in new API, from 3 to 4.
+
+Added optional "shrink" argument. Compatibility method registered.

--- a/scene/gui/rich_text_label.compat.inc
+++ b/scene/gui/rich_text_label.compat.inc
@@ -30,6 +30,18 @@
 
 #ifndef DISABLE_DEPRECATED
 
+void RichTextLabel::_push_font_bind_compat_79053(const Ref<Font> &p_font, int p_size) {
+	push_font(p_font, p_size);
+}
+
+void RichTextLabel::_set_table_column_expand_bind_compat_79053(int p_column, bool p_expand, int p_ratio) {
+	set_table_column_expand(p_column, p_expand, p_ratio, true);
+}
+
+void RichTextLabel::_set_table_column_expand_bind_compat_101482(int p_column, bool p_expand, int p_ratio) {
+	set_table_column_expand(p_column, p_expand, p_ratio, true);
+}
+
 void RichTextLabel::_push_meta_bind_compat_99481(const Variant &p_meta, MetaUnderline p_underline_mode) {
 	push_meta(p_meta, p_underline_mode, String());
 }
@@ -47,6 +59,9 @@ bool RichTextLabel::_remove_paragraph_bind_compat_91098(int p_paragraph) {
 }
 
 void RichTextLabel::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("push_font", "font", "font_size"), &RichTextLabel::_push_font_bind_compat_79053);
+	ClassDB::bind_compatibility_method(D_METHOD("set_table_column_expand", "column", "expand", "ratio"), &RichTextLabel::_set_table_column_expand_bind_compat_79053);
+	ClassDB::bind_compatibility_method(D_METHOD("set_table_column_expand", "column", "expand", "ratio"), &RichTextLabel::_set_table_column_expand_bind_compat_101482, DEFVAL(1));
 	ClassDB::bind_compatibility_method(D_METHOD("push_meta", "data", "underline_mode"), &RichTextLabel::_push_meta_bind_compat_99481, DEFVAL(META_UNDERLINE_ALWAYS));
 	ClassDB::bind_compatibility_method(D_METHOD("push_meta", "data"), &RichTextLabel::_push_meta_bind_compat_89024);
 	ClassDB::bind_compatibility_method(D_METHOD("add_image", "image", "width", "height", "color", "inline_align", "region"), &RichTextLabel::_add_image_bind_compat_80410, DEFVAL(0), DEFVAL(0), DEFVAL(Color(1.0, 1.0, 1.0)), DEFVAL(INLINE_ALIGNMENT_CENTER), DEFVAL(Rect2()));

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -132,10 +132,13 @@ protected:
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED
+	void _push_font_bind_compat_79053(const Ref<Font> &p_font, int p_size);
+	void _set_table_column_expand_bind_compat_79053(int p_column, bool p_expand, int p_ratio);
 	void _push_meta_bind_compat_99481(const Variant &p_meta, MetaUnderline p_underline_mode);
 	void _push_meta_bind_compat_89024(const Variant &p_meta);
 	void _add_image_bind_compat_80410(const Ref<Texture2D> &p_image, const int p_width, const int p_height, const Color &p_color, InlineAlignment p_alignment, const Rect2 &p_region);
 	bool _remove_paragraph_bind_compat_91098(int p_paragraph);
+	void _set_table_column_expand_bind_compat_101482(int p_column, bool p_expand, int p_ratio);
 	static void _bind_compatibility_methods();
 #endif
 
@@ -339,6 +342,7 @@ private:
 	struct ItemTable : public Item {
 		struct Column {
 			bool expand = false;
+			bool shrink = true;
 			int expand_ratio = 0;
 			int min_width = 0;
 			int max_width = 0;
@@ -724,7 +728,7 @@ public:
 	void push_fgcolor(const Color &p_color);
 	void push_customfx(Ref<RichTextEffect> p_custom_effect, Dictionary p_environment);
 	void push_context();
-	void set_table_column_expand(int p_column, bool p_expand, int p_ratio = 1);
+	void set_table_column_expand(int p_column, bool p_expand, int p_ratio = 1, bool p_shrink = true);
 	void set_cell_row_background_color(const Color &p_odd_row_bg, const Color &p_even_row_bg);
 	void set_cell_border_color(const Color &p_color);
 	void set_cell_size_override(const Size2 &p_min_size, const Size2 &p_max_size);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/101462

Can be used to disable cell shrinking to contents:

```bbcode
[table=3]
[cell expand=10][left][bgcolor=darkred]10%[/bgcolor][/left][/cell]
[cell expand=60][center][bgcolor=darkgreen]60%[/bgcolor][/center][/cell]
[cell expand=30][right][bgcolor=darkblue]30%[/bgcolor][/right][/cell]
[/table]

[table=3]
[cell expand=10 shrink=false bg=white][left][bgcolor=darkred]10%[/bgcolor][/left][/cell]
[cell expand=60 shrink=false bg=yellow][center][bgcolor=darkgreen]60%[/bgcolor][/center][/cell]
[cell expand=30 shrink=false bg=pink][right][bgcolor=darkblue]30%[/bgcolor][/right][/cell]
[/table]

[table=3]
[cell=10][bgcolor=darkred]10%[/bgcolor][/cell]
[cell=60][bgcolor=darkgreen]60%[/bgcolor][/cell]
[cell=30][bgcolor=darkblue]30%[/bgcolor][/cell]
[cell]............................................................................................................................[/cell]
[cell]............................................................................................................................[/cell]
[cell]............................................................................................................................[/cell]
[/table]
````
<img width="841" alt="Screenshot 2025-01-13 at 10 09 21" src="https://github.com/user-attachments/assets/2f32e9e9-9d0b-4fba-a8e1-17f84c22422a" />
