### PR TITLE
Fix theme options in project manager incorrectly using translated text

### DIFF
--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -97,6 +97,7 @@ void QuickSettingsDialog::_update_current_values() {
 			if (current_theme == theme_value) {
 				theme_option_button->set_text(current_theme);
 				theme_option_button->select(i);
+				theme_option_button->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 
 				custom_theme_label->set_visible(current_theme == "Custom");
 			}


### PR DESCRIPTION
In the editor settings, the theme option is to use the theme name directly as shown below:
![p1](https://github.com/user-attachments/assets/9fe147e2-7bd5-4d48-b393-f7d3a4115e88)


And in the Project Manager, the theme options use the translated text, which is inconsistent with the above:
![p2](https://github.com/user-attachments/assets/dba98766-f934-4c7a-95a8-0022a24504c5)

This PR will make the presentation in the Project Manager consistent with the editor settings.