### PR TITLE
Fix index check in MethodBind::get_argument_type

### DIFF
--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -90,7 +90,7 @@ public:
 	}
 
 	_FORCE_INLINE_ Variant::Type get_argument_type(int p_argument) const {
-		ERR_FAIL_COND_V(p_argument < -1 || p_argument > argument_count, Variant::NIL);
+		ERR_FAIL_COND_V(p_argument < -1 || p_argument >= argument_count, Variant::NIL);
 		return argument_types[p_argument + 1];
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

If a user accidentally calls get_argument_type() with `p_argument = argument_count`, the return value is read from the address out of `argument_types`.

For instance:
`argument_count` is 1, 
`argument_types` is `[ 0: return_type, 1: arg0_type ]`. 
then, `get_argument_type(1)` do unexpectedly pass the `ERR_FAIL_COND_V` check, and return with `argument_types[2]`. No error message is printed, and may cause access violation on specific platforms. 
 