### PR TITLE
Use `AHashMap` for `RBMap nodes` and `HashMap` `input_activity` (reverted)

### DIFF
--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -410,7 +410,7 @@ class AnimationNodeBlendTree : public AnimationRootNode {
 		Vector<StringName> connections;
 	};
 
-	RBMap<StringName, Node, StringName::AlphCompare> nodes;
+	AHashMap<StringName, Node> nodes;
 
 	Vector2 graph_offset;
 

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -306,8 +306,8 @@ private:
 		uint64_t last_pass = 0;
 		real_t activity = 0.0;
 	};
-	mutable HashMap<StringName, LocalVector<Activity>> input_activity_map;
-	mutable HashMap<StringName, LocalVector<Activity> *> input_activity_map_get;
+	mutable AHashMap<StringName, LocalVector<Activity>> input_activity_map;
+	mutable AHashMap<StringName, LocalVector<Activity> *> input_activity_map_get;
 
 	NodePath animation_player;
 


### PR DESCRIPTION
Forgot to change in #92554

Gives 15% more FPS on MPR from #101494.

Helps with #101494