### PR TITLE
Change translation APIs to translate to `String` instead of `StringName`.

### DIFF
--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -75,7 +75,7 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 		buckets.write[h % size].push_back(p);
 
 		//compress string
-		CharString src_s = p_from->get_message(E).operator String().utf8();
+		CharString src_s = p_from->get_message(E).utf8();
 		CompressedString ps;
 		ps.orig_len = src_s.size();
 		ps.offset = total_compression_size;
@@ -210,13 +210,13 @@ bool OptimizedTranslation::_get(const StringName &p_name, Variant &r_ret) const 
 	return true;
 }
 
-StringName OptimizedTranslation::get_message(const StringName &p_src_text, const StringName &p_context) const {
+String OptimizedTranslation::get_message(const StringName &p_src_text, const StringName &p_context) const {
 	// p_context passed in is ignore. The use of context is not yet supported in OptimizedTranslation.
 
 	int htsize = hash_table.size();
 
 	if (htsize == 0) {
-		return StringName();
+		return String();
 	}
 
 	CharString str = p_src_text.operator String().utf8();
@@ -232,7 +232,7 @@ StringName OptimizedTranslation::get_message(const StringName &p_src_text, const
 	uint32_t p = htptr[h % htsize];
 
 	if (p == 0xFFFFFFFF) {
-		return StringName(); //nothing
+		return String(); //nothing
 	}
 
 	const Bucket &bucket = *(const Bucket *)&btptr[p];
@@ -249,7 +249,7 @@ StringName OptimizedTranslation::get_message(const StringName &p_src_text, const
 	}
 
 	if (idx == -1) {
-		return StringName();
+		return String();
 	}
 
 	if (bucket.elem[idx].comp_size == bucket.elem[idx].uncomp_size) {
@@ -293,7 +293,7 @@ Vector<String> OptimizedTranslation::get_translated_message_list() const {
 	return msgs;
 }
 
-StringName OptimizedTranslation::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
+String OptimizedTranslation::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
 	// The use of plurals translation is not yet supported in OptimizedTranslation.
 	return get_message(p_src_text, p_context);
 }

--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -78,8 +78,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const override; //overridable for other implementations
-	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
+	virtual String get_message(const StringName &p_src_text, const StringName &p_context = "") const override; //overridable for other implementations
+	virtual String get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
 	virtual Vector<String> get_translated_message_list() const override;
 	void generate(const Ref<Translation> &p_from);
 

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -36,7 +36,7 @@
 
 Dictionary Translation::_get_messages() const {
 	Dictionary d;
-	for (const KeyValue<StringName, StringName> &E : translation_map) {
+	for (const KeyValue<StringName, String> &E : translation_map) {
 		d[E.key] = E.value;
 	}
 	return d;
@@ -46,7 +46,7 @@ Vector<String> Translation::_get_message_list() const {
 	Vector<String> msgs;
 	msgs.resize(translation_map.size());
 	int idx = 0;
-	for (const KeyValue<StringName, StringName> &E : translation_map) {
+	for (const KeyValue<StringName, String> &E : translation_map) {
 		msgs.set(idx, E.key);
 		idx += 1;
 	}
@@ -58,7 +58,7 @@ Vector<String> Translation::get_translated_message_list() const {
 	Vector<String> msgs;
 	msgs.resize(translation_map.size());
 	int idx = 0;
-	for (const KeyValue<StringName, StringName> &E : translation_map) {
+	for (const KeyValue<StringName, String> &E : translation_map) {
 		msgs.set(idx, E.value);
 		idx += 1;
 	}
@@ -91,7 +91,7 @@ void Translation::_notify_translation_changed_if_applies() {
 	}
 }
 
-void Translation::add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context) {
+void Translation::add_message(const StringName &p_src_text, const String &p_xlated_text, const StringName &p_context) {
 	translation_map[p_src_text] = p_xlated_text;
 }
 
@@ -101,8 +101,8 @@ void Translation::add_plural_message(const StringName &p_src_text, const Vector<
 	translation_map[p_src_text] = p_plural_xlated_texts[0];
 }
 
-StringName Translation::get_message(const StringName &p_src_text, const StringName &p_context) const {
-	StringName ret;
+String Translation::get_message(const StringName &p_src_text, const StringName &p_context) const {
+	StringName ret; // TODO API Mismatch; the GDVirtual function still has to return StringName.
 	if (GDVIRTUAL_CALL(_get_message, p_src_text, p_context, ret)) {
 		return ret;
 	}
@@ -111,15 +111,15 @@ StringName Translation::get_message(const StringName &p_src_text, const StringNa
 		WARN_PRINT("Translation class doesn't handle context. Using context in get_message() on a Translation instance is probably a mistake. \nUse a derived Translation class that handles context, such as TranslationPO class");
 	}
 
-	HashMap<StringName, StringName>::ConstIterator E = translation_map.find(p_src_text);
+	HashMap<StringName, String>::ConstIterator E = translation_map.find(p_src_text);
 	if (!E) {
-		return StringName();
+		return String();
 	}
 
 	return E->value;
 }
 
-StringName Translation::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
+String Translation::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
 	StringName ret;
 	if (GDVIRTUAL_CALL(_get_plural_message, p_src_text, p_plural_text, p_n, p_context, ret)) {
 		return ret;
@@ -138,7 +138,7 @@ void Translation::erase_message(const StringName &p_src_text, const StringName &
 }
 
 void Translation::get_message_list(List<StringName> *r_messages) const {
-	for (const KeyValue<StringName, StringName> &E : translation_map) {
+	for (const KeyValue<StringName, String> &E : translation_map) {
 		r_messages->push_back(E.key);
 	}
 }

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -39,7 +39,7 @@ class Translation : public Resource {
 	RES_BASE_EXTENSION("translation");
 
 	String locale = "en";
-	HashMap<StringName, StringName> translation_map;
+	HashMap<StringName, String> translation_map;
 
 	virtual Vector<String> _get_message_list() const;
 	virtual Dictionary _get_messages() const;
@@ -57,10 +57,10 @@ public:
 	void set_locale(const String &p_locale);
 	_FORCE_INLINE_ String get_locale() const { return locale; }
 
-	virtual void add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context = "");
+	virtual void add_message(const StringName &p_src_text, const String &p_xlated_text, const StringName &p_context = "");
 	virtual void add_plural_message(const StringName &p_src_text, const Vector<String> &p_plural_xlated_texts, const StringName &p_context = "");
-	virtual StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const; //overridable for other implementations
-	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const;
+	virtual String get_message(const StringName &p_src_text, const StringName &p_context = "") const; //overridable for other implementations
+	virtual String get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const;
 	virtual void erase_message(const StringName &p_src_text, const StringName &p_context = "");
 	virtual void get_message_list(List<StringName> *r_messages) const;
 	virtual int get_message_count() const;

--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -197,16 +197,16 @@ bool TranslationDomain::_is_placeholder(const String &p_message, int p_index) co
 					p_message[p_index + 1] == 'o' || p_message[p_index + 1] == 'x' || p_message[p_index + 1] == 'X' || p_message[p_index + 1] == 'f');
 }
 
-StringName TranslationDomain::get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_context) const {
-	StringName res;
+String TranslationDomain::get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_context) const {
+	String res;
 	int best_score = 0;
 
 	for (const Ref<Translation> &E : translations) {
 		ERR_CONTINUE(E.is_null());
 		int score = TranslationServer::get_singleton()->compare_locales(p_locale, E->get_locale());
 		if (score > 0 && score >= best_score) {
-			const StringName r = E->get_message(p_message, p_context);
-			if (!r) {
+			const String r = E->get_message(p_message, p_context);
+			if (r.is_empty()) {
 				continue;
 			}
 			res = r;
@@ -220,16 +220,16 @@ StringName TranslationDomain::get_message_from_translations(const String &p_loca
 	return res;
 }
 
-StringName TranslationDomain::get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
-	StringName res;
+String TranslationDomain::get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+	String res;
 	int best_score = 0;
 
 	for (const Ref<Translation> &E : translations) {
 		ERR_CONTINUE(E.is_null());
 		int score = TranslationServer::get_singleton()->compare_locales(p_locale, E->get_locale());
 		if (score > 0 && score >= best_score) {
-			const StringName r = E->get_plural_message(p_message, p_message_plural, p_n, p_context);
-			if (!r) {
+			const String r = E->get_plural_message(p_message, p_message_plural, p_n, p_context);
+			if (r.is_empty()) {
 				continue;
 			}
 			res = r;
@@ -286,31 +286,31 @@ void TranslationDomain::clear() {
 	translations.clear();
 }
 
-StringName TranslationDomain::translate(const StringName &p_message, const StringName &p_context) const {
+String TranslationDomain::translate(const StringName &p_message, const StringName &p_context) const {
 	const String &locale = TranslationServer::get_singleton()->get_locale();
-	StringName res = get_message_from_translations(locale, p_message, p_context);
+	String res = get_message_from_translations(locale, p_message, p_context);
 
 	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
-	if (!res && fallback.length() >= 2) {
+	if (res.is_empty() && fallback.length() >= 2) {
 		res = get_message_from_translations(fallback, p_message, p_context);
 	}
 
-	if (!res) {
-		return pseudolocalization.enabled ? pseudolocalize(p_message) : p_message;
+	if (res.is_empty()) {
+		return pseudolocalization.enabled ? pseudolocalize(p_message) : String(p_message);
 	}
 	return pseudolocalization.enabled ? pseudolocalize(res) : res;
 }
 
-StringName TranslationDomain::translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+String TranslationDomain::translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
 	const String &locale = TranslationServer::get_singleton()->get_locale();
-	StringName res = get_message_from_translations(locale, p_message, p_message_plural, p_n, p_context);
+	String res = get_message_from_translations(locale, p_message, p_message_plural, p_n, p_context);
 
 	const String &fallback = TranslationServer::get_singleton()->get_fallback_locale();
-	if (!res && fallback.length() >= 2) {
+	if (res.is_empty() && fallback.length() >= 2) {
 		res = get_message_from_translations(fallback, p_message, p_message_plural, p_n, p_context);
 	}
 
-	if (!res) {
+	if (res.is_empty()) {
 		if (p_n == 1) {
 			return p_message;
 		}
@@ -391,7 +391,7 @@ void TranslationDomain::set_pseudolocalization_suffix(const String &p_suffix) {
 	pseudolocalization.suffix = p_suffix;
 }
 
-StringName TranslationDomain::pseudolocalize(const StringName &p_message) const {
+String TranslationDomain::pseudolocalize(const StringName &p_message) const {
 	if (p_message.is_empty()) {
 		return p_message;
 	}

--- a/core/string/translation_domain.h
+++ b/core/string/translation_domain.h
@@ -65,8 +65,8 @@ protected:
 
 public:
 	// Methods in this section are not intended for scripting.
-	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_context) const;
-	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const;
+	String get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_context) const;
+	String get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const;
 	PackedStringArray get_loaded_locales() const;
 
 public:
@@ -76,8 +76,8 @@ public:
 	void remove_translation(const Ref<Translation> &p_translation);
 	void clear();
 
-	StringName translate(const StringName &p_message, const StringName &p_context) const;
-	StringName translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const;
+	String translate(const StringName &p_message, const StringName &p_context) const;
+	String translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const;
 
 	bool is_pseudolocalization_enabled() const;
 	void set_pseudolocalization_enabled(bool p_enabled);
@@ -98,7 +98,7 @@ public:
 	String get_pseudolocalization_suffix() const;
 	void set_pseudolocalization_suffix(const String &p_suffix);
 
-	StringName pseudolocalize(const StringName &p_message) const;
+	String pseudolocalize(const StringName &p_message) const;
 
 	TranslationDomain();
 };

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -69,10 +69,10 @@ Dictionary TranslationPO::_get_messages() const {
 
 	Dictionary d;
 
-	for (const KeyValue<StringName, HashMap<StringName, Vector<StringName>>> &E : translation_map) {
+	for (const KeyValue<StringName, HashMap<StringName, Vector<String>>> &E : translation_map) {
 		Dictionary d2;
 
-		for (const KeyValue<StringName, Vector<StringName>> &E2 : E.value) {
+		for (const KeyValue<StringName, Vector<String>> &E2 : E.value) {
 			d2[E2.key] = E2.value;
 		}
 
@@ -88,7 +88,7 @@ void TranslationPO::_set_messages(const Dictionary &p_messages) {
 	for (const KeyValue<Variant, Variant> &kv : p_messages) {
 		const Dictionary &id_str_map = kv.value;
 
-		HashMap<StringName, Vector<StringName>> temp_map;
+		HashMap<StringName, Vector<String>> temp_map;
 		for (const KeyValue<Variant, Variant> &kv_id : id_str_map) {
 			StringName id = kv_id.key;
 			temp_map[id] = kv_id.value;
@@ -100,13 +100,13 @@ void TranslationPO::_set_messages(const Dictionary &p_messages) {
 
 Vector<String> TranslationPO::get_translated_message_list() const {
 	Vector<String> msgs;
-	for (const KeyValue<StringName, HashMap<StringName, Vector<StringName>>> &E : translation_map) {
+	for (const KeyValue<StringName, HashMap<StringName, Vector<String>>> &E : translation_map) {
 		if (E.key != StringName()) {
 			continue;
 		}
 
-		for (const KeyValue<StringName, Vector<StringName>> &E2 : E.value) {
-			for (const StringName &E3 : E2.value) {
+		for (const KeyValue<StringName, Vector<String>> &E2 : E.value) {
+			for (const String &E3 : E2.value) {
 				msgs.push_back(E3);
 			}
 		}
@@ -237,8 +237,8 @@ void TranslationPO::set_plural_rule(const String &p_plural_rule) {
 	input_name.push_back("n");
 }
 
-void TranslationPO::add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context) {
-	HashMap<StringName, Vector<StringName>> &map_id_str = translation_map[p_context];
+void TranslationPO::add_message(const StringName &p_src_text, const String &p_xlated_text, const StringName &p_context) {
+	HashMap<StringName, Vector<String>> &map_id_str = translation_map[p_context];
 
 	if (map_id_str.has(p_src_text)) {
 		WARN_PRINT(vformat("Double translations for \"%s\" under the same context \"%s\" for locale \"%s\".\nThere should only be one unique translation for a given string under the same context.", String(p_src_text), String(p_context), get_locale()));
@@ -251,7 +251,7 @@ void TranslationPO::add_message(const StringName &p_src_text, const StringName &
 void TranslationPO::add_plural_message(const StringName &p_src_text, const Vector<String> &p_plural_xlated_texts, const StringName &p_context) {
 	ERR_FAIL_COND_MSG(p_plural_xlated_texts.size() != plural_forms, vformat("Trying to add plural texts that don't match the required number of plural forms for locale \"%s\".", get_locale()));
 
-	HashMap<StringName, Vector<StringName>> &map_id_str = translation_map[p_context];
+	HashMap<StringName, Vector<String>> &map_id_str = translation_map[p_context];
 
 	if (map_id_str.has(p_src_text)) {
 		WARN_PRINT(vformat("Double translations for \"%s\" under the same context \"%s\" for locale %s.\nThere should only be one unique translation for a given string under the same context.", p_src_text, p_context, get_locale()));
@@ -271,17 +271,17 @@ String TranslationPO::get_plural_rule() const {
 	return plural_rule;
 }
 
-StringName TranslationPO::get_message(const StringName &p_src_text, const StringName &p_context) const {
+String TranslationPO::get_message(const StringName &p_src_text, const StringName &p_context) const {
 	if (!translation_map.has(p_context) || !translation_map[p_context].has(p_src_text)) {
-		return StringName();
+		return String();
 	}
-	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].is_empty(), StringName(), vformat("Source text \"%s\" is registered but doesn't have a translation. Please report this bug.", String(p_src_text)));
+	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].is_empty(), String(), vformat("Source text \"%s\" is registered but doesn't have a translation. Please report this bug.", String(p_src_text)));
 
 	return translation_map[p_context][p_src_text][0];
 }
 
-StringName TranslationPO::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
-	ERR_FAIL_COND_V_MSG(p_n < 0, StringName(), "N passed into translation to get a plural message should not be negative. For negative numbers, use singular translation please. Search \"gettext PO Plural Forms\" online for the documentation on translating negative numbers.");
+String TranslationPO::get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context) const {
+	ERR_FAIL_COND_V_MSG(p_n < 0, String(), "N passed into translation to get a plural message should not be negative. For negative numbers, use singular translation please. Search \"gettext PO Plural Forms\" online for the documentation on translating negative numbers.");
 
 	// If the query is the same as last time, return the cached result.
 	if (p_n == last_plural_n && p_context == last_plural_context && p_src_text == last_plural_key) {
@@ -289,12 +289,12 @@ StringName TranslationPO::get_plural_message(const StringName &p_src_text, const
 	}
 
 	if (!translation_map.has(p_context) || !translation_map[p_context].has(p_src_text)) {
-		return StringName();
+		return String();
 	}
-	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].is_empty(), StringName(), vformat("Source text \"%s\" is registered but doesn't have a translation. Please report this bug.", String(p_src_text)));
+	ERR_FAIL_COND_V_MSG(translation_map[p_context][p_src_text].is_empty(), String(), vformat("Source text \"%s\" is registered but doesn't have a translation. Please report this bug.", String(p_src_text)));
 
 	int plural_index = _get_plural_index(p_n);
-	ERR_FAIL_COND_V_MSG(plural_index < 0 || translation_map[p_context][p_src_text].size() < plural_index + 1, StringName(), "Plural index returned or number of plural translations is not valid. Please report this bug.");
+	ERR_FAIL_COND_V_MSG(plural_index < 0 || translation_map[p_context][p_src_text].size() < plural_index + 1, String(), "Plural index returned or number of plural translations is not valid. Please report this bug.");
 
 	// Cache result so that if the next entry is the same, we can return directly.
 	// _get_plural_index(p_n) can get very costly, especially when evaluating long plural-rule (Arabic)
@@ -318,12 +318,12 @@ void TranslationPO::get_message_list(List<StringName> *r_messages) const {
 	// OptimizedTranslation uses this function to get the list of msgid.
 	// Return all the keys of translation_map under "" context.
 
-	for (const KeyValue<StringName, HashMap<StringName, Vector<StringName>>> &E : translation_map) {
+	for (const KeyValue<StringName, HashMap<StringName, Vector<String>>> &E : translation_map) {
 		if (E.key != StringName()) {
 			continue;
 		}
 
-		for (const KeyValue<StringName, Vector<StringName>> &E2 : E.value) {
+		for (const KeyValue<StringName, Vector<String>> &E2 : E.value) {
 			r_messages->push_back(E2.key);
 		}
 	}
@@ -332,7 +332,7 @@ void TranslationPO::get_message_list(List<StringName> *r_messages) const {
 int TranslationPO::get_message_count() const {
 	int count = 0;
 
-	for (const KeyValue<StringName, HashMap<StringName, Vector<StringName>>> &E : translation_map) {
+	for (const KeyValue<StringName, HashMap<StringName, Vector<String>>> &E : translation_map) {
 		count += E.value.size();
 	}
 

--- a/core/string/translation_po.h
+++ b/core/string/translation_po.h
@@ -43,7 +43,7 @@ class TranslationPO : public Translation {
 	// The value Vector<StringName> in the second map stores the translated strings. Index 0, 1, 2 matches msgstr[0], msgstr[1], msgstr[2]... in the case of plurals.
 	// Otherwise index 0 matches to msgstr in a singular translation.
 	// Strings without context have "" as first key.
-	HashMap<StringName, HashMap<StringName, Vector<StringName>>> translation_map;
+	HashMap<StringName, HashMap<StringName, Vector<String>>> translation_map;
 
 	int plural_forms = 0; // 0 means no "Plural-Forms" is given in the PO header file. The min for all languages is 1.
 	String plural_rule;
@@ -82,10 +82,10 @@ public:
 	Vector<String> get_translated_message_list() const override;
 	void get_message_list(List<StringName> *r_messages) const override;
 	int get_message_count() const override;
-	void add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context = "") override;
+	void add_message(const StringName &p_src_text, const String &p_xlated_text, const StringName &p_context = "") override;
 	void add_plural_message(const StringName &p_src_text, const Vector<String> &p_plural_xlated_texts, const StringName &p_context = "") override;
-	StringName get_message(const StringName &p_src_text, const StringName &p_context = "") const override;
-	StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
+	String get_message(const StringName &p_src_text, const StringName &p_context = "") const override;
+	String get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
 	void erase_message(const StringName &p_src_text, const StringName &p_context = "") override;
 
 	void set_plural_rule(const String &p_plural_rule);

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -405,7 +405,7 @@ void TranslationServer::clear() {
 	main_domain->clear();
 }
 
-StringName TranslationServer::translate(const StringName &p_message, const StringName &p_context) const {
+String TranslationServer::translate(const StringName &p_message, const StringName &p_context) const {
 	if (!enabled) {
 		return p_message;
 	}
@@ -413,7 +413,7 @@ StringName TranslationServer::translate(const StringName &p_message, const Strin
 	return main_domain->translate(p_message, p_context);
 }
 
-StringName TranslationServer::translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+String TranslationServer::translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
 	if (!enabled) {
 		if (p_n == 1) {
 			return p_message;
@@ -521,23 +521,23 @@ String TranslationServer::get_tool_locale() {
 	}
 }
 
-StringName TranslationServer::tool_translate(const StringName &p_message, const StringName &p_context) const {
+String TranslationServer::tool_translate(const StringName &p_message, const StringName &p_context) const {
 	return editor_domain->translate(p_message, p_context);
 }
 
-StringName TranslationServer::tool_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+String TranslationServer::tool_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
 	return editor_domain->translate_plural(p_message, p_message_plural, p_n, p_context);
 }
 
-StringName TranslationServer::property_translate(const StringName &p_message, const StringName &p_context) const {
+String TranslationServer::property_translate(const StringName &p_message, const StringName &p_context) const {
 	return property_domain->translate(p_message, p_context);
 }
 
-StringName TranslationServer::doc_translate(const StringName &p_message, const StringName &p_context) const {
+String TranslationServer::doc_translate(const StringName &p_message, const StringName &p_context) const {
 	return doc_domain->translate(p_message, p_context);
 }
 
-StringName TranslationServer::doc_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
+String TranslationServer::doc_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const {
 	return doc_domain->translate_plural(p_message, p_message_plural, p_n, p_context);
 }
 
@@ -572,7 +572,7 @@ void TranslationServer::reload_pseudolocalization() {
 	}
 }
 
-StringName TranslationServer::pseudolocalize(const StringName &p_message) const {
+String TranslationServer::pseudolocalize(const StringName &p_message) const {
 	return main_domain->pseudolocalize(p_message);
 }
 

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -123,10 +123,10 @@ public:
 	void add_translation(const Ref<Translation> &p_translation);
 	void remove_translation(const Ref<Translation> &p_translation);
 
-	StringName translate(const StringName &p_message, const StringName &p_context = "") const;
-	StringName translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
+	String translate(const StringName &p_message, const StringName &p_context = "") const;
+	String translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
 
-	StringName pseudolocalize(const StringName &p_message) const;
+	String pseudolocalize(const StringName &p_message) const;
 
 	bool is_pseudolocalization_enabled() const;
 	void set_pseudolocalization_enabled(bool p_enabled);
@@ -137,11 +137,11 @@ public:
 	int compare_locales(const String &p_locale_a, const String &p_locale_b) const;
 
 	String get_tool_locale();
-	StringName tool_translate(const StringName &p_message, const StringName &p_context = "") const;
-	StringName tool_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
-	StringName property_translate(const StringName &p_message, const StringName &p_context = "") const;
-	StringName doc_translate(const StringName &p_message, const StringName &p_context = "") const;
-	StringName doc_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
+	String tool_translate(const StringName &p_message, const StringName &p_context = "") const;
+	String tool_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
+	String property_translate(const StringName &p_message, const StringName &p_context = "") const;
+	String doc_translate(const StringName &p_message, const StringName &p_context = "") const;
+	String doc_translate_plural(const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const;
 
 	bool has_domain(const StringName &p_domain) const;
 	Ref<TranslationDomain> get_or_add_domain(const StringName &p_domain);

--- a/doc/classes/Translation.xml
+++ b/doc/classes/Translation.xml
@@ -32,7 +32,7 @@
 		<method name="add_message">
 			<return type="void" />
 			<param index="0" name="src_message" type="StringName" />
-			<param index="1" name="xlated_message" type="StringName" />
+			<param index="1" name="xlated_message" type="String" />
 			<param index="2" name="context" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
 				Adds a message if nonexistent, followed by its translation.
@@ -58,7 +58,7 @@
 			</description>
 		</method>
 		<method name="get_message" qualifiers="const">
-			<return type="StringName" />
+			<return type="String" />
 			<param index="0" name="src_message" type="StringName" />
 			<param index="1" name="context" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
@@ -78,7 +78,7 @@
 			</description>
 		</method>
 		<method name="get_plural_message" qualifiers="const">
-			<return type="StringName" />
+			<return type="String" />
 			<param index="0" name="src_message" type="StringName" />
 			<param index="1" name="src_plural_message" type="StringName" />
 			<param index="2" name="n" type="int" />

--- a/doc/classes/TranslationDomain.xml
+++ b/doc/classes/TranslationDomain.xml
@@ -31,7 +31,7 @@
 			</description>
 		</method>
 		<method name="pseudolocalize" qualifiers="const">
-			<return type="StringName" />
+			<return type="String" />
 			<param index="0" name="message" type="StringName" />
 			<description>
 				Returns the pseudolocalized string based on the [param message] passed in.
@@ -45,7 +45,7 @@
 			</description>
 		</method>
 		<method name="translate" qualifiers="const">
-			<return type="StringName" />
+			<return type="String" />
 			<param index="0" name="message" type="StringName" />
 			<param index="1" name="context" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
@@ -53,7 +53,7 @@
 			</description>
 		</method>
 		<method name="translate_plural" qualifiers="const">
-			<return type="StringName" />
+			<return type="String" />
 			<param index="0" name="message" type="StringName" />
 			<param index="1" name="message_plural" type="StringName" />
 			<param index="2" name="n" type="int" />

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -121,7 +121,7 @@
 			</description>
 		</method>
 		<method name="pseudolocalize" qualifiers="const">
-			<return type="StringName" />
+			<return type="String" />
 			<param index="0" name="message" type="StringName" />
 			<description>
 				Returns the pseudolocalized string based on the [param message] passed in.
@@ -166,7 +166,7 @@
 			</description>
 		</method>
 		<method name="translate" qualifiers="const">
-			<return type="StringName" />
+			<return type="String" />
 			<param index="0" name="message" type="StringName" />
 			<param index="1" name="context" type="StringName" default="&amp;&quot;&quot;" />
 			<description>
@@ -175,7 +175,7 @@
 			</description>
 		</method>
 		<method name="translate_plural" qualifiers="const">
-			<return type="StringName" />
+			<return type="String" />
 			<param index="0" name="message" type="StringName" />
 			<param index="1" name="plural_message" type="StringName" />
 			<param index="2" name="n" type="int" />


### PR DESCRIPTION
The reason for this change is to simplify the APIs, to reduce unnecessary overhead, and to reduce the size of the `StringName` table.

This change should reduce the number of `StringName` instances when using translations by around half (20k), reducing RAM use by up to 1mb.

## Background

I have noticed that using a translation for Godot almost doubles the amount of translated strings (tested with `bin/godot.macos.editor.arm64 --debug-stringnames`.

The baseline, without translations, is around `25302`. 
Using a translation, on Godot 4.3, the value is around `45489`, which includes every translated string. 
Considering `sizeof(StringName::_Data) == 56`, this should amount to about 1mb (* if napkin math suffices).

Translated strings should rarely (never?) be used as `StringName`. `StringName` should be used for _unique keys_, but translated strings will usually be used for display only. Dare I say, using a translated string as a key may actually be a misuse. 
The `String` function `RTR` (and similar) return `String` already. Only the translation API itself returns `StringName`, so translated strings are first packed into `StringName`, and then immediately unpacked again into a `String`. They are never used again as keys internally.

## Tests
Unfortunately, I have not been able to determine whether this change fixes this problem. My builds refuse to load translations for some reason, so I do not see a difference in `StringName` instances either way. I'm making this a draft until the change is confirmed to work.

## Benchmarks
I have not benchmarked (yet?) whether this change has any impact on translation load times and translate calls. Theoretically, it should be slightly faster than before.