### PR TITLE
Update `InputEventWithModifiers` documentation for modifier key behavior

### DIFF
--- a/doc/classes/InputEventWithModifiers.xml
+++ b/doc/classes/InputEventWithModifiers.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Stores information about mouse, keyboard, and touch gesture input events. This includes information about which modifier keys are pressed, such as [kbd]Shift[/kbd] or [kbd]Alt[/kbd]. See [method Node._input].
+		[b]Note:[/b] Modifier keys are considered modifiers only when used in combination with another key. As a result, their corresponding member variables, such as [member ctrl_pressed], will return [code]false[/code] if the key is pressed on its own.
 	</description>
 	<tutorials>
 		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>


### PR DESCRIPTION
Updated the `InputEventWithModifiers` documentation to include a note regarding the behaviour of modifier keys to avoid confusion.

Since the member variables such as `ctrl_pressed` return the state of the modifier keys being active, they will return `false` when used on their own, which might cause confusion, as one might expect them to return `true`.

Fixes #91573
