### PR TITLE
Optimize and expose `Basis::scaled_local` to script

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -232,15 +232,9 @@ Basis Basis::from_scale(const Vector3 &p_scale) {
 // Multiplies the matrix from left by the scaling matrix: M -> S.M
 // See the comment for Basis::rotated for further explanation.
 void Basis::scale(const Vector3 &p_scale) {
-	rows[0][0] *= p_scale.x;
-	rows[0][1] *= p_scale.x;
-	rows[0][2] *= p_scale.x;
-	rows[1][0] *= p_scale.y;
-	rows[1][1] *= p_scale.y;
-	rows[1][2] *= p_scale.y;
-	rows[2][0] *= p_scale.z;
-	rows[2][1] *= p_scale.z;
-	rows[2][2] *= p_scale.z;
+	rows[0] *= p_scale.x;
+	rows[1] *= p_scale.y;
+	rows[2] *= p_scale.z;
 }
 
 Basis Basis::scaled(const Vector3 &p_scale) const {
@@ -252,7 +246,9 @@ Basis Basis::scaled(const Vector3 &p_scale) const {
 void Basis::scale_local(const Vector3 &p_scale) {
 	// performs a scaling in object-local coordinate system:
 	// M -> (M.S.Minv).M = M.S.
-	*this = scaled_local(p_scale);
+	rows[0] *= p_scale;
+	rows[1] *= p_scale;
+	rows[2] *= p_scale;
 }
 
 void Basis::scale_orthogonal(const Vector3 &p_scale) {
@@ -283,7 +279,9 @@ real_t Basis::get_uniform_scale() const {
 }
 
 Basis Basis::scaled_local(const Vector3 &p_scale) const {
-	return (*this) * Basis::from_scale(p_scale);
+	Basis m = *this;
+	m.scale_local(p_scale);
+	return m;
 }
 
 Vector3 Basis::get_scale_abs() const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2299,6 +2299,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Basis, determinant, sarray(), varray());
 	bind_methodv(Basis, rotated, static_cast<Basis (Basis::*)(const Vector3 &, real_t) const>(&Basis::rotated), sarray("axis", "angle"), varray());
 	bind_method(Basis, scaled, sarray("scale"), varray());
+	bind_method(Basis, scaled_local, sarray("scale"), varray());
 	bind_method(Basis, get_scale, sarray(), varray());
 	bind_method(Basis, get_euler, sarray("order"), varray((int64_t)EulerOrder::YXZ));
 	bind_method(Basis, tdotx, sarray("with"), varray());

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -305,6 +305,40 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="scaled_local" qualifiers="const">
+			<return type="Basis" />
+			<param index="0" name="scale" type="Vector3" />
+			<description>
+				Returns this basis with each axis scaled by the corresponding component in the given [param scale].
+				The basis matrix's columns are multiplied by [param scale]'s components. This operation is a local scale (relative to self).
+				[codeblocks]
+				[gdscript]
+				var my_basis = Basis(
+				    Vector3(1, 1, 1),
+				    Vector3(2, 2, 2),
+				    Vector3(3, 3, 3)
+				)
+				my_basis = my_basis.scaled_local(Vector3(0, 2, -2))
+
+				print(my_basis.x) # Prints (0.0, 0.0, 0.0)
+				print(my_basis.y) # Prints (4.0, 4.0, 4.0)
+				print(my_basis.z) # Prints (-6.0, -6.0, -6.0)
+				[/gdscript]
+				[csharp]
+				var myBasis = new Basis(
+				    new Vector3(1.0f, 1.0f, 1.0f),
+				    new Vector3(2.0f, 2.0f, 2.0f),
+				    new Vector3(3.0f, 3.0f, 3.0f)
+				);
+				myBasis = myBasis.ScaledLocal(new Vector3(0.0f, 2.0f, -2.0f));
+
+				GD.Print(myBasis.X); // Prints (0, 0, 0)
+				GD.Print(myBasis.Y); // Prints (4, 4, 4)
+				GD.Print(myBasis.Z); // Prints (-6, -6, -6)
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="slerp" qualifiers="const" keywords="interpolate">
 			<return type="Basis" />
 			<param index="0" name="to" type="Basis" />


### PR DESCRIPTION
`Basis::scaled_local` is a very common 3D math operation that was not exposed to scripts. This PR exposes it.
It was also previously unnecessarily performing a matrix-by-matrix multiplication. This PR optimizes it to simply scale each axis.
Finally, the code in `Basis::scale` was also streamlined a bit (no perf gain/loss, only clarity).

Tested visually with a rotated 3D mesh, and also tested by printout with the sample code in the documentation.

Closes [#11560](https://github.com/godotengine/godot-proposals/issues/11560).