### PR TITLE
Fix Project Dialog Removing Home Dir. from Project Path

### DIFF
--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -134,6 +134,8 @@ private:
 
 	void ok_pressed() override;
 
+	bool _is_path_home_or_doc_dir(const String &p_path);
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #101528

Code changes are made in the [editor/project_manager/project_dialog.cpp](https://github.com/godotengine/godot/blob/master/editor/project_manager/project_dialog.cpp) file.

Since the error is only an issue when the home directory is removed by the script, I added an `if` statement to check if the target path is equal to the home directory (or the documents directory). The script then only removes the last file path if the path is not.

Since the same if statement is also used in `_validate_path()`, I extracted the statement and created a separate boolean function `_is_path_home_or_doc_dir(const String &p_path)`.

Please let me know if looks good. Thanks!