### PR TITLE
Fix conversion plugin search showing errors on `TextFile` and `OtherFile`.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6574,7 +6574,7 @@ Vector<Ref<EditorResourceConversionPlugin>> EditorNode::find_resource_conversion
 Vector<Ref<EditorResourceConversionPlugin>> EditorNode::find_resource_conversion_plugin_for_type_name(const String &p_type) {
 	Vector<Ref<EditorResourceConversionPlugin>> ret;
 
-	if (ClassDB::can_instantiate(p_type)) {
+	if (ClassDB::class_exists(p_type) && ClassDB::can_instantiate(p_type)) {
 		Ref<Resource> temp = Object::cast_to<Resource>(ClassDB::instantiate(p_type));
 		if (temp.is_valid()) {
 			for (Ref<EditorResourceConversionPlugin> resource_conversion_plugin : resource_conversion_plugins) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/101447

Editor file system use special `TextFile` / `OtherFile` type names for some files that are not Godot class names but still shown in the FS dock.
