### PR TITLE
Fix crash when using a modulo operator between a float and an integer

### DIFF
--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -591,7 +591,8 @@ void GDScriptByteCodeGenerator::write_binary_operator(const Address &p_target, V
 	if (valid && (p_operator == Variant::OP_DIVIDE || p_operator == Variant::OP_MODULE)) {
 		switch (p_left_operand.type.builtin_type) {
 			case Variant::INT:
-				valid = p_right_operand.type.builtin_type != Variant::INT;
+				// Cannot use modulo between int / float, we should raise an error later in GDScript
+				valid = p_right_operand.type.builtin_type != Variant::INT && p_operator == Variant::OP_DIVIDE;
 				break;
 			case Variant::VECTOR2I:
 			case Variant::VECTOR3I:


### PR DESCRIPTION
Thanks to this change this scripts:
```gdscript
extends SceneTree

func _init():
  var result = randi() % floor(10.0)
```

Returns this error:
```
SCRIPT ERROR: Invalid operands 'int' and 'float' in operator '%'.
          at: _init (res://crash.gd:4)
```

Otherwise it used to crash

*Bugsquad edit:*
- Fixes #80486