### PR TITLE
Fix shifted joint radius index in SpringBone gizmo and remove unused `end_bone_tip_radius` property

### DIFF
--- a/doc/classes/SpringBoneSimulator3D.xml
+++ b/doc/classes/SpringBoneSimulator3D.xml
@@ -126,13 +126,6 @@
 				Returns the end bone name of the bone chain.
 			</description>
 		</method>
-		<method name="get_end_bone_tip_radius" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="index" type="int" />
-			<description>
-				Returns the end bone tip radius of the bone chain when [method is_end_bone_extended] is [code]true[/code].
-			</description>
-		</method>
 		<method name="get_exclude_collision_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
@@ -421,14 +414,6 @@
 				[b]Note:[/b] End bone must be the root bone or a child of the root bone. If they are the same, the tail must be extended by [method set_extend_end_bone] to jiggle the bone.
 			</description>
 		</method>
-		<method name="set_end_bone_tip_radius">
-			<return type="void" />
-			<param index="0" name="index" type="int" />
-			<param index="1" name="radius" type="float" />
-			<description>
-				Sets the end bone tip radius of the bone chain when [method is_end_bone_extended] is [code]true[/code].
-			</description>
-		</method>
 		<method name="set_exclude_collision_count">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
@@ -452,6 +437,8 @@
 			<param index="1" name="enabled" type="bool" />
 			<description>
 				If [param enabled] is [code]true[/code], the end bone is extended to have the tail.
+				The extended tail config is allocated to the last element in the joint list.
+				In other words, if you set [param enabled] is [code]false[/code], the config of last element in the joint list has no effect in the simulated result.
 			</description>
 		</method>
 		<method name="set_gravity">

--- a/editor/plugins/gizmos/spring_bone_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/spring_bone_3d_gizmo_plugin.cpp
@@ -140,7 +140,7 @@ Ref<ArrayMesh> SpringBoneSimulator3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_s
 				Transform3D parent_global_pose = p_skeleton->get_bone_global_rest(prev_bone);
 				Transform3D global_pose = p_skeleton->get_bone_global_rest(current_bone);
 				draw_line(surface_tool, parent_global_pose.origin, global_pose.origin, bone_color);
-				draw_sphere(surface_tool, global_pose.basis, global_pose.origin, p_simulator->get_joint_radius(i, j), bone_color);
+				draw_sphere(surface_tool, global_pose.basis, global_pose.origin, p_simulator->get_joint_radius(i, j - 1), bone_color);
 			}
 			if (j == joint_end && p_simulator->is_end_bone_extended(i) && p_simulator->get_end_bone_length(i) > 0) {
 				Vector3 axis = p_simulator->get_end_bone_axis(current_bone, p_simulator->get_end_bone_direction(i));
@@ -153,7 +153,7 @@ Ref<ArrayMesh> SpringBoneSimulator3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_s
 				Transform3D global_pose = p_skeleton->get_bone_global_rest(current_bone);
 				axis = global_pose.xform(axis * p_simulator->get_end_bone_length(i));
 				draw_line(surface_tool, global_pose.origin, axis, bone_color);
-				draw_sphere(surface_tool, global_pose.basis, axis, p_simulator->get_end_bone_tip_radius(i), bone_color);
+				draw_sphere(surface_tool, global_pose.basis, axis, p_simulator->get_joint_radius(i, j), bone_color);
 			} else {
 				bones[0] = current_bone;
 				surface_tool->set_bones(bones);

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -56,8 +56,6 @@ bool SpringBoneSimulator3D::_set(const StringName &p_path, const Variant &p_valu
 				set_end_bone_direction(which, static_cast<BoneDirection>((int)p_value));
 			} else if (opt == "length") {
 				set_end_bone_length(which, p_value);
-			} else if (opt == "tip_radius") {
-				set_end_bone_tip_radius(which, p_value);
 			} else {
 				return false;
 			}
@@ -178,8 +176,6 @@ bool SpringBoneSimulator3D::_get(const StringName &p_path, Variant &r_ret) const
 				r_ret = (int)get_end_bone_direction(which);
 			} else if (opt == "length") {
 				r_ret = get_end_bone_length(which);
-			} else if (opt == "tip_radius") {
-				r_ret = get_end_bone_tip_radius(which);
 			} else {
 				return false;
 			}
