### PR TITLE
Don't instantiate `ColorPicker` in `EditorPropertyColor` constructor

### DIFF
--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -593,8 +593,9 @@ class EditorPropertyColor : public EditorProperty {
 	GDCLASS(EditorPropertyColor, EditorProperty);
 	ColorPickerButton *picker = nullptr;
 	void _color_changed(const Color &p_color);
+	void _picker_created();
+	void _popup_opening();
 	void _popup_closed();
-	void _picker_opening();
 
 	Color last_color;
 	bool live_changes_enabled = true;


### PR DESCRIPTION
- Fixes #101569

The `EditorPropertyColor` constructor was using `ColorPickerButton::get_popup()` and `ColorPickerButton::get_picker()`, which was instantiating the ColorPicker without it being opened first. This led to 40+ pickers being instantiated in some cases.

This PR avoids calling those getters by using the `ColorPickerButton::picker_created` signal to setup the picker at a later stage.

On a debug build I get these results (quickly measured by eye & timer):
- Opening `Editor Settings > Text Editor > Theme`:
  - Master: 2 sec
  - This PR: instant
- Opening the MRP inspector:
  - Master: 1.5 sec
  - This PR: 0.2 sec (must be other Node properties making it not instant)
 
Switching away to another setting or inspector is faster now too, since there's no need to delete all the pickers.