### PR TITLE
Improve wording on recursive transition detection warning

### DIFF
--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -911,7 +911,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 		}
 
 		if (transition_path.has(next.node)) {
-			WARN_PRINT_ONCE_ED("AnimationNodeStateMachinePlayback: " + base_path + "playback aborts the transition by detecting one or more looped transitions in the same frame to prevent to infinity loop. You may need to check the transition settings.");
+			WARN_PRINT_ONCE_ED("AnimationNodeStateMachinePlayback: " + base_path + "playback has detected one or more looped transitions in a single frame and aborted to prevent an infinite loop. You may need to check the transition settings.");
 			break; // Maybe infinity loop, do nothing more.
 		}
 


### PR DESCRIPTION
The wording was very awkward and had incorrect grammar at the end.

Previous:

> _transition_to_next_recursive: AnimationNodeStateMachinePlayback: parameters/basic_movement/playback aborts the transition by detecting one or more looped transitions in the same frame to prevent to infinity loop. You may need to check the transition settings.

New:

> _transition_to_next_recursive: AnimationNodeStateMachinePlayback: parameters/basic_movement/playback has detected one or more looped transitions in a single frame and aborted to prevent an infinite loop. You may need to check the transition settings.

