### PR TITLE
[TextServer] Fix text buffer not processing strings added after `shape`.

### DIFF
--- a/tests/servers/test_text_server.h
+++ b/tests/servers/test_text_server.h
@@ -815,12 +815,12 @@ TEST_SUITE("[TextServer]") {
 		SUBCASE("[TextServer] Word break") {
 			for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
 				Ref<TextServer> ts = TextServerManager::get_singleton()->get_interface(i);
+				CHECK_FALSE_MESSAGE(ts.is_null(), "Invalid TS interface.");
 
 				if (!ts->has_feature(TextServer::FEATURE_SIMPLE_LAYOUT)) {
 					continue;
 				}
 
-				CHECK_FALSE_MESSAGE(ts.is_null(), "Invalid TS interface.");
 				{
 					String text1 = U"linguistically similar and effectively form";
 					//                           14^     22^ 26^         38^
@@ -916,6 +916,47 @@ TEST_SUITE("[TextServer]") {
 						CHECK(breaks[38] == 42);
 					}
 				}
+			}
+		}
+
+		SUBCASE("[TextServer] Buffer invalidation") {
+			for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
+				Ref<TextServer> ts = TextServerManager::get_singleton()->get_interface(i);
+				CHECK_FALSE_MESSAGE(ts.is_null(), "Invalid TS interface.");
+
+				if (!ts->has_feature(TextServer::FEATURE_SIMPLE_LAYOUT)) {
+					continue;
+				}
+
+				RID font1 = ts->create_font();
+				ts->font_set_data_ptr(font1, _font_NotoSans_Regular, _font_NotoSans_Regular_size);
+
+				Array font;
+				font.push_back(font1);
+
+				RID ctx = ts->create_shaped_text();
+				CHECK_FALSE_MESSAGE(ctx == RID(), "Creating text buffer failed.");
+				bool ok = ts->shaped_text_add_string(ctx, "T", font, 16);
+				CHECK_FALSE_MESSAGE(!ok, "Adding text to the buffer failed.");
+				int gl_size = ts->shaped_text_get_glyph_count(ctx);
+				CHECK_MESSAGE(gl_size == 1, "Shaping failed, invalid glyph count");
+
+				ok = ts->shaped_text_add_object(ctx, "key", Size2(20, 20), INLINE_ALIGNMENT_CENTER, 1, 0.0);
+				CHECK_FALSE_MESSAGE(!ok, "Adding text to the buffer failed.");
+				gl_size = ts->shaped_text_get_glyph_count(ctx);
+				CHECK_MESSAGE(gl_size == 2, "Shaping failed, invalid glyph count");
+
+				ok = ts->shaped_text_add_string(ctx, "B", font, 16);
+				CHECK_FALSE_MESSAGE(!ok, "Adding text to the buffer failed.");
+				gl_size = ts->shaped_text_get_glyph_count(ctx);
+				CHECK_MESSAGE(gl_size == 3, "Shaping failed, invalid glyph count");
+
+				ts->free_rid(ctx);
+
+				for (int j = 0; j < font.size(); j++) {
+					ts->free_rid(font[j]);
+				}
+				font.clear();
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/101580

In most cases (probably all built-in UI), new content is never added to the buffer after shaping, but it supposed to be possible.