### PR TITLE
Optimize and simplify `is_enclosed_in` and `is_quoted` implementations.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3612,20 +3612,12 @@ bool String::begins_with(const char *p_string) const {
 	return *p_string == 0;
 }
 
-bool String::is_enclosed_in(const String &p_string) const {
-	return begins_with(p_string) && ends_with(p_string);
-}
-
 bool String::is_subsequence_of(const String &p_string) const {
 	return _base_is_subsequence_of(p_string, false);
 }
 
 bool String::is_subsequence_ofn(const String &p_string) const {
 	return _base_is_subsequence_of(p_string, true);
-}
-
-bool String::is_quoted() const {
-	return is_enclosed_in("\"") || is_enclosed_in("'");
 }
 
 bool String::is_lowercase() const {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -417,10 +417,14 @@ public:
 	bool begins_with(const char *p_string) const;
 	bool ends_with(const String &p_string) const;
 	bool ends_with(const char *p_string) const;
-	bool is_enclosed_in(const String &p_string) const;
+	bool is_enclosed_in(char32_t p_left, char32_t p_right) const {
+		return length() >= 2 && ptr()[0] == p_left && ptr()[length() - 1] == p_right;
+	}
+	bool is_quoted() const {
+		return is_enclosed_in('"', '"') || is_enclosed_in('\'', '\'');
+	}
 	bool is_subsequence_of(const String &p_string) const;
 	bool is_subsequence_ofn(const String &p_string) const;
-	bool is_quoted() const;
 	bool is_lowercase() const;
 	Vector<String> bigrams() const;
 	float similarity(const String &p_string) const;


### PR DESCRIPTION
The functions were doing far too much work for what they were needed for.
This should speed up calls of this function by severalfold:
- Calls will no longer allocate for the arguments (the argument used to be `String`).
- The call can be inlined and simplified by the compiler.
- The call will no longer needlessly call `begins_with` and `ends_with`.

### Changes

- `is_quoted` will no longer return true on single `"` and `'`. I don't think it's likely this was wanted behavior for any callers.
- `is_enclosed_in` is no longer callable with more than one character.
    - This was previously unused, therefore not needed (the function is actually only used by `is_quoted`). If this is needed in the future, the function can be re-implemented easily.
    - Most combinations e.g. `is_enclosed_in("~(")`  do not make sense, as usually you'd expect the end to be a mirrored start. It would only make sense with multiple same characters.

