### PR TITLE
[Linux] Implement native color picker.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -64,6 +64,16 @@
 				[b]Note:[/b] This method is only implemented on Linux (X11/Wayland).
 			</description>
 		</method>
+		<method name="color_picker">
+			<return type="bool" />
+			<param index="0" name="callback" type="Callable" />
+			<description>
+				Displays OS native color picker.
+				Callbacks have the following arguments: [code]status: bool, color: Color[/code].
+				[b]Note:[/b] This method is implemented if the display server has the [constant FEATURE_NATIVE_COLOR_PICKER] feature.
+				[b]Note:[/b] This method is only implemented on Linux (X11/Wayland).
+			</description>
+		</method>
 		<method name="create_status_indicator">
 			<return type="int" />
 			<param index="0" name="icon" type="Texture2D" />
@@ -1951,6 +1961,9 @@
 		</constant>
 		<constant name="FEATURE_EMOJI_AND_SYMBOL_PICKER" value="31" enum="Feature">
 			Display server supports system emoji and symbol picker. [b]Windows, macOS[/b]
+		</constant>
+		<constant name="FEATURE_NATIVE_COLOR_PICKER" value="32" enum="Feature">
+			Display server supports native color picker. [b]Linux (X11/Wayland)[/b]
 		</constant>
 		<constant name="MOUSE_MODE_VISIBLE" value="0" enum="MouseMode">
 			Makes the mouse cursor visible if it is hidden.

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -52,6 +52,7 @@
 #define BUS_INTERFACE_PROPERTIES "org.freedesktop.DBus.Properties"
 #define BUS_INTERFACE_SETTINGS "org.freedesktop.portal.Settings"
 #define BUS_INTERFACE_FILE_CHOOSER "org.freedesktop.portal.FileChooser"
