### PR TITLE
Fix GPUParticles3D emitting `finished` signal on ready

### DIFF
--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -92,7 +92,11 @@ void GPUParticles3D::set_one_shot(bool p_one_shot) {
 
 	if (is_emitting()) {
 		if (!one_shot) {
-			restart();
+			if (!use_fixed_seed) {
+				set_seed(Math::rand());
+			}
+
+			RenderingServer::get_singleton()->particles_restart(particles);
 		}
 	}
 }


### PR DESCRIPTION
Fixes a bug introduced by PR: https://github.com/godotengine/godot/pull/92089
Fixes: https://github.com/godotengine/godot/pull/101596
Fixes: #101733
Fixes #101975

The bug being that all gpu_particle_3ds emit the ``finished`` signal on ``ready``.

Discussion in rocket chat can be found here: https://chat.godotengine.org/channel/vfx-tech-art/thread/WhhDnzLmTke5vYHF9

Details are as follows.

@QbieShay 's pr changes this method:

```cpp
void GPUParticles3D::set_one_shot(bool p_one_shot) {
	one_shot = p_one_shot;
	RS::get_singleton()->particles_set_one_shot(particles, one_shot);

	if (is_emitting()) {
		if (!one_shot) {
			RenderingServer::get_singleton()->particles_restart(particles);
		}
	}
}
```

To

```cpp
void GPUParticles3D::set_one_shot(bool p_one_shot) {
	one_shot = p_one_shot;
	RS::get_singleton()->particles_set_one_shot(particles, one_shot);

	if (is_emitting()) {
		if (!one_shot) {
			restart();
		}
	}
}
```

Specifically the part ``RenderingServer::get_singleton()->particles_restart(particles);`` being changed to ``restart();`` is what introduces this bug.  If we inspect the ``restart`` method, we see that some fields get set:

```cpp
void GPUParticles3D::restart(bool p_keep_seed) {
	if (!p_keep_seed && !use_fixed_seed) {
		set_seed(Math::rand());
	}
	RenderingServer::get_singleton()->particles_restart(particles);
	RenderingServer::get_singleton()->particles_set_emitting(particles, true);

	emitting = true;
	active = true;
	signal_canceled = false;
	time = 0;
	emission_time = lifetime * (1 - explosiveness_ratio);
	active_time = lifetime * (2 - explosiveness_ratio);
	set_process_internal(true);
}
```

These fields are then evaluated in ``void GPUParticles3D::_notification`` here:

```cpp
if (time > active_time) {
	if (active && !signal_canceled) {
		emit_signal(SceneStringName(finished));
	}
	active = false;
	if (!emitting) {
		set_process_internal(false);
	}
}
```

But you still may be wondering, who calls the ``set_one_shot`` method?  That gets called by the constructor as can be seen by my debugger:

![image](https://github.com/user-attachments/assets/c3a08341-b52f-4495-a872-fa4048d6ed6d)

In summary, the issue is:

constructor calls ``set_one_shot`` -> calls ``restart`` -> sets fields incorrectly indicating particle system started -> ``GPUParticles3D::_notification`` sees that the particle system isn't running but incorrectly thinks it was started so it incorrectly emits the ``finished`` signal.

By reverting ``void GPUParticles3D::set_one_shot`` it goes back to behaving how it was before.  To be thorough, I checked GPUParticles2D and can confirm this is how it is currently implemented over there so there is no bug with GPUParticle2D.

Thank you for the help debugging this @QbieShay! :heart: