### PR TITLE
[macOS, iOS] Dynamically load MetalFX.

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -44,6 +44,17 @@
 #endif
 #endif
 
+#ifdef __OBJC__
+
+#pragma mark - MetalFX dynamic loading
+
+void *get_MetalFX();
+Class get_MTLFXSpatialScalerDescriptor();
+Class get_MTLFXTemporalScalerDescriptor();
+void unload_MetalFX();
+
+#endif
+
 class RenderingContextDriverMetal;
 
 class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) RenderingDeviceDriverMetal : public RenderingDeviceDriver {

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -245,7 +245,6 @@ def configure(env: "SConsEnvironment"):
         env.AppendUnique(CPPDEFINES=["METAL_ENABLED", "RD_ENABLED"])
         extra_frameworks.add("Metal")
         extra_frameworks.add("MetalKit")
-        extra_frameworks.add("MetalFX")
         env.Prepend(CPPPATH=["#thirdparty/spirv-cross"])
 
     if env["vulkan"]:

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -1307,12 +1307,10 @@ bool DisplayServer::can_create_rendering_device() {
 	}
 #endif
 #ifdef METAL_ENABLED
-	if (rcd == nullptr) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-		// Eliminate "RenderingContextDriverMetal is only available on iOS 14.0 or newer".
-		rcd = memnew(RenderingContextDriverMetal);
-#pragma clang diagnostic pop
+	if (__builtin_available(macOS 11.0, iOS 14.0, *)) {
+		if (rcd == nullptr) {
+			rcd = memnew(RenderingContextDriverMetal);
+		}
 	}
 #endif
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1750,7 +1750,11 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 			break;
 		case RS::VIEWPORT_SCALING_3D_MODE_METALFX_TEMPORAL:
 #ifdef METAL_ENABLED
-			scale_type = SCALE_MFX;
+			if (RD::get_singleton()->has_feature(RD::SUPPORTS_METALFX_TEMPORAL)) {
+				scale_type = SCALE_MFX;
+			} else {
+				scale_type = SCALE_NONE;
+			}
 #else
 			scale_type = SCALE_NONE;
 #endif

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -437,7 +437,9 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 			spatial_upscaler = fsr;
 		} else if (scale_mode == RS::VIEWPORT_SCALING_3D_MODE_METALFX_SPATIAL) {
 #if METAL_ENABLED
-			spatial_upscaler = mfx_spatial;
+			if (RD::get_singleton()->has_feature(RD::SUPPORTS_METALFX_SPATIAL)) {
+				spatial_upscaler = mfx_spatial;
+			}
 #endif
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/101585

Tested building, exporting and running with enabled MetalFX upscaling on macOS 15.2 and iOS 18.2.1.

A bit hacky, but dynamically loading stuff from Apple frameworks should be fine for AppStore (not sure if we have any other options apart from providing multiple builds, removing MetalFX upscaling entirely, or bumping min. iOS version all the way to 16.0).