### PR TITLE
Clarify the impact of "Normal Map (RG Channels)" on texture imports.

### DIFF
--- a/doc/classes/ResourceImporterLayeredTexture.xml
+++ b/doc/classes/ResourceImporterLayeredTexture.xml
@@ -14,7 +14,7 @@
 			Controls how color channels should be used in the imported texture.
 			[b]sRGB Friendly:[/b], prevents the RG color format from being used, as it does not support sRGB color.
 			[b]Optimized:[/b], allows the RG color format to be used if the texture does not use the blue channel. This reduces memory usage if the texture's blue channel can be discarded (all pixels must have a blue value of [code]0[/code]).
-			[b]Normal Map (RG Channels):[/b] This forces all layers from the texture to be imported with the RG color format to reduce memory usage, with only the red and green channels preserved. This only has an effect on textures with the VRAM Compressed or Basis Universal compression modes. This mode is only available in layered textures ([Cubemap], [CubemapArray], [Texture2DArray] and [Texture3D]).
+			[b]Normal Map (RG Channels):[/b] This forces all layers from the texture to be imported with the RG color format, with only the red and green channels preserved. RGTC (Red-Green Texture Compression) compression is able to preserve its detail much better, while using the same amount of memory as a standard RGBA VRAM-compressed texture. This only has an effect on textures with the VRAM Compressed or Basis Universal compression modes. This mode is only available in layered textures ([Cubemap], [CubemapArray], [Texture2DArray] and [Texture3D]).
 		</member>
 		<member name="compress/hdr_compression" type="int" setter="" getter="" default="1">
 			Controls how VRAM compression should be performed for HDR images.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Updating class docs to specify that the RG texture compression does not reduce memory usage, it improves quality. [Per Clay John](https://github.com/godotengine/godot/issues/101610#issuecomment-2593974739), this is a documentation issue not a code issue.

Fixes #101610