### PR TITLE
Add comment clarifying server multithreading macro nomenclature

### DIFF
--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -41,7 +41,7 @@
 #endif
 
 // Macros for wrapping multithreaded server calls.
-// - FUNC{n} is a straightforward call with no return type that takes n arguments (implicitly C given that n is 0).
+// - FUNC{n} is a straightforward call with no return type that takes n arguments.
 // - FUNC{n}R is a call to a method with a return type.
 // - FUNC{n}S is a call to a method that requires synchronization with the main thread.
 // - FUNC{n}C is const, indicating that the method does not mutate internal server state.

--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -41,7 +41,7 @@
 #endif
 
 // Macros for wrapping multithreaded server calls.
-// - FUNC{n} is a straightforward call w/no return type that takes n arguments (implicitly C given that n is 0).
+// - FUNC{n} is a straightforward call with no return type that takes n arguments (implicitly C given that n is 0).
 // - FUNC{n}R is a call to a method with a return type.
 // - FUNC{n}S is a call to a method that requires synchronization with the main thread.
 // - FUNC{n}C is const, indicating that the method does not mutate internal server state.

--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -28,12 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-// Macros for wrapping multithreaded server calls.
-// - FUNC{n} is a straightforward call w/no return type that takes n arguments (implicitly C given that n is 0).
-// - FUNC{n}R is a call to a method with a return type.
-// - FUNC{n}S is a call to a method that requires synchronization with the main thread.
-// - FUNC{n}C is const, indicating that the method does not mutate internal server state.
-
 #ifndef SERVER_WRAP_MT_COMMON_H
 #define SERVER_WRAP_MT_COMMON_H
 
@@ -45,6 +39,12 @@
 #else
 #define MAIN_THREAD_SYNC_CHECK
 #endif
+
+// Macros for wrapping multithreaded server calls.
+// - FUNC{n} is a straightforward call w/no return type that takes n arguments (implicitly C given that n is 0).
+// - FUNC{n}R is a call to a method with a return type.
+// - FUNC{n}S is a call to a method that requires synchronization with the main thread.
+// - FUNC{n}C is const, indicating that the method does not mutate internal server state.
 
 #define FUNC0R(m_r, m_type)                                                     \
 	virtual m_r m_type() override {                                             \

--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -28,6 +28,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+// Macros for wrapping multithreaded server calls.
+// - FUNC{n} is a straightforward call w/no return type that takes n arguments (implicitly C given that n is 0).
+// - FUNC{n}R is a call to a method with a return type.
+// - FUNC{n}S is a call to a method that requires synchronization with the main thread.
+// - FUNC{n}C is const, indicating that the method does not mutate internal server state.
+
 #ifndef SERVER_WRAP_MT_COMMON_H
 #define SERVER_WRAP_MT_COMMON_H
 


### PR DESCRIPTION
Added comment clarifying macro nomenclature in servers/server_wrap_mt_common.h

> Macros for wrapping multithreaded server calls.
> - FUNC{n} is a straightforward call w/no return type that takes n arguments (implicitly C given that n is 0).
> - FUNC{n}R is a call to a method with a return type.
> - FUNC{n}S is a call to a method that requires synchronization with the main thread.
> - FUNC{n}C is const, indicating that the method does not mutate internal server state.
