### PR TITLE
Nest `.uid` file in `.cs` file for Visual Studio

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectGenerator.cs
@@ -34,6 +34,10 @@ namespace GodotTools.ProjectEditor
             if (sanitizedName != name)
                 mainGroup.AddProperty("RootNamespace", sanitizedName);
 
+            // Nest .uid file in .cs file.
+            var itemGroup = root.AddItemGroup();
+            itemGroup.AddItem("None", "**\\*.uid");
+
             return root;
         }
 


### PR DESCRIPTION
Partially address https://github.com/godotengine/godot-proposals/issues/11565

Add an ItemGroup to default csproj to make `.uid` files included in VS solutions.

csproj file now looks like:
```csproj
<Project Sdk="Godot.NET.Sdk/4.4.0-beta">
  <PropertyGroup>
    <TargetFramework>net8.0</TargetFramework>
    <EnableDynamicLoading>true</EnableDynamicLoading>
  </PropertyGroup>
  <ItemGroup>
    <None Include="**\*.uid" />
  </ItemGroup>
</Project>
```

User need to further choose file nesting setting "Web" for `.uid` files to be hidden and follow `.cs` files. This needs to be documented. Unfortunately my English is not good so I need some help in this part. 