### PR TITLE
Resource importer scene: Don't validate save paths when they are UIDs

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2874,7 +2874,9 @@ Error ResourceImporterScene::_check_resource_save_paths(const Dictionary &p_data
 		if (bool(settings.get("save_to_file/enabled", false)) && settings.has("save_to_file/path")) {
 			const String &save_path = settings["save_to_file/path"];
 
-			ERR_FAIL_COND_V(!save_path.is_empty() && !DirAccess::exists(save_path.get_base_dir()), ERR_FILE_BAD_PATH);
+			if (!save_path.begins_with("uid://")) {
+				ERR_FAIL_COND_V(!save_path.is_empty() && !DirAccess::exists(save_path.get_base_dir()), ERR_FILE_BAD_PATH);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #101256
Fixes #99573

Ensures that the parent path validation only occurs when the path isn't a UID.