### PR TITLE
Add `has_custom_data()` to TileData

### DIFF
--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -64,7 +64,7 @@
 			<return type="Variant" />
 			<param index="0" name="layer_name" type="String" />
 			<description>
-				Returns the custom data value for custom data layer named [param layer_name].
+				Returns the custom data value for custom data layer named [param layer_name]. To check if a custom data layer exists, use [method has_custom_data].
 			</description>
 		</method>
 		<method name="get_custom_data_by_layer_id" qualifiers="const">
@@ -120,6 +120,13 @@
 			<param index="0" name="peering_bit" type="int" enum="TileSet.CellNeighbor" />
 			<description>
 				Returns the tile's terrain bit for the given [param peering_bit] direction. To check that a direction is valid, use [method is_valid_terrain_peering_bit].
+			</description>
+		</method>
+		<method name="has_custom_data" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_name" type="String" />
+			<description>
+				Returns whether there exists a custom data layer named [param layer_name].
 			</description>
 		</method>
 		<method name="is_collision_polygon_one_way" qualifiers="const">

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -319,6 +319,13 @@
 				Returns if there is a coodinates-level proxy for the given identifiers.
 			</description>
 		</method>
+		<method name="has_custom_data_layer_by_name" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="layer_name" type="String" />
+			<description>
+				Returns if there is a custom data layer named [param layer_name].
+			</description>
+		</method>
 		<method name="has_source" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="source_id" type="int" />

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -1122,6 +1122,10 @@ void TileSet::set_custom_data_layer_name(int p_layer_id, String p_value) {
 	emit_changed();
 }
 
+bool TileSet::has_custom_data_layer_by_name(const String &p_value) const {
+	return custom_data_layers_by_name.has(p_value);
+}
+
 String TileSet::get_custom_data_layer_name(int p_layer_id) const {
 	ERR_FAIL_INDEX_V(p_layer_id, custom_data_layers.size(), "");
 	return custom_data_layers[p_layer_id].name;
@@ -4354,6 +4358,7 @@ void TileSet::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_custom_data_layer", "layer_index"), &TileSet::remove_custom_data_layer);
 	ClassDB::bind_method(D_METHOD("get_custom_data_layer_by_name", "layer_name"), &TileSet::get_custom_data_layer_by_name);
 	ClassDB::bind_method(D_METHOD("set_custom_data_layer_name", "layer_index", "layer_name"), &TileSet::set_custom_data_layer_name);
+	ClassDB::bind_method(D_METHOD("has_custom_data_layer_by_name", "layer_name"), &TileSet::has_custom_data_layer_by_name);
 	ClassDB::bind_method(D_METHOD("get_custom_data_layer_name", "layer_index"), &TileSet::get_custom_data_layer_name);
 	ClassDB::bind_method(D_METHOD("set_custom_data_layer_type", "layer_index", "layer_type"), &TileSet::set_custom_data_layer_type);
 	ClassDB::bind_method(D_METHOD("get_custom_data_layer_type", "layer_index"), &TileSet::get_custom_data_layer_type);
@@ -6636,6 +6641,11 @@ Variant TileData::get_custom_data(String p_layer_name) const {
 	return get_custom_data_by_layer_id(p_layer_id);
 }
 
+bool TileData::has_custom_data(const String &p_layer_name) const {
+	ERR_FAIL_NULL_V(tile_set, false);
+	return tile_set->has_custom_data_layer_by_name(p_layer_name);
+}
+
 void TileData::set_custom_data_by_layer_id(int p_layer_id, Variant p_value) {
 	ERR_FAIL_INDEX(p_layer_id, custom_data.size());
 	custom_data.write[p_layer_id] = p_value;
@@ -7116,6 +7126,7 @@ void TileData::_bind_methods() {
 	// Custom data.
 	ClassDB::bind_method(D_METHOD("set_custom_data", "layer_name", "value"), &TileData::set_custom_data);
 	ClassDB::bind_method(D_METHOD("get_custom_data", "layer_name"), &TileData::get_custom_data);
+	ClassDB::bind_method(D_METHOD("has_custom_data", "layer_name"), &TileData::has_custom_data);
 	ClassDB::bind_method(D_METHOD("set_custom_data_by_layer_id", "layer_id", "value"), &TileData::set_custom_data_by_layer_id);
 	ClassDB::bind_method(D_METHOD("get_custom_data_by_layer_id", "layer_id"), &TileData::get_custom_data_by_layer_id);
 

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -491,6 +491,7 @@ public:
 	void remove_custom_data_layer(int p_index);
 	int get_custom_data_layer_by_name(String p_value) const;
 	void set_custom_data_layer_name(int p_layer_id, String p_value);
+	bool has_custom_data_layer_by_name(const String &p_value) const;
 	String get_custom_data_layer_name(int p_layer_id) const;
 	void set_custom_data_layer_type(int p_layer_id, Variant::Type p_value);
 	Variant::Type get_custom_data_layer_type(int p_layer_id) const;
@@ -999,6 +1000,7 @@ public:
 	// Custom data.
 	void set_custom_data(String p_layer_name, Variant p_value);
 	Variant get_custom_data(String p_layer_name) const;
+	bool has_custom_data(const String &p_layer_name) const;
 	void set_custom_data_by_layer_id(int p_layer_id, Variant p_value);
 	Variant get_custom_data_by_layer_id(int p_layer_id) const;
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This PR adds the method `has_custom_data` to `TileData`, allowing users to check if a data layer exists or not.

Closes https://github.com/godotengine/godot-proposals/issues/11317
