### PR TITLE
[4.3] Remove outer navigation map read locks

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -670,7 +670,6 @@ Vector3 NavMap::get_closest_point_to_segment(const Vector3 &p_from, const Vector
 }
 
 Vector3 NavMap::get_closest_point(const Vector3 &p_point) const {
-	RWLockRead read_lock(map_rwlock);
 	if (iteration_id == 0) {
 		NAVMAP_ITERATION_ZERO_ERROR_MSG();
 		return Vector3();
@@ -680,7 +679,6 @@ Vector3 NavMap::get_closest_point(const Vector3 &p_point) const {
 }
 
 Vector3 NavMap::get_closest_point_normal(const Vector3 &p_point) const {
-	RWLockRead read_lock(map_rwlock);
 	if (iteration_id == 0) {
 		NAVMAP_ITERATION_ZERO_ERROR_MSG();
 		return Vector3();
@@ -690,7 +688,6 @@ Vector3 NavMap::get_closest_point_normal(const Vector3 &p_point) const {
 }
 
 RID NavMap::get_closest_point_owner(const Vector3 &p_point) const {
-	RWLockRead read_lock(map_rwlock);
 	if (iteration_id == 0) {
 		NAVMAP_ITERATION_ZERO_ERROR_MSG();
 		return RID();


### PR DESCRIPTION
Removes outer navigation map read locks as we apparently go where no one knows what will happen when we dare to lock twice.

Fixes https://github.com/godotengine/godot/issues/101318 for Godot 4.3.

Not relevant for Godot 4.2. as that was happy-thread-crash-land without those locks and also not relevant for Godot 4.4 as that has this entire code changed and works with a single map iteration lock.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
