### PR TITLE
Fix project manager window size when `EDSCALE` is not 1.0.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -149,7 +149,7 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 
 // Main layout.
 
-void ProjectManager::_update_size_limits() {
+void ProjectManager::_update_size_limits(bool p_custom_res) {
 	const Size2 minimum_size = Size2(720, 450) * EDSCALE;
 	const Size2 default_size = Size2(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT) * EDSCALE;
 
@@ -159,20 +159,21 @@ void ProjectManager::_update_size_limits() {
 		// Calling Window methods this early doesn't sync properties with DS.
 		w->set_min_size(minimum_size);
 		DisplayServer::get_singleton()->window_set_min_size(minimum_size);
-		if (DisplayServer::get_singleton()->window_get_size() == default_size) {
+		if (!p_custom_res) {
 			// Only set window size if it currently matches the default, which is defined in `main/main.cpp`.
 			// This allows CLI arguments to override the window size.
 			w->set_size(default_size);
 			DisplayServer::get_singleton()->window_set_size(default_size);
 		}
 	}
+	Size2 real_size = DisplayServer::get_singleton()->window_get_size();
 
 	Rect2i screen_rect = DisplayServer::get_singleton()->screen_get_usable_rect(DisplayServer::get_singleton()->window_get_current_screen());
 	if (screen_rect.size != Vector2i()) {
 		// Center the window on the screen.
 		Vector2i window_position;
-		window_position.x = screen_rect.position.x + (screen_rect.size.x - default_size.x) / 2;
-		window_position.y = screen_rect.position.y + (screen_rect.size.y - default_size.y) / 2;
+		window_position.x = screen_rect.position.x + (screen_rect.size.x - real_size.x) / 2;
+		window_position.y = screen_rect.position.y + (screen_rect.size.y - real_size.y) / 2;
 		DisplayServer::get_singleton()->window_set_position(window_position);
 
 		// Limit popup menus to prevent unusably long lists.
@@ -1152,7 +1153,7 @@ void ProjectManager::_titlebar_resized() {
 
 // Object methods.
 
-ProjectManager::ProjectManager() {
+ProjectManager::ProjectManager(bool p_custom_res) {
 	singleton = this;
 
 	set_translation_domain("godot.editor");
@@ -1740,7 +1741,7 @@ ProjectManager::ProjectManager() {
 		title_bar->connect(SceneStringName(item_rect_changed), callable_mp(this, &ProjectManager::_titlebar_resized));
 	}
 
-	_update_size_limits();
+	_update_size_limits(p_custom_res);
 }
 
 ProjectManager::~ProjectManager() {

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -70,7 +70,7 @@ class ProjectManager : public Control {
 
 	Ref<Theme> theme;
 
-	void _update_size_limits();
+	void _update_size_limits(bool p_custom_res);
 	void _update_theme(bool p_skip_creation = false);
 	void _titlebar_resized();
 
@@ -262,7 +262,7 @@ public:
 
 	void add_new_tag(const String &p_tag);
 
-	ProjectManager();
+	ProjectManager(bool p_custom_res);
 	~ProjectManager();
 };
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -230,6 +230,8 @@ static bool init_use_custom_pos = false;
 static bool init_use_custom_screen = false;
 static Vector2 init_custom_pos;
 static int64_t init_embed_parent_window_id = 0;
+static bool use_custom_res = true;
+static bool force_res = false;
 
 // Debug
 
@@ -1019,8 +1021,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String remotefs_pass;
 
 	Vector<String> breakpoints;
-	bool use_custom_res = true;
-	bool force_res = false;
 	bool delta_smoothing_override = false;
 
 	String default_renderer = "";
@@ -4318,7 +4318,7 @@ int Main::start() {
 				translation_server->get_editor_domain()->set_pseudolocalization_enabled(true);
 			}
 
-			ProjectManager *pmanager = memnew(ProjectManager);
+			ProjectManager *pmanager = memnew(ProjectManager(force_res || use_custom_res));
 			ProgressDialog *progress_dialog = memnew(ProgressDialog);
 			pmanager->add_child(progress_dialog);
 


### PR DESCRIPTION
Fixes regression from https://github.com/godotengine/godot/pull/91889

Initial size set in the `main/main.cpp` do not account for EDSCALE (and it's currently impossible to fix, since calculation EDSCALE require functional `DisplayServer` and initial window size/position are passed to the `DisplayServer` constructor).
