### PR TITLE
[3.6] Change order of `find_vc_pdir` arguments

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -798,7 +798,7 @@ def find_visual_c_batch_file(env):
     # Scons 4.6.0+ removed passing env, so we need to get the product_dir ourselves first,
     # then pass that as the last param instead of env as the first param as before.
     # We should investigate if we can avoid relying on SCons internals here.
-    product_dir = find_vc_pdir(env, msvc_version)
+    product_dir = find_vc_pdir(msvc_version, env)
     return find_batch_file(msvc_version, host_platform, target_platform, product_dir)[0]
 
 


### PR DESCRIPTION
```
Dadaskis@HOME-PC MINGW64 /c/GodotGit/godot (dadaskis_find_vc_pdir_vcproj_fix)
$ scons platform=windows vsproj=yes
scons: Reading SConscript files ...
Auto-detected 4 CPU cores available for build parallelism. Using 4 cores by default. You can override it with the -j argument.
Configuring for Windows: target=debug, bits=default
Found MSVC version 14.3, arch amd64, bits=64
Note: Building a debug binary (which will run slowly). Use `target=release_debug` to build an optimized release binary.
AttributeError: 'str' object has no attribute 'get':
  File "C:\GodotGit\godot\SConstruct", line 769:
    methods.generate_vs_project(env, GetOption("num_jobs"))
  File "C:\GodotGit\godot\methods.py", line 847:
    batch_file = find_visual_c_batch_file(env)
  File "C:\GodotGit\godot\methods.py", line 801:
    product_dir = find_vc_pdir(env, msvc_version)
  File "C:\Users\Dadaskis\AppData\Local\Programs\Python\Python312\Lib\site-packages\SCons\Tool\MSCommon\vc.py", line 1733:
    frozen_binary, _ = _VSWhereExecutable.vswhere_freeze_env(env)
  File "C:\Users\Dadaskis\AppData\Local\Programs\Python\Python312\Lib\site-packages\SCons\Tool\MSCommon\vc.py", line 1209:
    elif not env.get('VSWHERE'):

Dadaskis@HOME-PC MINGW64 /c/GodotGit/godot (dadaskis_find_vc_pdir_vcproj_fix)
$
```

I wanted to get Visual Studio solution file by using `scons platform=windows vsproj=yes` as it was said in documentation, however, i got an error here. After investigation, i found that one of the functions got its arguments swapped, so i decided to make a little fix in methods.py that would resolve this issue.

The only problem though, i'm not sure if this is a good fix, and if it is applicable to master branch, i was mostly interested to compile 3.6 only hence why i am making this pull request.
