### PR TITLE
Cache `String` concatenation in `_blend_node`

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -290,22 +290,26 @@ AnimationNode::NodeTimeInfo AnimationNode::_blend_node(Ref<AnimationNode> p_node
 		}
 	}
 
-	String new_path;
 	AnimationNode *new_parent;
 
-	// This is the slowest part of processing, but as strings process in powers of 2, and the paths always exist, it will not result in that many allocations.
 	if (p_new_parent) {
 		new_parent = p_new_parent;
-		new_path = String(node_state.base_path) + String(p_subpath) + "/";
 	} else {
 		ERR_FAIL_NULL_V(node_state.parent, NodeTimeInfo());
 		new_parent = node_state.parent;
-		new_path = String(new_parent->node_state.base_path) + String(p_subpath) + "/";
+	}
+
+	StringName &base_path = p_new_parent != nullptr ? node_state.base_path : new_parent->node_state.base_path;
+
+	if (unlikely(base_path != p_node->current_base_path || p_subpath != p_node->current_subpath)) {
+		p_node->current_base_path = base_path;
+		p_node->current_subpath = p_subpath;
+		String new_path = String(base_path) + String(p_subpath) + "/";
+		p_node->set_node_state_base_path(std::move(new_path));
 	}
 
 	// This process, which depends on p_sync is needed to process sync correctly in the case of
 	// that a synced AnimationNodeSync exists under the un-synced AnimationNodeSync.
-	p_node->set_node_state_base_path(new_path);
 	p_node->node_state.parent = new_parent;
 	if (!p_playback_info.seeked && !p_sync && !any_valid) {
 		p_playback_info.delta = 0.0;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -125,6 +125,8 @@ public:
 
 private:
 	mutable AHashMap<StringName, int> property_cache;
+	StringName current_base_path;
+	StringName current_subpath;
 
 public:
 	void set_node_state_base_path(const StringName p_base_path) {


### PR DESCRIPTION
Caches the slowest part of the `AnimationTree`. If something changes with the tree (a node is added or removed), the cache for all nodes will become dirty.
Combined with #101548 adds 50% to the FPS for MRP from #101494.