### PR TITLE
Remove unused `EditorSceneFormatImporter::_get_import_flags`

### DIFF
--- a/doc/classes/EditorSceneFormatImporter.xml
+++ b/doc/classes/EditorSceneFormatImporter.xml
@@ -16,11 +16,6 @@
 				Return supported file extensions for this scene importer.
 			</description>
 		</method>
-		<method name="_get_import_flags" qualifiers="virtual const" deprecated="Unused by the engine, and will be removed in a future version. Implementing this has no effect.">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="_get_import_options" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="path" type="String" />

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1796,10 +1796,6 @@ void ColladaImport::create_animation(int p_clip, bool p_import_value_tracks) {
 /*************************************** SCENE ***********************************/
 /*********************************************************************************/
 
-uint32_t EditorSceneFormatImporterCollada::get_import_flags() const {
-	return IMPORT_SCENE | IMPORT_ANIMATION;
-}
-
 void EditorSceneFormatImporterCollada::get_extensions(List<String> *r_extensions) const {
 	r_extensions->push_back("dae");
 }

--- a/editor/import/3d/editor_import_collada.h
+++ b/editor/import/3d/editor_import_collada.h
@@ -37,7 +37,6 @@ class EditorSceneFormatImporterCollada : public EditorSceneFormatImporter {
 	GDCLASS(EditorSceneFormatImporterCollada, EditorSceneFormatImporter);
 
 public:
-	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps = nullptr, Error *r_err = nullptr) override;
 

--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -38,10 +38,6 @@
 #include "scene/resources/mesh.h"
 #include "scene/resources/surface_tool.h"
 
-uint32_t EditorOBJImporter::get_import_flags() const {
-	return IMPORT_SCENE;
-}
-
 static Error _parse_material_library(const String &p_path, HashMap<String, Ref<StandardMaterial3D>> &material_map, List<String> *r_missing_deps) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, vformat("Couldn't open MTL file '%s', it may not exist or not be readable.", p_path));

--- a/editor/import/3d/resource_importer_obj.h
+++ b/editor/import/3d/resource_importer_obj.h
@@ -37,7 +37,6 @@ class EditorOBJImporter : public EditorSceneFormatImporter {
 	GDCLASS(EditorOBJImporter, EditorSceneFormatImporter);
 
 public:
-	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -57,15 +57,6 @@
 #include "scene/resources/packed_scene.h"
 #include "scene/resources/resource_format_text.h"
 
-uint32_t EditorSceneFormatImporter::get_import_flags() const {
-	uint32_t ret;
-	if (GDVIRTUAL_CALL(_get_import_flags, ret)) {
-		return ret;
-	}
-
-	ERR_FAIL_V(0);
-}
-
 void EditorSceneFormatImporter::get_extensions(List<String> *r_extensions) const {
 	Vector<String> arr;
 	if (GDVIRTUAL_CALL(_get_extensions, arr)) {
@@ -118,7 +109,6 @@ void EditorSceneFormatImporter::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_import_option", "name", "value"), &EditorSceneFormatImporter::add_import_option);
 	ClassDB::bind_method(D_METHOD("add_import_option_advanced", "type", "name", "default_value", "hint", "hint_string", "usage_flags"), &EditorSceneFormatImporter::add_import_option_advanced, DEFVAL(PROPERTY_HINT_NONE), DEFVAL(""), DEFVAL(PROPERTY_USAGE_DEFAULT));
 
-	GDVIRTUAL_BIND(_get_import_flags);
 	GDVIRTUAL_BIND(_get_extensions);
 	GDVIRTUAL_BIND(_import_scene, "path", "flags", "options");
 	GDVIRTUAL_BIND(_get_import_options, "path");
@@ -3280,10 +3270,6 @@ void ResourceImporterScene::get_scene_importer_extensions(List<String> *p_extens
 }
 
 ///////////////////////////////////////
-
-uint32_t EditorSceneFormatImporterESCN::get_import_flags() const {
-	return IMPORT_SCENE;
-}
 
 void EditorSceneFormatImporterESCN::get_extensions(List<String> *r_extensions) const {
 	r_extensions->push_back("escn");

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -58,7 +58,6 @@ protected:
 	Node *import_scene_wrapper(const String &p_path, uint32_t p_flags, const Dictionary &p_options);
 	Ref<Animation> import_animation_wrapper(const String &p_path, uint32_t p_flags, const Dictionary &p_options);
 
-	GDVIRTUAL0RC(uint32_t, _get_import_flags)
 	GDVIRTUAL0RC(Vector<String>, _get_extensions)
 	GDVIRTUAL3R(Object *, _import_scene, String, uint32_t, Dictionary)
 	GDVIRTUAL1(_get_import_options, String)
@@ -77,7 +76,6 @@ public:
 
 	void add_import_option(const String &p_name, const Variant &p_default_value);
 	void add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = String(), int p_usage_flags = PROPERTY_USAGE_DEFAULT);
-	virtual uint32_t get_import_flags() const;
 	virtual void get_extensions(List<String> *r_extensions) const;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr);
 	virtual void get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options);
@@ -322,7 +320,6 @@ class EditorSceneFormatImporterESCN : public EditorSceneFormatImporter {
 	GDCLASS(EditorSceneFormatImporterESCN, EditorSceneFormatImporter);
 
 public:
-	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err = nullptr) override;
 };

