### PR TITLE
OpenGL3 renderer supports transparent boot splash

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -470,9 +470,9 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 	glViewport(0, 0, win_size.width, win_size.height);
 	glEnable(GL_BLEND);
-	glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
+	glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE);
 	glDepthMask(GL_FALSE);
-	glClearColor(p_color.r, p_color.g, p_color.b, 1.0);
+	glClearColor(p_color.r, p_color.g, p_color.b, OS::get_singleton()->is_layered_allowed() ? p_color.a : 1.0);
 	glClear(GL_COLOR_BUFFER_BIT);
 
 	RID texture = texture_storage->texture_allocate();


### PR DESCRIPTION
A little strange why opacity was forced before? The `gl_compatibility` renderer now supports a startup background color with transparency like other renderers.
Project settings:
![屏幕截图_20250114_045011](https://github.com/user-attachments/assets/9cfcdded-ad31-4823-b230-78d925b17a00)

forward+:
![屏幕截图_20250114_045153](https://github.com/user-attachments/assets/7d7a3136-4eaf-4c9e-ba96-3d0c1712d576)

master gl_compatibility:
![屏幕截图_20250114_045647](https://github.com/user-attachments/assets/b3e986a7-4b4c-4f9e-94dc-67bdaa01aeca)

this pr gl_compatibility:
![屏幕截图_20250114_055759](https://github.com/user-attachments/assets/6dbe2de2-b7f9-4304-afc0-8d8cbc157915)
