### PR TITLE
Metal: Enable GPU buffer address support

### DIFF
--- a/drivers/metal/metal_device_properties.h
+++ b/drivers/metal/metal_device_properties.h
@@ -93,6 +93,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MetalFeatures {
 	bool needs_arg_encoders = true;
 	bool metal_fx_spatial = false; /**< If true, Metal FX spatial functions are supported. */
 	bool metal_fx_temporal = false; /**< If true, Metal FX temporal functions are supported. */
+	bool supports_gpu_address = false; /**< If true, referencing a GPU address in a shader is supported. */
 };
 
 struct MetalLimits {

--- a/drivers/metal/metal_device_properties.mm
+++ b/drivers/metal/metal_device_properties.mm
@@ -99,6 +99,10 @@ void MetalDeviceProperties::init_features(id<MTLDevice> p_device) {
 		features.supports32BitMSAA = p_device.supports32BitMSAA;
 	}
 
+	if (@available(macOS 13.0, iOS 16.0, tvOS 16.0, *)) {
+		features.supports_gpu_address = true;
+	}
+
 	features.hostMemoryPageSize = sysconf(_SC_PAGESIZE);
 
 	for (SampleCount sc = SampleCount1; sc <= SampleCount64; sc <<= 1) {

--- a/drivers/metal/metal_objects.h
+++ b/drivers/metal/metal_objects.h
@@ -65,7 +65,6 @@
 #import <zlib.h>
 #import <initializer_list>
 #import <optional>
-#import <spirv.hpp>
 
 // These types can be used in Vector and other containers that use
 // pointer operations not supported by ARC.
@@ -563,7 +562,7 @@ struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) BindingInfo {
 	MTLBindingAccess access = MTLBindingAccessReadOnly;
 	MTLResourceUsage usage = 0;
 	MTLTextureType textureType = MTLTextureType2D;
-	spv::ImageFormat imageFormat = spv::ImageFormatUnknown;
+	int imageFormat = 0;
 	uint32_t arrayLength = 0;
 	bool isMultisampled = false;
 


### PR DESCRIPTION
This completes #100062 by enabling GPU buffer address support for Metal.

Tested all buffer types without offsets:

![CleanShot 2025-01-16 at 05 59 38@2x](https://github.com/user-attachments/assets/3a11790f-2165-4761-9f0f-0fe1cb4ffa0a)

and enabling offsets:

![CleanShot 2025-01-16 at 05 59 22@2x](https://github.com/user-attachments/assets/bd7715a7-5fdf-4015-9927-d57c87c7dd45)
