### PR TITLE
Fix SpringBone gizmo updating with independent joint setter

### DIFF
--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -853,6 +853,9 @@ void SpringBoneSimulator3D::set_joint_radius(int p_index, int p_joint, float p_r
 	Vector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, joints.size());
 	joints[p_joint]->radius = p_radius;
+#ifdef TOOLS_ENABLED
+	update_gizmos();
+#endif // TOOLS_ENABLED
 }
 
 float SpringBoneSimulator3D::get_joint_radius(int p_index, int p_joint) const {


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/101409

Lacking gizmo update in case of independent config of joint radius.