### PR TITLE
Implement `XR_EXT_performance_settings` OpenXR extension

### DIFF
--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -128,6 +128,20 @@
 				Sets the given action set as active or inactive.
 			</description>
 		</method>
+		<method name="set_cpu_level">
+			<return type="void" />
+			<param index="0" name="level" type="int" enum="OpenXRInterface.PerfSettingsLevel" />
+			<description>
+				Sets the CPU performance level of the OpenXR device.
+			</description>
+		</method>
+		<method name="set_gpu_level">
+			<return type="void" />
+			<param index="0" name="level" type="int" enum="OpenXRInterface.PerfSettingsLevel" />
+			<description>
+				Sets the GPU performance level of the OpenXR device.
+			</description>
+		</method>
 		<method name="set_motion_range">
 			<return type="void" />
 			<param index="0" name="hand" type="int" enum="OpenXRInterface.Hand" />
@@ -162,6 +176,22 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="cpu_level_changed">
+			<param index="0" name="sub_domain" type="int" />
+			<param index="1" name="from_level" type="int" />
+			<param index="2" name="to_level" type="int" />
+			<description>
+				Informs the device CPU performance level has changed in the specified subdomain.
+			</description>
+		</signal>
+		<signal name="gpu_level_changed">
+			<param index="0" name="sub_domain" type="int" />
+			<param index="1" name="from_level" type="int" />
+			<param index="2" name="to_level" type="int" />
+			<description>
+				Informs the device GPU performance level has changed in the specified subdomain.
+			</description>
+		</signal>
 		<signal name="instance_exiting">
 			<description>
 				Informs our OpenXR instance is exiting.
@@ -316,6 +346,36 @@
 		</constant>
 		<constant name="HAND_JOINT_MAX" value="26" enum="HandJoints">
 			Maximum value for the hand joint enum.
+		</constant>
+		<constant name="PERF_SETTINGS_LEVEL_POWER_SAVINGS" value="0" enum="PerfSettingsLevel">
+			The application has entered a non-XR section (head-locked / static screen), during which power savings are to be prioritized.
+		</constant>
+		<constant name="PERF_SETTINGS_LEVEL_SUSTAINED_LOW" value="1" enum="PerfSettingsLevel">
+			The application has entered a low and stable complexity section, during which reducing power is more important than occasional late rendering frames.
+		</constant>
+		<constant name="PERF_SETTINGS_LEVEL_SUSTAINED_HIGH" value="2" enum="PerfSettingsLevel">
+			The application has entered a high or dynamic complexity section, during which the XR Runtime strives for consistent XR compositing and frame rendering within a thermally sustainable range.
+		</constant>
+		<constant name="PERF_SETTINGS_LEVEL_BOOST" value="3" enum="PerfSettingsLevel">
+			The application has entered a section with very high complexity, during which the XR Runtime is allowed to step up beyond the thermally sustainable range.
+		</constant>
+		<constant name="PERF_SETTINGS_SUB_DOMAIN_COMPOSITING" value="0" enum="PerfSettingsSubDomain">
+			The compositing performance within the runtime has reached a new level.
+		</constant>
+		<constant name="PERF_SETTINGS_SUB_DOMAIN_RENDERING" value="1" enum="PerfSettingsSubDomain">
+			The application rendering performance has reached a new level.
+		</constant>
+		<constant name="PERF_SETTINGS_SUB_DOMAIN_THERMAL" value="2" enum="PerfSettingsSubDomain">
+			The temperature of the device has reached a new level.
+		</constant>
+		<constant name="PERF_SETTINGS_NOTIF_LEVEL_NORMAL" value="0" enum="PerfSettingsNotificationLevel">
+			The sub-domain has reached a level where no further actions other than currently applied are necessary.
+		</constant>
+		<constant name="PERF_SETTINGS_NOTIF_LEVEL_WARNING" value="1" enum="PerfSettingsNotificationLevel">
+			The sub-domain has reached an early warning level where the application should start proactive mitigation actions.
+		</constant>
+		<constant name="PERF_SETTINGS_NOTIF_LEVEL_IMPAIRED" value="2" enum="PerfSettingsNotificationLevel">
+			The sub-domain has reached a critical level where the application should start drastic mitigation actions.
 		</constant>
 		<constant name="HAND_JOINT_NONE" value="0" enum="HandJointFlags" is_bitfield="true">
 			No flags are set.

