### PR TITLE
Reduce `ref/unref` and remove unnecessary `has` in animation

### DIFF
--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -404,19 +404,23 @@ public:
 class AnimationNodeBlendTree : public AnimationRootNode {
 	GDCLASS(AnimationNodeBlendTree, AnimationRootNode);
 
+public:
 	struct Node {
 		Ref<AnimationNode> node;
 		Vector2 position;
 		Vector<StringName> connections;
 	};
 
-	RBMap<StringName, Node, StringName::AlphCompare> nodes;
+private:
+	AHashMap<StringName, Node> nodes;
 
 	Vector2 graph_offset;
 
 	void _node_changed(const StringName &p_node);
 
 	void _initialize_node_tree();
+
+	Ref<AnimationNode> _get_node(const StringName &p_name) const;
 
 protected:
 	static void _bind_methods();
@@ -442,7 +446,10 @@ public:
 	};
 
 	void add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position = Vector2());
-	Ref<AnimationNode> get_node(const StringName &p_name) const;
+	const Ref<AnimationNode> &get_node(const StringName &p_name) const;
+
+	const KeyValue<StringName, Node> &find_name_node_pair(const Ref<AnimationNode> &p_node);
+
 	void remove_node(const StringName &p_name);
 	void rename_node(const StringName &p_name, const StringName &p_new_name);
 	bool has_node(const StringName &p_name) const;

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -403,6 +403,9 @@ protected:
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 
+private:
+	Ref<Animation> _get_animation(const StringName &p_name) const;
+
 public:
 	/* ---- Data lists ---- */
 	Dictionary *get_animation_libraries();
@@ -417,7 +420,7 @@ public:
 	void rename_animation_library(const StringName &p_name, const StringName &p_new_name);
 
 	void get_animation_list(List<StringName> *p_animations) const;
-	Ref<Animation> get_animation(const StringName &p_name) const;
+	const Ref<Animation> &get_animation(const StringName &p_name) const;
 	bool has_animation(const StringName &p_name) const;
 	StringName find_animation(const Ref<Animation> &p_animation) const;
 
@@ -460,7 +463,7 @@ public:
 	Vector3 get_root_motion_scale_accumulator() const;
 
 	/* ---- Blending processor ---- */
-	void make_animation_instance(const StringName &p_name, const PlaybackInfo p_playback_info);
+	void make_animation_instance(const StringName &p_name, const PlaybackInfo &p_playback_info);
 	void clear_animation_instances();
 	virtual void advance(double p_time);
 	virtual void clear_caches(); // Must be called by hand if an animation was modified after added.

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -125,6 +125,10 @@ public:
 
 private:
 	mutable AHashMap<StringName, int> property_cache;
+	StringName current_base_path;
+	StringName current_subpath;
+
+	Variant _get_parameter(const StringName &p_name) const;
 
 public:
 	void set_node_state_base_path(const StringName p_base_path) {
@@ -165,9 +169,9 @@ protected:
 	virtual NodeTimeInfo process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false); // To organize time information. Virtualizing for especially AnimationNodeAnimation needs to take "backward" into account.
 	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false); // Main process.
 
-	void blend_animation(const StringName &p_animation, AnimationMixer::PlaybackInfo p_playback_info);
+	void blend_animation(const StringName &p_animation, AnimationMixer::PlaybackInfo &p_playback_info);
 	NodeTimeInfo blend_node(Ref<AnimationNode> p_node, const StringName &p_subpath, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
-	NodeTimeInfo blend_input(int p_input, AnimationMixer::PlaybackInfo p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
+	NodeTimeInfo blend_input(int p_input, AnimationMixer::PlaybackInfo &p_playback_info, FilterAction p_filter = FILTER_IGNORE, bool p_sync = true, bool p_test_only = false);
 
 	// Bind-able methods to expose for compatibility, moreover AnimationMixer::PlaybackInfo is not exposed.
 	void blend_animation_ex(const StringName &p_animation, double p_time, double p_delta, bool p_seeked, bool p_is_external_seeking, real_t p_blend, Animation::LoopedFlag p_looped_flag = Animation::LOOPED_FLAG_NONE);
@@ -196,7 +200,7 @@ public:
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const;
 
 	void set_parameter(const StringName &p_name, const Variant &p_value);
-	Variant get_parameter(const StringName &p_name) const;
+	const Variant &get_parameter(const StringName &p_name) const;
 
 	void set_node_time_info(const NodeTimeInfo &p_node_time_info); // Wrapper of set_parameter().
 	virtual NodeTimeInfo get_node_time_info() const; // Wrapper of get_parameter().
@@ -306,8 +310,8 @@ private:
 		uint64_t last_pass = 0;
 		real_t activity = 0.0;
 	};
-	mutable HashMap<StringName, LocalVector<Activity>> input_activity_map;
-	mutable HashMap<StringName, LocalVector<Activity> *> input_activity_map_get;
+	mutable AHashMap<StringName, LocalVector<Activity>> input_activity_map;
+	mutable AHashMap<StringName, LocalVector<Activity> *> input_activity_map_get;
 
 	NodePath animation_player;
 


### PR DESCRIPTION
Requires  #101564 and #101548

Adds 70% to the FPS for MRP from #101494.

Master:
Project FPS: 70 (14.28 mspf)
Project FPS: 70 (14.28 mspf)
Project FPS: 69 (14.49 mspf)

Current PR:
Project FPS: 124 (8.06 mspf)
Project FPS: 123 (8.13 mspf)
Project FPS: 125 (8.00 mspf)

> [!NOTE]
Turn off `Active` for `AnimationPlayer` in the `node_3d` scene before testing.

Also for some reason it's only for my computer these results, and @clayjohn gets much worse results.