### PR TITLE
Expose OpenXR action handles to GDExtension

### DIFF
--- a/modules/openxr/doc_classes/OpenXRAPIExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRAPIExtension.xml
@@ -17,6 +17,13 @@
 		<link title="XrPosef documentation">https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrPosef.html</link>
 	</tutorials>
 	<methods>
+		<method name="action_get_handle">
+			<return type="int" />
+			<param index="0" name="action" type="RID" />
+			<description>
+				Returns the corresponding [code]XrAction[/code] OpenXR handle for the given action RID.
+			</description>
+		</method>
 		<method name="begin_debug_label_region">
 			<return type="void" />
 			<param index="0" name="label_name" type="String" />
@@ -34,6 +41,14 @@
 			<return type="void" />
 			<description>
 				Marks the end of a debug label region. Removes the latest debug label region added by calling [method begin_debug_label_region].
+			</description>
+		</method>
+		<method name="find_action">
+			<return type="RID" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="action_set" type="RID" />
+			<description>
+				Returns the [RID] corresponding to an [code]Action[/code] of a matching name, optionally limited to a specified action set.
 			</description>
 		</method>
 		<method name="get_error_string">

--- a/modules/openxr/openxr_api_extension.cpp
+++ b/modules/openxr/openxr_api_extension.cpp
@@ -56,6 +56,9 @@ void OpenXRAPIExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_next_frame_time"), &OpenXRAPIExtension::get_next_frame_time);
 	ClassDB::bind_method(D_METHOD("can_render"), &OpenXRAPIExtension::can_render);
 
+	ClassDB::bind_method(D_METHOD("find_action", "name", "action_set"), &OpenXRAPIExtension::find_action);
+	ClassDB::bind_method(D_METHOD("action_get_handle", "action"), &OpenXRAPIExtension::action_get_handle);
+
 	ClassDB::bind_method(D_METHOD("get_hand_tracker", "hand_index"), &OpenXRAPIExtension::get_hand_tracker);
 
 	ClassDB::bind_method(D_METHOD("register_composition_layer_provider", "extension"), &OpenXRAPIExtension::register_composition_layer_provider);
@@ -195,6 +198,17 @@ int64_t OpenXRAPIExtension::get_next_frame_time() {
 bool OpenXRAPIExtension::can_render() {
 	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), false);
 	return OpenXRAPI::get_singleton()->can_render();
+}
+
+RID OpenXRAPIExtension::find_action(const String &p_name, const RID &p_action_set) {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), RID());
+	return OpenXRAPI::get_singleton()->find_action(p_name, p_action_set);
+}
+
+uint64_t OpenXRAPIExtension::action_get_handle(RID p_action) {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), 0);
+	XrAction action_hanlde = OpenXRAPI::get_singleton()->action_get_handle(p_action);
+	return reinterpret_cast<uint64_t>(action_hanlde);
 }
 
 uint64_t OpenXRAPIExtension::get_hand_tracker(int p_hand_index) {

--- a/modules/openxr/openxr_api_extension.h
+++ b/modules/openxr/openxr_api_extension.h
@@ -76,6 +76,9 @@ public:
 	int64_t get_next_frame_time();
 	bool can_render();
 
+	RID find_action(const String &p_name, const RID &p_action_set = RID());
+	uint64_t action_get_handle(RID p_action);
+
 	uint64_t get_hand_tracker(int p_hand_index);
 
 	void register_composition_layer_provider(OpenXRExtensionWrapperExtension *p_extension);


### PR DESCRIPTION
This PR exposes two `OpenXRAPI` functions for use with GDExtension: `find_action()` and `action_get_handle()`. This makes it so that an extension could get the OpenXR `XrAction` handle for a corresponding action by searching for the actions name.

Getting access to action handles would be useful in the context of the [XR_FB_haptic_amplitude_envelope](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_haptic_amplitude_envelope) and [XR_FB_haptic_pcm](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_FB_haptic_pcm) OpenXR extensions, as both extensions require access to the action handle for haptic output.