### PR TITLE
Lock the `StringName::mutex` after hashing the string, to spend less time hoarding it unnecessarily.

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -269,12 +269,10 @@ StringName::StringName(const char *p_name, bool p_static) {
 		return; //empty, ignore
 	}
 
+	const uint32_t hash = String::hash(p_name);
+	const uint32_t idx = hash & STRING_TABLE_MASK;
+
 	MutexLock lock(mutex);
-
-	uint32_t hash = String::hash(p_name);
-
-	uint32_t idx = hash & STRING_TABLE_MASK;
-
 	_data = _table[idx];
 
 	while (_data) {
@@ -328,12 +326,10 @@ StringName::StringName(const StaticCString &p_static_string, bool p_static) {
 
 	ERR_FAIL_COND(!p_static_string.ptr || !p_static_string.ptr[0]);
 
+	const uint32_t hash = String::hash(p_static_string.ptr);
+	const uint32_t idx = hash & STRING_TABLE_MASK;
+
 	MutexLock lock(mutex);
-
-	uint32_t hash = String::hash(p_static_string.ptr);
-
-	uint32_t idx = hash & STRING_TABLE_MASK;
-
 	_data = _table[idx];
 
 	while (_data) {
@@ -388,11 +384,10 @@ StringName::StringName(const String &p_name, bool p_static) {
 		return;
 	}
 
+	const uint32_t hash = p_name.hash();
+	const uint32_t idx = hash & STRING_TABLE_MASK;
+
 	MutexLock lock(mutex);
-
-	uint32_t hash = p_name.hash();
-	uint32_t idx = hash & STRING_TABLE_MASK;
-
 	_data = _table[idx];
 
 	while (_data) {
@@ -446,11 +441,10 @@ StringName StringName::search(const char *p_name) {
 		return StringName();
 	}
 
+	const uint32_t hash = String::hash(p_name);
+	const uint32_t idx = hash & STRING_TABLE_MASK;
+
 	MutexLock lock(mutex);
-
-	uint32_t hash = String::hash(p_name);
-	uint32_t idx = hash & STRING_TABLE_MASK;
-
 	_Data *_data = _table[idx];
 
 	while (_data) {
@@ -482,12 +476,10 @@ StringName StringName::search(const char32_t *p_name) {
 		return StringName();
 	}
 
+	const uint32_t hash = String::hash(p_name);
+	const uint32_t idx = hash & STRING_TABLE_MASK;
+
 	MutexLock lock(mutex);
-
-	uint32_t hash = String::hash(p_name);
-
-	uint32_t idx = hash & STRING_TABLE_MASK;
-
 	_Data *_data = _table[idx];
 
 	while (_data) {
@@ -508,12 +500,10 @@ StringName StringName::search(const char32_t *p_name) {
 StringName StringName::search(const String &p_name) {
 	ERR_FAIL_COND_V(p_name.is_empty(), StringName());
 
+	const uint32_t hash = p_name.hash();
+	const uint32_t idx = hash & STRING_TABLE_MASK;
+
 	MutexLock lock(mutex);
-
-	uint32_t hash = p_name.hash();
-
-	uint32_t idx = hash & STRING_TABLE_MASK;
-
 	_Data *_data = _table[idx];
 
 	while (_data) {


### PR DESCRIPTION
This is a tiny optimization. Spending less time on the mutex should speed up highly parallel `StringName` lookups, especially for long strings.