+#define BUS_INTERFACE_SCREENSHOT "org.freedesktop.portal.Screenshot"
 
 bool FreeDesktopPortalDesktop::try_parse_variant(DBusMessage *p_reply_message, int p_type, void *r_value) {
 	DBusMessageIter iter[3];
@@ -295,6 +296,61 @@ void FreeDesktopPortalDesktop::append_dbus_dict_bool(DBusMessageIter *p_iter, co
 	dbus_message_iter_close_container(p_iter, &dict_iter);
 }
 
+bool FreeDesktopPortalDesktop::color_picker_parse_response(DBusMessageIter *p_iter, bool &r_cancel, Color &r_color) {
+	ERR_FAIL_COND_V(dbus_message_iter_get_arg_type(p_iter) != DBUS_TYPE_UINT32, false);
+
+	dbus_uint32_t resp_code;
+	dbus_message_iter_get_basic(p_iter, &resp_code);
+	if (resp_code != 0) {
+		r_cancel = true;
+	} else {
+		r_cancel = false;
+		ERR_FAIL_COND_V(!dbus_message_iter_next(p_iter), false);
+		ERR_FAIL_COND_V(dbus_message_iter_get_arg_type(p_iter) != DBUS_TYPE_ARRAY, false);
+
+		DBusMessageIter dict_iter;
+		dbus_message_iter_recurse(p_iter, &dict_iter);
+		while (dbus_message_iter_get_arg_type(&dict_iter) == DBUS_TYPE_DICT_ENTRY) {
+			DBusMessageIter iter;
+			dbus_message_iter_recurse(&dict_iter, &iter);
+			if (dbus_message_iter_get_arg_type(&iter) == DBUS_TYPE_STRING) {
+				const char *key;
+				dbus_message_iter_get_basic(&iter, &key);
+				dbus_message_iter_next(&iter);
+
+				DBusMessageIter var_iter;
+				dbus_message_iter_recurse(&iter, &var_iter);
+				if (strcmp(key, "color") == 0) { // (ddd)
+					if (dbus_message_iter_get_arg_type(&var_iter) == DBUS_TYPE_STRUCT) {
+						DBusMessageIter struct_iter;
+						dbus_message_iter_recurse(&var_iter, &struct_iter);
+						int idx = 0;
+						while (dbus_message_iter_get_arg_type(&struct_iter) == DBUS_TYPE_DOUBLE) {
+							double value = 0.0;
+							dbus_message_iter_get_basic(&struct_iter, &value);
+							if (idx == 0) {
+								r_color.r = value;
+							} else if (idx == 1) {
+								r_color.g = value;
+							} else if (idx == 2) {
+								r_color.b = value;
+							}
+							idx++;
+							if (!dbus_message_iter_next(&struct_iter)) {
+								break;
+							}
+						}
+					}
+				}
+			}
+			if (!dbus_message_iter_next(&dict_iter)) {
+				break;
+			}
+		}
+	}
+	return true;
+}
+
 bool FreeDesktopPortalDesktop::file_chooser_parse_response(DBusMessageIter *p_iter, const Vector<String> &p_names, const HashMap<String, String> &p_ids, bool &r_cancel, Vector<String> &r_urls, int &r_index, Dictionary &r_options) {
 	ERR_FAIL_COND_V(dbus_message_iter_get_arg_type(p_iter) != DBUS_TYPE_UINT32, false);
 
@@ -388,6 +444,92 @@ bool FreeDesktopPortalDesktop::file_chooser_parse_response(DBusMessageIter *p_it
 	return true;
 }
 
+bool FreeDesktopPortalDesktop::color_picker(const String &p_xid, const Callable &p_callback) {
+	if (unsupported) {
+		return false;
+	}
+
+	DBusError err;
+	dbus_error_init(&err);
+
+	// Open connection and add signal handler.
+	ColorPickerData cd;
+	cd.callback = p_callback;
+
+	CryptoCore::RandomGenerator rng;
+	ERR_FAIL_COND_V_MSG(rng.init(), false, "Failed to initialize random number generator.");
+	uint8_t uuid[64];
+	Error rng_err = rng.get_random_bytes(uuid, 64);
+	ERR_FAIL_COND_V_MSG(rng_err, false, "Failed to generate unique token.");
+
+	String dbus_unique_name = String::utf8(dbus_bus_get_unique_name(monitor_connection));
+	String token = String::hex_encode_buffer(uuid, 64);
+	String path = vformat("/org/freedesktop/portal/desktop/request/%s/%s", dbus_unique_name.replace(".", "_").replace(":", ""), token);
+
+	cd.path = path;
+	cd.filter = vformat("type='signal',sender='org.freedesktop.portal.Desktop',path='%s',interface='org.freedesktop.portal.Request',member='Response',destination='%s'", path, dbus_unique_name);
+	dbus_bus_add_match(monitor_connection, cd.filter.utf8().get_data(), &err);
+	if (dbus_error_is_set(&err)) {
+		ERR_PRINT(vformat("Failed to add DBus match: %s", err.message));
+		dbus_error_free(&err);
+		return false;
+	}
+
+	DBusMessage *message = dbus_message_new_method_call(BUS_OBJECT_NAME, BUS_OBJECT_PATH, BUS_INTERFACE_SCREENSHOT, "PickColor");
+	{
+		DBusMessageIter iter;
+		dbus_message_iter_init_append(message, &iter);
+
+		append_dbus_string(&iter, p_xid);
+
+		DBusMessageIter arr_iter;
+		dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "{sv}", &arr_iter);
+		append_dbus_dict_string(&arr_iter, "handle_token", token);
+		dbus_message_iter_close_container(&iter, &arr_iter);
+	}
+	DBusMessage *reply = dbus_connection_send_with_reply_and_block(monitor_connection, message, DBUS_TIMEOUT_INFINITE, &err);
+	dbus_message_unref(message);
+
+	if (!reply || dbus_error_is_set(&err)) {
+		ERR_PRINT(vformat("Failed to send DBus message: %s", err.message));
+		dbus_error_free(&err);
+		dbus_bus_remove_match(monitor_connection, cd.filter.utf8().get_data(), &err);
+		return false;
+	}
+
+	// Update signal path.
+	{
+		DBusMessageIter iter;
+		if (dbus_message_iter_init(reply, &iter)) {
+			if (dbus_message_iter_get_arg_type(&iter) == DBUS_TYPE_OBJECT_PATH) {
+				const char *new_path = nullptr;
+				dbus_message_iter_get_basic(&iter, &new_path);
+				if (String::utf8(new_path) != path) {
+					dbus_bus_remove_match(monitor_connection, cd.filter.utf8().get_data(), &err);
+					if (dbus_error_is_set(&err)) {
+						ERR_PRINT(vformat("Failed to remove DBus match: %s", err.message));
+						dbus_error_free(&err);
+						return false;
+					}
+					cd.filter = String::utf8(new_path);
+					dbus_bus_add_match(monitor_connection, cd.filter.utf8().get_data(), &err);
+					if (dbus_error_is_set(&err)) {
+						ERR_PRINT(vformat("Failed to add DBus match: %s", err.message));
+						dbus_error_free(&err);
+						return false;
+					}
+				}
+			}
+		}
+	}
+	dbus_message_unref(reply);
+
+	MutexLock lock(color_picker_mutex);
+	color_pickers.push_back(cd);
+
+	return true;
+}
+
 bool FreeDesktopPortalDesktop::_is_interface_supported(const char *p_iface) {
 	bool supported = false;
 	DBusError err;
@@ -439,6 +581,14 @@ bool FreeDesktopPortalDesktop::is_settings_supported() {
 	static int supported = -1;
 	if (supported == -1) {
 		supported = _is_interface_supported(BUS_INTERFACE_SETTINGS);
+	}
+	return supported;
+}
+
+bool FreeDesktopPortalDesktop::is_screenshot_supported() {
+	static int supported = -1;
+	if (supported == -1) {
+		supported = _is_interface_supported(BUS_INTERFACE_SCREENSHOT);
 	}
 	return supported;
 }
@@ -592,29 +742,47 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServer::WindowID p_windo
 	return OK;
 }
 
-void FreeDesktopPortalDesktop::process_file_dialog_callbacks() {
-	MutexLock lock(file_dialog_mutex);
-	while (!pending_cbs.is_empty()) {
-		FileDialogCallback cb = pending_cbs.front()->get();
-		pending_cbs.pop_front();
+void FreeDesktopPortalDesktop::process_callbacks() {
+	{
+		MutexLock lock(file_dialog_mutex);
+		while (!pending_file_cbs.is_empty()) {
+			FileDialogCallback cb = pending_file_cbs.front()->get();
+			pending_file_cbs.pop_front();
 
-		if (cb.opt_in_cb) {
-			Variant ret;
-			Callable::CallError ce;
-			const Variant *args[4] = { &cb.status, &cb.files, &cb.index, &cb.options };
+			if (cb.opt_in_cb) {
+				Variant ret;
+				Callable::CallError ce;
+				const Variant *args[4] = { &cb.status, &cb.files, &cb.index, &cb.options };
 
-			cb.callback.callp(args, 4, ret, ce);
-			if (ce.error != Callable::CallError::CALL_OK) {
-				ERR_PRINT(vformat("Failed to execute file dialog callback: %s.", Variant::get_callable_error_text(cb.callback, args, 4, ce)));
+				cb.callback.callp(args, 4, ret, ce);
+				if (ce.error != Callable::CallError::CALL_OK) {
+					ERR_PRINT(vformat("Failed to execute file dialog callback: %s.", Variant::get_callable_error_text(cb.callback, args, 4, ce)));
+				}
+			} else {
+				Variant ret;
+				Callable::CallError ce;
+				const Variant *args[3] = { &cb.status, &cb.files, &cb.index };
+
+				cb.callback.callp(args, 3, ret, ce);
+				if (ce.error != Callable::CallError::CALL_OK) {
+					ERR_PRINT(vformat("Failed to execute file dialog callback: %s.", Variant::get_callable_error_text(cb.callback, args, 3, ce)));
+				}
 			}
-		} else {
+		}
+	}
+	{
+		MutexLock lock(color_picker_mutex);
+		while (!pending_color_cbs.is_empty()) {
+			ColorPickerCallback cb = pending_color_cbs.front()->get();
+			pending_color_cbs.pop_front();
+
 			Variant ret;
 			Callable::CallError ce;
-			const Variant *args[3] = { &cb.status, &cb.files, &cb.index };
+			const Variant *args[2] = { &cb.status, &cb.color };
 
-			cb.callback.callp(args, 3, ret, ce);
+			cb.callback.callp(args, 2, ret, ce);
 			if (ce.error != Callable::CallError::CALL_OK) {
-				ERR_PRINT(vformat("Failed to execute file dialog callback: %s.", Variant::get_callable_error_text(cb.callback, args, 3, ce)));
+				ERR_PRINT(vformat("Failed to execute color picker callback: %s.", Variant::get_callable_error_text(cb.callback, args, 2, ce)));
 			}
 		}
 	}
@@ -645,40 +813,72 @@ void FreeDesktopPortalDesktop::_thread_monitor(void *p_ud) {
 					}
 				} else if (dbus_message_is_signal(msg, "org.freedesktop.portal.Request", "Response")) {
 					String path = String::utf8(dbus_message_get_path(msg));
-					MutexLock lock(portal->file_dialog_mutex);
-					for (int i = 0; i < portal->file_dialogs.size(); i++) {
-						FreeDesktopPortalDesktop::FileDialogData &fd = portal->file_dialogs.write[i];
-						if (fd.path == path) {
-							DBusMessageIter iter;
-							if (dbus_message_iter_init(msg, &iter)) {
-								bool cancel = false;
-								Vector<String> uris;
-								Dictionary options;
-								int index = 0;
-								file_chooser_parse_response(&iter, fd.filter_names, fd.option_ids, cancel, uris, index, options);
+					{
+						MutexLock lock(portal->file_dialog_mutex);
+						for (int i = 0; i < portal->file_dialogs.size(); i++) {
+							FreeDesktopPortalDesktop::FileDialogData &fd = portal->file_dialogs.write[i];
+							if (fd.path == path) {
+								DBusMessageIter iter;
+								if (dbus_message_iter_init(msg, &iter)) {
+									bool cancel = false;
+									Vector<String> uris;
+									Dictionary options;
+									int index = 0;
+									file_chooser_parse_response(&iter, fd.filter_names, fd.option_ids, cancel, uris, index, options);
 
-								if (fd.callback.is_valid()) {
-									FileDialogCallback cb;
-									cb.callback = fd.callback;
-									cb.status = !cancel;
-									cb.files = uris;
-									cb.index = index;
-									cb.options = options;
-									cb.opt_in_cb = fd.opt_in_cb;
-									portal->pending_cbs.push_back(cb);
+									if (fd.callback.is_valid()) {
+										FileDialogCallback cb;
+										cb.callback = fd.callback;
+										cb.status = !cancel;
+										cb.files = uris;
+										cb.index = index;
+										cb.options = options;
+										cb.opt_in_cb = fd.opt_in_cb;
+										portal->pending_file_cbs.push_back(cb);
+									}
+									if (fd.prev_focus != DisplayServer::INVALID_WINDOW_ID) {
+										callable_mp(DisplayServer::get_singleton(), &DisplayServer::window_move_to_foreground).call_deferred(fd.prev_focus);
+									}
 								}
-								if (fd.prev_focus != DisplayServer::INVALID_WINDOW_ID) {
-									callable_mp(DisplayServer::get_singleton(), &DisplayServer::window_move_to_foreground).call_deferred(fd.prev_focus);
-								}
+
+								DBusError err;
+								dbus_error_init(&err);
+								dbus_bus_remove_match(portal->monitor_connection, fd.filter.utf8().get_data(), &err);
+								dbus_error_free(&err);
+
+								portal->file_dialogs.remove_at(i);
+								break;
 							}
+						}
+					}
+					{
+						MutexLock lock(portal->color_picker_mutex);
+						for (int i = 0; i < portal->color_pickers.size(); i++) {
+							FreeDesktopPortalDesktop::ColorPickerData &cd = portal->color_pickers.write[i];
+							if (cd.path == path) {
+								DBusMessageIter iter;
+								if (dbus_message_iter_init(msg, &iter)) {
+									bool cancel = false;
+									Color c;
+									color_picker_parse_response(&iter, cancel, c);
 
-							DBusError err;
-							dbus_error_init(&err);
-							dbus_bus_remove_match(portal->monitor_connection, fd.filter.utf8().get_data(), &err);
-							dbus_error_free(&err);
+									if (cd.callback.is_valid()) {
+										ColorPickerCallback cb;
+										cb.callback = cd.callback;
+										cb.color = c;
+										cb.status = !cancel;
+										portal->pending_color_cbs.push_back(cb);
+									}
+								}
 
-							portal->file_dialogs.remove_at(i);
-							break;
+								DBusError err;
+								dbus_error_init(&err);
+								dbus_bus_remove_match(portal->monitor_connection, cd.filter.utf8().get_data(), &err);
+								dbus_error_free(&err);
+
+								portal->color_pickers.remove_at(i);
+								break;
+							}
 						}
 					}
 				}

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -55,6 +55,23 @@ private:
 	static void append_dbus_dict_string(DBusMessageIter *p_iter, const String &p_key, const String &p_value, bool p_as_byte_array = false);
 	static void append_dbus_dict_bool(DBusMessageIter *p_iter, const String &p_key, bool p_value);
 	static bool file_chooser_parse_response(DBusMessageIter *p_iter, const Vector<String> &p_names, const HashMap<String, String> &p_ids, bool &r_cancel, Vector<String> &r_urls, int &r_index, Dictionary &r_options);
+	static bool color_picker_parse_response(DBusMessageIter *p_iter, bool &r_cancel, Color &r_color);
+
+	struct ColorPickerData {
+		Callable callback;
+		String filter;
+		String path;
+	};
+
+	struct ColorPickerCallback {
+		Callable callback;
+		Variant status;
+		Variant color;
+	};
+	List<ColorPickerCallback> pending_color_cbs;
+
+	Mutex color_picker_mutex;
+	Vector<ColorPickerData> color_pickers;
 
 	struct FileDialogData {
 		Vector<String> filter_names;
@@ -74,7 +91,7 @@ private:
 		Variant options;
 		bool opt_in_cb = false;
 	};
-	List<FileDialogCallback> pending_cbs;
+	List<FileDialogCallback> pending_file_cbs;
 
 	Mutex file_dialog_mutex;
 	Vector<FileDialogData> file_dialogs;
@@ -96,11 +113,11 @@ public:
 	bool is_supported() { return !unsupported; }
 	bool is_file_chooser_supported();
 	bool is_settings_supported();
+	bool is_screenshot_supported();
 
 	// org.freedesktop.portal.FileChooser methods.
-
 	Error file_dialog_show(DisplayServer::WindowID p_window_id, const String &p_xid, const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, DisplayServer::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb);
-	void process_file_dialog_callbacks();
+	void process_callbacks();
 
 	// org.freedesktop.portal.Settings methods.
 
@@ -112,6 +129,9 @@ public:
 	void set_system_theme_change_callback(const Callable &p_system_theme_changed) {
 		system_theme_changed = p_system_theme_changed;
 	}
+
+	// org.freedesktop.portal.Screenshot methods.
+	bool color_picker(const String &p_xid, const Callable &p_callback);
 };
 
 #endif // DBUS_ENABLED

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -222,6 +222,9 @@ bool DisplayServerWayland::has_feature(Feature p_feature) const {
 		case FEATURE_NATIVE_DIALOG_FILE_MIME: {
 			return (portal_desktop && portal_desktop->is_supported() && portal_desktop->is_file_chooser_supported());
 		} break;
+		case FEATURE_NATIVE_COLOR_PICKER: {
+			return (portal_desktop && portal_desktop->is_supported() && portal_desktop->is_screenshot_supported());
+		} break;
 #endif
 
 #ifdef SPEECHD_ENABLED
@@ -1165,6 +1168,14 @@ Key DisplayServerWayland::keyboard_get_keycode_from_physical(Key p_keycode) cons
 	return key;
 }
 
+bool DisplayServerWayland::color_picker(const Callable &p_callback) {
+	WindowID window_id = MAIN_WINDOW_ID;
+	// TODO: Use window IDs for multiwindow support.
+
+	WaylandThread::WindowState *ws = wayland_thread.wl_surface_get_window_state(wayland_thread.window_get_wl_surface(window_id));
+	return portal_desktop->color_picker((ws ? ws->exported_handle : String()), p_callback);
+}
+
 void DisplayServerWayland::try_suspend() {
 	// Due to various reasons, we manually handle display synchronization by
 	// waiting for a frame event (request to draw) or, if available, the actual
@@ -1321,7 +1332,7 @@ void DisplayServerWayland::process_events() {
 
 #ifdef DBUS_ENABLED
 	if (portal_desktop) {
-		portal_desktop->process_file_dialog_callbacks();
+		portal_desktop->process_callbacks();
 	}
 #endif
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -300,6 +300,8 @@ public:
 	virtual String keyboard_get_layout_name(int p_index) const override;
 	virtual Key keyboard_get_keycode_from_physical(Key p_keycode) const override;
 
+	virtual bool color_picker(const Callable &p_callback) override;
+
 	virtual void process_events() override;
 
 	virtual void release_rendering_thread() override;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -156,6 +156,9 @@ bool DisplayServerX11::has_feature(Feature p_feature) const {
 		case FEATURE_NATIVE_DIALOG_FILE_MIME: {
 			return (portal_desktop && portal_desktop->is_supported() && portal_desktop->is_file_chooser_supported());
 		} break;
+		case FEATURE_NATIVE_COLOR_PICKER: {
+			return (portal_desktop && portal_desktop->is_supported() && portal_desktop->is_screenshot_supported());
+		} break;
 #endif
 		case FEATURE_SCREEN_CAPTURE: {
 			return !xwayland;
@@ -3469,6 +3472,17 @@ Key DisplayServerX11::keyboard_get_label_from_physical(Key p_keycode) const {
 	return (Key)(key | modifiers);
 }
 
+bool DisplayServerX11::color_picker(const Callable &p_callback) {
+	WindowID window_id = last_focused_window;
+
+	if (!windows.has(window_id)) {
+		window_id = MAIN_WINDOW_ID;
+	}
+
+	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
+	return portal_desktop->color_picker(xid, p_callback);
+}
+
 DisplayServerX11::Property DisplayServerX11::_read_property(Display *p_display, Window p_window, Atom p_property) {
 	Atom actual_type = None;
 	int actual_format = 0;
@@ -5347,7 +5361,7 @@ void DisplayServerX11::process_events() {
 
 #ifdef DBUS_ENABLED
 	if (portal_desktop) {
-		portal_desktop->process_file_dialog_callbacks();
+		portal_desktop->process_callbacks();
 	}
 #endif
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -554,6 +554,8 @@ public:
 	virtual Key keyboard_get_keycode_from_physical(Key p_keycode) const override;
 	virtual Key keyboard_get_label_from_physical(Key p_keycode) const override;
 
+	virtual bool color_picker(const Callable &p_callback) override;
+
 	virtual void process_events() override;
 
 	virtual void release_rendering_thread() override;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -61,7 +61,10 @@ void ColorPicker::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 			// FIXME: The embedding check is needed to fix a bug in single-window mode (GH-93718).
-			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SCREEN_CAPTURE) && !get_tree()->get_root()->is_embedding_subwindows()) {
+			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_COLOR_PICKER)) {
+				btn_pick->set_tooltip_text(ETR("Pick a color from the screen."));
+				btn_pick->connect(SceneStringName(pressed), callable_mp(this, &ColorPicker::_pick_button_pressed_native));
+			} else if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SCREEN_CAPTURE) && !get_tree()->get_root()->is_embedding_subwindows()) {
 				btn_pick->set_tooltip_text(ETR("Pick a color from the screen."));
 				btn_pick->connect(SceneStringName(pressed), callable_mp(this, &ColorPicker::_pick_button_pressed));
 			} else {
@@ -1691,6 +1694,26 @@ void ColorPicker::_text_changed(const String &) {
 void ColorPicker::_add_preset_pressed() {
 	add_preset(color);
 	emit_signal(SNAME("preset_added"), color);
+}
+
+void ColorPicker::_pick_button_pressed_native() {
+	if (!DisplayServer::get_singleton()->color_picker(callable_mp(this, &ColorPicker::_native_cb))) {
+		// Fallback to default/legacy picker.
+		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_SCREEN_CAPTURE) && !get_tree()->get_root()->is_embedding_subwindows()) {
+			_pick_button_pressed();
+		} else {
+			_pick_button_pressed_legacy();
+		}
+	}
+}
+
+void ColorPicker::_native_cb(bool p_status, const Color &p_color) {
+	if (p_status) {
+		set_pick_color(p_color);
+		if (!deferred_mode_enabled) {
+			emit_signal(SNAME("color_changed"), color);
+		}
+	}
 }
 
 void ColorPicker::_pick_button_pressed() {

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -308,6 +308,10 @@ private:
 	void _update_menu_items();
 	void _options_menu_cbk(int p_which);
 
+	// Native color picking.
+	void _pick_button_pressed_native();
+	void _native_cb(bool p_status, const Color &p_color);
+
 	// Legacy color picking.
 	void _pick_button_pressed_legacy();
 	void _picker_texture_input(const Ref<InputEvent> &p_event);

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -742,6 +742,10 @@ Key DisplayServer::keyboard_get_label_from_physical(Key p_keycode) const {
 void DisplayServer::show_emoji_and_symbol_picker() const {
 }
 
+bool DisplayServer::color_picker(const Callable &p_callback) {
+	return false;
+}
+
 void DisplayServer::force_process_and_drop_events() {
 }
 
@@ -1049,6 +1053,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("keyboard_get_label_from_physical", "keycode"), &DisplayServer::keyboard_get_label_from_physical);
 
 	ClassDB::bind_method(D_METHOD("show_emoji_and_symbol_picker"), &DisplayServer::show_emoji_and_symbol_picker);
+	ClassDB::bind_method(D_METHOD("color_picker", "callback"), &DisplayServer::color_picker);
 
 	ClassDB::bind_method(D_METHOD("process_events"), &DisplayServer::process_events);
 	ClassDB::bind_method(D_METHOD("force_process_and_drop_events"), &DisplayServer::force_process_and_drop_events);
@@ -1108,6 +1113,7 @@ void DisplayServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEATURE_WINDOW_EMBEDDING);
 	BIND_ENUM_CONSTANT(FEATURE_NATIVE_DIALOG_FILE_MIME);
 	BIND_ENUM_CONSTANT(FEATURE_EMOJI_AND_SYMBOL_PICKER);
+	BIND_ENUM_CONSTANT(FEATURE_NATIVE_COLOR_PICKER);
 
 	BIND_ENUM_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_HIDDEN);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -162,6 +162,7 @@ public:
 		FEATURE_WINDOW_EMBEDDING,
 		FEATURE_NATIVE_DIALOG_FILE_MIME,
 		FEATURE_EMOJI_AND_SYMBOL_PICKER,
+		FEATURE_NATIVE_COLOR_PICKER,
 	};
 
 	virtual bool has_feature(Feature p_feature) const = 0;
@@ -604,6 +605,7 @@ public:
 	virtual Key keyboard_get_keycode_from_physical(Key p_keycode) const;
 	virtual Key keyboard_get_label_from_physical(Key p_keycode) const;
 	virtual void show_emoji_and_symbol_picker() const;
+	virtual bool color_picker(const Callable &p_callback);
 
 	virtual int tablet_get_driver_count() const { return 1; }
 	virtual String tablet_get_driver_name(int p_driver) const { return "default"; }


### PR DESCRIPTION
Implements native color picker on Linux.

- Fixes issues with color picker on XWayland (see https://github.com/godotengine/godot/pull/101513).
- Allows picking color outside window on Wayland.
- Show also look a bit better on native X11.


https://github.com/user-attachments/assets/5d080456-d8a5-4709-965a-d5ac177c32ac