--- a/modules/openxr/extensions/openxr_performance_settings_extension.cpp
+++ b/modules/openxr/extensions/openxr_performance_settings_extension.cpp
@@ -1,0 +1,156 @@
+/**************************************************************************/
+/*  openxr_performance_settings_extension.cpp                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_performance_settings_extension.h"
+
+#include "../openxr_api.h"
+
+OpenXRPerformanceSettingsExtension *OpenXRPerformanceSettingsExtension::singleton = nullptr;
+
+OpenXRPerformanceSettingsExtension *OpenXRPerformanceSettingsExtension::get_singleton() {
+	return singleton;
+}
+
+OpenXRPerformanceSettingsExtension::OpenXRPerformanceSettingsExtension() {
+	singleton = this;
+}
+
+OpenXRPerformanceSettingsExtension::~OpenXRPerformanceSettingsExtension() {
+	singleton = nullptr;
+}
+
+HashMap<String, bool *> OpenXRPerformanceSettingsExtension::get_requested_extensions() {
+	HashMap<String, bool *> request_extensions;
+
+	request_extensions[XR_EXT_PERFORMANCE_SETTINGS_EXTENSION_NAME] = &available;
+
+	return request_extensions;
+}
+
+void OpenXRPerformanceSettingsExtension::on_instance_created(const XrInstance p_instance) {
+	if (available) {
+		EXT_INIT_XR_FUNC(xrPerfSettingsSetPerformanceLevelEXT);
+	}
+}
+
+bool OpenXRPerformanceSettingsExtension::on_event_polled(const XrEventDataBuffer &event) {
+	switch (event.type) {
+		case XR_TYPE_EVENT_DATA_PERF_SETTINGS_EXT: {
+			const XrEventDataPerfSettingsEXT *perf_settings_event = (XrEventDataPerfSettingsEXT *)&event;
+
+			OpenXRInterface::PerfSettingsSubDomain sub_domain = openxr_to_sub_domain(perf_settings_event->subDomain);
+			OpenXRInterface::PerfSettingsNotificationLevel from_level = openxr_to_notification_level(perf_settings_event->fromLevel);
+			OpenXRInterface::PerfSettingsNotificationLevel to_level = openxr_to_notification_level(perf_settings_event->toLevel);
+
+			OpenXRInterface *openxr_interface = OpenXRAPI::get_singleton()->get_xr_interface();
+
+			if (perf_settings_event->domain == XR_PERF_SETTINGS_DOMAIN_CPU_EXT) {
+				openxr_interface->on_cpu_level_changed(sub_domain, from_level, to_level);
+			} else if (perf_settings_event->domain == XR_PERF_SETTINGS_DOMAIN_GPU_EXT) {
+				openxr_interface->on_gpu_level_changed(sub_domain, from_level, to_level);
+			} else {
+				print_error(vformat("OpenXR: no matching performance settings domain for %s", perf_settings_event->domain));
+			}
+			return true;
+		} break;
+		default:
+			return false;
+	}
+}
+
+bool OpenXRPerformanceSettingsExtension::is_available() {
+	return available;
+}
+
+void OpenXRPerformanceSettingsExtension::set_cpu_level(OpenXRInterface::PerfSettingsLevel p_level) {
+	XrSession session = OpenXRAPI::get_singleton()->get_session();
+	XrPerfSettingsLevelEXT xr_level = level_to_openxr(p_level);
+
+	XrResult result = xrPerfSettingsSetPerformanceLevelEXT(session, XR_PERF_SETTINGS_DOMAIN_CPU_EXT, xr_level);
+	if (XR_FAILED(result)) {
+		print_error(vformat("OpenXR: failed to set CPU performance level [%s]", OpenXRAPI::get_singleton()->get_error_string(result)));
+	}
+}
+
+void OpenXRPerformanceSettingsExtension::set_gpu_level(OpenXRInterface::PerfSettingsLevel p_level) {
+	XrSession session = OpenXRAPI::get_singleton()->get_session();
+	XrPerfSettingsLevelEXT xr_level = level_to_openxr(p_level);
+
+	XrResult result = xrPerfSettingsSetPerformanceLevelEXT(session, XR_PERF_SETTINGS_DOMAIN_GPU_EXT, xr_level);
+	if (XR_FAILED(result)) {
+		print_error(vformat("OpenXR: failed to set GPU performance level [%s]", OpenXRAPI::get_singleton()->get_error_string(result)));
+	}
+}
+
+XrPerfSettingsLevelEXT OpenXRPerformanceSettingsExtension::level_to_openxr(OpenXRInterface::PerfSettingsLevel p_level) {
+	switch (p_level) {
+		case OpenXRInterface::PerfSettingsLevel::PERF_SETTINGS_LEVEL_POWER_SAVINGS:
+			return XR_PERF_SETTINGS_LEVEL_POWER_SAVINGS_EXT;
+			break;
+		case OpenXRInterface::PerfSettingsLevel::PERF_SETTINGS_LEVEL_SUSTAINED_LOW:
+			return XR_PERF_SETTINGS_LEVEL_SUSTAINED_LOW_EXT;
+			break;
+		case OpenXRInterface::PerfSettingsLevel::PERF_SETTINGS_LEVEL_SUSTAINED_HIGH:
+			return XR_PERF_SETTINGS_LEVEL_SUSTAINED_HIGH_EXT;
+		case OpenXRInterface::PerfSettingsLevel::PERF_SETTINGS_LEVEL_BOOST:
+			return XR_PERF_SETTINGS_LEVEL_BOOST_EXT;
+		default:
+			print_error("Invalid performance settings level.");
+			return XR_PERF_SETTINGS_LEVEL_SUSTAINED_HIGH_EXT;
+	}
+}
+
+OpenXRInterface::PerfSettingsSubDomain OpenXRPerformanceSettingsExtension::openxr_to_sub_domain(XrPerfSettingsSubDomainEXT p_sub_domain) {
+	switch (p_sub_domain) {
+		case XR_PERF_SETTINGS_SUB_DOMAIN_COMPOSITING_EXT:
+			return OpenXRInterface::PerfSettingsSubDomain::PERF_SETTINGS_SUB_DOMAIN_COMPOSITING;
+		case XR_PERF_SETTINGS_SUB_DOMAIN_RENDERING_EXT:
+			return OpenXRInterface::PerfSettingsSubDomain::PERF_SETTINGS_SUB_DOMAIN_RENDERING;
+		case XR_PERF_SETTINGS_SUB_DOMAIN_THERMAL_EXT:
+			return OpenXRInterface::PerfSettingsSubDomain::PERF_SETTINGS_SUB_DOMAIN_THERMAL;
+		default:
+			print_error("Invalid performance settings sub domain.");
+			return OpenXRInterface::PerfSettingsSubDomain::PERF_SETTINGS_SUB_DOMAIN_COMPOSITING;
+	}
+}
+
+OpenXRInterface::PerfSettingsNotificationLevel OpenXRPerformanceSettingsExtension::openxr_to_notification_level(XrPerfSettingsNotificationLevelEXT p_notification_level) {
+	switch (p_notification_level) {
+		case XR_PERF_SETTINGS_NOTIF_LEVEL_NORMAL_EXT:
+			return OpenXRInterface::PerfSettingsNotificationLevel::PERF_SETTINGS_NOTIF_LEVEL_NORMAL;
+		case XR_PERF_SETTINGS_NOTIF_LEVEL_WARNING_EXT:
+			return OpenXRInterface::PerfSettingsNotificationLevel::PERF_SETTINGS_NOTIF_LEVEL_WARNING;
+		case XR_PERF_SETTINGS_NOTIF_LEVEL_IMPAIRED_EXT:
+			return OpenXRInterface::PerfSettingsNotificationLevel::PERF_SETTINGS_NOTIF_LEVEL_IMPAIRED;
+		default:
+			print_error("Invalid performance settings notification level.");
+			return OpenXRInterface::PerfSettingsNotificationLevel::PERF_SETTINGS_NOTIF_LEVEL_NORMAL;
+	}
+}

--- a/modules/openxr/extensions/openxr_performance_settings_extension.h
+++ b/modules/openxr/extensions/openxr_performance_settings_extension.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  openxr_performance_settings_extension.h                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "../openxr_interface.h"
+#include "../util.h"
+#include "openxr_extension_wrapper.h"
+
+class OpenXRPerformanceSettingsExtension : public OpenXRExtensionWrapper {
+public:
+	static OpenXRPerformanceSettingsExtension *get_singleton();
+
+	OpenXRPerformanceSettingsExtension();
+	virtual ~OpenXRPerformanceSettingsExtension() override;
+
+	virtual HashMap<String, bool *> get_requested_extensions() override;
+
+	virtual void on_instance_created(const XrInstance p_instance) override;
+	virtual bool on_event_polled(const XrEventDataBuffer &event) override;
+
+	bool is_available();
+
+	void set_cpu_level(OpenXRInterface::PerfSettingsLevel p_level);
+	void set_gpu_level(OpenXRInterface::PerfSettingsLevel p_level);
+
+private:
+	static OpenXRPerformanceSettingsExtension *singleton;
+
+	bool available = false;
+
+	XrPerfSettingsLevelEXT level_to_openxr(OpenXRInterface::PerfSettingsLevel p_level);
+	OpenXRInterface::PerfSettingsSubDomain openxr_to_sub_domain(XrPerfSettingsSubDomainEXT p_sub_domain);
+	OpenXRInterface::PerfSettingsNotificationLevel openxr_to_notification_level(XrPerfSettingsNotificationLevelEXT p_notification_level);
+
+	EXT_PROTO_XRRESULT_FUNC3(xrPerfSettingsSetPerformanceLevelEXT, (XrSession), session, (XrPerfSettingsDomainEXT), domain, (XrPerfSettingsLevelEXT), level)
+};

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -291,6 +291,31 @@ public:
 
 	virtual RID get_vrs_texture() override;
 
+	// Performance settings.
+	enum PerfSettingsLevel {
+		PERF_SETTINGS_LEVEL_POWER_SAVINGS,
+		PERF_SETTINGS_LEVEL_SUSTAINED_LOW,
+		PERF_SETTINGS_LEVEL_SUSTAINED_HIGH,
+		PERF_SETTINGS_LEVEL_BOOST,
+	};
+
+	enum PerfSettingsSubDomain {
+		PERF_SETTINGS_SUB_DOMAIN_COMPOSITING,
+		PERF_SETTINGS_SUB_DOMAIN_RENDERING,
+		PERF_SETTINGS_SUB_DOMAIN_THERMAL,
+	};
+
+	enum PerfSettingsNotificationLevel {
+		PERF_SETTINGS_NOTIF_LEVEL_NORMAL,
+		PERF_SETTINGS_NOTIF_LEVEL_WARNING,
+		PERF_SETTINGS_NOTIF_LEVEL_IMPAIRED,
+	};
+
+	void set_cpu_level(PerfSettingsLevel p_level);
+	void set_gpu_level(PerfSettingsLevel p_level);
+	void on_cpu_level_changed(PerfSettingsSubDomain p_sub_domain, PerfSettingsNotificationLevel p_from_level, PerfSettingsNotificationLevel p_to_level);
+	void on_gpu_level_changed(PerfSettingsSubDomain p_sub_domain, PerfSettingsNotificationLevel p_from_level, PerfSettingsNotificationLevel p_to_level);
+
 	OpenXRInterface();
 	~OpenXRInterface();
 };
@@ -299,4 +324,7 @@ VARIANT_ENUM_CAST(OpenXRInterface::Hand)
 VARIANT_ENUM_CAST(OpenXRInterface::HandMotionRange)
 VARIANT_ENUM_CAST(OpenXRInterface::HandTrackedSource)
 VARIANT_ENUM_CAST(OpenXRInterface::HandJoints)
+VARIANT_ENUM_CAST(OpenXRInterface::PerfSettingsLevel)
+VARIANT_ENUM_CAST(OpenXRInterface::PerfSettingsSubDomain)
+VARIANT_ENUM_CAST(OpenXRInterface::PerfSettingsNotificationLevel)
 VARIANT_BITFIELD_CAST(OpenXRInterface::HandJointFlags)

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -63,6 +63,7 @@
 #include "extensions/openxr_ml2_controller_extension.h"
 #include "extensions/openxr_mxink_extension.h"
 #include "extensions/openxr_palm_pose_extension.h"
+#include "extensions/openxr_performance_settings_extension.h"
 #include "extensions/openxr_pico_controller_extension.h"
 #include "extensions/openxr_valve_analog_threshold_extension.h"
 #include "extensions/openxr_visibility_mask_extension.h"
@@ -139,6 +140,7 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRHandInteractionExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRMxInkExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRVisibilityMaskExtension));
+			OpenXRAPI::register_extension_wrapper(memnew(OpenXRPerformanceSettingsExtension));
 
 			// register gated extensions
 			if (int(GLOBAL_GET("xr/openxr/extensions/debug_utils")) > 0) {


### PR DESCRIPTION
Provides an API for developers to set CPU/GPU performance levels via the [XR_EXT_performance_settings](https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_EXT_performance_settings) OpenXR extension.

I've also created some signals that should fire when an `XrEventDataPerfSettingsEXT` event is triggered by the runtime, which developers could use to be notified on the status of performance / device temperature. I've not been able to get one of these events polled on my Quest 3 or Quest Pro yet, but it _should_ work in theory!