### PR TITLE
Add MeshInstance3D primitive conversion options

### DIFF
--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.h
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.h
@@ -63,6 +63,18 @@ class MeshInstance3DEditor : public Control {
 		SHAPE_TYPE_SINGLE_CONVEX,
 		SHAPE_TYPE_SIMPLIFIED_CONVEX,
 		SHAPE_TYPE_MULTIPLE_CONVEX,
+		SHAPE_TYPE_BOUNDING_BOX,
+		SHAPE_TYPE_CAPSULE,
+		SHAPE_TYPE_CYLINDER,
+		SHAPE_TYPE_SPHERE,
+		SHAPE_TYPE_PRIMITIVE,
+	};
+
+	enum ShapeAxis {
+		SHAPE_AXIS_X,
+		SHAPE_AXIS_Y,
+		SHAPE_AXIS_Z,
+		SHAPE_AXIS_LONGEST,
 	};
 
 	MeshInstance3D *node = nullptr;
@@ -75,6 +87,9 @@ class MeshInstance3DEditor : public Control {
 	ConfirmationDialog *shape_dialog = nullptr;
 	OptionButton *shape_type = nullptr;
 	OptionButton *shape_placement = nullptr;
+	Label *shape_axis_label = nullptr;
+	OptionButton *shape_axis = nullptr;
+	Transform3D shape_offset_transform;
 
 	AcceptDialog *err_dialog = nullptr;
 
@@ -85,6 +100,8 @@ class MeshInstance3DEditor : public Control {
 
 	ConfirmationDialog *navigation_mesh_dialog = nullptr;
 
+	void _shape_dialog_about_to_popup();
+	void _shape_type_selected(int p_option);
 	void _create_collision_shape();
 	Vector<Ref<Shape3D>> create_shape_from_mesh(Ref<Mesh> p_mesh, int p_option, bool p_verbose);
 	void _menu_option(int p_option);


### PR DESCRIPTION
- closes https://github.com/godotengine/godot-proposals/issues/9685
- closes https://github.com/godotengine/godot-proposals/issues/10802
- closes https://github.com/godotengine/godot-proposals/issues/5868

Adds Bounding Box, Capsule, Cylinder, Sphere, and Primitive options. 

![image](https://github.com/user-attachments/assets/7d7ba100-21c8-49e4-badf-839bf6aa6d9f)

The primitive option is only enabled when a supported PrimitiveMesh is selected. This will make the corresponding collision shape. When multiple meshes are selected, each PrimitiveMesh will create their own shape and all others will do nothing.
The other options first check for their corresponding PrimitiveMesh, and if it is not found the mesh AABB is used instead.
I didn't call the Bounding Box option AABB since we don't have an AABB collision shape type. It uses a box and it may be rotated so I thought it could be misleading.
I made sure that the collision shape node will be offset to match the AABB.
The sphere radius is based on the longest axis. 

When Capsule or Cylinder is selected an axis option will show, to allow you to configure the long axis of it. The longest axis is the default. I could add a shortest axis option if it is wanted.

![image](https://github.com/user-attachments/assets/70d1b3f4-acb6-416d-b139-987b94e0962a)
