### PR TITLE
Add support for white parameter to AgX tonemapper

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -321,7 +321,7 @@
 		</member>
 		<member name="tonemap_white" type="float" setter="set_tonemap_white" getter="get_tonemap_white" default="1.0">
 			The white reference value for tonemapping (also called "whitepoint"). Higher values can make highlights look less blown out, and will also slightly darken the whole scene as a result. See also [member tonemap_exposure].
-			[b]Note:[/b] [member tonemap_white] is ignored when using [constant TONE_MAPPER_LINEAR] or [constant TONE_MAPPER_AGX].
+			[b]Note:[/b] [member tonemap_white] is ignored when using [constant TONE_MAPPER_LINEAR].
 		</member>
 		<member name="volumetric_fog_albedo" type="Color" setter="set_volumetric_fog_albedo" getter="get_volumetric_fog_albedo" default="Color(1, 1, 1, 1)">
 			The [Color] of the volumetric fog when interacting with lights. Mist and fog have an albedo close to [code]Color(1, 1, 1, 1)[/code] while smoke has a darker albedo.

--- a/drivers/gles3/shaders/tonemap_inc.glsl
+++ b/drivers/gles3/shaders/tonemap_inc.glsl
@@ -99,7 +99,8 @@ vec3 agx_contrast_approx(vec3 x) {
 // This is an approximation and simplification of EaryChow's AgX implementation that is used by Blender.
 // This code is based off of the script that generates the AgX_Base_sRGB.cube LUT that Blender uses.
 // Source: https://github.com/EaryChow/AgX_LUT_Gen/blob/main/AgXBasesRGB.py
-vec3 tonemap_agx(vec3 color) {
+// max_ev is a log2 encoded white parameter.
+vec3 tonemap_agx(vec3 color, float max_ev) {
 	// Combined linear sRGB to linear Rec 2020 and Blender AgX inset matrices:
 	const mat3 srgb_to_rec2020_agx_inset_matrix = mat3(
 			0.54490813676363087053, 0.14044005884001287035, 0.088827411851915368603,
@@ -113,10 +114,8 @@ vec3 tonemap_agx(vec3 color) {
 			-0.10886710826831608324, -0.027084020983874825605, 1.402665347143271889);
 
 	// LOG2_MIN      = -10.0
-	// LOG2_MAX      =  +6.5
 	// MIDDLE_GRAY   =  0.18
 	const float min_ev = -12.4739311883324; // log2(pow(2, LOG2_MIN) * MIDDLE_GRAY)
-	const float max_ev = 4.02606881166759; // log2(pow(2, LOG2_MAX) * MIDDLE_GRAY)
 
 	// Large negative values in one channel and large positive values in other
 	// channels can result in a colour that appears darker and more saturated than
@@ -175,7 +174,7 @@ vec3 apply_tonemapping(vec3 color, float p_white) { // inputs are LINEAR
 	} else if (tonemapper == TONEMAPPER_ACES) {
 		return tonemap_aces(max(vec3(0.0f), color), p_white);
 	} else { // TONEMAPPER_AGX
-		return tonemap_agx(color);
+		return tonemap_agx(color, p_white);
 	}
 }
 

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1120,8 +1120,7 @@ void Environment::_validate_property(PropertyInfo &p_property) const {
 		}
 	}
 
-	if (p_property.name == "tonemap_white" && (tone_mapper == TONE_MAPPER_LINEAR || tone_mapper == TONE_MAPPER_AGX)) {
-		// Whitepoint adjustment is not available with AgX or linear as it's hardcoded there.
+	if (p_property.name == "tonemap_white" && tone_mapper == TONE_MAPPER_LINEAR) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
@@ -1278,7 +1277,7 @@ void Environment::_bind_methods() {
 	ADD_GROUP("Tonemap", "tonemap_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tonemap_mode", PROPERTY_HINT_ENUM, "Linear,Reinhard,Filmic,ACES,AgX"), "set_tonemapper", "get_tonemapper");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_exposure", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_exposure", "get_tonemap_exposure");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_white", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_white", "get_tonemap_white");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_white", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_tonemap_white", "get_tonemap_white");
 
 	// SSR
 

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -279,7 +279,8 @@ vec3 agx_contrast_approx(vec3 x) {
 // This is an approximation and simplification of EaryChow's AgX implementation that is used by Blender.
 // This code is based off of the script that generates the AgX_Base_sRGB.cube LUT that Blender uses.
 // Source: https://github.com/EaryChow/AgX_LUT_Gen/blob/main/AgXBasesRGB.py
-vec3 tonemap_agx(vec3 color) {
+// max_ev is a log2 encoded white parameter.
+vec3 tonemap_agx(vec3 color, float max_ev) {
 	// Combined linear sRGB to linear Rec 2020 and Blender AgX inset matrices:
 	const mat3 srgb_to_rec2020_agx_inset_matrix = mat3(
 			0.54490813676363087053, 0.14044005884001287035, 0.088827411851915368603,
@@ -293,10 +294,8 @@ vec3 tonemap_agx(vec3 color) {
 			-0.10886710826831608324, -0.027084020983874825605, 1.402665347143271889);
 
 	// LOG2_MIN      = -10.0
-	// LOG2_MAX      =  +6.5
 	// MIDDLE_GRAY   =  0.18
 	const float min_ev = -12.4739311883324; // log2(pow(2, LOG2_MIN) * MIDDLE_GRAY)
-	const float max_ev = 4.02606881166759; // log2(pow(2, LOG2_MAX) * MIDDLE_GRAY)
 
 	// Large negative values in one channel and large positive values in other
 	// channels can result in a colour that appears darker and more saturated than
@@ -362,7 +361,7 @@ vec3 apply_tonemapping(vec3 color, float white) { // inputs are LINEAR
 	} else if (params.tonemapper == TONEMAPPER_ACES) {
 		return tonemap_aces(max(vec3(0.0f), color), white);
 	} else { // TONEMAPPER_AGX
-		return tonemap_agx(color);
+		return tonemap_agx(color, white);
 	}
 }
 

--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -208,7 +208,7 @@ void RendererEnvironmentStorage::environment_set_tonemap(RID p_env, RS::Environm
 	ERR_FAIL_NULL(env);
 	env->exposure = p_exposure;
 	env->tone_mapper = p_tone_mapper;
-	env->white = p_white;
+	env->white = p_tone_mapper == RS::ENV_TONE_MAPPER_AGX ? log2f(p_white) : p_white;
 }
 
 RS::EnvironmentToneMapper RendererEnvironmentStorage::environment_get_tone_mapper(RID p_env) const {


### PR DESCRIPTION
- Fixes #101558

Not cherry-pickable to 4.3, as AgX is only in 4.4.

### Usage

In addition to resolving issues with the Mobile renderer, the white parameter can be used to give higher contrast to AgX by decreasing both `exposure` and `white`. This approach is higher quality than using the Environment's contrast adjustment and less also less computationally expensive.

| Forward+ with no white parameter (16 white) | Forward+ with white parameter (adjusted exposure and white)
| --- | ---
| ![image](https://github.com/user-attachments/assets/302a3fb7-948d-427a-b979-29bb28ee0bef) | ![image](https://github.com/user-attachments/assets/b8a9a5cc-1c74-474c-a024-942006cdfc92)

#### Consistent rendering between Mobile and Forward+
Because the Mobile renderer only provides values to the tonemapper up to `2.0`, you can achieve the same look with AgX between the Mobile and Forward+ renderers by setting the `white` paramter to `2.0` or less. This makes it easy to use AgX on a cross-platform game that must use the Mobile renderer on some platforms, but uses the Forward+ renderer on others.

### TODO
~~☑ Fix issue that sometimes occurs when `white <= 1.0` and Compatibility renderer.~~ (seems to be a local build issue...)
☑ Optional: Limit editor's range of `White` parameter to prevent value of `0.0`.