### PR TITLE
Fix serve.py stuck before serving files

### DIFF
--- a/platform/web/serve.py
+++ b/platform/web/serve.py
@@ -32,7 +32,7 @@ def shell_open(url):
         os.startfile(url)
     else:
         opener = "open" if sys.platform == "darwin" else "xdg-open"
-        subprocess.call([opener, url])
+        subprocess.Popen([opener, url])
 
 
 def serve(root, port, run_browser):


### PR DESCRIPTION
I'm running `serve.py` on Ubuntu 24.04 from command line to serve a project.
When browser is opened by serve.py, script is stuck at subprocess.call and doesn't serve files.
I replaced subprocess.call() with nonblocking function subprocess.Popen()