@@ -294,7 +290,6 @@ void SpringBoneSimulator3D::_get_property_list(List<PropertyInfo> *p_list) const
 		p_list->push_back(PropertyInfo(Variant::BOOL, path + "extend_end_bone"));
 		p_list->push_back(PropertyInfo(Variant::INT, path + "end_bone/direction", PROPERTY_HINT_ENUM, "+X,-X,+Y,-Y,+Z,-Z,FromParent"));
 		p_list->push_back(PropertyInfo(Variant::FLOAT, path + "end_bone/length", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,suffix:m"));
-		p_list->push_back(PropertyInfo(Variant::FLOAT, path + "end_bone/tip_radius", PROPERTY_HINT_RANGE, "0,1,0.001,or_greater,suffix:m"));
 		p_list->push_back(PropertyInfo(Variant::INT, path + "center_from", PROPERTY_HINT_ENUM, "WorldOrigin,Node,Bone"));
 		p_list->push_back(PropertyInfo(Variant::NODE_PATH, path + "center_node"));
 		p_list->push_back(PropertyInfo(Variant::STRING, path + "center_bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint));
@@ -514,17 +509,6 @@ void SpringBoneSimulator3D::set_end_bone_length(int p_index, float p_length) {
 float SpringBoneSimulator3D::get_end_bone_length(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, settings.size(), 0);
 	return settings[p_index]->end_bone_length;
-}
-
-void SpringBoneSimulator3D::set_end_bone_tip_radius(int p_index, float p_radius) {
-	ERR_FAIL_INDEX(p_index, settings.size());
-	settings[p_index]->end_bone_tip_radius = p_radius;
-	_make_joints_dirty(p_index);
-}
-
-float SpringBoneSimulator3D::get_end_bone_tip_radius(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), 0);
-	return settings[p_index]->end_bone_tip_radius;
 }
 
 Vector3 SpringBoneSimulator3D::get_end_bone_axis(int p_end_bone, BoneDirection p_direction) const {
@@ -853,6 +837,9 @@ void SpringBoneSimulator3D::set_joint_radius(int p_index, int p_joint, float p_r
 	Vector<SpringBone3DJointSetting *> &joints = settings[p_index]->joints;
 	ERR_FAIL_INDEX(p_joint, joints.size());
 	joints[p_joint]->radius = p_radius;
+#ifdef TOOLS_ENABLED
+	update_gizmos();
+#endif // TOOLS_ENABLED
 }
 
 float SpringBoneSimulator3D::get_joint_radius(int p_index, int p_joint) const {
@@ -1119,8 +1106,6 @@ void SpringBoneSimulator3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_end_bone_direction", "index"), &SpringBoneSimulator3D::get_end_bone_direction);
 	ClassDB::bind_method(D_METHOD("set_end_bone_length", "index", "length"), &SpringBoneSimulator3D::set_end_bone_length);
 	ClassDB::bind_method(D_METHOD("get_end_bone_length", "index"), &SpringBoneSimulator3D::get_end_bone_length);
-	ClassDB::bind_method(D_METHOD("set_end_bone_tip_radius", "index", "radius"), &SpringBoneSimulator3D::set_end_bone_tip_radius);
-	ClassDB::bind_method(D_METHOD("get_end_bone_tip_radius", "index"), &SpringBoneSimulator3D::get_end_bone_tip_radius);
 
 	ClassDB::bind_method(D_METHOD("set_center_from", "index", "center_from"), &SpringBoneSimulator3D::set_center_from);
 	ClassDB::bind_method(D_METHOD("get_center_from", "index"), &SpringBoneSimulator3D::get_center_from);

--- a/scene/3d/spring_bone_simulator_3d.h
+++ b/scene/3d/spring_bone_simulator_3d.h
@@ -181,8 +181,6 @@ public:
 	BoneDirection get_end_bone_direction(int p_index) const;
 	void set_end_bone_length(int p_index, float p_length);
 	float get_end_bone_length(int p_index) const;
-	void set_end_bone_tip_radius(int p_index, float p_radius);
-	float get_end_bone_tip_radius(int p_index) const;
 	Vector3 get_end_bone_axis(int p_end_bone, BoneDirection p_direction) const; // Helper.
 
 	void set_center_from(int p_index, CenterFrom p_center_from);


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/101409

The joint drawing index was misaligned and will be corrected.

Before this fix, the root bone's radius was being treated as if it were invalid, when in fact it was valid.

Wrong gizmo:
```
-(1)-(2)-(3)-(end)
```
Wrong gizmo (extend end bone):
```
-(1)-(2)-(3)-(end)-(tip)
```

---

Internally, it behaved like this in the colliding process:
```
-(root)-(1)-(2)-(3)
```
Internally, it behaved like this in the colliding process (extend end bone):
```
-(root)-(1)-(2)-(3)-(end)
```

So this PR fix gizmo index to the latter.

The tip radius was only being used for drawing purposes, but was not actually working in colliding process. Since the end bone's radius is actually used and tip radius is not doing anything, remove it.

Also write end_bone behavior in detail in the documentation.