### PR TITLE
Fix stray pixel artifacts when BaseMaterial3D Deep Parallax is enabled

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -725,8 +725,9 @@ void BaseMaterial3D::_update_shader() {
 	// used. The losers will free their shader.
 
 	String texfilter_str;
-	// Force linear filtering for the heightmap texture, as the heightmap effect
+	// Force linear filtering with no mipmaps for the heightmap texture, as the heightmap effect
 	// looks broken with nearest-neighbor filtering (with and without Deep Parallax).
+	// Mipmaps also result in stray pixel artifacts when Deep Parallax is enabled.
 	String texfilter_height_str;
 	switch (texture_filter) {
 		case TEXTURE_FILTER_NEAREST:
@@ -739,19 +740,19 @@ void BaseMaterial3D::_update_shader() {
 			break;
 		case TEXTURE_FILTER_NEAREST_WITH_MIPMAPS:
 			texfilter_str = "filter_nearest_mipmap";
-			texfilter_height_str = "filter_linear_mipmap";
+			texfilter_height_str = "filter_linear";
 			break;
 		case TEXTURE_FILTER_LINEAR_WITH_MIPMAPS:
 			texfilter_str = "filter_linear_mipmap";
-			texfilter_height_str = "filter_linear_mipmap";
+			texfilter_height_str = "filter_linear";
 			break;
 		case TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC:
 			texfilter_str = "filter_nearest_mipmap_anisotropic";
-			texfilter_height_str = "filter_linear_mipmap_anisotropic";
+			texfilter_height_str = "filter_linear";
 			break;
 		case TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC:
 			texfilter_str = "filter_linear_mipmap_anisotropic";
-			texfilter_height_str = "filter_linear_mipmap_anisotropic";
+			texfilter_height_str = "filter_linear";
 			break;
 		case TEXTURE_FILTER_MAX:
 			break; // Internal value, skip.


### PR DESCRIPTION
- *Related to https://github.com/godotengine/godot/pull/97646.*

Mipmaps for the heightmap seem to cause issues with the parallax occlusion mapping algorithm used. This is most noticeable with steep height changes where surrounding pixels will occasionally appear depending on the view angle. This occurs regardless of the **Min Layers** and **Max Layers** values.

Note that there may be a better solution to this, such as sampling the heightmap texture differently (e.g. `textureGrad()`). This could result in better performance as mipmaps allow the GPU to sample a lower-resolution texture in the distance – however, for this to be beneficial, the different texture sampling method must not be more expensive than disabling mipmaps.

I found this issue (and the way to fix it) using https://github.com/Calinou/godot-rendering-tests' texture sampling test.

**Edit:** Xtarsia mentioned on the Godot VFX Discord that this could resolved in a more optimized way in Forward+/Mobile:

> textureLod() for the heightmap read, rather than disabling mipmaps entirely?
> 1 call to textureQueryLod() before the loop should be sufficient. This is likley to be faster than no mipmaps at all?
>
> Can fall back to textureLod(height_sampler, uv, 0.0) for Compatibility

**Testing project:** https://github.com/Calinou/godot-parallax-test-4.0

## Preview

### Before

https://github.com/user-attachments/assets/1287249f-73ec-4884-aca8-456e0b306167

### After

https://github.com/user-attachments/assets/9c367434-8b7b-4346-9052-57a728fe8967

