### PR TITLE
[RTL] Fix character effect offset.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1222,7 +1222,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 								custom_fx_ok = effect_status;
 
 								char_xform = charfx->transform;
-								fx_offset += charfx->offset;
+								fx_offset = charfx->offset;
 								font_color = charfx->color;
 								frid = charfx->font;
 								gl = charfx->glyph_index;


### PR DESCRIPTION
| Before | After |
| -- | -- |
| <img width="379" alt="Screenshot 2025-01-14 at 11 59 00" src="https://github.com/user-attachments/assets/fb65e1b1-f882-4e3b-a12d-0d1aafb7d404" /> | <img width="379" alt="Screenshot 2025-01-14 at 12 02 19" src="https://github.com/user-attachments/assets/9cae3138-4fd8-4502-82ea-20900d3d1fa5" /> |

Note: I have changed the `offset` effect code in the MRP to make it compatible with `wave` (add offset to it instead of overriding it):
```gdscript
func _process_custom_fx(char_fx):
	char_fx.offset += Vector2(10, 10)
	return true
```

Fixes https://github.com/godotengine/godot/issues/101496