### PR TITLE
Fix regression from already disconnected emission shape changed signal

### DIFF
--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -557,7 +557,6 @@ void GPUParticles3D::_notification(int p_what) {
 
 			Ref<ParticleProcessMaterial> material = get_process_material();
 			ERR_FAIL_COND(material.is_null());
-			material->disconnect("emission_shape_changed", callable_mp((Node3D *)this, &GPUParticles3D::update_gizmos));
 		} break;
 
 		case NOTIFICATION_SUSPENDED:


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/101502

Could not reproduce the error regarding an already connected signal
