### PR TITLE
Fix union order to simplify empty initializers

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -35,12 +35,12 @@
 
 struct HashMapData {
 	union {
+		uint64_t data;
 		struct
 		{
 			uint32_t hash;
 			uint32_t hash_to_key;
 		};
-		uint64_t data;
 	};
 };
 

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -251,6 +251,10 @@ private:
 
 		union {
 			struct {
+				uint64_t sort_key1;
+				uint64_t sort_key2;
+			};
+			struct {
 				uint64_t lod_index : 8;
 				uint64_t surface_index : 8;
 				uint64_t geometry_id : 32;
@@ -264,10 +268,6 @@ private:
 				uint64_t uses_lightmap : 1;
 				uint64_t depth_layer : 4;
 				uint64_t priority : 8;
-			};
-			struct {
-				uint64_t sort_key1;
-				uint64_t sort_key2;
 			};
 		} sort;
 

--- a/scene/3d/voxelizer.h
+++ b/scene/3d/voxelizer.h
@@ -72,13 +72,13 @@ private:
 
 	struct CellSort {
 		union {
+			uint64_t key = 0;
 			struct {
 				uint64_t z : 16;
 				uint64_t y : 16;
 				uint64_t x : 16;
 				uint64_t level : 16;
 			};
-			uint64_t key = 0;
 		};
 
 		int32_t index = 0;

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -150,11 +150,11 @@ public:
 private:
 	struct ConnectionType {
 		union {
+			uint64_t key = 0;
 			struct {
 				uint32_t type_a;
 				uint32_t type_b;
 			};
-			uint64_t key = 0;
 		};
 
 		static uint32_t hash(const ConnectionType &p_conn) {

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -429,6 +429,10 @@ private:
 
 		union {
 			struct {
+				uint64_t sort_key1;
+				uint64_t sort_key2;
+			};
+			struct {
 				uint64_t lod_index : 8;
 				uint64_t surface_index : 8;
 				uint64_t geometry_id : 32;
@@ -442,10 +446,6 @@ private:
 				uint64_t uses_lightmap : 1;
 				uint64_t depth_layer : 4;
 				uint64_t priority : 8;
-			};
-			struct {
-				uint64_t sort_key1;
-				uint64_t sort_key2;
 			};
 		} sort;
 
@@ -541,6 +541,8 @@ private:
 
 	struct GlobalPipelineData {
 		union {
+			uint32_t key;
+
 			struct {
 				uint32_t texture_samples : 3;
 				uint32_t use_reflection_probes : 1;
@@ -556,8 +558,6 @@ private:
 				uint32_t use_shadow_cubemaps : 1;
 				uint32_t use_shadow_dual_paraboloid : 1;
 			};
-
-			uint32_t key;
 		};
 	};
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -398,6 +398,10 @@ protected:
 
 		union {
 			struct {
+				uint64_t sort_key1;
+				uint64_t sort_key2;
+			};
+			struct {
 				// !BAS! CHECK BITS!!!
 
 				uint64_t surface_index : 10;
@@ -412,10 +416,6 @@ protected:
 
 				// uint64_t lod_index : 8; // no need to sort on LOD
 				// uint64_t uses_forward_gi : 1; // no GI here, remove
-			};
-			struct {
-				uint64_t sort_key1;
-				uint64_t sort_key2;
 			};
 		} sort;
 
@@ -575,6 +575,8 @@ public:
 
 	struct GlobalPipelineData {
 		union {
+			uint32_t key;
+
 			struct {
 				uint32_t texture_samples : 3;
 				uint32_t target_samples : 3;
@@ -586,8 +588,6 @@ public:
 				uint32_t use_shadow_cubemaps : 1;
 				uint32_t use_shadow_dual_paraboloid : 1;
 			};
-
-			uint32_t key;
 		};
 	};
 


### PR DESCRIPTION
This is a followup to PR #101344 (commit 0e06eb80bc9cf08000bf86d06c0ce57bcf7775be).

Some of them were not an issue because Godot was initializing all members, but they were "fixed" just in case since it could become a problem in the future.

Valgrind was specifically complaining about HashMapData & GlobalPipelineData.