### PR TITLE
Add a note to `DisplayServer.get_display_safe_area()` method documentation

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -214,6 +214,7 @@
 			<return type="Rect2i" />
 			<description>
 				Returns the unobscured area of the display where interactive controls should be rendered. See also [method get_display_cutouts].
+				[b]Note:[/b] Currently only implemented on Android and iOS. On other platforms, [code]screen_get_usable_rect(SCREEN_OF_MAIN_WINDOW)[/code] will be returned as a fallback. See also [method screen_get_usable_rect].
 			</description>
 		</method>
 		<method name="get_keyboard_focus_screen" qualifiers="const">


### PR DESCRIPTION
Closes [#10490](https://github.com/godotengine/godot-docs/issues/10490)

#### Changes made
- Added a note to clarify that the `DisplayServer.get_display_safe_area()` method is currently only implemented on **Android** and **iOS**, with `screen_get_usable_rect(SCREEN_OF_MAIN_WINDOW)` being used as a fallback on other platforms.