--- a/misc/extension_api_validation/4.3-stable.expected
+++ b/misc/extension_api_validation/4.3-stable.expected
@@ -301,3 +301,11 @@ Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/uniform_b
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/vertex_buffer_create/arguments': size changed value in new API, from 3 to 4.
 
 Optional argument added. Compatibility methods registered.
+
+
+GH-101531
+---------
+Validate extension JSON: API was removed: classes/EditorSceneFormatImporter/methods/_get_import_flags
+
+This virtual method, and the internal public `get_import_flags`, were never used by the engine, since it was open sourced.
+So we're removing it despite the compat breakage as there's no way for users to rely on this affecting engine behavior.

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.cpp
@@ -38,10 +38,6 @@
 
 #include "modules/gltf/gltf_document.h"
 
-uint32_t EditorSceneFormatImporterFBX2GLTF::get_import_flags() const {
-	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
-}
-
 void EditorSceneFormatImporterFBX2GLTF::get_extensions(List<String> *r_extensions) const {
 	r_extensions->push_back("fbx");
 }

--- a/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
+++ b/modules/fbx/editor/editor_scene_importer_fbx2gltf.h
@@ -42,7 +42,6 @@ class EditorSceneFormatImporterFBX2GLTF : public EditorSceneFormatImporter {
 	GDCLASS(EditorSceneFormatImporterFBX2GLTF, EditorSceneFormatImporter);
 
 public:
-	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,

--- a/modules/fbx/editor/editor_scene_importer_ufbx.cpp
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.cpp
@@ -37,10 +37,6 @@
 
 #include "core/config/project_settings.h"
 
-uint32_t EditorSceneFormatImporterUFBX::get_import_flags() const {
-	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
-}
-
 void EditorSceneFormatImporterUFBX::get_extensions(List<String> *r_extensions) const {
 	r_extensions->push_back("fbx");
 }

--- a/modules/fbx/editor/editor_scene_importer_ufbx.h
+++ b/modules/fbx/editor/editor_scene_importer_ufbx.h
@@ -46,7 +46,6 @@ public:
 		FBX_IMPORTER_UFBX,
 		FBX_IMPORTER_FBX2GLTF,
 	};
-	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -102,10 +102,6 @@ static bool _get_blender_version(const String &p_path, int &r_major, int &r_mino
 	return true;
 }
 
-uint32_t EditorSceneFormatImporterBlend::get_import_flags() const {
-	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
-}
-
 void EditorSceneFormatImporterBlend::get_extensions(List<String> *r_extensions) const {
 	r_extensions->push_back("blend");
 }

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -67,7 +67,6 @@ public:
 		BLEND_MODIFIERS_ALL
 	};
 
-	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -35,10 +35,6 @@
 #include "../gltf_defines.h"
 #include "../gltf_document.h"
 
-uint32_t EditorSceneFormatImporterGLTF::get_import_flags() const {
-	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
-}
-
 void EditorSceneFormatImporterGLTF::get_extensions(List<String> *r_extensions) const {
 	r_extensions->push_back("gltf");
 	r_extensions->push_back("glb");

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -42,7 +42,6 @@ class EditorSceneFormatImporterGLTF : public EditorSceneFormatImporter {
 	GDCLASS(EditorSceneFormatImporterGLTF, EditorSceneFormatImporter);
 
 public:
-	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const HashMap<StringName, Variant> &p_options,


### PR DESCRIPTION
This has never been used since Godot was open sourced.

Import flags are used but directly through `_import_scene`.

We normally try not to break compatibility by removing APIs, but since this one really does nothing, it doesn't seem to serve any purpose to keep it until 5.0 (if we ever remember to remove it then).