### PR TITLE
Optimize AgX tonemapper's handling of negative values

### DIFF
--- a/drivers/gles3/shaders/tonemap_inc.glsl
+++ b/drivers/gles3/shaders/tonemap_inc.glsl
@@ -86,7 +86,7 @@ vec3 tonemap_aces(vec3 color, float p_white) {
 
 // Polynomial approximation of EaryChow's AgX sigmoid curve.
 // x must be within the range [0.0, 1.0]
-vec3 agx_default_contrast_approx(vec3 x) {
+vec3 agx_contrast_approx(vec3 x) {
 	// Generated with Excel trendline
 	// Input data: Generated using python sigmoid with EaryChow's configuration and 57 steps
 	// Additional padding values were added to give correct intersections at 0.0 and 1.0
@@ -96,25 +96,21 @@ vec3 agx_default_contrast_approx(vec3 x) {
 	return 0.021 * x + 4.0111 * x2 - 25.682 * x2 * x + 70.359 * x4 - 74.778 * x4 * x + 27.069 * x4 * x2;
 }
 
-const mat3 LINEAR_SRGB_TO_LINEAR_REC2020 = mat3(
-		vec3(0.6274, 0.0691, 0.0164),
-		vec3(0.3293, 0.9195, 0.0880),
-		vec3(0.0433, 0.0113, 0.8956));
-
 // This is an approximation and simplification of EaryChow's AgX implementation that is used by Blender.
 // This code is based off of the script that generates the AgX_Base_sRGB.cube LUT that Blender uses.
 // Source: https://github.com/EaryChow/AgX_LUT_Gen/blob/main/AgXBasesRGB.py
 vec3 tonemap_agx(vec3 color) {
-	const mat3 agx_inset_matrix = mat3(
-			0.856627153315983, 0.137318972929847, 0.11189821299995,
-			0.0951212405381588, 0.761241990602591, 0.0767994186031903,
-			0.0482516061458583, 0.101439036467562, 0.811302368396859);
+	// Combined linear sRGB to linear Rec 2020 and Blender AgX inset matrices:
+	const mat3 srgb_to_rec2020_agx_inset_matrix = mat3(
+			0.54490813676363087053, 0.14044005884001287035, 0.088827411851915368603,
+			0.37377945959812267119, 0.75410959864013760045, 0.17887712465043811023,
+			0.081384976686407536266, 0.10543358536857773485, 0.73224999956948382528);
 
 	// Combined inverse AgX outset matrix and linear Rec 2020 to linear sRGB matrices.
 	const mat3 agx_outset_rec2020_to_srgb_matrix = mat3(
-			1.9648846919172409596, -0.29937618452442253746, -0.16440106280678278299,
-			-0.85594737466675834968, 1.3263980951083531115, -0.23819967517076844919,
-			-0.10883731725048386702, -0.02702191058393112346, 1.4025007379775505276);
+			1.9645509602733325934, -0.29932243390911083839, -0.16436833806080403409,
+			-0.85585845117807513559, 1.3264510741502356555, -0.23822464068860595117,
+			-0.10886710826831608324, -0.027084020983874825605, 1.402665347143271889);
 
 	// LOG2_MIN      = -10.0
 	// LOG2_MAX      =  +6.5
@@ -122,26 +118,32 @@ vec3 tonemap_agx(vec3 color) {
 	const float min_ev = -12.4739311883324; // log2(pow(2, LOG2_MIN) * MIDDLE_GRAY)
 	const float max_ev = 4.02606881166759; // log2(pow(2, LOG2_MAX) * MIDDLE_GRAY)
 
-	// Do AGX in rec2020 to match Blender.
-	color = LINEAR_SRGB_TO_LINEAR_REC2020 * color;
+	// Large negative values in one channel and large positive values in other
+	// channels can result in a colour that appears darker and more saturated than
+	// desired after passing it through the inset matrix. For this reason, it is
+	// best to prevent negative input values.
+	// This is done before the Rec. 2020 transform to allow the Rec. 2020
+	// transform to be combined with the AgX inset matrix. This results in a loss
+	// of color information that could be correctly interpreted within the
+	// Rec. 2020 color space as positive RGB values, but it is less common for Godot
+	// to provide this function with negative sRGB values and therefore not worth
+	// the performance cost of an additional matrix multiplication.
+	// A value of 2e-10 intentionally introduces insignificant error to prevent
+	// log2(0.0) after the inset matrix is applied; color will be >= 1e-10 after
+	// the matrix transform.
+	color = max(color, 2e-10);
 
-	// Preventing negative values is required for the AgX inset matrix to behave correctly.
-	// This could also be done before the Rec. 2020 transform, allowing the transform to
-	// be combined with the AgX inset matrix, but doing this causes a loss of color information
-	// that could be correctly interpreted within the Rec. 2020 color space.
-	color = max(color, vec3(0.0));
-
-	color = agx_inset_matrix * color;
+	// Do AGX in rec2020 to match Blender and then apply inset matrix.
+	color = srgb_to_rec2020_agx_inset_matrix * color;
 
 	// Log2 space encoding.
-	color = max(color, 1e-10); // Prevent log2(0.0). Possibly unnecessary.
-	// Must be clamped because agx_blender_default_contrast_approx may not work
+	// Must be clamped because agx_contrast_approx may not work
 	// well with values outside of the range [0.0, 1.0]
 	color = clamp(log2(color), min_ev, max_ev);
 	color = (color - min_ev) / (max_ev - min_ev);
 
 	// Apply sigmoid function approximation.
-	color = agx_default_contrast_approx(color);
+	color = agx_contrast_approx(color);
 
 	// Convert back to linear before applying outset matrix.
 	color = pow(color, vec3(2.4));
@@ -149,9 +151,9 @@ vec3 tonemap_agx(vec3 color) {
 	// Apply outset to make the result more chroma-laden and then go back to linear sRGB.
 	color = agx_outset_rec2020_to_srgb_matrix * color;
 
-	// Simply hard clip instead of Blender's complex lusRGB.compensate_low_side.
-	color = max(color, vec3(0.0));
-
+	// Blender's lusRGB.compensate_low_side is too complex for this shader, so
+	// simply return the color, even if it has negative components. These negative
+	// components may be useful for subsequent color adjustments.
 	return color;
 }
 


### PR DESCRIPTION
This PR has three parts:

1. Remove `max` call by introducing insignificant error.
2. Remove unnecessary final negative clipping.
3. Remove support for negative sRGB input values.

I can separate these into two separate PRs if that is preferred, as the first two parts are simply optimizations and improvements while the third part affects how renders appear for some scenarios.

### 1. Remove `max` call by introducing error

Both the Rec. 2020 and Blender AgX inset matrices are entirely positive values. This makes it quite easy to reason about them. For the [`log2` function](https://registry.khronos.org/OpenGL-Refpages/gl4/html/log2.xhtml):

> The result is undefined if x≤0

To prevent undefined behaviour, I originally had a separate `color = max(color, 1e-10)`, but I've realized that I can simply add an insignificant error to the RGB value to ensure that, even after the color is transformed, it will still be a positive non-zero value:

```
// A value of 2e-10 intentionally introduces insignificant error to prevent
// log2(0.0) after the inset matrix is applied. color will be >= 1e-10 after
// the matrix.
color = max(color, 2e-10);

color = agx_inset_matrix * color;

color = clamp(log2(color), min_ev, max_ev);
```

I have reviewed images generated with this change in all three renderers and compared them to the current `master` build. I could not find a single pixel in any of the images that was different, even by a single bit in a 24-bit sRGB gamma space image. If my reasoning and math is correct, I believe this is a safe and simple optimization. Given that tonemapping functions like this one are typically hard-coded to specific matrices and do not change over time with new versions of the engine, I don't see the increased complexity of changing matrices in the code to be a downside.

| `master` | Insignificant error added
| --- | ---
| ![image](https://github.com/user-attachments/assets/b7e8d4e6-1df4-4a48-8e7f-78930d9a47f1) | ![image](https://github.com/user-attachments/assets/cb65731d-d715-4ab0-929f-a8b213613153)

### 2. Remove unnecessary final clipping

In Blender's AgX LUT generation, the final tonemapped value is put through the complex `lusRGB.compensate_low_side` function. This function takes the negative values and smoothly converts them to non-negative values, while maintaining vibrancy to the colours. Since we cannot implement this function in a realtime shader, it actually makes most sense to simply return the negative RGB values from this tone mapping function. This way, the hue of the final color is not affected by clipping and the value will be better suited for post processing effects. In the end, if it remains negative it will be clipped when it is presented to the user anyway.

To further support this decision to remove this final clipping, the existing ACES tone mapper also returns negative values, even when the input is entirely positive sRGB values. In the following images, any RGB value returned from the tonemapper less than `-1e-6` is highlighted as green:

| ACES | AgX without final clipping
| --- | ---
| ![image](https://github.com/user-attachments/assets/e647ade3-c81f-4072-a476-81cff75b0c4d) | ![image](https://github.com/user-attachments/assets/f8d34930-e226-47ca-bcf8-02d4d3648370)

### 3. Remove support for negative sRGB input values

This change improves performance of the AgX tonemapper by allowing two matrix multiplications to be combined into one. This comes at the cost of loss of color information that could be correctly interpreted as positive RGB values in the Rec. 2020 color space.

Negative input values are most common with HDR images (such as an HDR skybox?) or negative lights. There might be other scenarios, so please comment if you know of any. Currently, no tonemapper except for the Linear tonemapper supports negative RGB input values.

The decision was made to use a highly simplified version of Blender's AgX that removes the logic that prevents hue shifts. Additionally, smooth handling of negative input and output values (`lusRGB.compensate_low_side`) is not included in Godot's AgX. To get these features, a LUT texture and a new custom tonemapping feature must be added to Godot. I believe that removing support for negative input values is in the spirit of the decisions that were made up until this point. I expect only a few users would truly benefit and prefer Godot's AgX to support negative input values that can be represented as positive values in Rec. 2020 space. It seems wrong to add an extra matrix multiplication that would benefit few users.

This change has no impact on many actual game project renders in the Forward+ renderer, because it seems uncommon for substantial (`< -0.01`) negative RGB values to be given as an input to the tonemapping function outside of the examples I gave...

I can write more and provide comparison images, but I'd rather get this PR published sooner rather than later.

### Other notes
I also regenerated both combined matrices to ensure the colour space conversions match accurately. The original rec 709 to 2020 and vice-versa matrices were of low precision, so I recalculated them using the high precision matrices from Blender/EaryChow's code.