### PR TITLE
Optimize `TTR`, `TTRN`, `RTR`, `RTRN` to accept `StringName` instead of `String` for the translation key.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5985,7 +5985,7 @@ Vector<uint8_t> String::to_multibyte_char_buffer(const String &p_encoding) const
  * NOTE: Only use `TTR()` in editor-only code (typically within the `editor/` folder).
  * For translations that can be supplied by exported projects, use `RTR()` instead.
  */
-String TTR(const String &p_text, const String &p_context) {
+String TTR(const StringName &p_text, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		return TranslationServer::get_singleton()->tool_translate(p_text, p_context);
 	}
@@ -6005,7 +6005,7 @@ String TTR(const String &p_text, const String &p_context) {
  * NOTE: Only use `TTRN()` in editor-only code (typically within the `editor/` folder).
  * For translations that can be supplied by exported projects, use `RTRN()` instead.
  */
-String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+String TTRN(const StringName &p_text, const StringName &p_text_plural, int p_n, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		return TranslationServer::get_singleton()->tool_translate_plural(p_text, p_text_plural, p_n, p_context);
 	}
@@ -6067,7 +6067,7 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
  * NOTE: Do not use `RTR()` in editor-only code (typically within the `editor/`
  * folder). For editor translations, use `TTR()` instead.
  */
-String RTR(const String &p_text, const String &p_context) {
+String RTR(const StringName &p_text, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		String rtr = TranslationServer::get_singleton()->tool_translate(p_text, p_context);
 		if (rtr.is_empty() || rtr == p_text) {
@@ -6090,7 +6090,7 @@ String RTR(const String &p_text, const String &p_context) {
  * NOTE: Do not use `RTRN()` in editor-only code (typically within the `editor/`
  * folder). For editor translations, use `TTRN()` instead.
  */
-String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+String RTRN(const StringName &p_text, const StringName &p_text_plural, int p_n, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		String rtr = TranslationServer::get_singleton()->tool_translate_plural(p_text, p_text_plural, p_n, p_context);
 		if (rtr.is_empty() || rtr == p_text || rtr == p_text_plural) {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5715,7 +5715,7 @@ Vector<uint8_t> String::to_multibyte_char_buffer(const String &p_encoding) const
  * NOTE: Only use `TTR()` in editor-only code (typically within the `editor/` folder).
  * For translations that can be supplied by exported projects, use `RTR()` instead.
  */
-String TTR(const String &p_text, const String &p_context) {
+String TTR(const StringName &p_text, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		return TranslationServer::get_singleton()->get_editor_domain()->translate(p_text, p_context);
 	}
@@ -5735,7 +5735,7 @@ String TTR(const String &p_text, const String &p_context) {
  * NOTE: Only use `TTRN()` in editor-only code (typically within the `editor/` folder).
  * For translations that can be supplied by exported projects, use `RTRN()` instead.
  */
-String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+String TTRN(const StringName &p_text, const StringName &p_text_plural, int p_n, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 		return TranslationServer::get_singleton()->get_editor_domain()->translate_plural(p_text, p_text_plural, p_n, p_context);
 	}
@@ -5797,7 +5797,7 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
  * NOTE: Do not use `RTR()` in editor-only code (typically within the `editor/`
  * folder). For editor translations, use `TTR()` instead.
  */
-String RTR(const String &p_text, const String &p_context) {
+String RTR(const StringName &p_text, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 #ifdef TOOLS_ENABLED
 		String rtr = TranslationServer::get_singleton()->get_editor_domain()->translate(p_text, p_context);
@@ -5822,7 +5822,7 @@ String RTR(const String &p_text, const String &p_context) {
  * NOTE: Do not use `RTRN()` in editor-only code (typically within the `editor/`
  * folder). For editor translations, use `TTRN()` instead.
  */
-String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context) {
+String RTRN(const StringName &p_text, const StringName &p_text_plural, int p_n, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
 #ifdef TOOLS_ENABLED
 		String rtr = TranslationServer::get_singleton()->get_editor_domain()->translate_plural(p_text, p_text_plural, p_n, p_context);

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -717,8 +717,8 @@ struct FileNoCaseComparator {
 // and doc translate for the class reference (DTR).
 #ifdef TOOLS_ENABLED
 // Gets parsed.
-String TTR(const String &p_text, const String &p_context = "");
-String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String TTR(const StringName &p_text, const String &p_context = "");
+String TTRN(const StringName &p_text, const StringName &p_text_plural, int p_n, const String &p_context = "");
 String DTR(const String &p_text, const String &p_context = "");
 String DTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
 // Use for C strings.
@@ -742,8 +742,8 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 #define GNAME(m_value, m_prefix) (m_value)
 
 // Runtime translate for the public node API.
-String RTR(const String &p_text, const String &p_context = "");
-String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String RTR(const StringName &p_text, const String &p_context = "");
+String RTRN(const StringName &p_text, const StringName &p_text_plural, int p_n, const String &p_context = "");
 
 /**
  * "Extractable TRanslate". Used for strings that can appear inside an exported

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -37,6 +37,7 @@
 #include "core/typedefs.h"
 
 class String;
+class StringName;
 template <typename T>
 class CharStringT;
 
@@ -757,8 +758,8 @@ struct FileNoCaseComparator {
 // and doc translate for the class reference (DTR).
 #ifdef TOOLS_ENABLED
 // Gets parsed.
-String TTR(const String &p_text, const String &p_context = "");
-String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String TTR(const StringName &p_text, const String &p_context = "");
+String TTRN(const StringName &p_text, const StringName &p_text_plural, int p_n, const String &p_context = "");
 String DTR(const String &p_text, const String &p_context = "");
 String DTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
 // Use for C strings.
@@ -782,8 +783,8 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 #define GNAME(m_value, m_prefix) (m_value)
 
 // Runtime translate for the public node API.
-String RTR(const String &p_text, const String &p_context = "");
-String RTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+String RTR(const StringName &p_text, const String &p_context = "");
+String RTRN(const StringName &p_text, const StringName &p_text_plural, int p_n, const String &p_context = "");
 
 /**
  * "Extractable TRanslate". Used for strings that can appear inside an exported

--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -127,7 +127,9 @@ Control *EditorTextureTooltipPlugin::make_tooltip_for_path(const String &p_resou
 	vb->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 
 	Vector2 dimensions = p_metadata.get("dimensions", Vector2());
-	Label *label = memnew(Label(vformat(TTR(U"Dimensions: %d × %d"), dimensions.x, dimensions.y)));
+	// StringName has no UTF-32 constructor, so we need to use a temporary String to translate the text.
+	static constexpr char32_t dimensions_label_text_key[] = TTRC(U"Dimensions: %d × %d");
+	Label *label = memnew(Label(vformat(TTRGET(String(dimensions_label_text_key)), dimensions.x, dimensions.y)));
 	vb->add_child(label);
 
 	TextureRect *tr = memnew(TextureRect);

--- a/editor/plugins/editor_resource_tooltip_plugins.cpp
+++ b/editor/plugins/editor_resource_tooltip_plugins.cpp
@@ -114,7 +114,9 @@ Control *EditorTextureTooltipPlugin::make_tooltip_for_path(const String &p_resou
 	vb->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 
 	Vector2 dimensions = p_metadata.get("dimensions", Vector2());
-	Label *label = memnew(Label(vformat(TTR(U"Dimensions: %d × %d"), dimensions.x, dimensions.y)));
+	// StringName has no UTF-32 constructor, so we need to use a temporary String to translate the text.
+	static constexpr char32_t dimensions_label_text_key[] = TTRC(U"Dimensions: %d × %d");
+	Label *label = memnew(Label(vformat(TTRGET(String(dimensions_label_text_key)), dimensions.x, dimensions.y)));
 	vb->add_child(label);
 
 	TextureRect *tr = memnew(TextureRect);


### PR DESCRIPTION
This avoids unnecessary allocation, and should make calls to translate slightly faster.

This PR has the side effect of crashing the program if `TTR` (or any of the other functions) are called before the `StringName` table is initialized. Unit tests should fail if this were the case anywhere in the codebase, especially because `TTR` calls will fail before the translation server is started anyway.
(I needed to fix one instance of this problem recently in https://github.com/godotengine/godot/pull/101592).

## Reasoning
Let's look at the current implementation of `TTR` as an example.

```c++
String TTR(const String &p_text, const String &p_context) {
	if (TranslationServer::get_singleton()) {
		return TranslationServer::get_singleton()->tool_translate(p_text, p_context);
	}

	return p_text;
}
// Usually called like 
TTR("Translation Key")
```

On call, the `char *` is converted to `String` by allocating memory and copying into it. 
Then, it could go 2 ways. If `TranslationServer` exists, `tool_translate` is called. The function accepts a `StringName`, and thus has to convert `String` to `StringName`. If `TranslationServer` does not exist, the string is returned unchanged. 
To summarize, a `String` object is always allocated, and is usually converted to `StringName`.

Let's change the function to take `StringName`:
```c++
String TTR(const StringName &p_text, const String &p_context) {
	if (TranslationServer::get_singleton()) {
		return TranslationServer::get_singleton()->tool_translate(p_text, p_context);
	}

	return p_text;
}
```

On call, the `char *` is converted to `StringName` by searching the `StringName` table without allocation. This is (nearly) guaranteed because whatever is passed into `TTR` corresponds to a `StringName` that was already created for the translation server.
Then, it could go 2 ways. If `TranslationServer` exists, `tool_translate` is called. `p_text` is passed to it without change. If `TranslationServer` does not exist, the `StringName` has to be converted to `String`. 
To summarize, a `StringName` object is always used, and is rarely converted to `String`.

#### Verdict

The new implementation is _almost always_ cheaper than the old implementation, **except when** `TranslationServer` does not exist, _and_ the input is already a `String` (instead of `char *`). In this case, the `StringName` database is unnecessarily searched (though no unnecessary data is allocated, and thus not much time is lost). I don't think this case is important, because searches for `TTR\([^"]` and similar do not yield many results.
